### PR TITLE
chore(ci): mcp-tool-count drift guard (closes #2107)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -412,6 +412,63 @@ jobs:
           fi
           echo "✅ No stale references to removed paths"
 
+      # MCP tool count must agree across every file that claims to know it
+      # (see #2106 for the failure mode — three files claimed 29/30/31). The
+      # source of truth is the `tools: [...]` array in
+      # `packages/nexus-agents/src/mcp/tools/index.ts`. Other callers mirror
+      # it, and silent drift means marketplace metadata lies about what we ship.
+      - name: Guard against MCP_TOOL_COUNT drift (#2107)
+        run: |
+          set -e
+          TOOLS_SRC=packages/nexus-agents/src/mcp/tools/index.ts
+          SITE_DATA=website/src/data/site-data.ts
+          SERVER_JSON=packages/nexus-agents/server.json
+          README=README.md
+
+          # 1. Authoritative count: lines of the form `    'tool_name',` between
+          #    `tools: [` and the next `]`. Grep is robust to reformatting.
+          src_count=$(awk '/tools: \[/,/\]/' "$TOOLS_SRC" \
+            | grep -cE "^\s+'[a-z_]+'," || true)
+          echo "Authoritative tool count (from $TOOLS_SRC): $src_count"
+
+          # 2. MCP_TOOL_COUNT constant in site-data.ts
+          site_count=$(grep -oE "MCP_TOOL_COUNT\s*=\s*[0-9]+" "$SITE_DATA" \
+            | grep -oE "[0-9]+" | head -1)
+
+          # 3. server.json tools array length (simple JSON-aware parse via jq)
+          server_count=$(jq '.tools | length' "$SERVER_JSON")
+
+          # 4. server.json description prose: "N MCP tools"
+          server_desc_count=$(jq -r '.description' "$SERVER_JSON" \
+            | grep -oE "[0-9]+ MCP tools" | grep -oE "^[0-9]+" | head -1)
+
+          # 5. README.md prose: "N MCP tools" (may appear multiple times)
+          readme_counts=$(grep -oE "[0-9]+ MCP tools" "$README" \
+            | grep -oE "^[0-9]+" | sort -u)
+
+          any_drift=0
+          check() {
+            local label="$1" actual="$2"
+            if [ "$actual" != "$src_count" ]; then
+              echo "::error::MCP tool count drift: $label reports '$actual' but source has $src_count"
+              any_drift=1
+            fi
+          }
+          check "site-data.ts MCP_TOOL_COUNT" "$site_count"
+          check "server.json tools[]" "$server_count"
+          check "server.json description prose" "$server_desc_count"
+          while IFS= read -r n; do
+            [ -n "$n" ] && check "README.md prose '$n MCP tools'" "$n"
+          done <<< "$readme_counts"
+
+          if [ "$any_drift" -ne 0 ]; then
+            echo ""
+            echo "Update the drifted value(s) to match $TOOLS_SRC."
+            echo "See #2107 for context."
+            exit 1
+          fi
+          echo "✅ MCP_TOOL_COUNT agrees everywhere ($src_count)"
+
   # Job 10.6: Skills Index Freshness (#1828)
   skills-index-check:
     name: Skills Index Freshness

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -26,6 +26,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 <!-- PIPELINE NOTE: TypeDoc Verification CI job (docs-check.yml) downgraded from blocking failure to warning annotation (#2027, 2026-04-19) — drift was creating merge-round-trip noise without providing actionable signal -->
 <!-- PIPELINE NOTE: link-check.yml bumped actions/cache v5.0.4 → v5.0.5 (patch-level bump; no behavioral change) (#2087, 2026-04-20) -->
 <!-- PIPELINE NOTE: docs-check.yml link-check job removed; it invoked markdown-link-check with `|| true` so all failures were swallowed. lychee in link-check.yml is now the single canonical link-validation path (#2101, 2026-04-21) -->
+<!-- PIPELINE NOTE: docs-check.yml docs-content-drift job extended with MCP_TOOL_COUNT cross-check — fails CI when site-data.ts MCP_TOOL_COUNT, server.json tools[], server.json description prose, or README.md prose disagree with the authoritative count in src/mcp/tools/index.ts registerTools() (#2107, 2026-04-22) -->
 
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 


### PR DESCRIPTION
## Summary

Closes #2107. Adds a ~40-line shell guard to the existing \`docs-content-drift\` job in \`docs-check.yml\` that cross-checks the MCP tool count across every file that claims to know it:

- Authoritative: \`tools: [...]\` array in \`packages/nexus-agents/src/mcp/tools/index.ts\`
- \`website/src/data/site-data.ts\` — \`MCP_TOOL_COUNT\` constant
- \`packages/nexus-agents/server.json\` — \`tools\` array length
- \`packages/nexus-agents/server.json\` — description prose (\"N MCP tools\")
- \`README.md\` — prose (\"N MCP tools\", may appear multiple times)

Fails CI with a per-mismatch error when any value drifts.

## Why this scope (narrow)

PR #2106 had to harmonize three files that each claimed a different MCP tool count (29/30/31). Marketplace descriptions and the landing-page stats bar had been wrong for an unknown stretch. The guard covers the exact drift pattern that actually happened.

Other \`site-data.ts\` constants (\`EXPERT_TYPE_COUNT\`, \`CLI_ADAPTER_COUNT\`, \`ROUTING_STAGE_COUNT\`, etc.) can get their own guards in follow-ups once their canonical-source patterns stabilize. Bundling them all now would balloon the guard beyond what the user-visible drift warranted.

## Honoring prior guidance

The Contrarian Analyst's vote on #2096 flagged over-engineering risk in custom AST tooling. This guard is **40 lines of bash + jq**, not a parser. Extends the existing drift-prevention surface in \`docs-content-drift\` rather than adding a new CI job — same place the #1619 removed-files guard lives, so all docops linting stays in one spot.

## Verification

Locally:
```
src=31, site=31, server=31, desc=31, readme=31 → ✅ agree
```

Sanity check with deliberately drifted value:
```
site=99 → ✗ flagged, exits 1
```

## Test plan

- [x] Guard passes on this branch
- [x] Guard correctly flags a deliberately drifted value (tested locally)
- [ ] CI runs the guard on this PR
- [ ] Future PRs that update the tool list must touch all 4 mirrors or the guard fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)