### PR TITLE
fix(adapters): derive Claude models from registry (#2186 Child 1)

### DIFF
--- a/packages/nexus-agents/src/adapters/claude-adapter-helpers.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-helpers.test.ts
@@ -169,6 +169,30 @@ describe('resolveModelId', () => {
   it('returns raw id for unknown alias', () => {
     expect(resolveModelId('custom-model-id')).toBe('custom-model-id');
   });
+
+  // Issue #2186 Child 1: aliases derive from model-capabilities.ts (single
+  // source of truth), so the legacy claude-opus-4 / claude-sonnet-4 / claude-haiku-4
+  // aliases must resolve to the current registry values, not the May-2025 strings
+  // that were hardcoded in claude-adapter-types.ts.
+  it('resolves claude-opus-4 to the current registry cliModelName (not stale 4-20250514)', () => {
+    expect(resolveModelId('claude-opus-4')).toBe('claude-opus-4-6');
+  });
+
+  it('resolves claude-sonnet-4 to the current registry cliModelName', () => {
+    expect(resolveModelId('claude-sonnet-4')).toBe('claude-sonnet-4-6');
+  });
+
+  it('resolves claude-haiku-4 to the current registry cliModelName', () => {
+    expect(resolveModelId('claude-haiku-4')).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('honors legacy claude-haiku-3 alias and routes it to the current haiku', () => {
+    expect(resolveModelId('claude-haiku-3')).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('passes through bare CLI aliases like "opus" via the registry', () => {
+    expect(resolveModelId('opus')).toBe('claude-opus-4-6');
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/adapters/claude-adapter-helpers.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-helpers.ts
@@ -13,7 +13,21 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages';
 import type { ContentBlock, Message, ToolDefinition, StopReason } from '../core/index.js';
 import { ModelCapability } from '../core/index.js';
-import { CLAUDE_MODEL_ALIASES } from './claude-adapter-types.js';
+import { getCliModelName, resolveCliAlias } from '../config/model-config-helpers.js';
+
+/**
+ * Legacy version-suffix aliases that pre-date the canonical model registry.
+ * They map historical user-facing names to the current registry id, so the
+ * actual cliModelName comes from `model-capabilities.ts` (single source of
+ * truth — issue #2186 Child 1). Add legacy entries here, never the model
+ * version strings themselves.
+ */
+const LEGACY_CLAUDE_ALIASES: Record<string, string> = {
+  'claude-opus-4': 'claude-opus',
+  'claude-sonnet-4': 'claude-sonnet',
+  'claude-haiku-4': 'claude-haiku',
+  'claude-haiku-3': 'claude-haiku',
+};
 
 /**
  * Maps Anthropic stop reasons to our StopReason type.
@@ -116,10 +130,22 @@ export function mapTool(tool: ToolDefinition): Anthropic.Tool {
 }
 
 /**
- * Resolves model alias to full model identifier.
+ * Resolves a Claude model alias to the full identifier the SDK expects.
+ *
+ * Resolution order:
+ *   1. Legacy aliases (`claude-opus-4`, `claude-haiku-3`, etc.) → current registry id
+ *   2. Registry CLI aliases (`opus`, `sonnet`, `haiku`) → registry id
+ *   3. Pass through unknown ids unchanged (e.g., custom Bedrock identifiers)
+ *
+ * The canonical model strings live in `config/model-capabilities.ts`; this
+ * function never holds them directly (issue #2186 Child 1).
  */
 export function resolveModelId(modelId: string): string {
-  return CLAUDE_MODEL_ALIASES[modelId] ?? modelId;
+  const legacyId = LEGACY_CLAUDE_ALIASES[modelId];
+  if (legacyId !== undefined) return getCliModelName(legacyId as never);
+  const registryId = resolveCliAlias(modelId);
+  if (registryId !== undefined) return getCliModelName(registryId);
+  return modelId;
 }
 
 /**

--- a/packages/nexus-agents/src/adapters/claude-adapter-types.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-types.ts
@@ -6,23 +6,31 @@
  * @module adapters/claude-adapter-types
  */
 
+import { getCliModelName } from '../config/model-config-helpers.js';
+
 /**
  * Supported Claude model identifiers.
+ *
+ * Derived from `config/model-capabilities.ts` (single source of truth — issue
+ * #2186). Do not hardcode model-version strings here; update the registry.
  */
 export const CLAUDE_MODELS = {
-  OPUS_4: 'claude-opus-4-20250514',
-  SONNET_4: 'claude-sonnet-4-20250514',
-  HAIKU_4: 'claude-haiku-4-5-20251001',
+  OPUS_4: getCliModelName('claude-opus'),
+  SONNET_4: getCliModelName('claude-sonnet'),
+  HAIKU_4: getCliModelName('claude-haiku'),
 } as const;
 
 /**
- * Model aliases for convenience.
+ * Legacy version-suffix aliases mapped to the current registry cliModelName.
+ *
+ * Values come from `CLAUDE_MODELS` so they stay in sync with the canonical
+ * registry. Add legacy entries here, never the version strings themselves.
  */
 export const CLAUDE_MODEL_ALIASES: Record<string, string> = {
   'claude-opus-4': CLAUDE_MODELS.OPUS_4,
   'claude-sonnet-4': CLAUDE_MODELS.SONNET_4,
   'claude-haiku-4': CLAUDE_MODELS.HAIKU_4,
-  // Legacy alias
+  // Legacy alias — pre-4.x users routed to the current haiku.
   'claude-haiku-3': CLAUDE_MODELS.HAIKU_4,
 } as const;
 

--- a/packages/nexus-agents/src/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.test.ts
@@ -740,9 +740,11 @@ describe('createClaudeAdapter', () => {
 });
 
 describe('CLAUDE_MODELS', () => {
-  it('should have correct model identifiers', () => {
-    expect(CLAUDE_MODELS.OPUS_4).toBe('claude-opus-4-20250514');
-    expect(CLAUDE_MODELS.SONNET_4).toBe('claude-sonnet-4-20250514');
+  it('derives current cliModelName from the canonical registry (issue #2186)', () => {
+    // Values now come from config/model-capabilities.ts so they refresh
+    // automatically when the registry is updated, not when this file is edited.
+    expect(CLAUDE_MODELS.OPUS_4).toBe('claude-opus-4-6');
+    expect(CLAUDE_MODELS.SONNET_4).toBe('claude-sonnet-4-6');
     expect(CLAUDE_MODELS.HAIKU_4).toBe('claude-haiku-4-5-20251001');
   });
 });


### PR DESCRIPTION
## Summary

First child of epic #2186: stop maintaining a parallel Claude model registry in `claude-adapter-types.ts`. The hardcoded `4-20250514` strings have been stale since May 2025; routing layers were silently producing requests against retired model IDs.

> Replaces #2194 (which was based on a stale local main; this branch starts from post-merge `origin/main`).

## Changes

- `CLAUDE_MODELS.OPUS_4 / SONNET_4 / HAIKU_4` now derive their values from `config/model-capabilities.ts` via `getCliModelName()`. The constants stay as a public re-export for backward compatibility.
- `resolveModelId()` in `claude-adapter-helpers.ts` no longer imports the local alias map. Resolution order: legacy aliases (`claude-opus-4`, `claude-haiku-3`) → current registry id → `cliModelName`. Pass-through for unknown ids.
- New tests assert the current registry values (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) plus the legacy alias paths and CLI alias lookup.

## Behavior change

Callers passing `claude-opus-4` now resolve to `claude-opus-4-6` instead of `claude-opus-4-20250514`. This is the intended fix.

## Test plan

- [x] `pnpm vitest run src/adapters/` — 739 tests, all pass
- [x] Failing tests written first (5 new); confirmed red before migration
- [x] `pnpm exec eslint` clean on changed files
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green
- [ ] Fitness audit ≥ 90/100

## Epic progress (#2186)

- [x] **Child 1** (this PR) — Migrate `CLAUDE_MODELS` and `CLAUDE_MODEL_ALIASES` to derive from `config/model-capabilities.ts`. Also covers Child 2 (drop local alias map from helpers).
- [ ] Child 3 — Refresh registry with `4-7` family if/when public
- [ ] Child 4 — Drop the public re-exports of `CLAUDE_MODELS` from `adapters/index.ts` and `exports/adapters.ts`
- [ ] Child 5 — Add fitness-guard rule blocking new `/claude-(opus|sonnet|haiku)-\d/` literals outside `config/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)