### PR TITLE
fix(ci): make CLI review check informational instead of failing (#1742)

### DIFF
--- a/.github/workflows/verify-review.yml
+++ b/.github/workflows/verify-review.yml
@@ -42,16 +42,14 @@ jobs:
             const hasLabel = pr.labels.some(label => label.name === 'cli-reviewed');
 
             if (!hasLabel) {
-              core.setFailed(`
-              ❌ PR requires CLI review before merge.
-
-              To review this PR:
-              1. Run: pnpm review ${context.payload.pull_request.number}
-              2. Or manually add the 'cli-reviewed' label after review
-
-              Available CLI tools: claude, gemini, codex
-              See: docs/proposals/cli-pr-review-workflow.md
-              `);
+              // Informational — warn instead of failing CI (#1742).
+              // Use branch protection "require labels" for enforcement.
+              core.warning([
+                'PR has not been CLI-reviewed yet.',
+                `To review: pnpm review ${context.payload.pull_request.number}`,
+                "Or manually add the 'cli-reviewed' label after review.",
+                'Available CLI tools: claude, gemini, codex',
+              ].join('\n'));
             } else {
               console.log('✅ PR has been reviewed with CLI tools');
             }


### PR DESCRIPTION
## Summary

- Change `core.setFailed()` to `core.warning()` in the "Check CLI Review" workflow
- PRs without the `cli-reviewed` label now show a warning annotation instead of failing CI
- Branch protection "require labels" can enforce the label if hard enforcement is desired

This check was failing on every PR, creating CI noise. The review reminder is still visible as a warning.

Fixes #1742

## Test plan

- [x] Workflow syntax valid (YAML lint)
- [ ] This PR itself should show "Check CLI Review" as **pass** with a warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)