### PR TITLE
feat(adapters): runtime retire-and-retry on MODEL_NOT_FOUND (#2540 PR 8)

### DIFF
--- a/.changeset/2540-pr8-model-not-found-fallback.md
+++ b/.changeset/2540-pr8-model-not-found-fallback.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+`withModelNotFoundFallback` — runtime retire-and-retry primitive (#2540 PR 8 of 8, completes the epic).
+
+When a vendor retires a model id (Codex moving to GPT-5.4 while older 5.x releases 404, Anthropic bumping minor versions, etc.), the next request returns 404 / `model_not_found` / "this model is deprecated." This PR closes that gap end-to-end:
+
+- **Distinct error code**: `ErrorCode.MODEL_NOT_FOUND`. `BaseAdapter` now classifies HTTP 404 + the standard vendor messages ("model not found", "no such model", "model is deprecated", etc.) under this code, separate from transient `MODEL_UNAVAILABLE` (502/503).
+- **Wrapper utility**: `withModelNotFoundFallback(adapter, { cache, registry?, adapterFactory?, onRetirement? })`. On a `MODEL_NOT_FOUND`, the wrapper refreshes the `AvailableModelsCache` (PR 6), uses `ModelRegistry` (PR 1) to find the closest same-vendor/same-family alternative from what's now routable, and:
+  - With an `adapterFactory`: builds a fallback adapter and retries the call once. Returns the second error verbatim if the retry fails.
+  - Without a factory: surfaces the original error enriched with the suggested fallback id, so the caller can re-route.
+- **Single retry by design** — looping risks wedging when a whole family is retired. Caller escalates after one attempt.
+- **Streams left as passthrough** — streaming retries need partial-result reconciliation that belongs in a follow-up.
+
+Closes the wiring loop opened by epic #2540: PR 1 unified the registry, PR 2 migrated AgenticAdapter, PR 5 added `listModels()` across direct-API and CLI adapters, PR 6 stitched those probes into a stale-while-revalidate cache, PR 7 gated `CompositeRouter`'s candidate set on the cache, and PR 8 closes the loop at the call site — when an inflight request hits a retired id, the system observes the retirement, picks a fallback, and keeps moving.

--- a/packages/nexus-agents/docs/research/registry/papers.yaml
+++ b/packages/nexus-agents/docs/research/registry/papers.yaml
@@ -1,0 +1,2 @@
+schema_version: '1.0'
+papers: {}

--- a/packages/nexus-agents/docs/research/registry/techniques.yaml
+++ b/packages/nexus-agents/docs/research/registry/techniques.yaml
@@ -1,0 +1,2 @@
+schema_version: '1.0'
+techniques: {}

--- a/packages/nexus-agents/src/adapters/base-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/base-adapter.test.ts
@@ -407,6 +407,22 @@ describe('BaseAdapter', () => {
       );
     });
 
+    it('should set MODEL_NOT_FOUND for 404 status (#2540 PR 8)', () => {
+      const error = Object.assign(new Error('Not found'), { status: 404 });
+      expect(adapter.testTransformError(error).code).toBe(ErrorCode.MODEL_NOT_FOUND);
+    });
+
+    it.each([
+      'model not found',
+      'model_not_found',
+      'no such model',
+      'model is deprecated',
+      'model has been deprecated',
+      'model is no longer available',
+    ])('should classify "%s" message as MODEL_NOT_FOUND (#2540 PR 8)', (msg) => {
+      expect(adapter.testTransformError(new Error(msg)).code).toBe(ErrorCode.MODEL_NOT_FOUND);
+    });
+
     it('should log the error', () => {
       adapter.testTransformError(new Error('Test error'));
       expect(mockLogger.error).toHaveBeenCalledWith(

--- a/packages/nexus-agents/src/adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/adapters/base-adapter.ts
@@ -376,12 +376,40 @@ export abstract class BaseAdapter implements IModelAdapter {
       return ErrorCode.MODEL_TIMEOUT;
     }
 
+    // Check for model-not-found (#2540 PR 8) — distinct from transient
+    // MODEL_UNAVAILABLE (502/503). 404 + vendor-specific phrases ("model
+    // not found", "deprecated", "no such model") all mean: this id is
+    // gone, retry won't help, route to a different one.
+    if (this.isModelNotFoundError(message, errorObj)) {
+      return ErrorCode.MODEL_NOT_FOUND;
+    }
+
     // Check for model unavailable
     if (this.isUnavailableError(message, errorObj)) {
       return ErrorCode.MODEL_UNAVAILABLE;
     }
 
     return ErrorCode.MODEL_ERROR;
+  }
+
+  /**
+   * (#2540 PR 8) Detect model-retirement errors. Distinct from transient
+   * 502/503: 404 + vendor messages indicating the model id is gone.
+   */
+  private isModelNotFoundError(
+    message: string,
+    errorObj: { status?: number; code?: string }
+  ): boolean {
+    if (errorObj.status === 404) return true;
+    const patterns = [
+      'model not found',
+      'model_not_found',
+      'no such model',
+      'model is deprecated',
+      'model has been deprecated',
+      'model is no longer available',
+    ];
+    return patterns.some((p) => message.includes(p));
   }
 
   /**

--- a/packages/nexus-agents/src/adapters/index.ts
+++ b/packages/nexus-agents/src/adapters/index.ts
@@ -183,3 +183,9 @@ export {
 export { SdkAdapter } from './sdk/index.js';
 export type { SdkAdapterConfig, SdkProviderId } from './sdk/index.js';
 export { PROVIDER_ENV_KEYS } from './sdk/index.js';
+
+// (#2540 PR 8) Runtime retire-and-retry primitive — wraps any
+// IModelAdapter so a `MODEL_NOT_FOUND` error refreshes the
+// AvailableModelsCache and retries through the closest sibling.
+export { withModelNotFoundFallback } from './model-not-found-fallback.js';
+export type { ModelNotFoundFallbackOptions, RetirementInfo } from './model-not-found-fallback.js';

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for `withModelNotFoundFallback` (#2540 PR 8).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { withModelNotFoundFallback } from './model-not-found-fallback.js';
+import {
+  err,
+  ErrorCode,
+  ModelError,
+  ok,
+  type IModelAdapter,
+  type CompletionRequest,
+  type CompletionResponse,
+  type Result,
+} from '../core/index.js';
+import { AvailableModelsCache } from '../config/available-models-cache.js';
+
+function fakeAdapter(
+  modelId: string,
+  complete: (req: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
+): IModelAdapter {
+  return {
+    providerId: 'anthropic',
+    modelId,
+    capabilities: [],
+    complete,
+    stream: (): AsyncIterable<never> => {
+      throw new Error('not implemented');
+    },
+    countTokens: () => Promise.resolve(0),
+    validateConfig: () => ok(undefined),
+  };
+}
+
+function successResponse(content = 'ok'): Result<CompletionResponse, ModelError> {
+  return ok({
+    content: [{ type: 'text', text: content }],
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    stopReason: 'end_turn',
+    model: 'mocked',
+  });
+}
+
+const dummyRequest: CompletionRequest = { messages: [{ role: 'user', content: 'hi' }] };
+
+describe('withModelNotFoundFallback (#2540 PR 8)', () => {
+  it('passes through successful complete()', async () => {
+    const inner = fakeAdapter('claude-opus-4-7', () => Promise.resolve(successResponse()));
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(true);
+  });
+
+  it('passes through non-MODEL_NOT_FOUND errors untouched', async () => {
+    const inner = fakeAdapter('claude-opus-4-7', () =>
+      Promise.resolve(err(new ModelError('rate limited', { code: ErrorCode.MODEL_RATE_LIMITED })))
+    );
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+  });
+
+  it('on MODEL_NOT_FOUND with no factory, surfaces enriched error w/ fallback id', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(
+        err(new ModelError('404 model_not_found', { code: ErrorCode.MODEL_NOT_FOUND }))
+      )
+    );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe(ErrorCode.MODEL_NOT_FOUND);
+      expect(r.error.message).toContain('claude-opus-4-7');
+    }
+  });
+
+  it('on MODEL_NOT_FOUND with factory, retries through new adapter and returns success', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const fallbackComplete = vi.fn(() => Promise.resolve(successResponse('from-fallback')));
+    const factory = vi.fn(() => fakeAdapter('claude-opus-4-7', fallbackComplete));
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache, adapterFactory: factory });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(true);
+    expect(factory).toHaveBeenCalledWith('claude-opus-4-7');
+    expect(fallbackComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the second error if the fallback adapter also fails', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const factory = (): IModelAdapter =>
+      fakeAdapter('claude-opus-4-7', () =>
+        Promise.resolve(err(new ModelError('boom', { code: ErrorCode.MODEL_RATE_LIMITED })))
+      );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache, adapterFactory: factory });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+      expect(r.error.message).toContain('Fallback claude-opus-4-7');
+    }
+  });
+
+  it('surfaces the original error when no fallback can be found', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const cache = new AvailableModelsCache({
+      sources: [{ name: 'anthropic', listModels: () => Promise.resolve([]) }],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('404');
+  });
+
+  it('falls back across vendors only as a last resort (same family preferred)', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () =>
+            Promise.resolve([
+              { id: 'claude-haiku-3.5' }, // same vendor, different family
+              { id: 'claude-opus-4-7' }, // same family — should win
+            ]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    if (r.ok) throw new Error('expected error');
+    expect(r.error.message).toContain('claude-opus-4-7');
+  });
+
+  it('invokes onRetirement with retired + fallback ids', async () => {
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const onRetirement = vi.fn();
+    const wrapped = withModelNotFoundFallback(inner, { cache, onRetirement });
+    await wrapped.complete(dummyRequest);
+    expect(onRetirement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retiredModelId: 'claude-opus-4-6',
+        fallbackModelId: 'claude-opus-4-7',
+      })
+    );
+  });
+});

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
@@ -1,0 +1,212 @@
+/**
+ * withModelNotFoundFallback (#2540 PR 8 of 8).
+ *
+ * Wraps an `IModelAdapter` so that calls that fail with `MODEL_NOT_FOUND`
+ * (404 / "model is deprecated" / etc.) are retried once with the closest
+ * available alternative from the same vendor family — picked from the
+ * adapter's `listModels()` and the registry.
+ *
+ * Why this exists: nexus-agents has historically baked model ids into
+ * configuration. When a vendor retires a model (Codex on GPT-5.4 vs an
+ * older 5.1, Claude bumping minor versions, etc.), the next request 404s.
+ * This primitive turns that 404 into a single observable retry against
+ * the latest sibling — operators see the retirement in the log, work
+ * keeps moving, and the cache (PR 6) is invalidated so subsequent calls
+ * pick up the new ground truth.
+ *
+ * Design notes:
+ *   - Single retry only. If the fallback also 404s, surface the second
+ *     error (callers can escalate). Don't loop — that risks wedging.
+ *   - The wrapper keeps the same `providerId`/`modelId` shape as the
+ *     wrapped adapter so downstream consumers (telemetry, OutcomeStore)
+ *     don't see schema changes. The chosen fallback id appears in
+ *     `errorMessage` of the original error and in the logger.
+ *   - `stream()` is left as passthrough — streaming retries belong in
+ *     a future iteration where partial-result reconciliation is handled.
+ */
+
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  IModelAdapter,
+  ModelError,
+  Result,
+  StreamChunk,
+} from '../core/index.js';
+import { err, ErrorCode, ok, ModelError as ModelErrorClass } from '../core/index.js';
+import { createLogger } from '../core/logger.js';
+import { getDefaultRegistry, type ModelRegistry } from '../config/model-registry.js';
+import type { AvailableModelsCache } from '../config/available-models-cache.js';
+
+const logger = createLogger({ component: 'model-not-found-fallback' });
+
+export interface ModelNotFoundFallbackOptions {
+  /** Process-local cache of routable models. Refreshed on a 404. */
+  readonly cache: AvailableModelsCache;
+  /** Registry used to resolve vendor/family from a model id. Defaults to global. */
+  readonly registry?: ModelRegistry;
+  /**
+   * Optional adapter factory used to build a new IModelAdapter for the
+   * fallback model id. When provided, the wrapper retries through the
+   * factory's adapter. When omitted, the wrapper logs + emits a
+   * `MODEL_NOT_FOUND` error enriched with the suggested fallback id —
+   * the caller (orchestrator / router) is responsible for re-routing.
+   */
+  readonly adapterFactory?: (modelId: string) => IModelAdapter;
+  /**
+   * Optional callback invoked when a retirement is detected. Use for
+   * telemetry / sticky-state updates. Failures in the callback are
+   * swallowed — the user's call is what matters.
+   */
+  readonly onRetirement?: (info: RetirementInfo) => void;
+}
+
+export interface RetirementInfo {
+  readonly retiredModelId: string;
+  readonly fallbackModelId: string;
+  readonly providerId: string;
+  readonly errorMessage: string;
+}
+
+/**
+ * Decorate an IModelAdapter with retire-and-retry. Behaviour:
+ *
+ *  1. Forward `complete(request)` to the inner adapter.
+ *  2. On `MODEL_NOT_FOUND`: refresh the cache, find the closest
+ *     same-family alternative, retry once with `request.model =
+ *     <fallback>`. Original error is returned if no fallback found.
+ *  3. The wrapper returns the SECOND error if the retry also fails.
+ *  4. `stream`, `countTokens`, `validateConfig`, `listModels` are
+ *     passthrough.
+ */
+export function withModelNotFoundFallback(
+  inner: IModelAdapter,
+  options: ModelNotFoundFallbackOptions
+): IModelAdapter {
+  const registry = options.registry ?? getDefaultRegistry();
+  const wrapped: IModelAdapter = {
+    providerId: inner.providerId,
+    modelId: inner.modelId,
+    capabilities: inner.capabilities,
+    countTokens: (text) => inner.countTokens(text),
+    validateConfig: () => inner.validateConfig(),
+    stream: (request: CompletionRequest): AsyncIterable<StreamChunk> => inner.stream(request),
+    complete: (request: CompletionRequest) =>
+      completeWithFallback(inner, request, options, registry),
+  };
+  if (typeof inner.listModels === 'function') {
+    const list = inner.listModels.bind(inner);
+    wrapped.listModels = () => list();
+  }
+  return wrapped;
+}
+
+async function completeWithFallback(
+  inner: IModelAdapter,
+  request: CompletionRequest,
+  options: ModelNotFoundFallbackOptions,
+  registry: ModelRegistry
+): Promise<Result<CompletionResponse, ModelError>> {
+  const first = await inner.complete(request);
+  if (first.ok) return first;
+  if (first.error.code !== ErrorCode.MODEL_NOT_FOUND) return first;
+
+  const fallback = await pickFallback(inner.modelId, options.cache, registry);
+  if (fallback === null) {
+    logger.warn('Model not found and no fallback available', {
+      modelId: inner.modelId,
+      providerId: inner.providerId,
+      errorMessage: first.error.message,
+    });
+    return first;
+  }
+
+  logger.info('Model retirement detected; retrying with fallback', {
+    retiredModelId: inner.modelId,
+    fallbackModelId: fallback,
+    providerId: inner.providerId,
+  });
+  notifyRetirement(options.onRetirement, {
+    retiredModelId: inner.modelId,
+    fallbackModelId: fallback,
+    providerId: inner.providerId,
+    errorMessage: first.error.message,
+  });
+
+  // No factory wired → enrich the original error with a suggested
+  // fallback id and let the caller decide. This is the safe default
+  // for adapters where reconfiguring per-call isn't supported.
+  if (options.adapterFactory === undefined) {
+    return err(
+      new ModelErrorClass(`${first.error.message} — suggested fallback: ${fallback}`, {
+        code: ErrorCode.MODEL_NOT_FOUND,
+        cause: first.error,
+      })
+    );
+  }
+
+  const fallbackAdapter = options.adapterFactory(fallback);
+  const retried = await fallbackAdapter.complete(request);
+  if (retried.ok) return retried;
+  // Surface the SECOND error so callers see the retry's failure
+  // mode, not the (already-handled) original 404.
+  return err(
+    new ModelErrorClass(`Fallback ${fallback} also failed: ${retried.error.message}`, {
+      code: retried.error.code,
+      cause: retried.error,
+    })
+  );
+}
+
+function notifyRetirement(
+  cb: ((info: RetirementInfo) => void) | undefined,
+  info: RetirementInfo
+): void {
+  if (cb === undefined) return;
+  try {
+    cb(info);
+  } catch (e: unknown) {
+    logger.debug('onRetirement callback threw', {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+}
+
+/**
+ * Pick the closest available alternative to a retired model. Strategy:
+ *   1. Refresh the cache (the retirement signal is authoritative).
+ *   2. Resolve the retired id's vendor + family via the registry.
+ *   3. Among the now-available ids, take the first match in the same
+ *      family. If none match family, fall back to vendor.
+ *   4. If still nothing, return null — surfaces the original error.
+ *
+ * Deliberately simple — picking the "best" sibling deserves its own
+ * scoring/ranking pass; here we just need ANY same-family id to keep
+ * the user moving. Caller logs both ids so the behaviour is auditable.
+ */
+async function pickFallback(
+  retiredModelId: string,
+  cache: AvailableModelsCache,
+  registry: ModelRegistry
+): Promise<string | null> {
+  const refreshed = await cache.refresh();
+  if (refreshed.length === 0) return null;
+  const target = registry.getEntry(retiredModelId);
+
+  const sameFamily = refreshed.find((m) => {
+    if (m.id === retiredModelId) return false;
+    const candidate = registry.getEntry(m.id);
+    return candidate.family === target.family && candidate.vendor === target.vendor;
+  });
+  if (sameFamily !== undefined) return sameFamily.id;
+
+  const sameVendor = refreshed.find((m) => {
+    if (m.id === retiredModelId) return false;
+    const candidate = registry.getEntry(m.id);
+    return candidate.vendor === target.vendor;
+  });
+  return sameVendor?.id ?? null;
+}
+
+// Re-export ok for tests that synthesise success results.
+export { ok };

--- a/packages/nexus-agents/src/core/errors.ts
+++ b/packages/nexus-agents/src/core/errors.ts
@@ -22,6 +22,15 @@ export const ErrorCode = {
   // Model errors
   MODEL_ERROR: 'MODEL_ERROR',
   MODEL_UNAVAILABLE: 'MODEL_UNAVAILABLE',
+  /**
+   * Model is reachable but the requested id no longer exists — typically a
+   * 404 from /v1/chat/completions, an Anthropic `model_not_found` error,
+   * or a vendor "this model has been deprecated" message. Distinct from
+   * MODEL_UNAVAILABLE (transient 502/503 service overload) — this one
+   * means the model is gone, retry won't help, route to a different id.
+   * See `withModelNotFoundFallback` for the retire-and-retry primitive.
+   */
+  MODEL_NOT_FOUND: 'MODEL_NOT_FOUND',
   MODEL_RATE_LIMITED: 'MODEL_RATE_LIMITED',
   MODEL_TIMEOUT: 'MODEL_TIMEOUT',
 

--- a/packages/nexus-agents/src/exports/adapters.ts
+++ b/packages/nexus-agents/src/exports/adapters.ts
@@ -79,4 +79,11 @@ export {
   PROVIDER_ENV_KEYS as SDK_PROVIDER_ENV_KEYS,
   type SdkAdapterConfig,
   type SdkProviderId,
+  // (#2540 PR 8) Runtime retire-and-retry on MODEL_NOT_FOUND.
+  // Wraps any IModelAdapter so a 404 / "model is deprecated" error
+  // refreshes the AvailableModelsCache and retries through the
+  // closest sibling per the registry.
+  withModelNotFoundFallback,
+  type ModelNotFoundFallbackOptions,
+  type RetirementInfo,
 } from '../adapters/index.js';

--- a/packages/nexus-agents/src/exports/config.ts
+++ b/packages/nexus-agents/src/exports/config.ts
@@ -48,3 +48,23 @@ export {
   type ProbeFn,
   type FallbackEntry,
 } from '../config/index.js';
+
+// (#2540) Unified ModelRegistry + harness-driven AvailableModelsCache.
+// Registry answers "how should this model behave"; cache answers
+// "is this model routable right now". Both are public surface.
+export {
+  ModelRegistry,
+  deriveEntry,
+  getDefaultRegistry,
+  setDefaultRegistry,
+  DEFAULT_ENTRY,
+  AvailableModelsCache,
+  type ModelEntry,
+  type ModelRegistryOptions,
+  type EntrySource,
+  type ToolDefinitionFormat,
+  type PromptCachingMode,
+  type AvailableModelsSource,
+  type AvailableModel,
+  type AvailableModelsCacheOptions,
+} from '../config/index.js';


### PR DESCRIPTION
## Summary

PR 8 of 8 in epic #2540 — closes the wiring loop end-to-end.

When a vendor retires a model id (Codex moving to GPT-5.4 while older 5.x releases 404, Anthropic bumping minor versions, etc.), the next request returns 404 / `model_not_found` / "this model is deprecated." Today nexus-agents bubbles that as a generic ModelError. After this PR:

1. **Distinct error code**: `ErrorCode.MODEL_NOT_FOUND`. `BaseAdapter` now classifies HTTP 404 + the standard vendor messages ("model not found", "no such model", "model is deprecated", etc.) under this code, separate from transient `MODEL_UNAVAILABLE` (502/503).

2. **Retire-and-retry primitive**: `withModelNotFoundFallback(adapter, { cache, registry?, adapterFactory?, onRetirement? })`. On a `MODEL_NOT_FOUND`:
   - Refreshes the `AvailableModelsCache` (PR 6).
   - Uses `ModelRegistry` (PR 1) to find the closest same-vendor/same-family alternative from what's now routable.
   - **With `adapterFactory`** → builds a fallback adapter and retries once. Returns the second error verbatim if the retry fails.
   - **Without a factory** → surfaces the original error enriched with the suggested fallback id, so the caller can re-route.

3. **Single retry by design** — looping risks wedging when a whole family is retired. Caller escalates after one attempt.

4. **Streams left as passthrough** — streaming retries need partial-result reconciliation; deferred to a follow-up.

## How this closes the epic

- PR 1 unified the registry (capabilities + behavior in one place).
- PR 2 migrated `AgenticAdapter` to the registry.
- PR 5 added `listModels()` across direct-API and CLI adapters.
- PR 6 stitched those probes into a stale-while-revalidate cache.
- PR 7 gated `CompositeRouter`'s candidate set on the cache.
- **PR 8 closes the loop at the call site** — when an inflight request hits a retired id, the system observes the retirement, picks a fallback, and keeps moving.

## Test plan
- [x] 8 new unit tests covering passthrough, error code routing, factory and no-factory paths, double-failure surface, no-fallback-found, family-preferred selection, retirement callback
- [x] 7 new base-adapter classification tests (404 + vendor-message patterns → `MODEL_NOT_FOUND`)
- [x] `pnpm typecheck` clean

## Deferred follow-ups (filed as issues if surfaced in operator usage)
- OutcomeStore key-normalization to track outcomes by resolved identity instead of literal id.
- Wire `withModelNotFoundFallback` into `UnifiedAdapterRegistry` factory paths so every constructed adapter benefits automatically.
- Streaming retry with partial-result reconciliation.
- `nexus-eval-*` repositories using the new registry/cache wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)