### PR TITLE
feat(#1009): Add cross-session persistence for StrategyDistiller and OutcomeStore

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -47,8 +47,12 @@ import {
   type ResourceStrategyConfig,
   type DistilledRuleStageConfig,
 } from './routing/stages/index.js';
-import { StrategyDistiller } from '../learning/strategy-distiller.js';
+import {
+  StrategyDistiller,
+  createPersistentDistillerOrFallback,
+} from '../learning/strategy-distiller.js';
 import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import { isPersistenceEnabled } from '../config/learning-persistence.js';
 import {
   CompositeRouterConfigSchema,
   CompositeRoutingError,
@@ -271,7 +275,9 @@ export class CompositeRouter implements ICompositeRouter {
       this.resourceStrategyStage = new ResourceStrategyStage(stageConfigs.resourceStrategy);
     }
     if (this.config.enableStrategyDistillation) {
-      this.strategyDistiller = new StrategyDistiller(getOutcomeStore(), this.logger);
+      this.strategyDistiller = isPersistenceEnabled()
+        ? createPersistentDistillerOrFallback(getOutcomeStore(), this.logger)
+        : new StrategyDistiller(getOutcomeStore(), this.logger);
       this.distilledRuleStage = new DistilledRuleStage(
         this.strategyDistiller,
         stageConfigs.distilledRule

--- a/packages/nexus-agents/src/config/learning-persistence.ts
+++ b/packages/nexus-agents/src/config/learning-persistence.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared configuration for cross-session learning persistence.
+ *
+ * Controls where learning data (outcomes, distilled rules) is stored
+ * on disk and whether persistence is enabled via feature flag.
+ *
+ * @module config/learning-persistence
+ * (Source: Issue #1009 — Cross-session persistence)
+ */
+
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Base directory for learning persistence data. */
+export const LEARNING_DIR = join(homedir(), '.nexus-agents', 'learning');
+
+/** JSONL file for persisted task outcomes. */
+export const OUTCOMES_FILE = join(LEARNING_DIR, 'outcomes.jsonl');
+
+/** JSON file for persisted distilled rules. */
+export const RULES_FILE = join(LEARNING_DIR, 'rules.json');
+
+/** Directory mode: owner-only (rwx------). */
+const DIR_MODE = 0o700;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Check whether learning persistence is enabled via feature flag. */
+export function isPersistenceEnabled(): boolean {
+  return process.env['NEXUS_PERSIST_LEARNING'] === 'true';
+}
+
+/** Ensure the learning data directory exists. */
+export function ensureLearningDir(dir: string = LEARNING_DIR): void {
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+}

--- a/packages/nexus-agents/src/exports/learning.ts
+++ b/packages/nexus-agents/src/exports/learning.ts
@@ -78,6 +78,11 @@ export {
   detectFailurePatterns,
   detectSuccessPatterns,
   detectLatencyPatterns,
+  // Strategy Distiller Persistence (Issue #1009)
+  PersistentStrategyDistiller,
+  RulesSnapshotSchema,
+  type RulesSnapshot,
+  type PersistentDistillerConfig,
   // A/B Test Tracker (Issue #273)
   type ExperimentStatus,
   type ExperimentVariant,

--- a/packages/nexus-agents/src/exports/orchestration.ts
+++ b/packages/nexus-agents/src/exports/orchestration.ts
@@ -168,11 +168,13 @@ export {
   getOutcomeStore,
   OutcomeStore,
   TaskOutcomeSchema as OutcomeTaskSchema,
+  PersistentOutcomeStore,
 } from '../orchestration/index.js';
 export type {
   TaskOutcome as OutcomeTaskRecord,
   PerformanceSummary,
   OutcomeStoreConfig,
+  PersistentOutcomeStoreConfig,
 } from '../orchestration/index.js';
 
 // Adaptive Thresholds — Learning Loop (Issue #901, Phase 4)

--- a/packages/nexus-agents/src/learning/index.ts
+++ b/packages/nexus-agents/src/learning/index.ts
@@ -102,11 +102,20 @@ export { DEFAULT_DISTILLER_CONFIG } from './strategy-distiller-types.js';
 export {
   StrategyDistiller,
   createStrategyDistiller,
+  createPersistentDistillerOrFallback,
+  registerPersistentDistillerFactory,
   sigmoidConfidence,
   detectFailurePatterns,
   detectSuccessPatterns,
   detectLatencyPatterns,
 } from './strategy-distiller.js';
+
+// Strategy Distiller Persistence (Issue #1009)
+export {
+  PersistentStrategyDistiller,
+  RulesSnapshotSchema,
+} from './strategy-distiller-persistence.js';
+export type { RulesSnapshot, PersistentDistillerConfig } from './strategy-distiller-persistence.js';
 
 // A/B Test Tracker (Issue #273)
 export type {

--- a/packages/nexus-agents/src/learning/learning-persistence.integration.test.ts
+++ b/packages/nexus-agents/src/learning/learning-persistence.integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Integration tests for cross-session learning persistence (Issue #1009).
+ *
+ * End-to-end tests: append outcomes → distill → simulate restart → hydrate →
+ * verify rules are preserved. Also tests feature flag off behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+import { PersistentOutcomeStore } from '../orchestration/outcomes/outcome-store-persistence.js';
+import { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import { PersistentStrategyDistiller } from './strategy-distiller-persistence.js';
+import { StrategyDistiller } from './strategy-distiller.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `nexus-integ-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeOutcome(overrides?: Partial<TaskOutcome>): TaskOutcome {
+  return {
+    id: `out-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
+    cli: 'claude',
+    category: 'code_generation',
+    model: 'claude-sonnet-4-5',
+    success: false,
+    durationMs: 1200,
+    timestamp: '2026-02-07T10:00:00Z',
+    source: 'delegate',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+describe('Learning Persistence Integration', () => {
+  let tmpDir: string;
+  let outcomesFile: string;
+  let rulesFile: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    outcomesFile = join(tmpDir, 'outcomes.jsonl');
+    rulesFile = join(tmpDir, 'rules.json');
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('end-to-end: outcomes → distill → restart → rules preserved', () => {
+    // Session 1: accumulate outcomes and distill rules
+    const store1 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+
+    for (let i = 0; i < 15; i++) {
+      store1.append(
+        makeOutcome({
+          id: `s1-${String(i)}`,
+          cli: 'claude',
+          category: 'code_generation',
+          success: false,
+        })
+      );
+    }
+
+    const distiller1 = new PersistentStrategyDistiller(
+      store1,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, minObservationsForDraft: 3 }
+    );
+    distiller1.distill();
+
+    const session1Rules = distiller1.getRules();
+    expect(session1Rules.length).toBeGreaterThan(0);
+    expect(store1.size).toBe(15);
+
+    // Session 2: simulate restart — new instances, same files
+    const store2 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    expect(store2.size).toBe(15);
+
+    const distiller2 = new PersistentStrategyDistiller(
+      store2,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, minObservationsForDraft: 3 }
+    );
+
+    const session2Rules = distiller2.getRules();
+    expect(session2Rules).toHaveLength(session1Rules.length);
+
+    for (const rule of session1Rules) {
+      const loaded = session2Rules.find((r) => r.id === rule.id);
+      expect(loaded).toBeDefined();
+      expect(loaded?.confidence).toBe(rule.confidence);
+    }
+  });
+
+  it('outcomes grow across sessions', () => {
+    // Session 1
+    const store1 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    store1.append(makeOutcome({ id: 'session1-1' }));
+    store1.append(makeOutcome({ id: 'session1-2' }));
+    expect(store1.size).toBe(2);
+
+    // Session 2
+    const store2 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    expect(store2.size).toBe(2);
+    store2.append(makeOutcome({ id: 'session2-1' }));
+    expect(store2.size).toBe(3);
+
+    // Session 3
+    const store3 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    expect(store3.size).toBe(3);
+  });
+
+  it('rules evolve across distill cycles', () => {
+    const store = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+
+    // Cycle 1: failures for claude
+    for (let i = 0; i < 10; i++) {
+      store.append(makeOutcome({ id: `c1-${String(i)}`, cli: 'claude', success: false }));
+    }
+
+    const d1 = new PersistentStrategyDistiller(
+      store,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, successRateThreshold: 0.7, minObservationsForDraft: 3 }
+    );
+    d1.distill();
+    const count1 = d1.getRules().length;
+
+    // Cycle 2: add successes for gemini (simulate restart with new store)
+    const store2 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    for (let i = 0; i < 10; i++) {
+      store2.append(
+        makeOutcome({
+          id: `c2-${String(i)}`,
+          cli: 'gemini',
+          category: 'research',
+          success: true,
+        })
+      );
+    }
+
+    const d2 = new PersistentStrategyDistiller(
+      store2,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, successRateThreshold: 0.7, minObservationsForDraft: 3 }
+    );
+    d2.distill();
+    // Should have rules from both cycles
+    expect(d2.getRules().length).toBeGreaterThanOrEqual(count1);
+  });
+
+  it('feature flag off → no files created', () => {
+    // When not using persistent stores, no files should be created
+    const plainStore = new OutcomeStore();
+    for (let i = 0; i < 10; i++) {
+      plainStore.append(makeOutcome({ id: `plain-${String(i)}` }));
+    }
+
+    const plainDistiller = new StrategyDistiller(plainStore, undefined, {
+      failureRateThreshold: 0.5,
+    });
+    plainDistiller.distill();
+
+    // No persistence files should exist
+    expect(existsSync(outcomesFile)).toBe(false);
+    expect(existsSync(rulesFile)).toBe(false);
+
+    // Rules exist in memory
+    expect(plainDistiller.getRules().length).toBeGreaterThan(0);
+  });
+
+  it('distiller applies hydrated rules to routing stage', () => {
+    // Save rules in session 1
+    const store1 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    for (let i = 0; i < 10; i++) {
+      store1.append(makeOutcome({ id: `r-${String(i)}`, success: false }));
+    }
+
+    const d1 = new PersistentStrategyDistiller(
+      store1,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, minObservationsForDraft: 3, minObservationsForActive: 5 }
+    );
+    d1.distill();
+    const activeRules = d1.getRules('active');
+    expect(activeRules.length).toBeGreaterThan(0);
+
+    // Session 2: hydrate and verify active rules are accessible
+    const store2 = new PersistentOutcomeStore({
+      filePath: outcomesFile,
+      dataDir: tmpDir,
+    });
+    const d2 = new PersistentStrategyDistiller(
+      store2,
+      { filePath: rulesFile, dataDir: tmpDir },
+      undefined,
+      { failureRateThreshold: 0.5, minObservationsForDraft: 3, minObservationsForActive: 5 }
+    );
+
+    // Active rules should be present from hydration
+    const hydratedActive = d2.getRules('active');
+    expect(hydratedActive.length).toBe(activeRules.length);
+  });
+
+  it('handles missing data directory gracefully', () => {
+    const deepDir = join(tmpDir, 'a', 'b', 'c');
+    const deepFile = join(deepDir, 'outcomes.jsonl');
+
+    // Should create directory automatically
+    const store = new PersistentOutcomeStore({
+      filePath: deepFile,
+      dataDir: deepDir,
+    });
+    store.append(makeOutcome({ id: 'deep-1' }));
+
+    expect(existsSync(deepFile)).toBe(true);
+    expect(store.size).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/learning/strategy-distiller-persistence.test.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller-persistence.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for PersistentStrategyDistiller (Issue #1009).
+ *
+ * Covers: hydration from JSON, atomic persistence, corruption handling,
+ * schema validation, version check, and round-trip save→load.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+import { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import {
+  PersistentStrategyDistiller,
+  RulesSnapshotSchema,
+} from './strategy-distiller-persistence.js';
+import type { RulesSnapshot } from './strategy-distiller-persistence.js';
+import type { DistilledRule } from './strategy-distiller-types.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `nexus-rules-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeRule(overrides?: Partial<DistilledRule>): DistilledRule {
+  return {
+    id: 'failure-rate:claude:code_generation',
+    patternType: 'failure-rate',
+    cli: 'claude',
+    category: 'code_generation',
+    action: 'penalize',
+    confidence: 0.8,
+    observationCount: 40,
+    metric: 0.7,
+    status: 'active',
+    createdAt: 1000,
+    updatedAt: 2000,
+    tainted: false,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(rules: DistilledRule[]): RulesSnapshot {
+  return {
+    version: 1,
+    savedAt: '2026-02-13T10:00:00Z',
+    rules,
+  };
+}
+
+function makeOutcome(overrides?: Partial<TaskOutcome>): TaskOutcome {
+  return {
+    id: `out-${String(Date.now())}`,
+    cli: 'claude',
+    category: 'code_generation',
+    model: 'claude-sonnet-4-5',
+    success: false,
+    durationMs: 1200,
+    timestamp: '2026-02-07T10:00:00Z',
+    source: 'delegate',
+    ...overrides,
+  };
+}
+
+// Populate an OutcomeStore with enough failure outcomes to trigger pattern detection
+function populateFailures(store: OutcomeStore, count: number): void {
+  for (let i = 0; i < count; i++) {
+    store.append(makeOutcome({ id: `fail-${String(i)}`, success: false }));
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('PersistentStrategyDistiller', () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    filePath = join(tmpDir, 'rules.json');
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // Hydration
+  // --------------------------------------------------------------------------
+
+  describe('hydration', () => {
+    it('starts with no rules when no file exists', () => {
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(0);
+    });
+
+    it('hydrates valid rules from snapshot file', () => {
+      const rules = [
+        makeRule({ id: 'failure-rate:claude:code_generation' }),
+        makeRule({
+          id: 'success-rate:gemini:research',
+          cli: 'gemini',
+          patternType: 'success-rate',
+          action: 'boost',
+        }),
+      ];
+      writeFileSync(filePath, JSON.stringify(makeSnapshot(rules)));
+
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(2);
+    });
+
+    it('starts fresh on corrupt JSON', () => {
+      writeFileSync(filePath, '{not valid json');
+
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(0);
+    });
+
+    it('starts fresh on schema mismatch', () => {
+      writeFileSync(filePath, JSON.stringify({ version: 99, rules: [] }));
+
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(0);
+    });
+
+    it('validates version number strictly', () => {
+      // version: 2 should fail
+      writeFileSync(filePath, JSON.stringify({ version: 2, savedAt: 'now', rules: [] }));
+
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(0);
+    });
+
+    it('rejects rules with invalid fields', () => {
+      const badSnapshot = {
+        version: 1,
+        savedAt: 'now',
+        rules: [{ id: 'x', patternType: 'unknown-type' }],
+      };
+      writeFileSync(filePath, JSON.stringify(badSnapshot));
+
+      const store = new OutcomeStore();
+      const distiller = new PersistentStrategyDistiller(store, {
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(distiller.getRules()).toHaveLength(0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Persistence
+  // --------------------------------------------------------------------------
+
+  describe('persistence', () => {
+    it('saves rules atomically on distill()', () => {
+      const store = new OutcomeStore();
+      populateFailures(store, 10);
+
+      const distiller = new PersistentStrategyDistiller(
+        store,
+        { filePath, dataDir: tmpDir },
+        undefined,
+        { failureRateThreshold: 0.5, minObservationsForDraft: 3 }
+      );
+      distiller.distill();
+
+      expect(existsSync(filePath)).toBe(true);
+      const content = readFileSync(filePath, 'utf-8');
+      const parsed = RulesSnapshotSchema.parse(JSON.parse(content));
+      expect(parsed.version).toBe(1);
+      expect(parsed.rules.length).toBeGreaterThan(0);
+    });
+
+    it('does not leave temp files on successful write', () => {
+      const store = new OutcomeStore();
+      populateFailures(store, 10);
+
+      const distiller = new PersistentStrategyDistiller(
+        store,
+        { filePath, dataDir: tmpDir },
+        undefined,
+        { failureRateThreshold: 0.5 }
+      );
+      distiller.distill();
+
+      expect(existsSync(filePath + '.tmp')).toBe(false);
+    });
+
+    it('handles write error gracefully', () => {
+      const store = new OutcomeStore();
+      populateFailures(store, 10);
+
+      // Constructor can create the dir, but let's point to an impossible path
+      const distiller = new PersistentStrategyDistiller(
+        store,
+        { filePath: join('/dev/null/impossible', 'rules.json'), dataDir: tmpDir },
+        undefined,
+        { failureRateThreshold: 0.5 }
+      );
+      // Should not throw
+      expect(() => {
+        distiller.distill();
+      }).not.toThrow();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Round-trip
+  // --------------------------------------------------------------------------
+
+  describe('round-trip', () => {
+    it('save → load → verify rules match', () => {
+      const store = new OutcomeStore();
+      populateFailures(store, 10);
+
+      // First distiller: distill + save
+      const distiller1 = new PersistentStrategyDistiller(
+        store,
+        { filePath, dataDir: tmpDir },
+        undefined,
+        { failureRateThreshold: 0.5, minObservationsForDraft: 3 }
+      );
+      distiller1.distill();
+      const savedRules = distiller1.getRules();
+      expect(savedRules.length).toBeGreaterThan(0);
+
+      // Second distiller: hydrate from file
+      const store2 = new OutcomeStore();
+      const distiller2 = new PersistentStrategyDistiller(
+        store2,
+        { filePath, dataDir: tmpDir },
+        undefined,
+        { failureRateThreshold: 0.5, minObservationsForDraft: 3 }
+      );
+      const loadedRules = distiller2.getRules();
+
+      expect(loadedRules).toHaveLength(savedRules.length);
+      for (const saved of savedRules) {
+        const loaded = loadedRules.find((r) => r.id === saved.id);
+        expect(loaded).toBeDefined();
+        expect(loaded?.confidence).toBe(saved.confidence);
+        expect(loaded?.action).toBe(saved.action);
+        expect(loaded?.status).toBe(saved.status);
+      }
+    });
+
+    it('accumulates rules across multiple distill+restart cycles', () => {
+      // Cycle 1: failure pattern for claude
+      const store1 = new OutcomeStore();
+      populateFailures(store1, 10);
+      const d1 = new PersistentStrategyDistiller(store1, { filePath, dataDir: tmpDir }, undefined, {
+        failureRateThreshold: 0.5,
+        minObservationsForDraft: 3,
+      });
+      d1.distill();
+      const count1 = d1.getRules().length;
+      expect(count1).toBeGreaterThan(0);
+
+      // Cycle 2: add success pattern for gemini
+      const store2 = new OutcomeStore();
+      for (let i = 0; i < 10; i++) {
+        store2.append(
+          makeOutcome({
+            id: `gem-${String(i)}`,
+            cli: 'gemini',
+            category: 'research',
+            success: true,
+          })
+        );
+      }
+      const d2 = new PersistentStrategyDistiller(store2, { filePath, dataDir: tmpDir }, undefined, {
+        successRateThreshold: 0.7,
+        minObservationsForDraft: 3,
+      });
+      d2.distill();
+      // Should have rules from both cycles
+      expect(d2.getRules().length).toBeGreaterThanOrEqual(count1);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // RulesSnapshotSchema validation
+  // --------------------------------------------------------------------------
+
+  describe('RulesSnapshotSchema', () => {
+    it('accepts valid snapshot', () => {
+      const result = RulesSnapshotSchema.safeParse(makeSnapshot([makeRule()]));
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing version', () => {
+      const result = RulesSnapshotSchema.safeParse({ savedAt: 'now', rules: [] });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects wrong version number', () => {
+      const result = RulesSnapshotSchema.safeParse({ version: 2, savedAt: 'now', rules: [] });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
@@ -1,0 +1,173 @@
+/**
+ * Persistent StrategyDistiller — JSON-backed cross-session persistence.
+ *
+ * Extends StrategyDistiller with atomic disk writes (write tmp + rename)
+ * for distilled rules. Hydrates from a versioned JSON snapshot on
+ * construction; saves after every distill() call.
+ *
+ * @module learning/strategy-distiller-persistence
+ * (Source: Issue #1009 — Cross-session persistence)
+ */
+
+import { writeFileSync, readFileSync, renameSync, unlinkSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { z } from 'zod';
+
+import type { ILogger } from '../core/index.js';
+import { createLogger } from '../core/index.js';
+import type { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import type { DistilledRule, DistillerConfig } from './strategy-distiller-types.js';
+import { StrategyDistiller, registerPersistentDistillerFactory } from './strategy-distiller.js';
+import { ensureLearningDir, RULES_FILE } from '../config/learning-persistence.js';
+
+// ============================================================================
+// Versioned Schema
+// ============================================================================
+
+const DistilledRuleSchema = z.object({
+  id: z.string(),
+  patternType: z.enum(['failure-rate', 'success-rate', 'latency-spike']),
+  cli: z.enum(['claude', 'gemini', 'codex']),
+  category: z.string(),
+  action: z.enum(['penalize', 'boost', 'avoid']),
+  confidence: z.number(),
+  observationCount: z.number(),
+  metric: z.number(),
+  status: z.enum(['draft', 'active', 'promoted', 'expired']),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  tainted: z.boolean(),
+});
+
+/** Versioned snapshot schema for atomic saves. */
+export const RulesSnapshotSchema = z.object({
+  version: z.literal(1),
+  savedAt: z.string(),
+  rules: z.array(DistilledRuleSchema),
+});
+
+export type RulesSnapshot = z.infer<typeof RulesSnapshotSchema>;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export interface PersistentDistillerConfig {
+  /** Override the file path (useful for testing). */
+  readonly filePath?: string;
+  /** Override the data directory (useful for testing). */
+  readonly dataDir?: string;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/**
+ * StrategyDistiller that persists distilled rules to a JSON file.
+ *
+ * - Construction: hydrates from rules.json via Zod validation
+ * - distill(): calls super.distill() then atomically saves snapshot
+ * - Corruption: warn + start fresh (no partial loads)
+ */
+export class PersistentStrategyDistiller extends StrategyDistiller {
+  private readonly filePath: string;
+  private readonly persistLogger: ILogger;
+
+  constructor(
+    outcomeStore: OutcomeStore,
+    persistConfig?: PersistentDistillerConfig,
+    logger?: ILogger,
+    distillerConfig?: Partial<DistillerConfig>
+  ) {
+    super(outcomeStore, logger, distillerConfig);
+    this.filePath = persistConfig?.filePath ?? RULES_FILE;
+    this.persistLogger = logger ?? createLogger({ component: 'PersistentStrategyDistiller' });
+
+    const dataDir = persistConfig?.dataDir;
+    ensureLearningDir(dataDir);
+    this.hydrate();
+  }
+
+  /** Override distill to persist rules after each run. */
+  override distill(): void {
+    super.distill();
+    this.saveSnapshot();
+  }
+
+  // ==========================================================================
+  // Private
+  // ==========================================================================
+
+  private hydrate(): void {
+    if (!existsSync(this.filePath)) {
+      this.persistLogger.debug('No rules file found, starting fresh', {
+        path: this.filePath,
+      });
+      return;
+    }
+
+    try {
+      const content = readFileSync(this.filePath, 'utf-8');
+      const parsed: unknown = JSON.parse(content);
+      const result = RulesSnapshotSchema.safeParse(parsed);
+
+      if (!result.success) {
+        this.persistLogger.warn('Rules file failed validation, starting fresh', {
+          path: this.filePath,
+          error: result.error.message,
+        });
+        return;
+      }
+
+      this.loadRules(result.data.rules);
+      this.persistLogger.info('Hydrated distilled rules from disk', {
+        ruleCount: result.data.rules.length,
+        savedAt: result.data.savedAt,
+        path: this.filePath,
+      });
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.persistLogger.warn('Failed to hydrate rules from disk', {
+        error: msg,
+        path: this.filePath,
+      });
+    }
+  }
+
+  private saveSnapshot(): void {
+    const rules = this.getRules();
+    const snapshot: RulesSnapshot = {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      rules: rules as DistilledRule[],
+    };
+
+    const tmpPath = this.filePath + '.tmp';
+    try {
+      // Ensure parent directory exists
+      ensureLearningDir(dirname(this.filePath));
+      // Atomic write: temp file + rename
+      writeFileSync(tmpPath, JSON.stringify(snapshot, null, 2), 'utf-8');
+      renameSync(tmpPath, this.filePath);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.persistLogger.warn('Failed to persist rules to disk', {
+        error: msg,
+        path: this.filePath,
+      });
+      // Clean up temp file on failure
+      try {
+        if (existsSync(tmpPath)) unlinkSync(tmpPath);
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  }
+}
+
+// Self-register factory so CompositeRouter can create PersistentStrategyDistiller
+// without a circular top-level import.
+registerPersistentDistillerFactory(
+  (outcomeStore, logger) => new PersistentStrategyDistiller(outcomeStore, undefined, logger)
+);

--- a/packages/nexus-agents/src/learning/strategy-distiller.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller.ts
@@ -284,6 +284,17 @@ export class StrategyDistiller {
   }
 
   // ==========================================================================
+  // Protected — for subclass hydration (Issue #1009)
+  // ==========================================================================
+
+  /** Load pre-existing rules (e.g., from disk). Used by PersistentStrategyDistiller. */
+  protected loadRules(rules: readonly DistilledRule[]): void {
+    for (const rule of rules) {
+      this.rules.set(rule.id, rule);
+    }
+  }
+
+  // ==========================================================================
   // Private
   // ==========================================================================
 
@@ -380,4 +391,34 @@ export function createStrategyDistiller(
   config?: Partial<DistillerConfig>
 ): StrategyDistiller {
   return new StrategyDistiller(outcomeStore, logger, config);
+}
+
+// ============================================================================
+// Persistent factory registration (Issue #1009)
+// ============================================================================
+
+type DistillerFactory = (outcomeStore: OutcomeStore, logger: ILogger) => StrategyDistiller;
+let persistentDistillerFactory: DistillerFactory | undefined;
+
+/**
+ * Register a factory for creating PersistentStrategyDistiller instances.
+ * Called from strategy-distiller-persistence.ts at import time to break
+ * the circular dependency with composite-router.
+ */
+export function registerPersistentDistillerFactory(factory: DistillerFactory): void {
+  persistentDistillerFactory = factory;
+}
+
+/**
+ * Create a persistent distiller if the factory is registered, else a plain one.
+ * Used by CompositeRouter when NEXUS_PERSIST_LEARNING=true.
+ */
+export function createPersistentDistillerOrFallback(
+  outcomeStore: OutcomeStore,
+  logger: ILogger
+): StrategyDistiller {
+  if (persistentDistillerFactory !== undefined) {
+    return persistentDistillerFactory(outcomeStore, logger);
+  }
+  return new StrategyDistiller(outcomeStore, logger);
 }

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -176,8 +176,9 @@ export {
   OutcomeStore,
   getOutcomeStore,
   resetOutcomeStore,
+  PersistentOutcomeStore,
 } from './outcomes/index.js';
-export type { OutcomeStoreConfig } from './outcomes/index.js';
+export type { OutcomeStoreConfig, PersistentOutcomeStoreConfig } from './outcomes/index.js';
 
 // Adaptive Thresholds — Learning Loop (Issue #901, Phase 4)
 export { computeAdaptiveThresholds, detectTrend } from './outcomes/index.js';

--- a/packages/nexus-agents/src/orchestration/outcomes/index.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/index.ts
@@ -20,8 +20,15 @@ export {
   OutcomeStore,
   getOutcomeStore,
   resetOutcomeStore,
+  registerPersistentOutcomeStoreFactory,
   type OutcomeStoreConfig,
 } from './outcome-store.js';
+
+// Persistence (Issue #1009)
+export {
+  PersistentOutcomeStore,
+  type PersistentOutcomeStoreConfig,
+} from './outcome-store-persistence.js';
 
 // Adaptive thresholds — Learning loop (Issue #901, Phase 4)
 export { computeAdaptiveThresholds, detectTrend } from './adaptive-thresholds.js';

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for PersistentOutcomeStore (Issue #1009).
+ *
+ * Covers: hydration from JSONL, persistence on append, corruption handling,
+ * FIFO eviction on hydrate, graceful degradation on disk errors,
+ * and feature flag behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { TaskOutcome } from './outcome-types.js';
+import { PersistentOutcomeStore } from './outcome-store-persistence.js';
+import {
+  resetOutcomeStore,
+  getOutcomeStore,
+  registerPersistentOutcomeStoreFactory,
+} from './outcome-store.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `nexus-persist-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeOutcome(overrides?: Partial<TaskOutcome>): TaskOutcome {
+  return {
+    id: `out-${String(Date.now())}`,
+    cli: 'claude',
+    category: 'code_generation',
+    model: 'claude-sonnet-4-5',
+    success: true,
+    durationMs: 1200,
+    timestamp: '2026-02-07T10:00:00Z',
+    source: 'delegate',
+    ...overrides,
+  };
+}
+
+function makeOutcomeLine(overrides?: Partial<TaskOutcome>): string {
+  return JSON.stringify(makeOutcome(overrides));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('PersistentOutcomeStore', () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    filePath = join(tmpDir, 'outcomes.jsonl');
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // Hydration
+  // --------------------------------------------------------------------------
+
+  describe('hydration', () => {
+    it('starts empty when no file exists', () => {
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(0);
+    });
+
+    it('hydrates valid JSONL on construction', () => {
+      const lines =
+        [
+          makeOutcomeLine({ id: 'out-1' }),
+          makeOutcomeLine({ id: 'out-2' }),
+          makeOutcomeLine({ id: 'out-3' }),
+        ].join('\n') + '\n';
+      writeFileSync(filePath, lines);
+
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(3);
+    });
+
+    it('skips malformed lines gracefully', () => {
+      const lines =
+        [
+          makeOutcomeLine({ id: 'out-1' }),
+          'not-json-at-all',
+          '{"partial": true}',
+          makeOutcomeLine({ id: 'out-4' }),
+        ].join('\n') + '\n';
+      writeFileSync(filePath, lines);
+
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(2);
+    });
+
+    it('handles empty file', () => {
+      writeFileSync(filePath, '');
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(0);
+    });
+
+    it('handles file with only blank lines', () => {
+      writeFileSync(filePath, '\n\n\n');
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(0);
+    });
+
+    it('enforces FIFO eviction when hydrated count exceeds maxEntries', () => {
+      const lines =
+        Array.from({ length: 10 }, (_, i) => makeOutcomeLine({ id: `out-${String(i)}` })).join(
+          '\n'
+        ) + '\n';
+      writeFileSync(filePath, lines);
+
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+        maxEntries: 5,
+      });
+      expect(store.size).toBe(5);
+      // Should retain the last 5 (FIFO eviction)
+      const entries = store.query();
+      expect(entries[0]?.id).toBe('out-5');
+      expect(entries[4]?.id).toBe('out-9');
+    });
+
+    it('skips partially corrupt files (some valid, some invalid)', () => {
+      const lines =
+        [
+          makeOutcomeLine({ id: 'valid-1' }),
+          '{"id":"x","cli":"claude"}', // missing required fields
+          '{invalid json',
+          makeOutcomeLine({ id: 'valid-2' }),
+        ].join('\n') + '\n';
+      writeFileSync(filePath, lines);
+
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store.size).toBe(2);
+      const entries = store.query();
+      expect(entries[0]?.id).toBe('valid-1');
+      expect(entries[1]?.id).toBe('valid-2');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Persistence
+  // --------------------------------------------------------------------------
+
+  describe('persistence', () => {
+    it('writes each append to disk', () => {
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+
+      store.append(makeOutcome({ id: 'new-1' }));
+      store.append(makeOutcome({ id: 'new-2' }));
+
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(2);
+
+      const parsed1 = JSON.parse(lines[0] ?? '') as TaskOutcome;
+      const parsed2 = JSON.parse(lines[1] ?? '') as TaskOutcome;
+      expect(parsed1.id).toBe('new-1');
+      expect(parsed2.id).toBe('new-2');
+    });
+
+    it('appends to existing file content', () => {
+      writeFileSync(filePath, makeOutcomeLine({ id: 'existing' }) + '\n');
+
+      const store = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      store.append(makeOutcome({ id: 'appended' }));
+
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(2);
+    });
+
+    it('creates the data directory if it does not exist', () => {
+      const nestedDir = join(tmpDir, 'nested', 'deep');
+      const nestedFile = join(nestedDir, 'outcomes.jsonl');
+
+      const store = new PersistentOutcomeStore({
+        filePath: nestedFile,
+        dataDir: nestedDir,
+      });
+      store.append(makeOutcome({ id: 'nested-1' }));
+
+      expect(existsSync(nestedFile)).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Graceful degradation
+  // --------------------------------------------------------------------------
+
+  describe('graceful degradation', () => {
+    it('logs warning on hydration read error (non-file path)', () => {
+      // Point to a directory instead of a file — readFileSync will throw
+      const store = new PersistentOutcomeStore({
+        filePath: tmpDir, // a directory, not a file
+        dataDir: tmpDir,
+      });
+      // Should not throw, just log warning and start empty
+      expect(store.size).toBe(0);
+    });
+
+    it('logs warning on persist write error', () => {
+      const readonlyDir = join(tmpDir, 'readonly');
+      mkdirSync(readonlyDir, { recursive: true });
+      // Point to a path inside a non-existent dir to cause write failure
+      const badPath = join(tmpDir, 'no-such-dir', 'outcomes.jsonl');
+
+      const store = new PersistentOutcomeStore({
+        filePath: badPath,
+        dataDir: tmpDir,
+      });
+      // Should not throw on append even if write fails
+      expect(() => {
+        store.append(makeOutcome());
+      }).not.toThrow();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Round-trip
+  // --------------------------------------------------------------------------
+
+  describe('round-trip', () => {
+    it('survives save → load cycle', () => {
+      const store1 = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      store1.append(makeOutcome({ id: 'rt-1', cli: 'claude', success: true }));
+      store1.append(makeOutcome({ id: 'rt-2', cli: 'gemini', success: false }));
+      store1.append(makeOutcome({ id: 'rt-3', cli: 'codex', durationMs: 5000 }));
+
+      // Create a new store from the same file (simulates restart)
+      const store2 = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(store2.size).toBe(3);
+
+      const entries = store2.query();
+      expect(entries[0]?.id).toBe('rt-1');
+      expect(entries[1]?.cli).toBe('gemini');
+      expect(entries[2]?.durationMs).toBe(5000);
+    });
+
+    it('preserves data through multiple restart cycles', () => {
+      for (let cycle = 0; cycle < 3; cycle++) {
+        const store = new PersistentOutcomeStore({
+          filePath,
+          dataDir: tmpDir,
+        });
+        store.append(makeOutcome({ id: `cycle-${String(cycle)}` }));
+      }
+
+      const finalStore = new PersistentOutcomeStore({
+        filePath,
+        dataDir: tmpDir,
+      });
+      expect(finalStore.size).toBe(3);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Feature flag integration
+  // --------------------------------------------------------------------------
+
+  describe('feature flag integration', () => {
+    beforeEach(() => {
+      resetOutcomeStore();
+    });
+
+    afterEach(() => {
+      resetOutcomeStore();
+      delete process.env['NEXUS_PERSIST_LEARNING'];
+    });
+
+    it('getOutcomeStore returns plain store when flag is off', () => {
+      delete process.env['NEXUS_PERSIST_LEARNING'];
+      const store = getOutcomeStore();
+      expect(store).not.toBeInstanceOf(PersistentOutcomeStore);
+    });
+
+    it('getOutcomeStore returns persistent store when flag is on and factory registered', () => {
+      process.env['NEXUS_PERSIST_LEARNING'] = 'true';
+      resetOutcomeStore();
+      // Factory was registered at import time by outcome-store-persistence.ts
+      // Re-register pointing to our tmp dir for test isolation
+      registerPersistentOutcomeStoreFactory(
+        () => new PersistentOutcomeStore({ filePath, dataDir: tmpDir })
+      );
+      const store = getOutcomeStore();
+      expect(store).toBeInstanceOf(PersistentOutcomeStore);
+    });
+  });
+});

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.ts
@@ -1,0 +1,127 @@
+/**
+ * Persistent OutcomeStore — JSONL-backed cross-session persistence.
+ *
+ * Extends the in-memory OutcomeStore with disk-backed append-only
+ * JSONL storage. Hydrates on construction, appends on every write.
+ * Corrupt lines are skipped with a warning (graceful degradation).
+ *
+ * @module orchestration/outcomes/outcome-store-persistence
+ * (Source: Issue #1009 — Cross-session persistence)
+ */
+
+import { appendFileSync, readFileSync, existsSync } from 'node:fs';
+
+import type { ILogger } from '../../core/index.js';
+import { createLogger } from '../../core/index.js';
+import { TaskOutcomeSchema } from './outcome-types.js';
+import type { TaskOutcome } from './outcome-types.js';
+import { OutcomeStore, registerPersistentOutcomeStoreFactory } from './outcome-store.js';
+import type { OutcomeStoreConfig } from './outcome-store.js';
+import { ensureLearningDir, OUTCOMES_FILE } from '../../config/learning-persistence.js';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export interface PersistentOutcomeStoreConfig extends OutcomeStoreConfig {
+  /** Override the file path (useful for testing). */
+  readonly filePath?: string;
+  /** Override the data directory (useful for testing). */
+  readonly dataDir?: string;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/**
+ * OutcomeStore that persists entries to a JSONL file on disk.
+ *
+ * - Construction: hydrates from existing JSONL file (Zod-validates each line)
+ * - Append: calls super.append() then appendFileSync one JSON line
+ * - Corruption: bad lines are skipped with a warning log
+ */
+export class PersistentOutcomeStore extends OutcomeStore {
+  private readonly filePath: string;
+  private readonly logger: ILogger;
+
+  constructor(config?: PersistentOutcomeStoreConfig, logger?: ILogger) {
+    super(config);
+    this.filePath = config?.filePath ?? OUTCOMES_FILE;
+    this.logger = logger ?? createLogger({ component: 'PersistentOutcomeStore' });
+
+    const dataDir = config?.dataDir;
+    ensureLearningDir(dataDir);
+    this.hydrate();
+  }
+
+  /** Override append to persist each entry to disk. */
+  override append(outcome: TaskOutcome): void {
+    super.append(outcome);
+    this.persistLine(outcome);
+  }
+
+  // ==========================================================================
+  // Private
+  // ==========================================================================
+
+  private hydrate(): void {
+    if (!existsSync(this.filePath)) {
+      this.logger.debug('No outcomes file found, starting fresh', {
+        path: this.filePath,
+      });
+      return;
+    }
+
+    try {
+      const content = readFileSync(this.filePath, 'utf-8');
+      const lines = content.split('\n').filter((line) => line.trim().length > 0);
+      let loaded = 0;
+      let skipped = 0;
+
+      for (const line of lines) {
+        try {
+          const parsed: unknown = JSON.parse(line);
+          const result = TaskOutcomeSchema.safeParse(parsed);
+          if (result.success) {
+            super.append(result.data);
+            loaded++;
+          } else {
+            skipped++;
+          }
+        } catch {
+          skipped++;
+        }
+      }
+
+      this.logger.info('Hydrated outcomes from disk', {
+        loaded,
+        skipped,
+        total: lines.length,
+        path: this.filePath,
+      });
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn('Failed to hydrate outcomes from disk', {
+        error: msg,
+        path: this.filePath,
+      });
+    }
+  }
+
+  private persistLine(outcome: TaskOutcome): void {
+    try {
+      appendFileSync(this.filePath, JSON.stringify(outcome) + '\n', 'utf-8');
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn('Failed to persist outcome to disk', {
+        error: msg,
+        path: this.filePath,
+      });
+    }
+  }
+}
+
+// Self-register factory so getOutcomeStore() can create PersistentOutcomeStore
+// without a circular top-level import.
+registerPersistentOutcomeStoreFactory(() => new PersistentOutcomeStore());

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
@@ -10,6 +10,7 @@
  */
 
 import type { TaskOutcome, OutcomeQuery, PerformanceSummary, GroupStats } from './outcome-types.js';
+import { isPersistenceEnabled } from '../../config/learning-persistence.js';
 
 // ============================================================================
 // Constants
@@ -101,15 +102,41 @@ export class OutcomeStore {
 
 let singletonStore: OutcomeStore | undefined;
 
-/** Get the shared OutcomeStore singleton. */
+/**
+ * Get the shared OutcomeStore singleton.
+ * Returns PersistentOutcomeStore when NEXUS_PERSIST_LEARNING=true
+ * and the factory has been registered (import outcome-store-persistence first).
+ */
 export function getOutcomeStore(): OutcomeStore {
-  singletonStore ??= new OutcomeStore();
+  if (singletonStore === undefined) {
+    if (isPersistenceEnabled() && persistentFactory !== undefined) {
+      singletonStore = persistentFactory();
+    } else {
+      singletonStore = new OutcomeStore();
+    }
+  }
   return singletonStore;
 }
 
 /** Reset the singleton (for testing). */
 export function resetOutcomeStore(): void {
   singletonStore = undefined;
+}
+
+// ============================================================================
+// Persistent factory registration (Issue #1009)
+// ============================================================================
+
+type OutcomeStoreFactory = () => OutcomeStore;
+let persistentFactory: OutcomeStoreFactory | undefined;
+
+/**
+ * Register a factory for creating PersistentOutcomeStore instances.
+ * Called from outcome-store-persistence.ts at import time to break
+ * the circular dependency.
+ */
+export function registerPersistentOutcomeStoreFactory(factory: OutcomeStoreFactory): void {
+  persistentFactory = factory;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add JSONL-backed `PersistentOutcomeStore` and JSON-backed `PersistentStrategyDistiller` that persist learning data across process restarts
- Both use subclass wrapper pattern — zero changes to core `OutcomeStore` or `StrategyDistiller` logic
- Feature flag `NEXUS_PERSIST_LEARNING=true` (default: off) gates all persistence
- Data stored in `~/.nexus-agents/learning/` (outcomes.jsonl + rules.json)

## Key Design Decisions

- **Factory registration pattern** breaks circular imports between composite-router and persistence modules
- **JSONL for outcomes** — append-friendly, line-skip on corruption (matches TraceWriter pattern)
- **Atomic JSON for rules** — temp file + rename prevents partial writes (max 90 rules)
- **Zod validation** on every line during hydration; corrupt lines are skipped with warning

## Test plan

- [x] 16 PersistentOutcomeStore tests (hydration, persistence, corruption, FIFO, round-trip)
- [x] 14 PersistentStrategyDistiller tests (hydration, schema, atomic writes, round-trip)
- [x] 6 integration tests (end-to-end restart cycles, feature flag off)
- [x] 27 existing OutcomeStore tests — no regression
- [x] 28 existing StrategyDistiller tests — no regression
- [x] 63 CompositeRouter tests — no regression
- [x] 52 export contract tests — no regression
- [x] Typecheck passes (DTS build: 1.07 MB)
- [x] Fitness score: 98/100

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)