### PR TITLE
fix(deps): patch basic-ftp CVE (GHSA-rp42-5vxx-qpwr)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "markdown-it": ">=14.1.1",
       "qs": ">=6.14.2",
-      "basic-ftp": ">=5.2.2",
+      "basic-ftp": ">=5.3.0",
       "defu": ">=6.1.5",
       "smol-toml": ">=1.6.1",
       "markdownlint-cli>minimatch": ">=10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   markdown-it: '>=14.1.1'
   qs: '>=6.14.2'
-  basic-ftp: '>=5.2.2'
+  basic-ftp: '>=5.3.0'
   defu: '>=6.1.5'
   smol-toml: '>=1.6.1'
   markdownlint-cli>minimatch: '>=10.2.3'
@@ -3552,10 +3552,10 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
-  basic-ftp@5.2.2:
+  basic-ftp@5.3.0:
     resolution:
       {
-        integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==,
+        integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==,
       }
     engines: { node: '>=10.0.0' }
 
@@ -10390,7 +10390,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -10695,7 +10695,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -11585,7 +11585,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Patches the last vulnerability flagged by OSSF Scorecard: basic-ftp <=5.2.2 DoS via unbounded memory in `Client.list()`.

- Updated pnpm override: `>=5.2.2` → `>=5.3.0`
- Resolved to basic-ftp@5.3.0 (fix version)
- Should move Vulnerabilities score from 9/10 → 10/10

## Test plan

- [x] `pnpm install` resolves cleanly
- [x] Zero open Dependabot alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)