### PR TITLE
feat(mcp): structured error envelope contract + helpers (#2649 — Epic A)

### DIFF
--- a/.rules/mcp.md
+++ b/.rules/mcp.md
@@ -32,12 +32,61 @@ server.tool(
   async (args) => {
     const validated = Schema.safeParse(args);
     if (!validated.success) {
-      return { isError: true, content: [{ type: 'text', text: validated.error.message }] };
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validated.error)}`,
+      });
     }
-    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    return toolSuccessStructured(result);
   }
 );
 ```
+
+## Error Envelope Contract (#2649)
+
+Every error return (`isError: true`) MUST carry a structured envelope, built
+via `toolStructuredError(...)` from `src/mcp/error-envelope.ts`. The envelope
+lives in `structuredContent.error`; the `message` is mirrored into
+`content[].text` for display. The `check:mcp-error-envelope` CI gate fails any
+tool that returns `isError: true` without a parseable envelope.
+
+```typescript
+toolStructuredError({
+  errorCategory: 'validation', // see taxonomy below
+  message: 'human-readable summary (≤ 2000 chars)',
+  isRetryable: false, // optional — derived from category if omitted
+  detail: { field: 'url' }, // optional structured context
+});
+```
+
+**Category taxonomy** — caller-facing resolution, "what recovery path?":
+
+| Category     | Meaning                                                | `isRetryable` default |
+| ------------ | ------------------------------------------------------ | --------------------- |
+| `transient`  | Network blip, rate limit, timeout — retry is safe      | `true`                |
+| `validation` | Input shape/values wrong — caller must fix its args    | `false`               |
+| `permission` | Auth / authorization / sandbox / access-policy denial  | `false`               |
+| `business`   | Domain-logic refusal (dedup hit, precondition not met) | `false`               |
+| `internal`   | Unexpected, bug-class — escalate, do not retry         | `false`               |
+
+`business` is an expected, non-bug outcome (e.g. `research_add` finds the
+paper already exists) — distinct from `internal`, and distinct from
+`permission` (which is an access-control denial, not a domain refusal).
+
+**Scope — caller-facing only.** This envelope is NOT consumed by the
+routing/circuit-breaker layer, which keeps its own granular 11-value
+`OutcomeFailureCategory` (`orchestration/outcomes/outcome-types.ts`) and
+classifies adapter subprocess failures through `categorizeOutcomeError()`.
+When a tool has caught an already-classified routing error and wants to
+surface it, `coarsenFailureCategory()` is the single authoritative one-way
+projection from the 11-value taxonomy to the 5-value one — never the reverse.
+
+**`detail` is not output-sanitized.** Never put secrets, credentials,
+absolute filesystem paths, or raw `Error`/response objects in `detail`.
+
+`toolError(msg)` remains as a back-compat alias mapping to a non-retryable
+`internal` envelope — acceptable for the legacy migration sweep, but new code
+should call `toolStructuredError` with the correct category.
 
 ## Security Essentials
 

--- a/packages/nexus-agents/src/mcp/error-envelope.test.ts
+++ b/packages/nexus-agents/src/mcp/error-envelope.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the structured tool error envelope (#2649).
+ *
+ * @module mcp/error-envelope.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OutcomeFailureCategory } from '../orchestration/outcomes/outcome-types.js';
+import {
+  ErrorCategorySchema,
+  ToolErrorEnvelopeSchema,
+  defaultRetryable,
+  coarsenFailureCategory,
+  parseToolErrorEnvelope,
+  type ErrorCategory,
+} from './error-envelope.js';
+import { toolError, toolStructuredError } from './tools/tool-result.js';
+
+const ALL_CATEGORIES: ErrorCategory[] = [
+  'transient',
+  'validation',
+  'permission',
+  'business',
+  'internal',
+];
+
+describe('ErrorCategorySchema', () => {
+  it('accepts every defined category', () => {
+    for (const category of ALL_CATEGORIES) {
+      expect(ErrorCategorySchema.safeParse(category).success).toBe(true);
+    }
+  });
+
+  it('rejects unknown categories', () => {
+    expect(ErrorCategorySchema.safeParse('timeout').success).toBe(false);
+    expect(ErrorCategorySchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('ToolErrorEnvelopeSchema', () => {
+  it('parses a complete envelope', () => {
+    const result = ToolErrorEnvelopeSchema.safeParse({
+      errorCategory: 'validation',
+      isRetryable: false,
+      message: 'bad input',
+      detail: { field: 'url' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses an envelope without the optional detail field', () => {
+    const result = ToolErrorEnvelopeSchema.safeParse({
+      errorCategory: 'transient',
+      isRetryable: true,
+      message: 'rate limited',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty message', () => {
+    const result = ToolErrorEnvelopeSchema.safeParse({
+      errorCategory: 'internal',
+      isRetryable: false,
+      message: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a message longer than 2000 chars', () => {
+    const result = ToolErrorEnvelopeSchema.safeParse({
+      errorCategory: 'internal',
+      isRetryable: false,
+      message: 'x'.repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('defaultRetryable', () => {
+  it('marks transient errors retryable', () => {
+    expect(defaultRetryable('transient')).toBe(true);
+  });
+
+  it('marks every non-transient category non-retryable', () => {
+    for (const category of ALL_CATEGORIES.filter((c) => c !== 'transient')) {
+      expect(defaultRetryable(category)).toBe(false);
+    }
+  });
+});
+
+describe('coarsenFailureCategory', () => {
+  const cases: Array<[OutcomeFailureCategory, ErrorCategory]> = [
+    ['timeout', 'transient'],
+    ['rate_limit', 'transient'],
+    ['connection', 'transient'],
+    ['authentication', 'permission'],
+    ['validation', 'validation'],
+    ['parse', 'validation'],
+    ['crash', 'internal'],
+    ['adapter_unavailable', 'internal'],
+    ['execution', 'internal'],
+    ['generic', 'internal'],
+    ['unknown', 'internal'],
+  ];
+
+  it('projects every routing-layer category to a caller-facing one', () => {
+    for (const [input, expected] of cases) {
+      expect(coarsenFailureCategory(input)).toBe(expected);
+    }
+  });
+
+  it('covers all 11 OutcomeFailureCategory values', () => {
+    // Guards against the map silently going stale if a 12th routing
+    // category is added without extending FAILURE_CATEGORY_COARSENING.
+    expect(cases).toHaveLength(11);
+  });
+});
+
+describe('parseToolErrorEnvelope', () => {
+  it('extracts a valid envelope from structuredContent', () => {
+    const envelope = parseToolErrorEnvelope({
+      error: { errorCategory: 'business', isRetryable: false, message: 'dedup hit' },
+    });
+    expect(envelope).not.toBeNull();
+    expect(envelope?.errorCategory).toBe('business');
+  });
+
+  it('returns null for non-object input', () => {
+    expect(parseToolErrorEnvelope(null)).toBeNull();
+    expect(parseToolErrorEnvelope('error')).toBeNull();
+    expect(parseToolErrorEnvelope(undefined)).toBeNull();
+  });
+
+  it('returns null when the error key is missing', () => {
+    expect(parseToolErrorEnvelope({ notError: {} })).toBeNull();
+  });
+
+  it('returns null when the error payload is malformed', () => {
+    expect(parseToolErrorEnvelope({ error: { errorCategory: 'nope' } })).toBeNull();
+  });
+});
+
+describe('toolStructuredError', () => {
+  it('builds an error result with the envelope in structuredContent', () => {
+    const result = toolStructuredError({
+      errorCategory: 'validation',
+      message: 'bad url',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe('bad url');
+    const envelope = parseToolErrorEnvelope(result.structuredContent);
+    expect(envelope).toEqual({
+      errorCategory: 'validation',
+      isRetryable: false,
+      message: 'bad url',
+    });
+  });
+
+  it('derives isRetryable from the category when omitted', () => {
+    const result = toolStructuredError({ errorCategory: 'transient', message: 'blip' });
+    expect(parseToolErrorEnvelope(result.structuredContent)?.isRetryable).toBe(true);
+  });
+
+  it('honors an explicit isRetryable override', () => {
+    const result = toolStructuredError({
+      errorCategory: 'internal',
+      message: 'flaky downstream',
+      isRetryable: true,
+    });
+    expect(parseToolErrorEnvelope(result.structuredContent)?.isRetryable).toBe(true);
+  });
+
+  it('includes detail when provided and omits it otherwise', () => {
+    const withDetail = toolStructuredError({
+      errorCategory: 'business',
+      message: 'exists',
+      detail: { sourceId: 'abc' },
+    });
+    expect(parseToolErrorEnvelope(withDetail.structuredContent)?.detail).toEqual({
+      sourceId: 'abc',
+    });
+    const withoutDetail = toolStructuredError({ errorCategory: 'business', message: 'exists' });
+    expect(parseToolErrorEnvelope(withoutDetail.structuredContent)?.detail).toBeUndefined();
+  });
+});
+
+describe('toolError back-compat alias', () => {
+  it('maps legacy string errors to a non-retryable internal envelope', () => {
+    const result = toolError('something broke');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe('something broke');
+    expect(parseToolErrorEnvelope(result.structuredContent)).toEqual({
+      errorCategory: 'internal',
+      isRetryable: false,
+      message: 'something broke',
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/error-envelope.ts
+++ b/packages/nexus-agents/src/mcp/error-envelope.ts
@@ -1,0 +1,133 @@
+/**
+ * nexus-agents/mcp - Structured Tool Error Envelope
+ *
+ * Caller-facing error contract for MCP tools. Replaces the opaque
+ * `{ isError: true, content: [{ text }] }` string shape with a structured
+ * envelope so callers (other tools, voter panels, the Claude/Codex/Gemini/
+ * OpenCode harnesses) can reason about retry-safety and recovery path
+ * instead of string-matching arbitrary text.
+ *
+ * SCOPE — this envelope is caller-facing ONLY. The routing/circuit-breaker
+ * layer classifies adapter subprocess failures through its own
+ * `categorizeOutcomeError()` path (orchestration/outcomes/outcome-types.ts)
+ * and never reads this envelope. `coarsenFailureCategory()` is a one-way
+ * convenience for the rare tool that internally catches an
+ * `OutcomeFailureCategory`-classified error and wants to surface it to its
+ * caller — it is not, and must not become, a routing input. The two
+ * taxonomies serve different layers; this is the single authoritative
+ * projection between them.
+ *
+ * @module mcp/error-envelope
+ * @see Issue #2649
+ */
+
+import { z } from 'zod';
+import type { OutcomeFailureCategory } from '../orchestration/outcomes/outcome-types.js';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+/**
+ * Caller-facing error category. Deliberately coarser than the routing
+ * layer's 11-value `OutcomeFailureCategory` — a tool's caller only needs
+ * enough resolution to choose a recovery path:
+ *
+ * - `transient`  — network blip, rate limit, timeout. Retry is safe.
+ * - `validation` — input shape/values wrong. Caller must fix its args.
+ * - `permission` — auth / authorization / sandbox / access-policy denial.
+ * - `business`   — domain-logic refusal (dedup hit, precondition not met).
+ *                  An expected, non-bug outcome — not a failure to retry.
+ * - `internal`   — unexpected, bug-class. Not retry-class; escalate.
+ */
+export const ErrorCategorySchema = z.enum([
+  'transient',
+  'validation',
+  'permission',
+  'business',
+  'internal',
+]);
+
+export type ErrorCategory = z.infer<typeof ErrorCategorySchema>;
+
+/**
+ * Structured error envelope returned by MCP tools. Carried in the tool
+ * result's `structuredContent` under the `error` key; the human-readable
+ * `message` is also mirrored into `content[].text` for display.
+ */
+export const ToolErrorEnvelopeSchema = z.object({
+  errorCategory: ErrorCategorySchema,
+  /** Whether retrying the same call could succeed without caller changes. */
+  isRetryable: z.boolean(),
+  /** Human-readable summary. Bounded to keep stack traces out of results. */
+  message: z.string().min(1).max(2000),
+  /**
+   * Optional structured context. MUST NOT carry secrets, credentials,
+   * absolute filesystem paths, or raw Error/response objects — those are
+   * an information-disclosure risk (this field is not output-sanitized).
+   */
+  detail: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ToolErrorEnvelope = z.infer<typeof ToolErrorEnvelopeSchema>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Default retry-safety for a category. Only `transient` errors are
+ * retry-safe by default; callers can override per-call when a specific
+ * `internal` or `business` error is known to be retryable.
+ */
+export function defaultRetryable(category: ErrorCategory): boolean {
+  return category === 'transient';
+}
+
+/**
+ * The single authoritative projection from the routing layer's 11-value
+ * `OutcomeFailureCategory` down to the 5-value caller-facing
+ * `ErrorCategory`. A `Record` over every key — adding a 12th
+ * `OutcomeFailureCategory` value without extending this map is a compile
+ * error, which is the drift safeguard.
+ *
+ * One-way only: there is no `un-coarsen`, by design — the routing layer
+ * keeps its own granular classification and never round-trips through here.
+ */
+const FAILURE_CATEGORY_COARSENING: Record<OutcomeFailureCategory, ErrorCategory> = {
+  timeout: 'transient',
+  rate_limit: 'transient',
+  connection: 'transient',
+  authentication: 'permission',
+  validation: 'validation',
+  parse: 'validation',
+  crash: 'internal',
+  adapter_unavailable: 'internal',
+  execution: 'internal',
+  generic: 'internal',
+  unknown: 'internal',
+};
+
+/**
+ * Coarsen a routing-layer `OutcomeFailureCategory` to a caller-facing
+ * `ErrorCategory`. Use this only when a tool has caught an error already
+ * classified by the routing layer and wants to surface it in its envelope.
+ */
+export function coarsenFailureCategory(category: OutcomeFailureCategory): ErrorCategory {
+  return FAILURE_CATEGORY_COARSENING[category];
+}
+
+/**
+ * Extract and validate a `ToolErrorEnvelope` from a tool result's
+ * `structuredContent`. Returns `null` when the content is absent or does
+ * not carry a parseable envelope under the `error` key. Used by the
+ * `check:mcp-error-envelope` CI gate and by envelope-aware callers.
+ */
+export function parseToolErrorEnvelope(structuredContent: unknown): ToolErrorEnvelope | null {
+  if (structuredContent === null || typeof structuredContent !== 'object') {
+    return null;
+  }
+  const candidate = (structuredContent as Record<string, unknown>)['error'];
+  const result = ToolErrorEnvelopeSchema.safeParse(candidate);
+  return result.success ? result.data : null;
+}

--- a/packages/nexus-agents/src/mcp/tools/index.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.test.ts
@@ -266,9 +266,11 @@ describe('MCP tools index', () => {
       expect(result.isError).toBe(true);
     });
 
-    it('does not include structuredContent', () => {
+    it('carries a structured internal error envelope (#2649)', () => {
       const result = toolError('fail');
-      expect(result.structuredContent).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        error: { errorCategory: 'internal', isRetryable: false, message: 'fail' },
+      });
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/tool-result.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-result.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { toolError, toolSuccess, toolSuccessStructured } from './tool-result.js';
+import {
+  toolError,
+  toolSuccess,
+  toolSuccessStructured,
+  toolStructuredError,
+} from './tool-result.js';
 import type { ToolResult } from './tool-result.js';
+import { parseToolErrorEnvelope } from '../error-envelope.js';
 
 describe('tool-result helpers', () => {
   describe('toolSuccess', () => {
@@ -18,17 +24,36 @@ describe('tool-result helpers', () => {
   });
 
   describe('toolError', () => {
-    it('creates an error result with isError true', () => {
+    it('creates an error result carrying a structured internal envelope (#2649)', () => {
       const result: ToolResult = toolError('something failed');
-      expect(result).toEqual({
-        isError: true,
-        content: [{ type: 'text', text: 'something failed' }],
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: 'text', text: 'something failed' }]);
+      expect(parseToolErrorEnvelope(result.structuredContent)).toEqual({
+        errorCategory: 'internal',
+        isRetryable: false,
+        message: 'something failed',
       });
     });
 
     it('sets isError to true', () => {
       const result = toolError('err');
       expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('toolStructuredError', () => {
+    it('creates an error result with the requested category and derived retryability', () => {
+      const result: ToolResult = toolStructuredError({
+        errorCategory: 'transient',
+        message: 'rate limited',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: 'text', text: 'rate limited' }]);
+      expect(parseToolErrorEnvelope(result.structuredContent)).toEqual({
+        errorCategory: 'transient',
+        isRetryable: true,
+        message: 'rate limited',
+      });
     });
   });
 

--- a/packages/nexus-agents/src/mcp/tools/tool-result.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-result.ts
@@ -11,6 +11,7 @@
 import type { ILogger } from '../../core/index.js';
 import type { RateLimiter } from '../middleware/rate-limiter.js';
 import type { SecurityConfig } from '../../config/schemas.js';
+import { defaultRetryable, type ErrorCategory, type ToolErrorEnvelope } from '../error-envelope.js';
 
 // ============================================================================
 // Base Dependencies
@@ -99,21 +100,58 @@ export function toolSuccessStructured(data: Record<string, unknown>): ToolResult
 }
 
 /**
- * Creates an error tool result.
- *
- * @param message - The error message
- * @returns A ToolResult with isError set to true
+ * Input for {@link toolStructuredError}. `isRetryable` is optional — when
+ * omitted it is derived from the category via `defaultRetryable()`.
+ */
+export interface ToolStructuredErrorInput {
+  errorCategory: ErrorCategory;
+  message: string;
+  isRetryable?: boolean;
+  detail?: Record<string, unknown>;
+}
+
+/**
+ * Creates a structured error tool result (#2649). The envelope is carried
+ * in `structuredContent.error` so callers can reason about retry-safety
+ * and recovery path; `message` is mirrored into `content[].text` for
+ * display.
  *
  * @example
  * ```typescript
- * if (!input.ok) {
- *   return toolError(`Validation failed: ${input.error}`);
+ * if (!validated.success) {
+ *   return toolStructuredError({
+ *     errorCategory: 'validation',
+ *     message: `Validation error: ${formatZodError(validated.error)}`,
+ *   });
  * }
  * ```
  */
-export function toolError(message: string): ToolResult {
+export function toolStructuredError(input: ToolStructuredErrorInput): ToolResult {
+  const envelope: ToolErrorEnvelope = {
+    errorCategory: input.errorCategory,
+    isRetryable: input.isRetryable ?? defaultRetryable(input.errorCategory),
+    message: input.message,
+    ...(input.detail !== undefined ? { detail: input.detail } : {}),
+  };
   return {
     isError: true,
-    content: [{ type: 'text', text: message }],
+    content: [{ type: 'text', text: envelope.message }],
+    structuredContent: { error: envelope },
   };
+}
+
+/**
+ * Creates an error tool result.
+ *
+ * Back-compat alias for {@link toolStructuredError} — maps to the
+ * conservative `internal` / non-retryable envelope. New code should call
+ * `toolStructuredError` directly with the correct category; this alias
+ * exists so the ~64 legacy call sites keep working during the #2649
+ * migration sweep.
+ *
+ * @param message - The error message
+ * @returns A ToolResult with isError set to true and an `internal` envelope
+ */
+export function toolError(message: string): ToolResult {
+  return toolStructuredError({ errorCategory: 'internal', message });
 }


### PR DESCRIPTION
First child PR of [#2649](https://github.com/williamzujkowski/nexus-agents/issues/2649) (Epic A [#2651](https://github.com/williamzujkowski/nexus-agents/issues/2651)). **Helper-first** slice — ships the contract + helpers; per-tool migration follows in per-domain PRs.

## Why

MCP tool errors are currently opaque: `{ isError: true, content: [{ text: '<arbitrary string>' }] }`. Callers (other tools, voter panels, the Claude/Codex/Gemini/OpenCode harnesses) can't tell *should I retry?*, *what category?*, or *is this customer-readable?* — they string-match. This PR lands the structured contract.

## What changed

**New `src/mcp/error-envelope.ts`:**
- `ErrorCategorySchema` — caller-facing 5-value enum: `transient | validation | permission | business | internal`. Deliberately **coarser** than the routing layer's 11-value `OutcomeFailureCategory` — different layer, different audience.
- `ToolErrorEnvelopeSchema` — `{ errorCategory, isRetryable, message (1..2000), detail? }`.
- `defaultRetryable()` — `transient` is retry-safe by default; others aren't.
- `coarsenFailureCategory()` — the **single authoritative one-way projection** from `OutcomeFailureCategory` → `ErrorCategory`. A `Record` over all 11 keys, so adding a 12th routing category without extending the map is a compile error (drift safeguard).
- `parseToolErrorEnvelope()` — extract/validate the envelope from `structuredContent.error`; used by callers and the upcoming CI gate.

**`tool-result.ts`:**
- `toolStructuredError()` — builds an `isError` result with the envelope in `structuredContent.error`, `message` mirrored into `content[].text`. The MCP SDK skips `outputSchema` validation on `isError` results (`mcp.js:193`), so this does **not** collide with tools' success schemas.
- `toolError(msg)` → back-compat alias mapping to a non-retryable `internal` envelope. Keeps the ~64 legacy call sites working through the migration sweep.

**`.rules/mcp.md`** — documents the contract, the category taxonomy, the **caller-facing-only scope** (the routing layer keeps its own classification and never reads this envelope), and the `detail`-is-not-output-sanitized constraint.

## Design provenance

Approved by `consensus_vote` (`higher_order`, 4 approve / 1 contrarian; 2 voters hit the known MCP `-32001` client timeout). The contrarian raised two valid catches, both incorporated here:
1. A `permission` vs `business` wording contradiction in the original proposal — resolved: `permission` = access-control denial, `business` = domain-logic refusal.
2. The need to state **caller-facing-only** scope explicitly so there's no implied fidelity loss in the routing layer — now documented in `error-envelope.ts` and `.rules/mcp.md`.

## Out of scope (tracked, follows in this epic)

- Per-tool migration of the ~64 `toolError` call sites → per-domain PRs (orchestration / research / voting / memory+observability+repo).
- CI gate `check:mcp-error-envelope` → lands with the **final** migration PR, when all 38 tools are compliant.
- `secure-handler.ts`'s 3 ad-hoc error builders → folded into the envelope in the final PR.
- First behavioral consumer of `isRetryable` → Epic B territory; will be tracked as its own issue.

## Verification

- `pnpm typecheck` clean.
- `pnpm eslint` clean on all touched files.
- New `error-envelope.test.ts` — 19 tests (schema, `defaultRetryable`, all 11 `coarsenFailureCategory` mappings, `parseToolErrorEnvelope`, `toolStructuredError`, `toolError` alias).
- Full `src/mcp` suite: 2992/2992 pass. Downstream test updates: `tool-result.test.ts` + `index.test.ts` adjusted for `toolError` now carrying an envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)