### PR TITLE
feat(adapters): generic OpenAI-compatible gateway adapter (#2468)

### DIFF
--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the OpenAI-compatible gateway adapter (#2468).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  readOpenAICompatEnv,
+  discoverModels,
+  buildOpenAICompatAdapters,
+  createOpenAICompatAdapter,
+  type OpenAICompatConfig,
+} from './openai-compat-adapter.js';
+import { ConfigError } from '../core/index.js';
+
+// Mock the OpenAI SDK so tests don't make real HTTP calls.
+const { mockList } = vi.hoisted(() => ({ mockList: vi.fn() }));
+vi.mock('openai', () => {
+  class MockOpenAI {
+    models = { list: mockList };
+    chat = { completions: { create: vi.fn() } };
+  }
+  return { default: MockOpenAI };
+});
+
+describe('readOpenAICompatEnv (#2468)', () => {
+  beforeEach(() => {
+    delete process.env['NEXUS_OPENAI_COMPAT_URL'];
+    delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+  });
+
+  it('returns null when both env vars are unset', () => {
+    expect(readOpenAICompatEnv()).toBeNull();
+  });
+
+  it('returns null when only URL is set', () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+    expect(readOpenAICompatEnv()).toBeNull();
+  });
+
+  it('returns null when only key is set', () => {
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+    expect(readOpenAICompatEnv()).toBeNull();
+  });
+
+  it('returns null when env var is empty string', () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = '';
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+    expect(readOpenAICompatEnv()).toBeNull();
+  });
+
+  it('returns config when both vars are set', () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+    const result = readOpenAICompatEnv();
+    expect(result).toEqual({ baseUrl: 'https://gateway.example/v1', apiKey: 'sk-test' });
+  });
+
+  it('trims whitespace from env vars', () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = '  https://gateway.example/v1  ';
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = '  sk-test  ';
+    const result = readOpenAICompatEnv();
+    expect(result?.baseUrl).toBe('https://gateway.example/v1');
+    expect(result?.apiKey).toBe('sk-test');
+  });
+});
+
+describe('discoverModels (#2468)', () => {
+  beforeEach(() => {
+    mockList.mockReset();
+  });
+
+  const config: OpenAICompatConfig = {
+    baseUrl: 'https://gateway.example/v1',
+    apiKey: 'sk-test',
+  };
+
+  it('returns all models the gateway exposes', async () => {
+    mockList.mockResolvedValue({
+      data: [
+        { id: 'gpt-4o', created: 1700000000, owned_by: 'openai' },
+        { id: 'claude-sonnet-4', created: 1710000000, owned_by: 'anthropic' },
+        { id: 'gemini-2-pro', created: 1720000000, owned_by: 'google' },
+      ],
+    });
+    const result = await discoverModels(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(3);
+    expect(result.value.map((m) => m.id)).toEqual(['gpt-4o', 'claude-sonnet-4', 'gemini-2-pro']);
+  });
+
+  it('preserves created + ownedBy fields when present', async () => {
+    mockList.mockResolvedValue({
+      data: [{ id: 'm1', created: 1234567890, owned_by: 'someone' }],
+    });
+    const result = await discoverModels(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value[0]?.created).toBe(1234567890);
+    expect(result.value[0]?.ownedBy).toBe('someone');
+  });
+
+  it('handles models without optional fields', async () => {
+    mockList.mockResolvedValue({ data: [{ id: 'minimal-model' }] });
+    const result = await discoverModels(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value[0]?.id).toBe('minimal-model');
+    expect(result.value[0]?.created).toBeUndefined();
+    expect(result.value[0]?.ownedBy).toBeUndefined();
+  });
+
+  it('returns ConfigError with actionable message when gateway fails', async () => {
+    mockList.mockRejectedValue(new Error('connect ECONNREFUSED'));
+    const result = await discoverModels(config);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ConfigError);
+    expect(result.error.message).toContain('https://gateway.example/v1');
+    expect(result.error.message).toContain('NEXUS_OPENAI_COMPAT_URL');
+    expect(result.error.message).toContain('connect ECONNREFUSED');
+  });
+
+  it('handles 401 / auth failures with the same actionable message', async () => {
+    mockList.mockRejectedValue(new Error('401 Unauthorized'));
+    const result = await discoverModels(config);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('NEXUS_OPENAI_COMPAT_KEY');
+  });
+});
+
+describe('createOpenAICompatAdapter (#2468)', () => {
+  it('creates an OpenAIAdapter pointed at the gateway', () => {
+    const adapter = createOpenAICompatAdapter('any-model', {
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    expect(adapter).toBeDefined();
+    // BaseAdapter.providerId is 'openai' by construction; modelId is what we passed.
+    expect(adapter.modelId).toBe('any-model');
+  });
+});
+
+describe('buildOpenAICompatAdapters (#2468)', () => {
+  let originalUrl: string | undefined;
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalUrl = process.env['NEXUS_OPENAI_COMPAT_URL'];
+    originalKey = process.env['NEXUS_OPENAI_COMPAT_KEY'];
+    mockList.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env['NEXUS_OPENAI_COMPAT_URL'];
+    else process.env['NEXUS_OPENAI_COMPAT_URL'] = originalUrl;
+    if (originalKey === undefined) delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+    else process.env['NEXUS_OPENAI_COMPAT_KEY'] = originalKey;
+  });
+
+  it('returns null when env not configured (caller treats as "no source")', async () => {
+    delete process.env['NEXUS_OPENAI_COMPAT_URL'];
+    delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+    const result = await buildOpenAICompatAdapters();
+    expect(result).toBeNull();
+  });
+
+  it('returns one adapter per discovered model when configured', async () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+    mockList.mockResolvedValue({
+      data: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    });
+    const result = await buildOpenAICompatAdapters();
+    expect(result).not.toBeNull();
+    expect(result?.ok).toBe(true);
+    if (result === null) return;
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(3);
+    expect(result.value.map((a) => a.modelId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('propagates discovery errors', async () => {
+    process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+    process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+    mockList.mockRejectedValue(new Error('gateway down'));
+    const result = await buildOpenAICompatAdapters();
+    expect(result?.ok).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -1,0 +1,119 @@
+/**
+ * OpenAI-compatible gateway adapter — talk to any HTTP gateway that exposes
+ * the OpenAI Chat Completions API. The gateway may itself be a multi-model
+ * router (Bedrock/Vertex/Azure proxy, OpenRouter, vLLM, etc.). nexus-agents
+ * sees one adapter, the gateway exposes N models, and the existing routing
+ * pipeline picks among them.
+ *
+ * Source: Issue #2468 (epic #2467 child).
+ *
+ * Configuration is env-var-driven so operators don't have to thread config
+ * through the model registry just to point at a custom gateway:
+ *   - NEXUS_OPENAI_COMPAT_URL — base URL (e.g. https://gateway.example/v1)
+ *   - NEXUS_OPENAI_COMPAT_KEY — API key for the gateway
+ *
+ * Models are discovered via GET {base}/v1/models at first use. Each model
+ * the gateway exposes can be selected by ID; the adapter wraps the existing
+ * `OpenAIAdapter` for the actual chat-completions request, so streaming +
+ * tool use + the full IModelAdapter contract come for free.
+ */
+
+import OpenAI from 'openai';
+
+import type { Result } from '../core/index.js';
+import { ok, err, ConfigError, getErrorMessage } from '../core/index.js';
+import { OpenAIAdapter } from './openai-adapter.js';
+
+export interface OpenAICompatConfig {
+  /** Gateway base URL — must reach `/v1/models` and `/v1/chat/completions`. */
+  readonly baseUrl: string;
+  /** API key the gateway expects. */
+  readonly apiKey: string;
+}
+
+export interface DiscoveredModel {
+  readonly id: string;
+  /** Unix epoch seconds when the model was created (per OpenAI API). */
+  readonly created?: number;
+  /** Owning organization or upstream provider name. */
+  readonly ownedBy?: string;
+}
+
+/**
+ * Read the env-var-driven gateway config. Returns `null` when either var is
+ * unset or empty — caller can fall back to other adapter sources without
+ * surfacing a hard error.
+ */
+export function readOpenAICompatEnv(): OpenAICompatConfig | null {
+  const baseUrl = process.env['NEXUS_OPENAI_COMPAT_URL']?.trim();
+  const apiKey = process.env['NEXUS_OPENAI_COMPAT_KEY']?.trim();
+  if (baseUrl === undefined || baseUrl === '') return null;
+  if (apiKey === undefined || apiKey === '') return null;
+  return { baseUrl, apiKey };
+}
+
+/**
+ * Discover available models by calling `GET {baseUrl}/v1/models`. Uses the
+ * official `openai` SDK's `client.models.list()` so we benefit from its
+ * pagination + retry handling. The list is the strongly authoritative
+ * source: nexus-agents won't try to dispatch to a model the gateway doesn't
+ * expose.
+ */
+export async function discoverModels(
+  config: OpenAICompatConfig
+): Promise<Result<readonly DiscoveredModel[], ConfigError>> {
+  try {
+    const client = new OpenAI({ baseURL: config.baseUrl, apiKey: config.apiKey });
+    const list = await client.models.list();
+    const models: readonly DiscoveredModel[] = list.data.map((m) => ({
+      id: m.id,
+      created: m.created,
+      ownedBy: m.owned_by,
+    }));
+    return ok(models);
+  } catch (e: unknown) {
+    return err(
+      new ConfigError(
+        `Failed to discover models from ${config.baseUrl}: ${getErrorMessage(e)}. ` +
+          `Verify NEXUS_OPENAI_COMPAT_URL and NEXUS_OPENAI_COMPAT_KEY, then retry.`
+      )
+    );
+  }
+}
+
+/**
+ * Create an OpenAIAdapter pointed at the gateway for a specific model ID.
+ * Caller is expected to have validated the model ID against the discovery
+ * result first; we don't redundantly call /v1/models here per call.
+ *
+ * When invoked via MCP, the host harness's model identifier is passed
+ * through verbatim — nexus-agents doesn't second-guess what the host is
+ * already routing.
+ */
+export function createOpenAICompatAdapter(
+  modelId: string,
+  config: OpenAICompatConfig
+): OpenAIAdapter {
+  return new OpenAIAdapter({ modelId, apiKey: config.apiKey, baseUrl: config.baseUrl });
+}
+
+/**
+ * Convenience: read env, discover, return adapter instances for every
+ * discovered model. Returns `null` (not an error) when env vars aren't set
+ * — the caller treats unset gateway as "no adapter from this source."
+ *
+ * Use case: the unified registry / factory calls this at startup; if the
+ * operator has configured a gateway, every discovered model becomes a
+ * dispatch target alongside the existing claude/codex/gemini/opencode
+ * adapter slots.
+ */
+export async function buildOpenAICompatAdapters(): Promise<Result<
+  readonly OpenAIAdapter[],
+  ConfigError
+> | null> {
+  const config = readOpenAICompatEnv();
+  if (config === null) return null;
+  const discovered = await discoverModels(config);
+  if (!discovered.ok) return discovered;
+  return ok(discovered.value.map((m) => createOpenAICompatAdapter(m.id, config)));
+}


### PR DESCRIPTION
Closes #2468 (epic #2467 child 4 of 6).

## Summary

Adds a single configuration point for any HTTP gateway exposing the OpenAI Chat Completions API. The gateway may itself route across multiple frontier providers (Bedrock / Vertex / Azure / OpenRouter / vLLM); nexus-agents sees one adapter, the gateway exposes N models, the existing routing pipeline picks among them.

## Configuration

```bash
export NEXUS_OPENAI_COMPAT_URL=https://gateway.example/v1
export NEXUS_OPENAI_COMPAT_KEY=<api-key>
```

That's it. No code changes, no model registry edits.

## Public API

- `readOpenAICompatEnv()` — returns config or null
- `discoverModels(config)` — calls `GET /v1/models` via the official `openai` SDK
- `createOpenAICompatAdapter(modelId, config)` — wraps the existing `OpenAIAdapter` pointed at the gateway
- `buildOpenAICompatAdapters()` — convenience: env + discovery + per-model adapter list

Streaming + tool use + the full `IModelAdapter` contract come for free since `OpenAIAdapter` already supports `baseUrl`. We don't reimplement the chat completions wire format.

## Two-mode contract (per the issue's Q1 answer)

- **Standalone mode**: discover-on-init via `/v1/models`, route via `CompositeRouter` across discovered models.
- **MCP-host mode**: when invoked as an MCP server inside another harness, pass the host's model ID through verbatim — don't second-guess the host's routing.

## Anti-sprawl

This is **one adapter that exposes N models**, not N adapter slots in the registry. The gateway is the integration boundary; behind it the operator can have any combination of frontier providers without exploding nexus-agents' adapter list.

## What this does NOT do

- **Doesn't auto-wire the adapter into `unified-registry`.** That's a separate small follow-up; the building blocks are in place. Keeping this PR focused on the adapter module + tests.
- **Doesn't add cost/usage reporting per call** — that's #2469 (next child in the epic).
- **Doesn't change existing OpenAIAdapter behavior.**

## Test plan

- [x] 15 unit tests with mocked OpenAI SDK
- [x] env-var precedence (null when missing, trims whitespace)
- [x] discovery happy path + 401 + connection failure
- [x] `ConfigError` messages name the env vars to fix
- [x] `buildOpenAICompatAdapters` per-model wiring
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)