### PR TITLE
docs: document 3 session-added env vars in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,17 +47,20 @@ nexus-agents --help       # Full command list
 **Required:** Node.js 22.x LTS, pnpm 9.x (or npm 10.x)
 **Optional:** Docker (sandbox mode), Claude CLI (MCP mode)
 
-| Variable                 | Required For                        | Default                       |
-| ------------------------ | ----------------------------------- | ----------------------------- |
-| `ANTHROPIC_API_KEY`      | Claude adapter                      | None                          |
-| `OPENAI_API_KEY`         | OpenAI adapter                      | None                          |
-| `GOOGLE_AI_API_KEY`      | Gemini adapter                      | None                          |
-| `OPENROUTER_API_KEY`     | OpenRouter adapter (free models)    | None                          |
-| `NEXUS_LOG_LEVEL`        | Logging verbosity                   | `info`                        |
-| `NEXUS_CONFIG_PATH`      | Custom config path                  | `./nexus-agents.yaml`         |
-| `NEXUS_AUTH_ENABLED`     | Network auth (not needed for stdio) | `true` (auto-generates token) |
-| `NEXUS_BILLING_MODE`     | Model routing cost handling         | `plan` (monthly subscription) |
-| `NEXUS_PERSIST_LEARNING` | Cross-session learning persistence  | `true`                        |
+| Variable                       | Required For                                | Default                       |
+| ------------------------------ | ------------------------------------------- | ----------------------------- |
+| `ANTHROPIC_API_KEY`            | Claude adapter                              | None                          |
+| `OPENAI_API_KEY`               | OpenAI adapter                              | None                          |
+| `GOOGLE_AI_API_KEY`            | Gemini adapter                              | None                          |
+| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)            | None                          |
+| `NEXUS_LOG_LEVEL`              | Logging verbosity                           | `info`                        |
+| `NEXUS_CONFIG_PATH`            | Custom config path                          | `./nexus-agents.yaml`         |
+| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)         | `true` (auto-generates token) |
+| `NEXUS_BILLING_MODE`           | Model routing cost handling                 | `plan` (monthly subscription) |
+| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence          | `true`                        |
+| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `enforce` | `off`                         |
+| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`1` to enable)   | unset (disabled)              |
+| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1] | `0.85`                        |
 
 **Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
 


### PR DESCRIPTION
## Summary

Closes a small documentation gap: three env vars landed this session but none were listed in CLAUDE.md's prerequisites table.

- \`NEXUS_ACCESS_POLICY_MODE\` (#1977, #2021, #2024, #2026) — ClawGuard off/audit/enforce mode. Default off.
- \`NEXUS_TASK_STATE_ENABLED\` (#2033, #2045) — structured task-state log opt-in. Set to \`1\` to enable; default disabled.
- \`NEXUS_CONTEXT_WARN_THRESHOLD\` (#2031) — per-expert context-budget warning threshold (0..1]. Default \`0.85\`.

All three are opt-in / safe-by-default, so the docs gap didn't affect runtime — but operators looking to activate any of them needed to read source to find them.

## Test plan

- [x] Governance inject check still clean (no governance sections touched)
- [ ] Doc gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)