### PR TITLE
chore(ci): replace dead Rust SBOM flow with Node-native cdxgen

### DIFF
--- a/.changeset/sbom-node-native.md
+++ b/.changeset/sbom-node-native.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+Replace the dead Rust-targeted SBOM flow with a Node-native CycloneDX SBOM (#2326 follow-up).
+
+The release workflow's SBOM steps had been silently skipping every release since 2.29.1 because they were gated on `crates/iso-parser/Cargo.toml`, a path that has never existed in this repo (copy-paste from a Rust project). The same root cause was also dropping a `cargo-audit` and `cargo-deny` job from `ci.yml` on every PR run.
+
+Changes:
+
+- `.github/workflows/release.yml` now generates a CycloneDX 1.6 SBOM via `npx @cyclonedx/cdxgen@12.3.1` against `pnpm-lock.yaml`. The output (`sbom.cdx.json`) is uploaded to the GitHub Release and attested via `actions/attest-build-provenance`. SPDX is dropped — CycloneDX is the dominant format for the npm ecosystem.
+- `.github/workflows/release.yml` Rust toolchain install + `cargo install cargo-sbom` removed (~45s saved per release).
+- `.github/workflows/ci.yml` `cargo-audit` and `cargo-deny` jobs removed (~90s saved per CI run; both were no-ops).
+- npm package provenance attestation (`NPM_CONFIG_PROVENANCE: true` + the `Attest npm package` step) is unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,52 +207,13 @@ jobs:
         run: pnpm audit --audit-level=high
         continue-on-error: true
 
-  cargo-audit:
-    name: Cargo Audit
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
-      - name: Run cargo-audit
-        run: |
-          if [ -d "crates/iso-parser" ]; then
-            cargo install cargo-audit
-            cd crates/iso-parser && cargo audit
-          else
-            echo "crates/iso-parser not found, skipping cargo audit"
-          fi
-
-  cargo-deny:
-    name: Cargo Deny
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
-      - name: Run cargo-deny
-        run: |
-          if [ -d "crates/iso-parser" ]; then
-            cargo install cargo-deny
-            cd crates/iso-parser && cargo deny check advisories bans licenses
-          else
-            echo "crates/iso-parser not found, skipping cargo deny"
-          fi
-
-  # Gate for branch protection - requires all checks to pass
+  # Gate for branch protection - requires all checks to pass.
+  # Cargo Audit / Cargo Deny jobs were removed: this is a Node.js
+  # project, the jobs were guarded on a non-existent crates/iso-parser/
+  # path (copy-paste from a Rust project) and skipped on every run.
   ci-success:
     name: CI Success
-    needs: [commitlint, lint, typecheck, build, test, fitness-audit, cargo-audit, cargo-deny]
+    needs: [commitlint, lint, typecheck, build, test, fitness-audit]
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     if: always()
@@ -265,9 +226,7 @@ jobs:
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
-             [[ "${{ needs.fitness-audit.result }}" != "success" ]] || \
-             [[ "${{ needs.cargo-audit.result }}" != "success" ]] || \
-             [[ "${{ needs.cargo-deny.result }}" != "success" ]]; then
+             [[ "${{ needs.fitness-audit.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
-      - name: Install cargo-sbom
-        run: cargo install cargo-sbom
-
       - uses: ./.github/actions/setup-node
         with:
           registry-url: 'https://registry.npmjs.org'
@@ -62,25 +54,34 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Generate SBOM artifacts
-        # cargo-sbom 0.10 output formats: spdx_json_2_3 | cyclone_dx_json_1_6
-        # (not `spdx` / `cyclonedx`); SBOM is written to stdout, not --file.
-        if: steps.changesets.outputs.published == 'true' && hashFiles('crates/iso-parser/Cargo.toml') != ''
+      - name: Generate CycloneDX SBOM
+        # Node-native SBOM via @cyclonedx/cdxgen against pnpm-lock.yaml.
+        # Replaces the prior Rust-only cargo-sbom flow (#1852) which was
+        # gated on a non-existent crates/iso-parser/Cargo.toml and silently
+        # skipped on every release from 2.29.1 onward. cdxgen 12.3+ is run
+        # via npx so we don't need pnpm 10 (cdxgen 12.x's stated minimum).
+        # CycloneDX 1.6 is the current stable spec version.
+        if: steps.changesets.outputs.published == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          cd crates/iso-parser
-          cargo sbom --output-format spdx_json_2_3 > ../../sbom.spdx.json
-          cargo sbom --output-format cyclone_dx_json_1_6 > ../../sbom.cdx.json
-          ls -la ../../sbom.*.json
+          npx -y @cyclonedx/cdxgen@12.3.1 \
+            -t pnpm \
+            --spec-version 1.6 \
+            -o sbom.cdx.json \
+            --no-recurse
+          # Sanity: confirm output is a valid CycloneDX 1.6 doc with components.
+          jq -e '.bomFormat == "CycloneDX" and .specVersion == "1.6" and (.components | length > 0)' \
+            sbom.cdx.json > /dev/null
+          echo "SBOM generated: $(jq '.components | length' sbom.cdx.json) components"
 
-      - name: Upload SBOM artifacts to GitHub Release
+      - name: Upload SBOM to GitHub Release
         # changesets/action creates the GitHub release itself via
         # @changesets/changelog-github; it does NOT expose an `uploadUrl`
-        # output for the legacy actions/upload-release-asset to consume.
-        # Derive the release tag from publishedPackages and use `gh release
-        # upload` which looks up the release by tag. (#1841 follow-up)
-        if: steps.changesets.outputs.published == 'true' && hashFiles('sbom.spdx.json') != ''
+        # output. Derive the release tag from publishedPackages and use
+        # `gh release upload` which looks up the release by tag.
+        # (#1841 follow-up; SPDX dropped — CycloneDX is dominant for npm.)
+        if: steps.changesets.outputs.published == 'true' && hashFiles('sbom.cdx.json') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
@@ -93,16 +94,14 @@ jobs:
             echo "::warning::nexus-agents not in publishedPackages; skipping SBOM upload"
             exit 0
           fi
-          echo "Uploading SBOMs to release tag: $TAG"
-          gh release upload "$TAG" sbom.spdx.json sbom.cdx.json --clobber
+          echo "Uploading SBOM to release tag: $TAG"
+          gh release upload "$TAG" sbom.cdx.json --clobber
 
-      - name: Attest SBOM artifacts
-        if: steps.changesets.outputs.published == 'true' && hashFiles('sbom.spdx.json') != ''
+      - name: Attest SBOM
+        if: steps.changesets.outputs.published == 'true' && hashFiles('sbom.cdx.json') != ''
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: |
-            sbom.spdx.json
-            sbom.cdx.json
+          subject-path: sbom.cdx.json
 
       - name: Attest npm package
         if: steps.changesets.outputs.published == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,7 @@ _Auto-generated from source. 34 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-02_
+_Governance Version: 2026-05-03_
 
 <!-- GOVERNANCE:VERSION:END -->
 


### PR DESCRIPTION
## Summary

Two related dead-code findings, same root cause: copy-paste from a Rust project left guards on \`crates/iso-parser/Cargo.toml\` — a path that **has never existed in this repo**.

## What was broken

**release.yml SBOM** — silently skipped since 2.29.1 (~30 releases). The 'fix' in PR #1852 patched 3 format/upload bugs but kept the Rust-only path; the entire generate + upload + attest chain is gated on \`hashFiles('crates/iso-parser/Cargo.toml') != ''\`, which always evaluates false. Recent releases (2.63.0 / 2.63.1 / 2.63.2) all have **0 SBOM assets** attached.

**ci.yml cargo-audit + cargo-deny** — runs on every PR. Both jobs install Rust toolchain + the cargo tool (~45s each), then \`if -d crates/iso-parser; then ... else echo "skipping" fi\` takes the else branch every time. ~90s of dead CI per PR.

## Fix

\`release.yml\`:
- Drop \`Install Rust toolchain\` + \`Install cargo-sbom\` steps.
- Replace \`Generate SBOM artifacts\` with \`npx -y @cyclonedx/cdxgen@12.3.1 -t pnpm --spec-version 1.6 -o sbom.cdx.json --no-recurse\`.
- Drop SPDX (CycloneDX is dominant in the npm ecosystem; one format keeps the workflow simple).
- Upload + attest steps reshaped to point at a single file (\`sbom.cdx.json\`).
- Sanity-check inline: \`jq -e '.bomFormat == \"CycloneDX\" and .specVersion == \"1.6\" and (.components | length > 0)'\` to fail fast if cdxgen produces malformed output.

\`ci.yml\`:
- Delete \`cargo-audit\` job.
- Delete \`cargo-deny\` job.
- Remove both from \`ci-success.needs[]\` and the result-checks. Branch protection only requires \`CI Success\`, verified via GitHub API.

## Why cdxgen via \`npx\` instead of \`pnpm dlx\`

cdxgen 12.x's \`engines\` declares \`pnpm >= 10\` but this monorepo is on pnpm 9.15.0. \`npx\` doesn't enforce that constraint — only Node version matters for cdxgen at runtime, and the runner has Node 22. Surgical: doesn't bundle a pnpm version bump into a CI cleanup PR.

## Local verification

\`\`\`
$ npx -y @cyclonedx/cdxgen@12.3.1 -t pnpm --spec-version 1.6 -o /tmp/sbom-test.cdx.json --no-recurse
$ jq '{specVersion, bomFormat, components: (.components | length)}' /tmp/sbom-test.cdx.json
{
  \"specVersion\": \"1.6\",
  \"bomFormat\": \"CycloneDX\",
  \"components\": 1298
}
\`\`\`

## Test plan

- [x] Local cdxgen invocation produces a valid CycloneDX 1.6 SBOM (1,298 components from this repo's lock file).
- [x] yaml.safe_load() validates both modified workflow files.
- [x] Branch protection's required check is \`CI Success\` only — confirmed via \`gh api repos/.../branches/main/protection\`.
- [ ] CI green on this PR.
- [ ] Next release exercises the new path end-to-end; \`sbom.cdx.json\` shows up as a release asset on \`nexus-agents@2.63.3\` (or whatever ships next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)