### PR TITLE
chore: heartbeat + synthesis-history Date.now() → provider (#2068)

### DIFF
--- a/packages/nexus-agents/src/agents/heartbeat-monitor.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.ts
@@ -10,6 +10,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
+import { getTimeProvider } from '../core/index.js';
 
 // ============================================================================
 // Types
@@ -110,7 +111,7 @@ export class HeartbeatMonitor {
   /** Start tracking a new expert session. Returns session ID. */
   startSession(expertId: string): string {
     const sessionId = `hb-${expertId}-${randomBytes(6).toString('hex')}`;
-    const now = Date.now();
+    const now = getTimeProvider().now();
     this.sessions.set(sessionId, {
       expertId,
       startedAt: now,
@@ -125,7 +126,7 @@ export class HeartbeatMonitor {
   heartbeat(sessionId: string): void {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) return;
-    entry.lastHeartbeat = Date.now();
+    entry.lastHeartbeat = getTimeProvider().now();
     entry.heartbeatCount++;
   }
 
@@ -138,7 +139,7 @@ export class HeartbeatMonitor {
   isStalled(sessionId: string): boolean {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) return false;
-    const elapsed = Date.now() - entry.lastHeartbeat;
+    const elapsed = getTimeProvider().now() - entry.lastHeartbeat;
     return elapsed >= this.config.stalledThresholdMs;
   }
 
@@ -146,12 +147,12 @@ export class HeartbeatMonitor {
   isExpired(sessionId: string): boolean {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) return false;
-    return Date.now() - entry.startedAt >= this.config.absoluteMaxMs;
+    return getTimeProvider().now() - entry.startedAt >= this.config.absoluteMaxMs;
   }
 
   /** Get aggregate health report for all active sessions. */
   getHealth(): AgentHealthReport {
-    const now = Date.now();
+    const now = getTimeProvider().now();
     const sessions: ExpertSessionSnapshot[] = [];
     let stalledCount = 0;
 
@@ -187,7 +188,7 @@ export class HeartbeatMonitor {
   getSessionHealth(sessionId: string): HealthTransition | undefined {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) return undefined;
-    const now = Date.now();
+    const now = getTimeProvider().now();
     const timeSince = now - entry.lastHeartbeat;
     const health = this.classifyHealth(timeSince);
     const changed = health !== entry.previousHealth;

--- a/packages/nexus-agents/src/orchestration/aorchestra/synthesis-history.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/synthesis-history.ts
@@ -8,6 +8,8 @@
  * @module orchestration/aorchestra/synthesis-history
  */
 
+import { getTimeProvider } from '../../core/index.js';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -67,13 +69,13 @@ export class SynthesisHistoryTracker {
         tier2Successes: 0,
         tier3Successes: 0,
         consecutiveTier2Failures: 0,
-        lastUpdated: Date.now(),
+        lastUpdated: getTimeProvider().now(),
       };
       this.patterns.set(patternKey, entry);
     }
 
     entry.totalAttempts++;
-    entry.lastUpdated = Date.now();
+    entry.lastUpdated = getTimeProvider().now();
 
     if (tier === 2) {
       if (success) {


### PR DESCRIPTION
## Summary

Continued sweep of #2068. Two more subsystems migrated to \`getTimeProvider().now()\`:

- \`agents/heartbeat-monitor.ts\` — 6 sites. Heartbeat timing (\`Date.now() - lastHeartbeat\`) is windowing; tests benefit from injection
- \`orchestration/aorchestra/synthesis-history.ts\` — 2 sites. \`lastUpdated\` is used for LRU eviction ordering; deterministic time matters for reproducible tests

Together with #2072 (TTL sites), this knocks out most of the high-value injection candidates from #2068. Duration-measurement sites (observation-only) remain untouched per your guidance.

## Test plan

- [x] \`pnpm --filter nexus-agents typecheck\` — clean
- [x] 42 related tests pass
- [x] Fitness audit: still 100/100
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)