### PR TITLE
fix(security): 2 more sibling-prefix bypasses + safe-path sep

### DIFF
--- a/packages/nexus-agents/src/config/product-matrix/index.ts
+++ b/packages/nexus-agents/src/config/product-matrix/index.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import * as yaml from 'yaml';
 
 import { ProductMatrixSchema } from './types.js';
@@ -220,9 +220,10 @@ export const DEFAULT_PRODUCT_MATRIX: ProductMatrix = {
  */
 function validateFilePath(filePath: string): string {
   const resolved = resolve(filePath);
-  const cwd = process.cwd();
-  if (!resolved.startsWith(resolve(cwd))) {
-    throw new Error(`Path traversal detected: ${filePath} escapes ${cwd}`);
+  const resolvedCwd = resolve(process.cwd());
+  // Guards against sibling-prefix bypass (#1816): cwd=/foo must not accept /foobar.
+  if (!resolved.startsWith(resolvedCwd + sep) && resolved !== resolvedCwd) {
+    throw new Error(`Path traversal detected: ${filePath} escapes ${resolvedCwd}`);
   }
   return resolved;
 }

--- a/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFile, stat } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
@@ -120,10 +120,11 @@ export async function queryTraceFromDisk(
   const dir = runsDir ?? DEFAULT_RUNS_DIR;
   const tracePath = join(dir, input.runId, 'trace.jsonl');
 
-  // Path traversal guard: resolved path must stay within runs directory
+  // Path traversal guard: resolved path must stay within runs directory.
+  // Guards against sibling-prefix bypass (#1816): dir=/foo must not accept /foobar.
   const resolvedDir = resolve(dir);
   const resolvedTrace = resolve(tracePath);
-  if (!resolvedTrace.startsWith(resolvedDir)) {
+  if (!resolvedTrace.startsWith(resolvedDir + sep) && resolvedTrace !== resolvedDir) {
     return { runId: input.runId, ...EMPTY_RESPONSE };
   }
 

--- a/packages/nexus-agents/src/security/safe-path.ts
+++ b/packages/nexus-agents/src/security/safe-path.ts
@@ -13,7 +13,7 @@
  * @module security/safe-path
  */
 
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 
 /**
  * Resolve a scanner-supplied path against the workspace root, returning null
@@ -28,6 +28,6 @@ export function resolveInsideRoot(filePath: string, root: string = process.cwd()
   const resolvedRoot = resolve(root);
   const resolved = resolve(resolvedRoot, filePath);
   if (resolved === resolvedRoot) return resolved;
-  if (resolved.startsWith(resolvedRoot + '/')) return resolved;
+  if (resolved.startsWith(resolvedRoot + sep)) return resolved;
   return null;
 }


### PR DESCRIPTION
Round-2 follow-up to #1817. Grep audit found the same bug pattern in 2 more call sites:
- `config/product-matrix/index.ts:224` validateFilePath
- `mcp/tools/query-trace-tool.ts:126` inline trace-path check

Also fixes `safe-path.ts` to use `path.sep` instead of literal `/` for cross-platform correctness.

593 tests pass; typecheck clean. Logged to `.security-discoveries.jsonl`.