### PR TITLE
feat(security): ClawGuard skeleton — types + off-mode deriver + enforcer (#1977 partial)

### DIFF
--- a/.changeset/1977-clawguard-skeleton.md
+++ b/.changeset/1977-clawguard-skeleton.md
@@ -1,0 +1,36 @@
+---
+'nexus-agents': minor
+---
+
+feat(security): add access-constraint-deriver skeleton (#1977 partial)
+
+Lands the skeleton module for ClawGuard-style per-task tool access
+policies (arxiv-2604.11790). Current state is **skeleton only** —
+off/audit/enforce modes all return a bypass (allow-all) policy.
+
+**New exports from `nexus-agents/security`:**
+
+- `deriveAccessPolicy(objective): Promise<TaskAccessPolicy>` — returns a bypass policy in all modes today
+- `checkAccess(toolName, policy): AccessDecision` — enforcer; passes through under bypass
+- `resolveAccessPolicyMode(env?): 'off' | 'audit' | 'enforce'` — reads `NEXUS_ACCESS_POLICY_MODE`
+- `TaskAccessPolicy`, `AccessDecision`, `AccessPolicyMode`, `AccessOperation` types + Zod schemas
+
+**Runtime behavior: unchanged.** Default `NEXUS_ACCESS_POLICY_MODE=off` is a no-op. Dispatch path is NOT yet wired to the enforcer; that lands when the full LLM-derivation implementation arrives (follow-up commit).
+
+**Why land the skeleton separately:**
+
+Design was vote-approved in #1977 with 7 mandatory PR conditions. This PR covers conditions that can land without the LLM integration:
+
+- ✅ Types + Zod validation (condition 2)
+- ✅ Result-style `AccessDecision` discriminated union (condition 2)
+- ✅ Deterministic tests for the skeleton surface (condition 7)
+- ⏳ UnifiedAdapterRegistry LLM call (condition 1) — deferred
+- ⏳ Hardcoded unbypassable denylist (condition 3) — deferred
+- ⏳ Trust-tier gating on objective (condition 4) — deferred
+- ⏳ Timeout + cache (condition 5) — deferred
+- ⏳ <500ms p95 validation (condition 6) — deferred
+
+17 tests cover mode resolution, objective hashing, skeleton derivation,
+and enforcer contract (allow/deny/log-and-allow).
+
+Full security suite passes (1640/1640).

--- a/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
@@ -1,0 +1,27 @@
+/**
+ * Access Constraint Deriver — Configuration (#1977).
+ *
+ * Reads the NEXUS_ACCESS_POLICY_MODE env var to determine operating mode.
+ * Default is `off` during initial rollout; switch to `audit` once the module
+ * is wired into the dispatch path with telemetry; switch to `enforce` only
+ * after empirical validation per the vote conditions on issue #1977.
+ *
+ * @module security/access-constraint-deriver/config
+ */
+
+import { AccessPolicyModeSchema, type AccessPolicyMode } from './types.js';
+
+/**
+ * Resolves the current access-policy mode from the environment.
+ *
+ * Returns `off` (safe default) if the env var is unset, empty, or invalid.
+ * Invalid values are silently coerced — they are never a fatal startup error,
+ * because this is a security layer and production must not fail-closed on a
+ * misconfiguration.
+ */
+export function resolveAccessPolicyMode(env: NodeJS.ProcessEnv = process.env): AccessPolicyMode {
+  const raw = env['NEXUS_ACCESS_POLICY_MODE'];
+  if (typeof raw !== 'string' || raw.length === 0) return 'off';
+  const parsed = AccessPolicyModeSchema.safeParse(raw.toLowerCase());
+  return parsed.success ? parsed.data : 'off';
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the access-constraint-deriver skeleton (#1977).
+ *
+ * The current implementation is a skeleton: off/audit/enforce modes all
+ * return a bypass policy. These tests lock in the skeleton contract so
+ * later LLM integration cannot regress the public surface.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveAccessPolicy,
+  hashObjective,
+  resolveAccessPolicyMode,
+  checkAccess,
+  TaskAccessPolicySchema,
+} from './index.js';
+
+describe('resolveAccessPolicyMode', () => {
+  it('defaults to "off" when env var is unset', () => {
+    expect(resolveAccessPolicyMode({})).toBe('off');
+  });
+
+  it('returns "audit" when env is set to audit', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'audit' })).toBe('audit');
+  });
+
+  it('returns "enforce" when env is set to enforce', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'enforce' })).toBe('enforce');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'AUDIT' })).toBe('audit');
+  });
+
+  it('falls back to "off" on invalid values', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'lockdown' })).toBe('off');
+  });
+
+  it('falls back to "off" on empty string', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: '' })).toBe('off');
+  });
+});
+
+describe('hashObjective', () => {
+  it('returns a 16-char hex digest', () => {
+    const h = hashObjective('summarize this issue');
+    expect(h).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(hashObjective('same task')).toBe(hashObjective('same task'));
+  });
+
+  it('changes for different inputs', () => {
+    expect(hashObjective('a')).not.toBe(hashObjective('b'));
+  });
+});
+
+describe('deriveAccessPolicy (skeleton)', () => {
+  it('returns a bypass policy with allow-all tools/ops', async () => {
+    const policy = await deriveAccessPolicy('summarize this issue');
+    expect(policy.allowedTools).toBe('*');
+    expect(policy.allowedOperations).toBe('*');
+    expect(policy.source).toBe('bypass');
+  });
+
+  it('includes the objective hash for audit tracking', async () => {
+    const policy = await deriveAccessPolicy('fix the login bug');
+    expect(policy.objectiveHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('returns a valid TaskAccessPolicy per Zod schema', async () => {
+    const policy = await deriveAccessPolicy('test');
+    const parsed = TaskAccessPolicySchema.safeParse(policy);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('sets the mode field from current env', async () => {
+    const policy = await deriveAccessPolicy('test');
+    expect(['off', 'audit', 'enforce']).toContain(policy.mode);
+  });
+});
+
+describe('checkAccess (enforcer)', () => {
+  const bypassPolicy = {
+    allowedTools: '*' as const,
+    allowedPathPatterns: [],
+    allowedOperations: '*' as const,
+    objectiveHash: 'deadbeefcafef00d',
+    derivedAt: '2026-04-19T00:00:00.000Z',
+    source: 'bypass' as const,
+    mode: 'off' as const,
+  };
+
+  it('allows any tool under a bypass policy', () => {
+    expect(checkAccess('gh_issue_close', bypassPolicy).decision).toBe('allow');
+  });
+
+  it('allows tools in the allowedTools list', () => {
+    const policy = { ...bypassPolicy, allowedTools: ['gh_issue_view', 'memory_query'] as const };
+    expect(checkAccess('gh_issue_view', policy).decision).toBe('allow');
+  });
+
+  it('denies tools not in the allowedTools list under enforce mode', () => {
+    const policy = {
+      ...bypassPolicy,
+      allowedTools: ['gh_issue_view'] as const,
+      mode: 'enforce' as const,
+    };
+    const result = checkAccess('gh_issue_close', policy);
+    expect(result.decision).toBe('deny');
+    if (result.decision === 'deny') {
+      expect(result.reason).toContain('gh_issue_close');
+    }
+  });
+
+  it('returns log-and-allow under audit mode for out-of-scope tools', () => {
+    const policy = {
+      ...bypassPolicy,
+      allowedTools: ['gh_issue_view'] as const,
+      mode: 'audit' as const,
+    };
+    const result = checkAccess('gh_issue_close', policy);
+    expect(result.decision).toBe('log-and-allow');
+  });
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/deriver.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/deriver.ts
@@ -1,0 +1,53 @@
+/**
+ * Access Constraint Deriver — Policy derivation (#1977).
+ *
+ * **Current state: skeleton only — `off` and `audit` modes return an
+ * unrestricted `bypass` policy; the LLM-based derivation path is not
+ * yet wired up.** The full implementation (LLM call via
+ * UnifiedAdapterRegistry + regex fallback) is tracked in #1977 and
+ * must satisfy the 7 PR conditions from the design-approval vote
+ * before being enabled.
+ *
+ * @module security/access-constraint-deriver/deriver
+ */
+
+import { createHash } from 'node:crypto';
+import { resolveAccessPolicyMode } from './config.js';
+import type { TaskAccessPolicy, AccessPolicyMode } from './types.js';
+
+/**
+ * Derives an access policy for the given user objective.
+ *
+ * In the current skeleton state this returns a bypass policy (no
+ * restrictions) in all modes. Once the LLM derivation path lands, the
+ * `audit` and `enforce` modes will call the LLM and apply the resulting
+ * constraints; `off` will continue to return bypass.
+ */
+export function deriveAccessPolicy(userObjective: string): Promise<TaskAccessPolicy> {
+  const mode = resolveAccessPolicyMode();
+  // TODO(#1977): in audit/enforce mode, call LLM-based deriver with regex
+  // fallback. Gate on the 7 PR conditions (UnifiedAdapterRegistry, Zod,
+  // hardcoded unbypassable denylist, trust-tier input gating, timeout+cache,
+  // <500ms p95 validation, deterministic mocked tests). The Promise return
+  // type is already correct for the future async LLM integration; the
+  // skeleton resolves synchronously.
+  return Promise.resolve(buildBypassPolicy(userObjective, mode));
+}
+
+/** Builds an unrestricted policy. */
+function buildBypassPolicy(userObjective: string, mode: AccessPolicyMode): TaskAccessPolicy {
+  return {
+    allowedTools: '*',
+    allowedPathPatterns: [],
+    allowedOperations: '*',
+    objectiveHash: hashObjective(userObjective),
+    derivedAt: new Date().toISOString(),
+    source: 'bypass',
+    mode,
+  };
+}
+
+/** Stable SHA-256 hash of a user objective for audit + policy caching. */
+export function hashObjective(userObjective: string): string {
+  return createHash('sha256').update(userObjective, 'utf8').digest('hex').slice(0, 16);
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
@@ -1,0 +1,40 @@
+/**
+ * Access Constraint Deriver — Policy enforcement (#1977).
+ *
+ * Pure function that checks a proposed tool call against a derived policy
+ * and returns an AccessDecision. Enforcement depends on the policy's mode:
+ * `off` and `audit` never block (audit would log to telemetry — wiring TBD);
+ * `enforce` blocks violations.
+ *
+ * @module security/access-constraint-deriver/enforcer
+ */
+
+import type { AccessDecision, TaskAccessPolicy } from './types.js';
+
+/**
+ * Checks a proposed tool call against a task's access policy.
+ *
+ * In skeleton state the policy is always a bypass (allow-all) so this
+ * function always returns `allow`. Once the deriver produces real policies,
+ * this enforcer will match `toolName` against `allowedTools` and return
+ * `deny` (in enforce mode) or `log-and-allow` (in audit mode) when a call
+ * falls outside the derived scope.
+ */
+export function checkAccess(toolName: string, policy: TaskAccessPolicy): AccessDecision {
+  if (policy.allowedTools === '*') return { decision: 'allow' };
+
+  if (policy.allowedTools.includes(toolName)) return { decision: 'allow' };
+
+  if (policy.mode === 'audit') {
+    return {
+      decision: 'log-and-allow',
+      warning: `tool "${toolName}" not in derived policy (audit mode)`,
+    };
+  }
+
+  return {
+    decision: 'deny',
+    reason: `tool "${toolName}" not in derived policy`,
+    matchedRule: 'allowedTools',
+  };
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Access Constraint Deriver — Barrel export (#1977).
+ *
+ * @module security/access-constraint-deriver
+ */
+
+export { resolveAccessPolicyMode } from './config.js';
+export { deriveAccessPolicy, hashObjective } from './deriver.js';
+export { checkAccess } from './enforcer.js';
+export {
+  AccessPolicyModeSchema,
+  AccessPolicySourceSchema,
+  AccessOperationSchema,
+  TaskAccessPolicySchema,
+} from './types.js';
+export type {
+  AccessDecision,
+  AccessOperation,
+  AccessPolicyMode,
+  AccessPolicySource,
+  TaskAccessPolicy,
+} from './types.js';

--- a/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Access Constraint Deriver — Type definitions (#1977).
+ *
+ * Task-objective-derived tool access policies enforced at the tool-call
+ * boundary. See arxiv-2604.11790 (ClawGuard). Design doc: issue #1977.
+ *
+ * @module security/access-constraint-deriver/types
+ */
+
+import { z } from 'zod';
+
+/** Operating modes for the access-constraint-deriver pipeline. */
+export const AccessPolicyModeSchema = z.enum(['off', 'audit', 'enforce']);
+export type AccessPolicyMode = z.infer<typeof AccessPolicyModeSchema>;
+
+/** Source of the derived policy. */
+export const AccessPolicySourceSchema = z.enum(['llm', 'fallback-keyword', 'bypass']);
+export type AccessPolicySource = z.infer<typeof AccessPolicySourceSchema>;
+
+/** Categories of operations a task may perform. */
+export const AccessOperationSchema = z.enum(['read', 'write', 'execute', 'network']);
+export type AccessOperation = z.infer<typeof AccessOperationSchema>;
+
+/**
+ * Task access policy derived from the user objective at task start.
+ *
+ * A policy restricts which tools, paths, and operations the agent may invoke
+ * during execution. `allowedTools: '*'` and `allowedOperations: '*'` represent
+ * an unrestricted policy (used in `off` mode or when derivation is bypassed).
+ */
+export const TaskAccessPolicySchema = z.object({
+  allowedTools: z.union([z.array(z.string()).readonly(), z.literal('*')]),
+  allowedPathPatterns: z.array(z.string()).readonly(),
+  allowedOperations: z.union([z.array(AccessOperationSchema).readonly(), z.literal('*')]),
+  objectiveHash: z.string(),
+  derivedAt: z.string(),
+  source: AccessPolicySourceSchema,
+  mode: AccessPolicyModeSchema,
+});
+export type TaskAccessPolicy = z.infer<typeof TaskAccessPolicySchema>;
+
+/** Result of checking a proposed tool call against a policy. */
+export type AccessDecision =
+  | { readonly decision: 'allow' }
+  | { readonly decision: 'deny'; readonly reason: string; readonly matchedRule: string }
+  | { readonly decision: 'log-and-allow'; readonly warning: string };

--- a/packages/nexus-agents/src/security/index.ts
+++ b/packages/nexus-agents/src/security/index.ts
@@ -83,6 +83,12 @@ export { sanitizeOutput, REDACTED_KEY_PLACEHOLDER } from './output-sanitizer.js'
 // Hostile input firewall (Issue #826)
 export * from './firewall/index.js';
 
+// Access constraint deriver — ClawGuard-style per-task tool allowlist (#1977)
+// NOTE: current implementation is a skeleton; off/audit/enforce modes all
+// return a bypass policy. Full LLM-derivation path gated on the 7 PR conditions
+// from the design-approval vote (see #1977).
+export * from './access-constraint-deriver/index.js';
+
 // SARIF parser for security scanner output (#1682)
 export { parseSarif } from './sarif-parser.js';
 export type { SecurityFinding, SarifParseResult, FindingSeverity } from './sarif-types.js';


### PR DESCRIPTION
Partial implementation of #1977 (ClawGuard / arxiv-2604.11790). Lands the type-safe skeleton; the LLM-derivation path lands in a follow-up.

## What's in this PR

**New module:** \`packages/nexus-agents/src/security/access-constraint-deriver/\`

- \`types.ts\` — TaskAccessPolicy, AccessDecision, 3 operating modes (off/audit/enforce), all with Zod schemas
- \`config.ts\` — \`NEXUS_ACCESS_POLICY_MODE\` env var with safe-default fallback
- \`deriver.ts\` — returns a bypass policy in all modes today; ready for LLM integration
- \`enforcer.ts\` — pure function, allow/deny/log-and-allow semantics per mode
- \`deriver.test.ts\` — 17 tests lock in the public surface
- \`index.ts\` — barrel export
- Exported from \`security/index.ts\`

## Vote-approved conditions (from #1977 design review)

- [x] 2. Types + Zod validation
- [x] 2. Result-style AccessDecision discriminated union
- [x] 7. Deterministic tests (no LLM dependency)
- [ ] 1. UnifiedAdapterRegistry LLM call (follow-up)
- [ ] 3. Hardcoded unbypassable denylist (follow-up)
- [ ] 4. Trust-tier gating on objective (follow-up)
- [ ] 5. Timeout + cache (follow-up)
- [ ] 6. Empirical <500ms p95 validation (follow-up)

## Runtime impact: none

Default mode \`off\` → all policies are bypass → all tool calls allowed. Dispatch path is not yet wired to the enforcer. This PR is pure scaffolding; no behavior change.

## Why land the skeleton separately

- Unblocks type consumers (future callers can import \`TaskAccessPolicy\` now)
- Locks in the public API surface via tests before adding LLM complexity
- Smaller, reviewable diff (356 lines) vs a 500+ LOC all-in-one PR

## Validation

- \`pnpm typecheck\`: 0 errors
- \`pnpm vitest run src/security/\`: 1640/1640 passed
- \`pnpm vitest run src/security/access-constraint-deriver/\`: 17/17 passed
- TypeDoc regenerated

## Test plan

- [ ] CI passes
- [ ] No import regressions in downstream consumers
- [ ] Follow-up PR wires the LLM deriver + denylist + trust-tier gate