### PR TITLE
feat(mcp): add outputSchema to research_query + research_add (#2340 batch 1)

### DIFF
--- a/.changeset/2340-output-schemas-batch1.md
+++ b/.changeset/2340-output-schemas-batch1.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+Add `outputSchema` to `research_query` + `research_add` MCP tools (#2340 batch 1).
+
+Per the audit (#2337), 11 MCP tools (research*\*, memory*\*, plus a few others) lacked `outputSchema` while `consensus_vote` already had `CONSENSUS_VOTE_OUTPUT_SCHEMA`. MCP clients that respect output schemas (Claude Desktop, MCP Inspector, structured-pipeline frameworks) couldn't validate response shapes for the unschemaed tools.
+
+This PR migrates the first two:
+
+- `research_query` — envelope schema `{ action: string, success: boolean, data: unknown }`. Inner `data` is `z.unknown()` because the four action variants (status/overlap/stats/search) return different shapes; per-action schemas deferred.
+- `research_add` — concrete schema `{ success, paperId?, title?, message, dryRun? }` matching `executeResearchAdd`'s actual return type.
+
+Both handlers switched from `toolSuccess(JSON.stringify(...))` to `toolSuccessStructured(...)` so the SDK has `structuredContent` to validate against the schema.
+
+Remaining tools tracked in #2340 for follow-up batches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,7 @@ _Auto-generated from source. 34 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-03_
+_Governance Version: 2026-05-04_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/mcp/tools/research-add.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add.ts
@@ -17,7 +17,12 @@ import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middlewar
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import { addResearchPaper, paperExists } from '../../cli/research-helpers.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 import { getToolMemory } from './tool-memory.js';
 
 // =============================================================================
@@ -157,7 +162,7 @@ function createResearchAddHandler(deps: ResearchAddDeps) {
         return toolError(result.message);
       }
 
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
   };
 }
@@ -198,9 +203,18 @@ export function registerResearchAddTool(server: McpServer, deps: ResearchAddDeps
     logger,
   });
 
+  // Concrete shape returned by executeResearchAdd (#2340).
+  const outputSchema = {
+    success: z.boolean(),
+    paperId: z.string().optional(),
+    title: z.string().optional(),
+    message: z.string(),
+    dryRun: z.boolean().optional(),
+  };
+
   server.registerTool(
     'research_add',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_add tool with secure handler and timeout protection');

--- a/packages/nexus-agents/src/mcp/tools/research-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-query.ts
@@ -12,7 +12,12 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -202,7 +207,7 @@ function createResearchQueryHandler(deps: ResearchQueryDeps) {
     const logger = deps.logger ?? createLogger({ tool: 'research_query' });
     return withToolError('Research query failed', logger, async () => {
       const result = await executeQuery(validationResult.data);
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
   };
 }
@@ -250,9 +255,19 @@ export function registerResearchQueryTool(server: McpServer, deps: ResearchQuery
     logger,
   });
 
+  // Envelope schema (#2340). Inner `data` is intentionally `z.unknown()` —
+  // the four action variants (status/overlap/stats/search) return different
+  // shapes; modeling each precisely would require schema-per-action and is
+  // deferred. The envelope still gives MCP clients a stable validation surface.
+  const outputSchema = {
+    action: z.string(),
+    success: z.boolean(),
+    data: z.unknown(),
+  };
+
   server.registerTool(
     'research_query',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_query tool with secure handler and timeout protection');


### PR DESCRIPTION
Partial #2340. Audit-epic-#2337 finding.

## Summary

Per the audit, 11 MCP tools (research_*, memory_*, plus a few others) lacked \`outputSchema\` while \`consensus_vote\` already had \`CONSENSUS_VOTE_OUTPUT_SCHEMA\`. MCP clients that respect output schemas couldn't validate response shapes for the unschemaed tools.

This PR migrates the first two tools, establishing the pattern for follow-up batches.

## What changed

- **\`research_query\`** — envelope schema \`{ action: string, success: boolean, data: unknown }\`. Inner \`data\` is \`z.unknown()\` because the four action variants (status/overlap/stats/search) return different shapes; per-action schemas deferred.
- **\`research_add\`** — concrete schema \`{ success, paperId?, title?, message, dryRun? }\` matching \`executeResearchAdd\`'s actual return type.

Both handlers switched from \`toolSuccess(JSON.stringify(...))\` to \`toolSuccessStructured(...)\` so the SDK has \`structuredContent\` to validate against the schema (per the contract documented in \`tool-result.ts:81–86\`).

## Why partial

The remaining tools have varying response shapes that benefit from individual modeling. Forcing one PR to cover all 11 would mean either (a) using a permissive \`{}\` schema that delivers no contract value, or (b) making the PR sprawl across files I'd need to read carefully. Two-tool batches keep the diff reviewable and let me ship incremental progress.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm vitest run src/mcp/tools/research-query.test.ts src/mcp/tools/research-add.test.ts\` → 15 passed
- [ ] CI

## Closes (partial)

Closes #2340 partially — issue stays open until all tools migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)