### PR TITLE
fix(#704): GitHub OR logic, Semantic Scholar sort, sinceDate wiring

### DIFF
--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for academic source discovery providers (Semantic Scholar, Papers with Code).
+ *
+ * @module cli/research-helpers-sources-academic.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  discoverSemanticScholar,
+  discoverPapersWithCode,
+} from './research-helpers-sources-academic.js';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('discoverSemanticScholar', () => {
+  it('should parse valid response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              paperId: 'abc123',
+              title: 'Multi-Agent Orchestration',
+              url: 'https://semanticscholar.org/paper/abc123',
+              abstract: 'A paper about agents.',
+              citationCount: 150,
+              year: 2025,
+              isOpenAccess: true,
+              externalIds: { ArXiv: '2401.12345' },
+            },
+          ],
+        }),
+    });
+
+    const result = await discoverSemanticScholar('orchestration', 10);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]?.source).toBe('semantic_scholar');
+      expect(result.value[0]?.title).toBe('Multi-Agent Orchestration');
+      expect(result.value[0]?.url).toContain('2401.12345');
+      expect(result.value[0]?.relevance).toBe('high');
+    }
+  });
+
+  it('should not include sort parameter in URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    });
+    await discoverSemanticScholar('test', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    expect(calledUrl).not.toContain('sort=');
+  });
+
+  it('should handle HTTP errors', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
+    const result = await discoverSemanticScholar('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('HTTP_ERROR');
+  });
+
+  it('should handle network errors', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+    const result = await discoverSemanticScholar('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('NETWORK');
+  });
+
+  it('should return PARSE_ERROR on invalid schema', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve('not an object'),
+    });
+    const result = await discoverSemanticScholar('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('PARSE_ERROR');
+  });
+
+  it('should filter out papers without titles', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            { paperId: 'a', title: '', abstract: 'no title' },
+            { paperId: 'b', title: 'Valid Paper', abstract: 'has title' },
+          ],
+        }),
+    });
+    const result = await discoverSemanticScholar('test', 10);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+});
+
+describe('discoverPapersWithCode', () => {
+  it('should parse valid response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              id: 'paper1',
+              title: 'Agent Framework',
+              url_abs: 'https://paperswithcode.com/paper/agent-framework',
+              abstract: 'A framework for agents',
+              repository_count: 3,
+            },
+          ],
+        }),
+    });
+
+    const result = await discoverPapersWithCode('agent framework', 10);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]?.source).toBe('papers_with_code');
+      expect(result.value[0]?.relevance).toBe('high');
+    }
+  });
+
+  it('should handle HTTP errors', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    const result = await discoverPapersWithCode('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('HTTP_ERROR');
+  });
+
+  it('should return PARSE_ERROR on invalid schema', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(42),
+    });
+    const result = await discoverPapersWithCode('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('PARSE_ERROR');
+  });
+
+  it('should mark papers without repos as medium relevance', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            { title: 'No Code Paper', url_abs: 'https://example.com', repository_count: 0 },
+          ],
+        }),
+    });
+    const result = await discoverPapersWithCode('test', 10);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value[0]?.relevance).toBe('medium');
+  });
+});

--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
@@ -111,7 +111,8 @@ export async function discoverSemanticScholar(
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
   const query = encodeURIComponent(topic);
   const fields = 'title,url,abstract,citationCount,year,isOpenAccess,externalIds';
-  const url = `https://api.semanticscholar.org/graph/v1/paper/search?query=${query}&limit=${String(maxResults)}&fields=${fields}&sort=citationCount:desc`;
+  // Note: sort parameter only works on /paper/search/bulk, not /paper/search
+  const url = `https://api.semanticscholar.org/graph/v1/paper/search?query=${query}&limit=${String(maxResults)}&fields=${fields}`;
 
   const fetchResult = await fetchSource({
     url,

--- a/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
@@ -107,6 +107,18 @@ describe('discoverGitHubRepos', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('TIMEOUT');
   });
+
+  it('should use OR logic for language filters', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [] }),
+    });
+    await discoverGitHubRepos('agent orchestration', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).toContain('language:python OR language:typescript');
+    expect(decoded).not.toContain('language:python language:typescript');
+  });
 });
 
 describe('fetchSource', () => {
@@ -201,6 +213,28 @@ describe('discoverArxiv', () => {
     expect(calledUrl).toContain('ti%3A');
     expect(calledUrl).toContain('abs%3A');
     expect(calledUrl).not.toContain('all%3A');
+  });
+
+  it('should include submittedDate filter when sinceDate is provided', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('<feed></feed>'),
+    });
+    await discoverArxiv('agents', 5, '2025-01-15');
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).toContain('submittedDate:[20250115 TO');
+  });
+
+  it('should not include date filter when sinceDate is absent', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('<feed></feed>'),
+    });
+    await discoverArxiv('agents', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).not.toContain('submittedDate:[');
   });
 });
 

--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -151,7 +151,7 @@ export async function discoverGitHubRepos(
   topic: string,
   maxResults = 10
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  const query = encodeURIComponent(`${topic} language:python language:typescript`);
+  const query = encodeURIComponent(`${topic} language:python OR language:typescript`);
   const url = `https://api.github.com/search/repositories?q=${query}&sort=stars&order=desc&per_page=${String(maxResults)}`;
 
   const fetchResult = await fetchSource({
@@ -176,15 +176,32 @@ export async function discoverGitHubRepos(
 // ARXIV-BASED DISCOVERY (shared helper)
 // =============================================================================
 
+/** Options for arXiv-based discovery. */
+interface ArxivQueryOptions {
+  readonly topic: string;
+  readonly authorFilter: string;
+  readonly maxResults: number;
+  readonly sinceDate?: string | undefined;
+}
+
 /**
  * Builds an arXiv API search URL with targeted field queries.
  * Uses ti: (title) and abs: (abstract) instead of all: for better relevance.
+ * Optionally adds a submittedDate range filter when sinceDate is provided.
  */
-function buildArxivUrl(topic: string, authorFilter: string, maxResults: number): string {
-  const topicQuery = `(ti:${topic} OR abs:${topic})`;
-  const fullQuery = authorFilter !== '' ? `${topicQuery} AND ${authorFilter}` : topicQuery;
+function buildArxivUrl(opts: ArxivQueryOptions): string {
+  const topicQuery = `(ti:${opts.topic} OR abs:${opts.topic})`;
+  let fullQuery = opts.authorFilter !== '' ? `${topicQuery} AND ${opts.authorFilter}` : topicQuery;
+
+  // Add date range filter if sinceDate provided (format: YYYYMMDD)
+  if (opts.sinceDate !== undefined && /^\d{4}-\d{2}-\d{2}$/.test(opts.sinceDate)) {
+    const dateNum = opts.sinceDate.replace(/-/g, '');
+    const today = new Date().toISOString().split('T')[0]?.replace(/-/g, '') ?? '';
+    fullQuery = `${fullQuery} AND submittedDate:[${dateNum} TO ${today}]`;
+  }
+
   const encoded = encodeURIComponent(fullQuery);
-  return `https://export.arxiv.org/api/query?search_query=${encoded}&start=0&max_results=${String(maxResults)}&sortBy=submittedDate&sortOrder=descending`;
+  return `https://export.arxiv.org/api/query?search_query=${encoded}&start=0&max_results=${String(opts.maxResults)}&sortBy=submittedDate&sortOrder=descending`;
 }
 
 /**
@@ -195,9 +212,10 @@ async function discoverFromArxiv(
   topic: string,
   authorFilter: string,
   source: string,
-  maxResults: number
+  maxResults: number,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  const url = buildArxivUrl(topic, authorFilter, maxResults);
+  const url = buildArxivUrl({ topic, authorFilter, maxResults, sinceDate });
   const fetchResult = await fetchSource({ url, source });
   if (!fetchResult.ok) return fetchResult;
 
@@ -216,13 +234,15 @@ async function discoverFromArxiv(
  *
  * @param topic - Search topic
  * @param maxResults - Maximum results (default 10)
+ * @param sinceDate - Optional date filter (YYYY-MM-DD)
  * @returns Result containing discovered items
  */
 export async function discoverArxiv(
   topic: string,
-  maxResults = 10
+  maxResults = 10,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  return discoverFromArxiv(topic, '', 'arxiv', maxResults);
+  return discoverFromArxiv(topic, '', 'arxiv', maxResults, sinceDate);
 }
 
 // =============================================================================
@@ -238,13 +258,15 @@ export async function discoverArxiv(
  */
 export async function discoverGoogleAI(
   topic: string,
-  maxResults = 10
+  maxResults = 10,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
   return discoverFromArxiv(
     topic,
     '(au:"Google Research" OR au:"Google DeepMind" OR au:"Google Brain")',
     'google_ai',
-    maxResults
+    maxResults,
+    sinceDate
   );
 }
 
@@ -261,13 +283,15 @@ export async function discoverGoogleAI(
  */
 export async function discoverMetaFAIR(
   topic: string,
-  maxResults = 10
+  maxResults = 10,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
   return discoverFromArxiv(
     topic,
     '(au:"Meta AI" OR au:FAIR OR au:"Meta Research")',
     'meta_fair',
-    maxResults
+    maxResults,
+    sinceDate
   );
 }
 
@@ -284,9 +308,16 @@ export async function discoverMetaFAIR(
  */
 export async function discoverMicrosoftResearch(
   topic: string,
-  maxResults = 10
+  maxResults = 10,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  return discoverFromArxiv(topic, '(au:"Microsoft Research" OR au:MSR)', 'microsoft', maxResults);
+  return discoverFromArxiv(
+    topic,
+    '(au:"Microsoft Research" OR au:MSR)',
+    'microsoft',
+    maxResults,
+    sinceDate
+  );
 }
 
 // =============================================================================
@@ -302,9 +333,16 @@ export async function discoverMicrosoftResearch(
  */
 export async function discoverDeepMind(
   topic: string,
-  maxResults = 10
+  maxResults = 10,
+  sinceDate?: string
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  return discoverFromArxiv(topic, '(au:DeepMind OR au:"Google DeepMind")', 'deepmind', maxResults);
+  return discoverFromArxiv(
+    topic,
+    '(au:DeepMind OR au:"Google DeepMind")',
+    'deepmind',
+    maxResults,
+    sinceDate
+  );
 }
 
 // =============================================================================

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -208,21 +208,22 @@ async function discoverFromExtendedSource(
   source: string,
   topic: string,
   maxResults: number,
-  logger: ILogger
+  logger: ILogger,
+  sinceDate?: string
 ): Promise<DiscoveredItem[]> {
   let result;
   switch (source) {
     case 'google_ai':
-      result = await discoverGoogleAI(topic, maxResults);
+      result = await discoverGoogleAI(topic, maxResults, sinceDate);
       break;
     case 'meta_fair':
-      result = await discoverMetaFAIR(topic, maxResults);
+      result = await discoverMetaFAIR(topic, maxResults, sinceDate);
       break;
     case 'microsoft':
-      result = await discoverMicrosoftResearch(topic, maxResults);
+      result = await discoverMicrosoftResearch(topic, maxResults, sinceDate);
       break;
     case 'deepmind':
-      result = await discoverDeepMind(topic, maxResults);
+      result = await discoverDeepMind(topic, maxResults, sinceDate);
       break;
     case 'semantic_scholar':
       result = await discoverSemanticScholar(topic, maxResults);
@@ -234,7 +235,11 @@ async function discoverFromExtendedSource(
       return [];
   }
   if (!result.ok) {
-    logger.warn(`${source} discovery failed`, { error: result.error.message });
+    logger.warn(`${source} discovery failed`, {
+      source,
+      errorCode: result.error.code,
+      error: result.error.message,
+    });
     return [];
   }
   return toDiscoveredItems(result.value);
@@ -327,20 +332,27 @@ async function queryAllSources(
   // arXiv uses dedicated discoverArxiv() with targeted ti:/abs: queries
   if (shouldQuery('arxiv')) {
     sources.push('arxiv');
-    const r = await discoverArxiv(input.topic, input.maxResults);
+    const r = await discoverArxiv(input.topic, input.maxResults, input.sinceDate);
     if (r.ok) items = items.concat(toDiscoveredItems(r.value));
-    else logger.warn('arxiv discovery failed', { error: r.error.message });
+    else logger.warn('arxiv discovery failed', { source: 'arxiv', error: r.error.message });
   }
   if (shouldQuery('github')) {
     sources.push('github');
     const r = await discoverGitHubRepos(input.topic, input.maxResults);
     if (r.ok) items = items.concat(toDiscoveredItems(r.value));
+    else logger.warn('github discovery failed', { source: 'github', error: r.error.message });
   }
   for (const src of ALL_SOURCES) {
     if (shouldQuery(src)) {
       sources.push(src);
       items = items.concat(
-        await discoverFromExtendedSource(src, input.topic, input.maxResults, logger)
+        await discoverFromExtendedSource(
+          src,
+          input.topic,
+          input.maxResults,
+          logger,
+          input.sinceDate
+        )
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes #704: GitHub and Semantic Scholar discovery sources return empty results.

- **GitHub query fix**: Changed `language:python language:typescript` (AND logic, requires both) to `language:python OR language:typescript` (inclusive, matches either). This was causing zero results for most research topics.
- **Semantic Scholar fix**: Removed `sort=citationCount:desc` from the API URL. The [sort parameter is only supported on `/paper/search/bulk`](https://api.semanticscholar.org/api-docs/), not the regular `/paper/search` endpoint. The invalid parameter was causing the API to reject or ignore requests.
- **Wire sinceDate to arXiv API**: The `sinceDate` parameter was accepted by the input schema but never applied to queries. Now adds `submittedDate:[YYYYMMDD TO YYYYMMDD]` range filter to arXiv queries when provided.
- **Enrich error context**: Discovery failure logs now include source name, error code, and structured context for faster debugging.
- **13 new tests**: Semantic Scholar (6), Papers with Code (4), sinceDate filtering (2), GitHub OR logic (1).

## Consensus Votes

- sinceDate wiring: 3/3 approve (quick majority)
- Error context enrichment: 3/3 approve (quick majority)

## Test plan

- [x] 54 related tests pass (13 new)
- [x] Full suite: 10,881 tests pass, 0 failures
- [x] Lint clean, typecheck clean
- [x] Fitness score: 97/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)