### PR TITLE
chore(governance): sync plugin.json to 2.30.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agents",
-  "version": "2.29.2",
+  "version": "2.30.0",
   "description": "Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 30 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.",
   "author": {
     "name": "William Zujkowski",


### PR DESCRIPTION
Changesets bumps packages/*/package.json but not .claude-plugin/plugin.json, so every release leaves plugin.json one version behind on main — Governance Drift Check then fails on any subsequent PR (noticed on #1847 and #1848). This PR just re-runs `inject-governance.ts inject` to resync.

Follow-up to teach the release workflow to run the regen step before opening the version PR is worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)