### PR TITLE
chore(ci): pin pr-review.yml action references to commit SHAs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -73,18 +73,18 @@ jobs:
           echo "API key configured — proceeding."
 
       - name: Checkout PR head
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         # Version is read from package.json's packageManager field — passing
         # `version:` here conflicts with that and fails with ERR_PNPM_BAD_PM_VERSION.
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Post review summary as PR comment
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

Resolves Scorecard alerts #212, #214, #215, #216 (Pinned-Dependencies, all medium). The \`pr-review.yml\` workflow was the last in this repo with mutable \`@v<n>\` action refs; the rest of the repo already pins to commit SHAs with a version comment.

## Changes

| Action | Before | After |
| --- | --- | --- |
| \`actions/checkout\` | \`@v6\` | \`@de0fac2e... # v6\` |
| \`actions/setup-node\` | \`@v6\` | \`@48b55a01... # v6\` |
| \`pnpm/action-setup\` | \`@v4\` | \`@b906affc... # v4\` |
| \`actions/github-script\` | \`@v9\` | \`@3a2844b7... # v9\` |

The first, second, and fourth SHAs already appear in other workflows in this repo. \`pnpm/action-setup\` is kept on v4 (other workflows use v5) because the inline comment notes that passing \`version:\` here conflicts with the \`packageManager\` field; bumping to v5 is a separate concern.

## Verification

- \`grep "uses: " .github/workflows/pr-review.yml\` → all four references pinned to SHA + comment
- SHAs resolved via \`gh api repos/<owner>/<action>/git/refs/tags/v<n>\` for each

## Closes

Closes Scorecard alerts #212, #214, #215, #216 — they will auto-dismiss after the next Scorecard run on main once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)