### PR TITLE
test(consensus): pin scope_steward × pm correlation behavior (#2227)

### DIFF
--- a/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
@@ -424,6 +424,137 @@ describe('OWVoting', () => {
 
       expect(result.decision).toBe('no_consensus');
     });
+
+    // =========================================================================
+    // #2227: scope_steward × pm correlation regression
+    // -------------------------------------------------------------------------
+    // The 7-role panel (#2185) added scope_steward, which evaluates the same
+    // build-vs-buy / scope axis as pm. When the two co-vote, higher_order MUST
+    // down-weight the redundant signal — otherwise scope_steward + pm acting
+    // in lockstep effectively double-count the product perspective.
+    //
+    // CorrelationTracker is dynamic (no hardcoded fixture), so the empirical
+    // measurement accumulates as live votes accrue. These tests pin the
+    // BEHAVIOR: given a correlation observation, the strategy must respond
+    // correctly regardless of which roles are involved.
+    // =========================================================================
+    describe('#2227: scope_steward × pm correlation behavior', () => {
+      it('down-weights pm when scope_steward × pm correlation is high', () => {
+        // 7-role panel, scope_steward + pm both approve in lockstep with high
+        // correlation. Other roles split. Expectation: at least one of
+        // {pm, scope_steward} appears in downweightedAgents.
+        const votes = createVoteMap([
+          ['architect', 'approve'],
+          ['security', 'reject'],
+          ['devex', 'approve'],
+          ['ai_ml', 'reject'],
+          ['pm', 'approve'],
+          ['catfish', 'reject'],
+          ['scope_steward', 'approve'],
+        ]);
+        const correlationMatrix = createCorrelationMatrix([
+          ['scope_steward', 'pm', 0.9], // The correlated pair this test guards
+          // All other pairs near-independent so we isolate the signal.
+          ['architect', 'security', 0.1],
+          ['architect', 'devex', 0.1],
+          ['architect', 'pm', 0.1],
+          ['architect', 'scope_steward', 0.1],
+          ['security', 'pm', 0.1],
+          ['security', 'scope_steward', 0.1],
+          ['devex', 'pm', 0.1],
+          ['devex', 'scope_steward', 0.1],
+          ['catfish', 'pm', 0.1],
+          ['catfish', 'scope_steward', 0.1],
+          ['ai_ml', 'pm', 0.1],
+          ['ai_ml', 'scope_steward', 0.1],
+        ]);
+
+        const result = voting.aggregateWithCorrelation(votes, correlationMatrix);
+
+        const downweighted = new Set(result.downweightedAgents);
+        expect(downweighted.has('pm') || downweighted.has('scope_steward')).toBe(true);
+      });
+
+      it('does NOT down-weight pm when scope_steward × pm correlation is low', () => {
+        // Same vote pattern, but scope_steward and pm are independent. The
+        // strategy should treat their joint approval as two real signals.
+        const votes = createVoteMap([
+          ['architect', 'approve'],
+          ['security', 'reject'],
+          ['devex', 'approve'],
+          ['ai_ml', 'reject'],
+          ['pm', 'approve'],
+          ['catfish', 'reject'],
+          ['scope_steward', 'approve'],
+        ]);
+        const correlationMatrix = createCorrelationMatrix([
+          ['scope_steward', 'pm', 0.05], // INDEPENDENT
+          ['architect', 'security', 0.1],
+          ['architect', 'devex', 0.1],
+          ['architect', 'pm', 0.1],
+          ['architect', 'scope_steward', 0.1],
+          ['security', 'pm', 0.1],
+          ['security', 'scope_steward', 0.1],
+          ['devex', 'pm', 0.1],
+          ['devex', 'scope_steward', 0.1],
+          ['catfish', 'pm', 0.1],
+          ['catfish', 'scope_steward', 0.1],
+          ['ai_ml', 'pm', 0.1],
+          ['ai_ml', 'scope_steward', 0.1],
+        ]);
+
+        const result = voting.aggregateWithCorrelation(votes, correlationMatrix);
+
+        const downweighted = new Set(result.downweightedAgents);
+        expect(downweighted.has('pm')).toBe(false);
+        expect(downweighted.has('scope_steward')).toBe(false);
+      });
+
+      it('reports lower effectiveVoteCount when scope_steward × pm are correlated', () => {
+        // Direct comparison: same votes, only the scope_steward × pm
+        // correlation differs. The correlated case must produce a strictly
+        // smaller effectiveVoteCount.
+        const votes = createVoteMap([
+          ['architect', 'approve'],
+          ['security', 'approve'],
+          ['devex', 'approve'],
+          ['ai_ml', 'approve'],
+          ['pm', 'approve'],
+          ['catfish', 'approve'],
+          ['scope_steward', 'approve'],
+        ]);
+        const baseCorrelations: Array<[string, string, number]> = [
+          ['architect', 'security', 0.1],
+          ['architect', 'devex', 0.1],
+          ['architect', 'pm', 0.1],
+          ['architect', 'scope_steward', 0.1],
+          ['security', 'pm', 0.1],
+          ['security', 'scope_steward', 0.1],
+          ['devex', 'pm', 0.1],
+          ['devex', 'scope_steward', 0.1],
+          ['catfish', 'pm', 0.1],
+          ['catfish', 'scope_steward', 0.1],
+          ['ai_ml', 'pm', 0.1],
+          ['ai_ml', 'scope_steward', 0.1],
+        ];
+
+        const independentResult = voting.aggregateWithCorrelation(
+          votes,
+          createCorrelationMatrix([...baseCorrelations, ['scope_steward', 'pm', 0.05]])
+        );
+        const correlatedResult = voting.aggregateWithCorrelation(
+          votes,
+          createCorrelationMatrix([...baseCorrelations, ['scope_steward', 'pm', 0.95]])
+        );
+
+        // Correlated case must aggregate strictly less than independent.
+        // The exact delta depends on weight thresholds, so we assert the
+        // monotonic property, not a specific number.
+        expect(correlatedResult.effectiveVoteCount).toBeLessThan(
+          independentResult.effectiveVoteCount
+        );
+      });
+    });
   });
 
   describe('computeISP', () => {


### PR DESCRIPTION
## Summary

Adds 3 regression tests to \`higher-order-voting.test.ts\` that pin the correlation-aware aggregation behavior using the actual 7-role panel introduced in #2185.

## Background

#2185 added \`scope_steward\` to the consensus panel. The PM voter raised a concern (4-1 supermajority) that \`scope_steward\` and \`pm\` both lean on roadmap-fit / business-value reasoning — when they co-vote, the higher_order Bayesian aggregator must down-weight the redundant signal or it effectively double-counts the product axis.

## Important framing

\`CorrelationTracker\` is **dynamic** (no hardcoded fixture), so #2227's "measure correlation empirically with 50+ proposals" acceptance criterion is satisfied automatically by the persistent tracker as real votes accrue. What was missing was a regression test that pins the **behavior** — given an observed high correlation, the strategy must respond correctly. This PR provides that.

## Tests added

In \`describe('#2227: scope_steward × pm correlation behavior')\`:

1. **down-weights pm when scope_steward × pm correlation is high** — 7-role panel with 0.9 correlation → at least one of \`{pm, scope_steward}\` appears in \`downweightedAgents\`.
2. **does NOT down-weight pm when correlation is low** — same vote pattern but 0.05 correlation → neither downweighted.
3. **reports lower effectiveVoteCount when correlated** — identical 7-role unanimous-approve votes, only the \`scope_steward × pm\` correlation differs (0.05 vs 0.95). The correlated case must aggregate strictly less.

## Test plan

- [x] 53/53 tests pass in \`higher-order-voting.test.ts\` (3 new + 50 existing)
- [x] ESLint clean
- [ ] CI green on PR

## #2227 acceptance status

- [x] Regression test pinning the correlation behavior — this PR
- [x] Strategy handles the new \`scope_steward\` role (no fixture to update; tracker is role-agnostic; no hardcoded role list found in \`src/consensus/\`)
- [ ] 50+ proposal corpus measurement — happens automatically via the persistent \`CorrelationTracker\` as live votes accrue. No manual measurement step needed.

Refs #2227, #2185, #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)