### PR TITLE
feat(#982): Enhanced Claude Code status line for swarm monitoring

### DIFF
--- a/docs/guides/claude-code-observability/README.md
+++ b/docs/guides/claude-code-observability/README.md
@@ -11,7 +11,7 @@ nexus-agents provides three layers of observability for Claude Code users:
 | --------------- | ---------------------------------- | ------------------------------------------------- |
 | **MCP Logging** | `notifications/message` (built-in) | Structured events in Claude Code's verbose output |
 | **Hooks**       | Claude Code hooks config           | Tool invocation logging to a state file           |
-| **Status Line** | Claude Code status line            | Persistent bottom bar showing active tools/models |
+| **Status Line** | Claude Code status line            | 2-line dashboard with swarm health and weather    |
 
 ## Layer 1: MCP Logging Notifications (Built-in)
 
@@ -50,6 +50,17 @@ chmod +x .claude/nexus-hook.sh
 ```json
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/nexus-hook.sh session",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "mcp__nexus-agents__.*",
@@ -78,22 +89,41 @@ chmod +x .claude/nexus-hook.sh
 }
 ```
 
-The hook script logs tool invocations to `/tmp/nexus-agents-session.json`, which the
-status line script reads.
+The hook script logs tool invocations to `/tmp/nexus-agents-{session_id}.json` with
+`0600` permissions and `flock` for atomic updates.
 
-### What Gets Logged
+### State File Schema (v2)
 
-Each tool invocation records:
+Each session gets its own state file tracking:
 
-- Tool name (e.g., `orchestrate`, `consensus_vote`)
-- Timestamp
-- Duration (for PostToolUse events)
-- Cumulative session statistics (total calls, calls per tool)
+| Field        | Description                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------- |
+| `toolCounts` | Per-group counters: delegate, vote, orchestrate, expert, workflow, graph, research, memory, other |
+| `lastModel`  | Most recent model routed by `delegate_to_model`                                                   |
+| `experts`    | Active and completed expert types                                                                 |
+| `vote`       | Current/last vote: proposal, agents voted, approve/reject counts, strategy                        |
+| `graph`      | Graph pipeline: workflow name, total steps, completed nodes                                       |
+| `cliUsage`   | Per-CLI (claude/gemini/codex) call counts and success/failure                                     |
+| `activity`   | Rolling buffer of last 5 tool invocations with status                                             |
+
+### Tool Group Mapping
+
+| Tools                             | Group       |
+| --------------------------------- | ----------- |
+| `delegate_to_model`               | delegate    |
+| `consensus_vote`                  | vote        |
+| `orchestrate`                     | orchestrate |
+| `create_expert`, `execute_expert` | expert      |
+| `run_workflow`, `execute_spec`    | workflow    |
+| `run_graph_workflow`              | graph       |
+| `research_*`                      | research    |
+| `memory_*`                        | memory      |
+| Everything else                   | other       |
 
 ## Layer 3: Status Line
 
-The status line shows a persistent bar at the bottom of Claude Code with
-nexus-agents activity.
+The status line shows a persistent 2-line dashboard at the bottom of Claude Code
+with real-time swarm monitoring.
 
 ### Setup
 
@@ -117,26 +147,56 @@ chmod +x .claude/nexus-statusline.sh
 
 ### What It Shows
 
+**Line 1 — Primary (identity, activity, budget):**
+
 ```
-[nexus] orchestrate | claude-opus | 3 tools | 2 experts | 1 vote
+● claude-opus  → orchestrate  tools 12  experts 3  votes 1 (5:0)  $1.24  ctx ▓▓▓▓▓▓░░░░ 67%
 ```
 
-- **Active tool**: Currently running nexus-agents tool (or last completed)
-- **Last model**: Most recent model routed by delegate_to_model
-- **Tool count**: Total nexus-agents tool calls this session
-- **Expert count**: Number of expert executions
-- **Vote count**: Number of consensus votes
+- **Health dot**: Green (healthy), yellow (CLI failures), red (last tool errored)
+- **Model**: Last model routed by delegate_to_model (or session model)
+- **Active tool**: Currently running tool (yellow) or last completed (dim)
+- **Counters**: Total tools, experts, votes (with approve:reject ratio)
+- **Graph**: Step X/N when a graph workflow is running
+- **Cost**: Session cost from Claude Code
+- **Context gauge**: 10-char bar with color thresholds (green <60%, yellow 60-84%, red ≥85%)
+
+**Line 2 — Secondary (weather, session):**
+
+```
+weather  claude █████ 100%   gemini ████░ 80%   codex ███░░ 60%  session 14m · 38 calls
+```
+
+- **Per-CLI weather**: Success rate bars (5-char) with color coding
+- **Session**: Uptime and total tool calls
+
+### Color Thresholds
+
+| Metric        | Green   | Yellow   | Red   |
+| ------------- | ------- | -------- | ----- |
+| Health dot    | Healthy | CLI fail | Error |
+| CLI success   | ≥ 80%   | 60-79%   | < 60% |
+| Context usage | < 60%   | 60-84%   | ≥ 85% |
+
+### Graceful Degradation
+
+The status line adapts to available data:
+
+- **No state file**: Shows minimal `● nexus model $cost ctx X%`
+- **No routing data**: Shows `weather  no routing data` on line 2
+- **No graph running**: Graph section omitted
+- **No votes/experts**: Counter sections omitted
 
 ## Combining All Three
 
 For maximum observability, use all three layers together. MCP logging provides
 detailed events for debugging, hooks capture tool lifecycle data, and the status
-line gives at-a-glance awareness.
+line gives at-a-glance awareness of the multi-agent swarm.
 
 ## Files in This Directory
 
-| File                  | Purpose                                          |
-| --------------------- | ------------------------------------------------ |
-| `nexus-hook.sh`       | Hook script for PreToolUse/PostToolUse events    |
-| `nexus-statusline.sh` | Status line script showing nexus-agents activity |
-| `README.md`           | This guide                                       |
+| File                  | Purpose                                             |
+| --------------------- | --------------------------------------------------- |
+| `nexus-hook.sh`       | Hook script for SessionStart/PreToolUse/PostToolUse |
+| `nexus-statusline.sh` | 2-line status line dashboard                        |
+| `README.md`           | This guide                                          |

--- a/docs/guides/claude-code-observability/nexus-hook.sh
+++ b/docs/guides/claude-code-observability/nexus-hook.sh
@@ -1,91 +1,222 @@
 #!/usr/bin/env bash
-# nexus-agents Claude Code Hook Script
+# nexus-agents Claude Code Hook Script (v2)
 #
-# Logs nexus-agents MCP tool invocations to a state file for
-# the status line script to read.
+# Tracks nexus-agents MCP tool invocations in a session state file.
+# Supports PreToolUse, PostToolUse, and SessionStart hooks.
+#
+# State schema v2: per-tool counters, expert tracking, vote progress,
+# graph pipeline state, per-CLI usage, activity ring buffer.
 #
 # Usage in .claude/settings.json:
 #   "hooks": {
+#     "SessionStart": [{ "hooks": [{ "type": "command", "command": ".claude/nexus-hook.sh session" }] }],
 #     "PreToolUse": [{ "matcher": "mcp__nexus-agents__.*", "hooks": [{ "type": "command", "command": ".claude/nexus-hook.sh pre" }] }],
 #     "PostToolUse": [{ "matcher": "mcp__nexus-agents__.*", "hooks": [{ "type": "command", "command": ".claude/nexus-hook.sh post" }] }]
 #   }
 #
-# (Source: Issue #977, Epic #973 — Claude Code Observability)
+# Security: State file uses session ID in path (CWE-377 mitigation).
+# Permissions: 0600 (owner read/write only).
+#
+# (Source: Issue #982, Epic #973 — Claude Code Observability)
 
 set -euo pipefail
 
 PHASE="${1:-post}"
-STATE_FILE="/tmp/nexus-agents-session.json"
-LOCK_FILE="/tmp/nexus-agents-session.lock"
 
 # Read hook input from stdin
 INPUT=$(cat)
 
-# Extract tool name (strip mcp__nexus-agents__ prefix)
-FULL_TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
-TOOL="${FULL_TOOL#mcp__nexus-agents__}"
-TIMESTAMP=$(date +%s)
+# Extract session ID for per-session state file
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null || echo "default")
+STATE_FILE="/tmp/nexus-agents-${SESSION_ID}.json"
+LOCK_FILE="/tmp/nexus-agents-${SESSION_ID}.lock"
 
-# Ensure state file exists with defaults
-if [ ! -f "$STATE_FILE" ]; then
-  cat > "$STATE_FILE" << 'INIT'
-{"active_tool":null,"last_tool":null,"last_model":null,"total_calls":0,"expert_calls":0,"vote_calls":0,"workflow_calls":0,"delegate_calls":0,"orchestrate_calls":0,"last_updated":0}
+# Map tool name to group
+map_tool_group() {
+  case "$1" in
+    delegate_to_model)                     echo "delegate" ;;
+    consensus_vote)                        echo "vote" ;;
+    orchestrate)                           echo "orchestrate" ;;
+    create_expert|execute_expert)          echo "expert" ;;
+    run_workflow|execute_spec)             echo "workflow" ;;
+    run_graph_workflow)                    echo "graph" ;;
+    research_query|research_add|research_discover|research_analyze|research_catalog_review)
+                                           echo "research" ;;
+    memory_query|memory_stats)             echo "memory" ;;
+    *)                                     echo "other" ;;
+  esac
+}
+
+# Initialize state file for new session
+init_state() {
+  local TS
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  cat > "$STATE_FILE" << INIT
+{"version":2,"sessionId":"${SESSION_ID}","startTime":"${TS}","totalCalls":0,"toolCounts":{"delegate":0,"vote":0,"orchestrate":0,"expert":0,"workflow":0,"graph":0,"research":0,"memory":0,"other":0},"lastModel":null,"lastToolError":false,"experts":{"active":{},"completed":[]},"vote":{"proposal":null,"agentsVoted":0,"agentsTotal":6,"approve":0,"reject":0,"strategy":null},"graph":{"workflow":null,"currentStep":0,"totalSteps":0,"completedNodes":0},"cliUsage":{"claude":{"calls":0,"ok":0,"fail":0},"gemini":{"calls":0,"ok":0,"fail":0},"codex":{"calls":0,"ok":0,"fail":0}},"activity":[],"lastUpdate":"${TS}"}
 INIT
-fi
+  chmod 0600 "$STATE_FILE"
+}
 
-# Use flock for atomic updates (if available)
+# Main update logic
 do_update() {
+  local TS
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # SessionStart: initialize fresh state
+  if [ "$PHASE" = "session" ]; then
+    init_state
+    echo '{}'
+    return
+  fi
+
+  # Ensure state file exists
+  if [ ! -f "$STATE_FILE" ]; then
+    init_state
+  fi
+
   local STATE
   STATE=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
 
+  # Check schema version, reinitialize if v1
+  local VER
+  VER=$(echo "$STATE" | jq -r '.version // 1' 2>/dev/null || echo "1")
+  if [ "$VER" != "2" ]; then
+    init_state
+    STATE=$(cat "$STATE_FILE")
+  fi
+
+  # Extract tool name
+  local FULL_TOOL TOOL GROUP
+  FULL_TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  TOOL="${FULL_TOOL#mcp__nexus-agents__}"
+  GROUP=$(map_tool_group "$TOOL")
+
   if [ "$PHASE" = "pre" ]; then
-    # Mark tool as active
-    STATE=$(echo "$STATE" | jq --arg tool "$TOOL" --argjson ts "$TIMESTAMP" '
-      .active_tool = $tool |
-      .last_updated = $ts
+    # PreToolUse: increment counter, push activity, tool-specific pre-processing
+    STATE=$(echo "$STATE" | jq \
+      --arg tool "$TOOL" \
+      --arg group "$GROUP" \
+      --arg ts "$TS" '
+      .totalCalls += 1 |
+      .toolCounts[$group] = ((.toolCounts[$group] // 0) + 1) |
+      .lastToolError = false |
+      .lastUpdate = $ts |
+      .activity = ([{"tool": $tool, "status": "running", "ts": $ts}] + .activity)[:5]
     ')
+
+    # Tool-specific PreToolUse enrichment
+    case "$GROUP" in
+      expert)
+        if [ "$TOOL" = "create_expert" ]; then
+          local ROLE
+          ROLE=$(echo "$INPUT" | jq -r '.tool_input.role // "unknown"' 2>/dev/null || echo "unknown")
+          STATE=$(echo "$STATE" | jq --arg r "$ROLE" '.experts.active[$r] = "started"')
+        fi
+        ;;
+      vote)
+        local PROPOSAL STRATEGY
+        PROPOSAL=$(echo "$INPUT" | jq -r '.tool_input.proposal // "" | .[0:80]' 2>/dev/null || echo "")
+        STRATEGY=$(echo "$INPUT" | jq -r '.tool_input.strategy // "majority"' 2>/dev/null || echo "majority")
+        STATE=$(echo "$STATE" | jq \
+          --arg p "$PROPOSAL" \
+          --arg s "$STRATEGY" '
+          .vote.proposal = $p |
+          .vote.strategy = $s |
+          .vote.agentsVoted = 0 |
+          .vote.approve = 0 |
+          .vote.reject = 0
+        ')
+        ;;
+      graph)
+        local WORKFLOW
+        WORKFLOW=$(echo "$INPUT" | jq -r '.tool_input.workflow // "unknown"' 2>/dev/null || echo "unknown")
+        STATE=$(echo "$STATE" | jq --arg w "$WORKFLOW" '
+          .graph.workflow = $w |
+          .graph.currentStep = 0 |
+          .graph.totalSteps = 0 |
+          .graph.completedNodes = 0
+        ')
+        ;;
+    esac
+
   else
-    # Post: update counters and clear active
-    local TOTAL
-    TOTAL=$(echo "$STATE" | jq -r '.total_calls // 0')
-    TOTAL=$((TOTAL + 1))
+    # PostToolUse: extract results, update activity status
+    local HAS_ERROR
+    HAS_ERROR=$(echo "$INPUT" | jq -r 'if .tool_response then (.tool_response | test("isError.*true"; "i") // false) else false end' 2>/dev/null || echo "false")
 
     STATE=$(echo "$STATE" | jq \
       --arg tool "$TOOL" \
-      --argjson ts "$TIMESTAMP" \
-      --argjson total "$TOTAL" '
-      .active_tool = null |
-      .last_tool = $tool |
-      .total_calls = $total |
-      .last_updated = $ts
+      --arg ts "$TS" \
+      --argjson err "$HAS_ERROR" '
+      .lastUpdate = $ts |
+      .lastToolError = $err |
+      (.activity[0] // {}).status = (if $err then "failed" else "done" end)
     ')
 
-    # Increment tool-specific counters
-    case "$TOOL" in
-      execute_expert)
-        STATE=$(echo "$STATE" | jq '.expert_calls = (.expert_calls // 0) + 1') ;;
-      consensus_vote)
-        STATE=$(echo "$STATE" | jq '.vote_calls = (.vote_calls // 0) + 1') ;;
-      run_workflow|run_graph_workflow)
-        STATE=$(echo "$STATE" | jq '.workflow_calls = (.workflow_calls // 0) + 1') ;;
-      delegate_to_model)
-        STATE=$(echo "$STATE" | jq '.delegate_calls = (.delegate_calls // 0) + 1')
-        # Try to extract the recommended model from tool response
-        local MODEL
-        MODEL=$(echo "$INPUT" | jq -r '.tool_response // "" | if type == "string" then (fromjson? // {}) else . end | .recommended_model // empty' 2>/dev/null || true)
+    # Tool-specific PostToolUse enrichment
+    case "$GROUP" in
+      delegate)
+        # Extract model and CLI from response
+        local RESP MODEL CLI
+        RESP=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null || echo "")
+        MODEL=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .recommendation.model // empty' 2>/dev/null || true)
+        CLI=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .recommendation.cli // empty' 2>/dev/null || true)
         if [ -n "$MODEL" ]; then
-          STATE=$(echo "$STATE" | jq --arg m "$MODEL" '.last_model = $m')
+          STATE=$(echo "$STATE" | jq --arg m "$MODEL" '.lastModel = $m')
+        fi
+        if [ -n "$CLI" ]; then
+          STATE=$(echo "$STATE" | jq --arg c "$CLI" '
+            .cliUsage[$c].calls = ((.cliUsage[$c].calls // 0) + 1) |
+            .cliUsage[$c].ok = ((.cliUsage[$c].ok // 0) + 1)
+          ')
         fi
         ;;
-      orchestrate)
-        STATE=$(echo "$STATE" | jq '.orchestrate_calls = (.orchestrate_calls // 0) + 1') ;;
+      expert)
+        if [ "$TOOL" = "execute_expert" ]; then
+          local ROLE
+          ROLE=$(echo "$INPUT" | jq -r '.tool_input.expertId // "" | split("-") | .[0] // "unknown"' 2>/dev/null || echo "unknown")
+          STATE=$(echo "$STATE" | jq --arg r "$ROLE" '
+            .experts.active |= (del(.[$r]) // {}) |
+            .experts.completed = ((.experts.completed // []) + [$r])[:10]
+          ')
+        fi
+        ;;
+      vote)
+        # Extract vote results
+        local RESP VOTED APPROVE REJECT
+        RESP=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null || echo "")
+        VOTED=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .voteCounts | ((.approve // 0) + (.reject // 0) + (.abstain // 0))' 2>/dev/null || echo "0")
+        APPROVE=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .voteCounts.approve // 0' 2>/dev/null || echo "0")
+        REJECT=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .voteCounts.reject // 0' 2>/dev/null || echo "0")
+        STATE=$(echo "$STATE" | jq \
+          --argjson v "$VOTED" \
+          --argjson a "$APPROVE" \
+          --argjson r "$REJECT" '
+          .vote.agentsVoted = $v |
+          .vote.approve = $a |
+          .vote.reject = $r
+        ')
+        ;;
+      graph)
+        # Extract graph execution results
+        local RESP STEPS NODES
+        RESP=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null || echo "")
+        STEPS=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .totalSteps // 0' 2>/dev/null || echo "0")
+        NODES=$(echo "$RESP" | jq -r 'if type == "string" then (fromjson? // {}) else . end | .completedNodes // 0' 2>/dev/null || echo "0")
+        STATE=$(echo "$STATE" | jq \
+          --argjson s "$STEPS" \
+          --argjson n "$NODES" '
+          .graph.totalSteps = $s |
+          .graph.completedNodes = $n
+        ')
+        ;;
     esac
   fi
 
   echo "$STATE" > "$STATE_FILE"
 }
 
-# Try flock for atomicity, fall back to direct write
+# Use flock for atomic updates (if available)
 if command -v flock >/dev/null 2>&1; then
   (
     flock -w 2 200 || true

--- a/docs/guides/claude-code-observability/nexus-statusline.sh
+++ b/docs/guides/claude-code-observability/nexus-statusline.sh
@@ -1,76 +1,201 @@
 #!/usr/bin/env bash
-# nexus-agents Claude Code Status Line Script
+# nexus-agents Claude Code Status Line Script (v2)
 #
-# Reads from the hook state file and displays nexus-agents activity
-# in Claude Code's persistent status bar.
+# Two-line dashboard showing real-time swarm monitoring:
+#   Line 1: Health dot + model + active tool + counters + cost + context gauge
+#   Line 2: Per-CLI weather bars + session trend
+#
+# Reads from: hook state file + Claude Code session JSON (stdin)
 #
 # Usage in ~/.claude/settings.json:
 #   "statusLine": { "type": "command", "command": ".claude/nexus-statusline.sh" }
 #
-# (Source: Issue #977, Epic #973 — Claude Code Observability)
+# (Source: Issue #982, Epic #973 — Claude Code Observability)
 
 set -euo pipefail
-
-STATE_FILE="/tmp/nexus-agents-session.json"
-
-# Read session JSON from stdin (provided by Claude Code)
-cat > /dev/null
-
-# Check if state file exists
-if [ ! -f "$STATE_FILE" ]; then
-  echo "[nexus] idle"
-  exit 0
-fi
-
-STATE=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
-
-# Extract fields
-ACTIVE=$(echo "$STATE" | jq -r '.active_tool // empty')
-LAST_TOOL=$(echo "$STATE" | jq -r '.last_tool // empty')
-LAST_MODEL=$(echo "$STATE" | jq -r '.last_model // empty')
-TOTAL=$(echo "$STATE" | jq -r '.total_calls // 0')
-EXPERTS=$(echo "$STATE" | jq -r '.expert_calls // 0')
-VOTES=$(echo "$STATE" | jq -r '.vote_calls // 0')
 
 # ANSI colors
 GREEN='\033[32m'
 YELLOW='\033[33m'
+RED='\033[31m'
 CYAN='\033[36m'
 DIM='\033[2m'
+BOLD='\033[1m'
 RESET='\033[0m'
 
-# Build status line
-if [ -n "$ACTIVE" ]; then
-  # Tool is currently running
-  TOOL_PART="${YELLOW}${ACTIVE}${RESET}"
-elif [ -n "$LAST_TOOL" ]; then
-  TOOL_PART="${DIM}${LAST_TOOL}${RESET}"
-else
-  TOOL_PART="${DIM}idle${RESET}"
+# Read Claude Code session JSON from stdin
+SESSION_JSON=$(cat)
+
+# Extract session data (cost, context, model)
+CTX_PCT=$(echo "$SESSION_JSON" | jq -r '.context_window.used_percentage // 0' 2>/dev/null || echo "0")
+COST=$(echo "$SESSION_JSON" | jq -r '.cost.total_cost_usd // 0' 2>/dev/null || echo "0")
+MODEL=$(echo "$SESSION_JSON" | jq -r '.model.display_name // .model.id // "unknown"' 2>/dev/null || echo "unknown")
+
+# Find state file (prefer session-specific, fall back to default)
+SESSION_ID=$(echo "$SESSION_JSON" | jq -r '.session_id // "default"' 2>/dev/null || echo "default")
+STATE_FILE="/tmp/nexus-agents-${SESSION_ID}.json"
+if [ ! -f "$STATE_FILE" ]; then
+  STATE_FILE="/tmp/nexus-agents-default.json"
 fi
 
-# Model part
-if [ -n "$LAST_MODEL" ]; then
-  MODEL_PART=" ${CYAN}${LAST_MODEL}${RESET}"
+# Load state (or empty defaults)
+if [ -f "$STATE_FILE" ]; then
+  STATE=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
 else
-  MODEL_PART=""
+  # No state file — show minimal status
+  echo -e "${DIM}●${RESET} ${DIM}nexus${RESET}  ${DIM}${MODEL}${RESET}  ${DIM}\$${COST}${RESET}  ${DIM}ctx ${CTX_PCT}%${RESET}"
+  exit 0
 fi
 
-# Stats
-STATS_PARTS=""
+# ── Extract state fields ──────────────────────────────────────────────
+TOTAL=$(echo "$STATE" | jq -r '.totalCalls // 0')
+LAST_MODEL=$(echo "$STATE" | jq -r '.lastModel // empty')
+LAST_ERROR=$(echo "$STATE" | jq -r '.lastToolError // false')
+EXPERTS_DONE=$(echo "$STATE" | jq -r '.experts.completed | length // 0' 2>/dev/null || echo "0")
+EXPERTS_ACTIVE=$(echo "$STATE" | jq -r '.experts.active | length // 0' 2>/dev/null || echo "0")
+VOTE_APPROVE=$(echo "$STATE" | jq -r '.vote.approve // 0')
+VOTE_REJECT=$(echo "$STATE" | jq -r '.vote.reject // 0')
+VOTE_TOTAL=$(echo "$STATE" | jq -r '.vote.agentsVoted // 0')
+VOTES_DONE=$(echo "$STATE" | jq -r '.toolCounts.vote // 0')
+GRAPH_WF=$(echo "$STATE" | jq -r '.graph.workflow // empty')
+GRAPH_STEPS=$(echo "$STATE" | jq -r '.graph.totalSteps // 0')
+GRAPH_NODES=$(echo "$STATE" | jq -r '.graph.completedNodes // 0')
+DELEGATES=$(echo "$STATE" | jq -r '.toolCounts.delegate // 0')
+CLI_CLAUDE_OK=$(echo "$STATE" | jq -r '.cliUsage.claude.ok // 0')
+CLI_CLAUDE_FAIL=$(echo "$STATE" | jq -r '.cliUsage.claude.fail // 0')
+CLI_CLAUDE_CALLS=$(echo "$STATE" | jq -r '.cliUsage.claude.calls // 0')
+CLI_GEMINI_OK=$(echo "$STATE" | jq -r '.cliUsage.gemini.ok // 0')
+CLI_GEMINI_FAIL=$(echo "$STATE" | jq -r '.cliUsage.gemini.fail // 0')
+CLI_GEMINI_CALLS=$(echo "$STATE" | jq -r '.cliUsage.gemini.calls // 0')
+CLI_CODEX_OK=$(echo "$STATE" | jq -r '.cliUsage.codex.ok // 0')
+CLI_CODEX_FAIL=$(echo "$STATE" | jq -r '.cliUsage.codex.fail // 0')
+CLI_CODEX_CALLS=$(echo "$STATE" | jq -r '.cliUsage.codex.calls // 0')
+ACTIVITY_TOOL=$(echo "$STATE" | jq -r '.activity[0].tool // empty' 2>/dev/null || true)
+ACTIVITY_STATUS=$(echo "$STATE" | jq -r '.activity[0].status // empty' 2>/dev/null || true)
+
+# ── Helper: render gauge bar (10 chars) ───────────────────────────────
+render_gauge() {
+  local pct="$1" color="$2"
+  local filled=$((pct / 10))
+  local empty=$((10 - filled))
+  local bar=""
+  for ((i=0; i<filled; i++)); do bar+="▓"; done
+  for ((i=0; i<empty; i++)); do bar+="░"; done
+  echo -e "${color}${bar}${RESET}"
+}
+
+# ── Helper: CLI success rate with color ───────────────────────────────
+cli_rate() {
+  local ok="$1" calls="$2" name="$3"
+  if [ "$calls" -eq 0 ]; then
+    echo -e "${DIM}${name}:—${RESET}"
+    return
+  fi
+  local pct=$((ok * 100 / calls))
+  local color="$GREEN"
+  if [ "$pct" -lt 60 ]; then color="$RED"
+  elif [ "$pct" -lt 80 ]; then color="$YELLOW"
+  fi
+  # Mini bar (5 chars)
+  local filled=$((pct / 20))
+  local empty=$((5 - filled))
+  local bar=""
+  for ((i=0; i<filled; i++)); do bar+="█"; done
+  for ((i=0; i<empty; i++)); do bar+="░"; done
+  echo -e "${DIM}${name}${RESET} ${color}${bar}${RESET} ${color}${pct}%${RESET}"
+}
+
+# ── Health dot ────────────────────────────────────────────────────────
+HEALTH_DOT="${GREEN}●${RESET}"
+if [ "$LAST_ERROR" = "true" ]; then
+  HEALTH_DOT="${RED}●${RESET}"
+elif [ "$CLI_GEMINI_FAIL" -gt 0 ] || [ "$CLI_CODEX_FAIL" -gt 0 ] || [ "$CLI_CLAUDE_FAIL" -gt 0 ]; then
+  HEALTH_DOT="${YELLOW}●${RESET}"
+fi
+
+# ── Active tool / last tool ───────────────────────────────────────────
+TOOL_PART=""
+if [ "$ACTIVITY_STATUS" = "running" ] && [ -n "$ACTIVITY_TOOL" ]; then
+  TOOL_PART=" ${DIM}→${RESET} ${YELLOW}${ACTIVITY_TOOL}${RESET}"
+elif [ -n "$ACTIVITY_TOOL" ]; then
+  TOOL_PART=" ${DIM}→${RESET} ${DIM}${ACTIVITY_TOOL}${RESET}"
+fi
+
+# ── Display model (prefer last routed model, fall back to session model)
+DISPLAY_MODEL="${LAST_MODEL:-$MODEL}"
+
+# ── Counters ──────────────────────────────────────────────────────────
+COUNTERS=""
 if [ "$TOTAL" -gt 0 ]; then
-  STATS_PARTS="${GREEN}${TOTAL}${RESET} tools"
+  COUNTERS="${DIM}tools${RESET} ${GREEN}${TOTAL}${RESET}"
 fi
-if [ "$EXPERTS" -gt 0 ]; then
-  STATS_PARTS="${STATS_PARTS:+${STATS_PARTS} | }${GREEN}${EXPERTS}${RESET} experts"
+EXPERT_COUNT=$((EXPERTS_DONE + EXPERTS_ACTIVE))
+if [ "$EXPERT_COUNT" -gt 0 ]; then
+  COUNTERS="${COUNTERS:+${COUNTERS}  }${DIM}experts${RESET} ${GREEN}${EXPERT_COUNT}${RESET}"
 fi
-if [ "$VOTES" -gt 0 ]; then
-  STATS_PARTS="${STATS_PARTS:+${STATS_PARTS} | }${GREEN}${VOTES}${RESET} votes"
+if [ "$VOTES_DONE" -gt 0 ]; then
+  VOTE_DETAIL=""
+  if [ "$VOTE_TOTAL" -gt 0 ]; then
+    VOTE_DETAIL=" ${DIM}(${VOTE_APPROVE}:${VOTE_REJECT})${RESET}"
+  fi
+  COUNTERS="${COUNTERS:+${COUNTERS}  }${DIM}votes${RESET} ${GREEN}${VOTES_DONE}${RESET}${VOTE_DETAIL}"
 fi
 
-# Output
-if [ -n "$STATS_PARTS" ]; then
-  echo -e "[nexus] ${TOOL_PART}${MODEL_PART} | ${STATS_PARTS}"
-else
-  echo -e "[nexus] ${TOOL_PART}${MODEL_PART}"
+# ── Graph pipeline ────────────────────────────────────────────────────
+GRAPH_PART=""
+if [ -n "$GRAPH_WF" ] && [ "$GRAPH_STEPS" -gt 0 ]; then
+  GRAPH_PART="  ${DIM}graph${RESET} ${BOLD}${GRAPH_NODES}${RESET}${DIM}/${GRAPH_STEPS}${RESET}"
 fi
+
+# ── Context gauge ─────────────────────────────────────────────────────
+CTX_INT=${CTX_PCT%.*}
+CTX_INT=${CTX_INT:-0}
+CTX_COLOR="$GREEN"
+if [ "$CTX_INT" -ge 85 ]; then CTX_COLOR="$RED"
+elif [ "$CTX_INT" -ge 60 ]; then CTX_COLOR="$YELLOW"
+fi
+CTX_GAUGE=$(render_gauge "$CTX_INT" "$CTX_COLOR")
+
+# ── Cost (always dim) ────────────────────────────────────────────────
+COST_FMT=$(printf "%.2f" "$COST" 2>/dev/null || echo "0.00")
+
+# ══════════════════════════════════════════════════════════════════════
+# LINE 1: Health + model + tool + counters + graph + cost + context
+# ══════════════════════════════════════════════════════════════════════
+LINE1="${HEALTH_DOT} ${BOLD}${DISPLAY_MODEL}${RESET}${TOOL_PART}"
+if [ -n "$COUNTERS" ]; then
+  LINE1="${LINE1}  ${COUNTERS}"
+fi
+LINE1="${LINE1}${GRAPH_PART}  ${DIM}\$${COST_FMT}${RESET}  ${DIM}ctx${RESET} ${CTX_GAUGE} ${CTX_COLOR}${CTX_INT}%${RESET}"
+
+# ══════════════════════════════════════════════════════════════════════
+# LINE 2: Per-CLI weather + session info
+# ══════════════════════════════════════════════════════════════════════
+CLI_TOTAL=$((CLI_CLAUDE_CALLS + CLI_GEMINI_CALLS + CLI_CODEX_CALLS))
+
+if [ "$CLI_TOTAL" -gt 0 ]; then
+  C_RATE=$(cli_rate "$CLI_CLAUDE_OK" "$CLI_CLAUDE_CALLS" "claude")
+  G_RATE=$(cli_rate "$CLI_GEMINI_OK" "$CLI_GEMINI_CALLS" "gemini")
+  X_RATE=$(cli_rate "$CLI_CODEX_OK" "$CLI_CODEX_CALLS" "codex")
+  LINE2="${DIM}weather${RESET}  ${C_RATE}   ${G_RATE}   ${X_RATE}"
+elif [ "$DELEGATES" -gt 0 ]; then
+  LINE2="${DIM}weather${RESET}  ${DIM}collecting data...${RESET}"
+else
+  LINE2="${DIM}weather${RESET}  ${DIM}no routing data${RESET}"
+fi
+
+# Session uptime
+START_TIME=$(echo "$STATE" | jq -r '.startTime // empty' 2>/dev/null || true)
+if [ -n "$START_TIME" ]; then
+  START_EPOCH=$(date -d "$START_TIME" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$START_TIME" +%s 2>/dev/null || echo "0")
+  NOW_EPOCH=$(date +%s)
+  if [ "$START_EPOCH" -gt 0 ]; then
+    ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
+    MINS=$(( ELAPSED / 60 ))
+    LINE2="${LINE2}  ${DIM}session ${MINS}m · ${TOTAL} calls${RESET}"
+  fi
+fi
+
+# ── Output both lines ─────────────────────────────────────────────────
+echo -e "$LINE1"
+echo -e "$LINE2"


### PR DESCRIPTION
## Summary
- Rewrote `nexus-hook.sh` with state schema v2: SessionStart support, 9 tool groups, expert/vote/graph/CLI tracking, activity ring buffer, session-specific state files (CWE-377 mitigation), flock atomic writes
- Rewrote `nexus-statusline.sh` with 2-line dashboard: health dot, model routing, active tool, counters, graph pipeline progress, cost, 10-char context gauge, per-CLI weather bars, session uptime
- Updated README with setup guide, schema v2 documentation, and color threshold reference

## Test plan
- [x] Bash syntax validation (both scripts)
- [x] SessionStart hook: state file created with correct v2 schema
- [x] PreToolUse hook: counters increment, vote/expert/graph state enriched
- [x] PostToolUse hook: vote counts, delegate model/CLI, graph steps extracted
- [x] Status line with full state: all sections render correctly
- [x] Status line graceful degradation: minimal output with no state file
- [x] Context gauge color thresholds: green (<60%), yellow (60-84%), red (≥85%)

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)