### PR TITLE
fix(delegate_to_model): reasoning text states when preferred CLI was filtered (#2722 final)

### DIFF
--- a/.changeset/2722-reasoning-text.md
+++ b/.changeset/2722-reasoning-text.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+`delegate_to_model` reasoning text now states when the preferred CLI didn't win ([#2722](https://github.com/williamzujkowski/nexus-agents/issues/2722) final sub-bug).
+
+Pre-fix the reasoning line read `architecture task (prefer gemini)` unconditionally, even when gemini got filtered out (by `needsMcp`, score loss, etc.) and an opencode/claude/codex model was actually selected. So an LLM caller reading the response saw text contradicting the recommendation.
+
+`buildReasons` now takes the chosen CLI; if `specialization.primaryCli !== chosenCli` the reasoning says `architecture task (preferred gemini, selected opencode after filtering)`. Same when the preference matches, just without the "selected after filtering" tail.
+
+This closes the third and final #2722 sub-bug. The first two (MCP_KEYWORDS narrowed in #2737, adapter availability via #2735) were resolved earlier.

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-helpers.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-helpers.ts
@@ -209,11 +209,24 @@ export function buildReasons(
   requirements: TaskRequirements,
   pref?: string,
   billingMode: BillingMode = 'api',
-  specialization: SpecializationMatch | null = null
+  specialization: SpecializationMatch | null = null,
+  chosenCli?: string
 ): string[] {
   const reasons = REASON_MAP.filter(([key]) => requirements[key] === true).map(([, desc]) => desc);
-  if (specialization !== null)
-    reasons.push(`${specialization.category} task (prefer ${specialization.primaryCli})`);
+  if (specialization !== null) {
+    // Pre-#2722 this read "architecture task (prefer gemini)" even when
+    // the actual selection was an opencode model (because gemini was
+    // filtered out by needsMcp). The reasoning text now states whether
+    // the preferred CLI was matched, so the explanation doesn't
+    // contradict the recommendation.
+    if (chosenCli !== undefined && specialization.primaryCli !== chosenCli) {
+      reasons.push(
+        `${specialization.category} task (preferred ${specialization.primaryCli}, selected ${chosenCli} after filtering)`
+      );
+    } else {
+      reasons.push(`${specialization.category} task (preferred ${specialization.primaryCli})`);
+    }
+  }
   if (pref !== undefined && pref !== '') reasons.push(`preferred: ${pref}`);
   if (billingMode === 'plan') reasons.push('plan billing (cost ignored)');
   return reasons;
@@ -356,7 +369,8 @@ export function selectModel(
     requirements,
     input.preferred_capability,
     billingMode,
-    specialization
+    specialization,
+    getCliForModel(best.name)
   );
   const reasoning =
     reasons.length > 0


### PR DESCRIPTION
Closes the third and final #2722 sub-bug. Pre-fix reasoning read "architecture task (prefer gemini)" unconditionally — even when gemini was filtered by needsMcp and an opencode/claude model was actually selected. buildReasons now takes the chosen CLI; when specialization.primaryCli != chosenCli the reasoning explicitly says "preferred X, selected Y after filtering".

Closes #2722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)