### PR TITLE
feat(config): migrate Claude legacy aliases into ModelCapability.aliases (#2199 Child 5)

### DIFF
--- a/packages/nexus-agents/src/adapters/claude-adapter-helpers.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-helpers.ts
@@ -16,20 +16,6 @@ import { ModelCapability } from '../core/index.js';
 import { getCliModelName, resolveCliAlias } from '../config/model-config-helpers.js';
 
 /**
- * Legacy version-suffix aliases that pre-date the canonical model registry.
- * They map historical user-facing names to the current registry id, so the
- * actual cliModelName comes from `model-capabilities.ts` (single source of
- * truth — issue #2186 Child 1). Add legacy entries here, never the model
- * version strings themselves.
- */
-const LEGACY_CLAUDE_ALIASES: Record<string, string> = {
-  'claude-opus-4': 'claude-opus',
-  'claude-sonnet-4': 'claude-sonnet',
-  'claude-haiku-4': 'claude-haiku',
-  'claude-haiku-3': 'claude-haiku',
-};
-
-/**
  * Maps Anthropic stop reasons to our StopReason type.
  */
 export function mapStopReason(anthropicReason: string | null): StopReason {
@@ -132,17 +118,14 @@ export function mapTool(tool: ToolDefinition): Anthropic.Tool {
 /**
  * Resolves a Claude model alias to the full identifier the SDK expects.
  *
- * Resolution order:
- *   1. Legacy aliases (`claude-opus-4`, `claude-haiku-3`, etc.) → current registry id
- *   2. Registry CLI aliases (`opus`, `sonnet`, `haiku`) → registry id
- *   3. Pass through unknown ids unchanged (e.g., custom Bedrock identifiers)
+ * `resolveCliAlias` consults the canonical registry — both the cliAlias /
+ * id columns AND the `aliases` array (#2199 Child 5 migration). Unknown
+ * ids pass through (e.g., custom Bedrock identifiers).
  *
  * The canonical model strings live in `config/model-capabilities.ts`; this
  * function never holds them directly (issue #2186 Child 1).
  */
 export function resolveModelId(modelId: string): string {
-  const legacyId = LEGACY_CLAUDE_ALIASES[modelId];
-  if (legacyId !== undefined) return getCliModelName(legacyId as never);
   const registryId = resolveCliAlias(modelId);
   if (registryId !== undefined) return getCliModelName(registryId);
   return modelId;

--- a/packages/nexus-agents/src/config/model-capabilities.ts
+++ b/packages/nexus-agents/src/config/model-capabilities.ts
@@ -88,6 +88,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliName: 'claude',
       cliAlias: 'opus',
       cliModelName: 'claude-opus-4-6',
+      aliases: ['claude-opus-4'],
     },
     {
       id: 'claude-sonnet',
@@ -105,6 +106,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliName: 'claude',
       cliAlias: 'sonnet',
       cliModelName: 'claude-sonnet-4-6',
+      aliases: ['claude-sonnet-4'],
     },
     {
       id: 'claude-haiku',
@@ -122,6 +124,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliName: 'claude',
       cliAlias: 'haiku',
       cliModelName: 'claude-haiku-4-5-20251001',
+      aliases: ['claude-haiku-4', 'claude-haiku-3'],
     },
     // ----- Google Gemini -----
     {

--- a/packages/nexus-agents/src/config/model-config-helpers.test.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.test.ts
@@ -135,6 +135,25 @@ describe('resolveCliAlias', () => {
     const resolved = resolveCliAlias('totally-fake');
     expect(resolved).toBeUndefined();
   });
+
+  // #2199 Child 5: aliases field migration. Legacy version-suffix names
+  // resolve via the registry's `aliases` array, so adapter files don't need
+  // to maintain their own LEGACY_CLAUDE_ALIASES lookups.
+  it('resolves claude-opus-4 legacy alias to claude-opus via registry aliases', () => {
+    expect(resolveCliAlias('claude-opus-4')).toBe('claude-opus');
+  });
+
+  it('resolves claude-sonnet-4 legacy alias to claude-sonnet via registry aliases', () => {
+    expect(resolveCliAlias('claude-sonnet-4')).toBe('claude-sonnet');
+  });
+
+  it('resolves claude-haiku-4 legacy alias to claude-haiku via registry aliases', () => {
+    expect(resolveCliAlias('claude-haiku-4')).toBe('claude-haiku');
+  });
+
+  it('resolves claude-haiku-3 legacy alias to claude-haiku (pre-4.x compat)', () => {
+    expect(resolveCliAlias('claude-haiku-3')).toBe('claude-haiku');
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -75,9 +75,17 @@ export function getCliModelName(modelId: ModelId): string {
   return cap?.cliModelName ?? cap?.cliAlias ?? modelId;
 }
 
-/** Resolve a CLI alias (e.g., 'opus') to its canonical ModelId. */
+/**
+ * Resolve a CLI alias (e.g., 'opus') or legacy version-suffix name (e.g.,
+ * 'claude-opus-4') to its canonical ModelId. Resolution order:
+ *   1. cliAlias match ('opus' → claude-opus)
+ *   2. id match ('claude-opus' → claude-opus)
+ *   3. aliases[] membership (legacy version names — #2199 Child 5)
+ */
 export function resolveCliAlias(alias: string): ModelId | undefined {
-  return DEFAULT_MODEL_CAPABILITIES.models.find((m) => m.cliAlias === alias || m.id === alias)?.id;
+  return DEFAULT_MODEL_CAPABILITIES.models.find(
+    (m) => m.cliAlias === alias || m.id === alias || (m.aliases?.includes(alias) ?? false)
+  )?.id;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/model-string-drift-allowlist.ts
+++ b/scripts/model-string-drift-allowlist.ts
@@ -43,18 +43,6 @@ export const ALLOWLIST: readonly AllowlistEntry[] = [
     trackingIssue: 2200,
   },
   {
-    file: 'packages/nexus-agents/src/adapters/claude-adapter-types.ts',
-    reason:
-      'Legacy CLAUDE_MODEL_ALIASES re-export surface (kept for backward compat with external imports). Will be reviewed in #2186 Child 4 (drop public re-exports).',
-    trackingIssue: 2186,
-  },
-  {
-    file: 'packages/nexus-agents/src/adapters/claude-adapter-helpers.ts',
-    reason:
-      'LEGACY_CLAUDE_ALIASES table maps user-supplied legacy names to current registry ids. Will fold into ModelCapability.aliases via #2200 Child 1.',
-    trackingIssue: 2200,
-  },
-  {
     file: 'packages/nexus-agents/src/adapters/gemini-types.ts',
     reason:
       'Runtime model id constants + alias map for Gemini. Migrate to ModelCapability.aliases via #2200 Child 2.',


### PR DESCRIPTION
## Summary

Fifth child of [epic #2199](https://github.com/williamzujkowski/nexus-agents/issues/2199). Demonstrates the end-to-end migration cycle: legacy aliases out of an adapter file → into the canonical registry's new `aliases` field → drift allowlist shrinks.

## Changes

1. **Registry data:** added `aliases` to the three Claude entries in `model-capabilities.ts`:
   - `claude-opus`: `['claude-opus-4']`
   - `claude-sonnet`: `['claude-sonnet-4']`
   - `claude-haiku`: `['claude-haiku-4', 'claude-haiku-3']`

2. **Resolution helper:** `resolveCliAlias()` now consults `aliases[]` in addition to `id` and `cliAlias` (4 new tests).

3. **Adapter cleanup:** `claude-adapter-helpers.ts` deletes its local `LEGACY_CLAUDE_ALIASES` table. `resolveModelId()` now goes straight through `resolveCliAlias()` → registry — no parallel registry left in this file.

4. **Allowlist:** removed the now-clean `claude-adapter-helpers.ts` AND `claude-adapter-types.ts` entries from `scripts/model-string-drift-allowlist.ts`. Count went from 9 → 7 (−22%).

## Behavior

No external behavior change. Same call → same `cliModelName`:
- `resolveModelId('claude-opus-4')` → `'claude-opus-4-6'` (was: same)
- `resolveModelId('claude-haiku-3')` → `'claude-haiku-4-5-20251001'` (was: same)
- `resolveModelId('opus')` → `'claude-opus-4-6'` (was: same)

The implementation routes the same data through one source of truth.

## Test plan

- [x] 4 new tests for `resolveCliAlias()` — TDD red→green
- [x] All 1348 tests in `config/` + `adapters/` pass
- [x] `pnpm check:model-drift` exits 0 (allowlist shrank from 9 → 7)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Epic progress (#2199)

- [x] Child 1 — Schema field (#2202)
- [x] Child 2 — Drift script + allowlist (#2203)
- [x] Child 3 — CI advisory job (#2204)
- [ ] Child 4 — Flip to blocking (waits ≥1 week soak per Architect's vote)
- [x] **Child 5** — This PR

## Companion epic (#2200)

Still has 7 Category-A sites awaiting migration (Gemini, OpenAI, Codex adapters + setup-custom-api + auto-adapter env-var fallback + token-counter tiktoken map). This PR demonstrates the migration pattern those will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)