### PR TITLE
refactor(security/sandbox): flatten security/sandbox/__tests__ — ninth slice of #2565, closes basename-collision sweep

### DIFF
--- a/packages/nexus-agents/src/security/sandbox/command-allowlist-extended.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/command-allowlist-extended.test.ts
@@ -18,7 +18,7 @@ import {
   ALLOWED_COMMANDS,
   DENIED_COMMANDS,
   DENIED_ARG_PATTERNS,
-} from '../command-allowlist.js';
+} from './command-allowlist.js';
 
 describe('Command Allowlist', () => {
   describe('validateCommand', () => {

--- a/packages/nexus-agents/src/security/sandbox/default-policies-extended.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/default-policies-extended.test.ts
@@ -18,10 +18,10 @@ import {
   DEFAULT_POLICIES,
   getPolicy,
   getDefaultPolicyForContext,
-} from '../default-policies.js';
-import { DEFAULT_RESOURCE_LIMITS } from '../sandbox-types.js';
-import { COMMAND_CATEGORIES, ALLOWED_COMMANDS } from '../command-allowlist.js';
-import { SAFE_ENV_VARS } from '../env-sanitizer.js';
+} from './default-policies.js';
+import { DEFAULT_RESOURCE_LIMITS } from './sandbox-types.js';
+import { COMMAND_CATEGORIES, ALLOWED_COMMANDS } from './command-allowlist.js';
+import { SAFE_ENV_VARS } from './env-sanitizer.js';
 
 describe('Default Policies', () => {
   describe('RESTRICTIVE_POLICY', () => {

--- a/packages/nexus-agents/src/security/sandbox/env-sanitizer-extended.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/env-sanitizer-extended.test.ts
@@ -17,7 +17,7 @@ import {
   SAFE_ENV_VARS,
   DENIED_ENV_PREFIXES,
   DENIED_ENV_PATTERNS,
-} from '../env-sanitizer.js';
+} from './env-sanitizer.js';
 
 describe('Environment Sanitizer', () => {
   describe('sanitizeEnvironment', () => {

--- a/packages/nexus-agents/src/security/sandbox/sandbox-executor-extended.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-executor-extended.test.ts
@@ -9,10 +9,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { PolicySandboxExecutor, createSandboxExecutor } from '../sandbox-executor.js';
-import { STANDARD_POLICY, RESTRICTIVE_POLICY } from '../default-policies.js';
-import type { SandboxExecutionOptions, SandboxPolicy } from '../sandbox-types.js';
-import { DEFAULT_RESOURCE_LIMITS } from '../sandbox-types.js';
+import { PolicySandboxExecutor, createSandboxExecutor } from './sandbox-executor.js';
+import { STANDARD_POLICY, RESTRICTIVE_POLICY } from './default-policies.js';
+import type { SandboxExecutionOptions, SandboxPolicy } from './sandbox-types.js';
+import { DEFAULT_RESOURCE_LIMITS } from './sandbox-types.js';
 
 // Mock child_process
 vi.mock('node:child_process', () => ({

--- a/packages/nexus-agents/src/security/sandbox/sandbox-manager-extended.test.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-manager-extended.test.ts
@@ -16,11 +16,11 @@ import {
   isSandboxInitialized,
   getSandboxMode,
   resetSandboxManager,
-} from '../sandbox-manager.js';
-import * as factory from '../sandbox-factory.js';
+} from './sandbox-manager.js';
+import * as factory from './sandbox-factory.js';
 
 // Mock the sandbox factory
-vi.mock('../sandbox-factory.js', () => ({
+vi.mock('./sandbox-factory.js', () => ({
   createSandbox: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary

Ninth and **final basename-collision slice** of #2565. `security/sandbox/__tests__` had 5 files with same-basename top-level counterparts; each nested file used the parallel-suite style (single wrapping describe block) at smaller scope than its top-level counterpart.

| File | Top describes | Nested describe | Renamed |
|---|---|---|---|
| `command-allowlist.test.ts` | `COMMAND_CATEGORIES`, `ALLOWED_COMMANDS`, `DENIED_COMMANDS`, … | `Command Allowlist` | `command-allowlist-extended.test.ts` |
| `default-policies.test.ts` | `RESTRICTIVE_POLICY`, `STANDARD_POLICY`, `DEVELOPMENT_POLICY`, … | `Default Policies` | `default-policies-extended.test.ts` |
| `env-sanitizer.test.ts` | `SAFE_ENV_VARS`, `DENIED_ENV_PREFIXES`, `DENIED_ENV_PATTERNS`, … | `Environment Sanitizer` | `env-sanitizer-extended.test.ts` |
| `sandbox-executor.test.ts` | `createSandboxExecutor`, `PolicySandboxExecutor - validate`, `PolicySandboxExecutor - path traversal prevention`, … | `PolicySandboxExecutor`, `createSandboxExecutor`, `security scenarios` | `sandbox-executor-extended.test.ts` |
| `sandbox-manager.test.ts` | `initializeSandbox`, `getSandboxExecutor`, `getSandboxExecutorOrNull`, … | `Sandbox Manager` | `sandbox-manager-extended.test.ts` |

## Change

- Move + rename 5 files
- Fix `from '../X'` static imports → `./X`
- Fix `vi.mock('../X')` paths (which earlier slices missed in the sed substitution; surfaced as `TypeError: mockCreateSandbox.mockResolvedValue is not a function` on `sandbox-manager-extended`) → `./X`
- Fix `await import('../X')` / `await import('../../X')` → local paths
- Remove `__tests__/` directory

## Test plan

- [x] `pnpm vitest run src/security/sandbox/` — **362/362 pass**
- [ ] CI on this PR

## #2565 status

With this PR, **no `__tests__/` subdirectory remains under `packages/nexus-agents/src/`**. Each module's tests live as top-level `<module>/<name>.test.ts` files with no two files in the same module sharing a basename. The Definition of Done items from #2565 are met for the basename-collision sweep portion of the issue.

A future pass can audit each "-extended.test.ts" file against its corresponding top-level test to consolidate where the suites materially overlap. That's optional cleanup; the original issue's primary value (no duplicate filenames) is now realized.

Done across slices: audit, mcp/safety, security, learning, workflows, cli, core, mcp/middleware, security/sandbox (9 PRs total: #2575, #2576, #2577, #2579, #2580, #2581, #2582, #2583, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)