### PR TITLE
feat(#983): Increase agent timeouts for complex tasks

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/cli-timeout-profiles.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-timeout-profiles.test.ts
@@ -38,7 +38,7 @@ describe('getTimeoutForTask', () => {
     it('should return correct timeouts for codex', () => {
       expect(getTimeoutForTask('codex', 'simple')).toBe(10_000);
       expect(getTimeoutForTask('codex', 'standard')).toBe(30_000);
-      expect(getTimeoutForTask('codex', 'complex')).toBe(60_000);
+      expect(getTimeoutForTask('codex', 'complex')).toBe(90_000);
     });
   });
 
@@ -227,7 +227,7 @@ describe('getTimeoutForTaskAuto', () => {
     it('should work correctly for codex', () => {
       expect(getTimeoutForTaskAuto('codex', 'Simple function')).toBe(10_000);
       expect(getTimeoutForTaskAuto('codex', 'Normal implementation')).toBe(30_000);
-      expect(getTimeoutForTaskAuto('codex', 'Architecture design')).toBe(60_000);
+      expect(getTimeoutForTaskAuto('codex', 'Architecture design')).toBe(90_000);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/cli-timeout-profiles.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-timeout-profiles.ts
@@ -30,7 +30,7 @@ export interface TimeoutProfile {
 export const CLI_TIMEOUT_PROFILES: Record<string, TimeoutProfile> = {
   claude: { simple: 30_000, standard: 60_000, complex: 120_000 },
   gemini: { simple: 30_000, standard: 60_000, complex: 180_000 },
-  codex: { simple: 10_000, standard: 30_000, complex: 60_000 },
+  codex: { simple: 10_000, standard: 30_000, complex: 90_000 },
 };
 
 /** Default profile used when CLI is unknown. */

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -55,18 +55,19 @@ export {
   extractTextFromResponse,
   executeSingleVoteAttempt,
   validateTimeout,
+  resolveVoteTimeout,
   type RetryOptions,
   executeWithRetries,
 } from './voter-execution.js';
 
 // Import from execution module for internal use
 import {
-  DEFAULT_VOTE_TIMEOUT_MS,
   DEFAULT_MAX_RETRIES,
   createErrorVoteResult,
   createSimulationVoteResult,
   createSimulatedVotes,
   executeWithRetries,
+  resolveVoteTimeout,
 } from './voter-execution.js';
 
 // ============================================================================
@@ -81,7 +82,7 @@ export interface VoterAgentOptions {
   readonly logger?: ILogger;
   /** Model adapter to use (auto-selected if not provided) */
   readonly adapter?: IModelAdapter;
-  /** Timeout per vote in milliseconds (default: 30000) */
+  /** Timeout per vote in milliseconds (default: 120000, override via NEXUS_VOTE_TIMEOUT_MS) */
   readonly timeoutMs?: number;
   /** Maximum retries per vote (default: 2) */
   readonly maxRetries?: number;
@@ -108,7 +109,7 @@ export async function executeAgentVote(
   options?: { timeoutMs?: number; maxRetries?: number; allowSimulation?: boolean }
 ): Promise<AgentVoteResult> {
   const start = getTimeProvider().now();
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_VOTE_TIMEOUT_MS;
+  const timeoutMs = options?.timeoutMs ?? resolveVoteTimeout();
   const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
   const allowSimulation = options?.allowSimulation ?? false;
 
@@ -272,7 +273,7 @@ export async function collectRealVotes(
 ): Promise<readonly AgentVoteResult[]> {
   const logger = options.logger ?? defaultLogger;
   const { roles, proposal, simulate, allowSimulation } = options;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_VOTE_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? resolveVoteTimeout();
   const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
 
   if (simulate === true) {

--- a/packages/nexus-agents/src/cli/voter-execution.test.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.test.ts
@@ -22,6 +22,7 @@ import {
   executeSingleVoteAttempt,
   executeWithRetries,
   validateTimeout,
+  resolveVoteTimeout,
 } from './voter-execution.js';
 import type { VoterRole } from './vote-types.js';
 import type { IModelAdapter, CompletionResponse, ILogger, Result } from '../core/index.js';
@@ -32,8 +33,8 @@ type MockCompletionResult = Result<CompletionResponse, ModelError>;
 describe('voter-execution', () => {
   describe('constants', () => {
     it('should have reasonable timeout value', () => {
-      // Increased to 90s per Issue #607 to allow time for complex proposal analysis
-      expect(DEFAULT_VOTE_TIMEOUT_MS).toBe(90_000);
+      // Increased to 120s per Issue #983 to allow time for complex proposal analysis
+      expect(DEFAULT_VOTE_TIMEOUT_MS).toBe(120_000);
     });
 
     it('should have 5 minute max timeout', () => {
@@ -78,6 +79,43 @@ describe('voter-execution', () => {
       const maxResult = validateTimeout(MAX_VOTE_TIMEOUT_MS);
       expect(maxResult.value).toBe(MAX_VOTE_TIMEOUT_MS);
       expect(maxResult.clamped).toBe(false);
+    });
+  });
+
+  describe('resolveVoteTimeout (Issue #983)', () => {
+    const originalEnv = process.env['NEXUS_VOTE_TIMEOUT_MS'];
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env['NEXUS_VOTE_TIMEOUT_MS'] = originalEnv;
+      } else {
+        delete process.env['NEXUS_VOTE_TIMEOUT_MS'];
+      }
+    });
+
+    it('should return default when env var is not set', () => {
+      delete process.env['NEXUS_VOTE_TIMEOUT_MS'];
+      expect(resolveVoteTimeout()).toBe(DEFAULT_VOTE_TIMEOUT_MS);
+    });
+
+    it('should use env var value when set', () => {
+      process.env['NEXUS_VOTE_TIMEOUT_MS'] = '180000';
+      expect(resolveVoteTimeout()).toBe(180_000);
+    });
+
+    it('should clamp env var to min', () => {
+      process.env['NEXUS_VOTE_TIMEOUT_MS'] = '5000';
+      expect(resolveVoteTimeout()).toBe(MIN_VOTE_TIMEOUT_MS);
+    });
+
+    it('should clamp env var to max', () => {
+      process.env['NEXUS_VOTE_TIMEOUT_MS'] = '999999';
+      expect(resolveVoteTimeout()).toBe(MAX_VOTE_TIMEOUT_MS);
+    });
+
+    it('should ignore invalid env var values', () => {
+      process.env['NEXUS_VOTE_TIMEOUT_MS'] = 'not-a-number';
+      expect(resolveVoteTimeout()).toBe(DEFAULT_VOTE_TIMEOUT_MS);
     });
   });
 

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -16,11 +16,28 @@ import { VOTER_SYSTEM_PROMPTS, SIMULATED_VOTE_REASONING } from './voter-prompts.
 import { buildVotePrompt, parseVoteResponse, SyntheticVoteError } from './voter-response.js';
 
 /**
- * Default vote execution timeout (90 seconds).
- * Increased from 30s per Issue #607 - complex proposals require more time
- * for CLI agents to analyze and respond properly.
+ * Default vote execution timeout (120 seconds).
+ * Increased from 90s per Issue #983 - complex proposals with 6 agents
+ * need adequate time, especially on slower CLIs (Gemini/Codex).
+ * Override with NEXUS_VOTE_TIMEOUT_MS environment variable.
  */
-export const DEFAULT_VOTE_TIMEOUT_MS = 90_000;
+export const DEFAULT_VOTE_TIMEOUT_MS = 120_000;
+
+/**
+ * Resolves vote timeout from env var or returns default.
+ * NEXUS_VOTE_TIMEOUT_MS env var overrides the default, clamped to [MIN, MAX].
+ * (Source: Issue #983)
+ */
+export function resolveVoteTimeout(): number {
+  const envVal = process.env['NEXUS_VOTE_TIMEOUT_MS'];
+  if (envVal !== undefined) {
+    const parsed = Number(envVal);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return validateTimeout(parsed).value;
+    }
+  }
+  return DEFAULT_VOTE_TIMEOUT_MS;
+}
 
 /**
  * Maximum vote execution timeout (5 minutes).

--- a/packages/nexus-agents/src/config/defaults-timeout-profiles.ts
+++ b/packages/nexus-agents/src/config/defaults-timeout-profiles.ts
@@ -23,8 +23,8 @@ import { isKnownCliName } from './defaults-types.js';
  */
 export const TIMEOUT_PROFILES = {
   claude: { simple: 30_000, standard: 60_000, complex: 120_000 },
-  gemini: { simple: 15_000, standard: 45_000, complex: 90_000 },
-  codex: { simple: 10_000, standard: 30_000, complex: 60_000 },
+  gemini: { simple: 15_000, standard: 45_000, complex: 120_000 },
+  codex: { simple: 10_000, standard: 30_000, complex: 90_000 },
   /** Default profile for unknown CLIs */
   default: { simple: 30_000, standard: 60_000, complex: 120_000 },
 } as const satisfies Record<KnownCliName, TimeoutProfile>;

--- a/packages/nexus-agents/src/config/defaults.test.ts
+++ b/packages/nexus-agents/src/config/defaults.test.ts
@@ -104,13 +104,13 @@ describe('TIMEOUT_PROFILES', () => {
   it('should have correct Gemini profile values', () => {
     expect(TIMEOUT_PROFILES.gemini.simple).toBe(15_000);
     expect(TIMEOUT_PROFILES.gemini.standard).toBe(45_000);
-    expect(TIMEOUT_PROFILES.gemini.complex).toBe(90_000);
+    expect(TIMEOUT_PROFILES.gemini.complex).toBe(120_000);
   });
 
   it('should have correct Codex profile values', () => {
     expect(TIMEOUT_PROFILES.codex.simple).toBe(10_000);
     expect(TIMEOUT_PROFILES.codex.standard).toBe(30_000);
-    expect(TIMEOUT_PROFILES.codex.complex).toBe(60_000);
+    expect(TIMEOUT_PROFILES.codex.complex).toBe(90_000);
   });
 });
 
@@ -304,7 +304,7 @@ describe('getTimeoutForCli', () => {
   });
 
   it('should return correct timeout for Gemini complex task', () => {
-    expect(getTimeoutForCli('gemini', 'complex')).toBe(90_000);
+    expect(getTimeoutForCli('gemini', 'complex')).toBe(120_000);
   });
 
   it('should use default profile for unknown CLI', () => {
@@ -410,10 +410,10 @@ describe('backward compatibility', () => {
     expect(TIMEOUT_PROFILES.claude.complex).toBe(120_000);
     expect(TIMEOUT_PROFILES.gemini.simple).toBe(15_000);
     expect(TIMEOUT_PROFILES.gemini.standard).toBe(45_000);
-    expect(TIMEOUT_PROFILES.gemini.complex).toBe(90_000);
+    expect(TIMEOUT_PROFILES.gemini.complex).toBe(120_000);
     expect(TIMEOUT_PROFILES.codex.simple).toBe(10_000);
     expect(TIMEOUT_PROFILES.codex.standard).toBe(30_000);
-    expect(TIMEOUT_PROFILES.codex.complex).toBe(60_000);
+    expect(TIMEOUT_PROFILES.codex.complex).toBe(90_000);
   });
 
   it('should match existing DEFAULT_TEST_RUNNER_CONFIG values', () => {

--- a/packages/nexus-agents/src/orchestration/consensus-plan-types.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan-types.ts
@@ -108,8 +108,8 @@ export interface ConsensusPlanResult {
 export const ConsensusPlanConfigSchema = z.object({
   /** Max CLIs to dispatch to (default: 3). */
   maxClis: z.number().int().min(1).max(4).default(3),
-  /** Per-CLI timeout in ms (default: 90_000). */
-  perCliTimeoutMs: z.number().int().min(1000).max(300_000).default(90_000),
+  /** Per-CLI timeout in ms (default: 120_000, increased per Issue #983). */
+  perCliTimeoutMs: z.number().int().min(1000).max(300_000).default(120_000),
   /** Max chars per CLI response (default: 8000). */
   maxOutputCharsPerCli: z.number().int().min(100).max(30_000).default(8000),
 });

--- a/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
@@ -86,7 +86,7 @@ describe('createDefaultPlanConfig', () => {
   it('returns expected defaults', () => {
     const config = createDefaultPlanConfig();
     expect(config.maxClis).toBe(3);
-    expect(config.perCliTimeoutMs).toBe(90_000);
+    expect(config.perCliTimeoutMs).toBe(120_000);
     expect(config.maxOutputCharsPerCli).toBe(8000);
   });
 });

--- a/packages/nexus-agents/src/orchestration/triangulated-review-types.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review-types.ts
@@ -77,8 +77,8 @@ export interface TriangulatedReviewResult {
 export const TriangulatedReviewConfigSchema = z.object({
   /** Max CLIs to dispatch to (default: 3). */
   maxClis: z.number().int().min(1).max(4).default(3),
-  /** Per-CLI timeout in ms (default: 90_000). */
-  perCliTimeoutMs: z.number().int().min(1000).max(300_000).default(90_000),
+  /** Per-CLI timeout in ms (default: 120_000, increased per Issue #983). */
+  perCliTimeoutMs: z.number().int().min(1000).max(300_000).default(120_000),
   /** Max chars per CLI response (default: 8000). */
   maxOutputCharsPerCli: z.number().int().min(100).max(30_000).default(8000),
   /** Line proximity for dedup: findings within N lines are considered same (default: 5). */

--- a/packages/nexus-agents/src/orchestration/triangulated-review.test.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.test.ts
@@ -86,7 +86,7 @@ describe('createDefaultReviewConfig', () => {
   it('returns expected defaults', () => {
     const config = createDefaultReviewConfig();
     expect(config.maxClis).toBe(3);
-    expect(config.perCliTimeoutMs).toBe(90_000);
+    expect(config.perCliTimeoutMs).toBe(120_000);
     expect(config.maxOutputCharsPerCli).toBe(8000);
     expect(config.lineProximity).toBe(5);
   });


### PR DESCRIPTION
## Summary

- Increase per-agent vote timeout from 90s to 120s (`DEFAULT_VOTE_TIMEOUT_MS`)
- Increase Gemini complex CLI timeout from 90s to 120s
- Increase Codex complex CLI timeout from 60s to 90s
- Increase per-CLI timeout for consensus-plan and triangulated-review from 90s to 120s
- Add `resolveVoteTimeout()` with `NEXUS_VOTE_TIMEOUT_MS` env var override
- All test assertions updated for new timeout values

Addresses frequent timeouts on complex consensus voting with 6 agents. Follow-up centralization tracked in #984.

## Test plan

- [x] voter-execution tests (49 tests) — new `resolveVoteTimeout` tests added
- [x] config defaults tests (51 tests) — updated timeout assertions
- [x] cli-timeout-profiles tests (42 tests) — updated Codex complex assertion
- [x] consensus-plan tests — updated perCliTimeoutMs
- [x] triangulated-review tests — updated perCliTimeoutMs
- [x] Export contract tests (52 tests) pass
- [x] Build clean (ESM + DTS)
- [x] Fitness: 98/100

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)