### PR TITLE
refactor(research): CLI add subcommand delegates to MCP executeResearchAdd (#2640 Phase 1)

### DIFF
--- a/packages/nexus-agents/src/cli/research-command.ts
+++ b/packages/nexus-agents/src/cli/research-command.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Central dispatch for all research subcommands (governance: 400-600 OK if cohesive). */
 /**
  * Research Registry CLI Commands
  *
@@ -19,7 +20,6 @@ import {
   formatStatusResult,
   findOverlaps,
   formatOverlapResult,
-  addResearchPaper,
 } from './research-helpers.js';
 import {
   discoverGitHubRepos,
@@ -52,6 +52,8 @@ import {
   getResearchIndexHelp,
 } from './research-index-command.js';
 import { handleImportCommand } from './research-import-command.js';
+import { executeResearchAdd } from '../mcp/tools/research-add.js';
+import { createLogger } from '../core/index.js';
 export type {
   ResearchIndexOptions,
   ResearchIndexResult,
@@ -169,13 +171,21 @@ async function handleAddCommand(args: string[], options: Record<string, unknown>
   if (arxivId === undefined || arxivId === '') {
     return 'Error: arxiv-id is required for add command';
   }
-  const addOptions: ResearchAddOptions = {
+  // Delegate to the shared core (#2640 Phase 1). The MCP path's
+  // executeResearchAdd includes a dedup check, session-memory
+  // recording on success, and a quality-tier annotation — the CLI
+  // previously bypassed all three by calling addResearchPaper
+  // directly.
+  const topic = optString(options, 'topic');
+  const priority = optString(options, 'priority') as ResearchAddOptions['priority'];
+  const input = {
     arxivId,
-    topic: optString(options, 'topic'),
-    priority: optString(options, 'priority') as ResearchAddOptions['priority'],
     dryRun: optBoolean(options, 'dryRun'),
+    ...(topic !== undefined && { topic }),
+    ...(priority !== undefined && { priority }),
   };
-  const result = await addResearchPaper(addOptions);
+  const logger = createLogger({ component: 'cli-research-add' });
+  const result = await executeResearchAdd(input, logger);
   return result.message;
 }
 

--- a/packages/nexus-agents/src/mcp/tools/research-add.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add.ts
@@ -84,8 +84,21 @@ export interface ResearchAddResponse {
 // HANDLER
 // =============================================================================
 
-/** Executes the research add operation. */
-async function executeResearchAdd(
+/**
+ * Executes the research add operation.
+ *
+ * Shared core for both the MCP `research_add` tool and the CLI
+ * `research add` subcommand (#2640 Phase 1). Includes:
+ *   - Dedup check via `paperExists`
+ *   - arXiv metadata fetch + registry persist via `addResearchPaper`
+ *   - Session-memory recording on success (best-effort)
+ *   - Quality-tier annotation appended to the message
+ *
+ * Returns a structured `ResearchAddResponse` — callers render it
+ * however suits their context (MCP → `toolSuccessStructured`,
+ * CLI → pretty-printed text).
+ */
+export async function executeResearchAdd(
   input: ResearchAddInput,
   logger: ILogger
 ): Promise<ResearchAddResponse> {


### PR DESCRIPTION
Phase 1 of the [#2640](https://github.com/williamzujkowski/nexus-agents/issues/2640) research consolidation epic.

## Why

Audit found that the CLI \`research add\` subcommand was missing three features the MCP \`research_add\` tool had. This isn't pure duplication — it's silent behavioral drift where the CLI path was simpler than the MCP path on purpose at some point and never re-aligned.

| Feature | MCP \`research_add\` | CLI \`research add\` (before) |
|---|---|---|
| Dedup check via \`paperExists(arxivId)\` | ✅ | ❌ Silent dup writes |
| Session-memory \`recordLearning\` on success | ✅ | ❌ Skipped |
| Quality-tier annotation in message | ✅ | ❌ Generic message |

## What changed

Per design questions resolved on #2640:

- **(a) Shared core in MCP tool file.** \`executeResearchAdd\` in \`mcp/tools/research-add.ts\` is now exported. CLI imports it.
- **(c) Structured TS return type.** \`ResearchAddResponse\` is the wire format. CLI renders \`.message\`; MCP wraps via existing \`toolSuccessStructured\`. No new adapter helper needed.
- **mutating-only dryRun.** Already in place — \`ResearchAddInputSchema\` accepts \`dryRun?\`. CLI now forwards it.

The CLI \`handleAddCommand\` is now ~20 lines that build the input shape and delegate. The three missing features come for free.

## Side effect

\`research-command.ts\` tipped over the 400-line max-lines cap by 4 effective code lines. Added the documented \`/* eslint-disable max-lines */\` escape hatch with a rationale comment, matching the existing pattern in \`consensus-vote.ts\`. (Governance allows 400-600 OK if cohesive — research-command.ts is the central dispatch for all research subcommands.)

## Verification

- \`pnpm typecheck\` clean.
- \`pnpm eslint src/\` clean.
- 480 tests pass across \`cli/research\` and \`mcp/tools/research-add\`.

## Next phases (separate PRs)

- **Phase 2**: \`research query\` — read-only, lowest risk.
- **Phase 3**: \`research discover\` — multi-source.
- **Phase 4**: \`research analyze\` + \`research synthesize\`.
- **Phase 5**: \`research catalog-review\` + \`research add-source\`.

## Test plan

- [ ] CI green
- [ ] Spot-check: \`nexus-agents research add 2401.12345 --topic transformers --dry-run\` returns the MCP-style structured message (with the quality-tier annotation when not dryRun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)