### PR TITLE
fix(cli): suppress info log noise on interactive subcommands by default (#2443)

### DIFF
--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -9,6 +9,10 @@
  * (Source: Node.js 22.x parseArgs documentation)
  */
 
+// MUST stay the first import: side-effect mutates process.env.NEXUS_LOG_LEVEL
+// before any module loads core/logger.ts. See #2443.
+import './cli/cli-log-bootstrap.js';
+
 import { parseArgs } from 'node:util';
 import { createLogger } from './core/index.js';
 import { detectMode, isValidServerMode } from './cli/index.js';

--- a/packages/nexus-agents/src/cli/cli-log-bootstrap.test.ts
+++ b/packages/nexus-agents/src/cli/cli-log-bootstrap.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for cli-log-bootstrap (#2443).
+ *
+ * The bootstrap quiets info-level logs for interactive subcommands. Unit-test
+ * the pure logic via the exported `applyCliLogDefault` so we don't have to
+ * spawn a child process.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock logger.setGlobalLogLevel so we can assert it was called.
+const setGlobalLogLevelMock = vi.fn();
+vi.mock('../core/logger.js', () => ({
+  setGlobalLogLevel: setGlobalLogLevelMock,
+  getGlobalLogLevel: vi.fn(() => 'info'),
+}));
+
+// Import AFTER vi.mock so the bootstrap module-load side effect uses the mock.
+const { applyCliLogDefault } = await import('./cli-log-bootstrap.js');
+
+describe('applyCliLogDefault (#2443)', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env['NEXUS_LOG_LEVEL'];
+    delete process.env['NEXUS_LOG_LEVEL'];
+    setGlobalLogLevelMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['NEXUS_LOG_LEVEL'];
+    else process.env['NEXUS_LOG_LEVEL'] = originalEnv;
+  });
+
+  it('quiets to warn when an interactive subcommand has no overrides', () => {
+    applyCliLogDefault(['vote', '--quick', '--proposal', 'x']);
+    expect(setGlobalLogLevelMock).toHaveBeenCalledWith('warn');
+  });
+
+  it('quiets for any subcommand by default (allowlist of allowed-quiet, not denylist)', () => {
+    applyCliLogDefault(['orchestrate', 'do a thing']);
+    expect(setGlobalLogLevelMock).toHaveBeenCalledWith('warn');
+  });
+
+  it('does NOT quiet when no subcommand is present (MCP server stdio mode)', () => {
+    applyCliLogDefault([]);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when subcommand is `server`', () => {
+    applyCliLogDefault(['server']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when --verbose is present', () => {
+    applyCliLogDefault(['vote', '--verbose', '--proposal', 'x']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when -v short flag is present', () => {
+    applyCliLogDefault(['vote', '-v']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when --debug is present', () => {
+    applyCliLogDefault(['vote', '--debug']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when NEXUS_LOG_LEVEL is set explicitly (operator override wins)', () => {
+    process.env['NEXUS_LOG_LEVEL'] = 'info';
+    applyCliLogDefault(['vote']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT quiet when NEXUS_LOG_LEVEL is set to debug', () => {
+    process.env['NEXUS_LOG_LEVEL'] = 'debug';
+    applyCliLogDefault(['vote']);
+    expect(setGlobalLogLevelMock).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty NEXUS_LOG_LEVEL as unset', () => {
+    process.env['NEXUS_LOG_LEVEL'] = '';
+    applyCliLogDefault(['vote']);
+    expect(setGlobalLogLevelMock).toHaveBeenCalledWith('warn');
+  });
+
+  it('finds the subcommand even when flags come before it', () => {
+    // nexus-agents --some-flag vote ...
+    applyCliLogDefault(['--some-flag', 'vote', '--proposal', 'x']);
+    expect(setGlobalLogLevelMock).toHaveBeenCalledWith('warn');
+  });
+});

--- a/packages/nexus-agents/src/cli/cli-log-bootstrap.ts
+++ b/packages/nexus-agents/src/cli/cli-log-bootstrap.ts
@@ -1,0 +1,72 @@
+/**
+ * cli-log-bootstrap — set the default log level for interactive CLI commands
+ * before any subcommand handler emits its first info log.
+ *
+ * Source: Issue #2443 (round-14 onboarding audit). Running `nexus-agents vote`
+ * (or any other interactive subcommand) used to flood the terminal with
+ * info-level JSON logs from PreferenceRouter, LinUCB warm-up, and the config
+ * loader before the human-readable output appeared. New users couldn't tell
+ * what was an error and what was init noise.
+ *
+ * Mechanism:
+ * - Calls `setGlobalLogLevel('warn')` on the logger module so every logger
+ *   instance that hasn't been individually `setLevel`'d falls back to warn.
+ *   Per-instance overrides (e.g. `--verbose` flow in cli-orchestrator.ts:97)
+ *   still win.
+ * - Imported FIRST in `cli.ts`. ESM imports execute their side-effects in
+ *   source order; chunk-level `createLogger(...)` calls only construct
+ *   logger objects (no `info()` calls fire until command execution), so
+ *   the order of "chunk imports run" vs "bootstrap runs" doesn't matter as
+ *   long as the bootstrap runs before the first `.info()` call.
+ *
+ * No-op when:
+ *   - `NEXUS_LOG_LEVEL` is already set (operator override wins)
+ *   - argv has no subcommand (MCP server stdio mode — Claude needs the JSON)
+ *   - subcommand is in SERVER_COMMANDS (`server` synonym)
+ *   - `--verbose` / `-v` / `--debug` is present (operator wants the noise)
+ *
+ * To turn the noise back on without `--verbose`, set `NEXUS_LOG_LEVEL=info`.
+ */
+
+import { argv, env } from 'node:process';
+import { setGlobalLogLevel } from '../core/logger.js';
+
+const SERVER_COMMANDS = new Set(['server']);
+const VERBOSE_FLAGS = new Set(['--verbose', '-v', '--debug']);
+
+function findSubcommand(args: readonly string[]): string | undefined {
+  for (const a of args) {
+    if (!a.startsWith('-')) return a;
+  }
+  return undefined;
+}
+
+function shouldQuiet(args: readonly string[]): boolean {
+  // Operator override always wins.
+  if (env['NEXUS_LOG_LEVEL'] !== undefined && env['NEXUS_LOG_LEVEL'] !== '') return false;
+
+  const sub = findSubcommand(args);
+  // No subcommand => MCP server stdio mode. Claude reads JSON; don't downgrade.
+  if (sub === undefined) return false;
+  if (SERVER_COMMANDS.has(sub)) return false;
+
+  // --verbose / -v / --debug → user wants info-level logs back.
+  for (const flag of args) {
+    if (VERBOSE_FLAGS.has(flag)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Apply the quiet default if applicable. Exported so unit tests can drive it
+ * with synthetic argv without spawning a child process.
+ */
+export function applyCliLogDefault(args: readonly string[]): void {
+  if (shouldQuiet(args)) {
+    setGlobalLogLevel('warn');
+  }
+}
+
+// Module-load side effect: cli.ts imports this FIRST.
+applyCliLogDefault(argv.slice(2));

--- a/packages/nexus-agents/src/core/logger.test.ts
+++ b/packages/nexus-agents/src/core/logger.test.ts
@@ -4,8 +4,15 @@
  * Covers sanitize, sanitizeDeep, createLogger, and secret redaction.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { sanitize, sanitizeDeep, createLogger } from './logger.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  sanitize,
+  sanitizeDeep,
+  createLogger,
+  setGlobalLogLevel,
+  getGlobalLogLevel,
+  type LogLevel,
+} from './logger.js';
 import { FixedTimeProvider, setTimeProvider, resetTimeProvider } from './time-provider.js';
 import {
   FAKE_OPENAI_KEY,
@@ -191,6 +198,54 @@ describe('createLogger', () => {
       expect(stderrSpy).toHaveBeenCalledTimes(1);
     } finally {
       stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
+// ============================================================================
+// Issue #2443 — module-level GLOBAL_LEVEL fallback
+// ============================================================================
+
+describe('setGlobalLogLevel (#2443)', () => {
+  let savedLevel: LogLevel;
+
+  beforeEach(() => {
+    savedLevel = getGlobalLogLevel();
+  });
+
+  afterEach(() => {
+    setGlobalLogLevel(savedLevel);
+  });
+
+  it('downgrades existing logger instances that have not been individually setLevel-d', () => {
+    setGlobalLogLevel('info');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      // Create logger BEFORE setGlobalLogLevel('warn') — proves the global
+      // fallback applies to already-constructed instances.
+      const logger = createLogger({ component: 'global-fallback-test' });
+      setGlobalLogLevel('warn');
+      logger.info('should-be-suppressed-by-global-warn');
+      logger.warn('should-pass-through');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const written = String(stderrSpy.mock.calls[0]?.[0] ?? '');
+      expect(written).toContain('should-pass-through');
+      expect(written).not.toContain('should-be-suppressed-by-global-warn');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('per-instance setLevel still wins over the global fallback', () => {
+    setGlobalLogLevel('warn');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const logger = createLogger({ component: 'per-instance-override-test' });
+      logger.setLevel('debug'); // pin this instance below the global threshold
+      logger.info('should-pass-through-because-instance-pinned-debug');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+    } finally {
       stderrSpy.mockRestore();
     }
   });

--- a/packages/nexus-agents/src/core/logger.ts
+++ b/packages/nexus-agents/src/core/logger.ts
@@ -322,15 +322,48 @@ function writeLog(entry: LogEntry): void {
 }
 
 /**
+ * Module-level fallback level. All loggers that haven't had their own
+ * `setLevel(...)` called read this. Lets `setGlobalLogLevel(...)` quiet
+ * every existing instance at once — needed because by the time a CLI
+ * subcommand handler runs, dozens of module-level `createLogger(...)`
+ * calls have already returned closures holding their own `currentLevel`.
+ * Issue #2443.
+ */
+let GLOBAL_LEVEL: LogLevel = getDefaultLogLevel();
+
+/**
+ * Override the fallback log level for every logger that hasn't been
+ * individually `setLevel`'d. Called by the CLI dispatcher to suppress
+ * info-level init noise during interactive subcommands (#2443).
+ *
+ * Per-instance `setLevel(...)` still wins — call sites that explicitly
+ * raised a logger to debug (e.g. `--verbose` paths) keep that override.
+ */
+export function setGlobalLogLevel(level: LogLevel): void {
+  GLOBAL_LEVEL = level;
+}
+
+/** Read the current global fallback level (for tests / introspection). */
+export function getGlobalLogLevel(): LogLevel {
+  return GLOBAL_LEVEL;
+}
+
+/**
  * Creates a structured logger with configurable format and destination.
  * (Source: Issue #485 - Wire logging.format and logging.destination)
  */
 export function createLogger(baseContext?: LogContext): ILogger {
-  let currentLevel: LogLevel = getDefaultLogLevel();
+  // `undefined` means "follow GLOBAL_LEVEL". Calling `setLevel` pins this
+  // instance to a specific level regardless of GLOBAL_LEVEL changes.
+  let instanceLevel: LogLevel | undefined;
   const context = baseContext ?? {};
 
+  function effectiveLevel(): LogLevel {
+    return instanceLevel ?? GLOBAL_LEVEL;
+  }
+
   function shouldLog(level: LogLevel): boolean {
-    return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[currentLevel];
+    return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[effectiveLevel()];
   }
 
   function log(level: LogLevel, msg: string, ctx?: LogContext, e?: Error): void {
@@ -354,7 +387,7 @@ export function createLogger(baseContext?: LogContext): ILogger {
     },
     child: (childCtx): ILogger => createLogger({ ...context, ...childCtx }),
     setLevel: (level): void => {
-      currentLevel = level;
+      instanceLevel = level;
     },
     setFormat: (format): void => {
       globalFormat = format;


### PR DESCRIPTION
## Summary

Closes #2443 (round-14 onboarding audit). Running interactive subcommands (`vote`, `orchestrate`, `doctor`, etc.) used to flood the terminal with info-level JSON log frames (PreferenceRouter init, LinUCB warm-up, "Configuration loaded successfully", etc.) before the human-readable output appeared. New users couldn't tell what was an error and what was init noise.

## Before / after

```
$ nexus-agents vote --quick --proposal X --dry-run

Nexus Agents Consensus Vote
============================
[DRY RUN] Simulated votes - no actual agent execution
Proposal: X

Collecting votes from 3 agents (timeout: 300s each)...

# BEFORE: 100+ chars of JSON per agent here
# AFTER: nothing. Goes straight to:

Votes
  ✓ Software Architect: APPROVE (62%) [SIMULATED]
  ...
```

## How it works

Two pieces:

1. **`setGlobalLogLevel(level)`** in `core/logger.ts` — a new module-scope fallback that applies to every logger that hasn't been individually `setLevel`'d. Per-instance `setLevel(...)` (e.g. `cli-server.ts:508` `--verbose` path, `cli-orchestrator.ts:97`) still wins.
   - **Why we can't just set `NEXUS_LOG_LEVEL`:** ESM bundle hoisting means many `var logger = createLogger(...)` calls fire during chunk-load, before any subcommand handler runs. The closures already captured `getDefaultLogLevel()`. The new global fallback fixes that.

2. **`cli-log-bootstrap`** — a tiny module imported FIRST in `cli.ts`. On import it inspects argv and calls `setGlobalLogLevel('warn')` when all of:
   - argv has a subcommand (so this isn't MCP stdio mode)
   - subcommand isn't `server`
   - no `--verbose` / `-v` / `--debug` flag
   - `NEXUS_LOG_LEVEL` not already set

## Operator escape hatches

In priority order:

| What you want                         | How                                       |
| ------------------------------------- | ----------------------------------------- |
| Verbose for one command (debug)       | `--verbose` (or `-v` / `--debug`)         |
| Verbose for the session               | `export NEXUS_LOG_LEVEL=info`             |
| Server keeps its current behavior     | (no change — `nexus-agents` / `server`)   |

## What did NOT change

- Per-instance `logger.setLevel(...)` semantics — `cli-server.ts:508`, `cli-orchestrator.ts:97`, and `repl.ts:217` still bump their loggers to debug on `--verbose` exactly as before. The global fallback is only consulted when `instanceLevel` is undefined.
- MCP stdio mode (no subcommand) — Claude still gets the structured JSON frames it parses.
- Default level when `NEXUS_LOG_LEVEL` is unset for the bare `nexus-agents` invocation — still `info`.

## Test plan

- [x] 11 new unit tests for `applyCliLogDefault` covering every escape hatch
- [x] 2 new unit tests for `setGlobalLogLevel` (existing-instance downgrade + per-instance override wins)
- [x] All 179 logger / cli-server / cli-orchestrator tests still pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Live smoke: vote (quiet), `vote --verbose` (loud), `NEXUS_LOG_LEVEL=info vote` (loud), `doctor` (quiet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)