### PR TITLE
docs: fix stale 5 CLIs claim → 4 CLIs (#2003)

### DIFF
--- a/.changeset/2003-cli-count-fix.md
+++ b/.changeset/2003-cli-count-fix.md
@@ -1,0 +1,8 @@
+---
+'nexus-agents': patch
+---
+
+docs: fix stale 5 CLIs claim → 4 CLIs (closes #2003)
+
+Per CLI_NAMES in src/config/model-capabilities-types.ts. codex-mcp
+is not a distinct CLI.

--- a/docs/architecture/SOFTWARE_FACTORY_REPORT.md
+++ b/docs/architecture/SOFTWARE_FACTORY_REPORT.md
@@ -27,7 +27,7 @@ Task -> BudgetRouter -> ZeroRouter -> PreferenceRouter -> TopsisRouter -> LinUCB
 ```
 
 - 5-stage composite routing with contextual bandit (LinUCB) final selection
-- Multiple supported models across 5 CLIs (claude, gemini, codex, codex-mcp, opencode)
+- Multiple supported models across 4 CLIs (claude, gemini, codex, opencode)
 - OutcomeStore records task outcomes for reward computation
 
 ### Orchestration Graph

--- a/docs/security/API_KEY_BOUNDARIES.md
+++ b/docs/security/API_KEY_BOUNDARIES.md
@@ -47,7 +47,7 @@ This warning appears during adapter initialization when `anthropic/` or `custom/
 
 ## Safe Multi-Model Diversity
 
-For consensus voting and multi-model orchestration, 5 CLIs (claude, gemini, codex, codex-mcp, opencode) provide diversity:
+For consensus voting and multi-model orchestration, 4 CLIs (claude, gemini, codex, opencode) provide diversity:
 
 | Strategy             | CLIs Used               | Sufficient For                                         |
 | -------------------- | ----------------------- | ------------------------------------------------------ |


### PR DESCRIPTION
Closes #2003.

## Fix

Two docs claimed "5 CLIs (claude, gemini, codex, codex-mcp, opencode)" but \`packages/nexus-agents/src/config/model-capabilities-types.ts\` is authoritative — \`CLI_NAMES = ['claude', 'gemini', 'codex', 'opencode']\`. \`codex-mcp\` is not a distinct CLI.

- \`docs/security/API_KEY_BOUNDARIES.md\` line ~50
- \`docs/architecture/SOFTWARE_FACTORY_REPORT.md\` line ~30

Grep confirmed only one match per file; no other "5 CLIs" or "codex-mcp" mentions.

## Test plan

- [ ] CI passes (docs-only change)