### PR TITLE
fix(repo_analyze): detect gitleaks via .gitleaks.toml (#2732)

### DIFF
--- a/.changeset/2732-security-plan-gitleaks.md
+++ b/.changeset/2732-security-plan-gitleaks.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+`repo_analyze` / `repo_security_plan`: detect gitleaks via `.gitleaks.toml` ([#2732](https://github.com/williamzujkowski/nexus-agents/issues/2732)).
+
+Pre-fix the `detectSecurityTooling` rule list didn't include gitleaks config files, so a repo with `.gitleaks.toml` at the top level reported `existingTooling: [security-policy, codeowners, semgrep, codeql]` — gitleaks invisible. Downstream `repo_security_plan` consequently showed `coverage[secrets] = { covered: true, scanners: [] }` (covered by existing-but-undetected tooling), which read as inconsistent.
+
+Now matches `.gitleaks.toml` (canonical), `gitleaks.toml` (legacy), and `.gitleaksignore`. `existingTooling` includes `gitleaks` when any are present; `coverage[secrets]` now has the matching tool in `scanners` or in `existing` consistently.
+
+The other #2732 sub-bugs (`ciSnippet: null` for most scanners, "3 critical SCA scanners" priority noise) are scanner-registry data work — they're tracked separately because they're 60+ lines of YAML edits, not a code fix.

--- a/packages/nexus-agents/src/mcp/tools/repo-analyze.ts
+++ b/packages/nexus-agents/src/mcp/tools/repo-analyze.ts
@@ -80,17 +80,30 @@ function detectWorkflowSecurity(
   return found;
 }
 
+/** Root-level config files that imply a security tool is in use. */
+const ROOT_SECURITY_FILES: ReadonlyArray<readonly [readonly string[], string]> = [
+  [['.semgrep.yml', '.semgrep'], 'semgrep'],
+  [['.snyk'], 'snyk'],
+  [['SECURITY.md'], 'security-policy'],
+  [['.grype.yaml'], 'grype'],
+  [['CODEOWNERS'], 'codeowners'],
+  // gitleaks (#2732). Catches `.gitleaks.toml` (canonical) plus legacy
+  // `gitleaks.toml` / `.gitleaksignore` variants. Without this, a repo
+  // carrying `.gitleaks.toml` reported `existingTooling` without gitleaks,
+  // and `repo_security_plan` then showed `secrets: covered: true,
+  // scanners: []` (covered by existing-but-undetected tooling).
+  [['.gitleaks.toml', 'gitleaks.toml', '.gitleaksignore'], 'gitleaks'],
+];
+
 /** Detect security tooling from root files and CI workflow filenames (#1674). */
 export function detectSecurityTooling(
   entries: readonly string[],
   workflowEntries?: readonly string[]
 ): readonly string[] {
   const tools: string[] = [];
-  if (entries.includes('.semgrep.yml') || entries.includes('.semgrep')) tools.push('semgrep');
-  if (entries.includes('.snyk')) tools.push('snyk');
-  if (entries.includes('SECURITY.md')) tools.push('security-policy');
-  if (entries.includes('.grype.yaml')) tools.push('grype');
-  if (entries.includes('CODEOWNERS')) tools.push('codeowners');
+  for (const [files, tool] of ROOT_SECURITY_FILES) {
+    if (files.some((f) => entries.includes(f))) tools.push(tool);
+  }
   if (workflowEntries !== undefined) {
     tools.push(...detectWorkflowSecurity(workflowEntries, tools));
   }


### PR DESCRIPTION
Round 8 of the #2720 epic. Small fix that resolves the main #2732 user-visible symptom.

\`detectSecurityTooling\` didn't have a rule for gitleaks config files, so a repo carrying \`.gitleaks.toml\` at the top level reported \`existingTooling\` without gitleaks. Downstream \`repo_security_plan\` then showed \`coverage[secrets] = { covered: true, scanners: [] }\` — covered by existing-but-undetected tooling. Now matches \`.gitleaks.toml\` (canonical), \`gitleaks.toml\` (legacy), and \`.gitleaksignore\`.

Also refactored the detector to a table-driven \`ROOT_SECURITY_FILES\` list to stay under the complexity cap and make future additions trivial.

The other #2732 sub-bugs (\`ciSnippet: null\` for most scanners, 3 critical SCA scanners priority noise) are scanner-registry YAML edits in `repo-security-plan-fallback.ts` — tracked separately.

## Test plan

- [x] \`repo-analyze.test.ts\` 81 tests pass.
- [x] eslint + typecheck clean.

Partial close on #2732. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)