### PR TITLE
test(mcp): add tests for extract-symbols-tool + search-codebase-tool (closes #2159)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for extract-symbols-tool (#2159).
+ *
+ * Focus: the path-traversal guard at line 59 is the security-critical surface
+ * this tool exposes, and it was previously untested. Also exercises input-
+ * schema validation and mode dispatch.
+ *
+ * Calls `_testing.extractSymbolsHandler` directly — bypassing the
+ * secure-handler / timeout wrappers — so we test the core logic in
+ * isolation. The wrappers are covered elsewhere.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
+
+// Mock the symbol extractor so we don't need real source files for every test.
+vi.mock('../../indexer/symbol-extractor.js', () => ({
+  extractSymbols: vi.fn(),
+  extractSymbolIndex: vi.fn(),
+}));
+
+import { _testing } from './extract-symbols-tool.js';
+import { createLogger } from '../../core/index.js';
+import * as symbolExtractor from '../../indexer/symbol-extractor.js';
+
+const { extractSymbolsHandler } = _testing;
+
+const mockedExtractSymbols = vi.mocked(symbolExtractor.extractSymbols);
+const mockedExtractSymbolIndex = vi.mocked(symbolExtractor.extractSymbolIndex);
+
+function makeCtx(): Parameters<typeof extractSymbolsHandler>[1] {
+  // Minimal RequestContext — the handler only reads ctx.logger, so the
+  // requestContext shape doesn't need to be complete for these tests.
+  return {
+    requestContext: {
+      requestId: 'test-req',
+      toolName: 'extract_symbols',
+      startTimeMs: 0,
+    } as unknown as Parameters<typeof extractSymbolsHandler>[1]['requestContext'],
+    logger: createLogger({ component: 'test' }),
+  };
+}
+
+describe('extract-symbols-tool (#2159)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('path-traversal guard', () => {
+    it('rejects paths outside the cwd subtree', async () => {
+      const result = await extractSymbolsHandler({ filePath: '/etc/passwd' }, makeCtx());
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/Path traversal denied/);
+    });
+
+    it('rejects relative paths that escape via ..', async () => {
+      // resolve('../../etc/passwd') from cwd may or may not escape depending
+      // on nesting — but a clearly-outside absolute path always fails.
+      const outside = resolve('/');
+      const result = await extractSymbolsHandler({ filePath: outside }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('accepts paths inside the cwd subtree', async () => {
+      mockedExtractSymbolIndex.mockResolvedValueOnce('fn foo:10\nfn bar:20');
+      const inside = resolve('./package.json'); // real file, resolves under cwd
+      const result = await extractSymbolsHandler({ filePath: inside }, makeCtx());
+      // Should not be flagged as traversal even if the file isn't a TS file.
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).not.toMatch(/Path traversal/);
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects missing filePath', async () => {
+      const result = await extractSymbolsHandler({}, makeCtx());
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/Validation error/);
+    });
+
+    it('rejects empty filePath (min length 1)', async () => {
+      const result = await extractSymbolsHandler({ filePath: '' }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects filePath longer than 500 chars', async () => {
+      const result = await extractSymbolsHandler({ filePath: 'x'.repeat(501) }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects invalid mode enum value', async () => {
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./x.ts'), mode: 'raw' },
+        makeCtx()
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('mode dispatch', () => {
+    it('defaults to index mode (calls extractSymbolIndex, not extractSymbols)', async () => {
+      mockedExtractSymbolIndex.mockResolvedValueOnce('fn foo:10');
+      await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
+      expect(mockedExtractSymbolIndex).toHaveBeenCalledTimes(1);
+      expect(mockedExtractSymbols).not.toHaveBeenCalled();
+    });
+
+    it('uses full mode when explicitly requested', async () => {
+      mockedExtractSymbols.mockResolvedValueOnce({
+        filePath: '/x.ts',
+        totalLines: 10,
+        totalChars: 100,
+        symbolChars: 50,
+        savingsPercent: 50,
+        symbols: [
+          {
+            name: 'foo',
+            kind: 'function',
+            startLine: 1,
+            endLine: 5,
+            exported: true,
+            text: 'function foo() {}',
+          },
+        ],
+      } as never);
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./x.ts'), mode: 'full' },
+        makeCtx()
+      );
+      expect(mockedExtractSymbols).toHaveBeenCalledTimes(1);
+      expect(mockedExtractSymbolIndex).not.toHaveBeenCalled();
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toContain('savingsPercent');
+    });
+
+    it('returns a friendly message when index is empty (non-TS/JS file)', async () => {
+      mockedExtractSymbolIndex.mockResolvedValueOnce('');
+      const result = await extractSymbolsHandler({ filePath: resolve('./x.md') }, makeCtx());
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/No symbols found/);
+    });
+  });
+
+  describe('error propagation', () => {
+    it('wraps extractor failures in a toolError (not a thrown exception)', async () => {
+      mockedExtractSymbolIndex.mockRejectedValueOnce(new Error('parse crashed'));
+      const result = await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/Symbol extraction failed/);
+      expect(text).toMatch(/parse crashed/);
+    });
+
+    it('coerces non-Error throws into a string message', async () => {
+      mockedExtractSymbolIndex.mockRejectedValueOnce('string error');
+      const result = await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
@@ -100,6 +100,16 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
 }
 
 // ============================================================================
+// Testing exports (#2159)
+// ============================================================================
+
+/** Test-only surface — do not import in production code. */
+export const _testing = {
+  /** Raw handler for unit testing (bypasses secure-handler + timeout middleware). */
+  extractSymbolsHandler,
+};
+
+// ============================================================================
 // Registration
 // ============================================================================
 

--- a/packages/nexus-agents/src/mcp/tools/search-codebase-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-codebase-tool.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for search-codebase-tool (#2159).
+ *
+ * Focus: input-schema validation, path-traversal guard, cache hit/miss
+ * behavior (the whole point of the module-level `cachedIndex`), and the
+ * three operating modes (search / summary / list). Calls
+ * `_testing.searchCodebaseHandler` directly so the secure-handler and
+ * timeout middleware are out of scope.
+ *
+ * Uses a constructor spy on `CodebaseIndex` to verify the cache: one call
+ * per unique directory, zero extra calls when the same directory is hit
+ * twice. `_testing.clearIndexCache()` resets between suites.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
+
+// `vi.mock` factories are hoisted above top-level code, so the mock objects
+// they reference must be created inside `vi.hoisted()` to also be hoisted.
+const mocks = vi.hoisted(() => {
+  const indexInstance = {
+    index: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockReturnValue([]),
+    listFiles: vi.fn().mockReturnValue([]),
+    getFileSummary: vi.fn().mockReturnValue(undefined),
+    stats: { files: 0, symbols: 0 },
+  };
+  // vitest 4: arrow functions aren't constructor-callable. Use a real
+  // function so `new CodebaseIndex(dir)` works.
+  const ctor = vi.fn(function () {
+    return indexInstance;
+  });
+  return { indexInstance, ctor };
+});
+
+vi.mock('../../indexer/codebase-search.js', () => ({
+  CodebaseIndex: mocks.ctor,
+}));
+
+import { _testing } from './search-codebase-tool.js';
+import { createLogger } from '../../core/index.js';
+
+const { searchCodebaseHandler, resolveSearchDir, clearIndexCache } = _testing;
+
+function makeCtx(): Parameters<typeof searchCodebaseHandler>[1] {
+  // Minimal RequestContext — the handler only reads ctx.logger, so the
+  // requestContext shape doesn't need to be complete for these tests.
+  return {
+    requestContext: {
+      requestId: 'test-req',
+      toolName: 'search_codebase',
+      startTimeMs: 0,
+    } as unknown as Parameters<typeof searchCodebaseHandler>[1]['requestContext'],
+    logger: createLogger({ component: 'test' }),
+  };
+}
+
+describe('search-codebase-tool (#2159)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearIndexCache();
+    // Reset the stubbed index instance between tests (vi.clearAllMocks only
+    // resets call history, not `mockReturnValue` setups — this keeps the
+    // defaults fresh).
+    mocks.indexInstance.search.mockReturnValue([]);
+    mocks.indexInstance.listFiles.mockReturnValue([]);
+    mocks.indexInstance.getFileSummary.mockReturnValue(undefined);
+    mocks.indexInstance.stats = { files: 0, symbols: 0 };
+  });
+
+  describe('input validation', () => {
+    it('rejects missing query', async () => {
+      const result = await searchCodebaseHandler({}, makeCtx());
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/Validation error/);
+    });
+
+    it('rejects empty query (min length 1)', async () => {
+      const result = await searchCodebaseHandler({ query: '' }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects query longer than 200 chars', async () => {
+      const result = await searchCodebaseHandler({ query: 'x'.repeat(201) }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('enforces limit upper bound of 50', async () => {
+      const result = await searchCodebaseHandler({ query: 'foo', limit: 51 }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('enforces limit lower bound of 1', async () => {
+      const result = await searchCodebaseHandler({ query: 'foo', limit: 0 }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects invalid mode enum value', async () => {
+      const result = await searchCodebaseHandler({ query: 'foo', mode: 'fuzzy' }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('path-traversal guard', () => {
+    it('rejects directories outside cwd subtree', () => {
+      const r = resolveSearchDir('/etc');
+      expect('error' in r).toBe(true);
+      if ('error' in r) expect(r.error).toMatch(/Path traversal denied/);
+    });
+
+    it('accepts directories inside cwd subtree', () => {
+      const r = resolveSearchDir('./src');
+      expect('dir' in r).toBe(true);
+      if ('dir' in r) expect(r.dir).toBe(resolve('./src'));
+    });
+
+    it('defaults to process.cwd() when directory is undefined', () => {
+      const r = resolveSearchDir(undefined);
+      expect('dir' in r).toBe(true);
+      if ('dir' in r) expect(r.dir).toBe(resolve('.'));
+    });
+
+    it('propagates traversal error through the handler', async () => {
+      const result = await searchCodebaseHandler({ query: 'foo', directory: '/etc' }, makeCtx());
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('index cache (#2159 — cache hit/miss is the whole point of the module state)', () => {
+    it('builds the index once on first call, reuses it on second call for same dir', async () => {
+      await searchCodebaseHandler({ query: 'foo', directory: './src' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(1);
+
+      // Second call, same dir → cache hit. No new index built.
+      await searchCodebaseHandler({ query: 'bar', directory: './src' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(1);
+    });
+
+    it('rebuilds the index when a different directory is used', async () => {
+      await searchCodebaseHandler({ query: 'foo', directory: './src' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(1);
+
+      await searchCodebaseHandler({ query: 'foo', directory: './docs' }, makeCtx());
+      // Different dir → cache miss → new index.
+      expect(mocks.ctor).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearIndexCache forces a rebuild on the next call', async () => {
+      await searchCodebaseHandler({ query: 'foo', directory: './src' }, makeCtx());
+      clearIndexCache();
+      await searchCodebaseHandler({ query: 'foo', directory: './src' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('mode dispatch', () => {
+    it('search mode: reports zero results cleanly', async () => {
+      mocks.indexInstance.search.mockReturnValue([]);
+      mocks.indexInstance.stats = { files: 3, symbols: 17 };
+      const result = await searchCodebaseHandler({ query: 'missing' }, makeCtx());
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/No symbols matching "missing"/);
+      expect(text).toMatch(/3 indexed files/);
+    });
+
+    it('search mode: formats non-empty results with matchType + kind + location', async () => {
+      mocks.indexInstance.search.mockReturnValue([
+        {
+          matchType: 'exact',
+          symbol: {
+            name: 'doThing',
+            kind: 'function',
+            exported: true,
+            filePath: 'src/foo.ts',
+            startLine: 42,
+          },
+        },
+      ]);
+      const result = await searchCodebaseHandler({ query: 'doThing' }, makeCtx());
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/1 results for "doThing"/);
+      expect(text).toMatch(/\[exact\] export function doThing \(src\/foo\.ts:42\)/);
+    });
+
+    it('list mode: emits per-file symbol + line counts', async () => {
+      mocks.indexInstance.listFiles.mockReturnValue([
+        { path: 'a.ts', symbols: 5, lines: 100 },
+        { path: 'b.ts', symbols: 10, lines: 50 },
+      ]);
+      mocks.indexInstance.stats = { files: 2, symbols: 15 };
+      const result = await searchCodebaseHandler({ query: '*', mode: 'list' }, makeCtx());
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/2 files, 15 symbols indexed/);
+      // Sorted by symbol count desc → b.ts first.
+      const bIdx = text.indexOf('b.ts');
+      const aIdx = text.indexOf('a.ts');
+      expect(bIdx).toBeGreaterThan(-1);
+      expect(aIdx).toBeGreaterThan(bIdx);
+    });
+
+    it('summary mode: reports file not found when summary is undefined', async () => {
+      mocks.indexInstance.getFileSummary.mockReturnValue(undefined);
+      const result = await searchCodebaseHandler(
+        { query: 'missing.ts', mode: 'summary' },
+        makeCtx()
+      );
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/File "missing.ts" not found in index/);
+    });
+
+    it('summary mode: returns JSON summary when present', async () => {
+      mocks.indexInstance.getFileSummary.mockReturnValue({ path: 'x.ts', symbols: 3 });
+      const result = await searchCodebaseHandler({ query: 'x.ts', mode: 'summary' }, makeCtx());
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(JSON.parse(text)).toEqual({ path: 'x.ts', symbols: 3 });
+    });
+  });
+
+  describe('error propagation', () => {
+    it('wraps indexer failures in a toolError', async () => {
+      mocks.indexInstance.search.mockImplementationOnce(() => {
+        throw new Error('index corrupted');
+      });
+      const result = await searchCodebaseHandler({ query: 'foo' }, makeCtx());
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toMatch(/Search failed/);
+      expect(text).toMatch(/index corrupted/);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
@@ -137,6 +137,23 @@ async function searchCodebaseHandler(args: unknown, ctx: HandlerContext): Promis
 }
 
 // ============================================================================
+// Testing exports (#2159)
+// ============================================================================
+
+/** Test-only surface — do not import in production code. */
+export const _testing = {
+  /** Raw handler for unit testing (bypasses secure-handler + timeout middleware). */
+  searchCodebaseHandler,
+  /** Exposes the shared dir-validation + resolution logic. */
+  resolveSearchDir,
+  /** Clears the module-level index cache so tests can start fresh. */
+  clearIndexCache: (): void => {
+    cachedIndex = undefined;
+    cachedDir = '';
+  },
+};
+
+// ============================================================================
 // Registration
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Ninth child of epic #2151. Adds test files for two public MCP tools that had zero direct coverage — \`extract-symbols-tool.ts\` (security-critical path-traversal guard) and \`search-codebase-tool.ts\` (module-level cache hit/miss behavior, three operating modes).

## Design

Both tools gained a \`_testing\` export with their raw handlers so tests can hit the core logic directly, bypassing the secure-handler + timeout middleware (those wrappers are covered elsewhere). \`search-codebase-tool\` also exposes \`resolveSearchDir\` and \`clearIndexCache\` for direct cache testing.

## Coverage

**\`extract-symbols-tool.test.ts\` — 12 tests:**
- Path-traversal guard: rejects \`/etc/passwd\` + absolute escape; accepts paths within cwd
- Input validation: missing/empty/too-long \`filePath\`, invalid mode enum
- Mode dispatch: defaults to index mode, \`full\` calls different function, empty index gives friendly message
- Error propagation: extractor exceptions → \`toolError\`, non-Error throws coerced

**\`search-codebase-tool.test.ts\` — 19 tests:**
- Input validation: query bounds (1-200), limit bounds (1-50), invalid mode enum
- Path-traversal guard: tested via exposed \`resolveSearchDir\` + through the handler
- **Cache behavior**: builds index once per unique dir, reuses on same dir, rebuilds on dir change, \`clearIndexCache\` forces rebuild (the core module-state surface this tool exposes)
- Mode dispatch: search zero-results + non-empty formatting, list with per-file counts sorted by symbol count, summary not-found + JSON
- Error propagation

Cache testing uses a \`vi.hoisted\` factory to wire a constructor spy on \`CodebaseIndex\` so we can count instantiations across calls — vitest 4 requires a non-arrow function for the constructor mock to be \`new\`-callable (caught during TDD).

## Test plan

- [x] 31 tests pass
- [x] Typecheck + lint clean

Closes #2159. Epic: #2151.