### PR TITLE
fix(arxiv): single-pass XML entity decode (CodeQL #217)

### DIFF
--- a/.changeset/codeql-217-double-escape.md
+++ b/.changeset/codeql-217-double-escape.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Fix CodeQL alert #217 (`js/double-escaping`) in `research-helpers-arxiv.ts`.
+
+The pre-fix `decodeXmlEntities` chained `.replace(/&amp;/g, '&')` followed by `.replace(/&lt;/g, '<')`. Order-sensitive: input `&amp;lt;` (the XML encoding of literal `&lt;`) became `<` instead of `&lt;`. Replaced with a single-pass regex + entity map so each entity is decoded atomically.
+
+Two regression tests pin both behaviors: `Paper &amp;lt;tag&amp;gt; Title` now decodes to `Paper &lt;tag&gt; Title` (one pass), and standard single-encoded input (`&amp; Co.`, `&quot;quoted&quot;`) still decodes correctly. Verified to fail on pre-fix logic.

--- a/packages/nexus-agents/src/cli/research-helpers-arxiv.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-arxiv.test.ts
@@ -66,6 +66,48 @@ describe('research-helpers-arxiv', () => {
       }
     });
 
+    // CodeQL alert #217 (js/double-escaping): pre-fix the entity decoder
+    // chained `.replace(/&amp;/g, '&')` then `.replace(/&lt;/g, '<')`. Input
+    // `&amp;lt;` (the XML encoding of literal `&lt;`) became `<` instead of
+    // `&lt;`. Single-pass decoder fixes the order-sensitivity.
+    it('does not double-unescape XML entities in title (#217)', async () => {
+      const doubleEncoded = `<?xml version="1.0" encoding="UTF-8"?>
+<feed><entry><title>Paper &amp;lt;tag&amp;gt; Title</title>
+<published>2024-01-15T12:00:00Z</published></entry></feed>`;
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(doubleEncoded),
+      } as Response);
+
+      const result = await fetchArxivMetadataResult('2401.12345');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // After one decode pass: &amp;lt; → &lt; (NOT < ). Single pass
+        // preserves the original literal `&lt;` the source intended.
+        expect(result.value.title).toBe('Paper &lt;tag&gt; Title');
+      }
+    });
+
+    it('decodes single-encoded XML entities in title', async () => {
+      const singleEncoded = `<?xml version="1.0" encoding="UTF-8"?>
+<feed><entry><title>Paper &amp; Co. on &quot;quoted&quot; topics</title>
+<published>2024-01-15T12:00:00Z</published></entry></feed>`;
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(singleEncoded),
+      } as Response);
+
+      const result = await fetchArxivMetadataResult('2401.12345');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.title).toBe('Paper & Co. on "quoted" topics');
+      }
+    });
+
     it('should normalize whitespace in title and summary', async () => {
       const xmlWithWhitespace = `<?xml version="1.0" encoding="UTF-8"?>
 <feed>

--- a/packages/nexus-agents/src/cli/research-helpers-arxiv.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-arxiv.ts
@@ -51,14 +51,24 @@ function extractEntryXml(xml: string): string | null {
   return entryMatch?.[1] ?? null;
 }
 
-/** Decode the XML entities arXiv encodes in `<title>` / `<summary>` content. */
+/**
+ * Decode the XML entities arXiv encodes in `<title>` / `<summary>` content.
+ *
+ * Single-pass to avoid the `js/double-escaping` class of bugs CodeQL flagged
+ * as alert #217 — chaining `.replace(/&amp;/g, '&')` followed by
+ * `.replace(/&lt;/g, '<')` double-decodes input like `&amp;lt;` (the XML
+ * encoding of a literal `&lt;`) into `<`. A single regex with a switch
+ * keeps each entity atomic.
+ */
+const XML_ENTITIES: Readonly<Record<string, string>> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+};
 function decodeXmlEntities(s: string): string {
-  return s
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+  return s.replace(/&(?:amp|lt|gt|quot|apos);/g, (m) => XML_ENTITIES[m] ?? m);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Closes CodeQL alert #217 (`js/double-escaping`). The arXiv XML entity decoder chained `.replace(/&amp;/g, '&')` then `.replace(/&lt;/g, '<')`, which double-decodes input like `&amp;lt;` (the XML encoding of a literal `&lt;`) into `<` instead of `&lt;`.
- Single-pass decoder via one regex + entity map keeps each entity atomic. No more order-sensitivity.

## Why this matters
arXiv content occasionally contains pre-encoded XML entities (papers describing markup, code samples in titles). The chained decoder corrupted these. Test case:
- Input title `Paper &amp;lt;tag&amp;gt; Title`
- Before: `Paper <tag> Title` (incorrect — lost the literal `<` `>`)
- After: `Paper &lt;tag&gt; Title` (correct — preserves the encoded markup)

## Test plan
- [x] `pnpm vitest run src/cli/research-helpers-arxiv.test.ts` → 20 passed (was 18, +2 regression tests)
- [x] Pre-fix sed-revert → gate fails with `expected 'Paper <tag> Title' to be 'Paper &lt;tag&gt; Title'`
- [x] Single-encoded input (`&amp; Co.`, `&quot;quoted&quot;`) still decodes correctly
- [x] `pnpm typecheck`, `pnpm lint` clean
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
