### PR TITLE
fix(adapter): lazy-init capacityTracker so doctor stops reporting fictional 100% (#2714)

### DIFF
--- a/.changeset/2714-doctor-capacity-tracker.md
+++ b/.changeset/2714-doctor-capacity-tracker.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Fix doctor's fictional "Capacity: 100% remaining" + 4-warning-per-run spam ([#2714](https://github.com/williamzujkowski/nexus-agents/issues/2714)).
+
+`BaseCliAdapter.getCapacity()` warned and returned a hardcoded 100k-token fallback when `capacityTracker` was null. `doctor.ts:337` calls `adapter.getCapacity()` without first running `adapter.initialize()` (which is what assigns the tracker), so every `doctor` invocation logged 4 `Capacity tracker uninitialized` WARNs (one per CLI) AND surfaced a fictional `Capacity: 100% remaining` line in human-readable output — making the gauge look like real data when it was a constant.
+
+`getCapacity()` now lazy-inits the tracker on first read. The pre-existing test that pinned `remainingRequests: 100_000` was checking the fallback value, not anything real — updated to assert the canonical claude defaults from `capacity-tracker.ts` (`100_000` tokens, `50` requests per minute).

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
@@ -514,12 +514,17 @@ describe('CodexCliAdapter (Subprocess)', () => {
   });
 
   describe('getCapacity()', () => {
-    it('should return default fallback capacity when tracker uninitialized', async () => {
+    it('should lazy-init the tracker and return real codex defaults (#2714)', async () => {
+      // Pre-#2714 this test asserted the 100k DEFAULT_CAPACITY_FALLBACK
+      // because getCapacity() bailed when tracker was null without ever
+      // initializing it (Issue #1463 framed that as intentional, but
+      // doctor never called initialize() before getCapacity() so the
+      // fallback fired every time and produced fictional "100%" output).
+      // getCapacity() now lazy-inits — assert the real codex defaults.
       const capacity = await adapter.getCapacity();
 
-      // Before initialize(), tracker is null so fallback is used (Issue #1463)
-      expect(capacity.remainingTokens).toBe(100_000);
-      expect(capacity.remainingRequests).toBe(100_000);
+      expect(capacity.remainingTokens).toBe(500_000); // codex DEFAULT_TOKEN_LIMIT
+      expect(capacity.remainingRequests).toBe(500); // codex DEFAULT_REQUEST_LIMIT
       expect(capacity.exhausted).toBe(false);
       expect(capacity.utilizationPercent).toBe(0);
     });

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
@@ -302,10 +302,12 @@ describe('CodexMcpAdapter', () => {
   });
 
   describe('getCapacity()', () => {
-    it('should return capacity status', async () => {
+    it('should return real codex capacity status (#2714)', async () => {
+      // Pre-#2714 asserted 100k (the DEFAULT_CAPACITY_FALLBACK). Now
+      // lazy-init returns codex's real DEFAULT_TOKEN_LIMIT.
       const capacity = await adapter.getCapacity();
 
-      expect(capacity.remainingTokens).toBe(100_000);
+      expect(capacity.remainingTokens).toBe(500_000); // codex DEFAULT_TOKEN_LIMIT
       expect(capacity.exhausted).toBe(false);
       expect(capacity.utilizationPercent).toBe(0);
     });

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
@@ -291,11 +291,18 @@ describe('BaseCliAdapter', () => {
   });
 
   describe('getCapacity()', () => {
-    it('should return full capacity by default', async () => {
+    it('should return the real CLI default capacity from the tracker (#2714)', async () => {
+      // Pre-#2714 the assertion read `remainingRequests: 100_000` — the
+      // DEFAULT_CAPACITY_FALLBACK constant that getCapacity() returned ONLY
+      // when the tracker was still null. doctor never called initialize()
+      // before getCapacity(), so the fallback fired every time and the
+      // test was pinning the bug behavior. Now getCapacity() lazy-inits
+      // and the test asserts the real claude defaults from capacity-tracker
+      // (claude: 100k tokens / 50 requests per minute).
       const capacity = await adapter.getCapacity();
 
-      expect(capacity.remainingTokens).toBe(100_000);
-      expect(capacity.remainingRequests).toBe(100_000);
+      expect(capacity.remainingTokens).toBe(100_000); // claude DEFAULT_TOKEN_LIMIT
+      expect(capacity.remainingRequests).toBe(50); // claude DEFAULT_REQUEST_LIMIT
       expect(capacity.utilizationPercent).toBe(0);
       expect(capacity.exhausted).toBe(false);
     });

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -254,20 +254,25 @@ export abstract class BaseCliAdapter implements ICliAdapter {
    * @see Issue #456 - Real API rate limit tracking
    */
   getCapacity(): Promise<CapacityStatus> {
+    // Lazy-init the tracker if no caller has run initialize() yet (#2714).
+    // Pre-fix every doctor invocation tripped this path: doctor calls
+    // adapter.getCapacity() WITHOUT first calling adapter.initialize(),
+    // so each of the four adapters logged a "Capacity tracker uninitialized"
+    // WARN and returned a hardcoded 100k-token fallback. The fallback
+    // surfaced in doctor's output as "Capacity: 100% remaining" — a
+    // fictional reading, not a real one. The tracker is per-process and
+    // idempotent under createCapacityTracker, so initializing on first
+    // read is safe.
     if (this.capacityTracker === null) {
-      this.logger.warn('Capacity tracker uninitialized, returning default fallback', {
-        cli: this.name,
-        fallbackTokens: DEFAULT_CAPACITY_FALLBACK,
-      });
-      return Promise.resolve({
-        remainingTokens: DEFAULT_CAPACITY_FALLBACK,
-        remainingRequests: DEFAULT_CAPACITY_FALLBACK,
-        resetTime: new Date(getTimeProvider().now() + 3600_000),
-        utilizationPercent: 0,
-        exhausted: false,
-      });
+      this.initCapacityTracker();
     }
-    return Promise.resolve(this.capacityTracker.getCapacity());
+    const tracker = this.capacityTracker;
+    if (tracker === null) {
+      // Unreachable in practice — initCapacityTracker assigns the field —
+      // but keep the type-safe path for the impossible case.
+      throw new Error(`Capacity tracker initialization failed for ${this.name}`);
+    }
+    return Promise.resolve(tracker.getCapacity());
   }
 
   /**


### PR DESCRIPTION
\`BaseCliAdapter.getCapacity()\` warned and returned a hardcoded 100k-token fallback when \`capacityTracker\` was null. \`doctor.ts:337\` calls \`adapter.getCapacity()\` without first running \`adapter.initialize()\` (which assigns the tracker), so every \`doctor\` invocation logged 4 \`Capacity tracker uninitialized\` WARNs (one per CLI) AND surfaced \`Capacity: 100% remaining\` — fictional, not real.

\`getCapacity()\` now lazy-inits the tracker on first read. Per-process, idempotent, safe.

The existing test asserted \`remainingRequests: 100_000\` — the fallback value when the tracker was uninit. Updated to assert the canonical claude defaults from \`capacity-tracker.ts\` (100k tokens, 50 requests/min).

## Test plan

- [x] \`base-adapter.test.ts\` 38 tests pass.
- [x] typecheck + lint clean.

Closes #2714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)