### PR TITLE
chore(security): pin dtolnay/rust-toolchain + node Docker image by hash (#1901)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 

--- a/Dockerfile.npm-verify
+++ b/Dockerfile.npm-verify
@@ -11,7 +11,7 @@
 #        cd packages/nexus-agents && pnpm build && npm pack --pack-destination /tmp
 #        docker build -t nexus-verify -f Dockerfile.npm-verify .
 #        docker run --rm -v /tmp/nexus-agents-2.29.0.tgz:/pkg.tgz nexus-verify bash /home/verifier/verify.sh /pkg.tgz
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383
 
 ARG NEXUS_VERSION=latest
 ENV NEXUS_LOG_LEVEL=warn


### PR DESCRIPTION
## Summary

Closes #1901 — addresses 4 of 5 actionable OpenSSF Scorecard PinnedDependenciesID alerts.

| File | Before | After |
|---|---|---|
| `.github/workflows/ci.yml` (×2) | `dtolnay/rust-toolchain@stable` | `@29eef33...` |
| `.github/workflows/release.yml` | `dtolnay/rust-toolchain@stable` | `@29eef33...` |
| `Dockerfile.npm-verify` | `node:22-bookworm-slim` | `@sha256:f3a68cf...` |

5th alert (`scripts/verify-npm-install.sh` npmCommand) is a false positive — npm version is implicitly pinned by the Docker image digest.

## Test plan

- [ ] CI green (especially cargo-audit + cargo-deny which use the Rust toolchain)
- [ ] release.yml not affected (it's the same pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)