### PR TITLE
fix: vote timeout 180s→300s + restore ignoreDeprecations

### DIFF
--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -58,8 +58,10 @@ export const CLI_TIMEOUTS = {
  * Increased from 90s to 120s per Issue #983 for slower CLIs.
  */
 export const VOTE_TIMEOUTS = {
-  /** Default per-agent vote timeout. */
-  defaultMs: 180_000,
+  /** Default per-agent vote timeout.
+   * Increased from 180s to 300s per Issue #1640 — architecture/security
+   * experts regularly exceed 180s on complex proposals (avg 315s observed). */
+  defaultMs: 300_000,
   /** Minimum allowed vote timeout (floor for env override). */
   minMs: 30_000,
   /** Maximum allowed vote timeout (cap for env override). */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary
Two fixes:

### Vote per-agent timeout (#1640)
Increased from 180s to 300s. Weather report (10,000 tasks) shows architecture
experts avg 315s, security expert degraded with 3 consecutive timeouts.
27% of all task failures are timeout-related.

### tsconfig ignoreDeprecations
Restored `ignoreDeprecations: "6.0"` — a dependency uses `baseUrl` which
errors without this. Build was broken on main after the earlier removal.

## Test plan
- [x] `pnpm build` passes
- [x] Pre-commit hooks pass (ESLint, Prettier, gitleaks)
- [x] Fitness score 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)