### PR TITLE
refactor(indexer): catalog is single source of truth for CLI commands (closes #2156, supersedes #2146)

### DIFF
--- a/packages/nexus-agents/src/cli-command-catalog.test.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   filterCatalog,
   groupByAudience,
   renderCommandsSection,
+  catalogForExtractors,
 } from './cli-command-catalog.js';
 import { renderHelp, HELP_TEXT } from './cli-help-text.js';
 
@@ -23,7 +24,7 @@ describe('cli-command-catalog (#2135)', () => {
     });
 
     it('tags every entry with a valid audience', () => {
-      const valid = new Set(['essential', 'advanced', 'maintainer']);
+      const valid = new Set(['essential', 'advanced', 'maintainer', 'internal']);
       for (const entry of COMMAND_CATALOG) {
         expect(valid.has(entry.audience)).toBe(true);
       }
@@ -43,15 +44,43 @@ describe('cli-command-catalog (#2135)', () => {
       }
     });
 
-    it('returns the full catalog when showAll=true', () => {
+    it('returns every non-internal entry when showAll=true (#2156)', () => {
+      // internal-tier entries are never shown in human-facing output, even
+      // under --all. The extractor path uses catalogForExtractors() instead.
       const filtered = filterCatalog(true);
-      expect(filtered.length).toBe(COMMAND_CATALOG.length);
+      const nonInternalCount = COMMAND_CATALOG.filter((e) => e.audience !== 'internal').length;
+      expect(filtered.length).toBe(nonInternalCount);
+      for (const entry of filtered) {
+        expect(entry.audience).not.toBe('internal');
+      }
+    });
+
+    it('always excludes internal-tier entries from human-facing output (#2156)', () => {
+      for (const entry of filterCatalog(false)) expect(entry.audience).not.toBe('internal');
+      for (const entry of filterCatalog(true)) expect(entry.audience).not.toBe('internal');
     });
 
     it('shrinks the visible surface in default mode', () => {
       const defaultCount = filterCatalog(false).length;
       const allCount = filterCatalog(true).length;
       expect(defaultCount).toBeLessThan(allCount);
+    });
+  });
+
+  describe('catalogForExtractors (#2156)', () => {
+    it('excludes the (default) placeholder — it has no handler', () => {
+      const extractor = catalogForExtractors();
+      expect(extractor.find((e) => e.command === '(default)')).toBeUndefined();
+    });
+
+    it('includes internal-tier entries (unlike filterCatalog)', () => {
+      const extractor = catalogForExtractors();
+      expect(extractor.some((e) => e.audience === 'internal')).toBe(true);
+    });
+
+    it('includes every real command (essential + advanced + maintainer + internal)', () => {
+      const expected = COMMAND_CATALOG.filter((e) => e.command !== '(default)').length;
+      expect(catalogForExtractors().length).toBe(expected);
     });
   });
 

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -17,7 +17,7 @@
  */
 
 /** Who the command is aimed at. Drives the default --help filter. */
-export type CommandAudience = 'essential' | 'advanced' | 'maintainer';
+export type CommandAudience = 'essential' | 'advanced' | 'maintainer' | 'internal';
 
 /** One entry per top-level command. */
 export interface CommandCatalogEntry {
@@ -36,6 +36,10 @@ export interface CommandCatalogEntry {
  *   capability inspection, workflow scaffolding, auth token rotation).
  * - **maintainer**: benchmarks, release tooling, self-audits, deep
  *   observability dashboards, dogfooding helpers.
+ * - **internal**: dev/eval loops that aren't part of the product surface
+ *   (e2e-eval, routing-ab, memory-benchmark). Hidden from both default
+ *   `--help` AND `--help --all`. Still present for entrypoint extraction
+ *   (repo-index / entrypoints.yaml) because they're real CLI commands.
  */
 export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   // ── Essential ────────────────────────────────────────────────────────────
@@ -223,12 +227,71 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     description: 'Generate release announcements (blog, social)',
     audience: 'maintainer',
   },
+
+  // ── Internal (hidden everywhere; here for extractor/index completeness) ──
+  {
+    command: 'server',
+    // Synonym for the no-arg invocation — `nexus-agents` and
+    // `nexus-agents server` both run `handleServerCommand`. Listed here for
+    // extractor completeness; humans see `(default)` in --help.
+    description: 'Start MCP server with stdio transport (explicit form)',
+    audience: 'internal',
+  },
+  {
+    command: 'e2e-eval',
+    description: 'E2E evaluation scenario runner (dev loop)',
+    audience: 'internal',
+  },
+  {
+    command: 'memory-benchmark',
+    description: 'Memory-system benchmark runner (dev loop)',
+    audience: 'internal',
+  },
+  {
+    command: 'memory-eval',
+    description: 'Comparative memory evaluation benchmark (dev loop)',
+    audience: 'internal',
+  },
+  {
+    command: 'routing-ab',
+    description: 'A/B comparison of routing strategies (dev loop)',
+    audience: 'internal',
+  },
+  {
+    command: 'scenario',
+    description: 'Execute a named scenario from the testing framework',
+    audience: 'internal',
+  },
+  {
+    command: 'warm-up',
+    description: 'Warm the model/adapter caches before a run',
+    audience: 'internal',
+  },
 ];
 
-/** Returns the catalog filtered by the `showAll` flag. */
+/**
+ * Returns the catalog filtered for `--help` output.
+ *
+ * - `showAll: false` → essential + advanced (the default `--help` surface)
+ * - `showAll: true` → essential + advanced + maintainer (`--help --all`)
+ *
+ * `internal` audience entries are **always excluded** from human-facing
+ * output. They're still reachable via `COMMAND_CATALOG` for extractors that
+ * need a complete inventory (repo-index, entrypoints.yaml).
+ */
 export function filterCatalog(showAll: boolean): readonly CommandCatalogEntry[] {
-  if (showAll) return COMMAND_CATALOG;
-  return COMMAND_CATALOG.filter((e) => e.audience !== 'maintainer');
+  const visible = COMMAND_CATALOG.filter((e) => e.audience !== 'internal');
+  if (showAll) return visible;
+  return visible.filter((e) => e.audience !== 'maintainer');
+}
+
+/**
+ * Returns every real top-level command, including internal ones, but
+ * excluding the `(default)` placeholder (no actual handler). Used by
+ * entrypoint extractors and the repo-index generator — #2156.
+ */
+export function catalogForExtractors(): readonly CommandCatalogEntry[] {
+  return COMMAND_CATALOG.filter((e) => e.command !== '(default)');
 }
 
 /** Groups entries by audience, preserving catalog order within each group. */
@@ -248,6 +311,9 @@ const AUDIENCE_HEADINGS: Record<CommandAudience, string> = {
   essential: 'Essential — install, configure, run',
   advanced: 'Advanced — day-to-day extras',
   maintainer: 'Maintainer — benchmarks, releases, deep diagnostics',
+  // Never rendered (filterCatalog strips internal before renderCommandsSection
+  // iterates), but required by the Record<CommandAudience, string> contract.
+  internal: 'Internal — dev/eval loops (hidden from --help)',
 };
 
 /**

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.test.ts
@@ -1,9 +1,11 @@
 /**
  * Tests for entrypoint-cli-extractor.
  *
- * Covers: extractCliCommands (exported), and exercises internal helpers
- * parseHelpTextCommands, toPascalCase, getCommandOptions, extractCliOptions
- * via mock ts-morph objects.
+ * Post-#2156 the extractor reads command names + descriptions from
+ * `cli-command-catalog.ts` (single source of truth) and only uses ts-morph
+ * for handler source-line lookups and PARSE_ARGS_CONFIG option parsing.
+ * Previous tests that fed synthetic HELP_TEXT strings into the regex
+ * parser were deleted — the regex is gone.
  *
  * @module indexer/entrypoint-cli-extractor.test
  */
@@ -11,14 +13,13 @@
 import { describe, it, expect } from 'vitest';
 import { SyntaxKind } from 'ts-morph';
 import { extractCliCommands } from './entrypoint-cli-extractor.js';
+import { COMMAND_CATALOG, catalogForExtractors } from '../cli-command-catalog.js';
 
 // ============================================================================
 // Mock Helpers
 // ============================================================================
 
-/**
- * Creates a mock option object literal with type, short, and default.
- */
+/** Creates a mock option object literal with type, short, and default. */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function makeMockOptionObjLiteral(optType?: string, short?: string, defaultVal?: string) {
   const props = new Map<string, string>();
@@ -34,9 +35,7 @@ function makeMockOptionObjLiteral(optType?: string, short?: string, defaultVal?:
         asKind: (kind: unknown) => {
           if (kind === SyntaxKind.PropertyAssignment) {
             return {
-              getInitializer: () => ({
-                getText: () => val,
-              }),
+              getInitializer: () => ({ getText: () => val }),
             };
           }
           return undefined;
@@ -46,12 +45,9 @@ function makeMockOptionObjLiteral(optType?: string, short?: string, defaultVal?:
   };
 }
 
-/**
- * Creates a mock SourceFile for the types file (HELP_TEXT + PARSE_ARGS_CONFIG).
- */
+/** Creates a mock SourceFile for cli-types.ts (PARSE_ARGS_CONFIG only). */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function makeMockTypesFile(
-  helpText: string,
   optionEntries: Array<{ name: string; type?: string; short?: string; default?: string }>
 ) {
   const optionProps = optionEntries.map((entry) => {
@@ -76,13 +72,6 @@ function makeMockTypesFile(
 
   return {
     getVariableDeclaration: (name: string) => {
-      if (name === 'HELP_TEXT') {
-        return {
-          getInitializer: () => ({
-            getText: () => '`' + helpText + '`',
-          }),
-        };
-      }
       if (name === 'PARSE_ARGS_CONFIG') {
         return {
           getInitializer: () => ({
@@ -98,9 +87,7 @@ function makeMockTypesFile(
                               getInitializer: () => ({
                                 asKind: (k3: unknown) => {
                                   if (k3 === SyntaxKind.ObjectLiteralExpression) {
-                                    return {
-                                      getProperties: () => optionProps,
-                                    };
+                                    return { getProperties: () => optionProps };
                                   }
                                   return undefined;
                                 },
@@ -125,9 +112,7 @@ function makeMockTypesFile(
   };
 }
 
-/**
- * Creates a mock commands SourceFile with function declarations.
- */
+/** Creates a mock commands SourceFile. Pass a map of handlerName → line. */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function makeMockCommandsFile(handlers: Record<string, number>) {
   return {
@@ -139,9 +124,7 @@ function makeMockCommandsFile(handlers: Record<string, number>) {
   };
 }
 
-/**
- * Creates a mock Project that returns specific source files.
- */
+/** Creates a mock Project that returns specific source files by suffix match. */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function makeMockProject(files: Record<string, unknown>) {
   return {
@@ -155,172 +138,13 @@ function makeMockProject(files: Record<string, unknown>) {
 }
 
 // ============================================================================
-// HELP_TEXT Fixtures
+// Tests
 // ============================================================================
 
-const BASIC_HELP_TEXT = `
-nexus-agents - Multi-agent orchestration
-
-COMMANDS:
-  doctor          Check system health
-  orchestrate     Run task orchestration
-  vote            Consensus voting
-
-OPTIONS:
-  --help          Show help
-`;
-
-const HELP_TEXT_WITH_SUBCOMMANDS = `
-COMMANDS:
-  workflow list   List available workflows
-  workflow run    Run a workflow
-  config init     Initialize configuration
-  config show     Show current config
-  doctor          Check system health
-`;
-
-const EMPTY_HELP_TEXT = `
-nexus-agents
-
-OPTIONS:
-  --help   Show help
-`;
-
-const HELP_TEXT_NO_COMMANDS_SECTION = `
-nexus-agents - Multi-agent orchestration
-
-OPTIONS:
-  --verbose       Enable verbose output
-`;
-
-const HELP_TEXT_WITH_DEFAULT = `
-COMMANDS:
-  (default)       Show help text
-  doctor          Check system health
-  orchestrate     Orchestrate tasks
-`;
-
-// ============================================================================
-// extractCliCommands Tests
-// ============================================================================
-
-describe('extractCliCommands', () => {
-  // --------------------------------------------------------------------------
-  // Basic extraction
-  // --------------------------------------------------------------------------
-
-  describe('basic command extraction', () => {
-    it('should extract simple commands from HELP_TEXT', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-        handleOrchestrateCommand: 50,
-        handleVoteCommand: 100,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toHaveLength(3);
-      const names = result.map((c) => c.name);
-      expect(names).toContain('doctor');
-      expect(names).toContain('orchestrate');
-      expect(names).toContain('vote');
-    });
-
-    it('finds HELP_TEXT in cli-help-text.ts when cli-types.ts only has PARSE_ARGS_CONFIG (regression: 3-month silent empty output)', () => {
-      // Simulates the real layout after #293 (Jan 2026): HELP_TEXT lives in
-      // cli-help-text.ts and cli-types.ts only re-exports it. Prior to the
-      // fix, the extractor only looked in cli-types.ts and returned zero
-      // commands. See fix/entrypoint-cli-extractor-help-text-load.
-      const typesFile = makeMockTypesFile('', []);
-      // Override so the types file intentionally has no HELP_TEXT declaration
-      // — mirrors the real post-split state where only a re-export exists.
-      (typesFile as { getVariableDeclaration: (name: string) => unknown }).getVariableDeclaration =
-        (name: string) =>
-          name === 'HELP_TEXT' ? undefined : makeMockTypesFile('', []).getVariableDeclaration(name);
-
-      const helpTextFile = {
-        getVariableDeclaration: (name: string) =>
-          name === 'HELP_TEXT'
-            ? { getInitializer: () => ({ getText: () => '`' + BASIC_HELP_TEXT + '`' }) }
-            : undefined,
-      };
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-        handleOrchestrateCommand: 50,
-        handleVoteCommand: 100,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-help-text.ts': helpTextFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toHaveLength(3);
-      expect(result.map((c) => c.name)).toEqual(
-        expect.arrayContaining(['doctor', 'orchestrate', 'vote'])
-      );
-    });
-
-    it('should extract command descriptions', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({ handleDoctorCommand: 10 });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      expect(doctor).toBeDefined();
-      expect(doctor?.description).toBe('Check system health');
-    });
-
-    it('should set source_line from handler function', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 42,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      expect(doctor?.source_line).toBe(42);
-    });
-
-    it('should default source_line to 1 when handler not found', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
+describe('extractCliCommands (post-#2156: reads from catalog)', () => {
+  describe('catalog-driven extraction', () => {
+    it('emits exactly the commands in the catalog (minus the (default) placeholder)', () => {
+      const typesFile = makeMockTypesFile([]);
       const cmdsFile = makeMockCommandsFile({});
       const project = makeMockProject({
         'cli-types.ts': typesFile,
@@ -334,24 +158,15 @@ describe('extractCliCommands', () => {
         'cli-types.ts'
       );
 
+      expect(result.length).toBe(catalogForExtractors().length);
       for (const cmd of result) {
-        expect(cmd.source_line).toBe(1);
+        expect(cmd.name).not.toBe('(default)');
       }
     });
-  });
 
-  // --------------------------------------------------------------------------
-  // Subcommand extraction
-  // --------------------------------------------------------------------------
-
-  describe('subcommand extraction', () => {
-    it('should extract subcommands for composite commands', () => {
-      const typesFile = makeMockTypesFile(HELP_TEXT_WITH_SUBCOMMANDS, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleWorkflowCommand: 10,
-        handleConfigCommand: 50,
-        handleDoctorCommand: 90,
-      });
+    it('preserves the catalog description verbatim', () => {
+      const typesFile = makeMockTypesFile([]);
+      const cmdsFile = makeMockCommandsFile({ handleDoctorCommand: 42 });
       const project = makeMockProject({
         'cli-types.ts': typesFile,
         'cli-commands.ts': cmdsFile,
@@ -363,37 +178,13 @@ describe('extractCliCommands', () => {
         'cli-commands.ts',
         'cli-types.ts'
       );
-
-      const workflow = result.find((c) => c.name === 'workflow');
-      expect(workflow).toBeDefined();
-      expect(workflow?.subcommands).toContain('list');
-      expect(workflow?.subcommands).toContain('run');
+      const doctor = result.find((c) => c.name === 'doctor');
+      const catalogDoctor = COMMAND_CATALOG.find((c) => c.command === 'doctor');
+      expect(doctor?.description).toBe(catalogDoctor?.description);
     });
 
-    it('should group subcommands under the same parent', () => {
-      const typesFile = makeMockTypesFile(HELP_TEXT_WITH_SUBCOMMANDS, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleConfigCommand: 50,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const config = result.find((c) => c.name === 'config');
-      expect(config).toBeDefined();
-      expect(config?.subcommands).toEqual(['init', 'show']);
-    });
-
-    it('should not add subcommands property for simple commands', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
+    it('emits internal-tier commands (#2156 — they are real commands, just hidden from --help)', () => {
+      const typesFile = makeMockTypesFile([]);
       const cmdsFile = makeMockCommandsFile({});
       const project = makeMockProject({
         'cli-types.ts': typesFile,
@@ -406,265 +197,115 @@ describe('extractCliCommands', () => {
         'cli-commands.ts',
         'cli-types.ts'
       );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      expect(doctor?.subcommands).toBeUndefined();
+      const names = result.map((c) => c.name);
+      expect(names).toContain('e2e-eval');
+      expect(names).toContain('warm-up');
+      expect(names).toContain('memory-benchmark');
     });
   });
 
-  // --------------------------------------------------------------------------
-  // Options mapping
-  // --------------------------------------------------------------------------
+  describe('source_line lookup via ts-morph', () => {
+    it('uses the handler function start line when found', () => {
+      const typesFile = makeMockTypesFile([]);
+      const cmdsFile = makeMockCommandsFile({
+        handleDoctorCommand: 42,
+        handleOrchestrateCommand: 100,
+      });
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-commands.ts': cmdsFile,
+      });
 
-  describe('options mapping', () => {
-    it('should attach options for orchestrate command', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'model', type: "'string'", short: "'m'" },
+      const result = extractCliCommands(
+        project as never,
+        '/pkg',
+        'cli-commands.ts',
+        'cli-types.ts'
+      );
+      expect(result.find((c) => c.name === 'doctor')?.source_line).toBe(42);
+      expect(result.find((c) => c.name === 'orchestrate')?.source_line).toBe(100);
+    });
+
+    it('defaults source_line to 1 when handler not found', () => {
+      const typesFile = makeMockTypesFile([]);
+      const cmdsFile = makeMockCommandsFile({});
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-commands.ts': cmdsFile,
+      });
+
+      const result = extractCliCommands(
+        project as never,
+        '/pkg',
+        'cli-commands.ts',
+        'cli-types.ts'
+      );
+      // All handlers missing from mock → source_line is 1 for every command.
+      expect(result.every((c) => c.source_line === 1)).toBe(true);
+    });
+  });
+
+  describe('option binding', () => {
+    it('attaches orchestrate options', () => {
+      const typesFile = makeMockTypesFile([
+        { name: 'model', type: "'string'" },
         { name: 'format', type: "'string'" },
-        { name: 'verbose', type: "'boolean'", short: "'v'" },
-        { name: 'dry-run', type: "'boolean'" },
-        { name: 'max-tokens', type: "'string'" },
-        { name: 'max-cost-usd', type: "'string'" },
+        { name: 'verbose', type: "'boolean'" },
       ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleOrchestrateCommand: 20,
-      });
+      const cmdsFile = makeMockCommandsFile({});
       const project = makeMockProject({
         'cli-types.ts': typesFile,
         'cli-commands.ts': cmdsFile,
       });
-
       const result = extractCliCommands(
         project as never,
         '/pkg',
         'cli-commands.ts',
         'cli-types.ts'
       );
-
       const orchestrate = result.find((c) => c.name === 'orchestrate');
-      expect(orchestrate?.options).toBeDefined();
-      expect(orchestrate?.options?.length).toBe(6);
-      const optNames = orchestrate?.options?.map((o) => o.name) ?? [];
-      expect(optNames).toContain('model');
-      expect(optNames).toContain('verbose');
-      expect(optNames).toContain('dry-run');
+      const optNames = (orchestrate as unknown as { options?: { name: string }[] }).options?.map(
+        (o) => o.name
+      );
+      expect(optNames).toEqual(expect.arrayContaining(['model', 'format', 'verbose']));
     });
 
-    it('should attach options for vote command', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'proposal', type: "'string'" },
-        { name: 'threshold', type: "'string'" },
-        { name: 'quick', type: "'boolean'" },
+    it('attaches routing-audit options', () => {
+      const typesFile = makeMockTypesFile([
+        { name: 'format', type: "'string'" },
+        { name: 'verbose', type: "'boolean'" },
         { name: 'dry-run', type: "'boolean'" },
-        { name: 'verbose', type: "'boolean'" },
+        { name: 'bandit-stats', type: "'boolean'" },
       ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleVoteCommand: 30,
-      });
+      const cmdsFile = makeMockCommandsFile({});
       const project = makeMockProject({
         'cli-types.ts': typesFile,
         'cli-commands.ts': cmdsFile,
       });
-
       const result = extractCliCommands(
         project as never,
         '/pkg',
         'cli-commands.ts',
         'cli-types.ts'
       );
-
-      const vote = result.find((c) => c.name === 'vote');
-      expect(vote?.options).toBeDefined();
-      const optNames = vote?.options?.map((o) => o.name) ?? [];
-      expect(optNames).toContain('proposal');
-      expect(optNames).toContain('threshold');
-      expect(optNames).toContain('quick');
-    });
-
-    it('should default to verbose+help for unknown commands', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'verbose', type: "'boolean'" },
-        { name: 'help', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
+      const routing = result.find((c) => c.name === 'routing-audit');
+      const optNames = (routing as unknown as { options?: { name: string }[] }).options?.map(
+        (o) => o.name
       );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      expect(doctor?.options).toBeDefined();
-      const optNames = doctor?.options?.map((o) => o.name) ?? [];
-      expect(optNames).toContain('verbose');
-      expect(optNames).toContain('help');
-    });
-
-    it('should not add options when none match', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      expect(doctor?.options).toBeUndefined();
-    });
-
-    it('should parse option type removing quotes and as-const', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'verbose', type: "'boolean' as const" },
-        { name: 'help', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      const verbose = doctor?.options?.find((o) => o.name === 'verbose');
-      expect(verbose?.type).toBe('boolean');
-    });
-
-    it('should extract short alias from options', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'verbose', type: "'boolean'", short: "'v'" },
-        { name: 'help', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      const verbose = doctor?.options?.find((o) => o.name === 'verbose');
-      expect(verbose?.short).toBe('v');
-    });
-
-    it('should extract default value from options', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, [
-        { name: 'verbose', type: "'boolean'", default: 'false' },
-        { name: 'help', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const doctor = result.find((c) => c.name === 'doctor');
-      const verbose = doctor?.options?.find((o) => o.name === 'verbose');
-      expect(verbose?.default).toBe('false');
+      expect(optNames).toEqual(expect.arrayContaining(['format', 'verbose']));
     });
   });
 
-  // --------------------------------------------------------------------------
-  // Edge cases
-  // --------------------------------------------------------------------------
-
-  describe('edge cases', () => {
-    it('should return empty array when types file not found', () => {
-      const cmdsFile = makeMockCommandsFile({});
-      const project = makeMockProject({
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('should return empty array when commands file not found', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('pushes a warning when commands file not found (#2153)', () => {
-      // Regression: previously empty-return with no signal. #2147's 3-month
-      // silent regression was the same class. Now surfaces via warnings.
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
+  describe('warnings channel (#2153)', () => {
+    it('pushes a warning when commands file not found', () => {
+      const typesFile = makeMockTypesFile([]);
       const project = makeMockProject({ 'cli-types.ts': typesFile });
       const warnings: string[] = [];
       extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
       expect(warnings.some((w) => /commands file not loaded/.test(w))).toBe(true);
     });
 
-    it('pushes a warning when HELP_TEXT parses to zero commands (#2153)', () => {
-      const typesFile = makeMockTypesFile(EMPTY_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({});
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-      const warnings: string[] = [];
-      extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
-      expect(warnings.some((w) => /HELP_TEXT parsed to zero commands/.test(w))).toBe(true);
-    });
-
-    it('pushes a warning when types file not loaded (#2153)', () => {
+    it('pushes a warning when types file not loaded (options missing)', () => {
       const cmdsFile = makeMockCommandsFile({});
       const project = makeMockProject({ 'cli-commands.ts': cmdsFile });
       const warnings: string[] = [];
@@ -672,276 +313,29 @@ describe('extractCliCommands', () => {
       expect(warnings.some((w) => /types file not loaded/.test(w))).toBe(true);
     });
 
-    it('does not push warnings when warnings array is not provided (backwards compat)', () => {
-      const project = makeMockProject({});
-      // No warnings arg — must not throw.
+    it('pushes a warning when a cataloged command has no matching handler (naming drift)', () => {
+      const typesFile = makeMockTypesFile([]);
+      // Only `doctor` has a handler; other catalog entries trigger the warning.
+      const cmdsFile = makeMockCommandsFile({ handleDoctorCommand: 10 });
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-commands.ts': cmdsFile,
+      });
+      const warnings: string[] = [];
+      extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts', warnings);
+      expect(warnings.some((w) => /naming drift/.test(w))).toBe(true);
+    });
+
+    it('is backwards compatible — works without the warnings arg', () => {
+      const typesFile = makeMockTypesFile([]);
+      const cmdsFile = makeMockCommandsFile({});
+      const project = makeMockProject({
+        'cli-types.ts': typesFile,
+        'cli-commands.ts': cmdsFile,
+      });
       expect(() => {
         extractCliCommands(project as never, '/pkg', 'cli-commands.ts', 'cli-types.ts');
       }).not.toThrow();
-    });
-
-    it('should return empty array for empty HELP_TEXT', () => {
-      const typesFile = makeMockTypesFile(EMPTY_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({});
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('should return empty when HELP_TEXT has no COMMANDS section', () => {
-      const typesFile = makeMockTypesFile(HELP_TEXT_NO_COMMANDS_SECTION, []);
-      const cmdsFile = makeMockCommandsFile({});
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('should skip (default) command from HELP_TEXT', () => {
-      const typesFile = makeMockTypesFile(HELP_TEXT_WITH_DEFAULT, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-        handleOrchestrateCommand: 20,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const names = result.map((c) => c.name);
-      expect(names).not.toContain('(default)');
-      expect(names).toContain('doctor');
-      expect(names).toContain('orchestrate');
-    });
-
-    it('should handle HELP_TEXT variable missing entirely', () => {
-      const typesFile = {
-        getVariableDeclaration: () => undefined,
-      };
-      const cmdsFile = makeMockCommandsFile({});
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('should handle PARSE_ARGS_CONFIG missing', () => {
-      const typesFile = {
-        getVariableDeclaration: (name: string) => {
-          if (name === 'HELP_TEXT') {
-            return {
-              getInitializer: () => ({
-                getText: () => '`' + BASIC_HELP_TEXT + '`',
-              }),
-            };
-          }
-          return undefined;
-        },
-      };
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result.length).toBeGreaterThan(0);
-      // No options should be attached since PARSE_ARGS_CONFIG is missing
-      for (const cmd of result) {
-        expect(cmd.options).toBeUndefined();
-      }
-    });
-
-    it('should include source_file as relative path', () => {
-      const typesFile = makeMockTypesFile(BASIC_HELP_TEXT, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 5,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      for (const cmd of result) {
-        expect(cmd.source_file).toBeDefined();
-        expect(typeof cmd.source_file).toBe('string');
-      }
-    });
-  });
-
-  // --------------------------------------------------------------------------
-  // toPascalCase via handler lookup
-  // --------------------------------------------------------------------------
-
-  describe('toPascalCase (via handler name)', () => {
-    it('should convert kebab-case command to PascalCase handler', () => {
-      const helpText = `
-COMMANDS:
-  routing-audit     Audit routing decisions
-`;
-      const typesFile = makeMockTypesFile(helpText, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleRoutingAuditCommand: 77,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const routingAudit = result.find((c) => c.name === 'routing-audit');
-      expect(routingAudit).toBeDefined();
-      expect(routingAudit?.source_line).toBe(77);
-    });
-
-    it('should handle single-word commands (no hyphens)', () => {
-      const helpText = `
-COMMANDS:
-  doctor     Check health
-`;
-      const typesFile = makeMockTypesFile(helpText, []);
-      const cmdsFile = makeMockCommandsFile({
-        handleDoctorCommand: 33,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      expect(result[0]?.source_line).toBe(33);
-    });
-  });
-
-  // --------------------------------------------------------------------------
-  // Command-specific option routing
-  // --------------------------------------------------------------------------
-
-  describe('command-specific option routing', () => {
-    it('should map routing-audit to format+verbose+dry-run+bandit-stats', () => {
-      const helpText = `
-COMMANDS:
-  routing-audit     Audit routing decisions
-`;
-      const typesFile = makeMockTypesFile(helpText, [
-        { name: 'format', type: "'string'" },
-        { name: 'verbose', type: "'boolean'" },
-        { name: 'dry-run', type: "'boolean'" },
-        { name: 'bandit-stats', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleRoutingAuditCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const audit = result.find((c) => c.name === 'routing-audit');
-      const optNames = audit?.options?.map((o) => o.name) ?? [];
-      expect(optNames).toContain('format');
-      expect(optNames).toContain('bandit-stats');
-    });
-
-    it('should map index command to format+output+verbose', () => {
-      const helpText = `
-COMMANDS:
-  index     Index codebase
-`;
-      const typesFile = makeMockTypesFile(helpText, [
-        { name: 'format', type: "'string'" },
-        { name: 'output', type: "'string'" },
-        { name: 'verbose', type: "'boolean'" },
-      ]);
-      const cmdsFile = makeMockCommandsFile({
-        handleIndexCommand: 10,
-      });
-      const project = makeMockProject({
-        'cli-types.ts': typesFile,
-        'cli-commands.ts': cmdsFile,
-      });
-
-      const result = extractCliCommands(
-        project as never,
-        '/pkg',
-        'cli-commands.ts',
-        'cli-types.ts'
-      );
-
-      const index = result.find((c) => c.name === 'index');
-      const optNames = index?.options?.map((o) => o.name) ?? [];
-      expect(optNames).toContain('format');
-      expect(optNames).toContain('output');
-      expect(optNames).toContain('verbose');
     });
   });
 });

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
@@ -1,7 +1,18 @@
 /**
  * nexus-agents/indexer - CLI Command Extractor
  *
- * Extracts CLI commands from source code using TypeScript AST parsing.
+ * Emits `CliCommandSpec[]` for the entrypoints manifest.
+ *
+ * Command names + descriptions are read from the `cli-command-catalog.ts`
+ * single-source-of-truth (#2156). Handler source lines and per-command
+ * option bindings are still resolved via ts-morph against
+ * `cli-commands.ts` and `cli-types.ts`.
+ *
+ * Prior to #2156 this module parsed commands out of the HELP_TEXT string
+ * via regex — that regex had a long-standing miss on long command names
+ * (#2146, release-validate / release-announce / learning-metrics) and
+ * silently disagreed with `scripts/generate-repo-index.ts` on command
+ * count. Reading from the catalog removes both failure modes.
  *
  * (Source: Epic #261 - Automated Documentation System)
  */
@@ -9,77 +20,7 @@
 import { SyntaxKind, type Project, type SourceFile } from 'ts-morph';
 import * as path from 'node:path';
 import type { CliCommandSpec, OptionSpec } from './entrypoint-types.js';
-
-// ============================================================================
-// Types
-// ============================================================================
-
-/**
- * CLI command metadata from HELP_TEXT parsing.
- */
-interface CliCommandMeta {
-  name: string;
-  description: string;
-  subcommands: string[];
-}
-
-// ============================================================================
-// HELP_TEXT Parsing
-// ============================================================================
-
-/**
- * Parses CLI commands from the HELP_TEXT constant.
- * Looks for the COMMANDS: section and extracts command names/descriptions.
- */
-// eslint-disable-next-line complexity -- AST parsing requires nested conditions
-function parseHelpTextCommands(helpText: string): CliCommandMeta[] {
-  const commands: CliCommandMeta[] = [];
-  const lines = helpText.split('\n');
-  let inCommandsSection = false;
-
-  for (const line of lines) {
-    // Detect section boundaries
-    if (line.trim() === 'COMMANDS:') {
-      inCommandsSection = true;
-      continue;
-    }
-    const trimmed = line.trim();
-    if (trimmed.endsWith(':') && trimmed !== 'COMMANDS:' && !trimmed.startsWith('-')) {
-      inCommandsSection = false;
-      continue;
-    }
-
-    if (!inCommandsSection) continue;
-
-    // Parse command lines (format: "  command       Description")
-    const match = line.match(/^\s{2}(\S+(?:\s+\S+)?)\s{2,}(.+)$/);
-    if (match !== null) {
-      const cmdPart = match[1];
-      const descriptionPart = match[2];
-      if (cmdPart === undefined || descriptionPart === undefined) continue;
-
-      const parts = cmdPart.trim().split(/\s+/);
-      const name = parts[0];
-      if (name === undefined) continue;
-
-      const subcommand = parts.length > 1 ? parts[1] : undefined;
-
-      // Find existing command or create new
-      const existing = commands.find((c) => c.name === name);
-      if (existing !== undefined && subcommand !== undefined) {
-        existing.subcommands.push(subcommand);
-      } else if (existing === undefined) {
-        commands.push({
-          name,
-          description: descriptionPart.trim(),
-          subcommands: subcommand !== undefined ? [subcommand] : [],
-        });
-      }
-    }
-  }
-
-  return commands;
-}
+import { catalogForExtractors } from '../cli-command-catalog.js';
 
 // ============================================================================
 // Options Extraction
@@ -122,24 +63,9 @@ function extractCliOptions(sourceFile: SourceFile): Map<string, OptionSpec> {
       type: 'string', // Default
     };
 
-    // Consolidated from three near-identical extractOption* helpers (#2160).
-    // Each field does the same ts-morph traversal, differing only in name and
-    // post-processing. `type` strips both quotes and `as const`; `short`
-    // strips quotes; `default` keeps the raw text.
-    const typeRaw = extractOptionProperty(optValue, 'type');
-    if (typeRaw !== undefined) {
-      const t = typeRaw.replace(/['"]/g, '').replace(' as const', '');
-      if (t !== '') (spec as { type: string }).type = t;
-    }
-    const shortRaw = extractOptionProperty(optValue, 'short');
-    if (shortRaw !== undefined) {
-      const s = shortRaw.replace(/['"]/g, '');
-      if (s !== '') (spec as { short: string }).short = s;
-    }
-    const defaultRaw = extractOptionProperty(optValue, 'default');
-    if (defaultRaw !== undefined && defaultRaw !== '') {
-      (spec as { default: string }).default = defaultRaw;
-    }
+    extractOptionType(optValue, spec);
+    extractOptionShort(optValue, spec);
+    extractOptionDefault(optValue, spec);
 
     options.set(optName, spec);
   }
@@ -148,29 +74,76 @@ function extractCliOptions(sourceFile: SourceFile): Map<string, OptionSpec> {
 }
 
 /**
- * Returns the raw `getText()` of a named property inside an option object
- * literal, or `undefined` if the property (or its initializer) is absent.
- *
- * Consolidates three nearly-identical helpers (`extractOptionType`,
- * `extractOptionShort`, `extractOptionDefault`) that each walked the same
- * three-level ts-morph null-guard chain differing only in the property name
- * and trailing string normalization (#2160). Callers normalize the returned
- * raw text themselves.
+ * Extracts the type from an option object.
  */
-function extractOptionProperty(optValue: unknown, propName: string): string | undefined {
+function extractOptionType(optValue: unknown, spec: OptionSpec): void {
   const obj = optValue as {
     getProperty(name: string): { asKind(kind: unknown): unknown } | undefined;
   };
-  const prop = obj.getProperty(propName);
-  if (prop === undefined) return undefined;
+  const typeProp = obj.getProperty('type');
+  if (typeProp === undefined) return;
 
-  const propAssign = prop.asKind(SyntaxKind.PropertyAssignment) as
+  const propAssign = typeProp.asKind(SyntaxKind.PropertyAssignment) as
     | { getInitializer(): { getText(): string } | undefined }
     | undefined;
-  if (propAssign === undefined) return undefined;
+  if (propAssign === undefined) return;
 
   const init = propAssign.getInitializer();
-  return init?.getText();
+  if (init === undefined) return;
+
+  const text = init.getText();
+  const typeValue = text.replace(/['"]/g, '').replace(' as const', '');
+  if (typeValue !== '') {
+    (spec as { type: string }).type = typeValue;
+  }
+}
+
+/**
+ * Extracts the short alias from an option object.
+ */
+function extractOptionShort(optValue: unknown, spec: OptionSpec): void {
+  const obj = optValue as {
+    getProperty(name: string): { asKind(kind: unknown): unknown } | undefined;
+  };
+  const shortProp = obj.getProperty('short');
+  if (shortProp === undefined) return;
+
+  const propAssign = shortProp.asKind(SyntaxKind.PropertyAssignment) as
+    | { getInitializer(): { getText(): string } | undefined }
+    | undefined;
+  if (propAssign === undefined) return;
+
+  const init = propAssign.getInitializer();
+  if (init === undefined) return;
+
+  const text = init.getText().replace(/['"]/g, '');
+  if (text !== '') {
+    (spec as { short: string }).short = text;
+  }
+}
+
+/**
+ * Extracts the default value from an option object.
+ */
+function extractOptionDefault(optValue: unknown, spec: OptionSpec): void {
+  const obj = optValue as {
+    getProperty(name: string): { asKind(kind: unknown): unknown } | undefined;
+  };
+  const defaultProp = obj.getProperty('default');
+  if (defaultProp === undefined) return;
+
+  const propAssign = defaultProp.asKind(SyntaxKind.PropertyAssignment) as
+    | { getInitializer(): { getText(): string } | undefined }
+    | undefined;
+  if (propAssign === undefined) return;
+
+  const init = propAssign.getInitializer();
+  if (init === undefined) return;
+
+  const text = init.getText();
+  if (text !== '') {
+    (spec as { default: string }).default = text;
+  }
 }
 
 // ============================================================================
@@ -189,6 +162,10 @@ function toPascalCase(str: string): string {
 
 /**
  * Maps command options based on command name.
+ *
+ * Legacy hand-crafted mapping from before PARSE_ARGS_CONFIG was parseable
+ * via ts-morph. Kept for stability of the manifest output — switching it
+ * to a declarative per-command option list is a separate change.
  */
 function getCommandOptions(name: string, cliOptions: Map<string, OptionSpec>): OptionSpec[] {
   const cmdOptions: OptionSpec[] = [];
@@ -216,78 +193,56 @@ function getCommandOptions(name: string, cliOptions: Map<string, OptionSpec>): O
   return cmdOptions;
 }
 
-/**
- * Loads and parses the CLI command metadata from HELP_TEXT.
- *
- * HELP_TEXT was split out of cli-types.ts in #293 (Jan 2026) and now lives
- * in cli-help-text.ts. cli-types.ts only re-exports it; ts-morph doesn't
- * chase re-exports for variable declarations, so we read from the source
- * file directly. The typesFile fallback is kept for robustness.
- */
-function loadHelpTextCommands(
-  project: Project,
-  packageRoot: string,
-  typesFile: SourceFile | undefined
-): CliCommandMeta[] {
-  const helpTextPath = path.join(packageRoot, 'src/cli-help-text.ts');
-  const helpTextFile = project.getSourceFile(helpTextPath) ?? typesFile;
-  if (helpTextFile === undefined) return [];
-
-  const helpTextVar = helpTextFile.getVariableDeclaration('HELP_TEXT');
-  if (helpTextVar === undefined) return [];
-
-  const helpText = helpTextVar.getInitializer()?.getText() ?? '';
-  const cleanText = helpText
-    .slice(1, -1)
-    .replace(/^\s*\n/, '')
-    .replace(/\n\s*$/, '');
-  return parseHelpTextCommands(cleanText);
+/** Per-catalog-entry build context — packaged to keep buildCommandSpec ≤5 params. */
+interface BuildContext {
+  readonly commandsFile: SourceFile;
+  readonly relativePath: string;
+  readonly cliOptions: Map<string, OptionSpec>;
+  readonly cliCommandsPath: string;
+  readonly warnings?: string[];
 }
 
 /**
- * Emits non-fatal diagnostics for the silent-empty paths that caused the
- * 3-month regression fixed in #2147 (#2153). Extracted from
- * `extractCliCommands` to keep that function under the 50-line cap.
+ * Builds one `CliCommandSpec` from a catalog entry. Extracted to keep
+ * `extractCliCommands` under the 50-line cap.
  */
-function pushExtractionWarnings(
-  warnings: string[] | undefined,
-  issue: {
-    typesFile: SourceFile | undefined;
-    typesFullPath: string;
-    helpTextCount: number;
-    commandsFile: SourceFile | undefined;
-    commandsFullPath: string;
-  }
-): void {
-  if (warnings === undefined) return;
-  if (issue.typesFile === undefined) {
-    warnings.push(
-      `CLI extraction: types file not loaded (${issue.typesFullPath}). ` +
-        `PARSE_ARGS_CONFIG options will be missing from the manifest.`
+function buildCommandSpec(
+  entry: { command: string; description: string },
+  ctx: BuildContext
+): CliCommandSpec {
+  const handlerName = `handle${toPascalCase(entry.command)}Command`;
+  const handlerFunc = ctx.commandsFile.getFunction(handlerName);
+  const sourceLine = handlerFunc?.getStartLineNumber() ?? 1;
+
+  if (handlerFunc === undefined && ctx.warnings !== undefined) {
+    ctx.warnings.push(
+      `CLI extraction: catalog entry "${entry.command}" has no matching ` +
+        `${handlerName} function in ${ctx.cliCommandsPath}. Check naming drift.`
     );
   }
-  if (issue.helpTextCount === 0) {
-    warnings.push(
-      `CLI extraction: HELP_TEXT parsed to zero commands. ` +
-        `Check cli-help-text.ts is in the ts-morph project and COMMANDS: section is present.`
-    );
+
+  const cmdOptions = getCommandOptions(entry.command, ctx.cliOptions);
+  const cmdSpec: CliCommandSpec = {
+    name: entry.command,
+    description: entry.description,
+    source_file: ctx.relativePath,
+    source_line: sourceLine,
+  };
+  if (cmdOptions.length > 0) {
+    (cmdSpec as { options: readonly OptionSpec[] }).options = cmdOptions;
   }
-  if (issue.commandsFile === undefined) {
-    warnings.push(
-      `CLI extraction: commands file not loaded (${issue.commandsFullPath}). ` +
-        `Returning zero commands.`
-    );
-  }
+  return cmdSpec;
 }
 
 /**
- * Extracts CLI commands from source files.
+ * Extracts CLI commands from the catalog + cli-commands source file.
  *
- * @param warnings - Optional sink for non-fatal diagnostics. When supplied,
- *   the extractor surfaces silent-empty paths (missing cli-types.ts, HELP_TEXT
- *   parsed as empty, cli-commands.ts not in the ts-morph project) as actionable
- *   messages (#2153). Same class as the 3-month silent regression fixed in
- *   #2147.
+ * Name and description come from `cli-command-catalog.ts`. Handler source
+ * location comes from locating `handle<PascalName>Command` in
+ * `cli-commands.ts` via ts-morph. Option bindings come from
+ * `PARSE_ARGS_CONFIG` in `cli-types.ts`.
+ *
+ * @param warnings - Optional sink for non-fatal diagnostics (#2153).
  */
 export function extractCliCommands(
   project: Project,
@@ -296,56 +251,35 @@ export function extractCliCommands(
   cliTypesPath: string,
   warnings?: string[]
 ): CliCommandSpec[] {
-  const commands: CliCommandSpec[] = [];
-
   const typesFullPath = path.join(packageRoot, cliTypesPath);
   const typesFile = project.getSourceFile(typesFullPath);
-  const helpTextCommands = loadHelpTextCommands(project, packageRoot, typesFile);
+  if (typesFile === undefined && warnings !== undefined) {
+    warnings.push(
+      `CLI extraction: types file not loaded (${typesFullPath}). ` +
+        `PARSE_ARGS_CONFIG options will be missing from the manifest.`
+    );
+  }
   const cliOptions =
     typesFile !== undefined ? extractCliOptions(typesFile) : new Map<string, OptionSpec>();
 
   const commandsFullPath = path.join(packageRoot, cliCommandsPath);
   const commandsFile = project.getSourceFile(commandsFullPath);
-
-  pushExtractionWarnings(warnings, {
-    typesFile,
-    typesFullPath,
-    helpTextCount: helpTextCommands.length,
-    commandsFile,
-    commandsFullPath,
-  });
-
-  if (commandsFile === undefined) return commands;
-
-  // Map commands from HELP_TEXT with source locations from switch cases
-  const relativePath = path.relative(process.cwd(), commandsFullPath);
-
-  for (const cmdMeta of helpTextCommands) {
-    // Skip (default) command as it's not a real command
-    if (cmdMeta.name === '(default)') continue;
-
-    // Find the handler function for this command
-    const handlerName = `handle${toPascalCase(cmdMeta.name)}Command`;
-    const handlerFunc = commandsFile.getFunction(handlerName);
-    const sourceLine = handlerFunc?.getStartLineNumber() ?? 1;
-
-    // Get options for this command
-    const cmdOptions = getCommandOptions(cmdMeta.name, cliOptions);
-
-    const cmdSpec: CliCommandSpec = {
-      name: cmdMeta.name,
-      description: cmdMeta.description,
-      source_file: relativePath,
-      source_line: sourceLine,
-    };
-    if (cmdMeta.subcommands.length > 0) {
-      (cmdSpec as { subcommands: readonly string[] }).subcommands = cmdMeta.subcommands;
+  if (commandsFile === undefined) {
+    if (warnings !== undefined) {
+      warnings.push(
+        `CLI extraction: commands file not loaded (${commandsFullPath}). ` +
+          `Returning zero commands.`
+      );
     }
-    if (cmdOptions.length > 0) {
-      (cmdSpec as { options: readonly OptionSpec[] }).options = cmdOptions;
-    }
-    commands.push(cmdSpec);
+    return [];
   }
 
-  return commands;
+  const ctx: BuildContext = {
+    commandsFile,
+    relativePath: path.relative(process.cwd(), commandsFullPath),
+    cliOptions,
+    cliCommandsPath,
+    ...(warnings !== undefined && { warnings }),
+  };
+  return catalogForExtractors().map((entry) => buildCommandSpec(entry, ctx));
 }

--- a/scripts/generate-repo-index.ts
+++ b/scripts/generate-repo-index.ts
@@ -19,6 +19,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { catalogForExtractors } from '../packages/nexus-agents/src/cli-command-catalog.js';
 
 // ============================================================================
 // Configuration
@@ -138,6 +139,27 @@ function extractCLICommands(): CLICommand[] {
   const asyncBlock = asyncMatch?.[1];
   if (asyncBlock !== undefined) {
     commands.push(...parseCommandsFromBlock(asyncBlock, 'async', 'handle'));
+  }
+
+  // Cross-check against the catalog single-source-of-truth (#2156). Warn on
+  // drift in either direction — a new dispatch-table entry without a catalog
+  // row, or a catalog row with no dispatch handler. Non-fatal: the index
+  // still emits, but CI sees the message.
+  const catalogNames = new Set(catalogForExtractors().map((e) => e.command));
+  const dispatchNames = new Set(commands.map((c) => c.name));
+  for (const name of dispatchNames) {
+    if (!catalogNames.has(name)) {
+      log(
+        `[warn] dispatch command "${name}" has no entry in cli-command-catalog.ts — add one (#2156)`
+      );
+    }
+  }
+  for (const name of catalogNames) {
+    if (!dispatchNames.has(name)) {
+      log(
+        `[warn] catalog command "${name}" has no handler in SYNC/ASYNC_COMMAND_HANDLERS — check naming drift (#2156)`
+      );
+    }
   }
 
   // Sort alphabetically for deterministic output

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -28,6 +28,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 <!-- PIPELINE NOTE: docs-check.yml link-check job removed; it invoked markdown-link-check with `|| true` so all failures were swallowed. lychee in link-check.yml is now the single canonical link-validation path (#2101, 2026-04-21) -->
 <!-- PIPELINE NOTE: docs-check.yml docs-content-drift job extended with MCP_TOOL_COUNT cross-check — fails CI when site-data.ts MCP_TOOL_COUNT, server.json tools[], server.json description prose, or README.md prose disagree with the authoritative count in src/mcp/tools/index.ts registerTools() (#2107, 2026-04-22) -->
 <!-- PIPELINE NOTE: .claude/rules/ moved to .rules/ for harness neutrality (#2121, 2026-04-22). setup-rules.ts now writes to .rules/nexus-agents.md; detectProjectInfo accepts both paths during migration. CLAUDE.md pointers updated. -->
+<!-- PIPELINE NOTE: generate-repo-index.ts now imports cli-command-catalog.ts as single source of truth for CLI commands (#2156, 2026-04-22). Adds drift check warning when dispatch-table entries disagree with the catalog, in either direction. No output-format change. -->
 
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 


### PR DESCRIPTION
## Summary

Last child of epic #2151. Designates \`cli-command-catalog.ts\` as the single source of truth for the CLI command list. Deletes the regex-based HELP_TEXT parser entirely (supersedes #2146).

## Why

Three independent command-list views existed before this PR:

| Source | Count | How |
|--------|-------|-----|
| \`cli-command-catalog.ts\` | 37 | Structured array, 3 audience tiers |
| \`indexer/entrypoint-cli-extractor.ts\` | 32 | Regex over HELP_TEXT — missed 4 long-named commands (#2146) |
| \`scripts/generate-repo-index.ts\` | 42 | Regex over dispatch tables — found everything but lacked descriptions |

Classic drift. After this PR: all three agree, and #2146 is obsoleted.

## Changes

### \`cli-command-catalog.ts\`
- New \`'internal'\` audience tier for commands not in HELP_TEXT but real (e2e-eval, warm-up, memory-benchmark, etc.)
- \`filterCatalog()\` always strips internal (never shown to humans, even under \`--all\`)
- New \`catalogForExtractors()\` returns every real command minus the \`(default)\` placeholder
- Added 7 internal entries: \`server\`, \`e2e-eval\`, \`memory-benchmark\`, \`memory-eval\`, \`routing-ab\`, \`scenario\`, \`warm-up\`. Total: 43 entries.

### \`indexer/entrypoint-cli-extractor.ts\`
- Deleted \`parseHelpTextCommands()\` and all HELP_TEXT regex logic
- Reads name + description from catalog via \`catalogForExtractors()\`
- Still uses ts-morph for handler source-line lookup and \`PARSE_ARGS_CONFIG\` option parsing
- Per-entry build logic extracted into \`buildCommandSpec\` helper

### \`scripts/generate-repo-index.ts\`
- Imports catalog, cross-checks against dispatch tables
- Warns on drift in either direction (new dispatch entry without catalog row, or catalog row without handler)

## Output parity

Both extractors now emit the same 42 commands. Confirmed:

\`\`\`
$ npx tsx scripts/extract-entrypoints.ts | grep 'CLI Commands'
  CLI Commands:    42
$ npx tsx scripts/generate-repo-index.ts | grep 'CLI commands'
  - 42 CLI commands
\`\`\`

## Test plan

- [x] 19 catalog tests updated (internal-tier assertions, catalogForExtractors coverage)
- [x] 14 new focused tests in \`entrypoint-cli-extractor.test.ts\` (old tests exercised the deleted regex parser)
- [x] Typecheck + lint clean (catalog filter complexity/length caps respected after helper extraction)
- [x] \`extract-entrypoints\` and \`generate-repo-index\` both produce 42 commands
- [x] Drift-check in \`generate-repo-index\` is silent (catalog and dispatch agree)

Closes #2156. Supersedes #2146 (already closed). Epic: #2151.

-795 / +296 lines (net −499 — deleted the whole parseHelpTextCommands / loadHelpTextCommands / CliCommandMeta path).