### PR TITLE
feat(swe-bench): pre-flight research lookup for runAgentOnInstance (#1414)

### DIFF
--- a/.changeset/1414-preflight-research.md
+++ b/.changeset/1414-preflight-research.md
@@ -1,0 +1,38 @@
+---
+'nexus-agents': minor
+---
+
+feat(swe-bench): pre-flight research lookup for runAgentOnInstance (#1414 option 3)
+
+Opt-in pre-flight research that appends top-3 relevant papers from
+the in-repo research registry to the system prompt before the first
+iteration runs.
+
+- New module `swe-bench/preflight-research.ts`:
+  - `findRelevantPapers(problemStatement, topN=3)` — scores every
+    paper in `docs/research/registry/papers.yaml` against keywords
+    extracted from the problem statement; returns top-N hits
+  - `extractKeywords(text)` — simple heuristic: alphanumeric tokens
+    ≥ 4 chars, stopwords filtered, deduped, capped at 15
+  - `renderResearchContext(hits)` — compact markdown fragment ready
+    to concatenate to the system prompt
+  - `isPreflightResearchEnabled()` — reads `NEXUS_PREFLIGHT_RESEARCH=1`
+    (default off)
+- Wired into `runAgentOnInstance`: when enabled AND hits found,
+  appends the research context block to the system prompt once before
+  the iteration loop starts. No-op otherwise.
+
+## Zero-cost design
+
+- No LLM calls
+- Registry is bundled with the package (loaded via
+  `loadPapersRegistry()`)
+- Pure in-memory keyword matching
+- Off by default so cost-sensitive runs see no extra prompt size
+
+11 new tests cover keyword extraction, env gate, paper scoring, and
+rendering. 9 existing agent-runner tests pass unchanged.
+
+Closes the last option from my #1414 resume-plan message. Remaining
+work for the epic: Phase 5 PipelineRunner refactor (design call) +
+Verified 500 sweep (#2035 cost-gated).

--- a/packages/nexus-agents/src/swe-bench/agent-runner.ts
+++ b/packages/nexus-agents/src/swe-bench/agent-runner.ts
@@ -20,6 +20,7 @@ import {
 import { initTaskState, updateStage, appendBlocker } from '../context/structured-task-state.js';
 import type { SWEBenchInstance, SWEBenchRunResult, SWEBenchConfig } from './types.js';
 import { buildVerifyOutcome } from './verify-loop.js';
+import { findRelevantPapers, renderResearchContext } from './preflight-research.js';
 import {
   SWE_BENCH_SYSTEM_PROMPT,
   createInstancePrompt,
@@ -315,19 +316,7 @@ export async function runAgentOnInstance(
     finalPatch: undefined,
   };
 
-  const loopOptions: IterationLoopOptions = {
-    config,
-    signal,
-    startTime,
-    onMessage,
-    systemPrompt: options.systemPrompt,
-    iterationContext: createEmptyContext(),
-    verifyAttempts: 0,
-    ...(options.verifyAdapter !== undefined ? { verifyAdapter: options.verifyAdapter } : {}),
-    ...(options.maxVerifyRetries !== undefined
-      ? { maxVerifyRetries: options.maxVerifyRetries }
-      : {}),
-  };
+  const loopOptions = await buildLoopOptions(instance, options, startTime);
 
   // Derive ClawGuard policy + init task state before the iteration loop.
   // Both are no-ops when respective env flags are disabled.
@@ -340,6 +329,37 @@ export async function runAgentOnInstance(
   );
   recordRunnerTaskFinal(taskId, result, runnerLogger);
   return { ok: true, value: result };
+}
+
+/**
+ * Build the iteration-loop options, including pre-flight research
+ * context injection (#1414 option 3). Extracted to keep
+ * runAgentOnInstance under the max-lines cap.
+ */
+async function buildLoopOptions(
+  instance: SWEBenchInstance,
+  options: RunOptions,
+  startTime: number
+): Promise<IterationLoopOptions> {
+  const researchContext = await findRelevantPapers(instance.problem_statement);
+  const systemPrompt =
+    researchContext.length > 0
+      ? `${options.systemPrompt ?? SWE_BENCH_SYSTEM_PROMPT}\n\n${renderResearchContext(researchContext)}`
+      : options.systemPrompt;
+
+  return {
+    config: options.config,
+    signal: options.signal,
+    startTime,
+    onMessage: options.onMessage,
+    systemPrompt,
+    iterationContext: createEmptyContext(),
+    verifyAttempts: 0,
+    ...(options.verifyAdapter !== undefined ? { verifyAdapter: options.verifyAdapter } : {}),
+    ...(options.maxVerifyRetries !== undefined
+      ? { maxVerifyRetries: options.maxVerifyRetries }
+      : {}),
+  };
 }
 
 /**

--- a/packages/nexus-agents/src/swe-bench/preflight-research.test.ts
+++ b/packages/nexus-agents/src/swe-bench/preflight-research.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for pre-flight research lookup (#1414 option 3).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  extractKeywords,
+  findRelevantPapers,
+  isPreflightResearchEnabled,
+  renderResearchContext,
+  type PaperHit,
+} from './preflight-research.js';
+
+beforeEach(() => {
+  delete process.env['NEXUS_PREFLIGHT_RESEARCH'];
+});
+
+afterEach(() => {
+  delete process.env['NEXUS_PREFLIGHT_RESEARCH'];
+});
+
+describe('isPreflightResearchEnabled', () => {
+  it('defaults to false when env var unset', () => {
+    expect(isPreflightResearchEnabled()).toBe(false);
+  });
+
+  it('activates only when set to "1"', () => {
+    process.env['NEXUS_PREFLIGHT_RESEARCH'] = '1';
+    expect(isPreflightResearchEnabled()).toBe(true);
+
+    process.env['NEXUS_PREFLIGHT_RESEARCH'] = 'true';
+    expect(isPreflightResearchEnabled()).toBe(false);
+
+    process.env['NEXUS_PREFLIGHT_RESEARCH'] = '0';
+    expect(isPreflightResearchEnabled()).toBe(false);
+  });
+});
+
+describe('extractKeywords', () => {
+  it('extracts lowercased alphanumeric tokens >= 4 chars', () => {
+    const kw = extractKeywords('Parser NullPointerException when input is empty');
+    expect(kw).toContain('parser');
+    expect(kw).toContain('nullpointerexception');
+    expect(kw).toContain('input');
+    expect(kw).toContain('empty');
+  });
+
+  it('filters out common stopwords', () => {
+    const kw = extractKeywords('The test bug error issue with fix');
+    // All these are stopwords per the built-in set.
+    expect(kw).toHaveLength(0);
+  });
+
+  it('dedupes', () => {
+    const kw = extractKeywords('parser parser parser');
+    expect(kw).toEqual(['parser']);
+  });
+
+  it('caps at 15 keywords', () => {
+    const words = Array.from({ length: 30 }, (_, i) => `word${String(i).padStart(2, '0')}`).join(
+      ' '
+    );
+    const kw = extractKeywords(words);
+    expect(kw.length).toBeLessThanOrEqual(15);
+  });
+
+  it('handles empty and whitespace-only input', () => {
+    expect(extractKeywords('')).toEqual([]);
+    expect(extractKeywords('   \n\t  ')).toEqual([]);
+  });
+});
+
+describe('findRelevantPapers', () => {
+  it('returns empty array when disabled', async () => {
+    // Default: NEXUS_PREFLIGHT_RESEARCH unset.
+    const hits = await findRelevantPapers('parser nullpointerexception');
+    expect(hits).toEqual([]);
+  });
+
+  it('returns papers when enabled and registry has matches', async () => {
+    process.env['NEXUS_PREFLIGHT_RESEARCH'] = '1';
+    // Use keywords likely to match the actual registry bundled in the repo.
+    // "memory" and "agent" are very common in papers.yaml tags.
+    const hits = await findRelevantPapers('Debug agent memory retrieval failure');
+    // We don't assert specific papers (registry changes); just assert
+    // the call succeeds and returns a valid shape.
+    expect(Array.isArray(hits)).toBe(true);
+    for (const hit of hits) {
+      expect(typeof hit.arxivId).toBe('string');
+      expect(typeof hit.title).toBe('string');
+      expect(typeof hit.score).toBe('number');
+      expect(hit.score).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('renderResearchContext', () => {
+  it('returns empty string for empty hits', () => {
+    expect(renderResearchContext([])).toBe('');
+  });
+
+  it('renders hits as a compact markdown block', () => {
+    const hits: PaperHit[] = [
+      {
+        arxivId: 'arxiv-1234.5678',
+        title: 'Test Paper',
+        summary: 'A summary of the paper.',
+        score: 5,
+      },
+    ];
+    const rendered = renderResearchContext(hits);
+    expect(rendered).toContain('## Relevant research');
+    expect(rendered).toContain('Test Paper');
+    expect(rendered).toContain('arxiv-1234.5678');
+    expect(rendered).toContain('A summary of the paper.');
+  });
+});

--- a/packages/nexus-agents/src/swe-bench/preflight-research.ts
+++ b/packages/nexus-agents/src/swe-bench/preflight-research.ts
@@ -1,0 +1,169 @@
+/**
+ * Pre-flight research lookup for SWE-bench instances (#1414 option 3).
+ *
+ * Loads the in-repo research registry (`docs/research/registry/papers.yaml`)
+ * and finds the top-N papers whose summary or tags overlap with keywords
+ * extracted from a SWE-bench instance's problem statement. Returns a
+ * compact prompt fragment ready to splice into the agent's system prompt.
+ *
+ * Zero-cost: no LLM calls. The registry is already bundled with the
+ * package, so this is pure in-memory keyword matching.
+ *
+ * Opt-in via `NEXUS_PREFLIGHT_RESEARCH=1` (default off) so cost-conscious
+ * users never see extra prompt size unless they want it.
+ *
+ * @module swe-bench/preflight-research
+ */
+
+import { loadPapersRegistry } from '../cli/research-helpers-io.js';
+import { createLogger } from '../core/index.js';
+
+const logger = createLogger({ component: 'preflight-research' });
+
+/** Opt-in flag. Default off so prompts stay compact for cost-sensitive runs. */
+export function isPreflightResearchEnabled(): boolean {
+  return process.env['NEXUS_PREFLIGHT_RESEARCH'] === '1';
+}
+
+/**
+ * Extract candidate search keywords from a problem statement. Simple
+ * heuristic: lowercase, strip punctuation, take words >= 4 chars that
+ * aren't stopwords. Dedupe. Cap at 15 keywords.
+ */
+const KEYWORD_STOPWORDS: ReadonlySet<string> = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'that',
+  'this',
+  'from',
+  'have',
+  'when',
+  'where',
+  'which',
+  'will',
+  'should',
+  'would',
+  'could',
+  'what',
+  'whose',
+  'their',
+  'then',
+  'than',
+  'them',
+  'there',
+  'here',
+  'been',
+  'being',
+  'does',
+  'doesn',
+  'isn',
+  'into',
+  'more',
+  'some',
+  'also',
+  'such',
+  'only',
+  'over',
+  'like',
+  'between',
+  'error',
+  'issue',
+  'problem',
+  'bug',
+  'fix',
+  'test',
+]);
+
+export function extractKeywords(problemStatement: string): readonly string[] {
+  const words = problemStatement
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .split(/\s+/)
+    .filter((w) => w.length >= 4 && !KEYWORD_STOPWORDS.has(w));
+  return Array.from(new Set(words)).slice(0, 15);
+}
+
+/** A ranked paper hit. */
+export interface PaperHit {
+  readonly arxivId: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly score: number;
+}
+
+/**
+ * Score a single paper against a set of keywords. Summary matches weight
+ * 1, tag matches weight 2 (tags are curated, more signal per match).
+ */
+function scorePaper(
+  paper: { summary?: string; tags?: readonly string[] },
+  keywords: readonly string[]
+): number {
+  const summary = (paper.summary ?? '').toLowerCase();
+  const tags = (paper.tags ?? []).map((t) => t.toLowerCase());
+  let score = 0;
+  for (const kw of keywords) {
+    if (summary.includes(kw)) score += 1;
+    for (const tag of tags) {
+      if (tag.includes(kw)) score += 2;
+    }
+  }
+  return score;
+}
+
+/**
+ * Find top-N papers most relevant to the problem statement's keywords.
+ * Returns empty array when disabled, registry unavailable, or no
+ * matches cross the minimum score threshold.
+ */
+export async function findRelevantPapers(
+  problemStatement: string,
+  topN = 3
+): Promise<readonly PaperHit[]> {
+  if (!isPreflightResearchEnabled()) return [];
+  try {
+    const registryResult = await loadPapersRegistry();
+    if (!registryResult.ok) {
+      logger.debug('preflight-research: registry unavailable', {
+        error: registryResult.error.message,
+      });
+      return [];
+    }
+    const registry = registryResult.value;
+    const keywords = extractKeywords(problemStatement);
+    if (keywords.length === 0) return [];
+    const hits: PaperHit[] = [];
+    for (const [arxivId, paper] of Object.entries(registry.papers)) {
+      const score = scorePaper(paper, keywords);
+      if (score > 0) {
+        hits.push({
+          arxivId,
+          title: paper.title,
+          summary: paper.summary.slice(0, 200),
+          score,
+        });
+      }
+    }
+    return hits.sort((a, b) => b.score - a.score).slice(0, topN);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.warn('preflight-research: lookup failed, skipping', { error: msg });
+    return [];
+  }
+}
+
+/**
+ * Render paper hits as a compact prompt fragment. Returns empty string
+ * when the hits array is empty so the caller can naively concatenate.
+ */
+export function renderResearchContext(hits: readonly PaperHit[]): string {
+  if (hits.length === 0) return '';
+  const lines = ['## Relevant research (pre-flight)', ''];
+  for (const hit of hits) {
+    lines.push(`- **${hit.title}** (${hit.arxivId}): ${hit.summary}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Opt-in pre-flight research that appends top-3 relevant papers from the in-repo research registry to the system prompt before the first iteration runs. **Zero-cost**: no LLM calls, pure in-memory keyword matching on the bundled \`papers.yaml\` registry.

## Changes

- **New module** \`swe-bench/preflight-research.ts\`:
  - \`findRelevantPapers(problemStatement, topN=3)\` scores every paper against extracted keywords (summary weight 1, tag weight 2)
  - \`extractKeywords(text)\` — alphanumeric tokens ≥ 4 chars, stopwords filtered, deduped, capped at 15
  - \`renderResearchContext(hits)\` produces a compact markdown block
  - \`isPreflightResearchEnabled()\` reads \`NEXUS_PREFLIGHT_RESEARCH=1\` (default off)
- **Wired into \`runAgentOnInstance\`** via new \`buildLoopOptions\` helper: when enabled AND hits found, appends the block to the system prompt once before iteration loop
- **buildLoopOptions** extraction keeps \`runAgentOnInstance\` under the max-lines cap

## Default off

The env flag defaults to off, so cost-sensitive runs see zero change to prompt size. Operators opt in by setting \`NEXUS_PREFLIGHT_RESEARCH=1\`.

## Test plan

- [x] typecheck clean
- [x] 11 new tests (env gate, keyword extraction, paper scoring, rendering)
- [x] 9 existing agent-runner tests pass unchanged
- [ ] CI green

## #1414 status after this PR

- ✅ ClawGuard + task state wiring (#2078)
- ✅ Verify adapter factory + threading (#2080)
- ✅ Pre-flight research hook (this PR)
- ⏳ Phase 5 PipelineRunner refactor (design decision needed)
- ⏳ Actual Verified 500 sweep (#2035 — cost-gated)

Three of five #1414 remaining items landed. Only two left, both blocked on human decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)