### PR TITLE
fix(research): consolidate 3 PaperStatusSchema copies + add deferred + surface Zod details (#2717)

### DIFF
--- a/.changeset/2717-paper-status-drift.md
+++ b/.changeset/2717-paper-status-drift.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+Consolidate the three drifting `PaperStatusSchema` definitions to one canonical source + add `deferred` + surface Zod issues in validation errors ([#2717](https://github.com/williamzujkowski/nexus-agents/issues/2717)).
+
+Pre-fix the codebase had three disagreeing copies of the same enum: `indexer/research-index/research-index-base-types.ts` (6 values incl. in-progress), `research/research-schemas.ts` (5 values, no in-progress), and `cli/research-types.ts:31 PaperImplementationStatus` (4-value TS union with no partial / rejected). The data (`papers.yaml`) used a 7th value, `deferred`, that NONE of them accepted — `nexus-agents research stats` / `research check` / `research refresh` all failed with the opaque message `Validation failed for papers.yaml`, no further detail.
+
+- **Canonical source**: `PaperStatusSchema` in `research-index-base-types.ts` now includes `deferred` (legitimate distinct state — 2 papers have it with a documented `deferral_rationale` + explicit re-open trigger block).
+- **`research/research-schemas.ts`** imports + re-exports the canonical schema; no parallel z.enum.
+- **`cli/research-types.ts`** `PaperImplementationStatus` is now `z.infer<typeof PaperStatusSchema>`-equivalent (TS-only `PaperStatus` re-export).
+- **Validation error path** now includes the first 5 Zod issues in the user-facing message (`Validation failed for <path> — papers.X.implementation_status: Invalid option …; (+N more)`). Pre-fix the issues were stored in `error.details` but never made it to the user.
+
+`research-index-test.ts:539` integration suite (skip-on-invalid-registry) un-blocks once this lands — was silently skipping itself for ~26 days because the registry didn't parse.

--- a/packages/nexus-agents/src/cli/research-types.ts
+++ b/packages/nexus-agents/src/cli/research-types.ts
@@ -26,9 +26,14 @@ export type PaperSource = 'arxiv' | 'conference' | 'journal' | 'preprint';
 export type Relevance = 'high' | 'medium' | 'low';
 
 /**
- * Paper implementation status
+ * Paper implementation status — re-export from the canonical source
+ * (#2717). Pre-fix this was a hand-maintained 4-value union (no `partial`,
+ * `rejected`, or `deferred`), narrower than the Zod schemas it was supposed
+ * to mirror — so the CLI's TypeScript surface rejected values the registry
+ * happily stored.
  */
-export type PaperImplementationStatus = 'not-started' | 'planned' | 'in-progress' | 'implemented';
+export type PaperImplementationStatus =
+  import('../indexer/research-index/research-index-base-types.js').PaperStatus;
 
 /**
  * Research paper entry in papers.yaml

--- a/packages/nexus-agents/src/indexer/research-index/research-index-base-types.ts
+++ b/packages/nexus-agents/src/indexer/research-index/research-index-base-types.ts
@@ -41,7 +41,14 @@ export const TechniqueStatusSchema = z.enum([
 export type TechniqueStatus = z.infer<typeof TechniqueStatusSchema>;
 
 /**
- * Paper implementation status.
+ * Paper implementation status. Canonical source for this enum (#2717).
+ * Other files MUST import this; do not re-declare a parallel z.enum.
+ *
+ * `deferred` is its own state — distinct from `rejected` (won't-do-ever),
+ * `not-started` (haven't-gotten-to-it), and `in-progress` (working-on-it).
+ * Used by papers that the team consciously deferred with a documented
+ * `deferral_rationale` + explicit `Re-open triggers:` block. Pre-#2717 the
+ * 2 papers using it failed strict validation against this schema.
  */
 export const PaperStatusSchema = z.enum([
   'implemented',
@@ -50,6 +57,7 @@ export const PaperStatusSchema = z.enum([
   'in-progress',
   'not-started',
   'rejected',
+  'deferred',
 ]);
 export type PaperStatus = z.infer<typeof PaperStatusSchema>;
 

--- a/packages/nexus-agents/src/indexer/research-index/research-index-parser.ts
+++ b/packages/nexus-agents/src/indexer/research-index/research-index-parser.ts
@@ -50,6 +50,30 @@ import {
  * The cli/research-helpers-io.ts path still scaffolds files on disk; this
  * one just doesn't fail loudly when nothing's there.
  */
+/**
+ * Build a ResearchIndexParseError that surfaces Zod issue details (#2717).
+ * Pre-fix the user-facing message was just `Validation failed for <path>`
+ * even though the Zod result.error carried the issues array.
+ */
+function buildValidationError(filePath: string, validationErr: unknown): ResearchIndexParseError {
+  const zodErr = validationErr as {
+    issues?: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }>;
+  };
+  const issues = zodErr.issues ?? [];
+  const issuesPreview = issues
+    .slice(0, 5)
+    .map((i) => `${i.path.slice(0, 4).join('.')}: ${i.message}`)
+    .join('; ');
+  const more = issues.length > 5 ? ` (+${String(issues.length - 5)} more)` : '';
+  return new ResearchIndexParseError(
+    issuesPreview.length > 0
+      ? `Validation failed for ${filePath} — ${issuesPreview}${more}`
+      : `Validation failed for ${filePath}`,
+    filePath,
+    validationErr
+  );
+}
+
 function readYamlFile<T>(
   filePath: string,
   schema: { safeParse: (data: unknown) => { success: boolean; data?: T; error?: unknown } },
@@ -74,14 +98,7 @@ function readYamlFile<T>(
 
     const result = schema.safeParse(parsed);
     if (!result.success) {
-      return {
-        ok: false,
-        error: new ResearchIndexParseError(
-          `Validation failed for ${filePath}`,
-          filePath,
-          result.error
-        ),
-      };
+      return { ok: false, error: buildValidationError(filePath, result.error) };
     }
 
     return { ok: true, value: result.data as T };

--- a/packages/nexus-agents/src/research/research-schemas.ts
+++ b/packages/nexus-agents/src/research/research-schemas.ts
@@ -87,16 +87,19 @@ export const TechniqueStatusSchema = z.enum([
 export type TechniqueStatus = z.infer<typeof TechniqueStatusSchema>;
 
 /**
- * Paper implementation status.
+ * Paper implementation status — import + re-export from the canonical
+ * source (#2717). Previously this file declared a parallel z.enum that
+ * disagreed with both `indexer/research-index/research-index-base-types.ts`
+ * (the other Zod copy) and `cli/research-types.ts` (the TS type union).
+ * The import binds the name in this module so the schema can be used in
+ * the object below; the re-export keeps existing consumers working.
  */
-export const PaperStatusSchema = z.enum([
-  'implemented',
-  'planned',
-  'partial',
-  'not-started',
-  'rejected',
-]);
-export type PaperStatus = z.infer<typeof PaperStatusSchema>;
+import {
+  PaperStatusSchema as _PaperStatusSchema,
+  type PaperStatus as _PaperStatus,
+} from '../indexer/research-index/research-index-base-types.js';
+export const PaperStatusSchema = _PaperStatusSchema;
+export type PaperStatus = _PaperStatus;
 
 /**
  * Technique priority levels.


### PR DESCRIPTION
Round 7 of the #2720 epic. The fattest drift cluster I found in Wave 1 — three disagreeing copies of the same enum across the codebase.

## Before

| Source | Values |
|---|---|
| \`indexer/research-index/research-index-base-types.ts:46\` | implemented, planned, partial, **in-progress**, not-started, rejected (6) |
| \`research/research-schemas.ts:92\` | implemented, planned, partial, not-started, rejected (5 — no in-progress) |
| \`cli/research-types.ts:31\` \`PaperImplementationStatus\` | not-started, planned, in-progress, implemented (4 — no partial, rejected) |
| \`papers.yaml\` (data) | **deferred** appears 2× — NO definition accepts it |

`nexus-agents research stats / research check / research refresh` all failed with `Validation failed for papers.yaml`, no further detail.

## After

- **Canonical**: `PaperStatusSchema` in `research-index-base-types.ts` is the single source. Now includes `deferred` (legitimate distinct state — has documented `deferral_rationale` + explicit re-open trigger block in the data).
- **`research/research-schemas.ts`** imports + re-exports the canonical schema.
- **`cli/research-types.ts`** `PaperImplementationStatus` is the TS infer of the canonical schema.
- **Validation errors** now embed the first 5 Zod issues:
  ```
  Validation failed for papers.yaml — papers.X.implementation_status: Invalid option ...; (+N more)
  ```

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `research-index/` + `research/` test suites — 278 pass.
- [x] `tsx` invocation of `parseRegistry` against the real registry succeeds (no error output).
- [ ] After merge: `nexus-agents research stats` succeeds.
- [ ] The `research-index-test.ts:539` integration suite (`describe.skipIf(!registryParseable)`) un-blocks — was silently skipping itself for ~26 days because the registry didn't parse.

Closes #2717. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)