### PR TITLE
fix(#1060): Auto-recover agent state machine from error state

### DIFF
--- a/packages/nexus-agents/src/agents/base-agent-task-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/base-agent-task-helpers.test.ts
@@ -5,7 +5,110 @@
 
 import { describe, it, expect } from 'vitest';
 import { AgentError } from '../core/index.js';
-import { transformTaskError } from './base-agent-task-helpers.js';
+import { transformTaskError, checkAgentAvailability } from './base-agent-task-helpers.js';
+import { AgentStateMachine } from './state-machine.js';
+
+// ============================================================================
+// checkAgentAvailability
+// ============================================================================
+
+describe('checkAgentAvailability', () => {
+  it('returns ok when agent is idle', () => {
+    const sm = new AgentStateMachine();
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns error when agent is thinking', () => {
+    const sm = new AgentStateMachine();
+    sm.transition('task_assigned');
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('not idle');
+      expect(result.error.message).toContain('thinking');
+    }
+  });
+
+  it('returns error when agent is acting', () => {
+    const sm = new AgentStateMachine();
+    sm.transition('task_assigned');
+    sm.transition('plan_completed');
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('acting');
+    }
+  });
+
+  it('auto-recovers from error state and returns ok', () => {
+    const sm = new AgentStateMachine();
+    sm.transition('task_assigned');
+    sm.transition('failure');
+    expect(sm.state).toBe('error');
+
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(true);
+    expect(sm.state).toBe('idle');
+  });
+
+  it('auto-recovers from error state even when maxErrorCount exceeded', () => {
+    const sm = new AgentStateMachine({ maxErrorCount: 1 });
+    // Error 1
+    sm.transition('task_assigned');
+    sm.transition('failure');
+    expect(sm.errors).toBe(1);
+    expect(sm.state).toBe('error');
+    // recover() would fail here due to maxErrorCount, but reset() should work
+    const recoverResult = sm.recover();
+    expect(recoverResult.ok).toBe(false);
+
+    // checkAgentAvailability should still auto-recover via reset()
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(true);
+    expect(sm.state).toBe('idle');
+    expect(sm.errors).toBe(0);
+  });
+
+  it('resets error count after auto-recovery', () => {
+    const sm = new AgentStateMachine();
+    // Accumulate 2 errors
+    sm.transition('task_assigned');
+    sm.transition('failure');
+    sm.recover();
+    sm.transition('task_assigned');
+    sm.transition('failure');
+    expect(sm.errors).toBe(2);
+
+    const result = checkAgentAvailability({
+      agentId: 'a1',
+      taskId: 't1',
+      stateMachine: sm,
+    });
+    expect(result.ok).toBe(true);
+    expect(sm.errors).toBe(0);
+  });
+});
 
 // ============================================================================
 // transformTaskError

--- a/packages/nexus-agents/src/agents/base-agent-task-helpers.ts
+++ b/packages/nexus-agents/src/agents/base-agent-task-helpers.ts
@@ -42,9 +42,15 @@ export interface CheckAvailabilityParams {
   stateMachine: AgentStateMachine;
 }
 
-/** Checks if an agent is available to execute a task. */
+/** Checks if an agent is available to execute a task. Auto-recovers from error state. */
 export function checkAgentAvailability(params: CheckAvailabilityParams): Result<void, AgentError> {
   const { agentId, taskId, stateMachine } = params;
+
+  // Auto-recover from error state so agents don't get permanently stuck (#1060)
+  if (stateMachine.hasError()) {
+    stateMachine.reset();
+  }
+
   if (!stateMachine.isAvailable()) {
     return err(
       new AgentError(`Agent is not idle (current state: ${stateMachine.state})`, {


### PR DESCRIPTION
## Summary
- Fixes agent state machine getting permanently stuck in `error` state after 3+ failures
- `checkAgentAvailability()` now auto-resets error state before task execution
- No server restart required — system is self-healing

## Root Cause
The `AgentStateMachine.recover()` is blocked when `errorCount >= maxErrorCount` (default 3), and the MCP orchestrate handler never calls `recover()`, `resetErrorCount()`, or `reset()`. Once an agent hit 3 cumulative errors, it was permanently stuck.

## Fix
Added 3 lines to `checkAgentAvailability()` — if the state machine `hasError()`, call `reset()` before checking availability. This uses the existing `reset()` method which force-transitions to `idle` and clears error count.

## Test plan
- [x] 6 new tests for `checkAgentAvailability` (idle, thinking, acting, auto-recover, maxErrorCount exceeded, error count reset)
- [x] 116 agent tests pass (state-machine + base-agent)
- [x] 35 orchestrate MCP tool tests pass
- [x] Typecheck clean
- [x] Fitness: 98/100

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)