### PR TITLE
fix(drift): round 4 — #2718 getWeatherContext reads correct field; #2722 tighten MCP_KEYWORDS

### DIFF
--- a/.changeset/drift-cleanups-round4.md
+++ b/.changeset/drift-cleanups-round4.md
@@ -1,0 +1,8 @@
+---
+'nexus-agents': patch
+---
+
+Drift cleanups — round 4 of the #2720 umbrella ([#2718](https://github.com/williamzujkowski/nexus-agents/issues/2718), [#2722](https://github.com/williamzujkowski/nexus-agents/issues/2722) partial).
+
+- **#2718 — `getWeatherContext` now reads `m.recommendedCli` (the real field).** The pre-fix code cast `recommendedMappings` to `Array<{cli: string}>` and read `m.cli`, which doesn't exist — so every agent invocation that called `getWeatherContext` had `category → undefined` lines injected into its plan/exec prompt context. The mock in `agent-executor.test.ts` had propagated the same wrong shape, hiding the bug from tests. Test fixture now drift-gates on a literal `'→ undefined'` substring.
+- **#2722 (partial) — Tighten `MCP_KEYWORDS`.** Removed `'interact'` and `'browse'` — both false-positive on plain English (`"how do these components interact?"` flipped `needsMcp` true and silently filtered out gemini; `'browse the documentation'` did the same). Replaced with the explicit phrases `'mcp tool'`, `'browse the web'`, `'browser automation'`. Test fixture pins the negative cases (`'interact'` in normal prose → `needsMcp: false`) and the positive cases (`'browser automation'` → `needsMcp: true`). #2722's other two sub-bugs (adapter-availability check + reasoning-text accuracy) tracked separately under the same issue — #2725 already addressed half of (b) downstream.

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-helpers.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-helpers.test.ts
@@ -98,6 +98,30 @@ describe('analyzeTask', () => {
     expect(result.needsSpeed).toBe(false);
     expect(result.needsCodeGen).toBe(false);
   });
+
+  it('does NOT flip needsMcp on the plain-English word "interact" (#2722)', () => {
+    // Pre-#2722 MCP_KEYWORDS contained 'interact' which matched any prose
+    // using the verb in its English sense. Tasks like the architecture-review
+    // task below silently triggered the MCP filter, dropping gemini even
+    // though the task had nothing to do with MCP.
+    const result = analyzeTask(
+      'Review the architecture: how do voter roles and aggregation interact?'
+    );
+    expect(result.needsMcp).toBe(false);
+  });
+
+  it('does NOT flip needsMcp on "browse the documentation" (#2722)', () => {
+    // 'browse' was equally over-broad; replaced with the more explicit
+    // 'browse the web' / 'browser automation' phrases.
+    const result = analyzeTask('browse the documentation for the X library');
+    expect(result.needsMcp).toBe(false);
+  });
+
+  it('does flip needsMcp on explicit MCP phrases', () => {
+    expect(analyzeTask('Use an mcp tool to do X').needsMcp).toBe(true);
+    expect(analyzeTask('Needs computer use for screenshots').needsMcp).toBe(true);
+    expect(analyzeTask('Browser automation to fill the form').needsMcp).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-types.ts
@@ -236,8 +236,23 @@ export const AUDIO_OUTPUT_KEYWORDS = [
   'narrate',
 ] as const;
 
-/** Keywords indicating MCP tool needs (Issue #685). */
-export const MCP_KEYWORDS = ['mcp', 'tool use', 'computer use', 'browse', 'interact'] as const;
+/**
+ * Keywords indicating the task explicitly needs MCP tool invocation
+ * (Issue #685). Phrases must be unambiguous — `'interact'` and `'browse'`
+ * (the pre-#2722 entries) false-positive on plain English: a task asking
+ * "how do these components **interact**?" flipped `needsMcp` true and
+ * silently filtered out gemini, then misleadingly reported "prefer gemini"
+ * while picking a non-gemini model. Keep entries explicit MCP / browser-
+ * automation phrases.
+ */
+export const MCP_KEYWORDS = [
+  'mcp',
+  'mcp tool',
+  'tool use',
+  'computer use',
+  'browse the web',
+  'browser automation',
+] as const;
 
 /** Keywords indicating exploration/research tasks (Issue #807). */
 export const EXPLORATION_KEYWORDS = [

--- a/packages/nexus-agents/src/pipeline/agent-executor.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.test.ts
@@ -173,9 +173,13 @@ describe('createAgentStages — central workflow hub', () => {
       mockGetOutcomeSummaryText.mockReturnValue('');
       mockGenerateWeatherReport.mockReturnValue({
         overall: { totalTasks: 30, successRate: 0.9, avgDurationMs: 2000 },
+        // Real RecommendedMapping shape — `recommendedCli`, not `cli`.
+        // Pre-#2718 the consumer read `m.cli` (which doesn't exist on the
+        // real type) and emitted "category → undefined"; this mock had
+        // propagated the same wrong shape, hiding the bug from tests.
         recommendedMappings: [
-          { category: 'code_generation', cli: 'claude' },
-          { category: 'research', cli: 'gemini' },
+          { category: 'code_generation', recommendedCli: 'claude' },
+          { category: 'research', recommendedCli: 'gemini' },
         ],
       });
       mockExecuteExpert.mockResolvedValue({
@@ -192,6 +196,9 @@ describe('createAgentStages — central workflow hub', () => {
       expect(call[1]).toContain('code_generation');
       expect(call[1]).toContain('claude');
       expect(call[1]).toContain('gemini');
+      // Drift gate: the prompt must NOT contain the literal "undefined"
+      // string the pre-fix consumer was producing.
+      expect(call[1]).not.toContain('→ undefined');
     });
 
     it('handles empty outcome store gracefully', async () => {

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -237,9 +237,15 @@ async function getWeatherContext(): Promise<string> {
     const report = generateWeatherReport({ includeAdaptive: true });
     const mappings = 'recommendedMappings' in report ? report.recommendedMappings : [];
     if (!Array.isArray(mappings) || mappings.length === 0) return '';
-    const lines = (mappings as Array<{ category: string; cli: string }>)
-      .map((m) => `  ${m.category} → ${m.cli}`)
-      .join('\n');
+    // Pre-#2718 this read `m.cli` via a wrong `as Array<{cli: string}>`
+    // cast — `RecommendedMapping` has `recommendedCli`, not `cli`, so every
+    // line rendered as "category → undefined". Cast to the real shape from
+    // weather-report-types.ts.
+    const typedMappings = mappings as ReadonlyArray<{
+      readonly category: string;
+      readonly recommendedCli: string;
+    }>;
+    const lines = typedMappings.map((m) => `  ${m.category} → ${m.recommendedCli}`).join('\n');
     return (
       `\n\n## CLI Health (${String(report.overall.totalTasks)} tasks, ` +
       `${String(Math.round(report.overall.successRate * 100))}% success)\n` +


### PR DESCRIPTION
## Summary

Round 4 of the #2720 epic. Two small fixes both in the delegate/agent routing path.

### #2718 — `getWeatherContext` reads `m.recommendedCli` (not the non-existent `m.cli`)

Pre-fix: \`agent-executor.ts:240\` cast \`recommendedMappings\` to \`Array<{cli: string}>\` and read \`m.cli\` — but \`RecommendedMapping\` (the real type from \`weather-report-types.ts:120\`) has \`recommendedCli\`, not \`cli\`. Every agent invocation that called \`getWeatherContext\` had \`category → undefined\` lines injected into its plan/exec prompt context. The mock in \`agent-executor.test.ts\` propagated the same wrong shape, hiding the bug from tests.

Drift gate added: assert prompt does NOT contain \`'→ undefined'\`.

### #2722 (partial) — Tighten `MCP_KEYWORDS`

Pre-fix: \`MCP_KEYWORDS = ['mcp', 'tool use', 'computer use', 'browse', 'interact']\`. Both \`'interact'\` and \`'browse'\` false-positive on plain English. The architecture-task wording \`"how do voter roles and aggregation interact?"\` flipped \`needsMcp\` true, silently filtered gemini out, and the reasoning text misleadingly read \`"architecture task (prefer gemini)"\` while picking opencode-custom-opus.

Replaced with explicit phrases: \`'mcp tool'\`, \`'browse the web'\`, \`'browser automation'\`. Test fixture pins negative (plain prose → \`needsMcp: false\`) AND positive (\`'browser automation'\` → \`needsMcp: true\`) cases.

The other two #2722 sub-bugs — no adapter-availability check, misleading reasoning text — are tracked separately; #2725 addressed half of the availability check already.

## Test plan

- [x] \`delegate-to-model-helpers.test.ts\` — 28 tests pass (3 new for #2722).
- [x] \`agent-executor.test.ts\` — 64 tests pass, including the new \`'→ undefined'\` drift gate for #2718.
- [x] \`pnpm typecheck\` + eslint clean.

Closes #2718; partial progress on #2722. Epic #2720 progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)