### PR TITLE
feat(config): add optional aliases field to ModelCapability schema (#2199 Child 1)

### DIFF
--- a/packages/nexus-agents/src/config/model-capabilities-types.ts
+++ b/packages/nexus-agents/src/config/model-capabilities-types.ts
@@ -160,6 +160,17 @@ export const ModelCapabilitySchema = z.object({
   cliAlias: z.string().optional(),
   /** Model name the CLI binary expects (e.g., 'gemini-2.5-pro') */
   cliModelName: z.string().optional(),
+  /**
+   * Legacy / version-suffixed names that resolve to this model. Used by
+   * adapters and routing to map historical user-facing names (e.g.,
+   * `claude-opus-4-5-20251101`, `gemini-2.5-pro`) to the current registry
+   * entry. Empty strings are rejected; uniqueness within the array is not
+   * enforced at schema level (caller responsibility).
+   *
+   * Added for issue #2199 Child 1; populated by the companion migration
+   * epic #2200.
+   */
+  aliases: z.array(z.string().min(1)).optional(),
   /** Whether this model is deprecated and should receive a scoring penalty */
   deprecated: z.boolean().optional(),
   /** ISO date when the model was deprecated (informational) */

--- a/packages/nexus-agents/src/config/model-capabilities.test.ts
+++ b/packages/nexus-agents/src/config/model-capabilities.test.ts
@@ -359,6 +359,53 @@ describe('deprecation schema fields', () => {
 });
 
 // ---------------------------------------------------------------------------
+// aliases field (epic #2199 Child 1)
+//
+// Optional `aliases: readonly string[]` lets the registry hold the legacy
+// version-suffixed names that adapters currently maintain in their own
+// parallel registries (companion epic #2200). Schema-only addition; no
+// migration of existing aliases happens in this child.
+// ---------------------------------------------------------------------------
+
+describe('aliases schema field (#2199)', () => {
+  it('accepts model without aliases field (backward compatible)', () => {
+    const base = DEFAULT_MODEL_CAPABILITIES.models[0];
+    const result = ModelCapabilitySchema.safeParse(base);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts model with aliases array of strings', () => {
+    const base = {
+      ...DEFAULT_MODEL_CAPABILITIES.models[0],
+      aliases: ['claude-opus-4', 'claude-opus-4-5-20251101'],
+    };
+    const result = ModelCapabilitySchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.aliases).toEqual(['claude-opus-4', 'claude-opus-4-5-20251101']);
+    }
+  });
+
+  it('accepts model with empty aliases array', () => {
+    const base = { ...DEFAULT_MODEL_CAPABILITIES.models[0], aliases: [] };
+    const result = ModelCapabilitySchema.safeParse(base);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects model with non-string alias entries', () => {
+    const base = { ...DEFAULT_MODEL_CAPABILITIES.models[0], aliases: ['ok', 42] };
+    const result = ModelCapabilitySchema.safeParse(base);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects model with empty-string alias', () => {
+    const base = { ...DEFAULT_MODEL_CAPABILITIES.models[0], aliases: ['valid', ''] };
+    const result = ModelCapabilitySchema.safeParse(base);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Data Integrity (cross-project learning from tsundoku)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

First child of [epic #2199](https://github.com/williamzujkowski/nexus-agents/issues/2199) (fitness-guard rule against hardcoded model-version drift).

Adds an optional `aliases?: readonly string[]` field to `ModelCapabilitySchema`. Schema-only — no data migration of existing adapter parallel registries (that's the companion epic #2200).

## Why now

The `aliases` field unblocks two parallel workstreams:
- **#2199 Child 2** (the actual fitness-guard rule) — needs an authoritative list of acceptable alias strings so its allowlist isn't day-1 polluted with stable user-facing aliases.
- **#2200 children 1-4** — need the field to actually fold legacy maps out of `claude-adapter.ts`, `gemini-types.ts`, and `openai-types.ts` and into the registry.

## What changed

- `packages/nexus-agents/src/config/model-capabilities-types.ts`: optional `aliases: z.array(z.string().min(1)).optional()` on `ModelCapabilitySchema`.
- 5 new tests covering: backward compat (no field), valid arrays, empty arrays, non-string entries rejected, empty-string entries rejected.

## What didn't change

- `DEFAULT_MODEL_CAPABILITIES` data — no entries populated with aliases yet. Migration is the companion epic.
- No callers — the schema is additive; the field is consumed in subsequent children.
- No cross-model uniqueness validation — caller responsibility, will surface via the fitness-guard rule itself.

## Test plan

- [x] 5 new tests, red→green verified (3 failed pre-fix, all 48 pass post-fix)
- [x] `pnpm vitest run src/config/` — 605 tests pass
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green
- [ ] Fitness audit ≥ 90/100

Refs #2199 (epic) | #2200 (companion migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)