### PR TITLE
fix: Resolve 2 test failures from missing mocks and module-scope homedir()

### DIFF
--- a/packages/nexus-agents/src/cli-server.test.ts
+++ b/packages/nexus-agents/src/cli-server.test.ts
@@ -92,6 +92,7 @@ vi.mock('./config/index.js', () => ({
       warnings: [],
     },
   })),
+  validateNexusEnv: vi.fn(),
 }));
 
 vi.mock('./cli-server-experts.js', () => ({

--- a/packages/nexus-agents/src/config/learning-persistence.ts
+++ b/packages/nexus-agents/src/config/learning-persistence.ts
@@ -16,8 +16,17 @@ import { homedir } from 'node:os';
 // Constants
 // ============================================================================
 
+/** Resolve home directory with fallback for mocked environments. */
+function safeHomedir(): string {
+  try {
+    return homedir() || '/tmp';
+  } catch {
+    return '/tmp';
+  }
+}
+
 /** Base directory for learning persistence data. */
-export const LEARNING_DIR = join(homedir(), '.nexus-agents', 'learning');
+export const LEARNING_DIR = join(safeHomedir(), '.nexus-agents', 'learning');
 
 /** JSONL file for persisted task outcomes. */
 export const OUTCOMES_FILE = join(LEARNING_DIR, 'outcomes.jsonl');


### PR DESCRIPTION
## Summary
- Add missing `validateNexusEnv` mock in cli-server.test.ts (needed after #1016)
- Make `homedir()` call resilient in learning-persistence.ts to handle mocked `node:os` in transitive import chains

## Test plan
- [x] Full test suite: 853 files, 22,873 tests, 0 failures
- [x] `setup-helpers.test.ts` no longer crashes during collection
- [x] `cli-server.test.ts` all 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>