### PR TITLE
fix(indexer): load cli-help-text.ts so entrypoint extractor finds HELP_TEXT

### DIFF
--- a/docs/.generated/entrypoints.yaml
+++ b/docs/.generated/entrypoints.yaml
@@ -1,6 +1,141 @@
 schema_version: '1.0'
-generated_at: 04/04/2026, 00:11:17
-cli_commands: []
+generated_at: 04/22/2026, 02:58:28
+cli_commands:
+  - name: hello
+    description: Show welcome message and quick start (no API keys needed)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: demo
+    description: API-free exploration mode (no API keys needed)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: setup
+    description: Configure Claude CLI integration (MCP + CLAUDE.md rules)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: verify
+    description: Quick installation verification (no API keys needed)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: doctor
+    description: Check CLI installations and health status
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: config
+    description: Manage configuration (init, get, set, list, reset, export, import)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: expert
+    description: List available experts (built-in and custom)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+    subcommands:
+      - list
+  - name: workflow
+    description: List available workflow templates
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+    subcommands:
+      - list
+      - run
+  - name: review
+    description: Review a GitHub pull request (dogfooding)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+    subcommands:
+      - <url>
+  - name: routing-audit
+    description: Debug model routing decisions
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: orchestrate
+    description: Execute task using CLI tools (standalone mode)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: vote
+    description: Run consensus vote on a proposal (6 agents)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: system-review
+    description: Run automated system review (5-phase checklist)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: sprint
+    description: Automated sprint planning from open issues
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: session
+    description: Manage session persistence (list, show, export, delete, prune)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: evaluate
+    description: Self-evaluation of codebase components
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: issue
+    description: Issue template validation and management
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: index
+    description: Generate and manage codebase index
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: research
+    description: Manage research registry and index
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: validation
+    description: Show learning validation dashboard
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: swe-bench
+    description: Run SWE-bench evaluation benchmark
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: atbench
+    description: Run ATBench trajectory-safety evaluation (#1981)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: hooks
+    description: Claude CLI hook integration commands
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: fitness-audit
+    description: Run CLI orchestration fitness score audit
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: release-notes
+    description: Generate release notes from git commits
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: scaffold
+    description: Generate project files from templates (tool, expert, workflow, command)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: visualize
+    description: Generate Mermaid diagrams and ASCII dashboards (architecture, swarm, flow)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: capabilities
+    description: Show model capabilities matrix (modalities, tools, features)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: status
+    description: At-a-glance project health dashboard (fitness, adapters, version)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: health
+    description: Swarm health metrics dashboard (utilization, routing accuracy, failures)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: validate
+    description: Run unified validation (doctor + fitness + config)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
+  - name: auth
+    description: Manage MCP authentication tokens (init, show, rotate)
+    source_file: packages/nexus-agents/src/cli-commands.ts
+    source_line: 1
 mcp_tools:
   - name: name
     description: ''
@@ -11,7 +146,7 @@ mcp_tools:
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/consensus-vote.ts
-    source_line: 430
+    source_line: 586
   - name: create_expert
     description: ''
     parameters: []
@@ -21,27 +156,32 @@ mcp_tools:
     description: Route a task to the optimal model based on capability matching. Returns model recommendation with reasoning.
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
-    source_line: 313
+    source_line: 314
+  - name: run_dev_pipeline
+    description: DevPipelineInputSchema.shape
+    parameters: []
+    source_file: packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+    source_line: 187
   - name: execute_spec
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/execute-spec-tool.ts
-    source_line: 140
+    source_line: 145
   - name: extract_symbols
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
-    source_line: 129
+    source_line: 135
   - name: issue_triage
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
-    source_line: 163
+    source_line: 168
   - name: list_experts
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/list-experts.ts
-    source_line: 211
+    source_line: 213
   - name: list_workflows
     description: ''
     parameters: []
@@ -66,12 +206,22 @@ mcp_tools:
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/orchestrate.ts
-    source_line: 741
+    source_line: 1017
+  - name: run_pipeline
+    description: PipelineInputSchema.shape
+    parameters: []
+    source_file: packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+    source_line: 156
+  - name: query_task_state
+    description: ''
+    parameters: []
+    source_file: packages/nexus-agents/src/mcp/tools/query-task-state-tool.ts
+    source_line: 89
   - name: query_trace
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
-    source_line: 226
+    source_line: 227
   - name: registry_import
     description: ''
     parameters: []
@@ -111,7 +261,7 @@ mcp_tools:
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/research-discover.ts
-    source_line: 617
+    source_line: 623
   - name: research_query
     description: ''
     parameters: []
@@ -141,7 +291,7 @@ mcp_tools:
         description: Enable audit trail logging
         required: false
     source_file: packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
-    source_line: 254
+    source_line: 259
   - name: run_workflow
     description: Execute a workflow template with provided inputs, supporting built-in templates and custom paths
     parameters:
@@ -164,7 +314,7 @@ mcp_tools:
     description: ''
     parameters: []
     source_file: packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
-    source_line: 152
+    source_line: 168
   - name: name
     description: ''
     parameters: []

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
@@ -236,6 +236,48 @@ describe('extractCliCommands', () => {
       expect(names).toContain('vote');
     });
 
+    it('finds HELP_TEXT in cli-help-text.ts when cli-types.ts only has PARSE_ARGS_CONFIG (regression: 3-month silent empty output)', () => {
+      // Simulates the real layout after #293 (Jan 2026): HELP_TEXT lives in
+      // cli-help-text.ts and cli-types.ts only re-exports it. Prior to the
+      // fix, the extractor only looked in cli-types.ts and returned zero
+      // commands. See fix/entrypoint-cli-extractor-help-text-load.
+      const typesFile = makeMockTypesFile('', []);
+      // Override so the types file intentionally has no HELP_TEXT declaration
+      // — mirrors the real post-split state where only a re-export exists.
+      (typesFile as { getVariableDeclaration: (name: string) => unknown }).getVariableDeclaration =
+        (name: string) =>
+          name === 'HELP_TEXT' ? undefined : makeMockTypesFile('', []).getVariableDeclaration(name);
+
+      const helpTextFile = {
+        getVariableDeclaration: (name: string) =>
+          name === 'HELP_TEXT'
+            ? { getInitializer: () => ({ getText: () => '`' + BASIC_HELP_TEXT + '`' }) }
+            : undefined,
+      };
+      const cmdsFile = makeMockCommandsFile({
+        handleDoctorCommand: 10,
+        handleOrchestrateCommand: 50,
+        handleVoteCommand: 100,
+      });
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-help-text.ts': helpTextFile,
+        'cli-commands.ts': cmdsFile,
+      });
+
+      const result = extractCliCommands(
+        project as never,
+        '/pkg',
+        'cli-commands.ts',
+        'cli-types.ts'
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result.map((c) => c.name)).toEqual(
+        expect.arrayContaining(['doctor', 'orchestrate', 'vote'])
+      );
+    });
+
     it('should extract command descriptions', () => {
       const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
       const cmdsFile = makeMockCommandsFile({ handleDoctorCommand: 10 });

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
@@ -249,9 +249,36 @@ function getCommandOptions(name: string, cliOptions: Map<string, OptionSpec>): O
 }
 
 /**
+ * Loads and parses the CLI command metadata from HELP_TEXT.
+ *
+ * HELP_TEXT was split out of cli-types.ts in #293 (Jan 2026) and now lives
+ * in cli-help-text.ts. cli-types.ts only re-exports it; ts-morph doesn't
+ * chase re-exports for variable declarations, so we read from the source
+ * file directly. The typesFile fallback is kept for robustness.
+ */
+function loadHelpTextCommands(
+  project: Project,
+  packageRoot: string,
+  typesFile: SourceFile | undefined
+): CliCommandMeta[] {
+  const helpTextPath = path.join(packageRoot, 'src/cli-help-text.ts');
+  const helpTextFile = project.getSourceFile(helpTextPath) ?? typesFile;
+  if (helpTextFile === undefined) return [];
+
+  const helpTextVar = helpTextFile.getVariableDeclaration('HELP_TEXT');
+  if (helpTextVar === undefined) return [];
+
+  const helpText = helpTextVar.getInitializer()?.getText() ?? '';
+  const cleanText = helpText
+    .slice(1, -1)
+    .replace(/^\s*\n/, '')
+    .replace(/\n\s*$/, '');
+  return parseHelpTextCommands(cleanText);
+}
+
+/**
  * Extracts CLI commands from source files.
  */
-// eslint-disable-next-line complexity -- Multi-step extraction with early returns
 export function extractCliCommands(
   project: Project,
   packageRoot: string,
@@ -260,29 +287,11 @@ export function extractCliCommands(
 ): CliCommandSpec[] {
   const commands: CliCommandSpec[] = [];
 
-  // Load CLI types file for HELP_TEXT and options
   const typesFullPath = path.join(packageRoot, cliTypesPath);
   const typesFile = project.getSourceFile(typesFullPath);
-
-  let helpTextCommands: CliCommandMeta[] = [];
-  let cliOptions = new Map<string, OptionSpec>();
-
-  if (typesFile !== undefined) {
-    // Extract HELP_TEXT
-    const helpTextVar = typesFile.getVariableDeclaration('HELP_TEXT');
-    if (helpTextVar !== undefined) {
-      const helpText = helpTextVar.getInitializer()?.getText() ?? '';
-      // Remove template literal backticks and trim
-      const cleanText = helpText
-        .slice(1, -1)
-        .replace(/^\s*\n/, '')
-        .replace(/\n\s*$/, '');
-      helpTextCommands = parseHelpTextCommands(cleanText);
-    }
-
-    // Extract options from PARSE_ARGS_CONFIG
-    cliOptions = extractCliOptions(typesFile);
-  }
+  const helpTextCommands = loadHelpTextCommands(project, packageRoot, typesFile);
+  const cliOptions =
+    typesFile !== undefined ? extractCliOptions(typesFile) : new Map<string, OptionSpec>();
 
   // Load CLI commands file for source locations
   const commandsFullPath = path.join(packageRoot, cliCommandsPath);

--- a/packages/nexus-agents/src/indexer/entrypoint-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-extractor.ts
@@ -61,6 +61,11 @@ function createProject(opts: EntrypointExtractorOptions): Project {
   project.addSourceFilesAtPaths([
     path.join(opts.packageRoot, opts.cliCommandsPath),
     path.join(opts.packageRoot, 'src/cli-types.ts'),
+    // HELP_TEXT was extracted to cli-help-text.ts in #293 (Jan 2026) and
+    // cli-types.ts now only re-exports it. The extractor reads it via AST,
+    // so we have to load the defining file — a bare re-export isn't enough.
+    // Without this line the CLI command list silently came back empty.
+    path.join(opts.packageRoot, 'src/cli-help-text.ts'),
     path.join(opts.packageRoot, opts.mcpToolsPath, '*.ts'),
   ]);
   return project;


### PR DESCRIPTION
## Summary

Silent 3-month-old bug: \`docs/.generated/entrypoints.yaml\` has been generated with \`cli_commands: []\` since Jan 2026. PR #293 split HELP_TEXT out of \`cli-types.ts\` into \`cli-help-text.ts\`, but the entrypoint extractor's ts-morph project was never updated to load the new file. \`typesFile.getVariableDeclaration('HELP_TEXT')\` has been returning undefined ever since.

Discovered while investigating DRY-audit work (#2069).

## Fix

- \`entrypoint-extractor.ts\`: add \`src/cli-help-text.ts\` to the ts-morph project sources
- \`entrypoint-cli-extractor.ts\`: read HELP_TEXT from \`cli-help-text.ts\` with \`cli-types.ts\` as fallback
- Extracted \`loadHelpTextCommands\` helper to keep \`extractCliCommands\` under the 50-line cap

## Scope (intentionally narrow)

Only fixes the \"declaration not found\" root cause. A **separate** pre-existing regex miss (\`parseHelpTextCommands\` skips long-named commands like \`release-validate\`, \`release-announce\`, \`learning-metrics\` because their HELP_TEXT rows have only 1 space before the description) is filed as #2146. Extraction goes from 0 → 32 commands here; after #2146 that'll be 36.

## Test plan

- [x] Added regression test \`finds HELP_TEXT in cli-help-text.ts when cli-types.ts only has PARSE_ARGS_CONFIG\` that locks in the load path
- [x] All 27 extractor tests pass
- [x] Confirmed end-to-end: \`npx tsx scripts/extract-entrypoints.ts\` now produces 32 CLI commands (was 0)
- [x] Typecheck + lint clean