### PR TITLE
chore(deps): bump production-dependencies group (supersedes #2089)

### DIFF
--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -63,10 +63,10 @@
     "prepublishOnly": "pnpm run build"
   },
   "optionalDependencies": {
-    "@atproto/api": "^0.19.8"
+    "@atproto/api": "^0.19.9"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.88.0",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@google/genai": "^1.50.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
@@ -90,7 +90,7 @@
     "ai": "^6.0.168",
     "fast-check": "^4.7.0",
     "tsup": "^8.5.1",
-    "typedoc": "0.28.18",
+    "typedoc": "0.28.19",
     "vitest": "4.1.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
   packages/nexus-agents:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.88.0
-        version: 0.88.0(zod@4.3.6)
+        specifier: ^0.90.0
+        version: 0.90.0(zod@4.3.6)
       '@google/genai':
         specifier: ^1.50.1
         version: 1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
@@ -133,8 +133,8 @@ importers:
         version: 4.3.6
     optionalDependencies:
       '@atproto/api':
-        specifier: ^0.19.8
-        version: 0.19.8
+        specifier: ^0.19.9
+        version: 0.19.9
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
@@ -164,8 +164,8 @@ importers:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(typescript@6.0.3)(yaml@2.8.3)
       typedoc:
-        specifier: 0.28.18
-        version: 0.28.18(typescript@6.0.3)
+        specifier: 0.28.19
+        version: 0.28.19(typescript@6.0.3)
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
@@ -253,10 +253,10 @@ packages:
         integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==,
       }
 
-  '@anthropic-ai/sdk@0.88.0':
+  '@anthropic-ai/sdk@0.90.0':
     resolution:
       {
-        integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==,
+        integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==,
       }
     hasBin: true
     peerDependencies:
@@ -350,16 +350,16 @@ packages:
         integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==,
       }
 
-  '@atproto/api@0.19.8':
+  '@atproto/api@0.19.9':
     resolution:
       {
-        integrity: sha512-b79kuI3AzEmpLLi9afRNq6T0KFEEVL4d+vHFAtWxeDwS7lfwUOIIngMjAVvwmwC5nJRZIrK8L9d4y7LD8zdvsg==,
+        integrity: sha512-+sUYNuiA1Rv8HemMCURHwRkMp2D7cq6nNquefjosu6UB54IzkD0MLK3YY383poLRShiApouOxRse2OKK25dbQw==,
       }
 
-  '@atproto/common-web@0.4.20':
+  '@atproto/common-web@0.4.21':
     resolution:
       {
-        integrity: sha512-RcsYT28yQgVi/Glb/hHPGpqpzIlKrbMLeldEd7PmmMLWDaJL2j3lb92qytvxjl1yhi2Ssq2TEuMZ2NlWaAbpow==,
+        integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==,
       }
 
   '@atproto/lex-data@0.0.15':
@@ -368,10 +368,10 @@ packages:
         integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==,
       }
 
-  '@atproto/lex-json@0.0.15':
+  '@atproto/lex-json@0.0.16':
     resolution:
       {
-        integrity: sha512-kCLdP629H6GhgPjBTpZibUoqlpmW0hnVfZVwcD4s4Jch1KAqY/QcfL24Ih8wrW0Ok1YvtMIhjk98evdTA2OJcw==,
+        integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==,
       }
 
   '@atproto/lexicon@0.6.2':
@@ -380,10 +380,10 @@ packages:
         integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==,
       }
 
-  '@atproto/syntax@0.5.3':
+  '@atproto/syntax@0.5.4':
     resolution:
       {
-        integrity: sha512-gzhlHOJHm5KXdCc17fXi1fXM81ccs5jJfNgCui84ay9JGvczxegpYHNqdMlv+iBuhtBzFIjgx6ChjRxN/kO8kQ==,
+        integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==,
       }
 
   '@atproto/xrpc@0.7.7':
@@ -8608,10 +8608,10 @@ packages:
       }
     engines: { node: '>= 0.6' }
 
-  typedoc@0.28.18:
+  typedoc@0.28.19:
     resolution:
       {
-        integrity: sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==,
+        integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==,
       }
     engines: { node: '>= 18', pnpm: '>= 10' }
     hasBin: true
@@ -9405,7 +9405,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@anthropic-ai/sdk@0.88.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -9527,11 +9527,11 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
-  '@atproto/api@0.19.8':
+  '@atproto/api@0.19.9':
     dependencies:
-      '@atproto/common-web': 0.4.20
+      '@atproto/common-web': 0.4.21
       '@atproto/lexicon': 0.6.2
-      '@atproto/syntax': 0.5.3
+      '@atproto/syntax': 0.5.4
       '@atproto/xrpc': 0.7.7
       await-lock: 2.2.2
       multiformats: 9.9.0
@@ -9539,11 +9539,11 @@ snapshots:
       zod: 3.25.76
     optional: true
 
-  '@atproto/common-web@0.4.20':
+  '@atproto/common-web@0.4.21':
     dependencies:
       '@atproto/lex-data': 0.0.15
-      '@atproto/lex-json': 0.0.15
-      '@atproto/syntax': 0.5.3
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
       zod: 3.25.76
     optional: true
 
@@ -9555,7 +9555,7 @@ snapshots:
       unicode-segmenter: 0.14.5
     optional: true
 
-  '@atproto/lex-json@0.0.15':
+  '@atproto/lex-json@0.0.16':
     dependencies:
       '@atproto/lex-data': 0.0.15
       tslib: 2.8.1
@@ -9563,14 +9563,14 @@ snapshots:
 
   '@atproto/lexicon@0.6.2':
     dependencies:
-      '@atproto/common-web': 0.4.20
-      '@atproto/syntax': 0.5.3
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
       zod: 3.25.76
     optional: true
 
-  '@atproto/syntax@0.5.3':
+  '@atproto/syntax@0.5.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -14795,12 +14795,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typedoc@0.28.18(typescript@6.0.3):
+  typedoc@0.28.19(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       typescript: 6.0.3
       yaml: 2.8.3
 


### PR DESCRIPTION
## Summary

Supersedes #2089 which had a `pnpm-lock.yaml` conflict with `main` after the website UX-pass (PR #2083) added `mermaid`.

Re-applied the original dependency bumps from dependabot's package.json, then regenerated the lockfile cleanly on top of current main.

### Updates

- `@anthropic-ai/sdk` 0.88.0 → 0.90.0 — adds claude-opus-4-7 model support, token budgets, user_profiles; deprecates Sonnet/Opus 4
- `typedoc` 0.28.18 → 0.28.19
- `@atproto/api` 0.19.8 → 0.19.9 (optional dep)

## Test plan

- [x] `pnpm install` completes cleanly
- [ ] CI passes
- [ ] Close #2089 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)