### PR TITLE
feat(skills): tier D1 — cross-pollinate code-review + docs (#2385)

### DIFF
--- a/.changeset/2385-tier-d1-cross-pollinate.md
+++ b/.changeset/2385-tier-d1-cross-pollinate.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+Tier D1 of epic #2385 — cross-pollinate addyosmani/agent-skills patterns into 2 existing skills:
+
+**`reviewing-code`** (was 104 → now 137 lines):
+
+- Five-axis review framework (Correctness / Readability / Architecture / Security / Performance)
+- Anti-rationalization table (6 rows: small-change excuse, tests-pass-so-correct, trust-the-author, CI-catches-everything, refactor-differently, author-decides)
+- Output categorization (Critical / Important / Suggestion) with discipline note ("if everything is Critical, nothing is")
+- References cross-link to security-checklist and testing-patterns
+- Cross-link to .claude/agents/code-reviewer.md persona
+
+**`documentation-management`** (was 305 → now 380 lines):
+
+- New ADR section: when to write, full template, lifecycle (PROPOSED → ACCEPTED → SUPERSEDED/DEPRECATED), when NOT to ADR
+- Anti-rationalization table for documentation (6 rows: code-self-documenting, document-later, next-release, comments-lie, nobody-reads, internal-API-doesn't-need)
+- New verification checklist for doc changes
+- Cross-link to docs/adr/ tree
+
+Both skills retain their existing content unchanged — purely additive cross-pollination. Pure-patch release.

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -298,8 +298,92 @@ For our auto-generated tables (CLAUDE.md MCP tools, `capabilities.md`, `docs/int
 
 ---
 
+## Architecture Decision Records (ADRs)
+
+ADRs capture the _why_ behind significant technical decisions. Code shows _what_ was built; ADRs explain _why this way_ and _what alternatives were rejected_. They're the highest-leverage documentation in the repo for onboarding (humans and agents) and for evaluating future changes.
+
+ADRs live in [`docs/adr/`](../../docs/adr/) with sequential numbering: `0001-foo.md`, `0002-bar.md`, …
+
+### When to write an ADR
+
+- Choosing a framework, library, or major dependency (consensus_vote candidate)
+- Designing a data model or schema
+- Selecting an authentication, voting, or routing strategy
+- Deciding on a public-API shape (REST, MCP tool, CLI command)
+- **Any decision expensive to reverse** — that's the threshold
+
+### ADR template
+
+```markdown
+# ADR-NNNN: <decision in present tense>
+
+## Status
+
+Proposed | Accepted | Superseded by ADR-MMMM | Deprecated
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+What problem are we solving? What constraints (technical, organizational, time-bound) apply?
+Cite the issue, vote, or incident that prompted the decision.
+
+## Decision
+
+The chosen approach, in 1-3 sentences.
+
+## Alternatives Considered
+
+Each as its own subsection. Pros, cons, and **why rejected**. Don't skip — the rejected
+alternatives are how future readers understand the trade-off space.
+
+## Consequences
+
+Positive AND negative outcomes. What new constraints does this create?
+What follow-up work falls out of this decision?
+```
+
+### ADR lifecycle
+
+```text
+PROPOSED → ACCEPTED → (SUPERSEDED-BY-NNNN | DEPRECATED)
+```
+
+- **Don't delete old ADRs.** They're historical context. A superseded ADR + its replacement together tell the story of why the system evolved.
+- **When a decision changes, write a new ADR** that references and supersedes the old one. Update the old one's `Status:` line to `Superseded by ADR-NNNN`.
+- ADRs are **immutable after Accepted** in spirit — fix typos, but don't rewrite the substance. New thinking goes in a new ADR.
+
+### When NOT to write an ADR
+
+- Reversible decisions (small refactor choices, naming style nits)
+- Mechanical changes (dependency bump, lockfile update)
+- Decisions already captured in a higher-level doc (`CLAUDE.md`, `.rules/`) — reference, don't duplicate
+
+## Anti-rationalization — Documentation
+
+| Excuse                                      | Counter                                                                                                                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The code is self-documenting"              | Code says **how**, not **why**. The why-this-not-that lives nowhere if not in an ADR or doc comment.                                                                            |
+| "I'll document it later"                    | Later never comes. The context decays within days; what felt obvious now will be a mystery to next-quarter-you. Document at decision time.                                      |
+| "We'll update the docs in the next release" | Drift compounds. By the next release, the doc says one thing, the code does another, and the audit gate fires (see #2225 audit). Update docs in the same PR as the code change. |
+| "Comments lie, only code is truth"          | Lies-in-comments is a culture problem, not a comments problem. Code can also lie (subtly broken implementations). Both need review.                                             |
+| "Nobody reads the docs anyway"              | Future-you reads them. New contributors (human or agent) read them. The skill-tree of the project depends on them.                                                              |
+| "It's just an internal API"                 | Internal APIs accumulate Hyrum's Law just like public ones (see `api-and-interface-design`). Internal docs prevent internal coupling.                                           |
+
+## Verification — Documentation changes
+
+- [ ] Every public-API change has a documentation update in the same PR
+- [ ] Significant architectural decisions have an ADR (or reference an existing one)
+- [ ] Auto-generated docs regenerated via the pipeline scripts after source changes
+- [ ] Doc additions follow the Tier system (Tier 1 essential / Tier 2 reference / Tier 3 detail)
+- [ ] No drift from canonical sources — `npx tsx scripts/check-docs-indexed.ts` passes
+- [ ] Markdown lint clean: `npx markdownlint 'docs/**/*.md' '*.md'`
+
 ## Related Documents
 
 - **DocOps Spec:** [docs/ops/docops-spec.md](../../docs/ops/docops-spec.md)
 - **Documentation Index:** [docs/README.md](../../docs/README.md)
 - **Inventory:** [docs/ops/docs-inventory.md](../../docs/ops/docs-inventory.md)
+- **ADR directory:** [docs/adr/](../../docs/adr/)

--- a/skills/reviewing-code/SKILL.md
+++ b/skills/reviewing-code/SKILL.md
@@ -10,10 +10,24 @@ allowed-tools: Read, Grep, Glob, Bash, LSP
 
 # Code Review Skill
 
-<!-- CANONICAL SOURCES:
+<!--
+  CANONICAL SOURCES:
   - CODING_STANDARDS.md
   - docs/architecture/SECURITY.md
+  - skills/references/security-checklist.md (OWASP Top 10, validation patterns)
+  - skills/references/testing-patterns.md (test-quality assessment)
+  - .claude/agents/code-reviewer.md (Staff-Engineer narrative-review persona)
 -->
+
+## Five-axis review framework
+
+Evaluate every change across these dimensions. The order matters — correctness gates merge; the rest are quality.
+
+1. **Correctness** — does the code do what the spec says? Are edge cases (null, empty, boundary, error paths) handled? Are the tests actually testing the behavior, not just the implementation?
+2. **Readability** — would another engineer understand this without explanation? Names follow project conventions? Control flow straightforward?
+3. **Architecture** — does it follow existing canonical patterns (`CLAUDE.md` "Canonical Paths") or introduce a new one? Module boundaries respected? No circular deps? Abstraction level appropriate?
+4. **Security** — input validated at boundaries (per `.rules/untrusted-input.md`)? Secrets out of code/logs? Auth/authz where needed? Parameterized queries? See [security-checklist](../references/security-checklist.md).
+5. **Performance** — N+1 patterns? Unbounded data fetching? Sync I/O in hot paths? Re-render storms? Missing pagination? Don't optimize without evidence — see `performance-optimization` skill.
 
 **Full documentation:**
 
@@ -82,6 +96,27 @@ Before flagging any finding, run this checklist:
 If any check raises "wait, actually..." → **drop the finding**. Don't
 file, don't include in the report. False positives compound: pollute
 the backlog, train future agents on noise, erode trust in tooling.
+
+## Anti-rationalization — Code review
+
+| Excuse                                             | Counter                                                                                                                                                                     |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It's a small change, no need for thorough review" | Small changes hide subtle bugs: off-by-one, missed null check, type narrowing slipped. Apply the 4-point gate to every finding regardless of diff size.                     |
+| "Tests pass, so it's correct"                      | Tests verify what was tested. Edge cases the tests don't cover are still bugs. Use the five-axis framework — correctness ≠ "tests green."                                   |
+| "I trust the author"                               | Trust is for the human relationship; the review is for the code. Apply the same gate to senior contributors as to first-timers.                                             |
+| "The CI gates would catch any real issue"          | CI catches a known set of failure modes. Reviews catch the ones CI doesn't model — architecture drift, unclear naming, subtle security gaps, unintended public-API changes. |
+| "I'd refactor this differently, but it works"      | If the existing pattern is canonical (per CLAUDE.md), don't fight it. If your way is genuinely better, file a follow-up — don't gate the merge.                             |
+| "I'll flag it; the author can decide"              | Every flagged finding costs review-cycle time. Apply the 4-point gate first; only flag what passed all four.                                                                |
+
+## Output categorization
+
+Every finding gets one of three tags. The bar matters — over-flagging dilutes the signal.
+
+- **Critical** — must fix before merge. Security vulnerability, data loss risk, broken functionality, public-API regression.
+- **Important** — should fix before merge. Missing test, wrong abstraction, poor error handling, type-safety violation.
+- **Suggestion** — consider for improvement. Naming, code style, optional optimization, alternative approach. Author may accept or defer.
+
+If you tag everything Critical, nothing is Critical. Three or more Critical findings on a non-emergency PR usually means the PR is too big — split it.
 
 ## Review Output
 


### PR DESCRIPTION
## Summary

Tier D1 of epic #2385 — cross-pollinate addyosmani/agent-skills patterns into 2 existing skills. **Purely additive** — existing content unchanged.

## reviewing-code (104 → 137 lines)

- **Five-axis review framework**: Correctness / Readability / Architecture / Security / Performance, explicitly named at the top. Our existing 4-point verification gate (#2225 audit) preserved as the gate-on-flagging.
- **Anti-rationalization table** (6 rows): small-change excuse, tests-pass-so-correct, trust-the-author, CI-catches-everything, refactor-differently, author-decides.
- **Output categorization**: Critical / Important / Suggestion, with discipline note ('if everything is Critical, nothing is').
- References cross-link to `security-checklist.md`, `testing-patterns.md`, and `.claude/agents/code-reviewer.md` persona.

## documentation-management (305 → 380 lines)

- **New ADR section**: when to write, full template, lifecycle (PROPOSED → ACCEPTED → SUPERSEDED/DEPRECATED), when NOT to ADR.
- **Anti-rationalization table** (6 rows): code-self-documenting, document-later, next-release, comments-lie, nobody-reads, internal-API-doesn't-need.
- **New verification checklist** for doc changes (pipeline scripts, lint, ADR for arch decisions).
- Cross-link to `docs/adr/` tree.

## Pure-patch

- No API change
- No behavior change
- No new skills (count stays at 25)
- skills/index.yaml unchanged (frontmatter not touched)

## Verification

- `npx markdownlint 'skills/**/*.md'` clean
- `npx tsx scripts/inject-governance.ts` regen confirms 25 skills

## Test plan

- [x] markdownlint clean
- [ ] CI green
- [ ] `consensus_vote` QA approves

Refs #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)