### PR TITLE
feat(adapters): migrate adapter cluster off DEFAULT_MODEL_CAPABILITIES (#2546 slice C2)

### DIFF
--- a/packages/nexus-agents/src/adapters/auto-adapter.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.ts
@@ -22,8 +22,7 @@ import type { CliName } from '../cli-adapters/types.js';
 import type { ICliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
 import { createCliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
 import { CUSTOM_API_DEFAULT_MODEL } from '../config/defaults.js';
-import { getCliModelName } from '../config/model-config-helpers.js';
-import { DEFAULT_MODEL_PER_CLI } from '../config/model-capabilities.js';
+import { getCliModelName, getDefaultModelForCli } from '../config/model-config-helpers.js';
 
 /**
  * Adapter selection priority.
@@ -157,9 +156,9 @@ function resolveApiKeyFromEnv(configKey: string | undefined, envVar: string): st
  */
 function tryApiAdapter(config: AutoAdapterConfig, logger: ILogger): AdapterSelection | null {
   // Derive default model IDs from canonical registry instead of hardcoding
-  const claudeModelId = getCliModelName(DEFAULT_MODEL_PER_CLI['claude']);
-  const codexModelId = getCliModelName(DEFAULT_MODEL_PER_CLI['codex']);
-  const geminiModelId = getCliModelName(DEFAULT_MODEL_PER_CLI['gemini']);
+  const claudeModelId = getCliModelName(getDefaultModelForCli('claude'));
+  const codexModelId = getCliModelName(getDefaultModelForCli('codex'));
+  const geminiModelId = getCliModelName(getDefaultModelForCli('gemini'));
 
   // 1. Anthropic — use native ClaudeAdapter (battle-tested)
   const anthropicKey = resolveApiKeyFromEnv(config.anthropicApiKey, 'ANTHROPIC_API_KEY');

--- a/packages/nexus-agents/src/adapters/unified-registry.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.ts
@@ -28,8 +28,12 @@ import {
 import type { CliName } from '../cli-adapters/types.js';
 import { TASK_SPECIALIZATION_MATRIX, detectTaskCategory } from '../config/task-specialization.js';
 import type { TaskCategory } from '../config/task-specialization-types.js';
-import { DEFAULT_MODEL_CAPABILITIES, DEFAULT_MODEL_PER_CLI } from '../config/model-capabilities.js';
+import {
+  getDefaultModelForCli,
+  getInTreeCapabilitiesMatrix,
+} from '../config/model-config-helpers.js';
 import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+import { CLI_NAMES } from '../config/model-capabilities-types.js';
 
 // ============================================================================
 // Types
@@ -116,7 +120,7 @@ export class UnifiedAdapterRegistry {
     this.taskRouting = this.buildTaskRouting();
     this.logger.info('UnifiedAdapterRegistry initialized', {
       categories: this.taskRouting.size,
-      models: DEFAULT_MODEL_CAPABILITIES.models.length,
+      models: getInTreeCapabilitiesMatrix().models.length,
       missingModelFallback: this.enableMissingModelFallback,
     });
   }
@@ -206,7 +210,8 @@ export class UnifiedAdapterRegistry {
     // both 'gemini-pro' and 'gemini-pro-experimental' resolves correctly even
     // though the registry's natural array order isn't sorted by id length.
     // Defense-in-depth — no current registry has prefix overlaps. (#2192)
-    const exact = DEFAULT_MODEL_CAPABILITIES.models.find(
+    const allModels = getInTreeCapabilitiesMatrix().models;
+    const exact = allModels.find(
       (m) =>
         m.id === modelPreference ||
         m.cliAlias === modelPreference ||
@@ -214,7 +219,7 @@ export class UnifiedAdapterRegistry {
     );
     const prefix =
       exact ??
-      [...DEFAULT_MODEL_CAPABILITIES.models]
+      [...allModels]
         .filter((m) => modelPreference.startsWith(m.id))
         .sort((a, b) => b.id.length - a.id.length)[0];
     const model = prefix;
@@ -263,7 +268,7 @@ export class UnifiedAdapterRegistry {
     return {
       taskRouting: [...this.taskRouting.values()],
       cachedAdapters: [...this.cliAdapters.keys()],
-      availableModels: DEFAULT_MODEL_CAPABILITIES.models.length,
+      availableModels: getInTreeCapabilitiesMatrix().models.length,
     };
   }
 
@@ -330,8 +335,8 @@ const ROLE_TO_CATEGORY: Record<string, TaskCategory> = {
 
 /** Resolve the default model name for a CLI from the canonical registry. */
 function resolveDefaultModel(cli: string): string {
-  if (cli in DEFAULT_MODEL_PER_CLI) {
-    return DEFAULT_MODEL_PER_CLI[cli as CliNameLiteral];
+  if ((CLI_NAMES as readonly string[]).includes(cli)) {
+    return getDefaultModelForCli(cli as CliNameLiteral);
   }
   return cli;
 }

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
@@ -17,11 +17,11 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { ClaudeResponseParser } from '../parsers/claude-parser.js';
-import { findModelsByCli } from '../../config/model-capabilities.js';
 import {
   getDefaultModelForCli,
   getCliModelName,
   buildModelInfo,
+  findInTreeByCli,
 } from '../../config/model-config-helpers.js';
 
 /**
@@ -34,7 +34,7 @@ const MODEL_TO_CLI_ALIAS: Record<string, string> = buildClaudeAliasMap();
 
 function buildClaudeAliasMap(): Record<string, string> {
   const map: Record<string, string> = {};
-  for (const model of findModelsByCli('claude')) {
+  for (const model of findInTreeByCli('claude')) {
     if (model.cliAlias === undefined) continue;
     const alias = model.cliAlias;
     map[alias] = alias;

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -43,15 +43,13 @@ import {
 import { GEMINI_LEGACY_DEFAULTS, createCircuitOpenError } from './gemini-adapter-helpers.js';
 import { executeCliRetryLoop } from '../cli-retry-loop.js';
 import {
-  DEFAULT_MODEL_PER_CLI,
-  DEFAULT_MODEL_CAPABILITIES,
-} from '../../config/model-capabilities.js';
-import { buildModelInfo } from '../../config/model-config-helpers.js';
+  buildModelInfo,
+  getCliModelName,
+  getDefaultModelForCli,
+} from '../../config/model-config-helpers.js';
 
 /** Derive the CLI model name for the default Gemini model from the canonical registry. */
-const DEFAULT_GEMINI_CLI_MODEL: string =
-  DEFAULT_MODEL_CAPABILITIES.models.find((m) => m.id === DEFAULT_MODEL_PER_CLI.gemini)
-    ?.cliModelName ?? DEFAULT_MODEL_PER_CLI.gemini;
+const DEFAULT_GEMINI_CLI_MODEL: string = getCliModelName(getDefaultModelForCli('gemini'));
 
 /** Configuration for Gemini adapter. Extends BaseAdapterOptions with retry/circuit breaker. */
 export interface GeminiConfig extends BaseAdapterOptions {

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
@@ -27,8 +27,8 @@ import {
   getDefaultModelForCli,
   getCliModelName,
   buildModelInfo,
+  findInTreeByCli,
 } from '../../config/model-config-helpers.js';
-import { findModelsByCli } from '../../config/model-capabilities.js';
 import { createLogger } from '../../core/index.js';
 
 const logger = createLogger({ component: 'opencode-adapter' });
@@ -45,7 +45,7 @@ const MODEL_TO_CLI_NAME: Record<string, string> = buildOpenCodeAliasMap();
 
 function buildOpenCodeAliasMap(): Record<string, string> {
   const map: Record<string, string> = {};
-  for (const model of findModelsByCli('opencode')) {
+  for (const model of findInTreeByCli('opencode')) {
     if (model.cliModelName === undefined) continue;
     // Map internal ID → CLI model name
     map[model.id] = model.cliModelName;

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -380,6 +380,18 @@ export function lookupInTreeCapability(modelId: string): ModelCapability | undef
   return entry !== undefined ? entryToCapability(entry) : undefined;
 }
 
+/**
+ * Registry-backed equivalent of `findModelsByCli(cli)`. Iterates
+ * the registry's in-tree entries and returns those whose `cliName`
+ * matches (#2546 slice C2). Used by adapters that previously
+ * imported `findModelsByCli` from `model-capabilities.ts`.
+ */
+export function findInTreeByCli(cliName: CliNameLiteral): ModelCapability[] {
+  return buildInTreeEntries()
+    .filter((e) => e.cliName === cliName)
+    .map(entryToCapability);
+}
+
 export function buildMockModelInfo(): Record<CliNameLiteral, ModelInfoShape> {
   const result = {} as Record<CliNameLiteral, ModelInfoShape>;
   const byId = inTreeById();


### PR DESCRIPTION
## Summary

Slice C2 of #2546 epic — adapter cluster (5 files) no longer imports `DEFAULT_MODEL_CAPABILITIES`, `findModelsByCli`, or `DEFAULT_MODEL_PER_CLI` from `model-capabilities.ts`.

## Files migrated

- `adapters/unified-registry.ts` — central adapter registry
- `adapters/auto-adapter.ts` — API-fallback selector
- `cli-adapters/adapters/claude-adapter.ts`
- `cli-adapters/adapters/gemini-adapter.ts`
- `cli-adapters/adapters/opencode-adapter.ts`

## New helper

- `findInTreeByCli(cliName)` in `model-config-helpers.ts` — registry-backed equivalent of `findModelsByCli`. Used by the adapter alias-map builders.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/adapters/ src/cli-adapters/adapters/` — 986/986 pass
- [x] Full coverage suite green
- [x] No behaviour change: alias-map builders see same model list; default-model resolver picks same id per CLI; adapter-by-preference selection uses same exact/prefix logic.

Closes #2601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)