### PR TITLE
docs(install): inline EACCES workaround as primary Linux/macOS path (#2436)

### DIFF
--- a/docs/getting-started/INSTALLATION.md
+++ b/docs/getting-started/INSTALLATION.md
@@ -50,6 +50,23 @@ Install globally for CLI access:
 npm install -g nexus-agents
 ```
 
+> **Linux / macOS without nvm or asdf?** A bare `npm install -g` will fail with
+> `EACCES: permission denied, mkdir '/usr/local/lib/node_modules/...'` because
+> the system npm prefix is not user-writable. **Do not run `sudo npm install -g`**
+> — npm itself recommends against it. Instead, configure a user-local prefix
+> once:
+>
+> ```bash
+> mkdir -p ~/.npm-global
+> npm config set prefix '~/.npm-global'
+> echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc   # or ~/.zshrc
+> source ~/.bashrc
+> npm install -g nexus-agents
+> ```
+>
+> If you can't or don't want to change the prefix, use `npx nexus-agents`
+> (see below) — every invocation works without a global install.
+
 After install, you'll see a hint to run setup. Configure everything:
 
 ```bash
@@ -61,6 +78,7 @@ Verify installation:
 ```bash
 nexus-agents doctor        # Checks CLIs, API keys, sqlite, data dirs
 nexus-agents doctor --fix  # Auto-fix missing data dirs and config
+nexus-agents login         # Show per-CLI auth status + login fix instructions
 ```
 
 ### pnpm


### PR DESCRIPTION
## Summary

- Hoist the `npm config set prefix` workaround from Troubleshooting to right beside the canonical `npm install -g nexus-agents` command, since round-14 onboarding (#2435 / #2436) found it's the **first** failure a new Linux/macOS user hits.
- Explicitly flag `sudo npm install -g` as discouraged.
- Surface the new `nexus-agents login` verification step that shipped in #2448.

## Why

`npm install -g nexus-agents` is what README + INSTALLATION.md tell users to run first. Without nvm/asdf, npm's default prefix (`/usr/local/lib`) isn't user-writable, so the install fails with EACCES before the user has any chance to read the troubleshooting section. The fix was always there — it just lived below the install command, where users wouldn't reach it until after the failure.

## Scope of #2436 covered

- ✅ Ask 1 — INSTALLATION.md update
- ✅ Ask 3 — already shipped in #2448 (QUICK_START.md npx)
- ⏭ Ask 2 — postinstall message detection: out of scope here. The install **fails before** any postinstall hook runs (mkdir EACCES is pre-extraction), so a postinstall script can't help. Documented as wontfix in the close comment.

## Test plan

- [ ] Render the markdown — verify the blockquote renders inline above the verify section
- [ ] Run `pnpm --filter nexus-agents docs:check` (Documentation Coverage CI)
- [ ] Run `npx tsx scripts/generate-docs.ts --check` (llms.txt freshness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)