### PR TITLE
fix(ci): unbreak SICA Weekly Test Generation workflow

### DIFF
--- a/.github/workflows/sica-test-generation.yml
+++ b/.github/workflows/sica-test-generation.yml
@@ -54,7 +54,15 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: |
           echo "📊 Measuring current test coverage..."
-          pnpm test:coverage --reporter=json > coverage-report.json 2>&1 || true
+          # Note: don't pipe to coverage-report.json — that's two failures rolled
+          # into one. (1) `pnpm test:coverage` is `turbo test:coverage`, which
+          # rejects --reporter=json with "Unknown option: 'run'", and (2) the
+          # captured output gets staged for the auto-PR step where lint-staged
+          # runs prettier on *.json files and chokes on the non-JSON content.
+          # Coverage data we actually need is read from coverage-summary.json
+          # below; the captured run output is only useful as debug, so write
+          # it to a non-staged path with a non-JSON extension.
+          pnpm test:coverage > coverage-report.log 2>&1 || true
 
           # Extract coverage metrics
           if [ -f packages/nexus-agents/coverage/coverage-summary.json ]; then
@@ -134,7 +142,9 @@ jobs:
         if: steps.generate.outputs.test_count > 0
         run: |
           echo "✅ Validating generated tests..."
-          pnpm test --run 2>&1 || echo "Some tests may need adjustment"
+          # `pnpm test` is `turbo test`, which already runs vitest in --run
+          # mode; passing --run through to turbo trips "Unknown option: 'run'".
+          pnpm test 2>&1 || echo "Some tests may need adjustment"
 
       - name: Create Pull Request
         if: |


### PR DESCRIPTION
## Summary

Closes #2263.

The SICA Weekly Test Generation workflow has been failing every scheduled run since **2026-03-16** (six consecutive weekly fails as of 2026-04-27). Two compounding turbo/pnpm script bugs caused it:

### Bug 1 (line 57 → was)

```bash
pnpm test:coverage --reporter=json > coverage-report.json 2>&1 || true
```

- The root `test:coverage` script is `turbo test:coverage`.
- Turbo rejects `--reporter=json` with `Unknown option: 'run'` (turbo's own arg parser misreads it).
- The error text gets piped to `coverage-report.json` — making it not actually JSON.
- The bad file is then staged for the auto-PR step, where lint-staged runs prettier on `*.{json,md,yaml,yml}` and chokes: `SyntaxError: Unexpected token (2:1)`.

**Fix:** drop the broken `--reporter=json` flag and rename the output file to `coverage-report.log` so it's caught by the existing `*.log` rule in `.gitignore` and skipped by lint-staged. The actual coverage data we need is already extracted from `packages/nexus-agents/coverage/coverage-summary.json` immediately below.

### Bug 2 (line 145 → was)

```bash
pnpm test --run
```

Same shape: `pnpm test` is `turbo test`, which already runs vitest in `--run` mode. Forwarding `--run` to turbo trips the same `Unknown option: 'run'` error.

**Fix:** drop the redundant flag.

## Test plan

- [ ] CI green on this PR (lint + workflow validation)
- [ ] Next scheduled run of `SICA Weekly Test Generation` (Mondays ~05:00 UTC) succeeds — track via Actions → SICA Weekly Test Generation
- [ ] If the next scheduled run still fails, the failure mode will be different (the SICA generator's own logic, not the script bugs above) and I'll re-open

## Why bundle both fixes

Both are the same root cause (`turbo` arg-passthrough confusion vs `pnpm` script defaults), both are 1-line changes, and the workflow is broken end-to-end without both. Splitting into two PRs would just create more sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)