### PR TITLE
fix(ci): replace ad-hoc pnpm install with hash-pinned pnpm/action-setup

### DIFF
--- a/.changeset/mcp-timeout-deadlines.md
+++ b/.changeset/mcp-timeout-deadlines.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+**fix(mcp): wall-clock deadline safeguards for `consensus_vote` and `orchestrate`**
+
+Both long-running MCP tools now clamp their internal wall-clock deadline below the outer `wrapToolWithTimeout` cap via `getMcpSafeDeadlineMs`, and return a structured partial result when the deadline fires — instead of the naked `Operation '<tool>' timed out after Nms` error that clients saw before.
+
+- `consensus_vote` (#2108): stuck roles surface as `{ source: 'error', error: 'overall consensus deadline exceeded' }`; every completed vote survives.
+- `orchestrate` (#2110): a new `raceAgainstDeadline` primitive in `core/race/` races `executeOrchestration` against a 890s deadline (900s cap − 10s safety buffer). On timeout, the client receives a schema-valid `OrchestrateOutput` with `metadata.timeoutReason = 'orchestration overall deadline exceeded'`, preserving captured setup state (`taskId`, `agentPlan`, `workerDispatch`).
+
+New in the public schema: `OrchestrateOutputSchema.metadata.timeoutReason` is an optional string. Additive, non-breaking.
+
+Closes epic #2104. Follow-up #2111 tracks the state-snapshot fidelity improvement (deferred from the MVP).

--- a/.github/workflows/ecosystem-smoke.yml
+++ b/.github/workflows/ecosystem-smoke.yml
@@ -90,12 +90,17 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup pnpm (hash-pinned action, replaces ad-hoc `npm install -g pnpm@9`)
+        if: steps.detect.outputs.type == 'node' && steps.detect.outputs.pkgmgr == 'pnpm'
+        uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
+        with:
+          version: 9
+
       - name: Install (pnpm)
         if: steps.detect.outputs.type == 'node' && steps.detect.outputs.pkgmgr == 'pnpm'
         working-directory: target
         run: |
           set -euo pipefail
-          npm install -g pnpm@9
           pnpm install --frozen-lockfile
 
       - name: Install (npm)
@@ -103,6 +108,12 @@ jobs:
         working-directory: target
         run: |
           set -euo pipefail
+          # `npm ci` requires a package-lock.json; target ecosystem repos may
+          # not ship one, in which case falling back to `npm install` is the
+          # only viable install path for smoke-testing. Scorecard flags this
+          # as "not pinned by hash" but pinning an install that runs against
+          # an arbitrary external repo's manifest is not meaningful — the
+          # target's own lockfile (or lack thereof) is the contract.
           npm ci || npm install
 
       - name: Run smoke test
@@ -121,6 +132,10 @@ jobs:
               echo "::warning::No test or build script found"
             fi
           elif [[ -f pyproject.toml ]]; then
+            # Same constraint as the npm case: the target repo is arbitrary,
+            # its dependency set is defined by its own pyproject/requirements,
+            # and hash-pinning installs against an external repo's manifest
+            # is not a meaningful operation. Scorecard flags this.
             pip install -e . || pip install -r requirements.txt
             pytest --no-header || exit 1
           else


### PR DESCRIPTION
## Summary

Closes Scorecard Pinned-Dependencies alert #195 by replacing \`npm install -g pnpm@9\` in \`ecosystem-smoke.yml\` with \`pnpm/action-setup@b307475...\` — the same hash-pinned action already used by \`.github/actions/setup-node\`.

## Why the other 3 Scorecard alerts on this file can't / shouldn't be \"fixed\"

Alerts #196, #197, #198 flag \`npm ci || npm install\` and \`pip install -e . || pip install -r requirements.txt\`. Those commands operate on the **arbitrary cloned target repo**, not on nexus-agents' own deps — the target's own lockfile (or absence of one) is the contract.

Pinning an install that runs against an external manifest is not a meaningful operation: the hashes we'd pin would change per-target, defeating the point. Inline comments added to both spots so these flags don't become drive-by cleanup targets for future PRs.

## Expected impact on Scorecard

- Pinned-Dependencies check: 2 → higher (one real unpinned dep removed)
- Aggregate: 7.7 → should tick up

## Test plan

- [ ] CI passes (this file is exercised by the ecosystem-smoke workflow on push to main)
- [ ] After merge: Scorecard re-run shows alert #195 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)