### PR TITLE
feat(sandbox): surface PolicyEvaluation.configurationWarnings (#2428 ask 1)

### DIFF
--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.test.ts
@@ -83,6 +83,40 @@ describe('DenoSandboxExecutor.validate', () => {
     expect(result.violations.length).toBeGreaterThan(0);
     expect(result.violations[0]?.type).toBe('command');
   });
+
+  // #2428 ask 1: configurationWarnings surface "capability declared but
+  // unenforceable" mismatches via the SandboxResult, so callers can detect
+  // config gaps without scraping logs.
+  it('surfaces configurationWarnings when policy has unenforceable capabilities', () => {
+    const exec = new DenoSandboxExecutor();
+    // process_spawn declared but allowedCommands kept ['echo','git'] so cmd
+    // validation still passes; pad with filesystem_read + env_access without
+    // their allowlists to trigger two warnings.
+    const result = exec.validate(
+      'echo',
+      [],
+      makeOptions({
+        policy: makePolicy({
+          capabilities: ['process_spawn', 'filesystem_read', 'env_access'],
+          allowedCommands: ['echo'],
+          allowedEnvVars: [],
+          pathRules: [],
+        }),
+      })
+    );
+    expect(result.allowed).toBe(true);
+    expect(result.configurationWarnings).toBeDefined();
+    expect(result.configurationWarnings).toHaveLength(2);
+    expect(result.configurationWarnings?.[0]).toContain('filesystem_read');
+    expect(result.configurationWarnings?.[1]).toContain('env_access');
+  });
+
+  it('omits configurationWarnings field when none apply', () => {
+    const exec = new DenoSandboxExecutor();
+    const result = exec.validate('echo', [], makeOptions());
+    // Default policy has process_spawn + ['echo','git'], no warnings expected.
+    expect(result.configurationWarnings).toBeUndefined();
+  });
 });
 
 describe('DenoSandboxExecutor.execute', () => {

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-executor.ts
@@ -43,7 +43,12 @@ import {
   parseExecError,
   truncateOutput,
 } from './docker-sandbox-helpers.js';
-import { isDenoAvailable, policyToDenoFlags, resetDenoCache } from './deno-sandbox-helpers.js';
+import {
+  isDenoAvailable,
+  policyToDenoFlags,
+  resetDenoCache,
+  collectPolicyConfigurationWarnings,
+} from './deno-sandbox-helpers.js';
 
 // Re-export for symmetry with docker-sandbox-executor.
 export { isDenoAvailable, resetDenoCache };
@@ -148,15 +153,23 @@ export class DenoSandboxExecutor implements ISandboxExecutor {
     const argsViolation = validateArgs(args);
     if (argsViolation !== null) violations.push(argsViolation);
 
-    const result: PolicyEvaluation = {
+    // #2428 ask 1: surface "capability declared but unenforceable" mismatches
+    // so operators reading the SandboxResult can detect config gaps without
+    // scraping logs. These aren't security violations (Deno fails closed on
+    // missing flags); they're feedback that the operator's intent diverges
+    // from the deployed config.
+    const configurationWarnings = collectPolicyConfigurationWarnings(policy);
+
+    const base: PolicyEvaluation = {
       allowed: violations.length === 0,
       policyId: policy.id,
       violations,
+      ...(configurationWarnings.length > 0 ? { configurationWarnings } : {}),
     };
     if (violations.length > 0 && violations[0] !== undefined) {
-      return { ...result, reason: violations[0].reason };
+      return { ...base, reason: violations[0].reason };
     }
-    return result;
+    return base;
   }
 
   // --------------------------------------------------------------------------

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.test.ts
@@ -19,7 +19,12 @@ vi.mock('node:util', () => ({
   promisify: () => mockExecFileAsync,
 }));
 
-import { isDenoAvailable, resetDenoCache, policyToDenoFlags } from './deno-sandbox-helpers.js';
+import {
+  isDenoAvailable,
+  resetDenoCache,
+  policyToDenoFlags,
+  collectPolicyConfigurationWarnings,
+} from './deno-sandbox-helpers.js';
 
 function makePolicy(overrides: Partial<SandboxPolicy> = {}): SandboxPolicy {
   return {
@@ -194,5 +199,79 @@ describe('policyToDenoFlags', () => {
       })
     );
     expect(flags).toEqual(['--allow-read=/tmp']);
+  });
+});
+
+// ============================================================================
+// collectPolicyConfigurationWarnings (#2428 ask 1)
+// ============================================================================
+
+describe('collectPolicyConfigurationWarnings (#2428)', () => {
+  it('returns an empty list for an empty policy', () => {
+    expect(collectPolicyConfigurationWarnings(makePolicy())).toEqual([]);
+  });
+
+  it('returns an empty list when all declared capabilities have allowlists', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({
+        capabilities: ['process_spawn', 'filesystem_read', 'env_access'],
+        allowedCommands: ['git'],
+        allowedEnvVars: ['HOME'],
+        pathRules: [{ path: '/tmp', access: 'read' }],
+      })
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it('flags process_spawn with empty allowedCommands', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({ capabilities: ['process_spawn'], allowedCommands: [] })
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('process_spawn capability requested');
+    expect(warnings[0]).toContain('allowedCommands is empty');
+  });
+
+  it('flags filesystem_read with no path rules', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({ capabilities: ['filesystem_read'], pathRules: [] })
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('filesystem_read');
+  });
+
+  it('flags filesystem_write when only read rules are present', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({
+        capabilities: ['filesystem_write'],
+        pathRules: [{ path: '/tmp', access: 'read' }],
+      })
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('filesystem_write');
+  });
+
+  it('flags env_access with empty allowedEnvVars', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({ capabilities: ['env_access'], allowedEnvVars: [] })
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('env_access');
+  });
+
+  it('does NOT flag network — coarse on/off has no allowlist gap (#2428 phase 1)', () => {
+    const warnings = collectPolicyConfigurationWarnings(makePolicy({ capabilities: ['network'] }));
+    // Per-host network filtering is Phase 2 (#2428 ask 2); v1 has no
+    // allowlist for `network`, so there's nothing to flag as missing.
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns multiple warnings when multiple capabilities are misconfigured', () => {
+    const warnings = collectPolicyConfigurationWarnings(
+      makePolicy({
+        capabilities: ['process_spawn', 'filesystem_read', 'env_access'],
+      })
+    );
+    expect(warnings).toHaveLength(3);
   });
 });

--- a/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.ts
+++ b/packages/nexus-agents/src/security/sandbox/deno-sandbox-helpers.ts
@@ -125,6 +125,52 @@ function buildAllowEnvFlag(caps: ReadonlySet<string>, policy: SandboxPolicy): st
 }
 
 /**
+ * Surface configuration mismatches operators can act on (#2428 ask 1):
+ * capabilities declared in `policy.capabilities` but unenforceable because
+ * the corresponding allowlist is empty. These are the same conditions that
+ * `policyToDenoFlags` logs to `logger.warn`, but returned as a structured
+ * array so the SandboxResult can carry them up to the caller.
+ *
+ * Operators reading `SandboxResult.policyEvaluation.configurationWarnings`
+ * see "I asked for X capability but my config didn't enable it" without
+ * having to scrape logs.
+ */
+export function collectPolicyConfigurationWarnings(policy: SandboxPolicy): readonly string[] {
+  const caps = new Set(policy.capabilities);
+  return [
+    ...checkRunWarning(caps, policy),
+    ...checkPathWarning(caps, policy, 'read'),
+    ...checkPathWarning(caps, policy, 'write'),
+    ...checkEnvWarning(caps, policy),
+  ];
+}
+
+function checkRunWarning(caps: ReadonlySet<string>, policy: SandboxPolicy): readonly string[] {
+  if (!caps.has('process_spawn') || policy.allowedCommands.length > 0) return [];
+  return [
+    'process_spawn capability requested but allowedCommands is empty — Deno --allow-run NOT added (would be a wildcard)',
+  ];
+}
+
+function checkPathWarning(
+  caps: ReadonlySet<string>,
+  policy: SandboxPolicy,
+  level: 'read' | 'write'
+): readonly string[] {
+  const cap = level === 'read' ? 'filesystem_read' : 'filesystem_write';
+  if (!caps.has(cap)) return [];
+  if (collectAccessPaths(policy, level).length > 0) return [];
+  return [`${cap} capability requested but no path rules — Deno --allow-${level} NOT added`];
+}
+
+function checkEnvWarning(caps: ReadonlySet<string>, policy: SandboxPolicy): readonly string[] {
+  if (!caps.has('env_access') || policy.allowedEnvVars.length > 0) return [];
+  return [
+    'env_access capability requested but allowedEnvVars is empty — Deno --allow-env NOT added',
+  ];
+}
+
+/**
  * Pull the path-strings out of a policy's pathRules whose access matches
  * the requested level. `'read'` includes `'write'` rules (write implies
  * read in Deno).

--- a/packages/nexus-agents/src/security/sandbox/sandbox-types.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-types.ts
@@ -103,6 +103,13 @@ export interface PolicyEvaluation {
   readonly policyId: string;
   /** Violations found. */
   readonly violations: readonly PolicyViolation[];
+  /**
+   * Configuration mismatches the executor surfaces to operators — capabilities
+   * declared in the policy but unenforceable because the corresponding
+   * allowlist is empty (e.g. `process_spawn` set but `allowedCommands: []`).
+   * Source: #2428 ask 1. Not security violations; informational only.
+   */
+  readonly configurationWarnings?: readonly string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Architect feedback on PR #2427: `policyToDenoFlags` warns + skips when a capability is declared but the allowlist is empty (e.g. `process_spawn` set with `allowedCommands: []`). Skipping is fail-closed but the warning only goes to logs — operators reading the SandboxResult can't detect "capability declared but unenforceable" without scraping logs.

This PR ships ask 1 of #2428.

## Changes
- New pure function `collectPolicyConfigurationWarnings(policy)` returns the same conditions as the inline `logger.warn` calls in structured form.
- New optional field `PolicyEvaluation.configurationWarnings: readonly string[]`. Omitted when none apply, so downstream `?.length` guards stay simple.
- `DenoSandboxExecutor.validate` populates the field via the new helper.
- `network` capability is NOT flagged — Phase 1 has no allowlist for it (per-host filtering is Phase 2, ask 2).

## Test plan
- [x] 8 new tests for `collectPolicyConfigurationWarnings` (happy path + each mismatch + multi-warning case)
- [x] 2 new tests on `DenoSandboxExecutor.validate` (field set when warnings apply, omitted otherwise)
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [ ] CI green on Ubuntu + macOS

Refs #2428 (item 1 of 5; items 2-5 remain open for separate work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)