### PR TITLE
fix(orchestrate): wall-clock deadline safeguard returns structured partial result (closes sub-issue B of #2104)

### DIFF
--- a/packages/nexus-agents/src/core/race/race-against-deadline.test.ts
+++ b/packages/nexus-agents/src/core/race/race-against-deadline.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { raceAgainstDeadline } from './race-against-deadline.js';
+
+describe('raceAgainstDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the promise value when it settles before the deadline', async () => {
+    const promise = Promise.resolve('ok');
+    const onTimeout = vi.fn((_elapsed: number) => 'timeout' as const);
+
+    const result = await raceAgainstDeadline(promise, 1_000, onTimeout);
+
+    expect(result).toBe('ok');
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('invokes onTimeout when the deadline fires before the promise settles', async () => {
+    const hanging = new Promise<string>(() => {
+      // never settles
+    });
+    const onTimeout = vi.fn((elapsed: number) => `timeout:${String(elapsed)}`);
+
+    const resultP = raceAgainstDeadline(hanging, 500, onTimeout);
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await resultP;
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout.mock.calls[0]?.[0]).toBeGreaterThanOrEqual(500);
+    expect(result).toMatch(/^timeout:/);
+  });
+
+  it('clamps deadlineMs <= 0 to fire on the next microtask', async () => {
+    const hanging = new Promise<string>(() => {});
+    const onTimeout = vi.fn(() => 'timed-out');
+
+    const resultP = raceAgainstDeadline(hanging, -100, onTimeout);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await resultP;
+
+    expect(result).toBe('timed-out');
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onTimeout when the promise rejects before the deadline', async () => {
+    const rejecting = Promise.reject(new Error('boom'));
+    const onTimeout = vi.fn(() => 'timeout' as const);
+
+    await expect(raceAgainstDeadline(rejecting, 1_000, onTimeout)).rejects.toThrow('boom');
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('clears the timer when the promise wins the race (no dangling handle)', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const promise = Promise.resolve('quick');
+    const onTimeout = vi.fn(() => 'late');
+
+    await raceAgainstDeadline(promise, 10_000, onTimeout);
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('passes the elapsed ms (approximately deadlineMs) to onTimeout', async () => {
+    const hanging = new Promise<number>(() => {});
+    let captured = -1;
+    const onTimeout = (elapsed: number): number => {
+      captured = elapsed;
+      return elapsed;
+    };
+
+    const resultP = raceAgainstDeadline(hanging, 1_234, onTimeout);
+    await vi.advanceTimersByTimeAsync(1_234);
+    await resultP;
+
+    expect(captured).toBeGreaterThanOrEqual(1_234);
+  });
+
+  it('preserves the generic type of the promise', async () => {
+    interface Shape {
+      ok: boolean;
+      data: number;
+    }
+    const promise = Promise.resolve<Shape>({ ok: true, data: 42 });
+    const onTimeout = (): Shape => ({ ok: false, data: 0 });
+
+    const result = await raceAgainstDeadline(promise, 1_000, onTimeout);
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toBe(42);
+  });
+});

--- a/packages/nexus-agents/src/core/race/race-against-deadline.ts
+++ b/packages/nexus-agents/src/core/race/race-against-deadline.ts
@@ -1,0 +1,58 @@
+/**
+ * Generic wall-clock deadline race primitive.
+ *
+ * Races a promise against a timer. If the promise settles first, its value is
+ * returned. If the timer fires first, `onTimeout(elapsedMs)` is called and its
+ * return value resolves the race. The timer is always cleaned up.
+ *
+ * Used by MCP tools whose inner work may hang (subprocess IPC, multi-step
+ * orchestration) to guarantee a structured result before the outer
+ * `wrapToolWithTimeout` middleware fires a naked timeout error. Pair with
+ * `getMcpSafeDeadlineMs` from `config/timeouts.ts` so the internal deadline
+ * always fires before the MCP wrapper.
+ *
+ * Unlike `voter-agents-deadline.ts::raceWithDeadline`, this is not coupled to
+ * a specific error-vote shape — the caller synthesises whatever partial
+ * result makes sense in their domain.
+ *
+ * @module core/race/race-against-deadline
+ * @see Issue #2104 (sub-issue B)
+ */
+
+/**
+ * Races `promise` against `deadlineMs`. Returns the first settled value.
+ *
+ * On timeout, calls `onTimeout(elapsedMs)` and resolves with its return
+ * value. `elapsedMs` is the time between the call site and the timeout
+ * firing — useful for recording in metadata.
+ *
+ * - The timer is cleared in a `.finally()` branch so a late-settling promise
+ *   does not leave a dangling handle.
+ * - If `deadlineMs <= 0`, the timeout fires on the next microtask.
+ * - The original promise continues running after a timeout (there is no
+ *   cancellation primitive at this layer); callers who need to abort
+ *   downstream work should pass an AbortController into the promise creator.
+ */
+export async function raceAgainstDeadline<T>(
+  promise: Promise<T>,
+  deadlineMs: number,
+  onTimeout: (elapsedMs: number) => T
+): Promise<T> {
+  const startedAt = Date.now();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutP = new Promise<T>((resolve) => {
+    timer = setTimeout(
+      () => {
+        resolve(onTimeout(Date.now() - startedAt));
+      },
+      Math.max(0, deadlineMs)
+    );
+  });
+
+  try {
+    return await Promise.race([promise, timeoutP]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-deadline.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-deadline.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the orchestrate wall-clock deadline safeguard (sub-issue B of #2104).
+ *
+ * The full handler is exercised in orchestrate.test.ts; this file narrowly
+ * covers the timeout-path helper that shapes the partial OrchestrateOutput
+ * returned when the outer race fires before executeOrchestration settles.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildTimeoutOrchestrationResult, OrchestrateOutputSchema } from './orchestrate.js';
+
+describe('buildTimeoutOrchestrationResult (#2104 sub-issue B)', () => {
+  it('returns an ok Result with a schema-valid OrchestrateOutput', () => {
+    const result = buildTimeoutOrchestrationResult(
+      'task-timeout-1',
+      590_000,
+      'orchestration overall deadline exceeded'
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return; // type narrow
+
+    const parsed = OrchestrateOutputSchema.safeParse(result.value);
+    if (!parsed.success) {
+      throw new Error(`Schema validation failed: ${JSON.stringify(parsed.error.issues)}`);
+    }
+    expect(parsed.success).toBe(true);
+  });
+
+  it('populates metadata.timeoutReason so clients can distinguish truncated runs', () => {
+    const result = buildTimeoutOrchestrationResult('task-1', 1_234, 'deadline reached');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.metadata.timeoutReason).toBe('deadline reached');
+  });
+
+  it('records the elapsed ms in metadata.durationMs', () => {
+    const result = buildTimeoutOrchestrationResult('task-2', 42_000, 'reason');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.metadata.durationMs).toBe(42_000);
+  });
+
+  it('leaves result undefined and stepsCompleted at 0 (explicit truncation signal)', () => {
+    const result = buildTimeoutOrchestrationResult('task-3', 500, 'reason');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.result).toBeUndefined();
+    expect(result.value.stepsCompleted).toBe(0);
+  });
+
+  it("echoes the reason into analysis.approach so it's surfaced even if a client ignores metadata", () => {
+    const result = buildTimeoutOrchestrationResult('task-4', 1, 'overall deadline exceeded');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.analysis.approach).toContain('overall deadline exceeded');
+  });
+
+  it('uses the minimum-allowed complexity (1) and taskType "unknown" as truncated-run sentinels', () => {
+    // Schema min for complexity is 1; the distinguishing signal for a
+    // truncated run is metadata.timeoutReason, not a 0 complexity.
+    const result = buildTimeoutOrchestrationResult('task-5', 100, 'x');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.analysis.complexity).toBe(1);
+    expect(result.value.analysis.taskType).toBe('unknown');
+  });
+
+  it('carries the taskId through to both the output root and analysis.taskId', () => {
+    const result = buildTimeoutOrchestrationResult('task-trace-me', 100, 'x');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.taskId).toBe('task-trace-me');
+    expect(result.value.analysis.taskId).toBe('task-trace-me');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -67,6 +67,12 @@ export const OrchestrateOutputSchema = z.object({
     durationMs: z.number(),
     tokensUsed: z.number(),
     expertsUsed: z.array(z.string()),
+    /**
+     * Populated only when the outer wall-clock deadline fires before
+     * `executeOrchestration` settles. Clients inspect this to distinguish a
+     * complete low-depth run from a truncated partial result. See #2104.
+     */
+    timeoutReason: z.string().optional(),
   }),
 });
 

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -8,8 +8,9 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger, Result, Task, TaskContext } from '../../core/index.js';
 import { getErrorMessage } from '../../core/index.js';
-import { MCP_TIMEOUTS, HEARTBEAT_TIMEOUTS } from '../../config/timeouts.js';
+import { MCP_TIMEOUTS, HEARTBEAT_TIMEOUTS, getMcpSafeDeadlineMs } from '../../config/timeouts.js';
 import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
+import { raceAgainstDeadline } from '../../core/race/race-against-deadline.js';
 
 import {
   orchestrateInputToTaskContract,
@@ -820,6 +821,118 @@ function recordAndReflect(
   }
 }
 
+/**
+ * Builds a structured partial OrchestrateOutput for wall-clock timeouts
+ * (sub-issue B of #2104). Returns an `ok` Result so the happy-path
+ * assembler runs and the client sees structured data instead of a naked
+ * wrapper error. `timeoutReason` in `metadata` is the client's signal to
+ * distinguish a truncated run from a normal low-depth one.
+ *
+ * Exported for unit testing only; downstream code should NOT call this
+ * helper directly — it is internal plumbing for `executeOrchestrationWithDeadline`.
+ */
+export function buildTimeoutOrchestrationResult(
+  taskId: string,
+  elapsedMs: number,
+  reason: string
+): Result<OrchestrateOutput, OrchestrationError> {
+  // analysis.complexity has a schema min of 1 (see orchestrate-types.ts);
+  // use 1 as the "unknown / truncated" sentinel. The distinguishing signal
+  // for a truncated run is `metadata.timeoutReason` being set.
+  return ok({
+    taskId,
+    analysis: {
+      taskId,
+      complexity: 1,
+      taskType: 'unknown',
+      requirements: [],
+      risks: [],
+      needsDecomposition: false,
+      approach: `Orchestration aborted: ${reason}`,
+      estimatedEffort: 0,
+    },
+    result: undefined,
+    stepsCompleted: 0,
+    metadata: {
+      durationMs: elapsedMs,
+      tokensUsed: 0,
+      expertsUsed: [],
+      timeoutReason: reason,
+    },
+  });
+}
+
+/**
+ * Races `executeOrchestration` against a wall-clock deadline clamped below
+ * the MCP wrapper cap (sub-issue B of #2104). On timeout, returns a
+ * structured partial result. See buildTimeoutOrchestrationResult.
+ */
+async function executeOrchestrationWithDeadline(params: {
+  readonly input: OrchestrateInput;
+  readonly deps: OrchestrateDeps;
+  readonly notifier: ReturnType<typeof createMcpNotifier>;
+  readonly logger: ILogger;
+}): Promise<Result<OrchestrateOutput, OrchestrationError>> {
+  const { input, deps, notifier, logger } = params;
+  const overallDeadlineMs = getMcpSafeDeadlineMs(
+    MCP_TIMEOUTS.perTool['orchestrate'] ?? MCP_TIMEOUTS.defaultMs,
+    'orchestrate'
+  );
+  const timeoutTaskId = generateTaskId();
+  return raceAgainstDeadline(
+    withProgressHeartbeat('orchestrate', notifier, () => executeOrchestration(input, deps)),
+    overallDeadlineMs,
+    (elapsedMs) => {
+      logger.warn('Orchestration overall deadline reached; returning partial result', {
+        overallDeadlineMs,
+        elapsedMs,
+      });
+      return buildTimeoutOrchestrationResult(
+        timeoutTaskId,
+        elapsedMs,
+        'orchestration overall deadline exceeded'
+      );
+    }
+  );
+}
+
+/** Body of the depth-guarded orchestration pipeline (extracted for line limit). */
+async function runOrchestratePipeline(params: {
+  readonly input: OrchestrateInput;
+  readonly deps: OrchestrateDeps;
+  readonly notifier: ReturnType<typeof createMcpNotifier>;
+  readonly logger: ILogger;
+}): Promise<ToolResult> {
+  const { input, deps, notifier, logger } = params;
+  logger.debug('Starting orchestration', { taskLength: input.task.length });
+  notifier.info('orchestrate', { event: 'orchestrate_start', taskLength: input.task.length });
+  const startMs = getTimeProvider().now();
+  const v2Config = resolveV2Config();
+  if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(input, logger);
+
+  const agentPlan = v2Config.aorchestraEnabled ? computeAgentPlan(input.task, logger) : undefined;
+  const workerDispatchResult = await tryWorkerDispatch(
+    agentPlan,
+    input.task,
+    deps,
+    logger,
+    notifier
+  );
+  recordAndReflect(workerDispatchResult, input.task, deps);
+
+  // Wall-clock safeguard (sub-issue B of #2104): see helper doc.
+  const result = await executeOrchestrationWithDeadline({ input, deps, notifier, logger });
+  if (!result.ok) {
+    return toolError(`Orchestration error: ${result.error.message}`);
+  }
+  notifier.info('orchestrate', {
+    event: 'orchestrate_complete',
+    subtaskCount: result.value.stepsCompleted,
+    durationMs: getTimeProvider().now() - startMs,
+  });
+  return assembleOrchestrateOutput(result.value, agentPlan, workerDispatchResult);
+}
+
 function createOrchestrateHandler(deps: OrchestrateDeps) {
   const notifier = deps.notifier ?? NOOP_NOTIFIER;
   return async (args: unknown, ctx: HandlerContext) => {
@@ -828,47 +941,16 @@ function createOrchestrateHandler(deps: OrchestrateDeps) {
       ctx.logger.warn('Invalid orchestrate input', { errors: validated.error.issues });
       return toolError(`Validation error: ${formatZodError(validated.error)}`);
     }
-
     // Depth guard: prevent runaway nested orchestration (#1500)
     try {
-      return await withDepthGuard('orchestrate', async () => {
-        ctx.logger.debug('Starting orchestration', { taskLength: validated.data.task.length });
-        notifier.info('orchestrate', {
-          event: 'orchestrate_start',
-          taskLength: validated.data.task.length,
-        });
-        const startMs = getTimeProvider().now();
-        const v2Config = resolveV2Config();
-        if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(validated.data, ctx.logger);
-
-        const agentPlan = v2Config.aorchestraEnabled
-          ? computeAgentPlan(validated.data.task, ctx.logger)
-          : undefined;
-        const workerDispatchResult = await tryWorkerDispatch(
-          agentPlan,
-          validated.data.task,
+      return await withDepthGuard('orchestrate', () =>
+        runOrchestratePipeline({
+          input: validated.data,
           deps,
-          ctx.logger,
-          notifier
-        );
-
-        recordAndReflect(workerDispatchResult, validated.data.task, deps);
-
-        const result = await withProgressHeartbeat('orchestrate', notifier, () =>
-          executeOrchestration(validated.data, deps)
-        );
-        if (!result.ok) {
-          return toolError(`Orchestration error: ${result.error.message}`);
-        }
-
-        notifier.info('orchestrate', {
-          event: 'orchestrate_complete',
-          subtaskCount: result.value.stepsCompleted,
-          durationMs: getTimeProvider().now() - startMs,
-        });
-
-        return assembleOrchestrateOutput(result.value, agentPlan, workerDispatchResult);
-      });
+          notifier,
+          logger: ctx.logger,
+        })
+      );
     } catch (depthError: unknown) {
       const msg = depthError instanceof Error ? depthError.message : String(depthError);
       ctx.logger.warn('Orchestration depth guard triggered', { error: msg });


### PR DESCRIPTION
## Summary

Closes sub-issue B of epic #2104. Mirrors the #2108 pattern for `orchestrate`: a wall-clock deadline, clamped below the `wrapToolWithTimeout` cap via the existing `getMcpSafeDeadlineMs`, so the client always receives a structured `OrchestrateOutput` instead of a naked `Operation 'orchestrate' timed out after 900000ms` error when the inner chain hangs.

## Before / after

Before (hang in `executeOrchestration`):
```
{ "error": "Operation 'orchestrate' timed out after 900000ms (request: req_…)" }
```
All captured setup state — `taskId`, `agentPlan`, `workerDispatchResult` — lost.

After (same hang, with this fix):
```jsonc
{
  "taskId": "orch-…",
  "analysis": { "complexity": 1, "taskType": "unknown", "approach": "Orchestration aborted: …", … },
  "result": null,
  "stepsCompleted": 0,
  "metadata": {
    "durationMs": 889840,
    "tokensUsed": 0,
    "expertsUsed": [],
    "timeoutReason": "orchestration overall deadline exceeded"
  },
  "agentPlan": { … },          // when aorchestra is on
  "workerDispatch": { … }      // when worker dispatch ran pre-hang
}
```

## Files

- **New** `src/core/race/race-against-deadline.ts` — generic `raceAgainstDeadline<T>(promise, deadlineMs, onTimeout)` primitive. Pure, no DI. Kept separate from the role-coupled `voter-agents-deadline.ts::raceWithDeadline`.
- **New** `src/core/race/race-against-deadline.test.ts` — 7 tests (promise-wins, timeout-wins, negative-deadline clamp, rejection pass-through, timer cleanup, elapsed-ms accuracy, generic preservation).
- **Modified** `src/mcp/tools/orchestrate.ts` — injected `executeOrchestrationWithDeadline()` between the handler and `executeOrchestration`; added `buildTimeoutOrchestrationResult()` for the on-timeout shape. Extracted `runOrchestratePipeline()` to satisfy `max-lines-per-function`.
- **Modified** `src/mcp/tools/orchestrate-types.ts` — added optional `metadata.timeoutReason: z.string().optional()`. Non-breaking additive schema change.
- **New** `src/mcp/tools/orchestrate-deadline.test.ts` — 7 tests asserting the OrchestrateOutput shape, schema validity, timeoutReason propagation, sentinel values.

## Design choices (resolved without a formal vote since scope was small)

| Question | Decision | Rationale |
|---|---|---|
| State-snapshot checkpoint in this PR? | **Deferred.** MVP returns setup-only partial result. | Mid-flight snapshot of analysis/routing is a fidelity improvement; the MVP already fixes the user-visible naked-timeout bug. |
| Helper in `core/race/` or `cli/`? | **`core/race/`** | More reusable, clearer signal. Keeps `voter-agents-deadline.ts` unchanged (role-coupled shape is legitimately different). |
| Safety buffer size? | **10s (same as consensus_vote)** | Orchestrate's partial-result construction is a synchronous object literal — 10s is plenty of headroom. |

## Verification

```
✓ src/core/race/race-against-deadline.test.ts (7 tests)
✓ src/mcp/tools/orchestrate-deadline.test.ts (7 tests)
✓ src/mcp/tools/orchestrate.test.ts (35 tests — all unchanged)
✓ src/config/timeouts.test.ts (58 tests — sub-issue A)
✓ src/cli/voter-agents-deadline.test.ts (3 tests — sub-issue A)
110/110 tests passing, 0 lint, 0 tsc errors
```

## Follow-ups (filed separately after this lands)

- State-snapshot option from the original vote — capture analysis and routing sub-steps so partial results include them, not just setup state.
- Once this PR merges, epic #2104 has no remaining sub-issues — ready to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)