### PR TITLE
fix: remove deprecated baseUrl/paths from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "ES2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "astro/tsconfigs/strict",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  }
+  "extends": "astro/tsconfigs/strict"
 }


### PR DESCRIPTION
## Summary
- Remove unused `@/*` path alias from `website/tsconfig.json` (zero imports reference it)
- Remove `ignoreDeprecations: "6.0"` from root `tsconfig.json`
- Resolves TypeScript 7.0 deprecation warning for `baseUrl`+`paths`

## Related
- Fixes #1618

## Test plan
- [x] `pnpm typecheck` passes (no import breakage since alias was unused)
- [x] Pre-commit hooks pass (prettier, gitleaks)
- [x] Fitness score: 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)