### PR TITLE
feat(security): clawguard denylist + policy cache (#1977 partial)

### DIFF
--- a/.changeset/1977-clawguard-denylist-cache.md
+++ b/.changeset/1977-clawguard-denylist-cache.md
@@ -1,0 +1,45 @@
+---
+'nexus-agents': minor
+---
+
+feat(security): ClawGuard denylist + policy cache (#1977 partial)
+
+Extends the access-constraint-deriver skeleton (#1993) with two
+vote-approved conditions from the design review of #1977:
+
+**Condition 3: Hardcoded unbypassable denylist** (`denylist.ts`)
+
+A list of file-path patterns and tool names that no LLM-derived policy
+may override. Applied FIRST in the enforcer, before the per-task policy
+check. Malicious user objectives or poisoned LLM output cannot grant
+access to credentials/secrets because the denylist rule wins regardless.
+
+Path patterns cover: `.env` files, SSH keys, AWS/Azure/GCP/kube creds,
+`/etc/shadow`, `/etc/sudoers`, common secret file patterns.
+
+Tool names cover: force-pushes, destructive git/fs operations, identity
+mutations, remote destruction.
+
+**Condition 5: Policy cache** (`cache.ts`)
+
+In-memory LRU cache keyed by objectiveHash. Avoids re-derivation on
+repeated invocations of the same task. Default capacity 256 entries
+with LRU eviction. Singleton with reset for tests.
+
+**Enforcer now takes an optional `args.path`** so file-path denylist
+matching works. Existing callers (none in production yet — skeleton
+not wired to dispatch) unaffected.
+
+## Still remaining for #1977 full implementation
+
+- [ ] Condition 1: UnifiedAdapterRegistry LLM call with regex fallback
+- [ ] Condition 4: Trust-tier gating on objective input
+- [ ] Condition 6: Empirical <500ms p95 validation before enforce mode
+- [ ] Dispatch path wiring (MCP tool boundary hook)
+
+## Validation
+
+- 51 tests across 3 files (17 original + 18 denylist + 16 cache/enforcer extension)
+- Full security suite: all passing
+- typecheck clean
+- TypeDoc regenerated

--- a/packages/nexus-agents/src/security/access-constraint-deriver/cache.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/cache.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the in-memory policy cache (#1977 condition 5).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PolicyCache, getPolicyCache, resetPolicyCache } from './index.js';
+import type { TaskAccessPolicy } from './types.js';
+
+function makePolicy(hash: string): TaskAccessPolicy {
+  return {
+    allowedTools: '*',
+    allowedPathPatterns: [],
+    allowedOperations: '*',
+    objectiveHash: hash,
+    derivedAt: '2026-04-19T00:00:00.000Z',
+    source: 'bypass',
+    mode: 'off',
+  };
+}
+
+beforeEach(() => {
+  resetPolicyCache();
+});
+
+describe('PolicyCache', () => {
+  it('stores and retrieves policies by hash', () => {
+    const cache = new PolicyCache();
+    const policy = makePolicy('abc123');
+    cache.set('abc123', policy);
+    expect(cache.get('abc123')).toEqual(policy);
+  });
+
+  it('returns undefined for missing hashes', () => {
+    const cache = new PolicyCache();
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('tracks size correctly', () => {
+    const cache = new PolicyCache();
+    expect(cache.size).toBe(0);
+    cache.set('a', makePolicy('a'));
+    cache.set('b', makePolicy('b'));
+    expect(cache.size).toBe(2);
+  });
+
+  it('evicts oldest entry at capacity', () => {
+    const cache = new PolicyCache(2);
+    cache.set('a', makePolicy('a'));
+    cache.set('b', makePolicy('b'));
+    cache.set('c', makePolicy('c'));
+    expect(cache.size).toBe(2);
+    expect(cache.get('a')).toBeUndefined(); // evicted
+    expect(cache.get('b')).toBeDefined();
+    expect(cache.get('c')).toBeDefined();
+  });
+
+  it('refreshes LRU position on get', () => {
+    const cache = new PolicyCache(2);
+    cache.set('a', makePolicy('a'));
+    cache.set('b', makePolicy('b'));
+    cache.get('a'); // refresh a to most-recently-used
+    cache.set('c', makePolicy('c')); // should evict 'b' not 'a'
+    expect(cache.get('a')).toBeDefined();
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBeDefined();
+  });
+
+  it('updates existing entries without growing size', () => {
+    const cache = new PolicyCache();
+    const p1 = makePolicy('x');
+    const p2 = { ...makePolicy('x'), derivedAt: '2026-04-20T00:00:00.000Z' };
+    cache.set('x', p1);
+    cache.set('x', p2);
+    expect(cache.size).toBe(1);
+    expect(cache.get('x')?.derivedAt).toBe('2026-04-20T00:00:00.000Z');
+  });
+
+  it('clear() removes all entries', () => {
+    const cache = new PolicyCache();
+    cache.set('a', makePolicy('a'));
+    cache.set('b', makePolicy('b'));
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get('a')).toBeUndefined();
+  });
+});
+
+describe('getPolicyCache (singleton)', () => {
+  it('returns the same instance across calls', () => {
+    const a = getPolicyCache();
+    const b = getPolicyCache();
+    expect(a).toBe(b);
+  });
+
+  it('resetPolicyCache() yields a fresh instance', () => {
+    const a = getPolicyCache();
+    a.set('k', makePolicy('k'));
+    resetPolicyCache();
+    const b = getPolicyCache();
+    expect(a).not.toBe(b);
+    expect(b.get('k')).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/cache.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/cache.ts
@@ -1,0 +1,73 @@
+/**
+ * Access Constraint Deriver — Policy cache (#1977 condition 5).
+ *
+ * In-memory LRU cache keyed by objectiveHash. Avoids re-deriving a policy
+ * for repeated invocations of the same user task. Capped size prevents
+ * unbounded growth in long-running sessions.
+ *
+ * The cache is a process-local singleton by design — it does not persist
+ * across restarts because policies are cheap to re-derive and staleness
+ * across process boundaries is not worth debugging.
+ *
+ * @module security/access-constraint-deriver/cache
+ */
+
+import type { TaskAccessPolicy } from './types.js';
+
+/** Max number of policies retained in the cache before LRU eviction. */
+const DEFAULT_MAX_ENTRIES = 256;
+
+interface CacheEntry {
+  readonly policy: TaskAccessPolicy;
+  readonly insertedAt: number;
+}
+
+export class PolicyCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {}
+
+  /** Gets a cached policy or undefined. Side effect: bumps LRU position. */
+  get(objectiveHash: string): TaskAccessPolicy | undefined {
+    const entry = this.entries.get(objectiveHash);
+    if (entry === undefined) return undefined;
+    // Re-insert to refresh LRU position
+    this.entries.delete(objectiveHash);
+    this.entries.set(objectiveHash, entry);
+    return entry.policy;
+  }
+
+  /** Stores a policy. Evicts the oldest entry if at capacity. */
+  set(objectiveHash: string, policy: TaskAccessPolicy): void {
+    if (this.entries.has(objectiveHash)) {
+      this.entries.delete(objectiveHash);
+    } else if (this.entries.size >= this.maxEntries) {
+      // Map preserves insertion order; the first key is the oldest.
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+    this.entries.set(objectiveHash, { policy, insertedAt: Date.now() });
+  }
+
+  /** Clears all entries. Useful for tests. */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+/** Singleton cache. */
+let instance: PolicyCache | undefined;
+
+export function getPolicyCache(): PolicyCache {
+  instance ??= new PolicyCache();
+  return instance;
+}
+
+/** Reset for tests. */
+export function resetPolicyCache(): void {
+  instance = undefined;
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/denylist.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/denylist.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the unbypassable denylist (#1977 condition 3).
+ *
+ * Critical property: these rules win against ANY policy, including
+ * LLM-derived policies that claim to allow credentials or destructive tools.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isPathDenied,
+  isToolDenied,
+  matchDenyPattern,
+  UNBYPASSABLE_PATH_PATTERNS,
+  UNBYPASSABLE_TOOL_NAMES,
+} from './index.js';
+
+describe('matchDenyPattern', () => {
+  it('matches exact .env filename', () => {
+    expect(matchDenyPattern('.env', '.env')).toBe(true);
+    expect(matchDenyPattern('env', '.env')).toBe(false);
+  });
+
+  it('matches nested .env via **', () => {
+    expect(matchDenyPattern('backend/.env', '**/.env')).toBe(true);
+    expect(matchDenyPattern('app/server/.env', '**/.env')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchDenyPattern('.ENV', '.env')).toBe(true);
+    expect(matchDenyPattern('~/.SSH/id_rsa', '~/.ssh/**')).toBe(true);
+  });
+
+  it('treats ~/ as a home-anchor prefix', () => {
+    expect(matchDenyPattern('~/.ssh/id_ed25519', '~/.ssh/**')).toBe(true);
+    expect(matchDenyPattern('/home/user/.ssh/id_rsa', '~/.ssh/**')).toBe(true);
+  });
+
+  it('does not match partial segment names with *', () => {
+    expect(matchDenyPattern('foo/bar/.envtest', '**/.env')).toBe(false);
+  });
+});
+
+describe('isPathDenied', () => {
+  it('denies .env at any depth', () => {
+    expect(isPathDenied('.env')).toBe(true);
+    expect(isPathDenied('server/.env')).toBe(true);
+    expect(isPathDenied('packages/app/.env.production')).toBe(true);
+  });
+
+  it('denies SSH keys', () => {
+    expect(isPathDenied('~/.ssh/id_rsa')).toBe(true);
+    expect(isPathDenied('/home/user/.ssh/id_ed25519')).toBe(true);
+    expect(isPathDenied('keys/my_rsa')).toBe(true);
+  });
+
+  it('denies cloud credentials', () => {
+    expect(isPathDenied('~/.aws/credentials')).toBe(true);
+    expect(isPathDenied('~/.azure/access-token.json')).toBe(true);
+    expect(isPathDenied('~/.kube/config')).toBe(true);
+  });
+
+  it('denies /etc/shadow and sudoers', () => {
+    expect(isPathDenied('/etc/shadow')).toBe(true);
+    expect(isPathDenied('/etc/sudoers.d/admin')).toBe(true);
+  });
+
+  it('denies secret file name patterns', () => {
+    expect(isPathDenied('packages/app/secrets.yaml')).toBe(true);
+    expect(isPathDenied('config/credentials.json')).toBe(true);
+    expect(isPathDenied('keys/private_key.pem')).toBe(true);
+  });
+
+  it('allows ordinary source files', () => {
+    expect(isPathDenied('src/index.ts')).toBe(false);
+    expect(isPathDenied('packages/core/src/router.ts')).toBe(false);
+    expect(isPathDenied('README.md')).toBe(false);
+  });
+});
+
+describe('isToolDenied', () => {
+  it('denies destructive git tools', () => {
+    expect(isToolDenied('git_push_force')).toBe(true);
+    expect(isToolDenied('git_reset_hard')).toBe(true);
+  });
+
+  it('denies destructive fs tools', () => {
+    expect(isToolDenied('rm_recursive_force')).toBe(true);
+  });
+
+  it('denies identity mutations', () => {
+    expect(isToolDenied('ssh_add_key')).toBe(true);
+    expect(isToolDenied('npm_publish_force')).toBe(true);
+  });
+
+  it('denies remote destruction', () => {
+    expect(isToolDenied('github_repo_delete')).toBe(true);
+    expect(isToolDenied('aws_account_close')).toBe(true);
+  });
+
+  it('allows ordinary tools', () => {
+    expect(isToolDenied('gh_issue_view')).toBe(false);
+    expect(isToolDenied('memory_query')).toBe(false);
+  });
+});
+
+describe('UNBYPASSABLE lists', () => {
+  it('path patterns list is non-empty', () => {
+    expect(UNBYPASSABLE_PATH_PATTERNS.length).toBeGreaterThan(10);
+  });
+
+  it('tool names list is non-empty', () => {
+    expect(UNBYPASSABLE_TOOL_NAMES.length).toBeGreaterThan(5);
+  });
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
@@ -78,21 +78,15 @@ export const UNBYPASSABLE_TOOL_NAMES: readonly string[] = [
 ];
 
 /**
- * Returns true if the given file path matches any unbypassable deny pattern.
- * Uses simple glob semantics: `**` matches any segment, `*` matches any
- * non-separator characters. Case-insensitive.
+ * Compiles a glob pattern to a regex at module-load time.
+ * Supports: `**` (any path segments), `*` (any non-separator chars),
+ * `~/` (home-anchor prefix). All other regex metachars escaped.
  *
- * Exported for testing; in production callers should use `isPathDenied`.
+ * Regexes built here come from the hardcoded `UNBYPASSABLE_PATH_PATTERNS`
+ * constant — never from user input — so they are ReDoS-safe by construction.
  */
-export function matchDenyPattern(path: string, pattern: string): boolean {
-  const normalized = path.toLowerCase();
+function compileGlobToRegex(pattern: string): RegExp {
   const pat = pattern.toLowerCase();
-
-  // Expand glob to regex:
-  //   **  → .*
-  //   *   → [^/]*
-  //   .   → escaped
-  //   ~/  → anchor at home-prefix
   const escaped = pat
     .replace(/[.+^$()|[\]{}]/g, '\\$&')
     .replace(/\*\*/g, '__DOUBLESTAR__')
@@ -103,14 +97,37 @@ export function matchDenyPattern(path: string, pattern: string): boolean {
     : escaped.startsWith('/')
       ? `^${escaped}$`
       : `(^|/)${escaped}$`;
+  return new RegExp(anchored);
+}
 
-  const re = new RegExp(anchored);
-  return re.test(normalized);
+/**
+ * Precompiled regexes for every unbypassable path pattern, computed once
+ * at module load. Static inputs → no ReDoS surface.
+ */
+const COMPILED_PATH_PATTERNS: ReadonlyArray<{
+  readonly pattern: string;
+  readonly regex: RegExp;
+}> = UNBYPASSABLE_PATH_PATTERNS.map((pattern) => ({
+  pattern,
+  regex: compileGlobToRegex(pattern),
+}));
+
+/**
+ * Returns true if a lowercased file path matches the given pattern.
+ * Exported for tests; production code should use `isPathDenied`.
+ */
+export function matchDenyPattern(path: string, pattern: string): boolean {
+  const normalized = path.toLowerCase();
+  const compiled = COMPILED_PATH_PATTERNS.find((c) => c.pattern === pattern);
+  if (compiled !== undefined) return compiled.regex.test(normalized);
+  // Fallback for ad-hoc test patterns not in the static list.
+  return compileGlobToRegex(pattern).test(normalized);
 }
 
 /** Returns true if the path hits any unbypassable pattern. */
 export function isPathDenied(path: string): boolean {
-  return UNBYPASSABLE_PATH_PATTERNS.some((p) => matchDenyPattern(path, p));
+  const normalized = path.toLowerCase();
+  return COMPILED_PATH_PATTERNS.some((c) => c.regex.test(normalized));
 }
 
 /** Returns true if the tool name is unconditionally denied. */

--- a/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
@@ -87,8 +87,12 @@ export const UNBYPASSABLE_TOOL_NAMES: readonly string[] = [
  */
 function compileGlobToRegex(pattern: string): RegExp {
   const pat = pattern.toLowerCase();
+  // Escape regex metacharacters INCLUDING backslash (per CodeQL — without
+  // backslash in the class, a `\` in input would leak into the regex output
+  // unescaped). Do NOT escape `*` here — it's a glob wildcard that the
+  // subsequent replaces expand into regex wildcards.
   const escaped = pat
-    .replace(/[.+^$()|[\]{}]/g, '\\$&')
+    .replace(/[\\.+^$()|[\]{}]/g, '\\$&')
     .replace(/\*\*/g, '__DOUBLESTAR__')
     .replace(/\*/g, '[^/]*')
     .replace(/__DOUBLESTAR__/g, '.*');

--- a/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
@@ -1,0 +1,119 @@
+/**
+ * Access Constraint Deriver — Unbypassable denylist (#1977 condition 3).
+ *
+ * Hardcoded patterns that no LLM-derived policy may override. Applied FIRST
+ * in the enforcer, before checking the per-task policy. If the LLM (or a
+ * malicious user objective) produces a policy that would allow access to
+ * `.env`, SSH keys, cloud credentials, or similar, the denylist still wins.
+ *
+ * This exists because the LLM deriver is the weakest link — a user objective
+ * that says "I need to view my AWS credentials to debug" would otherwise
+ * produce a policy allowing `~/.aws/**`. The denylist refuses regardless.
+ *
+ * @module security/access-constraint-deriver/denylist
+ */
+
+/**
+ * File-path patterns that are unconditionally denied. Glob-style wildcards.
+ * All matching is case-insensitive to catch `~/.SSH` and similar.
+ */
+export const UNBYPASSABLE_PATH_PATTERNS: readonly string[] = [
+  // Environment files
+  '.env',
+  '.env.*',
+  '**/.env',
+  '**/.env.*',
+
+  // SSH credentials
+  '~/.ssh/**',
+  '**/ssh/id_*',
+  '**/*_rsa',
+  '**/*_ed25519',
+  '**/*.pem',
+
+  // Cloud credentials
+  '~/.aws/**',
+  '~/.azure/**',
+  '~/.gcp/**',
+  '~/.config/gcloud/**',
+  '~/.kube/config',
+
+  // Unix secret files
+  '/etc/shadow',
+  '/etc/sudoers',
+  '/etc/sudoers.d/**',
+
+  // Common secret file patterns
+  '**/secrets.*',
+  '**/credentials.*',
+  '**/private_key.*',
+  '**/id_rsa*',
+];
+
+/**
+ * Tool names that are unconditionally denied regardless of derived policy.
+ * These are tools that should never be callable during automated agent
+ * dispatch — they require explicit human action.
+ */
+export const UNBYPASSABLE_TOOL_NAMES: readonly string[] = [
+  // Destructive git operations
+  'git_push_force',
+  'git_reset_hard',
+  'git_branch_delete_force',
+  'git_clean_force',
+
+  // Destructive filesystem
+  'rm_recursive_force',
+  'chmod_recursive',
+
+  // Identity / auth mutations
+  'ssh_add_key',
+  'gpg_add_key',
+  'npm_publish_force',
+
+  // Remote destruction
+  'github_repo_delete',
+  'github_org_transfer',
+  'aws_account_close',
+];
+
+/**
+ * Returns true if the given file path matches any unbypassable deny pattern.
+ * Uses simple glob semantics: `**` matches any segment, `*` matches any
+ * non-separator characters. Case-insensitive.
+ *
+ * Exported for testing; in production callers should use `isPathDenied`.
+ */
+export function matchDenyPattern(path: string, pattern: string): boolean {
+  const normalized = path.toLowerCase();
+  const pat = pattern.toLowerCase();
+
+  // Expand glob to regex:
+  //   **  → .*
+  //   *   → [^/]*
+  //   .   → escaped
+  //   ~/  → anchor at home-prefix
+  const escaped = pat
+    .replace(/[.+^$()|[\]{}]/g, '\\$&')
+    .replace(/\*\*/g, '__DOUBLESTAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLESTAR__/g, '.*');
+  const anchored = escaped.startsWith('~/')
+    ? `(^|/)${escaped.slice(2)}$`
+    : escaped.startsWith('/')
+      ? `^${escaped}$`
+      : `(^|/)${escaped}$`;
+
+  const re = new RegExp(anchored);
+  return re.test(normalized);
+}
+
+/** Returns true if the path hits any unbypassable pattern. */
+export function isPathDenied(path: string): boolean {
+  return UNBYPASSABLE_PATH_PATTERNS.some((p) => matchDenyPattern(path, p));
+}
+
+/** Returns true if the tool name is unconditionally denied. */
+export function isToolDenied(toolName: string): boolean {
+  return UNBYPASSABLE_TOOL_NAMES.includes(toolName);
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
@@ -6,14 +6,19 @@
  * later LLM integration cannot regress the public surface.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   deriveAccessPolicy,
   hashObjective,
   resolveAccessPolicyMode,
   checkAccess,
+  resetPolicyCache,
   TaskAccessPolicySchema,
 } from './index.js';
+
+beforeEach(() => {
+  resetPolicyCache();
+});
 
 describe('resolveAccessPolicyMode', () => {
   it('defaults to "off" when env var is unset', () => {
@@ -122,5 +127,68 @@ describe('checkAccess (enforcer)', () => {
     };
     const result = checkAccess('gh_issue_close', policy);
     expect(result.decision).toBe('log-and-allow');
+  });
+
+  it('denies unbypassable tools even under bypass policy', () => {
+    const result = checkAccess('git_push_force', bypassPolicy);
+    expect(result.decision).toBe('deny');
+    if (result.decision === 'deny') {
+      expect(result.matchedRule).toBe('unbypassable:tool');
+    }
+  });
+
+  it('denies unbypassable tools even when LLM policy tries to allow them', () => {
+    const policy = {
+      ...bypassPolicy,
+      allowedTools: ['git_push_force', 'rm_recursive_force'] as const,
+      mode: 'enforce' as const,
+    };
+    // Even though policy claims to allow, denylist still wins.
+    const result = checkAccess('git_push_force', policy);
+    expect(result.decision).toBe('deny');
+    if (result.decision === 'deny') {
+      expect(result.matchedRule).toBe('unbypassable:tool');
+    }
+  });
+
+  it('denies unbypassable paths even under bypass policy', () => {
+    const result = checkAccess('read_file', bypassPolicy, { path: '.env' });
+    expect(result.decision).toBe('deny');
+    if (result.decision === 'deny') {
+      expect(result.matchedRule).toBe('unbypassable:path');
+    }
+  });
+
+  it('denies SSH key paths regardless of policy', () => {
+    const policy = {
+      ...bypassPolicy,
+      allowedTools: ['read_file'] as const,
+      mode: 'enforce' as const,
+    };
+    const result = checkAccess('read_file', policy, { path: '~/.ssh/id_rsa' });
+    expect(result.decision).toBe('deny');
+    if (result.decision === 'deny') {
+      expect(result.matchedRule).toBe('unbypassable:path');
+    }
+  });
+
+  it('allows ordinary paths under bypass policy', () => {
+    const result = checkAccess('read_file', bypassPolicy, { path: 'src/index.ts' });
+    expect(result.decision).toBe('allow');
+  });
+});
+
+describe('deriveAccessPolicy caching (#1977 condition 5)', () => {
+  it('returns the same policy for repeat invocations with same objective', async () => {
+    const a = await deriveAccessPolicy('test objective');
+    const b = await deriveAccessPolicy('test objective');
+    // Same cache hit → identical reference (or at least identical derivedAt)
+    expect(a.derivedAt).toBe(b.derivedAt);
+  });
+
+  it('returns distinct policies for different objectives', async () => {
+    const a = await deriveAccessPolicy('first task');
+    const b = await deriveAccessPolicy('second task');
+    expect(a.objectiveHash).not.toBe(b.objectiveHash);
   });
 });

--- a/packages/nexus-agents/src/security/access-constraint-deriver/deriver.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/deriver.ts
@@ -12,6 +12,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { getPolicyCache } from './cache.js';
 import { resolveAccessPolicyMode } from './config.js';
 import type { TaskAccessPolicy, AccessPolicyMode } from './types.js';
 
@@ -25,22 +26,35 @@ import type { TaskAccessPolicy, AccessPolicyMode } from './types.js';
  */
 export function deriveAccessPolicy(userObjective: string): Promise<TaskAccessPolicy> {
   const mode = resolveAccessPolicyMode();
+  const hash = hashObjective(userObjective);
+
+  // Condition 5: cache by objectiveHash to avoid re-derivation on repeated
+  // invocations of the same task. Cache hit short-circuits the LLM call
+  // (once wired) AND the mode check — the cached mode wins so policies
+  // stay stable across an env-var flip mid-session (tests exercise this).
+  const cache = getPolicyCache();
+  const cached = cache.get(hash);
+  if (cached !== undefined) return Promise.resolve(cached);
+
   // TODO(#1977): in audit/enforce mode, call LLM-based deriver with regex
-  // fallback. Gate on the 7 PR conditions (UnifiedAdapterRegistry, Zod,
-  // hardcoded unbypassable denylist, trust-tier input gating, timeout+cache,
-  // <500ms p95 validation, deterministic mocked tests). The Promise return
-  // type is already correct for the future async LLM integration; the
-  // skeleton resolves synchronously.
-  return Promise.resolve(buildBypassPolicy(userObjective, mode));
+  // fallback. Gate on remaining PR conditions (UnifiedAdapterRegistry call,
+  // trust-tier input gating, <500ms p95 validation).
+  const policy = buildBypassPolicy(userObjective, mode, hash);
+  cache.set(hash, policy);
+  return Promise.resolve(policy);
 }
 
 /** Builds an unrestricted policy. */
-function buildBypassPolicy(userObjective: string, mode: AccessPolicyMode): TaskAccessPolicy {
+function buildBypassPolicy(
+  _userObjective: string,
+  mode: AccessPolicyMode,
+  hash: string
+): TaskAccessPolicy {
   return {
     allowedTools: '*',
     allowedPathPatterns: [],
     allowedOperations: '*',
-    objectiveHash: hashObjective(userObjective),
+    objectiveHash: hash,
     derivedAt: new Date().toISOString(),
     source: 'bypass',
     mode,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
@@ -9,18 +9,48 @@
  * @module security/access-constraint-deriver/enforcer
  */
 
+import { isPathDenied, isToolDenied } from './denylist.js';
 import type { AccessDecision, TaskAccessPolicy } from './types.js';
 
 /**
- * Checks a proposed tool call against a task's access policy.
+ * Checks a proposed tool call against the unbypassable denylist AND the
+ * task's derived access policy.
  *
- * In skeleton state the policy is always a bypass (allow-all) so this
- * function always returns `allow`. Once the deriver produces real policies,
- * this enforcer will match `toolName` against `allowedTools` and return
- * `deny` (in enforce mode) or `log-and-allow` (in audit mode) when a call
- * falls outside the derived scope.
+ * Order of operations (important — the denylist is FIRST and unbypassable):
+ * 1. If the tool is on the hardcoded deny-tool list → deny regardless
+ *    of policy. This is unbypassable even in `off` mode.
+ * 2. If a file-path argument is provided and matches an unbypassable path
+ *    pattern (e.g. `~/.ssh/**`, `/etc/shadow`) → deny regardless.
+ * 3. Otherwise, fall back to the per-task policy (bypass in skeleton).
+ *
+ * The denylist check runs before the policy check so a malicious LLM-derived
+ * policy cannot grant access to secrets/credentials by listing the tool in
+ * `allowedTools`.
  */
-export function checkAccess(toolName: string, policy: TaskAccessPolicy): AccessDecision {
+export function checkAccess(
+  toolName: string,
+  policy: TaskAccessPolicy,
+  args?: { readonly path?: string }
+): AccessDecision {
+  // 1. Unbypassable tool denylist — applies in all modes.
+  if (isToolDenied(toolName)) {
+    return {
+      decision: 'deny',
+      reason: `tool "${toolName}" is on the unbypassable deny-tool list`,
+      matchedRule: 'unbypassable:tool',
+    };
+  }
+
+  // 2. Unbypassable path denylist — applies when a path argument is given.
+  if (typeof args?.path === 'string' && args.path.length > 0 && isPathDenied(args.path)) {
+    return {
+      decision: 'deny',
+      reason: `path "${args.path}" is on the unbypassable deny-path list`,
+      matchedRule: 'unbypassable:path',
+    };
+  }
+
+  // 3. Per-task policy check.
   if (policy.allowedTools === '*') return { decision: 'allow' };
 
   if (policy.allowedTools.includes(toolName)) return { decision: 'allow' };

--- a/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
@@ -8,6 +8,14 @@ export { resolveAccessPolicyMode } from './config.js';
 export { deriveAccessPolicy, hashObjective } from './deriver.js';
 export { checkAccess } from './enforcer.js';
 export {
+  UNBYPASSABLE_PATH_PATTERNS,
+  UNBYPASSABLE_TOOL_NAMES,
+  isPathDenied,
+  isToolDenied,
+  matchDenyPattern,
+} from './denylist.js';
+export { PolicyCache, getPolicyCache, resetPolicyCache } from './cache.js';
+export {
   AccessPolicyModeSchema,
   AccessPolicySourceSchema,
   AccessOperationSchema,


### PR DESCRIPTION
Follow-up to #1993 (ClawGuard skeleton). Covers 2 more of the 7 vote-approved conditions from #1977.

## Condition 3: Unbypassable denylist

New \`denylist.ts\` with hardcoded patterns no LLM-derived policy can override. Applied FIRST in the enforcer.

**Path patterns blocked:** \`.env\` files, SSH keys, AWS/Azure/GCP/kube credentials, \`/etc/shadow\`, \`/etc/sudoers\`, common secret file patterns, private keys.

**Tool names blocked:** destructive git (force-push, reset --hard), destructive fs (rm -rf), identity mutations (ssh-add, npm publish --force), remote destruction (github_repo_delete, aws_account_close).

Critical property: a malicious user objective or poisoned LLM output cannot grant credential access because the denylist check runs before the policy check.

## Condition 5: Policy cache

New \`cache.ts\` with in-memory LRU cache keyed by objectiveHash. Avoids re-derivation on repeat invocations. 256-entry default with LRU eviction.

## Enforcer signature extension

\`checkAccess(tool, policy, args?)\` — new optional \`args.path\` for file-path denylist matching. No production callers affected (skeleton not wired to dispatch yet).

## Condition coverage

- [x] 2. Zod types (landed in #1993)
- [x] 3. Hardcoded unbypassable denylist ← **this PR**
- [x] 5. Timeout + cache — cache done; timeout arrives with LLM call
- [x] 7. Deterministic tests (expanded from 17 → 51)
- [ ] 1. UnifiedAdapterRegistry LLM call (follow-up)
- [ ] 4. Trust-tier gating (follow-up)
- [ ] 6. <500ms p95 empirical validation (runtime)

## Runtime impact: none

Adapter still not wired to dispatch. Default mode stays \`off\`.

## Validation

- typecheck: 0 errors
- src/security/access-constraint-deriver/: 51/51 tests pass (17 + 18 denylist + 16 cache/enforcer extensions)
- full src/security/: green
- TypeDoc regenerated

## Test plan

- [ ] CI passes
- [ ] No import regressions
- [ ] Follow-up wires LLM call + trust-tier gating