### PR TITLE
fix(docs): correct KnnRoutingStage arXiv citation (#2776)

### DIFF
--- a/.changeset/2776-knn-citation.md
+++ b/.changeset/2776-knn-citation.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Correct the arXiv citation for `KnnRoutingStage` (#2776). 7 sites cited arXiv:2507.05370, which is a general-relativity paper on Schwarzschild-de Sitter spacetimes — not KNN routing. The intended source is arXiv:2505.12601 — "Rethinking Predictive Modeling for LLM Routing: When Simple kNN Beats Complex Learned Routers" (May 2025) — which matches `KnnRoutingStage`'s actual implementation (cosine similarity over keyword vectors, K-nearest experience patterns, weighted by success rate).
+
+Discovered during Phase 1 of the memory unification epic (#2766, #2767) when the survey agent fetched arXiv:2507.05370 to verify prior-art citations. Companion PR registers the correct paper in the research registry.
+
+Pure documentation/citation fix; no behavior change.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -78,7 +78,7 @@ export interface StageDependencies {
   resourceStrategyStage: ResourceStrategyStage | undefined;
   /** Distilled rule stage instance (Issue #999) */
   distilledRuleStage: DistilledRuleStage | undefined;
-  /** KNN routing stage instance (arXiv:2507.05370) */
+  /** KNN routing stage instance (arXiv:2505.12601) */
   knnRoutingStage: KnnRoutingStage | undefined;
 }
 
@@ -377,13 +377,13 @@ export async function runDistilledRuleStage(
   return { scores: new Map(scores), rulesApplied };
 }
 
-/** KNN routing stage result. (arXiv:2507.05370) */
+/** KNN routing stage result. (arXiv:2505.12601) */
 export interface KnnRoutingStageResult {
   scores: Map<CliName, number>;
   hasExperience: boolean;
 }
 
-/** Runs KNN experience-based routing stage. (arXiv:2507.05370) */
+/** Runs KNN experience-based routing stage. (arXiv:2505.12601) */
 export async function runKnnRoutingStage(
   task: CliTask,
   candidates: CliName[],

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -68,7 +68,7 @@ export const CompositeRouterConfigSchema = z.object({
   enableLatencyTracking: z.boolean().default(true),
   /** Enable routing memory for learned routing (default: false) (Issue #463, #461) */
   enableRoutingMemory: z.boolean().default(false),
-  /** Enable KNN experience-based routing (default: false) (arXiv:2507.05370) */
+  /** Enable KNN experience-based routing (default: false) (arXiv:2505.12601) */
   enableKnnRouting: z.boolean().default(false),
   /** Weight for latency score in final routing (0-1, default: 0.2) */
   latencyScoreWeight: z.number().min(0).max(1).default(0.2),
@@ -147,7 +147,7 @@ export const DEFAULT_COMPOSITE_CONFIG: CompositeRouterConfig = {
   enableStrategyDistillation: false, // Issue #999 - Automatic strategy distillation (opt-in)
   enableLatencyTracking: true,
   enableRoutingMemory: false,
-  enableKnnRouting: false, // arXiv:2507.05370 - KNN experience-based routing
+  enableKnnRouting: false, // arXiv:2505.12601 - KNN experience-based routing
   enableCapacityBalancing: true, // Issue #807 - Deprioritize exhausted CLIs
   latencyScoreWeight: 0.2,
   billingMode: 'plan',

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -160,7 +160,7 @@ export class CompositeRouter implements ICompositeRouter {
   private resourceStrategyStage?: ResourceStrategyStage;
   /** Distilled rule stage instance (Issue #999) */
   private distilledRuleStage?: DistilledRuleStage;
-  /** KNN routing stage instance (arXiv:2507.05370) */
+  /** KNN routing stage instance (arXiv:2505.12601) */
   private knnRoutingStage?: KnnRoutingStage;
   /** Strategy distiller instance (Issue #999) */
   private strategyDistiller?: StrategyDistiller;
@@ -607,7 +607,7 @@ export class CompositeRouter implements ICompositeRouter {
       resourceStrategyStage: this.resourceStrategyStage,
       // Issue #999 distilled rule stage
       distilledRuleStage: this.distilledRuleStage,
-      // arXiv:2507.05370 KNN routing
+      // arXiv:2505.12601 KNN routing
       knnRoutingStage: this.knnRoutingStage,
     };
   }

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/knn-routing-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/knn-routing-stage.ts
@@ -6,7 +6,7 @@
  * retrieves similar past tasks and weights by success rate.
  *
  * @module cli-adapters/routing/stages/knn-routing-stage
- * (Source: arXiv:2507.05370 — KNN-based model routing)
+ * (Source: arXiv:2505.12601 — KNN-based model routing)
  */
 
 import type { Result } from '../../../core/result.js';


### PR DESCRIPTION
## Summary
- Closes #2776. 7 sites cited arXiv:2507.05370 as the source for `KnnRoutingStage`. That paper is "Limiting geometry and spectral instability in Schwarzschild-de Sitter spacetimes" — general relativity, not KNN routing.
- Correct citation: **arXiv:2505.12601** — "Rethinking Predictive Modeling for LLM Routing: When Simple kNN Beats Complex Learned Routers" (May 2025). Cosine similarity in embedding space + KNN — exactly matches `KnnRoutingStage`'s docstring.
- Discovered during Phase 1 of the memory unification epic (#2766, #2767) when the survey agent fetched both arxiv IDs.

## Sites updated
- `composite-router-stages.ts:81, 380, 386`
- `composite-router-types.ts:71, 150`
- `composite-router.ts:163, 610`
- `routing/stages/knn-routing-stage.ts:9`

## Test plan
- [x] `pnpm typecheck` clean
- [x] grep verifies all 7 sites now cite `arXiv:2505.12601`
- [x] No grep hits for the old `2507.05370`

Pure documentation fix; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
