### PR TITLE
feat(adapters): auto-wire withModelNotFoundFallback into UnifiedAdapterRegistry (#2549)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,7 @@ _Auto-generated from source. 38 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-10_
+_Governance Version: 2026-05-11_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/adapters/index.ts
+++ b/packages/nexus-agents/src/adapters/index.ts
@@ -187,5 +187,12 @@ export { PROVIDER_ENV_KEYS } from './sdk/index.js';
 // (#2540 PR 8) Runtime retire-and-retry primitive — wraps any
 // IModelAdapter so a `MODEL_NOT_FOUND` error refreshes the
 // AvailableModelsCache and retries through the closest sibling.
-export { withModelNotFoundFallback } from './model-not-found-fallback.js';
-export type { ModelNotFoundFallbackOptions, RetirementInfo } from './model-not-found-fallback.js';
+export {
+  withModelNotFoundFallback,
+  wrapResilientWithFallback,
+} from './model-not-found-fallback.js';
+export type {
+  ModelNotFoundFallbackOptions,
+  RetirementInfo,
+  ResilientLike,
+} from './model-not-found-fallback.js';

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
@@ -1,8 +1,13 @@
 /**
- * Tests for `withModelNotFoundFallback` (#2540 PR 8).
+ * Tests for `withModelNotFoundFallback` (#2540 PR 8) and the
+ * `wrapResilientWithFallback` helper (#2549).
  */
-import { describe, it, expect, vi } from 'vitest';
-import { withModelNotFoundFallback } from './model-not-found-fallback.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  withModelNotFoundFallback,
+  wrapResilientWithFallback,
+  type ResilientLike,
+} from './model-not-found-fallback.js';
 import {
   err,
   ErrorCode,
@@ -13,7 +18,11 @@ import {
   type CompletionResponse,
   type Result,
 } from '../core/index.js';
-import { AvailableModelsCache } from '../config/available-models-cache.js';
+import {
+  AvailableModelsCache,
+  getDefaultAvailableModelsCache,
+  setDefaultAvailableModelsCache,
+} from '../config/available-models-cache.js';
 
 function fakeAdapter(
   modelId: string,
@@ -193,5 +202,127 @@ describe('withModelNotFoundFallback (#2540 PR 8)', () => {
         fallbackModelId: 'claude-opus-4-7',
       })
     );
+  });
+});
+
+// ============================================================================
+// Singleton default cache (#2549)
+// ============================================================================
+
+describe('default AvailableModelsCache singleton (#2549)', () => {
+  afterEach(() => {
+    // Reset the default so test order is irrelevant.
+    setDefaultAvailableModelsCache(null);
+  });
+
+  it('returns the same instance on repeated calls', () => {
+    const a = getDefaultAvailableModelsCache();
+    const b = getDefaultAvailableModelsCache();
+    expect(a).toBe(b);
+  });
+
+  it('honours setDefaultAvailableModelsCache for test injection', () => {
+    const custom = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    setDefaultAvailableModelsCache(custom);
+    expect(getDefaultAvailableModelsCache()).toBe(custom);
+  });
+
+  it('falls back to the default cache when fallback options omit `cache`', async () => {
+    const custom = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    setDefaultAvailableModelsCache(custom);
+
+    const inner = fakeAdapter('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const wrapped = withModelNotFoundFallback(inner); // no cache passed
+    const r = await wrapped.complete(dummyRequest);
+    if (r.ok) throw new Error('expected error');
+    expect(r.error.message).toContain('claude-opus-4-7');
+  });
+});
+
+// ============================================================================
+// wrapResilientWithFallback (#2549)
+// ============================================================================
+
+function fakeResilient(
+  modelId: string,
+  complete: (req: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
+): ResilientLike {
+  const getHealth = vi.fn(() => ({ status: 'ok' }));
+  const refresh = vi.fn(() => Promise.resolve());
+  const setPreferredCli = vi.fn();
+  const onFailover = vi.fn(() => () => undefined);
+  const dispose = vi.fn();
+  return {
+    providerId: 'anthropic',
+    modelId,
+    capabilities: [],
+    complete,
+    stream: (): AsyncIterable<never> => {
+      throw new Error('not implemented');
+    },
+    countTokens: () => Promise.resolve(0),
+    validateConfig: () => ok(undefined),
+    getHealth,
+    refresh,
+    setPreferredCli,
+    onFailover,
+    dispose,
+  };
+}
+
+describe('wrapResilientWithFallback (#2549)', () => {
+  it('preserves the resilient health/lifecycle methods on the wrapped adapter', () => {
+    const inner = fakeResilient('claude-opus-4-7', () => Promise.resolve(successResponse()));
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = wrapResilientWithFallback(inner, { cache });
+
+    expect(typeof wrapped.getHealth).toBe('function');
+    expect(typeof wrapped.refresh).toBe('function');
+    expect(typeof wrapped.setPreferredCli).toBe('function');
+    expect(typeof wrapped.onFailover).toBe('function');
+    expect(typeof wrapped.dispose).toBe('function');
+
+    // The wrapped methods forward to the inner adapter.
+    wrapped.dispose();
+    expect((inner.dispose as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    wrapped.setPreferredCli('claude');
+    expect((inner.setPreferredCli as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it('still applies the MODEL_NOT_FOUND retry path through complete()', async () => {
+    const inner = fakeResilient('claude-opus-4-6', () =>
+      Promise.resolve(err(new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })))
+    );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = wrapResilientWithFallback(inner, { cache });
+    const r = await wrapped.complete(dummyRequest);
+    if (r.ok) throw new Error('expected error');
+    expect(r.error.message).toContain('claude-opus-4-7');
   });
 });

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
@@ -36,13 +36,20 @@ import type {
 import { err, ErrorCode, ok, ModelError as ModelErrorClass } from '../core/index.js';
 import { createLogger } from '../core/logger.js';
 import { getDefaultRegistry, type ModelRegistry } from '../config/model-registry.js';
-import type { AvailableModelsCache } from '../config/available-models-cache.js';
+import {
+  type AvailableModelsCache,
+  getDefaultAvailableModelsCache,
+} from '../config/available-models-cache.js';
 
 const logger = createLogger({ component: 'model-not-found-fallback' });
 
 export interface ModelNotFoundFallbackOptions {
-  /** Process-local cache of routable models. Refreshed on a 404. */
-  readonly cache: AvailableModelsCache;
+  /**
+   * Process-local cache of routable models. Refreshed on a 404. Defaults
+   * to `getDefaultAvailableModelsCache()` — passing one explicitly is the
+   * right move for tests and for multi-cache topologies.
+   */
+  readonly cache?: AvailableModelsCache;
   /** Registry used to resolve vendor/family from a model id. Defaults to global. */
   readonly registry?: ModelRegistry;
   /**
@@ -81,9 +88,16 @@ export interface RetirementInfo {
  */
 export function withModelNotFoundFallback(
   inner: IModelAdapter,
-  options: ModelNotFoundFallbackOptions
+  options: ModelNotFoundFallbackOptions = {}
 ): IModelAdapter {
   const registry = options.registry ?? getDefaultRegistry();
+  const cache = options.cache ?? getDefaultAvailableModelsCache();
+  const resolvedOptions: ResolvedOptions = {
+    cache,
+    registry,
+    adapterFactory: options.adapterFactory,
+    onRetirement: options.onRetirement,
+  };
   const wrapped: IModelAdapter = {
     providerId: inner.providerId,
     modelId: inner.modelId,
@@ -91,8 +105,7 @@ export function withModelNotFoundFallback(
     countTokens: (text) => inner.countTokens(text),
     validateConfig: () => inner.validateConfig(),
     stream: (request: CompletionRequest): AsyncIterable<StreamChunk> => inner.stream(request),
-    complete: (request: CompletionRequest) =>
-      completeWithFallback(inner, request, options, registry),
+    complete: (request: CompletionRequest) => completeWithFallback(inner, request, resolvedOptions),
   };
   if (typeof inner.listModels === 'function') {
     const list = inner.listModels.bind(inner);
@@ -101,17 +114,23 @@ export function withModelNotFoundFallback(
   return wrapped;
 }
 
+interface ResolvedOptions {
+  readonly cache: AvailableModelsCache;
+  readonly registry: ModelRegistry;
+  readonly adapterFactory?: ((modelId: string) => IModelAdapter) | undefined;
+  readonly onRetirement?: ((info: RetirementInfo) => void) | undefined;
+}
+
 async function completeWithFallback(
   inner: IModelAdapter,
   request: CompletionRequest,
-  options: ModelNotFoundFallbackOptions,
-  registry: ModelRegistry
+  options: ResolvedOptions
 ): Promise<Result<CompletionResponse, ModelError>> {
   const first = await inner.complete(request);
   if (first.ok) return first;
   if (first.error.code !== ErrorCode.MODEL_NOT_FOUND) return first;
 
-  const fallback = await pickFallback(inner.modelId, options.cache, registry);
+  const fallback = await pickFallback(inner.modelId, options.cache, options.registry);
   if (fallback === null) {
     logger.warn('Model not found and no fallback available', {
       modelId: inner.modelId,
@@ -210,3 +229,48 @@ async function pickFallback(
 
 // Re-export ok for tests that synthesise success results.
 export { ok };
+
+// ============================================================================
+// Resilient-adapter aware wrapper (#2549).
+//
+// `withModelNotFoundFallback` returns an `IModelAdapter` — fine for direct-API
+// adapters that satisfy that surface directly. For `IResilientAdapter` callers
+// who also depend on `getHealth` / `refresh` / `setPreferredCli` / `onFailover`
+// / `dispose`, this helper preserves those methods while routing `complete()`
+// through the fallback path.
+// ============================================================================
+
+/**
+ * Minimal shape of `IResilientAdapter` — duplicated here as a local
+ * type so that `model-not-found-fallback.ts` doesn't acquire a circular
+ * import with `adapters/resilient-adapter-types.ts`. The shape matches
+ * the resilient adapter's extension methods over `IModelAdapter`.
+ */
+export interface ResilientLike extends IModelAdapter {
+  getHealth(): unknown;
+  refresh(): Promise<void>;
+  setPreferredCli(cli: unknown): void;
+  onFailover(cb: (info: unknown) => void): () => void;
+  dispose(): void;
+}
+
+/**
+ * Wrap an `IResilientAdapter` (or anything that satisfies `ResilientLike`)
+ * so its `complete()` path retries on MODEL_NOT_FOUND while its
+ * health/lifecycle methods continue to work unchanged.
+ */
+export function wrapResilientWithFallback<T extends ResilientLike>(
+  inner: T,
+  options: ModelNotFoundFallbackOptions = {}
+): T {
+  const wrapped = withModelNotFoundFallback(inner, options);
+  // Object.assign re-attaches the resilient-specific methods bound to
+  // the original adapter so health/lifecycle behaviour is unchanged.
+  return Object.assign(wrapped, {
+    getHealth: inner.getHealth.bind(inner),
+    refresh: inner.refresh.bind(inner),
+    setPreferredCli: inner.setPreferredCli.bind(inner),
+    onFailover: inner.onFailover.bind(inner),
+    dispose: inner.dispose.bind(inner),
+  }) as unknown as T;
+}

--- a/packages/nexus-agents/src/adapters/unified-registry.test.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.test.ts
@@ -319,3 +319,52 @@ describe('global registry singleton', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 });
+
+// ============================================================================
+// MODEL_NOT_FOUND fallback wiring (#2549)
+// ============================================================================
+
+describe('UnifiedAdapterRegistry enableMissingModelFallback (#2549)', () => {
+  afterEach(() => {
+    resetGlobalRegistry();
+  });
+
+  it('returns raw resilient adapters by default (flag off)', () => {
+    const registry = createUnifiedRegistry({ logger: mockLogger });
+    const adapter = registry.getAdapterForCli('claude');
+    // The raw resilient adapter exposes setPreferredCli; sanity-check
+    // that the surface includes it.
+    expect(typeof adapter.setPreferredCli).toBe('function');
+    expect(typeof adapter.complete).toBe('function');
+    expect(typeof adapter.getHealth).toBe('function');
+    registry.dispose();
+  });
+
+  it('wraps adapters with fallback when the flag is enabled', () => {
+    const registry = createUnifiedRegistry({
+      logger: mockLogger,
+      enableMissingModelFallback: true,
+    });
+    const adapter = registry.getAdapterForCli('claude');
+    // Wrapped adapter still implements the resilient surface — the
+    // wrapper preserves health/lifecycle methods via the
+    // `wrapResilientWithFallback` helper.
+    expect(typeof adapter.setPreferredCli).toBe('function');
+    expect(typeof adapter.getHealth).toBe('function');
+    expect(typeof adapter.refresh).toBe('function');
+    expect(typeof adapter.dispose).toBe('function');
+    expect(typeof adapter.complete).toBe('function');
+    registry.dispose();
+  });
+
+  it('caches the wrapped adapter — repeated lookups return the same instance', () => {
+    const registry = createUnifiedRegistry({
+      logger: mockLogger,
+      enableMissingModelFallback: true,
+    });
+    const first = registry.getAdapterForCli('claude');
+    const second = registry.getAdapterForCli('claude');
+    expect(first).toBe(second);
+    registry.dispose();
+  });
+});

--- a/packages/nexus-agents/src/adapters/unified-registry.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.ts
@@ -21,6 +21,10 @@ import type { ILogger } from '../core/index.js';
 import { createLogger } from '../core/index.js';
 import { createResilientAdapter } from './resilient-adapter.js';
 import type { IResilientAdapter } from './resilient-adapter-types.js';
+import {
+  wrapResilientWithFallback,
+  type ModelNotFoundFallbackOptions,
+} from './model-not-found-fallback.js';
 import type { CliName } from '../cli-adapters/types.js';
 import { TASK_SPECIALIZATION_MATRIX, detectTaskCategory } from '../config/task-specialization.js';
 import type { TaskCategory } from '../config/task-specialization-types.js';
@@ -37,6 +41,26 @@ export interface UnifiedRegistryConfig {
   readonly logger?: ILogger;
   /** Default CLI timeout for subprocess calls (ms) */
   readonly defaultCliTimeoutMs?: number;
+  /**
+   * Auto-wrap every constructed adapter with `withModelNotFoundFallback`
+   * (#2549). When enabled, the registry routes `complete()` through the
+   * fallback path so a `MODEL_NOT_FOUND` error (typically from a vendor
+   * 404 / "model deprecated" message) refreshes the AvailableModelsCache
+   * and retries through the closest same-family alternative.
+   *
+   * Defaults to `false` — operators opt in by wiring up an
+   * `AvailableModelsCache` via `setDefaultAvailableModelsCache()` and
+   * setting this flag. Safe-on-empty: if no cache is provided or the
+   * cache has no sources, the wrap is transparent (no retry happens,
+   * original error surfaces).
+   */
+  readonly enableMissingModelFallback?: boolean;
+  /**
+   * Optional override for the fallback decorator. When omitted, the
+   * decorator uses `getDefaultAvailableModelsCache()` and
+   * `getDefaultRegistry()`.
+   */
+  readonly missingModelFallbackOptions?: ModelNotFoundFallbackOptions;
 }
 
 /** Summary of the pre-computed task routing table. */
@@ -72,6 +96,8 @@ export interface RegistrySnapshot {
 export class UnifiedAdapterRegistry {
   private readonly logger: ILogger;
   private readonly defaultCliTimeoutMs: number | undefined;
+  private readonly enableMissingModelFallback: boolean;
+  private readonly missingModelFallbackOptions: ModelNotFoundFallbackOptions | undefined;
 
   /** Pre-computed task → CLI routing (immutable after construction). */
   private readonly taskRouting: ReadonlyMap<TaskCategory, TaskRoutingEntry>;
@@ -85,11 +111,26 @@ export class UnifiedAdapterRegistry {
   constructor(config?: UnifiedRegistryConfig) {
     this.logger = config?.logger ?? createLogger({ component: 'unified-registry' });
     this.defaultCliTimeoutMs = config?.defaultCliTimeoutMs;
+    this.enableMissingModelFallback = config?.enableMissingModelFallback ?? false;
+    this.missingModelFallbackOptions = config?.missingModelFallbackOptions;
     this.taskRouting = this.buildTaskRouting();
     this.logger.info('UnifiedAdapterRegistry initialized', {
       categories: this.taskRouting.size,
       models: DEFAULT_MODEL_CAPABILITIES.models.length,
+      missingModelFallback: this.enableMissingModelFallback,
     });
+  }
+
+  /**
+   * Apply the MODEL_NOT_FOUND fallback decorator if enabled, otherwise
+   * return the adapter unchanged. The recursion guard from the original
+   * issue is unnecessary here: the decorator's retry path uses the
+   * caller-supplied `adapterFactory`; without one, it surfaces an
+   * enriched error and never re-enters the resilient layer.
+   */
+  private maybeWrap(adapter: IResilientAdapter): IResilientAdapter {
+    if (!this.enableMissingModelFallback) return adapter;
+    return wrapResilientWithFallback(adapter, this.missingModelFallbackOptions);
   }
 
   // --------------------------------------------------------------------------
@@ -138,15 +179,19 @@ export class UnifiedAdapterRegistry {
     const cached = this.cliAdapters.get(cli);
     if (cached !== undefined) return cached;
 
-    const adapter = createResilientAdapter({
+    const raw = createResilientAdapter({
       logger: this.logger,
       preferredCli: cli,
       ...(this.defaultCliTimeoutMs !== undefined && {
         defaultCliTimeoutMs: this.defaultCliTimeoutMs,
       }),
     });
+    const adapter = this.maybeWrap(raw);
     this.cliAdapters.set(cli, adapter);
-    this.logger.info('Created CLI-specific adapter', { cli });
+    this.logger.info('Created CLI-specific adapter', {
+      cli,
+      missingModelFallback: this.enableMissingModelFallback,
+    });
     return adapter;
   }
 
@@ -201,12 +246,13 @@ export class UnifiedAdapterRegistry {
    */
   getDefault(): IResilientAdapter {
     if (this.defaultAdapter !== undefined) return this.defaultAdapter;
-    this.defaultAdapter = createResilientAdapter({
+    const raw = createResilientAdapter({
       logger: this.logger,
       ...(this.defaultCliTimeoutMs !== undefined && {
         defaultCliTimeoutMs: this.defaultCliTimeoutMs,
       }),
     });
+    this.defaultAdapter = this.maybeWrap(raw);
     return this.defaultAdapter;
   }
 

--- a/packages/nexus-agents/src/config/available-models-cache.test.ts
+++ b/packages/nexus-agents/src/config/available-models-cache.test.ts
@@ -126,4 +126,42 @@ describe('AvailableModelsCache (#2540)', () => {
     await Promise.all([a, b]);
     expect(probe).toHaveBeenCalledTimes(1);
   });
+
+  // ============================================================================
+  // Dynamic source registration (#2549)
+  // ============================================================================
+
+  describe('addSource / removeSource (#2549)', () => {
+    it('addSource appends to the union after construction', async () => {
+      const cache = new AvailableModelsCache({ sources: [] });
+      expect(await cache.getAll()).toHaveLength(0);
+
+      cache.addSource(source('anthropic', ['claude-opus-4-7'], 'anthropic'));
+      const all = await cache.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.id).toBe('claude-opus-4-7');
+    });
+
+    it('addSource is idempotent by name', async () => {
+      const cache = new AvailableModelsCache({ sources: [] });
+      const probe = vi.fn(() => Promise.resolve([{ id: 'gpt-4o' }]));
+      cache.addSource({ name: 'gateway', listModels: probe });
+      cache.addSource({ name: 'gateway', listModels: probe });
+      const all = await cache.getAll();
+      // Single source registered → single probe call after dedup.
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(all).toHaveLength(1);
+    });
+
+    it('removeSource drops the source from subsequent probes', async () => {
+      const probe = vi.fn(() => Promise.resolve([{ id: 'gpt-4o' }]));
+      const cache = new AvailableModelsCache({
+        sources: [{ name: 'gateway', listModels: probe }],
+      });
+      cache.removeSource('gateway');
+      const all = await cache.getAll();
+      expect(all).toHaveLength(0);
+      expect(probe).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/nexus-agents/src/config/available-models-cache.ts
+++ b/packages/nexus-agents/src/config/available-models-cache.ts
@@ -77,14 +77,14 @@ interface SourceState {
 }
 
 export class AvailableModelsCache {
-  private readonly sources: readonly AvailableModelsSource[];
+  private sources: AvailableModelsSource[];
   private readonly ttlMs: number;
   private readonly staleTtlMs: number;
   private readonly now: () => number;
   private readonly states: Map<string, SourceState>;
 
   constructor(options: AvailableModelsCacheOptions) {
-    this.sources = options.sources;
+    this.sources = [...options.sources];
     this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
     this.staleTtlMs = options.staleTtlMs ?? DEFAULT_STALE_TTL_MS;
     this.now = options.now ?? Date.now;
@@ -92,6 +92,27 @@ export class AvailableModelsCache {
     for (const s of this.sources) {
       this.states.set(s.name, { value: null, fetchedAt: 0, inFlight: null });
     }
+  }
+
+  /**
+   * Register a source after construction. Used by adapter factories that
+   * wire themselves into the default cache lazily as they're built.
+   * Duplicate names are ignored (first registration wins, on the
+   * assumption that the same factory might run twice in a test session).
+   */
+  addSource(source: AvailableModelsSource): void {
+    if (this.states.has(source.name)) return;
+    this.sources.push(source);
+    this.states.set(source.name, { value: null, fetchedAt: 0, inFlight: null });
+  }
+
+  /**
+   * Remove a previously-registered source. Used by tests + by factories
+   * that want to drop a probe when an adapter is being disposed.
+   */
+  removeSource(name: string): void {
+    this.sources = this.sources.filter((s) => s.name !== name);
+    this.states.delete(name);
   }
 
   /**
@@ -200,4 +221,33 @@ function normaliseEntry(raw: { id: string }, source: AvailableModelsSource): Ava
     return { id: raw.id, source: source.name, provider: source.providerHint };
   }
   return { id: raw.id, source: source.name };
+}
+
+// ============================================================================
+// Default (process-singleton) instance — used by adapter factories that
+// auto-wire `withModelNotFoundFallback`. Operators that need a different
+// cache (different TTLs, custom sources) can override via
+// `setDefaultAvailableModelsCache` at startup.
+// ============================================================================
+
+let defaultCache: AvailableModelsCache | null = null;
+
+/**
+ * Get (or lazily construct) the process-default cache. Starts with no
+ * sources — adapter factories register themselves via `addSource` on
+ * construction. Until at least one source is added, the cache returns
+ * empty snapshots and `withModelNotFoundFallback` degrades to surfacing
+ * the original error (safe).
+ */
+export function getDefaultAvailableModelsCache(): AvailableModelsCache {
+  defaultCache ??= new AvailableModelsCache({ sources: [] });
+  return defaultCache;
+}
+
+/**
+ * Override the default cache. Useful for tests and for operators that
+ * want a pre-populated cache wired at startup.
+ */
+export function setDefaultAvailableModelsCache(cache: AvailableModelsCache | null): void {
+  defaultCache = cache;
 }

--- a/packages/nexus-agents/src/config/index.ts
+++ b/packages/nexus-agents/src/config/index.ts
@@ -292,7 +292,11 @@ export type {
 // `ModelRegistry` answers "how should this model behave"; this cache
 // answers "is this model routable right now". CompositeRouter (PR 7)
 // gates on this cache before scoring.
-export { AvailableModelsCache } from './available-models-cache.js';
+export {
+  AvailableModelsCache,
+  getDefaultAvailableModelsCache,
+  setDefaultAvailableModelsCache,
+} from './available-models-cache.js';
 export type {
   AvailableModelsSource,
   AvailableModel,

--- a/packages/nexus-agents/src/exports/adapters.ts
+++ b/packages/nexus-agents/src/exports/adapters.ts
@@ -84,6 +84,8 @@ export {
   // refreshes the AvailableModelsCache and retries through the
   // closest sibling per the registry.
   withModelNotFoundFallback,
+  wrapResilientWithFallback,
   type ModelNotFoundFallbackOptions,
   type RetirementInfo,
+  type ResilientLike,
 } from '../adapters/index.js';

--- a/packages/nexus-agents/src/exports/config.ts
+++ b/packages/nexus-agents/src/exports/config.ts
@@ -59,6 +59,8 @@ export {
   setDefaultRegistry,
   DEFAULT_ENTRY,
   AvailableModelsCache,
+  getDefaultAvailableModelsCache,
+  setDefaultAvailableModelsCache,
   type ModelEntry,
   type ModelRegistryOptions,
   type EntrySource,


### PR DESCRIPTION
## Summary

Closes #2549. PR 8 (#2545) shipped the runtime retire-and-retry decorator. Until now callers had to apply it at each adapter-construction site — exactly the kind of opt-in that drifts. This PR closes the loop with one explicit flag on `UnifiedAdapterRegistry`.

## What changed

### `AvailableModelsCache` — process default + dynamic sources

- New `getDefaultAvailableModelsCache()` / `setDefaultAvailableModelsCache(cache | null)` (test-injectable).
- New `cache.addSource(source)` / `cache.removeSource(name)`. Adapter factories can now register themselves lazily as they're built.
- Default singleton starts with **zero sources** — degrades safely; the fallback path returns the original error when nothing is wired.

### `withModelNotFoundFallback` — defaults to the singleton

- `cache` is now optional; falls back to `getDefaultAvailableModelsCache()`.
- `registry` is now optional; falls back to `getDefaultRegistry()`.
- Back-compat: all PR 8 callers (passing explicit `cache`) continue to work.

### `wrapResilientWithFallback<T extends ResilientLike>(inner, opts)` — new helper

- Routes `complete()` through the fallback decorator.
- Preserves the resilient-adapter surface (`getHealth`, `refresh`, `setPreferredCli`, `onFailover`, `dispose`) via `Object.assign` so `IResilientAdapter` consumers keep working.
- Importantly: the registry returns `IResilientAdapter`, not plain `IModelAdapter` — wrapping directly with `withModelNotFoundFallback` would have stripped those methods.

### `UnifiedAdapterRegistry` — opt-in flag

- New `enableMissingModelFallback?: boolean` config (default `false`).
- New `missingModelFallbackOptions?: ModelNotFoundFallbackOptions` (passes through to the decorator).
- When the flag is on, every adapter returned by `getAdapterForCli` and `getDefault()` is wrapped.
- Recursion guard is unnecessary: without an `adapterFactory`, the decorator's retry path surfaces an enriched error rather than re-entering the resilient layer.

### Public exports

- `config.ts` re-exports `getDefaultAvailableModelsCache` + `setDefaultAvailableModelsCache`.
- `adapters.ts` re-exports `wrapResilientWithFallback` + `ResilientLike` type.

## Tests added (11 new across 3 suites)

- `available-models-cache.test.ts`: addSource appends; addSource is idempotent by name; removeSource drops the source.
- `model-not-found-fallback.test.ts`: singleton returns same instance; `setDefault*` overrides for test injection; decorator uses default cache when none passed; `wrapResilientWithFallback` preserves health methods; wrapper still applies retry on 404.
- `unified-registry.test.ts`: flag-off returns raw resilient adapter; flag-on wraps with preserved surface; wrapped adapter is cached on repeat lookups.

## Verification

- `pnpm typecheck` — clean
- `pnpm vitest run src/adapters/ src/config/available-models-cache.test.ts src/exports/export-contracts.test.ts` — **869/869 pass**

## What didn't change

- Default behavior is unchanged for all callers — the flag is explicit opt-in. Operators who want the auto-wiring set `enableMissingModelFallback: true` in their registry config and register cache sources via `setDefaultAvailableModelsCache(...)` at startup.
- The direct-API constructors (`createClaudeAdapter` etc.) still return raw adapters. That's a separate question — those want the wrap too but at a different layer (operators using them directly already know what model they're calling).

## Test plan

- [x] Typecheck clean
- [x] Adapter + config + exports tests green
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)