### PR TITLE
feat(research): register arXiv:2505.12601 (KNN routing) in research registry

### DIFF
--- a/docs/research/registry/papers.yaml
+++ b/docs/research/registry/papers.yaml
@@ -5312,3 +5312,39 @@ papers:
     venue_tier: 0
     quality_score: 2
     evidence_tier: low
+  arxiv-2505.12601:
+    title: 'Rethinking Predictive Modeling for LLM Routing: When Simple kNN Beats Complex Learned Routers'
+    authors: []
+    source: arxiv
+    arxiv_id: '2505.12601'
+    url: https://arxiv.org/abs/2505.12601
+    publication_date: 2025-05
+    venue: null
+    topics:
+      - routing
+    tags:
+      - knn
+      - routing
+      - llm
+      - cosine-similarity
+    reviewed_date: 2026-05-16
+    reviewed_in: ''
+    summary: |
+      Demonstrates that a well-tuned k-Nearest Neighbors (kNN) router matches
+      or outperforms state-of-the-art learned routers across diverse tasks.
+      Uses cosine similarity in embedding space for nearest-neighbor lookup.
+      Theoretical lower-sample-complexity argument for kNN when the embedding
+      space has strong locality. Source paper cited by KnnRoutingStage (#2776).
+    key_findings:
+      - kNN router matches learned-router performance with lower sample complexity
+      - Strong locality in embedding spaces favors cosine-similarity retrieval
+      - Theoretical bounds on sample complexity for kNN routing
+    relevance: high
+    techniques_extracted:
+      - knn-routing
+    related_issues:
+      - 2776
+    implementation_status: implemented
+    venue_tier: 0
+    quality_score: 3
+    evidence_tier: low


### PR DESCRIPTION
## Summary
- Companion to #2777 (the citation source-fix). Adds the canonical arXiv:2505.12601 paper to `docs/research/registry/papers.yaml` so the in-tree bibliography reflects what `KnnRoutingStage` actually implements.
- `techniques_extracted: [knn-routing]` links it to the alignment map (`research-alignment-map.ts`).

## Why
With the source citation fixed in #2777, the registry should reflect the corrected paper too — otherwise the bibliography still implies arXiv:2507.05370 is the source.

## Notes
- Tried via the MCP `research_add` tool. First call timed out, second hit arXiv 429 rate limit, third call succeeded but the tool reformatted the entire papers.yaml (single→double quotes) producing a 1276-line diff for what should be a 36-line addition. Manually appended the entry to keep the diff scoped. **The MCP tool's reformatting behavior is its own follow-up to consider.**

## Test plan
- [x] `papers.yaml` parses (yaml-lint clean)
- [x] Diff is +36 lines, no unrelated reformatting
- [x] Entry follows the same shape as existing entries (e.g., arxiv-2501.06322)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
