### PR TITLE
feat(#1015): Seed LinUCB bandit arms from persisted outcomes on startup

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -230,6 +230,7 @@ export class CompositeRouter implements ICompositeRouter {
     if (this.config.enableTopsisRanking) this.topsisRouter = new TopsisRouter();
     if (this.config.enableLinUCBSelection && this.cliNames.length > 0) {
       this.linucbBandit = new LinUCBBandit(this.cliNames, { alpha: this.config.linucbAlpha });
+      this.warmStartBandit();
     }
     if (this.config.enableLatencyTracking) this.latencyTracker = new LatencyTracker(latencyConfig);
   }
@@ -282,6 +283,24 @@ export class CompositeRouter implements ICompositeRouter {
         this.strategyDistiller,
         stageConfigs.distilledRule
       );
+    }
+  }
+
+  /** Warm-start LinUCB bandit from persisted outcomes (Issue #1015). Best-effort. */
+  private warmStartBandit(): void {
+    if (this.linucbBandit === undefined || !isPersistenceEnabled()) return;
+    try {
+      const outcomes = getOutcomeStore().query();
+      if (outcomes.length === 0) return;
+      const replayed = this.linucbBandit.warmStart(outcomes);
+      this.logger.info('LinUCB warm-started from persisted outcomes', {
+        outcomesAvailable: outcomes.length,
+        outcomesReplayed: replayed,
+      });
+    } catch (error: unknown) {
+      this.logger.warn('LinUCB warm-start failed, starting cold', {
+        error: getErrorMessage(error),
+      });
     }
   }
 

--- a/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
@@ -10,6 +10,7 @@
 
 import type { BanditContext, LinUCBConfig } from './budget-router-types.js';
 import { DEFAULT_LINUCB_CONFIG, LinUCBConfigSchema } from './budget-router-types.js';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 import {
   createIdentityMatrix,
   createIdentityMatrixInverse,
@@ -252,6 +253,37 @@ export class LinUCBBandit {
         this.update(i, neutralContext, clampedReward);
       }
     }
+  }
+
+  /**
+   * Warm-start bandit from persisted task outcomes (Issue #1015).
+   *
+   * Replays historical outcomes through update() to reconstruct arm weights
+   * from persisted data. Uses a neutral context (same as seedPriors) since
+   * the original task context is not stored in TaskOutcome.
+   *
+   * @param outcomes - Persisted task outcomes to replay
+   * @returns Number of outcomes successfully replayed
+   */
+  warmStart(outcomes: readonly TaskOutcome[]): number {
+    const neutralContext: BanditContext = {
+      taskComplexity: 0.5,
+      contextLengthNormalized: 0.5,
+      isCodeTask: 0,
+      isReasoningTask: 0,
+      budgetUtilization: 0.5,
+      timePressure: 0.5,
+    };
+
+    let replayed = 0;
+    for (const outcome of outcomes) {
+      const armIndex = this.armNames.indexOf(outcome.cli);
+      if (armIndex < 0) continue;
+      const reward = outcome.success ? 0.7 : 0.1;
+      this.update(armIndex, neutralContext, reward);
+      replayed++;
+    }
+    return replayed;
   }
 
   /**

--- a/packages/nexus-agents/src/cli-adapters/linucb-warm-start.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-warm-start.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for LinUCB warm-start from persisted outcomes (Issue #1015).
+ *
+ * Verifies that warmStart() replays historical outcomes to reconstruct
+ * arm weights, giving the bandit a head start on restart.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LinUCBBandit } from './linucb-bandit.js';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+
+const ARM_NAMES = ['claude', 'gemini', 'codex'] as const;
+
+function makeOutcome(overrides?: Partial<TaskOutcome>): TaskOutcome {
+  return {
+    id: `out-${String(Date.now())}`,
+    cli: 'claude',
+    category: 'code_generation',
+    model: 'claude-sonnet-4-5',
+    success: true,
+    durationMs: 1200,
+    timestamp: '2026-02-13T10:00:00Z',
+    source: 'delegate',
+    ...overrides,
+  };
+}
+
+describe('LinUCBBandit.warmStart()', () => {
+  let bandit: LinUCBBandit;
+
+  beforeEach(() => {
+    bandit = new LinUCBBandit(ARM_NAMES);
+  });
+
+  it('returns 0 for empty outcomes array', () => {
+    const replayed = bandit.warmStart([]);
+    expect(replayed).toBe(0);
+  });
+
+  it('replays outcomes for known arms', () => {
+    const outcomes = [
+      makeOutcome({ cli: 'claude', success: true }),
+      makeOutcome({ cli: 'gemini', success: false }),
+      makeOutcome({ cli: 'codex', success: true }),
+    ];
+
+    const replayed = bandit.warmStart(outcomes);
+    expect(replayed).toBe(3);
+  });
+
+  it('skips outcomes for unknown CLIs', () => {
+    const outcomes = [
+      makeOutcome({ cli: 'claude', success: true }),
+      // 'unknown' is not a valid CLI in the arm names, but we cast for testing
+      { ...makeOutcome(), cli: 'unknown' as TaskOutcome['cli'] },
+    ];
+
+    const replayed = bandit.warmStart(outcomes);
+    expect(replayed).toBe(1);
+  });
+
+  it('updates arm pull counts after warm-start', () => {
+    const outcomes = [
+      makeOutcome({ cli: 'claude', success: true }),
+      makeOutcome({ cli: 'claude', success: true }),
+      makeOutcome({ cli: 'claude', success: false }),
+      makeOutcome({ cli: 'gemini', success: true }),
+    ];
+
+    bandit.warmStart(outcomes);
+
+    const stats = bandit.getStats();
+    const totalPulls = stats.reduce((sum, s) => sum + s.pullCount, 0);
+    expect(totalPulls).toBe(4);
+    // Claude should have 3 pulls, gemini 1
+    const claudeArm = stats.find((s) => s.name === 'claude');
+    const geminiArm = stats.find((s) => s.name === 'gemini');
+    expect(claudeArm?.pullCount).toBe(3);
+    expect(geminiArm?.pullCount).toBe(1);
+  });
+
+  it('produces different arm weights than cold-start', () => {
+    // Cold-start — all arms have 0 pulls
+    const coldBandit = new LinUCBBandit(ARM_NAMES);
+    const coldStats = coldBandit.getStats();
+    const coldClaudePulls = coldStats.find((s) => s.name === 'claude')?.pullCount ?? 0;
+    expect(coldClaudePulls).toBe(0);
+
+    // Warm-started — claude arm has learned weights
+    const warmBandit = new LinUCBBandit(ARM_NAMES);
+    const outcomes = Array.from({ length: 20 }, () =>
+      makeOutcome({ cli: 'claude', success: true })
+    );
+    warmBandit.warmStart(outcomes);
+    const warmStats = warmBandit.getStats();
+    const warmClaudePulls = warmStats.find((s) => s.name === 'claude')?.pullCount ?? 0;
+
+    // Warm bandit should have pulls from warm-start
+    expect(warmClaudePulls).toBe(20);
+    expect(warmClaudePulls).toBeGreaterThan(coldClaudePulls);
+  });
+
+  it('assigns lower reward for failed outcomes', () => {
+    const failBandit = new LinUCBBandit(ARM_NAMES);
+    const failOutcomes = Array.from({ length: 10 }, () =>
+      makeOutcome({ cli: 'claude', success: false })
+    );
+    failBandit.warmStart(failOutcomes);
+
+    const successBandit = new LinUCBBandit(ARM_NAMES);
+    const successOutcomes = Array.from({ length: 10 }, () =>
+      makeOutcome({ cli: 'claude', success: true })
+    );
+    successBandit.warmStart(successOutcomes);
+
+    // Compare avg rewards — success bandit should have higher avg for claude
+    const failStats = failBandit.getStats();
+    const successStats = successBandit.getStats();
+    const failClaudeAvg = failStats.find((s) => s.name === 'claude')?.avgReward ?? 0;
+    const successClaudeAvg = successStats.find((s) => s.name === 'claude')?.avgReward ?? 0;
+
+    // Success outcomes use reward=0.7, failure uses reward=0.1
+    expect(successClaudeAvg).toBeGreaterThan(failClaudeAvg);
+    expect(successClaudeAvg).toBeCloseTo(0.7, 1);
+    expect(failClaudeAvg).toBeCloseTo(0.1, 1);
+  });
+
+  it('handles mixed CLIs across many outcomes', () => {
+    const outcomes = [
+      ...Array.from({ length: 5 }, () => makeOutcome({ cli: 'claude', success: true })),
+      ...Array.from({ length: 3 }, () => makeOutcome({ cli: 'gemini', success: true })),
+      ...Array.from({ length: 2 }, () => makeOutcome({ cli: 'codex', success: false })),
+    ];
+
+    const replayed = bandit.warmStart(outcomes);
+    expect(replayed).toBe(10);
+
+    const stats = bandit.getStats();
+    const totalPulls = stats.reduce((sum, s) => sum + s.pullCount, 0);
+    expect(totalPulls).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `warmStart(outcomes)` method to `LinUCBBandit` — replays persisted `TaskOutcome[]` to reconstruct arm weights
- Wire into `CompositeRouter.initializeRouters()` — calls `warmStartBandit()` when `NEXUS_PERSIST_LEARNING=true`
- Uses neutral context with binary reward (success=0.7, failure=0.1), matching `seedPriors()` pattern
- Best-effort: logs warning on failure, falls back to cold start

Closes #1015

## Test plan
- [x] `linucb-warm-start.test.ts` — 7 tests: empty, known/unknown arms, pull counts, weight differences, mixed CLIs
- [x] `linucb-bandit.test.ts` — 20 tests pass (no regression)
- [x] `composite-router.test.ts` — 63 tests pass (no regression)
- [x] `pnpm typecheck` clean
- [x] Fitness audit 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)