### PR TITLE
feat(config): migrate remaining DEFAULT_MODEL_CAPABILITIES consumers (#2546 slice C4)

### DIFF
--- a/packages/nexus-agents/src/agents/coordination/capability-estimator.ts
+++ b/packages/nexus-agents/src/agents/coordination/capability-estimator.ts
@@ -11,7 +11,7 @@
 
 import type { ModelCapability, ScalingTaskType } from './scaling-types.js';
 import { clamp } from '../../utils/math-utils.js';
-import { DEFAULT_MODEL_CAPABILITIES } from '../../config/model-capabilities.js';
+import { getInTreeCapabilitiesMatrix } from '../../config/model-config-helpers.js';
 
 // =============================================================================
 // Capability Data — derived from canonical model registry
@@ -40,7 +40,7 @@ const PROVIDER_AVG_LATENCY: Record<string, number> = {
  */
 function deriveFromCanonical(): Record<string, BaseCapability> {
   const result: Record<string, BaseCapability> = {};
-  for (const m of DEFAULT_MODEL_CAPABILITIES.models) {
+  for (const m of getInTreeCapabilitiesMatrix().models) {
     const q = m.qualityScores;
     if (q === undefined) continue;
     const avgQuality = (q.reasoning + q.codeGeneration) / 2;

--- a/packages/nexus-agents/src/config/capability-discovery.ts
+++ b/packages/nexus-agents/src/config/capability-discovery.ts
@@ -25,7 +25,7 @@ import { z } from 'zod';
 
 import type { ILogger } from '../core/index.js';
 import { createLogger } from '../core/index.js';
-import { DEFAULT_MODEL_CAPABILITIES, getModelCapabilities } from './model-capabilities.js';
+import { getInTreeCapabilitiesMatrix } from './model-config-helpers.js';
 import type {
   ModelCapabilitiesMatrix,
   ModelCapability,
@@ -119,7 +119,7 @@ export interface ResolvedCapability {
 // ---------------------------------------------------------------------------
 
 export interface CapabilityDiscoveryConfig {
-  /** T1 canonical registry. Defaults to `DEFAULT_MODEL_CAPABILITIES`. */
+  /** T1 canonical registry. Defaults to the in-tree matrix from the ModelRegistry. */
   readonly canonical?: ModelCapabilitiesMatrix;
   /** T2 bundled generated registry. Pass `null` to force-skip T2. */
   readonly generated?: GeneratedRegistry | null;
@@ -140,7 +140,10 @@ export class CapabilityDiscovery {
   private readonly generatedById: Map<string, GeneratedModelEntry>;
 
   constructor(config: CapabilityDiscoveryConfig = {}) {
-    this.canonical = config.canonical ?? DEFAULT_MODEL_CAPABILITIES;
+    // The helper returns a readonly view; loosen here because
+    // `ModelCapabilitiesMatrix` predates the registry and uses mutable
+    // arrays. Callers in this class only read.
+    this.canonical = config.canonical ?? (getInTreeCapabilitiesMatrix() as ModelCapabilitiesMatrix);
     this.generated = config.generated ?? null;
     this.overlay = config.overlay ?? [];
     this.fallback = config.conservativeDefault ?? LEGACY_200K_DEFAULT;
@@ -192,7 +195,7 @@ export class CapabilityDiscovery {
   }
 
   private lookupCanonical(modelId: string): ModelCapability | undefined {
-    return getModelCapabilities(modelId, this.canonical);
+    return this.canonical.models.find((m) => m.id === modelId);
   }
 
   private lookupGenerated(modelId: string): GeneratedModelEntry | undefined {

--- a/packages/nexus-agents/src/core/trace-pricing.ts
+++ b/packages/nexus-agents/src/core/trace-pricing.ts
@@ -10,7 +10,7 @@
  * (Source: Issue #807, Issue #1149)
  */
 
-import { DEFAULT_MODEL_CAPABILITIES } from '../config/model-capabilities.js';
+import { getInTreeCapabilitiesMatrix } from '../config/model-config-helpers.js';
 
 // =============================================================================
 // Types
@@ -61,10 +61,11 @@ function isPrefixMatch(
  * Matches by: exact (id, cliModelName, cliAlias), then prefix match.
  */
 function lookupCanonicalPricing(model: string): ModelPricing | undefined {
-  for (const m of DEFAULT_MODEL_CAPABILITIES.models) {
+  const models = getInTreeCapabilitiesMatrix().models;
+  for (const m of models) {
     if (isExactMatch(m, model)) return toPricing(m.pricing);
   }
-  for (const m of DEFAULT_MODEL_CAPABILITIES.models) {
+  for (const m of models) {
     if (m.pricing !== undefined && isPrefixMatch(m, model)) return toPricing(m.pricing);
   }
   return undefined;

--- a/packages/nexus-agents/src/learning/usage-log.ts
+++ b/packages/nexus-agents/src/learning/usage-log.ts
@@ -23,7 +23,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from
 import { dirname, join } from 'node:path';
 
 import { getNexusDataDir } from '../config/nexus-data-dir.js';
-import { getModelCapabilities } from '../config/model-capabilities.js';
+import { lookupInTreeCapability } from '../config/model-config-helpers.js';
 
 export interface UsageEvent {
   /** ISO 8601 timestamp of the call. */
@@ -57,7 +57,7 @@ export interface UsageEvent {
  * `config/model-capabilities.ts` to add their pricing.
  */
 export function computeCostUSD(modelId: string, inputTokens: number, outputTokens: number): number {
-  const cap = getModelCapabilities(modelId);
+  const cap = lookupInTreeCapability(modelId);
   if (cap === undefined) return 0;
   const inputPer1M = cap.pricing?.inputPer1M ?? 0;
   const outputPer1M = cap.pricing?.outputPer1M ?? 0;


### PR DESCRIPTION
## Summary

Slice C4 of #2546 epic — the last 4 production files importing `DEFAULT_MODEL_CAPABILITIES` directly are now registry-backed.

## Files migrated

- `agents/coordination/capability-estimator.ts` — iterates the canonical model list to derive accuracy/cost/latency.
- `core/trace-pricing.ts` — pricing lookup for cost tracking.
- `config/capability-discovery.ts` — T1/T2/T3 tier resolver; default `canonical` matrix is now registry-backed.
- `learning/usage-log.ts` — `computeCostUSD()` via `lookupInTreeCapability()`.

## What's left for slices D and E

- After this lands, the only direct importers of `DEFAULT_MODEL_CAPABILITIES` are `model-capabilities.ts` itself and `model-config-helpers.ts` (the helper layer encapsulating it).
- Slice D (#2604): replace `MODEL_IDS` with a derived view.
- Slice E (#2605): delete `model-capabilities.ts` entirely.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/agents/coordination/ src/core/ src/config/ src/learning/` — 2438/2438 pass
- [x] Full coverage suite green

Closes #2603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)