### PR TITLE
feat: wire session memory into MCP tool execution pipeline

### DIFF
--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -47,6 +47,7 @@ import {
   logRestApiConfig,
 } from './cli-server-rest.js';
 import type { RestApiServer } from './api/rest-server.js';
+import { shutdownToolMemory } from './mcp/tools/tool-memory.js';
 
 // Re-export for backward compatibility
 export { type OrchestratorModeOptions } from './cli-orchestrator.js';
@@ -272,6 +273,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     recordServerShutdown(observer, eventContext);
     logFinalHealthMetrics(observer, logger);
+
+    // Persist tool memory session to disk (Issue #690)
+    shutdownToolMemory();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -23,6 +23,7 @@ import type { SecurityConfig } from '../../config/schemas.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import type { Expert } from '../../agents/index.js';
+import { getToolMemory } from './tool-memory.js';
 
 /**
  * Input schema for execute_expert tool.
@@ -176,6 +177,38 @@ function buildSuccessResponse(
 }
 
 /**
+ * Records a successful expert execution to session memory. (Issue #690)
+ */
+function recordExpertSuccess(expertId: string, role: string, durationMs: number): void {
+  try {
+    const memory = getToolMemory();
+    memory.recordTask({
+      approach: `Expert execution: ${role} (${expertId})`,
+      challenges: [],
+      durationMs,
+    });
+  } catch {
+    // Best-effort memory recording
+  }
+}
+
+/**
+ * Records a failed expert execution to session memory. (Issue #690)
+ */
+function recordExpertError(expertId: string, role: string, errorMessage: string): void {
+  try {
+    const memory = getToolMemory();
+    memory.recordError({
+      error: `Expert ${role} (${expertId}): ${errorMessage.slice(0, 150)}`,
+      solution: 'Pending - expert execution failed',
+      filePattern: 'mcp/tools/execute-expert',
+    });
+  } catch {
+    // Best-effort memory recording
+  }
+}
+
+/**
  * Handles the execute_expert tool execution.
  */
 async function handleExecuteExpert(
@@ -205,6 +238,8 @@ async function handleExecuteExpert(
 
   if (!result.ok) {
     deps.logger?.warn('Expert execution failed', { expertId, error: result.error.message });
+    // Record error to session memory (Issue #690)
+    recordExpertError(expertId, expert.role, result.error.message);
     return {
       ok: true,
       value: buildErrorResponse(expertId, expert.role, result.error.message, durationMs),
@@ -216,6 +251,9 @@ async function handleExecuteExpert(
     durationMs,
     tokensUsed: result.value.metadata.tokensUsed,
   });
+
+  // Record success to session memory (Issue #690)
+  recordExpertSuccess(expertId, expert.role, durationMs);
 
   return {
     ok: true,

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -31,6 +31,7 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
 import type { ExecutionPlan, Expert } from '../../agents/index.js';
 import { createTechLeadWithSica } from './orchestrate-sica.js';
 import { OrchestratorFactory } from '../../orchestration/orchestrator-factory.js';
+import { getToolMemory } from './tool-memory.js';
 
 /**
  * Input schema for the orchestrate tool.
@@ -274,6 +275,57 @@ function createErrorOptions(
 }
 
 /**
+ * Records a successful orchestration to session memory.
+ * Safe to call - silently degrades if memory unavailable. (Issue #690)
+ */
+function recordOrchestrationSuccess(
+  taskId: string,
+  taskDescription: string,
+  stepsCompleted: number,
+  durationMs: number
+): void {
+  try {
+    const memory = getToolMemory();
+    memory.recordTask({
+      approach: `Orchestrated: ${taskDescription.slice(0, 100)}`,
+      challenges: [],
+      durationMs,
+    });
+    memory.recordLearning({
+      pattern: `Orchestration completed in ${String(stepsCompleted)} steps`,
+      context: `task=${taskId}`,
+      confidence: 0.7,
+      source: 'orchestrate-tool',
+    });
+  } catch {
+    // Memory recording is best-effort; never fail orchestration for it
+  }
+}
+
+/**
+ * Records an orchestration error to session memory.
+ * Safe to call - silently degrades if memory unavailable. (Issue #690)
+ */
+function recordOrchestrationError(errorMessage: string, taskDescription: string): void {
+  try {
+    const memory = getToolMemory();
+    memory.recordError({
+      error: errorMessage.slice(0, 200),
+      solution: 'Pending - orchestration failed',
+      filePattern: 'mcp/tools/orchestrate',
+    });
+    memory.recordLearning({
+      pattern: `Orchestration failure: ${errorMessage.slice(0, 80)}`,
+      context: `task=${taskDescription.slice(0, 60)}`,
+      confidence: 0.5,
+      source: 'orchestrate-tool-error',
+    });
+  } catch {
+    // Memory recording is best-effort; never fail orchestration for it
+  }
+}
+
+/**
  * Executes the orchestration logic.
  * Uses unified IOrchestrator interface via factory (Issue #595).
  */
@@ -297,6 +349,8 @@ async function executeOrchestration(
     if (!result.ok) {
       logger.error('Orchestration failed', result.error, { taskId });
       const cause = result.error instanceof Error ? result.error : undefined;
+      // Record error to session memory (Issue #690)
+      recordOrchestrationError(result.error.message, input.task);
       return err(
         new OrchestrationError(
           `Task execution failed: ${result.error.message}`,
@@ -307,6 +361,9 @@ async function executeOrchestration(
 
     const durationMs = getTimeProvider().now() - startTime;
     const output = buildOutputFromOrchestratorResult(taskId, result.value, durationMs);
+
+    // Record success to session memory (Issue #690)
+    recordOrchestrationSuccess(taskId, input.task, output.stepsCompleted, durationMs);
 
     logger.info('Orchestration completed', {
       taskId,
@@ -319,6 +376,8 @@ async function executeOrchestration(
     const message = error instanceof Error ? error.message : 'Unknown error';
     const cause = error instanceof Error ? error : undefined;
     logger.error('Orchestration exception', cause, { taskId });
+    // Record exception to session memory (Issue #690)
+    recordOrchestrationError(message, input.task);
     return err(
       new OrchestrationError(
         `Orchestration failed unexpectedly: ${message}`,

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.test.ts
@@ -1,0 +1,267 @@
+/**
+ * nexus-agents/mcp - Tool Memory Integration Tests
+ * (Source: Issue #690 - Wire memory system into MCP tool execution pipeline)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ILogger } from '../../core/index.js';
+
+/**
+ * These tests verify the ToolMemoryManager API surface and singleton behavior.
+ * SessionMemory is mocked at the module level to avoid filesystem side effects.
+ */
+
+// Mock SessionMemory before importing ToolMemoryManager
+const mockSessionMemory = {
+  startSession: vi.fn().mockReturnValue({ ok: true, value: [] }),
+  endSession: vi.fn().mockReturnValue({
+    ok: true,
+    value: { learnings: [], tasksCompleted: [], errorsResolved: [] },
+  }),
+  recordTask: vi.fn().mockReturnValue({ ok: true, value: undefined }),
+  recordLearning: vi.fn().mockReturnValue({ ok: true, value: undefined }),
+  recordError: vi.fn().mockReturnValue({ ok: true, value: undefined }),
+  isSessionActive: vi.fn().mockReturnValue(true),
+  searchLearnings: vi.fn().mockReturnValue([]),
+  getRecentErrorSolutions: vi.fn().mockReturnValue([]),
+};
+
+vi.mock('../../context/session-memory.js', () => ({
+  SessionMemory: vi.fn(() => mockSessionMemory),
+}));
+
+import { ToolMemoryManager, getToolMemory, shutdownToolMemory } from './tool-memory.js';
+import { SessionMemory } from '../../context/session-memory.js';
+
+/** Reset all mock return values after vi.clearAllMocks() clears them. */
+function resetMockDefaults(): void {
+  mockSessionMemory.startSession.mockReturnValue({ ok: true, value: [] });
+  mockSessionMemory.endSession.mockReturnValue({
+    ok: true,
+    value: { learnings: [], tasksCompleted: [], errorsResolved: [] },
+  });
+  mockSessionMemory.recordTask.mockReturnValue({ ok: true, value: undefined });
+  mockSessionMemory.recordLearning.mockReturnValue({ ok: true, value: undefined });
+  mockSessionMemory.recordError.mockReturnValue({ ok: true, value: undefined });
+  mockSessionMemory.isSessionActive.mockReturnValue(true);
+  mockSessionMemory.searchLearnings.mockReturnValue([]);
+  mockSessionMemory.getRecentErrorSolutions.mockReturnValue([]);
+}
+
+function createMockLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    setLevel: vi.fn(),
+  };
+}
+
+describe('ToolMemoryManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDefaults();
+    shutdownToolMemory();
+  });
+
+  afterEach(() => {
+    shutdownToolMemory();
+  });
+
+  describe('constructor', () => {
+    it('should create a SessionMemory and start a session', () => {
+      const logger = createMockLogger();
+      new ToolMemoryManager(logger);
+
+      expect(SessionMemory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memoryDir: expect.stringContaining('memory'),
+          logger,
+        })
+      );
+      expect(mockSessionMemory.startSession).toHaveBeenCalledWith(expect.stringContaining('mcp-'));
+    });
+
+    it('should handle session start failure gracefully', () => {
+      mockSessionMemory.startSession.mockReturnValueOnce({
+        ok: false,
+        error: { message: 'disk full' },
+      });
+
+      const logger = createMockLogger();
+      new ToolMemoryManager(logger);
+
+      expect(logger.warn).toHaveBeenCalledWith('Tool memory session start failed', {
+        error: 'disk full',
+      });
+    });
+
+    it('should store past learnings from session start', () => {
+      const pastLearnings = [{ pattern: 'test pattern', context: 'test ctx', confidence: 0.8 }];
+      mockSessionMemory.startSession.mockReturnValueOnce({
+        ok: true,
+        value: pastLearnings,
+      });
+
+      const manager = new ToolMemoryManager(createMockLogger());
+      expect(manager.getPastLearnings()).toEqual(pastLearnings);
+    });
+  });
+
+  describe('recordTask', () => {
+    it('should record a task to session memory', () => {
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.recordTask({
+        approach: 'Test approach',
+        challenges: ['challenge 1'],
+        durationMs: 1000,
+      });
+
+      expect(mockSessionMemory.recordTask).toHaveBeenCalledWith({
+        approach: 'Test approach',
+        challenges: ['challenge 1'],
+        durationMs: 1000,
+      });
+    });
+
+    it('should silently skip if session is inactive', () => {
+      mockSessionMemory.isSessionActive.mockReturnValue(false);
+
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.recordTask({ approach: 'Test', challenges: [] });
+
+      expect(mockSessionMemory.recordTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordLearning', () => {
+    it('should record a learning to session memory', () => {
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.recordLearning({
+        pattern: 'Orchestration completed',
+        context: 'task=123',
+        confidence: 0.7,
+        source: 'test',
+      });
+
+      expect(mockSessionMemory.recordLearning).toHaveBeenCalledWith({
+        pattern: 'Orchestration completed',
+        context: 'task=123',
+        confidence: 0.7,
+        source: 'test',
+      });
+    });
+  });
+
+  describe('recordError', () => {
+    it('should record an error to session memory', () => {
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.recordError({
+        error: 'Test error',
+        solution: 'Test solution',
+        filePattern: 'test/*.ts',
+      });
+
+      expect(mockSessionMemory.recordError).toHaveBeenCalledWith({
+        error: 'Test error',
+        solution: 'Test solution',
+        filePattern: 'test/*.ts',
+      });
+    });
+  });
+
+  describe('searchLearnings', () => {
+    it('should delegate search to session memory', () => {
+      const expected = [{ pattern: 'found', context: 'ctx', confidence: 0.9 }];
+      mockSessionMemory.searchLearnings.mockReturnValueOnce(expected);
+
+      const manager = new ToolMemoryManager(createMockLogger());
+      const result = manager.searchLearnings('test query');
+
+      expect(mockSessionMemory.searchLearnings).toHaveBeenCalledWith('test query');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getRecentErrorSolutions', () => {
+    it('should delegate to session memory', () => {
+      const expected = [{ error: 'err', solution: 'fix' }];
+      mockSessionMemory.getRecentErrorSolutions.mockReturnValueOnce(expected);
+
+      const manager = new ToolMemoryManager(createMockLogger());
+      const result = manager.getRecentErrorSolutions(5);
+
+      expect(mockSessionMemory.getRecentErrorSolutions).toHaveBeenCalledWith(5);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('endSession', () => {
+    it('should end the session and persist data', () => {
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.endSession();
+
+      expect(mockSessionMemory.endSession).toHaveBeenCalledWith('MCP session ended');
+    });
+
+    it('should skip if session is inactive', () => {
+      mockSessionMemory.isSessionActive.mockReturnValue(false);
+
+      const manager = new ToolMemoryManager(createMockLogger());
+      manager.endSession();
+
+      expect(mockSessionMemory.endSession).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('getToolMemory singleton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDefaults();
+    shutdownToolMemory();
+  });
+
+  afterEach(() => {
+    shutdownToolMemory();
+  });
+
+  it('should return the same instance on multiple calls', () => {
+    const a = getToolMemory();
+    const b = getToolMemory();
+    expect(a).toBe(b);
+  });
+
+  it('should create a new instance after shutdown', () => {
+    const a = getToolMemory();
+    shutdownToolMemory();
+    const b = getToolMemory();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('shutdownToolMemory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDefaults();
+    shutdownToolMemory();
+  });
+
+  it('should call endSession on the singleton', () => {
+    getToolMemory();
+    vi.clearAllMocks();
+    mockSessionMemory.isSessionActive.mockReturnValue(true);
+
+    shutdownToolMemory();
+
+    expect(mockSessionMemory.endSession).toHaveBeenCalled();
+  });
+
+  it('should be safe to call multiple times', () => {
+    shutdownToolMemory();
+    shutdownToolMemory();
+    // Should not throw
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -1,0 +1,168 @@
+/**
+ * nexus-agents/mcp - Tool Memory Integration
+ *
+ * Shared session memory for MCP tools. Enables learning persistence
+ * across tool calls within a session. Tools record task outcomes,
+ * learnings, and error resolutions which persist to disk.
+ *
+ * @module mcp/tools/tool-memory
+ * (Source: Issue #690 - Wire memory system into MCP tool execution pipeline)
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ILogger } from '../../core/index.js';
+import { createLogger, getTimeProvider } from '../../core/index.js';
+import { SessionMemory } from '../../context/session-memory.js';
+import type {
+  SessionLearning,
+  CompletedTask,
+  ResolvedError,
+} from '../../context/session-memory-types.js';
+
+// Re-export types tools may need
+export type { SessionLearning, CompletedTask, ResolvedError };
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default memory directory under user home. */
+const DEFAULT_MEMORY_DIR = path.join(os.homedir(), '.nexus-agents', 'memory', 'sessions');
+
+// ============================================================================
+// Shared Instance (Singleton per process)
+// ============================================================================
+
+let sharedInstance: ToolMemoryManager | null = null;
+
+/**
+ * Get or create the shared ToolMemoryManager singleton.
+ * Automatically starts a session on first access.
+ */
+export function getToolMemory(logger?: ILogger): ToolMemoryManager {
+  sharedInstance ??= new ToolMemoryManager(logger);
+  return sharedInstance;
+}
+
+/**
+ * Shut down the shared memory instance. Call during server cleanup.
+ */
+export function shutdownToolMemory(): void {
+  if (sharedInstance !== null) {
+    sharedInstance.endSession();
+    sharedInstance = null;
+  }
+}
+
+// ============================================================================
+// ToolMemoryManager
+// ============================================================================
+
+/**
+ * Manages session memory for MCP tool execution.
+ * Auto-initializes a session and provides safe recording methods
+ * that silently degrade if memory is unavailable.
+ */
+export class ToolMemoryManager {
+  private readonly memory: SessionMemory;
+  private readonly log: ILogger;
+  private pastLearnings: readonly SessionLearning[] = [];
+
+  constructor(logger?: ILogger) {
+    this.log = logger ?? createLogger({ component: 'ToolMemory' });
+
+    this.memory = new SessionMemory({
+      memoryDir: DEFAULT_MEMORY_DIR,
+      logger: this.log,
+    });
+
+    // Auto-start session
+    const sessionId = `mcp-${String(getTimeProvider().now())}`;
+    const result = this.memory.startSession(sessionId);
+    if (result.ok) {
+      this.pastLearnings = result.value;
+      this.log.info('Tool memory session started', {
+        sessionId,
+        pastLearnings: this.pastLearnings.length,
+      });
+    } else {
+      this.log.warn('Tool memory session start failed', {
+        error: result.error.message,
+      });
+    }
+  }
+
+  /**
+   * Get learnings from previous sessions.
+   */
+  getPastLearnings(): readonly SessionLearning[] {
+    return this.pastLearnings;
+  }
+
+  /**
+   * Record a completed task. Safe to call even if session inactive.
+   */
+  recordTask(task: CompletedTask): void {
+    if (!this.memory.isSessionActive()) return;
+
+    const result = this.memory.recordTask(task);
+    if (!result.ok) {
+      this.log.debug('Failed to record task', { error: result.error.message });
+    }
+  }
+
+  /**
+   * Record a learning. Safe to call even if session inactive.
+   */
+  recordLearning(learning: SessionLearning): void {
+    if (!this.memory.isSessionActive()) return;
+
+    const result = this.memory.recordLearning(learning);
+    if (!result.ok) {
+      this.log.debug('Failed to record learning', { error: result.error.message });
+    }
+  }
+
+  /**
+   * Record a resolved error. Safe to call even if session inactive.
+   */
+  recordError(error: ResolvedError): void {
+    if (!this.memory.isSessionActive()) return;
+
+    const result = this.memory.recordError(error);
+    if (!result.ok) {
+      this.log.debug('Failed to record error', { error: result.error.message });
+    }
+  }
+
+  /**
+   * Search past learnings for relevant patterns.
+   */
+  searchLearnings(query: string): readonly SessionLearning[] {
+    return this.memory.searchLearnings(query);
+  }
+
+  /**
+   * Get recent error solutions.
+   */
+  getRecentErrorSolutions(limit?: number): readonly ResolvedError[] {
+    return this.memory.getRecentErrorSolutions(limit);
+  }
+
+  /**
+   * End the current session and persist to disk.
+   */
+  endSession(): void {
+    if (!this.memory.isSessionActive()) return;
+
+    const result = this.memory.endSession('MCP session ended');
+    if (result.ok) {
+      this.log.info('Tool memory session saved', {
+        learnings: result.value.learnings.length,
+        tasks: result.value.tasksCompleted.length,
+        errors: result.value.errorsResolved.length,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #690

- **Create `tool-memory.ts`** — shared `ToolMemoryManager` singleton that wraps `SessionMemory` for MCP tools. Auto-starts a session on first access, provides safe recording methods that silently degrade if memory is unavailable.
- **Wire into `orchestrate` tool** — records task completion (approach, duration), learnings (step count), and errors to session memory on every orchestration call
- **Wire into `execute-expert` tool** — records expert execution success/failure to session memory
- **Wire shutdown into server lifecycle** — `shutdownToolMemory()` called during MCP server cleanup to persist session data to disk
- **15 tests** covering ToolMemoryManager API, singleton behavior, and shutdown safety

The memory system was complete but dormant — this PR activates it for the two most-used MCP tools so learnings and error resolutions persist across sessions.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all 10726 tests pass (337 files)
- [x] Fitness score: 97/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)