### PR TITLE
feat(config): dynamic model identity + behavior profile (#2529 PR A)

### DIFF
--- a/packages/nexus-agents/src/adapters/openai-adapter-list-models.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter-list-models.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for `OpenAIAdapter.listModels` (#2529 — `GET /v1/models` probe).
+ *
+ * Mocks the openai SDK at the `client.models.list` level so no real
+ * HTTP requests happen.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockCreate: vi.fn(),
+    mockModelsList: vi.fn(),
+  };
+});
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: { create: mocks.mockCreate },
+    };
+    models = {
+      list: mocks.mockModelsList,
+    };
+  },
+}));
+
+import { createOpenAIAdapter } from './openai-adapter.js';
+
+describe('OpenAIAdapter.listModels', () => {
+  beforeEach(() => {
+    mocks.mockModelsList.mockReset();
+  });
+
+  it('returns normalised ModelMetadata from /v1/models', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [
+        { id: 'gpt-4o', object: 'model', created: 1715367049, owned_by: 'system' },
+        {
+          id: 'anthropic/claude-sonnet-4-6',
+          object: 'model',
+          created: 1715367050,
+          owned_by: 'anthropic',
+        },
+      ],
+    });
+
+    const adapter = createOpenAIAdapter({ modelId: 'gpt-4o', apiKey: 'k' });
+    const models = await adapter.listModels();
+    expect(models).toHaveLength(2);
+    expect(models[0]).toEqual({
+      id: 'gpt-4o',
+      ownedBy: 'system',
+      createdAt: 1715367049,
+    });
+    expect(models[1]?.ownedBy).toBe('anthropic');
+  });
+
+  it('caches results — second call within TTL does not re-fetch', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [{ id: 'gpt-4o', object: 'model', created: 1, owned_by: 'system' }],
+    });
+
+    const adapter = createOpenAIAdapter({ modelId: 'gpt-4o', apiKey: 'k' });
+    await adapter.listModels();
+    await adapter.listModels();
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the in-flight promise across concurrent callers', async () => {
+    let resolve: (v: unknown) => void = () => {};
+    mocks.mockModelsList.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        })
+    );
+
+    const adapter = createOpenAIAdapter({ modelId: 'gpt-4o', apiKey: 'k' });
+    const a = adapter.listModels();
+    const b = adapter.listModels();
+    resolve({ data: [{ id: 'x', object: 'model', owned_by: 'system' }] });
+    await Promise.all([a, b]);
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on /v1/models error so identity resolver knows to fall back', async () => {
+    mocks.mockModelsList.mockRejectedValue(new Error('endpoint not supported'));
+    const adapter = createOpenAIAdapter({ modelId: 'gpt-4o', apiKey: 'k' });
+    await expect(adapter.listModels()).rejects.toThrow('endpoint not supported');
+  });
+
+  it('handles models without owned_by gracefully', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [{ id: 'mystery-model', object: 'model', created: 1234 }],
+    });
+    const adapter = createOpenAIAdapter({ modelId: 'gpt-4o', apiKey: 'k' });
+    const models = await adapter.listModels();
+    expect(models[0]).toEqual({ id: 'mystery-model', createdAt: 1234 });
+  });
+});

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   CompletionRequest,
   CompletionResponse,
+  ModelMetadata,
   StreamChunk,
   TokenUsage,
 } from '../core/index.js';
@@ -364,7 +365,57 @@ export class OpenAIAdapter extends BaseAdapter {
       model: response.model,
     };
   }
+
+  /**
+   * (#2529) List models served by this OpenAI-compatible endpoint.
+   *
+   * Wraps `GET /v1/models`. Result is cached for `LIST_MODELS_TTL_MS`
+   * so identity resolution doesn't round-trip on every adapter.
+   * Concurrent callers share the in-flight promise.
+   *
+   * Throws on non-2xx so the harness-side identity resolver knows to
+   * fall back to modelId parsing — silent empty-list returns would be
+   * indistinguishable from "this gateway has no models", which a
+   * misconfigured endpoint shouldn't be allowed to claim.
+   */
+  async listModels(): Promise<readonly ModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelsCache !== null && now - this.modelsCache.fetchedAt < LIST_MODELS_TTL_MS) {
+      return this.modelsCache.value;
+    }
+    if (this.modelsInFlight !== null) {
+      return this.modelsInFlight;
+    }
+    const inFlight = this.fetchModels();
+    this.modelsInFlight = inFlight;
+    try {
+      const value = await inFlight;
+      this.modelsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } finally {
+      this.modelsInFlight = null;
+    }
+  }
+
+  private modelsCache: { value: readonly ModelMetadata[]; fetchedAt: number } | null = null;
+  private modelsInFlight: Promise<readonly ModelMetadata[]> | null = null;
+
+  private async fetchModels(): Promise<readonly ModelMetadata[]> {
+    const list = await this.client.models.list();
+    return list.data.map((m): ModelMetadata => {
+      const meta: ModelMetadata = { id: m.id };
+      if (typeof m.owned_by === 'string') {
+        return { ...meta, ownedBy: m.owned_by, createdAt: m.created };
+      }
+      if (typeof m.created === 'number') {
+        return { ...meta, createdAt: m.created };
+      }
+      return meta;
+    });
+  }
 }
+
+const LIST_MODELS_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Creates an OpenAIAdapter with the specified configuration.

--- a/packages/nexus-agents/src/config/model-behavior-profile.test.ts
+++ b/packages/nexus-agents/src/config/model-behavior-profile.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the model behaviour profile lookup (#2529).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { resolveModelIdentitySync } from './model-identity.js';
+import {
+  DEFAULT_PROFILE,
+  lookupModelProfile,
+  lookupProfileFromModelId,
+} from './model-behavior-profile.js';
+
+describe('lookupModelProfile — vendor inheritance', () => {
+  it('claude-sonnet inherits anthropic-default + claude-sonnet family is identity', () => {
+    const profile = lookupProfileFromModelId('claude-sonnet-4-6');
+    // Anthropic: parallel tools on, ephemeral caching, anthropic format
+    expect(profile.parallelToolCalls).toBe(true);
+    expect(profile.promptCaching).toBe('ephemeral');
+    expect(profile.toolDefinitionFormat).toBe('anthropic');
+  });
+
+  it('claude-opus uses opus family override (higher turn budget)', () => {
+    const profile = lookupProfileFromModelId('claude-opus-4-1');
+    expect(profile.profileId).toBe('claude-opus');
+    expect(profile.maxRecommendedTurnBudget).toBe(20);
+  });
+
+  it('claude-haiku uses haiku family override (lower turn budget)', () => {
+    const profile = lookupProfileFromModelId('claude-haiku-4');
+    expect(profile.profileId).toBe('claude-haiku');
+    expect(profile.maxRecommendedTurnBudget).toBe(8);
+  });
+
+  it('gpt-4o uses openai-default profile', () => {
+    const profile = lookupProfileFromModelId('gpt-4o');
+    expect(profile.profileId).toBe('openai-default');
+    expect(profile.parallelToolCalls).toBe(true);
+    expect(profile.toolDefinitionFormat).toBe('openai');
+  });
+
+  it('o1-preview uses o-reasoning profile (higher turn budget)', () => {
+    const profile = lookupProfileFromModelId('o1-preview');
+    expect(profile.profileId).toBe('openai-o-reasoning');
+    expect(profile.maxRecommendedTurnBudget).toBe(25);
+  });
+
+  it('gemini-flash uses gemini-flash profile (lower budget, gemini format)', () => {
+    const profile = lookupProfileFromModelId('gemini-2.0-flash');
+    expect(profile.profileId).toBe('gemini-flash');
+    expect(profile.toolDefinitionFormat).toBe('gemini');
+    expect(profile.maxRecommendedTurnBudget).toBe(8);
+  });
+
+  it('llama uses meta-default with sequential tools', () => {
+    const profile = lookupProfileFromModelId('meta-llama/llama-3.3-70b-instruct');
+    expect(profile.profileId).toBe('meta-default');
+    expect(profile.parallelToolCalls).toBe(false);
+    expect(profile.toolDefinitionFormat).toBe('openai');
+  });
+
+  it('nemotron uses nvidia-nemotron-default', () => {
+    const profile = lookupProfileFromModelId('nemotron-70b');
+    expect(profile.profileId).toBe('nvidia-nemotron-default');
+    expect(profile.parallelToolCalls).toBe(false);
+  });
+
+  it('unknown vendor falls back to default profile', () => {
+    const profile = lookupProfileFromModelId('mystery-fast-model');
+    expect(profile.profileId).toBe('default');
+    expect(profile).toEqual(DEFAULT_PROFILE);
+  });
+});
+
+describe('lookupModelProfile — quirk overlay', () => {
+  it('thinking quirk bumps turn budget by 1.5x', () => {
+    const identity = resolveModelIdentitySync('claude-opus-4-1-thinking');
+    const profile = lookupModelProfile(identity);
+    // Base claude-opus is 20; thinking → ceil(20 * 1.5) = 30
+    expect(profile.maxRecommendedTurnBudget).toBe(30);
+    expect(profile.quirks).toContain('thinking');
+  });
+
+  it('embedding quirk propagates so AgenticAdapter can refuse', () => {
+    const identity = resolveModelIdentitySync('text-embedding-3-large');
+    const profile = lookupModelProfile(identity);
+    expect(profile.quirks).toContain('embedding');
+  });
+
+  it('quirks merge across identity + profile', () => {
+    const identity = resolveModelIdentitySync('gpt-4o-mini');
+    const profile = lookupModelProfile(identity);
+    // gpt-4o family has no extra quirks; identity quirks are 'small'
+    expect(profile.quirks).toContain('small');
+  });
+});
+
+describe('lookupModelProfile — hint-driven', () => {
+  it('hints can force a profile (e.g., gateway-renamed model)', () => {
+    const identity = resolveModelIdentitySync('workspace-prod-1', {
+      vendor: 'anthropic',
+      family: 'claude-opus',
+    });
+    const profile = lookupModelProfile(identity);
+    expect(profile.profileId).toBe('claude-opus');
+  });
+});

--- a/packages/nexus-agents/src/config/model-behavior-profile.ts
+++ b/packages/nexus-agents/src/config/model-behavior-profile.ts
@@ -1,0 +1,281 @@
+/**
+ * Per-model behaviour profiles (#2529).
+ *
+ * Once `resolveModelIdentity` has classified a served model, this
+ * module looks up the behaviour profile that drives the
+ * `AgenticAdapter` loop — parallel-vs-sequential tool execution,
+ * prompt-caching opt-in, tool-format translation, JSON-strictness on
+ * response parsing, recommended turn budget.
+ *
+ * Profiles are pattern-inherited:
+ *
+ *   `claude-opus`  ← `claude-*`  ← `anthropic-*`  ← `default`
+ *
+ * Adding a new model variant doesn't need a new profile — pattern
+ * matching at `vendor + family` level covers any future
+ * `claude-opus-5`, `gpt-5o`, etc.
+ *
+ * The active profile = layered overlay:
+ *
+ *   `modelHints` overrides → outcome-driven adjustments (future) →
+ *   manifest overrides (future) → in-tree pattern-matched defaults
+ *
+ * For v1 only the in-tree defaults + modelHints are wired; the
+ * other two layers land in PR C of the #2529 plan.
+ *
+ * @module config/model-behavior-profile
+ */
+
+import {
+  resolveModelIdentitySync,
+  type ResolvedModelIdentity,
+  type ModelVendor,
+} from './model-identity.js';
+
+/**
+ * Tool-definition format the model expects in `CompletionRequest.tools`.
+ * Each `IModelAdapter` already translates from the canonical
+ * `ToolDefinition` shape into the provider's native form, so this
+ * field is informational for now — but lets us record cross-provider
+ * differences explicitly.
+ */
+export type ToolDefinitionFormat = 'openai' | 'anthropic' | 'gemini';
+
+/**
+ * How aggressively the agentic adapter should opt into prompt
+ * caching. `'none'` = never set caching markers. `'ephemeral'` =
+ * mark tool definitions as `cache_control: ephemeral` (Anthropic
+ * only; harmless on other providers because the canonical request
+ * shape strips unsupported fields). `'aggressive'` = also cache the
+ * system prompt + recent assistant turns. Reserved.
+ */
+export type PromptCachingMode = 'none' | 'ephemeral' | 'aggressive';
+
+/**
+ * Profile that parameterises the agent loop's behaviour.
+ *
+ * Every field has a sensible default in the `DEFAULT_PROFILE` constant
+ * below; per-vendor and per-family profiles override only the fields
+ * they care about (lookup merges with inheritance).
+ */
+export interface ModelBehaviorProfile {
+  /**
+   * Run multiple `tool_use` blocks from one assistant turn in parallel
+   * (`Promise.all`) when true, sequentially when false. OpenAI tool
+   * use is parallel-friendly; Anthropic batches but expects sequential
+   * tool execution semantics. Defaults to `false` (safer everywhere).
+   */
+  readonly parallelToolCalls: boolean;
+  /**
+   * Prompt-caching opt-in level. `'none'` is safe everywhere;
+   * `'ephemeral'` adds Anthropic-style markers that other providers
+   * ignore.
+   */
+  readonly promptCaching: PromptCachingMode;
+  /**
+   * Provider-native tool-definition format. Informational at v1 (each
+   * IModelAdapter already translates), but recorded so behaviour
+   * differences are auditable in eval logs.
+   */
+  readonly toolDefinitionFormat: ToolDefinitionFormat;
+  /** Soft recommendation; harnesses can override. */
+  readonly maxRecommendedTurnBudget: number;
+  /**
+   * Strict JSON parsing on tool-call arguments. Some smaller models
+   * emit single-quoted JSON or trailing commas; setting this to
+   * `false` would enable a lenient parser. v1 always uses strict
+   * JSON; the field exists so PR C's outcome-driven adjustment can
+   * flip it without an API change.
+   */
+  readonly strictJson: boolean;
+  /**
+   * Free-form quirk hints applied to this profile — `'reasoning'`,
+   * `'embedding'`, `'gateway-renamed'`, etc. Mostly informational at
+   * v1 except `'embedding'` which the adapter uses to refuse to
+   * construct (agent loop is meaningless on an embedding model).
+   */
+  readonly quirks: readonly string[];
+  /** Profile id, useful for logs and observability. */
+  readonly profileId: string;
+}
+
+/**
+ * Default profile — applied when nothing more specific matches. Safe
+ * everywhere: sequential tool calls, no caching, OpenAI-format tool
+ * defs (de facto standard), strict JSON.
+ */
+export const DEFAULT_PROFILE: ModelBehaviorProfile = {
+  parallelToolCalls: false,
+  promptCaching: 'none',
+  toolDefinitionFormat: 'openai',
+  maxRecommendedTurnBudget: 10,
+  strictJson: true,
+  quirks: [],
+  profileId: 'default',
+};
+
+// ============================================================================
+// Per-vendor + per-family profiles (sparse — each row overrides only
+// the fields it cares about; lookup merges with DEFAULT_PROFILE).
+// ============================================================================
+
+type ProfileOverride = Partial<Omit<ModelBehaviorProfile, 'profileId'>> & {
+  readonly profileId: string;
+};
+
+const VENDOR_PROFILES: Partial<Record<ModelVendor, ProfileOverride>> = {
+  anthropic: {
+    profileId: 'anthropic-default',
+    promptCaching: 'ephemeral',
+    toolDefinitionFormat: 'anthropic',
+    parallelToolCalls: true, // Claude 4.x supports parallel tool_use blocks
+    maxRecommendedTurnBudget: 15,
+  },
+  openai: {
+    profileId: 'openai-default',
+    parallelToolCalls: true,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 15,
+  },
+  google: {
+    profileId: 'google-default',
+    toolDefinitionFormat: 'gemini',
+    parallelToolCalls: true,
+    maxRecommendedTurnBudget: 15,
+  },
+  meta: {
+    profileId: 'meta-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false, // many open-weight Llamas struggle with parallel tools
+    maxRecommendedTurnBudget: 8,
+  },
+  qwen: {
+    profileId: 'qwen-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false,
+    maxRecommendedTurnBudget: 8,
+  },
+  nvidia: {
+    profileId: 'nvidia-nemotron-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false,
+    maxRecommendedTurnBudget: 8,
+  },
+  mistral: {
+    profileId: 'mistral-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false,
+    maxRecommendedTurnBudget: 8,
+  },
+  cohere: {
+    profileId: 'cohere-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false,
+    maxRecommendedTurnBudget: 8,
+  },
+  deepseek: {
+    profileId: 'deepseek-default',
+    toolDefinitionFormat: 'openai',
+    parallelToolCalls: false,
+    maxRecommendedTurnBudget: 10,
+  },
+};
+
+/** Family-level overrides — keyed `<family-name>` with `vendor` filter. */
+interface FamilyProfileEntry {
+  readonly vendor: ModelVendor;
+  readonly family: string;
+  readonly override: ProfileOverride;
+}
+
+const FAMILY_PROFILES: readonly FamilyProfileEntry[] = [
+  {
+    vendor: 'anthropic',
+    family: 'claude-opus',
+    override: { profileId: 'claude-opus', maxRecommendedTurnBudget: 20 },
+  },
+  {
+    vendor: 'anthropic',
+    family: 'claude-haiku',
+    override: { profileId: 'claude-haiku', maxRecommendedTurnBudget: 8 },
+  },
+  {
+    vendor: 'openai',
+    family: 'o-reasoning',
+    override: {
+      profileId: 'openai-o-reasoning',
+      // o1-style reasoning models burn extra turns thinking; recommend
+      // a higher budget. They also don't support `temperature`.
+      maxRecommendedTurnBudget: 25,
+    },
+  },
+  {
+    vendor: 'google',
+    family: 'gemini-flash',
+    override: { profileId: 'gemini-flash', maxRecommendedTurnBudget: 8 },
+  },
+];
+
+// ============================================================================
+// Lookup
+// ============================================================================
+
+/**
+ * Resolve a behaviour profile for a model identity.
+ *
+ * Inheritance order (least → most specific):
+ *   `DEFAULT_PROFILE` → vendor profile → family profile → quirks overlay
+ *
+ * Quirks contribute small overrides:
+ *   - `'embedding'` → flag `embedding` quirk on result, retain other
+ *     fields; `AgenticAdapter` checks for this and refuses to construct
+ *   - `'thinking'` → bump `maxRecommendedTurnBudget` by 1.5x
+ */
+export function lookupModelProfile(identity: ResolvedModelIdentity): ModelBehaviorProfile {
+  let profile: ModelBehaviorProfile = { ...DEFAULT_PROFILE };
+
+  const vendorOverride = VENDOR_PROFILES[identity.vendor];
+  if (vendorOverride !== undefined) profile = mergeProfile(profile, vendorOverride);
+
+  const familyOverride = FAMILY_PROFILES.find(
+    (e) => e.vendor === identity.vendor && e.family === identity.family
+  );
+  if (familyOverride !== undefined) profile = mergeProfile(profile, familyOverride.override);
+
+  profile = applyQuirkOverlay(profile, identity.quirks);
+
+  return profile;
+}
+
+function mergeProfile(base: ModelBehaviorProfile, override: ProfileOverride): ModelBehaviorProfile {
+  // Override always wins; profileId from override.
+  return {
+    ...base,
+    ...override,
+  };
+}
+
+function applyQuirkOverlay(
+  profile: ModelBehaviorProfile,
+  identityQuirks: readonly string[]
+): ModelBehaviorProfile {
+  if (identityQuirks.length === 0) return profile;
+  const merged = new Set<string>([...profile.quirks, ...identityQuirks]);
+  let maxBudget = profile.maxRecommendedTurnBudget;
+  if (identityQuirks.includes('thinking')) {
+    maxBudget = Math.ceil(maxBudget * 1.5);
+  }
+  return {
+    ...profile,
+    quirks: [...merged],
+    maxRecommendedTurnBudget: maxBudget,
+  };
+}
+
+/**
+ * Convenience: skip the `ResolvedModelIdentity` round-trip when the
+ * caller has a model id string and just wants a profile.
+ */
+export function lookupProfileFromModelId(modelId: string): ModelBehaviorProfile {
+  return lookupModelProfile(resolveModelIdentitySync(modelId));
+}

--- a/packages/nexus-agents/src/config/model-identity.test.ts
+++ b/packages/nexus-agents/src/config/model-identity.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the model-identity resolver (#2529).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { ok } from '../core/index.js';
+import type { IModelAdapter, ModelMetadata } from '../core/types/model.js';
+
+import { parseModelId, resolveModelIdentity, resolveModelIdentitySync } from './model-identity.js';
+
+function makeAdapter(
+  modelId: string,
+  listModels?: () => Promise<readonly ModelMetadata[]>
+): IModelAdapter {
+  return {
+    providerId: 'openai',
+    modelId,
+    capabilities: [],
+    complete: vi.fn() as never,
+    stream: (() => (async function* () {})()) as never,
+    countTokens: () => Promise.resolve(0),
+    validateConfig: () => ok(undefined),
+    ...(listModels !== undefined && { listModels }),
+  };
+}
+
+describe('parseModelId — clean upstream names', () => {
+  it('classifies claude-sonnet-4-6', () => {
+    const r = parseModelId('claude-sonnet-4-6');
+    expect(r.vendor).toBe('anthropic');
+    expect(r.family).toBe('claude-sonnet');
+    expect(r.version).toBe('4-6');
+  });
+
+  it('classifies gpt-4o', () => {
+    const r = parseModelId('gpt-4o');
+    expect(r.vendor).toBe('openai');
+    expect(r.family).toBe('gpt-4o');
+  });
+
+  it('classifies gemini-2.0-flash', () => {
+    const r = parseModelId('gemini-2.0-flash');
+    expect(r.vendor).toBe('google');
+    expect(r.family).toBe('gemini-flash');
+  });
+
+  it('classifies o1-preview as reasoning', () => {
+    const r = parseModelId('o1-preview');
+    expect(r.vendor).toBe('openai');
+    expect(r.family).toBe('o-reasoning');
+  });
+
+  it('classifies o3-mini as reasoning', () => {
+    const r = parseModelId('o3-mini');
+    expect(r.vendor).toBe('openai');
+    expect(r.family).toBe('o-reasoning');
+    expect(r.quirks).toContain('small');
+  });
+});
+
+describe('parseModelId — vendor-prefixed', () => {
+  it('classifies anthropic/claude-sonnet-4-6', () => {
+    const r = parseModelId('anthropic/claude-sonnet-4-6');
+    expect(r.vendor).toBe('anthropic');
+    expect(r.family).toBe('claude-sonnet');
+  });
+
+  it('classifies meta-llama/llama-3.3-70b-instruct', () => {
+    const r = parseModelId('meta-llama/llama-3.3-70b-instruct');
+    expect(r.vendor).toBe('meta');
+    expect(r.family).toBe('llama-3');
+    expect(r.quirks).toContain('instruct');
+    expect(r.quirks).toContain('sized-suffix');
+  });
+});
+
+describe('parseModelId — wild names', () => {
+  it('handles 2025-claude-opus-4_0_high', () => {
+    const r = parseModelId('2025-claude-opus-4_0_high');
+    expect(r.vendor).toBe('anthropic');
+    expect(r.family).toBe('claude-opus');
+    expect(r.quirks).toContain('high-variant');
+  });
+
+  it('handles workspace-claude-prod (gateway-renamed, no family signal)', () => {
+    const r = parseModelId('workspace-claude-prod');
+    expect(r.vendor).toBe('anthropic');
+    expect(r.family).toBeUndefined();
+  });
+
+  it('handles gpt-4o-mini-2024-08', () => {
+    const r = parseModelId('gpt-4o-mini-2024-08');
+    expect(r.vendor).toBe('openai');
+    expect(r.family).toBe('gpt-4o');
+    expect(r.quirks).toContain('small');
+  });
+
+  it('flags text-embedding-3-large as embedding (not chat)', () => {
+    const r = parseModelId('text-embedding-3-large');
+    expect(r.quirks).toContain('embedding');
+    expect(r.quirks).toContain('large');
+  });
+
+  it('handles nemotron-70b', () => {
+    const r = parseModelId('nemotron-70b');
+    expect(r.vendor).toBe('nvidia');
+  });
+
+  it('handles internal-fast-model (totally opaque)', () => {
+    const r = parseModelId('internal-fast-model');
+    expect(r.vendor).toBeUndefined();
+    expect(r.family).toBeUndefined();
+  });
+
+  it('handles claude-3-5-sonnet-20241022', () => {
+    const r = parseModelId('claude-3-5-sonnet-20241022');
+    expect(r.vendor).toBe('anthropic');
+    expect(r.family).toBe('claude-sonnet');
+    expect(r.quirks).toContain('dated');
+  });
+
+  it('detects thinking quirk', () => {
+    const r = parseModelId('claude-opus-4-1-thinking');
+    expect(r.quirks).toContain('thinking');
+  });
+
+  it('detects coder quirk', () => {
+    const r = parseModelId('qwen-2.5-coder-32b-instruct');
+    expect(r.vendor).toBe('qwen');
+    expect(r.quirks).toContain('coder');
+    expect(r.quirks).toContain('instruct');
+  });
+
+  it('handles mixtral-8x22b-instruct-v0.1', () => {
+    const r = parseModelId('mixtral-8x22b-instruct-v0.1');
+    expect(r.vendor).toBe('mistral');
+    expect(r.family).toBe('mixtral');
+  });
+
+  it('handles command-r-plus-2024-08', () => {
+    const r = parseModelId('command-r-plus-2024-08');
+    expect(r.vendor).toBe('cohere');
+  });
+});
+
+describe('parseModelId — no false positives', () => {
+  it('does not match claudia (only claude with word boundary)', () => {
+    const r = parseModelId('claudia-7b');
+    expect(r.vendor).toBeUndefined();
+  });
+
+  it('does not match opus inside an unrelated model', () => {
+    const r = parseModelId('llama-opus-music-7b');
+    // Vendor wins on llama. Family lookup is scoped to vendor=meta:
+    // there's no `llama-3` substring here, so family is undefined.
+    // The point of this test: 'opus' (which matches claude-opus
+    // family for vendor=anthropic) does NOT leak across vendor.
+    expect(r.vendor).toBe('meta');
+    expect(r.family).toBeUndefined();
+  });
+});
+
+describe('resolveModelIdentity — async with probe', () => {
+  it('calls listModels and uses owned_by when adapter exposes it', async () => {
+    const listModels = vi.fn(() =>
+      Promise.resolve([{ id: 'opaque', ownedBy: 'anthropic-research' }] as readonly ModelMetadata[])
+    );
+    const adapter = makeAdapter('opaque', listModels);
+    const identity = await resolveModelIdentity(adapter);
+    expect(identity.vendor).toBe('anthropic');
+    expect(identity.source).toBe('probe');
+  });
+
+  it('falls back to modelId parse when probe fails', async () => {
+    const listModels = vi.fn(() => {
+      throw new Error('endpoint not supported');
+    });
+    const adapter = makeAdapter('claude-opus-4-6', listModels);
+    const identity = await resolveModelIdentity(adapter);
+    expect(identity.vendor).toBe('anthropic');
+    expect(identity.source).toBe('modelIdParse');
+  });
+
+  it('falls back to modelId parse when adapter has no listModels', async () => {
+    const adapter = makeAdapter('claude-sonnet-4-6');
+    const identity = await resolveModelIdentity(adapter);
+    expect(identity.vendor).toBe('anthropic');
+    expect(identity.source).toBe('modelIdParse');
+  });
+
+  it('respects skipProbe option', async () => {
+    const listModels = vi.fn(() => Promise.resolve([] as readonly ModelMetadata[]));
+    const adapter = makeAdapter('claude-sonnet-4-6', listModels);
+    const identity = await resolveModelIdentity(adapter, { skipProbe: true });
+    expect(listModels).not.toHaveBeenCalled();
+    expect(identity.source).toBe('modelIdParse');
+  });
+
+  it('hints override probe and parse', async () => {
+    const listModels = vi.fn(() =>
+      Promise.resolve([{ id: 'm', ownedBy: 'meta' }] as readonly ModelMetadata[])
+    );
+    const adapter = makeAdapter('claude-opus', listModels);
+    const identity = await resolveModelIdentity(adapter, {
+      hints: { vendor: 'cohere' },
+    });
+    expect(identity.vendor).toBe('cohere');
+    expect(identity.source).toBe('modelHints');
+  });
+
+  it('hints fill only specified fields; others fall through', async () => {
+    const adapter = makeAdapter('claude-opus-4-6');
+    const identity = await resolveModelIdentity(adapter, {
+      hints: { quirks: ['custom-tag'] },
+    });
+    expect(identity.vendor).toBe('anthropic');
+    expect(identity.family).toBe('claude-opus');
+    expect(identity.quirks).toContain('custom-tag');
+  });
+
+  it('returns unknown vendor + family for opaque model with no probe', async () => {
+    const adapter = makeAdapter('mystery-fast-7');
+    const identity = await resolveModelIdentity(adapter);
+    expect(identity.vendor).toBe('unknown');
+    expect(identity.family).toBe('unknown');
+    expect(identity.source).toBe('default');
+  });
+
+  it('records rawModelId regardless of source', async () => {
+    const adapter = makeAdapter('weird-string-23');
+    const identity = await resolveModelIdentity(adapter);
+    expect(identity.rawModelId).toBe('weird-string-23');
+  });
+});
+
+describe('resolveModelIdentitySync', () => {
+  it('produces same result as async without probe', () => {
+    const sync = resolveModelIdentitySync('gpt-4o');
+    expect(sync.vendor).toBe('openai');
+    expect(sync.family).toBe('gpt-4o');
+    expect(sync.source).toBe('modelIdParse');
+  });
+
+  it('honors hints', () => {
+    const sync = resolveModelIdentitySync('whatever', { vendor: 'cohere' });
+    expect(sync.vendor).toBe('cohere');
+    expect(sync.source).toBe('modelHints');
+  });
+});

--- a/packages/nexus-agents/src/config/model-identity.ts
+++ b/packages/nexus-agents/src/config/model-identity.ts
@@ -1,0 +1,393 @@
+/**
+ * Dynamic model-identity resolver (#2529).
+ *
+ * Real-world `modelId` strings are messy:
+ *   - clean upstream: `claude-sonnet-4-6`, `gpt-4o`, `gemini-2.0-flash`
+ *   - vendor-prefixed: `anthropic/claude-sonnet-4-6`, `meta-llama/llama-3.3-70b`
+ *   - dated: `claude-3-5-sonnet-20241022`, `gpt-4o-2024-08-06`
+ *   - operator-renamed: `2025-claude-opus-4_0_high`, `workspace-claude-prod`
+ *   - opaque: `internal-fast-model`
+ *
+ * This module turns any of those into a `ResolvedModelIdentity` —
+ * vendor + family + version + capability hints — so the
+ * agentic-adapter layer can pick a behaviour profile based on the
+ * actual served model, NOT on `IModelAdapter.providerId` (which for a
+ * custom OpenAI gateway is always `openai` regardless of what model
+ * the gateway is fronting).
+ *
+ * Resolution priority (highest first):
+ *   1. operator `modelHints` — explicit override at construction
+ *   2. probe of `IModelAdapter.listModels()` — `owned_by` field
+ *   3. modelId-string parse — fuzzy regex table on the normalised id
+ *   4. `unknown` defaults
+ *
+ * Each layer fills only the fields its higher-priority neighbour left
+ * blank, so an operator can hint `{ vendor: 'anthropic' }` and still
+ * let `family` come from the probe / parse.
+ *
+ * @module config/model-identity
+ */
+
+import type { IModelAdapter, ModelMetadata } from '../core/types/model.js';
+
+/** Coarse vendor bucket — drives behaviour-profile lookup downstream. */
+export type ModelVendor =
+  | 'anthropic'
+  | 'openai'
+  | 'google'
+  | 'meta'
+  | 'qwen'
+  | 'nvidia'
+  | 'mistral'
+  | 'cohere'
+  | 'deepseek'
+  | 'unknown';
+
+/**
+ * Family inside a vendor — `claude-opus`, `claude-sonnet`, `gpt-4o`,
+ * `gemini-flash`, `llama-3`, etc. `unknown` when we recognised the
+ * vendor but not the specific family (e.g., gateway-renamed model).
+ */
+export type ModelFamily = string;
+
+/** Where each piece of the resolved identity came from — useful for audit logs. */
+export type IdentitySource = 'modelHints' | 'probe' | 'modelIdParse' | 'default';
+
+/**
+ * Resolved identity for a served model. Returned by `resolveModelIdentity`.
+ *
+ * The `quirks` array carries free-form capability hints lifted from
+ * the modelId string — `'embedding'` to flag non-chat models,
+ * `'thinking'` for reasoning variants, `'vision'`, `'mini'`, `'high'`,
+ * etc. Behaviour profiles consult this to override their defaults.
+ */
+export interface ResolvedModelIdentity {
+  readonly vendor: ModelVendor;
+  readonly family: ModelFamily;
+  readonly version?: string;
+  readonly quirks: readonly string[];
+  readonly source: IdentitySource;
+  readonly rawModelId: string;
+}
+
+/** Operator-supplied identity overrides. Any field forces; others fall through. */
+export interface ModelHints {
+  readonly vendor?: ModelVendor;
+  readonly family?: ModelFamily;
+  readonly version?: string;
+  readonly quirks?: readonly string[];
+}
+
+/** Options for the resolver. Probe is on by default; `skipProbe: true` opts out. */
+export interface ResolveModelIdentityOptions {
+  readonly hints?: ModelHints;
+  readonly skipProbe?: boolean;
+}
+
+// ============================================================================
+// Pattern table — vendor + family detection from the normalised modelId
+// ============================================================================
+
+interface VendorPattern {
+  readonly vendor: ModelVendor;
+  readonly regex: RegExp;
+}
+
+/**
+ * Vendor-detection patterns. `\b` word boundary matters here — without
+ * it, `claudia-7b` would match the `claude` vendor. With it,
+ * `2025-claude-opus-4` (after normalisation: `2025-claude-opus-4`)
+ * matches because the leading `-` and trailing `-` are non-word.
+ */
+const VENDOR_PATTERNS: readonly VendorPattern[] = [
+  { vendor: 'anthropic', regex: /\b(claude|anthropic)\b/ },
+  // OpenAI: gpt, o1-o9 reasoning, chatgpt, openai prefix
+  { vendor: 'openai', regex: /\b(gpt|o[1-9]|chatgpt|openai)\b/ },
+  { vendor: 'google', regex: /\b(gemini|bison|gecko|palm|google)\b/ },
+  { vendor: 'meta', regex: /\b(llama|meta-llama|meta)\b/ },
+  { vendor: 'qwen', regex: /\b(qwen)\b/ },
+  { vendor: 'nvidia', regex: /\b(nemotron|nvidia)\b/ },
+  { vendor: 'mistral', regex: /\b(mistral|mixtral|codestral)\b/ },
+  { vendor: 'cohere', regex: /\b(command-r|command|cohere)\b/ },
+  { vendor: 'deepseek', regex: /\b(deepseek)\b/ },
+];
+
+interface FamilyPattern {
+  readonly vendor: ModelVendor;
+  readonly family: string;
+  readonly regex: RegExp;
+}
+
+/**
+ * Family-detection patterns. Vendor-scoped — only consulted after the
+ * vendor is known. Order matters: more specific patterns come first
+ * (`gpt-4o` before `gpt-4`).
+ */
+const FAMILY_PATTERNS: readonly FamilyPattern[] = [
+  // Anthropic
+  { vendor: 'anthropic', family: 'claude-opus', regex: /\b(opus)\b/ },
+  { vendor: 'anthropic', family: 'claude-sonnet', regex: /\b(sonnet)\b/ },
+  { vendor: 'anthropic', family: 'claude-haiku', regex: /\b(haiku)\b/ },
+  // OpenAI
+  { vendor: 'openai', family: 'o-reasoning', regex: /\bo[1-9]\b/ },
+  { vendor: 'openai', family: 'gpt-4o', regex: /\b(gpt-4o|gpt4o|4o)\b/ },
+  { vendor: 'openai', family: 'gpt-4', regex: /\b(gpt-4)\b/ },
+  { vendor: 'openai', family: 'gpt-3.5', regex: /\b(gpt-3-5|gpt-3\.5|gpt35)\b/ },
+  // Google
+  { vendor: 'google', family: 'gemini-pro', regex: /\bgemini.*\bpro\b/ },
+  { vendor: 'google', family: 'gemini-flash', regex: /\bgemini.*\bflash\b/ },
+  { vendor: 'google', family: 'gemini', regex: /\bgemini\b/ },
+  // Meta
+  { vendor: 'meta', family: 'llama-3', regex: /\bllama-?3\b/ },
+  { vendor: 'meta', family: 'llama-2', regex: /\bllama-?2\b/ },
+  // Qwen — version is in the family name
+  { vendor: 'qwen', family: 'qwen-3', regex: /\bqwen-?3\b/ },
+  { vendor: 'qwen', family: 'qwen-2.5', regex: /\bqwen-?2-?5\b/ },
+  { vendor: 'qwen', family: 'qwen-2', regex: /\bqwen-?2\b/ },
+  // Mistral
+  { vendor: 'mistral', family: 'mixtral', regex: /\bmixtral\b/ },
+  { vendor: 'mistral', family: 'codestral', regex: /\bcodestral\b/ },
+  { vendor: 'mistral', family: 'mistral', regex: /\bmistral\b/ },
+];
+
+/**
+ * Quirk hints lifted from the normalised id. Detected after vendor
+ * resolution so they're free of false positives ("opus" inside a
+ * Llama name won't trigger).
+ */
+const QUIRK_PATTERNS: ReadonlyArray<{ regex: RegExp; quirk: string }> = [
+  { regex: /\b(embedding|embed)\b/, quirk: 'embedding' },
+  { regex: /\b(thinking|reasoning)\b/, quirk: 'thinking' },
+  { regex: /\bvision\b/, quirk: 'vision' },
+  { regex: /\b(coder|code)\b/, quirk: 'coder' },
+  { regex: /\binstruct\b/, quirk: 'instruct' },
+  { regex: /\b(mini|nano|tiny|small|lite)\b/, quirk: 'small' },
+  { regex: /\b(large|xl|big|maxi)\b/, quirk: 'large' },
+  { regex: /\bhigh\b/, quirk: 'high-variant' },
+  { regex: /\b(\d+)b\b/, quirk: 'sized-suffix' }, // 7b, 70b, 405b
+  { regex: /\b\d{8}\b/, quirk: 'dated' }, // 20240806 etc
+];
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Resolve a model adapter to a canonical identity. Always succeeds —
+ * unknown models get `vendor: 'unknown'`, `family: 'unknown'`.
+ *
+ * @param adapter - the model adapter being identified
+ * @param options - operator hints + probe controls
+ */
+export async function resolveModelIdentity(
+  adapter: IModelAdapter,
+  options: ResolveModelIdentityOptions = {}
+): Promise<ResolvedModelIdentity> {
+  const rawModelId = adapter.modelId;
+  const hints = options.hints ?? {};
+  let probe: ProbeResult | undefined;
+  if (options.skipProbe !== true && typeof adapter.listModels === 'function') {
+    probe = await runProbe(adapter, rawModelId);
+  }
+  const parsed = parseModelId(rawModelId);
+
+  return mergeIdentity({ rawModelId, hints, probe, parsed });
+}
+
+/**
+ * Sync variant: skip the probe and resolve from `modelId` only.
+ * Useful in hot paths (per-request routing) where the async probe
+ * latency isn't tolerable. The async `resolveModelIdentity` caches
+ * probe results internally so the perf delta after the first call
+ * is small.
+ */
+export function resolveModelIdentitySync(
+  modelId: string,
+  hints?: ModelHints
+): ResolvedModelIdentity {
+  return mergeIdentity({
+    rawModelId: modelId,
+    hints: hints ?? {},
+    probe: undefined,
+    parsed: parseModelId(modelId),
+  });
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+interface ParseResult {
+  readonly vendor?: ModelVendor;
+  readonly family?: string;
+  readonly version?: string;
+  readonly quirks: readonly string[];
+}
+
+interface ProbeResult {
+  readonly vendor?: ModelVendor;
+  readonly metadata?: ModelMetadata;
+}
+
+/**
+ * Parse a modelId string into vendor + family + version hints.
+ * Public for tests; not re-exported from the package.
+ */
+export function parseModelId(modelId: string): ParseResult {
+  const normalised = normaliseModelId(modelId);
+  const vendor = detectVendor(normalised);
+  const family = vendor !== undefined ? detectFamily(normalised, vendor) : undefined;
+  const version =
+    vendor !== undefined && family !== undefined ? extractVersion(normalised, family) : undefined;
+  const quirks = detectQuirks(normalised);
+
+  return {
+    ...(vendor !== undefined && { vendor }),
+    ...(family !== undefined && { family }),
+    ...(version !== undefined && { version }),
+    quirks,
+  };
+}
+
+/**
+ * Lowercase + replace `_` and `/` with `-` so word boundaries land on
+ * the real model-name tokens. Collapses runs of `-` so we don't get
+ * empty tokens from `--`.
+ */
+function normaliseModelId(modelId: string): string {
+  return modelId.toLowerCase().replace(/[_/]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+}
+
+function detectVendor(normalised: string): ModelVendor | undefined {
+  for (const { vendor, regex } of VENDOR_PATTERNS) {
+    if (regex.test(normalised)) return vendor;
+  }
+  return undefined;
+}
+
+function detectFamily(normalised: string, vendor: ModelVendor): string | undefined {
+  for (const fp of FAMILY_PATTERNS) {
+    if (fp.vendor !== vendor) continue;
+    if (fp.regex.test(normalised)) return fp.family;
+  }
+  return undefined;
+}
+
+/**
+ * Pull the version-ish substring after the family — `claude-opus-4-1`
+ * → `4-1`, `gpt-4o-2024-08-06` → `2024-08-06`. Best-effort; many
+ * models won't have a clean post-family numeric run, in which case
+ * we return undefined.
+ */
+function extractVersion(normalised: string, family: string): string | undefined {
+  // Strip vendor prefix if present, then look for a numeric segment
+  // after the family root.
+  const familyRoot = family.replace(/^claude-|^gemini-|^llama-|^qwen-|^gpt-/, '');
+  const idx = normalised.indexOf(familyRoot);
+  if (idx === -1) return undefined;
+  const tail = normalised.slice(idx + familyRoot.length);
+  const m = /^[-]?(\d[\d.\-]*)/.exec(tail);
+  if (m === null) return undefined;
+  return m[1]?.replace(/-+$/, '') ?? undefined;
+}
+
+function detectQuirks(normalised: string): readonly string[] {
+  const out: string[] = [];
+  for (const { regex, quirk } of QUIRK_PATTERNS) {
+    if (regex.test(normalised) && !out.includes(quirk)) out.push(quirk);
+  }
+  return out;
+}
+
+interface ListModelsCapable {
+  listModels: () => Promise<readonly ModelMetadata[]>;
+}
+
+async function runProbe(adapter: IModelAdapter, modelId: string): Promise<ProbeResult | undefined> {
+  try {
+    const capable = adapter as unknown as ListModelsCapable;
+    const models = await capable.listModels();
+    const matched = models.find((m) => m.id === modelId);
+    if (matched === undefined) return undefined;
+    const result: ProbeResult = { metadata: matched };
+    if (matched.ownedBy !== undefined) {
+      const vendor = vendorFromOwnedBy(matched.ownedBy);
+      if (vendor !== undefined) {
+        return { ...result, vendor };
+      }
+    }
+    return result;
+  } catch {
+    // Probe is best-effort. Failure (network, unsupported endpoint,
+    // bad auth) silently falls back to modelId-only resolution.
+    return undefined;
+  }
+}
+
+/**
+ * Map an OpenAI `/v1/models` `owned_by` field to a vendor bucket.
+ * Different gateways report differently — OpenRouter says `anthropic`,
+ * upstream OpenAI says `openai`/`system`/`openai-internal`, vLLM says
+ * the org name. We do conservative substring matching.
+ *
+ * Implemented as a data-driven lookup so the cyclomatic-complexity
+ * check (max 10) doesn't trip on the chain of `if`s.
+ */
+const OWNED_BY_PATTERNS: ReadonlyArray<{ readonly substr: string; readonly vendor: ModelVendor }> =
+  [
+    { substr: 'anthropic', vendor: 'anthropic' },
+    { substr: 'openai', vendor: 'openai' },
+    { substr: 'google', vendor: 'google' },
+    { substr: 'meta', vendor: 'meta' },
+    { substr: 'alibaba', vendor: 'qwen' },
+    { substr: 'qwen', vendor: 'qwen' },
+    { substr: 'nvidia', vendor: 'nvidia' },
+    { substr: 'nemotron', vendor: 'nvidia' },
+    { substr: 'mistral', vendor: 'mistral' },
+    { substr: 'cohere', vendor: 'cohere' },
+    { substr: 'deepseek', vendor: 'deepseek' },
+  ];
+
+function vendorFromOwnedBy(ownedBy: string): ModelVendor | undefined {
+  const lc = ownedBy.toLowerCase();
+  for (const { substr, vendor } of OWNED_BY_PATTERNS) {
+    if (lc.includes(substr)) return vendor;
+  }
+  return undefined;
+}
+
+interface MergeArgs {
+  readonly rawModelId: string;
+  readonly hints: ModelHints;
+  readonly probe: ProbeResult | undefined;
+  readonly parsed: ParseResult;
+}
+
+function mergeIdentity(args: MergeArgs): ResolvedModelIdentity {
+  const { rawModelId, hints, probe, parsed } = args;
+  return {
+    vendor: hints.vendor ?? probe?.vendor ?? parsed.vendor ?? 'unknown',
+    family: hints.family ?? parsed.family ?? 'unknown',
+    ...(pickVersion(hints, parsed) !== undefined && {
+      version: pickVersion(hints, parsed),
+    }),
+    quirks: [...new Set([...(hints.quirks ?? []), ...parsed.quirks])],
+    source: pickSource(hints, probe, parsed),
+    rawModelId,
+  };
+}
+
+function pickVersion(hints: ModelHints, parsed: ParseResult): string | undefined {
+  return hints.version ?? parsed.version;
+}
+
+function pickSource(
+  hints: ModelHints,
+  probe: ProbeResult | undefined,
+  parsed: ParseResult
+): IdentitySource {
+  if (hints.vendor !== undefined) return 'modelHints';
+  if (probe?.vendor !== undefined) return 'probe';
+  if (parsed.vendor !== undefined) return 'modelIdParse';
+  return 'default';
+}

--- a/packages/nexus-agents/src/core/types/index.ts
+++ b/packages/nexus-agents/src/core/types/index.ts
@@ -15,6 +15,7 @@ export type {
   TokenUsage,
   StopReason,
   StreamChunk,
+  ModelMetadata,
 } from './model.js';
 export { ModelCapability } from './model.js';
 

--- a/packages/nexus-agents/src/core/types/model.ts
+++ b/packages/nexus-agents/src/core/types/model.ts
@@ -172,4 +172,43 @@ export interface IModelAdapter {
    * @returns Ok if valid, ConfigError if invalid
    */
   validateConfig(): Result<void, ConfigError>;
+
+  /**
+   * (Optional, #2529) List models served by this adapter's endpoint.
+   *
+   * Implemented by adapters facing OpenAI-compatible endpoints (the
+   * upstream OpenAI API, OpenRouter, vLLM, custom gateways, etc.) —
+   * usually wraps `GET /v1/models`. Result is the harness-side identity
+   * resolver's most-trusted signal for "what model is actually being
+   * served behind this adapter."
+   *
+   * Subprocess-CLI adapters (claude / codex / gemini / opencode) leave
+   * this undefined; identity for those falls back to `modelId` parse.
+   *
+   * Implementations should cache the result for ~5 minutes — operators
+   * shouldn't pay round-trip latency on every resolve. Failures
+   * (network error, endpoint unsupported, auth missing) should throw
+   * so the caller can fall back; do NOT silently return an empty list.
+   */
+  listModels?(): Promise<readonly ModelMetadata[]>;
+}
+
+/**
+ * Metadata for one model served by an OpenAI-compatible endpoint
+ * (#2529). Mirrors the shape of `GET /v1/models`. Most fields are
+ * optional because gateways differ in what they expose.
+ */
+export interface ModelMetadata {
+  /** Stable model id — matches what callers pass as `modelId` to `complete`. */
+  readonly id: string;
+  /** Free-form vendor / org tag. Upstream OpenAI: `openai`/`system`. OpenRouter: `anthropic`/`google`/etc. */
+  readonly ownedBy?: string;
+  /** Unix epoch seconds when the model was created (when the gateway reports it). */
+  readonly createdAt?: number;
+  /** Free-form capability strings the gateway exposes — passthrough, no normalisation. */
+  readonly capabilities?: readonly string[];
+  /** Maximum context window in tokens — populated by gateways that report it (OpenRouter does). */
+  readonly contextLength?: number;
+  /** Pricing — passthrough only. Gateway-defined units. */
+  readonly pricing?: { readonly input?: number; readonly output?: number };
 }


### PR DESCRIPTION
## Summary

Pre-work for the AgenticAdapter to behave per-model rather than per-`IModelAdapter`. Closes the gap that surfaces with custom OpenAI gateways: `providerId='openai'` regardless of whether the gateway is fronting Claude, Llama, Qwen, or a renamed model. With this PR the harness can ask "what's actually being served?" and pick a behaviour profile to match.

## Three layers

### 1. Model identity resolver — `config/model-identity.ts`

Normalises `modelId` (lowercase, `_`/`/` → `-`, collapse runs), then runs:

- **Vendor regex table** with `\b` word boundaries: anthropic, openai (`gpt` + `o[1-9]` reasoning), google, meta, qwen, nvidia (nemotron), mistral (+ mixtral + codestral), cohere, deepseek
- **Family detection** scoped to vendor so `opus` inside a Llama name doesn't cross-vendor: claude-opus / claude-sonnet / claude-haiku, gpt-4o / o-reasoning, gemini-pro / gemini-flash, llama-3, qwen-3, mixtral, codestral, ...
- **Quirk patterns**: embedding / thinking / vision / coder / instruct / small / large / high-variant / sized-suffix / dated

Resolution priority: `modelHints` > `/v1/models` probe > `modelId` parse > `'unknown'` default. Each layer fills only what its higher-priority neighbour left blank.

### 2. Per-model behaviour profile — `config/model-behavior-profile.ts`

Pattern-inherited profiles drive the agent loop:

- `DEFAULT_PROFILE` = safe everywhere (sequential tools, no caching, openai format, strict JSON, 10-turn budget)
- Vendor profiles override: anthropic = ephemeral caching + parallel tools; openai = parallel tools; google = gemini format + parallel; meta/qwen/nvidia/mistral/cohere/deepseek default to sequential
- Family overrides: `claude-opus` 20-turn budget, `claude-haiku` 8, `o-reasoning` 25, `gemini-flash` 8
- Quirk overlay: `thinking` bumps budget 1.5×; `embedding` flagged so `AgenticAdapter` can refuse construction

### 3. `IModelAdapter.listModels?()` optional method

- Wraps `GET /v1/models` for OpenAI-compatible endpoints (the upstream OpenAI API, OpenRouter, vLLM, custom gateways)
- Returns `ModelMetadata[]` with `id` + `ownedBy` + `createdAt` + optional `capabilities` / `contextLength` / `pricing` passthrough
- `OpenAIAdapter` implements with 5-min cache + concurrent-caller promise sharing + throw-on-error (so identity resolver knows to fall back to modelId-only)
- Subprocess-CLI adapters (claude/codex/gemini/opencode) leave it undefined; identity falls back to modelId parse

## Tests

48 new unit tests covering:

- **Wild names**: `2025-claude-opus-4_0_high`, `workspace-claude-prod`, `text-embedding-3-large`, `internal-fast-model`, `mixtral-8x22b-instruct-v0.1`, `command-r-plus-2024-08`, `qwen-2.5-coder-32b-instruct`, `gpt-4o-mini-2024-08`
- **No false positives**: `claudia-7b` ≠ claude vendor; `opus` inside `llama-opus-music-7b` doesn't cross-vendor
- **Async resolver**: probe success / probe failure (silent fallback) / `skipProbe: true` / hints-override / opaque-model-with-no-probe
- **Vendor inheritance** + family overrides + quirk overlay (thinking bumps budget, embedding flagged)
- **listModels**: normalised metadata, cache hit, in-flight promise sharing, throw-on-error, missing `owned_by` gracefully

## What's NOT in this PR

- **PR B** (next): `AgenticAdapter` consumes the profile — replaces `'native:openai'` providerId-based stamping with profile-driven behaviour (`parallelToolCalls`, `promptCaching`, etc.).
- **PR C** (deferred): YAML manifest support + outcome-driven adjustment loop.

## Test plan

- [x] 48 new unit tests, all green
- [x] `pnpm typecheck` clean (full workspace)
- [x] `pnpm build` clean (ESM + DTS)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)