### PR TITLE
feat(adapters): streaming retry on MODEL_NOT_FOUND — restart-from-zero (#2550)

### DIFF
--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.test.ts
@@ -326,3 +326,172 @@ describe('wrapResilientWithFallback (#2549)', () => {
     expect(r.error.message).toContain('claude-opus-4-7');
   });
 });
+
+// ============================================================================
+// Streaming retry (#2550)
+// ============================================================================
+
+import type { StreamChunk } from '../core/index.js';
+
+/** Helper: collect all chunks from an AsyncIterable. */
+async function collectStream(stream: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = [];
+  for await (const chunk of stream) {
+    out.push(chunk);
+  }
+  return out;
+}
+
+/** Fake adapter that yields N text-delta chunks then optionally throws. */
+function streamingFakeAdapter(
+  modelId: string,
+  chunkTexts: readonly string[],
+  throwAfterAll: ModelError | null = null
+): IModelAdapter {
+  return {
+    providerId: 'anthropic',
+    modelId,
+    capabilities: [],
+    complete: () => Promise.resolve(successResponse()),
+    countTokens: () => Promise.resolve(0),
+    validateConfig: () => ok(undefined),
+    // eslint-disable-next-line @typescript-eslint/require-await
+    stream: async function* () {
+      for (let i = 0; i < chunkTexts.length; i++) {
+        const text = chunkTexts[i] ?? '';
+        const chunk: StreamChunk = {
+          type: 'content_block_delta',
+          index: i,
+          delta: { type: 'text_delta', text },
+        };
+        yield chunk;
+      }
+      if (throwAfterAll !== null) {
+        throw throwAfterAll;
+      }
+    },
+  };
+}
+
+describe('withModelNotFoundFallback streaming retry (#2550)', () => {
+  it('passes through a successful stream unchanged', async () => {
+    const inner = streamingFakeAdapter('claude-opus-4-7', ['a', 'b', 'c']);
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    const chunks = await collectStream(wrapped.stream(dummyRequest));
+    expect(chunks).toHaveLength(3);
+  });
+
+  it('passes through non-MODEL_NOT_FOUND throws unchanged', async () => {
+    const inner = streamingFakeAdapter(
+      'claude-opus-4-7',
+      [],
+      new ModelError('boom', { code: ErrorCode.MODEL_RATE_LIMITED })
+    );
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    await expect(collectStream(wrapped.stream(dummyRequest))).rejects.toThrow('boom');
+  });
+
+  it('on MODEL_NOT_FOUND throw, restarts from the fallback adapter (restart-from-zero)', async () => {
+    const inner = streamingFakeAdapter(
+      'claude-opus-4-6',
+      ['retired-1'],
+      new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })
+    );
+    const fallbackAdapterImpl = streamingFakeAdapter('claude-opus-4-7', ['new-1', 'new-2']);
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, {
+      cache,
+      adapterFactory: () => fallbackAdapterImpl,
+    });
+    const chunks = await collectStream(wrapped.stream(dummyRequest));
+    // Consumer sees the retired adapter's 1 chunk AND the fallback's 2
+    // chunks — restart-from-zero replays the fallback from its start
+    // but does NOT drop chunks already yielded.
+    expect(chunks).toHaveLength(3);
+    expect(
+      chunks
+        .filter(
+          (c): c is Extract<StreamChunk, { type: 'content_block_delta' }> =>
+            c.type === 'content_block_delta'
+        )
+        .map((c) => c.delta.text)
+    ).toEqual(['retired-1', 'new-1', 'new-2']);
+  });
+
+  it('re-throws original error enriched with fallback id when no adapterFactory is wired', async () => {
+    const inner = streamingFakeAdapter(
+      'claude-opus-4-6',
+      [],
+      new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })
+    );
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const wrapped = withModelNotFoundFallback(inner, { cache });
+    await expect(collectStream(wrapped.stream(dummyRequest))).rejects.toThrow(
+      /suggested fallback: claude-opus-4-7/
+    );
+  });
+
+  it('invokes onRetirement when stream falls back', async () => {
+    const inner = streamingFakeAdapter(
+      'claude-opus-4-6',
+      [],
+      new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })
+    );
+    const fallbackAdapterImpl = streamingFakeAdapter('claude-opus-4-7', ['x']);
+    const cache = new AvailableModelsCache({
+      sources: [
+        {
+          name: 'anthropic',
+          providerHint: 'anthropic',
+          listModels: () => Promise.resolve([{ id: 'claude-opus-4-7' }]),
+        },
+      ],
+    });
+    const onRetirement = vi.fn();
+    const wrapped = withModelNotFoundFallback(inner, {
+      cache,
+      adapterFactory: () => fallbackAdapterImpl,
+      onRetirement,
+    });
+    await collectStream(wrapped.stream(dummyRequest));
+    expect(onRetirement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retiredModelId: 'claude-opus-4-6',
+        fallbackModelId: 'claude-opus-4-7',
+      })
+    );
+  });
+
+  it('re-throws original when no fallback model is available', async () => {
+    const inner = streamingFakeAdapter(
+      'claude-opus-4-6',
+      [],
+      new ModelError('404', { code: ErrorCode.MODEL_NOT_FOUND })
+    );
+    // Empty cache → no fallback can be picked → original error propagates.
+    const cache = new AvailableModelsCache({ sources: [] });
+    const wrapped = withModelNotFoundFallback(inner, {
+      cache,
+      adapterFactory: () => streamingFakeAdapter('never', []),
+    });
+    await expect(collectStream(wrapped.stream(dummyRequest))).rejects.toThrow('404');
+  });
+});

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
@@ -83,8 +83,18 @@ export interface RetirementInfo {
  *     same-family alternative, retry once with `request.model =
  *     <fallback>`. Original error is returned if no fallback found.
  *  3. The wrapper returns the SECOND error if the retry also fails.
- *  4. `stream`, `countTokens`, `validateConfig`, `listModels` are
- *     passthrough.
+ *  4. `stream()` retries via restart-from-zero (#2550): when the inner
+ *     stream throws a `MODEL_NOT_FOUND` ModelError, the wrapper closes
+ *     the failed stream, picks a same-family fallback via the cache +
+ *     registry, builds a new adapter through `adapterFactory`, and
+ *     yields chunks from the fallback stream. The consumer sees a clean
+ *     second stream — partial content already delivered by the first
+ *     stream is NOT replayed; that's a known trade-off (the alternative
+ *     resume-with-reconciliation strategy is heavier and only useful
+ *     for tool-use loops; not implemented per the deliberate scoping in
+ *     #2550). Without `adapterFactory`, the original throw propagates
+ *     unchanged.
+ *  5. `countTokens`, `validateConfig`, `listModels` are passthrough.
  */
 export function withModelNotFoundFallback(
   inner: IModelAdapter,
@@ -104,7 +114,8 @@ export function withModelNotFoundFallback(
     capabilities: inner.capabilities,
     countTokens: (text) => inner.countTokens(text),
     validateConfig: () => inner.validateConfig(),
-    stream: (request: CompletionRequest): AsyncIterable<StreamChunk> => inner.stream(request),
+    stream: (request: CompletionRequest): AsyncIterable<StreamChunk> =>
+      streamWithFallback(inner, request, resolvedOptions),
     complete: (request: CompletionRequest) => completeWithFallback(inner, request, resolvedOptions),
   };
   if (typeof inner.listModels === 'function') {
@@ -175,6 +186,104 @@ async function completeWithFallback(
       cause: retried.error,
     })
   );
+}
+
+/**
+ * Restart-from-zero streaming retry on MODEL_NOT_FOUND (#2550).
+ *
+ * Iterates the inner stream; if it throws a `ModelError` with code
+ * `MODEL_NOT_FOUND`, refreshes the cache, picks a same-family fallback,
+ * builds a new adapter via `adapterFactory`, and yields chunks from
+ * the fallback stream. The consumer sees a clean second stream — any
+ * partial content already delivered by the first stream is NOT
+ * replayed; that's the documented trade-off of restart-from-zero
+ * (alternative resume-with-reconciliation strategy is heavier and
+ * deferred per #2550's scope decision).
+ *
+ * Without `adapterFactory` the original throw propagates unchanged —
+ * the wrapper has no way to construct the retry adapter, so the
+ * consumer can re-route at a higher layer if it wants.
+ */
+async function* streamWithFallback(
+  inner: IModelAdapter,
+  request: CompletionRequest,
+  options: ResolvedOptions
+): AsyncGenerator<StreamChunk> {
+  try {
+    for await (const chunk of inner.stream(request)) {
+      yield chunk;
+    }
+    return;
+  } catch (e: unknown) {
+    if (!isModelNotFoundError(e)) throw e;
+    const fallbackAdapter = await resolveStreamFallback(inner, e, options);
+    // Restart-from-zero: the consumer gets a fresh stream starting from
+    // the first chunk. Any partial chunks the inner stream already
+    // yielded are NOT replayed.
+    for await (const chunk of fallbackAdapter.stream(request)) {
+      yield chunk;
+    }
+  }
+}
+
+/**
+ * Pick a same-family fallback model, run the retirement callback, and
+ * return the constructed fallback adapter. Throws (with appropriate
+ * enrichment) when no factory is wired or no fallback is available.
+ */
+async function resolveStreamFallback(
+  inner: IModelAdapter,
+  cause: unknown,
+  options: ResolvedOptions
+): Promise<IModelAdapter> {
+  const fallback = await pickFallback(inner.modelId, options.cache, options.registry);
+  if (fallback === null) {
+    logger.warn('Stream model not found and no fallback available', {
+      modelId: inner.modelId,
+      providerId: inner.providerId,
+      errorMessage: cause instanceof Error ? cause.message : String(cause),
+    });
+    throw cause;
+  }
+
+  logger.info('Stream retirement detected; restarting with fallback (restart-from-zero)', {
+    retiredModelId: inner.modelId,
+    fallbackModelId: fallback,
+    providerId: inner.providerId,
+  });
+  notifyRetirement(options.onRetirement, {
+    retiredModelId: inner.modelId,
+    fallbackModelId: fallback,
+    providerId: inner.providerId,
+    errorMessage: cause instanceof Error ? cause.message : String(cause),
+  });
+
+  if (options.adapterFactory === undefined) {
+    // No factory wired → can't construct the retry adapter. Re-throw
+    // with the original error enriched so callers at a higher layer
+    // can attempt their own re-routing.
+    const message = `${cause instanceof Error ? cause.message : String(cause)} — suggested fallback: ${fallback}`;
+    const causeErr = cause instanceof Error ? cause : undefined;
+    throw new ModelErrorClass(
+      message,
+      causeErr !== undefined
+        ? { code: ErrorCode.MODEL_NOT_FOUND, cause: causeErr }
+        : { code: ErrorCode.MODEL_NOT_FOUND }
+    );
+  }
+
+  return options.adapterFactory(fallback);
+}
+
+function isModelNotFoundError(e: unknown): boolean {
+  if (e instanceof ModelErrorClass) {
+    return e.code === ErrorCode.MODEL_NOT_FOUND;
+  }
+  // Some adapters throw a plain Error with the code as a string property.
+  if (typeof e === 'object' && e !== null && 'code' in e) {
+    return e.code === ErrorCode.MODEL_NOT_FOUND;
+  }
+  return false;
 }
 
 function notifyRetirement(


### PR DESCRIPTION
## Summary

Closes #2550. PR 8 (#2545) shipped retry-on-MODEL_NOT_FOUND for `complete()` but explicitly left `stream()` as passthrough. The issue body picks restart-from-zero as the right default (resume-with-reconciliation is heavier and only useful for tool-use loops — deferred per the issue's explicit scope decision).

## What changed

### New `streamWithFallback` async generator

Iterates the inner stream; if it throws a `ModelError` with code `MODEL_NOT_FOUND`:

1. Refreshes the cache + picks a same-family fallback via `pickFallback(...)`.
2. If `adapterFactory` is wired → builds a new adapter and yields chunks from the fallback's stream (restart-from-zero).
3. Without `adapterFactory` → re-throws the original error enriched with the suggested fallback id so a higher-layer caller can re-route.
4. Without a same-family fallback → re-throws the original error unchanged.

Extracted `resolveStreamFallback` helper to keep complexity under the lint cap.

### `onRetirement` integration

Stream-mid retirements fire the same `onRetirement` callback shape as `complete()` retirements: `{retiredModelId, fallbackModelId, providerId, errorMessage}`.

### Trade-off (documented inline)

Restart-from-zero gives the consumer the retired adapter's already-emitted chunks PLUS the fallback's full stream — does not replay or drop. Resume-with-reconciliation would dedupe but requires consumer cooperation; deferred.

## Tests added (+6 cases)

- successful stream pass-through
- non-MODEL_NOT_FOUND throws propagate
- MODEL_NOT_FOUND mid-stream → restart-from-zero with fallback adapter
- no adapterFactory → enriched error with suggested fallback
- onRetirement invoked on stream-mid retirement
- empty cache → original propagates

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (no max-warnings violations)
- `pnpm vitest run src/adapters/model-not-found-fallback.test.ts` — **19/19 pass**

## What didn't change

- `complete()` retry path (unchanged)
- `wrapResilientWithFallback` helper (the resilient `stream()` is forwarded, so it picks up the new behavior automatically)
- Resume-with-reconciliation strategy (deferred per #2550's explicit scope decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)