### PR TITLE
feat(swe-bench): wire verify loop into agent-runner (#2043, #2032)

### DIFF
--- a/.changeset/2043-verify-loop-integration.md
+++ b/.changeset/2043-verify-loop-integration.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): wire verify loop into agent-runner (#2043 / #2032)
+
+Final integration from the #2043 follow-up epic. The pure verify-loop
+utilities from #2042 are now consumable by the SWE-bench agent runner
+via a new `IVerifyAdapter` interface on `RunOptions`.
+
+- New `IVerifyAdapter` + `VerifyResult` types on `agent-runner.ts`.
+  Adapters take `(instance, patch, workDir)` and return
+  `{passed, stderr, stdout}` — SWE-bench wiring to the real
+  evaluation-harness is a separate follow-up so this PR is reviewable
+  as a pure contract extension.
+- New optional `verifyAdapter` + `maxVerifyRetries` fields on
+  `RunOptions`. When `verifyAdapter` is absent, behavior is exactly
+  as before — zero change for callers that haven't opted in.
+- New `runPostPatchVerify` helper. After each successful patch, it:
+  - Calls `adapter.verify(...)` to run the instance's test suite
+  - Feeds stdout/stderr to `buildVerifyOutcome` from `verify-loop.ts`
+  - On `willRetry`, sets `state.lastError` to the retry hint and
+    `state.lastPatch` to the failed patch, then `continue`s the
+    iteration loop — the agent sees the hint in its next prompt
+- 4 new tests cover the adapter contract and the opt-in shape.
+- 29 existing agent-runner + verify-loop tests pass unchanged.
+
+Completes 5 of 5 integrations from #2043.

--- a/packages/nexus-agents/src/swe-bench/agent-runner-verify.test.ts
+++ b/packages/nexus-agents/src/swe-bench/agent-runner-verify.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration tests for post-patch verify-loop in agent-runner
+ * (#2032 → #2043 final integration).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IAgentExecutor, IVerifyAdapter, VerifyResult } from './agent-runner.js';
+import type { SWEBenchInstance, SWEBenchConfig } from './types.js';
+
+// The tests verify the verify-adapter contract + wiring without actually
+// executing the real agent-runner (which would require git, docker, etc).
+// We exercise the verify policy logic through direct IVerifyAdapter impls.
+
+function makeAdapter(results: readonly VerifyResult[]): {
+  adapter: IVerifyAdapter;
+  calls: VerifyResult[];
+} {
+  const queue = [...results];
+  const calls: VerifyResult[] = [];
+  const adapter: IVerifyAdapter = {
+    verify: vi.fn(() => {
+      const next = queue.shift() ?? { passed: true, stderr: '', stdout: '' };
+      calls.push(next);
+      return Promise.resolve(next);
+    }),
+  };
+  return { adapter, calls };
+}
+
+describe('IVerifyAdapter contract', () => {
+  it('is a structural interface with a verify method', () => {
+    const { adapter } = makeAdapter([{ passed: true, stderr: '', stdout: '' }]);
+    expect(typeof adapter.verify).toBe('function');
+  });
+
+  it('returns VerifyResult-shaped value', async () => {
+    const { adapter } = makeAdapter([
+      { passed: false, stderr: 'patch does not apply', stdout: '' },
+    ]);
+    const instance = {
+      instance_id: 'test-1',
+      repo: 'test/repo',
+      base_commit: 'HEAD',
+    } as unknown as SWEBenchInstance;
+
+    const result = await adapter.verify(instance, 'diff...', '/tmp/work');
+    expect(result.passed).toBe(false);
+    expect(result.stderr).toContain('patch does not apply');
+  });
+
+  it('can be queued to simulate retry-then-pass', async () => {
+    const { adapter } = makeAdapter([
+      { passed: false, stderr: 'FAILED tests/test_foo.py::bar', stdout: '' },
+      { passed: true, stderr: '', stdout: 'PASSED' },
+    ]);
+    const instance = { instance_id: 'x' } as SWEBenchInstance;
+
+    const first = await adapter.verify(instance, 'p1', '/tmp');
+    const second = await adapter.verify(instance, 'p2', '/tmp');
+    expect(first.passed).toBe(false);
+    expect(second.passed).toBe(true);
+  });
+});
+
+describe('runAgentOnInstance — verify adapter opt-in', () => {
+  // The runner itself requires filesystem access to exercise fully, so we
+  // keep this to a shape test that confirms the option is accepted.
+  it('accepts verifyAdapter in RunOptions without type error', () => {
+    const executor: IAgentExecutor = {
+      execute: () =>
+        Promise.resolve({
+          ok: true,
+          value: { response: '', tokensUsed: 0, durationMs: 0 },
+        }),
+    };
+    const { adapter } = makeAdapter([{ passed: true, stderr: '', stdout: '' }]);
+    const config = { max_iterations: 5, timeout_ms: 60_000 } as SWEBenchConfig;
+    const opts = {
+      executor,
+      config,
+      verifyAdapter: adapter,
+      maxVerifyRetries: 1,
+    };
+    // Compile-time check: these are the only assertions needed here.
+    expect(opts.verifyAdapter).toBe(adapter);
+    expect(opts.maxVerifyRetries).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/swe-bench/agent-runner.ts
+++ b/packages/nexus-agents/src/swe-bench/agent-runner.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Cohesive runner module: iteration loop + verify loop + helpers. */
 /**
  * nexus-agents/swe-bench - Agent Runner
  *
@@ -10,6 +11,7 @@
 import type { Result } from '../core/result.js';
 import { getTimeProvider } from '../core/index.js';
 import type { SWEBenchInstance, SWEBenchRunResult, SWEBenchConfig } from './types.js';
+import { buildVerifyOutcome } from './verify-loop.js';
 import {
   SWE_BENCH_SYSTEM_PROMPT,
   createInstancePrompt,
@@ -86,6 +88,27 @@ interface IterationLoopOptions {
   readonly onMessage: ((msg: string) => void) | undefined;
   readonly systemPrompt: string | undefined;
   iterationContext: IterationContext;
+  readonly verifyAdapter?: IVerifyAdapter;
+  readonly maxVerifyRetries?: number;
+  verifyAttempts: number;
+}
+
+/**
+ * Result of a post-patch verification attempt (#2032 integration).
+ */
+export interface VerifyResult {
+  readonly passed: boolean;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+/**
+ * Adapter that runs the instance's test suite against a freshly-applied
+ * patch (#2032 integration). Verification is opt-in — when no adapter
+ * is provided, the runner behaves exactly as before.
+ */
+export interface IVerifyAdapter {
+  verify(instance: SWEBenchInstance, patch: string, workDir: string): Promise<VerifyResult>;
 }
 
 /**
@@ -98,6 +121,15 @@ export interface RunOptions {
   readonly signal?: AbortSignal;
   /** Override system prompt (e.g., with memory-enriched version). */
   readonly systemPrompt?: string;
+  /**
+   * Optional post-patch verify adapter (#2032). When provided, successful
+   * patches are verified by running the instance's test suite; failures
+   * trigger a bounded retry loop using the classification + retry-hint
+   * logic from `verify-loop.ts`. Default cap: 2 retries.
+   */
+  readonly verifyAdapter?: IVerifyAdapter;
+  /** Override max verify retries (default 2). */
+  readonly maxVerifyRetries?: number;
 }
 
 // ============================================================================
@@ -282,6 +314,11 @@ export async function runAgentOnInstance(
     onMessage,
     systemPrompt: options.systemPrompt,
     iterationContext: createEmptyContext(),
+    verifyAttempts: 0,
+    ...(options.verifyAdapter !== undefined ? { verifyAdapter: options.verifyAdapter } : {}),
+    ...(options.maxVerifyRetries !== undefined
+      ? { maxVerifyRetries: options.maxVerifyRetries }
+      : {}),
   };
   const result = await runIterationLoop(executor, context, state, loopOptions);
   return { ok: true, value: result };
@@ -357,6 +394,87 @@ function buildDuplicateResult(
   return buildFailedResult(instanceId, 'Duplicate patch — agent is stuck', startTime, state);
 }
 
+/** Invoke the verify adapter and build the outcome. Pure wrapper. */
+async function invokeVerifyAdapter(
+  adapter: IVerifyAdapter,
+  patch: string,
+  context: AgentContext,
+  options: IterationLoopOptions
+): Promise<ReturnType<typeof buildVerifyOutcome>> {
+  const { passed, stderr, stdout } = await adapter.verify(context.instance, patch, context.workDir);
+  return buildVerifyOutcome({
+    passed,
+    iteration: options.verifyAttempts - 1,
+    stderr,
+    stdout,
+    ...(options.maxVerifyRetries !== undefined ? { maxRetries: options.maxVerifyRetries } : {}),
+  });
+}
+
+/** Record verification-failure state and reset finalPatch so the next iteration runs. */
+function applyVerifyRetry(
+  outcome: ReturnType<typeof buildVerifyOutcome>,
+  state: IterationState,
+  onMessage: ((msg: string) => void) | undefined
+): void {
+  const category = outcome.classification?.category ?? 'unknown';
+  onMessage?.(`Verify failed (${category}); retrying with hint`);
+  state.lastError = outcome.retryHint ?? 'Verification failed; re-emit the patch';
+  state.lastPatch = state.finalPatch;
+  state.finalPatch = undefined;
+}
+
+/**
+ * Run post-patch verification if a verify adapter is configured (#2032).
+ * Returns `true` when the outer iteration loop should break (no adapter,
+ * verify passes, or retry cap reached). Returns `false` when retry is
+ * permitted — state.lastError now holds the retry hint for the agent.
+ */
+async function runPostPatchVerify(
+  context: AgentContext,
+  state: IterationState,
+  options: IterationLoopOptions
+): Promise<boolean> {
+  const adapter = options.verifyAdapter;
+  if (adapter === undefined || state.finalPatch === undefined) return true;
+  options.verifyAttempts += 1;
+  options.onMessage?.(`Verifying patch (attempt ${String(options.verifyAttempts)})`);
+  const outcome = await invokeVerifyAdapter(adapter, state.finalPatch, context, options);
+  if (outcome.ok) return true;
+  if (!outcome.willRetry) {
+    const category = outcome.classification?.category ?? 'unknown';
+    options.onMessage?.(`Verify failed (${category}); no more retries`);
+    return true;
+  }
+  applyVerifyRetry(outcome, state, options.onMessage);
+  return false;
+}
+
+/** Outcome of a single loop iteration: keep looping, break, or early-exit with a built result. */
+type IterationControl = 'break' | 'continue' | { readonly result: SWEBenchRunResult };
+
+async function handleIterationDone(
+  context: AgentContext,
+  state: IterationState,
+  options: IterationLoopOptions,
+  seenPatches: Set<string>
+): Promise<IterationControl> {
+  if (isDuplicatePatch(state.finalPatch, seenPatches)) {
+    state.finalPatch = undefined;
+    return {
+      result: buildDuplicateResult(
+        context.instance.instance_id,
+        options.startTime,
+        state,
+        options.onMessage
+      ),
+    };
+  }
+  options.onMessage?.('Patch applies successfully');
+  const verifyOk = await runPostPatchVerify(context, state, options);
+  return verifyOk ? 'break' : 'continue';
+}
+
 async function runIterationLoop(
   executor: IAgentExecutor,
   context: AgentContext,
@@ -375,12 +493,10 @@ async function runIterationLoop(
 
     const done = await executeOneIteration(executor, context, state, options);
     if (done) {
-      if (isDuplicatePatch(state.finalPatch, seenPatches)) {
-        state.finalPatch = undefined;
-        return buildDuplicateResult(context.instance.instance_id, startTime, state, onMessage);
-      }
-      onMessage?.('Patch applies successfully');
-      break;
+      const control = await handleIterationDone(context, state, options, seenPatches);
+      if (control === 'break') break;
+      if (control === 'continue') continue;
+      return control.result;
     }
 
     if (isDuplicatePatch(state.lastPatch, seenPatches)) {


### PR DESCRIPTION
## Summary

Final integration from the #2043 follow-up epic. Wires the pure verify utilities from #2042 into the SWE-bench agent runner via a new \`IVerifyAdapter\` interface on \`RunOptions\`.

Completes **5 of 5** integrations from #2043.

## Changes

- **New types** on \`agent-runner.ts\`:
  - \`VerifyResult\` — \`{passed, stderr, stdout}\` shape adapters return
  - \`IVerifyAdapter\` — structural interface with \`verify(instance, patch, workDir): Promise<VerifyResult>\`
- **New optional fields** on \`RunOptions\`: \`verifyAdapter?\` + \`maxVerifyRetries?\` (default 2). Absent adapter → **zero change** in runner behavior
- **New helpers**: \`runPostPatchVerify\`, \`invokeVerifyAdapter\`, \`applyVerifyRetry\`, \`handleIterationDone\`. After each successful patch the runner calls \`adapter.verify()\`, feeds stderr/stdout to \`buildVerifyOutcome\`, and on \`willRetry\` injects the retry hint into \`state.lastError\` so the next iteration's prompt sees it

## Deliberately NOT in this PR

- **No real evaluation-harness adapter** — this PR establishes the contract; wiring up the actual test-suite execution is a separate follow-up so consumers can prototype their own adapters today

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] \`pnpm --filter nexus-agents build\` — clean (ESM + DTS)
- [x] 4 new tests (adapter contract, queued verify results, RunOptions shape)
- [x] 29 existing agent-runner + verify-loop tests pass unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)