### PR TITLE
fix(security): path traversal in fix-generator (HIGH, follow-up to #1813)

### DIFF
--- a/packages/nexus-agents/src/security/fix-generator.test.ts
+++ b/packages/nexus-agents/src/security/fix-generator.test.ts
@@ -90,6 +90,30 @@ describe('generateFix', () => {
     expect(prompt).toContain('detect-eval');
     expect(prompt).toContain('CWE-94');
   });
+
+  it('refuses relative path traversal via finding.file (cwd guard)', async () => {
+    const delegateFn = vi.fn().mockResolvedValue(VALID_FIX_JSON);
+    await generateFix(
+      makeFinding({ file: '../../../../etc/passwd' }),
+      makeVerdict({ confirmed: true }),
+      delegateFn
+    );
+    const prompt = delegateFn.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('(source unavailable)');
+    expect(prompt).not.toContain('root:x:');
+  });
+
+  it('refuses absolute path traversal via finding.file (cwd guard)', async () => {
+    const delegateFn = vi.fn().mockResolvedValue(VALID_FIX_JSON);
+    await generateFix(
+      makeFinding({ file: '/etc/passwd' }),
+      makeVerdict({ confirmed: true }),
+      delegateFn
+    );
+    const prompt = delegateFn.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('(source unavailable)');
+    expect(prompt).not.toContain('root:x:');
+  });
 });
 
 describe('generateFixBatch', () => {

--- a/packages/nexus-agents/src/security/fix-generator.ts
+++ b/packages/nexus-agents/src/security/fix-generator.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
 import type { TriageVerdict } from './finding-triage.js';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 // ============================================================================
 // Types
@@ -50,10 +51,18 @@ export const DEFAULT_FIX_CONFIG: FixGeneratorConfig = {
 
 /**
  * Read source context around a finding location.
+ * Guards against path traversal: scanner-controlled file must resolve inside
+ * the current working directory. Otherwise returns '(source unavailable)' to
+ * avoid exfiltrating arbitrary files via the LLM prompt.
  */
 function readSourceContext(file: string, startLine: number, contextLines: number): string {
+  const root = resolve(process.cwd());
+  const resolved = resolve(root, file);
+  if (!resolved.startsWith(root + '/') && resolved !== root) {
+    return '(source unavailable)';
+  }
   try {
-    const content = readFileSync(file, 'utf-8');
+    const content = readFileSync(resolved, 'utf-8');
     const lines = content.split('\n');
     const start = Math.max(0, startLine - contextLines - 1);
     const end = Math.min(lines.length, startLine + contextLines);


### PR DESCRIPTION
## Summary
**Severity: HIGH (CWE-22)** — same path-traversal pattern as #1813 in \`fix-generator.readSourceContext\`. Scanner-controlled \`finding.file\` was passed to \`readFileSync\` with no validation; file contents were then embedded in the LLM fix-generation prompt and sent to the external provider.

## Fix
Resolve path against \`process.cwd()\` and return \`'(source unavailable)'\` when it escapes the workspace root.

## Follow-up
A shared path-guard helper should be extracted to prevent further drift — noted in commit.

## Test plan
- [x] 2 regression tests (relative + absolute traversal) pass
- [x] All 11 fix-generator tests pass
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)