### PR TITLE
docs(readme): add pr_review and query_task_state to MCP tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,38 +187,40 @@ See [docs/ENTRYPOINTS.md](./docs/ENTRYPOINTS.md) for the complete CLI reference 
 
 When running as an MCP server, the following tools are available:
 
-| Tool                      | Description                                              |
-| ------------------------- | -------------------------------------------------------- |
-| `orchestrate`             | Task orchestration with Orchestrator coordination        |
-| `create_expert`           | Create a specialized expert agent                        |
-| `execute_expert`          | Execute a task using a created expert                    |
-| `run_workflow`            | Execute a workflow template                              |
-| `delegate_to_model`       | Route task to optimal model                              |
-| `consensus_vote`          | Multi-model consensus voting on proposals                |
-| `list_experts`            | List available expert types                              |
-| `list_workflows`          | List available workflow templates                        |
-| `research_query`          | Query research registry (status, overlap, stats, search) |
-| `research_add`            | Add paper to registry by arXiv ID                        |
-| `research_discover`       | Discover papers/repos from external sources              |
-| `research_analyze`        | Analyze registry for gaps, trends, coverage              |
-| `research_catalog_review` | Review auto-cataloged research references                |
-| `memory_query`            | Query across all memory backends                         |
-| `memory_stats`            | Memory system statistics dashboard                       |
-| `memory_write`            | Write to typed memory backends                           |
-| `weather_report`          | Multi-CLI performance weather report                     |
-| `issue_triage`            | Triage GitHub issues with trust classification           |
-| `run_graph_workflow`      | Execute graph-based workflows with checkpointing         |
-| `execute_spec`            | Execute AI software factory spec pipeline                |
-| `registry_import`         | Generate draft model registry entry                      |
-| `query_trace`             | Query execution traces for observability                 |
-| `repo_analyze`            | Analyze GitHub repository structure                      |
-| `repo_security_plan`      | Generate security scanning pipeline for a repo           |
-| `research_add_source`     | Add non-paper source (GitHub repo, tool, blog)           |
-| `research_synthesize`     | Synthesize registry into topic clusters with themes      |
-| `extract_symbols`         | Extract code symbols from source files for analysis      |
-| `search_codebase`         | Search codebase for patterns, symbols, or text           |
-| `run_dev_pipeline`        | Full dev pipeline: research, plan, vote, implement, QA   |
-| `run_pipeline`            | Execute a pipeline plugin by name with typed input       |
+| Tool                      | Description                                                 |
+| ------------------------- | ----------------------------------------------------------- |
+| `orchestrate`             | Task orchestration with Orchestrator coordination           |
+| `create_expert`           | Create a specialized expert agent                           |
+| `execute_expert`          | Execute a task using a created expert                       |
+| `run_workflow`            | Execute a workflow template                                 |
+| `delegate_to_model`       | Route task to optimal model                                 |
+| `consensus_vote`          | Multi-model consensus voting on proposals                   |
+| `list_experts`            | List available expert types                                 |
+| `list_workflows`          | List available workflow templates                           |
+| `research_query`          | Query research registry (status, overlap, stats, search)    |
+| `research_add`            | Add paper to registry by arXiv ID                           |
+| `research_discover`       | Discover papers/repos from external sources                 |
+| `research_analyze`        | Analyze registry for gaps, trends, coverage                 |
+| `research_catalog_review` | Review auto-cataloged research references                   |
+| `memory_query`            | Query across all memory backends                            |
+| `memory_stats`            | Memory system statistics dashboard                          |
+| `memory_write`            | Write to typed memory backends                              |
+| `weather_report`          | Multi-CLI performance weather report                        |
+| `issue_triage`            | Triage GitHub issues with trust classification              |
+| `run_graph_workflow`      | Execute graph-based workflows with checkpointing            |
+| `execute_spec`            | Execute AI software factory spec pipeline                   |
+| `registry_import`         | Generate draft model registry entry                         |
+| `query_trace`             | Query execution traces for observability                    |
+| `query_task_state`        | Query the structured task-state log for a task ID           |
+| `repo_analyze`            | Analyze GitHub repository structure                         |
+| `repo_security_plan`      | Generate security scanning pipeline for a repo              |
+| `research_add_source`     | Add non-paper source (GitHub repo, tool, blog)              |
+| `research_synthesize`     | Synthesize registry into topic clusters with themes         |
+| `extract_symbols`         | Extract code symbols from source files for analysis         |
+| `search_codebase`         | Search codebase for patterns, symbols, or text              |
+| `run_dev_pipeline`        | Full dev pipeline: research, plan, vote, implement, QA      |
+| `run_pipeline`            | Execute a pipeline plugin by name with typed input          |
+| `pr_review`               | Multi-voter PR review with verification gate (experimental) |
 
 ---
 


### PR DESCRIPTION
## Summary

The README MCP tools table had drifted from the registered surface (32 tools per the auto-generated CLAUDE.md governance from `inject-governance.ts`). Adds the two missing entries:

- `pr_review` — shipped in v2.57.0 ([Epic #2233](https://github.com/williamzujkowski/nexus-agents/issues/2233)), marked **experimental** to match the v2.57.0 changeset and `docs/ENTRYPOINTS.md` framing
- `query_task_state` — predates v2.57.0 but was never added to the README table (was already in `docs/ENTRYPOINTS.md` from PR #2264)

The same drift was fixed in `docs/ENTRYPOINTS.md` as part of #2264 release-prep. README is currently maintained manually; a follow-up to derive it from `model-config-helpers` (or just from the same source the inject-governance script uses) would prevent future drift — filing as separate idea, not blocking this small fix.

## Test plan

- [ ] CI green (lint + governance + spell + markdown lint + link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)