### PR TITLE
refactor(cli): rename 'login' to 'auth status'; keep login as alias (#2449)

### DIFF
--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-05-08T20:12:42.733Z",
+  "generated": "2026-05-08T22:19:36.452Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.70.0",
   "cli": {
@@ -14,7 +14,7 @@
       },
       {
         "name": "auth",
-        "type": "sync",
+        "type": "async",
         "handler": "handleAuthCommand",
         "file": "src/cli-commands-handlers.ts"
       },

--- a/docs/getting-started/INSTALLATION.md
+++ b/docs/getting-started/INSTALLATION.md
@@ -78,7 +78,7 @@ Verify installation:
 ```bash
 nexus-agents doctor        # Checks CLIs, API keys, sqlite, data dirs
 nexus-agents doctor --fix  # Auto-fix missing data dirs and config
-nexus-agents login         # Show per-CLI auth status + login fix instructions
+nexus-agents auth status   # Show per-CLI auth state + login fix instructions
 ```
 
 ### pnpm

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-05-08T20:12:42.733Z
+**Generated:** 2026-05-08T22:19:36.452Z
 **Package Version:** 2.70.0
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -16,7 +16,7 @@ Binary: `nexus-agents`
 | Command | Type | Handler | Source File |
 | --------- | ------ | --------- | ------------- |
 | `atbench` | async | `handleAtbenchCommand` | `src/cli-commands-handlers.ts` |
-| `auth` | sync | `handleAuthCommand` | `src/cli-commands-handlers.ts` |
+| `auth` | async | `handleAuthCommand` | `src/cli-commands-handlers.ts` |
 | `capabilities` | sync | `handleCapabilitiesCommand` | `src/cli-commands-handlers.ts` |
 | `config` | async | `handleConfigCommand` | `src/cli-commands-handlers.ts` |
 | `demo` | async | `handleDemoCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-auth-handler.test.ts
+++ b/packages/nexus-agents/src/cli-auth-handler.test.ts
@@ -6,6 +6,10 @@ vi.mock('./cli/index.js', () => ({
   authCommand: vi.fn(),
 }));
 
+vi.mock('./cli/login-command.js', () => ({
+  handleLoginCommand: vi.fn(() => Promise.resolve()),
+}));
+
 function createArgs(
   subcommand: string | undefined,
   options: Record<string, unknown> = {}
@@ -25,31 +29,49 @@ describe('handleAuthCommand', () => {
 
   it('should call authCommand with subcommand', async () => {
     const { authCommand } = await import('./cli/index.js');
-    handleAuthCommand(createArgs('init'));
+    await handleAuthCommand(createArgs('init'));
     expect(authCommand).toHaveBeenCalledWith('init', { force: false, format: 'text' });
   });
 
   it('should pass force option', async () => {
     const { authCommand } = await import('./cli/index.js');
-    handleAuthCommand(createArgs('rotate', { force: true }));
+    await handleAuthCommand(createArgs('rotate', { force: true }));
     expect(authCommand).toHaveBeenCalledWith('rotate', { force: true, format: 'text' });
   });
 
   it('should pass json format', async () => {
     const { authCommand } = await import('./cli/index.js');
-    handleAuthCommand(createArgs('show', { format: 'json' }));
+    await handleAuthCommand(createArgs('show', { format: 'json' }));
     expect(authCommand).toHaveBeenCalledWith('show', { force: false, format: 'json' });
   });
 
   it('should default format to text for non-json values', async () => {
     const { authCommand } = await import('./cli/index.js');
-    handleAuthCommand(createArgs('show', { format: 'yaml' }));
+    await handleAuthCommand(createArgs('show', { format: 'yaml' }));
     expect(authCommand).toHaveBeenCalledWith('show', { force: false, format: 'text' });
   });
 
   it('should pass undefined subcommand', async () => {
     const { authCommand } = await import('./cli/index.js');
-    handleAuthCommand(createArgs(undefined));
+    await handleAuthCommand(createArgs(undefined));
     expect(authCommand).toHaveBeenCalledWith(undefined, { force: false, format: 'text' });
+  });
+
+  // Issue #2449: `auth status` routes to the shared login-command probe.
+  it('routes "auth status" subcommand to handleLoginCommand', async () => {
+    const { authCommand } = await import('./cli/index.js');
+    const { handleLoginCommand } = await import('./cli/login-command.js');
+    await handleAuthCommand(createArgs('status'));
+    expect(handleLoginCommand).toHaveBeenCalledOnce();
+    // The legacy auth-token handler must NOT fire for "status".
+    expect(authCommand).not.toHaveBeenCalled();
+  });
+
+  it('does NOT route "init"/"show"/"rotate" through handleLoginCommand', async () => {
+    const { handleLoginCommand } = await import('./cli/login-command.js');
+    await handleAuthCommand(createArgs('init'));
+    await handleAuthCommand(createArgs('show'));
+    await handleAuthCommand(createArgs('rotate'));
+    expect(handleLoginCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/nexus-agents/src/cli-auth-handler.ts
+++ b/packages/nexus-agents/src/cli-auth-handler.ts
@@ -9,14 +9,24 @@
  */
 
 import { authCommand } from './cli/index.js';
+import { handleLoginCommand } from './cli/login-command.js';
 import type { ParsedCliArgs } from './cli-types.js';
 
 /**
  * Handles auth command for token management.
+ *
+ * `auth status` (#2449) routes to the shared login-command handler, which
+ * probes per-CLI auth state. It is the canonical name; `nexus-agents login`
+ * is kept as an alias for one minor cycle to avoid rotting docs that just
+ * shipped.
+ *
  * (Source: Issue #739 - enable MCP authentication by default)
  */
-export function handleAuthCommand(args: ParsedCliArgs): void {
-  const subcommand = args.subcommand;
+export async function handleAuthCommand(args: ParsedCliArgs): Promise<void> {
+  if (args.subcommand === 'status') {
+    await handleLoginCommand(args);
+    return;
+  }
   const format: 'text' | 'json' = args.options.format === 'json' ? 'json' : 'text';
-  authCommand(subcommand, { force: args.options.force, format });
+  authCommand(args.subcommand, { force: args.options.force, format });
 }

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -107,14 +107,14 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   },
   {
     command: 'auth',
-    description: 'Manage MCP authentication tokens (init, show, rotate)',
-    audience: 'advanced',
+    description:
+      'Manage authentication: init/show/rotate MCP tokens; status shows per-CLI auth state',
+    audience: 'essential',
   },
   {
     command: 'login',
-    description:
-      'Show per-CLI auth status (claude/codex/gemini/opencode) with login fix instructions',
-    audience: 'essential',
+    description: '[deprecated alias] Soft alias of "auth status"; renamed in #2449',
+    audience: 'maintainer',
   },
   {
     command: 'status',

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -180,8 +180,6 @@ const SYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => void) | un
   issue: handleIssueCommand,
   // System Mandate LOOP I: Fitness Audit
   'fitness-audit': handleFitnessAuditCommand,
-  // Issue #739: Auth command
-  auth: handleAuthCommand,
   // Issue #653: Scaffold Command
   scaffold: handleScaffoldCommand,
   // Creative: Visualize Command
@@ -241,8 +239,11 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
     atbench: handleAtbenchCommand,
     hooks: handleHooksCommand,
     setup: handleSetupCommandAsync, // Uses async for interactive wizard support (Issue #425)
-    // Issue #2447: nexus-agents login — async because it spawns codex/opencode for status probes
+    // Issue #2447: nexus-agents login — async because it spawns codex/opencode for status probes.
+    // Issue #2449 made `auth status` the canonical name; this remains as a soft alias.
     login: handleLoginCommand,
+    // Issue #739/#2449: auth command (now async — `auth status` routes to login probe)
+    auth: handleAuthCommand,
     // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)
     init: handleInitCommand,
     demo: handleDemoCommand, // Made async for live CLI execution

--- a/packages/nexus-agents/src/cli/auth-command.ts
+++ b/packages/nexus-agents/src/cli/auth-command.ts
@@ -16,8 +16,13 @@ import {
 
 /**
  * Auth command subcommands.
+ *
+ * `status` shows per-CLI authentication state (claude/codex/gemini/opencode)
+ * via the shared auth probe (#2449). It is async and handled before the
+ * sync `runAuthCommand` switch — callers should check
+ * `isAsyncAuthSubcommand(sub)` first.
  */
-export type AuthSubcommand = 'init' | 'show' | 'rotate' | 'help';
+export type AuthSubcommand = 'init' | 'show' | 'rotate' | 'help' | 'status';
 
 /**
  * Options for auth command.
@@ -57,7 +62,18 @@ export interface AuthCommandResult {
  * Validates auth subcommand.
  */
 export function isValidAuthSubcommand(value: string | undefined): value is AuthSubcommand {
-  return value === 'init' || value === 'show' || value === 'rotate' || value === 'help';
+  return (
+    value === 'init' ||
+    value === 'show' ||
+    value === 'rotate' ||
+    value === 'help' ||
+    value === 'status'
+  );
+}
+
+/** Subcommands that need async I/O — handled outside `runAuthCommand`. */
+export function isAsyncAuthSubcommand(value: AuthSubcommand): value is 'status' {
+  return value === 'status';
 }
 
 /**
@@ -201,7 +217,7 @@ export function runAuthCommand(options: AuthCommandOptions): AuthCommandResult {
         operation: 'help',
         tokenFile: getDefaultTokenPath(),
         tokenExists: existsSync(getDefaultTokenPath()),
-        error: `Unknown subcommand: ${String(subcommand)}`,
+        error: `Unknown subcommand: ${subcommand}`,
       };
   }
 }
@@ -218,6 +234,7 @@ function formatHelpText(result: AuthCommandResult): string {
     '  init     Generate a new authentication token',
     '  show     Show token status (file location, permissions)',
     '  rotate   Generate a new token, invalidating the old one',
+    '  status   Show per-CLI auth state (claude/codex/gemini/opencode) + login fixes',
     '',
     'OPTIONS:',
     '  --force          Overwrite existing token (for init)',

--- a/packages/nexus-agents/src/cli/login-command.ts
+++ b/packages/nexus-agents/src/cli/login-command.ts
@@ -63,7 +63,14 @@ function printNextStepFor(r: AuthProbeResult & { state: 'needs-login' }): void {
   }
 }
 
-export async function handleLoginCommand(_args: ParsedCliArgs): Promise<void> {
+export async function handleLoginCommand(args: ParsedCliArgs): Promise<void> {
+  // Deprecation hint when invoked via the standalone `login` command.
+  // Routing through `auth status` is silent. Issue #2449.
+  if (args.command === 'login') {
+    console.error(
+      "hint: 'nexus-agents login' is now 'nexus-agents auth status' — both work for one minor cycle."
+    );
+  }
   console.log('Nexus Agents — CLI authentication status');
   console.log('=========================================');
   console.log('');


### PR DESCRIPTION
## Summary

Closes #2449 (follow-up to #2448 QA review). Resolves the `login` / `auth` namespace collision both QA reviewers flagged on PR #2448.

## Before / after

```
$ nexus-agents auth status
Nexus Agents — CLI authentication status
=========================================
  ✓  Claude Code    authenticated   via CLI credentials
  ✓  Gemini CLI     authenticated   via CLI credentials
  ⚠  OpenCode CLI   needs login     No providers configured in opencode
     fix: opencode auth login
...

$ nexus-agents login
hint: 'nexus-agents login' is now 'nexus-agents auth status' — both work for one minor cycle.
Nexus Agents — CLI authentication status
...
```

## Why

Architect: *"A user typing `nexus-agents auth` vs `nexus-agents login` will not predict which manages which."*

Security: *"Renaming it to `auth status` is recommended (and prevents users from piping sensitive MCP tokens into the wrong command by mistake)."*

`auth init` / `show` / `rotate` already manage MCP server tokens; adding `auth status` slots in cleanly without conflict.

## Implementation

- `AuthSubcommand` union now includes `'status'`.
- `handleAuthCommand` is async; dispatches `status` to the shared `handleLoginCommand` (which probes per-CLI auth state). All other subcommands continue going through the sync `runAuthCommand` path unchanged.
- Moved `auth: handleAuthCommand` from `SYNC_COMMAND_HANDLERS` to `ASYNC_COMMAND_HANDLERS` in cli-commands.ts.
- `handleLoginCommand` emits a one-line deprecation hint to stderr (NOT stdout) when invoked via the `login` command name. Routing through `auth status` is silent. The hint is **not** test-visible noise — it goes to stderr and existing scripts that pipe stdout are unaffected.
- Catalog: `auth` description updated, `login` entry marked `[deprecated alias]` and demoted to `maintainer` audience.
- INSTALLATION.md updated to use the canonical name.

## What did NOT change

- `nexus-agents login` still works exactly the same. Removal is deferred to the next minor cycle so docs that just shipped (#2448's QUICK_START.md update) don't immediately rot.
- The probe semantics (cred file shape + env var fallback) are untouched. This is a name/wiring change only.

## Test plan

- [x] 7 cli-auth-handler tests pass (was 5; +1 for `auth status` → handleLoginCommand routing, +1 negative for init/show/rotate not going through login)
- [x] 12 auth-command tests still pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Live smoke: both `auth status` and `login` produce the expected output; `login` shows the deprecation hint on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)