### PR TITLE
feat(setup): getting-started banner at end of setup (closes #2138)

### DIFF
--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -800,6 +800,35 @@ export function printSetupResult(result: SetupResult, verbose: boolean): void {
 }
 
 /**
+ * Prints the post-setup "Getting Started" banner (#2138).
+ *
+ * Three numbered steps tailored to what setup actually configured. If Claude
+ * Code's MCP wiring succeeded we point step 2 at the integrated harness
+ * (`/mcp` in Claude); otherwise we suggest the standalone `orchestrate`
+ * command. Always shown after a successful setup — printing 3 lines is not
+ * worth gating on first-run detection.
+ *
+ * @param mcpConfigured - True when an MCP harness (Claude/etc.) was wired up.
+ */
+function printGettingStartedBanner(mcpConfigured: boolean): void {
+  writeEmptyLine();
+  writeLine(formatHeader('Getting started'));
+  writeLine('─'.repeat(40));
+
+  writeLine('  1. nexus-agents hello             — guided tour (no API keys needed)');
+  if (mcpConfigured) {
+    writeLine('  2. Use through Claude Code        — type /mcp in Claude to list tools');
+  } else {
+    writeLine('  2. nexus-agents orchestrate "..."  — run your first task');
+  }
+  writeLine('  3. nexus-agents workflow list     — explore built-in workflows');
+
+  writeEmptyLine();
+  writeLine(`  ${colors.dim}Docs: https://github.com/williamzujkowski/nexus-agents${colors.reset}`);
+  writeLine(`  ${colors.dim}Harness wiring: docs/guides/HARNESS_COMPATIBILITY.md${colors.reset}`);
+}
+
+/**
  * Runs the post-setup health gate (#2137).
  *
  * After setup writes its files, this runs the verify checks and prints a
@@ -906,6 +935,9 @@ async function runInteractiveSetup(options: SetupCommandOptions): Promise<number
   const result = runSetup(mergedOptions);
   printSetupResult(result, mergedOptions.verbose ?? false);
   const healthOk = await runPostSetupHealthGate(mergedOptions.dryRun ?? false);
+  if (result.success && !(mergedOptions.dryRun ?? false)) {
+    printGettingStartedBanner(result.mcpConfigured === true);
+  }
   return result.success && healthOk ? 0 : 1;
 }
 
@@ -914,11 +946,34 @@ export async function setupCommandAsync(options: SetupCommandOptions = {}): Prom
     return runInteractiveSetup(options);
   }
 
-  // Sync setup, then run the health gate.
-  const setupExitCode = setupCommand(options);
+  // Sync setup, then run the health gate, then print the getting-started banner.
+  const setupResult = runSetupAndPrint(options);
   const healthOk = await runPostSetupHealthGate(options.dryRun ?? false);
+  if (setupResult.exitCode === 0 && !(options.dryRun ?? false)) {
+    printGettingStartedBanner(setupResult.mcpConfigured);
+  }
   // Hard health failures override a successful setup; warnings don't.
-  return setupExitCode !== 0 || !healthOk ? 1 : 0;
+  return setupResult.exitCode !== 0 || !healthOk ? 1 : 0;
+}
+
+/**
+ * Runs setupCommand and captures both the exit code and the
+ * `mcpConfigured` signal we need for the banner. Wraps the existing
+ * synchronous path without changing its signature.
+ */
+function runSetupAndPrint(options: SetupCommandOptions): {
+  exitCode: number;
+  mcpConfigured: boolean;
+} {
+  const parsedOptions = SetupOptionsSchema.parse(options);
+  if (!isInteractive() && !parsedOptions.nonInteractive) {
+    writeLine('Non-interactive environment detected.');
+    writeLine('Run with --non-interactive or set CI=true.');
+    return { exitCode: 1, mcpConfigured: false };
+  }
+  const result = runSetup(options);
+  printSetupResult(result, parsedOptions.verbose);
+  return { exitCode: result.success ? 0 : 1, mcpConfigured: result.mcpConfigured === true };
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/cli/setup-health-gate.test.ts
+++ b/packages/nexus-agents/src/cli/setup-health-gate.test.ts
@@ -221,6 +221,51 @@ describe('setup health gate (#2137)', () => {
     expect(exitCode).toBe(0);
   });
 
+  it('prints the Getting Started banner after a successful setup (#2138)', async () => {
+    mockedRunVerify.mockResolvedValueOnce(
+      makeVerifyResult([{ name: 'OK', passed: true, message: 'ok' }], true)
+    );
+
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(output).toContain('Getting started');
+    expect(output).toContain('1. nexus-agents hello');
+    expect(output).toContain('3. nexus-agents workflow list');
+    expect(output).toContain('Docs: https://github.com/williamzujkowski/nexus-agents');
+    // Default (no MCP wired) → step 2 is the standalone orchestrate hint.
+    expect(output).toContain('2. nexus-agents orchestrate');
+    expect(output).not.toContain('Use through Claude Code');
+  });
+
+  it('omits the Getting Started banner in --dry-run mode (#2138)', async () => {
+    const output = await captureStdout(async () => {
+      await setupCommandAsync({
+        nonInteractive: true,
+        dryRun: true,
+        skipMcp: true,
+        skipRules: true,
+        skipHooks: true,
+        skipConfig: true,
+        skipOpencode: true,
+        skipGemini: true,
+        skipCodex: true,
+      });
+    });
+
+    expect(output).not.toContain('Getting started');
+  });
+
   it('returns exit 1 when a hard-severity health check failed', async () => {
     mockedRunVerify.mockResolvedValueOnce(
       makeVerifyResult(


### PR DESCRIPTION
## Summary

After the post-setup health gate (#2141), print a 3-line numbered banner with concrete next commands. Step 2 adapts based on whether MCP was wired up.

Final child of epic #2134. **Stacked on #2141** (which is stacked on #2140).

## Output

After successful setup with no MCP harness wired:

\`\`\`
Getting started
────────────────────────────────────────
  1. nexus-agents hello             — guided tour (no API keys needed)
  2. nexus-agents orchestrate "..."  — run your first task
  3. nexus-agents workflow list     — explore built-in workflows

  Docs: https://github.com/williamzujkowski/nexus-agents
  Harness wiring: docs/guides/HARNESS_COMPATIBILITY.md
\`\`\`

If MCP was successfully configured, step 2 becomes:
\`\`\`
  2. Use through Claude Code        — type /mcp in Claude to list tools
\`\`\`

Skipped in \`--dry-run\` mode.

## Test plan

- [x] 2 new tests in \`setup-health-gate.test.ts\` cover banner shown after success and banner suppressed in dry-run (8 total in that file)
- [x] All 60 existing setup-command.test.ts still pass
- [x] Smoke-tested: banner appears after \`Health check\` block when setup succeeds
- [x] Typecheck + lint clean

Closes #2138. Epic: #2134. Stacked on #2141 (#2140 → #2141 → this).