### PR TITLE
feat(orchestration): emit dependsOn from planAgentTeam (#2055)

### DIFF
--- a/.changeset/2055-planner-deps-emission.md
+++ b/.changeset/2055-planner-deps-emission.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): emit dependsOn from planAgentTeam (#2055)
+
+Makes the #2049 integration actually active. `planAgentTeam` now
+populates `dependsOn` on each `AgentPlanEntry` whose role has
+declared dependencies in the existing `EXPERT_DEPENDENCIES` map,
+filtered to roles actually present in the plan.
+
+- `assignDependencyAwareWaves` previously only mutated the `wave`
+  number; now it also sets `dependsOn` (filtered to present deps)
+- `applyDependencyWaves` in `worker-dispatcher.ts` (#2049) now sees
+  these edges and runs `topologicalWaveAssign` — end-to-end DAG
+  dispatch is live without any caller-side change
+- Never emits empty arrays — the field is either absent or
+  has ≥1 role
+- 3 new tests confirm emission, absence on degenerate plans, and
+  no-empty-arrays contract
+- 66 existing agent-planner tests pass unchanged
+
+Closes the dormant integration path from #2049. SWE-bench runs and
+other orchestrate paths now get dependency-aware wave ordering for
+free.

--- a/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.test.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.test.ts
@@ -670,4 +670,38 @@ describe('AgentPlanner', () => {
       expect(roles).toContain('code');
     });
   });
+
+  describe('dependsOn emission (#2055)', () => {
+    it('emits dependsOn on entries whose role has declared dependencies', () => {
+      // code_implementation/complex pulls in code + testing + architecture.
+      // testing depends on ['code'] per EXPERT_DEPENDENCIES.
+      const plan = planFor('code_implementation', 'complex');
+      const testingEntry = plan.entries.find((e) => e.role === 'testing');
+      if (testingEntry !== undefined) {
+        expect(testingEntry.dependsOn).toEqual(['code']);
+      }
+    });
+
+    it('omits dependsOn when the declared deps are not present in the plan', () => {
+      // A plan that has only architecture (no code) — architecture has no
+      // declared dependencies, and testing won't be included here.
+      const plan = planFor('documentation', 'simple');
+      for (const entry of plan.entries) {
+        const declaredDeps = EXPERT_DEPENDENCIES[entry.role] ?? [];
+        const presentDeps = declaredDeps.filter((d) => plan.entries.some((e) => e.role === d));
+        if (presentDeps.length === 0) {
+          expect(entry.dependsOn).toBeUndefined();
+        }
+      }
+    });
+
+    it('never emits empty dependsOn arrays', () => {
+      const plan = planFor('code_implementation', 'complex');
+      for (const entry of plan.entries) {
+        if (entry.dependsOn !== undefined) {
+          expect(entry.dependsOn.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
 });

--- a/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/agent-planner.ts
@@ -334,10 +334,16 @@ function assignDependencyAwareWaves(entries: readonly AgentPlanEntry[]): AgentPl
     }
   }
 
-  return entries.map((entry) => ({
-    ...entry,
-    wave: roleToWave.get(entry.role) ?? entry.wave,
-  }));
+  return entries.map((entry) => {
+    const deps = EXPERT_DEPENDENCIES[entry.role];
+    // Only include roles that are actually present in the plan.
+    const presentDeps = deps?.filter((d) => roleToWave.has(d)) ?? [];
+    return {
+      ...entry,
+      wave: roleToWave.get(entry.role) ?? entry.wave,
+      ...(presentDeps.length > 0 ? { dependsOn: presentDeps } : {}),
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes the #2049 integration actually active. \`planAgentTeam\` now populates \`dependsOn\` on each \`AgentPlanEntry\` whose role has declared dependencies in the existing \`EXPERT_DEPENDENCIES\` map, filtered to roles actually present in the plan.

Closes #2055.

## Changes

- \`assignDependencyAwareWaves\` previously only mutated the \`wave\` number; now it also sets \`dependsOn\` (filtered to present deps)
- \`applyDependencyWaves\` in \`worker-dispatcher.ts\` (#2049) now sees these edges and runs \`topologicalWaveAssign\` — end-to-end DAG dispatch is live with **zero caller-side change**
- Never emits empty arrays — the field is either absent or has ≥1 role

## Why this matters

Before this PR, the wave-assignment math was already dependency-aware at the \`wave\` level, but the \`dependsOn\` field was never populated, so the \`topologicalWaveAssign\` utility I landed in #2038/#2049 was dormant. This PR activates it.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 3 new tests (emission on mixed plans, absence on degenerate plans, no-empty-arrays)
- [x] 66 existing agent-planner tests pass unchanged
- [x] All 126 aorchestra tests pass together
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)