### PR TITLE
feat(skills): tier D3 — final cross-pollination batch (#2385)

### DIFF
--- a/.changeset/2385-tier-d3-cross-pollinate.md
+++ b/.changeset/2385-tier-d3-cross-pollinate.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Tier D3 of epic #2385 — final cross-pollination batch. Enhances 3 existing skills with patterns from addyosmani/agent-skills (MIT, © 2025 Addy Osmani):
+
+**`requirements-gathering`** — adds Divergent → Convergent thinking (3-step ideation pass: diverge with sharpening questions + 2-3 variations, converge by clustering and stress-testing, sharpen-and-ship with explicit "Not Doing" list). Adds dependency-graph identification for multi-task plans (parallel-safe vs serial bottlenecks). Anti-rationalization table (5 rows: solution-not-problem, obvious-no-need-to-write, scope-as-we-go, "works"-criterion, ignore-dependencies).
+
+**`implement-feature`** — adds Thin vertical slices methodology (Implement → Test → Verify → Commit → Next slice cycle), the 100-line rule (stop and reconsider before writing more than ~100 lines without testing), anti-rationalization table for incremental implementation (5 rows).
+
+**`ui-ux-design`** — adds "Avoid the AI aesthetic" table calling out 8 common LLM-generated UI tells (gradient hero, lorem ipsum, oversized padding, stock card grids, shadow-heavy elevation, emoji icons, every-weight sans-serif, generic CTAs) with production-quality alternatives. Adds composition-over-configuration pattern with cross-link to api-and-interface-design. Anti-rationalization table (6 rows).
+
+All edits purely additive — existing content unchanged. Pure-patch release. Completes Tier D of the epic.

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -117,3 +117,40 @@ Before marking ANY technique or feature as "implemented", verify ALL of the foll
 - [ ] PR merged (if applicable)
 
 **Do NOT mark as implemented if:** tests fail, implementation is partial, or feature is behind a flag.
+
+## Thin vertical slices (incremental implementation)
+
+Build the smallest end-to-end working piece first, then expand. Avoid implementing the whole feature in one pass — each slice should leave the system in a working, testable state.
+
+### The increment cycle
+
+```text
+Implement → Test → Verify → Commit → Next slice
+```
+
+For each slice:
+
+1. **Implement** the smallest complete piece of functionality (must be end-to-end, not just one layer)
+2. **Test** — run the test suite (write a new test if none covers this slice — see `test-driven-development` skill)
+3. **Verify** — confirm the slice works (tests pass, build succeeds, manual check if user-facing)
+4. **Commit** — small, focused commit with a clear message
+5. **Next slice** — only after the previous one is verifiable
+
+### The 100-line rule
+
+If you're about to write more than ~100 lines without testing, **stop**. Either:
+
+- Split the work into a smaller slice that fits the cycle, OR
+- Confirm with the user that the larger scope is justified (e.g., a generated stub from a schema)
+
+Larger commits hide bugs, fight `git bisect`, and bloat code review surface. Small commits compound; large commits accumulate risk.
+
+### Anti-rationalization — Incremental implementation
+
+| Excuse                                             | Counter                                                                                                                      |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| "It's all related, makes sense to commit together" | "Related" hides the failure boundary. Atomic commits separate "the failing change" from "everything else."                   |
+| "I'll test it all at the end"                      | The end is when you're already deep into the next problem. The cycle catches issues while you still have context.            |
+| "Splitting this is artificial"                     | Each slice should be end-to-end (vertical, not horizontal). If you can't make a slice end-to-end, the design is too coupled. |
+| "This is faster as one big push"                   | Maybe per-keystroke. Per-PR-merged-to-main, the cycle is faster because debug time grows superlinearly with diff size.       |
+| "I'll commit when tests pass"                      | Tests passing is the floor, not the ceiling. Each slice gets its own commit; tests passing is what makes the commit safe.    |

--- a/skills/requirements-gathering/SKILL.md
+++ b/skills/requirements-gathering/SKILL.md
@@ -115,3 +115,50 @@ Summarize the implementation approach:
 - Planning a new epic or large feature
 - Evaluating whether a request is feasible with current capabilities
 - Bridging between user intent and technical implementation
+
+## Divergent → Convergent thinking
+
+For ambiguous or open-ended requests, run a structured ideation pass before settling on requirements:
+
+### Step 1 — Diverge
+
+Restate the idea in your own words, then ask three sharpening questions:
+
+1. **What problem does this actually solve?** Often the request describes a solution, not the problem.
+2. **Who is harmed if we don't do this?** Identifies the real stakeholder.
+3. **What would success look like at the end of the first hour of use?** Concretizes the acceptance criterion.
+
+Then generate 2-3 variations of the request — different scopes, different users, different mechanisms.
+
+### Step 2 — Converge
+
+For each variation:
+
+- **Cluster** — what assumptions does this share with the others?
+- **Stress-test** — what's the failure mode? What if the assumption is wrong?
+- **Surface hidden constraints** — what is the user assuming we already know? (Tech stack, deadlines, audience, success metrics)
+
+### Step 3 — Sharpen and ship
+
+Produce a one-pager with: Problem statement, Recommended direction, Key assumptions, MVP scope, **Not Doing** list. The Not Doing list is the highest-value section — it makes scope decisions explicit.
+
+## Dependency-graph identification
+
+When the request becomes a multi-task plan, map dependencies before sequencing:
+
+1. **List the tasks.**
+2. **For each task, identify what must exist before it can run** (schemas, APIs, data, other modules, tests, docs).
+3. **Identify parallel-safe tasks** — those with no shared dependencies.
+4. **Identify serial bottlenecks** — single tasks that block many downstream items.
+
+Sequence: serial bottlenecks first, then parallel-safe waves of 3-4 (per `.rules/subagent-coordination.md`), then late-stage integration tasks.
+
+## Anti-rationalization — Requirements
+
+| Excuse                                                        | Counter                                                                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| "The user said X, so we build X"                              | Users describe solutions; you need the problem. Restate, ask the three sharpening questions.                             |
+| "This is obvious, no need to write it down"                   | Obvious to whom? Different stakeholders read "obvious" differently. The Not Doing list catches the silent disagreements. |
+| "We can figure out scope as we go"                            | Scope creep is the most expensive bug. Lock the MVP and the Not Doing list before writing code.                          |
+| "The acceptance criterion is 'when it works'"                 | "Works" is unfalsifiable. The criterion is a test or a user scenario the spec can be measured against.                   |
+| "We don't need to identify dependencies, we'll just hit them" | Hitting dependencies serial costs ~Nx the time vs identified-and-parallelized. Map first, then sequence.                 |

--- a/skills/ui-ux-design/SKILL.md
+++ b/skills/ui-ux-design/SKILL.md
@@ -344,3 +344,54 @@ Every output MUST satisfy:
 - CSP-compatible patterns (no inline event handlers)
 - Validate form inputs client-side AND server-side
 - No sensitive data in client-side state or URLs
+
+## Avoid the AI aesthetic
+
+LLM-generated UI has recognizable tells. Avoid all of them — they signal low quality and break visual hierarchy.
+
+| AI default                                                  | Why it's a problem                                                           | Production quality                                                               |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Gradient hero backgrounds                                   | Template-driven, no connection to content or brand                           | Content-first layouts that reflect the actual product                            |
+| Lorem ipsum-style copy                                      | Hides layout problems real content would expose (length, wrapping, overflow) | Realistic placeholder content of expected length                                 |
+| Oversized padding everywhere                                | Equal generous padding destroys visual hierarchy and wastes space            | Consistent spacing scale (project's design system)                               |
+| Stock card grids for everything                             | Uniform grids ignore information priority and scanning patterns              | Purpose-driven layouts (lists, dashboards, dense tables — chosen, not defaulted) |
+| Shadow-heavy "elevation" everywhere                         | Competing depth slows rendering on low-end devices and flattens hierarchy    | Subtle or no shadows unless the design system specifies                          |
+| Emoji-as-iconography                                        | Inconsistent platform rendering, accessibility issues                        | Project's icon library (named, not emoji)                                        |
+| "Modern" sans-serif at every weight                         | No type hierarchy; everything looks the same                                 | Project's typography scale with intentional weight choices                       |
+| Generic call-to-action labels ("Get Started", "Learn More") | Don't tell the user what they'll get                                         | Action-specific labels matching the user's actual next step                      |
+
+## Composition over configuration
+
+Prefer composable component primitives over a monolithic component with 30 props.
+
+```tsx
+// Bad: configuration explosion
+<Card
+  title="..."
+  showHeader
+  showFooter
+  variant="bordered"
+  paddingSize="lg"
+  bodyAlignment="center"
+/>
+
+// Good: explicit composition
+<Card>
+  <CardHeader>...</CardHeader>
+  <CardBody>...</CardBody>
+  <CardFooter>...</CardFooter>
+</Card>
+```
+
+The composed version is more flexible (omit any sub-component, add new ones), and consumers see the structure in their own code rather than buried in `Card`'s prop interface. Cross-reference: `api-and-interface-design` skill — discriminated unions over flag fields applies here too.
+
+## Anti-rationalization — Frontend
+
+| Excuse                                      | Counter                                                                                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| "The AI aesthetic is fine for now"          | It signals low quality and erodes user trust. Use the project's actual design system from the start.                                       |
+| "I'll add accessibility later"              | "Later" doesn't come. Keyboard nav, ARIA labels, focus management ship in the same PR as the component (see `accessibility-checklist.md`). |
+| "Lorem ipsum is fine for placeholder"       | It hides text-length bugs that show up in production with real content. Use realistic placeholder copy.                                    |
+| "We'll polish the spacing in design review" | Spacing inconsistencies are the foundation; design review can't unfound them. Use the design-system spacing scale from line 1.             |
+| "Emoji icons are fine and faster"           | Cross-platform render is unreliable; accessibility is poor. Use the project icon library.                                                  |
+| "It works on my screen"                     | Test the breakpoints. Mobile (≤640px), tablet (640-1024), desktop (≥1024). At least three sizes per change.                                |


### PR DESCRIPTION
## Summary

Tier D3 of epic #2385 — final cross-pollination batch. **Closes Tier D** of the epic. Pure-patch additive across 3 skills.

## requirements-gathering

- **Divergent → Convergent thinking** (3-step ideation):
  - **Diverge**: restate, ask 3 sharpening questions, generate 2-3 variations
  - **Converge**: cluster, stress-test, surface hidden constraints
  - **Sharpen**: produce one-pager with explicit "Not Doing" list
- **Dependency-graph identification** for multi-task plans (parallel-safe vs serial bottlenecks)
- Anti-rationalization (5 rows: solution-not-problem, obvious-no-write, scope-as-we-go, 'works'-criterion, ignore-deps)

## implement-feature

- **Thin vertical slices** methodology (Implement → Test → Verify → Commit → Next slice cycle)
- **The 100-line rule** (stop and reconsider before writing > ~100 lines without testing)
- Anti-rationalization (5 rows)

## ui-ux-design

- **Avoid the AI aesthetic** table — 8 common LLM-generated UI tells with production-quality alternatives:

  | AI default | Production quality |
  |---|---|
  | Gradient hero backgrounds | Content-first layouts |
  | Lorem ipsum copy | Realistic placeholder text |
  | Oversized padding everywhere | Design-system spacing scale |
  | Stock card grids for everything | Purpose-driven layouts |
  | Shadow-heavy 'elevation' | Subtle/no shadows unless DS specifies |
  | Emoji-as-iconography | Project icon library |
  | 'Modern' sans-serif at every weight | Intentional type hierarchy |
  | Generic CTAs ('Get Started', 'Learn More') | Action-specific labels |

- **Composition over configuration** pattern with cross-link to `api-and-interface-design`
- Anti-rationalization (6 rows)

## Pure-patch

- No API change, no behavior change, no new skills (count stays at 25)
- Frontmatter unchanged in all 3 skills
- Trigger-whitespace regression test (#2389) still passes (7/7)

## Verification

- `npx markdownlint 'skills/**/*.md'` clean
- `npx vitest run scripts/generate-skills-index.test.ts` 7/7 passed

## Test plan

- [x] markdownlint + script test green
- [ ] CI green
- [ ] `consensus_vote` QA approves

Refs #2385

🤖 Generated with [Claude Code](https://claude.com/claude-code)