### PR TITLE
test(config): model_ids invariant — registry parity test (#2546 slice D)

### DIFF
--- a/packages/nexus-agents/src/config/model-capabilities-types.ts
+++ b/packages/nexus-agents/src/config/model-capabilities-types.ts
@@ -85,6 +85,27 @@ export const DEFAULT_CLI: CliNameLiteral = 'claude';
 /** Default confidence score for routing when no task analysis is performed. */
 export const DEFAULT_ROUTING_CONFIDENCE = 0.85;
 
+/**
+ * Canonical model id enum used for narrow `ModelId` typing and as the
+ * argument to `z.enum(MODEL_IDS)` in `ModelCapabilitySchema`.
+ *
+ * This is a hand-maintained narrow tuple rather than a derived view
+ * from `ModelRegistry` because the literal-union type is load-bearing:
+ * — Zod schemas (`ModelCapabilitySchema.id`, `replacedBy`) need a
+ *   closed enum at compile time.
+ * — Many function signatures across `src/` accept `ModelId` and rely
+ *   on the narrowed type for exhaustiveness.
+ *
+ * The runtime invariant — `MODEL_IDS` matches the in-tree registry
+ * entries — is asserted by `model-ids-invariant.test.ts`. If you add
+ * or remove a model in `DEFAULT_MODEL_CAPABILITIES.models`, you must
+ * also update this list (and the test will tell you when they drift).
+ *
+ * Slice E of #2546 will collapse `model-capabilities.ts` itself; at
+ * that point `MODEL_IDS` either moves to `model-config-helpers.ts` or
+ * its consumers are loosened to `string`. This narrow type stays
+ * until then.
+ */
 export const MODEL_IDS = [
   'claude-opus',
   'claude-sonnet',

--- a/packages/nexus-agents/src/config/model-ids-invariant.test.ts
+++ b/packages/nexus-agents/src/config/model-ids-invariant.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Invariant test for the MODEL_IDS narrow-union enum (#2546 slice D).
+ *
+ * `MODEL_IDS` in `model-capabilities-types.ts` is a hand-maintained
+ * tuple that drives the `ModelId` literal-union type and the
+ * `z.enum(MODEL_IDS)` validation in `ModelCapabilitySchema`. This
+ * test asserts the tuple stays in sync with the registry's in-tree
+ * entries — if you add or remove an entry from
+ * `DEFAULT_MODEL_CAPABILITIES.models`, you must also update
+ * `MODEL_IDS` (and this test will fail until you do).
+ *
+ * The narrow type can't be auto-derived because TypeScript needs a
+ * compile-time literal-tuple for `as const`; deriving from a runtime
+ * `.map(e => e.id)` widens to `string[]`. Slice E (#2605) revisits
+ * this when `model-capabilities.ts` is deleted.
+ *
+ * @module config/model-ids-invariant.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildInTreeEntries } from './in-tree-entries.js';
+import { MODEL_IDS } from './model-capabilities-types.js';
+
+describe('MODEL_IDS invariant (#2546 slice D)', () => {
+  it('matches the set of in-tree registry entry ids exactly', () => {
+    const registryIds = new Set(buildInTreeEntries().map((e) => e.id));
+    const enumIds = new Set<string>(MODEL_IDS);
+
+    const inRegistryNotEnum = [...registryIds].filter((id) => !enumIds.has(id));
+    const inEnumNotRegistry = [...enumIds].filter((id) => !registryIds.has(id));
+
+    expect(
+      inRegistryNotEnum,
+      'Registry has model ids missing from MODEL_IDS — add them to model-capabilities-types.ts'
+    ).toEqual([]);
+    expect(
+      inEnumNotRegistry,
+      'MODEL_IDS has ids missing from the registry — remove them or add matching entries'
+    ).toEqual([]);
+  });
+
+  it('enum length matches registry entry count', () => {
+    expect(MODEL_IDS.length).toBe(buildInTreeEntries().length);
+  });
+});


### PR DESCRIPTION
## Summary

Slice D of #2546 epic.

The epic spec asked for `MODEL_IDS` to become a "derived view over `registry.allEntries()`". On investigation that turned out to be unreachable while the narrow type is load-bearing:

- `MODEL_IDS` drives the `ModelId = (typeof MODEL_IDS)[number]` literal-union type.
- `ModelCapabilitySchema.id` is `z.enum(MODEL_IDS)`; ditto `replacedBy`.
- Many function signatures across `src/` rely on the narrowed `ModelId` for exhaustiveness.

A runtime-derived `MODEL_IDS = buildInTreeEntries().map((e) => e.id)` would widen to `string[]` and break all of the above.

## What this slice does instead

- Adds `model-ids-invariant.test.ts` — asserts the tuple matches the registry's in-tree entry ids exactly, with directional diagnostics so adding or removing a model in `DEFAULT_MODEL_CAPABILITIES.models` without updating `MODEL_IDS` (or vice versa) fails with a clear message.
- Updates the doc-comment on `MODEL_IDS` to document the constraint and point at the test + at slice E (#2605) for the eventual deletion path.

When slice E lands and `model-capabilities.ts` is deleted, the same question gets revisited: either move `MODEL_IDS` to `model-config-helpers.ts` (with the same invariant test) or loosen `ModelId` to `string` and replace `z.enum(MODEL_IDS)` with `z.string()` everywhere.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] New invariant test passes (2/2)

Closes #2604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)