### PR TITLE
feat(experts): Reference Implementation sections for 7 remaining experts (#1862)

### DIFF
--- a/packages/nexus-agents/src/agents/experts/expert-prompts/data-visualization-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/data-visualization-expert.ts
@@ -74,6 +74,11 @@ Example response:
 - **Svelte + LayerCake**: Svelte-native chart components with SSR support
 - **CSS-only charts**: Lightweight bar/progress charts that work without JS
 
+## Reference Implementation
+- **Dashboard design doc**: \`docs/architecture/EXECUTION_DASHBOARD_DESIGN.md\` — layering strategy, info hierarchy for observability views.
+- **Expert spec**: \`agents/data-visualization-expert.md\` — chart selection and application patterns for this codebase.
+- When no canonical in-repo viz exists, commit to ONE chart type per problem. Cite the data source explicitly. Never default to a bar chart because it's "safe."
+
 ## Data Analysis Capabilities
 - Identify distributions, outliers, and clusters in numeric data
 - Calculate summary statistics (mean, median, percentiles, IQR)

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/documentation-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/documentation-expert.ts
@@ -67,6 +67,12 @@ Respond with JSON matching this structure:
 - All docs must be indexed in docs/README.md to be valid (canonical index)
 - Use YAML frontmatter (title, description, tier, keywords) for tier 1/2 docs
 
+### Reference Implementation
+- **Canonical index**: \`docs/README.md\` — every new doc MUST be linked here. Unindexed docs are invalid.
+- **Exemplar architectural doc**: \`docs/architecture/SECURITY.md\` — threat model + sandbox + CVE mitigations in one coherent narrative. Use as the template for depth and structure.
+- **Exemplar compliance doc**: \`docs/architecture/UNTRUSTED_INPUT_HARDENING.md\` — trust tiers, invariants, typed actions. Shows how to document policy with enforcement hooks.
+- **Research index**: \`docs/research/RESEARCH_INDEX.md\` — the pattern for a registry-backed doc category.
+
 ### Output Guidance
 - Always include a confidence score (0-1) with reasoning for the score
 - Reference specific files by absolute path when documenting code behavior

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/infrastructure-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/infrastructure-expert.ts
@@ -212,6 +212,12 @@ Respond with JSON matching this structure:
   "confidence": 0.0-1.0
 }
 
+## Reference Implementation
+- **Sandbox + threat model**: \`docs/architecture/SECURITY.md\` — trust boundaries, isolation guarantees, CVE mitigations.
+- **MCP protocol contract**: \`docs/architecture/MCP_PROTOCOL.md\` — transport + capability surface; template for inter-system contracts.
+- **Pipeline architecture**: \`docs/architecture/RESEARCH_PIPELINE.md\` — staged data flow with explicit stage boundaries.
+- Always document the access path (SSH, OOB, console) and the fallback before recommending any infrastructure change.
+
 ## Output Guidance
 - Always include a confidence score (0-1) with reasoning for the score
 - Reference specific hostnames, IPs, or file paths when making recommendations

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/pm-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/pm-expert.ts
@@ -60,6 +60,11 @@ Respond with JSON matching this structure:
 - Stakeholder communication and alignment
 - Technical feasibility assessment
 
+## Reference Implementation
+- **Well-scoped epic template**: issue #1860 (applying audit pattern across experts) — parent with explicit child issues, each addressable independently, success criteria stated. Copy this shape for new epics.
+- **Canonical-paths reference**: \`CLAUDE.md\` Canonical Paths table — when drafting requirements, cite existing canonical modules rather than proposing new ones.
+- **Research synthesis pattern**: \`docs/research/RESEARCH_INDEX.md\` — how this codebase tracks decisions backed by prior research. Use for justification.
+
 ## Output Guidance
 - Always include a confidence score (0-1) with reasoning for the score
 - Reference specific issues, PRs, or file paths when making recommendations

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/research-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/research-expert.ts
@@ -59,6 +59,11 @@ When analyzing research, consider the existing registry:
 - Suggest priority assignments based on system alignment
 - Flag stale or outdated entries for review
 
+## Reference Implementation
+- **Research registry**: \`docs/research/RESEARCH_INDEX.md\` — the canonical index of every paper/technique/repo tracked. Every new finding must be added here.
+- **Pipeline spec**: \`docs/architecture/RESEARCH_PIPELINE.md\` — staged data flow (discover → evaluate → synthesize → align). Use as the template for new research workflows.
+- **Synthesis output exemplar**: \`docs/research/topics/\` (browse for well-synthesized topics) — clusters with themes, insights, and implementation opportunities.
+
 ## Output Guidance
 - Always include a confidence score (0-1) with reasoning for the score
 - Reference arXiv IDs, GitHub URLs, or specific file paths for all findings

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/security-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/security-expert.ts
@@ -107,6 +107,12 @@ When reviewing web-facing code, check for presence and correctness of these head
 
 **Severity guidance:** Missing frame-ancestors/X-Frame-Options → medium. Missing SRI on external scripts → high. unsafe-eval without wasm-unsafe-eval justification → high. No CSP at all on public-facing app → high.
 
+### Reference Implementation
+- **Test-secrets canon**: \`packages/nexus-agents/src/testing/test-secrets.ts\` — FAKE_* constants (obviously fake by construction) that satisfy GitHub secret-scanning without false positives. Import these instead of inventing new fakes.
+- **Threat model + sandbox**: \`docs/architecture/SECURITY.md\` — canonical threat model, sandbox boundaries, CVE mitigations. Cite its sections when making recommendations.
+- **Untrusted-input policy**: \`docs/architecture/UNTRUSTED_INPUT_HARDENING.md\` — trust tiers, Rule of Two, typed actions, corroboration requirements. Use when evaluating new agent/MCP surfaces.
+- **Security rules summary**: \`.claude/rules/security.md\` — quick reference the agent operator sees first.
+
 ### Failure Patterns to Avoid
 - Do not flag test files for containing fake secrets (they use FAKE_* constants by design)
 - Do not report generic OWASP findings without codebase-specific evidence

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/testing-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/testing-expert.ts
@@ -82,6 +82,12 @@ Respond with JSON matching this structure:
 - For broad "add tests" requests, start with untested critical paths rather than attempting exhaustive coverage
 - Prefer completing thorough tests for one module over shallow tests across many modules
 
+### Reference Implementation
+- **Structural template**: \`packages/nexus-agents/src/agents/experts/expert-prompts/prompt-composer.test.ts\` — focused unit tests, clear describe/it nesting, no hidden fixtures.
+- **\`describe.each\` pattern**: \`packages/nexus-agents/src/agents/experts/code-architecture-mode-split.test.ts\` — shared-invariant testing across multiple modes/variants. Use when asserting the same invariant across parameterized subjects.
+- **MCP integration testing**: use \`InMemoryTransport\` from \`@modelcontextprotocol/sdk/inMemory.js\` as shown in \`.claude/rules/testing.md\`. Prefer over mocked transport.
+- **Canonical test-secrets**: import FAKE_* constants from \`packages/nexus-agents/src/testing/test-secrets.ts\` — never invent new fake secrets.
+
 ### Output Guidance
 - Always include a confidence score (0-1) with reasoning for the score
 - Reference specific files by absolute path (file:line format) when reporting coverage gaps

--- a/packages/nexus-agents/src/agents/experts/reference-implementation.test.ts
+++ b/packages/nexus-agents/src/agents/experts/reference-implementation.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for Reference Implementation section presence (Issue #1862).
+ *
+ * Every expert prompt must include a `Reference Implementation` section
+ * citing concrete files / modules / documents in this codebase so the
+ * agent's recommendations are anchored to real prior art, not generic
+ * patterns it might apply to any codebase.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CODE_EXPERT_BASE_PROMPT } from './expert-prompts/code-expert.js';
+import { ARCHITECTURE_EXPERT_BASE_PROMPT } from './expert-prompts/architecture-expert.js';
+import { DATA_VISUALIZATION_EXPERT_BASE_PROMPT } from './expert-prompts/data-visualization-expert.js';
+import { DOCUMENTATION_EXPERT_BASE_PROMPT } from './expert-prompts/documentation-expert.js';
+import { INFRASTRUCTURE_EXPERT_BASE_PROMPT } from './expert-prompts/infrastructure-expert.js';
+import { PM_EXPERT_BASE_PROMPT } from './expert-prompts/pm-expert.js';
+import { RESEARCH_EXPERT_BASE_PROMPT } from './expert-prompts/research-expert.js';
+import { SECURITY_EXPERT_BASE_PROMPT } from './expert-prompts/security-expert.js';
+import { TESTING_EXPERT_BASE_PROMPT } from './expert-prompts/testing-expert.js';
+
+const EXPERTS: Array<[string, string]> = [
+  ['code', CODE_EXPERT_BASE_PROMPT],
+  ['architecture', ARCHITECTURE_EXPERT_BASE_PROMPT],
+  ['data-visualization', DATA_VISUALIZATION_EXPERT_BASE_PROMPT],
+  ['documentation', DOCUMENTATION_EXPERT_BASE_PROMPT],
+  ['infrastructure', INFRASTRUCTURE_EXPERT_BASE_PROMPT],
+  ['pm', PM_EXPERT_BASE_PROMPT],
+  ['research', RESEARCH_EXPERT_BASE_PROMPT],
+  ['security', SECURITY_EXPERT_BASE_PROMPT],
+  ['testing', TESTING_EXPERT_BASE_PROMPT],
+];
+
+describe.each(EXPERTS)('Expert %s has Reference Implementation section', (_name, prompt) => {
+  it('includes a Reference Implementation heading', () => {
+    expect(prompt).toContain('Reference Implementation');
+  });
+
+  it('cites at least one concrete repo path', () => {
+    // Any of: src/, docs/, packages/, or .claude/rules/
+    expect(prompt).toMatch(/`(src\/|docs\/|packages\/|\.claude\/|agents\/|CLAUDE\.md)/);
+  });
+});
+
+// Specific cites per expert — verify the canonical files actually appear
+describe('Expert-specific reference cites', () => {
+  it('code cites unified-registry and Result<T,E>', () => {
+    expect(CODE_EXPERT_BASE_PROMPT).toContain('src/adapters/unified-registry.ts');
+    expect(CODE_EXPERT_BASE_PROMPT).toContain('Result<T, E>');
+  });
+
+  it('architecture cites adapter + graph + pipeline primitives', () => {
+    expect(ARCHITECTURE_EXPERT_BASE_PROMPT).toContain('unified-registry.ts');
+    expect(ARCHITECTURE_EXPERT_BASE_PROMPT).toContain('graph-builder.ts');
+    expect(ARCHITECTURE_EXPERT_BASE_PROMPT).toContain('pipeline-runner.ts');
+  });
+
+  it('data-visualization cites EXECUTION_DASHBOARD_DESIGN', () => {
+    expect(DATA_VISUALIZATION_EXPERT_BASE_PROMPT).toContain('EXECUTION_DASHBOARD_DESIGN');
+  });
+
+  it('documentation cites docs/README.md canonical index', () => {
+    expect(DOCUMENTATION_EXPERT_BASE_PROMPT).toContain('docs/README.md');
+    expect(DOCUMENTATION_EXPERT_BASE_PROMPT).toContain('SECURITY.md');
+  });
+
+  it('infrastructure cites SECURITY.md + MCP_PROTOCOL', () => {
+    expect(INFRASTRUCTURE_EXPERT_BASE_PROMPT).toContain('SECURITY.md');
+    expect(INFRASTRUCTURE_EXPERT_BASE_PROMPT).toContain('MCP_PROTOCOL.md');
+  });
+
+  it('pm cites an exemplar epic + canonical paths', () => {
+    expect(PM_EXPERT_BASE_PROMPT).toContain('#1860');
+    expect(PM_EXPERT_BASE_PROMPT).toContain('Canonical Paths');
+  });
+
+  it('research cites RESEARCH_INDEX + RESEARCH_PIPELINE', () => {
+    expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('RESEARCH_INDEX.md');
+    expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('RESEARCH_PIPELINE.md');
+  });
+
+  it('security cites test-secrets + UNTRUSTED_INPUT_HARDENING', () => {
+    expect(SECURITY_EXPERT_BASE_PROMPT).toContain('test-secrets.ts');
+    expect(SECURITY_EXPERT_BASE_PROMPT).toContain('UNTRUSTED_INPUT_HARDENING.md');
+  });
+
+  it('testing cites prompt-composer.test.ts + describe.each template', () => {
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('prompt-composer.test.ts');
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('code-architecture-mode-split.test.ts');
+  });
+});


### PR DESCRIPTION
Closes #1862 (child of #1860). Adds `Reference Implementation` sections citing real in-repo files to data-viz, docs, infra, pm, research, security, testing experts. 27 new tests + 623 experts-suite total pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)