### PR TITLE
chore(swe-bench): soft-deprecate in-tree wrappers in favor of nexus-eval-swebench (#1966)

### DIFF
--- a/.changeset/deprecate-in-tree-swe-bench.md
+++ b/.changeset/deprecate-in-tree-swe-bench.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+deprecate(swe-bench): mark in-tree SWE-bench wrappers as superseded by nexus-eval-swebench (#1966)
+
+The standalone [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench) package (built on the `BenchmarkAdapter` contract) is now the recommended way to run SWE-bench from nexus-agents.
+
+Changes in this release:
+
+- `nexus-agents swe-bench` CLI prints a one-time deprecation warning on invocation. Suppress with `NEXUS_SUPPRESS_SWEBENCH_DEPRECATION=1`.
+- `printSweBenchHelp()` surfaces the migration path at the top of `--help` output.
+- `src/exports/swe-bench.ts` barrel has a deprecation notice in its docstring with a migration example.
+
+The in-tree runner and types remain fully functional and exported — `nexus-eval-swebench` itself consumes `SWEBenchRunner` via peer dep, so we cannot remove them without a breaking change. This deprecation is informational only; no runtime behavior changes.
+
+Migration:
+
+```ts
+// Before
+import { SWEBenchRunner } from 'nexus-agents';
+const runner = new SWEBenchRunner({ variant: 'lite' });
+
+// After (recommended)
+import { runBenchmark } from 'nexus-agents';
+import { SweBenchAdapter } from 'nexus-eval-swebench';
+const summary = await runBenchmark(new SweBenchAdapter({ variant: 'lite' }), {});
+```

--- a/packages/nexus-agents/src/cli/swe-bench-command.ts
+++ b/packages/nexus-agents/src/cli/swe-bench-command.ts
@@ -463,6 +463,10 @@ export function printSweBenchHelp(): void {
   console.log(`
 Usage: nexus-agents swe-bench <subcommand> [options]
 
+DEPRECATED: This command is being superseded by \`nexus-eval-swebench\`
+(https://github.com/williamzujkowski/nexus-eval-swebench). It remains
+functional for backwards compatibility but will not receive new features.
+
 Subcommands:
   run       Run agents on SWE-bench instances
   status    Show progress and completed predictions
@@ -488,12 +492,27 @@ Evaluate options:
 `);
 }
 
+let deprecationWarned = false;
+
+function emitDeprecationWarning(): void {
+  if (deprecationWarned) return;
+  deprecationWarned = true;
+  if (process.env['NEXUS_SUPPRESS_SWEBENCH_DEPRECATION'] === '1') return;
+  console.warn(
+    '[deprecation] `nexus-agents swe-bench` is superseded by `nexus-eval-swebench` ' +
+      '(https://github.com/williamzujkowski/nexus-eval-swebench). This in-tree command ' +
+      'remains functional but will not receive new benchmark features. Suppress this ' +
+      'warning with NEXUS_SUPPRESS_SWEBENCH_DEPRECATION=1.'
+  );
+}
+
 /** Main SWE-bench command handler. */
 export async function sweBenchCommand(args: readonly string[]): Promise<number> {
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     printSweBenchHelp();
     return 0;
   }
+  emitDeprecationWarning();
   const options = parseSweBenchArgs(args);
   try {
     const result =

--- a/packages/nexus-agents/src/exports/swe-bench.ts
+++ b/packages/nexus-agents/src/exports/swe-bench.ts
@@ -1,7 +1,30 @@
 /**
- * SWE-Bench barrel exports
+ * SWE-Bench barrel exports.
+ *
+ * NOTE (deprecation, #1960/#1966): This in-tree SWE-bench suite is being
+ * superseded by the standalone [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench)
+ * package, which implements the `BenchmarkAdapter` contract and is the
+ * recommended integration point going forward. These exports remain
+ * functional for backwards compatibility and will be kept for at least
+ * one minor version cycle.
+ *
+ * Migration:
+ *
+ *   // Before (in-tree):
+ *   import { SWEBenchRunner } from 'nexus-agents';
+ *
+ *   // After (standalone, recommended):
+ *   import { runBenchmark } from 'nexus-agents';
+ *   import { SweBenchAdapter } from 'nexus-eval-swebench';
+ *   const summary = await runBenchmark(new SweBenchAdapter({ variant: 'lite' }), {});
+ *
+ * The underlying runner types (SWEBenchRunner, SWEBenchInstance, etc.)
+ * are still exported from here because `nexus-eval-swebench` depends on
+ * them via peer dep. Removing them is a breaking change tracked
+ * separately.
+ *
  * @module exports/swe-bench
- * (Source: Issue #257 - SWE-Bench Evaluation)
+ * (Source: Issue #257 - SWE-Bench Evaluation; Issue #1960 extraction epic)
  */
 
 export * from '../swe-bench/index.js';


### PR DESCRIPTION
## Summary

- CLI \`nexus-agents swe-bench\` now emits a one-time deprecation warning on invocation (suppress via \`NEXUS_SUPPRESS_SWEBENCH_DEPRECATION=1\`).
- \`--help\` output surfaces the migration path to [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench) at the top.
- \`src/exports/swe-bench.ts\` barrel docstring documents the deprecation with a migration example.

## Why soft, not hard

\`nexus-eval-swebench\` consumes \`SWEBenchRunner\` and the SWEBench* types via peer dep, so removing the exports is not possible without a breaking change to the ecosystem package. This is an informational (soft) deprecation — runtime behavior is unchanged.

## Test plan

- [x] \`pnpm vitest run src/cli/swe-bench-command.test.ts src/swe-bench/\` — 744 tests across 38 files, all pass
- [x] Changeset added (\`patch\` bump)

Closes #1966. Completes the extraction arc opened in #1960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)