### PR TITLE
fix(#1045,#1047): Increase expert timeout and reduce cold-start threshold

### DIFF
--- a/packages/nexus-agents/src/cli/doctor-deep.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-deep.test.ts
@@ -110,9 +110,9 @@ describe('doctor-deep', () => {
       expect(diag.routingConvergence.converged).toBe(false);
     });
 
-    it('should report coldStartThreshold as 10', () => {
+    it('should report coldStartThreshold as 5', () => {
       const diag = runDeepDiagnostics();
-      expect(diag.dataSufficiency.coldStartThreshold).toBe(10);
+      expect(diag.dataSufficiency.coldStartThreshold).toBe(5);
     });
   });
 

--- a/packages/nexus-agents/src/cli/doctor-deep.ts
+++ b/packages/nexus-agents/src/cli/doctor-deep.ts
@@ -54,7 +54,7 @@ export interface RoutingConvergence {
 // ============================================================================
 
 const CLI_NAMES = ['claude', 'gemini', 'codex'] as const;
-const COLD_START_THRESHOLD = 10;
+const COLD_START_THRESHOLD = 5;
 
 // ============================================================================
 // Diagnostics

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -256,7 +256,7 @@ describe('Centralized Timeout Configuration', () => {
 
   describe('EXPERT_TIMEOUTS', () => {
     it('has correct complexity tiers', () => {
-      expect(EXPERT_TIMEOUTS.complexMs).toBe(180_000);
+      expect(EXPERT_TIMEOUTS.complexMs).toBe(300_000);
       expect(EXPERT_TIMEOUTS.standardMs).toBe(90_000);
     });
 
@@ -268,7 +268,8 @@ describe('Centralized Timeout Configuration', () => {
     it('lists complex categories', () => {
       expect(EXPERT_TIMEOUTS.complexCategories).toContain('architecture');
       expect(EXPERT_TIMEOUTS.complexCategories).toContain('security_review');
-      expect(EXPERT_TIMEOUTS.complexCategories).toHaveLength(2);
+      expect(EXPERT_TIMEOUTS.complexCategories).toContain('planning');
+      expect(EXPERT_TIMEOUTS.complexCategories).toHaveLength(3);
     });
   });
 
@@ -280,11 +281,11 @@ describe('Centralized Timeout Configuration', () => {
     });
 
     it('returns complex timeout for architecture tasks', () => {
-      expect(getExpertTaskTimeout('Review the system architecture')).toBe(180_000);
+      expect(getExpertTaskTimeout('Review the system architecture')).toBe(300_000);
     });
 
     it('returns complex timeout for security tasks', () => {
-      expect(getExpertTaskTimeout('Perform a security review of auth')).toBe(180_000);
+      expect(getExpertTaskTimeout('Perform a security review of auth')).toBe(300_000);
     });
 
     it('returns standard timeout for code generation tasks', () => {

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -160,13 +160,16 @@ export const INTERNAL_TIMEOUTS = {
 
 /**
  * Expert execution timeouts by inferred task complexity.
- * Complex reasoning tasks (architecture, security) need longer timeouts
- * than standard code generation or documentation tasks.
+ * Complex reasoning tasks (architecture, security, planning) need longer
+ * timeouts than standard code generation or documentation tasks.
  * (Source: Issue #1028 — Dynamic expert timeout)
+ * (Updated: Issue #1045 — E2E testing revealed 180s insufficient for
+ *  architecture design tasks; consensus_vote proves 94s is normal for
+ *  complex deliberation, so 300s gives adequate headroom)
  */
 export const EXPERT_TIMEOUTS = {
-  /** Complex reasoning tasks: architecture, security_review. */
-  complexMs: 180_000,
+  /** Complex reasoning tasks: architecture, security_review, planning. */
+  complexMs: 300_000,
   /** Standard tasks: code_generation, testing, code_review, etc. */
   standardMs: 90_000,
   /** Minimum allowed expert timeout. */
@@ -174,7 +177,7 @@ export const EXPERT_TIMEOUTS = {
   /** Maximum allowed expert timeout. */
   maxMs: 600_000,
   /** Categories considered complex (longer timeout). */
-  complexCategories: ['architecture', 'security_review'] as readonly string[],
+  complexCategories: ['architecture', 'security_review', 'planning'] as readonly string[],
 } as const;
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -181,7 +181,7 @@ export interface WeatherReportResponse {
 
 export const WeatherReportConfigSchema = z.object({
   /** Minimum observations before adjusting bonuses. */
-  coldStartThreshold: z.number().int().min(1).max(1000).default(10),
+  coldStartThreshold: z.number().int().min(1).max(1000).default(5),
   /** Exploration rate: fraction of random routing (0.0-1.0). */
   explorationRate: z.number().min(0).max(1).default(0.1),
   /** Max adaptive bonus adjustment (+/-). */

--- a/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 describe('createDefaultWeatherConfig', () => {
   it('returns expected defaults', () => {
     const config = createDefaultWeatherConfig();
-    expect(config.coldStartThreshold).toBe(10);
+    expect(config.coldStartThreshold).toBe(5);
     expect(config.explorationRate).toBe(0.1);
     expect(config.maxBonusAdjustment).toBe(5);
   });
@@ -165,13 +165,13 @@ describe('generateWeatherReport', () => {
     const report = generateWeatherReport({});
 
     expect(report.explorationRate).toBe(0.1);
-    expect(report.coldStartThreshold).toBe(10);
+    expect(report.coldStartThreshold).toBe(5);
   });
 });
 
 describe('getAdaptiveBonus', () => {
   it('returns 0 below cold-start threshold', () => {
-    seedOutcomes(5, { cli: 'claude', category: 'code_generation', success: true });
+    seedOutcomes(3, { cli: 'claude', category: 'code_generation', success: true });
 
     const bonus = getAdaptiveBonus('claude', 'code_generation');
     expect(bonus).toBe(0);

--- a/packages/nexus-agents/src/orchestration/outcomes/adaptive-thresholds.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/adaptive-thresholds.test.ts
@@ -43,16 +43,16 @@ describe('computeAdaptiveThresholds', () => {
   });
 
   it('returns defaults below cold start threshold', () => {
-    seedStore(store, 5, { cli: 'claude', category: 'code_generation' });
+    seedStore(store, 3, { cli: 'claude', category: 'code_generation' });
 
     const result = computeAdaptiveThresholds(store, 'claude', 'code_generation');
 
     expect(result.baseline).toBe(0.7);
     expect(result.maxBonus).toBe(5);
-    expect(result.coldStart).toBe(10);
+    expect(result.coldStart).toBe(5);
     expect(result.trend).toBe('stable');
     expect(result.confidence).toBe(0);
-    expect(result.sampleCount).toBe(5);
+    expect(result.sampleCount).toBe(3);
   });
 
   it('returns defaults for empty store', () => {

--- a/packages/nexus-agents/src/orchestration/outcomes/adaptive-thresholds.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/adaptive-thresholds.ts
@@ -41,7 +41,9 @@ export interface AdaptiveThresholdResult {
 
 const DEFAULT_BASELINE = 0.7;
 const DEFAULT_MAX_BONUS = 5;
-const COLD_START_THRESHOLD = 10;
+// Reduced from 10 to 5 per E2E findings (#1047): real interactive sessions
+// generate too few outcomes to ever reach 10, leaving adaptive bonuses dead.
+const COLD_START_THRESHOLD = 5;
 const DEFAULT_WINDOW_SIZE = 25;
 const FULL_CONFIDENCE_SAMPLES = 50;
 const TREND_DELTA_THRESHOLD = 0.05;


### PR DESCRIPTION
## Summary
- Increase expert complex timeout from 180s to 300s based on E2E findings (#1045)
- Add 'planning' to complex categories (alongside architecture, security_review)
- Reduce cold-start threshold from 10 to 5 outcomes (#1047) to activate adaptive learning sooner

## Context
Real E2E testing with changelog-gen and dependency-health-dashboard projects revealed:
- architecture_expert times out at 180s while consensus_vote completes in 94s
- Weather report shows 0 adaptive bonuses because all CLIs are below threshold of 10

## Test plan
- [x] 92 tests updated and passing (timeouts, weather-report, doctor-deep, adaptive-thresholds)
- [x] Fitness audit: 98/100

Closes #1045, Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>