### PR TITLE
feat(mcp): record timeout-mismatch events to queryable JSONL (#2703)

### DIFF
--- a/.changeset/2703-timeout-mismatch-telemetry.md
+++ b/.changeset/2703-timeout-mismatch-telemetry.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': minor
+---
+
+Record timeout-mismatch events to a queryable JSONL ([#2703](https://github.com/williamzujkowski/nexus-agents/issues/2703), Epic [#2631](https://github.com/williamzujkowski/nexus-agents/issues/2631) prerequisite).
+
+The `toSdkCallbackWithBudgetCheck` WARN added in #2632 was log-only — operators could grep for "budget exceeds client default" but couldn't answer "of N mismatched calls, what fraction ended in a timeout?" Each mismatch is now also appended to `$NEXUS_DATA_DIR/mcp-telemetry/timeout-mismatch-events.jsonl` as one JSON row carrying a correlation `eventId` (also surfaced in the WARN log entry's context) and the call's eventual outcome (`success` / `error` + `errorCategory` from the post-#2649 envelope when present). Joinable per the Contrarian's correlation point on the #2631 disposition vote — bare counts don't prove causation.
+
+Schema documented in `docs/architecture/MCP_PROTOCOL.md` (Correlation-keyed event log section). Best-effort recording: a telemetry-write failure logs at `debug` and never fails the user's tool call. The aggregation surface ("does mismatch dominate timeouts?") belongs in `improvement_review` / a fitness report and is intentionally out of scope here.

--- a/docs/architecture/MCP_PROTOCOL.md
+++ b/docs/architecture/MCP_PROTOCOL.md
@@ -473,6 +473,27 @@ const result = await client.request(
 
 If you see this WARN on every long-running tool call, the client is misconfigured — fix the client, not the server timeout.
 
+### Correlation-keyed event log (#2703)
+
+The WARN above is also recorded as one JSONL row per mismatch at `$NEXUS_DATA_DIR/mcp-telemetry/timeout-mismatch-events.jsonl`. Each row carries a correlation `eventId` that **also appears in the WARN log entry's context**, so a mismatched call can be joined from server logs to the recorded outcome — not just counted in aggregate.
+
+Schema (one JSON object per line):
+
+| Field                 | Type                   | Notes                                                        |
+| --------------------- | ---------------------- | ------------------------------------------------------------ |
+| `eventId`             | string (UUID)          | Join key against the WARN log entry's `eventId` field        |
+| `toolName`            | string                 | E.g. `consensus_vote`, `orchestrate`                         |
+| `configuredTimeoutMs` | number                 | Server-side budget that triggered the mismatch               |
+| `mcpSdkDefaultMs`     | number                 | `60000` — the SDK client default the budget exceeds          |
+| `startedAt`           | string (ISO 8601)      | When the wrapper fired the WARN                              |
+| `endedAt`             | string (ISO 8601)      | When the call returned or threw                              |
+| `durationMs`          | number                 | `endedAt - startedAt`                                        |
+| `outcome`             | `'success' \| 'error'` | Whether the call's eventual result was `isError: true`       |
+| `errorCategory`       | string (optional)      | From the post-#2649 envelope (`_meta['nexus-agents/error']`) |
+| `errorMessage`        | string (optional)      | First text-content line or thrown error, truncated to 500c   |
+
+This is the data surface for Epic #2631's "when this is worth doing" gate: "of mismatches, what fraction end in `errorCategory: 'timeout'`?" The aggregation belongs in `improvement_review` / a fitness report (out of scope for #2703).
+
 ---
 
 ## Claude Desktop Integration

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper-budget-check.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper-budget-check.test.ts
@@ -8,15 +8,26 @@
  * cover: short-budget tool (no warn), long-budget with progressToken (no
  * warn), long-budget without progressToken (warn).
  *
+ * #2703 extended the wrapper to ALSO record each mismatch event to a
+ * queryable JSONL at `$NEXUS_DATA_DIR/mcp-telemetry/timeout-mismatch-events.jsonl`
+ * with a correlation `eventId` shared with the WARN log entry — so the
+ * #2631 epic gate ("does client-config mismatch dominate timeouts?") can
+ * be answered by joining events against outcomes, not just counted.
+ *
  * @module mcp/middleware/tool-wrapper-budget-check.test
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ILogger } from '../../core/index.js';
 import {
   MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+  TIMEOUT_MISMATCH_TELEMETRY_REL_PATH,
   toSdkCallbackWithBudgetCheck,
+  type TimeoutMismatchEvent,
 } from './tool-wrapper.js';
 
 function makeMockLogger(): ILogger & { warn: ReturnType<typeof vi.fn> } {
@@ -32,6 +43,29 @@ const passthroughHandler = (): Promise<{
   content: Array<{ type: 'text'; text: string }>;
 }> => Promise.resolve({ content: [{ type: 'text', text: 'ok' }] });
 
+/** Override $NEXUS_DATA_DIR per test so the JSONL writes land in a tmpdir. */
+let prevDataDir: string | undefined;
+let testDataDir: string;
+beforeEach(() => {
+  prevDataDir = process.env['NEXUS_DATA_DIR'];
+  testDataDir = mkdtempSync(join(tmpdir(), 'nexus-budget-check-'));
+  process.env['NEXUS_DATA_DIR'] = testDataDir;
+});
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+  else process.env['NEXUS_DATA_DIR'] = prevDataDir;
+  rmSync(testDataDir, { recursive: true, force: true });
+});
+
+function readEvents(): TimeoutMismatchEvent[] {
+  const path = join(testDataDir, TIMEOUT_MISMATCH_TELEMETRY_REL_PATH);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as TimeoutMismatchEvent);
+}
+
 describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
   it('does not warn when configured budget fits within MCP SDK default', async () => {
     const logger = makeMockLogger();
@@ -46,6 +80,7 @@ describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
     await callback({}, { _meta: {} });
 
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(readEvents()).toHaveLength(0);
   });
 
   it('does not warn when client sent a progressToken (long budget OK)', async () => {
@@ -64,6 +99,7 @@ describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
     );
 
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(readEvents()).toHaveLength(0);
   });
 
   it('warns when configured budget exceeds MCP SDK default AND no progressToken', async () => {
@@ -86,6 +122,9 @@ describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
     expect(ctx['tool']).toBe('consensus_vote');
     expect(ctx['configuredTimeoutMs']).toBe(600_000);
     expect(ctx['mcpSdkDefaultMs']).toBe(MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS);
+    // #2703: the WARN log carries the correlation eventId that the recorded
+    // event will share.
+    expect(typeof ctx['eventId']).toBe('string');
   });
 
   it('still invokes the underlying handler even when warning fires', async () => {
@@ -98,5 +137,119 @@ describe('toSdkCallbackWithBudgetCheck (#2619 / #2631 audit)', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith({ key: 'value' });
     expect(result.content[0]?.text).toBe('ok');
+  });
+});
+
+describe('toSdkCallbackWithBudgetCheck #2703 telemetry — correlation-keyed JSONL', () => {
+  it('records a success event with eventId matching the WARN log', async () => {
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      passthroughHandler,
+      'consensus_vote',
+      600_000,
+      logger
+    );
+
+    await callback({}, { _meta: {} });
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    const [, logCtx] = logger.warn.mock.calls[0] as [string, Record<string, unknown>];
+    // Same eventId in both places — the join key the Epic #2631 gate needs.
+    expect(event.eventId).toBe(logCtx['eventId']);
+    expect(event.toolName).toBe('consensus_vote');
+    expect(event.configuredTimeoutMs).toBe(600_000);
+    expect(event.mcpSdkDefaultMs).toBe(MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS);
+    expect(event.outcome).toBe('success');
+    expect(event.errorCategory).toBeUndefined();
+    expect(event.errorMessage).toBeUndefined();
+    expect(typeof event.startedAt).toBe('string');
+    expect(typeof event.endedAt).toBe('string');
+    expect(event.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records an error event with errorCategory from the post-#2649 envelope', async () => {
+    // Handler returns the post-#2649 structured-error shape: isError:true plus
+    // the envelope in _meta['nexus-agents/error'].
+    const errorHandler = (): Promise<{
+      content: Array<{ type: 'text'; text: string }>;
+      isError: boolean;
+      _meta: Record<string, unknown>;
+    }> =>
+      Promise.resolve({
+        content: [{ type: 'text', text: 'CLI subprocess timed out after 600000ms' }],
+        isError: true,
+        _meta: {
+          'nexus-agents/error': {
+            errorCategory: 'timeout',
+            isRetryable: true,
+            message: 'CLI timeout',
+          },
+        },
+      });
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(errorHandler, 'consensus_vote', 600_000, logger);
+
+    await callback({}, { _meta: {} });
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.outcome).toBe('error');
+    expect(event.errorCategory).toBe('timeout');
+    expect(event.errorMessage).toContain('timed out after 600000ms');
+  });
+
+  it('records an error event when the handler throws', async () => {
+    const throwingHandler = (): Promise<never> => {
+      throw new Error('handler exploded');
+    };
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      throwingHandler,
+      'consensus_vote',
+      600_000,
+      logger
+    );
+
+    await expect(callback({}, { _meta: {} })).rejects.toThrow('handler exploded');
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.outcome).toBe('error');
+    expect(events[0]!.errorMessage).toBe('handler exploded');
+    expect(events[0]!.errorCategory).toBeUndefined();
+  });
+
+  it('records nothing when no mismatch fires (the non-mismatch path stays silent)', async () => {
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      passthroughHandler,
+      'short_tool',
+      MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS - 1_000,
+      logger
+    );
+
+    await callback({}, { _meta: {} });
+
+    expect(readEvents()).toHaveLength(0);
+  });
+
+  it('eventIds are unique across mismatched calls', async () => {
+    const logger = makeMockLogger();
+    const callback = toSdkCallbackWithBudgetCheck(
+      passthroughHandler,
+      'consensus_vote',
+      600_000,
+      logger
+    );
+
+    await callback({}, { _meta: {} });
+    await callback({}, { _meta: {} });
+
+    const events = readEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0]!.eventId).not.toBe(events[1]!.eventId);
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
@@ -8,6 +8,10 @@
  * (Source: Issue #271, CVE-2026-0621 mitigation)
  */
 
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
 import type { ILogger } from '../../core/index.js';
 import type { TimeoutConfig, SecurityConfig } from '../../config/schemas.js';
 import type { IPolicyFirewall, ExecutionMode } from './policy.js';
@@ -27,6 +31,7 @@ import {
   type ProgressContext,
 } from '../mcp-notifier.js';
 import { createLogger as createInternalLogger, getErrorMessage } from '../../core/index.js';
+import { getNexusDataDir } from '../../config/nexus-data-dir.js';
 
 /**
  * Default timeout configuration.
@@ -246,6 +251,10 @@ type SdkToolResult = {
   content: Array<{ type: 'text'; text: string }>;
   isError?: boolean;
   structuredContent?: Record<string, unknown>;
+  // Post-#2649: the structured error envelope lives in `_meta` under
+  // `nexus-agents/error` (not in `structuredContent`, which is validated
+  // against `outputSchema` even on error results).
+  _meta?: Record<string, unknown>;
 };
 
 function runWithContexts(
@@ -301,6 +310,147 @@ export function toSdkCallback(
 export const MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 /**
+ * Relative path under `$NEXUS_DATA_DIR` for the timeout-mismatch event log.
+ * The #2632 WARN was log-only — useful in tail but not queryable. #2703
+ * records each mismatch event as a JSONL row keyed by a correlation
+ * `eventId` shared with the log entry, so "did mismatch cause this
+ * timeout?" can be answered by joining the warning's eventId against the
+ * recorded outcome — not just counted in aggregate.
+ *
+ * Schema lives at `docs/architecture/MCP_PROTOCOL.md` (Timeout-mismatch
+ * telemetry section).
+ */
+export const TIMEOUT_MISMATCH_TELEMETRY_REL_PATH = 'mcp-telemetry/timeout-mismatch-events.jsonl';
+
+/** A single timeout-mismatch event recorded to the telemetry JSONL. */
+export interface TimeoutMismatchEvent {
+  readonly eventId: string;
+  readonly toolName: string;
+  readonly configuredTimeoutMs: number;
+  readonly mcpSdkDefaultMs: number;
+  readonly startedAt: string;
+  readonly endedAt: string;
+  readonly durationMs: number;
+  readonly outcome: 'success' | 'error';
+  /** From the post-#2649 structured error envelope when present. */
+  readonly errorCategory?: string;
+  readonly errorMessage?: string;
+}
+
+/** Best-effort append — telemetry recording must never fail the user's tool call. */
+function appendTimeoutMismatchEvent(event: TimeoutMismatchEvent): void {
+  try {
+    const path = join(getNexusDataDir(), TIMEOUT_MISMATCH_TELEMETRY_REL_PATH);
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(path, JSON.stringify(event) + '\n', 'utf-8');
+  } catch (err) {
+    wrapperLogger.debug('Best-effort timeout-mismatch event recording failed', {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+/** Pull the post-#2649 errorCategory off an error result's `_meta` envelope. */
+function extractErrorCategoryFromResult(result: SdkToolResult): string | undefined {
+  const envelope = result._meta?.['nexus-agents/error'];
+  if (envelope !== null && typeof envelope === 'object' && 'errorCategory' in envelope) {
+    const cat = (envelope as { errorCategory?: unknown }).errorCategory;
+    if (typeof cat === 'string') return cat;
+  }
+  return undefined;
+}
+
+/** First text-content line of an error result, truncated for logging. */
+function extractErrorMessageFromResult(result: SdkToolResult): string | undefined {
+  const first = result.content[0];
+  if (first?.type === 'text' && typeof first.text === 'string') {
+    return first.text.slice(0, 500);
+  }
+  return undefined;
+}
+
+interface MismatchCallContext {
+  readonly log: ILogger;
+  readonly handler: ToolHandler;
+  readonly args: unknown;
+  readonly progressCtx: ProgressContext | undefined;
+  readonly signal: AbortSignal | undefined;
+  readonly toolName: string;
+  readonly configuredTimeoutMs: number;
+}
+
+interface MismatchOutcome {
+  readonly outcome: 'success' | 'error';
+  readonly errorCategory?: string;
+  readonly errorMessage?: string;
+}
+
+/** Build a complete event record from a finished mismatched call. */
+function buildMismatchEvent(
+  ctx: MismatchCallContext,
+  eventId: string,
+  t0: number,
+  outcome: MismatchOutcome
+): TimeoutMismatchEvent {
+  const t1 = Date.now();
+  return {
+    eventId,
+    toolName: ctx.toolName,
+    configuredTimeoutMs: ctx.configuredTimeoutMs,
+    mcpSdkDefaultMs: MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+    startedAt: new Date(t0).toISOString(),
+    endedAt: new Date(t1).toISOString(),
+    durationMs: t1 - t0,
+    outcome: outcome.outcome,
+    ...(outcome.errorCategory !== undefined ? { errorCategory: outcome.errorCategory } : {}),
+    ...(outcome.errorMessage !== undefined ? { errorMessage: outcome.errorMessage } : {}),
+  };
+}
+
+/** Classify a tool result into a MismatchOutcome (success or structured error). */
+function classifyResult(result: SdkToolResult): MismatchOutcome {
+  if (result.isError !== true) return { outcome: 'success' };
+  const errorCategory = extractErrorCategoryFromResult(result);
+  const errorMessage = extractErrorMessageFromResult(result);
+  return {
+    outcome: 'error',
+    ...(errorCategory !== undefined ? { errorCategory } : {}),
+    ...(errorMessage !== undefined ? { errorMessage } : {}),
+  };
+}
+
+/** Run a mismatched call, recording its outcome to the JSONL. */
+async function runMismatchedCall(ctx: MismatchCallContext): Promise<SdkToolResult> {
+  const eventId = randomUUID();
+  const t0 = Date.now();
+  ctx.log.warn(
+    'MCP tool budget exceeds client default and no progressToken received — request likely to be killed by client before server-side deadline',
+    {
+      tool: ctx.toolName,
+      eventId,
+      configuredTimeoutMs: ctx.configuredTimeoutMs,
+      mcpSdkDefaultMs: MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+      remediation:
+        'Client should pass `onprogress` and `resetTimeoutOnProgress: true` when calling, or extend `options.timeout`. See docs/architecture/MCP_PROTOCOL.md.',
+    }
+  );
+  try {
+    const result = await runWithContexts(ctx.handler, ctx.args, ctx.progressCtx, ctx.signal);
+    appendTimeoutMismatchEvent(buildMismatchEvent(ctx, eventId, t0, classifyResult(result)));
+    return result;
+  } catch (err) {
+    appendTimeoutMismatchEvent(
+      buildMismatchEvent(ctx, eventId, t0, {
+        outcome: 'error',
+        errorMessage: getErrorMessage(err).slice(0, 500),
+      })
+    );
+    throw err;
+  }
+}
+
+/**
  * Like `toSdkCallback`, but emits a one-shot WARN at invocation start when
  * the configured per-tool budget exceeds the MCP SDK client default AND the
  * client did not send a `progressToken`. The call is almost certainly going
@@ -314,6 +464,14 @@ export const MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
  * `toSdkCallback`. Tools whose budget already fits within
  * `MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS` should keep using `toSdkCallback`.
  *
+ * Each mismatch is **also recorded** to
+ * `$NEXUS_DATA_DIR/mcp-telemetry/timeout-mismatch-events.jsonl` with a
+ * correlation `eventId` (also surfaced in the WARN log entry) and the
+ * call's eventual outcome (`success` / `error` + post-#2649 errorCategory
+ * if present). This lets the Epic #2631 gate be answered with data —
+ * "of N mismatches, what fraction ended in a timeout?" — not just counted
+ * in aggregate (#2703).
+ *
  * (Source: audit on #2619 / #2631 — observability for client-timeout mismatch)
  */
 export function toSdkCallbackWithBudgetCheck(
@@ -326,19 +484,18 @@ export function toSdkCallbackWithBudgetCheck(
   return (args: unknown, extra: unknown) => {
     const progressCtx = extractProgressContext(extra);
     const signal = (extra as SdkExtra | undefined)?.signal;
-    if (configuredTimeoutMs > MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS && progressCtx === undefined) {
-      log.warn(
-        'MCP tool budget exceeds client default and no progressToken received — request likely to be killed by client before server-side deadline',
-        {
-          tool: toolName,
-          configuredTimeoutMs,
-          mcpSdkDefaultMs: MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS,
-          remediation:
-            'Client should pass `onprogress` and `resetTimeoutOnProgress: true` when calling, or extend `options.timeout`. See docs/architecture/MCP_PROTOCOL.md.',
-        }
-      );
-    }
-    return runWithContexts(handler, args, progressCtx, signal);
+    const isMismatch =
+      configuredTimeoutMs > MCP_SDK_DEFAULT_REQUEST_TIMEOUT_MS && progressCtx === undefined;
+    if (!isMismatch) return runWithContexts(handler, args, progressCtx, signal);
+    return runMismatchedCall({
+      log,
+      handler,
+      args,
+      progressCtx,
+      signal,
+      toolName,
+      configuredTimeoutMs,
+    });
   };
 }
 


### PR DESCRIPTION
## Summary

Prerequisite for Epic **#2631**. The #2632 WARN-on-mismatch in `toSdkCallbackWithBudgetCheck` was log-only — operators could grep server logs for "budget exceeds client default" but couldn't answer the epic's gate question ("of N mismatched calls, what fraction ended in a timeout?") from queryable data.

Each mismatch is now also appended to `$NEXUS_DATA_DIR/mcp-telemetry/timeout-mismatch-events.jsonl` as one JSON row carrying:

- A correlation **`eventId`** that's also surfaced in the WARN log entry's context — the join key between log and stored outcome.
- The call's eventual outcome — `success` / `error` plus `errorCategory` from the post-#2649 envelope when present.
- Timing (`startedAt`, `endedAt`, `durationMs`) and budget metadata.

The `eventId` is the join key the #2631 disposition vote's Contrarian dissent required: a bare count of "50 mismatches, 10 timeouts" does not prove causation; an event row tied to its own outcome does.

## Scope (what NOT to expect here)

- **Best-effort recording** — a telemetry-write failure logs at `debug` and never fails the user's tool call.
- **Aggregation is out of scope.** "Does mismatch dominate timeouts?" answers belong in `improvement_review` / a fitness report; #2703 just produces the raw data. Once Epic #2631's "~1 week of data" window has accumulated, the aggregation gate can be answered from this file.

## Files

- `packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts` — `extractErrorCategoryFromResult`, `extractErrorMessageFromResult`, `buildMismatchEvent`, `classifyResult`, `runMismatchedCall`, plus the new `TIMEOUT_MISMATCH_TELEMETRY_REL_PATH` / `TimeoutMismatchEvent` exports.
- `packages/nexus-agents/src/mcp/middleware/tool-wrapper-budget-check.test.ts` — 5 new tests (success-recording with shared eventId, error-recording via #2649 envelope, throw-recording, non-mismatch silence, eventId uniqueness) on top of the 4 existing ones.
- `docs/architecture/MCP_PROTOCOL.md` — schema documented in a new "Correlation-keyed event log (#2703)" subsection.
- `.changeset/2703-timeout-mismatch-telemetry.md` — minor.

## Test plan

- [x] eslint + markdownlint clean
- [x] 9/9 budget-check tests pass (4 existing + 5 new)
- [ ] Next merged tool call on a long-budget MCP tool (e.g. `consensus_vote`) produces a row in `~/.nexus-agents/mcp-telemetry/timeout-mismatch-events.jsonl` with the correlation eventId

Closes #2703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)