### PR TITLE
feat(mcp): warn on client-timeout mismatch for long-running tools

### DIFF
--- a/docs/architecture/MCP_PROTOCOL.md
+++ b/docs/architecture/MCP_PROTOCOL.md
@@ -376,6 +376,44 @@ mcp:
 
 ---
 
+## Client Request Timeouts — Long-Running Tools
+
+The MCP TypeScript SDK ships with `DEFAULT_REQUEST_TIMEOUT_MSEC = 60_000` (see [`@modelcontextprotocol/sdk` → `shared/protocol.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/shared/protocol.ts)). That is a **client-side** cap on how long the client will wait for a tool response. If a nexus-agents tool has a configured per-tool budget that exceeds this, the client will kill the request before the server-side deadline can fire.
+
+**Long-running tools** (`orchestrate`, `consensus_vote`, `run_workflow`) have multi-minute budgets configured in `MCP_TIMEOUTS.perTool` (`packages/nexus-agents/src/config/timeouts.ts`). Callers MUST configure their client to:
+
+1. **Pass `options.onprogress`** in the SDK `client.request()` call. The SDK only injects `_meta.progressToken` into the JSON-RPC payload when an `onprogress` handler is supplied (`shared/protocol.ts:643`). Without `progressToken`, the server's `withProgressHeartbeat` emits notifications into a void.
+
+2. **Set `options.resetTimeoutOnProgress: true`**. The SDK only resets the per-request timer when an `notifications/progress` arrives AND this flag is true (`shared/protocol.ts:714`). Default is `false`.
+
+3. **OR raise `options.timeout`** explicitly to the tool's worst-case budget (e.g. `600_000` for `consensus_vote`, `900_000` for `orchestrate`). Sufficient if you don't want streaming progress, but the request will block for that long.
+
+```ts
+// Example: invoking consensus_vote from a custom MCP client
+const result = await client.request(
+  { method: 'tools/call', params: { name: 'consensus_vote', arguments: { ... } } },
+  CallToolResultSchema,
+  {
+    timeout: 600_000,
+    resetTimeoutOnProgress: true,
+    onprogress: (notif) => console.log(`heartbeat #${notif.progress}`),
+  }
+);
+```
+
+### Operator diagnostic
+
+`toSdkCallbackWithBudgetCheck` (`packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts`) emits a WARN at invocation time when a tool's configured budget exceeds the SDK default AND the request arrived without `_meta.progressToken`. The WARN names the tool, the configured budget, and the SDK default — operators can grep server logs to confirm whether a "tool timed out" failure is actually a client-config mismatch rather than a real CLI failure. (Source: audit on #2619 / #2631.)
+
+```
+[warn] MCP tool budget exceeds client default and no progressToken received — request likely to be killed by client before server-side deadline
+  tool=consensus_vote configuredTimeoutMs=600000 mcpSdkDefaultMs=60000
+```
+
+If you see this WARN on every long-running tool call, the client is misconfigured — fix the client, not the server timeout.
+
+---
+
 ## Claude Desktop Integration
 
 ### Setup

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper-budget-check.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper-budget-check.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `toSdkCallbackWithBudgetCheck` (audit on #2619 / #2631).
+ *
+ * The WARN fires when a long-running tool is invoked without `progressToken`
+ * in the request's `_meta`. That mismatch means the MCP client will kill the
+ * request at its default ~60s timeout regardless of what the server-side
+ * timeout config says. These tests pin the three cases the matcher has to
+ * cover: short-budget tool (no warn), long-budget with progressToken (no
+ * warn), long-budget without progressToken (warn).
+ *
+ * @module mcp/middleware/tool-wrapper-budget-check.test
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ILogger } from '../../core/index.js';
+import {
+  MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+  toSdkCallbackWithBudgetCheck,
+} from './tool-wrapper.js';
+
+function makeMockLogger(): ILogger & { warn: ReturnType<typeof vi.fn> } {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ILogger & { warn: ReturnType<typeof vi.fn> };
+}
+
+const passthroughHandler = (): Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+}> => Promise.resolve({ content: [{ type: 'text', text: 'ok' }] });
+
+describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
+  it('does not warn when configured budget fits within MCP SDK default', async () => {
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      passthroughHandler,
+      'short_tool',
+      MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS - 1_000,
+      logger
+    );
+
+    // No progressToken — but the budget fits, so the mismatch doesn't apply.
+    await callback({}, { _meta: {} });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when client sent a progressToken (long budget OK)', async () => {
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(passthroughHandler, 'long_tool', 600_000, logger);
+
+    // The MCP SDK only sets _meta.progressToken when the caller passed
+    // `onprogress`. Pair it with sendNotification so extractProgressContext
+    // returns a non-undefined context.
+    await callback(
+      {},
+      {
+        _meta: { progressToken: 42 },
+        sendNotification: () => Promise.resolve(),
+      }
+    );
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when configured budget exceeds MCP SDK default AND no progressToken', async () => {
+    // This is the #2619 reporter's failure mode: server-side budget is 10
+    // minutes for consensus_vote, but the client request times out at 60s
+    // because no progressToken was sent.
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      passthroughHandler,
+      'consensus_vote',
+      600_000,
+      logger
+    );
+
+    await callback({}, { _meta: {} });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message, ctx] = logger.warn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toContain('budget exceeds client default');
+    expect(ctx['tool']).toBe('consensus_vote');
+    expect(ctx['configuredTimeoutMs']).toBe(600_000);
+    expect(ctx['mcpSdkDefaultMs']).toBe(MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS);
+  });
+
+  it('still invokes the underlying handler even when warning fires', async () => {
+    const logger = makeMockLogger();
+    const handler = vi.fn(passthroughHandler);
+    const callback = toSdkCallbackWithBudgetCheck(handler, 'long_tool', 600_000, logger);
+
+    const result = await callback({ key: 'value' }, { _meta: {} });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ key: 'value' });
+    expect(result.content[0]?.text).toBe('ok');
+  });
+});

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
@@ -289,6 +289,60 @@ export function toSdkCallback(
 }
 
 /**
+ * MCP SDK client default request timeout. Matches `DEFAULT_REQUEST_TIMEOUT_MSEC`
+ * in `@modelcontextprotocol/sdk` (`shared/protocol.js`). If a tool's
+ * configured server-side budget exceeds this and the client did not send a
+ * `progressToken` (i.e. did not pass `onprogress` to its `request()` call),
+ * the client kills the request at this threshold regardless of what the
+ * server is doing — heartbeats fire but go nowhere.
+ *
+ * (Source: audit on #2619 / #2631 — root cause of "MCP error -32001 at 60010ms")
+ */
+export const MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Like `toSdkCallback`, but emits a one-shot WARN at invocation start when
+ * the configured per-tool budget exceeds the MCP SDK client default AND the
+ * client did not send a `progressToken`. The call is almost certainly going
+ * to die at the client default (~60s) regardless of server-side timeout
+ * config or progress heartbeats — surface that at the moment of invocation
+ * so operators can spot the mismatch in logs without waiting for the
+ * timeout to fire.
+ *
+ * Wrap a long-running tool (`orchestrate`, `consensus_vote`,
+ * `execute_expert`, `run_workflow`) with this instead of plain
+ * `toSdkCallback`. Tools whose budget already fits within
+ * `MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS` should keep using `toSdkCallback`.
+ *
+ * (Source: audit on #2619 / #2631 — observability for client-timeout mismatch)
+ */
+export function toSdkCallbackWithBudgetCheck(
+  handler: ToolHandler,
+  toolName: string,
+  configuredTimeoutMs: number,
+  logger?: ILogger
+): (args: unknown, extra: unknown) => Promise<SdkToolResult> {
+  const log = logger ?? wrapperLogger;
+  return (args: unknown, extra: unknown) => {
+    const progressCtx = extractProgressContext(extra);
+    const signal = (extra as SdkExtra | undefined)?.signal;
+    if (configuredTimeoutMs > MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS && progressCtx === undefined) {
+      log.warn(
+        'MCP tool budget exceeds client default and no progressToken received — request likely to be killed by client before server-side deadline',
+        {
+          tool: toolName,
+          configuredTimeoutMs,
+          mcpSdkDefaultMs: MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+          remediation:
+            'Client should pass `onprogress` and `resetTimeoutOnProgress: true` when calling, or extend `options.timeout`. See docs/architecture/MCP_PROTOCOL.md.',
+        }
+      );
+    }
+    return runWithContexts(handler, args, progressCtx, signal);
+  };
+}
+
+/**
  * Re-export middleware factory for advanced use cases.
  */
 export { createMiddlewareFactory, withMiddleware };

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -16,7 +16,11 @@ import {
 } from '../../core/index.js';
 import type { IMcpNotifier } from '../mcp-notifier.js';
 import { createMcpNotifier, NOOP_NOTIFIER, withProgressHeartbeat } from '../mcp-notifier.js';
-import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
+import {
+  wrapToolWithTimeout,
+  toSdkCallbackWithBudgetCheck,
+  getToolTimeout,
+} from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
 import type { ConsensusAlgorithm, Vote, ConsensusResult, Proposal } from '../../consensus/types.js';
@@ -595,7 +599,7 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
   server.registerTool(
     'consensus_vote',
     { description, inputSchema: toolSchema, outputSchema: CONSENSUS_VOTE_OUTPUT_SCHEMA },
-    toSdkCallback(wrappedHandler)
+    toSdkCallbackWithBudgetCheck(wrappedHandler, 'consensus_vote', timeoutMs, logger)
   );
   logger.info('Registered consensus_vote tool with secure handler and timeout protection');
 }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -36,7 +36,7 @@ import type {
   OrchestratorDefinition,
   OrchestratorType,
 } from '../../core/types/orchestrator.js';
-import { wrapToolWithTimeout, toSdkCallback } from '../middleware/tool-wrapper.js';
+import { wrapToolWithTimeout, toSdkCallbackWithBudgetCheck } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { withDepthGuard } from '../middleware/spawn-depth-guard.js';
 import { toolError, toolSuccess, type ToolResult } from './tool-result.js';
@@ -1049,15 +1049,16 @@ export function registerOrchestrateTool(server: McpServer, deps: OrchestrateDeps
   });
 
   // Canonical source: config/timeouts.ts (Issue #1046)
+  const configuredTimeoutMs = MCP_TIMEOUTS.perTool['orchestrate'] ?? MCP_TIMEOUTS.defaultMs;
   const wrappedHandler = wrapToolWithTimeout('orchestrate', secureHandler, {
-    timeoutMs: MCP_TIMEOUTS.perTool['orchestrate'] ?? MCP_TIMEOUTS.defaultMs,
+    timeoutMs: configuredTimeoutMs,
     logger,
   });
 
   server.registerTool(
     'orchestrate',
     { description, inputSchema: ORCHESTRATE_TOOL_SCHEMA },
-    toSdkCallback(wrappedHandler)
+    toSdkCallbackWithBudgetCheck(wrappedHandler, 'orchestrate', configuredTimeoutMs, logger)
   );
   logger.info('Registered orchestrate tool with secure handler and timeout protection');
 }

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -20,7 +20,11 @@ import {
 } from '../../core/index.js';
 
 import type { WorkflowDefinition, IWorkflowEngine } from '../../core/index.js';
-import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
+import {
+  wrapToolWithTimeout,
+  toSdkCallbackWithBudgetCheck,
+  getToolTimeout,
+} from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { createMcpNotifier, NOOP_NOTIFIER } from '../mcp-notifier.js';
 import type {
@@ -294,7 +298,7 @@ export function registerRunWorkflowTool(server: McpServer, deps: RunWorkflowDeps
         'Execute a workflow template with provided inputs, supporting built-in templates and custom paths',
       inputSchema: toolInputSchema,
     },
-    toSdkCallback(wrappedHandler)
+    toSdkCallbackWithBudgetCheck(wrappedHandler, 'run_workflow', timeoutMs, logger)
   );
   logger.info('Registered run_workflow tool with secure handler and timeout protection');
 }


### PR DESCRIPTION
Implements items A + B from the #2619 audit. Follow-up to PR #2629.

## Why

The MCP TS SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC = 60_000` is a **client-side** cap. nexus-agents tools with multi-minute server-side budgets (`consensus_vote: 600s`, `orchestrate: 900s`, `run_workflow: 900s`) get killed by the client at 60s unless the caller sets up streaming progress correctly. The audit on #2619 found three client knobs that all need to align:

1. `options.timeout` must exceed the server-side budget (default 60_000)
2. `options.onprogress` must be set (only then does the SDK inject `_meta.progressToken`)
3. `options.resetTimeoutOnProgress: true` must be set (else progress notifications don't keep the request alive)

Without these, server-side `withProgressHeartbeat` emits notifications into a void and the client gives up at 60s. This is what the #2619 reporter hit ("MCP error -32001 at 60010ms").

## What this PR does

**A — observability.** Adds `toSdkCallbackWithBudgetCheck` in `tool-wrapper.ts`. On every invocation of a registered long-running tool, it checks whether (configured-budget > MCP-SDK-default) AND (no `progressToken` received). If so, it logs a single WARN naming the tool, the configured budget, and the remediation. Operators can grep their server logs to confirm whether a "tool timed out" failure is actually a client-config mismatch rather than a real CLI failure.

**B — docs.** New section in `docs/architecture/MCP_PROTOCOL.md` ("Client Request Timeouts — Long-Running Tools") documents the three client knobs, gives a working code example, and explains the WARN operators see.

Three tool registrations updated to use the new wrapper: `orchestrate`, `consensus_vote`, `run_workflow`. `execute_expert` already uses `server.experimental.tasks.registerToolTask` (the MCP Tasks primitive) and doesn't need this — it's the official async path.

## Why this doesn't fix the underlying issue

It just surfaces it. The real fix is either (a) clients send the right knobs, or (b) job-style invocation (#2631) sidesteps the request-timeout problem entirely. (a) is on callers; (b) is a future epic.

## Verification

- 4 new tests (`tool-wrapper-budget-check.test.ts`) pin all cases.
- All 21 tool-wrapper tests pass (17 existing + 4 new).
- `pnpm typecheck` clean.
- `pnpm eslint` clean on changed files.

## Test plan

- [ ] CI green
- [ ] Spot-check that the next live invocation of `consensus_vote` from Claude Code produces the WARN — that confirms the root-cause theory from the audit
- [ ] If the WARN does NOT fire (i.e. progressToken IS being sent), then Claude Code is doing the right thing on the client side and the timeout failures have a different root cause; revisit #2630 with that data

🤖 Generated with [Claude Code](https://claude.com/claude-code)