### PR TITLE
feat(orchestration): wire step notifications into consensus-plan + triangulated-review

### DIFF
--- a/.changeset/step-notifications-consensus-review.md
+++ b/.changeset/step-notifications-consensus-review.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+feat(orchestration): wire step notifications into consensus-plan + triangulated-review
+
+Second wave of step-notification migrations (follows #1930). Both
+multi-CLI orchestration entry points now emit `step.started`/`completed`
+events to the shared step bus, with useful summaries:
+
+- `consensus-plan` → `"3 agreed, 1 divergent, 3/3 CLIs"`
+- `triangulated-review` → `"7 findings (12 raw), 3/3 CLIs"`
+
+The previous `logger.info` start/end pairs are replaced by `withStep(...)`;
+the ILogger is still used for per-CLI dispatch logs and outcome recording.
+JSON logs remain the source of truth (step events flow through the same
+bus and get logged by the existing bridge).

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -18,6 +18,7 @@ import {
   createLogger,
   getTimeProvider,
   extractJsonObject,
+  withStep,
 } from '../core/index.js';
 
 import type { ICliAdapter, CliName, CliResponse, CliError } from '../cli-adapters/types.js';
@@ -65,43 +66,46 @@ export async function executeConsensusPlan(
     return err(new Error('No CLI adapters available for planning'));
   }
 
-  logger.info('Starting consensus planning', {
-    clis: selectedClis.map((s) => s.cli),
-    taskLength: task.length,
-  });
+  return withStep(
+    {
+      name: 'consensus-plan',
+      kind: 'consensus.vote',
+      attrs: {
+        clis: selectedClis.map((s) => s.cli),
+        taskLength: task.length,
+      },
+    },
+    async (ctx) => {
+      const startTime = getTimeProvider().now();
+      const partitions = await dispatchPlans(task, selectedClis, config, logger);
+      const totalDurationMs = getTimeProvider().now() - startTime;
+      const clisUsed = partitions.filter((p) => p.success).map((p) => p.cli);
+      const successPlans = partitions.filter((p) => p.success && p.plan !== null);
 
-  const startTime = getTimeProvider().now();
-  const partitions = await dispatchPlans(task, selectedClis, config, logger);
-  const totalDurationMs = getTimeProvider().now() - startTime;
-  const clisUsed = partitions.filter((p) => p.success).map((p) => p.cli);
-  const successPlans = partitions.filter((p) => p.success && p.plan !== null);
+      const { agreedSteps, divergences } = synthesize(successPlans);
+      const risks = collectRisks(successPlans);
+      const alternatives = collectAlternatives(successPlans);
+      const summary = buildPlanSummary(agreedSteps, divergences, clisUsed);
 
-  const { agreedSteps, divergences } = synthesize(successPlans);
-  const risks = collectRisks(successPlans);
-  const alternatives = collectAlternatives(successPlans);
-  const summary = buildPlanSummary(agreedSteps, divergences, clisUsed);
+      recordPlanOutcomes(partitions);
 
-  recordPlanOutcomes(partitions);
+      const result: ConsensusPlanResult = {
+        partitions,
+        agreedSteps,
+        divergences,
+        risks,
+        alternatives,
+        summary,
+        clisUsed,
+        totalDurationMs,
+      };
 
-  const result: ConsensusPlanResult = {
-    partitions,
-    agreedSteps,
-    divergences,
-    risks,
-    alternatives,
-    summary,
-    clisUsed,
-    totalDurationMs,
-  };
-
-  logger.info('Consensus planning completed', {
-    totalDurationMs,
-    clisUsed,
-    agreedSteps: agreedSteps.length,
-    divergences: divergences.length,
-  });
-
-  return ok(result);
+      ctx.setSummary(
+        `${String(agreedSteps.length)} agreed, ${String(divergences.length)} divergent, ${String(clisUsed.length)}/${String(selectedClis.length)} CLIs`
+      );
+      return ok(result);
+    }
+  );
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/orchestration/triangulated-review.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.ts
@@ -17,6 +17,7 @@ import {
   createLogger,
   getTimeProvider,
   extractJsonArray,
+  withStep,
 } from '../core/index.js';
 
 import type { ICliAdapter, CliName, CliResponse, CliError } from '../cli-adapters/types.js';
@@ -63,45 +64,48 @@ export async function executeTriangulatedReview(
     return err(new Error('No CLI adapters available for review'));
   }
 
-  logger.info('Starting triangulated review', {
-    clis: selectedClis.map((s) => s.cli),
-    diffLength: diff.length,
-  });
+  return withStep(
+    {
+      name: 'triangulated-review',
+      kind: 'consensus.vote',
+      attrs: {
+        clis: selectedClis.map((s) => s.cli),
+        diffLength: diff.length,
+      },
+    },
+    async (ctx) => {
+      const startTime = getTimeProvider().now();
 
-  const startTime = getTimeProvider().now();
+      const partitions = await dispatchReviews(diff, selectedClis, config, logger);
 
-  const partitions = await dispatchReviews(diff, selectedClis, config, logger);
+      const totalDurationMs = getTimeProvider().now() - startTime;
+      const clisUsed = partitions.filter((p) => p.success).map((p) => p.cli);
 
-  const totalDurationMs = getTimeProvider().now() - startTime;
-  const clisUsed = partitions.filter((p) => p.success).map((p) => p.cli);
+      // Collect all findings and deduplicate
+      const allFindings = partitions.flatMap((p) => (p.success ? [...p.findings] : []));
+      const deduplicated = deduplicateFindings(allFindings, partitions, config.lineProximity);
 
-  // Collect all findings and deduplicate
-  const allFindings = partitions.flatMap((p) => (p.success ? [...p.findings] : []));
-  const deduplicated = deduplicateFindings(allFindings, partitions, config.lineProximity);
+      const countBySeverity = countFindings(deduplicated);
+      const summary = buildSummary(deduplicated, clisUsed);
 
-  const countBySeverity = countFindings(deduplicated);
-  const summary = buildSummary(deduplicated, clisUsed);
+      // Record outcomes (best-effort)
+      recordReviewOutcomes(partitions);
 
-  // Record outcomes (best-effort)
-  recordReviewOutcomes(partitions);
+      const result: TriangulatedReviewResult = {
+        partitions,
+        findings: deduplicated,
+        clisUsed,
+        totalDurationMs,
+        summary,
+        countBySeverity,
+      };
 
-  const result: TriangulatedReviewResult = {
-    partitions,
-    findings: deduplicated,
-    clisUsed,
-    totalDurationMs,
-    summary,
-    countBySeverity,
-  };
-
-  logger.info('Triangulated review completed', {
-    totalDurationMs,
-    clisUsed,
-    totalFindings: allFindings.length,
-    deduplicatedFindings: deduplicated.length,
-  });
-
-  return ok(result);
+      ctx.setSummary(
+        `${String(deduplicated.length)} findings (${String(allFindings.length)} raw), ${String(clisUsed.length)}/${String(selectedClis.length)} CLIs`
+      );
+      return ok(result);
+    }
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Second wave of step-notification migrations, following #1930. Both multi-CLI orchestration entry points now emit `step.started` / `step.completed` events to the shared step bus with useful summaries:

- `consensus-plan` → `"3 agreed, 1 divergent, 3/3 CLIs"`
- `triangulated-review` → `"7 findings (12 raw), 3/3 CLIs"`

Replaces the `logger.info('Starting ...')` / `logger.info('... completed')` pairs with `withStep(...)` wrappers. The `ILogger` is still used for per-CLI dispatch logs and outcome recording — only the bookend notifications change path.

## Rollout progress

Per the #1930 rollout plan, remaining sites to migrate (future PRs):
- [ ] `execute-expert.ts` — expert execution start/end
- [ ] `subprocess-adapter.ts` — CLI subprocess call boundaries
- [ ] `graph-hooks.ts` — graph node transitions

## Test plan

- [x] `pnpm --filter nexus-agents lint` — clean
- [x] `pnpm --filter nexus-agents typecheck` — clean
- [x] `src/orchestration/consensus-plan.test.ts` + `triangulated-review.test.ts` — 33 tests pass
- [x] Behavior unchanged — only the notification path differs; all existing assertions hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)