### PR TITLE
chore: resilient-adapter + composite-router Date.now migrations (#2068)

### DIFF
--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -23,6 +23,7 @@ import type { Result } from '../core/result.js';
 import { ok, err } from '../core/result.js';
 import { ModelError, ConfigError } from '../core/errors.js';
 import type { ILogger } from '../core/index.js';
+import { getTimeProvider, getRandomProvider } from '../core/index.js';
 import { getErrorMessage, createLogger } from '../core/index.js';
 
 import { createAutoAdapter, type AdapterSelection } from './auto-adapter.js';
@@ -113,7 +114,7 @@ export class ResilientAdapter implements IResilientAdapter {
       const rlError = toRateLimitError(result.error, adapter.providerId);
       recordRateLimitEvent({
         provider: adapter.providerId,
-        timestamp: Date.now(),
+        timestamp: getTimeProvider().now(),
         retryAfterMs: rlError.retryAfterMs,
       });
       this.logger.warn('Rate limit detected', {
@@ -304,7 +305,7 @@ export class ResilientAdapter implements IResilientAdapter {
     try {
       const eventBus = getGlobalEventBus();
       eventBus.emit({
-        eventId: `failover-${Date.now().toString(36)}`,
+        eventId: `failover-${getTimeProvider().now().toString(36)}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
         timestamp: new Date().toISOString(),
         topic: 'adapter.failover',
         payload: info,

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -328,7 +328,7 @@ export class CompositeRouter implements ICompositeRouter {
         // Use 30-day lookback — stale all-time data was overriding
         // specialization matrix changes (e.g., architecture claude→gemini) (#1667)
         const WARM_START_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
-        const since = new Date(Date.now() - WARM_START_LOOKBACK_MS).toISOString();
+        const since = new Date(getTimeProvider().now() - WARM_START_LOOKBACK_MS).toISOString();
         const outcomes = getOutcomeStore().query({
           since,
           excludeQualitySignals: ['e2e-eval'],


### PR DESCRIPTION
## Summary

Fifth sweep of #2068:

- \`adapters/resilient-adapter.ts\` (2 sites): rate-limit event timestamp (feeds backoff window calculations) + failover event ID generator
- \`cli-adapters/composite-router.ts\` (1 site): LinUCB warm-start lookback window

## Test plan

- [x] typecheck clean
- [x] 29 adapters tests pass unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)