### PR TITLE
chore(release): changeset for v2.54.0 — MCP timeout deadline safeguards

### DIFF
--- a/.changeset/mcp-timeout-deadlines.md
+++ b/.changeset/mcp-timeout-deadlines.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+**fix(mcp): wall-clock deadline safeguards for `consensus_vote` and `orchestrate`**
+
+Both long-running MCP tools now clamp their internal wall-clock deadline below the outer `wrapToolWithTimeout` cap via `getMcpSafeDeadlineMs`, and return a structured partial result when the deadline fires — instead of the naked `Operation '<tool>' timed out after Nms` error that clients saw before.
+
+- `consensus_vote` (#2108): stuck roles surface as `{ source: 'error', error: 'overall consensus deadline exceeded' }`; every completed vote survives.
+- `orchestrate` (#2110): a new `raceAgainstDeadline` primitive in `core/race/` races `executeOrchestration` against a 890s deadline (900s cap − 10s safety buffer). On timeout, the client receives a schema-valid `OrchestrateOutput` with `metadata.timeoutReason = 'orchestration overall deadline exceeded'`, preserving captured setup state (`taskId`, `agentPlan`, `workerDispatch`).
+
+New in the public schema: `OrchestrateOutputSchema.metadata.timeoutReason` is an optional string. Additive, non-breaking.
+
+Closes epic #2104. Follow-up #2111 tracks the state-snapshot fidelity improvement (deferred from the MVP).


### PR DESCRIPTION
## Summary

Adds a minor-bump changeset for the epic #2104 timeout fixes so the release workflow opens a \"Version Packages\" PR and tags \`nexus-agents@2.54.0\` on merge.

## What's in v2.54.0

- **fix(mcp): wall-clock deadline safeguards for \`consensus_vote\` and \`orchestrate\`** (#2108, #2110, closes #2104)
- New public surface: optional \`OrchestrateOutputSchema.metadata.timeoutReason\` (additive, non-breaking → minor bump, not patch)

## Why minor, not patch

Both tools' output contracts now guarantee a structured response on timeout where before they could die at the MCP wrapper. That's a behavior change a downstream client might key on, so minor is appropriate. If you'd rather ship as 2.53.1 patch, switch \`minor\` → \`patch\` in the changeset before merge and close/reopen this PR.

## Release flow

1. Merge this PR → changeset lands on \`main\`
2. Release workflow opens a \"Version Packages\" PR bumping package.json + CHANGELOG
3. Merge that PR → tag \`nexus-agents@2.54.0\` + npm publish

## Test plan

- [x] Changeset markdown validates against Changesets format
- [ ] CI passes
- [ ] After merge: confirm Release workflow opens the Version Packages PR within 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)