### PR TITLE
fix(#734): isolate source errors in research_discover source=all mode

### DIFF
--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -159,7 +159,15 @@ export async function discoverGitHubRepos(
   });
   if (!fetchResult.ok) return fetchResult;
 
-  const raw = await fetchResult.value.json();
+  let raw: unknown;
+  try {
+    raw = await fetchResult.value.json();
+  } catch {
+    return {
+      ok: false,
+      error: createError('PARSE_ERROR', 'github', 'Response is not valid JSON'),
+    };
+  }
   const parsed = GitHubSearchResponseSchema.safeParse(raw);
   if (!parsed.success) {
     return {

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -345,15 +345,20 @@ async function queryAllSources(
   for (const src of ALL_SOURCES) {
     if (shouldQuery(src)) {
       sources.push(src);
-      items = items.concat(
-        await discoverFromExtendedSource(
-          src,
-          input.topic,
-          input.maxResults,
-          logger,
-          input.sinceDate
-        )
-      );
+      try {
+        items = items.concat(
+          await discoverFromExtendedSource(
+            src,
+            input.topic,
+            input.maxResults,
+            logger,
+            input.sinceDate
+          )
+        );
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn('Extended source discovery failed', { source: src, error: message });
+      }
     }
   }
   return { sources, items };


### PR DESCRIPTION
## Summary
- Add error isolation around individual source discovery calls in `queryAllSources()`
- When `source: "all"`, a single failing source (returning HTML instead of JSON/XML) no longer crashes the entire discovery operation
- Wrap GitHub API `json()` parsing in try-catch to handle HTML error pages gracefully
- Failed sources are logged as warnings and skipped, partial results returned

Closes #734

## Test plan
- [ ] All 10,976 existing tests pass
- [ ] `research_discover` with individual sources still works
- [ ] `research_discover` with `source: "all"` returns partial results when some sources fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)