### PR TITLE
feat(setup): nexus-agents setup --custom-api for gateway configuration (closes #2124)

### DIFF
--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -135,6 +135,16 @@ const SETUP_HELP: CommandHelpEntry = {
       defaultValue: 'user',
     },
     { flag: '--dry-run', description: 'Show changes without applying them' },
+    {
+      flag: '--custom-api <url>',
+      description:
+        'Configure OpenAI-compatible gateway (short-circuits normal setup; validates URL + probes /models) [#2124]',
+    },
+    { flag: '--custom-api-key <key>', description: 'API key for --custom-api (else prompt/env)' },
+    {
+      flag: '--custom-model <id>',
+      description: 'Default model for --custom-api (default: gpt-4o)',
+    },
   ],
 };
 

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -380,8 +380,18 @@ export function handleSetupCommand(args: ParsedCliArgs): void {
 /**
  * Handles setup command with interactive wizard support (async version).
  * (Source: Issue #425 - Interactive setup wizard)
+ *
+ * #2124: when `--custom-api <url>` is set, short-circuits the normal flow
+ * and just configures the custom gateway (URL validation + probe + shell
+ * fragment). Rationale: normal setup configures Claude/OpenCode/Codex
+ * MCP hookup; custom-api is orthogonal — the user has a gateway they
+ * want to plug in, not a harness they want to wire up.
  */
 export async function handleSetupCommandAsync(args: ParsedCliArgs): Promise<void> {
+  if (args.options.customApi !== undefined && args.options.customApi !== '') {
+    const exitCode = await runCustomApiSetup(args);
+    process.exit(exitCode);
+  }
   const exitCode = await setupCommandAsync({
     interactive: args.options.interactive,
     nonInteractive: args.options.nonInteractive,
@@ -398,6 +408,31 @@ export async function handleSetupCommandAsync(args: ParsedCliArgs): Promise<void
     scope: args.options.scope === 'project' ? 'project' : 'user',
   });
   process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+}
+
+/** Wrapper for `setup --custom-api` (#2124). */
+async function runCustomApiSetup(args: ParsedCliArgs): Promise<number> {
+  const { configureCustomApi } = await import('./cli/setup-custom-api.js');
+  const baseUrl = args.options.customApi;
+  if (baseUrl === undefined) return EXIT_CODES.SERVER_START_FAILED;
+  const input: Parameters<typeof configureCustomApi>[0] = {
+    baseUrl,
+    nonInteractive: args.options.nonInteractive,
+    ...(args.options.customApiKey !== undefined ? { apiKey: args.options.customApiKey } : {}),
+    ...(args.options.customModel !== undefined ? { model: args.options.customModel } : {}),
+  };
+  const result = await configureCustomApi(input);
+  if (!result.ok) {
+    process.stderr.write(`✗ ${result.error.message}\n`);
+    return EXIT_CODES.SERVER_START_FAILED;
+  }
+  const { baseUrl: canonical, model, probeSucceeded, shellFragment } = result.value;
+  process.stdout.write(`✓ Gateway validated: ${canonical}\n`);
+  process.stdout.write(`✓ Model: ${model}\n`);
+  if (probeSucceeded) process.stdout.write(`✓ Probe succeeded (GET /models → 2xx)\n`);
+  process.stdout.write('\nAdd the following to your shell rc (~/.bashrc, ~/.zshrc, etc.):\n\n');
+  process.stdout.write(shellFragment);
+  return EXIT_CODES.SUCCESS;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -139,6 +139,10 @@ export interface ParsedCliArgs {
     skipGemini: boolean;
     skipCodex: boolean;
     scope?: 'user' | 'project';
+    // Setup --custom-api for OpenAI-compatible gateway configuration (#2124)
+    customApi?: string;
+    customApiKey?: string;
+    customModel?: string;
     // Demo command options
     mock: boolean;
     // Doctor command options (Issue #1031)
@@ -365,6 +369,16 @@ export const PARSE_ARGS_CONFIG = {
     scope: {
       type: 'string' as const,
       default: 'user',
+    },
+    // Setup --custom-api for OpenAI-compatible gateway configuration (#2124)
+    'custom-api': {
+      type: 'string' as const,
+    },
+    'custom-api-key': {
+      type: 'string' as const,
+    },
+    'custom-model': {
+      type: 'string' as const,
     },
     // Demo command options
     mock: {

--- a/packages/nexus-agents/src/cli/setup-custom-api.test.ts
+++ b/packages/nexus-agents/src/cli/setup-custom-api.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { configureCustomApi, type HttpFetcher } from './setup-custom-api.js';
+
+describe('configureCustomApi (#2124)', () => {
+  const originalKey = process.env['NEXUS_CUSTOM_API_KEY'];
+
+  beforeEach(() => {
+    Reflect.deleteProperty(process.env, 'NEXUS_CUSTOM_API_KEY');
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env['NEXUS_CUSTOM_API_KEY'] = originalKey;
+    } else {
+      Reflect.deleteProperty(process.env, 'NEXUS_CUSTOM_API_KEY');
+    }
+  });
+
+  const okFetcher: HttpFetcher = () => Promise.resolve({ status: 200, body: '{"data":[]}' });
+  const unauthorizedFetcher: HttpFetcher = () =>
+    Promise.resolve({ status: 401, body: '{"error":"unauthorized"}' });
+  const serverErrorFetcher: HttpFetcher = () =>
+    Promise.resolve({ status: 500, body: '{"error":"internal"}' });
+  const throwsFetcher: HttpFetcher = () => Promise.reject(new Error('ENOTFOUND'));
+
+  const minimalInput = (
+    overrides: Partial<Parameters<typeof configureCustomApi>[0]> = {}
+  ): Parameters<typeof configureCustomApi>[0] => ({
+    baseUrl: 'https://gateway.example.com/v1',
+    apiKey: 'test-key',
+    nonInteractive: true,
+    fetcher: okFetcher,
+    ...overrides,
+  });
+
+  describe('happy path', () => {
+    it('succeeds end-to-end with a valid gateway', async () => {
+      const result = await configureCustomApi(minimalInput());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.baseUrl).toBe('https://gateway.example.com/v1');
+      expect(result.value.probeSucceeded).toBe(true);
+      expect(result.value.model).toBe('gpt-4o');
+    });
+
+    it('respects a custom model override', async () => {
+      const result = await configureCustomApi(minimalInput({ model: 'claude-opus-4-5' }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.model).toBe('claude-opus-4-5');
+    });
+
+    it('produces a shell fragment the user can paste into their shell rc', async () => {
+      const result = await configureCustomApi(minimalInput());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.shellFragment).toContain('export NEXUS_CUSTOM_API_BASE_URL=');
+      expect(result.value.shellFragment).toContain('export NEXUS_CUSTOM_API_KEY=');
+      expect(result.value.shellFragment).toContain('export NEXUS_CUSTOM_MODEL=');
+      expect(result.value.shellFragment).toContain('test-key');
+      expect(result.value.shellFragment).toContain('gateway.example.com');
+    });
+
+    it('includes NEXUS_CUSTOM_API_ALLOW_PRIVATE export when allowPrivate is set', async () => {
+      const result = await configureCustomApi(
+        minimalInput({ baseUrl: 'http://10.0.0.5/v1', allowPrivate: true })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.shellFragment).toContain('NEXUS_CUSTOM_API_ALLOW_PRIVATE=1');
+    });
+  });
+
+  describe('URL validation (reuses #2125 SSRF guard)', () => {
+    it('rejects loopback without allowPrivate', async () => {
+      const result = await configureCustomApi(minimalInput({ baseUrl: 'http://localhost/v1' }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/loopback/);
+    });
+
+    it('rejects non-http(s) protocols', async () => {
+      const result = await configureCustomApi(minimalInput({ baseUrl: 'file:///etc/passwd' }));
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects garbage input', async () => {
+      const result = await configureCustomApi(minimalInput({ baseUrl: 'not-a-url' }));
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('API key resolution', () => {
+    it('uses the provided apiKey when passed explicitly', async () => {
+      const result = await configureCustomApi(minimalInput({ apiKey: 'explicit-key' }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.shellFragment).toContain('explicit-key');
+    });
+
+    it('falls back to NEXUS_CUSTOM_API_KEY env var', async () => {
+      process.env['NEXUS_CUSTOM_API_KEY'] = 'from-env';
+      const { apiKey: _apiKey, ...rest } = minimalInput();
+      void _apiKey;
+      const result = await configureCustomApi(rest);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.shellFragment).toContain('from-env');
+    });
+
+    it('fails cleanly in non-interactive mode when no key is available', async () => {
+      const { apiKey: _apiKey, ...rest } = minimalInput();
+      void _apiKey;
+      const result = await configureCustomApi(rest);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/API key required/i);
+    });
+  });
+
+  describe('probe error handling', () => {
+    it('reports unauthorized with actionable guidance', async () => {
+      const result = await configureCustomApi(minimalInput({ fetcher: unauthorizedFetcher }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/probe failed/i);
+      expect(result.error.message).toMatch(/api key has \/models read scope/i);
+    });
+
+    it('reports 5xx with same actionable guidance', async () => {
+      const result = await configureCustomApi(minimalInput({ fetcher: serverErrorFetcher }));
+      expect(result.ok).toBe(false);
+    });
+
+    it('swallows network-layer exceptions into a structured failure', async () => {
+      const result = await configureCustomApi(minimalInput({ fetcher: throwsFetcher }));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/probe failed/i);
+    });
+
+    it('skips the probe entirely when skipProbe is true', async () => {
+      const result = await configureCustomApi(
+        minimalInput({ skipProbe: true, fetcher: throwsFetcher })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.probeSucceeded).toBe(false);
+    });
+  });
+
+  describe('probe URL construction', () => {
+    it('appends /models to the base URL (stripping trailing slash)', async () => {
+      const probed: string[] = [];
+      const recordingFetcher: HttpFetcher = (url) => {
+        probed.push(url);
+        return Promise.resolve({ status: 200, body: '{}' });
+      };
+      await configureCustomApi(
+        minimalInput({ baseUrl: 'https://gateway.example.com/v1/', fetcher: recordingFetcher })
+      );
+      expect(probed[0]).toBe('https://gateway.example.com/v1/models');
+    });
+
+    it('sends Authorization: Bearer <key>', async () => {
+      let capturedAuth = '';
+      const recordingFetcher: HttpFetcher = (_, init) => {
+        capturedAuth = init.headers['Authorization'] ?? '';
+        return Promise.resolve({ status: 200, body: '{}' });
+      };
+      await configureCustomApi(minimalInput({ apiKey: 'secret-key', fetcher: recordingFetcher }));
+      expect(capturedAuth).toBe('Bearer secret-key');
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli/setup-custom-api.ts
+++ b/packages/nexus-agents/src/cli/setup-custom-api.ts
@@ -1,0 +1,203 @@
+/**
+ * Interactive setup for a custom OpenAI-compatible gateway (#2124).
+ *
+ * Closes the last child of epic #2119. The runtime adapter (#2125) is
+ * already live — this module is the ergonomics layer: a single command
+ * that validates the URL, probes connectivity, and tells the user
+ * exactly what env vars to set for their shell.
+ *
+ * Writes nothing by default (dry-run is the safe behavior for a CLI
+ * that touches shell state). Prints the shell fragment; user copies
+ * it into ~/.bashrc / ~/.zshrc / ~/.config/fish/config.fish. Rationale:
+ * harness-neutral — we don't know which shell the user runs or where
+ * their nexus-agents.yaml lives.
+ *
+ * @module cli/setup-custom-api
+ */
+
+import { createInterface } from 'node:readline';
+import { validateCustomApiBaseUrl } from '../adapters/sdk/custom-api-validation.js';
+import { CUSTOM_API_BASE_URL_ENV, CUSTOM_API_ALLOW_PRIVATE_ENV } from '../adapters/sdk/types.js';
+import { ok, err, type Result } from '../core/index.js';
+
+/** Inputs to `configureCustomApi`. */
+export interface CustomApiSetupInput {
+  /** Gateway base URL (required). SSRF guard from adapters/sdk is applied. */
+  readonly baseUrl: string;
+  /** API key. If absent, `configureCustomApi` will prompt (or fail non-interactively). */
+  readonly apiKey?: string;
+  /** Model id to default to. Omitted → documented fallback "gpt-4o". */
+  readonly model?: string;
+  /** Skip the TTY prompt for the API key — useful for CI and scripting. */
+  readonly nonInteractive?: boolean;
+  /** Omit HTTP probe — useful for dry-run / offline verify. */
+  readonly skipProbe?: boolean;
+  /** Allow private / loopback base URLs (overrides the SSRF guard). */
+  readonly allowPrivate?: boolean;
+  /** Stream for prompts/output. Defaults to process.stdout / stdin. */
+  readonly stream?: { readonly output: NodeJS.WritableStream };
+  /**
+   * Pluggable HTTP fetcher for tests. Defaults to global fetch.
+   * Called as `fetch(url, { headers })`; should return `{ status, body }`.
+   */
+  readonly fetcher?: HttpFetcher;
+}
+
+/** Minimal HTTP fetcher shape — lets tests inject a mock without network. */
+export type HttpFetcher = (
+  url: string,
+  init: { readonly headers: Readonly<Record<string, string>> }
+) => Promise<{ readonly status: number; readonly body: string }>;
+
+/** Outcome of `configureCustomApi`. */
+export interface CustomApiSetupResult {
+  /** Validated base URL (may differ trivially from input — e.g. canonical form). */
+  readonly baseUrl: string;
+  /** Resolved model id. */
+  readonly model: string;
+  /** Whether the /v1/models probe succeeded (always true unless skipped). */
+  readonly probeSucceeded: boolean;
+  /**
+   * Shell fragment the user should add to their shell rc so nexus-agents
+   * picks up the gateway on subsequent invocations. Already-set env
+   * equivalents of these lines are all that's needed at runtime.
+   */
+  readonly shellFragment: string;
+}
+
+const DEFAULT_MODEL = 'gpt-4o';
+
+/**
+ * Configures a custom OpenAI-compatible gateway.
+ *
+ * Steps:
+ * 1. Validate base URL via the SSRF guard (same as the runtime adapter).
+ * 2. Resolve the API key (from input, env, or TTY prompt).
+ * 3. Probe `GET {baseUrl}/models` with Bearer auth to confirm connectivity.
+ * 4. Emit the shell-fragment the user adds to their shell rc.
+ *
+ * Returns an `ok` Result on success, or a `ConfigError`-bearing `err`
+ * Result on any failure (invalid URL, missing API key in non-interactive,
+ * probe failure). Never throws.
+ */
+export async function configureCustomApi(
+  input: CustomApiSetupInput
+): Promise<Result<CustomApiSetupResult, Error>> {
+  const urlValidation = validateCustomApiBaseUrl(input.baseUrl, {
+    ...(input.allowPrivate === true ? { allowPrivate: true } : {}),
+  });
+  if (!urlValidation.ok) return err(urlValidation.error);
+  const baseUrl = urlValidation.value.toString();
+
+  const apiKeyResult = await resolveApiKey(input);
+  if (!apiKeyResult.ok) return err(apiKeyResult.error);
+  const apiKey = apiKeyResult.value;
+
+  const probeSucceeded = input.skipProbe === true ? false : await runProbe(baseUrl, apiKey, input);
+  if (input.skipProbe !== true && !probeSucceeded) {
+    return err(
+      new Error(
+        `Gateway probe failed: GET ${stripTrailingSlash(baseUrl)}/models did not return 2xx. ` +
+          `Check that the URL is the chat-completions base (typically ends with /v1) and the API key has /models read scope.`
+      )
+    );
+  }
+
+  const model = input.model ?? DEFAULT_MODEL;
+  return ok({
+    baseUrl,
+    model,
+    probeSucceeded,
+    shellFragment: buildShellFragment({ baseUrl, apiKey, model, allowPrivate: input.allowPrivate }),
+  });
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+/**
+ * Performs the /v1/models probe. Returns true on any 2xx response.
+ * Swallows errors into `false` — the caller reports the failure.
+ */
+async function runProbe(
+  baseUrl: string,
+  apiKey: string,
+  input: CustomApiSetupInput
+): Promise<boolean> {
+  const url = `${stripTrailingSlash(baseUrl)}/models`;
+  const fetcher = input.fetcher ?? defaultFetcher;
+  try {
+    const res = await fetcher(url, {
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' },
+    });
+    return res.status >= 200 && res.status < 300;
+  } catch {
+    return false;
+  }
+}
+
+const defaultFetcher: HttpFetcher = async (url, init) => {
+  const res = await fetch(url, { headers: init.headers });
+  const body = await res.text();
+  return { status: res.status, body };
+};
+
+/**
+ * Resolves the API key in priority order: input → env var → TTY prompt
+ * (unless non-interactive, in which case the absence is a fail).
+ */
+async function resolveApiKey(input: CustomApiSetupInput): Promise<Result<string, Error>> {
+  if (input.apiKey !== undefined && input.apiKey !== '') return ok(input.apiKey);
+  const envKey = process.env['NEXUS_CUSTOM_API_KEY'];
+  if (envKey !== undefined && envKey !== '') return ok(envKey);
+  if (input.nonInteractive === true) {
+    return err(
+      new Error(
+        'Custom API key required but not provided. Pass --custom-api-key or set NEXUS_CUSTOM_API_KEY.'
+      )
+    );
+  }
+  const prompted = await promptForApiKey(input.stream?.output ?? process.stdout);
+  if (prompted === '') {
+    return err(new Error('No API key entered; aborting.'));
+  }
+  return ok(prompted);
+}
+
+async function promptForApiKey(out: NodeJS.WritableStream): Promise<string> {
+  out.write('Enter the API key for your custom gateway: ');
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+  try {
+    return await new Promise<string>((resolve) => {
+      rl.question('', (answer) => {
+        resolve(answer.trim());
+      });
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Formats the shell fragment the user should paste into their shell rc.
+ * Designed to be POSIX-portable; fish users can adapt `export` to `set -gx`.
+ */
+function buildShellFragment(params: {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly model: string;
+  readonly allowPrivate: boolean | undefined;
+}): string {
+  const { baseUrl, apiKey, model, allowPrivate } = params;
+  const lines: string[] = [
+    '# nexus-agents custom-openai gateway (nexus-agents setup --custom-api)',
+    `export ${CUSTOM_API_BASE_URL_ENV}="${baseUrl}"`,
+    `export NEXUS_CUSTOM_API_KEY="${apiKey}"`,
+    `export NEXUS_CUSTOM_MODEL="${model}"`,
+  ];
+  if (allowPrivate === true) {
+    lines.push(`export ${CUSTOM_API_ALLOW_PRIVATE_ENV}=1   # SSRF-guard bypass`);
+  }
+  return lines.join('\n') + '\n';
+}


### PR DESCRIPTION
## Summary

Closes #2124 — the last deferred child of epic #2119.

The runtime adapter (#2125, v2.55.0) lets nexus-agents talk to an OpenAI-compatible gateway via env vars. This PR is the **ergonomics layer**: a single command that validates the URL, probes connectivity, and tells you exactly what to put in your shell rc.

## Usage

```bash
$ nexus-agents setup --custom-api https://gw.example.com/v1 \
    --custom-api-key $MY_KEY --custom-model claude-opus-4-5
✓ Gateway validated: https://gw.example.com/v1
✓ Model: claude-opus-4-5
✓ Probe succeeded (GET /models → 2xx)

Add the following to your shell rc (~/.bashrc, ~/.zshrc, etc.):

# nexus-agents custom-openai gateway (nexus-agents setup --custom-api)
export NEXUS_CUSTOM_API_BASE_URL="https://gw.example.com/v1"
export NEXUS_CUSTOM_API_KEY="$MY_KEY"
export NEXUS_CUSTOM_MODEL="claude-opus-4-5"
```

## Design

`--custom-api <url>` **short-circuits** the normal setup flow (which wires Claude/OpenCode/Codex MCP integrations — a separate concern). Custom-api is orthogonal to harness wiring.

### Steps

1. Validate base URL via the SSRF guard from #2125 — same rejection rules (loopback, RFC 1918, link-local, AWS IMDS, IPv6 equivalents, non-http(s)).
2. Resolve API key: `--custom-api-key` flag → `NEXUS_CUSTOM_API_KEY` env var → TTY prompt (or fail if `--non-interactive`).
3. Probe `GET {baseUrl}/models` with `Bearer` auth. 2xx → success; anything else → actionable error pointing at the most likely causes (wrong URL, /models scope missing).
4. Print a POSIX shell fragment the user pastes into `~/.bashrc` / `~/.zshrc` / fish config.

### Why print instead of write?

We don't know which shell the user runs, or where their secrets manager lives. Writing `nexus-agents.yaml` would be a second code path reading the same info — the runtime adapter already reads the env vars. Shell fragments compose with `dotenv`, `direnv`, 1Password CLI, etc., without extra infra.

## Files

- `cli/setup-custom-api.ts` (new) — `configureCustomApi()` + `HttpFetcher` injection seam
- `cli/setup-custom-api.test.ts` (new) — **16 tests**: happy path, URL validation (reuses #2125 SSRF guard), API key resolution precedence, probe error shapes (401, 5xx, network throw, skip), probe URL construction (trailing slash, Bearer header)
- `cli-commands-handlers.ts` — `handleSetupCommandAsync` short-circuits to the new flow
- `cli-types.ts` — three new flags (`customApi`, `customApiKey`, `customModel`)
- `cli-command-help.ts` — flags documented

## Verification

```
✓ cli/setup-custom-api.test.ts (16 tests)
✓ cli-commands-handlers.test.ts (unchanged, 16 tests)
32/32 green, 0 lint, 0 tsc errors
```

## Closes

Epic #2119 is already closed; this closes the last deferred child #2124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)