### PR TITLE
refactor(mcp/safety): flatten safety/__tests__ — second slice of #2565

### DIFF
--- a/packages/nexus-agents/src/mcp/safety/stpa-validation-boundaries.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation-boundaries.test.ts
@@ -10,14 +10,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateToolAgainstConstraints } from '../stpa-validation.js';
+import { validateToolAgainstConstraints } from './stpa-validation.js';
 import {
   type ToolDefinition,
   type SafetyConstraint,
   HazardSeverity,
   ConstraintEnforcement,
   ConstraintPriority,
-} from '../stpa-types.js';
+} from './stpa-types.js';
 // ToolCategory may be used in future tests for hazard mapping
 void 0; // Intentionally unused import removed
 


### PR DESCRIPTION
## Summary

Second slice of #2565. The `mcp/safety/` directory had two test files with the same basename:

- `safety/stpa-validation.test.ts` (387 lines) — tests `validateToolAgainstConstraints` (the constraint-matching engine).
- `safety/__tests__/stpa-validation.test.ts` (853 lines) — tests STPA Input Validation + Security Boundaries (entirely different scope).

Same filename, different concerns. Confusing in IDE jump-to-definition and grep.

## Change

- Rename `safety/__tests__/stpa-validation.test.ts` → `safety/stpa-validation-boundaries.test.ts` (reflects actual scope: input validation + security boundaries).
- Fix `../X` imports → `./X`.
- Remove empty `__tests__/` directory.

## Test plan

- [x] `pnpm vitest run src/mcp/safety/` — **410/410 pass**
- [ ] CI on this PR

## Next slices

Remaining `__tests__` directories per `find` (excluding sandbox/ which is complex — pairs are complementary not duplicate):

- `cli/__tests__`, `core/__tests__`, `learning/__tests__`, `workflows/__tests__`, `mcp/middleware/__tests__`, `security/__tests__`. Each as a separate PR.

`security/sandbox/__tests__` is harder — all 5 nested files have identical-basename top-level counterparts with overlapping-but-different content. Will need a separate audit pass before consolidating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)