### PR TITLE
fix(#715): research discovery query fixes for arXiv, Semantic Scholar, PwC

### DIFF
--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
@@ -86,6 +86,19 @@ describe('discoverSemanticScholar', () => {
     if (!result.ok) expect(result.error.code).toBe('PARSE_ERROR');
   });
 
+  it('should return PARSE_ERROR when response is HTML instead of JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError("Unexpected token '<'")),
+    });
+    const result = await discoverSemanticScholar('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PARSE_ERROR');
+      expect(result.error.source).toBe('semantic_scholar');
+    }
+  });
+
   it('should filter out papers without titles', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -145,6 +158,19 @@ describe('discoverPapersWithCode', () => {
     const result = await discoverPapersWithCode('test', 5);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('PARSE_ERROR');
+  });
+
+  it('should return PARSE_ERROR when response is HTML error page', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token \'<\', "<!doctype "...')),
+    });
+    const result = await discoverPapersWithCode('test', 5);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PARSE_ERROR');
+      expect(result.error.message).toContain('not valid JSON');
+    }
   });
 
   it('should mark papers without repos as medium relevance', async () => {

--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
@@ -117,11 +117,23 @@ export async function discoverSemanticScholar(
   const fetchResult = await fetchSource({
     url,
     source: 'semantic_scholar',
-    headers: { 'User-Agent': 'nexus-agents' },
+    headers: { 'User-Agent': 'nexus-agents', Accept: 'application/json' },
   });
   if (!fetchResult.ok) return fetchResult;
 
-  const raw = await fetchResult.value.json();
+  let raw: unknown;
+  try {
+    raw = await fetchResult.value.json();
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: 'PARSE_ERROR',
+        source: 'semantic_scholar',
+        message: 'Response is not valid JSON',
+      },
+    };
+  }
   const parsed = SemanticScholarResponseSchema.safeParse(raw);
   if (!parsed.success) {
     return {
@@ -145,12 +157,26 @@ export async function discoverSemanticScholar(
 // PAPERS WITH CODE DISCOVERY
 // =============================================================================
 
+/** Map validated PwC paper to DiscoveredSource. */
+function mapPwcPaper(paper: z.infer<typeof PapersWithCodePaperSchema>): DiscoveredSource {
+  const hasCode = (paper.repository_count ?? 0) > 0;
+  return {
+    source: 'papers_with_code',
+    title: paper.title ?? '',
+    url: paper.url_abs ?? '',
+    description: truncate(paper.abstract ?? ''),
+    relevance: hasCode ? 'high' : 'medium',
+    discoveredAt: getToday(),
+  };
+}
+
+/** Parse error for a source. */
+function pwcParseError(message: string): { ok: false; error: DiscoverError } {
+  return { ok: false, error: { code: 'PARSE_ERROR', source: 'papers_with_code', message } };
+}
+
 /**
  * Discover research papers from Papers with Code.
- *
- * @param topic - Search topic
- * @param maxResults - Maximum results (default 10)
- * @returns Result containing discovered papers with code
  */
 export async function discoverPapersWithCode(
   topic: string,
@@ -162,37 +188,22 @@ export async function discoverPapersWithCode(
   const fetchResult = await fetchSource({
     url,
     source: 'papers_with_code',
-    headers: { 'User-Agent': 'nexus-agents' },
+    headers: { 'User-Agent': 'nexus-agents', Accept: 'application/json' },
   });
   if (!fetchResult.ok) return fetchResult;
 
-  const raw = await fetchResult.value.json();
-  const parsed = PapersWithCodeResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    return {
-      ok: false,
-      error: {
-        code: 'PARSE_ERROR',
-        source: 'papers_with_code',
-        message: 'Response schema mismatch',
-      },
-    };
+  let raw: unknown;
+  try {
+    raw = await fetchResult.value.json();
+  } catch {
+    return pwcParseError('Response is not valid JSON (possible HTML error page)');
   }
+  const parsed = PapersWithCodeResponseSchema.safeParse(raw);
+  if (!parsed.success) return pwcParseError('Response schema mismatch');
 
-  const papers = parsed.data.results ?? [];
-  const items: DiscoveredSource[] = papers
+  const items = (parsed.data.results ?? [])
     .filter((p) => p.title !== undefined && p.title !== '')
-    .map((paper) => {
-      const hasCode = (paper.repository_count ?? 0) > 0;
-      return {
-        source: 'papers_with_code',
-        title: paper.title ?? '',
-        url: paper.url_abs ?? '',
-        description: truncate(paper.abstract ?? ''),
-        relevance: hasCode ? 'high' : 'medium',
-        discoveredAt: getToday(),
-      };
-    });
+    .map(mapPwcPaper);
 
   return { ok: true, value: items };
 }

--- a/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
@@ -215,6 +215,30 @@ describe('discoverArxiv', () => {
     expect(calledUrl).not.toContain('all%3A');
   });
 
+  it('should quote multi-word topics for phrase matching', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('<feed></feed>'),
+    });
+    await discoverArxiv('agent memory consolidation', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).toContain('ti:"agent memory consolidation"');
+    expect(decoded).toContain('abs:"agent memory consolidation"');
+  });
+
+  it('should not quote single-word topics', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('<feed></feed>'),
+    });
+    await discoverArxiv('orchestration', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).toContain('ti:orchestration');
+    expect(decoded).not.toContain('"orchestration"');
+  });
+
   it('should include submittedDate filter when sinceDate is provided', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -58,7 +58,6 @@ const GitHubSearchResponseSchema = z.object({
 // =============================================================================
 // HELPERS
 // =============================================================================
-
 /** Creates a discover error. */
 function createError(
   code: DiscoverErrorCode,
@@ -77,7 +76,6 @@ function getToday(): string {
 // =============================================================================
 // SHARED FETCH HELPER
 // =============================================================================
-
 /** Options for fetchSource helper. */
 interface FetchSourceOptions {
   readonly url: string;
@@ -190,7 +188,8 @@ interface ArxivQueryOptions {
  * Optionally adds a submittedDate range filter when sinceDate is provided.
  */
 function buildArxivUrl(opts: ArxivQueryOptions): string {
-  const topicQuery = `(ti:${opts.topic} OR abs:${opts.topic})`;
+  const q = opts.topic.includes(' ') ? `"${opts.topic}"` : opts.topic;
+  const topicQuery = `(ti:${q} OR abs:${q})`;
   let fullQuery = opts.authorFilter !== '' ? `${topicQuery} AND ${opts.authorFilter}` : topicQuery;
 
   // Add date range filter if sinceDate provided (format: YYYYMMDD)


### PR DESCRIPTION
## Summary
- ArXiv: Quote multi-word topics for phrase matching (e.g., `ti:"agent memory"` instead of `ti:agent memory`) to prevent irrelevant results
- Semantic Scholar: Add `Accept: application/json` header and protect `.json()` parsing from HTML error pages
- Papers with Code: Add `Accept: application/json` header and try-catch around `.json()` to handle HTML responses gracefully

## Test plan
- [x] 4 new tests added covering JSON parse protection and arXiv quoting
- [x] All 50 research source tests pass
- [x] Full suite: 349 files, 10,917 tests pass
- [x] Fitness score: 97/100
- [x] ESLint + Prettier clean

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)