### PR TITLE
chore: Fix qs DoS vulnerability (Dependabot #14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "hono": "^4.11.7",
       "@hono/node-server": "^1.19.9",
       "@isaacs/brace-expansion": ">=5.0.1",
-      "markdown-it": ">=14.1.1"
+      "markdown-it": ">=14.1.1",
+      "qs": ">=6.14.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@hono/node-server': ^1.19.9
   '@isaacs/brace-expansion': '>=5.0.1'
   markdown-it: '>=14.1.1'
+  qs: '>=6.14.2'
 
 importers:
   .:
@@ -5320,10 +5321,10 @@ packages:
       }
     engines: { node: '>=6' }
 
-  qs@6.14.1:
+  qs@6.14.2:
     resolution:
       {
-        integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==,
+        integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
       }
     engines: { node: '>=0.6' }
 
@@ -7858,7 +7859,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.14.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -8443,7 +8444,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.14.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -9753,7 +9754,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary
- Adds pnpm override for `qs` to force version ≥6.14.2
- Resolves last remaining Dependabot alert (#14) — arrayLimit bypass DoS
- Transitive dependency via express → body-parser (from @modelcontextprotocol/sdk)

## Test plan
- [x] Typecheck clean
- [x] All qs instances now at 6.14.2
- [x] Fitness: 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)