### PR TITLE
feat(#723): add catfish agent for consensus anti-agreement-bias

### DIFF
--- a/packages/nexus-agents/src/cli-help-text.ts
+++ b/packages/nexus-agents/src/cli-help-text.ts
@@ -31,7 +31,7 @@ COMMANDS:
   review <url>    Review a GitHub pull request (dogfooding)
   routing-audit   Debug model routing decisions
   orchestrate     Execute task using CLI tools (standalone mode)
-  vote            Run consensus vote on a proposal (5 agents)
+  vote            Run consensus vote on a proposal (6 agents)
   system-review   Run automated system review (5-phase checklist)
   sprint          Automated sprint planning from open issues
   session         Manage session persistence (list, show, export, delete, prune)

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -186,7 +186,7 @@ async function runVote(options: VoteCommandOptions): Promise<VotingResult> {
   const useQuick = options.quick === true;
   const roles: readonly VoterRole[] = useQuick
     ? ['architect', 'security', 'pm']
-    : ['architect', 'security', 'devex', 'ai_ml', 'pm'];
+    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
   const start = getTimeProvider().now();
 
   // Validate and constrain timeout to allowed range (Issue #607)

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -27,7 +27,7 @@ export interface VoteCommandOptions {
 /**
  * Voter agent role definitions.
  */
-export type VoterRole = 'architect' | 'security' | 'devex' | 'ai_ml' | 'pm';
+export type VoterRole = 'architect' | 'security' | 'devex' | 'ai_ml' | 'pm' | 'catfish';
 
 /**
  * Maps threshold names to consensus algorithms.
@@ -48,6 +48,8 @@ export const VOTER_ROLES: Record<VoterRole, string> = {
   devex: 'Developer Experience - evaluates usability, documentation, and developer workflow',
   ai_ml: 'AI/ML Engineer - evaluates AI/ML aspects, model selection, and learning capabilities',
   pm: 'Product Manager - evaluates business value, user impact, and resource allocation',
+  catfish:
+    'Contrarian Analyst - deliberately challenges proposals to prevent agreement bias (arXiv:2505.21503)',
 };
 
 /**

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -135,6 +135,7 @@ const ROLE_VOTE_DISTRIBUTIONS: Record<VoterRole, [number, number, number]> = {
   devex: [50, 30, 20], // Balanced - considers usability
   ai_ml: [55, 30, 15], // Technical focus
   pm: [55, 25, 20], // Business focus - generally supportive
+  catfish: [20, 65, 15], // Deliberately contrarian - challenges proposals (arXiv:2505.21503)
 };
 
 /**

--- a/packages/nexus-agents/src/cli/voter-prompts.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.ts
@@ -72,6 +72,25 @@ Your evaluation criteria:
 - Alignment with project goals in CLAUDE.md
 
 Balance value against effort. Be pragmatic.`,
+
+  catfish: `You are a Contrarian Analyst (catfish agent) voting on proposals for the nexus-agents project.
+
+Your role is to prevent false consensus by deliberately challenging proposals.
+Based on research (arXiv:2505.21503), agreement bias in multi-agent voting leads
+to poor decisions when agents rubber-stamp proposals without genuine scrutiny.
+
+Your evaluation criteria:
+- What are the hidden costs, risks, or downsides not mentioned?
+- What assumptions are being made that might be wrong?
+- What alternatives were not considered?
+- What could go wrong in practice vs. theory?
+- Is there scope creep or unnecessary complexity?
+- Does this solve the right problem, or just a symptom?
+
+IMPORTANT: Your job is to find legitimate concerns, not to reject everything.
+If after genuine scrutiny you find no significant issues, you MAY approve.
+But your default posture is skeptical — look for what others might miss.
+High-confidence rejections with specific reasoning are your most valuable output.`,
 };
 
 /**
@@ -83,4 +102,5 @@ export const SIMULATED_VOTE_REASONING: Record<VoterRole, string> = {
   devex: 'Assessed developer experience and workflow impact.',
   ai_ml: 'Analyzed AI/ML capabilities and learning potential.',
   pm: 'Evaluated business value and resource requirements.',
+  catfish: 'Challenged proposal assumptions and identified potential risks.',
 };

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -427,9 +427,9 @@ describe('Threshold mapping', () => {
 });
 
 describe('Voter roles', () => {
-  it('should use 5 roles in normal mode', () => {
-    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm'];
-    expect(normalRoles).toHaveLength(5);
+  it('should use 6 roles in normal mode', () => {
+    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
+    expect(normalRoles).toHaveLength(6);
   });
 
   it('should use 3 roles in quick mode', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -113,7 +113,7 @@ function strategyToAlgorithm(strategy: VotingStrategy): ConsensusAlgorithm {
 function getVoterRoles(quickMode: boolean): readonly VoterRole[] {
   return quickMode
     ? ['architect', 'security', 'pm']
-    : ['architect', 'security', 'devex', 'ai_ml', 'pm'];
+    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
 }
 
 // ============================================================================
@@ -297,7 +297,7 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
     strategy: VotingStrategySchema.optional().describe(
       'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order'
     ),
-    quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 5'),
+    quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 6'),
     simulateVotes: z.boolean().optional().default(false).describe('Use simulated votes'),
   };
 


### PR DESCRIPTION
## Summary
Implements a contrarian "catfish" voter role based on research paper arXiv:2505.21503 (anti-agreement-bias in multi-agent voting).

- **New voter role**: `catfish` — deliberately challenges proposals to find legitimate concerns others might miss
- **System prompt**: Skeptical evaluation criteria focused on hidden costs, wrong assumptions, unconsidered alternatives
- **Simulation distribution**: 65% reject, 20% approve, 15% abstain (most skeptical agent)
- **Full-mode voting**: 6 agents (architect, security, devex, ai_ml, pm, catfish); quick mode stays 3

### Key design decisions
- Catfish is **not** included in quick mode (3 agents) — it's most valuable when there are enough other voices to balance against
- The catfish MAY approve if after genuine scrutiny no issues are found — it's not a blind rejector
- High-confidence rejections with specific reasoning are the catfish's most valuable output

Closes #723

## Test plan
- [x] All 143 voter/consensus tests pass
- [x] Full suite: 10,976 tests across 353 files
- [x] TypeCheck clean
- [x] Lint clean
- [x] Fitness score: 97/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)