### PR TITLE
fix(drift): round 3 — #2725 wire auth probe into isCliAvailable, #2727 stubs exit non-zero

### DIFF
--- a/.changeset/drift-cleanups-round3.md
+++ b/.changeset/drift-cleanups-round3.md
@@ -1,0 +1,8 @@
+---
+'nexus-agents': patch
+---
+
+Drift cleanups — round 3 of the #2720 umbrella ([#2725](https://github.com/williamzujkowski/nexus-agents/issues/2725), [#2727](https://github.com/williamzujkowski/nexus-agents/issues/2727)).
+
+- **#2725 — `isCliAvailable` now consults the auth probe alongside `healthCheck()`.** The #2447 fix added a real authentication probe and applied it to `doctor`, but the parallel consumer `isCliAvailable` (and the `getAvailableClis` rollup it powers) kept the binary-detection-only path — so `nexus-agents orchestrate --dry-run --verbose` listed `opencode` as "Available" when the user wasn't logged in. The factory now runs `adapter.healthCheck()` and `probeCli(cli)` in parallel; a CLI is reported available only when both pass. Cache entries record the auth-failure reason in the `message` field so a follow-up `doctor` doesn't have to re-probe.
+- **#2727 — Unimplemented CLI subcommands now exit non-zero and write to stderr.** The `expert create` / `expert execute` / unimplemented `workflow` subcommands previously printed `"The 'X' command is coming soon."` to **stdout** and exited with `EXIT_CODES.SUCCESS (0)` — automation scripts couldn't detect the no-op. Now: stderr, exit `EXIT_CODES.NOT_IMPLEMENTED (4)`, and when an MCP equivalent exists (`create_expert`, `execute_expert`), the message names it so the operator has an escape hatch today.

--- a/packages/nexus-agents/src/cli-adapters/factory.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.ts
@@ -19,6 +19,7 @@ import { OpenCodeCliAdapter } from './adapters/opencode-adapter.js';
 import type { ILogger } from '../core/index.js';
 import type { ICliDetectionCache } from './cli-detection-cache.js';
 import { CliDetectionCache } from './cli-detection-cache.js';
+import { probeCli } from '../cli/cli-auth-probe.js';
 
 /**
  * Configuration for creating a CLI adapter.
@@ -134,14 +135,35 @@ export async function isCliAvailable(cli: CliName, cache?: ICliDetectionCache): 
 
   try {
     const adapter = createCliAdapter({ cli });
-    const health = await adapter.healthCheck();
+    // Pre-#2725 only ran healthCheck() — which confirms the binary exists
+    // and runs but does NOT probe authentication. Result: orchestrate listed
+    // opencode as "Available" when the user wasn't logged in, and the next
+    // call failed with an opaque subprocess error. Auth must agree with the
+    // probe doctor already uses (cli-auth-probe.ts, #2447).
+    const [health, auth] = await Promise.all([adapter.healthCheck(), probeCli(cli)]);
+    const available = health.healthy && auth.state === 'authenticated';
 
-    // Store in cache if provided
+    // Store in cache if provided. Synthesize a degraded health record when
+    // the binary is healthy but auth failed, so downstream consumers see
+    // "unavailable" without losing the version string.
     if (cache !== undefined) {
-      cache.set(cli, CliDetectionCache.fromHealthStatus(health));
+      if (available) {
+        cache.set(cli, CliDetectionCache.fromHealthStatus(health));
+      } else {
+        cache.set(cli, {
+          healthy: false,
+          version: health.version,
+          versionStatus: health.versionStatus,
+          checkedAt: new Date(),
+          message:
+            auth.state === 'authenticated'
+              ? health.message
+              : `auth: ${auth.state}` + ('reason' in auth ? ` (${auth.reason})` : ''),
+        });
+      }
     }
 
-    return health.healthy;
+    return available;
   } catch {
     // Store negative result in cache
     if (cache !== undefined) {

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -75,11 +75,31 @@ export {
 } from './cli-commands-handlers-complex.js';
 
 /**
- * Handles unimplemented commands with a coming soon message.
+ * Handles unimplemented CLI subcommands. Writes to stderr (not stdout) so
+ * a shell script piping stdout doesn't silently consume the notice, and
+ * the caller is expected to follow up with `process.exit(EXIT_CODES.NOT_IMPLEMENTED)`.
+ *
+ * Pre-#2727 this wrote to stdout and callers exited with EXIT_CODES.SUCCESS —
+ * automation scripts couldn't tell that nothing happened.
+ *
+ * Where possible we name the equivalent MCP tool the user CAN call today
+ * (e.g. `expert create` → `create_expert` MCP tool), so the message
+ * carries an escape hatch.
  */
+const MCP_EQUIVALENTS: Record<string, string> = {
+  'expert create': 'create_expert',
+  'expert execute': 'execute_expert',
+};
+
 export function handleUnimplementedCommand(command: string): void {
-  process.stdout.write(`The '${command}' command is coming soon.\n`);
-  process.stdout.write('Run "nexus-agents --help" for available options.\n');
+  const equiv = MCP_EQUIVALENTS[command];
+  process.stderr.write(`The '${command}' CLI subcommand is not yet implemented.\n`);
+  if (equiv !== undefined) {
+    process.stderr.write(
+      `Equivalent today: run \`nexus-agents --mode=server\` and call the \`${equiv}\` MCP tool.\n`
+    );
+  }
+  process.stderr.write('Run "nexus-agents --help" for available options.\n');
 }
 
 /**
@@ -92,7 +112,7 @@ export function handleExpertCommand(args: ParsedCliArgs): void {
     process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
   } else {
     handleUnimplementedCommand(`expert ${args.subcommand ?? ''}`);
-    process.exit(EXIT_CODES.SUCCESS);
+    process.exit(EXIT_CODES.NOT_IMPLEMENTED);
   }
 }
 
@@ -120,7 +140,7 @@ export async function handleWorkflowCommand(args: ParsedCliArgs): Promise<void> 
     process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
   } else {
     handleUnimplementedCommand(`workflow ${args.subcommand ?? ''}`);
-    process.exit(EXIT_CODES.SUCCESS);
+    process.exit(EXIT_CODES.NOT_IMPLEMENTED);
   }
 }
 

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -22,6 +22,8 @@ export const EXIT_CODES = {
   SERVER_START_FAILED: 1,
   SHUTDOWN_ERROR: 2,
   INVALID_ARGS: 3,
+  /** Subcommand is stubbed / advertised but not implemented (#2727). */
+  NOT_IMPLEMENTED: 4,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Round 3 of the #2720 surface-vs-state-drift epic. Two fixes that touch the CLI's "is this command/CLI actually usable" surface.

### #2725 — `isCliAvailable` now consults the auth probe

The #2447 fix added a real authentication probe (`cli-auth-probe.ts`) and applied it to `doctor`. But the parallel consumer `isCliAvailable` in `cli-adapters/factory.ts:126` kept the binary-detection-only path. Result: `nexus-agents orchestrate --dry-run --verbose` listed `opencode` as "Available" when the operator wasn't logged in, and the next call would fail with an opaque subprocess error.

`isCliAvailable` now runs `adapter.healthCheck()` and `probeCli(cli)` in parallel and reports available iff **both** pass. Cache entries for a failed auth case record the reason in the `message` field, so a follow-up `doctor` doesn't have to re-probe.

Affected downstream consumers (they all stop seeing opencode-as-available when auth fails): `getAvailableClis`, `voter-agents`, `auto-adapter`, `mcp/middleware/adapter-availability`, `orchestrate-command`.

### #2727 — Unimplemented subcommands exit non-zero + tell the user about MCP equivalents

`handleUnimplementedCommand` previously wrote `"The 'expert create' command is coming soon."` to **stdout** and the dispatcher exited `EXIT_CODES.SUCCESS (0)`. A shell script automating `nexus-agents expert create ...; echo $?` saw `0` even though nothing happened.

Three fixes:
- Write to **stderr**.
- New \`EXIT_CODES.NOT_IMPLEMENTED (4)\` returned by all dispatch sites that hit a stub.
- `MCP_EQUIVALENTS` table maps `expert create` → `create_expert` and `expert execute` → `execute_expert` — when an MCP equivalent exists, the message names it so the operator has an escape hatch today.

## Test plan

- [x] \`packages/nexus-agents/src/cli-adapters/factory.test.ts\` — 20 tests pass.
- [x] \`packages/nexus-agents/src/cli-commands-handlers.test.ts\` — 16 tests pass.
- [x] \`pnpm typecheck\` clean.
- [ ] After merge: `nexus-agents orchestrate --dry-run --verbose` does NOT list `opencode` as Available when `doctor` says it's unauthenticated.
- [ ] After merge: `nexus-agents expert create x y; echo $?` prints `4`.

Closes #2725, #2727. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)