### PR TITLE
refactor(pipeline): extract buildBaseTaskContract from v2-orchestrate + v2-delegate (#2343)

### DIFF
--- a/.changeset/2343-task-contract-builder.md
+++ b/.changeset/2343-task-contract-builder.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Extract `buildBaseTaskContract` shared by `v2-orchestrate` and `v2-delegate` (#2343).
+
+Both V2 MCP entrypoints had near-identical converters: the same id template, same `'approved'` status, same empty-default constraints/capabilities/capability-gaps/artifacts, same timestamps. Only the id-prefix, analysis summary, and metadata differ.
+
+Extracted the shared scaffolding to `pipeline/task-contract-builders.ts`. Each call site now supplies only the fields that genuinely differ. Adding a new field to `TaskContractSchema` requires updating one place rather than two.
+
+No behavior change. 32 v2 tests still pass; 7 new builder tests added.

--- a/packages/nexus-agents/src/pipeline/task-contract-builders.test.ts
+++ b/packages/nexus-agents/src/pipeline/task-contract-builders.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for `buildBaseTaskContract`.
+ * (Source: Issue #2343, audit-epic #2337)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildBaseTaskContract } from './task-contract-builders.js';
+import { TaskContractSchema } from './task-contract.js';
+
+describe('buildBaseTaskContract', () => {
+  const baseInput = {
+    idPrefix: 'orchestrate',
+    task: 'Implement feature X',
+    analysis: { complexity: 'high', taskType: 'orchestration', ambiguityScore: 0.3 },
+    metadata: { source: 'orchestrate', extra: 'value' },
+  } as const;
+
+  it('produces a TaskContract that validates against the canonical schema', () => {
+    const result = TaskContractSchema.safeParse(buildBaseTaskContract(baseInput));
+    expect(result.success).toBe(true);
+  });
+
+  it('id is prefixed and includes a uuid suffix', () => {
+    const contract = buildBaseTaskContract(baseInput);
+    expect(contract.id).toMatch(/^orchestrate-[0-9a-f]{8}$/);
+  });
+
+  it('createdAt and updatedAt are equal at construction time', () => {
+    const contract = buildBaseTaskContract(baseInput);
+    expect(contract.createdAt).toBe(contract.updatedAt);
+  });
+
+  it('metadata is copied (not aliased) so callers cannot mutate stored state', () => {
+    const metadata: Record<string, unknown> = { source: 'orchestrate' };
+    const contract = buildBaseTaskContract({ ...baseInput, metadata });
+    metadata['after'] = 'mutated';
+    expect(contract.metadata).not.toHaveProperty('after');
+  });
+
+  it('returns empty defaults for constraints / capabilities / capability gaps / artifacts', () => {
+    const contract = buildBaseTaskContract(baseInput);
+    expect(contract.constraints.scope).toEqual([]);
+    expect(contract.requiredCapabilities).toEqual({ tools: [], experts: [] });
+    expect(contract.capabilityGaps.allSatisfied).toBe(true);
+    expect(contract.capabilityGaps.gaps).toEqual([]);
+    expect(contract.artifacts).toEqual([]);
+  });
+
+  it("status is 'approved' (skips intake/clarifying/planning per V2 entrypoint convention)", () => {
+    const contract = buildBaseTaskContract(baseInput);
+    expect(contract.status).toBe('approved');
+  });
+
+  it('preserves the analysis summary verbatim', () => {
+    const contract = buildBaseTaskContract({
+      ...baseInput,
+      analysis: { complexity: 'low', taskType: 'routing', ambiguityScore: 0.1 },
+    });
+    expect(contract.analysis).toEqual({
+      complexity: 'low',
+      taskType: 'routing',
+      ambiguityScore: 0.1,
+    });
+  });
+});

--- a/packages/nexus-agents/src/pipeline/task-contract-builders.ts
+++ b/packages/nexus-agents/src/pipeline/task-contract-builders.ts
@@ -1,0 +1,59 @@
+/**
+ * Builders for `TaskContract` instances.
+ *
+ * Extracted from `v2-orchestrate.ts` and `v2-delegate.ts`, which previously
+ * each had their own near-identical converter. The shared scaffolding (id
+ * template, status, empty-default constraints/capabilities/artifacts,
+ * timestamps) lives here; callers supply only the fields that genuinely
+ * differ between entry points (idPrefix, task description, analysis summary,
+ * metadata).
+ *
+ * (Source: Issue #2343, audit-epic #2337)
+ *
+ * @module pipeline/task-contract-builders
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { TaskContract } from './task-contract.js';
+
+/** Inputs needed to build a fresh `'approved'` `TaskContract`. */
+export interface BaseTaskContractInput {
+  /** Prefix for the auto-generated id (e.g., `'orchestrate'`, `'delegate'`). */
+  readonly idPrefix: string;
+  /** The task description (free-text). */
+  readonly task: string;
+  /** Lightweight analysis summary (complexity / taskType / ambiguityScore). */
+  readonly analysis: TaskContract['analysis'];
+  /** Caller-controlled metadata (source tag + entry-point-specific fields). */
+  readonly metadata: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Build a fresh `TaskContract` in the `'approved'` status with empty-default
+ * constraints, required capabilities, capability gaps, and artifacts.
+ *
+ * The two MCP entrypoints (`orchestrate`, `delegate_to_model`) build their
+ * task contracts via this helper rather than copy-pasting the full shape.
+ * Adding a new field to `TaskContractSchema` only requires updating this one
+ * place.
+ */
+export function buildBaseTaskContract(input: BaseTaskContractInput): TaskContract {
+  const now = Date.now();
+  return {
+    id: `${input.idPrefix}-${randomUUID().slice(0, 8)}`,
+    description: input.task,
+    status: 'approved',
+    analysis: input.analysis,
+    constraints: { scope: [] },
+    requiredCapabilities: { tools: [], experts: [] },
+    capabilityGaps: {
+      available: { tools: [], experts: [] },
+      gaps: [],
+      allSatisfied: true,
+    },
+    artifacts: [],
+    metadata: { ...input.metadata },
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -13,14 +13,13 @@
  *
  * @module pipeline/v2-delegate
  */
-import { randomUUID } from 'node:crypto';
-
 import { createLogger } from '../core/index.js';
 
 import { PipelineRunner } from './pipeline-runner.js';
 import { getPipelineEventBus } from './event-bus.js';
 import { createDefaultPolicyEngine } from './policy-engine.js';
 import { evaluatePolicy, getPolicyMode } from './policy-evaluator.js';
+import { buildBaseTaskContract } from './task-contract-builders.js';
 
 import type { CompiledPipeline } from './pipeline-runner.js';
 import type { TaskContract, PlanContract } from './task-contract.js';
@@ -79,7 +78,6 @@ export interface PipelineMetrics {
  * Input fields are preserved in metadata for downstream pipeline stages.
  */
 export function delegateInputToTaskContract(input: DelegateInputLike): TaskContract {
-  const now = Date.now();
   const metadata: Record<string, unknown> = { source: 'delegate_to_model' };
   if (input.preferred_capability !== undefined) {
     metadata['preferredCapability'] = input.preferred_capability;
@@ -93,27 +91,12 @@ export function delegateInputToTaskContract(input: DelegateInputLike): TaskContr
   if (input.estimate_tokens === true) {
     metadata['estimateTokens'] = true;
   }
-  return {
-    id: `delegate-${randomUUID().slice(0, 8)}`,
-    description: input.task,
-    status: 'approved',
-    analysis: {
-      complexity: 'moderate',
-      taskType: 'routing',
-      ambiguityScore: 0.1,
-    },
-    constraints: { scope: [] },
-    requiredCapabilities: { tools: [], experts: [] },
-    capabilityGaps: {
-      available: { tools: [], experts: [] },
-      gaps: [],
-      allSatisfied: true,
-    },
-    artifacts: [],
+  return buildBaseTaskContract({
+    idPrefix: 'delegate',
+    task: input.task,
+    analysis: { complexity: 'moderate', taskType: 'routing', ambiguityScore: 0.1 },
     metadata,
-    createdAt: now,
-    updatedAt: now,
-  };
+  });
 }
 
 /**

--- a/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
@@ -13,11 +13,10 @@
  *
  * @module pipeline/v2-orchestrate
  */
-import { randomUUID } from 'node:crypto';
-
 import { createDelegatePipeline, checkPipelinePolicy } from './v2-delegate.js';
 import { PipelineRunner } from './pipeline-runner.js';
 import { getPipelineEventBus } from './event-bus.js';
+import { buildBaseTaskContract } from './task-contract-builders.js';
 
 import type { TaskContract } from './task-contract.js';
 import type { PipelineMetrics } from './v2-delegate.js';
@@ -39,24 +38,15 @@ export interface OrchestrateInputLike {
 
 /** Converts orchestrate input to a TaskContract. */
 export function orchestrateInputToTaskContract(input: OrchestrateInputLike): TaskContract {
-  const now = Date.now();
   const metadata: Record<string, unknown> = { source: 'orchestrate' };
   if (input.context !== undefined) metadata['context'] = input.context;
   if (input.maxIterations !== undefined) metadata['maxIterations'] = input.maxIterations;
-
-  return {
-    id: `orchestrate-${randomUUID().slice(0, 8)}`,
-    description: input.task,
-    status: 'approved',
+  return buildBaseTaskContract({
+    idPrefix: 'orchestrate',
+    task: input.task,
     analysis: { complexity: 'high', taskType: 'orchestration', ambiguityScore: 0.3 },
-    constraints: { scope: [] },
-    requiredCapabilities: { tools: [], experts: [] },
-    capabilityGaps: { available: { tools: [], experts: [] }, gaps: [], allSatisfied: true },
-    artifacts: [],
     metadata,
-    createdAt: now,
-    updatedAt: now,
-  };
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #2343. Audit-epic-#2337 finding.

## Summary

V2 MCP entrypoints \`v2-orchestrate.ts\` and \`v2-delegate.ts\` each had near-identical \`TaskContract\` converters. Same id template, same \`'approved'\` status, same empty-default constraints/capabilities/capability-gaps/artifacts, same timestamps. Only the id-prefix, analysis summary, and metadata differ.

Extracted the shared scaffolding to a new \`pipeline/task-contract-builders.ts\`. Each call site now supplies only the fields that differ. Adding a new field to \`TaskContractSchema\` requires updating one place instead of two.

## Side-by-side

| | Before | After |
| --- | --- | --- |
| \`v2-orchestrate.ts\` | 20 lines of inline \`TaskContract\` literal | 6 lines calling \`buildBaseTaskContract\` |
| \`v2-delegate.ts\` | 35 lines of inline \`TaskContract\` literal | 6 lines calling \`buildBaseTaskContract\` |
| Shared scaffolding | duplicated across both files | centralized in \`task-contract-builders.ts\` |

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm vitest run src/pipeline/v2-orchestrate.test.ts src/pipeline/v2-delegate.test.ts\` → 32 passed
- [x] New \`task-contract-builders.test.ts\` (7 tests): schema validation, id format, timestamp equality, metadata copy-not-alias, empty defaults, status, analysis preservation
- [ ] CI

## Closes

Closes #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)