### PR TITLE
chore(schemas): share VoteThreshold + ErrorPolicy Zod schemas (#2638)

### DIFF
--- a/packages/nexus-agents/src/cli-commands-validators.ts
+++ b/packages/nexus-agents/src/cli-commands-validators.ts
@@ -10,6 +10,12 @@
 import type { ExpertListFormat, IndexSubcommand } from './cli/index.js';
 import type { CliNameLiteral } from './config/model-capabilities-types.js';
 import { CLI_NAMES } from './config/model-capabilities-types.js';
+import {
+  VoteThresholdSchema,
+  ErrorPolicySchema,
+  type VoteThreshold,
+  type ErrorPolicy,
+} from './mcp/tools/consensus-vote-types.js';
 
 /**
  * Validates and coerces format to ExpertListFormat.
@@ -26,22 +32,19 @@ export function isValidOrchestrateModel(value: string): value is CliNameLiteral 
 }
 
 /**
- * Validates threshold option for vote command.
+ * Validates threshold option for vote command. Uses `VoteThresholdSchema`
+ * as the single source of truth (#2638).
  */
-export function isValidThreshold(
-  value: string
-): value is 'majority' | 'supermajority' | 'unanimous' {
-  return ['majority', 'supermajority', 'unanimous'].includes(value);
+export function isValidThreshold(value: string): value is VoteThreshold {
+  return VoteThresholdSchema.safeParse(value).success;
 }
 
 /**
- * Validates errorPolicy option for vote command (#2630). Mirrors
- * `ErrorPolicySchema` in `consensus-vote-types.ts` — keep in sync.
+ * Validates errorPolicy option for vote command (#2630). Uses
+ * `ErrorPolicySchema` as the single source of truth (#2638).
  */
-export function isValidErrorPolicy(
-  value: string
-): value is 'reduce_denominator' | 'count_as_abstain' | 'fail_closed' {
-  return ['reduce_denominator', 'count_as_abstain', 'fail_closed'].includes(value);
+export function isValidErrorPolicy(value: string): value is ErrorPolicy {
+  return ErrorPolicySchema.safeParse(value).success;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -9,6 +9,7 @@
 
 import type { ServerMode } from './cli/index.js';
 import type { CliNameLiteral } from './config/model-capabilities-types.js';
+import type { ErrorPolicy, VoteThreshold } from './mcp/tools/consensus-vote-types.js';
 
 // Re-export help text from extracted module for backward compatibility
 export { HELP_TEXT } from './cli-help-text.js';
@@ -114,11 +115,11 @@ export interface ParsedCliArgs {
     fix: boolean;
     // Vote command options
     proposal?: string;
-    threshold?: 'majority' | 'supermajority' | 'unanimous';
+    threshold?: VoteThreshold;
     quick: boolean;
     timeoutMs?: number;
     /** #2630 — see `applyErrorPolicy`. */
-    errorPolicy?: 'reduce_denominator' | 'count_as_abstain' | 'fail_closed';
+    errorPolicy?: ErrorPolicy;
     // SWE-bench command options
     variant?: 'lite' | 'verified' | 'full';
     limit?: number;

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -26,6 +26,12 @@ import {
 import { dispatchCommand } from './cli-commands.js';
 import { formatCommandHelp } from './cli-command-help.js';
 import { CLI_NAMES, type CliNameLiteral } from './config/model-capabilities-types.js';
+import {
+  VoteThresholdSchema,
+  ErrorPolicySchema,
+  type VoteThreshold,
+  type ErrorPolicy,
+} from './mcp/tools/consensus-vote-types.js';
 
 // Re-export types and constants for external use
 export { EXIT_CODES, type CliCommand, type ParsedCliArgs } from './cli-types.js';
@@ -181,24 +187,24 @@ function buildOrchestrateOptions(values: ParsedValues): Record<string, unknown> 
   };
 }
 
-/** Validates threshold option for vote command. */
-function parseThreshold(
-  value: string | undefined
-): 'majority' | 'supermajority' | 'unanimous' | undefined {
-  if (value === 'majority' || value === 'supermajority' || value === 'unanimous') {
-    return value;
-  }
-  return undefined;
+/**
+ * Validates threshold option for vote command. Uses `VoteThresholdSchema`
+ * as the single source of truth (#2638).
+ */
+function parseThreshold(value: string | undefined): VoteThreshold | undefined {
+  if (value === undefined) return undefined;
+  const parsed = VoteThresholdSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
-/** Validates errorPolicy option for vote command (#2630). */
-function parseErrorPolicy(
-  value: string | undefined
-): 'reduce_denominator' | 'count_as_abstain' | 'fail_closed' | undefined {
-  if (value === 'reduce_denominator' || value === 'count_as_abstain' || value === 'fail_closed') {
-    return value;
-  }
-  return undefined;
+/**
+ * Validates errorPolicy option for vote command (#2630). Uses
+ * `ErrorPolicySchema` as the single source of truth (#2638).
+ */
+function parseErrorPolicy(value: string | undefined): ErrorPolicy | undefined {
+  if (value === undefined) return undefined;
+  const parsed = ErrorPolicySchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 /** Builds vote-specific options. */

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -7,13 +7,14 @@
  */
 
 import type { ConsensusAlgorithm, Vote, ConsensusResult } from '../consensus/types.js';
+import type { ErrorPolicy, VoteThreshold } from '../mcp/tools/consensus-vote-types.js';
 
 /**
  * Options for the vote command.
  */
 export interface VoteCommandOptions {
   readonly proposal: string;
-  readonly threshold?: 'majority' | 'supermajority' | 'unanimous';
+  readonly threshold?: VoteThreshold;
   /** Use simulated votes instead of LLM execution (maps from --dry-run CLI flag) */
   readonly dryRun?: boolean;
   readonly quick?: boolean;
@@ -27,7 +28,7 @@ export interface VoteCommandOptions {
    * the same per-strategy default `executeVoting` uses applies:
    * `fail_closed` for unanimous, `reduce_denominator` otherwise.
    */
-  readonly errorPolicy?: 'reduce_denominator' | 'count_as_abstain' | 'fail_closed';
+  readonly errorPolicy?: ErrorPolicy;
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/gateway/governance-enforcer.ts
+++ b/packages/nexus-agents/src/mcp/gateway/governance-enforcer.ts
@@ -13,9 +13,15 @@
 import type { ILogger } from '../../core/index.js';
 import { createLogger } from '../../core/index.js';
 import { classifyRequestTier, RequestTier, type TierOverrides } from './tier-classifier.js';
+import type { VoteThreshold } from '../tools/consensus-vote-types.js';
 
-/** Voting threshold required by governance policy. */
-export type VotingThreshold = 'majority' | 'supermajority' | 'unanimous';
+/**
+ * Voting threshold required by governance policy.
+ * Alias of `VoteThreshold` from `consensus-vote-types.ts` — kept as a
+ * named local re-export for readability at call sites in this module
+ * (#2638 — single source of truth).
+ */
+export type VotingThreshold = VoteThreshold;
 
 /** Governance domain that triggered Tier 3 promotion. */
 export type GovernanceDomain = 'security' | 'architecture' | 'none';

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -68,9 +68,24 @@ export const VotingStrategySchema = z.enum([
  * total voters, the vote always fails. Catches "all CLIs are down" — a
  * 2-voter consensus is not a real consensus.
  */
-export type ErrorPolicy = 'reduce_denominator' | 'count_as_abstain' | 'fail_closed';
-
 export const ErrorPolicySchema = z.enum(['reduce_denominator', 'count_as_abstain', 'fail_closed']);
+
+export type ErrorPolicy = z.infer<typeof ErrorPolicySchema>;
+
+/**
+ * Threshold values accepted by the `--threshold` CLI flag and the
+ * \`threshold\` MCP input field (#2638 — single source of truth).
+ *
+ * Maps to consensus algorithms via:
+ * `majority → simple_majority`, `supermajority → supermajority`, `unanimous → unanimous`.
+ *
+ * Used as the canonical Zod schema for CLI parsing
+ * (`cli.ts:parseThreshold`), validation (`cli-commands-validators.ts:isValidThreshold`),
+ * and the `ConsensusVoteInputSchema.threshold` field.
+ */
+export const VoteThresholdSchema = z.enum(['majority', 'supermajority', 'unanimous']);
+
+export type VoteThreshold = z.infer<typeof VoteThresholdSchema>;
 
 /**
  * Fraction of total voters that, if errored, forces the vote to fail
@@ -91,12 +106,9 @@ export function getDefaultErrorPolicy(strategy: VotingStrategy): ErrorPolicy {
 
 export const ConsensusVoteInputSchema = z.object({
   proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
-  threshold: z
-    .enum(['majority', 'supermajority', 'unanimous'])
-    .optional()
-    .describe(
-      'Voting threshold (legacy): majority, supermajority, unanimous. Use strategy instead.'
-    ),
+  threshold: VoteThresholdSchema.optional().describe(
+    'Voting threshold (legacy): majority, supermajority, unanimous. Use strategy instead.'
+  ),
   strategy: VotingStrategySchema.optional().describe(
     'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order (Bayesian-optimal)'
   ),
@@ -153,7 +165,7 @@ export interface HigherOrderMetadata {
 
 export interface ConsensusVoteResponse {
   proposal: string;
-  threshold?: 'majority' | 'supermajority' | 'unanimous';
+  threshold?: VoteThreshold;
   strategy: VotingStrategy;
   decision: VoteDecisionStatus;
   approvalPercentage: number;

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -40,6 +40,7 @@ import {
 import {
   MAX_PROPOSAL_LENGTH,
   VotingStrategySchema,
+  VoteThresholdSchema,
   ConsensusVoteInputSchema,
   buildResponse,
   getDefaultErrorPolicy,
@@ -686,7 +687,7 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
         .optional(),
     })
   ),
-  threshold: z.enum(['majority', 'supermajority', 'unanimous']).optional(),
+  threshold: VoteThresholdSchema.optional(),
   durationMs: z.number(),
   simulateVotes: z.boolean(),
   higherOrderMetadata: z


### PR DESCRIPTION
Closes #2638. Third of five DRY follow-ups.

## Why

Two enum literals were duplicated across the codebase:

- **VoteThreshold (`'majority' | 'supermajority' | 'unanimous'`)** — **8 places**: \`cli.ts:parseThreshold\`, \`cli-commands-validators.ts:isValidThreshold\`, \`cli-types.ts:ParsedCliArgs.options.threshold\`, \`cli/vote-types.ts:VoteCommandOptions.threshold\`, \`consensus-vote-types.ts\` (inline twice), \`consensus-vote.ts:689\` (inline), \`governance-enforcer.ts:VotingThreshold\`.
- **ErrorPolicy (`'reduce_denominator' | 'count_as_abstain' | 'fail_closed'`)** — **6 places**: same pattern.

Each new value would have required editing all 8 (or 6) sites in lockstep. Adding \`errorPolicy\` in PR #2633 surfaced this — that PR had to maintain the same enum in three places (\`ErrorPolicySchema\`, \`isValidErrorPolicy\`, \`parseErrorPolicy\`) to keep them in sync.

## What changed

- **\`VoteThresholdSchema\`** (new, in \`consensus-vote-types.ts\`) — canonical Zod enum.
- **\`VoteThreshold\`** type (new) — \`z.infer<typeof VoteThresholdSchema>\`.
- **\`ErrorPolicy\`** type — moved to \`z.infer\`-derived for consistency.
- **All TS literal duplications** replaced with imports of \`VoteThreshold\` / \`ErrorPolicy\`.
- **All hand-rolled string checks** replaced with \`Schema.safeParse(value).success\` (`parseThreshold`, `parseErrorPolicy`, `isValidThreshold`, `isValidErrorPolicy`).
- **\`governance-enforcer.ts:VotingThreshold\`** — aliased to canonical \`VoteThreshold\`.

## Drift eliminated

Adding a new threshold value or error policy is now a **one-line change** in \`consensus-vote-types.ts\`. The CLI parser, validator, input schema, response schema, and consumer TS types all derive from the same enum.

## Verification

- \`pnpm typecheck\` clean.
- \`pnpm eslint src/\` clean.
- 917 tests pass.

## Test plan

- [ ] CI green
- [ ] Spot-check that existing \`--threshold supermajority\` and \`--error-policy fail_closed\` CLI invocations still parse identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)