### PR TITLE
fix(mcp): capture fallback duration in tryExpertFallback (#2189)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -374,8 +374,10 @@ async function tryExpertFallback(
   const fallbackResult = createExpert(expert.expertConfig, { adapter: fallbackAdapter });
   if (!fallbackResult.ok) return undefined;
 
+  const fallbackStart = getTimeProvider().now();
   const result = await fallbackResult.value.execute(task);
   if (!result.ok) return undefined;
+  const fallbackDurationMs = getTimeProvider().now() - fallbackStart;
 
   return {
     ok: true,
@@ -383,7 +385,7 @@ async function tryExpertFallback(
       expertId: expert.id,
       role: expert.role,
       output: result.value.output,
-      durationMs: 0,
+      durationMs: fallbackDurationMs,
       tokensUsed: result.value.metadata.tokensUsed,
       modelUsed: fallbackCli,
     }),


### PR DESCRIPTION
## Summary

`execute-expert.ts:386` hardcoded `durationMs: 0` in the fallback path, so weather-report aggregates and metrics rolls were silently hiding slow fallback executions.

## Fix

Capture `getTimeProvider().now()` before the fallback execute and compute elapsed on completion. No public API change.

## Test plan

- [x] `pnpm vitest run src/mcp/tools/execute-expert*` — 36 tests pass
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean

A focused unit test for `tryExpertFallback` would require mocking `getGlobalRegistry` + the fallback chain — not in scope for this 3-line fix. Filed for follow-up if needed.

Closes #2189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)