### PR TITLE
fix(envelope): widen auth regex + integration test + sanitised debug dump (#2455)

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
@@ -123,4 +123,72 @@ describe('parseCliErrorEnvelope (#2440)', () => {
     const result = parseCliErrorEnvelope(env, 'claude');
     expect(result?.code).toBe('NOT_AUTHENTICATED');
   });
+
+  // #2455 ask 1: widened auth regex set
+  describe('widened NOT_AUTHENTICATED patterns (#2455)', () => {
+    it('matches "API key expired"', () => {
+      const env = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'API key expired. Generate a new one in the console.',
+      });
+      const result = parseCliErrorEnvelope(env, 'claude');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+      expect(result?.hint).toContain('claude /login');
+    });
+
+    it('matches "API key revoked"', () => {
+      const env = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'API key revoked',
+      });
+      const result = parseCliErrorEnvelope(env, 'codex');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+      expect(result?.hint).toContain('codex login');
+    });
+
+    it('matches "API key missing"', () => {
+      const env = JSON.stringify({ error: 'API key missing — set ANTHROPIC_API_KEY' });
+      const result = parseCliErrorEnvelope(env, 'claude');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+    });
+
+    it('matches "api-key expired" (hyphenated form)', () => {
+      const env = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'api-key expired, please re-authenticate',
+      });
+      const result = parseCliErrorEnvelope(env, 'claude');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+    });
+
+    it('matches "Token expired" without "unauthorized" keyword', () => {
+      const env = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'Token expired. Please re-authenticate.',
+      });
+      const result = parseCliErrorEnvelope(env, 'claude');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+    });
+
+    it('matches "token revoked"', () => {
+      const env = JSON.stringify({ error: 'token revoked by issuer' });
+      const result = parseCliErrorEnvelope(env, 'codex');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+    });
+
+    it('does NOT match "permission denied" (authz, not authn — see #2455 ask 1)', () => {
+      const env = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'Permission denied: workspace requires admin access',
+      });
+      const result = parseCliErrorEnvelope(env, 'claude');
+      expect(result?.code).toBe('EXECUTION_ERROR');
+      expect(result?.hint).toBeUndefined();
+    });
+  });
 });

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
@@ -82,6 +82,15 @@ const NOT_AUTH_PATTERNS: readonly RegExp[] = [
   /authentication (?:required|expired|failed)/i,
   /invalid (?:api ?key|credentials)/i,
   /unauthorized/i,
+  // #2455 ask 1: catch "API key expired" / "API key revoked" / "API key
+  // missing" — the bare /invalid api key/ pattern misses these. Architects
+  // explicitly ruled OUT `permission denied` (that's authz, not authn —
+  // routing to /login is the wrong fix).
+  /api[- ]?key (?:expired|revoked|missing)/i,
+  // Token expiry/revocation as a standalone signal, not co-occurring with
+  // "unauthorized" — some upstreams emit "Token expired. Please re-auth."
+  // without the unauthorized keyword.
+  /token (?:expired|revoked)/i,
 ];
 
 function classifyMessage(message: string): { code: CliErrorCode; auth: boolean } {

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -837,6 +837,67 @@ describe('SubprocessCliAdapter', () => {
         expect(result.value.sessionId).toBe('session-123');
       }
     });
+
+    // #2455 ask 2: integration test that envelope unwrap wins over plaintext
+    // fallback. The 30-char plaintext threshold could otherwise catch error
+    // envelopes whose `result` happens to be short (e.g. "Not logged in"
+    // is 13 chars, so the wrapping JSON is well over 30 chars and the
+    // plaintext fallback would happily return the raw envelope as
+    // "response text" if envelope unwrap weren't checked first.
+    it('envelope unwrap wins over plaintext fallback (#2455 ask 2)', async () => {
+      // Use a parser that always fails so we hit handleUnparseableOutput.
+      class FailingParserAdapter extends TestSubprocessAdapter {
+        protected override readonly parser: ICliResponseParser = {
+          name: 'failing-parser',
+          supportedVersionRange: '>=1.0.0',
+          parse: () => {
+            throw new Error('parse failed');
+          },
+          extractResponse: () => null,
+          extractUsage: () => null,
+          extractSessionId: () => null,
+        };
+      }
+      const failingAdapter = new FailingParserAdapter();
+      failingAdapter.setCommandConfig({ command: 'test', args: [] });
+
+      const task: CliTask = { content: 'test' };
+      const options: Required<ExecutionOptions> = {
+        timeoutMs: 5000,
+        allowRetry: true,
+        maxRetries: 1,
+        trackUsage: true,
+        onProgress: undefined,
+      };
+
+      const { mockChild, stdout } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const promise = failingAdapter.executeTask(task, options);
+
+      // A Claude error envelope. Both the envelope path AND the plaintext
+      // fallback would accept this: the envelope-shaped JSON is well over
+      // 30 chars so plaintext fallback's heuristic would treat it as a valid
+      // text response and silently swallow the auth failure. The envelope
+      // path runs first and must win.
+      const envelope = JSON.stringify({
+        type: 'result',
+        is_error: true,
+        result: 'Not logged in',
+      });
+      setImmediate(() => {
+        stdout.emit('data', Buffer.from(`${envelope}\n`));
+        mockChild.emit('close', 0);
+      });
+
+      const result = await promise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('NOT_AUTHENTICATED');
+        expect(result.error.message).toContain('Not logged in');
+        expect(result.error.message).toContain('claude /login');
+      }
+    });
   });
 
   describe('handleSubprocessError()', () => {

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -544,11 +544,22 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
         envelope.hint !== undefined
           ? `${envelope.message}\n  → ${envelope.hint}`
           : envelope.message;
+      // #2455 ask 3: at debug level, dump the full sanitized envelope so
+      // operators can recover context without re-running. Sanitized via
+      // output-sanitizer.ts so leaked tokens (some upstreams echo back the
+      // bad token in error responses) don't reach logs.
+      subprocessLogger.debug('CLI error envelope unwrapped', {
+        cli: this.name,
+        code: envelope.code,
+        rawSanitized: sanitizeOutput(stdout),
+      });
       return err(this.createError(envelope.code, msg));
     }
     const plaintext = tryPlaintextFallback(stdout);
     if (plaintext !== null) {
-      subprocessLogger.debug('Using plaintext fallback for unparseable output');
+      subprocessLogger.debug('Using plaintext fallback for unparseable output', {
+        rawSanitized: sanitizeOutput(stdout),
+      });
       return ok(
         this.normalizeResponse(plaintext, undefined, {
           durationMs: getTimeProvider().now() - startTime,


### PR DESCRIPTION
## Summary
Three follow-ups from PR #2454's QA review (closed #2440), all in the same code path so bundled per the issue.

### Ask 1 — widen NOT_AUTHENTICATED regex set
Adds two patterns to `cli-error-envelope.ts`:
- `/api[- ]?key (?:expired|revoked|missing)/i` — catches "API key expired/revoked/missing"
- `/token (?:expired|revoked)/i` — catches "Token expired" without co-occurring "unauthorized"

Explicitly does NOT add `permission denied` — that's authz, not authn (per architect+security review).

### Ask 2 — integration test for envelope precedence
Adds a test in `subprocess-adapter.test.ts` that exercises the full chain: failing-parser → `handleUnparseableOutput` → envelope unwrap. Asserts envelope wins over plaintext fallback even when the raw stdout is well over the 30-char plaintext threshold.

### Ask 3 — sanitised debug-mode envelope dump
When `NEXUS_LOG_LEVEL=debug` is set, the envelope-unwrap path now logs the original full stdout. Routed through `sanitizeOutput()` from `security/output-sanitizer.ts` — some upstream CLIs echo back the (invalid) token in error responses; we must not log those raw.

## Test plan
- [x] 7 new tests in `cli-error-envelope.test.ts` cover the widened patterns + explicit `permission denied → EXECUTION_ERROR` to lock in authz/authn boundary
- [x] 1 new integration test in `subprocess-adapter.test.ts` for envelope precedence
- [x] Existing 13 + 35 tests still pass (55/55 total in the affected files)
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [ ] CI green on Ubuntu + macOS

closes #2455

🤖 Generated with [Claude Code](https://claude.com/claude-code)