### PR TITLE
feat(research): source provenance through research synthesis (#2663 — Epic E)

### DIFF
--- a/.changeset/epic-e-synthesis-provenance.md
+++ b/.changeset/epic-e-synthesis-provenance.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+Source provenance through research synthesis ([#2663](https://github.com/williamzujkowski/nexus-agents/issues/2663), Epic E).
+
+`research_synthesize` previously dropped source attribution at the merge: `extractPapers` pulled `id`/`title`/`summary`/`keyFindings` but not `url`/`arxiv_id`/`publication_date`, and `keyInsights` was a flat string array — a voter couldn't trace any synthesized claim back to a paper.
+
+Research scoped this to the single leaking path — `research_catalog_review` is a review-queue manager (no merge) and `pr_review` aggregation already preserves per-finding attribution, so neither is touched.
+
+- `SynthesisPaper` carries `sourceUri` + `publicationDate`; `SynthesisPaperRef` carries them into `ClusterSynthesis.papers` (now `{id, title, sourceUri}` refs, not bare titles).
+- `keyInsights` is now `AttributedInsight[]` — `{insight, sourcePaperIds}`. When two papers assert the same finding, **both** ids survive, so a contradiction is _representable_ rather than silently collapsed into one source's claim.
+- Structural enforcement, not just a doc rule: `AttributedInsightSchema` (Zod `.min(1)` on `sourcePaperIds`) is parsed at construction — every merged claim is a validated-attributed claim.
+- New `.rules/research.md` documents the provenance invariants.

--- a/.rules/research.md
+++ b/.rules/research.md
@@ -1,0 +1,45 @@
+---
+paths: ['packages/**/cli/research-*.ts', 'packages/**/mcp/tools/research-*.ts', 'docs/research/**']
+description: Research synthesis provenance invariants — every merged claim stays attributed to its source
+---
+
+# Research Provenance Rules
+
+Synthesis merges multiple papers into voter-facing output. The risk: when
+two sources disagree, a synthesizer can pick one without flagging the
+conflict — voters then can't tell "the literature says X" from "Source A
+claims X, Source B disputes it." Issue #2663 makes provenance a structural
+invariant, not a hope.
+
+## Invariants
+
+1. **No unattributed claim.** Every synthesized insight carries
+   `sourcePaperIds` with **at least one** id. Enforced structurally by
+   `AttributedInsightSchema` (`research-helpers-synthesize.ts`) — a Zod
+   `.min(1)` on `sourcePaperIds`, parsed at construction. A documentation
+   rule alone is fragile; the schema makes it a validated guarantee.
+
+2. **Contradictions are representable, not collapsed.** When two papers
+   assert the same finding, **both** ids land in `sourcePaperIds` — the
+   output structure can express "two sources, possibly disagreeing"
+   rather than silently picking one. `attributeFindings` keys findings by
+   normalized text and unions the source ids; it never drops a source.
+
+3. **Provenance flows from the registry, untruncated.** The registry
+   (`docs/research/registry/papers.yaml`) carries `arxiv_id`, `url`,
+   `publication_date`. `extractPapers` threads these onto `SynthesisPaper`
+   (`sourceUri`, `publicationDate`); `SynthesisPaperRef` carries them into
+   cluster output. Do not extract a paper into a synthesis path while
+   dropping its source URI.
+
+## When adding or changing a synthesis path
+
+A "synthesis path" is any code that merges 2+ research sources into one
+output (today: `research_synthesize` / `research-helpers-synthesize.ts`).
+`research_catalog_review` is a review-queue manager (no merge) and
+`pr_review` aggregation already preserves per-finding `role`/`location` —
+neither is a synthesis path.
+
+If you add one: the merged output type must carry source ids per claim,
+validated by a `.min(1)` schema. If you cannot attribute a merged claim
+to a source, that is a bug in the path, not an acceptable output.

--- a/packages/nexus-agents/src/cli/research-command.ts
+++ b/packages/nexus-agents/src/cli/research-command.ts
@@ -392,11 +392,14 @@ function formatSynthesisResult(synthesis: SynthesisResult): string {
 /** Format a single cluster section. */
 function formatCluster(cluster: SynthesisResult['clusters'][number], lines: string[]): void {
   lines.push(`## ${cluster.topic} (${String(cluster.paperCount)} papers)`);
-  lines.push(`Papers: ${cluster.papers.join(', ')}`);
+  lines.push(`Papers: ${cluster.papers.map((p) => p.title).join(', ')}`);
   if (cluster.commonThemes.length > 0) lines.push(`Themes: ${cluster.commonThemes.join(', ')}`);
   if (cluster.keyInsights.length > 0) {
     lines.push('Key insights:');
-    for (const insight of cluster.keyInsights.slice(0, 5)) lines.push(`  - ${insight}`);
+    // #2663 — each insight carries its source paper ids.
+    for (const insight of cluster.keyInsights.slice(0, 5)) {
+      lines.push(`  - ${insight.insight} [${insight.sourcePaperIds.join(', ')}]`);
+    }
   }
   if (cluster.implementationOpportunities.length > 0) {
     lines.push(`Opportunities: ${cluster.implementationOpportunities.join(', ')}`);

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
@@ -242,9 +242,40 @@ describe('synthesizeResearch', () => {
     const cluster = result.value.clusters[0];
     if (cluster === undefined) return;
     const retrievalFindings = cluster.keyInsights.filter((i) =>
-      i.toLowerCase().includes('retrieval')
+      i.insight.toLowerCase().includes('retrieval')
     );
     expect(retrievalFindings.length).toBe(1);
+    // #2663 — every synthesized insight carries at least one source paper id.
+    for (const insight of cluster.keyInsights) {
+      expect(insight.sourcePaperIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('attributes a shared finding to every paper that asserts it (#2663)', async () => {
+    mockLoadPapersRegistry.mockResolvedValue({
+      ok: true,
+      value: makeRegistry({
+        p1: makePaper('1', 'Paper A', ['memory'], ['retrieval'], {
+          key_findings: ['Shared finding about retrieval'],
+        }),
+        p2: makePaper('2', 'Paper B', ['memory'], ['retrieval'], {
+          key_findings: ['Shared finding about retrieval'],
+        }),
+      }),
+    });
+    const result = await synthesizeResearch('memory');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const cluster = result.value.clusters[0];
+    if (cluster === undefined) return;
+    const shared = cluster.keyInsights.find((i) => i.insight.includes('Shared finding'));
+    // Both papers asserted it — both ids survive into the output, the
+    // structure that makes a contradiction representable rather than collapsed.
+    expect([...(shared?.sourcePaperIds ?? [])].sort()).toEqual(['p1', 'p2']);
+    // Paper refs carry provenance (#2663), not just titles.
+    expect(cluster.papers.find((p) => p.id === 'p1')?.sourceUri).toBe(
+      'https://arxiv.org/abs/test-1'
+    );
   });
 
   it('identifies aligned techniques with implementation status', async () => {

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
@@ -8,6 +8,7 @@
  * (Source: Issue #1386 — Research Synthesis Pipeline)
  */
 
+import { z } from 'zod';
 import { loadPapersRegistry } from './research-helpers-io.js';
 import type { PapersRegistry } from './research-types.js';
 import type { Result } from '../core/result.js';
@@ -32,7 +33,43 @@ export interface SynthesisPaper {
   readonly techniquesExtracted: readonly string[];
   readonly qualityScore: number;
   readonly evidenceTier: 'high' | 'medium' | 'low';
+  /** Source URI — the paper URL, or `arxiv:<id>` (#2663 provenance). */
+  readonly sourceUri?: string;
+  /** Publication date as recorded in the registry (#2663 provenance). */
+  readonly publicationDate?: string;
 }
+
+/**
+ * A reference to a source paper, carried into synthesis output so a
+ * cluster is traceable back to its inputs (#2663).
+ */
+export interface SynthesisPaperRef {
+  readonly id: string;
+  readonly title: string;
+  readonly sourceUri?: string;
+}
+
+/**
+ * A synthesized insight with its provenance (#2663). `sourcePaperIds` is
+ * never empty — every merged claim is attributed. When two papers assert
+ * the same finding, BOTH ids appear, so a contradiction is *representable*
+ * as multiple attributed sources rather than silently collapsed into one.
+ */
+export interface AttributedInsight {
+  readonly insight: string;
+  readonly sourcePaperIds: readonly string[];
+}
+
+/**
+ * Structural enforcement of the #2663 provenance invariant: every
+ * synthesized insight must carry at least one source paper id. A doc rule
+ * alone is fragile — this Zod schema makes "no unattributed claim" a
+ * validated guarantee, not a hope.
+ */
+export const AttributedInsightSchema = z.object({
+  insight: z.string().min(1),
+  sourcePaperIds: z.array(z.string().min(1)).min(1),
+});
 
 /** A cluster of related papers grouped by topic. */
 export interface PaperCluster {
@@ -61,9 +98,9 @@ export interface QualityDistribution {
 export interface ClusterSynthesis {
   readonly topic: string;
   readonly paperCount: number;
-  readonly papers: readonly string[];
+  readonly papers: readonly SynthesisPaperRef[];
   readonly commonThemes: readonly string[];
-  readonly keyInsights: readonly string[];
+  readonly keyInsights: readonly AttributedInsight[];
   readonly techniques: readonly string[];
   readonly implementationOpportunities: readonly string[];
   readonly gaps: readonly string[];
@@ -184,20 +221,33 @@ function safeArray(value: readonly string[]): string[] {
 }
 
 /** Extract papers from the registry structure. */
+/** Source URI for a paper: prefer the URL, else `arxiv:<id>` (#2663). */
+function paperSourceUri(p: PapersRegistry['papers'][string]): string | undefined {
+  if (typeof p.url === 'string' && p.url.length > 0) return p.url;
+  if (typeof p.arxiv_id === 'string' && p.arxiv_id.length > 0) return `arxiv:${p.arxiv_id}`;
+  return undefined;
+}
+
 function extractPapers(registry: PapersRegistry): SynthesisPaper[] {
-  return Object.entries(registry.papers).map(([id, p]) => ({
-    id,
-    title: p.title,
-    topics: safeArray(p.topics),
-    tags: safeArray(p.tags),
-    summary: p.summary.trim(),
-    keyFindings: safeArray(p.key_findings),
-    relevance: p.relevance,
-    implementationStatus: p.implementation_status,
-    techniquesExtracted: safeArray(p.techniques_extracted),
-    qualityScore: p.quality_score ?? 0,
-    evidenceTier: p.evidence_tier ?? 'low',
-  }));
+  return Object.entries(registry.papers).map(([id, p]) => {
+    const sourceUri = paperSourceUri(p);
+    return {
+      id,
+      title: p.title,
+      topics: safeArray(p.topics),
+      tags: safeArray(p.tags),
+      summary: p.summary.trim(),
+      keyFindings: safeArray(p.key_findings),
+      relevance: p.relevance,
+      implementationStatus: p.implementation_status,
+      techniquesExtracted: safeArray(p.techniques_extracted),
+      qualityScore: p.quality_score ?? 0,
+      evidenceTier: p.evidence_tier ?? 'low',
+      // #2663 — carry provenance from the registry into synthesis.
+      ...(sourceUri !== undefined ? { sourceUri } : {}),
+      ...(typeof p.publication_date === 'string' ? { publicationDate: p.publication_date } : {}),
+    };
+  });
 }
 
 // =============================================================================
@@ -256,7 +306,6 @@ function synthesizeCluster(cluster: PaperCluster): ClusterSynthesis {
   const allTechniques = collectFrequencies(
     cluster.papers.flatMap((p) => [...p.techniquesExtracted])
   );
-  const allFindings = cluster.papers.flatMap((p) => [...p.keyFindings]);
 
   // Common themes: tags that appear in 2+ papers
   const commonThemes = [...allTags.entries()]
@@ -305,9 +354,9 @@ function synthesizeCluster(cluster: PaperCluster): ClusterSynthesis {
   return {
     topic: cluster.topic,
     paperCount: cluster.paperCount,
-    papers: cluster.papers.map((p) => p.title),
+    papers: cluster.papers.map(toPaperRef),
     commonThemes,
-    keyInsights: deduplicateFindings(allFindings).slice(0, 10),
+    keyInsights: attributeFindings(cluster.papers).slice(0, 10),
     techniques,
     implementationOpportunities: uniqueOpportunities,
     gaps,
@@ -411,16 +460,41 @@ function collectFrequencies(items: readonly string[]): Map<string, number> {
   return counts;
 }
 
-/** Deduplicate findings by removing near-identical strings. */
-function deduplicateFindings(findings: readonly string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const finding of findings) {
-    const normalized = finding.toLowerCase().trim();
-    if (normalized.length === 0) continue;
-    if (seen.has(normalized)) continue;
-    seen.add(normalized);
-    result.push(finding);
+/** Project a source paper to the lean reference carried into output (#2663). */
+function toPaperRef(p: SynthesisPaper): SynthesisPaperRef {
+  return {
+    id: p.id,
+    title: p.title,
+    ...(p.sourceUri !== undefined ? { sourceUri: p.sourceUri } : {}),
+  };
+}
+
+/**
+ * Deduplicate findings across a cluster's papers WHILE preserving
+ * provenance (#2663). Findings are keyed by normalized text; when two
+ * papers assert the same finding, both ids are collected — so a
+ * contradiction is representable as multiple attributed sources rather
+ * than silently collapsed. Every returned insight is validated to carry
+ * at least one source id (`AttributedInsightSchema`).
+ */
+function attributeFindings(papers: readonly SynthesisPaper[]): AttributedInsight[] {
+  const byNormalized = new Map<string, { insight: string; sourcePaperIds: Set<string> }>();
+  for (const paper of papers) {
+    for (const finding of paper.keyFindings) {
+      const normalized = finding.toLowerCase().trim();
+      if (normalized.length === 0) continue;
+      const existing = byNormalized.get(normalized);
+      if (existing !== undefined) {
+        existing.sourcePaperIds.add(paper.id);
+      } else {
+        byNormalized.set(normalized, {
+          insight: finding,
+          sourcePaperIds: new Set([paper.id]),
+        });
+      }
+    }
   }
-  return result;
+  return [...byNormalized.values()].map((e) =>
+    AttributedInsightSchema.parse({ insight: e.insight, sourcePaperIds: [...e.sourcePaperIds] })
+  );
 }


### PR DESCRIPTION
Second child of Epic E [#2664](https://github.com/williamzujkowski/nexus-agents/issues/2664). Closes [#2663](https://github.com/williamzujkowski/nexus-agents/issues/2663).

> **Stacked on #2692** (#2662). `--onto` rebased after that lands.

## The bug

`research_synthesize` dropped source attribution at the merge: `extractPapers` pulled `id`/`title`/`summary`/`keyFindings` but **not** `url`/`arxiv_id`/`publication_date`, and `keyInsights` was a flat `string[]` — no synthesized claim was traceable to a paper.

## Scope (research-corrected)

The issue implied a cross-cutting overhaul across multiple synthesis paths. Codebase research found **only one** actually leaks: `research_catalog_review` is a review-queue manager (no merge) and `pr_review` aggregation already preserves per-finding `role`/`location`/`claim`. So this is a single-tool fix.

## What changed

- `SynthesisPaper` carries `sourceUri` (the URL, or `arxiv:<id>`) + `publicationDate`; `SynthesisPaperRef` carries them into `ClusterSynthesis.papers` — now `{id, title, sourceUri}` refs, not bare title strings.
- `keyInsights` is now `AttributedInsight[]` — `{insight, sourcePaperIds}`. `attributeFindings` keys findings by normalized text and **unions** source ids: when two papers assert the same finding, **both** ids survive — a contradiction is *representable*, not silently collapsed into one source's claim.
- **Structural enforcement** (the contrarian's point — a doc rule alone is fragile): `AttributedInsightSchema` (Zod `.min(1)` on `sourcePaperIds`) is parsed at construction, so "no unattributed claim" is a *validated* guarantee.
- New `.rules/research.md` documents the provenance invariants.
- `research-command.ts` consumer updated for the new shapes.

## Verification

- `pnpm typecheck` + `pnpm eslint` clean; governance check passes.
- 54 synthesis + research-command tests pass — 2 new (per-insight attribution; shared-finding survives as two attributed sources).

## Epic E — complete

- [x] #2662 — stratified outcome report (#2692)
- [x] **#2663 — synthesis provenance (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)