### PR TITLE
fix(e2e): wrap analyzer.analyze in Promise.resolve for measureLatency

### DIFF
--- a/packages/nexus-agents/src/testing/e2e/agents/agent-skill-library.e2e.test.ts
+++ b/packages/nexus-agents/src/testing/e2e/agents/agent-skill-library.e2e.test.ts
@@ -236,7 +236,7 @@ describe('Agent Skill Library E2E Tests', () => {
     it('should analyze tasks quickly', async () => {
       const task = createTestTask('Review this code for security issues');
       const analyzer = createSharedTaskAnalyzer();
-      const { result, ms } = await measureLatency(() => analyzer.analyze(task));
+      const { result, ms } = await measureLatency(() => Promise.resolve(analyzer.analyze(task)));
 
       expect(result).toBeDefined();
       expect(ms).toBeLessThan(100); // Should be very fast


### PR DESCRIPTION
Followup to PR #2378. The agent-skill-library e2e performance test was using `measureLatency(() => analyzer.analyze(task))` after migration to `SharedTaskAnalyzer`. Local `pnpm typecheck` passed (Vitest's loose TS resolution masked the issue), but CI's `tsc --noEmit` caught that `analyze()` returns `TaskAnalysisResult` synchronously while `measureLatency` requires `() => Promise<T>`.

Wrap with `Promise.resolve()` so the signature matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)