### PR TITLE
fix(#709): add memory bounds and FIFO eviction to session memory

### DIFF
--- a/packages/nexus-agents/src/context/session-memory-types.ts
+++ b/packages/nexus-agents/src/context/session-memory-types.ts
@@ -149,6 +149,14 @@ export interface SessionMemoryConfig {
   readonly maxLearningsInContext?: number;
   /** Minimum confidence threshold for learnings */
   readonly minConfidenceThreshold?: number;
+  /** Maximum learnings per session (FIFO eviction). */
+  readonly maxLearningsPerSession?: number;
+  /** Maximum tasks per session (FIFO eviction). */
+  readonly maxTasksPerSession?: number;
+  /** Maximum errors per session (FIFO eviction). */
+  readonly maxErrorsPerSession?: number;
+  /** Maximum episode files to retain on disk. Oldest are deleted. */
+  readonly maxEpisodeFiles?: number;
   /** Logger instance */
   readonly logger?: ILogger;
 }
@@ -157,4 +165,8 @@ export const DEFAULT_SESSION_MEMORY_CONFIG = {
   maxEpisodesToLoad: 10,
   maxLearningsInContext: 20,
   minConfidenceThreshold: 0.5,
+  maxLearningsPerSession: 500,
+  maxTasksPerSession: 200,
+  maxErrorsPerSession: 200,
+  maxEpisodeFiles: 50,
 } as const;

--- a/packages/nexus-agents/src/context/session-memory.test.ts
+++ b/packages/nexus-agents/src/context/session-memory.test.ts
@@ -475,3 +475,109 @@ describe('SessionMemory integration', () => {
     memory2.endSession('Session 2 complete');
   });
 });
+
+// ============================================================================
+// Memory Bounds Tests (Issue #709)
+// ============================================================================
+
+describe('SessionMemory bounds', () => {
+  describe('per-session FIFO eviction', () => {
+    it('should evict oldest learnings when limit exceeded', () => {
+      const memory = createSessionMemory(testDir, { maxLearningsPerSession: 3 });
+      memory.startSession('eviction-test');
+
+      for (let i = 0; i < 5; i++) {
+        memory.recordLearning({
+          pattern: `Pattern ${String(i)}`,
+          context: `Context ${String(i)}`,
+          confidence: 0.8,
+        });
+      }
+
+      const result = memory.endSession('Test');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.learnings).toHaveLength(3);
+        expect(result.value.learnings[0]?.pattern).toBe('Pattern 2');
+        expect(result.value.learnings[2]?.pattern).toBe('Pattern 4');
+      }
+    });
+
+    it('should evict oldest tasks when limit exceeded', () => {
+      const memory = createSessionMemory(testDir, { maxTasksPerSession: 2 });
+      memory.startSession('task-eviction');
+
+      for (let i = 0; i < 4; i++) {
+        memory.recordTask({
+          approach: `Approach ${String(i)}`,
+          challenges: [],
+        });
+      }
+
+      const result = memory.endSession('Test');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.tasksCompleted).toHaveLength(2);
+        expect(result.value.tasksCompleted[0]?.approach).toBe('Approach 2');
+      }
+    });
+
+    it('should evict oldest errors when limit exceeded', () => {
+      const memory = createSessionMemory(testDir, { maxErrorsPerSession: 2 });
+      memory.startSession('error-eviction');
+
+      for (let i = 0; i < 4; i++) {
+        memory.recordError({
+          error: `Error ${String(i)}`,
+          solution: `Fix ${String(i)}`,
+        });
+      }
+
+      const result = memory.endSession('Test');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.errorsResolved).toHaveLength(2);
+        expect(result.value.errorsResolved[0]?.error).toBe('Error 2');
+      }
+    });
+  });
+
+  describe('episode file retention', () => {
+    it('should delete oldest episode files when limit exceeded', () => {
+      const memory = createSessionMemory(testDir, { maxEpisodeFiles: 3 });
+
+      for (let i = 0; i < 5; i++) {
+        memory.startSession(`retention-${String(i)}`);
+        memory.recordLearning({
+          pattern: `Pattern ${String(i)}`,
+          context: 'Retention test',
+          confidence: 0.8,
+        });
+        memory.endSession(`Session ${String(i)}`);
+      }
+
+      const files = fs.readdirSync(testDir).filter((f) => f.endsWith('.json'));
+      expect(files.length).toBe(3);
+    });
+
+    it('should keep most recent episodes when enforcing retention', () => {
+      const memory = createSessionMemory(testDir, { maxEpisodeFiles: 2 });
+
+      for (let i = 0; i < 4; i++) {
+        memory.startSession(`keep-recent-${String(i)}`);
+        memory.recordLearning({
+          pattern: `Pattern ${String(i)}`,
+          context: 'Test',
+          confidence: 0.8,
+        });
+        memory.endSession(`Session ${String(i)}`);
+      }
+
+      const episodes = memory.loadEpisodes(10);
+      expect(episodes.length).toBe(2);
+      // Most recent should be kept (sorted by filename descending)
+      expect(episodes[0]?.sessionId).toBe('keep-recent-3');
+      expect(episodes[1]?.sessionId).toBe('keep-recent-2');
+    });
+  });
+});

--- a/packages/nexus-agents/src/context/session-memory.ts
+++ b/packages/nexus-agents/src/context/session-memory.ts
@@ -1,13 +1,8 @@
 /**
- * nexus-agents/context - Session Memory Manager
- *
- * Cross-session episodic memory persistence using YAML files.
- * Enables learning retention across sessions as specified in issue #130.
- *
+ * Cross-session episodic memory persistence with FIFO eviction bounds.
  * @module context/session-memory
- * (Source: Issue #130, arXiv:2303.11366 - Reflexion)
+ * (Source: Issue #130, #709 - arXiv:2303.11366 - Reflexion)
  */
-
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Result } from '../core/result.js';
@@ -31,7 +26,6 @@ import {
   DEFAULT_SESSION_MEMORY_CONFIG,
 } from './session-memory-types.js';
 
-// Re-export types for backward compatibility
 export type {
   SessionLearning,
   CompletedTask,
@@ -47,41 +41,34 @@ export {
   SessionMemoryError,
 } from './session-memory-types.js';
 
-// ============================================================================
-// Session Memory Implementation
-// ============================================================================
-
-/**
- * Manages cross-session episodic memory persistence.
- * (Source: Issue #130, arXiv:2303.11366 - Reflexion)
- */
+/** Manages cross-session episodic memory with per-session bounds and disk retention. */
 export class SessionMemory {
   private readonly memoryDir: string;
   private readonly maxEpisodesToLoad: number;
   private readonly maxLearningsInContext: number;
   private readonly minConfidenceThreshold: number;
+  private readonly maxLearningsPerSession: number;
+  private readonly maxTasksPerSession: number;
+  private readonly maxErrorsPerSession: number;
+  private readonly maxEpisodeFiles: number;
   private readonly log: ILogger;
   private currentSession: SessionEpisode | null = null;
   private sessionStartTime: number | null = null;
 
   constructor(config: SessionMemoryConfig) {
+    const d = DEFAULT_SESSION_MEMORY_CONFIG;
     this.memoryDir = config.memoryDir;
-    this.maxEpisodesToLoad =
-      config.maxEpisodesToLoad ?? DEFAULT_SESSION_MEMORY_CONFIG.maxEpisodesToLoad;
-    this.maxLearningsInContext =
-      config.maxLearningsInContext ?? DEFAULT_SESSION_MEMORY_CONFIG.maxLearningsInContext;
-    this.minConfidenceThreshold =
-      config.minConfidenceThreshold ?? DEFAULT_SESSION_MEMORY_CONFIG.minConfidenceThreshold;
+    this.maxEpisodesToLoad = config.maxEpisodesToLoad ?? d.maxEpisodesToLoad;
+    this.maxLearningsInContext = config.maxLearningsInContext ?? d.maxLearningsInContext;
+    this.minConfidenceThreshold = config.minConfidenceThreshold ?? d.minConfidenceThreshold;
+    this.maxLearningsPerSession = config.maxLearningsPerSession ?? d.maxLearningsPerSession;
+    this.maxTasksPerSession = config.maxTasksPerSession ?? d.maxTasksPerSession;
+    this.maxErrorsPerSession = config.maxErrorsPerSession ?? d.maxErrorsPerSession;
+    this.maxEpisodeFiles = config.maxEpisodeFiles ?? d.maxEpisodeFiles;
     this.log = config.logger ?? createLogger({ component: 'SessionMemory' });
   }
 
-  // --------------------------------------------------------------------------
-  // Session Lifecycle
-  // --------------------------------------------------------------------------
-
-  /**
-   * Start a new session and load relevant memories.
-   */
+  /** Start a new session and load relevant memories. */
   startSession(sessionId: string): Result<readonly SessionLearning[], SessionMemoryError> {
     if (this.currentSession !== null) {
       return err(
@@ -111,9 +98,7 @@ export class SessionMemory {
     return ok(relevantLearnings);
   }
 
-  /**
-   * End the current session and persist episode.
-   */
+  /** End the current session and persist episode. */
   endSession(summary: string): Result<SessionEpisode, SessionMemoryError> {
     if (this.currentSession === null || this.sessionStartTime === null) {
       return err(new SessionMemoryError('No session in progress'));
@@ -142,27 +127,17 @@ export class SessionMemory {
     return ok(episode);
   }
 
-  /**
-   * Check if a session is currently active.
-   */
+  /** Check if a session is currently active. */
   isSessionActive(): boolean {
     return this.currentSession !== null;
   }
 
-  /**
-   * Get the current session ID.
-   */
+  /** Get the current session ID. */
   getCurrentSessionId(): string | null {
     return this.currentSession?.sessionId ?? null;
   }
 
-  // --------------------------------------------------------------------------
-  // Recording Methods
-  // --------------------------------------------------------------------------
-
-  /**
-   * Record a learning during the current session.
-   */
+  /** Record a learning during the current session. */
   recordLearning(learning: SessionLearning): Result<void, SessionMemoryError> {
     if (this.currentSession === null) {
       return err(new SessionMemoryError('No session in progress'));
@@ -177,18 +152,18 @@ export class SessionMemory {
       );
     }
 
-    this.currentSession = {
-      ...this.currentSession,
-      learnings: [...this.currentSession.learnings, learning],
-    };
+    const updated = [...this.currentSession.learnings, learning];
+    if (updated.length > this.maxLearningsPerSession) {
+      updated.splice(0, updated.length - this.maxLearningsPerSession);
+      this.log.debug('Learning FIFO eviction', { kept: this.maxLearningsPerSession });
+    }
+    this.currentSession = { ...this.currentSession, learnings: updated };
 
     this.log.debug('Learning recorded', { pattern: learning.pattern });
     return ok(undefined);
   }
 
-  /**
-   * Record a completed task during the current session.
-   */
+  /** Record a completed task during the current session. */
   recordTask(task: CompletedTask): Result<void, SessionMemoryError> {
     if (this.currentSession === null) {
       return err(new SessionMemoryError('No session in progress'));
@@ -203,18 +178,18 @@ export class SessionMemory {
       );
     }
 
-    this.currentSession = {
-      ...this.currentSession,
-      tasksCompleted: [...this.currentSession.tasksCompleted, task],
-    };
+    const updated = [...this.currentSession.tasksCompleted, task];
+    if (updated.length > this.maxTasksPerSession) {
+      updated.splice(0, updated.length - this.maxTasksPerSession);
+      this.log.debug('Task FIFO eviction', { kept: this.maxTasksPerSession });
+    }
+    this.currentSession = { ...this.currentSession, tasksCompleted: updated };
 
     this.log.debug('Task recorded', { issue: task.issue });
     return ok(undefined);
   }
 
-  /**
-   * Record a resolved error during the current session.
-   */
+  /** Record a resolved error during the current session. */
   recordError(error: ResolvedError): Result<void, SessionMemoryError> {
     if (this.currentSession === null) {
       return err(new SessionMemoryError('No session in progress'));
@@ -229,22 +204,18 @@ export class SessionMemory {
       );
     }
 
-    this.currentSession = {
-      ...this.currentSession,
-      errorsResolved: [...this.currentSession.errorsResolved, error],
-    };
+    const updated = [...this.currentSession.errorsResolved, error];
+    if (updated.length > this.maxErrorsPerSession) {
+      updated.splice(0, updated.length - this.maxErrorsPerSession);
+      this.log.debug('Error FIFO eviction', { kept: this.maxErrorsPerSession });
+    }
+    this.currentSession = { ...this.currentSession, errorsResolved: updated };
 
     this.log.debug('Error resolution recorded', { error: error.error });
     return ok(undefined);
   }
 
-  // --------------------------------------------------------------------------
-  // Retrieval Methods
-  // --------------------------------------------------------------------------
-
-  /**
-   * Load all episodes from the memory directory.
-   */
+  /** Load all episodes from the memory directory. */
   loadEpisodes(limit?: number): readonly SessionEpisode[] {
     this.ensureMemoryDir();
     const files = this.getEpisodeFiles();
@@ -261,9 +232,7 @@ export class SessionMemory {
     return episodes;
   }
 
-  /**
-   * Load learnings relevant to the current context.
-   */
+  /** Load learnings relevant to the current context. */
   loadRelevantLearnings(): readonly SessionLearning[] {
     const episodes = this.loadEpisodes();
     const allLearnings: SessionLearning[] = [];
@@ -282,9 +251,7 @@ export class SessionMemory {
       .slice(0, this.maxLearningsInContext);
   }
 
-  /**
-   * Search for learnings matching a query.
-   */
+  /** Search for learnings matching a query. */
   searchLearnings(query: string): readonly SessionLearning[] {
     const episodes = this.loadEpisodes();
     const queryLower = query.toLowerCase();
@@ -302,9 +269,7 @@ export class SessionMemory {
     return matches.sort((a, b) => b.confidence - a.confidence);
   }
 
-  /**
-   * Get recent errors and their solutions.
-   */
+  /** Get recent errors and their solutions. */
   getRecentErrorSolutions(limit = 10): readonly ResolvedError[] {
     const episodes = this.loadEpisodes();
     const errors: ResolvedError[] = [];
@@ -315,10 +280,6 @@ export class SessionMemory {
 
     return errors.slice(0, limit);
   }
-
-  // --------------------------------------------------------------------------
-  // Private Helpers
-  // --------------------------------------------------------------------------
 
   private ensureMemoryDir(): void {
     if (!fs.existsSync(this.memoryDir)) {
@@ -369,21 +330,36 @@ export class SessionMemory {
       const content = JSON.stringify(episode, null, 2);
       fs.writeFileSync(filepath, content, 'utf-8');
       this.log.debug('Episode persisted', { filename });
+      this.enforceEpisodeRetention();
       return ok(undefined);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return err(new SessionMemoryError(`Failed to persist episode: ${message}`));
     }
   }
+
+  /** Delete oldest episode files when count exceeds maxEpisodeFiles. */
+  private enforceEpisodeRetention(): void {
+    try {
+      const files = this.getEpisodeFiles(); // sorted most-recent-first
+      if (files.length <= this.maxEpisodeFiles) return;
+      const toDelete = files.slice(this.maxEpisodeFiles);
+      for (const file of toDelete) {
+        fs.unlinkSync(path.join(this.memoryDir, file));
+      }
+      this.log.info('Episode retention enforced', {
+        kept: this.maxEpisodeFiles,
+        deleted: toDelete.length,
+      });
+    } catch (error: unknown) {
+      this.log.debug('Episode retention cleanup failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }
 
-// ============================================================================
-// Factory Function
-// ============================================================================
-
-/**
- * Create a SessionMemory instance with default configuration.
- */
+/** Create a SessionMemory instance with default configuration. */
 export function createSessionMemory(
   memoryDir: string,
   config?: Partial<Omit<SessionMemoryConfig, 'memoryDir'>>


### PR DESCRIPTION
## Summary
- Add configurable per-session caps with FIFO eviction to prevent unbounded array growth during long-running sessions: `maxLearningsPerSession` (500), `maxTasksPerSession` (200), `maxErrorsPerSession` (200)
- Add episode file retention policy (`maxEpisodeFiles` = 50) to limit disk usage from accumulated `~/.nexus-agents/memory/sessions/` files
- Compress session-memory.ts from 395 to 358 lines while adding new functionality

## Test plan
- [x] 5 new tests for FIFO eviction (learnings, tasks, errors) and episode retention
- [x] All 27 session-memory tests pass
- [x] All 28 tool-memory tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Fitness score 97/100

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)