### PR TITLE
feat(adapter): codex subagent-limit awareness in voter fan-out (#2659 — Epic D)

### DIFF
--- a/.changeset/epic-d-codex-thread-limits.md
+++ b/.changeset/epic-d-codex-thread-limits.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Codex subagent-limit awareness ([#2659](https://github.com/williamzujkowski/nexus-agents/issues/2659), Epic D).
+
+Codex CLI's `~/.codex/config.toml` `[agents]` section defaults to `max_depth = 1` and `max_threads = 6` (the originating issue's `max_thread_depth` key name was wrong — corrected against the Codex config reference).
+
+Per the #2659 design vote (Option C), nexus-agents now **warns** at fan-out time when a planned topology would exceed these — it does not write the operator's global config or silently auto-flatten routing. `collectRealVotes` emits a structured warning when more voter roles land on Codex than `max_threads` (the narrow single-CLI-fallback case; the existing round-robin + the `worker-dispatcher` cap-of-3 already keep the common paths within limits). New `src/cli-adapters/codex-limits.ts` exports the defaults + `checkCodexConcurrency` / `checkCodexDepth`; `.rules/subagent-coordination.md` documents the Codex limits.

--- a/.rules/subagent-coordination.md
+++ b/.rules/subagent-coordination.md
@@ -107,6 +107,22 @@ When surfacing a blocker per rule 2, redact secrets before writing the status:
 - For missing-file blockers, include the relative path but not absolute paths containing usernames or tokens (`/home/<user>/…` → `~/…`)
 - When unsure whether a string contains a secret, describe the error category (`auth failed`, `connection refused`) rather than pasting the raw message
 
+## Codex subagent limits (#2659)
+
+Codex CLI's `~/.codex/config.toml` `[agents]` section defaults to:
+
+- `max_depth = 1` — nested subagent depth (a subagent spawning a subagent).
+- `max_threads = 6` — concurrent subagent threads.
+
+nexus-agents does **not** write the operator's global `~/.codex/config.toml`, and does **not** silently auto-flatten routing topology. Instead it **warns** at fan-out time when a planned topology would exceed these (`checkCodexConcurrency` / `checkCodexDepth` in `src/cli-adapters/codex-limits.ts`) — the operator stays in control and can raise their own `[agents]` limits.
+
+The existing parallel-dispatch sites are already conservative:
+
+- `worker-dispatcher.ts` caps a wave at `MAX_WORKERS_PER_WAVE = 3` concurrent workers — well under `max_threads`.
+- `collectRealVotes` round-robins voter roles across available CLIs and staggers launches. The warned case is the narrow one: a single-CLI fallback where a full voter panel (7 roles) all lands on Codex, exceeding `max_threads = 6`.
+
+When adding a new parallel-dispatch site that may route to Codex, gate the fan-out count through `checkCodexConcurrency` and surface the warning — don't let it fail silently as a generic Codex error.
+
 ## Adoption
 
 - No CI enforcement (yet). Rules apply by convention and are checked during review.

--- a/packages/nexus-agents/src/cli-adapters/codex-limits.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/codex-limits.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for Codex subagent-limit detection (#2659).
+ *
+ * @module cli-adapters/codex-limits.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CODEX_DEFAULT_MAX_DEPTH,
+  CODEX_DEFAULT_MAX_THREADS,
+  checkCodexConcurrency,
+  checkCodexDepth,
+} from './codex-limits.js';
+
+describe('checkCodexConcurrency', () => {
+  it('returns null at or below max_threads', () => {
+    expect(checkCodexConcurrency(0)).toBeNull();
+    expect(checkCodexConcurrency(CODEX_DEFAULT_MAX_THREADS)).toBeNull();
+  });
+
+  it('returns a structured warning above max_threads', () => {
+    const warning = checkCodexConcurrency(CODEX_DEFAULT_MAX_THREADS + 1);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('max_threads');
+    expect(warning).toContain(String(CODEX_DEFAULT_MAX_THREADS + 1));
+    // Names the remediation, not just the problem.
+    expect(warning).toContain('~/.codex/config.toml');
+  });
+
+  it('flags the default 7-voter panel on a single-CLI Codex fallback', () => {
+    // The narrow real-world case: all 7 voter roles land on Codex.
+    expect(checkCodexConcurrency(7)).not.toBeNull();
+  });
+});
+
+describe('checkCodexDepth', () => {
+  it('returns null at or below max_depth', () => {
+    expect(checkCodexDepth(CODEX_DEFAULT_MAX_DEPTH)).toBeNull();
+  });
+
+  it('returns a structured warning above max_depth', () => {
+    const warning = checkCodexDepth(CODEX_DEFAULT_MAX_DEPTH + 1);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('max_depth');
+    expect(warning).toContain('~/.codex/config.toml');
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/codex-limits.ts
+++ b/packages/nexus-agents/src/cli-adapters/codex-limits.ts
@@ -1,0 +1,57 @@
+/**
+ * Codex CLI subagent limits (#2659, Epic D).
+ *
+ * Codex's `~/.codex/config.toml` `[agents]` section defaults to
+ * `max_depth = 1` and `max_threads = 6` (verified against
+ * developers.openai.com/codex config reference — the originating issue's
+ * `max_thread_depth` key name was wrong).
+ *
+ * nexus-agents does NOT write the operator's global `~/.codex/config.toml`
+ * (that would clobber operator-owned state) and does NOT silently
+ * auto-flatten routing topology. Instead — Option C from the #2659 design
+ * vote — it WARNS at fan-out time when a planned concurrency would exceed
+ * Codex's defaults, so the operator can raise their own `[agents]` limits
+ * or spread the panel across more CLIs. The two existing parallel-dispatch
+ * sites are already conservative: `worker-dispatcher.ts` caps a wave at 3
+ * concurrent workers, and `collectRealVotes` round-robins voter roles
+ * across available CLIs. The warned case is the narrow one — a single-CLI
+ * fallback where every voter role lands on Codex.
+ *
+ * @module cli-adapters/codex-limits
+ * @see Issue #2659
+ */
+
+/** Codex `[agents] max_depth` default — nested subagent depth. */
+export const CODEX_DEFAULT_MAX_DEPTH = 1;
+
+/** Codex `[agents] max_threads` default — concurrent subagent threads. */
+export const CODEX_DEFAULT_MAX_THREADS = 6;
+
+/**
+ * A structured warning when `codexBoundConcurrency` parallel calls are
+ * about to be dispatched to Codex, exceeding its default `max_threads`.
+ * Returns `null` when within limits. Does not block — the operator stays
+ * in control (Option C).
+ */
+export function checkCodexConcurrency(codexBoundConcurrency: number): string | null {
+  if (codexBoundConcurrency <= CODEX_DEFAULT_MAX_THREADS) return null;
+  return (
+    `${String(codexBoundConcurrency)} parallel calls are bound for Codex, exceeding its ` +
+    `default max_threads=${String(CODEX_DEFAULT_MAX_THREADS)}. Codex may queue or drop the ` +
+    `excess. Raise [agents] max_threads in ~/.codex/config.toml, or spread the panel across ` +
+    `more CLIs (claude/gemini) so fewer roles land on Codex.`
+  );
+}
+
+/**
+ * A structured warning when a planned subagent nesting `depth` exceeds
+ * Codex's default `max_depth`. Returns `null` when within limits.
+ */
+export function checkCodexDepth(depth: number): string | null {
+  if (depth <= CODEX_DEFAULT_MAX_DEPTH) return null;
+  return (
+    `planned subagent nesting depth ${String(depth)} exceeds Codex's default ` +
+    `max_depth=${String(CODEX_DEFAULT_MAX_DEPTH)}. Codex will reject the nested spawn. ` +
+    `Raise [agents] max_depth in ~/.codex/config.toml, or flatten the expert chain.`
+  );
+}

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -23,6 +23,7 @@ import { createLogger, getTimeProvider, getErrorMessage } from '../core/index.js
 import { getGlobalRegistry } from '../adapters/unified-registry.js';
 import { getAvailableClis } from '../cli-adapters/factory.js';
 import type { CliName } from '../cli-adapters/types.js';
+import { checkCodexConcurrency } from '../cli-adapters/codex-limits.js';
 
 // Re-export prompts for backward compatibility
 export { VOTER_SYSTEM_PROMPTS, SIMULATED_VOTE_REASONING } from './voter-prompts.js';
@@ -214,6 +215,23 @@ function resolveAdapter(
   }
 }
 
+/**
+ * #2659 — warn (don't block) when more voter roles land on Codex than its
+ * default `max_threads`, e.g. a single-CLI fallback with a full panel.
+ */
+function warnIfCodexConcurrencyExceeded(
+  roleAdapters: ReadonlyMap<VoterRole, IModelAdapter>,
+  logger: ILogger
+): void {
+  const codexBound = [...roleAdapters.values()].filter(
+    (a) => (a as { name?: string }).name === 'codex'
+  ).length;
+  const warning = checkCodexConcurrency(codexBound);
+  if (warning !== null) {
+    logger.warn('Codex concurrency limit may be exceeded', { detail: warning });
+  }
+}
+
 /** Assigns a single adapter to all roles (fallback path). */
 function assignUniformAdapter(
   roles: readonly VoterRole[],
@@ -378,6 +396,9 @@ export async function collectRealVotes(
     options.adapter !== undefined
       ? assignUniformAdapter(roles, adapterResult.adapter)
       : await resolveDiverseAdapters(roles, logger, adapterResult.adapter);
+
+  warnIfCodexConcurrencyExceeded(roleAdapters, logger);
+
   const voteOptions = { timeoutMs, maxRetries, allowSimulation: allowSimulation ?? false };
   const interDelay = options.interAgentDelayMs ?? DEFAULT_INTER_AGENT_DELAY_MS;
 


### PR DESCRIPTION
Second child of Epic D [#2661](https://github.com/williamzujkowski/nexus-agents/issues/2661). Closes [#2659](https://github.com/williamzujkowski/nexus-agents/issues/2659).

> **Stacked on #2688** (#2658). `--onto` rebased after that lands.

## What

Codex CLI's `~/.codex/config.toml` `[agents]` section defaults to `max_depth = 1` / `max_threads = 6`. Per the #2659 design vote (**Option C — warn, don't write the operator's global config or auto-flatten routing**):

- **`src/cli-adapters/codex-limits.ts`** — the Codex defaults as named constants + `checkCodexConcurrency` / `checkCodexDepth`, returning a structured warning (with remediation) or `null`.
- **`collectRealVotes`** warns when more voter roles land on Codex than `max_threads`.
- **`.rules/subagent-coordination.md`** documents the Codex limits + the warn-at-fan-out convention.

## Research correction

The issue's config key `max_thread_depth` doesn't exist — verified against the Codex config reference, the real keys are `[agents] max_depth` / `[agents] max_threads`.

## Why Option C is proportionate (the contrarian's throttle point)

The contrarian on the vote suggested a client-side concurrency throttle. Investigation showed the existing parallel-dispatch sites are *already* Codex-friendly: `worker-dispatcher.ts` caps a wave at `MAX_WORKERS_PER_WAVE = 3`, and `collectRealVotes` round-robins voter roles across available CLIs and staggers launches. The only uncovered case is the narrow single-CLI fallback where a full 7-voter panel all lands on Codex — and a structured warning there is the proportionate fix, not a new throttle layer duplicating what worker-dispatcher already does.

## Verification

- `pnpm typecheck` + `pnpm eslint` clean.
- 5 `codex-limits` unit tests + 52 `voter-agents` tests pass.

## Epic D progress

- [x] #2658 — OpenCode permission parity (#2688)
- [x] **#2659 — Codex subagent-limit awareness (this PR)**
- [ ] #2660 — Codex Skills cross-vendor validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)