### PR TITLE
fix(system-review): wrong-CWD precondition check (#2760)

### DIFF
--- a/.changeset/2760-system-review-wrong-cwd.md
+++ b/.changeset/2760-system-review-wrong-cwd.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+`system-review` now aborts early with a clear "must run from source repo" error when invoked from a directory that doesn't contain `CLAUDE.md` (#2760, #2720 brainstorm item #5).
+
+Pre-fix `system-review` from `/tmp` ran all five phases anyway. Every tracked doc came back `unknown` → mapped to `stale` by `mapFreshnessStatus` → 7× `DOC_STALE_PENALTY` deducted, plus typecheck/lint fail penalties. The user saw `Health Score: 35/100` (looks "warning-ish") and the docs all marked stale "(0 days)" — surface said "your repo is unhealthy," state said "I'm running in the wrong directory." Same shape as the closed #2716 and #2759.
+
+The fix mirrors #2759: a `detectWrongProjectRoot` precondition checked in `systemReviewCommand` before any phase runs. CLAUDE.md is the canonical marker because it's in the repo root but NOT in the npm tarball — so it cleanly distinguishes "source repo" from "anywhere else."
+
+The dispatcher's exit-code plumbing (#2761) propagates `systemReviewCommand`'s return value via `handleSystemReviewCommand` → confirmed `exit: 1` from `/tmp` with this fix; no separate plumbing change needed for this command.
+
+One regression test pins the wrong-CWD message + early-abort behavior. Verified to fail on pre-fix logic.

--- a/packages/nexus-agents/src/cli/system-review.test.ts
+++ b/packages/nexus-agents/src/cli/system-review.test.ts
@@ -46,8 +46,10 @@ describe('system-review', () => {
     vi.clearAllMocks();
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
-    // Default mocks
-    mockExistsSync.mockReturnValue(false);
+    // Default mocks. CLAUDE.md must exist for #2760's wrong-CWD precondition
+    // to pass; phase-1 file existence is overridden per-test via additional
+    // `mockReturnValueOnce`/`mockImplementation` calls.
+    mockExistsSync.mockImplementation((p: fs.PathLike) => String(p).endsWith('CLAUDE.md'));
     mockExecSync.mockReturnValue('');
     mockAnalyzeFreshness.mockReturnValue({
       documents: [],
@@ -431,6 +433,28 @@ describe('system-review', () => {
 
       const output = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
       expect(output).toContain('Failed to create issue');
+    });
+
+    // #2760: pre-fix `system-review` from /tmp produced "Health Score: 35/100"
+    // (every doc unknown → mapped to stale → 7× DOC_STALE_PENALTY) and exited
+    // 0 anyway. Now: detect "CLAUDE.md missing from projectRoot" up-front and
+    // return 1 with a clear message before running any phases. Same shape as
+    // the closed #2716 + #2759 fixes.
+    it('returns 1 with wrong-CWD message when CLAUDE.md missing from projectRoot', () => {
+      // Override beforeEach default: pretend no file exists, including CLAUDE.md
+      mockExistsSync.mockReturnValue(false);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      const exitCode = systemReviewCommand({ projectRoot: '/tmp' });
+
+      expect(exitCode).toBe(1);
+      const stderr = stderrSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stderr).toContain('system-review must run from the nexus-agents source repo');
+      expect(stderr).toContain('/tmp/CLAUDE.md');
+      // Phase output should NOT have been printed — the precondition aborts early
+      const stdout = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stdout).not.toContain('Phase 1: Registry Reconciliation');
+      stderrSpy.mockRestore();
     });
   });
 

--- a/packages/nexus-agents/src/cli/system-review.ts
+++ b/packages/nexus-agents/src/cli/system-review.ts
@@ -257,6 +257,26 @@ function applyFixes(projectRoot: string, result: SystemReviewResult): string[] {
   return fixes;
 }
 
+/**
+ * Returns the wrong-CWD error message when `projectRoot` doesn't contain
+ * the canonical nexus-agents source files, else null (#2760 / #2720 brainstorm
+ * item #5). Pre-fix `system-review` from `/tmp` produced "Health Score: 35/100"
+ * (every doc unknown → mapped to stale → 7× penalty) and exited 0 — same
+ * silent-fail shape as the closed #2716 and #2759.
+ */
+function detectWrongProjectRoot(projectRoot: string): string | null {
+  // CLAUDE.md is in the repo root, README.md in both the repo root and the
+  // npm tarball — checking CLAUDE.md alone catches "user is not in the
+  // source repo" without false-positives for the installed package.
+  const claudeMd = path.join(projectRoot, 'CLAUDE.md');
+  if (fs.existsSync(claudeMd)) return null;
+  return (
+    `system-review must run from the nexus-agents source repo, but ${claudeMd} ` +
+    `does not exist. Clone the repo and re-run from the workspace root (or pass ` +
+    `--project-root once that flag is wired). The installed npm package ships only the bundled dist/.`
+  );
+}
+
 /** Runs the system review. */
 export function runSystemReview(options: SystemReviewOptions = {}): SystemReviewResult {
   const pr = options.projectRoot ?? process.cwd();
@@ -281,6 +301,13 @@ export function runSystemReview(options: SystemReviewOptions = {}): SystemReview
 
 /** Main system-review command. */
 export function systemReviewCommand(options: SystemReviewOptions = {}): number {
+  const pr = options.projectRoot ?? process.cwd();
+  const wrongRootMessage = detectWrongProjectRoot(pr);
+  if (wrongRootMessage !== null) {
+    process.stderr.write(`${formatStatus('fail')} ${wrongRootMessage}\n`);
+    return 1;
+  }
+
   const result = runSystemReview(options);
   printResult(result);
   if (options.createIssue === true) {


### PR DESCRIPTION
## Summary
- Closes #2760. `system-review` invoked from any directory that doesn't contain `CLAUDE.md` now aborts early with a clear error + exit 1, instead of running all five phases against a non-source-repo CWD and producing a misleading `Health Score: 35/100`.
- Same precondition pattern as #2759 (`index freshness` silent-success fix). CLAUDE.md is the canonical marker — present in the repo root, absent from the npm tarball.

## Smoke output

**From `/tmp` (before/after):**
- Before: 5-phase output, all docs marked stale "(0 days)", Health Score 35/100. Bonus: tests showed exit was 0 because of the dispatcher bug — but with this fix the precondition aborts before any phase runs.
- After: `✗ system-review must run from the nexus-agents source repo, but /tmp/CLAUDE.md does not exist. Clone the repo and re-run from the workspace root (or pass --project-root once that flag is wired). The installed npm package ships only the bundled dist/.` and exits 1.

**From repo root (unchanged):**
- Health Score: 73/100 (real, accurate review), exit 0.

## Why CLAUDE.md as the marker

It's the cleanest discriminant for "source repo vs anywhere else":
- Present at the repo root
- Absent from the npm tarball (governance-only file)
- Stable file name unlikely to be renamed

The detection is intentionally minimal — no walk-up, no auto-recovery. The user gets a one-line error pointing at the exact problem.

## Out of scope (tracked in #2761)
The broader exit-code dispatcher bug still exists in other commands (e.g., `research index check` returns `exitCode: 1` but process exits 0). For `system-review` specifically the dispatcher works correctly — confirmed `exit: 1` from `/tmp` after this fix.

## Test plan
- [x] `pnpm vitest run src/cli/system-review.test.ts` → 21 passed (was 20, +1)
- [x] Pre-fix regression check → new test fails with the expected message-not-found assertion
- [x] `pnpm typecheck`, `pnpm lint` clean
- [x] Smoke from `/tmp` and repo root → outputs match the table above
- [x] Changeset added

Closes #2760. Part of #2720 (brainstorm item #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
