### PR TITLE
perf(mcp): replace synchronous readFileSync in pipeline handlers (#2354)

### DIFF
--- a/.changeset/2354-async-file-reads.md
+++ b/.changeset/2354-async-file-reads.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+`run_pipeline` and `run_dev_pipeline` no longer block libuv on file reads (#2354).
+
+`resolveTask()` (pipeline-tool.ts) and `resolveTaskInput()` (dev-pipeline-tool.ts) used `fs.readFileSync` inside async MCP request handlers. For multi-megabyte spec/plan files this stalled all in-flight MCP requests for the duration of the read. Both functions are now `async` and use `fs.promises.readFile`. Existing `ENOENT` error message is preserved (caught and rethrown as the same "Spec file not found" / "Plan file not found" string).

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -113,8 +113,13 @@ export type DevPipelineInput = z.infer<typeof DevPipelineInputSchema>;
 // Input Resolution
 // ============================================================================
 
-/** Resolve task input from direct instructions or file. */
-function resolveTaskInput(input: DevPipelineInput): string {
+/**
+ * Resolve task input from direct instructions or file.
+ *
+ * Async because plan files can be large and the previous synchronous read
+ * blocked libuv for the duration, stalling concurrent MCP requests (#2354).
+ */
+async function resolveTaskInput(input: DevPipelineInput): Promise<string> {
   if (input.task !== undefined && input.task.trim() !== '') {
     return input.task;
   }
@@ -125,10 +130,14 @@ function resolveTaskInput(input: DevPipelineInput): string {
     if (!resolved.startsWith(cwdRoot)) {
       throw new Error(`Path traversal denied: planFile must be within ${cwdRoot}`);
     }
-    if (!fs.existsSync(resolved)) {
-      throw new Error(`Plan file not found: ${resolved}`);
+    try {
+      return await fs.promises.readFile(resolved, 'utf-8');
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`Plan file not found: ${resolved}`);
+      }
+      throw err;
     }
-    return fs.readFileSync(resolved, 'utf-8');
   }
   throw new Error('Either task or planFile must be provided');
 }
@@ -200,7 +209,7 @@ export function registerDevPipelineTool(
       }
 
       try {
-        const taskText = resolveTaskInput(input);
+        const taskText = await resolveTaskInput(input);
         const stages = await createStages(input);
         const pipelineOptions = {
           ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -110,8 +110,13 @@ function buildOutput(result: AdaptiveOrchestratorResult): Record<string, unknown
 // Input Resolution
 // ============================================================================
 
-/** Resolve task text — prepend spec file content if provided. */
-function resolveTask(task: string, specFile: string | undefined): string {
+/**
+ * Resolve task text — prepend spec file content if provided.
+ *
+ * Async because spec files can be large and the previous synchronous read
+ * blocked libuv for the duration, stalling concurrent MCP requests (#2354).
+ */
+async function resolveTask(task: string, specFile: string | undefined): Promise<string> {
   if (specFile === undefined) return task;
   const resolved = path.resolve(specFile);
   // Path traversal guard — restrict to cwd subtree (security audit 2026-04-10)
@@ -119,11 +124,15 @@ function resolveTask(task: string, specFile: string | undefined): string {
   if (!resolved.startsWith(cwdRoot)) {
     throw new Error(`Path traversal denied: specFile must be within ${cwdRoot}`);
   }
-  if (!fs.existsSync(resolved)) {
-    throw new Error(`Spec file not found: ${resolved}`);
+  try {
+    const specContent = await fs.promises.readFile(resolved, 'utf-8');
+    return `${specContent}\n\n---\n\n${task}`;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Spec file not found: ${resolved}`);
+    }
+    throw err;
   }
-  const specContent = fs.readFileSync(resolved, 'utf-8');
-  return `${specContent}\n\n---\n\n${task}`;
 }
 
 /** Select the appropriate stage registry based on template or auto-detection. */
@@ -166,7 +175,7 @@ export function registerPipelineTool(
       }
 
       try {
-        const task = resolveTask(input.task, input.specFile);
+        const task = await resolveTask(input.task, input.specFile);
         const agentStages = createAgentStages({
           simulateVotes: input.simulateVotes,
           votingStrategy: input.votingStrategy,


### PR DESCRIPTION
Closes #2354. Audit-epic-#2337 wave-6 finding.

## Summary

Two MCP request handlers were doing \`fs.readFileSync\` inside async callbacks, blocking libuv for the duration of the read. Under concurrent load with multi-megabyte spec/plan files, all in-flight MCP requests stall.

## What changed

- \`pipeline-tool.ts:resolveTask()\` → \`async\`, uses \`fs.promises.readFile\`
- \`dev-pipeline-tool.ts:resolveTaskInput()\` → same conversion
- Both call sites updated to \`await\` the result
- \`ENOENT\` handling preserved: caught and rethrown with the same human-readable \"Spec file not found\" / \"Plan file not found\" message so consumers see no behavior change

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm vitest run src/mcp/tools/dev-pipeline-tool.test.ts src/mcp/mcp-standalone-tools.test.ts\` → 18 passed (11 integration + 7 unit)
- [ ] CI

## Closes

Closes #2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)