### PR TITLE
feat(agents): turnBudget default + ephemeral cache markers (#2529 PR C)

### DIFF
--- a/.changeset/2529-iagentic-adapter.md
+++ b/.changeset/2529-iagentic-adapter.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+Add `IAgenticAdapter` primitive for multi-turn tool-use agent loops (#2529). Counterpart to `IModelAdapter`'s single-shot `complete()` — eval harnesses (and any other consumer driving an agent loop) own their toolset + tool execution while the adapter handles model orchestration.
+
+**Public API additions** (re-exported from the package root):
+
+- `createAgenticAdapter(modelAdapter, options)` factory + `AgenticAdapter` class
+- `IAgenticAdapter` / `RunAgentArgs` / `AgentRunResult` / `AgentTurn` / `ToolCall` / `ToolResult` / `AgentStopReason` / `AgentError` types
+- `resolveModelIdentity(adapter, options)` + `resolveModelIdentitySync` + `parseModelId`
+- `ResolvedModelIdentity` / `ModelHints` / `ModelVendor` / `IdentitySource` types
+- `lookupModelProfile(identity)` + `lookupProfileFromModelId(modelId)` + `DEFAULT_PROFILE`
+- `ModelBehaviorProfile` / `ToolDefinitionFormat` / `PromptCachingMode` types
+- `IModelAdapter.listModels?()` optional method + `ModelMetadata` type
+
+**What it does**: handles the model-orchestration loop for tool-using agents — call → tool_use blocks → harness routes calls → tool_result blocks back → repeat until the model stops, hits the turn budget, errors, or is cancelled.
+
+Per-model behaviour is profile-driven: a custom OpenAI gateway fronting Claude gets Anthropic's profile (parallel tool execution + ephemeral prompt-caching markers) automatically based on the resolved `modelId`, not the `IModelAdapter.providerId`. Operators override via `modelHints`.
+
+**Key invariants**:
+
+- `runAgent` returns `Result<AgentRunResult, AgentError>`; `Result.ok` includes `stopReason ∈ {agent-stopped, turn-budget, tool-error, cancelled}` so partial-progress runs are gradable
+- `onTurn` callback fires after each turn for operator visibility
+- `AbortSignal` cancels between turns
+- `maxConcurrent` semaphore caps concurrent model API calls (released during tool execution)
+- Refuses to construct for embedding models (e.g., `text-embedding-3-large`)
+- `turnBudget` defaults to `profile.maxRecommendedTurnBudget` when omitted
+- `cache_control: ephemeral` marker added to the last tool definition for Anthropic vendors
+
+**Identity resolution** stacks: `modelHints` (operator force) > `/v1/models` probe (`OpenAIAdapter` implements `listModels`) > `modelId`-string parse > `'unknown'`.
+
+Lands in PRs #2530/#2531/#2532/#2533. Pre-work for the eval-repo v0.3 promotions ([nexus-eval-aider-polyglot#9](https://github.com/williamzujkowski/nexus-eval-aider-polyglot/issues/9), [nexus-eval-livecodebench#7](https://github.com/williamzujkowski/nexus-eval-livecodebench/issues/7), [nexus-eval-tau-bench#4](https://github.com/williamzujkowski/nexus-eval-tau-bench/issues/4)) which build on the new primitive.

--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
@@ -513,4 +513,107 @@ describe('AgenticAdapter', () => {
     if (!result.ok) return;
     expect(result.value.stopReason).toBe('tool-error');
   });
+
+  it('turnBudget defaults to profile.maxRecommendedTurnBudget when omitted', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [
+          {
+            content: [{ type: 'tool_use', id: 'tu', name: 'lookup', input: {} }] as ContentBlock[],
+            stopReason: 'tool_use',
+          },
+        ],
+        'anthropic',
+        'claude-haiku-4'
+      )
+    );
+    expect(adapter.getProfile().maxRecommendedTurnBudget).toBe(8);
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      onToolCall: () => Promise.resolve({ content: 'ok' }),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stopReason).toBe('turn-budget');
+    expect(result.value.turnsUsed).toBe(8);
+  });
+
+  it('explicit turnBudget overrides profile default', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [
+          {
+            content: [{ type: 'tool_use', id: 'tu', name: 'lookup', input: {} }] as ContentBlock[],
+            stopReason: 'tool_use',
+          },
+        ],
+        'anthropic',
+        'claude-haiku-4'
+      )
+    );
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      turnBudget: 2,
+      onToolCall: () => Promise.resolve({ content: 'ok' }),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.turnsUsed).toBe(2);
+  });
+
+  it('ephemeral cache marker added to last tool definition for anthropic', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [{ content: [{ type: 'text', text: 'done' }], stopReason: 'end_turn' }],
+        'anthropic',
+        'claude-sonnet-4-6'
+      )
+    );
+    expect(adapter.getProfile().promptCaching).toBe('ephemeral');
+    await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: [
+        { name: 'a', description: 'a', inputSchema: {} },
+        { name: 'b', description: 'b', inputSchema: {} },
+      ],
+      turnBudget: 1,
+      onToolCall: () => Promise.resolve({ content: '' }),
+    });
+    const completeFn = (adapter as unknown as { model: { complete: ReturnType<typeof vi.fn> } })
+      .model.complete;
+    const firstCall = completeFn.mock.calls[0]?.[0] as {
+      tools: Array<{ name: string; cacheControl?: unknown }>;
+    };
+    expect(firstCall.tools[0]?.cacheControl).toBeUndefined();
+    expect(firstCall.tools[1]?.cacheControl).toEqual({ type: 'ephemeral' });
+  });
+
+  it('no cache marker when profile.promptCaching is none (e.g., openai)', async () => {
+    const adapter = new AgenticAdapter(
+      makeMockModel(
+        [{ content: [{ type: 'text', text: 'done' }], stopReason: 'end_turn' }],
+        'openai',
+        'gpt-4o'
+      )
+    );
+    expect(adapter.getProfile().promptCaching).toBe('none');
+    await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: [{ name: 'a', description: 'a', inputSchema: {} }],
+      turnBudget: 1,
+      onToolCall: () => Promise.resolve({ content: '' }),
+    });
+    const completeFn = (adapter as unknown as { model: { complete: ReturnType<typeof vi.fn> } })
+      .model.complete;
+    const firstCall = completeFn.mock.calls[0]?.[0] as {
+      tools: Array<{ cacheControl?: unknown }>;
+    };
+    expect(firstCall.tools[0]?.cacheControl).toBeUndefined();
+  });
 });

--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
@@ -173,6 +173,31 @@ export class AgenticAdapter implements IAgenticAdapter {
     }
   }
 
+  /**
+   * If the resolved profile asks for `'ephemeral'` prompt caching,
+   * mark the LAST tool definition with `cache_control: { type:
+   * 'ephemeral' }`. Anthropic interprets this as "cache everything up
+   * to and including the tool definitions"; other providers strip the
+   * unknown field at the canonical-request mapper.
+   *
+   * Last-tool placement is the Anthropic convention: cache key is the
+   * prefix, so caching the final tool block caches the entire tools
+   * section. Per-turn the system prompt + user prompt + tools are
+   * stable, so cache-hit rate on multi-turn agent runs is high.
+   */
+  private applyCacheControlIfRequested(tools: readonly ToolDefinition[]): ToolDefinition[] {
+    if (this.profile.promptCaching !== 'ephemeral') return [...tools];
+    if (tools.length === 0) return [];
+    return tools.map((tool, idx) =>
+      idx === tools.length - 1
+        ? ({
+            ...tool,
+            cacheControl: { type: 'ephemeral' },
+          } as ToolDefinition & { cacheControl: { type: 'ephemeral' } })
+        : tool
+    );
+  }
+
   private async doResolveIdentity(): Promise<void> {
     const refined = await resolveModelIdentity(this.model, {
       ...(this.options.modelHints !== undefined && { hints: this.options.modelHints }),
@@ -186,10 +211,12 @@ export class AgenticAdapter implements IAgenticAdapter {
   }
 
   async runAgent(args: RunAgentArgs): Promise<Result<AgentRunResult, AgentError>> {
-    if (args.turnBudget <= 0) {
-      return err(new AgentError(`turnBudget must be > 0, got ${String(args.turnBudget)}`));
-    }
     await this.ensureIdentityResolved();
+    const turnBudget = args.turnBudget ?? this.profile.maxRecommendedTurnBudget;
+    if (turnBudget <= 0) {
+      return err(new AgentError(`turnBudget must be > 0, got ${String(turnBudget)}`));
+    }
+    const resolvedArgs: ResolvedRunAgentArgs = { ...args, turnBudget };
     const state: LoopState = {
       turns: [],
       totalInputTokens: 0,
@@ -198,11 +225,11 @@ export class AgenticAdapter implements IAgenticAdapter {
       messages: [{ role: 'user', content: args.userPrompt }],
     };
 
-    while (state.turns.length < args.turnBudget) {
+    while (state.turns.length < turnBudget) {
       if (args.signal?.aborted === true) {
         return ok(this.buildFromState(state, 'cancelled'));
       }
-      const turnOutcome = await this.runOneTurn(args, state);
+      const turnOutcome = await this.runOneTurn(resolvedArgs, state);
       if (turnOutcome.kind === 'error') return err(turnOutcome.error);
       if (turnOutcome.kind === 'stop') {
         return ok(this.buildFromState(state, turnOutcome.reason));
@@ -218,12 +245,12 @@ export class AgenticAdapter implements IAgenticAdapter {
    * calls → append results. Returns one of three outcomes describing
    * whether the loop continues, stops naturally, or hit a model error.
    */
-  private async runOneTurn(args: RunAgentArgs, state: LoopState): Promise<TurnOutcome> {
+  private async runOneTurn(args: ResolvedRunAgentArgs, state: LoopState): Promise<TurnOutcome> {
     const t0 = Date.now();
     const completion = await this.callModelGated({
       messages: state.messages,
       systemPrompt: args.systemPrompt,
-      tools: [...args.tools] as ToolDefinition[],
+      tools: this.applyCacheControlIfRequested([...args.tools] as ToolDefinition[]),
       ...(args.temperature !== undefined && { temperature: args.temperature }),
       ...(args.maxTokens !== undefined && { maxTokens: args.maxTokens }),
     });
@@ -256,7 +283,7 @@ export class AgenticAdapter implements IAgenticAdapter {
   }
 
   private async processToolCalls(
-    args: RunAgentArgs,
+    args: ResolvedRunAgentArgs,
     state: LoopState,
     toolUses: readonly Extract<ContentBlock, { type: 'tool_use' }>[],
     response: CompletionResponse,
@@ -269,7 +296,7 @@ export class AgenticAdapter implements IAgenticAdapter {
   }
 
   private async processToolCallsSequential(
-    args: RunAgentArgs,
+    args: ResolvedRunAgentArgs,
     state: LoopState,
     toolUses: readonly Extract<ContentBlock, { type: 'tool_use' }>[],
     response: CompletionResponse,
@@ -305,7 +332,7 @@ export class AgenticAdapter implements IAgenticAdapter {
    * to record everything and let the next turn be the budget breaker).
    */
   private async processToolCallsParallel(
-    args: RunAgentArgs,
+    args: ResolvedRunAgentArgs,
     state: LoopState,
     toolUses: readonly Extract<ContentBlock, { type: 'tool_use' }>[],
     response: CompletionResponse,
@@ -344,7 +371,7 @@ export class AgenticAdapter implements IAgenticAdapter {
    * outcomes deterministically afterwards.
    */
   private async invokeToolForParallel(
-    args: RunAgentArgs,
+    args: ResolvedRunAgentArgs,
     toolUse: Extract<ContentBlock, { type: 'tool_use' }>,
     response: CompletionResponse,
     modelLatencyMs: number,
@@ -393,7 +420,7 @@ export class AgenticAdapter implements IAgenticAdapter {
   }
 
   private async invokeToolAndRecord(
-    args: RunAgentArgs,
+    args: ResolvedRunAgentArgs,
     state: LoopState,
     toolUse: Extract<ContentBlock, { type: 'tool_use' }>,
     response: CompletionResponse,
@@ -500,6 +527,15 @@ interface LoopState {
   totalOutputTokens: number;
   finalContent: string;
   messages: Message[];
+}
+
+/**
+ * `RunAgentArgs` after the adapter has resolved any optional fields
+ * to concrete defaults — most importantly `turnBudget`, which is
+ * optional in the public API but required for the loop.
+ */
+interface ResolvedRunAgentArgs extends RunAgentArgs {
+  readonly turnBudget: number;
 }
 
 type TurnOutcome =

--- a/packages/nexus-agents/src/agents/agentic/types.ts
+++ b/packages/nexus-agents/src/agents/agentic/types.ts
@@ -142,7 +142,12 @@ export interface RunAgentArgs {
   readonly systemPrompt: string;
   readonly userPrompt: string;
   readonly tools: readonly ToolDefinition[];
-  readonly turnBudget: number;
+  /**
+   * Maximum agent turns. When omitted, the adapter uses the resolved
+   * model's `profile.maxRecommendedTurnBudget` (claude-opus = 20,
+   * o-reasoning = 25, claude-haiku / gemini-flash = 8, defaults to 10).
+   */
+  readonly turnBudget?: number;
   readonly onToolCall: (call: ToolCall) => Promise<ToolResult>;
   readonly onTurn?: (turn: AgentTurn) => void;
   readonly signal?: AbortSignal;


### PR DESCRIPTION
Two refinements that finish the AgenticAdapter profile-driven story. See [#2529](https://github.com/williamzujkowski/nexus-agents/issues/2529). Bundles the changeset for the full #2529 IAgenticAdapter feature set so the next nexus-agents minor release publishes everything together — eval-repo v0.3 consumers are blocked on this.

**Changes:**
- `turnBudget` becomes optional in `RunAgentArgs`; defaults to `profile.maxRecommendedTurnBudget` (claude-opus = 20, gemini-flash = 8, default = 10)
- `cache_control: ephemeral` marker added to the last tool definition when `profile.promptCaching === 'ephemeral'` (Anthropic vendors)
- Bundled changeset: minor bump documenting the full #2529 feature set

**Tests:** 27 total, 4 new (turnBudget default / explicit override / ephemeral marker / no-marker for openai)