### PR TITLE
fix(security): tighten path-traversal guard in security-scan target (#1913 Class D)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/security-scan.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/security-scan.test.ts
@@ -42,6 +42,36 @@ describe('executeSecurityScan', () => {
     const result = await executeSecurityScan(input);
     expect('error' in result).toBe(true);
   });
+
+  it('rejects target outside cwd (path traversal guard #1913)', async () => {
+    // An absolute path outside cwd must be rejected, not silently accepted.
+    // Prior check `resolved.startsWith(path.resolve('/'))` was a no-op.
+    const input: SecurityScanInput = {
+      target: '/etc/passwd',
+      scanner: 'auto',
+      rulesets: ['p/default'],
+      maxFindings: 10,
+    };
+    const result = await executeSecurityScan(input);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toMatch(/Invalid target path/);
+    }
+  });
+
+  it('rejects ../ traversal', async () => {
+    const input: SecurityScanInput = {
+      target: '../../../etc',
+      scanner: 'auto',
+      rulesets: ['p/default'],
+      maxFindings: 10,
+    };
+    const result = await executeSecurityScan(input);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toMatch(/Invalid target path/);
+    }
+  });
 });
 
 describe('SecurityScanInputSchema', () => {

--- a/packages/nexus-agents/src/mcp/tools/security-scan.ts
+++ b/packages/nexus-agents/src/mcp/tools/security-scan.ts
@@ -48,11 +48,22 @@ async function runSemgrep(targetDir: string, rulesets: readonly string[]): Promi
   return stdout;
 }
 
-/** Validate that target path is safe (no traversal). */
+/**
+ * Validate that target path is safe (no traversal).
+ *
+ * Security: the target must resolve inside the current working directory.
+ * The previous check `resolved.startsWith(path.resolve('/'))` was
+ * effectively a no-op on POSIX (every absolute path starts with `/`).
+ * (#1913 Class D — path traversal gap.)
+ */
 function validateTargetPath(target: string): string {
-  const resolved = path.resolve(target);
-  if (!resolved.startsWith(path.resolve('/'))) {
-    throw new Error('Invalid target path');
+  const root = path.resolve(process.cwd());
+  const resolved = path.resolve(root, target);
+  // Require resolved path to be inside cwd (or cwd itself).
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error(
+      `Invalid target path: must resolve inside ${root} (got ${resolved})`,
+    );
   }
   return resolved;
 }
@@ -66,7 +77,12 @@ function validateTargetPath(target: string): string {
 export async function executeSecurityScan(
   input: SecurityScanInput
 ): Promise<SarifParseResult | { error: string }> {
-  const targetDir = validateTargetPath(input.target);
+  let targetDir: string;
+  try {
+    targetDir = validateTargetPath(input.target);
+  } catch (e: unknown) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
 
   logger.info('Starting security scan', {
     target: targetDir,


### PR DESCRIPTION
## Summary

`validateTargetPath()` used `resolved.startsWith(path.resolve('/'))` which is a **no-op on POSIX** — every absolute path starts with `/`. A malicious MCP client could scan `/etc`, `/root`, etc., and exfiltrate file contents via SARIF output.

## Fix

Require resolved target to be inside `process.cwd()`. Callers get structured `{ error }` instead of an uncaught throw on invalid input.

## Test plan

- [x] 2 new regression tests: reject /etc/passwd, reject ../../../etc
- [x] All 7/7 existing + new tests pass

Partial closure of #1913 Class D (path traversal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)