### PR TITLE
feat(graph): HITL Phase 2 hardening (#2425)

### DIFF
--- a/packages/nexus-agents/src/orchestration/graph/checkpoint-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/checkpoint-types.ts
@@ -29,6 +29,24 @@ export interface CheckpointInterrupt {
   readonly value: unknown;
   /** ISO timestamp when the interrupt fired. */
   readonly createdAt: string;
+  /**
+   * ISO timestamp when this interrupt was consumed by a successful
+   * resumeFromCheckpoint() call. A second resume against the same checkpoint
+   * is rejected — see #2425 idempotency requirement.
+   */
+  readonly consumedAt?: string;
+  /**
+   * Additional interrupts dropped because they fired in the same super-step
+   * as the primary one (#2425 multi-interrupt observability). Phase 1
+   * silently dropped these; Phase 2 surfaces them so operators can detect
+   * lost human-input requests in the wild. The executor still only honors
+   * the primary interrupt; downstream tooling can fan out from this list.
+   */
+  readonly additionalInterrupts?: readonly {
+    readonly nodeId: string;
+    readonly interruptId: string;
+    readonly value: unknown;
+  }[];
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor-hitl-phase2.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor-hitl-phase2.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for graph HITL Phase 2 hardening (#2425).
+ *
+ * Covers:
+ *   - Command.goto wiring (#2425 sub-task 1)
+ *   - Multi-interrupt-per-super-step observability (#2425 sub-task 2)
+ *   - Resume idempotency (#2425 sub-task 3)
+ *   - Resume failure path contract (#2425 sub-task 4)
+ *   - resumeValues Zod validation (#2425 sub-task 5)
+ *   - Status-leak audit safety (#2425 sub-task 6)
+ *
+ * Phase 1 contract surface is exercised in graph-executor-hitl.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { GraphBuilder, overwrite, START, END } from './graph-builder.js';
+import { executeGraph, resumeFromCheckpoint } from './graph-executor.js';
+import { interrupt } from './graph-types.js';
+import type { NodeContext, NodeReturn } from './graph-types.js';
+import { InMemoryCheckpointStore } from './checkpoint-store.js';
+
+describe('Command.goto (#2425 sub-task 1)', () => {
+  it('redirects the next runnable set to the goto target instead of resolving edges', async () => {
+    const graph = new GraphBuilder()
+      .addState('trail', overwrite<string>(''))
+      .addNode('a', () =>
+        Promise.resolve({
+          type: 'command' as const,
+          update: { trail: 'a' },
+          goto: 'c',
+        })
+      )
+      .addNode('b', (state) => Promise.resolve({ trail: `${(state['trail'] as string) || ''}+b` }))
+      .addNode('c', (state) => Promise.resolve({ trail: `${(state['trail'] as string) || ''}+c` }))
+      .addEdge(START, 'a')
+      .addEdge('a', 'b')
+      .addEdge('b', END)
+      .addEdge('c', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    if (!result.ok) return;
+    // Without goto: trail would be 'a+b'. With goto to c: trail is 'a+c'; b never runs.
+    expect(result.value.finalState['trail']).toBe('a+c');
+    expect(result.value.nodeResults.find((r) => r.nodeId === 'b')).toBeUndefined();
+    expect(result.value.nodeResults.find((r) => r.nodeId === 'c')).toBeDefined();
+  });
+
+  it('logs and ignores goto targets that are not in the compiled graph', async () => {
+    const graph = new GraphBuilder()
+      .addState('trail', overwrite<string>(''))
+      .addNode('a', () =>
+        Promise.resolve({ type: 'command' as const, update: { trail: 'a' }, goto: 'nonexistent' })
+      )
+      .addNode('b', (state) => Promise.resolve({ trail: `${(state['trail'] as string) || ''}+b` }))
+      .addEdge(START, 'a')
+      .addEdge('a', 'b')
+      .addEdge('b', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    if (!result.ok) return;
+    // Invalid target ignored — falls back to standard edge resolution: a → b.
+    expect(result.value.finalState['trail']).toBe('a+b');
+  });
+});
+
+describe('Multi-interrupt observability (#2425 sub-task 2)', () => {
+  // eslint-disable-next-line complexity -- many sequential narrowing checks
+  it('records primary + additional interrupts when two nodes interrupt in the same super-step', async () => {
+    const graph = new GraphBuilder()
+      .addState('seed', overwrite(0))
+      .addNode('one', () => Promise.resolve(interrupt('q-one', 'first?')))
+      .addNode('two', () => Promise.resolve(interrupt('q-two', 'second?')))
+      .addEdge(START, 'one')
+      .addEdge(START, 'two')
+      .addEdge('one', END)
+      .addEdge('two', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const result = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'multi-1',
+      }
+    );
+    if (!result.ok) return;
+
+    expect(result.value.halted).toBeDefined();
+    const checkpoint = store.latest('multi-1');
+    expect(checkpoint?.interrupt).toBeDefined();
+    expect(checkpoint?.interrupt?.additionalInterrupts?.length).toBe(1);
+    // The additional interrupt should be the one that wasn't picked as primary.
+    const primaryNodeId = result.value.halted?.nodeId;
+    const additionalNodeId = checkpoint?.interrupt?.additionalInterrupts?.[0]?.nodeId;
+    expect(['one', 'two']).toContain(primaryNodeId);
+    expect(['one', 'two']).toContain(additionalNodeId);
+    expect(primaryNodeId).not.toBe(additionalNodeId);
+  });
+
+  it('omits additionalInterrupts when only one node interrupted', async () => {
+    const graph = new GraphBuilder()
+      .addNode('only', () => Promise.resolve(interrupt('q', 'ctx')))
+      .addEdge(START, 'only')
+      .addEdge('only', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const result = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'multi-2',
+      }
+    );
+    if (!result.ok) return;
+
+    const checkpoint = store.latest('multi-2');
+    expect(checkpoint?.interrupt?.additionalInterrupts).toBeUndefined();
+  });
+});
+
+describe('Resume idempotency (#2425 sub-task 3)', () => {
+  it('rejects a second resume against the same checkpoint', async () => {
+    let askCalls = 0;
+    const graph = new GraphBuilder()
+      .addState('answer', overwrite<string | undefined>(undefined))
+      .addNode('ask', (_state, ctx?: NodeContext): Promise<NodeReturn> => {
+        askCalls += 1;
+        const supplied = ctx?.resumeValues['approval'];
+        if (typeof supplied === 'string') {
+          return Promise.resolve({ answer: supplied });
+        }
+        return Promise.resolve(interrupt('approval', 'go?'));
+      })
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'idem-1',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    const firstResume = await resumeFromCheckpoint(
+      graph.value,
+      checkpointId,
+      {
+        approval: 'yes',
+      },
+      { checkpointStore: store }
+    );
+    expect(firstResume.ok).toBe(true);
+
+    const secondResume = await resumeFromCheckpoint(
+      graph.value,
+      checkpointId,
+      {
+        approval: 'yes',
+      },
+      { checkpointStore: store }
+    );
+    expect(secondResume.ok).toBe(false);
+    if (secondResume.ok) return;
+    expect(secondResume.error.message).toContain('already resumed');
+    // The handler should NOT have been called a third time (1 initial + 1 successful resume).
+    expect(askCalls).toBe(2);
+  });
+
+  it('marks the checkpoint with a consumedAt timestamp on successful resume', async () => {
+    const graph = new GraphBuilder()
+      .addState('answer', overwrite<string | undefined>(undefined))
+      .addNode('ask', (_state, ctx?: NodeContext): Promise<NodeReturn> => {
+        const supplied = ctx?.resumeValues['approval'];
+        if (typeof supplied === 'string') return Promise.resolve({ answer: supplied });
+        return Promise.resolve(interrupt('approval', 'go?'));
+      })
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'idem-2',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    expect(store.load(checkpointId)?.interrupt?.consumedAt).toBeUndefined();
+    await resumeFromCheckpoint(
+      graph.value,
+      checkpointId,
+      { approval: 'yes' },
+      {
+        checkpointStore: store,
+      }
+    );
+    expect(store.load(checkpointId)?.interrupt?.consumedAt).toBeTypeOf('string');
+  });
+});
+
+describe('Resume failure path (#2425 sub-task 4)', () => {
+  it('returns a NodeResult with status=failed when the resumed node throws', async () => {
+    const graph = new GraphBuilder()
+      .addNode('ask', (_state, ctx?: NodeContext): Promise<NodeReturn> => {
+        const supplied = ctx?.resumeValues['q'];
+        if (supplied !== undefined) {
+          throw new Error('post-resume boom');
+        }
+        return Promise.resolve(interrupt('q', 'ctx'));
+      })
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'throw-1',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    const resumed = await resumeFromCheckpoint(
+      graph.value,
+      checkpointId,
+      { q: 'value' },
+      {
+        checkpointStore: store,
+      }
+    );
+    expect(resumed.ok).toBe(true); // Top-level executeGraph returns ok; failure is per-node.
+    if (!resumed.ok) return;
+    // nodeResults is cumulative across original-run + resumed-run; use the
+    // last entry for 'ask' to read the post-resume outcome.
+    const askResults = resumed.value.nodeResults.filter((r) => r.nodeId === 'ask');
+    expect(askResults.length).toBe(2);
+    expect(askResults[0]?.status).toBe('interrupted');
+    expect(askResults[1]?.status).toBe('failed');
+    expect(askResults[1]?.error).toContain('post-resume boom');
+  });
+});
+
+describe('resumeValues Zod validation (#2425 sub-task 5)', () => {
+  it('rejects non-object resumeValues (array)', async () => {
+    const graph = new GraphBuilder()
+      .addNode('ask', () => Promise.resolve(interrupt('q', 'ctx')))
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'zod-1',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    // Pass an array instead of a record.
+    const resumed = await resumeFromCheckpoint(graph.value, checkpointId, ['nope'], {
+      checkpointStore: store,
+    });
+    expect(resumed.ok).toBe(false);
+    if (resumed.ok) return;
+    expect(resumed.error.message).toContain('failed validation');
+  });
+
+  it('rejects null resumeValues', async () => {
+    const graph = new GraphBuilder()
+      .addNode('ask', () => Promise.resolve(interrupt('q', 'ctx')))
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'zod-2',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    const resumed = await resumeFromCheckpoint(graph.value, checkpointId, null, {
+      checkpointStore: store,
+    });
+    expect(resumed.ok).toBe(false);
+  });
+
+  it('accepts a plain object with arbitrary value shapes', async () => {
+    const graph = new GraphBuilder()
+      .addState('answer', overwrite<unknown>(undefined))
+      .addNode('ask', (_state, ctx?: NodeContext): Promise<NodeReturn> => {
+        const supplied = ctx?.resumeValues['q'];
+        if (supplied !== undefined) return Promise.resolve({ answer: supplied });
+        return Promise.resolve(interrupt('q', 'ctx'));
+      })
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const store = new InMemoryCheckpointStore();
+    const first = await executeGraph(
+      graph.value,
+      {},
+      {
+        checkpointStore: store,
+        executionId: 'zod-3',
+      }
+    );
+    if (!first.ok) return;
+    const checkpointId = first.value.halted?.checkpointId;
+    if (checkpointId === undefined) return;
+
+    const resumed = await resumeFromCheckpoint(
+      graph.value,
+      checkpointId,
+      { q: { nested: { object: true } } },
+      { checkpointStore: store }
+    );
+    expect(resumed.ok).toBe(true);
+    if (!resumed.ok) return;
+    expect(resumed.value.finalState['answer']).toEqual({ nested: { object: true } });
+  });
+});
+
+describe('Status-leak audit (#2425 sub-task 6)', () => {
+  it('keeps NodeResult.status === "interrupted" inside graph land — coercion is the consumer\'s job', async () => {
+    // Defense-in-depth check: the graph executor preserves the precise
+    // 'interrupted' status. Downstream consumers (pipeline-runner,
+    // scenario-live-executor) coerce to 'skipped' for their 3-state contract,
+    // and that coercion lives at their boundary — NOT in graph code.
+    const graph = new GraphBuilder()
+      .addNode('ask', () => Promise.resolve(interrupt('q', 'ctx')))
+      .addEdge(START, 'ask')
+      .addEdge('ask', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    if (!result.ok) return;
+    const askResult = result.value.nodeResults.find((r) => r.nodeId === 'ask');
+    expect(askResult?.status).toBe('interrupted');
+    // Sanity: 'interrupted' is distinguishable from 'skipped' at this layer.
+    expect(askResult?.status).not.toBe('skipped');
+  });
+
+  it('preserves the Interrupt envelope on NodeResult so downstream auditors can trace pause origins', async () => {
+    const graph = new GraphBuilder()
+      .addNode('gate', () =>
+        Promise.resolve(interrupt('require-human', 'sensitive: validate identity'))
+      )
+      .addEdge(START, 'gate')
+      .addEdge('gate', END)
+      .compile();
+    if (!graph.ok) return;
+
+    const result = await executeGraph(graph.value, {});
+    if (!result.ok) return;
+    const gateResult = result.value.nodeResults.find((r) => r.nodeId === 'gate');
+    expect(gateResult?.interrupt?.id).toBe('require-human');
+    expect(gateResult?.interrupt?.value).toBe('sensitive: validate identity');
+  });
+});

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -17,6 +17,7 @@ import { getErrorMessage, ok, err, createLogger, getTimeProvider } from '../../c
 
 import type {
   CompiledGraph,
+  Command,
   GraphState,
   GraphNode,
   GraphEdge,
@@ -28,7 +29,7 @@ import type {
   GraphExecuteOptions,
   StateFieldSchema,
 } from './graph-types.js';
-import { END, isInterrupt, isCommand } from './graph-types.js';
+import { END, isInterrupt, isCommand, ResumeValuesSchema } from './graph-types.js';
 import { createCheckpoint } from './checkpoint-store.js';
 import type { ICheckpointStore } from './checkpoint-types.js';
 import {
@@ -59,7 +60,13 @@ interface ExecutionContext {
   /** Resume values keyed by interrupt id, surfaced to nodes via NodeContext (#1895). */
   resumeValues: Readonly<Record<string, unknown>>;
   /** Set when a node in the current super-step returned an Interrupt (#1895). */
-  pendingInterrupt: { readonly nodeId: string; readonly interrupt: Interrupt } | undefined;
+  pendingInterrupt:
+    | {
+        readonly nodeId: string;
+        readonly interrupt: Interrupt;
+        readonly additional: readonly { readonly nodeId: string; readonly interrupt: Interrupt }[];
+      }
+    | undefined;
 }
 
 /**
@@ -123,25 +130,35 @@ export async function executeGraph(
  * Resume a paused graph execution from a HITL interrupt checkpoint (#1895).
  *
  * Loads the named checkpoint, validates that it carries interrupt metadata,
- * and re-runs the graph starting from the interrupted node. The supplied
- * `resumeValues` map (keyed by interrupt id) is delivered to that node's
- * NodeContext on the run that follows the resume call.
+ * Zod-parses `resumeValues` at the API boundary (#2425), checks idempotency
+ * (#2425), and re-runs the graph starting from the interrupted node. The
+ * supplied `resumeValues` map (keyed by interrupt id) is delivered to that
+ * node's NodeContext on the run that follows the resume call.
  *
  * Errors:
+ *   - checkpointStore not configured
  *   - checkpoint not found
- *   - checkpoint exists but isn't an interrupt checkpoint
+ *   - checkpoint has no interrupt metadata
+ *   - resumeValues fails Zod validation (#2425)
  *   - resumeValues missing the interrupt id this checkpoint is waiting for
+ *   - checkpoint already consumed (#2425)
  */
-export async function resumeFromCheckpoint(
-  graph: CompiledGraph,
+/**
+ * Validate the resume request — checkpoint loadable + valid resumeValues +
+ * matches the interrupt id + not already consumed. Returns either the
+ * validated context or an error.
+ */
+function validateResumeRequest(
+  store: ICheckpointStore,
   checkpointId: string,
-  resumeValues: Readonly<Record<string, unknown>>,
-  options: GraphExecuteOptions
-): Promise<Result<GraphExecutionResult, Error>> {
-  const store: ICheckpointStore | undefined = options.checkpointStore;
-  if (store === undefined) {
-    return err(new Error('resumeFromCheckpoint requires options.checkpointStore'));
-  }
+  resumeValues: unknown
+): Result<
+  {
+    checkpoint: NonNullable<ReturnType<ICheckpointStore['load']>>;
+    values: Record<string, unknown>;
+  },
+  Error
+> {
   const checkpoint = store.load(checkpointId);
   if (checkpoint === undefined) {
     return err(new Error(`Checkpoint not found: ${checkpointId}`));
@@ -152,20 +169,56 @@ export async function resumeFromCheckpoint(
       new Error(`Checkpoint ${checkpointId} has no interrupt metadata; not a paused execution.`)
     );
   }
-  if (!Object.prototype.hasOwnProperty.call(resumeValues, interruptCtx.interruptId)) {
+  if (interruptCtx.consumedAt !== undefined) {
+    return err(
+      new Error(
+        `Checkpoint ${checkpointId} already resumed at ${interruptCtx.consumedAt}; double-resume rejected.`
+      )
+    );
+  }
+  const parsed = ResumeValuesSchema.safeParse(resumeValues);
+  if (!parsed.success) {
+    return err(new Error(`resumeValues failed validation: ${parsed.error.message}`));
+  }
+  if (!Object.prototype.hasOwnProperty.call(parsed.data, interruptCtx.interruptId)) {
     return err(
       new Error(
         `resumeValues missing interrupt id '${interruptCtx.interruptId}' (paused at node '${interruptCtx.nodeId}')`
       )
     );
   }
+  return ok({ checkpoint, values: parsed.data });
+}
+
+export async function resumeFromCheckpoint(
+  graph: CompiledGraph,
+  checkpointId: string,
+  resumeValues: unknown,
+  options: GraphExecuteOptions
+): Promise<Result<GraphExecutionResult, Error>> {
+  const store: ICheckpointStore | undefined = options.checkpointStore;
+  if (store === undefined) {
+    return err(new Error('resumeFromCheckpoint requires options.checkpointStore'));
+  }
+  const validated = validateResumeRequest(store, checkpointId, resumeValues);
+  if (!validated.ok) return validated;
+  const { checkpoint, values } = validated.value;
+  const existing = checkpoint.interrupt;
+  if (existing === undefined) {
+    return err(new Error('unreachable: validateResumeRequest already checked .interrupt'));
+  }
+  // Mark consumed before re-running so a concurrent second call sees it.
+  store.save({
+    ...checkpoint,
+    interrupt: { ...existing, consumedAt: new Date().toISOString() },
+  });
   return executeGraph(
     graph,
     {},
     {
       ...options,
       executionId: checkpoint.executionId,
-      resumeValues,
+      resumeValues: values,
     }
   );
 }
@@ -176,6 +229,36 @@ export async function resumeFromCheckpoint(
  * or undefined when no checkpoint store was configured (interrupts still halt
  * the loop, but resumption is unavailable without persistence). (#1895)
  */
+function buildInterruptCheckpoint(
+  ctx: ExecutionContext,
+  execId: string,
+  pending: NonNullable<ExecutionContext['pendingInterrupt']>
+): ReturnType<typeof createCheckpoint> {
+  const { nodeId, interrupt, additional } = pending;
+  const additionalInterrupts =
+    additional.length > 0
+      ? additional.map((a) => ({
+          nodeId: a.nodeId,
+          interruptId: a.interrupt.id,
+          value: a.interrupt.value,
+        }))
+      : undefined;
+  return createCheckpoint({
+    executionId: execId,
+    stepNumber: ctx.stepsExecuted,
+    state: ctx.state,
+    pendingNodeIds: [nodeId],
+    completedResults: ctx.allResults,
+    interrupt: {
+      nodeId,
+      interruptId: interrupt.id,
+      value: interrupt.value,
+      createdAt: new Date().toISOString(),
+      ...(additionalInterrupts !== undefined ? { additionalInterrupts } : {}),
+    },
+  });
+}
+
 function saveInterruptCheckpoint(
   ctx: ExecutionContext,
   options?: GraphExecuteOptions
@@ -186,24 +269,11 @@ function saveInterruptCheckpoint(
     return undefined;
   }
   const { nodeId, interrupt } = ctx.pendingInterrupt;
-  const checkpoint = createCheckpoint({
-    executionId: execId,
-    stepNumber: ctx.stepsExecuted,
-    state: ctx.state,
-    // Re-run the interrupted node first on resume.
-    pendingNodeIds: [nodeId],
-    completedResults: ctx.allResults,
-    interrupt: {
-      nodeId,
-      interruptId: interrupt.id,
-      value: interrupt.value,
-      createdAt: new Date().toISOString(),
-    },
-  });
+  const checkpoint = buildInterruptCheckpoint(ctx, execId, ctx.pendingInterrupt);
   try {
     store.save(checkpoint);
-  } catch (err: unknown) {
-    const error = err instanceof Error ? err : new Error(String(err));
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e : new Error(String(e));
     logger.warn('Interrupt checkpoint save failed; resume unavailable', {
       executionId: execId,
       nodeId,
@@ -277,12 +347,43 @@ async function executeSuperStep(
   // Resume values are single-shot — clear after the super-step that consumed them. (#1895)
   ctx.resumeValues = {};
 
-  // Halt if any node returned an Interrupt — surfaces upward via ctx.pendingInterrupt.
-  // Multi-interrupt support is Phase 2; v1 records the first one.
-  const interrupted = results.find((r) => r.status === 'interrupted');
-  if (interrupted?.interrupt !== undefined) {
-    ctx.pendingInterrupt = { nodeId: interrupted.nodeId, interrupt: interrupted.interrupt };
-    ctx.runnableIds = [];
+  // Halt on any Interrupt return. The first becomes the primary; any others
+  // in the same super-step are surfaced as `additionalInterrupts` on the
+  // checkpoint so operators don't silently lose human-input requests (#2425).
+  const interrupted = results.filter(
+    (r) => r.status === 'interrupted' && r.interrupt !== undefined
+  );
+  if (interrupted.length > 0) {
+    const primary = interrupted[0];
+    if (primary?.interrupt !== undefined) {
+      const additional = interrupted.slice(1);
+      ctx.pendingInterrupt = {
+        nodeId: primary.nodeId,
+        interrupt: primary.interrupt,
+        additional: additional.map((r) => ({
+          nodeId: r.nodeId,
+          interrupt: r.interrupt as Interrupt,
+        })),
+      };
+      if (additional.length > 0) {
+        logger.warn('Multiple interrupts in one super-step — only primary is honored', {
+          primaryNodeId: primary.nodeId,
+          primaryInterruptId: primary.interrupt.id,
+          additionalCount: additional.length,
+          additionalNodeIds: additional.map((r) => r.nodeId),
+        });
+      }
+      ctx.runnableIds = [];
+      fireSuperStepCallbacks(results, ctx, options);
+      return;
+    }
+  }
+
+  // Honor Command.goto: if a node returned a Command with a goto target,
+  // override the normal edge-resolved next-runnable set. (#2425)
+  const overrides = collectGotoOverrides(graph, results);
+  if (overrides !== undefined) {
+    ctx.runnableIds = overrides;
     fireSuperStepCallbacks(results, ctx, options);
     return;
   }
@@ -290,6 +391,35 @@ async function executeSuperStep(
   const completedIds = results.filter((r) => r.status === 'success').map((r) => r.nodeId);
   ctx.runnableIds = resolveNextNodes(graph, completedIds, ctx.state, ctx);
   fireSuperStepCallbacks(results, ctx, options);
+}
+
+/**
+ * Walk the per-node returns and collect Command.goto targets. Returns the
+ * de-duplicated list of node IDs to redirect to, or undefined when no goto
+ * was issued (normal edge resolution path).
+ *
+ * Logs and skips invalid targets (unknown nodes); does not abort the run.
+ */
+function collectGotoOverrides(
+  graph: CompiledGraph,
+  results: readonly NodeResult[]
+): string[] | undefined {
+  const targets: string[] = [];
+  for (const r of results) {
+    const goto = r.gotoTarget;
+    if (goto === undefined) continue;
+    if (graph.nodes.has(goto)) {
+      targets.push(goto);
+    } else {
+      logger.warn('Command.goto target unknown — ignoring redirect', {
+        nodeId: r.nodeId,
+        target: goto,
+      });
+    }
+  }
+  if (targets.length === 0) return undefined;
+  // De-duplicate while preserving first-seen order.
+  return [...new Set(targets)];
 }
 
 /** Fire onNodeComplete + emit lifecycle events + save checkpoint. */
@@ -487,18 +617,24 @@ function preconditionFailedResult(
 }
 
 /**
- * Reduce a raw NodeReturn into the (stateUpdates, interrupt?) pair the
- * executor cares about. Centralizes Interrupt/Command unwrapping (#1895).
+ * Reduce a raw NodeReturn into the (stateUpdates, interrupt?, gotoTarget?)
+ * triple the executor cares about. Centralizes Interrupt/Command unwrapping
+ * (#1895, #2425).
  */
 function extractNodeOutput(returned: NodeReturn): {
   stateUpdates: Partial<GraphState>;
   interrupt?: Interrupt;
+  gotoTarget?: string;
 } {
   if (isInterrupt(returned)) {
     return { stateUpdates: {}, interrupt: returned };
   }
   if (isCommand(returned)) {
-    return { stateUpdates: returned.update ?? {} };
+    const cmd: Command = returned;
+    return {
+      stateUpdates: cmd.update ?? {},
+      ...(cmd.goto !== undefined ? { gotoTarget: cmd.goto } : {}),
+    };
   }
   return { stateUpdates: returned };
 }
@@ -518,7 +654,7 @@ async function executeWithVerification(args: ExecVerifyArgs): Promise<NodeResult
   const nodeTimeout = node.timeout ?? options?.timeout ?? DEFAULT_TIMEOUT_MS;
   const returned = await withTimeout(node.handler(state, nodeCtx), nodeTimeout);
   const handlerDuration = getTimeProvider().now() - startTime;
-  const { stateUpdates, interrupt } = extractNodeOutput(returned);
+  const { stateUpdates, interrupt, gotoTarget } = extractNodeOutput(returned);
 
   if (interrupt !== undefined) {
     return {
@@ -543,7 +679,13 @@ async function executeWithVerification(args: ExecVerifyArgs): Promise<NodeResult
     };
   }
 
-  return { nodeId, stateUpdates, durationMs: handlerDuration, status: 'success' };
+  return {
+    nodeId,
+    stateUpdates,
+    durationMs: handlerDuration,
+    status: 'success',
+    ...(gotoTarget !== undefined ? { gotoTarget } : {}),
+  };
 }
 
 /** Executes a single node with preconditions, timeout, verification, and error handling. */

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -9,6 +9,8 @@
  * (Source: Issue #831 — Graph-based workflow orchestration)
  */
 
+import { z } from 'zod';
+
 import type { Result } from '../../core/index.js';
 import type { ICheckpointStore } from './checkpoint-types.js';
 
@@ -171,6 +173,15 @@ export interface NodeContext {
 export type NodeReturn = Partial<GraphState> | Interrupt | Command;
 
 /**
+ * Schema for `resumeValues` passed to `resumeFromCheckpoint(...)`.
+ * The values are arbitrary user-supplied JSON; we validate that the container
+ * is a plain object and reject things like arrays or null. (#2425, security
+ * voter feedback on PR #2424.)
+ */
+export const ResumeValuesSchema = z.record(z.string(), z.unknown());
+export type ResumeValues = z.infer<typeof ResumeValuesSchema>;
+
+/**
  * Handler function for a graph node. Receives current state and an optional
  * per-run context, returns either:
  *   - `Partial<GraphState>` (legacy, common case) — merged via reducers
@@ -246,6 +257,13 @@ export interface NodeResult {
   readonly error?: string;
   /** Set when the node returned an Interrupt envelope (#1895). */
   readonly interrupt?: Interrupt;
+  /**
+   * Set when the node returned a Command with `goto`. The executor uses this
+   * to redirect the next runnable set instead of resolving outgoing edges.
+   * Validated against the compiled graph; unknown targets are logged + ignored.
+   * (#2425)
+   */
+  readonly gotoTarget?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #2425.

## What

Implements all 6 sub-tasks from QA-vote follow-ups on PR #2424 (#1895 Phase 1):

1. **\`Command.goto\`** wiring — node returns Command with goto target; executor validates target exists in compiled graph + redirects next runnable. Unknown targets logged + ignored.
2. **Multi-interrupt observability** — when multiple nodes interrupt in the same super-step, primary becomes checkpoint anchor; rest recorded in \`CheckpointInterrupt.additionalInterrupts\`. Warning logged.
3. **Resume idempotency** — \`CheckpointInterrupt.consumedAt\` timestamp marks consumed checkpoints. Second resume rejected with \`already resumed\` error.
4. **Resume failure path contract** — test pinning that a resumed-then-throwing node flips status from \`'interrupted'\` → \`'failed'\`; both NodeResults visible in cumulative array.
5. **\`resumeValues\` Zod validation** — \`ResumeValuesSchema\` (\`z.record(z.string(), z.unknown())\`) parses inputs at API boundary. Arrays / null / non-object values rejected.
6. **Status-leak audit** — verified no consumer of \`StepResult.status === 'skipped'\` treats it as \"safely bypassed.\" Coercion lives at consumer boundary; graph-internal NodeResult preserves \`'interrupted'\`. Tests pin both behaviors.

## Other refactors

- \`NodeResult.gotoTarget\` optional field for executor pipeline
- \`ExecutionContext.pendingInterrupt\` extended with \`additional[]\`
- \`saveInterruptCheckpoint\` + \`resumeFromCheckpoint\` split into \`buildInterruptCheckpoint\` + \`validateResumeRequest\` to clear max-lines-per-function

## Tests

12 new tests in \`graph-executor-hitl-phase2.test.ts\`, one per sub-task plus edge cases. **155/155 graph tests pass**, typecheck + lint clean.

## Backward compatibility

- All Phase 1 behavior preserved.
- \`CheckpointInterrupt.consumedAt\` and \`additionalInterrupts\` are optional — existing checkpoint readers ignore them.
- \`resumeFromCheckpoint\` signature: \`resumeValues\` widened from \`Readonly<Record<string, unknown>>\` → \`unknown\` (now Zod-validated). Source-compat for Phase 1 callers passing well-typed records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)