### PR TITLE
docs(governance): add verification gate for code-review subagent findings (#2225)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,10 +288,24 @@ When you encounter a bug, incorrect behavior, or significant gap **outside the s
 - Tests that **assert wrong behavior** (testing the bug, not the fix)
 - Documentation that **directly contradicts** code behavior
 
+### Verify Before Filing — Mandatory Gate
+
+> **Background:** A 2026-04-25 audit found a 100% false-positive rate in second-pass code-review subagent findings (#2225). Each false positive cost ~5 minutes of triage. The pattern: agents flagged `cli-handlers.ts:107 missing bounds check` but the bounds check existed at line 108 — the agent didn't read the next line. The same pattern across O(n²) claims (missed a `.slice(0, 20)` cap), TOCTOU claims (no `await` between check + write), Map mutation claims (sequential get-then-set, no concurrent iteration).
+
+Before filing ANY discovered issue, complete this verification checklist:
+
+1. **Re-read the cited line PLUS at least 5 lines before and 5 lines after.** Most false positives die here — the next line had the guard, or the previous line had the validation, or the loop had a slice cap.
+2. **Trace the call path.** Is the flagged code reachable from a real entry point? Or does upstream validation (`isValidCommand`, schema parsing, etc.) filter the input before it gets here?
+3. **Identify the observable failure.** What test would assert the bug? "Wrong return value", "leaked listener", "raised exception" — concrete. If you can't name a failing assertion, the finding is not load-bearing.
+4. **Rule out language-level non-issues.** JS is single-threaded — "race conditions" require `await` between read and write. Maps are safe to mutate during iteration per ECMA-262. `NaN` comparisons fail closed silently.
+
+If any of (1)–(4) raises a "wait, actually..." moment, **drop the finding**. Don't file it; don't even mention it in the report. False positives compound: they pollute the backlog, they train future agents on noise, they erode trust in the review tooling.
+
 ### When NOT to Create a Public Issue
 
 - Style preferences or subjective improvements
 - "Could be better" observations without concrete impact
+- **Defense-in-depth gaps with no observable wrong behavior** — e.g. "this could be safer" without a reachable failure mode
 - **Security vulnerabilities** — use the [Security Discovery Protocol](#security-discovery-protocol) instead
 - Anything you're not confident about — when in doubt, skip it
 
@@ -318,9 +332,15 @@ Types: `bug:`, `tech-debt:`, `docs:`, `test:`, `perf:`, `research:`
 
 ### Subagent Discovery Protocol
 
-Subagent prompts should include: _"If you discover bugs or issues outside your task scope, include a `## Discoveries` section at the end of your response with: file path, line number, one-sentence description, and severity."_
+Subagent prompts should include: _"If you discover bugs or issues outside your task scope, include a `## Discoveries` section at the end of your response with: file path, line number, one-sentence description, severity, AND the verification gate output: which of the (1)–(4) checks above did this finding pass? If you can't name them concretely, the finding is not ready to file."_
 
-The parent agent MUST process subagent `## Discoveries` sections: deduplicate against open issues, then create issues for confirmed findings.
+The parent agent MUST process subagent `## Discoveries` sections:
+
+1. **Re-verify each finding before filing** — do NOT just trust the subagent's confidence. Open the cited file, read the line + surroundings, trace the call path. The 2026-04-25 audit (#2225) found subagents had a 100% false-positive rate on second-pass findings — every one disqualified by reading 5 more lines or noticing a slice cap. Trust but verify.
+2. **Deduplicate** against open issues (`gh issue list --search "..."`).
+3. **Create issues only for findings that survive verification.** Each filed issue must include the specific failure mode in its body (a sentence that says "the failing test would assert X").
+
+If a subagent surfaces N findings and 0 survive verification, that's a useful signal — note it as a meta-observation but don't file noise issues. The cost-benefit of a false positive is asymmetric: 30s to file, 5min to triage, indefinite backlog noise.
 
 ### Security Discovery Protocol
 

--- a/scripts/review-pr-prompt.ts
+++ b/scripts/review-pr-prompt.ts
@@ -1,0 +1,38 @@
+/**
+ * Prompt template for CLI-based PR review (#182).
+ *
+ * Extracted from review-pr.ts to keep that file within the max-lines budget
+ * after expanding the verification gate (#2225).
+ *
+ * @module scripts/review-pr-prompt
+ */
+
+export const REVIEW_PROMPT = `You are reviewing a pull request for the nexus-agents project.
+
+REVIEW FOCUS:
+1. Security: No secrets, input validation, path traversal prevention, no user-provided RegExp
+2. Code Quality: TypeScript best practices, Result<T,E> pattern, function ≤50 lines, file ≤400 lines
+3. Testing: Adequate coverage, edge cases, error paths
+4. Architecture: Clear boundaries, interfaces before implementations
+5. Documentation: Accurate, no marketing fluff, working examples
+
+VERIFICATION GATE — REQUIRED for every finding (#2225). Drop the finding if any check fails:
+1. Read line + 5 above + 5 below — most "missing X" claims die here (X exists on next line)
+2. Reachable? Or filtered by upstream validation / Zod / guards?
+3. Name the OBSERVABLE failure (wrong return, leaked resource, raised exception). Can't write the asserting test → drop it.
+4. JS non-issues: no race without await between read/write (single-threaded); Maps are safe during iteration (ECMA-262); NaN fails closed; \`as\` casts are safe with downstream typeof guards.
+
+False positives cost ~5min triage each and erode trust. Lean toward fewer, higher-confidence findings.
+
+OUTPUT FORMAT:
+Start with DECISION: APPROVE, REQUEST_CHANGES, or COMMENT
+
+Then list findings as:
+- [SEVERITY] Category: Description (file:line if applicable). Verified-via: <which gate items (1)-(4) you applied>.
+
+Severities: CRITICAL, HIGH, MEDIUM, LOW, INFO
+
+End with a brief summary.
+
+PR DIFF:
+`;

--- a/scripts/review-pr.ts
+++ b/scripts/review-pr.ts
@@ -15,11 +15,18 @@
 /* eslint-disable no-console */
 // Console output is intentional for CLI user feedback
 
-import { execSync, execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import {
+  execSync,
+  execFileSync,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+import { REVIEW_PROMPT } from './review-pr-prompt.js';
 
 // Types
 interface ReviewOptions {
@@ -53,27 +60,6 @@ interface PRInfo {
 }
 
 // Constants
-const REVIEW_PROMPT = `You are reviewing a pull request for the nexus-agents project.
-
-REVIEW FOCUS:
-1. Security: No secrets, input validation, path traversal prevention, no user-provided RegExp
-2. Code Quality: TypeScript best practices, Result<T,E> pattern, function ≤50 lines, file ≤400 lines
-3. Testing: Adequate coverage, edge cases, error paths
-4. Architecture: Clear boundaries, interfaces before implementations
-5. Documentation: Accurate, no marketing fluff, working examples
-
-OUTPUT FORMAT:
-Start with DECISION: APPROVE, REQUEST_CHANGES, or COMMENT
-
-Then list findings as:
-- [SEVERITY] Category: Description (file:line if applicable)
-
-Severities: CRITICAL, HIGH, MEDIUM, LOW, INFO
-
-End with a brief summary.
-
-PR DIFF:
-`;
 
 const MODEL_COMMANDS: Record<string, { cmd: string; args: string[] }> = {
   claude: { cmd: 'claude', args: ['-p', '--output-format', 'text'] },

--- a/skills/reviewing-code/SKILL.md
+++ b/skills/reviewing-code/SKILL.md
@@ -54,6 +54,35 @@ pnpm lint && pnpm typecheck && pnpm test
 pnpm test:coverage
 ```
 
+## Verification Gate — MANDATORY for every finding
+
+> A 2026-04-25 audit (#2225) found a 100% false-positive rate in
+> second-pass code-review findings. Each false positive cost ~5min of
+> triage. The fix is a stricter pre-file gate.
+
+Before flagging any finding, run this checklist:
+
+1. **Read the cited line + 5 lines before + 5 lines after.** Most false
+   positives die here — "missing bounds check" turns out to be at the
+   next line; "O(n²) loop" has a `.slice(0, 20)` cap on the line above.
+2. **Trace the call path.** Is the flagged code reachable in practice?
+   Or does upstream validation (e.g. `isValidCommand`, Zod schema)
+   already filter the input?
+3. **Name the observable failure.** What test would assert the bug?
+   "Wrong return value", "leaked resource", "raised exception" — be
+   concrete. If you can't, the finding is not load-bearing.
+4. **Rule out JS non-issues:**
+   - **No "race condition" without `await` between read and write** —
+     JS is single-threaded; sync code is atomic at microtask level
+   - Maps support set/delete during iteration per ECMA-262
+   - `NaN` comparisons fail closed silently (no observable bad state)
+   - `as Record<string, unknown>` is safe IF every access has `typeof`
+     guards — read the whole function before flagging the cast
+
+If any check raises "wait, actually..." → **drop the finding**. Don't
+file, don't include in the report. False positives compound: pollute
+the backlog, train future agents on noise, erode trust in tooling.
+
 ## Review Output
 
 ```markdown


### PR DESCRIPTION
## Summary

Closes #2225. Process work surfaced by the 2026-04-25 audit: **6/6 second-pass code-review subagent findings were false positives** (#2219–#2224, all closed as not-bugs on careful re-read). Each one cost ~5 minutes of triage. The pattern was consistent: agents flagged \"missing X\" but X existed on the next line, claimed \"O(n²)\" but missed the slice cap, alleged \"race conditions\" in fully-synchronous code.

## What changed (3 layers)

### 1. `CLAUDE.md` (governance)
- New **\"Verify Before Filing — Mandatory Gate\"** subsection with a 4-point checklist (read line ±5; trace reachability; name the observable failure; rule out JS non-issues).
- Updated **Subagent Discovery Protocol** so the parent agent re-verifies each finding before filing — explicit \"trust but verify\" rule with the lesson from #2225.
- Added \"Defense-in-depth gaps with no observable wrong behavior\" to the When-NOT-to-File list.

### 2. `skills/reviewing-code/SKILL.md`
- Mirrors the 4-point gate.
- Documents the JS non-issues that have been the most common false-positive pattern (sync atomicity, ECMA-262 Map iteration safety, NaN fail-closed, `as` casts safe with downstream typeof guards).

### 3. `scripts/review-pr.ts` + new `scripts/review-pr-prompt.ts`
- `REVIEW_PROMPT` now includes the verification gate and requires each finding to declare `Verified-via: <which gate items (1)-(4) you applied>`.
- Prompt extracted to a separate file because review-pr.ts would have exceeded `max-lines: 400` after the expansion.

## Why this matters

False positives compound:
- **Filing cost:** ~30s per issue
- **Triage cost:** ~5min per issue (read code, verify, write closure rationale)
- **Backlog noise:** dilutes signal for real bugs
- **Trust erosion:** future agents are \"taught\" by the issue tracker that low-confidence findings are acceptable

For a 6-finding session that produced 0 valid findings, that's ~40 minutes of cost with zero shipped value. The next session that uses these stricter prompts should produce materially fewer false positives.

## Test plan

- [x] `pnpm exec eslint` clean (extracted prompt to keep review-pr.ts under 400 lines)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm governance:check` passes
- [x] `pnpm check:model-drift` clean
- [x] `pnpm vitest run scripts/check-model-string-drift.test.ts` passes
- [ ] CI green
- [ ] Future session validates the gate empirically (the real test — a follow-up code review using these prompts should produce fewer false positives)

## Not changed

- The `Agent` tool's `Explore` subagent type is built into Claude Code, not defined in this repo. The session-level instruction to those agents (when I spawn them) is governed by my orchestration prompt in CLAUDE.md, which IS updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)