### PR TITLE
feat(skills): add debugging discipline — stop-the-line + triage + anti-rationalization

### DIFF
--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -1,0 +1,47 @@
+# Debugging & Error-Recovery Rules
+
+Auto-loaded when a test / build / lint fails, or when the user asks for a debug / triage / "why is this broken" investigation. **Full workflow:** [skills/bug-fix/SKILL.md](../../skills/bug-fix/SKILL.md)
+
+## Stop-the-Line (non-negotiable)
+
+On ANY failure in the middle of a multi-step task:
+
+1. **STOP** — do not edit, retry, or "try one more thing"
+2. **PRESERVE** — capture raw error, stack, last-passing commit, repro command
+3. **DIAGNOSE** — Triage Sequence below; find the _causal_ layer, not the surfacing layer
+4. **FIX** — root cause only. No speculative refactors alongside the fix.
+5. **GUARD** — regression test that would have caught the original failure
+6. **RESUME** — re-run full checks before continuing the original task
+
+Failures compound. An unresolved bug at step N makes every change N+1…N+k incorrect.
+
+## Triage Sequence
+
+1. **Reproduce** reliably (or document conditions if intermittent)
+2. **Localize** to a layer: UI / service / data / build / external — verify with a log, not a hunch
+3. **Reduce** to minimal failing case
+4. **Fix** at the root. Upstream fix = usually right; downstream dedupe/catch = usually a symptom patch
+5. **Guard** with regression test that fails without the fix
+6. **Verify** end-to-end
+
+## Anti-Rationalization
+
+| Excuse                           | Counter                                                                                                                                                  |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I know what the bug is"         | Unverified guesses succeed ~70%. Reproduce before fixing — cost of confirming is minutes, cost of a wrong fix is hours + a regression.                   |
+| "The failing test must be wrong" | Sometimes true, but verify against the spec _before_ changing the test. Tests asserting correct-but-inconvenient behavior get "fixed" to assert the bug. |
+| "It works on my machine"         | Diff Node version, env vars, lockfile drift, CI container, clock/timezone, fs case sensitivity. Environment is a variable.                               |
+| "This is flaky, ignore it"       | Flaky = real race / ordering / timing bug being exposed. Fix it or understand why. `.skip` with a TODO is ticking debt.                                  |
+
+## Non-Reproducible Bugs
+
+- Timing / race: add timestamps, widen race windows with artificial delays
+- Env-dependent: diff local vs CI env vars, Node/pnpm versions, lockfile
+- State-dependent: isolate the triggering sequence; clear DB/cache between attempts
+- Regression: `git bisect run` with a one-line repro script beats manual inspection
+
+## Instrumentation
+
+- Add logging _only when necessary_, remove on resolution
+- Keep only permanent telemetry (error boundaries, API logging, metrics)
+- Never leave `console.log` / ad-hoc prints in committed code — use the logger

--- a/skills/bug-fix/SKILL.md
+++ b/skills/bug-fix/SKILL.md
@@ -13,6 +13,41 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 
 **Full workflow:** [CONTRIBUTION_GUIDE.md](../../docs/development/CONTRIBUTION_GUIDE.md)
 
+## Stop-the-Line Protocol
+
+When a test, build, or lint fails mid-flow — **before** making any more changes:
+
+1. **STOP** — do not edit, do not retry, do not "just try one more thing"
+2. **PRESERVE** — capture the raw error, stack trace, last passing commit, and repro command. Paste into the PR description if relevant
+3. **DIAGNOSE** — run the Triage Sequence below; identify the _causal_ layer, not the first surface that surfaced the error
+4. **FIX** — change the _root cause only_. No speculative refactors, no drive-by cleanups
+5. **GUARD** — add a regression test that would have caught the original failure
+6. **RESUME** — re-run the full check suite; only then continue the original task
+
+Rationale: failures compound. A bug unresolved at step N makes every change N+1…N+k incorrect. We observed this in #1871 (consensus_vote silent hang) — the symptoms looked like adapter timeouts, the cause was missing overall-deadline race.
+
+## Triage Sequence
+
+Run this order **before** "Implement fix." Skipping steps produces symptom-level patches that regress.
+
+1. **Reproduce** reliably. If non-reproducible: log timestamps, add artificial delays to widen race windows, diff CI vs local env. Document the conditions.
+2. **Localize** to a layer: UI / service / data / build / external dep. Resist "it must be X" — verify with a log, not a hunch.
+3. **Reduce** to the minimal failing case. Smaller repros make the cause obvious; large repros hide it.
+4. **Fix** the root cause. If your fix is _upstream_ of where the error surfaced, you're probably right. If it's _downstream_ (dedupe in the view, catch in the caller), you're probably patching the symptom.
+5. **Guard** with a regression test that fails without the fix.
+6. **Verify** end-to-end: `pnpm lint && pnpm typecheck && pnpm test` plus any integration/smoke test for the affected area.
+
+## Anti-Rationalization — Debugging
+
+Debugging tempts four recurring shortcuts. Each is a trap.
+
+| Excuse                           | Counter                                                                                                                                                    |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I know what the bug is"         | Unverified guesses resolve only ~70% of the time. Reproduce first — the cost of confirming is minutes; the cost of a wrong fix is hours plus a regression. |
+| "The failing test must be wrong" | Sometimes true, but verify against the spec _before_ changing the test. A test asserting correct-but-inconvenient behavior gets "fixed" to assert the bug. |
+| "It works on my machine"         | Environment is a variable. Diff Node version, env vars, lockfile drift, CI container, clock/timezone, file system case sensitivity.                        |
+| "This is flaky, ignore it"       | Flaky = the test is exposing a real race/ordering/timing bug. Fix the intermittency or understand why it happens. `.skip` with a TODO is a ticking debt.   |
+
 ## Workflow
 
 1. **Create/verify GitHub issue** with reproduction steps
@@ -56,8 +91,12 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 
 ## Quality Checklist
 
+- [ ] Reproduced reliably (or non-reproducibility documented)
+- [ ] Localized to the causal layer (not the surfacing layer)
 - [ ] Failing test written before fix
-- [ ] Fix is minimal (no unrelated changes)
+- [ ] Fix is at the root cause, not the symptom
+- [ ] Fix is minimal (no unrelated refactors)
 - [ ] Similar patterns checked elsewhere
+- [ ] Regression test would have caught the original bug
 - [ ] `pnpm lint && pnpm typecheck && pnpm test` passes
 - [ ] Issue referenced in commit


### PR DESCRIPTION
## Summary

Adapted 3 high-value concepts from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) `debugging-and-error-recovery` into our `bug-fix` skill + a new `.claude/rules/debugging.md` for auto-load on any failure context.

- **Stop-the-Line Protocol** — on any mid-flow failure: STOP, PRESERVE, DIAGNOSE, FIX, GUARD, RESUME. Targets the compound-error anti-pattern we hit in #1871.
- **Triage Sequence** — reproduce → localize → reduce → fix → guard → verify. Elevates root-cause vs symptom distinction before the PR mechanics.
- **Anti-Rationalization Table** — 4 common agent debugging excuses with counter-arguments.

## Explicitly NOT incorporated

YAGNI / already covered:
- spec-driven-development → we have `requirements-gathering`
- TDD Beyonce rule → CLAUDE.md global TDD policy
- Chesterton's Fence / Rule of 500 → governance refactor gate (`.claude/rules/governance.md`)
- browser DevTools → already covered by claude-in-chrome MCP

## Dogfooding

Approved via `consensus_vote` (simple_majority, 2/2 non-errored, 100% — architect 0.88, security 0.95; pm timed out gracefully thanks to #1871 fix).

## Test plan

- [x] Both files under governance limits (bug-fix 108 lines, debugging.md 47 lines — well under 400)
- [ ] CI green — DocOps skill-sync check will verify the skill edit is properly logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)