### PR TITLE
chore(mcp): migrate run_dev_pipeline + run_pipeline to server.registerTool() (#2339)

### DIFF
--- a/.changeset/2339-mcp-register-tool.md
+++ b/.changeset/2339-mcp-register-tool.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Standardize MCP tool registration on `server.registerTool()` (#2339).
+
+`run_dev_pipeline` and `run_pipeline` were the only two of 34 MCP tools still using the older `server.tool(name, schema, handler)` API. The other 32 use `server.registerTool(name, { description, inputSchema, ... }, handler)`. Migrated both so MCP clients see consistent metadata for every tool, and the `eslint-disable @typescript-eslint/no-deprecated` workarounds are gone.
+
+No client-visible behavior change beyond the tool descriptions now being available in MCP listings (they previously weren't).

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -17,7 +17,7 @@ import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
 import type { DevPipelineResult } from '../../pipeline/dev-pipeline.js';
 import { createAgentStages, flushPipelineMemory } from '../../pipeline/agent-executor.js';
 import { createTaskTracker, detectBackend } from '../../pipeline/task-tracker.js';
-// toolSuccessStructured not used directly — server.tool() expects different return type
+// toolSuccessStructured not used directly — registerTool callback expects a CallToolResult-shaped value
 import type {} from '../../pipeline/task-tracker.js';
 
 // ============================================================================
@@ -182,44 +182,50 @@ function buildStructuredOutput(result: DevPipelineResult): Record<string, unknow
   };
 }
 
+const RUN_DEV_PIPELINE_DESCRIPTION =
+  'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).';
+
 /** Register the run_dev_pipeline MCP tool. */
 export function registerDevPipelineTool(
   server: McpServer,
   _deps: { logger: unknown; rateLimiter: unknown }
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- matches existing tool registration pattern
-  server.tool('run_dev_pipeline', DevPipelineInputSchema.shape, async (args) => {
-    const input = DevPipelineInputSchema.parse(args);
-    if (input.simulateVotes) {
-      warnIfSimulatedOutsideTests('run_dev_pipeline', createLogger({ tool: 'run_dev_pipeline' }));
-    }
+  server.registerTool(
+    'run_dev_pipeline',
+    { description: RUN_DEV_PIPELINE_DESCRIPTION, inputSchema: DevPipelineInputSchema.shape },
+    async (args) => {
+      const input = DevPipelineInputSchema.parse(args);
+      if (input.simulateVotes) {
+        warnIfSimulatedOutsideTests('run_dev_pipeline', createLogger({ tool: 'run_dev_pipeline' }));
+      }
 
-    try {
-      const taskText = resolveTaskInput(input);
-      const stages = await createStages(input);
-      const pipelineOptions = {
-        ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
-        ...(input.dryRun ? { dryRun: true } : {}),
-        ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
-      };
-      const hasOptions = Object.keys(pipelineOptions).length > 0;
-      const result = await runDevPipeline(
-        taskText,
-        stages,
-        hasOptions ? pipelineOptions : undefined
-      );
-      // Always flush memory session — including dry-run exits (#1716)
-      flushPipelineMemory();
-      const structured = buildStructuredOutput(result);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
-        structuredContent: structured,
-      };
-    } catch (error: unknown) {
-      return {
-        content: [{ type: 'text' as const, text: `Pipeline error: ${getErrorMessage(error)}` }],
-        isError: true,
-      };
+      try {
+        const taskText = resolveTaskInput(input);
+        const stages = await createStages(input);
+        const pipelineOptions = {
+          ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+          ...(input.dryRun ? { dryRun: true } : {}),
+          ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
+        };
+        const hasOptions = Object.keys(pipelineOptions).length > 0;
+        const result = await runDevPipeline(
+          taskText,
+          stages,
+          hasOptions ? pipelineOptions : undefined
+        );
+        // Always flush memory session — including dry-run exits (#1716)
+        flushPipelineMemory();
+        const structured = buildStructuredOutput(result);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
+          structuredContent: structured,
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Pipeline error: ${getErrorMessage(error)}` }],
+          isError: true,
+        };
+      }
     }
-  });
+  );
 }

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -148,43 +148,49 @@ function selectStageRegistry(
 // Tool Registration
 // ============================================================================
 
+const RUN_PIPELINE_DESCRIPTION =
+  'Single unified entry point for all pipeline templates (dev/research/audit/greenfield). Auto-detects template from task content or accepts an explicit override.';
+
 /** Register the run_pipeline MCP tool. */
 export function registerPipelineTool(
   server: McpServer,
   _deps: { logger: unknown; rateLimiter: unknown }
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- matches existing tool registration pattern
-  server.tool('run_pipeline', PipelineInputSchema.shape, async (args) => {
-    const input = PipelineInputSchema.parse(args);
-    if (input.simulateVotes) {
-      warnIfSimulatedOutsideTests('run_pipeline', createLogger({ tool: 'run_pipeline' }));
+  server.registerTool(
+    'run_pipeline',
+    { description: RUN_PIPELINE_DESCRIPTION, inputSchema: PipelineInputSchema.shape },
+    async (args) => {
+      const input = PipelineInputSchema.parse(args);
+      if (input.simulateVotes) {
+        warnIfSimulatedOutsideTests('run_pipeline', createLogger({ tool: 'run_pipeline' }));
+      }
+
+      try {
+        const task = resolveTask(input.task, input.specFile);
+        const agentStages = createAgentStages({
+          simulateVotes: input.simulateVotes,
+          votingStrategy: input.votingStrategy,
+          quickMode: input.quickMode,
+        });
+        const stages = selectStageRegistry(input.template, task, agentStages);
+
+        const result = await runAdaptiveOrchestrator(task, {
+          stages,
+          templateId: input.template,
+          dryRun: input.dryRun,
+        });
+
+        const structured = buildOutput(result);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
+          structuredContent: structured,
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Pipeline error: ${getErrorMessage(error)}` }],
+          isError: true,
+        };
+      }
     }
-
-    try {
-      const task = resolveTask(input.task, input.specFile);
-      const agentStages = createAgentStages({
-        simulateVotes: input.simulateVotes,
-        votingStrategy: input.votingStrategy,
-        quickMode: input.quickMode,
-      });
-      const stages = selectStageRegistry(input.template, task, agentStages);
-
-      const result = await runAdaptiveOrchestrator(task, {
-        stages,
-        templateId: input.template,
-        dryRun: input.dryRun,
-      });
-
-      const structured = buildOutput(result);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
-        structuredContent: structured,
-      };
-    } catch (error: unknown) {
-      return {
-        content: [{ type: 'text' as const, text: `Pipeline error: ${getErrorMessage(error)}` }],
-        isError: true,
-      };
-    }
-  });
+  );
 }


### PR DESCRIPTION
Fixes #2339. Audit-epic-#2337 finding.

## Summary

Two of 34 MCP tool registrations used the older \`server.tool(name, schema, handler)\` API; the other 32 use \`server.registerTool(name, { description, inputSchema, ... }, handler)\`. Standardized both holdouts.

## What changed

| File | Before | After |
| --- | --- | --- |
| \`mcp/tools/dev-pipeline-tool.ts:191\` | \`server.tool('run_dev_pipeline', schema, handler)\` + \`eslint-disable @typescript-eslint/no-deprecated\` | \`server.registerTool('run_dev_pipeline', { description, inputSchema }, handler)\` |
| \`mcp/tools/pipeline-tool.ts:157\` | \`server.tool('run_pipeline', schema, handler)\` + \`eslint-disable\` | \`server.registerTool('run_pipeline', { description, inputSchema }, handler)\` |

Descriptions are pulled from the curated map in \`scripts/inject-governance.ts\` so they match the rest of the registry. Hoisted to \`RUN_DEV_PIPELINE_DESCRIPTION\` / \`RUN_PIPELINE_DESCRIPTION\` constants for a single point of edit.

## Behavior change

MCP clients now see structured tool descriptions for these two tools (they previously didn't). No other client-visible change. No timeout or secure-handler infrastructure added — that's a separate larger refactor (these two tools intentionally use the simpler inline-handler shape).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (the two \`eslint-disable\` lines are gone, no new warnings)
- [x] \`pnpm vitest run src/mcp/tools/dev-pipeline-tool.test.ts src/mcp/tools/index.test.ts\` → 73/73 passed
- [x] \`grep -nE \"server\\.tool\\(\" packages/nexus-agents/src/mcp/tools/*.ts | grep -v \\.test\\.ts\` → empty
- [ ] CI

## Closes

Closes #2339

🤖 Generated with [Claude Code](https://claude.com/claude-code)