### PR TITLE
chore(cleanup): remove dead-code stragglers surfaced by QA pass

### DIFF
--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -50,15 +50,6 @@ export type VoterRole =
   | 'scope_steward';
 
 /**
- * Maps threshold names to consensus algorithms.
- */
-export const THRESHOLD_MAP: Record<string, ConsensusAlgorithm> = {
-  majority: 'simple_majority',
-  supermajority: 'supermajority',
-  unanimous: 'unanimous',
-};
-
-/**
  * Agent role descriptions for prompt generation.
  */
 export const VOTER_ROLES: Record<VoterRole, string> = {

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -56,7 +56,6 @@ export {
   delay,
   extractTextFromResponse,
   executeSingleVoteAttempt,
-  validateTimeout,
   resolveVoteTimeout,
   type RetryOptions,
   executeWithRetries,


### PR DESCRIPTION
QA pass over today's DRY series (PRs #2627, #2628, #2629, #2632, #2633, #2635, #2641, #2642, #2643) found two pieces of dead code introduced as collateral by the consolidation.

## Findings

1. **\`THRESHOLD_MAP\` in \`cli/vote-types.ts:55\`** — used to be referenced by the inline \`runVote\` implementation. PR #2635 deleted that code path when CLI runVote started delegating to \`executeVoting\`. \`grep THRESHOLD_MAP packages/nexus-agents/src\` returns zero references outside the definition itself.

2. **\`validateTimeout\` re-export in \`cli/voter-agents.ts:59\`** — became dead in PR #2642 when \`vote-command.ts\` switched to importing \`validateTimeout\` directly from \`config/timeouts.js\`. Other re-export at \`voter-execution.ts:69\` IS still consumed (by \`voter-execution.test.ts\`), so that one stays.

Both confirmed via grep across src/ and tests/. Build artifacts (\`dist/\`, \`coverage/\`, \`docs/codebase-index.yaml\`) reference \`THRESHOLD_MAP\` but those are auto-regenerated.

## QA full-pass summary (the whole reason this PR exists)

Ran a full QA pass on main after merging all 9 DRY+fix PRs from today:

| Check | Result |
|---|---|
| \`pnpm typecheck\` (full monorepo) | ✅ clean |
| \`pnpm eslint src/\` (full) | ✅ clean |
| \`pnpm vitest run\` (full suite) | ✅ **25,278 pass, 16 skip, 0 fail** across 1,031 files |
| \`inject-governance.ts check\` | ✅ passes |
| \`inject-governance.ts\` idempotent | ✅ no diff on re-run |
| Zero literal duplications for VoteThreshold/ErrorPolicy | ✅ |
| Back-compat re-exports working | ✅ (EXPERT_TIMEOUT_FLOOR_MS, MAX_COOLDOWN_MS, etc.) |
| Canonical Paths CI validator | ✅ |

The only fixable findings were these two dead-code stragglers. No regressions, no broken contracts.

## Verification

- \`pnpm typecheck\` clean.
- \`pnpm eslint src/\` clean.
- 336 tests pass across cli/vote, cli/voter, mcp/tools/consensus-vote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)