### PR TITLE
refactor(workflows): flatten workflows/__tests__ — fifth slice of #2565

### DIFF
--- a/packages/nexus-agents/src/workflows/parallel-executor-orchestration.test.ts
+++ b/packages/nexus-agents/src/workflows/parallel-executor-orchestration.test.ts
@@ -6,14 +6,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { WorkflowStep, StepResult } from '../../core/index.js';
-import { TaskQueue, createTaskQueue } from '../task-queue.js';
+import type { WorkflowStep, StepResult } from './../core/index.js';
+import { TaskQueue, createTaskQueue } from './task-queue.js';
 import {
   createExecutionPlan,
   validateWorkflowDependencies,
   getExecutionOrder,
   type ExecutionPlan,
-} from '../execution-planner.js';
+} from './execution-planner.js';
 import {
   executeParallel,
   withRetries,
@@ -21,7 +21,7 @@ import {
   getFailedSteps,
   type ExecutionContext,
   type StepExecutor,
-} from '../parallel-executor.js';
+} from './parallel-executor.js';
 
 // --- Test Helpers ---
 

--- a/packages/nexus-agents/src/workflows/workflow-parser-integration.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-parser-integration.test.ts
@@ -13,13 +13,13 @@ import {
   parseWorkflowJson,
   loadWorkflowFile,
   validateWorkflow,
-} from '../workflow-parser.js';
+} from './workflow-parser.js';
 import {
   buildDependencyGraph,
   validateDependencyGraph,
   getTopologicalOrder,
-} from '../dependency-graph.js';
-import type { WorkflowDefinition } from '../../core/index.js';
+} from './dependency-graph.js';
+import type { WorkflowDefinition } from './../core/index.js';
 
 describe('parseWorkflowYaml', () => {
   it('should parse valid YAML workflow', () => {


### PR DESCRIPTION
## Summary

Fifth slice of #2565. Both `workflows/__tests__` files collided with same-basename top-level files, but each nested file covered a strictly broader class-level scope than its top-level helper-level counterpart.

| File | Top (lines / scope) | Nested (lines / scope) |
|---|---|---|
| `parallel-executor.test.ts` | 227 / utility helpers (`allSucceeded`, `getFailedSteps`, `withRetries`, `executeParallel`) | 685 / class orchestration (`TaskQueue`, `ExecutionPlanner`, `ParallelExecutor`) |
| `workflow-parser.test.ts` | 437 / `parseWorkflowYaml`, `parseWorkflowJson`, `validateWorkflow` | 696 / parsers + `loadWorkflowFile` + `DependencyGraph` + Integration Tests |

Rename nested files with scope suffixes reflecting their actual coverage:

- nested `parallel-executor.test.ts` → `parallel-executor-orchestration.test.ts`
- nested `workflow-parser.test.ts` → `workflow-parser-integration.test.ts`

## Change

- Move + rename both files
- Fix `../X` static imports → `./X`
- Fix `await import('../../X')` dynamic imports → `await import('../X')`
- Remove empty `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/workflows/` — **1265/1265 pass**
- [ ] CI on this PR

## Remaining #2565 slices

Tracked in #2578. Four directories remaining: `security/sandbox/__tests__` (5 collisions, complex), `cli/__tests__` (2 collisions), `core/__tests__` (5 collisions), `mcp/middleware/__tests__` (4 collisions). All need pair-by-pair diff review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)