### PR TITLE
feat(mcp): migrate research-domain tools to structured error envelope (#2649)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/compare-data-feeds.ts
+++ b/packages/nexus-agents/src/mcp/tools/compare-data-feeds.ts
@@ -30,7 +30,7 @@ import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middlewar
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -326,7 +326,10 @@ function createCompareDataFeedsHandler(deps: CompareDataFeedsDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validation = CompareDataFeedsInputSchema.safeParse(args);
     if (!validation.success) {
-      return toolError(`Validation error: ${formatZodError(validation.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validation.error)}`,
+      });
     }
     const logger = deps.logger ?? createLogger({ tool: 'compare_data_feeds' });
     ctx.logger.debug('Comparing data feeds', {

--- a/packages/nexus-agents/src/mcp/tools/research-add-source.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add-source.ts
@@ -25,11 +25,12 @@ import {
 import { computeSourceQualityScore } from '../../research/source-quality.js';
 import type { ResearchSource } from '../../indexer/research-index/research-index-base-types.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
 } from './tool-result.js';
+import type { ErrorCategory } from '../error-envelope.js';
 import { getToolMemory } from './tool-memory.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
@@ -89,6 +90,12 @@ export interface ResearchAddSourceResponse {
   evidence_tier: string;
   message: string;
   dryRun: boolean;
+  /**
+   * Error category when `success` is false (#2649). `business` for a
+   * dedup hit (source already in registry), `internal` for a write
+   * failure; absent otherwise.
+   */
+  errorCategory?: ErrorCategory;
 }
 
 // =============================================================================
@@ -147,6 +154,7 @@ interface ResponseParams {
   qualityScore: number;
   message: string;
   dryRun: boolean;
+  errorCategory?: ErrorCategory;
 }
 
 /** Build a standard response object. */
@@ -159,6 +167,7 @@ function buildResponse(params: ResponseParams): ResearchAddSourceResponse {
     evidence_tier: deriveEvidenceTier(params.qualityScore),
     message: params.message,
     dryRun: params.dryRun,
+    ...(params.errorCategory !== undefined ? { errorCategory: params.errorCategory } : {}),
   };
 }
 
@@ -190,6 +199,7 @@ function prepareSource(input: ResearchAddSourceInput): { entry: SourceEntry; sco
   return { entry, score };
 }
 
+// eslint-disable-next-line max-lines-per-function -- cohesive exists→build→write→record sequence; +2 lines for #2649 errorCategory tags tipped it past 50.
 async function executeResearchAddSource(
   input: ResearchAddSourceInput,
   logger: ILogger
@@ -204,6 +214,7 @@ async function executeResearchAddSource(
       qualityScore: 0,
       message: `Source already exists: ${input.url}`,
       dryRun: input.dryRun,
+      errorCategory: 'business',
     });
   }
 
@@ -228,6 +239,7 @@ async function executeResearchAddSource(
       qualityScore: score,
       message: writeResult.error.message,
       dryRun: false,
+      errorCategory: 'internal',
     });
   }
 
@@ -251,7 +263,10 @@ function createResearchAddSourceHandler(deps: ResearchAddSourceDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchAddSourceInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Adding research source', { url: validationResult.data.url });
@@ -261,7 +276,10 @@ function createResearchAddSourceHandler(deps: ResearchAddSourceDeps) {
       const result = await executeResearchAddSource(validationResult.data, logger);
 
       if (!result.success) {
-        return toolError(result.message);
+        return toolStructuredError({
+          errorCategory: result.errorCategory ?? 'internal',
+          message: result.message,
+        });
       }
 
       return toolSuccessStructured(result as unknown as Record<string, unknown>);

--- a/packages/nexus-agents/src/mcp/tools/research-add.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add.ts
@@ -18,11 +18,12 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
 import { withToolError } from '../middleware/tool-error-handler.js';
 import { addResearchPaper, paperExists } from '../../cli/research-helpers.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
 } from './tool-result.js';
+import type { ErrorCategory } from '../error-envelope.js';
 import { getToolMemory } from './tool-memory.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
@@ -79,6 +80,12 @@ export interface ResearchAddResponse {
   message: string;
   /** Whether this was a dry run */
   dryRun: boolean;
+  /**
+   * Error category when `success` is false (#2649). `business` for a
+   * dedup hit (paper already in registry); absent otherwise — the MCP
+   * handler treats absent as `internal`.
+   */
+  errorCategory?: ErrorCategory;
 }
 
 // =============================================================================
@@ -112,6 +119,7 @@ export async function executeResearchAdd(
       title: '',
       message: `Paper arxiv-${input.arxivId} already exists in registry`,
       dryRun: input.dryRun,
+      errorCategory: 'business',
     };
   }
 
@@ -163,7 +171,10 @@ function createResearchAddHandler(deps: ResearchAddDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchAddInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Adding research paper', { arxivId: validationResult.data.arxivId });
@@ -173,7 +184,10 @@ function createResearchAddHandler(deps: ResearchAddDeps) {
       const result = await executeResearchAdd(validationResult.data, logger);
 
       if (!result.success) {
-        return toolError(result.message);
+        return toolStructuredError({
+          errorCategory: result.errorCategory ?? 'internal',
+          message: result.message,
+        });
       }
 
       return toolSuccessStructured(result as unknown as Record<string, unknown>);

--- a/packages/nexus-agents/src/mcp/tools/research-analyze.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-analyze.ts
@@ -13,7 +13,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -392,7 +392,10 @@ function createResearchAnalyzeHandler(deps: ResearchAnalyzeDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchAnalyzeInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Analyzing research registry', {

--- a/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
@@ -14,7 +14,7 @@ import type { ILogger } from '../../core/index.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -236,7 +236,10 @@ function createCatalogReviewHandler(deps: ResearchCatalogReviewDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchCatalogReviewInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Catalog review', { action: validationResult.data.action });
@@ -246,7 +249,9 @@ function createCatalogReviewHandler(deps: ResearchCatalogReviewDeps) {
       const result = await executeCatalogReview(validationResult.data, logger);
 
       if (!result.success) {
-        return toolError(result.message);
+        // Every catalog-review failure path is a missing/not-found
+        // identifier — the caller must fix its args.
+        return toolStructuredError({ errorCategory: 'validation', message: result.message });
       }
 
       return toolSuccessStructured(result as unknown as Record<string, unknown>);

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -22,7 +22,7 @@ import {
 import { normalizeTopicToCanonical } from '../../research/topic-aliases.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -568,7 +568,10 @@ function createResearchDiscoverHandler(deps: ResearchDiscoverDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchDiscoverInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Discovering research', {

--- a/packages/nexus-agents/src/mcp/tools/research-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-query.ts
@@ -13,7 +13,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { withToolError } from '../middleware/tool-error-handler.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -200,7 +200,10 @@ function createResearchQueryHandler(deps: ResearchQueryDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchQueryInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     ctx.logger.debug('Executing research query', { action: validationResult.data.action });

--- a/packages/nexus-agents/src/mcp/tools/research-synthesize.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-synthesize.ts
@@ -19,7 +19,7 @@ import { synthesizeResearch } from '../../cli/research-helpers-synthesize.js';
 import type { SynthesisResult } from '../../cli/research-helpers-synthesize.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -63,14 +63,20 @@ function createResearchSynthesizeHandler(
   return async (args: unknown, _ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = ResearchSynthesizeInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     const logger = deps.logger ?? createLogger({ tool: 'research_synthesize' });
     return withToolError('Synthesis failed', logger, async () => {
       const result = await synthesizeResearch(validationResult.data.topic);
       if (!result.ok) {
-        return toolError(`Synthesis failed: ${result.error.message}`);
+        return toolStructuredError({
+          errorCategory: 'internal',
+          message: `Synthesis failed: ${result.error.message}`,
+        });
       }
       return toolSuccessStructured(result.value as unknown as Record<string, unknown>);
     });

--- a/packages/nexus-agents/src/mcp/tools/survey-oss-landscape.ts
+++ b/packages/nexus-agents/src/mcp/tools/survey-oss-landscape.ts
@@ -37,7 +37,7 @@ import { fetchSource, type DiscoverError } from '../../cli/research-helpers-sour
 import { resolveToken } from '../../scm/token-resolver.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -267,7 +267,10 @@ function createSurveyHandler(deps: SurveyOssLandscapeDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validation = SurveyOssLandscapeInputSchema.safeParse(args);
     if (!validation.success) {
-      return toolError(`Validation error: ${formatZodError(validation.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validation.error)}`,
+      });
     }
     const logger = deps.logger ?? createLogger({ tool: 'survey_oss_landscape' });
     ctx.logger.debug('Surveying OSS landscape', {

--- a/packages/nexus-agents/src/mcp/tools/vendor-publishing-audit.ts
+++ b/packages/nexus-agents/src/mcp/tools/vendor-publishing-audit.ts
@@ -29,7 +29,7 @@ import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middlewar
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -91,7 +91,10 @@ function createVendorPublishingAuditHandler(deps: VendorPublishingAuditDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validation = VendorPublishingAuditInputSchema.safeParse(args);
     if (!validation.success) {
-      return toolError(`Validation error: ${formatZodError(validation.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validation.error)}`,
+      });
     }
     const logger = deps.logger ?? createLogger({ tool: 'vendor_publishing_audit' });
     ctx.logger.debug('Vendor publishing audit', { vendor: validation.data.vendor });


### PR DESCRIPTION
Per-domain migration PR for [#2649](https://github.com/williamzujkowski/nexus-agents/issues/2649) (Epic A [#2651](https://github.com/williamzujkowski/nexus-agents/issues/2651)). Follows #2671 (helper) and #2672 (orchestration). Migrates the **research & data** tool domain.

## What changed

Replaces direct `toolError(msg)` returns with `toolStructuredError({ errorCategory, message })`. **10 files, 14 call sites.**

| File(s) | Category judgments |
|---------|--------------------|
| `research-query`, `research-discover`, `research-analyze`, `research-synthesize`, `survey-oss-landscape`, `vendor-publishing-audit`, `compare-data-feeds` | Zod input failure → `validation` |
| `research-synthesize` | synthesis operation failure → `internal` |
| `research-catalog-review` | Zod input → `validation`; every `executeCatalogReview` failure path (missing / not-found identifier) → `validation` |
| `research-add`, `research-add-source` | Zod input → `validation`; **dedup hit → `business`**, write failure → `internal` |

## The `business` category — threading

`research-add` and `research-add-source` are the canonical `business`-category case from the issue: adding a paper/source that's *already in the registry* is a domain-logic refusal, not a bug. To surface that accurately, both thread an optional `errorCategory` through their response types (`ResearchAddResponse` / `ResearchAddSourceResponse`):

- dedup hit (`"already exists in registry"`) → `errorCategory: 'business'`
- write failure → `errorCategory: 'internal'`
- the MCP handler defaults a missing category to `internal`

This is the "migration is not purely mechanical" work the design vote called out — a contained, per-file change to two response types.

`executeResearchAddSource` tipped to 51 lines from the two `errorCategory` tags — given a targeted `eslint-disable` with rationale, same pattern as the #2648 registration functions.

## Behavior

`content[].text` and `isError` unchanged at every site. The change is the added `structuredContent.error` envelope and more accurate categories (`validation` / `business`) than the previous implicit `internal`.

## Verification

- `pnpm typecheck` + `pnpm eslint` clean.
- 121/121 research-domain tool tests pass (10 test files).

## Epic A #2649 progress

- [x] Helper-first contract (#2671)
- [x] Orchestration domain (#2672)
- [x] **Research domain (this PR)**
- [ ] Voting & review domain
- [ ] Memory / observability / repo domain + `secure-handler.ts` refactor + `check:mcp-error-envelope` CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)