### PR TITLE
feat(#974): Add MCP logging notifications for Claude Code observability

### DIFF
--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-02-11T20:00:15.443Z",
+  "generated": "2026-02-11T21:40:25.283Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.7.1",
   "cli": {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-02-11T20:00:15.443Z
+**Generated:** 2026-02-11T21:40:25.283Z
 **Package Version:** 2.7.1
 **Generator:** `scripts/generate-repo-index.ts`
 

--- a/packages/nexus-agents/src/exports/mcp.ts
+++ b/packages/nexus-agents/src/exports/mcp.ts
@@ -47,6 +47,11 @@ export {
   createDefaultPolicyFirewall,
   evaluatePolicy,
   createPolicyContext,
+  // MCP Notifier (Issue #974 — Claude Code Observability)
+  createMcpNotifier,
+  NOOP_NOTIFIER,
+  type IMcpNotifier,
+  type McpLogLevel,
   // EventBus Bridge (Issue #307, #538)
   initializeEventBusBridge,
   getEventBusStats,

--- a/packages/nexus-agents/src/mcp/index.ts
+++ b/packages/nexus-agents/src/mcp/index.ts
@@ -58,6 +58,14 @@ export {
   createPolicyContext,
 } from './middleware/index.js';
 
+// MCP Notifier (Issue #974 — Claude Code Observability)
+export {
+  createMcpNotifier,
+  NOOP_NOTIFIER,
+  type IMcpNotifier,
+  type McpLogLevel,
+} from './mcp-notifier.js';
+
 // EventBus Bridge (Issue #307)
 export {
   initializeEventBusBridge,

--- a/packages/nexus-agents/src/mcp/mcp-notifier.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-notifier.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for MCP Notification Helper.
+ *
+ * @module mcp/mcp-notifier.test
+ * (Source: Issue #974 — Claude Code Observability)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createMcpNotifier, NOOP_NOTIFIER } from './mcp-notifier.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createMockServer(sendFn?: (...args: unknown[]) => Promise<void>) {
+  return {
+    sendLoggingMessage: sendFn ?? vi.fn(() => Promise.resolve()),
+  } as unknown as McpServer;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('createMcpNotifier', () => {
+  it('sends info-level notification', () => {
+    const sendFn = vi.fn(() => Promise.resolve());
+    const server = createMockServer(sendFn);
+    const notifier = createMcpNotifier(server);
+
+    notifier.info('delegate', { event: 'model_selected', model: 'claude-opus' });
+
+    expect(sendFn).toHaveBeenCalledWith({
+      level: 'info',
+      logger: 'delegate',
+      data: { event: 'model_selected', model: 'claude-opus' },
+    });
+  });
+
+  it('sends debug-level notification', () => {
+    const sendFn = vi.fn(() => Promise.resolve());
+    const server = createMockServer(sendFn);
+    const notifier = createMcpNotifier(server);
+
+    notifier.debug('consensus', { event: 'vote_collected', role: 'architect' });
+
+    expect(sendFn).toHaveBeenCalledWith({
+      level: 'debug',
+      logger: 'consensus',
+      data: { event: 'vote_collected', role: 'architect' },
+    });
+  });
+
+  it('sends warning-level notification', () => {
+    const sendFn = vi.fn(() => Promise.resolve());
+    const server = createMockServer(sendFn);
+    const notifier = createMcpNotifier(server);
+
+    notifier.warn('workflow', { event: 'step_failed', step: 'analyze' });
+
+    expect(sendFn).toHaveBeenCalledWith({
+      level: 'warning',
+      logger: 'workflow',
+      data: { event: 'step_failed', step: 'analyze' },
+    });
+  });
+
+  it('does not throw when sendLoggingMessage rejects', () => {
+    const sendFn = vi.fn(() => Promise.reject(new Error('not connected')));
+    const server = createMockServer(sendFn);
+    const notifier = createMcpNotifier(server);
+
+    // Should not throw
+    expect(() => {
+      notifier.info('test', { event: 'test' });
+    }).not.toThrow();
+  });
+
+  it('does not throw when sendLoggingMessage throws synchronously', () => {
+    const sendFn = vi.fn(() => {
+      throw new Error('server not initialized');
+    });
+    const server = createMockServer(sendFn);
+    const notifier = createMcpNotifier(server);
+
+    // Should not throw — caught by try/catch wrapper
+    expect(() => {
+      notifier.info('test', { event: 'test' });
+    }).not.toThrow();
+  });
+
+  it('does not throw when server lacks sendLoggingMessage', () => {
+    const server = {} as unknown as McpServer;
+    const notifier = createMcpNotifier(server);
+
+    // Should not throw
+    expect(() => {
+      notifier.info('test', { event: 'test' });
+    }).not.toThrow();
+  });
+});
+
+describe('NOOP_NOTIFIER', () => {
+  it('has info/debug/warn methods that do nothing', () => {
+    NOOP_NOTIFIER.info('test', {});
+    NOOP_NOTIFIER.debug('test', {});
+    NOOP_NOTIFIER.warn('test', {});
+    // No-op: methods complete without error
+    expect(true).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/mcp/mcp-notifier.ts
+++ b/packages/nexus-agents/src/mcp/mcp-notifier.ts
@@ -1,0 +1,81 @@
+/**
+ * nexus-agents/mcp - MCP Notification Helper
+ *
+ * Sends structured logging notifications to MCP clients via
+ * the `notifications/message` protocol method.
+ * Clients (e.g., Claude Code) can display these for real-time
+ * observability of orchestration events.
+ *
+ * @module mcp/mcp-notifier
+ * (Source: Issue #973, #974 — Claude Code Observability)
+ * (Source: MCP Protocol 2025-11-25, Logging Specification)
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createLogger, getErrorMessage } from '../core/index.js';
+
+/**
+ * Logging levels for MCP notifications (RFC 5424 syslog).
+ */
+export type McpLogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
+
+/**
+ * MCP notifier for sending structured log events to clients.
+ */
+export interface IMcpNotifier {
+  /** Send info-level notification (key orchestration events) */
+  info(logger: string, data: Record<string, unknown>): void;
+  /** Send debug-level notification (detailed execution steps) */
+  debug(logger: string, data: Record<string, unknown>): void;
+  /** Send warning-level notification */
+  warn(logger: string, data: Record<string, unknown>): void;
+}
+
+const internalLogger = createLogger({ component: 'mcp-notifier' });
+
+/**
+ * Creates an MCP notifier that sends logging notifications to connected clients.
+ *
+ * Notifications are fire-and-forget — failures are logged but never
+ * propagate to callers. This ensures observability never breaks tool execution.
+ */
+export function createMcpNotifier(server: McpServer): IMcpNotifier {
+  function send(level: McpLogLevel, logger: string, data: Record<string, unknown>): void {
+    try {
+      server.sendLoggingMessage({ level, logger, data }).catch((error: unknown) => {
+        internalLogger.debug('Failed to send MCP notification', {
+          level,
+          logger,
+          error: getErrorMessage(error),
+        });
+      });
+    } catch (error: unknown) {
+      internalLogger.debug('Failed to send MCP notification', {
+        level,
+        logger,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  return {
+    info: (logger, data) => {
+      send('info', logger, data);
+    },
+    debug: (logger, data) => {
+      send('debug', logger, data);
+    },
+    warn: (logger, data) => {
+      send('warning', logger, data);
+    },
+  };
+}
+
+/**
+ * No-op notifier for when MCP server is not available.
+ */
+export const NOOP_NOTIFIER: IMcpNotifier = {
+  info: () => undefined,
+  debug: () => undefined,
+  warn: () => undefined,
+};

--- a/packages/nexus-agents/src/mcp/server.ts
+++ b/packages/nexus-agents/src/mcp/server.ts
@@ -96,10 +96,17 @@ export function createServer(config?: ServerConfig): Result<ServerInstance, Serv
       version: serverVersion,
     });
 
-    const server = new McpServer({
-      name: serverName,
-      version: serverVersion,
-    });
+    const server = new McpServer(
+      {
+        name: serverName,
+        version: serverVersion,
+      },
+      {
+        capabilities: {
+          logging: {},
+        },
+      }
+    );
 
     logger.debug('MCP server created successfully');
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -21,6 +21,8 @@ import {
 } from '../../core/index.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
+import { createMcpNotifier, NOOP_NOTIFIER } from '../mcp-notifier.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import type { ConsensusAlgorithm, Vote, ConsensusResult, Proposal } from '../../consensus/types.js';
@@ -88,6 +90,8 @@ export interface ConsensusVoteDeps {
   logger?: ILogger;
   rateLimiter: RateLimiter;
   security?: SecurityConfig | undefined;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  notifier?: IMcpNotifier | undefined;
 }
 
 // ============================================================================
@@ -352,6 +356,7 @@ type ConsensusVoteToolResponse = {
 };
 
 function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
+  const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext): Promise<ConsensusVoteToolResponse> => {
     const validationResult = ConsensusVoteInputSchema.safeParse(args);
     if (!validationResult.success) {
@@ -363,15 +368,35 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
       };
     }
 
+    const strategy = validationResult.data.strategy ?? 'simple_majority';
     ctx.logger.debug('Starting consensus vote', {
-      strategy: validationResult.data.strategy ?? 'simple_majority',
+      strategy,
       quickMode: validationResult.data.quickMode,
+    });
+    notifier.info('consensus_vote', {
+      event: 'vote_start',
+      proposalLength: validationResult.data.proposal.length,
+      strategy,
     });
 
     const result = await handleConsensusVote(deps, validationResult.data);
     if (!result.ok) {
       return { isError: true, content: [{ type: 'text', text: result.error }] };
     }
+
+    for (const vote of result.value.votes) {
+      notifier.debug('consensus_vote', {
+        event: 'vote_collected',
+        role: vote.role,
+        decision: vote.decision,
+      });
+    }
+    notifier.info('consensus_vote', {
+      event: 'vote_complete',
+      decision: result.value.decision,
+      approvalPercentage: result.value.approvalPercentage,
+      voteCount: result.value.votes.length,
+    });
     return { content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }] };
   };
 }
@@ -382,6 +407,8 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
  */
 export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVoteDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'consensus_vote' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
+  const depsWithNotifier = { ...deps, notifier };
   const toolSchema = {
     proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
     threshold: z
@@ -401,7 +428,7 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
     'to vote on proposals with configurable strategies. ' +
     'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514).';
 
-  const secureHandler = createSecureHandler(createConsensusVoteHandler(deps), {
+  const secureHandler = createSecureHandler(createConsensusVoteHandler(depsWithNotifier), {
     toolName: 'consensus_vote',
     rateLimiter: deps.rateLimiter,
     logger,

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
@@ -12,6 +12,7 @@ import type { ILogger, ICompositeRouter } from '../../core/index.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
 import type { IFeedbackIntegration } from '../../learning/feedback-integration.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
 
 /**
  * Billing mode for model routing.
@@ -117,6 +118,8 @@ export interface DelegateDeps {
   feedbackIntegration?: IFeedbackIntegration | undefined;
   /** Security configuration (includes timeout settings - Issue #271) */
   security?: SecurityConfig | undefined;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  notifier?: IMcpNotifier | undefined;
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
@@ -39,6 +39,7 @@ import {
   getCliForModel,
 } from './delegate-to-model-helpers.js';
 import { getToolMemory } from './tool-memory.js';
+import { createMcpNotifier, NOOP_NOTIFIER, type IMcpNotifier } from '../mcp-notifier.js';
 import { getOutcomeStore } from '../../orchestration/outcomes/index.js';
 import { detectTaskCategory } from '../../config/task-specialization.js';
 import type { CliName } from '../../cli-adapters/types-core.js';
@@ -179,6 +180,33 @@ function instrumentV2Pipeline(input: { task: string }, logger: ILogger): void {
   });
 }
 
+/** Options for notifyAndRecord. */
+interface NotifyRecordOpts {
+  notifier: IMcpNotifier;
+  task: string;
+  model: string;
+  router: string;
+  startMs: number;
+  governance: GovernanceClassification;
+}
+
+/** Notifies model selection and records delegation. */
+function notifyAndRecord(opts: NotifyRecordOpts): void {
+  opts.notifier.info('delegate', {
+    event: 'model_selected',
+    model: opts.model,
+    router: opts.router,
+    durationMs: Date.now() - opts.startMs,
+  });
+  recordDelegation(
+    opts.task,
+    opts.model,
+    opts.router === 'CompositeRouter',
+    opts.startMs,
+    opts.governance
+  );
+}
+
 /**
  * Creates the core handler logic for delegate_to_model tool.
  * Uses CompositeRouter when available, falls back to local model selection.
@@ -186,6 +214,7 @@ function instrumentV2Pipeline(input: { task: string }, logger: ILogger): void {
 function createDelegateHandler(
   deps: DelegateDeps
 ): (args: unknown, ctx: HandlerContext) => Promise<ToolResult> {
+  const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const startMs = Date.now();
     const validated = DelegateInputSchema.safeParse(args);
@@ -194,25 +223,33 @@ function createDelegateHandler(
       return errorResult(`Validation error: ${formatZodError(validated.error)}`);
     }
     const input = validated.data;
+    notifier.info('delegate', { event: 'routing_start', taskLength: input.task.length });
     ctx.logger.info('Analyzing task for model routing', { taskLength: input.task.length });
     const requirements = analyzeTask(input.task);
     const governance = classifyDelegateGovernance(input, ctx.logger);
     if (resolveV2Config().delegateEnabled) instrumentV2Pipeline(input, ctx.logger);
     // Try CompositeRouter first if available
     if (deps.router !== undefined) {
-      const routingResult = await routeViaCompositeRouter(
+      const routerResult = await routeViaCompositeRouter(
         input.task,
         deps.router,
         deps.feedbackIntegration,
         ctx.logger
       );
-      if (routingResult !== null) {
+      if (routerResult !== null) {
         const output = mapCompositeDecisionToOutput(
-          routingResult.decision,
+          routerResult.decision,
           requirements.estimatedTokens
         );
         ctx.logger.info('Routed via CompositeRouter', { model: output.recommended_model });
-        recordDelegation(input.task, output.recommended_model, true, startMs, governance);
+        notifyAndRecord({
+          notifier,
+          task: input.task,
+          model: output.recommended_model,
+          router: 'CompositeRouter',
+          startMs,
+          governance,
+        });
         return successResult(JSON.stringify(enrichWithGovernance(output, governance), null, 2));
       }
       ctx.logger.info('Falling back to local model selection');
@@ -222,7 +259,14 @@ function createDelegateHandler(
     const output = buildDelegateOutput(selection, requirements);
     if (!output) return errorResult(`Unknown model: ${selection.model}`);
     ctx.logger.info('Model recommendation complete', { model: output.recommended_model });
-    recordDelegation(input.task, output.recommended_model, false, startMs, governance);
+    notifyAndRecord({
+      notifier,
+      task: input.task,
+      model: output.recommended_model,
+      router: 'local',
+      startMs,
+      governance,
+    });
     return successResult(JSON.stringify(enrichWithGovernance(output, governance), null, 2));
   };
 }
@@ -238,9 +282,11 @@ function createDelegateHandler(
  */
 export function registerDelegateToModelTool(server: McpServer, deps: DelegateDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'delegate_to_model' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
 
   // Wrap handler with secure handler for rate limiting and request context (Issue #531)
-  const secureHandler = createSecureHandler(createDelegateHandler(deps), {
+  const depsWithNotifier = { ...deps, notifier };
+  const secureHandler = createSecureHandler(createDelegateHandler(depsWithNotifier), {
     toolName: 'delegate_to_model',
     rateLimiter: deps.rateLimiter,
     logger,

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -22,6 +22,8 @@ import {
 } from '../../core/index.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
+import { createMcpNotifier, NOOP_NOTIFIER } from '../mcp-notifier.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import type { Expert } from '../../agents/index.js';
@@ -58,6 +60,8 @@ export interface ExecuteExpertDeps {
   security?: SecurityConfig | undefined;
   /** Optional CLI detection cache for checking available CLIs (Issue #747) */
   cliCache?: ICliDetectionCache;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  notifier?: IMcpNotifier | undefined;
 }
 
 /**
@@ -320,6 +324,7 @@ type ExecuteExpertToolResponse = {
  * @returns Context-aware handler function
  */
 function createExecuteExpertHandler(deps: ExecuteExpertDeps) {
+  const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext): Promise<ExecuteExpertToolResponse> => {
     // Validate input
     const validationResult = ExecuteExpertInputSchema.safeParse(args);
@@ -337,6 +342,11 @@ function createExecuteExpertHandler(deps: ExecuteExpertDeps) {
       taskLength: validationResult.data.task.length,
     });
 
+    // Look up expert role for notification
+    const expert = deps.expertRegistry.get(validationResult.data.expertId);
+    const role = expert?.role ?? 'unknown';
+    notifier.info('execute_expert', { event: 'expert_start', role });
+
     // Execute tool logic
     const result = await handleExecuteExpert(deps, validationResult.data);
 
@@ -346,6 +356,13 @@ function createExecuteExpertHandler(deps: ExecuteExpertDeps) {
         content: [{ type: 'text', text: `Failed to execute expert: ${result.error}` }],
       };
     }
+
+    notifier.info('execute_expert', {
+      event: 'expert_complete',
+      role: result.value.role,
+      confidence: result.value.status === 'success' ? 1 : 0,
+      tokenUsage: result.value.tokensUsed,
+    });
 
     return {
       content: [{ type: 'text', text: JSON.stringify(result.value, null, 2) }],
@@ -364,6 +381,8 @@ function createExecuteExpertHandler(deps: ExecuteExpertDeps) {
  */
 export function registerExecuteExpertTool(server: McpServer, deps: ExecuteExpertDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'execute_expert' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
+  const depsWithNotifier = { ...deps, notifier };
   const toolSchema = {
     expertId: z.string().min(1).describe('Expert ID from create_expert tool'),
     task: z.string().min(1).describe('Task description for the expert to execute'),
@@ -375,7 +394,7 @@ export function registerExecuteExpertTool(server: McpServer, deps: ExecuteExpert
     'Returns the expert analysis including output, confidence, and token usage.';
 
   // Wrap handler with secure handler for rate limiting and request context (Issue #531)
-  const secureHandler = createSecureHandler(createExecuteExpertHandler(deps), {
+  const secureHandler = createSecureHandler(createExecuteExpertHandler(depsWithNotifier), {
     toolName: 'execute_expert',
     rateLimiter: deps.rateLimiter,
     logger,

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -13,6 +13,7 @@ import type { IOrchestrator, OrchestratorType } from '../../core/types/orchestra
 import type { WorkflowPattern } from '../../orchestration/workflow-router-types.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
 import type { ExecutionPlan, Expert } from '../../agents/index.js';
 import { OrchestratorFactory } from '../../orchestration/orchestrator-factory.js';
 
@@ -133,6 +134,8 @@ export interface OrchestrateDeps {
   security?: SecurityConfig | undefined;
   /** Model adapter for fallback orchestration path (Issue #827) */
   modelAdapter?: import('../../core/index.js').IModelAdapter | undefined;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  notifier?: IMcpNotifier | undefined;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../core/types/orchestrator.js';
 import { wrapToolWithTimeout, toSdkCallback } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
+import { createMcpNotifier, NOOP_NOTIFIER } from '../mcp-notifier.js';
 import type { ExecutionPlan } from '../../agents/index.js';
 import { createOrchestratorWithSica } from './orchestrate-sica.js';
 import { OrchestratorFactory } from '../../orchestration/orchestrator-factory.js';
@@ -395,6 +396,7 @@ function instrumentV2Orchestrate(input: { task: string }, logger: ILogger): void
 }
 
 function createOrchestrateHandler(deps: OrchestrateDeps) {
+  const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext) => {
     const validated = OrchestrateInputSchema.safeParse(args);
     if (!validated.success) {
@@ -407,6 +409,11 @@ function createOrchestrateHandler(deps: OrchestrateDeps) {
       };
     }
     ctx.logger.debug('Starting orchestration', { taskLength: validated.data.task.length });
+    notifier.info('orchestrate', {
+      event: 'orchestrate_start',
+      taskLength: validated.data.task.length,
+    });
+    const startMs = getTimeProvider().now();
     const v2Config = resolveV2Config();
     if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(validated.data, ctx.logger);
 
@@ -423,6 +430,12 @@ function createOrchestrateHandler(deps: OrchestrateDeps) {
       };
     }
 
+    notifier.info('orchestrate', {
+      event: 'orchestrate_complete',
+      subtaskCount: result.value.stepsCompleted,
+      durationMs: getTimeProvider().now() - startMs,
+    });
+
     // Merge agent plan into output when available
     const output = agentPlan !== undefined ? { ...result.value, agentPlan } : result.value;
     return { content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }] };
@@ -435,10 +448,12 @@ function createOrchestrateHandler(deps: OrchestrateDeps) {
  */
 export function registerOrchestrateTool(server: McpServer, deps: OrchestrateDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'orchestrate' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
+  const depsWithNotifier = { ...deps, notifier };
   const description =
     'Orchestrate a task by analyzing it, breaking it into subtasks if needed, and coordinating expert agents';
 
-  const secureHandler = createSecureHandler(createOrchestrateHandler(deps), {
+  const secureHandler = createSecureHandler(createOrchestrateHandler(depsWithNotifier), {
     toolName: 'orchestrate',
     rateLimiter: deps.rateLimiter,
     logger,

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -21,6 +21,8 @@ import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middlewar
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
+import { createMcpNotifier } from '../mcp-notifier.js';
 
 // ============================================================================
 // Types & Schema
@@ -47,6 +49,8 @@ export interface RunGraphWorkflowDeps {
   readonly logger?: ILogger | undefined;
   readonly rateLimiter: RateLimiter;
   readonly security?: SecurityConfig | undefined;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  readonly notifier?: IMcpNotifier | undefined;
 }
 
 export interface RunGraphWorkflowResponse {
@@ -175,13 +179,30 @@ async function handleRunGraphWorkflow(
 // Registration
 // ============================================================================
 
-/** Registers the run_graph_workflow tool with an MCP server. */
-export function registerRunGraphWorkflowTool(server: McpServer, deps: RunGraphWorkflowDeps): void {
-  const logger = deps.logger ?? createLogger({ tool: 'run_graph_workflow' });
+type ToolResponse = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
 
-  type ToolResponse = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
+const GRAPH_WORKFLOW_DESCRIPTION =
+  'Execute a predefined graph-based workflow with checkpointing, event streaming, and audit trail support';
 
-  const handler = async (args: unknown, _ctx: HandlerContext): Promise<ToolResponse> => {
+const GRAPH_WORKFLOW_SCHEMA = {
+  workflow: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe(
+      'Workflow name: echo, pipeline, code-review, security-scan. Use "list" for available workflows.'
+    ),
+  inputs: z.record(z.unknown()).optional().describe('Input values for the workflow'),
+  enableCheckpointing: z.boolean().optional().describe('Enable checkpoint saving'),
+  enableAuditTrail: z.boolean().optional().describe('Enable audit trail logging'),
+};
+
+/** Creates the handler for run_graph_workflow tool. */
+function createGraphWorkflowHandler(
+  logger: ILogger,
+  notifier: IMcpNotifier
+): (args: unknown, ctx: HandlerContext) => Promise<ToolResponse> {
+  return async (args: unknown, _ctx: HandlerContext): Promise<ToolResponse> => {
     const parsed = RunGraphWorkflowInputSchema.safeParse(args);
     if (!parsed.success) {
       return {
@@ -192,9 +213,26 @@ export function registerRunGraphWorkflowTool(server: McpServer, deps: RunGraphWo
     if (parsed.data.workflow === 'list') {
       return { content: [{ type: 'text', text: JSON.stringify(getGraphWorkflowList(), null, 2) }] };
     }
+    notifier.info('run_graph_workflow', {
+      event: 'graph_workflow_start',
+      workflow: parsed.data.workflow,
+    });
     const result = await handleRunGraphWorkflow(parsed.data, logger);
+    notifier.info('run_graph_workflow', {
+      event: 'graph_workflow_complete',
+      workflow: result.workflow,
+      nodeCount: result.nodesExecuted,
+      durationMs: result.durationMs,
+    });
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   };
+}
+
+/** Registers the run_graph_workflow tool with an MCP server. */
+export function registerRunGraphWorkflowTool(server: McpServer, deps: RunGraphWorkflowDeps): void {
+  const logger = deps.logger ?? createLogger({ tool: 'run_graph_workflow' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
+  const handler = createGraphWorkflowHandler(logger, notifier);
 
   const secureHandler = createSecureHandler(handler, {
     toolName: 'run_graph_workflow',
@@ -205,28 +243,11 @@ export function registerRunGraphWorkflowTool(server: McpServer, deps: RunGraphWo
   const timeoutMs = getToolTimeout('run_graph_workflow', deps.security);
   const wrapped = wrapToolWithTimeout('run_graph_workflow', secureHandler, { timeoutMs, logger });
 
-  const toolSchema = {
-    workflow: z
-      .string()
-      .min(1)
-      .max(100)
-      .describe(
-        'Workflow name: echo, pipeline, code-review, security-scan. Use "list" for available workflows.'
-      ),
-    inputs: z.record(z.unknown()).optional().describe('Input values for the workflow'),
-    enableCheckpointing: z.boolean().optional().describe('Enable checkpoint saving'),
-    enableAuditTrail: z.boolean().optional().describe('Enable audit trail logging'),
-  };
-
-  const description =
-    'Execute a predefined graph-based workflow with checkpointing, event streaming, and audit trail support';
-
   server.registerTool(
     'run_graph_workflow',
-    { description, inputSchema: toolSchema },
+    { description: GRAPH_WORKFLOW_DESCRIPTION, inputSchema: GRAPH_WORKFLOW_SCHEMA },
     toSdkCallback(wrapped)
   );
-
   logger.info('Registered run_graph_workflow tool');
 }
 

--- a/packages/nexus-agents/src/mcp/tools/run-workflow-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow-types.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import type { IWorkflowEngine, ILogger } from '../../core/index.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import type { IMcpNotifier } from '../mcp-notifier.js';
 
 // ============================================================================
 // Input Schema
@@ -79,4 +80,6 @@ export interface RunWorkflowDeps {
   rateLimiter: RateLimiter;
   /** Security configuration (includes timeout settings - Issue #271, CVE-2026-0621) */
   security?: SecurityConfig | undefined;
+  /** MCP notifier for client-visible logging (Issue #974) */
+  notifier?: IMcpNotifier | undefined;
 }

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -22,6 +22,7 @@ import {
 import type { WorkflowDefinition, IWorkflowEngine } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
+import { createMcpNotifier, NOOP_NOTIFIER } from '../mcp-notifier.js';
 import type {
   RunWorkflowInput,
   WorkflowToolResult,
@@ -228,6 +229,7 @@ const toolInputSchema = {
 function createRunWorkflowHandler(
   deps: RunWorkflowDeps
 ): (args: unknown, ctx: HandlerContext) => Promise<ToolResponse> {
+  const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResponse> => {
     const validated = RunWorkflowInputSchema.safeParse(args);
     if (!validated.success) {
@@ -244,8 +246,21 @@ function createRunWorkflowHandler(
       template: validated.data.template,
       dryRun: validated.data.dryRun,
     });
+    notifier.info('run_workflow', { event: 'workflow_start', template: validated.data.template });
+    const startMs = getTimeProvider().now();
 
-    return handleRunWorkflow(deps, validated.data);
+    const result = await handleRunWorkflow(deps, validated.data);
+
+    // Notify on completion (only for non-error responses)
+    if (result.isError !== true) {
+      notifier.info('run_workflow', {
+        event: 'workflow_complete',
+        template: validated.data.template,
+        durationMs: getTimeProvider().now() - startMs,
+      });
+    }
+
+    return result;
   };
 }
 
@@ -260,9 +275,11 @@ function createRunWorkflowHandler(
  */
 export function registerRunWorkflowTool(server: McpServer, deps: RunWorkflowDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run_workflow' });
+  const notifier = deps.notifier ?? createMcpNotifier(server);
+  const depsWithNotifier = { ...deps, notifier };
 
   // Wrap handler with secure handler for rate limiting and request context (Issue #531)
-  const secureHandler = createSecureHandler(createRunWorkflowHandler(deps), {
+  const secureHandler = createSecureHandler(createRunWorkflowHandler(depsWithNotifier), {
     toolName: 'run_workflow',
     rateLimiter: deps.rateLimiter,
     logger,


### PR DESCRIPTION
## Summary
- Implements Phase 1 of Claude Code Observability (Epic #973, Issue #974)
- MCP clients now receive structured `notifications/message` logging events for key orchestration activities
- Fire-and-forget semantics ensure notifications never break tool execution

## Changes
- **New**: `src/mcp/mcp-notifier.ts` — `IMcpNotifier` interface, `createMcpNotifier(server)`, `NOOP_NOTIFIER`
- **New**: `src/mcp/mcp-notifier.test.ts` — 7 tests covering all notifier behavior
- **Modified**: `src/mcp/server.ts` — Declare `logging: {}` capability in MCP server options
- **Instrumented 6 tools** with notification events:
  - `delegate_to_model`: `routing_start`, `model_selected`
  - `consensus_vote`: `vote_start`, `vote_collected` (debug), `vote_complete`
  - `orchestrate`: `orchestrate_start`, `orchestrate_complete`
  - `execute_expert`: `expert_start`, `expert_complete`
  - `run_workflow`: `workflow_start`, `workflow_complete`
  - `run_graph_workflow`: `graph_workflow_start`, `graph_workflow_complete`
- **Exports**: `IMcpNotifier`, `McpLogLevel`, `createMcpNotifier`, `NOOP_NOTIFIER` from mcp barrel

## Test plan
- [x] 7 new notifier tests (info/debug/warn levels, rejection, sync throw, missing method, NOOP)
- [x] 187 existing tool tests pass (delegate, consensus, orchestrate, expert, workflow, graph)
- [x] 10 MCP integration tests pass
- [x] 52 export contract tests pass
- [x] Build clean (ESM + DTS)
- [x] Fitness: 98/100

Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)