### PR TITLE
fix(release): auto-regen plugin.json + repo-index + TypeDoc during version bump (#1879)

### DIFF
--- a/.changeset/fix-1879-release-workflow-regen.md
+++ b/.changeset/fix-1879-release-workflow-regen.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+fix(release): auto-regen plugin.json + repo-index + TypeDoc during version bump (#1879)
+
+Every release left main with stale `.claude-plugin/plugin.json`, `artifacts/repo-index.json`, `docs/reference/capabilities.md`, and TypeDoc HTML — which then failed Governance Drift / Repository Index Verification / TypeDoc Verification checks on every subsequent PR until someone manually pushed a regen commit.
+
+Extended `pnpm changeset:version` to chain the regen scripts after the version bump. `changesets/action` runs this script when opening the version-bump PR, so the regenerated artifacts land in the same PR as the version bump and main stays in sync after merge. Future PRs no longer trigger drift failures.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-04-15T09:47:46.210Z",
+  "generated": "2026-04-15T09:56:05.095Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.30.1",
   "cli": {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-04-15T09:47:46.210Z
+**Generated:** 2026-04-15T09:56:05.095Z
 **Package Version:** 2.30.1
 **Generator:** `scripts/generate-repo-index.ts`
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "review": "npx tsx scripts/review-pr.ts",
     "link-check": "npx lychee --config lychee.toml .",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && pnpm governance:inject && npx tsx scripts/generate-repo-index.ts && pnpm --filter nexus-agents docs",
     "changeset:publish": "changeset publish",
     "release": "pnpm build && changeset publish"
   },


### PR DESCRIPTION
## Summary

Closes #1879 — every release leaves main with stale generated artifacts (plugin.json one version behind, repo-index/capabilities/TypeDoc out of date), which then fails Governance Drift / Repo Index Verification / TypeDoc Verification on every subsequent PR. Manual regen has been needed on at least 4 PRs this session (#1878, #1880, plus the regen commits on #1881, #1883, #1884, #1887, #1899).

## Fix

One-line change to `pnpm changeset:version` in root package.json — chain the regen scripts after `changeset version`:

```json
"changeset:version": "changeset version && pnpm governance:inject && npx tsx scripts/generate-repo-index.ts && pnpm --filter nexus-agents docs"
```

`changesets/action` runs this script when opening the version-bump PR. The regenerated artifacts land in the same PR as the version bump → main stays in sync after merge → future PRs no longer trigger drift failures.

## Test plan

This is structurally hard to test before the next release runs. Validation will be: the version-bump PR opened by changesets after this PR merges should include the regen artifacts. If it does, future PRs won't need manual regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)