### PR TITLE
feat: add pre-push fitness guard hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Pre-push fitness guard
+# Runs nexus-agents fitness-audit before push to prevent score degradation.
+# Consensus-approved enhancement (3/3 votes, simple_majority strategy).
+# Skip with: git push --no-verify
+
+# Only run if the CLI is built (skip gracefully otherwise)
+CLI_PATH="packages/nexus-agents/dist/cli.js"
+if [ ! -f "$CLI_PATH" ]; then
+  echo "[fitness-guard] CLI not built, skipping fitness check"
+  exit 0
+fi
+
+echo "[fitness-guard] Running fitness audit..."
+RESULT=$(node "$CLI_PATH" fitness-audit --format=json 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+  echo "[fitness-guard] Fitness audit failed to run, skipping"
+  exit 0
+fi
+
+SCORE=$(echo "$RESULT" | grep -o '"score":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+if [ -z "$SCORE" ]; then
+  echo "[fitness-guard] Could not parse fitness score, skipping"
+  exit 0
+fi
+
+THRESHOLD=90
+
+if [ "$SCORE" -lt "$THRESHOLD" ]; then
+  echo ""
+  echo "[fitness-guard] BLOCKED: Fitness score $SCORE/100 < $THRESHOLD threshold"
+  echo "[fitness-guard] Run 'nexus-agents fitness-audit' for details"
+  echo "[fitness-guard] Skip with: git push --no-verify"
+  exit 1
+fi
+
+echo "[fitness-guard] Fitness score: $SCORE/100 (threshold: $THRESHOLD)"


### PR DESCRIPTION
## Summary

- Adds a husky pre-push hook that runs `nexus-agents fitness-audit` before push
- Blocks push if fitness score drops below 90/100 threshold (governance requirement)
- Gracefully skips if CLI not built (no friction for fresh clones)
- **Consensus-approved** by 3/3 agents using `simple_majority` voting strategy:
  - Software Architect (0.88 confidence): "aligns with governance enforcement"
  - Security Engineer (0.82 confidence): "minimal risk, enforces existing policy"
  - Product Manager (0.78 confidence): "highest ROI by enforcing existing ≥90 requirement"

## Test plan

- [x] Hook runs successfully when CLI is built (shows "Fitness score: 97/100")
- [x] Hook skips gracefully when CLI not built
- [x] Bypassable with `git push --no-verify`
- [x] Hook is executable (`chmod +x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)