### PR TITLE
fix(ci): grant issues:write to System Review create-issue job

### DIFF
--- a/.github/workflows/system-review.yml
+++ b/.github/workflows/system-review.yml
@@ -241,6 +241,12 @@ jobs:
       (github.event.inputs.create_issue == 'true' || github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # The job uses `gh issue create`; the top-level `permissions: read-all`
+    # blocks that with "Resource not accessible by integration (createIssue)".
+    # Scope the write to this job only.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
The System Review workflow has been failing on main with \`Resource not accessible by integration (createIssue)\`. Root cause: top-level \`permissions: read-all\` denies \`gh issue create\` in the \`create-issue\` job.

## Fix

Scoped \`issues: write\` to the single job that needs it; other jobs (\`check-trigger\`, \`run-review\`) keep \`read-all\`. Minimal blast radius.

## Verification

- Last failure: run [25321345385](https://github.com/williamzujkowski/nexus-agents/actions/runs/25321345385) at 2026-05-04T13:28:01Z, exit code 1, exact error \`GraphQL: Resource not accessible by integration (createIssue)\`.
- After this PR ships, the next scheduled run (Mon 09:00 UTC) should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)