### PR TITLE
feat(ci): flip model-string drift check from advisory to blocking (#2199 Child 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-node
 
-      # Advisory mode (#2199 Child 3). Findings print to job summary but do
-      # not fail the build. Will flip to blocking via NEXUS_DRIFT_ADVISORY=0
-      # in #2199 Child 4 after at least one merge cycle without false positives.
-      - name: Run model-string drift check (advisory)
+      # Blocking mode (#2199 Child 4). Drift findings fail the build.
+      #
+      # Rollback to advisory: set the env var below to '1' (or any non-'0' value).
+      #   env:
+      #     NEXUS_DRIFT_ADVISORY: '1'
+      # The drift script defaults to advisory; the explicit '0' below is what
+      # makes this job blocking.
+      - name: Run model-string drift check (blocking)
+        env:
+          NEXUS_DRIFT_ADVISORY: '0'
         run: |
           set +e
           OUTPUT=$(pnpm --silent check:model-drift 2>&1)
@@ -165,7 +171,7 @@ jobs:
               echo "✓ No new drift. Allowlisted sites tracked in scripts/model-string-drift-allowlist.ts."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
+          exit $STATUS
 
   index-check:
     name: Index Freshness Check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -40,3 +40,17 @@ if [ "$SCORE" -lt "$THRESHOLD" ]; then
 fi
 
 echo "[fitness-guard] Fitness score: $SCORE/100 (threshold: $THRESHOLD)"
+
+# Model-string drift check (#2199 Child 4) — blocking
+# Rollback: set NEXUS_DRIFT_ADVISORY=1 in your shell or skip with --no-verify.
+echo "[drift-guard] Running model-string drift check..."
+if NEXUS_DRIFT_ADVISORY=0 npx --quiet tsx scripts/check-model-string-drift.ts; then
+  echo "[drift-guard] No new model-version drift detected."
+else
+  echo ""
+  echo "[drift-guard] BLOCKED: hardcoded model-version string outside config/."
+  echo "[drift-guard] Migrate to config/model-capabilities.ts or add an"
+  echo "[drift-guard] allowlist entry referencing companion epic #2200."
+  echo "[drift-guard] Skip with: git push --no-verify"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes [#2199](https://github.com/williamzujkowski/nexus-agents/issues/2199) — the final child of the fitness-guard rule epic. Flips the CI advisory job to blocking and adds the same check to the pre-push hook.

## Authorization & risk

Original Architect's vote condition was a ≥1-week soak before flipping. User explicitly overrode (\"perform all other actions ... implement the entire epic and all subtasks\"). Re-vote: **5-1 approved** (Architect, Security, DevEx, AI/ML, PM approve; Contrarian flags insufficient soak data).

Risk evidence:
- 20 unit tests including 4 explicit JSDoc/comment immunity tests
- 4 clean CI cycles since #2204 merge — zero false positives
- 4 grandfathered sites captured in structured allowlist
- Local verification: clean main passes both modes; injected violation correctly fails blocking and passes advisory

## Rollback

**Single-line revert** (no code change required):

```yaml
# In .github/workflows/ci.yml model-string-drift job:
env:
  NEXUS_DRIFT_ADVISORY: '1'  # ← change from '0' to '1'
```

For pre-push: developers can `git push --no-verify` for emergencies. To globally restore advisory: ` export NEXUS_DRIFT_ADVISORY=1` in shell or remove the drift block from \`.husky/pre-push\`.

## Test plan

- [x] Clean main: blocking exit=0
- [x] Injected violation (`/tmp/drift-test.ts` with stale claude string): blocking exit=1, advisory exit=0
- [x] Pre-push hook tested locally
- [ ] CI green (this PR will be the first to exercise blocking mode — should pass since allowlist covers all current sites)

## Epic #2199 progress (CLOSING)

- [x] Child 1 — Schema field (#2202)
- [x] Child 2 — Drift script + structured allowlist (#2203)
- [x] Child 3 — CI advisory job (#2204)
- [x] **Child 4 — This PR** (CI blocking + pre-push hook)
- [x] Child 5 — Allowlist migration (#2205)

Once this merges, #2199 is fully done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)