### PR TITLE
fix(research): arxiv parse null on no <entry> + HTML-decode titles (#2719 main path)

### DIFF
--- a/.changeset/2719-arxiv-feed-fallback.md
+++ b/.changeset/2719-arxiv-feed-fallback.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Fix the main belief-pollution path: `parseArxivXml` no longer falls back to feed-level XML when no `<entry>` is present ([#2719](https://github.com/williamzujkowski/nexus-agents/issues/2719)).
+
+`extractEntryXml` used to return the full feed XML when the arXiv API response contained no `<entry>` tags (paper not found / API miss). The feed's outer `<title>` is something like `arXiv Query: search_query=&id_list=X&start=0&max_results=10` — which then got persisted as the paper's "title" and recorded as a belief-memory learning. `memory_query` audit found 1671 belief rows, a substantial fraction shaped like:
+
+```
+topic=routing, priority=P2 learned-pattern Added paper: arXiv Query: search_query=&amp;id_list=2602.03814&amp;...
+```
+
+— including HTML-encoded ampersands because XML entities weren't decoded.
+
+`extractEntryXml` now returns `null` when no `<entry>` is found; `parseArxivXml` returns `null` instead of inventing data. `decodeXmlEntities` runs over the title + summary so persisted text is plain.
+
+The other #2719 sub-findings (typed/mobimem backends 0 entries despite "available"; decay 100 runs / 0 evictions) are separate; they need a "where are the writers, do they fire" audit and aren't blocked by this fix.

--- a/packages/nexus-agents/src/cli/research-helpers-arxiv.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-arxiv.ts
@@ -40,9 +40,25 @@ export interface ArxivFetchError {
  * Extracts the first &lt;entry&gt; block from arXiv Atom XML to avoid
  * matching feed-level metadata (e.g., feed title "arXiv Query: ...").
  */
-function extractEntryXml(xml: string): string {
+function extractEntryXml(xml: string): string | null {
   const entryMatch = xml.match(/<entry>([\s\S]*?)<\/entry>/);
-  return entryMatch?.[1] ?? xml;
+  // Pre-#2719 this fell back to returning the full feed XML when no
+  // <entry> tag was present. The feed-level <title> for a no-results
+  // query is literally "arXiv Query: search_query=&id_list=X&start=0&
+  // max_results=10" — which then got persisted as the paper's "title"
+  // and recorded as a belief learning. Return null so the caller surfaces
+  // a genuine "paper not found" instead of inventing one.
+  return entryMatch?.[1] ?? null;
+}
+
+/** Decode the XML entities arXiv encodes in `<title>` / `<summary>` content. */
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
 }
 
 /**
@@ -50,6 +66,9 @@ function extractEntryXml(xml: string): string {
  */
 function parseArxivXml(arxivId: string, xml: string): ArxivMetadata | null {
   const entryXml = extractEntryXml(xml);
+  // No <entry> tag → no paper. Return null so the caller treats this as
+  // a fetch miss (#2719) rather than synthesizing data from the feed.
+  if (entryXml === null) return null;
 
   const titleMatch = entryXml.match(/<title>([^<]+)<\/title>/);
   const summaryMatch = entryXml.match(/<summary>([^<]+)<\/summary>/s);
@@ -58,11 +77,13 @@ function parseArxivXml(arxivId: string, xml: string): ArxivMetadata | null {
   const titleContent = titleMatch?.[1];
   if (titleContent === undefined || titleContent === '') return null;
 
+  // Decode XML entities (`&amp;` → `&` etc.) so persisted titles are plain
+  // text. Pre-#2719 a title like "Stats &amp; ML" kept the literal token.
   return {
     id: arxivId,
-    title: titleContent.trim().replace(/\s+/g, ' '),
+    title: decodeXmlEntities(titleContent.trim().replace(/\s+/g, ' ')),
     authors: [], // Would need more complex parsing
-    summary: summaryMatch?.[1]?.trim().replace(/\s+/g, ' ') ?? '',
+    summary: decodeXmlEntities(summaryMatch?.[1]?.trim().replace(/\s+/g, ' ') ?? ''),
     published: publishedMatch?.[1] ?? '',
     updated: '',
     categories: [],


### PR DESCRIPTION
Round 9 of the #2720 epic. Fix the main belief-pollution path discovered in Wave 1B.

\`extractEntryXml\` fell back to the full feed XML when no \`<entry>\` was present. The feed's outer \`<title>\` is literally \`arXiv Query: search_query=&id_list=X&start=0&max_results=10\` — which got persisted as the paper's "title" and recorded as a belief-memory learning. \`memory_query\` audit found 1671 belief rows with a substantial fraction looking like:

\`\`\`
topic=routing, priority=P2 learned-pattern Added paper: arXiv Query: search_query=&amp;id_list=2602.03814&amp;...
\`\`\`

— complete with un-decoded HTML entities.

## Fix

- \`extractEntryXml\` returns \`null\` when no \`<entry>\` tag is present (no fallback to feed).
- \`parseArxivXml\` returns \`null\` instead of synthesizing data from the feed.
- New \`decodeXmlEntities\` helper decodes \`&amp;\` / \`&lt;\` etc. for persisted title + summary text.

## Out of scope here (separate #2719 sub-findings)

- \`typed\` / \`mobimem\` backends report \`available: true\` with 0 entries forever — needs a "where are the writers, do they fire" audit. Tracked in the same #2719 but blocked on that audit, not this fix.
- Decay ran 100 times pruning 0 entries — same.

## Test plan

- [x] \`research-helpers-arxiv.test.ts\` 18 tests pass.
- [x] typecheck clean.

Partial close on #2719. Progress on epic #2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)