### PR TITLE
feat(#1025): Add structured error taxonomy for task outcomes

### DIFF
--- a/packages/nexus-agents/src/exports/orchestration.ts
+++ b/packages/nexus-agents/src/exports/orchestration.ts
@@ -168,10 +168,14 @@ export {
   getOutcomeStore,
   OutcomeStore,
   TaskOutcomeSchema as OutcomeTaskSchema,
+  OutcomeFailureCategorySchema,
+  categorizeOutcomeError,
+  categorizeOutcomeErrorMessage,
   PersistentOutcomeStore,
 } from '../orchestration/index.js';
 export type {
   TaskOutcome as OutcomeTaskRecord,
+  OutcomeFailureCategory,
   PerformanceSummary,
   OutcomeStoreConfig,
   PersistentOutcomeStoreConfig,

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -29,7 +29,11 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
 import type { Expert } from '../../agents/index.js';
 import { getToolMemory } from './tool-memory.js';
 import { getAutoCatalog } from './research-auto-catalog.js';
-import { getOutcomeStore } from '../../orchestration/outcomes/index.js';
+import {
+  getOutcomeStore,
+  categorizeOutcomeErrorMessage,
+} from '../../orchestration/outcomes/index.js';
+import type { OutcomeFailureCategory } from '../../orchestration/outcomes/index.js';
 import { detectTaskCategory } from '../../config/task-specialization.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
@@ -154,23 +158,25 @@ function buildSuccessResponse(params: SuccessResponseParams): ExecuteExpertRespo
 }
 
 /** Records expert execution outcome to OutcomeStore (Issue #1014). Best-effort. */
-function recordExpertOutcome(
-  task: string,
-  success: boolean,
-  durationMs: number,
-  model?: string
-): void {
+function recordExpertOutcome(opts: {
+  task: string;
+  success: boolean;
+  durationMs: number;
+  model?: string;
+  failureCategory?: OutcomeFailureCategory;
+}): void {
   try {
-    const match = detectTaskCategory(task);
+    const match = detectTaskCategory(opts.task);
     getOutcomeStore().append({
       id: `exp-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
       cli: 'claude',
       category: match?.category ?? 'exploration',
-      model: model ?? 'expert',
-      success,
-      durationMs,
+      model: opts.model ?? 'expert',
+      success: opts.success,
+      durationMs: opts.durationMs,
       timestamp: new Date(getTimeProvider().now()).toISOString(),
       source: 'delegate',
+      ...(opts.failureCategory !== undefined ? { failureCategory: opts.failureCategory } : {}),
     });
   } catch (error: unknown) {
     createLogger({ tool: 'execute_expert' }).debug('Best-effort outcome recording failed', {
@@ -258,6 +264,40 @@ function autoCatalogScan(output: string, expertId: string, logger?: ILogger): vo
   }
 }
 
+/** Records failure outcome and returns error result. */
+function handleExpertFailure(
+  args: ExecuteExpertInput,
+  expert: { expertId: string; role: string; modelId?: string },
+  errorMsg: string,
+  durationMs: number
+): { ok: false; error: string } {
+  recordExpertError(expert.expertId, expert.role, errorMsg);
+  const fc = categorizeOutcomeErrorMessage(errorMsg);
+  recordExpertOutcome({
+    task: args.task,
+    success: false,
+    durationMs,
+    failureCategory: fc,
+    ...(expert.modelId !== undefined ? { model: expert.modelId } : {}),
+  });
+  return { ok: false, error: `Expert execution failed: ${errorMsg}` };
+}
+
+/** Records success outcome and tracking. */
+function handleExpertSuccess(
+  args: ExecuteExpertInput,
+  expert: { expertId: string; role: string; modelId?: string },
+  durationMs: number
+): void {
+  recordExpertSuccess(expert.expertId, expert.role, durationMs);
+  recordExpertOutcome({
+    task: args.task,
+    success: true,
+    durationMs,
+    ...(expert.modelId !== undefined ? { model: expert.modelId } : {}),
+  });
+}
+
 /**
  * Handles the execute_expert tool execution.
  * (Issue #747 - CLI detection support)
@@ -269,16 +309,11 @@ async function handleExecuteExpert(
   const { expertId } = args;
 
   const lookup = lookupExpert(deps.expertRegistry, expertId);
-  if (!lookup.ok) {
-    return { ok: false, error: lookup.error };
-  }
+  if (!lookup.ok) return { ok: false, error: lookup.error };
   const expert = lookup.expert;
 
-  // Validate adapter availability before execution (Issue #656, #747, #749)
   const adapterError = await requireAdapterAvailable(deps.cliCache);
-  if (adapterError !== undefined) {
-    return { ok: false, error: adapterError };
-  }
+  if (adapterError !== undefined) return { ok: false, error: adapterError };
 
   const task = buildTask(args);
   injectErrorHints(task, expert.role);
@@ -287,25 +322,20 @@ async function handleExecuteExpert(
   const startTime = getTimeProvider().now();
   const result = await expert.execute(task);
   const durationMs = getTimeProvider().now() - startTime;
+  const modelId = expert.expertConfig.modelPreference?.modelId;
+  const info = {
+    expertId,
+    role: expert.role,
+    ...(modelId !== undefined ? { modelId } : {}),
+  };
 
   if (!result.ok) {
     deps.logger?.warn('Expert execution failed', { expertId, error: result.error.message });
-    recordExpertError(expertId, expert.role, result.error.message);
-    recordExpertOutcome(args.task, false, durationMs, expert.expertConfig.modelPreference?.modelId);
-    return {
-      ok: false,
-      error: `Expert execution failed: ${result.error.message}`,
-    };
+    return handleExpertFailure(args, info, result.error.message, durationMs);
   }
 
-  deps.logger?.info('Expert execution completed', {
-    expertId,
-    durationMs,
-    tokensUsed: result.value.metadata.tokensUsed,
-  });
-
-  recordExpertSuccess(expertId, expert.role, durationMs);
-  recordExpertOutcome(args.task, true, durationMs, expert.expertConfig.modelPreference?.modelId);
+  deps.logger?.info('Expert execution completed', { expertId, durationMs });
+  handleExpertSuccess(args, info, durationMs);
   autoCatalogScan(result.value.output as string, expertId, deps.logger);
 
   return {

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -37,7 +37,11 @@ import { createWorkflowRouter, type IWorkflowRouter } from '../../orchestration/
 import { getToolMemory } from './tool-memory.js';
 import { getAutoCatalog } from './research-auto-catalog.js';
 import { computeAgentPlan } from './orchestrate-aorchestra.js';
-import { getOutcomeStore } from '../../orchestration/outcomes/index.js';
+import {
+  getOutcomeStore,
+  categorizeOutcomeErrorMessage,
+} from '../../orchestration/outcomes/index.js';
+import type { OutcomeFailureCategory } from '../../orchestration/outcomes/index.js';
 import { detectTaskCategory } from '../../config/task-specialization.js';
 import {
   OrchestrateInputSchema,
@@ -203,7 +207,12 @@ function triggerPromotionPipeline(toolName: string): void {
 }
 
 /** Records orchestration outcome to OutcomeStore (Issue #1014). Best-effort, never throws. */
-function recordToOutcomeStore(taskDescription: string, success: boolean, durationMs: number): void {
+function recordToOutcomeStore(
+  taskDescription: string,
+  success: boolean,
+  durationMs: number,
+  failureCategory?: OutcomeFailureCategory
+): void {
   try {
     const match = detectTaskCategory(taskDescription);
     getOutcomeStore().append({
@@ -215,6 +224,7 @@ function recordToOutcomeStore(taskDescription: string, success: boolean, duratio
       durationMs,
       timestamp: new Date(getTimeProvider().now()).toISOString(),
       source: 'delegate',
+      ...(failureCategory !== undefined ? { failureCategory } : {}),
     });
   } catch (error: unknown) {
     createLogger({ tool: 'orchestrate' }).debug('Best-effort outcome recording failed', {
@@ -290,7 +300,8 @@ function recordOrchestrationError(
       error: getErrorMessage(error),
     });
   }
-  recordToOutcomeStore(taskDescription, false, durationMs ?? 0);
+  const fc = categorizeOutcomeErrorMessage(errorMessage);
+  recordToOutcomeStore(taskDescription, false, durationMs ?? 0, fc);
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -123,6 +123,13 @@ export interface ToolPerformanceEntry {
   readonly errorCount: number;
 }
 
+/** Failure breakdown entry for the weather report (Issue #1025). */
+export interface FailureBreakdownEntry {
+  readonly category: string;
+  readonly count: number;
+  readonly percentage: number;
+}
+
 /** Full weather report response. */
 export interface WeatherReportResponse {
   readonly overall: {
@@ -142,6 +149,8 @@ export interface WeatherReportResponse {
   readonly rateLimits?: readonly RateLimitReport[];
   /** Per-tool invocation metrics (Issue #1022). */
   readonly toolPerformance?: readonly ToolPerformanceEntry[];
+  /** Failure breakdown by category (Issue #1025). */
+  readonly failureBreakdown?: readonly FailureBreakdownEntry[];
   readonly explorationRate: number;
   readonly coldStartThreshold: number;
   readonly collectedAt: string;

--- a/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
@@ -129,6 +129,38 @@ describe('generateWeatherReport', () => {
     expect(report.adaptiveBonuses).toHaveLength(0);
   });
 
+  it('includes failureBreakdown when failures have categories', () => {
+    getOutcomeStore().append(makeOutcome({ success: false, failureCategory: 'timeout' }));
+    getOutcomeStore().append(makeOutcome({ success: false, failureCategory: 'timeout' }));
+    getOutcomeStore().append(makeOutcome({ success: false, failureCategory: 'rate_limit' }));
+    seedOutcomes(3); // successes
+
+    const report = generateWeatherReport({});
+
+    expect(report.failureBreakdown).toBeDefined();
+    const breakdown = report.failureBreakdown ?? [];
+    expect(breakdown).toHaveLength(2);
+    const timeoutEntry = breakdown.find((e) => e.category === 'timeout');
+    expect(timeoutEntry?.count).toBe(2);
+    expect(timeoutEntry?.percentage).toBeCloseTo(66.7, 0);
+    const rateLimitEntry = breakdown.find((e) => e.category === 'rate_limit');
+    expect(rateLimitEntry?.count).toBe(1);
+  });
+
+  it('omits failureBreakdown when no failures', () => {
+    seedOutcomes(5);
+    const report = generateWeatherReport({});
+    expect(report.failureBreakdown).toBeUndefined();
+  });
+
+  it('assigns unknown category to failures without failureCategory', () => {
+    getOutcomeStore().append(makeOutcome({ success: false }));
+    const report = generateWeatherReport({});
+    const breakdown = report.failureBreakdown ?? [];
+    expect(breakdown).toHaveLength(1);
+    expect(breakdown[0]?.category).toBe('unknown');
+  });
+
   it('reports exploration rate and cold start threshold', () => {
     const report = generateWeatherReport({});
 

--- a/packages/nexus-agents/src/mcp/tools/weather-report.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.ts
@@ -24,6 +24,7 @@ import type {
   LearningInsight,
   RecommendedMapping,
   ToolPerformanceEntry,
+  FailureBreakdownEntry,
 } from './weather-report-types.js';
 import type { RateLimitReport } from './weather-report-types.js';
 import { createDefaultWeatherConfig } from './weather-report-types.js';
@@ -56,6 +57,7 @@ export function generateWeatherReport(
   const tierRecommendations = buildTierRecommendations(summary);
   const rateLimits = buildRateLimitReport();
   const toolPerformance = buildToolPerformance();
+  const failureBreakdown = buildFailureBreakdown(input);
   const base = {
     overall: {
       totalTasks: summary.totalTasks,
@@ -67,6 +69,7 @@ export function generateWeatherReport(
     tierRecommendations,
     ...(rateLimits.length > 0 ? { rateLimits } : {}),
     ...(toolPerformance.length > 0 ? { toolPerformance } : {}),
+    ...(failureBreakdown.length > 0 ? { failureBreakdown } : {}),
     explorationRate: cfg.explorationRate,
     coldStartThreshold: cfg.coldStartThreshold,
     collectedAt: new Date().toISOString(),
@@ -281,6 +284,30 @@ function buildRecommendedMappings(): readonly RecommendedMapping[] {
   }
 
   return mappings;
+}
+
+/** Builds failure breakdown from failed outcomes (Issue #1025). */
+function buildFailureBreakdown(input: WeatherReportOptions): readonly FailureBreakdownEntry[] {
+  const store = getOutcomeStore();
+  const outcomes = store.query(buildQuery(input.cli, input.category));
+  const failed = outcomes.filter((o) => !o.success);
+  if (failed.length === 0) return [];
+
+  const counts = new Map<string, number>();
+  for (const o of failed) {
+    const cat = o.failureCategory ?? 'unknown';
+    counts.set(cat, (counts.get(cat) ?? 0) + 1);
+  }
+
+  const entries: FailureBreakdownEntry[] = [];
+  for (const [category, count] of counts) {
+    entries.push({
+      category,
+      count,
+      percentage: Math.round((count / failed.length) * 1000) / 10,
+    });
+  }
+  return entries.sort((a, b) => b.count - a.count);
 }
 
 /** Builds per-tool performance stats from recorded metrics (#1022). */

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -167,12 +167,16 @@ export type {
   TaskOutcome,
   OutcomeQuery,
   OutcomeSource,
+  OutcomeFailureCategory,
   PerformanceSummary,
   GroupStats,
 } from './outcomes/index.js';
 export {
   TaskOutcomeSchema,
   OutcomeQuerySchema,
+  OutcomeFailureCategorySchema,
+  categorizeOutcomeError,
+  categorizeOutcomeErrorMessage,
   OutcomeStore,
   getOutcomeStore,
   resetOutcomeStore,

--- a/packages/nexus-agents/src/orchestration/outcomes/error-taxonomy.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/error-taxonomy.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Error taxonomy — Unit Tests (Issue #1025)
+ *
+ * Tests for OutcomeFailureCategory schema and error classification functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  OutcomeFailureCategorySchema,
+  categorizeOutcomeError,
+  categorizeOutcomeErrorMessage,
+} from './outcome-types.js';
+import { TaskOutcomeSchema } from './outcome-types.js';
+
+describe('OutcomeFailureCategorySchema', () => {
+  it('accepts all valid categories', () => {
+    const categories = [
+      'timeout',
+      'authentication',
+      'rate_limit',
+      'connection',
+      'crash',
+      'adapter_unavailable',
+      'validation',
+      'execution',
+      'unknown',
+    ];
+    for (const c of categories) {
+      expect(OutcomeFailureCategorySchema.parse(c)).toBe(c);
+    }
+  });
+
+  it('rejects invalid category', () => {
+    expect(() => OutcomeFailureCategorySchema.parse('bogus')).toThrow();
+  });
+});
+
+describe('TaskOutcomeSchema with failureCategory', () => {
+  const base = {
+    id: 'test-1',
+    cli: 'claude' as const,
+    category: 'code_generation' as const,
+    model: 'claude-sonnet',
+    success: false,
+    durationMs: 500,
+    timestamp: '2026-01-01T00:00:00Z',
+    source: 'delegate' as const,
+  };
+
+  it('accepts outcome without failureCategory', () => {
+    const result = TaskOutcomeSchema.safeParse(base);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts outcome with valid failureCategory', () => {
+    const result = TaskOutcomeSchema.safeParse({ ...base, failureCategory: 'timeout' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects outcome with invalid failureCategory', () => {
+    const result = TaskOutcomeSchema.safeParse({ ...base, failureCategory: 'bogus' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('categorizeOutcomeError', () => {
+  it('returns timeout for timeout errors', () => {
+    expect(categorizeOutcomeError(new Error('Request timed out'))).toBe('timeout');
+  });
+
+  it('returns authentication for auth errors', () => {
+    expect(categorizeOutcomeError(new Error('Unauthorized access'))).toBe('authentication');
+  });
+
+  it('returns rate_limit for 429 errors', () => {
+    expect(categorizeOutcomeError(new Error('429 Too Many Requests'))).toBe('rate_limit');
+  });
+
+  it('returns connection for connection errors', () => {
+    expect(categorizeOutcomeError(new Error('ECONNREFUSED'))).toBe('connection');
+  });
+
+  it('returns crash for process crash errors', () => {
+    expect(categorizeOutcomeError(new Error('Process killed by SIGTERM'))).toBe('crash');
+  });
+
+  it('returns adapter_unavailable for adapter errors', () => {
+    expect(categorizeOutcomeError(new Error('No model adapter configured'))).toBe(
+      'adapter_unavailable'
+    );
+  });
+
+  it('returns validation for validation errors', () => {
+    expect(categorizeOutcomeError(new Error('Validation failed for input'))).toBe('validation');
+  });
+
+  it('returns execution for generic Error instances', () => {
+    expect(categorizeOutcomeError(new Error('Something broke'))).toBe('execution');
+  });
+
+  it('returns unknown for non-Error values', () => {
+    expect(categorizeOutcomeError('string error')).toBe('unknown');
+    expect(categorizeOutcomeError(42)).toBe('unknown');
+    expect(categorizeOutcomeError(null)).toBe('unknown');
+  });
+
+  it('checks error name for classification', () => {
+    const err = new Error('generic');
+    err.name = 'TimeoutError';
+    expect(categorizeOutcomeError(err)).toBe('timeout');
+  });
+});
+
+describe('categorizeOutcomeErrorMessage', () => {
+  it('classifies timeout messages', () => {
+    expect(categorizeOutcomeErrorMessage('Operation timed out after 30s')).toBe('timeout');
+  });
+
+  it('classifies rate limit messages', () => {
+    expect(categorizeOutcomeErrorMessage('rate limit exceeded')).toBe('rate_limit');
+  });
+
+  it('classifies adapter unavailable messages', () => {
+    expect(categorizeOutcomeErrorMessage('No model adapter available')).toBe('adapter_unavailable');
+  });
+
+  it('classifies zod validation messages', () => {
+    expect(categorizeOutcomeErrorMessage('Zod parse error')).toBe('validation');
+  });
+
+  it('returns execution for unrecognized messages', () => {
+    expect(categorizeOutcomeErrorMessage('Something went wrong')).toBe('execution');
+  });
+});

--- a/packages/nexus-agents/src/orchestration/outcomes/index.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/index.ts
@@ -12,10 +12,17 @@ export type {
   TaskOutcome,
   OutcomeQuery,
   OutcomeSource,
+  OutcomeFailureCategory,
   PerformanceSummary,
   GroupStats,
 } from './outcome-types.js';
-export { TaskOutcomeSchema, OutcomeQuerySchema } from './outcome-types.js';
+export {
+  TaskOutcomeSchema,
+  OutcomeQuerySchema,
+  OutcomeFailureCategorySchema,
+  categorizeOutcomeError,
+  categorizeOutcomeErrorMessage,
+} from './outcome-types.js';
 export {
   OutcomeStore,
   getOutcomeStore,

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
@@ -21,6 +21,19 @@ const CliNameSchema = z.enum(['claude', 'gemini', 'codex']);
 /** Source of the task outcome. */
 const OutcomeSourceSchema = z.enum(['delegate', 'consensus', 'manual']);
 
+/** Failure category for failed task outcomes (Issue #1025). */
+export const OutcomeFailureCategorySchema = z.enum([
+  'timeout',
+  'authentication',
+  'rate_limit',
+  'connection',
+  'crash',
+  'adapter_unavailable',
+  'validation',
+  'execution',
+  'unknown',
+]);
+
 /** Schema for a single recorded task outcome. */
 export const TaskOutcomeSchema = z.object({
   id: z.string().min(1),
@@ -31,6 +44,7 @@ export const TaskOutcomeSchema = z.object({
   durationMs: z.number().nonnegative(),
   timestamp: z.string().min(1),
   qualitySignals: z.array(z.string()).optional(),
+  failureCategory: OutcomeFailureCategorySchema.optional(),
   source: OutcomeSourceSchema,
 });
 
@@ -55,6 +69,52 @@ export type OutcomeQuery = z.infer<typeof OutcomeQuerySchema>;
 
 /** Source of the outcome record. */
 export type OutcomeSource = z.infer<typeof OutcomeSourceSchema>;
+
+/** Category of failure for failed outcomes (Issue #1025). */
+export type OutcomeFailureCategory = z.infer<typeof OutcomeFailureCategorySchema>;
+
+// ============================================================================
+// Error Classification (Issue #1025)
+// ============================================================================
+
+const TIMEOUT_PATTERNS = ['timeout', 'timed out'];
+const AUTH_PATTERNS = ['auth', 'unauthorized', 'forbidden', 'oauth'];
+const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429'];
+const CONNECTION_PATTERNS = ['connection', 'econnrefused', 'enotfound'];
+const CRASH_PATTERNS = ['crash', 'exited', 'killed', 'sigterm', 'sigkill'];
+const ADAPTER_PATTERNS = ['no model adapter', 'adapter unavailable', 'no adapter'];
+const VALIDATION_PATTERNS = ['validation', 'invalid input', 'parse error', 'zod'];
+
+function matchesAny(text: string, patterns: string[]): boolean {
+  return patterns.some((p) => text.includes(p));
+}
+
+/** Classifies an error into an OutcomeFailureCategory for recording. */
+export function categorizeOutcomeError(error: unknown): OutcomeFailureCategory {
+  if (!(error instanceof Error)) return 'unknown';
+  const text = `${error.message.toLowerCase()} ${error.name.toLowerCase()}`;
+  if (matchesAny(text, TIMEOUT_PATTERNS)) return 'timeout';
+  if (matchesAny(text, AUTH_PATTERNS)) return 'authentication';
+  if (matchesAny(text, RATE_LIMIT_PATTERNS)) return 'rate_limit';
+  if (matchesAny(text, ADAPTER_PATTERNS)) return 'adapter_unavailable';
+  if (matchesAny(text, CONNECTION_PATTERNS)) return 'connection';
+  if (matchesAny(text, CRASH_PATTERNS)) return 'crash';
+  if (matchesAny(text, VALIDATION_PATTERNS)) return 'validation';
+  return 'execution';
+}
+
+/** Classifies an error message string into an OutcomeFailureCategory. */
+export function categorizeOutcomeErrorMessage(msg: string): OutcomeFailureCategory {
+  const text = msg.toLowerCase();
+  if (matchesAny(text, TIMEOUT_PATTERNS)) return 'timeout';
+  if (matchesAny(text, AUTH_PATTERNS)) return 'authentication';
+  if (matchesAny(text, RATE_LIMIT_PATTERNS)) return 'rate_limit';
+  if (matchesAny(text, ADAPTER_PATTERNS)) return 'adapter_unavailable';
+  if (matchesAny(text, CONNECTION_PATTERNS)) return 'connection';
+  if (matchesAny(text, CRASH_PATTERNS)) return 'crash';
+  if (matchesAny(text, VALIDATION_PATTERNS)) return 'validation';
+  return 'execution';
+}
 
 /** Aggregated stats for a group of outcomes. */
 export interface GroupStats {


### PR DESCRIPTION
## Summary
- Adds `OutcomeFailureCategory` enum (9 values: timeout, authentication, rate_limit, connection, crash, adapter_unavailable, validation, execution, unknown) to `TaskOutcome` schema
- Failed outcomes from `orchestrate` and `execute-expert` tools are now classified via pattern-matching error messages
- Weather report surfaces `failureBreakdown` section with per-category counts and percentages
- Exports `categorizeOutcomeError()` and `categorizeOutcomeErrorMessage()` for error classification

## Test plan
- [x] 20 new tests in `error-taxonomy.test.ts` covering schema validation and error classification
- [x] 3 new weather report tests covering failure breakdown generation
- [x] All 141 existing outcome/export tests pass
- [x] All 25 execute-expert tests pass
- [x] Typecheck clean
- [x] Fitness: 98/100

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)