### PR TITLE
fix(config): centralize CUSTOM_API_DEFAULT_MODEL constant (#2200 Child 4)

### DIFF
--- a/packages/nexus-agents/src/adapters/auto-adapter.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.ts
@@ -21,6 +21,7 @@ import { SdkAdapter } from './sdk/index.js';
 import type { CliName } from '../cli-adapters/types.js';
 import type { ICliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
 import { createCliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
+import { CUSTOM_API_DEFAULT_MODEL } from '../config/defaults.js';
 import { getCliModelName } from '../config/model-config-helpers.js';
 import { DEFAULT_MODEL_PER_CLI } from '../config/model-capabilities.js';
 
@@ -221,7 +222,7 @@ function tryCustomOpenAiAdapter(logger: ILogger): AdapterSelection | null {
   if (customKey === undefined || customBaseUrl === undefined || customBaseUrl === '') {
     return null;
   }
-  const customModelId = process.env['NEXUS_CUSTOM_MODEL'] ?? 'gpt-4o';
+  const customModelId = process.env['NEXUS_CUSTOM_MODEL'] ?? CUSTOM_API_DEFAULT_MODEL;
   logger.info('Using custom-openai SDK adapter', {
     model: customModelId,
     baseUrl: customBaseUrl,

--- a/packages/nexus-agents/src/cli/setup-custom-api.ts
+++ b/packages/nexus-agents/src/cli/setup-custom-api.ts
@@ -18,6 +18,7 @@
 import { createInterface } from 'node:readline';
 import { validateCustomApiBaseUrl } from '../adapters/sdk/custom-api-validation.js';
 import { CUSTOM_API_BASE_URL_ENV, CUSTOM_API_ALLOW_PRIVATE_ENV } from '../adapters/sdk/types.js';
+import { CUSTOM_API_DEFAULT_MODEL as DEFAULT_MODEL } from '../config/defaults.js';
 import { ok, err, type Result } from '../core/index.js';
 
 /** Inputs to `configureCustomApi`. */
@@ -64,8 +65,6 @@ export interface CustomApiSetupResult {
    */
   readonly shellFragment: string;
 }
-
-const DEFAULT_MODEL = 'gpt-4o';
 
 /**
  * Configures a custom OpenAI-compatible gateway.

--- a/packages/nexus-agents/src/config/defaults.ts
+++ b/packages/nexus-agents/src/config/defaults.ts
@@ -81,6 +81,23 @@ import {
 } from './timeouts.js';
 
 // ============================================================================
+// Default Model IDs (#2200 Child 4)
+// ============================================================================
+
+/**
+ * Default model identifier for the custom OpenAI-compatible API gateway.
+ *
+ * Used by both `cli/setup-custom-api.ts` (write to nexus-agents.yaml) and
+ * `adapters/auto-adapter.ts` (NEXUS_CUSTOM_MODEL env-var fallback). Single
+ * source of truth so changes flow through all consumers.
+ *
+ * `gpt-4o` is widely supported across OpenAI-compatible gateways (vLLM,
+ * LiteLLM, Together AI, etc.) — a pragmatic baseline rather than the
+ * cheapest or most capable. Operators are expected to override.
+ */
+export const CUSTOM_API_DEFAULT_MODEL = 'gpt-4o';
+
+// ============================================================================
 // Central Defaults Object
 // ============================================================================
 

--- a/scripts/model-string-drift-allowlist.ts
+++ b/scripts/model-string-drift-allowlist.ts
@@ -55,22 +55,9 @@ export const ALLOWLIST: readonly AllowlistEntry[] = [
     trackingIssue: 2200,
   },
   {
-    file: 'packages/nexus-agents/src/cli/setup-custom-api.ts',
-    reason:
-      'Default `gpt-4o` for custom API fallback. Migrate to a config constant via #2200 Child 4.',
-    trackingIssue: 2200,
-  },
-  {
-    file: 'packages/nexus-agents/src/adapters/auto-adapter.ts',
-    literal: 'gpt-4o',
-    reason:
-      'Fallback when NEXUS_CUSTOM_MODEL env var is unset. Same migration target as setup-custom-api.ts — #2200 Child 4.',
-    trackingIssue: 2200,
-  },
-  {
     file: 'packages/nexus-agents/src/context/token-counter-types.ts',
     reason:
-      'tiktoken model map (external library mapping). May legitimately stay; review in #2200 Child 4.',
+      'tiktoken library identifiers (NOT nexus-agents model IDs). Documented architectural exception — these stay outside the canonical registry intentionally because they map to tiktoken encodings, not API model versions. Reviewed and confirmed legitimate during #2200 Child 4.',
     trackingIssue: 2200,
   },
 ];


### PR DESCRIPTION
## Summary

Fourth child of [epic #2200](https://github.com/williamzujkowski/nexus-agents/issues/2200). Two consumers each hardcoded `'gpt-4o'` as the default model for the custom OpenAI-compatible gateway:

- `cli/setup-custom-api.ts:68` — `const DEFAULT_MODEL = 'gpt-4o'`
- `adapters/auto-adapter.ts:224` — `process.env['NEXUS_CUSTOM_MODEL'] ?? 'gpt-4o'`

Centralized into `config/defaults.ts` as `CUSTOM_API_DEFAULT_MODEL`. Future model changes flow through one edit.

## Allowlist progress

- Removed: `cli/setup-custom-api.ts` (literal eliminated)
- Removed: `adapters/auto-adapter.ts` (literal eliminated)
- **Reclassified** as permanent architectural exception: `context/token-counter-types.ts` — these are tiktoken library identifiers, not nexus-agents model IDs. They map to encoding names (`o200k_base`), not API model versions. Documented in the allowlist entry.

Allowlist: 6 → 4 (−33% this PR; 9 → 4 since #2199 day-1, **−56% total**).

## Test plan

- [x] All 4532 tests in `cli/` + `adapters/` + `config/` pass
- [x] `pnpm check:model-drift` exits 0 (4 allowlist entries remaining)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Migration progress (#2200)

- [x] Child 1 — Claude CLI adapter (#2206)
- [x] Child 2 — Gemini current models (#2207)
- [ ] Child 3 — OpenAI direct-API: deferred — structural mismatch with CLI-routing schema (see [#2200 comment](https://github.com/williamzujkowski/nexus-agents/issues/2200#issuecomment-4320131167))
- [x] **Child 4** — This PR (CUSTOM_API_DEFAULT_MODEL + tiktoken exception)
- [ ] Child 5 — Allowlist count verification at end of epic

## Remaining allowlist entries (4)

| File | Reason | Disposition |
|---|---|---|
| `cli-adapters/adapters/codex-adapter-helpers.ts` | Codex/o3/o4 fallback display + cost (models not yet canonical) | Migrate when o3/o4 land in registry |
| `adapters/gemini-types.ts` | Legacy Gemini 1.5/2.0 strings (deprecated upstream) | Public API back-compat — needs deprecation cycle |
| `adapters/openai-types.ts` | OPENAI_MODELS + OPENAI_MODEL_ALIASES | Child 3 deferred; structural change required |
| `context/token-counter-types.ts` | tiktoken library identifiers | **Permanent legitimate exception** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)