### PR TITLE
fix: move ts-morph to dependencies and fix macOS test env leak

### DIFF
--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -75,6 +75,7 @@
     "openai": "^6.33.0",
     "semver": "^7.7.4",
     "tiktoken": "^1.0.22",
+    "ts-morph": "^27.0.2",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
@@ -86,7 +87,6 @@
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "4.1.2",
     "ai": "^6.0.141",
-    "ts-morph": "^27.0.2",
     "tsup": "^8.5.1",
     "typedoc": "0.28.18",
     "vitest": "4.1.2"

--- a/packages/nexus-agents/src/scm/github-provider-traits.test.ts
+++ b/packages/nexus-agents/src/scm/github-provider-traits.test.ts
@@ -66,7 +66,11 @@ describe('GitHubReviewer', () => {
     reviewer = new GitHubReviewer(provider);
     mockExecFile.mockReset();
     resetGhTokenCache();
-    // Set GH_TOKEN so resolveGhToken doesn't spawn `gh auth token`
+    // Ensure resolveGhToken finds a token from env and doesn't spawn `gh auth token`
+    // (which would consume a mockResolvedValueOnce meant for the API call).
+    // GITHUB_TOKEN is checked first by resolveGhTokenImpl, so delete it to avoid
+    // an empty-string value (e.g. from CI) bypassing GH_TOKEN.
+    delete process.env['GITHUB_TOKEN'];
     process.env['GH_TOKEN'] = 'test-token';
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       tiktoken:
         specifier: ^1.0.22
         version: 1.0.22
+      ts-morph:
+        specifier: ^27.0.2
+        version: 27.0.2
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -170,9 +173,6 @@ importers:
       ai:
         specifier: ^6.0.141
         version: 6.0.141(zod@4.3.6)
-      ts-morph:
-        specifier: ^27.0.2
-        version: 27.0.2
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- **ts-morph dependency**: Moved from `devDependencies` to `dependencies` — it's imported at runtime by 9 source files (indexer modules, ast-fixer) and was missing when the package was installed on macOS
- **macOS test fix**: `getPullRequestDetail` test failed because `GITHUB_TOKEN` (checked first by `resolveGhTokenImpl`) could be set to an empty string by the CI runner, bypassing `GH_TOKEN` and falling through to `gh auth token` subprocess — which consumed the first `mockResolvedValueOnce` meant for the API call. Fix: explicitly `delete process.env['GITHUB_TOKEN']` in `beforeEach`

## Test plan
- [x] `pnpm vitest run src/scm/github-provider-traits.test.ts` — 11/11 tests pass
- [x] `pnpm --filter nexus-agents build` — ESM + DTS build passes
- [x] `ts-morph` in `dependencies`, not in `devDependencies`
- [x] Fitness score: 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)