### PR TITLE
feat(plugin): add marketplace.json + PLUGIN_INSTALL docs (#1826)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "williamzujkowski",
+  "description": "William Zujkowski's Claude Code plugin marketplace — hosts nexus-agents.",
+  "plugins": [
+    {
+      "name": "nexus-agents",
+      "source": {
+        "type": "github",
+        "owner": "williamzujkowski",
+        "repo": "nexus-agents"
+      },
+      "description": "Intelligent orchestration platform for AI coding tools — 30 MCP tools (orchestrate, consensus voting, research, pipelines), 17 skills, 5 expert agents, governance hooks.",
+      "keywords": ["orchestration", "mcp", "consensus", "pipelines", "multi-agent"]
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,10 +68,11 @@ Detailed technical documentation:
 
 #### Getting Started
 
-| Document                                               | Description                 | Status    |
-| ------------------------------------------------------ | --------------------------- | --------- |
-| [INSTALLATION.md](./getting-started/INSTALLATION.md)   | Platform installation guide | Canonical |
-| [CONFIGURATION.md](./getting-started/CONFIGURATION.md) | YAML and env configuration  | Canonical |
+| Document                                                 | Description                                  | Status    |
+| -------------------------------------------------------- | -------------------------------------------- | --------- |
+| [INSTALLATION.md](./getting-started/INSTALLATION.md)     | Platform installation guide                  | Canonical |
+| [CONFIGURATION.md](./getting-started/CONFIGURATION.md)   | YAML and env configuration                   | Canonical |
+| [PLUGIN_INSTALL.md](./getting-started/PLUGIN_INSTALL.md) | Install nexus-agents as a Claude Code plugin | Canonical |
 
 #### Architecture
 

--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -1,0 +1,70 @@
+# Installing nexus-agents as a Claude Code plugin
+
+**Status:** Canonical
+**Issue:** [#1826](https://github.com/williamzujkowski/nexus-agents/issues/1826)
+
+Nexus-agents ships as a Claude Code plugin. Installing it exposes:
+
+- 30 MCP tools (`orchestrate`, `consensus_vote`, `research_*`, `run_*`, etc.)
+- 17 skills (research-and-vote, implement-feature, bug-fix, …)
+- 5 agent mirrors (security, architecture, code, research, testing experts)
+- 2 governance hooks (fitness-gate, secret-scan)
+
+## Prerequisites
+
+- **Node.js 22.x LTS** — required for the MCP server
+- **Claude Code** (or another agent that reads `.claude-plugin/` directly)
+
+## Install
+
+The marketplace is self-hosted on this repo. Add it once, then install nexus-agents:
+
+```
+/plugin marketplace add williamzujkowski/nexus-agents
+/plugin install nexus-agents@williamzujkowski
+```
+
+Claude Code resolves the marketplace from `.claude-plugin/marketplace.json` at the repo root and pins the source to the current commit SHA. Updates re-resolve the SHA.
+
+## Verify
+
+After install, confirm the 30 MCP tools are reachable:
+
+```
+/mcp
+```
+
+You should see `nexus-agents` listed with tools like `orchestrate`, `consensus_vote`, `run_pipeline`. The 17 skills appear in `/skills`, and the 5 agents in `/agents`.
+
+## What gets installed
+
+| Component          | Path in repo                                | Loaded by                                                                               |
+| ------------------ | ------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Plugin manifest    | `.claude-plugin/plugin.json`                | Claude Code                                                                             |
+| MCP config         | `.mcp.json` (copy from `.mcp.json.example`) | Claude Code (stdio server)                                                              |
+| Skills (canonical) | `skills/<name>/SKILL.md` (17)               | Claude Code autoloads; non-Claude agents discover via `AGENTS.md` → `skills/index.yaml` |
+| Agents             | `agents/*.md` (5)                           | `/agents` UI                                                                            |
+| Hooks              | `hooks/hooks.json` + `*.sh`                 | `PreToolUse` matchers                                                                   |
+
+## Uninstall
+
+```
+/plugin uninstall nexus-agents
+```
+
+Cache at `~/.claude/plugins/` is cleared automatically.
+
+## Troubleshooting
+
+**MCP tools don't appear.** Ensure Node 22+ is on your `PATH` — the server launches via `npx -y nexus-agents --mode=server`. Check the Claude Code logs for `ENOENT` or `EACCES`.
+
+**Hooks don't fire.** Hooks are registered at plugin root via `${CLAUDE_PLUGIN_ROOT}/hooks/*.sh`. Verify the plugin's runtime root is resolvable via `echo $CLAUDE_PLUGIN_ROOT` inside a hook script.
+
+**Skill activation misses.** Claude Code autoloads SKILL.md frontmatter by description. If a trigger isn't firing, make the `description` more explicit (e.g., quote the exact user phrase). Non-Claude agents use `skills/index.yaml` for discovery — see `AGENTS.md`.
+
+## Related
+
+- [AGENTS.md](../../AGENTS.md) — guidance for non-Claude agents
+- [docs/ENTRYPOINTS.md](../ENTRYPOINTS.md) — full CLI/MCP reference
+- [docs/architecture/RESEARCH_PIPELINE.md](../architecture/RESEARCH_PIPELINE.md) — research pipeline component
+- Epic [#1825](https://github.com/williamzujkowski/nexus-agents/issues/1825) — plugin integration


### PR DESCRIPTION
Closes #1826. Finalizes epic #1825 plugin distribution scaffolding.

- `.claude-plugin/marketplace.json` — self-hosted marketplace manifest
- `docs/getting-started/PLUGIN_INSTALL.md` — canonical install guide

Combined with #1828 (skills), #1829 (agents), #1830 (hooks), the existing `.claude-plugin/plugin.json` + `.mcp.json.example`, nexus-agents is now a fully scaffolded Claude Code plugin.

```
/plugin marketplace add williamzujkowski/nexus-agents
/plugin install nexus-agents@williamzujkowski
```