### PR TITLE
fix: create missing schemas.ts and compile-stage for WIP packages (#1729, #1730)

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,0 +1,134 @@
+/**
+ * Zod validation schemas for core domain types.
+ *
+ * Uses Zod v4 API — SafeParseReturnType was removed in v4,
+ * replaced by the inferred return type of schema.safeParse().
+ *
+ * (Source: Issue #1729)
+ */
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Paper Schema (matches PaperSearchResult port)
+// ---------------------------------------------------------------------------
+export const PaperSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  abstract: z.string(),
+  authors: z.array(z.string()),
+  publishedAt: z.string(),
+  url: z.string(),
+  citations: z.number().optional(),
+});
+
+export type Paper = z.infer<typeof PaperSchema>;
+
+// ---------------------------------------------------------------------------
+// Author Schema (matches AuthorArtifact port)
+// ---------------------------------------------------------------------------
+export const AuthorSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type Author = z.infer<typeof AuthorSchema>;
+
+// ---------------------------------------------------------------------------
+// Author Aggregate
+// ---------------------------------------------------------------------------
+export const AuthorAggregateSchema = z.object({
+  name: z.string(),
+  affiliation: z.string().optional(),
+  paperIds: z.array(z.string()),
+  paperCount: z.number(),
+});
+
+export type AuthorAggregate = z.infer<typeof AuthorAggregateSchema>;
+
+// ---------------------------------------------------------------------------
+// Enrichment Candidate
+// ---------------------------------------------------------------------------
+export const EnrichmentCandidateSchema = z.object({
+  name: z.string(),
+  affiliation: z.string().optional(),
+  paperIds: z.array(z.string()),
+});
+
+export type EnrichmentCandidate = z.infer<typeof EnrichmentCandidateSchema>;
+
+// ---------------------------------------------------------------------------
+// Enriched Author
+// ---------------------------------------------------------------------------
+export const EnrichedAuthorSchema = z.object({
+  originalName: z.string(),
+  affiliation: z.string().optional(),
+  paperIds: z.array(z.string()),
+  confidenceScore: z.number(),
+  evidence: z.array(z.unknown()),
+  resolvedIdentity: z
+    .object({
+      name: z.string(),
+      affiliation: z.string().optional(),
+      email: z.string().optional(),
+      bio: z.string().optional(),
+      location: z.string().optional(),
+      profiles: z.record(z.string(), z.string()),
+    })
+    .optional(),
+  searchedAt: z.string(),
+});
+
+export type EnrichedAuthor = z.infer<typeof EnrichedAuthorSchema>;
+
+// ---------------------------------------------------------------------------
+// Stage Checkpoint (matches CheckpointData port)
+// ---------------------------------------------------------------------------
+export const StageCheckpointSchema = z.object({
+  cursor: z.string(),
+  timestamp: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type StageCheckpoint = z.infer<typeof StageCheckpointSchema>;
+
+// ---------------------------------------------------------------------------
+// Safe-parse wrappers
+// Uses Zod v4 inferred return type (not z.SafeParseReturnType which was removed)
+// ---------------------------------------------------------------------------
+type SafeParseResult<T extends z.ZodType> = ReturnType<T['safeParse']>;
+
+export function safeParsePaper(data: unknown): SafeParseResult<typeof PaperSchema> {
+  return PaperSchema.safeParse(data);
+}
+
+export function safeParseAuthor(data: unknown): SafeParseResult<typeof AuthorSchema> {
+  return AuthorSchema.safeParse(data);
+}
+
+export function safeParseAuthorAggregate(
+  data: unknown
+): SafeParseResult<typeof AuthorAggregateSchema> {
+  return AuthorAggregateSchema.safeParse(data);
+}
+
+export function safeParseEnrichmentCandidate(
+  data: unknown
+): SafeParseResult<typeof EnrichmentCandidateSchema> {
+  return EnrichmentCandidateSchema.safeParse(data);
+}
+
+export function safeParseEnrichedAuthor(
+  data: unknown
+): SafeParseResult<typeof EnrichedAuthorSchema> {
+  return EnrichedAuthorSchema.safeParse(data);
+}
+
+export function safeParseStageCheckpoint(
+  data: unknown
+): SafeParseResult<typeof StageCheckpointSchema> {
+  return StageCheckpointSchema.safeParse(data);
+}

--- a/packages/pipeline/src/stages/compile-stage.ts
+++ b/packages/pipeline/src/stages/compile-stage.ts
@@ -1,0 +1,102 @@
+/**
+ * Compile stage — transforms enriched data into final compiled output.
+ *
+ * Follows the same Stage interface pattern as SourcingStage/DedupStage/EnrichStage.
+ *
+ * (Source: Issue #1730)
+ */
+import type {
+  Stage,
+  StageName,
+  StageResult,
+  StageContext,
+  Checkpoint,
+  NormalizedPaper,
+} from './types.js';
+import type {
+  EnrichedAuthorSummary,
+  CompiledAuthor,
+  CompileOutput,
+  CompileMetrics,
+} from './types.js';
+
+export class CompileStage implements Stage {
+  readonly name: StageName = 'compile';
+  readonly description = 'Compile enriched data into final output';
+
+  execute(ctx: StageContext): Promise<StageResult> {
+    const prevCheckpoint = ctx.previousCheckpoint;
+
+    if (ctx.dryRun === true) {
+      return Promise.resolve({
+        ok: true as const,
+        stage: this.name,
+        data: { compiledAuthors: [], metrics: this.emptyMetrics() },
+      });
+    }
+
+    const authors =
+      (prevCheckpoint?.data['enrichedAuthors'] as EnrichedAuthorSummary[] | undefined) ?? [];
+    const papers = (prevCheckpoint?.data['papers'] as NormalizedPaper[] | undefined) ?? [];
+
+    const output = this.compile(authors, papers);
+
+    const checkpoint: Checkpoint = {
+      stage: this.name,
+      completedAt: new Date().toISOString(),
+      data: {
+        compiledAuthors: output.compiledAuthors,
+        metrics: output.metrics,
+      },
+    };
+
+    return Promise.resolve({
+      ok: true as const,
+      stage: this.name,
+      data: output,
+      checkpoint,
+    });
+  }
+
+  private compile(authors: EnrichedAuthorSummary[], papers: NormalizedPaper[]): CompileOutput {
+    const paperMap = new Map<string, NormalizedPaper>();
+    for (const paper of papers) {
+      paperMap.set(paper.id, paper);
+    }
+
+    const compiledAuthors: CompiledAuthor[] = authors.map((author) => {
+      const authorPapers = author.paperIds
+        .map((id) => paperMap.get(id))
+        .filter((p): p is NormalizedPaper => p !== undefined)
+        .map((p) => ({
+          id: p.id,
+          title: p.title,
+          url: p.url,
+          publishedAt: p.publishedAt,
+        }));
+
+      return {
+        name: author.originalName,
+        affiliation: author.affiliation,
+        paperCount: authorPapers.length,
+        papers: authorPapers,
+        confidenceScore: author.confidenceScore,
+        resolvedProfiles: author.resolvedIdentity?.profiles ?? {},
+        compiledAt: new Date().toISOString(),
+      };
+    });
+
+    return {
+      compiledAuthors,
+      metrics: {
+        authorsCompiled: compiledAuthors.length,
+        papersCompiled: papers.length,
+        outputFiles: 1,
+      },
+    };
+  }
+
+  private emptyMetrics(): CompileMetrics {
+    return { authorsCompiled: 0, papersCompiled: 0, outputFiles: 0 };
+  }
+}

--- a/packages/pipeline/src/stages/types.ts
+++ b/packages/pipeline/src/stages/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Stage-specific type definitions.
+ *
+ * Re-exports shared types and defines stage-level interfaces.
+ *
+ * (Source: Issue #1730)
+ */
+export type {
+  Stage,
+  StageName,
+  StageResult,
+  StageContext,
+  Checkpoint,
+  NormalizedPaper,
+} from '../types.js';
+
+export interface CompileInput {
+  papers: import('../types.js').NormalizedPaper[];
+  enrichedAuthors: EnrichedAuthorSummary[];
+  outputDir?: string;
+}
+
+export interface EnrichedAuthorSummary {
+  originalName: string;
+  affiliation?: string;
+  paperIds: string[];
+  confidenceScore: number;
+  resolvedIdentity?: {
+    name: string;
+    profiles: Record<string, string>;
+  };
+}
+
+export interface CompiledAuthor {
+  name: string;
+  affiliation?: string | undefined;
+  paperCount: number;
+  papers: { id: string; title: string; url: string; publishedAt: string }[];
+  confidenceScore: number;
+  resolvedProfiles: Record<string, string>;
+  compiledAt: string;
+}
+
+export interface CompileMetrics {
+  authorsCompiled: number;
+  papersCompiled: number;
+  outputFiles: number;
+}
+
+export interface CompileOutput {
+  compiledAuthors: CompiledAuthor[];
+  metrics: CompileMetrics;
+}


### PR DESCRIPTION
## Summary
- **#1729**: Create `packages/core/src/schemas.ts` with 6 Zod schemas and safe-parse wrappers using Zod v4 API (`ReturnType<T['safeParse']>` instead of removed `z.SafeParseReturnType`). Schemas match port interfaces (PaperSearchResult, AuthorArtifact, CheckpointData).
- **#1730**: Create `packages/pipeline/src/stages/compile-stage.ts` (CompileStage implementing Stage interface) and `src/stages/types.ts` (stage-specific type definitions) to satisfy tsup entry points referenced in tsup.config.ts.

Both are private WIP packages. The full monorepo build (`pnpm -r build`) now succeeds for all 3 workspace packages.

## Test plan
- [x] `cd packages/core && pnpm build` — tsc succeeds, no TS2307/TS2694 errors
- [x] `cd packages/pipeline && pnpm build` — tsup ESM + DTS build succeeds
- [x] `pnpm -r build` — all 3 workspace packages build
- [x] `pnpm vitest run src/exports/export-contracts.test.ts` — 63 tests pass (no regression)
- [x] Fitness score: 98/100

Closes #1729
Closes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)