### PR TITLE
chore(config): centralize hardcoded timeout literals (#2636)

### DIFF
--- a/packages/nexus-agents/src/cli/orchestrate-puppeteer.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-puppeteer.ts
@@ -19,6 +19,7 @@ import type { IAgent, Task as AgentTask } from '../core/types/agent.js';
 import type { CliName, ICliAdapter } from '../cli-adapters/index.js';
 import type { OrchestrateOptions, PuppeteerOrchestrationResult } from './orchestrate-types.js';
 import { CliAdapterAgent } from './cli-adapter-agent.js';
+import { INTERNAL_TIMEOUTS } from '../config/timeouts.js';
 
 // Re-export for backward compatibility
 export type { PuppeteerOrchestrationResult } from './orchestrate-types.js';
@@ -105,7 +106,7 @@ export function createOrchestrator(
   agents: IAgent[],
   options: OrchestrateOptions
 ): PuppeteerOrchestrator {
-  const config = { maxSteps: options.maxSteps ?? 5, timeoutMs: 300_000 };
+  const config = { maxSteps: options.maxSteps ?? 5, timeoutMs: INTERNAL_TIMEOUTS.puppeteerMs };
 
   return options.learn === true
     ? new PuppeteerOrchestrator({

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -80,7 +80,7 @@ import { launchVotesWithOverallDeadline } from './voter-agents-deadline.js';
  * this deadline bounds total wall time and lets partial results return.
  *
  * Formula: worst-case legitimate completion (timeoutMs * (maxRetries+1))
- * plus staggered launch headroom, plus a 60s buffer.
+ * plus staggered launch headroom, plus `VOTE_TIMEOUTS.overallDeadlineBufferMs`.
  */
 export function computeOverallConsensusDeadlineMs(
   timeoutMs: number,
@@ -90,7 +90,7 @@ export function computeOverallConsensusDeadlineMs(
 ): number {
   const perVoteBudget = timeoutMs * (maxRetries + 1);
   const staggerBudget = Math.max(0, roleCount - 1) * interDelayMs;
-  return perVoteBudget + staggerBudget + 60_000;
+  return perVoteBudget + staggerBudget + VOTE_TIMEOUTS.overallDeadlineBufferMs;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -68,6 +68,14 @@ export const VOTE_TIMEOUTS = {
   maxMs: 600_000,
   /** Default max retries per agent. */
   maxRetries: 2,
+  /**
+   * Slack buffer added to the overall wall-clock deadline in
+   * `computeOverallConsensusDeadlineMs` (#1871). Acts as a safety net
+   * above per-vote × (retries+1) + stagger. Centralized so the formula
+   * can be tuned in one place.
+   * (Issue #2636 — was hardcoded `60_000` in voter-agents.ts:93)
+   */
+  overallDeadlineBufferMs: 60_000,
 } as const;
 
 /**
@@ -210,6 +218,25 @@ export const INTERNAL_TIMEOUTS = {
   waveTaskMs: 60_000,
   /** Puppeteer orchestration timeout. */
   puppeteerMs: 300_000,
+  /**
+   * Initial cooldown before a disabled worker role can attempt recovery
+   * (Issue #1458). Used by `worker-dispatcher.ts` circuit-breaker logic.
+   * (Issue #2636 — re-homed from worker-dispatcher.ts:57)
+   */
+  workerRecoveryCooldownMs: 30_000,
+  /**
+   * Maximum cooldown after exponential backoff (Issue #1458). Caps the
+   * worker-dispatcher circuit-breaker backoff so a permanently-broken
+   * role doesn't hold the slot indefinitely.
+   * (Issue #2636 — re-homed from worker-dispatcher.ts:60)
+   */
+  workerMaxCooldownMs: 300_000,
+  /**
+   * Minimum spacing between requests to rate-limited worker roles
+   * (Issue #1458).
+   * (Issue #2636 — re-homed from worker-dispatcher.ts:63)
+   */
+  workerRateLimitSpacingMs: 2_000,
 } as const;
 
 /**
@@ -232,6 +259,14 @@ export const EXPERT_TIMEOUTS = {
   minMs: 30_000,
   /** Maximum allowed expert timeout. */
   maxMs: 900_000,
+  /**
+   * Stricter floor for `execute_expert` specifically — LLM inference takes
+   * 20-90s minimum (#1163, #1330), so this caller-facing floor prevents
+   * configuring a timeout that's guaranteed to fail. The global `minMs`
+   * (30s) remains the absolute floor for non-execute paths.
+   * (Issue #2636 — was hardcoded `EXPERT_TIMEOUT_FLOOR_MS = 120_000` in execute-expert.ts:68)
+   */
+  executeFloorMs: 120_000,
   /** Categories considered complex (longer timeout).
    * Updated: Issue #1675 — devops (avg 54s) and documentation (avg 64s on gemini)
    * regularly exceed the 120s standard CLI timeout. */

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -55,7 +55,11 @@ import {
 // threshold (default 85%, overridable via NEXUS_CONTEXT_WARN_THRESHOLD).
 import { observeExpertContext } from './expert-context-observer.js';
 import type { ExpertContextObservation } from './expert-context-observer.js';
-import { getExpertTaskTimeout, HEARTBEAT_TIMEOUTS } from '../../config/timeouts.js';
+import {
+  getExpertTaskTimeout,
+  HEARTBEAT_TIMEOUTS,
+  EXPERT_TIMEOUTS,
+} from '../../config/timeouts.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
 import { getExpertPool } from '../../agents/expert-pool.js';
@@ -64,8 +68,12 @@ import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
 import { clampTaskTtl, DEFAULT_TASK_TTL_MS } from '../task-store.js';
 import { toolError, toolSuccess, type BaseMcpToolDeps } from './tool-result.js';
 
-/** Minimum effective timeout for expert tasks — LLM inference takes 20-90s minimum. (#1163, #1330) */
-export const EXPERT_TIMEOUT_FLOOR_MS = 120_000;
+/**
+ * Minimum effective timeout for expert tasks — LLM inference takes 20-90s
+ * minimum (#1163, #1330). Re-exported from `EXPERT_TIMEOUTS.executeFloorMs`
+ * for backward compatibility with existing imports (#2636).
+ */
+export const EXPERT_TIMEOUT_FLOOR_MS = EXPERT_TIMEOUTS.executeFloorMs;
 
 /**
  * Input schema for execute_expert tool.
@@ -81,7 +89,7 @@ export const ExecuteExpertInputSchema = z.object({
     .number()
     .int()
     .min(EXPERT_TIMEOUT_FLOOR_MS)
-    .max(900_000)
+    .max(EXPERT_TIMEOUTS.maxMs)
     .optional()
     .describe('Optional timeout in ms (120s-900s). Overrides auto-detected timeout.'),
   previousExpertSummary: z
@@ -551,7 +559,7 @@ const EXECUTE_EXPERT_TOOL_SCHEMA = {
     .number()
     .int()
     .min(EXPERT_TIMEOUT_FLOOR_MS)
-    .max(900_000)
+    .max(EXPERT_TIMEOUTS.maxMs)
     .optional()
     .describe('Optional timeout in ms (120s-900s). Overrides auto-detected timeout.'),
 };

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
@@ -15,7 +15,7 @@ import type { AgentPlanEntry } from './agent-planner.js';
 import { MAX_WORKERS_PER_WAVE } from './agent-planner.js';
 import { topologicalWaveAssign } from './topological-wave.js';
 import { createLogger, getErrorMessage } from '../../core/index.js';
-import { getExpertTaskTimeout, WORKER_TIMEOUTS } from '../../config/timeouts.js';
+import { getExpertTaskTimeout, WORKER_TIMEOUTS, INTERNAL_TIMEOUTS } from '../../config/timeouts.js';
 import { isRateLimitError } from '../../cli/voter-execution.js';
 import type { IEventBus } from '../../pipeline/event-types.js';
 import { withWatchdog } from './watchdog.js';
@@ -53,14 +53,23 @@ export const DEFAULT_STAGGER_DELAY_MS = 500;
  */
 export const CONSECUTIVE_FAILURE_THRESHOLD = 3;
 
-/** Initial cooldown before a disabled role can attempt recovery (Issue #1458). */
-export const RECOVERY_COOLDOWN_MS = 30_000;
+/**
+ * Initial cooldown before a disabled role can attempt recovery (Issue #1458).
+ * Re-exported from central config for backward compatibility (#2636).
+ */
+export const RECOVERY_COOLDOWN_MS = INTERNAL_TIMEOUTS.workerRecoveryCooldownMs;
 
-/** Maximum cooldown after exponential backoff (5 minutes, Issue #1458). */
-export const MAX_COOLDOWN_MS = 300_000;
+/**
+ * Maximum cooldown after exponential backoff (5 minutes, Issue #1458).
+ * Re-exported from central config for backward compatibility (#2636).
+ */
+export const MAX_COOLDOWN_MS = INTERNAL_TIMEOUTS.workerMaxCooldownMs;
 
-/** Minimum spacing between requests to rate-limited roles (Issue #1458). */
-export const RATE_LIMIT_SPACING_MS = 2_000;
+/**
+ * Minimum spacing between requests to rate-limited roles (Issue #1458).
+ * Re-exported from central config for backward compatibility (#2636).
+ */
+export const RATE_LIMIT_SPACING_MS = INTERNAL_TIMEOUTS.workerRateLimitSpacingMs;
 
 // ============================================================================
 // Types


### PR DESCRIPTION
Closes #2636. First of five DRY follow-ups from the audit on PR #2635.

## Why

Five sites had timeout magic numbers outside `config/timeouts.ts`, each a drift risk if the central config is tuned for performance. The vote-CLI delegation refactor (#2635) surfaced that scattered hardcodes were holding back the consistency win.

## What changed

| Site | Was | Now |
|---|---|---|
| `voter-agents.ts:93` (overall deadline buffer) | `60_000` | `VOTE_TIMEOUTS.overallDeadlineBufferMs` |
| `execute-expert.ts:68` (execute floor) | local `EXPERT_TIMEOUT_FLOOR_MS = 120_000` | `EXPERT_TIMEOUTS.executeFloorMs` (re-exported as `EXPERT_TIMEOUT_FLOOR_MS` for back-compat) |
| `execute-expert.ts:88,558` (Zod `.max`) | `900_000` | `EXPERT_TIMEOUTS.maxMs` |
| `worker-dispatcher.ts:57,60,63` (cooldown/spacing) | local consts | `INTERNAL_TIMEOUTS.worker{Recovery,Max}CooldownMs` + `workerRateLimitSpacingMs` (re-exported as `RECOVERY_COOLDOWN_MS`, `MAX_COOLDOWN_MS`, `RATE_LIMIT_SPACING_MS` for back-compat) |
| `orchestrate-puppeteer.ts:108` (puppeteer timeout) | `300_000` | `INTERNAL_TIMEOUTS.puppeteerMs` |

## Backward-compatible

Every existing local export (`EXPERT_TIMEOUT_FLOOR_MS`, `MAX_COOLDOWN_MS`, `RECOVERY_COOLDOWN_MS`, `RATE_LIMIT_SPACING_MS`) keeps working — they're now thin re-exports of the canonical constants. No call sites need to change. The literals at those sites still resolve to the same numeric values.

## Verification

- `pnpm typecheck` clean.
- `pnpm eslint src/` clean.
- 203 tests pass across `config/timeouts`, `cli/voter-agents`, `mcp/tools/execute-expert`, `orchestration/aorchestra/worker-dispatcher`.

## Test plan

- [ ] CI green
- [ ] Confirm fitness-audit "Canonical Paths / duplicate path elimination" score doesn't regress (this PR strictly improves it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)