### PR TITLE
fix(vote): name the rejection cause when threshold isn't met (#2442)

### DIFF
--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -210,22 +210,34 @@ describe('formatVoteRow (#2441)', () => {
   });
 });
 
-describe('explainOutcome (#2441)', () => {
+describe('explainOutcome (#2441 + #2442)', () => {
   const baseVotes: readonly AgentVoteResult[] = [
     makeVoteRow({ role: 'architect', source: 'llm' }),
     makeVoteRow({ role: 'security', source: 'error', error: 'Not logged in' }),
     makeVoteRow({ role: 'scope_steward', source: 'error', error: 'MCP closed' }),
   ];
 
+  function ctx(
+    overrides: Partial<Parameters<typeof explainOutcome>[0]> = {}
+  ): Parameters<typeof explainOutcome>[0] {
+    return {
+      outcome: 'rejected',
+      quorumReached: false,
+      errored: 0,
+      votes: [] as readonly AgentVoteResult[],
+      approvalPercentage: 0,
+      threshold: 'supermajority' as const,
+      ...overrides,
+    };
+  }
+
   it('returns empty string when outcome is approved', () => {
-    expect(
-      explainOutcome({ outcome: 'approved', quorumReached: true, errored: 0, votes: [] })
-    ).toBe('');
+    expect(explainOutcome(ctx({ outcome: 'approved', quorumReached: true }))).toBe('');
   });
 
   it('explains "quorum not reached" with errored-voter count when applicable', () => {
     const explained = stripAnsi(
-      explainOutcome({ outcome: 'rejected', quorumReached: false, errored: 2, votes: baseVotes })
+      explainOutcome(ctx({ quorumReached: false, errored: 2, votes: baseVotes }))
     );
     expect(explained).toContain('quorum not reached');
     expect(explained).toContain('2 of 3 voter(s) failed');
@@ -233,20 +245,31 @@ describe('explainOutcome (#2441)', () => {
   });
 
   it('explains "quorum not reached" without error count when no voters errored', () => {
-    const explained = stripAnsi(
-      explainOutcome({ outcome: 'rejected', quorumReached: false, errored: 0, votes: [] })
-    );
+    const explained = stripAnsi(explainOutcome(ctx({ quorumReached: false, errored: 0 })));
     expect(explained).toContain('quorum not reached');
     expect(explained).not.toContain('voter(s) failed');
   });
 
-  it('returns empty string when rejected with quorum reached (real defeat, not infrastructure)', () => {
-    const explained = explainOutcome({
-      outcome: 'rejected',
-      quorumReached: true,
-      errored: 0,
-      votes: [],
-    });
-    expect(explained).toBe('');
+  it('explains threshold-not-met when quorum reached but rejected (#2442)', () => {
+    // The original report: "Approval: 100% / Result: REJECTED" with no
+    // explanation. After this fix, the result line names the threshold and
+    // the actual approval that fell short of it.
+    const explained = stripAnsi(
+      explainOutcome(
+        ctx({ quorumReached: true, approvalPercentage: 60, threshold: 'supermajority' })
+      )
+    );
+    expect(explained).toContain('supermajority threshold not met');
+    expect(explained).toContain('60.0%');
+    // Must NOT collapse to the empty string the way the pre-#2442 code did.
+    expect(explained.length).toBeGreaterThan(0);
+  });
+
+  it('formats unanimous threshold rejection cleanly', () => {
+    const explained = stripAnsi(
+      explainOutcome(ctx({ quorumReached: true, approvalPercentage: 80, threshold: 'unanimous' }))
+    );
+    expect(explained).toContain('unanimous threshold not met');
+    expect(explained).toContain('80.0%');
   });
 });

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -104,7 +104,14 @@ function printSummary(ctx: SummaryContext): void {
 
   const outcomeColor =
     outcome === 'approved' ? colors.green : outcome === 'rejected' ? colors.red : colors.yellow;
-  const cause = explainOutcome({ outcome, quorumReached, errored, votes });
+  const cause = explainOutcome({
+    outcome,
+    quorumReached,
+    errored,
+    votes,
+    approvalPercentage,
+    threshold,
+  });
   writeLine(
     `\n${colors.bold}Result: ${outcomeColor}${outcome.toUpperCase()}${colors.reset}${cause}\n`
   );
@@ -123,9 +130,22 @@ export interface OutcomeExplainCtx {
   readonly quorumReached: boolean;
   readonly errored: number;
   readonly votes: readonly AgentVoteResult[];
+  readonly approvalPercentage: number;
+  readonly threshold: ConsensusAlgorithm;
 }
 
-/** @internal — exported for tests only. */
+/**
+ * Names the *reason* a vote was rejected so operators don't see e.g.
+ * "Approval: 100% / Result: REJECTED" with no explanation. Issue #2442.
+ *
+ * Three rejection paths the summary now distinguishes:
+ *   1. Quorum failed because voters errored — surfaces the failed count.
+ *   2. Quorum failed for any other reason (panel was too small, voters
+ *      didn't return a decision in time).
+ *   3. Quorum reached but the supermajority/unanimous threshold wasn't met.
+ *
+ * @internal — exported for tests only.
+ */
 export function explainOutcome(ctx: OutcomeExplainCtx): string {
   if (ctx.outcome !== 'rejected') return '';
   if (!ctx.quorumReached && ctx.errored > 0) {
@@ -136,7 +156,8 @@ export function explainOutcome(ctx: OutcomeExplainCtx): string {
   if (!ctx.quorumReached) {
     return ` ${colors.dim}— quorum not reached${colors.reset}`;
   }
-  return '';
+  // Quorum reached but rejected ⇒ approval threshold wasn't met.
+  return ` ${colors.dim}— ${ctx.threshold} threshold not met (got ${ctx.approvalPercentage.toFixed(1)}%)${colors.reset}`;
 }
 
 function printHashes(votes: readonly AgentVoteResult[]): void {


### PR DESCRIPTION
## Summary

Closes #2442 (round-14 onboarding audit). Finishes the third rejection-explanation case left over from PR #2451.

The audit reported that `Result: REJECTED` could appear with no explanation. PR #2451 covered:

1. ✅ Quorum failed because voters errored — `REJECTED — quorum not reached (2 of 3 voter(s) failed; only 1 vote(s) recorded)`
2. ✅ Quorum failed for any other reason — `REJECTED — quorum not reached`
3. ❌ Quorum reached but threshold wasn't met — `REJECTED` (silent — fixed in this PR)

## Before / after

```
$ nexus-agents vote --quick --proposal X --dry-run

Approval: 50.0%
Threshold: supermajority

# BEFORE
Result: REJECTED

# AFTER
Result: REJECTED — supermajority threshold not met (got 50.0%)
```

For unanimous: `Result: REJECTED — unanimous threshold not met (got 80.0%)`.

## Implementation

- `OutcomeExplainCtx` gains `approvalPercentage` and `threshold` fields (already known in `printSummary` via `result` and `ctx.threshold`).
- `explainOutcome` now has a third branch for `quorumReached && rejected`.
- 2 new unit tests (supermajority and unanimous paths).

## Test plan

- [x] 18 unit tests pass (was 17, +2 for #2442, -1 for the now-removed "returns empty when quorum reached" test that asserted the old broken behavior)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Live dry-run smoke shows the new line

🤖 Generated with [Claude Code](https://claude.com/claude-code)