### PR TITLE
fix: update consensus vote description to reflect 6 agents with catfish

### DIFF
--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -57,7 +57,7 @@ Most commonly used commands:
 | `routing-audit`        | `<task>`        | Debug routing decisions (dry-run)           | any          |
 | `orchestrate`          | `<task>`        | Execute task standalone                     | orchestrator |
 | `system-review`        | -               | Run 5-phase system review                   | any          |
-| `vote`                 | `--proposal`    | Consensus voting with 5 agents              | any          |
+| `vote`                 | `--proposal`    | Consensus voting with 6 agents              | any          |
 | `research`             | `status`        | Show technique implementation status        | any          |
 | `research`             | `overlap`       | Find overlapping techniques                 | any          |
 | `research`             | `add`           | Add new paper from arXiv                    | any          |

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -303,7 +303,7 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
 
   const description =
     'Execute multi-model consensus voting on a proposal. ' +
-    'Uses 5 specialized agent roles (architect, security, devex, ai_ml, pm) ' +
+    'Uses 6 specialized agent roles (architect, security, devex, ai_ml, pm, catfish) ' +
     'to vote on proposals with configurable strategies. ' +
     'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514).';
 

--- a/website/src/content/docs/guides/cli-usage.md
+++ b/website/src/content/docs/guides/cli-usage.md
@@ -60,7 +60,7 @@ Most commonly used commands:
 | `routing-audit`        | `<task>`        | Debug routing decisions (dry-run)           | any          |
 | `orchestrate`          | `<task>`        | Execute task standalone                     | orchestrator |
 | `system-review`        | -               | Run 5-phase system review                   | any          |
-| `vote`                 | `--proposal`    | Consensus voting with 5 agents              | any          |
+| `vote`                 | `--proposal`    | Consensus voting with 6 agents              | any          |
 | `research`             | `status`        | Show technique implementation status        | any          |
 | `research`             | `overlap`       | Find overlapping techniques                 | any          |
 | `research`             | `add`           | Add new paper from arXiv                    | any          |


### PR DESCRIPTION
## Summary
- Update MCP `consensus_vote` tool description from "5 specialized agent roles" to "6 specialized agent roles" including catfish
- Update ENTRYPOINTS.md and website CLI usage docs to say "6 agents"

Missed in #727 when the catfish role was added.

## Test plan
- [ ] CI passes
- [ ] MCP tool description accurately reflects 6 roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)