### PR TITLE
fix(governance): fitness-audit bails cleanly when run against installed npm package (#2716)

### DIFF
--- a/.changeset/drift-cleanups-round5b-fitness.md
+++ b/.changeset/drift-cleanups-round5b-fitness.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Round 5b — fix fitness-audit's published-package false-finding cascade ([#2716](https://github.com/williamzujkowski/nexus-agents/issues/2716)).
+
+The audit's `existsSync` checks look at `SRC_ROOT`-relative paths (`cli-adapters/composite-router.ts`, `cli/doctor.ts`, etc.). The actual cause of the "CompositeRouter missing / No CLAUDE.md / 0 createLogger / Missing Doctor" findings I originally diagnosed as "CWD-dependent": **`npx nexus-agents fitness-audit` resolves to the GLOBAL `npm install -g nexus-agents` binary**, not the local workspace bundle. The published 2.76.0 package ships `src/` containing **only** `workflows/` (workflow templates loaded at runtime) — none of the dirs fitness-audit checks for. So every existsSync returned false against the installed copy.
+
+`audit()` now checks for `${SRC_ROOT}/cli-adapters` at the start; if missing, returns a single info-level finding with score 0 telling the operator to run from the source repo (or use `pnpm fitness-audit` from the workspace root). Same audit run from a real source checkout is unchanged.
+
+This also stops `improvement_review` from emitting bogus tech-debt signals downstream of the fitness-audit pollution.

--- a/packages/nexus-agents/src/governance/fitness-score.ts
+++ b/packages/nexus-agents/src/governance/fitness-score.ts
@@ -213,6 +213,20 @@ export class FitnessScoreCalculator {
     const findings: FitnessFinding[] = [];
     const dimensions: Record<string, number> = {};
 
+    // #2716 — the audit's existsSync checks look at SRC_ROOT-relative paths
+    // (cli-adapters/composite-router.ts, cli/doctor.ts, etc). When run from
+    // an `npm install -g nexus-agents` copy, SRC_ROOT points at the installed
+    // package's `src/` which only contains workflow templates — not the full
+    // source tree. Result: every existsSync returns false and the audit
+    // emits a parade of fictional "missing" findings against a healthy
+    // source tree. (`npx nexus-agents fitness-audit` from a repo root hits
+    // this path because npx resolves to the GLOBAL bin, not the local
+    // workspace bundle.) Bail with a clear single-finding result instead.
+    const cliAdaptersDir = join(SRC_ROOT, 'cli-adapters');
+    if (!existsSync(cliAdaptersDir)) {
+      return this.notSourceRepoResult(version);
+    }
+
     for (const check of this.checks) {
       this.logger.debug(`Running fitness check: ${check.name}`);
       const result = check.check();
@@ -242,6 +256,42 @@ export class FitnessScoreCalculator {
       score,
       dimensions: typedDimensions,
       findings,
+      timestamp: new Date().toISOString(),
+      version,
+    };
+  }
+
+  /**
+   * Return when the runtime SRC_ROOT doesn't look like the nexus-agents
+   * source tree (#2716). One finding, score 0 — distinct from "the source
+   * tree is broken" because every existsSync would falsely report missing.
+   */
+  private notSourceRepoResult(version: string): FitnessAudit {
+    const finding: FitnessFinding = {
+      dimension: 'governanceIntegration',
+      severity: 'info',
+      description:
+        'fitness-audit must run against the nexus-agents source repo, ' +
+        `but ${SRC_ROOT}/cli-adapters does not exist. You are likely ` +
+        'running the installed npm package via `npx nexus-agents`, which ' +
+        'ships only the bundled dist/. Clone the source repo and run ' +
+        '`node packages/nexus-agents/dist/cli.js fitness-audit` (or invoke ' +
+        '`pnpm fitness-audit` from the workspace root).',
+      pointsDeducted: 0,
+    };
+    return {
+      score: 0,
+      dimensions: {
+        canonicalPaths: 0,
+        explicitBehavior: 0,
+        determinism: 0,
+        observability: 0,
+        configSimplicity: 0,
+        layerSeparation: 0,
+        operatorErgonomics: 0,
+        governanceIntegration: 0,
+      },
+      findings: [finding],
       timestamp: new Date().toISOString(),
       version,
     };


### PR DESCRIPTION
## Real root cause (different from my original #2716 diagnosis)

I originally called this "CWD-dependent": same dist, score 86 from repo root vs 100 from \`packages/nexus-agents/\`. Wrong diagnosis. The actual mechanism:

- \`npx nexus-agents fitness-audit\` from anywhere resolves to the **global** \`/home/$USER/.local/.../bin/nexus-agents\` symlink → \`~/.../lib/node_modules/nexus-agents/dist/cli.js\` (the published 2.76.0).
- \`node dist/cli.js fitness-audit\` from \`packages/nexus-agents/\` invokes the **local** workspace bundle.

The published package ships \`src/\` containing ONLY \`workflows/\` (the workflow templates loaded at runtime); none of the directories fitness-audit's \`existsSync\` checks for (\`cli-adapters/\`, \`cli/\`, \`governance/\`, etc.). So when run against the installed copy, every existsSync returns false and the audit emits a parade of "missing" findings against a perfectly fine source tree.

## Fix

\`audit()\` precheck-bails when \`SRC_ROOT/cli-adapters\` doesn't exist — returns one info-level finding (score 0) telling the operator the tool needs a source checkout. Source-tree runs are unchanged.

## Downstream cleanup

\`improvement_review\` was reading the fictional fitness findings and surfacing them as critical tech-debt signals (canonicalPaths, governanceIntegration). Those will stop appearing once this lands.

## Acceptance

- [x] \`pnpm typecheck\` clean, eslint clean, governance suite (20 tests) passes.
- [ ] After merge: \`npx nexus-agents fitness-audit\` from any CWD against the npm-installed copy returns one info finding (not 13 fictional ones) + score 0.
- [ ] \`node packages/nexus-agents/dist/cli.js fitness-audit\` from the source repo continues to return real findings + real score.

Closes #2716. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)