### PR TITLE
refactor(security): flatten security/__tests__ — third slice of #2565

### DIFF
--- a/packages/nexus-agents/src/security/input-validation.test.ts
+++ b/packages/nexus-agents/src/security/input-validation.test.ts
@@ -10,10 +10,10 @@
 import { describe, it, expect } from 'vitest';
 
 // Import tool schemas
-import { OrchestrateInputSchema } from '../../mcp/tools/orchestrate.js';
-import { DelegateInputSchema } from '../../mcp/tools/delegate-to-model.js';
-import { CreateExpertInputSchema } from '../../mcp/tools/create-expert.js';
-import { RunWorkflowInputSchema } from '../../mcp/tools/run-workflow.js';
+import { OrchestrateInputSchema } from './../mcp/tools/orchestrate.js';
+import { DelegateInputSchema } from './../mcp/tools/delegate-to-model.js';
+import { CreateExpertInputSchema } from './../mcp/tools/create-expert.js';
+import { RunWorkflowInputSchema } from './../mcp/tools/run-workflow.js';
 
 describe('Input Validation - Zod Schemas', () => {
   describe('OrchestrateInputSchema', () => {

--- a/packages/nexus-agents/src/security/path-traversal.test.ts
+++ b/packages/nexus-agents/src/security/path-traversal.test.ts
@@ -21,14 +21,14 @@ import * as fsSync from 'node:fs';
 import * as os from 'node:os';
 
 // Import path validation functions from various modules
-import { loadTemplateFile } from '../../workflows/template-loader.js';
-import { SecurityError } from '../../core/index.js';
+import { loadTemplateFile } from './../workflows/template-loader.js';
+import { SecurityError } from './../core/index.js';
 import {
   validateWorkflowPath,
   getAllowedWorkflowDirs,
   isFilePath,
-} from '../../mcp/tools/run-workflow-helpers.js';
-import type { RunWorkflowDeps } from '../../mcp/tools/run-workflow-types.js';
+} from './../mcp/tools/run-workflow-helpers.js';
+import type { RunWorkflowDeps } from './../mcp/tools/run-workflow-types.js';
 
 // ============================================================================
 // Test Constants
@@ -174,7 +174,7 @@ describe('Path Traversal Prevention - Research Helpers IO', () => {
   describe('loadTechniquesRegistry path validation', () => {
     it('should reject rootDir with path traversal patterns', async () => {
       // Import dynamically after mocking
-      const { loadTechniquesRegistry } = await import('../../cli/research-helpers-io.js');
+      const { loadTechniquesRegistry } = await import('../cli/research-helpers-io.js');
 
       for (const maliciousRoot of MALICIOUS_PATHS) {
         const result = await loadTechniquesRegistry(maliciousRoot);
@@ -192,7 +192,7 @@ describe('Path Traversal Prevention - Research Helpers IO', () => {
     });
 
     it('should normalize paths with .. segments', async () => {
-      const { loadTechniquesRegistry } = await import('../../cli/research-helpers-io.js');
+      const { loadTechniquesRegistry } = await import('../cli/research-helpers-io.js');
 
       // Root with parent directory reference gets resolved
       const result = await loadTechniquesRegistry('/test/foo/../root');
@@ -205,7 +205,7 @@ describe('Path Traversal Prevention - Research Helpers IO', () => {
 
   describe('loadPapersRegistry path validation', () => {
     it('should reject rootDir with path traversal patterns', async () => {
-      const { loadPapersRegistry } = await import('../../cli/research-helpers-io.js');
+      const { loadPapersRegistry } = await import('../cli/research-helpers-io.js');
 
       for (const maliciousRoot of MALICIOUS_PATHS) {
         const result = await loadPapersRegistry(maliciousRoot);
@@ -220,7 +220,7 @@ describe('Path Traversal Prevention - Research Helpers IO', () => {
 
   describe('saveTechniquesRegistry path validation', () => {
     it('should reject rootDir with path traversal', async () => {
-      const { saveTechniquesRegistry } = await import('../../cli/research-helpers-io.js');
+      const { saveTechniquesRegistry } = await import('../cli/research-helpers-io.js');
 
       const mockRegistry = {
         schema_version: '1.0',
@@ -271,7 +271,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
       it(`should reject path traversal via env: ${maliciousPath}`, async () => {
         process.env['NEXUS_CONFIG_PATH'] = maliciousPath;
 
-        const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+        const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
         const result = loadCustomExperts();
 
         // Should have security error for path traversal
@@ -287,7 +287,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
       it(`should reject absolute paths that escape cwd: ${absolutePath}`, async () => {
         process.env['NEXUS_CONFIG_PATH'] = absolutePath;
 
-        const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+        const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
         const result = loadCustomExperts();
 
         // Absolute paths outside cwd should be rejected
@@ -306,7 +306,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
       // This is NOT a security vulnerability on Linux - the path would just fail to resolve
       process.env['NEXUS_CONFIG_PATH'] = 'C:\\Windows\\System32\\config\\SAM';
 
-      const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+      const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
       const result = loadCustomExperts();
 
       // On Linux, this is treated as a relative path (within cwd), so no security error
@@ -322,7 +322,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
       const { existsSync } = await import('node:fs');
       vi.mocked(existsSync).mockReturnValue(true);
 
-      const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+      const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
       const result = loadCustomExperts();
 
       // Should not have security errors for valid path
@@ -335,7 +335,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
     it('should allow same-directory path via env', async () => {
       process.env['NEXUS_CONFIG_PATH'] = './nexus-agents.yaml';
 
-      const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+      const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
       const result = loadCustomExperts();
 
       const securityError = result.errors.find(
@@ -347,7 +347,7 @@ describe('Path Traversal Prevention - Custom Expert Loader', () => {
     it('should include helpful suggestion for path traversal errors', async () => {
       process.env['NEXUS_CONFIG_PATH'] = '../../../etc/passwd';
 
-      const { loadCustomExperts } = await import('../../cli/custom-expert-loader.js');
+      const { loadCustomExperts } = await import('../cli/custom-expert-loader.js');
       const result = loadCustomExperts();
 
       const securityError = result.errors.find((e) => e.field === 'path');

--- a/packages/nexus-agents/src/security/rate-limiting.test.ts
+++ b/packages/nexus-agents/src/security/rate-limiting.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { RateLimiter, createDefaultRateLimiter } from '../../mcp/middleware/rate-limiter.js';
+import { RateLimiter, createDefaultRateLimiter } from './../mcp/middleware/rate-limiter.js';
 
 describe('Rate Limiting', () => {
   beforeEach(() => {

--- a/packages/nexus-agents/src/security/secrets-sanitization.test.ts
+++ b/packages/nexus-agents/src/security/secrets-sanitization.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { NexusError, ValidationError, SecurityError, AgentError } from '../../core/errors.js';
+import { NexusError, ValidationError, SecurityError, AgentError } from './../core/errors.js';
 
 describe('Secrets Sanitization', () => {
   const SENSITIVE_PATTERNS = [


### PR DESCRIPTION
## Summary

Third slice of #2565. 4 files in `security/__tests__/` — all had unique basenames (no collision with top-level `security/*.test.ts`), making this the cleanest slice yet:

- `input-validation.test.ts`
- `path-traversal.test.ts`
- `rate-limiting.test.ts`
- `secrets-sanitization.test.ts`

## Change

- Move each to `security/<name>.test.ts`
- Fix `../X` static imports → `./X`
- Fix `await import('../../X')` dynamic imports → `await import('../X')` (path-traversal uses these to defer module load past `vi.mock` calls)
- Remove the empty `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/security/` — **1413/1413 pass**
- [ ] CI on this PR

## Status of remaining #2565 slices

✅ Done: `audit/__tests__` (#2575), `mcp/safety/__tests__` (#2576), `security/__tests__` (this PR)

⏳ Pending (basename collisions — need pair-by-pair diff review):

- `security/sandbox/__tests__` — 5 files, all collide with extended top-level counterparts
- `cli/__tests__` — 2 files, both collide
- `core/__tests__` — 5 files, all collide
- `learning/__tests__` — 1 file, collides
- `workflows/__tests__` — 2 files, both collide
- `mcp/middleware/__tests__` — 4 files, all collide

The collision cases are not safe to bulk-rename — pairs are overlapping-but-different, requiring careful diff review to decide between rename-with-suffix vs merge-into-one. Those slices should be filed as separate sub-issues or done one directory at a time in dedicated review sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)