### PR TITLE
chore(scripts): close out #2200 — allowlist as permanent decisions (#2200 Child 5)

### DIFF
--- a/scripts/check-model-string-drift.ts
+++ b/scripts/check-model-string-drift.ts
@@ -128,7 +128,7 @@ function main(): void {
     const allowedCount = ALLOWLIST.length;
     process.stdout.write(
       `✓ No new model-version drift detected. Source root: ${SRC_ROOT}\n` +
-        `  ${String(allowedCount)} grandfathered site(s) in allowlist (#2200 will reduce this).\n`
+        `  ${String(allowedCount)} grandfathered site(s) in allowlist (documented architectural decisions).\n`
     );
     process.exit(0);
   }

--- a/scripts/model-string-drift-allowlist.ts
+++ b/scripts/model-string-drift-allowlist.ts
@@ -2,13 +2,24 @@
  * Allowlist for the model-string drift fitness-guard (#2199 Child 2).
  *
  * Each entry grandfathers an existing hardcoded model-version string that
- * lives outside `packages/nexus-agents/src/config/`. Migration of these
- * sites is tracked in companion epic #2200 — every entry here MUST cite a
- * tracking-issue number so the allowlist can shrink as that epic lands.
+ * lives outside `packages/nexus-agents/src/config/`. After companion epic
+ * #2200 closure (2026-04-25), the four remaining entries are documented
+ * **architectural decisions**, not pending technical debt:
  *
- * Adding a new entry without a real tracking issue is the failure mode this
- * file is designed to prevent. Reviewers: reject PRs that add entries
- * without a `trackingIssue` referencing an open ticket.
+ *   - tiktoken library identifiers (token-counter-types.ts) — permanent;
+ *     they map to encoding names, not API model versions
+ *   - OpenAI direct-API constants (openai-types.ts) — permanent; the
+ *     CLI-routing canonical registry doesn't fit OpenAI direct API,
+ *     and adding 'openai' to CLI_NAMES would force exhaustive switches
+ *   - Gemini 1.5 / 2.0 legacy constants (gemini-types.ts) — pending
+ *     a public-API deprecation cycle (breaking change)
+ *   - Codex fallback display/cost data (codex-adapter-helpers.ts) —
+ *     pending o3/o4 inclusion in the canonical registry
+ *
+ * **Adding a new entry** requires either: a `trackingIssue` referencing
+ * an open ticket (technical debt with a migration plan), OR a clear
+ * architectural-decision rationale in the `reason` field (permanent
+ * exception). Reviewers: reject PRs that add entries without one of those.
  *
  * @module scripts/model-string-drift-allowlist
  */
@@ -30,34 +41,39 @@ export interface AllowlistEntry {
 }
 
 /**
- * Day-1 allowlist captured during research for #2199. Sourced from the
- * Category-A audit in the epic body. Each file-level entry covers all the
- * legacy version strings discovered there; tightening to per-literal
- * entries happens as the migration epic #2200 lands children.
+ * Post-#2200 allowlist (2026-04-25). Day-1 had 9 entries; epic #2200
+ * migrated 5 (Claude CLI adapter, Gemini current models, Claude SDK
+ * helpers, setup-custom-api defaults, auto-adapter env-var fallback) and
+ * documented 4 as permanent architectural decisions.
+ *
+ * Reducing this list further requires either:
+ *   - Gemini: a deprecation cycle for the public 1.5/2.0 constants
+ *   - Codex: o3/o4 added to the canonical model registry upstream
+ *   - OpenAI / tiktoken: schema redesign (see file header)
  */
 export const ALLOWLIST: readonly AllowlistEntry[] = [
   {
     file: 'packages/nexus-agents/src/adapters/gemini-types.ts',
     reason:
-      'Runtime model id constants + alias map for Gemini. Migrate to ModelCapability.aliases via #2200 Child 2.',
+      'Legacy Gemini 1.5 / 2.0 string constants (PRO_1_5, FLASH_1_5, FLASH_2_0). Google deprecated these generations upstream in 2025. Constants persist as a public re-export surface — full removal requires a deprecation cycle. Pending separate epic.',
     trackingIssue: 2200,
   },
   {
     file: 'packages/nexus-agents/src/adapters/openai-types.ts',
     reason:
-      'Runtime model id constants + alias map for OpenAI / GPT. Migrate to ModelCapability.aliases via #2200 Child 3.',
+      'Permanent architectural exception. OpenAI direct-API uses HTTPS, not a CLI binary; the canonical registry CLI_NAMES enum (claude/gemini/codex/opencode) does not include "openai" by design. Adding it would force exhaustive-switch updates across 255 cliName references and misrepresent OpenAI as a CLI. See file header for full rationale (#2200 Child 3).',
     trackingIssue: 2200,
   },
   {
     file: 'packages/nexus-agents/src/cli-adapters/adapters/codex-adapter-helpers.ts',
     reason:
-      'Codex/o3/o4 fallback display + cost data. Models not yet canonical; collapse into registry once o3/o4 land.',
+      'Codex / o3 / o4 fallback display + cost data. These models are not yet canonical (registry tracks codex-5.x family). Collapse into registry once Anthropic/OpenAI publishes o3/o4 specs and they land in model-capabilities.ts.',
     trackingIssue: 2200,
   },
   {
     file: 'packages/nexus-agents/src/context/token-counter-types.ts',
     reason:
-      'tiktoken library identifiers (NOT nexus-agents model IDs). Documented architectural exception — these stay outside the canonical registry intentionally because they map to tiktoken encodings, not API model versions. Reviewed and confirmed legitimate during #2200 Child 4.',
+      'Permanent legitimate exception. These are tiktoken library identifiers (NOT nexus-agents model IDs) — they map to BPE encoding names like "o200k_base", not API model versions. Confirmed legitimate during #2200 Child 4 review.',
     trackingIssue: 2200,
   },
 ];


### PR DESCRIPTION
## Summary

Closes [#2200](https://github.com/williamzujkowski/nexus-agents/issues/2200) — final bookkeeping child. The drift allowlist stabilizes at 4 entries, each now documented as a deliberate architectural decision rather than pending technical debt.

## What changed

- `scripts/model-string-drift-allowlist.ts`: file header explains disposition criteria. Each entry's `reason` field now states whether it's:
  - Permanent (tiktoken library mappings, OpenAI direct-API constants)
  - Pending deprecation cycle (Gemini 1.5/2.0 public constants)
  - Pending external dependency (Codex o3/o4 not yet canonical)
- `scripts/check-model-string-drift.ts`: output message updated from "#2200 will reduce this" to "documented architectural decisions" since the epic has closed.

## Net allowlist progression (#2199 day-1 → epic #2200 closure)

```
9 entries (2026-04-25 morning)
  ↓ #2205 — Claude SDK helpers migrated
7 entries
  ↓ #2206 — Claude CLI adapter migrated
6 entries
  ↓ #2208 — setup-custom-api + auto-adapter centralized to CUSTOM_API_DEFAULT_MODEL
4 entries  (-56% reduction)
```

## Test plan

- [x] All 20 drift script tests pass
- [x] `pnpm check:model-drift` exits 0 with new wording
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Closes

- [x] #2199 (closed via #2210)
- [x] **#2200** (closes via this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)