### PR TITLE
docs: update stale model-capabilities.ts references after #2546 slice E

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,18 +87,18 @@ Full tool reference: [docs/ENTRYPOINTS.md](./docs/ENTRYPOINTS.md).
 
 Do not create parallel implementations — modify existing files at these canonical locations. Never create `enhanced_*`, `new_*`, `v2_*`, or `refactor_*` forks; migrate logic to the canonical location and remove the deprecated file.
 
-| Concern           | Canonical path                                                          |
-| ----------------- | ----------------------------------------------------------------------- |
-| Task analysis     | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts` |
-| Task routing      | `CompositeRouter` — `src/cli-adapters/composite-router.ts`              |
-| Consensus voting  | `ConsensusEngine` — `src/consensus/engine.ts`                           |
-| CLI adapters      | `createAllAdapters()` — `src/cli-adapters/factory.ts`                   |
-| MCP tools         | `registerTools()` — `src/mcp/tools/index.ts`                            |
-| Model registry    | `DEFAULT_MODEL_CAPABILITIES` — `src/config/model-capabilities.ts`       |
-| Adapter registry  | `UnifiedAdapterRegistry` — `src/adapters/unified-registry.ts`           |
-| Graph workflows   | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`             |
-| Pipeline runner   | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                    |
-| Security pipeline | `src/security/index.ts`                                                 |
+| Concern           | Canonical path                                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| Task analysis     | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts`                                        |
+| Task routing      | `CompositeRouter` — `src/cli-adapters/composite-router.ts`                                                     |
+| Consensus voting  | `ConsensusEngine` — `src/consensus/engine.ts`                                                                  |
+| CLI adapters      | `createAllAdapters()` — `src/cli-adapters/factory.ts`                                                          |
+| MCP tools         | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
+| Model registry    | `ModelRegistry` + `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`) |
+| Adapter registry  | `UnifiedAdapterRegistry` — `src/adapters/unified-registry.ts`                                                  |
+| Graph workflows   | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
+| Pipeline runner   | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
+| Security pipeline | `src/security/index.ts`                                                                                        |
 
 All task routing goes through: `Task → BudgetRouter → ZeroRouter → PreferenceRouter → TopsisRouter → LinUCB → Selected Model`. Do NOT directly instantiate stage routers — use `CompositeRouter.route(task)`.
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -69,7 +69,7 @@ Single source of truth for all model metadata and application configuration.
 
 **Key components:**
 
-- **Model Registry** (`config/model-capabilities.ts`, Issue #683): `DEFAULT_MODEL_CAPABILITIES` — pricing, quality scores, context windows, max output, CLI aliases for all supported models.
+- **Model Registry** (`config/model-registry.ts` + `config/in-tree-data.ts`, Issues #683 / #2540 / #2546): `ModelRegistry` class + `DEFAULT_MODEL_CAPABILITIES` data — pricing, quality scores, context windows, max output, CLI aliases for all supported models.
 - **Model Helpers** (`config/model-config-helpers.ts`, Issue #807): Derived helpers — `getModelPricing()`, `buildModelInfo()`, `findCanonicalModel()`, `resolveCliAlias()`, `buildTopsisProfiles()`
 - **App Config** (`config/schemas.ts`): Zod-validated `AppConfigSchema` — logging, security, observability, gateway
 - **Defaults** (`config/defaults.ts`): `DEFAULTS` object — centralized timeout, rate-limit, retry, circuit-breaker defaults

--- a/docs/design/interfaces.md
+++ b/docs/design/interfaces.md
@@ -213,7 +213,7 @@ enum RequestTier {
 
 ### 9. Model Registry Interface
 
-**Source:** `src/config/model-capabilities.ts`
+**Source:** `src/config/model-registry.ts` (registry class) + `src/config/in-tree-data.ts` (matrix data)
 
 ```typescript
 interface ModelCapability {

--- a/docs/guides/CUSTOM_ENDPOINT_SETUP.md
+++ b/docs/guides/CUSTOM_ENDPOINT_SETUP.md
@@ -118,7 +118,7 @@ nexus-agents includes two pre-configured model profiles for custom endpoints:
 | `opencode-custom-opus`   | `custom/claude-opus-4-5`   | reasoning: 10, code: 9, speed: 5 |
 | `opencode-custom-sonnet` | `custom/claude-sonnet-4-5` | reasoning: 9, code: 9, speed: 7  |
 
-These are registered in `config/model-capabilities.ts` with `provider: 'custom-openai'` and `cliName: 'opencode'`.
+These are registered in `config/in-tree-data.ts` with `provider: 'custom-openai'` and `cliName: 'opencode'`.
 
 ## Step 4: Routing
 
@@ -166,7 +166,7 @@ If your gateway uses different model identifiers, two changes are needed:
 }
 ```
 
-**2. nexus-agents registry** (`config/model-capabilities.ts`) — `cliModelName` must match `<provider>/<model-key>`:
+**2. nexus-agents registry** (`config/in-tree-data.ts`) — `cliModelName` must match `<provider>/<model-key>`:
 
 ```typescript
 {
@@ -304,7 +304,7 @@ The `Dockerfile.sandbox` extends `docker/sandbox-templates:opencode` with nexus-
 
 **Model not selected by router**: Custom models default to `cliName: 'opencode'`. If OpenCode is unavailable, the router skips opencode models entirely. Check `nexus-agents doctor` for adapter status.
 
-**Wrong model used**: Verify `cliModelName` in `model-capabilities.ts` matches the provider ID in `opencode.json`. The format is `<provider-id>/<model-id>`.
+**Wrong model used**: Verify `cliModelName` in `in-tree-data.ts` matches the provider ID in `opencode.json`. The format is `<provider-id>/<model-id>`.
 
 ## Related
 

--- a/docs/research/topics/cli-tools/README.md
+++ b/docs/research/topics/cli-tools/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Research on integrating external CLI tools (Claude CLI, Gemini CLI, Codex CLI, OpenCode) plus OpenRouter-backed free models with nexus-agents for multi-model orchestration. Covers authentication patterns, capability profiles, and MCP integration. The live, canonical model registry (pricing, quality, context windows) lives in [`packages/nexus-agents/src/config/model-capabilities.ts`](../../../../packages/nexus-agents/src/config/model-capabilities.ts) — prefer it over this summary when they disagree.
+Research on integrating external CLI tools (Claude CLI, Gemini CLI, Codex CLI, OpenCode) plus OpenRouter-backed free models with nexus-agents for multi-model orchestration. Covers authentication patterns, capability profiles, and MCP integration. The live, canonical model registry (pricing, quality, context windows) lives in [`packages/nexus-agents/src/config/in-tree-data.ts`](../../../../packages/nexus-agents/src/config/in-tree-data.ts) — prefer it over this summary when they disagree.
 
 ## CLI Comparison
 

--- a/docs/v2/01-as-is-architecture.md
+++ b/docs/v2/01-as-is-architecture.md
@@ -126,7 +126,7 @@ There is no single type that a task "is" throughout its lifecycle.
 ## What Works Well
 
 1. **MCP tool dispatch** — 21 tools, Zod-validated, timeout-wrapped, consistently registered.
-2. **Model registry** — Single source of truth (`model-capabilities.ts`). All adapters derive from it.
+2. **Model registry** — Single source of truth (`model-registry.ts` + `in-tree-data.ts`). All adapters derive from it.
 3. **Graph execution** — Compile step (cycle detection, reachability), BSP super-steps, state reducers, checkpointing, bounded iteration (maxSteps=100, timeout=120s), conditional edges.
 4. **Security pipeline** — 8 modules fully wired, firewall composition, ATL labels.
 5. **Consensus voting** — Real multi-CLI votes, round-robin diversity, 6 strategies.

--- a/packages/nexus-agents/src/cli/config-init.ts
+++ b/packages/nexus-agents/src/cli/config-init.ts
@@ -142,7 +142,7 @@ function renderConfigTemplate(): string {
 # Documentation: https://github.com/williamzujkowski/nexus-agents
 #
 # Model identifiers below are derived from the canonical registry at
-# config/model-capabilities.ts. Update there to change defaults; this
+# config/in-tree-data.ts. Update there to change defaults; this
 # template is regenerated each time config init runs.
 
 # Model configuration

--- a/packages/nexus-agents/src/config/model-ids-invariant.test.ts
+++ b/packages/nexus-agents/src/config/model-ids-invariant.test.ts
@@ -11,8 +11,9 @@
  *
  * The narrow type can't be auto-derived because TypeScript needs a
  * compile-time literal-tuple for `as const`; deriving from a runtime
- * `.map(e => e.id)` widens to `string[]`. Slice E (#2605) revisits
- * this when `model-capabilities.ts` is deleted.
+ * `.map(e => e.id)` widens to `string[]`. Slice E (#2605) deleted
+ * `model-capabilities.ts` and renamed the data to `in-tree-data.ts`,
+ * but the narrow-type constraint is unchanged.
  *
  * @module config/model-ids-invariant.test
  */


### PR DESCRIPTION
## Summary

Mechanical cleanup of 8 files with stale references to \`model-capabilities.ts\`, which was renamed to \`in-tree-data.ts\` in PR #2613 (#2546 slice E). These references weren't caught by CI because they're prose / docstrings, not imports.

## Files touched

- \`packages/nexus-agents/src/cli/config-init.ts\` — user-visible config template comment
- \`packages/nexus-agents/src/config/model-ids-invariant.test.ts\` — past-tense the now-completed comment
- \`AGENTS.md\` — Canonical Paths row brought into parity with CLAUDE.md
- \`docs/guides/CUSTOM_ENDPOINT_SETUP.md\` — 3 stale instructions for users adding custom endpoints
- \`docs/design/components.md\` — component inventory entry
- \`docs/design/interfaces.md\` — source citation for the model-registry interface section
- \`docs/research/topics/cli-tools/README.md\` — broken markdown link
- \`docs/v2/01-as-is-architecture.md\` — archived doc, refreshed for consistency

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] Targeted tests pass (model-ids-invariant, config-init)
- [x] No remaining production references to \`model-capabilities.ts\` (only historical changelog mentions left)

Closes #2614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)