### PR TITLE
chore: migrate TTL/cache Date.now() sites to getTimeProvider() (#2068)

### DIFF
--- a/packages/nexus-agents/src/config/model-availability.ts
+++ b/packages/nexus-agents/src/config/model-availability.ts
@@ -9,6 +9,7 @@
  * (Source: Issue #869)
  */
 
+import { getTimeProvider } from '../core/index.js';
 import type { ModelId, CliNameLiteral } from './model-capabilities-types.js';
 import { DEFAULT_MODEL_PER_CLI } from './model-capabilities.js';
 
@@ -67,7 +68,7 @@ export class AvailabilityCache {
   get(modelId: ModelId): ProbeResult | undefined {
     const entry = this.cache.get(modelId);
     if (entry === undefined) return undefined;
-    if (Date.now() - entry.checkedAt > this.ttlMs) {
+    if (getTimeProvider().now() - entry.checkedAt > this.ttlMs) {
       this.cache.delete(modelId);
       return undefined;
     }
@@ -91,7 +92,7 @@ export class AvailabilityCache {
       modelId,
       available: false,
       latencyMs: 0,
-      checkedAt: Date.now(),
+      checkedAt: getTimeProvider().now(),
       error,
     });
   }
@@ -102,7 +103,7 @@ export class AvailabilityCache {
       modelId,
       available: true,
       latencyMs,
-      checkedAt: Date.now(),
+      checkedAt: getTimeProvider().now(),
     });
   }
 

--- a/packages/nexus-agents/src/mcp/tools/reflective-retriever.ts
+++ b/packages/nexus-agents/src/mcp/tools/reflective-retriever.ts
@@ -14,7 +14,7 @@
 
 import { z } from 'zod';
 import type { IModelAdapter, ILogger } from '../../core/index.js';
-import { createLogger, getErrorMessage } from '../../core/index.js';
+import { createLogger, getErrorMessage, getTimeProvider } from '../../core/index.js';
 import { withTimeout } from '../../utils/async-utils.js';
 
 // ============================================================================
@@ -81,7 +81,7 @@ export class ReflectionCache {
     const key = this.normalize(query);
     const entry = this.entries.get(key);
     if (entry === undefined) return undefined;
-    if (Date.now() - entry.timestamp > this.ttlMs) {
+    if (getTimeProvider().now() - entry.timestamp > this.ttlMs) {
       this.entries.delete(key);
       return undefined;
     }
@@ -99,7 +99,7 @@ export class ReflectionCache {
       const oldest = this.entries.keys().next();
       if (oldest.done !== true) this.entries.delete(oldest.value);
     }
-    this.entries.set(key, { criteria, timestamp: Date.now() });
+    this.entries.set(key, { criteria, timestamp: getTimeProvider().now() });
   }
 
   get size(): number {

--- a/packages/nexus-agents/src/security/reputation-model.ts
+++ b/packages/nexus-agents/src/security/reputation-model.ts
@@ -11,6 +11,7 @@
 
 import { z } from 'zod';
 
+import { getTimeProvider } from '../core/index.js';
 import type { TrustTier, GitHubUserRole, InjectionFlag } from './trust-types.js';
 import { TRUST_TIER_NUMERIC, ROLE_DEFAULT_TRUST } from './trust-types.js';
 
@@ -109,7 +110,7 @@ export class ReputationCache {
   get(username: string): ReputationAssessment | undefined {
     const entry = this.cache.get(username);
     if (entry === undefined) return undefined;
-    if (Date.now() > entry.expiresAt) {
+    if (getTimeProvider().now() > entry.expiresAt) {
       this.cache.delete(username);
       return undefined;
     }
@@ -122,7 +123,7 @@ export class ReputationCache {
     }
     this.cache.set(username, {
       assessment,
-      expiresAt: Date.now() + this.ttlMs,
+      expiresAt: getTimeProvider().now() + this.ttlMs,
     });
   }
 


### PR DESCRIPTION
## Summary

First targeted sweep of #2068. Three TTL/cache-expiry callsites migrated to \`getTimeProvider().now()\` per #2068's categorization:

- \`security/reputation-model.ts\` — entry.expiresAt check + write
- \`mcp/tools/reflective-retriever.ts\` — TTL check + timestamp record
- \`config/model-availability.ts\` — checkedAt TTL (3 sites)

## What's NOT in this PR

Observation-only sites (duration measurement, audit timestamps, log events) are **deliberately skipped** per your guidance — real wall-clock elapsed time there is the actual telemetry signal, so non-injectability is intentional.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 91 related tests pass (reputation-model, reflective-retriever, model-availability)
- [x] Fitness audit: still 100/100
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)