### PR TITLE
feat(skills): document + test-lock the cross-vendor SKILL.md contract (#2660 — Epic D)

### DIFF
--- a/.changeset/epic-d-skill-cross-vendor.md
+++ b/.changeset/epic-d-skill-cross-vendor.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Codex Skills cross-vendor compatibility ([#2660](https://github.com/williamzujkowski/nexus-agents/issues/2660), Epic D).
+
+Research refuted the issue's "translation layer" premise: Codex's Skills primitive (Dec 2025) uses the **same** `SKILL.md` filename and the **same** required frontmatter (`name`, `description`) as the Anthropic Agent Skills spec — the 31 skills are already cross-vendor compatible, and `generate-skills-index.ts` already validates the required fields and is CI-gated. There is nothing to convert and no redundant new gate to add.
+
+Delivered instead: the `name`/`description` validation in `generate-skills-index.ts` is now documented + test-locked as the cross-vendor contract, and `AGENTS.md` documents Codex's discovery path (`.agents/skills/` or a `[[skills.config]]` entry pointing at `skills/`) so Codex operators get the full catalog.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Workflow playbooks live at `skills/<name>/SKILL.md` (canonical per the Anthropic
 - **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 31 skills.
 - When a user request matches a skill's triggers, read the full `SKILL.md` at the listed path and follow its workflow.
 - `skills/index.yaml` is regenerated via `scripts/generate-skills-index.ts` and gated in CI. Never edit it by hand.
+- **Codex Skills (#2660):** Codex's Skills primitive uses the same `SKILL.md` filename + the same required frontmatter (`name`, `description`) as the Anthropic spec — these skills are already cross-vendor compatible, no translation layer needed. Codex discovers skills under `.agents/skills/` or via `[[skills.config]]` path entries in the agent config; point either at this repo's `skills/` directory. The `name`/`description` validation in `generate-skills-index.ts` is the enforced cross-vendor contract.
 
 ## Expert agents
 

--- a/scripts/generate-skills-index.test.ts
+++ b/scripts/generate-skills-index.test.ts
@@ -68,6 +68,25 @@ describe('skills/index.yaml', () => {
     expect(withTriggers.length).toBeGreaterThanOrEqual(Math.floor(index.skills.length * 0.8));
   });
 
+  it('every SKILL.md carries the cross-vendor required frontmatter (#2660)', () => {
+    // Codex's Skills primitive uses the same SKILL.md filename + the same
+    // required fields (name, description) as the Anthropic Agent Skills
+    // spec. This locks that cross-vendor contract: every skill file must
+    // parse and declare both, so the catalog stays loadable from Claude
+    // Code AND Codex without a translation layer.
+    const index = loadIndex();
+    for (const entry of index.skills) {
+      const content = readFileSync(join(ROOT, entry.path), 'utf-8');
+      const fm = /^---\n([\s\S]*?)\n---/.exec(content)?.[1];
+      expect(fm, `${entry.path} has no frontmatter`).toBeDefined();
+      const parsed = parseYaml(fm ?? '') as Record<string, unknown>;
+      expect(typeof parsed['name'], `${entry.path} name`).toBe('string');
+      expect(typeof parsed['description'], `${entry.path} description`).toBe('string');
+      expect((parsed['name'] as string).length).toBeGreaterThan(0);
+      expect((parsed['description'] as string).length).toBeGreaterThan(0);
+    }
+  });
+
   it('no trigger contains internal whitespace beyond single spaces', () => {
     // Regression guard for #2389: YAML literal-block descriptions wrap at
     // column 80, which previously caused trigger phrases to contain literal

--- a/scripts/generate-skills-index.ts
+++ b/scripts/generate-skills-index.ts
@@ -10,6 +10,15 @@
  * this index. Other CLI workers (OpenCode, Codex, Gemini CLI, Aider) use
  * the index to decide which skill to load on demand.
  *
+ * Cross-vendor contract (#2660): the `name` + `description` required-field
+ * validation in `parseFrontmatter` below IS the cross-vendor contract.
+ * Codex's Skills primitive uses the same `SKILL.md` filename and the same
+ * required frontmatter as the Anthropic Agent Skills spec, so no
+ * translation layer is needed — but do not weaken that validation; it is
+ * what keeps the 31 skills loadable from both Claude Code and Codex. Codex
+ * discovery is documented in AGENTS.md (`.agents/skills/` or a
+ * `[[skills.config]]` entry pointing at `skills/`).
+ *
  * Usage:
  *   npx tsx scripts/generate-skills-index.ts          # generate
  *   npx tsx scripts/generate-skills-index.ts --check  # CI validation


### PR DESCRIPTION
Third child of Epic D [#2661](https://github.com/williamzujkowski/nexus-agents/issues/2661). Closes [#2660](https://github.com/williamzujkowski/nexus-agents/issues/2660).

> **Stacked on #2688 + #2689.** `--onto` rebased after those land.

## The reframe

The issue assumed Codex Skills might need a frontmatter translation layer. Web research (developers.openai.com/codex/skills) **refuted that**: Codex's Skills primitive (Dec 2025) uses the **same** `SKILL.md` filename and the **same** required frontmatter (`name`, `description`) as the Anthropic Agent Skills spec. And `generate-skills-index.ts` *already* validates `name`+`description` and is CI-gated (`Skills Index Freshness`).

So: **nothing to convert, no redundant new gate** — the existing validation already *is* the cross-vendor gate.

## What ships (honestly scoped)

- `generate-skills-index.ts` — the `name`/`description` validation is now documented as the cross-vendor (Anthropic + Codex) required-field contract, with a "don't weaken it" note.
- A test in `generate-skills-index.test.ts` **locks** that contract: every `SKILL.md` must parse and declare both fields.
- `AGENTS.md` documents Codex's discovery path — `.agents/skills/` or a `[[skills.config]]` entry pointing at this repo's `skills/`.

## Verification

- `pnpm eslint` clean.
- 8 `generate-skills-index` tests pass (1 new — cross-vendor-contract lock).

## Epic D — complete

- [x] #2658 — OpenCode permission parity (#2688)
- [x] #2659 — Codex subagent-limit awareness (#2689)
- [x] **#2660 — cross-vendor SKILL.md contract (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)