### PR TITLE
fix(test): mock dataset-loader in atbench adapter test (#2482)

### DIFF
--- a/packages/nexus-agents/src/benchmarks/atbench/adapter.test.ts
+++ b/packages/nexus-agents/src/benchmarks/atbench/adapter.test.ts
@@ -5,12 +5,24 @@
  * evaluate (confusion), isPass, summarize (precision/recall/F1).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ATBenchAdapter, classifyConfusion, scoreTrajectoryStub } from './index.js';
 import type { ATBenchTrajectory } from './types.js';
+
+// #2482: mock the dataset-loader so the HF-fallback test doesn't depend on
+// real network. The previous test relied on the assumption that the HF API
+// is unreachable from the test runner — locally that holds, but in CI the
+// call sometimes succeeded (no rejection) or failed with a message that
+// didn't match the regex, producing a flaky failure that hit four
+// unrelated PRs in one autonomous session before being fixed.
+vi.mock('./dataset-loader.js', () => ({
+  fetchAtbenchFromHf: vi.fn(() =>
+    Promise.resolve({ ok: false, error: new Error('mocked: HF load failed (network unavailable)') })
+  ),
+}));
 
 function makeTrajectory(overrides: Partial<ATBenchTrajectory> = {}): ATBenchTrajectory {
   return {


### PR DESCRIPTION
Closes #2482. Removes the network-dependent flaky test that hit 4 unrelated PRs in one session (#2474, #2479, #2480, #2481), forcing --admin overrides on every merge.

The test asserted that the HF-fallback path fires + the error surfaces. It relied on the assumption that the HuggingFace API would be unreachable from the test runner — locally that held, but in CI the call sometimes succeeded (no rejection) or failed with a different message that didn't match the regex.

Mock `./dataset-loader.js` so `fetchAtbenchFromHf` deterministically returns an error matching the regex. The test's intent (fallback fires + error surfaces) is preserved; the network dependency is gone.

## Verification

- [x] 17 atbench adapter tests pass deterministically across 5 consecutive runs (no flakes)
- [x] 12 dataset-loader.test.ts tests still pass (their mocks are file-scoped, not affected)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)