### PR TITLE
fix(ci): align deploy-website + release workflows to composite setup-node

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,15 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node
 
       - name: Build website
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,16 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: ./.github/actions/setup-node
         with:
-          node-version: '22'
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build all packages
         run: pnpm build


### PR DESCRIPTION
## Summary

Deploy Website has been failing on every push to main since at least 2026-04-17T10:57Z (3+ consecutive failures). Fixing now.

## Root cause

\`\`\`
ERR_PNPM_BROKEN_LOCKFILE: The lockfile is broken:
expected a single document in the stream, but found more
\`\`\`

Deploy workflow used \`pnpm/action-setup@v6.0.0\` directly, while all other workflows use the \`.github/actions/setup-node\` composite which pins \`pnpm/action-setup@v5.0.0\`. The v6 action appears to install a newer/stricter pnpm that rejects our current lockfile structure.

The \`ci.yml\` passes because it uses the composite. The deploy and release manual-publish jobs were the outliers.

## Fix

- \`.github/workflows/deploy-website.yml\`: switched to composite setup-node action
- \`.github/workflows/release.yml\` manual-publish job: same switch

No behavior change — just version normalization across workflows.

## Verification

- [x] Website builds cleanly locally: \`cd website && pnpm build\` → 39 pages in 4s
- [x] \`pnpm install --frozen-lockfile\` works locally on pnpm 9.15.0

## Follow-up consideration

Could pin a specific \`version:\` parameter on \`pnpm/action-setup\` in the composite action itself to make it fully explicit, rather than relying on \`packageManager\` field auto-detection. Filing as a thought, not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)