### PR TITLE
chore: bundled low-severity cleanup items (closes #2163)

### DIFF
--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -91,12 +91,19 @@ export function setupShutdownHandlers(cleanup: () => Promise<void>, logger: ILog
     }
   };
 
-  process.on('SIGINT', () => {
-    void handleShutdown('SIGINT');
-  });
-  process.on('SIGTERM', () => {
-    void handleShutdown('SIGTERM');
-  });
+  // `handleShutdown` has an internal try/catch that calls `process.exit` on
+  // both success and failure, so the chance of an unhandled rejection is
+  // low. Attach `.catch` anyway — defence against future edits that might
+  // throw synchronously before the try block, and to make the error path
+  // explicit (#2163).
+  const onSignal = (signal: string) => (): void => {
+    handleShutdown(signal).catch((err: unknown) => {
+      logger.error('Shutdown handler crashed', err instanceof Error ? err : new Error(String(err)));
+      process.exit(EXIT_CODES.SHUTDOWN_ERROR);
+    });
+  };
+  process.on('SIGINT', onSignal('SIGINT'));
+  process.on('SIGTERM', onSignal('SIGTERM'));
 
   // Handle uncaught errors
   process.on('uncaughtException', (error: Error) => {
@@ -478,6 +485,16 @@ async function initializeSubsystems(
  * @param modeWasExplicit - Whether mode was explicitly set via --mode flag
  * @param orchestratorOptions - Options for orchestrator mode (when mode is 'orchestrator')
  */
+/**
+ * Watchdog timeout for the server-mode startup sequence (#2163).
+ *
+ * If subsystem init, transport connect, or anything else on the path to
+ * "waiting for requests" hangs past this deadline, we log and exit rather
+ * than leave a zombie process. Chosen conservatively — subsystem init on
+ * a fresh install has been observed ~5-8s, so 30s leaves ample headroom.
+ */
+const SERVER_STARTUP_TIMEOUT_MS = 30_000;
+
 export async function startServer(
   verbose: boolean,
   mode: ServerMode,
@@ -494,6 +511,19 @@ export async function startServer(
     await startOrchestratorMode(orchestratorOptions ?? { verbose });
     return;
   }
+
+  // Watchdog: if startup hangs, surface it rather than hang indefinitely
+  // (#2163). Cleared once we reach "waiting for requests".
+  const startupWatchdog = setTimeout(() => {
+    logger.error(
+      `Server startup exceeded ${String(SERVER_STARTUP_TIMEOUT_MS)}ms — aborting. ` +
+        'Common causes: hung config load, blocked subsystem init, stdio transport stall.'
+    );
+    process.exit(EXIT_CODES.SERVER_START_FAILED);
+  }, SERVER_STARTUP_TIMEOUT_MS);
+  // Prevent the watchdog from keeping the process alive if everything shuts
+  // down cleanly before it fires (for short-lived test harnesses).
+  startupWatchdog.unref();
 
   const detectionResult = detectMode({ explicitMode: modeWasExplicit ? mode : undefined });
   logStartupInfo(logger, detectionResult, verbose);
@@ -534,5 +564,8 @@ export async function startServer(
   });
   setupShutdownHandlers(cleanup, logger);
 
+  // Startup complete — cancel the watchdog so it can't fire during request
+  // handling (#2163).
+  clearTimeout(startupWatchdog);
   logger.debug('Server running, waiting for requests...');
 }

--- a/packages/nexus-agents/src/exports/agents-compat.ts
+++ b/packages/nexus-agents/src/exports/agents-compat.ts
@@ -1,4 +1,0 @@
-/**
- * Backward compatibility aliases for agent exports (deprecated, will be removed in v3.0)
- * Split from agents.ts for file size compliance (Issue #285)
- */

--- a/packages/nexus-agents/src/exports/agents.ts
+++ b/packages/nexus-agents/src/exports/agents.ts
@@ -310,5 +310,4 @@ export {
   type WaveTaskExecutor,
 } from '../agents/index.js';
 
-// Backward compatibility aliases: agents-compat.ts
 // Skills module exports: agents-skills.ts

--- a/packages/nexus-agents/src/exports/index.ts
+++ b/packages/nexus-agents/src/exports/index.ts
@@ -10,7 +10,6 @@ export * from './core.js';
 export * from './config.js';
 export * from './adapters.js';
 export * from './agents.js';
-export * from './agents-compat.js';
 export * from './agents-skills.js';
 export * from './agents-ictm.js';
 export * from './workflows.js';

--- a/packages/nexus-agents/src/governance/fitness-score.ts
+++ b/packages/nexus-agents/src/governance/fitness-score.ts
@@ -327,9 +327,15 @@ export class FitnessScoreCalculator {
 
   /**
    * Check explicit behavior: penalize hidden/magic behavior.
-   * TODO: This dimension lacks strong filesystem signals. Currently checks
-   * for NEXUS_ALLOW_MOCK_ORCHESTRATION guard and magic routing patterns.
-   * Future: add AST-based detection of implicit fallbacks.
+   *
+   * Implementation is intentionally filesystem-signal-based (no AST parse).
+   * The `NEXUS_ALLOW_MOCK_ORCHESTRATION` guard and magic-routing pattern
+   * grep capture the observable failure modes that historically slipped
+   * past review. AST-based detection of implicit fallbacks was considered
+   * but not pursued — it would significantly widen this function's
+   * footprint and the filesystem signals already catch the recurring
+   * regressions. Revisit only if a new class of hidden-behavior bug
+   * surfaces that this grep-over-source approach can't catch.
    */
   private checkExplicitBehavior(): FitnessCheckResult {
     const findings: FitnessFinding[] = [];

--- a/packages/nexus-agents/src/index.ts
+++ b/packages/nexus-agents/src/index.ts
@@ -37,9 +37,6 @@ export * from './exports/adapters.js';
 // Agents - Agent framework, Orchestrator, Experts
 export * from './exports/agents.js';
 
-// Agents - Backward compatibility aliases (deprecated, will be removed in v3.0)
-export * from './exports/agents-compat.js';
-
 // Agents - Skills module exports (Voyager-style skill library)
 export * from './exports/agents-skills.js';
 


### PR DESCRIPTION
## Summary

Eighth child of epic #2151. Four independent cleanup items flagged in the post-UX-pass code review, bundled because each is too small to justify its own PR.

## Items

### 1. Delete dead \`exports/agents-compat.ts\` shim

Gutted by commit 35d6a34a in April — left behind a file with only a comment header and two \`export *\` re-exports that re-exported nothing. Zero downstream consumers.

**Confirmation:** file contents were a single comment; \`grep\` for \`agents-compat\` outside the re-export points found zero imports.

### 2. Resolve \`governance/fitness-score.ts:329\` stale TODO

The 6-month-old \"TODO: add AST-based detection of implicit fallbacks\" replaced with explicit rationale for staying filesystem-signal-based. AST-based detection was considered but not pursued — the grep-over-source signals already catch every observed regression in this dimension.

### 3. \`.catch()\` on signal handlers

\`setupShutdownHandlers\` uses \`void handleShutdown(signal)\` for SIGINT/SIGTERM. \`handleShutdown\` has an internal try/catch that calls \`process.exit\` on both paths, so unhandled rejection is unlikely — but a future edit that throws synchronously before the try block would silently swallow the error. Added explicit \`.catch()\` + error log + exit code.

### 4. \`startServer\` watchdog timeout

If subsystem init, transport connect, or anything else on the path to \`waiting for requests\` hangs, the process now aborts after 30s with an actionable message. \`unref\`'d so the watchdog doesn't keep short-lived test harnesses alive. Cleared once startup completes.

## Test plan

- [x] Typecheck + lint clean
- [x] All 24 cli-server tests still pass
- [x] No behavior change on non-error paths

Closes #2163. Epic: #2151.