### PR TITLE
chore(#979): Deprecate nexus-tui package

### DIFF
--- a/docs/architecture/deprecation-pipeline.md
+++ b/docs/architecture/deprecation-pipeline.md
@@ -249,6 +249,14 @@ const count = stats.total;
 | ~~`EnhancedGeminiCliAdapter`~~  | ~~`gemini-adapter.ts:386`~~                | `GeminiCliAdapter` (**removed v2.6.0**) | v2.4  |
 | `SwarmObserver`                 | `orchestration-observer.ts:451`            | `OrchestrationObserver`                 | v2.3  |
 
+### nexus-tui Package (Issue #979, Epic #973)
+
+**Deprecated:** `packages/nexus-tui/` (entire package)
+**Replacement:** Claude Code observability features (MCP logging, hooks, status line)
+**Since:** v2.7.1
+
+The standalone TUI is superseded by Claude Code's native observability integration. See `docs/guides/claude-code-observability/` for the replacement.
+
 ## Per ADR-0005: Router Deprecation Queue (Phase 3)
 
 Once all routing stages are validated, these routers should be deprecated:
@@ -267,7 +275,8 @@ Once all routing stages are validated, these routers should be deprecated:
 
 ## Metrics
 
-- **Total deprecated items**: 43
+- **Total deprecated items**: 44
+- **v3.0 package removals**: 1 (nexus-tui)
 - **v3.0 module removals**: 7
 - **v3.0 interface/type removals**: 11
 - **v3.0 function/method removals**: 11
@@ -286,5 +295,5 @@ Before removing any deprecated item:
 
 ---
 
-_Updated: 2026-02-05 (Issue #755 - replacement stages implemented)_
+_Updated: 2026-02-11 (Issue #979 - nexus-tui deprecated)_
 _Next review: Before v3.0 release_

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -2,6 +2,7 @@
   "name": "nexus-tui",
   "version": "0.1.0",
   "description": "Interactive REPL and terminal UI for nexus-agents orchestration",
+  "deprecated": "Use Claude Code observability features instead. See docs/guides/claude-code-observability/",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Marks `packages/nexus-tui/` as deprecated in package.json
- Adds deprecation entry to the canonical deprecation pipeline document
- Scheduled for removal in v3.0

## Rationale
Claude Code's native observability features (MCP logging notifications, hooks, status line) provide better real-time visibility than the standalone TUI. Per user direction and 5/6 consensus vote on Epic #973.

## Test plan
- [x] No code changes — metadata only
- [x] Deprecation documented in deprecation-pipeline.md
- [x] Fitness: 98/100

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)