### PR TITLE
refactor(mcp/middleware): flatten mcp/middleware/__tests__ — eighth slice of #2565

### DIFF
--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain-extended.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain-extended.test.ts
@@ -11,9 +11,9 @@ import {
   createMiddlewareFactory,
   type ContextAwareToolHandler,
   type ToolResult,
-} from '../middleware-chain.js';
-import { createDefaultPolicyFirewall } from '../policy.js';
-import { RateLimiter } from '../rate-limiter.js';
+} from './middleware-chain.js';
+import { createDefaultPolicyFirewall } from './policy.js';
+import { RateLimiter } from './rate-limiter.js';
 
 describe('Middleware Chain', () => {
   const successResult: ToolResult = {

--- a/packages/nexus-agents/src/mcp/middleware/request-context-extended.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context-extended.test.ts
@@ -12,7 +12,7 @@ import {
   contextForLogging,
   isRequestContext,
   type RequestContext,
-} from '../request-context.js';
+} from './request-context.js';
 
 describe('RequestContext', () => {
   describe('generateRequestId', () => {

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler-extended.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler-extended.test.ts
@@ -9,9 +9,9 @@ import {
   createSecureHandlerFactory,
   type ToolHandler,
   type ContextAwareHandler,
-} from '../secure-handler.js';
-import { createDefaultPolicyFirewall, type IPolicyFirewall } from '../policy.js';
-import { RateLimiter } from '../rate-limiter.js';
+} from './secure-handler.js';
+import { createDefaultPolicyFirewall, type IPolicyFirewall } from './policy.js';
+import { RateLimiter } from './rate-limiter.js';
 
 describe('SecureHandler', () => {
   // Mock handler that returns success

--- a/packages/nexus-agents/src/mcp/middleware/tool-rate-limiter-extended.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-rate-limiter-extended.test.ts
@@ -11,8 +11,8 @@ import {
   getGlobalToolRateLimiterFactory,
   setGlobalToolRateLimiterFactory,
   resetGlobalToolRateLimiterFactory,
-} from '../tool-rate-limiter.js';
-import { DEFAULT_TOOL_RATE_LIMITS } from '../../../config/schemas.js';
+} from './tool-rate-limiter.js';
+import { DEFAULT_TOOL_RATE_LIMITS } from './../../config/schemas.js';
 
 describe('ToolRateLimiterFactory', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Eighth slice of #2565. `mcp/middleware/__tests__` had 4 files with basename collisions, all parallel suites covering the same surface as their top-level counterparts but at smaller scope.

| File | Top lines | Nested lines | Renamed |
|---|---|---|---|
| `middleware-chain.test.ts` | 1387 | 377 | `middleware-chain-extended.test.ts` |
| `request-context.test.ts` | 314 | 183 | `request-context-extended.test.ts` |
| `secure-handler.test.ts` | 1425 | 256 | `secure-handler-extended.test.ts` |
| `tool-rate-limiter.test.ts` | 219 | 255 | `tool-rate-limiter-extended.test.ts` |

## Change

- Move + rename 4 files
- Fix `../X` static + dynamic imports → local
- Remove `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/mcp/middleware/` — **616/616 pass**
- [ ] CI on this PR

## Status of #2565

Done: audit, mcp/safety, security, learning, workflows, cli, core, mcp/middleware (8 slices, 8 PRs).
Remaining: only `security/sandbox/__tests__` (5 files, complex overlapping pairs). Captured in #2578 for dedicated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)