### PR TITLE
fix: flaky port allocation, silent catch observability, auto-catalog tests

### DIFF
--- a/packages/nexus-agents/src/api/rest-server.test.ts
+++ b/packages/nexus-agents/src/api/rest-server.test.ts
@@ -5,9 +5,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { RestApiServer } from './rest-server.js';
 
-/** Get a random port between 40000-50000 for testing. */
+/**
+ * Generates a test port using PID + random offset to minimize EADDRINUSE collisions
+ * in parallel test execution. Range: 10000-60000.
+ */
+let portCounter = 0;
 function getTestPort(): number {
-  return 40000 + Math.floor(Math.random() * 10000);
+  const base = 10000 + (process.pid % 50000);
+  return ((base + portCounter++) % 50000) + 10000;
 }
 
 describe('RestApiServer', () => {

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -188,8 +188,12 @@ function recordExpertSuccess(expertId: string, role: string, durationMs: number)
       challenges: [],
       durationMs,
     });
-  } catch {
+  } catch (error: unknown) {
     // Best-effort memory recording
+    createLogger({ tool: 'execute_expert' }).debug('Best-effort success recording failed', {
+      error: error instanceof Error ? error.message : String(error),
+      expertId,
+    });
   }
 }
 
@@ -204,8 +208,25 @@ function recordExpertError(expertId: string, role: string, errorMessage: string)
       solution: 'Pending - expert execution failed',
       filePattern: 'mcp/tools/execute-expert',
     });
-  } catch {
+  } catch (error: unknown) {
     // Best-effort memory recording
+    createLogger({ tool: 'execute_expert' }).debug('Best-effort error recording failed', {
+      error: error instanceof Error ? error.message : String(error),
+      expertId,
+    });
+  }
+}
+
+/** Scans expert output for research references (best-effort). */
+function autoCatalogScan(output: string, expertId: string, logger?: ILogger): void {
+  try {
+    const catalog = getAutoCatalog();
+    catalog.scanAndRecord(output, 'execute_expert');
+  } catch (error: unknown) {
+    logger?.debug('Best-effort auto-catalog scan failed', {
+      error: error instanceof Error ? error.message : String(error),
+      expertId,
+    });
   }
 }
 
@@ -239,7 +260,6 @@ async function handleExecuteExpert(
 
   if (!result.ok) {
     deps.logger?.warn('Expert execution failed', { expertId, error: result.error.message });
-    // Record error to session memory (Issue #690)
     recordExpertError(expertId, expert.role, result.error.message);
     return {
       ok: true,
@@ -253,16 +273,8 @@ async function handleExecuteExpert(
     tokensUsed: result.value.metadata.tokensUsed,
   });
 
-  // Record success to session memory (Issue #690)
   recordExpertSuccess(expertId, expert.role, durationMs);
-
-  // Auto-catalog: scan output for research references
-  try {
-    const catalog = getAutoCatalog();
-    catalog.scanAndRecord(result.value.output as string, 'execute_expert');
-  } catch {
-    // Auto-catalog is best-effort
-  }
+  autoCatalogScan(result.value.output as string, expertId, deps.logger);
 
   return {
     ok: true,

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -298,16 +298,23 @@ function recordOrchestrationSuccess(
       confidence: 0.7,
       source: 'orchestrate-tool',
     });
-  } catch {
+  } catch (error: unknown) {
     // Memory recording is best-effort; never fail orchestration for it
+    createLogger({ tool: 'orchestrate' }).debug('Best-effort memory recording failed', {
+      error: error instanceof Error ? error.message : String(error),
+      taskId,
+    });
   }
 
   // Auto-catalog: scan task description for research references
   try {
     const catalog = getAutoCatalog();
     catalog.scanAndRecord(taskDescription, 'orchestrate');
-  } catch {
+  } catch (error: unknown) {
     // Auto-catalog is best-effort
+    createLogger({ tool: 'orchestrate' }).debug('Best-effort auto-catalog scan failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 
@@ -329,8 +336,11 @@ function recordOrchestrationError(errorMessage: string, taskDescription: string)
       confidence: 0.5,
       source: 'orchestrate-tool-error',
     });
-  } catch {
+  } catch (error: unknown) {
     // Memory recording is best-effort; never fail orchestration for it
+    createLogger({ tool: 'orchestrate' }).debug('Best-effort error recording failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 

--- a/packages/nexus-agents/src/mcp/tools/research-auto-catalog.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-auto-catalog.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for research auto-catalog module.
+ *
+ * Covers: pattern extraction, duplicate detection, persistence,
+ * pending/review/dismiss/flush operations, and error handling.
+ *
+ * @module mcp/tools/research-auto-catalog.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import { ResearchAutoCatalog, resetAutoCatalog, getAutoCatalog } from './research-auto-catalog.js';
+
+// Mock fs and tool-memory to isolate unit tests
+vi.mock('node:fs');
+vi.mock('./tool-memory.js', () => ({
+  getToolMemory: () => ({
+    recordLearning: vi.fn(),
+  }),
+}));
+
+const mockFs = vi.mocked(fs);
+
+beforeEach(() => {
+  resetAutoCatalog();
+  mockFs.existsSync.mockReturnValue(false);
+  mockFs.readFileSync.mockReturnValue('');
+  mockFs.mkdirSync.mockReturnValue(undefined);
+  mockFs.writeFileSync.mockReturnValue(undefined);
+  mockFs.renameSync.mockReturnValue(undefined);
+  mockFs.unlinkSync.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ResearchAutoCatalog', () => {
+  describe('scanAndRecord', () => {
+    it('should detect arXiv IDs in text', () => {
+      const catalog = new ResearchAutoCatalog();
+      const count = catalog.scanAndRecord(
+        'Check out paper 2401.12345 for details on multi-agent systems.',
+        'test_tool'
+      );
+      expect(count).toBe(1);
+      const pending = catalog.getPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.type).toBe('arxiv');
+      expect(pending[0]?.identifier).toBe('2401.12345');
+      expect(pending[0]?.sourceTool).toBe('test_tool');
+    });
+
+    it('should detect multiple arXiv IDs', () => {
+      const catalog = new ResearchAutoCatalog();
+      const count = catalog.scanAndRecord(
+        'Papers 2401.12345 and 2403.67890 are relevant.',
+        'test_tool'
+      );
+      expect(count).toBe(2);
+      expect(catalog.getPending()).toHaveLength(2);
+    });
+
+    it('should detect GitHub URLs', () => {
+      const catalog = new ResearchAutoCatalog();
+      const count = catalog.scanAndRecord(
+        'See https://github.com/owner/repo for implementation.',
+        'test_tool'
+      );
+      expect(count).toBe(1);
+      const pending = catalog.getPending();
+      expect(pending[0]?.type).toBe('github');
+      expect(pending[0]?.identifier).toBe('https://github.com/owner/repo');
+    });
+
+    it('should detect both arXiv and GitHub in same text', () => {
+      const catalog = new ResearchAutoCatalog();
+      const count = catalog.scanAndRecord(
+        'Paper 2401.12345 has code at github.com/org/project.',
+        'test_tool'
+      );
+      expect(count).toBe(2);
+    });
+
+    it('should skip duplicate arXiv IDs', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 is great.', 'tool1');
+      const count = catalog.scanAndRecord('Again 2401.12345 mentioned.', 'tool2');
+      expect(count).toBe(0);
+      expect(catalog.getPending()).toHaveLength(1);
+    });
+
+    it('should skip duplicate GitHub URLs', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('See github.com/org/repo for details.', 'tool1');
+      const count = catalog.scanAndRecord('Also github.com/org/repo here.', 'tool2');
+      expect(count).toBe(0);
+      expect(catalog.getPending()).toHaveLength(1);
+    });
+
+    it('should return 0 for text with no references', () => {
+      const catalog = new ResearchAutoCatalog();
+      const count = catalog.scanAndRecord('No references here at all.', 'test_tool');
+      expect(count).toBe(0);
+      expect(catalog.getPending()).toHaveLength(0);
+    });
+
+    it('should extract surrounding context', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord(
+        'The paper 2401.12345 discusses multi-agent orchestration patterns.',
+        'test_tool'
+      );
+      const pending = catalog.getPending();
+      expect(pending[0]?.context).toContain('2401.12345');
+      expect(pending[0]?.context.length).toBeLessThanOrEqual(120);
+    });
+  });
+
+  describe('markReviewed', () => {
+    it('should mark a reference as reviewed', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 here.', 'test_tool');
+      expect(catalog.getPending()).toHaveLength(1);
+
+      const marked = catalog.markReviewed('2401.12345');
+      expect(marked).toBe(true);
+      expect(catalog.getPending()).toHaveLength(0);
+      expect(catalog.getAll()).toHaveLength(1);
+    });
+
+    it('should return false for unknown identifier', () => {
+      const catalog = new ResearchAutoCatalog();
+      expect(catalog.markReviewed('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('dismiss', () => {
+    it('should remove a reference', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 here.', 'test_tool');
+      expect(catalog.getAll()).toHaveLength(1);
+
+      const dismissed = catalog.dismiss('2401.12345');
+      expect(dismissed).toBe(true);
+      expect(catalog.getAll()).toHaveLength(0);
+    });
+
+    it('should return false for unknown identifier', () => {
+      const catalog = new ResearchAutoCatalog();
+      expect(catalog.dismiss('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('flush', () => {
+    it('should clear all pending references', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 and 2403.67890.', 'test_tool');
+      expect(catalog.getAll()).toHaveLength(2);
+
+      catalog.flush();
+      expect(catalog.getAll()).toHaveLength(0);
+      expect(catalog.getPending()).toHaveLength(0);
+    });
+  });
+
+  describe('MAX_PENDING limit', () => {
+    it('should drop oldest entry when limit is reached', () => {
+      const catalog = new ResearchAutoCatalog();
+      // Record 100 entries to fill the limit
+      for (let i = 0; i < 100; i++) {
+        catalog.recordReference({
+          type: 'arxiv',
+          identifier: `id-${String(i).padStart(3, '0')}`,
+          context: 'test',
+          sourceTool: 'test',
+          discoveredAt: new Date().toISOString(),
+          reviewed: false,
+        });
+      }
+      expect(catalog.getAll()).toHaveLength(100);
+
+      // Adding one more should drop the oldest
+      catalog.recordReference({
+        type: 'arxiv',
+        identifier: 'id-overflow',
+        context: 'test',
+        sourceTool: 'test',
+        discoveredAt: new Date().toISOString(),
+        reviewed: false,
+      });
+      expect(catalog.getAll()).toHaveLength(100);
+      const all = catalog.getAll();
+      expect(all[0]?.identifier).toBe('id-001');
+      expect(all[all.length - 1]?.identifier).toBe('id-overflow');
+    });
+  });
+
+  describe('persistence', () => {
+    it('should load persisted references on construction', () => {
+      const persistedData = JSON.stringify({
+        version: 1,
+        references: [
+          {
+            type: 'arxiv',
+            identifier: '2401.99999',
+            context: 'persisted',
+            sourceTool: 'old_tool',
+            discoveredAt: '2026-01-01T00:00:00.000Z',
+            reviewed: false,
+          },
+        ],
+        savedAt: '2026-01-01T00:00:00.000Z',
+      });
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(persistedData);
+
+      const catalog = new ResearchAutoCatalog();
+      expect(catalog.getAll()).toHaveLength(1);
+      expect(catalog.getAll()[0]?.identifier).toBe('2401.99999');
+    });
+
+    it('should start fresh on invalid persisted data', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue('{"invalid": true}');
+
+      const catalog = new ResearchAutoCatalog();
+      expect(catalog.getAll()).toHaveLength(0);
+    });
+
+    it('should start fresh on corrupted file', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const catalog = new ResearchAutoCatalog();
+      expect(catalog.getAll()).toHaveLength(0);
+    });
+
+    it('should persist on scanAndRecord', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 here.', 'test_tool');
+      expect(mockFs.writeFileSync).toHaveBeenCalled();
+      expect(mockFs.renameSync).toHaveBeenCalled();
+    });
+
+    it('should persist on flush', () => {
+      const catalog = new ResearchAutoCatalog();
+      catalog.scanAndRecord('Paper 2401.12345 here.', 'test_tool');
+      vi.clearAllMocks();
+
+      catalog.flush();
+      expect(mockFs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('should handle write failure gracefully', () => {
+      mockFs.writeFileSync.mockImplementation(() => {
+        throw new Error('ENOSPC: no space left on device');
+      });
+
+      const catalog = new ResearchAutoCatalog();
+      // Should not throw
+      expect(() => catalog.scanAndRecord('Paper 2401.12345 here.', 'test_tool')).not.toThrow();
+      // Reference still in memory even if persistence failed
+      expect(catalog.getAll()).toHaveLength(1);
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return same instance on repeated calls', () => {
+      const a = getAutoCatalog();
+      const b = getAutoCatalog();
+      expect(a).toBe(b);
+    });
+
+    it('should return new instance after reset', () => {
+      const a = getAutoCatalog();
+      resetAutoCatalog();
+      const b = getAutoCatalog();
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/research-auto-catalog.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-auto-catalog.ts
@@ -83,8 +83,11 @@ function loadPersistedCatalog(logger: ILogger): CatalogedReference[] {
       return [];
     }
     return result.data.references;
-  } catch {
-    logger.debug('Could not load pending catalog, starting fresh');
+  } catch (error: unknown) {
+    logger.debug('Could not load pending catalog, starting fresh', {
+      error: error instanceof Error ? error.message : String(error),
+      filePath,
+    });
     return [];
   }
 }
@@ -110,7 +113,7 @@ function savePersistedCatalog(references: readonly CatalogedReference[], logger:
     try {
       fs.unlinkSync(tempPath);
     } catch {
-      /* ignore */
+      // Temp file cleanup failure is non-critical
     }
     const message = error instanceof Error ? error.message : String(error);
     logger.warn('Failed to persist pending catalog', { error: message });
@@ -228,8 +231,11 @@ export class ResearchAutoCatalog {
         confidence: 0.5,
         source: 'auto-catalog',
       });
-    } catch {
-      this.logger.debug('Failed to persist to session memory');
+    } catch (error: unknown) {
+      this.logger.debug('Failed to persist to session memory', {
+        error: error instanceof Error ? error.message : String(error),
+        identifier: entry.identifier,
+      });
     }
   }
 
@@ -295,8 +301,11 @@ export class ResearchAutoCatalog {
   private persistToDisk(): void {
     try {
       savePersistedCatalog(this.pendingReferences, this.logger);
-    } catch {
-      this.logger.debug('Failed to persist auto-catalog to disk');
+    } catch (error: unknown) {
+      this.logger.debug('Failed to persist auto-catalog to disk', {
+        error: error instanceof Error ? error.message : String(error),
+        pendingCount: this.pendingReferences.length,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- **Flaky test fix**: Replace random port allocation (40000-49999) in `rest-server.test.ts` with PID-based sequential ports to eliminate EADDRINUSE collisions in parallel CI execution
- **Observability**: Add error context (error message, operation details) to 9 bare `catch` blocks across `orchestrate.ts`, `execute-expert.ts`, and `research-auto-catalog.ts` — all best-effort operations now log debug details on failure
- **Test coverage**: Add 22 new tests for `research-auto-catalog.ts` covering pattern extraction, duplicate detection, persistence, review/dismiss/flush, MAX_PENDING limit, and singleton behavior

## Consensus votes
All three proposals unanimously approved (3/3):
1. Fix flaky rest-server port allocation — 100% approve
2. Add error context to silent catch blocks — 100% approve
3. Add test coverage for research-auto-catalog — 100% approve

## Test plan
- [x] All 349 test files pass (10,905 tests)
- [x] 22 new auto-catalog tests pass
- [x] rest-server tests pass with new port strategy
- [x] TypeScript strict mode clean
- [x] ESLint clean (extracted `autoCatalogScan` helper to meet 50-line limit)
- [x] Fitness score: 97/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)