### PR TITLE
fix(security): sibling-prefix bypass in validatePath guards (#1816)

### DIFF
--- a/packages/nexus-agents/src/cli/research-helpers-sources-io.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-io.ts
@@ -75,7 +75,8 @@ function validatePath(
 ): Result<string, SourcesIOError> {
   const resolved = path.resolve(constructedPath);
   const root = path.resolve(allowedRoot);
-  if (!resolved.startsWith(root)) {
+  // Guards against sibling-prefix bypass (#1816): root=/foo must not accept /foobar.
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
     return {
       ok: false,
       error: { code: 'PATH_TRAVERSAL', message: `Path ${resolved} is outside ${root}` },

--- a/packages/nexus-agents/src/config/config-loader.ts
+++ b/packages/nexus-agents/src/config/config-loader.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, sep } from 'node:path';
 import { homedir } from 'node:os';
 import * as yaml from 'yaml';
 import { AppConfigSchema, type AppConfig, defaultConfig } from './schemas.js';
@@ -79,8 +79,10 @@ export interface ConfigLoadOptions {
  * Validates that a path doesn't escape the allowed root.
  */
 function validatePath(userPath: string, root: string): Result<string, ConfigLoadError> {
-  const resolved = resolve(root, userPath);
-  if (!resolved.startsWith(resolve(root))) {
+  const resolvedRoot = resolve(root);
+  const resolved = resolve(resolvedRoot, userPath);
+  // Guards against sibling-prefix bypass (#1816): root=/foo must not accept /foobar.
+  if (!resolved.startsWith(resolvedRoot + sep) && resolved !== resolvedRoot) {
     return err(
       new ConfigLoadError(
         `Config path traversal detected: ${userPath} escapes ${root}`,


### PR DESCRIPTION
Fixes #1816 — 2 of 5 duplicated validatePath implementations used startsWith(root) without trailing separator (CWE-22 sibling-prefix bypass). Found during DRY audit after #1813/#1814/#1815.