### PR TITLE
fix(consensus-vote): clamp overall deadline to MCP wrapper timeout

### DIFF
--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -69,7 +69,7 @@ import {
   createSimulatedVotes,
   executeWithRetries,
 } from './voter-execution.js';
-import { resolveVoteTimeout, VOTE_TIMEOUTS } from '../config/timeouts.js';
+import { resolveVoteTimeout, VOTE_TIMEOUTS, getMcpSafeDeadlineMs } from '../config/timeouts.js';
 import { launchVotesWithOverallDeadline } from './voter-agents-deadline.js';
 
 /**
@@ -305,12 +305,26 @@ async function launchStaggeredVotes(
   input: StaggeredVoteInput
 ): Promise<readonly AgentVoteResult[]> {
   const { roles, proposal, roleAdapters, fallbackAdapter, logger, voteOptions, interDelay } = input;
-  const overallDeadlineMs = computeOverallConsensusDeadlineMs(
+  // Raw "worst legitimate completion" estimate — retained unchanged so the
+  // formula still answers "how long could this vote take in principle?".
+  const computedDeadlineMs = computeOverallConsensusDeadlineMs(
     voteOptions.timeoutMs,
     voteOptions.maxRetries,
     roles.length,
     interDelay
   );
+  // Clamp below the outer MCP tool-wrapper timeout. Without this, the
+  // middleware kills the promise chain before launchVotesWithOverallDeadline
+  // can produce structured partial results — clients see a naked timeout
+  // error instead of a `source: 'error' / error: 'overall consensus deadline
+  // exceeded'` vote per stuck role. (Issue #2105)
+  const overallDeadlineMs = getMcpSafeDeadlineMs(computedDeadlineMs, 'consensus_vote');
+  if (overallDeadlineMs < computedDeadlineMs) {
+    logger.debug('Consensus deadline clamped to MCP wrapper timeout', {
+      computedDeadlineMs,
+      overallDeadlineMs,
+    });
+  }
   return launchVotesWithOverallDeadline({
     roles,
     proposal,

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -28,6 +28,7 @@ import {
   resolveWorkerTimeout,
   getCliTimeout,
   getExpertTaskTimeout,
+  getMcpSafeDeadlineMs,
   resolveVoteTimeout,
   resolveEnvTimeout,
   validateTimeout,
@@ -88,6 +89,59 @@ describe('Centralized Timeout Configuration', () => {
       expect(MCP_TIMEOUTS.perTool['consensus_vote']).toBe(600_000);
       expect(MCP_TIMEOUTS.perTool['execute_expert']).toBe(900_000);
       expect(MCP_TIMEOUTS.perTool['run_workflow']).toBe(900_000);
+    });
+
+    it('exposes a safety buffer for internal deadlines', () => {
+      expect(MCP_TIMEOUTS.perToolSafetyBufferMs).toBeGreaterThan(0);
+      // Must be much smaller than the smallest per-tool cap so clamping
+      // never swallows the whole timeout.
+      const smallestPerTool = Math.min(...Object.values(MCP_TIMEOUTS.perTool));
+      expect(MCP_TIMEOUTS.perToolSafetyBufferMs).toBeLessThan(smallestPerTool / 10);
+    });
+  });
+
+  describe('getMcpSafeDeadlineMs()', () => {
+    it('clamps a computed deadline larger than the MCP wrapper minus buffer', () => {
+      // consensus_vote cap is 600_000; buffer is 10_000 → safe cap 590_000.
+      // computed 970_000 (the pre-fix default) → clamped to 590_000.
+      const computed = 970_000;
+      const result = getMcpSafeDeadlineMs(computed, 'consensus_vote');
+      expect(result).toBe(
+        MCP_TIMEOUTS.perTool['consensus_vote']! - MCP_TIMEOUTS.perToolSafetyBufferMs
+      );
+      expect(result).toBeLessThan(MCP_TIMEOUTS.perTool['consensus_vote']!);
+    });
+
+    it('leaves a computed deadline smaller than the safe cap unchanged', () => {
+      // A fast call with a short computed deadline must not be inflated.
+      const computed = 120_000; // 2 min
+      expect(getMcpSafeDeadlineMs(computed, 'consensus_vote')).toBe(120_000);
+    });
+
+    it('falls back to the default MCP timeout for unknown tool names', () => {
+      // Unknown tool: safe cap = defaultMs (60_000) - buffer (10_000) = 50_000.
+      const computed = 900_000;
+      expect(getMcpSafeDeadlineMs(computed, 'not_a_real_tool')).toBe(50_000);
+    });
+
+    it('floors the return value so tools remain minimally useful', () => {
+      // If a future change set perTool.x to a tiny value, we never return
+      // less than defaultMs / 2 (= 30_000) — the tool is still callable.
+      // We can't mutate the frozen record, so we simulate via the unknown-
+      // tool path with a computed deadline much smaller than the safe cap.
+      const tiny = 1;
+      const out = getMcpSafeDeadlineMs(tiny, 'consensus_vote');
+      // min(tiny, safeCap) = 1 → floored to 30_000
+      expect(out).toBe(Math.floor(MCP_TIMEOUTS.defaultMs / 2));
+    });
+
+    it('the clamped consensus_vote deadline always fires before the MCP wrapper', () => {
+      // Guard the core invariant: no matter what the caller computes, the
+      // clamped deadline is strictly less than the MCP per-tool timeout.
+      for (const computed of [100, 600_000, 970_000, 1_800_000]) {
+        const out = getMcpSafeDeadlineMs(computed, 'consensus_vote');
+        expect(out).toBeLessThan(MCP_TIMEOUTS.perTool['consensus_vote']!);
+      }
     });
   });
 

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -79,6 +79,17 @@ export const MCP_TIMEOUTS = {
   defaultMs: 60_000,
   /** Maximum allowed MCP tool timeout. */
   maxMs: 900_000,
+  /**
+   * Safety buffer between an internal wall-clock deadline (e.g. the consensus
+   * overall deadline) and when the outer `wrapToolWithTimeout` middleware
+   * would fire. Tools that race their own partial-result deadline MUST clamp
+   * that deadline to `perTool[toolName] - perToolSafetyBufferMs` so the
+   * internal timeout always fires first; otherwise the middleware kills the
+   * promise chain before the tool can serialise its partial response and the
+   * client sees a naked `Operation '<tool>' timed out after Nms` error.
+   * (Source: Issue #2104 — MCP wrapper aborts before internal deadline)
+   */
+  perToolSafetyBufferMs: 10_000,
   /** Per-tool timeout overrides for long-running tools. */
   perTool: {
     orchestrate: 900_000, // 15 min — multi-step agent orchestration
@@ -87,6 +98,31 @@ export const MCP_TIMEOUTS = {
     run_workflow: 900_000, // 15 min — multi-step workflow execution
   } as Readonly<Record<string, number>>,
 } as const;
+
+/**
+ * Clamps a computed internal wall-clock deadline so it always fires before
+ * the outer MCP tool-wrapper timeout. Returns the smaller of:
+ *   - the caller's computed deadline,
+ *   - `perTool[toolName] - perToolSafetyBufferMs`.
+ *
+ * Floored at `defaultMs / 2` so the tool remains minimally useful even if a
+ * future change lowers the MCP cap far below what the tool's formula expects.
+ *
+ * @param computedMs - The tool's own wall-clock deadline (e.g. sum of per-vote
+ *                     budgets plus stagger + response buffer).
+ * @param toolName - Key into `MCP_TIMEOUTS.perTool`; falls back to `defaultMs`
+ *                   for unknown tools.
+ * @returns Clamped deadline in milliseconds.
+ * (Source: Issue #2105 — consensus_vote overallDeadlineMs > MCP wrapper)
+ */
+export function getMcpSafeDeadlineMs(computedMs: number, toolName: string): number {
+  const perToolCap = MCP_TIMEOUTS.perTool[toolName] ?? MCP_TIMEOUTS.defaultMs;
+  const safeCap = perToolCap - MCP_TIMEOUTS.perToolSafetyBufferMs;
+  const floor = Math.floor(MCP_TIMEOUTS.defaultMs / 2);
+  // Never return less than the floor (keeps tools usable under tight caps).
+  const capped = Math.min(computedMs, safeCap);
+  return Math.max(capped, floor);
+}
 
 /**
  * Workflow execution timeouts.


### PR DESCRIPTION
Closes #2105. Part of epic #2104.

## The bug

\`consensus_vote\`'s \`computeOverallConsensusDeadlineMs\` produces wall-clock deadlines of ~16 minutes (\`VOTE_TIMEOUTS.defaultMs * (maxRetries+1) + stagger + 60s buffer = 964_000–970_000\`ms), while the outer \`wrapToolWithTimeout\` middleware aborts \`consensus_vote\` at 10 minutes (\`MCP_TIMEOUTS.perTool.consensus_vote = 600_000\`).

On any slow run — e.g. one CLI adapter hanging through an IPC wait — the MCP wrapper fires first and kills the promise chain before \`launchVotesWithOverallDeadline\` (the "always return partial results" path from #1871) gets a chance to synthesize an error vote for the stuck role. The client sees:

\`\`\`
{"error":"Operation 'consensus_vote' timed out after 600000ms (request: req_…)"}
\`\`\`

instead of a structured \`ConsensusResult\` with the stuck role surfaced as \`source: 'error' / error: 'overall consensus deadline exceeded'\`. The #1871 partial-results guarantee is silently defeated.

## The fix

1. **\`config/timeouts.ts\`** — add \`MCP_TIMEOUTS.perToolSafetyBufferMs\` (10_000) and a pure helper:
   \`\`\`ts
   function getMcpSafeDeadlineMs(computedMs: number, toolName: string): number
   \`\`\`
   that clamps to \`perTool[toolName] - safetyBuffer\`, floored at \`defaultMs / 2\` so the tool remains minimally useful if a future change lowers the MCP cap.
2. **\`cli/voter-agents.ts::launchStaggeredVotes\`** — pipe \`computeOverallConsensusDeadlineMs\` output through \`getMcpSafeDeadlineMs(..., 'consensus_vote')\`. The internal wall-clock deadline now *always* fires before the MCP wrapper.

## Impact (concrete)

| Mode | Roles | Internal deadline (before) | Internal deadline (after) | MCP wrapper |
| --- | --- | --- | --- | --- |
| quickMode=true | 3 | 964_000 ms | **590_000 ms** | 600_000 ms |
| quickMode=false | 6 | 970_000 ms | **590_000 ms** | 600_000 ms |

With the clamp, the deadline-launcher (tested extensively in \`voter-agents-deadline.test.ts\` for #1871) always gets 10 seconds of headroom to return partial results before the MCP wrapper would fire.

## Tests

- 5 new cases in \`timeouts.test.ts\` covering:
  - clamp above the cap (970_000 → 590_000)
  - pass-through below the cap (120_000 → 120_000)
  - unknown-tool fallback (uses \`defaultMs\`)
  - floor (tiny computed → \`defaultMs/2\`)
  - **invariant**: clamped deadline \`< MCP_TIMEOUTS.perTool.consensus_vote\` for any input
- Existing \`voter-agents-deadline.test.ts\` (3 tests for #1871) still green — the deadline-launcher contract didn't change, it now just gets an input that respects the MCP wrapper.
- **61 / 61** tests green (\`timeouts.test.ts\` + \`voter-agents-deadline.test.ts\`); typecheck clean; eslint clean.

## Non-goals

- No change to \`computeOverallConsensusDeadlineMs\` itself — it still answers "how long could this vote take in the worst legitimate case?".
- No retune of default per-vote timeouts (\`VOTE_TIMEOUTS.defaultMs = 300_000\`, \`maxRetries = 2\`) — those are load-tested against real CLI turns.
- \`orchestrate\` has the same structural issue (no deadline-launcher layer at all) — separate PR under epic #2104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)