### PR TITLE
fix(cli): demote `usage` from essential to advanced (#2491)

### DIFF
--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -120,7 +120,7 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     command: 'usage',
     description:
       'Cost / usage / quality dashboard from per-call telemetry (#2469). --format=json for scripting.',
-    audience: 'essential',
+    audience: 'advanced',
   },
   {
     command: 'status',


### PR DESCRIPTION
## Summary
- The `essential` audience tier in `cli-command-catalog.ts` had grown to 13 entries, breaking the ≤12 invariant in `cli-command-catalog.test.ts`. The cap exists so new users see a focused surface (onboarding + core actions + diagnostics) — not the full operator toolbox.
- `usage` (#2469) is a per-call telemetry dashboard. Operators reach for it after running tasks, not on first install. Demoting it to `advanced` brings the count back to 12.
- Discovered while shipping #2482 (PR #2490): the atbench mock fix passed, but every other PR's `Test (ubuntu-latest)` step then failed on this catalog test, which had nothing to do with atbench.

## Test plan
- [x] `pnpm vitest run src/cli-command-catalog.test.ts` — 19/19 pass
- [ ] CI green on Ubuntu + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)