### PR TITLE
refactor(core): flatten core/__tests__ — seventh slice of #2565

### DIFF
--- a/packages/nexus-agents/src/core/artifact-extended.test.ts
+++ b/packages/nexus-agents/src/core/artifact-extended.test.ts
@@ -11,7 +11,7 @@ import {
   isArtifactOfType,
   deriveArtifact,
   type ArtifactTypeValue,
-} from '../artifact.js';
+} from './artifact.js';
 
 describe('Artifact', () => {
   describe('ArtifactType', () => {

--- a/packages/nexus-agents/src/core/logger-credentials.test.ts
+++ b/packages/nexus-agents/src/core/logger-credentials.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sanitize, sanitizeDeep } from '../logger.js';
-import { FAKE_OPENAI_KEY, FAKE_BEARER_TOKEN, FAKE_AWS_KEY_ID } from '../../testing/test-secrets.js';
+import { sanitize, sanitizeDeep } from './logger.js';
+import { FAKE_OPENAI_KEY, FAKE_BEARER_TOKEN, FAKE_AWS_KEY_ID } from './../testing/test-secrets.js';
 
 describe('Logger sanitize', () => {
   describe('API keys', () => {

--- a/packages/nexus-agents/src/core/result-fp.test.ts
+++ b/packages/nexus-agents/src/core/result-fp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ok, err, isOk, isErr, map, mapErr, unwrap, unwrapOr, type Result } from '../result.js';
+import { ok, err, isOk, isErr, map, mapErr, unwrap, unwrapOr, type Result } from './result.js';
 
 describe('Result', () => {
   describe('ok()', () => {

--- a/packages/nexus-agents/src/core/trace-exporter-formats.test.ts
+++ b/packages/nexus-agents/src/core/trace-exporter-formats.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { Tracer } from '../trace.js';
+import { Tracer } from './trace.js';
 import {
   exportTraceToFile,
   exportTraceToString,
@@ -15,7 +15,7 @@ import {
   printTrace,
   generateTraceFilename,
   type ExportedTrace,
-} from '../trace-exporter.js';
+} from './trace-exporter.js';
 
 // =============================================================================
 // Test Setup

--- a/packages/nexus-agents/src/core/trace-extended.test.ts
+++ b/packages/nexus-agents/src/core/trace-extended.test.ts
@@ -9,7 +9,7 @@ import {
   calculateCost,
   generateTraceId,
   generateSpanId,
-} from '../trace.js';
+} from './trace.js';
 
 describe('trace', () => {
   describe('generateTraceId', () => {


### PR DESCRIPTION
## Summary

Seventh slice of #2565. `core/__tests__` had 5 files with basename collisions. Each pair has nested coverage that's parallel to or extends its top-level counterpart, so the safe move is rename-with-scope-suffix to eliminate basename collisions while preserving all test cases.

| File | Top lines / scope | Nested lines / scope | Renamed to |
|---|---|---|---|
| `artifact.test.ts` | 372 / Artifact | 511 / Artifact (more cases) | `artifact-extended.test.ts` |
| `logger.test.ts` | 252 / sanitize/sanitizeDeep/createLogger/setGlobalLogLevel | 353 / credential-pattern detection (API keys, Bearer, AWS/Azure/GCP, GitHub) | `logger-credentials.test.ts` |
| `result.test.ts` | 223 / ok/err/isOk/isErr/map | 141 / single `Result` describe + unwrap/unwrapOr FP helpers | `result-fp.test.ts` |
| `trace-exporter.test.ts` | 178 / 3 export fns | 309 / + exportToFile, printTrace, generateTraceFilename | `trace-exporter-formats.test.ts` |
| `trace.test.ts` | 1233 / Tracer (comprehensive) | 617 / Tracer (parallel suite) | `trace-extended.test.ts` |

## Change

- Move + rename 5 files
- Fix `../X` static + `../../X`/`../X` dynamic imports → local paths
- Remove empty `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/core/` — **1171/1171 pass**
- [ ] CI on this PR

## Remaining #2565 slices (tracked in #2578)

Two directories with collisions remaining:

- `security/sandbox/__tests__` — 5 files, complex (pairs overlap with subtle differences)
- `mcp/middleware/__tests__` — 4 files

Both warrant careful pair-by-pair review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)