### PR TITLE
fix(indexer): surface silent-empty extraction as warnings (closes #2153)

### DIFF
--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
@@ -642,6 +642,44 @@ describe('extractCliCommands', () => {
       expect(result).toEqual([]);
     });
 
+    it('pushes a warning when commands file not found (#2153)', () => {
+      // Regression: previously empty-return with no signal. #2147's 3-month
+      // silent regression was the same class. Now surfaces via warnings.
+      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
+      const project = makeMockProject({ 'cli-types.ts': typesFile });
+      const warnings: string[] = [];
+      extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
+      expect(warnings.some((w) => /commands file not loaded/.test(w))).toBe(true);
+    });
+
+    it('pushes a warning when HELP_TEXT parses to zero commands (#2153)', () => {
+      const typesFile = makeMockTypesFile(EMPTY_HELP_TEXT, []);
+      const cmdsFile = makeMockCommandsFile({});
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-commands.ts': cmdsFile,
+      });
+      const warnings: string[] = [];
+      extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
+      expect(warnings.some((w) => /HELP_TEXT parsed to zero commands/.test(w))).toBe(true);
+    });
+
+    it('pushes a warning when types file not loaded (#2153)', () => {
+      const cmdsFile = makeMockCommandsFile({});
+      const project = makeMockProject({ 'cli-commands.ts': cmdsFile });
+      const warnings: string[] = [];
+      extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
+      expect(warnings.some((w) => /types file not loaded/.test(w))).toBe(true);
+    });
+
+    it('does not push warnings when warnings array is not provided (backwards compat)', () => {
+      const project = makeMockProject({});
+      // No warnings arg — must not throw.
+      expect(() => {
+        extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts');
+      }).not.toThrow();
+    });
+
     it('should return empty array for empty HELP_TEXT', () => {
       const typesFile = makeMockTypesFile(EMPTY_HELP_TEXT, []);
       const cmdsFile = makeMockCommandsFile({});

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
@@ -277,13 +277,56 @@ function loadHelpTextCommands(
 }
 
 /**
+ * Emits non-fatal diagnostics for the silent-empty paths that caused the
+ * 3-month regression fixed in #2147 (#2153). Extracted from
+ * `extractCliCommands` to keep that function under the 50-line cap.
+ */
+function pushExtractionWarnings(
+  warnings: string[] | undefined,
+  issue: {
+    typesFile: SourceFile | undefined;
+    typesFullPath: string;
+    helpTextCount: number;
+    commandsFile: SourceFile | undefined;
+    commandsFullPath: string;
+  }
+): void {
+  if (warnings === undefined) return;
+  if (issue.typesFile === undefined) {
+    warnings.push(
+      `CLI extraction: types file not loaded (${issue.typesFullPath}). ` +
+        `PARSE_ARGS_CONFIG options will be missing from the manifest.`
+    );
+  }
+  if (issue.helpTextCount === 0) {
+    warnings.push(
+      `CLI extraction: HELP_TEXT parsed to zero commands. ` +
+        `Check cli-help-text.ts is in the ts-morph project and COMMANDS: section is present.`
+    );
+  }
+  if (issue.commandsFile === undefined) {
+    warnings.push(
+      `CLI extraction: commands file not loaded (${issue.commandsFullPath}). ` +
+        `Returning zero commands.`
+    );
+  }
+}
+
+/**
  * Extracts CLI commands from source files.
+ *
+ * @param warnings - Optional sink for non-fatal diagnostics. When supplied,
+ *   the extractor surfaces silent-empty paths (missing cli-types.ts, HELP_TEXT
+ *   parsed as empty, cli-commands.ts not in the ts-morph project) as actionable
+ *   messages (#2153). Same class as the 3-month silent regression fixed in
+ *   #2147.
  */
 export function extractCliCommands(
   project: Project,
   packageRoot: string,
   cliCommandsPath: string,
-  cliTypesPath: string
+  cliTypesPath: string,
+  warnings?: string[]
 ): CliCommandSpec[] {
   const commands: CliCommandSpec[] = [];
 
@@ -293,9 +336,16 @@ export function extractCliCommands(
   const cliOptions =
     typesFile !== undefined ? extractCliOptions(typesFile) : new Map<string, OptionSpec>();
 
-  // Load CLI commands file for source locations
   const commandsFullPath = path.join(packageRoot, cliCommandsPath);
   const commandsFile = project.getSourceFile(commandsFullPath);
+
+  pushExtractionWarnings(warnings, {
+    typesFile,
+    typesFullPath,
+    helpTextCount: helpTextCommands.length,
+    commandsFile,
+    commandsFullPath,
+  });
 
   if (commandsFile === undefined) return commands;
 

--- a/packages/nexus-agents/src/indexer/entrypoint-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-extractor.ts
@@ -86,13 +86,18 @@ export function extractEntrypoints(
 
   try {
     const project = createProject(opts);
+    // Both extractors push non-fatal diagnostics into `warnings` (#2153).
+    // Previously they returned empty results on mis-configuration with zero
+    // signal — that's how the #2147 HELP_TEXT regression went unnoticed for
+    // 3 months.
     const cliCommands = extractCliCommands(
       project,
       opts.packageRoot,
       opts.cliCommandsPath,
-      'src/cli-types.ts'
+      'src/cli-types.ts',
+      warnings
     );
-    const mcpTools = extractMcpTools(project, opts.packageRoot, opts.mcpToolsPath);
+    const mcpTools = extractMcpTools(project, opts.packageRoot, opts.mcpToolsPath, warnings);
 
     const finalCommands = opts.sanitize ? cliCommands.map(sanitizeCommand) : cliCommands;
     const finalTools = opts.sanitize ? mcpTools.map(sanitizeTool) : mcpTools;

--- a/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.test.ts
@@ -88,4 +88,32 @@ describe('extractMcpTools', () => {
       expect(tools).toHaveLength(0);
     });
   });
+
+  describe('empty-glob warning channel (#2153)', () => {
+    it('pushes a warning when the tools directory glob matches zero files', () => {
+      // Create a project with NO files in the tools dir — repro for the
+      // 3-month silent regression class (#2147) at this layer.
+      const project = new Project({ useInMemoryFileSystem: true });
+      const warnings: string[] = [];
+      const tools = extractMcpTools(project, '/', '/nonexistent/tools', warnings);
+      expect(tools).toHaveLength(0);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/matched zero files/);
+      expect(warnings[0]).toContain('/nonexistent/tools');
+    });
+
+    it('omits the warning when warnings array is not provided (backwards compat)', () => {
+      const project = new Project({ useInMemoryFileSystem: true });
+      // Call without the warnings parameter — must not throw.
+      expect(() => extractMcpTools(project, '/', '/nonexistent/tools')).not.toThrow();
+    });
+
+    it('does not push a warning when the glob matches files (happy path)', () => {
+      const source = `server.tool('real', 'desc', {}, async () => {});`;
+      const { project, toolsDir } = makeProject('real.ts', source);
+      const warnings: string[] = [];
+      extractMcpTools(project, '/', toolsDir, warnings);
+      expect(warnings).toHaveLength(0);
+    });
+  });
 });

--- a/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
@@ -81,17 +81,31 @@ function extractZodParameters(schemaObj: Node): ParameterSpec[] {
 
 /**
  * Extracts MCP tools from the tools directory.
+ *
+ * @param warnings - Optional sink for non-fatal diagnostics (e.g. the tools
+ *   directory glob matched zero files — a repeat-offender silent-failure
+ *   class that shipped the `cli_commands: []` regression for 3 months before
+ *   #2147 caught it). When supplied, the extractor pushes actionable
+ *   messages here rather than silently returning an empty result (#2153).
  */
 export function extractMcpTools(
   project: Project,
   packageRoot: string,
-  mcpToolsPath: string
+  mcpToolsPath: string,
+  warnings?: string[]
 ): McpToolSpec[] {
   const tools: McpToolSpec[] = [];
   const toolsDir = path.join(packageRoot, mcpToolsPath);
 
   // Get all TypeScript files in the tools directory
   const toolFiles = project.getSourceFiles(`${toolsDir}/*.ts`);
+
+  if (toolFiles.length === 0 && warnings !== undefined) {
+    warnings.push(
+      `MCP tool extraction: glob "${toolsDir}/*.ts" matched zero files. ` +
+        `Check that the path exists and is included in the ts-morph project.`
+    );
+  }
 
   for (const sourceFile of toolFiles) {
     const filePath = sourceFile.getFilePath();


### PR DESCRIPTION
## Summary

Second child of epic #2151. Adds repeat-offender protection against the silent-fail class that shipped the #2147 regression.

The #2147 HELP_TEXT bug went unnoticed for 3 months because the extractor returned \`cli_commands: []\` with zero diagnostic when a required source file wasn't in the ts-morph project. The MCP extractor has the same class of bug: if the tools-dir glob matches zero files, it silently returns \`[]\`. This PR makes both visible.

## Design

- \`extractCliCommands\` and \`extractMcpTools\` gain an optional \`warnings?: string[]\` parameter (additive, backwards compatible)
- On silent-empty paths, they push actionable messages:
  - MCP: \`glob \"/path/to/tools/*.ts\" matched zero files\`
  - CLI: \`types file not loaded\`, \`HELP_TEXT parsed to zero commands\`, \`commands file not loaded\`
- \`extractEntrypoints\` wires its existing \`warnings\` array through — the channel was already there, unused

## Test plan

- [x] 38 tests pass (up from 31): 3 new CLI warning tests, 3 new MCP warning tests, both include a backwards-compat no-arg call path
- [x] End-to-end: \`npx tsx scripts/extract-entrypoints.ts\` still produces 32 CLI commands + 30 MCP tools
- [x] Typecheck + lint clean

## Compatibility

Purely additive. \`npx tsx scripts/generate-repo-index.ts\` and existing extractor consumers (tests, scripts) all keep working without changes.

Closes #2153. Epic: #2151.