### PR TITLE
docs(retry): cross-reference sibling retry impl (#2230)

### DIFF
--- a/packages/nexus-agents/src/adapters/retry.ts
+++ b/packages/nexus-agents/src/adapters/retry.ts
@@ -1,8 +1,22 @@
 /**
  * nexus-agents/adapters - Retry Logic with Exponential Backoff
  *
- * Provides retry functionality for fallible operations with exponential backoff
- * and jitter to prevent thundering herd problems.
+ * Provides generic, type-parameterized retry functionality for fallible
+ * operations with exponential backoff and jitter to prevent thundering
+ * herd problems. Returns Result<T, RetryExhaustedError> — type-safe error
+ * boundary suitable for cross-layer use.
+ *
+ * Sibling implementation (see #2230): cli-retry-loop.ts holds a CLI-specific
+ * retry loop with built-in circuit-breaker integration, FailureCategory
+ * mapping, and CliResponse return shape. Don't reach for that one from
+ * non-CLI code; don't reach for this one when you need circuit-breaker
+ * coupling. Math primitives differ deliberately:
+ *   - this file: 0-indexed attempt, ±jitterFactor, cap-before-jitter
+ *   - cli-retry-loop.ts: 1-indexed attempt, +0..30% jitter, cap-after
+ *
+ * If you find yourself writing a third retry loop: stop, run
+ * `consensus_vote` with scope_steward in the panel, and pick whichever
+ * of these two fits — don't add a third.
  *
  * (Source: AWS Architecture Blog - Exponential Backoff and Jitter)
  * (Source: Google Cloud API Design Guide - Retry Strategy)

--- a/packages/nexus-agents/src/cli-adapters/cli-retry-loop.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-retry-loop.ts
@@ -1,8 +1,21 @@
 /**
  * nexus-agents/cli-adapters - Unified CLI Retry Loop
  *
- * Single retry loop used by all CLI adapters (base + Gemini).
- * Supports optional circuit breaker integration.
+ * CLI-specific retry loop used by all CLI adapters (base + Gemini).
+ * Supports optional circuit-breaker integration, returns CliResponse
+ * with retryCount, and maps to FailureCategory for breaker tracking.
+ *
+ * Sibling implementation (see #2230): adapters/retry.ts holds the
+ * generic, type-parameterized `withRetry<T>` for non-CLI use. Don't
+ * reach for that one when you need circuit-breaker coupling; don't
+ * reach for this one from non-CLI code. Math primitives differ
+ * deliberately:
+ *   - this file: 1-indexed attempt, +0..30% jitter, cap-after
+ *   - adapters/retry.ts: 0-indexed attempt, ±jitterFactor, cap-before-jitter
+ *
+ * If you find yourself writing a third retry loop: stop, run
+ * `consensus_vote` with scope_steward in the panel, and pick whichever
+ * of these two fits — don't add a third.
  *
  * (Source: Issue #1596 — Extract shared prompt utils and rate-limit patterns)
  */


### PR DESCRIPTION
## Summary

Closes #2230. Adds module-level cross-references to `adapters/retry.ts` and `cli-adapters/cli-retry-loop.ts` so future readers and consensus voters see both implementations together with a clear "use which when" decision and a scope_steward escalation cue.

## Why minimal cross-ref instead of consolidation

I started this with the goal of consolidating the two implementations as #2230 suggested. After reading both side-by-side, they are **not** the same algorithm with cosmetic differences — the math primitives diverge in three ways that matter to timing:

| Concern | `adapters/retry.ts` | `cli-adapters/cli-retry-loop.ts` |
|---|---|---|
| Attempt index | 0-based (`base * 2^attempt`) | 1-based (`base * 2^(attempt-1)`) |
| Jitter shape | ±jitterFactor (symmetric, configurable) | +0..30% (positive, hardcoded) |
| Cap order | Cap before jitter | Cap after jitter |
| Return shape | `Result<T, RetryExhaustedError>` (generic) | `Result<CliRetryResult, CliError>` (CLI-specific) |
| Circuit-breaker coupling | None | Built-in via `categorizeError` → `FailureCategory` |

These aren't duplicates — they're two valid abstractions for two use cases. Forcing them into one would change timing behavior in subtle ways for either CLI or generic retries. Net negative.

## What this PR does instead

The actual problem #2230 documented was **discoverability** — the consensus panel almost approved a *third* retry implementation because the two existing ones weren't visible enough to most voters. That's a docs problem, not a code problem.

So:

- Each module now has a docstring naming the sibling, listing the math differences explicitly, and stating "use this when..." vs "use the sibling when..."
- A scope_steward escalation cue: "If you find yourself writing a third retry loop: stop, run `consensus_vote` with scope_steward in the panel"
- Total diff: 31 lines of comments, no behavior change

## What's NOT in this PR

- No code-level consolidation (would change behavior — see comparison table)
- No new shared "retry math kernel" module (premature abstraction; we have two implementations and that's fine — a third would warrant the kernel)
- No fitness-audit gate flagging raw `setTimeout(...).then(retry)` patterns (separate concern; could be a follow-up if drift recurs despite the cross-refs)

## Test plan

- [x] `pnpm typecheck` clean (docstring-only change)
- [ ] CI green (lint, typecheck, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)