### PR TITLE
docs: sync README + JSDoc + CONFIGURATION.md after recent PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 | **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                         |
 | **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                                                                 |
 | **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                                                            |
-| **30 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                              |
+| **31 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                              |
 
 ---
 

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -192,12 +192,16 @@ All configuration can be overridden with environment variables:
 
 ### Model Provider Keys
 
-| Variable            | Description                                           |
-| ------------------- | ----------------------------------------------------- |
-| `ANTHROPIC_API_KEY` | Claude API key                                        |
-| `OPENAI_API_KEY`    | OpenAI API key                                        |
-| `GOOGLE_AI_API_KEY` | Google AI (Gemini) API key                            |
-| `OLLAMA_HOST`       | Ollama server URL (default: `http://localhost:11434`) |
+| Variable                    | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`         | Claude API key                                                 |
+| `OPENAI_API_KEY`            | OpenAI API key                                                 |
+| `GOOGLE_AI_API_KEY`         | Google AI (Gemini) API key                                     |
+| `OPENROUTER_API_KEY`        | OpenRouter API key (for free-model adapters)                   |
+| `OLLAMA_HOST`               | Ollama server URL (default: `http://localhost:11434`)          |
+| `NEXUS_CUSTOM_API_BASE_URL` | Custom OpenAI-compatible gateway base URL                      |
+| `NEXUS_CUSTOM_API_KEY`      | API key for the custom gateway                                 |
+| `NEXUS_CUSTOM_MODEL`        | Model id for the custom gateway (default: `gpt-4o`, see #2208) |
 
 ### Routing Variables
 
@@ -209,12 +213,13 @@ All configuration can be overridden with environment variables:
 
 ### Security Variables
 
-| Variable             | Description         | Default  |
-| -------------------- | ------------------- | -------- |
-| `NEXUS_SANDBOX_MODE` | Sandbox mode        | `policy` |
-| `NEXUS_RATE_LIMIT`   | Requests per minute | `60`     |
-| `NEXUS_AUTH_ENABLED` | Enable MCP auth     | `true`   |
-| `NEXUS_AUTH_METHOD`  | Auth method         | `token`  |
+| Variable               | Description                                                           | Default  |
+| ---------------------- | --------------------------------------------------------------------- | -------- |
+| `NEXUS_SANDBOX_MODE`   | Sandbox mode                                                          | `policy` |
+| `NEXUS_RATE_LIMIT`     | Requests per minute                                                   | `60`     |
+| `NEXUS_AUTH_ENABLED`   | Enable MCP auth                                                       | `true`   |
+| `NEXUS_AUTH_METHOD`    | Auth method                                                           | `token`  |
+| `NEXUS_DRIFT_ADVISORY` | Model-string drift CI gate: `1`=advisory (warn), `0`=blocking (#2199) | `0`      |
 
 ### Orchestration Variables
 

--- a/packages/nexus-agents/src/index.ts
+++ b/packages/nexus-agents/src/index.ts
@@ -12,7 +12,7 @@
  * const result = await startStdioServer({ name: 'my-server', version: '1.0.0' });
  *
  * // Or use programmatically
- * const adapter = createClaudeAdapter({ model: 'claude-sonnet-4-20250514' });
+ * const adapter = createClaudeAdapter({ model: 'claude-sonnet-4' });
  * const orchestrator = new Orchestrator({ adapter });
  * ```
  *


### PR DESCRIPTION
## Summary

Three small documentation drifts surfaced by a scoped review pass:

1. **`README.md:129`** — table claimed "30 MCP Tools" while line 23 + the architecture diagram on line 53 both say 31 (matches `src/mcp/tools/index.ts`). Updated to 31 for self-consistency.

2. **`src/index.ts:15` JSDoc example** — used the May-2025 stale model string `'claude-sonnet-4-20250514'`. Switched to the stable alias `'claude-sonnet-4'`, which now resolves through the canonical registry (#2202 added `aliases[]`). The example survives future model bumps without code edits.

3. **`docs/getting-started/CONFIGURATION.md`** — missing entries for env vars added in recent PRs:
   - `NEXUS_DRIFT_ADVISORY` (#2210, model-string drift gate)
   - `NEXUS_CUSTOM_API_BASE_URL` / `NEXUS_CUSTOM_API_KEY` / `NEXUS_CUSTOM_MODEL` (#2208 centralized the default model but the env vars themselves weren't in the table)
   - `OPENROUTER_API_KEY` (referenced in `CLAUDE.md` but absent here)

## Code findings deliberately not bundled

The same review surfaced potential code issues that were verified as defense-in-depth gaps with no observable impact (e.g., `failure-detector.ts` NaN comparison fails closed safely; `forest-engine.ts` null is already handled at line 213 before any access; `cli-commands.ts` "silent unknown command" is unreachable because `isValidCommand` filters upstream and `main().catch()` wraps everything). Skipping per YAGNI.

## Test plan

- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm check:model-drift` exits 0 (allowlist unchanged at 4)
- [x] `pnpm vitest run` — no behavior changes, no test impact
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)