### PR TITLE
fix(ci): make docs-coverage check non-blocking (#675)

### DIFF
--- a/.claude/skills/documentation-management.md
+++ b/.claude/skills/documentation-management.md
@@ -13,6 +13,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 <!-- DOCOPS MANIFEST CHECKSUM: [auto-updated by CI] -->
 <!-- PIPELINE NOTE: generate-repo-index.ts outputs MD060-compliant tables (2026-02-03) -->
 <!-- PIPELINE NOTE: generate-docs.ts, generate-docs-full.ts, inject-governance.ts table formatting normalized (2026-02-03) -->
+<!-- PIPELINE NOTE: docs-check.yml docs-coverage job set continue-on-error:true for non-blocking (2026-02-03) -->
 
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -77,11 +77,12 @@ jobs:
             fi
           done
 
-  # Job 3: Documentation Coverage Check
+  # Job 3: Documentation Coverage Check (non-blocking warning per DevEx amendment)
   docs-coverage:
     name: Documentation Coverage
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    continue-on-error: true
 
     # Skip if [skip-docs] is in PR title or body
     # Rate limited per escape hatch controls


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `docs-coverage` job in `docs-check.yml`
- This check was documented as non-blocking (warning only) but was actually blocking PR merges
- PRs #670, #672, #673, #674 all required `--admin` merge due to this check

## Test plan

- [x] Workflow syntax is valid
- [x] DocOps skill updated per governance rules

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)