### PR TITLE
chore(release): v2.57.0 — pr_review epic, scope_steward, registry hardening

### DIFF
--- a/.changeset/v2-57-0-pr-review-shipping.md
+++ b/.changeset/v2-57-0-pr-review-shipping.md
@@ -1,0 +1,80 @@
+---
+'nexus-agents': minor
+---
+
+**v2.57.0 — Multi-voter PR review, scope_steward role, model registry hardening**
+
+This release ships Epic #2233 (multi-voter PR review) along with a new consensus role, several architectural improvements, and the model-registry pricing alignment from the weekly drift check.
+
+### Multi-voter PR review (Epic #2233 — experimental)
+
+A new `pr_review` MCP tool that wires the existing 5 consensus voters (architect, security, devex, catfish, scope_steward) to GitHub PR diffs. Each voter emits a typed `PRReview` with mandatory verification-gate output (matching the 4-point check from #2225 — re-read line, trace call path, name assertion, rule out language non-issue).
+
+- Tool: `pr_review` ([#2236](https://github.com/williamzujkowski/nexus-agents/pull/2236)) — children 1+2 of the epic
+- Verification gate enforcement in voter prompts ([#2238](https://github.com/williamzujkowski/nexus-agents/pull/2238))
+- 10-PR seed dataset + batch harness + scorer ([#2243](https://github.com/williamzujkowski/nexus-agents/pull/2243))
+- YAML findings format in voter system prompts ([#2248](https://github.com/williamzujkowski/nexus-agents/pull/2248))
+- Hybrid dataset with synthetic diff-readable bugs ([#2249](https://github.com/williamzujkowski/nexus-agents/pull/2249))
+- Soft-block aggregation tier on majority dissent ([#2251](https://github.com/williamzujkowski/nexus-agents/pull/2251))
+- Voter `maxTokens` bumped 500 → 2000 to fit PR-review-sized findings ([#2253](https://github.com/williamzujkowski/nexus-agents/pull/2253))
+- JSON-native findings — moved from lossy YAML-in-string to top-level JSON `findings` array ([#2254](https://github.com/williamzujkowski/nexus-agents/pull/2254))
+- v5 promoted to live PRs (Child 6, opt-in) ([#2256](https://github.com/williamzujkowski/nexus-agents/pull/2256))
+- Fail-fast when no model API key is configured ([#2257](https://github.com/williamzujkowski/nexus-agents/pull/2257))
+- **Local-mode runner** `scripts/pr-review-local.ts` for subscription-plan auth — runs voters through the local Claude/Codex/Gemini CLI subprocess so subscription quota is consumed interactively (the intended use). The GitHub Actions workflow at `.github/workflows/pr-review.yml` is now dormant by default; flip the trigger to re-enable when a metered API key is available. See [`docs/guides/PR_REVIEW_LOCAL.md`](https://github.com/williamzujkowski/nexus-agents/blob/main/docs/guides/PR_REVIEW_LOCAL.md). ([#2261](https://github.com/williamzujkowski/nexus-agents/pull/2261))
+
+Empirical validation (v5 retest): 100% bug-catch on diff-readable bugs in the synthetic dataset, 0% strict false-positive rate, and the v5 run caught a real bug ([#2255](https://github.com/williamzujkowski/nexus-agents/pull/2255)) that no human reviewer noticed.
+
+`pr_review` is **experimental** — surface, output schema, and aggregation tiers may change as we collect data on live PRs.
+
+### scope_steward consensus role ([#2228](https://github.com/williamzujkowski/nexus-agents/pull/2228))
+
+Adds a 7th voter role focused on build-vs-buy gating: should we extend an existing tool/library or build something new? The role asks: does an existing tool already cover this? what's the maintenance cost of building? would adoption-pressure on the new code split the team's attention? Useful when the architect/AI-ML voters skew toward "let's build it" — scope_steward is the counter-pull.
+
+### Verification gate for code-review subagents ([#2225](https://github.com/williamzujkowski/nexus-agents/pull/2225) → [#2226](https://github.com/williamzujkowski/nexus-agents/pull/2226))
+
+A 2026-04-25 audit found that second-pass code-review subagents had a 100% false-positive rate on findings — every claim disqualified by reading 5 more lines or noticing a slice cap. The CLAUDE.md governance now enforces a 4-point gate on every discovered-issue finding before filing: (1) re-read line + 5 above + 5 below, (2) trace the call path, (3) name the failing assertion, (4) rule out language-level non-issues. Subagent prompts must surface which checks each finding passed; the parent agent verifies before filing.
+
+### Audit-trail gap fix ([#2218](https://github.com/williamzujkowski/nexus-agents/pull/2218))
+
+When an MCP tool handler throws, audit events are now emitted with the error context. Previously the throw bypassed the audit pipeline, leaving observability blind on the most actionable subset of tool runs.
+
+### Security: ReDoS in base64 detection ([#2191](https://github.com/williamzujkowski/nexus-agents/pull/2191) → [#2216](https://github.com/williamzujkowski/nexus-agents/pull/2216))
+
+Rewrote the `base64_encoded` injection pattern to eliminate catastrophic backtracking — the previous lookahead-plus-quantifier shape (`(?=X*Y)X{n,}`) was polynomial-time on adversarial inputs.
+
+### Research source repair ([#2234](https://github.com/williamzujkowski/nexus-agents/pull/2234) → [#2235](https://github.com/williamzujkowski/nexus-agents/pull/2235), [#2255](https://github.com/williamzujkowski/nexus-agents/pull/2255))
+
+Restored `research_discover` for GitHub (dropped the `OR` clause that returned 0 results — simpler query returns 359) and Semantic Scholar (added optional `SEMANTIC_SCHOLAR_API_KEY` env var, surfaced 401 → `RATE_LIMIT` for retry). The 429 rate-limit message now uses `GITHUB_TOKEN` (correct) instead of `GITHUB_API_KEY` (wrong) — caught by the pr_review devex voter and fixed before this release.
+
+### Cloud provider setup guide ([#2229](https://github.com/williamzujkowski/nexus-agents/pull/2229) → [#2237](https://github.com/williamzujkowski/nexus-agents/pull/2237))
+
+New `docs/guides/CLOUD_PROVIDER_SETUP.md` covering Bedrock, Vertex AI, and Azure OpenAI configuration paths.
+
+### Model registry — pricing + context window alignment ([#2259](https://github.com/williamzujkowski/nexus-agents/issues/2259) → [#2262](https://github.com/williamzujkowski/nexus-agents/pull/2262))
+
+Eight fields aligned to the litellm community catalog after the weekly drift check:
+
+- `gemini-3-pro` / `gemini-pro` / `gemini-3-flash` / `gemini-flash`: contextWindow 1,000,000 → 1,048,576 (exact 2^20)
+- `codex-5.3`: contextWindow 1,000,000 → 1,050,000
+- `codex-5.2`: contextWindow 400,000 → 272,000, inputPer1M $2.00 → $1.75, outputPer1M $8.00 → $14.00
+
+### Adapter parallel-registry consolidation (#2199, #2200)
+
+Several adapters had their own private alias/model lookups that drifted from the canonical `model-capabilities.ts` registry. Migrated Claude/Gemini/OpenAI parallel registries to derive from the canonical registry's `aliases[]` field with longest-prefix-wins fallback. The model-string drift CI check is now blocking ([#2210](https://github.com/williamzujkowski/nexus-agents/pull/2210)) — registry inconsistencies fail the build instead of being advisory.
+
+### CLAUDE.md governance reconciliation ([#2231](https://github.com/williamzujkowski/nexus-agents/pull/2231))
+
+Vote-count drift (5→7 agents), phantom subagent types, and stale tool counts reconciled. The agent table now reflects the actual enum (Explore, Plan, general-purpose, claude-code-guide).
+
+### Other fixes
+
+- Backup user config before `--force` overwrite in CLI setup ([#2215](https://github.com/williamzujkowski/nexus-agents/pull/2215))
+- Propagate `AbortSignal` in aorchestra worker dispatcher ([#2214](https://github.com/williamzujkowski/nexus-agents/pull/2214))
+- `getAdapterForModel` longest-prefix-wins fallback ([#2209](https://github.com/williamzujkowski/nexus-agents/pull/2209))
+- Capture fallback duration in `tryExpertFallback` ([#2196](https://github.com/williamzujkowski/nexus-agents/pull/2196))
+- Defensive hardening: 3 fixes from code review ([#2193](https://github.com/williamzujkowski/nexus-agents/pull/2193))
+- Pin `peter-evans/create-pull-request` to SHA (Scorecard MED) ([#2198](https://github.com/williamzujkowski/nexus-agents/pull/2198))
+- Scope `registry-refresh` permissions to refresh job ([#2197](https://github.com/williamzujkowski/nexus-agents/pull/2197))
+- Indexer cleanup: silent-empty extraction surfaces as warnings ([#2165](https://github.com/williamzujkowski/nexus-agents/pull/2165)), `extractOption` consolidation ([#2167](https://github.com/williamzujkowski/nexus-agents/pull/2167)), CLI commands single-source-of-truth ([#2173](https://github.com/williamzujkowski/nexus-agents/pull/2173))
+
+No breaking changes.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-04-26T15:57:20.363Z",
+  "generated": "2026-04-27T11:34:51.784Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.56.0",
   "cli": {

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -328,11 +328,14 @@ nexus-agents hooks stop --check-tasks
 | `memory_write`            | Write a memory entry to a specific backend                         | None (local) | Shared bucket |
 | `registry_import`         | Generate draft model registry entry                                | None (local) | Shared bucket |
 | `query_trace`             | Query execution traces by run ID                                   | None (local) | Shared bucket |
+| `query_task_state`        | Query structured task-state log                                    | None (local) | Shared bucket |
+| `run_pipeline`            | Run a typed pipeline by name with provided inputs                  | None (local) | Shared bucket |
 | `repo_analyze`            | Analyze GitHub repository structure                                | None (local) | Shared bucket |
 | `repo_security_plan`      | Generate security scanning pipeline for a repository               | None (local) | Shared bucket |
 | `extract_symbols`         | Extract code symbols (functions, classes, types) from source files | None (local) | Shared bucket |
 | `search_codebase`         | Search codebase for code patterns, symbols, or text                | None (local) | Shared bucket |
 | `run_dev_pipeline`        | Multi-agent dev pipeline: research→plan→vote→implement→QA→security | Optional     | Shared bucket |
+| `pr_review`               | Multi-voter PR review with verification gate (experimental)        | None (local) | Shared bucket |
 
 **Rate limiting:** All tools share a single token bucket rate limiter (capacity: 100 tokens, refill: 10 tokens/sec). Each tool call consumes one token.
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-04-26T15:57:20.363Z
+**Generated:** 2026-04-27T11:34:51.784Z
 **Package Version:** 2.56.0
 **Generator:** `scripts/generate-repo-index.ts`
 


### PR DESCRIPTION
## Summary

Release-prep for **v2.57.0** (minor bump from 2.56.0). Adds the changeset describing the surface shipped since the last release and regenerates doc artifacts.

## What ships in v2.57.0

**Multi-voter PR review (Epic #2233 — experimental):** new `pr_review` MCP tool, verification-gate enforcement in voter prompts, hybrid synthetic+historical dataset, soft-block aggregation tier, JSON-native findings serialization, fail-fast on missing API keys, and a local-mode runner (\`scripts/pr-review-local.ts\`) for subscription-plan auth users — see [PR_REVIEW_LOCAL.md](https://github.com/williamzujkowski/nexus-agents/blob/main/docs/guides/PR_REVIEW_LOCAL.md). v5 retest hit 100% bug-catch on diff-readable bugs and caught a real bug in #2235 that no human reviewer noticed.

**scope_steward consensus role (#2228):** 7th voter focused on build-vs-buy gating; counter-pull when architect/AI-ML voters skew toward "let's build it."

**Verification gate for code-review subagents (#2225 → #2226):** 4-point checklist enforced before any discovered-issue finding can be filed; closes the 100% false-positive rate observed in second-pass reviews.

**Other fixes:** audit-trail emission on tool throws (#2218), ReDoS in base64 detection (#2191/#2216), GitHub research source repair + GITHUB_TOKEN env-var fix (#2234/#2255), cloud provider setup guide (#2237), adapter parallel-registry consolidation (#2199/#2200), model-string drift CI check promoted to blocking (#2210), CLAUDE.md governance reconciliation (#2231), and the pricing/context-window alignment from the weekly drift check (#2259/#2262).

No breaking changes.

## Validation

Approach validated via \`consensus_vote\` (simple_majority): **6 approve / 1 reject = 85.7%** on 2026-04-27. The dissenting voter (Contrarian) flagged JSON-native findings as a potential breaking change for downstream consumers — but \`pr_review\` is a brand-new tool first introduced in this release window (#2236), and the YAML-in-string format never shipped a release, so there are no existing consumers of the legacy format. Approving voters' conditions incorporated: \`pr_review\` is explicitly marked experimental in the changeset, local-mode runner is documented for subscription-plan users, and \`docs/ENTRYPOINTS.md\` now exposes the tool (plus two others that had drifted out of the table).

## Rollout

This PR is doc-only — no production code changes.

1. Merge this PR
2. The \`changesets/action\` bot opens \`chore(release): version packages\` automatically
3. Merging that PR runs \`pnpm release\` → npm publish + GitHub release auto-fires (with SBOM upload + attestations from the release workflow)

## Test plan

- [ ] \`pnpm changeset status\` reports nexus-agents at minor (already verified locally)
- [ ] CI green (lint, typecheck, build, test, governance, docs, fitness, security)
- [ ] After merge: \`changesets/action\` bot opens version PR within ~5 min
- [ ] After version PR merge: \`Release\` workflow publishes to npm and creates the \`nexus-agents@2.57.0\` GH release

🤖 Generated with [Claude Code](https://claude.com/claude-code)