### PR TITLE
docs: sweep stale references to deleted swe-bench / atbench / sandbox executors (#2563)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,7 @@ _Auto-generated from source. 38 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-05-10_
+_Governance Version: 2026-05-11_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -47,49 +47,47 @@ Most commonly used commands:
 
 **Entry Point:** `nexus-agents [command] [options]`
 
-| Command                | Subcommand                | Description                                      | Mode         |
-| ---------------------- | ------------------------- | ------------------------------------------------ | ------------ |
-| `(default)`            | -                         | Start MCP server                                 | server       |
-| `--help`               | -                         | Display help text                                | any          |
-| `--version`            | -                         | Display version                                  | any          |
-| `doctor`               | -                         | Check CLI health and dependencies                | any          |
-| `config`               | `init`                    | Generate starter configuration file              | any          |
-| `expert`               | `list`                    | List available experts (built-in + custom)       | any          |
-| `workflow`             | `list`                    | List available workflow templates                | any          |
-| `workflow`             | `run <name>`              | Execute a workflow template                      | orchestrator |
-| `server`               | -                         | Start MCP server (explicit)                      | server       |
-| `server`               | `--interactive`           | Start interactive REPL mode                      | server       |
-| `review`               | `<url>`                   | Review a GitHub PR                               | orchestrator |
-| `routing-audit`        | `<task>`                  | Debug routing decisions (dry-run)                | any          |
-| `orchestrate`          | `<task>`                  | Execute task standalone                          | orchestrator |
-| `system-review`        | -                         | Run 5-phase system review                        | any          |
-| `vote`                 | `--proposal`              | Consensus voting with 6 agents                   | any          |
-| `research`             | `status`                  | Show technique implementation status             | any          |
-| `research`             | `overlap`                 | Find overlapping techniques                      | any          |
-| `research`             | `add`                     | Add new paper from arXiv                         | any          |
-| `research`             | `discover`                | Discover papers/repos from external sources      | any          |
-| `research`             | `review`                  | Discover, score, and rank research findings      | any          |
-| `research`             | `prioritize`              | Rank actionable techniques by priority           | any          |
-| `verify`               | -                         | Quick verification check                         | any          |
-| `review-demo`          | -                         | PR review demo with wizard UX                    | orchestrator |
-| `validation-dashboard` | -                         | A/B testing and validation dashboard             | any          |
-| `swe-bench`            | `run`                     | Run SWE-bench evaluation                         | orchestrator |
-| `swe-bench`            | `evaluate`                | Evaluate predictions                             | any          |
-| `swe-bench`            | `status`                  | Show evaluation status                           | any          |
-| `setup`                | -                         | Configure Claude CLI integration                 | any          |
-| `learning-metrics`     | -                         | Show learning metrics dashboard                  | any          |
-| `index`                | `generate`                | Generate codebase index                          | any          |
-| `index`                | `check`                   | Validate index freshness                         | any          |
-| `index`                | `diagram`                 | Generate Mermaid dependency diagram              | any          |
-| `hooks`                | `session-start`           | Handle SessionStart hook events                  | any          |
-| `hooks`                | `session-end`             | Handle SessionEnd hook events                    | any          |
-| `hooks`                | `pre-tool`                | Handle PreToolUse hook events                    | any          |
-| `hooks`                | `post-tool`               | Handle PostToolUse hook events                   | any          |
-| `hooks`                | `stop`                    | Handle Stop hook events                          | any          |
-| `init`                 | `--portable`              | Bootstrap workspace-local `.nexus-agents/`       | any          |
-| `init`                 | `--portable --mcp-config` | …and emit `.mcp.json` for Claude Code            | any          |
-| `init`                 | `--portable --install`    | …and install nexus-agents into `cli/` + bin shim | any          |
-| `init`                 | `--portable --uninstall`  | Remove portable install (preserves data dir)     | any          |
+| Command                | Subcommand                    | Description                                                                                                                                                                              | Mode         |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `(default)`            | -                             | Start MCP server                                                                                                                                                                         | server       |
+| `--help`               | -                             | Display help text                                                                                                                                                                        | any          |
+| `--version`            | -                             | Display version                                                                                                                                                                          | any          |
+| `doctor`               | -                             | Check CLI health and dependencies                                                                                                                                                        | any          |
+| `config`               | `init`                        | Generate starter configuration file                                                                                                                                                      | any          |
+| `expert`               | `list`                        | List available experts (built-in + custom)                                                                                                                                               | any          |
+| `workflow`             | `list`                        | List available workflow templates                                                                                                                                                        | any          |
+| `workflow`             | `run <name>`                  | Execute a workflow template                                                                                                                                                              | orchestrator |
+| `server`               | -                             | Start MCP server (explicit)                                                                                                                                                              | server       |
+| `server`               | `--interactive`               | Start interactive REPL mode                                                                                                                                                              | server       |
+| `review`               | `<url>`                       | Review a GitHub PR                                                                                                                                                                       | orchestrator |
+| `routing-audit`        | `<task>`                      | Debug routing decisions (dry-run)                                                                                                                                                        | any          |
+| `orchestrate`          | `<task>`                      | Execute task standalone                                                                                                                                                                  | orchestrator |
+| `system-review`        | -                             | Run 5-phase system review                                                                                                                                                                | any          |
+| `vote`                 | `--proposal`                  | Consensus voting with 6 agents                                                                                                                                                           | any          |
+| `research`             | `status`                      | Show technique implementation status                                                                                                                                                     | any          |
+| `research`             | `overlap`                     | Find overlapping techniques                                                                                                                                                              | any          |
+| `research`             | `add`                         | Add new paper from arXiv                                                                                                                                                                 | any          |
+| `research`             | `discover`                    | Discover papers/repos from external sources                                                                                                                                              | any          |
+| `research`             | `review`                      | Discover, score, and rank research findings                                                                                                                                              | any          |
+| `research`             | `prioritize`                  | Rank actionable techniques by priority                                                                                                                                                   | any          |
+| `verify`               | -                             | Quick verification check                                                                                                                                                                 | any          |
+| `review-demo`          | -                             | PR review demo with wizard UX                                                                                                                                                            | orchestrator |
+| `validation-dashboard` | -                             | A/B testing and validation dashboard                                                                                                                                                     | any          |
+| `swe-bench`            | `run` / `evaluate` / `status` | **Deprecated** — harness extracted to [`nexus-eval-swebench`](https://github.com/williamzujkowski/nexus-eval-swebench) (epic #2514). In-tree commands stub out with a migration message. | any          |
+| `setup`                | -                             | Configure Claude CLI integration                                                                                                                                                         | any          |
+| `learning-metrics`     | -                             | Show learning metrics dashboard                                                                                                                                                          | any          |
+| `index`                | `generate`                    | Generate codebase index                                                                                                                                                                  | any          |
+| `index`                | `check`                       | Validate index freshness                                                                                                                                                                 | any          |
+| `index`                | `diagram`                     | Generate Mermaid dependency diagram                                                                                                                                                      | any          |
+| `hooks`                | `session-start`               | Handle SessionStart hook events                                                                                                                                                          | any          |
+| `hooks`                | `session-end`                 | Handle SessionEnd hook events                                                                                                                                                            | any          |
+| `hooks`                | `pre-tool`                    | Handle PreToolUse hook events                                                                                                                                                            | any          |
+| `hooks`                | `post-tool`                   | Handle PostToolUse hook events                                                                                                                                                           | any          |
+| `hooks`                | `stop`                        | Handle Stop hook events                                                                                                                                                                  | any          |
+| `init`                 | `--portable`                  | Bootstrap workspace-local `.nexus-agents/`                                                                                                                                               | any          |
+| `init`                 | `--portable --mcp-config`     | …and emit `.mcp.json` for Claude Code                                                                                                                                                    | any          |
+| `init`                 | `--portable --install`        | …and install nexus-agents into `cli/` + bin shim                                                                                                                                         | any          |
+| `init`                 | `--portable --uninstall`      | Remove portable install (preserves data dir)                                                                                                                                             | any          |
 
 ### Mode Selection
 
@@ -249,10 +247,8 @@ nexus-agents review-demo
 # Validation dashboard
 nexus-agents validation-dashboard
 
-# SWE-bench evaluation
-nexus-agents swe-bench run --variant=lite --limit=10
-nexus-agents swe-bench evaluate predictions.jsonl
-nexus-agents swe-bench status
+# SWE-bench evaluation — DEPRECATED, see https://github.com/williamzujkowski/nexus-eval-swebench
+# (the in-tree commands stub out with a migration message; harness lives in its own repo per #2514)
 
 # Setup Claude CLI integration
 nexus-agents setup                    # Auto-configure MCP + hooks + rules

--- a/docs/INDEX.yaml
+++ b/docs/INDEX.yaml
@@ -207,7 +207,6 @@ source_map:
   security: 'packages/nexus-agents/src/security/'
   learning: 'packages/nexus-agents/src/learning/'
   observability: 'packages/nexus-agents/src/observability/'
-  swe_bench: 'packages/nexus-agents/src/swe-bench/'
   testing: 'packages/nexus-agents/src/testing/'
 
 # =============================================================================

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -162,7 +162,6 @@ packages/nexus-agents/src/
 ├── context/               # Memory management
 ├── consensus/             # Voting protocols
 ├── mcp/                   # MCP server
-├── swe-bench/             # SWE-Bench evaluation harness
 └── observability/         # Metrics, tracing
 ```
 

--- a/docs/architecture/SECURITY.md
+++ b/docs/architecture/SECURITY.md
@@ -504,26 +504,26 @@ const summary = getSafetyTaxonomySummary();
 
 ## Source Files
 
-| File                                              | Purpose                       |
-| ------------------------------------------------- | ----------------------------- |
-| `src/mcp/middleware/auth-handler.ts`              | Token-based authentication    |
-| `src/mcp/middleware/secure-handler.ts`            | Tool-level security wrapper   |
-| `src/mcp/middleware/request-context.ts`           | Request tracking and auth     |
-| `src/mcp/middleware/rate-limiter.ts`              | Rate limiting                 |
-| `src/security/sandbox/sandbox-manager.ts`         | Sandbox orchestration         |
-| `src/security/sandbox/docker-sandbox-executor.ts` | Container isolation           |
-| `src/security/input-sanitizer.ts`                 | Input validation              |
-| `src/security/output-sanitizer.ts`                | Output sanitization / secrets |
-| `src/security/trust-classifier.ts`                | Trust tier classification     |
-| `src/security/policy-gate.ts`                     | Policy enforcement            |
-| `src/security/corroboration-validator.ts`         | Action corroboration checks   |
-| `src/security/reputation-model.ts`                | Agent reputation scoring      |
-| `src/security/audit-trail.ts`                     | Security logging              |
-| `src/security/firewall/`                          | Firewall pipeline             |
-| `src/security/safety-bench/`                      | SafetyBench evaluation        |
-| `src/security/safety-bench/safety-categories.ts`  | Category taxonomy             |
-| `src/security/safety-bench/safety-enums.ts`       | Risk levels, outcomes         |
-| `src/security/safety-bench/safety-schemas.ts`     | Validation schemas            |
+| File                                             | Purpose                       |
+| ------------------------------------------------ | ----------------------------- |
+| `src/mcp/middleware/auth-handler.ts`             | Token-based authentication    |
+| `src/mcp/middleware/secure-handler.ts`           | Tool-level security wrapper   |
+| `src/mcp/middleware/request-context.ts`          | Request tracking and auth     |
+| `src/mcp/middleware/rate-limiter.ts`             | Rate limiting                 |
+| `src/security/sandbox/sandbox-manager.ts`        | Sandbox orchestration         |
+| `src/security/sandbox/sandbox-executor.ts`       | Policy-based execution        |
+| `src/security/input-sanitizer.ts`                | Input validation              |
+| `src/security/output-sanitizer.ts`               | Output sanitization / secrets |
+| `src/security/trust-classifier.ts`               | Trust tier classification     |
+| `src/security/policy-gate.ts`                    | Policy enforcement            |
+| `src/security/corroboration-validator.ts`        | Action corroboration checks   |
+| `src/security/reputation-model.ts`               | Agent reputation scoring      |
+| `src/security/audit-trail.ts`                    | Security logging              |
+| `src/security/firewall/`                         | Firewall pipeline             |
+| `src/security/safety-bench/`                     | SafetyBench evaluation        |
+| `src/security/safety-bench/safety-categories.ts` | Category taxonomy             |
+| `src/security/safety-bench/safety-enums.ts`      | Risk levels, outcomes         |
+| `src/security/safety-bench/safety-schemas.ts`    | Validation schemas            |
 
 ---
 

--- a/docs/architecture/SECURITY.md
+++ b/docs/architecture/SECURITY.md
@@ -156,25 +156,17 @@ All agent-executed code runs through the sandbox system.
 
 ### Execution Modes
 
-| Mode        | Description                      | Security Level | Use Case                    |
-| ----------- | -------------------------------- | -------------- | --------------------------- |
-| `none`      | No sandboxing (development only) | None           | Local dev, debugging        |
-| `policy`    | Command allowlist enforcement    | Medium         | Standard operation          |
-| `container` | Full Docker isolation            | High           | Production, untrusted input |
+| Mode                 | Description                                                            | Security Level | Use Case             |
+| -------------------- | ---------------------------------------------------------------------- | -------------- | -------------------- |
+| `none`               | No sandboxing (development only)                                       | None           | Local dev, debugging |
+| `policy`             | Command allowlist enforcement (`PolicySandboxExecutor`)                | Medium         | Standard operation   |
+| `container` / `deno` | Accepted for config back-compat; resolves to `policy` mode after #2551 | (see below)    | (see below)          |
 
-### Docker Security (Container Mode)
+### Real isolation: out-of-process via OpenCode sandbox bootstrap (#2500)
 
-```bash
-docker run \
-  --cap-drop=ALL \           # Drop all Linux capabilities
-  --read-only \              # Read-only root filesystem
-  --network=none \           # No network access
-  --user=node \              # Non-root user
-  --memory=512m \            # Memory limit
-  --cpus=2 \                 # CPU limit
-  --pids-limit=10 \          # Process limit
-  --security-opt=no-new-privileges
-```
+Nexus-agents is **sandbox-compatible, not a sandbox-builder**. The in-process Docker / Deno executors were deleted in [#2551](https://github.com/williamzujkowski/nexus-agents/issues/2551) — they were dead code masquerading as security boundary. For real isolation, set the `NEXUS_SANDBOX` environment variable and run nexus-agents inside an OpenCode-managed Docker sandbox; see [docs/getting-started/SANDBOXED-USAGE.md](../getting-started/SANDBOXED-USAGE.md).
+
+The `container` and `deno` modes are kept in the `SandboxMode` config union so existing config files don't fail validation, but the factory resolves both to `policy` mode at runtime with a warning. New deployments wanting container-level isolation should use the OpenCode bootstrap.
 
 ### Command Classification
 

--- a/docs/architecture/UNTRUSTED_INPUT_HARDENING.md
+++ b/docs/architecture/UNTRUSTED_INPUT_HARDENING.md
@@ -438,7 +438,7 @@ function requiresCitation(type: string): boolean {
 - `src/security/policy-gate.ts` — deterministic rule engine
 - `src/security/corroboration-validator.ts` — source verification
 - `src/security/mutation-gate.ts` — approval queue for state changes
-- Integration with existing GitHub clients (`src/dogfooding/github-client.ts` (workflows/self-development/github-client.ts removed in #2402))
+- Integration with the canonical SCM provider at `src/scm/` (consolidated in #1136; `dogfooding/github-client.ts` migrated and deleted in #2553; `workflows/self-development/github-client.ts` deleted in #2402)
 
 **Failure mode:** Fails closed — mutations without policy gate approval are blocked. Read-only actions still pass through.
 


### PR DESCRIPTION
## Summary

Closes #2563. Updates five doc pages that still referenced files / directories deleted in recent cleanup PRs (#2515, #2516, #2551, #2553).

## Changes

| File | What changed |
|---|---|
| `docs/architecture/README.md` | File map dropped the `swe-bench/` line — the directory is gone (extracted to `nexus-eval-swebench` per epic #2514). |
| `docs/INDEX.yaml` | Dropped the `swe_bench:` source_map entry pointing at the deleted directory. |
| `docs/architecture/SECURITY.md` | Replaced the `docker-sandbox-executor.ts` row with `sandbox-executor.ts` (the surviving `PolicySandboxExecutor` after #2551). |
| `docs/architecture/UNTRUSTED_INPUT_HARDENING.md` | Clarified the confusing "Integration with existing GitHub clients" line; now points at `src/scm/` and notes both prior clients are deleted (#2402 + #2553). |
| `docs/ENTRYPOINTS.md` | `swe-bench run/evaluate/status` rows collapsed to one DEPRECATED line pointing at `nexus-eval-swebench`; example shell block replaced with a "see the extracted harness" pointer. |

## What didn't change

- `docs/reference/capabilities.md` — auto-generated; the `swe-bench` / `atbench` rows correctly reflect the deprecation-shim handlers that still exist. Removal happens when the shims do.
- `docs/architecture/SWE_BENCH_HARNESS.md` and `docs/workflows/SELF_DEVELOPMENT_WORKFLOW.md` — already correctly marked "EXTRACTED" / "Replaced" at the top. Leave.

## Test plan

- [x] All edits are documentation-only
- [x] `grep` confirms only legitimate historical-context lines remain in `docs/`
- [ ] CI on this PR (doc-link / markdown-lint checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)