### PR TITLE
feat(config): migrate model-config-helpers to ModelRegistry (#2546 slice B)

### DIFF
--- a/packages/nexus-agents/src/config/in-tree-entries.ts
+++ b/packages/nexus-agents/src/config/in-tree-entries.ts
@@ -18,7 +18,8 @@
 
 import { DEFAULT_MODEL_CAPABILITIES } from './model-capabilities.js';
 import type { ModelCapability, Provider } from './model-capabilities-types.js';
-import { deriveEntry, type ModelEntry } from './model-registry.js';
+import { deriveEntry } from './model-derivation.js';
+import type { ModelEntry } from './model-registry.js';
 import { resolveModelIdentitySync, type ModelVendor } from './model-identity.js';
 
 /**
@@ -43,6 +44,18 @@ function providerToVendor(provider: Provider): ModelVendor {
  * fields come from `deriveEntry()` (so vendor/family defaults apply);
  * capability fields come from the matrix.
  */
+function optionalFields(model: ModelCapability): Partial<ModelEntry> {
+  const out: Partial<{ -readonly [K in keyof ModelEntry]: ModelEntry[K] }> = {};
+  if (model.maxOutputTokens !== undefined) out.maxOutputTokens = model.maxOutputTokens;
+  if (model.pricing !== undefined) out.pricing = model.pricing;
+  if (model.qualityScores !== undefined) out.qualityScores = model.qualityScores;
+  if (model.notes !== undefined) out.notes = model.notes;
+  if (model.cliName !== undefined) out.cliName = model.cliName;
+  if (model.cliAlias !== undefined) out.cliAlias = model.cliAlias;
+  if (model.cliModelName !== undefined) out.cliModelName = model.cliModelName;
+  return out;
+}
+
 function toEntry(model: ModelCapability): ModelEntry {
   const vendorHint = providerToVendor(model.provider);
   const identity = resolveModelIdentitySync(model.id, { vendor: vendorHint });
@@ -53,24 +66,19 @@ function toEntry(model: ModelCapability): ModelEntry {
     allAliases.add(model.cliModelName);
   }
 
-  const entry: ModelEntry = {
+  return {
     ...derived,
     id: model.id,
     ...(allAliases.size > 0 && { aliases: [...allAliases] }),
     displayName: model.displayName,
     contextWindow: model.contextWindow,
-    ...(model.maxOutputTokens !== undefined && { maxOutputTokens: model.maxOutputTokens }),
     inputModalities: model.inputModalities,
     outputModalities: model.outputModalities,
     toolCapabilities: model.toolCapabilities,
     specialFeatures: model.specialFeatures,
-    ...(model.pricing !== undefined && { pricing: model.pricing }),
-    ...(model.qualityScores !== undefined && { qualityScores: model.qualityScores }),
-    ...(model.notes !== undefined && { notes: model.notes }),
+    ...optionalFields(model),
     source: 'in-tree',
   };
-
-  return entry;
 }
 
 /**

--- a/packages/nexus-agents/src/config/manifest-overlay.ts
+++ b/packages/nexus-agents/src/config/manifest-overlay.ts
@@ -170,7 +170,16 @@ export function loadManifestOverlay(options?: {
   const logger = options?.logger ?? createLogger({ component: 'manifest-overlay' });
   const path = options?.path ?? resolveManifestPath(options?.env);
 
-  if (!existsSync(path)) {
+  // Defensive: tests sometimes `vi.mock('node:fs', ...)` with a subset
+  // of exports that omits `existsSync`. Treat any throw from the probe
+  // as "no manifest" rather than letting it crash module-load callers.
+  let exists = false;
+  try {
+    exists = existsSync(path);
+  } catch {
+    return { entries: [], rejections: [], path, status: 'missing' };
+  }
+  if (!exists) {
     return { entries: [], rejections: [], path, status: 'missing' };
   }
 

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -1,19 +1,21 @@
 /**
  * nexus-agents/config - Model Config Helpers
  *
- * Derived helper functions that read from the canonical model registry.
+ * Derived helper functions that read from the canonical ModelRegistry.
  * All model metadata consumers should import from here instead of
  * maintaining their own hardcoded tables.
  *
+ * As of #2546 slice B, the internals read from
+ * `getDefaultRegistry().getEntry()` / `.allEntries()` rather than
+ * `DEFAULT_MODEL_CAPABILITIES.models.find()`. Public signatures
+ * unchanged so downstream consumers see no diff.
+ *
  * @module config/model-config-helpers
- * (Source: Issue #807)
+ * (Source: Issue #807; registry migration #2546)
  */
 
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  DEFAULT_MODEL_PER_CLI,
-  getModelCapabilities,
-} from './model-capabilities.js';
+import { buildInTreeEntries } from './in-tree-entries.js';
+import { DEFAULT_MODEL_PER_CLI } from './model-capabilities.js';
 import type {
   ModelId,
   ModelCapability,
@@ -21,19 +23,54 @@ import type {
   Pricing,
   QualityScores,
 } from './model-capabilities-types.js';
+import { getDefaultRegistry, type ModelEntry } from './model-registry.js';
+
+/**
+ * Average latency estimates per CLI (ms). Returned by a function (not
+ * a top-level const) to dodge TDZ in circular-load scenarios — module
+ * loaders sometimes re-enter `model-config-helpers` mid-evaluation
+ * via the `topsis-types → buildTopsisProfiles` chain, and function
+ * declarations are hoisted while `const` declarations are not.
+ */
+function cliAvgLatency(): Record<CliNameLiteral, number> {
+  return { claude: 800, gemini: 400, codex: 500, opencode: 600 };
+}
 
 // ---------------------------------------------------------------------------
 // Single-Model Lookups
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve a modelId to an in-tree entry via the global registry.
+ * Returns undefined when no in-tree authoritative entry exists
+ * (e.g. unknown id, gateway model). Routes through `getDefaultRegistry()`
+ * so manifest-overlay + snapshot tiers can still influence runtime
+ * behaviour. Used by single-model lookup helpers.
+ */
+function lookupInTree(modelId: string): ModelEntry | undefined {
+  const entry = getDefaultRegistry().getEntry(modelId);
+  return entry.source === 'in-tree' ? entry : undefined;
+}
+
+/**
+ * Filesystem-free variant: builds an `id → entry` map from the
+ * in-tree converter only. Used by bulk builders that run at
+ * module-load time (e.g. `buildCliCapabilityProfiles`), where we
+ * cannot afford to trigger `getDefaultRegistry()` because that
+ * touches the filesystem (manifest-overlay, snapshot loader).
+ */
+function inTreeById(): Map<string, ModelEntry> {
+  return new Map(buildInTreeEntries().map((e) => [e.id, e] as const));
+}
+
 /** Get pricing for a model, or undefined if not set. */
 export function getModelPricing(modelId: ModelId): Pricing | undefined {
-  return getModelCapabilities(modelId)?.pricing;
+  return lookupInTree(modelId)?.pricing;
 }
 
 /** Get display name for a model. Falls back to the modelId string. */
 export function getModelDisplayName(modelId: ModelId): string {
-  return getModelCapabilities(modelId)?.displayName ?? modelId;
+  return lookupInTree(modelId)?.displayName ?? modelId;
 }
 
 /**
@@ -51,17 +88,17 @@ export function getModelDisplayName(modelId: ModelId): string {
  * should call `CapabilityDiscovery.resolve(id)` directly — #2176.
  */
 export function getModelContextWindow(modelId: ModelId): number {
-  return getModelCapabilities(modelId)?.contextWindow ?? 8_192;
+  return lookupInTree(modelId)?.contextWindow ?? 8_192;
 }
 
 /** Get max output tokens for a model, or undefined if not set. */
 export function getModelMaxOutput(modelId: ModelId): number | undefined {
-  return getModelCapabilities(modelId)?.maxOutputTokens;
+  return lookupInTree(modelId)?.maxOutputTokens;
 }
 
 /** Get quality scores for a model, or undefined if not set. */
 export function getModelQualityScores(modelId: ModelId): QualityScores | undefined {
-  return getModelCapabilities(modelId)?.qualityScores;
+  return lookupInTree(modelId)?.qualityScores;
 }
 
 /** Get the default (strongest) model for a given CLI tool. */
@@ -71,8 +108,8 @@ export function getDefaultModelForCli(cli: CliNameLiteral): ModelId {
 
 /** Get the model name the CLI binary expects (e.g., 'gemini-2.5-pro'). */
 export function getCliModelName(modelId: ModelId): string {
-  const cap = getModelCapabilities(modelId);
-  return cap?.cliModelName ?? cap?.cliAlias ?? modelId;
+  const entry = lookupInTree(modelId);
+  return entry?.cliModelName ?? entry?.cliAlias ?? modelId;
 }
 
 /**
@@ -83,9 +120,14 @@ export function getCliModelName(modelId: ModelId): string {
  *   3. aliases[] membership (legacy version names — #2199 Child 5)
  */
 export function resolveCliAlias(alias: string): ModelId | undefined {
-  return DEFAULT_MODEL_CAPABILITIES.models.find(
-    (m) => m.cliAlias === alias || m.id === alias || (m.aliases?.includes(alias) ?? false)
-  )?.id;
+  const match = getDefaultRegistry()
+    .allEntries()
+    .find(
+      (e) =>
+        e.source === 'in-tree' &&
+        (e.cliAlias === alias || e.id === alias || (e.aliases?.includes(alias) ?? false))
+    );
+  return match?.id as ModelId | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,12 +152,12 @@ interface CapabilityProfileShape {
  */
 export function buildCapabilityProfiles(): Record<string, CapabilityProfileShape> {
   const result: Record<string, CapabilityProfileShape> = {};
-  for (const model of DEFAULT_MODEL_CAPABILITIES.models) {
-    const q = model.qualityScores;
-    if (q !== undefined) {
-      result[model.id] = {
+  for (const entry of buildInTreeEntries()) {
+    const q = entry.qualityScores;
+    if (q !== undefined && entry.contextWindow !== undefined) {
+      result[entry.id] = {
         reasoning: q.reasoning,
-        contextWindow: model.contextWindow,
+        contextWindow: entry.contextWindow,
         codeGeneration: q.codeGeneration,
         speed: q.speed,
         cost: q.cost,
@@ -131,15 +173,16 @@ export function buildCapabilityProfiles(): Record<string, CapabilityProfileShape
  */
 export function buildCliCapabilityProfiles(): Record<CliNameLiteral, CapabilityProfileShape> {
   const result = {} as Record<CliNameLiteral, CapabilityProfileShape>;
+  const byId = inTreeById();
   for (const [cli, modelId] of Object.entries(DEFAULT_MODEL_PER_CLI) as Array<
     [CliNameLiteral, ModelId]
   >) {
-    const model = getModelCapabilities(modelId);
-    const q = model?.qualityScores;
-    if (model !== undefined && q !== undefined) {
+    const entry = byId.get(modelId);
+    const q = entry?.qualityScores;
+    if (entry !== undefined && q !== undefined && entry.contextWindow !== undefined) {
       result[cli] = {
         reasoning: q.reasoning,
-        contextWindow: model.contextWindow,
+        contextWindow: entry.contextWindow,
         codeGeneration: q.codeGeneration,
         speed: q.speed,
         cost: q.cost,
@@ -161,39 +204,33 @@ interface TopsisProfileShape {
   readonly qualityScore: number;
 }
 
-/** Average latency estimates per CLI (ms). */
-const CLI_AVG_LATENCY: Record<CliNameLiteral, number> = {
-  claude: 800,
-  gemini: 400,
-  codex: 500,
-  opencode: 600,
-};
-
 /**
  * Build TOPSIS model profiles for the default model of each CLI.
  * Used by topsis-types.ts to replace DEFAULT_MODEL_PROFILES.
  */
 export function buildTopsisProfiles(): readonly TopsisProfileShape[] {
   const profiles: TopsisProfileShape[] = [];
+  const byId = inTreeById();
   for (const [cli, modelId] of Object.entries(DEFAULT_MODEL_PER_CLI) as Array<
     [CliNameLiteral, ModelId]
   >) {
-    const model = getModelCapabilities(modelId);
-    const q = model?.qualityScores;
-    const p = model?.pricing;
-    if (model === undefined || q === undefined || p === undefined) continue;
+    const entry = byId.get(modelId);
+    const q = entry?.qualityScores;
+    const p = entry?.pricing;
+    if (entry === undefined || q === undefined || p === undefined) continue;
+    if (entry.contextWindow === undefined) continue;
     profiles.push({
       cliName: cli,
       capabilities: {
         reasoning: q.reasoning,
-        contextWindow: model.contextWindow,
+        contextWindow: entry.contextWindow,
         codeGeneration: q.codeGeneration,
         speed: q.speed,
         cost: q.cost,
       },
       costPerMillionInput: p.inputPer1M,
       costPerMillionOutput: p.outputPer1M,
-      averageLatencyMs: CLI_AVG_LATENCY[cli],
+      averageLatencyMs: cliAvgLatency()[cli],
       qualityScore: (q.reasoning + q.codeGeneration) / 2,
     });
   }
@@ -225,19 +262,60 @@ export interface ModelInfoShape {
  *   3. `id` — registry identifier ('gemini-pro', 'claude-opus') (#2200 Child 2)
  *   4. `aliases[]` membership — legacy / version-suffix names that resolve
  *      to this entry (#2200 Child 1)
+ *
+ * Returns the legacy ModelCapability shape for backward compatibility
+ * with adapter consumers; values are pulled from the registry's
+ * authoritative in-tree entries.
  */
 export function findCanonicalModel(
   cli: CliNameLiteral,
   cliModelName: string
 ): ModelCapability | undefined {
-  return DEFAULT_MODEL_CAPABILITIES.models.find(
-    (m) =>
-      m.cliName === cli &&
-      (m.cliModelName === cliModelName ||
-        m.cliAlias === cliModelName ||
-        m.id === cliModelName ||
-        (m.aliases?.includes(cliModelName) ?? false))
-  );
+  const entry = getDefaultRegistry()
+    .allEntries()
+    .find(
+      (e) =>
+        e.source === 'in-tree' &&
+        e.cliName === cli &&
+        (e.cliModelName === cliModelName ||
+          e.cliAlias === cliModelName ||
+          e.id === cliModelName ||
+          (e.aliases?.includes(cliModelName) ?? false))
+    );
+  return entry !== undefined ? entryToCapability(entry) : undefined;
+}
+
+/**
+ * Project a ModelEntry back to the legacy ModelCapability shape for
+ * adapter callers that still expect the old type. New callers should
+ * read fields directly off `ModelEntry`.
+ */
+type Writable<T> = { -readonly [K in keyof T]: T[K] };
+
+function applyOptionalCapabilityFields(entry: ModelEntry, target: Writable<ModelCapability>): void {
+  if (entry.notes !== undefined) target.notes = entry.notes;
+  if (entry.pricing !== undefined) target.pricing = entry.pricing;
+  if (entry.qualityScores !== undefined) target.qualityScores = entry.qualityScores;
+  if (entry.maxOutputTokens !== undefined) target.maxOutputTokens = entry.maxOutputTokens;
+  if (entry.cliName !== undefined) target.cliName = entry.cliName as ModelCapability['cliName'];
+  if (entry.cliAlias !== undefined) target.cliAlias = entry.cliAlias;
+  if (entry.cliModelName !== undefined) target.cliModelName = entry.cliModelName;
+  if (entry.aliases !== undefined) target.aliases = [...entry.aliases];
+}
+
+function entryToCapability(entry: ModelEntry): ModelCapability {
+  const cap: ModelCapability = {
+    id: entry.id as ModelId,
+    displayName: entry.displayName ?? entry.id,
+    provider: (entry.vendor === 'unknown' ? 'openai' : entry.vendor) as ModelCapability['provider'],
+    contextWindow: entry.contextWindow ?? 0,
+    outputModalities: [...(entry.outputModalities ?? ['text'])],
+    inputModalities: [...(entry.inputModalities ?? ['text'])],
+    toolCapabilities: [...(entry.toolCapabilities ?? [])],
+    specialFeatures: [...(entry.specialFeatures ?? [])],
+  };
+  applyOptionalCapabilityFields(entry, cap);
+  return cap;
 }
 
 /**
@@ -271,23 +349,23 @@ export function buildModelInfo(
  */
 export function buildMockModelInfo(): Record<CliNameLiteral, ModelInfoShape> {
   const result = {} as Record<CliNameLiteral, ModelInfoShape>;
+  const byId = inTreeById();
   for (const [cli, modelId] of Object.entries(DEFAULT_MODEL_PER_CLI) as Array<
     [CliNameLiteral, ModelId]
   >) {
-    const model = getModelCapabilities(modelId);
-    if (model === undefined) continue;
+    const entry = byId.get(modelId);
+    if (entry?.contextWindow === undefined) continue;
     const info: ModelInfoShape = {
-      id: model.id,
-      name: model.displayName,
-      contextWindow: model.contextWindow,
+      id: entry.id,
+      name: entry.displayName ?? entry.id,
+      contextWindow: entry.contextWindow,
     };
-    // Only set optional properties when values exist (exactOptionalPropertyTypes)
-    if (model.maxOutputTokens !== undefined) {
-      (info as { maxOutput: number }).maxOutput = model.maxOutputTokens;
+    if (entry.maxOutputTokens !== undefined) {
+      (info as { maxOutput: number }).maxOutput = entry.maxOutputTokens;
     }
-    if (model.pricing !== undefined) {
-      (info as { costPerMillionInput: number }).costPerMillionInput = model.pricing.inputPer1M;
-      (info as { costPerMillionOutput: number }).costPerMillionOutput = model.pricing.outputPer1M;
+    if (entry.pricing !== undefined) {
+      (info as { costPerMillionInput: number }).costPerMillionInput = entry.pricing.inputPer1M;
+      (info as { costPerMillionOutput: number }).costPerMillionOutput = entry.pricing.outputPer1M;
     }
     result[cli] = info;
   }

--- a/packages/nexus-agents/src/config/model-derivation.ts
+++ b/packages/nexus-agents/src/config/model-derivation.ts
@@ -1,0 +1,164 @@
+/**
+ * Pattern-derivation logic for ModelRegistry — extracted from
+ * `model-registry.ts` to break a runtime circular import with
+ * `in-tree-entries.ts` (which needs `deriveEntry` to build the
+ * in-tree slice for `buildDefaultRegistry()`).
+ *
+ * No state lives here; everything is pure. The `ModelEntry` type
+ * is imported type-only from `model-registry.ts` to avoid a runtime
+ * dependency cycle.
+ *
+ * @module config/model-derivation
+ */
+
+import type { ModelHints, ModelVendor, ResolvedModelIdentity } from './model-identity.js';
+import type { ModelEntry } from './model-registry.js';
+
+/**
+ * Universal fallback. Used when nothing more specific matches —
+ * unknown vendor + family + no probe data. Safe defaults.
+ */
+export const DEFAULT_ENTRY: Omit<ModelEntry, 'id' | 'vendor' | 'family' | 'profileId' | 'source'> =
+  {
+    parallelToolCalls: false,
+    promptCaching: 'none',
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 10,
+    strictJson: true,
+    quirks: [],
+  };
+
+type VendorOverride = Partial<Omit<ModelEntry, 'id' | 'vendor' | 'family' | 'source'>>;
+
+const VENDOR_DEFAULTS: Partial<Record<ModelVendor, VendorOverride>> = {
+  anthropic: {
+    profileId: 'anthropic-default',
+    parallelToolCalls: true,
+    promptCaching: 'ephemeral',
+    toolDefinitionFormat: 'anthropic',
+    maxRecommendedTurnBudget: 15,
+  },
+  openai: {
+    profileId: 'openai-default',
+    parallelToolCalls: true,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 15,
+  },
+  google: {
+    profileId: 'google-default',
+    parallelToolCalls: true,
+    toolDefinitionFormat: 'gemini',
+    maxRecommendedTurnBudget: 15,
+  },
+  meta: {
+    profileId: 'meta-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 8,
+  },
+  qwen: {
+    profileId: 'qwen-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 8,
+  },
+  nvidia: {
+    profileId: 'nvidia-nemotron-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 8,
+  },
+  mistral: {
+    profileId: 'mistral-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 8,
+  },
+  cohere: {
+    profileId: 'cohere-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 8,
+  },
+  deepseek: {
+    profileId: 'deepseek-default',
+    parallelToolCalls: false,
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 10,
+  },
+};
+
+interface FamilyOverrideEntry {
+  readonly vendor: ModelVendor;
+  readonly family: string;
+  readonly override: VendorOverride;
+}
+
+const FAMILY_DEFAULTS: readonly FamilyOverrideEntry[] = [
+  {
+    vendor: 'anthropic',
+    family: 'claude-opus',
+    override: { profileId: 'claude-opus', maxRecommendedTurnBudget: 20 },
+  },
+  {
+    vendor: 'anthropic',
+    family: 'claude-haiku',
+    override: { profileId: 'claude-haiku', maxRecommendedTurnBudget: 8 },
+  },
+  {
+    vendor: 'openai',
+    family: 'o-reasoning',
+    override: { profileId: 'openai-o-reasoning', maxRecommendedTurnBudget: 25 },
+  },
+  {
+    vendor: 'google',
+    family: 'gemini-flash',
+    override: { profileId: 'gemini-flash', maxRecommendedTurnBudget: 8 },
+  },
+];
+
+/**
+ * Build an entry from vendor + family + quirks when no authoritative
+ * row matches. Source stamped `'derived'`; capability fields left
+ * undefined (derived entries don't have measured pricing/quality data).
+ */
+export function deriveEntry(modelId: string, identity: ResolvedModelIdentity): ModelEntry {
+  const vendorOverride = VENDOR_DEFAULTS[identity.vendor] ?? {};
+  const familyOverride =
+    FAMILY_DEFAULTS.find((f) => f.vendor === identity.vendor && f.family === identity.family)
+      ?.override ?? {};
+
+  const merged = {
+    ...DEFAULT_ENTRY,
+    profileId: 'default',
+    ...vendorOverride,
+    ...familyOverride,
+  };
+
+  // Apply quirk overlay — `'thinking'` bumps budget 1.5×, `'embedding'`
+  // is propagated for adapter consumers to refuse construction.
+  const quirks = [...new Set([...merged.quirks, ...identity.quirks])];
+  let budget = merged.maxRecommendedTurnBudget;
+  if (identity.quirks.includes('thinking')) {
+    budget = Math.ceil(budget * 1.5);
+  }
+
+  return {
+    id: modelId,
+    vendor: identity.vendor,
+    family: identity.family,
+    ...(identity.version !== undefined && { version: identity.version }),
+    parallelToolCalls: merged.parallelToolCalls,
+    promptCaching: merged.promptCaching,
+    toolDefinitionFormat: merged.toolDefinitionFormat,
+    maxRecommendedTurnBudget: budget,
+    strictJson: merged.strictJson,
+    quirks,
+    profileId: merged.profileId,
+    source: 'derived',
+  };
+}
+
+// Re-export so old call sites that pulled hints type from this side
+// of the tree don't need to change.
+export type { ModelHints };

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -33,14 +33,10 @@
  * @module config/model-registry
  */
 
-import {
-  resolveModelIdentitySync,
-  type ModelHints,
-  type ModelVendor,
-  type ResolvedModelIdentity,
-} from './model-identity.js';
+import { resolveModelIdentitySync, type ModelHints, type ModelVendor } from './model-identity.js';
 import { buildInTreeEntries } from './in-tree-entries.js';
 import { loadManifestOverlay } from './manifest-overlay.js';
+import { DEFAULT_ENTRY, deriveEntry } from './model-derivation.js';
 import { loadModelsDevSnapshot } from './models-dev-snapshot-loader.js';
 import type {
   InputModality,
@@ -122,6 +118,14 @@ export interface ModelEntry {
   readonly qualityScores?: QualityScores;
   readonly notes?: string;
 
+  // ---- CLI routing metadata (in-tree entries only) ----
+  /** Which CLI tool this model belongs to (e.g. 'claude', 'gemini'). */
+  readonly cliName?: string;
+  /** Short alias the CLI accepts (e.g. 'opus' for claude). */
+  readonly cliAlias?: string;
+  /** Vendor model id the CLI passes upstream (e.g. 'claude-opus-4-6'). */
+  readonly cliModelName?: string;
+
   // ---- Behaviour (carried from ModelBehaviorProfile) ----
   readonly parallelToolCalls: boolean;
   readonly promptCaching: PromptCachingMode;
@@ -137,118 +141,10 @@ export interface ModelEntry {
   readonly verifiedAt?: string;
 }
 
-// ============================================================================
-// Defaults
-// ============================================================================
-
-/**
- * Universal fallback. Used when nothing more specific matches —
- * unknown vendor + family + no probe data. Safe defaults.
- */
-export const DEFAULT_ENTRY: Omit<ModelEntry, 'id' | 'vendor' | 'family' | 'profileId' | 'source'> =
-  {
-    parallelToolCalls: false,
-    promptCaching: 'none',
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 10,
-    strictJson: true,
-    quirks: [],
-  };
-
-/**
- * Per-vendor default behaviour. Used when the vendor is known but
- * no in-tree authoritative entry exists for the specific model.
- *
- * Sparse: only fields that differ from `DEFAULT_ENTRY` are listed.
- */
-type VendorOverride = Partial<Omit<ModelEntry, 'id' | 'vendor' | 'family' | 'source'>>;
-
-const VENDOR_DEFAULTS: Partial<Record<ModelVendor, VendorOverride>> = {
-  anthropic: {
-    profileId: 'anthropic-default',
-    parallelToolCalls: true,
-    promptCaching: 'ephemeral',
-    toolDefinitionFormat: 'anthropic',
-    maxRecommendedTurnBudget: 15,
-  },
-  openai: {
-    profileId: 'openai-default',
-    parallelToolCalls: true,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 15,
-  },
-  google: {
-    profileId: 'google-default',
-    parallelToolCalls: true,
-    toolDefinitionFormat: 'gemini',
-    maxRecommendedTurnBudget: 15,
-  },
-  meta: {
-    profileId: 'meta-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 8,
-  },
-  qwen: {
-    profileId: 'qwen-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 8,
-  },
-  nvidia: {
-    profileId: 'nvidia-nemotron-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 8,
-  },
-  mistral: {
-    profileId: 'mistral-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 8,
-  },
-  cohere: {
-    profileId: 'cohere-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 8,
-  },
-  deepseek: {
-    profileId: 'deepseek-default',
-    parallelToolCalls: false,
-    toolDefinitionFormat: 'openai',
-    maxRecommendedTurnBudget: 10,
-  },
-};
-
-interface FamilyOverrideEntry {
-  readonly vendor: ModelVendor;
-  readonly family: string;
-  readonly override: VendorOverride;
-}
-
-const FAMILY_DEFAULTS: readonly FamilyOverrideEntry[] = [
-  {
-    vendor: 'anthropic',
-    family: 'claude-opus',
-    override: { profileId: 'claude-opus', maxRecommendedTurnBudget: 20 },
-  },
-  {
-    vendor: 'anthropic',
-    family: 'claude-haiku',
-    override: { profileId: 'claude-haiku', maxRecommendedTurnBudget: 8 },
-  },
-  {
-    vendor: 'openai',
-    family: 'o-reasoning',
-    override: { profileId: 'openai-o-reasoning', maxRecommendedTurnBudget: 25 },
-  },
-  {
-    vendor: 'google',
-    family: 'gemini-flash',
-    override: { profileId: 'gemini-flash', maxRecommendedTurnBudget: 8 },
-  },
-];
+// Derivation (DEFAULT_ENTRY, VENDOR_DEFAULTS, FAMILY_DEFAULTS, deriveEntry)
+// lives in `./model-derivation.ts` so `in-tree-entries.ts` can import
+// `deriveEntry` without creating a runtime cycle back through this file.
+// We re-export below for backward compatibility with existing call sites.
 
 // ============================================================================
 // Registry
@@ -372,51 +268,9 @@ function mergeSnapshotWithDerived(snapshot: ModelEntry, derived: ModelEntry): Mo
   };
 }
 
-// ============================================================================
-// Derivation — build a ModelEntry from a ResolvedModelIdentity
-// ============================================================================
-
-/**
- * Build an entry from vendor + family + quirks when no authoritative
- * row matches. Source stamped `'derived'`; capability fields left
- * undefined (derived entries don't have measured pricing/quality data).
- */
-export function deriveEntry(modelId: string, identity: ResolvedModelIdentity): ModelEntry {
-  const vendorOverride = VENDOR_DEFAULTS[identity.vendor] ?? {};
-  const familyOverride =
-    FAMILY_DEFAULTS.find((f) => f.vendor === identity.vendor && f.family === identity.family)
-      ?.override ?? {};
-
-  const merged = {
-    ...DEFAULT_ENTRY,
-    profileId: 'default',
-    ...vendorOverride,
-    ...familyOverride,
-  };
-
-  // Apply quirk overlay — `'thinking'` bumps budget 1.5×, `'embedding'`
-  // is propagated for adapter consumers to refuse construction.
-  const quirks = [...new Set([...merged.quirks, ...identity.quirks])];
-  let budget = merged.maxRecommendedTurnBudget;
-  if (identity.quirks.includes('thinking')) {
-    budget = Math.ceil(budget * 1.5);
-  }
-
-  return {
-    id: modelId,
-    vendor: identity.vendor,
-    family: identity.family,
-    ...(identity.version !== undefined && { version: identity.version }),
-    parallelToolCalls: merged.parallelToolCalls,
-    promptCaching: merged.promptCaching,
-    toolDefinitionFormat: merged.toolDefinitionFormat,
-    maxRecommendedTurnBudget: budget,
-    strictJson: merged.strictJson,
-    quirks,
-    profileId: merged.profileId,
-    source: 'derived',
-  };
-}
+// Re-export the derivation surface so existing consumers keep working
+// without needing to update their import paths.
+export { DEFAULT_ENTRY, deriveEntry };
 
 // ============================================================================
 // Convenience — global default registry, populated lazily

--- a/packages/nexus-agents/src/config/models-dev-snapshot-loader.ts
+++ b/packages/nexus-agents/src/config/models-dev-snapshot-loader.ts
@@ -57,7 +57,16 @@ export function loadModelsDevSnapshot(options?: {
   const logger = createLogger({ component: 'models-dev-snapshot' });
   const path = options?.path ?? defaultSnapshotPath();
 
-  if (!existsSync(path)) {
+  // Defensive against partial `vi.mock('node:fs', ...)` in tests that
+  // omit `existsSync` — match manifest-overlay's behaviour and treat
+  // any probe failure as "no snapshot."
+  let exists = false;
+  try {
+    exists = existsSync(path);
+  } catch {
+    return { entries: [], path, status: 'missing' };
+  }
+  if (!exists) {
     return { entries: [], path, status: 'missing' };
   }
 


### PR DESCRIPTION
## Summary

Slice B of #2546 epic — switches `model-config-helpers.ts` internals to read from `getDefaultRegistry().getEntry()` instead of `DEFAULT_MODEL_CAPABILITIES.models.find()`. Every public signature is preserved.

## Structural side-effects (required to land cleanly)

1. **Extract `deriveEntry` to `model-derivation.ts`** — slice A introduced a runtime cycle (`model-registry → in-tree-entries → model-registry`) that was dormant because nothing called the registry at module-load time. Slice B's helpers expose the cycle. Extracting derivation breaks it. `model-registry.ts` re-exports `deriveEntry` + `DEFAULT_ENTRY` for backward compat.

2. **Add CLI fields to `ModelEntry`** — `cliName`, `cliAlias`, `cliModelName`. Required by `getCliModelName`, `resolveCliAlias`, `findCanonicalModel`. The in-tree converter populates them from the matrix.

3. **Bulk builders bypass the registry** — `buildCapabilityProfiles`, `buildCliCapabilityProfiles`, `buildTopsisProfiles`, `buildMockModelInfo` run at module-load time via consumers like `topsis-types.ts` and `delegate-to-model-types.ts`. Going through `getDefaultRegistry()` from these triggers filesystem reads at import time which fails under partial `vi.mock('node:fs', ...)` setups. They now read from `buildInTreeEntries()` directly — filesystem-free.

4. **Defensive `existsSync` probes** in `manifest-overlay.ts` and `models-dev-snapshot-loader.ts` — partial `vi.mock('node:fs', ...)` setups that omit `existsSync` no longer crash the registry.

5. **`cliAvgLatency()` is now a function, not a top-level const** — dodges TDZ in circular-load scenarios via `topsis-types → buildTopsisProfiles`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/config/` — 756/756 pass
- [x] Full coverage suite — 24,996+ pass, 0 fail
- [x] No public-signature changes to any helper (downstream consumers unchanged)

Closes #2599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)