### PR TITLE
feat(sandbox): Deno permission fallback for users without Docker (#1898)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,7 +557,7 @@ _Auto-generated from source. 38 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-07_
+_Governance Version: 2026-05-08_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/security/__tests__/docker-sandbox.test.ts
+++ b/packages/nexus-agents/src/security/__tests__/docker-sandbox.test.ts
@@ -225,12 +225,16 @@ describe('createSandbox factory', () => {
       const result = await createSandbox({
         mode: 'container',
         fallbackToPolicy: true,
+        // Skip the new Deno fallback (#1898) so the fallback chain reaches policy.
+        fallbackToDeno: false,
       });
 
       expect(result.executor.name).toBe('PolicySandboxExecutor');
       expect(result.actualMode).toBe('policy');
       expect(result.usedFallback).toBe(true);
-      expect(result.warning).toContain('Docker not available');
+      // Updated for #1898 fallback chain — message now reads
+      // "Neither Docker nor Deno available" when both are absent.
+      expect(result.warning).toMatch(/Docker not available|Neither Docker nor Deno/);
     });
 
     it('should throw when Docker not available and no fallback', async () => {
@@ -238,8 +242,9 @@ describe('createSandbox factory', () => {
         createSandbox({
           mode: 'container',
           fallbackToPolicy: false,
+          fallbackToDeno: false,
         })
-      ).rejects.toThrow('Docker is not available');
+      ).rejects.toThrow(/Docker|Deno/);
     });
   });
 

--- a/packages/nexus-agents/src/security/sandbox/__tests__/sandbox-factory.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/__tests__/sandbox-factory.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createSandbox, getRecommendedMode } from '../sandbox-factory.js';
 import * as dockerHelpers from '../docker-sandbox-helpers.js';
+import * as denoHelpers from '../deno-sandbox-helpers.js';
 
 // Mock Docker availability check
 vi.mock('../docker-sandbox-helpers.js', async () => {
@@ -21,11 +22,24 @@ vi.mock('../docker-sandbox-helpers.js', async () => {
   };
 });
 
+// Mock Deno availability check (#1898)
+vi.mock('../deno-sandbox-helpers.js', async () => {
+  const actual = await vi.importActual('../deno-sandbox-helpers.js');
+  return {
+    ...actual,
+    isDenoAvailable: vi.fn(),
+  };
+});
+
 const mockIsDockerAvailable = vi.mocked(dockerHelpers.isDockerAvailable);
+const mockIsDenoAvailable = vi.mocked(denoHelpers.isDenoAvailable);
 
 describe('Sandbox Factory', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to Deno unavailable so legacy "Docker unavailable → policy"
+    // tests preserve their assertions. Tests covering Deno set this true.
+    mockIsDenoAvailable.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -80,6 +94,7 @@ describe('Sandbox Factory', () => {
 
       it('should fall back to policy when Docker unavailable and fallback enabled', async () => {
         mockIsDockerAvailable.mockResolvedValue(false);
+        // Default beforeEach already sets isDenoAvailable false.
 
         const result = await createSandbox({
           mode: 'container',
@@ -89,7 +104,8 @@ describe('Sandbox Factory', () => {
         expect(result.executor.name).toBe('PolicySandboxExecutor');
         expect(result.actualMode).toBe('policy');
         expect(result.usedFallback).toBe(true);
-        expect(result.warning).toContain('Docker not available');
+        // Updated for #1898: warning now reads "Neither Docker nor Deno available".
+        expect(result.warning).toMatch(/Neither Docker nor Deno|Docker not available/);
       });
 
       it('should throw when Docker unavailable and fallback disabled', async () => {
@@ -100,7 +116,7 @@ describe('Sandbox Factory', () => {
             mode: 'container',
             fallbackToPolicy: false,
           })
-        ).rejects.toThrow('Docker is not available');
+        ).rejects.toThrow(/Docker|Deno/);
       });
 
       it('should pass dockerConfig to executor', async () => {

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for DenoSandboxExecutor (#1898).
+ *
+ * Mocks the deno binary at the execFile boundary so tests run without Deno
+ * installed. Verifies argv assembly, validation, denied/unavailable paths,
+ * and result shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SandboxExecutionOptions, SandboxPolicy } from './sandbox-types.js';
+
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: () => mockExecFileAsync,
+}));
+
+import { DenoSandboxExecutor, buildDenoArgs, resetDenoCache } from './deno-sandbox-executor.js';
+
+function makePolicy(overrides: Partial<SandboxPolicy> = {}): SandboxPolicy {
+  return {
+    id: 'test',
+    name: 'test',
+    mode: 'deno',
+    allowedCommands: ['echo', 'git'],
+    allowedEnvVars: [],
+    pathRules: [],
+    capabilities: ['process_spawn'],
+    limits: {},
+    ...overrides,
+  };
+}
+
+function makeOptions(overrides: Partial<SandboxExecutionOptions> = {}): SandboxExecutionOptions {
+  return {
+    policy: makePolicy(),
+    ...overrides,
+  };
+}
+
+describe('buildDenoArgs', () => {
+  it('emits eval + flags + JSON-encoded command/args (no shell parsing)', () => {
+    const args = buildDenoArgs('echo', ['hello world'], makeOptions());
+    expect(args[0]).toBe('eval');
+    expect(args).toContain('--allow-run=echo,git');
+    // Last arg is the eval script: should reference the JSON-encoded command + args.
+    const evalScript = args[args.length - 1];
+    expect(evalScript).toContain('"echo"');
+    expect(evalScript).toContain('["hello world"]');
+    expect(evalScript).toContain('Deno.Command');
+    expect(evalScript).toContain('Deno.exit');
+  });
+
+  it('JSON-encodes args containing shell metacharacters safely', () => {
+    const args = buildDenoArgs('echo', ['$(rm -rf /)'], makeOptions());
+    const evalScript = args[args.length - 1];
+    expect(evalScript).toContain('["$(rm -rf /)"]');
+    expect(evalScript).toMatch(/Deno\.Command\(\s*"echo"/);
+  });
+});
+
+describe('DenoSandboxExecutor.validate', () => {
+  it('allows commands in the policy allowlist', () => {
+    const exec = new DenoSandboxExecutor();
+    const result = exec.validate('git', ['status'], makeOptions());
+    expect(result.allowed).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('rejects commands NOT in the policy allowlist', () => {
+    const exec = new DenoSandboxExecutor();
+    const result = exec.validate('curl', [], makeOptions());
+    expect(result.allowed).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+    expect(result.violations[0]?.type).toBe('command');
+  });
+});
+
+describe('DenoSandboxExecutor.execute', () => {
+  beforeEach(() => {
+    resetDenoCache();
+    mockExecFileAsync.mockReset();
+  });
+
+  it('returns denied when policy rejects the command', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: 'deno 2.0.0', stderr: '' });
+    const exec = new DenoSandboxExecutor();
+    const result = await exec.execute('curl', [], makeOptions());
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(126);
+    expect(result.stderr).toContain('policy denied');
+  });
+
+  it("returns deno-unavailable when deno isn't installed", async () => {
+    // First call (deno --version) fails — Deno not available.
+    mockExecFileAsync.mockRejectedValueOnce(new Error('command not found'));
+    const exec = new DenoSandboxExecutor();
+    const result = await exec.execute('echo', ['hi'], makeOptions());
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(127);
+    expect(result.stderr).toContain('Deno is not available');
+  });
+
+  it('runs the command via deno when available + allowed', async () => {
+    // First call: --version (availability check). Second: the actual run.
+    mockExecFileAsync
+      .mockResolvedValueOnce({ stdout: 'deno 2.0.0', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'hello', stderr: '' });
+
+    const exec = new DenoSandboxExecutor();
+    const result = await exec.execute('echo', ['hi'], makeOptions());
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello');
+    // Verify the deno invocation went through with the eval + flag set.
+    expect(mockExecFileAsync.mock.calls[1]?.[0]).toBe('deno');
+    const denoArgs = mockExecFileAsync.mock.calls[1]?.[1] as readonly string[];
+    expect(denoArgs[0]).toBe('eval');
+    expect(denoArgs).toContain('--allow-run=echo,git');
+  });
+
+  it('translates execFile errors into a SandboxResult instead of throwing', async () => {
+    mockExecFileAsync
+      .mockResolvedValueOnce({ stdout: 'deno 2.0.0', stderr: '' })
+      .mockRejectedValueOnce(
+        Object.assign(new Error('boom'), { code: 7, stdout: '', stderr: 'failed' })
+      );
+
+    const exec = new DenoSandboxExecutor();
+    const result = await exec.execute('echo', ['hi'], makeOptions());
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(7);
+    expect(result.stderr).toContain('failed');
+  });
+});

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
@@ -45,9 +45,12 @@ function makeOptions(overrides: Partial<SandboxExecutionOptions> = {}): SandboxE
 }
 
 describe('buildDenoArgs', () => {
-  it('emits eval + flags + JSON-encoded command/args (no shell parsing)', () => {
+  it('emits eval + --no-prompt + flags + JSON-encoded command/args (no shell parsing)', () => {
     const args = buildDenoArgs('echo', ['hello world'], makeOptions());
     expect(args[0]).toBe('eval');
+    // --no-prompt must be present so denied permissions throw rather than
+    // hang on TTY (security review on PR #2427).
+    expect(args).toContain('--no-prompt');
     expect(args).toContain('--allow-run=echo,git');
     // Last arg is the eval script: should reference the JSON-encoded command + args.
     const evalScript = args[args.length - 1];

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
@@ -1,0 +1,290 @@
+/**
+ * nexus-agents/security/sandbox - Deno Sandbox Executor
+ *
+ * Process-level permission sandbox using Deno's `--allow-*` flags (#1898).
+ *
+ * Deno provides per-process gating for filesystem read/write, network,
+ * subprocess spawn, and env access. We translate the existing SandboxPolicy
+ * into the corresponding flag set and then run the target command via
+ * `deno run --allow-X dlx-bridge.ts -- <cmd> <args>` — Deno acts as a
+ * permission supervisor over a small bridge script that re-spawns the
+ * actual command with the gated permissions.
+ *
+ * **Tradeoffs vs Docker** (intentional, documented in SandboxMode):
+ *   - Process-level isolation (same OS) vs container-level (separate kernel
+ *     namespaces). Docker is stronger.
+ *   - No CPU/memory cgroup limits — Deno doesn't expose those.
+ *   - Network filtering is coarse: `--allow-net` is on/off in Phase 1;
+ *     per-host filtering is Phase 2.
+ *   - Works without Docker — Mac without Docker Desktop, locked-down CI
+ *     runners, etc.
+ *
+ * @module security/sandbox/deno-sandbox-executor
+ * (Source: Issue #1898 — WASM/Deno fallback for users without Docker)
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { createLogger, getTimeProvider } from '../../core/index.js';
+
+import type {
+  ISandboxExecutor,
+  PolicyEvaluation,
+  PolicyViolation,
+  SandboxExecutionOptions,
+  SandboxResult,
+} from './sandbox-types.js';
+import { DEFAULT_RESOURCE_LIMITS } from './sandbox-types.js';
+import { validateCommand, validateArgs } from './command-allowlist.js';
+import {
+  createDeniedResult,
+  createResourceUsageFromOutput,
+  parseExecError,
+  truncateOutput,
+} from './docker-sandbox-helpers.js';
+import { isDenoAvailable, policyToDenoFlags, resetDenoCache } from './deno-sandbox-helpers.js';
+
+// Re-export for symmetry with docker-sandbox-executor.
+export { isDenoAvailable, resetDenoCache };
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger({ component: 'deno-sandbox' });
+
+/** Configuration knobs for the Deno executor. */
+export interface DenoSandboxConfig {
+  /**
+   * If true, log the assembled deno command line at info level. Useful for
+   * debugging permission-flag mismatches; off by default to avoid leaking
+   * env-var names into logs.
+   */
+  readonly logCommandLine?: boolean;
+}
+
+/**
+ * Result from `deno run -- <cmd> <args>`.
+ */
+interface DenoExecOutcome {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * Result when Deno isn't installed on the host.
+ */
+function createDenoUnavailableResult(): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  return {
+    exitCode: 127,
+    stdout: '',
+    stderr: 'Deno is not available. Install Deno (>=2.0) to use the deno sandbox mode.',
+  };
+}
+
+/**
+ * Deno-based sandbox executor.
+ *
+ * Runs the target command under Deno's permission system. The flag set is
+ * derived from the SandboxPolicy via `policyToDenoFlags(...)`. Capabilities
+ * not granted by the policy are denied at the process boundary by Deno
+ * itself — there is no need for a wrapper script in v1 because we use
+ * `--allow-run=<cmd>` and Deno-spawn the target as a subprocess.
+ */
+export class DenoSandboxExecutor implements ISandboxExecutor {
+  readonly name = 'DenoSandboxExecutor';
+  private readonly config: DenoSandboxConfig;
+
+  constructor(config?: DenoSandboxConfig) {
+    this.config = config ?? {};
+  }
+
+  async execute(
+    command: string,
+    args: readonly string[],
+    options: SandboxExecutionOptions
+  ): Promise<SandboxResult> {
+    const startTime = getTimeProvider().now();
+
+    const evaluation = this.validate(command, args, options);
+    if (!evaluation.allowed) {
+      return this.buildDeniedResult(evaluation, startTime);
+    }
+
+    const denoAvailable = await isDenoAvailable();
+    if (!denoAvailable) {
+      return this.buildDenoUnavailableResult(evaluation, startTime);
+    }
+
+    const limits = { ...DEFAULT_RESOURCE_LIMITS, ...options.policy.limits, ...options.limits };
+    const denoArgs = buildDenoArgs(command, args, options);
+
+    if (this.config.logCommandLine === true) {
+      logger.info('Deno sandbox invocation', { args: denoArgs });
+    }
+
+    try {
+      const outcome = await runDeno(denoArgs, limits.maxWallTimeMs);
+      return this.buildSuccessResult(outcome, evaluation, startTime);
+    } catch (error: unknown) {
+      return this.buildErrorResult(error, evaluation, startTime);
+    }
+  }
+
+  validate(
+    command: string,
+    args: readonly string[],
+    options: SandboxExecutionOptions
+  ): PolicyEvaluation {
+    const policy = options.policy;
+    const violations: PolicyViolation[] = [];
+
+    const cmdViolation = validateCommand(command, policy.allowedCommands);
+    if (cmdViolation !== null) violations.push(cmdViolation);
+
+    const argsViolation = validateArgs(args);
+    if (argsViolation !== null) violations.push(argsViolation);
+
+    const result: PolicyEvaluation = {
+      allowed: violations.length === 0,
+      policyId: policy.id,
+      violations,
+    };
+    if (violations.length > 0 && violations[0] !== undefined) {
+      return { ...result, reason: violations[0].reason };
+    }
+    return result;
+  }
+
+  // --------------------------------------------------------------------------
+  // Result builders
+  // --------------------------------------------------------------------------
+
+  private buildDeniedResult(evaluation: PolicyEvaluation, startTime: number): SandboxResult {
+    const durationMs = getTimeProvider().now() - startTime;
+    const denied = createDeniedResult(evaluation, durationMs);
+    return {
+      success: false,
+      exitCode: denied.exitCode,
+      stdout: denied.stdout,
+      stderr: denied.stderr,
+      durationMs,
+      resourceUsage: denied.resourceUsage,
+      policyEvaluation: evaluation,
+    };
+  }
+
+  private buildDenoUnavailableResult(
+    evaluation: PolicyEvaluation,
+    startTime: number
+  ): SandboxResult {
+    const durationMs = getTimeProvider().now() - startTime;
+    const result = createDenoUnavailableResult();
+    return {
+      success: false,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      durationMs,
+      resourceUsage: createResourceUsageFromOutput(result.stdout, result.stderr, durationMs),
+      policyEvaluation: evaluation,
+    };
+  }
+
+  private buildSuccessResult(
+    outcome: DenoExecOutcome,
+    evaluation: PolicyEvaluation,
+    startTime: number
+  ): SandboxResult {
+    const durationMs = getTimeProvider().now() - startTime;
+    return {
+      success: outcome.exitCode === 0,
+      exitCode: outcome.exitCode,
+      stdout: outcome.stdout,
+      stderr: outcome.stderr,
+      durationMs,
+      resourceUsage: createResourceUsageFromOutput(outcome.stdout, outcome.stderr, durationMs),
+      policyEvaluation: evaluation,
+    };
+  }
+
+  private buildErrorResult(
+    error: unknown,
+    evaluation: PolicyEvaluation,
+    startTime: number
+  ): SandboxResult {
+    const durationMs = getTimeProvider().now() - startTime;
+    const parsed = parseExecError(error);
+    return {
+      success: false,
+      exitCode: parsed.exitCode,
+      stdout: parsed.stdout,
+      stderr: parsed.stderr,
+      durationMs,
+      resourceUsage: createResourceUsageFromOutput(parsed.stdout, parsed.stderr, durationMs),
+      policyEvaluation: evaluation,
+    };
+  }
+}
+
+// ============================================================================
+// Free helpers (kept top-level so tests can exercise them without instantiating
+// the class).
+// ============================================================================
+
+/**
+ * Assemble the `deno run` argv that runs `<command> <args>` under
+ * permission flags derived from the policy. Uses Deno's bash-style `--`
+ * separator so the target command receives its raw args verbatim.
+ */
+export function buildDenoArgs(
+  command: string,
+  args: readonly string[],
+  options: SandboxExecutionOptions
+): string[] {
+  const flags = policyToDenoFlags(options.policy);
+  // `deno run` requires a script — for command-mode we use eval to spawn the target
+  // via Deno.Command, since `deno run` of an arbitrary binary isn't supported.
+  // The eval text is small and produces the same exit code as the spawned process.
+  const evalScript = buildEvalSpawn(command, args);
+  return ['eval', ...flags, evalScript];
+}
+
+/**
+ * Build the small `Deno.Command` invocation that re-spawns the target with
+ * its raw args and forwards stdout/stderr/exit. Argument values are JSON-
+ * stringified so quoting is safe (no shell parsing).
+ */
+function buildEvalSpawn(command: string, args: readonly string[]): string {
+  const argsJson = JSON.stringify(args);
+  const cmdJson = JSON.stringify(command);
+  return [
+    'const r = await new Deno.Command(',
+    cmdJson,
+    ', { args: ',
+    argsJson,
+    ', stdout: "piped", stderr: "piped" }).output();',
+    'await Deno.stdout.write(r.stdout);',
+    'await Deno.stderr.write(r.stderr);',
+    'Deno.exit(r.code);',
+  ].join('');
+}
+
+/**
+ * Run the Deno binary with the given argv. Wraps execFile so callers can
+ * mock the exec layer in tests.
+ */
+async function runDeno(denoArgs: readonly string[], timeoutMs: number): Promise<DenoExecOutcome> {
+  const result = await execFileAsync('deno', denoArgs as string[], {
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024,
+  });
+  return {
+    exitCode: 0,
+    stdout: truncateOutput(result.stdout),
+    stderr: truncateOutput(result.stderr),
+  };
+}

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
@@ -236,9 +236,12 @@ export class DenoSandboxExecutor implements ISandboxExecutor {
 // ============================================================================
 
 /**
- * Assemble the `deno run` argv that runs `<command> <args>` under
- * permission flags derived from the policy. Uses Deno's bash-style `--`
- * separator so the target command receives its raw args verbatim.
+ * Assemble the `deno eval` argv that runs `<command> <args>` under
+ * permission flags derived from the policy. Always passes `--no-prompt`
+ * (security review on PR #2427) — without it, Deno suspends and prompts
+ * the user when a permission gate denies an operation. In a CI runner or
+ * autonomous-loop context that hangs the parent process; `--no-prompt`
+ * forces immediate `PermissionDenied` on missing capabilities.
  */
 export function buildDenoArgs(
   command: string,
@@ -250,13 +253,21 @@ export function buildDenoArgs(
   // via Deno.Command, since `deno run` of an arbitrary binary isn't supported.
   // The eval text is small and produces the same exit code as the spawned process.
   const evalScript = buildEvalSpawn(command, args);
-  return ['eval', ...flags, evalScript];
+  return ['eval', '--no-prompt', ...flags, evalScript];
 }
 
 /**
  * Build the small `Deno.Command` invocation that re-spawns the target with
- * its raw args and forwards stdout/stderr/exit. Argument values are JSON-
- * stringified so quoting is safe (no shell parsing).
+ * its raw args and forwards stdout/stderr/exit. Both `command` and `args`
+ * pass through `JSON.stringify` — that produces valid JS string literals
+ * for any input (escapes quotes, backslashes, control chars, U+2028/2029),
+ * and the deserialized values flow into `Deno.Command({ args: [...] })` in
+ * array form, so there's no shell parsing on the deno side. The argv
+ * injection surface is reduced to the SandboxPolicy allowlist gates
+ * (validateCommand + validateArgs) already applied in `validate()`.
+ *
+ * Do not refactor this to a template-string interpolation — that would
+ * reintroduce a shell-style injection class.
  */
 function buildEvalSpawn(command: string, args: readonly string[]): string {
   const argsJson = JSON.stringify(args);

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for Deno Sandbox Helpers (#1898).
+ *
+ * Covers Deno availability check + policy → permission flag mapping.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SandboxPolicy } from './sandbox-types.js';
+
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: () => mockExecFileAsync,
+}));
+
+import { isDenoAvailable, resetDenoCache, policyToDenoFlags } from './deno-sandbox-helpers.js';
+
+function makePolicy(overrides: Partial<SandboxPolicy> = {}): SandboxPolicy {
+  return {
+    id: 'test',
+    name: 'test',
+    mode: 'deno',
+    allowedCommands: [],
+    allowedEnvVars: [],
+    pathRules: [],
+    capabilities: [],
+    limits: {},
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// isDenoAvailable
+// ============================================================================
+
+describe('isDenoAvailable', () => {
+  beforeEach(() => {
+    resetDenoCache();
+    mockExecFileAsync.mockReset();
+  });
+
+  it('returns true when `deno --version` succeeds', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: 'deno 2.0.0', stderr: '' });
+    expect(await isDenoAvailable()).toBe(true);
+  });
+
+  it('returns false when `deno --version` fails', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('command not found'));
+    expect(await isDenoAvailable()).toBe(false);
+  });
+
+  it('caches the availability check across calls', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: 'deno 2.0.0', stderr: '' });
+    await isDenoAvailable();
+    await isDenoAvailable();
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetDenoCache clears the cache', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: 'deno 2.0.0', stderr: '' });
+    await isDenoAvailable();
+    resetDenoCache();
+    await isDenoAvailable();
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ============================================================================
+// policyToDenoFlags
+// ============================================================================
+
+describe('policyToDenoFlags', () => {
+  it('returns no flags for an empty policy', () => {
+    expect(policyToDenoFlags(makePolicy())).toEqual([]);
+  });
+
+  it('emits --allow-run when process_spawn capability + allowedCommands', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['process_spawn'],
+        allowedCommands: ['git', 'npm'],
+      })
+    );
+    expect(flags).toEqual(['--allow-run=git,npm']);
+  });
+
+  it('skips --allow-run if process_spawn requested but no allowedCommands (no wildcard)', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({ capabilities: ['process_spawn'], allowedCommands: [] })
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it('emits coarse --allow-net for network capability', () => {
+    const flags = policyToDenoFlags(makePolicy({ capabilities: ['network'] }));
+    expect(flags).toEqual(['--allow-net']);
+  });
+
+  it('emits --allow-read with paths from filesystem_read + read rules', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['filesystem_read'],
+        pathRules: [
+          { path: '/tmp', access: 'read' },
+          { path: '/var/log', access: 'read' },
+        ],
+      })
+    );
+    expect(flags).toEqual(['--allow-read=/tmp,/var/log']);
+  });
+
+  it('write rules imply read access (write paths show up in --allow-read)', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['filesystem_read', 'filesystem_write'],
+        pathRules: [{ path: '/tmp', access: 'write' }],
+      })
+    );
+    expect(flags).toContain('--allow-read=/tmp');
+    expect(flags).toContain('--allow-write=/tmp');
+  });
+
+  it('emits --allow-write only for write rules', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['filesystem_write'],
+        pathRules: [
+          { path: '/data', access: 'write' },
+          { path: '/etc', access: 'read' },
+        ],
+      })
+    );
+    expect(flags).toEqual(['--allow-write=/data']);
+  });
+
+  it('skips --allow-read/-write entirely if capability requested but no rules', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['filesystem_read', 'filesystem_write'],
+        pathRules: [],
+      })
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it('emits --allow-env with allowed vars', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['env_access'],
+        allowedEnvVars: ['HOME', 'PATH'],
+      })
+    );
+    expect(flags).toEqual(['--allow-env=HOME,PATH']);
+  });
+
+  it('skips --allow-env if env_access requested but allowedEnvVars is empty', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({ capabilities: ['env_access'], allowedEnvVars: [] })
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it('combines flags for a multi-capability policy', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['process_spawn', 'network', 'filesystem_read', 'env_access'],
+        allowedCommands: ['git'],
+        allowedEnvVars: ['HOME'],
+        pathRules: [{ path: '/tmp', access: 'read' }],
+      })
+    );
+    expect(flags).toEqual([
+      '--allow-run=git',
+      '--allow-net',
+      '--allow-read=/tmp',
+      '--allow-env=HOME',
+    ]);
+  });
+
+  it('ignores rules with access=none', () => {
+    const flags = policyToDenoFlags(
+      makePolicy({
+        capabilities: ['filesystem_read'],
+        pathRules: [
+          { path: '/secret', access: 'none' },
+          { path: '/tmp', access: 'read' },
+        ],
+      })
+    );
+    expect(flags).toEqual(['--allow-read=/tmp']);
+  });
+});

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.ts
@@ -1,0 +1,141 @@
+/**
+ * nexus-agents/security/sandbox - Deno Sandbox Helper Functions
+ *
+ * Pure helper functions for Deno-based sandbox execution (#1898).
+ * Maps the existing SandboxPolicy to Deno's `--allow-*` permission flags
+ * and provides availability detection.
+ *
+ * Deno's permission model is process-level (not OS-level like Docker
+ * containers). It's a fallback for environments without Docker, not a
+ * replacement — see SandboxMode docs in sandbox-types.ts for the
+ * tradeoffs.
+ *
+ * @module security/sandbox/deno-sandbox-helpers
+ * (Source: Issue #1898 — WASM/Deno fallback for users without Docker)
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { CLI_SUBPROCESS_TIMEOUTS } from '../../config/timeouts.js';
+import { createLogger } from '../../core/logger.js';
+
+import type { SandboxPolicy } from './sandbox-types.js';
+
+const logger = createLogger({ component: 'deno-sandbox-helpers' });
+
+const execFileAsync = promisify(execFile);
+
+/** Deno availability check result (cached). */
+let denoAvailableCache: boolean | null = null;
+
+/**
+ * Check whether Deno is available on the host. Cached after the first call.
+ */
+export async function isDenoAvailable(): Promise<boolean> {
+  if (denoAvailableCache !== null) {
+    return denoAvailableCache;
+  }
+
+  try {
+    await execFileAsync('deno', ['--version'], {
+      timeout: CLI_SUBPROCESS_TIMEOUTS.dockerCheckMs,
+    });
+    denoAvailableCache = true;
+    return true;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug('Deno not available', { error: msg });
+    denoAvailableCache = false;
+    return false;
+  }
+}
+
+/** Reset Deno availability cache (for testing). */
+export function resetDenoCache(): void {
+  denoAvailableCache = null;
+}
+
+/**
+ * Translate a SandboxPolicy's capability + path-rules + allowed-commands
+ * into the corresponding Deno `--allow-*` flag set.
+ *
+ * Mapping:
+ *   - `process_spawn` → `--allow-run=cmd1,cmd2,...` from policy.allowedCommands
+ *   - `network`       → `--allow-net` (no host filter — Phase 1 keeps it
+ *                       coarse; per-host filtering is Phase 2)
+ *   - `filesystem_read`  → `--allow-read=path1,path2,...` from path rules
+ *   - `filesystem_write` → `--allow-write=path1,path2,...` from path rules
+ *   - `env_access`    → `--allow-env=VAR1,VAR2,...` from allowedEnvVars
+ *
+ * Capabilities NOT in the policy produce no flag — Deno defaults to deny.
+ *
+ * Returns an array of CLI args ready to be passed to `deno run`.
+ */
+export function policyToDenoFlags(policy: SandboxPolicy): string[] {
+  const caps = new Set(policy.capabilities);
+  const flags: string[] = [];
+  const runFlag = buildAllowRunFlag(caps, policy);
+  if (runFlag !== undefined) flags.push(runFlag);
+  if (caps.has('network')) flags.push('--allow-net');
+  const readFlag = buildPathFlag(caps, policy, 'read');
+  if (readFlag !== undefined) flags.push(readFlag);
+  const writeFlag = buildPathFlag(caps, policy, 'write');
+  if (writeFlag !== undefined) flags.push(writeFlag);
+  const envFlag = buildAllowEnvFlag(caps, policy);
+  if (envFlag !== undefined) flags.push(envFlag);
+  return flags;
+}
+
+function buildAllowRunFlag(caps: ReadonlySet<string>, policy: SandboxPolicy): string | undefined {
+  if (!caps.has('process_spawn')) return undefined;
+  if (policy.allowedCommands.length === 0) {
+    logger.warn(
+      'process_spawn capability requested but allowedCommands is empty — Deno --allow-run NOT added (would be a wildcard)'
+    );
+    return undefined;
+  }
+  return `--allow-run=${policy.allowedCommands.join(',')}`;
+}
+
+function buildPathFlag(
+  caps: ReadonlySet<string>,
+  policy: SandboxPolicy,
+  level: 'read' | 'write'
+): string | undefined {
+  const cap = level === 'read' ? 'filesystem_read' : 'filesystem_write';
+  if (!caps.has(cap)) return undefined;
+  const paths = collectAccessPaths(policy, level);
+  if (paths.length === 0) {
+    logger.warn(`${cap} capability requested but no path rules — Deno --allow-${level} NOT added`);
+    return undefined;
+  }
+  return `--allow-${level}=${paths.join(',')}`;
+}
+
+function buildAllowEnvFlag(caps: ReadonlySet<string>, policy: SandboxPolicy): string | undefined {
+  if (!caps.has('env_access')) return undefined;
+  if (policy.allowedEnvVars.length === 0) {
+    logger.warn(
+      'env_access capability requested but allowedEnvVars is empty — Deno --allow-env NOT added'
+    );
+    return undefined;
+  }
+  return `--allow-env=${policy.allowedEnvVars.join(',')}`;
+}
+
+/**
+ * Pull the path-strings out of a policy's pathRules whose access matches
+ * the requested level. `'read'` includes `'write'` rules (write implies
+ * read in Deno).
+ */
+function collectAccessPaths(policy: SandboxPolicy, level: 'read' | 'write'): string[] {
+  const paths: string[] = [];
+  for (const rule of policy.pathRules) {
+    if (rule.access === 'none') continue;
+    if (level === 'write' && rule.access !== 'write') continue;
+    // Read level: any non-'none' rule grants read (write implies read).
+    paths.push(rule.path);
+  }
+  return paths;
+}

--- a/packages/nexus-agents/src/security/sandbox/index.ts
+++ b/packages/nexus-agents/src/security/sandbox/index.ts
@@ -71,6 +71,11 @@ export {
 } from './docker-sandbox-executor.js';
 export type { DockerSandboxConfig } from './docker-sandbox-executor.js';
 
+// Deno-based executor (#1898)
+export { DenoSandboxExecutor, isDenoAvailable, resetDenoCache } from './deno-sandbox-executor.js';
+export { policyToDenoFlags } from './deno-sandbox-helpers.js';
+export type { DenoSandboxConfig } from './deno-sandbox-executor.js';
+
 // Factory
 export { createSandbox, getRecommendedMode } from './sandbox-factory.js';
 export type { SandboxFactoryOptions, SandboxCreationResult } from './sandbox-factory.js';

--- a/packages/nexus-agents/src/security/sandbox/sandbox-factory.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-factory.test.ts
@@ -13,6 +13,7 @@ import {
 } from './sandbox-factory.js';
 import { PolicySandboxExecutor } from './sandbox-executor.js';
 import { DockerSandboxExecutor, isDockerAvailable } from './docker-sandbox-executor.js';
+import { DenoSandboxExecutor, isDenoAvailable } from './deno-sandbox-executor.js';
 
 // ============================================================================
 // Mocks
@@ -25,6 +26,16 @@ vi.mock('./docker-sandbox-executor.js', async () => {
   return {
     ...actual,
     isDockerAvailable: vi.fn(),
+  };
+});
+
+vi.mock('./deno-sandbox-executor.js', async () => {
+  const actual = await vi.importActual<typeof import('./deno-sandbox-executor.js')>(
+    './deno-sandbox-executor.js'
+  );
+  return {
+    ...actual,
+    isDenoAvailable: vi.fn(),
   };
 });
 
@@ -154,16 +165,17 @@ describe('createSandbox - container mode (Docker available)', () => {
 // createSandbox - container mode (Docker unavailable, fallback enabled)
 // ============================================================================
 
-describe('createSandbox - container mode (Docker unavailable, fallback enabled)', () => {
+describe('createSandbox - container mode (Docker unavailable, Deno unavailable, fallback enabled)', () => {
   beforeEach(() => {
     vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(false);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('falls back to policy mode when Docker unavailable', async () => {
+  it('falls back to policy mode when neither Docker nor Deno available', async () => {
     const result = await createSandbox({
       mode: 'container',
       fallbackToPolicy: true,
@@ -181,7 +193,7 @@ describe('createSandbox - container mode (Docker unavailable, fallback enabled)'
     });
 
     expect(result.warning).toBeDefined();
-    expect(result.warning).toContain('Docker not available');
+    expect(result.warning).toContain('Neither Docker nor Deno');
     expect(result.warning).toContain('policy-based');
   });
 
@@ -211,25 +223,104 @@ describe('createSandbox - container mode (Docker unavailable, fallback enabled)'
 });
 
 // ============================================================================
-// createSandbox - container mode (Docker unavailable, fallback disabled)
+// createSandbox - container mode (Docker unavailable, Deno available) — #1898
 // ============================================================================
 
-describe('createSandbox - container mode (Docker unavailable, fallback disabled)', () => {
+describe('createSandbox - container mode (Docker unavailable, Deno available)', () => {
   beforeEach(() => {
     vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(true);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('throws error when Docker unavailable and fallback disabled', async () => {
+  it('falls back to deno mode (process-level isolation) when Docker missing', async () => {
+    const result = await createSandbox({ mode: 'container', fallbackToPolicy: true });
+    expect(result.executor).toBeInstanceOf(DenoSandboxExecutor);
+    expect(result.actualMode).toBe('deno');
+    expect(result.usedFallback).toBe(true);
+    expect(result.warning).toContain('Deno permission sandbox');
+  });
+
+  it('respects fallbackToDeno: false (skips Deno, falls to policy)', async () => {
+    const result = await createSandbox({
+      mode: 'container',
+      fallbackToPolicy: true,
+      fallbackToDeno: false,
+    });
+    expect(result.executor).toBeInstanceOf(PolicySandboxExecutor);
+    expect(result.actualMode).toBe('policy');
+  });
+});
+
+// ============================================================================
+// createSandbox - deno mode (#1898)
+// ============================================================================
+
+describe('createSandbox - deno mode (Deno available)', () => {
+  beforeEach(() => {
+    vi.mocked(isDenoAvailable).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns DenoSandboxExecutor without fallback', async () => {
+    const result = await createSandbox({ mode: 'deno' });
+    expect(result.executor).toBeInstanceOf(DenoSandboxExecutor);
+    expect(result.actualMode).toBe('deno');
+    expect(result.usedFallback).toBe(false);
+  });
+});
+
+describe('createSandbox - deno mode (Deno unavailable)', () => {
+  beforeEach(() => {
+    vi.mocked(isDenoAvailable).mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls back to policy mode when fallbackToPolicy is true', async () => {
+    const result = await createSandbox({ mode: 'deno', fallbackToPolicy: true });
+    expect(result.executor).toBeInstanceOf(PolicySandboxExecutor);
+    expect(result.actualMode).toBe('policy');
+    expect(result.usedFallback).toBe(true);
+    expect(result.warning).toContain('Deno not available');
+  });
+
+  it('throws when fallbackToPolicy is false', async () => {
+    await expect(createSandbox({ mode: 'deno', fallbackToPolicy: false })).rejects.toThrow(
+      /Deno is not available/
+    );
+  });
+});
+
+// ============================================================================
+// createSandbox - container mode (Docker unavailable, fallback disabled)
+// ============================================================================
+
+describe('createSandbox - container mode (Docker + Deno unavailable, fallback disabled)', () => {
+  beforeEach(() => {
+    vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws error when neither Docker nor Deno available and fallback disabled', async () => {
     await expect(
       createSandbox({
         mode: 'container',
         fallbackToPolicy: false,
       })
-    ).rejects.toThrow('Docker is not available');
+    ).rejects.toThrow(/neither Docker nor Deno/);
   });
 
   it('error message suggests installation or fallback', async () => {
@@ -238,7 +329,7 @@ describe('createSandbox - container mode (Docker unavailable, fallback disabled)
         mode: 'container',
         fallbackToPolicy: false,
       })
-    ).rejects.toThrow(/Install Docker|fallbackToPolicy/);
+    ).rejects.toThrow(/Install Docker|Deno|fallbackToPolicy/);
   });
 });
 
@@ -331,16 +422,17 @@ describe('getRecommendedMode - Docker available', () => {
 // getRecommendedMode - Docker unavailable
 // ============================================================================
 
-describe('getRecommendedMode - Docker unavailable', () => {
+describe('getRecommendedMode - Docker unavailable, Deno unavailable', () => {
   beforeEach(() => {
     vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(false);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('recommends policy mode when Docker is unavailable', async () => {
+  it('recommends policy mode when neither Docker nor Deno is available', async () => {
     const mode = await getRecommendedMode();
 
     expect(mode).toBe('policy');
@@ -350,6 +442,21 @@ describe('getRecommendedMode - Docker unavailable', () => {
     await getRecommendedMode();
 
     expect(isDockerAvailable).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getRecommendedMode - Docker unavailable, Deno available (#1898)', () => {
+  beforeEach(() => {
+    vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('recommends deno mode when Docker missing but Deno present', async () => {
+    expect(await getRecommendedMode()).toBe('deno');
   });
 });
 
@@ -389,6 +496,7 @@ describe('Integration - complete workflow', () => {
 describe('Edge cases', () => {
   beforeEach(() => {
     vi.mocked(isDockerAvailable).mockResolvedValue(false);
+    vi.mocked(isDenoAvailable).mockResolvedValue(false);
   });
 
   afterEach(() => {

--- a/packages/nexus-agents/src/security/sandbox/sandbox-factory.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-factory.ts
@@ -15,6 +15,11 @@ import {
   isDockerAvailable,
   type DockerSandboxConfig,
 } from './docker-sandbox-executor.js';
+import {
+  DenoSandboxExecutor,
+  isDenoAvailable,
+  type DenoSandboxConfig,
+} from './deno-sandbox-executor.js';
 import { STANDARD_POLICY } from './default-policies.js';
 
 const logger = createLogger({ component: 'sandbox-factory' });
@@ -27,10 +32,20 @@ export interface SandboxFactoryOptions {
   readonly mode: SandboxMode;
   /** Whether to fall back to policy mode if container not available. */
   readonly fallbackToPolicy?: boolean;
+  /**
+   * Whether to fall back to the Deno permission sandbox when Docker is
+   * unavailable (#1898). Inserts Deno between container and policy in the
+   * fallback chain when both `fallbackToDeno` and `fallbackToPolicy` are
+   * true. Default: `true` — Deno gives meaningful process-level isolation
+   * vs policy mode which is enforcement-only.
+   */
+  readonly fallbackToDeno?: boolean;
   /** Policy sandbox configuration. */
   readonly policyConfig?: Partial<SandboxConfig>;
   /** Docker sandbox configuration. */
   readonly dockerConfig?: DockerSandboxConfig;
+  /** Deno sandbox configuration (#1898). */
+  readonly denoConfig?: DenoSandboxConfig;
 }
 
 /**
@@ -53,6 +68,7 @@ export interface SandboxCreationResult {
 const DEFAULT_OPTIONS: SandboxFactoryOptions = {
   mode: 'policy',
   fallbackToPolicy: true,
+  fallbackToDeno: true,
 };
 
 /**
@@ -75,6 +91,9 @@ export async function createSandbox(
 
     case 'container':
       return createContainerMode(opts);
+
+    case 'deno':
+      return createDenoMode(opts);
 
     default: {
       // TypeScript exhaustiveness check
@@ -121,7 +140,8 @@ function createPolicyMode(config?: Partial<SandboxConfig>): SandboxCreationResul
 }
 
 /**
- * Create a container-based executor with optional fallback.
+ * Create a container-based executor with optional fallback chain
+ * Docker → Deno → Policy. Both fallback toggles default to true.
  */
 async function createContainerMode(opts: SandboxFactoryOptions): Promise<SandboxCreationResult> {
   const dockerAvailable = await isDockerAvailable();
@@ -138,9 +158,25 @@ async function createContainerMode(opts: SandboxFactoryOptions): Promise<Sandbox
     };
   }
 
-  // Docker not available
+  // Docker not available — try Deno before falling all the way to policy. (#1898)
+  if (opts.fallbackToDeno !== false) {
+    const denoAvailable = await isDenoAvailable();
+    if (denoAvailable) {
+      logger.warn('Docker not available, falling back to "deno" mode');
+      const executor = new DenoSandboxExecutor(opts.denoConfig);
+      return {
+        executor,
+        actualMode: 'deno',
+        usedFallback: true,
+        warning:
+          'Docker not available. Using Deno permission sandbox (process-level isolation, not container-level).',
+      };
+    }
+  }
+
+  // Neither Docker nor Deno — last resort is policy enforcement.
   if (opts.fallbackToPolicy === true) {
-    logger.warn('Docker not available, falling back to "policy" mode');
+    logger.warn('Docker and Deno unavailable, falling back to "policy" mode');
 
     const executor = new PolicySandboxExecutor(opts.policyConfig);
 
@@ -148,27 +184,65 @@ async function createContainerMode(opts: SandboxFactoryOptions): Promise<Sandbox
       executor,
       actualMode: 'policy',
       usedFallback: true,
-      warning: 'Docker not available. Using policy-based sandbox with limited isolation.',
+      warning:
+        'Neither Docker nor Deno available. Using policy-based sandbox with limited isolation.',
     };
   }
 
   // No fallback allowed, throw error
   throw new Error(
-    'Container sandbox mode requested but Docker is not available. ' +
-      'Install Docker or set fallbackToPolicy: true.'
+    'Container sandbox mode requested but neither Docker nor Deno is available. ' +
+      'Install Docker (for container isolation) or Deno (for process-level isolation), ' +
+      'or set fallbackToPolicy: true.'
+  );
+}
+
+/**
+ * Create a Deno-based executor (#1898). Falls back to policy if Deno is
+ * unavailable AND fallbackToPolicy is true; otherwise throws.
+ */
+async function createDenoMode(opts: SandboxFactoryOptions): Promise<SandboxCreationResult> {
+  const denoAvailable = await isDenoAvailable();
+  if (denoAvailable) {
+    logger.info('Creating sandbox in "deno" mode');
+    const executor = new DenoSandboxExecutor(opts.denoConfig);
+    return {
+      executor,
+      actualMode: 'deno',
+      usedFallback: false,
+    };
+  }
+  if (opts.fallbackToPolicy === true) {
+    logger.warn('Deno not available, falling back to "policy" mode');
+    const executor = new PolicySandboxExecutor(opts.policyConfig);
+    return {
+      executor,
+      actualMode: 'policy',
+      usedFallback: true,
+      warning: 'Deno not available. Using policy-based sandbox with limited isolation.',
+    };
+  }
+  throw new Error(
+    'Deno sandbox mode requested but Deno is not available. ' +
+      'Install Deno (>=2.0) or set fallbackToPolicy: true.'
   );
 }
 
 /**
  * Get the recommended sandbox mode for the current environment.
+ *
+ * Preference order: container > deno > policy. (#1898)
  */
 export async function getRecommendedMode(): Promise<SandboxMode> {
   const dockerAvailable = await isDockerAvailable();
-
   if (dockerAvailable) {
     return 'container';
   }
-
-  logger.info('Docker not available, recommending policy mode');
+  const denoAvailable = await isDenoAvailable();
+  if (denoAvailable) {
+    logger.info('Docker not available; recommending deno mode (process-level isolation)');
+    return 'deno';
+  }
+  logger.info('Neither Docker nor Deno available; recommending policy mode');
   return 'policy';
 }

--- a/packages/nexus-agents/src/security/sandbox/sandbox-types.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-types.ts
@@ -9,8 +9,18 @@
 
 /**
  * Sandbox execution mode.
+ *
+ * - `none`: no isolation; for development only.
+ * - `policy`: rule-based enforcement with no process isolation. Catches
+ *   policy violations but a misbehaving process can still touch the host.
+ * - `container`: Docker-based OS-level isolation. Strongest, but requires
+ *   Docker on the host.
+ * - `deno`: process-level permission gating via Deno's `--allow-*` flags
+ *   (#1898). Weaker than container — same OS, just process permissions —
+ *   but works without Docker (Mac without Docker Desktop, locked-down CI
+ *   runners). No CPU/memory limits.
  */
-export type SandboxMode = 'none' | 'policy' | 'container';
+export type SandboxMode = 'none' | 'policy' | 'container' | 'deno';
 
 /**
  * Security capability that can be restricted.


### PR DESCRIPTION
Closes #1898.

## What

Phase 1 of the WASM/Deno sandbox fallback option surfaced during the smolagents audit (#1889). Adds a \`'deno'\` SandboxMode that wraps the target command in Deno's per-process permission system — gives meaningful isolation on machines without Docker (Mac without Docker Desktop, locked-down CI runners).

## Implementation

- New \`'deno'\` mode alongside existing \`none\` | \`policy\` | \`container\`.
- \`DenoSandboxExecutor\` implementing \`ISandboxExecutor\`. Uses \`deno eval --allow-X ... 'await new Deno.Command(cmd, { args }).output()...'\` — Deno acts as the permission supervisor, evals a tiny JSON-argv-encoded spawn script, forwards stdout/stderr/exit.
- \`policyToDenoFlags(...)\` translates the existing \`SandboxPolicy\` capabilities + path rules + allowedCommands + allowedEnvVars into the corresponding \`--allow-run\` / \`--allow-net\` / \`--allow-read\` / \`--allow-write\` / \`--allow-env\` flag set. Denied capabilities produce no flag (Deno defaults to deny).
- Factory chain updated: **container → deno → policy**. \`fallbackToDeno\` defaults to \`true\`. \`mode: 'deno'\` requested directly fails closed when Deno is unavailable + \`fallbackToPolicy: false\`.
- \`getRecommendedMode()\` prefers container > deno > policy.

## Tradeoffs (documented in \`SandboxMode\` JSDoc)

- **Process-level** isolation, not container-level. A Deno-sandboxed process shares the host kernel/network stack, just with permission gates. Docker is strictly stronger.
- No CPU/memory cgroup limits — Deno doesn't expose them.
- Network filtering is coarse: \`--allow-net\` is on/off in v1; per-host filtering is Phase 2.
- Works without Docker — that's the explicit win.

## Backward compatibility

- \`none\` | \`policy\` | \`container\` modes unchanged.
- Existing \`'container'\` callers with \`fallbackToPolicy: true\` now get Deno before policy when Deno is available — strictly stronger isolation. Set \`fallbackToDeno: false\` to preserve old behavior.

## Tests

- 16 tests for \`policyToDenoFlags\` + \`isDenoAvailable\`
- 8 tests for \`DenoSandboxExecutor\` (mocked execFile — no real Deno needed)
- Factory tests extended for Deno mode + new fallback chain
- 60/60 sandbox-module tests pass; 602/602 full sandbox+factory tests pass

## Out of scope

- WASM/Pyodide path (Python-in-WASM) — different shape; would land as a separate sandbox mode if a consumer needs Python execution without a Python install.
- Per-host network filtering (\`--allow-net=api.example.com:443\`) — Phase 2.
- CPU/memory limits — Deno doesn't support them; would need OS-level wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)