### PR TITLE
feat(orchestration): port Magentic-One Task/Progress Ledger pattern (closes #2278)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,7 @@ _Auto-generated from source. 32 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-04-27_
+_Governance Version: 2026-04-28_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/context/structured-task-state-types.ts
+++ b/packages/nexus-agents/src/context/structured-task-state-types.ts
@@ -49,6 +49,60 @@ export const TaskPositionSchema = z.object({
 export type TaskPosition = z.infer<typeof TaskPositionSchema>;
 
 /**
+ * Magentic-One Task Ledger — outer-loop "facts and guesses" about the task (#2278).
+ *
+ * Mirrors AutoGen's `magentic-one` Orchestrator pattern: the outer loop maintains
+ * a ledger of verifiable facts, working assumptions (guesses), and open questions
+ * the orchestrator still needs to resolve. The inner loop's `ProgressLedger`
+ * decides whether to continue, replan (which triggers a TaskLedger refresh), or
+ * escalate.
+ *
+ * Reference: microsoft.github.io/autogen — Magentic-One Task Ledger / Progress
+ * Ledger pattern.
+ */
+export const TaskLedgerSchema = z.object({
+  /** Verifiable observations: what we have observed/measured/confirmed. */
+  facts: z.array(z.string()),
+  /** Working assumptions: useful guesses we proceed under, marked separately. */
+  guesses: z.array(z.string()),
+  /** Things we still need to figure out before the plan is sound. */
+  openQuestions: z.array(z.string()),
+  updatedAt: z.iso.datetime(),
+});
+export type TaskLedger = z.infer<typeof TaskLedgerSchema>;
+
+/**
+ * Magentic-One Progress Ledger — the inner-loop self-reflection at each step (#2278).
+ *
+ * After each step, the orchestrator (or whoever is driving) emits one
+ * `ProgressLedgerEntry` summarizing whether the outer plan is still valid,
+ * whether we are stuck, and what to do next. Append-only; the most recent entry's
+ * `suggestedAction` is what `Orchestrator.reflect()` returns.
+ */
+export const ReflectActionSchema = z.enum([
+  'continue',
+  'revise_plan',
+  'escalate_to_human',
+  'abort',
+]);
+export type ReflectAction = z.infer<typeof ReflectActionSchema>;
+
+export const ProgressLedgerEntrySchema = z.object({
+  ts: z.iso.datetime(),
+  /** What just happened (the step we are reflecting on). */
+  step: z.string().min(1),
+  /** Is the outer Task Ledger plan still right after this step? */
+  planStillValid: z.boolean(),
+  /** Are we making progress, or have we stalled? */
+  stuck: z.boolean(),
+  /** What the orchestrator should do next based on this reflection. */
+  suggestedAction: ReflectActionSchema,
+  /** Why this action was chosen — required so future readers can audit the call. */
+  rationale: z.string().min(1),
+});
+export type ProgressLedgerEntry = z.infer<typeof ProgressLedgerEntrySchema>;
+
+/**
  * Structured state for a single long-running task.
  *
  * All arrays are append-only during the task's lifetime; a blocker can
@@ -61,6 +115,18 @@ export const StructuredTaskStateSchema = z.object({
   decisions: z.array(TaskDecisionSchema),
   blockers: z.array(TaskBlockerSchema),
   position: TaskPositionSchema,
+  /**
+   * Magentic-One Task Ledger (#2278). Mutable single-object outer-loop state:
+   * facts/guesses/openQuestions revised together when the plan is replanned.
+   * Optional so the field can be added later without breaking existing logs.
+   */
+  taskLedger: TaskLedgerSchema.optional(),
+  /**
+   * Magentic-One Progress Ledger (#2278). Append-only inner-loop reflections.
+   * Most recent entry's `suggestedAction` is what `reflect()` returns. Optional
+   * for the same backward-compat reason as `taskLedger`.
+   */
+  progressLedger: z.array(ProgressLedgerEntrySchema).optional(),
   updatedAt: z.iso.datetime(),
 });
 export type StructuredTaskState = z.infer<typeof StructuredTaskStateSchema>;
@@ -98,6 +164,19 @@ export const StructuredTaskLogEntrySchema = z.discriminatedUnion('event', [
     event: z.literal('position'),
     ts: z.iso.datetime(),
     position: TaskPositionSchema,
+  }),
+  // Magentic-One Task Ledger replacement event — the outer loop revises the
+  // entire ledger atomically when replanning. Always replaces, never partial.
+  z.object({
+    event: z.literal('task_ledger'),
+    ts: z.iso.datetime(),
+    ledger: TaskLedgerSchema,
+  }),
+  // Magentic-One Progress Ledger append event — one self-reflection per step.
+  z.object({
+    event: z.literal('progress_ledger'),
+    ts: z.iso.datetime(),
+    entry: ProgressLedgerEntrySchema,
   }),
 ]);
 export type StructuredTaskLogEntry = z.infer<typeof StructuredTaskLogEntrySchema>;

--- a/packages/nexus-agents/src/context/structured-task-state.test.ts
+++ b/packages/nexus-agents/src/context/structured-task-state.test.ts
@@ -9,14 +9,22 @@ import * as os from 'node:os';
 import {
   appendBlocker,
   appendDecision,
+  appendProgressLedgerEntry,
   initTaskState,
   readTaskState,
   reduceLogEntries,
+  reflect,
   resolveBlocker,
   updatePosition,
   updateStage,
+  updateTaskLedger,
 } from './structured-task-state.js';
-import type { StructuredTaskLogEntry, StructuredTaskState } from './structured-task-state-types.js';
+import type {
+  ProgressLedgerEntry,
+  StructuredTaskLogEntry,
+  StructuredTaskState,
+  TaskLedger,
+} from './structured-task-state-types.js';
 
 let tmpDir: string;
 
@@ -219,5 +227,133 @@ describe('malformed log resilience', () => {
     if (r.ok) {
       expect(r.value.decisions.length).toBe(1);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Magentic-One Task Ledger + Progress Ledger (#2278)
+// ---------------------------------------------------------------------------
+
+function makeTaskLedger(updatedAt = '2026-04-28T00:00:00Z'): TaskLedger {
+  return {
+    facts: ['repo uses TypeScript', 'main is clean'],
+    guesses: ['failing test is a flake'],
+    openQuestions: ['does the new code path break under concurrent load?'],
+    updatedAt,
+  };
+}
+
+function makeProgressEntry(overrides: Partial<ProgressLedgerEntry> = {}): ProgressLedgerEntry {
+  return {
+    ts: '2026-04-28T00:01:00Z',
+    step: 'ran the tests',
+    planStillValid: true,
+    stuck: false,
+    suggestedAction: 'continue',
+    rationale: 'tests pass; proceed to PR',
+    ...overrides,
+  };
+}
+
+describe('Magentic-One Task Ledger', () => {
+  it('round-trips through replay', () => {
+    const initial = makeInitialState();
+    initTaskState(initial, tmpDir);
+    const ledger = makeTaskLedger();
+    const r = updateTaskLedger('task-1', ledger, tmpDir);
+    expect(r.ok).toBe(true);
+
+    const read = readTaskState('task-1', tmpDir);
+    expect(read.ok).toBe(true);
+    if (read.ok) {
+      expect(read.value.taskLedger).toEqual(ledger);
+      expect(read.value.updatedAt).toBe('2026-04-28T00:00:00Z');
+    }
+  });
+
+  it('replaces atomically — most recent ledger wins', () => {
+    const initial = makeInitialState();
+    initTaskState(initial, tmpDir);
+    updateTaskLedger('task-1', makeTaskLedger('2026-04-28T00:00:00Z'), tmpDir);
+    const revised: TaskLedger = {
+      facts: ['repo uses TypeScript', 'main is clean', 'concurrent test passes'],
+      guesses: [],
+      openQuestions: [],
+      updatedAt: '2026-04-28T00:05:00Z',
+    };
+    updateTaskLedger('task-1', revised, tmpDir);
+
+    const read = readTaskState('task-1', tmpDir);
+    expect(read.ok).toBe(true);
+    if (read.ok) {
+      expect(read.value.taskLedger).toEqual(revised);
+    }
+  });
+});
+
+describe('Magentic-One Progress Ledger', () => {
+  it('appends entries in order', () => {
+    initTaskState(makeInitialState(), tmpDir);
+    appendProgressLedgerEntry(
+      'task-1',
+      makeProgressEntry({ ts: '2026-04-28T00:01:00Z', step: 'first step' }),
+      tmpDir
+    );
+    appendProgressLedgerEntry(
+      'task-1',
+      makeProgressEntry({
+        ts: '2026-04-28T00:02:00Z',
+        step: 'second step',
+        suggestedAction: 'revise_plan',
+        stuck: true,
+        rationale: 'tests are flaking; replan',
+      }),
+      tmpDir
+    );
+
+    const read = readTaskState('task-1', tmpDir);
+    expect(read.ok).toBe(true);
+    if (read.ok) {
+      expect(read.value.progressLedger?.length).toBe(2);
+      expect(read.value.progressLedger?.[0]?.step).toBe('first step');
+      expect(read.value.progressLedger?.[1]?.suggestedAction).toBe('revise_plan');
+    }
+  });
+});
+
+describe('reflect()', () => {
+  it("returns 'continue' when no progress-ledger entries exist yet", () => {
+    initTaskState(makeInitialState(), tmpDir);
+    const r = reflect('task-1', tmpDir);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe('continue');
+  });
+
+  it('returns the most recent entry suggested action', () => {
+    initTaskState(makeInitialState(), tmpDir);
+    appendProgressLedgerEntry(
+      'task-1',
+      makeProgressEntry({ ts: '2026-04-28T00:01:00Z', suggestedAction: 'continue' }),
+      tmpDir
+    );
+    appendProgressLedgerEntry(
+      'task-1',
+      makeProgressEntry({
+        ts: '2026-04-28T00:02:00Z',
+        suggestedAction: 'escalate_to_human',
+        stuck: true,
+        rationale: 'three replans without progress',
+      }),
+      tmpDir
+    );
+
+    const r = reflect('task-1', tmpDir);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe('escalate_to_human');
+  });
+
+  it('errors cleanly when the task log does not exist', () => {
+    const r = reflect('does-not-exist', tmpDir);
+    expect(r.ok).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/context/structured-task-state.ts
+++ b/packages/nexus-agents/src/context/structured-task-state.ts
@@ -22,10 +22,13 @@ import { ok, err } from '../core/result.js';
 import { createLogger } from '../core/logger.js';
 import {
   StructuredTaskLogEntrySchema,
+  type ProgressLedgerEntry,
+  type ReflectAction,
   type StructuredTaskLogEntry,
   type StructuredTaskState,
   type TaskBlocker,
   type TaskDecision,
+  type TaskLedger,
   type TaskPosition,
   type TaskStage,
 } from './structured-task-state-types.js';
@@ -146,6 +149,47 @@ export function updatePosition(
 }
 
 /**
+ * Replace the Magentic-One Task Ledger atomically (#2278). The outer loop calls
+ * this when it replans — facts/guesses/openQuestions are revised together so
+ * downstream reflections are reading a consistent set.
+ */
+export function updateTaskLedger(
+  taskId: string,
+  ledger: TaskLedger,
+  customDir?: string
+): Result<void, Error> {
+  return appendLogEntry(taskId, { event: 'task_ledger', ts: ledger.updatedAt, ledger }, customDir);
+}
+
+/**
+ * Append a Magentic-One Progress Ledger entry (#2278). Inner-loop reflection
+ * after a step: was the plan still valid, are we stuck, what to do next.
+ */
+export function appendProgressLedgerEntry(
+  taskId: string,
+  entry: ProgressLedgerEntry,
+  customDir?: string
+): Result<void, Error> {
+  return appendLogEntry(taskId, { event: 'progress_ledger', ts: entry.ts, entry }, customDir);
+}
+
+/**
+ * Read the most recent ProgressLedger entry's suggested action — what
+ * `Orchestrator.reflect()` returns. Returns `'continue'` when no progress-ledger
+ * entries exist yet (default to "no reflection has flagged a problem"), and an
+ * error if the task log itself can't be read.
+ */
+export function reflect(taskId: string, customDir?: string): Result<ReflectAction, Error> {
+  const stateResult = readTaskState(taskId, customDir);
+  if (!stateResult.ok) return err(stateResult.error);
+  const ledger = stateResult.value.progressLedger;
+  if (ledger === undefined || ledger.length === 0) return ok('continue');
+  const last = ledger[ledger.length - 1];
+  if (last === undefined) return ok('continue');
+  return ok(last.suggestedAction);
+}
+
+/**
  * Read the log file and reduce it to the current state snapshot.
  *
  * Returns `err` when the file doesn't exist or no `init` entry is
@@ -258,5 +302,13 @@ function applyLogEntry(
       return { ...state, stage: entry.stage, updatedAt: entry.ts };
     case 'position':
       return { ...state, position: entry.position, updatedAt: entry.ts };
+    case 'task_ledger':
+      return { ...state, taskLedger: entry.ledger, updatedAt: entry.ts };
+    case 'progress_ledger':
+      return {
+        ...state,
+        progressLedger: [...(state.progressLedger ?? []), entry.entry],
+        updatedAt: entry.ts,
+      };
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/query-task-state-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/query-task-state-tool.ts
@@ -71,8 +71,10 @@ export function registerQueryTaskStateTool(server: McpServer, deps: QueryTaskSta
 
   const description =
     'Read the structured state log for a task ID and return the current ' +
-    'snapshot. Structured state is only written when NEXUS_TASK_STATE_ENABLED=1 ' +
-    'was set during the orchestrate invocation.';
+    'snapshot. Includes Magentic-One Task Ledger (facts/guesses/openQuestions) ' +
+    'and Progress Ledger (per-step reflections with suggestedAction) when ' +
+    'orchestrators have written them. Structured state is only written when ' +
+    'NEXUS_TASK_STATE_ENABLED=1 was set during the orchestrate invocation.';
 
   const secureHandler = createSecureHandler(queryTaskStateHandler, {
     toolName: 'query_task_state',


### PR DESCRIPTION
## Summary

Closes #2278 — the audit's #1 priority pattern from the #2232 build-vs-buy audit. Ports AutoGen's Magentic-One two-ledger pattern in TypeScript on top of our existing structured task-state log.

This is the only component where another framework had a meaningfully better primitive than ours; the rest of the audit recommended building.

## What ships

**Types** (`structured-task-state-types.ts`):

- `TaskLedger` — outer-loop facts/guesses/openQuestions, replaced atomically when replanning
- `ProgressLedgerEntry` — inner-loop reflection: `planStillValid`, `stuck`, `suggestedAction`, `rationale`
- `ReflectAction` — `continue | revise_plan | escalate_to_human | abort`
- Two new log-entry events: `task_ledger` (replace) + `progress_ledger` (append)
- Both fields optional on `StructuredTaskState` so existing logs remain valid

**Writer** (`structured-task-state.ts`):

- `updateTaskLedger(taskId, ledger)` — atomic outer-loop replacement
- `appendProgressLedgerEntry(taskId, entry)` — inner-loop append
- `reflect(taskId)` — returns the most-recent `suggestedAction`, defaults to `'continue'`. Same Result pattern as the rest of the module

**MCP tool**: `query_task_state` description updated to mention the ledgers (return type already covers them; no API change).

## What this does NOT do

- **Doesn't wire `reflect()` into the existing `orchestrate` flow.** That touches control flow, not the data model — a separate concern. Filing as a follow-up.
- **Doesn't add LLM-driven reflection generation.** This PR ships the primitives; adding "ask a model to produce the next ProgressLedgerEntry" is an additive layer per YAGNI.

The audit issue's acceptance criteria specifically split data model from wiring, and this PR ships the data model.

## Tests

6 new tests, 18 total now passing (12 original):

- TaskLedger round-trip through replay
- TaskLedger atomic replacement (latest wins)
- ProgressLedger append ordering
- `reflect()` defaults to `'continue'` when empty
- `reflect()` returns most-recent suggestedAction
- `reflect()` errors cleanly when log doesn't exist

## Acceptance criteria from #2278

- [x] `TaskLedger` and `ProgressLedger` types exported from a stable path
- [x] `reflect()` method implemented + tested (function-level — clean Result return, matches the module's style)
- [ ] At least one workflow uses `reflect()` — **deferred to follow-up** (data layer is the prerequisite; wiring is a separate concern that touches control flow)
- [x] `query_task_state` returns ledger contents (no API change required; existing typed return covers it)
- [x] Documentation cites AutoGen Magentic-One as source

## Test plan

- [x] `pnpm typecheck` clean
- [x] All 18 tests pass locally
- [ ] CI green

## Refs

- [AutoGen Magentic-One docs](https://microsoft.github.io/autogen/) — pattern source
- #2232 audit comment — context for why this is the highest-priority borrow
- v2.50 task-state log infrastructure — what this builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)