### PR TITLE
chore(release): add changeset for v2.29.1 patch

### DIFF
--- a/.changeset/typescript-runtime-dep.md
+++ b/.changeset/typescript-runtime-dep.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Fix install-time crash by adding `typescript` to runtime dependencies (#1841).
+
+`src/indexer/symbol-extractor.ts` imports `typescript` directly (used by `ts-morph` internals), but the dep was missing from the published 2.29.0 bundle. Anyone running `npm install -g nexus-agents` or `npx -y nexus-agents --mode=server` (the marketplace install path) hit `ERR_MODULE_NOT_FOUND: typescript` on first invocation, blocking all Claude Code plugin installs.
+
+Also adds Docker-based pre-publish smoke testing (`Dockerfile.npm-verify` + `scripts/verify-npm-install.sh` + `.github/workflows/npm-verify.yml`) so the same regression cannot reach npm again. The 6-phase smoke runs on every PR touching `package.json` or `src/`, packs the source tarball, installs it in a clean container, and verifies the binary works + MCP stdio handshake returns 30 tools.


### PR DESCRIPTION
Adds a patch-level changeset describing the #1841 / #1842 typescript runtime-dep fix.

## What this PR does

Just adds `.changeset/typescript-runtime-dep.md`. **No code changes.**

## What happens after this merges

1. Push to main triggers `changesets/action` in `.github/workflows/release.yml`
2. It opens a second PR titled `chore(release): version packages` that:
   - Bumps `packages/nexus-agents/package.json` from 2.29.0 → 2.29.1
   - Updates CHANGELOG.md
   - Deletes `.changeset/typescript-runtime-dep.md`
3. **You merge that version PR** → the same workflow runs `pnpm release` and publishes 2.29.1 to npm with **OIDC-attested provenance** (`id-token: write` + `NPM_CONFIG_PROVENANCE: true` + `NODE_AUTH_TOKEN`).

Two human merges, each with full diff visibility. Nothing publishes without explicit approval.

## Why this matters

Published 2.29.0 is broken — fresh install crashes on `ERR_MODULE_NOT_FOUND: typescript`. This blocks every plugin marketplace install (#1825, #1839). 2.29.1 will be the first working release since 2.29.0 shipped.