### PR TITLE
fix(#1011): Add side-effect imports for persistence factory registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,15 +39,16 @@ nexus-agents --help       # Full command list
 **Required:** Node.js 22.x LTS, pnpm 9.x (or npm 10.x)
 **Optional:** Docker (sandbox mode), Claude CLI (MCP mode)
 
-| Variable             | Required For                        | Default                       |
-| -------------------- | ----------------------------------- | ----------------------------- |
-| `ANTHROPIC_API_KEY`  | Claude adapter                      | None                          |
-| `OPENAI_API_KEY`     | OpenAI adapter                      | None                          |
-| `GOOGLE_AI_API_KEY`  | Gemini adapter                      | None                          |
-| `NEXUS_LOG_LEVEL`    | Logging verbosity                   | `info`                        |
-| `NEXUS_CONFIG_PATH`  | Custom config path                  | `./nexus-agents.yaml`         |
-| `NEXUS_AUTH_ENABLED` | Network auth (not needed for stdio) | `true` (auto-generates token) |
-| `NEXUS_BILLING_MODE` | Model routing cost handling         | `plan` (monthly subscription) |
+| Variable                 | Required For                        | Default                       |
+| ------------------------ | ----------------------------------- | ----------------------------- |
+| `ANTHROPIC_API_KEY`      | Claude adapter                      | None                          |
+| `OPENAI_API_KEY`         | OpenAI adapter                      | None                          |
+| `GOOGLE_AI_API_KEY`      | Gemini adapter                      | None                          |
+| `NEXUS_LOG_LEVEL`        | Logging verbosity                   | `info`                        |
+| `NEXUS_CONFIG_PATH`      | Custom config path                  | `./nexus-agents.yaml`         |
+| `NEXUS_AUTH_ENABLED`     | Network auth (not needed for stdio) | `true` (auto-generates token) |
+| `NEXUS_BILLING_MODE`     | Model routing cost handling         | `plan` (monthly subscription) |
+| `NEXUS_PERSIST_LEARNING` | Cross-session learning persistence  | `false`                       |
 
 **Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
 

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -209,6 +209,17 @@ All configuration can be overridden with environment variables:
 | `NEXUS_AUTH_ENABLED` | Enable MCP auth     | `false`  |
 | `NEXUS_AUTH_METHOD`  | Auth method         | `token`  |
 
+### Learning Variables
+
+| Variable                 | Description                        | Default |
+| ------------------------ | ---------------------------------- | ------- |
+| `NEXUS_PERSIST_LEARNING` | Cross-session learning persistence | `false` |
+
+When enabled, outcomes and distilled routing rules persist to `~/.nexus-agents/learning/`:
+
+- `outcomes.jsonl` — Append-only JSONL of task outcomes
+- `rules.json` — Atomic JSON snapshot of distilled routing rules
+
 ### API Variables
 
 | Variable            | Description            | Default |

--- a/packages/nexus-agents/src/learning/index.ts
+++ b/packages/nexus-agents/src/learning/index.ts
@@ -111,6 +111,9 @@ export {
 } from './strategy-distiller.js';
 
 // Strategy Distiller Persistence (Issue #1009)
+// Side-effect import: registers PersistentDistillerFactory so CompositeRouter
+// uses the persistent variant when NEXUS_PERSIST_LEARNING=true. Do not remove.
+import './strategy-distiller-persistence.js';
 export {
   PersistentStrategyDistiller,
   RulesSnapshotSchema,

--- a/packages/nexus-agents/src/orchestration/outcomes/index.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/index.ts
@@ -25,6 +25,9 @@ export {
 } from './outcome-store.js';
 
 // Persistence (Issue #1009)
+// Side-effect import: registers PersistentOutcomeStoreFactory so getOutcomeStore()
+// returns the persistent variant when NEXUS_PERSIST_LEARNING=true. Do not remove.
+import './outcome-store-persistence.js';
 export {
   PersistentOutcomeStore,
   type PersistentOutcomeStoreConfig,

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store-persistence.test.ts
@@ -331,5 +331,18 @@ describe('PersistentOutcomeStore', () => {
       const store = getOutcomeStore();
       expect(store).toBeInstanceOf(PersistentOutcomeStore);
     });
+
+    it('factory is auto-registered by side-effect import from barrel', async () => {
+      // Import the barrel — the side-effect import in outcomes/index.ts
+      // should trigger outcome-store-persistence.ts module load,
+      // which calls registerPersistentOutcomeStoreFactory() at module scope.
+      await import('./index.js');
+
+      process.env['NEXUS_PERSIST_LEARNING'] = 'true';
+      resetOutcomeStore();
+      // Factory should already be registered from the barrel import
+      const store = getOutcomeStore();
+      expect(store).toBeInstanceOf(PersistentOutcomeStore);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fix critical bug where `NEXUS_PERSIST_LEARNING=true` was silently ignored because ESM re-exports don't trigger module side effects
- Add explicit side-effect imports in barrel files to ensure factory registration runs
- Document `NEXUS_PERSIST_LEARNING` env var in CLAUDE.md and CONFIGURATION.md

## Root Cause

ESM `export { X } from './mod.js'` syntax re-exports symbols without executing the module's side effects. Both persistence modules relied on self-registration code running at module load time, but the barrels only used re-export syntax.

## Test plan

- [x] New test: `factory is auto-registered by side-effect import from barrel` 
- [x] All 144 existing tests pass — no regression
- [x] Fitness score: 98/100

Closes #1011
Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)