### PR TITLE
feat(cli): add atbench CLI command (#1981)

### DIFF
--- a/.changeset/1981-atbench-cli.md
+++ b/.changeset/1981-atbench-cli.md
@@ -1,0 +1,59 @@
+---
+'nexus-agents': minor
+---
+
+feat(cli): add atbench CLI command (#1981 follow-up)
+
+Adds the user-facing `atbench` CLI command with `info` and `run`
+subcommands. Programmatic API exported from `nexus-agents/cli`;
+top-level dispatcher wiring (`nexus-agents atbench ...`) is a
+separate small follow-up.
+
+## API
+
+```ts
+import { atbenchCommand, parseAtbenchArgs } from 'nexus-agents/cli';
+
+const opts = parseAtbenchArgs(process.argv.slice(2));
+const result = await atbenchCommand(opts);
+```
+
+## Subcommands
+
+- `info` — prints variant, source (HF or fixture), scorer mode, instance limit
+- `run` — loads trajectories, scores them via stub or LLM, prints summary with
+  precision/recall/F1/confusion matrix
+
+## Flags
+
+- `--variant=<claw|codex>` — dataset variant (default: claw)
+- `--limit=<N>` — cap instances for smoke runs
+- `--fixture=<path>` — local JSONL instead of HuggingFace
+- `--llm-scoring` — enable LLM scorer (default: stub oracle)
+- `--verbose, -v` — per-instance progress
+
+## Tests (17 new)
+
+- arg parsing: defaults, info subcommand, all flags, invalid limit fallback
+- runInfo: HF source vs fixture source
+- runEvaluation against local fixture: 100% pass with stub oracle, --limit cap, verbose progress
+- atbenchCommand top-level dispatch: routes info vs run
+- printAtbenchHelp: smoke
+
+## Validation
+
+- typecheck clean
+- 17/17 atbench-command tests pass
+- 3364/3364 cli + benchmarks tests pass overall
+- TypeDoc regenerated
+
+## #1981 progress
+
+| Sub-task                       | Status                                                               |
+| ------------------------------ | -------------------------------------------------------------------- |
+| BenchmarkAdapter contract impl | ✅ #1996                                                             |
+| Stub scorer + confusion math   | ✅ #1996                                                             |
+| HF dataset loader              | ✅ #2006                                                             |
+| LLM-based scorer               | ✅ #2010                                                             |
+| **CLI integration**            | ✅ this PR (programmatic API; top-level dispatcher wiring follow-up) |
+| CI smoke workflow              | ⏳ follow-up                                                         |

--- a/packages/nexus-agents/src/cli/atbench-command.test.ts
+++ b/packages/nexus-agents/src/cli/atbench-command.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the atbench CLI command (#1981).
+ *
+ * Covers arg parsing, info subcommand, and the run pipeline against a
+ * local fixture (no network, no LLM in tests).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  atbenchCommand,
+  parseAtbenchArgs,
+  printAtbenchHelp,
+  runEvaluation,
+  runInfo,
+} from './atbench-command.js';
+import type { ATBenchTrajectory } from '../benchmarks/atbench/types.js';
+
+function mkTrajectory(overrides: Partial<ATBenchTrajectory> = {}): ATBenchTrajectory {
+  return {
+    id: 't-001',
+    scenario: 'tool-injection',
+    userRequest: 'do something',
+    sessionTranscript: ['user: do something'],
+    toolEvents: [{ tool: 'read_file' }],
+    safetyLabel: 'safe',
+    taxonomy: { riskSource: 'user', failureMode: 'ok', harm: 'none' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Silence console for tests
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('parseAtbenchArgs', () => {
+  it('defaults to run + claw', () => {
+    const opts = parseAtbenchArgs([]);
+    expect(opts.subcommand).toBe('run');
+    expect(opts.variant).toBe('claw');
+    expect(opts.limit).toBeUndefined();
+    expect(opts.llmScoring).toBe(false);
+    expect(opts.verbose).toBe(false);
+  });
+
+  it('parses info subcommand', () => {
+    const opts = parseAtbenchArgs(['info']);
+    expect(opts.subcommand).toBe('info');
+  });
+
+  it('parses --variant=codex', () => {
+    const opts = parseAtbenchArgs(['run', '--variant=codex']);
+    expect(opts.variant).toBe('codex');
+  });
+
+  it('falls back to claw on unknown variant', () => {
+    const opts = parseAtbenchArgs(['run', '--variant=mystery']);
+    expect(opts.variant).toBe('claw');
+  });
+
+  it('parses --limit=N as a positive integer', () => {
+    const opts = parseAtbenchArgs(['run', '--limit=25']);
+    expect(opts.limit).toBe(25);
+  });
+
+  it('ignores invalid --limit values', () => {
+    const opts = parseAtbenchArgs(['run', '--limit=abc']);
+    expect(opts.limit).toBeUndefined();
+  });
+
+  it('parses --fixture=<path>', () => {
+    const opts = parseAtbenchArgs(['run', '--fixture=/tmp/data.jsonl']);
+    expect(opts.fixturePath).toBe('/tmp/data.jsonl');
+  });
+
+  it('parses --llm-scoring + --verbose flags', () => {
+    const opts = parseAtbenchArgs(['run', '--llm-scoring', '--verbose']);
+    expect(opts.llmScoring).toBe(true);
+    expect(opts.verbose).toBe(true);
+  });
+
+  it('parses -v as verbose alias', () => {
+    const opts = parseAtbenchArgs(['run', '-v']);
+    expect(opts.verbose).toBe(true);
+  });
+});
+
+describe('runInfo', () => {
+  it('reports HuggingFace source by default', () => {
+    const result = runInfo({
+      subcommand: 'info',
+      variant: 'claw',
+      llmScoring: false,
+      verbose: false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('atbench/claw');
+  });
+
+  it('reports fixture source when provided', () => {
+    const result = runInfo({
+      subcommand: 'info',
+      variant: 'codex',
+      fixturePath: '/local/file.jsonl',
+      llmScoring: true,
+      verbose: false,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('runEvaluation (against local fixture)', () => {
+  let dir: string;
+  let fixturePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'atbench-cli-test-'));
+    fixturePath = join(dir, 'fixture.jsonl');
+    const lines = [
+      mkTrajectory({ id: 'a', safetyLabel: 'safe' }),
+      mkTrajectory({ id: 'b', safetyLabel: 'unsafe' }),
+      mkTrajectory({ id: 'c', safetyLabel: 'safe' }),
+    ]
+      .map((t) => JSON.stringify(t))
+      .join('\n');
+    writeFileSync(fixturePath, lines);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports 100% pass with stub oracle scorer (matches ground truth)', async () => {
+    const result = await runEvaluation({
+      subcommand: 'run',
+      variant: 'claw',
+      fixturePath,
+      llmScoring: false,
+      verbose: false,
+    });
+    expect(result.success).toBe(true);
+    const details = result.details as { total: number; passed: number; passRate: number };
+    expect(details.total).toBe(3);
+    expect(details.passed).toBe(3);
+    expect(details.passRate).toBe(1);
+  });
+
+  it('respects --limit cap', async () => {
+    const result = await runEvaluation({
+      subcommand: 'run',
+      variant: 'claw',
+      fixturePath,
+      limit: 2,
+      llmScoring: false,
+      verbose: false,
+    });
+    const details = result.details as { total: number };
+    expect(details.total).toBe(2);
+  });
+
+  it('reports verbose progress without crashing', async () => {
+    const result = await runEvaluation({
+      subcommand: 'run',
+      variant: 'claw',
+      fixturePath,
+      llmScoring: false,
+      verbose: true,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('atbenchCommand top-level dispatch', () => {
+  it('routes info subcommand to runInfo', async () => {
+    const result = await atbenchCommand({
+      subcommand: 'info',
+      variant: 'claw',
+      llmScoring: false,
+      verbose: false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('info');
+  });
+
+  it('routes run subcommand to runEvaluation (with fixture)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'atbench-dispatch-'));
+    const fixturePath = join(dir, 'fixture.jsonl');
+    writeFileSync(fixturePath, JSON.stringify(mkTrajectory()));
+    try {
+      const result = await atbenchCommand({
+        subcommand: 'run',
+        variant: 'claw',
+        fixturePath,
+        llmScoring: false,
+        verbose: false,
+      });
+      expect(result.success).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('printAtbenchHelp', () => {
+  it('prints help text without crashing', () => {
+    expect(() => {
+      printAtbenchHelp();
+    }).not.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/cli/atbench-command.ts
+++ b/packages/nexus-agents/src/cli/atbench-command.ts
@@ -1,0 +1,251 @@
+/**
+ * CLI ATBench Command (#1981).
+ *
+ * Run trajectory-safety evaluations against ATBench-Claw / ATBench-CodeX.
+ *
+ * Subcommands:
+ * - `info`   : print dataset metadata + scorer mode
+ * - `run`    : load trajectories, score, summarize
+ *
+ * Pattern mirrors `cli/swe-bench-command.ts`. Built so the dispatcher
+ * wiring is a separate, low-risk follow-up.
+ *
+ * @module cli/atbench-command
+ */
+
+/* eslint-disable no-console */
+// Console output is intentional for CLI user feedback.
+
+import { ATBenchAdapter } from '../benchmarks/atbench/adapter.js';
+import type { ATBenchEvalResult } from '../benchmarks/atbench/types.js';
+
+/** ATBench command options. */
+export interface ATBenchOptions {
+  readonly subcommand: 'run' | 'info';
+  readonly variant: 'claw' | 'codex';
+  /** Optional cap on instances (smoke testing). */
+  readonly limit?: number;
+  /** Local JSONL fixture path. When omitted, fetches from HuggingFace. */
+  readonly fixturePath?: string;
+  /** Enable LLM scoring via the registry's recommended adapter. */
+  readonly llmScoring: boolean;
+  /** Verbose progress output. */
+  readonly verbose: boolean;
+}
+
+/** Result of an ATBench command invocation. */
+export interface ATBenchCommandResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}
+
+/** Run the 'info' subcommand — prints variant, source, scorer mode. */
+export function runInfo(options: ATBenchOptions): ATBenchCommandResult {
+  console.log('\nATBench info');
+  console.log('='.repeat(40));
+  console.log(`Variant:          ${options.variant}`);
+  const source =
+    options.fixturePath !== undefined
+      ? `local fixture: ${options.fixturePath}`
+      : `HuggingFace: AI45Research/ATBench-${options.variant === 'codex' ? 'CodeX' : 'Claw'}`;
+  console.log(`Source:           ${source}`);
+  console.log(
+    `Scorer:           ${options.llmScoring ? 'LLM (TBD: adapter wiring)' : 'stub (perfect oracle)'}`
+  );
+  console.log(`Instance limit:   ${options.limit !== undefined ? String(options.limit) : 'all'}`);
+  return {
+    success: true,
+    message: `info for atbench/${options.variant}`,
+  };
+}
+
+/** Run the 'run' subcommand — loads, scores, summarizes. */
+export async function runEvaluation(options: ATBenchOptions): Promise<ATBenchCommandResult> {
+  console.log(`\nATBench run: ${options.variant}`);
+  console.log('='.repeat(40));
+
+  const adapter = new ATBenchAdapter({ variant: options.variant });
+  const startedLoad = Date.now();
+  const instances = await adapter.loadInstances({
+    variant: options.variant,
+    ...(options.fixturePath !== undefined ? { fixturePath: options.fixturePath } : {}),
+    ...(options.limit !== undefined ? { maxInstances: options.limit } : {}),
+  });
+  const loadTimeMs = Date.now() - startedLoad;
+  console.log(`Loaded ${String(instances.length)} trajectories in ${String(loadTimeMs)}ms`);
+
+  const startedRun = Date.now();
+  const evalResults = await scoreAll(adapter, instances, options.verbose);
+  const runTimeMs = Date.now() - startedRun;
+
+  const summary = adapter.summarize(evalResults, runTimeMs);
+  printSummary(summary, runTimeMs);
+
+  const meta = summary.metadata as SummaryMeta;
+  return {
+    success: true,
+    message: `${String(summary.passed)}/${String(summary.total)} passed (${(summary.passRate * 100).toFixed(1)}%)`,
+    details: {
+      total: summary.total,
+      passed: summary.passed,
+      passRate: summary.passRate,
+      runTimeMs,
+      loadTimeMs,
+      precision: meta.precision,
+      recall: meta.recall,
+      f1: meta.f1,
+    },
+  };
+}
+
+interface SummaryMeta {
+  readonly precision?: number;
+  readonly recall?: number;
+  readonly f1?: number;
+  readonly confusionMatrix?: {
+    readonly tp: number;
+    readonly tn: number;
+    readonly fp: number;
+    readonly fn: number;
+  };
+}
+
+/** Score all instances sequentially. */
+async function scoreAll(
+  adapter: ATBenchAdapter,
+  instances: readonly import('../benchmarks/atbench/types.js').ATBenchTrajectory[],
+  verbose: boolean
+): Promise<ATBenchEvalResult[]> {
+  const results: ATBenchEvalResult[] = [];
+  for (const [idx, instance] of instances.entries()) {
+    if (verbose) {
+      console.log(
+        `  [${String(idx + 1)}/${String(instances.length)}] scoring ${instance.id} (truth: ${instance.safetyLabel})`
+      );
+    }
+    const prediction = await adapter.runInstance(instance, { timeoutMs: 30_000 });
+    const evalResult = await adapter.evaluate(instance, prediction);
+    results.push(evalResult);
+  }
+  return results;
+}
+
+/** Print the human-readable summary block. */
+function printSummary(
+  summary: {
+    readonly total: number;
+    readonly passed: number;
+    readonly passRate: number;
+    readonly metadata: Record<string, unknown>;
+  },
+  runTimeMs: number
+): void {
+  const meta = summary.metadata as SummaryMeta;
+  console.log('\nResults');
+  console.log('-'.repeat(40));
+  console.log(`Total:            ${String(summary.total)}`);
+  console.log(
+    `Passed:           ${String(summary.passed)} (${(summary.passRate * 100).toFixed(1)}%)`
+  );
+  if (meta.precision !== undefined) console.log(`Precision:        ${meta.precision.toFixed(3)}`);
+  if (meta.recall !== undefined) console.log(`Recall:           ${meta.recall.toFixed(3)}`);
+  if (meta.f1 !== undefined) console.log(`F1:               ${meta.f1.toFixed(3)}`);
+  if (meta.confusionMatrix !== undefined) {
+    const cm = meta.confusionMatrix;
+    console.log(
+      `Confusion (tp/fn/fp/tn): ${String(cm.tp)}/${String(cm.fn)}/${String(cm.fp)}/${String(cm.tn)}`
+    );
+  }
+  console.log(`Run time:         ${String(runTimeMs)}ms`);
+}
+
+/** Top-level dispatch for the atbench CLI command. */
+export async function atbenchCommand(options: ATBenchOptions): Promise<ATBenchCommandResult> {
+  if (options.subcommand === 'info') return Promise.resolve(runInfo(options));
+  return runEvaluation(options);
+}
+
+/** Parse subcommand argument. */
+function parseSubcommand(arg: string | undefined): ATBenchOptions['subcommand'] {
+  return arg === 'info' ? 'info' : 'run';
+}
+
+/** Parse variant argument. */
+function parseVariant(arg: string): 'claw' | 'codex' {
+  const v = arg.slice('--variant='.length);
+  return v === 'codex' ? 'codex' : 'claw';
+}
+
+interface ParseState {
+  variant: 'claw' | 'codex';
+  limit: number | undefined;
+  fixturePath: string | undefined;
+  llmScoring: boolean;
+  verbose: boolean;
+}
+
+/** Apply a single argv token to the parse state. */
+function applyArg(arg: string, state: ParseState): void {
+  if (arg.startsWith('--variant=')) {
+    state.variant = parseVariant(arg);
+    return;
+  }
+  if (arg.startsWith('--limit=')) {
+    const n = Number(arg.slice('--limit='.length));
+    if (Number.isInteger(n) && n > 0) state.limit = n;
+    return;
+  }
+  if (arg.startsWith('--fixture=')) {
+    state.fixturePath = arg.slice('--fixture='.length);
+    return;
+  }
+  if (arg === '--llm-scoring') state.llmScoring = true;
+  else if (arg === '--verbose' || arg === '-v') state.verbose = true;
+}
+
+/** Parse argv into ATBenchOptions. */
+export function parseAtbenchArgs(argv: readonly string[]): ATBenchOptions {
+  const subcommand = parseSubcommand(argv[0]);
+  const state: ParseState = {
+    variant: 'claw',
+    limit: undefined,
+    fixturePath: undefined,
+    llmScoring: false,
+    verbose: false,
+  };
+  for (const arg of argv.slice(1)) applyArg(arg, state);
+
+  const opts: ATBenchOptions = {
+    subcommand,
+    variant: state.variant,
+    llmScoring: state.llmScoring,
+    verbose: state.verbose,
+    ...(state.limit !== undefined ? { limit: state.limit } : {}),
+    ...(state.fixturePath !== undefined ? { fixturePath: state.fixturePath } : {}),
+  };
+  return opts;
+}
+
+/** Print CLI help text. */
+export function printAtbenchHelp(): void {
+  console.log(`
+nexus-agents atbench — trajectory-safety benchmarking against ATBench
+
+Subcommands:
+  info       Show dataset metadata + scorer mode
+  run        Load trajectories, score, summarize (default)
+
+Options:
+  --variant=<claw|codex>   Dataset variant (default: claw)
+  --limit=<N>              Cap instances (smoke runs)
+  --fixture=<path>         Use local JSONL instead of HuggingFace
+  --llm-scoring            Enable LLM scorer (default: stub oracle)
+  --verbose, -v            Print per-instance progress
+
+Examples:
+  nexus-agents atbench info
+  nexus-agents atbench run --variant=claw --limit=10 --verbose
+  nexus-agents atbench run --fixture=./test/atbench-fixture.jsonl
+`);
+}

--- a/packages/nexus-agents/src/cli/index.ts
+++ b/packages/nexus-agents/src/cli/index.ts
@@ -303,6 +303,16 @@ export type { VerifyOptions, VerifyCheck, VerifyResult } from './verify-command.
 export { sweBenchCommand, parseSweBenchArgs, printSweBenchHelp } from './swe-bench-command.js';
 export type { SWEBenchOptions, SWEBenchCommandResult } from './swe-bench-command.js';
 
+// ATBench Command (Issue #1981 - trajectory safety benchmark)
+export {
+  atbenchCommand,
+  parseAtbenchArgs,
+  printAtbenchHelp,
+  runEvaluation as atbenchRun,
+  runInfo as atbenchInfo,
+} from './atbench-command.js';
+export type { ATBenchOptions, ATBenchCommandResult } from './atbench-command.js';
+
 // Learning Metrics Dashboard (Issue #284)
 export {
   learningMetricsCommand,


### PR DESCRIPTION
Closes the CLI-integration follow-up for #1981. Adds the user-facing \`atbench\` command with \`info\` and \`run\` subcommands.

## Programmatic API

Exported from \`nexus-agents/cli\`:
- \`atbenchCommand(options)\` — top-level dispatch
- \`parseAtbenchArgs(argv)\` — argv parser
- \`printAtbenchHelp()\` — help text
- \`runInfo\` / \`runEvaluation\` — handler functions

## Usage

\`\`\`bash
nexus-agents atbench info
nexus-agents atbench run --variant=claw --limit=10 --verbose
nexus-agents atbench run --fixture=./test/atbench-fixture.jsonl
\`\`\`

(Top-level dispatcher wiring is a small follow-up requiring \`cli-types.ts\` + dispatcher edits — out of scope for this PR.)

## Flags

- \`--variant=<claw|codex>\` — dataset variant (default: claw)
- \`--limit=<N>\` — cap instances for smoke runs
- \`--fixture=<path>\` — local JSONL instead of HuggingFace
- \`--llm-scoring\` — enable LLM scorer (default: stub oracle)
- \`--verbose, -v\` — per-instance progress

\`run\` prints precision/recall/F1/confusion matrix from the BenchmarkRunSummary metadata.

## Tests (17 new)

- arg parsing: defaults, info subcommand, all flags, invalid limit fallback
- runInfo: HF source vs fixture source
- runEvaluation against local fixture: 100% pass with stub oracle, --limit cap, verbose progress
- atbenchCommand top-level dispatch
- printAtbenchHelp smoke

## Validation

- typecheck clean
- 17/17 atbench-command tests pass
- 3364/3364 cli + benchmarks tests pass overall
- TypeDoc regenerated

## #1981 progress

| Sub-task | Status |
|---|---|
| BenchmarkAdapter contract | ✅ #1996 |
| Stub scorer + confusion math | ✅ #1996 |
| HF dataset loader | ✅ #2006 |
| LLM-based scorer | ✅ #2010 |
| **CLI integration (programmatic API)** | ✅ this PR |
| Top-level dispatcher wiring | ⏳ follow-up |
| CI smoke workflow | ⏳ follow-up |