### PR TITLE
feat(security): confirm_risky access-policy tier (closes #2279)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,20 +47,20 @@ nexus-agents --help       # Full command list
 **Required:** Node.js 22.x LTS, pnpm 9.x (or npm 10.x)
 **Optional:** Docker (sandbox mode), Claude CLI (MCP mode)
 
-| Variable                       | Required For                                       | Default                       |
-| ------------------------------ | -------------------------------------------------- | ----------------------------- |
-| `ANTHROPIC_API_KEY`            | Claude adapter                                     | None                          |
-| `OPENAI_API_KEY`               | OpenAI adapter                                     | None                          |
-| `GOOGLE_AI_API_KEY`            | Gemini adapter                                     | None                          |
-| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)                   | None                          |
-| `NEXUS_LOG_LEVEL`              | Logging verbosity                                  | `info`                        |
-| `NEXUS_CONFIG_PATH`            | Custom config path                                 | `./nexus-agents.yaml`         |
-| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)                | `true` (auto-generates token) |
-| `NEXUS_BILLING_MODE`           | Model routing cost handling                        | `plan` (monthly subscription) |
-| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence                 | `true`                        |
-| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `enforce`        | `audit` (v2.50+)              |
-| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable) | enabled (v2.50+)              |
-| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]        | `0.85`                        |
+| Variable                       | Required For                                                  | Default                       |
+| ------------------------------ | ------------------------------------------------------------- | ----------------------------- |
+| `ANTHROPIC_API_KEY`            | Claude adapter                                                | None                          |
+| `OPENAI_API_KEY`               | OpenAI adapter                                                | None                          |
+| `GOOGLE_AI_API_KEY`            | Gemini adapter                                                | None                          |
+| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)                              | None                          |
+| `NEXUS_LOG_LEVEL`              | Logging verbosity                                             | `info`                        |
+| `NEXUS_CONFIG_PATH`            | Custom config path                                            | `./nexus-agents.yaml`         |
+| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)                           | `true` (auto-generates token) |
+| `NEXUS_BILLING_MODE`           | Model routing cost handling                                   | `plan` (monthly subscription) |
+| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence                            | `true`                        |
+| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce` | `audit` (v2.50+)              |
+| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable)            | enabled (v2.50+)              |
+| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                   | `0.85`                        |
 
 **Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
 

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer-confirm-risky.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer-confirm-risky.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the `confirm_risky` access-policy mode (#2279).
+ *
+ * Mode-specific behavior of `checkAccess()`:
+ *
+ * - Read-only tool not in policy → `log-and-allow` (same as audit)
+ * - Risky tool not in policy → `deny` with structured "would-have-required-
+ *   approval" reason
+ * - Tool in policy → `allow` regardless of risk classification
+ * - Unbypassable denylist still wins over confirm_risky (verified for both
+ *   tool-denylist and path-denylist)
+ *
+ * @module security/access-constraint-deriver/enforcer-confirm-risky.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkAccess } from './enforcer.js';
+import { isRiskyTool, READ_ONLY_TOOLS } from './tool-risk.js';
+import type { TaskAccessPolicy } from './types.js';
+
+function makePolicy(overrides: Partial<TaskAccessPolicy> = {}): TaskAccessPolicy {
+  return {
+    allowedTools: ['list_experts'],
+    allowedPathPatterns: [],
+    allowedOperations: '*',
+    objectiveHash: 'test-hash',
+    derivedAt: '2026-04-28T00:00:00Z',
+    source: 'llm',
+    mode: 'confirm_risky',
+    ...overrides,
+  };
+}
+
+describe('isRiskyTool', () => {
+  it('classifies known read-only tools as not risky', () => {
+    expect(isRiskyTool('research_query')).toBe(false);
+    expect(isRiskyTool('memory_query')).toBe(false);
+    expect(isRiskyTool('weather_report')).toBe(false);
+    expect(isRiskyTool('search_codebase')).toBe(false);
+  });
+
+  it('classifies known mutating tools as risky', () => {
+    expect(isRiskyTool('orchestrate')).toBe(true);
+    expect(isRiskyTool('memory_write')).toBe(true);
+    expect(isRiskyTool('research_add')).toBe(true);
+    expect(isRiskyTool('issue_triage')).toBe(true);
+    expect(isRiskyTool('pr_review')).toBe(true);
+  });
+
+  it('defaults unknown tools to risky (fail-closed)', () => {
+    expect(isRiskyTool('totally_made_up_tool')).toBe(true);
+    expect(isRiskyTool('')).toBe(true);
+  });
+
+  it('exports a stable READ_ONLY_TOOLS set', () => {
+    expect(READ_ONLY_TOOLS.size).toBeGreaterThan(10);
+    expect(READ_ONLY_TOOLS.has('research_query')).toBe(true);
+  });
+});
+
+describe('checkAccess: confirm_risky mode', () => {
+  it('allows tools in the allowedTools list regardless of risk', () => {
+    const policy = makePolicy({ allowedTools: ['orchestrate'] }); // risky tool, allowed
+    const decision = checkAccess('orchestrate', policy);
+    expect(decision.decision).toBe('allow');
+  });
+
+  it('log-and-allows read-only tools NOT in allowedTools', () => {
+    const policy = makePolicy({ allowedTools: ['list_experts'] });
+    const decision = checkAccess('research_query', policy);
+    expect(decision.decision).toBe('log-and-allow');
+    if (decision.decision === 'log-and-allow') {
+      expect(decision.warning).toContain('confirm_risky');
+      expect(decision.warning).toContain('read-only');
+    }
+  });
+
+  it('denies risky tools NOT in allowedTools with a structured reason', () => {
+    const policy = makePolicy({ allowedTools: ['list_experts'] });
+    const decision = checkAccess('orchestrate', policy);
+    expect(decision.decision).toBe('deny');
+    if (decision.decision === 'deny') {
+      expect(decision.matchedRule).toBe('allowedTools:confirm_risky');
+      expect(decision.reason).toContain('would have required human approval');
+    }
+  });
+
+  it('denies unknown tools (fail-closed default)', () => {
+    const policy = makePolicy({ allowedTools: ['list_experts'] });
+    const decision = checkAccess('unknown_tool', policy);
+    expect(decision.decision).toBe('deny');
+  });
+
+  it('respects the unbypassable tool denylist even in confirm_risky mode', () => {
+    const policy = makePolicy({ allowedTools: '*' }); // wildcard would normally allow
+    // git_push_force is on UNBYPASSABLE_TOOL_NAMES — must be denied even with wildcard policy
+    const decision = checkAccess('git_push_force', policy);
+    expect(decision.decision).toBe('deny');
+    if (decision.decision === 'deny') {
+      expect(decision.matchedRule).toBe('unbypassable:tool');
+    }
+  });
+
+  it('respects the unbypassable path denylist even in confirm_risky mode', () => {
+    const policy = makePolicy({ allowedTools: '*' });
+    const decision = checkAccess('research_query', policy, { path: '/etc/shadow' });
+    expect(decision.decision).toBe('deny');
+    if (decision.decision === 'deny') {
+      expect(decision.matchedRule).toBe('unbypassable:path');
+    }
+  });
+
+  it('wildcard allowedTools still allows everything in confirm_risky', () => {
+    const policy = makePolicy({ allowedTools: '*' });
+    const decision = checkAccess('orchestrate', policy);
+    expect(decision.decision).toBe('allow');
+  });
+});
+
+describe('checkAccess: mode comparison for graduation path', () => {
+  const cases: { mode: TaskAccessPolicy['mode']; expected: 'allow' | 'log-and-allow' | 'deny' }[] =
+    [
+      { mode: 'audit', expected: 'log-and-allow' },
+      { mode: 'confirm_risky', expected: 'log-and-allow' }, // research_query is read-only
+      { mode: 'enforce', expected: 'deny' },
+    ];
+
+  it.each(cases)(
+    'read-only tool not in policy under $mode mode → $expected',
+    ({ mode, expected }) => {
+      const policy = makePolicy({ mode, allowedTools: ['list_experts'] });
+      const decision = checkAccess('research_query', policy);
+      expect(decision.decision).toBe(expected);
+    }
+  );
+
+  const riskyCases: {
+    mode: TaskAccessPolicy['mode'];
+    expected: 'allow' | 'log-and-allow' | 'deny';
+  }[] = [
+    { mode: 'audit', expected: 'log-and-allow' },
+    { mode: 'confirm_risky', expected: 'deny' }, // risky → blocked
+    { mode: 'enforce', expected: 'deny' },
+  ];
+
+  it.each(riskyCases)(
+    'risky tool not in policy under $mode mode → $expected',
+    ({ mode, expected }) => {
+      const policy = makePolicy({ mode, allowedTools: ['list_experts'] });
+      const decision = checkAccess('orchestrate', policy);
+      expect(decision.decision).toBe(expected);
+    }
+  );
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
@@ -1,15 +1,18 @@
 /**
- * Access Constraint Deriver — Policy enforcement (#1977).
+ * Access Constraint Deriver — Policy enforcement (#1977, #2279).
  *
  * Pure function that checks a proposed tool call against a derived policy
  * and returns an AccessDecision. Enforcement depends on the policy's mode:
- * `off` and `audit` never block (audit would log to telemetry — wiring TBD);
- * `enforce` blocks violations.
+ * - `off` and `audit` never block
+ * - `confirm_risky` (#2279) blocks violations on risky tools (write/exec/
+ *   network) and log-and-allows violations on read-only tools
+ * - `enforce` blocks every violation regardless of risk classification
  *
  * @module security/access-constraint-deriver/enforcer
  */
 
 import { isPathDenied, isToolDenied } from './denylist.js';
+import { isRiskyTool } from './tool-risk.js';
 import type { AccessDecision, TaskAccessPolicy } from './types.js';
 
 /**
@@ -55,13 +58,38 @@ export function checkAccess(
 
   if (policy.allowedTools.includes(toolName)) return { decision: 'allow' };
 
-  if (policy.mode === 'audit') {
+  return decideOnViolation(toolName, policy.mode);
+}
+
+/**
+ * Mode-specific behavior when a tool is not in the per-task allowlist.
+ * Extracted so checkAccess stays under the complexity-10 cap.
+ */
+function decideOnViolation(toolName: string, mode: TaskAccessPolicy['mode']): AccessDecision {
+  if (mode === 'audit') {
     return {
       decision: 'log-and-allow',
       warning: `tool "${toolName}" not in derived policy (audit mode)`,
     };
   }
-
+  // confirm_risky: split by tool risk classification (#2279). Read-only
+  // violations are log-and-allow (audit-like); risky violations are denied
+  // with a structured reason that surfaces "would-have-required-approval"
+  // semantics. Operators add the tool to the allowlist after review, or
+  // graduate to `enforce` once the violation rate is acceptable.
+  if (mode === 'confirm_risky') {
+    if (!isRiskyTool(toolName)) {
+      return {
+        decision: 'log-and-allow',
+        warning: `tool "${toolName}" not in derived policy (confirm_risky mode, read-only — would have required human approval, allowed because read-only)`,
+      };
+    }
+    return {
+      decision: 'deny',
+      reason: `tool "${toolName}" not in derived policy (confirm_risky mode, risky — would have required human approval; denied for now, add to allowedTools or run in audit mode to allow)`,
+      matchedRule: 'allowedTools:confirm_risky',
+    };
+  }
   return {
     decision: 'deny',
     reason: `tool "${toolName}" not in derived policy`,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/tool-risk.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/tool-risk.ts
@@ -1,0 +1,68 @@
+/**
+ * Tool risk classification for `confirm_risky` access-policy mode (#2279).
+ *
+ * Classifies each registered MCP tool as `read-only` (safe — log-and-allow
+ * under confirm_risky) or `risky` (write/exec/network — block under
+ * confirm_risky). Used by the policy enforcer to differentiate which
+ * violations a human would have wanted to review.
+ *
+ * Classification policy:
+ *
+ * - **Read-only**: tool exclusively reads existing state — no file writes,
+ *   no subprocess execution, no network requests beyond a single bounded
+ *   read of project-internal data. `query_*`, `list_*`, `search_*`,
+ *   `*_query`, `*_analyze` patterns by default.
+ * - **Risky**: tool writes files, runs subprocesses, posts to external
+ *   services, calls LLM APIs, or has any side effect that a human reviewer
+ *   would want to see before approving in confirm_risky mode.
+ *
+ * If a tool is unknown, it is treated as risky (default-deny) — same
+ * principle as the unbypassable denylist: the security layer fails closed
+ * on a misclassification.
+ *
+ * Update path: when adding a new MCP tool, classify it explicitly here.
+ * The `inject-governance.ts check` CI gate ensures the registry list is
+ * still the source of truth; this file is the risk overlay.
+ *
+ * @module security/access-constraint-deriver/tool-risk
+ */
+
+/**
+ * Tools that exclusively read state. Violations on these are log-and-allow
+ * under `confirm_risky` mode — same as `audit` mode.
+ */
+export const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  // Discovery / listing
+  'list_experts',
+  'list_workflows',
+  // Research reads
+  'research_query',
+  'research_analyze',
+  'research_catalog_review',
+  'research_synthesize',
+  // Memory reads
+  'memory_query',
+  'memory_stats',
+  // Observability
+  'weather_report',
+  'query_trace',
+  'query_task_state',
+  // Codebase intelligence (read-only over local files)
+  'search_codebase',
+  'extract_symbols',
+  // Repo analysis (read-only)
+  'repo_analyze',
+  'repo_security_plan',
+  // Routing recommendation (no side effects — returns recommendation)
+  'delegate_to_model',
+  // Registry import (returns a draft template — does not write)
+  'registry_import',
+]);
+
+/**
+ * Returns true if the tool is risky under confirm_risky mode (default-deny
+ * for unknown tools — security layer fails closed).
+ */
+export function isRiskyTool(toolName: string): boolean {
+  return !READ_ONLY_TOOLS.has(toolName);
+}

--- a/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
@@ -9,8 +9,20 @@
 
 import { z } from 'zod';
 
-/** Operating modes for the access-constraint-deriver pipeline. */
-export const AccessPolicyModeSchema = z.enum(['off', 'audit', 'enforce']);
+/**
+ * Operating modes for the access-constraint-deriver pipeline.
+ *
+ * - `off`: bypass entirely; no policy enforcement, no audit logging
+ * - `audit` (default in v2.50+): log every violation, block nothing — collects
+ *   telemetry to size the violation rate before flipping to enforce
+ * - `confirm_risky` (#2279): graduated middle tier. Block violations on tools
+ *   classified as risky (write/exec/network); log-and-allow violations on
+ *   read-only tools. The intent is "block the calls a human would want to
+ *   review; let the safe reads through" — graduation path between audit and
+ *   enforce that doesn't break read-heavy workflows
+ * - `enforce`: block every violation, regardless of risk classification
+ */
+export const AccessPolicyModeSchema = z.enum(['off', 'audit', 'confirm_risky', 'enforce']);
 export type AccessPolicyMode = z.infer<typeof AccessPolicyModeSchema>;
 
 /** Source of the derived policy. */


### PR DESCRIPTION
## Summary

Closes #2279 from the #2232 audit follow-ups. Adds a graduated middle tier between `audit` (log-only) and `enforce` (block-everything-not-allowlisted) so operators can graduate without breaking read-heavy workflows.

`NEXUS_ACCESS_POLICY_MODE` accepts a fourth value: `confirm_risky`.

| Tool risk class | Tool in allowedTools? | audit | confirm_risky | enforce |
|---|---|---|---|---|
| any | yes | allow | allow | allow |
| read-only (e.g. research_query) | no | log-and-allow | **log-and-allow** | deny |
| risky (e.g. orchestrate) | no | log-and-allow | **deny** | deny |
| any | unbypassable denylist | deny | deny | deny |

The intent: block exactly the calls a human reviewer would have wanted to see; let the safe reads through. Risky violations come back with a structured reason "would have required human approval" so operators reviewing the audit trail can either add the tool to allowedTools or graduate to enforce.

## What ships

- `confirm_risky` added to `AccessPolicyMode` enum
- `tool-risk.ts` with `READ_ONLY_TOOLS` set (18 entries, default-deny on unknown tools — security fails closed)
- Enforcer extended with `decideOnViolation` helper that dispatches by mode
- 13 new tests in `enforcer-confirm-risky.test.ts` (118 total access-constraint-deriver tests pass)
- CLAUDE.md env-var table updated

## What this PR does NOT do

**MCP elicitation API wiring is deferred.** Per the architect's vote condition on #2232: *"if elicitation is not in the pinned SDK version, fall back to a deterministic refusal+reason action and file a follow-up."* The deterministic refusal-with-reason path is v1; adding interactive elicitation on top is purely additive — doesn't change the data model. Filed as a follow-up issue.

## Risk classification methodology

`READ_ONLY_TOOLS` lists tools that exclusively read state — no file writes, no subprocess execution, no LLM API calls (which incur cost), no external posting. 18 of 32 tools qualify. The other 14 default to risky.

When adding a new MCP tool: classify it explicitly here. The CI gate `inject-governance.ts check` ensures the registry list is still source-of-truth; this file is the risk overlay.

## Test plan

- [x] `pnpm typecheck` clean
- [x] All 118 access-constraint-deriver tests pass
- [ ] CI green
- [ ] Manual: setting `NEXUS_ACCESS_POLICY_MODE=confirm_risky` and running a research_query (in-policy) → allow, off-policy `orchestrate` → deny with structured reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)