### PR TITLE
refactor(cli): consolidate CLI binary detection into one helper (#2155)

### DIFF
--- a/packages/nexus-agents/src/cli/setup-cli-detection.test.ts
+++ b/packages/nexus-agents/src/cli/setup-cli-detection.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for shared CLI binary detection helpers (#2155).
+ *
+ * Pure-function tests for `extractSemver` + `getCliLocatorCommand`. The
+ * `detectCliBinary` integration is exercised through each existing
+ * `setup-*.test.ts` (codex, gemini, opencode) so we don't duplicate the
+ * fs/process mocking here.
+ *
+ * @module cli/setup-cli-detection.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { extractSemver, getCliLocatorCommand, detectCliBinary } from './setup-cli-detection.js';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return { ...actual, platform: vi.fn(() => actual.platform()) };
+});
+
+import { platform } from 'node:os';
+
+describe('extractSemver', () => {
+  it('extracts X.Y.Z from a typical CLI version banner', () => {
+    expect(extractSemver('claude version 1.2.3')).toBe('1.2.3');
+    expect(extractSemver('gemini-cli/0.7.12')).toBe('0.7.12');
+  });
+
+  it('extracts the first match when multiple semvers appear', () => {
+    expect(extractSemver('codex 1.0.0 (build 2.4.7)')).toBe('1.0.0');
+  });
+
+  it('returns undefined when no semver is present', () => {
+    expect(extractSemver('opencode')).toBeUndefined();
+    expect(extractSemver('1.2')).toBeUndefined(); // partial — no third segment
+    expect(extractSemver('')).toBeUndefined();
+  });
+
+  it('handles multi-digit segments', () => {
+    expect(extractSemver('v12.345.6789')).toBe('12.345.6789');
+  });
+});
+
+describe('getCliLocatorCommand', () => {
+  it("returns 'which' on POSIX platforms", () => {
+    vi.mocked(platform).mockReturnValueOnce('linux');
+    expect(getCliLocatorCommand()).toBe('which');
+  });
+
+  it("returns 'which' on macOS", () => {
+    vi.mocked(platform).mockReturnValueOnce('darwin');
+    expect(getCliLocatorCommand()).toBe('which');
+  });
+
+  it("returns 'where' on Windows", () => {
+    vi.mocked(platform).mockReturnValueOnce('win32');
+    expect(getCliLocatorCommand()).toBe('where');
+  });
+});
+
+describe('detectCliBinary', () => {
+  it('returns installed=false when the binary is not on PATH', () => {
+    // 'definitely-not-a-real-cli-binary-xyz' should not exist; the locator
+    // call fails, returning installed:false with a classified error.
+    const result = detectCliBinary('definitely-not-a-real-cli-binary-xyz');
+    expect(result.installed).toBe(false);
+    expect(result.version).toBeUndefined();
+    expect(result.detectionError).toBeDefined();
+  });
+});

--- a/packages/nexus-agents/src/cli/setup-cli-detection.ts
+++ b/packages/nexus-agents/src/cli/setup-cli-detection.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared CLI binary detection helpers (#2155, child of #2151).
+ *
+ * Consolidates the near-identical detection logic that previously lived in
+ * `setup-codex.ts`, `setup-gemini.ts`, and `setup-opencode.ts`. Each setup
+ * file now delegates to `detectCliBinary(name)` instead of carrying its
+ * own copy of the platform-aware locator + version-extraction logic.
+ *
+ * The per-CLI `ConfigResult` interfaces remain separate because they
+ * legitimately differ (Codex writes via MCP, Gemini and OpenCode write to
+ * config files with paths).
+ *
+ * @module cli/setup-cli-detection
+ */
+
+import { execFileSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+import { classifyExecError, type DetectionError } from './cli-detection-error.js';
+
+/** Generic CLI detection result. Consumed by every `setup-*.ts` detector. */
+export interface CliDetectionInfo {
+  readonly installed: boolean;
+  readonly version: string | undefined;
+  /**
+   * Classification of why detection failed. Set when `installed` is `false`
+   * OR when the binary was located but `--version` failed (#2152).
+   */
+  readonly detectionError?: DetectionError;
+}
+
+/** Returns the platform-appropriate command for locating an executable. */
+export function getCliLocatorCommand(): 'where' | 'which' {
+  return platform() === 'win32' ? 'where' : 'which';
+}
+
+/**
+ * Extracts a semver triple (`X.Y.Z`) from CLI `--version` output.
+ *
+ * Pure helper — exported for direct unit testing. Returns the matched
+ * version string or undefined when no semver-shaped substring is present.
+ */
+export function extractSemver(output: string): string | undefined {
+  const match = /(\d+\.\d+\.\d+)/.exec(output);
+  return match?.[1];
+}
+
+/**
+ * Detects whether a CLI binary is installed and reports its version.
+ *
+ * Two-phase detection:
+ *   1. Locate via `which` / `where` — fast PATH check (3s timeout).
+ *   2. If located, run `<name> --version` and extract semver (5s timeout).
+ *
+ * Both phases trap `execFileSync` exceptions and return a `CliDetectionInfo`
+ * with a classified `detectionError`. Callers never see exceptions from
+ * this function.
+ */
+export function detectCliBinary(name: string): CliDetectionInfo {
+  try {
+    execFileSync(getCliLocatorCommand(), [name], { timeout: 3000, stdio: 'pipe' });
+  } catch (err: unknown) {
+    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
+  }
+
+  try {
+    const output = execFileSync(name, ['--version'], {
+      timeout: 5000,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+    return { installed: true, version: extractSemver(output) };
+  } catch (err: unknown) {
+    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
+  }
+}

--- a/packages/nexus-agents/src/cli/setup-codex.ts
+++ b/packages/nexus-agents/src/cli/setup-codex.ts
@@ -9,23 +9,20 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { platform } from 'node:os';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
-import { classifyExecError, type DetectionError } from './cli-detection-error.js';
+import { detectCliBinary, type CliDetectionInfo } from './setup-cli-detection.js';
 
 const logger = createLogger({ component: 'setup-codex' });
 
-/** Codex CLI detection result. */
-export interface CodexCliInfo {
-  readonly installed: boolean;
-  readonly version: string | undefined;
-  /**
-   * Classification of why detection failed. Only set when `installed` is
-   * `false` OR when the binary was located but `--version` failed (#2152).
-   */
-  readonly detectionError?: DetectionError;
-}
+/**
+ * Codex CLI detection result.
+ *
+ * Type alias of {@link CliDetectionInfo} — kept as a named type for the
+ * public API surface (re-exported from `cli/index.ts`). Identical shape
+ * across all three CLI setups (#2155).
+ */
+export type CodexCliInfo = CliDetectionInfo;
 
 /** Codex MCP configuration result. */
 export interface CodexConfigResult {
@@ -34,28 +31,9 @@ export interface CodexConfigResult {
   readonly message: string;
 }
 
-/**
- * Detects Codex CLI installation.
- */
+/** Detects Codex CLI installation. Delegates to {@link detectCliBinary}. */
 export function detectCodexCli(): CodexCliInfo {
-  try {
-    const cmd = platform() === 'win32' ? 'where' : 'which';
-    execFileSync(cmd, ['codex'], { timeout: 3000, stdio: 'pipe' });
-  } catch (err: unknown) {
-    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
-  }
-
-  try {
-    const output = execFileSync('codex', ['--version'], {
-      timeout: 5000,
-      stdio: 'pipe',
-      encoding: 'utf-8',
-    });
-    const match = /(\d+\.\d+\.\d+)/.exec(output);
-    return { installed: true, version: match?.[1] };
-  } catch (err: unknown) {
-    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
-  }
+  return detectCliBinary('codex');
 }
 
 /**

--- a/packages/nexus-agents/src/cli/setup-gemini.ts
+++ b/packages/nexus-agents/src/cli/setup-gemini.ts
@@ -8,27 +8,20 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
-import { homedir, platform } from 'node:os';
+import { homedir } from 'node:os';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
-import { classifyExecError, type DetectionError } from './cli-detection-error.js';
+import { detectCliBinary, type CliDetectionInfo } from './setup-cli-detection.js';
 
 const logger = createLogger({ component: 'setup-gemini' });
 
-/** Gemini CLI detection result. */
-export interface GeminiCliInfo {
-  readonly installed: boolean;
-  readonly version: string | undefined;
-  /**
-   * Classification of why detection failed. Only set when `installed` is
-   * `false` OR when the binary was located but `--version` failed. Lets
-   * doctor/verify distinguish "not installed" from "installed but broken
-   * or inaccessible" (#2152).
-   */
-  readonly detectionError?: DetectionError;
-}
+/**
+ * Gemini CLI detection result.
+ *
+ * Type alias of {@link CliDetectionInfo} — see #2155.
+ */
+export type GeminiCliInfo = CliDetectionInfo;
 
 /** Gemini MCP configuration result. */
 export interface GeminiConfigResult {
@@ -45,30 +38,9 @@ interface GeminiMcpEntry {
   readonly timeout: number;
 }
 
-/**
- * Detects Gemini CLI installation.
- */
+/** Detects Gemini CLI installation. Delegates to {@link detectCliBinary}. */
 export function detectGeminiCli(): GeminiCliInfo {
-  try {
-    const cmd = platform() === 'win32' ? 'where' : 'which';
-    execFileSync(cmd, ['gemini'], { timeout: 3000, stdio: 'pipe' });
-  } catch (err: unknown) {
-    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
-  }
-
-  try {
-    const output = execFileSync('gemini', ['--version'], {
-      timeout: 5000,
-      stdio: 'pipe',
-      encoding: 'utf-8',
-    });
-    const match = /(\d+\.\d+\.\d+)/.exec(output);
-    return { installed: true, version: match?.[1] };
-  } catch (err: unknown) {
-    // The binary was located but `--version` failed. Still treat as installed
-    // so downstream flow can proceed, but surface why version-probing failed.
-    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
-  }
+  return detectCliBinary('gemini');
 }
 
 /** Resolves the Gemini config directory path based on scope. */

--- a/packages/nexus-agents/src/cli/setup-opencode.ts
+++ b/packages/nexus-agents/src/cli/setup-opencode.ts
@@ -9,26 +9,21 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
-import { homedir, platform } from 'node:os';
+import { homedir } from 'node:os';
 import { parse as jsoncParse, modify, applyEdits } from 'jsonc-parser';
 import { getErrorMessage } from '../core/index.js';
 import { createLogger } from '../core/index.js';
-import { classifyExecError, type DetectionError } from './cli-detection-error.js';
+import { detectCliBinary, type CliDetectionInfo } from './setup-cli-detection.js';
 
 const logger = createLogger({ component: 'setup-opencode' });
 
-/** OpenCode detection result. */
-export interface OpenCodeCliInfo {
-  readonly installed: boolean;
-  readonly version: string | undefined;
-  /**
-   * Classification of why detection failed. Only set when `installed` is
-   * `false` OR when the binary was located but `--version` failed (#2152).
-   */
-  readonly detectionError?: DetectionError;
-}
+/**
+ * OpenCode detection result.
+ *
+ * Type alias of {@link CliDetectionInfo} — see #2155.
+ */
+export type OpenCodeCliInfo = CliDetectionInfo;
 
 /** OpenCode MCP configuration result. */
 export interface OpenCodeConfigResult {
@@ -45,28 +40,9 @@ export interface ResolvedConfig {
   readonly exists: boolean;
 }
 
-/**
- * Detects OpenCode CLI installation.
- */
+/** Detects OpenCode CLI installation. Delegates to {@link detectCliBinary}. */
 export function detectOpenCodeCli(): OpenCodeCliInfo {
-  try {
-    const cmd = platform() === 'win32' ? 'where' : 'which';
-    execFileSync(cmd, ['opencode'], { timeout: 3000, stdio: 'pipe' });
-  } catch (err: unknown) {
-    return { installed: false, version: undefined, detectionError: classifyExecError(err) };
-  }
-
-  try {
-    const output = execFileSync('opencode', ['--version'], {
-      timeout: 5000,
-      stdio: 'pipe',
-      encoding: 'utf-8',
-    });
-    const match = /(\d+\.\d+\.\d+)/.exec(output);
-    return { installed: true, version: match?.[1] };
-  } catch (err: unknown) {
-    return { installed: true, version: undefined, detectionError: classifyExecError(err) };
-  }
+  return detectCliBinary('opencode');
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes [#2155](https://github.com/williamzujkowski/nexus-agents/issues/2155) (child of epic #2151). Consolidates near-identical CLI binary detection across `setup-codex.ts`, `setup-gemini.ts`, and `setup-opencode.ts`. Same shape as the recent retryable-error-codes consolidation (#2181).

## Changes

- **New `cli/setup-cli-detection.ts`** with three pure helpers:
  - `getCliLocatorCommand()` — `which`/`where` based on platform
  - `extractSemver(output)` — pulls X.Y.Z from CLI version banners
  - `detectCliBinary(name)` — two-phase locate + version probe with classified errors
- **`detect*Cli()` functions become 1-line wrappers** that delegate to `detectCliBinary`. Public API surface preserved.
- **`CodexCliInfo` / `GeminiCliInfo` / `OpenCodeCliInfo`** become type aliases of the shared `CliDetectionInfo` (re-exports from `cli/index.ts` keep working).
- **`ConfigResult` interfaces NOT consolidated** — Codex (no configPath, MCP-based) and Gemini/OpenCode (with configPath, file-based) legitimately differ.
- **8 new TDD tests** for the pure helpers (red→green via straightforward unit cases).

## Diff stats

- −76 LOC of duplicated detection code
- +1 shared helper file (~50 LOC of source + 70 LOC of tests)

## Test plan

- [x] All 42 existing `setup-*.test.ts` tests pass unchanged (codex/gemini/opencode each)
- [x] 8 new tests for `extractSemver` (multi-digit, partial, missing) + `getCliLocatorCommand` (linux/darwin/win32) + `detectCliBinary` smoke test
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)