### PR TITLE
feat(cli-adapters): add generateObject<T> with parse-retry-with-feedback (#1897)

### DIFF
--- a/.changeset/generate-object.md
+++ b/.changeset/generate-object.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+feat(cli-adapters): add generateObject<T> for typed structured output with retry-with-feedback (#1897)
+
+New `generateObject()` helper wraps CLI adapter execution with:
+
+- Zod schema → JSON Schema instruction appended to prompt
+- Automatic JSON extraction from LLM response (object or array)
+- Zod validation of extracted data
+- On validation failure: retry once with the validation error fed back
+  to the LLM ("Your previous response failed JSON validation: ...")
+- Returns `Result<GenerateObjectResult<T>, GenerateObjectError>`
+
+This replaces the manual `extractJsonObject → JSON.parse → Zod.parse`
+pattern scattered across consensus-plan, triangulated-review, security
+fix-generator, and finding-triage. Inspired by vercel/ai's
+`generateObject` and pydantic-ai's parse-retry-with-feedback pattern
+(surfaced in #1892 research).

--- a/packages/nexus-agents/src/cli-adapters/generate-object.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/generate-object.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for generateObject — typed structured output with retry-with-feedback.
+ * (Source: Issue #1897)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { generateObject } from './generate-object.js';
+import type { ICliAdapter } from './types.js';
+import type { CliResponse, CliError } from './types-core.js';
+import type { Result } from '../core/index.js';
+
+/** Create a mock adapter that returns the given responses in sequence. */
+function mockAdapter(...responses: Array<Result<CliResponse, CliError>>): ICliAdapter {
+  const execute = vi.fn();
+  for (const r of responses) {
+    execute.mockResolvedValueOnce(r);
+  }
+  return {
+    name: 'claude',
+    transport: 'subprocess',
+    capabilities: { reasoning: 9, contextWindow: 200000, codeGeneration: 9, speed: 7, cost: 6 },
+    execute,
+    healthCheck: vi.fn(),
+    getCapacity: vi.fn(),
+    getVersion: vi.fn(),
+    getModelInfo: vi.fn(),
+    initialize: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as ICliAdapter;
+}
+
+function okResponse(text: string): Result<CliResponse, CliError> {
+  return {
+    ok: true,
+    value: { text, usage: { inputTokens: 100, outputTokens: 50 } },
+  };
+}
+
+function errResponse(message: string): Result<CliResponse, CliError> {
+  return {
+    ok: false,
+    error: { code: 'EXECUTION_ERROR' as const, message, retryable: false, cli: 'claude' },
+  };
+}
+
+const FindingsSchema = z.object({
+  findings: z.array(
+    z.object({
+      severity: z.enum(['high', 'medium', 'low']),
+      description: z.string(),
+    })
+  ),
+});
+
+describe('generateObject', () => {
+  it('extracts and validates JSON on first attempt', async () => {
+    const json = JSON.stringify({
+      findings: [{ severity: 'high', description: 'SQL injection' }],
+    });
+    const adapter = mockAdapter(okResponse(`Here is the result:\n${json}`));
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.data.findings).toHaveLength(1);
+      expect(result.value.data.findings[0]?.severity).toBe('high');
+      expect(result.value.attempts).toBe(1);
+    }
+  });
+
+  it('retries with feedback on validation failure', async () => {
+    const badJson = JSON.stringify({ findings: [{ severity: 'critical', description: 'XSS' }] });
+    const goodJson = JSON.stringify({
+      findings: [{ severity: 'high', description: 'XSS' }],
+    });
+    const adapter = mockAdapter(
+      okResponse(badJson), // First: 'critical' not in enum
+      okResponse(goodJson) // Retry: fixed
+    );
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.attempts).toBe(2);
+      expect(result.value.data.findings[0]?.severity).toBe('high');
+    }
+
+    // Verify retry prompt includes validation error
+    const calls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls;
+    const retryCall = calls[1] as unknown[];
+    const retryContent = (retryCall[0] as { content: string }).content;
+    expect(retryContent).toContain('failed JSON validation');
+    expect(retryContent).toContain('severity');
+  });
+
+  it('returns error when adapter fails', async () => {
+    const adapter = mockAdapter(errResponse('Model overloaded'));
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('adapter_error');
+      expect(result.error.message).toBe('Model overloaded');
+    }
+  });
+
+  it('returns error when no JSON found in response', async () => {
+    const adapter = mockAdapter(okResponse('Sorry, I cannot analyze this code.'));
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('no_json');
+    }
+  });
+
+  it('returns validation_error after retry exhaustion', async () => {
+    const badJson = JSON.stringify({ findings: [{ severity: 'critical', description: 'XSS' }] });
+    const adapter = mockAdapter(
+      okResponse(badJson), // First: invalid
+      okResponse(badJson) // Retry: still invalid
+    );
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.zodErrors).toBeDefined();
+    }
+  });
+
+  it('handles JSON parse errors', async () => {
+    const adapter = mockAdapter(okResponse('{ broken json }'), okResponse('{ "findings": [] }'));
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    // Should retry on parse error and succeed
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.attempts).toBe(2);
+    }
+  });
+
+  it('supports array extraction with isArray flag', async () => {
+    const ArraySchema = z.array(z.object({ name: z.string() }));
+    const json = JSON.stringify([{ name: 'alpha' }, { name: 'beta' }]);
+    const adapter = mockAdapter(okResponse(`Results: ${json}`));
+
+    const result = await generateObject({
+      adapter,
+      prompt: 'List items',
+      schema: ArraySchema,
+      isArray: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.data).toHaveLength(2);
+      expect(result.value.data[0]?.name).toBe('alpha');
+    }
+  });
+
+  it('appends schema instruction to prompt', async () => {
+    const adapter = mockAdapter(okResponse('{ "findings": [] }'));
+
+    await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+    });
+
+    const calls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls;
+    const firstCall = calls[0] as unknown[];
+    const content = (firstCall[0] as { content: string }).content;
+    expect(content).toContain('Respond ONLY with valid JSON');
+  });
+
+  it('passes timeoutMs to adapter task', async () => {
+    const adapter = mockAdapter(okResponse('{ "findings": [] }'));
+
+    await generateObject({
+      adapter,
+      prompt: 'Analyze code',
+      schema: FindingsSchema,
+      timeoutMs: 30000,
+    });
+
+    const calls = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls;
+    const firstCall = calls[0] as unknown[];
+    const task = firstCall[0] as { timeoutMs?: number };
+    expect(task.timeoutMs).toBe(30000);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/generate-object.ts
+++ b/packages/nexus-agents/src/cli-adapters/generate-object.ts
@@ -1,0 +1,244 @@
+/**
+ * nexus-agents/cli-adapters - Typed Structured Output Generation
+ *
+ * Wraps CLI adapter execution with Zod schema validation and
+ * retry-with-feedback. Inspired by vercel/ai's `generateObject` and
+ * pydantic-ai's parse-retry pattern.
+ *
+ * @module cli-adapters/generate-object
+ * (Source: Issue #1897 — typed generateObject<T> abstraction)
+ */
+
+import type { ZodType, ZodError } from 'zod';
+import type { Result } from '../core/index.js';
+import { ok, err, extractJsonObject, extractJsonArray } from '../core/index.js';
+import type { ICliAdapter, CliTask } from './types.js';
+import type { CliResponse } from './types-core.js';
+
+/** Options for generateObject. */
+export interface GenerateObjectOptions<T> {
+  /** The CLI adapter to execute the task on. */
+  readonly adapter: ICliAdapter;
+  /** The user prompt describing what to generate. */
+  readonly prompt: string;
+  /** Zod schema defining the expected output shape. */
+  readonly schema: ZodType<T>;
+  /** Whether the expected shape is an array (uses extractJsonArray). */
+  readonly isArray?: boolean;
+  /** Optional system-level instructions prepended to the prompt. */
+  readonly systemPrompt?: string;
+  /** Optional timeout in milliseconds. */
+  readonly timeoutMs?: number;
+}
+
+/** Structured error from generateObject. */
+export interface GenerateObjectError {
+  /** What went wrong. */
+  readonly code: 'adapter_error' | 'no_json' | 'parse_error' | 'validation_error';
+  /** Human-readable message. */
+  readonly message: string;
+  /** Raw CLI response text (if available). */
+  readonly rawText?: string;
+  /** Zod validation issues (if validation_error). */
+  readonly zodErrors?: ZodError;
+}
+
+/** Result of a successful generateObject call. */
+export interface GenerateObjectResult<T> {
+  /** The validated, typed object. */
+  readonly data: T;
+  /** Token usage from the adapter. */
+  readonly usage?: CliResponse['usage'];
+  /** Number of attempts (1 = first try, 2 = retried with feedback). */
+  readonly attempts: number;
+}
+
+/**
+ * Build the schema instruction suffix that tells the LLM to respond with JSON.
+ */
+function buildSchemaInstruction<T>(schema: ZodType<T>): string {
+  // Zod v4 uses .toJsonSchema() but we keep a safe fallback
+  const jsonSchema = getJsonSchema(schema);
+  const schemaStr = JSON.stringify(jsonSchema, null, 2);
+  return [
+    '',
+    'IMPORTANT: Respond ONLY with valid JSON matching this schema (no markdown fences, no explanation):',
+    schemaStr,
+  ].join('\n');
+}
+
+/** Extract JSON schema from Zod, with safe fallback. */
+function getJsonSchema<T>(schema: ZodType<T>): Record<string, unknown> {
+  // Zod v4 has .toJsonSchema(); Zod v3 needs zod-to-json-schema
+  const s = schema as unknown as Record<string, unknown>;
+  if ('toJsonSchema' in s && typeof s['toJsonSchema'] === 'function') {
+    return (s['toJsonSchema'] as () => Record<string, unknown>)();
+  }
+  // Fallback: describe shape textually
+  return { description: 'See prompt for expected shape' };
+}
+
+/**
+ * Build the retry prompt with validation feedback.
+ */
+function buildRetryPrompt(
+  originalPrompt: string,
+  rawText: string,
+  validationError: string
+): string {
+  return [
+    originalPrompt,
+    '',
+    'Your previous response failed JSON validation:',
+    validationError,
+    '',
+    `Your previous response (first 500 chars): ${rawText.slice(0, 500)}`,
+    '',
+    'Please respond again with valid JSON only. No markdown fences, no explanation.',
+  ].join('\n');
+}
+
+/**
+ * Try to extract and validate JSON from CLI response text.
+ */
+function tryExtractAndValidate<T>(
+  text: string,
+  schema: ZodType<T>,
+  isArray: boolean
+): Result<T, GenerateObjectError> {
+  const jsonStr = isArray ? extractJsonArray(text) : extractJsonObject(text);
+  if (jsonStr === undefined) {
+    return err({
+      code: 'no_json',
+      message: `No JSON ${isArray ? 'array' : 'object'} found in response`,
+      rawText: text,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch (e: unknown) {
+    return err({
+      code: 'parse_error',
+      message: `JSON parse failed: ${e instanceof Error ? e.message : String(e)}`,
+      rawText: text,
+    });
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return err({
+      code: 'validation_error',
+      message: formatZodErrors(result.error),
+      rawText: text,
+      zodErrors: result.error,
+    });
+  }
+
+  return ok(result.data);
+}
+
+/** Format Zod errors into a concise feedback string for the LLM. */
+function formatZodErrors(error: ZodError): string {
+  return error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; ');
+}
+
+/**
+ * Generate a typed object from a CLI adapter with schema validation
+ * and retry-with-feedback on validation failure.
+ *
+ * @example
+ * ```ts
+ * const result = await generateObject({
+ *   adapter,
+ *   prompt: 'Analyze this code for security issues',
+ *   schema: z.object({
+ *     findings: z.array(z.object({
+ *       severity: z.enum(['high', 'medium', 'low']),
+ *       description: z.string(),
+ *     })),
+ *   }),
+ * });
+ * if (result.ok) {
+ *   console.log(result.value.data.findings);
+ * }
+ * ```
+ */
+/** Build a CliTask from prompt and optional timeout. */
+function buildTask(content: string, timeoutMs: number | undefined): CliTask {
+  if (timeoutMs !== undefined) {
+    return { content, timeoutMs };
+  }
+  return { content };
+}
+
+/** Retry context passed to retryWithFeedback. */
+interface RetryContext<T> {
+  readonly adapter: ICliAdapter;
+  readonly fullPrompt: string;
+  readonly rawText: string;
+  readonly errorMsg: string;
+  readonly schema: ZodType<T>;
+  readonly isArray: boolean;
+  readonly timeoutMs: number | undefined;
+}
+
+/** Attempt retry with validation feedback. */
+async function retryWithFeedback<T>(
+  ctx: RetryContext<T>
+): Promise<Result<GenerateObjectResult<T>, GenerateObjectError> | undefined> {
+  const retryPrompt = buildRetryPrompt(ctx.fullPrompt, ctx.rawText, ctx.errorMsg);
+  const retryResponse = await ctx.adapter.execute(buildTask(retryPrompt, ctx.timeoutMs));
+
+  if (!retryResponse.ok) {
+    return err({ code: 'adapter_error', message: retryResponse.error.message });
+  }
+
+  const retryAttempt = tryExtractAndValidate(retryResponse.value.text, ctx.schema, ctx.isArray);
+  if (retryAttempt.ok) {
+    return ok({ data: retryAttempt.value, usage: retryResponse.value.usage, attempts: 2 });
+  }
+  return undefined; // retry failed, caller decides
+}
+
+/**
+ * Generate a typed object from a CLI adapter with schema validation
+ * and retry-with-feedback on validation failure.
+ */
+export async function generateObject<T>(
+  opts: GenerateObjectOptions<T>
+): Promise<Result<GenerateObjectResult<T>, GenerateObjectError>> {
+  const { adapter, schema, isArray = false, timeoutMs } = opts;
+  const schemaInstruction = buildSchemaInstruction(schema);
+  const fullPrompt = (opts.systemPrompt ?? '') + opts.prompt + schemaInstruction;
+
+  // First attempt
+  const response = await adapter.execute(buildTask(fullPrompt, timeoutMs));
+  if (!response.ok) {
+    return err({ code: 'adapter_error', message: response.error.message });
+  }
+
+  const firstAttempt = tryExtractAndValidate(response.value.text, schema, isArray);
+  if (firstAttempt.ok) {
+    return ok({ data: firstAttempt.value, usage: response.value.usage, attempts: 1 });
+  }
+
+  // No JSON at all — don't retry (model didn't even try)
+  if (firstAttempt.error.code === 'no_json') {
+    return err(firstAttempt.error);
+  }
+
+  // Retry with validation feedback
+  const retryResult = await retryWithFeedback({
+    adapter,
+    fullPrompt,
+    rawText: response.value.text,
+    errorMsg: firstAttempt.error.message,
+    schema,
+    isArray,
+    timeoutMs,
+  });
+
+  return retryResult ?? err(firstAttempt.error);
+}

--- a/packages/nexus-agents/src/cli-adapters/index.ts
+++ b/packages/nexus-agents/src/cli-adapters/index.ts
@@ -428,6 +428,14 @@ export {
 } from './unified-routing-types.js';
 export type { RoutingStrategy, UnifiedRoutingDecision } from './unified-routing-types.js';
 
+// Typed Structured Output (Issue #1897)
+export { generateObject } from './generate-object.js';
+export type {
+  GenerateObjectOptions,
+  GenerateObjectResult,
+  GenerateObjectError,
+} from './generate-object.js';
+
 // Cascade Router Base (Issue #574)
 export { CascadeRouterBase, DEFAULT_CASCADE_BASE_CONFIG } from './cascade-router-base.js';
 export type {


### PR DESCRIPTION
## Summary

Adds `generateObject<T>()` — a typed structured output helper that wraps CLI adapter execution with Zod schema validation and retry-with-feedback. Closes #1897, Phase 6 deliverable (#1401).

**Before:** Every caller manually does `extractJsonObject → JSON.parse → Zod.parse` with no retry on validation failure (4+ call sites: consensus-plan, triangulated-review, fix-generator, finding-triage).

**After:**
```ts
const result = await generateObject({
  adapter,
  prompt: 'Analyze this code for security issues',
  schema: z.object({
    findings: z.array(z.object({
      severity: z.enum(['high', 'medium', 'low']),
      description: z.string(),
    })),
  }),
});
// result.value.data is typed as { findings: Array<{severity, description}> }
```

### How it works

1. Appends Zod schema (as JSON Schema) instruction to the prompt
2. Executes via the adapter
3. Extracts JSON from response text (object or array mode)
4. Validates with Zod
5. On validation/parse failure: **retries once with the error fed back** to the LLM:
   > "Your previous response failed JSON validation: findings.0.severity: Invalid enum value. Expected 'high' | 'medium' | 'low', received 'critical'. Respond again with valid JSON only."
6. Returns `Result<GenerateObjectResult<T>, GenerateObjectError>`

### Architectural inspiration

- **vercel/ai** `generateObject()` — same API shape
- **pydantic-ai** `RetryPromptPart` — feeds validation errors back to LLM (surfaced in #1892 research, identified as our biggest gap)

### Follow-up (not in this PR)

Migrating existing call sites (consensus-plan, triangulated-review, fix-generator, finding-triage) to use `generateObject` instead of manual extraction. Each migration is a separate PR.

## Test plan

- [x] `pnpm --filter nexus-agents lint` — clean
- [x] `pnpm --filter nexus-agents typecheck` — clean
- [x] 9 tests: first-attempt success, retry-with-feedback, adapter errors, no-JSON, parse errors, array extraction, schema injection, timeout passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)