### PR TITLE
feat(mcp): migrate voting/review-domain tools to structured error envelope (#2649)

### DIFF
--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -22,7 +22,12 @@ import {
   getToolTimeout,
 } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
-import { toolError, toolSuccess, type ToolResult, type BaseMcpToolDeps } from './tool-result.js';
+import {
+  toolStructuredError,
+  toolSuccess,
+  type ToolResult,
+  type BaseMcpToolDeps,
+} from './tool-result.js';
 import type { ConsensusAlgorithm, Vote, ConsensusResult, Proposal } from '../../consensus/types.js';
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
@@ -610,7 +615,10 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ConsensusVoteToolResponse> => {
     const validationResult = ConsensusVoteInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     const strategy = validationResult.data.strategy ?? 'simple_majority';
@@ -628,7 +636,7 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
       handleConsensusVote(deps, validationResult.data)
     );
     if (!result.ok) {
-      return toolError(result.error);
+      return toolStructuredError({ errorCategory: 'internal', message: result.error });
     }
 
     for (const vote of result.value.votes) {

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -24,7 +24,7 @@ import { createLogger, formatZodError } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
-  toolError,
+  toolStructuredError,
   toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
@@ -454,7 +454,10 @@ export async function runImprovementReview(
 async function reviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
   const parsed = ImprovementReviewInputSchema.safeParse(args);
   if (!parsed.success) {
-    return toolError(`Validation error: ${formatZodError(parsed.error)}`);
+    return toolStructuredError({
+      errorCategory: 'validation',
+      message: `Validation error: ${formatZodError(parsed.error)}`,
+    });
   }
   const response = await runImprovementReview(parsed.data, { logger: ctx.logger });
   return toolSuccessStructured(response as unknown as Record<string, unknown>);

--- a/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
@@ -16,7 +16,12 @@ import {
   getTimeProvider,
   getRandomProvider,
 } from '../../core/index.js';
-import { toolError, toolSuccess, type BaseMcpToolDeps, type ToolResult } from './tool-result.js';
+import {
+  toolStructuredError,
+  toolSuccess,
+  type BaseMcpToolDeps,
+  type ToolResult,
+} from './tool-result.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { IssueTriage } from '../../dogfooding/issue-triage.js';
@@ -103,7 +108,10 @@ function createIssueTriageHandler(_deps: IssueTriageDeps) {
   return async (args: unknown, ctx: HandlerContext): Promise<ToolResult> => {
     const validationResult = IssueTriageInputSchema.safeParse(args);
     if (!validationResult.success) {
-      return toolError(`Validation error: ${formatZodError(validationResult.error)}`);
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(validationResult.error)}`,
+      });
     }
 
     const input = validationResult.data;
@@ -116,7 +124,10 @@ function createIssueTriageHandler(_deps: IssueTriageDeps) {
 
     if (!result.ok) {
       recordTriageOutcome(false, durationMs, result.error.message);
-      return toolError(`Triage failed: ${result.error.message}`);
+      return toolStructuredError({
+        errorCategory: 'internal',
+        message: `Triage failed: ${result.error.message}`,
+      });
     }
 
     recordTriageSuccess(result.value.category, result.value.categoryConfidence, durationMs);

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -20,7 +20,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError, getErrorMessage } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
-import { toolError, toolSuccess, type BaseMcpToolDeps, type ToolResult } from './tool-result.js';
+import {
+  toolStructuredError,
+  toolSuccess,
+  type BaseMcpToolDeps,
+  type ToolResult,
+} from './tool-result.js';
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { getToolAnnotations } from '../tool-annotations.js';
@@ -296,7 +301,10 @@ function summarizeReviews(reviews: readonly PrReviewVote[]): {
 async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
   const parsed = PrReviewInputSchema.safeParse(args);
   if (!parsed.success) {
-    return toolError(`Validation error: ${formatZodError(parsed.error)}`);
+    return toolStructuredError({
+      errorCategory: 'validation',
+      message: `Validation error: ${formatZodError(parsed.error)}`,
+    });
   }
   const input = parsed.data;
   const start = Date.now();
@@ -323,7 +331,10 @@ async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<Tool
     };
     return toolSuccess(JSON.stringify(response, null, 2));
   } catch (error) {
-    return toolError(`PR review failed: ${getErrorMessage(error)}`);
+    return toolStructuredError({
+      errorCategory: 'internal',
+      message: `PR review failed: ${getErrorMessage(error)}`,
+    });
   }
 }
 

--- a/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.ts
+++ b/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.ts
@@ -21,7 +21,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError, getErrorMessage } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
-import { toolError, toolSuccess, type BaseMcpToolDeps, type ToolResult } from './tool-result.js';
+import {
+  toolStructuredError,
+  toolSuccess,
+  type BaseMcpToolDeps,
+  type ToolResult,
+} from './tool-result.js';
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { getToolAnnotations } from '../tool-annotations.js';
@@ -356,7 +361,10 @@ function toPanelVote(result: AgentVoteResult, axes: readonly string[]): PanelVot
 async function tradeoffPanelHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
   const parsed = SupplyChainTradeoffPanelInputSchema.safeParse(args);
   if (!parsed.success) {
-    return toolError(`Validation error: ${formatZodError(parsed.error)}`);
+    return toolStructuredError({
+      errorCategory: 'validation',
+      message: `Validation error: ${formatZodError(parsed.error)}`,
+    });
   }
   const input = parsed.data;
   const axes = input.axes ?? DEFAULT_AXES;
@@ -390,7 +398,10 @@ async function tradeoffPanelHandler(args: unknown, ctx: HandlerContext): Promise
     };
     return toolSuccess(JSON.stringify(response, null, 2));
   } catch (error) {
-    return toolError(`Tradeoff panel failed: ${getErrorMessage(error)}`);
+    return toolStructuredError({
+      errorCategory: 'internal',
+      message: `Tradeoff panel failed: ${getErrorMessage(error)}`,
+    });
   }
 }
 


### PR DESCRIPTION
Per-domain migration PR for [#2649](https://github.com/williamzujkowski/nexus-agents/issues/2649) (Epic A [#2651](https://github.com/williamzujkowski/nexus-agents/issues/2651)). Follows #2671, #2672, #2673. Migrates the **voting & review** tool domain.

## What changed

Replaces direct `toolError(msg)` returns with `toolStructuredError({ errorCategory, message })`. **5 files, 9 call sites.**

| File | Category judgments |
|------|--------------------|
| `consensus-vote` | Zod input → `validation`; vote-orchestration failure (`handleConsensusVote` `!ok`) → `internal` |
| `pr-review-tool` | Zod input → `validation`; caught exception → `internal` |
| `supply-chain-tradeoff-panel` | Zod input → `validation`; caught exception → `internal` |
| `improvement-review` | Zod input → `validation` |
| `issue-triage-tool` | Zod input → `validation`; triage operation failure → `internal` |

## Behavior

`content[].text` and `isError` unchanged at every site. The change is the added `structuredContent.error` envelope and, for the Zod sites, a more accurate `validation` category than the previous implicit `internal`.

## Verification

- `pnpm typecheck` + `pnpm eslint` clean.
- 181/181 voting/review-domain tool tests pass (7 test files).

## Epic A #2649 progress

- [x] Helper-first contract (#2671)
- [x] Orchestration domain (#2672)
- [x] Research domain (#2673)
- [x] **Voting & review domain (this PR)**
- [ ] Memory / observability / repo domain + `secure-handler.ts` refactor + `check:mcp-error-envelope` CI gate (final PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)