### PR TITLE
feat(swe-bench): per-expert context-budget observer (#2031)

### DIFF
--- a/.changeset/2031-expert-context-observer.md
+++ b/.changeset/2031-expert-context-observer.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): per-expert context-budget observer (#2031)
+
+Adds non-blocking context-utilization telemetry around
+`expert.execute(task)` in the `execute_expert` MCP tool path.
+
+- After each expert call succeeds, computes utilization =
+  `tokensUsed / contextWindow` (window looked up from the canonical
+  model registry via `getModelContextWindow`).
+- When utilization >= `NEXUS_CONTEXT_WARN_THRESHOLD` (default 0.85),
+  emits a `context_warning` log entry with `expertId`, `role`,
+  `modelId`, raw token counts, percent utilization, and task length.
+- Below threshold, emits `context_utilization` at debug level.
+- Never throws — telemetry failure must not break the caller.
+
+Addresses #2031 (child of #1574 SWE-bench Verified prep epic). The
+workflow layer already has budget enforcement via
+`budget-circuit-breaker.ts`, but expert-direct calls via
+`execute_expert` bypass that path. This closes the visibility gap.
+
+Next step (separate issue): aggregate these events in the SWE-bench
+runner to identify context-exhaustion failure modes on SWE-bench
+Verified.

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -50,6 +50,11 @@ import {
   withAccessPolicy,
   resolveAccessPolicyMode,
 } from '../../security/access-constraint-deriver/index.js';
+// Per-expert context-budget observer (#2031). Telemetry-only; never
+// influences the call. Emits `context_warning` when utilization crosses
+// threshold (default 85%, overridable via NEXUS_CONTEXT_WARN_THRESHOLD).
+import { observeExpertContext } from './expert-context-observer.js';
+import type { ExpertContextObservation } from './expert-context-observer.js';
 import { getExpertTaskTimeout, HEARTBEAT_TIMEOUTS } from '../../config/timeouts.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
@@ -227,6 +232,30 @@ function buildSuccessResponse(params: SuccessResponseParams): ExecuteExpertRespo
 }
 
 /** Injects past error solutions into task context (best-effort). */
+/**
+ * Observe context-budget utilization if the expert call succeeded
+ * (#2031). Extracted to keep runExpertTask under the 50-line limit.
+ */
+function observeExpertContextIfOk(
+  result: Awaited<ReturnType<Expert['execute']>>,
+  expert: Expert,
+  task: Task,
+  durationMs: number,
+  logger: ILogger | undefined
+): void {
+  if (!result.ok) return;
+  const expertModelId = expert.expertConfig.modelPreference?.modelId;
+  const observation: ExpertContextObservation = {
+    expertId: expert.id,
+    role: expert.role,
+    modelId: expertModelId as ExpertContextObservation['modelId'],
+    tokensUsed: result.value.metadata.tokensUsed,
+    taskDescription: task.description,
+    durationMs,
+  };
+  observeExpertContext(observation, logger);
+}
+
 /**
  * Derive a ClawGuard access policy for this expert invocation (#1977, #2022).
  *
@@ -451,6 +480,7 @@ async function runExpertTask(
         monitor.endSession(sessionId);
       }
       const durationMs = getTimeProvider().now() - startTime;
+      observeExpertContextIfOk(result, expert, task, durationMs, deps.logger);
       const classified = await classifyExpertResult({
         result,
         expert,

--- a/packages/nexus-agents/src/mcp/tools/expert-context-observer.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/expert-context-observer.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for per-expert context-budget observer (#2031).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ILogger } from '../../core/index.js';
+import {
+  DEFAULT_CONTEXT_WARN_THRESHOLD,
+  computeExpertContextUtilization,
+  observeExpertContext,
+  resolveContextWarnThreshold,
+  type ExpertContextObservation,
+} from './expert-context-observer.js';
+
+function makeLogger(): ILogger {
+  const logger: Record<string, unknown> = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    setLevel: vi.fn(),
+  };
+  logger['child'] = vi.fn(() => logger as unknown as ILogger);
+  return logger as unknown as ILogger;
+}
+
+function makeObservation(
+  overrides: Partial<ExpertContextObservation> = {}
+): ExpertContextObservation {
+  return {
+    expertId: 'test-expert-1',
+    role: 'code',
+    modelId: 'claude-opus',
+    tokensUsed: 10_000,
+    taskDescription: 'test task',
+    durationMs: 1200,
+    ...overrides,
+  };
+}
+
+describe('resolveContextWarnThreshold', () => {
+  beforeEach(() => {
+    delete process.env['NEXUS_CONTEXT_WARN_THRESHOLD'];
+  });
+
+  afterEach(() => {
+    delete process.env['NEXUS_CONTEXT_WARN_THRESHOLD'];
+  });
+
+  it('returns default when env var unset', () => {
+    expect(resolveContextWarnThreshold()).toBe(DEFAULT_CONTEXT_WARN_THRESHOLD);
+  });
+
+  it('honors valid env override in (0, 1]', () => {
+    process.env['NEXUS_CONTEXT_WARN_THRESHOLD'] = '0.7';
+    expect(resolveContextWarnThreshold()).toBe(0.7);
+
+    process.env['NEXUS_CONTEXT_WARN_THRESHOLD'] = '1';
+    expect(resolveContextWarnThreshold()).toBe(1);
+  });
+
+  it('falls back to default on invalid values', () => {
+    for (const bad of ['', 'abc', '0', '-0.5', '1.5', '2']) {
+      process.env['NEXUS_CONTEXT_WARN_THRESHOLD'] = bad;
+      expect(resolveContextWarnThreshold()).toBe(DEFAULT_CONTEXT_WARN_THRESHOLD);
+    }
+  });
+});
+
+describe('computeExpertContextUtilization', () => {
+  it('uses 200k default window when modelId is undefined', () => {
+    const u = computeExpertContextUtilization({ modelId: undefined, tokensUsed: 100_000 });
+    expect(u.contextWindow).toBe(200_000);
+    expect(u.utilization).toBeCloseTo(0.5, 5);
+    expect(u.warned).toBe(false);
+  });
+
+  it('sets warned=true when utilization >= threshold', () => {
+    const u = computeExpertContextUtilization({ modelId: undefined, tokensUsed: 170_000 }, 0.85);
+    expect(u.utilization).toBeCloseTo(0.85, 5);
+    expect(u.warned).toBe(true);
+  });
+
+  it('sets warned=false when utilization < threshold', () => {
+    const u = computeExpertContextUtilization({ modelId: undefined, tokensUsed: 100_000 }, 0.85);
+    expect(u.warned).toBe(false);
+  });
+
+  it('honors custom threshold', () => {
+    const u = computeExpertContextUtilization({ modelId: undefined, tokensUsed: 80_000 }, 0.3);
+    expect(u.warned).toBe(true);
+  });
+});
+
+describe('observeExpertContext', () => {
+  it('emits warn log when threshold crossed', () => {
+    const logger = makeLogger();
+    // claude-opus has a 1M context window per model-capabilities.ts, so
+    // 900k tokens is 90% utilization → above default threshold.
+    observeExpertContext(makeObservation({ modelId: 'claude-opus', tokensUsed: 900_000 }), logger);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'context_warning',
+      expect.objectContaining({
+        event: 'context_warning',
+        expertId: 'test-expert-1',
+        role: 'code',
+        modelId: 'claude-opus',
+        utilizationPercent: 90,
+        thresholdPercent: 85,
+      })
+    );
+  });
+
+  it('emits debug log when below threshold', () => {
+    const logger = makeLogger();
+    observeExpertContext(makeObservation({ modelId: 'claude-opus', tokensUsed: 100_000 }), logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'context_utilization',
+      expect.objectContaining({
+        event: 'context_utilization',
+        utilizationPercent: 10,
+      })
+    );
+  });
+
+  it('honors custom threshold argument', () => {
+    const logger = makeLogger();
+    observeExpertContext(
+      makeObservation({ modelId: 'claude-opus', tokensUsed: 400_000 }),
+      logger,
+      0.3
+    );
+    // 400k / 1M = 40% > 30% → warn
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('returns safe defaults when logger is undefined', () => {
+    const result = observeExpertContext(
+      makeObservation({ modelId: 'claude-opus', tokensUsed: 900_000 }),
+      undefined
+    );
+    expect(result.warned).toBe(true);
+    expect(result.utilization).toBeCloseTo(0.9, 5);
+  });
+
+  it('never throws even on adversarial inputs', () => {
+    const logger = makeLogger();
+    expect(() =>
+      observeExpertContext(makeObservation({ tokensUsed: Number.NaN }), logger)
+    ).not.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/expert-context-observer.ts
+++ b/packages/nexus-agents/src/mcp/tools/expert-context-observer.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-expert context-budget observer (#2031, child of #1574).
+ *
+ * Non-blocking telemetry wrapper: after an expert call completes, read
+ * tokensUsed from the result metadata, compare against the model's
+ * context window, and emit a `context_warning` log entry when the
+ * utilization ratio crosses a configurable threshold.
+ *
+ * Default threshold: 0.85 (85% of context window used). Operators can
+ * override via `NEXUS_CONTEXT_WARN_THRESHOLD` env var.
+ *
+ * Runs AFTER `expert.execute(task)` returns — it cannot influence the
+ * call itself. The observer is purely informational; downstream SWE-
+ * bench work uses this telemetry to size tasks to fit fresh context
+ * windows.
+ *
+ * @module mcp/tools/expert-context-observer
+ */
+
+import type { ILogger } from '../../core/index.js';
+import { getModelContextWindow } from '../../config/model-config-helpers.js';
+import type { ModelId } from '../../config/model-capabilities-types.js';
+
+/** Default utilization threshold for emitting a context warning. */
+export const DEFAULT_CONTEXT_WARN_THRESHOLD = 0.85;
+
+/** Env-var name for overriding the default threshold. */
+export const CONTEXT_WARN_THRESHOLD_ENV = 'NEXUS_CONTEXT_WARN_THRESHOLD';
+
+/**
+ * Resolve the utilization threshold from environment or default.
+ *
+ * Invalid values (non-numeric, <= 0, > 1) silently fall back to the
+ * default — this is a telemetry layer and must not fail startup on a
+ * misconfiguration.
+ */
+export function resolveContextWarnThreshold(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[CONTEXT_WARN_THRESHOLD_ENV];
+  if (typeof raw !== 'string' || raw.length === 0) return DEFAULT_CONTEXT_WARN_THRESHOLD;
+  const parsed = Number.parseFloat(raw);
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 1) return parsed;
+  return DEFAULT_CONTEXT_WARN_THRESHOLD;
+}
+
+/**
+ * Observation inputs — what the observer needs to decide whether to warn.
+ */
+export interface ExpertContextObservation {
+  readonly expertId: string;
+  readonly role: string;
+  readonly modelId: ModelId | undefined;
+  readonly tokensUsed: number;
+  readonly taskDescription: string;
+  readonly durationMs: number;
+}
+
+/**
+ * Utilization calculation result. Exported for tests + telemetry
+ * consumers (e.g., the SWE-bench runner may aggregate these).
+ */
+export interface ContextUtilization {
+  readonly tokensUsed: number;
+  readonly contextWindow: number;
+  readonly utilization: number; // 0..1
+  readonly warned: boolean;
+  readonly threshold: number;
+}
+
+/**
+ * Compute utilization without emitting a log entry. Separated so the
+ * SWE-bench runner can aggregate stats across many calls without
+ * spamming the log channel.
+ */
+export function computeExpertContextUtilization(
+  observation: Pick<ExpertContextObservation, 'modelId' | 'tokensUsed'>,
+  threshold: number = DEFAULT_CONTEXT_WARN_THRESHOLD
+): ContextUtilization {
+  const contextWindow =
+    observation.modelId !== undefined ? getModelContextWindow(observation.modelId) : 200_000;
+  const utilization = contextWindow > 0 ? observation.tokensUsed / contextWindow : 0;
+  return {
+    tokensUsed: observation.tokensUsed,
+    contextWindow,
+    utilization,
+    warned: utilization >= threshold,
+    threshold,
+  };
+}
+
+/**
+ * Observe + log. Called by the expert-execute path right after
+ * `expert.execute(task)` returns. Logger is optional (tests may omit).
+ *
+ * Always non-throwing — observer failure must never break the caller.
+ */
+export function observeExpertContext(
+  observation: ExpertContextObservation,
+  logger?: ILogger,
+  threshold: number = resolveContextWarnThreshold()
+): ContextUtilization {
+  try {
+    const util = computeExpertContextUtilization(observation, threshold);
+    if (util.warned) {
+      logger?.warn('context_warning', {
+        event: 'context_warning',
+        expertId: observation.expertId,
+        role: observation.role,
+        modelId: observation.modelId,
+        tokensUsed: util.tokensUsed,
+        contextWindow: util.contextWindow,
+        utilizationPercent: Math.round(util.utilization * 100),
+        thresholdPercent: Math.round(threshold * 100),
+        durationMs: observation.durationMs,
+        taskLength: observation.taskDescription.length,
+      });
+    } else {
+      logger?.debug('context_utilization', {
+        event: 'context_utilization',
+        expertId: observation.expertId,
+        role: observation.role,
+        modelId: observation.modelId,
+        utilizationPercent: Math.round(util.utilization * 100),
+      });
+    }
+    return util;
+  } catch {
+    // Telemetry must never throw. Return a safe default.
+    return {
+      tokensUsed: observation.tokensUsed,
+      contextWindow: 0,
+      utilization: 0,
+      warned: false,
+      threshold,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds non-blocking context-utilization telemetry around \`expert.execute(task)\` in the \`execute_expert\` MCP tool path. Closes #2031 — child of the #1574 SWE-bench Verified prep epic (#2030 breakdown).

After each successful expert call, computes \`utilization = tokensUsed / contextWindow\` (window looked up from the canonical model registry). When utilization crosses the threshold (default 0.85), emits a \`context_warning\` log event with expert id, role, model id, raw token counts, percent utilization, and task length.

## Why

The workflow layer already has context-budget enforcement via \`budget-circuit-breaker.ts\`, but expert-direct calls through the \`execute_expert\` MCP tool bypass that path. Top SWE-bench Verified systems all report context-exhaustion as a dominant failure mode; without per-expert utilization telemetry we can't identify which expert roles are approaching their budgets.

This PR is telemetry-only — zero behavior change. The downstream use is aggregation in the SWE-bench runner to drive task-sizing improvements.

## Config

| Env var | Default | Valid range | Behavior on invalid |
|---|---|---|---|
| \`NEXUS_CONTEXT_WARN_THRESHOLD\` | \`0.85\` | \`(0, 1]\` | Silently fall back to default |

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] \`pnpm --filter nexus-agents build\` — clean (ESM + DTS)
- [x] 12 new observer tests pass (threshold resolution, utilization math inc. NaN, warn vs. debug logging, undefined-logger safety)
- [x] 30 existing execute-expert tests pass (no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)