### PR TITLE
feat(orchestration): wire topological wave recomputation into worker-dispatcher (#2043, #2034)

### DIFF
--- a/.changeset/2043-topological-wave-integration.md
+++ b/.changeset/2043-topological-wave-integration.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): wire topological wave recomputation into worker-dispatcher (#2043 / #2034)
+
+Integration follow-up for #2034. The pure utility has been live since
+#2038; this PR makes it take effect in real dispatch:
+
+- Adds optional `dependsOn?: readonly BuiltInExpertType[]` field on
+  `AgentPlanEntry`. Absent or empty → entry keeps its priority-based
+  wave assignment; pre-dependsOn plans are unaffected.
+- New `applyDependencyWaves(entries)` helper in `worker-dispatcher.ts`
+  checks whether any entry declares `dependsOn`; if yes, runs the plan
+  through `topologicalWaveAssign` before dispatch; if no, returns the
+  plan unchanged by identity.
+- `dispatchWorkers` calls `applyDependencyWaves` before `groupByWave`,
+  so the live pipeline now respects DAG edges.
+- Fallback policy: cycles or missing refs log a warning and revert to
+  the original priority-based assignment — dispatch never fails because
+  the plan's dependency graph is malformed.
+- 6 new integration tests cover: unchanged pass-through, linear chain,
+  diamond grouping, cycle fallback, missing-ref fallback, empty plan.
+- 133 existing aorchestra tests still pass unchanged.
+
+Planner-side emission of `dependsOn` (so `planAgentTeam` actually
+produces DAGs) is a deliberate follow-up — this PR establishes the
+consumer contract so custom planners and trigger-table authors can
+start producing DAGs today.
+
+Remaining from #2043: verify-loop integration (#2032) into agent-runner.

--- a/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.ts
@@ -35,6 +35,14 @@ export interface AgentPlanEntry {
   readonly reasoning: string;
   /** Wave group for parallel execution (1-based, lower = earlier) */
   readonly wave: number;
+  /**
+   * Optional DAG dependency — roles that MUST complete before this entry
+   * can run. When present, the consumer (worker-dispatcher) runs the plan
+   * through `topologicalWaveAssign` to recompute wave assignments
+   * (#2034 → #2043 integration). Absent or empty → entry keeps its
+   * priority-based wave.
+   */
+  readonly dependsOn?: readonly BuiltInExpertType[];
 }
 
 /** Minimum expert success rate before deprioritization (Issue #1325). */

--- a/packages/nexus-agents/src/orchestration/aorchestra/index.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/index.ts
@@ -18,6 +18,7 @@ export type { AgentPlan, AgentPlanEntry, PlanAgentTeamOptions } from './agent-pl
 export {
   dispatchWorkers,
   groupByWave,
+  applyDependencyWaves,
   WORKER_TIMEOUT_MS,
   DEFAULT_STAGGER_DELAY_MS,
   RoleFailureTracker,

--- a/packages/nexus-agents/src/orchestration/aorchestra/topological-wave-integration.test.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/topological-wave-integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration test for topological-wave recomputation in worker-dispatcher
+ * (#2034 → #2043). Verifies that dispatch consumes `dependsOn` when
+ * present and ignores it cleanly when absent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { AgentPlanEntry } from './agent-planner.js';
+import { applyDependencyWaves, groupByWave } from './worker-dispatcher.js';
+
+function entry(overrides: Partial<AgentPlanEntry> & Pick<AgentPlanEntry, 'role'>): AgentPlanEntry {
+  return {
+    subTask: overrides.subTask ?? 'do thing',
+    priority: overrides.priority ?? 1,
+    reasoning: overrides.reasoning ?? 'test',
+    wave: overrides.wave ?? 1,
+    ...overrides,
+  };
+}
+
+describe('applyDependencyWaves', () => {
+  it('returns plan unchanged when no entry has dependsOn', () => {
+    const plan = [entry({ role: 'code', wave: 1 }), entry({ role: 'testing', wave: 2 })];
+    const result = applyDependencyWaves(plan);
+    // Object identity — no new array created when no deps to recompute.
+    expect(result).toBe(plan);
+  });
+
+  it('recomputes waves when dependsOn is present', () => {
+    const plan = [
+      entry({ role: 'architecture', wave: 1 }),
+      entry({ role: 'code', wave: 1, dependsOn: ['architecture'] }),
+      entry({ role: 'testing', wave: 1, dependsOn: ['code'] }),
+    ];
+    const result = applyDependencyWaves(plan);
+    const waves = Object.fromEntries(result.map((e) => [e.role, e.wave]));
+    expect(waves['architecture']).toBe(1);
+    expect(waves['code']).toBe(2);
+    expect(waves['testing']).toBe(3);
+  });
+
+  it('groups into correct waves after recomputation', () => {
+    const plan = [
+      entry({ role: 'architecture', wave: 1 }),
+      entry({ role: 'code', wave: 1, dependsOn: ['architecture'] }),
+      entry({ role: 'documentation', wave: 1, dependsOn: ['architecture'] }),
+      entry({ role: 'testing', wave: 1, dependsOn: ['code'] }),
+    ];
+    const result = applyDependencyWaves(plan);
+    const grouped = groupByWave(result);
+    expect(grouped.length).toBe(3);
+    expect(grouped[0]?.map((e) => e.role)).toEqual(['architecture']);
+    // Wave 2: both code and documentation depend on architecture only.
+    expect(grouped[1]?.map((e) => e.role).sort()).toEqual(['code', 'documentation']);
+    expect(grouped[2]?.map((e) => e.role)).toEqual(['testing']);
+  });
+
+  it('falls back to original wave assignment on cycle (never fails dispatch)', () => {
+    const plan = [
+      entry({ role: 'code', wave: 3, dependsOn: ['testing'] }),
+      entry({ role: 'testing', wave: 5, dependsOn: ['code'] }),
+    ];
+    const result = applyDependencyWaves(plan);
+    // Fall-through returns original plan; tests see the original waves.
+    expect(result[0]?.wave).toBe(3);
+    expect(result[1]?.wave).toBe(5);
+  });
+
+  it('falls back on missing dependency reference', () => {
+    const plan = [entry({ role: 'code', wave: 1, dependsOn: ['nonexistent'] as never })];
+    const result = applyDependencyWaves(plan);
+    // Original plan returned; no throw.
+    expect(result).toBe(plan);
+  });
+
+  it('empty plan returns empty array without error', () => {
+    const plan: AgentPlanEntry[] = [];
+    const result = applyDependencyWaves(plan);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
@@ -13,6 +13,7 @@
 
 import type { AgentPlanEntry } from './agent-planner.js';
 import { MAX_WORKERS_PER_WAVE } from './agent-planner.js';
+import { topologicalWaveAssign } from './topological-wave.js';
 import { createLogger, getErrorMessage } from '../../core/index.js';
 import { getExpertTaskTimeout, WORKER_TIMEOUTS } from '../../config/timeouts.js';
 import { isRateLimitError } from '../../cli/voter-execution.js';
@@ -137,6 +138,29 @@ export interface WorkerDispatchOptions {
 // ============================================================================
 // Wave Grouping
 // ============================================================================
+
+/**
+ * Apply topological wave recomputation when any entry declares
+ * `dependsOn` (#2034 → #2043). Returns the plan unchanged when no
+ * dependencies are declared, so pre-dependsOn plans are unaffected.
+ * Cycles or missing refs log a warning and fall back to the original
+ * priority-based wave assignment — never fail the dispatch over a
+ * bad plan.
+ */
+export function applyDependencyWaves(
+  entries: readonly AgentPlanEntry[]
+): readonly AgentPlanEntry[] {
+  const hasDeps = entries.some((e) => e.dependsOn !== undefined && e.dependsOn.length > 0);
+  if (!hasDeps) return entries;
+  const result = topologicalWaveAssign(entries);
+  if (!result.ok) {
+    logger.warn('Topological wave assignment failed, falling back to priority-only', {
+      error: result.error.message,
+    });
+    return entries;
+  }
+  return result.value;
+}
 
 /**
  * Groups plan entries by their wave number, sorted ascending.
@@ -337,7 +361,8 @@ export async function dispatchWorkers(
   if (entries.length === 0) return [];
 
   const maxConcurrency = options.maxConcurrency ?? MAX_WORKERS_PER_WAVE;
-  const waves = groupByWave(entries);
+  const effectiveEntries = applyDependencyWaves(entries);
+  const waves = groupByWave(effectiveEntries);
   const allResults: WorkerResult[] = [];
   const failureTracker = new RoleFailureTracker(
     options.consecutiveFailureThreshold ?? CONSECUTIVE_FAILURE_THRESHOLD


### PR DESCRIPTION
## Summary

Integration follow-up for #2034. The pure utility has been live since #2038; this PR makes it take effect in real dispatch.

## Changes

- Adds optional \`dependsOn?: readonly BuiltInExpertType[]\` field on \`AgentPlanEntry\`. Absent or empty → entry keeps its priority-based wave; **pre-dependsOn plans are unaffected**.
- New \`applyDependencyWaves(entries)\` helper in \`worker-dispatcher.ts\`:
  - When no entry has \`dependsOn\` → returns the plan by identity (zero allocation, zero behavior change)
  - When any entry has \`dependsOn\` → runs \`topologicalWaveAssign\` and returns the recomputed plan
- \`dispatchWorkers\` calls \`applyDependencyWaves\` before \`groupByWave\`, so the live pipeline now respects DAG edges
- **Fallback policy**: cycles or missing refs log a warning and revert to the original priority-based assignment — dispatch never fails because the plan's dependency graph is malformed

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] \`pnpm --filter nexus-agents build\` — clean (ESM + DTS)
- [x] 6 new integration tests (pass-through, linear, diamond, cycle, missing-ref, empty)
- [x] 133 existing aorchestra tests pass unchanged
- [ ] CI green

## Remaining from #2043

- Planner-side emission of \`dependsOn\` (so \`planAgentTeam\` actually produces DAGs) — deliberate follow-up
- Verify-loop (#2032) integration into \`agent-runner.ts\` — larger piece

🤖 Generated with [Claude Code](https://claude.com/claude-code)