### PR TITLE
fix(ci): scope SICA PR staging to generated artifacts only

### DIFF
--- a/.github/workflows/sica-test-generation.yml
+++ b/.github/workflows/sica-test-generation.yml
@@ -153,6 +153,14 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Limit the PR to the actual generated artifacts so the
+          # workflow's scratch `generate-tests.ts` heredoc and
+          # `coverage-report.log` debug output don't get staged —
+          # lint-staged's ESLint pass rejects the scratch file and
+          # fails the whole PR-creation step. See issue #2591.
+          add-paths: |
+            **/*.sica.test.ts
+            sica-results.json
           commit-message: |
             test: add SICA-generated tests
 


### PR DESCRIPTION
## Summary

- The `SICA Weekly Test Generation` workflow has been red for the last two scheduled runs (2026-05-04, 2026-05-11). Different failure mode than #2263.
- Root cause: `peter-evans/create-pull-request` stages all working-tree changes by default, picking up the workflow's heredoc-generated `generate-tests.ts` at repo root. Husky pre-commit + lint-staged ESLint rejects the scratch file.
- Fix: explicit `add-paths` whitelist so only `**/*.sica.test.ts` and `sica-results.json` reach staging.

## Test plan

- [ ] YAML parses (verified locally).
- [ ] Workflow can be manually triggered via `workflow_dispatch` after merge to verify the next run lands a PR (or no-ops if nothing was generated).

Closes #2591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)