### PR TITLE
fix(observability): surface capacity-monitor callback errors (#1913 Class B wave 2)

### DIFF
--- a/packages/nexus-agents/src/adapters/capacity-monitor.ts
+++ b/packages/nexus-agents/src/adapters/capacity-monitor.ts
@@ -9,7 +9,7 @@
  * @see Google Cloud: https://cloud.google.com/docs/quota
  */
 
-import { getTimeProvider } from '../core/index.js';
+import { getTimeProvider, createLogger, type ILogger } from '../core/index.js';
 import { clampPercent } from '../utils/math-utils.js';
 import {
   type CapacityInfo,
@@ -62,6 +62,7 @@ export class CapacityMonitor implements ICapacityMonitor {
   private readonly providers: Map<string, ProviderCapacityState>;
   private readonly callbacks: Set<LowCapacityCallback>;
   private readonly config: Required<CapacityMonitorConfig>;
+  private readonly logger: ILogger = createLogger({ component: 'capacity-monitor' });
 
   constructor(config?: CapacityMonitorConfig) {
     this.providers = new Map();
@@ -218,8 +219,15 @@ export class CapacityMonitor implements ICapacityMonitor {
       for (const callback of this.callbacks) {
         try {
           callback(provider, state.remainingTokens, info);
-        } catch {
-          // Ignore callback errors
+        } catch (error: unknown) {
+          // Callback errors must not halt the capacity-check loop, but
+          // silent catch loses visibility when a user-provided callback
+          // misbehaves. Log at warn so it surfaces in normal operation.
+          const msg = error instanceof Error ? error.message : String(error);
+          this.logger.warn('Capacity-monitor callback threw; continuing loop', {
+            provider,
+            error: msg,
+          });
         }
       }
     }

--- a/packages/nexus-agents/src/governance/fitness-score.ts
+++ b/packages/nexus-agents/src/governance/fitness-score.ts
@@ -223,9 +223,24 @@ export class FitnessScoreCalculator {
     const score = Object.values(dimensions).reduce((sum, val) => sum + val, 0);
     this.logger.info('Fitness audit complete', { score, version });
 
+    // Build a strictly-typed FitnessDimensions instead of `as unknown as` cast
+    // (#1913 Class G). If a check skipped a dimension it defaults to 0,
+    // making it explicit rather than UB.
+    const safeDim = (k: keyof FitnessDimensions): number => dimensions[k] ?? 0;
+    const typedDimensions: FitnessDimensions = {
+      canonicalPaths: safeDim('canonicalPaths'),
+      explicitBehavior: safeDim('explicitBehavior'),
+      determinism: safeDim('determinism'),
+      observability: safeDim('observability'),
+      configSimplicity: safeDim('configSimplicity'),
+      layerSeparation: safeDim('layerSeparation'),
+      operatorErgonomics: safeDim('operatorErgonomics'),
+      governanceIntegration: safeDim('governanceIntegration'),
+    };
+
     return {
       score,
-      dimensions: dimensions as unknown as FitnessDimensions,
+      dimensions: typedDimensions,
       findings,
       timestamp: new Date().toISOString(),
       version,


### PR DESCRIPTION
Follow-up to #1914. CapacityMonitor silently dropped callback exceptions; now logs at warn level.

Part of #1913 Class B (silent catches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)