### PR TITLE
feat(swe-bench): createHarnessVerifyAdapter factory + verify threading (#1414)

### DIFF
--- a/.changeset/1414-verify-adapter-factory.md
+++ b/.changeset/1414-verify-adapter-factory.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): add createHarnessVerifyAdapter factory + thread verify into runSingleInstance (#1414)
+
+Builds on #2056 (HarnessVerifyAdapter class) and #2078 (runner
+ClawGuard + task-state wiring) to expose post-patch verification at
+the benchmark-runner layer.
+
+- New `createHarnessVerifyAdapter({ modelName, evalConfig })` factory
+  in `benchmark-runner.ts`. Validates the evaluation harness
+  environment (Docker, disk, CPU) before constructing the adapter;
+  returns `Result.err` if prerequisites aren't met so callers can
+  fall back to running without verify.
+- `SingleInstanceOptions` extended with optional `verifyAdapter` +
+  `maxVerifyRetries` fields that flow into `RunOptions`.
+- `runSingleInstance` threads both into `runAgentOnInstance`.
+- 2 new factory tests: Result shape on environment failure, options
+  type compatibility.
+- 12 existing benchmark-runner tests pass unchanged.
+
+Enables SWE-bench sweeps to opt into the retry loop:
+
+```ts
+const adapterResult = await createHarnessVerifyAdapter({
+  modelName: executor.getModelId(),
+  evalConfig,
+});
+const verifyAdapter = adapterResult.ok ? adapterResult.value : undefined;
+await runSingleInstance({ ...opts, verifyAdapter });
+```

--- a/packages/nexus-agents/src/swe-bench/benchmark-runner-verify.test.ts
+++ b/packages/nexus-agents/src/swe-bench/benchmark-runner-verify.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the verify-adapter factory in benchmark-runner (#1414 runner wiring).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHarnessVerifyAdapter, type CreateVerifyAdapterOptions } from './benchmark-runner.js';
+import type { EvaluationHarnessConfig } from './evaluation-config-types.js';
+
+function makeOpts(): CreateVerifyAdapterOptions {
+  return {
+    modelName: 'test-model',
+    evalConfig: {} as EvaluationHarnessConfig,
+  };
+}
+
+describe('createHarnessVerifyAdapter', () => {
+  it('returns err when Docker/environment is unavailable', async () => {
+    // In most CI environments Docker isn't available for the evaluation
+    // harness. Verify the factory returns a proper Result.err rather
+    // than throwing — callers can fall back to running without verify.
+    const result = await createHarnessVerifyAdapter(makeOpts());
+    // The result shape — ok=true OR ok=false with an AgentRunnerError
+    // message — is what we're asserting.
+    expect(typeof result.ok).toBe('boolean');
+    if (!result.ok) {
+      expect(result.error.message).toContain('Verify adapter unavailable');
+    }
+  });
+
+  it('accepts the CreateVerifyAdapterOptions shape', () => {
+    const opts: CreateVerifyAdapterOptions = {
+      modelName: 'claude-opus',
+      evalConfig: {} as EvaluationHarnessConfig,
+    };
+    // Shape-only test: if the type compiled, this passes.
+    expect(opts.modelName).toBe('claude-opus');
+  });
+});

--- a/packages/nexus-agents/src/swe-bench/benchmark-runner.ts
+++ b/packages/nexus-agents/src/swe-bench/benchmark-runner.ts
@@ -12,7 +12,15 @@
 
 import type { Result } from '../core/result.js';
 import type { SWEBenchConfig, SWEBenchInstance, SWEBenchRunResult } from './types.js';
-import { runAgentOnInstance, type RunOptions, type IAgentExecutor } from './agent-runner.js';
+import {
+  runAgentOnInstance,
+  type RunOptions,
+  type IAgentExecutor,
+  type IVerifyAdapter,
+} from './agent-runner.js';
+import { HarnessVerifyAdapter } from './harness-verify-adapter.js';
+import { createValidatedHarness } from './evaluation-harness.js';
+import type { EvaluationHarnessConfig } from './evaluation-config-types.js';
 import { AgentRunnerError } from './agent-runner.js';
 import { PredictionWriter } from './prediction-writer.js';
 import { createNexusExecutorFromEnv } from './nexus-agent-executor.js';
@@ -64,6 +72,37 @@ export interface ExecutorWithModel extends IAgentExecutor {
 export interface CreateExecutorOptions {
   readonly verbose: boolean;
   readonly mcpEnabled?: boolean;
+}
+
+/** Options for constructing a HarnessVerifyAdapter. */
+export interface CreateVerifyAdapterOptions {
+  readonly modelName: string;
+  readonly evalConfig: EvaluationHarnessConfig;
+}
+
+/**
+ * Construct a HarnessVerifyAdapter for per-instance post-patch
+ * verification. Validates the harness environment first (Docker,
+ * disk, CPU) — returns `err` if prerequisites aren't met so callers
+ * can fall back to running without verify.
+ *
+ * Consumers pass the returned adapter to `runAgentOnInstance` via
+ * `RunOptions.verifyAdapter` to enable the retry loop from #2032.
+ */
+export async function createHarnessVerifyAdapter(
+  opts: CreateVerifyAdapterOptions
+): Promise<Result<IVerifyAdapter, AgentRunnerError>> {
+  const harnessResult = await createValidatedHarness();
+  if (!harnessResult.ok) {
+    return {
+      ok: false,
+      error: new AgentRunnerError(`Verify adapter unavailable: ${harnessResult.error.message}`),
+    };
+  }
+  return {
+    ok: true,
+    value: new HarnessVerifyAdapter(harnessResult.value, opts.modelName, opts.evalConfig),
+  };
 }
 
 /**
@@ -144,14 +183,21 @@ export interface SingleInstanceOptions {
   readonly writer: IBenchmarkWriter;
   readonly verbose: boolean;
   readonly systemPrompt?: string;
+  /**
+   * Optional post-patch verify adapter (#2032). When present, runs the
+   * instance's test suite after each successful patch; on failure,
+   * feeds a retry hint back to the agent for up to `maxVerifyRetries`
+   * iterations. Construct via `createHarnessVerifyAdapter`.
+   */
+  readonly verifyAdapter?: IVerifyAdapter;
+  /** Override max verify retries (default 2). */
+  readonly maxVerifyRetries?: number;
 }
 
-/** Run single instance and handle result. */
-export async function runSingleInstance(
-  opts: SingleInstanceOptions
-): Promise<{ completed: boolean; tokens: number }> {
-  const { instance, executor, config, writer, verbose, systemPrompt } = opts;
-  const runOpts: RunOptions = {
+/** Build RunOptions for runAgentOnInstance from SingleInstanceOptions. */
+function buildRunOptions(opts: SingleInstanceOptions): RunOptions {
+  const { executor, config, verbose, systemPrompt, verifyAdapter, maxVerifyRetries } = opts;
+  return {
     executor,
     config,
     ...(verbose && {
@@ -160,7 +206,17 @@ export async function runSingleInstance(
       },
     }),
     ...(systemPrompt !== undefined && { systemPrompt }),
+    ...(verifyAdapter !== undefined && { verifyAdapter }),
+    ...(maxVerifyRetries !== undefined && { maxVerifyRetries }),
   };
+}
+
+/** Run single instance and handle result. */
+export async function runSingleInstance(
+  opts: SingleInstanceOptions
+): Promise<{ completed: boolean; tokens: number }> {
+  const { instance, writer } = opts;
+  const runOpts = buildRunOptions(opts);
 
   const result = await runAgentOnInstance(instance, runOpts);
 


### PR DESCRIPTION
## Summary

Builds on #2056 (HarnessVerifyAdapter class) and #2078 (runner ClawGuard + task-state wiring) to expose post-patch verification at the benchmark-runner layer.

- \`createHarnessVerifyAdapter({ modelName, evalConfig })\` factory validates the harness env (Docker, disk, CPU) before constructing; returns Result.err on failure so callers gracefully fall back to no-verify
- \`SingleInstanceOptions\` extended with optional verifyAdapter + maxVerifyRetries fields
- \`runSingleInstance\` threads them into \`runAgentOnInstance\` via a new \`buildRunOptions\` helper

Usage:
\`\`\`ts
const adapterResult = await createHarnessVerifyAdapter({
  modelName: executor.getModelId(),
  evalConfig,
});
const verifyAdapter = adapterResult.ok ? adapterResult.value : undefined;
await runSingleInstance({ ...opts, verifyAdapter });
\`\`\`

## Test plan

- [x] typecheck clean
- [x] build clean (ESM + DTS)
- [x] 2 new factory tests pass + 12 existing benchmark-runner tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)