### PR TITLE
feat(sandbox): wire openai-compat gateway into runtime + sandbox-mode fail-fast (#2502)

### DIFF
--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -105,7 +105,10 @@ RUN cat > /home/nexus/opencode.json <<'OCEOF'
       ],
       "enabled": true,
       "environment": {
-        "NEXUS_ALLOW_MOCK_ORCHESTRATION": "true"
+        "NEXUS_SANDBOX": "{env:NEXUS_SANDBOX}",
+        "NEXUS_DATA_DIR": "{env:NEXUS_DATA_DIR}",
+        "NEXUS_OPENAI_COMPAT_URL": "{env:CUSTOM_API_BASE_URL}",
+        "NEXUS_OPENAI_COMPAT_KEY": "{env:CUSTOM_API_KEY}"
       }
     }
   }

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -43,15 +43,27 @@ COPY --from=builder /app/packages/nexus-agents/dist /opt/nexus-agents/dist
 COPY --from=builder /app/packages/nexus-agents/package.json /opt/nexus-agents/
 COPY --from=runtime-deps /opt/nexus-agents/node_modules /opt/nexus-agents/node_modules
 
+# Sandbox awareness (#2501, epic #2500). Tells nexus-agents it's running
+# inside a host-provided sandbox so it adapts boot behaviour: defaults
+# NEXUS_DATA_DIR to the multi-repo root, fail-fast on missing gateway
+# config, suppresses CLI-detection noise.
+ENV NEXUS_SANDBOX=docker-opencode
+
 # Redirect all runtime data (memory, learning, audit, voting, sessions,
-# checkpoints, traces) to the workspace volume so it survives sandbox
-# restarts and stays scoped to the workspace, not the container's $HOME
-# (#2302, child of #2301). Pre-create the dir so first writes don't race.
+# checkpoints, traces) to a workspace-mounted volume so it survives
+# sandbox restarts and stays scoped to the workspace, not the container's
+# $HOME (#2302, child of #2301). Operators override at launch time when
+# they mount a different multi-repo root.
 ENV NEXUS_DATA_DIR=/workspace/.nexus-agents
 RUN mkdir -p /workspace/.nexus-agents
 
 # Create opencode config with MCP server pointing to nexus-agents
 # OpenCode reads from ~/.config/opencode/opencode.json (global config)
+#
+# NEXUS_OPENAI_COMPAT_URL / NEXUS_OPENAI_COMPAT_KEY are NOT baked in here.
+# The host injects them at launch time so the workspace proxy URL + key
+# stay out of the image. nexus-agents fail-fast at boot if they're
+# missing while NEXUS_SANDBOX is set (#2502).
 RUN mkdir -p /home/agent/.config/opencode && \
     cat > /home/agent/.config/opencode/opencode.json <<'OCEOF'
 {
@@ -66,7 +78,10 @@ RUN mkdir -p /home/agent/.config/opencode && \
       ],
       "enabled": true,
       "environment": {
-        "NEXUS_ALLOW_MOCK_ORCHESTRATION": "true"
+        "NEXUS_SANDBOX": "{env:NEXUS_SANDBOX}",
+        "NEXUS_DATA_DIR": "{env:NEXUS_DATA_DIR}",
+        "NEXUS_OPENAI_COMPAT_URL": "{env:NEXUS_OPENAI_COMPAT_URL}",
+        "NEXUS_OPENAI_COMPAT_KEY": "{env:NEXUS_OPENAI_COMPAT_KEY}"
       }
     }
   }

--- a/packages/nexus-agents/src/cli-server-gateway.test.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for tryWireGatewayAdapter (#2502, child 2 of epic #2500).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ok, err, ConfigError, type IModelAdapter, type ILogger } from './core/index.js';
+
+const buildOpenAICompatAdaptersMock = vi.fn();
+const readOpenAICompatEnvMock = vi.fn();
+
+vi.mock('./adapters/openai-compat-adapter.js', () => ({
+  buildOpenAICompatAdapters: (...args: unknown[]) =>
+    buildOpenAICompatAdaptersMock(...args) as unknown,
+  readOpenAICompatEnv: (...args: unknown[]) => readOpenAICompatEnvMock(...args) as unknown,
+}));
+
+import { tryWireGatewayAdapter } from './cli-server-gateway.js';
+
+function makeMockAdapter(modelId: string): IModelAdapter {
+  return {
+    providerId: 'openai-compat',
+    modelId,
+    capabilities: [],
+    complete: () =>
+      Promise.resolve({
+        ok: false as const,
+        error: { code: 'EXECUTION_ERROR' as const, message: 'mock' },
+      } as never),
+    stream: (() => (async function* () {})()) as never,
+    countTokens: () => Promise.resolve(0),
+    validateConfig: () => ({ ok: true as const, value: undefined }),
+  };
+}
+
+type MockLogger = ILogger & {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+};
+
+function makeMockLogger(): MockLogger {
+  const logger: MockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    setLevel: vi.fn(),
+    getLevel: vi.fn(),
+    setFormat: vi.fn(),
+    setDestination: vi.fn(),
+    child: vi.fn(),
+  } as unknown as MockLogger;
+  (logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+  return logger;
+}
+
+describe('tryWireGatewayAdapter', () => {
+  let savedSandbox: string | undefined;
+  let savedExit: typeof process.exit;
+
+  beforeEach(() => {
+    savedSandbox = process.env['NEXUS_SANDBOX'];
+    delete process.env['NEXUS_SANDBOX'];
+    buildOpenAICompatAdaptersMock.mockReset();
+    readOpenAICompatEnvMock.mockReset();
+    savedExit = process.exit;
+    process.exit = vi.fn((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(() => {
+    if (savedSandbox === undefined) delete process.env['NEXUS_SANDBOX'];
+    else process.env['NEXUS_SANDBOX'] = savedSandbox;
+    process.exit = savedExit;
+  });
+
+  describe('non-sandbox mode', () => {
+    it('returns undefined when env vars unset', async () => {
+      readOpenAICompatEnvMock.mockReturnValue(null);
+      const result = await tryWireGatewayAdapter(makeMockLogger());
+      expect(result).toBeUndefined();
+      expect(buildOpenAICompatAdaptersMock).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined + warns when probe fails', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      buildOpenAICompatAdaptersMock.mockResolvedValue(err(new ConfigError('ENOTFOUND')));
+      const logger = makeMockLogger();
+      const result = await tryWireGatewayAdapter(logger);
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('probe failed'),
+        expect.objectContaining({ error: expect.stringContaining('ENOTFOUND') as unknown })
+      );
+    });
+
+    it('returns first adapter when probe succeeds', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      const adapters = [makeMockAdapter('claude-sonnet-4-6'), makeMockAdapter('gpt-5-nano')];
+      buildOpenAICompatAdaptersMock.mockResolvedValue(ok(adapters));
+      const logger = makeMockLogger();
+      const result = await tryWireGatewayAdapter(logger);
+      expect(result).toBe(adapters[0]);
+      expect(logger.info).toHaveBeenCalledWith(
+        'OpenAI-compatible gateway wired',
+        expect.objectContaining({
+          baseUrl: 'https://gateway.example/v1',
+          modelCount: 2,
+        })
+      );
+    });
+
+    it('returns undefined when gateway returns 0 models (without exiting)', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      buildOpenAICompatAdaptersMock.mockResolvedValue(ok([]));
+      const logger = makeMockLogger();
+      const result = await tryWireGatewayAdapter(logger);
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('0 models'));
+    });
+  });
+
+  describe('sandbox mode', () => {
+    beforeEach(() => {
+      process.env['NEXUS_SANDBOX'] = 'docker-opencode';
+    });
+
+    it('exits when env vars unset', async () => {
+      readOpenAICompatEnvMock.mockReturnValue(null);
+      const logger = makeMockLogger();
+      await expect(tryWireGatewayAdapter(logger)).rejects.toThrow('process.exit');
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Sandbox mode active but NEXUS_OPENAI_COMPAT_URL'),
+        expect.any(Error)
+      );
+    });
+
+    it('exits when probe fails', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      buildOpenAICompatAdaptersMock.mockResolvedValue(err(new ConfigError('ECONNREFUSED')));
+      const logger = makeMockLogger();
+      await expect(tryWireGatewayAdapter(logger)).rejects.toThrow('process.exit');
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Sandbox mode active and OpenAI-compatible gateway probe failed'),
+        expect.any(Error)
+      );
+    });
+
+    it('exits when gateway returns 0 models', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      buildOpenAICompatAdaptersMock.mockResolvedValue(ok([]));
+      const logger = makeMockLogger();
+      await expect(tryWireGatewayAdapter(logger)).rejects.toThrow('process.exit');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('returns first adapter when probe succeeds', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-test',
+      });
+      const adapters = [makeMockAdapter('m1'), makeMockAdapter('m2')];
+      buildOpenAICompatAdaptersMock.mockResolvedValue(ok(adapters));
+      const result = await tryWireGatewayAdapter(makeMockLogger());
+      expect(result).toBe(adapters[0]);
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+
+    it('does not log the API key when wiring succeeds', async () => {
+      readOpenAICompatEnvMock.mockReturnValue({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'sk-secret-key-should-not-leak',
+      });
+      const adapters = [makeMockAdapter('m1')];
+      buildOpenAICompatAdaptersMock.mockResolvedValue(ok(adapters));
+      const logger = makeMockLogger();
+      await tryWireGatewayAdapter(logger);
+      const allLogCalls = [
+        ...logger.info.mock.calls,
+        ...logger.warn.mock.calls,
+        ...logger.error.mock.calls,
+        ...logger.debug.mock.calls,
+      ];
+      const flat = JSON.stringify(allLogCalls);
+      expect(flat).not.toContain('sk-secret-key-should-not-leak');
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-server-gateway.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.ts
@@ -1,0 +1,109 @@
+/**
+ * Gateway adapter bootstrap (#2502, child 2 of epic #2500).
+ *
+ * The OpenAI-compatible gateway adapter (`adapters/openai-compat-adapter.ts`,
+ * #2468) was implemented but never wired into the runtime. This module
+ * closes that loop: at MCP-server startup, when `NEXUS_OPENAI_COMPAT_URL`
+ * + `NEXUS_OPENAI_COMPAT_KEY` are set, we discover the gateway's models
+ * and produce a single `IModelAdapter` that orchestrator/expert tools can
+ * use directly. In sandbox mode (#2501), we fail-fast on misconfiguration
+ * because there's no human at a CLI prompt to recover.
+ *
+ * @module cli-server-gateway
+ */
+
+import type { ILogger, IModelAdapter } from './core/index.js';
+import {
+  readOpenAICompatEnv,
+  buildOpenAICompatAdapters,
+} from './adapters/openai-compat-adapter.js';
+import { detectSandbox } from './config/sandbox-detection.js';
+import { EXIT_CODES } from './cli-types.js';
+
+/**
+ * Try to wire an OpenAI-compatible gateway as an `IModelAdapter`.
+ *
+ * Behavioural matrix:
+ *
+ * | Sandbox | Env vars | Probe   | Outcome                                  |
+ * | :------ | :------- | :------ | :--------------------------------------- |
+ * | active  | unset    | n/a     | exit(SERVER_START_FAILED)                |
+ * | active  | set      | fails   | exit(SERVER_START_FAILED) with HTTP info |
+ * | active  | set      | succeed | log + return first discovered adapter    |
+ * | inactive| unset    | n/a     | return undefined (CLI flow handles it)   |
+ * | inactive| set      | fails   | log warning + return undefined           |
+ * | inactive| set      | succeed | log + return first discovered adapter    |
+ *
+ * The "first discovered" choice is intentional: when the harness is the
+ * one routing models (via MCP tool params), nexus-agents should use
+ * whichever the gateway lists. Per-model adapter selection lives in the
+ * tool handlers, not in the bootstrap.
+ */
+export async function tryWireGatewayAdapter(logger: ILogger): Promise<IModelAdapter | undefined> {
+  const sandboxActive = detectSandbox().active;
+  const env = readOpenAICompatEnv();
+  if (env === null) {
+    handleMissingEnv(logger, sandboxActive);
+    return undefined;
+  }
+
+  const result = await buildOpenAICompatAdapters();
+  if (result === null) return undefined; // env-was-set guard; build contract allows it
+  if (!result.ok) {
+    handleProbeFailure(logger, sandboxActive, result.error.message);
+    return undefined;
+  }
+  if (result.value.length === 0) {
+    handleZeroModels(logger, sandboxActive);
+    return undefined;
+  }
+
+  // Log the discovered model IDs at info level — operators want to confirm
+  // the gateway's catalog matches what they configured upstream. The API
+  // key never reaches logs (env-only read).
+  logger.info('OpenAI-compatible gateway wired', {
+    baseUrl: env.baseUrl,
+    modelCount: result.value.length,
+    models: result.value.map((a) => a.modelId),
+  });
+  return result.value[0];
+}
+
+function handleMissingEnv(logger: ILogger, sandboxActive: boolean): void {
+  if (sandboxActive) {
+    logger.error(
+      'Sandbox mode active but NEXUS_OPENAI_COMPAT_URL / NEXUS_OPENAI_COMPAT_KEY are not set. ' +
+        'Configure the gateway in your launch env or opencode.json. ' +
+        'See docs/getting-started/SANDBOXED-USAGE.md.',
+      new Error('Missing gateway configuration in sandbox mode')
+    );
+    process.exit(EXIT_CODES.SERVER_START_FAILED);
+  }
+  return undefined;
+}
+
+function handleProbeFailure(logger: ILogger, sandboxActive: boolean, reason: string): void {
+  if (sandboxActive) {
+    logger.error(
+      'Sandbox mode active and OpenAI-compatible gateway probe failed.',
+      new Error(reason)
+    );
+    process.exit(EXIT_CODES.SERVER_START_FAILED);
+  }
+  logger.warn('OpenAI-compatible gateway probe failed; continuing with CLI adapters', {
+    error: reason,
+  });
+  return undefined;
+}
+
+function handleZeroModels(logger: ILogger, sandboxActive: boolean): void {
+  if (sandboxActive) {
+    logger.error(
+      'Sandbox mode active and gateway returned 0 models. Check upstream provider quotas / list filters.',
+      new Error('Gateway discovered 0 models')
+    );
+    process.exit(EXIT_CODES.SERVER_START_FAILED);
+  }
+  logger.warn('OpenAI-compatible gateway returned 0 models; ignoring');
+  return undefined;
+}

--- a/packages/nexus-agents/src/cli-server.test.ts
+++ b/packages/nexus-agents/src/cli-server.test.ts
@@ -40,6 +40,14 @@ vi.mock('./core/index.js', () => ({
   createLogger: vi.fn(() => createMockLogger()),
 }));
 
+// #2502: cli-server now imports cli-server-gateway, which transitively pulls
+// in the openai-compat / openai SDK adapter chain. Those need full ./core
+// exports (ModelError etc.) — mock the gateway helper directly so this test
+// stays focused on cli-server's own surface.
+vi.mock('./cli-server-gateway.js', () => ({
+  tryWireGatewayAdapter: vi.fn(() => Promise.resolve(undefined)),
+}));
+
 vi.mock('./version.js', () => ({
   VERSION: '0.0.0-test',
 }));

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -43,6 +43,7 @@ import {
   type AppConfig,
 } from './config/index.js';
 import { initializeExperts } from './cli-server-experts.js';
+import { tryWireGatewayAdapter } from './cli-server-gateway.js';
 import { initializeSkillLibrary } from './cli-server-skills.js';
 import { initializeSica } from './cli-server-sica.js';
 import { initializeFeedbackIntegration } from './cli-server-feedback.js';
@@ -356,7 +357,13 @@ async function initializeAndRegisterTools(
 
   // Issue #1149: Unified registry — task routing computed at startup, detection lazy
   const adapterRegistry = createAdapterRegistry(logger);
-  const modelAdapter = adapterRegistry.getDefault();
+  // #2502 (epic #2500 child 2): when the OpenAI-compat gateway is configured,
+  // it becomes the default model adapter. In sandbox mode the gateway is the
+  // only available channel to LLMs, so a missing or unreachable gateway is a
+  // hard startup failure (see tryWireGatewayAdapter for the matrix). Outside
+  // sandbox mode it's optional — falls through to the CLI-based default.
+  const gatewayAdapter = await tryWireGatewayAdapter(logger);
+  const modelAdapter = gatewayAdapter ?? adapterRegistry.getDefault();
   const policyVals = getPolicyValues(config);
   const allowedPaths = config.security?.allowedPaths;
   const securityConfig = config.security;


### PR DESCRIPTION
## Summary
Child 2 of epic #2500. The load-bearing change — once this lands, real orchestration through the gateway works even without children 3-4 (operators can use the env vars directly).

`OpenAICompatAdapter` (#2468) was implemented + tested but never wired into the runtime. `buildOpenAICompatAdapters()` was exported and called nowhere. As a result, sandboxes configured with `NEXUS_OPENAI_COMPAT_URL` + `NEXUS_OPENAI_COMPAT_KEY` still fell through to `OrchestratorUnavailableError`, masked by `NEXUS_ALLOW_MOCK_ORCHESTRATION=true` returning heuristic mock results that look real but aren't LLM calls.

### Changes
- New `cli-server-gateway.ts` with `tryWireGatewayAdapter(logger)` — the boot-time bridge between `buildOpenAICompatAdapters` and the unified registry.
- `cli-server.ts` `initializeAndRegisterTools` now does `gatewayAdapter ?? adapterRegistry.getDefault()` for the model adapter passed to tools.
- **Sandbox-mode fail-fast** (#2501): when `NEXUS_SANDBOX` is set and the gateway is missing, probe fails, or returns 0 models — exit at startup with a clear error pointing at the docs.
- **Non-sandbox**: missing/failed gateway just falls through to CLI-based default. Zero regression for laptop users.
- `Dockerfile.sandbox` + `Dockerfile.opencode`: drop `NEXUS_ALLOW_MOCK_ORCHESTRATION=true` (band-aid no longer needed). Add `NEXUS_SANDBOX=docker-opencode`. Pass through gateway env vars via `{env:VAR}` so the host injects them at launch instead of baking secrets into the image.

### Behavioural matrix

| Sandbox | Env vars | Probe   | Outcome                                  |
| :------ | :------- | :------ | :--------------------------------------- |
| active  | unset    | n/a     | exit(SERVER_START_FAILED)                |
| active  | set      | fails   | exit(SERVER_START_FAILED) with HTTP info |
| active  | set      | succeed | log + return first discovered adapter    |
| inactive| unset    | n/a     | return undefined (CLI flow handles it)   |
| inactive| set      | fails   | log warning + return undefined           |
| inactive| set      | succeed | log + return first discovered adapter    |

### Test plan
- [x] 9 new tests covering all 6 cells of the matrix + an explicit assertion that the API key never appears in any log call
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [ ] CI green on Ubuntu + macOS

Refs #2500 (epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)