### PR TITLE
fix(adapters): OpenAI direct-API partial migration + boundary doc (#2200 Child 3)

### DIFF
--- a/packages/nexus-agents/src/adapters/openai-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.test.ts
@@ -781,18 +781,32 @@ describe('OPENAI_MODELS', () => {
 });
 
 describe('OPENAI_MODEL_ALIASES', () => {
-  it('should map GPT-5.2 aliases to full model IDs', () => {
-    expect(OPENAI_MODEL_ALIASES['gpt-5.2']).toBe(OPENAI_MODELS.GPT_5_2);
-    expect(OPENAI_MODEL_ALIASES['gpt-5.2-instant']).toBe(OPENAI_MODELS.GPT_5_2_INSTANT);
-    expect(OPENAI_MODEL_ALIASES['gpt-5.2-chat-latest']).toBe(OPENAI_MODELS.GPT_5_2_INSTANT);
-    expect(OPENAI_MODEL_ALIASES['gpt-5.2-pro']).toBe(OPENAI_MODELS.GPT_5_2_PRO);
-    expect(OPENAI_MODEL_ALIASES['gpt-5.2-codex']).toBe(OPENAI_MODELS.GPT_5_2_CODEX);
+  // After #2200 Child 3, identity-only mappings were removed
+  // (resolveModelId passes unknown ids through unchanged via `?? modelId`).
+  // Only entries that translate a shorthand to a dated version remain.
+  it('contains only shorthand → dated entries (no identity mappings)', () => {
+    expect(Object.keys(OPENAI_MODEL_ALIASES).sort()).toEqual([
+      'gpt-3.5-turbo',
+      'gpt-4-turbo',
+      'gpt-4o',
+      'gpt-4o-mini',
+      'gpt-5.2-instant',
+    ]);
   });
 
-  it('should map GPT-4o aliases to full model IDs', () => {
+  it('shorthand aliases map to dated identifiers', () => {
+    expect(OPENAI_MODEL_ALIASES['gpt-5.2-instant']).toBe(OPENAI_MODELS.GPT_5_2_INSTANT);
     expect(OPENAI_MODEL_ALIASES['gpt-4o']).toBe(OPENAI_MODELS.GPT_4O);
     expect(OPENAI_MODEL_ALIASES['gpt-4o-mini']).toBe(OPENAI_MODELS.GPT_4O_MINI);
     expect(OPENAI_MODEL_ALIASES['gpt-4-turbo']).toBe(OPENAI_MODELS.GPT_4_TURBO);
     expect(OPENAI_MODEL_ALIASES['gpt-3.5-turbo']).toBe(OPENAI_MODELS.GPT_35_TURBO);
+  });
+});
+
+describe('OPENAI_MODELS — derived constants', () => {
+  it('GPT_5_2_CODEX derives from canonical registry codex-5.2 entry', () => {
+    // Locks in #2200 Child 3 partial migration: this single overlap with
+    // the CLI registry (codex-5.2's cliModelName) is registry-derived.
+    expect(OPENAI_MODELS.GPT_5_2_CODEX).toBe('gpt-5.2-codex');
   });
 });

--- a/packages/nexus-agents/src/adapters/openai-types.ts
+++ b/packages/nexus-agents/src/adapters/openai-types.ts
@@ -1,20 +1,41 @@
 /**
  * nexus-agents/adapters - OpenAI Type Helpers
  *
- * Type definitions and constants for OpenAI adapter.
+ * Type definitions and constants for the OpenAI direct-API SDK adapter.
+ *
+ * **Architectural boundary (#2200 Child 3):** these constants do NOT live
+ * in `config/model-capabilities.ts`. The canonical registry's `cliName`
+ * dimension targets CLI tools (`claude` / `gemini` / `codex` / `opencode`)
+ * — there is no `openai` CLI binary. Adding `'openai'` to the CLI_NAMES
+ * enum would force a fifth case in 4+ exhaustive switches across the
+ * codebase, violating the semantic of "CLI tool name."
+ *
+ * The OpenAI direct adapter is conceptually different from CLI adapters:
+ * it talks to the OpenAI HTTPS API directly, not via a subprocess CLI.
+ * Its model identifiers are OpenAI's own (`gpt-4o-2024-11-20`,
+ * `gpt-3.5-turbo-0125`, etc.) — these are upstream API constants, not
+ * versions WE chose. They drift only when OpenAI ships new dated releases.
+ *
+ * This file is the single source of truth for OpenAI direct-API model
+ * identifiers. The model-string drift fitness-guard (#2199) treats it as
+ * a documented architectural exception in the allowlist.
  */
 
 import type { ModelCapability } from '../core/index.js';
 import { ModelCapability as MC } from '../core/index.js';
+import { getCliModelName } from '../config/model-config-helpers.js';
 
 /**
- * Supported OpenAI model identifiers.
+ * Supported OpenAI direct-API model identifiers (OpenAI's own dated names).
+ *
+ * GPT_5_2_CODEX derives from the canonical registry (codex-5.2's cliModelName)
+ * because it overlaps with the Codex CLI; the rest are pure-API constants.
  */
 export const OPENAI_MODELS = {
   GPT_5_2: 'gpt-5.2',
   GPT_5_2_INSTANT: 'gpt-5.2-chat-latest',
   GPT_5_2_PRO: 'gpt-5.2-pro',
-  GPT_5_2_CODEX: 'gpt-5.2-codex',
+  GPT_5_2_CODEX: getCliModelName('codex-5.2'),
   GPT_4O: 'gpt-4o-2024-11-20',
   GPT_4O_MINI: 'gpt-4o-mini-2024-07-18',
   GPT_4_TURBO: 'gpt-4-turbo-2024-04-09',
@@ -22,16 +43,15 @@ export const OPENAI_MODELS = {
 } as const;
 
 /**
- * Model aliases for convenience.
+ * User-friendly OpenAI aliases → dated model identifiers.
+ *
+ * Identity-only mappings (e.g., `'gpt-5.2-pro' → 'gpt-5.2-pro'`) were
+ * removed in #2200 Child 3 — `resolveModelId` already passes unknown ids
+ * through unchanged via `?? modelId`. Only entries that translate a
+ * shorthand into a dated version remain.
  */
 export const OPENAI_MODEL_ALIASES: Record<string, string> = {
-  // GPT-5.2 aliases
-  'gpt-5.2': OPENAI_MODELS.GPT_5_2,
   'gpt-5.2-instant': OPENAI_MODELS.GPT_5_2_INSTANT,
-  'gpt-5.2-chat-latest': OPENAI_MODELS.GPT_5_2_INSTANT,
-  'gpt-5.2-pro': OPENAI_MODELS.GPT_5_2_PRO,
-  'gpt-5.2-codex': OPENAI_MODELS.GPT_5_2_CODEX,
-  // GPT-4o aliases
   'gpt-4o': OPENAI_MODELS.GPT_4O,
   'gpt-4o-mini': OPENAI_MODELS.GPT_4O_MINI,
   'gpt-4-turbo': OPENAI_MODELS.GPT_4_TURBO,


### PR DESCRIPTION
## Summary

Closes #2200 Child 3. Partial migration of the OpenAI direct-API adapter, with the rest of the file documented as a permanent architectural exception (not technical debt).

## The architectural finding

OpenAI direct-API adapter is structurally different from CLI adapters:
- **CLI adapters** (Claude, Gemini, Codex, OpenCode): subprocess + CLI binary
- **OpenAI direct adapter**: HTTPS API client, no subprocess, no `openai` CLI binary exists

The canonical registry's `cliName` enum (`'claude' | 'gemini' | 'codex' | 'opencode'`) targets CLI tools. Adding `'openai'` would:
- Force a 5th case in 4+ exhaustive switches across the codebase (255 `CliNameLiteral` references)
- Violate the semantic of "CLI tool name"
- Misrepresent OpenAI as a CLI when it isn't

The OpenAI dated identifiers (`gpt-4o-2024-11-20`, `gpt-3.5-turbo-0125`) are **upstream API constants**, not nexus-internal versions. They drift only when OpenAI ships dated releases.

## Partial migration that DOES cleanly fit

- `OPENAI_MODELS.GPT_5_2_CODEX` now derives from `getCliModelName('codex-5.2')` — the one entry that overlaps with the CLI registry (Codex CLI uses `gpt-5.2-codex`).
- `OPENAI_MODEL_ALIASES` trims 9 → 5 entries: identity-only mappings removed since `resolveModelId` passes unknown ids through unchanged.
- File header documents the architectural boundary clearly so future contributors know `openai-types.ts` is the single source of truth for OpenAI direct-API identifiers (not a parallel registry).

## Why allowlist count stays at 4

Removing `openai-types.ts` from the drift allowlist would require either:
- Migrating its constants into the CLI registry (architecturally wrong — they aren't CLI models), OR
- Eliminating the constants entirely (breaking the OpenAI SDK adapter)

Neither is valuable. The allowlist correctly captures this as a permanent legitimate exception, same shape as the `tiktoken` entry.

## Test plan

- [x] All 52 OpenAI adapter tests pass (rewrote 2 alias-content assertions for trimmed map)
- [x] `pnpm check:model-drift` exits 0 (4 entries unchanged)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean

## Migration progress (#2200)

- [x] Child 1 — Claude CLI adapter (#2206)
- [x] Child 2 — Gemini current models (#2207)
- [x] **Child 3 — This PR** (OpenAI partial + boundary doc)
- [x] Child 4 — CUSTOM_API_DEFAULT_MODEL (#2208)
- [ ] Child 5 — Allowlist closure (4 entries; all documented architectural decisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)