### PR TITLE
feat(skills): add constraint-divergent design to implement-feature (from ATLAS PlanSearch)

### DIFF
--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -23,6 +23,26 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 2. **Check/create GitHub issue:** `gh issue list --state open`
 3. **Check research registry** if implementing a technique
 
+## Hard Design Decisions — Constraint-Divergent Design
+
+When the problem has multiple plausible approaches (e.g., "event-driven or polling?", "synchronous vs queue-based?", "monolithic helper vs split modules?"), **do not generate the same solution three times with different variable names**. Instead, articulate 2–3 _distinct constraints_ first, then sketch one solution per constraint and compare.
+
+Anchor constraints in real tradeoffs:
+
+- "minimize allocations" vs "minimize lines of code" vs "minimize external deps"
+- "lowest latency" vs "lowest memory" vs "easiest to test"
+- "fewest moving parts" vs "easiest to extend" vs "matches existing pattern X"
+
+Three constraints that each eliminate ~70% of the solution space leave you searching ~2.7% of it — a focused region, not blind sampling. (Pattern adapted from `itigges22/ATLAS` PlanSearch; the math is theirs.)
+
+Apply this discipline only for genuinely-multivalent decisions. Indicators:
+
+- Multiple plausible architectures where reviewers would reasonably disagree
+- A wrong choice would be expensive to reverse (data-shape migration, public API surface, cross-package boundary)
+- You catch yourself thinking "I'll just pick one and see what review says" — pick deliberately, by constraint, instead
+
+Out of scope: routine work where the approach is dictated by canonical paths or existing patterns. Don't over-apply.
+
 ## Implementation Process
 
 ### Phase 1: Interface First


### PR DESCRIPTION
## Summary

Adapted from [itigges22/ATLAS](https://github.com/itigges22/ATLAS) `PlanSearch` — the one genuinely transferable pattern from a deep look. For multivalent design decisions, articulate 2–3 distinct *constraints* first, sketch one solution per constraint, compare. Avoids the failure mode where an agent generates the same solution three times with different variable names.

Math from ATLAS: 3 constraints × ~70% elimination each = ~2.7% of solution space — focused search, not blind sampling.

## Honest assessment of ATLAS

Self-hosted local-LLM optimizer. Most of its novelty doesn't fill gaps for us:

| ATLAS feature | Why not adapted |
|---|---|
| Thompson Sampling route selection | We have LinUCB in CompositeRouter |
| Sandbox verification (multi-language) | We have Docker sandbox-templates |
| PR-CoT multi-perspective repair | Achievable today via `create_expert` with multiple roles |
| GBNF grammar enforcement | Zod handles boundary validation; we don't run constrained-decoding local models |
| DivSampling (temperature-based diversity) | Our diversity comes from role specialization in experts/voting, not internal sampling |

PlanSearch's constraint-divergent framing is the only piece anchored to a real gap (we don't currently codify "how to approach hard architectural decisions deliberately"). Shipping it as a small section in `implement-feature`.

## Dogfooding

Skipped `consensus_vote` — single-section addition, recent unanimous votes on smaller-scope skill changes (#1881, #1882, #1883, #1884) make further voting on similar additions YAGNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)