### PR TITLE
fix(drift): round 2 — #2721 query_trace error messages, #2723 dead estimate_tokens flag, #2730 Dockerfile prefix

### DIFF
--- a/.changeset/drift-cleanups-round2.md
+++ b/.changeset/drift-cleanups-round2.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Drift cleanups — round 2 of the #2720 umbrella ([#2721](https://github.com/williamzujkowski/nexus-agents/issues/2721), [#2723](https://github.com/williamzujkowski/nexus-agents/issues/2723), [#2730](https://github.com/williamzujkowski/nexus-agents/issues/2730)).
+
+- **#2723 — `delegate_to_model` removes the dead `estimate_tokens` flag.** The field was declared in two schemas (`DelegateInputSchema`, `TOOL_SCHEMA`) plus echoed in `cli-server-stpa.ts` and `v2-delegate.ts`'s `DelegateInputLike` interface, but no consumer read it. Calling `delegate_to_model { estimate_tokens: true }` returned the same response as omitting the flag. Removed from all four sites + the test that pinned its propagation through the v2 pipeline. The `estimated_tokens` output field is unchanged.
+- **#2730 — `repo_analyze.hasDockerfile` matches `Dockerfile.<purpose>`.** The exact-match check missed `Dockerfile.npm-verify`, `Dockerfile.opencode`, `Dockerfile.sandbox` (this repo) and similar multi-target setups elsewhere. Now uses prefix match (`e === 'Dockerfile' || e.startsWith('Dockerfile.')`). Test fixture pins the new positive cases and a negative case (`Dockerfiler` doesn't match). `repo_security_plan`'s container-scanner recommendation will now appear for repos that genuinely have Dockerfiles.
+- **#2721 — `query_trace` emits clean per-category error messages.** The old `sanitizeErrorMessage` regex stripped paths starting with `/` but left relative segments exposed, producing artifacts like `errorMessage: "ENOENT: no such file or directory, stat 'runs<path>'"`. Replaced with `userFacingTraceError(err, runId)` that classifies and synthesizes a deterministic message per category — matching the pattern `query_task_state` already uses (`"No state log for task: …"`). No sanitization needed because we never include filesystem text.

--- a/packages/nexus-agents/src/cli-server-stpa.ts
+++ b/packages/nexus-agents/src/cli-server-stpa.ts
@@ -32,7 +32,7 @@ export const TOOL_DEFINITIONS: readonly ToolDefinition[] = [
         task: { type: 'string', description: 'Task to execute or analyze' },
         preferred_capability: { type: 'string', description: 'Preferred capability for routing' },
         model_hint: { type: 'string', description: 'Explicit model preference' },
-        estimate_tokens: { type: 'boolean', description: 'Return token estimate only' },
+        // estimate_tokens flag removed (#2723) — was never read downstream.
       },
       required: ['task'],
     },

--- a/packages/nexus-agents/src/exports/export-contracts.test.ts
+++ b/packages/nexus-agents/src/exports/export-contracts.test.ts
@@ -236,7 +236,7 @@ describe('Export contracts — delegate helpers', () => {
   it('exports selectModel', () => {
     expect(typeof selectModel).toBe('function');
     const req = analyzeDelegateTask('analyze code');
-    const result = selectModel({ task: 'analyze code', estimate_tokens: false }, req);
+    const result = selectModel({ task: 'analyze code' }, req);
     expect(typeof result.model).toBe('string');
     expect(typeof result.reasoning).toBe('string');
     expect(Array.isArray(result.alternatives)).toBe(true);

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
@@ -64,11 +64,12 @@ export const DelegateInputSchema = z.object({
     .max(100)
     .optional()
     .describe('Explicit model preference (e.g., claude-opus, gemini-pro)'),
-  estimate_tokens: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe('If true, return token estimate only without execution'),
+  // estimate_tokens flag removed (#2723). The field was declared in two schemas
+  // (here and in TOOL_SCHEMA below) but never read by any consumer — calling
+  // `delegate_to_model { estimate_tokens: true }` returned the full routing
+  // decision identical to omitting the flag. The output already carries
+  // `estimated_tokens` so the use case the flag advertised is satisfied
+  // without the flag.
   billing_mode: z
     .enum(['plan', 'api'])
     .optional()
@@ -260,6 +261,6 @@ export const TOOL_SCHEMA = {
     .optional()
     .describe('Preferred capability for routing'),
   model_hint: z.string().max(100).optional().describe('Explicit model preference'),
-  estimate_tokens: z.boolean().optional().describe('Return token estimate only'),
+  // estimate_tokens removed (#2723) — see comment above on DelegateInputSchema.
   billing_mode: z.enum(['plan', 'api']).optional().describe('Billing mode for cost handling'),
 };

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
@@ -216,10 +216,7 @@ describe('delegate_to_model Tool', () => {
         needsExploration: false,
       };
 
-      const result = selectModel(
-        { task: 'test', model_hint: 'gemini-flash', estimate_tokens: false },
-        requirements
-      );
+      const result = selectModel({ task: 'test', model_hint: 'gemini-flash' }, requirements);
 
       expect(result.model).toBe('gemini-flash');
       expect(result.reasoning).toContain('explicitly requested');
@@ -239,10 +236,7 @@ describe('delegate_to_model Tool', () => {
         needsExploration: false,
       };
 
-      const result = selectModel(
-        { task: 'complex analysis', estimate_tokens: false },
-        requirements
-      );
+      const result = selectModel({ task: 'complex analysis' }, requirements);
 
       // Top-tier models should be selected for reasoning tasks
       expect([
@@ -270,10 +264,7 @@ describe('delegate_to_model Tool', () => {
         needsExploration: false,
       };
 
-      const result = selectModel(
-        { task: 'implement function', estimate_tokens: false },
-        requirements
-      );
+      const result = selectModel({ task: 'implement function' }, requirements);
 
       expect(result.alternatives.length).toBeLessThanOrEqual(3);
       result.alternatives.forEach((alt) => {

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
@@ -43,7 +43,6 @@ describe('delegate_to_model Tool', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.task).toBe('Analyze this codebase');
-        expect(result.data.estimate_tokens).toBe(false);
       }
     });
 
@@ -52,7 +51,6 @@ describe('delegate_to_model Tool', () => {
         task: 'Implement a new feature',
         preferred_capability: 'code',
         model_hint: 'claude-sonnet',
-        estimate_tokens: true,
       };
       const result = DelegateInputSchema.safeParse(input);
 
@@ -60,7 +58,6 @@ describe('delegate_to_model Tool', () => {
       if (result.success) {
         expect(result.data.preferred_capability).toBe('code');
         expect(result.data.model_hint).toBe('claude-sonnet');
-        expect(result.data.estimate_tokens).toBe(true);
       }
     });
 

--- a/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
@@ -88,12 +88,26 @@ export function classifyTraceError(err: unknown): TraceErrorCategory {
   return 'unknown';
 }
 
-/** Sanitize error message: remove file paths and stack traces. */
-function sanitizeErrorMessage(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message.replace(/\/[^\s:]+/g, '<path>');
+/**
+ * Build a clean, deterministic user-facing error message for a trace-query
+ * failure (#2721). The previous `sanitizeErrorMessage` regex stripped paths
+ * starting with `/` but left their relative-root segment exposed, producing
+ * artifacts like `stat 'runs<path>'` that told the user nothing about what
+ * actually went wrong. Synthesize the message from the classified category
+ * instead — same approach as `query_task_state` ("No state log for task: X").
+ */
+function userFacingTraceError(err: unknown, runId: string): string {
+  const category = classifyTraceError(err);
+  switch (category) {
+    case 'not_found':
+      return `No trace file for runId '${runId}'`;
+    case 'permission_error':
+      return `Permission denied reading trace for runId '${runId}'`;
+    case 'parse_error':
+      return `Trace file for runId '${runId}' is malformed (invalid JSONL)`;
+    default:
+      return 'Failed to read trace';
   }
-  return 'An unexpected error occurred';
 }
 
 /** Parse JSONL content into records, skipping malformed lines. */
@@ -157,7 +171,7 @@ export async function queryTraceFromDisk(
     };
   } catch (err: unknown) {
     const category = classifyTraceError(err);
-    const message = sanitizeErrorMessage(err);
+    const message = userFacingTraceError(err, input.runId);
 
     if (category === 'not_found') {
       traceLogger.debug('Trace file not found', { runId: input.runId });

--- a/packages/nexus-agents/src/mcp/tools/repo-analyze.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/repo-analyze.test.ts
@@ -483,6 +483,22 @@ describe('analyzeRepo', () => {
     expect(r2.hasDockerfile).toBe(true);
   });
 
+  it('detects Dockerfile.<purpose> variants (#2730)', () => {
+    // The repo this codebase lives in has Dockerfile.npm-verify /
+    // Dockerfile.opencode / Dockerfile.sandbox — the pre-fix exact-match
+    // check reported hasDockerfile: false against the nexus-agents repo.
+    const r1 = analyzeRepo(baseMetadata, ['Dockerfile.sandbox']);
+    expect(r1.hasDockerfile).toBe(true);
+
+    const r2 = analyzeRepo(baseMetadata, ['Dockerfile.dev', 'Dockerfile.prod']);
+    expect(r2.hasDockerfile).toBe(true);
+
+    // Negative: a string that starts with 'Dockerfile' but isn't one
+    // (no dot suffix) should NOT match — e.g. a file literally named 'Dockerfiler'.
+    const r3 = analyzeRepo(baseMetadata, ['Dockerfiler']);
+    expect(r3.hasDockerfile).toBe(false);
+  });
+
   it('detects Helm charts via Chart.yaml', () => {
     const result = analyzeRepo(baseMetadata, ['Chart.yaml']);
     expect(result.hasHelmCharts).toBe(true);

--- a/packages/nexus-agents/src/mcp/tools/repo-analyze.ts
+++ b/packages/nexus-agents/src/mcp/tools/repo-analyze.ts
@@ -290,8 +290,11 @@ export function analyzeRepo(
     packageManager: detectPackageManager(topLevelEntries),
     ciProvider,
     securityTooling: secTooling,
+    // Match `Dockerfile`, `Dockerfile.<purpose>` (e.g. `Dockerfile.sandbox`),
+    // and docker-compose variants. Pre-#2730 the check was exact-match only,
+    // so a repo with three legitimate `Dockerfile.*` files reported false.
     hasDockerfile:
-      topLevelEntries.includes('Dockerfile') ||
+      topLevelEntries.some((e) => e === 'Dockerfile' || e.startsWith('Dockerfile.')) ||
       topLevelEntries.includes('docker-compose.yml') ||
       topLevelEntries.includes('docker-compose.yaml'),
     hasHelmCharts:

--- a/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
@@ -137,14 +137,8 @@ describe('delegateInputToTaskContract', () => {
     expect(contract.metadata['billingMode']).toBe('plan');
   });
 
-  it('preserves estimate_tokens flag in metadata', () => {
-    const input: DelegateInputLike = {
-      task: 'Count tokens',
-      estimate_tokens: true,
-    };
-    const contract = delegateInputToTaskContract(input);
-    expect(contract.metadata['estimateTokens']).toBe(true);
-  });
+  // estimate_tokens flag removed (#2723) — was never read downstream;
+  // the test that pinned its propagation is no longer applicable.
 
   it('omits undefined optional fields from metadata', () => {
     const input: DelegateInputLike = { task: 'Simple task' };

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -60,7 +60,6 @@ export interface DelegateInputLike {
   readonly preferred_capability?: string | undefined;
   readonly model_hint?: string | undefined;
   readonly billing_mode?: string | undefined;
-  readonly estimate_tokens?: boolean | undefined;
 }
 
 /** Metrics from V2 pipeline execution. */
@@ -88,9 +87,7 @@ export function delegateInputToTaskContract(input: DelegateInputLike): TaskContr
   if (input.billing_mode !== undefined) {
     metadata['billingMode'] = input.billing_mode;
   }
-  if (input.estimate_tokens === true) {
-    metadata['estimateTokens'] = true;
-  }
+  // estimate_tokens flag removed (#2723) — was never read downstream.
   return buildBaseTaskContract({
     idPrefix: 'delegate',
     task: input.task,


### PR DESCRIPTION
## Summary

Round 2 of the #2720 surface-vs-state-drift epic. Three small fixes batched because each is a one-or-two-file change in the same theme.

| # | Fix |
|---|---|
| **#2723** | `delegate_to_model` removes the dead `estimate_tokens` flag — was declared in two schemas + echoed in `cli-server-stpa.ts` + `v2-delegate.ts` interface, but no consumer read it. Removed from all 4 sites + the v2-delegate test that pinned the no-op metadata propagation. |
| **#2730** | `repo_analyze.hasDockerfile` now matches `Dockerfile.<purpose>` variants via prefix-match. Test fixture covers positive cases (`Dockerfile.sandbox`, `Dockerfile.dev`) and a negative (`Dockerfiler` doesn't match). Fixes the downstream `repo_security_plan` container-coverage false-negative. |
| **#2721** | `query_trace` emits clean per-category error messages via `userFacingTraceError(err, runId)` — same pattern `query_task_state` already uses. No more `errorMessage: "ENOENT: no such file or directory, stat 'runs<path>'"` artifacts. |

## Test plan

- [x] `expert-factory + repo-analyze + delegate-to-model + v2-delegate + query-trace-tool` test suites: 153 tests pass.
- [x] eslint clean across all 8 changed files.
- [ ] After merge: `query_trace { runId: "nonexistent" }` returns `errorMessage: "No trace file for runId 'nonexistent'"` (no `<path>` artifact).
- [ ] After merge: `repo_analyze { repo: "williamzujkowski/nexus-agents" }` reports `hasDockerfile: true`.

Closes #2721, #2723, #2730. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)