### PR TITLE
feat(agents): agentic adapter consumes per-model profile (#2529 PR B)

### DIFF
--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
@@ -351,4 +351,166 @@ describe('AgenticAdapter', () => {
     if (!result.ok) return;
     expect(result.value.finalContent).toBe('final answer');
   });
+
+  it('refuses to construct for an embedding model', () => {
+    expect(
+      () => new AgenticAdapter(makeMockModel([{}], 'openai', 'text-embedding-3-large'))
+    ).toThrow(/embedding/);
+  });
+
+  it('exposes the resolved profile via getProfile()', () => {
+    const adapter = new AgenticAdapter(makeMockModel([{}], 'anthropic', 'claude-opus-4-1'));
+    const profile = adapter.getProfile();
+    expect(profile.profileId).toBe('claude-opus');
+    expect(profile.parallelToolCalls).toBe(true);
+    expect(profile.promptCaching).toBe('ephemeral');
+    expect(profile.maxRecommendedTurnBudget).toBe(20);
+  });
+
+  it('exposes the resolved identity via getResolvedIdentity()', () => {
+    const adapter = new AgenticAdapter(makeMockModel([{}], 'openai', 'claude-sonnet-4-6'));
+    // providerId='openai' (gateway) but modelId says claude → vendor=anthropic
+    const identity = adapter.getResolvedIdentity();
+    expect(identity.vendor).toBe('anthropic');
+    expect(identity.family).toBe('claude-sonnet');
+  });
+
+  it('strategy stamp uses resolved vendor, not providerId (gateway scenario)', () => {
+    // Custom OpenAI gateway fronting Claude.
+    const adapter = new AgenticAdapter(
+      makeMockModel([{}], 'openai', 'anthropic/claude-sonnet-4-6')
+    );
+    expect(adapter.adapterStrategy).toBe('native:anthropic');
+  });
+
+  it('modelHints override force a different profile', () => {
+    const adapter = new AgenticAdapter(makeMockModel([{}], 'openai', 'mystery-model'), {
+      modelHints: { vendor: 'anthropic', family: 'claude-opus' },
+    });
+    expect(adapter.getProfile().profileId).toBe('claude-opus');
+    expect(adapter.adapterStrategy).toBe('native:anthropic');
+  });
+
+  it('forceProfile bypasses identity-driven lookup', () => {
+    const customProfile = {
+      parallelToolCalls: false,
+      promptCaching: 'none' as const,
+      toolDefinitionFormat: 'openai' as const,
+      maxRecommendedTurnBudget: 99,
+      strictJson: true,
+      quirks: [],
+      profileId: 'test-custom',
+    };
+    const adapter = new AgenticAdapter(makeMockModel([{}], 'anthropic', 'claude-opus-4-1'), {
+      forceProfile: customProfile,
+    });
+    expect(adapter.getProfile().profileId).toBe('test-custom');
+    expect(adapter.getProfile().maxRecommendedTurnBudget).toBe(99);
+  });
+
+  it('parallel tool calls run via Promise.all when profile says so', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [
+          {
+            content: [
+              { type: 'tool_use', id: 'a', name: 'lookup', input: { id: '1' } },
+              { type: 'tool_use', id: 'b', name: 'lookup', input: { id: '2' } },
+              { type: 'tool_use', id: 'c', name: 'lookup', input: { id: '3' } },
+            ] as ContentBlock[],
+            stopReason: 'tool_use',
+          },
+          { content: [{ type: 'text', text: 'done' }], stopReason: 'end_turn' },
+        ],
+        'anthropic',
+        'claude-opus-4-1'
+      )
+    );
+    expect(adapter.getProfile().parallelToolCalls).toBe(true);
+
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      turnBudget: 5,
+      onToolCall: async (): Promise<ToolResult> => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        return { content: 'ok' };
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(maxInFlight).toBeGreaterThanOrEqual(2);
+    expect(result.value.turnsUsed).toBe(3);
+  });
+
+  it('parallel tool execution preserves turn ordering in the trace', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [
+          {
+            content: [
+              { type: 'tool_use', id: 'first', name: 'lookup', input: {} },
+              { type: 'tool_use', id: 'second', name: 'lookup', input: {} },
+              { type: 'tool_use', id: 'third', name: 'lookup', input: {} },
+            ] as ContentBlock[],
+            stopReason: 'tool_use',
+          },
+          { content: [{ type: 'text', text: 'done' }], stopReason: 'end_turn' },
+        ],
+        'anthropic',
+        'claude-opus-4-1'
+      )
+    );
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      turnBudget: 5,
+      onToolCall: async (call): Promise<ToolResult> => {
+        const delay = call.id === 'third' ? 0 : call.id === 'second' ? 5 : 10;
+        await new Promise((r) => setTimeout(r, delay));
+        return { content: call.id };
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.turns.map((t) => t.toolCall.id)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('parallel: tool error in any slot stops the loop', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [
+          {
+            content: [
+              { type: 'tool_use', id: 'a', name: 'lookup', input: {} },
+              { type: 'tool_use', id: 'b', name: 'lookup', input: {} },
+            ] as ContentBlock[],
+            stopReason: 'tool_use',
+          },
+        ],
+        'anthropic',
+        'claude-opus-4-1'
+      )
+    );
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      turnBudget: 5,
+      onToolCall: (call) => {
+        if (call.id === 'b') return Promise.reject(new Error('boom'));
+        return Promise.resolve({ content: 'ok' });
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stopReason).toBe('tool-error');
+  });
 });

--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- 458 lines, single cohesive class + helpers; under the 600-line governance ceiling. */
 /**
  * `AgenticAdapter` — multi-turn tool-use loop over any `IModelAdapter`.
  *
@@ -34,6 +35,16 @@ import type {
   Result,
   ToolDefinition,
 } from '../../core/index.js';
+import {
+  resolveModelIdentity,
+  resolveModelIdentitySync,
+  type ModelHints,
+  type ResolvedModelIdentity,
+} from '../../config/model-identity.js';
+import {
+  lookupModelProfile,
+  type ModelBehaviorProfile,
+} from '../../config/model-behavior-profile.js';
 
 import {
   AgentError,
@@ -45,9 +56,6 @@ import {
   type ToolResult,
 } from './types.js';
 
-/** Providers we recognise — affects the `adapterStrategy` stamp on results. */
-const KNOWN_NATIVE_PROVIDERS = new Set(['anthropic', 'openai', 'gemini', 'google']);
-
 export interface AgenticAdapterOptions {
   /**
    * Maximum number of concurrent model API calls across all in-flight
@@ -55,33 +63,133 @@ export interface AgenticAdapterOptions {
    * provider rate-limits aggressively.
    */
   readonly maxConcurrent?: number;
+  /**
+   * Per-model identity overrides — gateway-renamed models, custom
+   * deployments, or anything the modelId-string parser can't classify.
+   * Each field is optional; provided fields force, others fall through
+   * to probe / parse.
+   */
+  readonly modelHints?: ModelHints;
+  /**
+   * Skip the `IModelAdapter.listModels()` probe at first `runAgent`.
+   * Useful when the gateway doesn't expose `/v1/models` or when
+   * deterministic startup matters more than identity fidelity.
+   */
+  readonly skipProbe?: boolean;
+  /**
+   * Force a specific behaviour profile, bypassing identity-driven
+   * lookup entirely. Reserved for tests + diagnostic runs; in
+   * production prefer `modelHints` so identity stays auditable.
+   */
+  readonly forceProfile?: ModelBehaviorProfile;
 }
 
 export class AgenticAdapter implements IAgenticAdapter {
   readonly providerId: string;
   readonly modelId: string;
-  readonly adapterStrategy: string;
+  /**
+   * Adapter strategy stamp — composed from the resolved model
+   * identity, NOT the IModelAdapter's providerId. For a custom OpenAI
+   * gateway fronting Claude, this reads `native:anthropic` even though
+   * `IModelAdapter.providerId === 'openai'`.
+   *
+   * Initialised eagerly from the modelId parse (sync); upgraded after
+   * the first `runAgent` if the probe contributes a higher-confidence
+   * vendor signal.
+   */
+  adapterStrategy: string;
 
   private readonly model: IModelAdapter;
+  private readonly options: AgenticAdapterOptions;
   private readonly semaphore: Semaphore | null;
+  private resolvedIdentity: ResolvedModelIdentity;
+  private profile: ModelBehaviorProfile;
+  private profileResolutionPromise: Promise<void> | null = null;
 
   constructor(modelAdapter: IModelAdapter, options: AgenticAdapterOptions = {}) {
     this.model = modelAdapter;
+    this.options = options;
     this.providerId = modelAdapter.providerId;
     this.modelId = modelAdapter.modelId;
-    this.adapterStrategy = KNOWN_NATIVE_PROVIDERS.has(modelAdapter.providerId)
-      ? `native:${modelAdapter.providerId}`
-      : 'wrapper';
+
+    // Sync resolution gets us a sensible starting profile. The async
+    // probe (if listModels exists + skipProbe is false) refines it
+    // before the first runAgent.
+    this.resolvedIdentity = resolveModelIdentitySync(modelAdapter.modelId, options.modelHints);
+    this.profile = options.forceProfile ?? lookupModelProfile(this.resolvedIdentity);
+    this.adapterStrategy = stampStrategy(this.resolvedIdentity);
+
+    if (this.profile.quirks.includes('embedding')) {
+      throw new AgentError(
+        `Refusing to construct AgenticAdapter for an embedding model (${modelAdapter.modelId}). ` +
+          `Agentic loops require a chat-completion model.`
+      );
+    }
+
     this.semaphore =
       options.maxConcurrent !== undefined && options.maxConcurrent > 0
         ? new Semaphore(options.maxConcurrent)
         : null;
   }
 
+  /**
+   * Read-only accessor for the resolved profile. Mostly used in tests
+   * + observability surfaces; production callers shouldn't need this.
+   */
+  getProfile(): ModelBehaviorProfile {
+    return this.profile;
+  }
+
+  /**
+   * Read-only accessor for the resolved identity. After the first
+   * `runAgent` call (if a probe ran), this may differ from what the
+   * sync constructor stored — useful for audit logs.
+   */
+  getResolvedIdentity(): ResolvedModelIdentity {
+    return this.resolvedIdentity;
+  }
+
+  /**
+   * Lazily resolve identity via the async probe + refresh the profile.
+   * Idempotent + concurrent-call-safe (multiple `runAgent`s share the
+   * same in-flight resolution).
+   */
+  private async ensureIdentityResolved(): Promise<void> {
+    if (this.options.forceProfile !== undefined) return; // tests / diagnostic
+    if (this.options.skipProbe === true) return;
+    if (typeof this.model.listModels !== 'function') return;
+    if (this.profileResolutionPromise !== null) {
+      await this.profileResolutionPromise;
+      return;
+    }
+    this.profileResolutionPromise = this.doResolveIdentity();
+    try {
+      await this.profileResolutionPromise;
+    } finally {
+      // Keep the promise resolved/rejected — subsequent calls can
+      // re-await it cheaply, but we've already memoised the result
+      // into `this.profile` so they'll hit the early-return paths
+      // above on the next call.
+    }
+  }
+
+  private async doResolveIdentity(): Promise<void> {
+    const refined = await resolveModelIdentity(this.model, {
+      ...(this.options.modelHints !== undefined && { hints: this.options.modelHints }),
+    });
+    // Only upgrade if the probe contributed a more-specific source.
+    if (refined.source === 'probe' || refined.source === 'modelHints') {
+      this.resolvedIdentity = refined;
+      this.profile = lookupModelProfile(refined);
+      this.adapterStrategy = stampStrategy(refined);
+    }
+  }
+
   async runAgent(args: RunAgentArgs): Promise<Result<AgentRunResult, AgentError>> {
     if (args.turnBudget <= 0) {
       return err(new AgentError(`turnBudget must be > 0, got ${String(args.turnBudget)}`));
     }
+    await this.ensureIdentityResolved();
     const state: LoopState = {
       turns: [],
       totalInputTokens: 0,
@@ -154,6 +262,19 @@ export class AgenticAdapter implements IAgenticAdapter {
     response: CompletionResponse,
     modelLatencyMs: number
   ): Promise<TurnOutcome> {
+    if (this.profile.parallelToolCalls && toolUses.length > 1) {
+      return this.processToolCallsParallel(args, state, toolUses, response, modelLatencyMs);
+    }
+    return this.processToolCallsSequential(args, state, toolUses, response, modelLatencyMs);
+  }
+
+  private async processToolCallsSequential(
+    args: RunAgentArgs,
+    state: LoopState,
+    toolUses: readonly Extract<ContentBlock, { type: 'tool_use' }>[],
+    response: CompletionResponse,
+    modelLatencyMs: number
+  ): Promise<TurnOutcome> {
     const toolResultBlocks: Extract<ContentBlock, { type: 'tool_result' }>[] = [];
     for (const toolUse of toolUses) {
       if (state.turns.length >= args.turnBudget) break;
@@ -167,12 +288,108 @@ export class AgenticAdapter implements IAgenticAdapter {
       if (outcome.kind === 'stop') return outcome;
       toolResultBlocks.push(outcome.toolResultBlock);
     }
-    // Anthropic + OpenAI both expect tool_result blocks batched into a
-    // single follow-up user message after a multi-tool_use assistant turn.
     if (toolResultBlocks.length > 0) {
       state.messages.push({ role: 'user', content: toolResultBlocks });
     }
     return { kind: 'continue' };
+  }
+
+  /**
+   * Profile-driven parallel tool execution. Used when
+   * `profile.parallelToolCalls === true` AND the model emitted >1
+   * tool_use block in a single turn.
+   *
+   * Each tool call still produces its own `AgentTurn`; turn-budget
+   * applies to the post-completion count (we don't pre-cap the
+   * Promise.all because the model already issued all calls — better
+   * to record everything and let the next turn be the budget breaker).
+   */
+  private async processToolCallsParallel(
+    args: RunAgentArgs,
+    state: LoopState,
+    toolUses: readonly Extract<ContentBlock, { type: 'tool_use' }>[],
+    response: CompletionResponse,
+    modelLatencyMs: number
+  ): Promise<TurnOutcome> {
+    // Snapshot the starting turnIndex so concurrent invocations get
+    // sequential indices instead of all stamping the same one.
+    const startIndex = state.turns.length;
+    const promises = toolUses.map((toolUse, offset) =>
+      this.invokeToolForParallel(args, toolUse, response, modelLatencyMs, startIndex + offset)
+    );
+    const outcomes = await Promise.all(promises);
+
+    // Order-stable record + announce.
+    const toolResultBlocks: Extract<ContentBlock, { type: 'tool_result' }>[] = [];
+    for (const outcome of outcomes) {
+      if (outcome.kind === 'stop-tool-error') {
+        state.turns.push(outcome.turn);
+        args.onTurn?.(outcome.turn);
+        return { kind: 'stop', reason: 'tool-error' };
+      }
+      state.turns.push(outcome.turn);
+      args.onTurn?.(outcome.turn);
+      toolResultBlocks.push(outcome.toolResultBlock);
+    }
+    if (toolResultBlocks.length > 0) {
+      state.messages.push({ role: 'user', content: toolResultBlocks });
+    }
+    return { kind: 'continue' };
+  }
+
+  /**
+   * Per-call wrapper used by parallel execution. Returns a captured
+   * outcome (turn + result-block, OR turn + tool-error flag) without
+   * touching shared state — `processToolCallsParallel` reduces the
+   * outcomes deterministically afterwards.
+   */
+  private async invokeToolForParallel(
+    args: RunAgentArgs,
+    toolUse: Extract<ContentBlock, { type: 'tool_use' }>,
+    response: CompletionResponse,
+    modelLatencyMs: number,
+    turnIndex: number
+  ): Promise<ParallelToolOutcome> {
+    const toolCall: ToolCall = {
+      id: toolUse.id,
+      name: toolUse.name,
+      arguments: toolUse.input as Record<string, unknown>,
+    };
+    const tt0 = Date.now();
+    try {
+      const toolResult = await args.onToolCall(toolCall);
+      const turn = buildTurn({
+        turnIndex,
+        toolCall,
+        toolResult,
+        modelLatencyMs,
+        toolLatencyMs: Date.now() - tt0,
+        response,
+      });
+      return {
+        kind: 'recorded',
+        turn,
+        toolResultBlock: {
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: toolResult.content,
+          ...(toolResult.isError === true && { is_error: true }),
+        },
+      };
+    } catch (caught: unknown) {
+      const turn = buildTurn({
+        turnIndex,
+        toolCall,
+        toolResult: {
+          content: caught instanceof Error ? caught.message : String(caught),
+          isError: true,
+        },
+        modelLatencyMs,
+        toolLatencyMs: Date.now() - tt0,
+        response,
+      });
+      return { kind: 'stop-tool-error', turn };
+    }
   }
 
   private async invokeToolAndRecord(
@@ -296,6 +513,30 @@ type ToolOutcome =
       readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result' }>;
     }
   | { readonly kind: 'stop'; readonly reason: AgentRunResult['stopReason'] };
+
+/**
+ * Outcome of one parallel tool call. Differs from `ToolOutcome` because
+ * the parallel path captures the `turn` for later ordered recording —
+ * sequential path can record into shared state directly.
+ */
+type ParallelToolOutcome =
+  | {
+      readonly kind: 'recorded';
+      readonly turn: AgentTurn;
+      readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result' }>;
+    }
+  | { readonly kind: 'stop-tool-error'; readonly turn: AgentTurn };
+
+/**
+ * Compose the `adapterStrategy` stamp from the resolved identity. For
+ * known vendors we record `native:<vendor>`; unknown vendors get
+ * `wrapper`. The source of resolution (`modelHints` / `probe` /
+ * `modelIdParse` / `default`) is not in the strategy string but is
+ * available on `getResolvedIdentity()` for audit logs.
+ */
+function stampStrategy(identity: ResolvedModelIdentity): string {
+  return identity.vendor === 'unknown' ? 'wrapper' : `native:${identity.vendor}`;
+}
 
 interface BuildTurnArgs {
   readonly turnIndex: number;

--- a/packages/nexus-agents/src/config/model-identity.ts
+++ b/packages/nexus-agents/src/config/model-identity.ts
@@ -365,12 +365,11 @@ interface MergeArgs {
 
 function mergeIdentity(args: MergeArgs): ResolvedModelIdentity {
   const { rawModelId, hints, probe, parsed } = args;
+  const version = pickVersion(hints, parsed);
   return {
     vendor: hints.vendor ?? probe?.vendor ?? parsed.vendor ?? 'unknown',
     family: hints.family ?? parsed.family ?? 'unknown',
-    ...(pickVersion(hints, parsed) !== undefined && {
-      version: pickVersion(hints, parsed),
-    }),
+    ...(version !== undefined && { version }),
     quirks: [...new Set([...(hints.quirks ?? []), ...parsed.quirks])],
     source: pickSource(hints, probe, parsed),
     rawModelId,


### PR DESCRIPTION
## Summary

Wires `AgenticAdapter` to use the dynamic model identity + behaviour profile from [#2531](https://github.com/williamzujkowski/nexus-agents/pull/2531). For a custom OpenAI gateway fronting Claude / Llama / Qwen / weirdly-renamed models, the loop now picks behaviour from the actually-served model rather than from `IModelAdapter.providerId`.

## Constructor changes (additive)

```ts
new AgenticAdapter(modelAdapter, {
  modelHints?: ModelHints,           // operator force on identity fields
  skipProbe?: boolean,               // opt out of /v1/models probe
  forceProfile?: ModelBehaviorProfile, // tests / diagnostic
  maxConcurrent?: number,            // (existing)
})
```

`modelHints` is the escape hatch for gateway-renamed models: pass `{ vendor: 'anthropic' }` and the adapter picks the Anthropic profile (parallel tools + ephemeral caching) regardless of what `modelId` says.

## Identity resolution flow

1. **Constructor** — sync resolve from `modelId` + hints. Stamps initial profile + `adapterStrategy`. Fast, no network.
2. **First `runAgent`** — `ensureIdentityResolved()` runs the `/v1/models` probe when the adapter exposes `listModels`. Upgrades profile + strategy if the probe contributes a higher-confidence vendor. Memoised.
3. **Subsequent `runAgent`** — cached profile reused.

`adapterStrategy` now reads `native:<resolved-vendor>` for known vendors, `wrapper` for unknown — sourced from modelId parse + probe, not from `providerId`. Gateway scenario gets the right answer.

## Behaviour driven by profile

- **`parallelToolCalls=true`** (Anthropic Claude 4.x + OpenAI gpt-4o families): when the model emits >1 `tool_use` in one assistant turn, run them via `Promise.all`. Open-weight families (llama, qwen, nemotron, mistral, cohere, deepseek) stay sequential.
- **`quirks.includes('embedding')`**: constructor throws `AgentError`. Agentic loops are meaningless for embedding models.

Parallel execution preserves trace ordering: `turns[]` ordered by `tool_use` emission order, not completion order, so eval logs stay deterministic. A tool error in any parallel slot stops the loop with `stopReason='tool-error'`, matching sequential semantics.

## What's NOT in this PR

- **`promptCaching: 'ephemeral'`** marker injection on tool definitions. Will require a small change to `ToolDefinition` for per-tool `cache_control` overlay; landing as PR C alongside YAML manifest support.
- **`maxRecommendedTurnBudget`** as default when caller omits `turnBudget`. Currently still required.
- YAML manifest + outcome-driven adjustment loop (PR C).

## Tests

9 new + 14 pre-existing = 23 in `agents/agentic/`:

- Refuses to construct embedding models
- Exposes `getProfile()` + `getResolvedIdentity()` accessors
- Strategy stamp follows resolved vendor (gateway scenario: `providerId='openai'` + `modelId='anthropic/claude-sonnet-4-6'` → `native:anthropic`)
- `modelHints` override forces a different profile + `forceProfile` bypass
- Parallel: 3 tool calls run with `maxInFlight ≥ 2`
- Parallel: ordering preserved despite reverse completion order
- Parallel: tool error in any slot returns `stopReason='tool-error'`

## Test plan

- [x] 23 unit tests, all green
- [x] `pnpm typecheck` clean (full workspace)
- [x] `pnpm build` clean (ESM + DTS)
- [ ] CI on this PR

## Stacked on

[#2531](https://github.com/williamzujkowski/nexus-agents/pull/2531) (PR A — model identity + behaviour profile + listModels). Already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)