### PR TITLE
feat(setup): post-setup health gate with actionable remediation (closes #2137)

### DIFF
--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -39,6 +39,11 @@ import { detectCodexCli, configureCodex } from './setup-codex.js';
 import { VERSION } from '../version.js';
 import { runWizard } from './setup-wizard.js';
 import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-permissions.js';
+// #2137: post-setup health gate. Surfaces install-time issues that are easy
+// to miss (better-sqlite3 native build, missing API keys, unwritable data
+// dirs) inline at the end of setup, with copy-pasteable remediation.
+import { runVerify } from './verify-command.js';
+import { colors, symbols } from './ansi-output.js';
 
 // ============================================================================
 // Output Helpers
@@ -795,6 +800,61 @@ export function printSetupResult(result: SetupResult, verbose: boolean): void {
 }
 
 /**
+ * Runs the post-setup health gate (#2137).
+ *
+ * After setup writes its files, this runs the verify checks and prints a
+ * structured health summary inline. Returns `true` when no `severity: 'hard'`
+ * checks failed — warnings still pass the gate.
+ *
+ * In `--dry-run` mode, the gate is skipped entirely (the user is previewing,
+ * not actually installing).
+ */
+async function runPostSetupHealthGate(dryRun: boolean): Promise<boolean> {
+  if (dryRun) return true;
+
+  const result = await runVerify();
+  const passed = result.checks.filter((c) => c.passed).length;
+  const total = result.checks.length;
+
+  writeEmptyLine();
+  writeLine(formatHeader(`Health check (${String(passed)}/${String(total)} passed)`));
+  writeLine('─'.repeat(40));
+
+  for (const check of result.checks) {
+    let symbol: string;
+    if (check.passed) {
+      symbol = `${colors.green}${symbols.check}${colors.reset}`;
+    } else if (check.severity === 'warn') {
+      symbol = `${colors.yellow}${symbols.warn}${colors.reset}`;
+    } else {
+      symbol = `${colors.red}${symbols.cross}${colors.reset}`;
+    }
+    writeLine(`  ${symbol} ${check.name}: ${check.message}`);
+    if (!check.passed && check.fix !== undefined) {
+      writeLine(`     ${colors.dim}→ Fix: ${check.fix}${colors.reset}`);
+    }
+  }
+
+  writeEmptyLine();
+  if (!result.noHardFailures) {
+    writeLine(
+      `${colors.red}${colors.bold}Action required: fix the blocking issues above before using nexus-agents.${colors.reset}`
+    );
+  } else if (!result.allPassed) {
+    const warnCount = result.checks.filter((c) => !c.passed).length;
+    writeLine(
+      `${colors.yellow}${colors.bold}Setup complete with ${String(warnCount)} warning(s) — nexus-agents will run but some features are degraded.${colors.reset}`
+    );
+  } else {
+    writeLine(
+      `${colors.green}${colors.bold}All health checks passed. nexus-agents is ready.${colors.reset}`
+    );
+  }
+
+  return result.noHardFailures;
+}
+
+/**
  * Setup command entry point (synchronous, non-interactive).
  *
  * @returns Exit code (0 = success, 1 = failure)
@@ -824,29 +884,41 @@ export interface SetupCommandOptions extends Partial<SetupOptions> {
  * Setup command entry point with interactive wizard support.
  * (Source: Issue #425 - Interactive setup wizard)
  *
- * @returns Exit code (0 = success, 1 = failure)
+ * Also runs the post-setup health gate (#2137): after the configuration
+ * steps complete, calls into `runVerify()` to surface install-time issues
+ * that are easy to miss but break things at runtime (better-sqlite3 native
+ * build, data dir writability, missing API keys). Health-gate warnings do
+ * NOT fail setup — only `severity: 'hard'` failures do.
+ *
+ * @returns Exit code (0 = setup + no hard health failures, 1 = either failed)
  */
+/**
+ * Runs the interactive wizard branch and returns its exit code.
+ * Extracted from `setupCommandAsync` to keep cyclomatic complexity ≤10.
+ */
+async function runInteractiveSetup(options: SetupCommandOptions): Promise<number> {
+  const wizardOptions = await runWizard();
+  if (wizardOptions === undefined) return 1; // User cancelled.
+
+  const mergedOptions = { ...options, ...wizardOptions };
+  delete mergedOptions.interactive;
+
+  const result = runSetup(mergedOptions);
+  printSetupResult(result, mergedOptions.verbose ?? false);
+  const healthOk = await runPostSetupHealthGate(mergedOptions.dryRun ?? false);
+  return result.success && healthOk ? 0 : 1;
+}
+
 export async function setupCommandAsync(options: SetupCommandOptions = {}): Promise<number> {
-  // Run interactive wizard if requested
   if (options.interactive === true) {
-    const wizardOptions = await runWizard();
-
-    if (wizardOptions === undefined) {
-      // User cancelled the wizard
-      return 1;
-    }
-
-    // Merge wizard options with any existing options (wizard options take precedence)
-    const mergedOptions = { ...options, ...wizardOptions };
-    delete mergedOptions.interactive; // Remove interactive flag
-
-    const result = runSetup(mergedOptions);
-    printSetupResult(result, mergedOptions.verbose ?? false);
-    return result.success ? 0 : 1;
+    return runInteractiveSetup(options);
   }
 
-  // Fall back to synchronous command
-  return setupCommand(options);
+  // Sync setup, then run the health gate.
+  const setupExitCode = setupCommand(options);
+  const healthOk = await runPostSetupHealthGate(options.dryRun ?? false);
+  // Hard health failures override a successful setup; warnings don't.
+  return setupExitCode !== 0 || !healthOk ? 1 : 0;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/cli/setup-health-gate.test.ts
+++ b/packages/nexus-agents/src/cli/setup-health-gate.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the post-setup health gate (#2137).
+ *
+ * Verifies that `setupCommandAsync` runs the verify checks at the end and
+ * that warn-only failures don't change the exit code (only `severity: 'hard'`
+ * failures do). End-to-end: stubs the verify result via module mocking so we
+ * don't depend on the host environment.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process so setup's CLI detection doesn't shell out (perf, isolation).
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(() => {
+      throw new Error('not found');
+    }),
+    execFileSync: vi.fn(() => {
+      throw new Error('not found');
+    }),
+  };
+});
+
+// Mock verify-command so we control what the health gate sees.
+vi.mock('./verify-command.js', () => ({
+  runVerify: vi.fn(),
+}));
+
+import { setupCommandAsync } from './setup-command.js';
+import { runVerify } from './verify-command.js';
+import type { VerifyResult } from './verify-command.js';
+
+const mockedRunVerify = vi.mocked(runVerify);
+
+/** Helper: build a VerifyResult quickly for the gate to render. */
+function makeVerifyResult(checks: VerifyResult['checks'], noHardFailures: boolean): VerifyResult {
+  return {
+    version: '2.55.1',
+    nodeVersion: 'v22.0.0',
+    checks,
+    allPassed: checks.every((c) => c.passed),
+    noHardFailures,
+    durationMs: 1,
+  };
+}
+
+/** Captures stdout writes for the duration of `fn`. */
+async function captureStdout(fn: () => Promise<unknown>): Promise<string> {
+  const writes: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString());
+    return true;
+  });
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return writes.join('');
+}
+
+describe('setup health gate (#2137)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('runs verify after setup and prints the structured health summary', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult(
+        [
+          { name: 'Node.js Version', passed: true, message: 'v22.0.0' },
+          { name: 'SQLite Storage', passed: true, message: 'OK' },
+        ],
+        true
+      )
+    );
+
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(mockedRunVerify).toHaveBeenCalledTimes(1);
+    expect(output).toContain('Health check (2/2 passed)');
+    expect(output).toContain('Node.js Version');
+    expect(output).toContain('SQLite Storage');
+    expect(output).toContain('All health checks passed');
+  });
+
+  it('skips the health gate entirely in --dry-run mode (preview, not install)', async () => {
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        dryRun: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(mockedRunVerify).not.toHaveBeenCalled();
+    expect(output).not.toContain('Health check');
+  });
+
+  it('renders warn-severity failures with the ⚠ symbol and remediation text', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult(
+        [
+          { name: 'Node.js Version', passed: true, message: 'v22.0.0' },
+          {
+            name: 'SQLite Storage',
+            passed: false,
+            severity: 'warn',
+            message: 'better-sqlite3 not installed',
+            fix: 'pnpm rebuild better-sqlite3',
+          },
+        ],
+        true
+      )
+    );
+
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(output).toContain('Health check (1/2 passed)');
+    expect(output).toContain('better-sqlite3 not installed');
+    expect(output).toContain('→ Fix: pnpm rebuild better-sqlite3');
+    expect(output).toMatch(/warning\(s\) — nexus-agents will run/);
+  });
+
+  it('renders hard-severity failures with the ✗ symbol and "Action required" message', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult(
+        [
+          {
+            name: 'Node.js Version',
+            passed: false,
+            severity: 'hard',
+            message: 'v18.0.0 (unsupported)',
+            fix: 'Install Node.js 22.x LTS',
+          },
+        ],
+        false
+      )
+    );
+
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(output).toContain('Action required');
+    expect(output).toContain('v18.0.0 (unsupported)');
+    expect(output).toContain('→ Fix: Install Node.js 22.x LTS');
+  });
+
+  it('returns exit 0 when only warn-severity health checks failed', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult(
+        [
+          { name: 'OK', passed: true, message: 'ok' },
+          {
+            name: 'Adapter Availability',
+            passed: false,
+            severity: 'warn',
+            message: 'no API keys configured',
+            fix: 'set ANTHROPIC_API_KEY',
+          },
+        ],
+        true
+      )
+    );
+
+    const exitCode = await setupCommandAsync({
+      nonInteractive: true,
+      skipMcp: true,
+      skipRules: true,
+      skipHooks: true,
+      skipConfig: true,
+      skipOpencode: true,
+      skipGemini: true,
+      skipCodex: true,
+    });
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('returns exit 1 when a hard-severity health check failed', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult(
+        [
+          {
+            name: 'Node.js Version',
+            passed: false,
+            severity: 'hard',
+            message: 'v18 unsupported',
+          },
+        ],
+        false
+      )
+    );
+
+    const exitCode = await setupCommandAsync({
+      nonInteractive: true,
+      skipMcp: true,
+      skipRules: true,
+      skipHooks: true,
+      skipConfig: true,
+      skipOpencode: true,
+      skipGemini: true,
+      skipCodex: true,
+    });
+
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

After \`nexus-agents setup\` writes its config files, runs the verify checks inline so install-time issues that are easy to miss surface with copy-pasteable fixes right where the user just ran setup.

Third child of epic #2134. **Stacked on #2140** (it consumes the new \`severity\` and \`noHardFailures\` fields added there). Once #2140 merges, GitHub will auto-rebase the base.

## Why

Today \`nexus-agents setup\` finishes with "✓ Setup completed successfully!" and the user has to know to run \`doctor\` separately to learn that better-sqlite3 didn't compile, no API keys are set, or the data dirs aren't writable. The fixes are easy — the discovery is the painful part.

## Output (warn-only example, no API key configured)

\`\`\`
✓ Setup completed successfully!

Health check (6/7 passed)
────────────────────────────────────────
  ✓ Node.js Version: v22.22.0 (LTS)
  ✓ Package Exports: All core modules accessible
  ✓ Configuration: Default config accessible
  ✓ Expert System: 12 expert types available
  ✓ SQLite Storage: better-sqlite3 loaded
  ✓ Data Directories: /home/user/.nexus-agents (all subdirectories writable)
  ⚠ Adapter Availability: No API keys configured (...)
     → Fix: Set at least one API key, or install a CLI ...

Setup complete with 1 warning(s) — nexus-agents will run but some features are degraded.
\`\`\`

Exit code: \`0\` (warning only).

## Design

- **Reuses runVerify() from #2136** — no parallel implementation.
- **Severity-aware exit codes**: only \`severity: 'hard'\` failures flip the exit code. Warnings (no API keys, missing better-sqlite3) print but exit 0.
- **\`--dry-run\` skips the gate entirely** — preview is preview, not install.
- **Cyclomatic complexity**: extracted the interactive branch into \`runInteractiveSetup\` to keep \`setupCommandAsync\` ≤ 10 (governance threshold).

## Test plan

- [x] 6 new tests in \`setup-health-gate.test.ts\` cover: structured rendering, dry-run skip, warn rendering, hard rendering, exit-code contract for warn vs hard
- [x] All 60 existing setup-command.test.ts tests still pass
- [x] Smoke-tested locally: warn path exits 0 with ⚠ symbol; success path shows "All health checks passed"; dry-run produces no Health check section
- [x] Typecheck + lint clean

Closes #2137. Epic: #2134. Depends on #2140 (base branch will retarget when that merges).