### PR TITLE
feat(swe-bench): concrete HarnessVerifyAdapter for verify-loop integration (#2054)

### DIFF
--- a/.changeset/2054-harness-verify-adapter.md
+++ b/.changeset/2054-harness-verify-adapter.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): concrete HarnessVerifyAdapter for verify-loop integration (#2054)
+
+Closes the dormant integration path from #2051 by providing a
+production-ready `IVerifyAdapter` implementation that delegates to the
+existing `IEvaluationHarness`.
+
+- New `swe-bench/harness-verify-adapter.ts` with:
+  - `HarnessVerifyAdapter` class — wraps `harness.evaluateInstance`
+    and translates `InstanceEvaluationResult` to the `VerifyResult`
+    shape the agent-runner expects
+  - `translateEvaluationResult(result)` — pure translator exported
+    for tests and alternative adapter implementations
+- Mapping:
+  - `passed` = `resolved` (all FAIL_TO_PASS pass + all PASS_TO_PASS
+    still pass)
+  - `stderr` = patch application error, timeout notice, or
+    pytest-style list of failed tests (truncated at 20)
+  - `stdout` = human-readable summary (counts + status + duration)
+- Never-throw contract: on any harness exception, returns
+  `{passed: false, stderr: "Harness evaluation failed: ..."}` so the
+  retry loop can make a sensible decision rather than crashing
+- 8 tests cover the result translator across 5 statuses
+  (resolved/unresolved/error/timeout), the pass/fail wiring, the
+  truncation, and the never-throws contract
+
+Consumers activate verification by:
+
+```ts
+const harness = await createValidatedHarness(...);
+const verifyAdapter = new HarnessVerifyAdapter(harness, modelName, evalConfig);
+runAgentOnInstance(instance, { executor, config, verifyAdapter });
+```
+
+With this PR, the `#2051` integration is no longer dormant — SWE-bench
+runs can opt into post-patch verification end-to-end.

--- a/packages/nexus-agents/src/swe-bench/harness-verify-adapter.test.ts
+++ b/packages/nexus-agents/src/swe-bench/harness-verify-adapter.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for HarnessVerifyAdapter (#2054).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { HarnessVerifyAdapter, translateEvaluationResult } from './harness-verify-adapter.js';
+import type { InstanceEvaluationResult } from './evaluation-result-types.js';
+import type { IEvaluationHarness } from './evaluation-interface-types.js';
+import type { EvaluationHarnessConfig } from './evaluation-config-types.js';
+import type { SWEBenchInstance } from './types.js';
+
+function mockEvalConfig(): EvaluationHarnessConfig {
+  return {} as EvaluationHarnessConfig;
+}
+
+function mockInstance(id = 'test-1'): SWEBenchInstance {
+  return { instance_id: id, repo: 'test/repo', base_commit: 'HEAD' } as unknown as SWEBenchInstance;
+}
+
+function makeResult(overrides: Partial<InstanceEvaluationResult>): InstanceEvaluationResult {
+  return {
+    instanceId: 'test-1',
+    modelNameOrPath: 'test-model',
+    resolved: true,
+    status: 'resolved',
+    testResults: [],
+    testsPassed: 0,
+    testsFailed: 0,
+    testsTotal: 0,
+    patchApplied: true,
+    durationMs: 100,
+    ...overrides,
+  } as InstanceEvaluationResult;
+}
+
+describe('translateEvaluationResult', () => {
+  it('marks passed=true when resolved', () => {
+    const r = translateEvaluationResult(makeResult({ resolved: true, status: 'resolved' }));
+    expect(r.passed).toBe(true);
+    expect(r.stderr).toBe('');
+  });
+
+  it('marks passed=false when unresolved', () => {
+    const r = translateEvaluationResult(
+      makeResult({
+        resolved: false,
+        status: 'unresolved',
+        patchApplied: true,
+        testResults: [
+          { testName: 'test_foo', status: 'failed', durationMs: 50, errorMessage: 'boom' },
+        ],
+        testsFailed: 1,
+        testsTotal: 1,
+      })
+    );
+    expect(r.passed).toBe(false);
+    expect(r.stderr).toContain('FAILED test_foo');
+    expect(r.stderr).toContain('boom');
+  });
+
+  it('surfaces patch application error as stderr when patchApplied=false', () => {
+    const r = translateEvaluationResult(
+      makeResult({
+        resolved: false,
+        status: 'error',
+        patchApplied: false,
+        patchError: 'hunk #1 FAILED',
+      })
+    );
+    expect(r.passed).toBe(false);
+    expect(r.stderr).toContain('patch does not apply');
+    expect(r.stderr).toContain('hunk #1 FAILED');
+  });
+
+  it('flags timeout in stderr', () => {
+    const r = translateEvaluationResult(
+      makeResult({ resolved: false, status: 'timeout', durationMs: 300_000 })
+    );
+    expect(r.stderr).toContain('timed out');
+    expect(r.stderr).toContain('300000');
+  });
+
+  it('truncates failed-test list to 20 entries', () => {
+    const testResults = Array.from({ length: 30 }, (_, i) => ({
+      testName: `test_${String(i)}`,
+      status: 'failed' as const,
+      durationMs: 1,
+    }));
+    const r = translateEvaluationResult(
+      makeResult({
+        resolved: false,
+        status: 'unresolved',
+        patchApplied: true,
+        testResults,
+        testsFailed: 30,
+        testsTotal: 30,
+      })
+    );
+    const failedLines = r.stderr.split('\n').filter((l) => l.startsWith('FAILED'));
+    expect(failedLines.length).toBe(20);
+  });
+
+  it('produces a readable stdout summary', () => {
+    const r = translateEvaluationResult(
+      makeResult({
+        resolved: true,
+        status: 'resolved',
+        testsPassed: 5,
+        testsTotal: 5,
+        durationMs: 123,
+      })
+    );
+    expect(r.stdout).toContain('Instance: test-1');
+    expect(r.stdout).toContain('Status: resolved');
+    expect(r.stdout).toContain('5/5 passed');
+    expect(r.stdout).toContain('123ms');
+  });
+});
+
+describe('HarnessVerifyAdapter', () => {
+  it('delegates to harness.evaluateInstance', async () => {
+    const evaluateInstance = vi.fn<IEvaluationHarness['evaluateInstance']>(() =>
+      Promise.resolve(makeResult({ resolved: true, status: 'resolved' }))
+    );
+    const harness = { evaluateInstance } as unknown as IEvaluationHarness;
+    const adapter = new HarnessVerifyAdapter(harness, 'test-model', mockEvalConfig());
+
+    const result = await adapter.verify(mockInstance(), 'diff...', '/tmp');
+    expect(result.passed).toBe(true);
+    expect(evaluateInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance_id: 'test-1',
+        model_name_or_path: 'test-model',
+        model_patch: 'diff...',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('never throws — returns passed=false on harness exception', async () => {
+    const evaluateInstance = vi.fn<IEvaluationHarness['evaluateInstance']>(() =>
+      Promise.reject(new Error('docker unavailable'))
+    );
+    const harness = { evaluateInstance } as unknown as IEvaluationHarness;
+    const adapter = new HarnessVerifyAdapter(harness, 'test-model', mockEvalConfig());
+
+    const result = await adapter.verify(mockInstance(), 'diff...', '/tmp');
+    expect(result.passed).toBe(false);
+    expect(result.stderr).toContain('Harness evaluation failed');
+    expect(result.stderr).toContain('docker unavailable');
+  });
+});

--- a/packages/nexus-agents/src/swe-bench/harness-verify-adapter.ts
+++ b/packages/nexus-agents/src/swe-bench/harness-verify-adapter.ts
@@ -1,0 +1,114 @@
+/**
+ * Harness-backed verify adapter (#2054).
+ *
+ * Concrete implementation of `IVerifyAdapter` that delegates to the
+ * existing `IEvaluationHarness` to actually run the instance's test
+ * suite. Translates the harness's `InstanceEvaluationResult` into the
+ * `VerifyResult` shape the agent-runner expects.
+ *
+ * Wire this into the agent-runner via `RunOptions.verifyAdapter`:
+ *
+ * ```typescript
+ * const harness = await createValidatedHarness(...);
+ * const verifyAdapter = new HarnessVerifyAdapter(harness, modelName, evalConfig);
+ * runAgentOnInstance(instance, { executor, config, verifyAdapter });
+ * ```
+ *
+ * @module swe-bench/harness-verify-adapter
+ */
+
+import type { IVerifyAdapter, VerifyResult } from './agent-runner.js';
+import type { IEvaluationHarness } from './evaluation-interface-types.js';
+import type { EvaluationHarnessConfig } from './evaluation-config-types.js';
+import type { InstanceEvaluationResult } from './evaluation-result-types.js';
+import type { SWEBenchInstance, SWEBenchPrediction } from './types.js';
+import { createLogger } from '../core/index.js';
+
+const logger = createLogger({ component: 'harness-verify-adapter' });
+
+/**
+ * Builds a `VerifyResult` from an `InstanceEvaluationResult`.
+ *
+ * Mapping:
+ * - `passed` = `resolved` (all FAIL_TO_PASS now pass, all PASS_TO_PASS still pass)
+ * - `stderr` = patch application error, if any; else pytest-style summary of failed tests
+ * - `stdout` = run summary (counts + status)
+ *
+ * Exported for direct use by tests.
+ */
+export function translateEvaluationResult(result: InstanceEvaluationResult): VerifyResult {
+  const stderr = buildStderr(result);
+  const stdout = buildStdout(result);
+  return {
+    passed: result.resolved,
+    stderr,
+    stdout,
+  };
+}
+
+function buildStderr(result: InstanceEvaluationResult): string {
+  if (!result.patchApplied) {
+    return `patch does not apply: ${result.patchError ?? 'unknown error'}`;
+  }
+  if (result.status === 'timeout') {
+    return `Test run timed out after ${String(result.durationMs)}ms`;
+  }
+  if (result.status === 'error') {
+    return `Runtime error during evaluation: ${result.patchError ?? 'unknown'}`;
+  }
+  // Patch applied but tests failed — build a pytest-style summary
+  const failed = result.testResults.filter((t) => t.status === 'failed');
+  if (failed.length === 0) return '';
+  const lines = failed
+    .slice(0, 20)
+    .map((t) => `FAILED ${t.testName}${t.errorMessage !== undefined ? `: ${t.errorMessage}` : ''}`);
+  return lines.join('\n');
+}
+
+function buildStdout(result: InstanceEvaluationResult): string {
+  const summary = [
+    `Instance: ${result.instanceId}`,
+    `Status: ${result.status}`,
+    `Patch applied: ${String(result.patchApplied)}`,
+    `Tests: ${String(result.testsPassed)}/${String(result.testsTotal)} passed`,
+    `Duration: ${String(result.durationMs)}ms`,
+  ];
+  if (result.testsFailed > 0) summary.push(`Failed: ${String(result.testsFailed)}`);
+  return summary.join('\n');
+}
+
+/**
+ * Concrete `IVerifyAdapter` that calls `harness.evaluateInstance` per
+ * verify request. Requires a validated harness — call
+ * `createValidatedHarness()` first, then pass the result here.
+ */
+export class HarnessVerifyAdapter implements IVerifyAdapter {
+  constructor(
+    private readonly harness: IEvaluationHarness,
+    private readonly modelNameOrPath: string,
+    private readonly evalConfig: EvaluationHarnessConfig
+  ) {}
+
+  async verify(instance: SWEBenchInstance, patch: string, _workDir: string): Promise<VerifyResult> {
+    const prediction: SWEBenchPrediction = {
+      instance_id: instance.instance_id,
+      model_name_or_path: this.modelNameOrPath,
+      model_patch: patch,
+    };
+    try {
+      const result = await this.harness.evaluateInstance(prediction, this.evalConfig);
+      return translateEvaluationResult(result);
+    } catch (cause) {
+      const msg = cause instanceof Error ? cause.message : String(cause);
+      logger.warn('Harness verify failed, treating as unresolved', {
+        instanceId: instance.instance_id,
+        error: msg,
+      });
+      return {
+        passed: false,
+        stderr: `Harness evaluation failed: ${msg}`,
+        stdout: '',
+      };
+    }
+  }
+}

--- a/packages/nexus-agents/src/swe-bench/index.ts
+++ b/packages/nexus-agents/src/swe-bench/index.ts
@@ -72,7 +72,12 @@ export type {
   IAgentExecutor,
   AgentExecutionResult,
   RunOptions,
+  IVerifyAdapter,
+  VerifyResult,
 } from './agent-runner.js';
+
+// Harness-backed verify adapter (#2054)
+export { HarnessVerifyAdapter, translateEvaluationResult } from './harness-verify-adapter.js';
 
 // Nexus agent executor (API-based)
 export { NexusAgentExecutor, createNexusExecutorFromEnv } from './nexus-agent-executor.js';


### PR DESCRIPTION
## Summary

Closes the dormant integration path from #2051 by providing a production-ready \`IVerifyAdapter\` implementation that delegates to the existing \`IEvaluationHarness\`.

Closes #2054.

## What's in the PR

- **\`HarnessVerifyAdapter\`** class wraps \`harness.evaluateInstance\` and translates \`InstanceEvaluationResult\` to \`VerifyResult\`
- **\`translateEvaluationResult\`** — pure translator exported for tests and alternative implementations
- **Mapping:**
  - \`passed\` = \`resolved\` (FAIL_TO_PASS pass + PASS_TO_PASS still pass)
  - \`stderr\` = patch application error OR timeout notice OR pytest-style list of failed tests (truncated at 20)
  - \`stdout\` = human-readable summary (counts + status + duration)
- **Never-throw contract:** on harness exception returns \`{passed: false, stderr: "Harness evaluation failed: ..."}\` so the retry loop can decide sensibly rather than crash
- **8 tests** cover: all 4 resolution statuses, pass/fail translation, list truncation, never-throws contract, proper delegation

## Usage

\`\`\`ts
const harness = await createValidatedHarness(...);
const verifyAdapter = new HarnessVerifyAdapter(harness, modelName, evalConfig);
runAgentOnInstance(instance, { executor, config, verifyAdapter });
\`\`\`

With this PR, #2051's integration is no longer dormant — SWE-bench runs can opt into post-patch verification end-to-end.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] \`pnpm --filter nexus-agents build\` — clean (ESM + DTS)
- [x] 8 new tests pass
- [x] No existing tests affected (pure addition)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)