### PR TITLE
feat(ci): wire model-string-drift check as advisory job (#2199 Child 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,41 @@ jobs:
           name: fitness-report-${{ matrix.os }}
           path: ${{ steps.fitness.outputs.report-path }}
 
+  model-string-drift:
+    name: Model String Drift Check
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-node
+
+      # Advisory mode (#2199 Child 3). Findings print to job summary but do
+      # not fail the build. Will flip to blocking via NEXUS_DRIFT_ADVISORY=0
+      # in #2199 Child 4 after at least one merge cycle without false positives.
+      - name: Run model-string drift check (advisory)
+        run: |
+          set +e
+          OUTPUT=$(pnpm --silent check:model-drift 2>&1)
+          STATUS=$?
+          echo "$OUTPUT"
+          {
+            echo "## Model String Drift Check"
+            echo ""
+            echo '```'
+            echo "$OUTPUT"
+            echo '```'
+            echo ""
+            if [ $STATUS -ne 0 ] || echo "$OUTPUT" | grep -q "violation(s) found"; then
+              echo "⚠ Drift detected. Migrate to \`config/model-capabilities.ts\` or"
+              echo "add a structured allowlist entry referencing #2200."
+            else
+              echo "✓ No new drift. Allowlisted sites tracked in scripts/model-string-drift-allowlist.ts."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
   index-check:
     name: Index Freshness Check
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}


### PR DESCRIPTION
## Summary

Third child of [epic #2199](https://github.com/williamzujkowski/nexus-agents/issues/2199). Wires `pnpm check:model-drift` (added in #2203) into `.github/workflows/ci.yml` as an advisory CI job.

## Behavior

- **Advisory by default.** Exits 0 even when violations are found. PRs are NOT blocked.
- Findings + summary printed to the GitHub Actions job summary panel.
- Will flip to blocking in [Child 4](https://github.com/williamzujkowski/nexus-agents/issues/2199) after at least one merge cycle without false positives, per Architect's vote condition.
- Job is intentionally **separate** from fitness-audit (which has its own scoring) so drift surfaces as its own line item.

## Permissions

`contents: read` only — the check is read-only by design. No write/PR permissions needed.

## Test plan

- [x] YAML schema valid (`yaml.safe_load`)
- [x] `pnpm check:model-drift` exits 0 on `main` (allowlist captures all 9 grandfathered sites)
- [ ] CI green (this PR will be the first to exercise the new job — it should pass)
- [ ] Job summary renders correctly in GitHub Actions UI

## Epic progress (#2199)

- [x] Child 1 — Schema field (#2202 merged)
- [x] Child 2 — The drift script + allowlist (#2203 merged)
- [x] **Child 3** — This PR (CI advisory)
- [ ] Child 4 — Flip to blocking + add to `.husky/pre-push` (after ≥1 week soak)
- [ ] Child 5 — Migrate Category-C sites that fold cleanly into `aliases` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)