### PR TITLE
chore(security): bump vulnerable transitives in pnpm overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,7 +582,7 @@ _Auto-generated from source. 38 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-09_
+_Governance Version: 2026-05-10_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -47,10 +47,14 @@ Full applications built on top of nexus-agents, demonstrating real-world usage p
 
 Standalone benchmark harnesses implementing the `BenchmarkAdapter` contract from nexus-agents ≥2.33.1. Each is a runnable npm package with its own CLI; nexus-agents supplies the orchestrator (`runBenchmark`), types, and reporting surface.
 
-| Repo                                                                           | Benchmark                                                  | Pattern                                                 |
-| ------------------------------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------- |
-| [nexus-eval-template](https://github.com/williamzujkowski/nexus-eval-template) | Template scaffold — copy via GitHub "Use this template"    | `is_template=true` + topic `nexus-agents-eval-template` |
-| [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench) | SWE-bench Lite / Verified / Full — GitHub issue resolution | Wraps `SWEBenchRunner`; prediction-only MVP             |
+| Repo                                                                                       | Benchmark                                                                                             | Pattern                                                 |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [nexus-eval-template](https://github.com/williamzujkowski/nexus-eval-template)             | Template scaffold — copy via GitHub "Use this template"                                               | `is_template=true` + topic `nexus-agents-eval-template` |
+| [nexus-eval-swebench](https://github.com/williamzujkowski/nexus-eval-swebench)             | SWE-bench Lite / Verified / Full — GitHub issue resolution                                            | v0.2 clean-room model-only baseline                     |
+| [nexus-eval-swebench-pro](https://github.com/williamzujkowski/nexus-eval-swebench-pro)     | SWE-bench Pro — 731 multi-language instances (ScaleAI)                                                | v0.2 model-only baseline; Docker-eval = v0.4            |
+| [nexus-eval-aider-polyglot](https://github.com/williamzujkowski/nexus-eval-aider-polyglot) | Aider polyglot — multi-language code edits across 6 langs (Python/JS/TS/Go/Rust/C++)                  | v0.1 model-only baseline; test-based pass/fail = v0.3   |
+| [nexus-eval-livecodebench](https://github.com/williamzujkowski/nexus-eval-livecodebench)   | LiveCodeBench — competitive-programming with deterministic hidden tests (LeetCode/AtCoder/Codeforces) | v0.1 model-only baseline; sandboxed Python = v0.2       |
+| [nexus-eval-atbench](https://github.com/williamzujkowski/nexus-eval-atbench)               | atbench — agent-trajectory safety                                                                     | v0.1 extracted from in-tree                             |
 
 New harnesses land here as they are extracted. To build one, start from the template: `gh repo create yourname/nexus-eval-<bench> --template williamzujkowski/nexus-eval-template --public`.
 

--- a/package.json
+++ b/package.json
@@ -93,8 +93,10 @@
   "pnpm": {
     "overrides": {
       "@modelcontextprotocol/sdk>ajv": ">=8.18.0",
-      "hono": ">=4.12.14",
+      "hono": ">=4.12.18",
       "@hono/node-server": ">=1.19.13",
+      "fast-uri": ">=3.1.2",
+      "ip-address": ">=10.2.0",
       "@isaacs/brace-expansion": ">=5.0.1",
       "markdown-it": ">=14.1.1",
       "qs": ">=6.14.2",
@@ -103,7 +105,7 @@
       "smol-toml": ">=1.6.1",
       "markdownlint-cli>minimatch": ">=10.2.3",
       "rollup": ">=4.59.0",
-      "@modelcontextprotocol/sdk>express-rate-limit": ">=8.3.0",
+      "@modelcontextprotocol/sdk>express-rate-limit": ">=8.5.1",
       "lodash": ">=4.17.23",
       "flatted@<=3.4.1": ">=3.4.2",
       "h3@<1.15.9": ">=1.15.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,10 @@ settings:
 
 overrides:
   '@modelcontextprotocol/sdk>ajv': '>=8.18.0'
-  hono: '>=4.12.14'
+  hono: '>=4.12.18'
   '@hono/node-server': '>=1.19.13'
+  fast-uri: '>=3.1.2'
+  ip-address: '>=10.2.0'
   '@isaacs/brace-expansion': '>=5.0.1'
   markdown-it: '>=14.1.1'
   qs: '>=6.14.2'
@@ -16,7 +18,7 @@ overrides:
   smol-toml: '>=1.6.1'
   markdownlint-cli>minimatch: '>=10.2.3'
   rollup: '>=4.59.0'
-  '@modelcontextprotocol/sdk>express-rate-limit': '>=8.3.0'
+  '@modelcontextprotocol/sdk>express-rate-limit': '>=8.5.1'
   lodash: '>=4.17.23'
   flatted@<=3.4.1: '>=3.4.2'
   h3@<1.15.9: '>=1.15.9'
@@ -1149,7 +1151,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.18'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3298,8 +3300,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.5.1:
+    resolution: {integrity: sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -3341,8 +3343,8 @@ packages:
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -3567,8 +3569,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3655,8 +3657,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6603,9 +6605,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.13(hono@4.12.14)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   '@humanfs/core@0.19.1': {}
 
@@ -6771,7 +6773,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.14)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6780,8 +6782,8 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
+      express-rate-limit: 8.5.1(express@5.2.1)
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7727,14 +7729,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8741,10 +8743,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -8809,7 +8811,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.1.6:
     dependencies:
@@ -9120,7 +9122,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  hono@4.12.14: {}
+  hono@4.12.18: {}
 
   html-escaper@2.0.2: {}
 
@@ -9186,7 +9188,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

Closes Scorecard CodeQL alert [#85](https://github.com/williamzujkowski/nexus-agents/security/code-scanning/85) (8 known vulnerabilities surfaced by OpenSSF Scorecard's Vulnerabilities check). All findings are transitive deps of `@modelcontextprotocol/sdk@1.29.0`:

| GHSA | Severity | Package | Before | After |
| --- | --- | --- | --- | --- |
| GHSA-q3j6-qgpj-74h6 | high | fast-uri | 3.1.0 | 3.1.2 |
| GHSA-v39h-62p7-jpjc | high | fast-uri | 3.1.0 | 3.1.2 |
| GHSA-9vqf-7f2p-gf9v | moderate | hono | 4.12.14 | 4.12.18 |
| GHSA-69xw-7hcm-h432 | moderate | hono | 4.12.14 | 4.12.18 |
| GHSA-qp7p-654g-cw7p | moderate | hono | 4.12.14 | 4.12.18 |
| GHSA-p77w-8qqv-26rm | moderate | hono | 4.12.14 | 4.12.18 |
| GHSA-hm8q-7f3q-5f36 | low | hono | 4.12.14 | 4.12.18 |
| GHSA-v2v4-37r5-5v8g | moderate | ip-address | 10.1.0 | 10.2.0 |

## Approach

Tighten existing pnpm overrides + add two new ones. The MCP SDK declares peer ranges (`hono ^4.11.4`, `express-rate-limit ^8.2.1`) that already allow the patched versions — overrides just force resolution to the patched end of those ranges. **No code changes needed.**

```diff
   "@modelcontextprotocol/sdk>ajv": ">=8.18.0",
-  "hono": ">=4.12.14",
+  "hono": ">=4.12.18",
   "@hono/node-server": ">=1.19.13",
+  "fast-uri": ">=3.1.2",
+  "ip-address": ">=10.2.0",
   ...
-  "@modelcontextprotocol/sdk>express-rate-limit": ">=8.3.0",
+  "@modelcontextprotocol/sdk>express-rate-limit": ">=8.5.1",
```

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm audit` — 0 vulnerabilities
- [x] `pnpm typecheck` clean (full workspace)
- [x] `pnpm vitest run src/mcp/eventbus-bridge.test.ts` — 35/35 (sanity-check on a hono-adjacent surface)
- [x] `pnpm build` — ESM + DTS both succeed
- [ ] Full CI on this PR

## Related

- Companion PRs already merged on the eval repos: [aider-polyglot#3](https://github.com/williamzujkowski/nexus-eval-aider-polyglot/pull/3), [livecodebench#3](https://github.com/williamzujkowski/nexus-eval-livecodebench/pull/3), [template#3](https://github.com/williamzujkowski/nexus-eval-template/pull/3) — all bumped `nexus-agents` devDep to ^2.71.0 + regenerated lockfile, but those couldn't fix nexus-agents's own transitive set. This PR closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)