### PR TITLE
feat(pr-review): local-mode runner for subscription auth

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,11 +1,21 @@
-# Multi-voter PR review (#2233 Child 6)
+# Multi-voter PR review (#2233 Child 6) — DISABLED BY DEFAULT
 #
-# Runs on every PR by default. Add the `skip-pr-review` label to opt out
-# (e.g. for trivial typo fixes, dependabot bumps, or cost-sensitive periods).
+# This workflow is dormant by default because nexus-agents users on Anthropic's
+# subscription plan (Claude Pro/Max) cannot use ANTHROPIC_API_KEY in CI without
+# violating the subscription ToS. The validated rollout path for that auth model
+# is `scripts/pr-review-local.ts` running on the maintainer's machine, where
+# voters route through the local Claude CLI subprocess and consume subscription
+# quota interactively (which is the intended use).
 #
-# Each voter (architect, security, devex, catfish, scope_steward) emits an
-# approve/request_changes/abstain decision with citation-backed findings.
-# Output is posted as a single PR comment.
+# Re-enabling this workflow:
+# To turn this back into "runs on every PR" mode, change the `if:` condition to:
+#   if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-pr-review') }}
+# AND ensure ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_AI_API_KEY /
+# OPENROUTER_API_KEY) is set as a repo secret with a real metered API key
+# (NOT a subscription account's session token).
+#
+# Current trigger: only fires when the `pr-review-ci` label is added to a PR.
+# That label doesn't exist by default — adding it is the explicit opt-in.
 #
 # Aggregate decision tiers (per #2251 + #2254):
 #   ❌ verified blocker — ≥1 voter has ≥1 verified finding (4-point gate
@@ -18,23 +28,12 @@
 # Empirical validation: v5 retest hit 100% bug-catch on diff-readable bugs,
 # caught a real bug in #2235 that no human reviewer noticed. See
 # docs/research/pr-review-experiment-results-v5.md.
-#
-# Required secrets: ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_AI_API_KEY)
-# for the underlying voter LLM calls.
-#
-# Cost: ~50 voter LLM calls per PR (~10 messages of subscription quota).
-# If quota becomes a problem, add `skip-pr-review` to high-volume automation
-# PRs (dependabot, etc) or revert this file's trigger to label-gated mode.
-#
-# Rollback: change the `if:` condition below to
-#   contains(github.event.pull_request.labels.*.name, 'pr-review')
-# and rename the label everywhere to revert to opt-in mode.
 
 name: PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -44,10 +43,9 @@ permissions:
 jobs:
   pr-review:
     name: Multi-voter PR review
-    # Skip when the opt-out label is present. Runs on every other PR by
-    # default (#2242 Child 6 promotion — empirically validated 100% bug-catch
-    # on the v5 retest dataset).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-pr-review') }}
+    # OPT-IN: only runs when the `pr-review-ci` label is added.
+    # Default is local-mode via scripts/pr-review-local.ts (subscription auth).
+    if: contains(github.event.pull_request.labels.*.name, 'pr-review-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,7 @@ Detailed technical documentation:
 | [WORKFLOW_TEMPLATES.md](./guides/WORKFLOW_TEMPLATES.md)           | Creating YAML workflows                                        |
 | [CUSTOM_ENDPOINT_SETUP.md](./guides/CUSTOM_ENDPOINT_SETUP.md)     | Custom OpenAI-compatible gateway (direct SDK + OpenCode paths) |
 | [CLOUD_PROVIDERS.md](./guides/CLOUD_PROVIDERS.md)                 | Bedrock/Vertex/Azure via OpenRouter / LiteLLM / custom-gateway |
+| [PR_REVIEW_LOCAL.md](./guides/PR_REVIEW_LOCAL.md)                 | Run pr_review on your machine using subscription CLI auth      |
 | [HARNESS_COMPATIBILITY.md](./guides/HARNESS_COMPATIBILITY.md)     | Wire nexus-agents from OpenCode/Codex/Cursor/Aider/Cline       |
 | [DEBUGGING_OBSERVABILITY.md](./guides/DEBUGGING_OBSERVABILITY.md) | Debug logging, tracing                                         |
 | [Claude Code Observability](./guides/claude-code-observability/)  | Hooks, status line, MCP logging for Claude Code                |

--- a/docs/guides/PR_REVIEW_LOCAL.md
+++ b/docs/guides/PR_REVIEW_LOCAL.md
@@ -1,0 +1,123 @@
+---
+title: Local pr_review (subscription auth)
+description: Run multi-voter PR review on your local machine using your Claude/Codex/Gemini CLI subscription auth — instead of CI with API keys
+tier: 2
+keywords: [pr-review, local, subscription, auth, claude-pro]
+---
+
+# Local pr_review (subscription auth)
+
+For nexus-agents users on Anthropic's subscription plan (Claude Pro/Max), the GitHub Actions workflow at `.github/workflows/pr-review.yml` is **dormant by default**. Running multi-voter review in CI requires a metered API key (`ANTHROPIC_API_KEY`), and using a subscription account's credentials in automated CI violates the subscription ToS.
+
+The validated path for subscription users is `scripts/pr-review-local.ts` — runs on your machine, voters route through your local Claude CLI (which uses your subscription auth interactively), and posts the comment back via `gh`.
+
+## Prerequisites
+
+- Claude CLI installed and authenticated (or Codex / Gemini / OpenCode CLI)
+- `gh` CLI authenticated against the repo
+- Node 22.x
+
+## One-shot
+
+Review a single PR by number:
+
+```bash
+npx tsx scripts/pr-review-local.ts 2257
+```
+
+What it does:
+
+1. Fetches the PR diff via `gh api`
+2. Runs the 5 voter pipeline (`architect`, `security`, `devex`, `catfish`, `scope_steward`) — each voter uses your local CLI subscription auth
+3. Aggregates with the 4-tier rule (verified blocker / soft blocker / approve / abstain)
+4. Posts a single review comment via `gh pr comment`
+5. Adds the `pr-reviewed` label so a subsequent `--watch` run skips it
+
+Cost: ~5 voter calls = ~5 messages of subscription quota at typical PR size, ~2 minutes wall-clock.
+
+### Dry run
+
+Pass `--no-post` to print results without commenting on the PR:
+
+```bash
+npx tsx scripts/pr-review-local.ts 2257 --no-post
+```
+
+## Watch mode
+
+Poll open PRs every N seconds, review any without the `pr-reviewed` label:
+
+```bash
+npx tsx scripts/pr-review-local.ts --watch
+npx tsx scripts/pr-review-local.ts --watch --interval 600   # 10-min poll
+npx tsx scripts/pr-review-local.ts --watch --include-drafts
+```
+
+Skip rules in watch mode:
+
+- Skips PRs already labeled `pr-reviewed`
+- Skips PRs labeled `skip-pr-review` (matches the workflow's opt-out)
+- Skips draft PRs unless `--include-drafts`
+
+Stop with `Ctrl+C`.
+
+## Aggregate decision tiers
+
+Same as the CI workflow (per #2251 + #2254):
+
+- ❌ **Verified blocker** — ≥1 voter has ≥1 verified finding (4-point gate passed with substantive `named_assertion`). Strict block.
+- ⚠️ **Soft blocker** — ≥3 of 5 non-error voters voted `request_changes` but no verified findings. Reviewers apply the gate themselves.
+- ✅ **Approve** — all non-error voters approved.
+- ➖ **Abstain** — anything else (mixed, all-errors, etc).
+
+## Empirical validation
+
+The v5 retest (see [`pr-review-experiment-results-v5.md`](../research/pr-review-experiment-results-v5.md)) hit:
+
+- 100% bug-catch on diff-readable bugs
+- 0% strict false positives (the "false positives" were real findings the dataset mislabeled)
+- 26 verified findings across 10 PRs
+- Caught a real bug in #2235 that no human reviewer noticed (devex flagged `GITHUB_API_KEY` instead of `GITHUB_TOKEN`)
+
+## Running as a long-lived watcher
+
+To make `--watch` survive logouts and restarts, wrap it in a systemd user service:
+
+```ini
+# ~/.config/systemd/user/pr-review-watch.service
+[Unit]
+Description=nexus-agents pr_review local watcher
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/william/git/nexus-agents
+ExecStart=/usr/bin/npx tsx scripts/pr-review-local.ts --watch --interval 600
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now pr-review-watch.service
+journalctl --user -u pr-review-watch -f
+```
+
+## Re-enabling the GitHub Actions workflow
+
+If you later get a metered API key and want the workflow to fire on every PR (the original Child 6 design), edit `.github/workflows/pr-review.yml`:
+
+- Change `if: contains(github.event.pull_request.labels.*.name, 'pr-review-ci')` to `if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-pr-review') }}`
+- Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_AI_API_KEY` / `OPENROUTER_API_KEY`) in repo Actions secrets
+
+The workflow's precheck step will reject runs without a configured key with an actionable error.
+
+## Refs
+
+- [`pr-review-experiment-results-v5.md`](../research/pr-review-experiment-results-v5.md) — empirical validation
+- #2233 (epic, closed)
+- #2256 (Child 6 — original CI promotion, now dormant)
+- #2258 (the API-key issue that motivated the local mode)

--- a/scripts/pr-review-local.ts
+++ b/scripts/pr-review-local.ts
@@ -1,0 +1,427 @@
+#!/usr/bin/env npx tsx
+/**
+ * Local pr_review runner — uses your local Claude CLI subscription auth
+ * instead of API keys (which would violate Anthropic's subscription ToS
+ * when used in automated CI).
+ *
+ * Usage:
+ *   npx tsx scripts/pr-review-local.ts <pr-number>           # one-shot
+ *   npx tsx scripts/pr-review-local.ts --watch               # poll loop
+ *   npx tsx scripts/pr-review-local.ts --watch --interval 600 # custom poll
+ *   npx tsx scripts/pr-review-local.ts <pr-number> --no-post # dry run
+ *
+ * What it does (one-shot):
+ *   1. Fetches PR diff via `gh api`
+ *   2. Runs the same 5-voter pipeline pr_review uses (voters route
+ *      through CLI subprocesses → use your local subscription auth)
+ *   3. Posts a single review comment back via `gh pr comment`
+ *   4. Adds the `pr-reviewed` label so --watch mode skips on next pass
+ *
+ * What it does (watch mode):
+ *   Polls open PRs without the `pr-reviewed` label, runs review on each,
+ *   sleeps for --interval seconds (default 300), repeats.
+ *
+ * Safety:
+ *   - Adds `pr-reviewed` label so the same PR isn't reviewed twice
+ *   - Skips PRs with `skip-pr-review` label (matches the workflow's opt-out)
+ *   - Skips draft PRs by default (use --include-drafts to override)
+ *   - Adds [bot] suffix to comment body so it's clearly automated
+ *
+ * Cost: ~5 voter LLM calls per PR (5 messages of subscription quota at
+ * typical PR size, ~2 minutes wall-clock per PR).
+ *
+ * @module scripts/pr-review-local
+ */
+
+/* eslint-disable no-console -- this is a CLI script that prints progress */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { collectRealVotes } from '../packages/nexus-agents/src/cli/voter-agents.js';
+import {
+  PR_REVIEW_ROLES,
+  buildPrReviewProposal,
+  mapVoteDecisionToPrDecision,
+  aggregatePrDecisions,
+  MAX_DIFF_LENGTH,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-tool.js';
+import {
+  isFindingVerified,
+  type Finding,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
+
+const execFileP = promisify(execFile);
+
+const REPO_OWNER = 'williamzujkowski';
+const REPO_NAME = 'nexus-agents';
+const REVIEWED_LABEL = 'pr-reviewed';
+const SKIP_LABEL = 'skip-pr-review';
+
+// ============================================================================
+// CLI args
+// ============================================================================
+
+interface Args {
+  readonly mode: 'one-shot' | 'watch';
+  readonly prNumber: number | undefined;
+  readonly intervalSec: number;
+  readonly post: boolean;
+  readonly includeDrafts: boolean;
+}
+
+function parseInterval(raw: string | undefined, current: number): number {
+  if (raw === undefined) return current;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= 60 ? v : current;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const flags = new Set<string>();
+  let prNumber: number | undefined;
+  let intervalSec = 300;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
+    if (a === '--watch' || a === '--no-post' || a === '--include-drafts') {
+      flags.add(a);
+    } else if (a === '--interval') {
+      intervalSec = parseInterval(argv[i + 1], intervalSec);
+      i++;
+    } else if (/^\d+$/.test(a)) {
+      prNumber = Number(a);
+    }
+  }
+
+  return {
+    mode: flags.has('--watch') ? 'watch' : 'one-shot',
+    prNumber,
+    intervalSec,
+    post: !flags.has('--no-post'),
+    includeDrafts: flags.has('--include-drafts'),
+  };
+}
+
+// ============================================================================
+// gh CLI wrappers
+// ============================================================================
+
+interface OpenPr {
+  readonly number: number;
+  readonly title: string;
+  readonly isDraft: boolean;
+  readonly labels: readonly string[];
+}
+
+async function listOpenPrs(): Promise<readonly OpenPr[]> {
+  const { stdout } = await execFileP('gh', [
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--json',
+    'number,title,isDraft,labels',
+    '--limit',
+    '100',
+  ]);
+  const parsed = JSON.parse(stdout) as Array<{
+    number: number;
+    title: string;
+    isDraft: boolean;
+    labels: Array<{ name: string }>;
+  }>;
+  return parsed.map((p) => ({
+    number: p.number,
+    title: p.title,
+    isDraft: p.isDraft,
+    labels: p.labels.map((l) => l.name),
+  }));
+}
+
+async function fetchPrDiff(
+  prNumber: number
+): Promise<{
+  diff: string;
+  truncated: boolean;
+  baseRef: string;
+  headRef: string;
+  title: string;
+  body: string;
+}> {
+  const [{ stdout: meta }, { stdout: diffOut }] = await Promise.all([
+    execFileP('gh', [
+      'api',
+      `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
+      '--jq',
+      '{title, body, head: .head.ref, base: .base.ref}',
+    ]),
+    execFileP(
+      'gh',
+      [
+        'api',
+        `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
+        '-H',
+        'Accept: application/vnd.github.v3.diff',
+      ],
+      { maxBuffer: 16 * 1024 * 1024 }
+    ),
+  ]);
+  const m = JSON.parse(meta) as { title?: string; body?: string; head?: string; base?: string };
+  const truncated = diffOut.length > MAX_DIFF_LENGTH;
+  const diff = truncated ? `${diffOut.slice(0, MAX_DIFF_LENGTH)}\n[...truncated]` : diffOut;
+  return {
+    diff,
+    truncated,
+    title: m.title ?? '',
+    body: m.body ?? '',
+    headRef: m.head ?? '',
+    baseRef: m.base ?? '',
+  };
+}
+
+async function postPrComment(prNumber: number, body: string): Promise<void> {
+  // Use stdin to avoid shell-escape headaches on the markdown body.
+  const child = execFile('gh', ['pr', 'comment', String(prNumber), '--body-file', '-']);
+  child.stdin?.write(body);
+  child.stdin?.end();
+  await new Promise<void>((resolve, reject) => {
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`gh pr comment exited ${String(code ?? -1)}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function applyLabel(prNumber: number, label: string): Promise<void> {
+  try {
+    await execFileP('gh', ['pr', 'edit', String(prNumber), '--add-label', label]);
+  } catch (e) {
+    // Don't fail the run if labeling fails (label may not exist yet).
+    console.warn(`  label '${label}' not applied: ${(e as Error).message.slice(0, 100)}`);
+  }
+}
+
+// ============================================================================
+// Voter run
+// ============================================================================
+
+interface VoterResult {
+  readonly role: string;
+  readonly decision: 'approve' | 'request_changes' | 'abstain';
+  readonly confidence: number;
+  readonly reasoning: string;
+  readonly findings: readonly Finding[];
+  readonly source: 'llm' | 'simulation' | 'error';
+  readonly cli?: string | undefined;
+}
+
+async function runReview(
+  prNumber: number
+): Promise<{ summary: string; verified: boolean; reviews: VoterResult[] }> {
+  console.log(`\n[#${String(prNumber)}] fetching diff…`);
+  const { diff, title, body, baseRef, headRef } = await fetchPrDiff(prNumber);
+  console.log(`  ${title}`);
+  console.log(`  diff size: ${String(diff.length)} chars`);
+
+  const proposal = buildPrReviewProposal({
+    prTitle: title,
+    prDescription: body,
+    prDiff: diff,
+    ...(baseRef !== '' && { baseRef }),
+    ...(headRef !== '' && { headRef }),
+    simulate: false,
+  });
+
+  console.log(`  running ${String(PR_REVIEW_ROLES.length)} voters via local CLI auth…`);
+  const voteResults = await collectRealVotes({
+    roles: PR_REVIEW_ROLES,
+    proposal,
+    simulate: false,
+  });
+
+  const reviews: VoterResult[] = voteResults.map((r) => {
+    const raw = r.vote.findings;
+    const findings: Finding[] =
+      raw !== undefined && raw.length > 0
+        ? raw.map((f) => ({
+            summary: f.summary,
+            location: f.location,
+            severity: f.severity,
+            gate: f.gate,
+            claim: f.claim,
+            verified: isFindingVerified(f.gate),
+          }))
+        : [];
+    return {
+      role: r.role,
+      decision: mapVoteDecisionToPrDecision(r.vote.decision),
+      confidence: r.vote.confidence,
+      reasoning: r.vote.reasoning,
+      findings,
+      source: r.source,
+      cli: r.cli,
+    };
+  });
+
+  const aggregate = aggregatePrDecisions(reviews);
+  return { summary: aggregate.decision, verified: aggregate.verified, reviews };
+}
+
+// ============================================================================
+// Comment formatting
+// ============================================================================
+
+function formatHeader(summary: string, verified: boolean): { icon: string; tag: string } {
+  const isSoftBlock = summary === 'request_changes' && !verified;
+  if (isSoftBlock) return { icon: '⚠️', tag: 'REQUEST CHANGES (UNVERIFIED — majority dissent)' };
+  const icons: Record<string, string> = { approve: '✅', request_changes: '❌', abstain: '➖' };
+  return { icon: icons[summary] ?? '❓', tag: summary.toUpperCase() };
+}
+
+function formatVoterTable(reviews: readonly VoterResult[]): string[] {
+  const rows: string[] = [
+    '| Voter | Decision | Confidence | CLI | Findings |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+  for (const r of reviews) {
+    const verifiedN = r.findings.filter((f) => f.verified).length;
+    const total = r.findings.length;
+    const findingsCol = total === 0 ? '—' : `${String(verifiedN)}/${String(total)} verified`;
+    rows.push(
+      `| ${r.role} | ${r.decision} | ${(r.confidence * 100).toFixed(0)}% | ${r.cli ?? '—'} | ${findingsCol} |`
+    );
+  }
+  return rows;
+}
+
+function formatVerifiedFindings(reviews: readonly VoterResult[]): string[] {
+  const verified = reviews.flatMap((r) => r.findings.filter((f) => f.verified));
+  if (verified.length === 0) return [];
+  const lines: string[] = ['', '### Verified findings'];
+  for (const f of verified) {
+    lines.push('', `- **${f.summary}** (\`${f.location}\`, ${f.severity})`, `  - ${f.claim}`);
+  }
+  return lines;
+}
+
+function formatReasoningDetails(reviews: readonly VoterResult[]): string[] {
+  const lines: string[] = ['', '<details><summary>Reasoning per voter</summary>', ''];
+  for (const r of reviews) {
+    lines.push(`### ${r.role} — ${r.decision}`, '', r.reasoning, '');
+  }
+  lines.push('</details>');
+  return lines;
+}
+
+function formatComment(result: {
+  summary: string;
+  verified: boolean;
+  reviews: VoterResult[];
+}): string {
+  const { icon, tag } = formatHeader(result.summary, result.verified);
+  const isSoftBlock = result.summary === 'request_changes' && !result.verified;
+  const softNote = isSoftBlock
+    ? [
+        '',
+        '> ⚠️ Majority of voters requested changes but none produced a verified finding. Apply the verification gate (`.rules/discovered-issues.md`) before acting on these concerns — they may be false positives.',
+      ]
+    : [];
+  return [
+    `## ${icon} Multi-voter PR Review [bot]`,
+    '',
+    `**Overall:** ${tag}`,
+    ...softNote,
+    '',
+    ...formatVoterTable(result.reviews),
+    ...formatVerifiedFindings(result.reviews),
+    ...formatReasoningDetails(result.reviews),
+    '',
+    '---',
+    `_Run locally via \`scripts/pr-review-local.ts\` — uses subscription quota (~5 LLM calls). To opt out, add the \`${SKIP_LABEL}\` label._`,
+  ].join('\n');
+}
+
+// ============================================================================
+// One-shot + watch
+// ============================================================================
+
+async function runOnce(prNumber: number, post: boolean): Promise<void> {
+  const result = await runReview(prNumber);
+  const counts = result.reviews.reduce(
+    (acc, r) => {
+      if (r.source === 'error') acc.err++;
+      else if (r.decision === 'approve') acc.approve++;
+      else if (r.decision === 'request_changes') acc.rc++;
+      else acc.abstain++;
+      return acc;
+    },
+    { approve: 0, rc: 0, abstain: 0, err: 0 }
+  );
+  console.log(
+    `  → ${result.summary.toUpperCase()}${result.verified ? '' : ' (unverified)'} ` +
+      `(approve=${String(counts.approve)}, rc=${String(counts.rc)}, abstain=${String(counts.abstain)}, err=${String(counts.err)})`
+  );
+
+  if (counts.err === result.reviews.length) {
+    console.error(`  all voters errored — likely auth or transport issue. Skipping comment.`);
+    return;
+  }
+
+  if (!post) {
+    console.log(`  --no-post: skipping PR comment.`);
+    return;
+  }
+
+  const body = formatComment(result);
+  await postPrComment(prNumber, body);
+  await applyLabel(prNumber, REVIEWED_LABEL);
+  console.log(`  posted comment + applied '${REVIEWED_LABEL}' label.`);
+}
+
+async function runWatch(args: Args): Promise<void> {
+  console.log(`Watch mode (interval ${String(args.intervalSec)}s). Ctrl+C to stop.\n`);
+  for (;;) {
+    try {
+      const prs = await listOpenPrs();
+      const eligible = prs.filter((p) => {
+        if (p.labels.includes(REVIEWED_LABEL)) return false;
+        if (p.labels.includes(SKIP_LABEL)) return false;
+        if (!args.includeDrafts && p.isDraft) return false;
+        return true;
+      });
+      console.log(
+        `[${new Date().toISOString()}] ${String(prs.length)} open PRs, ${String(eligible.length)} eligible.`
+      );
+      for (const pr of eligible) {
+        await runOnce(pr.number, args.post);
+      }
+    } catch (e) {
+      console.error(`watch poll failed: ${(e as Error).message}`);
+    }
+    await new Promise((r) => setTimeout(r, args.intervalSec * 1000));
+  }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.mode === 'watch') {
+    await runWatch(args);
+    return;
+  }
+
+  if (args.prNumber === undefined) {
+    console.error('Usage: pr-review-local.ts <pr-number> [--no-post]');
+    console.error('   or: pr-review-local.ts --watch [--interval 300] [--include-drafts]');
+    process.exit(1);
+  }
+
+  await runOnce(args.prNumber, args.post);
+}
+
+await main();


### PR DESCRIPTION
## Summary

- Adds `scripts/pr-review-local.ts` — runs the multi-voter pr_review pipeline on the maintainer's machine using local Claude/Codex/Gemini CLI subscription auth, instead of in CI with metered API keys
- Disables `.github/workflows/pr-review.yml` by default (now requires the `pr-review-ci` label which doesn't exist by default) — the original Child 6 design assumed `ANTHROPIC_API_KEY` in repo secrets, which is not safe to use with subscription plan credentials
- Adds `docs/guides/PR_REVIEW_LOCAL.md` covering one-shot, `--watch`, and systemd user-service deployment

## Why

Anthropic's subscription plans (Claude Pro/Max) disallow using account credentials in automated CI — doing so risks account termination. The validated Child 6 path of \"runs on every PR\" via GH Actions assumed a metered API key, which we do not have.

The local-mode runner solves this by leveraging the existing harness: `collectRealVotes` already routes through the local Claude CLI subprocess for each voter, and that CLI uses the user's interactive subscription auth. Running locally consumes the subscription quota interactively (which IS the intended use), avoiding any ToS violation.

Closes #2258 (API-key alternative — local mode supersedes).

## What ships

**One-shot:**
\`\`\`bash
npx tsx scripts/pr-review-local.ts 2257
\`\`\`

**Watch mode:**
\`\`\`bash
npx tsx scripts/pr-review-local.ts --watch --interval 600
\`\`\`

Skip rules in watch mode:
- Skips PRs already labeled \`pr-reviewed\`
- Skips PRs labeled \`skip-pr-review\`
- Skips drafts unless \`--include-drafts\`

**Cost:** ~5 voter calls per PR = ~5 messages of subscription quota, ~2 min wall-clock.

## Re-enabling CI mode

If a metered API key becomes available later, the workflow's header comment documents the one-line revert (change the trigger label from \`pr-review-ci\` to \`!skip-pr-review\` and add a model API key secret).

## Test plan

- [ ] CI green (lint, typecheck, build, test, type-check-test, security)
- [ ] \`npx tsx scripts/pr-review-local.ts <pr> --no-post\` produces voter table + per-voter reasoning without erroring
- [ ] \`gh pr comment\` posting works on a non-draft test PR
- [ ] \`pr-reviewed\` label gets applied after a successful run
- [ ] \`--watch\` skips already-labeled PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)