### PR TITLE
feat(cli): wire init --opencode --validate (follow-up to #2504)

### DIFF
--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -461,7 +461,32 @@ async function runInitOpencodeFlow(args: ParsedCliArgs): Promise<void> {
   if (args.options.dryRun || result.action !== 'unchanged') {
     process.stdout.write(`${result.diff}\n`);
   }
+
+  if (args.options.validate === true) {
+    const exitCode = await renderOpencodeValidate(opencodePath);
+    process.exit(exitCode);
+  }
   process.exit(EXIT_CODES.SUCCESS);
+}
+
+/**
+ * Run --validate via the helper in cli/init-opencode and render the
+ * outcome to stdout/stderr. Returns the exit code (0 success, 1 fail).
+ */
+async function renderOpencodeValidate(opencodePath: string): Promise<number> {
+  const { runOpencodeValidate } = await import('./cli/init-opencode.js');
+  const result = await runOpencodeValidate(opencodePath);
+  if (!result.ok) {
+    process.stderr.write(`init --opencode --validate: ${result.reason ?? 'failed'}\n`);
+    return 1;
+  }
+  process.stdout.write(
+    `init --opencode --validate: ${String(result.models?.length ?? 0)} model(s) discovered at ${result.baseURL ?? '(unknown)'}:\n`
+  );
+  for (const id of result.models ?? []) {
+    process.stdout.write(`  - ${id}\n`);
+  }
+  return 0;
 }
 
 /**

--- a/packages/nexus-agents/src/cli/init-opencode.test.ts
+++ b/packages/nexus-agents/src/cli/init-opencode.test.ts
@@ -20,7 +20,19 @@ vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
-import { runInitOpencode, buildNexusMcpBlock } from './init-opencode.js';
+const { mockReadOpencodeGateway, mockDiscoverModels } = vi.hoisted(() => ({
+  mockReadOpencodeGateway: vi.fn<(p: string) => unknown>(),
+  mockDiscoverModels: vi.fn<(c: unknown) => Promise<unknown>>(),
+}));
+vi.mock('../config/opencode-bridge.js', () => ({
+  readOpencodeGateway: mockReadOpencodeGateway,
+}));
+vi.mock('../adapters/openai-compat-adapter.js', () => ({
+  discoverModels: mockDiscoverModels,
+}));
+
+import { runInitOpencode, buildNexusMcpBlock, runOpencodeValidate } from './init-opencode.js';
+import { ok, err, ConfigError } from '../core/index.js';
 
 describe('buildNexusMcpBlock', () => {
   it('produces the canonical block with passthrough env vars', () => {
@@ -196,5 +208,70 @@ describe('runInitOpencode', () => {
         cliPath: '/opt/cli.js',
       })
     ).toThrow();
+  });
+});
+
+describe('runOpencodeValidate', () => {
+  beforeEach(() => {
+    mockReadOpencodeGateway.mockReset();
+    mockDiscoverModels.mockReset();
+  });
+
+  it('returns ok when gateway resolves and models are discovered', async () => {
+    mockReadOpencodeGateway.mockReturnValue({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    mockDiscoverModels.mockResolvedValue(ok([{ id: 'm1' }, { id: 'm2' }]));
+
+    const result = await runOpencodeValidate('/projects/opencode.json');
+    expect(result.ok).toBe(true);
+    expect(result.baseURL).toBe('https://gateway.example/v1');
+    expect(result.models).toEqual(['m1', 'm2']);
+  });
+
+  it('returns failure when bridge cannot resolve config', async () => {
+    mockReadOpencodeGateway.mockReturnValue(null);
+    const result = await runOpencodeValidate('/projects/opencode.json');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('does not resolve a usable gateway');
+    expect(mockDiscoverModels).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when probe fails', async () => {
+    mockReadOpencodeGateway.mockReturnValue({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    mockDiscoverModels.mockResolvedValue(err(new ConfigError('ECONNREFUSED')));
+
+    const result = await runOpencodeValidate('/projects/opencode.json');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('ECONNREFUSED');
+    expect(result.baseURL).toBe('https://gateway.example/v1');
+  });
+
+  it('returns failure when gateway returns 0 models', async () => {
+    mockReadOpencodeGateway.mockReturnValue({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    mockDiscoverModels.mockResolvedValue(ok([]));
+
+    const result = await runOpencodeValidate('/projects/opencode.json');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('0 models');
+  });
+
+  it('does not include the API key in the result payload', async () => {
+    mockReadOpencodeGateway.mockReturnValue({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'sk-secret-do-not-leak',
+    });
+    mockDiscoverModels.mockResolvedValue(ok([{ id: 'm1' }]));
+
+    const result = await runOpencodeValidate('/projects/opencode.json');
+    const flat = JSON.stringify(result);
+    expect(flat).not.toContain('sk-secret-do-not-leak');
   });
 });

--- a/packages/nexus-agents/src/cli/init-opencode.ts
+++ b/packages/nexus-agents/src/cli/init-opencode.ts
@@ -27,6 +27,8 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { createLogger } from '../core/index.js';
+import { readOpencodeGateway } from '../config/opencode-bridge.js';
+import { discoverModels } from '../adapters/openai-compat-adapter.js';
 
 const logger = createLogger({ component: 'init-opencode' });
 
@@ -204,4 +206,55 @@ export function ensureOpencodeDirExists(path: string): void {
     );
   }
   logger.debug('opencode.json target directory exists', { dir });
+}
+
+/**
+ * --validate flow for `init --opencode` (follow-up to #2504).
+ *
+ * After the merge step writes the file, optionally probe the gateway it
+ * points at. Reuses the same opencode-bridge loader (#2503) that the
+ * runtime uses, so what we validate is exactly what the server will see
+ * at boot.
+ *
+ * Returns:
+ *   - `{ ok: true, models }` when the gateway is reachable and returns ≥1 model
+ *   - `{ ok: false, reason }` for every failure path (config missing,
+ *     probe failed, zero models)
+ *
+ * Caller (cli-commands-handlers) maps to exit codes + stderr / stdout.
+ * The API key never reaches the returned object — only model IDs +
+ * baseURL appear in the success payload.
+ */
+export interface OpencodeValidateResult {
+  readonly ok: boolean;
+  readonly baseURL?: string;
+  readonly models?: readonly string[];
+  readonly reason?: string;
+}
+
+export async function runOpencodeValidate(opencodePath: string): Promise<OpencodeValidateResult> {
+  const config = readOpencodeGateway(opencodePath);
+  if (config === null) {
+    return {
+      ok: false,
+      reason:
+        'opencode.json does not resolve a usable gateway. Check that providers.openai-compat.options.{baseURL, apiKey} are set and that any {env:VAR} interpolation references are exported.',
+    };
+  }
+  const result = await discoverModels({ baseUrl: config.baseURL, apiKey: config.apiKey });
+  if (!result.ok) {
+    return { ok: false, baseURL: config.baseURL, reason: result.error.message };
+  }
+  if (result.value.length === 0) {
+    return {
+      ok: false,
+      baseURL: config.baseURL,
+      reason: 'gateway returned 0 models. Check upstream provider quotas / list filters.',
+    };
+  }
+  return {
+    ok: true,
+    baseURL: config.baseURL,
+    models: result.value.map((m) => m.id),
+  };
 }


### PR DESCRIPTION
## Summary
#2504 added a `--validate` flag to `cli-types.ts` but the handler never read it. This implements the missing behaviour: after the merge step, optionally probe the gateway and exit non-zero if unreachable.

The probe reuses the runtime path:
- `readOpencodeGateway()` from #2503 — resolves `providers.openai-compat.options.{baseURL, apiKey}` including `{env:VAR}` interpolation
- `discoverModels()` from #2468 — lists models via `/v1/models`

So `--validate` checks exactly what the MCP server will see at boot. No "config in two places" footgun.

### Changes
- New `runOpencodeValidate(path)` exported from `src/cli/init-opencode.ts` returning `OpencodeValidateResult`. Pure relative to fs writes; testable without the dispatch path.
- Handler in `cli-commands-handlers.ts`: when `--validate` is set, calls `renderOpencodeValidate()` after the merge step.
- Result payload **never includes the API key** — only model IDs and baseURL. Locked in via test that scans the stringified result for the secret pattern.

### Smoke test (live)
```
$ node dist/cli.js init --opencode /tmp/x.json
$ node dist/cli.js init --opencode /tmp/x.json --validate
init --opencode unchanged /tmp/x.json
init --opencode --validate: opencode.json does not resolve a usable gateway. ...
$ echo $?
1
```

Exit 1 + stderr message confirms the bridge's `{env:VAR}`-unset detection fires.

### Test plan
- [x] 5 new tests on `runOpencodeValidate`: happy path, bridge-null, probe failure, zero-models, API-key sanitisation
- [x] `pnpm typecheck` clean, `pnpm lint` clean
- [x] Smoke-tested live
- [ ] CI green on Ubuntu + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)