### PR TITLE
feat(adapters): listModels() across direct-API + CLI adapters (#2540 PR 5)

### DIFF
--- a/.changeset/2540-pr5-listmodels-cli-adapters.md
+++ b/.changeset/2540-pr5-listmodels-cli-adapters.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': minor
+---
+
+`listModels()` across direct-API and CLI adapters (#2540 PR 5 of 8).
+
+Anthropic and Google direct-API adapters (`ClaudeAdapter`, `GeminiAdapter`) gain `listModels()` that wraps the SDKs' `client.models.list()` surface — 5-min cache, in-flight promise sharing, throws on probe failure so the harness-side identity resolver can fall back. The OpenCode CLI adapter (`OpenCodeCliAdapter`) gains a `listModels()` that reshapes the existing `opencode models` probe into `CliModelInfo` rows, splitting `provider/model` ids when present.
+
+`ICliAdapter` gains an optional `listModels?(): Promise<readonly CliModelInfo[]>` slot mirroring the one on `IModelAdapter`. The new `CliModelInfo` type is exported from `cli-adapters/types`. The custom-OpenAI gateway wrapper (`openai-compat-adapter.ts`) now forwards `listModels` from the inner adapter when the inner adapter exposes one — so a multi-vendor gateway (Claude/Gemini/OpenAI/etc behind one base URL) reports its inventory honestly.
+
+Subprocess CLI adapters whose CLIs have no native list surface (`claude`, `codex`, `gemini`) intentionally leave `listModels` undefined. Identity for those falls back to `modelId` parse via `ModelRegistry`.

--- a/packages/nexus-agents/src/adapters/claude-adapter-list-models.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-list-models.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for `ClaudeAdapter.listModels` (#2540 PR 5 — Anthropic
+ * `client.models.list()` probe). Mocks `@anthropic-ai/sdk` at the
+ * `client.models.list` level so no real HTTP requests happen.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockCreate: vi.fn(),
+    mockStream: vi.fn(),
+    mockModelsList: vi.fn(),
+  };
+});
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: mocks.mockCreate,
+      stream: mocks.mockStream,
+    };
+    models = {
+      list: mocks.mockModelsList,
+    };
+  },
+}));
+
+import { ClaudeAdapter } from './claude-adapter.js';
+
+describe('ClaudeAdapter.listModels (#2540)', () => {
+  beforeEach(() => {
+    mocks.mockModelsList.mockReset();
+  });
+
+  it('normalises Anthropic model rows to ModelMetadata', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [
+        {
+          id: 'claude-opus-4-7',
+          type: 'model',
+          display_name: 'Claude Opus 4.7',
+          created_at: '2026-04-01T00:00:00Z',
+        },
+        {
+          id: 'claude-sonnet-4-6',
+          type: 'model',
+          display_name: 'Claude Sonnet 4.6',
+          created_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    const models = await adapter.listModels();
+    expect(models).toHaveLength(2);
+    expect(models[0]?.id).toBe('claude-opus-4-7');
+    expect(models[0]?.ownedBy).toBe('anthropic');
+    expect(typeof models[0]?.createdAt).toBe('number');
+  });
+
+  it('caches within the 5-min TTL', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [{ id: 'claude-opus-4-7', type: 'model' }],
+    });
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    await adapter.listModels();
+    await adapter.listModels();
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the in-flight promise across concurrent callers', async () => {
+    let resolveFn: (v: unknown) => void = () => {};
+    mocks.mockModelsList.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveFn = r;
+        })
+    );
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    const a = adapter.listModels();
+    const b = adapter.listModels();
+    resolveFn({ data: [{ id: 'claude-opus-4-7', type: 'model' }] });
+    await Promise.all([a, b]);
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on probe failure so identity resolver can fall back', async () => {
+    mocks.mockModelsList.mockRejectedValue(new Error('unauthorized'));
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    await expect(adapter.listModels()).rejects.toThrow('unauthorized');
+  });
+});

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   CompletionRequest,
   CompletionResponse,
+  ModelMetadata,
   StreamChunk,
   ContentBlock,
   TokenUsage,
@@ -350,7 +351,52 @@ export class ClaudeAdapter extends BaseAdapter {
         return null;
     }
   }
+
+  /**
+   * (#2540) List models the Anthropic API currently exposes.
+   * Wraps `client.models.list()`. Cached for 5 min, in-flight promise
+   * shared across concurrent callers, throws on non-2xx so the
+   * harness-side identity resolver knows to fall back.
+   */
+  async listModels(): Promise<readonly ModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelsCache !== null && now - this.modelsCache.fetchedAt < CLAUDE_LIST_MODELS_TTL_MS) {
+      return this.modelsCache.value;
+    }
+    if (this.modelsInFlight !== null) return this.modelsInFlight;
+    const inFlight = this.fetchModels();
+    this.modelsInFlight = inFlight;
+    try {
+      const value = await inFlight;
+      this.modelsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } finally {
+      this.modelsInFlight = null;
+    }
+  }
+
+  private modelsCache: { value: readonly ModelMetadata[]; fetchedAt: number } | null = null;
+  private modelsInFlight: Promise<readonly ModelMetadata[]> | null = null;
+
+  private async fetchModels(): Promise<readonly ModelMetadata[]> {
+    const list = await this.client.models.list();
+    const out: ModelMetadata[] = [];
+    for (const m of list.data) {
+      const entry: ModelMetadata = { id: m.id };
+      if (typeof m.created_at === 'string') {
+        const ts = Date.parse(m.created_at);
+        if (!Number.isNaN(ts)) {
+          out.push({ ...entry, ownedBy: 'anthropic', createdAt: Math.floor(ts / 1000) });
+          continue;
+        }
+      }
+      out.push({ ...entry, ownedBy: 'anthropic' });
+    }
+    return out;
+  }
 }
+
+const CLAUDE_LIST_MODELS_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Creates a ClaudeAdapter with the specified configuration.

--- a/packages/nexus-agents/src/adapters/gemini-adapter-list-models.test.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter-list-models.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `GeminiAdapter.listModels` (#2540 PR 5 — Google
+ * `client.models.list()` probe). Mocks `@google/genai` at the
+ * `client.models.list` level. The SDK returns a Pager (AsyncIterable),
+ * so the mock yields rows asynchronously.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockGenerateContent: vi.fn(),
+    mockGenerateContentStream: vi.fn(),
+    mockModelsList: vi.fn(),
+  };
+});
+
+function asPager<T>(items: T[]): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (i < items.length) {
+            const value = items[i++];
+            return Promise.resolve({ value, done: false } as IteratorResult<T>);
+          }
+          return Promise.resolve({ value: undefined as unknown as T, done: true });
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    models = {
+      generateContent: mocks.mockGenerateContent,
+      generateContentStream: mocks.mockGenerateContentStream,
+      list: mocks.mockModelsList,
+    };
+  },
+}));
+
+import { GeminiAdapter } from './gemini-adapter.js';
+
+describe('GeminiAdapter.listModels (#2540)', () => {
+  beforeEach(() => {
+    mocks.mockModelsList.mockReset();
+  });
+
+  it('strips the `models/` prefix and tags ownedBy=google', async () => {
+    mocks.mockModelsList.mockResolvedValue(
+      asPager([
+        {
+          name: 'models/gemini-3-pro',
+          displayName: 'Gemini 3 Pro',
+          supportedActions: ['generateContent', 'streamGenerateContent'],
+        },
+        { name: 'models/gemini-3-flash' },
+      ])
+    );
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    const models = await adapter.listModels();
+    expect(models).toHaveLength(2);
+    expect(models[0]).toEqual({
+      id: 'gemini-3-pro',
+      ownedBy: 'google',
+      capabilities: ['generateContent', 'streamGenerateContent'],
+    });
+    expect(models[1]).toEqual({ id: 'gemini-3-flash', ownedBy: 'google' });
+  });
+
+  it('caches within the 5-min TTL', async () => {
+    mocks.mockModelsList.mockResolvedValue(asPager([{ name: 'models/gemini-3-pro' }]));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    await adapter.listModels();
+    await adapter.listModels();
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips rows with empty/missing names', async () => {
+    mocks.mockModelsList.mockResolvedValue(asPager([{ name: '' }, { name: 'models/x' }, {}]));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    const models = await adapter.listModels();
+    expect(models).toEqual([{ id: 'x', ownedBy: 'google' }]);
+  });
+
+  it('throws on probe failure so identity resolver can fall back', async () => {
+    mocks.mockModelsList.mockRejectedValue(new Error('quota exceeded'));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    await expect(adapter.listModels()).rejects.toThrow('quota exceeded');
+  });
+});

--- a/packages/nexus-agents/src/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   CompletionRequest,
   CompletionResponse,
+  ModelMetadata,
   StreamChunk,
   ContentBlock,
   TokenUsage,
@@ -359,7 +360,51 @@ export class GeminiAdapter extends BaseAdapter {
       model: this.resolvedModelId,
     };
   }
+
+  /**
+   * (#2540) List Gemini models exposed by the configured API key.
+   * Wraps `client.models.list()` (returns a Pager). 5-min cache,
+   * concurrent-caller promise sharing.
+   */
+  async listModels(): Promise<readonly ModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelsCache !== null && now - this.modelsCache.fetchedAt < GEMINI_LIST_MODELS_TTL_MS) {
+      return this.modelsCache.value;
+    }
+    if (this.modelsInFlight !== null) return this.modelsInFlight;
+    const inFlight = this.fetchModels();
+    this.modelsInFlight = inFlight;
+    try {
+      const value = await inFlight;
+      this.modelsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } finally {
+      this.modelsInFlight = null;
+    }
+  }
+
+  private modelsCache: { value: readonly ModelMetadata[]; fetchedAt: number } | null = null;
+  private modelsInFlight: Promise<readonly ModelMetadata[]> | null = null;
+
+  private async fetchModels(): Promise<readonly ModelMetadata[]> {
+    const pager = await this.client.models.list();
+    const out: ModelMetadata[] = [];
+    for await (const m of pager) {
+      const rawName = typeof m.name === 'string' ? m.name : '';
+      if (rawName === '') continue;
+      const id = rawName.startsWith('models/') ? rawName.slice('models/'.length) : rawName;
+      const caps: string[] = [];
+      if (Array.isArray(m.supportedActions)) {
+        for (const a of m.supportedActions) if (typeof a === 'string') caps.push(a);
+      }
+      const meta: ModelMetadata = { id, ownedBy: 'google' };
+      out.push(caps.length > 0 ? { ...meta, capabilities: caps } : meta);
+    }
+    return out;
+  }
 }
+
+const GEMINI_LIST_MODELS_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Creates a GeminiAdapter with the specified configuration.

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -25,6 +25,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   ModelError,
+  ModelMetadata,
   IModelAdapter,
 } from '../core/index.js';
 import { ok, err, ConfigError, getErrorMessage, getTimeProvider } from '../core/index.js';
@@ -140,7 +141,7 @@ export function createOpenAICompatAdapter(
  * line gets written per call.
  */
 function withUsageRecording(inner: IModelAdapter): IModelAdapter {
-  return {
+  const wrapped: IModelAdapter = {
     providerId: inner.providerId,
     modelId: inner.modelId,
     capabilities: inner.capabilities,
@@ -183,6 +184,20 @@ function withUsageRecording(inner: IModelAdapter): IModelAdapter {
       return result;
     },
   };
+  attachListModels(wrapped, inner);
+  return wrapped;
+}
+
+/**
+ * (#2540) Forward `listModels` through the wrapper when the inner adapter
+ * exposes one. Only attach when defined so the wrapper's `listModels?:`
+ * hint stays accurate for the resolver. The inner reference is captured
+ * by closure so the forwarded call binds `this` to the inner adapter.
+ */
+function attachListModels(wrapped: IModelAdapter, inner: IModelAdapter): void {
+  const list = inner.listModels?.bind(inner);
+  if (list === undefined) return;
+  wrapped.listModels = (): Promise<readonly ModelMetadata[]> => list();
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.test.ts
@@ -587,6 +587,48 @@ describe('OpenCodeCliAdapter', () => {
     });
   });
 
+  describe('listModels (#2540)', () => {
+    it('reshapes the probe output into CliModelInfo rows with provider split', async () => {
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: string, _args: unknown, _opts: unknown, cb: unknown) => {
+          (cb as ExecFileCallback)(
+            null,
+            'opencode/big-pickle\nopencode/gpt-5-nano\nanthropic/claude-haiku-3.5\nbarefoo\n',
+            ''
+          );
+          return undefined as unknown as ReturnType<typeof execFile>;
+        }
+      );
+      const fresh = new OpenCodeCliAdapter();
+      const models = await fresh.listModels();
+      expect(models).toEqual([
+        { id: 'opencode/big-pickle', provider: 'opencode' },
+        { id: 'opencode/gpt-5-nano', provider: 'opencode' },
+        { id: 'anthropic/claude-haiku-3.5', provider: 'anthropic' },
+        { id: 'barefoo' },
+      ]);
+    });
+
+    it('reuses the probe cache across calls', async () => {
+      const probeImpl = vi.fn(
+        (
+          _cmd: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: unknown
+        ): ReturnType<typeof execFile> => {
+          (cb as ExecFileCallback)(null, 'opencode/big-pickle\n', '');
+          return undefined as unknown as ReturnType<typeof execFile>;
+        }
+      );
+      vi.mocked(execFile).mockImplementation(probeImpl);
+      const fresh = new OpenCodeCliAdapter();
+      await fresh.listModels();
+      await fresh.listModels();
+      expect(probeImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('lifecycle', () => {
     it('should initialize successfully', async () => {
       await expect(adapter.initialize()).resolves.not.toThrow();

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
@@ -12,6 +12,7 @@ import { execFile } from 'node:child_process';
 import type {
   ICliResponseParser,
   CliTask,
+  CliModelInfo,
   ModelInfo,
   CliName,
   BaseAdapterOptions,
@@ -234,6 +235,26 @@ export class OpenCodeCliAdapter extends SubprocessCliAdapter {
         : task.content;
 
     return { command: 'opencode', args, stdin: content };
+  }
+
+  /**
+   * (#2540) Lists models the local OpenCode installation can route to.
+   * Wraps the existing `probeAvailableModels()` (already 5-min cached)
+   * and reshapes the result into the CliModelInfo schema. Splits
+   * `provider/model` ids when present.
+   */
+  async listModels(): Promise<readonly CliModelInfo[]> {
+    const ids = await probeAvailableModels();
+    const out: CliModelInfo[] = [];
+    for (const raw of ids) {
+      const slash = raw.indexOf('/');
+      if (slash > 0 && slash < raw.length - 1) {
+        out.push({ id: raw, provider: raw.slice(0, slash) });
+      } else {
+        out.push({ id: raw });
+      }
+    }
+    return out;
   }
 }
 

--- a/packages/nexus-agents/src/cli-adapters/types-capability.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-capability.ts
@@ -161,6 +161,24 @@ export interface ICliAdapter {
    * Called on shutdown.
    */
   dispose(): Promise<void>;
+
+  /**
+   * (#2540) Optional: list models the underlying CLI installation/runtime
+   * has available. Implementations should cache for ~5 min and throw on
+   * failure so the caller can fall back. Adapters whose CLIs have no
+   * native list surface (claude, codex, gemini) leave this undefined.
+   */
+  listModels?(): Promise<readonly CliModelInfo[]>;
+}
+
+/**
+ * (#2540) One row from a CLI's `models`-listing surface. `id` matches what
+ * the CLI accepts as `--model`. `provider` is split out when the CLI uses
+ * `provider/model` ids (e.g. opencode `anthropic/claude-3-5-sonnet`).
+ */
+export interface CliModelInfo {
+  readonly id: string;
+  readonly provider?: string;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/types.ts
+++ b/packages/nexus-agents/src/cli-adapters/types.ts
@@ -34,6 +34,7 @@ export type {
   ICliAdapter,
   ICliResponseParser,
   VersionRequirements,
+  CliModelInfo,
 } from './types-capability.js';
 
 export { CLI_VERSION_REQUIREMENTS, DEFAULT_CAPABILITIES } from './types-capability.js';


### PR DESCRIPTION
## Summary

PR 5 of 8 in epic #2540 (unified ModelRegistry + harness-driven model availability).

- `ClaudeAdapter.listModels()` — wraps `client.models.list()` from the Anthropic SDK; 5-min cache, in-flight promise sharing, throws on probe failure.
- `GeminiAdapter.listModels()` — wraps `client.models.list()` from `@google/genai` (returns a Pager, async-iterated). Strips `models/` prefix; passes through `supportedActions` as `capabilities`.
- `OpenCodeCliAdapter.listModels()` — reshapes the existing `opencode models` probe into `CliModelInfo` rows, splitting `provider/model` ids when present.
- `OpenAICompatAdapter` (custom-OpenAI gateway wrapper) forwards `listModels` from the inner adapter when the inner exposes one — multi-vendor gateways (Claude/Gemini/OpenAI/nvidia/etc behind one base URL) report their inventory honestly.
- `ICliAdapter` gains `listModels?(): Promise<readonly CliModelInfo[]>` mirroring `IModelAdapter`. New `CliModelInfo` type exported.
- Subprocess CLI adapters whose CLIs lack a list surface (`claude`, `codex`, `gemini`) leave `listModels` undefined by design — identity falls back to `modelId` parse via `ModelRegistry`.

Sets up PR 6 (`AvailableModelsCache`) which queries `listModels` across attached adapters and caches the union.

## Test plan
- [x] `pnpm typecheck` clean
- [x] New unit tests for ClaudeAdapter (4), GeminiAdapter (4), OpenCodeCliAdapter (2 new) — all green
- [x] Existing OpenAICompatAdapter tests (20) still pass — wrapper now forwards `listModels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)