### PR TITLE
fix(ci): [skip-docops] honored on PR runs (#2411)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,7 +557,7 @@ _Auto-generated from source. 38 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-05_
+_Governance Version: 2026-05-06_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/scripts/check-docops-skill.test.ts
+++ b/scripts/check-docops-skill.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the DocOps skill-sync escape-hatch fix (#2411).
+ *
+ * The bug: `git log -1 --pretty=%B` reads only the latest commit message,
+ * which on GitHub Actions PR runs is the auto-generated merge-commit
+ * subject, NOT the developer's commit message. The fix walks the full
+ * PR commit range when GITHUB_BASE_REF is set so [skip-docops] in any
+ * commit on the branch is honored.
+ *
+ * Strategy: build a tiny throwaway git repo per test, set up a base ref
+ * and a feature branch, and assert getCommitMessagesForEscapeHatch returns
+ * the right text under each environment configuration.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { getCommitMessagesForEscapeHatch } from './check-docops-skill.js';
+
+interface RepoCtx {
+  dir: string;
+  origCwd: string;
+  origBaseRef: string | undefined;
+}
+
+function git(repoDir: string, cmd: string): string {
+  return execSync(`git -C "${repoDir}" ${cmd}`, { encoding: 'utf-8' });
+}
+
+function setupRepo(): RepoCtx {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docops-test-'));
+  const origCwd = process.cwd();
+  const origBaseRef = process.env['GITHUB_BASE_REF'];
+
+  git(dir, 'init -q -b main');
+  git(dir, 'config user.email test@example.com');
+  git(dir, 'config user.name Test');
+  git(dir, 'commit --allow-empty -q -m "initial commit on main"');
+
+  process.chdir(dir);
+  return { dir, origCwd, origBaseRef };
+}
+
+function teardownRepo(ctx: RepoCtx): void {
+  process.chdir(ctx.origCwd);
+  if (ctx.origBaseRef === undefined) {
+    delete process.env['GITHUB_BASE_REF'];
+  } else {
+    process.env['GITHUB_BASE_REF'] = ctx.origBaseRef;
+  }
+  fs.rmSync(ctx.dir, { recursive: true, force: true });
+}
+
+describe('getCommitMessagesForEscapeHatch (#2411)', () => {
+  let ctx: RepoCtx;
+
+  beforeEach(() => {
+    ctx = setupRepo();
+  });
+
+  afterEach(() => {
+    teardownRepo(ctx);
+  });
+
+  it('finds [skip-docops] in the latest commit when no PR base ref is set', () => {
+    delete process.env['GITHUB_BASE_REF'];
+    git(ctx.dir, 'commit --allow-empty -q -m "feat: change [skip-docops]"');
+
+    const out = getCommitMessagesForEscapeHatch(ctx.dir);
+
+    expect(out).toContain('[skip-docops]');
+  });
+
+  it('walks the PR commit range when GITHUB_BASE_REF is set, honoring branch tokens', () => {
+    git(ctx.dir, 'checkout -q -b feature');
+    git(ctx.dir, 'commit --allow-empty -q -m "feat: real change [skip-docops]"');
+    git(ctx.dir, 'commit --allow-empty -q -m "chore: lint fix"');
+
+    git(ctx.dir, 'update-ref refs/remotes/origin/main main');
+    process.env['GITHUB_BASE_REF'] = 'main';
+
+    const out = getCommitMessagesForEscapeHatch(ctx.dir);
+
+    expect(out).toContain('[skip-docops]');
+    expect(out).toContain('chore: lint fix');
+  });
+
+  it('does NOT see [skip-docops] when only the merge-commit message has it (the original bug)', () => {
+    git(ctx.dir, 'checkout -q -b feature');
+    git(ctx.dir, 'commit --allow-empty -q -m "feat: real change without bypass token"');
+
+    git(ctx.dir, 'update-ref refs/remotes/origin/main main');
+    process.env['GITHUB_BASE_REF'] = 'main';
+
+    const out = getCommitMessagesForEscapeHatch(ctx.dir);
+
+    expect(out).not.toContain('[skip-docops]');
+    expect(out).toContain('feat: real change without bypass token');
+  });
+
+  it('falls back to HEAD-only when GITHUB_BASE_REF points at a non-existent ref', () => {
+    git(ctx.dir, 'commit --allow-empty -q -m "feat: head-only message [skip-docops]"');
+    process.env['GITHUB_BASE_REF'] = 'nonexistent-base-ref-xyz';
+
+    const out = getCommitMessagesForEscapeHatch(ctx.dir);
+
+    expect(out).toContain('[skip-docops]');
+  });
+});

--- a/scripts/check-docops-skill.ts
+++ b/scripts/check-docops-skill.ts
@@ -89,13 +89,31 @@ function getChangedFiles(): string[] {
 }
 
 /**
- * Get the latest commit message to check for escape hatch.
+ * Get commit messages for the escape-hatch check.
+ *
+ * On GitHub Actions PR events, actions/checkout creates a merge ref so
+ * `git log -1` returns the auto-generated merge-commit subject, not the
+ * developer's commit. We walk the full PR commit range so [skip-docops]
+ * in any commit on the branch is honored. (#2411)
  */
-function getLatestCommitMessage(): string {
+function getCommitMessagesForEscapeHatch(cwd: string = REPO_ROOT): string {
+  const baseRef = process.env['GITHUB_BASE_REF'];
+  if (baseRef !== undefined && baseRef !== '') {
+    try {
+      return execSync(`git log origin/${baseRef}...HEAD --pretty=%B`, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch {
+      // fall through to HEAD-only
+    }
+  }
   try {
     return execSync('git log -1 --pretty=%B', {
-      cwd: REPO_ROOT,
+      cwd,
       encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
   } catch {
     return '';
@@ -176,8 +194,8 @@ function performCheck(_verbose: boolean): CheckResult {
     return result;
   }
 
-  // Check for escape hatch
-  const commitMessage = getLatestCommitMessage();
+  // Check for escape hatch — walks PR commit range when GITHUB_BASE_REF is set (#2411)
+  const commitMessage = getCommitMessagesForEscapeHatch();
   if (commitMessage.includes('[skip-docops]')) {
     result.escapeHatchUsed = true;
     result.success = true;
@@ -281,4 +299,9 @@ Escape hatch:
   process.exit(success ? 0 : 1);
 }
 
-main();
+export { getCommitMessagesForEscapeHatch };
+
+const invokedDirectly = process.argv[1]?.endsWith('check-docops-skill.ts') === true;
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
Closes #2411.

## What

`scripts/check-docops-skill.ts` was using `git log -1 --pretty=%B` to detect the `[skip-docops]` escape-hatch token. On GitHub Actions PR runs, `actions/checkout` defaults to the merge ref, so `git log -1` returns the auto-generated merge-commit subject (`Merge X into Y`), not the developer's commit message. The escape hatch was effectively non-functional in the context it was designed for.

## Fix

When `GITHUB_BASE_REF` is set, walk the full PR commit range:

```ts
git log origin/$GITHUB_BASE_REF...HEAD --pretty=%B
```

Any commit on the branch can carry the bypass token. Falls back to HEAD-only when not running in PR context (preserves direct-push behavior).

## Tests

Added `scripts/check-docops-skill.test.ts` with 4 unit tests that build a throwaway git repo per case and assert the function's behavior under each environment configuration:

- HEAD-only mode finds the token (non-PR context)
- PR mode finds the token in any commit on the branch
- PR mode does NOT see a token that only exists on the merge commit (the original bug)
- Falls back gracefully when `GITHUB_BASE_REF` points at a non-existent ref

Required a minor refactor: function now takes an optional `cwd` parameter (defaults to `REPO_ROOT`) so tests can target a temp dir; the script also gates `main()` behind a direct-invocation check so the module is importable.

## Why

The escape hatch is documented in the script's own error output, in `docs/ops/docops-spec.md`, and in `skills/documentation-management/SKILL.md`. Documented escape hatches that don't actually work are a trust bug — when someone tries `[skip-docops]` and gets the same VIOLATION, they learn that documented bypasses lie. Ships a working version of what's already promised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)