### PR TITLE
fix(adapters): migrate Gemini current models to canonical registry (#2200 Child 2)

### DIFF
--- a/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
@@ -681,23 +681,19 @@ describe('GEMINI_MODELS', () => {
 });
 
 describe('GEMINI_MODEL_ALIASES', () => {
-  it('should map Gemini 2.5 aliases to full model IDs', () => {
-    expect(GEMINI_MODEL_ALIASES['gemini-2.5-pro']).toBe(GEMINI_MODELS.PRO_2_5);
-    expect(GEMINI_MODEL_ALIASES['gemini-2.5-flash']).toBe(GEMINI_MODELS.FLASH_2_5);
+  // After #2200 Child 2, only legacy 1.5 / 2.0 aliases live in this map.
+  // 2.5+ and short aliases resolve via the canonical registry.
+  it('contains only Gemini 1.5 / 2.0 legacy entries (registry covers current)', () => {
+    expect(Object.keys(GEMINI_MODEL_ALIASES).sort()).toEqual([
+      'gemini-1.5-flash',
+      'gemini-1.5-pro',
+      'gemini-2.0-flash',
+    ]);
   });
 
-  it('should map Gemini 2.x aliases to full model IDs', () => {
-    expect(GEMINI_MODEL_ALIASES['gemini-2.5-flash']).toBe(GEMINI_MODELS.FLASH_2_5);
-    expect(GEMINI_MODEL_ALIASES['gemini-2.0-flash']).toBe(GEMINI_MODELS.FLASH_2_0);
-  });
-
-  it('should map Gemini 1.5 aliases to full model IDs', () => {
+  it('legacy 1.5 / 2.0 entries pass through unchanged', () => {
     expect(GEMINI_MODEL_ALIASES['gemini-1.5-pro']).toBe(GEMINI_MODELS.PRO_1_5);
     expect(GEMINI_MODEL_ALIASES['gemini-1.5-flash']).toBe(GEMINI_MODELS.FLASH_1_5);
-  });
-
-  it('should map short aliases to latest versions', () => {
-    expect(GEMINI_MODEL_ALIASES['gemini-flash']).toBe(GEMINI_MODELS.FLASH_2_5);
-    expect(GEMINI_MODEL_ALIASES['gemini-pro']).toBe(GEMINI_MODELS.PRO_2_5);
+    expect(GEMINI_MODEL_ALIASES['gemini-2.0-flash']).toBe(GEMINI_MODELS.FLASH_2_0);
   });
 });

--- a/packages/nexus-agents/src/adapters/gemini-types.ts
+++ b/packages/nexus-agents/src/adapters/gemini-types.ts
@@ -7,33 +7,38 @@
 import type { Content, Part, FunctionDeclaration } from '@google/genai';
 import type { ContentBlock, Message, ToolDefinition, StopReason } from '../core/index.js';
 import { ModelCapability, getTimeProvider, getRandomProvider } from '../core/index.js';
+import { findCanonicalModel, getCliModelName } from '../config/model-config-helpers.js';
 
 /**
  * Supported Gemini model identifiers.
+ *
+ * Current models (2.5+ and 3.x) derive from `config/model-capabilities.ts`
+ * (single source of truth — #2200 Child 2). Legacy 1.5 / 2.0 strings remain
+ * as constants for backward compat with external consumers; they are not in
+ * the canonical registry because Google deprecated those generations
+ * upstream in 2025.
  */
 export const GEMINI_MODELS = {
-  PRO_2_5: 'gemini-2.5-pro',
-  FLASH_2_5: 'gemini-2.5-flash',
+  PRO_2_5: getCliModelName('gemini-pro'),
+  FLASH_2_5: getCliModelName('gemini-flash'),
+  // Legacy — not in canonical registry. Kept for backward compat.
   FLASH_2_0: 'gemini-2.0-flash',
   PRO_1_5: 'gemini-1.5-pro',
   FLASH_1_5: 'gemini-1.5-flash',
 } as const;
 
 /**
- * Model aliases for convenience.
+ * Legacy aliases for Gemini models not in the canonical registry.
+ *
+ * 2.5 / 3.x aliases are NOT in this map — they resolve via the canonical
+ * registry (cliModelName / cliAlias / aliases[]). See `resolveModelId`.
+ * Only generations Google has deprecated upstream live here, kept for
+ * backward compat with users who hardcoded these strings.
  */
 export const GEMINI_MODEL_ALIASES: Record<string, string> = {
-  // Gemini 2.5 aliases (current latest)
-  'gemini-2.5-pro': GEMINI_MODELS.PRO_2_5,
-  'gemini-2.5-flash': GEMINI_MODELS.FLASH_2_5,
-  // Gemini 2.0 aliases
   'gemini-2.0-flash': GEMINI_MODELS.FLASH_2_0,
-  // Gemini 1.5 aliases
   'gemini-1.5-pro': GEMINI_MODELS.PRO_1_5,
   'gemini-1.5-flash': GEMINI_MODELS.FLASH_1_5,
-  // Short aliases (point to latest versions — Gemini 2.5)
-  'gemini-flash': GEMINI_MODELS.FLASH_2_5,
-  'gemini-pro': GEMINI_MODELS.PRO_2_5,
 } as const;
 
 /**
@@ -158,9 +163,17 @@ export function mapToolToFunctionDeclaration(tool: ToolDefinition): FunctionDecl
 }
 
 /**
- * Resolves model alias to full model identifier.
+ * Resolves a Gemini model alias to the full identifier the SDK expects.
+ *
+ * Resolution order:
+ *   1. Canonical registry (cliModelName / cliAlias / aliases[]) — handles
+ *      'gemini-pro', 'gemini-2.5-pro', 'gemini-flash', 'gemini-3-pro', etc.
+ *   2. Legacy 1.5 / 2.0 alias map — pre-deprecation generations
+ *   3. Pass through unknown ids unchanged
  */
 export function resolveModelId(modelId: string): string {
+  const canonical = findCanonicalModel('gemini', modelId);
+  if (canonical?.cliModelName !== undefined) return canonical.cliModelName;
   return GEMINI_MODEL_ALIASES[modelId] ?? modelId;
 }
 

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -222,7 +222,8 @@ export interface ModelInfoShape {
  * Matches against (in order):
  *   1. `cliModelName` ('gemini-2.5-pro', 'claude-opus-4-6')
  *   2. `cliAlias` ('opus', 'sonnet', 'haiku')
- *   3. `aliases[]` membership — legacy / version-suffix names that resolve
+ *   3. `id` — registry identifier ('gemini-pro', 'claude-opus') (#2200 Child 2)
+ *   4. `aliases[]` membership — legacy / version-suffix names that resolve
  *      to this entry (#2200 Child 1)
  */
 export function findCanonicalModel(
@@ -234,6 +235,7 @@ export function findCanonicalModel(
       m.cliName === cli &&
       (m.cliModelName === cliModelName ||
         m.cliAlias === cliModelName ||
+        m.id === cliModelName ||
         (m.aliases?.includes(cliModelName) ?? false))
   );
 }


### PR DESCRIPTION
## Summary

Second child of [epic #2200](https://github.com/williamzujkowski/nexus-agents/issues/2200). Trims the Gemini parallel registry — current 2.5+ and 3.x models now resolve through the canonical registry. Only deprecated 1.5 / 2.0 strings remain locally (Google deprecated those generations upstream in 2025).

## Changes

1. **`findCanonicalModel(cli, name)`** also matches by registry `id` (e.g., `'gemini-pro'` resolves to the gemini-pro entry). Was: cliModelName / cliAlias / aliases only.
2. **`GEMINI_MODELS.PRO_2_5 / FLASH_2_5`** derive from `getCliModelName()` — no more hardcoded current-version strings.
3. **`GEMINI_MODEL_ALIASES`** trims from 7 → 3 entries. Current 2.5 aliases and short-forms (`gemini-pro`, `gemini-flash`) now resolve via the canonical registry. Only deprecated 1.5 / 2.0 strings remain locally.
4. **`resolveModelId()`** consults the registry first; legacy map only fires for 1.5 / 2.0 names not in registry.
5. Test rewrite: `GEMINI_MODEL_ALIASES` content tests assert the trimmed shape (3 keys: 1.5/2.0 only) instead of old 7-key map.

## Behavior

No external behavior change for current models:
- `resolveModelId('gemini-pro')` → `'gemini-2.5-pro'` (was: same, via legacy map; now: via registry)
- `resolveModelId('gemini-2.5-flash')` → `'gemini-2.5-flash'` (was: same; now: via registry)
- `resolveModelId('gemini-1.5-pro')` → `'gemini-1.5-pro'` (was: same; now: via legacy map fallback)

## Test plan

- [x] All 3930 tests in `adapters/` + `config/` + `cli-adapters/` pass
- [x] `pnpm check:model-drift` exits 0 (allowlist unchanged at 6)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Why allowlist count stays at 6

`gemini-types.ts` still has 3 legacy strings (`'gemini-2.0-flash'`, `'gemini-1.5-pro'`, `'gemini-1.5-flash'`) preserved as exported constants for back-compat with external consumers who imported them. Their full removal is a breaking public-API change that should go through a deprecation cycle — tracked separately if desired.

## Migration progress (#2200)

- [x] Child 1 — Claude CLI adapter (#2206 merged)
- [x] **Child 2** — Gemini types/adapter (this PR)
- [ ] Child 3 — OpenAI types/adapter
- [ ] Child 4 — `setup-custom-api.ts` + `auto-adapter.ts` env-var fallback + `token-counter-types.ts` review
- [ ] Child 5 — Verify allowlist count, tighten rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)