### PR TITLE
fix(indexer): reject non-literal tool names in MCP extractor (closes #2148)

### DIFF
--- a/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for entrypoint-mcp-extractor.
+ *
+ * Focused on the string-literal check for tool names (#2148) — prior to the
+ * fix, Proxy/wrapper modules that forwarded `registerTool(name, ...)` calls
+ * produced spurious tools named "name" in the extracted manifest.
+ *
+ * @module indexer/entrypoint-mcp-extractor.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Project } from 'ts-morph';
+import { extractMcpTools } from './entrypoint-mcp-extractor.js';
+
+/**
+ * Builds an in-memory ts-morph project with a single virtual source file
+ * under a synthetic tools directory. Returns the project and the tools dir
+ * path so `extractMcpTools` can be called directly.
+ */
+function makeProject(fileName: string, source: string): { project: Project; toolsDir: string } {
+  const toolsDir = '/virtual/mcp-tools';
+  const project = new Project({ useInMemoryFileSystem: true });
+  project.createSourceFile(`${toolsDir}/${fileName}`, source);
+  return { project, toolsDir };
+}
+
+describe('extractMcpTools', () => {
+  describe('string-literal tool-name check (#2148)', () => {
+    it('skips registerTool calls where the name arg is a parameter identifier (proxy/wrapper pattern)', () => {
+      // Matches the real annotation-proxy.ts / tool-observability-proxy.ts
+      // shape: Proxy forwards the call, so the first arg is a parameter
+      // `name` not a string literal. Must NOT produce a "name" tool.
+      const source = `
+        import type { ToolCallback, ToolConfig } from '@modelcontextprotocol/sdk';
+        type Target = { registerTool(name: string, config: ToolConfig, cb: ToolCallback): unknown };
+        export function makeProxy(target: Target): Target {
+          return new Proxy(target, {
+            get(t, prop, receiver) {
+              if (prop === 'registerTool') {
+                return (name: string, config: ToolConfig, cb: ToolCallback): unknown => {
+                  return target.registerTool(name, config, cb);
+                };
+              }
+              return Reflect.get(t, prop, receiver);
+            },
+          });
+        }
+      `;
+      const { project, toolsDir } = makeProject('proxy.ts', source);
+      const tools = extractMcpTools(project, '/', toolsDir);
+      expect(tools.find((t) => t.name === 'name')).toBeUndefined();
+    });
+
+    it('still extracts real tools with string-literal names', () => {
+      const source = `
+        server.registerTool('real_tool', {
+          description: 'A real tool',
+          inputSchema: { query: z.string() },
+        }, async () => ({ content: [] }));
+      `;
+      const { project, toolsDir } = makeProject('real-tool.ts', source);
+      const tools = extractMcpTools(project, '/', toolsDir);
+      expect(tools.find((t) => t.name === 'real_tool')).toBeDefined();
+    });
+
+    it('accepts both single-quoted and double-quoted string-literal names', () => {
+      const source = `
+        server.tool("double_quoted", 'description', { x: z.string() }, async () => {});
+        server.tool('single_quoted', 'description', { y: z.string() }, async () => {});
+      `;
+      const { project, toolsDir } = makeProject('quotes.ts', source);
+      const tools = extractMcpTools(project, '/', toolsDir);
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('double_quoted');
+      expect(names).toContain('single_quoted');
+    });
+
+    it('skips tool names passed via template literal interpolation (dynamic)', () => {
+      // Template with substitution (TemplateExpression) isn't a literal, so
+      // skip. Only NoSubstitutionTemplateLiteral (backtick with no ${})
+      // is literal-equivalent and accepted.
+      const source = `
+        const prefix = 'foo';
+        server.registerTool(\`\${prefix}_tool\`, { description: 'x', inputSchema: {} }, async () => {});
+      `;
+      const { project, toolsDir } = makeProject('dynamic.ts', source);
+      const tools = extractMcpTools(project, '/', toolsDir);
+      expect(tools).toHaveLength(0);
+    });
+  });
+});

--- a/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
@@ -130,10 +130,22 @@ function extractToolsFromFile(
     const args = callExpr.getArguments();
     if (args.length < 2) continue;
 
-    // Extract tool name (first string argument)
+    // Extract tool name (first string argument).
+    //
+    // Reject non-literal first arguments — Proxy/wrapper modules forward
+    // calls like `target.registerTool(name, ...)` where `name` is a
+    // parameter, not a tool identifier. Accepting those produces spurious
+    // tools named "name". See #2148.
     const nameArg = args[0];
     if (nameArg === undefined) continue;
-    const toolName = nameArg.getText().replace(/['"]/g, '');
+    const nameKind = nameArg.getKind();
+    if (
+      nameKind !== SyntaxKind.StringLiteral &&
+      nameKind !== SyntaxKind.NoSubstitutionTemplateLiteral
+    ) {
+      continue;
+    }
+    const toolName = nameArg.getText().replace(/['"`]/g, '');
 
     // Extract description and schema based on call type
     const { description, schemaArg } = extractToolMeta(callText, args, sourceFile);


### PR DESCRIPTION
## Summary

Proxy/wrapper modules in \`packages/nexus-agents/src/mcp/tools/\` (annotation-proxy.ts, tool-observability-proxy.ts) forward calls like \`target.registerTool(name, config, cb)\` where \`name\` is a parameter identifier. The MCP extractor was naively reading the identifier and producing two spurious tools literally named \`name\` in \`docs/.generated/entrypoints.yaml\`.

## Fix

\`packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts\` now requires the first argument to be a \`StringLiteral\` or \`NoSubstitutionTemplateLiteral\` \`SyntaxKind\`. Identifiers, template expressions with interpolation, and other non-literal forms are rejected.

## Scope

Narrow. Complements #2147 (silent 3-month HELP_TEXT load bug) in the same extractor pipeline — both found during investigation for the UX-pass DRY audit.

## Before / After

\`\`\`
Before: 32 MCP tools in entrypoints.yaml (30 real + 2 spurious \"name\" entries)
After:  30 MCP tools (all real)
\`\`\`

## Test plan

- [x] New test file \`entrypoint-mcp-extractor.test.ts\` covers:
  - Proxy-forward pattern produces no \"name\" tool (regression)
  - String-literal names still extract normally
  - Both single and double quotes work
  - Template-literal interpolation is rejected
- [x] Typecheck + lint clean
- [x] Confirmed end-to-end: \`npx tsx scripts/extract-entrypoints.ts\` → 30 MCP tools (was 32)

Closes #2148.