### PR TITLE
docs: remove Devin/Factory adapter claim + refresh ENTRYPOINTS coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ related_files: [CODING_STANDARDS.md, docs/ENTRYPOINTS.md]
 
 # Nexus Agents - Claude Code Instructions
 
-**Project:** Governance substrate for AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry. The agents (Claude/Codex/Gemini/OpenCode, plus Devin/Factory adapters) do the engineering; nexus-agents enforces the rules they have to follow, reviews their work adversarially, and audits everything they touch.
+**Project:** Governance substrate for AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry. The agents (Claude/Codex/Gemini/OpenCode) do the engineering; nexus-agents enforces the rules they have to follow, reviews their work adversarially, and audits everything they touch.
 **Repository:** github.com/williamzujkowski/nexus-agents
 **Owner:** @williamzujkowski
 

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -7,7 +7,7 @@ keywords: [entrypoints, cli, mcp, api, tools, commands, reference]
 
 # Nexus-Agents Entrypoints
 
-**Last Updated:** 2026-03-01 (ET)
+**Last Updated:** 2026-05-12 (ET)
 **Canonical Source:** This document is the single source of truth for all entrypoints.
 **Issue:** #210 (Epic #209)
 
@@ -302,42 +302,46 @@ nexus-agents hooks stop --check-tasks
 **Protocol:** Model Context Protocol (2025-11-25)
 **Transport:** JSON-RPC 2.0 over stdio
 
-| Tool                          | Description                                                        | Auth         | Rate Limit    |
-| ----------------------------- | ------------------------------------------------------------------ | ------------ | ------------- |
-| `orchestrate`                 | Task orchestration with Orchestrator coordination                  | None (local) | Shared bucket |
-| `create_expert`               | Dynamic expert agent creation                                      | None (local) | Shared bucket |
-| `execute_expert`              | Execute a task using a created expert agent                        | None (local) | Shared bucket |
-| `run_workflow`                | Execute workflow template                                          | None (local) | Shared bucket |
-| `delegate_to_model`           | Route task to optimal model                                        | None (local) | Shared bucket |
-| `consensus_vote`              | Multi-model consensus voting on proposals                          | None (local) | Shared bucket |
-| `list_experts`                | List available expert types for discoverability                    | None (local) | Shared bucket |
-| `list_workflows`              | List available workflow templates                                  | None (local) | Shared bucket |
-| `research_query`              | Query research registry (status, overlap, stats, search)           | None (local) | Shared bucket |
-| `research_add`                | Add paper to registry by arXiv ID                                  | None (local) | Shared bucket |
-| `research_discover`           | Discover papers/repos from external sources                        | None (local) | Shared bucket |
-| `research_analyze`            | Analyze registry for gaps, trends, coverage                        | None (local) | Shared bucket |
-| `research_add_source`         | Add non-paper source (repo, tool, blog) with quality scoring       | None (local) | Shared bucket |
-| `research_catalog_review`     | Review auto-cataloged research references                          | None (local) | Shared bucket |
-| `research_synthesize`         | Synthesize registry into quality-aware topic clusters              | None (local) | Shared bucket |
-| `memory_query`                | Query across all memory backends with unified results              | None (local) | Shared bucket |
-| `memory_stats`                | Memory system statistics dashboard                                 | None (local) | Shared bucket |
-| `issue_triage`                | Triage GitHub issue using full security pipeline                   | None (local) | Shared bucket |
-| `run_graph_workflow`          | Execute predefined graph workflow with checkpointing               | None (local) | Shared bucket |
-| `weather_report`              | Multi-CLI performance weather report                               | None (local) | Shared bucket |
-| `execute_spec`                | Execute AI software factory spec pipeline                          | None (local) | Shared bucket |
-| `memory_write`                | Write a memory entry to a specific backend                         | None (local) | Shared bucket |
-| `registry_import`             | Generate draft model registry entry                                | None (local) | Shared bucket |
-| `query_trace`                 | Query execution traces by run ID                                   | None (local) | Shared bucket |
-| `query_task_state`            | Query structured task-state log (incl. Magentic-One ledgers)       | None (local) | Shared bucket |
-| `verify_audit_chain`          | Verify hash chain of a FileAuditStorage audit log directory        | None (local) | Shared bucket |
-| `run_pipeline`                | Run a typed pipeline by name with provided inputs                  | None (local) | Shared bucket |
-| `repo_analyze`                | Analyze GitHub repository structure                                | None (local) | Shared bucket |
-| `repo_security_plan`          | Generate security scanning pipeline for a repository               | None (local) | Shared bucket |
-| `extract_symbols`             | Extract code symbols (functions, classes, types) from source files | None (local) | Shared bucket |
-| `search_codebase`             | Search codebase for code patterns, symbols, or text                | None (local) | Shared bucket |
-| `run_dev_pipeline`            | Multi-agent dev pipeline: research→plan→vote→implement→QA→security | Optional     | Shared bucket |
-| `pr_review`                   | Multi-voter PR review with verification gate (experimental)        | None (local) | Shared bucket |
-| `supply_chain_tradeoff_panel` | Per-axis tradeoff vote for build-vs-buy / supply-chain decisions   | None (local) | Shared bucket |
+| Tool                          | Description                                                                                                    | Auth         | Rate Limit    |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------ | ------------- |
+| `orchestrate`                 | Task orchestration with Orchestrator coordination                                                              | None (local) | Shared bucket |
+| `create_expert`               | Dynamic expert agent creation                                                                                  | None (local) | Shared bucket |
+| `execute_expert`              | Execute a task using a created expert agent                                                                    | None (local) | Shared bucket |
+| `run_workflow`                | Execute workflow template                                                                                      | None (local) | Shared bucket |
+| `delegate_to_model`           | Route task to optimal model                                                                                    | None (local) | Shared bucket |
+| `consensus_vote`              | Multi-model consensus voting on proposals                                                                      | None (local) | Shared bucket |
+| `list_experts`                | List available expert types for discoverability                                                                | None (local) | Shared bucket |
+| `list_workflows`              | List available workflow templates                                                                              | None (local) | Shared bucket |
+| `research_query`              | Query research registry (status, overlap, stats, search)                                                       | None (local) | Shared bucket |
+| `research_add`                | Add paper to registry by arXiv ID                                                                              | None (local) | Shared bucket |
+| `research_discover`           | Discover papers/repos from external sources                                                                    | None (local) | Shared bucket |
+| `research_analyze`            | Analyze registry for gaps, trends, coverage                                                                    | None (local) | Shared bucket |
+| `research_add_source`         | Add non-paper source (repo, tool, blog) with quality scoring                                                   | None (local) | Shared bucket |
+| `research_catalog_review`     | Review auto-cataloged research references                                                                      | None (local) | Shared bucket |
+| `research_synthesize`         | Synthesize registry into quality-aware topic clusters                                                          | None (local) | Shared bucket |
+| `memory_query`                | Query across all memory backends with unified results                                                          | None (local) | Shared bucket |
+| `memory_stats`                | Memory system statistics dashboard                                                                             | None (local) | Shared bucket |
+| `issue_triage`                | Triage GitHub issue using full security pipeline                                                               | None (local) | Shared bucket |
+| `run_graph_workflow`          | Execute predefined graph workflow with checkpointing                                                           | None (local) | Shared bucket |
+| `weather_report`              | Multi-CLI performance weather report                                                                           | None (local) | Shared bucket |
+| `execute_spec`                | Execute AI software factory spec pipeline                                                                      | None (local) | Shared bucket |
+| `memory_write`                | Write a memory entry to a specific backend                                                                     | None (local) | Shared bucket |
+| `registry_import`             | Generate draft model registry entry                                                                            | None (local) | Shared bucket |
+| `query_trace`                 | Query execution traces by run ID                                                                               | None (local) | Shared bucket |
+| `query_task_state`            | Query structured task-state log (incl. Magentic-One ledgers)                                                   | None (local) | Shared bucket |
+| `verify_audit_chain`          | Verify hash chain of a FileAuditStorage audit log directory                                                    | None (local) | Shared bucket |
+| `run_pipeline`                | Run a typed pipeline by name with provided inputs                                                              | None (local) | Shared bucket |
+| `repo_analyze`                | Analyze GitHub repository structure                                                                            | None (local) | Shared bucket |
+| `repo_security_plan`          | Generate security scanning pipeline for a repository                                                           | None (local) | Shared bucket |
+| `extract_symbols`             | Extract code symbols (functions, classes, types) from source files                                             | None (local) | Shared bucket |
+| `search_codebase`             | Search codebase for code patterns, symbols, or text                                                            | None (local) | Shared bucket |
+| `run_dev_pipeline`            | Multi-agent dev pipeline: research→plan→vote→implement→QA→security                                             | Optional     | Shared bucket |
+| `pr_review`                   | Multi-voter PR review with verification gate (experimental)                                                    | None (local) | Shared bucket |
+| `supply_chain_tradeoff_panel` | Per-axis tradeoff vote for build-vs-buy / supply-chain decisions                                               | None (local) | Shared bucket |
+| `compare_data_feeds`          | Diff two YAML/JSON feeds: coverage + per-field axes                                                            | None (local) | Shared bucket |
+| `survey_oss_landscape`        | Transient OSS project search (license, stars, last-commit) via GitHub                                          | None (local) | Shared bucket |
+| `vendor_publishing_audit`     | Look up a vendor's signing infrastructure (GPG keys, URL patterns)                                             | None (local) | Shared bucket |
+| `improvement_review`          | Threshold-gated observability loop — surfaces routing/tech-debt/bug/security signals from outcome+fitness data | None (local) | Shared bucket |
 
 **Rate limiting:** All tools share a single token bucket rate limiter (capacity: 100 tokens, refill: 10 tokens/sec). Each tool call consumes one token.
 


### PR DESCRIPTION
## Summary

Two prose-level corrections + a doc refresh.

### CLAUDE.md
Removed misleading reference to non-existent "Devin/Factory adapters". Per the prior deprioritization note in memory (#2282 + #2283 both closed 2026-05-04, no subscriptions planned), no Devin/Factory integration exists or is planned. The prose now lists only the actually-implemented adapters: Claude / Codex / Gemini / OpenCode.

AGENTS.md was already clean — only CLAUDE.md had the stale claim.

### ENTRYPOINTS.md
Was 72 days stale (\`Last Updated: 2026-03-01\`). The short MCP-tools table was missing 4 tools that exist in \`REGISTERED_TOOL_NAMES\`:
- \`compare_data_feeds\`
- \`survey_oss_landscape\`
- \`vendor_publishing_audit\`
- \`improvement_review\`

Added short-table rows for all 4 and refreshed the timestamp.

The deeper \"Tool Schemas\" section (input/output Zod shapes, examples) still doesn't have entries for those 4 tools — that's a heavier sync filed separately as #2620.

## Test plan

- [x] No new tool-count drift introduced
- [x] Short MCP tools table now mirrors source-of-truth \`REGISTERED_TOOL_NAMES\`
- [x] No \"Devin\" or \"Factory\" mentions in CLAUDE.md / AGENTS.md

Closes #2616. Spawns #2620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)