### PR TITLE
fix(drift): #2715 expert-factory + #2728 run_pipeline template list + 6th AgentRoleSchema copy

### DIFF
--- a/.changeset/drift-cleanups-round1.md
+++ b/.changeset/drift-cleanups-round1.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+Drift cleanups — round 1 of the #2720 umbrella ([#2715](https://github.com/williamzujkowski/nexus-agents/issues/2715), [#2728](https://github.com/williamzujkowski/nexus-agents/issues/2728), plus a 7th drift instance uncovered along the way).
+
+**#2715 — `createAllBuiltInExperts` now derives from `BUILT_IN_EXPERTS` keys.** The previous hardcoded 9-element list silently dropped `infrastructure-expert`, `qa-expert`, and `data-visualization-expert` from the runtime registry even though `expert list` advertised all 12. A drift test now pins `result.value.length === Object.keys(BUILT_IN_EXPERTS).length` so adding a future expert in `expert-config.ts` can't silently miss the factory.
+
+**#2728 — `run_pipeline` description now reads `listTemplateIds()` dynamically.** The MCP tool description had hardcoded the pre-`general` 4-template list; now it can't drift from `PIPELINE_TEMPLATES`.
+
+**Surfaced en route: a 6-way `AgentRoleSchema` drift cluster.** Fixing #2715 made `createAllBuiltInExperts` actually instantiate the previously-dropped 3 experts — at which point `BaseAgentOptionsSchema.role` (`agents/agent-schemas.ts:95`) rejected `qa_expert` and `data_visualization_expert` as invalid roles. The canonical `AgentRole` type in `core/types/agent.ts:18` includes them; this one Zod copy didn't. Patched here so the experts actually load; the full 6-copy consolidation is tracked in #2720.
+
+Other drifting `AgentRoleSchema` definitions (NOT touched in this PR — each one needs its own review):
+
+- `workflows/workflow-types.ts:52` — 8 values (missing 9 from canonical)
+- `workflows/template-types.ts:112` — 13 values
+- `skills/skill-security-schemas.ts:33` — 11 values
+- `agents/experts/expert-config.ts:95` — 14 values
+
+Same enum, six different copies, none in full agreement. The right fix is one `AgentRoleSchema = z.enum(AGENT_ROLES)` derived from the canonical `AgentRole` type — left for a follow-up because changing schemas in `workflows/` may affect serialized workflow templates.

--- a/packages/nexus-agents/src/agents/agent-schemas.ts
+++ b/packages/nexus-agents/src/agents/agent-schemas.ts
@@ -104,6 +104,8 @@ export const BaseAgentOptionsSchema = z.object({
     'pm_expert',
     'ux_expert',
     'infrastructure_expert',
+    'qa_expert', // #2715 — was missing from this Zod copy; canonical AgentRole has it
+    'data_visualization_expert', // #2715 — same
     'thinker',
     'worker',
     'verifier',

--- a/packages/nexus-agents/src/agents/experts/expert-factory.test.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-factory.test.ts
@@ -344,12 +344,15 @@ describe('ExpertFactory', () => {
   });
 
   describe('createAllBuiltIn', () => {
-    it('should create all built-in experts', () => {
+    it('should create one expert per BUILT_IN_EXPERTS key (no drift, #2715)', () => {
       const result = ExpertFactory.createAllBuiltIn();
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value).toHaveLength(9);
+        // Drift gate: factory output count must match the canonical registry size.
+        // Pre-#2715 the factory hardcoded 9 types while BUILT_IN_EXPERTS had 12,
+        // so `expert list` advertised 12 but only 9 were registered on startup.
+        expect(result.value).toHaveLength(Object.keys(BUILT_IN_EXPERTS).length);
 
         const ids = result.value.map((e) => e.id);
         expect(ids).toContain('code-expert');
@@ -359,6 +362,10 @@ describe('ExpertFactory', () => {
         expect(ids).toContain('security-expert');
         expect(ids).toContain('documentation-expert');
         expect(ids).toContain('testing-expert');
+        // The three that were previously dropped:
+        expect(ids).toContain('infrastructure-expert');
+        expect(ids).toContain('qa-expert');
+        expect(ids).toContain('data-visualization-expert');
       }
     });
 

--- a/packages/nexus-agents/src/agents/experts/expert-factory.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-factory.ts
@@ -341,17 +341,12 @@ export function createManyExperts(
 export function createAllBuiltInExperts(
   options?: CreateExpertOptions
 ): Result<Expert[], FactoryError> {
-  const types: BuiltInExpertType[] = [
-    'code',
-    'architecture',
-    'security',
-    'documentation',
-    'testing',
-    'devops',
-    'research',
-    'pm',
-    'ux',
-  ];
+  // Derive the type list from BUILT_IN_EXPERTS so adding a new expert in
+  // expert-config.ts can't silently drop it here (#2715). The previous
+  // hardcoded 9-element list was missing infrastructure / qa /
+  // data-visualization — those three were listed by `expert list` but
+  // never registered on CLI startup.
+  const types = Object.keys(BUILT_IN_EXPERTS) as BuiltInExpertType[];
 
   const experts: Expert[] = [];
 

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -43,7 +43,7 @@ export const PipelineInputSchema = z.object({
     .max(500)
     .optional()
     .describe('Path to a spec file — content prepended to task for greenfield projects'),
-  /** Override template (dev, research, audit, greenfield). Auto-detected if omitted. */
+  /** Override template — see `listTemplateIds()` for the canonical list (#2728). Auto-detected if omitted. */
   template: z
     .string()
     .max(50)
@@ -159,8 +159,10 @@ function selectStageRegistry(
 // Tool Registration
 // ============================================================================
 
-const RUN_PIPELINE_DESCRIPTION =
-  'Single unified entry point for all pipeline templates (dev/research/audit/greenfield). Auto-detects template from task content or accepts an explicit override.';
+// Templates listed dynamically so a new entry in PIPELINE_TEMPLATES can't
+// drift this description (#2728 — previously hardcoded the pre-`general`
+// 4-template list).
+const RUN_PIPELINE_DESCRIPTION = `Single unified entry point for all pipeline templates (${listTemplateIds().join('/')}). Auto-detects template from task content or accepts an explicit override.`;
 
 /** Register the run_pipeline MCP tool. */
 export function registerPipelineTool(

--- a/scripts/tool-descriptions-data.ts
+++ b/scripts/tool-descriptions-data.ts
@@ -81,7 +81,7 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
   run_dev_pipeline:
     'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).',
   run_pipeline:
-    'Single unified entry point for all pipeline templates (dev/research/audit/greenfield). Auto-detects template from task content or accepts an explicit override.',
+    'Single unified entry point for all pipeline templates (dev/research/audit/greenfield/general). Auto-detects template from task content or accepts an explicit override.',
   pr_review:
     'Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, security, devex, catfish, scope_steward) each emit approve/request_changes/abstain with reasoning and citations. Reuses consensus_vote infra; experimental.',
   supply_chain_tradeoff_panel:


### PR DESCRIPTION
## Summary

Round 1 of the #2720 surface-vs-state-drift epic. Three connected fixes:

1. **#2715** — \`createAllBuiltInExperts\` hardcoded a 9-element type list when \`BUILT_IN_EXPERTS\` has 12. \`infrastructure-expert\`, \`qa-expert\`, \`data-visualization-expert\` were advertised by \`expert list\` but silently never registered on CLI startup. Now derives from \`Object.keys(BUILT_IN_EXPERTS)\`; drift test pins the count.

2. **#2728** — \`run_pipeline\` MCP tool description hardcoded the pre-\`general\` 4-template list. Now reads \`listTemplateIds()\` dynamically so adding to \`PIPELINE_TEMPLATES\` can't drift this description.

3. **Surfaced en route**: fixing #1 made \`createAllBuiltInExperts\` actually instantiate the 3 previously-dropped experts — at which point \`BaseAgentOptionsSchema.role\` in \`agents/agent-schemas.ts:95\` rejected \`qa_expert\` and \`data_visualization_expert\` because it's the 6th copy of \`AgentRoleSchema\` in the codebase, and this copy is missing two values the canonical \`AgentRole\` type has. Patched here so the experts load.

### The bigger drift cluster left for #2720

Six \`AgentRoleSchema\`-shaped enum definitions, none in full agreement. Audit:

| File | Value count | Notable gaps vs canonical \`AgentRole\` type |
|---|---:|---|
| \`core/types/agent.ts:18\` (TS type — canonical) | 17 | — |
| \`agents/agent-schemas.ts:95\` (this PR after) | 17 | (was 15) |
| \`agents/experts/expert-config.ts:95\` | 14 | no thinker/worker/verifier |
| \`workflows/template-types.ts:112\` | 13 | no pm/ux/qa/data_viz |
| \`agents/skills/skill-security-schemas.ts:33\` | 11 | no devops/research/pm/ux/qa/data_viz |
| \`workflows/workflow-types.ts:52\` | 8 | most narrow |

Consolidating to one shared \`z.enum(AGENT_ROLES)\` derived from the canonical type is the right fix but touches workflow templates and serialized state — left for its own PR, tracked in #2720.

## Test plan

- [x] \`expert-factory.test.ts\` — 29/29 pass (was 27/29 broken by the createAllBuiltInExperts change before the agent-schemas patch).
- [x] \`packages/nexus-agents/src/agents/experts/\` suite — 27 test files, 669 tests, all pass.
- [x] eslint + markdownlint clean.
- [x] CLAUDE.md / README regenerated via \`pnpm governance:inject\` (picks up run_pipeline description change).
- [ ] Next CLI startup log should read \`Registered built-in experts: count=12\` (was 9).

Closes #2715, #2728. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)