### PR TITLE
docs: reframe project as governance substrate (closes #2284)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Standalone guidance for AI coding agents (OpenCode, Codex CLI, Cursor, Aider, Cline, Continue, Goose, Claude Code) working in this repo. Self-contained — no required redirect to other files.
 
+**About this project:** Nexus-agents is a _governance substrate_ for AI coding agents — adversarial PR review, drift-detected charter, immutable audit, closed-loop telemetry. The agents you (the reader) belong to are exactly the kind of agent nexus-agents governs. Rules in `.rules/` are enforced by CI gates and PR-review voters, not just suggestions.
+
 > Claude Code users: the legacy entry point at [CLAUDE.md](./CLAUDE.md) is still authoritative for Claude-Code-specific integrations (auto-loaded rules, plugin marketplace). The content below is the harness-neutral subset.
 
 ## Prime directive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,7 @@ _Auto-generated from source. 32 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-04-27_
+_Governance Version: 2026-04-28_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ related_files: [CODING_STANDARDS.md, docs/ENTRYPOINTS.md]
 
 # Nexus Agents - Claude Code Instructions
 
-**Project:** Intelligent orchestration platform for AI coding tools
+**Project:** Governance substrate for AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry. The agents (Claude/Codex/Gemini/OpenCode, plus Devin/Factory adapters) do the engineering; nexus-agents enforces the rules they have to follow, reviews their work adversarially, and audits everything they touch.
 **Repository:** github.com/williamzujkowski/nexus-agents
 **Owner:** @williamzujkowski
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12365/badge)](https://www.bestpractices.dev/projects/12365) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/williamzujkowski/nexus-agents/badge)](https://securityscorecards.dev/viewer/?uri=github.com/williamzujkowski/nexus-agents)
 
-> The intelligence layer between you and your AI coding tools
+> Governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry
 
 [![npm version](https://img.shields.io/npm/v/nexus-agents)](https://www.npmjs.com/package/nexus-agents)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -12,62 +12,64 @@
 
 ## Why Nexus Agents?
 
-nexus-agents makes your AI coding tools work together intelligently. It coordinates Claude, Codex, Gemini, and OpenCode — routing each task to the best model using data-driven algorithms, validating outputs through multi-model consensus voting, and continuously improving through outcome-driven learning. Connect it to any MCP-compatible editor (Claude Code, Cursor, VS Code) and it handles the rest.
+**Nexus-agents is a governance layer that sits above your AI coding agents** — Claude Code, Codex, Gemini, OpenCode (and, via adapters, Devin / Factory). The agents do the engineering; nexus-agents enforces the rules they have to follow, reviews their work adversarially before it ships, audits everything they touch, and routes the next task based on what actually worked.
 
-**What it does for you:**
+**What it gives you:**
 
-- **Routes intelligently** — LinUCB bandit + TOPSIS scoring + adaptive bonuses pick the right model for each task, learned from real outcomes
-- **Enforces quality** — consensus voting (6 strategies including Bayesian higher-order), QA review loops, security scans with SARIF
-- **Learns over time** — 5 memory backends (session, belief, agentic, adaptive, typed) track what works, feeding routing, planning, and research decisions
-- **Runs a full dev pipeline** — research papers, plan architecture, vote on proposals, decompose into tasks, implement, QA review, ship
-- **Connects everything** — 32 MCP tools, 9 research sources, graph workflows, checkpoint/resume, GitHub/GitLab issue tracking
+- **Adversarial PR review** — `pr_review` runs 5 voter roles (architect, security, devex, catfish, scope_steward) with a 4-point verification gate that catches false positives. Empirically: 100% bug-catch on diff-readable bugs, 0% strict false-positive rate
+- **Drift-detected charter** — `CLAUDE.md` + `governance:check` + blocking CI gates fail the build when documented rules drift from registered behavior (model registry, MCP tools, expert types, skills)
+- **Immutable audit trail** — every tool call, every voter decision, every routing choice flows through `AuditTrail` with structured logging and (in flight) hash-chained append-only storage
+- **Closed-loop routing** — `OutcomeStore` feeds production telemetry back into LinUCB + TOPSIS scoring so the system actually learns from what shipped vs what regressed
+- **Multi-voter consensus** — 6 strategies (simple/super-majority, unanimous, higher-order Bayesian, opinion-wise, proof-of-learning) for proposals where one agent's word isn't enough
 
 ```
-You: "Review this code for security and performance"
-     ↓
-CompositeRouter selects best CLI per category → Security Expert + Code Expert
-     ↓
-Consensus-validated response — outcomes feed back into routing for next time
+You:               "Review this PR / orchestrate this task / vote on this proposal"
+                    ↓
+nexus-agents:       enforce rules → route → adversarial review → audit → learn from outcome
+                    ↓
+Engineering agents: Claude Code · Codex · Gemini · OpenCode · (Devin / Factory adapters)
+                    ↓
+Code:               actual edits, tests, PRs, issues
 ```
 
-**What it is NOT:**
+**What this is NOT:**
 
-- Not an autonomous agent — humans stay in the loop via votes and harness mode
-- Not a chat framework — it orchestrates real CLI tools with real file I/O
-- Not a model API proxy — the intelligence IS the routing, quality gates, and learning
+- **Not another autonomous coding agent.** OpenHands, SWE-agent, AutoGen, Devin, Factory — those are agents. Nexus-agents is the layer above them. Use whichever agents fit; we govern them
+- **Not a chat framework.** Nothing here orchestrates conversations. It orchestrates real CLI tool invocations with real file I/O and outcome tracking
+- **Not a model API proxy.** The value is the rules, the gates, the audit, and the learning. Routing is a side effect of the governance work, not the product
 
 ---
 
-## Architecture at a Glance
+## Where nexus-agents sits in your stack
 
 ```
-                         ┌─────────────────────────────────┐
-                         │         Your IDE / CLI           │
-                         │  (Claude Code, Cursor, VS Code)  │
-                         └──────────────┬──────────────────┘
-                                        │ MCP Protocol
-                         ┌──────────────▼──────────────────┐
-                         │       nexus-agents server        │
-                         │                                  │
-                         │  ┌──────────┐  ┌──────────────┐ │
-                         │  │ 32 MCP   │  │ Dev Pipeline  │ │
-                         │  │ Tools    │  │ research→plan │ │
-                         │  └────┬─────┘  │ →vote→impl   │ │
-                         │       │        │ →QA→ship      │ │
-                         │  ┌────▼─────┐  └──────────────┘ │
-                         │  │Composite │                    │
-                         │  │Router    │  ┌──────────────┐ │
-                         │  │(9 stages)│  │ 5 Memory     │ │
-                         │  └────┬─────┘  │ Backends     │ │
-                         │       │        └──────────────┘ │
-                         └───────┼─────────────────────────┘
-                    ┌────────────┼────────────┐
-                    ▼            ▼             ▼
-               ┌────────┐  ┌────────┐   ┌──────────┐
-               │ Claude │  │ Gemini │   │  Codex   │ ...
-               │  CLI   │  │  CLI   │   │   CLI    │
-               └────────┘  └────────┘   └──────────┘
+   Human / IDE / CLI
+   (Claude Code, Cursor, VS Code, terminal)
+            │ MCP Protocol
+            ▼
+  ┌─────────────────────────────────────────────────────┐
+  │  GOVERNANCE SUBSTRATE — what nexus-agents provides   │
+  │                                                       │
+  │   Charter (drift-checked)   Adversarial PR review    │
+  │   Role registry             Multi-voter consensus    │
+  │   Immutable audit trail     Closed-loop telemetry    │
+  │                                                       │
+  │   32 MCP tools · 9-stage CompositeRouter             │
+  └────────────────────────┬────────────────────────────┘
+                           │
+                           ▼ delegates execution to
+  ┌─────────────────────────────────────────────────────┐
+  │  ENGINEERING AGENTS — what does the actual work      │
+  │                                                       │
+  │   Claude Code · Codex · Gemini · OpenCode            │
+  │   (Devin / Factory adapters in flight)               │
+  └────────────────────────┬────────────────────────────┘
+                           │
+                           ▼ produces
+                   Code, tests, PRs, issues
 ```
+
+The governance substrate is the layer that catches the mistakes engineering agents would otherwise make — bad code shipped, rules drifting from intent, audit gaps, telemetry-free routing — and routes the next task based on what actually worked the last time.
 
 ---
 
@@ -116,17 +118,20 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 
 ## Capabilities
 
-| Category                       | Details                                                                                                                                                                          |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Intelligent Routing**        | 9-stage CompositeRouter: budget-aware, LinUCB bandit, TOPSIS multi-criteria, preference-trained, weather-adaptive. Learns from outcomes.                                         |
-| **Multi-Expert Orchestration** | 11 built-in expert types (code, architecture, security, testing, docs, devops, research, PM, UX, infrastructure, data-visualization) coordinated by TechLead/Orchestrator agents |
-| **Consensus Voting**           | 6 strategies: simple_majority, supermajority, unanimous, higher_order (Bayesian correlation-aware), opinion_wise, proof_of_learning                                              |
-| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run                                                    |
-| **Memory & Learning**          | 5 user-facing backends (session, belief, agentic, adaptive, typed). Cross-session persistence. Outcomes feed routing.                                                            |
-| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                         |
-| **Security**                   | Sandboxing (Docker/policy), trust classification, SARIF parsing, input sanitization, red team pipeline, firewall                                                                 |
-| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                                                            |
-| **32 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                              |
+| Category                       | Details                                                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Adversarial PR Review**      | `pr_review` MCP tool: 5 voter roles (architect, security, devex, catfish, scope_steward) with 4-point verification gate. 100% bug-catch on diff-readable bugs in v5 evaluation |
+| **Consensus Voting**           | 6 strategies: simple_majority, supermajority, unanimous, higher_order (Bayesian correlation-aware), opinion_wise, proof_of_learning                                            |
+| **Drift-Detected Charter**     | `CLAUDE.md` + `inject-governance.ts check` enforces single-source registries (model registry, MCP tools, expert types). Blocking CI gate fails build on drift                  |
+| **Audit Trail**                | Structured logging for every tool call, voter decision, and routing choice. Hash-chained immutable storage in flight (#2281)                                                   |
+| **Closed-Loop Telemetry**      | `OutcomeStore` records production results; LinUCB bandit + TOPSIS scoring + adaptive routing bonuses adjust based on what actually worked. No other framework closes this loop |
+| **Security Pipeline**          | Sandboxing (Docker/policy), trust-tiered input handling, SARIF parsing, red-team patterns, ClawGuard access policies (audit/enforce)                                           |
+| **Multi-Expert Orchestration** | 12 built-in expert types coordinated by Orchestrator. Roles bind prompt + tools + memory                                                                                       |
+| **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run                                                  |
+| **Memory & Learning**          | 5 user-facing backends (session, belief, agentic, adaptive, typed). Cross-session persistence feeds routing decisions                                                          |
+| **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                       |
+| **Graph Workflows**            | DAG-based workflow execution with checkpoint/resume, state reduction, and event hooks                                                                                          |
+| **32 MCP Tools**               | Agent management, workflow execution, research, memory, codebase intelligence, repo analysis, consensus, operations                                                            |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #2284. First of 7 follow-ups from the #2232 build-vs-buy audit.

The audit found that calling nexus-agents an "autonomous SDLC framework" was the trigger for the failed 4-3 vote on autonomous-SDLC architecture work — it invited "isn't this what AutoGen / OpenHands / Devin does?" comparisons that the audit itself disproved (top candidate covers 44% of our charter; we sit a layer above the engineering agents, not alongside them).

This PR is positioning, not features. Code unchanged; what changes is how we describe it.

## Changes

**README.md** (largest diff):

- **Tagline**: "intelligence layer between you and your AI coding tools" → "governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry"
- **"Why" section**: leads with adversarial PR review (the v2.57.0 headline), drift detection, audit trail, closed-loop telemetry, multi-voter consensus — not routing
- **"What this is NOT" bullets**: explicitly distinguish from OpenHands / SWE-agent / AutoGen / Devin / Factory ("those are agents; we're the layer above them")
- **Architecture diagram**: replaced with a stack diagram showing Human → Governance Substrate → Engineering Agents → Code. Emphasizes nexus-agents sits ABOVE the agents, not alongside
- **Capabilities table**: reordered to lead with governance gates. Added rows for Adversarial PR Review, Drift-Detected Charter, Audit Trail to surface previously-buried capabilities

**CLAUDE.md** (1 line):

- Project header: "Intelligent orchestration platform" → "Governance substrate for AI coding agents — ..."

**AGENTS.md** (1 paragraph):

- Added a new "About this project" paragraph after the standalone-guidance intro so harness-neutral readers (OpenCode, Codex, etc.) get the substrate framing too. Also notes that rules in `.rules/` are CI-enforced, not just suggestions

## Why this and not bigger changes

The audit recommendation was *positioning*, not API/feature redesign. Surgical edits get the message right without expanding scope. Marketing-page / website / blog updates can follow as separate PRs once this lands.

## Test plan

- [ ] CI green (lint, markdown lint, link check, governance check, spell check)
- [ ] No code changes — typecheck/test/build are smoke tests on the doc artifacts
- [ ] Manual: re-read the README front-page; does it now tell the build-vs-buy story correctly?

## Refs

- #2232 audit comment — verdict section ("Stop framing it as 'autonomous SDLC framework'")
- #2284 — original issue
- The 4-3 dissent vote that triggered #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)