### PR TITLE
refactor(learning): flatten learning/__tests__ — fourth slice of #2565

### DIFF
--- a/packages/nexus-agents/src/learning/outcome-storage-mockdb.test.ts
+++ b/packages/nexus-agents/src/learning/outcome-storage-mockdb.test.ts
@@ -12,7 +12,7 @@ import {
   type StoredReward,
   type ISQLiteDatabase,
   type ISQLiteStatement,
-} from '../index.js';
+} from './index.js';
 
 // In-memory mock database for testing
 class MockStatement<T> implements ISQLiteStatement<T> {


### PR DESCRIPTION
## Summary

Fourth slice of #2565. `learning/__tests__/outcome-storage.test.ts` collided with the top-level `learning/outcome-storage.test.ts`. The two are parallel test suites for the same module (`SQLiteOutcomeStorage`) at different abstraction levels:

- **Top-level** (825 lines): vi.fn-based unit mocks; 14 describe blocks covering the full surface.
- **Nested** (232 lines): class-based mock-database fake (`MockStatement`, `ISQLiteDatabase`); 6 describe blocks covering the core CRUD surface in an integration style.

Diffing `it()` blocks, 7 nested test names don't appear verbatim in the top file — preserve both suites to avoid coverage loss. Rename the nested one to `outcome-storage-mockdb.test.ts` (reflects the mock-database-fake style) and move to top level.

## Change

- `learning/__tests__/outcome-storage.test.ts` → `learning/outcome-storage-mockdb.test.ts`
- `../X` imports → `./X`
- Remove empty `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/learning/` — **398/398 pass**
- [ ] CI on this PR

## Remaining #2565 slices

Tracked in #2578 — 5 more directories with basename collisions need pair-by-pair review (security/sandbox, cli, core, workflows, mcp/middleware). This slice closes the easy/safe ones (audit, mcp/safety, security, learning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)