### PR TITLE
fix(adapters): migrate Claude CLI adapter parallel registry to canonical aliases (#2200 Child 1)

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.test.ts
@@ -202,24 +202,28 @@ describe('ClaudeCliAdapter', () => {
       expect(info.costPerMillionOutput).toBe(25.0);
     });
 
-    it('should return correct info for opus model', () => {
+    it('resolves legacy claude-opus-4 alias to current Opus via registry (#2200 Child 1)', () => {
+      // Pre-#2200: returned stale V4 pricing (15/75) from a hardcoded fallback
+      // map. Post-#2200: legacy alias routes to claude-opus registry entry,
+      // returning current Opus 4.6 pricing — which matches what Anthropic
+      // actually charges when the request lands.
       const opusAdapter = new ClaudeCliAdapter({ model: 'claude-opus-4' });
       const info = opusAdapter.getModelInfo();
 
       expect(info.id).toBe('claude-opus-4');
-      expect(info.name).toBe('Claude Opus 4');
-      expect(info.costPerMillionInput).toBe(15.0);
-      expect(info.costPerMillionOutput).toBe(75.0);
+      expect(info.name).toBe('Claude Opus 4.6');
+      expect(info.costPerMillionInput).toBe(5.0);
+      expect(info.costPerMillionOutput).toBe(25.0);
     });
 
-    it('should return correct info for haiku model', () => {
+    it('resolves legacy claude-haiku-3 alias to current Haiku via registry (#2200 Child 1)', () => {
       const haikuAdapter = new ClaudeCliAdapter({ model: 'claude-haiku-3' });
       const info = haikuAdapter.getModelInfo();
 
       expect(info.id).toBe('claude-haiku-3');
-      expect(info.name).toBe('Claude Haiku 3');
-      expect(info.costPerMillionInput).toBe(0.25);
-      expect(info.costPerMillionOutput).toBe(1.25);
+      expect(info.name).toBe('Claude Haiku 4.5');
+      expect(info.costPerMillionInput).toBe(1.0);
+      expect(info.costPerMillionOutput).toBe(5.0);
     });
 
     it('should use default costs for unknown model', () => {

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
@@ -25,65 +25,35 @@ import {
 } from '../../config/model-config-helpers.js';
 
 /**
- * Maps internal model names to Claude CLI aliases.
- * CLI accepts: 'sonnet', 'opus', 'haiku' or full names like 'claude-sonnet-4-6'
- * Built from canonical registry + legacy names for backward compatibility.
+ * Maps internal model names → Claude CLI aliases. Derived entirely from the
+ * canonical registry: every claude entry contributes its `cliAlias` (passthrough),
+ * its `cliModelName`, and every legacy-name in `aliases[]`. Migration of these
+ * legacy strings into the registry happened in #2200 Child 1.
  */
 const MODEL_TO_CLI_ALIAS: Record<string, string> = buildClaudeAliasMap();
 
-/** Builds alias map from canonical registry + legacy versioned names. */
 function buildClaudeAliasMap(): Record<string, string> {
   const map: Record<string, string> = {};
   for (const model of DEFAULT_MODEL_CAPABILITIES.models) {
-    if (model.cliName === 'claude' && model.cliAlias !== undefined) {
-      // Allow direct alias pass-through
-      map[model.cliAlias] = model.cliAlias;
+    if (model.cliName !== 'claude' || model.cliAlias === undefined) continue;
+    const alias = model.cliAlias;
+    map[alias] = alias;
+    if (model.cliModelName !== undefined) map[model.cliModelName] = alias;
+    for (const legacyName of model.aliases ?? []) {
+      map[legacyName] = alias;
     }
   }
-  // Legacy versioned names → short CLI aliases
-  map['claude-sonnet-4'] = 'sonnet';
-  map['claude-sonnet-4-6'] = 'sonnet';
-  map['claude-sonnet-4-5-20250929'] = 'sonnet'; // Legacy compat
-  map['claude-opus-4'] = 'opus';
-  map['claude-opus-4-6'] = 'opus';
-  map['claude-opus-4-5-20251101'] = 'opus';
-  map['claude-haiku-3'] = 'haiku';
-  map['claude-haiku-4-5-20251001'] = 'haiku';
   return map;
 }
 
-/** Legacy fallback values for Claude models not in the canonical registry. */
-const CLAUDE_LEGACY_DEFAULTS = {
-  displayNames: {
-    'claude-opus-4': 'Claude Opus 4',
-    'claude-sonnet-4': 'Claude Sonnet 4',
-    'claude-haiku-3': 'Claude Haiku 3',
-    'claude-opus-4-5-20251101': 'Claude Opus 4.5',
-    opus: 'Claude Opus 4.6',
-    sonnet: 'Claude Sonnet 4.6',
-    haiku: 'Claude Haiku 4.5',
-  } as Readonly<Record<string, string>>,
-  inputCosts: {
-    'claude-opus-4': 15.0,
-    'claude-opus-4-5-20251101': 5.0,
-    'claude-sonnet-4': 3.0,
-    'claude-haiku-3': 0.25,
-    opus: 5.0,
-    sonnet: 3.0,
-    haiku: 1.0,
-  } as Readonly<Record<string, number>>,
-  outputCosts: {
-    'claude-opus-4': 75.0,
-    'claude-opus-4-5-20251101': 25.0,
-    'claude-sonnet-4': 15.0,
-    'claude-haiku-3': 1.25,
-    opus: 25.0,
-    sonnet: 15.0,
-    haiku: 5.0,
-  } as Readonly<Record<string, number>>,
-  inputCost: 5.0,
-  outputCost: 25.0,
-} as const;
+/**
+ * Default cost when an unrecognized model id is passed (pricing matches
+ * current Opus, the strongest tier — conservative over-estimate). Per-model
+ * legacy cost overrides were removed in #2200 Child 1; they're reachable
+ * via the registry now.
+ */
+const UNKNOWN_MODEL_DEFAULT_INPUT_COST = 5.0;
+const UNKNOWN_MODEL_DEFAULT_OUTPUT_COST = 25.0;
 
 /**
  * Claude CLI adapter using subprocess transport.
@@ -102,9 +72,13 @@ export class ClaudeCliAdapter extends SubprocessCliAdapter {
 
   /**
    * Gets Claude model information.
-   * buildModelInfo matches both cliModelName and cliAlias, so a single
-   * call handles 'opus', 'sonnet', 'haiku', and full model names.
-   * Falls back to legacy lookup for unrecognized models.
+   * `buildModelInfo` matches `cliModelName`, `cliAlias`, and `aliases[]` —
+   * a single call handles 'opus', 'sonnet', 'haiku', current model names,
+   * and the legacy `claude-opus-4` / `claude-haiku-3` / etc. entries that
+   * live in the registry's aliases since #2200 Child 1.
+   *
+   * Truly unrecognized models fall through to conservative defaults
+   * (current Opus pricing).
    */
   getModelInfo(): ModelInfo {
     const fromRegistry = buildModelInfo('claude', this.model);
@@ -112,13 +86,11 @@ export class ClaudeCliAdapter extends SubprocessCliAdapter {
 
     return {
       id: this.model,
-      name: CLAUDE_LEGACY_DEFAULTS.displayNames[this.model] ?? this.model,
+      name: this.model,
       contextWindow: 200_000,
       maxOutput: 64_000,
-      costPerMillionInput:
-        CLAUDE_LEGACY_DEFAULTS.inputCosts[this.model] ?? CLAUDE_LEGACY_DEFAULTS.inputCost,
-      costPerMillionOutput:
-        CLAUDE_LEGACY_DEFAULTS.outputCosts[this.model] ?? CLAUDE_LEGACY_DEFAULTS.outputCost,
+      costPerMillionInput: UNKNOWN_MODEL_DEFAULT_INPUT_COST,
+      costPerMillionOutput: UNKNOWN_MODEL_DEFAULT_OUTPUT_COST,
     };
   }
 

--- a/packages/nexus-agents/src/cli-adapters/factory.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.test.ts
@@ -61,11 +61,13 @@ describe('createCliAdapter', () => {
   });
 
   it('should pass model option to Claude adapter', () => {
+    // Legacy claude-opus-4 alias resolves to current Claude Opus via the
+    // registry's aliases[] field (#2200 Child 1).
     const adapter = createCliAdapter({ cli: 'claude', model: 'claude-opus-4' });
     const info = adapter.getModelInfo();
 
     expect(info.id).toBe('claude-opus-4');
-    expect(info.name).toBe('Claude Opus 4');
+    expect(info.name).toBe('Claude Opus 4.6');
   });
 
   it('should pass model option to Gemini adapter', () => {

--- a/packages/nexus-agents/src/config/model-capabilities.ts
+++ b/packages/nexus-agents/src/config/model-capabilities.ts
@@ -88,7 +88,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliName: 'claude',
       cliAlias: 'opus',
       cliModelName: 'claude-opus-4-6',
-      aliases: ['claude-opus-4'],
+      aliases: ['claude-opus-4', 'claude-opus-4-5-20251101'],
     },
     {
       id: 'claude-sonnet',
@@ -106,7 +106,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliName: 'claude',
       cliAlias: 'sonnet',
       cliModelName: 'claude-sonnet-4-6',
-      aliases: ['claude-sonnet-4'],
+      aliases: ['claude-sonnet-4', 'claude-sonnet-4-5-20250929'],
     },
     {
       id: 'claude-haiku',

--- a/packages/nexus-agents/src/config/model-config-helpers.test.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.test.ts
@@ -187,6 +187,24 @@ describe('findCanonicalModel', () => {
     // 'o3' is a codex model, not gemini
     expect(findCanonicalModel('gemini', 'o3')).toBeUndefined();
   });
+
+  // #2200 Child 1: legacy version-suffix names resolve via aliases[]
+  it('finds claude model by legacy alias from aliases[] (claude-opus-4)', () => {
+    const model = findCanonicalModel('claude', 'claude-opus-4');
+    expect(model).toBeDefined();
+    expect(model?.id).toBe('claude-opus');
+  });
+
+  it('finds claude model by legacy alias from aliases[] (claude-haiku-3)', () => {
+    const model = findCanonicalModel('claude', 'claude-haiku-3');
+    expect(model).toBeDefined();
+    expect(model?.id).toBe('claude-haiku');
+  });
+
+  it('does not match alias if cli does not match', () => {
+    // claude-opus-4 is a claude alias, not gemini
+    expect(findCanonicalModel('gemini', 'claude-opus-4')).toBeUndefined();
+  });
 });
 
 describe('buildModelInfo', () => {

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -218,15 +218,23 @@ export interface ModelInfoShape {
 
 /**
  * Search the canonical registry by CLI name + CLI model identifier.
- * Matches against both cliModelName (e.g., 'o3', 'gemini-2.5-pro')
- * and cliAlias (e.g., 'opus', 'sonnet') for CLI tools that use aliases.
+ *
+ * Matches against (in order):
+ *   1. `cliModelName` ('gemini-2.5-pro', 'claude-opus-4-6')
+ *   2. `cliAlias` ('opus', 'sonnet', 'haiku')
+ *   3. `aliases[]` membership — legacy / version-suffix names that resolve
+ *      to this entry (#2200 Child 1)
  */
 export function findCanonicalModel(
   cli: CliNameLiteral,
   cliModelName: string
 ): ModelCapability | undefined {
   return DEFAULT_MODEL_CAPABILITIES.models.find(
-    (m) => m.cliName === cli && (m.cliModelName === cliModelName || m.cliAlias === cliModelName)
+    (m) =>
+      m.cliName === cli &&
+      (m.cliModelName === cliModelName ||
+        m.cliAlias === cliModelName ||
+        (m.aliases?.includes(cliModelName) ?? false))
   );
 }
 

--- a/scripts/model-string-drift-allowlist.ts
+++ b/scripts/model-string-drift-allowlist.ts
@@ -37,12 +37,6 @@ export interface AllowlistEntry {
  */
 export const ALLOWLIST: readonly AllowlistEntry[] = [
   {
-    file: 'packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts',
-    reason:
-      'Legacy Claude CLI alias map + display/cost fallbacks for retired versions. Migrate to ModelCapability.aliases via #2200 Child 1.',
-    trackingIssue: 2200,
-  },
-  {
     file: 'packages/nexus-agents/src/adapters/gemini-types.ts',
     reason:
       'Runtime model id constants + alias map for Gemini. Migrate to ModelCapability.aliases via #2200 Child 2.',


### PR DESCRIPTION
## Summary

First child of [epic #2200](https://github.com/williamzujkowski/nexus-agents/issues/2200) (companion migration to fitness-guard #2199). Eliminates the Claude CLI adapter's hardcoded parallel registry — legacy aliases now resolve through the canonical model registry.

## Behavior change (intentional)

Legacy aliases like `claude-opus-4` and `claude-haiku-3` previously returned **stale legacy pricing** from a hardcoded fallback map. They now route to the current model and return current pricing — which matches what Anthropic actually charges:

| Input alias | Before | After |
|---|---|---|
| `claude-opus-4` | name=Claude Opus 4, $15/$75 | name=Claude Opus 4.6, $5/$25 |
| `claude-haiku-3` | name=Claude Haiku 3, $0.25/$1.25 | name=Claude Haiku 4.5, $1/$5 |
| `claude-sonnet-4` | unchanged route, just no parallel-registry override |

Cost estimation was previously off by 2-4x on legacy aliases. This is the fix.

## Implementation

1. **`findCanonicalModel(cli, name)`** now also checks `aliases[]`. One-line + 3 new tests.
2. **Registry:** added retired version names to `aliases[]` of corresponding entries:
   - `claude-opus.aliases`: `+ 'claude-opus-4-5-20251101'`
   - `claude-sonnet.aliases`: `+ 'claude-sonnet-4-5-20250929'`
   - `claude-haiku` already covered via #2199 Child 5
3. **`cli-adapters/adapters/claude-adapter.ts`**: `buildClaudeAliasMap()` now derives entirely from registry (cliAlias + cliModelName + aliases[]). The 16-entry `CLAUDE_LEGACY_DEFAULTS` object — three lookup maps for display names, input costs, output costs — collapses into two scalar defaults for genuinely unknown models.
4. **Allowlist:** removed `cli-adapters/adapters/claude-adapter.ts`. Drift count: 7 → 6.

## Test plan

- [x] 3 new TDD tests for `findCanonicalModel` (red→green verified)
- [x] All 3193 tests in `cli-adapters/` + `config/` pass
- [x] `pnpm check:model-drift` exits 0 (allowlist shrinks 7 → 6)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green
- [ ] Fitness audit ≥ 90/100

## Migration progress (#2200)

- [x] **Child 1** — Claude CLI adapter (this PR)
- [ ] Child 2 — Gemini types/adapter
- [ ] Child 3 — OpenAI types/adapter
- [ ] Child 4 — `setup-custom-api.ts` + `auto-adapter.ts` env-var fallback + `token-counter-types.ts` review
- [ ] Child 5 — Verify allowlist count = 0 at end

🤖 Generated with [Claude Code](https://claude.com/claude-code)