### PR TITLE
docs: update MCP registry assets for marketplace submissions (#1726)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agents",
-  "description": "Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 29 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.",
+  "description": "Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 30 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.",
   "author": {
     "name": "William Zujkowski",
     "email": "williamzujkowski@gmail.com",

--- a/llms-install.md
+++ b/llms-install.md
@@ -56,7 +56,7 @@ export GOOGLE_AI_API_KEY=your-key    # For Gemini adapter
 
 At least one API key is needed for real model routing. Without keys, tools like `consensus_vote` can use `simulateVotes: true` for testing.
 
-## Available Tools (29)
+## Available Tools (30)
 
 Once connected, these MCP tools are available:
 
@@ -70,6 +70,7 @@ Once connected, these MCP tools are available:
 - `weather_report` — CLI performance monitoring and routing health
 - `repo_analyze` / `repo_security_plan` — Repository analysis and security planning
 - `search_codebase` / `extract_symbols` — Code intelligence
+- `run_pipeline` — Configurable multi-stage pipeline execution
 - And 15 more (run `nexus-agents --help` for full list)
 
 ## Troubleshooting

--- a/packages/nexus-agents/server.json
+++ b/packages/nexus-agents/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.williamzujkowski/nexus-agents",
-  "description": "Intelligent orchestration platform for AI coding tools. Routes tasks to the best model (Claude, Codex, Gemini, OpenCode) using data-driven algorithms (LinUCB, TOPSIS), enforces quality through multi-model consensus voting, and learns from outcomes across sessions. 29 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.",
+  "description": "Intelligent orchestration platform for AI coding tools. Routes tasks to the best model (Claude, Codex, Gemini, OpenCode) using data-driven algorithms (LinUCB, TOPSIS), enforces quality through multi-model consensus voting, and learns from outcomes across sessions. 30 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.",
   "repository": {
     "url": "https://github.com/williamzujkowski/nexus-agents",
     "source": "github"
   },
-  "version": "2.28.0",
+  "version": "2.29.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "nexus-agents",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "runtime": "node",
       "runtimeArguments": ["--experimental-vm-modules"],
       "packageArguments": ["--mode=server"],
@@ -76,6 +76,6 @@
     "extract_symbols",
     "query_trace",
     "run_dev_pipeline",
-    "run_research_pipeline"
+    "run_pipeline"
   ]
 }


### PR DESCRIPTION
## Summary
- **server.json**: Bump version 2.28.0 → 2.29.0, fix tool name `run_research_pipeline` → `run_pipeline`, update count to 30 tools
- **plugin.json**: Update tool count 29 → 30
- **llms-install.md**: Update tool count 29 → 30, add `run_pipeline` to listing

These are the code-side changes needed before submitting to MCP registries. The submission checklist in #1726 tracks the external registry submissions (Official MCP Registry, Cline Marketplace, mcp.so, etc.).

## Test plan
- [x] `pnpm --filter nexus-agents build` — passes
- [x] server.json version matches package.json (2.29.0)
- [x] Tool list in server.json matches canonical `tools: [...]` array (30 tools)
- [x] Fitness score: 98/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)