### PR TITLE
feat(adapter): opencode permission-system parity (#2658 — Epic D)

### DIFF
--- a/.changeset/epic-d-opencode-permissions.md
+++ b/.changeset/epic-d-opencode-permissions.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+OpenCode permission-system parity ([#2658](https://github.com/williamzujkowski/nexus-agents/issues/2658), Epic D).
+
+`nexus-agents init --opencode` now emits a conservative default `permission` block into `opencode.json` instead of leaving operators on OpenCode's defaults:
+
+- `bash` → `ask` (highest-risk surface)
+- `edit` → `ask` for everything, with `.env*` / `*.pem` / `*.key` / `id_rsa*` / `secrets/**` / `.git/**` **hard-denied**. OpenCode resolves glob maps last-match-wins, so the deny patterns are ordered after the broad `"*"` rule.
+- `skill` → `allow` (trusted, in-repo, CI-validated content)
+
+Never overwrites an operator's existing `permission` block (merge-not-overwrite, matching the file's existing pattern). Documented in `.rules/security.md`.

--- a/.rules/security.md
+++ b/.rules/security.md
@@ -45,4 +45,22 @@ function validatePath(userPath: string, root: string): Result<string, Error> {
 }
 ```
 
+## Per-Adapter Permission Posture
+
+Each harness has its own access-control primitive; nexus-agents emits a
+conservative default for the one it scaffolds:
+
+- **OpenCode** — `nexus-agents init --opencode` writes a `permission` block
+  into `opencode.json` (#2658): `bash` → `ask` (highest-risk surface),
+  `edit` → `ask` for everything with `.env*` / `*.pem` / `*.key` / `id_rsa*`
+  / `secrets/**` / `.git/**` **hard-denied** (deny patterns ordered after
+  `"*"` because OpenCode resolves globs last-match-wins), `skill` → `allow`
+  (trusted, in-repo, CI-validated content). Never overwrites an operator's
+  existing `permission` block. See `buildDefaultPermissionBlock()` in
+  `src/cli/init-opencode.ts`.
+- **Claude Code** — `allowedTools` in the harness config; not emitted by
+  nexus-agents scaffolding.
+- **Codex** — `sandbox_mode` in `~/.codex/config.toml`; not emitted by
+  nexus-agents scaffolding.
+
 See [SECURITY.md](../../docs/architecture/SECURITY.md) for sandbox configuration.

--- a/packages/nexus-agents/src/cli/init-opencode.test.ts
+++ b/packages/nexus-agents/src/cli/init-opencode.test.ts
@@ -31,7 +31,12 @@ vi.mock('../adapters/openai-compat-adapter.js', () => ({
   discoverModels: mockDiscoverModels,
 }));
 
-import { runInitOpencode, buildNexusMcpBlock, runOpencodeValidate } from './init-opencode.js';
+import {
+  runInitOpencode,
+  buildNexusMcpBlock,
+  buildDefaultPermissionBlock,
+  runOpencodeValidate,
+} from './init-opencode.js';
 import { ok, err, ConfigError } from '../core/index.js';
 
 describe('buildNexusMcpBlock', () => {
@@ -61,6 +66,28 @@ describe('buildNexusMcpBlock', () => {
   });
 });
 
+describe('buildDefaultPermissionBlock (#2658)', () => {
+  it('asks for bash and edit, allows skill', () => {
+    const p = buildDefaultPermissionBlock();
+    expect(p['bash']).toBe('ask');
+    expect(p['skill']).toBe('allow');
+    expect(typeof p['edit']).toBe('object');
+  });
+
+  it('hard-denies secrets, keys, and .git in edit — with deny patterns AFTER "*"', () => {
+    const edit = buildDefaultPermissionBlock()['edit'] as Record<string, string>;
+    // OpenCode evaluates last-matching-rule-wins, so the broad `*` must come
+    // first and the deny patterns after, or secrets would resolve to `ask`.
+    const keys = Object.keys(edit);
+    expect(keys[0]).toBe('*');
+    expect(edit['*']).toBe('ask');
+    for (const denied of ['**/.env', '**/.env.*', '**/*.pem', '**/*.key', '**/.git/**']) {
+      expect(edit[denied]).toBe('deny');
+      expect(keys.indexOf(denied)).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe('runInitOpencode', () => {
   beforeEach(() => {
     mockExistsSync.mockReset();
@@ -83,6 +110,42 @@ describe('runInitOpencode', () => {
     expect(parsed['providers']).toBeDefined();
     expect(parsed['mcp']).toBeDefined();
     expect((parsed['mcp'] as Record<string, unknown>)['nexus-agents']).toBeDefined();
+    // #2658 — a new file gets the default permission block.
+    expect(parsed['permission']).toEqual(buildDefaultPermissionBlock());
+  });
+
+  it('adds the default permission block to an existing file that lacks one (#2658)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ $schema: 'https://opencode.ai/config.json', theme: 'tokyo-night' })
+    );
+    const result = runInitOpencode({
+      path: '/projects/opencode.json',
+      cliPath: '/opt/nexus-agents/dist/cli.js',
+    });
+    expect(result.action).toBe('updated');
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]?.[1] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(written['permission']).toEqual(buildDefaultPermissionBlock());
+  });
+
+  it('never overwrites an operator-set permission block (#2658)', () => {
+    mockExistsSync.mockReturnValue(true);
+    const operatorPermission = { bash: 'allow', edit: 'allow' };
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        $schema: 'https://opencode.ai/config.json',
+        permission: operatorPermission,
+      })
+    );
+    runInitOpencode({ path: '/projects/opencode.json', cliPath: '/opt/nexus-agents/dist/cli.js' });
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0]?.[1] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(written['permission']).toEqual(operatorPermission);
   });
 
   it('preserves existing operator-set keys when merging', () => {

--- a/packages/nexus-agents/src/cli/init-opencode.ts
+++ b/packages/nexus-agents/src/cli/init-opencode.ts
@@ -60,7 +60,39 @@ interface OpencodeFile {
   $schema?: string;
   providers?: Record<string, unknown>;
   mcp?: Record<string, unknown>;
+  permission?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+/**
+ * Conservative default OpenCode `permission` block (#2658). OpenCode
+ * evaluates a glob map with **last-matching-rule-winning**, so the broad
+ * `"*"` rule is listed first and the hard `deny` patterns last.
+ *
+ * - `edit` — everything `ask`s; secrets, keys, and `.git/` are hard-denied
+ *   regardless of operator confirmation. The deny patterns come after
+ *   `"*"` so last-match-wins makes them stick.
+ * - `bash` — `ask` unconditionally. Shell is the highest-risk surface.
+ * - `skill` — `allow`. Skills are trusted, in-repo, CI-validated content.
+ *
+ * Emitted only when the operator has not already set their own
+ * `permission` block — never overwrites operator config.
+ */
+export function buildDefaultPermissionBlock(): Record<string, unknown> {
+  return {
+    edit: {
+      '*': 'ask',
+      '**/.env': 'deny',
+      '**/.env.*': 'deny',
+      '**/*.pem': 'deny',
+      '**/*.key': 'deny',
+      '**/id_rsa*': 'deny',
+      '**/secrets/**': 'deny',
+      '**/.git/**': 'deny',
+    },
+    bash: 'ask',
+    skill: 'allow',
+  };
 }
 
 /**
@@ -137,6 +169,7 @@ function mergeNexusBlock(existing: OpencodeFile | null, opts: InitOpencodeOption
     return {
       $schema: 'https://opencode.ai/config.json',
       providers: { 'openai-compat': stubOpenaiCompatProvider() },
+      permission: buildDefaultPermissionBlock(),
       mcp: { 'nexus-agents': block },
     };
   }
@@ -154,8 +187,13 @@ function mergeNexusBlock(existing: OpencodeFile | null, opts: InitOpencodeOption
     environment: { ...block.environment, ...(existingNexus.environment ?? {}) },
   };
 
+  // Add the default permission block only when the operator has not set
+  // their own — never overwrite an existing `permission` key.
+  const permission = existing.permission ?? buildDefaultPermissionBlock();
+
   return {
     ...existing,
+    permission,
     mcp: { ...existingMcp, 'nexus-agents': mergedBlock },
   };
 }


### PR DESCRIPTION
First child of Epic D [#2661](https://github.com/williamzujkowski/nexus-agents/issues/2661). Closes [#2658](https://github.com/williamzujkowski/nexus-agents/issues/2658).

## What

`nexus-agents init --opencode` now emits a conservative default `permission` block into `opencode.json` — operators were previously left on OpenCode's defaults.

```json
"permission": {
  "edit": { "*": "ask", "**/.env": "deny", "**/.env.*": "deny", "**/*.pem": "deny",
            "**/*.key": "deny", "**/id_rsa*": "deny", "**/secrets/**": "deny", "**/.git/**": "deny" },
  "bash": "ask",
  "skill": "allow"
}
```

## Research corrections

Web-verified against `opencode.ai/docs` before building — the issue had two errors:
1. OpenCode's permission value is a **string** (`"allow"`/`"ask"`/`"deny"`) **or a glob→verb map** — not `{allow:[],ask:[],deny:[]}` as the issue stated.
2. The integration point is **`init-opencode.ts`** (the `--opencode` flow), not `init --portable` (which never writes `opencode.json`).

## Security — deny-ordering matters

OpenCode resolves glob maps **last-match-wins**. So the broad `"*": "ask"` rule is listed *first* and the secret-path `deny` patterns *after* — otherwise `.env` would resolve to `ask` instead of `deny`. This is the contrarian's secrets-access concern from the `consensus_vote`, addressed structurally. `bash` is `ask` (highest-risk surface); `skill` is `allow` (trusted in-repo CI-validated content).

**Merge-not-overwrite**: an operator's existing `permission` block is never touched.

## Verification

- `pnpm typecheck` + `pnpm eslint` clean.
- 18 `init-opencode` tests pass — 5 new (block shape, deny-after-`*` ordering, new-file emission, add-to-existing-without-permission, never-overwrite-operator).
- `.rules/security.md` documents the per-adapter permission posture.

## Epic D progress

- [x] **#2658 — OpenCode permission parity (this PR)**
- [ ] #2659 — Codex thread-limit handling
- [ ] #2660 — Codex Skills cross-vendor validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)