### PR TITLE
chore(security): harden verify-npm-install.sh with --ignore-scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,7 +514,7 @@ _Auto-generated from source. 30 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-04-15_
+_Governance Version: 2026-04-16_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/scripts/verify-npm-install.sh
+++ b/scripts/verify-npm-install.sh
@@ -36,7 +36,12 @@ if [[ -f "$VERSION" ]]; then
 else
   INSTALL_SPEC="nexus-agents@${VERSION}"
 fi
-if ! npm install -g "$INSTALL_SPEC" --omit=optional 2>&1; then
+# Defense in depth: --ignore-scripts blocks postinstall hooks from arbitrary
+# packages in the dep tree. We can't hash-pin `npm install -g <name>@<version>`
+# the way Scorecard suggests (hash-pinning via --require-hashes needs a lock
+# file; global installs are by-name), but --ignore-scripts mitigates the class
+# of threats the pin-check defends against.
+if ! npm install -g "$INSTALL_SPEC" --omit=optional --ignore-scripts 2>&1; then
   fail "npm install failed" 1
 fi
 ok "installed"


### PR DESCRIPTION
Follow-up to #1901. Addresses the last actionable Scorecard PinnedDependenciesID alert at scripts/verify-npm-install.sh (alert #192).

`--require-hashes` isn't applicable to global name-based installs. `--ignore-scripts` mitigates the class of threats the pin-check defends against (malicious postinstall hooks from deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)