### PR TITLE
feat(mcp): add outputSchema to remaining research_* tools (#2340 batch 3, closes)

### DIFF
--- a/.changeset/2340-output-schemas-batch3.md
+++ b/.changeset/2340-output-schemas-batch3.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Add `outputSchema` to remaining 5 research\_\* MCP tools (#2340 batch 3 — closes the issue).
+
+Final batch: `research_add_source`, `research_analyze`, `research_catalog_review`, `research_discover`, `research_synthesize`. Each handler switched from `toolSuccess(JSON.stringify(...))` to `toolSuccessStructured(...)` so the SDK validates `structuredContent` against the schema.
+
+Permissive shapes throughout this batch — the response inner content varies per action/source/cluster, and CI runs hit partial-init paths where some fields are absent. Top-level field names are typed; nested data uses `z.unknown()`.
+
+After this PR all 11 tools called out in the audit have `outputSchema`. The two remaining unschemaed tools — `weather_report` and `repo_analyze` — were intentionally deferred upstream (per the existing `outputSchema deferred for weather_report due to complex dynamic shape` note).

--- a/packages/nexus-agents/src/mcp/tools/research-add-source.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add-source.ts
@@ -24,7 +24,12 @@ import {
 } from '../../cli/research-helpers-sources-io.js';
 import { computeSourceQualityScore } from '../../research/source-quality.js';
 import type { ResearchSource } from '../../indexer/research-index/research-index-base-types.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 import { getToolMemory } from './tool-memory.js';
 
 // =============================================================================
@@ -258,7 +263,7 @@ function createResearchAddSourceHandler(deps: ResearchAddSourceDeps) {
         return toolError(result.message);
       }
 
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
   };
 }
@@ -312,7 +317,21 @@ export function registerResearchAddSourceTool(
 
   server.registerTool(
     'research_add_source',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema: RESEARCH_ADD_SOURCE_OUTPUT_SCHEMA },
     toSdkCallback(wrappedHandler)
   );
 }
+
+// Permissive shape — actual handler returns success+sourceId+name+
+// quality_score+evidence_tier+message+dryRun on success path, error on
+// failure (#2340 batch 3). Hoisted out of the registration fn for the
+// max-lines-per-function gate.
+const RESEARCH_ADD_SOURCE_OUTPUT_SCHEMA = {
+  success: z.boolean(),
+  sourceId: z.string().optional(),
+  name: z.string().optional(),
+  quality_score: z.number().optional(),
+  evidence_tier: z.string().optional(),
+  message: z.string().optional(),
+  dryRun: z.boolean().optional(),
+};

--- a/packages/nexus-agents/src/mcp/tools/research-analyze.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-analyze.ts
@@ -12,7 +12,12 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -396,7 +401,7 @@ function createResearchAnalyzeHandler(deps: ResearchAnalyzeDeps) {
     const logger = deps.logger ?? createLogger({ tool: 'research_analyze' });
     return withToolError('Analysis failed', logger, async () => {
       const result = await executeAnalysis(validationResult.data);
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
   };
 }
@@ -433,9 +438,18 @@ export function registerResearchAnalyzeTool(server: McpServer, deps: ResearchAna
     logger,
   });
 
+  // Permissive shape — handler returns ResearchAnalyzeResponse with focus,
+  // success, analysis (varies per focus), recommendations (#2340 batch 3).
+  const outputSchema = {
+    focus: z.string().optional(),
+    success: z.boolean().optional(),
+    analysis: z.unknown().optional(),
+    recommendations: z.array(z.string()).optional(),
+  };
+
   server.registerTool(
     'research_analyze',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_analyze tool with secure handler and timeout protection');

--- a/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
@@ -13,7 +13,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -243,7 +248,7 @@ function createCatalogReviewHandler(deps: ResearchCatalogReviewDeps) {
         return toolError(result.message);
       }
 
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
   };
 }
@@ -285,9 +290,18 @@ export function registerResearchCatalogReviewTool(
     logger,
   });
 
+  // Permissive shape — handler returns ResearchCatalogReviewResponse with
+  // action, success, message, optional data (#2340 batch 3).
+  const outputSchema = {
+    action: z.string().optional(),
+    success: z.boolean().optional(),
+    message: z.string().optional(),
+    data: z.unknown().optional(),
+  };
+
   server.registerTool(
     'research_catalog_review',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_catalog_review tool');

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -21,7 +21,12 @@ import {
 } from '../../core/index.js';
 import { normalizeTopicToCanonical } from '../../research/topic-aliases.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -555,7 +560,7 @@ function createResearchDiscoverHandler(deps: ResearchDiscoverDeps) {
     const response = await withToolError('Discovery failed', logger, async () => {
       const result = await executeDiscovery(validationResult.data, logger);
       recordDiscoverySuccess(result.topic, result.newItems, result.sourcesQueried);
-      return toolSuccess(JSON.stringify(result, null, 2));
+      return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
     const durationMs = Date.now() - startMs;
     if (response.isError === true) {
@@ -622,8 +627,24 @@ export function registerResearchDiscoverTool(server: McpServer, deps: ResearchDi
 
   server.registerTool(
     'research_discover',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema: RESEARCH_DISCOVER_OUTPUT_SCHEMA },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_discover tool with secure handler and timeout protection');
 }
+
+// Permissive shape — handler returns ResearchDiscoverResponse with topic,
+// sourcesQueried, failedSources, items, totalFound, alreadyInRegistry,
+// newItems, filteredByRelevance (#2340 batch 3). Items vary per source so
+// `items` is array-of-unknown. Hoisted out of the registration fn for the
+// max-lines-per-function gate.
+const RESEARCH_DISCOVER_OUTPUT_SCHEMA = {
+  topic: z.string().optional(),
+  sourcesQueried: z.array(z.string()).optional(),
+  failedSources: z.array(z.string()).optional(),
+  items: z.array(z.unknown()).optional(),
+  totalFound: z.number().optional(),
+  alreadyInRegistry: z.number().optional(),
+  newItems: z.number().optional(),
+  filteredByRelevance: z.number().optional(),
+};

--- a/packages/nexus-agents/src/mcp/tools/research-synthesize.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-synthesize.ts
@@ -17,7 +17,12 @@ import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middlewar
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { synthesizeResearch } from '../../cli/research-helpers-synthesize.js';
 import type { SynthesisResult } from '../../cli/research-helpers-synthesize.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolError,
+  toolSuccessStructured,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 
 // =============================================================================
 // SCHEMAS
@@ -66,7 +71,7 @@ function createResearchSynthesizeHandler(
       if (!result.ok) {
         return toolError(`Synthesis failed: ${result.error.message}`);
       }
-      return toolSuccess(JSON.stringify(result.value, null, 2));
+      return toolSuccessStructured(result.value as unknown as Record<string, unknown>);
     });
   };
 }
@@ -108,9 +113,19 @@ export function registerResearchSynthesizeTool(
     logger,
   });
 
+  // Permissive shape — handler returns SynthesisResult (clusters, alignment,
+  // cross-cutting themes, etc.); inner shapes vary, model the envelope only
+  // (#2340 batch 3).
+  const outputSchema = {
+    clusters: z.array(z.unknown()).optional(),
+    alignmentSummary: z.unknown().optional(),
+    crossCuttingThemes: z.array(z.unknown()).optional(),
+    generatedAt: z.string().optional(),
+  };
+
   server.registerTool(
     'research_synthesize',
-    { description, inputSchema: toolSchema },
+    { description, inputSchema: toolSchema, outputSchema },
     toSdkCallback(wrappedHandler)
   );
   logger.info('Registered research_synthesize tool');


### PR DESCRIPTION
Closes #2340. Audit-epic-#2337 finding. Final batch.

## Summary

Final batch of #2340 covering the last 5 research_* tools: \`research_add_source\`, \`research_analyze\`, \`research_catalog_review\`, \`research_discover\`, \`research_synthesize\`. Each handler switched from \`toolSuccess(JSON.stringify(...))\` to \`toolSuccessStructured(...)\` so the SDK validates \`structuredContent\` against the schema.

## Schemas (permissive — see \"Why permissive\" below)

| Tool | Schema |
| --- | --- |
| \`research_add_source\` | \`{ success, sourceId?, name?, quality_score?, evidence_tier?, message?, dryRun? }\` |
| \`research_analyze\` | \`{ focus?, success?, analysis?, recommendations? }\` |
| \`research_catalog_review\` | \`{ action?, success?, message?, data? }\` |
| \`research_discover\` | \`{ topic?, sourcesQueried?, failedSources?, items?, totalFound?, alreadyInRegistry?, newItems?, filteredByRelevance? }\` |
| \`research_synthesize\` | \`{ clusters?, alignmentSummary?, crossCuttingThemes?, generatedAt? }\` |

## Why permissive

Batch 2 (PR #2352) initially shipped a strict \`memory_stats\` schema that broke \`mcp-standalone-tools.test.ts\` in CI — backend init state differs in CI, and strict schemas reject responses with absent fields. Lesson learned: top-level field names are typed; nested data uses \`z.unknown()\`. This still gives MCP clients a stable validation surface ("response is an object with these named fields") without rejecting valid responses where some fields are absent.

## What's still unschemaed

- \`weather_report\` — intentionally deferred per existing TODO ("complex dynamic shape")
- \`repo_analyze\`, \`repo_security_plan\`, \`extract_symbols\`, \`search_codebase\` — also lack \`outputSchema\` but are out of scope for #2340 (not called out in the original audit).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (two functions had to hoist their schemas to module scope to fit the max-lines-per-function gate)
- [x] \`pnpm vitest run src/mcp/tools/research-*.test.ts\` → 31 passed
- [x] \`pnpm vitest run src/mcp/mcp-standalone-tools.test.ts\` → 11 passed (integration suite that broke batch 2 CI)
- [ ] CI

## Closes

Closes #2340

🤖 Generated with [Claude Code](https://claude.com/claude-code)