### PR TITLE
feat(pipeline): add research-to-project pipeline (#1711)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,8 +504,9 @@ Governance rules (voting thresholds, refactor gates, fitness audit, documentatio
 | `extract_symbols`         | Extract code symbols (functions, classes, types) from source files for analysis.                                                              |
 | `search_codebase`         | Search the codebase for code patterns, symbols, or text across all source files.                                                              |
 | `run_dev_pipeline`        | run_dev_pipeline tool                                                                                                                         |
+| `run_research_pipeline`   | Execute research-to-project pipeline: decompose prompt into tracks, investigate in parallel, synthesize, vote go/no-go, generate deliverables |
 
-_Auto-generated from source. 29 tools registered._
+_Auto-generated from source. 30 tools registered._
 
 <!-- GOVERNANCE:TOOL_INDEX:END -->
 

--- a/packages/nexus-agents/src/cli-server-tools.test.ts
+++ b/packages/nexus-agents/src/cli-server-tools.test.ts
@@ -234,6 +234,11 @@ vi.mock('./mcp/tools/dev-pipeline-tool.js', () => ({
   registerDevPipelineTool: vi.fn(),
 }));
 
+// Mock research pipeline tool (tested separately in research-pipeline-tool.test.ts)
+vi.mock('./mcp/tools/research-pipeline-tool.js', () => ({
+  registerResearchPipelineTool: vi.fn(),
+}));
+
 // Mock observability proxy as identity (tested separately in tool-observability-proxy.test.ts)
 vi.mock('./mcp/tools/tool-observability-proxy.js', () => ({
   createToolObservabilityProxy: (server: unknown) => server,

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -46,6 +46,7 @@ import {
 // Import mock directly from source (not public API - used as fallback when no adapter)
 import { createMockTechLead } from './mcp/tools/orchestrate.js';
 import { registerDevPipelineTool } from './mcp/tools/dev-pipeline-tool.js';
+import { registerResearchPipelineTool } from './mcp/tools/research-pipeline-tool.js';
 
 import type { Expert } from './agents/index.js';
 import { createRealWorkflowEngine } from './workflows/index.js';
@@ -559,6 +560,7 @@ const STANDALONE_TOOLS: ReadonlyArray<{
   { name: 'extract_symbols', register: registerExtractSymbolsTool as never },
   { name: 'search_codebase', register: registerSearchCodebaseTool as never },
   { name: 'run_dev_pipeline', register: registerDevPipelineTool as never },
+  { name: 'run_research_pipeline', register: registerResearchPipelineTool as never },
 ];
 
 /** Registers tool categories, skipping those blocked by allowlist. (Issue #740) */

--- a/packages/nexus-agents/src/exports/pipeline.ts
+++ b/packages/nexus-agents/src/exports/pipeline.ts
@@ -138,4 +138,16 @@ export {
   cleanupCheckpoint,
   checkpointToResult,
   type PipelineCheckpointState,
+  // Research Pipeline (#1711)
+  runResearchPipeline,
+  createResearchStages,
+  type ResearchPipelineStages,
+  type ResearchPipelineOptions,
+  type ResearchPipelineResult,
+  type ResearchTrack,
+  type TrackFinding,
+  type EvidenceItem,
+  type ResearchSynthesis,
+  type ResearchDeliverable,
+  type ResearchAgentConfig,
 } from '../pipeline/index.js';

--- a/packages/nexus-agents/src/mcp/tools/index.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.test.ts
@@ -67,7 +67,7 @@ import {
   RepoSecurityPlanInputSchema,
 } from './index.js';
 
-const EXPECTED_TOOL_COUNT = 29;
+const EXPECTED_TOOL_COUNT = 30;
 
 const EXPECTED_TOOL_NAMES = [
   'orchestrate',
@@ -99,6 +99,7 @@ const EXPECTED_TOOL_NAMES = [
   'extract_symbols',
   'search_codebase',
   'run_dev_pipeline',
+  'run_research_pipeline',
 ];
 
 describe('MCP tools index', () => {

--- a/packages/nexus-agents/src/mcp/tools/index.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.ts
@@ -327,6 +327,12 @@ export {
 } from './query-trace-tool.js';
 
 // Research pipeline tool (Issue #1711)
+export {
+  registerResearchPipelineTool,
+  ResearchPipelineInputSchema,
+  type ResearchPipelineInput,
+} from './research-pipeline-tool.js';
+
 // Tool annotations and side effects (Issue #993)
 export {
   TOOL_ANNOTATIONS,
@@ -451,6 +457,7 @@ export function registerTools(
       'extract_symbols',
       'search_codebase',
       'run_dev_pipeline',
+      'run_research_pipeline',
     ],
     logger,
     rateLimiter,

--- a/packages/nexus-agents/src/mcp/tools/research-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-pipeline-tool.ts
@@ -1,0 +1,137 @@
+/**
+ * run_research_pipeline MCP Tool (#1711)
+ *
+ * Exposes the research-to-project pipeline as an MCP tool.
+ * Unlike run_dev_pipeline (self-improvement), this pipeline produces
+ * external-facing research deliverables and project feasibility studies.
+ *
+ * @module mcp/tools/research-pipeline-tool
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getErrorMessage } from '../../core/index.js';
+import { runResearchPipeline } from '../../pipeline/research-pipeline.js';
+import type { ResearchPipelineResult } from '../../pipeline/research-pipeline.js';
+import { createResearchStages } from '../../pipeline/research-agent-executor.js';
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const ResearchPipelineInputSchema = z.object({
+  /** The research prompt — what to investigate. */
+  topic: z.string().min(10).max(10000).describe('Research prompt describing what to investigate'),
+  /** Whether to run in dry-run mode (research+vote only, no deliverables). */
+  dryRun: z
+    .boolean()
+    .default(false)
+    .describe('If true, stop after vote (no deliverable generation)'),
+  /** Maximum vote iterations (default: 3). */
+  maxVoteIterations: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .default(3)
+    .describe('Max synthesize→vote iterations'),
+  /** Maximum parallel research tracks (default: 4). */
+  maxParallelTracks: z
+    .number()
+    .int()
+    .min(1)
+    .max(8)
+    .default(4)
+    .describe('Max parallel investigation tracks'),
+  /** Session ID for checkpoint/resume. */
+  sessionId: z
+    .string()
+    .max(128)
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .optional()
+    .describe('Session ID for checkpoint/resume (crash recovery)'),
+  /** Use simulated votes (for testing without real CLIs). */
+  simulateVotes: z
+    .boolean()
+    .default(false)
+    .describe('Use simulated votes (for testing without real CLIs)'),
+});
+
+export type ResearchPipelineInput = z.infer<typeof ResearchPipelineInputSchema>;
+
+// ============================================================================
+// Output Formatting
+// ============================================================================
+
+/** Build structured JSON output for consumption. */
+function buildStructuredOutput(result: ResearchPipelineResult): Record<string, unknown> {
+  return {
+    completed: result.completed,
+    voteIterations: result.voteIterations,
+    trackCount: result.tracks.length,
+    tracks: result.tracks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      description: t.description,
+    })),
+    findings: result.findings.map((f) => ({
+      trackId: f.trackId,
+      confidence: f.confidence,
+      summary: f.summary.slice(0, 500),
+      gaps: f.gaps,
+    })),
+    vote: result.vote,
+    recommendation: result.synthesis?.recommendation ?? null,
+    contradictions: result.synthesis?.contradictions ?? [],
+    deliverables: result.deliverables.map((d) => ({
+      type: d.type,
+      title: d.title,
+      contentLength: d.content.length,
+      content: d.content,
+    })),
+  };
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+/** Register the run_research_pipeline MCP tool. */
+export function registerResearchPipelineTool(
+  server: McpServer,
+  _deps: { logger: unknown; rateLimiter: unknown }
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- matches existing tool registration pattern
+  server.tool('run_research_pipeline', ResearchPipelineInputSchema.shape, async (args) => {
+    const input = ResearchPipelineInputSchema.parse(args);
+
+    try {
+      const stages = createResearchStages({
+        simulateVotes: input.simulateVotes,
+      });
+
+      const result = await runResearchPipeline(input.topic, stages, {
+        sessionId: input.sessionId,
+        dryRun: input.dryRun,
+        maxVoteIterations: input.maxVoteIterations,
+        maxParallelTracks: input.maxParallelTracks,
+      });
+
+      const structured = buildStructuredOutput(result);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
+        structuredContent: structured,
+      };
+    } catch (error: unknown) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Research pipeline error: ${getErrorMessage(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+}

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -209,6 +209,23 @@ export type {
 export { runQaLoop, DEFAULT_MAX_QA_ITERATIONS } from '../orchestration/qa-loop.js';
 export type { QaVerdict, QaReviewOutput, QaLoopResult } from '../orchestration/qa-loop.js';
 
+// Research Pipeline — external research + project feasibility (#1711)
+export { runResearchPipeline } from './research-pipeline.js';
+export type {
+  ResearchPipelineStages,
+  ResearchPipelineOptions,
+  ResearchPipelineResult,
+  ResearchTrack,
+  TrackFinding,
+  EvidenceItem,
+  ResearchSynthesis,
+  ResearchDeliverable,
+} from './research-pipeline.js';
+
+// Research Agent Executor — wires research stages to real agents (#1711)
+export { createResearchStages } from './research-agent-executor.js';
+export type { ResearchAgentConfig } from './research-agent-executor.js';
+
 // Replay — decision trace comparison (#1688)
 export { parseTraceJsonl, extractDecisions, compareDecisions } from '../replay/replay-executor.js';
 export type { TracedDecision, ReplayComparison, ReplaySummary } from '../replay/replay-executor.js';

--- a/packages/nexus-agents/src/pipeline/research-agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/research-agent-executor.ts
@@ -1,0 +1,332 @@
+/**
+ * Research Agent Executor — Connects research pipeline stages to nexus-agents (#1711)
+ *
+ * Wires ResearchPipelineStages to real expert agents for:
+ * - LLM-assisted prompt decomposition
+ * - Parallel track investigation via research experts
+ * - Finding synthesis via architect experts
+ * - Consensus voting via ConsensusEngine
+ * - Deliverable generation via PM experts
+ *
+ * @module pipeline/research-agent-executor
+ */
+
+import { createLogger } from '../core/index.js';
+import type {
+  ResearchPipelineStages,
+  ResearchTrack,
+  TrackFinding,
+  ResearchSynthesis,
+  ResearchDeliverable,
+} from './research-pipeline.js';
+import type { VoteResult } from './dev-pipeline.js';
+import { createVoteResult } from './dev-pipeline.js';
+import { executeExpert } from './expert-bridge.js';
+
+const logger = createLogger({ component: 'research-agent-executor' });
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/** Configuration for research agent stages. */
+export interface ResearchAgentConfig {
+  /** Use simulated votes instead of real CLI consensus. */
+  readonly simulateVotes?: boolean | undefined;
+}
+
+// ============================================================================
+// LLM-Assisted Decomposition
+// ============================================================================
+
+/** Decompose a research prompt into bounded tracks using an architect expert. */
+async function decomposePrompt(prompt: string): Promise<ResearchTrack[]> {
+  const instruction = buildDecomposeInstruction(prompt);
+  const result = await executeExpert('architecture', instruction);
+
+  if (!result.success || result.text.trim() === '') {
+    logger.warn('LLM decomposition failed, using heuristic fallback');
+    return heuristicDecompose(prompt);
+  }
+
+  return parseTracksFromLlm(result.text, prompt);
+}
+
+/** Build the instruction for the architect to decompose the prompt. */
+function buildDecomposeInstruction(prompt: string): string {
+  return [
+    'Decompose this research prompt into 2-6 bounded research tracks.',
+    'Each track should be independently investigable.',
+    '',
+    'Return ONLY a JSON array of objects with these fields:',
+    '- id: kebab-case identifier (e.g., "security-analysis")',
+    '- title: human-readable title',
+    '- description: what to investigate (2-3 sentences)',
+    '- methodology: how to investigate (primary sources, code inspection, etc.)',
+    '- sources: array of source types to consult',
+    '',
+    'Example: [{"id":"track-a","title":"Security Analysis","description":"...","methodology":"...","sources":["upstream-repo","CVE-DB"]}]',
+    '',
+    '---',
+    prompt,
+  ].join('\n');
+}
+
+/** Parse LLM output into ResearchTrack array. */
+function parseTracksFromLlm(text: string, prompt: string): ResearchTrack[] {
+  try {
+    const jsonMatch = /\[[\s\S]*\]/.exec(text);
+    if (jsonMatch === null) return heuristicDecompose(prompt);
+
+    const parsed = JSON.parse(jsonMatch[0]) as unknown[];
+    return parsed
+      .filter((item): item is Record<string, unknown> => typeof item === 'object' && item !== null)
+      .map((item, i) => {
+        const id = typeof item['id'] === 'string' ? item['id'] : `track-${String(i + 1)}`;
+        const title = typeof item['title'] === 'string' ? item['title'] : `Track ${String(i + 1)}`;
+        const desc = typeof item['description'] === 'string' ? item['description'] : '';
+        const method =
+          typeof item['methodology'] === 'string' ? item['methodology'] : 'Primary sources';
+        const sources = Array.isArray(item['sources'])
+          ? (item['sources'] as unknown[]).filter((s): s is string => typeof s === 'string')
+          : [];
+        return { id, title, description: desc, methodology: method, outputBudget: 2000, sources };
+      });
+  } catch {
+    logger.debug('Failed to parse LLM tracks, falling back to heuristic');
+    return heuristicDecompose(prompt);
+  }
+}
+
+// ============================================================================
+// Heuristic Fallback
+// ============================================================================
+
+/** Keyword-based heuristic decomposition when LLM is unavailable. */
+function heuristicDecompose(prompt: string): ResearchTrack[] {
+  const lower = prompt.toLowerCase();
+  const tracks: ResearchTrack[] = [];
+  let idx = 0;
+
+  const addTrack = (id: string, title: string, desc: string): void => {
+    tracks.push({
+      id,
+      title,
+      description: desc,
+      methodology: 'Primary sources and documentation review',
+      outputBudget: 2000,
+      sources: [],
+    });
+    idx++;
+  };
+
+  if (matchesAny(lower, ['security', 'vulnerability', 'cve', 'threat', 'audit'])) {
+    addTrack(
+      'security-analysis',
+      'Security Analysis',
+      'Investigate security posture and known vulnerabilities'
+    );
+  }
+  if (matchesAny(lower, ['alternative', 'competitor', 'compare', 'landscape', 'vs'])) {
+    addTrack(
+      'competitive-landscape',
+      'Competitive Landscape',
+      'Research existing alternatives and compare capabilities'
+    );
+  }
+  if (matchesAny(lower, ['architecture', 'design', 'implement', 'build', 'feasib'])) {
+    addTrack(
+      'feasibility-assessment',
+      'Feasibility Assessment',
+      'Assess technical feasibility of proposed approach'
+    );
+  }
+  if (matchesAny(lower, ['risk', 'threat', 'model', 'attack'])) {
+    addTrack('threat-modeling', 'Threat Modeling', 'Define explicit threat models and mitigations');
+  }
+
+  // Always include at least a general track
+  if (idx === 0) {
+    addTrack('general-research', 'General Research', `Investigate: ${prompt.slice(0, 200)}`);
+  }
+
+  return tracks;
+}
+
+function matchesAny(text: string, keywords: readonly string[]): boolean {
+  return keywords.some((kw) => text.includes(kw));
+}
+
+// ============================================================================
+// Investigation
+// ============================================================================
+
+/** Investigate a single research track using a research expert. */
+async function investigateTrack(track: ResearchTrack): Promise<TrackFinding> {
+  const instruction = [
+    `Research track: ${track.title}`,
+    `Description: ${track.description}`,
+    `Methodology: ${track.methodology}`,
+    '',
+    'Use research_discover and research_analyze to gather evidence.',
+    'Prefer primary sources. Cite everything. Distinguish facts from speculation.',
+    `Max output: ${String(track.outputBudget)} characters.`,
+    '',
+    'Return a structured summary with: key findings, evidence quality, confidence level, and gaps.',
+  ].join('\n');
+
+  const result = await executeExpert('research', instruction);
+
+  return {
+    trackId: track.id,
+    summary: result.text || `Investigation of ${track.title} completed`,
+    evidence: [
+      {
+        source: result.success ? 'research-expert' : 'fallback',
+        claim: result.text.slice(0, 500) || 'No evidence gathered',
+        tier: result.success ? 'primary' : 'tertiary',
+      },
+    ],
+    confidence: result.success ? 'medium' : 'low',
+    gaps: result.success ? [] : ['Expert unavailable — manual investigation needed'],
+  };
+}
+
+// ============================================================================
+// Synthesis
+// ============================================================================
+
+/** Synthesize findings across tracks using an architect expert. */
+async function synthesizeFindings(
+  prompt: string,
+  findings: readonly TrackFinding[],
+  priorFeedback?: string
+): Promise<ResearchSynthesis> {
+  const feedbackSection =
+    priorFeedback !== undefined ? `\n\nPrior feedback to address:\n${priorFeedback}` : '';
+
+  const instruction = [
+    'Synthesize these research findings into a cohesive assessment.',
+    '',
+    `Original prompt: ${prompt.slice(0, 500)}`,
+    '',
+    'Findings:',
+    ...findings.map((f) => `### ${f.trackId} (${f.confidence} confidence)\n${f.summary}`),
+    feedbackSection,
+    '',
+    'Produce:',
+    '1. Overall recommendation (go/no-go/conditional with reasoning)',
+    '2. List any contradictions between tracks',
+    '3. Draft deliverable content for: executive_memo, risk_register',
+  ].join('\n');
+
+  const result = await executeExpert('architecture', instruction);
+
+  return {
+    findings: findings.slice(),
+    contradictions: [],
+    recommendation: result.text || 'Unable to synthesize — expert unavailable',
+    deliverables: [
+      {
+        type: 'executive_memo',
+        title: 'Executive Assessment Memo',
+        content: result.text || 'Synthesis failed — manual review required',
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// Voting
+// ============================================================================
+
+/** Run consensus vote on the research synthesis. */
+async function voteOnSynthesis(
+  synthesis: ResearchSynthesis,
+  simulateVotes: boolean
+): Promise<VoteResult> {
+  if (simulateVotes) {
+    return createVoteResult(true, '', 83);
+  }
+
+  const proposal = [
+    'Should this project proceed based on the research findings?',
+    '',
+    `Recommendation: ${synthesis.recommendation.slice(0, 1000)}`,
+    '',
+    `Tracks analyzed: ${String(synthesis.findings.length)}`,
+    `Contradictions found: ${String(synthesis.contradictions.length)}`,
+  ].join('\n');
+
+  const result = await executeExpert('architecture', `Vote on this proposal:\n\n${proposal}`);
+
+  // Parse vote from expert response
+  const lower = (result.text || '').toLowerCase();
+  const isGo = lower.includes('approve') || lower.includes('go') || lower.includes('proceed');
+  return createVoteResult(isGo, result.text || '', isGo ? 75 : 33);
+}
+
+// ============================================================================
+// Scaffolding
+// ============================================================================
+
+/** Generate project deliverables using a PM expert. */
+async function scaffoldProject(synthesis: ResearchSynthesis): Promise<ResearchDeliverable[]> {
+  const instruction = [
+    'Based on this research synthesis, generate project deliverables.',
+    '',
+    `Recommendation: ${synthesis.recommendation.slice(0, 500)}`,
+    '',
+    'Generate content for each deliverable type:',
+    '1. executive_memo — go/no-go decision with risk summary',
+    '2. security_report — confirmed issues, unconfirmed allegations, unknowns',
+    '3. mvp_scope — minimum viable scope if proceeding',
+    '4. architecture_rec — recommended architecture approach',
+    '5. risk_register — key risks and mitigations',
+  ].join('\n');
+
+  const result = await executeExpert('pm', instruction);
+  const text = result.text || 'Deliverable generation failed — manual creation required';
+
+  // Generate all 5 deliverable types
+  const types: ReadonlyArray<ResearchDeliverable['type']> = [
+    'executive_memo',
+    'security_report',
+    'mvp_scope',
+    'architecture_rec',
+    'risk_register',
+  ];
+
+  return types.map((type) => ({
+    type,
+    title: formatDeliverableTitle(type),
+    content: text,
+  }));
+}
+
+function formatDeliverableTitle(type: ResearchDeliverable['type']): string {
+  const titles: Record<ResearchDeliverable['type'], string> = {
+    executive_memo: 'Executive Assessment Memo',
+    security_report: 'Security Findings Report',
+    mvp_scope: 'Proposed MVP Scope',
+    architecture_rec: 'Architecture Recommendation',
+    risk_register: 'Project Risk Register',
+  };
+  return titles[type];
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/** Create research pipeline stages wired to real agents. */
+export function createResearchStages(config: ResearchAgentConfig = {}): ResearchPipelineStages {
+  const sim = config.simulateVotes === true;
+  return {
+    decompose: decomposePrompt,
+    investigate: investigateTrack,
+    synthesize: synthesizeFindings,
+    vote: (synthesis) => voteOnSynthesis(synthesis, sim),
+    scaffold: scaffoldProject,
+  };
+}

--- a/packages/nexus-agents/src/pipeline/research-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/research-pipeline.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for Research-to-Project Pipeline (#1711)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runResearchPipeline } from './research-pipeline.js';
+import type {
+  ResearchPipelineStages,
+  ResearchTrack,
+  TrackFinding,
+  ResearchSynthesis,
+  ResearchDeliverable,
+} from './research-pipeline.js';
+import type { VoteResult } from './dev-pipeline.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function makeTrack(id: string, title: string): ResearchTrack {
+  return {
+    id,
+    title,
+    description: `Research ${title}`,
+    methodology: 'Primary sources',
+    outputBudget: 2000,
+    sources: ['upstream-repo', 'CVE-DB'],
+  };
+}
+
+function makeFinding(trackId: string): TrackFinding {
+  return {
+    trackId,
+    summary: `Findings for ${trackId}`,
+    evidence: [{ source: 'repo', claim: 'Verified', tier: 'primary' }],
+    confidence: 'high',
+    gaps: [],
+  };
+}
+
+function makeSynthesis(recommendation: string): ResearchSynthesis {
+  return {
+    findings: [makeFinding('track-1')],
+    contradictions: [],
+    recommendation,
+    deliverables: [{ type: 'executive_memo', title: 'Assessment', content: 'Go recommendation' }],
+  };
+}
+
+function makeApprovedVote(): VoteResult {
+  return { kind: 'approved', approvalPercentage: 83 };
+}
+
+function makeRejectedVote(feedback: string): VoteResult {
+  return { kind: 'rejected', feedback, approvalPercentage: 33 };
+}
+
+function makeConditionalVote(): VoteResult {
+  return {
+    kind: 'conditional_go',
+    conditions: ['Must validate reproducible builds'],
+    caveats: ['Hardware testing burden is high'],
+    approvalPercentage: 67,
+  };
+}
+
+function makeDeliverable(type: ResearchDeliverable['type']): ResearchDeliverable {
+  return { type, title: `${type} deliverable`, content: `Content for ${type}` };
+}
+
+function createMockStages(): ResearchPipelineStages {
+  return {
+    decompose: vi
+      .fn<(prompt: string) => Promise<ResearchTrack[]>>()
+      .mockResolvedValue([
+        makeTrack('track-a', 'Security Analysis'),
+        makeTrack('track-b', 'Competitive Landscape'),
+      ]),
+    investigate: vi
+      .fn<(track: ResearchTrack) => Promise<TrackFinding>>()
+      .mockImplementation((track) => Promise.resolve(makeFinding(track.id))),
+    synthesize: vi
+      .fn<
+        (
+          prompt: string,
+          findings: readonly TrackFinding[],
+          priorFeedback?: string
+        ) => Promise<ResearchSynthesis>
+      >()
+      .mockResolvedValue(makeSynthesis('Go — credible security gaps found')),
+    vote: vi
+      .fn<(synthesis: ResearchSynthesis) => Promise<VoteResult>>()
+      .mockResolvedValue(makeApprovedVote()),
+    scaffold: vi
+      .fn<(synthesis: ResearchSynthesis) => Promise<ResearchDeliverable[]>>()
+      .mockResolvedValue([makeDeliverable('executive_memo'), makeDeliverable('risk_register')]),
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('runResearchPipeline', () => {
+  let stages: ResearchPipelineStages;
+
+  beforeEach(() => {
+    stages = createMockStages();
+  });
+
+  it('runs all 5 phases end-to-end when vote approves', async () => {
+    const result = await runResearchPipeline('Investigate Ventoy security', stages);
+
+    expect(result.completed).toBe(true);
+    expect(result.tracks).toHaveLength(2);
+    expect(result.findings).toHaveLength(2);
+    expect(result.synthesis).not.toBeNull();
+    expect(result.vote).toEqual(makeApprovedVote());
+    expect(result.deliverables).toHaveLength(2);
+    expect(result.voteIterations).toBe(1);
+
+    expect(stages.decompose).toHaveBeenCalledOnce();
+    expect(stages.investigate).toHaveBeenCalledTimes(2);
+    expect(stages.synthesize).toHaveBeenCalledOnce();
+    expect(stages.vote).toHaveBeenCalledOnce();
+    expect(stages.scaffold).toHaveBeenCalledOnce();
+  });
+
+  it('skips scaffold when vote rejects', async () => {
+    vi.mocked(stages.vote).mockResolvedValue(makeRejectedVote('Insufficient evidence'));
+
+    const result = await runResearchPipeline('Investigate Ventoy', stages, {
+      maxVoteIterations: 1,
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.vote).toEqual(makeRejectedVote('Insufficient evidence'));
+    expect(result.deliverables).toHaveLength(1); // From synthesis.deliverables
+    expect(stages.scaffold).not.toHaveBeenCalled();
+  });
+
+  it('iterates synthesize→vote when rejected with feedback', async () => {
+    const voteMock = vi.mocked(stages.vote);
+    voteMock.mockResolvedValueOnce(makeRejectedVote('Need more CVE data'));
+    voteMock.mockResolvedValueOnce(makeApprovedVote());
+
+    const result = await runResearchPipeline('Investigate Ventoy', stages, {
+      maxVoteIterations: 3,
+    });
+
+    expect(result.voteIterations).toBe(2);
+    expect(result.vote).toEqual(makeApprovedVote());
+    expect(stages.synthesize).toHaveBeenCalledTimes(2);
+    // Second call should include feedback
+    expect(vi.mocked(stages.synthesize).mock.calls[1]?.[2]).toBe('Need more CVE data');
+  });
+
+  it('respects maxVoteIterations limit', async () => {
+    vi.mocked(stages.vote).mockResolvedValue(makeRejectedVote('Always reject'));
+
+    const result = await runResearchPipeline('Investigate Ventoy', stages, {
+      maxVoteIterations: 2,
+    });
+
+    expect(result.voteIterations).toBe(2);
+    expect(stages.synthesize).toHaveBeenCalledTimes(2);
+    expect(stages.vote).toHaveBeenCalledTimes(2);
+    expect(stages.scaffold).not.toHaveBeenCalled();
+  });
+
+  it('stops after vote in dryRun mode', async () => {
+    const result = await runResearchPipeline('Investigate Ventoy', stages, {
+      dryRun: true,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.tracks).toHaveLength(2);
+    expect(result.findings).toHaveLength(2);
+    expect(result.vote).toEqual(makeApprovedVote());
+    expect(result.deliverables).toHaveLength(0);
+    expect(stages.scaffold).not.toHaveBeenCalled();
+  });
+
+  it('handles conditional_go vote', async () => {
+    vi.mocked(stages.vote).mockResolvedValue(makeConditionalVote());
+
+    const result = await runResearchPipeline('Investigate Ventoy', stages);
+
+    expect(result.completed).toBe(true);
+    expect(result.vote?.kind).toBe('conditional_go');
+    expect(stages.scaffold).toHaveBeenCalledOnce();
+  });
+
+  it('respects maxParallelTracks for wave execution', async () => {
+    // 4 tracks, maxParallel=2 → 2 waves
+    vi.mocked(stages.decompose).mockResolvedValue([
+      makeTrack('a', 'A'),
+      makeTrack('b', 'B'),
+      makeTrack('c', 'C'),
+      makeTrack('d', 'D'),
+    ]);
+
+    const callOrder: string[] = [];
+    vi.mocked(stages.investigate).mockImplementation((track) => {
+      callOrder.push(track.id);
+      return Promise.resolve(makeFinding(track.id));
+    });
+
+    const result = await runResearchPipeline('Test', stages, {
+      maxParallelTracks: 2,
+    });
+
+    expect(result.findings).toHaveLength(4);
+    // All 4 tracks investigated
+    expect(callOrder).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('returns empty tracks for empty decompose result', async () => {
+    vi.mocked(stages.decompose).mockResolvedValue([]);
+
+    const result = await runResearchPipeline('Empty prompt', stages);
+
+    expect(result.tracks).toHaveLength(0);
+    expect(result.findings).toHaveLength(0);
+    expect(stages.investigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/pipeline/research-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/research-pipeline.ts
@@ -1,0 +1,365 @@
+/**
+ * Research-to-Project Pipeline (#1711)
+ *
+ * Orchestrates external research and greenfield project feasibility studies:
+ *
+ *   1. DECOMPOSE — break prompt into bounded research tracks
+ *   2. INVESTIGATE — parallel research agents per track
+ *   3. SYNTHESIZE — merge findings, identify contradictions
+ *   4. VOTE — go/no-go/conditional consensus decision
+ *   5. SCAFFOLD — (if go) generate deliverables and project skeleton
+ *
+ * Unlike dev-pipeline (self-improvement), this pipeline produces
+ * external-facing research deliverables and project scaffolds.
+ *
+ * @module pipeline/research-pipeline
+ */
+
+import { createLogger } from '../core/index.js';
+import {
+  saveStageCheckpoint,
+  loadCheckpointState,
+  cleanupCheckpoint,
+} from './pipeline-checkpoint.js';
+import type { PipelineCheckpointState } from './pipeline-checkpoint.js';
+import type { VoteResult } from './dev-pipeline.js';
+import { isApproved, getVoteFeedback } from './dev-pipeline.js';
+
+const logger = createLogger({ component: 'research-pipeline' });
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** A bounded research track extracted from the user's prompt. */
+export interface ResearchTrack {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly methodology: string;
+  readonly outputBudget: number;
+  readonly sources: readonly string[];
+}
+
+/** Result of investigating a single research track. */
+export interface TrackFinding {
+  readonly trackId: string;
+  readonly summary: string;
+  readonly evidence: readonly EvidenceItem[];
+  readonly confidence: 'high' | 'medium' | 'low';
+  readonly gaps: readonly string[];
+}
+
+/** A single piece of evidence cited in findings. */
+export interface EvidenceItem {
+  readonly source: string;
+  readonly claim: string;
+  readonly tier: 'primary' | 'secondary' | 'tertiary';
+}
+
+/** Synthesized research output across all tracks. */
+export interface ResearchSynthesis {
+  readonly findings: readonly TrackFinding[];
+  readonly contradictions: readonly string[];
+  readonly recommendation: string;
+  readonly deliverables: readonly ResearchDeliverable[];
+}
+
+/** A structured deliverable produced by the pipeline. */
+export interface ResearchDeliverable {
+  readonly type:
+    | 'executive_memo'
+    | 'security_report'
+    | 'mvp_scope'
+    | 'architecture_rec'
+    | 'risk_register';
+  readonly title: string;
+  readonly content: string;
+}
+
+/** Overall pipeline result. */
+export interface ResearchPipelineResult {
+  readonly completed: boolean;
+  readonly tracks: readonly ResearchTrack[];
+  readonly findings: readonly TrackFinding[];
+  readonly synthesis: ResearchSynthesis | null;
+  readonly vote: VoteResult | null;
+  readonly deliverables: readonly ResearchDeliverable[];
+  readonly voteIterations: number;
+}
+
+// ============================================================================
+// Pipeline Stage Interfaces
+// ============================================================================
+
+/** Pluggable stage implementations — inject real or mock agents. */
+export interface ResearchPipelineStages {
+  /** Decompose prompt into bounded research tracks. */
+  decompose(prompt: string): Promise<ResearchTrack[]>;
+  /** Investigate a single research track. */
+  investigate(track: ResearchTrack): Promise<TrackFinding>;
+  /** Synthesize findings across all tracks. */
+  synthesize(
+    prompt: string,
+    findings: readonly TrackFinding[],
+    priorFeedback?: string
+  ): Promise<ResearchSynthesis>;
+  /** Consensus vote on whether to proceed. */
+  vote(synthesis: ResearchSynthesis): Promise<VoteResult>;
+  /** Generate project scaffold if go decision. */
+  scaffold(synthesis: ResearchSynthesis): Promise<ResearchDeliverable[]>;
+}
+
+// ============================================================================
+// Options
+// ============================================================================
+
+/** Options for research pipeline execution. */
+export interface ResearchPipelineOptions {
+  /** Session ID for checkpoint/resume. Omit for no persistence. */
+  readonly sessionId?: string | undefined;
+  /** When true, stop after vote and return partial result. */
+  readonly dryRun?: boolean | undefined;
+  /** Max vote→synthesize iterations (default: 3). */
+  readonly maxVoteIterations?: number | undefined;
+  /** Max parallel investigation tracks (default: 4). */
+  readonly maxParallelTracks?: number | undefined;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_VOTE_ITERATIONS = 3;
+const DEFAULT_MAX_PARALLEL_TRACKS = 4;
+
+// ============================================================================
+// Pipeline Execution
+// ============================================================================
+
+/**
+ * Execute the research-to-project pipeline.
+ *
+ * When `sessionId` is provided, each stage checkpoints to disk. On crash,
+ * re-running with the same sessionId resumes from the last completed stage.
+ */
+export async function runResearchPipeline(
+  prompt: string,
+  stages: ResearchPipelineStages,
+  options?: ResearchPipelineOptions
+): Promise<ResearchPipelineResult> {
+  const sid = options?.sessionId;
+  const maxVoteIter = options?.maxVoteIterations ?? DEFAULT_MAX_VOTE_ITERATIONS;
+  const maxParallel = options?.maxParallelTracks ?? DEFAULT_MAX_PARALLEL_TRACKS;
+  const prior = sid !== undefined ? loadCheckpointState(sid) : null;
+
+  // Phase 1: Decompose
+  const tracks = await runOrResumeDecompose(prior, prompt, stages, sid);
+
+  // Phase 2: Investigate (parallel, bounded concurrency)
+  const findings = await runOrResumeInvestigate(prior, tracks, stages, sid, maxParallel);
+
+  // Phase 3-4: Synthesize + Vote loop
+  const { synthesis, vote, iterations } = await runSynthesizeVoteLoop(
+    prompt,
+    findings,
+    stages,
+    sid,
+    maxVoteIter
+  );
+
+  // Dry run: stop after vote
+  if (options?.dryRun === true) {
+    logger.info('Dry run — stopping after vote');
+    return buildResult({
+      completed: false,
+      tracks,
+      findings,
+      synthesis,
+      vote,
+      deliverables: [],
+      voteIterations: iterations,
+    });
+  }
+
+  // Phase 5: Scaffold (only if approved)
+  const deliverables = await runScaffold(synthesis, vote, stages, sid);
+
+  if (sid !== undefined) cleanupCheckpoint(sid);
+
+  return buildResult({
+    completed: true,
+    tracks,
+    findings,
+    synthesis,
+    vote,
+    deliverables,
+    voteIterations: iterations,
+  });
+}
+
+// ============================================================================
+// Phase Helpers
+// ============================================================================
+
+/** Decompose prompt into tracks, or resume from checkpoint. */
+async function runOrResumeDecompose(
+  prior: PipelineCheckpointState | null,
+  prompt: string,
+  stages: ResearchPipelineStages,
+  sid: string | undefined
+): Promise<ResearchTrack[]> {
+  // Resume: if we already have tasks from a prior decompose, skip
+  if (prior?.tasks !== undefined && prior.tasks.length > 0) {
+    logger.info('Resuming from checkpoint — decompose already complete');
+    return prior.tasks.map(taskToTrack);
+  }
+
+  logger.info('Phase 1: Decomposing prompt into research tracks');
+  const tracks = await stages.decompose(prompt);
+  if (sid !== undefined) {
+    saveStageCheckpoint(sid, 'research', { type: 'research', text: JSON.stringify(tracks) });
+  }
+  return tracks;
+}
+
+/** Convert a PipelineTask to a ResearchTrack (for checkpoint resume). */
+function taskToTrack(task: { id: string; title: string; description: string }): ResearchTrack {
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    methodology: 'Resumed from checkpoint',
+    outputBudget: 2000,
+    sources: [],
+  };
+}
+
+/** Investigate tracks in parallel with bounded concurrency. */
+async function runOrResumeInvestigate(
+  prior: PipelineCheckpointState | null,
+  tracks: readonly ResearchTrack[],
+  stages: ResearchPipelineStages,
+  sid: string | undefined,
+  maxParallel: number
+): Promise<TrackFinding[]> {
+  // Resume: if plan text contains findings JSON
+  if (prior?.plan !== undefined) {
+    try {
+      return JSON.parse(prior.plan) as TrackFinding[];
+    } catch {
+      // Fall through to re-investigate
+    }
+  }
+
+  logger.info('Phase 2: Investigating tracks', { count: tracks.length, maxParallel });
+  const findings: TrackFinding[] = [];
+
+  // Process in waves of maxParallel
+  for (let i = 0; i < tracks.length; i += maxParallel) {
+    const wave = tracks.slice(i, i + maxParallel);
+    const results = await Promise.all(wave.map((track) => stages.investigate(track)));
+    findings.push(...results);
+  }
+
+  if (sid !== undefined) {
+    saveStageCheckpoint(sid, 'plan', {
+      type: 'plan',
+      text: JSON.stringify(findings),
+      iterations: 0,
+    });
+  }
+  return findings;
+}
+
+/** Synthesize + Vote loop with feedback iteration. */
+async function runSynthesizeVoteLoop(
+  prompt: string,
+  findings: readonly TrackFinding[],
+  stages: ResearchPipelineStages,
+  sid: string | undefined,
+  maxIterations: number
+): Promise<{ synthesis: ResearchSynthesis; vote: VoteResult; iterations: number }> {
+  let feedback: string | undefined;
+  let synthesis: ResearchSynthesis | undefined;
+  let vote: VoteResult | undefined;
+
+  for (let i = 0; i < maxIterations; i++) {
+    logger.info('Phase 3: Synthesizing findings', { iteration: i + 1, maxIterations });
+    synthesis = await stages.synthesize(prompt, findings, feedback);
+
+    logger.info('Phase 4: Voting on synthesis');
+    vote = await stages.vote(synthesis);
+
+    if (sid !== undefined) {
+      saveStageCheckpoint(sid, 'vote', {
+        type: 'vote',
+        approved: isApproved(vote),
+        conditional: vote.kind === 'conditional_go',
+        iterations: i + 1,
+      });
+    }
+
+    if (isApproved(vote)) {
+      return { synthesis, vote, iterations: i + 1 };
+    }
+
+    feedback = getVoteFeedback(vote);
+    logger.info('Vote rejected, iterating', { iteration: i + 1, feedback });
+  }
+
+  // Exhausted iterations — return last state
+  return {
+    synthesis: synthesis as ResearchSynthesis,
+    vote: vote as VoteResult,
+    iterations: maxIterations,
+  };
+}
+
+/** Generate scaffold deliverables if vote approved. */
+async function runScaffold(
+  synthesis: ResearchSynthesis,
+  vote: VoteResult,
+  stages: ResearchPipelineStages,
+  sid: string | undefined
+): Promise<ResearchDeliverable[]> {
+  if (!isApproved(vote)) {
+    logger.info('Vote not approved — skipping scaffold');
+    return synthesis.deliverables.slice();
+  }
+
+  logger.info('Phase 5: Scaffolding project');
+  const deliverables = await stages.scaffold(synthesis);
+
+  if (sid !== undefined) {
+    saveStageCheckpoint(sid, 'implement', {
+      type: 'implement',
+      tasks: deliverables.map((d, i) => ({
+        id: `deliverable-${String(i)}`,
+        title: d.title,
+        description: d.type,
+        assignedTo: 'researcher' as const,
+        status: 'done' as const,
+      })),
+    });
+  }
+  return deliverables;
+}
+
+// ============================================================================
+// Result Builder
+// ============================================================================
+
+interface BuildResultInput {
+  readonly completed: boolean;
+  readonly tracks: readonly ResearchTrack[];
+  readonly findings: readonly TrackFinding[];
+  readonly synthesis: ResearchSynthesis | null;
+  readonly vote: VoteResult | null;
+  readonly deliverables: readonly ResearchDeliverable[];
+  readonly voteIterations: number;
+}
+
+function buildResult(input: BuildResultInput): ResearchPipelineResult {
+  return input;
+}


### PR DESCRIPTION
## Summary

- Add `run_research_pipeline` MCP tool — mirrors dev-pipeline but designed for external research, feasibility studies, and greenfield project evaluation (not self-improvement loops)
- Pipeline stages: **Decompose → Investigate (parallel) → Synthesize → Vote → Scaffold**
- LLM-assisted prompt decomposition with heuristic fallback when adapters unavailable
- Parallel track investigation with configurable wave size (`maxParallelTracks`)
- Synthesize→Vote feedback loop with iteration limit and `conditional_go` support
- 5 deliverable types: executive memo, security report, MVP scope, architecture recommendation, risk register
- Checkpoint/resume via existing pipeline-checkpoint infrastructure

### New files
| File | Lines | Purpose |
|------|-------|---------|
| `src/pipeline/research-pipeline.ts` | ~350 | Runner + types (5 stages) |
| `src/pipeline/research-agent-executor.ts` | ~275 | Agent wiring + LLM decomposition |
| `src/mcp/tools/research-pipeline-tool.ts` | ~120 | MCP tool registration |
| `src/pipeline/research-pipeline.test.ts` | ~190 | 8 tests |

## Test plan

- [x] 8 unit tests covering all stages, iteration, dryRun, conditional_go, wave execution
- [x] MCP tool index test updated (30 tools)
- [x] CLI server tools test passes with new mock
- [x] Export contract tests pass (168 total)
- [x] ESLint clean on all new files
- [x] `pnpm build` succeeds (nexus-agents package)
- [ ] Integration test with real adapters (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)