### PR TITLE
chore: watchdog + worker-checkpoint Date.now() → provider (#2068)

### DIFF
--- a/packages/nexus-agents/src/orchestration/aorchestra/watchdog.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/watchdog.ts
@@ -12,7 +12,7 @@
  * @module orchestration/aorchestra/watchdog
  */
 
-import { createLogger } from '../../core/index.js';
+import { createLogger, getTimeProvider } from '../../core/index.js';
 
 const logger = createLogger({ component: 'worker-watchdog' });
 
@@ -66,7 +66,7 @@ export async function withWatchdog<T>(
 ): Promise<T> {
   const entry: WatchdogEntry = {
     role,
-    startMs: Date.now(),
+    startMs: getTimeProvider().now(),
     timeoutMs,
     state: 'healthy',
   };
@@ -80,7 +80,7 @@ export async function withWatchdog<T>(
       logger.warn('Worker terminated by watchdog', {
         role,
         timeoutMs,
-        elapsed: Date.now() - entry.startMs,
+        elapsed: getTimeProvider().now() - entry.startMs,
         state: 'terminated',
       });
       reject(new Error(`Worker timeout after ${String(timeoutMs)}ms`));
@@ -89,11 +89,11 @@ export async function withWatchdog<T>(
 
   // Periodic check for warn escalation
   const watchdogTimer = setInterval(() => {
-    const newState = evaluateState(entry, Date.now());
+    const newState = evaluateState(entry, getTimeProvider().now());
     if (newState !== entry.state) {
       entry.state = newState;
       if (newState === 'warned') {
-        const elapsed = Date.now() - entry.startMs;
+        const elapsed = getTimeProvider().now() - entry.startMs;
         logger.warn('Worker approaching timeout', {
           role,
           elapsed,

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-checkpoint.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-checkpoint.ts
@@ -13,6 +13,8 @@
  * @module orchestration/aorchestra/worker-checkpoint
  */
 
+import { getTimeProvider } from '../../core/index.js';
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -51,7 +53,7 @@ export function createCheckpoint(
     subTask,
     partialOutput,
     elapsedMs: 0,
-    timestamp: Date.now(),
+    timestamp: getTimeProvider().now(),
   };
 }
 


### PR DESCRIPTION
## Summary

Fourth sweep of #2068:

- \`orchestration/aorchestra/watchdog.ts\` (4 sites) — Watchdog computes elapsed time for timeout-based state escalation (healthy/warned/terminated). Windowing.
- \`orchestration/aorchestra/worker-checkpoint.ts\` (1 site) — timestamp used for LRU-style eviction ordering.

## Test plan

- [x] typecheck clean
- [x] 24 related tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)