### PR TITLE
feat(cli): read in-tree model matrix via registry helper (#2546 slice C1)

### DIFF
--- a/packages/nexus-agents/src/cli/capabilities-command.ts
+++ b/packages/nexus-agents/src/cli/capabilities-command.ts
@@ -12,18 +12,20 @@
 import type { ParsedCliArgs } from '../cli-types.js';
 import { EXIT_CODES } from '../cli-types.js';
 import {
-  DEFAULT_MODEL_CAPABILITIES,
   findModelsByOutputModality,
   findModelsByInputModality,
   findModelsByToolCapability,
   findModelsByFeature,
-  getModelCapabilities,
   OUTPUT_MODALITIES,
   INPUT_MODALITIES,
   TOOL_CAPABILITIES,
   SPECIAL_FEATURES,
 } from '../config/model-capabilities.js';
 import type { ModelCapability } from '../config/model-capabilities.js';
+import {
+  getInTreeCapabilitiesMatrix,
+  lookupInTreeCapability,
+} from '../config/model-config-helpers.js';
 
 // ============================================================================
 // Constants
@@ -86,8 +88,9 @@ function fmtContext(tokens: number): string {
 // ============================================================================
 
 function renderListTable(): void {
-  const models = DEFAULT_MODEL_CAPABILITIES.models;
-  const ver = String(DEFAULT_MODEL_CAPABILITIES.version);
+  const matrix = getInTreeCapabilitiesMatrix();
+  const models = matrix.models;
+  const ver = String(matrix.version);
   write(`\n${C.bold}Model Capabilities Matrix${C.reset} (v${ver})\n`);
 
   write(
@@ -112,11 +115,11 @@ function renderListTable(): void {
 }
 
 function renderListJson(): void {
-  write(JSON.stringify(DEFAULT_MODEL_CAPABILITIES, null, 2));
+  write(JSON.stringify(getInTreeCapabilitiesMatrix(), null, 2));
 }
 
 function renderListMarkdown(): void {
-  const models = DEFAULT_MODEL_CAPABILITIES.models;
+  const models = getInTreeCapabilitiesMatrix().models;
   write('# Model Capabilities Matrix\n');
   write('| Model | Provider | Context | Image Out | Audio | MCP | Sandbox | Thinking | Research |');
   write('|-------|----------|---------|-----------|-------|-----|---------|----------|----------|');
@@ -254,11 +257,13 @@ function handleCompare(args: ParsedCliArgs): void {
     write(`${C.red}Usage: nexus-agents capabilities compare <model1> <model2>${C.reset}`);
     process.exit(EXIT_CODES.INVALID_ARGS);
   }
-  const m1 = getModelCapabilities(id1);
-  const m2 = getModelCapabilities(id2);
+  const m1 = lookupInTreeCapability(id1);
+  const m2 = lookupInTreeCapability(id2);
   if (m1 === undefined || m2 === undefined) {
     const missing = m1 === undefined ? id1 : id2;
-    const ids = DEFAULT_MODEL_CAPABILITIES.models.map((m) => m.id).join(', ');
+    const ids = getInTreeCapabilitiesMatrix()
+      .models.map((m) => m.id)
+      .join(', ');
     write(`${C.red}Unknown model: ${missing}${C.reset}`);
     write(`Valid models: ${ids}`);
     process.exit(EXIT_CODES.INVALID_ARGS);

--- a/packages/nexus-agents/src/cli/config-init.ts
+++ b/packages/nexus-agents/src/cli/config-init.ts
@@ -11,7 +11,7 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { getErrorMessage } from '../core/index.js';
 import { colors } from './ansi-output.js';
-import { DEFAULT_MODEL_CAPABILITIES } from '../config/model-capabilities.js';
+import { getInTreeCapabilitiesMatrix } from '../config/model-config-helpers.js';
 import type { ModelCapability } from '../config/model-capabilities-types.js';
 
 /**
@@ -45,9 +45,9 @@ const DEFAULT_CONFIG_FILE = 'nexus-agents.yaml';
  * hardcoded model IDs (claude-sonnet-4, gpt-4o, o1-pro) that aren't in the
  * registry — config init produced a YAML that immediately failed to route.
  *
- * Now we derive the lists at template-generation time from
- * DEFAULT_MODEL_CAPABILITIES, so updates to the registry flow into
- * `config init` automatically.
+ * Now we derive the lists at template-generation time from the
+ * canonical registry (via `getInTreeCapabilitiesMatrix()`), so
+ * updates to the registry flow into `config init` automatically.
  *
  * Tier picks per provider (limit one per provider per tier to keep the
  * starter YAML readable):
@@ -73,7 +73,7 @@ function qualifiesBalanced(m: ModelCapability): boolean {
 }
 
 function bucketModels(): { fast: string[]; balanced: string[]; powerful: string[] } {
-  const all = DEFAULT_MODEL_CAPABILITIES.models;
+  const all = getInTreeCapabilitiesMatrix().models;
   const seenProvider = new Set<string>();
   const sortedByReasoning = [...all].sort(
     (a, b) => (b.qualityScores?.reasoning ?? 0) - (a.qualityScores?.reasoning ?? 0)
@@ -114,7 +114,7 @@ function pickOnePerProvider(
 
 /** Pick the doc-quality default model: highest-reasoning model overall. */
 function pickDefaultModel(): string {
-  const sorted = [...DEFAULT_MODEL_CAPABILITIES.models].sort(
+  const sorted = [...getInTreeCapabilitiesMatrix().models].sort(
     (a, b) => (b.qualityScores?.reasoning ?? 0) - (a.qualityScores?.reasoning ?? 0)
   );
   // Prefer claude-sonnet over claude-opus as default — opus is overkill for

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -29,7 +29,7 @@ import {
 } from '../config/learning-persistence.js';
 import { createAllAdapters } from '../cli-adapters/factory.js';
 import type { CliName, HealthStatus, CapacityStatus } from '../cli-adapters/types.js';
-import { DEFAULT_MODEL_CAPABILITIES } from '../config/model-capabilities.js';
+import { getInTreeCapabilitiesMatrix } from '../config/model-config-helpers.js';
 import { createServer } from '../mcp/server.js';
 import { printDoctorResults } from './doctor-formatting.js';
 import { probeCli } from './cli-auth-probe.js';
@@ -418,7 +418,8 @@ function checkMcpServerReady(): boolean {
 function buildRegistryAdvisory(cliResults: CliCheckResult[]): RegistryAdvisory {
   const installedClis = new Set(cliResults.filter((c) => c.installed).map((c) => c.name));
 
-  const models: ModelAdvisory[] = DEFAULT_MODEL_CAPABILITIES.models
+  const matrix = getInTreeCapabilitiesMatrix();
+  const models: ModelAdvisory[] = matrix.models
     .filter((m) => m.cliName !== undefined)
     .map((m) => {
       const cliName = m.cliName ?? '';
@@ -429,7 +430,7 @@ function buildRegistryAdvisory(cliResults: CliCheckResult[]): RegistryAdvisory {
 
   // Registry staleness check (#1549, threshold revised in #2445)
   const STALE_THRESHOLD_DAYS = 90;
-  const updatedAt = new Date(DEFAULT_MODEL_CAPABILITIES.updatedAt);
+  const updatedAt = new Date(matrix.updatedAt);
   const nowMs = getTimeProvider().now();
   const ageDays = Math.floor((nowMs - updatedAt.getTime()) / (1000 * 60 * 60 * 24));
 

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import { buildInTreeEntries } from './in-tree-entries.js';
-import { DEFAULT_MODEL_PER_CLI } from './model-capabilities.js';
+import { DEFAULT_MODEL_CAPABILITIES, DEFAULT_MODEL_PER_CLI } from './model-capabilities.js';
 import type {
   ModelId,
   ModelCapability,
@@ -347,6 +347,39 @@ export function buildModelInfo(
  * Build mock model info for each CLI (using default model per CLI).
  * Used by testing/adapters/mock-adapter-helpers.ts to replace MODEL_INFO_BY_NAME.
  */
+/**
+ * Project the registry's in-tree entries back to the legacy
+ * `ModelCapabilitiesMatrix` shape. Lets CLI commands and other
+ * consumers iterate in-tree models via the registry without
+ * importing `DEFAULT_MODEL_CAPABILITIES` directly (#2546 slice C1).
+ *
+ * Matrix-level metadata (`version`, `updatedAt`) is still read
+ * from `DEFAULT_MODEL_CAPABILITIES` because the registry doesn't
+ * carry it — slice E closes that gap when the legacy module is
+ * deleted entirely.
+ */
+export function getInTreeCapabilitiesMatrix(): {
+  readonly version: number;
+  readonly updatedAt: string;
+  readonly models: readonly ModelCapability[];
+} {
+  return {
+    version: DEFAULT_MODEL_CAPABILITIES.version,
+    updatedAt: DEFAULT_MODEL_CAPABILITIES.updatedAt,
+    models: buildInTreeEntries().map(entryToCapability),
+  };
+}
+
+/**
+ * Single-model lookup that mirrors `getModelCapabilities` but reads
+ * via the registry. Returns the legacy `ModelCapability` shape so
+ * call sites that haven't migrated to `ModelEntry` yet still work.
+ */
+export function lookupInTreeCapability(modelId: string): ModelCapability | undefined {
+  const entry = lookupInTree(modelId);
+  return entry !== undefined ? entryToCapability(entry) : undefined;
+}
+
 export function buildMockModelInfo(): Record<CliNameLiteral, ModelInfoShape> {
   const result = {} as Record<CliNameLiteral, ModelInfoShape>;
   const byId = inTreeById();


### PR DESCRIPTION
## Summary

Slice C1 of #2546 epic — CLI commands no longer import `DEFAULT_MODEL_CAPABILITIES` directly.

## Changes

- **New helper** `getInTreeCapabilitiesMatrix()` in `model-config-helpers.ts` — returns matrix-shaped data (`{ version, updatedAt, models }`) backed by the registry's in-tree entries.
- **New helper** `lookupInTreeCapability(modelId)` — single-model lookup that returns the legacy `ModelCapability` shape, registry-backed.
- **Migrated:**
  - `cli/capabilities-command.ts` — `DEFAULT_MODEL_CAPABILITIES.{models,version,updatedAt}` → `getInTreeCapabilitiesMatrix()`. `getModelCapabilities(id)` → `lookupInTreeCapability(id)`.
  - `cli/config-init.ts` — `.models` iteration via the new helper.
  - `cli/doctor.ts` — `.models` + `.updatedAt` via the new helper.
- `cli/demo-command.ts` was type-only (`DEFAULT_CLI`) — no change needed.

## What this PR does NOT change

- `findModelsByOutputModality`, `findModelsByInputModality`, etc. — still imported from `model-capabilities.ts`. These helpers are slice C3 / D scope.
- `ModelCapability` type usage — kept for backward compat with the still-imported find* helpers' return types.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/cli/ src/config/` — 4069/4069 pass
- [x] Full coverage suite green
- [x] CLI command output byte-identical (no behaviour change; same data, same shape)

Closes #2600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)