### PR TITLE
refactor(research): CLI discover delegates to MCP executeDiscovery (#2640 Phase 3)

### DIFF
--- a/packages/nexus-agents/src/cli/research-command.ts
+++ b/packages/nexus-agents/src/cli/research-command.ts
@@ -53,6 +53,11 @@ import {
 } from './research-index-command.js';
 import { handleImportCommand } from './research-import-command.js';
 import { executeResearchAdd } from '../mcp/tools/research-add.js';
+import {
+  executeDiscovery,
+  ResearchDiscoverInputSchema,
+  type ResearchDiscoverResponse,
+} from '../mcp/tools/research-discover.js';
 import { createLogger } from '../core/index.js';
 export type {
   ResearchIndexOptions,
@@ -247,22 +252,26 @@ async function queryDiscoverSources(
   return { results, errors };
 }
 
-/** Format discovery results into display string. */
-function formatDiscoverResults(
-  topic: string,
-  items: readonly DiscoveredSource[],
-  errors: readonly string[],
-  maxResults: number
-): string {
+/**
+ * Render a structured `ResearchDiscoverResponse` for terminal output.
+ * Used after delegating to the MCP \`executeDiscovery\` core (#2640 Phase 3).
+ * Surfaces the extra info from the core (filtered counts, registry hits)
+ * that the old CLI rendering didn't have.
+ */
+function renderDiscoverResponse(response: ResearchDiscoverResponse): string {
   const lines: string[] = [];
-  lines.push(`Discovery Results: "${topic}"`);
+  lines.push(`Discovery Results: "${response.topic}"`);
   lines.push('='.repeat(60));
-  lines.push(`Found ${String(items.length)} items`);
+  lines.push(
+    `Found ${String(response.totalFound)} items (${String(response.newItems)} new, ${String(response.alreadyInRegistry)} already in registry, ${String(response.filteredByRelevance)} filtered by relevance)`
+  );
   lines.push('');
-  for (const item of items.slice(0, maxResults)) {
+  for (const item of response.items) {
     lines.push(`  [${item.source}] ${item.title}`);
     lines.push(`    URL: ${item.url}`);
-    lines.push(`    Relevance: ${item.relevance}`);
+    if (item.relevanceScore !== undefined) {
+      lines.push(`    Relevance: ${item.relevanceScore.toFixed(2)}`);
+    }
     if (item.description !== '') {
       const desc =
         item.description.length > 100 ? item.description.slice(0, 97) + '...' : item.description;
@@ -270,14 +279,20 @@ function formatDiscoverResults(
     }
     lines.push('');
   }
-  if (errors.length > 0) {
-    lines.push('Errors:');
-    for (const err of errors) lines.push(`  - ${err}`);
+  if (response.failedSources.length > 0) {
+    lines.push('Failed sources:');
+    for (const src of response.failedSources) lines.push(`  - ${src}`);
   }
   return lines.join('\n');
 }
 
-/** Handle discover subcommand. */
+/**
+ * Handle discover subcommand. Delegates to the MCP tool's `executeDiscovery`
+ * core (#2640 Phase 3) so the CLI picks up the features it was previously
+ * missing: dedup against registry, relevance-threshold filtering, arXiv as
+ * a canonical source, topic normalization, and best-effort outcome
+ * telemetry.
+ */
 async function handleDiscoverCommand(
   args: string[],
   options: Record<string, unknown>
@@ -286,10 +301,21 @@ async function handleDiscoverCommand(
   if (topic === undefined || topic === '') {
     return 'Error: --topic is required for discover command';
   }
-  const source = (optString(options, 'source') as DiscoverSource | undefined) ?? 'all';
-  const maxResults = optNumber(options, 'maxResults') ?? 10;
-  const { results, errors } = await queryDiscoverSources(topic, source, maxResults);
-  return formatDiscoverResults(topic, results, errors, maxResults);
+  // Use Zod parse so defaults (source='all', maxResults=10, relevanceThreshold,
+  // etc.) come from the canonical schema, not from CLI-side duplicate values.
+  const parsed = ResearchDiscoverInputSchema.safeParse({
+    topic,
+    ...(optString(options, 'source') !== undefined && { source: optString(options, 'source') }),
+    ...(optNumber(options, 'maxResults') !== undefined && {
+      maxResults: optNumber(options, 'maxResults'),
+    }),
+  });
+  if (!parsed.success) {
+    return `Error: ${parsed.error.issues.map((i) => i.message).join('; ')}`;
+  }
+  const logger = createLogger({ component: 'cli-research-discover' });
+  const response = await executeDiscovery(parsed.data, logger);
+  return renderDiscoverResponse(response);
 }
 
 // =============================================================================

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -424,7 +424,22 @@ async function queryAllSources(
 }
 
 /** Runs discovery across selected sources. */
-async function executeDiscovery(
+/**
+ * Discover research items + record telemetry. The single canonical
+ * implementation for both the MCP `research_discover` tool and the CLI
+ * `research discover` subcommand (#2640 Phase 3).
+ *
+ * Combines:
+ *   - Topic normalization to canonical form (#1576 Wave 4)
+ *   - Multi-source fan-out via `queryAllSources` (arxiv + extended providers)
+ *   - Dedup against the registry via `getExistingArxivIds`
+ *   - Relevance-threshold filtering via `filterByRelevance`
+ *   - Outcome telemetry via `recordDiscoverySuccess` (best-effort)
+ *
+ * Callers render the structured `ResearchDiscoverResponse` however suits
+ * their context (MCP → `toolSuccessStructured`, CLI → terminal output).
+ */
+export async function executeDiscovery(
   rawInput: ResearchDiscoverInput,
   logger: ILogger
 ): Promise<ResearchDiscoverResponse> {
@@ -461,7 +476,7 @@ async function executeDiscovery(
     });
   }
 
-  return {
+  const response: ResearchDiscoverResponse = {
     topic: input.topic,
     sourcesQueried: sourcesToQuery,
     failedSources,
@@ -471,6 +486,11 @@ async function executeDiscovery(
     newItems: relevantItems.length,
     filteredByRelevance: filteredOut,
   };
+  // Best-effort session-memory recording (#2640 Phase 3 — was previously
+  // only invoked from the MCP handler; now baked into the core so CLI
+  // delegations get it for free).
+  recordDiscoverySuccess(response.topic, response.newItems, response.sourcesQueried);
+  return response;
 }
 
 // =============================================================================
@@ -559,7 +579,7 @@ function createResearchDiscoverHandler(deps: ResearchDiscoverDeps) {
     const startMs = Date.now();
     const response = await withToolError('Discovery failed', logger, async () => {
       const result = await executeDiscovery(validationResult.data, logger);
-      recordDiscoverySuccess(result.topic, result.newItems, result.sourcesQueried);
+      // recordDiscoverySuccess is now baked into executeDiscovery (#2640).
       return toolSuccessStructured(result as unknown as Record<string, unknown>);
     });
     const durationMs = Date.now() - startMs;


### PR DESCRIPTION
Phase 3 of the #2640 research consolidation epic. Closes silent drift where the CLI \`research discover\` subcommand was missing 5 features the MCP \`research_discover\` tool had.

## Drift before this PR

| Feature | MCP \`research_discover\` | CLI \`research discover\` (before) |
|---|---|---|
| Dedup against registry | ✅ via \`getExistingArxivIds\` | ❌ showed dups silently |
| Relevance scoring + threshold filter | ✅ 0-1 score per item | ❌ no scoring |
| arXiv as a canonical source | ✅ | ❌ \`SOURCE_PROVIDERS\` omitted arxiv; both \`--source arxiv\` and \`--source all\` silently skipped it |
| Topic normalization (#1576) | ✅ via \`normalizeTopicToCanonical\` | ❌ raw user string |
| Outcome telemetry | ✅ \`recordLearning\` | ❌ skipped |

## Changes

- **\`executeDiscovery\` exported** from \`mcp/tools/research-discover.ts\`, with \`recordDiscoverySuccess\` moved INTO it so CLI delegations get telemetry transparently.
- **MCP handler simplified** — telemetry call removed (now baked in). \`recordDiscoveryOutcome\` (success/failure separator) stays at the handler layer since it depends on \`ToolResult.isError\`.
- **CLI \`handleDiscoverCommand\` delegates** to \`executeDiscovery\` after \`ResearchDiscoverInputSchema.safeParse\` — defaults come from the canonical Zod schema, not CLI-side duplicates.
- **\`renderDiscoverResponse\`** replaces \`formatDiscoverResults\` to consume the structured \`ResearchDiscoverResponse\`. Surface gains: totalFound + alreadyInRegistry + filteredByRelevance counts in the header.

## Audit findings on remaining phases (also commented on #2640)

| Phase | Status |
|---|---|
| 1 (research add) | ✅ Done (PR #2645) |
| 2 (research query) | Skipped — already shares helpers, no drift |
| **3 (research discover)** | **This PR** |
| 4 (analyze + synthesize) | Skipped — separate feature sets / already shared |
| 5 (catalog-review + add-source) | Reframed — CLI doesn't have these subcommands at all; that's a feature-add, not DRY consolidation |

After this lands, the #2640 epic is effectively complete.

## Verification

- \`pnpm typecheck\` clean.
- \`pnpm eslint src/\` clean.
- 498 tests pass across \`cli/research\` and \`mcp/tools/research-discover\`.

## Test plan

- [ ] CI green
- [ ] Spot-check: \`nexus-agents research discover --topic transformers --source all --max-results 5\` now shows new counts (totalFound, alreadyInRegistry, filteredByRelevance) and includes arxiv results

🤖 Generated with [Claude Code](https://claude.com/claude-code)