### PR TITLE
fix(ci): scope registry-refresh permissions (Scorecard HIGH)

### DIFF
--- a/.github/workflows/registry-refresh.yml
+++ b/.github/workflows/registry-refresh.yml
@@ -21,15 +21,19 @@ on:
           - 'false'
           - 'true'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Top-level: read-only by default. Write scopes are granted only to the
+# refresh job that needs them for `peter-evans/create-pull-request`
+# (Scorecard TokenPermissions / OpenSSF SLSA-1 hardening).
+permissions: read-all
 
 jobs:
   refresh:
     name: Regenerate bundled registry
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

CodeQL / OpenSSF Scorecard TokenPermissionsID flagged \`.github/workflows/registry-refresh.yml:25\` (HIGH): top-level \`contents: write\` and \`pull-requests: write\` granted broad write to every job in the workflow.

## Fix

Move the writes to the \`refresh\` job (which actually needs them for \`peter-evans/create-pull-request\`) and set top-level to \`read-all\`. Behavior unchanged; attack surface narrows.

## Test plan

- [x] YAML syntax valid
- [ ] CI green
- [ ] Workflow still creates the PR on next scheduled run

Closes the CodeQL alert at \`.github/workflows/registry-refresh.yml:25\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)