### PR TITLE
feat(cli): NEXUS_DATA_DIR env var for portable / sandbox installs (#2302)

### DIFF
--- a/.changeset/nexus-data-dir-env.md
+++ b/.changeset/nexus-data-dir-env.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': minor
+---
+
+feat(cli): `NEXUS_DATA_DIR` env var for portable / sandbox installs (#2302, child of #2301)
+
+Adds a single resolver `getNexusDataDir()` (in `src/config/nexus-data-dir.ts`) that returns the absolute root of nexus-agents runtime state. Resolution order:
+
+1. `$NEXUS_DATA_DIR` if set + non-empty (resolved against `process.cwd()`)
+2. `~/.nexus-agents` (zero-breakage fallback — current behavior)
+
+Refactors 11 source-file callsites that previously hardcoded `homedir() + '.nexus-agents'` (audit, doctor, sessions, model-registry, mobimem, traces, memory, voting correlations, wave checkpoints, MCP auth tokens, research auto-catalog) to derive from the resolver.
+
+`Dockerfile.sandbox` now sets `ENV NEXUS_DATA_DIR=/workspace/.nexus-agents` so a mounted workspace owns its own state — memory/learning/audit no longer leak across sandbox runs into the container's `$HOME`.
+
+Approved scope per consensus_vote 5/1 (contrarian-narrowed): explicitly does NOT include git-style ancestor walk-up discovery (CVE-2022-24765 risk class) or a `nexus-agents init --portable` command. Those are deferred to separate children of #2301 with a security design pass.
+
+Zero behavior change when env var is unset.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ nexus-agents --help       # Full command list
 | `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce` | `audit` (v2.50+)              |
 | `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable)            | enabled (v2.50+)              |
 | `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                   | `0.85`                        |
+| `NEXUS_DATA_DIR`               | Override runtime data root (memory/audit/voting/sessions/…)   | `~/.nexus-agents` (v2.60+)    |
 
 **Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
 

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -43,6 +43,13 @@ COPY --from=builder /app/packages/nexus-agents/dist /opt/nexus-agents/dist
 COPY --from=builder /app/packages/nexus-agents/package.json /opt/nexus-agents/
 COPY --from=runtime-deps /opt/nexus-agents/node_modules /opt/nexus-agents/node_modules
 
+# Redirect all runtime data (memory, learning, audit, voting, sessions,
+# checkpoints, traces) to the workspace volume so it survives sandbox
+# restarts and stays scoped to the workspace, not the container's $HOME
+# (#2302, child of #2301). Pre-create the dir so first writes don't race.
+ENV NEXUS_DATA_DIR=/workspace/.nexus-agents
+RUN mkdir -p /workspace/.nexus-agents
+
 # Create opencode config with MCP server pointing to nexus-agents
 # OpenCode reads from ~/.config/opencode/opencode.json (global config)
 RUN mkdir -p /home/agent/.config/opencode && \

--- a/packages/nexus-agents/src/agents/wave-checkpoint-persistence.ts
+++ b/packages/nexus-agents/src/agents/wave-checkpoint-persistence.ts
@@ -14,7 +14,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 import type { Result } from '../core/result.js';
 import { ok, err } from '../core/result.js';
 import { createLogger } from '../core/logger.js';
@@ -26,7 +26,7 @@ import { WaveCheckpointEntrySchema } from './wave-checkpoint-types.js';
 const logger = createLogger({ component: 'wave-checkpoint' });
 
 /** Default checkpoint directory under homedir. */
-const CHECKPOINT_DIR = path.join('.nexus-agents', 'checkpoints');
+const CHECKPOINT_SUBDIR = 'checkpoints';
 
 /** File permissions: user read/write only. */
 const FILE_MODE = 0o600;
@@ -45,7 +45,7 @@ function getCheckpointDir(customDir?: string): string {
   if (customDir !== undefined) {
     return path.resolve(customDir);
   }
-  return path.join(os.homedir(), CHECKPOINT_DIR);
+  return nexusDataPath(CHECKPOINT_SUBDIR);
 }
 
 /**

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -43,8 +43,7 @@ import { runE2EEval, formatE2EEvalResult } from './cli/e2e-eval.js';
 import { runRoutingAB, formatABReport } from './cli/routing-ab.js';
 import { runMemoryEval, formatMemoryEvalReport } from './cli/memory-eval.js';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { getNexusDataDir } from './config/nexus-data-dir.js';
 import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
 import { startServer, type OrchestratorModeOptions } from './cli-server.js';
 import {
@@ -143,7 +142,7 @@ function buildOrchestratorOptions(args: ParsedCliArgs): OrchestratorModeOptions 
 function printFirstRunHint(): void {
   const isTTY = process.stderr.isTTY;
   if (!isTTY) return;
-  const dataDir = join(homedir(), '.nexus-agents');
+  const dataDir = getNexusDataDir();
   const hasConfig = existsSync('./nexus-agents.yaml') || existsSync('./nexus-agents.yml');
   if (existsSync(dataDir) || hasConfig) return;
   process.stderr.write(

--- a/packages/nexus-agents/src/cli-server-audit.ts
+++ b/packages/nexus-agents/src/cli-server-audit.ts
@@ -7,15 +7,14 @@
  * (Source: Issue #740 Phase 2 - audit logging and security config)
  */
 
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 import type { ILogger } from './core/index.js';
 import { createAuditLogger, type AuditLogger } from './audit/index.js';
 import type { SecurityConfig, AppConfig } from './config/index.js';
+import { nexusDataPath } from './config/nexus-data-dir.js';
 import { createDefaultPolicyFirewall } from './mcp/middleware/index.js';
 
-/** Default audit log directory under ~/.nexus-agents. */
-const DEFAULT_AUDIT_DIR = join(homedir(), '.nexus-agents', 'audit');
+/** Default audit log directory under the resolved nexus data dir (#2302). */
+const DEFAULT_AUDIT_DIR = nexusDataPath('audit');
 
 /**
  * Initializes the audit logger from security configuration.

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -11,8 +11,8 @@
  */
 
 import { existsSync, readFileSync, accessSync, constants as fsConstants } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getNexusDataDir } from '../config/nexus-data-dir.js';
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import {
   isPersistenceEnabled,
@@ -486,7 +486,7 @@ export async function checkSqlite(): Promise<SqliteCheck> {
  * pipeline.
  */
 export function checkDataDirectory(): DataDirectoryCheck {
-  const rootPath = join(homedir(), '.nexus-agents');
+  const rootPath = getNexusDataDir();
   const rootExists = existsSync(rootPath);
 
   const subdirectories: DataSubdirStatus[] = DATA_SUBDIRECTORIES.map((name) => {

--- a/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.ts
@@ -7,23 +7,25 @@
  * (Source: Issue #413-#415 - Hook handlers implementation)
  */
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import {
+  getNexusDataDir as resolveNexusDataDir,
+  nexusDataPath,
+} from '../../../config/nexus-data-dir.js';
 
 /**
  * Default database path for session storage.
- * Uses ~/.nexus-agents/sessions.db
+ * Resolves to `<NEXUS_DATA_DIR>/sessions.db` (#2302).
  */
 export function getDefaultDbPath(): string {
-  return join(homedir(), '.nexus-agents', 'sessions.db');
+  return nexusDataPath('sessions.db');
 }
 
 /**
- * Gets the nexus-agents data directory path.
- * Creates ~/.nexus-agents if needed.
+ * Gets the nexus-agents data directory path (#2302).
+ * Re-exported for hook handlers; canonical source is `config/nexus-data-dir.ts`.
  */
 export function getNexusDataDir(): string {
-  return join(homedir(), '.nexus-agents');
+  return resolveNexusDataDir();
 }
 
 /**

--- a/packages/nexus-agents/src/cli/registry-command.ts
+++ b/packages/nexus-agents/src/cli/registry-command.ts
@@ -20,8 +20,8 @@
 
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 
 import {
   defaultGeneratedRegistryPath,
@@ -257,8 +257,7 @@ async function refreshCommand(options: RegistryCommandOptions): Promise<Registry
   const artifact = await fetchAndVerify(source, options.fetchImpl ?? fetch);
   if ('text' in artifact) return artifact;
 
-  const dest =
-    options.destPath ?? join(homedir(), '.nexus-agents', 'model-registry.generated.json');
+  const dest = options.destPath ?? nexusDataPath('model-registry.generated.json');
   if (options.dryRun === true) {
     return { text: formatRefreshReport('would write to', source, artifact, dest), exitCode: 0 };
   }
@@ -314,7 +313,7 @@ export function formatRegistryUsage(): string {
     '  nexus-agents registry refresh --source=<url> [--dry-run]',
     '      Download a signed model-registry.generated.json from <url>,',
     '      SHA256-verify against <url>.sha256, and write to:',
-    `      ${join(homedir(), '.nexus-agents', 'model-registry.generated.json')}`,
+    `      ${nexusDataPath('model-registry.generated.json')}`,
     '',
     `Overlay path (T3) is ${defaultOverlayPath()} by default,`,
     `or whatever ${OVERLAY_ENV_VAR} points to. Overlay max size is ${String(OVERLAY_MAX_BYTES)} bytes.`,

--- a/packages/nexus-agents/src/cli/session-commands.ts
+++ b/packages/nexus-agents/src/cli/session-commands.ts
@@ -9,7 +9,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 import type { Result } from '../core/result.js';
 import { ok, err } from '../core/result.js';
 import type { ILogger } from '../core/logger.js';
@@ -62,7 +62,7 @@ export interface SessionPruneOptions extends SessionCommandOptions {
 
 /** Get default database path. */
 export function getDefaultDbPath(): string {
-  return path.join(os.homedir(), '.nexus-agents', 'sessions.db');
+  return nexusDataPath('sessions.db');
 }
 
 function ensureDbDirectory(dbPath: string): void {

--- a/packages/nexus-agents/src/cli/setup-data-dir.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.ts
@@ -9,12 +9,21 @@
  */
 
 import { mkdirSync, existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { DATA_SUBDIRECTORIES } from './doctor.js';
+import { getNexusDataDir } from '../config/nexus-data-dir.js';
 
-/** Root data directory path. */
-export const NEXUS_DATA_DIR = join(homedir(), '.nexus-agents');
+/**
+ * Root data directory path.
+ *
+ * Resolves to `$NEXUS_DATA_DIR` when set, else `<homedir>/.nexus-agents`.
+ * See `src/config/nexus-data-dir.ts` for resolution rules (#2302).
+ *
+ * Evaluated at module-import time. Tests that mutate `NEXUS_DATA_DIR`
+ * mid-process should call `resetNexusDataDirCache()` and re-import, or
+ * call `getNexusDataDir()` directly.
+ */
+export const NEXUS_DATA_DIR = getNexusDataDir();
 
 /** Subdirectories requiring restricted permissions (owner-only). */
 const RESTRICTED_DIRS = new Set(['auth']);

--- a/packages/nexus-agents/src/config/nexus-data-dir.test.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for getNexusDataDir() helper (#2302, child of #2301).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { homedir } from 'node:os';
+import { join, resolve, isAbsolute } from 'node:path';
+import { getNexusDataDir, nexusDataPath, resetNexusDataDirCache } from './nexus-data-dir.js';
+
+describe('getNexusDataDir', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env['NEXUS_DATA_DIR'];
+    delete process.env['NEXUS_DATA_DIR'];
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalEnv;
+    resetNexusDataDirCache();
+  });
+
+  it('falls back to <homedir>/.nexus-agents when env var is unset', () => {
+    expect(getNexusDataDir()).toBe(join(homedir(), '.nexus-agents'));
+  });
+
+  it('uses NEXUS_DATA_DIR when set to an absolute path', () => {
+    process.env['NEXUS_DATA_DIR'] = '/var/lib/nexus-portable';
+    expect(getNexusDataDir()).toBe('/var/lib/nexus-portable');
+  });
+
+  it('resolves relative NEXUS_DATA_DIR against process.cwd() at first call', () => {
+    process.env['NEXUS_DATA_DIR'] = '.nexus-agents';
+    const result = getNexusDataDir();
+    expect(isAbsolute(result)).toBe(true);
+    expect(result).toBe(resolve('.nexus-agents'));
+  });
+
+  it('treats empty string env var as unset (homedir fallback)', () => {
+    process.env['NEXUS_DATA_DIR'] = '';
+    expect(getNexusDataDir()).toBe(join(homedir(), '.nexus-agents'));
+  });
+
+  it('treats whitespace-only env var as unset (homedir fallback)', () => {
+    process.env['NEXUS_DATA_DIR'] = '   ';
+    expect(getNexusDataDir()).toBe(join(homedir(), '.nexus-agents'));
+  });
+
+  it('re-reads the env var on every call (no caching)', () => {
+    process.env['NEXUS_DATA_DIR'] = '/first';
+    expect(getNexusDataDir()).toBe('/first');
+    process.env['NEXUS_DATA_DIR'] = '/second';
+    expect(getNexusDataDir()).toBe('/second');
+  });
+
+  it('resetNexusDataDirCache() is a documented no-op', () => {
+    expect(() => {
+      resetNexusDataDirCache();
+    }).not.toThrow();
+  });
+
+  it('handles paths with trailing whitespace by trimming', () => {
+    process.env['NEXUS_DATA_DIR'] = '  /trimmed  ';
+    expect(getNexusDataDir()).toBe('/trimmed');
+  });
+});
+
+describe('nexusDataPath', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env['NEXUS_DATA_DIR'];
+    delete process.env['NEXUS_DATA_DIR'];
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalEnv;
+    resetNexusDataDirCache();
+  });
+
+  it('joins segments under the resolved data dir (homedir default)', () => {
+    expect(nexusDataPath('audit', 'log.jsonl')).toBe(
+      join(homedir(), '.nexus-agents', 'audit', 'log.jsonl')
+    );
+  });
+
+  it('joins segments under NEXUS_DATA_DIR when set', () => {
+    process.env['NEXUS_DATA_DIR'] = '/var/nexus';
+    expect(nexusDataPath('memory', 'beliefs.json')).toBe('/var/nexus/memory/beliefs.json');
+  });
+
+  it('returns the data dir itself when called with no segments', () => {
+    process.env['NEXUS_DATA_DIR'] = '/var/nexus';
+    expect(nexusDataPath()).toBe('/var/nexus');
+  });
+});

--- a/packages/nexus-agents/src/config/nexus-data-dir.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.ts
@@ -1,0 +1,48 @@
+/**
+ * Nexus runtime data directory resolver (#2302, child of #2301).
+ *
+ * Returns the absolute path under which nexus-agents stores all runtime
+ * state — memory, learning, audit, voting, sessions, checkpoints, traces,
+ * model registry. Single source of truth so portable / sandbox / CI
+ * deployments can redirect state to a workspace-local folder via the
+ * `NEXUS_DATA_DIR` environment variable.
+ *
+ * Resolution order (first match wins):
+ * 1. `NEXUS_DATA_DIR` env var if set + non-empty (resolved against `cwd`).
+ * 2. `<homedir>/.nexus-agents` (zero-breakage fallback).
+ *
+ * No caching, no filesystem walks, no discovery. The contrarian-narrowed
+ * scope (#2301 vote) explicitly defers ancestor-walking to a separate
+ * child with a security design pass per CVE-2022-24765. Recomputing the
+ * trivial env-or-homedir lookup on each call is ~100ns and avoids cache
+ * coordination issues with tests that mock `homedir()`.
+ *
+ * @module config/nexus-data-dir
+ */
+
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/** Returns the absolute path to the nexus-agents data directory. */
+export function getNexusDataDir(): string {
+  const fromEnv = process.env['NEXUS_DATA_DIR']?.trim();
+  if (fromEnv !== undefined && fromEnv !== '') {
+    return resolve(fromEnv);
+  }
+  return join(homedir(), '.nexus-agents');
+}
+
+/**
+ * No-op kept for source-compatibility with consumers that called this
+ * earlier in development. The resolver is no longer cached, so resetting
+ * is unnecessary. Kept exported (rather than removed) to avoid breaking
+ * imports in tests that may have already adopted it.
+ */
+export function resetNexusDataDirCache(): void {
+  // intentionally empty — see module docstring
+}
+
+/** Returns a path joined under the resolved data directory. */
+export function nexusDataPath(...segments: string[]): string {
+  return join(getNexusDataDir(), ...segments);
+}

--- a/packages/nexus-agents/src/consensus/correlation-persistence.ts
+++ b/packages/nexus-agents/src/consensus/correlation-persistence.ts
@@ -12,8 +12,7 @@
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 import { z } from 'zod';
 import type { Result } from '../core/result.js';
 import { ok, err } from '../core/result.js';
@@ -26,8 +25,8 @@ import { createCorrelationTracker } from './correlation-tracker.js';
 
 const logger: ILogger = createLogger({ component: 'correlation-persistence' });
 
-/** Directory under homedir for voting data */
-const VOTING_DIR = path.join('.nexus-agents', 'voting');
+/** Subdirectory name under the resolved nexus data dir for voting data. */
+const VOTING_SUBDIR = 'voting';
 
 /** Filename for persisted correlation data */
 const CORRELATIONS_FILE = 'correlations.json';
@@ -92,18 +91,17 @@ export type PersistedCorrelationData = z.infer<typeof PersistedCorrelationDataSc
 
 /**
  * Returns the absolute path to the correlation data file.
- *
- * @returns Absolute path to ~/.nexus-agents/voting/correlations.json
+ * Resolves under `$NEXUS_DATA_DIR/voting/correlations.json` (#2302).
  */
 export function getCorrelationDataPath(): string {
-  return path.join(os.homedir(), VOTING_DIR, CORRELATIONS_FILE);
+  return nexusDataPath(VOTING_SUBDIR, CORRELATIONS_FILE);
 }
 
 /**
  * Ensures the voting data directory exists with appropriate permissions.
  */
 function ensureVotingDirectory(): Result<void, Error> {
-  const dirPath = path.join(os.homedir(), VOTING_DIR);
+  const dirPath = nexusDataPath(VOTING_SUBDIR);
   try {
     fs.mkdirSync(dirPath, { recursive: true, mode: DIR_MODE });
     return ok(undefined);

--- a/packages/nexus-agents/src/mcp/middleware/auth-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/auth-handler.ts
@@ -11,8 +11,8 @@
 
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
+import { dirname } from 'node:path';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
 import type { ILogger } from '../../core/index.js';
 import { createLogger } from '../../core/index.js';
 import type { AuthConfig } from '../../config/schemas-security.js';
@@ -49,7 +49,7 @@ export interface AuthHandlerConfig {
 /**
  * Default auth directory relative to home.
  */
-const DEFAULT_AUTH_DIR = '.nexus-agents/auth';
+const DEFAULT_AUTH_SUBDIR = 'auth';
 
 /**
  * Default token file name.
@@ -65,7 +65,7 @@ const TOKEN_LENGTH_BYTES = 32;
  * Gets the default token file path.
  */
 export function getDefaultTokenPath(): string {
-  return join(homedir(), DEFAULT_AUTH_DIR, DEFAULT_TOKEN_FILE);
+  return nexusDataPath(DEFAULT_AUTH_SUBDIR, DEFAULT_TOKEN_FILE);
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/research-auto-catalog.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-auto-catalog.ts
@@ -10,8 +10,7 @@
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
 import { z } from 'zod';
 import type { ILogger } from '../../core/index.js';
 import { getErrorMessage, createLogger } from '../../core/index.js';
@@ -43,7 +42,7 @@ export interface CatalogedReference {
 // =============================================================================
 
 /** Path to the persistent pending catalog file. */
-const CATALOG_DIR = path.join('.nexus-agents', 'research');
+const CATALOG_SUBDIR = 'research';
 const CATALOG_FILE = 'pending-catalog.json';
 const FILE_MODE = 0o600;
 const DIR_MODE = 0o700;
@@ -64,9 +63,9 @@ const PersistedCatalogSchema = z.object({
   savedAt: z.string(),
 });
 
-/** Returns path to ~/.nexus-agents/research/pending-catalog.json */
+/** Returns path to `<NEXUS_DATA_DIR>/research/pending-catalog.json` (#2302). */
 function getCatalogPath(): string {
-  return path.join(os.homedir(), CATALOG_DIR, CATALOG_FILE);
+  return nexusDataPath(CATALOG_SUBDIR, CATALOG_FILE);
 }
 
 /** Loads pending references from disk. Returns empty array on failure. */
@@ -95,7 +94,7 @@ function loadPersistedCatalog(logger: ILogger): CatalogedReference[] {
 
 /** Saves pending references to disk with atomic write. */
 function savePersistedCatalog(references: readonly CatalogedReference[], logger: ILogger): void {
-  const dirPath = path.join(os.homedir(), CATALOG_DIR);
+  const dirPath = nexusDataPath(CATALOG_SUBDIR);
   const filePath = getCatalogPath();
   const tempPath = `${filePath}.tmp.${String(process.pid)}`;
   try {

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -13,8 +13,8 @@
  */
 
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
 import type { ILogger } from '../../core/index.js';
 import { getErrorMessage, createLogger, getTimeProvider } from '../../core/index.js';
 
@@ -95,8 +95,8 @@ export type { DecayRunStats, DecayAggregateStats } from './memory-decay.js';
 // Constants
 // ============================================================================
 
-/** Default memory directory under user home. */
-const MEMORY_BASE = path.join(os.homedir(), '.nexus-agents', 'memory');
+/** Default memory directory under the resolved nexus data dir (#2302). */
+const MEMORY_BASE = nexusDataPath('memory');
 const DEFAULT_MEMORY_DIR = path.join(MEMORY_BASE, 'sessions');
 const AGENTIC_DB_PATH = path.join(MEMORY_BASE, 'agentic.db');
 const ADAPTIVE_DB_PATH = path.join(MEMORY_BASE, 'adaptive.db');

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -158,11 +158,10 @@ async function persistMobiMemState(): Promise<void> {
   try {
     const { isPersistenceEnabled } = await import('../config/learning-persistence.js');
     if (!isPersistenceEnabled()) return;
-    const os = await import('node:os');
-    const path = await import('node:path');
+    const { nexusDataPath } = await import('../config/nexus-data-dir.js');
     const { createMobiMem } = await import('../context/mobimem.js');
     const mobimem = createMobiMem();
-    const savePath = path.join(os.homedir(), '.nexus-agents', 'memory', 'mobimem-state.json');
+    const savePath = nexusDataPath('memory', 'mobimem-state.json');
     await mobimem.save(savePath);
   } catch {
     // MobiMem persistence failure must never block pipeline completion

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -18,8 +18,7 @@
  * @module pipeline/dev-pipeline
  */
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 
 import { runQaLoop } from '../orchestration/qa-loop.js';
 
@@ -242,7 +241,7 @@ async function runDevPipelineInner(
 function createTraceWriter(sessionId: string | undefined): TraceWriter | null {
   if (sessionId === undefined) return null;
   try {
-    const tracesDir = join(homedir(), '.nexus-agents', 'traces');
+    const tracesDir = nexusDataPath('traces');
     return new TraceWriter(getPipelineEventBus(), {
       runsDir: tracesDir,
       runId: `pipeline-${sessionId}`,

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -302,9 +302,9 @@ async function extractSymbolsForTask(task: string): Promise<string | null> {
 async function retrieveAdaptiveMemory(task: string): Promise<string | null> {
   try {
     const { AdaptiveMemoryBackend } = await import('../context/adaptive-memory.js');
-    const os = await import('node:os');
     const path = await import('node:path');
-    const baseDir = path.join(os.homedir(), '.nexus-agents', 'memory');
+    const { nexusDataPath } = await import('../config/nexus-data-dir.js');
+    const baseDir = nexusDataPath('memory');
     const memory = new AdaptiveMemoryBackend({
       dbPath: path.join(baseDir, 'adaptive.db'),
       markdownDir: path.join(baseDir, 'adaptive-md'),


### PR DESCRIPTION
Closes #2302. Child of #2301.

## Summary

- Single resolver \`getNexusDataDir()\` in \`src/config/nexus-data-dir.ts\` — env var first, then \`~/.nexus-agents\` fallback. No caching, no walk-up, no init command (those are deferred children per consensus vote)
- 11 source-file callsites refactored from \`homedir()\` to the resolver: audit, doctor, sessions, registry, mobimem, traces, memory, voting correlations, wave checkpoints, MCP auth, research auto-catalog
- \`Dockerfile.sandbox\` sets \`ENV NEXUS_DATA_DIR=/workspace/.nexus-agents\` so workspace state stops leaking into the container's \`\$HOME\`

## Pipeline

Followed the full pipeline per CLAUDE.md:

1. **Smoke tests run** — 18 E2E test files / 183 tests pass; security smoke 11 tests pass; doctor reports Status: Ready
2. **Research** — audited 32+ \`homedir()\` callsites; identified 11 nexus-data ones (vs. unrelated paths to claude/gemini/opencode configs)
3. **Vote** — quickMode consensus_vote: 5 approve / 1 reject. Contrarian (0.95 conf) raised CVE-2022-24765 risk for git-style walk-up + caching footgun. Architect + Security raised same concerns as conditions
4. **Epic + children** — filed epic #2301, child #2302 (this PR), 5 deferred siblings (#2303-style, listed in epic body)
5. **Implement** — adopted contrarian's narrower scope: env var only, no walk-up, no init command. Caching dropped after test failures confirmed it was a footgun (the contrarian's exact concern)

## Test plan

- [x] 11 unit tests in \`nexus-data-dir.test.ts\` covering env-set, env-empty/whitespace, env-relative, env-absolute, env-trimming, no-cache behavior, joined paths
- [x] \`pnpm vitest run src/config/ src/cli/ src/consensus/ src/agents/ src/mcp/ src/pipeline/\` — all 11,827 tests across 499 files pass
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm build\` clean (ESM + DTS)
- [x] \`npx tsx scripts/inject-governance.ts check\` — registries in sync
- [x] \`npx tsx scripts/generate-docs-content.ts\` — no documentation drift

## Behavior change

**Zero** when \`NEXUS_DATA_DIR\` is unset. All existing users continue writing to \`~/.nexus-agents\`.

When \`NEXUS_DATA_DIR=/path\`: every nexus-data write redirects to \`/path/{memory,audit,voting,sessions,checkpoints,traces,research,model-registry.generated.json,…}\`.

## Out of scope (filed under #2301)

- Workspace discovery walk-up (CVE-2022-24765 risk class — needs security design pass)
- \`nexus-agents init --portable\` bootstrap command
- \`.gitignore\` automation
- Workspace-relative MCP config generator
- Devcontainer feature spec
- Portable npm package install path (\`.nexus/cli/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)