### PR TITLE
fix(2245): bump voter maxTokens 500 → 2000 (closes truncation root cause)

### DIFF
--- a/packages/nexus-agents/src/cli/voter-execution.test.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.test.ts
@@ -412,6 +412,32 @@ describe('voter-execution', () => {
       }
     });
 
+    // Pin the maxTokens to prevent regression to the truncated value (#2245).
+    // The v3 retest showed JSON parse failures at character positions 267 and
+    // 791 — caused by 500-token output cap cutting the JSON envelope mid-string.
+    // Lower bound = 1500 leaves headroom; upper bound prevents accidental
+    // unbounded growth.
+    it('should configure maxTokens large enough to fit JSON envelope + reasoning + YAML findings (#2245)', async () => {
+      const mockResponse: MockCompletionResult = {
+        ok: true,
+        value: {
+          content: [{ type: 'text', text: VALID_VOTE_JSON }],
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          stopReason: 'end_turn',
+          model: 'test-model',
+        },
+      };
+      vi.mocked(mockAdapter.complete).mockResolvedValue(mockResponse);
+
+      await executeSingleVoteAttempt('devex', 'Test proposal', mockAdapter, 5000);
+
+      const calls = vi.mocked(mockAdapter.complete).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const request = calls[0]?.[0] as { maxTokens?: number };
+      expect(request.maxTokens).toBeGreaterThanOrEqual(1500);
+      expect(request.maxTokens).toBeLessThanOrEqual(8000);
+    });
+
     it('should return error on adapter failure', async () => {
       const mockResponse: MockCompletionResult = {
         ok: false,

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -240,7 +240,12 @@ export async function executeSingleVoteAttempt(
       { role: 'system', content: VOTER_SYSTEM_PROMPTS[role] },
       { role: 'user', content: buildVotePrompt(proposal) },
     ],
-    maxTokens: 500,
+    // 500 was correct for short proposal-style votes but caused mid-string
+    // truncation ("Unterminated string in JSON at position N") in #2241 v3
+    // when voters review code diffs — the JSON envelope + reasoning + YAML
+    // findings block routinely exceed 500 tokens. Bumped to 2000 (#2245);
+    // refine per use case if needed.
+    maxTokens: 2000,
     temperature: 0.3, // Low temperature for consistent evaluations
   };
 


### PR DESCRIPTION
## Summary

Closes #2245. The v3 retest (#2241) empirically surfaced \"Unterminated string in JSON at position N\" parse failures as the dominant voter error category. **Root cause: \`voter-execution.ts:243\` hardcoded \`maxTokens: 500\`.**

500 tokens worked fine for short proposal-style votes (\`consensus_vote\` with a tagline-length proposal). But the PR-review use case has:
- Long system prompt (role + #2244 YAML format addendum)
- Up to 50k-char diff in the proposal body
- JSON envelope + reasoning (typical 1000+ chars) + YAML findings block at the END of reasoning

Total easily 1000-1500 tokens of legitimate output → 500-cap truncates the JSON mid-string, parser fails, voter is recorded as errored.

## Fix

Bump to 2000. Pinned with a regression test (1500 ≤ maxTokens ≤ 8000 bounds) so future tightening doesn't reintroduce the truncation.

## Predicted impact (to verify in next retest)

- Voter error rate: ~20-40% → near-zero
- Verified-finding rate: 0% → non-zero (YAML block actually emitted)
- Soft-block threshold easier to hit (more valid voters per PR)
- Bug-catch rate: 50% → likely 80-100% on synthetic dataset

## Test plan

- [x] 57/57 voter-execution tests pass (1 new regression test added)
- [x] tsup ESM + DTS build clean
- [x] ESLint clean
- [ ] CI green on PR

## Refs

- Closes #2245
- Triggered by #2241 v3 retest (\`docs/research/pr-review-experiment-results-v3.md\`)
- Refs #2244 (YAML format), #2233 (epic), #2251 (soft-block aggregator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)