### PR TITLE
fix(ci): allow PascalCase / start-case in commit subjects (#2572)

### DIFF
--- a/.rules/git.md
+++ b/.rules/git.md
@@ -28,11 +28,14 @@ perf(topsis): cache normalized scores across routing calls
 
 ```
 Update routing           # missing type
-feat: Add Feature        # uppercase subject (warning)
+feat: Foo bar            # sentence-case subject (rejected post-#2572)
+feat: FOO BAR            # upper-case subject (rejected)
 feature(routing): add x  # wrong type (feature → feat)
 ```
 
-**Config:** `commitlint.config.ts` extends `@commitlint/config-conventional`.
+**Subject case allowance** (#2572): PascalCase / start-case is **allowed** in subjects so they can reference code symbols like `OutcomeStore`, `CompositeRouter`, `IModelAdapter`. Only sentence-case (`Foo bar`) and upper-case (`FOO BAR`) are rejected.
+
+**Config:** `commitlint.config.ts` extends `@commitlint/config-conventional` with overrides documented inline.
 
 ## Branch Naming
 

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -20,6 +20,11 @@ const config: UserConfig = {
     'subject-empty': [2, 'never'],
     // Type must not be empty
     'type-empty': [2, 'never'],
+    // Subject case: still reject "Foo: bar" (sentence-case) and "FOO: BAR"
+    // (upper-case), but allow PascalCase / start-case so subjects can
+    // reference code symbols like `OutcomeStore`, `CompositeRouter`,
+    // `IModelAdapter` without rejection (#2572).
+    'subject-case': [2, 'never', ['sentence-case', 'upper-case']],
     // No max header length — some descriptions need context
     'header-max-length': [1, 'always', 100],
     // Body and footer are optional


### PR DESCRIPTION
## Summary

Closes #2572. `@commitlint/config-conventional` rejected subjects with PascalCase first words, which tripped up commits referencing code symbols like \`OutcomeStore\`, \`CompositeRouter\`, \`IModelAdapter\`. Two of my commits this session were rejected purely for naming a real class in the subject.

## Change

\`commitlint.config.ts\`:

\`\`\`diff
+    // Subject case: still reject "Foo: bar" (sentence-case) and "FOO: BAR"
+    // (upper-case), but allow PascalCase / start-case so subjects can
+    // reference code symbols like \`OutcomeStore\`, \`CompositeRouter\`,
+    // \`IModelAdapter\` without rejection (#2572).
+    'subject-case': [2, 'never', ['sentence-case', 'upper-case']],
\`\`\`

Also updates \`.rules/git.md\` with the new allowance documented and a corrected bad-example list.

## What still rejects

- \`Foo bar\` (sentence-case)
- \`FOO BAR\` (upper-case)
- Missing type (\`Update routing\`)
- Wrong type (\`feature: ...\`)

## What now passes

- \`feat(adapters): OutcomeStore family-fallback for warm-start\`
- \`refactor(routing): replace CompositeRouter with new variant\`
- \`fix(types): tighten IModelAdapter signature\`

## Test plan

- [x] \`git commit -m "feat(scope): OutcomeStore foo"\` now passes locally
- [x] \`git commit -m "feat: Foo bar"\` still rejects (sentence-case)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)