### PR TITLE
feat: flip ClawGuard (audit) and task-state to default-on

### DIFF
--- a/.changeset/2050-default-on-clawguard-taskstate.md
+++ b/.changeset/2050-default-on-clawguard-taskstate.md
@@ -1,0 +1,41 @@
+---
+'nexus-agents': minor
+---
+
+feat: flip ClawGuard and structured-task-state to default-on (user-visible)
+
+Two previously opt-in features now default to on — approved for a v2.x
+minor release.
+
+## ClawGuard: `off` → `audit` by default
+
+`NEXUS_ACCESS_POLICY_MODE` default flipped from `off` to `audit`. Every
+orchestrate / execute_expert call now derives an access policy and
+logs `access-policy: audit violation` when tool calls fall outside the
+derived allowlist. Nothing is blocked — enforcement still requires
+explicit `NEXUS_ACCESS_POLICY_MODE=enforce`.
+
+- Operators wanting the pre-v2.50 behavior: set
+  `NEXUS_ACCESS_POLICY_MODE=off`
+- Operators wanting blocking: set `NEXUS_ACCESS_POLICY_MODE=enforce`
+
+## Structured task state: disabled → enabled by default
+
+`NEXUS_TASK_STATE_ENABLED` default flipped from "unset disables" to
+"unset enables". Orchestrations now write a JSONL log per task under
+`~/.nexus-agents/tasks/state-{taskId}.jsonl` capturing stage
+transitions, decisions, and blockers. The log is read back via the
+`query_task_state` MCP tool.
+
+- Operators wanting the pre-v2.50 behavior: set
+  `NEXUS_TASK_STATE_ENABLED=0` (or `false`)
+
+## Why now
+
+- ClawGuard has shipped for multiple releases with 53+ tests and zero
+  known regressions. Audit mode gives telemetry without risk.
+- Structured task state has been available since #2045. Default-on
+  closes the "why did my orchestration fail?" feedback loop — the log
+  file survives session restarts.
+
+Updated 16 test cases to match the new defaults; all pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,20 +47,20 @@ nexus-agents --help       # Full command list
 **Required:** Node.js 22.x LTS, pnpm 9.x (or npm 10.x)
 **Optional:** Docker (sandbox mode), Claude CLI (MCP mode)
 
-| Variable                       | Required For                                | Default                       |
-| ------------------------------ | ------------------------------------------- | ----------------------------- |
-| `ANTHROPIC_API_KEY`            | Claude adapter                              | None                          |
-| `OPENAI_API_KEY`               | OpenAI adapter                              | None                          |
-| `GOOGLE_AI_API_KEY`            | Gemini adapter                              | None                          |
-| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)            | None                          |
-| `NEXUS_LOG_LEVEL`              | Logging verbosity                           | `info`                        |
-| `NEXUS_CONFIG_PATH`            | Custom config path                          | `./nexus-agents.yaml`         |
-| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)         | `true` (auto-generates token) |
-| `NEXUS_BILLING_MODE`           | Model routing cost handling                 | `plan` (monthly subscription) |
-| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence          | `true`                        |
-| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `enforce` | `off`                         |
-| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`1` to enable)   | unset (disabled)              |
-| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1] | `0.85`                        |
+| Variable                       | Required For                                       | Default                       |
+| ------------------------------ | -------------------------------------------------- | ----------------------------- |
+| `ANTHROPIC_API_KEY`            | Claude adapter                                     | None                          |
+| `OPENAI_API_KEY`               | OpenAI adapter                                     | None                          |
+| `GOOGLE_AI_API_KEY`            | Gemini adapter                                     | None                          |
+| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)                   | None                          |
+| `NEXUS_LOG_LEVEL`              | Logging verbosity                                  | `info`                        |
+| `NEXUS_CONFIG_PATH`            | Custom config path                                 | `./nexus-agents.yaml`         |
+| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)                | `true` (auto-generates token) |
+| `NEXUS_BILLING_MODE`           | Model routing cost handling                        | `plan` (monthly subscription) |
+| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence                 | `true`                        |
+| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `enforce`        | `audit` (v2.50+)              |
+| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable) | enabled (v2.50+)              |
+| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]        | `0.85`                        |
 
 **Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
 

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-access-policy.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-access-policy.test.ts
@@ -2,8 +2,9 @@
  * Tests for the ClawGuard access-policy opt-in in orchestrate (#2022).
  *
  * Verifies that:
- * - When NEXUS_ACCESS_POLICY_MODE is unset/off, the derived policy is
- *   bypass/off and the middleware short-circuits (no behavior change).
+ * - When NEXUS_ACCESS_POLICY_MODE is unset, defaults to 'audit' mode.
+ *   When explicitly set to 'off', the derived policy is bypass/off and
+ *   the middleware short-circuits.
  * - When mode is 'audit', a policy is derived with the configured mode
  *   and the orchestrator.execute call observes it in ALS.
  */
@@ -28,8 +29,8 @@ describe('orchestrate access-policy opt-in (#2022)', () => {
     resetPolicyCache();
   });
 
-  it('defaults to off mode when env var unset', () => {
-    expect(resolveAccessPolicyMode()).toBe('off');
+  it('defaults to audit mode when env var unset (v2.50+)', () => {
+    expect(resolveAccessPolicyMode()).toBe('audit');
   });
 
   it('derives bypass policy in off mode (no behavior change)', async () => {
@@ -64,13 +65,14 @@ describe('orchestrate access-policy opt-in (#2022)', () => {
   });
 
   it('honors env var override', () => {
-    process.env['NEXUS_ACCESS_POLICY_MODE'] = 'audit';
-    expect(resolveAccessPolicyMode()).toBe('audit');
+    process.env['NEXUS_ACCESS_POLICY_MODE'] = 'off';
+    expect(resolveAccessPolicyMode()).toBe('off');
 
     process.env['NEXUS_ACCESS_POLICY_MODE'] = 'enforce';
     expect(resolveAccessPolicyMode()).toBe('enforce');
 
+    // Invalid values silently fall through to the default (audit).
     process.env['NEXUS_ACCESS_POLICY_MODE'] = 'invalid';
-    expect(resolveAccessPolicyMode()).toBe('off');
+    expect(resolveAccessPolicyMode()).toBe('audit');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-task-state.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-task-state.test.ts
@@ -29,18 +29,28 @@ afterEach(() => {
   delete process.env['NEXUS_TASK_STATE_ENABLED'];
 });
 
-describe('structured-task-state env gate', () => {
-  it('flag is opt-in (unset → disabled)', () => {
+describe('structured-task-state env gate (default-on from v2.50+)', () => {
+  it('flag defaults to enabled when env var unset', () => {
     expect(process.env['NEXUS_TASK_STATE_ENABLED']).toBeUndefined();
+    // Implementation treats unset / empty as enabled.
   });
 
-  it('flag activates only when set to "1"', () => {
-    process.env['NEXUS_TASK_STATE_ENABLED'] = '1';
-    expect(process.env['NEXUS_TASK_STATE_ENABLED']).toBe('1');
-
-    process.env['NEXUS_TASK_STATE_ENABLED'] = 'true';
-    // Implementation checks === '1' strictly; other truthy values don't activate.
-    expect(process.env['NEXUS_TASK_STATE_ENABLED']).not.toBe('1');
+  it('disables only when explicitly set to "0" or "false"', () => {
+    const disableValues = ['0', 'false', 'FALSE'];
+    const enableValues = ['1', 'true', 'yes', ''];
+    for (const val of disableValues) {
+      process.env['NEXUS_TASK_STATE_ENABLED'] = val;
+      // Implementation: raw === '0' || raw.toLowerCase() === 'false' → disabled.
+      const normalized = val.toLowerCase();
+      expect(normalized === '0' || normalized === 'false').toBe(true);
+    }
+    for (const val of enableValues) {
+      process.env['NEXUS_TASK_STATE_ENABLED'] = val;
+      const raw = process.env['NEXUS_TASK_STATE_ENABLED'] ?? '';
+      const normalized = raw.toLowerCase();
+      const disabled = raw === '0' || normalized === 'false';
+      expect(disabled).toBe(false);
+    }
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -72,8 +72,9 @@ import {
   withAccessPolicy,
   resolveAccessPolicyMode,
 } from '../../security/access-constraint-deriver/index.js';
-// Structured task state (#2033, integration from #2043). Opt-in via
-// NEXUS_TASK_STATE_ENABLED=1 — when disabled, helpers no-op silently.
+// Structured task state (#2033, integration from #2043). Enabled by
+// default from v2.50+; set NEXUS_TASK_STATE_ENABLED=0 to opt out.
+// When disabled, helpers no-op silently.
 import { initTaskState, updateStage, appendBlocker } from '../../context/structured-task-state.js';
 import type { StructuredTaskState } from '../../context/structured-task-state-types.js';
 
@@ -628,14 +629,22 @@ async function runOrchestratorWithStateTracking(params: {
 }
 
 /** Opt-in flag for structured-task-state recording (#2033). */
+/**
+ * Structured task-state recording is ON by default as of v2.50+. Set
+ * `NEXUS_TASK_STATE_ENABLED=0` (or `false`) to opt out — any other value
+ * (or unset) leaves it enabled.
+ */
 function isTaskStateEnabled(): boolean {
-  return process.env['NEXUS_TASK_STATE_ENABLED'] === '1';
+  const raw = process.env['NEXUS_TASK_STATE_ENABLED'];
+  if (raw === undefined || raw === '') return true;
+  const normalized = raw.toLowerCase();
+  return normalized !== '0' && normalized !== 'false';
 }
 
 /**
- * Initialize structured state for this orchestration (#2033). No-op
- * when NEXUS_TASK_STATE_ENABLED is unset — zero behavior change by
- * default. Never throws; failures are logged and ignored.
+ * Initialize structured state for this orchestration (#2033). On by
+ * default; set NEXUS_TASK_STATE_ENABLED=0 to opt out. Never throws —
+ * failures are logged and ignored.
  */
 function recordTaskStateInit(taskId: string, taskText: string, logger: ILogger): void {
   if (!isTaskStateEnabled()) return;

--- a/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
@@ -2,26 +2,33 @@
  * Access Constraint Deriver — Configuration (#1977).
  *
  * Reads the NEXUS_ACCESS_POLICY_MODE env var to determine operating mode.
- * Default is `off` during initial rollout; switch to `audit` once the module
- * is wired into the dispatch path with telemetry; switch to `enforce` only
- * after empirical validation per the vote conditions on issue #1977.
+ *
+ * **Default: `audit`** — violations are logged but not blocked. This gives
+ * operators telemetry on policy-relevant tool calls out of the box without
+ * blocking any traffic. Set `NEXUS_ACCESS_POLICY_MODE=off` to opt out of
+ * audit-level logging entirely; set `enforce` to actually block violating
+ * tool calls after the audit telemetry shows acceptable precision.
  *
  * @module security/access-constraint-deriver/config
  */
 
 import { AccessPolicyModeSchema, type AccessPolicyMode } from './types.js';
 
+/** Default mode when the env var is unset. Flipped from `off` → `audit`
+ * in v2.50+ to surface telemetry by default. */
+export const DEFAULT_ACCESS_POLICY_MODE: AccessPolicyMode = 'audit';
+
 /**
  * Resolves the current access-policy mode from the environment.
  *
- * Returns `off` (safe default) if the env var is unset, empty, or invalid.
- * Invalid values are silently coerced — they are never a fatal startup error,
- * because this is a security layer and production must not fail-closed on a
- * misconfiguration.
+ * Returns `DEFAULT_ACCESS_POLICY_MODE` (currently `audit`) if the env var
+ * is unset, empty, or invalid. Invalid values are silently coerced — they
+ * are never a fatal startup error, because this is a security layer and
+ * production must not fail-closed on a misconfiguration.
  */
 export function resolveAccessPolicyMode(env: NodeJS.ProcessEnv = process.env): AccessPolicyMode {
   const raw = env['NEXUS_ACCESS_POLICY_MODE'];
-  if (typeof raw !== 'string' || raw.length === 0) return 'off';
+  if (typeof raw !== 'string' || raw.length === 0) return DEFAULT_ACCESS_POLICY_MODE;
   const parsed = AccessPolicyModeSchema.safeParse(raw.toLowerCase());
-  return parsed.success ? parsed.data : 'off';
+  return parsed.success ? parsed.data : DEFAULT_ACCESS_POLICY_MODE;
 }

--- a/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/deriver.test.ts
@@ -21,12 +21,16 @@ beforeEach(() => {
 });
 
 describe('resolveAccessPolicyMode', () => {
-  it('defaults to "off" when env var is unset', () => {
-    expect(resolveAccessPolicyMode({})).toBe('off');
+  it('defaults to "audit" when env var is unset (v2.50+)', () => {
+    expect(resolveAccessPolicyMode({})).toBe('audit');
   });
 
   it('returns "audit" when env is set to audit', () => {
     expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'audit' })).toBe('audit');
+  });
+
+  it('returns "off" when env is explicitly set to off', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'off' })).toBe('off');
   });
 
   it('returns "enforce" when env is set to enforce', () => {
@@ -37,12 +41,12 @@ describe('resolveAccessPolicyMode', () => {
     expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'AUDIT' })).toBe('audit');
   });
 
-  it('falls back to "off" on invalid values', () => {
-    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'lockdown' })).toBe('off');
+  it('falls back to default (audit) on invalid values', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: 'lockdown' })).toBe('audit');
   });
 
-  it('falls back to "off" on empty string', () => {
-    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: '' })).toBe('off');
+  it('falls back to default (audit) on empty string', () => {
+    expect(resolveAccessPolicyMode({ NEXUS_ACCESS_POLICY_MODE: '' })).toBe('audit');
   });
 });
 
@@ -62,8 +66,11 @@ describe('hashObjective', () => {
 });
 
 describe('deriveAccessPolicy (skeleton)', () => {
-  it('returns a bypass policy with allow-all tools/ops', async () => {
-    const policy = await deriveAccessPolicy('summarize this issue');
+  it('returns a fallback-keyword policy by default (v2.50+ audit mode)', async () => {
+    // Default env is now 'audit', which produces regex-fallback policies
+    // (no adapter available in the test). Explicit mode: 'off' restores
+    // the bypass-policy behavior for tests that need it.
+    const policy = await deriveAccessPolicy('summarize this issue', { mode: 'off' });
     expect(policy.allowedTools).toBe('*');
     expect(policy.allowedOperations).toBe('*');
     expect(policy.source).toBe('bypass');


### PR DESCRIPTION
## Summary

Two previously opt-in features now default to on — user-approved for a v2.x minor release.

## Changes

**ClawGuard: \`off\` → \`audit\` by default**
- \`NEXUS_ACCESS_POLICY_MODE\` default flipped to \`audit\`
- Every orchestrate / execute_expert call now derives an access policy and logs \`access-policy: audit violation\` when tool calls fall outside the derived allowlist
- Nothing is blocked; enforcement still requires explicit \`NEXUS_ACCESS_POLICY_MODE=enforce\`
- Opt back out: \`NEXUS_ACCESS_POLICY_MODE=off\`

**Structured task state: disabled → enabled by default**
- \`NEXUS_TASK_STATE_ENABLED\` default flipped to enabled
- Orchestrations now write a JSONL log per task to \`~/.nexus-agents/tasks/state-{taskId}.jsonl\`
- Read back via the \`query_task_state\` MCP tool
- Opt back out: \`NEXUS_TASK_STATE_ENABLED=0\` (or \`false\`)

## Why now

- ClawGuard has shipped for multiple releases (#1977 → #2021 → #2024 → #2026) with 53+ tests and zero known regressions; audit mode gives telemetry without risk
- Structured task state (#2033 → #2045 → #2048) closes the \"why did my orchestration fail?\" feedback loop — the log file survives session restarts

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 149 orchestrate + 112 ClawGuard tests pass with new defaults
- [x] 16 test cases updated to match new defaults
- [x] CLAUDE.md env-var table reflects new defaults
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)