### PR TITLE
fix(security): prevent path traversal in finding-triage (HIGH)

### DIFF
--- a/packages/nexus-agents/src/security/finding-triage.test.ts
+++ b/packages/nexus-agents/src/security/finding-triage.test.ts
@@ -182,4 +182,53 @@ describe('triageFindings', () => {
 
     expect(result.original).toBe(findings);
   });
+
+  it('refuses to read files outside the current working directory (path traversal guard)', async () => {
+    // A malicious scanner emits a traversal path. Before the fix, triage
+    // would readFileSync('/etc/passwd') and include its contents in the LLM
+    // prompt. After the fix, the prompt falls back to the scanner snippet.
+    const evil = createFinding({
+      file: '../../../../etc/passwd',
+      snippet: '  safe-snippet-only;',
+    });
+    let promptSeen = '';
+    const delegateFn = vi.fn((prompt: string) => {
+      promptSeen = prompt;
+      return Promise.resolve(
+        JSON.stringify({
+          confirmed: false,
+          confidence: 0.9,
+          reasoning: 'traversal-probe',
+          suggestedSeverity: 'info',
+        })
+      );
+    });
+    await triageFinding(evil, delegateFn);
+    // Prompt must contain the scanner snippet, NOT any traversed file content.
+    expect(promptSeen).toContain('safe-snippet-only');
+    expect(promptSeen).not.toContain('root:x:');
+    expect(promptSeen).not.toContain('/etc/passwd\n');
+  });
+
+  it('refuses absolute paths outside cwd (path traversal guard)', async () => {
+    const evil = createFinding({
+      file: '/etc/passwd',
+      snippet: '  scanner-snippet;',
+    });
+    let promptSeen = '';
+    const delegateFn = vi.fn((prompt: string) => {
+      promptSeen = prompt;
+      return Promise.resolve(
+        JSON.stringify({
+          confirmed: false,
+          confidence: 0.9,
+          reasoning: 't',
+          suggestedSeverity: 'info',
+        })
+      );
+    });
+    await triageFinding(evil, delegateFn);
+    expect(promptSeen).toContain('scanner-snippet');
+    expect(promptSeen).not.toContain('root:x:');
+  });
 });

--- a/packages/nexus-agents/src/security/finding-triage.ts
+++ b/packages/nexus-agents/src/security/finding-triage.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
 import { SEVERITY_ORDER } from './sarif-types.js';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 /** Verdict from triage assessment. */
 export const TriageVerdictSchema = z.object({
@@ -37,10 +38,19 @@ export const DEFAULT_CONFIG: TriageConfig = {
 
 /**
  * Read source code around a finding location.
+ * Guards against path traversal: finding.file is scanner-controlled and must
+ * resolve inside the current working directory. Otherwise falls back to the
+ * scanner-provided snippet to avoid arbitrary file reads being exfiltrated
+ * via LLM prompts.
  */
 function readContext(finding: SecurityFinding, contextLines: number): string {
+  const root = resolve(process.cwd());
+  const resolved = resolve(root, finding.file);
+  if (!resolved.startsWith(root + '/') && resolved !== root) {
+    return finding.snippet ?? '';
+  }
   try {
-    const content = readFileSync(finding.file, 'utf-8');
+    const content = readFileSync(resolved, 'utf-8');
     const lines = content.split('\n');
     const start = Math.max(0, finding.startLine - contextLines - 1);
     const end = Math.min(lines.length, finding.endLine ?? finding.startLine + contextLines);


### PR DESCRIPTION
## Summary
**Severity: HIGH (CWE-22)** — \`finding-triage.readContext\` passed scanner-controlled \`finding.file\` directly to \`readFileSync\` with no validation. A malicious SARIF file or compromised scanner could cause arbitrary file read, with contents then included in the LLM triage prompt and exfiltrated to the external LLM provider.

## Fix
Resolve \`finding.file\` against \`process.cwd()\` and reject anything outside it, falling back to the scanner-supplied snippet.

## Discovery
Found during adversarial audit of the security pipeline modules as part of pipeline-eval expansion. Logged to \`.security-discoveries.jsonl\` per protocol.

## Test plan
- [x] 2 regression tests (relative \`../../etc/passwd\` and absolute \`/etc/passwd\`) pass
- [x] Existing 9 triage tests still pass (11/11 total)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)