### PR TITLE
chore(ci): make TypeDoc drift non-blocking (#2027)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -22,6 +22,12 @@ concurrency:
   cancel-in-progress: true
 jobs:
   # Job 1: TypeDoc Drift Detection
+  #
+  # The TypeDoc HTML output is non-deterministic in small ways (hierarchy/
+  # navigation metadata re-orders when unrelated enum shapes change). Rather
+  # than blocking every PR that touches a typed function, we surface drift
+  # as a warning annotation and let humans regenerate when it accumulates.
+  # (#2027)
   typedoc-check:
     name: TypeDoc Verification
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -39,9 +45,8 @@ jobs:
           if git diff --exit-code packages/nexus-agents/docs/api/; then
             echo "✅ TypeDoc output is in sync"
           else
-            echo "::error::TypeDoc output has drifted from committed version"
-            echo "Run 'pnpm --filter nexus-agents docs' and commit the changes"
-            exit 1
+            echo "::warning title=TypeDoc drift::Generated docs have drifted from committed version. Run 'pnpm --filter nexus-agents docs' and commit when convenient. Not blocking per #2027."
+            # Exit 0 — drift is non-blocking.
           fi
 
   # Job 2: Link Validation

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -23,6 +23,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 <!-- PIPELINE NOTE: docops-spec.md tagged with "last validated 2026-04-19" banner per #2004 audit; no functional pipeline change -->
 <!-- PIPELINE NOTE: outdated-docs banner pattern documented for use when content drift exists but no immediate refresh is scheduled (2026-04-19) -->
 <!-- PIPELINE NOTE: docops-spec.md skill file reference updated from `.claude/skills/documentation-management.md` to `skills/documentation-management/SKILL.md` (#2014, 2026-04-19) -->
+<!-- PIPELINE NOTE: TypeDoc Verification CI job (docs-check.yml) downgraded from blocking failure to warning annotation (#2027, 2026-04-19) — drift was creating merge-round-trip noise without providing actionable signal -->
 
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 


### PR DESCRIPTION
## Summary

Downgrades the \`TypeDoc Verification\` CI check from blocking failure to a warning annotation. Closes #2027.

## Why

TypeDoc HTML output is non-deterministic in small ways — hierarchy/navigation metadata re-orders when unrelated enum shapes change. Three recent PRs (#2021, #2024, #2026) all hit this gate with trivial drift, each requiring a round-trip regen commit. This is operational noise, not a quality signal.

## Alternatives considered

1. **Drop the gate entirely** — too aggressive; we still want the signal.
2. **Make it non-blocking (this PR)** — warning annotation preserves visibility.
3. **Auto-commit regen from CI** — rejected for now: adds \`contents: write\` permission to the docs-check workflow, which is a larger security/complexity tradeoff for a low-severity issue. Revisit if noise accumulates.

## Test plan

- [x] Workflow syntax valid
- [ ] CI green (any drift now reports as warning, not error)
- [ ] Verify next merge with minor TypeDoc drift isn't blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)