### PR TITLE
refactor(research): source TechniqueStatus from canonical Zod schema (#2720)

### DIFF
--- a/.changeset/techniquestatus-drift.md
+++ b/.changeset/techniquestatus-drift.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+`TechniqueStatus` in `cli/research-types.ts` is now sourced from the canonical Zod enum (`TechniqueStatusSchema` in `research-index-base-types.ts`) instead of a hand-maintained 5-value union (#2720 umbrella, same shape as the #2717 `PaperImplementationStatus` fix).
+
+Pre-fix both definitions named the same 5 values, so the surface and the schema agreed _right now_ — but nothing forced them to agree the next time someone added a value. The union was redundant code that the next contributor could trivially make wrong. The CLI now reads `import('...').TechniqueStatus`, the same single-source pattern `PaperImplementationStatus` uses.

--- a/packages/nexus-agents/src/cli/research-types.ts
+++ b/packages/nexus-agents/src/cli/research-types.ts
@@ -81,14 +81,12 @@ export interface PapersRegistry {
 // =============================================================================
 
 /**
- * Technique implementation status
+ * Technique implementation status. Sourced from `TechniqueStatusSchema`
+ * (the canonical Zod enum) so the CLI surface and the registry schema
+ * can't drift apart (#2720 umbrella, same shape as #2717).
  */
 export type TechniqueStatus =
-  | 'not-started'
-  | 'planned'
-  | 'in-progress'
-  | 'implemented'
-  | 'rejected';
+  import('../indexer/research-index/research-index-base-types.js').TechniqueStatus;
 
 /**
  * Technique priority level


### PR DESCRIPTION
## Summary
- `cli/research-types.ts:86` hand-maintained the same 5 values that `research-index-base-types.ts:34`'s canonical `TechniqueStatusSchema` enumerates. Pre-fix both agreed, but nothing forced them to agree the next time someone added a value.
- The CLI now re-exports `import('...').TechniqueStatus`, the same single-source pattern `PaperImplementationStatus` adopted in the #2717 fix.

## Why this matters
Surface-vs-state drift (umbrella #2720). Same shape as #2717: a hand-maintained TypeScript union mirroring a canonical Zod enum. The duplication is dormant — values happen to match right now — but the next contributor adds a value to one and forgets the other, and the surface starts rejecting/accepting values the registry disagrees with.

## Test plan
- [x] `pnpm typecheck` clean (TS resolves the cross-file `import('...').T` reference)
- [x] `pnpm vitest run src/cli/research-helpers-status.test.ts` → 35 passed
- [x] Changeset added

Part of #2720 (drift between canonical source and derived type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
