### PR TITLE
docs(claude): add Autonomous Operation Rules section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,56 @@ If the ask is ambiguous (could be trivial or could be structural), lean toward *
 
 ---
 
+## Autonomous Operation Rules
+
+When the user gives a standing directive like "run autonomously", "keep working", "work on the backlog", "multi-day OK", or invokes `/loop`, these rules apply. They override the default "pause at clean handoff points to check in" behavior.
+
+### Never pause to ask "what's next" while the backlog is non-empty
+
+Finishing a task is not a stop condition. A clean commit, a merged PR, a closed issue — none of those end the session. Pick the next item from the backlog and keep going. If you catch yourself about to write "ready to pick up the next cycle or pause here" or "your call on priority" while there are open issues or actionable alerts, that's the failure mode. Proceed instead.
+
+### Order of consideration (work the backlog top-down)
+
+1. **CI red or security alerts** — failing workflows on main, CodeQL criticals, Scorecard regressions, dependabot advisories
+2. **Open epics** — pick one with an open child; if all children are gated, check if the epic itself can close
+3. **Open bugs labeled `bug` or with a clear RCA comment** — highest-leverage fixes
+4. **Open PRs** — your own (complete CI → merge), dependabot (review → merge or close), auto-created (triage)
+5. **CodeQL / Scorecard findings** — high / critical first
+6. **Stale issues** — older than 90 days with no activity: verify, update, or close
+7. **Research queued** — topics filed as `research:` issues
+8. **Brainstorming** — file new issues for: drift observed during other work, TODO comments older than X, known-broken patterns in the code, vestigial modules, missing tests on critical paths
+
+At every step, **file issues for tangential findings** rather than sidetracking. "See something, say something" — CLAUDE.md already covers the mechanics.
+
+### Tie-break via `consensus_vote`, not user ask
+
+If genuinely unsure which of two or three backlog items to pick, run `consensus_vote` with `quickMode: true, strategy: simple_majority`. The vote result **is** the decision. Do not route ambiguity back to the user as "what do you want me to work on" — the user's autonomous directive already resolved that: whatever the vote picks.
+
+### Hard stop conditions (only these)
+
+Genuinely pause and surface to the user ONLY when:
+
+- **Cost-gated work** that needs prior approval not already granted (e.g. running a $100+ benchmark sweep)
+- **Destructive operations** where the blast radius exceeds what the user authorized (force-push to main, delete data, revoke access)
+- **Waiting on external system** with no path to progress (e.g. a dependency PR is stuck in another org's review, and there's no other autonomous work left)
+- **CI failure requiring a human design decision** (not a mechanical fix)
+- **Repeated failures** — same error 3+ times with distinct fix attempts, genuinely stuck
+
+For everything else: keep working, summarize progress at end of turn, begin the next item.
+
+### End-of-turn protocol for autonomous mode
+
+Close each turn with a short status block:
+
+```
+Done this turn: <1-line summary of what shipped>
+Up next: <the specific item being started, with issue/PR #>
+```
+
+No question marks at the end of turns. No "let me know if you want me to continue." The autonomous directive already authorized continuation.
+
+---
+
 ## Governance
 
 Governance rules (voting thresholds, refactor gates, fitness audit, documentation governance) are in `.claude/rules/governance.md` — auto-loaded when relevant.


### PR DESCRIPTION
## Summary

Adds a new \"Autonomous Operation Rules\" section to \`CLAUDE.md\` between Default Working Mode and Governance. Codifies the behavior the user asked for after today's session: **keep working through the backlog when given an autonomous directive; don't pause at clean handoff points to ask \"what's next\".**

## What the rules establish

- **Never pause while the backlog is non-empty.** A clean commit, a merged PR, a closed issue — none of those end the session under autonomous mode. Pick the next item and go.
- **Explicit work-order top-down:** CI red → open epics → bugs → PRs (own + dependabot) → CodeQL/Scorecard → stale issues → research queued → brainstorming + filing new issues for things noticed along the way.
- **Tie-break with \`consensus_vote\`, not user ask.** If genuinely unsure which of 2–3 items to pick, run a quick-mode vote. The result IS the decision.
- **Hard stop conditions** are enumerated and narrow: cost-gated work without prior approval, destructive operations beyond authorized blast radius, waiting-on-external-system with no parallel work left, CI design-decision failures, 3+ repeated same-error failures. Everything else: keep working.
- **End-of-turn protocol:** \`Done this turn: <X> / Up next: <Y>\`. No question marks, no \"your call on priority.\"

## Why now

Existing feedback memory (\`feedback_autonomous_loop_not_poll.md\`) already captured this exact failure mode from 2026-04-22:

> when the wake-up prompt mentions \"if nothing actionable, reschedule\" — interpret that as \"reschedule ONLY if I can't find anything autonomous to do.\"

But memory summaries can get evicted as context fills up; CLAUDE.md is always loaded. Promoting the rule from memory-only to always-loaded makes it load-bearing.

## Reads with the existing Default Working Mode section

The two sections are complementary:
- **Default Working Mode** = HOW to work on a non-trivial item (research → vote → plan → epic → children → implement)
- **Autonomous Operation Rules** = WHAT to pick next and when to actually stop

## Test plan

- [ ] CI passes
- [ ] After merge, user invokes \`/loop\` to kick off the autonomous sweep (timeout sub-issue B + PR/CodeQL/Scorecard work) — the new rules take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)