### PR TITLE
refactor(security): extract shared path-guard helper (follow-up to #1813/#1814)

### DIFF
--- a/packages/nexus-agents/src/security/finding-triage.ts
+++ b/packages/nexus-agents/src/security/finding-triage.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
 import { SEVERITY_ORDER } from './sarif-types.js';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolveInsideRoot } from './safe-path.js';
 
 /** Verdict from triage assessment. */
 export const TriageVerdictSchema = z.object({
@@ -44,11 +44,8 @@ export const DEFAULT_CONFIG: TriageConfig = {
  * via LLM prompts.
  */
 function readContext(finding: SecurityFinding, contextLines: number): string {
-  const root = resolve(process.cwd());
-  const resolved = resolve(root, finding.file);
-  if (!resolved.startsWith(root + '/') && resolved !== root) {
-    return finding.snippet ?? '';
-  }
+  const resolved = resolveInsideRoot(finding.file);
+  if (resolved === null) return finding.snippet ?? '';
   try {
     const content = readFileSync(resolved, 'utf-8');
     const lines = content.split('\n');

--- a/packages/nexus-agents/src/security/fix-generator.ts
+++ b/packages/nexus-agents/src/security/fix-generator.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
 import type { TriageVerdict } from './finding-triage.js';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolveInsideRoot } from './safe-path.js';
 
 // ============================================================================
 // Types
@@ -56,11 +56,8 @@ export const DEFAULT_FIX_CONFIG: FixGeneratorConfig = {
  * avoid exfiltrating arbitrary files via the LLM prompt.
  */
 function readSourceContext(file: string, startLine: number, contextLines: number): string {
-  const root = resolve(process.cwd());
-  const resolved = resolve(root, file);
-  if (!resolved.startsWith(root + '/') && resolved !== root) {
-    return '(source unavailable)';
-  }
+  const resolved = resolveInsideRoot(file);
+  if (resolved === null) return '(source unavailable)';
   try {
     const content = readFileSync(resolved, 'utf-8');
     const lines = content.split('\n');

--- a/packages/nexus-agents/src/security/safe-path.test.ts
+++ b/packages/nexus-agents/src/security/safe-path.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for safe-path helpers (#1813, #1814).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveInsideRoot } from './safe-path.js';
+import { resolve } from 'node:path';
+
+describe('resolveInsideRoot', () => {
+  const root = resolve(process.cwd());
+
+  it('accepts simple relative paths inside root', () => {
+    expect(resolveInsideRoot('src/app.ts')).toBe(resolve(root, 'src/app.ts'));
+  });
+
+  it('accepts the root itself', () => {
+    expect(resolveInsideRoot('.')).toBe(root);
+  });
+
+  it('rejects relative traversal (../../etc/passwd)', () => {
+    expect(resolveInsideRoot('../../../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects absolute paths outside root', () => {
+    expect(resolveInsideRoot('/etc/passwd')).toBeNull();
+  });
+
+  it('rejects paths that look inside but escape', () => {
+    expect(resolveInsideRoot('src/../../../etc/passwd')).toBeNull();
+  });
+
+  it('accepts nested paths', () => {
+    expect(resolveInsideRoot('src/foo/bar/baz.ts')).toBe(resolve(root, 'src/foo/bar/baz.ts'));
+  });
+
+  it('rejects sibling-root prefix attack (/rootsibling)', () => {
+    // If root is /foo, /foobar should not be accepted just because it starts with /foo.
+    const tmpRoot = '/tmp/a';
+    expect(resolveInsideRoot('/tmp/abc/x', tmpRoot)).toBeNull();
+  });
+
+  it('accepts absolute path inside explicit root', () => {
+    const tmpRoot = '/tmp/a';
+    expect(resolveInsideRoot('/tmp/a/x', tmpRoot)).toBe('/tmp/a/x');
+  });
+});

--- a/packages/nexus-agents/src/security/safe-path.ts
+++ b/packages/nexus-agents/src/security/safe-path.ts
@@ -1,0 +1,33 @@
+/**
+ * Safe Path — Path traversal guards for scanner-controlled inputs (#1813, #1814)
+ *
+ * When reading files whose path comes from untrusted input (e.g., SARIF
+ * scanner output), we must verify the resolved path stays within the
+ * workspace root. Without this, a malicious scanner can cause arbitrary
+ * file reads whose contents are exfiltrated via downstream LLM prompts
+ * (CWE-22).
+ *
+ * Shared helper to prevent the finding-triage/fix-generator drift that
+ * required two separate fixes.
+ *
+ * @module security/safe-path
+ */
+
+import { resolve } from 'node:path';
+
+/**
+ * Resolve a scanner-supplied path against the workspace root, returning null
+ * if it escapes. Null means the caller must fall back to a safe alternative
+ * (e.g., scanner-provided snippet) rather than reading the file.
+ *
+ * @param filePath - Scanner-supplied path (may be relative or absolute)
+ * @param root - Workspace root (defaults to process.cwd())
+ * @returns Resolved absolute path if inside root, null otherwise
+ */
+export function resolveInsideRoot(filePath: string, root: string = process.cwd()): string | null {
+  const resolvedRoot = resolve(root);
+  const resolved = resolve(resolvedRoot, filePath);
+  if (resolved === resolvedRoot) return resolved;
+  if (resolved.startsWith(resolvedRoot + '/')) return resolved;
+  return null;
+}


### PR DESCRIPTION
## Summary
The path-traversal guard was duplicated across \`finding-triage.readContext\` and \`fix-generator.readSourceContext\` — the exact pattern that required two separate fixes (#1813, #1814). Extracted to \`resolveInsideRoot\` in \`src/security/safe-path.ts\`.

## Test plan
- [x] 8 new safe-path unit tests (relative, absolute, sibling-prefix, root-equal, nested)
- [x] All 11 finding-triage tests still pass
- [x] All 11 fix-generator tests still pass
- [x] 30/30 tests pass total

🤖 Generated with [Claude Code](https://claude.com/claude-code)