### PR TITLE
feat(cli): improvement-review subcommand wraps the MCP tool (#2444)

### DIFF
--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-05-09T09:12:20.285Z",
+  "generated": "2026-05-09T14:21:22.405Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.70.0",
   "cli": {
@@ -82,6 +82,12 @@
         "name": "hooks",
         "type": "async",
         "handler": "handleHooksCommand",
+        "file": "src/cli-commands-handlers.ts"
+      },
+      {
+        "name": "improvement-review",
+        "type": "async",
+        "handler": "handleImprovementReviewCommand",
         "file": "src/cli-commands-handlers.ts"
       },
       {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-05-09T09:12:20.285Z
+**Generated:** 2026-05-09T14:21:22.405Z
 **Package Version:** 2.70.0
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CLI Commands (46)
+## CLI Commands (47)
 
 Binary: `nexus-agents`
 
@@ -28,6 +28,7 @@ Binary: `nexus-agents`
 | `health` | sync | `handleHealthCommand` | `src/cli-commands-handlers.ts` |
 | `hello` | sync | `handleHelloCommand` | `src/cli-commands-handlers.ts` |
 | `hooks` | async | `handleHooksCommand` | `src/cli-commands-handlers.ts` |
+| `improvement-review` | async | `handleImprovementReviewCommand` | `src/cli-commands-handlers.ts` |
 | `index` | async | `handleIndexCommand` | `src/cli-commands-handlers.ts` |
 | `init` | async | `handleInitCommand` | `src/cli-commands-handlers.ts` |
 | `issue` | sync | `handleIssueCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -157,6 +157,12 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     description: 'Generate and manage codebase index',
     audience: 'advanced',
   },
+  {
+    command: 'improvement-review',
+    description:
+      'Observability-driven improvement loop (#2402). Surfaces threshold breaches; --file-issues opt-in.',
+    audience: 'advanced',
+  },
 
   // ── Maintainer (hidden by default) ───────────────────────────────────────
   {

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -124,6 +124,8 @@ import { handleAuthCommand } from './cli-auth-handler.js';
 import { handleLoginCommand } from './cli/login-command.js';
 // Issue #2469: nexus-agents usage — cost / usage / quality dashboard
 import { handleUsageCommand } from './cli/usage-command.js';
+// Issue #2444: nexus-agents improvement-review — observability-driven improvement loop CLI surface
+import { handleImprovementReviewCommand } from './cli/improvement-review-command.js';
 // Issue #637: Release Automation Suite
 import {
   handleReleaseNotesCommand,
@@ -248,6 +250,8 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
     auth: handleAuthCommand,
     // Issue #2469: usage command (cost / usage / quality dashboard)
     usage: handleUsageCommand,
+    // Issue #2444: improvement-review command (observability-driven improvement loop)
+    'improvement-review': handleImprovementReviewCommand,
     // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)
     init: handleInitCommand,
     demo: handleDemoCommand, // Made async for live CLI execution

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -74,7 +74,8 @@ export type CliCommand =
   | 'validate'
   | 'registry'
   | 'login'
-  | 'usage';
+  | 'usage'
+  | 'improvement-review';
 
 /**
  * Parsed CLI arguments and command.
@@ -444,6 +445,20 @@ export const PARSE_ARGS_CONFIG = {
       type: 'boolean' as const,
       default: false,
     },
+    // improvement-review command options (#2444)
+    'lookback-days': {
+      type: 'string' as const,
+    },
+    'file-issues': {
+      type: 'boolean' as const,
+      default: false,
+    },
+    'min-sample-size': {
+      type: 'string' as const,
+    },
+    'fitness-floor': {
+      type: 'string' as const,
+    },
   },
   allowPositionals: true,
   strict: true,
@@ -498,6 +513,7 @@ const VALID_COMMANDS: readonly CliCommand[] = [
   'registry',
   'login',
   'usage',
+  'improvement-review',
 ];
 
 /**

--- a/packages/nexus-agents/src/cli/improvement-review-command.test.ts
+++ b/packages/nexus-agents/src/cli/improvement-review-command.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for `nexus-agents improvement-review` CLI subcommand (#2444).
+ *
+ * The handler delegates to `runImprovementReview()` from the MCP module —
+ * we mock that so the tests don't depend on a real OutcomeStore or fitness
+ * audit. The CLI's job is parsing flags, choosing format, and printing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ParsedCliArgs } from '../cli-types.js';
+import type { ImprovementReviewResponse } from '../mcp/tools/improvement-review.js';
+
+const runMock = vi.fn();
+vi.mock('../mcp/tools/improvement-review.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../mcp/tools/improvement-review.js')>();
+  return {
+    ...actual,
+    runImprovementReview: (...args: unknown[]) => runMock(...args) as unknown,
+  };
+});
+
+import { handleImprovementReviewCommand } from './improvement-review-command.js';
+
+function makeArgs(overrides: Record<string, unknown> = {}): ParsedCliArgs {
+  return {
+    command: 'improvement-review',
+    options: overrides as ParsedCliArgs['options'],
+    positionals: [],
+  };
+}
+
+const emptyResponse: ImprovementReviewResponse = {
+  window: '7d',
+  totalOutcomes: 0,
+  signals: [],
+  issuesFiled: [],
+  issuesSkipped: [],
+};
+
+import type { MockInstance } from 'vitest';
+
+describe('handleImprovementReviewCommand', () => {
+  let stdout: string[] = [];
+  let writeSpy: MockInstance | undefined;
+  let logSpy: MockInstance | undefined;
+
+  beforeEach(() => {
+    runMock.mockReset();
+    runMock.mockResolvedValue(emptyResponse);
+    stdout = [];
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+    logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      stdout.push(args.map((a) => String(a)).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    writeSpy?.mockRestore();
+    logSpy?.mockRestore();
+  });
+
+  it('defaults lookback to 7 days, file-issues off', async () => {
+    await handleImprovementReviewCommand(makeArgs());
+
+    expect(runMock).toHaveBeenCalledOnce();
+    const call = runMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call['lookbackDays']).toBe(7);
+    expect(call['fileIssues']).toBe(false);
+    expect(call['minSampleSize']).toBe(5);
+    expect(call['fitnessFloor']).toBe(90);
+  });
+
+  it('parses --lookback-days, --min-sample-size, --fitness-floor', async () => {
+    await handleImprovementReviewCommand(
+      makeArgs({
+        'lookback-days': '14',
+        'min-sample-size': '10',
+        'fitness-floor': '85',
+      })
+    );
+
+    const call = runMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call['lookbackDays']).toBe(14);
+    expect(call['minSampleSize']).toBe(10);
+    expect(call['fitnessFloor']).toBe(85);
+  });
+
+  it('forwards --file-issues=true', async () => {
+    await handleImprovementReviewCommand(makeArgs({ 'file-issues': true }));
+    const call = runMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call['fileIssues']).toBe(true);
+  });
+
+  it('--dry-run forces fileIssues to false even when --file-issues is set', async () => {
+    await handleImprovementReviewCommand(makeArgs({ 'file-issues': true, 'dry-run': true }));
+    const call = runMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call['fileIssues']).toBe(false);
+  });
+
+  it('json format emits a parseable payload', async () => {
+    runMock.mockResolvedValueOnce({
+      ...emptyResponse,
+      totalOutcomes: 12,
+      signals: [
+        {
+          category: 'routing',
+          signalKey: 'routing:cli-floor:claude:research',
+          severity: 'warning',
+          title: 'routing: claude success rate 50% on research (7d)',
+          body: '...',
+          evidence: { samples: 8, window: '7d', observedValue: 0.5, threshold: 0.6 },
+        },
+      ],
+    });
+
+    await handleImprovementReviewCommand(makeArgs({ format: 'json' }));
+
+    const stdoutText = stdout.join('');
+    const parsed = JSON.parse(stdoutText) as ImprovementReviewResponse;
+    expect(parsed.totalOutcomes).toBe(12);
+    expect(parsed.signals).toHaveLength(1);
+    expect(parsed.signals[0]?.signalKey).toBe('routing:cli-floor:claude:research');
+  });
+
+  it('text format prints a header and the no-breach hint when empty', async () => {
+    await handleImprovementReviewCommand(makeArgs());
+    const text = stdout.join('\n');
+    expect(text).toContain('Nexus Agents — Improvement Review');
+    expect(text).toContain('No threshold breaches');
+  });
+
+  it('text format prints filed-issue URLs when present', async () => {
+    runMock.mockResolvedValueOnce({
+      ...emptyResponse,
+      signals: [
+        {
+          category: 'routing',
+          signalKey: 'routing:cli-floor:claude:research',
+          severity: 'warning',
+          title: 'routing breach',
+          body: '...',
+          evidence: { samples: 8, window: '7d', observedValue: 0.5, threshold: 0.6 },
+        },
+      ],
+      issuesFiled: [
+        {
+          signalKey: 'routing:cli-floor:claude:research',
+          issueUrl: 'https://github.com/owner/repo/issues/9999',
+        },
+      ],
+    });
+
+    await handleImprovementReviewCommand(makeArgs({ 'file-issues': true }));
+    const text = stdout.join('\n');
+    expect(text).toContain('Filed 1 issue');
+    expect(text).toContain('issues/9999');
+  });
+
+  it('rejects out-of-range lookback (101 days) via Zod schema', async () => {
+    await expect(
+      handleImprovementReviewCommand(makeArgs({ 'lookback-days': '101' }))
+    ).rejects.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/cli/improvement-review-command.ts
+++ b/packages/nexus-agents/src/cli/improvement-review-command.ts
@@ -1,0 +1,148 @@
+/**
+ * `nexus-agents improvement-review` — observability-driven improvement loop.
+ *
+ * Source: Issue #2444 (epic #2435 child).
+ *
+ * CLI surface for the existing `improvement_review` MCP tool. Reads the
+ * OutcomeStore + fitness audit, surfaces patterns crossing documented
+ * thresholds (CLI < 60% with ≥5 samples, fitness below floor, single
+ * failure category > 50% of failures), and optionally files candidate
+ * GitHub issues via `gh issue create`. Never auto-merges; humans or
+ * `consensus_vote` decide what to implement.
+ *
+ * Flags:
+ *   --lookback-days <n>      Outcome window in days (default 7, max 90)
+ *   --file-issues            File candidate issues (rate-limited 5/run, deduped)
+ *   --dry-run                Force `--file-issues` off (CI-safe alias)
+ *   --min-sample-size <n>    Minimum samples before a CLI signal fires (default 5)
+ *   --fitness-floor <n>      Fitness score below this triggers tech-debt (default 90)
+ *   --format <text|json>     Output mode (default text)
+ */
+
+/* eslint-disable no-console */
+
+import type { ParsedCliArgs } from '../cli-types.js';
+import {
+  runImprovementReview,
+  ImprovementReviewInputSchema,
+  type ImprovementSignal,
+  type ImprovementReviewResponse,
+} from '../mcp/tools/improvement-review.js';
+
+interface CliOptions {
+  readonly lookbackDays: number;
+  readonly fileIssues: boolean;
+  readonly minSampleSize: number;
+  readonly fitnessFloor: number;
+  readonly format: 'text' | 'json';
+}
+
+function parseOptions(args: ParsedCliArgs): CliOptions {
+  // The cli-types options bag is strictly typed; flags this command accepts
+  // (`--lookback-days`, `--file-issues`, `--dry-run`, `--min-sample-size`,
+  // `--fitness-floor`, `--format`) aren't first-class. Read as a record
+  // — the schema below validates ranges at runtime.
+  const opts = args.options as unknown as Record<string, unknown>;
+
+  const lookbackRaw = typeof opts['lookback-days'] === 'string' ? opts['lookback-days'] : '7';
+  const lookbackParsed = Number.parseInt(lookbackRaw, 10);
+
+  const minSamplesRaw = typeof opts['min-sample-size'] === 'string' ? opts['min-sample-size'] : '5';
+  const minSamplesParsed = Number.parseInt(minSamplesRaw, 10);
+
+  const fitnessRaw = typeof opts['fitness-floor'] === 'string' ? opts['fitness-floor'] : '90';
+  const fitnessParsed = Number.parseInt(fitnessRaw, 10);
+
+  const dryRun = opts['dry-run'] === true;
+  const fileIssuesFlag = opts['file-issues'] === true;
+  const fileIssues = !dryRun && fileIssuesFlag;
+
+  const formatRaw = typeof opts['format'] === 'string' ? opts['format'] : 'text';
+  const format: 'text' | 'json' = formatRaw === 'json' ? 'json' : 'text';
+
+  // Validate via the same Zod schema the MCP tool uses — keeps ranges
+  // (1..90 for lookback, etc.) consistent across the two surfaces.
+  const validated = ImprovementReviewInputSchema.parse({
+    lookbackDays: lookbackParsed,
+    fileIssues,
+    minSampleSize: minSamplesParsed,
+    fitnessFloor: fitnessParsed,
+  });
+
+  return {
+    lookbackDays: validated.lookbackDays,
+    fileIssues: validated.fileIssues,
+    minSampleSize: validated.minSampleSize,
+    fitnessFloor: validated.fitnessFloor,
+    format,
+  };
+}
+
+export async function handleImprovementReviewCommand(args: ParsedCliArgs): Promise<void> {
+  const cli = parseOptions(args);
+  const response = await runImprovementReview({
+    lookbackDays: cli.lookbackDays,
+    fileIssues: cli.fileIssues,
+    minSampleSize: cli.minSampleSize,
+    fitnessFloor: cli.fitnessFloor,
+  });
+
+  if (cli.format === 'json') {
+    process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+    return;
+  }
+
+  printTextReport(response, cli);
+}
+
+function printTextReport(response: ImprovementReviewResponse, opts: CliOptions): void {
+  console.log('Nexus Agents — Improvement Review');
+  console.log('=================================');
+  console.log(`Window: last ${String(opts.lookbackDays)} day(s)`);
+  console.log(`Outcomes scanned: ${String(response.totalOutcomes)}`);
+  console.log(`Signals surfaced: ${String(response.signals.length)}`);
+  console.log(`Issue filing: ${opts.fileIssues ? 'enabled' : 'disabled (dry-run)'}\n`);
+
+  if (response.signals.length === 0) {
+    console.log('No threshold breaches in the current window.');
+    console.log('');
+    console.log('Thresholds:');
+    console.log(`  - CLI success rate < 60% with ≥${String(opts.minSampleSize)} samples`);
+    console.log(`  - Fitness score below ${String(opts.fitnessFloor)}/100`);
+    console.log('  - A single failure category accounting for > 50% of failures');
+    return;
+  }
+
+  for (const signal of response.signals) {
+    printSignal(signal);
+  }
+
+  if (response.issuesFiled.length > 0) {
+    console.log(`\nFiled ${String(response.issuesFiled.length)} issue(s):`);
+    for (const f of response.issuesFiled) {
+      console.log(`  - ${f.signalKey} → ${f.issueUrl}`);
+    }
+  }
+  if (response.issuesSkipped.length > 0) {
+    console.log(`\nSkipped ${String(response.issuesSkipped.length)} signal(s):`);
+    for (const s of response.issuesSkipped) {
+      console.log(`  - ${s.signalKey} (${s.reason})`);
+    }
+  }
+}
+
+function printSignal(signal: ImprovementSignal): void {
+  const sevTag = signal.severity.toUpperCase();
+  console.log(`[${sevTag}] (${signal.category}) ${signal.title}`);
+  if (signal.evidence.observedValue !== undefined && signal.evidence.threshold !== undefined) {
+    console.log(
+      `  observed=${signal.evidence.observedValue.toFixed(3)} threshold=${signal.evidence.threshold.toFixed(3)}`
+    );
+  }
+  if (signal.evidence.samples !== undefined) {
+    console.log(
+      `  samples=${String(signal.evidence.samples)} window=${signal.evidence.window ?? 'n/a'}`
+    );
+  }
+  console.log('');
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -411,18 +411,24 @@ async function fileSignalsAsIssues(
   return { issuesFiled, issuesSkipped };
 }
 
-async function reviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
-  const parsed = ImprovementReviewInputSchema.safeParse(args);
-  if (!parsed.success) {
-    return toolError(`Validation error: ${formatZodError(parsed.error)}`);
-  }
-  const { lookbackDays, fileIssues, minSampleSize, fitnessFloor } = parsed.data;
+/**
+ * Context-free runner exposed for both the MCP handler and the
+ * `nexus-agents improvement-review` CLI subcommand (#2444). Pure dependencies
+ * — pass a logger and an OutcomeStore-query result if you want to inject test
+ * data; defaults read the global store and a no-op logger.
+ */
+export async function runImprovementReview(
+  input: ImprovementReviewInput,
+  deps: { readonly logger?: ReturnType<typeof createLogger> } = {}
+): Promise<ImprovementReviewResponse> {
+  const logger = deps.logger ?? createLogger({ component: 'improvement_review' });
+  const { lookbackDays, fileIssues, minSampleSize, fitnessFloor } = input;
   const now = Date.now();
   const windowLabel = `${String(lookbackDays)}d`;
 
   const allOutcomes = getOutcomeStore().query();
   const windowed = filterByLookback(allOutcomes, lookbackDays, now);
-  const audit = safeFitnessAudit(now, ctx);
+  const audit = safeFitnessAudit(now, { logger } as HandlerContext);
 
   const signals: ImprovementSignal[] = [
     ...detectCliPerformanceFloor(windowed, minSampleSize, windowLabel),
@@ -432,17 +438,24 @@ async function reviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolRe
   signals.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
 
   const { issuesFiled, issuesSkipped } = fileIssues
-    ? await fileSignalsAsIssues(signals, ctx)
+    ? await fileSignalsAsIssues(signals, { logger } as HandlerContext)
     : { issuesFiled: [], issuesSkipped: [] };
 
-  const response: ImprovementReviewResponse = {
+  return {
     window: windowLabel,
     totalOutcomes: windowed.length,
     signals,
     issuesFiled,
     issuesSkipped,
   };
+}
 
+async function reviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
+  const parsed = ImprovementReviewInputSchema.safeParse(args);
+  if (!parsed.success) {
+    return toolError(`Validation error: ${formatZodError(parsed.error)}`);
+  }
+  const response = await runImprovementReview(parsed.data, { logger: ctx.logger });
   return toolSuccessStructured(response as unknown as Record<string, unknown>);
 }
 


### PR DESCRIPTION
## Summary
- Adds `nexus-agents improvement-review` CLI surface, wrapping the existing `improvement_review` MCP tool (#2402).
- Extracts a context-free `runImprovementReview()` from `mcp/tools/improvement-review.ts` so both surfaces share one code path.
- Wires the command through `cli-types.ts` (CliCommand + VALID_COMMANDS), `cli-commands.ts` (ASYNC_COMMAND_HANDLERS), and `cli-command-catalog.ts` (advanced tier).

## Flags

```
--lookback-days <n>       Outcome window in days (default 7, 1..90)
--file-issues             File candidate issues (rate-limited 5/run, dedup)
--dry-run                 Force --file-issues off (CI-safe alias)
--min-sample-size <n>     Min samples before a CLI signal fires (default 5)
--fitness-floor <n>       Below this triggers tech-debt (default 90)
--format <text|json>      Output mode (default text)
```

## Test plan
- [x] 8 new tests on the CLI handler (default args, flag parsing, --dry-run override, json format, text empty + filed-issue branches, Zod range enforcement)
- [x] Existing 37 tests on the MCP module still pass against the refactored runner
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [x] Smoke-tested against live OutcomeStore (1d window, 901 outcomes scanned, 2 signals surfaced — output matches expected text + json shapes)
- [ ] CI green on Ubuntu + macOS

closes #2444

🤖 Generated with [Claude Code](https://claude.com/claude-code)