### PR TITLE
fix(config): auto-detect sandboxed environments + announce + auto-gitignore (#2471)

### DIFF
--- a/packages/nexus-agents/src/cli/cli-log-bootstrap.ts
+++ b/packages/nexus-agents/src/cli/cli-log-bootstrap.ts
@@ -30,6 +30,7 @@
 
 import { argv, env } from 'node:process';
 import { setGlobalLogLevel } from '../core/logger.js';
+import { applyPortableMode } from '../config/portable-mode.js';
 
 const SERVER_COMMANDS = new Set(['server']);
 const VERBOSE_FLAGS = new Set(['--verbose', '-v', '--debug']);
@@ -68,5 +69,7 @@ export function applyCliLogDefault(args: readonly string[]): void {
   }
 }
 
-// Module-load side effect: cli.ts imports this FIRST.
+// Module-load side effects: cli.ts imports this FIRST so both run before
+// any other module reads NEXUS_DATA_DIR or constructs a logger.
 applyCliLogDefault(argv.slice(2));
+applyPortableMode();

--- a/packages/nexus-agents/src/config/portable-mode.test.ts
+++ b/packages/nexus-agents/src/config/portable-mode.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for portable-mode (#2471).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
+import * as fs from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyPortableMode, detectPortableMode, _resetDetectedForTests } from './portable-mode.js';
+
+const SANDBOX_VARS = [
+  'KUBERNETES_SERVICE_HOST',
+  'DOCKER_CONTAINER',
+  'ECS_CONTAINER_METADATA_URI',
+  'ECS_CONTAINER_METADATA_URI_V4',
+  'SANDBOX',
+  'NEXUS_SANDBOX',
+];
+
+function clearAllPortableEnv(): void {
+  delete process.env['NEXUS_DATA_DIR'];
+  delete process.env['NEXUS_PORTABLE_MODE'];
+  // Setting a literal-keyed env var to undefined is the lint-clean way to
+  // clear computed-key entries (the dynamic-delete rule blocks `delete obj[k]`
+  // for non-literal `k`). Empty string is treated as "not set" by callers.
+  for (const v of SANDBOX_VARS) {
+    process.env[v] = '';
+  }
+}
+
+describe('detectPortableMode (#2471)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'portable-test-'));
+    clearAllPortableEnv();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    clearAllPortableEnv();
+  });
+
+  it('respects NEXUS_DATA_DIR explicit set', () => {
+    process.env['NEXUS_DATA_DIR'] = tmp;
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(false);
+    expect(result.reason).toBe('env-data-dir');
+  });
+
+  it('honors NEXUS_PORTABLE_MODE=0 opt-out (no auto-detect)', () => {
+    process.env['NEXUS_PORTABLE_MODE'] = '0';
+    process.env['SANDBOX'] = '1'; // would normally trigger
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(false);
+    expect(result.reason).toBe('env-opt-out');
+  });
+
+  it('honors NEXUS_PORTABLE_MODE=1 opt-in (no need for heuristics)', () => {
+    process.env['NEXUS_PORTABLE_MODE'] = '1';
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(true);
+    expect(result.dataDir).toBe(join(tmp, '.nexus-agents'));
+    expect(result.reason).toBe('env-opt-in');
+  });
+
+  it('detects container env vars (KUBERNETES_SERVICE_HOST)', () => {
+    process.env['KUBERNETES_SERVICE_HOST'] = 'kube-host';
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(true);
+    expect(result.reason).toBe('container-env');
+  });
+
+  it('detects DOCKER_CONTAINER env var', () => {
+    process.env['DOCKER_CONTAINER'] = '1';
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(true);
+    expect(result.reason).toBe('container-env');
+  });
+
+  it('treats empty container env vars as not-set', () => {
+    process.env['SANDBOX'] = '';
+    const result = detectPortableMode(tmp);
+    expect(result.reason).toBe('default');
+  });
+
+  it('returns default (not portable) when nothing matches', () => {
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(false);
+    expect(result.reason).toBe('default');
+  });
+
+  it('NEXUS_DATA_DIR wins over container env (operator override)', () => {
+    process.env['NEXUS_DATA_DIR'] = tmp;
+    process.env['DOCKER_CONTAINER'] = '1';
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(false);
+    expect(result.reason).toBe('env-data-dir');
+  });
+
+  it('NEXUS_PORTABLE_MODE=0 wins over container env', () => {
+    process.env['NEXUS_PORTABLE_MODE'] = '0';
+    process.env['DOCKER_CONTAINER'] = '1';
+    const result = detectPortableMode(tmp);
+    expect(result.portable).toBe(false);
+    expect(result.reason).toBe('env-opt-out');
+  });
+});
+
+describe('applyPortableMode (#2471)', () => {
+  let tmp: string;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'portable-apply-'));
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    _resetDetectedForTests();
+    clearAllPortableEnv();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    stderrSpy.mockRestore();
+    clearAllPortableEnv();
+  });
+
+  it('sets NEXUS_DATA_DIR when sandbox detected via container env', () => {
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    expect(process.env['NEXUS_DATA_DIR']).toBe(join(tmp, '.nexus-agents'));
+  });
+
+  it('announces on stderr when sandbox auto-detected', () => {
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    expect(stderrSpy).toHaveBeenCalled();
+    const msg = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(msg).toContain('[portable-mode]');
+    expect(msg).toContain('container-env');
+    expect(msg).toContain('NEXUS_PORTABLE_MODE=0');
+  });
+
+  it('does NOT announce when operator opts in via NEXUS_PORTABLE_MODE=1', () => {
+    process.env['NEXUS_PORTABLE_MODE'] = '1';
+    applyPortableMode(tmp);
+    // Operator already knows; silent is correct.
+    const msg = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(msg).not.toContain('Sandbox detected');
+  });
+
+  it('is idempotent — second call is a no-op', () => {
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    const callsAfterFirst = stderrSpy.mock.calls.length;
+    applyPortableMode(tmp);
+    expect(stderrSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('does nothing when not portable', () => {
+    applyPortableMode(tmp);
+    expect(process.env['NEXUS_DATA_DIR']).toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('appends .nexus-agents/ to .gitignore when in a git repo and portable', () => {
+    fs.mkdirSync(join(tmp, '.git'), { recursive: true });
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    const gitignore = fs.readFileSync(join(tmp, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('.nexus-agents/');
+  });
+
+  it('does not duplicate the gitignore entry on repeat calls', () => {
+    fs.mkdirSync(join(tmp, '.git'), { recursive: true });
+    writeFileSync(join(tmp, '.gitignore'), '.nexus-agents/\n');
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    const gitignore = fs.readFileSync(join(tmp, '.gitignore'), 'utf-8');
+    const occurrences = gitignore.split('\n').filter((l) => l.trim() === '.nexus-agents/').length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('does not touch .gitignore when not in a git repo', () => {
+    process.env['SANDBOX'] = '1';
+    applyPortableMode(tmp);
+    expect(fs.existsSync(join(tmp, '.gitignore'))).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/config/portable-mode.ts
+++ b/packages/nexus-agents/src/config/portable-mode.ts
@@ -1,0 +1,183 @@
+/**
+ * portable-mode — auto-detect sandboxed execution environments and
+ * redirect nexus-agents data to a workspace-local directory.
+ *
+ * The existing `getNexusDataDir()` already respects `NEXUS_DATA_DIR` and
+ * `NEXUS_PORTABLE_MODE`. This module wires up the *auto-detection* path
+ * so operators running inside a Docker / restricted-FS / sandboxed
+ * environment don't have to set the env vars manually — nexus-agents
+ * notices and announces the flip.
+ *
+ * Source: Issue #2471 (epic #2467 child).
+ *
+ * Detection rules (first match wins):
+ *   1. `NEXUS_DATA_DIR` already set → respect, no auto-detect
+ *   2. `NEXUS_PORTABLE_MODE=0` → operator opted out, no auto-detect
+ *   3. `NEXUS_PORTABLE_MODE=1` → portable mode, no detection needed
+ *   4. Heuristic: home directory not writable
+ *   5. Heuristic: container env vars set (KUBERNETES_SERVICE_HOST,
+ *      DOCKER_CONTAINER, ECS_CONTAINER_METADATA_URI, SANDBOX, etc.)
+ *
+ * When portable mode fires:
+ *   - Sets `process.env.NEXUS_DATA_DIR` to `<cwd>/.nexus-agents`
+ *   - Announces once on stderr (subsequent calls are silent)
+ *   - If cwd is a git repo, appends `.nexus-agents/` to .gitignore
+ *
+ * To force off: `NEXUS_PORTABLE_MODE=0`. To force on without heuristics:
+ * `NEXUS_PORTABLE_MODE=1`. To override target dir: `NEXUS_DATA_DIR=...`.
+ */
+
+import { accessSync, constants, existsSync, readFileSync, appendFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/** Container / sandbox environment variables that strongly imply portable mode. */
+const SANDBOX_ENV_VARS: readonly string[] = [
+  'KUBERNETES_SERVICE_HOST',
+  'DOCKER_CONTAINER',
+  'ECS_CONTAINER_METADATA_URI',
+  'ECS_CONTAINER_METADATA_URI_V4',
+  'SANDBOX',
+  'NEXUS_SANDBOX',
+];
+
+let DETECTED = false;
+
+interface DetectionResult {
+  readonly portable: boolean;
+  readonly dataDir: string;
+  readonly reason:
+    | 'env-data-dir'
+    | 'env-opt-out'
+    | 'env-opt-in'
+    | 'home-unwritable'
+    | 'container-env'
+    | 'default';
+}
+
+function isHomeWritable(): boolean {
+  try {
+    const home = homedir();
+    if (!existsSync(home)) return false;
+    accessSync(home, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function inSandboxEnv(): boolean {
+  for (const v of SANDBOX_ENV_VARS) {
+    const val = process.env[v];
+    if (val !== undefined && val !== '') return true;
+  }
+  return false;
+}
+
+function checkExplicitEnv(cwd: string): DetectionResult | null {
+  const fromEnv = process.env['NEXUS_DATA_DIR']?.trim();
+  if (fromEnv !== undefined && fromEnv !== '') {
+    return { portable: false, dataDir: resolve(fromEnv), reason: 'env-data-dir' };
+  }
+  const portableEnv = process.env['NEXUS_PORTABLE_MODE'];
+  if (portableEnv === '0' || portableEnv === 'false') {
+    return { portable: false, dataDir: join(homedir(), '.nexus-agents'), reason: 'env-opt-out' };
+  }
+  if (portableEnv === '1' || portableEnv === 'true') {
+    return { portable: true, dataDir: join(cwd, '.nexus-agents'), reason: 'env-opt-in' };
+  }
+  return null;
+}
+
+function checkHeuristics(cwd: string): DetectionResult | null {
+  if (!isHomeWritable()) {
+    return { portable: true, dataDir: join(cwd, '.nexus-agents'), reason: 'home-unwritable' };
+  }
+  if (inSandboxEnv()) {
+    return { portable: true, dataDir: join(cwd, '.nexus-agents'), reason: 'container-env' };
+  }
+  return null;
+}
+
+/**
+ * Decide whether to flip nexus-agents to portable mode and what data dir
+ * to use. Pure function; no side effects beyond reading env + filesystem.
+ */
+export function detectPortableMode(cwd: string = process.cwd()): DetectionResult {
+  return (
+    checkExplicitEnv(cwd) ??
+    checkHeuristics(cwd) ?? {
+      portable: false,
+      dataDir: join(homedir(), '.nexus-agents'),
+      reason: 'default',
+    }
+  );
+}
+
+/**
+ * Apply detected portable mode at process startup. Idempotent (subsequent
+ * calls are no-ops). Announces on stderr once when the auto-detection
+ * heuristic triggers — env-opt-in/out doesn't announce because the
+ * operator already knows.
+ */
+export function applyPortableMode(cwd: string = process.cwd()): void {
+  if (DETECTED) return;
+  DETECTED = true;
+
+  const result = detectPortableMode(cwd);
+
+  // No env, no heuristic match — nothing to do.
+  if (!result.portable) return;
+
+  // The heuristic-driven cases announce; explicit opt-in is silent.
+  if (result.reason === 'home-unwritable' || result.reason === 'container-env') {
+    process.stderr.write(
+      `[portable-mode] Sandbox detected (${result.reason}). Using ${result.dataDir} for all nexus-agents data.\n` +
+        `                Set NEXUS_PORTABLE_MODE=0 to override; see docs/getting-started/SANDBOXED-USAGE.md\n`
+    );
+  }
+
+  process.env['NEXUS_DATA_DIR'] = result.dataDir;
+
+  if (isInsideGitRepo(cwd)) {
+    ensureGitignored(cwd, '.nexus-agents/');
+  }
+}
+
+function isInsideGitRepo(cwd: string): boolean {
+  try {
+    const gitDir = join(cwd, '.git');
+    return existsSync(gitDir) && statSync(gitDir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Append `entry` to `<cwd>/.gitignore` if not already present. Stderr
+ * announce on the first append.
+ */
+function ensureGitignored(cwd: string, entry: string): void {
+  const path = join(cwd, '.gitignore');
+  try {
+    const existing = existsSync(path) ? readFileSync(path, 'utf-8') : '';
+    const lines = existing.split('\n').map((l) => l.trim());
+    if (lines.includes(entry) || lines.includes(entry.replace(/\/$/, ''))) return;
+    const sep = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+    appendFileSync(path, `${sep}${entry}\n`, 'utf-8');
+    process.stderr.write(
+      `[portable-mode] Added '${entry}' to ${path} so nexus-agents data is gitignored.\n`
+    );
+  } catch (e: unknown) {
+    // Non-fatal — operator can add the line themselves.
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(
+      `[portable-mode] Could not auto-update ${path} (${msg}). Add '${entry}' manually if you don't want nexus-agents data tracked by git.\n`
+    );
+  }
+}
+
+/** Test-only reset of the once-only state. */
+export function _resetDetectedForTests(): void {
+  DETECTED = false;
+}


### PR DESCRIPTION
Closes #2471 (epic #2467 child 2 of 6).

## Summary

Auto-detect sandbox/container environments at CLI startup. When detected, redirect `NEXUS_DATA_DIR` to `<cwd>/.nexus-agents`, announce on stderr, and auto-gitignore. Operators no longer need to set `NEXUS_PORTABLE_MODE=1` manually inside Docker / restricted-FS sandboxes.

## Detection rules (highest to lowest priority)

| Priority | Trigger | Behavior |
| -------- | ------- | -------- |
| 1 | `NEXUS_DATA_DIR` set explicitly | Respect, no auto-detect |
| 2 | `NEXUS_PORTABLE_MODE=0` | Never portable (operator opt-out) |
| 3 | `NEXUS_PORTABLE_MODE=1` | Always portable, **silent** (operator knows) |
| 4 | Heuristic: `homedir()` not writable | Portable + announce |
| 5 | Heuristic: container env vars set | Portable + announce |

Container env vars detected: `KUBERNETES_SERVICE_HOST`, `DOCKER_CONTAINER`, `ECS_CONTAINER_METADATA_URI[_V4]`, `SANDBOX`, `NEXUS_SANDBOX`.

## Live smoke

```
$ SANDBOX=1 nexus-agents --version
[portable-mode] Sandbox detected (container-env). Using /path/to/cwd/.nexus-agents for all nexus-agents data.
                Set NEXUS_PORTABLE_MODE=0 to override; see docs/getting-started/SANDBOXED-USAGE.md
nexus-agents v2.70.0

$ nexus-agents --version
nexus-agents v2.70.0    ← silent, no false-positive announce
```

## Auto-gitignore

When portable mode triggers AND cwd is a git repo, appends `.nexus-agents/` to the project's `.gitignore` (idempotent — won't duplicate; emits its own one-line stderr announce on first add). Operator never accidentally commits nexus-agents state.

## Wiring

`applyPortableMode()` called from `cli/cli-log-bootstrap.ts` (the existing first-import in `cli.ts`). Both run before any other module reads `NEXUS_DATA_DIR` or constructs a logger, so the env-var flip is in effect everywhere downstream.

## What this does NOT do

- **No ancestor-walking** for `.git` discovery. cwd-only check; #2301 deferred ancestor-walking to a separate child with a security design pass per CVE-2022-24765. Same constraint applies here.
- **No new third-party CLI handling.** The `~/.claude/`, `~/.gemini/`, `~/.config/opencode/` paths used by the auth-probe (#2447) stay where the third-party CLIs expect them. Portable mode only redirects nexus-agents-internal data.
- **No retroactive migration.** If an operator previously had `~/.nexus-agents/` populated and then runs in a sandbox that flips to portable mode, the old data stays in `~`. Operator can copy it manually if desired.

## Test plan

- [x] 17 new unit tests for `detectPortableMode` + `applyPortableMode`
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Live smoke confirms announce-on-detect + silent-on-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)