### PR TITLE
feat(orchestration): topological wave assignment for agent plans (#2034)

### DIFF
--- a/.changeset/2034-topological-waves.md
+++ b/.changeset/2034-topological-waves.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): topological wave assignment for agent plans (#2034)
+
+Adds a DAG-based wave assignment utility to aorchestra. Agent plans
+can now declare `dependsOn: string[]` edges; `topologicalWaveAssign`
+returns the plan with each entry's wave set to
+`max(wave of deps) + 1`, so independent work parallelizes while
+dependent work sequences.
+
+- New module `orchestration/aorchestra/topological-wave.ts` with:
+  - `topologicalWaveAssign<T extends WaveEntry>(entries)` →
+    `Result<entries, CycleError | MissingDependencyError>`
+  - `groupByTopologicalWave<T extends WaveEntry>(entries)` →
+    `T[][]` grouped by wave, sorted ascending
+  - Named distinct from the existing `groupByWave` in
+    `worker-dispatcher.ts` to avoid export collision.
+- 13 tests cover: empty input, no-deps passthrough, linear chain,
+  diamond, disconnected components, direct cycle, self-loop,
+  missing dependency, input immutability, and wave grouping.
+- NOT yet integrated with the live worker-dispatcher pipeline —
+  that's an explicit follow-up so this first PR stays reviewable.
+
+Child of #1574 (SWE-bench Verified prep) via #2030 breakdown.

--- a/packages/nexus-agents/src/orchestration/aorchestra/index.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/index.ts
@@ -97,3 +97,11 @@ export {
 export type { WorkerCheckpoint } from './worker-checkpoint.js';
 export { triageWorkerFailure } from './worker-triage.js';
 export type { TriageAction, TriageResult } from './worker-triage.js';
+// DAG dependency resolution (#2034).
+export {
+  topologicalWaveAssign,
+  groupByTopologicalWave,
+  CycleError,
+  MissingDependencyError,
+} from './topological-wave.js';
+export type { WaveEntry } from './topological-wave.js';

--- a/packages/nexus-agents/src/orchestration/aorchestra/topological-wave.test.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/topological-wave.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for topological wave assignment (#2034).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  topologicalWaveAssign,
+  groupByTopologicalWave,
+  CycleError,
+  MissingDependencyError,
+  type WaveEntry,
+} from './topological-wave.js';
+
+function entry(role: string, priority: number, wave = 1, dependsOn?: string[]): WaveEntry {
+  return dependsOn !== undefined ? { role, priority, wave, dependsOn } : { role, priority, wave };
+}
+
+describe('topologicalWaveAssign', () => {
+  it('handles empty input', () => {
+    const result = topologicalWaveAssign([]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
+  });
+
+  it('preserves original wave when no dependsOn field present', () => {
+    const plan = [entry('code', 1, 1), entry('test', 2, 2)];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value[0]?.wave).toBe(1);
+      expect(result.value[1]?.wave).toBe(2);
+    }
+  });
+
+  it('assigns wave 1 to entries with empty dependsOn', () => {
+    const plan = [entry('code', 1, 5, [])]; // wave=5 original but no deps
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(true);
+    // Entry's wave is preserved when dependsOn is empty (treated like no deps).
+    if (result.ok) expect(result.value[0]?.wave).toBe(5);
+  });
+
+  it('linear chain A → B → C puts each in its own wave', () => {
+    const plan = [entry('a', 1, 1), entry('b', 2, 1, ['a']), entry('c', 3, 1, ['b'])];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const waves = Object.fromEntries(result.value.map((e) => [e.role, e.wave]));
+      expect(waves['a']).toBe(1);
+      expect(waves['b']).toBe(2);
+      expect(waves['c']).toBe(3);
+    }
+  });
+
+  it('diamond: A → {B, C} → D puts B+C in wave 2, D in wave 3', () => {
+    const plan = [
+      entry('a', 1, 1),
+      entry('b', 2, 1, ['a']),
+      entry('c', 3, 1, ['a']),
+      entry('d', 4, 1, ['b', 'c']),
+    ];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const waves = Object.fromEntries(result.value.map((e) => [e.role, e.wave]));
+      expect(waves['a']).toBe(1);
+      expect(waves['b']).toBe(2);
+      expect(waves['c']).toBe(2);
+      expect(waves['d']).toBe(3);
+    }
+  });
+
+  it('disconnected components both start at wave 1', () => {
+    const plan = [
+      entry('a', 1, 1),
+      entry('b', 2, 1, ['a']),
+      entry('x', 3, 1),
+      entry('y', 4, 1, ['x']),
+    ];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const waves = Object.fromEntries(result.value.map((e) => [e.role, e.wave]));
+      expect(waves['a']).toBe(1);
+      expect(waves['x']).toBe(1);
+      expect(waves['b']).toBe(2);
+      expect(waves['y']).toBe(2);
+    }
+  });
+
+  it('detects direct cycle A → B → A', () => {
+    const plan = [entry('a', 1, 1, ['b']), entry('b', 2, 1, ['a'])];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(CycleError);
+      expect((result.error as CycleError).cycleRoles).toContain('a');
+      expect((result.error as CycleError).cycleRoles).toContain('b');
+    }
+  });
+
+  it('detects self-loop A → A', () => {
+    const plan = [entry('a', 1, 1, ['a'])];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(CycleError);
+    }
+  });
+
+  it('surfaces missing dependency as MissingDependencyError', () => {
+    const plan = [entry('a', 1, 1, ['nonexistent'])];
+    const result = topologicalWaveAssign(plan);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(MissingDependencyError);
+      expect((result.error as MissingDependencyError).sourceRole).toBe('a');
+      expect((result.error as MissingDependencyError).missingRole).toBe('nonexistent');
+    }
+  });
+
+  it('does not mutate input array or entries', () => {
+    const plan = [entry('a', 1, 1), entry('b', 2, 1, ['a'])];
+    const frozen = Object.freeze(plan);
+    const result = topologicalWaveAssign(frozen);
+    expect(result.ok).toBe(true);
+    // Input should still have wave: 1 on both (mutation would break this).
+    expect(plan[0]?.wave).toBe(1);
+    expect(plan[1]?.wave).toBe(1);
+  });
+});
+
+describe('groupByTopologicalWave', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupByTopologicalWave([])).toEqual([]);
+  });
+
+  it('groups entries by wave in ascending order', () => {
+    const plan = [entry('c', 3, 2), entry('a', 1, 1), entry('d', 4, 3), entry('b', 2, 1)];
+    const waves = groupByTopologicalWave(plan);
+    expect(waves.length).toBe(3);
+    expect(waves[0]?.map((e) => e.role).sort()).toEqual(['a', 'b']);
+    expect(waves[1]?.map((e) => e.role)).toEqual(['c']);
+    expect(waves[2]?.map((e) => e.role)).toEqual(['d']);
+  });
+
+  it('preserves insertion order within a wave', () => {
+    const plan = [entry('z', 1, 1), entry('a', 2, 1)];
+    const waves = groupByTopologicalWave(plan);
+    expect(waves[0]?.map((e) => e.role)).toEqual(['z', 'a']);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/aorchestra/topological-wave.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/topological-wave.ts
@@ -1,0 +1,197 @@
+/**
+ * Topological wave assignment for agent plans (#2034).
+ *
+ * Agent plans optionally carry `dependsOn: string[]` (role-keyed) edges.
+ * This module produces a wave assignment such that an entry runs only
+ * after every role it depends on has completed. Waves are promoted
+ * greedily so independent work still parallelizes.
+ *
+ * Pure function — no I/O, no side effects. Returns a `Result` so callers
+ * can surface cycle errors without an exception.
+ *
+ * Keeps the existing priority-based `wave` field behavior intact when
+ * `dependsOn` is absent.
+ *
+ * @module orchestration/aorchestra/topological-wave
+ */
+
+import { ok, err, type Result } from '../../core/index.js';
+
+/** Minimal shape this module operates on. Real `AgentPlanEntry` satisfies this. */
+export interface WaveEntry {
+  readonly role: string;
+  readonly priority: number;
+  readonly wave: number;
+  readonly dependsOn?: readonly string[] | undefined;
+}
+
+/** Error surfaced when the dependency graph contains a cycle. */
+export class CycleError extends Error {
+  override readonly name = 'CycleError';
+  constructor(
+    message: string,
+    readonly cycleRoles: readonly string[]
+  ) {
+    super(message);
+  }
+}
+
+/** Error surfaced when `dependsOn` references a role not in the plan. */
+export class MissingDependencyError extends Error {
+  override readonly name = 'MissingDependencyError';
+  constructor(
+    message: string,
+    readonly sourceRole: string,
+    readonly missingRole: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Assign waves by topological sort over the dependency graph.
+ *
+ * Each entry's new `wave` = max(wave of every role it depends on) + 1,
+ * or 1 if it has no dependencies. Entries with only priority (no
+ * `dependsOn`) keep their original `wave`.
+ *
+ * Returns a new array in the same order; does not mutate inputs.
+ */
+export function topologicalWaveAssign<T extends WaveEntry>(
+  entries: readonly T[]
+): Result<readonly T[], CycleError | MissingDependencyError> {
+  if (entries.length === 0) return ok([]);
+
+  const byRole = buildRoleIndex(entries);
+  const missing = findMissingDependency(entries, byRole);
+  if (missing !== null) return err(missing);
+
+  const cycle = detectCycle(entries, byRole);
+  if (cycle !== null) return err(cycle);
+
+  const waveByRole = computeWaves(entries, byRole);
+  return ok(entries.map((e) => ({ ...e, wave: waveByRole.get(e.role) ?? e.wave })));
+}
+
+/**
+ * Group topologically-waved entries into wave buckets. Returned waves
+ * are sorted ascending; each wave contains the entries that may run in
+ * parallel once earlier waves complete.
+ *
+ * Named `groupByTopologicalWave` rather than `groupByWave` to avoid a
+ * collision with `worker-dispatcher.groupByWave`, which operates on the
+ * richer `AgentPlanEntry` union and is the canonical public export.
+ */
+export function groupByTopologicalWave<T extends WaveEntry>(entries: readonly T[]): readonly T[][] {
+  const buckets = new Map<number, T[]>();
+  for (const e of entries) {
+    const bucket = buckets.get(e.wave);
+    if (bucket === undefined) {
+      buckets.set(e.wave, [e]);
+    } else {
+      bucket.push(e);
+    }
+  }
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([, v]) => v);
+}
+
+function buildRoleIndex<T extends WaveEntry>(entries: readonly T[]): Map<string, T> {
+  const byRole = new Map<string, T>();
+  for (const e of entries) byRole.set(e.role, e);
+  return byRole;
+}
+
+function findMissingDependency<T extends WaveEntry>(
+  entries: readonly T[],
+  byRole: Map<string, T>
+): MissingDependencyError | null {
+  for (const e of entries) {
+    if (e.dependsOn === undefined) continue;
+    for (const dep of e.dependsOn) {
+      if (!byRole.has(dep)) {
+        return new MissingDependencyError(
+          `Entry for role "${e.role}" depends on unknown role "${dep}"`,
+          e.role,
+          dep
+        );
+      }
+    }
+  }
+  return null;
+}
+
+/** DFS-based cycle detection. Returns the first cycle found, or null. */
+function detectCycle<T extends WaveEntry>(
+  entries: readonly T[],
+  byRole: Map<string, T>
+): CycleError | null {
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const e of entries) color.set(e.role, WHITE);
+
+  function visit(role: string, stack: string[]): string[] | null {
+    const c = color.get(role);
+    if (c === BLACK) return null;
+    if (c === GRAY) {
+      const cycleStart = stack.indexOf(role);
+      return cycleStart >= 0 ? stack.slice(cycleStart).concat(role) : [role];
+    }
+    color.set(role, GRAY);
+    stack.push(role);
+    const entry = byRole.get(role);
+    if (entry?.dependsOn !== undefined) {
+      for (const dep of entry.dependsOn) {
+        const found = visit(dep, stack);
+        if (found !== null) return found;
+      }
+    }
+    stack.pop();
+    color.set(role, BLACK);
+    return null;
+  }
+
+  for (const e of entries) {
+    const found = visit(e.role, []);
+    if (found !== null) {
+      return new CycleError(`Dependency cycle detected: ${found.join(' → ')}`, found);
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute each role's wave as max(wave of deps) + 1. Roles without
+ * `dependsOn` keep their original wave so the priority-based assignment
+ * from `planAgentTeam` is preserved.
+ */
+function computeWaves<T extends WaveEntry>(
+  entries: readonly T[],
+  byRole: Map<string, T>
+): Map<string, number> {
+  const computed = new Map<string, number>();
+
+  function waveOf(role: string): number {
+    const cached = computed.get(role);
+    if (cached !== undefined) return cached;
+    const entry = byRole.get(role);
+    if (entry === undefined) return 1;
+    if (entry.dependsOn === undefined || entry.dependsOn.length === 0) {
+      computed.set(role, entry.wave);
+      return entry.wave;
+    }
+    let maxDepWave = 0;
+    for (const dep of entry.dependsOn) {
+      maxDepWave = Math.max(maxDepWave, waveOf(dep));
+    }
+    const newWave = maxDepWave + 1;
+    computed.set(role, newWave);
+    return newWave;
+  }
+
+  for (const e of entries) waveOf(e.role);
+  return computed;
+}


### PR DESCRIPTION
## Summary

Adds a pure, Result-returning utility for DAG-based wave assignment in \`orchestration/aorchestra\`. Agent plans can now declare \`dependsOn: string[]\` edges; \`topologicalWaveAssign\` returns the plan with each entry's wave set to \`max(wave of deps) + 1\` so independent work parallelizes while dependent work sequences correctly.

Child of #1574 (SWE-bench Verified prep) via #2030.

## What's in the PR

- **New module:** \`orchestration/aorchestra/topological-wave.ts\`
  - \`topologicalWaveAssign<T>(entries)\` → \`Result<entries, CycleError | MissingDependencyError>\`
  - \`groupByTopologicalWave<T>(entries)\` → \`T[][]\` grouped by wave ascending
  - Named distinctly from the existing \`groupByWave\` in \`worker-dispatcher.ts\` to avoid export collision. The existing function operates on the richer \`AgentPlanEntry\` union and remains the canonical public export.
- **New tests** (13): empty input, no-deps passthrough, linear chain, diamond, disconnected components, direct cycle, self-loop, missing dependency, input immutability, grouping.
- **Barrel export** added to \`aorchestra/index.ts\`.

## What's NOT in the PR

- **No integration** with the live \`dispatchWorkers\` path yet. Kept deliberately decoupled so this first PR is reviewable as a pure utility. Consumers can adopt by calling \`topologicalWaveAssign(plan.entries)\` on the output of \`planAgentTeam\` before dispatch.
- **No \`AgentPlanEntry.dependsOn\` field** added to \`agent-planner.ts\` yet — that shape change belongs in the integration PR.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 13 new tests pass
- [x] No existing tests affected (pure addition)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)