### PR TITLE
feat(cli): wire atbench into top-level dispatcher (#1981)

### DIFF
--- a/.changeset/1981-atbench-dispatcher.md
+++ b/.changeset/1981-atbench-dispatcher.md
@@ -1,0 +1,42 @@
+---
+'nexus-agents': minor
+---
+
+feat(cli): wire atbench into top-level dispatcher (#1981)
+
+Completes the CLI integration for ATBench. After this PR, end users
+can invoke the benchmark directly:
+
+```bash
+nexus-agents atbench info
+nexus-agents atbench run --variant=claw --limit=10
+nexus-agents atbench run --fixture=./test/fixture.jsonl --verbose
+```
+
+## Changes
+
+- `cli-types.ts` — added `'atbench'` to the command union and validCommands array
+- `cli-commands-handlers-complex.ts` — `handleAtbenchCommand` builds argv from parsed CLI args and dispatches to `atbenchCommand` from `cli/atbench-command.ts`
+- `cli-commands-handlers.ts` — re-exports `handleAtbenchCommand` for the dispatcher
+- `cli-commands.ts` — wired into the command-handler map (`atbench: handleAtbenchCommand`)
+- `cli-help-text.ts` — added ATBENCH OPTIONS block and example invocations
+- `cli-commands.test.ts` — added `handleAtbenchCommand` to the mock map
+
+## Tests
+
+- 38 dispatcher + handler tests pass
+- 26043/26059 full-suite pass
+- typecheck clean
+- TypeDoc regenerated
+
+## #1981 status
+
+| Sub-task                        | Status             |
+| ------------------------------- | ------------------ |
+| BenchmarkAdapter contract       | ✅                 |
+| Stub scorer + math              | ✅                 |
+| HF dataset loader               | ✅                 |
+| LLM-based scorer                | ✅                 |
+| CLI programmatic API            | ✅                 |
+| **Top-level dispatcher wiring** | ✅ this PR         |
+| CI smoke workflow               | ⏳ final follow-up |

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,11 +1,17 @@
 {
   "version": "1.0.0",
-  "generated": "2026-04-19T15:23:13.079Z",
+  "generated": "2026-04-19T15:51:13.191Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.39.1",
   "cli": {
     "binary": "nexus-agents",
     "commands": [
+      {
+        "name": "atbench",
+        "type": "async",
+        "handler": "handleAtbenchCommand",
+        "file": "src/cli-commands-handlers.ts"
+      },
       {
         "name": "auth",
         "type": "sync",

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-04-19T15:23:13.079Z
+**Generated:** 2026-04-19T15:51:13.191Z
 **Package Version:** 2.39.1
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -9,12 +9,13 @@
 
 ---
 
-## CLI Commands (41)
+## CLI Commands (42)
 
 Binary: `nexus-agents`
 
 | Command | Type | Handler | Source File |
 | --------- | ------ | --------- | ------------- |
+| `atbench` | async | `handleAtbenchCommand` | `src/cli-commands-handlers.ts` |
 | `auth` | sync | `handleAuthCommand` | `src/cli-commands-handlers.ts` |
 | `capabilities` | sync | `handleCapabilitiesCommand` | `src/cli-commands-handlers.ts` |
 | `config` | async | `handleConfigCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-commands-handlers-complex.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers-complex.ts
@@ -9,10 +9,12 @@
  */
 
 import {
+  atbenchCommand,
   configInitCommand,
   configCommand,
   isValidConfigAction,
   orchestrateCommand,
+  parseAtbenchArgs,
   sweBenchCommand,
 } from './cli/index.js';
 import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
@@ -185,4 +187,26 @@ function buildSweBenchSubArgs(args: ParsedCliArgs): string[] {
 export async function handleSweBenchCommand(args: ParsedCliArgs): Promise<void> {
   const exitCode = await sweBenchCommand(buildSweBenchSubArgs(args));
   process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+}
+
+/** Build raw argv for atbench from parsed CLI args (#1981). */
+function buildAtbenchArgv(args: ParsedCliArgs): readonly string[] {
+  // ParsedCliArgs is strictly typed; access loose options via Record cast.
+  const opts = args.options as unknown as Record<string, unknown>;
+  const argv: string[] = [args.positionals[1] ?? 'run'];
+  if (typeof opts['variant'] === 'string') argv.push(`--variant=${opts['variant']}`);
+  if (typeof opts['limit'] === 'number' || typeof opts['limit'] === 'string') {
+    argv.push(`--limit=${String(opts['limit'])}`);
+  }
+  if (typeof opts['fixture'] === 'string') argv.push(`--fixture=${opts['fixture']}`);
+  if (opts['llm-scoring'] === true || opts['llmScoring'] === true) argv.push('--llm-scoring');
+  if (opts['verbose'] === true) argv.push('--verbose');
+  return argv;
+}
+
+/** Handler for `nexus-agents atbench ...` (#1981). */
+export async function handleAtbenchCommand(args: ParsedCliArgs): Promise<void> {
+  const opts = parseAtbenchArgs(buildAtbenchArgv(args));
+  const result = await atbenchCommand(opts);
+  process.exit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -69,6 +69,7 @@ export {
   handleConfigCommand,
   handleOrchestrateCommand,
   handleSweBenchCommand,
+  handleAtbenchCommand,
 } from './cli-commands-handlers-complex.js';
 
 /**

--- a/packages/nexus-agents/src/cli-commands.test.ts
+++ b/packages/nexus-agents/src/cli-commands.test.ts
@@ -19,6 +19,7 @@ vi.mock('./cli-commands-handlers.js', () => ({
   handleValidationCommand: vi.fn(),
   handleLearningMetricsCommand: vi.fn(),
   handleSweBenchCommand: vi.fn(() => Promise.resolve()),
+  handleAtbenchCommand: vi.fn(() => Promise.resolve()),
   handleVerifyCommand: vi.fn(() => Promise.resolve()),
   handleDoctorCommand: vi.fn(() => Promise.resolve()),
   handleSetupCommand: vi.fn(),

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -31,6 +31,7 @@ export {
   handleValidationCommand,
   handleLearningMetricsCommand,
   handleSweBenchCommand,
+  handleAtbenchCommand,
   handleVerifyCommand,
   handleDoctorCommand,
   handleSetupCommand,
@@ -94,6 +95,7 @@ import {
   handleIndexCommand,
   handleResearchCommand,
   handleSweBenchCommand,
+  handleAtbenchCommand,
   handleSetupCommandAsync,
   handleHelloCommand,
   handleHooksCommand,
@@ -223,6 +225,7 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
     index: handleIndexCommand,
     research: handleResearchCommand,
     'swe-bench': handleSweBenchCommand,
+    atbench: handleAtbenchCommand,
     hooks: handleHooksCommand,
     setup: handleSetupCommandAsync, // Uses async for interactive wizard support (Issue #425)
     demo: handleDemoCommand, // Made async for live CLI execution

--- a/packages/nexus-agents/src/cli-help-text.ts
+++ b/packages/nexus-agents/src/cli-help-text.ts
@@ -42,6 +42,7 @@ COMMANDS:
   validation      Show learning validation dashboard
   learning-metrics Show aggregated learning metrics dashboard
   swe-bench       Run SWE-bench evaluation benchmark
+  atbench         Run ATBench trajectory-safety evaluation (#1981)
   hooks           Claude CLI hook integration commands
   fitness-audit   Run CLI orchestration fitness score audit
   release-notes   Generate release notes from git commits
@@ -170,6 +171,14 @@ SWE-BENCH OPTIONS:
   --resume               Skip already completed instances
   --instance=<id>        Run specific instance (can be repeated)
   --verbose              Enable verbose output
+
+ATBENCH OPTIONS:
+  atbench run            Score trajectories + summarize (default)
+  atbench info           Print dataset metadata + scorer mode
+  --variant=<claw|codex> Dataset variant (default: claw)
+  --limit=<N>            Cap instances (smoke runs)
+  --fixture=<path>       Use local JSONL instead of HuggingFace
+  --llm-scoring          Enable LLM scorer (default: stub oracle)
 
 HOOKS OPTIONS:
   hooks session-start    Handle SessionStart hook events
@@ -336,6 +345,8 @@ EXAMPLES:
   nexus-agents swe-bench run --limit=5            Run 5 SWE-bench instances
   nexus-agents swe-bench status                   Check progress
   nexus-agents swe-bench evaluate                 Evaluate predictions
+  nexus-agents atbench info                       Show ATBench info
+  nexus-agents atbench run --variant=claw --limit=10  Smoke-test ATBench
   nexus-agents hooks --help                       Show hooks command help
   nexus-agents hooks session-start                Handle session start hook
   nexus-agents hooks pre-tool --tool Bash         Handle pre-tool hook for Bash

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -45,6 +45,7 @@ export type CliCommand =
   | 'validation'
   | 'learning-metrics'
   | 'swe-bench'
+  | 'atbench'
   | 'setup'
   | 'hooks'
   | 'demo'
@@ -396,6 +397,7 @@ export function isValidCommand(value: string): value is CliCommand {
     'validation',
     'learning-metrics',
     'swe-bench',
+    'atbench',
     'setup',
     'hooks',
     'demo',


### PR DESCRIPTION
End-user can now invoke ATBench directly:

\`\`\`bash
nexus-agents atbench info
nexus-agents atbench run --variant=claw --limit=10
nexus-agents atbench run --fixture=./test/fixture.jsonl --verbose
\`\`\`

## Changes

- \`cli-types.ts\` — \`'atbench'\` added to command union + validCommands
- \`cli-commands-handlers-complex.ts\` — \`handleAtbenchCommand\` builds argv and dispatches
- \`cli-commands-handlers.ts\` — re-exports \`handleAtbenchCommand\`
- \`cli-commands.ts\` — wired into command-handler map
- \`cli-help-text.ts\` — ATBENCH OPTIONS block + examples
- \`cli-commands.test.ts\` — mock map updated

## Validation

- \`pnpm typecheck\`: 0 errors
- 38 dispatcher + handler tests pass
- 26043/26059 full-suite tests pass (16 pre-existing skips)
- TypeDoc regenerated

## Closes the wiring sub-task of #1981

Only remaining sub-task: CI smoke workflow that exercises \`atbench run --fixture=...\` against a tiny in-repo fixture.