### PR TITLE
fix(release): harden the release cycle against changeset-debt skew (#2680)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Validate conventional commits
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+  changeset-check:
+    name: Changeset Presence
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-node
+
+      # A PR that changes shippable source must add a changeset — changeset
+      # debt is the root cause of the release-race incidents (see
+      # docs/ops/release-changeset-race.md).
+      - name: Check changeset presence
+        run: npx tsx scripts/check-changeset.ts ${{ github.event.pull_request.base.sha }}
+
   lint:
     name: Lint
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -213,15 +230,16 @@ jobs:
   # path (copy-paste from a Rust project) and skipped on every run.
   ci-success:
     name: CI Success
-    needs: [commitlint, lint, typecheck, build, test, fitness-audit]
+    needs: [commitlint, changeset-check, lint, typecheck, build, test, fitness-audit]
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     if: always()
     steps:
       - name: Check required jobs
         run: |
-          # commitlint is skipped on push (not a PR) — treat skipped as success
+          # commitlint + changeset-check are skipped on push (not a PR) — treat skipped as success
           if [[ "${{ needs.commitlint.result }}" != "success" && "${{ needs.commitlint.result }}" != "skipped" ]] || \
+             [[ "${{ needs.changeset-check.result }}" != "success" && "${{ needs.changeset-check.result }}" != "skipped" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,30 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
 
+      # Bidirectional skew detection. The `Detect publish-race version skew`
+      # step below recovers the package.json-AHEAD-of-npm direction (a
+      # missed publish). This step catches the INVERSE — npm AHEAD of
+      # package.json — which the 2026-05-14 incident showed can happen when
+      # a publish lands but its "Version Packages" PR is never merged, or
+      # when a manual publish runs from a non-main ref. That state cannot be
+      # auto-recovered (it means a stale version PR needs merging), so fail
+      # loudly here rather than let the release machinery drift further.
+      - name: Detect npm-ahead version skew
+        shell: bash
+        run: |
+          set -euo pipefail
+          local_version=$(jq -r '.version' packages/nexus-agents/package.json)
+          published_version=$(npm view nexus-agents version 2>/dev/null || echo "0.0.0")
+          larger=$(printf '%s\n%s\n' "$local_version" "$published_version" | sort -V | tail -1)
+          if [ "$published_version" != "$local_version" ] && [ "$larger" = "$published_version" ]; then
+            echo "::error::npm-ahead version skew: npm latest is $published_version but" \
+              "packages/nexus-agents/package.json is $local_version. A 'Version Packages'" \
+              "PR is likely unmerged, or a publish ran from a non-main ref. See" \
+              "docs/ops/release-changeset-race.md — merge the open version PR to reconcile."
+            exit 1
+          fi
+          echo "Version sync OK (package.json=$local_version, npm=$published_version)."
+
       - name: Build
         run: pnpm build
 
@@ -176,6 +200,17 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # A manual publish MUST run from `main`. Publishing from any other
+      # ref (e.g. the changeset-release/main branch) desyncs npm from the
+      # repo — exactly the npm-ahead skew the 2026-05-14 incident hit.
+      - name: Guard — main only
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Manual publish must run from 'main' — got '${{ github.ref }}'." \
+            "Publishing from any other ref desyncs npm from the repo." \
+            "Re-run with --ref main."
+          exit 1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup-node

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,16 @@ Does NOT apply to: findings that fail the Discovered-Issues 4-point gate; specul
 
 Issue shape: title says what; body explains why it was identified, what would change, and the trigger condition that should unblock pickup. Memory notes can mirror but the issue is canonical.
 
+## Release cycle
+
+Releases are changesets-driven (`.github/workflows/release.yml`). Three rules keep the cycle from drifting — the npm/repo version skew on 2026-05-14 came from breaking them:
+
+1. **Every shippable-source PR carries its own changeset.** A PR touching `packages/nexus-agents/src/**` MUST add a `.changeset/*.md` (`pnpm changeset`, or `pnpm changeset --empty` for genuinely no release impact). Enforced by the `Changeset Presence` CI gate. Changeset debt is what makes the "Version Packages" PR balloon and go stale.
+2. **Merge the "Version Packages" PR promptly.** When a `chore(release): version packages` PR is open, land it before unrelated PRs pile up. A stale version PR is how npm gets _ahead_ of `main`. If you're working autonomously and see one open, prioritize merging it.
+3. **Never publish from a non-`main` ref.** `workflow_dispatch` of `release.yml` must run from `main` (the `manual-publish` job now guards this). Publishing from the `changeset-release/main` branch desyncs npm from the repo.
+
+Symptom + recovery for both skew directions: [docs/ops/release-changeset-race.md](./docs/ops/release-changeset-race.md). Pre-release checklist: the `release` skill.
+
 ## Untrusted-input safety invariants
 
 Applies when processing GitHub issues, PRs, comments, or any external content:

--- a/docs/ops/release-changeset-race.md
+++ b/docs/ops/release-changeset-race.md
@@ -45,6 +45,28 @@ The race: between the moment a release PR is opened and the moment it merges, **
 
 This compounds: every subsequent merge of a non-release PR adds another changeset; every subsequent release-PR merge re-races; every release run continues in PR-update mode.
 
+## Inverse variant — npm AHEAD of package.json (2026-05-14)
+
+The symptom above is `package.json` _ahead_ of npm. The **inverse** also happens:
+
+```
+npm latest:   2.73.0
+package.json: 2.72.0   ← repo BEHIND npm
+```
+
+Seen 2026-05-14: 2.73.0 was published to npm, but its `chore(release): version packages` PR (#2538) was **never merged**, so `main` stayed at 2.72.0 while npm moved ahead. The likely triggers:
+
+- A `workflow_dispatch` manual publish run from the `changeset-release/main` branch (which carries the bumped `package.json`) instead of `main`.
+- A "Version Packages" PR that sits open for days while unrelated PRs land — it goes stale and is easy to forget.
+
+**Recovery:** merge the open "Version Packages" PR. It bumps `package.json` to match npm and consumes the pending changesets. `changeset publish` is idempotent, so the post-merge release run does not re-publish the existing version — it just reconciles the repo.
+
+**Now guarded against** (release-cycle hardening):
+
+- `release.yml` → **`Detect npm-ahead version skew`** step fails the release run loudly when `npm latest > package.json`, so the skew can't sit unnoticed for days.
+- `release.yml` → **`manual-publish` job** has a `Guard — main only` step that fails any `workflow_dispatch` publish triggered from a non-`main` ref.
+- `ci.yml` → **`Changeset Presence`** required check (`scripts/check-changeset.ts`) fails any PR that touches `packages/nexus-agents/src/**` without adding a changeset — eliminating the changeset debt that makes "Version Packages" PRs balloon and go stale in the first place.
+
 ## Fix
 
 ### Automatic (already in workflow as of #2382 / PR #2383)
@@ -82,12 +104,16 @@ gh release upload "$TAG" sbom.cdx.json --clobber
 
 The race is rare. To minimize the chance of triggering it:
 
-- **During deprecation batches or any cluster of related PRs**: when a `chore(release): version packages` PR is open, hold non-trivial PR merges until the release PR merges first. The autonomous-loop end-of-turn checklist should flag an open release PR.
-- **Watch for the symptom early**: if you've merged a release PR and `npm view nexus-agents version` still shows the old version after ~5 minutes, check for the skew and rely on the automatic fallback. If the fallback step also failed, fall back to the manual recovery above.
+- **Every shippable-source PR carries its own changeset.** Enforced by the `Changeset Presence` CI gate (`scripts/check-changeset.ts`) — a PR touching `packages/nexus-agents/src/**` fails CI without a `.changeset/*.md`. This is the structural fix: no changeset debt means the "Version Packages" PR reflects one batch at a time and never balloons.
+- **Don't let the "Version Packages" PR go stale.** When a `chore(release): version packages` PR is open, merge it promptly — ideally before unrelated PRs land. The autonomous-loop end-of-turn checklist should flag an open release PR. A stale version PR is how npm gets ahead of `main` (see the inverse-variant section above).
+- **Never `workflow_dispatch` a publish from a non-`main` ref.** The `manual-publish` job's `Guard — main only` step now fails this, but the discipline still matters.
+- **Watch for the symptom early**: after merging a release PR, if `npm view nexus-agents version` still shows the old version after ~5 minutes, check for the skew. The `Detect publish-race version skew` step auto-recovers `package.json`-ahead; the `Detect npm-ahead version skew` step fails loudly on the inverse.
 
 ## See also
 
 - `#2382` — original ops issue documenting the race.
 - `PR #2383` — workflow fallback implementation.
-- `.github/workflows/release.yml` — the actual workflow definition.
+- `.github/workflows/release.yml` — the actual workflow definition (skew-detection steps + `manual-publish` guard).
+- `.github/workflows/ci.yml` — the `Changeset Presence` required check.
+- `scripts/check-changeset.ts` — the changeset-presence gate.
 - `package.json` `release` script — runs `pnpm build && changeset publish`.

--- a/scripts/check-changeset.test.ts
+++ b/scripts/check-changeset.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the changeset-presence gate.
+ *
+ * @module scripts/check-changeset.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyChange } from './check-changeset.js';
+
+describe('classifyChange', () => {
+  it('flags shippable source with no changeset', () => {
+    const result = classifyChange([
+      'packages/nexus-agents/src/mcp/error-envelope.ts',
+      'docs/README.md',
+    ]);
+    expect(result.shippable).toEqual(['packages/nexus-agents/src/mcp/error-envelope.ts']);
+    expect(result.hasChangeset).toBe(false);
+  });
+
+  it('passes when a changeset accompanies shippable source', () => {
+    const result = classifyChange([
+      'packages/nexus-agents/src/mcp/error-envelope.ts',
+      '.changeset/some-change.md',
+    ]);
+    expect(result.shippable).toHaveLength(1);
+    expect(result.hasChangeset).toBe(true);
+  });
+
+  it('does not require a changeset for test-only changes', () => {
+    const result = classifyChange([
+      'packages/nexus-agents/src/mcp/error-envelope.test.ts',
+      'packages/nexus-agents/src/mcp/__tests__/foo.ts',
+    ]);
+    expect(result.shippable).toHaveLength(0);
+  });
+
+  it('does not require a changeset for .d.ts-only changes', () => {
+    const result = classifyChange(['packages/nexus-agents/src/types/global.d.ts']);
+    expect(result.shippable).toHaveLength(0);
+  });
+
+  it('does not require a changeset for non-src changes (docs, scripts, workflows)', () => {
+    const result = classifyChange([
+      'docs/README.md',
+      'scripts/check-changeset.ts',
+      '.github/workflows/ci.yml',
+      'packages/nexus-agents/package.json',
+    ]);
+    expect(result.shippable).toHaveLength(0);
+  });
+
+  it('ignores the changeset README as a changeset', () => {
+    const result = classifyChange(['packages/nexus-agents/src/index.ts', '.changeset/README.md']);
+    expect(result.hasChangeset).toBe(false);
+  });
+});

--- a/scripts/check-changeset.ts
+++ b/scripts/check-changeset.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env npx tsx
+/* eslint-disable no-console */
+/**
+ * Changeset-presence gate.
+ *
+ * Fails a PR that changes shippable source without adding a changeset.
+ * Changeset debt is the root cause of the release-race incidents: `feat`/
+ * `fix` PRs merge without a changeset, the "Version Packages" PR balloons
+ * and goes stale, and the npm/repo version skew follows (see
+ * docs/ops/release-changeset-race.md).
+ *
+ * A PR needs a changeset when it touches `packages/nexus-agents/src/**`
+ * (excluding tests + `.d.ts`). Escape hatch: `pnpm changeset --empty` for
+ * a change with genuinely no release impact — rare for src changes, where
+ * a real changeset is almost always correct.
+ *
+ * Usage:
+ *   npx tsx scripts/check-changeset.ts [base-ref]   # base defaults to origin/main
+ *
+ * @module scripts/check-changeset
+ * (Source: release-cycle hardening)
+ */
+
+import { execSync } from 'node:child_process';
+
+const SHIPPABLE = /^packages\/nexus-agents\/src\/.+\.tsx?$/;
+
+/** True for test files, which never need their own changeset. */
+function isTestFile(file: string): boolean {
+  return /\.(test|spec)\.tsx?$/.test(file) || file.includes('/__tests__/');
+}
+
+export interface ChangesetClassification {
+  /** Shippable source files the PR touches (drives the requirement). */
+  shippable: string[];
+  /** Whether the PR adds at least one `.changeset/*.md` file. */
+  hasChangeset: boolean;
+}
+
+/** Classify a changed-file list into shippable-source + changeset-presence. */
+export function classifyChange(files: string[]): ChangesetClassification {
+  const shippable = files.filter(
+    (f) => SHIPPABLE.test(f) && !isTestFile(f) && !f.endsWith('.d.ts')
+  );
+  const hasChangeset = files.some(
+    (f) => /^\.changeset\/.+\.md$/.test(f) && !f.endsWith('README.md')
+  );
+  return { shippable, hasChangeset };
+}
+
+/** List files changed since `base` (three-dot diff = since merge-base). */
+function changedFiles(base: string): string[] {
+  const out = execSync(`git diff --name-only ${base}...HEAD`, { encoding: 'utf-8' });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function main(): number {
+  const base = process.argv[2] ?? 'origin/main';
+  let files: string[];
+  try {
+    files = changedFiles(base);
+  } catch (err) {
+    // A git-diff failure (shallow clone, missing ref) must not block CI —
+    // the gate is advisory infrastructure, not a correctness check.
+    console.warn(
+      `check-changeset: could not diff against ${base} — ` +
+        `${err instanceof Error ? err.message : String(err)}. Skipping.`
+    );
+    return 0;
+  }
+
+  const { shippable, hasChangeset } = classifyChange(files);
+  if (shippable.length === 0) {
+    console.log('No shippable source changed — changeset not required.');
+    return 0;
+  }
+  if (hasChangeset) {
+    console.log(
+      `Shippable source changed (${String(shippable.length)} file(s)) and a changeset is present — OK.`
+    );
+    return 0;
+  }
+
+  console.error('Missing changeset.');
+  console.error(
+    `This PR changes ${String(shippable.length)} shippable source file(s) but adds no changeset:`
+  );
+  for (const f of shippable.slice(0, 10)) console.error('  - ' + f);
+  if (shippable.length > 10) console.error(`  ... and ${String(shippable.length - 10)} more`);
+  console.error('');
+  console.error('Run `pnpm changeset` to describe the change (or `pnpm changeset --empty` if it');
+  console.error('genuinely has no release impact). Changeset debt is what caused the release-race');
+  console.error('incidents — see docs/ops/release-changeset-race.md.');
+  return 1;
+}
+
+// Guard the CLI so the test file can import `classifyChange` without a run.
+if (process.argv[1]?.endsWith('check-changeset.ts') === true) {
+  process.exit(main());
+}

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -46,7 +46,9 @@ The `pnpm changeset` workflow handles versioning, but the human-judgment gates b
 ### Pipeline health
 
 - [ ] Last 5 release runs on `main` succeeded (`gh run list --workflow=Release --limit 5`)
-- [ ] No release PR currently open (`gh pr list --search "version packages"`) — if one IS open, see "Avoid the publish race" below
+- [ ] No release PR currently open (`gh pr list --search "version packages"`) — if one IS open, merge it FIRST (a stale version PR is how npm gets ahead of `main`); see "Avoid the publish race" below
+- [ ] `npm view nexus-agents version` matches `packages/nexus-agents/package.json` — the `Detect npm-ahead version skew` step in `release.yml` also enforces this, but check before tagging
+- [ ] No changeset debt — every recent shippable-source PR shipped its own changeset (the `Changeset Presence` CI gate enforces this going forward)
 
 ### Avoid the publish race
 


### PR DESCRIPTION
Closes #2680.

## The incident

On 2026-05-14 the release machinery was found with **npm `latest` at 2.73.0 while the repo's `package.json` was 2.72.0** — npm *ahead* of the repo. 2.73.0 was published, but its Version Packages PR (#2538) was never merged and sat stale 4 days while 9 changeset-less PRs landed. The runbook only covered the *inverse* skew; there was no guard for npm-ahead, and — root cause — **nothing stopped `feat`/`fix` PRs merging without a changeset**.

## Three guards

| Guard | Where | What it does |
|-------|-------|--------------|
| **`Changeset Presence`** (required CI) | `ci.yml` + `scripts/check-changeset.ts` | Fails any PR touching `packages/nexus-agents/src/**` without a `.changeset/*.md`. Escape hatch: `pnpm changeset --empty`. **The structural fix** — no changeset debt means the Version Packages PR never balloons. |
| **`Detect npm-ahead version skew`** | `release.yml` | Fails the release run loudly when `npm latest > package.json` — the direction the prior `#2383` fallback didn't cover. |
| **`manual-publish` → `Guard — main only`** | `release.yml` | Fails a `workflow_dispatch` publish from any non-`main` ref (publishing from `changeset-release/main` is one way npm gets ahead). |

## Docs

- `docs/ops/release-changeset-race.md` — new inverse-variant section + the guards.
- `AGENTS.md` — new "Release cycle" section (3 rules: every src PR carries a changeset; merge the version PR promptly; never publish from a non-main ref).
- `skills/release/SKILL.md` — pre-launch checklist updated.

## Immediate skew — already resolved

#2538 was merged (admin) — `main` is back in sync at 2.73.0 = npm. `changeset publish` is idempotent so no re-publish occurred.

## Verification

- `scripts/check-changeset.ts` — 6 unit tests pass; run against this branch correctly reports "no shippable source changed."
- Both workflow YAMLs parse cleanly.
- CI/workflow/docs only — **no `src/` change, so this PR needs no changeset under its own new gate** (a nice self-consistency check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)