### PR TITLE
fix(cli): classify CLI detection errors by type (closes #2152)

### DIFF
--- a/packages/nexus-agents/src/cli/cli-detection-error.test.ts
+++ b/packages/nexus-agents/src/cli/cli-detection-error.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for cli-detection-error (#2152).
+ *
+ * Verifies that execFileSync-style errors are classified into a stable
+ * `DetectionError` enum so doctor/verify can tell "not installed" from
+ * "hung PATH" from "binary not executable".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyExecError,
+  DETECTION_ERROR_MESSAGES,
+  type DetectionError,
+} from './cli-detection-error.js';
+
+describe('classifyExecError (#2152)', () => {
+  it('maps ENOENT to not-found (binary missing from PATH)', () => {
+    expect(classifyExecError({ code: 'ENOENT' })).toBe('not-found');
+  });
+
+  it('maps ETIMEDOUT to timeout', () => {
+    expect(classifyExecError({ code: 'ETIMEDOUT' })).toBe('timeout');
+  });
+
+  it('maps execFileSync timeout shape (killed + SIGTERM) to timeout', () => {
+    // This is the shape Node actually throws when execFileSync's own timeout
+    // fires — the child is killed but .code is undefined.
+    expect(classifyExecError({ killed: true, signal: 'SIGTERM' })).toBe('timeout');
+  });
+
+  it('maps SIGKILL to timeout (some platforms use it)', () => {
+    expect(classifyExecError({ signal: 'SIGKILL' })).toBe('timeout');
+  });
+
+  it('maps EACCES to permission', () => {
+    expect(classifyExecError({ code: 'EACCES' })).toBe('permission');
+  });
+
+  it('maps EPERM to permission', () => {
+    expect(classifyExecError({ code: 'EPERM' })).toBe('permission');
+  });
+
+  it('falls through to "other" for anything unclassified', () => {
+    expect(classifyExecError({ code: 'EXYZ' })).toBe('other');
+    expect(classifyExecError(new Error('mystery'))).toBe('other');
+  });
+
+  it('returns "other" for non-object inputs without crashing', () => {
+    expect(classifyExecError(null)).toBe('other');
+    expect(classifyExecError(undefined)).toBe('other');
+    expect(classifyExecError('string error')).toBe('other');
+    expect(classifyExecError(42)).toBe('other');
+  });
+
+  it('classification priority: ENOENT wins over signal (defensive)', () => {
+    // If an error somehow has both, the OS-level code is the more specific
+    // signal — we want "not-found" to take precedence so the user sees the
+    // most actionable message.
+    expect(classifyExecError({ code: 'ENOENT', signal: 'SIGTERM' })).toBe('not-found');
+  });
+
+  it('every DetectionError value has a message', () => {
+    // Future-proofing: if someone adds a DetectionError variant, the message
+    // map must be updated too. This test prevents silent drift.
+    const allErrors: DetectionError[] = ['not-found', 'timeout', 'permission', 'other'];
+    for (const err of allErrors) {
+      expect(DETECTION_ERROR_MESSAGES[err]).toBeDefined();
+      expect(DETECTION_ERROR_MESSAGES[err].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli/cli-detection-error.ts
+++ b/packages/nexus-agents/src/cli/cli-detection-error.ts
@@ -1,0 +1,82 @@
+/**
+ * nexus-agents/cli - CLI detection error classification (#2152)
+ *
+ * Small helper shared by `setup-codex.ts`, `setup-gemini.ts`, `setup-opencode.ts`
+ * (and later `setup-cli-detection.ts` once #2155 consolidates them) so that a
+ * `which`/`where` or `<cli> --version` failure is classified instead of
+ * silently collapsed into `installed: false`.
+ *
+ * Before this file, all three setup modules did `catch { return { installed: false } }`,
+ * treating `ENOENT` (genuinely not installed), `ETIMEDOUT` (PATH lookup hung),
+ * `EACCES` (binary present but not executable), and arbitrary other exec
+ * failures identically. That made doctor/verify diagnostics unactionable.
+ *
+ * @module cli/cli-detection-error
+ */
+
+/**
+ * Stable classification of why a CLI-detection exec failed.
+ *
+ * - `not-found`: binary is not on PATH (`ENOENT`). User action: install the CLI.
+ * - `timeout`: the exec hung past the configured timeout (`ETIMEDOUT`,
+ *   `exit code null with signal`). User action: investigate PATH for hung
+ *   filesystems (NFS mounts, dead autofs entries).
+ * - `permission`: binary is present but the current user can't execute it
+ *   (`EACCES`, `EPERM`). User action: fix mode bits or ownership.
+ * - `other`: any other exec failure. User action: re-run with verbose
+ *   logging or inspect stderr directly.
+ */
+export type DetectionError = 'not-found' | 'timeout' | 'permission' | 'other';
+
+/**
+ * Human-readable explanation for each detection-error class. Intended for
+ * `doctor`/`verify` output — short enough to fit on one line next to the CLI
+ * name.
+ */
+export const DETECTION_ERROR_MESSAGES: Record<DetectionError, string> = {
+  'not-found': 'binary not on PATH',
+  timeout: 'detection timed out (hung PATH?)',
+  permission: 'binary present but not executable',
+  other: 'detection failed — check verbose logs',
+};
+
+/**
+ * Formats a user-facing "not installed" message that incorporates the
+ * detection-error class. Called by setup runners to replace the flat
+ * "<cli> not installed" message when the underlying cause is more specific.
+ *
+ * - `not-found` or undefined → "<cli> not installed"
+ * - other classes → "<cli> detection failed: <class-message>"
+ */
+export function formatDetectionMessage(cliName: string, detectionError?: DetectionError): string {
+  if (detectionError === undefined || detectionError === 'not-found') {
+    return `${cliName} not installed`;
+  }
+  return `${cliName} detection failed: ${DETECTION_ERROR_MESSAGES[detectionError]}`;
+}
+
+/**
+ * Classifies a thrown error from `execFileSync('which'|'where', ...)` or
+ * `execFileSync(cli, ['--version'])`.
+ *
+ * Node's `execFileSync` throws with a `code` property on the error object
+ * (string like `'ENOENT'`) for most OS-level failures. Timeouts additionally
+ * set `signal: 'SIGTERM'` and may have `code: undefined`. We probe both.
+ */
+export function classifyExecError(err: unknown): DetectionError {
+  if (typeof err !== 'object' || err === null) return 'other';
+
+  // Duck-type rather than instanceof — execFileSync errors aren't always
+  // `Error` instances across Node versions and test harnesses.
+  const e = err as { code?: unknown; signal?: unknown; killed?: unknown };
+
+  if (e.code === 'ENOENT') return 'not-found';
+  if (e.code === 'ETIMEDOUT') return 'timeout';
+  if (e.killed === true || e.signal === 'SIGTERM' || e.signal === 'SIGKILL') {
+    // execFileSync sets `killed: true` + SIGTERM when its own timeout fires.
+    return 'timeout';
+  }
+  if (e.code === 'EACCES' || e.code === 'EPERM') return 'permission';
+
+  return 'other';
+}

--- a/packages/nexus-agents/src/cli/setup-codex.ts
+++ b/packages/nexus-agents/src/cli/setup-codex.ts
@@ -12,6 +12,7 @@ import { execFileSync } from 'node:child_process';
 import { platform } from 'node:os';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
+import { classifyExecError, type DetectionError } from './cli-detection-error.js';
 
 const logger = createLogger({ component: 'setup-codex' });
 
@@ -19,6 +20,11 @@ const logger = createLogger({ component: 'setup-codex' });
 export interface CodexCliInfo {
   readonly installed: boolean;
   readonly version: string | undefined;
+  /**
+   * Classification of why detection failed. Only set when `installed` is
+   * `false` OR when the binary was located but `--version` failed (#2152).
+   */
+  readonly detectionError?: DetectionError;
 }
 
 /** Codex MCP configuration result. */
@@ -35,8 +41,8 @@ export function detectCodexCli(): CodexCliInfo {
   try {
     const cmd = platform() === 'win32' ? 'where' : 'which';
     execFileSync(cmd, ['codex'], { timeout: 3000, stdio: 'pipe' });
-  } catch {
-    return { installed: false, version: undefined };
+  } catch (err: unknown) {
+    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
   }
 
   try {
@@ -47,8 +53,8 @@ export function detectCodexCli(): CodexCliInfo {
     });
     const match = /(\d+\.\d+\.\d+)/.exec(output);
     return { installed: true, version: match?.[1] };
-  } catch {
-    return { installed: true, version: undefined };
+  } catch (err: unknown) {
+    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
   }
 }
 

--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -36,6 +36,7 @@ import { runConfigInitSync } from './setup-config.js';
 import { detectOpenCodeCli, configureOpenCode } from './setup-opencode.js';
 import { detectGeminiCli, configureGemini } from './setup-gemini.js';
 import { detectCodexCli, configureCodex } from './setup-codex.js';
+import { formatDetectionMessage } from './cli-detection-error.js';
 import { VERSION } from '../version.js';
 import { runWizard } from './setup-wizard.js';
 import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-permissions.js';
@@ -441,7 +442,7 @@ function runOpenCodeStep(options: SetupOptions): SetupStep {
     return {
       name: 'OpenCode MCP',
       status: 'skipped',
-      message: 'OpenCode CLI not installed',
+      message: formatDetectionMessage('OpenCode CLI', cliInfo.detectionError),
       durationMs: getTimeProvider().now() - startTime,
     };
   }
@@ -472,7 +473,7 @@ function runGeminiStep(options: SetupOptions): SetupStep {
     return {
       name: 'Gemini MCP',
       status: 'skipped',
-      message: 'Gemini CLI not installed',
+      message: formatDetectionMessage('Gemini CLI', cliInfo.detectionError),
       durationMs: getTimeProvider().now() - startTime,
     };
   }
@@ -528,7 +529,7 @@ function runCodexStep(options: SetupOptions): SetupStep {
     return {
       name: 'Codex MCP',
       status: 'skipped',
-      message: 'Codex CLI not installed',
+      message: formatDetectionMessage('Codex CLI', cliInfo.detectionError),
       durationMs: getTimeProvider().now() - startTime,
     };
   }

--- a/packages/nexus-agents/src/cli/setup-gemini.ts
+++ b/packages/nexus-agents/src/cli/setup-gemini.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
+import { classifyExecError, type DetectionError } from './cli-detection-error.js';
 
 const logger = createLogger({ component: 'setup-gemini' });
 
@@ -20,6 +21,13 @@ const logger = createLogger({ component: 'setup-gemini' });
 export interface GeminiCliInfo {
   readonly installed: boolean;
   readonly version: string | undefined;
+  /**
+   * Classification of why detection failed. Only set when `installed` is
+   * `false` OR when the binary was located but `--version` failed. Lets
+   * doctor/verify distinguish "not installed" from "installed but broken
+   * or inaccessible" (#2152).
+   */
+  readonly detectionError?: DetectionError;
 }
 
 /** Gemini MCP configuration result. */
@@ -44,8 +52,8 @@ export function detectGeminiCli(): GeminiCliInfo {
   try {
     const cmd = platform() === 'win32' ? 'where' : 'which';
     execFileSync(cmd, ['gemini'], { timeout: 3000, stdio: 'pipe' });
-  } catch {
-    return { installed: false, version: undefined };
+  } catch (err: unknown) {
+    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
   }
 
   try {
@@ -56,8 +64,10 @@ export function detectGeminiCli(): GeminiCliInfo {
     });
     const match = /(\d+\.\d+\.\d+)/.exec(output);
     return { installed: true, version: match?.[1] };
-  } catch {
-    return { installed: true, version: undefined };
+  } catch (err: unknown) {
+    // The binary was located but `--version` failed. Still treat as installed
+    // so downstream flow can proceed, but surface why version-probing failed.
+    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
   }
 }
 

--- a/packages/nexus-agents/src/cli/setup-opencode.ts
+++ b/packages/nexus-agents/src/cli/setup-opencode.ts
@@ -15,6 +15,7 @@ import { homedir, platform } from 'node:os';
 import { parse as jsoncParse, modify, applyEdits } from 'jsonc-parser';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
+import { classifyExecError, type DetectionError } from './cli-detection-error.js';
 
 const logger = createLogger({ component: 'setup-opencode' });
 
@@ -22,6 +23,11 @@ const logger = createLogger({ component: 'setup-opencode' });
 export interface OpenCodeCliInfo {
   readonly installed: boolean;
   readonly version: string | undefined;
+  /**
+   * Classification of why detection failed. Only set when `installed` is
+   * `false` OR when the binary was located but `--version` failed (#2152).
+   */
+  readonly detectionError?: DetectionError;
 }
 
 /** OpenCode MCP configuration result. */
@@ -46,8 +52,8 @@ export function detectOpenCodeCli(): OpenCodeCliInfo {
   try {
     const cmd = platform() === 'win32' ? 'where' : 'which';
     execFileSync(cmd, ['opencode'], { timeout: 3000, stdio: 'pipe' });
-  } catch {
-    return { installed: false, version: undefined };
+  } catch (err: unknown) {
+    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
   }
 
   try {
@@ -58,8 +64,8 @@ export function detectOpenCodeCli(): OpenCodeCliInfo {
     });
     const match = /(\d+\.\d+\.\d+)/.exec(output);
     return { installed: true, version: match?.[1] };
-  } catch {
-    return { installed: true, version: undefined };
+  } catch (err: unknown) {
+    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
   }
 }
 


### PR DESCRIPTION
## Summary

First child of epic #2151. Replaces the bare \`catch { return { installed: false } }\` pattern in the three CLI-detection functions with error-class discrimination so setup/verify diagnostics tell users _why_ detection failed instead of silently collapsing everything to \"not installed\".

## Before / after

**Before**: a hung PATH entry, wrong mode bits on the binary, and a genuine missing-binary all produce the same message:
\`\`\`
> Gemini CLI not installed
\`\`\`

**After**: the specific cause is surfaced:
\`\`\`
> Gemini CLI detection failed: detection timed out (hung PATH?)
> Codex CLI detection failed: binary present but not executable
> OpenCode CLI not installed    # (only for genuine ENOENT)
\`\`\`

## Design

- \`cli/cli-detection-error.ts\` — new small helper (59 LOC + 10 tests). Exports:
  - \`DetectionError\` = \`'not-found' | 'timeout' | 'permission' | 'other'\`
  - \`classifyExecError(err: unknown): DetectionError\` — duck-types Node's exec errors
  - \`DETECTION_ERROR_MESSAGES\` — one-liner per class
  - \`formatDetectionMessage(cliName, detectionError)\` — call-site formatter
- \`CodexCliInfo\`, \`GeminiCliInfo\`, \`OpenCodeCliInfo\` gain an optional \`detectionError\` field.
- Setup runners in \`setup-command.ts\` use \`formatDetectionMessage\` so the right message flows into setup-step output.

## Coordinates with #2155

The new helper module is sized to be absorbed into \`setup-cli-detection.ts\` when #2155 consolidates the triplicated detection logic.

## Test plan

- [x] 10 new tests for \`classifyExecError\` cover every \`DetectionError\` branch + non-object inputs + priority ordering (ENOENT wins over signals)
- [x] All 102 existing setup-*.ts tests still pass
- [x] Typecheck + lint clean
- [x] No runtime behavior change when detection succeeds

Closes #2152. Epic: #2151.