### PR TITLE
fix(exports): expose IAgenticAdapter from the package root (#2536)

### DIFF
--- a/.changeset/2536-expose-iagentic-adapter.md
+++ b/.changeset/2536-expose-iagentic-adapter.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Expose `IAgenticAdapter` + factory + types from the package root (#2536). The pieces landed in main as part of #2529's PRs but the `exports/agents.ts` re-export wiring was missed, so consumers importing from `'nexus-agents'` couldn't see `createAgenticAdapter`, `AgenticAdapter`, `IAgenticAdapter`, `AgentRunResult`, etc.
+
+Adds explicit re-exports of:
+
+- `AgenticAdapter`, `createAgenticAdapter`
+- `AgenticAdapterOptions`, `AgentRunResult`, `AgentStopReason`, `AgentTurn`, `IAgenticAdapter`, `RunAgentArgs`
+- `AgenticToolCall` (= `ToolCall` from agentic), `AgenticToolResult` (= `ToolResult` from agentic) — aliased to avoid collision with the existing MCP `ToolCall` / `ToolResult` shapes
+
+Eval-repo v0.3 consumers (aider-polyglot / livecodebench / tau-bench) can now import the agentic primitive directly. Patch bump only — no behaviour change, just visibility fix.

--- a/packages/nexus-agents/src/exports/agents.ts
+++ b/packages/nexus-agents/src/exports/agents.ts
@@ -301,6 +301,17 @@ export {
   type WaveExecutionResult,
   type WorkChunk,
   type WaveTaskExecutor,
+  // Agentic adapter (#2529) — multi-turn tool-use loop primitive
+  AgenticAdapter,
+  createAgenticAdapter,
+  type AgenticAdapterOptions,
+  type AgentRunResult,
+  type AgentStopReason,
+  type AgentTurn,
+  type IAgenticAdapter,
+  type RunAgentArgs,
+  type ToolCall as AgenticToolCall,
+  type ToolResult as AgenticToolResult,
 } from '../agents/index.js';
 
 // Skills module exports: agents-skills.ts


### PR DESCRIPTION
Re-export wiring fix. `IAgenticAdapter` etc. were in 2.72.0 source but missing from the package public surface — eval-repo v0.3 consumers couldn't import them. Adds explicit re-exports + changeset for a 2.72.1 patch release.

Aliased `ToolCall` / `ToolResult` to `AgenticToolCall` / `AgenticToolResult` to avoid collision with the existing MCP shapes.