### PR TITLE
docs: correct stale tool/expert/memory counts across tier-1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Consensus-validated response — outcomes feed back into routing for next time
                          │  ┌────▼─────┐  └──────────────┘ │
                          │  │Composite │                    │
                          │  │Router    │  ┌──────────────┐ │
-                         │  │(9 stages)│  │ 8 Memory     │ │
+                         │  │(9 stages)│  │ 5 Memory     │ │
                          │  └────┬─────┘  │ Backends     │ │
                          │       │        └──────────────┘ │
                          └───────┼─────────────────────────┘

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ nexus-agents makes your AI coding tools work together intelligently. It coordina
 **What it does for you:**
 
 - **Routes intelligently** — LinUCB bandit + TOPSIS scoring + adaptive bonuses pick the right model for each task, learned from real outcomes
-- **Enforces quality** — consensus voting (7 algorithms including Bayesian higher-order), QA review loops, security scans with SARIF
-- **Learns over time** — 8 memory backends track what works, feeding routing, planning, and research decisions
+- **Enforces quality** — consensus voting (6 strategies including Bayesian higher-order), QA review loops, security scans with SARIF
+- **Learns over time** — 5 memory backends (session, belief, agentic, adaptive, typed) track what works, feeding routing, planning, and research decisions
 - **Runs a full dev pipeline** — research papers, plan architecture, vote on proposals, decompose into tasks, implement, QA review, ship
-- **Connects everything** — 29 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
+- **Connects everything** — 30 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
 
 ```
 You: "Review this code for security and performance"
@@ -50,7 +50,7 @@ Consensus-validated response — outcomes feed back into routing for next time
                          │       nexus-agents server        │
                          │                                  │
                          │  ┌──────────┐  ┌──────────────┐ │
-                         │  │ 29 MCP   │  │ Dev Pipeline  │ │
+                         │  │ 30 MCP   │  │ Dev Pipeline  │ │
                          │  │ Tools    │  │ research→plan │ │
                          │  └────┬─────┘  │ →vote→impl   │ │
                          │       │        │ →QA→ship      │ │
@@ -108,17 +108,17 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 
 ## Capabilities
 
-| Category                       | Details                                                                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Intelligent Routing**        | 9-stage CompositeRouter: budget-aware, LinUCB bandit, TOPSIS multi-criteria, preference-trained, weather-adaptive. Learns from outcomes.    |
-| **Multi-Expert Orchestration** | 9 built-in expert types (code, architecture, security, testing, docs, devops, research, PM, UX) coordinated by TechLead/Orchestrator agents |
-| **Consensus Voting**           | 7 algorithms: simple majority, supermajority, unanimous, weighted, ordered-weighted, higher-order Bayesian, incremental quorum              |
-| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run               |
-| **Memory & Learning**          | 8 backends (session, belief, adaptive, routing, graph, hybrid, agentic, typed). Cross-session persistence. Outcomes feed routing.           |
-| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                    |
-| **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                            |
-| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                       |
-| **29 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                         |
+| Category                       | Details                                                                                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Intelligent Routing**        | 9-stage CompositeRouter: budget-aware, LinUCB bandit, TOPSIS multi-criteria, preference-trained, weather-adaptive. Learns from outcomes.                                         |
+| **Multi-Expert Orchestration** | 11 built-in expert types (code, architecture, security, testing, docs, devops, research, PM, UX, infrastructure, data-visualization) coordinated by TechLead/Orchestrator agents |
+| **Consensus Voting**           | 6 strategies: simple_majority, supermajority, unanimous, higher_order (Bayesian correlation-aware), opinion_wise, proof_of_learning                                              |
+| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run                                                    |
+| **Memory & Learning**          | 5 user-facing backends (session, belief, agentic, adaptive, typed). Cross-session persistence. Outcomes feed routing.                                                            |
+| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                         |
+| **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                                                                 |
+| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                                                            |
+| **30 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                              |
 
 ---
 
@@ -136,6 +136,7 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 | PM             | Product management, requirements, priorities |
 | UX             | User experience, usability, accessibility    |
 | Infrastructure | Server management, bare metal, networking    |
+| Data Viz       | Charts, dashboards, visual data presentation |
 
 ---
 
@@ -209,6 +210,7 @@ When running as an MCP server, the following tools are available:
 | `extract_symbols`         | Extract code symbols from source files for analysis      |
 | `search_codebase`         | Search codebase for patterns, symbols, or text           |
 | `run_dev_pipeline`        | Full dev pipeline: research, plan, vote, implement, QA   |
+| `run_pipeline`            | Execute a pipeline plugin by name with typed input       |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ keywords: [documentation, index, reference, navigation, docs]
 
 # Nexus Agents Documentation
 
-**Canonical Documentation Index** | Last Updated: 2026-03-01 (infrastructure skill added, 15 skills total)
+**Canonical Documentation Index** | Last Updated: 2026-04-17 (18 skills, 30 MCP tools, 11 expert types, 11 workflow templates)
 
 This is the **single source of truth** for all nexus-agents documentation. All documentation must be indexed here to be considered valid.
 

--- a/docs/distribution/LISTING_SUBMISSIONS.md
+++ b/docs/distribution/LISTING_SUBMISSIONS.md
@@ -10,12 +10,12 @@ Intelligent orchestration platform for AI coding tools — routes tasks to the b
 
 ### Medium Description (for directories)
 
-nexus-agents makes your AI coding tools work together intelligently. It coordinates Claude, Codex, Gemini, and OpenCode — routing each task to the best model using data-driven algorithms (LinUCB bandit, TOPSIS scoring), validating outputs through multi-model consensus voting, and continuously improving through outcome-driven learning. 29 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.
+nexus-agents makes your AI coding tools work together intelligently. It coordinates Claude, Codex, Gemini, and OpenCode — routing each task to the best model using data-driven algorithms (LinUCB bandit, TOPSIS scoring), validating outputs through multi-model consensus voting, and continuously improving through outcome-driven learning. 30 MCP tools, 5 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.
 
 ### Awesome List Entry
 
 ```markdown
-- [nexus-agents](https://github.com/williamzujkowski/nexus-agents) - Intelligent orchestration platform that routes tasks to the best AI model (Claude, Codex, Gemini, OpenCode) using LinUCB bandits, validates through consensus voting, and learns from outcomes. 29 tools including dev pipeline, research discovery, memory, and codebase intelligence.
+- [nexus-agents](https://github.com/williamzujkowski/nexus-agents) - Intelligent orchestration platform that routes tasks to the best AI model (Claude, Codex, Gemini, OpenCode) using LinUCB bandits, validates through consensus voting, and learns from outcomes. 30 tools including dev pipeline, research discovery, memory, and codebase intelligence.
 ```
 
 ### Category Tags

--- a/docs/distribution/PUBLISHING_GUIDE.md
+++ b/docs/distribution/PUBLISHING_GUIDE.md
@@ -30,7 +30,7 @@ Fill in:
 
 - **Name:** nexus-agents
 - **Repository:** https://github.com/williamzujkowski/nexus-agents
-- **Description:** Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 29 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.
+- **Description:** Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 30 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.
 
 The `.claude-plugin/plugin.json` is already in the repo root.
 
@@ -59,7 +59,7 @@ Visit: https://mcpservers.org/submit
 Fill in:
 
 - **Server Name:** nexus-agents
-- **Short Description:** Intelligent orchestration platform that routes tasks to the best AI model using LinUCB bandits, validates through consensus voting, and learns from outcomes. 29 MCP tools, dev pipeline, 8 memory backends.
+- **Short Description:** Intelligent orchestration platform that routes tasks to the best AI model using LinUCB bandits, validates through consensus voting, and learns from outcomes. 30 MCP tools, dev pipeline, 5 memory backends.
 - **Link:** https://github.com/williamzujkowski/nexus-agents
 - **Category:** Development
 - **Contact Email:** williamzujkowski@gmail.com

--- a/docs/v2/00-executive-summary.md
+++ b/docs/v2/00-executive-summary.md
@@ -6,7 +6,7 @@ _Nexus Agents reviewing Nexus Agents. No marketing. Evidence-backed._
 
 ## What Nexus Agents Is Today
 
-An intelligent orchestration platform for AI coding tools (650+ source files, 900+ test files) that coordinates Claude, Gemini, Codex, and OpenCode CLIs via 29 MCP tools. It routes tasks to the best model using data-driven algorithms (LinUCB bandit, TOPSIS), validates through multi-model consensus, and learns from outcomes across sessions. Users can orchestrate tasks, run consensus votes, execute a full dev pipeline (research→plan→vote→implement→QA), and run graph workflows.
+An intelligent orchestration platform for AI coding tools (650+ source files, 900+ test files) that coordinates Claude, Gemini, Codex, and OpenCode CLIs via 30 MCP tools. It routes tasks to the best model using data-driven algorithms (LinUCB bandit, TOPSIS), validates through multi-model consensus, and learns from outcomes across sessions. Users can orchestrate tasks, run consensus votes, execute a full dev pipeline (research→plan→vote→implement→QA), and run graph workflows.
 
 ## What's Wrong
 

--- a/packages/nexus-agents/docs/api/media/README.md
+++ b/packages/nexus-agents/docs/api/media/README.md
@@ -17,10 +17,10 @@ nexus-agents makes your AI coding tools work together intelligently. It coordina
 **What it does for you:**
 
 - **Routes intelligently** — LinUCB bandit + TOPSIS scoring + adaptive bonuses pick the right model for each task, learned from real outcomes
-- **Enforces quality** — consensus voting (7 algorithms including Bayesian higher-order), QA review loops, security scans with SARIF
-- **Learns over time** — 8 memory backends track what works, feeding routing, planning, and research decisions
+- **Enforces quality** — consensus voting (6 strategies including Bayesian higher-order), QA review loops, security scans with SARIF
+- **Learns over time** — 5 memory backends (session, belief, agentic, adaptive, typed) track what works, feeding routing, planning, and research decisions
 - **Runs a full dev pipeline** — research papers, plan architecture, vote on proposals, decompose into tasks, implement, QA review, ship
-- **Connects everything** — 29 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
+- **Connects everything** — 30 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
 
 ```
 You: "Review this code for security and performance"
@@ -50,14 +50,14 @@ Consensus-validated response — outcomes feed back into routing for next time
                          │       nexus-agents server        │
                          │                                  │
                          │  ┌──────────┐  ┌──────────────┐ │
-                         │  │ 29 MCP   │  │ Dev Pipeline  │ │
+                         │  │ 30 MCP   │  │ Dev Pipeline  │ │
                          │  │ Tools    │  │ research→plan │ │
                          │  └────┬─────┘  │ →vote→impl   │ │
                          │       │        │ →QA→ship      │ │
                          │  ┌────▼─────┐  └──────────────┘ │
                          │  │Composite │                    │
                          │  │Router    │  ┌──────────────┐ │
-                         │  │(9 stages)│  │ 8 Memory     │ │
+                         │  │(9 stages)│  │ 5 Memory     │ │
                          │  └────┬─────┘  │ Backends     │ │
                          │       │        └──────────────┘ │
                          └───────┼─────────────────────────┘
@@ -108,17 +108,17 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 
 ## Capabilities
 
-| Category                       | Details                                                                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Intelligent Routing**        | 9-stage CompositeRouter: budget-aware, LinUCB bandit, TOPSIS multi-criteria, preference-trained, weather-adaptive. Learns from outcomes.    |
-| **Multi-Expert Orchestration** | 9 built-in expert types (code, architecture, security, testing, docs, devops, research, PM, UX) coordinated by TechLead/Orchestrator agents |
-| **Consensus Voting**           | 7 algorithms: simple majority, supermajority, unanimous, weighted, ordered-weighted, higher-order Bayesian, incremental quorum              |
-| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run               |
-| **Memory & Learning**          | 8 backends (session, belief, adaptive, routing, graph, hybrid, agentic, typed). Cross-session persistence. Outcomes feed routing.           |
-| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                    |
-| **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                            |
-| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                       |
-| **29 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                         |
+| Category                       | Details                                                                                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Intelligent Routing**        | 9-stage CompositeRouter: budget-aware, LinUCB bandit, TOPSIS multi-criteria, preference-trained, weather-adaptive. Learns from outcomes.                                         |
+| **Multi-Expert Orchestration** | 11 built-in expert types (code, architecture, security, testing, docs, devops, research, PM, UX, infrastructure, data-visualization) coordinated by TechLead/Orchestrator agents |
+| **Consensus Voting**           | 6 strategies: simple_majority, supermajority, unanimous, higher_order (Bayesian correlation-aware), opinion_wise, proof_of_learning                                              |
+| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run                                                    |
+| **Memory & Learning**          | 5 user-facing backends (session, belief, agentic, adaptive, typed). Cross-session persistence. Outcomes feed routing.                                                            |
+| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                         |
+| **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                                                                 |
+| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                                                            |
+| **30 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                              |
 
 ---
 
@@ -136,6 +136,7 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 | PM             | Product management, requirements, priorities |
 | UX             | User experience, usability, accessibility    |
 | Infrastructure | Server management, bare metal, networking    |
+| Data Viz       | Charts, dashboards, visual data presentation |
 
 ---
 
@@ -209,6 +210,7 @@ When running as an MCP server, the following tools are available:
 | `extract_symbols`         | Extract code symbols from source files for analysis      |
 | `search_codebase`         | Search codebase for patterns, symbols, or text           |
 | `run_dev_pipeline`        | Full dev pipeline: research, plan, vote, implement, QA   |
+| `run_pipeline`            | Execute a pipeline plugin by name with typed input       |
 
 ---
 


### PR DESCRIPTION
## Summary

Docs accuracy audit. Cross-referenced README.md, docs/README.md, CLAUDE.md, and distribution guides against authoritative sources (repo-index.json, actual source code). Fixed **10 numeric inaccuracies** across 5 files.

### Changes by file

**README.md:**
| Claim | Was | Now | Source |
|---|---|---|---|
| MCP tool count (3 places) | 29 | 30 | `jq '.mcp.tools | length' artifacts/repo-index.json` |
| Expert types | 9 | 11 | `create_expert` MCP schema enum |
| Memory backends (2 places, diagram) | 8 | 5 | `memory_write` MCP tool backend enum |
| Consensus strategies | 7 algorithms incl. non-existent "weighted", "ordered-weighted", "incremental quorum" | 6 strategies matching actual `consensus_vote` enum | `mcp/tools/consensus-vote.ts` |
| Available Experts table | 10 rows | 11 rows (added Data Viz) | N/A |
| MCP tools table | 29 rows | 30 rows (added run_pipeline) | `artifacts/repo-index.json` |

**docs/README.md:**
- Last Updated: 2026-03-01 (stale) → 2026-04-17 with accurate counts

**docs/distribution/LISTING_SUBMISSIONS.md, PUBLISHING_GUIDE.md, docs/v2/00-executive-summary.md:**
- "29 MCP tools" → "30 MCP tools" (5 total occurrences)
- "8 memory backends" → "5 memory backends" (2 occurrences)

### Exaggeration audit

Scanned tier-1 docs for marketing language (cutting-edge, revolutionary, seamless, blazing, etc). Found one hit ("state-of-the-art analysis" — accurate technical phrasing for literature review). No exaggerated claims need removal.

### Root cause

Stale counts drifted because the docs weren't regenerated when expert/backend/tool counts changed. The `scripts/inject-governance.ts` already re-counts on release (for CLAUDE.md tool table), but README and distribution docs are free-form prose that isn't auto-generated.

### Optional follow-up

Could add a `docs:check` script that parses numeric claims and validates against `artifacts/repo-index.json`. Filing as a follow-up rather than scope creep here.

## Test plan

- [x] All counts verified against source (`artifacts/repo-index.json`, `create-expert.ts`, `memory-write.ts`, `consensus-vote.ts`)
- [x] No behavior changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)