### PR TITLE
chore(docs): wave 5 cleanup — 6 stale model-capabilities.ts references

### DIFF
--- a/.changeset/wave5-stale-model-capabilities-refs.md
+++ b/.changeset/wave5-stale-model-capabilities-refs.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+Wave 5 vestigial-code sweep: 6 stale references to `model-capabilities.ts` (renamed to `in-tree-data.ts` in #2546 slice E) updated to point at the current canonical surface.
+
+Waves 3 + 4 (#2617, #2618, #2621, #2622, #2624) scoped their greps to `.md` + `.test.ts` files and to one round of source JSDoc audits. This sweep caught references that slipped through:
+
+- `core/trace-pricing.test.ts:5` — module header docstring
+- `learning/usage-log.ts:15, 38, 57` — 3 sites in JSDoc + interface docs
+- `cli-adapters/adapters/gemini-adapter-helpers.test.ts:25` — inline comment
+- `docs/design/ARCHITECTURE_MAP.json:72` — `canonical_paths.model_registry`
+
+Pure documentation drift; no behavior change. CHANGELOG and `docs/archive/design-v2/` references intentionally left alone (frozen historical context).
+
+Sweep methodology recorded in `cleanup_waves.md` (memory): cheap 15-min version — 5 parallel greps for sprawl filenames, `@deprecated`, dated TODOs, disabled workflows, recent renames. Found 0 hits on the first 4, real findings on the rename pattern (this fix).

--- a/docs/design/ARCHITECTURE_MAP.json
+++ b/docs/design/ARCHITECTURE_MAP.json
@@ -69,7 +69,7 @@
         "DEFAULTS"
       ],
       "canonical_paths": {
-        "model_registry": "src/config/model-capabilities.ts",
+        "model_registry": "src/config/in-tree-data.ts",
         "model_helpers": "src/config/model-config-helpers.ts",
         "app_config": "src/config/schemas.ts",
         "defaults": "src/config/defaults.ts"

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter-helpers.test.ts
@@ -22,7 +22,7 @@ import {
 
 describe('GEMINI_LEGACY_DEFAULTS', () => {
   it('has no per-model overrides (all models in canonical registry)', () => {
-    // All current models are in model-capabilities.ts
+    // All current models are in config/in-tree-data.ts (the canonical registry)
     expect(Object.keys(GEMINI_LEGACY_DEFAULTS.displayNames)).toHaveLength(0);
     expect(Object.keys(GEMINI_LEGACY_DEFAULTS.contextWindows)).toHaveLength(0);
     expect(Object.keys(GEMINI_LEGACY_DEFAULTS.inputCosts)).toHaveLength(0);

--- a/packages/nexus-agents/src/core/trace-pricing.test.ts
+++ b/packages/nexus-agents/src/core/trace-pricing.test.ts
@@ -2,7 +2,7 @@
  * Tests for trace-pricing utilities
  *
  * All pricing is derived from the canonical model registry
- * (config/model-capabilities.ts). No legacy model table.
+ * (config/in-tree-data.ts via getDefaultRegistry()). No legacy model table.
  *
  * @module core/trace-pricing.test
  */

--- a/packages/nexus-agents/src/learning/usage-log.ts
+++ b/packages/nexus-agents/src/learning/usage-log.ts
@@ -12,7 +12,7 @@
  *   2. `loadUsageEvents({...})` — read events for a window, filtered
  *      by model / category.
  *   3. `computeCostUSD(modelId, inputTokens, outputTokens)` — compute
- *      cost from `config/model-capabilities.ts` pricing.
+ *      cost from `config/in-tree-data.ts` pricing via `lookupInTreeCapability`.
  *
  * The `usage` CLI command (cli/usage-command.ts) consumes this for the
  * operator dashboard. Existing OutcomeStore is intentionally untouched
@@ -35,7 +35,7 @@ export interface UsageEvent {
   /** Token counts. */
   readonly inputTokens: number;
   readonly outputTokens: number;
-  /** Cost in USD. Computed at write time from pricing in model-capabilities. */
+  /** Cost in USD. Computed at write time from pricing in `config/in-tree-data.ts`. */
   readonly usdCost: number;
   /** Wall-clock latency in milliseconds. */
   readonly latencyMs: number;
@@ -54,7 +54,7 @@ export interface UsageEvent {
  * Compute cost in USD given a model and token counts. Returns 0 when the
  * model has no pricing data (e.g., free local model, gateway-routed model
  * we don't have rates for). Operators with custom gateways can extend
- * `config/model-capabilities.ts` to add their pricing.
+ * `config/in-tree-data.ts` to add their pricing.
  */
 export function computeCostUSD(modelId: string, inputTokens: number, outputTokens: number): number {
   const cap = lookupInTreeCapability(modelId);


### PR DESCRIPTION
## Summary
- Wave 5 of the periodic vestigial-code sweep. Cleans 6 stale references to `model-capabilities.ts` (renamed to `in-tree-data.ts` in #2546 slice E) that slipped through Waves 3+4 (#2617, #2618, #2621, #2622, #2624).
- Sweep methodology: the "cheap 15-minute version" — 5 parallel greps for sprawl filenames / `@deprecated` / dated TODOs / disabled workflows / recent renames. First 4 patterns came up empty (Waves 1–4 did thorough work). The rename pattern surfaced the 6 hits below.

## Sites updated

- `packages/nexus-agents/src/core/trace-pricing.test.ts:5` — module header
- `packages/nexus-agents/src/learning/usage-log.ts:15, 38, 57` — 3 JSDoc/interface-doc sites
- `packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter-helpers.test.ts:25` — inline comment
- `docs/design/ARCHITECTURE_MAP.json:72` — `canonical_paths.model_registry`

## Intentionally NOT touched

- `CHANGELOG.md` — frozen release history
- `docs/archive/design-v2/as-is.md` — explicitly archived design docs
- Source-file JSDocs that explicitly say *"the legacy `model-capabilities.ts`"* or *"renamed from"* — those are intentional historical context

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` on the 3 affected test files → 41 passed
- [x] `pnpm lint` clean (changeset triggers lint-staged on commit)
- [x] Final grep verification: no remaining `model-capabilities\.ts` refs outside of CHANGELOG / archive / intentional historical-explanation comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
