### PR TITLE
fix(routing): add performance floor override for LinUCB selection (#1790)

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -732,7 +732,7 @@ function applyLinUCBFloorOverride(
   linucbCli: CliName,
   topsisRanking: CliName[],
   opts: {
-    perfData?: ReadonlyMap<CliName, PerformanceFloorEntry>;
+    perfData?: ReadonlyMap<CliName, PerformanceFloorEntry> | undefined;
     taskType: string;
     stagesExecuted: string[];
   }

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -727,7 +727,29 @@ async function applyQualityConstraints(
   return ok({ candidates: qualityResult.eligible, qualityResult });
 }
 
+/** Override LinUCB selection if the chosen CLI is below performance floor (#1790). */
+function applyLinUCBFloorOverride(
+  linucbCli: CliName,
+  topsisRanking: CliName[],
+  opts: {
+    perfData?: ReadonlyMap<CliName, PerformanceFloorEntry>;
+    taskType: string;
+    stagesExecuted: string[];
+  }
+): CliName {
+  if (opts.perfData === undefined) return linucbCli;
+  const cliPerf = opts.perfData.get(linucbCli);
+  if (cliPerf === undefined || cliPerf.sampleCount < 20 || cliPerf.successRate >= 0.5) {
+    return linucbCli;
+  }
+  const topsisTop = topsisRanking[0];
+  if (topsisTop === undefined || topsisTop === linucbCli) return linucbCli;
+  opts.stagesExecuted.push('perf-floor-override');
+  return topsisTop;
+}
+
 /** Executes full pipeline and returns result. (Made async in Issue #1350) */
+// eslint-disable-next-line max-lines-per-function -- routing pipeline is a cohesive sequence
 export async function runPipeline(
   task: CliTask,
   taskProfile: TaskProfile,
@@ -764,12 +786,19 @@ export async function runPipeline(
     return err(new CompositeRoutingError('No candidates available', 'selection'));
   }
 
-  const latencyResult = runLatencyStage(candidates, stagesExecuted, deps);
-  const selectedCli = selectWithMemoryInfluence(
+  // Performance floor override: reject LinUCB selection if CLI is below floor (#1790)
+  const effectiveSelection = applyLinUCBFloorOverride(
     linucbResult.selectedCli,
-    scoring.memoryResult,
-    deps
+    topsisResult.ranking,
+    {
+      perfData: topsisOpts.performanceData,
+      taskType: taskProfile.taskType,
+      stagesExecuted,
+    }
   );
+
+  const latencyResult = runLatencyStage(candidates, stagesExecuted, deps);
+  const selectedCli = selectWithMemoryInfluence(effectiveSelection, scoring.memoryResult, deps);
 
   return ok(
     buildPipelineResult({


### PR DESCRIPTION
## Summary

Fixes the architecture task routing failure where claude handled 228/229 architecture tasks at 11.8% success despite gemini being configured as primary.

### Root Cause Analysis
5 contributing factors identified:

1. `CATEGORY_CHAIN_OVERRIDES` (architecture→gemini) is only used by circuit breaker, NOT by the main CompositeRouter pipeline
2. LinUCB bandit accumulated 228 historical claude-architecture outcomes that biased the arm selection
3. `adjustProfileForTask` boosts quality 1.2x for architecture but for ALL CLIs equally
4. `isReasoningTask=1` in bandit context historically rewarded claude
5. Performance floor penalty (-3.0 for <50% success) only applied to TOPSIS, not to the final LinUCB selection

### Fix
`applyLinUCBFloorOverride()` — after LinUCB selects a CLI, checks if it has <50% success rate for this category with >=20 samples. If so, overrides with the TOPSIS top pick (which already has the performance floor penalty applied).

This ensures the performance floor is respected in the final routing decision, not just the intermediate TOPSIS ranking that LinUCB was free to ignore.

### Observability
- Override logged as `perf-floor-override` in stagesExecuted
- Visible in weather report and outcome store for monitoring

## Test plan
- [x] 120 routing + integration tests pass
- [x] `pnpm --filter nexus-agents build` — passes
- [x] Fitness score: 98/100

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)