### PR TITLE
feat(adapter): direct custom-openai SDK adapter with SSRF guard (closes #2120)

### DIFF
--- a/docs/guides/CUSTOM_ENDPOINT_SETUP.md
+++ b/docs/guides/CUSTOM_ENDPOINT_SETUP.md
@@ -7,16 +7,35 @@ keywords: [custom, openai-compatible, gateway, opencode, endpoint, proxy]
 
 # Custom OpenAI-Compatible Endpoint Setup
 
-Route nexus-agents tasks through a custom OpenAI-compatible API gateway using OpenCode as the transport layer. This supports environments where models are brokered through an intermediary API endpoint.
+Route nexus-agents tasks through a custom OpenAI-compatible API gateway. Two paths are supported — pick based on whether you want nexus-agents to hold the credentials directly.
 
-## Architecture
+## Path A: Direct SDK (recommended for most cases, v2.54.2+)
+
+```
+nexus-agents → @ai-sdk/openai → Custom Gateway → Model Provider
+                (HTTP POST)      (OpenAI-compat)   (Claude, Gemini, etc.)
+```
+
+Set three env vars and any auto-adapter caller picks up the gateway:
+
+```bash
+export NEXUS_CUSTOM_API_BASE_URL="https://your-gateway.example.com/v1"
+export NEXUS_CUSTOM_API_KEY="your-api-key"
+export NEXUS_CUSTOM_MODEL="claude-opus-4-5"   # optional; default: gpt-4o
+```
+
+The adapter validates the base URL through an SSRF guard before making any request — loopback, RFC 1918 private ranges, and link-local (incl. AWS IMDS `169.254.169.254`) are rejected by default. Set `NEXUS_CUSTOM_API_ALLOW_PRIVATE=1` if your gateway runs on a trusted internal host.
+
+No CLI subprocess, no OpenCode in the chain. nexus-agents speaks OpenAI-compatible chat/completions directly. See [adapters/sdk/custom-api-validation.ts](../../packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts) for the guard rules.
+
+## Path B: OpenCode transport (for environments already managing creds in OpenCode)
 
 ```
 nexus-agents → OpenCode CLI → Custom Gateway → Model Provider
                 (subprocess)    (OpenAI-compat)   (Claude, etc.)
 ```
 
-nexus-agents invokes `opencode run --model custom/<model-name> <prompt>` as a subprocess. OpenCode handles the HTTP transport to the custom gateway. No API keys or credentials are managed by nexus-agents.
+nexus-agents invokes `opencode run --model custom/<model-name> <prompt>` as a subprocess. OpenCode handles the HTTP transport to the custom gateway. No API keys or credentials are managed by nexus-agents — handy when the user's gateway credentials are already in `opencode.json` and you don't want a second copy.
 
 ## Prerequisites
 

--- a/packages/nexus-agents/src/adapters/auto-adapter.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.ts
@@ -200,8 +200,43 @@ function tryApiAdapter(config: AutoAdapterConfig, logger: ILogger): AdapterSelec
     };
   }
 
+  // 4. Custom OpenAI-compatible gateway (multi-vendor proxies, self-hosted
+  //    LLM servers, corporate gateways). Extracted for line limit.
+  const custom = tryCustomOpenAiAdapter(logger);
+  if (custom !== null) return custom;
+
   logger.info('No API keys available for any provider');
   return null;
+}
+
+/**
+ * Tries the custom-openai SDK adapter if `NEXUS_CUSTOM_API_KEY` and
+ * `NEXUS_CUSTOM_API_BASE_URL` are both set. The adapter constructor
+ * runs the base URL through an SSRF guard (see
+ * adapters/sdk/custom-api-validation.ts). Epic #2119.
+ */
+function tryCustomOpenAiAdapter(logger: ILogger): AdapterSelection | null {
+  const customKey = resolveApiKeyFromEnv(undefined, 'NEXUS_CUSTOM_API_KEY');
+  const customBaseUrl = process.env['NEXUS_CUSTOM_API_BASE_URL'];
+  if (customKey === undefined || customBaseUrl === undefined || customBaseUrl === '') {
+    return null;
+  }
+  const customModelId = process.env['NEXUS_CUSTOM_MODEL'] ?? 'gpt-4o';
+  logger.info('Using custom-openai SDK adapter', {
+    model: customModelId,
+    baseUrl: customBaseUrl,
+  });
+  return {
+    adapter: new SdkAdapter({
+      providerId: 'custom-openai',
+      modelId: customModelId,
+      apiKey: customKey,
+      baseUrl: customBaseUrl,
+    }),
+    source: 'api',
+    name: 'custom-openai',
+    reason: `Using custom OpenAI-compatible gateway at ${customBaseUrl} (model: ${customModelId})`,
+  };
 }
 
 /** Try CLI first, then API as fallback. */

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateCustomApiBaseUrl } from './custom-api-validation.js';
+import { CUSTOM_API_ALLOW_PRIVATE_ENV } from './types.js';
+
+// Restore the original env var on every teardown so tests that flip
+// NEXUS_CUSTOM_API_ALLOW_PRIVATE don't leak into siblings.
+describe('validateCustomApiBaseUrl', () => {
+  const originalEnv = process.env[CUSTOM_API_ALLOW_PRIVATE_ENV];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      process.env['NEXUS_CUSTOM_API_ALLOW_PRIVATE'] = '';
+      // Full removal: reassign to match initial (undefined) shape
+      Reflect.deleteProperty(process.env, 'NEXUS_CUSTOM_API_ALLOW_PRIVATE');
+    } else {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = originalEnv;
+    }
+  });
+
+  describe('happy path', () => {
+    it('accepts a public https URL', () => {
+      const result = validateCustomApiBaseUrl('https://gateway.example.com/v1');
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts a public http URL (http is allowed; not every gateway has TLS)', () => {
+      const result = validateCustomApiBaseUrl('http://gateway.example.com/v1');
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts a URL with port and path', () => {
+      const result = validateCustomApiBaseUrl('https://gateway.example.com:8443/openai/v1');
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns the parsed URL object on success', () => {
+      const result = validateCustomApiBaseUrl('https://gateway.example.com/v1');
+      if (!result.ok) throw new Error('expected ok');
+      expect(result.value).toBeInstanceOf(URL);
+      expect(result.value.host).toBe('gateway.example.com');
+      expect(result.value.pathname).toBe('/v1');
+    });
+  });
+
+  describe('rejects malformed input', () => {
+    it('rejects undefined', () => {
+      const result = validateCustomApiBaseUrl(undefined);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/required but missing/i);
+    });
+
+    it('rejects empty string', () => {
+      const result = validateCustomApiBaseUrl('');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects whitespace-only string', () => {
+      const result = validateCustomApiBaseUrl('   ');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects non-URL text', () => {
+      const result = validateCustomApiBaseUrl('not a url at all');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/not a valid URL/i);
+    });
+
+    it('rejects non-http(s) protocols (file://)', () => {
+      const result = validateCustomApiBaseUrl('file:///etc/passwd');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/http or https/i);
+    });
+
+    it('rejects ftp://', () => {
+      const result = validateCustomApiBaseUrl('ftp://example.com/');
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('SSRF guard (default: deny private/loopback)', () => {
+    it('rejects localhost', () => {
+      const result = validateCustomApiBaseUrl('http://localhost:8080/v1');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/loopback/);
+    });
+
+    it('rejects 127.0.0.1', () => {
+      const result = validateCustomApiBaseUrl('http://127.0.0.1/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects 127.55.1.2 (any 127/8)', () => {
+      const result = validateCustomApiBaseUrl('http://127.55.1.2/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects 10.0.0.5 (RFC 1918)', () => {
+      const result = validateCustomApiBaseUrl('http://10.0.0.5/');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/private/i);
+    });
+
+    it('rejects 172.16.0.1 through 172.31.255.255', () => {
+      expect(validateCustomApiBaseUrl('http://172.16.0.1/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://172.31.255.1/').ok).toBe(false);
+      // But 172.15 is public, 172.32 is public
+      expect(validateCustomApiBaseUrl('http://172.15.0.1/').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://172.32.0.1/').ok).toBe(true);
+    });
+
+    it('rejects 192.168.x.x', () => {
+      const result = validateCustomApiBaseUrl('http://192.168.1.1/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects 169.254.169.254 (AWS IMDS endpoint — high-impact SSRF target)', () => {
+      const result = validateCustomApiBaseUrl('http://169.254.169.254/latest/meta-data/');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/link.?local/i);
+    });
+
+    it('rejects 0.0.0.0', () => {
+      const result = validateCustomApiBaseUrl('http://0.0.0.0/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects IPv6 loopback ::1', () => {
+      const result = validateCustomApiBaseUrl('http://[::1]/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects IPv6 link-local fe80:: prefix', () => {
+      const result = validateCustomApiBaseUrl('http://[fe80::1]/');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects IPv6 unique-local fc00::/7', () => {
+      expect(validateCustomApiBaseUrl('http://[fc00::1]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[fd12:3456:789a::1]/').ok).toBe(false);
+    });
+
+    it('rejects .localhost and .local hostnames', () => {
+      expect(validateCustomApiBaseUrl('http://gateway.localhost/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://gateway.local/').ok).toBe(false);
+    });
+  });
+
+  describe('SSRF guard escape hatch (NEXUS_CUSTOM_API_ALLOW_PRIVATE)', () => {
+    it('allows localhost when allowPrivate=true is passed explicitly', () => {
+      const result = validateCustomApiBaseUrl('http://localhost:8080/v1', {
+        allowPrivate: true,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('allows 10.0.0.5 when NEXUS_CUSTOM_API_ALLOW_PRIVATE=1 is set', () => {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = '1';
+      const result = validateCustomApiBaseUrl('http://10.0.0.5/');
+      expect(result.ok).toBe(true);
+    });
+
+    it('allows 127.0.0.1 when NEXUS_CUSTOM_API_ALLOW_PRIVATE=true is set', () => {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = 'true';
+      const result = validateCustomApiBaseUrl('http://127.0.0.1/');
+      expect(result.ok).toBe(true);
+    });
+
+    it('still rejects when NEXUS_CUSTOM_API_ALLOW_PRIVATE is anything else (e.g. "yes")', () => {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = 'yes';
+      const result = validateCustomApiBaseUrl('http://localhost/');
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
@@ -1,0 +1,182 @@
+/**
+ * Validation for the `custom-openai` SDK adapter's gateway URL.
+ *
+ * The base URL is user-provided, so without validation the adapter becomes
+ * an SSRF vector: a malicious prompt that reshaped env vars, or a typo in
+ * the config, could point nexus-agents at `http://169.254.169.254/` (AWS
+ * metadata) or `http://localhost:5432/` (internal services). This module
+ * rejects such URLs unless the user explicitly opts in via
+ * `NEXUS_CUSTOM_API_ALLOW_PRIVATE=1`.
+ *
+ * Called out in the #2119 consensus vote by the Security Engineer role.
+ *
+ * @module adapters/sdk/custom-api-validation
+ */
+
+import { isIPv4, isIPv6 } from 'node:net';
+import { ConfigError, ok, err, type Result } from '../../core/index.js';
+import { CUSTOM_API_ALLOW_PRIVATE_ENV } from './types.js';
+
+/**
+ * Why a given URL was rejected. Machine-readable so error messages can
+ * distinguish root causes in downstream tooling.
+ */
+export type BaseUrlRejectionReason =
+  | 'empty'
+  | 'not_a_url'
+  | 'not_http_https'
+  | 'loopback'
+  | 'link_local'
+  | 'private_range'
+  | 'reserved';
+
+interface RejectionDetail {
+  readonly reason: BaseUrlRejectionReason;
+  readonly message: string;
+}
+
+/**
+ * Validates a user-provided custom-gateway base URL. Returns the URL as an
+ * `ok` Result if it passes, or a `ConfigError` with a machine-readable
+ * reason if it fails.
+ *
+ * Pass `{ allowPrivate: true }` (or set the env var) to bypass the SSRF
+ * checks — use this only when the gateway is on a trusted internal host
+ * and you accept the risk.
+ */
+export function validateCustomApiBaseUrl(
+  raw: string | undefined,
+  opts: { readonly allowPrivate?: boolean } = {}
+): Result<URL, ConfigError> {
+  if (raw === undefined || raw.trim() === '') {
+    return err(
+      new ConfigError(
+        'Custom API base URL is required but missing. Set NEXUS_CUSTOM_API_BASE_URL or pass `baseUrl` in config.'
+      )
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return err(new ConfigError(`Custom API base URL is not a valid URL: ${raw}`));
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return err(
+      new ConfigError(`Custom API base URL must use http or https, got "${url.protocol}" in ${raw}`)
+    );
+  }
+
+  const allowPrivate = opts.allowPrivate === true || resolveAllowPrivateFromEnv();
+  if (!allowPrivate) {
+    const rejection = classifyPrivateHost(url.hostname);
+    if (rejection !== null) {
+      return err(
+        new ConfigError(
+          `Custom API base URL rejected (SSRF guard, reason="${rejection.reason}"): ${rejection.message}. ` +
+            `Set ${CUSTOM_API_ALLOW_PRIVATE_ENV}=1 to bypass if the gateway runs on a trusted internal host.`
+        )
+      );
+    }
+  }
+
+  return ok(url);
+}
+
+function resolveAllowPrivateFromEnv(): boolean {
+  const v = process.env[CUSTOM_API_ALLOW_PRIVATE_ENV];
+  return v === '1' || v === 'true';
+}
+
+/**
+ * Returns a rejection reason if the hostname resolves (by string form) to
+ * a loopback, link-local, or RFC 1918 private address; `null` otherwise.
+ *
+ * Note: this is a string-level check. It does NOT perform DNS resolution,
+ * so a public DNS name that secretly resolves to a private IP will pass.
+ * Callers who need that level of defense should add a runtime connect
+ * check and validate the socket peer address.
+ */
+function classifyPrivateHost(hostname: string): RejectionDetail | null {
+  // URL.hostname wraps IPv6 literals in brackets (e.g. "[::1]"); strip them
+  // before the net-module checks, which expect bare forms.
+  const stripped =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  const normalized = stripped.toLowerCase();
+
+  // Literal IPv4 loopback or private-range address
+  if (isIPv4(normalized)) {
+    return classifyIPv4(normalized);
+  }
+
+  // Literal IPv6 loopback (::1), link-local (fe80::/10), unique-local (fc00::/7)
+  if (isIPv6(normalized)) {
+    return classifyIPv6(normalized);
+  }
+
+  // Hostname literals that resolve to loopback without needing DNS
+  if (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized.endsWith('.local') // mDNS
+  ) {
+    return {
+      reason: 'loopback',
+      message: `hostname "${hostname}" resolves to loopback/mDNS`,
+    };
+  }
+
+  return null;
+}
+
+/** IPv4 ranges the SSRF guard rejects, in order of specificity. */
+const IPV4_RULES: ReadonlyArray<{
+  readonly match: (a: number, b: number) => boolean;
+  readonly reason: BaseUrlRejectionReason;
+  readonly label: string;
+}> = [
+  { match: (a) => a === 127, reason: 'loopback', label: 'IPv4 loopback' },
+  { match: (a) => a === 10, reason: 'private_range', label: 'IPv4 private (10/8)' },
+  {
+    match: (a, b) => a === 172 && b >= 16 && b <= 31,
+    reason: 'private_range',
+    label: 'IPv4 private (172.16/12)',
+  },
+  {
+    match: (a, b) => a === 192 && b === 168,
+    reason: 'private_range',
+    label: 'IPv4 private (192.168/16)',
+  },
+  {
+    match: (a, b) => a === 169 && b === 254,
+    reason: 'link_local',
+    label: 'IPv4 link-local (169.254/16 — AWS IMDS)',
+  },
+  { match: (a) => a === 0, reason: 'reserved', label: 'IPv4 reserved (0/8)' },
+];
+
+function classifyIPv4(ip: string): RejectionDetail | null {
+  const parts = ip.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return null;
+  const [a, b] = parts as [number, number, number, number];
+  for (const rule of IPV4_RULES) {
+    if (rule.match(a, b)) {
+      return { reason: rule.reason, message: `${rule.label} (${ip})` };
+    }
+  }
+  return null;
+}
+
+function classifyIPv6(ip: string): RejectionDetail | null {
+  const lower = ip.toLowerCase();
+  if (lower === '::1') return { reason: 'loopback', message: `IPv6 loopback (${ip})` };
+  if (lower.startsWith('fe80:'))
+    return { reason: 'link_local', message: `IPv6 link-local (${ip})` };
+  // Unique-local: fc00::/7 → first byte has high bit set and second-high bit set
+  if (/^fc|^fd/.test(lower)) {
+    return { reason: 'private_range', message: `IPv6 unique-local (${ip}, fc00::/7)` };
+  }
+  return null;
+}

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter-custom-openai.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter-custom-openai.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Construction-time tests for the SdkAdapter's custom-openai provider path
+ * (#2120). The constructor validates the base URL immediately; these tests
+ * confirm the validation short-circuits before any network/dependency load.
+ *
+ * Runtime tests (actual SDK calls against a mocked @ai-sdk/openai) are out
+ * of scope here — they'd require mocking the dynamic import and the AI SDK
+ * loader. The `custom-api-validation.test.ts` tests already cover the SSRF
+ * classifier in detail; these tests cover the integration with
+ * SdkAdapterConfig + env-var fallback.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { SdkAdapter } from './sdk-adapter.js';
+import { ConfigError } from '../../core/index.js';
+import { CUSTOM_API_BASE_URL_ENV, CUSTOM_API_ALLOW_PRIVATE_ENV } from './types.js';
+
+describe('SdkAdapter custom-openai provider (#2120)', () => {
+  const origBaseUrl = process.env[CUSTOM_API_BASE_URL_ENV];
+  const origAllowPrivate = process.env[CUSTOM_API_ALLOW_PRIVATE_ENV];
+
+  afterEach(() => {
+    restore(CUSTOM_API_BASE_URL_ENV, origBaseUrl);
+    restore(CUSTOM_API_ALLOW_PRIVATE_ENV, origAllowPrivate);
+  });
+
+  describe('construction-time base URL resolution', () => {
+    it('accepts a public https base URL in config', () => {
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'https://gateway.example.com/v1',
+          })
+      ).not.toThrow();
+    });
+
+    it('falls back to NEXUS_CUSTOM_API_BASE_URL env var when config omits baseUrl', () => {
+      process.env[CUSTOM_API_BASE_URL_ENV] = 'https://gateway.example.com/v1';
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+          })
+      ).not.toThrow();
+    });
+
+    it('throws ConfigError when no base URL is provided anywhere', () => {
+      Reflect.deleteProperty(process.env, CUSTOM_API_BASE_URL_ENV);
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+          })
+      ).toThrow(ConfigError);
+    });
+  });
+
+  describe('SSRF guard applied at construction', () => {
+    it('throws ConfigError for http://localhost', () => {
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'http://localhost:8080/v1',
+          })
+      ).toThrow(/SSRF guard/);
+    });
+
+    it('throws ConfigError for 169.254.169.254 (AWS IMDS)', () => {
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'http://169.254.169.254/',
+          })
+      ).toThrow(/link_local/);
+    });
+
+    it('allows private addresses when NEXUS_CUSTOM_API_ALLOW_PRIVATE=1', () => {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = '1';
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'http://10.0.0.5/v1',
+          })
+      ).not.toThrow();
+    });
+
+    it('rejects non-http(s) protocols', () => {
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'custom-openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'file:///etc/passwd',
+          })
+      ).toThrow(/http or https/);
+    });
+  });
+
+  describe('does not affect other providers', () => {
+    it('openai provider ignores baseUrl param (not a custom gateway)', () => {
+      // If someone accidentally passes baseUrl to the built-in 'openai'
+      // provider, the guard should NOT fire — that's out of scope for
+      // this feature.
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'openai',
+            modelId: 'gpt-4o',
+            apiKey: 'test-key',
+            baseUrl: 'http://localhost/v1',
+          })
+      ).not.toThrow();
+    });
+
+    it('anthropic provider unaffected', () => {
+      expect(
+        () =>
+          new SdkAdapter({
+            providerId: 'anthropic',
+            modelId: 'claude-3-5-sonnet-20241022',
+            apiKey: 'test-key',
+          })
+      ).not.toThrow();
+    });
+  });
+});
+
+function restore(key: string, original: string | undefined): void {
+  if (original === undefined) {
+    Reflect.deleteProperty(process.env, key);
+  } else {
+    process.env[key] = original;
+  }
+}

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -27,7 +27,8 @@ import { BaseAdapter, AdapterModelError } from '../base-adapter.js';
 import { ErrorCode } from '../../core/index.js';
 import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
-import { PROVIDER_ENV_KEYS } from './types.js';
+import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
+import { validateCustomApiBaseUrl } from './custom-api-validation.js';
 
 /** Minimal AI SDK model interface (duck-typed for optional dependency). */
 interface AiSdkModel {
@@ -114,6 +115,22 @@ function resolveApiKey(providerId: SdkProviderId, configKey?: string): string | 
 }
 
 /**
+ * For the `custom-openai` provider only: resolve the base URL (config >
+ * env) and run it through the SSRF guard. Returns `undefined` for every
+ * other provider (the AI SDK's built-in factories handle their own
+ * endpoints). Throws `ConfigError` at construction time for invalid
+ * custom-openai setups — catching misconfiguration immediately rather
+ * than on the first request.
+ */
+function resolveAndValidateCustomBaseUrl(config: SdkAdapterConfig): string | undefined {
+  if (config.providerId !== 'custom-openai') return undefined;
+  const raw = config.baseUrl ?? process.env[CUSTOM_API_BASE_URL_ENV];
+  const validated = validateCustomApiBaseUrl(raw);
+  if (!validated.ok) throw validated.error;
+  return validated.value.toString();
+}
+
+/**
  * Maps AI SDK finish reasons to our StopReason type.
  */
 function mapFinishReason(reason: string): CompletionResponse['stopReason'] {
@@ -159,6 +176,8 @@ export class SdkAdapter extends BaseAdapter {
   private model: AiSdkModel | undefined;
   private sdkFunctions: AiSdkFunctions | undefined;
   private readonly sdkConfig: SdkAdapterConfig;
+  /** Validated base URL for custom-openai provider; undefined for built-ins. */
+  private readonly customBaseUrl: string | undefined;
   /** Inflight init promise for coalescing concurrent calls (Issue #1438). */
   private initPromise: Promise<void> | undefined;
 
@@ -175,6 +194,7 @@ export class SdkAdapter extends BaseAdapter {
     });
     this.sdkProviderId = config.providerId;
     this.sdkConfig = config;
+    this.customBaseUrl = resolveAndValidateCustomBaseUrl(config);
   }
 
   /**
@@ -239,6 +259,18 @@ export class SdkAdapter extends BaseAdapter {
         const mod = await import('@ai-sdk/google');
         const factory = extractProviderFactory(mod, 'createGoogleGenerativeAI');
         const provider = factory({ apiKey });
+        return { model: provider(this.modelId) };
+      }
+      case 'custom-openai': {
+        // OpenAI-compatible gateway (multi-vendor proxies, self-hosted servers,
+        // corporate LLM gateways). Reuses @ai-sdk/openai with a configurable
+        // baseURL. See custom-api-validation.ts for the SSRF guard; the
+        // adapter constructor validates before this method is reached.
+        const mod = await import('@ai-sdk/openai');
+        const factory = extractProviderFactory(mod, 'createOpenAI');
+        const opts: Record<string, unknown> = { apiKey };
+        if (this.customBaseUrl !== undefined) opts['baseURL'] = this.customBaseUrl;
+        const provider = factory(opts);
         return { model: provider(this.modelId) };
       }
     }

--- a/packages/nexus-agents/src/adapters/sdk/types.ts
+++ b/packages/nexus-agents/src/adapters/sdk/types.ts
@@ -9,8 +9,12 @@
 
 /**
  * Supported AI SDK provider identifiers.
+ *
+ * `custom-openai` is for OpenAI-compatible gateways (multi-vendor proxies,
+ * self-hosted LLM servers, corporate model gateways) — uses the same
+ * @ai-sdk/openai package but with a configurable `baseURL`.
  */
-export type SdkProviderId = 'anthropic' | 'openai' | 'google';
+export type SdkProviderId = 'anthropic' | 'openai' | 'google' | 'custom-openai';
 
 /**
  * Configuration for creating an AI SDK adapter.
@@ -22,6 +26,12 @@ export interface SdkAdapterConfig {
   modelId: string;
   /** API key (falls back to environment variable) */
   apiKey?: string;
+  /**
+   * Base URL for OpenAI-compatible gateways. Required when
+   * `providerId === 'custom-openai'`, ignored otherwise. Falls back to
+   * the `NEXUS_CUSTOM_API_BASE_URL` environment variable.
+   */
+  baseUrl?: string;
   /** Request timeout in milliseconds */
   timeout?: number;
   /** Maximum retries on transient failures */
@@ -35,4 +45,19 @@ export const PROVIDER_ENV_KEYS: Record<SdkProviderId, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
   google: 'GOOGLE_AI_API_KEY',
+  'custom-openai': 'NEXUS_CUSTOM_API_KEY',
 };
+
+/**
+ * Environment variable name for the custom gateway base URL.
+ * Keep in sync with `SdkAdapterConfig.baseUrl`.
+ */
+export const CUSTOM_API_BASE_URL_ENV = 'NEXUS_CUSTOM_API_BASE_URL';
+
+/**
+ * Escape hatch: set to `1`/`true` to allow the custom gateway base URL to
+ * resolve to a loopback or RFC 1918 private address. Default is DENY —
+ * SSRF defense. Only disable this when you know the gateway runs on a
+ * trusted internal host and you accept the risk.
+ */
+export const CUSTOM_API_ALLOW_PRIVATE_ENV = 'NEXUS_CUSTOM_API_ALLOW_PRIVATE';


### PR DESCRIPTION
## Summary

Child 1 of epic #2119. Closes #2120.

The `custom-openai` provider is already in the model registry (config/model-capabilities.ts entries `opencode-custom-opus`, `opencode-custom-sonnet`), but the only code path reaching it was through the OpenCode CLI subprocess. This PR adds a **direct SDK path** using the existing @ai-sdk/openai factory with a configurable `baseURL`.

## What you can do now

Three env vars and any auto-adapter caller picks up your gateway:

```bash
export NEXUS_CUSTOM_API_BASE_URL="https://your-gateway.example.com/v1"
export NEXUS_CUSTOM_API_KEY="your-api-key"
export NEXUS_CUSTOM_MODEL="claude-opus-4-5"   # optional
```

No OpenCode required. The gateway must speak OpenAI-compatible chat/completions.

## Security — SSRF guard

The base URL is user-supplied, so without validation the adapter would become an SSRF vector. The constructor rejects:

- Loopback: `127.0.0.0/8`, `::1`, `localhost`, `*.localhost`, `*.local`
- Private RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
- Link-local: `169.254.0.0/16` (AWS IMDS `169.254.169.254`), IPv6 `fe80::/10`
- IPv6 unique-local: `fc00::/7`, `fd00::/7`
- Reserved: `0.0.0.0`
- Non-HTTP(S) protocols: `file://`, `ftp://`, etc.

Escape hatch for trusted internal hosts: `NEXUS_CUSTOM_API_ALLOW_PRIVATE=1`.

Caveat: this is a **string-level** check. DNS rebinding (a public domain that secretly resolves to a private IP) would pass — out of scope for this PR; would need a connect-time peer-address check.

## Tests

```
✓ adapters/sdk/custom-api-validation.test.ts (26 tests)
✓ adapters/sdk/sdk-adapter-custom-openai.test.ts (9 tests)
✓ adapters/sdk/sdk-adapter.test.ts (10 tests — unchanged)
✓ adapters/auto-adapter.test.ts (25 tests — unchanged)
70/70 passing, 0 lint, 0 tsc errors
```

## Docs

`docs/guides/CUSTOM_ENDPOINT_SETUP.md` now has two paths:
- **Path A (new):** Direct SDK — recommended for most cases
- **Path B (existing):** OpenCode transport — for environments already managing creds in OpenCode

## Still ahead in epic #2119

- #2121 move `.claude/rules/` → `.rules/`
- #2122 rewrite AGENTS.md as self-contained
- #2123 HARNESS_COMPATIBILITY.md
- #2124 (deferred) setup wizard extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)