### PR TITLE
fix(pr-review): move findings to top-level JSON field (v4 root cause)

### DIFF
--- a/packages/nexus-agents/src/cli/voter-prompts.test.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.test.ts
@@ -288,11 +288,13 @@ describe('voter-prompts', () => {
       });
     });
 
-    // #2244: PR-review-mode addendum (closes the 0-finding gap from #2241)
-    describe('PR-review YAML findings format (#2244)', () => {
-      it('mentions the YAML findings block in every role prompt', () => {
+    // #2244 + v4 #2245-followup: PR-review-mode addendum points voters at
+    // a TOP-LEVEL JSON findings field (was YAML inside reasoning, which
+    // was lossy across JSON serialization — see v4 retest results).
+    describe('PR-review findings format (#2244 + v4 fix)', () => {
+      it('mentions the top-level findings JSON field in every role prompt', () => {
         for (const role of allRoles) {
-          expect(VOTER_SYSTEM_PROMPTS[role]).toContain('```yaml findings');
+          expect(VOTER_SYSTEM_PROMPTS[role]).toContain('"findings"');
         }
       });
 
@@ -310,7 +312,6 @@ describe('voter-prompts', () => {
         for (const role of allRoles) {
           const prompt = VOTER_SYSTEM_PROMPTS[role];
           expect(prompt).toContain('substantive');
-          expect(prompt).toContain('not just "passed"');
         }
       });
 
@@ -320,26 +321,33 @@ describe('voter-prompts', () => {
         }
       });
 
-      it('tells voters to OMIT the block when approving', () => {
+      it('tells voters to OMIT the findings field when approving', () => {
         for (const role of allRoles) {
-          expect(VOTER_SYSTEM_PROMPTS[role]).toContain('OMIT the findings block');
+          expect(VOTER_SYSTEM_PROMPTS[role]).toContain('OMIT the findings field');
         }
       });
 
       it('explicitly scopes the addendum to PR-review mode (not all proposals)', () => {
-        // The addendum should NOT pollute non-PR-review consensus_vote use.
         for (const role of allRoles) {
           expect(VOTER_SYSTEM_PROMPTS[role]).toContain('PR-review mode');
           expect(VOTER_SYSTEM_PROMPTS[role]).toContain('non-diff proposal');
         }
       });
 
-      it('shows a few-shot example with substantive named_assertion', () => {
-        // The example must demonstrate what "substantive" looks like — a
-        // sentence-form failure description, not a single word.
+      it('emphasizes top-level placement (not embedded in reasoning)', () => {
+        // The v4 retest discovered the YAML-inside-reasoning encoding lost
+        // findings due to JSON-string serialization issues. Pin "top-level"
+        // and "NOT inside reasoning" to prevent regression.
         for (const role of allRoles) {
           const prompt = VOTER_SYSTEM_PROMPTS[role];
-          expect(prompt).toContain('Test loop-bounds.test.ts:42');
+          expect(prompt).toContain('top-level');
+          expect(prompt).toContain('NOT inside reasoning');
+        }
+      });
+
+      it('mentions #2245 history note', () => {
+        for (const role of allRoles) {
+          expect(VOTER_SYSTEM_PROMPTS[role]).toContain('#2245');
         }
       });
     });

--- a/packages/nexus-agents/src/cli/voter-prompts.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.ts
@@ -34,21 +34,26 @@ const DEFAULT_PROJECT = 'nexus-agents';
  */
 function prReviewModeAddendum(): string {
   return `
-PR-review mode — if you are reviewing a code diff (not a proposal) AND you have at least one concrete defect that justifies blocking the merge, append a fenced YAML block at the END of your reasoning, exactly like this:
+PR-review mode — if you are reviewing a code diff (not a proposal) AND you have at least one concrete defect that justifies blocking the merge, populate the OPTIONAL TOP-LEVEL "findings" field on your JSON response. NOT inside reasoning — top-level. The schema:
 
-\`\`\`yaml findings
-- summary: 'Off-by-one in event-loop bounds check'
-  location: src/loop.ts:142
-  severity: high
-  gate:
-    reread_cited_line: passed
-    traced_call_path: passed
-    named_assertion: 'Test loop-bounds.test.ts:42 asserts loop runs N times; this code runs N-1'
-    ruled_out_language_non_issue: passed
-  claim: 'Loop condition uses < but should be <= given inclusive end index'
-\`\`\`
+"findings": [
+  {
+    "summary": "One-line summary",
+    "location": "path/file.ext:LINE",
+    "severity": "critical" | "high" | "medium" | "low",
+    "gate": {
+      "reread_cited_line": "passed",
+      "traced_call_path": "passed",
+      "named_assertion": "Concrete failing assertion — what test would fail and how. Substantive, not 'passed'.",
+      "ruled_out_language_non_issue": "passed"
+    },
+    "claim": "What is wrong and why it justifies blocking."
+  }
+]
 
-A finding only triggers request_changes if all 4 gate fields = passed AND named_assertion is substantive (>10 chars naming a concrete failure, not just "passed"). Findings missing any of those surface as informational only — they do not block the merge. The 2026-04-25 audit (#2225) found a 100% false-positive rate when this gate wasn't enforced. If you're approving the diff, OMIT the findings block entirely. If reviewing a non-diff proposal, ignore this section.`;
+A finding only triggers strict request_changes if all 4 gate fields = "passed" AND named_assertion is substantive (>10 chars naming a concrete failure, not just "passed"). Findings missing any of those surface as informational only — they do not block on their own. The 2026-04-25 audit (#2225) found a 100% false-positive rate when this gate wasn't enforced. If you're approving the diff, OMIT the findings field entirely. If reviewing a non-diff proposal, ignore this section.
+
+History note: an earlier prompt asked for YAML inside reasoning; that format was lossy across JSON serialization (#2245). Use the top-level JSON array above.`;
 }
 
 /** Common footer appended to all voter prompts. */

--- a/packages/nexus-agents/src/cli/voter-response.ts
+++ b/packages/nexus-agents/src/cli/voter-response.ts
@@ -66,6 +66,35 @@ export interface ParseVoteOptions {
 // ============================================================================
 
 /**
+ * Pre-verified finding shape — voter emits this; downstream
+ * `isFindingVerified` adds the derived `verified` flag.
+ *
+ * #2245 follow-up: voters previously asked to embed YAML findings inside
+ * the JSON `reasoning` field. That format is lossy across JSON
+ * serialization (backticks/newlines). The v4 retest produced 0 findings
+ * across 9 request_changes voters because the LLM either dropped the
+ * YAML to keep JSON valid, or produced invalid JSON the parser rejected.
+ * Solution: expose findings as a top-level array on the vote response.
+ */
+export const RawFindingSchema = z.object({
+  summary: z.string().min(1).max(500).describe('One-line summary of the issue'),
+  location: z.string().min(1).max(200).describe('path/file.ext:line'),
+  severity: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
+  gate: z.object({
+    reread_cited_line: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+    traced_call_path: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+    named_assertion: z
+      .string()
+      .default('')
+      .describe('Concrete failing assertion — substantive, not a rubber-stamp word'),
+    ruled_out_language_non_issue: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+  }),
+  claim: z.string().min(1).max(2000).describe('What is wrong and why it justifies blocking'),
+});
+
+export type RawFinding = z.infer<typeof RawFindingSchema>;
+
+/**
  * Zod schema for parsing structured vote responses from LLM.
  */
 export const VoteResponseSchema = z.object({
@@ -88,6 +117,9 @@ export const VoteResponseSchema = z.object({
     )
     .optional()
     .describe('Rejection reason categories when decision is reject'),
+  /** Top-level structured findings for PR-review mode (#2245 v4 follow-up).
+   * Replaces the YAML-in-reasoning encoding that proved lossy. */
+  findings: z.array(RawFindingSchema).optional().describe('Structured findings (PR review only)'),
 });
 
 export type VoteResponse = z.infer<typeof VoteResponseSchema>;
@@ -95,6 +127,46 @@ export type VoteResponse = z.infer<typeof VoteResponseSchema>;
 // ============================================================================
 // Vote Prompt Construction
 // ============================================================================
+
+/** Example responses appended to vote prompts. Kept as a constant to keep
+ * `buildVotePrompt` under the max-lines-per-function lint cap. */
+const VOTE_PROMPT_EXAMPLES = `Example approve response:
+{
+  "decision": "approve",
+  "reasoning": "The proposal aligns with architectural patterns. Testability: high — unit tests can verify each component. Workflow integration: fits existing CI pipeline.",
+  "confidence": 0.85,
+  "conditions": ["Add unit tests before merge"]
+}
+
+Example reject response:
+{
+  "decision": "reject",
+  "reasoning": "This adds speculative abstractions for hypothetical future needs. Testability: unclear — no concrete test plan provided.",
+  "confidence": 0.80,
+  "rejectionCategories": ["YAGNI", "OVER_ENGINEERING"]
+}
+
+Example PR-review request_changes response with structured findings:
+{
+  "decision": "reject",
+  "reasoning": "Off-by-one in clampPageSize and missing null guard on response.timing — both visible in the diff.",
+  "confidence": 0.9,
+  "rejectionCategories": ["INSUFFICIENT_EVIDENCE"],
+  "findings": [
+    {
+      "summary": "Off-by-one in clampPageSize",
+      "location": "packages/nexus-agents/src/api/pagination.ts:18",
+      "severity": "high",
+      "gate": {
+        "reread_cited_line": "passed",
+        "traced_call_path": "passed",
+        "named_assertion": "Test would assert clampPageSize(50, 100) === 50; this returns 49.",
+        "ruled_out_language_non_issue": "passed"
+      },
+      "claim": "Function name says 'clamp to range' but returns requested-1 in the in-range path."
+    }
+  ]
+}`;
 
 /**
  * Constructs the user prompt for vote evaluation.
@@ -118,22 +190,9 @@ Respond with a JSON object containing:
 - confidence: Number between 0 and 1
 - conditions: Optional array of conditions for approval
 - rejectionCategories: Required when rejecting. Array of categories from: YAGNI, DRY_VIOLATION, OVER_ENGINEERING, SCOPE_CREEP, SECURITY_RISK, MISALIGNED, INSUFFICIENT_EVIDENCE
+- findings: PR-REVIEW MODE ONLY. Optional top-level array of structured findings — see "PR-review mode" in the system prompt. OMIT this field entirely when reviewing a non-diff proposal or when approving a diff.
 
-Example approve response:
-{
-  "decision": "approve",
-  "reasoning": "The proposal aligns with architectural patterns. Testability: high — unit tests can verify each component. Workflow integration: fits existing CI pipeline.",
-  "confidence": 0.85,
-  "conditions": ["Add unit tests before merge"]
-}
-
-Example reject response:
-{
-  "decision": "reject",
-  "reasoning": "This adds speculative abstractions for hypothetical future needs. Testability: unclear — no concrete test plan provided.",
-  "confidence": 0.80,
-  "rejectionCategories": ["YAGNI", "OVER_ENGINEERING"]
-}`;
+${VOTE_PROMPT_EXAMPLES}`;
 }
 
 // ============================================================================
@@ -192,6 +251,21 @@ function createFallbackVote(output: string, _role: VoterRole, reason: string): P
   };
 }
 
+/** Maps a validated VoteResponse into a ParsedVote, threading optional fields. */
+function buildParsedVote(data: VoteResponse): ParsedVote {
+  return {
+    decision: data.decision,
+    reasoning: data.reasoning,
+    confidence: data.confidence,
+    ...(data.conditions !== undefined ? { conditions: data.conditions } : {}),
+    ...(data.rejectionCategories !== undefined
+      ? { rejectionCategories: data.rejectionCategories }
+      : {}),
+    ...(data.findings !== undefined ? { findings: data.findings } : {}),
+    source: 'parsed',
+  };
+}
+
 /**
  * Parses vote response from LLM output.
  *
@@ -219,18 +293,7 @@ export function parseVoteResponse(
     const validated = VoteResponseSchema.safeParse(parsed);
 
     if (validated.success) {
-      return {
-        decision: validated.data.decision,
-        reasoning: validated.data.reasoning,
-        confidence: validated.data.confidence,
-        ...(validated.data.conditions !== undefined
-          ? { conditions: validated.data.conditions }
-          : {}),
-        ...(validated.data.rejectionCategories !== undefined
-          ? { rejectionCategories: validated.data.rejectionCategories }
-          : {}),
-        source: 'parsed', // Real vote from LLM
-      };
+      return buildParsedVote(validated.data);
     }
 
     // Validation failed - throw or fallback based on config

--- a/packages/nexus-agents/src/consensus/types-core.ts
+++ b/packages/nexus-agents/src/consensus/types-core.ts
@@ -66,6 +66,25 @@ export type RejectionCategory = z.infer<typeof RejectionCategorySchema>;
 export const REJECTION_CATEGORIES = RejectionCategorySchema.options;
 
 /**
+ * Pre-verified finding emitted by a voter (#2245 v4 follow-up).
+ * Mirrors `cli/voter-response.ts:RawFindingSchema` — kept inline here to
+ * avoid a circular cli→consensus import. Downstream code in mcp/tools
+ * adds the derived `verified` flag based on the gate fields.
+ */
+const FindingShapeSchema = z.object({
+  summary: z.string().min(1).max(500),
+  location: z.string().min(1).max(200),
+  severity: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
+  gate: z.object({
+    reread_cited_line: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+    traced_call_path: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+    named_assertion: z.string().default(''),
+    ruled_out_language_non_issue: z.enum(['passed', 'failed', 'skipped']).default('skipped'),
+  }),
+  claim: z.string().min(1).max(2000),
+});
+
+/**
  * A vote cast by an agent.
  */
 export const VoteSchema = z.object({
@@ -78,6 +97,9 @@ export const VoteSchema = z.object({
     .array(RejectionCategorySchema)
     .optional()
     .describe('Rejection reason categories when decision is reject'),
+  /** Pre-verified PR-review findings (#2245 v4 follow-up). Optional;
+   * populated only when the voter emits the structured top-level array. */
+  findings: z.array(FindingShapeSchema).optional().describe('PR-review findings (pre-verified)'),
   timestamp: z.iso.datetime().optional(),
 });
 export type Vote = z.infer<typeof VoteSchema>;

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -23,7 +23,12 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
 import { toolError, toolSuccess, type BaseMcpToolDeps, type ToolResult } from './tool-result.js';
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
-import { FINDINGS_FORMAT_INSTRUCTIONS, parseFindings, type Finding } from './pr-review-findings.js';
+import {
+  FINDINGS_FORMAT_INSTRUCTIONS,
+  isFindingVerified,
+  parseFindings,
+  type Finding,
+} from './pr-review-findings.js';
 
 export type { Finding, VerificationGate, FindingSeverity } from './pr-review-findings.js';
 
@@ -233,13 +238,33 @@ export function buildPrReviewProposal(input: PrReviewInput): string {
 // Result Mapping
 // ============================================================================
 
+/** Resolves findings for a voter result. Preferred path is the top-level
+ * `vote.findings` array (#2245 v4 follow-up — JSON-native, lossless). Falls
+ * back to parsing a YAML block from reasoning text for older voter outputs
+ * that may still emit the legacy format. */
+function resolveFindings(result: AgentVoteResult): readonly Finding[] {
+  const raw = result.vote.findings;
+  if (raw !== undefined && raw.length > 0) {
+    return raw.map((f) => ({
+      summary: f.summary,
+      location: f.location,
+      severity: f.severity,
+      gate: f.gate,
+      claim: f.claim,
+      verified: isFindingVerified(f.gate),
+    }));
+  }
+  // Fallback: legacy YAML-in-reasoning format.
+  return parseFindings(result.vote.reasoning);
+}
+
 function toPrReviewVote(result: AgentVoteResult): PrReviewVote {
   return {
     role: result.role,
     decision: mapVoteDecisionToPrDecision(result.vote.decision),
     confidence: result.vote.confidence,
     reasoning: result.vote.reasoning,
-    findings: parseFindings(result.vote.reasoning),
+    findings: resolveFindings(result),
     source: result.source,
     cli: result.cli,
     processingTimeMs: result.processingTimeMs,

--- a/scripts/pr-review-batch.ts
+++ b/scripts/pr-review-batch.ts
@@ -34,7 +34,11 @@ import {
   aggregatePrDecisions,
   MAX_DIFF_LENGTH,
 } from '../packages/nexus-agents/src/mcp/tools/pr-review-tool.js';
-import { parseFindings } from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
+import {
+  isFindingVerified,
+  parseFindings,
+  type Finding,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
 import {
   SampleDatasetSchema,
   type SampleDataset,
@@ -150,14 +154,41 @@ interface VoteResultLike {
     decision: 'approve' | 'reject' | 'abstain';
     confidence: number;
     reasoning: string;
+    findings?: ReadonlyArray<{
+      summary: string;
+      location: string;
+      severity: 'critical' | 'high' | 'medium' | 'low';
+      gate: {
+        reread_cited_line: 'passed' | 'failed' | 'skipped';
+        traced_call_path: 'passed' | 'failed' | 'skipped';
+        named_assertion: string;
+        ruled_out_language_non_issue: 'passed' | 'failed' | 'skipped';
+      };
+      claim: string;
+    }>;
   };
   readonly source: 'llm' | 'simulation' | 'error';
   readonly cli?: string | undefined;
   readonly processingTimeMs: number;
 }
 
+function resolveFindingsLike(r: VoteResultLike): readonly Finding[] {
+  const raw = r.vote.findings;
+  if (raw !== undefined && raw.length > 0) {
+    return raw.map((f) => ({
+      summary: f.summary,
+      location: f.location,
+      severity: f.severity,
+      gate: f.gate,
+      claim: f.claim,
+      verified: isFindingVerified(f.gate),
+    }));
+  }
+  return parseFindings(r.vote.reasoning);
+}
+
 function summarizeVoter(r: VoteResultLike): BatchPrResult['voters'][number] {
-  const findings = parseFindings(r.vote.reasoning);
+  const findings = resolveFindingsLike(r);
   return {
     role: r.role,
     decision: mapVoteDecisionToPrDecision(r.vote.decision),
@@ -246,7 +277,7 @@ function buildSuccessResult(
     decision: mapVoteDecisionToPrDecision(r.vote.decision),
     confidence: r.vote.confidence,
     reasoning: r.vote.reasoning,
-    findings: parseFindings(r.vote.reasoning),
+    findings: resolveFindingsLike(r),
     source: r.source,
     cli: r.cli,
     processingTimeMs: r.processingTimeMs,


### PR DESCRIPTION
## Summary

The v4 retest of #2241 — designed to validate the #2245 truncation fix (maxTokens 500 → 2000) — surfaced a deeper problem: **0 findings emitted across 9 request_changes votes**. JSONL inspection confirmed voters were producing valid JSON envelopes but the YAML findings block instructed by #2244 wasn't there.

## Root cause

Voters output JSON envelopes. We asked them to embed YAML inside the \`reasoning\` string field. **JSON serialization of arbitrary YAML (backticks, newlines, quotes) is lossy.** The LLM either:
- Dropped the YAML to keep JSON valid
- Escaped it into something the parser regex won't match
- Produced invalid JSON the parser rejected

## Fix

Move findings to a **top-level JSON array** native to the response schema.

### Changes

| File | What changed |
| --- | --- |
| \`cli/voter-response.ts\` | New \`RawFindingSchema\`; \`VoteResponseSchema.findings\` optional; prompt updated with JSON example; \`buildParsedVote\` helper (also fixes complexity-10 lint) |
| \`consensus/types-core.ts\` | \`VoteSchema.findings\` mirrors shape (inline schema avoids cli→consensus cycle) |
| \`cli/voter-prompts.ts\` | \`prReviewModeAddendum\` rewritten: JSON array spec, "NOT inside reasoning" emphasized, #2245 history note |
| \`mcp/tools/pr-review-tool.ts\` | New \`resolveFindings\` helper: prefers \`vote.findings\`, falls back to YAML parse for backward compat |
| \`scripts/pr-review-batch.ts\` | Same resolveFindings pattern |
| \`cli/voter-prompts.test.ts\` | 7 tests rewritten to pin top-level JSON format |

### Predicted v5 impact

- Verified-finding rate: 0% → non-zero (gate-level signal finally works)
- Some soft-blocks promote to verified-blocker tier
- Bug-catch rate may stay 50% (the 2 abstain cases were error-rate-bound, not finding-format-bound) but verified status upgrades for the 3 already-passing cases

## Test plan

- [x] 247 affected tests pass (60 voter-prompts, 78 voter-response, 57 voter-execution, 33 pr-review-tool, 19 pr-review-findings)
- [x] tsup ESM + DTS build clean
- [x] ESLint clean
- [ ] CI green on PR
- [ ] v5 retest after merge to validate

## Refs

- v4 follow-up to #2245, fixes the encoding issue surfaced by the retest
- Refs #2241, #2244, #2233 (epic)
- Closes the lossy-encoding hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)