### PR TITLE
fix(ci): pin peter-evans/create-pull-request to SHA (Scorecard MED)

### DIFF
--- a/.github/workflows/registry-refresh.yml
+++ b/.github/workflows/registry-refresh.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Open PR with refreshed registry
         if: steps.changed.outputs.changed == 'true' && inputs['dry-run'] != 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: automated/registry-refresh
           delete-branch: true


### PR DESCRIPTION
## Summary

CodeQL / OpenSSF Scorecard PinnedDependenciesID flagged \`.github/workflows/registry-refresh.yml:85\` (MED): \`peter-evans/create-pull-request@v7\` is a floating tag.

## Fix

Pin to the commit SHA \`22a9089034f40e5a961c8808d113e2c98fb63676\` (resolved from the v7 tag at time of PR). Supply-chain integrity no longer depends on Peter Evans's tag-management discipline.

## Test plan

- [x] SHA verified via \`gh api repos/peter-evans/create-pull-request/git/ref/tags/v7\`
- [ ] CI green
- [ ] Workflow still creates the PR on next scheduled run

Closes CodeQL alert #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)