### PR TITLE
fix(cli-adapter): unwrap CLI structured-error envelopes (#2440)

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for parseCliErrorEnvelope (#2440).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseCliErrorEnvelope } from './cli-error-envelope.js';
+
+describe('parseCliErrorEnvelope (#2440)', () => {
+  // Real-world example from the round-14 audit report.
+  const claudeNotLoggedIn = JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    is_error: true,
+    api_error_status: null,
+    duration_ms: 116,
+    duration_api_ms: 0,
+    num_turns: 1,
+    result: 'Not logged in · Please run /login',
+    stop_reason: 'stop_sequence',
+    session_id: '2aa32fa2-deadbeef',
+  });
+
+  it('unwraps Claude "Not logged in" envelope and classifies as NOT_AUTHENTICATED', () => {
+    const result = parseCliErrorEnvelope(claudeNotLoggedIn, 'claude');
+    expect(result).not.toBeNull();
+    expect(result?.message).toContain('Not logged in');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+    expect(result?.hint).toContain('claude /login');
+  });
+
+  it('appends a per-CLI login hint for codex', () => {
+    const codexEnv = JSON.stringify({ error: 'authentication required' });
+    const result = parseCliErrorEnvelope(codexEnv, 'codex');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+    expect(result?.hint).toContain('codex login');
+  });
+
+  it('appends a per-CLI login hint for gemini', () => {
+    const geminiEnv = JSON.stringify({ error: 'invalid api key' });
+    const result = parseCliErrorEnvelope(geminiEnv, 'gemini');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+    expect(result?.hint).toContain('gemini');
+  });
+
+  it('classifies a non-auth error envelope as EXECUTION_ERROR (not retryable)', () => {
+    const env = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'Model returned 500: temporary upstream issue',
+    });
+    const result = parseCliErrorEnvelope(env, 'claude');
+    expect(result?.code).toBe('EXECUTION_ERROR');
+    expect(result?.hint).toBeUndefined();
+  });
+
+  it('returns null for non-JSON stdout (caller falls back)', () => {
+    expect(parseCliErrorEnvelope('hello world', 'claude')).toBeNull();
+    expect(parseCliErrorEnvelope('', 'claude')).toBeNull();
+    expect(parseCliErrorEnvelope('  \n  ', 'claude')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseCliErrorEnvelope('{not real json', 'claude')).toBeNull();
+  });
+
+  it('returns null for JSON without an error envelope shape', () => {
+    expect(parseCliErrorEnvelope(JSON.stringify({ ok: true, data: 42 }), 'claude')).toBeNull();
+  });
+
+  it('returns null for Claude envelope with is_error: false', () => {
+    expect(
+      parseCliErrorEnvelope(
+        JSON.stringify({ type: 'result', is_error: false, result: 'normal output' }),
+        'claude'
+      )
+    ).toBeNull();
+  });
+
+  it('truncates very long error messages to 240 chars', () => {
+    const long = 'X'.repeat(1000);
+    const env = JSON.stringify({ type: 'result', is_error: true, result: long });
+    const result = parseCliErrorEnvelope(env, 'claude');
+    expect(result?.message.length).toBeLessThanOrEqual(240);
+  });
+
+  it('takes only the first line of multi-line error messages', () => {
+    const env = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'first line of error\nsecond line with stack trace\nthird line',
+    });
+    const result = parseCliErrorEnvelope(env, 'claude');
+    expect(result?.message).toBe('first line of error');
+  });
+
+  it('handles NDJSON (multi-line JSON) by trying the last line', () => {
+    const ndjson = [
+      JSON.stringify({ type: 'log', message: 'starting' }),
+      JSON.stringify({ type: 'log', message: 'thinking' }),
+      JSON.stringify({ type: 'result', is_error: true, result: 'Not logged in' }),
+    ].join('\n');
+    const result = parseCliErrorEnvelope(ndjson, 'claude');
+    expect(result?.message).toContain('Not logged in');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+  });
+
+  it('matches "unauthorized" anywhere in the message', () => {
+    const env = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: '401 Unauthorized: token expired',
+    });
+    const result = parseCliErrorEnvelope(env, 'claude');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+  });
+
+  it('matches "invalid API key"', () => {
+    const env = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'Invalid API key. Get one at https://console.anthropic.com',
+    });
+    const result = parseCliErrorEnvelope(env, 'claude');
+    expect(result?.code).toBe('NOT_AUTHENTICATED');
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
@@ -1,0 +1,155 @@
+/**
+ * cli-error-envelope — extract the actionable message from a CLI's
+ * structured error envelope.
+ *
+ * When `claude`, `codex`, etc. return a JSON envelope with `is_error: true`,
+ * the response parser correctly fails to find a usable assistant message
+ * and falls through to the generic PARSE_ERROR path in `subprocess-adapter`.
+ * That path stuffs the first 500 chars of the envelope into the error
+ * message, producing the unreadable wall of escaped JSON described in #2440.
+ *
+ * This module unwraps known envelope shapes so the operator sees:
+ *
+ *   ✗ Claude CLI: Not logged in
+ *     → claude /login, then retry
+ *
+ * instead of 600 characters of `{"timestamp":"...","level":"warn",...}`.
+ *
+ * Source: Issue #2440 (round-14 onboarding audit, ask 1 + ask 2).
+ */
+
+import type { CliErrorCode, CliName } from './types.js';
+
+/**
+ * Result of unwrapping a CLI's structured error envelope. `null` when the
+ * stdout doesn't match a known shape — caller falls back to the existing
+ * snippet behavior.
+ */
+export interface ParsedCliError {
+  /** Short, user-facing message — the unwrapped CLI error string. */
+  readonly message: string;
+  /** Classified code so the retry/fail-closed logic can do the right thing. */
+  readonly code: CliErrorCode;
+  /** Optional one-line hint with the canonical fix for this CLI. */
+  readonly hint?: string;
+}
+
+/**
+ * Claude CLI structured envelope shape:
+ *   {"type":"result","is_error":true,"result":"<reason>","session_id":"...",...}
+ *
+ * Use a structural type guard rather than parsing into a strict schema —
+ * upstream may add fields and we only care about three of them.
+ */
+interface ClaudeErrorEnvelope {
+  readonly type: 'result';
+  readonly is_error: true;
+  readonly result?: string;
+}
+
+function isClaudeErrorEnvelope(v: unknown): v is ClaudeErrorEnvelope {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as { type?: unknown; is_error?: unknown };
+  return obj.type === 'result' && obj.is_error === true;
+}
+
+/**
+ * Codex CLI envelope shape (best-effort — codex CLI's error shape is
+ * less stable than Claude's):
+ *   {"error":"<reason>"}  or  {"is_error":true,"message":"<reason>"}
+ */
+function unwrapCodexEnvelope(parsed: unknown): string | null {
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as { error?: unknown; message?: unknown; is_error?: unknown };
+  if (typeof obj.error === 'string' && obj.error !== '') return obj.error;
+  if (obj.is_error === true && typeof obj.message === 'string' && obj.message !== '') {
+    return obj.message;
+  }
+  return null;
+}
+
+/** Login hint matched against the parsed message text, per CLI. */
+const LOGIN_HINTS: Record<CliName, string> = {
+  claude: 'claude /login',
+  codex: 'codex login',
+  gemini: 'gemini',
+  opencode: 'opencode auth login',
+};
+
+const NOT_AUTH_PATTERNS: readonly RegExp[] = [
+  /not logged in/i,
+  /please run \/?login/i,
+  /authentication (?:required|expired|failed)/i,
+  /invalid (?:api ?key|credentials)/i,
+  /unauthorized/i,
+];
+
+function classifyMessage(message: string): { code: CliErrorCode; auth: boolean } {
+  for (const re of NOT_AUTH_PATTERNS) {
+    if (re.test(message)) return { code: 'NOT_AUTHENTICATED', auth: true };
+  }
+  return { code: 'EXECUTION_ERROR', auth: false };
+}
+
+/**
+ * Try to find the actionable error string inside a CLI's stdout. Returns
+ * `null` if the stdout doesn't look like a structured error envelope (the
+ * caller then falls back to the existing snippet truncation).
+ */
+export function parseCliErrorEnvelope(stdout: string, cliName: CliName): ParsedCliError | null {
+  const trimmed = stdout.trim();
+  if (trimmed === '' || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Whole-blob parse failed — could be NDJSON (one JSON object per line).
+    // Try the last line, which is where Claude/Codex emit the terminal
+    // envelope.
+    return tryLastLine(trimmed, cliName);
+  }
+
+  let message: string | undefined;
+  if (isClaudeErrorEnvelope(parsed) && typeof parsed.result === 'string') {
+    message = parsed.result;
+  } else {
+    const codex = unwrapCodexEnvelope(parsed);
+    if (codex !== null) message = codex;
+  }
+
+  if (message === undefined || message === '') return null;
+
+  return buildParsedError(message, cliName);
+}
+
+function tryLastLine(stdout: string, cliName: CliName): ParsedCliError | null {
+  const lines = stdout.split('\n').filter((l) => l.trim() !== '');
+  if (lines.length < 2) return null;
+  const last = lines.at(-1);
+  if (last === undefined) return null;
+  if (!last.startsWith('{')) return null;
+  try {
+    const parsed = JSON.parse(last) as unknown;
+    if (isClaudeErrorEnvelope(parsed) && typeof parsed.result === 'string') {
+      return buildParsedError(parsed.result, cliName);
+    }
+  } catch {
+    /* ignore — fall through to null */
+  }
+  return null;
+}
+
+function buildParsedError(message: string, cliName: CliName): ParsedCliError {
+  // Trim to first line + cap length — operators don't need 500 chars of envelope.
+  const firstLine = (message.split('\n')[0] ?? message).trim().slice(0, 240);
+  const { code, auth } = classifyMessage(firstLine);
+  if (auth) {
+    return {
+      message: firstLine,
+      code,
+      hint: `Run \`${LOGIN_HINTS[cliName]}\` to authenticate, then retry.`,
+    };
+  }
+  return { message: firstLine, code };
+}

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -24,6 +24,7 @@ import type {
 import { BaseCliAdapter } from './base-adapter.js';
 import { sanitizeOutput } from '../security/output-sanitizer.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
+import { parseCliErrorEnvelope } from './cli-error-envelope.js';
 
 /** Minimum length for plaintext fallback to kick in.
  * Lowered from 100→30 to recover short but valid CLI responses (#1401). */
@@ -454,27 +455,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
 
     const text = this.parser.extractResponse(stdout);
     if (text === null) {
-      // Check for rate-limit indicators in raw stdout (#1320)
-      if (isRateLimitText(stdout)) {
-        const snippet = stdout.slice(0, 500).trim();
-        return err(this.createError('RATE_LIMITED', snippet));
-      }
-      // Plaintext fallback: recover responses from CLIs outputting unstructured text (#1401)
-      const plaintext = tryPlaintextFallback(stdout);
-      if (plaintext !== null) {
-        subprocessLogger.debug('Using plaintext fallback for unparseable output');
-        return ok(
-          this.normalizeResponse(plaintext, undefined, {
-            durationMs: getTimeProvider().now() - startTime,
-            raw: stdout,
-          })
-        );
-      }
-      const snippet = stdout.slice(0, 500).trim();
-      const stderrHint = stderr !== '' ? ` [stderr: ${stderr.slice(0, 300).trim()}]` : '';
-      return err(
-        this.createError('PARSE_ERROR', `Failed to parse response: ${snippet}${stderrHint}`)
-      );
+      return this.handleUnparseableOutput(stdout, stderr, startTime);
     }
 
     const usage = this.parser.extractUsage(stdout);
@@ -486,6 +467,48 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
         raw: stdout,
         ...(sessionId !== null && { sessionId }),
       })
+    );
+  }
+
+  /**
+   * Handles the parse-failure branch: when the CLI's structured response
+   * parser returned null. Order of recovery attempts (most-specific first):
+   *   1. Rate-limit text in raw stdout (#1320)
+   *   2. Structured CLI error envelope (#2440)
+   *   3. Plaintext fallback for natural-language output (#1401)
+   *   4. Generic PARSE_ERROR with truncated snippet
+   */
+  private handleUnparseableOutput(
+    stdout: string,
+    stderr: string,
+    startTime: number
+  ): Result<CliResponse, CliError> {
+    if (isRateLimitText(stdout)) {
+      const snippet = stdout.slice(0, 500).trim();
+      return err(this.createError('RATE_LIMITED', snippet));
+    }
+    const envelope = parseCliErrorEnvelope(stdout, this.name);
+    if (envelope !== null) {
+      const msg =
+        envelope.hint !== undefined
+          ? `${envelope.message}\n  → ${envelope.hint}`
+          : envelope.message;
+      return err(this.createError(envelope.code, msg));
+    }
+    const plaintext = tryPlaintextFallback(stdout);
+    if (plaintext !== null) {
+      subprocessLogger.debug('Using plaintext fallback for unparseable output');
+      return ok(
+        this.normalizeResponse(plaintext, undefined, {
+          durationMs: getTimeProvider().now() - startTime,
+          raw: stdout,
+        })
+      );
+    }
+    const snippet = stdout.slice(0, 500).trim();
+    const stderrHint = stderr !== '' ? ` [stderr: ${stderr.slice(0, 300).trim()}]` : '';
+    return err(
+      this.createError('PARSE_ERROR', `Failed to parse response: ${snippet}${stderrHint}`)
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #2440 (round-14 onboarding audit). When a CLI returned a structured error envelope, the adapter wrapped the entire 600-character envelope into the error message. The actionable bit was buried 250 chars deep inside an escaped string inside another escaped string. New users had no chance.

## Before / after

**Before:**
```
error: Failed to parse response: {"type":"result","subtype":"success",
  "is_error":true,"api_error_status":null,"duration_ms":116,...
  "result":"Not logged in · Please run /login"...} [200+ more chars]
```

**After:**
```
error: Not logged in · Please run /login
  → Run `claude /login` to authenticate, then retry.
```

## Implementation

New `cli-adapters/cli-error-envelope.ts` with `parseCliErrorEnvelope(stdout, cliName)`:

- Tries whole-blob `JSON.parse`, falls back to last-line of NDJSON
- Recognises Claude's `{type:"result", is_error:true, result:"..."}` shape
- Recognises codex's `{error:"..."}` and `{is_error:true, message:"..."}` shapes
- Classifies any of `not logged in` / `unauthorized` / `invalid api key` / `auth failed/expired` / `please run /login` as **`NOT_AUTHENTICATED`** (which is **NOT** in `RETRYABLE_ERROR_CODES`, so we fail closed instead of burning retries on auth errors)
- Appends a per-CLI login hint for auth errors: `claude /login` / `codex login` / `gemini` / `opencode auth login`
- Truncates messages to first line + 240 chars (was: first 500 chars of the entire envelope)

`subprocess-adapter.ts` `handleSubprocessOutput` calls the helper before falling through to the generic PARSE_ERROR snippet path. Recovery order: rate-limit → envelope → plaintext fallback → generic. Extracted `handleUnparseableOutput` to keep the parent function under the complexity-10 cap.

## Test plan

- [x] 13 unit tests for the envelope parser (real-world Claude "Not logged in" envelope from the audit, per-CLI hints, non-auth classified as `EXECUTION_ERROR` with no hint, malformed JSON returns null, NDJSON last-line fallback, "unauthorized" / "Invalid API key" pattern matching, length truncation, multi-line first-line extraction)
- [x] All 2495 cli-adapters tests pass (no regression)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

## What did NOT change

- The retry machinery — `NOT_AUTHENTICATED` was already not in `RETRYABLE_ERROR_CODES`, so this PR just routes auth-shaped errors to that code instead of `PARSE_ERROR` (which IS retried up to 3 times — auth errors should fail fast).
- The plaintext fallback (#1401) — still kicks in when the stdout isn't a JSON envelope at all.
- The generic snippet path — still used as the last-resort when nothing matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)