### PR TITLE
fix(ci): stop System Review from spam-filing identical zero-finding issues

### DIFF
--- a/.github/workflows/system-review.yml
+++ b/.github/workflows/system-review.yml
@@ -14,8 +14,11 @@ on:
         required: false
         default: true
         type: boolean
-  issues:
-    types: [closed]
+  # Note: the `issues: closed` (epic_closed) trigger was REMOVED 2026-05-15
+  # because every epic closure fired a new identical "System Review:
+  # YYYY-MM-DD" issue (#2647 / #2679 / #2687 / #2691 / #2695 / #2700 / #2704
+  # piled up across one session). All metrics were 0; all action items were
+  # vacuous. The weekly cron is the canonical trigger.
 
 permissions: read-all
 
@@ -236,9 +239,27 @@ jobs:
   create-issue:
     name: Create Review Issue
     needs: [check-trigger, run-review]
+    # Gate on actionable signal (#2696 follow-up, 2026-05-15). Previously fired
+    # every run, producing identical zero-finding issues that piled up. Now
+    # only files when at least one phase surfaced something worth a human's
+    # attention: a stale issue, an open vulnerability, or a doc that hasn't
+    # been touched in over a month. Manual `workflow_dispatch` with
+    # `create_issue: true` still files unconditionally.
     if: |
       needs.check-trigger.outputs.should_run == 'true' &&
-      (github.event.inputs.create_issue == 'true' || github.event_name != 'workflow_dispatch')
+      (
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.create_issue == 'true')
+        ||
+        (
+          github.event_name != 'workflow_dispatch' &&
+          (
+            needs.run-review.outputs.issues_stale != '0' ||
+            needs.run-review.outputs.audit_vulns != '0' ||
+            needs.run-review.outputs.docs_claude_age > '30' ||
+            needs.run-review.outputs.docs_arch_age > '30'
+          )
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # The job uses `gh issue create`; the top-level `permissions: read-all`


### PR DESCRIPTION
## Summary

`.github/workflows/system-review.yml` fired on three triggers — weekly cron, manual dispatch, AND **every epic-closure** (`issues: closed` with an `epic` label). The epic-closure trigger was the noise source: every closed epic produced a new "System Review: YYYY-MM-DD" issue, and the `create-issue` body fired unconditionally regardless of whether any phase actually surfaced signal.

Across one session's epic-closures: #2647 / #2679 / #2687 / #2691 / #2695 / #2700 / #2704 — **seven identical issues**, all with 0 stale, 0 vulnerabilities, 0–2 days since doc updates, and the same vacuous action items ("Review stale issues / Update outdated docs / Address vulnerabilities"). All seven were closed as part of this cleanup.

## Two fixes

1. **Drop the `issues: closed` trigger.** Epic closures are already tracked through the epic's own close-comment trail; weekly cron + manual dispatch is the right cadence for a system review.
2. **Gate `create-issue` on actionable signal.** It now only files when at least one phase surfaced something worth a human's attention: a stale issue (`issues_stale != 0`), an open vulnerability (`audit_vulns != 0`), or a tracked doc untouched for >30 days (`docs_claude_age > 30` || `docs_arch_age > 30`). Manual `workflow_dispatch` with `create_issue: true` still files unconditionally so operators can force a snapshot.

No `packages/nexus-agents/src/**` changes — no changeset required.

## Test plan

- [x] YAML is valid
- [ ] Next epic-closure should NOT trigger a System Review run (verified by absence of new system-review issue)
- [ ] Next weekly cron with zero findings should NOT file an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)