### PR TITLE
feat(cli,docs): fix TypeDoc test exclusion + enrich dry-run + MCP permissions snippet (#1945, #1946, #1947)

### DIFF
--- a/packages/nexus-agents/src/cli/orchestrate-command.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-command.ts
@@ -26,6 +26,7 @@ import {
 import { getConfig, adaptRoutingConfig } from '../config/index.js';
 import { executeWithPuppeteer } from './orchestrate-puppeteer.js';
 import type { OrchestrateOptions, PuppeteerOrchestrationResult } from './orchestrate-types.js';
+import { buildDryRunReport, renderDryRunText, type DryRunReport } from './orchestrate-dry-run.js';
 
 // Re-export types for backward compatibility
 export type { OrchestrateEngine, OrchestrateOptions } from './orchestrate-types.js';
@@ -38,6 +39,8 @@ interface OrchestrationResult {
   routing?: CompositeRoutingDecision;
   error?: string;
   durationMs: number;
+  /** Present only when dryRun=true — enriched task analysis + cost estimate. */
+  dryRun?: DryRunReport;
 }
 
 /**
@@ -119,6 +122,7 @@ async function executeWithRouting(
       success: true,
       model: decision.cliName,
       routing: decision,
+      dryRun: buildDryRunReport(task, decision),
       durationMs: time.now() - startTime,
     };
   }
@@ -225,6 +229,12 @@ function formatPuppeteerStats(puppeteer: PuppeteerOrchestrationResult['puppeteer
 function formatResultText(result: OrchestrationResult | PuppeteerOrchestrationResult): string {
   const lines: string[] = [];
   const puppeteerResult = result as PuppeteerOrchestrationResult;
+  const resultWithDryRun = result as OrchestrationResult;
+
+  // Dry run: emit enriched report instead of minimal routing summary
+  if (resultWithDryRun.dryRun !== undefined) {
+    return renderDryRunText(resultWithDryRun.dryRun);
+  }
 
   if (result.success) {
     lines.push(`Task completed using ${result.model} (${String(result.durationMs)}ms)`);

--- a/packages/nexus-agents/src/cli/orchestrate-dry-run.test.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-dry-run.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for enriched dry-run report generation.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildDryRunReport, renderDryRunText } from './orchestrate-dry-run.js';
+import type { CliTask } from '../cli-adapters/index.js';
+import type { CompositeRoutingDecision } from '../cli-adapters/index.js';
+
+function makeTask(content: string): CliTask {
+  return { content };
+}
+
+function makeDecision(
+  cliName: 'claude' | 'gemini' | 'codex' | 'opencode'
+): CompositeRoutingDecision {
+  return {
+    cliName,
+    reason: 'test routing',
+    confidence: 0.82,
+    adapter: {} as CompositeRoutingDecision['adapter'],
+  } as CompositeRoutingDecision;
+}
+
+describe('buildDryRunReport', () => {
+  it('analyzes a simple task and returns structured report', () => {
+    const report = buildDryRunReport(
+      makeTask('Write a hello world program in Python'),
+      makeDecision('codex')
+    );
+    expect(report.analysis.taskType).toBeTruthy();
+    expect(report.analysis.estimatedInputTokens).toBeGreaterThan(0);
+    expect(report.analysis.estimatedOutputTokens).toBeGreaterThan(0);
+    expect(report.routing.selectedCli).toBe('codex');
+    expect(report.routing.confidence).toBe(0.82);
+  });
+
+  it('produces cost estimate when model is in canonical registry', () => {
+    const report = buildDryRunReport(
+      makeTask('Refactor the authentication middleware to use JWT'),
+      makeDecision('claude')
+    );
+    expect(report.costEstimate).toBeDefined();
+    if (report.costEstimate !== undefined) {
+      expect(report.costEstimate.totalUsd).toBeGreaterThanOrEqual(0);
+      expect(report.costEstimate.model).toBeTruthy();
+      expect(report.costEstimate.inputUsd + report.costEstimate.outputUsd).toBeCloseTo(
+        report.costEstimate.totalUsd,
+        6
+      );
+    }
+  });
+
+  it('estimates output tokens as ~60% of input', () => {
+    const report = buildDryRunReport(makeTask('x'.repeat(4000)), makeDecision('gemini'));
+    const ratio = report.analysis.estimatedOutputTokens / report.analysis.estimatedInputTokens;
+    expect(ratio).toBeGreaterThan(0.5);
+    expect(ratio).toBeLessThan(0.7);
+  });
+});
+
+describe('renderDryRunText', () => {
+  it('renders human-readable report with all sections', () => {
+    const report = buildDryRunReport(
+      makeTask('Analyze this codebase for security vulnerabilities'),
+      makeDecision('claude')
+    );
+    const text = renderDryRunText(report);
+    expect(text).toContain('[DRY RUN]');
+    expect(text).toContain('Task Analysis:');
+    expect(text).toContain('Routing:');
+    expect(text).toContain('Run without --dry-run to execute.');
+  });
+
+  it('includes cost estimate when available', () => {
+    const report = buildDryRunReport(makeTask('Write a simple CLI tool'), makeDecision('claude'));
+    const text = renderDryRunText(report);
+    if (report.costEstimate !== undefined) {
+      expect(text).toContain('Cost Estimate:');
+      expect(text).toContain('Total:');
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli/orchestrate-dry-run.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-dry-run.ts
@@ -1,0 +1,134 @@
+/**
+ * Enriched dry-run output for the orchestrate command.
+ *
+ * Produces a task analysis report showing what nexus-agents WOULD do,
+ * including complexity estimate, detected category, estimated tokens,
+ * and cost projection against the canonical model registry.
+ *
+ * @module cli/orchestrate-dry-run
+ * (Source: Issue #1946)
+ */
+
+import type { CliTask } from '../cli-adapters/index.js';
+import type { CompositeRoutingDecision } from '../cli-adapters/index.js';
+import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
+import { calculateCost } from '../core/index.js';
+import { getCliModelName, getDefaultModelForCli } from '../config/model-config-helpers.js';
+
+/** Estimated output tokens as a fraction of input tokens (typical LLM ratio). */
+const DEFAULT_OUTPUT_RATIO = 0.6;
+
+/** Structured dry-run report. */
+export interface DryRunReport {
+  readonly analysis: {
+    readonly taskType: string;
+    readonly taskTypeConfidence: number;
+    readonly reasoningType: string;
+    readonly reasoningConfidence: number;
+    readonly complexity: string;
+    readonly complexityScore: number;
+    readonly estimatedInputTokens: number;
+    readonly estimatedOutputTokens: number;
+  };
+  readonly costEstimate:
+    | {
+        readonly model: string;
+        readonly inputUsd: number;
+        readonly outputUsd: number;
+        readonly totalUsd: number;
+      }
+    | undefined;
+  readonly routing: {
+    readonly selectedCli: string;
+    readonly modelId: string;
+    readonly reason: string;
+    readonly confidence: number;
+  };
+}
+
+/**
+ * Build an enriched dry-run report for the given task + routing decision.
+ */
+export function buildDryRunReport(task: CliTask, decision: CompositeRoutingDecision): DryRunReport {
+  const analyzer = createSharedTaskAnalyzer();
+  // Analyzer accepts task content string or a full Task; pass content string.
+  const analysis = analyzer.analyze(task.content);
+  const estimatedInputTokens = analyzer.estimateTokens(task.content);
+  const estimatedOutputTokens = Math.round(estimatedInputTokens * DEFAULT_OUTPUT_RATIO);
+
+  const modelId = getCliModelName(getDefaultModelForCli(decision.cliName));
+  const costUsd = calculateCost(modelId, estimatedInputTokens, estimatedOutputTokens);
+  const inputCostUsd = calculateCost(modelId, estimatedInputTokens, 0);
+  const outputCostUsd = calculateCost(modelId, 0, estimatedOutputTokens);
+
+  return {
+    analysis: {
+      taskType: analysis.taskType,
+      taskTypeConfidence: analysis.taskTypeConfidence,
+      reasoningType: analysis.reasoningType,
+      reasoningConfidence: analysis.reasoningConfidence,
+      complexity: analysis.complexity,
+      complexityScore: analysis.complexityScore,
+      estimatedInputTokens,
+      estimatedOutputTokens,
+    },
+    costEstimate:
+      costUsd !== undefined && inputCostUsd !== undefined && outputCostUsd !== undefined
+        ? {
+            model: modelId,
+            inputUsd: inputCostUsd,
+            outputUsd: outputCostUsd,
+            totalUsd: costUsd,
+          }
+        : undefined,
+    routing: {
+      selectedCli: decision.cliName,
+      modelId,
+      reason: decision.reason,
+      confidence: decision.confidence,
+    },
+  };
+}
+
+/** Render the dry-run report as human-readable text. */
+export function renderDryRunText(report: DryRunReport): string {
+  const lines: string[] = ['[DRY RUN] Task would execute with the following plan:', ''];
+
+  lines.push('Task Analysis:');
+  lines.push(
+    `  Category:       ${report.analysis.taskType} (confidence: ${formatPct(report.analysis.taskTypeConfidence)})`
+  );
+  lines.push(
+    `  Reasoning type: ${report.analysis.reasoningType} (confidence: ${formatPct(report.analysis.reasoningConfidence)})`
+  );
+  lines.push(
+    `  Complexity:     ${report.analysis.complexity} (score: ${report.analysis.complexityScore.toFixed(2)})`
+  );
+  lines.push(
+    `  Est. tokens:    ~${String(report.analysis.estimatedInputTokens)} input / ~${String(report.analysis.estimatedOutputTokens)} output`
+  );
+
+  if (report.costEstimate !== undefined) {
+    lines.push('');
+    lines.push('Cost Estimate:');
+    lines.push(`  Model:  ${report.costEstimate.model}`);
+    lines.push(
+      `  Input:  $${report.costEstimate.inputUsd.toFixed(6)} · Output: $${report.costEstimate.outputUsd.toFixed(6)}`
+    );
+    lines.push(`  Total:  $${report.costEstimate.totalUsd.toFixed(6)}`);
+  }
+
+  lines.push('');
+  lines.push('Routing:');
+  lines.push(`  Selected:   ${report.routing.selectedCli} (${report.routing.modelId})`);
+  lines.push(`  Reason:     ${report.routing.reason}`);
+  lines.push(`  Confidence: ${formatPct(report.routing.confidence)}`);
+
+  lines.push('');
+  lines.push('Run without --dry-run to execute.');
+  return lines.join('\n');
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}

--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -38,6 +38,7 @@ import { detectGeminiCli, configureGemini } from './setup-gemini.js';
 import { detectCodexCli, configureCodex } from './setup-codex.js';
 import { VERSION } from '../version.js';
 import { runWizard } from './setup-wizard.js';
+import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-permissions.js';
 
 // ============================================================================
 // Output Helpers
@@ -752,6 +753,14 @@ function printDetailSections(result: SetupResult): void {
   }
   if (result.rulesPath !== undefined) printRulesFile(result.rulesPath);
   if (result.dataDirPath !== undefined) printDataDirSection(result);
+  printPermissionsSuggestion();
+}
+
+/** Prints the Claude Code permissions suggestion (#1945). */
+function printPermissionsSuggestion(): void {
+  const snippet = generatePermissionsSnippet('all');
+  const banner = buildPermissionsBanner(snippet);
+  writeLine(banner);
 }
 
 /** Prints the data directory section. */

--- a/packages/nexus-agents/src/cli/setup-permissions.test.ts
+++ b/packages/nexus-agents/src/cli/setup-permissions.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for Claude Code permissions snippet generator (#1945).
+ */
+import { describe, it, expect } from 'vitest';
+import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-permissions.js';
+
+describe('generatePermissionsSnippet', () => {
+  it('generates readonly snippet with only safe read tools', () => {
+    const snippet = generatePermissionsSnippet('readonly');
+    const parsed = JSON.parse(snippet) as string[];
+    expect(parsed.every((p) => p.startsWith('mcp__nexus-agents__'))).toBe(true);
+    // Should NOT contain execution tools
+    expect(parsed).not.toContain('mcp__nexus-agents__orchestrate');
+    expect(parsed).not.toContain('mcp__nexus-agents__create_expert');
+    // Should contain read-only tools
+    expect(parsed).toContain('mcp__nexus-agents__list_experts');
+    expect(parsed).toContain('mcp__nexus-agents__weather_report');
+    expect(parsed).toContain('mcp__nexus-agents__memory_query');
+  });
+
+  it('generates all snippet with execution + read tools', () => {
+    const snippet = generatePermissionsSnippet('all');
+    const parsed = JSON.parse(snippet) as string[];
+    expect(parsed).toContain('mcp__nexus-agents__orchestrate');
+    expect(parsed).toContain('mcp__nexus-agents__create_expert');
+    expect(parsed).toContain('mcp__nexus-agents__consensus_vote');
+    expect(parsed).toContain('mcp__nexus-agents__list_experts');
+  });
+
+  it('defaults to all level', () => {
+    const snippet = generatePermissionsSnippet();
+    const parsed = JSON.parse(snippet) as string[];
+    expect(parsed).toContain('mcp__nexus-agents__orchestrate');
+  });
+
+  it('returns entries sorted alphabetically', () => {
+    const snippet = generatePermissionsSnippet();
+    const parsed = JSON.parse(snippet) as string[];
+    const sorted: string[] = [...parsed].sort((a, b) => a.localeCompare(b));
+    expect(parsed).toEqual(sorted);
+  });
+
+  it('produces valid JSON array of strings', () => {
+    const snippet = generatePermissionsSnippet();
+    const parse = (): unknown => JSON.parse(snippet) as unknown;
+    expect(parse).not.toThrow();
+    const parsed = parse();
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+});
+
+describe('buildPermissionsBanner', () => {
+  it('wraps snippet with explanatory text', () => {
+    const snippet = generatePermissionsSnippet('readonly');
+    const banner = buildPermissionsBanner(snippet);
+    expect(banner).toContain("'don't ask' mode");
+    expect(banner).toContain('permissions.allow');
+    expect(banner).toContain('~/.claude/settings.json');
+    expect(banner).toContain(snippet);
+    expect(banner).toContain('1945');
+  });
+});

--- a/packages/nexus-agents/src/cli/setup-permissions.ts
+++ b/packages/nexus-agents/src/cli/setup-permissions.ts
@@ -1,0 +1,85 @@
+/**
+ * Claude Code permissions snippet generator (#1945).
+ *
+ * In "don't ask" permission mode, Claude Code hard-rejects MCP tool calls
+ * that aren't in the allowlist. For nexus-agents to be usable for agentic
+ * dogfooding (orchestrate, create_expert, consensus_vote), the tools must
+ * be pre-approved in ~/.claude/settings.json.
+ *
+ * This module generates a recommended snippet for users to paste into
+ * their settings.json. We do NOT auto-write permissions — that would be
+ * a security footgun.
+ *
+ * @module cli/setup-permissions
+ */
+
+/** MCP tool names that are safe to pre-approve (read-only or idempotent). */
+const SAFE_READONLY_TOOLS = [
+  'list_experts',
+  'list_workflows',
+  'weather_report',
+  'memory_query',
+  'memory_stats',
+  'query_trace',
+  'research_query',
+  'research_analyze',
+  'research_discover',
+  'research_synthesize',
+  'repo_analyze',
+  'repo_security_plan',
+  'extract_symbols',
+  'search_codebase',
+] as const;
+
+/** MCP tools that execute tasks but are commonly used for dogfooding. */
+const SAFE_EXECUTION_TOOLS = [
+  'orchestrate',
+  'create_expert',
+  'execute_expert',
+  'consensus_vote',
+  'delegate_to_model',
+  'run_workflow',
+  'issue_triage',
+  'registry_import',
+] as const;
+
+export type PermissionLevel = 'readonly' | 'all';
+
+/**
+ * Generate a JSON snippet of recommended permissions for Claude Code's
+ * `~/.claude/settings.json` to pre-approve nexus-agents MCP tools.
+ *
+ * Users paste this into the `permissions.allow` array.
+ */
+export function generatePermissionsSnippet(level: PermissionLevel = 'all'): string {
+  const tools =
+    level === 'readonly'
+      ? [...SAFE_READONLY_TOOLS]
+      : [...SAFE_READONLY_TOOLS, ...SAFE_EXECUTION_TOOLS];
+
+  const permissions = tools.map((t) => `mcp__nexus-agents__${t}`).sort();
+  return JSON.stringify(permissions, null, 2);
+}
+
+/**
+ * Return a human-readable banner explaining the permissions snippet,
+ * for inclusion in `nexus-agents setup` output.
+ */
+export function buildPermissionsBanner(snippet: string): string {
+  return [
+    '',
+    '--- Claude Code Permissions (optional) ---',
+    '',
+    "To use nexus-agents MCP tools in 'don't ask' mode (autonomous/headless",
+    'Claude Code sessions), add these entries to the `permissions.allow` array',
+    'in your `~/.claude/settings.json`:',
+    '',
+    snippet,
+    '',
+    'Without these, each MCP tool call will prompt for approval in interactive',
+    'mode, or be rejected outright in `dangerously-skip-permissions` mode.',
+    '',
+    'Reference: https://github.com/williamzujkowski/nexus-agents/issues/1945',
+    '',
+  ].join('\n');
+}

--- a/packages/nexus-agents/tsconfig.docs.json
+++ b/packages/nexus-agents/tsconfig.docs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.fuzz.test.ts",
+    "src/testing/**",
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/nexus-agents/typedoc.json
+++ b/packages/nexus-agents/typedoc.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.docs.json",
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/*.fuzz.test.ts"],
   "out": "docs/api",
   "name": "nexus-agents",
   "includeVersion": true,


### PR DESCRIPTION
## Summary

Three fixes bundled on this branch, all from dogfooding issues filed this session:

### 1. TypeDoc test exclusion (#1947)

Fixes recurring CI release failures. TypeDoc runs tsc internally — any type error in a test file broke the check even though production build and tests passed. Added `tsconfig.docs.json` that excludes `*.test.ts`, `*.spec.ts`, `*.fuzz.test.ts`, and `src/testing/**`. Verified: test file with intentional strict-null errors no longer trips TypeDoc; `pnpm typecheck` still catches them.

### 2. Enriched orchestrate --dry-run (#1946)

`nexus-agents orchestrate ... --dry-run` now prints task analysis, cost estimate, and routing instead of just the routing line.

**Before:**
```
Task completed using gemini (345ms)
Routing: Selected gemini, TOPSIS score 1.00, UCB score 1.40
Confidence: 63.8%
```

**After:**
```
[DRY RUN] Task would execute with the following plan:

Task Analysis:
  Category:       code_implementation (confidence: 47.6%)
  Reasoning type: unknown (confidence: 0.0%)
  Complexity:     simple (score: 0.01)
  Est. tokens:    ~519 input / ~311 output

Cost Estimate:
  Model:  gemini-3.1-pro-preview
  Input:  \$0.001038 · Output: \$0.003732
  Total:  \$0.004770

Routing:
  Selected:   gemini (gemini-3.1-pro-preview)
  Reason:     Selected gemini, within budget, TOPSIS 0.80, UCB 1.36
  Confidence: 56.6%

Run without --dry-run to execute.
```

Uses `SharedTaskAnalyzer` for classification + token estimation, `calculateCost` against the canonical model registry. Output ratio defaults to 60% of input.

### 3. Claude Code MCP permissions snippet (#1945)

When nexus-agents is installed as an MCP server, its tools are blocked in 'don't ask' mode (autonomous/headless Claude Code sessions) unless pre-approved in `~/.claude/settings.json`. Added `generatePermissionsSnippet()` + `buildPermissionsBanner()` that produce a ready-to-paste JSON snippet for the permissions.allow array. Wired into `nexus-agents setup` output so users see it on first install.

Two levels:
- `readonly`: 14 list/query/stats tools
- `all` (default): adds 8 execution tools (orchestrate, create_expert, consensus_vote, execute_expert, delegate_to_model, run_workflow, issue_triage, registry_import) — 22 entries

Deliberately does NOT auto-write to settings.json — permissions are a security boundary.

## Test plan

- [x] `pnpm --filter nexus-agents lint` — clean
- [x] `pnpm --filter nexus-agents typecheck` — clean
- [x] 11 new tests across 2 new test files pass
- [x] 60 existing setup-command tests still pass
- [x] End-to-end: `nexus-agents orchestrate --dry-run` prints new rich output

🤖 Generated with [Claude Code](https://claude.com/claude-code)