### PR TITLE
feat(#992): MCP tool response honesty contract

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -342,6 +342,46 @@ const rateLimiter = new TokenBucket({
 });
 ```
 
+### 5.4 Tool Response Honesty Contract
+
+Every MCP tool MUST accurately report whether its operation succeeded or failed. Silent failures and misleading success responses erode trust and cause cascading debugging costs.
+
+**Rules:**
+
+1. **Never report success when the action failed or was a no-op.** If a tool returns without `isError: true`, the caller is entitled to assume the operation completed as described. If the underlying action threw, returned an error, or produced no state change when one was expected, the tool MUST return `isError: true`.
+
+2. **Partial success must be explicit.** When a batch operation partially completes, the response MUST clearly distinguish completed items from failed items with reasons. Never report aggregate success when individual items failed.
+
+3. **Error propagation, not absorption.** Inner `Result<T, E>` errors from domain logic MUST propagate to the MCP response as `isError: true`. Never wrap a domain error inside `ok: true` to avoid "ugly" error responses — the caller needs accurate signals.
+
+4. **Notification accuracy.** MCP logging notifications (e.g., `notifier.info()`) MUST reflect actual outcome. A `*_complete` event should only fire on success; use `*_failed` for failures.
+
+```typescript
+// BAD — masks failure behind success wrapper
+if (!result.ok) {
+  return { ok: true, value: buildErrorResponse(result.error) };
+}
+
+// GOOD — propagates failure accurately
+if (!result.ok) {
+  return { ok: false, error: result.error.message };
+}
+
+// BAD — always reports completion regardless of outcome
+notifier.info('tool', { event: 'complete' });
+return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+
+// GOOD — notification matches actual outcome
+const succeeded = result.status === 'completed';
+notifier.info('tool', { event: succeeded ? 'complete' : 'failed' });
+return {
+  content: [{ type: 'text', text: JSON.stringify(result) }],
+  ...(succeeded ? {} : { isError: true }),
+};
+```
+
+**Enforcement:** Integration tests MUST verify that tool error paths return `isError: true`. See Section 8 for the honesty verification test pattern.
+
 ---
 
 ## 6. Agent & Skill Standards

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -123,26 +123,6 @@ function lookupExpert(
 }
 
 /**
- * Build error response for failed execution.
- */
-function buildErrorResponse(
-  expertId: string,
-  role: string,
-  errorMessage: string,
-  durationMs: number
-): ExecuteExpertResponse {
-  return {
-    expertId,
-    role,
-    output: '',
-    durationMs,
-    tokensUsed: 0,
-    status: 'error',
-    error: errorMessage,
-  };
-}
-
-/**
  * Build success response from execution result.
  */
 interface SuccessResponseParams {
@@ -284,8 +264,8 @@ async function handleExecuteExpert(
     deps.logger?.warn('Expert execution failed', { expertId, error: result.error.message });
     recordExpertError(expertId, expert.role, result.error.message);
     return {
-      ok: true,
-      value: buildErrorResponse(expertId, expert.role, result.error.message, durationMs),
+      ok: false,
+      error: `Expert execution failed: ${result.error.message}`,
     };
   }
 

--- a/packages/nexus-agents/src/mcp/tools/response-honesty.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/response-honesty.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tool Response Honesty Contract Tests
+ *
+ * Verifies that MCP tools accurately report success/failure.
+ * See CODING_STANDARDS.md §5.4 for the full contract.
+ *
+ * @module mcp/tools/response-honesty.test
+ * (Source: Issue #992 — Tool response honesty contract)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { createServer, connectTransport } from '../server.js';
+import { registerTools, registerExecuteExpertTool, registerRunGraphWorkflowTool } from './index.js';
+import type { Expert } from '../../agents/index.js';
+
+// ============================================================================
+// Test Infrastructure
+// ============================================================================
+
+interface TestContext {
+  client: Client;
+  expertRegistry: Map<string, Expert>;
+  cleanup: () => Promise<void>;
+}
+
+/** Creates a mock expert that always fails execution. */
+function createFailingExpert(role: string): Expert {
+  return {
+    id: `${role}-fail`,
+    role,
+    capabilities: ['task_execution'] as const,
+    state: 'idle',
+    expertConfig: {
+      id: `${role}-fail`,
+      name: `${role} Failing`,
+      role,
+      systemPrompt: 'Mock prompt',
+      capabilities: ['task_execution'],
+    },
+    name: `${role} Failing`,
+    metadata: undefined,
+    execute: vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false as const,
+        error: new Error('Model returned empty response'),
+      })
+    ),
+  } as unknown as Expert;
+}
+
+async function setupServer(): Promise<TestContext> {
+  const serverResult = createServer();
+  if (!serverResult.ok) throw new Error(serverResult.error.message);
+  const { server, logger } = serverResult.value;
+
+  const infra = registerTools(server, { logger });
+  const baseDeps = { logger: infra.logger, rateLimiter: infra.rateLimiter };
+  const expertRegistry = new Map<string, Expert>();
+
+  registerExecuteExpertTool(server, { ...baseDeps, expertRegistry });
+  registerRunGraphWorkflowTool(server, { ...baseDeps, rateLimiter: infra.rateLimiter });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const connectResult = await connectTransport(server, serverTransport, logger);
+  if (!connectResult.ok) throw new Error(connectResult.error.message);
+
+  const client = new Client({ name: 'honesty-test', version: '1.0.0' });
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    expertRegistry,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+// ============================================================================
+// Honesty Contract Tests
+// ============================================================================
+
+describe('Tool Response Honesty Contract (§5.4)', () => {
+  let ctx: TestContext;
+
+  beforeAll(async () => {
+    ctx = await setupServer();
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  // --------------------------------------------------------------------------
+  // Rule 1: Never report success when the action failed
+  // --------------------------------------------------------------------------
+
+  describe('Rule 1: Failed actions must return isError=true', () => {
+    it('execute_expert returns isError when expert execution fails', async () => {
+      const failingExpert = createFailingExpert('code_expert');
+      ctx.expertRegistry.set('failing-expert', failingExpert);
+
+      const result = await ctx.client.callTool({
+        name: 'execute_expert',
+        arguments: {
+          expertId: 'failing-expert',
+          task: 'Review this code',
+        },
+      });
+
+      // Honesty contract: failed execution MUST set isError=true
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0]?.text ?? '';
+      expect(text).toContain('failed');
+    });
+
+    it('run_graph_workflow returns isError for invalid workflow', async () => {
+      const result = await ctx.client.callTool({
+        name: 'run_graph_workflow',
+        arguments: { workflow: 'nonexistent-workflow-xyz' },
+      });
+
+      // Honesty contract: unknown workflow MUST set isError=true
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Rule 3: Error propagation, not absorption
+  // --------------------------------------------------------------------------
+
+  describe('Rule 3: Domain errors propagate to MCP response', () => {
+    it('execute_expert does not wrap domain errors in ok:true', async () => {
+      const failingExpert = createFailingExpert('security_expert');
+      ctx.expertRegistry.set('wrapped-error-test', failingExpert);
+
+      const result = await ctx.client.callTool({
+        name: 'execute_expert',
+        arguments: {
+          expertId: 'wrapped-error-test',
+          task: 'Audit this module',
+        },
+      });
+
+      // The error message should be surfaced, not hidden in a success JSON
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0]?.text ?? '';
+      // Should contain the original error, not a generic wrapper
+      expect(text.toLowerCase()).toContain('model returned empty response');
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -218,13 +218,17 @@ function createGraphWorkflowHandler(
       workflow: parsed.data.workflow,
     });
     const result = await handleRunGraphWorkflow(parsed.data, logger);
+    const succeeded = result.status === 'completed';
     notifier.info('run_graph_workflow', {
-      event: 'graph_workflow_complete',
+      event: succeeded ? 'graph_workflow_complete' : 'graph_workflow_failed',
       workflow: result.workflow,
       nodeCount: result.nodesExecuted,
       durationMs: result.durationMs,
     });
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      ...(succeeded ? {} : { isError: true }),
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

- Added **§5.4 Tool Response Honesty Contract** to CODING_STANDARDS.md with 4 rules: never report success on failure, explicit partial success, error propagation not absorption, notification accuracy
- **Fixed execute-expert bug**: expert execution failures were wrapped in `ok: true` with `status: 'error'` payload — callers checking `result.ok` saw success while the action actually failed. Now properly returns `ok: false` so the MCP handler sends `isError: true`
- **Fixed run-graph-workflow bug**: failed workflows returned success without `isError: true`, and notifications always said `graph_workflow_complete` even for failures. Now uses `isError: true` for failed workflows and `graph_workflow_failed` notification event
- Added 3 integration tests through InMemoryTransport verifying honesty contract compliance

## Test plan

- [x] 3 new honesty contract tests via MCP InMemoryTransport handler chain
- [x] Full test suite: 22,557 tests pass (831 files, 0 failures)
- [x] TypeScript typecheck passes clean
- [x] ESLint + Prettier pass via pre-commit hooks
- [x] Fitness score: 98/100

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)