### PR TITLE
refactor(config): extract findModelsByCli; use in claude+opencode adapters (#2342)

### DIFF
--- a/.changeset/2342-find-models-by-cli.md
+++ b/.changeset/2342-find-models-by-cli.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Add `findModelsByCli(cliName)` helper to `config/model-capabilities.ts` (#2342).
+
+The audit (#2337) flagged `buildClaudeAliasMap()` and `buildOpenCodeAliasMap()` as duplicated. On closer inspection the two builders have meaningfully different value-derivations (claude maps to `cliAlias`; opencode maps to `cliModelName`'s `provider/model` form), so a single shared builder would have forced a bad abstraction at n=2.
+
+The honest extraction is the **filter step**, which both builders share: "iterate models for a given cliName." This is now `findModelsByCli(cliName)`, mirroring the existing `findModelsByProvider`/`findModelsByOutputModality`/etc. helpers in the same file. Both adapters use it; each retains its CLI-specific value logic.

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
@@ -17,7 +17,7 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { ClaudeResponseParser } from '../parsers/claude-parser.js';
-import { DEFAULT_MODEL_CAPABILITIES } from '../../config/model-capabilities.js';
+import { findModelsByCli } from '../../config/model-capabilities.js';
 import {
   getDefaultModelForCli,
   getCliModelName,
@@ -34,8 +34,8 @@ const MODEL_TO_CLI_ALIAS: Record<string, string> = buildClaudeAliasMap();
 
 function buildClaudeAliasMap(): Record<string, string> {
   const map: Record<string, string> = {};
-  for (const model of DEFAULT_MODEL_CAPABILITIES.models) {
-    if (model.cliName !== 'claude' || model.cliAlias === undefined) continue;
+  for (const model of findModelsByCli('claude')) {
+    if (model.cliAlias === undefined) continue;
     const alias = model.cliAlias;
     map[alias] = alias;
     if (model.cliModelName !== undefined) map[model.cliModelName] = alias;

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
@@ -27,7 +27,7 @@ import {
   getCliModelName,
   buildModelInfo,
 } from '../../config/model-config-helpers.js';
-import { DEFAULT_MODEL_CAPABILITIES } from '../../config/model-capabilities.js';
+import { findModelsByCli } from '../../config/model-capabilities.js';
 import { createLogger } from '../../core/index.js';
 
 const logger = createLogger({ component: 'opencode-adapter' });
@@ -44,17 +44,16 @@ const MODEL_TO_CLI_NAME: Record<string, string> = buildOpenCodeAliasMap();
 
 function buildOpenCodeAliasMap(): Record<string, string> {
   const map: Record<string, string> = {};
-  for (const model of DEFAULT_MODEL_CAPABILITIES.models) {
-    if (model.cliName === 'opencode' && model.cliModelName !== undefined) {
-      // Map internal ID → CLI model name
-      map[model.id] = model.cliModelName;
-      // Map CLI alias → CLI model name
-      if (model.cliAlias !== undefined) {
-        map[model.cliAlias] = model.cliModelName;
-      }
-      // Pass through cliModelName itself
-      map[model.cliModelName] = model.cliModelName;
+  for (const model of findModelsByCli('opencode')) {
+    if (model.cliModelName === undefined) continue;
+    // Map internal ID → CLI model name
+    map[model.id] = model.cliModelName;
+    // Map CLI alias → CLI model name
+    if (model.cliAlias !== undefined) {
+      map[model.cliAlias] = model.cliModelName;
     }
+    // Pass through cliModelName itself
+    map[model.cliModelName] = model.cliModelName;
   }
   return map;
 }

--- a/packages/nexus-agents/src/config/model-capabilities-find.test.ts
+++ b/packages/nexus-agents/src/config/model-capabilities-find.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for findModelsByCli — the missing-from-the-family helper added in #2342.
+ *
+ * Mirrors the shape of findModelsByProvider / findModelsByOutputModality etc.
+ * Used by adapter alias-map builders so the "iterate models filtered by cliName"
+ * boilerplate lives in one place.
+ *
+ * @module config/model-capabilities-find.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findModelsByCli, DEFAULT_MODEL_CAPABILITIES } from './model-capabilities.js';
+
+describe('findModelsByCli', () => {
+  it('returns only models whose cliName matches the query', () => {
+    const result = findModelsByCli('claude');
+    expect(result.length).toBeGreaterThan(0);
+    for (const model of result) {
+      expect(model.cliName).toBe('claude');
+    }
+  });
+
+  it('partitions the registry: every model belongs to exactly one cliName bucket', () => {
+    const buckets: Record<string, number> = {};
+    for (const model of DEFAULT_MODEL_CAPABILITIES.models) {
+      const key = model.cliName ?? '__null__';
+      buckets[key] = (buckets[key] ?? 0) + 1;
+    }
+    let partitioned = 0;
+    for (const cli of Object.keys(buckets)) {
+      if (cli === '__null__') continue;
+      partitioned += findModelsByCli(cli as 'claude').length;
+    }
+    expect(partitioned).toBe(
+      DEFAULT_MODEL_CAPABILITIES.models.filter((m) => m.cliName !== undefined).length
+    );
+  });
+
+  it('returns an empty array for a CLI with no models', () => {
+    // Cast: the registry's CliName union doesn't include 'nonexistent', but
+    // the runtime filter handles unknown values gracefully.
+    const result = findModelsByCli('nonexistent' as 'claude');
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/config/model-capabilities.ts
+++ b/packages/nexus-agents/src/config/model-capabilities.ts
@@ -458,6 +458,23 @@ export function findModelsByProvider(
   return matrix.models.filter((m) => m.provider === provider);
 }
 
+/**
+ * Find all models that target a specific CLI (`cliName`).
+ *
+ * Used by adapter alias-map builders so the "iterate models filtered by
+ * cliName" boilerplate lives in one place. Each adapter still owns its own
+ * value-derivation logic — the filters and target shapes differ across CLIs
+ * (claude maps to `cliAlias`, opencode maps to `provider/model` form), so this
+ * helper deliberately stops at the filtering step rather than imposing a
+ * common map shape (#2342).
+ */
+export function findModelsByCli(
+  cliName: ModelCapability['cliName'],
+  matrix: ModelCapabilitiesMatrix = DEFAULT_MODEL_CAPABILITIES
+): ModelCapability[] {
+  return matrix.models.filter((m) => m.cliName === cliName);
+}
+
 /** Find the best model for a required output modality, preferring larger context. */
 export function findBestModelForOutput(
   modality: OutputModality,


### PR DESCRIPTION
Closes #2342. Audit-epic-#2337 finding.

## Summary

The audit flagged \`buildClaudeAliasMap()\` and \`buildOpenCodeAliasMap()\` as duplicated. On reading both side-by-side, the duplication is smaller than claimed — different filters, different keys, different values. Forcing a single shared builder at n=2 would require a higher-order parameter for the value-derivation, which costs more than it saves.

Instead, extracted the **shared filter step**: \"iterate models for a given cliName.\" Now \`findModelsByCli(cliName)\` in \`config/model-capabilities.ts\`, matching the existing \`findModelsByProvider\` / \`findModelsByOutputModality\` / etc. family pattern. Both adapters use it; each retains its CLI-specific value logic.

## Why not force a full consolidation

Side-by-side:

| | claude builder | opencode builder |
| --- | --- | --- |
| Filter | \`cliName === 'claude' && cliAlias !== undefined\` | \`cliName === 'opencode' && cliModelName !== undefined\` |
| Map keys | \`cliAlias\`, \`cliModelName\`, every \`aliases[]\` | \`id\`, \`cliAlias\`, \`cliModelName\` |
| Map values | \`cliAlias\` (alias-form) | \`cliModelName\` (provider/model form) |

CLAUDE.md DRY rule: \"two instances is a coincidence; three is a pattern worth extracting.\" Forcing a higher-order builder at n=2 with three differing axes creates worse code than two clear builders. The filter step is shared and is a one-liner per file — extracting that is the honest win.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm vitest run src/cli-adapters/adapters/ src/config/\` → 806 passed
- [x] New \`model-capabilities-find.test.ts\` (3 tests): filter contract, registry partitioning, unknown-cli safety
- [ ] CI

## Closes

Closes #2342

🤖 Generated with [Claude Code](https://claude.com/claude-code)