### PR TITLE
fix(release): stop publish-race fallback publishing off changeset-release/main (#2696)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,13 +99,29 @@ jobs:
         #
         # The third condition prevents publishing partial state when changesets
         # are still pending; in that case the next merge will close the loop.
+        #
+        # CRITICAL (#2696, 2026-05-14): in PR-update mode the changesets/action
+        # runs `changeset version` on a `changeset-release/main` branch and
+        # LEAVES THE WORKING TREE CHECKED OUT THERE. Reading package.json or
+        # .changeset/ from the working tree would see the NEXT version already
+        # bumped and the changesets already consumed — making this step
+        # force-publish an unreleased version straight off the changeset-release
+        # branch on every changeset-bearing feature merge, with no git tag
+        # pushed and no GitHub Release created (2.68.0–2.76.0 all published this
+        # way). `git checkout "$GITHUB_SHA"` pins the whole step to the
+        # triggering main commit so the skew check only ever reasons about main.
         if: steps.changesets.outputs.published != 'true'
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Pin to the triggering main commit — never trust the working tree,
+          # which changesets/action may have left on changeset-release/main.
+          git checkout --quiet "$GITHUB_SHA"
+
           local_version=$(jq -r '.version' packages/nexus-agents/package.json)
           published_version=$(npm view nexus-agents version 2>/dev/null || echo "0.0.0")
 
@@ -122,8 +138,32 @@ jobs:
             exit 0
           fi
 
-          echo "::warning::Detected publish-race version skew. package.json=$local_version, npm=$published_version, no pending changesets. Force-publishing $local_version."
+          echo "::warning::Detected publish-race version skew. package.json=$local_version, npm=$published_version, no pending changesets. Force-publishing $local_version from main ($GITHUB_SHA)."
           pnpm release
+
+          # `changeset publish` (inside `pnpm release`) creates the git tag
+          # LOCALLY but does not push it, and the GitHub Release is normally the
+          # changesets/action's job — which this fallback bypasses. Without the
+          # next block the tag + Release + SBOM trail is silently lost (#2696:
+          # 2.68.0–2.76.0 reached npm with no git tag and no GitHub Release).
+          TAG="nexus-agents@$local_version"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            git push origin "refs/tags/$TAG" || echo "::warning::tag $TAG already on origin"
+          else
+            echo "::warning::changeset publish did not create tag $TAG — creating it now"
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG"
+          fi
+          # Release notes = this version's section of the changesets CHANGELOG.
+          notes=$(awk -v v="## $local_version" '
+            $0 == v { f = 1; next } /^## / { f = 0 } f' packages/nexus-agents/CHANGELOG.md)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists — leaving it."
+          else
+            gh release create "$TAG" --title "$TAG" \
+              --notes "${notes:-Release $local_version. (CHANGELOG section not found — see packages/nexus-agents/CHANGELOG.md.)}"
+          fi
+
           # Signal downstream provenance + SBOM steps that we did publish.
           echo "published=true" >> "$GITHUB_OUTPUT"
           # Synthesize the publishedPackages output that the changesets/action

--- a/docs/ops/release-changeset-race.md
+++ b/docs/ops/release-changeset-race.md
@@ -79,6 +79,16 @@ Seen 2026-05-14: 2.73.0 was published to npm, but its `chore(release): version p
 
 If all three hold, the step runs `pnpm release` to force-publish the local version. Downstream SBOM upload, attest-build-provenance, and CycloneDX steps fire on either `steps.changesets.outputs.published == 'true'` or `steps.fallback-publish.outputs.published == 'true'`, so the recovery path produces the same supply-chain artifacts as the happy path.
 
+### Wrong-branch variant — fallback published from `changeset-release/main` (2026-05-14, #2696)
+
+A second, worse failure mode of that same fallback step. **Symptom:** npm marches forward version-by-version on every changeset-bearing feature merge, but **no git tags and no GitHub Releases** are created — SBOM upload and provenance attestation silently skip too. Seen 2026-05-14: 2.68.0–2.76.0 all reached npm with no tag and no Release; the GitHub Releases list stopped at 2.67.0.
+
+**Root cause.** In PR-update mode, `changesets/action` runs `changeset version` on a `changeset-release/main` branch and **leaves the working tree checked out on that branch** — `package.json` shows the _next_ bumped version and `.changeset/` is already consumed. The `Detect publish-race version skew` step then read `package.json` and `.changeset/` straight from the working tree, so on **every** changeset-bearing feature merge it saw "version ahead of npm, no pending changesets" and force-published the next version — straight off `changeset-release/main`, before the "Version Packages" PR was ever merged. Because the fallback bypasses `changesets/action`, `changeset publish` created the git tag only _locally_ (never pushed) and no GitHub Release was created at all.
+
+**Fix (this doc's companion PR).** The fallback step now runs `git checkout "$GITHUB_SHA"` first, pinning the entire skew check + publish to the triggering `main` commit — it can no longer see the changeset-release branch's state. And when it does legitimately force-publish, it now pushes the git tag and creates the GitHub Release itself (with the version's `CHANGELOG.md` section as notes), restoring the tag + Release + SBOM trail that `changesets/action` would have produced.
+
+**Backfill.** Tags + Releases for the versions published without them are restored separately — see #2696.
+
 ### Manual recovery (if the automatic fallback is somehow disabled)
 
 From `main` with `npm` credentials:
@@ -113,6 +123,7 @@ The race is rare. To minimize the chance of triggering it:
 
 - `#2382` — original ops issue documenting the race.
 - `PR #2383` — workflow fallback implementation.
+- `#2696` — the wrong-branch fallback variant: fallback published off `changeset-release/main`, skipping tags + Releases for 2.68.0–2.76.0.
 - `.github/workflows/release.yml` — the actual workflow definition (skew-detection steps + `manual-publish` guard).
 - `.github/workflows/ci.yml` — the `Changeset Presence` required check.
 - `scripts/check-changeset.ts` — the changeset-presence gate.


### PR DESCRIPTION
## RCA

`changesets/action` in PR-update mode runs `changeset version` on a `changeset-release/main` branch and **leaves the working tree checked out there** — `package.json` shows the *next* bumped version, `.changeset/` is already consumed. The `Detect publish-race version skew` fallback step in `release.yml` read `package.json` + `.changeset/` straight from the working tree.

Consequence: on **every** changeset-bearing feature merge, the fallback saw "version ahead of npm, no pending changesets" and force-published the next version — straight off `changeset-release/main`, before the "Version Packages" PR ever merged. And because the fallback bypasses `changesets/action`, `changeset publish` created the git tag only *locally* (never pushed) and no GitHub Release was created.

**Net effect:** 2.68.0–2.76.0 all reached npm with no git tag, no GitHub Release, no SBOM, no provenance attestation. The GitHub Releases list stopped at 2.67.0.

Confirmed in release run `25867636183` (the #2686 merge): its fallback step logged `nexus-agents is being published because our local version (2.76.0) has not been published on npm` and `Creating git tag... New tag: nexus-agents@2.76.0` — publishing 2.76.0 at 15:07:51, before PR #2694 (the actual 2.76.0 version PR) was even merged. npm publish timestamps line up exactly with this pattern across 2.68.0–2.76.0.

## Fix

- The fallback step now runs `git checkout "$GITHUB_SHA"` first — pinning the entire skew check + publish to the **triggering main commit**. It can no longer see the `changeset-release/main` branch's state, so it only fires on a genuine `package.json`-ahead-of-npm skew on `main` (the original #2382 case still works).
- When it *does* legitimately force-publish, it now **pushes the git tag** (`changeset publish` only creates it locally) and **creates the GitHub Release** (the version's `CHANGELOG.md` section as notes) — restoring the tag + Release + SBOM/attestation trail that `changesets/action` produces on the happy path.
- `docs/ops/release-changeset-race.md` documents the wrong-branch variant under "Wrong-branch variant".

No `packages/nexus-agents/src/**` changes — no changeset required.

## Remaining (tracked in #2696)

Backfilling the missing 2.68.0–2.76.0 git tags + GitHub Releases is the restorative cleanup half — handled separately so this workflow fix can land first and stop the bleeding.

## Test plan

- [x] `release.yml` parses as valid YAML
- [x] `awk` CHANGELOG-section extraction verified against `packages/nexus-agents/CHANGELOG.md` (2.76.0 section)
- [x] markdownlint clean
- [ ] Next changeset-bearing merge to main: the fallback step logs "Versions in sync" instead of force-publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)