### PR TITLE
fix(verify): use auth probe to align with doctor (#2437)

### DIFF
--- a/packages/nexus-agents/src/cli/verify-command.ts
+++ b/packages/nexus-agents/src/cli/verify-command.ts
@@ -14,6 +14,7 @@ import { defaultConfig } from '../config/index.js';
 import { BUILT_IN_EXPERTS } from '../agents/experts/expert-config.js';
 import { colors, symbols } from './ansi-output.js';
 import { checkSqlite, checkDataDirectory, checkApiKeys } from './doctor.js';
+import { probeAllClis } from './cli-auth-probe.js';
 
 /**
  * Verify command options.
@@ -246,27 +247,45 @@ function checkDataDirs(): VerifyCheck {
 
 /**
  * Checks that at least one execution path is configured — either an API key
- * (direct adapter) or a CLI binary pre-authenticated. Without either, the
- * orchestrator has nothing to dispatch to.
+ * (direct adapter) or a CLI that's actually authenticated. Without either,
+ * the orchestrator has nothing to dispatch to.
+ *
+ * #2437: previously only checked env vars, so verify reported "No API keys
+ * configured / degraded" while doctor (post-#2448) correctly reported the
+ * CLI as authed. Both were accurate but disagreed in tone, confusing
+ * operators. Now verify uses the same auth probe doctor uses, so they
+ * align on the available-paths question.
  */
-function checkAdapterAvailability(): VerifyCheck {
+async function checkAdapterAvailability(): Promise<VerifyCheck> {
   const keys = checkApiKeys();
-  const configured = keys.filter((k) => k.configured);
-  if (configured.length > 0) {
+  const configuredKeys = keys.filter((k) => k.configured);
+  const authedClis = (await probeAllClis()).filter((p) => p.state === 'authenticated');
+
+  if (configuredKeys.length > 0 || authedClis.length > 0) {
+    const parts: string[] = [];
+    if (configuredKeys.length > 0) {
+      parts.push(
+        `${String(configuredKeys.length)} API key(s): ${configuredKeys.map((k) => k.name).join(', ')}`
+      );
+    }
+    if (authedClis.length > 0) {
+      parts.push(
+        `${String(authedClis.length)} authed CLI(s): ${authedClis.map((p) => p.cli).join(', ')}`
+      );
+    }
     return {
       name: 'Adapter Availability',
       passed: true,
-      message: `${String(configured.length)} API key(s) configured: ${configured
-        .map((k) => k.name)
-        .join(', ')}`,
+      message: parts.join('; '),
     };
   }
+
   return {
     name: 'Adapter Availability',
     passed: false,
     severity: 'warn',
-    message: 'No API keys configured (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_AI_API_KEY)',
-    fix: 'Set at least one API key, or install a CLI (claude/gemini/codex/opencode) and run "nexus-agents doctor"',
+    message: 'No API keys and no authed CLIs detected',
+    fix: 'Run "nexus-agents login" to see per-CLI status, then "claude /login" / "codex login" / etc., or set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_AI_API_KEY',
   };
 }
 
@@ -284,7 +303,7 @@ export async function runVerify(): Promise<VerifyResult> {
     checkExpertSystem(),
     await checkSqliteAvailability(),
     checkDataDirs(),
-    checkAdapterAvailability(),
+    await checkAdapterAvailability(),
   ];
 
   const allPassed = checks.every((c) => c.passed);


### PR DESCRIPTION
## Summary

Closes #2437 (round-14 onboarding audit). Same container, same env, two adjacent commands telling the user different things about whether they could run nexus-agents:

```
$ nexus-agents verify
  ⚠ Adapter Availability: No API keys configured (...)
  Verified with 1 warning(s) — functional but degraded

$ nexus-agents doctor
  ✓ Claude CLI    Auth: CLI auth
  ✓ Gemini CLI   Auth: ADC/CLI auth
  Status: Ready
```

The audit reported this as "doctor + verify disagree." After PR #2448 wired doctor to the real auth probe (cred files + login subprocess + env), doctor became accurate. verify, though, still only checked env vars — so on a host where Claude was logged in via `~/.claude/.credentials.json` but no API keys were exported, verify reported "degraded" while doctor said "Ready." Both were technically accurate (different aspects), but the conflicting tone confused operators and verify's "degraded" status was wrong: the orchestrator had three working dispatch paths.

## Fix

`checkAdapterAvailability` now ALSO calls `probeAllClis()` (the same probe doctor and login use). It reports as PASSED when EITHER an API key is set OR a CLI is authed:

```
✓ Adapter Availability: 3 authed CLI(s): claude, gemini, codex
```

```
✓ Adapter Availability: 1 API key(s): ANTHROPIC_API_KEY; 2 authed CLI(s): claude, gemini
```

And only reports the warning when truly nothing is configured:

```
⚠ Adapter Availability: No API keys and no authed CLIs detected
  Fix: Run "nexus-agents login" to see per-CLI status, then "claude /login"
       / "codex login" / etc., or set ANTHROPIC_API_KEY / OPENAI_API_KEY /
       GOOGLE_AI_API_KEY
```

## What did NOT change

- The check still uses `severity: 'warn'` so the absence of any configured path doesn't fail verify with exit 1 (that's intentional — verify's job is to report, not gate).
- `doctor` is unchanged; this PR is just bringing verify up to the same accuracy bar.

## Test plan

- [x] All 24 verify-command tests still pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Live smoke on a host with 3 CLIs authed: verify says `3 authed CLI(s): claude, gemini, codex`, doctor agrees with `Status: Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)