### PR TITLE
chore: regenerate codebase index (1456 files, 27 modules)

### DIFF
--- a/packages/nexus-agents/docs/codebase-index.yaml
+++ b/packages/nexus-agents/docs/codebase-index.yaml
@@ -2,14 +2,15 @@
 # Generated automatically - do not edit manually
 
 schemaVersion: '1.0'
-generatedAt: 2026-02-02T06:20:28-05:00
+generatedAt: 2026-02-04T13:10:54-05:00
 stats:
-  totalFiles: 1328
-  totalLines: 374437
-  totalExports: 13808
+  totalFiles: 1456
+  totalLines: 396174
+  totalExports: 14405
   moduleCount: 27
   externalPackages:
     - '@anthropic-ai/sdk'
+    - '@atproto/api'
     - '@fastify/cors'
     - '@fastify/rate-limit'
     - '@fastify/swagger'
@@ -265,7 +266,7 @@ modules:
               - printResearchUsage
         description: nexus-agents CLI Command Handlers Individual command handler implementations extracted from cli-commands.ts.
       - path: cli-commands-usage.ts
-        lines: 106
+        lines: 109
         category: implementation
         exports:
           - name: printWorkflowRunUsage
@@ -333,7 +334,7 @@ modules:
               - IndexSubcommand
         description: nexus-agents CLI Commands - Validators Type validation functions for CLI command arguments.
       - path: cli-commands.ts
-        lines: 176
+        lines: 216
         category: implementation
         exports:
           - name: printHelp
@@ -453,6 +454,34 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./cli-commands-handlers.js
+          - name: handleReleaseNotesCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli-release-handlers.js
+          - name: handleReleaseValidateCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli-release-handlers.js
+          - name: handleReleaseAnnounceCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli-release-handlers.js
+          - name: handleScaffoldCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli-scaffold-handler.js
+          - name: handleVisualizeCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli/visualize-command.js
+          - name: handleCapabilitiesCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli/capabilities-command.js
+          - name: handleStatusCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cli/status-command.js
         dependencies:
           - specifier: ./version.js
             isExternal: false
@@ -492,9 +521,31 @@ modules:
               - handleEvaluateCommand
               - handleIssueCommand
               - handleFitnessAuditCommand
+          - specifier: ./cli-release-handlers.js
+            isExternal: false
+            imports:
+              - handleReleaseNotesCommand
+              - handleReleaseValidateCommand
+              - handleReleaseAnnounceCommand
+          - specifier: ./cli-scaffold-handler.js
+            isExternal: false
+            imports:
+              - handleScaffoldCommand
+          - specifier: ./cli/visualize-command.js
+            isExternal: false
+            imports:
+              - handleVisualizeCommand
+          - specifier: ./cli/capabilities-command.js
+            isExternal: false
+            imports:
+              - handleCapabilitiesCommand
+          - specifier: ./cli/status-command.js
+            isExternal: false
+            imports:
+              - handleStatusCommand
         description: nexus-agents CLI Commands Command dispatch and routing for the CLI.
       - path: cli-help-text.ts
-        lines: 304
+        lines: 371
         category: implementation
         exports:
           - name: HELP_TEXT
@@ -535,6 +586,52 @@ modules:
               - orchestrateCommand
               - OrchestrateOptions
         description: nexus-agents CLI Orchestrator Mode Standalone task execution mode for the CLI.
+      - path: cli-release-handlers.ts
+        lines: 83
+        category: implementation
+        exports:
+          - name: handleReleaseNotesCommand
+            kind: function
+            isReExport: false
+          - name: handleReleaseValidateCommand
+            kind: function
+            isReExport: false
+          - name: handleReleaseAnnounceCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ./cli-types.js
+            isExternal: false
+            imports:
+              - EXIT_CODES
+              - ParsedCliArgs
+          - specifier: ./cli/index.js
+            isExternal: false
+            imports:
+              - releaseNotesCommand
+              - releaseValidateCommand
+              - releaseAnnounceCommand
+        description: Release Automation Command Handlers Command handlers for release automation CLI commands.
+      - path: cli-scaffold-handler.ts
+        lines: 34
+        category: implementation
+        exports:
+          - name: handleScaffoldCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ./cli-types.js
+            isExternal: false
+            imports:
+              - EXIT_CODES
+              - ParsedCliArgs
+          - specifier: ./cli/index.js
+            isExternal: false
+            imports:
+              - scaffoldCommand
+              - isValidScaffoldType
+              - printScaffoldUsage
+        description: Scaffold Command Handler Command handler for the scaffold CLI command.
       - path: cli-server-experts.ts
         lines: 240
         category: implementation
@@ -762,7 +859,7 @@ modules:
           nexus-agents CLI Server SICA Initialization Wires SICA (Self-Improving Coding Agent) configuration from
           nexus-agents.yaml.
       - path: cli-server-skills.ts
-        lines: 122
+        lines: 154
         category: implementation
         exports:
           - name: initializeSkillLibrary
@@ -794,6 +891,14 @@ modules:
             isExternal: false
             imports:
               - SkillLibraryConfig
+          - specifier: ./agents/skills/bootstrap/index.js
+            isExternal: false
+            imports:
+              - registerStandardsSkills
+          - specifier: ./agents/skills/external-pack-loader.js
+            isExternal: false
+            imports:
+              - loadAllExternalPacks
         description:
           nexus-agents CLI Server Skill Library Initialization Wires skill library configuration from
           nexus-agents.yaml to the skill library.
@@ -853,7 +958,7 @@ modules:
               - HazardSeverity
         description: nexus-agents CLI Server STPA Integration STPA safety analysis integration for tool registration.
       - path: cli-server-tools.ts
-        lines: 348
+        lines: 392
         category: implementation
         exports:
           - name: registerMcpTools
@@ -888,6 +993,11 @@ modules:
               - registerListExpertsTool
               - registerListWorkflowsTool
               - registerConsensusVoteTool
+              - registerResearchQueryTool
+              - registerResearchAddTool
+              - registerResearchDiscoverTool
+              - registerResearchAnalyzeTool
+              - registerResearchCatalogReviewTool
               - createDefaultDeps
           - specifier: ./mcp/tools/orchestrate.js
             isExternal: false
@@ -918,7 +1028,7 @@ modules:
               - setGlobalToolRateLimiterFactory
         description: nexus-agents CLI Server Tool Registration MCP tool registration and configuration.
       - path: cli-server.ts
-        lines: 569
+        lines: 573
         category: implementation
         exports:
           - name: setupShutdownHandlers
@@ -1047,9 +1157,13 @@ modules:
             isExternal: false
             imports:
               - RestApiServer
+          - specifier: ./mcp/tools/tool-memory.js
+            isExternal: false
+            imports:
+              - shutdownToolMemory
         description: nexus-agents CLI Server Server startup and shutdown handling for the CLI.
       - path: cli-types.ts
-        lines: 331
+        lines: 345
         category: types
         exports:
           - name: isValidCommand
@@ -1185,10 +1299,10 @@ modules:
         dependencies: []
         description: nexus-agents - Version constant Standalone version export to avoid loading the entire package.
     stats:
-      fileCount: 24
-      totalLines: 5464
-      exportCount: 143
-      internalDeps: 81
+      fileCount: 26
+      totalLines: 5785
+      exportCount: 154
+      internalDeps: 93
       externalDeps: 9
     dependsOn:
       - adapters
@@ -2396,7 +2510,7 @@ modules:
               - mapStreamChunk
         description: nexus-agents/adapters - OpenAI Model Adapter Adapter for OpenAI models (GPT-4o, GPT-4-turbo, GPT-3.5-turbo).
       - path: adapters/openai-mappers.ts
-        lines: 345
+        lines: 351
         category: implementation
         exports:
           - name: mapStopReason
@@ -2979,7 +3093,7 @@ modules:
         description: nexus-agents/adapters - Streaming Utilities AsyncIterator-based streaming utilities for model responses.
     stats:
       fileCount: 35
-      totalLines: 12842
+      totalLines: 12848
       exportCount: 258
       internalDeps: 74
       externalDeps: 23
@@ -7982,7 +8096,7 @@ modules:
           nexus-agents/agents - TechLead Helper Functions Helper functions for TechLead task analysis, decomposition,
           and synthesis.
       - path: agents/tech-lead-types.ts
-        lines: 323
+        lines: 337
         category: types
         exports:
           - name: SubTask
@@ -8100,7 +8214,7 @@ modules:
               - TaskAnalysis
         description: nexus-agents/agents - TechLead Tests
       - path: agents/tech-lead.ts
-        lines: 472
+        lines: 483
         category: implementation
         exports:
           - name: createTechLead
@@ -13502,6 +13616,42 @@ modules:
         description:
           nexus-agents/agents - DocumentationExpert Expert agent specialized in documentation generation, API
           documentation, and README creation.
+      - path: agents/experts/enriched-prompts.ts
+        lines: 68
+        category: implementation
+        exports:
+          - name: buildArchitecturePrompt
+            kind: function
+            isReExport: false
+          - name: buildSecurityPrompt
+            kind: function
+            isReExport: false
+          - name: buildDevOpsPrompt
+            kind: function
+            isReExport: false
+          - name: buildResearchPrompt
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ./knowledge/architecture/index.js
+            isExternal: false
+            imports:
+              - getArchitectureKnowledgePrompt
+          - specifier: ./knowledge/security/index.js
+            isExternal: false
+            imports:
+              - getSecurityKnowledgePrompt
+          - specifier: ./knowledge/devops/index.js
+            isExternal: false
+            imports:
+              - getDevOpsKnowledgePrompt
+          - specifier: ./knowledge/research/index.js
+            isExternal: false
+            imports:
+              - getResearchKnowledgePrompt
+        description:
+          nexus-agents/agents - Enriched Expert Prompts Composes built-in expert system prompts with domain-specific
+          knowledge from the knowledge modules.
       - path: agents/experts/expert-base-types.ts
         lines: 44
         category: types
@@ -13542,7 +13692,7 @@ modules:
               - ExpertConfig
         description: nexus-agents/agents - Expert Config Tests
       - path: agents/experts/expert-config.ts
-        lines: 426
+        lines: 480
         category: config
         exports:
           - name: validateExpertConfig
@@ -13585,6 +13735,13 @@ modules:
             imports:
               - AgentRole
               - AgentCapability
+          - specifier: ./enriched-prompts.js
+            isExternal: false
+            imports:
+              - buildArchitecturePrompt
+              - buildSecurityPrompt
+              - buildDevOpsPrompt
+              - buildResearchPrompt
         description:
           nexus-agents/agents - Expert Configuration Configuration schema and types for dynamically creating expert
           agents.
@@ -13651,7 +13808,7 @@ modules:
               - BUILT_IN_EXPERTS
         description: nexus-agents/agents - Expert Factory Tests
       - path: agents/experts/expert-factory.ts
-        lines: 347
+        lines: 370
         category: implementation
         exports:
           - name: createExpert
@@ -13714,26 +13871,30 @@ modules:
               - BUILT_IN_EXPERTS
         description: nexus-agents/agents - Expert Factory Factory for creating expert agents from configuration.
       - path: agents/experts/expert-prompts.ts
-        lines: 254
+        lines: 9
         category: implementation
         exports:
           - name: TESTING_EXPERT_SYSTEM_PROMPT
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./expert-prompts/index.js
           - name: SECURITY_EXPERT_SYSTEM_PROMPT
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./expert-prompts/index.js
           - name: DOCUMENTATION_EXPERT_SYSTEM_PROMPT
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./expert-prompts/index.js
           - name: ARCHITECTURE_EXPERT_SYSTEM_PROMPT
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./expert-prompts/index.js
           - name: CODE_EXPERT_SYSTEM_PROMPT
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./expert-prompts/index.js
         dependencies: []
-        description: nexus-agents/agents - Expert System Prompts System prompts for expert agents.
       - path: agents/experts/expert-registry.test.ts
         lines: 510
         category: test
@@ -13984,7 +14145,7 @@ modules:
           nexus-agents/agents - Expert Selector Selects the best experts for a task based on capability matching,
           domain alignment, and scoring algorithms.
       - path: agents/experts/expert-types.ts
-        lines: 342
+        lines: 343
         category: types
         exports:
           - name: CodeAnalysisResult
@@ -18887,8 +19048,47 @@ modules:
               - SicaEventType
               - SicaConfig
         description: nexus-agents/agents - SICA Version Manager Manages agent versions and performance metrics for SICA.
+      - path: agents/skills/external-pack-loader.ts
+        lines: 242
+        category: implementation
+        exports:
+          - name: loadExternalPack
+            kind: function
+            isReExport: false
+          - name: loadAllExternalPacks
+            kind: function
+            isReExport: false
+          - name: ExternalPackError
+            kind: class
+            isReExport: false
+          - name: ExternalPackManifest
+            kind: interface
+            isReExport: false
+          - name: ExternalPackLoadResult
+            kind: interface
+            isReExport: false
+          - name: ExternalPackSourceConfig
+            kind: interface
+            isReExport: false
+          - name: ExternalPacksLoadSummary
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ./skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: nexus-agents - External Skill Pack Loader Loads skill packs from npm packages or local file paths.
       - path: agents/skills/index.ts
-        lines: 145
+        lines: 159
         category: index
         exports:
           - name: SkillPermission
@@ -19259,6 +19459,34 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./skill-loader.js
+          - name: ExternalPackManifest
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: ExternalPackLoadResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: ExternalPackSourceConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: ExternalPacksLoadSummary
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: ExternalPackError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: loadExternalPack
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
+          - name: loadAllExternalPacks
+            kind: unknown
+            isReExport: true
+            sourceModule: ./external-pack-loader.js
         dependencies: []
         description:
           nexus-agents/agents - Skills Module Voyager-style skill library for storing, retrieving, and composing
@@ -19846,7 +20074,7 @@ modules:
           nexus-agents/agents - Skill Loader Integration Hooks Integration functions for connecting the skill loader
           with the agent system.
       - path: agents/skills/skill-loader-types.ts
-        lines: 339
+        lines: 368
         category: types
         exports:
           - name: RoleSkillMapping
@@ -20416,7 +20644,7 @@ modules:
               - SkillRBACSchema
         description: nexus-agents/agents - Skill Security Controls Security validation functions for the Voyager skill library.
       - path: agents/skills/skill-types.ts
-        lines: 374
+        lines: 385
         category: types
         exports:
           - name: Skill
@@ -20514,12 +20742,1224 @@ modules:
             imports:
               - Constitution
         description: nexus-agents/agents - Code Generation Constitution Default constitution for evaluating code generation quality.
+      - path: agents/experts/expert-prompts/architecture-expert.ts
+        lines: 46
+        category: implementation
+        exports:
+          - name: ARCHITECTURE_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description:
+          nexus-agents/agents - Architecture Expert Base Prompt Modular prompt definition for the architecture expert
+          agent.
+      - path: agents/experts/expert-prompts/code-expert.ts
+        lines: 49
+        category: implementation
+        exports:
+          - name: CODE_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/agents - Code Expert Base Prompt Modular prompt definition for the code expert agent.
+      - path: agents/experts/expert-prompts/documentation-expert.ts
+        lines: 61
+        category: implementation
+        exports:
+          - name: DOCUMENTATION_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description:
+          nexus-agents/agents - Documentation Expert Base Prompt Modular prompt definition for the documentation
+          expert agent.
+      - path: agents/experts/expert-prompts/index.ts
+        lines: 41
+        category: index
+        exports:
+          - name: SECURITY_EXPERT_SYSTEM_PROMPT
+            kind: const
+            isReExport: false
+          - name: TESTING_EXPERT_SYSTEM_PROMPT
+            kind: const
+            isReExport: false
+          - name: CODE_EXPERT_SYSTEM_PROMPT
+            kind: const
+            isReExport: false
+          - name: ARCHITECTURE_EXPERT_SYSTEM_PROMPT
+            kind: const
+            isReExport: false
+          - name: DOCUMENTATION_EXPERT_SYSTEM_PROMPT
+            kind: const
+            isReExport: false
+          - name: SECURITY_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./security-expert.js
+          - name: TESTING_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./testing-expert.js
+          - name: CODE_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./code-expert.js
+          - name: ARCHITECTURE_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./architecture-expert.js
+          - name: DOCUMENTATION_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./documentation-expert.js
+          - name: RESEARCH_EXPERT_BASE_PROMPT
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-expert.js
+          - name: PromptComposer
+            kind: unknown
+            isReExport: true
+            sourceModule: ./prompt-composer.js
+          - name: KnowledgeSection
+            kind: unknown
+            isReExport: true
+            sourceModule: ./prompt-composer.js
+        dependencies:
+          - specifier: ./security-expert.js
+            isExternal: false
+            imports:
+              - SECURITY_EXPERT_BASE_PROMPT
+          - specifier: ./testing-expert.js
+            isExternal: false
+            imports:
+              - TESTING_EXPERT_BASE_PROMPT
+          - specifier: ./code-expert.js
+            isExternal: false
+            imports:
+              - CODE_EXPERT_BASE_PROMPT
+          - specifier: ./architecture-expert.js
+            isExternal: false
+            imports:
+              - ARCHITECTURE_EXPERT_BASE_PROMPT
+          - specifier: ./documentation-expert.js
+            isExternal: false
+            imports:
+              - DOCUMENTATION_EXPERT_BASE_PROMPT
+        description: nexus-agents/agents - Expert Prompts Module Re-exports all modular expert prompts and the prompt composer.
+      - path: agents/experts/expert-prompts/prompt-composer.ts
+        lines: 46
+        category: implementation
+        exports:
+          - name: PromptComposer
+            kind: class
+            isReExport: false
+          - name: KnowledgeSection
+            kind: interface
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/agents - Prompt Composer Composes expert base prompts with domain-specific knowledge sections.
+      - path: agents/experts/expert-prompts/research-expert.ts
+        lines: 62
+        category: implementation
+        exports:
+          - name: RESEARCH_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/agents - Research Expert Base Prompt Modular prompt definition for the research expert agent.
+      - path: agents/experts/expert-prompts/security-expert.ts
+        lines: 54
+        category: implementation
+        exports:
+          - name: SECURITY_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/agents - Security Expert Base Prompt Modular prompt definition for the security expert agent.
+      - path: agents/experts/expert-prompts/testing-expert.ts
+        lines: 58
+        category: implementation
+        exports:
+          - name: TESTING_EXPERT_BASE_PROMPT
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/agents - Testing Expert Base Prompt Modular prompt definition for the testing expert agent.
+      - path: agents/experts/knowledge/index.ts
+        lines: 19
+        category: index
+        exports:
+          - name: '*'
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+        dependencies: []
+        description: Expert Knowledge Modules Domain knowledge modules for enriching expert agent prompts.
+      - path: agents/experts/knowledge/types.ts
+        lines: 122
+        category: implementation
+        exports:
+          - name: KnowledgeRegistry
+            kind: class
+            isReExport: false
+          - name: KnowledgeSection
+            kind: interface
+            isReExport: false
+          - name: KnowledgeModule
+            kind: interface
+            isReExport: false
+          - name: KnowledgeDomain
+            kind: type
+            isReExport: false
+          - name: knowledgeRegistry
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: Expert Knowledge Module Types Core type definitions for the knowledge enrichment system.
+      - path: agents/skills/bootstrap/architecture-standards.ts
+        lines: 180
+        category: implementation
+        exports:
+          - name: ARCHITECTURE_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Bootstrap skills for architecture validation and documentation analysis.
+      - path: agents/skills/bootstrap/coding-standards.ts
+        lines: 205
+        category: implementation
+        exports:
+          - name: CODING_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Bootstrap skills for coding standards review and analysis.
+      - path: agents/skills/bootstrap/index.ts
+        lines: 68
+        category: index
+        exports:
+          - name: registerStandardsSkills
+            kind: function
+            isReExport: false
+          - name: SECURITY_SKILLS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./security-standards.js
+          - name: TESTING_SKILLS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./testing-standards.js
+          - name: CODING_SKILLS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./coding-standards.js
+          - name: ARCHITECTURE_SKILLS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./architecture-standards.js
+        dependencies:
+          - specifier: ../skill-library.js
+            isExternal: false
+            imports:
+              - SkillLibrary
+          - specifier: ../../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ./security-standards.js
+            isExternal: false
+            imports:
+              - SECURITY_SKILLS
+          - specifier: ./testing-standards.js
+            isExternal: false
+            imports:
+              - TESTING_SKILLS
+          - specifier: ./coding-standards.js
+            isExternal: false
+            imports:
+              - CODING_SKILLS
+          - specifier: ./architecture-standards.js
+            isExternal: false
+            imports:
+              - ARCHITECTURE_SKILLS
+        description: Standards-based skill bootstrap module.
+      - path: agents/skills/bootstrap/security-standards.ts
+        lines: 363
+        category: implementation
+        exports:
+          - name: SECURITY_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Security Standards Skills Bootstrap Pre-built security skills for the SkillLibrary system.
+      - path: agents/skills/bootstrap/testing-standards.ts
+        lines: 278
+        category: implementation
+        exports:
+          - name: TESTING_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: 'Testing Standards Skills Bootstrap Phase 2 of Epic #643: Standards Absorption into SkillLibrary.'
+      - path: agents/skills/packs/index.ts
+        lines: 108
+        category: index
+        exports:
+          - name: loadSkillPack
+            kind: function
+            isReExport: false
+          - name: loadPacksForProduct
+            kind: function
+            isReExport: false
+          - name: getAvailablePackNames
+            kind: function
+            isReExport: false
+          - name: getPacksForProductType
+            kind: function
+            isReExport: false
+          - name: SkillPackName
+            kind: type
+            isReExport: false
+        dependencies:
+          - specifier: ../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Skill Pack Registry Central registry for optional, lazy-loaded skill packs.
+      - path: agents/experts/knowledge/architecture/clean-architecture.ts
+        lines: 104
+        category: implementation
+        exports:
+          - name: CLEAN_ARCHITECTURE_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Clean Architecture Knowledge Module Covers hexagonal/ports-and-adapters, clean architecture layers, onion
+          architecture, SOLID principles, and module b...
+      - path: agents/experts/knowledge/architecture/index.ts
+        lines: 65
+        category: index
+        exports:
+          - name: getArchitectureKnowledgePrompt
+            kind: function
+            isReExport: false
+          - name: ARCHITECTURE_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: ARCHITECTURE_DOMAIN_PATTERNS
+            kind: const
+            isReExport: false
+          - name: ARCHITECTURE_BEST_PRACTICES
+            kind: const
+            isReExport: false
+          - name: CLEAN_ARCHITECTURE_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./clean-architecture.js
+          - name: MICROSERVICES_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./microservices.js
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./clean-architecture.js
+            isExternal: false
+            imports:
+              - CLEAN_ARCHITECTURE_MODULE
+          - specifier: ./microservices.js
+            isExternal: false
+            imports:
+              - MICROSERVICES_MODULE
+        description: Architecture Knowledge Modules Domain knowledge for enriching architecture expert agent prompts.
+      - path: agents/experts/knowledge/architecture/microservices.ts
+        lines: 127
+        category: implementation
+        exports:
+          - name: MICROSERVICES_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Microservices Architecture Knowledge Module Covers service decomposition, saga patterns, circuit breakers,
+          service mesh, API gateways, event-driven ar...
+      - path: agents/experts/knowledge/code/cicd-patterns.ts
+        lines: 114
+        category: implementation
+        exports:
+          - name: CICD_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          CI/CD Patterns Knowledge Module Actionable CI/CD pipeline patterns and deployment best practices for
+          enriching code expert agent prompts.
+      - path: agents/experts/knowledge/code/index.ts
+        lines: 30
+        category: index
+        exports:
+          - name: CODE_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: TYPESCRIPT_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./typescript-patterns.js
+          - name: PYTHON_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./python-patterns.js
+          - name: CICD_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./cicd-patterns.js
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./typescript-patterns.js
+            isExternal: false
+            imports:
+              - TYPESCRIPT_PATTERNS
+          - specifier: ./python-patterns.js
+            isExternal: false
+            imports:
+              - PYTHON_PATTERNS
+          - specifier: ./cicd-patterns.js
+            isExternal: false
+            imports:
+              - CICD_PATTERNS
+        description: Code Knowledge Modules Domain knowledge for enriching code expert agent prompts.
+      - path: agents/experts/knowledge/code/python-patterns.ts
+        lines: 128
+        category: implementation
+        exports:
+          - name: PYTHON_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Python Patterns Knowledge Module Actionable Python coding patterns and best practices for enriching code
+          expert agent prompts.
+      - path: agents/experts/knowledge/code/typescript-patterns.ts
+        lines: 125
+        category: implementation
+        exports:
+          - name: TYPESCRIPT_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          TypeScript Patterns Knowledge Module Actionable TypeScript coding patterns and best practices for enriching
+          code expert agent prompts.
+      - path: agents/experts/knowledge/devops/container-orchestration.ts
+        lines: 75
+        category: implementation
+        exports:
+          - name: CONTAINER_ORCHESTRATION_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Container Orchestration Knowledge Module Covers Kubernetes patterns, container best practices, Helm chart
+          design, and pod security standards.
+      - path: agents/experts/knowledge/devops/iac-patterns.ts
+        lines: 72
+        category: implementation
+        exports:
+          - name: IAC_PATTERNS_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Infrastructure as Code (IaC) Knowledge Module Covers Terraform patterns, state management, module design,
+          drift detection, and IaC security best pract...
+      - path: agents/experts/knowledge/devops/index.ts
+        lines: 70
+        category: index
+        exports:
+          - name: getDevOpsKnowledgePrompt
+            kind: function
+            isReExport: false
+          - name: DEVOPS_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: DEVOPS_DOMAIN_PATTERNS
+            kind: const
+            isReExport: false
+          - name: DEVOPS_BEST_PRACTICES
+            kind: const
+            isReExport: false
+          - name: IAC_PATTERNS_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./iac-patterns.js
+          - name: CONTAINER_ORCHESTRATION_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./container-orchestration.js
+          - name: OBSERVABILITY_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./observability.js
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./iac-patterns.js
+            isExternal: false
+            imports:
+              - IAC_PATTERNS_MODULE
+          - specifier: ./container-orchestration.js
+            isExternal: false
+            imports:
+              - CONTAINER_ORCHESTRATION_MODULE
+          - specifier: ./observability.js
+            isExternal: false
+            imports:
+              - OBSERVABILITY_MODULE
+        description: DevOps Knowledge Modules Domain knowledge for enriching DevOps/SRE expert agent prompts.
+      - path: agents/experts/knowledge/devops/observability.ts
+        lines: 88
+        category: implementation
+        exports:
+          - name: OBSERVABILITY_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Observability Knowledge Module Covers the three pillars of observability (metrics, logs, traces), SRE
+          golden signals, alerting strategies, and SLO/SLI...
+      - path: agents/experts/knowledge/documentation/diataxis.ts
+        lines: 155
+        category: implementation
+        exports:
+          - name: DIATAXIS_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Diataxis Documentation Framework Knowledge Module Covers the four documentation types (tutorials, how-to
+          guides, reference, explanation), ADR template...
+      - path: agents/experts/knowledge/documentation/index.ts
+        lines: 21
+        category: index
+        exports:
+          - name: DOCUMENTATION_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: DIATAXIS_MODULE
+            kind: unknown
+            isReExport: true
+            sourceModule: ./diataxis.js
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./diataxis.js
+            isExternal: false
+            imports:
+              - DIATAXIS_MODULE
+        description: Documentation Knowledge Modules Domain knowledge for enriching documentation expert agent prompts.
+      - path: agents/experts/knowledge/research/index.ts
+        lines: 131
+        category: index
+        exports:
+          - name: getResearchKnowledgePrompt
+            kind: function
+            isReExport: false
+          - name: RESEARCH_METHODOLOGY_MODULE
+            kind: const
+            isReExport: false
+          - name: ARXIV_CATEGORIES_MODULE
+            kind: const
+            isReExport: false
+          - name: GITHUB_EVALUATION_MODULE
+            kind: const
+            isReExport: false
+          - name: RESEARCH_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description: Research Knowledge Modules Domain knowledge for enriching research expert agent prompts.
+      - path: agents/experts/knowledge/security/authentication.ts
+        lines: 109
+        category: implementation
+        exports:
+          - name: AUTHENTICATION_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Authentication Knowledge Module OAuth2 flows, JWT validation, MFA patterns, session management, and
+          password storage best practices.
+      - path: agents/experts/knowledge/security/authorization.ts
+        lines: 110
+        category: implementation
+        exports:
+          - name: AUTHORIZATION_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Authorization Knowledge Module RBAC/ABAC decision trees, policy patterns, least privilege, and access
+          control enforcement.
+      - path: agents/experts/knowledge/security/index.ts
+        lines: 83
+        category: index
+        exports:
+          - name: getSecurityKnowledgePrompt
+            kind: function
+            isReExport: false
+          - name: SECURITY_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: SECURITY_DOMAIN_PATTERNS
+            kind: const
+            isReExport: false
+          - name: SECURITY_BEST_PRACTICES
+            kind: const
+            isReExport: false
+          - name: OWASP_API_TOP10_MODULE
+            kind: unknown
+            isReExport: false
+          - name: AUTHENTICATION_MODULE
+            kind: unknown
+            isReExport: false
+          - name: AUTHORIZATION_MODULE
+            kind: unknown
+            isReExport: false
+          - name: INPUT_VALIDATION_MODULE
+            kind: unknown
+            isReExport: false
+          - name: SECRETS_MANAGEMENT_MODULE
+            kind: unknown
+            isReExport: false
+          - name: THREAT_MODELING_MODULE
+            kind: unknown
+            isReExport: false
+          - name: NIST_CONTROLS_MODULE
+            kind: unknown
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./owasp-api-top10.js
+            isExternal: false
+            imports:
+              - OWASP_API_TOP10_MODULE
+          - specifier: ./authentication.js
+            isExternal: false
+            imports:
+              - AUTHENTICATION_MODULE
+          - specifier: ./authorization.js
+            isExternal: false
+            imports:
+              - AUTHORIZATION_MODULE
+          - specifier: ./input-validation.js
+            isExternal: false
+            imports:
+              - INPUT_VALIDATION_MODULE
+          - specifier: ./secrets-management.js
+            isExternal: false
+            imports:
+              - SECRETS_MANAGEMENT_MODULE
+          - specifier: ./threat-modeling.js
+            isExternal: false
+            imports:
+              - THREAT_MODELING_MODULE
+          - specifier: ./nist-controls.js
+            isExternal: false
+            imports:
+              - NIST_CONTROLS_MODULE
+        description: Security Knowledge Modules Domain knowledge for enriching security expert agent prompts.
+      - path: agents/experts/knowledge/security/input-validation.ts
+        lines: 120
+        category: implementation
+        exports:
+          - name: INPUT_VALIDATION_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Input Validation Knowledge Module Validation rules by input type, sanitization patterns, and injection
+          prevention guidance.
+      - path: agents/experts/knowledge/security/nist-controls.ts
+        lines: 158
+        category: implementation
+        exports:
+          - name: NIST_CONTROLS_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          NIST 800-53 Controls Reference Knowledge Module Control reference table for common security findings across
+          Access Control (AC), Identification and Au...
+      - path: agents/experts/knowledge/security/owasp-api-top10.ts
+        lines: 143
+        category: implementation
+        exports:
+          - name: OWASP_API_TOP10_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          OWASP API Security Top 10 (2023) Knowledge Module Detection patterns and remediation guidance for each
+          OWASP API security risk category.
+      - path: agents/experts/knowledge/security/secrets-management.ts
+        lines: 119
+        category: implementation
+        exports:
+          - name: SECRETS_MANAGEMENT_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Secrets Management Knowledge Module Secrets lifecycle, rotation patterns, vault integration, environment
+          variable handling, and pre-commit scanning.
+      - path: agents/experts/knowledge/security/threat-modeling.ts
+        lines: 144
+        category: implementation
+        exports:
+          - name: THREAT_MODELING_MODULE
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Threat Modeling Knowledge Module STRIDE methodology, attack trees, threat matrix templates, and risk
+          prioritization frameworks.
+      - path: agents/experts/knowledge/testing/e2e-patterns.ts
+        lines: 184
+        category: implementation
+        exports:
+          - name: E2E_TESTING_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          End-to-End Testing Knowledge Module Best practices for E2E testing including Page Object Model, selector
+          strategies, waiting patterns, and flaky test...
+      - path: agents/experts/knowledge/testing/index.ts
+        lines: 32
+        category: index
+        exports:
+          - name: TESTING_KNOWLEDGE_MODULES
+            kind: const
+            isReExport: false
+          - name: UNIT_TESTING_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./unit-patterns.js
+          - name: INTEGRATION_TESTING_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./integration-patterns.js
+          - name: E2E_TESTING_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./e2e-patterns.js
+          - name: PERFORMANCE_TESTING_PATTERNS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./performance-patterns.js
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+          - specifier: ./unit-patterns.js
+            isExternal: false
+            imports:
+              - UNIT_TESTING_PATTERNS
+          - specifier: ./integration-patterns.js
+            isExternal: false
+            imports:
+              - INTEGRATION_TESTING_PATTERNS
+          - specifier: ./e2e-patterns.js
+            isExternal: false
+            imports:
+              - E2E_TESTING_PATTERNS
+          - specifier: ./performance-patterns.js
+            isExternal: false
+            imports:
+              - PERFORMANCE_TESTING_PATTERNS
+        description: Testing Knowledge Modules Domain knowledge for enriching testing expert agent prompts.
+      - path: agents/experts/knowledge/testing/integration-patterns.ts
+        lines: 186
+        category: implementation
+        exports:
+          - name: INTEGRATION_TESTING_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Integration Testing Knowledge Module Best practices for integration testing including contract testing,
+          service virtualization, test containers, and d...
+      - path: agents/experts/knowledge/testing/performance-patterns.ts
+        lines: 185
+        category: implementation
+        exports:
+          - name: PERFORMANCE_TESTING_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Performance Testing Knowledge Module Best practices for performance testing including load profiles, key
+          metrics, SLO validation, k6 patterns, and pro...
+      - path: agents/experts/knowledge/testing/unit-patterns.ts
+        lines: 173
+        category: implementation
+        exports:
+          - name: UNIT_TESTING_PATTERNS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../types.js
+            isExternal: false
+            imports:
+              - KnowledgeModule
+        description:
+          Unit Testing Knowledge Module Best practices for unit testing including isolation, test doubles, TDD
+          workflow, coverage targets, and the testing pyram...
+      - path: agents/skills/packs/cloud/aws-advanced.ts
+        lines: 100
+        category: implementation
+        exports:
+          - name: AWS_ADVANCED_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          AWS Advanced Patterns Skills AWS-specific patterns for IAM, S3, DynamoDB, SQS/SNS, and
+          infrastructure-as-code best practices.
+      - path: agents/skills/packs/cloud/index.ts
+        lines: 34
+        category: index
+        exports:
+          - name: loadCloudPack
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Cloud Skill Pack Lazy-loaded cloud skills covering serverless, service mesh, AWS, and Kubernetes.
+      - path: agents/skills/packs/cloud/kubernetes-advanced.ts
+        lines: 102
+        category: implementation
+        exports:
+          - name: KUBERNETES_ADVANCED_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Kubernetes Advanced Patterns Skills Advanced Kubernetes patterns: custom operators, CRDs, resource
+          management, and security hardening.'
+      - path: agents/skills/packs/cloud/serverless-patterns.ts
+        lines: 56
+        category: implementation
+        exports:
+          - name: SERVERLESS_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Serverless Patterns Skills Patterns for serverless architectures: Lambda/Functions best practices, cold
+          start optimization, event-driven patterns, and...'
+      - path: agents/skills/packs/cloud/service-mesh-patterns.ts
+        lines: 57
+        category: implementation
+        exports:
+          - name: SERVICE_MESH_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Service Mesh Patterns Skills Patterns for service mesh architectures: traffic management, observability,
+          security policies, and resilience patterns.'
+      - path: agents/skills/packs/compliance/gdpr-checklist.ts
+        lines: 99
+        category: implementation
+        exports:
+          - name: GDPR_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: GDPR Data Handling Checklist Skills Compliance checks for EU General Data Protection Regulation.
+      - path: agents/skills/packs/compliance/hipaa-checklist.ts
+        lines: 58
+        category: implementation
+        exports:
+          - name: HIPAA_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: HIPAA Compliance Checklist Skills Health Insurance Portability and Accountability Act compliance checks.
+      - path: agents/skills/packs/compliance/index.ts
+        lines: 34
+        category: index
+        exports:
+          - name: loadCompliancePack
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Compliance Skill Pack Lazy-loaded compliance skills covering NIST 800-53, GDPR, HIPAA, and PCI-DSS.
+      - path: agents/skills/packs/compliance/nist-controls.ts
+        lines: 92
+        category: implementation
+        exports:
+          - name: NIST_CONTROLS_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: NIST 800-53 Control Mapping Skills Condensed control mapping checklist for NIST SP 800-53 Rev 5.
+      - path: agents/skills/packs/compliance/pci-dss-checklist.ts
+        lines: 58
+        category: implementation
+        exports:
+          - name: PCI_DSS_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: PCI-DSS Compliance Checklist Skills Payment Card Industry Data Security Standard compliance checks.
+      - path: agents/skills/packs/misc/accessibility.ts
+        lines: 57
+        category: implementation
+        exports:
+          - name: ACCESSIBILITY_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Accessibility (WCAG 2.1) Checklist Skills WCAG 2.1 accessibility checks: perceivable, operable,
+          understandable, and robust content requirements.'
+      - path: agents/skills/packs/misc/data-orchestration.ts
+        lines: 56
+        category: implementation
+        exports:
+          - name: DATA_ORCHESTRATION_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Data Orchestration Patterns Skills DAG-based data pipeline patterns: task dependencies, retry strategies,
+          backfill patterns, and scheduling.'
+      - path: agents/skills/packs/misc/data-quality.ts
+        lines: 56
+        category: implementation
+        exports:
+          - name: DATA_QUALITY_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Data Quality Skills Data validation rules and quality checks: schema validation, completeness,
+          consistency, and freshness monitoring.'
+      - path: agents/skills/packs/misc/index.ts
+        lines: 35
+        category: index
+        exports:
+          - name: loadMiscPack
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          Miscellaneous Skill Pack Lazy-loaded skills covering data orchestration, data quality, Vue.js patterns, and
+          accessibility (WCAG 2.1).
+      - path: agents/skills/packs/misc/vue-patterns.ts
+        lines: 56
+        category: implementation
+        exports:
+          - name: VUE_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Vue.js Patterns Skills Vue 3 Composition API patterns: reactivity, composables, state management, and
+          performance optimization.'
+      - path: agents/skills/packs/ml-ai/index.ts
+        lines: 32
+        category: index
+        exports:
+          - name: loadMlAiPack
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: ML/AI Skill Pack Lazy-loaded ML/AI skills covering testing, model serving, and MLOps pipelines.
+      - path: agents/skills/packs/ml-ai/ml-testing.ts
+        lines: 96
+        category: implementation
+        exports:
+          - name: ML_TESTING_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          ML Testing Patterns Skills Testing patterns for machine learning systems including data validation, model
+          evaluation, training-serving skew detection,...
+      - path: agents/skills/packs/ml-ai/mlops-pipeline.ts
+        lines: 87
+        category: implementation
+        exports:
+          - name: MLOPS_PIPELINE_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'MLOps Pipeline Patterns Skills Patterns for ML pipeline orchestration: experiment tracking,
+          reproducibility, model registry, CI/CD for ML, and feature...'
+      - path: agents/skills/packs/ml-ai/model-serving.ts
+        lines: 86
+        category: implementation
+        exports:
+          - name: MODEL_SERVING_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          'Model Serving Patterns Skills Patterns for serving ML models in production: inference optimization, A/B
+          testing, canary deployments, model versioning,...'
+      - path: agents/skills/packs/mobile/android-patterns.ts
+        lines: 97
+        category: implementation
+        exports:
+          - name: ANDROID_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          Android Development Patterns Skills Android-specific patterns covering lifecycle management, Jetpack
+          Compose, dependency injection, and architecture c...
+      - path: agents/skills/packs/mobile/index.ts
+        lines: 28
+        category: index
+        exports:
+          - name: loadMobilePack
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description: Mobile Skill Pack Lazy-loaded mobile skills covering Android, iOS, and React Native patterns.
+      - path: agents/skills/packs/mobile/ios-patterns.ts
+        lines: 86
+        category: implementation
+        exports:
+          - name: IOS_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          iOS Development Patterns Skills iOS-specific patterns covering SwiftUI, UIKit, Combine, and architecture
+          patterns for Apple platforms.
+      - path: agents/skills/packs/mobile/react-native-patterns.ts
+        lines: 96
+        category: implementation
+        exports:
+          - name: REACT_NATIVE_SKILLS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ../../skill-types.js
+            isExternal: false
+            imports:
+              - CreateSkillOptions
+        description:
+          React Native Patterns Skills React Native patterns covering bridge communication, navigation, performance
+          optimization, and platform-specific patterns...
     stats:
-      fileCount: 262
-      totalLines: 73667
-      exportCount: 3094
-      internalDeps: 718
-      externalDeps: 96
+      fileCount: 330
+      totalLines: 80258
+      exportCount: 3236
+      internalDeps: 811
+      externalDeps: 97
     dependsOn:
       - cli-adapters
       - context
@@ -20705,7 +22145,7 @@ modules:
         dependencies: []
         description: nexus-agents/api - REST API Module Fastify-based REST API gateway for non-MCP clients.
       - path: api/rest-server.test.ts
-        lines: 429
+        lines: 434
         category: test
         exports: []
         dependencies:
@@ -21290,7 +22730,7 @@ modules:
         description: nexus-agents/api - Workflow Route POST /api/v1/workflow endpoint for workflow execution.
     stats:
       fileCount: 17
-      totalLines: 3774
+      totalLines: 3779
       exportCount: 78
       internalDeps: 48
       externalDeps: 26
@@ -22294,6 +23734,29 @@ modules:
             isReExport: false
         dependencies: []
         description: ANSI Output Utilities Consolidated terminal output utilities for CLI commands.
+      - path: cli/bluesky-client.ts
+        lines: 122
+        category: implementation
+        exports:
+          - name: getBlueskyConfig
+            kind: function
+            isReExport: false
+          - name: createBlueskyPost
+            kind: function
+            isReExport: false
+          - name: BlueskyPostResult
+            kind: interface
+            isReExport: false
+          - name: BlueskyConfig
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: '@atproto/api'
+            isExternal: true
+            imports:
+              - AtpAgent
+              - RichText
+        description: Bluesky Client AT Protocol client for posting to Bluesky.
       - path: cli/box-drawing.ts
         lines: 78
         category: implementation
@@ -22326,6 +23789,53 @@ modules:
               - colors
               - color
         description: Box Drawing Utilities Shared ASCII box drawing helpers for CLI dashboard rendering.
+      - path: cli/capabilities-command.test.ts
+        lines: 123
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+          - specifier: ../cli-types.js
+            isExternal: false
+            imports:
+              - ParsedCliArgs
+        description:
+          'nexus-agents/cli - Capabilities Command Tests (Source: Issue #697 - Add test coverage for untested CLI
+          commands)'
+      - path: cli/capabilities-command.ts
+        lines: 308
+        category: cli
+        exports:
+          - name: handleCapabilitiesCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../cli-types.js
+            isExternal: false
+            imports:
+              - ParsedCliArgs
+          - specifier: ../config/model-capabilities.js
+            isExternal: false
+            imports:
+              - DEFAULT_MODEL_CAPABILITIES
+              - findModelsByOutputModality
+              - findModelsByInputModality
+              - findModelsByToolCapability
+              - findModelsByFeature
+              - getModelCapabilities
+              - OUTPUT_MODALITIES
+              - INPUT_MODALITIES
+              - TOOL_CAPABILITIES
+              - SPECIAL_FEATURES
+        description: nexus-agents/cli - Capabilities Command CLI command for displaying the model capabilities matrix.
       - path: cli/cli-adapter-agent.ts
         lines: 95
         category: implementation
@@ -23402,6 +24912,34 @@ modules:
             imports:
               - colors
         description: nexus-agents expert list command Lists all available experts (built-in and custom).
+      - path: cli/fitness-audit.test.ts
+        lines: 150
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ../governance/fitness-score.js
+            isExternal: false
+            imports:
+              - FitnessAudit
+          - specifier: ./fitness-audit.js
+            isExternal: false
+            imports:
+              - fitnessAuditCommand
+          - specifier: ../governance/index.js
+            isExternal: false
+            imports:
+              - calculateFitnessScore
+        description:
+          'nexus-agents/cli - Fitness Audit Command Tests (Source: Issue #697 - Add test coverage for untested CLI
+          commands)'
       - path: cli/fitness-audit.ts
         lines: 207
         category: implementation
@@ -23815,7 +25353,7 @@ modules:
               - IndexCommandResult
         description: nexus-agents/cli - Index Command CLI command to generate and manage the codebase index.
       - path: cli/index.ts
-        lines: 395
+        lines: 462
         category: index
         exports:
           - name: doctorCommand
@@ -25074,6 +26612,182 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./fitness-audit.js
+          - name: releaseNotesCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-command.js
+          - name: runReleaseNotes
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-command.js
+          - name: printReleaseNotesResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-command.js
+          - name: ReleaseNotesOptions
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-types.js
+          - name: ReleaseNotesResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-types.js
+          - name: CategorizedCommit
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-types.js
+          - name: ReleaseNotesCategory
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-types.js
+          - name: getLatestTag
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: getCommitsBetween
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: parseConventionalCommit
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: groupCommitsByCategory
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: generateChangelogFormat
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: suggestNextVersion
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-notes-helpers.js
+          - name: releaseValidateCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-command.js
+          - name: runReleaseValidate
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-command.js
+          - name: printReleaseValidateResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-command.js
+          - name: ReleaseValidateOptions
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-types.js
+          - name: ReleaseValidateResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-types.js
+          - name: ExpertValidationResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-types.js
+          - name: ValidationFinding
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-types.js
+          - name: ValidationSeverity
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-validate-types.js
+          - name: releaseAnnounceCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-command.js
+          - name: runReleaseAnnounce
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-command.js
+          - name: printReleaseAnnounceResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-command.js
+          - name: ReleaseAnnounceOptions
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-types.js
+          - name: ReleaseAnnounceResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-types.js
+          - name: ChannelAnnouncementResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-types.js
+          - name: AnnouncementChannel
+            kind: unknown
+            isReExport: true
+            sourceModule: ./release-announce-types.js
+          - name: getBlueskyConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./bluesky-client.js
+          - name: createBlueskyPost
+            kind: unknown
+            isReExport: true
+            sourceModule: ./bluesky-client.js
+          - name: BlueskyPostResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./bluesky-client.js
+          - name: BlueskyConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./bluesky-client.js
+          - name: scaffoldCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: runScaffold
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: printScaffoldResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: printScaffoldUsage
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: isValidScaffoldType
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: validateName
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: toPascalCase
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: toCamelCase
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: toScreamingSnake
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: ScaffoldType
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: ScaffoldOptions
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
+          - name: ScaffoldResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./scaffold.js
         dependencies: []
         description: nexus-agents/cli - CLI utilities Command implementations for the nexus-agents CLI.
       - path: cli/issue-command.test.ts
@@ -25808,6 +27522,354 @@ modules:
             imports:
               - CommandResult
         description: Orchestrate Command Shared Types Shared type definitions for the orchestrate command and puppeteer integration.
+      - path: cli/release-announce-command.ts
+        lines: 464
+        category: cli
+        exports:
+          - name: runReleaseAnnounce
+            kind: function
+            isReExport: false
+          - name: printReleaseAnnounceResult
+            kind: function
+            isReExport: false
+          - name: releaseAnnounceCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - readFileSync
+              - existsSync
+          - specifier: ./ansi-output.js
+            isExternal: false
+            imports:
+              - colors
+          - specifier: ./release-announce-types.js
+            isExternal: false
+            imports:
+              - ReleaseAnnounceOptions
+              - ReleaseAnnounceResult
+              - ChannelAnnouncementResult
+              - BlogPostMetadata
+              - AnnouncementChannel
+              - BLUESKY_LIMITS
+          - specifier: ./release-notes-helpers.js
+            isExternal: false
+            imports:
+              - getLatestTag
+              - getCommitsBetween
+              - parseConventionalCommit
+              - groupCommitsByCategory
+          - specifier: ./bluesky-client.js
+            isExternal: false
+            imports:
+              - getBlueskyConfig
+              - createBlueskyPost
+        description: Release Announce Command CLI command for generating release announcements.
+      - path: cli/release-announce-types.ts
+        lines: 88
+        category: types
+        exports:
+          - name: ReleaseAnnounceOptions
+            kind: interface
+            isReExport: false
+          - name: ChannelAnnouncementResult
+            kind: interface
+            isReExport: false
+          - name: BlogPostMetadata
+            kind: interface
+            isReExport: false
+          - name: ReleaseAnnounceResult
+            kind: interface
+            isReExport: false
+          - name: AnnouncementChannel
+            kind: type
+            isReExport: false
+          - name: BLUESKY_LIMITS
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: Release Announce Types Type definitions for the release-announce CLI command.
+      - path: cli/release-notes-command.test.ts
+        lines: 292
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./release-notes-types.js
+            isExternal: false
+            imports:
+              - CategorizedCommit
+              - ReleaseNotesCategory
+          - specifier: ./release-notes-command.js
+            isExternal: false
+            imports:
+              - runReleaseNotes
+              - printReleaseNotesResult
+              - releaseNotesCommand
+          - specifier: ./release-notes-helpers.js
+            isExternal: false
+            imports:
+              - getLatestTag
+              - getCommitsBetween
+              - parseConventionalCommit
+              - groupCommitsByCategory
+              - suggestNextVersion
+              - generateChangelogFormat
+              - generateJsonFormat
+              - generateMarkdownFormat
+        description:
+          'nexus-agents/cli - Release Notes Command Tests (Source: Issue #697 - Add test coverage for untested CLI
+          commands)'
+      - path: cli/release-notes-command.ts
+        lines: 190
+        category: cli
+        exports:
+          - name: runReleaseNotes
+            kind: function
+            isReExport: false
+          - name: printReleaseNotesResult
+            kind: function
+            isReExport: false
+          - name: releaseNotesCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ./ansi-output.js
+            isExternal: false
+            imports:
+              - colors
+          - specifier: ./release-notes-types.js
+            isExternal: false
+            imports:
+              - ReleaseNotesOptions
+              - ReleaseNotesResult
+              - CategorizedCommit
+          - specifier: ./release-notes-helpers.js
+            isExternal: false
+            imports:
+              - getLatestTag
+              - getCommitsBetween
+              - parseConventionalCommit
+              - groupCommitsByCategory
+              - generateChangelogFormat
+              - generateJsonFormat
+              - generateMarkdownFormat
+              - suggestNextVersion
+        description: Release Notes Command CLI command for generating release notes from git commits.
+      - path: cli/release-notes-helpers.ts
+        lines: 303
+        category: util
+        exports:
+          - name: getLatestTag
+            kind: function
+            isReExport: false
+          - name: getCommitsBetween
+            kind: function
+            isReExport: false
+          - name: parseConventionalCommit
+            kind: function
+            isReExport: false
+          - name: extractIssueNumbers
+            kind: function
+            isReExport: false
+          - name: mapTypeToCategory
+            kind: function
+            isReExport: false
+          - name: groupCommitsByCategory
+            kind: function
+            isReExport: false
+          - name: formatCommitEntry
+            kind: function
+            isReExport: false
+          - name: generateChangelogFormat
+            kind: function
+            isReExport: false
+          - name: generateJsonFormat
+            kind: function
+            isReExport: false
+          - name: generateMarkdownFormat
+            kind: function
+            isReExport: false
+          - name: suggestNextVersion
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: node:child_process
+            isExternal: true
+            imports:
+              - execSync
+          - specifier: ./release-notes-types.js
+            isExternal: false
+            imports:
+              - CategorizedCommit
+              - ReleaseNotesCategory
+              - COMMIT_TYPE_TO_CATEGORY
+              - CATEGORY_ORDER
+        description: Release Notes Helpers Helper functions for parsing commits and generating release notes.
+      - path: cli/release-notes-types.ts
+        lines: 133
+        category: types
+        exports:
+          - name: ReleaseNotesOptions
+            kind: interface
+            isReExport: false
+          - name: CategorizedCommit
+            kind: interface
+            isReExport: false
+          - name: ReleaseNotesCategory
+            kind: interface
+            isReExport: false
+          - name: CategorizationVote
+            kind: interface
+            isReExport: false
+          - name: ReleaseNotesResult
+            kind: interface
+            isReExport: false
+          - name: COMMIT_TYPE_TO_CATEGORY
+            kind: const
+            isReExport: false
+          - name: CATEGORY_ORDER
+            kind: const
+            isReExport: false
+        dependencies: []
+        description: Release Notes Types Type definitions for the release-notes CLI command.
+      - path: cli/release-validate-command.test.ts
+        lines: 303
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./release-validate-types.js
+            isExternal: false
+            imports:
+              - ReleaseValidateResult
+          - specifier: ./release-validate-command.js
+            isExternal: false
+            imports:
+              - runReleaseValidate
+              - printReleaseValidateResult
+              - releaseValidateCommand
+          - specifier: ./release-validate-helpers.js
+            isExternal: false
+            imports:
+              - validateSecurity
+              - validateArchitecture
+              - validateDocumentation
+              - validateDevOps
+        description:
+          'nexus-agents/cli - Release Validate Command Tests (Source: Issue #697 - Add test coverage for untested CLI
+          commands)'
+      - path: cli/release-validate-command.ts
+        lines: 218
+        category: cli
+        exports:
+          - name: runReleaseValidate
+            kind: function
+            isReExport: false
+          - name: printReleaseValidateResult
+            kind: function
+            isReExport: false
+          - name: releaseValidateCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - readFileSync
+          - specifier: ./ansi-output.js
+            isExternal: false
+            imports:
+              - colors
+          - specifier: ./release-validate-types.js
+            isExternal: false
+            imports:
+              - ReleaseValidateOptions
+              - ReleaseValidateResult
+              - ExpertValidationResult
+          - specifier: ./release-validate-helpers.js
+            isExternal: false
+            imports:
+              - validateSecurity
+              - validateArchitecture
+              - validateDocumentation
+              - validateDevOps
+        description: Release Validate Command CLI command for validating releases with expert swarm.
+      - path: cli/release-validate-helpers.ts
+        lines: 329
+        category: util
+        exports:
+          - name: validateSecurity
+            kind: function
+            isReExport: false
+          - name: validateArchitecture
+            kind: function
+            isReExport: false
+          - name: validateDocumentation
+            kind: function
+            isReExport: false
+          - name: validateDevOps
+            kind: function
+            isReExport: false
+          - name: ValidatorOptions
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: node:child_process
+            isExternal: true
+            imports:
+              - execSync
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - existsSync
+              - readFileSync
+          - specifier: ./release-validate-types.js
+            isExternal: false
+            imports:
+              - ExpertValidationResult
+              - ValidationFinding
+        description: Release Validate Helpers Expert validator functions for release validation.
+      - path: cli/release-validate-types.ts
+        lines: 92
+        category: types
+        exports:
+          - name: ReleaseValidateOptions
+            kind: interface
+            isReExport: false
+          - name: ValidationFinding
+            kind: interface
+            isReExport: false
+          - name: ExpertValidationResult
+            kind: interface
+            isReExport: false
+          - name: ReleaseValidateResult
+            kind: interface
+            isReExport: false
+          - name: ValidationSeverity
+            kind: type
+            isReExport: false
+          - name: ExpertValidator
+            kind: type
+            isReExport: false
+        dependencies: []
+        description: Release Validate Types Type definitions for the release-validate CLI command.
       - path: cli/repl-formatters.ts
         lines: 106
         category: implementation
@@ -25980,7 +28042,7 @@ modules:
               - ResearchStatusResult
         description: Research Registry CLI Tests Tests for research command implementations.
       - path: cli/research-command.ts
-        lines: 310
+        lines: 365
         category: cli
         exports:
           - name: isValidResearchSubcommand
@@ -26130,14 +28192,6 @@ modules:
             kind: unknown
             isReExport: false
         dependencies:
-          - specifier: node:fs/promises
-            isExternal: true
-            imports:
-              - '* as fs'
-          - specifier: node:path
-            isExternal: true
-            imports:
-              - '* as path'
           - specifier: ./research-types.js
             isExternal: false
             imports:
@@ -26152,13 +28206,32 @@ modules:
               - findOverlaps
               - formatOverlapResult
               - addResearchPaper
-          - specifier: ../indexer/research-index/index.js
+          - specifier: ./research-helpers-sources.js
             isExternal: false
             imports:
-              - parseRegistry
-              - generateIndexMarkdown
-              - generateStatsJson
-              - generateSummaryReport
+              - discoverGitHubRepos
+              - discoverGoogleAI
+              - discoverMetaFAIR
+              - discoverMicrosoftResearch
+              - discoverDeepMind
+              - DiscoveredSource
+          - specifier: ./research-helpers-sources-academic.js
+            isExternal: false
+            imports:
+              - discoverSemanticScholar
+              - discoverPapersWithCode
+          - specifier: ./research-helpers-index-ops.js
+            isExternal: false
+            imports:
+              - handleStatsCommand
+              - handleRefreshCommand
+              - handleCheckCommand
+          - specifier: ./research-helpers-review.js
+            isExternal: false
+            imports:
+              - executeReview
+              - formatReviewResults
+              - executePrioritize
           - specifier: ./research-index-command.js
             isExternal: false
             imports:
@@ -26208,6 +28281,36 @@ modules:
             imports:
               - addPaperToRegistry
         description: Research Registry arXiv Helpers Functions for fetching and parsing arXiv paper metadata.
+      - path: cli/research-helpers-index-ops.ts
+        lines: 127
+        category: util
+        exports:
+          - name: handleStatsCommand
+            kind: function
+            isReExport: false
+          - name: handleRefreshCommand
+            kind: function
+            isReExport: false
+          - name: handleCheckCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: node:fs/promises
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: ../indexer/research-index/index.js
+            isExternal: false
+            imports:
+              - parseRegistry
+              - generateIndexMarkdown
+              - generateStatsJson
+              - generateSummaryReport
+        description: Research Index Operations Extracted from research-command.ts to stay under file size limits.
       - path: cli/research-helpers-io.test.ts
         lines: 229
         category: test
@@ -26304,6 +28407,45 @@ modules:
               - TechniquesRegistry
               - PapersRegistry
         description: Research Registry I/O Operations File operations for loading and saving research registry YAML files.
+      - path: cli/research-helpers-issues.ts
+        lines: 156
+        category: util
+        exports:
+          - name: formatResearchIssueBody
+            kind: function
+            isReExport: false
+          - name: createResearchIssue
+            kind: function
+            isReExport: false
+          - name: CreateResearchIssueOptions
+            kind: interface
+            isReExport: false
+          - name: CreateResearchIssueResult
+            kind: interface
+            isReExport: false
+          - name: IssueCreationError
+            kind: interface
+            isReExport: false
+          - name: VoteResultSummary
+            kind: interface
+            isReExport: false
+          - name: ResearchFinding
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: node:child_process
+            isExternal: true
+            imports:
+              - execFile
+          - specifier: node:util
+            isExternal: true
+            imports:
+              - promisify
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+        description: Research Issue Helpers Functions for creating GitHub issues from research findings.
       - path: cli/research-helpers-overlap.ts
         lines: 194
         category: util
@@ -26424,6 +28566,268 @@ modules:
         description:
           Research Registry Paper Operations Functions for adding papers to the research registry with proper YAML
           formatting.
+      - path: cli/research-helpers-review.ts
+        lines: 211
+        category: util
+        exports:
+          - name: executeReview
+            kind: function
+            isReExport: false
+          - name: formatReviewResults
+            kind: function
+            isReExport: false
+          - name: executePrioritize
+            kind: function
+            isReExport: false
+          - name: ReviewOptions
+            kind: interface
+            isReExport: false
+          - name: ReviewResult
+            kind: interface
+            isReExport: false
+          - name: PrioritizeOptions
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: ./research-helpers-sources.js
+            isExternal: false
+            imports:
+              - DiscoveredSource
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+          - specifier: ./research-helpers-scoring.js
+            isExternal: false
+            imports:
+              - rankDiscoveredItems
+              - QualityScore
+          - specifier: ./research-helpers-issues.js
+            isExternal: false
+            imports:
+              - createResearchIssue
+              - formatResearchIssueBody
+              - ResearchFinding
+          - specifier: ./research-helpers-io.js
+            isExternal: false
+            imports:
+              - loadTechniquesRegistry
+          - specifier: ./research-types.js
+            isExternal: false
+            imports:
+              - TechniquesRegistry
+        description: Research Review and Prioritize Handlers Implements the discover → score → issue → vote end-to-end workflows.
+      - path: cli/research-helpers-scoring.test.ts
+        lines: 131
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+          - specifier: ./research-helpers-scoring.js
+            isExternal: false
+            imports:
+              - scoreDiscoveredItem
+              - rankDiscoveredItems
+          - specifier: ./research-helpers-sources.js
+            isExternal: false
+            imports:
+              - DiscoveredSource
+        description: Tests for research quality scoring.
+      - path: cli/research-helpers-scoring.ts
+        lines: 136
+        category: util
+        exports:
+          - name: scoreDiscoveredItem
+            kind: function
+            isReExport: false
+          - name: rankDiscoveredItems
+            kind: function
+            isReExport: false
+          - name: QualityScore
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: ./research-helpers-sources.js
+            isExternal: false
+            imports:
+              - DiscoveredSource
+        description:
+          Research Quality Scoring Scores discovered research items by relevance, impact, recency, and
+          reproducibility to aid prioritization.
+      - path: cli/research-helpers-sources-academic.test.ts
+        lines: 191
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+          - specifier: ./research-helpers-sources-academic.js
+            isExternal: false
+            imports:
+              - discoverSemanticScholar
+              - discoverPapersWithCode
+        description: Tests for academic source discovery providers (Semantic Scholar, Papers with Code).
+      - path: cli/research-helpers-sources-academic.ts
+        lines: 210
+        category: util
+        exports:
+          - name: discoverSemanticScholar
+            kind: function
+            isReExport: false
+          - name: discoverPapersWithCode
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+          - specifier: ./research-helpers-sources.js
+            isExternal: false
+            imports:
+              - DiscoverError
+              - DiscoveredSource
+        description: Academic Source Discovery Providers Semantic Scholar and Papers with Code discovery providers.
+      - path: cli/research-helpers-sources-io.ts
+        lines: 176
+        category: util
+        exports:
+          - name: loadSourcesRegistry
+            kind: function
+            isReExport: false
+          - name: saveSourcesRegistry
+            kind: function
+            isReExport: false
+          - name: sourceExistsInRegistry
+            kind: function
+            isReExport: false
+          - name: addSourceToRegistry
+            kind: function
+            isReExport: false
+          - name: SourceEntry
+            kind: interface
+            isReExport: false
+          - name: SourcesRegistry
+            kind: interface
+            isReExport: false
+          - name: SourcesIOError
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: node:fs/promises
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: yaml
+            isExternal: true
+            imports:
+              - parse
+              - stringify
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+          - specifier: ./research-helpers-io.js
+            isExternal: false
+            imports:
+              - REGISTRY_PATH
+              - getProjectRoot
+        description: Research Sources Registry I/O Functions for loading, saving, and querying the sources.yaml registry.
+      - path: cli/research-helpers-sources.test.ts
+        lines: 328
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+          - specifier: ./research-helpers-sources.js
+            isExternal: false
+            imports:
+              - discoverGitHubRepos
+              - discoverGoogleAI
+              - discoverMetaFAIR
+              - discoverMicrosoftResearch
+              - discoverDeepMind
+              - discoverArxiv
+              - fetchSource
+              - scoreRelevance
+        description: Tests for research source discovery providers.
+      - path: cli/research-helpers-sources.ts
+        lines: 401
+        category: util
+        exports:
+          - name: fetchSource
+            kind: function
+            isReExport: false
+          - name: discoverGitHubRepos
+            kind: function
+            isReExport: false
+          - name: discoverArxiv
+            kind: function
+            isReExport: false
+          - name: discoverGoogleAI
+            kind: function
+            isReExport: false
+          - name: discoverMetaFAIR
+            kind: function
+            isReExport: false
+          - name: discoverMicrosoftResearch
+            kind: function
+            isReExport: false
+          - name: discoverDeepMind
+            kind: function
+            isReExport: false
+          - name: scoreRelevance
+            kind: function
+            isReExport: false
+          - name: DiscoverError
+            kind: interface
+            isReExport: false
+          - name: DiscoveredSource
+            kind: interface
+            isReExport: false
+          - name: DiscoverErrorCode
+            kind: type
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+        description:
+          'Research Source Discovery Providers Functions for discovering research from external sources: GitHub,
+          Google AI, Meta FAIR, Microsoft Research, DeepMi...'
       - path: cli/research-helpers-status.ts
         lines: 205
         category: util
@@ -26490,7 +28894,7 @@ modules:
               - ResearchOverlapResult
         description: 'Tests for research-helpers (Source: Issue #249 - CLI test coverage)'
       - path: cli/research-helpers.ts
-        lines: 71
+        lines: 125
         category: util
         exports:
           - name: REGISTRY_PATH
@@ -26621,6 +29025,126 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./research-helpers-registry.js
+          - name: discoverGitHubRepos
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: discoverGoogleAI
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: discoverMetaFAIR
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: discoverMicrosoftResearch
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: discoverDeepMind
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: DiscoverError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: DiscoverErrorCode
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: DiscoveredSource
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources.js
+          - name: loadSourcesRegistry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: saveSourcesRegistry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: sourceExistsInRegistry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: addSourceToRegistry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: SourceEntry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: SourcesRegistry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: SourcesIOError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-io.js
+          - name: discoverSemanticScholar
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-academic.js
+          - name: discoverPapersWithCode
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-sources-academic.js
+          - name: scoreDiscoveredItem
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-scoring.js
+          - name: rankDiscoveredItems
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-scoring.js
+          - name: QualityScore
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-scoring.js
+          - name: handleStatsCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-index-ops.js
+          - name: handleRefreshCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-index-ops.js
+          - name: handleCheckCommand
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-index-ops.js
+          - name: createResearchIssue
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: formatResearchIssueBody
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: CreateResearchIssueOptions
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: CreateResearchIssueResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: IssueCreationError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: ResearchFinding
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
+          - name: VoteResultSummary
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-helpers-issues.js
         dependencies: []
         description:
           'Research Registry Helper Functions Entry point that re-exports from specialized modules: -
@@ -27433,6 +29957,91 @@ modules:
               - SandboxPolicy
               - PolicyViolation
         description: nexus-agents/cli - Sandbox Execution Helpers Provides sandbox-aware command execution for CLI commands.
+      - path: cli/scaffold-templates.ts
+        lines: 327
+        category: implementation
+        exports:
+          - name: generateToolFiles
+            kind: function
+            isReExport: false
+          - name: generateExpertFiles
+            kind: function
+            isReExport: false
+          - name: generateWorkflowFiles
+            kind: function
+            isReExport: false
+          - name: generateCommandFiles
+            kind: function
+            isReExport: false
+          - name: GeneratedFile
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: ./scaffold.js
+            isExternal: false
+            imports:
+              - toPascalCase
+              - toCamelCase
+              - toScreamingSnake
+        description: nexus-agents scaffold templates Template generators for each scaffold type.
+      - path: cli/scaffold.ts
+        lines: 172
+        category: implementation
+        exports:
+          - name: isValidScaffoldType
+            kind: function
+            isReExport: false
+          - name: validateName
+            kind: function
+            isReExport: false
+          - name: toPascalCase
+            kind: function
+            isReExport: false
+          - name: toCamelCase
+            kind: function
+            isReExport: false
+          - name: toScreamingSnake
+            kind: function
+            isReExport: false
+          - name: runScaffold
+            kind: function
+            isReExport: false
+          - name: printScaffoldResult
+            kind: function
+            isReExport: false
+          - name: printScaffoldUsage
+            kind: function
+            isReExport: false
+          - name: scaffoldCommand
+            kind: function
+            isReExport: false
+          - name: ScaffoldOptions
+            kind: interface
+            isReExport: false
+          - name: ScaffoldResult
+            kind: interface
+            isReExport: false
+          - name: ScaffoldType
+            kind: type
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: ./scaffold-templates.js
+            isExternal: false
+            imports:
+              - generateToolFiles
+              - generateExpertFiles
+              - generateWorkflowFiles
+              - generateCommandFiles
+              - GeneratedFile
+        description: nexus-agents scaffold command Generates project files following nexus-agents conventions.
       - path: cli/self-eval-format.ts
         lines: 236
         category: implementation
@@ -28848,6 +31457,63 @@ modules:
             imports:
               - CommandResult
         description: nexus-agents sprint command types Type definitions for the sprint planning CLI command.
+      - path: cli/status-command.test.ts
+        lines: 216
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+        description: 'Tests for status-command.ts (Issue #688, #691)'
+      - path: cli/status-command.ts
+        lines: 196
+        category: cli
+        exports:
+          - name: collectStatus
+            kind: function
+            isReExport: false
+          - name: handleStatusCommand
+            kind: function
+            isReExport: false
+          - name: StatusResult
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: ../version.js
+            isExternal: false
+            imports:
+              - VERSION
+          - specifier: ./ansi-output.js
+            isExternal: false
+            imports:
+              - colors
+              - symbols
+          - specifier: ../governance/fitness-score.js
+            isExternal: false
+            imports:
+              - createFitnessScoreCalculator
+          - specifier: ../core/index.js
+            isExternal: false
+            imports:
+              - createLogger
+          - specifier: ../cli-types.js
+            isExternal: false
+            imports:
+              - ParsedCliArgs
+          - specifier: node:child_process
+            isExternal: true
+            imports:
+              - execFileSync
+        description:
+          nexus-agents/cli - Status Command At-a-glance project health dashboard combining fitness score, adapter
+          availability (both CLI tools and API keys), an...
       - path: cli/swe-bench-command.test.ts
         lines: 187
         category: test
@@ -29288,6 +31954,61 @@ modules:
               - colors
               - symbols
         description: nexus-agents/cli - Verify Command Quick verification that installation works correctly.
+      - path: cli/visualize-command.ts
+        lines: 313
+        category: cli
+        exports:
+          - name: handleVisualizeCommand
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: ../cli-types.js
+            isExternal: false
+            imports:
+              - ParsedCliArgs
+          - specifier: ../utils/visual-output.js
+            isExternal: false
+            imports:
+              - generateArchitectureDiagram
+              - generateSwarmVisualization
+              - generateFlowDiagram
+              - generateOrchestrationSequence
+              - generateAsciiDashboard
+              - generateSystemSummary
+              - wrapInMarkdownFence
+              - ArchitectureComponent
+              - SwarmAgent
+              - OrchestrationVizData
+          - specifier: ./visualize-summary.js
+            isExternal: false
+            imports:
+              - gatherSystemSummary
+        description: nexus-agents/cli - Visualize Command CLI command for generating visual diagrams and dashboards.
+      - path: cli/visualize-summary.ts
+        lines: 97
+        category: implementation
+        exports:
+          - name: gatherSystemSummary
+            kind: function
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: node:url
+            isExternal: true
+            imports:
+              - fileURLToPath
+          - specifier: ../utils/visual-output.js
+            isExternal: false
+            imports:
+              - SystemSummaryData
+        description: nexus-agents/cli - Visualize Summary Data Gathers live codebase statistics for the system summary dashboard.
       - path: cli/vote-command.test.ts
         lines: 153
         category: test
@@ -30911,11 +33632,11 @@ modules:
           nexus-agents/cli/hooks/handlers - Stop Handler Handles Stop hook events by checking for incomplete tasks
           and optionally generating session summaries.
     stats:
-      fileCount: 162
-      totalLines: 43193
-      exportCount: 1286
-      internalDeps: 413
-      externalDeps: 137
+      fileCount: 192
+      totalLines: 49872
+      exportCount: 1470
+      internalDeps: 469
+      externalDeps: 164
     dependsOn:
       - adapters
       - agents
@@ -36750,7 +39471,7 @@ modules:
           nexus-agents/cli-adapters - Gemini CLI Adapter Helpers Extracted helper functions for model info, retry
           logic, and error handling.
       - path: cli-adapters/adapters/gemini-adapter.test.ts
-        lines: 262
+        lines: 241
         category: test
         exports: []
         dependencies:
@@ -36768,13 +39489,11 @@ modules:
             imports:
               - GeminiCliAdapter
               - createGeminiAdapter
-              - EnhancedGeminiCliAdapter
-              - createEnhancedGeminiAdapter
         description:
           'Tests for Gemini CLI Adapter Verifies Gemini-specific adapter functionality including: - Retry logic and
           circuit breaker integration - Enhanced timeou...'
       - path: cli-adapters/adapters/gemini-adapter.ts
-        lines: 396
+        lines: 370
         category: implementation
         exports:
           - name: createGeminiAdapter
@@ -36788,18 +39507,6 @@ modules:
             isReExport: false
           - name: GeminiExecutionResult
             kind: interface
-            isReExport: false
-          - name: EnhancedGeminiConfig
-            kind: type
-            isReExport: false
-          - name: EnhancedExecutionResult
-            kind: type
-            isReExport: false
-          - name: EnhancedGeminiCliAdapter
-            kind: const
-            isReExport: false
-          - name: createEnhancedGeminiAdapter
-            kind: const
             isReExport: false
         dependencies:
           - specifier: ../../core/index.js
@@ -36855,7 +39562,7 @@ modules:
           'nexus-agents/cli-adapters - Gemini CLI Adapter Subprocess-based adapter for Gemini CLI with: - Tiered
           timeout profiles based on task complexity - Resi...'
       - path: cli-adapters/adapters/index.ts
-        lines: 23
+        lines: 17
         category: index
         exports:
           - name: ClaudeCliAdapter
@@ -36883,22 +39590,6 @@ modules:
             isReExport: true
             sourceModule: ./gemini-adapter.js
           - name: GeminiExecutionResult
-            kind: unknown
-            isReExport: true
-            sourceModule: ./gemini-adapter.js
-          - name: EnhancedGeminiCliAdapter
-            kind: unknown
-            isReExport: true
-            sourceModule: ./gemini-adapter.js
-          - name: createEnhancedGeminiAdapter
-            kind: unknown
-            isReExport: true
-            sourceModule: ./gemini-adapter.js
-          - name: EnhancedGeminiConfig
-            kind: unknown
-            isReExport: true
-            sourceModule: ./gemini-adapter.js
-          - name: EnhancedExecutionResult
             kind: unknown
             isReExport: true
             sourceModule: ./gemini-adapter.js
@@ -38015,8 +40706,8 @@ modules:
         description: Zero Router Stage Adapts ZeroRouter to the IRouterStage interface for pipeline composition.
     stats:
       fileCount: 124
-      totalLines: 36474
-      exportCount: 1118
+      totalLines: 36421
+      exportCount: 1110
       internalDeps: 347
       externalDeps: 60
     dependsOn:
@@ -38510,7 +41201,7 @@ modules:
               - createGetEnvVarDocumentation
         description: Central Configuration Defaults Consolidates common default values used across the codebase.
       - path: config/index.ts
-        lines: 156
+        lines: 190
         category: index
         exports:
           - name: AppConfigSchema
@@ -38641,6 +41332,10 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./schemas.js
+          - name: ExternalPackSourceSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./schemas.js
           - name: DEFAULT_SKILLS_CONFIG
             kind: unknown
             isReExport: true
@@ -38766,6 +41461,10 @@ modules:
             isReExport: true
             sourceModule: ./schemas.js
           - name: SkillLibraryConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./schemas.js
+          - name: ExternalPackSource
             kind: unknown
             isReExport: true
             sourceModule: ./schemas.js
@@ -38977,8 +41676,302 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./defaults.js
+          - name: DEFAULT_MODEL_CAPABILITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: getModelCapabilities
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findModelsByOutputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findModelsByInputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findModelsByToolCapability
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findModelsByFeature
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findModelsByProvider
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: findBestModelForOutput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: modelSupportsAll
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ModelCapabilitiesMatrixSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ModelCapabilitySchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: OUTPUT_MODALITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: INPUT_MODALITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: TOOL_CAPABILITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: SPECIAL_FEATURES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: PROVIDERS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: MODEL_IDS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ModelCapabilitiesMatrix
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ModelCapability
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ModelId
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: OutputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: InputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: ToolCapability
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: SpecialFeature
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
+          - name: Provider
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities.js
         dependencies: []
         description: nexus-agents/config Configuration loading and validation for Nexus Agents
+      - path: config/model-capabilities-types.ts
+        lines: 125
+        category: types
+        exports:
+          - name: OutputModality
+            kind: type
+            isReExport: false
+          - name: InputModality
+            kind: type
+            isReExport: false
+          - name: ToolCapability
+            kind: type
+            isReExport: false
+          - name: SpecialFeature
+            kind: type
+            isReExport: false
+          - name: Provider
+            kind: type
+            isReExport: false
+          - name: ModelId
+            kind: type
+            isReExport: false
+          - name: ModelCapability
+            kind: type
+            isReExport: false
+          - name: ModelCapabilitiesMatrix
+            kind: type
+            isReExport: false
+          - name: OUTPUT_MODALITIES
+            kind: const
+            isReExport: false
+          - name: INPUT_MODALITIES
+            kind: const
+            isReExport: false
+          - name: TOOL_CAPABILITIES
+            kind: const
+            isReExport: false
+          - name: SPECIAL_FEATURES
+            kind: const
+            isReExport: false
+          - name: PROVIDERS
+            kind: const
+            isReExport: false
+          - name: MODEL_IDS
+            kind: const
+            isReExport: false
+          - name: ModelCapabilitySchema
+            kind: const
+            isReExport: false
+          - name: ModelCapabilitiesMatrixSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+        description:
+          nexus-agents/config - Model Capabilities Type Definitions Zod schemas and TypeScript interfaces for the
+          model capabilities matrix.
+      - path: config/model-capabilities.test.ts
+        lines: 255
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+          - specifier: ./model-capabilities.js
+            isExternal: false
+            imports:
+              - DEFAULT_MODEL_CAPABILITIES
+              - getModelCapabilities
+              - findModelsByOutputModality
+              - findModelsByInputModality
+              - findModelsByToolCapability
+              - findModelsByFeature
+              - findModelsByProvider
+              - findBestModelForOutput
+              - modelSupportsAll
+              - ModelCapabilitiesMatrixSchema
+              - MODEL_IDS
+        description: Tests for model capabilities matrix.
+      - path: config/model-capabilities.ts
+        lines: 280
+        category: config
+        exports:
+          - name: getModelCapabilities
+            kind: function
+            isReExport: false
+          - name: findModelsByOutputModality
+            kind: function
+            isReExport: false
+          - name: findModelsByInputModality
+            kind: function
+            isReExport: false
+          - name: findModelsByToolCapability
+            kind: function
+            isReExport: false
+          - name: findModelsByFeature
+            kind: function
+            isReExport: false
+          - name: findModelsByProvider
+            kind: function
+            isReExport: false
+          - name: findBestModelForOutput
+            kind: function
+            isReExport: false
+          - name: modelSupportsAll
+            kind: function
+            isReExport: false
+          - name: DEFAULT_MODEL_CAPABILITIES
+            kind: const
+            isReExport: false
+          - name: ModelCapabilitiesMatrix
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: ModelCapability
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: ModelId
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: OutputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: InputModality
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: ToolCapability
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: SpecialFeature
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: Provider
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: ModelCapabilitySchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: ModelCapabilitiesMatrixSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: OUTPUT_MODALITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: INPUT_MODALITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: TOOL_CAPABILITIES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: SPECIAL_FEATURES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: PROVIDERS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+          - name: MODEL_IDS
+            kind: unknown
+            isReExport: true
+            sourceModule: ./model-capabilities-types.js
+        dependencies:
+          - specifier: ./model-capabilities-types.js
+            isExternal: false
+            imports:
+              - ModelCapabilitiesMatrix
+              - ModelCapability
+              - ModelId
+              - OutputModality
+              - InputModality
+              - ToolCapability
+              - SpecialFeature
+              - Provider
+        description: nexus-agents/config - Model Capabilities Matrix Structured capability definitions for all supported AI models.
       - path: config/routing-config-adapter.test.ts
         lines: 263
         category: test
@@ -39230,7 +42223,7 @@ modules:
           nexus-agents/config - Routing Configuration Schemas Zod schemas for routing configuration exposed via
           nexus-agents.yaml.
       - path: config/schemas-security.ts
-        lines: 129
+        lines: 131
         category: config
         exports:
           - name: PolicyConfig
@@ -39297,11 +42290,17 @@ modules:
               - z
         description: nexus-agents/config - SICA Configuration Schemas Zod schemas for Self-Improving Coding Agent configuration.
       - path: config/schemas-skills.ts
-        lines: 55
+        lines: 72
         category: config
         exports:
+          - name: ExternalPackSource
+            kind: type
+            isReExport: false
           - name: SkillLibraryConfig
             kind: type
+            isReExport: false
+          - name: ExternalPackSourceSchema
+            kind: const
             isReExport: false
           - name: SkillLibraryConfigSchema
             kind: const
@@ -39316,7 +42315,7 @@ modules:
               - z
         description: nexus-agents/config - Skills Configuration Schemas Zod schemas for SkillLibrary configuration.
       - path: config/schemas.ts
-        lines: 178
+        lines: 179
         category: config
         exports:
           - name: AppConfig
@@ -39480,11 +42479,19 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./schemas-skills.js
+          - name: ExternalPackSourceSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./schemas-skills.js
           - name: DEFAULT_SKILLS_CONFIG
             kind: unknown
             isReExport: true
             sourceModule: ./schemas-skills.js
           - name: SkillLibraryConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./schemas-skills.js
+          - name: ExternalPackSource
             kind: unknown
             isReExport: true
             sourceModule: ./schemas-skills.js
@@ -39612,12 +42619,138 @@ modules:
             imports:
               - SicaConfigSchema
         description: nexus-agents/config - Configuration Schemas Aggregation module that re-exports all configuration schemas.
+      - path: config/product-matrix/index.ts
+        lines: 313
+        category: index
+        exports:
+          - name: loadProductMatrix
+            kind: function
+            isReExport: false
+          - name: findProductConfig
+            kind: function
+            isReExport: false
+          - name: getExpertWeightsByProduct
+            kind: function
+            isReExport: false
+          - name: DEFAULT_PRODUCT_MATRIX
+            kind: const
+            isReExport: false
+          - name: PRODUCT_TYPES
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductTypeSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: SkillBundleEntrySchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ExpertWeightSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductConfigSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductMatrixSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductType
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: SkillBundleEntry
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ExpertWeight
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+          - name: ProductMatrix
+            kind: unknown
+            isReExport: true
+            sourceModule: ./types.js
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - readFileSync
+              - existsSync
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - resolve
+          - specifier: yaml
+            isExternal: true
+            imports:
+              - '* as yaml'
+          - specifier: ./types.js
+            isExternal: false
+            imports:
+              - ProductMatrixSchema
+        description:
+          nexus-agents/config - Product Matrix Maps product types to skill bundles and expert weights for intelligent
+          task routing.
+      - path: config/product-matrix/types.ts
+        lines: 109
+        category: config
+        exports:
+          - name: ProductType
+            kind: type
+            isReExport: false
+          - name: SkillBundleEntry
+            kind: type
+            isReExport: false
+          - name: ExpertWeight
+            kind: type
+            isReExport: false
+          - name: ProductConfig
+            kind: type
+            isReExport: false
+          - name: ProductMatrix
+            kind: type
+            isReExport: false
+          - name: PRODUCT_TYPES
+            kind: const
+            isReExport: false
+          - name: ProductTypeSchema
+            kind: const
+            isReExport: false
+          - name: SkillBundleEntrySchema
+            kind: const
+            isReExport: false
+          - name: ExpertWeightSchema
+            kind: const
+            isReExport: false
+          - name: ProductConfigSchema
+            kind: const
+            isReExport: false
+          - name: ProductMatrixSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+        description:
+          nexus-agents/config - Product Matrix Type Definitions Zod schemas and TypeScript interfaces for mapping
+          product types to skill bundles and expert weig...
     stats:
-      fileCount: 21
-      totalLines: 4529
-      exportCount: 329
-      internalDeps: 30
-      externalDeps: 20
+      fileCount: 26
+      totalLines: 5665
+      exportCount: 427
+      internalDeps: 33
+      externalDeps: 26
     dependsOn:
       - cli-adapters
       - context
@@ -39668,6 +42801,106 @@ modules:
         description:
           nexus-agents/consensus - Correlation Helpers Helper functions for correlation tracking and independent
           subset partitioning.
+      - path: consensus/correlation-persistence.test.ts
+        lines: 447
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - beforeEach
+              - afterEach
+              - vi
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: ./correlation-persistence.js
+            isExternal: false
+            imports:
+              - getCorrelationDataPath
+              - saveCorrelationData
+              - loadCorrelationData
+              - createPersistentCorrelationTracker
+              - createPersistedProposal
+              - PersistedCorrelationDataSchema
+          - specifier: ./types-core.js
+            isExternal: false
+            imports:
+              - Vote
+        description: Tests for Correlation Persistence module.
+      - path: consensus/correlation-persistence.ts
+        lines: 402
+        category: implementation
+        exports:
+          - name: getCorrelationDataPath
+            kind: function
+            isReExport: false
+          - name: saveCorrelationData
+            kind: function
+            isReExport: false
+          - name: loadCorrelationData
+            kind: function
+            isReExport: false
+          - name: createPersistentCorrelationTracker
+            kind: function
+            isReExport: false
+          - name: createPersistedProposal
+            kind: function
+            isReExport: false
+          - name: PersistedCorrelationData
+            kind: type
+            isReExport: false
+          - name: PersistedCorrelationDataSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: node:os
+            isExternal: true
+            imports:
+              - '* as os'
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../core/result.js
+            isExternal: false
+            imports:
+              - Result
+          - specifier: ../core/logger.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ./higher-order-types.js
+            isExternal: false
+            imports:
+              - ICorrelationTracker
+              - HigherOrderVotingConfig
+          - specifier: ./types-core.js
+            isExternal: false
+            imports:
+              - Vote
+          - specifier: ./correlation-tracker.js
+            isExternal: false
+            imports:
+              - createCorrelationTracker
+        description: nexus-agents/consensus - Correlation Persistence Disk persistence for CorrelationTracker voting history.
       - path: consensus/correlation-tracker.test.ts
         lines: 280
         category: test
@@ -39799,7 +43032,7 @@ modules:
               - AgentPerformance
         description: nexus-agents/consensus - Unit Tests Tests for consensus engine and voting strategies.
       - path: consensus/engine.ts
-        lines: 493
+        lines: 518
         category: implementation
         exports:
           - name: createConsensusEngine
@@ -40106,7 +43339,7 @@ modules:
           nexus-agents/consensus - Higher-Order Voting Implementation Implements Opinion-Wise (OW) and Independent
           Subset Partition (ISP) voting methods that ac...
       - path: consensus/index.ts
-        lines: 187
+        lines: 199
         category: index
         exports:
           - name: ConsensusAlgorithm
@@ -40577,6 +43810,34 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./correlation-tracker.js
+          - name: PersistedCorrelationData
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: PersistedCorrelationDataSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: getCorrelationDataPath
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: saveCorrelationData
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: loadCorrelationData
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: createPersistentCorrelationTracker
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
+          - name: createPersistedProposal
+            kind: unknown
+            isReExport: true
+            sourceModule: ./correlation-persistence.js
           - name: OWVoting
             kind: unknown
             isReExport: true
@@ -41439,11 +44700,11 @@ modules:
           nexus-agents/consensus - Weighted Byzantine Voting Implementation Implements CP-WBFT (arXiv:2511.10400) for
           weighted Byzantine fault-tolerant voting.
     stats:
-      fileCount: 24
-      totalLines: 8985
-      exportCount: 346
-      internalDeps: 57
-      externalDeps: 9
+      fileCount: 26
+      totalLines: 9871
+      exportCount: 360
+      internalDeps: 64
+      externalDeps: 16
     dependsOn:
       - agents
       - core
@@ -41454,7 +44715,7 @@ modules:
     purpose: Context management, token counting, memory
     files:
       - path: context/adaptive-memory-helpers.ts
-        lines: 345
+        lines: 304
         category: util
         exports:
           - name: calculateRecencyScore
@@ -41469,22 +44730,10 @@ modules:
           - name: calculatePriorityScore
             kind: function
             isReExport: false
-          - name: memoryRowToEntry
-            kind: function
-            isReExport: false
           - name: filterScoredEntries
             kind: function
             isReExport: false
-          - name: getAllMemoryRows
-            kind: function
-            isReExport: false
-          - name: getMemoryRow
-            kind: function
-            isReExport: false
           - name: touchMemory
-            kind: function
-            isReExport: false
-          - name: memoryExists
             kind: function
             isReExport: false
           - name: scoreAndSortEntries
@@ -41532,9 +44781,6 @@ modules:
             isExternal: false
             imports:
               - memoryRowToEntry
-              - memoryExists
-              - getMemoryRow
-              - getAllMemoryRows
         description:
           Adaptive Memory Helpers Helper functions for adaptive memory scoring including recency decay, importance
           weighting, and relevance calculation.
@@ -41807,7 +45053,7 @@ modules:
           Tests for Agentic Memory Database Helpers Tests database-related helper functions for A-MEM attribute
           storage and retrieval.
       - path: context/agentic-memory-db-helpers.ts
-        lines: 146
+        lines: 145
         category: util
         exports:
           - name: parseAmemAttributes
@@ -41851,15 +45097,9 @@ modules:
               - extractAttributes
         description: Agentic Memory Database Helpers Database-related helper functions for A-MEM attribute storage and retrieval.
       - path: context/agentic-memory-extraction.ts
-        lines: 196
+        lines: 188
         category: implementation
         exports:
-          - name: tokenize
-            kind: function
-            isReExport: false
-          - name: tokenizeFiltered
-            kind: function
-            isReExport: false
           - name: extractKeywords
             kind: function
             isReExport: false
@@ -41873,6 +45113,9 @@ modules:
             kind: function
             isReExport: false
           - name: extractAttributes
+            kind: function
+            isReExport: false
+          - name: mergeExtractionConfig
             kind: function
             isReExport: false
         dependencies:
@@ -41890,108 +45133,11 @@ modules:
           - specifier: ../utils/text-utils.js
             isExternal: false
             imports:
-              - tokenize
               - tokenizeFiltered
               - stringifyValue
-        description: Agentic Memory Extraction Helpers Attribute extraction functions for A-MEM.
-      - path: context/agentic-memory-helpers.ts
-        lines: 81
-        category: util
-        exports:
-          - name: mergeExtractionConfig
-            kind: function
-            isReExport: false
-          - name: mergeLinkingConfig
-            kind: function
-            isReExport: false
-          - name: calculateKeywordSimilarity
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: calculateEntitySimilarity
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: calculateOverallSimilarity
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: inferRelationType
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: generateLinkSuggestions
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: detectEvolutionPair
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: detectEvolution
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-linking.js
-          - name: parseAmemAttributes
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: memoryRowToAgenticEntry
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: searchWithAttributes
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: getAttributeSet
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: getAttributesFromRow
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: findMatchingMemories
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-db-helpers.js
-          - name: tokenize
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: tokenizeFiltered
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: extractKeywords
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: extractSemanticTags
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: extractEntities
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: generateContextDescription
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-          - name: extractAttributes
-            kind: unknown
-            isReExport: true
-            sourceModule: ./agentic-memory-extraction.js
-        dependencies:
-          - specifier: ./agentic-memory-types.js
-            isExternal: false
-            imports:
-              - ExtractionConfig
-        description: Agentic Memory Helpers Helper functions for A-MEM attribute extraction.
+        description: Agentic Memory Extraction Helpers Rule-based attribute extraction for A-MEM agentic memory.
       - path: context/agentic-memory-linking.ts
-        lines: 278
+        lines: 296
         category: implementation
         exports:
           - name: calculateKeywordSimilarity
@@ -42013,6 +45159,9 @@ modules:
             kind: function
             isReExport: false
           - name: detectEvolution
+            kind: function
+            isReExport: false
+          - name: mergeLinkingConfig
             kind: function
             isReExport: false
         dependencies:
@@ -42132,7 +45281,7 @@ modules:
               - ExtractionConfig
               - AgenticMemoryEntry
               - LinkSuggestion
-          - specifier: ./agentic-memory-helpers.js
+          - specifier: ./agentic-memory-db-helpers.js
             isExternal: false
             imports:
               - getAttributesFromRow
@@ -42309,7 +45458,7 @@ modules:
           Agentic Memory Types Type definitions for A-MEM agentic memory with Zettelkasten-style dynamic linking,
           attribute extraction, and memory evolution.
       - path: context/agentic-memory.test.ts
-        lines: 670
+        lines: 672
         category: test
         exports: []
         dependencies:
@@ -42328,19 +45477,22 @@ modules:
               - createAgenticMemory
               - DEFAULT_EXTRACTION_CONFIG
               - DEFAULT_LINKING_CONFIG
-          - specifier: ./agentic-memory-helpers.js
+          - specifier: ./agentic-memory-extraction.js
             isExternal: false
             imports:
               - extractKeywords
               - extractSemanticTags
               - extractEntities
               - generateContextDescription
+              - mergeExtractionConfig
+          - specifier: ./agentic-memory-linking.js
+            isExternal: false
+            imports:
               - calculateKeywordSimilarity
               - calculateEntitySimilarity
               - calculateOverallSimilarity
               - generateLinkSuggestions
               - detectEvolution
-              - mergeExtractionConfig
               - mergeLinkingConfig
           - specifier: ../utils/text-utils.js
             isExternal: false
@@ -42360,7 +45512,7 @@ modules:
               - EntityReference
         description: Tests for Agentic Memory Backend (A-MEM).
       - path: context/agentic-memory.ts
-        lines: 393
+        lines: 394
         category: implementation
         exports:
           - name: createAgenticMemory
@@ -42473,14 +45625,20 @@ modules:
               - LinkingOptions
               - LinkSuggestion
               - EvolutionResult
-          - specifier: ./agentic-memory-helpers.js
+          - specifier: ./agentic-memory-extraction.js
             isExternal: false
             imports:
               - extractAttributes
+              - mergeExtractionConfig
+          - specifier: ./agentic-memory-linking.js
+            isExternal: false
+            imports:
               - generateLinkSuggestions
               - detectEvolution
-              - mergeExtractionConfig
               - mergeLinkingConfig
+          - specifier: ./agentic-memory-db-helpers.js
+            isExternal: false
+            imports:
               - searchWithAttributes
               - getAttributeSet
               - findMatchingMemories
@@ -42616,12 +45774,9 @@ modules:
               - generateId
         description: nexus-agents/context - Hindsight Belief Memory Audit Counterfactual reasoning, audit, and statistics methods.
       - path: context/belief-memory-helpers.ts
-        lines: 203
+        lines: 191
         category: util
         exports:
-          - name: generateId
-            kind: function
-            isReExport: false
           - name: compareConfidence
             kind: function
             isReExport: false
@@ -43146,13 +46301,10 @@ modules:
         dependencies: []
         description: Type declaration for better-sqlite3 module.
       - path: context/graph-memory-helpers.ts
-        lines: 306
+        lines: 274
         category: util
         exports:
           - name: rowToEdge
-            kind: function
-            isReExport: false
-          - name: memoryRowToEntry
             kind: function
             isReExport: false
           - name: resolveTraversalOptions
@@ -43171,12 +46323,6 @@ modules:
             kind: function
             isReExport: false
           - name: findShortestPath
-            kind: function
-            isReExport: false
-          - name: getMemoryEntry
-            kind: function
-            isReExport: false
-          - name: memoryExists
             kind: function
             isReExport: false
           - name: ResolvedTraversalOptions
@@ -43210,13 +46356,10 @@ modules:
             isExternal: false
             imports:
               - MemoryEntry
-              - MemoryRow
               - ISQLiteDatabase
           - specifier: ../utils/memory-db-utils.js
             isExternal: false
             imports:
-              - memoryRowToEntry
-              - memoryExists
               - getMemoryEntry
         description:
           Graph Memory Helpers Helper functions for graph memory operations including SQL queries and traversal
@@ -43405,7 +46548,7 @@ modules:
               - memoryExists
         description: Graph-Based Memory Backend Implements graph-structured memory with entity relationships.
       - path: context/index.ts
-        lines: 218
+        lines: 233
         category: index
         exports:
           - name: TokenCounter
@@ -43904,6 +47047,50 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./agentic-memory.js
+          - name: HindsightBeliefMemory
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-memory.js
+          - name: BeliefConfidence
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-core-types.js
+          - name: BeliefSourceType
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-core-types.js
+          - name: Belief
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: BeliefMemoryConfig
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: BeliefMemoryStats
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: BeliefQuery
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: BeliefUpdate
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: Counterfactual
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: HindsightRecord
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
+          - name: IHindsightBeliefMemory
+            kind: unknown
+            isReExport: true
+            sourceModule: ./belief-types.js
           - name: MobiMem
             kind: unknown
             isReExport: true
@@ -44568,7 +47755,7 @@ modules:
           'Memory System Integration Tests Comprehensive integration tests for: - Hindsight Belief Memory advanced
           scenarios - Cross-memory-system interactions -...'
       - path: context/memory-types.ts
-        lines: 249
+        lines: 255
         category: types
         exports:
           - name: TypedMemoryEntry
@@ -45123,7 +48310,7 @@ modules:
           nexus-agents/context - Routing Memory Bridge Bridges MobiMem's three modules (Profile, Experience, Action)
           with the model routing system to enable lea...
       - path: context/session-memory-types.ts
-        lines: 161
+        lines: 173
         category: types
         exports:
           - name: SessionMemoryError
@@ -45170,7 +48357,7 @@ modules:
               - ILogger
         description: Session Memory Types and Schemas Type definitions for cross-session episodic memory persistence.
       - path: context/session-memory.test.ts
-        lines: 478
+        lines: 584
         category: test
         exports: []
         dependencies:
@@ -45205,7 +48392,7 @@ modules:
               - ResolvedError
         description: Tests for Session Memory Manager.
       - path: context/session-memory.ts
-        lines: 396
+        lines: 372
         category: implementation
         exports:
           - name: createSessionMemory
@@ -45283,7 +48470,7 @@ modules:
               - ResolvedError
               - SessionEpisode
               - SessionMemoryConfig
-        description: nexus-agents/context - Session Memory Manager Cross-session episodic memory persistence using YAML files.
+        description: Cross-session episodic memory persistence with FIFO eviction bounds.
       - path: context/token-budget-helpers.ts
         lines: 243
         category: util
@@ -46002,10 +49189,10 @@ modules:
           nexus-agents/context - Work Balancer Automatic work balancing that assigns tasks based on capability
           matching AND available capacity using a weighted...
     stats:
-      fileCount: 68
-      totalLines: 23650
-      exportCount: 715
-      internalDeps: 227
+      fileCount: 67
+      totalLines: 23611
+      exportCount: 696
+      internalDeps: 229
       externalDeps: 50
     dependsOn:
       - cli-adapters
@@ -47051,7 +50238,7 @@ modules:
         dependencies: []
         description: Injectable Random Provider Provides a deterministic interface for random number generation.
       - path: core/result.ts
-        lines: 127
+        lines: 150
         category: implementation
         exports:
           - name: ok
@@ -48140,8 +51327,26 @@ modules:
         description:
           nexus-agents/core/task-analysis - Task Analysis Module Provides task classification and analysis utilities
           used by routing and protocol selection laye...
+      - path: core/task-analysis/product-type-detector.ts
+        lines: 78
+        category: implementation
+        exports:
+          - name: detectProductType
+            kind: function
+            isReExport: false
+          - name: ProductTypeDetection
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: ../../config/product-matrix/types.js
+            isExternal: false
+            imports:
+              - ProductType
+        description:
+          Product Type Detector Detects product type from task content using keyword matching against the 8-type
+          product matrix taxonomy.
       - path: core/task-analysis/shared-task-analyzer.ts
-        lines: 530
+        lines: 384
         category: implementation
         exports:
           - name: createSharedTaskAnalyzer
@@ -48181,11 +51386,63 @@ modules:
             isExternal: false
             imports:
               - Task
+          - specifier: ../../config/product-matrix/types.js
+            isExternal: false
+            imports:
+              - ProductType
+          - specifier: ./product-type-detector.js
+            isExternal: false
+            imports:
+              - detectProductType
+          - specifier: ./task-analysis-keywords.js
+            isExternal: false
+            imports:
+              - REASONING_PATTERNS
+              - KNOWLEDGE_PATTERNS
+              - TASK_TYPE_KEYWORDS
+              - HIGH_COMPLEXITY_KEYWORDS
+              - CODE_GEN_KEYWORDS
+              - MULTIMODAL_KEYWORDS
+              - PARALLEL_KEYWORDS
         description:
           'Shared Task Analyzer Unified task analysis providing multiple classification views: - ReasoningKnowledge:
           reasoning vs knowledge tasks (arXiv:2502.191...'
+      - path: core/task-analysis/task-analysis-keywords.ts
+        lines: 189
+        category: implementation
+        exports:
+          - name: WeightedPattern
+            kind: interface
+            isReExport: false
+          - name: REASONING_PATTERNS
+            kind: const
+            isReExport: false
+          - name: KNOWLEDGE_PATTERNS
+            kind: const
+            isReExport: false
+          - name: TASK_TYPE_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: HIGH_COMPLEXITY_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: CODE_GEN_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: MULTIMODAL_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: PARALLEL_KEYWORDS
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: ./shared-task-analyzer.js
+            isExternal: false
+            imports:
+              - TaskTypeCategory
+        description: Task Analysis Keyword Registries Centralized keyword/pattern data for task classification.
       - path: core/task-analysis/task-profile-adapter.ts
-        lines: 412
+        lines: 425
         category: implementation
         exports:
           - name: taskAnalysisResultToTaskProfile
@@ -48222,6 +51479,10 @@ modules:
               - TaskAnalysisResult
               - TaskTypeCategory
               - ComplexityLevel
+          - specifier: ../../config/product-matrix/types.js
+            isExternal: false
+            imports:
+              - ProductType
           - specifier: ../../utils/math-utils.js
             isExternal: false
             imports:
@@ -48264,7 +51525,7 @@ modules:
           Task Type Classifier Classifies tasks as "reasoning" or "knowledge" type to enable optimal protocol
           selection and routing decisions.
       - path: core/types/agent.ts
-        lines: 248
+        lines: 249
         category: implementation
         exports:
           - name: TaskContext
@@ -48851,14 +52112,15 @@ modules:
               - AgentRole
         description: nexus-agents/core - Workflow Types Interface for workflow execution engine.
     stats:
-      fileCount: 45
-      totalLines: 12957
-      exportCount: 587
-      internalDeps: 60
+      fileCount: 47
+      totalLines: 13115
+      exportCount: 597
+      internalDeps: 66
       externalDeps: 20
     dependsOn:
       - cli
       - cli-adapters
+      - config
       - utils
   dogfooding:
     name: dogfooding
@@ -56307,7 +59569,7 @@ modules:
               - TraceId
         description: 'nexus-agents/learning - FeedbackIntegration Tests (Source: Issue #167, Epic #164)'
       - path: learning/feedback-integration.ts
-        lines: 454
+        lines: 505
         category: implementation
         exports:
           - name: createFeedbackIntegration
@@ -56366,6 +59628,10 @@ modules:
             imports:
               - CompositeRoutingDecision
               - ICompositeRouter
+          - specifier: ../core/task-analysis/task-profile-adapter.js
+            isExternal: false
+            imports:
+              - TaskProfile
           - specifier: ../observability/swarm-observer-types.js
             isExternal: false
             imports:
@@ -57230,9 +60496,9 @@ modules:
         description: Tests for SQLite Outcome Storage.
     stats:
       fileCount: 19
-      totalLines: 5805
+      totalLines: 5856
       exportCount: 165
-      internalDeps: 63
+      internalDeps: 64
       externalDeps: 9
     dependsOn:
       - cli-adapters
@@ -57388,7 +60654,7 @@ modules:
           EventBus to MCP Server Bridge Bridges EventBus events to SwarmObserver for observability in Claude Desktop
           context.
       - path: mcp/index.ts
-        lines: 207
+        lines: 239
         category: index
         exports:
           - name: createServer
@@ -57820,6 +61086,130 @@ modules:
             isReExport: true
             sourceModule: ./tools/index.js
           - name: WorkflowInfo
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: registerResearchQueryTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchQueryInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchQueryInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchQueryDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchQueryResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: registerResearchAddTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAddInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAddInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAddDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAddResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: registerResearchDiscoverTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchDiscoverInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchDiscoverInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchDiscoverDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchDiscoverResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: DiscoveredItem
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: DiscoverySource
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: registerResearchAnalyzeTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAnalyzeInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAnalyzeInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAnalyzeDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAnalyzeResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: AnalysisFocus
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: registerResearchCatalogReviewTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchCatalogReviewInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchCatalogReviewInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchCatalogReviewDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchCatalogReviewResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: ResearchAutoCatalog
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: getAutoCatalog
+            kind: unknown
+            isReExport: true
+            sourceModule: ./tools/index.js
+          - name: CatalogedReference
             kind: unknown
             isReExport: true
             sourceModule: ./tools/index.js
@@ -59078,9 +62468,12 @@ modules:
               - SecurityConfig
         description: nexus-agents/mcp - Tool Wrapper Tests Tests for the tool wrapper helper functions.
       - path: mcp/middleware/tool-wrapper.ts
-        lines: 188
+        lines: 232
         category: implementation
         exports:
+          - name: getToolTimeout
+            kind: function
+            isReExport: false
           - name: createToolFactory
             kind: function
             isReExport: false
@@ -59097,6 +62490,9 @@ modules:
             kind: interface
             isReExport: false
           - name: DEFAULT_TIMEOUT_CONFIG
+            kind: const
+            isReExport: false
+          - name: DEFAULT_TOOL_TIMEOUTS
             kind: const
             isReExport: false
           - name: createMiddlewareFactory
@@ -60078,6 +63474,64 @@ modules:
             imports:
               - ToolCategory
         description: nexus-agents/mcp/safety - Trigger Patterns Pre-defined trigger patterns for unsafe control action detection.
+      - path: mcp/tools/consensus-vote-types.ts
+        lines: 190
+        category: types
+        exports:
+          - name: toAgentVoteSummary
+            kind: function
+            isReExport: false
+          - name: mapOutcomeToDecision
+            kind: function
+            isReExport: false
+          - name: buildResponse
+            kind: function
+            isReExport: false
+          - name: AgentVoteSummary
+            kind: interface
+            isReExport: false
+          - name: HigherOrderMetadata
+            kind: interface
+            isReExport: false
+          - name: ConsensusVoteResponse
+            kind: interface
+            isReExport: false
+          - name: ExtendedVotingResult
+            kind: interface
+            isReExport: false
+          - name: VotingStrategy
+            kind: type
+            isReExport: false
+          - name: ConsensusVoteInput
+            kind: type
+            isReExport: false
+          - name: VoteDecisionStatus
+            kind: type
+            isReExport: false
+          - name: MAX_PROPOSAL_LENGTH
+            kind: const
+            isReExport: false
+          - name: VotingStrategySchema
+            kind: const
+            isReExport: false
+          - name: ConsensusVoteInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../../cli/vote-types.js
+            isExternal: false
+            imports:
+              - AgentVoteResult
+              - VotingResult
+          - specifier: ../../consensus/higher-order-types.js
+            isExternal: false
+            imports:
+              - HigherOrderVotingResult
+        description: Types, schemas, and response helpers for the consensus_vote MCP tool.
       - path: mcp/tools/consensus-vote.test.ts
         lines: 522
         category: test
@@ -60107,7 +63561,7 @@ modules:
               - ConsensusVoteResponse
         description: 'nexus-agents/mcp - Consensus Vote Tool Tests (Source: Issue #500 - Add missing MCP tool test files)'
       - path: mcp/tools/consensus-vote.ts
-        lines: 586
+        lines: 329
         category: implementation
         exports:
           - name: resetCorrelationTracker
@@ -60119,30 +63573,42 @@ modules:
           - name: ConsensusVoteDeps
             kind: interface
             isReExport: false
-          - name: AgentVoteSummary
-            kind: interface
-            isReExport: false
-          - name: HigherOrderMetadata
-            kind: interface
-            isReExport: false
-          - name: ConsensusVoteResponse
-            kind: interface
-            isReExport: false
           - name: VotingStrategy
-            kind: type
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
           - name: ConsensusVoteInput
-            kind: type
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
+          - name: ConsensusVoteResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
+          - name: AgentVoteSummary
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
           - name: VoteDecisionStatus
-            kind: type
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
+          - name: HigherOrderMetadata
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
+          - name: ExtendedVotingResult
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
           - name: VotingStrategySchema
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
           - name: ConsensusVoteInputSchema
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./consensus-vote-types.js
         dependencies:
           - specifier: zod
             isExternal: true
@@ -60169,6 +63635,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -60180,11 +63647,11 @@ modules:
               - ConsensusAlgorithm
               - Vote
               - ConsensusResult
+              - Proposal
           - specifier: ../../cli/vote-types.js
             isExternal: false
             imports:
               - VoterRole
-              - VotingResult
               - AgentVoteResult
           - specifier: ../../cli/voter-agents.js
             isExternal: false
@@ -60203,10 +63670,22 @@ modules:
             isExternal: false
             imports:
               - HigherOrderVotingStrategy
-              - createCorrelationTracker
+          - specifier: ../../consensus/correlation-persistence.js
+            isExternal: false
+            imports:
+              - createPersistentCorrelationTracker
+              - createPersistedProposal
+              - saveCorrelationData
+          - specifier: ./consensus-vote-types.js
+            isExternal: false
+            imports:
+              - MAX_PROPOSAL_LENGTH
+              - VotingStrategySchema
+              - ConsensusVoteInputSchema
+              - buildResponse
         description: nexus-agents/mcp - Consensus Vote Tool MCP tool for multi-model consensus voting on proposals.
       - path: mcp/tools/create-expert.test.ts
-        lines: 412
+        lines: 414
         category: test
         exports: []
         dependencies:
@@ -60241,7 +63720,7 @@ modules:
               - getCapabilitiesForRole
         description: nexus-agents/mcp - Create Expert Tool Tests
       - path: mcp/tools/create-expert.ts
-        lines: 322
+        lines: 353
         category: implementation
         exports:
           - name: registerCreateExpertTool
@@ -60298,6 +63777,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -60312,7 +63792,7 @@ modules:
               - BUILT_IN_EXPERTS
         description: nexus-agents/mcp - Create Expert Tool MCP tool for creating expert agents dynamically.
       - path: mcp/tools/delegate-to-model-helpers.ts
-        lines: 234
+        lines: 292
         category: util
         exports:
           - name: hasKeyword
@@ -60337,6 +63817,9 @@ modules:
             kind: function
             isReExport: false
           - name: getTradeoff
+            kind: function
+            isReExport: false
+          - name: filterByModality
             kind: function
             isReExport: false
           - name: scoreAllModels
@@ -60372,6 +63855,11 @@ modules:
               - TaskRequirements
               - ScoredModel
               - ToolResult
+          - specifier: ../../config/model-capabilities.js
+            isExternal: false
+            imports:
+              - DEFAULT_MODEL_CAPABILITIES
+              - modelSupportsAll
         description: nexus-agents/mcp - Delegate to Model Helpers Helper functions for task analysis and model selection.
       - path: mcp/tools/delegate-to-model-router.ts
         lines: 96
@@ -60407,7 +63895,7 @@ modules:
               - DelegateOutput
         description: nexus-agents/mcp - Delegate to Model Router Integration CompositeRouter integration for delegate_to_model tool.
       - path: mcp/tools/delegate-to-model-types.ts
-        lines: 240
+        lines: 274
         category: types
         exports:
           - name: CapabilityProfile
@@ -60458,6 +63946,15 @@ modules:
           - name: COST_KEYWORDS
             kind: const
             isReExport: false
+          - name: IMAGE_GEN_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: AUDIO_OUTPUT_KEYWORDS
+            kind: const
+            isReExport: false
+          - name: MCP_KEYWORDS
+            kind: const
+            isReExport: false
           - name: TOOL_SCHEMA
             kind: const
             isReExport: false
@@ -60485,7 +63982,7 @@ modules:
               - IFeedbackIntegration
         description: nexus-agents/mcp - Delegate to Model Types Type definitions, schemas, and constants for model routing.
       - path: mcp/tools/delegate-to-model.test.ts
-        lines: 610
+        lines: 628
         category: test
         exports: []
         dependencies:
@@ -60523,7 +64020,7 @@ modules:
               - DelegateOutput
         description: nexus-agents/mcp - Delegate to Model Tool Tests Tests for the delegate_to_model MCP tool.
       - path: mcp/tools/delegate-to-model.ts
-        lines: 163
+        lines: 162
         category: implementation
         exports:
           - name: registerDelegateToModelTool
@@ -60595,6 +64092,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -60652,7 +64150,7 @@ modules:
               - ExecuteExpertDeps
         description: 'nexus-agents/mcp - Execute Expert Tool Tests (Source: Issue #500 - Add missing MCP tool test files)'
       - path: mcp/tools/execute-expert.ts
-        lines: 285
+        lines: 389
         category: implementation
         exports:
           - name: registerExecuteExpertTool
@@ -60697,6 +64195,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -60706,9 +64205,17 @@ modules:
             isExternal: false
             imports:
               - Expert
+          - specifier: ./tool-memory.js
+            isExternal: false
+            imports:
+              - getToolMemory
+          - specifier: ./research-auto-catalog.js
+            isExternal: false
+            imports:
+              - getAutoCatalog
         description: nexus-agents/mcp - Execute Expert Tool MCP tool for executing tasks with previously created expert agents.
       - path: mcp/tools/index.ts
-        lines: 237
+        lines: 304
         category: index
         exports:
           - name: registerTools
@@ -60968,6 +64475,130 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./consensus-vote.js
+          - name: registerResearchQueryTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-query.js
+          - name: ResearchQueryInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-query.js
+          - name: ResearchQueryInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-query.js
+          - name: ResearchQueryDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-query.js
+          - name: ResearchQueryResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-query.js
+          - name: registerResearchAddTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-add.js
+          - name: ResearchAddInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-add.js
+          - name: ResearchAddInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-add.js
+          - name: ResearchAddDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-add.js
+          - name: ResearchAddResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-add.js
+          - name: registerResearchDiscoverTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: ResearchDiscoverInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: ResearchDiscoverInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: ResearchDiscoverDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: ResearchDiscoverResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: DiscoveredItem
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: DiscoverySource
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-discover.js
+          - name: registerResearchAnalyzeTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: ResearchAnalyzeInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: ResearchAnalyzeInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: ResearchAnalyzeDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: ResearchAnalyzeResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: AnalysisFocus
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-analyze.js
+          - name: registerResearchCatalogReviewTool
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-catalog-review.js
+          - name: ResearchCatalogReviewInputSchema
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-catalog-review.js
+          - name: ResearchCatalogReviewInput
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-catalog-review.js
+          - name: ResearchCatalogReviewDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-catalog-review.js
+          - name: ResearchCatalogReviewResponse
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-catalog-review.js
+          - name: ResearchAutoCatalog
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-auto-catalog.js
+          - name: getAutoCatalog
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-auto-catalog.js
+          - name: CatalogedReference
+            kind: unknown
+            isReExport: true
+            sourceModule: ./research-auto-catalog.js
         dependencies:
           - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
             isExternal: true
@@ -61011,7 +64642,7 @@ modules:
               - RateLimiter
         description: Tests for list_experts MCP tool.
       - path: mcp/tools/list-experts.ts
-        lines: 219
+        lines: 216
         category: implementation
         exports:
           - name: registerListExpertsTool
@@ -61058,6 +64689,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -61217,6 +64849,83 @@ modules:
         description:
           nexus-agents/mcp - SICA Integration for Orchestrate Tool Wraps TechLead with SICA self-improvement
           capabilities when enabled.
+      - path: mcp/tools/orchestrate-types.ts
+        lines: 197
+        category: types
+        exports:
+          - name: createMockTechLead
+            kind: function
+            isReExport: false
+          - name: createMockOrchestrator
+            kind: function
+            isReExport: false
+          - name: OrchestrationError
+            kind: class
+            isReExport: false
+          - name: OrchestrationUnavailableError
+            kind: class
+            isReExport: false
+          - name: ITechLead
+            kind: interface
+            isReExport: false
+          - name: IExpertFactory
+            kind: interface
+            isReExport: false
+          - name: OrchestrateDeps
+            kind: interface
+            isReExport: false
+          - name: OrchestrateInput
+            kind: type
+            isReExport: false
+          - name: OrchestrateOutput
+            kind: type
+            isReExport: false
+          - name: OrchestrateInputSchema
+            kind: const
+            isReExport: false
+          - name: OrchestrateOutputSchema
+            kind: const
+            isReExport: false
+          - name: ORCHESTRATE_TOOL_SCHEMA
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - Result
+              - ILogger
+              - Task
+          - specifier: ../../utils/math-utils.js
+            isExternal: false
+            imports:
+              - clamp
+          - specifier: ../../core/types/orchestrator.js
+            isExternal: false
+            imports:
+              - IOrchestrator
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../../agents/index.js
+            isExternal: false
+            imports:
+              - ExecutionPlan
+              - Expert
+          - specifier: ../../orchestration/orchestrator-factory.js
+            isExternal: false
+            imports:
+              - OrchestratorFactory
+        description: Types, schemas, and test helpers for the orchestrate MCP tool.
       - path: mcp/tools/orchestrate.test.ts
         lines: 678
         category: test
@@ -61254,50 +64963,57 @@ modules:
               - OrchestrateInput
         description: nexus-agents/mcp - Orchestrate Tool Tests
       - path: mcp/tools/orchestrate.ts
-        lines: 462
+        lines: 329
         category: implementation
         exports:
           - name: registerOrchestrateTool
             kind: function
             isReExport: false
-          - name: createMockTechLead
-            kind: function
-            isReExport: false
-          - name: createMockOrchestrator
-            kind: function
-            isReExport: false
-          - name: OrchestrationError
-            kind: class
-            isReExport: false
-          - name: OrchestrationUnavailableError
-            kind: class
-            isReExport: false
-          - name: ITechLead
-            kind: interface
-            isReExport: false
-          - name: IExpertFactory
-            kind: interface
-            isReExport: false
-          - name: OrchestrateDeps
-            kind: interface
-            isReExport: false
           - name: OrchestrateInput
-            kind: type
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
           - name: OrchestrateOutput
-            kind: type
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: OrchestrateDeps
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: ITechLead
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: IExpertFactory
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
           - name: OrchestrateInputSchema
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
           - name: OrchestrateOutputSchema
-            kind: const
-            isReExport: false
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: OrchestrationError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: OrchestrationUnavailableError
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: createMockOrchestrator
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
+          - name: createMockTechLead
+            kind: unknown
+            isReExport: true
+            sourceModule: ./orchestrate-types.js
         dependencies:
-          - specifier: zod
-            isExternal: true
-            imports:
-              - z
           - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
             isExternal: true
             imports:
@@ -61309,23 +65025,11 @@ modules:
               - ILogger
               - Task
               - TaskContext
-          - specifier: ../../utils/math-utils.js
-            isExternal: false
-            imports:
-              - clamp
           - specifier: ../../core/types/orchestrator.js
             isExternal: false
             imports:
               - IOrchestrator
               - OrchestratorDefinition
-          - specifier: ../middleware/rate-limiter.js
-            isExternal: false
-            imports:
-              - RateLimiter
-          - specifier: ../../config/schemas.js
-            isExternal: false
-            imports:
-              - SecurityConfig
           - specifier: ../middleware/tool-wrapper.js
             isExternal: false
             imports:
@@ -61340,7 +65044,6 @@ modules:
             isExternal: false
             imports:
               - ExecutionPlan
-              - Expert
           - specifier: ./orchestrate-sica.js
             isExternal: false
             imports:
@@ -61349,7 +65052,591 @@ modules:
             isExternal: false
             imports:
               - OrchestratorFactory
+          - specifier: ./tool-memory.js
+            isExternal: false
+            imports:
+              - getToolMemory
+          - specifier: ./research-auto-catalog.js
+            isExternal: false
+            imports:
+              - getAutoCatalog
+          - specifier: ./orchestrate-types.js
+            isExternal: false
+            imports:
+              - OrchestrateInputSchema
+              - ORCHESTRATE_TOOL_SCHEMA
+              - OrchestrationError
         description: nexus-agents/mcp - Orchestrate Tool MCP tool for task orchestration using TechLead agent.
+      - path: mcp/tools/research-add.test.ts
+        lines: 137
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./research-add.js
+            isExternal: false
+            imports:
+              - registerResearchAddTool
+              - ResearchAddInputSchema
+              - ResearchAddDeps
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+        description: Tests for research_add MCP tool.
+      - path: mcp/tools/research-add.ts
+        lines: 229
+        category: implementation
+        exports:
+          - name: registerResearchAddTool
+            kind: function
+            isReExport: false
+          - name: ResearchAddDeps
+            kind: interface
+            isReExport: false
+          - name: ResearchAddResponse
+            kind: interface
+            isReExport: false
+          - name: ResearchAddInput
+            kind: type
+            isReExport: false
+          - name: ResearchAddInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
+            isExternal: true
+            imports:
+              - McpServer
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../middleware/tool-wrapper.js
+            isExternal: false
+            imports:
+              - wrapToolWithTimeout
+              - toSdkCallback
+              - getToolTimeout
+          - specifier: ../middleware/secure-handler.js
+            isExternal: false
+            imports:
+              - createSecureHandler
+              - HandlerContext
+          - specifier: ../../cli/research-helpers.js
+            isExternal: false
+            imports:
+              - addResearchPaper
+              - paperExists
+          - specifier: ./tool-memory.js
+            isExternal: false
+            imports:
+              - getToolMemory
+        description: nexus-agents/mcp - Research Add Tool MCP tool for adding papers to the research registry.
+      - path: mcp/tools/research-analyze.test.ts
+        lines: 149
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./research-analyze.js
+            isExternal: false
+            imports:
+              - registerResearchAnalyzeTool
+              - ResearchAnalyzeInputSchema
+              - ResearchAnalyzeDeps
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+        description: Tests for research_analyze MCP tool.
+      - path: mcp/tools/research-analyze.ts
+        lines: 434
+        category: implementation
+        exports:
+          - name: registerResearchAnalyzeTool
+            kind: function
+            isReExport: false
+          - name: ResearchAnalyzeDeps
+            kind: interface
+            isReExport: false
+          - name: ResearchAnalyzeResponse
+            kind: interface
+            isReExport: false
+          - name: AnalysisFocus
+            kind: type
+            isReExport: false
+          - name: ResearchAnalyzeInput
+            kind: type
+            isReExport: false
+          - name: ResearchAnalyzeInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
+            isExternal: true
+            imports:
+              - McpServer
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../middleware/tool-wrapper.js
+            isExternal: false
+            imports:
+              - wrapToolWithTimeout
+              - toSdkCallback
+              - getToolTimeout
+          - specifier: ../middleware/secure-handler.js
+            isExternal: false
+            imports:
+              - createSecureHandler
+              - HandlerContext
+          - specifier: ../../cli/research-helpers.js
+            isExternal: false
+            imports:
+              - loadTechniquesRegistry
+              - loadPapersRegistry
+        description:
+          nexus-agents/mcp - Research Analyze Tool MCP tool for analyzing the research registry for gaps, trends,
+          priorities, stale entries, and coverage.
+      - path: mcp/tools/research-auto-catalog-persistence.test.ts
+        lines: 307
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - beforeEach
+              - afterEach
+              - vi
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: ./research-auto-catalog.js
+            isExternal: false
+            imports:
+              - ResearchAutoCatalog
+              - resetAutoCatalog
+              - CatalogedReference
+        description: Tests for ResearchAutoCatalog persistence behavior.
+      - path: mcp/tools/research-auto-catalog.test.ts
+        lines: 285
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: ./research-auto-catalog.js
+            isExternal: false
+            imports:
+              - ResearchAutoCatalog
+              - resetAutoCatalog
+              - getAutoCatalog
+        description: Tests for research auto-catalog module.
+      - path: mcp/tools/research-auto-catalog.ts
+        lines: 349
+        category: implementation
+        exports:
+          - name: getAutoCatalog
+            kind: function
+            isReExport: false
+          - name: resetAutoCatalog
+            kind: function
+            isReExport: false
+          - name: ResearchAutoCatalog
+            kind: class
+            isReExport: false
+          - name: CatalogedReference
+            kind: interface
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: node:os
+            isExternal: true
+            imports:
+              - '* as os'
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ./tool-memory.js
+            isExternal: false
+            imports:
+              - getToolMemory
+        description:
+          nexus-agents/mcp - Research Auto-Catalog Automatically records research references found during normal tool
+          execution.
+      - path: mcp/tools/research-catalog-review.test.ts
+        lines: 160
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./research-catalog-review.js
+            isExternal: false
+            imports:
+              - registerResearchCatalogReviewTool
+              - ResearchCatalogReviewInputSchema
+              - ResearchCatalogReviewDeps
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+        description: Tests for research_catalog_review MCP tool.
+      - path: mcp/tools/research-catalog-review.ts
+        lines: 322
+        category: implementation
+        exports:
+          - name: registerResearchCatalogReviewTool
+            kind: function
+            isReExport: false
+          - name: ResearchCatalogReviewDeps
+            kind: interface
+            isReExport: false
+          - name: ResearchCatalogReviewResponse
+            kind: interface
+            isReExport: false
+          - name: ResearchCatalogReviewInput
+            kind: type
+            isReExport: false
+          - name: ResearchCatalogReviewInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
+            isExternal: true
+            imports:
+              - McpServer
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../middleware/tool-wrapper.js
+            isExternal: false
+            imports:
+              - wrapToolWithTimeout
+              - toSdkCallback
+              - getToolTimeout
+          - specifier: ../middleware/secure-handler.js
+            isExternal: false
+            imports:
+              - createSecureHandler
+              - HandlerContext
+          - specifier: ./research-auto-catalog.js
+            isExternal: false
+            imports:
+              - getAutoCatalog
+          - specifier: ../../cli/research-helpers.js
+            isExternal: false
+            imports:
+              - addResearchPaper
+              - paperExists
+          - specifier: ../../cli/research-helpers-issues.js
+            isExternal: false
+            imports:
+              - createResearchIssue
+              - formatResearchIssueBody
+        description: nexus-agents/mcp - Research Catalog Review Tool MCP tool for reviewing auto-cataloged research references.
+      - path: mcp/tools/research-discover-relevance.test.ts
+        lines: 211
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+          - specifier: ./research-discover.js
+            isExternal: false
+            imports:
+              - computeRelevanceScore
+              - filterByRelevance
+              - DiscoveredItem
+        description: Tests for research-discover relevance scoring and filtering.
+      - path: mcp/tools/research-discover.test.ts
+        lines: 152
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./research-discover.js
+            isExternal: false
+            imports:
+              - registerResearchDiscoverTool
+              - ResearchDiscoverInputSchema
+              - ResearchDiscoverDeps
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+        description: Tests for research_discover MCP tool.
+      - path: mcp/tools/research-discover.ts
+        lines: 504
+        category: implementation
+        exports:
+          - name: computeRelevanceScore
+            kind: function
+            isReExport: false
+          - name: filterByRelevance
+            kind: function
+            isReExport: false
+          - name: registerResearchDiscoverTool
+            kind: function
+            isReExport: false
+          - name: DiscoveredItem
+            kind: interface
+            isReExport: false
+          - name: ResearchDiscoverDeps
+            kind: interface
+            isReExport: false
+          - name: ResearchDiscoverResponse
+            kind: interface
+            isReExport: false
+          - name: DiscoverySource
+            kind: type
+            isReExport: false
+          - name: ResearchDiscoverInput
+            kind: type
+            isReExport: false
+          - name: ResearchDiscoverInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
+            isExternal: true
+            imports:
+              - McpServer
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../middleware/tool-wrapper.js
+            isExternal: false
+            imports:
+              - wrapToolWithTimeout
+              - toSdkCallback
+              - getToolTimeout
+          - specifier: ../middleware/secure-handler.js
+            isExternal: false
+            imports:
+              - createSecureHandler
+              - HandlerContext
+          - specifier: ../../cli/research-helpers.js
+            isExternal: false
+            imports:
+              - loadPapersRegistry
+          - specifier: ../../cli/research-helpers-sources.js
+            isExternal: false
+            imports:
+              - discoverGitHubRepos
+              - discoverGoogleAI
+              - discoverMetaFAIR
+              - discoverMicrosoftResearch
+              - discoverDeepMind
+              - discoverArxiv
+          - specifier: ../../cli/research-helpers-sources-academic.js
+            isExternal: false
+            imports:
+              - discoverSemanticScholar
+              - discoverPapersWithCode
+        description:
+          nexus-agents/mcp - Research Discover Tool MCP tool for discovering new research papers and repos from
+          external sources.
+      - path: mcp/tools/research-query.test.ts
+        lines: 145
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+          - specifier: ./research-query.js
+            isExternal: false
+            imports:
+              - registerResearchQueryTool
+              - ResearchQueryInputSchema
+              - ResearchQueryDeps
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+        description: Tests for research_query MCP tool.
+      - path: mcp/tools/research-query.ts
+        lines: 276
+        category: implementation
+        exports:
+          - name: registerResearchQueryTool
+            kind: function
+            isReExport: false
+          - name: ResearchQueryDeps
+            kind: interface
+            isReExport: false
+          - name: ResearchQueryResponse
+            kind: interface
+            isReExport: false
+          - name: ResearchQueryInput
+            kind: type
+            isReExport: false
+          - name: ResearchQueryInputSchema
+            kind: const
+            isReExport: false
+        dependencies:
+          - specifier: zod
+            isExternal: true
+            imports:
+              - z
+          - specifier: '@modelcontextprotocol/sdk/server/mcp.js'
+            isExternal: true
+            imports:
+              - McpServer
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../middleware/rate-limiter.js
+            isExternal: false
+            imports:
+              - RateLimiter
+          - specifier: ../../config/schemas.js
+            isExternal: false
+            imports:
+              - SecurityConfig
+          - specifier: ../middleware/tool-wrapper.js
+            isExternal: false
+            imports:
+              - wrapToolWithTimeout
+              - toSdkCallback
+              - getToolTimeout
+          - specifier: ../middleware/secure-handler.js
+            isExternal: false
+            imports:
+              - createSecureHandler
+              - HandlerContext
+          - specifier: ../../cli/research-helpers.js
+            isExternal: false
+            imports:
+              - getResearchStatus
+              - findOverlaps
+          - specifier: ../../indexer/research-index/index.js
+            isExternal: false
+            imports:
+              - parseRegistry
+        description: nexus-agents/mcp - Research Query Tool MCP tool for querying the research registry.
       - path: mcp/tools/run-workflow-helpers.test.ts
         lines: 312
         category: test
@@ -61527,7 +65814,7 @@ modules:
               - DryRunResult
         description: nexus-agents/mcp - Run Workflow Tool Tests
       - path: mcp/tools/run-workflow.ts
-        lines: 283
+        lines: 279
         category: implementation
         exports:
           - name: registerRunWorkflowTool
@@ -61626,6 +65913,7 @@ modules:
             imports:
               - wrapToolWithTimeout
               - toSdkCallback
+              - getToolTimeout
           - specifier: ../middleware/secure-handler.js
             isExternal: false
             imports:
@@ -61650,6 +65938,111 @@ modules:
               - createFailedResult
               - formatValidationErrors
         description: nexus-agents/mcp - Run Workflow Tool MCP tool for executing workflow templates with the workflow engine.
+      - path: mcp/tools/tool-memory.test.ts
+        lines: 500
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+              - vi
+              - beforeEach
+              - afterEach
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ./tool-memory.js
+            isExternal: false
+            imports:
+              - ToolMemoryManager
+              - getToolMemory
+              - shutdownToolMemory
+          - specifier: ../../context/session-memory.js
+            isExternal: false
+            imports:
+              - SessionMemory
+        description:
+          'nexus-agents/mcp - Tool Memory Integration Tests (Source: Issue #690 - Wire memory system into MCP tool
+          execution pipeline)'
+      - path: mcp/tools/tool-memory.ts
+        lines: 372
+        category: implementation
+        exports:
+          - name: getToolMemory
+            kind: function
+            isReExport: false
+          - name: shutdownToolMemory
+            kind: function
+            isReExport: false
+          - name: ToolMemoryManager
+            kind: class
+            isReExport: false
+          - name: SessionLearning
+            kind: unknown
+            isReExport: false
+          - name: CompletedTask
+            kind: unknown
+            isReExport: false
+          - name: ResolvedError
+            kind: unknown
+            isReExport: false
+          - name: Belief
+            kind: unknown
+            isReExport: false
+        dependencies:
+          - specifier: node:fs
+            isExternal: true
+            imports:
+              - '* as fs'
+          - specifier: node:os
+            isExternal: true
+            imports:
+              - '* as os'
+          - specifier: node:path
+            isExternal: true
+            imports:
+              - '* as path'
+          - specifier: ../../core/index.js
+            isExternal: false
+            imports:
+              - ILogger
+          - specifier: ../../context/session-memory.js
+            isExternal: false
+            imports:
+              - SessionMemory
+          - specifier: ../../context/session-memory-types.js
+            isExternal: false
+            imports:
+              - SessionLearning
+              - CompletedTask
+              - ResolvedError
+          - specifier: ../../context/belief-memory.js
+            isExternal: false
+            imports:
+              - HindsightBeliefMemory
+          - specifier: ../../context/belief-core-types.js
+            isExternal: false
+            imports:
+              - BeliefConfidence
+              - BeliefSourceType
+          - specifier: ../../context/agentic-memory.js
+            isExternal: false
+            imports:
+              - AgenticMemoryBackend
+          - specifier: ../../context/adaptive-memory.js
+            isExternal: false
+            imports:
+              - AdaptiveMemoryBackend
+          - specifier: ../../context/memory-backend-types.js
+            isExternal: false
+            imports:
+              - MemoryMetadata
+        description: nexus-agents/mcp - Tool Memory Integration Unified memory facade for MCP tools.
       - path: mcp/middleware/__tests__/middleware-chain.test.ts
         lines: 378
         category: test
@@ -61792,17 +66185,19 @@ modules:
           STPA Validation Tests Security-critical tests for STPA validation functions that verify tools against
           safety constraints.
     stats:
-      fileCount: 73
-      totalLines: 24997
-      exportCount: 719
-      internalDeps: 206
-      externalDeps: 63
+      fileCount: 91
+      totalLines: 29908
+      exportCount: 854
+      internalDeps: 282
+      externalDeps: 93
     dependsOn:
       - agents
       - cli
       - config
       - consensus
+      - context
       - core
+      - indexer
       - learning
       - observability
       - orchestration
@@ -63248,7 +67643,7 @@ modules:
           nexus-agents/orchestration - Orchestration Module Unified orchestration layer providing canonical
           IOrchestrator interface for all orchestration strate...
       - path: orchestration/orchestrator-adapters.ts
-        lines: 296
+        lines: 320
         category: implementation
         exports:
           - name: TechLeadAdapter
@@ -63278,6 +67673,7 @@ modules:
             isExternal: false
             imports:
               - getTimeProvider
+              - createLogger
           - specifier: ../core/types/index.js
             isExternal: false
             imports:
@@ -63351,7 +67747,7 @@ modules:
         description: nexus-agents/orchestration - Orchestrator Factory Factory for creating IOrchestrator instances.
     stats:
       fileCount: 3
-      totalLines: 713
+      totalLines: 737
       exportCount: 25
       internalDeps: 9
       externalDeps: 1
@@ -74997,7 +79393,7 @@ modules:
               - getRandomProvider
         description: nexus-agents/utils - ID Generation Utilities Shared utility functions for generating unique identifiers.
       - path: utils/index.ts
-        lines: 75
+        lines: 92
         category: index
         exports:
           - name: memoryRowToEntry
@@ -75220,6 +79616,62 @@ modules:
             kind: unknown
             isReExport: true
             sourceModule: ./type-coercion.js
+          - name: ModuleNode
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: ArchitectureComponent
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: SwarmAgent
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: FlowStep
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: OrchestrationStep
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: OrchestrationVizData
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateDependencyGraph
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateArchitectureDiagram
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateSwarmVisualization
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateFlowDiagram
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateOrchestrationSequence
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateAsciiDashboard
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: generateVoteSummary
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
+          - name: wrapInMarkdownFence
+            kind: unknown
+            isReExport: true
+            sourceModule: ./visual-output.js
         dependencies: []
         description:
           nexus-agents/utils - Shared Utilities Common utility functions extracted from multiple modules per ADR-0013
@@ -75394,12 +79846,89 @@ modules:
         description:
           nexus-agents/utils - Type Coercion Utilities Safe type coercion helpers for parsing and validating unknown
           values.
+      - path: utils/visual-output.test.ts
+        lines: 385
+        category: test
+        exports: []
+        dependencies:
+          - specifier: vitest
+            isExternal: true
+            imports:
+              - describe
+              - it
+              - expect
+          - specifier: ./visual-output.js
+            isExternal: false
+            imports:
+              - generateDependencyGraph
+              - generateArchitectureDiagram
+              - generateSwarmVisualization
+              - generateFlowDiagram
+              - generateOrchestrationSequence
+              - generateAsciiDashboard
+              - generateVoteSummary
+              - wrapInMarkdownFence
+              - OrchestrationVizData
+      - path: utils/visual-output.ts
+        lines: 647
+        category: implementation
+        exports:
+          - name: generateDependencyGraph
+            kind: function
+            isReExport: false
+          - name: generateArchitectureDiagram
+            kind: function
+            isReExport: false
+          - name: generateSwarmVisualization
+            kind: function
+            isReExport: false
+          - name: generateFlowDiagram
+            kind: function
+            isReExport: false
+          - name: generateOrchestrationSequence
+            kind: function
+            isReExport: false
+          - name: generateAsciiDashboard
+            kind: function
+            isReExport: false
+          - name: generateVoteSummary
+            kind: function
+            isReExport: false
+          - name: generateSystemSummary
+            kind: function
+            isReExport: false
+          - name: wrapInMarkdownFence
+            kind: function
+            isReExport: false
+          - name: ModuleNode
+            kind: interface
+            isReExport: false
+          - name: ArchitectureComponent
+            kind: interface
+            isReExport: false
+          - name: SwarmAgent
+            kind: interface
+            isReExport: false
+          - name: FlowStep
+            kind: interface
+            isReExport: false
+          - name: OrchestrationStep
+            kind: interface
+            isReExport: false
+          - name: OrchestrationVizData
+            kind: interface
+            isReExport: false
+          - name: SystemSummaryData
+            kind: interface
+            isReExport: false
+        dependencies: []
+        description: nexus-agents/utils - Visual Output Utilities Mermaid diagram generators for common visualizations.
     stats:
-      fileCount: 8
-      totalLines: 1195
-      exportCount: 111
-      internalDeps: 2
-      externalDeps: 1
+      fileCount: 10
+      totalLines: 2244
+      exportCount: 141
+      internalDeps: 3
+      externalDeps: 2
     dependsOn:
       - context
       - core
@@ -77155,7 +81684,7 @@ modules:
           nexus-agents/workflows - Step Executor Tests Tests for step execution, input resolution, retries, and
           conditions.
       - path: workflows/step-executor.ts
-        lines: 348
+        lines: 357
         category: implementation
         exports:
           - name: createStepExecutor
@@ -77369,7 +81898,7 @@ modules:
               - getBuiltInTemplatesWithMetadata
         description: nexus-agents/workflows - Template Registry Registry for managing workflow templates (built-in and custom).
       - path: workflows/template-types.ts
-        lines: 241
+        lines: 244
         category: types
         exports:
           - name: TemplateMetadata
@@ -82411,7 +86940,7 @@ modules:
           closure.
     stats:
       fileCount: 117
-      totalLines: 36426
+      totalLines: 36438
       exportCount: 1142
       internalDeps: 336
       externalDeps: 65


### PR DESCRIPTION
## Summary
- Regenerate codebase index to fix CI freshness check warning
- Index now covers 1456 files across 27 modules (up from stale state)
- Triggered by recent additions: memory facade (Phase 2), CLI test files

## Test plan
- [x] CI freshness check should pass
- [x] No source code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)