### PR TITLE
feat(#988): Implement MemR3 reflective memory retrieval

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.ts
@@ -17,6 +17,15 @@ import type { SecurityConfig } from '../../config/schemas.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { getToolMemory, type UnifiedMemoryResult } from './tool-memory.js';
+import {
+  ReflectiveRetriever,
+  ReflectionCache,
+  isReflectiveMemoryEnabled,
+  isReflectiveShadowMode,
+  type ReflectionResult,
+} from './reflective-retriever.js';
+import type { IModelAdapter } from '../../core/index.js';
+import { createAutoAdapter } from '../../adapters/auto-adapter.js';
 
 // ============================================================================
 // Schema & Types
@@ -77,8 +86,44 @@ export interface MemoryQueryResponse {
 // Handler
 // ============================================================================
 
+/** Shared reflection cache (persists across tool calls). */
+let reflectionCache: ReflectionCache | undefined;
+
+/** Shared adapter for reflection (lazy-initialized). */
+let reflectionAdapter: IModelAdapter | undefined;
+
+/**
+ * Get or create the reflective retriever.
+ * Returns undefined if reflection is disabled or adapter unavailable.
+ */
+async function getReflectiveRetriever(logger: ILogger): Promise<ReflectiveRetriever | undefined> {
+  const enabled = isReflectiveMemoryEnabled();
+  const shadow = isReflectiveShadowMode();
+  if (!enabled && !shadow) return undefined;
+
+  if (reflectionAdapter === undefined) {
+    try {
+      const selection = await createAutoAdapter({ logger });
+      reflectionAdapter = selection.adapter;
+    } catch {
+      logger.warn('No adapter for reflection, using keyword retrieval');
+      return undefined;
+    }
+  }
+
+  reflectionCache ??= new ReflectionCache();
+
+  return new ReflectiveRetriever({
+    adapter: reflectionAdapter,
+    logger,
+    shadowMode: shadow,
+    cache: reflectionCache,
+  });
+}
+
 /**
  * Handles the memory_query tool execution.
+ * Optionally uses MemR3 reflective enhancement when enabled.
  */
 async function executeMemoryQuery(
   input: MemoryQueryInput,
@@ -86,8 +131,19 @@ async function executeMemoryQuery(
 ): Promise<MemoryQueryResponse> {
   const toolMemory = getToolMemory();
 
+  // MemR3: Optionally enhance query with reflective reasoning
+  let reflection: ReflectionResult | undefined;
+  const retriever = await getReflectiveRetriever(logger);
+  if (retriever !== undefined) {
+    reflection = await retriever.enhance(input.query);
+  }
+
+  // Use enhanced query if reflection succeeded, otherwise original
+  const effectiveQuery =
+    reflection?.reflected === true ? reflection.keywords.join(' ') : input.query;
+
   // Query all memory backends
-  let results = await toolMemory.queryAll(input.query, input.limit);
+  let results = await toolMemory.queryAll(effectiveQuery, input.limit);
 
   // Filter by source if specified
   if (input.source !== 'all') {
@@ -96,8 +152,11 @@ async function executeMemoryQuery(
 
   logger.debug('Memory query executed', {
     query: input.query,
+    effectiveQuery: effectiveQuery !== input.query ? effectiveQuery : undefined,
     resultCount: results.length,
     source: input.source,
+    reflectionSource: reflection?.source,
+    reflectionDurationMs: reflection?.durationMs,
   });
 
   return {

--- a/packages/nexus-agents/src/mcp/tools/reflective-retriever.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/reflective-retriever.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for MemR3 Reflective Memory Retriever
+ *
+ * @module mcp/tools/reflective-retriever.test
+ * (Source: Issue #988)
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  ReflectiveRetriever,
+  ReflectionCache,
+  ReflectionCriteriaSchema,
+  isReflectiveMemoryEnabled,
+  isReflectiveShadowMode,
+} from './reflective-retriever.js';
+import type { IModelAdapter } from '../../core/index.js';
+import { createLogger } from '../../core/index.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+const silentLogger = createLogger({ component: 'test', level: 'silent' });
+
+function createMockAdapter(response: string, delay = 0): IModelAdapter {
+  return {
+    modelId: 'test-model',
+    providerId: 'test',
+
+    complete: vi.fn(async () => {
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      return {
+        ok: true as const,
+        value: {
+          content: response,
+          model: 'test-model',
+          usage: { inputTokens: 10, outputTokens: 20 },
+        },
+      };
+    }),
+  } as unknown as IModelAdapter;
+}
+
+function createFailingAdapter(errorMessage: string): IModelAdapter {
+  return {
+    modelId: 'test-model',
+    providerId: 'test',
+    // eslint-disable-next-line @typescript-eslint/require-await
+    complete: vi.fn(async () => ({
+      ok: false as const,
+      error: { message: errorMessage, code: 'TEST_ERROR' },
+    })),
+  } as unknown as IModelAdapter;
+}
+
+// Valid reflection response
+const VALID_REFLECTION = JSON.stringify({
+  keywords: ['routing', 'model', 'selection', 'performance', 'latency'],
+  context: 'Past experiences with model routing and performance optimization',
+});
+
+// ============================================================================
+// ReflectionCriteriaSchema
+// ============================================================================
+
+describe('ReflectionCriteriaSchema', () => {
+  it('should parse valid criteria', () => {
+    const result = ReflectionCriteriaSchema.safeParse({
+      keywords: ['routing', 'model'],
+      context: 'About routing',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty keywords', () => {
+    const result = ReflectionCriteriaSchema.safeParse({
+      keywords: [],
+      context: 'About routing',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject too many keywords', () => {
+    const result = ReflectionCriteriaSchema.safeParse({
+      keywords: Array.from({ length: 11 }, (_, i) => `kw${String(i)}`),
+      context: 'Too many',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing context', () => {
+    const result = ReflectionCriteriaSchema.safeParse({
+      keywords: ['test'],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// ReflectionCache
+// ============================================================================
+
+describe('ReflectionCache', () => {
+  it('should store and retrieve criteria', () => {
+    const cache = new ReflectionCache();
+    const criteria = { keywords: ['test'], context: 'test context' };
+    cache.set('my query', criteria);
+    expect(cache.get('my query')).toEqual(criteria);
+  });
+
+  it('should normalize keys (case-insensitive, trimmed)', () => {
+    const cache = new ReflectionCache();
+    const criteria = { keywords: ['test'], context: 'ctx' };
+    cache.set('  My Query  ', criteria);
+    expect(cache.get('my query')).toEqual(criteria);
+    expect(cache.get('MY QUERY')).toEqual(criteria);
+  });
+
+  it('should return undefined for cache miss', () => {
+    const cache = new ReflectionCache();
+    expect(cache.get('unknown')).toBeUndefined();
+  });
+
+  it('should evict oldest entry when full', () => {
+    const cache = new ReflectionCache(2);
+    const c1 = { keywords: ['a'], context: 'a' };
+    const c2 = { keywords: ['b'], context: 'b' };
+    const c3 = { keywords: ['c'], context: 'c' };
+    cache.set('q1', c1);
+    cache.set('q2', c2);
+    cache.set('q3', c3); // Should evict q1
+    expect(cache.get('q1')).toBeUndefined();
+    expect(cache.get('q2')).toEqual(c2);
+    expect(cache.get('q3')).toEqual(c3);
+  });
+
+  it('should expire entries after TTL', () => {
+    vi.useFakeTimers();
+    const cache = new ReflectionCache(50, 1000); // 1s TTL
+    cache.set('q', { keywords: ['x'], context: 'x' });
+    expect(cache.get('q')).toBeDefined();
+    vi.advanceTimersByTime(1001);
+    expect(cache.get('q')).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it('should track size correctly', () => {
+    const cache = new ReflectionCache();
+    expect(cache.size).toBe(0);
+    cache.set('q1', { keywords: ['a'], context: 'a' });
+    expect(cache.size).toBe(1);
+    cache.set('q2', { keywords: ['b'], context: 'b' });
+    expect(cache.size).toBe(2);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// ReflectiveRetriever
+// ============================================================================
+
+describe('ReflectiveRetriever', () => {
+  it('should enhance query with LLM reflection', async () => {
+    const adapter = createMockAdapter(VALID_REFLECTION);
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('optimize model routing performance');
+
+    expect(result.reflected).toBe(true);
+    expect(result.source).toBe('llm');
+    expect(result.keywords.length).toBeGreaterThan(3);
+    // Should contain original keywords
+    expect(result.keywords).toContain('optimize');
+    expect(result.keywords).toContain('model');
+    // Should contain expanded keywords
+    expect(result.keywords).toContain('selection');
+    expect(result.keywords).toContain('latency');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should use cache on repeated queries', async () => {
+    const adapter = createMockAdapter(VALID_REFLECTION);
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    await retriever.enhance('test query');
+    const result = await retriever.enhance('test query');
+
+    expect(result.source).toBe('cache');
+    expect(result.reflected).toBe(true);
+    // Adapter should only be called once
+    expect(adapter.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fall back on adapter failure', async () => {
+    const adapter = createFailingAdapter('Connection failed');
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('test query here');
+
+    expect(result.reflected).toBe(false);
+    expect(result.source).toBe('fallback');
+    // Should return original keywords
+    expect(result.keywords).toContain('test');
+    expect(result.keywords).toContain('query');
+    expect(result.keywords).toContain('here');
+  });
+
+  it('should fall back on invalid JSON response', async () => {
+    const adapter = createMockAdapter('This is not JSON at all');
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('test query');
+
+    expect(result.reflected).toBe(false);
+    expect(result.source).toBe('fallback');
+  });
+
+  it('should fall back on timeout', async () => {
+    const adapter = createMockAdapter(VALID_REFLECTION, 5000); // 5s delay
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+      timeoutMs: 100, // 100ms timeout
+    });
+
+    const result = await retriever.enhance('test query');
+
+    expect(result.reflected).toBe(false);
+    expect(result.source).toBe('fallback');
+  });
+
+  it('should handle markdown-fenced JSON in response', async () => {
+    const fenced = '```json\n' + VALID_REFLECTION + '\n```';
+    const adapter = createMockAdapter(fenced);
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('test query');
+
+    expect(result.reflected).toBe(true);
+    expect(result.source).toBe('llm');
+  });
+
+  it('should deduplicate merged keywords', async () => {
+    const response = JSON.stringify({
+      keywords: ['test', 'query', 'new_keyword'],
+      context: 'Relevant context',
+    });
+    const adapter = createMockAdapter(response);
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('test query');
+
+    // 'test' and 'query' should not be duplicated
+    const unique = new Set(result.keywords);
+    expect(unique.size).toBe(result.keywords.length);
+  });
+
+  it('should filter short keywords from expansion', async () => {
+    const response = JSON.stringify({
+      keywords: ['ab', 'routing', 'x', 'performance'],
+      context: 'Context',
+    });
+    const adapter = createMockAdapter(response);
+    const retriever = new ReflectiveRetriever({
+      adapter,
+      logger: silentLogger,
+    });
+
+    const result = await retriever.enhance('test query');
+
+    // 'ab' and 'x' should be filtered (length <= 2)
+    expect(result.keywords).not.toContain('ab');
+    expect(result.keywords).not.toContain('x');
+    expect(result.keywords).toContain('routing');
+  });
+
+  describe('shadow mode', () => {
+    it('should log comparison but return original keywords', async () => {
+      const adapter = createMockAdapter(VALID_REFLECTION);
+      const retriever = new ReflectiveRetriever({
+        adapter,
+        logger: silentLogger,
+        shadowMode: true,
+      });
+
+      const result = await retriever.enhance('optimize routing');
+
+      expect(result.reflected).toBe(false);
+      expect(result.source).toBe('fallback');
+      // Should return only original keywords
+      expect(result.keywords).toContain('optimize');
+      expect(result.keywords).toContain('routing');
+      expect(result.keywords).not.toContain('latency');
+      // LLM should still have been called
+      expect(adapter.complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cache criteria even in shadow mode', async () => {
+      const adapter = createMockAdapter(VALID_REFLECTION);
+      const cache = new ReflectionCache();
+      const retriever = new ReflectiveRetriever({
+        adapter,
+        logger: silentLogger,
+        shadowMode: true,
+        cache,
+      });
+
+      await retriever.enhance('test query');
+
+      // Criteria should be cached for later non-shadow use
+      expect(cache.get('test query')).toBeDefined();
+    });
+  });
+});
+
+// ============================================================================
+// Feature Flags
+// ============================================================================
+
+describe('feature flags', () => {
+  const originalEnv = process.env.NEXUS_REFLECTIVE_MEMORY;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.NEXUS_REFLECTIVE_MEMORY = originalEnv;
+    } else {
+      delete process.env.NEXUS_REFLECTIVE_MEMORY;
+    }
+  });
+
+  it('should be disabled by default', () => {
+    delete process.env.NEXUS_REFLECTIVE_MEMORY;
+    expect(isReflectiveMemoryEnabled()).toBe(false);
+    expect(isReflectiveShadowMode()).toBe(false);
+  });
+
+  it('should be enabled when set to true', () => {
+    process.env.NEXUS_REFLECTIVE_MEMORY = 'true';
+    expect(isReflectiveMemoryEnabled()).toBe(true);
+    expect(isReflectiveShadowMode()).toBe(false);
+  });
+
+  it('should detect shadow mode', () => {
+    process.env.NEXUS_REFLECTIVE_MEMORY = 'shadow';
+    expect(isReflectiveMemoryEnabled()).toBe(false);
+    expect(isReflectiveShadowMode()).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/reflective-retriever.ts
+++ b/packages/nexus-agents/src/mcp/tools/reflective-retriever.ts
@@ -1,0 +1,357 @@
+/**
+ * MemR3 Reflective Memory Retriever
+ *
+ * Enhances memory retrieval by using an LLM reasoning step to generate
+ * structured relevance criteria before keyword-based search.
+ * Based on MemR3 (arXiv:2512.20237).
+ *
+ * Feature-gated via NEXUS_REFLECTIVE_MEMORY (default: false).
+ * Falls back to keyword-based retrieval on any failure.
+ *
+ * @module mcp/tools/reflective-retriever
+ * (Source: Issue #988, Research Issue #736)
+ */
+
+import { z } from 'zod';
+import type { IModelAdapter, ILogger } from '../../core/index.js';
+import { createLogger, getErrorMessage } from '../../core/index.js';
+import { withTimeout } from '../../utils/async-utils.js';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Default timeout for reflection LLM call (aggressive — 2s). */
+const REFLECTION_TIMEOUT_MS = 2_000;
+
+/** Maximum LRU cache entries. */
+const MAX_CACHE_ENTRIES = 50;
+
+/** Cache TTL in milliseconds (5 minutes). */
+const CACHE_TTL_MS = 5 * 60_000;
+
+/** Maximum tokens for reflection prompt output. */
+const REFLECTION_MAX_TOKENS = 100;
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+/**
+ * Zod schema for structured reflection output.
+ * The LLM returns search criteria to improve retrieval.
+ */
+export const ReflectionCriteriaSchema = z.object({
+  keywords: z.array(z.string()).min(1).max(10).describe('Expanded keywords for memory search'),
+  context: z.string().max(200).describe('Brief context about what memories would be useful'),
+});
+
+export type ReflectionCriteria = z.infer<typeof ReflectionCriteriaSchema>;
+
+// ============================================================================
+// LRU Cache
+// ============================================================================
+
+interface CacheEntry {
+  criteria: ReflectionCriteria;
+  timestamp: number;
+}
+
+/**
+ * Simple LRU cache for reflection criteria.
+ * Keyed on normalized query string.
+ */
+export class ReflectionCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+
+  constructor(maxEntries = MAX_CACHE_ENTRIES, ttlMs = CACHE_TTL_MS) {
+    this.maxEntries = maxEntries;
+    this.ttlMs = ttlMs;
+  }
+
+  /** Normalize query for cache key. */
+  private normalize(query: string): string {
+    return query.toLowerCase().trim().replace(/\s+/g, ' ');
+  }
+
+  get(query: string): ReflectionCriteria | undefined {
+    const key = this.normalize(query);
+    const entry = this.entries.get(key);
+    if (entry === undefined) return undefined;
+    if (Date.now() - entry.timestamp > this.ttlMs) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    // Move to end (most recently used)
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.criteria;
+  }
+
+  set(query: string, criteria: ReflectionCriteria): void {
+    const key = this.normalize(query);
+    this.entries.delete(key); // Remove if exists for re-insertion at end
+    if (this.entries.size >= this.maxEntries) {
+      // Evict oldest (first entry)
+      const oldest = this.entries.keys().next();
+      if (oldest.done !== true) this.entries.delete(oldest.value);
+    }
+    this.entries.set(key, { criteria, timestamp: Date.now() });
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+// ============================================================================
+// Reflection Prompt
+// ============================================================================
+
+/** System prompt for reflection reasoning. */
+const REFLECTION_SYSTEM_PROMPT =
+  'You help improve memory search. Given a task, output JSON with expanded ' +
+  'keywords and brief context about what past experiences would be relevant. ' +
+  'Output ONLY valid JSON: {"keywords":["..."],"context":"..."}';
+
+/** Build the reflection user prompt. */
+function buildReflectionPrompt(query: string): string {
+  return (
+    `Task: "${query.slice(0, 200)}"\n\n` +
+    'What types of past experiences, patterns, and knowledge would help? ' +
+    'Generate 3-8 search keywords (including synonyms and related terms) ' +
+    'and a one-sentence context.'
+  );
+}
+
+// ============================================================================
+// Reflective Retriever
+// ============================================================================
+
+/** Options for creating a ReflectiveRetriever. */
+export interface ReflectiveRetrieverOptions {
+  /** Model adapter for LLM reflection calls. */
+  readonly adapter: IModelAdapter;
+  /** Logger instance. */
+  readonly logger?: ILogger;
+  /** Timeout for reflection call in ms (default: 2000). */
+  readonly timeoutMs?: number;
+  /** Whether to run in shadow mode (log comparison, return original). */
+  readonly shadowMode?: boolean;
+  /** Shared cache instance (creates new if not provided). */
+  readonly cache?: ReflectionCache;
+}
+
+/** Result of a reflection attempt. */
+export interface ReflectionResult {
+  /** Enhanced keywords from reflection (or original if fallback). */
+  readonly keywords: readonly string[];
+  /** Whether reflection was used (vs fallback). */
+  readonly reflected: boolean;
+  /** Source: 'cache', 'llm', 'fallback'. */
+  readonly source: 'cache' | 'llm' | 'fallback';
+  /** Processing time in ms. */
+  readonly durationMs: number;
+}
+
+/**
+ * Enhances memory retrieval queries via LLM reflection.
+ *
+ * Before searching memory, asks an LLM to reason about what types
+ * of memories would be most relevant, generating expanded keywords
+ * and search context. Falls back to original keywords on any failure.
+ */
+export class ReflectiveRetriever {
+  private readonly adapter: IModelAdapter;
+  private readonly logger: ILogger;
+  private readonly timeoutMs: number;
+  private readonly shadowMode: boolean;
+  private readonly cache: ReflectionCache;
+
+  constructor(options: ReflectiveRetrieverOptions) {
+    this.adapter = options.adapter;
+    this.logger = options.logger ?? createLogger({ component: 'reflective-retriever' });
+    this.timeoutMs = options.timeoutMs ?? REFLECTION_TIMEOUT_MS;
+    this.shadowMode = options.shadowMode ?? false;
+    this.cache = options.cache ?? new ReflectionCache();
+  }
+
+  /** Build a result object with timing. */
+  private buildResult(
+    keywords: readonly string[],
+    reflected: boolean,
+    source: ReflectionResult['source'],
+    start: number
+  ): ReflectionResult {
+    return { keywords, reflected, source, durationMs: Date.now() - start };
+  }
+
+  /** Handle successful reflection (or shadow mode). */
+  private handleReflectionSuccess(
+    criteria: ReflectionCriteria,
+    originalKeywords: string[],
+    start: number
+  ): ReflectionResult {
+    const enhanced = this.mergeKeywords(originalKeywords, criteria.keywords);
+    this.logger.info('Reflection enhanced query', {
+      original: originalKeywords.length,
+      enhanced: enhanced.length,
+      context: criteria.context.slice(0, 80),
+    });
+
+    if (this.shadowMode) {
+      this.logger.info('Shadow mode: returning original keywords', {
+        originalKeywords,
+        enhancedKeywords: enhanced,
+        reflectionContext: criteria.context,
+      });
+      return this.buildResult(originalKeywords, false, 'fallback', start);
+    }
+
+    return this.buildResult(enhanced, true, 'llm', start);
+  }
+
+  /**
+   * Enhance a query with reflective reasoning.
+   * Returns expanded keywords or falls back to original keywords.
+   */
+  async enhance(query: string): Promise<ReflectionResult> {
+    const start = Date.now();
+    const originalKeywords = this.extractKeywords(query);
+
+    // Check cache first
+    const cached = this.cache.get(query);
+    if (cached !== undefined) {
+      this.logger.debug('Reflection cache hit', { query: query.slice(0, 50) });
+      return this.buildResult(cached.keywords, true, 'cache', start);
+    }
+
+    // Call LLM for reflection
+    try {
+      const criteria = await this.callReflection(query);
+      this.cache.set(query, criteria);
+      return this.handleReflectionSuccess(criteria, originalKeywords, start);
+    } catch (error) {
+      this.logger.warn('Reflection failed, using keyword fallback', {
+        error: getErrorMessage(error),
+        query: query.slice(0, 50),
+      });
+      return this.buildResult(originalKeywords, false, 'fallback', start);
+    }
+  }
+
+  /** Extract basic keywords from query (existing approach). */
+  private extractKeywords(query: string): string[] {
+    return query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((k) => k.length > 2);
+  }
+
+  /** Merge original keywords with reflection-generated ones. */
+  private mergeKeywords(original: readonly string[], expanded: readonly string[]): string[] {
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    // Original keywords first (preserve order)
+    for (const k of original) {
+      const lower = k.toLowerCase();
+      if (!seen.has(lower)) {
+        seen.add(lower);
+        merged.push(lower);
+      }
+    }
+    // Add expanded keywords
+    for (const k of expanded) {
+      const lower = k.toLowerCase();
+      if (!seen.has(lower) && lower.length > 2) {
+        seen.add(lower);
+        merged.push(lower);
+      }
+    }
+    return merged;
+  }
+
+  /** Call LLM to generate reflection criteria. */
+  private async callReflection(query: string): Promise<ReflectionCriteria> {
+    const result = await withTimeout(
+      this.adapter.complete({
+        messages: [
+          { role: 'system', content: REFLECTION_SYSTEM_PROMPT },
+          { role: 'user', content: buildReflectionPrompt(query) },
+        ],
+        maxTokens: REFLECTION_MAX_TOKENS,
+        temperature: 0.1,
+      }),
+      this.timeoutMs,
+      `Reflection timeout after ${String(this.timeoutMs)}ms`
+    );
+
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    const response = result.value;
+    if (!response.ok) {
+      throw new Error(response.error.message);
+    }
+
+    const text = this.extractText(response.value.content);
+    return this.parseCriteria(text);
+  }
+
+  /** Extract text from completion response content. */
+  private extractText(content: unknown): string {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((block) => {
+          if (typeof block === 'object' && block !== null && 'type' in block) {
+            const typed = block as { type: string; text?: string };
+            if (typed.type === 'text' && typeof typed.text === 'string') {
+              return typed.text;
+            }
+          }
+          return '';
+        })
+        .join('');
+    }
+    return String(content);
+  }
+
+  /** Parse and validate LLM output as ReflectionCriteria. */
+  private parseCriteria(text: string): ReflectionCriteria {
+    // Extract JSON from response (may have markdown fences)
+    const jsonMatch = /\{[\s\S]*\}/.exec(text);
+    if (jsonMatch === null) {
+      throw new Error('No JSON object found in reflection response');
+    }
+
+    const parsed: unknown = JSON.parse(jsonMatch[0]);
+    const validated = ReflectionCriteriaSchema.parse(parsed);
+    return validated;
+  }
+}
+
+// ============================================================================
+// Feature Flag
+// ============================================================================
+
+/**
+ * Check if reflective memory retrieval is enabled.
+ */
+export function isReflectiveMemoryEnabled(): boolean {
+  return process.env.NEXUS_REFLECTIVE_MEMORY === 'true';
+}
+
+/**
+ * Check if shadow mode is enabled (run reflection but return original results).
+ */
+export function isReflectiveShadowMode(): boolean {
+  return process.env.NEXUS_REFLECTIVE_MEMORY === 'shadow';
+}


### PR DESCRIPTION
## Summary

- Implement MemR3 (arXiv:2512.20237) reflective memory retrieval for the `memory_query` MCP tool
- Add `ReflectiveRetriever` module with LLM-guided keyword expansion before memory search
- Feature-gated via `NEXUS_REFLECTIVE_MEMORY` env var (default: disabled)

## Key Design Decisions

- **Aggressive timeout (2s)**: Reflection must be faster than the retrieval it enhances
- **LRU cache (50 entries, 5min TTL)**: Avoid redundant LLM calls for similar queries
- **Zod-validated output**: Structured JSON schema for reflection criteria
- **Shadow mode**: `NEXUS_REFLECTIVE_MEMORY=shadow` runs both paths, logs comparison, returns keyword-based results — allows offline comparison before full rollout
- **Graceful fallback**: Any failure (timeout, invalid JSON, adapter error) falls back to original keyword-based retrieval

## Consensus Vote

Supermajority approved (83%, 5/6 agents). Contrarian recommended shadow mode (implemented).

## Test plan

- [x] 23 unit tests for ReflectiveRetriever (schema, cache, LLM, timeout, fallback)
- [x] 13 existing memory_query tests still pass
- [x] 1955 MCP tests pass
- [x] Build succeeds (ESM + DTS)
- [x] Fitness score: 98/100

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)