### PR TITLE
feat(testing-expert): flexible output format (#1863)

### DIFF
--- a/packages/nexus-agents/src/agents/experts/expert-prompts/testing-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/testing-expert.ts
@@ -15,6 +15,10 @@ export const TESTING_EXPERT_BASE_PROMPT = `You are a testing expert specializing
 5. Include edge cases and error scenarios
 
 ## Output Format
+
+**Default: flexible output.** When generating tests, lead with the runnable test code in fenced code blocks (with the target test file path as block info, e.g. \`\`\`typescript src/foo.test.ts). Include brief inline rationale only where non-obvious. Use JSON structure only when the caller is a programmatic consumer requesting it (e.g., coverage dashboards, PR-bot integrations).
+
+**Structured JSON (optional, for programmatic consumers):**
 Respond with JSON matching this structure:
 {
   "content": "Summary of testing analysis",

--- a/packages/nexus-agents/src/agents/experts/output-flexibility.test.ts
+++ b/packages/nexus-agents/src/agents/experts/output-flexibility.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for flexible output format across experts (Issue #1863).
+ *
+ * Code, architecture, and testing experts should prioritize running
+ * code over forced JSON structure when the task is generation-shaped.
+ * Code + architecture express this via mode split (generate/design).
+ * Testing expresses it via dual-output language in a single prompt.
+ *
+ * Security and data-visualization already handled this well — they
+ * serve as the pattern source.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CODE_EXPERT_GENERATE_PROMPT } from './expert-prompts/code-expert.js';
+import { ARCHITECTURE_EXPERT_DESIGN_PROMPT } from './expert-prompts/architecture-expert.js';
+import { TESTING_EXPERT_BASE_PROMPT } from './expert-prompts/testing-expert.js';
+
+describe('Code generate mode prefers running code over JSON', () => {
+  it('announces flexible output', () => {
+    expect(CODE_EXPERT_GENERATE_PROMPT).toContain('Output Format (flexible)');
+  });
+
+  it('marks JSON as optional for programmatic consumers only', () => {
+    expect(CODE_EXPERT_GENERATE_PROMPT).toContain(
+      'Only use JSON output if the caller is a programmatic consumer'
+    );
+  });
+});
+
+describe('Architecture design mode prefers narrative over JSON', () => {
+  it('announces flexible output', () => {
+    expect(ARCHITECTURE_EXPERT_DESIGN_PROMPT).toContain('Output Format (flexible)');
+  });
+
+  it('marks JSON as optional for programmatic callers', () => {
+    expect(ARCHITECTURE_EXPERT_DESIGN_PROMPT).toContain(
+      'JSON output optional, use only if the caller is programmatic'
+    );
+  });
+});
+
+describe('Testing expert output is flexible by default', () => {
+  it('defaults to running test code in fenced blocks', () => {
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('Default: flexible output');
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('runnable test code in fenced code blocks');
+  });
+
+  it('marks JSON structure as optional for programmatic consumers', () => {
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain(
+      'Use JSON structure only when the caller is a programmatic consumer'
+    );
+  });
+
+  it('retains the JSON schema for programmatic callers', () => {
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('"operationType"');
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('"tests"');
+    expect(TESTING_EXPERT_BASE_PROMPT).toContain('"coverage"');
+  });
+});


### PR DESCRIPTION
Closes #1863. Code+arch already done via #1867; this PR adds flexible-output language to testing-expert. 7 new tests; 603 experts-suite total pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)