### PR TITLE
fix(research): repair github + semantic_scholar source coverage (#2234)

### DIFF
--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -192,16 +192,17 @@ All configuration can be overridden with environment variables:
 
 ### Model Provider Keys
 
-| Variable                    | Description                                                    |
-| --------------------------- | -------------------------------------------------------------- |
-| `ANTHROPIC_API_KEY`         | Claude API key                                                 |
-| `OPENAI_API_KEY`            | OpenAI API key                                                 |
-| `GOOGLE_AI_API_KEY`         | Google AI (Gemini) API key                                     |
-| `OPENROUTER_API_KEY`        | OpenRouter API key (for free-model adapters)                   |
-| `OLLAMA_HOST`               | Ollama server URL (default: `http://localhost:11434`)          |
-| `NEXUS_CUSTOM_API_BASE_URL` | Custom OpenAI-compatible gateway base URL                      |
-| `NEXUS_CUSTOM_API_KEY`      | API key for the custom gateway                                 |
-| `NEXUS_CUSTOM_MODEL`        | Model id for the custom gateway (default: `gpt-4o`, see #2208) |
+| Variable                    | Description                                                                                                                                                                 |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`         | Claude API key                                                                                                                                                              |
+| `OPENAI_API_KEY`            | OpenAI API key                                                                                                                                                              |
+| `GOOGLE_AI_API_KEY`         | Google AI (Gemini) API key                                                                                                                                                  |
+| `OPENROUTER_API_KEY`        | OpenRouter API key (for free-model adapters)                                                                                                                                |
+| `OLLAMA_HOST`               | Ollama server URL (default: `http://localhost:11434`)                                                                                                                       |
+| `NEXUS_CUSTOM_API_BASE_URL` | Custom OpenAI-compatible gateway base URL                                                                                                                                   |
+| `NEXUS_CUSTOM_API_KEY`      | API key for the custom gateway                                                                                                                                              |
+| `NEXUS_CUSTOM_MODEL`        | Model id for the custom gateway (default: `gpt-4o`, see #2208)                                                                                                              |
+| `SEMANTIC_SCHOLAR_API_KEY`  | Optional. Lifts research_discover's semantic_scholar source past the unauthenticated 429 ceiling (#2234). Apply at https://www.semanticscholar.org/product/api#api-key-form |
 
 ### Routing Variables
 

--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.test.ts
@@ -69,11 +69,56 @@ describe('discoverSemanticScholar', () => {
     expect(calledUrl).not.toContain('sort=');
   });
 
-  it('should handle HTTP errors', async () => {
+  it('should surface 429 as RATE_LIMIT, not generic HTTP_ERROR (#2234)', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
     const result = await discoverSemanticScholar('test', 5);
     expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('RATE_LIMIT');
+  });
+
+  it('should handle non-429 HTTP errors as HTTP_ERROR', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    const result = await discoverSemanticScholar('test', 5);
+    expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('HTTP_ERROR');
+  });
+
+  it('should send x-api-key when SEMANTIC_SCHOLAR_API_KEY is set (#2234)', async () => {
+    const prev = process.env['SEMANTIC_SCHOLAR_API_KEY'];
+    process.env['SEMANTIC_SCHOLAR_API_KEY'] = 'test-key-abc';
+    try {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+      await discoverSemanticScholar('test', 5);
+      const calledOpts = mockFetch.mock.calls[0]?.[1] as { headers?: Record<string, string> };
+      expect(calledOpts?.headers?.['x-api-key']).toBe('test-key-abc');
+    } finally {
+      if (prev === undefined) {
+        delete process.env['SEMANTIC_SCHOLAR_API_KEY'];
+      } else {
+        process.env['SEMANTIC_SCHOLAR_API_KEY'] = prev;
+      }
+    }
+  });
+
+  it('should NOT send x-api-key when SEMANTIC_SCHOLAR_API_KEY is unset (#2234)', async () => {
+    const prev = process.env['SEMANTIC_SCHOLAR_API_KEY'];
+    delete process.env['SEMANTIC_SCHOLAR_API_KEY'];
+    try {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+      await discoverSemanticScholar('test', 5);
+      const calledOpts = mockFetch.mock.calls[0]?.[1] as { headers?: Record<string, string> };
+      expect(calledOpts?.headers?.['x-api-key']).toBeUndefined();
+    } finally {
+      if (prev !== undefined) {
+        process.env['SEMANTIC_SCHOLAR_API_KEY'] = prev;
+      }
+    }
   });
 
   it('should handle network errors', async () => {

--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
@@ -115,10 +115,22 @@ export async function discoverSemanticScholar(
   // Note: sort parameter only works on /paper/search/bulk, not /paper/search
   const url = `https://api.semanticscholar.org/graph/v1/paper/search?query=${query}&limit=${String(maxResults)}&fields=${fields}`;
 
+  // Unauthenticated requests are aggressively rate-limited (HTTP 429) by
+  // semantic_scholar, which surfaced as a 100% failure rate in #2234. Honor
+  // SEMANTIC_SCHOLAR_API_KEY when set so users can opt into the higher quota.
+  const headers: Record<string, string> = {
+    'User-Agent': 'nexus-agents',
+    Accept: 'application/json',
+  };
+  const apiKey = process.env['SEMANTIC_SCHOLAR_API_KEY'];
+  if (apiKey !== undefined && apiKey !== '') {
+    headers['x-api-key'] = apiKey;
+  }
+
   const fetchResult = await fetchSource({
     url,
     source: 'semantic_scholar',
-    headers: { 'User-Agent': 'nexus-agents', Accept: 'application/json' },
+    headers,
   });
   if (!fetchResult.ok) return fetchResult;
 

--- a/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
@@ -109,7 +109,7 @@ describe('discoverGitHubRepos', () => {
     if (!result.ok) expect(result.error.code).toBe('TIMEOUT');
   });
 
-  it('should use OR logic for language filters', async () => {
+  it('should not include language filter (#2234 — bare OR poisoned the search)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ items: [] }),
@@ -117,8 +117,24 @@ describe('discoverGitHubRepos', () => {
     await discoverGitHubRepos('agent orchestration', 5);
     const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
     const decoded = decodeURIComponent(calledUrl);
-    expect(decoded).toContain('language:python OR language:typescript');
-    expect(decoded).not.toContain('language:python language:typescript');
+    // Bare `OR` between qualifiers caused GitHub to interpret the query as a
+    // top-level disjunction and zero out matches when the topic had multiple
+    // distinguishing tokens. The fix drops the language filter entirely;
+    // downstream relevance scoring handles quality.
+    expect(decoded).not.toContain('language:python');
+    expect(decoded).not.toContain('language:typescript');
+    expect(decoded).toContain('agent orchestration');
+  });
+
+  it('should pass topic verbatim into the GitHub search query (#2234)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ items: [] }),
+    });
+    await discoverGitHubRepos('SWE-agent OpenHands autonomous coding agent', 5);
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const decoded = decodeURIComponent(calledUrl);
+    expect(decoded).toContain('SWE-agent OpenHands autonomous coding agent');
   });
 });
 
@@ -130,8 +146,20 @@ describe('fetchSource', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('should return HTTP_ERROR on non-ok response', async () => {
+  it('should return RATE_LIMIT on 429 with actionable message (#2234)', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
+    const result = await fetchSource({ url: 'https://example.com', source: 'semantic_scholar' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('RATE_LIMIT');
+      expect(result.error.source).toBe('semantic_scholar');
+      // Message must hint at the API-key escape hatch so users aren't stuck.
+      expect(result.error.message).toContain('SEMANTIC_SCHOLAR_API_KEY');
+    }
+  });
+
+  it('should return HTTP_ERROR on non-429 non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
     const result = await fetchSource({ url: 'https://example.com', source: 'test' });
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -21,7 +21,7 @@ import { resolveToken } from '../scm/token-resolver.js';
 const SOURCE_API_TIMEOUT_MS = 30_000;
 
 /** Error codes for source discovery. */
-export type DiscoverErrorCode = 'TIMEOUT' | 'NETWORK' | 'HTTP_ERROR' | 'PARSE_ERROR';
+export type DiscoverErrorCode = 'TIMEOUT' | 'NETWORK' | 'HTTP_ERROR' | 'PARSE_ERROR' | 'RATE_LIMIT';
 
 /** Structured error for discovery failures. */
 export interface DiscoverError {
@@ -99,9 +99,17 @@ export async function fetchSource(
     if (headers !== undefined) fetchInit.headers = headers;
     const response = await fetch(url, fetchInit);
     if (!response.ok) {
+      // Surface rate-limiting separately so callers can distinguish "your key
+      // is missing / quota exhausted" from "the API is broken" (#2234). The
+      // generic HTTP_ERROR message previously masked semantic_scholar's
+      // unauthenticated 429s as opaque failures.
+      const isRateLimit = response.status === 429;
+      const message = isRateLimit
+        ? `${source} rate-limited (HTTP 429) — set ${source.toUpperCase()}_API_KEY or retry later`
+        : `API returned ${String(response.status)}`;
       return {
         ok: false,
-        error: createError('HTTP_ERROR', source, `API returned ${String(response.status)}`),
+        error: createError(isRateLimit ? 'RATE_LIMIT' : 'HTTP_ERROR', source, message),
       };
     }
     return { ok: true, value: response };
@@ -151,7 +159,13 @@ export async function discoverGitHubRepos(
   topic: string,
   maxResults = 10
 ): Promise<Result<DiscoveredSource[], DiscoverError>> {
-  const query = encodeURIComponent(`${topic} language:python OR language:typescript`);
+  // GitHub's search API parses bare `OR` as a top-level operator, which
+  // splits the query into two unrelated clauses and zeroes out matches
+  // when the topic has multiple distinguishing tokens (#2234). Parenthesizing
+  // qualifiers does NOT work either. Best fix: drop the language filter and
+  // let the topic terms drive matching; downstream relevance scoring handles
+  // quality. Confirmed empirically against api.github.com.
+  const query = encodeURIComponent(topic);
   const url = `https://api.github.com/search/repositories?q=${query}&sort=stars&order=desc&per_page=${String(maxResults)}`;
 
   // Use SCM token-resolver for optional auth (Issue #1136)


### PR DESCRIPTION
## Summary

Two confirmed root causes for research_discover's source-coverage failures (verified live against the real APIs, not just code-reading):

### 1. GitHub — bare \`OR\` poisoned the search parser

The query was being constructed as \`\${topic} language:python OR language:typescript\`. GitHub's search API parses \`OR\` as a top-level disjunction, so any multi-token topic returned 0 hits.

| Query                                                                              | total_count |
| ---------------------------------------------------------------------------------- | ----------- |
| \`SWE-agent language:python\`                                                        | **359**     |
| \`SWE-agent OpenHands autonomous coding agent language:python OR language:typescript\` (the bug) | **0**       |
| \`SWE-agent OpenHands autonomous coding agent\` (the fix)                            | matches with relevance scoring |

Parenthesizing \`(language:python OR language:typescript)\` doesn't help — GitHub doesn't support that syntax for qualifiers either. The fix is to drop the language filter entirely and let the topic terms drive matching; downstream relevance scoring handles quality.

### 2. semantic_scholar — unauthenticated 429 on every call

Public API rate-limits unauthenticated requests aggressively, returning HTTP 429 on every call. The connector surfaced this as a generic \`HTTP_ERROR\`, so users couldn't tell "API is broken" from "you need a key."

Fix:
- Honor \`SEMANTIC_SCHOLAR_API_KEY\` env var (apply at https://www.semanticscholar.org/product/api#api-key-form)
- New \`RATE_LIMIT\` error code with an actionable message that names the env var

## Test plan

- [x] Unit tests updated/added (4 new, 2 updated). 65/65 pass.
- [x] Pin "no language filter in GitHub URL" + "topic passed verbatim"
- [x] Pin \`fetchSource\` 429 → \`RATE_LIMIT\`, non-429 → \`HTTP_ERROR\`
- [x] Pin \`semantic_scholar\` sends \`x-api-key\` when env set, NOT when unset
- [x] eslint clean
- [x] Verified empirically against api.github.com and api.semanticscholar.org with the failing queries from #2234
- [ ] CI green on PR

## Related

- Closes #2234
- Refs prior closed bugs #704 (\"GitHub and Semantic Scholar discovery sources return empty results\") and #1121 (\"research_discover 67% source failure rate\") — same failure surface, different root causes; this fix addresses what those didn't
- Unblocks the WebFetch workaround used by #2232 — \`research_discover\` should now work for the build-vs-buy audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)