### PR TITLE
feat(sandbox): read opencode.json for gateway config (#2503)

### DIFF
--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -108,7 +108,8 @@ RUN cat > /home/nexus/opencode.json <<'OCEOF'
         "NEXUS_SANDBOX": "{env:NEXUS_SANDBOX}",
         "NEXUS_DATA_DIR": "{env:NEXUS_DATA_DIR}",
         "NEXUS_OPENAI_COMPAT_URL": "{env:CUSTOM_API_BASE_URL}",
-        "NEXUS_OPENAI_COMPAT_KEY": "{env:CUSTOM_API_KEY}"
+        "NEXUS_OPENAI_COMPAT_KEY": "{env:CUSTOM_API_KEY}",
+        "NEXUS_OPENCODE_CONFIG": "/home/nexus/opencode.json"
       }
     }
   }

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -81,7 +81,8 @@ RUN mkdir -p /home/agent/.config/opencode && \
         "NEXUS_SANDBOX": "{env:NEXUS_SANDBOX}",
         "NEXUS_DATA_DIR": "{env:NEXUS_DATA_DIR}",
         "NEXUS_OPENAI_COMPAT_URL": "{env:NEXUS_OPENAI_COMPAT_URL}",
-        "NEXUS_OPENAI_COMPAT_KEY": "{env:NEXUS_OPENAI_COMPAT_KEY}"
+        "NEXUS_OPENAI_COMPAT_KEY": "{env:NEXUS_OPENAI_COMPAT_KEY}",
+        "NEXUS_OPENCODE_CONFIG": "/home/agent/.config/opencode/opencode.json"
       }
     }
   }

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
@@ -23,10 +23,22 @@ vi.mock('openai', () => {
   return { default: MockOpenAI };
 });
 
-describe('readOpenAICompatEnv (#2468)', () => {
+// #2503: stub the opencode-bridge so these tests stay focused on env-var
+// precedence. Per-test overrides via mockReturnValueOnce when needed.
+const { mockReadOpencodeGateway } = vi.hoisted(() => ({
+  mockReadOpencodeGateway: vi.fn<(path: string) => unknown>(),
+}));
+vi.mock('../config/opencode-bridge.js', () => ({
+  readOpencodeGateway: mockReadOpencodeGateway,
+}));
+
+describe('readOpenAICompatEnv (#2468 + #2503)', () => {
   beforeEach(() => {
     delete process.env['NEXUS_OPENAI_COMPAT_URL'];
     delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+    delete process.env['NEXUS_OPENCODE_CONFIG'];
+    mockReadOpencodeGateway.mockReset();
+    mockReadOpencodeGateway.mockReturnValue(null);
   });
 
   it('returns null when both env vars are unset', () => {
@@ -62,6 +74,63 @@ describe('readOpenAICompatEnv (#2468)', () => {
     const result = readOpenAICompatEnv();
     expect(result?.baseUrl).toBe('https://gateway.example/v1');
     expect(result?.apiKey).toBe('sk-test');
+  });
+
+  // #2503: precedence — env > opencode.json > unconfigured
+  describe('opencode.json precedence (#2503)', () => {
+    it('env vars win over opencode.json when both are configured', () => {
+      process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://env-gateway/v1';
+      process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-from-env';
+      process.env['NEXUS_OPENCODE_CONFIG'] = '/tmp/opencode.json';
+      mockReadOpencodeGateway.mockReturnValue({
+        baseURL: 'https://file-gateway/v1',
+        apiKey: 'sk-from-file',
+      });
+
+      const result = readOpenAICompatEnv();
+      expect(result?.baseUrl).toBe('https://env-gateway/v1');
+      expect(result?.apiKey).toBe('sk-from-env');
+      expect(mockReadOpencodeGateway).not.toHaveBeenCalled();
+    });
+
+    it('falls back to opencode.json when env vars are unset', () => {
+      process.env['NEXUS_OPENCODE_CONFIG'] = '/tmp/opencode.json';
+      mockReadOpencodeGateway.mockReturnValue({
+        baseURL: 'https://file-gateway/v1',
+        apiKey: 'sk-from-file',
+      });
+
+      const result = readOpenAICompatEnv();
+      expect(result?.baseUrl).toBe('https://file-gateway/v1');
+      expect(result?.apiKey).toBe('sk-from-file');
+      expect(mockReadOpencodeGateway).toHaveBeenCalledWith('/tmp/opencode.json');
+    });
+
+    it('returns null when env unset, opencode path set, but file resolves to null', () => {
+      process.env['NEXUS_OPENCODE_CONFIG'] = '/tmp/opencode.json';
+      mockReadOpencodeGateway.mockReturnValue(null);
+      expect(readOpenAICompatEnv()).toBeNull();
+    });
+
+    it('does not invoke opencode-bridge when NEXUS_OPENCODE_CONFIG is unset', () => {
+      // Both env vars unset, no opencode path either.
+      expect(readOpenAICompatEnv()).toBeNull();
+      expect(mockReadOpencodeGateway).not.toHaveBeenCalled();
+    });
+
+    it('falls back to opencode.json when only one env var is set', () => {
+      // Half-configured env (URL only) — must NOT be treated as configured;
+      // fall through to opencode.json path.
+      process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://env-gateway/v1';
+      process.env['NEXUS_OPENCODE_CONFIG'] = '/tmp/opencode.json';
+      mockReadOpencodeGateway.mockReturnValue({
+        baseURL: 'https://file-gateway/v1',
+        apiKey: 'sk-from-file',
+      });
+
+      const result = readOpenAICompatEnv();
+      expect(result?.baseUrl).toBe('https://file-gateway/v1');
+    });
   });
 });
 
@@ -146,11 +215,16 @@ describe('createOpenAICompatAdapter (#2468)', () => {
 describe('buildOpenAICompatAdapters (#2468)', () => {
   let originalUrl: string | undefined;
   let originalKey: string | undefined;
+  let originalOpencode: string | undefined;
 
   beforeEach(() => {
     originalUrl = process.env['NEXUS_OPENAI_COMPAT_URL'];
     originalKey = process.env['NEXUS_OPENAI_COMPAT_KEY'];
+    originalOpencode = process.env['NEXUS_OPENCODE_CONFIG'];
+    delete process.env['NEXUS_OPENCODE_CONFIG'];
     mockList.mockReset();
+    mockReadOpencodeGateway.mockReset();
+    mockReadOpencodeGateway.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -158,6 +232,8 @@ describe('buildOpenAICompatAdapters (#2468)', () => {
     else process.env['NEXUS_OPENAI_COMPAT_URL'] = originalUrl;
     if (originalKey === undefined) delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
     else process.env['NEXUS_OPENAI_COMPAT_KEY'] = originalKey;
+    if (originalOpencode === undefined) delete process.env['NEXUS_OPENCODE_CONFIG'];
+    else process.env['NEXUS_OPENCODE_CONFIG'] = originalOpencode;
   });
 
   it('returns null when env not configured (caller treats as "no source")', async () => {

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -7,10 +7,10 @@
  *
  * Source: Issue #2468 (epic #2467 child).
  *
- * Configuration is env-var-driven so operators don't have to thread config
- * through the model registry just to point at a custom gateway:
- *   - NEXUS_OPENAI_COMPAT_URL — base URL (e.g. https://gateway.example/v1)
- *   - NEXUS_OPENAI_COMPAT_KEY — API key for the gateway
+ * Configuration precedence (#2503, child 3 of epic #2500):
+ *   1. NEXUS_OPENAI_COMPAT_URL + NEXUS_OPENAI_COMPAT_KEY env vars (both required)
+ *   2. NEXUS_OPENCODE_CONFIG path → opencode.json → providers.openai-compat
+ *   3. Unconfigured → adapter not built
  *
  * Models are discovered via GET {base}/v1/models at first use. Each model
  * the gateway exposes can be selected by ID; the adapter wraps the existing
@@ -30,6 +30,7 @@ import type {
 import { ok, err, ConfigError, getErrorMessage, getTimeProvider } from '../core/index.js';
 import { OpenAIAdapter } from './openai-adapter.js';
 import { recordUsageEvent, computeCostUSD } from '../learning/usage-log.js';
+import { readOpencodeGateway } from '../config/opencode-bridge.js';
 
 export interface OpenAICompatConfig {
   /** Gateway base URL — must reach `/v1/models` and `/v1/chat/completions`. */
@@ -47,16 +48,36 @@ export interface DiscoveredModel {
 }
 
 /**
- * Read the env-var-driven gateway config. Returns `null` when either var is
- * unset or empty — caller can fall back to other adapter sources without
- * surfacing a hard error.
+ * Read the gateway config with the precedence chain documented in the
+ * module docstring: env vars > opencode.json > unconfigured.
+ *
+ * The env-var path (#2468) wins when both `NEXUS_OPENAI_COMPAT_URL` and
+ * `NEXUS_OPENAI_COMPAT_KEY` are set. Otherwise, when `NEXUS_OPENCODE_CONFIG`
+ * names a path, the opencode.json bridge tries to source the gateway from
+ * `providers.openai-compat.options.{baseURL, apiKey}` (#2503). Returns
+ * `null` when neither path yields a config — caller treats unset gateway
+ * as "no adapter from this source."
  */
 export function readOpenAICompatEnv(): OpenAICompatConfig | null {
-  const baseUrl = process.env['NEXUS_OPENAI_COMPAT_URL']?.trim();
-  const apiKey = process.env['NEXUS_OPENAI_COMPAT_KEY']?.trim();
-  if (baseUrl === undefined || baseUrl === '') return null;
-  if (apiKey === undefined || apiKey === '') return null;
-  return { baseUrl, apiKey };
+  const fromEnv = readGatewayFromEnv();
+  if (fromEnv !== null) return fromEnv;
+  return readGatewayFromOpencode();
+}
+
+function readGatewayFromEnv(): OpenAICompatConfig | null {
+  const envUrl = process.env['NEXUS_OPENAI_COMPAT_URL']?.trim();
+  const envKey = process.env['NEXUS_OPENAI_COMPAT_KEY']?.trim();
+  if (envUrl === undefined || envUrl === '') return null;
+  if (envKey === undefined || envKey === '') return null;
+  return { baseUrl: envUrl, apiKey: envKey };
+}
+
+function readGatewayFromOpencode(): OpenAICompatConfig | null {
+  const opencodePath = process.env['NEXUS_OPENCODE_CONFIG']?.trim();
+  if (opencodePath === undefined || opencodePath === '') return null;
+  const fromFile = readOpencodeGateway(opencodePath);
+  if (fromFile === null) return null;
+  return { baseUrl: fromFile.baseURL, apiKey: fromFile.apiKey };
 }
 
 /**

--- a/packages/nexus-agents/src/config/opencode-bridge.test.ts
+++ b/packages/nexus-agents/src/config/opencode-bridge.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for opencode.json gateway-config bridge (#2503).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { mockReadFileSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn<(path: string, encoding: string) => string>(),
+}));
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { readOpencodeGateway } from './opencode-bridge.js';
+
+describe('readOpencodeGateway', () => {
+  let savedProxyKey: string | undefined;
+  let savedMissing: string | undefined;
+
+  beforeEach(() => {
+    savedProxyKey = process.env['WORKSPACE_PROXY_KEY'];
+    savedMissing = process.env['MISSING_VAR'];
+    delete process.env['WORKSPACE_PROXY_KEY'];
+    delete process.env['MISSING_VAR'];
+    mockReadFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    if (savedProxyKey === undefined) delete process.env['WORKSPACE_PROXY_KEY'];
+    else process.env['WORKSPACE_PROXY_KEY'] = savedProxyKey;
+    if (savedMissing === undefined) delete process.env['MISSING_VAR'];
+    else process.env['MISSING_VAR'] = savedMissing;
+  });
+
+  it('returns null when the file does not exist (read throws ENOENT)', () => {
+    mockReadFileSync.mockImplementation(() => {
+      const err = new Error('ENOENT');
+      throw err;
+    });
+    expect(readOpencodeGateway('/nope.json')).toBeNull();
+  });
+
+  it('returns null when the file is malformed JSON', () => {
+    mockReadFileSync.mockReturnValue('{ this is not json');
+    expect(readOpencodeGateway('/broken.json')).toBeNull();
+  });
+
+  it('returns null when providers section is absent', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ mcp: {} }));
+    expect(readOpencodeGateway('/no-providers.json')).toBeNull();
+  });
+
+  it('returns null when providers.openai-compat is absent', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ providers: { anthropic: { options: { apiKey: 'sk-x' } } } })
+    );
+    expect(readOpencodeGateway('/no-compat.json')).toBeNull();
+  });
+
+  it('returns null when baseURL is missing', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: { 'openai-compat': { options: { apiKey: 'sk-x' } } },
+      })
+    );
+    expect(readOpencodeGateway('/no-baseurl.json')).toBeNull();
+  });
+
+  it('returns null when apiKey is missing', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': { options: { baseURL: 'https://gateway.example/v1' } },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/no-key.json')).toBeNull();
+  });
+
+  it('returns the resolved config when literal apiKey is provided', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': {
+            options: { baseURL: 'https://gateway.example/v1', apiKey: 'sk-literal' },
+          },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/literal.json')).toEqual({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-literal',
+    });
+  });
+
+  it('resolves {env:VAR} interpolation in apiKey when the env var is set', () => {
+    process.env['WORKSPACE_PROXY_KEY'] = 'sk-resolved-from-env';
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': {
+            options: {
+              baseURL: 'https://gateway.example/v1',
+              apiKey: '{env:WORKSPACE_PROXY_KEY}',
+            },
+          },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/interp.json')).toEqual({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-resolved-from-env',
+    });
+  });
+
+  it('returns null when {env:VAR} interpolation references an unset env var', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': {
+            options: {
+              baseURL: 'https://gateway.example/v1',
+              apiKey: '{env:MISSING_VAR}',
+            },
+          },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/missing-env.json')).toBeNull();
+  });
+
+  it('treats whitespace-only values as missing', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': { options: { baseURL: '   ', apiKey: 'sk-x' } },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/whitespace.json')).toBeNull();
+  });
+
+  it('preserves apiKey verbatim when it does not match the {env:VAR} pattern', () => {
+    // E.g. a literal "sk-{somethinghashy}" — only {env:NAME} is interpolated.
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        providers: {
+          'openai-compat': {
+            options: {
+              baseURL: 'https://gateway.example/v1',
+              apiKey: 'sk-literal-{not-an-env-ref}',
+            },
+          },
+        },
+      })
+    );
+    expect(readOpencodeGateway('/literal-curly.json')?.apiKey).toBe('sk-literal-{not-an-env-ref}');
+  });
+});

--- a/packages/nexus-agents/src/config/opencode-bridge.ts
+++ b/packages/nexus-agents/src/config/opencode-bridge.ts
@@ -1,0 +1,133 @@
+/**
+ * opencode.json gateway-config bridge (#2503, child 3 of epic #2500).
+ *
+ * When nexus-agents runs as an MCP loaded by OpenCode (typically inside a
+ * Docker sandbox), OpenCode's `opencode.json` already declares the
+ * OpenAI-compatible gateway the harness uses. Reading it from there saves
+ * the operator from re-declaring the same `baseURL` + `apiKey` as
+ * NEXUS_OPENAI_COMPAT_* env vars.
+ *
+ * Scope (per direction discussion 2026-05-09):
+ *   - **Only** reads `providers.openai-compat.options.{baseURL, apiKey}`.
+ *     Does NOT read OpenCode's MCP config, model list, logging, or other
+ *     settings. nexus-agents' own behaviour stays driven by
+ *     `nexus-agents.yaml` + `NEXUS_*` env vars.
+ *   - Resolves OpenCode's `{env:VAR}` interpolation in the apiKey field.
+ *   - Returns `null` on any failure path (missing file, parse error,
+ *     missing fields, unset interpolated env var) — caller falls back to
+ *     env-var precedence; we don't throw.
+ *
+ * Precedence (applied in `openai-compat-adapter.ts`):
+ *   1. `NEXUS_OPENAI_COMPAT_URL` + `NEXUS_OPENAI_COMPAT_KEY` env vars (if both set)
+ *   2. `NEXUS_OPENCODE_CONFIG` → `opencode.json` → `providers.openai-compat`
+ *   3. Unconfigured → `null`, no adapter registered
+ *
+ * Sanitised logging: never log the resolved apiKey. Only the baseURL is
+ * logged on success.
+ *
+ * @module config/opencode-bridge
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { createLogger } from '../core/index.js';
+
+const logger = createLogger({ component: 'opencode-bridge' });
+
+export interface OpencodeGatewayConfig {
+  readonly baseURL: string;
+  readonly apiKey: string;
+}
+
+/**
+ * Read `providers.openai-compat.options.{baseURL, apiKey}` from the given
+ * opencode.json path. Returns `null` on any failure — the caller falls
+ * back to env-var precedence.
+ */
+export function readOpencodeGateway(path: string): OpencodeGatewayConfig | null {
+  const raw = readFileOrNull(path);
+  if (raw === null) return null;
+
+  const parsed = parseJsonOrNull(raw, path);
+  if (parsed === null) return null;
+
+  const options = extractOpenAICompatOptions(parsed);
+  if (options === null) {
+    logger.debug('opencode.json has no providers.openai-compat.options block', { path });
+    return null;
+  }
+
+  const baseURL = typeof options.baseURL === 'string' ? options.baseURL.trim() : '';
+  const apiKeyRaw = typeof options.apiKey === 'string' ? options.apiKey.trim() : '';
+  if (baseURL === '' || apiKeyRaw === '') {
+    logger.warn('opencode.json providers.openai-compat missing baseURL or apiKey', { path });
+    return null;
+  }
+
+  const apiKey = resolveEnvInterpolation(apiKeyRaw);
+  if (apiKey === null) {
+    logger.warn(
+      'opencode.json apiKey references an env var that is not set; gateway not configured',
+      { path }
+    );
+    return null;
+  }
+
+  logger.info('Gateway config sourced from opencode.json', { baseURL, path });
+  return { baseURL, apiKey };
+}
+
+function readFileOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug('Could not read opencode.json', { path, error: msg });
+    return null;
+  }
+}
+
+function parseJsonOrNull(raw: string, path: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn('opencode.json is not valid JSON; ignoring', { path, error: msg });
+    return null;
+  }
+}
+
+/**
+ * Pull `providers.openai-compat.options` out of the parsed JSON without
+ * coupling to a Zod schema. OpenCode's config has many keys we don't
+ * care about; we only navigate to the one we need.
+ */
+function extractOpenAICompatOptions(
+  parsed: unknown
+): { baseURL?: unknown; apiKey?: unknown } | null {
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const root = parsed as { providers?: unknown };
+  const providers = root.providers;
+  if (typeof providers !== 'object' || providers === null) return null;
+  const provider = (providers as Record<string, unknown>)['openai-compat'];
+  if (typeof provider !== 'object' || provider === null) return null;
+  const options = (provider as { options?: unknown }).options;
+  if (typeof options !== 'object' || options === null) return null;
+  return options;
+}
+
+/**
+ * Resolve OpenCode's `{env:VAR}` interpolation. Only the literal pattern
+ * is supported (no shell expansion, no defaults). Returns the string as-is
+ * when no interpolation is present; returns `null` when the referenced
+ * env var is not set.
+ */
+function resolveEnvInterpolation(value: string): string | null {
+  const match = /^\{env:([A-Z0-9_]+)\}$/.exec(value);
+  if (match === null) return value;
+  const envName = match[1];
+  if (envName === undefined) return null;
+  const resolved = process.env[envName];
+  if (resolved === undefined || resolved === '') return null;
+  return resolved;
+}


### PR DESCRIPTION
## Summary
Child 3 of epic #2500. When nexus-agents runs as an MCP under OpenCode (typically inside a Docker sandbox), OpenCode's `opencode.json` already declares the OpenAI-compatible gateway. Reading it from there saves the operator from re-declaring the same `baseURL` + `apiKey` as `NEXUS_OPENAI_COMPAT_*` env vars.

**Scope is intentionally narrow** per direction discussion: only reads `providers.openai-compat.options.{baseURL, apiKey}`. `nexus-agents.yaml` + `NEXUS_*` env vars remain the source of truth for nexus-agents' own settings.

### Precedence chain
1. `NEXUS_OPENAI_COMPAT_URL` + `NEXUS_OPENAI_COMPAT_KEY` env vars (both required)
2. `NEXUS_OPENCODE_CONFIG` path → `providers.openai-compat`
3. Unconfigured → `null`, no adapter registered

### Changes
- New `config/opencode-bridge.ts` exports `readOpencodeGateway(path)`. Resolves `{env:VAR}` interpolation in `apiKey`. Returns `null` on every failure path (missing file, parse error, missing fields, unset interpolated env var). Sanitised logging — never logs the resolved apiKey.
- `readOpenAICompatEnv()` extended with precedence chain. Refactored into helpers to keep complexity ≤ 10.
- `Dockerfile.sandbox` + `Dockerfile.opencode` pass through `NEXUS_OPENCODE_CONFIG` so the bridge has a path to read.

### Test plan
- [x] 11 new tests on `readOpencodeGateway` (missing file, malformed JSON, missing fields, whitespace handling, env interpolation present/unset, literal apiKey passthrough)
- [x] 5 new precedence tests on `readOpenAICompatEnv`
- [x] Existing 13 + 4 tests still pass with mocked bridge
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [ ] CI green on Ubuntu + macOS

Refs #2500 (epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)