### PR TITLE
fix(mcp): emit audit event when tool handler throws (audit-trail gap)

### DIFF
--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
@@ -1373,5 +1373,53 @@ describe('SecureHandler', () => {
 
       expect(mockAuditLogger.logToolInvocation).not.toHaveBeenCalled();
     });
+
+    // Security review feedback: previously, when a tool handler THREW
+    // (vs returned isError:true), the catch block returned internalError
+    // but never emitted an audit. Auditors saw nothing — the tool
+    // appeared to never have run. Audit-trail gap (#2191 review fallout).
+    it('emits audit event with outcome=error when tool handler throws', async () => {
+      const handler: ToolHandler = () => {
+        throw new Error('boom');
+      };
+
+      const secureHandler = createSecureHandler(handler, {
+        toolName: 'throwing_tool',
+        logger: mockLogger,
+        auditLogger: mockAuditLogger,
+      });
+
+      const result = await secureHandler({});
+
+      // The caller still gets an internal-error response
+      expect(result.isError).toBe(true);
+      // The audit logger must have been called — auditor visibility.
+      expect(mockAuditLogger.logToolInvocation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: 'throwing_tool',
+          outcome: 'error',
+        })
+      );
+    });
+
+    it('emits audit event with outcome=error when tool returns rejected promise', async () => {
+      const handler: ToolHandler = () => Promise.reject(new Error('async boom'));
+
+      const secureHandler = createSecureHandler(handler, {
+        toolName: 'rejecting_tool',
+        logger: mockLogger,
+        auditLogger: mockAuditLogger,
+      });
+
+      const result = await secureHandler({});
+
+      expect(result.isError).toBe(true);
+      expect(mockAuditLogger.logToolInvocation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: 'rejecting_tool',
+          outcome: 'error',
+        })
+      );
+    });
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
@@ -265,6 +265,27 @@ function emitToolAudit(
   });
 }
 
+/**
+ * Emits an audit event when a tool handler throws (or returns a rejected
+ * Promise) — closes the audit-trail gap where unexpected exceptions left
+ * no auditor record (security-review fallout from #2191).
+ */
+function emitToolAuditException(
+  auditLogger: IAuditLogger,
+  toolName: string,
+  ctx: RequestContext,
+  durationMs: number
+): void {
+  const actor = actorFromContext(ctx);
+  auditLogger.logToolInvocation({
+    toolName,
+    outcome: 'error',
+    actor,
+    requestId: ctx.requestId,
+    durationMs,
+  });
+}
+
 /** Emits an audit event for a policy denial. */
 function emitPolicyAudit(
   auditLogger: IAuditLogger,
@@ -407,31 +428,54 @@ export function createSecureHandler(
     );
     if (preCheckError) return preCheckError;
 
-    const execStartTime = getTimeProvider().now();
-    try {
-      const result = await executeHandler(
-        handler,
-        sanitizedArgs,
-        { requestContext, logger: requestLogger },
-        requestLogger
-      );
-      sanitizeToolResult(result, requestLogger);
-      if (config.auditLogger) {
-        emitToolAudit(
-          config.auditLogger,
-          config.toolName,
-          requestContext,
-          result,
-          getTimeProvider().now() - execStartTime
-        );
-      }
-      return result;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      requestLogger.error('Tool execution failed', error instanceof Error ? error : undefined);
-      return internalError(message, requestContext.requestId);
-    }
+    return executeAndAudit(handler, sanitizedArgs, requestContext, requestLogger, config);
   };
+}
+
+/**
+ * Executes the wrapped handler with audit emission on both the success and
+ * exception paths. Extracted from `createSecureHandler` to keep that
+ * function within the 50-line budget.
+ */
+async function executeAndAudit(
+  handler: ToolHandler | ContextAwareHandler,
+  sanitizedArgs: unknown,
+  requestContext: RequestContext,
+  requestLogger: ILogger,
+  config: SecureHandlerConfig
+): Promise<ToolResult> {
+  const execStartTime = getTimeProvider().now();
+  try {
+    const result = await executeHandler(
+      handler,
+      sanitizedArgs,
+      { requestContext, logger: requestLogger },
+      requestLogger
+    );
+    sanitizeToolResult(result, requestLogger);
+    if (config.auditLogger) {
+      emitToolAudit(
+        config.auditLogger,
+        config.toolName,
+        requestContext,
+        result,
+        getTimeProvider().now() - execStartTime
+      );
+    }
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    requestLogger.error('Tool execution failed', error instanceof Error ? error : undefined);
+    if (config.auditLogger) {
+      emitToolAuditException(
+        config.auditLogger,
+        config.toolName,
+        requestContext,
+        getTimeProvider().now() - execStartTime
+      );
+    }
+    return internalError(message, requestContext.requestId);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the audit-trail gap surfaced during the security review of the same code path as #2191. When a tool handler **threw** (or returned a rejected Promise), `secure-handler.ts` caught the error, logged via `requestLogger.error()`, and returned `internalError()` — but **never called the auditLogger**. From the auditor's perspective, the tool invocation appeared to never have happened.

## The fix

The `AuditOutcome` enum (audit-types.ts:62-68) already has `'error'` specifically for "Unexpected error occurred." It was designed for this case but the catch block was missing the emit.

- New `emitToolAuditException` helper — calls `auditLogger.logToolInvocation` with `outcome: 'error'` and elapsed `durationMs`
- Catch block invokes it before returning `internalError`
- Extracted `executeAndAudit` helper to keep `createSecureHandler` within the 50-line function budget after adding the new path

## Test plan

- [x] **2 new TDD tests** (red→green verified):
  - Synchronous throw: `outcome: 'error'` audit emitted
  - Rejected Promise: `outcome: 'error'` audit emitted
- [x] **All 2772 MCP tests pass** unchanged
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Vote context

Security Engineer voted REJECT on the previous "stop the loop" proposal (4-2 approve, 33% reject) specifically citing this finding as unverified middleware risk. Verifying + fixing it removes that veto. The other middleware findings flagged in the same review (timeout-guard, request-context, tier-classifier) were either single-threaded JS non-issues or required real benchmarks/repros that didn't materialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)