### PR TITLE
feat(#1029): Concurrent expert admission control with semaphore pool

### DIFF
--- a/packages/nexus-agents/src/agents/expert-pool.test.ts
+++ b/packages/nexus-agents/src/agents/expert-pool.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for concurrent expert admission control.
+ *
+ * @module agents/expert-pool.test
+ * (Source: Issue #1029 — Concurrent expert admission control)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ExpertPool, getExpertPool, resetExpertPool } from './expert-pool.js';
+
+describe('ExpertPool', () => {
+  beforeEach(() => {
+    resetExpertPool();
+    delete process.env.NEXUS_MAX_CONCURRENT_EXPERTS;
+  });
+
+  afterEach(() => {
+    resetExpertPool();
+    delete process.env.NEXUS_MAX_CONCURRENT_EXPERTS;
+  });
+
+  describe('constructor', () => {
+    it('should default to capacity 6', () => {
+      const pool = new ExpertPool();
+      expect(pool.getStatus().capacity).toBe(6);
+    });
+
+    it('should accept custom capacity', () => {
+      const pool = new ExpertPool({ capacity: 3 });
+      expect(pool.getStatus().capacity).toBe(3);
+    });
+
+    it('should clamp capacity to minimum 1', () => {
+      const pool = new ExpertPool({ capacity: 0 });
+      expect(pool.getStatus().capacity).toBe(1);
+    });
+
+    it('should clamp capacity to maximum 20', () => {
+      const pool = new ExpertPool({ capacity: 100 });
+      expect(pool.getStatus().capacity).toBe(20);
+    });
+
+    it('should read capacity from NEXUS_MAX_CONCURRENT_EXPERTS', () => {
+      process.env.NEXUS_MAX_CONCURRENT_EXPERTS = '4';
+      const pool = new ExpertPool();
+      expect(pool.getStatus().capacity).toBe(4);
+    });
+  });
+
+  describe('acquire/release', () => {
+    it('should issue permit immediately when under capacity', async () => {
+      const pool = new ExpertPool({ capacity: 2 });
+      const permit = await pool.acquire();
+      expect(permit.id).toBe(1);
+      expect(permit.acquiredAt).toBeGreaterThan(0);
+      expect(pool.getStatus().active).toBe(1);
+    });
+
+    it('should track active count correctly', async () => {
+      const pool = new ExpertPool({ capacity: 3 });
+      const p1 = await pool.acquire();
+      const p2 = await pool.acquire();
+      expect(pool.getStatus().active).toBe(2);
+
+      pool.release(p1);
+      expect(pool.getStatus().active).toBe(1);
+
+      pool.release(p2);
+      expect(pool.getStatus().active).toBe(0);
+    });
+
+    it('should queue when at capacity and dequeue on release', async () => {
+      const pool = new ExpertPool({ capacity: 1 });
+      const p1 = await pool.acquire();
+      expect(pool.getStatus().active).toBe(1);
+
+      // This will queue since capacity is 1
+      const p2Promise = pool.acquire();
+      expect(pool.getStatus().queued).toBe(1);
+
+      // Release first permit — should dequeue the waiter
+      pool.release(p1);
+      const p2 = await p2Promise;
+      expect(p2.id).toBe(2);
+      expect(pool.getStatus().active).toBe(1);
+      expect(pool.getStatus().queued).toBe(0);
+
+      pool.release(p2);
+    });
+
+    it('should support 6 concurrent acquires at default capacity', async () => {
+      const pool = new ExpertPool();
+      const permits = await Promise.all(Array.from({ length: 6 }, () => pool.acquire()));
+      expect(pool.getStatus().active).toBe(6);
+      expect(permits).toHaveLength(6);
+
+      for (const p of permits) {
+        pool.release(p);
+      }
+      expect(pool.getStatus().active).toBe(0);
+    });
+
+    it('should timeout queued acquire after acquireTimeoutMs', async () => {
+      const pool = new ExpertPool({ capacity: 1, acquireTimeoutMs: 50 });
+      await pool.acquire(); // fills capacity
+
+      await expect(pool.acquire()).rejects.toThrow('Expert pool full');
+      await expect(pool.acquire()).rejects.toThrow('timed out');
+    });
+
+    it('should not go negative on extra release', async () => {
+      const pool = new ExpertPool({ capacity: 2 });
+      const p1 = await pool.acquire();
+      pool.release(p1);
+      pool.release(p1); // extra release
+      expect(pool.getStatus().active).toBe(0);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return correct status snapshot', async () => {
+      const pool = new ExpertPool({ capacity: 2 });
+      expect(pool.getStatus()).toEqual({ active: 0, queued: 0, capacity: 2 });
+
+      const p1 = await pool.acquire();
+      await pool.acquire();
+      expect(pool.getStatus()).toEqual({ active: 2, queued: 0, capacity: 2 });
+
+      pool.release(p1);
+      expect(pool.getStatus()).toEqual({ active: 1, queued: 0, capacity: 2 });
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return same instance from getExpertPool()', () => {
+      const a = getExpertPool();
+      const b = getExpertPool();
+      expect(a).toBe(b);
+    });
+
+    it('should create fresh instance after resetExpertPool()', () => {
+      const a = getExpertPool();
+      resetExpertPool();
+      const b = getExpertPool();
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/packages/nexus-agents/src/agents/expert-pool.ts
+++ b/packages/nexus-agents/src/agents/expert-pool.ts
@@ -1,0 +1,161 @@
+/**
+ * Concurrent expert admission control with semaphore pool.
+ *
+ * Limits the number of concurrent expert executions to prevent
+ * adapter saturation when multiple experts run in parallel.
+ *
+ * @module agents/expert-pool
+ * (Source: Issue #1029 — Concurrent expert admission control)
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Permit returned by acquire() — must be released after use. */
+export interface ExpertPermit {
+  readonly id: number;
+  readonly acquiredAt: number;
+}
+
+/** Pool status snapshot. */
+export interface ExpertPoolStatus {
+  readonly active: number;
+  readonly queued: number;
+  readonly capacity: number;
+}
+
+/** Configuration for the expert pool. */
+export interface ExpertPoolConfig {
+  /** Maximum concurrent experts (default: 6). */
+  readonly capacity: number;
+  /** Timeout for queued acquire requests in ms (default: 300_000). */
+  readonly acquireTimeoutMs: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_CAPACITY = 6;
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 300_000;
+const MIN_CAPACITY = 1;
+const MAX_CAPACITY = 20;
+
+/** Environment variable for capacity override. */
+const ENV_KEY = 'NEXUS_MAX_CONCURRENT_EXPERTS';
+
+// ============================================================================
+// ExpertPool
+// ============================================================================
+
+interface QueueEntry {
+  resolve: (permit: ExpertPermit) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Semaphore-based pool for concurrent expert executions.
+ *
+ * - `acquire()` returns a permit immediately if capacity allows, else queues
+ * - `release()` returns permit and dequeues next waiter
+ * - `getStatus()` returns current active/queued/capacity
+ */
+export class ExpertPool {
+  private readonly capacity: number;
+  private readonly acquireTimeoutMs: number;
+  private active = 0;
+  private nextId = 1;
+  private readonly queue: QueueEntry[] = [];
+
+  constructor(config?: Partial<ExpertPoolConfig>) {
+    const rawCapacity = config?.capacity ?? resolveCapacityFromEnv();
+    this.capacity = Math.min(Math.max(rawCapacity, MIN_CAPACITY), MAX_CAPACITY);
+    this.acquireTimeoutMs = config?.acquireTimeoutMs ?? DEFAULT_ACQUIRE_TIMEOUT_MS;
+  }
+
+  /** Acquire a permit. Resolves immediately if capacity, else queues. */
+  async acquire(): Promise<ExpertPermit> {
+    if (this.active < this.capacity) {
+      return this.issuePermit();
+    }
+
+    return new Promise<ExpertPermit>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = this.queue.findIndex((e) => e.resolve === resolve);
+        if (idx !== -1) {
+          this.queue.splice(idx, 1);
+        }
+        reject(
+          new Error(
+            `Expert pool full (${String(this.capacity)} capacity), ` +
+              `queued for ${String(this.acquireTimeoutMs)}ms — timed out`
+          )
+        );
+      }, this.acquireTimeoutMs);
+
+      this.queue.push({ resolve, reject, timer });
+    });
+  }
+
+  /** Release a permit back to the pool. */
+  release(_permit: ExpertPermit): void {
+    if (this.active <= 0) return;
+    this.active--;
+
+    if (this.queue.length > 0) {
+      const next = this.queue.shift();
+      if (next !== undefined) {
+        clearTimeout(next.timer);
+        next.resolve(this.issuePermit());
+      }
+    }
+  }
+
+  /** Get current pool status. */
+  getStatus(): ExpertPoolStatus {
+    return {
+      active: this.active,
+      queued: this.queue.length,
+      capacity: this.capacity,
+    };
+  }
+
+  private issuePermit(): ExpertPermit {
+    this.active++;
+    return { id: this.nextId++, acquiredAt: Date.now() };
+  }
+}
+
+// ============================================================================
+// Singleton
+// ============================================================================
+
+let globalPool: ExpertPool | undefined;
+
+/** Get or create the global expert pool singleton. */
+export function getExpertPool(): ExpertPool {
+  globalPool ??= new ExpertPool();
+  return globalPool;
+}
+
+/** Reset global pool (for testing). */
+export function resetExpertPool(): void {
+  globalPool = undefined;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolveCapacityFromEnv(): number {
+  const envVal = process.env[ENV_KEY];
+  if (envVal !== undefined) {
+    const parsed = parseInt(envVal, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_CAPACITY;
+}

--- a/packages/nexus-agents/src/agents/index.ts
+++ b/packages/nexus-agents/src/agents/index.ts
@@ -334,3 +334,13 @@ export {
   enrichAssignmentsWithICTM,
   type ICTMEnrichmentResult,
 } from './tech-lead-ictm-integration.js';
+
+// Expert Pool — concurrent admission control (Issue #1029)
+export {
+  ExpertPool,
+  getExpertPool,
+  resetExpertPool,
+  type ExpertPermit,
+  type ExpertPoolStatus,
+  type ExpertPoolConfig,
+} from './expert-pool.js';

--- a/packages/nexus-agents/src/config/env-schema.ts
+++ b/packages/nexus-agents/src/config/env-schema.ts
@@ -77,6 +77,7 @@ const NexusEnvSchema = z.object({
   NEXUS_RATE_LIMIT_REFILL_INTERVAL: positiveIntStr.optional(),
 
   // --- Workers & Concurrency ---
+  NEXUS_MAX_CONCURRENT_EXPERTS: positiveIntStr.optional(),
   NEXUS_WORKERS_MAX: positiveIntStr.optional(),
   NEXUS_WORKERS_POOL_SIZE: positiveIntStr.optional(),
   NEXUS_WORKERS_IDLE_TIMEOUT: positiveIntStr.optional(),

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -38,6 +38,7 @@ import { detectTaskCategory } from '../../config/task-specialization.js';
 import { getExpertTaskTimeout } from '../../config/timeouts.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
+import { getExpertPool } from '../../agents/expert-pool.js';
 
 /**
  * Input schema for execute_expert tool.
@@ -300,23 +301,15 @@ function handleExpertSuccess(
   });
 }
 
-/**
- * Handles the execute_expert tool execution.
- * (Issue #747 - CLI detection support)
- */
-async function handleExecuteExpert(
+type ExpertResult = { ok: true; value: ExecuteExpertResponse } | { ok: false; error: string };
+
+/** Runs the expert task and records outcomes. Assumes permit is held. */
+async function runExpertTask(
   deps: ExecuteExpertDeps,
-  args: ExecuteExpertInput
-): Promise<{ ok: true; value: ExecuteExpertResponse } | { ok: false; error: string }> {
+  args: ExecuteExpertInput,
+  expert: Expert
+): Promise<ExpertResult> {
   const { expertId } = args;
-
-  const lookup = lookupExpert(deps.expertRegistry, expertId);
-  if (!lookup.ok) return { ok: false, error: lookup.error };
-  const expert = lookup.expert;
-
-  const adapterError = await requireAdapterAvailable(deps.cliCache);
-  if (adapterError !== undefined) return { ok: false, error: adapterError };
-
   const task = buildTask(args);
   injectErrorHints(task, expert.role);
   deps.logger?.info('Executing expert task', { expertId, role: expert.role, taskId: task.id });
@@ -325,11 +318,7 @@ async function handleExecuteExpert(
   const result = await expert.execute(task);
   const durationMs = getTimeProvider().now() - startTime;
   const modelId = expert.expertConfig.modelPreference?.modelId;
-  const info = {
-    expertId,
-    role: expert.role,
-    ...(modelId !== undefined ? { modelId } : {}),
-  };
+  const info = { expertId, role: expert.role, ...(modelId !== undefined ? { modelId } : {}) };
 
   if (!result.ok) {
     deps.logger?.warn('Expert execution failed', { expertId, error: result.error.message });
@@ -351,6 +340,35 @@ async function handleExecuteExpert(
       modelUsed: expert.expertConfig.modelPreference?.modelId,
     }),
   };
+}
+
+/**
+ * Handles the execute_expert tool execution.
+ * (Issue #747 - CLI detection, Issue #1029 - admission control)
+ */
+async function handleExecuteExpert(
+  deps: ExecuteExpertDeps,
+  args: ExecuteExpertInput
+): Promise<ExpertResult> {
+  const lookup = lookupExpert(deps.expertRegistry, args.expertId);
+  if (!lookup.ok) return { ok: false, error: lookup.error };
+
+  const adapterError = await requireAdapterAvailable(deps.cliCache);
+  if (adapterError !== undefined) return { ok: false, error: adapterError };
+
+  const pool = getExpertPool();
+  let permit;
+  try {
+    permit = await pool.acquire();
+  } catch (acquireErr: unknown) {
+    return { ok: false, error: getErrorMessage(acquireErr) };
+  }
+
+  try {
+    return await runExpertTask(deps, args, lookup.expert);
+  } finally {
+    pool.release(permit);
+  }
 }
 
 /** MCP tool response type for execute_expert */


### PR DESCRIPTION
## Summary
- Adds `ExpertPool` class with semaphore-based admission control for concurrent expert executions
- Default capacity: 6 (matching consensus vote agent count), configurable via `NEXUS_MAX_CONCURRENT_EXPERTS`
- Wired into `execute-expert.ts` with try/finally permit lifecycle — 7th expert queues until slot opens
- Queue timeout produces clear error message with capacity and wait time

## Test plan
- [x] 14 new tests for ExpertPool (concurrency, queueing, timeout, env override, singleton)
- [x] 25 execute-expert tests pass
- [x] 52 export contract tests pass
- [x] Typecheck clean

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)