### PR TITLE
feat(#1028): Dynamic expert timeout based on task complexity

### DIFF
--- a/packages/nexus-agents/src/config/env-schema.ts
+++ b/packages/nexus-agents/src/config/env-schema.ts
@@ -60,6 +60,7 @@ const NexusEnvSchema = z.object({
   NEXUS_WORKFLOW_TIMEOUT_MS: positiveIntStr.optional(),
   NEXUS_GRAPH_TIMEOUT_MS: positiveIntStr.optional(),
   NEXUS_TEST_TIMEOUT_MS: positiveIntStr.optional(),
+  NEXUS_EXPERT_TIMEOUT_MS: positiveIntStr.optional(),
 
   // --- Retry ---
   NEXUS_RETRY_MAX_RETRIES: positiveIntStr.optional(),

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -16,9 +16,11 @@ import {
   API_TIMEOUTS,
   INTERNAL_TIMEOUTS,
   TEST_TIMEOUTS,
+  EXPERT_TIMEOUTS,
   TIMEOUT_ENV_VARS,
   getCliTimeoutProfile,
   getCliTimeout,
+  getExpertTaskTimeout,
   resolveVoteTimeout,
   resolveEnvTimeout,
   validateTimeout,
@@ -77,7 +79,7 @@ describe('Centralized Timeout Configuration', () => {
     it('has per-tool overrides for long-running tools', () => {
       expect(MCP_TIMEOUTS.perTool['orchestrate']).toBe(300_000);
       expect(MCP_TIMEOUTS.perTool['consensus_vote']).toBe(300_000);
-      expect(MCP_TIMEOUTS.perTool['execute_expert']).toBe(300_000);
+      expect(MCP_TIMEOUTS.perTool['execute_expert']).toBe(600_000);
       expect(MCP_TIMEOUTS.perTool['run_workflow']).toBe(300_000);
     });
   });
@@ -252,12 +254,74 @@ describe('Centralized Timeout Configuration', () => {
     });
   });
 
+  describe('EXPERT_TIMEOUTS', () => {
+    it('has correct complexity tiers', () => {
+      expect(EXPERT_TIMEOUTS.complexMs).toBe(180_000);
+      expect(EXPERT_TIMEOUTS.standardMs).toBe(90_000);
+    });
+
+    it('has correct bounds', () => {
+      expect(EXPERT_TIMEOUTS.minMs).toBe(30_000);
+      expect(EXPERT_TIMEOUTS.maxMs).toBe(600_000);
+    });
+
+    it('lists complex categories', () => {
+      expect(EXPERT_TIMEOUTS.complexCategories).toContain('architecture');
+      expect(EXPERT_TIMEOUTS.complexCategories).toContain('security_review');
+      expect(EXPERT_TIMEOUTS.complexCategories).toHaveLength(2);
+    });
+  });
+
+  describe('getExpertTaskTimeout()', () => {
+    const envKey = 'NEXUS_EXPERT_TIMEOUT_MS';
+
+    afterEach(() => {
+      delete process.env.NEXUS_EXPERT_TIMEOUT_MS;
+    });
+
+    it('returns complex timeout for architecture tasks', () => {
+      expect(getExpertTaskTimeout('Review the system architecture')).toBe(180_000);
+    });
+
+    it('returns complex timeout for security tasks', () => {
+      expect(getExpertTaskTimeout('Perform a security review of auth')).toBe(180_000);
+    });
+
+    it('returns standard timeout for code generation tasks', () => {
+      expect(getExpertTaskTimeout('Generate unit tests for the API')).toBe(90_000);
+    });
+
+    it('returns standard timeout for documentation tasks', () => {
+      expect(getExpertTaskTimeout('Write documentation for this module')).toBe(90_000);
+    });
+
+    it('returns standard timeout for unrecognized tasks', () => {
+      expect(getExpertTaskTimeout('do something random')).toBe(90_000);
+    });
+
+    it('respects env override', () => {
+      process.env[envKey] = '200000';
+      expect(getExpertTaskTimeout('architecture review')).toBe(200_000);
+    });
+
+    it('clamps env override to minimum', () => {
+      process.env[envKey] = '1000';
+      expect(getExpertTaskTimeout('any task')).toBe(30_000);
+    });
+
+    it('clamps env override to maximum', () => {
+      process.env[envKey] = '9999999';
+      expect(getExpertTaskTimeout('any task')).toBe(600_000);
+    });
+  });
+
   describe('TIMEOUT_ENV_VARS', () => {
     it('has correct env var names', () => {
       expect(TIMEOUT_ENV_VARS.vote).toBe('NEXUS_VOTE_TIMEOUT_MS');
       expect(TIMEOUT_ENV_VARS.mcp).toBe('NEXUS_MCP_TIMEOUT_MS');
       expect(TIMEOUT_ENV_VARS.workflow).toBe('NEXUS_WORKFLOW_TIMEOUT_MS');
       expect(TIMEOUT_ENV_VARS.graph).toBe('NEXUS_GRAPH_TIMEOUT_MS');
+      expect(TIMEOUT_ENV_VARS.expert).toBe('NEXUS_EXPERT_TIMEOUT_MS');
     });
   });
 });

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -23,6 +23,7 @@
 
 import type { TaskComplexity, KnownCliName, TimeoutProfile } from './defaults-types.js';
 import { isKnownCliName } from './defaults-types.js';
+import { detectTaskCategory } from './task-specialization.js';
 
 // Re-export types that consumers need
 export type { TaskComplexity, KnownCliName, TimeoutProfile };
@@ -79,7 +80,7 @@ export const MCP_TIMEOUTS = {
   perTool: {
     orchestrate: 300_000,
     consensus_vote: 300_000,
-    execute_expert: 300_000,
+    execute_expert: 600_000, // Increased to support complex expert tasks (Issue #1028)
     run_workflow: 300_000,
   } as Readonly<Record<string, number>>,
 } as const;
@@ -158,6 +159,25 @@ export const INTERNAL_TIMEOUTS = {
 } as const;
 
 /**
+ * Expert execution timeouts by inferred task complexity.
+ * Complex reasoning tasks (architecture, security) need longer timeouts
+ * than standard code generation or documentation tasks.
+ * (Source: Issue #1028 — Dynamic expert timeout)
+ */
+export const EXPERT_TIMEOUTS = {
+  /** Complex reasoning tasks: architecture, security_review. */
+  complexMs: 180_000,
+  /** Standard tasks: code_generation, testing, code_review, etc. */
+  standardMs: 90_000,
+  /** Minimum allowed expert timeout. */
+  minMs: 30_000,
+  /** Maximum allowed expert timeout. */
+  maxMs: 600_000,
+  /** Categories considered complex (longer timeout). */
+  complexCategories: ['architecture', 'security_review'] as readonly string[],
+} as const;
+
+/**
  * Test framework timeouts (not for production code).
  */
 export const TEST_TIMEOUTS = {
@@ -195,6 +215,31 @@ export function getCliTimeout(cli: string, complexity: TaskComplexity): number {
   return getCliTimeoutProfile(cli)[complexity];
 }
 
+/**
+ * Gets the timeout for an expert task based on task description complexity.
+ *
+ * Uses `detectTaskCategory()` to infer category, then maps to timeout tier.
+ * Supports `NEXUS_EXPERT_TIMEOUT_MS` env override.
+ *
+ * @param taskDescription - Task text to analyze for complexity
+ * @returns Timeout in milliseconds
+ * (Source: Issue #1028 — Dynamic expert timeout)
+ */
+export function getExpertTaskTimeout(taskDescription: string): number {
+  const envOverride = resolveEnvTimeout(
+    'NEXUS_EXPERT_TIMEOUT_MS',
+    0,
+    EXPERT_TIMEOUTS.minMs,
+    EXPERT_TIMEOUTS.maxMs
+  );
+  if (envOverride > 0) return envOverride;
+
+  const match = detectTaskCategory(taskDescription);
+  const category = match?.category ?? 'exploration';
+  const isComplex = EXPERT_TIMEOUTS.complexCategories.includes(category);
+  return isComplex ? EXPERT_TIMEOUTS.complexMs : EXPERT_TIMEOUTS.standardMs;
+}
+
 // ============================================================================
 // Environment Variable Resolution
 // ============================================================================
@@ -205,6 +250,7 @@ export const TIMEOUT_ENV_VARS = {
   mcp: 'NEXUS_MCP_TIMEOUT_MS',
   workflow: 'NEXUS_WORKFLOW_TIMEOUT_MS',
   graph: 'NEXUS_GRAPH_TIMEOUT_MS',
+  expert: 'NEXUS_EXPERT_TIMEOUT_MS',
 } as const;
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -35,6 +35,7 @@ import {
 } from '../../orchestration/outcomes/index.js';
 import type { OutcomeFailureCategory } from '../../orchestration/outcomes/index.js';
 import { detectTaskCategory } from '../../config/task-specialization.js';
+import { getExpertTaskTimeout } from '../../config/timeouts.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
 
@@ -96,6 +97,7 @@ export interface ExecuteExpertResponse {
  * Builds a task object from the tool input.
  */
 function buildTask(input: ExecuteExpertInput): Task {
+  const timeoutMs = getExpertTaskTimeout(input.task);
   return {
     id: `exec-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 9)}`,
     description: input.task,
@@ -104,7 +106,7 @@ function buildTask(input: ExecuteExpertInput): Task {
     },
     constraints: {
       maxTokens: 4096,
-      maxDuration: 90_000, // 90s inner timeout — must complete before MCP client timeout (120s)
+      maxDuration: timeoutMs, // Dynamic timeout based on task complexity (Issue #1028)
     },
   };
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded 90s inner timeout in `execute-expert.ts` with complexity-aware dynamic timeouts
- Architecture and security_review tasks get 180s; all other categories get 90s (standard)
- Adds `NEXUS_EXPERT_TIMEOUT_MS` env override (clamped to 30s-600s)
- Increases MCP-level `execute_expert` timeout from 300s to 600s to accommodate complex tasks

## Test plan
- [x] 8 new tests for `getExpertTaskTimeout()` covering all complexity tiers and env override
- [x] 42 total timeout tests pass
- [x] 25 execute-expert tests pass
- [x] 18 env-schema tests pass
- [x] Typecheck clean

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)