### PR TITLE
fix: complete scaffold TODOs and remove deprecated Gemini aliases

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
@@ -14,13 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  GeminiCliAdapter,
-  createGeminiAdapter,
-  // Test deprecated aliases work
-  EnhancedGeminiCliAdapter,
-  createEnhancedGeminiAdapter,
-} from './gemini-adapter.js';
+import { GeminiCliAdapter, createGeminiAdapter } from './gemini-adapter.js';
 
 describe('GeminiCliAdapter', () => {
   let adapter: GeminiCliAdapter;
@@ -95,21 +89,6 @@ describe('GeminiCliAdapter', () => {
     it('should pass configuration to adapter', () => {
       const instance = createGeminiAdapter({ model: 'gemini-2.5-pro' });
       expect(instance.getModelInfo().id).toBe('gemini-2.5-pro');
-    });
-
-    it('should support deprecated createEnhancedGeminiAdapter', () => {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      const instance = createEnhancedGeminiAdapter();
-      expect(instance).toBeInstanceOf(GeminiCliAdapter);
-    });
-  });
-
-  describe('deprecated aliases', () => {
-    it('should work with EnhancedGeminiCliAdapter alias', () => {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      const enhanced = new EnhancedGeminiCliAdapter();
-      expect(enhanced.name).toBe('gemini');
-      expect(enhanced).toBeInstanceOf(GeminiCliAdapter);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -66,11 +66,6 @@ export interface GeminiConfig {
   readonly enableCircuitBreaker?: boolean;
 }
 
-/**
- * @deprecated Use GeminiConfig instead
- */
-export type EnhancedGeminiConfig = GeminiConfig;
-
 /** Retry context for tracking retry state. */
 interface RetryContext {
   readonly attempt: number;
@@ -87,11 +82,6 @@ export interface GeminiExecutionResult {
   readonly complexity: TaskComplexity;
   readonly circuitState: 'closed' | 'open' | 'half-open';
 }
-
-/**
- * @deprecated Use GeminiExecutionResult instead
- */
-export type EnhancedExecutionResult = GeminiExecutionResult;
 
 const DEFAULT_CONFIG: Required<Omit<GeminiConfig, 'logger' | 'circuitBreakerConfig'>> = {
   model: 'gemini-2.5-flash',
@@ -189,16 +179,6 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
     const result = await this.executeWithRetryTracking(task, effectiveOptions);
 
     return this.buildExecutionResult(result, startTime, complexity);
-  }
-
-  /**
-   * @deprecated Use executeWithMetadata instead
-   */
-  async executeEnhanced(
-    task: CliTask,
-    options?: ExecutionOptions
-  ): Promise<Result<GeminiExecutionResult, CliError>> {
-    return this.executeWithMetadata(task, options);
   }
 
   /**
@@ -383,13 +363,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
   }
 }
 
-/** @deprecated Use GeminiCliAdapter instead */
-export const EnhancedGeminiCliAdapter = GeminiCliAdapter;
-
 /** Creates a Gemini CLI adapter with reliability features. */
 export function createGeminiAdapter(config?: GeminiConfig): GeminiCliAdapter {
   return new GeminiCliAdapter(config);
 }
-
-/** @deprecated Use createGeminiAdapter instead */
-export const createEnhancedGeminiAdapter = createGeminiAdapter;

--- a/packages/nexus-agents/src/cli-adapters/adapters/index.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/index.ts
@@ -14,9 +14,3 @@ export { CodexMcpAdapter } from './codex-mcp-adapter.js';
 // Gemini adapter with retry and circuit breaker (Issue #366, #389)
 export { GeminiCliAdapter, createGeminiAdapter } from './gemini-adapter.js';
 export type { GeminiConfig, GeminiExecutionResult } from './gemini-adapter.js';
-
-// Deprecated aliases re-exported for backward compatibility
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-export { EnhancedGeminiCliAdapter, createEnhancedGeminiAdapter } from './gemini-adapter.js';
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-export type { EnhancedGeminiConfig, EnhancedExecutionResult } from './gemini-adapter.js';

--- a/packages/nexus-agents/src/cli/scaffold-templates.ts
+++ b/packages/nexus-agents/src/cli/scaffold-templates.ts
@@ -40,8 +40,8 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
  * Input schema for ${name} tool.
  */
 export const ${pascal}InputSchema = z.object({
-  // TODO: Define input parameters
-  input: z.string().min(1).describe('Input for ${name}'),
+  input: z.string().min(1).describe('Primary input for ${name} operation'),
+  options: z.record(z.unknown()).optional().describe('Additional options'),
 });
 
 export type ${pascal}Input = z.infer<typeof ${pascal}InputSchema>;
@@ -75,9 +75,9 @@ function create${pascal}Handler(deps: ${pascal}Deps) {
 
     ctx.logger.debug('Executing ${name}', { input: validated.data.input });
 
-    // TODO: Implement tool logic
+    const output = { status: 'ok', input: validated.data.input };
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify({ status: 'ok' }, null, 2) }],
+      content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
     };
   };
 }
@@ -91,7 +91,7 @@ export function register${pascal}Tool(server: McpServer, deps: ${pascal}Deps): v
     input: z.string().min(1).describe('Input for ${name}'),
   };
 
-  const description = '${pascal} tool - TODO: add description';
+  const description = '${pascal} tool for ${name} operations.';
 
   const secureHandler = createSecureHandler(create${pascal}Handler(deps), {
     toolName: '${name}',
@@ -176,14 +176,18 @@ export function generateExpertFiles(name: string): GeneratedFile[] {
  * ${pascal} domain knowledge patterns.
  */
 export const ${screaming}_PATTERNS = [
-  // TODO: Add domain-specific patterns
+  'Analyze ${name} requirements before implementation',
+  'Validate ${name} outputs against acceptance criteria',
+  'Document ${name} decisions and trade-offs',
 ] as const;
 
 /**
  * ${pascal} best practices.
  */
 export const ${screaming}_BEST_PRACTICES = [
-  // TODO: Add best practices
+  'Follow single-responsibility principle for ${name} components',
+  'Write tests before implementing ${name} logic',
+  'Use structured error handling with Result types',
 ] as const;
 `,
     },
@@ -198,11 +202,11 @@ export function generateWorkflowFiles(name: string): GeneratedFile[] {
       content: `# ${name} Workflow Template
 # (Source: Issue #653 - Scaffolded)
 #
-# TODO: Add workflow description
+# Executes a ${name} analysis and generates a report.
 #
 name: "${name}"
 version: "1.0.0"
-description: "TODO: Describe ${name} workflow"
+description: "Analyze and report on ${name} targets."
 
 inputs:
   target:
@@ -216,7 +220,7 @@ steps:
     agent: "code_expert"
     prompt: |
       Analyze the target: {{target}}
-      TODO: Add specific instructions.
+      Identify key findings, potential issues, and recommendations.
     timeout: 120
 
   - id: "report"
@@ -239,7 +243,7 @@ function commandSourceContent(name: string, pascal: string, camel: string): stri
   return `/**
  * nexus-agents ${name} command
  *
- * TODO: Add command description.
+ * CLI command for ${name} operations.
  *
  * @module cli/${name}
  * (Source: Issue #653 - Scaffolded)
@@ -258,9 +262,10 @@ export interface ${pascal}Result {
  * Runs the ${name} command logic.
  */
 export function run${pascal}(options: ${pascal}Options): ${pascal}Result {
-  // TODO: Implement command logic
-  void options;
-  return { success: true, message: '${pascal} completed' };
+  if (options.verbose === true) {
+    process.stdout.write('Running ${name} in verbose mode...\\n');
+  }
+  return { success: true, message: '${pascal} completed successfully.' };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace all 10 TODO placeholders in scaffold-templates.ts with meaningful default template content
- Remove 5 deprecated Gemini adapter aliases that were overdue for removal since v2.4 (now v2.6.0):
  - `EnhancedGeminiConfig` → `GeminiConfig`
  - `EnhancedExecutionResult` → `GeminiExecutionResult`
  - `executeEnhanced()` → `executeWithMetadata()`
  - `EnhancedGeminiCliAdapter` → `GeminiCliAdapter`
  - `createEnhancedGeminiAdapter` → `createGeminiAdapter`

## Test plan
- [x] All 337 test files pass (10727 tests)
- [x] Lint clean
- [x] Typecheck clean
- [x] Fitness score 97/100
- [x] No remaining references to deprecated aliases in src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)