### PR TITLE
feat(#1000): Graph workflow hooks — preconditions & post-step verification

### DIFF
--- a/packages/nexus-agents/src/exports/orchestration.ts
+++ b/packages/nexus-agents/src/exports/orchestration.ts
@@ -51,6 +51,23 @@ export type {
   GraphCompileError,
   CompileResult,
   GraphEvent,
+  NodeHookContext,
+  HookError,
+  NodeHook,
+  PreconditionConfig,
+} from '../orchestration/index.js';
+
+// Node Hooks (Issue #994 + #997)
+export {
+  runPreconditions,
+  runVerification,
+  createStateComparisonVerifier,
+  createStateGuard,
+} from '../orchestration/index.js';
+export type {
+  PreconditionResult,
+  PreconditionOutcome,
+  VerificationResult,
 } from '../orchestration/index.js';
 
 // Event streaming (Issue #838)

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -277,6 +277,12 @@ function formatDetail(event: GraphEvent): string {
       return `${String(event.totalSteps)} steps, ${String(event.durationMs)}ms`;
     case 'state_updated':
       return event.updatedKeys.join(', ');
+    case 'hook_started':
+      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}`;
+    case 'hook_completed':
+      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId} in ${String(event.durationMs)}ms`;
+    case 'hook_failed':
+      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}: ${event.error}`;
   }
 }
 

--- a/packages/nexus-agents/src/orchestration/graph/graph-builder.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-builder.ts
@@ -22,6 +22,8 @@ import type {
   StateReducer,
   CompileResult,
   GraphCompileError,
+  PreconditionConfig,
+  NodeHook,
 } from './graph-types.js';
 import { START, END } from './graph-types.js';
 
@@ -59,9 +61,27 @@ export class GraphBuilder {
 
   /**
    * Adds a node to the graph.
+   * Supports optional precondition hooks (Issue #997) and verify hook (Issue #994).
    */
-  addNode(id: string, handler: NodeHandler, opts?: { timeout?: number; retries?: number }): this {
-    this.nodes.set(id, { id, handler, timeout: opts?.timeout, retries: opts?.retries });
+  addNode(
+    id: string,
+    handler: NodeHandler,
+    opts?: {
+      timeout?: number;
+      retries?: number;
+      preconditions?: readonly PreconditionConfig[];
+      verify?: NodeHook;
+    }
+  ): this {
+    const node: GraphNode = {
+      id,
+      handler,
+      ...(opts?.timeout !== undefined ? { timeout: opts.timeout } : {}),
+      ...(opts?.retries !== undefined ? { retries: opts.retries } : {}),
+      ...(opts?.preconditions !== undefined ? { preconditions: opts.preconditions } : {}),
+      ...(opts?.verify !== undefined ? { verify: opts.verify } : {}),
+    };
+    this.nodes.set(id, node);
     return this;
   }
 

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -33,6 +33,7 @@ import {
   emitStepCompleted,
   emitExecutionComplete,
 } from './graph-events.js';
+import { runPreconditions, runVerification } from './graph-hooks.js';
 
 const logger = createLogger({ component: 'GraphExecutor' });
 
@@ -276,7 +277,51 @@ async function executeNodes(
   return Promise.all(promises);
 }
 
-/** Executes a single node with timeout and error handling. */
+/** Returns a skipped NodeResult for a failed precondition. */
+function preconditionFailedResult(
+  nodeId: string,
+  results: readonly import('./graph-hooks.js').PreconditionOutcome[],
+  startTime: number
+): NodeResult {
+  const failed = results.find((r) => !r.passed);
+  return {
+    nodeId,
+    stateUpdates: {},
+    durationMs: getTimeProvider().now() - startTime,
+    status: 'skipped',
+    error: `Precondition '${failed?.name ?? 'unknown'}' failed: ${failed?.error ?? 'unknown'}`,
+  };
+}
+
+/** Executes node handler with verification, returning the NodeResult. */
+async function executeWithVerification(
+  node: GraphNode,
+  nodeId: string,
+  state: Readonly<GraphState>,
+  startTime: number,
+  options?: GraphExecuteOptions
+): Promise<NodeResult> {
+  const nodeTimeout = node.timeout ?? options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const result = await withTimeout(node.handler(state), nodeTimeout);
+  const handlerDuration = getTimeProvider().now() - startTime;
+
+  const mergedState = { ...state, ...result };
+  const verifyResult = await runVerification(node, mergedState, 0, options);
+  if (!verifyResult.passed) {
+    logger.warn('Post-step verification failed', { nodeId, error: verifyResult.error });
+    return {
+      nodeId,
+      stateUpdates: {},
+      durationMs: getTimeProvider().now() - startTime,
+      status: 'failed',
+      error: `Verification failed: ${verifyResult.error ?? 'unknown'}`,
+    };
+  }
+
+  return { nodeId, stateUpdates: result, durationMs: handlerDuration, status: 'success' };
+}
+
+/** Executes a single node with preconditions, timeout, verification, and error handling. */
 async function executeSingleNode(
   graph: CompiledGraph,
   nodeId: string,
@@ -295,16 +340,13 @@ async function executeSingleNode(
   }
 
   const startTime = getTimeProvider().now();
-  const nodeTimeout = node.timeout ?? options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const preResult = await runPreconditions(node, state, 0, options);
+  if (!preResult.passed) {
+    return preconditionFailedResult(nodeId, preResult.results, startTime);
+  }
 
   try {
-    const result = await withTimeout(node.handler(state), nodeTimeout);
-    return {
-      nodeId,
-      stateUpdates: result,
-      durationMs: getTimeProvider().now() - startTime,
-      status: 'success',
-    };
+    return await executeWithVerification(node, nodeId, state, startTime, options);
   } catch (error: unknown) {
     const message = getErrorMessage(error);
     logger.warn('Node execution failed', { nodeId, error: message });

--- a/packages/nexus-agents/src/orchestration/graph/graph-hooks.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-hooks.test.ts
@@ -1,0 +1,556 @@
+/**
+ * Tests for graph workflow hooks — preconditions and post-step verification.
+ *
+ * (Source: Issue #994 — Post-step verification, Issue #997 — Pre-condition hooks)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { GraphBuilder, overwrite, START, END } from './graph-builder.js';
+import { executeGraph } from './graph-executor.js';
+import { runPreconditions, runVerification, createStateGuard } from './graph-hooks.js';
+import type { GraphEvent, NodeHookContext, HookError, PreconditionConfig } from './graph-types.js';
+import type { Result } from '../../core/index.js';
+import { ok, err } from '../../core/index.js';
+
+// ============================================================================
+// Helper factories
+// ============================================================================
+
+function passingHook(name = 'pass'): PreconditionConfig {
+  return {
+    name,
+    required: true,
+    hook: () => Promise.resolve(ok(undefined)),
+  };
+}
+
+function failingHook(name = 'fail', message = 'hook failed'): PreconditionConfig {
+  return {
+    name,
+    required: true,
+    hook: (ctx: NodeHookContext) =>
+      Promise.resolve(err({ hookName: name, nodeId: ctx.nodeId, message })),
+  };
+}
+
+function optionalFailingHook(name = 'optional-fail'): PreconditionConfig {
+  return {
+    name,
+    required: false,
+    hook: (ctx: NodeHookContext) =>
+      Promise.resolve(err({ hookName: name, nodeId: ctx.nodeId, message: 'optional failed' })),
+  };
+}
+
+function passingVerify() {
+  return () => Promise.resolve(ok(undefined));
+}
+
+function failingVerify(message = 'verification failed') {
+  return (ctx: NodeHookContext) =>
+    Promise.resolve(err({ hookName: 'verify', nodeId: ctx.nodeId, message } as HookError));
+}
+
+// ============================================================================
+// Precondition Tests
+// ============================================================================
+
+describe('preconditions', () => {
+  describe('runPreconditions', () => {
+    it('returns passed=true when no preconditions configured', async () => {
+      const node = { id: 'A', handler: () => Promise.resolve({}) };
+      const result = await runPreconditions(node, {}, 0);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('returns passed=true when all preconditions pass', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        preconditions: [passingHook('check-1'), passingHook('check-2')],
+      };
+      const result = await runPreconditions(node, {}, 0);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(2);
+      expect(result.results.every((r) => r.passed)).toBe(true);
+    });
+
+    it('returns passed=false when required precondition fails', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        preconditions: [passingHook(), failingHook('budget-check', 'insufficient funds')],
+      };
+      const result = await runPreconditions(node, {}, 0);
+      expect(result.passed).toBe(false);
+      const failed = result.results.find((r) => !r.passed);
+      expect(failed?.name).toBe('budget-check');
+      expect(failed?.error).toContain('insufficient funds');
+    });
+
+    it('stops on first required failure (short-circuit)', async () => {
+      const thirdHook = vi.fn(() => Promise.resolve(ok(undefined)));
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        preconditions: [
+          passingHook(),
+          failingHook('blocker'),
+          { name: 'never-reached', required: true, hook: thirdHook },
+        ],
+      };
+      await runPreconditions(node, {}, 0);
+      expect(thirdHook).not.toHaveBeenCalled();
+    });
+
+    it('continues past optional precondition failures', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        preconditions: [optionalFailingHook(), passingHook('after-optional')],
+      };
+      const result = await runPreconditions(node, {}, 0);
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(2);
+      const first = result.results[0];
+      const second = result.results[1];
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+      expect(first?.passed).toBe(false);
+      expect(second?.passed).toBe(true);
+    });
+
+    it('handles hooks that throw exceptions', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        preconditions: [
+          {
+            name: 'throws',
+            required: true,
+            hook: () => Promise.reject(new Error('unexpected')),
+          },
+        ],
+      };
+      const result = await runPreconditions(node, {}, 0);
+      expect(result.passed).toBe(false);
+      const first = result.results[0];
+      expect(first).toBeDefined();
+      expect(first?.error).toContain('unexpected');
+    });
+
+    it('passes state and nodeId to hook context', async () => {
+      const hookFn = vi.fn(() => Promise.resolve(ok(undefined)));
+      const node = {
+        id: 'my-node',
+        handler: () => Promise.resolve({}),
+        preconditions: [{ name: 'spy', required: true, hook: hookFn }],
+      };
+      await runPreconditions(node, { budget: 1000 }, 5);
+      expect(hookFn).toHaveBeenCalledWith({
+        nodeId: 'my-node',
+        state: { budget: 1000 },
+        stepNumber: 5,
+      });
+    });
+  });
+
+  describe('integrated with executeGraph', () => {
+    it('skips node when required precondition fails', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.resolve({ value: 42 }), {
+          preconditions: [failingHook('guard', 'not ready')],
+        })
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Node skipped — state unchanged
+      expect(result.value.finalState['value']).toBe(0);
+      const nodeResult = result.value.nodeResults.find((r) => r.nodeId === 'A');
+      expect(nodeResult?.status).toBe('skipped');
+    });
+
+    it('executes node when all preconditions pass', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.resolve({ value: 42 }), {
+          preconditions: [passingHook('check-1'), passingHook('check-2')],
+        })
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.finalState['value']).toBe(42);
+    });
+  });
+});
+
+// ============================================================================
+// Verification Tests
+// ============================================================================
+
+describe('verification', () => {
+  describe('runVerification', () => {
+    it('returns passed=true when no verify hook configured', async () => {
+      const node = { id: 'A', handler: () => Promise.resolve({}) };
+      const result = await runVerification(node, {}, 0);
+      expect(result.passed).toBe(true);
+    });
+
+    it('returns passed=true when verify hook passes', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        verify: passingVerify(),
+      };
+      const result = await runVerification(node, {}, 0);
+      expect(result.passed).toBe(true);
+    });
+
+    it('returns passed=false when verify hook fails', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        verify: failingVerify('state mismatch'),
+      };
+      const result = await runVerification(node, {}, 0);
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('state mismatch');
+    });
+
+    it('handles verify hooks that throw', async () => {
+      const node = {
+        id: 'A',
+        handler: () => Promise.resolve({}),
+        verify: () => Promise.reject(new Error('boom')),
+      };
+      const result = await runVerification(node, {}, 0);
+      expect(result.passed).toBe(false);
+      expect(result.error).toContain('boom');
+    });
+  });
+
+  describe('integrated with executeGraph', () => {
+    it('fails node when verification fails', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.resolve({ value: 42 }), {
+          verify: failingVerify('integrity check failed'),
+        })
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Verification failed — state updates discarded
+      expect(result.value.finalState['value']).toBe(0);
+      const nodeResult = result.value.nodeResults.find((r) => r.nodeId === 'A');
+      expect(nodeResult?.status).toBe('failed');
+      expect(nodeResult?.error).toContain('Verification failed');
+    });
+
+    it('succeeds when verification passes', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.resolve({ value: 42 }), {
+          verify: passingVerify(),
+        })
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.finalState['value']).toBe(42);
+    });
+  });
+});
+
+// ============================================================================
+// Event Emission Tests
+// ============================================================================
+
+describe('hook events', () => {
+  it('emits hook_started and hook_completed for preconditions', async () => {
+    const events: GraphEvent[] = [];
+
+    const graph = new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }), {
+        preconditions: [passingHook('budget-check')],
+      })
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    await executeGraph(graph.value, {}, { onEvent: (e) => events.push(e) });
+
+    const hookStarted = events.filter((e) => e.type === 'hook_started');
+    const hookCompleted = events.filter((e) => e.type === 'hook_completed');
+    expect(hookStarted.length).toBeGreaterThanOrEqual(1);
+    expect(hookCompleted.length).toBeGreaterThanOrEqual(1);
+
+    const started = hookStarted[0];
+    expect(started).toBeDefined();
+    if (started?.type === 'hook_started') {
+      expect(started.hookName).toBe('budget-check');
+      expect(started.hookPhase).toBe('precondition');
+    }
+  });
+
+  it('emits hook_failed when precondition fails', async () => {
+    const events: GraphEvent[] = [];
+
+    const graph = new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }), {
+        preconditions: [failingHook('guard', 'blocked')],
+      })
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    await executeGraph(graph.value, {}, { onEvent: (e) => events.push(e) });
+
+    const hookFailed = events.filter((e) => e.type === 'hook_failed');
+    expect(hookFailed.length).toBeGreaterThanOrEqual(1);
+
+    const failed = hookFailed[0];
+    expect(failed).toBeDefined();
+    if (failed?.type === 'hook_failed') {
+      expect(failed.hookName).toBe('guard');
+      expect(failed.hookPhase).toBe('precondition');
+      expect(failed.error).toContain('blocked');
+    }
+  });
+
+  it('emits hook events for verification', async () => {
+    const events: GraphEvent[] = [];
+
+    const graph = new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }), {
+        verify: passingVerify(),
+      })
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    await executeGraph(graph.value, {}, { onEvent: (e) => events.push(e) });
+
+    const hookEvents = events.filter(
+      (e) => e.type === 'hook_started' || e.type === 'hook_completed'
+    );
+    const verifyEvents = hookEvents.filter(
+      (e) => (e.type === 'hook_started' || e.type === 'hook_completed') && e.hookPhase === 'verify'
+    );
+    expect(verifyEvents.length).toBeGreaterThanOrEqual(2); // started + completed
+  });
+});
+
+// ============================================================================
+// Built-in Hook Tests
+// ============================================================================
+
+describe('createStateGuard', () => {
+  it('creates a precondition that passes when predicate is true', async () => {
+    const guard = createStateGuard(
+      'has-budget',
+      (state) => (state['budget'] as number) > 0,
+      'No budget remaining'
+    );
+
+    const result = await guard.hook({
+      nodeId: 'A',
+      state: { budget: 1000 },
+      stepNumber: 0,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('creates a precondition that fails when predicate is false', async () => {
+    const guard = createStateGuard(
+      'has-budget',
+      (state) => (state['budget'] as number) > 0,
+      'No budget remaining'
+    );
+
+    const result = await guard.hook({
+      nodeId: 'A',
+      state: { budget: 0 },
+      stepNumber: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('No budget remaining');
+      expect(result.error.hookName).toBe('has-budget');
+    }
+  });
+
+  it('integrates with executeGraph as precondition', async () => {
+    const budgetGuard = createStateGuard(
+      'budget-guard',
+      (state) => (state['budget'] as number) > 100,
+      'Budget too low'
+    );
+
+    const graph = new GraphBuilder()
+      .addState('budget', overwrite(50))
+      .addState('built', overwrite(false))
+      .addNode('build', () => Promise.resolve({ built: true }), {
+        preconditions: [budgetGuard],
+      })
+      .addEdge(START, 'build')
+      .addEdge('build', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Budget too low → node skipped → built stays false
+    expect(result.value.finalState['built']).toBe(false);
+  });
+});
+
+// ============================================================================
+// Combined Precondition + Verification Tests
+// ============================================================================
+
+describe('combined hooks', () => {
+  it('runs both preconditions and verification on a single node', async () => {
+    const hookLog: string[] = [];
+
+    const precondition: PreconditionConfig = {
+      name: 'pre-check',
+      required: true,
+      hook: () => {
+        hookLog.push('precondition');
+        return Promise.resolve(ok(undefined));
+      },
+    };
+
+    const verify = (): Promise<Result<void, HookError>> => {
+      hookLog.push('verify');
+      return Promise.resolve(ok(undefined));
+    };
+
+    const graph = new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }), {
+        preconditions: [precondition],
+        verify,
+      })
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Both hooks ran in order
+    expect(hookLog).toEqual(['precondition', 'verify']);
+    expect(result.value.finalState['value']).toBe(1);
+  });
+
+  it('skips verification when precondition fails', async () => {
+    const verifyFn = vi.fn(passingVerify());
+
+    const graph = new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }), {
+        preconditions: [failingHook('blocker')],
+        verify: verifyFn,
+      })
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    await executeGraph(graph.value, {});
+
+    // Verification should not have been called
+    expect(verifyFn).not.toHaveBeenCalled();
+  });
+
+  it('shared preconditions work across multiple nodes', async () => {
+    const budgetGuard = createStateGuard(
+      'budget-guard',
+      (state) => (state['budget'] as number) > 100,
+      'Budget too low'
+    );
+
+    const graph = new GraphBuilder()
+      .addState('budget', overwrite(200))
+      .addState('a_done', overwrite(false))
+      .addState('b_done', overwrite(false))
+      .addNode('A', () => Promise.resolve({ a_done: true }), {
+        preconditions: [budgetGuard],
+      })
+      .addNode('B', () => Promise.resolve({ b_done: true }), {
+        preconditions: [budgetGuard],
+      })
+      .addEdge(START, 'A')
+      .addEdge(START, 'B')
+      .addEdge('A', END)
+      .addEdge('B', END)
+      .compile();
+
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Both nodes pass precondition (budget=200 > 100)
+    expect(result.value.finalState['a_done']).toBe(true);
+    expect(result.value.finalState['b_done']).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/graph/graph-hooks.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-hooks.ts
@@ -1,0 +1,345 @@
+/**
+ * nexus-agents/orchestration - Graph Workflow Hooks
+ *
+ * Execution logic for precondition and post-step verification hooks.
+ * Keeps hook concerns separate from the core executor flow.
+ *
+ * @module orchestration/graph/graph-hooks
+ * (Source: Issue #994 — Post-step verification, Issue #997 — Pre-condition hooks)
+ */
+
+import type { Result } from '../../core/index.js';
+import { ok, err, createLogger, getTimeProvider } from '../../core/index.js';
+import type {
+  GraphNode,
+  GraphState,
+  NodeHookContext,
+  HookError,
+  PreconditionConfig,
+  GraphExecuteOptions,
+} from './graph-types.js';
+
+const logger = createLogger({ component: 'GraphHooks' });
+
+// ============================================================================
+// Hook Result Types
+// ============================================================================
+
+/** Result of running all preconditions for a node. */
+export interface PreconditionResult {
+  readonly passed: boolean;
+  readonly results: readonly PreconditionOutcome[];
+}
+
+/** Outcome of a single precondition hook. */
+export interface PreconditionOutcome {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly durationMs: number;
+  readonly error?: string | undefined;
+}
+
+/** Result of running verification on a node. */
+export interface VerificationResult {
+  readonly passed: boolean;
+  readonly durationMs: number;
+  readonly error?: string | undefined;
+}
+
+// ============================================================================
+// Hook Execution
+// ============================================================================
+
+/**
+ * Runs all precondition hooks for a node.
+ * If any required precondition fails, returns passed=false.
+ * Optional precondition failures are logged but don't block execution.
+ */
+export async function runPreconditions(
+  node: GraphNode,
+  state: Readonly<GraphState>,
+  stepNumber: number,
+  options?: GraphExecuteOptions
+): Promise<PreconditionResult> {
+  const preconditions = node.preconditions;
+  if (preconditions === undefined || preconditions.length === 0) {
+    return { passed: true, results: [] };
+  }
+
+  const ctx: NodeHookContext = { nodeId: node.id, state, stepNumber };
+  const outcomes: PreconditionOutcome[] = [];
+  let allPassed = true;
+
+  for (const config of preconditions) {
+    const outcome = await runSinglePrecondition(config, ctx, options);
+    outcomes.push(outcome);
+
+    if (!outcome.passed) {
+      const isRequired = config.required !== false;
+      if (isRequired) {
+        allPassed = false;
+        logger.warn('Required precondition failed', {
+          nodeId: node.id,
+          hook: config.name,
+          error: outcome.error,
+        });
+        break;
+      }
+      logger.info('Optional precondition failed, continuing', {
+        nodeId: node.id,
+        hook: config.name,
+      });
+    }
+  }
+
+  return { passed: allPassed, results: outcomes };
+}
+
+/**
+ * Runs the post-step verification hook for a node.
+ * Returns the verification result.
+ */
+export async function runVerification(
+  node: GraphNode,
+  state: Readonly<GraphState>,
+  stepNumber: number,
+  options?: GraphExecuteOptions
+): Promise<VerificationResult> {
+  if (node.verify === undefined) {
+    return { passed: true, durationMs: 0 };
+  }
+
+  const ctx: NodeHookContext = { nodeId: node.id, state, stepNumber };
+  const startTime = getTimeProvider().now();
+
+  emitHookEvent({
+    type: 'hook_started',
+    nodeId: node.id,
+    hookName: 'verify',
+    hookPhase: 'verify',
+    stepNumber,
+    options,
+  });
+
+  try {
+    const result = await node.verify(ctx);
+    const durationMs = getTimeProvider().now() - startTime;
+
+    if (result.ok) {
+      emitHookEvent({
+        type: 'hook_completed',
+        nodeId: node.id,
+        hookName: 'verify',
+        hookPhase: 'verify',
+        stepNumber,
+        options,
+        durationMs,
+      });
+      return { passed: true, durationMs };
+    }
+
+    const errorMsg = result.error.message;
+    emitHookFailed({
+      nodeId: node.id,
+      hookName: 'verify',
+      hookPhase: 'verify',
+      error: errorMsg,
+      stepNumber,
+      options,
+    });
+    logger.warn('Verification failed', { nodeId: node.id, error: errorMsg });
+    return { passed: false, durationMs, error: errorMsg };
+  } catch (error: unknown) {
+    const durationMs = getTimeProvider().now() - startTime;
+    const msg = error instanceof Error ? error.message : String(error);
+    emitHookFailed({
+      nodeId: node.id,
+      hookName: 'verify',
+      hookPhase: 'verify',
+      error: msg,
+      stepNumber,
+      options,
+    });
+    logger.warn('Verification threw', { nodeId: node.id, error: msg });
+    return { passed: false, durationMs, error: msg };
+  }
+}
+
+// ============================================================================
+// Built-in Hooks
+// ============================================================================
+
+/**
+ * Creates a state-comparison verification hook.
+ * Checks that specified state fields changed after node execution.
+ */
+export function createStateComparisonVerifier(
+  fields: readonly string[]
+): (preState: Readonly<GraphState>) => PreconditionConfig['hook'] {
+  return (preState: Readonly<GraphState>) => {
+    const hook: PreconditionConfig['hook'] = (
+      ctx: NodeHookContext
+    ): Promise<Result<void, HookError>> => {
+      for (const field of fields) {
+        if (ctx.state[field] === preState[field]) {
+          return Promise.resolve(
+            err({
+              hookName: 'state-comparison',
+              nodeId: ctx.nodeId,
+              message: `Field '${field}' unchanged after execution`,
+            })
+          );
+        }
+      }
+      return Promise.resolve(ok(undefined));
+    };
+    return hook;
+  };
+}
+
+/**
+ * Creates a precondition that checks state field values.
+ * Useful for enforcing invariants before node execution.
+ */
+export function createStateGuard(
+  name: string,
+  predicate: (state: Readonly<GraphState>) => boolean,
+  errorMessage: string
+): PreconditionConfig {
+  return {
+    name,
+    required: true,
+    hook: (ctx: NodeHookContext): Promise<Result<void, HookError>> => {
+      if (predicate(ctx.state)) {
+        return Promise.resolve(ok(undefined));
+      }
+      return Promise.resolve(err({ hookName: name, nodeId: ctx.nodeId, message: errorMessage }));
+    },
+  };
+}
+
+// ============================================================================
+// Event Emission Helpers
+// ============================================================================
+
+interface HookEventOpts {
+  readonly type: 'hook_started' | 'hook_completed';
+  readonly nodeId: string;
+  readonly hookName: string;
+  readonly hookPhase: 'precondition' | 'verify';
+  readonly stepNumber: number;
+  readonly options?: GraphExecuteOptions;
+  readonly durationMs?: number;
+}
+
+function emitHookEvent(opts: HookEventOpts): void {
+  const emit = opts.options?.onEvent;
+  if (emit === undefined) return;
+  const ts = getTimeProvider().now();
+
+  if (opts.type === 'hook_started') {
+    emit({
+      type: 'hook_started',
+      nodeId: opts.nodeId,
+      hookName: opts.hookName,
+      hookPhase: opts.hookPhase,
+      stepNumber: opts.stepNumber,
+      timestamp: ts,
+    });
+  } else {
+    emit({
+      type: 'hook_completed',
+      nodeId: opts.nodeId,
+      hookName: opts.hookName,
+      hookPhase: opts.hookPhase,
+      durationMs: opts.durationMs ?? 0,
+      stepNumber: opts.stepNumber,
+      timestamp: ts,
+    });
+  }
+}
+
+interface HookFailedOpts {
+  readonly nodeId: string;
+  readonly hookName: string;
+  readonly hookPhase: 'precondition' | 'verify';
+  readonly error: string;
+  readonly stepNumber: number;
+  readonly options?: GraphExecuteOptions;
+}
+
+function emitHookFailed(opts: HookFailedOpts): void {
+  const emit = opts.options?.onEvent;
+  if (emit === undefined) return;
+  emit({
+    type: 'hook_failed',
+    nodeId: opts.nodeId,
+    hookName: opts.hookName,
+    hookPhase: opts.hookPhase,
+    error: opts.error,
+    stepNumber: opts.stepNumber,
+    timestamp: getTimeProvider().now(),
+  });
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+async function runSinglePrecondition(
+  config: PreconditionConfig,
+  ctx: NodeHookContext,
+  options?: GraphExecuteOptions
+): Promise<PreconditionOutcome> {
+  const startTime = getTimeProvider().now();
+
+  emitHookEvent({
+    type: 'hook_started',
+    nodeId: ctx.nodeId,
+    hookName: config.name,
+    hookPhase: 'precondition',
+    stepNumber: ctx.stepNumber,
+    options,
+  });
+
+  try {
+    const result = await config.hook(ctx);
+    const durationMs = getTimeProvider().now() - startTime;
+
+    if (result.ok) {
+      emitHookEvent({
+        type: 'hook_completed',
+        nodeId: ctx.nodeId,
+        hookName: config.name,
+        hookPhase: 'precondition',
+        stepNumber: ctx.stepNumber,
+        options,
+        durationMs,
+      });
+      return { name: config.name, passed: true, durationMs };
+    }
+
+    const errorMsg = result.error.message;
+    emitHookFailed({
+      nodeId: ctx.nodeId,
+      hookName: config.name,
+      hookPhase: 'precondition',
+      error: errorMsg,
+      stepNumber: ctx.stepNumber,
+      options,
+    });
+    return { name: config.name, passed: false, durationMs, error: errorMsg };
+  } catch (error: unknown) {
+    const durationMs = getTimeProvider().now() - startTime;
+    const msg = error instanceof Error ? error.message : String(error);
+    emitHookFailed({
+      nodeId: ctx.nodeId,
+      hookName: config.name,
+      hookPhase: 'precondition',
+      error: msg,
+      stepNumber: ctx.stepNumber,
+      options,
+    });
+    return { name: config.name, passed: false, durationMs, error: msg };
+  }
+}

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -13,6 +13,46 @@ import type { Result } from '../../core/index.js';
 import type { ICheckpointStore } from './checkpoint-types.js';
 
 // ============================================================================
+// Node Hooks (Issue #994 + #997)
+// ============================================================================
+
+/**
+ * Context passed to node hooks (preconditions and verification).
+ * Provides read-only access to current execution state.
+ */
+export interface NodeHookContext {
+  readonly nodeId: string;
+  readonly state: Readonly<GraphState>;
+  readonly stepNumber: number;
+}
+
+/**
+ * Error type for hook failures — identifies which hook failed and why.
+ */
+export interface HookError {
+  readonly hookName: string;
+  readonly nodeId: string;
+  readonly message: string;
+}
+
+/**
+ * Hook function signature. Returns ok(void) on success, err(HookError) on failure.
+ */
+export type NodeHook = (ctx: NodeHookContext) => Promise<Result<void, HookError>>;
+
+/**
+ * Configuration for a precondition hook.
+ * Preconditions run before node execution.
+ * If a required precondition fails, the node is skipped.
+ */
+export interface PreconditionConfig {
+  readonly name: string;
+  readonly hook: NodeHook;
+  /** If true (default), failure prevents node execution. */
+  readonly required?: boolean | undefined;
+}
+
+// ============================================================================
 // State & Reducers
 // ============================================================================
 
@@ -61,6 +101,10 @@ export interface GraphNode {
   readonly handler: NodeHandler;
   readonly timeout?: number | undefined;
   readonly retries?: number | undefined;
+  /** Precondition hooks run before node execution (Issue #997). */
+  readonly preconditions?: readonly PreconditionConfig[] | undefined;
+  /** Post-step verification hook run after node execution (Issue #994). */
+  readonly verify?: NodeHook | undefined;
 }
 
 /** Special sentinel for the graph entry point. */
@@ -183,6 +227,32 @@ export type GraphEvent =
       readonly totalSteps: number;
       readonly totalNodes: number;
       readonly durationMs: number;
+      readonly timestamp: number;
+    }
+  | {
+      readonly type: 'hook_started';
+      readonly nodeId: string;
+      readonly hookName: string;
+      readonly hookPhase: 'precondition' | 'verify';
+      readonly stepNumber: number;
+      readonly timestamp: number;
+    }
+  | {
+      readonly type: 'hook_completed';
+      readonly nodeId: string;
+      readonly hookName: string;
+      readonly hookPhase: 'precondition' | 'verify';
+      readonly durationMs: number;
+      readonly stepNumber: number;
+      readonly timestamp: number;
+    }
+  | {
+      readonly type: 'hook_failed';
+      readonly nodeId: string;
+      readonly hookName: string;
+      readonly hookPhase: 'precondition' | 'verify';
+      readonly error: string;
+      readonly stepNumber: number;
       readonly timestamp: number;
     };
 

--- a/packages/nexus-agents/src/orchestration/graph/index.ts
+++ b/packages/nexus-agents/src/orchestration/graph/index.ts
@@ -24,6 +24,10 @@ export type {
   GraphCompileError,
   CompileResult,
   GraphEvent,
+  NodeHookContext,
+  HookError,
+  NodeHook,
+  PreconditionConfig,
 } from './graph-types.js';
 export { START, END, formatCompileError } from './graph-types.js';
 
@@ -41,6 +45,15 @@ export { GraphBuilder, overwrite, append, customReducer } from './graph-builder.
 
 // Executor
 export { executeGraph } from './graph-executor.js';
+
+// Hooks (Issue #994 + #997)
+export type { PreconditionResult, PreconditionOutcome, VerificationResult } from './graph-hooks.js';
+export {
+  runPreconditions,
+  runVerification,
+  createStateComparisonVerifier,
+  createStateGuard,
+} from './graph-hooks.js';
 
 // Checkpointing (Issue #833)
 export type { Checkpoint, CheckpointSummary, ICheckpointStore } from './checkpoint-types.js';

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -56,7 +56,20 @@ export type {
   GraphCompileError,
   CompileResult,
   GraphEvent,
+  NodeHookContext,
+  HookError,
+  NodeHook,
+  PreconditionConfig,
 } from './graph/index.js';
+
+// Node Hooks (Issue #994 + #997)
+export {
+  runPreconditions,
+  runVerification,
+  createStateComparisonVerifier,
+  createStateGuard,
+} from './graph/index.js';
+export type { PreconditionResult, PreconditionOutcome, VerificationResult } from './graph/index.js';
 
 // Event streaming (Issue #838)
 export {


### PR DESCRIPTION
## Summary

Implements design-by-contract hooks for GraphBuilder nodes, addressing two paired issues:

- **Pre-condition hooks (#997)** — Run before node execution with fail-fast semantics. If a required precondition fails, the node is skipped (status: `skipped`). Optional preconditions log warnings but don't block.
- **Post-step verification hooks (#994)** — Run after node execution. If verification fails, the node's state updates are discarded (status: `failed`).

### Key features
- `preconditions` array on `addNode()` with `required` (default: true) vs optional semantics
- `verify` callback on `addNode()` for post-step integrity checking
- Built-in `createStateGuard()` helper for invariant enforcement
- Built-in `createStateComparisonVerifier()` for detecting state changes
- Hook lifecycle events (`hook_started`, `hook_completed`, `hook_failed`) for observability
- Exhaustive `GraphEvent` handling in MCP `run_graph_workflow` tool

### Consensus vote
Approved 3/3 (unanimous) — Architect (88%), Security (95%), PM (89%)

### Files changed
| File | Change |
|------|--------|
| `graph-types.ts` | New hook types: `NodeHookContext`, `HookError`, `NodeHook`, `PreconditionConfig` + 3 new `GraphEvent` variants |
| `graph-builder.ts` | `addNode()` accepts `preconditions` and `verify` options |
| `graph-executor.ts` | Wires precondition + verification execution into node lifecycle |
| `graph-hooks.ts` | **New** — Hook execution logic + built-in hooks |
| `graph-hooks.test.ts` | **New** — 24 tests covering all hook scenarios |
| `run-graph-workflow.ts` | Handles new `GraphEvent` variants in `formatDetail()` |
| `index.ts`, `orchestration.ts` | Export wiring |

## Test plan
- [x] 24 new hook tests pass (preconditions, verification, events, built-ins, combined)
- [x] 93 total graph workflow tests pass (0 regressions)
- [x] 22,533 full suite tests pass
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [x] Fitness score: 98/100

Closes #994
Closes #997
Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)