### PR TITLE
feat(swe-bench): post-patch verification loop utilities (#2032)

### DIFF
--- a/.changeset/2032-verify-loop.md
+++ b/.changeset/2032-verify-loop.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): post-patch verification loop utilities (#2032)
+
+Adds pure utilities for classifying patch-verification failures and
+deciding whether to retry the agent. Deliberately decoupled from the
+evaluation-harness I/O so consumers can unit-test the classifier
+without spinning up Docker; integration with `agent-runner.ts` is a
+separate follow-up so this first PR stays reviewable.
+
+- New `swe-bench/verify-loop.ts`:
+  - `classifyPatchFailure(stderr, stdout)` → `VerifyFailureClassification`
+    Recognizes `patch_not_applicable`, `syntax_error`, `timeout`,
+    `missing_dependency`, `runtime_error`, `test_failure`; falls
+    through to `unknown`.
+  - `shouldRetry(category, iteration, maxRetries)` — category-aware
+    retry policy. `timeout` never retries; `wrong_file_modified` and
+    `unknown` get exactly one retry; everything else is retryable
+    up to the cap.
+  - `buildRetryHint(classification, iteration, maxRetries)` — terse
+    prompt fragment with extracted test names (capped at 5).
+  - `buildVerifyOutcome({passed, iteration, stderr, stdout})` — the
+    one-call-per-attempt wrapper integration callers will use.
+- Default max retries: 2 (configurable per call).
+- Reuses the existing `FailureCategory` type from
+  `evaluation-failure-types.ts` — no new failure taxonomy.
+- 20 tests cover all patterns, retry-cap behavior, hint truncation,
+  empty-output safety, and end-to-end outcome construction.
+
+Child of #1574 via #2030.

--- a/packages/nexus-agents/src/swe-bench/verify-loop.test.ts
+++ b/packages/nexus-agents/src/swe-bench/verify-loop.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for post-patch verification loop (#2032).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MAX_VERIFY_RETRIES,
+  buildRetryHint,
+  buildVerifyOutcome,
+  classifyPatchFailure,
+  shouldRetry,
+} from './verify-loop.js';
+
+describe('classifyPatchFailure', () => {
+  it('recognizes patch_not_applicable from git/patch output', () => {
+    const r = classifyPatchFailure('error: patch does not apply', '');
+    expect(r.category).toBe('patch_not_applicable');
+    expect(r.summary).toContain('does not apply');
+  });
+
+  it('recognizes syntax_error with the Python message', () => {
+    const r = classifyPatchFailure(
+      '',
+      '  File "foo.py", line 12\n    def foo(:\n           ^\nSyntaxError: invalid syntax'
+    );
+    expect(r.category).toBe('syntax_error');
+    expect(r.summary).toContain('invalid syntax');
+  });
+
+  it('recognizes timeout', () => {
+    const r = classifyPatchFailure('Test timed out after 300s', '');
+    expect(r.category).toBe('timeout');
+  });
+
+  it('recognizes missing dependency and extracts module name', () => {
+    const r = classifyPatchFailure("ModuleNotFoundError: No module named 'requests'", '');
+    expect(r.category).toBe('missing_dependency');
+    expect(r.summary).toContain('requests');
+  });
+
+  it('recognizes generic runtime error', () => {
+    const r = classifyPatchFailure('TypeError: unsupported operand type(s)', '');
+    expect(r.category).toBe('runtime_error');
+    expect(r.summary).toContain('TypeError');
+  });
+
+  it('recognizes pytest test failures and extracts test ids', () => {
+    const stdout = 'FAILED tests/test_foo.py::test_bar\nFAILED tests/test_foo.py::test_baz';
+    const r = classifyPatchFailure('', stdout);
+    expect(r.category).toBe('test_failure');
+    expect(r.affectedTests).toContain('tests/test_foo.py::test_bar');
+    expect(r.affectedTests).toContain('tests/test_foo.py::test_baz');
+  });
+
+  it('falls back to unknown when no pattern matches', () => {
+    const r = classifyPatchFailure('strange error', 'more output');
+    expect(r.category).toBe('unknown');
+    expect(r.summary).toContain('strange error');
+  });
+
+  it('handles completely empty output', () => {
+    const r = classifyPatchFailure('', '');
+    expect(r.category).toBe('unknown');
+    expect(r.summary).toBe('No failure details captured');
+  });
+});
+
+describe('shouldRetry', () => {
+  it('respects the hard retry cap', () => {
+    expect(shouldRetry('test_failure', 2, 2)).toBe(false);
+    expect(shouldRetry('test_failure', 5, 2)).toBe(false);
+  });
+
+  it('allows retry on recoverable categories', () => {
+    for (const cat of [
+      'patch_not_applicable',
+      'syntax_error',
+      'missing_dependency',
+      'test_failure',
+      'runtime_error',
+      'incomplete_fix',
+    ] as const) {
+      expect(shouldRetry(cat, 0, 2)).toBe(true);
+      expect(shouldRetry(cat, 1, 2)).toBe(true);
+    }
+  });
+
+  it('refuses retry on timeout', () => {
+    expect(shouldRetry('timeout', 0, 2)).toBe(false);
+  });
+
+  it('gives exactly one retry for uncertain categories', () => {
+    expect(shouldRetry('wrong_file_modified', 0, 2)).toBe(true);
+    expect(shouldRetry('wrong_file_modified', 1, 2)).toBe(false);
+    expect(shouldRetry('unknown', 0, 2)).toBe(true);
+    expect(shouldRetry('unknown', 1, 2)).toBe(false);
+  });
+
+  it('uses DEFAULT_MAX_VERIFY_RETRIES when cap is not provided', () => {
+    expect(DEFAULT_MAX_VERIFY_RETRIES).toBe(2);
+    expect(shouldRetry('test_failure', 1)).toBe(true);
+    expect(shouldRetry('test_failure', 2)).toBe(false);
+  });
+});
+
+describe('buildRetryHint', () => {
+  it('includes category, summary, and iteration counter', () => {
+    const hint = buildRetryHint(
+      {
+        category: 'test_failure',
+        summary: 'Tests still failing: test_add',
+        affectedTests: ['test_math.py::test_add'],
+      },
+      0,
+      2
+    );
+    expect(hint).toContain('Verification attempt 1/3 failed');
+    expect(hint).toContain('Category: test_failure');
+    expect(hint).toContain('Summary: Tests still failing: test_add');
+    expect(hint).toContain('test_math.py::test_add');
+    expect(hint).toContain('Fix the root cause');
+  });
+
+  it('truncates affected-test list to 5 with ellipsis', () => {
+    const tests = Array.from({ length: 10 }, (_, i) => `t::case${String(i)}`);
+    const hint = buildRetryHint(
+      { category: 'test_failure', summary: 's', affectedTests: tests },
+      0
+    );
+    expect(hint).toContain('Affected tests (10):');
+    expect(hint).toContain('...');
+  });
+
+  it('omits affected-tests line when there are none', () => {
+    const hint = buildRetryHint({ category: 'timeout', summary: 'too slow', affectedTests: [] }, 0);
+    expect(hint).not.toContain('Affected tests');
+  });
+});
+
+describe('buildVerifyOutcome', () => {
+  it('returns ok=true with no classification on pass', () => {
+    const outcome = buildVerifyOutcome({
+      passed: true,
+      iteration: 0,
+      stderr: '',
+      stdout: 'PASSED',
+    });
+    expect(outcome.ok).toBe(true);
+    expect(outcome.willRetry).toBe(false);
+    expect(outcome.classification).toBeUndefined();
+    expect(outcome.retryHint).toBeUndefined();
+  });
+
+  it('classifies and schedules retry on failure with room left', () => {
+    const outcome = buildVerifyOutcome({
+      passed: false,
+      iteration: 0,
+      stderr: 'patch does not apply',
+      stdout: '',
+      maxRetries: 2,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.classification?.category).toBe('patch_not_applicable');
+    expect(outcome.willRetry).toBe(true);
+    expect(outcome.retryHint).toContain('patch_not_applicable');
+  });
+
+  it('classifies but does NOT retry when cap reached', () => {
+    const outcome = buildVerifyOutcome({
+      passed: false,
+      iteration: 2,
+      stderr: 'FAILED tests/test_x.py::test_y',
+      stdout: '',
+      maxRetries: 2,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.willRetry).toBe(false);
+    expect(outcome.retryHint).toBeDefined();
+  });
+
+  it('never retries timeout even at iteration 0', () => {
+    const outcome = buildVerifyOutcome({
+      passed: false,
+      iteration: 0,
+      stderr: 'Test timed out after 300s',
+      stdout: '',
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.classification?.category).toBe('timeout');
+    expect(outcome.willRetry).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/swe-bench/verify-loop.ts
+++ b/packages/nexus-agents/src/swe-bench/verify-loop.ts
@@ -1,0 +1,218 @@
+/**
+ * Post-patch verification loop (#2032).
+ *
+ * Pure utilities for classifying patch-verification failures, deciding
+ * whether to retry, and building retry hints for the agent. Deliberately
+ * decoupled from the evaluation-harness I/O so it can be unit-tested
+ * without spinning up Docker — integration with `agent-runner.ts` is a
+ * separate follow-up.
+ *
+ * Mirrors the pattern established by #2031 and #2034: ship pure logic
+ * first, wire into the live path in a follow-up PR so each change stays
+ * reviewable.
+ *
+ * @module swe-bench/verify-loop
+ */
+
+import type { FailureCategory } from './evaluation-failure-types.js';
+
+/** Default maximum retries per instance. */
+export const DEFAULT_MAX_VERIFY_RETRIES = 2;
+
+/**
+ * Classification of a single verify-phase failure, suitable for
+ * feeding back into the agent as a retry hint.
+ */
+export interface VerifyFailureClassification {
+  readonly category: FailureCategory;
+  /** Short description extracted from stdout/stderr. */
+  readonly summary: string;
+  /** Test names or file paths pulled out of the failure output. */
+  readonly affectedTests: readonly string[];
+}
+
+/** Pattern for recognizing a failure category in captured output. */
+interface FailurePattern {
+  readonly category: FailureCategory;
+  readonly regex: RegExp;
+  readonly summarizer: (match: RegExpExecArray, stderr: string, stdout: string) => string;
+}
+
+const FAILURE_PATTERNS: readonly FailurePattern[] = [
+  {
+    category: 'patch_not_applicable',
+    regex: /patch .*?does not apply|hunk #\d+ FAILED|Reversed .*patch detected/i,
+    summarizer: (m) => `Patch did not apply cleanly: ${m[0]}`,
+  },
+  {
+    category: 'syntax_error',
+    regex: /SyntaxError: (.*?)(?:\n|$)|IndentationError: (.*?)(?:\n|$)/,
+    summarizer: (m) => `Syntax error in generated patch: ${m[1] ?? m[2] ?? m[0]}`.trim(),
+  },
+  {
+    category: 'timeout',
+    regex: /Timeout\b|timed out after \d+\s?s\b|TIMEOUT_EXCEEDED/i,
+    summarizer: (m) => `Test run exceeded timeout: ${m[0]}`,
+  },
+  {
+    category: 'missing_dependency',
+    regex:
+      /ModuleNotFoundError: No module named '([^']+)'|ImportError: cannot import name '([^']+)'|No module named "([^"]+)"/,
+    summarizer: (m) =>
+      `Missing dependency: ${m[1] ?? m[2] ?? m[3] ?? 'unknown'}. Patch may need an import.`,
+  },
+  {
+    category: 'runtime_error',
+    regex: /([A-Z][a-zA-Z]+Error): (.*?)(?:\n|$)/,
+    summarizer: (m) => `Runtime error ${m[1] ?? ''}: ${m[2] ?? ''}`.trim(),
+  },
+  {
+    category: 'test_failure',
+    regex: /FAILED .*?::(\S+)|AssertionError|FAIL: (\S+)/,
+    summarizer: (_m, stderr, stdout) => {
+      const failed = extractFailedTests(stderr, stdout);
+      return failed.length > 0
+        ? `Tests still failing: ${failed.slice(0, 5).join(', ')}`
+        : 'One or more tests failed after patch';
+    },
+  },
+];
+
+/**
+ * Classify a verify-phase failure from captured stdout + stderr. Returns
+ * `unknown` category when no pattern matches.
+ */
+export function classifyPatchFailure(stderr: string, stdout: string): VerifyFailureClassification {
+  const haystack = `${stderr}\n${stdout}`;
+  for (const pattern of FAILURE_PATTERNS) {
+    const match = pattern.regex.exec(haystack);
+    if (match !== null) {
+      return {
+        category: pattern.category,
+        summary: pattern.summarizer(match, stderr, stdout),
+        affectedTests: extractFailedTests(stderr, stdout),
+      };
+    }
+  }
+  return {
+    category: 'unknown',
+    summary: haystack.trim().slice(0, 200) || 'No failure details captured',
+    affectedTests: extractFailedTests(stderr, stdout),
+  };
+}
+
+/**
+ * Pull `repo/path::test_name` style test identifiers out of pytest-style
+ * output. Best-effort — returns empty array when nothing parseable.
+ */
+function extractFailedTests(stderr: string, stdout: string): readonly string[] {
+  const combined = `${stderr}\n${stdout}`;
+  const results = new Set<string>();
+  const pytestPattern = /FAILED (\S+::\S+)/g;
+  let match;
+  while ((match = pytestPattern.exec(combined)) !== null) {
+    if (match[1] !== undefined) results.add(match[1]);
+  }
+  const unittestPattern = /FAIL: (\S+) \(/g;
+  while ((match = unittestPattern.exec(combined)) !== null) {
+    if (match[1] !== undefined) results.add(match[1]);
+  }
+  return Array.from(results);
+}
+
+/**
+ * Retry policy. Hard-capped at `maxRetries` iterations; certain
+ * failure categories (e.g. `missing_dependency`, `patch_not_applicable`)
+ * are always retryable because the agent can likely fix them; others
+ * (e.g. `timeout`) hit the cap immediately because extra iterations
+ * won't help.
+ */
+/** Categories that benefit from retrying — the agent can fix these. */
+const ALWAYS_RETRYABLE: ReadonlySet<FailureCategory> = new Set([
+  'patch_not_applicable',
+  'syntax_error',
+  'missing_dependency',
+  'test_failure',
+  'runtime_error',
+  'incomplete_fix',
+]);
+
+/** Categories that never benefit from retry (extra iterations won't help). */
+const NEVER_RETRYABLE: ReadonlySet<FailureCategory> = new Set(['timeout']);
+
+export function shouldRetry(
+  category: FailureCategory,
+  iteration: number,
+  maxRetries: number = DEFAULT_MAX_VERIFY_RETRIES
+): boolean {
+  if (iteration >= maxRetries) return false;
+  if (NEVER_RETRYABLE.has(category)) return false;
+  if (ALWAYS_RETRYABLE.has(category)) return true;
+  // Uncertain categories (wrong_file_modified, regression_introduced,
+  // unknown): give exactly one retry; anything more is noise.
+  return iteration < 1;
+}
+
+/**
+ * Build a prompt fragment the agent can use to focus the next
+ * iteration. Kept terse so the agent's context budget isn't dominated
+ * by verifier chatter.
+ */
+export function buildRetryHint(
+  classification: VerifyFailureClassification,
+  iteration: number,
+  maxRetries: number = DEFAULT_MAX_VERIFY_RETRIES
+): string {
+  const header = `Verification attempt ${String(iteration + 1)}/${String(maxRetries + 1)} failed.`;
+  const bodyLines = [
+    header,
+    `Category: ${classification.category}`,
+    `Summary: ${classification.summary}`,
+  ];
+  if (classification.affectedTests.length > 0) {
+    const count = String(classification.affectedTests.length);
+    const names = classification.affectedTests.slice(0, 5).join(', ');
+    const overflow = classification.affectedTests.length > 5 ? ', ...' : '';
+    bodyLines.push(`Affected tests (${count}): ${names}${overflow}`);
+  }
+  bodyLines.push('Fix the root cause, not the symptom. Re-emit the full patch.');
+  return bodyLines.join('\n');
+}
+
+/**
+ * Result of a single verify phase. Consumers chain these in a loop.
+ */
+export interface VerifyAttemptOutcome {
+  readonly ok: boolean;
+  readonly iteration: number;
+  readonly classification?: VerifyFailureClassification;
+  readonly retryHint?: string;
+  readonly willRetry: boolean;
+}
+
+/**
+ * Build the outcome record for one verify attempt. Pure — no I/O, no
+ * side effects. The integration layer calls this after running the
+ * actual test harness with the current patch.
+ */
+export function buildVerifyOutcome(params: {
+  readonly passed: boolean;
+  readonly iteration: number;
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly maxRetries?: number;
+}): VerifyAttemptOutcome {
+  const maxRetries = params.maxRetries ?? DEFAULT_MAX_VERIFY_RETRIES;
+  if (params.passed) {
+    return { ok: true, iteration: params.iteration, willRetry: false };
+  }
+  const classification = classifyPatchFailure(params.stderr, params.stdout);
+  const willRetry = shouldRetry(classification.category, params.iteration, maxRetries);
+  return {
+    ok: false,
+    iteration: params.iteration,
+    classification,
+    retryHint: buildRetryHint(classification, params.iteration, maxRetries),
+    willRetry,
+  };
+}


### PR DESCRIPTION
## Summary

Adds pure utilities for classifying patch-verification failures and deciding whether to retry the agent. Closes #2032 — child of #1574 SWE-bench Verified prep epic via #2030 breakdown.

Deliberately decoupled from the evaluation-harness I/O so consumers can unit-test the classifier without Docker. Integration with \`agent-runner.ts\` is a separate follow-up so this first PR stays reviewable (same pattern as #2031, #2033, #2034).

## What's in the PR

- **\`classifyPatchFailure(stderr, stdout)\`** — recognizes 6 known patterns (patch_not_applicable, syntax_error, timeout, missing_dependency, runtime_error, test_failure) plus \`unknown\` fallback. Reuses the existing \`FailureCategory\` type from \`evaluation-failure-types.ts\` — no new taxonomy.
- **\`shouldRetry(category, iteration, maxRetries)\`** — category-aware policy:
  - \`timeout\` never retries (extra iterations won't help)
  - Recoverable categories retry up to the cap (default 2)
  - Uncertain categories (\`wrong_file_modified\`, \`regression_introduced\`, \`unknown\`) get exactly one retry
- **\`buildRetryHint(classification, iteration, maxRetries)\`** — terse prompt fragment with extracted test names (capped at 5 with ellipsis)
- **\`buildVerifyOutcome({passed, iteration, stderr, stdout})\`** — one-call-per-attempt wrapper integration callers will use

## Deliberately NOT in this PR

- **No wiring into \`agent-runner.ts\`** — integration belongs in a follow-up alongside the actual harness execution
- **No new \`FailureCategory\` values** — reuses existing taxonomy

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 20 new tests pass (all 6 classification patterns + retry cap + hint truncation + empty-output safety + outcome construction)
- [x] No existing tests affected (pure addition)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)