### PR TITLE
refactor(cli): extract parsePositiveInt helper (closes #2161)

### DIFF
--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -54,6 +54,7 @@ import {
   isValidIndexFormat,
   isValidResearchFormat,
   isValidResearchSubcommand,
+  parsePositiveInt,
 } from './cli-commands-validators.js';
 import {
   printWorkflowRunUsage,
@@ -671,9 +672,7 @@ export function handleWarmUpCommand(_args: ParsedCliArgs): void {
  * (Source: Issue #1030 — E2E scenario runner)
  */
 export function handleE2EEvalCommand(args: ParsedCliArgs): void {
-  const countArg = args.positionals[1];
-  const taskCount = countArg !== undefined ? parseInt(countArg, 10) : 50;
-  const count = Number.isNaN(taskCount) || taskCount <= 0 ? 50 : taskCount;
+  const count = parsePositiveInt(args.positionals[1], 50);
   const result = runE2EEval({ taskCount: count });
   process.stdout.write(formatE2EEvalResult(result) + '\n');
   process.exit(result.passed ? EXIT_CODES.SUCCESS : 1);
@@ -684,9 +683,7 @@ export function handleE2EEvalCommand(args: ParsedCliArgs): void {
  * (Source: Issue #1033 — Routing strategy A/B framework)
  */
 export function handleRoutingABCommand(args: ParsedCliArgs): void {
-  const countArg = args.positionals[1];
-  const taskCount = countArg !== undefined ? parseInt(countArg, 10) : 30;
-  const count = Number.isNaN(taskCount) || taskCount <= 0 ? 30 : taskCount;
+  const count = parsePositiveInt(args.positionals[1], 30);
   const result = runRoutingAB({ taskCount: count });
   process.stdout.write(formatABReport(result) + '\n');
   process.exit(EXIT_CODES.SUCCESS);
@@ -697,9 +694,7 @@ export function handleRoutingABCommand(args: ParsedCliArgs): void {
  * (Source: Issue #1034 — Comparative memory evaluation benchmark)
  */
 export function handleMemoryEvalCommand(args: ParsedCliArgs): void {
-  const sizeArg = args.positionals[1];
-  const size = sizeArg !== undefined ? parseInt(sizeArg, 10) : 50;
-  const count = Number.isNaN(size) || size <= 0 ? 50 : size;
+  const count = parsePositiveInt(args.positionals[1], 50);
   const result = runMemoryEval(count);
   process.stdout.write(formatMemoryEvalReport(result) + '\n');
   process.exit(EXIT_CODES.SUCCESS);

--- a/packages/nexus-agents/src/cli-commands-validators.test.ts
+++ b/packages/nexus-agents/src/cli-commands-validators.test.ts
@@ -12,6 +12,7 @@ import {
   isValidIndexSubcommand,
   isValidIndexFormat,
   isValidResearchFormat,
+  parsePositiveInt,
 } from './cli-commands-validators.js';
 
 // ============================================================================
@@ -166,5 +167,48 @@ describe('isValidResearchFormat', () => {
 
   it('rejects empty string', () => {
     expect(isValidResearchFormat('')).toBe(false);
+  });
+});
+
+// ============================================================================
+// parsePositiveInt (#2161)
+// ============================================================================
+
+describe('parsePositiveInt', () => {
+  it('returns the parsed integer when input is a positive numeric string', () => {
+    expect(parsePositiveInt('7', 10)).toBe(7);
+    expect(parsePositiveInt('100', 50)).toBe(100);
+  });
+
+  it('returns defaultVal when arg is undefined', () => {
+    expect(parsePositiveInt(undefined, 50)).toBe(50);
+  });
+
+  it('returns defaultVal when input is not numeric', () => {
+    expect(parsePositiveInt('abc', 50)).toBe(50);
+    expect(parsePositiveInt('', 50)).toBe(50);
+  });
+
+  it('returns defaultVal for zero (boundary: <=0 is rejected)', () => {
+    expect(parsePositiveInt('0', 30)).toBe(30);
+  });
+
+  it('returns defaultVal for negative numbers', () => {
+    expect(parsePositiveInt('-5', 30)).toBe(30);
+  });
+
+  it('truncates floating-point-looking input (parseInt behavior)', () => {
+    // Documents the parseInt(arg, 10) truncation for future readers.
+    expect(parsePositiveInt('12.9', 0)).toBe(12);
+  });
+
+  it('parses leading numeric prefix (parseInt behavior)', () => {
+    // parseInt stops at the first non-numeric character. This is the same
+    // behavior the three original call sites had.
+    expect(parsePositiveInt('42abc', 0)).toBe(42);
+  });
+
+  it('respects radix 10 for inputs like "08" (not octal)', () => {
+    expect(parsePositiveInt('08', 0)).toBe(8);
   });
 });

--- a/packages/nexus-agents/src/cli-commands-validators.ts
+++ b/packages/nexus-agents/src/cli-commands-validators.ts
@@ -74,3 +74,26 @@ export { isValidResearchSubcommand } from './cli/index.js';
  * (Source: Issue #273)
  */
 export { isValidPeriod, isValidDashboardFormat } from './cli/index.js';
+
+/**
+ * Parses a positive-integer CLI argument, falling back to `defaultVal` on
+ * missing, non-numeric, zero, or negative input.
+ *
+ * Consolidates the `parseInt(arg, 10) + Number.isNaN(...) || x <= 0` pattern
+ * that was duplicated 3× in `cli-commands-handlers.ts` (e2e-eval, routing-ab,
+ * memory-eval) before #2161.
+ *
+ * Intentionally narrow — rejects zero and negatives since every caller uses
+ * this for a "count" or "size" argument where 0 would be a no-op and
+ * negatives are nonsensical. A caller that legitimately wants non-positive
+ * input should parse inline instead.
+ *
+ * @param arg - The CLI argument value (typically `args.positionals[N]`)
+ * @param defaultVal - Default when `arg` is undefined, non-numeric, or ≤ 0
+ * @returns The parsed positive integer, or `defaultVal`
+ */
+export function parsePositiveInt(arg: string | undefined, defaultVal: number): number {
+  if (arg === undefined) return defaultVal;
+  const parsed = parseInt(arg, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? defaultVal : parsed;
+}


### PR DESCRIPTION
## Summary

Fifth child of epic #2151. Extracts a shared helper for the \`parseInt + Number.isNaN + default\` pattern that was duplicated 3× in \`cli-commands-handlers.ts\`.

## Before / After

**Before** (3 call sites, two lines each):
\`\`\`typescript
const countArg = args.positionals[1];
const taskCount = countArg !== undefined ? parseInt(countArg, 10) : 50;
const count = Number.isNaN(taskCount) || taskCount <= 0 ? 50 : taskCount;
\`\`\`

**After**:
\`\`\`typescript
const count = parsePositiveInt(args.positionals[1], 50);
\`\`\`

## Design

New helper in \`cli-commands-validators.ts\` (where other CLI parser helpers live):

\`\`\`typescript
export function parsePositiveInt(
  arg: string | undefined,
  defaultVal: number,
): number
\`\`\`

Narrow intent — rejects 0 and negatives. Matches what each original handler semantically wanted (\"count\" or \"size\" where ≤0 is nonsensical). A caller that legitimately wants non-positive input should parse inline instead.

## Test plan

- [x] 8 new tests in \`cli-commands-validators.test.ts\` cover undefined, non-numeric, zero, negative, parseInt-truncation, parseInt-prefix, radix-10 (no octal) behavior
- [x] All 37 existing validator tests still pass
- [x] Typecheck + lint clean

Closes #2161. Epic: #2151.