### PR TITLE
docs(packaging): refresh server.json + README marketplace pointer + fix tool-count drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ nexus-agents makes your AI coding tools work together intelligently. It coordina
 - **Enforces quality** — consensus voting (6 strategies including Bayesian higher-order), QA review loops, security scans with SARIF
 - **Learns over time** — 5 memory backends (session, belief, agentic, adaptive, typed) track what works, feeding routing, planning, and research decisions
 - **Runs a full dev pipeline** — research papers, plan architecture, vote on proposals, decompose into tasks, implement, QA review, ship
-- **Connects everything** — 30 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
+- **Connects everything** — 31 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
 
 ```
 You: "Review this code for security and performance"
@@ -50,7 +50,7 @@ Consensus-validated response — outcomes feed back into routing for next time
                          │       nexus-agents server        │
                          │                                  │
                          │  ┌──────────┐  ┌──────────────┐ │
-                         │  │ 30 MCP   │  │ Dev Pipeline  │ │
+                         │  │ 31 MCP   │  │ Dev Pipeline  │ │
                          │  │ Tools    │  │ research→plan │ │
                          │  └────┬─────┘  │ →vote→impl   │ │
                          │       │        │ →QA→ship      │ │
@@ -78,6 +78,14 @@ Consensus-validated response — outcomes feed back into routing for next time
 ```bash
 npm install -g nexus-agents
 ```
+
+**Or as a Claude Code plugin** (single-command install from the official marketplace):
+
+```
+/plugin install nexus-agents
+```
+
+See [docs/getting-started/PLUGIN_INSTALL.md](docs/getting-started/PLUGIN_INSTALL.md) for plugin-specific setup, or [llms-install.md](llms-install.md) for the short install guide an AI agent can follow.
 
 ### 2. Verify
 

--- a/packages/nexus-agents/server.json
+++ b/packages/nexus-agents/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.williamzujkowski/nexus-agents",
-  "description": "Intelligent orchestration platform for AI coding tools. Routes tasks to the best model (Claude, Codex, Gemini, OpenCode) using data-driven algorithms (LinUCB, TOPSIS), enforces quality through multi-model consensus voting, and learns from outcomes across sessions. 30 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.",
+  "description": "Intelligent orchestration platform for AI coding tools. Routes tasks to the best model (Claude, Codex, Gemini, OpenCode) using data-driven algorithms (LinUCB, TOPSIS), enforces quality through multi-model consensus voting, and learns from outcomes across sessions. 31 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.",
   "repository": {
     "url": "https://github.com/williamzujkowski/nexus-agents",
     "source": "github"
   },
-  "version": "2.29.0",
+  "version": "2.53.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "nexus-agents",
-      "version": "2.29.0",
+      "version": "2.53.0",
       "runtime": "node",
       "runtimeArguments": ["--experimental-vm-modules"],
       "packageArguments": ["--mode=server"],
@@ -75,6 +75,7 @@
     "search_codebase",
     "extract_symbols",
     "query_trace",
+    "query_task_state",
     "run_dev_pipeline",
     "run_pipeline"
   ]

--- a/website/src/data/site-data.ts
+++ b/website/src/data/site-data.ts
@@ -10,7 +10,7 @@
  */
 
 /** MCP tools registered in src/mcp/tools/index.ts registerTools() */
-export const MCP_TOOL_COUNT = 29;
+export const MCP_TOOL_COUNT = 31;
 
 /**
  * Built-in expert types in src/agents/experts/expert-config.ts BUILT_IN_EXPERTS.


### PR DESCRIPTION
## Summary

Closes the last autonomous gaps in the packaging work for #1839 (Claude Code Plugin Marketplace) + #1726 (MCP Registry + awesome lists).

## Changes

### `packages/nexus-agents/server.json` — MCP Registry manifest refresh

This is the artifact the Official MCP Registry's `mcp-publisher` CLI reads. Was stale:

- `version` bumped **2.29.0 → 2.53.0** (matches `package.json`)
- `packages[0].version` bumped same
- Added missing **`query_task_state`** to the `tools` array — landed in #2048 as part of the structured task-state work but never backfilled into the manifest
- Description count corrected **30 → 31 MCP tools**
- Total tools: 31, which matches source-of-truth (`src/mcp/tools/index.ts registerTools()` array)

### `README.md` — marketplace pointer + count drift

- **Quick Start now has a marketplace install snippet** (`/plugin install nexus-agents`) with links to `docs/getting-started/PLUGIN_INSTALL.md` and `llms-install.md`. Satisfies the "README has clear install-via-marketplace instructions" item on #1839's pre-submission checklist
- `30 MCP tools` → `31 MCP tools` in both the Why-Nexus-Agents bullet list and the ASCII architecture diagram

### `website/src/data/site-data.ts` — canonical count corrected

- `MCP_TOOL_COUNT` 29 → 31. Comment on that line already said the source-of-truth is `src/mcp/tools/index.ts registerTools()`; the value had drifted

## Verification

Tool count cross-check after this PR:
- source array: 31
- CLAUDE.md auto-gen ("31 tools registered"): 31
- `server.json` tools array: 31
- `MCP_TOOL_COUNT`: 31

All four now agree.

## Out of scope / follow-up

- Other numeric counts (`PAPER_COUNT`, `CONSENSUS_ALGORITHM_COUNT`, `ROUTING_STAGE_COUNT`, etc.) have no automated drift guard. Same class of bug could surface elsewhere. Filing a follow-up issue to evaluate whether a CI check should cross-compare these constants with their documented source-of-truth.
- `nexus-agents@2.53.0` tag exists on HEAD's ancestor; the 2026-04-19 comment on #1839 claiming the tag was behind is itself outdated — will correct in the closing comments
- Several submissions in #1839 and #1726 are complete per the issue comment history; those issues can be closed once this lands (will do in a follow-up comment to each)

## Test plan

- [x] \`server.json\` parses as valid JSON
- [x] Tool lists in server.json and source agree (diff shows no entries unique to either)
- [x] README markdown renders (local preview)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)