### PR TITLE
chore: swap Math.random/Date.now in id generators for injectable providers (#2061)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -8,7 +8,12 @@
  * (Source: Issue #753 memory, Issue #1134 cold start)
  */
 
-import { createLogger, getErrorMessage } from '../../core/index.js';
+import {
+  createLogger,
+  getErrorMessage,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import { getToolMemory } from './tool-memory.js';
 import {
@@ -88,7 +93,7 @@ export function recordVoteOutcomes(votes: readonly AgentVoteResult[]): void {
           : DEFAULT_CLI;
       const voteSuccess = vote.source === 'llm';
       store.append({
-        id: `vote-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+        id: `vote-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
         cli: cliName,
         category: 'planning',
         model: 'consensus',

--- a/packages/nexus-agents/src/mcp/tools/create-expert-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/create-expert-recording.ts
@@ -8,7 +8,12 @@
  * (Source: Issue #1174 — Add observability to dark MCP tools)
  */
 
-import { createLogger, getErrorMessage } from '../../core/index.js';
+import {
+  createLogger,
+  getErrorMessage,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import { getToolMemory } from './tool-memory.js';
 import {
   getOutcomeStore,
@@ -70,7 +75,7 @@ export function recordExpertOutcome(
     const store = getOutcomeStore();
     const errorMsg = error ?? 'expert creation failed';
     store.append({
-      id: `expert-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `expert-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: DEFAULT_CLI,
       category: resolveCategory(role),
       model: 'expert',

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
@@ -18,6 +18,7 @@ import {
   createLogger,
   formatZodError,
   getTimeProvider,
+  getRandomProvider,
   type ILogger,
 } from '../../core/index.js';
 import { DEFAULTS } from '../../config/defaults.js';
@@ -129,7 +130,7 @@ function recordToOutcomeStore(
       qualitySignals.push(`governance:${governance.domain}`);
     }
     getOutcomeStore().append({
-      id: `del-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `del-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli,
       category: match?.category ?? 'exploration',
       model,

--- a/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
@@ -8,7 +8,12 @@
  * (Source: Issue #1298 — extracted during Layer 2 refactor)
  */
 
-import { createLogger, getErrorMessage, getTimeProvider } from '../../core/index.js';
+import {
+  createLogger,
+  getErrorMessage,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import type { OutcomeFailureCategory } from '../../orchestration/outcomes/index.js';
 import {
   getOutcomeStore,
@@ -62,7 +67,7 @@ export function recordExpertOutcome(opts: ExpertOutcomeOpts): void {
   try {
     const match = detectTaskCategory(opts.task);
     getOutcomeStore().append({
-      id: `exp-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `exp-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: match?.primaryCli ?? DEFAULT_CLI,
       category: resolveExpertCategory(opts),
       model: opts.model ?? 'expert',

--- a/packages/nexus-agents/src/mcp/tools/execute-spec-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-spec-tool.ts
@@ -11,7 +11,12 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
-import { createLogger, formatZodError } from '../../core/index.js';
+import {
+  createLogger,
+  formatZodError,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import { parseSpec } from '../../orchestration/spec-parser.js';
 import { decomposeSpec } from '../../orchestration/spec-decomposer.js';
 import { executeSpec } from '../../orchestration/spec-executor.js';
@@ -184,7 +189,7 @@ function recordSpecOutcome(success: boolean, durationMs: number, stage?: string)
     }
     const store = getOutcomeStore();
     store.append({
-      id: `spec-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `spec-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: DEFAULT_CLI,
       category: 'code_generation',
       model: 'spec-executor',

--- a/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
@@ -10,7 +10,12 @@
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError } from '../../core/index.js';
+import {
+  createLogger,
+  formatZodError,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import { toolError, toolSuccess, type BaseMcpToolDeps, type ToolResult } from './tool-result.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -207,7 +212,7 @@ function recordTriageOutcome(success: boolean, durationMs: number, errorMsg?: st
     }
     const store = getOutcomeStore();
     store.append({
-      id: `triage-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `triage-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: DEFAULT_CLI,
       category: 'planning',
       model: 'issue-triage',

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-dispatch.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-dispatch.ts
@@ -33,7 +33,7 @@ import {
   synthesizeResults,
   type SynthesisSource,
 } from '../../orchestration/aorchestra/result-synthesizer.js';
-import { getTimeProvider } from '../../core/index.js';
+import { getTimeProvider, getRandomProvider } from '../../core/index.js';
 import type { ContentBlock } from '../../core/types/model.js';
 import { DEFAULT_CLI, type CliNameLiteral } from '../../config/model-capabilities-types.js';
 import { resolveAdapterForRole, getExpertFallbackChain } from './create-expert-routing.js';
@@ -590,7 +590,7 @@ export function recordWorkerOutcomes(
       // Use actual CLI that executed (#1527), fall back to specialization recommendation
       const cli = (r.resolvedCli ?? fallbackCli) as CliNameLiteral;
       store.append({
-        id: `worker-${r.role}-${String(Date.now())}-${Math.random().toString(36).slice(2, 6)}`,
+        id: `worker-${r.role}-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 6)}`,
         cli,
         category,
         model: `worker-${r.role}`,

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -259,7 +259,7 @@ function recordToOutcomeStore(
     const cli = opts?.actualCli ?? match?.primaryCli ?? DEFAULT_CLI;
     const category = match?.category ?? 'exploration';
     getOutcomeStore().append({
-      id: `orch-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `orch-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli,
       category,
       model: 'orchestrator',

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -12,7 +12,13 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
-import { getErrorMessage, createLogger, formatZodError } from '../../core/index.js';
+import {
+  getErrorMessage,
+  createLogger,
+  formatZodError,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import { normalizeTopicToCanonical } from '../../research/topic-aliases.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
@@ -500,7 +506,7 @@ function recordDiscoveryOutcome(success: boolean, durationMs: number, errorMsg?:
     }
     const store = getOutcomeStore();
     store.append({
-      id: `research-discover-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `research-discover-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: DEFAULT_CLI,
       category: 'research',
       model: 'research-discover',

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -11,7 +11,12 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
-import { createLogger, formatZodError, getTimeProvider } from '../../core/index.js';
+import {
+  createLogger,
+  formatZodError,
+  getTimeProvider,
+  getRandomProvider,
+} from '../../core/index.js';
 import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
 import { executeGraph } from '../../orchestration/graph/index.js';
 import type { CompiledGraph, GraphEvent, GraphState } from '../../orchestration/graph/index.js';
@@ -361,7 +366,7 @@ function recordGraphWorkflowResult(result: RunGraphWorkflowResponse): void {
   try {
     const store = getOutcomeStore();
     store.append({
-      id: `graph-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+      id: `graph-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
       cli: DEFAULT_CLI,
       category: workflowToCategory(result.workflow),
       model: 'graph-workflow',

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -17,6 +17,7 @@ import {
   err,
   createLogger,
   getTimeProvider,
+  getRandomProvider,
   extractJsonObject,
   withStep,
 } from '../core/index.js';
@@ -464,7 +465,7 @@ function recordPlanOutcomes(partitions: readonly CliPlanPartition[]): void {
     const store = getOutcomeStore();
     for (const p of partitions) {
       store.append({
-        id: `cpn-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+        id: `cpn-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
         cli: p.cli,
         category: 'planning',
         model: p.model ?? 'unknown',

--- a/packages/nexus-agents/src/orchestration/parallel-exploration.ts
+++ b/packages/nexus-agents/src/orchestration/parallel-exploration.ts
@@ -10,7 +10,14 @@
  */
 
 import type { Result, ILogger } from '../core/index.js';
-import { getErrorMessage, ok, err, createLogger, getTimeProvider } from '../core/index.js';
+import {
+  getErrorMessage,
+  ok,
+  err,
+  createLogger,
+  getTimeProvider,
+  getRandomProvider,
+} from '../core/index.js';
 // CLI_NAMES canonical source: config/model-capabilities-types.ts
 // CliName type ensures these stay in sync with the canonical list
 
@@ -263,7 +270,7 @@ function recordOutcomes(partitions: readonly PartitionResult[], category: TaskCa
     const store = getOutcomeStore();
     for (const p of partitions) {
       store.append({
-        id: `pex-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+        id: `pex-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
         cli: p.cli,
         category,
         model: p.model ?? 'unknown',

--- a/packages/nexus-agents/src/orchestration/triangulated-review.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.ts
@@ -16,6 +16,7 @@ import {
   err,
   createLogger,
   getTimeProvider,
+  getRandomProvider,
   extractJsonArray,
   withStep,
 } from '../core/index.js';
@@ -432,7 +433,7 @@ function recordReviewOutcomes(partitions: readonly CliReviewPartition[]): void {
     const store = getOutcomeStore();
     for (const p of partitions) {
       store.append({
-        id: `rev-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`,
+        id: `rev-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
         cli: p.cli,
         category: 'code_review',
         model: p.model ?? 'unknown',


### PR DESCRIPTION
## Summary

Picks off the easiest chunk of #2061's fitness-audit findings: 13 id-generation sites that used \`Math.random()\` + \`Date.now()\` for uniqueness are now routed through \`getRandomProvider()\` + \`getTimeProvider()\`, matching the established injectability pattern used elsewhere in the codebase.

## Fitness impact

**98 → 99.** The unseeded \`Math.random()\` count dropped from 18 to 5 (the remaining 5 are in places where the non-injectable global is deliberate — e.g., \`e2e-eval\` seed default, \`weather-report\` exploration-rate sampling).

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] \`pnpm --filter nexus-agents build\` — clean (ESM + DTS)
- [x] Full test suite: **25,934 tests pass** unchanged
- [x] Fitness audit: score 98 → 99
- [ ] CI green

## Zero behavior change

The default \`TimeProvider\` and \`RandomProvider\` delegate to \`Date.now()\` and \`Math.random()\` under the hood. This is a pure injectability improvement — tests that want determinism can now inject fixed providers.

Related: #2061 (tech-debt tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)