### PR TITLE
feat(consensus): add scope_steward role for build-vs-buy gating (#2185)

### DIFF
--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -184,9 +184,14 @@ function recordVoteToGitHub(issueNumber: number, result: VotingResult): void {
 async function runVote(options: VoteCommandOptions): Promise<VotingResult> {
   const threshold = THRESHOLD_MAP[options.threshold ?? 'supermajority'] ?? 'supermajority';
   const useQuick = options.quick === true;
+  // Default panel expanded to 7 roles 2026-04-25 — added scope_steward to
+  // catch build-vs-buy blind spots that the 6-role panel demonstrably missed
+  // in the aegis-boot case (#2185). Supermajority threshold is 5/7 ≈ 71%.
+  // QuickMode panel substitutes scope_steward for pm: design + threat model +
+  // existence-justification cover the highest-impact failure modes for fast triage.
   const roles: readonly VoterRole[] = useQuick
-    ? ['architect', 'security', 'pm']
-    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
+    ? ['architect', 'security', 'scope_steward']
+    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish', 'scope_steward'];
   const start = getTimeProvider().now();
 
   // Validate and constrain timeout to allowed range (Issue #607)

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -26,8 +26,21 @@ export interface VoteCommandOptions {
 
 /**
  * Voter agent role definitions.
+ *
+ * `scope_steward` (#2185) was added 2026-04-25 to address a build-vs-buy
+ * blind spot in the original 6-role panel: the panel approved a proposal
+ * to build a USB-flasher CLI without flagging that Rufus already solves
+ * the problem. The scope-steward role explicitly checks for existing tools
+ * + biases toward "don't build."
  */
-export type VoterRole = 'architect' | 'security' | 'devex' | 'ai_ml' | 'pm' | 'catfish';
+export type VoterRole =
+  | 'architect'
+  | 'security'
+  | 'devex'
+  | 'ai_ml'
+  | 'pm'
+  | 'catfish'
+  | 'scope_steward';
 
 /**
  * Maps threshold names to consensus algorithms.
@@ -50,6 +63,8 @@ export const VOTER_ROLES: Record<VoterRole, string> = {
   pm: 'Product Manager - evaluates business value, user impact, and resource allocation',
   catfish:
     'Contrarian Analyst - deliberately challenges proposals to prevent agreement bias (arXiv:2505.21503)',
+  scope_steward:
+    'Scope Steward - asks whether to build at all; checks existing tools, biases toward kill-the-feature (#2185)',
 };
 
 /**

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -138,6 +138,7 @@ const ROLE_VOTE_DISTRIBUTIONS: Record<VoterRole, [number, number, number]> = {
   ai_ml: [55, 30, 15], // Technical focus
   pm: [55, 25, 20], // Business focus - generally supportive
   catfish: [20, 65, 15], // Deliberately contrarian - challenges proposals (arXiv:2505.21503)
+  scope_steward: [25, 60, 15], // Default-bias toward not shipping (#2185)
 };
 
 /**

--- a/packages/nexus-agents/src/cli/voter-prompts.test.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.test.ts
@@ -12,7 +12,15 @@ import type { VoterRole } from './vote-types.js';
 
 describe('voter-prompts', () => {
   describe('VOTER_SYSTEM_PROMPTS', () => {
-    const allRoles: VoterRole[] = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
+    const allRoles: VoterRole[] = [
+      'architect',
+      'security',
+      'devex',
+      'ai_ml',
+      'pm',
+      'catfish',
+      'scope_steward',
+    ];
 
     it('should define prompts for all voter roles', () => {
       expect(Object.keys(VOTER_SYSTEM_PROMPTS).sort()).toEqual(allRoles.sort());
@@ -150,6 +158,49 @@ describe('voter-prompts', () => {
       });
     });
 
+    describe('scope_steward prompt (#2185)', () => {
+      const prompt = VOTER_SYSTEM_PROMPTS.scope_steward;
+
+      it('defines the role as gating against build-vs-buy mistakes', () => {
+        expect(prompt).toContain('Scope Steward');
+        expect(prompt).toContain('build-when-buy-would-do');
+      });
+
+      it('cites the originating aegis-boot incident', () => {
+        expect(prompt).toContain('Rufus');
+        expect(prompt).toContain('USB flasher');
+      });
+
+      it('includes all 5 mandatory checks', () => {
+        expect(prompt).toContain('Existing-tool check');
+        expect(prompt).toContain('Build-vs-buy math');
+        expect(prompt).toContain('Mission alignment');
+        expect(prompt).toContain('Kill-the-feature option');
+        expect(prompt).toContain('Sprawl audit');
+      });
+
+      it('biases default toward not shipping', () => {
+        expect(prompt).toContain('Default bias: REJECT');
+        expect(prompt).toContain('this should not be built');
+      });
+
+      it('includes the few-shot Rufus rejection example', () => {
+        // Locks in the concrete pattern the role must learn from.
+        expect(prompt).toContain("REJECT (DON'T-BUILD)");
+        expect(prompt).toContain('100M+ installs');
+      });
+
+      it('still permits approval when build-vs-buy math justifies it', () => {
+        expect(prompt).toContain('You CAN approve');
+      });
+
+      it('classifies rejections with appropriate categories', () => {
+        expect(prompt).toContain('SCOPE_CREEP');
+        expect(prompt).toContain('YAGNI');
+        expect(prompt).toContain('OVER_ENGINEERING');
+      });
+    });
+
     describe('catfish prompt', () => {
       const prompt = VOTER_SYSTEM_PROMPTS.catfish;
 
@@ -239,7 +290,15 @@ describe('voter-prompts', () => {
   });
 
   describe('SIMULATED_VOTE_REASONING', () => {
-    const allRoles: VoterRole[] = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
+    const allRoles: VoterRole[] = [
+      'architect',
+      'security',
+      'devex',
+      'ai_ml',
+      'pm',
+      'catfish',
+      'scope_steward',
+    ];
 
     it('should define reasoning for all voter roles', () => {
       expect(Object.keys(SIMULATED_VOTE_REASONING).sort()).toEqual(allRoles.sort());

--- a/packages/nexus-agents/src/cli/voter-prompts.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.ts
@@ -138,6 +138,73 @@ But your default posture is skeptical — look for what others might miss.
 High-confidence rejections with specific reasoning are your most valuable output.`;
 }
 
+/**
+ * Build the scope_steward role prompt (#2185).
+ *
+ * Different axis from `pm` (which prioritizes WHICH features to build) and
+ * `catfish` (which doubts the framing). The steward asks: should we build
+ * this AT ALL? Existing tools usually win; default bias is "don't ship."
+ */
+function scopeStewardPrompt(project: string): string {
+  return `You are a Scope Steward voting on proposals for the ${project} project.
+
+Your job is to gate against build-when-buy-would-do and feature sprawl.
+The originating case (2026-04-24): a 6-role panel approved building a USB flasher
+CLI without anyone flagging that Rufus already solves the problem better, for the
+same audience, with 100M+ installs of battle-tested code. This role exists to
+catch that class of mistake.
+
+Your evaluation criteria — work through these mandatory checks in your reasoning:
+
+1. **Existing-tool check.** Search your knowledge for tools, libraries, or
+   services that already solve the stated problem. Name them concretely
+   (not "there might be alternatives" — actual names: Rufus, ripgrep,
+   esbuild, etc.). If you can't name an alternative, say so explicitly.
+
+2. **Build-vs-buy math.** For each existing tool you named: what would we
+   LOSE by adopting it (license, dependency surface, integration cost)?
+   What would we GAIN by building our own (tighter integration, no extra
+   binary, etc.)? Default lean: BUY. Building is justified only when the
+   loss column is concrete and the gain column is load-bearing.
+
+3. **Mission alignment.** Does this proposal serve the project's stated
+   mission, or is it scope drift? If drift, name the drift specifically.
+
+4. **Kill-the-feature option.** For every proposal, explicitly evaluate
+   "what if we just didn't do this?" as a ranked option. Many proposals
+   don't need to be built. Make the no-build case before the build case.
+
+5. **Sprawl audit.** Check whether similar functionality already exists
+   in the codebase. If it does, recommend extending — not forking. The
+   anti-sprawl policy in CLAUDE.md is specifically the rule this role
+   enforces.
+
+Default bias: REJECT proposals where an existing tool fits, even if our
+own implementation would be marginally nicer. Only approve when the
+existing-tool check fails AND the kill-the-feature option is worse AND
+mission alignment is clear AND no comparable in-codebase functionality
+exists.
+
+Few-shot example of a textbook rejection:
+> Proposal: "Add an aegis-boot subcommand to flash bootable USB sticks."
+> Steward response: "REJECT (DON'T-BUILD). Rufus has solved this for the
+> same audience for 10+ years with 100M+ installs and battle-tested code.
+> Adopting Rufus loses nothing material; building our own loses
+> maintenance bandwidth indefinitely. Mission alignment: aegis-boot's
+> mission is verifiable boot, not USB tooling. Kill option clearly wins.
+> No prior in-codebase functionality. Recommend: point users at Rufus in
+> the docs and stop here."
+
+${voterFooter()}
+
+When rejecting, you MUST classify reasons (YAGNI, DRY_VIOLATION,
+OVER_ENGINEERING, SCOPE_CREEP, MISALIGNED). The steward's most common
+categories are SCOPE_CREEP, YAGNI, and OVER_ENGINEERING.
+
+You CAN approve. But your default posture is: "this should not be built;
+prove me wrong with the build-vs-buy math."`;
+}
+
 export function getVoterPrompts(project: string = DEFAULT_PROJECT): Record<VoterRole, string> {
   return {
     architect: architectPrompt(project),
@@ -146,6 +213,7 @@ export function getVoterPrompts(project: string = DEFAULT_PROJECT): Record<Voter
     ai_ml: aiMlPrompt(project),
     pm: pmPrompt(project),
     catfish: catfishPrompt(project),
+    scope_steward: scopeStewardPrompt(project),
   };
 }
 
@@ -156,6 +224,9 @@ export const VOTER_SYSTEM_PROMPTS: Record<VoterRole, string> = getVoterPrompts()
 
 /**
  * Base reasoning templates for simulated votes.
+ *
+ * scope_steward simulated reasoning intentionally reflects the role's
+ * bias-toward-not-shipping posture (PM vote condition on #2185).
  */
 export const SIMULATED_VOTE_REASONING: Record<VoterRole, string> = {
   architect: 'Evaluated technical design and architecture implications.',
@@ -164,4 +235,6 @@ export const SIMULATED_VOTE_REASONING: Record<VoterRole, string> = {
   ai_ml: 'Analyzed AI/ML capabilities and learning potential.',
   pm: 'Evaluated business value and resource requirements.',
   catfish: 'Challenged proposal assumptions and identified potential risks.',
+  scope_steward:
+    'Checked existing tools, build-vs-buy math, kill-the-feature option; bias toward not shipping.',
 };

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -455,38 +455,56 @@ describe('Threshold mapping', () => {
 });
 
 describe('Voter roles', () => {
-  it('should use 6 roles in normal mode', () => {
-    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
-    expect(normalRoles).toHaveLength(6);
+  // Default panel expanded to 7 roles 2026-04-25 (#2185) — added scope_steward
+  // to catch build-vs-buy blind spots. QuickMode swaps pm for scope_steward.
+  it('should use 7 roles in normal mode', () => {
+    const normalRoles = [
+      'architect',
+      'security',
+      'devex',
+      'ai_ml',
+      'pm',
+      'catfish',
+      'scope_steward',
+    ];
+    expect(normalRoles).toHaveLength(7);
   });
 
   it('should use 3 roles in quick mode', () => {
-    const quickRoles = ['architect', 'security', 'pm'];
+    const quickRoles = ['architect', 'security', 'scope_steward'];
     expect(quickRoles).toHaveLength(3);
   });
 
   it('should always include architect role', () => {
-    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm'];
-    const quickRoles = ['architect', 'security', 'pm'];
+    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'scope_steward'];
+    const quickRoles = ['architect', 'security', 'scope_steward'];
 
     expect(normalRoles).toContain('architect');
     expect(quickRoles).toContain('architect');
   });
 
   it('should always include security role', () => {
-    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm'];
-    const quickRoles = ['architect', 'security', 'pm'];
+    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'scope_steward'];
+    const quickRoles = ['architect', 'security', 'scope_steward'];
 
     expect(normalRoles).toContain('security');
     expect(quickRoles).toContain('security');
   });
 
-  it('should always include pm role', () => {
-    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm'];
-    const quickRoles = ['architect', 'security', 'pm'];
+  it('should always include scope_steward role (#2185)', () => {
+    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'scope_steward'];
+    const quickRoles = ['architect', 'security', 'scope_steward'];
+
+    expect(normalRoles).toContain('scope_steward');
+    expect(quickRoles).toContain('scope_steward');
+  });
+
+  it('keeps pm in normal mode but not quickMode (#2185)', () => {
+    const normalRoles = ['architect', 'security', 'devex', 'ai_ml', 'pm', 'scope_steward'];
+    const quickRoles = ['architect', 'security', 'scope_steward'];
 
     expect(normalRoles).toContain('pm');
-    expect(quickRoles).toContain('pm');
+    expect(quickRoles).not.toContain('pm');
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -101,9 +101,12 @@ function strategyToAlgorithm(strategy: VotingStrategy): ConsensusAlgorithm {
 }
 
 function getVoterRoles(quickMode: boolean): readonly VoterRole[] {
+  // Default panel expanded to 7 roles 2026-04-25 — scope_steward added to
+  // catch build-vs-buy blind spots (#2185). QuickMode substitutes
+  // scope_steward for pm so fast triage covers existence-justification.
   return quickMode
-    ? ['architect', 'security', 'pm']
-    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish'];
+    ? ['architect', 'security', 'scope_steward']
+    : ['architect', 'security', 'devex', 'ai_ml', 'pm', 'catfish', 'scope_steward'];
 }
 
 // --- Voting Execution ---
@@ -561,13 +564,13 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
     strategy: VotingStrategySchema.optional().describe(
       'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order'
     ),
-    quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 6'),
+    quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 7'),
     simulateVotes: z.boolean().optional().default(false).describe('Use simulated votes'),
   };
 
   const description =
     'Execute multi-model consensus voting on a proposal. ' +
-    'Uses 6 specialized agent roles (architect, security, devex, ai_ml, pm, catfish) ' +
+    'Uses 7 specialized agent roles (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
     'to vote on proposals with configurable strategies. ' +
     'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514).';
 


### PR DESCRIPTION
## Summary

Closes [#2185](https://github.com/williamzujkowski/nexus-agents/issues/2185). Adds a 7th voter role — `scope_steward` — whose entire job is to catch build-vs-buy mistakes the existing 6-role panel demonstrably misses.

## The triggering case

On 2026-04-24 the existing 6-role panel approved a proposal to build a USB-flasher CLI for the aegis-boot project. None of the 6 roles flagged that **Rufus already solves this exact problem better, for the exact audience, battle-tested on 100M+ installs**. The maintainer caught it on review.

That's a systematic gap: the existing roles all focus on "how to build well," not "whether to build at all."

## What scope_steward does

Five mandatory checks for every proposal:
1. **Existing-tool check** — name actual alternatives (Rufus, ripgrep, esbuild)
2. **Build-vs-buy math** — explicit lose/gain analysis per tool
3. **Mission alignment** — name any scope drift
4. **Kill-the-feature option** — rank "do nothing" first
5. **Sprawl audit** — extend not fork

Default bias: REJECT. Few-shot example in the prompt is the canonical Rufus rejection.

## Panel composition (per consensus vote)

- **Default panel: 6 → 7 roles.** Supermajority threshold: 5/7 (~71%, was 4/6 ~67%). Slight tightening is **intentional** — documented in commit so future maintainers don't "fix" it back.
- **quickMode panel: pm → scope_steward.** Now `architect + security + scope_steward` — covers design soundness + threat surface + existence-justification, the highest-impact failure modes for fast triage.

## Consensus vote

**4-1 supermajority approved** (80%, supermajority strategy). Architect, Security, AI/ML, PM voted approve. Contrarian rejected citing `pm × scope_steward` correlation that would bias the `higher_order` strategy. That's real — filed as follow-up [#2227](https://github.com/williamzujkowski/nexus-agents/issues/2227). Default strategy is supermajority, which doesn't use correlation weighting, so this PR is behavior-correct independent of #2227.

## Coexistence with catfish

Both push back, on different axes:
- **catfish:** "you might be wrong about the problem" (problem framing)
- **scope_steward:** "you shouldn't bother solving it" (existence justification)

Keep both.

## Test plan

- [x] 7 new TDD tests for scope_steward prompt: defines the role, cites the originating incident, includes all 5 checks, biases toward not-shipping, includes the few-shot Rufus rejection, permits approval, classifies rejection categories
- [x] Panel composition tests refreshed: 7 roles in normal mode, 3 in quickMode, scope_steward always included, pm in normal but not quick
- [x] Existing role consistency tests now include the 7th entry
- [x] **All 3262 tests in `cli/` + `consensus-vote.test.ts` pass**
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [ ] CI green

## Acceptance criteria from #2185

- [x] New role type in VoterRole union
- [x] System prompt explicitly frames the 5 checks
- [x] Few-shot example for the Rufus rejection case
- [x] Default panel 6 → 7 roles
- [x] quickMode panel includes scope_steward
- [x] Consensus-vote tests + docs updated
- [ ] Live regression test against the canned aegis-boot proposal — left as e2e/manual since simulated votes use static reasoning templates. Prompt content is asserted in unit tests as proof the role is told to recommend Rufus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)