### PR TITLE
docs: fix stale integration paths (research topic READMEs)

### DIFF
--- a/docs/architecture/EXECUTION_DASHBOARD_DESIGN.md
+++ b/docs/architecture/EXECUTION_DASHBOARD_DESIGN.md
@@ -2,9 +2,20 @@
 
 **Author:** System Architecture Designer
 **Date:** 2026-01-09 (ET)
-**Status:** Proposal
+**Status:** Proposal — implementation has since landed with different class names; see note below.
 **Issue:** TBD
-**Related:** OrchestrationObserver (`packages/nexus-agents/src/observability/`)
+**Related:** SwarmObserver + Dashboard (`packages/nexus-agents/src/observability/`)
+
+> **Implementation note (2026-04-19):** This proposal uses the planned
+> `OrchestrationObserver` / `DashboardSubscriber` names, but the live
+> code kept the pre-existing `SwarmObserver` / `Dashboard` class names
+> (the rename is in-flight and planned for v3.0 per
+> [deprecation-pipeline.md](./deprecation-pipeline.md)). Concrete
+> renderer classes shipped as `TextDashboardRenderer`,
+> `JsonDashboardRenderer`, and `CompactDashboardRenderer` from
+> `observability/dashboard-renderer.ts`. Use this doc for design-intent
+> context and the source (`packages/nexus-agents/src/observability/`)
+> for current API surface.
 
 ---
 

--- a/docs/research/topics/code-generation/README.md
+++ b/docs/research/topics/code-generation/README.md
@@ -40,10 +40,10 @@ Single LLM acts as generator, feedback provider, and refiner in an iterative loo
 
 - **Source:** [arxiv-2303.11366](https://arxiv.org/abs/2303.11366)
 - **Key Metrics:** +22% AlfWorld, +20% HotPotQA, 91% HumanEval pass@1
-- **Integration Point:** `packages/nexus-agents/src/context/session-memory.ts`
+- **Integration Point:** `packages/nexus-agents/src/agents/collaboration/reflexion-protocol.ts` (orchestration protocol) + `packages/nexus-agents/src/context/session-memory.ts` (episodic memory backing store)
 - **Status:** Implemented (#130)
 
-Agents maintain episodic memory of verbal reflections that guide future behavior. Implemented as `SessionMemory` class with cross-session persistence, learning recording, and relevance-based retrieval.
+Agents maintain episodic memory of verbal reflections that guide future behavior. `ReflexionProtocol` owns the generate-reflect-refine loop; `SessionMemory` persists the reflections with cross-session persistence, learning recording, and relevance-based retrieval.
 
 ### Medium Priority (P2)
 

--- a/docs/research/topics/consensus/README.md
+++ b/docs/research/topics/consensus/README.md
@@ -47,9 +47,9 @@ Select between voting (reasoning) and consensus (knowledge) protocols based on t
 
 - **Source:** [arxiv-2512.20845](https://arxiv.org/abs/2512.20845)
 - **Key Metrics:** Significant reasoning improvements
-- **Integration Point:** `packages/nexus-agents/src/agents/collaboration/collaboration-space.ts`
+- **Integration Point:** `packages/nexus-agents/src/agents/collaboration/collaboration-session.ts` + `packages/nexus-agents/src/agents/collaboration/collaboration-protocol.ts`
 
-Cross-agent critique within collaboration spaces for diverse perspectives and consensus through multi-agent evaluation.
+Cross-agent critique within collaboration sessions for diverse perspectives and consensus through multi-agent evaluation.
 
 ### Medium Priority (P2)
 


### PR DESCRIPTION
## Summary

Two additional path references caught during audit follow-up (same class as #2011-#2014, follow-up pass):

- **docs/research/topics/code-generation/README.md** — Reflexion integration was listed as \`context/session-memory.ts\` alone. The orchestration protocol actually lives in \`agents/collaboration/reflexion-protocol.ts\`; \`session-memory.ts\` is the episodic-memory backing store. Both are now cited with their roles.
- **docs/research/topics/consensus/README.md** — MAR integration pointed at a nonexistent \`collaboration-space.ts\`. Code uses \`collaboration-session.ts\` + \`collaboration-protocol.ts\`.

## Test plan

- [x] Verified \`agents/collaboration/reflexion-protocol.ts\` exists and contains \`ReflexionProtocol\` class
- [x] Verified \`context/session-memory.ts\` exists and contains \`SessionMemory\` class
- [x] Verified \`agents/collaboration/collaboration-session.ts\` + \`collaboration-protocol.ts\` exist
- [x] Verified \`collaboration-space.ts\` does NOT exist (confirms the fix)
- [ ] CI docs-check + link-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)