### PR TITLE
docs: correct misleading deprecation markers on task-classifier + task-features (#1985)

### DIFF
--- a/.changeset/1985-correct-deprecation.md
+++ b/.changeset/1985-correct-deprecation.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+docs(cli-adapters,coordination): correct task-classifier and task-features deprecation markers (closes #1985)
+
+Audit during #1985 found that the `@deprecated — use SharedTaskAnalyzer`
+markers on two modules were aspirational, not actionable:
+
+- `cli-adapters/task-classifier.ts` exposes `FallbackTaskType` — a 5-value
+  taxonomy (code/research/documentation/analysis/general) tuned for
+  CLI fallback-chain selection. `SharedTaskAnalyzer.TaskTypeCategory`
+  has 9 values tuned for capability routing. They are not interchangeable.
+- `agents/coordination/task-features.ts` exposes `extractTaskFeatures` —
+  produces `ScalingTaskType`-categorized features for the scaling-predictor
+  model. That is a different feature set than `SharedTaskAnalyzer.analyze()`
+  produces for capability routing.
+
+Both modules serve distinct, still-needed purposes. Removed the misleading
+`@deprecated` markers and clarified each module's role + relationship to
+`SharedTaskAnalyzer`. No code behavior changes.
+
+The original issue #1985 ("migrate to SharedTaskAnalyzer") is resolved
+because there is nothing to migrate — the modules were incorrectly
+deprecated. A future unification (if warranted) would be a new design
+proposal, not a 1:1 migration.

--- a/packages/nexus-agents/src/agents/coordination/task-features.ts
+++ b/packages/nexus-agents/src/agents/coordination/task-features.ts
@@ -1,17 +1,19 @@
 /**
- * Task Feature Extraction
+ * Task Feature Extraction for Scaling Prediction
  *
- * Extracts features from tasks for scaling prediction.
- * Uses keyword matching, pattern detection, and structural analysis.
+ * Extracts features from tasks specifically for scaling-predictor inputs
+ * (how many agents to dispatch). Uses keyword matching, pattern detection,
+ * and structural analysis against the `ScalingTaskType` taxonomy.
  *
- * @deprecated Use SharedTaskAnalyzer from 'nexus-agents/core' instead.
- * This module is superseded by the unified SharedTaskAnalyzer (ADR-0004).
- * Migration: import { createSharedTaskAnalyzer } from 'nexus-agents/core'
- *   - analyze() provides unified feature extraction
- *   - getCapabilities() replaces parallelizable/multimodal detection
+ * This module is distinct from `SharedTaskAnalyzer`:
+ * - `task-features` (here): features for scaling-predictor model input
+ *   (sequential_reasoning / parallelizable / tool_heavy, etc.)
+ * - `SharedTaskAnalyzer` (core): features for capability-based CLI routing
+ *
+ * Both coexist by design.
  *
  * @module agents/coordination/task-features
- * (Source: Issue #337, arXiv:2512.08296)
+ * (Source: Issue #337, arXiv:2512.08296; Issue #1985 audit)
  */
 
 import type { Task } from '../../core/index.js';

--- a/packages/nexus-agents/src/cli-adapters/task-classifier.ts
+++ b/packages/nexus-agents/src/cli-adapters/task-classifier.ts
@@ -1,16 +1,19 @@
 /**
  * nexus-agents/cli-adapters - Task Classifier for Fallback Chains
  *
- * Classifies tasks into types for selecting appropriate fallback chains.
- * Uses keyword-based classification with configurable patterns.
+ * Classifies tasks into types for selecting appropriate CLI fallback chains.
+ * Uses keyword-based classification with configurable patterns. The 5-value
+ * `FallbackTaskType` taxonomy (code/research/documentation/analysis/general)
+ * is tuned for CLI-selection decisions and is distinct from
+ * `SharedTaskAnalyzer`'s 9-value `TaskTypeCategory`, which is tuned for
+ * capability-based routing.
  *
- * @deprecated Use SharedTaskAnalyzer from 'nexus-agents/core' instead.
- * This module is superseded by the unified SharedTaskAnalyzer (ADR-0004).
- * Migration: import { createSharedTaskAnalyzer } from 'nexus-agents/core'
- *   - getTaskType() provides similar classification with unified taxonomy
+ * Both modules coexist by design — they solve different problems:
+ * - `task-classifier` (here): which CLI to try in what order, by task shape
+ * - `SharedTaskAnalyzer` (core): which model capability to route to
  *
  * @module cli-adapters/task-classifier
- * (Source: Issue #362 - Task-type-aware fallback chains)
+ * (Source: Issue #362 - Task-type-aware fallback chains; Issue #1985 audit)
  */
 
 import { z } from 'zod';


### PR DESCRIPTION
Closes #1985.

## Summary

Audit of #1985 found the \`@deprecated — use SharedTaskAnalyzer\` markers on two modules were aspirational, not actionable.

## Finding

**task-classifier.ts** exposes \`FallbackTaskType\` — a 5-value taxonomy (\`code\` | \`research\` | \`documentation\` | \`analysis\` | \`general\`) tuned for **CLI fallback-chain selection**. \`SharedTaskAnalyzer.TaskTypeCategory\` has 9 values (\`architecture\`, \`code_implementation\`, etc.) tuned for **capability-based routing**. They are not interchangeable.

**task-features.ts** exposes \`extractTaskFeatures\` — produces \`ScalingTaskType\`-categorized features (\`sequential_reasoning\` / \`parallelizable\` / \`tool_heavy\`) for the scaling-predictor model. That is a different feature set than \`SharedTaskAnalyzer.analyze()\` produces for capability routing.

Both modules serve distinct, still-needed purposes.

## Changes

- Removed misleading \`@deprecated\` markers from both module docstrings
- Added clear language about each module's role and its relationship to SharedTaskAnalyzer
- No code behavior changes

## Why not migrate

Migration was impossible without breaking functionality. The fallback-chains registry keys on \`FallbackTaskType\`, and the scaling-predictor depends on \`ScalingTaskType\` features. A "migration" would be a new design proposal to unify three taxonomies — well beyond a deprecation cleanup.

## Test plan

- [ ] CI passes (typecheck confirmed locally)
- [ ] No import regressions