### PR TITLE
feat(audit): hash-chain verifyChain() function (closes #2281)

### DIFF
--- a/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
+++ b/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for verifyChain (#2281). Distinct from audit-logger.test.ts because
+ * those tests stub `node:crypto` to a deterministic fake hash; here we need
+ * real SHA-256 to validate round-trips.
+ *
+ * @module audit/audit-chain-verify.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import { verifyChain } from './audit-logger.js';
+import type { AuditEvent } from './audit-types.js';
+
+function realHash(event: AuditEvent): string {
+  const data = JSON.stringify({
+    id: event.id,
+    timestamp: event.timestamp,
+    category: event.category,
+    action: event.action,
+    outcome: event.outcome,
+    actor: event.actor,
+    previousHash: event.previousHash,
+  });
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function makeEvent(
+  id: string,
+  previousHash: string | undefined,
+  overrides: Partial<AuditEvent> = {}
+): AuditEvent {
+  const base: AuditEvent = {
+    id,
+    version: '1.0',
+    timestamp: '2026-04-28T00:00:00.000Z',
+    timestampMs: 1745798400000,
+    category: 'system',
+    severity: 'info',
+    outcome: 'success',
+    action: 'test.action',
+    actor: { type: 'system', id: 'nexus-agents', name: 'Test System' },
+    previousHash,
+    ...overrides,
+  };
+  return { ...base, hash: realHash(base) };
+}
+
+function chain(count: number): AuditEvent[] {
+  const events: AuditEvent[] = [];
+  let prevHash: string | undefined = undefined;
+  for (let i = 0; i < count; i++) {
+    const e = makeEvent(`aud_${String(i)}`, prevHash);
+    events.push(e);
+    prevHash = e.hash;
+  }
+  return events;
+}
+
+describe('verifyChain', () => {
+  it('returns ok for an empty chain', () => {
+    const r = verifyChain([]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.eventCount).toBe(0);
+  });
+
+  it('validates a clean 5-event chain', () => {
+    const r = verifyChain(chain(5));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.eventCount).toBe(5);
+  });
+
+  it('treats a log without hashes as un-chained (legacy compat)', () => {
+    const events: AuditEvent[] = [
+      {
+        id: 'aud_0',
+        version: '1.0',
+        timestamp: '2026-04-28T00:00:00.000Z',
+        timestampMs: 1745798400000,
+        category: 'system',
+        severity: 'info',
+        outcome: 'success',
+        action: 'test',
+        actor: { type: 'system', id: 'sys' },
+      },
+    ];
+    const r = verifyChain(events);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.eventCount).toBe(1);
+  });
+
+  it('detects hash_mismatch when an event body is tampered', () => {
+    const events = chain(3);
+    // Tamper the action field of event 1 without recomputing hash.
+    const tampered = { ...events[1]!, action: 'malicious.action' };
+    const r = verifyChain([events[0]!, tampered, events[2]!]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('hash_mismatch');
+      expect(r.eventIndex).toBe(1);
+    }
+  });
+
+  it('detects previous_hash_mismatch when an event is removed mid-chain', () => {
+    const events = chain(4);
+    // Drop event 2; event 3's previousHash now points to a missing predecessor.
+    const r = verifyChain([events[0]!, events[1]!, events[3]!]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('previous_hash_mismatch');
+      expect(r.eventIndex).toBe(2);
+    }
+  });
+
+  it('detects missing_hash when chain starts hashed but a later event has no hash', () => {
+    const events = chain(3);
+    const noHash = { ...events[1]! };
+    delete (noHash as { hash?: string }).hash;
+    const r = verifyChain([events[0]!, noHash, events[2]!]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('missing_hash');
+      expect(r.eventIndex).toBe(1);
+    }
+  });
+
+  it('returns the first detected tamper, not subsequent ones', () => {
+    const events = chain(4);
+    const tamperedAtTwo = { ...events[2]!, action: 'tampered' };
+    // Even though events[3] would also fail (its previousHash points to events[2] hash,
+    // but events[2] hash is now stale relative to its tampered body), the function
+    // should report event index 2 first.
+    const r = verifyChain([events[0]!, events[1]!, tamperedAtTwo, events[3]!]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.eventIndex).toBe(2);
+    }
+  });
+
+  it('reports a clear detail string with the failing event id', () => {
+    const events = chain(2);
+    const tampered = { ...events[1]!, action: 'evil' };
+    const r = verifyChain([events[0]!, tampered]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.eventId).toBe('aud_1');
+      expect(r.detail).toContain('does not match');
+    }
+  });
+});

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -56,6 +56,92 @@ function computeEventHash(event: AuditEvent): string {
 }
 
 // ============================================================================
+// Hash Chain Verification (#2281)
+// ============================================================================
+
+/**
+ * Discriminated result from `verifyChain()`. Either the chain validates cleanly,
+ * or one of three named tampering signals fires at a specific event index.
+ */
+export type ChainVerification =
+  | { ok: true; eventCount: number }
+  | {
+      ok: false;
+      reason: 'hash_mismatch' | 'previous_hash_mismatch' | 'missing_hash';
+      eventIndex: number;
+      eventId: string;
+      detail: string;
+    };
+
+/** Per-event check; null when the event passes. Extracted to keep verifyChain under the complexity cap. */
+function verifyEvent(
+  event: AuditEvent,
+  index: number,
+  priorHash: string | undefined
+): ChainVerification | null {
+  if (event.hash === undefined) {
+    return {
+      ok: false,
+      reason: 'missing_hash',
+      eventIndex: index,
+      eventId: event.id,
+      detail: `event at index ${String(index)} has no hash field but the chain started hashed`,
+    };
+  }
+  if (index > 0 && event.previousHash !== priorHash) {
+    return {
+      ok: false,
+      reason: 'previous_hash_mismatch',
+      eventIndex: index,
+      eventId: event.id,
+      detail: `event at index ${String(index)} previousHash=${event.previousHash ?? '(missing)'} does not match prior event hash=${priorHash ?? '(missing)'}`,
+    };
+  }
+  const recomputed = computeEventHash(event);
+  if (recomputed !== event.hash) {
+    return {
+      ok: false,
+      reason: 'hash_mismatch',
+      eventIndex: index,
+      eventId: event.id,
+      detail: `event at index ${String(index)} stored hash=${event.hash} does not match recomputed=${recomputed}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Verify a hash-chained sequence of audit events. Walks the array in order and
+ * checks (a) each event's `hash` field matches a recomputation of its content,
+ * (b) each event's `previousHash` matches the prior event's `hash`, and (c) no
+ * event in a hash-chained log is missing its `hash`. Returns the first
+ * detected tampering signal — does NOT continue past the first failure, since
+ * one tamper invalidates everything downstream.
+ *
+ * Backward compat: events written when `enableHashChain: false` carry no `hash`
+ * field. If the FIRST event has no `hash`, the entire batch is treated as
+ * un-chained and verification short-circuits to `{ok: true}`. If hash fields
+ * appear partway through (mixed-mode log), `missing_hash` fires.
+ *
+ * @param events - Sequence of AuditEvent in append order
+ * @returns ChainVerification result
+ */
+export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
+  if (events.length === 0) return { ok: true, eventCount: 0 };
+  if (events[0]?.hash === undefined) return { ok: true, eventCount: events.length };
+
+  let priorHash: string | undefined = undefined;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (event === undefined) continue;
+    const failure = verifyEvent(event, i, priorHash);
+    if (failure !== null) return failure;
+    priorHash = event.hash;
+  }
+  return { ok: true, eventCount: events.length };
+}
+
+// ============================================================================
 // System Actor (for internal events)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Closes #2281 from the #2232 audit follow-ups.

**Discovered while implementing this**: the hash-chain primitive is *already shipped* in `audit-logger.ts:45-56` (SHA-256 computation) + `audit-logger.ts:148-154` (chain via previousHash) + `AuditEventSchema` (hash/previousHash fields) + `enableHashChain: true` default. The audit committee's framing of "build hash-chained store" was based on incomplete repo recon — the chain exists.

The **actual gap** is a public verifier. Without it, the chain's tamper-evidence value is theoretical — nothing reads it back and validates.

This PR ships the verifier.

## What ships

- `verifyChain(events): ChainVerification` — walks events in order, recomputes SHA-256 from each event's content + previousHash, compares against the stored hash field
- Three named tamper signals: `hash_mismatch`, `previous_hash_mismatch`, `missing_hash`
- First-failure-wins (one tamper invalidates everything downstream; reporting one signal at a known index is more actionable than aggregating)
- Backward compatible: un-chained legacy logs short-circuit to `{ok: true}`; mixed-mode trips `missing_hash`

## Deferred to follow-ups (not in this PR)

- **OTEL export to customer collectors** (Splunk/Datadog/Loki) — its own adapter layer
- **Kill-switch wiring** to access-policy enforce mode — depends on #2279 + #2077 landing first
- **`docs/architecture/AUDIT_TRAIL.md`** — better authored alongside the OTEL PR since it covers both pieces

The verifier alone closes the most actionable gap. Without it, the existing chain is decorative.

## Tests

`packages/nexus-agents/src/audit/audit-chain-verify.test.ts` — 8 new tests:

- empty chain
- clean 5-event chain
- un-hashed legacy log (backward compat)
- tampered event body → `hash_mismatch`
- removed mid-chain event → `previous_hash_mismatch`
- mixed-mode log → `missing_hash`
- first-failure-wins
- detail string includes failing event id

All 166 existing audit tests still pass. Separate test file because `audit-logger.test.ts` mocks `node:crypto` to deterministic fake-hashes; verifier needs real SHA-256.

## Test plan

- [x] `pnpm typecheck` clean
- [x] All 174 audit tests pass (166 existing + 8 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)