### PR TITLE
fix(mcp): surface orchestrate worker-dispatch failure status (#2619 bug 1)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/orchestrate-dispatch-status.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-dispatch-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `assembleOrchestrateOutput` worker-dispatch status (#2619 bug 1).
+ *
+ * The orchestrate tool used to return `isError: false` with an empty
+ * `output` when every dispatched worker timed out. Callers that only
+ * checked the outer status silently got nothing back. These tests pin
+ * the four cases the fix has to cover: no dispatch ran; all workers
+ * succeeded; some succeeded; none succeeded.
+ *
+ * @module mcp/tools/orchestrate-dispatch-status.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { WorkerDispatchResult } from './orchestrate-dispatch.js';
+import { assembleOrchestrateOutput } from './orchestrate.js';
+
+// Minimal valid orchestration result; the assembler just spreads it.
+const ORCHESTRATION_RESULT = {
+  taskId: 'orch-test',
+  analysis: {
+    taskId: 'orch-test',
+    complexity: 5,
+    taskType: 'implementation',
+    requirements: [],
+    risks: [],
+    needsDecomposition: true,
+    approach: 'multi-worker',
+    estimatedEffort: 5,
+  },
+  result: { stub: true },
+  stepsCompleted: 3,
+  metadata: { durationMs: 1000, tokensUsed: 500, expertsUsed: [] },
+};
+
+function makeDispatch(successCount: number, errorCount: number): WorkerDispatchResult {
+  const total = successCount + errorCount;
+  const results: WorkerDispatchResult['results'] = Array.from({ length: total }, (_, i) =>
+    i < successCount
+      ? {
+          role: 'code',
+          subTask: `sub-${String(i)}`,
+          output: 'ok',
+          status: 'success' as const,
+          durationMs: 10,
+        }
+      : {
+          role: 'code',
+          subTask: `sub-${String(i)}`,
+          output: '',
+          status: 'error' as const,
+          durationMs: 60010,
+          error: 'MCP error -32001: Request timed out',
+          errorType: 'timeout' as const,
+        }
+  );
+  return {
+    results,
+    totalWorkers: total,
+    successCount,
+    errorCount,
+    durationMs: 60010,
+    conflicts: [],
+    totalModelCalls: total,
+  };
+}
+
+function parseBody(text: string): Record<string, unknown> {
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('assembleOrchestrateOutput worker-dispatch status (#2619 bug 1)', () => {
+  it('omits workerDispatchStatus when no workers were dispatched', () => {
+    const result = assembleOrchestrateOutput(ORCHESTRATION_RESULT, undefined, undefined);
+    expect(result.isError).toBeFalsy();
+    const body = parseBody((result.content[0] as { text: string }).text);
+    expect(body['workerDispatchStatus']).toBeUndefined();
+  });
+
+  it('omits workerDispatchStatus when totalWorkers is 0 (dispatch ran but no plan)', () => {
+    const dispatch = makeDispatch(0, 0);
+    const result = assembleOrchestrateOutput(ORCHESTRATION_RESULT, undefined, dispatch);
+    const body = parseBody((result.content[0] as { text: string }).text);
+    expect(body['workerDispatchStatus']).toBeUndefined();
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('reports workerDispatchStatus=success and isError=false when all workers succeed', () => {
+    const dispatch = makeDispatch(3, 0);
+    const result = assembleOrchestrateOutput(ORCHESTRATION_RESULT, undefined, dispatch);
+    const body = parseBody((result.content[0] as { text: string }).text);
+    expect(body['workerDispatchStatus']).toBe('success');
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('reports workerDispatchStatus=partial and isError=false when some workers fail', () => {
+    const dispatch = makeDispatch(1, 2);
+    const result = assembleOrchestrateOutput(ORCHESTRATION_RESULT, undefined, dispatch);
+    const body = parseBody((result.content[0] as { text: string }).text);
+    expect(body['workerDispatchStatus']).toBe('partial');
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('reports workerDispatchStatus=failed and isError=true when all workers fail', () => {
+    // This is the #2619 reporter's exact scenario: two workers both time
+    // out at ~60010ms with MCP error -32001. Before the fix the tool
+    // returned isError:false with an empty output; after the fix it
+    // flips to isError:true with the structured worker errors still in
+    // the body for the caller to inspect.
+    const dispatch = makeDispatch(0, 2);
+    const result = assembleOrchestrateOutput(ORCHESTRATION_RESULT, undefined, dispatch);
+    const body = parseBody((result.content[0] as { text: string }).text);
+    expect(body['workerDispatchStatus']).toBe('failed');
+    expect(result.isError).toBe(true);
+    // The structured worker results are still there for inspection.
+    const dispatchInBody = body['workerDispatch'] as { results: unknown[]; successCount: number };
+    expect(dispatchInBody.successCount).toBe(0);
+    expect(dispatchInBody.results).toHaveLength(2);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -74,6 +74,16 @@ export const OrchestrateOutputSchema = z.object({
      */
     timeoutReason: z.string().optional(),
   }),
+  /**
+   * Aggregate status of worker dispatch when subtasks were dispatched
+   * (#2619 bug 1). `success` = all workers returned; `partial` = some
+   * workers errored or timed out; `failed` = every dispatched worker
+   * errored. Absent when worker dispatch did not run (no decomposition
+   * or feature disabled). When `failed`, the tool result is also
+   * surfaced as an MCP error (`isError: true`) so callers that only
+   * check the outer status see the failure.
+   */
+  workerDispatchStatus: z.enum(['success', 'partial', 'failed']).optional(),
 });
 
 export type OrchestrateOutput = z.infer<typeof OrchestrateOutputSchema>;

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -812,22 +812,53 @@ async function tryWorkerDispatch(
   }
 }
 
-/** Assemble final orchestrate tool output (Issue #1310). */
-function assembleOrchestrateOutput(
+/**
+ * Compute aggregate worker-dispatch status (#2619 bug 1). Returns
+ * undefined when dispatch did not run (no decomposition / feature
+ * disabled / zero workers planned) so the field is omitted from the
+ * output. `failed` = every dispatched worker errored — caller needs to
+ * see this distinctly from a normal `successCount > 0` partial run.
+ */
+function computeWorkerDispatchStatus(
+  dispatch: { totalWorkers: number; successCount: number } | undefined
+): 'success' | 'partial' | 'failed' | undefined {
+  if (dispatch === undefined || dispatch.totalWorkers === 0) return undefined;
+  if (dispatch.successCount === 0) return 'failed';
+  if (dispatch.successCount === dispatch.totalWorkers) return 'success';
+  return 'partial';
+}
+
+/**
+ * Assemble final orchestrate tool output (Issue #1310).
+ *
+ * When every dispatched worker errored (`workerDispatchStatus === 'failed'`,
+ * see #2619 bug 1) the structured payload is returned via `toolError` so
+ * the MCP-layer `isError` flag flips true. The full JSON (including
+ * `workerDispatch.results[].errorMessage`) remains in the body so callers
+ * can inspect per-worker reasons; the only change is that callers that
+ * only check the outer status no longer silently get an empty success.
+ *
+ * Exported for unit testing only — downstream code should not call this
+ * helper directly.
+ */
+export function assembleOrchestrateOutput(
   orchestrationResult: Record<string, unknown>,
   agentPlan: ReturnType<typeof computeAgentPlan>,
   workerDispatchResult: Awaited<ReturnType<typeof executeWorkerDispatch>> | undefined
 ): ToolResult {
   const hasSynthesis =
     workerDispatchResult?.synthesis !== undefined && workerDispatchResult.synthesis !== '';
+  const workerDispatchStatus = computeWorkerDispatchStatus(workerDispatchResult);
 
   const output = {
     ...orchestrationResult,
     ...(agentPlan !== undefined ? { agentPlan } : {}),
     ...(workerDispatchResult !== undefined ? { workerDispatch: workerDispatchResult } : {}),
     ...(hasSynthesis ? { synthesizedResponse: workerDispatchResult.synthesis } : {}),
+    ...(workerDispatchStatus !== undefined ? { workerDispatchStatus } : {}),
   };
-  return toolSuccess(JSON.stringify(output, null, 2));
+  const body = JSON.stringify(output, null, 2);
+  return workerDispatchStatus === 'failed' ? toolError(body) : toolSuccess(body);
 }
 
 /** Record worker outcomes + fire-and-forget reflection (Issue #1323, #1392). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1600,8 +1600,8 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
@@ -1612,8 +1612,8 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -1621,8 +1621,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -4536,8 +4536,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -6566,7 +6566,7 @@ snapshots:
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       ws: 8.20.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
@@ -6923,24 +6923,24 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.1': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -7559,7 +7559,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -10234,18 +10234,18 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/codegen': 2.0.5
       '@protobufjs/eventemitter': 1.1.0
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 25.6.0
       long: 5.3.2
 


### PR DESCRIPTION
Closes part of #2619 (bug 1).

## Summary

When every dispatched worker errored or timed out, the `orchestrate` tool used to return `isError: false` with an empty `output`. The reporter on #2619 hit this with two workers both timing out at exactly 60010ms (`MCP error -32001`) — `successCount` was 0 but the outer MCP status was `success`, so a caller that only checked the outer status silently got nothing back.

## The fix

- New optional `workerDispatchStatus: 'success' | 'partial' | 'failed'` field on `OrchestrateOutputSchema`. Absent when worker dispatch did not run (no decomposition / feature disabled / zero workers planned).
- `assembleOrchestrateOutput` computes the status from `WorkerDispatchResult.{totalWorkers, successCount}`:
  - All succeeded → `success`
  - Some succeeded → `partial`
  - **All errored → `failed`**
- When `workerDispatchStatus === 'failed'`, the tool result is returned via `toolError` so `isError: true` flips on. The full structured JSON (including each worker's `errorMessage`) remains in `content[0].text` so callers can inspect per-worker reasons.

This is additive — old callers reading `output.metadata` etc. keep working. New callers can branch on either the outer `isError` or the inner `workerDispatchStatus`.

## Scope of bug 2 (consensus_vote) — deferred

The reporter's second issue — `consensus_vote` absorbing timed-out voters into the `abstain` bucket and distorting supermajority/unanimous thresholds — needs strategy-level design decisions (do error votes reduce the denominator like "votes not cast", or do they stay as abstains?). I'm filing a follow-up issue with the exact file:lines and proposed shape so it can be picked up cleanly.

## Verification

- 5 new tests in `orchestrate-dispatch-status.test.ts` pin all four cases (no dispatch / 0 workers / all success / partial / all failed).
- All **166 existing orchestrate tests** still pass.
- `pnpm typecheck` clean.
- `pnpm eslint` clean on changed files.

## Test plan

- [ ] CI green
- [ ] No downstream schema-fanout / registry-coverage flags
- [ ] Spot-check that `orchestrate.test.ts:252` (`OrchestrateOutputSchema` validation) still passes with the optional new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)