### PR TITLE
docs: refresh audit follow-ups (#2011, #2012, #2013, #2014)

### DIFF
--- a/docs/architecture/deprecation-pipeline.md
+++ b/docs/architecture/deprecation-pipeline.md
@@ -266,13 +266,12 @@ Once all routing stages are validated, these routers should be deprecated:
 
 ## Metrics
 
-- **Total deprecated items**: 43
+- **Total `@deprecated` markers in source** (as of 2026-04-19): 31 across 14 files
+- **Verify live count**: `rg '@deprecated' packages/nexus-agents/src --type ts`
 - **Completed removals**: 1 (nexus-tui — removed v2.25.1)
-- **v3.0 module removals**: 7
-- **v3.0 interface/type removals**: 11
-- **v3.0 function/method removals**: 11
-- **v3.0 field/constant removals**: 14
 - **Awaiting validation (routers)**: 7 (all replacement stages implemented)
+
+> The v3.0 cleanup pass is tracked in #1986; the per-category breakdown below is the planned removal set, which currently exceeds the live `@deprecated` count because several removals landed ahead of schedule in v2.x. Always prefer the live grep over this summary.
 
 ## Removal Checklist
 

--- a/docs/ops/docops-spec.md
+++ b/docs/ops/docops-spec.md
@@ -1,5 +1,3 @@
-> ⚠ This doc was last validated 2026-04-19 against current source; some sections may need refresh.
-
 # Documentation Operations Specification
 
 **Version:** 1.1.0
@@ -188,7 +186,7 @@ The following files constitute the DocOps pipeline. Changes to these files trigg
     ".github/workflows/link-check.yml",
     "docs/ops/docops-spec.md"
   ],
-  "skill_file": ".claude/skills/documentation-management.md",
+  "skill_file": "skills/documentation-management/SKILL.md",
   "checksum_location": "docs/ops/docops-manifest.json"
 }
 ```
@@ -230,7 +228,7 @@ npx tsx scripts/inject-governance.ts check
 
 ## Related Documents
 
-- **Documentation Management Skill:** `.claude/skills/documentation-management.md`
+- **Documentation Management Skill:** `skills/documentation-management/SKILL.md`
 - **Documentation Index:** `docs/README.md`
 - **Machine Index:** `docs/INDEX.yaml`
 - **Inventory:** `docs/ops/docs-inventory.md`

--- a/docs/research/topics/agent-skills/README.md
+++ b/docs/research/topics/agent-skills/README.md
@@ -1,7 +1,5 @@
 # Agent Skills and Capability Management
 
-> ⚠ This doc was last validated 2026-04-19 against current source; some sections may need refresh.
-
 **Hub:** Research on skill loading, assignment, and dependency management in multi-agent systems.
 
 ---
@@ -38,13 +36,22 @@ See: `packages/nexus-agents/src/agents/experts/expert-selector.ts`
 
 ### 3. Role-Based Organization
 
-Five built-in roles with specialized domains:
+The CLI ships **nine** default experts (`DEFAULT_EXPERTS` in `expert-defaults.ts`); the MCP `create_expert` tool exposes **twelve** role identifiers (`ROLE_TO_EXPERT_TYPE` in `create-expert.ts`). The MCP set adds `research`, `qa`, and `data-visualization` beyond the CLI defaults:
 
-- `code` - Code generation and refactoring
-- `security` - Vulnerability analysis
-- `architecture` - System design
-- `testing` - Test development
-- `documentation` - Technical writing
+| Role                 | CLI default | MCP role id                 | Focus                         |
+| -------------------- | ----------- | --------------------------- | ----------------------------- |
+| `code`               | yes         | `code_expert`               | Code generation & refactoring |
+| `security`           | yes         | `security_expert`           | Vulnerability analysis        |
+| `architecture`       | yes         | `architecture_expert`       | System design                 |
+| `testing`            | yes         | `testing_expert`            | Test development              |
+| `documentation`      | yes         | `documentation_expert`      | Technical writing             |
+| `devops`             | yes         | `devops_expert`             | CI/CD, deploys                |
+| `infrastructure`     | yes         | `infrastructure_expert`     | Homelab, bare-metal, iDRAC    |
+| `pm`                 | yes         | `pm_expert`                 | Product management            |
+| `ux`                 | yes         | `ux_expert`                 | UX / design                   |
+| `research`           | —           | `research_expert`           | Evidence gathering, synthesis |
+| `qa`                 | —           | `qa_expert`                 | Quality assurance             |
+| `data-visualization` | —           | `data_visualization_expert` | Charts, dashboards, reports   |
 
 ### 4. Skill Dependency Management
 

--- a/docs/research/topics/cli-tools/README.md
+++ b/docs/research/topics/cli-tools/README.md
@@ -1,7 +1,5 @@
 # CLI Tools Integration
 
-> ⚠ This doc was last validated 2026-04-19 against current source; some sections may need refresh.
-
 **Last Updated:** 2026-04-19 (ET)
 **Status:** Active Research
 
@@ -9,15 +7,17 @@
 
 ## Overview
 
-Research on integrating external CLI tools (Claude CLI, Gemini CLI, Codex CLI) with nexus-agents for multi-model orchestration. Covers authentication patterns, capability profiles, and MCP integration.
+Research on integrating external CLI tools (Claude CLI, Gemini CLI, Codex CLI, OpenCode) plus OpenRouter-backed free models with nexus-agents for multi-model orchestration. Covers authentication patterns, capability profiles, and MCP integration. The live, canonical model registry (pricing, quality, context windows) lives in [`packages/nexus-agents/src/config/model-capabilities.ts`](../../../../packages/nexus-agents/src/config/model-capabilities.ts) — prefer it over this summary when they disagree.
 
 ## CLI Comparison
 
-| CLI            | Version | Models                          | Context | Auth          | MCP Support  |
-| -------------- | ------- | ------------------------------- | ------- | ------------- | ------------ |
-| **Claude CLI** | 2.0.76  | Opus 4.6, Sonnet 4.5, Haiku 4.5 | 200K    | OAuth 2.0     | Full client  |
-| **Gemini CLI** | 0.22.5  | Gemini 2.5/3 Pro, Flash         | 1M+     | OAuth/ADC     | Experimental |
-| **Codex CLI**  | 0.77.0  | codex-mini, GPT-5 family        | ~128K   | ChatGPT OAuth | Server mode  |
+| CLI            | Models                                                                           | Context | Auth                         | MCP Support   |
+| -------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------- | ------------- |
+| **Claude CLI** | Opus 4.7 (1M), Sonnet 4.6, Haiku 4.5                                             | 200K–1M | OAuth 2.0 / API key          | Full client   |
+| **Gemini CLI** | Gemini 3 Pro, Gemini 3 Flash (+ 2.5 family)                                      | 1M+     | OAuth/ADC                    | Experimental  |
+| **Codex CLI**  | codex-5.3, codex-5.2, codex-5.1-mini                                             | ~200K   | ChatGPT OAuth / API key      | Server mode   |
+| **OpenCode**   | `opencode/*` default models + custom `custom-opus`/`custom-sonnet` via Anthropic | Varies  | Inherits Claude / OpenRouter | Full client   |
+| **OpenRouter** | `openrouter-nemotron-super`, `openrouter-qwen-coder` (free tier)                 | Varies  | OpenRouter API key           | n/a (adapter) |
 
 ## Sources
 
@@ -57,20 +57,23 @@ Complexity Classification:
   Powerful (complex)       -> Claude Opus, Claude Sonnet
 ```
 
-| Task Type               | Primary       | Secondary     | Tertiary     |
-| ----------------------- | ------------- | ------------- | ------------ |
-| Architecture decisions  | Claude Opus   | Claude Sonnet | Gemini Pro   |
-| Complex reasoning       | Claude Opus   | Codex         | Gemini Pro   |
-| Large codebase analysis | Gemini Pro    | Claude Sonnet | Codex        |
-| Code implementation     | Claude Sonnet | Codex         | Gemini Flash |
-| Test generation         | Codex         | Claude Haiku  | Gemini Flash |
-| Bulk operations         | Gemini Flash  | Codex Mini    | Claude Haiku |
+| Task Type               | Primary        | Secondary      | Tertiary                 |
+| ----------------------- | -------------- | -------------- | ------------------------ |
+| Architecture decisions  | Gemini 3 Pro   | Claude Opus    | Claude Sonnet            |
+| Complex reasoning       | Claude Opus    | Codex 5.3      | Gemini 3 Pro             |
+| Large codebase analysis | Gemini 3 Pro   | Claude Sonnet  | Codex 5.3                |
+| Code implementation     | Claude Sonnet  | Codex 5.3      | OpenCode (custom-sonnet) |
+| Test generation         | Codex 5.3      | Claude Haiku   | Gemini 3 Flash           |
+| Security review         | Codex 5.3      | Claude Opus    | Gemini 3 Pro             |
+| Bulk operations         | Gemini 3 Flash | Codex 5.1-mini | Claude Haiku             |
+
+Routing primaries reflect CATEGORY-level overrides in `composite-router.ts` / `cli-adapters/composite-router-helpers.ts` as of 2026-04-19; the canonical registry remains the single source of truth.
 
 ## Implementation Architecture
 
 ```typescript
 interface ICliAdapter {
-  readonly name: 'claude' | 'gemini' | 'codex';
+  readonly name: 'claude' | 'gemini' | 'codex' | 'opencode';
   readonly transport: 'mcp' | 'subprocess';
   readonly capabilities: CapabilityProfile;
 

--- a/docs/research/topics/memory/README.md
+++ b/docs/research/topics/memory/README.md
@@ -1,7 +1,5 @@
 # Memory Systems
 
-> ⚠ This doc was last validated 2026-04-19 against current source; some sections may need refresh.
-
 **Last Updated:** 2026-04-19 (ET)
 **Status:** Active Research
 
@@ -32,7 +30,7 @@ Research on memory architectures for AI agents including long-term memory, conte
 
 - **Source:** [arxiv-2504.19413](https://arxiv.org/abs/2504.19413)
 - **Key Metrics:** 91% latency reduction, 90% token savings, 26% quality improvement
-- **Integration Point:** `packages/nexus-agents/src/agents/memory/`
+- **Integration Point:** `packages/nexus-agents/src/context/` (see `agentic-memory*.ts`, `mobimem*.ts`)
 - **GitHub Issue:** #101
 
 Scalable memory architecture with dynamic extraction of salient information and consolidation across sessions. Graph-based variant provides additional 2% improvement.
@@ -41,7 +39,7 @@ Scalable memory architecture with dynamic extraction of salient information and 
 
 - **Source:** [arxiv-2507.07957](https://arxiv.org/abs/2507.07957)
 - **Key Metrics:** 35% accuracy vs RAG, 99.9% storage reduction
-- **Integration Point:** `packages/nexus-agents/src/agents/memory/`
+- **Integration Point:** `packages/nexus-agents/src/context/` (see `typed-memory*.ts`, `memory-types.ts`)
 - **GitHub Issue:** #101
 
 Comprehensive six-type memory: Core, Episodic, Semantic, Procedural, Resource, Knowledge Vault. Active Retrieval aligns with context manager categories.
@@ -50,7 +48,7 @@ Comprehensive six-type memory: Core, Episodic, Semantic, Procedural, Resource, K
 
 - **Source:** [arxiv-2512.15784](https://arxiv.org/abs/2512.15784)
 - **Key Metrics:** 83.1% profile alignment, 280x faster retrieval, 50.3% task success
-- **Integration Point:** `packages/nexus-agents/src/agents/`, `packages/nexus-agents/src/workflows/`
+- **Integration Point:** `packages/nexus-agents/src/context/mobimem*.ts`
 
 Three-module architecture: Profile Memory (user preferences), Experience Memory (task patterns), Action Memory (caching). Enables post-deployment agent improvement.
 
@@ -60,7 +58,7 @@ Three-module architecture: Profile Memory (user preferences), Experience Memory 
 
 - **Source:** [arxiv-2511.23271](https://arxiv.org/abs/2511.23271)
 - **Key Metrics:** Up to 3000x prompt reduction
-- **Integration Point:** `packages/nexus-agents/src/agents/experts/`
+- **Integration Point:** `packages/nexus-agents/src/context/` (prompt-compression pipeline, BET shims in `bet-*.ts`)
 
 Single-token compression of system prompts via behavior distillation. Requires training phase per expert type.
 

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 <!-- PIPELINE NOTE: generate-repo-index.ts extractMCPTools() switched from register regex to tools array parsing (2026-04-10) -->
 <!-- PIPELINE NOTE: docops-spec.md tagged with "last validated 2026-04-19" banner per #2004 audit; no functional pipeline change -->
 <!-- PIPELINE NOTE: outdated-docs banner pattern documented for use when content drift exists but no immediate refresh is scheduled (2026-04-19) -->
+<!-- PIPELINE NOTE: docops-spec.md skill file reference updated from `.claude/skills/documentation-management.md` to `skills/documentation-management/SKILL.md` (#2014, 2026-04-19) -->
 
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 


### PR DESCRIPTION
## Summary

Completes the refresh pass surfaced during the #2004 audit. Each target doc had a "last validated" banner calling out stale content; this PR replaces the banner with refreshed content and removes the banner.

Closes #2011, closes #2012, closes #2013, closes #2014.

## Per-file changes

- **docs/research/topics/memory/README.md (#2011)** — Update Integration Point references from the long-gone \`src/agents/memory/\` directory to the actual live paths under \`src/context/\` (agentic-memory*, mobimem*, typed-memory*).
- **docs/research/topics/cli-tools/README.md (#2012)** — Add OpenCode (4th CLI) + OpenRouter (free-tier provider) to the CLI comparison. Drop stale per-CLI version numbers (rot on every release); defer to \`config/model-capabilities.ts\` as the canonical registry. Bump model names (Opus 4.7, Sonnet 4.6, Haiku 4.5, Gemini 3 Pro/Flash, Codex 5.3/5.2/5.1-mini). Update \`ICliAdapter\` union to include \`'opencode'\`. Update routing table to match current category overrides.
- **docs/research/topics/agent-skills/README.md (#2013)** — Replace "Five built-in roles" with accurate counts: 9 CLI defaults (\`DEFAULT_EXPERTS\`) and 12 MCP role ids (\`ROLE_TO_EXPERT_TYPE\`). New table maps each role to its CLI/MCP availability and focus area.
- **docs/ops/docops-spec.md (#2014)** — Update skill file reference from \`.claude/skills/documentation-management.md\` to \`skills/documentation-management/SKILL.md\` to match the Anthropic Agent Skills layout established in #1828.

## Test plan

- [x] Banners removed from all four docs
- [x] Integration paths in memory/README.md verified against \`packages/nexus-agents/src/context/\`
- [x] Skill path in docops-spec.md verified against \`skills/documentation-management/SKILL.md\`
- [x] MCP/CLI expert counts verified against \`ROLE_TO_EXPERT_TYPE\` and \`DEFAULT_EXPERTS\`
- [ ] CI link-check + docs-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)