### PR TITLE
refactor(2368): batch C — remove deprecated public-barrel types

### DIFF
--- a/.changeset/2368-batch-c-public-barrel-removal.md
+++ b/.changeset/2368-batch-c-public-barrel-removal.md
@@ -1,0 +1,38 @@
+---
+'nexus-agents': minor
+---
+
+**Breaking (TypeScript-typed only)**: Remove deprecated public-barrel types from the MCP entry points (Batch C of #2368, completes #1986 partial).
+
+Removed from `mcp/index.ts` and `mcp/tools/index.ts` public re-exports, and from `OrchestrateDeps`:
+
+- `ITechLead` — internal-only now (kept for the SICA adapter cascade); no longer re-exported on public barrels. Use `IOrchestrator` from `core/types/orchestrator.js` instead.
+- `IOrchestratorLegacy` — pure dead alias of `ITechLead`. Removed.
+- `IExpertFactory` (the one in `orchestrate-types.ts`) — pure dead interface, only typed an unused field. The unrelated `IExpertFactory` interfaces in `workflows/step-executor.ts` and `mcp/tools/create-expert.ts` are unaffected.
+- `IOrchestrateExpertFactory` aliased re-export — no longer needed.
+- `createMockTechLead` — public export removed; the mock task-executor logic is now an inlined private helper inside `createMockOrchestrator`.
+- `OrchestrateDeps.techLead` field — use `OrchestrateDeps.orchestrator` instead. The internal cli-server-tools.ts callsite now wraps the legacy `Orchestrator` agent class with `OrchestratorFactory.create('tech_lead')` to produce an `IOrchestrator`.
+- `OrchestrateDeps.expertFactory` field — never used. Removed along with the `IExpertFactory` interface that typed it.
+
+**Migration**:
+
+```diff
+- import type { ITechLead, IOrchestratorLegacy } from 'nexus-agents';
++ import type { IOrchestrator } from 'nexus-agents';
+```
+
+```diff
+- registerOrchestrateTool(server, { techLead: myOrchestrator });
++ registerOrchestrateTool(server, { orchestrator: myOrchestrator });
+```
+
+```diff
+- import { createMockTechLead } from 'nexus-agents';
+- const mock = createMockTechLead();
++ import { createMockOrchestrator } from 'nexus-agents';
++ const mock = createMockOrchestrator();
+```
+
+Bake duration: deprecated since #595/#759 — multi-month under the `@deprecated` marker. Runtime semantics are unchanged; the cascade through `OrchestratorFactory.create('tech_lead')` produces identical behavior.
+
+The `useMockTechLead` config field name and `OrchestratorType = 'tech_lead' | …` discriminator are deliberately preserved for now — separate concerns, separate follow-up PRs.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -48,14 +48,15 @@ import {
   registerSearchCodebaseTool,
   createDefaultDeps,
 } from './mcp/index.js';
-// Import mock directly from source (not public API - used as fallback when no adapter)
-import { createMockTechLead } from './mcp/tools/orchestrate.js';
+import { createMockOrchestrator } from './mcp/tools/orchestrate-types.js';
+import { OrchestratorFactory } from './orchestration/orchestrator-factory.js';
+import type { IOrchestrator } from './core/types/orchestrator.js';
 import { registerDevPipelineTool } from './mcp/tools/dev-pipeline-tool.js';
 import { registerPipelineTool } from './mcp/tools/pipeline-tool.js';
 
 import type { Expert } from './agents/index.js';
 import { createRealWorkflowEngine } from './workflows/index.js';
-import type { IModelAdapter, WorkflowDefinition } from './core/index.js';
+import type { IModelAdapter, Result, WorkflowDefinition } from './core/index.js';
 import { getErrorMessage, NexusError, ErrorCode } from './core/index.js';
 
 import { Orchestrator } from './agents/index.js';
@@ -177,14 +178,20 @@ const MOCK_ORCHESTRATION_ENV = 'NEXUS_ALLOW_MOCK_ORCHESTRATION';
  *
  * @throws {OrchestratorUnavailableError} When no adapter and mock not explicitly requested
  */
-/* eslint-disable @typescript-eslint/no-deprecated -- Intentional: backwards compat, will migrate to IOrchestrator (Issue #595) */
 function createOrchestratorForOrchestration(
   modelAdapter: IModelAdapter | undefined,
   logger: ILogger,
   useMockTechLead?: boolean
-): import('./mcp/tools/orchestrate.js').ITechLead {
+): IOrchestrator {
   if (modelAdapter !== undefined) {
-    return new Orchestrator({ adapter: modelAdapter, logger });
+    const orchestratorAgent = new Orchestrator({ adapter: modelAdapter, logger });
+    const factory = new OrchestratorFactory({
+      logger,
+      techLead: orchestratorAgent as unknown as {
+        execute: (task: unknown) => Promise<Result<unknown, unknown>>;
+      },
+    });
+    return factory.create('tech_lead');
   }
 
   // Issue #554/#540: Check both config option and environment variable
@@ -196,7 +203,7 @@ function createOrchestratorForOrchestration(
     logger.warn(
       `Using mock orchestrator as explicitly configured via ${source} (no real adapter available)`
     );
-    return createMockTechLead();
+    return createMockOrchestrator();
   }
 
   throw new OrchestratorUnavailableError(
@@ -205,7 +212,6 @@ function createOrchestratorForOrchestration(
       'or configure an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_AI_API_KEY).'
   );
 }
-/* eslint-enable @typescript-eslint/no-deprecated */
 
 /** Tool registration context passed to helpers. */
 interface ToolRegistrationContext {
@@ -387,7 +393,7 @@ function registerOrchestrateToolSafe(ctx: ToolRegistrationContext): void {
       ctx.useMockTechLead
     );
     registerOrchestrateTool(ctx.server, {
-      techLead: orchestrator,
+      orchestrator,
       logger: ctx.logger,
       rateLimiter: ctx.rateLimiterFactory.getForTool('orchestrate'),
       security: ctx.securityConfig,

--- a/packages/nexus-agents/src/mcp/index.ts
+++ b/packages/nexus-agents/src/mcp/index.ts
@@ -156,10 +156,6 @@ export {
   type OrchestrateInput,
   type OrchestrateOutput,
   type OrchestrateDeps,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: re-export deprecated API for backwards compat
-  type ITechLead,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: re-export deprecated API for backwards compat
-  type IOrchestrateExpertFactory,
   // delegate_to_model tool
   registerDelegateToModelTool,
   DelegateInputSchema,

--- a/packages/nexus-agents/src/mcp/tools/index.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.ts
@@ -48,10 +48,6 @@ export {
   type OrchestrateInput,
   type OrchestrateOutput,
   type OrchestrateDeps,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: re-export deprecated API for backwards compat
-  type ITechLead,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: re-export deprecated API for backwards compat
-  type IExpertFactory as IOrchestrateExpertFactory,
 } from './orchestrate.js';
 
 // Note: createMockOrchestrator is available for testing via direct import from orchestrate.js

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-sica.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-sica.ts
@@ -13,7 +13,7 @@ import type { Result, ILogger, Task, AgentError, IModelAdapter } from '../../cor
 import { Orchestrator } from '../../agents/index.js';
 import { SicaAgent, createSicaAgent } from '../../agents/self-improving/sica-agent.js';
 import { isSicaEnabled, getSicaConfig } from '../../cli-server-sica.js';
-import type { ITechLead } from './orchestrate.js';
+import type { ITechLead } from './orchestrate-types.js';
 
 /**
  * Creates an orchestrator agent (optionally wrapped with SICA).
@@ -25,7 +25,7 @@ import type { ITechLead } from './orchestrate.js';
  * @param adapter - Optional model adapter for LLM-based analysis (Issue #827)
  * @returns Orchestrator-compatible agent
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: backwards compat (Issue #595)
+
 export function createOrchestratorWithSica(logger: ILogger, adapter?: IModelAdapter): ITechLead {
   const orchestrator = new Orchestrator({ logger, ...(adapter !== undefined ? { adapter } : {}) });
 
@@ -72,7 +72,7 @@ export function createOrchestratorWithSica(logger: ILogger, adapter?: IModelAdap
  *
  * Transforms SicaExecutionResult to the shape expected by orchestrate tool.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: backwards compat (Issue #595)
+
 function createSicaOrchestratorAdapter(sicaAgent: SicaAgent, _logger: ILogger): ITechLead {
   return {
     async execute(
@@ -115,7 +115,7 @@ function createSicaOrchestratorAdapter(sicaAgent: SicaAgent, _logger: ILogger): 
  * This is useful for accessing SICA-specific functionality like
  * version management and improvement history.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: backwards compat (Issue #595)
+
 export function getSicaAgentFromOrchestrator(_orchestrator: ITechLead): SicaAgent | undefined {
   // This function exists for future extensibility when we need
   // to access SICA internals from the wrapped agent.

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -13,7 +13,7 @@ import type { IOrchestrator, OrchestratorType } from '../../core/types/orchestra
 import type { WorkflowPattern } from '../../orchestration/workflow-router-types.js';
 import type { IMcpNotifier } from '../mcp-notifier.js';
 import type { BaseMcpToolDeps } from './tool-result.js';
-import type { ExecutionPlan, Expert } from '../../agents/index.js';
+import type { ExecutionPlan } from '../../agents/index.js';
 import { OrchestratorFactory } from '../../orchestration/orchestrator-factory.js';
 
 // ============================================================================
@@ -101,8 +101,8 @@ export const ORCHESTRATE_TOOL_SCHEMA = {
 // ============================================================================
 
 /**
- * @deprecated Use IOrchestrator from core/types/orchestrator.js instead.
- * Will be removed in v3.0. (Issue #595, #759)
+ * Internal task-executor shape used by the SICA orchestrator wrapping cascade.
+ * Not exported on public barrels — consumers should use `IOrchestrator`.
  */
 export interface ITechLead {
   execute(
@@ -110,30 +110,9 @@ export interface ITechLead {
   ): Promise<Result<{ taskId: string; output: unknown; metadata: unknown }, AgentError>>;
 }
 
-/**
- * Preferred alias for ITechLead.
- * @deprecated Use IOrchestrator from core/types/orchestrator.js for new code.
- */
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: backward compat alias
-export type IOrchestratorLegacy = ITechLead;
-
-/**
- * @deprecated Not used with unified orchestrator pattern.
- * Will be removed in v3.0. (Issue #595)
- */
-export interface IExpertFactory {
-  createBuiltIn(type: string): Result<Expert, AgentError>;
-}
-
 export interface OrchestrateDeps extends BaseMcpToolDeps {
   /** Pre-configured orchestrator instance (unified interface). */
   orchestrator?: IOrchestrator;
-  /** @deprecated Use orchestrator instead. Will be removed in v3.0. */
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: deprecated API for backwards compat
-  techLead?: ITechLead;
-  /** @deprecated Not used with unified orchestrator pattern. Will be removed in v3.0. */
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: deprecated API for backwards compat
-  expertFactory?: IExpertFactory;
   /** Model adapter for fallback orchestration path (Issue #827) */
   modelAdapter?: import('../../core/index.js').IModelAdapter | undefined;
   /** MCP notifier for client-visible logging (Issue #974) */
@@ -182,10 +161,9 @@ export class OrchestrationUnavailableError extends AgentError {
 // ============================================================================
 
 /**
- * @deprecated Use createMockOrchestrator instead. Will be removed in v3.0.
+ * Internal mock task executor used by `createMockOrchestrator`. Not exported.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Deprecated export for backwards compatibility
-export function createMockTechLead(): ITechLead {
+function createMockTaskExecutor(): ITechLead {
   return {
     execute(task: Task) {
       const complexity = clamp(Math.floor(task.description.length / 50), 1, 10);
@@ -229,10 +207,9 @@ export function createMockTechLead(): ITechLead {
 
 /** Creates a mock orchestrator for testing (Issue #595). */
 export function createMockOrchestrator(): IOrchestrator {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Using deprecated for backwards compat
-  const mockTechLead = createMockTechLead();
+  const mockExecutor = createMockTaskExecutor();
   const factory = new OrchestratorFactory({
-    techLead: mockTechLead as { execute: (task: unknown) => Promise<Result<unknown, unknown>> },
+    techLead: mockExecutor as { execute: (task: unknown) => Promise<Result<unknown, unknown>> },
   });
   return factory.create('tech_lead');
 }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -103,10 +103,6 @@ export {
   type OrchestrateDeps,
   type RoutingInfo,
 } from './orchestrate-types.js';
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Re-exporting deprecated types for backwards compat
-export type { ITechLead, IExpertFactory } from './orchestrate-types.js';
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- Re-exporting deprecated API for backwards compat
-export { createMockTechLead } from './orchestrate-types.js';
 
 // ============================================================================
 // Task Creation & Output Building
@@ -206,8 +202,7 @@ function createOrchestratorFromDeps(
   orchestratorType?: OrchestratorType
 ): IOrchestrator {
   if (deps.orchestrator !== undefined) return deps.orchestrator;
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Backwards compatibility
-  const techLead = deps.techLead ?? createOrchestratorWithSica(logger, deps.modelAdapter);
+  const techLead = createOrchestratorWithSica(logger, deps.modelAdapter);
   const factory = new OrchestratorFactory({
     logger,
     techLead: techLead as { execute: (task: unknown) => Promise<Result<unknown, unknown>> },


### PR DESCRIPTION
## Summary

Completes the deprecated-types removal from epic #2368 (closes the type-side of #1986). **Breaking — TypeScript-typed only.** Runtime semantics unchanged.

Drops the v3.0 gate per maintainer direction (2026-05-04). Bake duration: deprecated since #595/#759 — multi-month under the \`@deprecated\` marker.

## Removed from public MCP barrels (\`mcp/index.ts\` and \`mcp/tools/index.ts\`)

- \`ITechLead\` → use \`IOrchestrator\` from \`core/types/orchestrator.js\`
- \`IOrchestratorLegacy\` (alias of \`ITechLead\`) → use \`IOrchestrator\`
- \`IExpertFactory\` (the orchestrate-types.ts flavor) → unused; the unrelated \`IExpertFactory\` interfaces in \`workflows/step-executor.ts\` and \`mcp/tools/create-expert.ts\` are **unaffected**
- \`IOrchestrateExpertFactory\` aliased re-export
- \`createMockTechLead\` → use \`createMockOrchestrator\`
- \`OrchestrateDeps.techLead\` field → use \`OrchestrateDeps.orchestrator\`
- \`OrchestrateDeps.expertFactory\` field → never used at any consumer site

\`ITechLead\` survives as an **internal-only** type for the SICA adapter cascade (\`orchestrate-sica.ts\` still depends on the \`{execute(task)}\` shape to wrap with \`SicaAgent\`). Confirmed not reachable via any \`src/exports/*.ts\` barrel.

## Migration

\`\`\`diff
- import type { ITechLead, IOrchestratorLegacy } from 'nexus-agents';
+ import type { IOrchestrator } from 'nexus-agents';
\`\`\`

\`\`\`diff
- registerOrchestrateTool(server, { techLead: myOrchestrator });
+ registerOrchestrateTool(server, { orchestrator: myOrchestrator });
\`\`\`

\`\`\`diff
- import { createMockTechLead } from 'nexus-agents';
- const mock = createMockTechLead();
+ import { createMockOrchestrator } from 'nexus-agents';
+ const mock = createMockOrchestrator();
\`\`\`

## Internal callsite migration

\`cli-server-tools.ts\`'s \`createOrchestratorForOrchestration\` previously returned \`ITechLead\`. It now returns \`IOrchestrator\`, wrapping the legacy \`Orchestrator\` agent class via \`OrchestratorFactory.create('tech_lead')\` to produce the canonical interface. The mock path uses \`createMockOrchestrator()\` directly. The orchestrate registration now passes \`orchestrator:\` instead of \`techLead:\`.

## Out of scope (separate PRs)

- \`useMockTechLead\` config field rename → \`useMockOrchestrator\` (option-name break, narrower audience)
- \`agents/experts/task-analyzer.ts\` removal (separate concern, public \`analyzeTask\` on agents barrel)
- \`OrchestratorType = 'tech_lead' | 'workflow' | 'puppeteer' | 'custom'\` discriminator rename (separate type system, not an \`AgentRole\`)

## Verification

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- \`pnpm vitest run\`: **26,414 passed**, 16 skipped, 1055 files

## Test plan

- [x] Local typecheck/lint/test all green
- [ ] CI green
- [ ] Multi-voter consensus_vote QA approves
- [ ] No surprises in TypeDoc public-API drift

Refs #2368, #1986, #595, #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)