### PR TITLE
feat(#1023): Bootstrap LinUCB bandit with synthetic outcomes

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -53,6 +53,7 @@ import {
 } from '../learning/strategy-distiller.js';
 import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import { isPersistenceEnabled } from '../config/learning-persistence.js';
+import { generateSyntheticPriors } from '../cli/warm-up.js';
 import {
   CompositeRouterConfigSchema,
   CompositeRoutingError,
@@ -288,15 +289,25 @@ export class CompositeRouter implements ICompositeRouter {
 
   /** Warm-start LinUCB bandit from persisted outcomes (Issue #1015). Best-effort. */
   private warmStartBandit(): void {
-    if (this.linucbBandit === undefined || !isPersistenceEnabled()) return;
+    if (this.linucbBandit === undefined) return;
     try {
-      const outcomes = getOutcomeStore().query();
-      if (outcomes.length === 0) return;
-      const replayed = this.linucbBandit.warmStart(outcomes);
-      this.logger.info('LinUCB warm-started from persisted outcomes', {
-        outcomesAvailable: outcomes.length,
-        outcomesReplayed: replayed,
-      });
+      let replayed = 0;
+      if (isPersistenceEnabled()) {
+        const outcomes = getOutcomeStore().query();
+        if (outcomes.length > 0) {
+          replayed = this.linucbBandit.warmStart(outcomes);
+          this.logger.info('LinUCB warm-started from persisted outcomes', {
+            outcomesAvailable: outcomes.length,
+            outcomesReplayed: replayed,
+          });
+        }
+      }
+      // Cold-start fallback: seed from specialization matrix (Issue #1023)
+      if (replayed === 0) {
+        const priors = generateSyntheticPriors();
+        this.linucbBandit.seedPriors(priors, 3);
+        this.logger.info('LinUCB cold-start seeded from specialization matrix');
+      }
     } catch (error: unknown) {
       this.logger.warn('LinUCB warm-start failed, starting cold', {
         error: getErrorMessage(error),

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /**
  * nexus-agents CLI Command Handlers
  *
@@ -37,6 +38,7 @@ import {
   fitnessAuditCommand,
 } from './cli/index.js';
 import { hookCommand, printHookHelp } from './cli/hooks/index.js';
+import { runWarmUp } from './cli/warm-up.js';
 import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
 import { startServer, type OrchestratorModeOptions } from './cli-server.js';
 import {
@@ -577,4 +579,21 @@ export function handleFitnessAuditCommand(args: ParsedCliArgs): void {
     json: args.options.format === 'json',
   });
   process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+}
+
+// ============================================================================
+// Issue #1023: Warm-Up Command
+// ============================================================================
+
+/**
+ * Handles warm-up command for LinUCB bandit cold-start seeding.
+ * (Source: Issue #1023 — Bootstrap LinUCB with synthetic outcomes)
+ */
+export function handleWarmUpCommand(_args: ParsedCliArgs): void {
+  const result = runWarmUp();
+  const msg = result.skipped
+    ? `Warm-up skipped: ${result.reason ?? 'already seeded'}`
+    : `Seeded with ${String(result.seeded)} synthetic observations`;
+  process.stdout.write(msg + '\n');
+  process.exit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli-commands.test.ts
+++ b/packages/nexus-agents/src/cli-commands.test.ts
@@ -31,6 +31,7 @@ vi.mock('./cli-commands-handlers.js', () => ({
   handleEvaluateCommand: vi.fn(() => Promise.resolve()),
   handleIssueCommand: vi.fn(),
   handleFitnessAuditCommand: vi.fn(),
+  handleWarmUpCommand: vi.fn(),
 }));
 
 vi.mock('./cli-auth-handler.js', () => ({

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -45,6 +45,8 @@ export {
   handleIssueCommand,
   // System Mandate LOOP I: Fitness Audit
   handleFitnessAuditCommand,
+  // Issue #1023: Warm-Up Command
+  handleWarmUpCommand,
 } from './cli-commands-handlers.js';
 // Issue #739: Auth command
 export { handleAuthCommand } from './cli-auth-handler.js';
@@ -96,6 +98,8 @@ import {
   handleIssueCommand,
   // System Mandate LOOP I: Fitness Audit
   handleFitnessAuditCommand,
+  // Issue #1023: Warm-Up Command
+  handleWarmUpCommand,
 } from './cli-commands-handlers.js';
 // Issue #739: Auth command
 import { handleAuthCommand } from './cli-auth-handler.js';
@@ -154,6 +158,8 @@ const SYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => void) | un
   capabilities: handleCapabilitiesCommand,
   // Issue #688: Status Command
   status: handleStatusCommand,
+  // Issue #1023: Warm-Up Command
+  'warm-up': handleWarmUpCommand,
 };
 
 /**

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -61,7 +61,8 @@ export type CliCommand =
   | 'status'
   | 'memory-benchmark'
   | 'auth'
-  | 'scenario';
+  | 'scenario'
+  | 'warm-up';
 
 /**
  * Parsed CLI arguments and command.
@@ -345,6 +346,7 @@ export function isValidCommand(value: string): value is CliCommand {
     'memory-benchmark',
     'auth',
     'scenario',
+    'warm-up',
   ];
   return validCommands.includes(value as CliCommand);
 }

--- a/packages/nexus-agents/src/cli/index.ts
+++ b/packages/nexus-agents/src/cli/index.ts
@@ -460,6 +460,10 @@ export {
 } from './scaffold.js';
 export type { ScaffoldType, ScaffoldOptions, ScaffoldResult } from './scaffold.js';
 
+// Warm-Up Command (Issue #1023 - LinUCB cold-start seeding)
+export { generateSyntheticPriors, runWarmUp, SYNTHETIC_MARKER } from './warm-up.js';
+export type { WarmUpResult } from './warm-up.js';
+
 // Auth Command (Issue #739 - MCP authentication)
 export {
   authCommand,

--- a/packages/nexus-agents/src/cli/warm-up.test.ts
+++ b/packages/nexus-agents/src/cli/warm-up.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for LinUCB bandit warm-up from task specialization matrix.
+ *
+ * @module cli/warm-up.test
+ * (Source: Issue #1023 — Bootstrap LinUCB with synthetic outcomes)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateSyntheticPriors, runWarmUp, SYNTHETIC_MARKER } from './warm-up.js';
+import { resetOutcomeStore, getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import { TASK_CATEGORIES } from '../config/task-specialization-types.js';
+
+describe('warm-up', () => {
+  beforeEach(() => {
+    resetOutcomeStore();
+  });
+
+  describe('generateSyntheticPriors', () => {
+    it('should return exactly 3 CLI entries', () => {
+      const priors = generateSyntheticPriors();
+      expect(priors.size).toBe(3);
+      expect(priors.has('claude')).toBe(true);
+      expect(priors.has('gemini')).toBe(true);
+      expect(priors.has('codex')).toBe(true);
+    });
+
+    it('should produce rewards between 0 and 1', () => {
+      const priors = generateSyntheticPriors();
+      for (const [, reward] of priors) {
+        expect(reward).toBeGreaterThan(0);
+        expect(reward).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('should give highest reward to CLI with most primary assignments', () => {
+      const priors = generateSyntheticPriors();
+      // claude is primary for architecture, security_review, planning, devops (4)
+      // codex is primary for code_generation, code_review, testing (3)
+      // gemini is primary for research, documentation, exploration (3)
+      const claude = priors.get('claude') ?? 0;
+      const codex = priors.get('codex') ?? 0;
+      const gemini = priors.get('gemini') ?? 0;
+      expect(claude).toBeGreaterThan(codex);
+      expect(claude).toBeGreaterThan(gemini);
+    });
+
+    it('should distinguish primary from secondary reward levels', () => {
+      const priors = generateSyntheticPriors();
+      // Claude: 4 primary (0.85) + 6 secondary (0.6) + 0 other (0.35)
+      // Expected: (4*0.85 + 6*0.6) / 10 = 0.70
+      const claude = priors.get('claude') ?? 0;
+      expect(claude).toBeCloseTo(0.7, 2);
+    });
+
+    it('should return consistent results on repeated calls', () => {
+      const first = generateSyntheticPriors();
+      const second = generateSyntheticPriors();
+      for (const [cli, reward] of first) {
+        expect(second.get(cli)).toBe(reward);
+      }
+    });
+  });
+
+  describe('runWarmUp', () => {
+    it('should seed 30 synthetic outcomes (3 CLIs x 10 categories)', () => {
+      const result = runWarmUp();
+      expect(result.seeded).toBe(3 * TASK_CATEGORIES.length);
+      expect(result.skipped).toBe(false);
+    });
+
+    it('should mark all outcomes with synthetic marker', () => {
+      runWarmUp();
+      const outcomes = getOutcomeStore().query();
+      const synthetic = outcomes.filter(
+        (o) => o.qualitySignals?.includes(SYNTHETIC_MARKER) === true
+      );
+      expect(synthetic.length).toBe(30);
+    });
+
+    it('should record outcomes with source manual', () => {
+      runWarmUp();
+      const outcomes = getOutcomeStore().query();
+      for (const o of outcomes) {
+        expect(o.source).toBe('manual');
+      }
+    });
+
+    it('should mark primary CLI outcomes as success', () => {
+      runWarmUp();
+      const outcomes = getOutcomeStore().query();
+      // Primary (0.85) and secondary (0.6) are >= 0.5 so success=true
+      // Other (0.35) is < 0.5 so success=false
+      const successful = outcomes.filter((o) => o.success);
+      // 10 primary + 10 secondary = 20 successful
+      expect(successful.length).toBe(20);
+    });
+
+    it('should be idempotent — second call returns skipped', () => {
+      const first = runWarmUp();
+      expect(first.skipped).toBe(false);
+      expect(first.seeded).toBe(30);
+
+      const second = runWarmUp();
+      expect(second.skipped).toBe(true);
+      expect(second.seeded).toBe(0);
+      expect(second.reason).toBeDefined();
+    });
+
+    it('should not add more outcomes on idempotent call', () => {
+      runWarmUp();
+      const countAfterFirst = getOutcomeStore().size;
+      runWarmUp();
+      const countAfterSecond = getOutcomeStore().size;
+      expect(countAfterSecond).toBe(countAfterFirst);
+    });
+
+    it('should cover all 10 task categories', () => {
+      runWarmUp();
+      const outcomes = getOutcomeStore().query();
+      const categories = new Set(outcomes.map((o) => o.category));
+      expect(categories.size).toBe(TASK_CATEGORIES.length);
+      for (const cat of TASK_CATEGORIES) {
+        expect(categories.has(cat)).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli/warm-up.ts
+++ b/packages/nexus-agents/src/cli/warm-up.ts
@@ -1,0 +1,143 @@
+/**
+ * LinUCB bandit warm-up from task specialization matrix.
+ *
+ * Generates synthetic priors from the canonical TASK_SPECIALIZATION_MATRIX
+ * and seeds the LinUCB bandit to reduce cold-start exploration time.
+ *
+ * @module cli/warm-up
+ * (Source: Issue #1023 — Bootstrap LinUCB with synthetic outcomes)
+ */
+
+import { TASK_SPECIALIZATION_MATRIX } from '../config/task-specialization.js';
+import { TASK_CATEGORIES } from '../config/task-specialization-types.js';
+import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+import { createLogger, type ILogger } from '../core/index.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Reward hint for the primary CLI (strong prior). */
+const PRIMARY_REWARD = 0.85;
+
+/** Reward hint for the secondary CLI (moderate prior). */
+const SECONDARY_REWARD = 0.6;
+
+/** Reward hint for other CLIs (weak/exploratory prior). */
+const OTHER_REWARD = 0.35;
+
+/** Marker in qualitySignals to identify synthetic outcomes. */
+export const SYNTHETIC_MARKER = 'synthetic:warm-up';
+
+/** All known CLI names for bandit arms. */
+const CLI_NAMES = ['claude', 'gemini', 'codex'] as const;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface WarmUpResult {
+  readonly seeded: number;
+  readonly skipped: boolean;
+  readonly reason?: string;
+}
+
+// ============================================================================
+// Core Logic
+// ============================================================================
+
+/**
+ * Derive average reward hints per CLI from the task specialization matrix.
+ *
+ * For each category:
+ * - Primary CLI gets reward 0.85
+ * - Secondary CLI gets reward 0.6
+ * - Other CLIs get reward 0.35
+ *
+ * Returns the average reward across all categories per CLI.
+ */
+export function generateSyntheticPriors(): ReadonlyMap<string, number> {
+  const totals = new Map<string, number>();
+  for (const cli of CLI_NAMES) {
+    totals.set(cli, 0);
+  }
+
+  for (const spec of TASK_SPECIALIZATION_MATRIX) {
+    for (const cli of CLI_NAMES) {
+      const current = totals.get(cli) ?? 0;
+      if (cli === spec.primaryCli) {
+        totals.set(cli, current + PRIMARY_REWARD);
+      } else if (cli === spec.secondaryCli) {
+        totals.set(cli, current + SECONDARY_REWARD);
+      } else {
+        totals.set(cli, current + OTHER_REWARD);
+      }
+    }
+  }
+
+  const count = TASK_CATEGORIES.length;
+  const priors = new Map<string, number>();
+  for (const [cli, total] of totals) {
+    priors.set(cli, total / count);
+  }
+  return priors;
+}
+
+/**
+ * Seed the LinUCB bandit with synthetic priors and record synthetic outcomes.
+ *
+ * Idempotent: skips if OutcomeStore already contains outcomes with the
+ * synthetic marker in qualitySignals.
+ */
+export function runWarmUp(logger?: ILogger): WarmUpResult {
+  const log = logger ?? createLogger({ component: 'warm-up' });
+  const store = getOutcomeStore();
+
+  // Idempotency check: skip if synthetic outcomes already exist
+  const existing = store.query();
+  const hasSynthetic = existing.some((o) => o.qualitySignals?.includes(SYNTHETIC_MARKER) === true);
+  if (hasSynthetic) {
+    log.info('Warm-up skipped: synthetic outcomes already exist');
+    return { seeded: 0, skipped: true, reason: 'synthetic outcomes already exist' };
+  }
+
+  const priors = generateSyntheticPriors();
+  const now = new Date().toISOString();
+  let seeded = 0;
+
+  // Record one synthetic outcome per CLI per category
+  for (const spec of TASK_SPECIALIZATION_MATRIX) {
+    for (const cli of CLI_NAMES) {
+      let reward: number;
+      if (cli === spec.primaryCli) {
+        reward = PRIMARY_REWARD;
+      } else if (cli === spec.secondaryCli) {
+        reward = SECONDARY_REWARD;
+      } else {
+        reward = OTHER_REWARD;
+      }
+
+      const outcome: TaskOutcome = {
+        id: `synthetic-${cli}-${spec.category}`,
+        cli,
+        category: spec.category,
+        model: `${cli}-default`,
+        success: reward >= 0.5,
+        durationMs: 0,
+        timestamp: now,
+        qualitySignals: [SYNTHETIC_MARKER],
+        source: 'manual',
+      };
+      store.append(outcome);
+      seeded++;
+    }
+  }
+
+  log.info('LinUCB warm-up complete', {
+    seeded,
+    priors: Object.fromEntries(priors),
+  });
+
+  return { seeded, skipped: false };
+}


### PR DESCRIPTION
## Summary
- Derives synthetic reward priors from `TASK_SPECIALIZATION_MATRIX` (primary=0.85, secondary=0.6, other=0.35) to warm-start LinUCB bandit during cold-start
- Adds `warm-up` CLI command that seeds 30 synthetic outcomes (3 CLIs × 10 categories) with idempotency guard
- Wires automatic cold-start fallback into `CompositeRouter.warmStartBandit()` — triggers when no persisted outcomes exist

## Test plan
- [x] 12 new tests in `warm-up.test.ts` covering priors, outcomes, idempotency, category coverage
- [x] 63 existing composite-router tests pass
- [x] 17 cli-commands tests pass
- [x] 52 export contract tests pass
- [x] Typecheck clean

Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)