### PR TITLE
feat(outcomes): outcomeStore family-fallback for warm-start across siblings (#2548)

### DIFF
--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store.test.ts
@@ -123,11 +123,16 @@ describe('OutcomeStore', () => {
     expect(store.query()).toEqual([]);
   });
 
-  it('appends and retrieves outcomes', () => {
+  it('appends and retrieves outcomes (with #2548 vendor/family enrichment)', () => {
     const outcome = makeOutcome();
     store.append(outcome);
     expect(store.size).toBe(1);
-    expect(store.query()).toEqual([outcome]);
+    // Append enriches with vendor/family resolved from the registry
+    // (#2548). Original fields are preserved; vendor/family are added.
+    const retrieved = store.query()[0]!;
+    expect(retrieved).toMatchObject(outcome);
+    expect(typeof retrieved.vendor).toBe('string');
+    expect(typeof retrieved.family).toBe('string');
   });
 
   it('preserves insertion order', () => {
@@ -681,5 +686,94 @@ describe('getOutcomeSummaryText', () => {
     const text = getOutcomeSummaryText(2);
     // Should only show last 2 failures (limit=2 in query)
     expect(text).toContain('err');
+  });
+});
+
+// ============================================================================
+// queryByModelWithFamilyFallback (#2548)
+// ============================================================================
+
+describe('OutcomeStore.queryByModelWithFamilyFallback (#2548)', () => {
+  it('returns literal-scoped outcomes when sample count meets threshold', () => {
+    const store = new OutcomeStore();
+    for (let i = 0; i < 6; i++) {
+      store.append(makeOutcome({ id: `out-${String(i)}`, model: 'claude-opus-4-7' }));
+    }
+    const result = store.queryByModelWithFamilyFallback('claude-opus-4-7', { threshold: 5 });
+    expect(result.scope).toBe('literal');
+    expect(result.outcomes).toHaveLength(6);
+    expect(result.vendor).toBe('anthropic');
+  });
+
+  it('broadens to family-scoped outcomes when literal count is below threshold', () => {
+    const store = new OutcomeStore();
+    // 2 outcomes for the cold model (below threshold of 5)
+    for (let i = 0; i < 2; i++) {
+      store.append(makeOutcome({ id: `out-cold-${String(i)}`, model: 'claude-opus-4-7' }));
+    }
+    // 4 outcomes for a sibling in the same vendor+family
+    for (let i = 0; i < 4; i++) {
+      store.append(makeOutcome({ id: `out-sib-${String(i)}`, model: 'claude-opus-4-6' }));
+    }
+    const result = store.queryByModelWithFamilyFallback('claude-opus-4-7', { threshold: 5 });
+    expect(result.scope).toBe('family');
+    expect(result.outcomes).toHaveLength(6); // 2 cold + 4 siblings, same family
+    expect(result.vendor).toBe('anthropic');
+  });
+
+  it('does not cross vendor boundaries when broadening', () => {
+    const store = new OutcomeStore();
+    // 1 cold outcome for claude
+    store.append(makeOutcome({ id: 'cold', model: 'claude-opus-4-7' }));
+    // 4 outcomes for a DIFFERENT vendor (codex)
+    for (let i = 0; i < 4; i++) {
+      store.append(makeOutcome({ id: `codex-${String(i)}`, cli: 'codex', model: 'gpt-5.4' }));
+    }
+    const result = store.queryByModelWithFamilyFallback('claude-opus-4-7', { threshold: 5 });
+    // Family broadening must NOT pick up the codex outcomes — different vendor.
+    // With only 1 anthropic outcome in the family, the scope is 'family' but
+    // the result set still only contains the 1 anthropic outcome.
+    expect(result.scope).toBe('family');
+    expect(result.outcomes).toHaveLength(1);
+    expect(result.outcomes[0]?.cli).toBe('claude');
+  });
+
+  it('reports `empty` scope when no outcomes match literal OR family', () => {
+    const store = new OutcomeStore();
+    // Single outcome for an unrelated model
+    store.append(makeOutcome({ id: 'other', cli: 'codex', model: 'gpt-5.4' }));
+    const result = store.queryByModelWithFamilyFallback('claude-opus-4-7', { threshold: 5 });
+    expect(result.scope).toBe('empty');
+    expect(result.outcomes).toHaveLength(0);
+  });
+
+  it('respects extraFilter (e.g. category) when broadening', () => {
+    const store = new OutcomeStore();
+    for (let i = 0; i < 3; i++) {
+      store.append(
+        makeOutcome({
+          id: `code-${String(i)}`,
+          model: 'claude-opus-4-7',
+          category: 'code_generation',
+        })
+      );
+    }
+    for (let i = 0; i < 3; i++) {
+      store.append(
+        makeOutcome({
+          id: `arch-${String(i)}`,
+          model: 'claude-opus-4-7',
+          category: 'architecture',
+        })
+      );
+    }
+    const result = store.queryByModelWithFamilyFallback('claude-opus-4-7', {
+      threshold: 10,
+      extraFilter: { category: 'architecture' },
+    });
+    // Below threshold of 10 (only 3 architecture samples), broadens to family
+    // BUT the category filter applies to the family scope too.
+    expect(result.outcomes).toHaveLength(3);
+    expect(result.outcomes.every((o) => o.category === 'architecture')).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
@@ -12,6 +12,7 @@
 import type { TaskOutcome, OutcomeQuery, PerformanceSummary, GroupStats } from './outcome-types.js';
 import { categorizeOutcomeErrorMessage } from './outcome-types.js';
 import { isPersistenceEnabled } from '../../config/learning-persistence.js';
+import { getDefaultRegistry, type ModelRegistry } from '../../config/model-registry.js';
 
 // ============================================================================
 // Constants
@@ -26,7 +27,21 @@ const DEFAULT_MAX_ENTRIES = 10_000;
 
 export interface OutcomeStoreConfig {
   readonly maxEntries?: number;
+  /**
+   * Registry used to resolve vendor/family from `outcome.model` at write
+   * time (#2548). Defaults to the process singleton. Pass an explicit
+   * registry for tests that want deterministic resolution without
+   * touching global state.
+   */
+  readonly registry?: ModelRegistry;
 }
+
+/**
+ * Default minimum sample count before `queryByModelWithFamilyFallback`
+ * broadens to family-level data. Tuned so cold-start siblings inherit
+ * their family's signal until they accumulate ~5 of their own outcomes.
+ */
+export const DEFAULT_FAMILY_FALLBACK_THRESHOLD = 5;
 
 /**
  * Auto-classifies failed outcomes that are missing a failureCategory.
@@ -54,15 +69,36 @@ function hasErrorMessage(o: TaskOutcome): boolean {
 export class OutcomeStore {
   private readonly entries: TaskOutcome[] = [];
   private readonly maxEntries: number;
+  private readonly registry: ModelRegistry;
 
   constructor(config?: OutcomeStoreConfig) {
     this.maxEntries = config?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.registry = config?.registry ?? getDefaultRegistry();
   }
 
-  /** Append a new outcome. Auto-classifies failures missing failureCategory (#1441). */
+  /**
+   * Append a new outcome. Auto-classifies failures missing failureCategory
+   * (#1441) and resolves the outcome's `vendor` / `family` via the
+   * ModelRegistry (#2548) so family-level retrieval can warm-start
+   * siblings after a model retirement.
+   */
   append(outcome: TaskOutcome): void {
-    this.entries.push(autoClassify(outcome));
+    this.entries.push(this.enrich(autoClassify(outcome)));
     this.enforceLimit();
+  }
+
+  /**
+   * Attach `vendor` and `family` to the outcome if they're not already
+   * set. Idempotent — pre-enriched outcomes pass through unchanged.
+   */
+  private enrich(outcome: TaskOutcome): TaskOutcome {
+    if (outcome.vendor !== undefined && outcome.family !== undefined) return outcome;
+    const entry = this.registry.getEntry(outcome.model);
+    return {
+      ...outcome,
+      vendor: outcome.vendor ?? entry.vendor,
+      family: outcome.family ?? entry.family,
+    };
   }
 
   /** Query outcomes with optional filters. */
@@ -70,6 +106,50 @@ export class OutcomeStore {
     if (filter === undefined) return [...this.entries];
     const filtered = applyFilters(this.entries, filter);
     return filter.limit !== undefined ? filtered.slice(-filter.limit) : filtered;
+  }
+
+  /**
+   * Query outcomes for a specific model with a family-level warm-start
+   * fallback (#2548). When the literal `modelId` has fewer than
+   * `threshold` samples in the store, broaden the result to the model's
+   * `{vendor, family}` siblings — siblings within a family share enough
+   * behavior profile that their outcomes are useful priors for cold
+   * starts after a retirement.
+   *
+   * Returns the outcomes and a `scope` flag so callers know whether
+   * they're consuming literal-id data or family-broadened data.
+   */
+  queryByModelWithFamilyFallback(
+    modelId: string,
+    options?: {
+      readonly threshold?: number;
+      readonly extraFilter?: Omit<OutcomeQuery, 'limit'>;
+    }
+  ): {
+    readonly outcomes: readonly TaskOutcome[];
+    readonly scope: 'literal' | 'family' | 'empty';
+    readonly vendor?: string;
+    readonly family?: string;
+  } {
+    const threshold = options?.threshold ?? DEFAULT_FAMILY_FALLBACK_THRESHOLD;
+    const base = options?.extraFilter ?? {};
+    const literal = applyFilters(this.entries, base).filter((o) => o.model === modelId);
+    if (literal.length >= threshold) {
+      const entry = this.registry.getEntry(modelId);
+      return { outcomes: literal, scope: 'literal', vendor: entry.vendor, family: entry.family };
+    }
+    const entry = this.registry.getEntry(modelId);
+    const family = applyFilters(this.entries, base).filter(
+      (o) =>
+        // Cross-vendor transfer is out of scope (#2548) — vendor must match.
+        // Family must match too: an Anthropic claude-opus outcome shouldn't
+        // warm-start an Anthropic claude-haiku query.
+        o.vendor === entry.vendor && o.family === entry.family
+    );
+    if (family.length === 0) {
+      return { outcomes: literal, scope: 'empty', vendor: entry.vendor, family: entry.family };
+    }
+    return { outcomes: family, scope: 'family', vendor: entry.vendor, family: entry.family };
   }
 
   /** Aggregate outcomes into a performance summary. */

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
@@ -60,6 +60,10 @@ export const TaskOutcomeSchema = z.object({
   routingStage: z.string().max(50).optional(),
   /** Number of retry attempts before this outcome (#1785). */
   retryCount: z.number().int().nonnegative().optional(),
+  /** Vendor resolved from `model` via ModelRegistry at write time (#2548). */
+  vendor: z.string().min(1).max(40).optional(),
+  /** Family resolved from `model` via ModelRegistry at write time (#2548). */
+  family: z.string().min(1).max(80).optional(),
 });
 
 /** Schema for filtering outcomes. */


### PR DESCRIPTION
## Summary

Closes #2548. OutcomeStore previously keyed outcomes by literal `model` string. When a model retired and routing migrated to a sibling (via `withModelNotFoundFallback` from #2545 PR 8), the new model started cold even though same-vendor + same-family data was already in the store.

## What changed

### Schema (back-compat — both fields optional)

`TaskOutcomeSchema` gains:

- `vendor?: string` — resolved from `model` via `ModelRegistry.getEntry()`.
- `family?: string` — same source.

Old outcomes without these fields still parse.

### `OutcomeStore.append()`

Now resolves vendor/family from the registry at write time. Idempotent — outcomes that already carry vendor/family pass through unchanged.

### New `queryByModelWithFamilyFallback(modelId, options)`

```ts
const r = store.queryByModelWithFamilyFallback('claude-opus-4-7', { threshold: 5 });
// r.scope is 'literal' | 'family' | 'empty'
// r.outcomes is the appropriate slice
// r.vendor / r.family are the resolved identity
```

- Filters by literal `model` first.
- If count < `threshold` (default 5), broadens to `{vendor, family}` siblings.
- **Vendor isolation:** cross-vendor outcomes are NEVER merged. Family-broadening picks up same-vendor + same-family only.
- Supports `extraFilter` so callers can constrain to a category while broadening.

### `OutcomeStoreConfig.registry?` (test-injectable)

Optional override for tests that want deterministic resolution.

## Migration

Historical outcomes without `vendor`/`family` stay as-is. Since the family-fallback query looks for outcomes that DO carry vendor/family, old outcomes only match the literal scope until they age out of the bounded store — the routing benefit applies forward from the next retirement, not backward. Acceptable per the issue's scope.

## Tests (+5 cases)

- literal-scope when threshold met
- broadening to family when below threshold
- vendor isolation (no cross-vendor merging)
- empty-scope when no matches
- extraFilter respected during broadening

## Verification

- pnpm typecheck — clean
- pnpm vitest run src/orchestration/outcomes/ src/mcp/tools/weather-report.test.ts — **230/230 pass**

## What didn't change

- `queryWithLookback` in weather-report (CLI-grained, not model-grained) — out of scope.
- Cross-vendor outcome transfer — out of scope per #2548.
- Bounded-store eviction policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)