### PR TITLE
test(#697): add test coverage for fitness-audit, capabilities, and release-validate CLI commands

### DIFF
--- a/packages/nexus-agents/src/cli/capabilities-command.test.ts
+++ b/packages/nexus-agents/src/cli/capabilities-command.test.ts
@@ -1,0 +1,120 @@
+/**
+ * nexus-agents/cli - Capabilities Command Tests
+ * (Source: Issue #697 - Add test coverage for untested CLI commands)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ParsedCliArgs } from '../cli-types.js';
+
+describe('handleCapabilitiesCommand', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  function makeArgs(positionals: string[], options: Record<string, string> = {}): ParsedCliArgs {
+    return {
+      positionals,
+      options,
+    } as unknown as ParsedCliArgs;
+  }
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('should show usage when no subcommand is provided', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    expect(() => {
+      handleCapabilitiesCommand(makeArgs(['capabilities']));
+    }).toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('capabilities');
+    expect(output).toContain('SUBCOMMANDS');
+  });
+
+  it('should show usage and exit with error for invalid subcommand', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    expect(() => {
+      handleCapabilitiesCommand(makeArgs(['capabilities', 'invalid']));
+    }).toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS = 3
+  });
+
+  it('should list models with table format (default)', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    handleCapabilitiesCommand(makeArgs(['capabilities', 'list']));
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Model Capabilities Matrix');
+    expect(output).toContain('Provider');
+  });
+
+  it('should list models with json format', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    handleCapabilitiesCommand(makeArgs(['capabilities', 'list'], { format: 'json' }));
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const parsed = JSON.parse(output) as { models: unknown[] };
+    expect(parsed.models).toBeDefined();
+    expect(Array.isArray(parsed.models)).toBe(true);
+  });
+
+  it('should list models with markdown format', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    handleCapabilitiesCommand(makeArgs(['capabilities', 'list'], { format: 'markdown' }));
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('# Model Capabilities Matrix');
+    expect(output).toContain('|');
+  });
+
+  it('should require two models for compare subcommand', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    expect(() => {
+      handleCapabilitiesCommand(makeArgs(['capabilities', 'compare']));
+    }).toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalled();
+  });
+
+  it('should require a capability for find subcommand', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    expect(() => {
+      handleCapabilitiesCommand(makeArgs(['capabilities', 'find']));
+    }).toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalled();
+  });
+
+  it('should find models by capability', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    handleCapabilitiesCommand(makeArgs(['capabilities', 'find', 'mcp']));
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Models supporting');
+    expect(output).toContain('mcp');
+  });
+
+  it('should show message when no models found for capability', async () => {
+    const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
+
+    handleCapabilitiesCommand(makeArgs(['capabilities', 'find', 'nonexistent_capability']));
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('No models found');
+  });
+});

--- a/packages/nexus-agents/src/cli/fitness-audit.test.ts
+++ b/packages/nexus-agents/src/cli/fitness-audit.test.ts
@@ -1,0 +1,154 @@
+/**
+ * nexus-agents/cli - Fitness Audit Command Tests
+ * (Source: Issue #697 - Add test coverage for untested CLI commands)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../governance/index.js', () => ({
+  calculateFitnessScore: vi.fn().mockReturnValue({
+    score: 92,
+    version: 'v2.6.0-test',
+    timestamp: '2026-02-04T00:00:00Z',
+    dimensions: {
+      canonicalPaths: 18,
+      explicitBehavior: 14,
+      determinism: 14,
+      observability: 13,
+      configSimplicity: 9,
+      layerSeparation: 9,
+      operatorErgonomics: 10,
+      governanceIntegration: 5,
+    },
+    findings: [],
+  }),
+}));
+
+vi.mock('../version.js', () => ({
+  VERSION: '2.6.0-test',
+}));
+
+const writtenLines: string[] = [];
+vi.mock('./ansi-output.js', () => ({
+  colors: {
+    reset: '',
+    bold: '',
+    dim: '',
+    green: '',
+    yellow: '',
+    red: '',
+    cyan: '',
+  },
+  writeLine: vi.fn((text?: string) => {
+    writtenLines.push(text ?? '');
+  }),
+}));
+
+import { fitnessAuditCommand } from './fitness-audit.js';
+import { calculateFitnessScore } from '../governance/index.js';
+
+const defaultAudit = {
+  score: 92,
+  version: 'v2.6.0-test',
+  timestamp: '2026-02-04T00:00:00Z',
+  dimensions: {
+    canonicalPaths: 18,
+    explicitBehavior: 14,
+    determinism: 14,
+    observability: 13,
+    configSimplicity: 9,
+    layerSeparation: 9,
+    operatorErgonomics: 10,
+    governanceIntegration: 5,
+  },
+  findings: [] as Array<{
+    dimension: string;
+    severity: 'info' | 'warning' | 'critical';
+    description: string;
+    pointsDeducted: number;
+    suggestion?: string;
+  }>,
+};
+
+describe('fitnessAuditCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writtenLines.length = 0;
+    vi.mocked(calculateFitnessScore).mockReturnValue({ ...defaultAudit });
+  });
+
+  it('should return 0 when score meets minimum threshold', () => {
+    const exitCode = fitnessAuditCommand();
+    expect(exitCode).toBe(0);
+  });
+
+  it('should return 1 when score is below minimum threshold', () => {
+    vi.mocked(calculateFitnessScore).mockReturnValue({
+      ...defaultAudit,
+      score: 60,
+    });
+    const exitCode = fitnessAuditCommand();
+    expect(exitCode).toBe(1);
+  });
+
+  it('should output JSON when json option is true', () => {
+    const exitCode = fitnessAuditCommand({ json: true });
+    expect(exitCode).toBe(0);
+    const jsonOutput = writtenLines.find((l) => l.includes('"score"'));
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse(jsonOutput!) as { score: number };
+    expect(parsed.score).toBe(92);
+  });
+
+  it('should output formatted report when json option is false', () => {
+    fitnessAuditCommand({ json: false });
+    const output = writtenLines.join('\n');
+    expect(output).toContain('FITNESS AUDIT');
+    expect(output).toContain('92/100');
+    expect(output).toContain('PASS');
+  });
+
+  it('should call calculateFitnessScore with version', () => {
+    fitnessAuditCommand();
+    expect(calculateFitnessScore).toHaveBeenCalledWith('v2.6.0-test');
+  });
+
+  it('should display FAIL message for low scores in text mode', () => {
+    vi.mocked(calculateFitnessScore).mockReturnValue({
+      ...defaultAudit,
+      score: 50,
+    });
+    fitnessAuditCommand();
+    const output = writtenLines.join('\n');
+    expect(output).toContain('FAIL');
+    expect(output).toContain('50');
+  });
+
+  it('should display findings when present', () => {
+    vi.mocked(calculateFitnessScore).mockReturnValue({
+      ...defaultAudit,
+      findings: [
+        {
+          dimension: 'canonicalPaths',
+          severity: 'warning' as const,
+          description: 'Duplicate path found',
+          pointsDeducted: 2,
+          suggestion: 'Consolidate paths',
+        },
+      ],
+    });
+    fitnessAuditCommand();
+    const output = writtenLines.join('\n');
+    expect(output).toContain('Findings (1)');
+    expect(output).toContain('Duplicate path found');
+  });
+
+  it('should display dimension scores', () => {
+    fitnessAuditCommand();
+    const output = writtenLines.join('\n');
+    expect(output).toContain('Canonical Paths');
+    expect(output).toContain('Explicit Behavior');
+    expect(output).toContain('Determinism');
+    expect(output).toContain('Observability');
+  });
+});

--- a/packages/nexus-agents/src/cli/release-validate-command.test.ts
+++ b/packages/nexus-agents/src/cli/release-validate-command.test.ts
@@ -1,0 +1,258 @@
+/**
+ * nexus-agents/cli - Release Validate Command Tests
+ * (Source: Issue #697 - Add test coverage for untested CLI commands)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReleaseValidateResult } from './release-validate-types.js';
+
+vi.mock('./release-validate-helpers.js', () => ({
+  validateSecurity: vi.fn().mockResolvedValue({
+    expert: 'security',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  }),
+  validateArchitecture: vi.fn().mockResolvedValue({
+    expert: 'architecture',
+    passed: true,
+    findings: [
+      {
+        title: 'Fitness score: 92/100',
+        severity: 'info',
+        description: 'Fitness score meets threshold',
+      },
+    ],
+    durationMs: 10,
+  }),
+  validateDocumentation: vi.fn().mockResolvedValue({
+    expert: 'documentation',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  }),
+  validateDevOps: vi.fn().mockResolvedValue({
+    expert: 'devops',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  }),
+}));
+
+vi.mock('./ansi-output.js', () => ({
+  colors: {
+    reset: '',
+    bold: '',
+    dim: '',
+    green: '',
+    yellow: '',
+    red: '',
+    cyan: '',
+  },
+}));
+
+import {
+  runReleaseValidate,
+  printReleaseValidateResult,
+  releaseValidateCommand,
+} from './release-validate-command.js';
+import {
+  validateSecurity,
+  validateArchitecture,
+  validateDocumentation,
+  validateDevOps,
+} from './release-validate-helpers.js';
+
+function resetValidatorMocks(): void {
+  vi.mocked(validateSecurity).mockResolvedValue({
+    expert: 'security',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  });
+  vi.mocked(validateArchitecture).mockResolvedValue({
+    expert: 'architecture',
+    passed: true,
+    findings: [
+      {
+        title: 'Fitness score: 92/100',
+        severity: 'info' as const,
+        description: 'Fitness score meets threshold',
+      },
+    ],
+    durationMs: 10,
+  });
+  vi.mocked(validateDocumentation).mockResolvedValue({
+    expert: 'documentation',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  });
+  vi.mocked(validateDevOps).mockResolvedValue({
+    expert: 'devops',
+    passed: true,
+    findings: [],
+    durationMs: 10,
+  });
+}
+
+describe('runReleaseValidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetValidatorMocks();
+  });
+
+  it('should run all validators and return passed result', async () => {
+    const result = await runReleaseValidate({ version: '2.6.0' });
+
+    expect(result.passed).toBe(true);
+    expect(result.version).toBe('2.6.0');
+    expect(result.experts).toHaveLength(4);
+    expect(result.summary.errors).toBe(0);
+    expect(result.summary.warnings).toBe(0);
+  });
+
+  it('should fail when validators report errors', async () => {
+    vi.mocked(validateSecurity).mockResolvedValue({
+      expert: 'security',
+      passed: false,
+      findings: [{ title: 'Critical vuln', severity: 'error' as const }],
+      durationMs: 10,
+    });
+
+    const result = await runReleaseValidate({ version: '2.6.0' });
+
+    expect(result.passed).toBe(false);
+    expect(result.summary.errors).toBe(1);
+  });
+
+  it('should fail in strict mode when warnings exist', async () => {
+    vi.mocked(validateSecurity).mockResolvedValue({
+      expert: 'security',
+      passed: true,
+      findings: [{ title: 'Weak cipher', severity: 'warning' as const }],
+      durationMs: 10,
+    });
+
+    const result = await runReleaseValidate({ version: '2.6.0', strict: true });
+
+    expect(result.passed).toBe(false);
+    expect(result.summary.warnings).toBe(1);
+  });
+
+  it('should skip validators when skip option is provided', async () => {
+    await runReleaseValidate({ version: '2.6.0', skip: ['security', 'devops'] });
+
+    expect(validateSecurity).not.toHaveBeenCalled();
+    expect(validateDevOps).not.toHaveBeenCalled();
+    expect(validateArchitecture).toHaveBeenCalled();
+    expect(validateDocumentation).toHaveBeenCalled();
+  });
+
+  it('should extract fitness score from architecture findings', async () => {
+    const result = await runReleaseValidate({ version: '2.6.0' });
+
+    expect(result.fitnessScore).toBe(92);
+  });
+
+  it('should include durationMs in result', async () => {
+    const result = await runReleaseValidate({ version: '2.6.0' });
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('printReleaseValidateResult', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('should print passed result', () => {
+    const result: ReleaseValidateResult = {
+      success: true,
+      version: '2.6.0',
+      passed: true,
+      experts: [{ expert: 'security', passed: true, findings: [], durationMs: 10 }],
+      summary: { errors: 0, warnings: 0, infos: 0 },
+      durationMs: 100,
+    };
+
+    printReleaseValidateResult(result);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('Release Validation Report');
+    expect(output).toContain('PASS');
+    expect(output).toContain('0 errors');
+    consoleSpy.mockRestore();
+  });
+
+  it('should print failed result with findings', () => {
+    const result: ReleaseValidateResult = {
+      success: true,
+      version: '2.6.0',
+      passed: false,
+      experts: [
+        {
+          expert: 'security',
+          passed: false,
+          findings: [{ title: 'Critical issue', severity: 'error' as const }],
+          durationMs: 10,
+        },
+      ],
+      summary: { errors: 1, warnings: 0, infos: 0 },
+      durationMs: 100,
+    };
+
+    printReleaseValidateResult(result);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('FAIL');
+    expect(output).toContain('1 errors');
+    expect(output).toContain('Critical issue');
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('releaseValidateCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetValidatorMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('should return 0 when validation passes', async () => {
+    const exitCode = await releaseValidateCommand({
+      positionals: ['release-validate'],
+      options: { version: '2.6.0' },
+    });
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('should return 1 when validation fails', async () => {
+    vi.mocked(validateSecurity).mockResolvedValue({
+      expert: 'security',
+      passed: false,
+      findings: [{ title: 'Error', severity: 'error' as const }],
+      durationMs: 10,
+    });
+
+    const exitCode = await releaseValidateCommand({
+      positionals: ['release-validate'],
+      options: { version: '2.6.0' },
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('should pass skip option through', async () => {
+    await releaseValidateCommand({
+      positionals: ['release-validate'],
+      options: { version: '2.6.0', skip: ['security'] },
+    });
+
+    expect(validateSecurity).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 28 new tests across 3 previously untested CLI commands
- **fitness-audit.test.ts** (8 tests): JSON/text output, score thresholds, findings display, dimension scores
- **capabilities-command.test.ts** (9 tests): list/compare/find subcommands, JSON/markdown output, error handling
- **release-validate-command.test.ts** (11 tests): validator orchestration, strict mode, skip option, result printing

Partially addresses #697 (3 of 28 identified untested CLI files now have coverage).

## Test plan
- [x] All 10,959 tests pass (352 test files)
- [x] 28 new tests all passing
- [x] No regressions in existing tests
- [x] Lint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)