### PR TITLE
refactor(security): consolidate all 5 validatePath sites onto safe-path

### DIFF
--- a/packages/nexus-agents/src/cli/research-helpers-io.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-io.ts
@@ -10,7 +10,8 @@
  */
 
 import * as fs from 'node:fs/promises';
-import { join, resolve, sep } from 'node:path';
+import { join, resolve } from 'node:path';
+import { resolveInsideRoot } from '../security/safe-path.js';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Result } from '../core/index.js';
 import { SecurityError, getErrorMessage } from '../core/index.js';
@@ -55,14 +56,12 @@ export function getProjectRoot(): string {
  * @returns Result with validated absolute path or SecurityError
  */
 function validatePath(constructedPath: string, allowedRoot: string): Result<string, SecurityError> {
-  const resolvedRoot = resolve(allowedRoot);
-  const resolved = resolve(constructedPath);
-
-  if (!resolved.startsWith(resolvedRoot + sep) && resolved !== resolvedRoot) {
+  const resolved = resolveInsideRoot(constructedPath, allowedRoot);
+  if (resolved === null) {
     return {
       ok: false,
       error: new SecurityError('Path traversal detected: path escapes allowed root directory', {
-        context: { constructedPath, allowedRoot: resolvedRoot },
+        context: { constructedPath, allowedRoot: resolve(allowedRoot) },
       }),
     };
   }

--- a/packages/nexus-agents/src/cli/research-helpers-sources-io.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-io.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Result } from '../core/result.js';
 import { REGISTRY_PATH, getProjectRoot } from './research-helpers-io.js';
+import { resolveInsideRoot } from '../security/safe-path.js';
 import { getErrorMessage } from '../core/index.js';
 
 // =============================================================================
@@ -73,13 +74,15 @@ function validatePath(
   constructedPath: string,
   allowedRoot: string
 ): Result<string, SourcesIOError> {
-  const resolved = path.resolve(constructedPath);
-  const root = path.resolve(allowedRoot);
-  // Guards against sibling-prefix bypass (#1816): root=/foo must not accept /foobar.
-  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+  const resolved = resolveInsideRoot(constructedPath, allowedRoot);
+  if (resolved === null) {
+    const root = path.resolve(allowedRoot);
     return {
       ok: false,
-      error: { code: 'PATH_TRAVERSAL', message: `Path ${resolved} is outside ${root}` },
+      error: {
+        code: 'PATH_TRAVERSAL',
+        message: `Path ${path.resolve(constructedPath)} is outside ${root}`,
+      },
     };
   }
   return { ok: true, value: resolved };

--- a/packages/nexus-agents/src/config/config-loader.ts
+++ b/packages/nexus-agents/src/config/config-loader.ts
@@ -9,7 +9,8 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, join, sep } from 'node:path';
+import { resolve, join } from 'node:path';
+import { resolveInsideRoot } from '../security/safe-path.js';
 import { homedir } from 'node:os';
 import * as yaml from 'yaml';
 import { AppConfigSchema, type AppConfig, defaultConfig } from './schemas.js';
@@ -79,10 +80,8 @@ export interface ConfigLoadOptions {
  * Validates that a path doesn't escape the allowed root.
  */
 function validatePath(userPath: string, root: string): Result<string, ConfigLoadError> {
-  const resolvedRoot = resolve(root);
-  const resolved = resolve(resolvedRoot, userPath);
-  // Guards against sibling-prefix bypass (#1816): root=/foo must not accept /foobar.
-  if (!resolved.startsWith(resolvedRoot + sep) && resolved !== resolvedRoot) {
+  const resolved = resolveInsideRoot(userPath, root);
+  if (resolved === null) {
     return err(
       new ConfigLoadError(
         `Config path traversal detected: ${userPath} escapes ${root}`,

--- a/packages/nexus-agents/src/workflows/template-loader.ts
+++ b/packages/nexus-agents/src/workflows/template-loader.ts
@@ -12,6 +12,7 @@ import { dirname } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type { Result } from '../core/index.js';
 import { ParseError, SecurityError } from '../core/index.js';
+import { resolveInsideRoot } from '../security/safe-path.js';
 import type { WorkflowDefinition } from '../core/index.js';
 import {
   WorkflowDefinitionSchema,
@@ -38,14 +39,12 @@ export interface ParsedTemplate {
  * @returns Result with validated absolute path or SecurityError
  */
 function validatePath(userPath: string, allowedRoot: string): Result<string, SecurityError> {
-  const resolvedRoot = resolve(allowedRoot);
-  const resolved = resolve(allowedRoot, userPath);
-
-  if (!resolved.startsWith(resolvedRoot + sep) && resolved !== resolvedRoot) {
+  const resolved = resolveInsideRoot(userPath, allowedRoot);
+  if (resolved === null) {
     return {
       ok: false,
       error: new SecurityError('Path traversal detected: path escapes allowed root directory', {
-        context: { userPath, allowedRoot: resolvedRoot },
+        context: { userPath, allowedRoot: resolve(allowedRoot) },
       }),
     };
   }

--- a/packages/nexus-agents/src/workflows/workflow-parser.ts
+++ b/packages/nexus-agents/src/workflows/workflow-parser.ts
@@ -16,6 +16,7 @@ import {
   type WorkflowDefinitionOutput,
 } from './workflow-types.js';
 import { validateDependencyGraph } from './dependency-graph.js';
+import { resolveInsideRoot } from '../security/safe-path.js';
 
 /**
  * Maximum file size for workflow templates (1MB).
@@ -35,13 +36,11 @@ const SUPPORTED_EXTENSIONS = ['.yaml', '.yml', '.json'] as const;
  * @returns Result with validated absolute path or SecurityError
  */
 function validatePath(userPath: string, allowedRoot: string): Result<string, SecurityError> {
-  const resolvedRoot = path.resolve(allowedRoot);
-  const resolved = path.resolve(allowedRoot, userPath);
-
-  if (!resolved.startsWith(resolvedRoot + path.sep) && resolved !== resolvedRoot) {
+  const resolved = resolveInsideRoot(userPath, allowedRoot);
+  if (resolved === null) {
     return err(
       new SecurityError('Path traversal detected: path escapes allowed root directory', {
-        context: { userPath, allowedRoot: resolvedRoot },
+        context: { userPath, allowedRoot: path.resolve(allowedRoot) },
       })
     );
   }


### PR DESCRIPTION
Completes consolidation from #1815. All five duplicated validatePath implementations delegate to resolveInsideRoot; each wrapper keeps its original error type. Eliminates drift that produced #1813/#1814/#1817/#1818. 2733 tests pass.