### PR TITLE
fix(cli): backup user config before --force overwrite (#2183)

### DIFF
--- a/packages/nexus-agents/src/cli/setup-config.test.ts
+++ b/packages/nexus-agents/src/cli/setup-config.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, existsSync, rmSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runConfigInitSync } from './setup-config.js';
@@ -58,5 +58,61 @@ describe('runConfigInitSync (#1252)', () => {
     expect(result.created).toBe(true);
     expect(result.message).toContain('Would create');
     expect(existsSync(join(testDir, 'nexus-agents.yaml'))).toBe(false);
+  });
+
+  // #2183 — silent data loss bug: --force replaced 100+ lines of customization
+  // with a 12-line template. Fix: write a backup before overwriting and surface
+  // the backup path in the result message.
+  describe('--force backup safety (#2183)', () => {
+    it('writes a timestamped backup before overwriting', () => {
+      const original = '# user customization\nsecurity:\n  blockedPatterns:\n    - .env*\n';
+      writeFileSync(join(testDir, 'nexus-agents.yaml'), original, 'utf-8');
+
+      const result = runConfigInitSync(testDir, true, false);
+
+      expect(result.success).toBe(true);
+      expect(result.created).toBe(true);
+      // Backup exists alongside the new file
+      const entries = readdirSync(testDir);
+      const backup = entries.find(
+        (n) => n.startsWith('nexus-agents.yaml.bak.') && !n.endsWith('.tmp')
+      );
+      expect(backup).toBeDefined();
+      // Backup contents match the original file byte-for-byte
+      if (backup !== undefined) {
+        expect(readFileSync(join(testDir, backup), 'utf-8')).toBe(original);
+      }
+    });
+
+    it('surfaces the backup path in the result message', () => {
+      writeFileSync(join(testDir, 'nexus-agents.yaml'), 'existing: true', 'utf-8');
+
+      const result = runConfigInitSync(testDir, true, false);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toMatch(/backup.*nexus-agents\.yaml\.bak/);
+    });
+
+    it('does NOT create a backup when no existing file is present', () => {
+      const result = runConfigInitSync(testDir, true, false);
+
+      expect(result.success).toBe(true);
+      const entries = readdirSync(testDir);
+      const backupCount = entries.filter((n) => n.startsWith('nexus-agents.yaml.bak.')).length;
+      expect(backupCount).toBe(0);
+    });
+
+    it('does NOT create a backup in dry-run mode even with --force + existing file', () => {
+      writeFileSync(join(testDir, 'nexus-agents.yaml'), 'existing: true', 'utf-8');
+
+      const result = runConfigInitSync(testDir, true, true);
+
+      expect(result.success).toBe(true);
+      // No new files written; original remains intact, no backup created
+      expect(readFileSync(join(testDir, 'nexus-agents.yaml'), 'utf-8')).toBe('existing: true');
+      const entries = readdirSync(testDir);
+      const backupCount = entries.filter((n) => n.startsWith('nexus-agents.yaml.bak.')).length;
+      expect(backupCount).toBe(0);
+    });
   });
 });

--- a/packages/nexus-agents/src/cli/setup-config.ts
+++ b/packages/nexus-agents/src/cli/setup-config.ts
@@ -8,7 +8,7 @@
  * (Source: Issue #1252 - Setup auto-generates nexus-agents.yaml)
  */
 
-import { existsSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getErrorMessage } from '../core/index.js';
 
@@ -75,20 +75,50 @@ export function runConfigInitSync(
     };
   }
 
+  const backup = ensureBackup(outputPath);
+  if ('error' in backup) return backup.error;
+
   try {
     writeFileSync(outputPath, SETUP_CONFIG_TEMPLATE, 'utf-8');
-    return {
-      success: true,
-      path: outputPath,
-      created: true,
-      message: `Created: ${outputPath}`,
-    };
+    const message =
+      backup.path !== undefined
+        ? `Created: ${outputPath} (backup saved at ${backup.path})`
+        : `Created: ${outputPath}`;
+    return { success: true, path: outputPath, created: true, message };
   } catch (error: unknown) {
     return {
       success: false,
       path: outputPath,
       created: false,
       message: `Failed: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Saves a timestamped backup of an existing config file before overwrite (#2183).
+ *
+ * Returns `{ path }` with the backup path (or undefined if no existing file)
+ * on success, or `{ error }` with a populated `ConfigStepResult` on failure.
+ * Failure to write the backup aborts the overwrite — better to keep the
+ * user's customizations intact than to lose them silently.
+ */
+function ensureBackup(
+  outputPath: string
+): { path: string | undefined } | { error: ConfigStepResult } {
+  if (!existsSync(outputPath)) return { path: undefined };
+  const backupPath = `${outputPath}.bak.${String(Date.now())}`;
+  try {
+    copyFileSync(outputPath, backupPath);
+    return { path: backupPath };
+  } catch (err: unknown) {
+    return {
+      error: {
+        success: false,
+        path: outputPath,
+        created: false,
+        message: `Failed to back up existing config: ${getErrorMessage(err)}`,
+      },
     };
   }
 }


### PR DESCRIPTION
## Summary

Closes [#2183](https://github.com/williamzujkowski/nexus-agents/issues/2183) — silent data loss in `nexus-agents setup --scope=project --force`.

## Bug

`setup --force` over an existing user-customized `nexus-agents.yaml` (100+ lines from `config init` plus user-added `security.blockedPatterns`, `logging.destination`, etc.) **silently** replaced everything with a 12-line minimal template. No warning, no backup, no recovery path unless the file was version-controlled.

## Fix

Write a timestamped backup (`nexus-agents.yaml.bak.<ms-epoch>`) before overwriting, and surface the backup path in the result message. If the backup write itself fails, abort the overwrite — keeping the user's customizations intact is more important than forcing the new template.

## Behavior change

- `--force` still overwrites (preserves the documented contract)
- But it no longer destroys user data — the backup gives a one-step recovery via `cp`
- Result message now includes the backup path: `Created: <path> (backup saved at <path>.bak.<timestamp>)`

## Test plan

- [x] 4 new TDD tests (red→green verified):
  - Backup created when existing file is present
  - Result message references the backup
  - No backup created when no existing file (fresh dir)
  - No backup created in dry-run mode (no fs writes)
- [x] All 8 setup-config tests pass (4 existing + 4 new)
- [x] `pnpm exec eslint` clean (extracted `ensureBackup` helper to fit complexity budget)
- [x] `pnpm exec tsc --noEmit` clean

## Future work (out of scope for this PR)

The deeper fix would be a structural merge: parse both YAMLs, write only keys not already present in the user's file. That requires deciding the merge semantics (additive? union?) and handling Zod schema conflicts. Filed for later if the simple backup proves insufficient. For now: backup + clear message gives users an unambiguous recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)