### PR TITLE
fix(aorchestra): propagate AbortSignal in worker-dispatcher (#2188)

### DIFF
--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.test.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.test.ts
@@ -88,6 +88,65 @@ describe('dispatchWorkers', () => {
     );
   });
 
+  // #2188: AbortSignal cooperative cancellation between/within waves
+  describe('AbortSignal cancellation (#2188)', () => {
+    it('returns empty results when signal is already aborted before first wave', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const entries = [makeEntry('code', 1, 1), makeEntry('testing', 2, 2)];
+      const results = await dispatchWorkers(entries, {
+        executeWorker: mockExecute,
+        signal: controller.signal,
+      });
+      expect(results).toEqual([]);
+    });
+
+    it('skips remaining waves when aborted between waves', async () => {
+      const controller = new AbortController();
+      const wave1Roles: string[] = [];
+      const wave2Roles: string[] = [];
+
+      const tracker: WorkerDispatchOptions['executeWorker'] = (entry) => {
+        if (entry.wave === 1) wave1Roles.push(entry.role);
+        if (entry.wave === 2) wave2Roles.push(entry.role);
+        // Abort after the first wave entry runs — wave 2 should be skipped.
+        if (entry.wave === 1 && wave1Roles.length === 1) controller.abort();
+        return Promise.resolve({
+          role: entry.role,
+          subTask: entry.subTask,
+          output: `out ${entry.role}`,
+          status: 'success' as const,
+          durationMs: 1,
+        });
+      };
+
+      const entries = [
+        makeEntry('code', 1, 1),
+        makeEntry('testing', 2, 1),
+        makeEntry('documentation', 2, 2),
+      ];
+      const results = await dispatchWorkers(entries, {
+        executeWorker: tracker,
+        signal: controller.signal,
+        maxConcurrency: 1,
+      });
+
+      // Wave 1 entry should have run; wave 2 entries should NOT have started.
+      expect(wave1Roles).toEqual(['code']);
+      expect(wave2Roles).toEqual([]);
+      expect(results).toHaveLength(1);
+      expect(results.at(0)?.role).toBe('code');
+    });
+
+    it('omitting signal behaves like no-signal (regression guard)', async () => {
+      const entries = [makeEntry('code', 1, 1), makeEntry('testing', 1, 2)];
+      const results = await dispatchWorkers(entries, {
+        executeWorker: mockExecute,
+      });
+      expect(results).toHaveLength(2);
+    });
+  });
+
   it('executes all entries and returns results', async () => {
     const entries = [makeEntry('code', 1, 1), makeEntry('testing', 1, 2)];
     const results = await dispatchWorkers(entries, { executeWorker: mockExecute });

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
@@ -133,6 +133,15 @@ export interface WorkerDispatchOptions {
     entry: AgentPlanEntry,
     priorWaveResults?: readonly WorkerResult[]
   ) => Promise<WorkerResult>;
+  /**
+   * Optional AbortSignal for cooperative cancellation (#2188).
+   *
+   * Honored at two safe points: between waves (skips remaining waves) and
+   * before pulling the next task within a wave. In-flight workers are not
+   * forcibly killed — they finish their current task. Cancelled dispatches
+   * return whatever results accumulated up to the abort.
+   */
+  readonly signal?: AbortSignal;
 }
 
 // ============================================================================
@@ -313,18 +322,30 @@ export class RoleFailureTracker {
 // Concurrency-Limited Execution
 // ============================================================================
 
+/** Cooperative-cancellation predicate (#2188). Extracted for complexity budget. */
+function isCancelled(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 /**
  * Execute an array of async tasks with bounded concurrency.
+ *
+ * Honors an optional AbortSignal between tasks (#2188). In-flight workers
+ * are not forcibly killed — they finish their current task. Cancellation
+ * causes the remaining un-pulled tasks to be skipped and `results` to
+ * contain only what completed before the abort.
  */
 async function executeWithConcurrencyLimit<T>(
   tasks: ReadonlyArray<() => Promise<T>>,
-  limit: number
+  limit: number,
+  signal?: AbortSignal
 ): Promise<T[]> {
   const results: T[] = [];
   let nextIndex = 0;
 
   async function runNext(): Promise<void> {
     while (nextIndex < tasks.length) {
+      if (isCancelled(signal)) return;
       const currentIndex = nextIndex;
       nextIndex++;
       const task = tasks[currentIndex];
@@ -374,6 +395,8 @@ export async function dispatchWorkers(
   const staggerDelayMs = options.staggerDelayMs ?? DEFAULT_STAGGER_DELAY_MS;
 
   for (const [waveIdx, wave] of waves.entries()) {
+    if (isCancelled(options.signal)) break;
+
     const waveResults = await processWave(wave, waveIdx, waves.length, {
       bus,
       executionId: execId,
@@ -495,7 +518,11 @@ async function processWave(
     createWorkerTask(entry, taskIndex, waveNumber, opts)
   );
 
-  const waveResults = await executeWithConcurrencyLimit(tasks, opts.maxConcurrency);
+  const waveResults = await executeWithConcurrencyLimit(
+    tasks,
+    opts.maxConcurrency,
+    opts.options.signal
+  );
   for (const result of waveResults) {
     opts.failureTracker.record(result);
   }


### PR DESCRIPTION
## Summary

Closes [#2188](https://github.com/williamzujkowski/nexus-agents/issues/2188). Adds cooperative cancellation to `dispatchWorkers` via an optional `signal: AbortSignal` on `WorkerDispatchOptions`. Mirrors the recent #de0ae85d1 fix in the MCP worker layer — the aorchestra dispatcher had the same gap.

## Cancellation model

**Cooperative**, not preemptive — in-flight workers finish their current task. Two safe checkpoints:

1. **Between waves** (in `dispatchWorkers`): if the signal aborts during/after wave N, wave N+1 is skipped.
2. **Within a wave** (in `executeWithConcurrencyLimit`): if the signal aborts mid-wave, no more tasks are pulled. Currently-running tasks finish.

Cancelled dispatches return whatever results accumulated up to the abort.

## Tests

- 3 new TDD tests:
  - Pre-aborted signal returns empty results
  - Mid-flight abort between waves skips remaining waves
  - Omitting `signal` is a no-op (regression guard)
- All 54 existing tests pass unchanged

## Architectural note

The Architect's prior vote on #2188 said "concurrency lifecycle is an architecture decision, deserves its own focused design pass." This PR represents that focused design:

- **Cooperative model** chosen over preemptive (matches Promise/AbortSignal semantics; can't safely kill an in-flight async function in JS)
- **Safe-point checkpointing** chosen over per-task cancellation (clear semantics: a wave is atomic, between waves is a natural boundary)
- **Optional signal** chosen over required (zero-friction for callers who don't need cancellation)

## Test plan

- [x] 57 tests pass (54 existing + 3 new)
- [x] `pnpm exec eslint` clean (extracted `isCancelled` helper to stay within complexity-10)
- [x] `pnpm exec tsc --noEmit` clean (respects exactOptionalPropertyTypes)
- [x] `pnpm check:model-drift` exits 0 (4 entries, unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)