### PR TITLE
refactor(2373): remove deprecated BaseAgent.setState

### DIFF
--- a/.changeset/2373-remove-setstate.md
+++ b/.changeset/2373-remove-setstate.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Remove the deprecated `BaseAgent.setState()` method (#2373, follow-up to #2368/#1986).
+
+The protected `setState` method was marked `@deprecated Use stateMachine.transition() directly`. It is removed; callers should use `stateMachine.transition(event)` for known events, or the renamed helper `transitionToState({ stateMachine, logger, newState })` when only the target state is known.
+
+`base-agent-state-helpers.ts` `performLegacyStateTransition` is renamed to `transitionToState` (drops the deprecation marker, function preserved with the same `mapStatesToEvent` mapping logic). The 2 internal callers in `BaseAgent.complete()` and the test helper are updated accordingly.
+
+Patch-level break: `setState` was a `protected` method — internal-only. No public consumer impact.

--- a/packages/nexus-agents/src/agents/base-agent-state-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/base-agent-state-helpers.test.ts
@@ -3,11 +3,9 @@
  * @module agents/base-agent-state-helpers.test
  */
 
-/* eslint-disable @typescript-eslint/no-deprecated -- testing deprecated function */
-
 import { describe, it, expect, vi } from 'vitest';
 import type { AgentState } from '../core/index.js';
-import { performLegacyStateTransition, type SetStateParams } from './base-agent-state-helpers.js';
+import { transitionToState, type SetStateParams } from './base-agent-state-helpers.js';
 
 // ============================================================================
 // Test Helpers
@@ -37,26 +35,26 @@ function makeMockLogger() {
 }
 
 // ============================================================================
-// performLegacyStateTransition
+// transitionToState
 // ============================================================================
 
-describe('performLegacyStateTransition', () => {
+describe('transitionToState', () => {
   it('calls forceError when newState is error', () => {
     const sm = makeMockStateMachine('acting');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'error',
     } as unknown as SetStateParams);
-    expect(sm.forceError).toHaveBeenCalledWith({ reason: 'setState called with error' });
+    expect(sm.forceError).toHaveBeenCalledWith({ reason: 'transitionToState called with error' });
     expect(sm.transition).not.toHaveBeenCalled();
   });
 
   it('transitions via mapped event for idle->thinking', () => {
     const sm = makeMockStateMachine('idle');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'thinking',
@@ -68,7 +66,7 @@ describe('performLegacyStateTransition', () => {
   it('transitions via mapped event for thinking->acting', () => {
     const sm = makeMockStateMachine('thinking');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'acting',
@@ -79,7 +77,7 @@ describe('performLegacyStateTransition', () => {
   it('transitions via mapped event for acting->idle', () => {
     const sm = makeMockStateMachine('acting');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'idle',
@@ -90,7 +88,7 @@ describe('performLegacyStateTransition', () => {
   it('transitions via mapped event for error->idle (recovered)', () => {
     const sm = makeMockStateMachine('error');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'idle',
@@ -102,7 +100,7 @@ describe('performLegacyStateTransition', () => {
     const sm = makeMockStateMachine('idle');
     sm.transition.mockReturnValue({ ok: false, error: new Error('Invalid transition') });
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'thinking',
@@ -117,7 +115,7 @@ describe('performLegacyStateTransition', () => {
     const sm = makeMockStateMachine('idle');
     sm.canTransition.mockReturnValue(false);
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'thinking',
@@ -130,14 +128,14 @@ describe('performLegacyStateTransition', () => {
     const sm = makeMockStateMachine('idle');
     const logger = makeMockLogger();
     // idle -> waiting has no mapping
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'waiting',
     } as unknown as SetStateParams);
     expect(sm.transition).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      'Unmapped state change (legacy)',
+      'Unmapped state change',
       expect.objectContaining({ from: 'idle', to: 'waiting' })
     );
   });
@@ -145,7 +143,7 @@ describe('performLegacyStateTransition', () => {
   it('does nothing for same state (no mapping, same state)', () => {
     const sm = makeMockStateMachine('idle');
     const logger = makeMockLogger();
-    performLegacyStateTransition({
+    transitionToState({
       stateMachine: sm,
       logger,
       newState: 'idle',

--- a/packages/nexus-agents/src/agents/base-agent-state-helpers.ts
+++ b/packages/nexus-agents/src/agents/base-agent-state-helpers.ts
@@ -9,7 +9,7 @@ import type { ILogger, AgentState } from '../core/index.js';
 import type { AgentStateMachine } from './state-machine.js';
 import { mapStatesToEvent } from './state-machine-types.js';
 
-/** Parameters for legacy setState operation. */
+/** Parameters for transitioning to a target state. */
 export interface SetStateParams {
   stateMachine: AgentStateMachine;
   logger: ILogger;
@@ -17,16 +17,20 @@ export interface SetStateParams {
 }
 
 /**
- * Attempts a state transition using the state machine.
- * Maps legacy state names to state machine events for backward compatibility.
- * @deprecated Use stateMachine.transition() directly for new code
+ * Transition the state machine to a target state by deriving the
+ * appropriate event from (current → target). Used by BaseAgent's
+ * internal lifecycle hooks where the call site knows the target
+ * state but not the underlying event name.
+ *
+ * For state machines with explicit event names known at the call
+ * site, prefer `stateMachine.transition(event)` directly.
  */
-export function performLegacyStateTransition(params: SetStateParams): void {
+export function transitionToState(params: SetStateParams): void {
   const { stateMachine, logger, newState } = params;
   const currentState = stateMachine.state;
 
   if (newState === 'error') {
-    stateMachine.forceError({ reason: 'setState called with error' });
+    stateMachine.forceError({ reason: 'transitionToState called with error' });
     return;
   }
 
@@ -42,6 +46,6 @@ export function performLegacyStateTransition(params: SetStateParams): void {
       });
     }
   } else if (currentState !== newState) {
-    logger.debug('Unmapped state change (legacy)', { from: currentState, to: newState });
+    logger.debug('Unmapped state change', { from: currentState, to: newState });
   }
 }

--- a/packages/nexus-agents/src/agents/base-agent.test.ts
+++ b/packages/nexus-agents/src/agents/base-agent.test.ts
@@ -26,6 +26,7 @@ import {
   type BaseAgentOptions,
 } from './base-agent.js';
 import { SimpleAgent } from './simple-agent.js';
+import { transitionToState } from './base-agent-state-helpers.js';
 import type { IEventBus, TypedEvent } from './collaboration/event-bus-types.js';
 
 /**
@@ -180,8 +181,11 @@ class TestAgent extends BaseAgent {
   }
 
   testSetState(state: 'idle' | 'thinking' | 'acting' | 'waiting' | 'error'): void {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Test helper for deprecated method
-    this.setState(state);
+    transitionToState({
+      stateMachine: this.stateMachine,
+      logger: this.logger,
+      newState: state,
+    });
   }
 }
 

--- a/packages/nexus-agents/src/agents/base-agent.ts
+++ b/packages/nexus-agents/src/agents/base-agent.ts
@@ -27,7 +27,7 @@ import { TokenBudgetTracker, type ITokenBudgetTracker } from '../context/token-b
 import type { IMemoryBackend } from '../context/memory-backend-types.js';
 import type { ITypedMemory, TypedMemoryEntry } from '../context/memory-types.js';
 import { AgentStateMachine } from './state-machine.js';
-import { performLegacyStateTransition } from './base-agent-state-helpers.js';
+import { transitionToState } from './base-agent-state-helpers.js';
 import { setupStateMachine, initializeInfrastructure } from './base-agent-constructor-helpers.js';
 import { BaseAgentOptionsSchema } from './agent-schemas.js';
 import type { IEventBus } from './collaboration/event-bus-types.js';
@@ -195,16 +195,6 @@ export abstract class BaseAgent implements IAgent {
     };
   }
 
-  /** @deprecated Use stateMachine.transition() directly for new code */
-  protected setState(newState: AgentState): void {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional legacy support
-    performLegacyStateTransition({
-      stateMachine: this.stateMachine,
-      logger: this.logger,
-      newState,
-    });
-  }
-
   async initialize(ctx: AgentContext): Promise<Result<void, AgentError>> {
     const initCtx = buildInitializationContext(this.contextState);
     const result = await performInitialization(initCtx, ctx);
@@ -300,11 +290,17 @@ export abstract class BaseAgent implements IAgent {
     if (!adapterResult.ok) return adapterResult;
     const preCheckResult = await executePreCompletionChecks(ctx);
     if (!preCheckResult.ok) return preCheckResult;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Internal backward compatibility
-    this.setState('acting');
+    transitionToState({
+      stateMachine: this.stateMachine,
+      logger: this.logger,
+      newState: 'acting',
+    });
     const result = await runModelCompletion(ctx, adapterResult.value, request);
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- Internal backward compatibility
-    this.setState('thinking');
+    transitionToState({
+      stateMachine: this.stateMachine,
+      logger: this.logger,
+      newState: 'thinking',
+    });
     return result;
   }
 


### PR DESCRIPTION
## Summary

Removes the deprecated protected \`BaseAgent.setState()\` method (closes #2373, follow-up to epic #2368/#1986). Internal-only break — \`setState\` is \`protected\`, not on any public barrel.

The \`base-agent-state-helpers.ts\` \`performLegacyStateTransition\` function is renamed to \`transitionToState\`. The function body — \`mapStatesToEvent()\` mapping + \`stateMachine.transition()\` — is preserved verbatim. Only the \`@deprecated\` marker and the \"Legacy\" naming are dropped.

## Why

\`setState\` was marked \`@deprecated Use stateMachine.transition() directly for new code\` — but the helper it wraps does load-bearing work (maps \`AgentState\` pair → \`StateMachineEvent\`). Pure inlining at every call site would duplicate the mapping logic; renaming the helper to a non-deprecated identifier achieves the cleanup goal.

## Migration (internal callers)

| Callsite | Before | After |
|---|---|---|
| \`BaseAgent.complete()\` | \`this.setState('acting')\` | \`transitionToState({ stateMachine, logger, newState: 'acting' })\` |
| \`BaseAgent.test.ts:testSetState\` | \`this.setState(state)\` | \`transitionToState({ stateMachine: this.stateMachine, logger: this.logger, newState: state })\` |
| \`base-agent-state-helpers.test.ts\` | \`performLegacyStateTransition({...})\` | \`transitionToState({...})\` |

For external consumers: \`setState\` was \`protected\` — not part of any subclass-overriding pattern documented in the public API. If a downstream package extended \`BaseAgent\` and overrode \`setState\`, the override is now dead code. Migration: switch to overriding the lifecycle hooks that drive state changes (e.g., \`complete()\`, \`runTask()\`).

## Verification

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- \`pnpm vitest run\`: **26,414 passed**, 16 skipped, 1055 files

## Test plan

- [x] Local typecheck/lint/test all green
- [ ] CI green
- [ ] Multi-voter consensus_vote QA approves

Closes #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)