### PR TITLE
chore: use getTimeProvider().nowIso() for session-added timestamps

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -293,7 +293,7 @@ async function deriveExpertAccessPolicy(
       allowedPathPatterns: [],
       allowedOperations: '*',
       objectiveHash: 'derivation-failed',
-      derivedAt: new Date().toISOString(),
+      derivedAt: getTimeProvider().nowIso(),
       source: 'bypass',
       mode: 'off',
     };

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -639,7 +639,7 @@ function isTaskStateEnabled(): boolean {
  */
 function recordTaskStateInit(taskId: string, taskText: string, logger: ILogger): void {
   if (!isTaskStateEnabled()) return;
-  const now = new Date().toISOString();
+  const now = getTimeProvider().nowIso();
   const initial: StructuredTaskState = {
     taskId,
     stage: 'planning',
@@ -665,7 +665,7 @@ function recordTaskStateStage(
   logger: ILogger
 ): void {
   if (!isTaskStateEnabled()) return;
-  const result = updateStage(taskId, stage, new Date().toISOString());
+  const result = updateStage(taskId, stage, getTimeProvider().nowIso());
   if (!result.ok) {
     logger.warn('task-state: stage update failed', {
       taskId,
@@ -678,7 +678,7 @@ function recordTaskStateStage(
 /** Record a blocker. Silently swallows failures. */
 function recordTaskStateBlocker(taskId: string, blocker: string, logger: ILogger): void {
   if (!isTaskStateEnabled()) return;
-  const ts = new Date().toISOString();
+  const ts = getTimeProvider().nowIso();
   const result = appendBlocker(taskId, { ts, blocker });
   if (!result.ok) {
     logger.warn('task-state: blocker record failed', {
@@ -729,7 +729,7 @@ async function deriveOrchestratePolicy(
       allowedPathPatterns: [],
       allowedOperations: '*',
       objectiveHash: 'derivation-failed',
-      derivedAt: new Date().toISOString(),
+      derivedAt: getTimeProvider().nowIso(),
       source: 'bypass',
       mode: 'off',
     };


### PR DESCRIPTION
## Summary

Small tech-debt cleanup. Refactors 5 \`new Date().toISOString()\` sites I introduced earlier this session into the injectable \`getTimeProvider().nowIso()\` helper.

- \`orchestrate.ts\` (4 sites): \`recordTaskStateInit\`, \`recordTaskStateStage\`, \`recordTaskStateBlocker\`, \`deriveOrchestratePolicy\` bypass fallback
- \`execute-expert.ts\` (1 site): \`deriveExpertAccessPolicy\` bypass fallback

## Why

The time provider is designed specifically so timestamps are mockable for deterministic tests. Every new timestamp path should use it. This lands a small improvement on the fitness-audit \`determinism\` dimension.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 70 existing orchestrate + execute-expert tests pass (default TimeProvider delegates to Date.now/new Date() under the hood, so no behavior change)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)