### PR TITLE
refactor(cli): flatten cli/__tests__ — sixth slice of #2565

### DIFF
--- a/packages/nexus-agents/src/cli/sandbox-exec-security.test.ts
+++ b/packages/nexus-agents/src/cli/sandbox-exec-security.test.ts
@@ -15,8 +15,8 @@ import {
   execSandboxed,
   isCommandAllowed,
   type ExecContext,
-} from '../sandbox-exec.js';
-import { DEVELOPMENT_POLICY, RESTRICTIVE_POLICY } from '../../security/sandbox/index.js';
+} from './sandbox-exec.js';
+import { DEVELOPMENT_POLICY, RESTRICTIVE_POLICY } from './../security/sandbox/index.js';
 
 /** Command injection attack vectors. */
 const INJECTION_ATTACKS = [

--- a/packages/nexus-agents/src/cli/session-storage-mockdb.test.ts
+++ b/packages/nexus-agents/src/cli/session-storage-mockdb.test.ts
@@ -4,14 +4,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { SQLiteSessionStorage, createSessionStorage } from '../session-storage.js';
+import { SQLiteSessionStorage, createSessionStorage } from './session-storage.js';
 import type {
   ISQLiteDatabase,
   ISQLiteStatement,
   SessionRow,
   TaskRow,
   SessionSummaryRow,
-} from '../session-storage-types.js';
+} from './session-storage-types.js';
 
 // ============================================================================
 // Mock Helpers (split to reduce complexity)
@@ -283,7 +283,7 @@ describe('SQLiteSessionStorage', () => {
 describe('Session storage helpers', () => {
   describe('generateSessionId', () => {
     it('should generate unique IDs', async () => {
-      const { generateSessionId } = await import('../session-storage-helpers.js');
+      const { generateSessionId } = await import('./session-storage-helpers.js');
       const id1 = generateSessionId();
       const id2 = generateSessionId();
       expect(id1).not.toBe(id2);
@@ -293,7 +293,7 @@ describe('Session storage helpers', () => {
 
   describe('generateTaskId', () => {
     it('should generate unique IDs', async () => {
-      const { generateTaskId } = await import('../session-storage-helpers.js');
+      const { generateTaskId } = await import('./session-storage-helpers.js');
       const id1 = generateTaskId();
       const id2 = generateTaskId();
       expect(id1).not.toBe(id2);
@@ -303,7 +303,7 @@ describe('Session storage helpers', () => {
 
   describe('rowToSession', () => {
     it('should convert row to session', async () => {
-      const { rowToSession } = await import('../session-storage-helpers.js');
+      const { rowToSession } = await import('./session-storage-helpers.js');
       const row = {
         id: 'ses_test',
         created_at: '2026-01-11T12:00:00Z',


### PR DESCRIPTION
## Summary

Sixth slice of #2565. `cli/__tests__` had 2 files with basename collisions; each pair has the nested file covering a different angle than its top-level counterpart.

| File | Top (lines / scope) | Nested (lines / scope) |
|---|---|---|
| `sandbox-exec.test.ts` | 246 / general sandbox-exec | 544 / dedicated security testing (8 describe blocks: Input Validation, Command Allowlist, Command Injection Prevention, Path Traversal Prevention, Policy Selection, Safe Execution, Edge Cases, Security Regressions) |
| `session-storage.test.ts` | 504 / vi.fn unit tests of `SQLiteSessionStorage` CRUD | 320 / class-based mock-database fake for `SQLiteSessionStorage` + helpers |

## Change

- `cli/__tests__/sandbox-exec.test.ts` → `cli/sandbox-exec-security.test.ts`
- `cli/__tests__/session-storage.test.ts` → `cli/session-storage-mockdb.test.ts` (matches the naming pattern from PR #2579's learning slice)
- Fix all `../X` static + dynamic imports → `./X`
- Remove empty `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/cli/` — **3313/3313 pass**
- [ ] CI on this PR

## Remaining #2565 slices (tracked in #2578)

Three directories with collisions remaining:

- `security/sandbox/__tests__` — 5 files (complex; pairs are heavy on overlap)
- `core/__tests__` — 5 files
- `mcp/middleware/__tests__` — 4 files (one is `tool-rate-limiter` which doesn't actually have a collision after closer look — top is `rate-limiter.test.ts` AND `tool-rate-limiter.test.ts`)

Done so far: audit, mcp/safety, security, learning, workflows, cli (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)