### PR TITLE
docs(comments): sweep stale references to deleted model-behavior-profile + ArxivCrossrefAdapter (#2554)

### DIFF
--- a/packages/nexus-agents/src/config/index.ts
+++ b/packages/nexus-agents/src/config/index.ts
@@ -270,10 +270,9 @@ export type {
 } from './model-availability.js';
 
 // Unified Model Registry (#2540) — single source of truth for per-model
-// metadata (capability + behaviour). Supersedes the split between
-// `model-capabilities.ts` (canonical hardcoded MODEL_IDS) and
-// `model-behavior-profile.ts` (vendor-pattern-matched profiles, now
-// @deprecated and scheduled for removal).
+// metadata (capability + behaviour). Replaces the prior split between
+// `model-capabilities.ts` (still in-tree; migration in #2546) and the
+// deleted `model-behavior-profile.ts`.
 export {
   ModelRegistry,
   deriveEntry,

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -3,10 +3,10 @@
  *
  * Single source of truth for per-model metadata. Replaces the previous
  * split between:
- *   - `model-capabilities.ts` (canonical hardcoded list, capability +
- *     pricing + quality + context-window data)
+ *   - `model-capabilities.ts` (canonical hardcoded list, still in-tree;
+ *     migration tracked in #2546)
  *   - `model-behavior-profile.ts` (vendor-pattern-matched runtime
- *     behaviour: parallel tool calls, prompt caching, etc.)
+ *     behaviour; file deleted in #2540 PR 2)
  *
  * Each `ModelEntry` carries BOTH capability and behaviour fields. The
  * registry's `getEntry()` always returns something — exact match if
@@ -49,8 +49,8 @@ import type {
 } from './model-capabilities-types.js';
 
 // ============================================================================
-// Per-model behaviour types (carried over from model-behavior-profile.ts —
-// that file is marked @deprecated in PR 2 and deleted in PR 3)
+// Per-model behaviour types — were previously split into model-behavior-profile.ts
+// (deleted in #2540 PR 2 when AgenticAdapter migrated to ModelRegistry).
 // ============================================================================
 
 /**

--- a/packages/nexus-agents/src/research/index.ts
+++ b/packages/nexus-agents/src/research/index.ts
@@ -137,9 +137,3 @@ export {
 // ============================================================================
 
 export { TOPIC_ALIASES, normalizeTopicToCanonical } from './topic-aliases.js';
-
-// ============================================================================
-// ArxivCrossref Adapter (Fallback Paper Source)
-// ============================================================================
-
-// ArxivCrossrefAdapter and decomposeResearch — pending lint cleanup, not yet exported


### PR DESCRIPTION
## Summary

Closes #2554. Three short comment cleanups across `packages/nexus-agents/src/`:

- `config/index.ts:272-276` — ModelRegistry barrel comment said the now-deleted `model-behavior-profile.ts` was "scheduled for removal." Rewritten to describe the actual current state (deleted in #2540 PR 2; `model-capabilities.ts` migration tracked in #2546).
- `config/model-registry.ts:1-9, 50-53` — header docstring + inline marker had the same stale "in-flight plans" framing. Both now describe what shipped.
- `research/index.ts:141-145` — drop the dead comment promising `ArxivCrossrefAdapter` and `decomposeResearch`. Grep finds zero definitions of either symbol in the package; they were planned, never built, and the comment was left behind. If the operator wants either implemented, a fresh feature issue is the right vehicle.

## Verification

```
$ grep -rn "ArxivCrossrefAdapter\|decomposeResearch" packages/nexus-agents/src/
(no results)

$ grep -rn "model-behavior-profile" packages/nexus-agents/src/
config/index.ts:275:// deleted `model-behavior-profile.ts`.
config/model-registry.ts:8:  *   - `model-behavior-profile.ts` (vendor-pattern-matched runtime
config/model-registry.ts:52:// Per-model behaviour types — were previously split into model-behavior-profile.ts
```

The remaining references are historical context in the registry's documentation (correctly framed as "deleted in #2540 PR 2") — they document why the registry exists and what it replaced, which is load-bearing for new readers.

## Test plan

- [x] `npx tsx scripts/inject-governance.ts check` — passes
- [x] `npx vitest run src/config/model-registry.test.ts` — 14/14 pass
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)