### PR TITLE
feat(#1022): Add MCP tool usage analytics to weather report

### DIFF
--- a/packages/nexus-agents/src/mcp/middleware/index.ts
+++ b/packages/nexus-agents/src/mcp/middleware/index.ts
@@ -157,6 +157,19 @@ export {
   logSanitizationResult,
 } from './tool-input-sanitizer.js';
 
+// Tool usage metrics (Issue #1022)
+export {
+  // Types
+  type ToolMetric,
+  type ToolStats,
+  // Functions
+  recordToolMetric,
+  getToolMetrics,
+  getToolStats,
+  clearToolMetrics,
+  createMetricsMiddleware,
+} from './tool-metrics.js';
+
 // Per-tool rate limiter factory (Issue #274 Phase 2)
 export {
   // Types

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
@@ -16,6 +16,7 @@ import { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 import { type IPolicyFirewall, type ExecutionMode, createPolicyContext } from './policy.js';
 import { TimeoutGuard, type TimeoutGuardConfig } from './timeout-guard.js';
 import { createRequestContext, contextForLogging, type RequestContext } from './request-context.js';
+import { createMetricsMiddleware } from './tool-metrics.js';
 
 /**
  * MCP tool result type.
@@ -313,6 +314,7 @@ function buildMiddlewareStack(config: MiddlewareChainConfig): Middleware[] {
   const skip = config.skip ?? {};
   const middlewares: Middleware[] = [];
 
+  middlewares.push(createMetricsMiddleware()); // Tool usage analytics (#1022)
   addAuditMiddleware(middlewares, skip);
   addRateLimitMiddleware(middlewares, config, skip);
   addValidationMiddleware(middlewares, config, skip);

--- a/packages/nexus-agents/src/mcp/middleware/tool-metrics.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-metrics.test.ts
@@ -1,0 +1,200 @@
+/**
+ * tool-metrics — Unit Tests (Issue #1022)
+ *
+ * Tests for MCP tool usage metrics recorder and middleware.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  recordToolMetric,
+  getToolMetrics,
+  getToolStats,
+  clearToolMetrics,
+  createMetricsMiddleware,
+} from './tool-metrics.js';
+import type { MiddlewareContext, ToolResult } from './middleware-chain.js';
+
+function createMockContext(toolName: string): MiddlewareContext {
+  return {
+    requestContext: {
+      requestId: 'test-req-1',
+      toolName,
+      timestamp: new Date().toISOString(),
+      caller: { source: 'stdio' },
+      trustTier: '1',
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    },
+  } as unknown as MiddlewareContext;
+}
+
+function successResult(): ToolResult {
+  return { content: [{ type: 'text', text: 'ok' }] };
+}
+
+function errorResult(): ToolResult {
+  return { content: [{ type: 'text', text: 'err' }], isError: true };
+}
+
+describe('tool-metrics', () => {
+  beforeEach(() => {
+    clearToolMetrics();
+  });
+
+  describe('recordToolMetric', () => {
+    it('records and retrieves a metric', () => {
+      recordToolMetric({
+        toolName: 'delegate_to_model',
+        durationMs: 150,
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+      const metrics = getToolMetrics();
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.toolName).toBe('delegate_to_model');
+    });
+
+    it('enforces maximum entries via FIFO eviction', () => {
+      for (let i = 0; i < 5100; i++) {
+        recordToolMetric({
+          toolName: `tool_${String(i)}`,
+          durationMs: 1,
+          success: true,
+          timestamp: '2026-01-01T00:00:00Z',
+        });
+      }
+      expect(getToolMetrics().length).toBeLessThanOrEqual(5000);
+    });
+  });
+
+  describe('getToolStats', () => {
+    it('returns empty array when no metrics', () => {
+      expect(getToolStats()).toHaveLength(0);
+    });
+
+    it('aggregates metrics by tool name', () => {
+      recordToolMetric({
+        toolName: 'orchestrate',
+        durationMs: 100,
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+      recordToolMetric({
+        toolName: 'orchestrate',
+        durationMs: 200,
+        success: false,
+        timestamp: '2026-01-01T00:00:01Z',
+      });
+      recordToolMetric({
+        toolName: 'consensus_vote',
+        durationMs: 50,
+        success: true,
+        timestamp: '2026-01-01T00:00:02Z',
+      });
+
+      const stats = getToolStats();
+      expect(stats).toHaveLength(2);
+
+      const orchStats = stats.find((s) => s.toolName === 'orchestrate');
+      expect(orchStats).toBeDefined();
+      expect(orchStats?.totalCalls).toBe(2);
+      expect(orchStats?.successRate).toBe(0.5);
+      expect(orchStats?.avgDurationMs).toBe(150);
+      expect(orchStats?.errorCount).toBe(1);
+
+      const voteStats = stats.find((s) => s.toolName === 'consensus_vote');
+      expect(voteStats?.totalCalls).toBe(1);
+      expect(voteStats?.successRate).toBe(1);
+    });
+
+    it('sorts by total calls descending', () => {
+      for (let i = 0; i < 5; i++) {
+        recordToolMetric({
+          toolName: 'frequent',
+          durationMs: 10,
+          success: true,
+          timestamp: '2026-01-01T00:00:00Z',
+        });
+      }
+      recordToolMetric({
+        toolName: 'rare',
+        durationMs: 10,
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+
+      const stats = getToolStats();
+      expect(stats[0]?.toolName).toBe('frequent');
+      expect(stats[1]?.toolName).toBe('rare');
+    });
+  });
+
+  describe('clearToolMetrics', () => {
+    it('removes all recorded metrics', () => {
+      recordToolMetric({
+        toolName: 'test',
+        durationMs: 1,
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+      expect(getToolMetrics()).toHaveLength(1);
+      clearToolMetrics();
+      expect(getToolMetrics()).toHaveLength(0);
+    });
+  });
+
+  describe('createMetricsMiddleware', () => {
+    it('records success on successful tool execution', async () => {
+      const middleware = createMetricsMiddleware();
+      const ctx = createMockContext('delegate_to_model');
+      const next = vi.fn().mockResolvedValue(successResult());
+
+      await middleware({}, ctx, next);
+
+      const metrics = getToolMetrics();
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.toolName).toBe('delegate_to_model');
+      expect(metrics[0]?.success).toBe(true);
+      expect(metrics[0]?.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('records failure on error tool result', async () => {
+      const middleware = createMetricsMiddleware();
+      const ctx = createMockContext('execute_spec');
+      const next = vi.fn().mockResolvedValue(errorResult());
+
+      await middleware({}, ctx, next);
+
+      const metrics = getToolMetrics();
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.success).toBe(false);
+    });
+
+    it('records failure on thrown error', async () => {
+      const middleware = createMetricsMiddleware();
+      const ctx = createMockContext('orchestrate');
+      const next = vi.fn().mockRejectedValue(new Error('timeout'));
+
+      await expect(middleware({}, ctx, next)).rejects.toThrow('timeout');
+
+      const metrics = getToolMetrics();
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.success).toBe(false);
+    });
+
+    it('passes through the tool result unchanged', async () => {
+      const middleware = createMetricsMiddleware();
+      const ctx = createMockContext('list_experts');
+      const expected = successResult();
+      const next = vi.fn().mockResolvedValue(expected);
+
+      const result = await middleware({}, ctx, next);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/middleware/tool-metrics.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-metrics.ts
@@ -1,0 +1,127 @@
+/**
+ * Tool usage metrics recorder (Issue #1022)
+ *
+ * Lightweight, bounded, in-memory store for MCP tool invocation metrics.
+ * Records tool name, duration, and success/failure for every tool call.
+ * Used by the weather report to surface per-tool analytics.
+ *
+ * @module mcp/middleware/tool-metrics
+ */
+
+import { getTimeProvider } from '../../core/index.js';
+import type { Middleware, ToolResult } from './middleware-chain.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** A single recorded tool invocation metric. */
+export interface ToolMetric {
+  readonly toolName: string;
+  readonly durationMs: number;
+  readonly success: boolean;
+  readonly timestamp: string;
+}
+
+/** Aggregated stats for a single tool. */
+export interface ToolStats {
+  readonly toolName: string;
+  readonly totalCalls: number;
+  readonly successRate: number;
+  readonly avgDurationMs: number;
+  readonly errorCount: number;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+const MAX_ENTRIES = 5_000;
+const metrics: ToolMetric[] = [];
+
+/** Record a tool invocation metric. */
+export function recordToolMetric(metric: ToolMetric): void {
+  metrics.push(metric);
+  if (metrics.length > MAX_ENTRIES) {
+    metrics.splice(0, metrics.length - MAX_ENTRIES);
+  }
+}
+
+/** Get all recorded tool metrics (read-only snapshot). */
+export function getToolMetrics(): readonly ToolMetric[] {
+  return [...metrics];
+}
+
+/** Aggregate metrics into per-tool stats. */
+export function getToolStats(): readonly ToolStats[] {
+  const groups = new Map<string, ToolMetric[]>();
+
+  for (const m of metrics) {
+    const list = groups.get(m.toolName);
+    if (list !== undefined) {
+      list.push(m);
+    } else {
+      groups.set(m.toolName, [m]);
+    }
+  }
+
+  const stats: ToolStats[] = [];
+  for (const [toolName, list] of groups) {
+    const sc = list.filter((m) => m.success).length;
+    const td = list.reduce((s, m) => s + m.durationMs, 0);
+    stats.push({
+      toolName,
+      totalCalls: list.length,
+      successRate: sc / list.length,
+      avgDurationMs: td / list.length,
+      errorCount: list.length - sc,
+    });
+  }
+
+  return stats.sort((a, b) => b.totalCalls - a.totalCalls);
+}
+
+/** Clear all recorded metrics (for testing). */
+export function clearToolMetrics(): void {
+  metrics.length = 0;
+}
+
+// ============================================================================
+// Middleware
+// ============================================================================
+
+/**
+ * Creates a middleware that records tool invocation metrics.
+ * Should be placed as the outermost middleware (before audit)
+ * to capture the full request lifecycle including middleware overhead.
+ */
+export function createMetricsMiddleware(): Middleware {
+  return async (args, ctx, next): Promise<ToolResult> => {
+    const startTime = getTimeProvider().now();
+
+    try {
+      const result = await next(args, ctx);
+      const durationMs = getTimeProvider().now() - startTime;
+
+      recordToolMetric({
+        toolName: ctx.requestContext.toolName,
+        durationMs,
+        success: result.isError !== true,
+        timestamp: new Date().toISOString(),
+      });
+
+      return result;
+    } catch (error) {
+      const durationMs = getTimeProvider().now() - startTime;
+
+      recordToolMetric({
+        toolName: ctx.requestContext.toolName,
+        durationMs,
+        success: false,
+        timestamp: new Date().toISOString(),
+      });
+
+      throw error;
+    }
+  };
+}

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -114,6 +114,15 @@ export interface RateLimitReport {
   readonly avgRetryAfterMs: number | undefined;
 }
 
+/** Per-tool performance stats (Issue #1022). */
+export interface ToolPerformanceEntry {
+  readonly toolName: string;
+  readonly totalCalls: number;
+  readonly successRate: number;
+  readonly avgDurationMs: number;
+  readonly errorCount: number;
+}
+
 /** Full weather report response. */
 export interface WeatherReportResponse {
   readonly overall: {
@@ -131,6 +140,8 @@ export interface WeatherReportResponse {
   readonly recommendedMappings?: readonly RecommendedMapping[];
   /** Rate limit utilization per provider (Issue #996). */
   readonly rateLimits?: readonly RateLimitReport[];
+  /** Per-tool invocation metrics (Issue #1022). */
+  readonly toolPerformance?: readonly ToolPerformanceEntry[];
   readonly explorationRate: number;
   readonly coldStartThreshold: number;
   readonly collectedAt: string;

--- a/packages/nexus-agents/src/mcp/tools/weather-report.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.ts
@@ -23,12 +23,14 @@ import type {
   TierRecommendationEntry,
   LearningInsight,
   RecommendedMapping,
+  ToolPerformanceEntry,
 } from './weather-report-types.js';
 import type { RateLimitReport } from './weather-report-types.js';
 import { createDefaultWeatherConfig } from './weather-report-types.js';
 import { generateTierRecommendations } from '../gateway/tier-recommender.js';
 import { computeAdaptiveThresholds } from '../../orchestration/outcomes/adaptive-thresholds.js';
 import { getRateLimitStats } from '../../adapters/rate-limit-detector.js';
+import { getToolStats } from '../middleware/tool-metrics.js';
 
 // ============================================================================
 // Public API
@@ -53,6 +55,7 @@ export function generateWeatherReport(
   const adaptiveBonuses = includeAdaptive ? computeAdaptiveBonuses(cfg) : [];
   const tierRecommendations = buildTierRecommendations(summary);
   const rateLimits = buildRateLimitReport();
+  const toolPerformance = buildToolPerformance();
   const base = {
     overall: {
       totalTasks: summary.totalTasks,
@@ -63,6 +66,7 @@ export function generateWeatherReport(
     adaptiveBonuses,
     tierRecommendations,
     ...(rateLimits.length > 0 ? { rateLimits } : {}),
+    ...(toolPerformance.length > 0 ? { toolPerformance } : {}),
     explorationRate: cfg.explorationRate,
     coldStartThreshold: cfg.coldStartThreshold,
     collectedAt: new Date().toISOString(),
@@ -277,6 +281,17 @@ function buildRecommendedMappings(): readonly RecommendedMapping[] {
   }
 
   return mappings;
+}
+
+/** Builds per-tool performance stats from recorded metrics (#1022). */
+function buildToolPerformance(): readonly ToolPerformanceEntry[] {
+  return getToolStats().map((s) => ({
+    toolName: s.toolName,
+    totalCalls: s.totalCalls,
+    successRate: Math.round(s.successRate * 1000) / 1000,
+    avgDurationMs: Math.round(s.avgDurationMs),
+    errorCount: s.errorCount,
+  }));
 }
 
 /** Generates tier recommendations from outcome summary (#895). */


### PR DESCRIPTION
## Summary
- Adds `tool-metrics.ts` middleware that records every MCP tool invocation (tool name, duration, success/failure)
- Metrics middleware is the outermost in the chain to capture full lifecycle timing
- Weather report now includes a `toolPerformance` section with per-tool stats (calls, success rate, avg duration, error count)
- Bounded in-memory store with 5k FIFO eviction — zero config, minimal overhead

## Test plan
- [x] 10 new tests in `tool-metrics.test.ts` (recording, aggregation, middleware behavior, FIFO eviction)
- [x] All 607 middleware + weather report tests pass
- [x] All 52 export contract tests pass  
- [x] TypeScript build (ESM + DTS) succeeds
- [x] ESLint + Prettier clean
- [x] Fitness score: 98/100

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)