### PR TITLE
docs(sandbox): SANDBOXED-USAGE end-to-end OpenCode + gateway flow (#2505)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,23 +47,28 @@ nexus-agents --help       # Full command list
 **Required:** Node.js 22.x LTS, pnpm 9.x (or npm 10.x)
 **Optional:** Docker (sandbox mode), Claude CLI (MCP mode)
 
-| Variable                       | Required For                                                  | Default                       |
-| ------------------------------ | ------------------------------------------------------------- | ----------------------------- |
-| `ANTHROPIC_API_KEY`            | Claude adapter                                                | None                          |
-| `OPENAI_API_KEY`               | OpenAI adapter                                                | None                          |
-| `GOOGLE_AI_API_KEY`            | Gemini adapter                                                | None                          |
-| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)                              | None                          |
-| `NEXUS_LOG_LEVEL`              | Logging verbosity                                             | `info`                        |
-| `NEXUS_CONFIG_PATH`            | Custom config path                                            | `./nexus-agents.yaml`         |
-| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)                           | `true` (auto-generates token) |
-| `NEXUS_BILLING_MODE`           | Model routing cost handling                                   | `plan` (monthly subscription) |
-| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence                            | `true`                        |
-| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce` | `audit` (v2.50+)              |
-| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable)            | enabled (v2.50+)              |
-| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                   | `0.85`                        |
-| `NEXUS_DATA_DIR`               | Override runtime data root (memory/audit/voting/sessions/…)   | `~/.nexus-agents` (v2.60+)    |
+| Variable                       | Required For                                                                                               | Default                                                                             |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`            | Claude adapter                                                                                             | None                                                                                |
+| `OPENAI_API_KEY`               | OpenAI adapter                                                                                             | None                                                                                |
+| `GOOGLE_AI_API_KEY`            | Gemini adapter                                                                                             | None                                                                                |
+| `OPENROUTER_API_KEY`           | OpenRouter adapter (free models)                                                                           | None                                                                                |
+| `NEXUS_LOG_LEVEL`              | Logging verbosity                                                                                          | `info`                                                                              |
+| `NEXUS_CONFIG_PATH`            | Custom config path                                                                                         | `./nexus-agents.yaml`                                                               |
+| `NEXUS_AUTH_ENABLED`           | Network auth (not needed for stdio)                                                                        | `true` (auto-generates token)                                                       |
+| `NEXUS_BILLING_MODE`           | Model routing cost handling                                                                                | `plan` (monthly subscription)                                                       |
+| `NEXUS_PERSIST_LEARNING`       | Cross-session learning persistence                                                                         | `true`                                                                              |
+| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce`                                              | `audit` (v2.50+)                                                                    |
+| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log (`0`/`false` to disable)                                                         | enabled (v2.50+)                                                                    |
+| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                                                                | `0.85`                                                                              |
+| `NEXUS_DATA_DIR`               | Override runtime data root (memory/audit/voting/sessions/…)                                                | `~/.nexus-agents` (v2.60+; sandbox mode → `${NEXUS_SANDBOX_ROOT:-/}/.nexus-agents`) |
+| `NEXUS_SANDBOX`                | Host-provided sandbox flavor (`docker-opencode`, `codex`, …); presence enables sandbox-mode boot behaviour | unset (epic #2500)                                                                  |
+| `NEXUS_SANDBOX_ROOT`           | Multi-repo root the sandbox mounted (e.g. `/projects`)                                                     | unset (epic #2500)                                                                  |
+| `NEXUS_OPENAI_COMPAT_URL`      | OpenAI-compatible gateway base URL (e.g. `https://gateway.example/v1`)                                     | unset (#2468)                                                                       |
+| `NEXUS_OPENAI_COMPAT_KEY`      | API key for the gateway above                                                                              | unset (#2468)                                                                       |
+| `NEXUS_OPENCODE_CONFIG`        | Path to `opencode.json` for gateway-config bridge                                                          | unset (#2503)                                                                       |
 
-**Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md)
+**Getting started:** [docs/getting-started/INSTALLATION.md](./docs/getting-started/INSTALLATION.md) | **Configuration:** [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md) | **Sandboxed (Docker + OpenCode):** [docs/getting-started/SANDBOXED-USAGE.md](./docs/getting-started/SANDBOXED-USAGE.md)
 
 ---
 

--- a/docs/getting-started/SANDBOXED-USAGE.md
+++ b/docs/getting-started/SANDBOXED-USAGE.md
@@ -1,8 +1,23 @@
 ---
 title: 'Sandboxed Usage'
-description: Run nexus-agents inside Docker, restricted-FS sandboxes, and team-distribution flows.
+description: Run nexus-agents inside Docker, restricted-FS sandboxes, and team-distribution flows; OpenCode-in-Docker + OpenAI-compat gateway scenario.
 tier: 2
-keywords: [sandbox, portable, docker, container, team, distribution, getting-started]
+keywords:
+  [
+    sandbox,
+    portable,
+    docker,
+    container,
+    team,
+    distribution,
+    getting-started,
+    opencode,
+    mcp,
+    openai-compat,
+    gateway,
+    NEXUS_SANDBOX,
+    NEXUS_OPENCODE_CONFIG,
+  ]
 ---
 
 # Sandboxed Usage
@@ -126,8 +141,173 @@ nexus-agents doctor
 
 Both should complete without errors. The first invocation triggers the `[portable-mode]` announcement (if auto-detected) and the `.nexus-agents/` directory is created lazily by whichever subsequent command first writes data.
 
+## OpenCode-in-Docker + OpenAI-compat gateway (epic #2500)
+
+The portable-mode flow above covers the "I'm running nexus-agents directly in a sandbox" case. This section covers the more specific scenario where **nexus-agents is loaded as an MCP by OpenCode running inside a Docker sandbox**, with a custom OpenAI-compatible gateway proxying upstream provider keys at the host boundary.
+
+> Source: epic [#2500](https://github.com/williamzujkowski/nexus-agents/issues/2500), shipped across [#2501](https://github.com/williamzujkowski/nexus-agents/issues/2501)–[#2505](https://github.com/williamzujkowski/nexus-agents/issues/2505).
+
+### Architecture
+
+```text
+┌─ Host ──────────────────────────────────────────────────────┐
+│  Workspace key proxy (LiteLLM / OpenRouter / vLLM / …)      │
+│   → injects upstream provider keys before forwarding        │
+│   → exposes /v1/models + /v1/chat/completions               │
+│                                                             │
+│  $ docker run --rm -it \                                    │
+│       -v /projects:/projects \                              │
+│       -e NEXUS_SANDBOX_ROOT=/projects \                     │
+│       -e NEXUS_OPENAI_COMPAT_URL=$WORKSPACE_PROXY_URL \      │
+│       -e NEXUS_OPENAI_COMPAT_KEY=$WORKSPACE_PROXY_KEY \      │
+│       nexus-sandbox:latest opencode .                       │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─ Container ─────────────────────────────────────────────────┐
+│  /projects/{repo1, repo2, repo3, .nexus-agents/}            │
+│                                                             │
+│  OpenCode (entrypoint)                                      │
+│    └─ spawns nexus-agents MCP via opencode.json             │
+│        ├─ NEXUS_SANDBOX=docker-opencode                     │
+│        ├─ NEXUS_DATA_DIR=/projects/.nexus-agents            │
+│        ├─ NEXUS_OPENCODE_CONFIG=~/.config/opencode/...      │
+│        └─ NEXUS_OPENAI_COMPAT_URL/KEY (passthrough)         │
+│                                                             │
+│  At startup, nexus-agents:                                  │
+│    1. detectSandbox() → active=true, flavor=docker-opencode │
+│    2. tryWireGatewayAdapter() → probe /v1/models            │
+│    3. fail-fast if gateway unreachable                      │
+│    4. log "gateway wired: <baseURL>, N models discovered"   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Build the image
+
+`Dockerfile.sandbox` extends `docker/sandbox-templates:opencode` (the official OpenCode template) and bakes nexus-agents in alongside.
+
+```bash
+docker build -f Dockerfile.sandbox -t nexus-sandbox:latest .
+```
+
+The image sets `ENV NEXUS_SANDBOX=docker-opencode` so nexus-agents knows it's running inside a host-provided sandbox at startup ([#2501](https://github.com/williamzujkowski/nexus-agents/issues/2501)).
+
+### Configure the workspace key proxy on the host
+
+Don't put upstream provider keys in the image or pass them into the container. Run a workspace key proxy on the host that:
+
+- Accepts requests from the sandbox at `WORKSPACE_PROXY_URL` authenticated by `WORKSPACE_PROXY_KEY` (an opaque per-sandbox token you generate).
+- Injects the real upstream provider key before forwarding.
+- Exposes the standard OpenAI Chat Completions surface (`/v1/models`, `/v1/chat/completions`).
+
+Project-specific implementations include LiteLLM, OpenRouter's BYOK gateway, vLLM with API-key middleware, or a hand-rolled httpx proxy. The contract for the sandbox is one URL, one workspace key, OpenAI-compat models.
+
+### Run the sandbox
+
+```bash
+docker run --rm -it \
+  -v /path/to/your/projects:/projects \
+  -e NEXUS_SANDBOX_ROOT=/projects \
+  -e NEXUS_OPENAI_COMPAT_URL=$WORKSPACE_PROXY_URL \
+  -e NEXUS_OPENAI_COMPAT_KEY=$WORKSPACE_PROXY_KEY \
+  nexus-sandbox:latest opencode .
+```
+
+`NEXUS_SANDBOX_ROOT=/projects` tells nexus-agents this is the multi-repo root. State goes at `/projects/.nexus-agents/`, shared across all repo subfolders. `NEXUS_DATA_DIR` is unset on the host — the sandbox-mode default places state at `${NEXUS_SANDBOX_ROOT}/.nexus-agents/`.
+
+### opencode.json layout
+
+`Dockerfile.sandbox` writes a default `opencode.json` at `/home/agent/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "providers": {
+    "openai-compat": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "{env:NEXUS_OPENAI_COMPAT_URL}",
+        "apiKey": "{env:NEXUS_OPENAI_COMPAT_KEY}"
+      }
+    }
+  },
+  "mcp": {
+    "nexus-agents": {
+      "type": "local",
+      "command": ["node", "/opt/nexus-agents/dist/cli.js", "--mode=server"],
+      "enabled": true,
+      "environment": {
+        "NEXUS_SANDBOX": "{env:NEXUS_SANDBOX}",
+        "NEXUS_DATA_DIR": "{env:NEXUS_DATA_DIR}",
+        "NEXUS_OPENAI_COMPAT_URL": "{env:NEXUS_OPENAI_COMPAT_URL}",
+        "NEXUS_OPENAI_COMPAT_KEY": "{env:NEXUS_OPENAI_COMPAT_KEY}",
+        "NEXUS_OPENCODE_CONFIG": "/home/agent/.config/opencode/opencode.json"
+      }
+    }
+  }
+}
+```
+
+`{env:VAR}` is OpenCode's interpolation syntax — substitution happens when OpenCode reads the file, so values flow through to the MCP environment block at spawn time.
+
+`NEXUS_OPENCODE_CONFIG` is the bridge that lets nexus-agents read the gateway config from `opencode.json` directly ([#2503](https://github.com/williamzujkowski/nexus-agents/issues/2503)). Precedence: `NEXUS_OPENAI_COMPAT_URL/KEY` env vars > opencode.json > unconfigured.
+
+### Fail-fast behaviour
+
+When sandbox mode is active and the gateway is misconfigured, nexus-agents fails fast at startup ([#2502](https://github.com/williamzujkowski/nexus-agents/issues/2502)):
+
+- Missing env vars (and no `NEXUS_OPENCODE_CONFIG`-pointed file with `providers.openai-compat`): exit, error names the missing env vars + this doc.
+- `/v1/models` probe fails: exit, error includes the HTTP failure.
+- Gateway returns zero models: exit.
+
+This is intentional — there's no human at a CLI prompt inside the container to diagnose later, so a misconfigured gateway should surface at first boot, not on the operator's first orchestrate call.
+
+### Validating it works
+
+From inside the running container:
+
+```bash
+nexus-agents doctor
+```
+
+The doctor output now includes a "Sandbox awareness" section ([#2501](https://github.com/williamzujkowski/nexus-agents/issues/2501)) when active. Look for:
+
+- `✓ Sandbox flavor: docker-opencode`
+- `NEXUS_SANDBOX_ROOT: /projects` (your mounted root)
+- No mismatch warning (heuristic agrees: `/.dockerenv` present)
+- No `dataDirInsideRepo` warning (state at the multi-repo root, not inside a single repo)
+
+For a quick orchestrator probe:
+
+```bash
+nexus-agents orchestrate -t "Say hello"
+```
+
+The first call hits the gateway and returns from one of the configured upstream models.
+
+### Adding nexus-agents to an existing opencode.json
+
+If you're not using `Dockerfile.sandbox` directly — e.g., you have an existing `opencode.json` with your own provider config and want to add nexus-agents to it — run:
+
+```bash
+nexus-agents init --opencode /path/to/opencode.json --dry-run
+```
+
+This shows the proposed merge without writing. Drop `--dry-run` to commit. The merge ([#2504](https://github.com/williamzujkowski/nexus-agents/issues/2504)) preserves every existing key. Re-running is idempotent. Operator overrides like `enabled: false` are preserved across re-runs.
+
+### OpenCode-specific troubleshooting
+
+**"Sandbox mode active but NEXUS_OPENAI_COMPAT_URL / NEXUS_OPENAI_COMPAT_KEY are not set"** — Either pass the env vars when running the container, or set `NEXUS_OPENCODE_CONFIG` to point at an `opencode.json` whose `providers.openai-compat.options` resolves to a real URL + key.
+
+**Gateway probe fails** — From inside the container, `curl -H "Authorization: Bearer $NEXUS_OPENAI_COMPAT_KEY" $NEXUS_OPENAI_COMPAT_URL/v1/models`. If that fails, the workspace key proxy isn't reachable from the sandbox network. Check outbound network access to the proxy host and that the proxy is bound to an interface the container can reach.
+
+**"Mock orchestration" warnings appearing post-upgrade** — Older `Dockerfile.sandbox` builds set `NEXUS_ALLOW_MOCK_ORCHESTRATION=true` as a band-aid for the unwired gateway. With the gateway now wired ([#2502](https://github.com/williamzujkowski/nexus-agents/issues/2502)), drop that env var — orchestration uses real LLM calls. Mock-orchestration is heuristic-based and silently produces non-LLM results; leaving it on after the gateway is configured will mask real routing decisions.
+
 ## Related
 
 - [Installation](./INSTALLATION.md) — initial install path
 - [Configuration](./CONFIGURATION.md) — env vars, config files, model selection
 - [#2467 epic](https://github.com/williamzujkowski/nexus-agents/issues/2467) — the umbrella for OpenAI-compat gateway support, sandbox-safe operation, and reliability hardening
+- [#2500 epic](https://github.com/williamzujkowski/nexus-agents/issues/2500) — MCP-in-sandbox: full functionality with OpenCode + OpenAI-compat gateway
+- [`Dockerfile.sandbox`](../../Dockerfile.sandbox) — the canonical image for the OpenCode-in-Docker scenario
+- OpenCode's own [`opencode.json` reference](https://opencode.ai/docs/configuration)


### PR DESCRIPTION
## Summary
Child 5 (final) of epic #2500. User-facing docs that bring children 1-4 together, plus CLAUDE.md env-var-table updates.

### Changes
- `docs/getting-started/SANDBOXED-USAGE.md` — new section "OpenCode-in-Docker + OpenAI-compat gateway (epic #2500)" with architecture diagram, build/configure/run walkthrough, opencode.json layout, fail-fast behaviour, validation steps, `init --opencode` flow, and OpenCode-specific troubleshooting. Pre-existing portable-mode content preserved unchanged.
- `CLAUDE.md` env-var table: adds `NEXUS_SANDBOX`, `NEXUS_SANDBOX_ROOT`, `NEXUS_OPENAI_COMPAT_URL`, `NEXUS_OPENAI_COMPAT_KEY`, `NEXUS_OPENCODE_CONFIG`. Updates `NEXUS_DATA_DIR` row with sandbox-mode default. Adds quicklink to the new doc section.

### Note
Dockerfile changes (drop `NEXUS_ALLOW_MOCK_ORCHESTRATION`, add `NEXUS_SANDBOX`/passthrough vars) were already shipped in PRs #2507 + #2508 as part of children 2 and 3. This PR is docs-only.

### Test plan
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [x] `npx tsx scripts/check-docs-indexed.ts` — no unindexed files, no stale refs
- [x] Hand-verified rendered output (markdown structure, code blocks, cross-links)
- [ ] CI green on Ubuntu + macOS

Closes epic #2500 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)