### PR TITLE
feat(routing): compositeRouter consumes AvailableModelsCache (#2540 PR 7)

### DIFF
--- a/.changeset/2540-pr5-listmodels-cli-adapters.md
+++ b/.changeset/2540-pr5-listmodels-cli-adapters.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': minor
+---
+
+`listModels()` across direct-API and CLI adapters (#2540 PR 5 of 8).
+
+Anthropic and Google direct-API adapters (`ClaudeAdapter`, `GeminiAdapter`) gain `listModels()` that wraps the SDKs' `client.models.list()` surface — 5-min cache, in-flight promise sharing, throws on probe failure so the harness-side identity resolver can fall back. The OpenCode CLI adapter (`OpenCodeCliAdapter`) gains a `listModels()` that reshapes the existing `opencode models` probe into `CliModelInfo` rows, splitting `provider/model` ids when present.
+
+`ICliAdapter` gains an optional `listModels?(): Promise<readonly CliModelInfo[]>` slot mirroring the one on `IModelAdapter`. The new `CliModelInfo` type is exported from `cli-adapters/types`. The custom-OpenAI gateway wrapper (`openai-compat-adapter.ts`) now forwards `listModels` from the inner adapter when the inner adapter exposes one — so a multi-vendor gateway (Claude/Gemini/OpenAI/etc behind one base URL) reports its inventory honestly.
+
+Subprocess CLI adapters whose CLIs have no native list surface (`claude`, `codex`, `gemini`) intentionally leave `listModels` undefined. Identity for those falls back to `modelId` parse via `ModelRegistry`.

--- a/.changeset/2540-pr6-available-models-cache.md
+++ b/.changeset/2540-pr6-available-models-cache.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+`AvailableModelsCache` — harness-driven view of routable models (#2540 PR 6 of 8).
+
+PR 5 added `listModels()` on direct-API and CLI adapters. This PR stitches those probes into one queryable surface so `CompositeRouter` (PR 7) can gate scoring on what's actually routable right now.
+
+Design invariants:
+
+- **Sources are the source of truth.** If a harness drops a model, the registry never decides it's still routable. `ModelRegistry` answers "how should this model behave"; `AvailableModelsCache` answers "is this model routable at all."
+- **Stale-while-revalidate.** Fresh < 5 min. Stale-but-usable < 25 min (returns cached, kicks background refresh). Beyond → blocks. Defaults configurable per call site.
+- **Bad sources don't poison the union.** A failing `listModels` logs and is excluded from the next snapshot; remaining sources stay queryable.
+- **No persistence.** Process-local; operators restart and get a fresh probe.
+
+API: `new AvailableModelsCache({ sources, ttlMs?, staleTtlMs?, now? })` → `getAll()`, `byProvider(name)`, `has(modelId)`, `refresh()`. Sources adapt themselves to the minimal `AvailableModelsSource` interface (one `listModels()` method) so both `IModelAdapter` and `ICliAdapter` can be wrapped without entangling the cache with either contract.

--- a/.changeset/2540-pr7-router-cache-integration.md
+++ b/.changeset/2540-pr7-router-cache-integration.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+`CompositeRouter` consumes `AvailableModelsCache` (#2540 PR 7 of 8).
+
+`CompositeRouterConfigWithPreference` gains an optional `availableModelsCache` field. When set, the router gates its candidate-CLI list on the cache before running the routing pipeline:
+
+- A CLI is excluded only when the cache has been queried at least once and reports zero models for it.
+- An empty cache union (cold start, all sources failing) falls back to all registered CLIs — the gate never wedges routing on a transient cache miss.
+- Cache errors do not block routing — they are logged and the router falls through to all registered CLIs.
+
+`getAvailableModelsCache()` exposes the wired cache (or undefined) for downstream consumers (the runtime model-not-found fallback in PR 8 will use this).
+
+OutcomeStore wiring deferred to follow-on (#2540 makes the registry available for OutcomeStore key normalization, but the actual wiring touches more than this PR's scope).

--- a/packages/nexus-agents/src/adapters/claude-adapter-list-models.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter-list-models.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for `ClaudeAdapter.listModels` (#2540 PR 5 — Anthropic
+ * `client.models.list()` probe). Mocks `@anthropic-ai/sdk` at the
+ * `client.models.list` level so no real HTTP requests happen.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockCreate: vi.fn(),
+    mockStream: vi.fn(),
+    mockModelsList: vi.fn(),
+  };
+});
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: mocks.mockCreate,
+      stream: mocks.mockStream,
+    };
+    models = {
+      list: mocks.mockModelsList,
+    };
+  },
+}));
+
+import { ClaudeAdapter } from './claude-adapter.js';
+
+describe('ClaudeAdapter.listModels (#2540)', () => {
+  beforeEach(() => {
+    mocks.mockModelsList.mockReset();
+  });
+
+  it('normalises Anthropic model rows to ModelMetadata', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [
+        {
+          id: 'claude-opus-4-7',
+          type: 'model',
+          display_name: 'Claude Opus 4.7',
+          created_at: '2026-04-01T00:00:00Z',
+        },
+        {
+          id: 'claude-sonnet-4-6',
+          type: 'model',
+          display_name: 'Claude Sonnet 4.6',
+          created_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    const models = await adapter.listModels();
+    expect(models).toHaveLength(2);
+    expect(models[0]?.id).toBe('claude-opus-4-7');
+    expect(models[0]?.ownedBy).toBe('anthropic');
+    expect(typeof models[0]?.createdAt).toBe('number');
+  });
+
+  it('caches within the 5-min TTL', async () => {
+    mocks.mockModelsList.mockResolvedValue({
+      data: [{ id: 'claude-opus-4-7', type: 'model' }],
+    });
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    await adapter.listModels();
+    await adapter.listModels();
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the in-flight promise across concurrent callers', async () => {
+    let resolveFn: (v: unknown) => void = () => {};
+    mocks.mockModelsList.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveFn = r;
+        })
+    );
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    const a = adapter.listModels();
+    const b = adapter.listModels();
+    resolveFn({ data: [{ id: 'claude-opus-4-7', type: 'model' }] });
+    await Promise.all([a, b]);
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on probe failure so identity resolver can fall back', async () => {
+    mocks.mockModelsList.mockRejectedValue(new Error('unauthorized'));
+    const adapter = new ClaudeAdapter({ apiKey: 'k', modelId: 'claude-opus-4-7' });
+    await expect(adapter.listModels()).rejects.toThrow('unauthorized');
+  });
+});

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   CompletionRequest,
   CompletionResponse,
+  ModelMetadata,
   StreamChunk,
   ContentBlock,
   TokenUsage,
@@ -350,7 +351,52 @@ export class ClaudeAdapter extends BaseAdapter {
         return null;
     }
   }
+
+  /**
+   * (#2540) List models the Anthropic API currently exposes.
+   * Wraps `client.models.list()`. Cached for 5 min, in-flight promise
+   * shared across concurrent callers, throws on non-2xx so the
+   * harness-side identity resolver knows to fall back.
+   */
+  async listModels(): Promise<readonly ModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelsCache !== null && now - this.modelsCache.fetchedAt < CLAUDE_LIST_MODELS_TTL_MS) {
+      return this.modelsCache.value;
+    }
+    if (this.modelsInFlight !== null) return this.modelsInFlight;
+    const inFlight = this.fetchModels();
+    this.modelsInFlight = inFlight;
+    try {
+      const value = await inFlight;
+      this.modelsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } finally {
+      this.modelsInFlight = null;
+    }
+  }
+
+  private modelsCache: { value: readonly ModelMetadata[]; fetchedAt: number } | null = null;
+  private modelsInFlight: Promise<readonly ModelMetadata[]> | null = null;
+
+  private async fetchModels(): Promise<readonly ModelMetadata[]> {
+    const list = await this.client.models.list();
+    const out: ModelMetadata[] = [];
+    for (const m of list.data) {
+      const entry: ModelMetadata = { id: m.id };
+      if (typeof m.created_at === 'string') {
+        const ts = Date.parse(m.created_at);
+        if (!Number.isNaN(ts)) {
+          out.push({ ...entry, ownedBy: 'anthropic', createdAt: Math.floor(ts / 1000) });
+          continue;
+        }
+      }
+      out.push({ ...entry, ownedBy: 'anthropic' });
+    }
+    return out;
+  }
 }
+
+const CLAUDE_LIST_MODELS_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Creates a ClaudeAdapter with the specified configuration.

--- a/packages/nexus-agents/src/adapters/gemini-adapter-list-models.test.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter-list-models.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `GeminiAdapter.listModels` (#2540 PR 5 — Google
+ * `client.models.list()` probe). Mocks `@google/genai` at the
+ * `client.models.list` level. The SDK returns a Pager (AsyncIterable),
+ * so the mock yields rows asynchronously.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockGenerateContent: vi.fn(),
+    mockGenerateContentStream: vi.fn(),
+    mockModelsList: vi.fn(),
+  };
+});
+
+function asPager<T>(items: T[]): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (i < items.length) {
+            const value = items[i++];
+            return Promise.resolve({ value, done: false } as IteratorResult<T>);
+          }
+          return Promise.resolve({ value: undefined as unknown as T, done: true });
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    models = {
+      generateContent: mocks.mockGenerateContent,
+      generateContentStream: mocks.mockGenerateContentStream,
+      list: mocks.mockModelsList,
+    };
+  },
+}));
+
+import { GeminiAdapter } from './gemini-adapter.js';
+
+describe('GeminiAdapter.listModels (#2540)', () => {
+  beforeEach(() => {
+    mocks.mockModelsList.mockReset();
+  });
+
+  it('strips the `models/` prefix and tags ownedBy=google', async () => {
+    mocks.mockModelsList.mockResolvedValue(
+      asPager([
+        {
+          name: 'models/gemini-3-pro',
+          displayName: 'Gemini 3 Pro',
+          supportedActions: ['generateContent', 'streamGenerateContent'],
+        },
+        { name: 'models/gemini-3-flash' },
+      ])
+    );
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    const models = await adapter.listModels();
+    expect(models).toHaveLength(2);
+    expect(models[0]).toEqual({
+      id: 'gemini-3-pro',
+      ownedBy: 'google',
+      capabilities: ['generateContent', 'streamGenerateContent'],
+    });
+    expect(models[1]).toEqual({ id: 'gemini-3-flash', ownedBy: 'google' });
+  });
+
+  it('caches within the 5-min TTL', async () => {
+    mocks.mockModelsList.mockResolvedValue(asPager([{ name: 'models/gemini-3-pro' }]));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    await adapter.listModels();
+    await adapter.listModels();
+    expect(mocks.mockModelsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips rows with empty/missing names', async () => {
+    mocks.mockModelsList.mockResolvedValue(asPager([{ name: '' }, { name: 'models/x' }, {}]));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    const models = await adapter.listModels();
+    expect(models).toEqual([{ id: 'x', ownedBy: 'google' }]);
+  });
+
+  it('throws on probe failure so identity resolver can fall back', async () => {
+    mocks.mockModelsList.mockRejectedValue(new Error('quota exceeded'));
+    const adapter = new GeminiAdapter({ apiKey: 'k', modelId: 'gemini-3-pro' });
+    await expect(adapter.listModels()).rejects.toThrow('quota exceeded');
+  });
+});

--- a/packages/nexus-agents/src/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   CompletionRequest,
   CompletionResponse,
+  ModelMetadata,
   StreamChunk,
   ContentBlock,
   TokenUsage,
@@ -359,7 +360,51 @@ export class GeminiAdapter extends BaseAdapter {
       model: this.resolvedModelId,
     };
   }
+
+  /**
+   * (#2540) List Gemini models exposed by the configured API key.
+   * Wraps `client.models.list()` (returns a Pager). 5-min cache,
+   * concurrent-caller promise sharing.
+   */
+  async listModels(): Promise<readonly ModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelsCache !== null && now - this.modelsCache.fetchedAt < GEMINI_LIST_MODELS_TTL_MS) {
+      return this.modelsCache.value;
+    }
+    if (this.modelsInFlight !== null) return this.modelsInFlight;
+    const inFlight = this.fetchModels();
+    this.modelsInFlight = inFlight;
+    try {
+      const value = await inFlight;
+      this.modelsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } finally {
+      this.modelsInFlight = null;
+    }
+  }
+
+  private modelsCache: { value: readonly ModelMetadata[]; fetchedAt: number } | null = null;
+  private modelsInFlight: Promise<readonly ModelMetadata[]> | null = null;
+
+  private async fetchModels(): Promise<readonly ModelMetadata[]> {
+    const pager = await this.client.models.list();
+    const out: ModelMetadata[] = [];
+    for await (const m of pager) {
+      const rawName = typeof m.name === 'string' ? m.name : '';
+      if (rawName === '') continue;
+      const id = rawName.startsWith('models/') ? rawName.slice('models/'.length) : rawName;
+      const caps: string[] = [];
+      if (Array.isArray(m.supportedActions)) {
+        for (const a of m.supportedActions) if (typeof a === 'string') caps.push(a);
+      }
+      const meta: ModelMetadata = { id, ownedBy: 'google' };
+      out.push(caps.length > 0 ? { ...meta, capabilities: caps } : meta);
+    }
+    return out;
+  }
 }
+
+const GEMINI_LIST_MODELS_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Creates a GeminiAdapter with the specified configuration.

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -25,6 +25,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   ModelError,
+  ModelMetadata,
   IModelAdapter,
 } from '../core/index.js';
 import { ok, err, ConfigError, getErrorMessage, getTimeProvider } from '../core/index.js';
@@ -140,7 +141,7 @@ export function createOpenAICompatAdapter(
  * line gets written per call.
  */
 function withUsageRecording(inner: IModelAdapter): IModelAdapter {
-  return {
+  const wrapped: IModelAdapter = {
     providerId: inner.providerId,
     modelId: inner.modelId,
     capabilities: inner.capabilities,
@@ -183,6 +184,20 @@ function withUsageRecording(inner: IModelAdapter): IModelAdapter {
       return result;
     },
   };
+  attachListModels(wrapped, inner);
+  return wrapped;
+}
+
+/**
+ * (#2540) Forward `listModels` through the wrapper when the inner adapter
+ * exposes one. Only attach when defined so the wrapper's `listModels?:`
+ * hint stays accurate for the resolver. The inner reference is captured
+ * by closure so the forwarded call binds `this` to the inner adapter.
+ */
+function attachListModels(wrapped: IModelAdapter, inner: IModelAdapter): void {
+  const list = inner.listModels?.bind(inner);
+  if (list === undefined) return;
+  wrapped.listModels = (): Promise<readonly ModelMetadata[]> => list();
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.test.ts
@@ -587,6 +587,48 @@ describe('OpenCodeCliAdapter', () => {
     });
   });
 
+  describe('listModels (#2540)', () => {
+    it('reshapes the probe output into CliModelInfo rows with provider split', async () => {
+      vi.mocked(execFile).mockImplementation(
+        (_cmd: string, _args: unknown, _opts: unknown, cb: unknown) => {
+          (cb as ExecFileCallback)(
+            null,
+            'opencode/big-pickle\nopencode/gpt-5-nano\nanthropic/claude-haiku-3.5\nbarefoo\n',
+            ''
+          );
+          return undefined as unknown as ReturnType<typeof execFile>;
+        }
+      );
+      const fresh = new OpenCodeCliAdapter();
+      const models = await fresh.listModels();
+      expect(models).toEqual([
+        { id: 'opencode/big-pickle', provider: 'opencode' },
+        { id: 'opencode/gpt-5-nano', provider: 'opencode' },
+        { id: 'anthropic/claude-haiku-3.5', provider: 'anthropic' },
+        { id: 'barefoo' },
+      ]);
+    });
+
+    it('reuses the probe cache across calls', async () => {
+      const probeImpl = vi.fn(
+        (
+          _cmd: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: unknown
+        ): ReturnType<typeof execFile> => {
+          (cb as ExecFileCallback)(null, 'opencode/big-pickle\n', '');
+          return undefined as unknown as ReturnType<typeof execFile>;
+        }
+      );
+      vi.mocked(execFile).mockImplementation(probeImpl);
+      const fresh = new OpenCodeCliAdapter();
+      await fresh.listModels();
+      await fresh.listModels();
+      expect(probeImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('lifecycle', () => {
     it('should initialize successfully', async () => {
       await expect(adapter.initialize()).resolves.not.toThrow();

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
@@ -12,6 +12,7 @@ import { execFile } from 'node:child_process';
 import type {
   ICliResponseParser,
   CliTask,
+  CliModelInfo,
   ModelInfo,
   CliName,
   BaseAdapterOptions,
@@ -234,6 +235,26 @@ export class OpenCodeCliAdapter extends SubprocessCliAdapter {
         : task.content;
 
     return { command: 'opencode', args, stdin: content };
+  }
+
+  /**
+   * (#2540) Lists models the local OpenCode installation can route to.
+   * Wraps the existing `probeAvailableModels()` (already 5-min cached)
+   * and reshapes the result into the CliModelInfo schema. Splits
+   * `provider/model` ids when present.
+   */
+  async listModels(): Promise<readonly CliModelInfo[]> {
+    const ids = await probeAvailableModels();
+    const out: CliModelInfo[] = [];
+    for (const raw of ids) {
+      const slash = raw.indexOf('/');
+      if (slash > 0 && slash < raw.length - 1) {
+        out.push({ id: raw, provider: raw.slice(0, slash) });
+      } else {
+        out.push({ id: raw });
+      }
+    }
+    return out;
   }
 }
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -121,6 +121,14 @@ export interface CompositeRouterConfigWithPreference extends CompositeRouterConf
   metricsCollector?: IRoutingMetricsCollector;
   /** Orchestration observer for routing decision tracking (optional) (Issue #587) */
   orchestrationObserver?: IOrchestrationObserver;
+  /**
+   * (#2540 PR 7) Harness-driven cache of currently-routable models.
+   * When set, the router gates its candidate-CLI list on the cache:
+   * a CLI is excluded if the cache has been queried at least once and
+   * reports zero available models for that source. Unset → no gating
+   * (preserves prior behaviour).
+   */
+  availableModelsCache?: import('../config/available-models-cache.js').AvailableModelsCache;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -881,4 +881,58 @@ describe('CompositeRouter ZeroRouter integration (Issue #347)', () => {
       expect(executeWasCalled).toBe(true);
     });
   });
+
+  describe('availableModelsCache integration (#2540 PR 7)', () => {
+    it('exposes the wired cache via getAvailableModelsCache()', () => {
+      const cache = makeMockCache(['claude:claude-opus-4-7']);
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      expect(r.getAvailableModelsCache()).toBe(cache);
+    });
+
+    it('returns undefined when no cache is configured', () => {
+      const r = new CompositeRouter(adapters);
+      expect(r.getAvailableModelsCache()).toBeUndefined();
+    });
+
+    it('falls back to all CLIs when the cache reports zero models', async () => {
+      const cache = makeMockCache([]);
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      const result = await r.route({ content: 'hello' });
+      expect(result.ok).toBe(true);
+    });
+
+    it('falls back to all CLIs when the filtered set would be empty', async () => {
+      // Cache only knows a CLI we don't have an adapter for.
+      const cache = makeMockCache(['unknown-cli:foo']);
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      const result = await r.route({ content: 'hello' });
+      expect(result.ok).toBe(true);
+      // Without the empty-filter guard the router would error on selection.
+    });
+
+    it('does not block routing when the cache throws', async () => {
+      const cache = {
+        getAll: vi.fn().mockRejectedValue(new Error('cache offline')),
+      } as unknown as import('../config/available-models-cache.js').AvailableModelsCache;
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      const result = await r.route({ content: 'hello' });
+      expect(result.ok).toBe(true);
+    });
+  });
 });
+
+/**
+ * Tiny mock for AvailableModelsCache covering only the interface the
+ * router uses. Each entry is `source:id`.
+ */
+function makeMockCache(
+  entries: string[]
+): import('../config/available-models-cache.js').AvailableModelsCache {
+  const all = entries.map((e) => {
+    const [source, id] = e.split(':');
+    return { id: id ?? '', source: source ?? '' };
+  });
+  return {
+    getAll: vi.fn().mockResolvedValue(all),
+  } as unknown as import('../config/available-models-cache.js').AvailableModelsCache;
+}

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -165,6 +165,12 @@ export class CompositeRouter implements ICompositeRouter {
   /** Strategy distiller instance (Issue #999) */
   private strategyDistiller?: StrategyDistiller;
   private readonly cliNames: CliName[];
+  /**
+   * (#2540 PR 7) Optional harness-driven availability gate. When set,
+   * `executeRouting` filters the candidate CLI list to only those with
+   * ≥1 routable model per the cache. See `getCandidateCliNames`.
+   */
+  private readonly availableModelsCache?: import('../config/available-models-cache.js').AvailableModelsCache;
 
   // Statistics tracking
   private totalDecisions = 0;
@@ -200,6 +206,7 @@ export class CompositeRouter implements ICompositeRouter {
       distilledRuleStageConfig,
       metricsCollector,
       orchestrationObserver,
+      availableModelsCache,
       ...baseConfig
     } = config ?? {};
     this.config = CompositeRouterConfigSchema.parse(baseConfig);
@@ -214,6 +221,11 @@ export class CompositeRouter implements ICompositeRouter {
     if (orchestrationObserver !== undefined) {
       this.orchestrationObserver = orchestrationObserver;
       this.logger.debug('OrchestrationObserver wired to CompositeRouter');
+    }
+    // (#2540 PR 7) Wire optional availability cache.
+    if (availableModelsCache !== undefined) {
+      this.availableModelsCache = availableModelsCache;
+      this.logger.debug('AvailableModelsCache wired to CompositeRouter');
     }
     this.initializeCoreRouters(
       adapters,
@@ -513,11 +525,12 @@ export class CompositeRouter implements ICompositeRouter {
     try {
       const taskProfile = analyzeTaskProfile(task, stagesExecuted);
       const deps = this.getStageDependencies();
+      const candidateCliNames = await this.getCandidateCliNames();
       const pipelineResult = await runPipeline(
         task,
         taskProfile,
         stagesExecuted,
-        this.cliNames,
+        candidateCliNames,
         deps
       );
       if (!pipelineResult.ok) {
@@ -536,6 +549,42 @@ export class CompositeRouter implements ICompositeRouter {
     } catch (error: unknown) {
       return this.handleRoutingError(error, stagesExecuted);
     }
+  }
+
+  /**
+   * (#2540 PR 7) Returns the CLI candidate set for the routing pipeline,
+   * filtered by harness-driven availability when the cache is wired.
+   *
+   * Filtering rules:
+   *   - No cache configured → return all registered CLI names (prior behaviour).
+   *   - Cache configured → query getAll(); a CLI is excluded only if the
+   *     cache reports zero models for it. If the cache returns an empty union
+   *     (cold start, all sources failing), fall back to all registered CLIs
+   *     so the router never wedges on a transient cache miss.
+   *   - Errors in the cache do not block routing — log and fall through.
+   */
+  private async getCandidateCliNames(): Promise<CliName[]> {
+    if (this.availableModelsCache === undefined) return this.cliNames;
+    try {
+      const all = await this.availableModelsCache.getAll();
+      if (all.length === 0) return this.cliNames;
+      const sourcesWithModels = new Set(all.map((m) => m.source));
+      const filtered = this.cliNames.filter((name) => sourcesWithModels.has(name));
+      // Guard against fully empty filter — never let the gate wedge routing.
+      return filtered.length > 0 ? filtered : this.cliNames;
+    } catch (e: unknown) {
+      this.logger.warn('AvailableModelsCache query failed; falling back to all CLIs', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return this.cliNames;
+    }
+  }
+
+  /** (#2540 PR 7) Public accessor for the wired cache (or undefined). */
+  getAvailableModelsCache():
+    | import('../config/available-models-cache.js').AvailableModelsCache
+    | undefined {
+    return this.availableModelsCache;
   }
 
   private getStageDependencies(): StageDependencies {

--- a/packages/nexus-agents/src/cli-adapters/types-capability.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-capability.ts
@@ -161,6 +161,24 @@ export interface ICliAdapter {
    * Called on shutdown.
    */
   dispose(): Promise<void>;
+
+  /**
+   * (#2540) Optional: list models the underlying CLI installation/runtime
+   * has available. Implementations should cache for ~5 min and throw on
+   * failure so the caller can fall back. Adapters whose CLIs have no
+   * native list surface (claude, codex, gemini) leave this undefined.
+   */
+  listModels?(): Promise<readonly CliModelInfo[]>;
+}
+
+/**
+ * (#2540) One row from a CLI's `models`-listing surface. `id` matches what
+ * the CLI accepts as `--model`. `provider` is split out when the CLI uses
+ * `provider/model` ids (e.g. opencode `anthropic/claude-3-5-sonnet`).
+ */
+export interface CliModelInfo {
+  readonly id: string;
+  readonly provider?: string;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/types.ts
+++ b/packages/nexus-agents/src/cli-adapters/types.ts
@@ -34,6 +34,7 @@ export type {
   ICliAdapter,
   ICliResponseParser,
   VersionRequirements,
+  CliModelInfo,
 } from './types-capability.js';
 
 export { CLI_VERSION_REQUIREMENTS, DEFAULT_CAPABILITIES } from './types-capability.js';

--- a/packages/nexus-agents/src/config/available-models-cache.test.ts
+++ b/packages/nexus-agents/src/config/available-models-cache.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for AvailableModelsCache (#2540 PR 6).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { AvailableModelsCache, type AvailableModelsSource } from './available-models-cache.js';
+
+function source(name: string, ids: string[], providerHint?: string): AvailableModelsSource {
+  const list = vi.fn(() => Promise.resolve(ids.map((id) => ({ id }))));
+  return providerHint !== undefined
+    ? { name, providerHint, listModels: list }
+    : { name, listModels: list };
+}
+
+function failingSource(name: string, message = 'boom'): AvailableModelsSource {
+  return { name, listModels: () => Promise.reject(new Error(message)) };
+}
+
+describe('AvailableModelsCache (#2540)', () => {
+  it('unions ids across sources and tags by provider', async () => {
+    const claude = source('claude', ['claude-opus-4-7'], 'anthropic');
+    const opencode = source('opencode', ['opencode/big-pickle', 'anthropic/claude-haiku-3.5']);
+    const cache = new AvailableModelsCache({ sources: [claude, opencode] });
+    const all = await cache.getAll();
+    expect(all).toHaveLength(3);
+    expect(all.find((m) => m.id === 'claude-opus-4-7')?.provider).toBe('anthropic');
+    expect(all.find((m) => m.id === 'opencode/big-pickle')?.provider).toBe('opencode');
+    expect(all.find((m) => m.id === 'anthropic/claude-haiku-3.5')?.provider).toBe('anthropic');
+  });
+
+  it('caches within TTL — second call does not re-probe', async () => {
+    const probe = vi.fn(() => Promise.resolve([{ id: 'gpt-4o' }]));
+    const src: AvailableModelsSource = { name: 'gateway', listModels: probe };
+    const cache = new AvailableModelsCache({ sources: [src] });
+    await cache.getAll();
+    await cache.getAll();
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves stale value while kicking a background refresh', async () => {
+    let calls = 0;
+    let now = 1_000_000;
+    const probe = vi.fn(() => {
+      calls += 1;
+      return Promise.resolve([{ id: `v${String(calls)}` }]);
+    });
+    const src: AvailableModelsSource = { name: 'gateway', listModels: probe };
+    const cache = new AvailableModelsCache({
+      sources: [src],
+      ttlMs: 100,
+      staleTtlMs: 1000,
+      now: () => now,
+    });
+    const first = await cache.getAll();
+    expect(first[0]?.id).toBe('v1');
+    now += 200; // beyond ttlMs (100), within staleTtlMs (1000)
+    const second = await cache.getAll();
+    expect(second[0]?.id).toBe('v1'); // served stale
+    // background refresh is now in flight or completed; await microtasks
+    await new Promise((r) => setTimeout(r, 0));
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks on refresh when fully expired', async () => {
+    let now = 1_000_000;
+    const probe = vi.fn(() => Promise.resolve([{ id: 'v' }]));
+    const src: AvailableModelsSource = { name: 'g', listModels: probe };
+    const cache = new AvailableModelsCache({
+      sources: [src],
+      ttlMs: 100,
+      staleTtlMs: 1000,
+      now: () => now,
+    });
+    await cache.getAll();
+    now += 5000; // past stale TTL
+    await cache.getAll();
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it('one failing source does not poison the union', async () => {
+    const ok = source('ok', ['a']);
+    const bad = failingSource('bad');
+    const cache = new AvailableModelsCache({ sources: [ok, bad] });
+    const all = await cache.getAll();
+    expect(all).toEqual([{ id: 'a', source: 'ok' }]);
+  });
+
+  it('byProvider filters by source name', async () => {
+    const a = source('a', ['x']);
+    const b = source('b', ['y']);
+    const cache = new AvailableModelsCache({ sources: [a, b] });
+    expect(await cache.byProvider('a')).toEqual([{ id: 'x', source: 'a' }]);
+  });
+
+  it('has() returns true iff a source reports the id', async () => {
+    const cache = new AvailableModelsCache({ sources: [source('a', ['x'])] });
+    expect(await cache.has('x')).toBe(true);
+    expect(await cache.has('y')).toBe(false);
+  });
+
+  it('refresh() invalidates every source and re-probes', async () => {
+    const probe = vi.fn(() => Promise.resolve([{ id: 'x' }]));
+    const cache = new AvailableModelsCache({
+      sources: [{ name: 'a', listModels: probe }],
+    });
+    await cache.getAll();
+    await cache.getAll();
+    expect(probe).toHaveBeenCalledTimes(1);
+    await cache.refresh();
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares the in-flight probe across concurrent callers', async () => {
+    let resolveFn: (v: { id: string }[]) => void = () => {};
+    const probe = vi.fn(
+      () =>
+        new Promise<{ id: string }[]>((r) => {
+          resolveFn = r;
+        })
+    );
+    const cache = new AvailableModelsCache({
+      sources: [{ name: 'a', listModels: probe }],
+    });
+    const a = cache.getAll();
+    const b = cache.getAll();
+    resolveFn([{ id: 'x' }]);
+    await Promise.all([a, b]);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/config/available-models-cache.ts
+++ b/packages/nexus-agents/src/config/available-models-cache.ts
@@ -1,0 +1,203 @@
+/**
+ * AvailableModelsCache (#2540 PR 6 of 8).
+ *
+ * Central, harness-driven view of what models the runtime can actually
+ * dispatch to right now. PR 5 added `listModels()` on direct-API adapters
+ * (Anthropic, Google, OpenAI gateway) and on the OpenCode CLI adapter;
+ * this cache stitches those probes together into one queryable surface.
+ *
+ * Design invariants:
+ *
+ *   1. Sources are the source of truth — if a harness drops a model,
+ *      the registry never decides it's still routable. The
+ *      `ModelRegistry` (PR 1) answers "how should this model behave"
+ *      while this cache answers "is this model routable at all".
+ *
+ *   2. Stale-while-revalidate: serve the most recent successful result
+ *      while a refresh runs in the background, so callers never block on
+ *      a slow `models.list` round-trip.
+ *
+ *   3. One bad source must not poison the others. A failing `listModels`
+ *      logs and is excluded from the next snapshot; remaining sources
+ *      remain queryable.
+ *
+ *   4. No persistence. Process-local cache only — operators restart and
+ *      get a fresh probe. Persistence belongs in PR 7 if it's needed.
+ */
+
+import { createLogger } from '../core/logger.js';
+
+const logger = createLogger({ component: 'available-models-cache' });
+
+/** Default freshness TTL: 5 minutes — matches per-adapter listModels TTL. */
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+/** Default stale TTL: 25 minutes — beyond this, callers wait on a refresh. */
+const DEFAULT_STALE_TTL_MS = 25 * 60 * 1000;
+
+/**
+ * One adapter (CLI or API) that can be asked what models it currently has.
+ * Exists so this cache doesn't have to know about IModelAdapter vs
+ * ICliAdapter — both can adapt themselves to this minimal surface.
+ */
+export interface AvailableModelsSource {
+  /** Stable, human-readable identifier — e.g. `claude`, `gateway-openrouter`. */
+  readonly name: string;
+  /**
+   * Optional vendor-family hint — `anthropic` / `openai` / `google` / etc.
+   * Used to pre-tag entries when the source's own model ids don't carry
+   * a `provider/` prefix (Anthropic API, Google API).
+   */
+  readonly providerHint?: string;
+  /** Probe the underlying surface for currently available models. */
+  listModels(): Promise<readonly { id: string }[]>;
+}
+
+/** One row in the cache: model id + which source first reported it. */
+export interface AvailableModel {
+  readonly id: string;
+  readonly source: string;
+  /** `provider/` prefix when the source uses one; otherwise the providerHint. */
+  readonly provider?: string;
+}
+
+export interface AvailableModelsCacheOptions {
+  readonly sources: readonly AvailableModelsSource[];
+  /** Freshness TTL (ms). Defaults to 5 minutes. */
+  readonly ttlMs?: number;
+  /** Beyond this, callers block on the next refresh. Defaults to 25 minutes. */
+  readonly staleTtlMs?: number;
+  /** Override `Date.now` for tests. */
+  readonly now?: () => number;
+}
+
+interface SourceState {
+  value: readonly AvailableModel[] | null;
+  fetchedAt: number;
+  inFlight: Promise<readonly AvailableModel[]> | null;
+}
+
+export class AvailableModelsCache {
+  private readonly sources: readonly AvailableModelsSource[];
+  private readonly ttlMs: number;
+  private readonly staleTtlMs: number;
+  private readonly now: () => number;
+  private readonly states: Map<string, SourceState>;
+
+  constructor(options: AvailableModelsCacheOptions) {
+    this.sources = options.sources;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.staleTtlMs = options.staleTtlMs ?? DEFAULT_STALE_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.states = new Map();
+    for (const s of this.sources) {
+      this.states.set(s.name, { value: null, fetchedAt: 0, inFlight: null });
+    }
+  }
+
+  /**
+   * Returns the union of every source's available models. Stale-while-
+   * revalidate: serve fresh-or-stale immediately, refresh stale entries
+   * in the background. First call (no cache yet) blocks on every source.
+   */
+  async getAll(): Promise<readonly AvailableModel[]> {
+    const probes = this.sources.map((s) => this.probeOne(s));
+    const results = await Promise.all(probes);
+    const out: AvailableModel[] = [];
+    for (const r of results) {
+      for (const m of r) out.push(m);
+    }
+    return out;
+  }
+
+  /** Models reported by one named source (subset of getAll). */
+  async byProvider(sourceName: string): Promise<readonly AvailableModel[]> {
+    const all = await this.getAll();
+    return all.filter((m) => m.source === sourceName);
+  }
+
+  /** True iff some source currently reports the given model id. */
+  async has(modelId: string): Promise<boolean> {
+    const all = await this.getAll();
+    return all.some((m) => m.id === modelId);
+  }
+
+  /** Force a synchronous refresh of every source — used after a 404. */
+  async refresh(): Promise<readonly AvailableModel[]> {
+    for (const s of this.sources) {
+      const state = this.states.get(s.name);
+      if (state === undefined) continue;
+      state.fetchedAt = 0;
+      state.value = null;
+    }
+    return this.getAll();
+  }
+
+  /**
+   * Probe one source. Returns:
+   *  - cached value if still fresh
+   *  - cached value AND kicks a background refresh if stale-but-not-expired
+   *  - blocks on the source if no cache or fully expired
+   *
+   * Source errors yield an empty list (logged) so one bad source can't
+   * poison the union.
+   */
+  private async probeOne(source: AvailableModelsSource): Promise<readonly AvailableModel[]> {
+    const state = this.getState(source.name);
+    const age = this.now() - state.fetchedAt;
+
+    if (state.value !== null && age < this.ttlMs) {
+      return state.value;
+    }
+    if (state.value !== null && age < this.staleTtlMs) {
+      state.inFlight ??= this.fetchSource(source).finally(() => {
+        state.inFlight = null;
+      });
+      return state.value;
+    }
+    if (state.inFlight !== null) return state.inFlight;
+    state.inFlight = this.fetchSource(source).finally(() => {
+      state.inFlight = null;
+    });
+    return state.inFlight;
+  }
+
+  private async fetchSource(source: AvailableModelsSource): Promise<readonly AvailableModel[]> {
+    const state = this.getState(source.name);
+    try {
+      const raw = await source.listModels();
+      const value = raw.map((m) => normaliseEntry(m, source));
+      state.value = value;
+      state.fetchedAt = this.now();
+      return value;
+    } catch (e: unknown) {
+      logger.warn('AvailableModelsCache source probe failed', {
+        source: source.name,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      // Keep the stale value if we have one; otherwise empty.
+      return state.value ?? [];
+    }
+  }
+
+  private getState(name: string): SourceState {
+    const state = this.states.get(name);
+    // Constructor seeds an entry for every configured source, and the public
+    // surface only routes through `this.sources`, so a missing state would
+    // be a programming error — surface it loudly rather than masking it.
+    if (state === undefined) {
+      throw new Error(`AvailableModelsCache: unknown source "${name}"`);
+    }
+    return state;
+  }
+}
+
+function normaliseEntry(raw: { id: string }, source: AvailableModelsSource): AvailableModel {
+  const slash = raw.id.indexOf('/');
+  if (slash > 0 && slash < raw.id.length - 1) {
+    return { id: raw.id, source: source.name, provider: raw.id.slice(0, slash) };
+  }
+  if (source.providerHint !== undefined) {
+    return { id: raw.id, source: source.name, provider: source.providerHint };
+  }
+  return { id: raw.id, source: source.name };
+}

--- a/packages/nexus-agents/src/config/index.ts
+++ b/packages/nexus-agents/src/config/index.ts
@@ -288,3 +288,14 @@ export type {
   ToolDefinitionFormat,
   PromptCachingMode,
 } from './model-registry.js';
+
+// (#2540 PR 6) Harness-driven cache of currently-available models.
+// `ModelRegistry` answers "how should this model behave"; this cache
+// answers "is this model routable right now". CompositeRouter (PR 7)
+// gates on this cache before scoring.
+export { AvailableModelsCache } from './available-models-cache.js';
+export type {
+  AvailableModelsSource,
+  AvailableModel,
+  AvailableModelsCacheOptions,
+} from './available-models-cache.js';


### PR DESCRIPTION
## Summary

PR 7 of 8 in epic #2540. Wires `AvailableModelsCache` (PR 6) into `CompositeRouter`. Stacked on top of #2543 (PR 6).

When a cache is configured:

- The router gates its candidate-CLI list on `cache.getAll()` before running the routing pipeline.
- A CLI is excluded only when the cache reports zero models for it (the source's `listModels()` returned an empty list).
- An empty cache union (cold start, all sources failing) falls back to all registered CLIs — the gate never wedges routing on a transient cache miss.
- Cache errors do not block routing — logged and treated as "no gating."

`getAvailableModelsCache()` exposes the wired cache (or `undefined`) for downstream consumers — PR 8's runtime model-not-found fallback uses this.

## Deferred to follow-on

OutcomeStore key-normalization (using ModelRegistry's `resolveModelIdentity` to normalize per-model keys) — the registry is available now but the actual wiring touches more than this PR's scope.

## Test plan
- [x] 5 new unit tests covering cache wiring, fallbacks (empty union, empty filter), and error tolerance
- [x] Existing 63 router tests still pass
- [x] `pnpm typecheck` clean

## Stacked
- #2543 (PR 6) → this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)