### PR TITLE
feat(nexus-memory): scaffold workspace package + IMemoryBackend contract (Phase 3 of #2766)

### DIFF
--- a/.changeset/2769-nexus-memory-scaffold.md
+++ b/.changeset/2769-nexus-memory-scaffold.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': minor
+---
+
+Scaffold the `nexus-memory` workspace package (Phase 3 of #2766). Closes #2769.
+
+New package at `packages/nexus-memory/` with:
+
+- **`IMemoryBackend<TKey, TValue>` contract** — every concept-space implements `read`, `write`, `query`, `delete`, `stats`, `close`. Async surface; sync `better-sqlite3` inside.
+- **`MemoryRegistry`** — singleton via `getMemoryRegistry()`, test-injectable via `setMemoryRegistry()`. Backends share one SQLite connection. `createInMemoryMemoryRegistry()` for tests.
+- **`SqliteBackend`** + **`InMemoryBackend`** — both implement the same contract; the contract test in `backends/contract.test.ts` runs against both with identical assertions.
+- **Telemetry** — aggregated counters (default) + opt-in full-audit mode via `NEXUS_MEMORY_AUDIT_MODE=audit` (Phase 2 vote ballot 2: C with 6/7 supermajority). `recordMemoryEvent` / `subscribeToMemoryEvents` / `getMemoryEventCounters`. Audit-mode summaries truncated to 120/240 chars (catfish-mitigation: per-event payload capture, not just counters).
+- **Cold-archive Zod validation** (Phase 2 vote mitigation #1, security dissent) — any backend constructed with `schema` rejects invalid writes via `MemoryValidationError` before they hit storage.
+- **Importer skeleton** — `registerImporter` / `runImporters` with marker-file gating. Phase 4+ migrations plug in concrete importers (MobiMem JSON, OutcomeStore JSONL, agentic.db, etc.). `backupSourceFile` helper renames source to `.bak.<timestamp>` after a successful import.
+
+57 tests across 4 files. Contract test ensures both backends behave identically; telemetry tests pin both default-mode and audit-mode behaviors; importer tests cover idempotency + error isolation.
+
+No nexus-agents migrations yet — that starts in Phase 4 (#2770).

--- a/packages/nexus-memory/package.json
+++ b/packages/nexus-memory/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "nexus-memory",
+  "version": "0.1.0",
+  "description": "Unified memory subsystem for nexus-agents and nexus-eval-* — IMemoryBackend contract, MemoryRegistry, telemetry, one-shot importer",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.9.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "tsup": "^8.5.0",
+    "typescript": "^6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/nexus-memory/src/backends/contract.test.ts
+++ b/packages/nexus-memory/src/backends/contract.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Contract test — every IMemoryBackend implementation must pass these.
+ *
+ * Phase 2 acceptance: "same contract-test passes against both InMemoryBackend
+ * and SqliteBackend." Run the suite once per backend factory.
+ *
+ * @module nexus-memory/backends/contract.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { IMemoryBackend } from '../types.js';
+import { InMemoryBackend, MemoryValidationError } from './memory.js';
+import { SqliteBackend } from './sqlite.js';
+import { resetMemoryTelemetry } from '../telemetry.js';
+
+interface SamplePayload {
+  readonly text: string;
+  readonly count: number;
+}
+
+const SampleSchema = z.object({
+  text: z.string(),
+  count: z.number().int().nonnegative(),
+});
+
+type BackendFactory = (
+  domain: string,
+  schema?: z.ZodType<SamplePayload>
+) => IMemoryBackend<string, SamplePayload>;
+
+const factories: Array<[string, BackendFactory]> = [
+  [
+    'InMemoryBackend',
+    (domain, schema) =>
+      new InMemoryBackend<string, SamplePayload>({
+        domain,
+        ...(schema !== undefined && { schema }),
+      }),
+  ],
+  [
+    'SqliteBackend(:memory:)',
+    (domain, schema) =>
+      new SqliteBackend<string, SamplePayload>({
+        domain,
+        dbPath: ':memory:',
+        ...(schema !== undefined && { schema }),
+      }),
+  ],
+];
+
+for (const [name, factory] of factories) {
+  describe(`IMemoryBackend contract — ${name}`, () => {
+    let backend: IMemoryBackend<string, SamplePayload>;
+
+    beforeEach(() => {
+      resetMemoryTelemetry();
+      backend = factory(`test_${name.replace(/[^a-z0-9]/gi, '_')}`);
+    });
+
+    afterEach(async () => {
+      await backend.close();
+    });
+
+    it('read returns undefined for missing key', async () => {
+      expect(await backend.read('nope')).toBeUndefined();
+    });
+
+    it('write then read round-trips', async () => {
+      await backend.write('k1', { text: 'hello', count: 1 });
+      expect(await backend.read('k1')).toEqual({ text: 'hello', count: 1 });
+    });
+
+    it('write upserts on existing key', async () => {
+      await backend.write('k1', { text: 'first', count: 1 });
+      await backend.write('k1', { text: 'second', count: 2 });
+      expect(await backend.read('k1')).toEqual({ text: 'second', count: 2 });
+    });
+
+    it('delete removes the row and returns true', async () => {
+      await backend.write('k1', { text: 'hi', count: 1 });
+      expect(await backend.delete('k1')).toBe(true);
+      expect(await backend.read('k1')).toBeUndefined();
+    });
+
+    it('delete returns false for missing key', async () => {
+      expect(await backend.delete('nope')).toBe(false);
+    });
+
+    it('query returns all rows when no filter', async () => {
+      await backend.write('a', { text: 'one', count: 1 });
+      await backend.write('b', { text: 'two', count: 2 });
+      const rows = await backend.query();
+      expect(rows).toHaveLength(2);
+    });
+
+    it('query filters by where clause', async () => {
+      await backend.write('a', { text: 'match', count: 1 });
+      await backend.write('b', { text: 'nope', count: 2 });
+      const rows = await backend.query({ where: { text: 'match' } });
+      expect(rows).toEqual([{ text: 'match', count: 1 }]);
+    });
+
+    it('query filters by cli tag', async () => {
+      await backend.write('a', { text: 'x', count: 1 }, { cli: 'claude' });
+      await backend.write('b', { text: 'y', count: 2 }, { cli: 'gemini' });
+      const rows = await backend.query({ cli: 'gemini' });
+      expect(rows).toEqual([{ text: 'y', count: 2 }]);
+    });
+
+    it('query honors limit', async () => {
+      for (let i = 0; i < 5; i++) {
+        await backend.write(`k${String(i)}`, { text: 't', count: i });
+      }
+      const rows = await backend.query({ limit: 2 });
+      expect(rows).toHaveLength(2);
+    });
+
+    it('query honors orderBy + orderDir', async () => {
+      await backend.write('a', { text: 't', count: 3 });
+      await backend.write('b', { text: 't', count: 1 });
+      await backend.write('c', { text: 't', count: 2 });
+      const asc = await backend.query({ orderBy: 'count', orderDir: 'asc' });
+      expect(asc.map((r) => r.count)).toEqual([1, 2, 3]);
+      const desc = await backend.query({ orderBy: 'count', orderDir: 'desc' });
+      expect(desc.map((r) => r.count)).toEqual([3, 2, 1]);
+    });
+
+    it('stats returns count + bounds', async () => {
+      await backend.write('a', { text: 't', count: 1 }, { timestamp: 1000 });
+      await backend.write('b', { text: 't', count: 2 }, { timestamp: 3000 });
+      const stats = await backend.stats();
+      expect(stats.count).toBe(2);
+      expect(stats.oldestTimestamp).toBe(1000);
+      expect(stats.newestTimestamp).toBe(3000);
+    });
+
+    it('stats returns null bounds when empty', async () => {
+      const stats = await backend.stats();
+      expect(stats.count).toBe(0);
+      expect(stats.oldestTimestamp).toBeNull();
+      expect(stats.newestTimestamp).toBeNull();
+    });
+
+    it('close prevents further operations', async () => {
+      await backend.close();
+      await expect(backend.read('k1')).rejects.toThrow(/is closed/);
+    });
+
+    it('close is idempotent', async () => {
+      await backend.close();
+      await expect(backend.close()).resolves.toBeUndefined();
+    });
+
+    // Phase 2 vote mitigation #1 — security dissent. Schema-validation rejects bad writes.
+    it('schema-backed backend rejects invalid writes', async () => {
+      await backend.close();
+      backend = factory(`test_${name.replace(/[^a-z0-9]/gi, '_')}_validated`, SampleSchema);
+      await expect(backend.write('bad', { text: 42 } as unknown as SamplePayload)).rejects.toThrow(
+        MemoryValidationError
+      );
+    });
+
+    it('schema-backed backend accepts valid writes', async () => {
+      await backend.close();
+      backend = factory(`test_${name.replace(/[^a-z0-9]/gi, '_')}_validated2`, SampleSchema);
+      await expect(backend.write('ok', { text: 'hi', count: 1 })).resolves.toBeUndefined();
+    });
+  });
+}

--- a/packages/nexus-memory/src/backends/memory.ts
+++ b/packages/nexus-memory/src/backends/memory.ts
@@ -1,0 +1,200 @@
+/**
+ * In-memory backend — primarily for tests, but also used as the cold-archive
+ * fallback when no `dbPath` is provided.
+ *
+ * Implements {@link IMemoryBackend}; passes the same contract test as
+ * {@link SqliteBackend}.
+ *
+ * @module nexus-memory/backends/memory
+ */
+
+import type { z } from 'zod';
+import { recordMemoryEvent } from '../telemetry.js';
+import type { BackendStats, IMemoryBackend, QueryFilter, WriteMeta } from '../types.js';
+
+interface Row<TValue> {
+  readonly value: TValue;
+  readonly cli?: string;
+  readonly source?: string;
+  readonly timestamp: number;
+  readonly trustTier?: 1 | 2 | 3 | 4;
+}
+
+export interface InMemoryBackendOptions<TValue> {
+  readonly domain: string;
+  /**
+   * Optional Zod schema. Phase 2 vote mitigation #1 (security dissent):
+   * when supplied, every `write()` validates the value first; invalid
+   * payloads throw `MemoryValidationError`.
+   */
+  readonly schema?: z.ZodType<TValue>;
+}
+
+export class MemoryValidationError extends Error {
+  constructor(domain: string, cause: unknown) {
+    super(`nexus-memory: write rejected for domain "${domain}": ${String(cause)}`);
+    this.name = 'MemoryValidationError';
+  }
+}
+
+function buildInMemoryRow<TValue>(value: TValue, meta: WriteMeta | undefined): Row<TValue> {
+  return {
+    value,
+    ...(meta?.cli !== undefined && { cli: meta.cli }),
+    ...(meta?.source !== undefined && { source: meta.source }),
+    timestamp: meta?.timestamp ?? Date.now(),
+    ...(meta?.trustTier !== undefined && { trustTier: meta.trustTier }),
+  };
+}
+
+/** Apply `where`, `orderBy`, `limit` to an in-memory row set. Extracted from
+ * `query` to satisfy the eslint complexity gate. */
+function applyInMemoryFilter<T>(values: T[], filter?: QueryFilter<T>): T[] {
+  let out = values;
+  if (filter?.where !== undefined) {
+    const where = filter.where;
+    out = out.filter((v) => {
+      for (const [k, expected] of Object.entries(where)) {
+        if ((v as Record<string, unknown>)[k] !== expected) return false;
+      }
+      return true;
+    });
+  }
+  if (filter?.orderBy !== undefined) {
+    const orderBy = filter.orderBy;
+    const dir = filter.orderDir === 'desc' ? -1 : 1;
+    out = [...out].sort((a, b) => {
+      const av = (a as Record<string | symbol | number, unknown>)[orderBy];
+      const bv = (b as Record<string | symbol | number, unknown>)[orderBy];
+      if (av === bv) return 0;
+      if (av === undefined || av === null) return 1;
+      if (bv === undefined || bv === null) return -1;
+      return (av < bv ? -1 : 1) * dir;
+    });
+  }
+  if (filter?.limit !== undefined) {
+    out = out.slice(0, filter.limit);
+  }
+  return out;
+}
+
+export class InMemoryBackend<TKey, TValue> implements IMemoryBackend<TKey, TValue> {
+  readonly domain: string;
+  private readonly rows = new Map<TKey, Row<TValue>>();
+  private readonly schema?: z.ZodType<TValue>;
+  private closed = false;
+
+  constructor(options: InMemoryBackendOptions<TValue>) {
+    this.domain = options.domain;
+    if (options.schema !== undefined) {
+      this.schema = options.schema;
+    }
+  }
+
+  async read(key: TKey): Promise<TValue | undefined> {
+    this.assertOpen();
+    const start = Date.now();
+    const row = this.rows.get(key);
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'read',
+      hit: row !== undefined,
+      durationMs: Date.now() - start,
+      key,
+      result: row?.value,
+    });
+    return Promise.resolve(row?.value);
+  }
+
+  private validate(value: TValue): void {
+    if (this.schema === undefined) return;
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new MemoryValidationError(this.domain, result.error);
+    }
+  }
+
+  async write(key: TKey, value: TValue, meta?: WriteMeta): Promise<void> {
+    this.assertOpen();
+    const start = Date.now();
+    this.validate(value);
+    this.rows.set(key, buildInMemoryRow(value, meta));
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'write',
+      ...(meta?.cli !== undefined && { cli: meta.cli }),
+      durationMs: Date.now() - start,
+      key,
+      payload: value,
+    });
+    return Promise.resolve();
+  }
+
+  async query(filter?: QueryFilter<TValue>): Promise<readonly TValue[]> {
+    this.assertOpen();
+    const start = Date.now();
+    let rows = [...this.rows.values()];
+    if (filter?.cli !== undefined) {
+      rows = rows.filter((r) => r.cli === filter.cli);
+    }
+    const values = applyInMemoryFilter(
+      rows.map((r) => r.value),
+      filter
+    );
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'query',
+      hit: values.length > 0,
+      ...(filter?.cli !== undefined && { cli: filter.cli }),
+      durationMs: Date.now() - start,
+      key: filter,
+      result: { count: values.length },
+    });
+    return Promise.resolve(values);
+  }
+
+  async delete(key: TKey): Promise<boolean> {
+    this.assertOpen();
+    const start = Date.now();
+    const removed = this.rows.delete(key);
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'delete',
+      hit: removed,
+      durationMs: Date.now() - start,
+      key,
+    });
+    return Promise.resolve(removed);
+  }
+
+  async stats(): Promise<BackendStats> {
+    this.assertOpen();
+    const start = Date.now();
+    const timestamps = [...this.rows.values()].map((r) => r.timestamp);
+    const result: BackendStats = {
+      domain: this.domain,
+      count: this.rows.size,
+      oldestTimestamp: timestamps.length > 0 ? Math.min(...timestamps) : null,
+      newestTimestamp: timestamps.length > 0 ? Math.max(...timestamps) : null,
+    };
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'stats',
+      durationMs: Date.now() - start,
+      result,
+    });
+    return Promise.resolve(result);
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.rows.clear();
+    return Promise.resolve();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error(`nexus-memory: backend "${this.domain}" is closed`);
+    }
+  }
+}

--- a/packages/nexus-memory/src/backends/sqlite.ts
+++ b/packages/nexus-memory/src/backends/sqlite.ts
@@ -1,0 +1,288 @@
+/**
+ * SQLite backend — async wrapper over `better-sqlite3` (which is sync).
+ *
+ * One table per domain (Phase 2 vote shape C, hot-table side). The schema
+ * is intentionally minimal: `key`, `value` (JSON-serialized), `cli`,
+ * `source`, `timestamp`, `trust_tier`. Hot-path backends extending this
+ * will add typed columns and indexes for query performance.
+ *
+ * Async surface: every method returns `Promise<T>` so we can swap in a
+ * network-backed implementation later without changing callers. The
+ * actual SQLite ops are sync inside.
+ *
+ * @module nexus-memory/backends/sqlite
+ */
+
+import Database, { type Database as DatabaseType, type Statement } from 'better-sqlite3';
+import type { z } from 'zod';
+import { recordMemoryEvent } from '../telemetry.js';
+import type { BackendStats, IMemoryBackend, QueryFilter, WriteMeta } from '../types.js';
+import { MemoryValidationError } from './memory.js';
+
+export interface SqliteBackendOptions<TValue> {
+  readonly domain: string;
+  /** Absolute path to the SQLite file. Use `':memory:'` for tests. */
+  readonly dbPath: string;
+  /**
+   * Zod schema for cold-archive validation (Phase 2 vote mitigation #1).
+   * When supplied, every `write()` validates first.
+   */
+  readonly schema?: z.ZodType<TValue>;
+  /** Pre-existing database handle. Used by `MemoryRegistry` to share a single connection. */
+  readonly db?: DatabaseType;
+}
+
+interface SqliteRow {
+  readonly key: string;
+  readonly value: string;
+  readonly cli: string | null;
+  readonly source: string | null;
+  readonly timestamp: number;
+  readonly trust_tier: number | null;
+}
+
+function buildWriteRow(
+  key: unknown,
+  value: unknown,
+  meta: WriteMeta | undefined
+): Record<string, string | number | null> {
+  return {
+    key: keyToString(key),
+    value: JSON.stringify(value),
+    cli: meta?.cli ?? null,
+    source: meta?.source ?? null,
+    timestamp: meta?.timestamp ?? Date.now(),
+    trust_tier: meta?.trustTier ?? null,
+  };
+}
+
+/** Stringify a key so SQLite primary-key lookups stay simple. */
+function keyToString(key: unknown): string {
+  if (typeof key === 'string') return key;
+  if (typeof key === 'number' || typeof key === 'boolean') return String(key);
+  return JSON.stringify(key);
+}
+
+/** Apply `where`, `orderBy`, `limit` to an in-memory row set. Extracted from
+ * `query` to satisfy the eslint complexity gate. */
+function applyQueryFilter<T>(values: T[], filter?: QueryFilter<T>): T[] {
+  let out = values;
+  if (filter?.where !== undefined) {
+    const where = filter.where;
+    out = out.filter((v) => {
+      for (const [k, expected] of Object.entries(where)) {
+        if ((v as Record<string, unknown>)[k] !== expected) return false;
+      }
+      return true;
+    });
+  }
+  if (filter?.orderBy !== undefined) {
+    const orderBy = filter.orderBy;
+    const dir = filter.orderDir === 'desc' ? -1 : 1;
+    out = [...out].sort((a, b) => {
+      const av = (a as Record<string | symbol | number, unknown>)[orderBy];
+      const bv = (b as Record<string | symbol | number, unknown>)[orderBy];
+      if (av === bv) return 0;
+      if (av === undefined || av === null) return 1;
+      if (bv === undefined || bv === null) return -1;
+      return (av < bv ? -1 : 1) * dir;
+    });
+  }
+  if (filter?.limit !== undefined) {
+    out = out.slice(0, filter.limit);
+  }
+  return out;
+}
+
+export class SqliteBackend<TKey, TValue> implements IMemoryBackend<TKey, TValue> {
+  readonly domain: string;
+  private readonly db: DatabaseType;
+  private readonly ownsDb: boolean;
+  private readonly schema?: z.ZodType<TValue>;
+  private readonly stmts: {
+    read: Statement;
+    write: Statement;
+    delete: Statement;
+    count: Statement;
+    bounds: Statement;
+    queryAll: Statement;
+  };
+  private closed = false;
+
+  constructor(options: SqliteBackendOptions<TValue>) {
+    this.domain = options.domain;
+    if (options.db !== undefined) {
+      this.db = options.db;
+      this.ownsDb = false;
+    } else {
+      this.db = new Database(options.dbPath);
+      this.db.pragma('journal_mode = WAL');
+      this.ownsDb = true;
+    }
+    if (options.schema !== undefined) {
+      this.schema = options.schema;
+    }
+    this.ensureTable();
+    this.stmts = this.prepareStatements();
+  }
+
+  private ensureTable(): void {
+    // Table name = domain. Domain comes from in-tree code, never untrusted input,
+    // so direct interpolation is safe; still validate the shape defensively.
+    if (!/^[a-z][a-z0-9_]{0,63}$/i.test(this.domain)) {
+      throw new Error(
+        `nexus-memory: invalid domain "${this.domain}" — must match [a-zA-Z][a-zA-Z0-9_]{0,63}`
+      );
+    }
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ${this.domain} (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        cli TEXT,
+        source TEXT,
+        timestamp INTEGER NOT NULL,
+        trust_tier INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS ${this.domain}_cli ON ${this.domain}(cli);
+      CREATE INDEX IF NOT EXISTS ${this.domain}_timestamp ON ${this.domain}(timestamp);
+    `);
+  }
+
+  private prepareStatements(): SqliteBackend<TKey, TValue>['stmts'] {
+    return {
+      read: this.db.prepare(
+        `SELECT key, value, cli, source, timestamp, trust_tier FROM ${this.domain} WHERE key = ?`
+      ),
+      write: this.db.prepare(
+        `INSERT INTO ${this.domain} (key, value, cli, source, timestamp, trust_tier)
+         VALUES (@key, @value, @cli, @source, @timestamp, @trust_tier)
+         ON CONFLICT(key) DO UPDATE SET
+           value = excluded.value,
+           cli = excluded.cli,
+           source = excluded.source,
+           timestamp = excluded.timestamp,
+           trust_tier = excluded.trust_tier`
+      ),
+      delete: this.db.prepare(`DELETE FROM ${this.domain} WHERE key = ?`),
+      count: this.db.prepare(`SELECT COUNT(*) AS count FROM ${this.domain}`),
+      bounds: this.db.prepare(
+        `SELECT MIN(timestamp) AS oldest, MAX(timestamp) AS newest FROM ${this.domain}`
+      ),
+      queryAll: this.db.prepare(
+        `SELECT key, value, cli, source, timestamp, trust_tier FROM ${this.domain}`
+      ),
+    };
+  }
+
+  async read(key: TKey): Promise<TValue | undefined> {
+    this.assertOpen();
+    const start = Date.now();
+    const row = this.stmts.read.get(keyToString(key)) as SqliteRow | undefined;
+    const value = row !== undefined ? (JSON.parse(row.value) as TValue) : undefined;
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'read',
+      hit: value !== undefined,
+      ...(row?.cli !== null && row?.cli !== undefined && { cli: row.cli as never }),
+      durationMs: Date.now() - start,
+      key,
+      result: value,
+    });
+    return Promise.resolve(value);
+  }
+
+  private validate(value: TValue): void {
+    if (this.schema === undefined) return;
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new MemoryValidationError(this.domain, result.error);
+    }
+  }
+
+  async write(key: TKey, value: TValue, meta?: WriteMeta): Promise<void> {
+    this.assertOpen();
+    const start = Date.now();
+    this.validate(value);
+    this.stmts.write.run(buildWriteRow(key, value, meta));
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'write',
+      ...(meta?.cli !== undefined && { cli: meta.cli }),
+      durationMs: Date.now() - start,
+      key,
+      payload: value,
+    });
+    return Promise.resolve();
+  }
+
+  async query(filter?: QueryFilter<TValue>): Promise<readonly TValue[]> {
+    this.assertOpen();
+    const start = Date.now();
+    // Phase 3 keeps query simple — full table scan with in-process filter.
+    // Hot-path backends will override or extend with indexed columns.
+    let rows = this.stmts.queryAll.all() as SqliteRow[];
+    if (filter?.cli !== undefined) {
+      rows = rows.filter((r) => r.cli === filter.cli);
+    }
+    let values = rows.map((r) => JSON.parse(r.value) as TValue);
+    values = applyQueryFilter(values, filter);
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'query',
+      hit: values.length > 0,
+      ...(filter?.cli !== undefined && { cli: filter.cli }),
+      durationMs: Date.now() - start,
+      key: filter,
+      result: { count: values.length },
+    });
+    return Promise.resolve(values);
+  }
+
+  async delete(key: TKey): Promise<boolean> {
+    this.assertOpen();
+    const start = Date.now();
+    const result = this.stmts.delete.run(keyToString(key));
+    const removed = result.changes > 0;
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'delete',
+      hit: removed,
+      durationMs: Date.now() - start,
+      key,
+    });
+    return Promise.resolve(removed);
+  }
+
+  async stats(): Promise<BackendStats> {
+    this.assertOpen();
+    const start = Date.now();
+    const countRow = this.stmts.count.get() as { count: number };
+    const boundsRow = this.stmts.bounds.get() as { oldest: number | null; newest: number | null };
+    const result: BackendStats = {
+      domain: this.domain,
+      count: countRow.count,
+      oldestTimestamp: boundsRow.oldest,
+      newestTimestamp: boundsRow.newest,
+    };
+    recordMemoryEvent({
+      domain: this.domain,
+      op: 'stats',
+      durationMs: Date.now() - start,
+      result,
+    });
+    return Promise.resolve(result);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    this.closed = true;
+    if (this.ownsDb) this.db.close();
+    return Promise.resolve();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error(`nexus-memory: backend "${this.domain}" is closed`);
+    }
+  }
+}

--- a/packages/nexus-memory/src/factory.ts
+++ b/packages/nexus-memory/src/factory.ts
@@ -1,0 +1,38 @@
+/**
+ * Test factories. Production code uses {@link getMemoryRegistry} from
+ * `./registry.js`; tests use these helpers to avoid touching disk.
+ *
+ * @module nexus-memory/factory
+ */
+
+import { MemoryRegistry } from './registry.js';
+
+/**
+ * Create a registry that lives entirely in memory. Every `register()`
+ * call returns an {@link InMemoryBackend}; nothing is persisted.
+ *
+ * Use this in `beforeEach`:
+ *
+ * ```ts
+ * beforeEach(() => {
+ *   setMemoryRegistry(createInMemoryMemoryRegistry());
+ * });
+ * afterEach(async () => {
+ *   await closeMemoryRegistry();
+ * });
+ * ```
+ */
+export function createInMemoryMemoryRegistry(): MemoryRegistry {
+  return new MemoryRegistry({
+    /* no dbPath → InMemoryBackend per domain */
+  });
+}
+
+/**
+ * Create a SQLite-backed registry rooted at `dbPath`. Pass `':memory:'`
+ * for tests that need to exercise the SQLite code path (e.g.,
+ * migration tests, parity tests).
+ */
+export function createSqliteMemoryRegistry(dbPath: string): MemoryRegistry {
+  return new MemoryRegistry({ dbPath });
+}

--- a/packages/nexus-memory/src/importer.test.ts
+++ b/packages/nexus-memory/src/importer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Importer tests — registration, marker-file gating, error isolation.
+ *
+ * @module nexus-memory/importer.test
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  backupSourceFile,
+  listImporters,
+  registerImporter,
+  resetImporters,
+  runImporters,
+} from './importer.js';
+import { writeFileSync } from 'node:fs';
+import { createInMemoryMemoryRegistry, type MemoryRegistry } from './index.js';
+
+describe('importer registry', () => {
+  let registry: MemoryRegistry;
+  let markerDir: string;
+
+  beforeEach(() => {
+    resetImporters();
+    registry = createInMemoryMemoryRegistry();
+    markerDir = mkdtempSync(join(tmpdir(), 'nexus-memory-importer-'));
+  });
+
+  afterEach(async () => {
+    await registry.close();
+    rmSync(markerDir, { recursive: true, force: true });
+  });
+
+  it('registerImporter adds to the registry', () => {
+    registerImporter({
+      id: 'one',
+      domain: 'd1',
+      run: () => {
+        return Promise.resolve({ domain: 'd1', rowsImported: 0, sourcePathBackup: null });
+      },
+    });
+    expect(listImporters()).toEqual(['one']);
+  });
+
+  it('registerImporter rejects duplicates', () => {
+    registerImporter({
+      id: 'dup',
+      domain: 'd',
+      run: () => {
+        return Promise.resolve({ domain: 'd', rowsImported: 0, sourcePathBackup: null });
+      },
+    });
+    expect(() => {
+      registerImporter({
+        id: 'dup',
+        domain: 'd2',
+        run: () => {
+          return Promise.resolve({ domain: 'd2', rowsImported: 0, sourcePathBackup: null });
+        },
+      });
+    }).toThrow(/already registered/);
+  });
+
+  it('runImporters runs each once and writes marker file', async () => {
+    let calls = 0;
+    registerImporter({
+      id: 'one-shot',
+      domain: 'os',
+      run: () => {
+        calls++;
+        return Promise.resolve({ domain: 'os', rowsImported: 3, sourcePathBackup: null });
+      },
+    });
+    const first = await runImporters(registry, { markerDir });
+    expect(first.runs).toHaveLength(1);
+    expect(calls).toBe(1);
+    const second = await runImporters(registry, { markerDir });
+    // Marker prevents re-run.
+    expect(second.runs).toHaveLength(0);
+    expect(calls).toBe(1);
+    const marker = join(markerDir, '.imported-one-shot');
+    expect(existsSync(marker)).toBe(true);
+    const markerJson = JSON.parse(readFileSync(marker, 'utf-8')) as Record<string, unknown>;
+    expect(markerJson['rowsImported']).toBe(3);
+  });
+
+  it('force option overrides marker', async () => {
+    let calls = 0;
+    registerImporter({
+      id: 'force-test',
+      domain: 'ft',
+      run: () => {
+        calls++;
+        return Promise.resolve({ domain: 'ft', rowsImported: 1, sourcePathBackup: null });
+      },
+    });
+    await runImporters(registry, { markerDir });
+    expect(calls).toBe(1);
+    await runImporters(registry, { markerDir, force: true });
+    expect(calls).toBe(2);
+  });
+
+  it('one importer failing does not block others', async () => {
+    registerImporter({
+      id: 'fails',
+      domain: 'f',
+      run: () => Promise.reject(new Error('boom')),
+    });
+    registerImporter({
+      id: 'succeeds',
+      domain: 's',
+      run: () => {
+        return Promise.resolve({ domain: 's', rowsImported: 1, sourcePathBackup: null });
+      },
+    });
+    const result = await runImporters(registry, { markerDir });
+    expect(result.runs.map((r) => r.domain)).toEqual(['s']);
+    expect(result.errors.map((e) => e.id)).toEqual(['fails']);
+  });
+});
+
+describe('backupSourceFile', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-memory-backup-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('renames the source to .bak.<timestamp>', () => {
+    const src = join(tmpDir, 'outcomes.jsonl');
+    writeFileSync(src, '{}\n');
+    const backup = backupSourceFile(src);
+    expect(backup).not.toBeNull();
+    expect(backup).toMatch(/outcomes\.jsonl\.bak\.\d+$/);
+    expect(existsSync(src)).toBe(false);
+    if (backup !== null) {
+      expect(existsSync(backup)).toBe(true);
+    }
+  });
+
+  it('returns null when source does not exist', () => {
+    expect(backupSourceFile(join(tmpDir, 'nope'))).toBeNull();
+  });
+});

--- a/packages/nexus-memory/src/importer.ts
+++ b/packages/nexus-memory/src/importer.ts
@@ -1,0 +1,115 @@
+/**
+ * One-shot importer scaffold. Each Phase 4+ migration registers its own
+ * importer here; the registry runs them on first launch (after a marker
+ * file check) and renames source files to `.bak.<timestamp>` once
+ * complete.
+ *
+ * This file ships the skeleton + the marker-file logic; concrete
+ * importers (MobiMem JSON, OutcomeStore JSONL, agentic.db, etc.) plug in
+ * during their respective migration phases.
+ *
+ * @module nexus-memory/importer
+ */
+
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { MemoryRegistry } from './registry.js';
+
+export interface ImporterRun {
+  readonly domain: string;
+  readonly rowsImported: number;
+  readonly sourcePathBackup: string | null;
+}
+
+export interface Importer {
+  /** Stable identifier — used in the marker filename to track completion. */
+  readonly id: string;
+  /** Logical domain this importer targets in the registry. */
+  readonly domain: string;
+  /**
+   * Run the import. Implementations: (1) check if source data exists,
+   * (2) parse + validate it, (3) write rows into the registry's backend,
+   * (4) rename source to `.bak.<timestamp>` and return the backup path.
+   * Idempotent — if marker file says we already ran, the registry skips it.
+   */
+  run(registry: MemoryRegistry): Promise<ImporterRun>;
+}
+
+const importers = new Map<string, Importer>();
+
+/** Register an importer. Phase 4+ migrations call this at module load. */
+export function registerImporter(importer: Importer): void {
+  if (importers.has(importer.id)) {
+    throw new Error(`nexus-memory: importer "${importer.id}" already registered`);
+  }
+  importers.set(importer.id, importer);
+}
+
+/** For tests: clear all registered importers. */
+export function resetImporters(): void {
+  importers.clear();
+}
+
+/** Snapshot of registered importer IDs. */
+export function listImporters(): readonly string[] {
+  return [...importers.keys()];
+}
+
+export interface RunImportersOptions {
+  /**
+   * Directory holding `.imported-{id}` marker files. Defaults to the
+   * registry's data dir; tests should override.
+   */
+  readonly markerDir: string;
+  /** Skip the marker check (forces re-run). Tests only. */
+  readonly force?: boolean;
+}
+
+/**
+ * Run every registered importer that hasn't yet completed (per marker
+ * file). Returns the list of runs that actually executed.
+ *
+ * Failures are NOT fatal — a single importer's exception is logged via
+ * the returned `errors` array; other importers still get a chance to run.
+ */
+export async function runImporters(
+  registry: MemoryRegistry,
+  options: RunImportersOptions
+): Promise<{ runs: readonly ImporterRun[]; errors: readonly { id: string; error: Error }[] }> {
+  mkdirSync(options.markerDir, { recursive: true });
+  const runs: ImporterRun[] = [];
+  const errors: { id: string; error: Error }[] = [];
+  for (const importer of importers.values()) {
+    const marker = join(options.markerDir, `.imported-${importer.id}`);
+    if (options.force !== true && existsSync(marker)) continue;
+    try {
+      const run = await importer.run(registry);
+      writeMarker(marker, run);
+      runs.push(run);
+    } catch (err) {
+      errors.push({ id: importer.id, error: err instanceof Error ? err : new Error(String(err)) });
+    }
+  }
+  return { runs, errors };
+}
+
+function writeMarker(path: string, run: ImporterRun): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({ ...run, completedAt: new Date().toISOString() }, null, 2),
+    'utf-8'
+  );
+}
+
+/**
+ * Rename a source file to `.bak.<unix-timestamp>`. Used by concrete
+ * importers after a successful migration. Returns the backup path, or
+ * `null` when the source doesn't exist.
+ */
+export function backupSourceFile(sourcePath: string): string | null {
+  if (!existsSync(sourcePath)) return null;
+  const backup = `${sourcePath}.bak.${String(Date.now())}`;
+  renameSync(sourcePath, backup);
+  return backup;
+}

--- a/packages/nexus-memory/src/index.ts
+++ b/packages/nexus-memory/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * nexus-memory — unified memory subsystem for nexus-agents.
+ *
+ * Phase 3 scaffold of epic #2766. Exposes:
+ * - {@link IMemoryBackend} — every concept-space implements this contract
+ * - {@link MemoryRegistry} — singleton registry; `getMemoryRegistry()` is the entry point
+ * - {@link SqliteBackend}, {@link InMemoryBackend} — the two backends
+ * - Telemetry: `recordMemoryEvent`, `getMemoryEventCounters`, `subscribeToMemoryEvents`
+ * - Importer: `registerImporter`, `runImporters` — the one-shot migration hook
+ * - Test helpers: `createInMemoryMemoryRegistry`, `setMemoryRegistry`, `closeMemoryRegistry`
+ *
+ * @module nexus-memory
+ */
+
+// Types
+export type {
+  BackendStats,
+  CliName,
+  ColdArchiveSchema,
+  IMemoryBackend,
+  MemoryEvent,
+  MemoryEventCounters,
+  MemoryEventListener,
+  QueryFilter,
+  WriteMeta,
+} from './types.js';
+
+// Backends
+export { InMemoryBackend, MemoryValidationError } from './backends/memory.js';
+export type { InMemoryBackendOptions } from './backends/memory.js';
+export { SqliteBackend } from './backends/sqlite.js';
+export type { SqliteBackendOptions } from './backends/sqlite.js';
+
+// Registry
+export {
+  MemoryRegistry,
+  getMemoryRegistry,
+  setMemoryRegistry,
+  closeMemoryRegistry,
+} from './registry.js';
+export type { MemoryRegistryOptions, RegisterBackendOptions } from './registry.js';
+
+// Factory (test helpers)
+export { createInMemoryMemoryRegistry, createSqliteMemoryRegistry } from './factory.js';
+
+// Telemetry
+export {
+  recordMemoryEvent,
+  getMemoryEventCounters,
+  subscribeToMemoryEvents,
+  resetMemoryTelemetry,
+} from './telemetry.js';
+
+// Importer
+export {
+  registerImporter,
+  resetImporters,
+  listImporters,
+  runImporters,
+  backupSourceFile,
+} from './importer.js';
+export type { Importer, ImporterRun, RunImportersOptions } from './importer.js';

--- a/packages/nexus-memory/src/registry.test.ts
+++ b/packages/nexus-memory/src/registry.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MemoryRegistry tests — registration, lookup, isolation.
+ *
+ * @module nexus-memory/registry.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MemoryRegistry,
+  closeMemoryRegistry,
+  getMemoryRegistry,
+  setMemoryRegistry,
+} from './registry.js';
+import { createInMemoryMemoryRegistry, createSqliteMemoryRegistry } from './factory.js';
+
+describe('MemoryRegistry', () => {
+  let registry: MemoryRegistry;
+
+  beforeEach(() => {
+    registry = createInMemoryMemoryRegistry();
+  });
+
+  afterEach(async () => {
+    await registry.close();
+  });
+
+  it('register returns a working backend', async () => {
+    const backend = registry.register<string, { v: number }>({ domain: 'test_register' });
+    await backend.write('k', { v: 1 });
+    expect(await backend.read('k')).toEqual({ v: 1 });
+  });
+
+  it('get returns the registered backend', () => {
+    const a = registry.register<string, { v: number }>({ domain: 'test_get' });
+    const b = registry.get<string, { v: number }>('test_get');
+    expect(b).toBe(a);
+  });
+
+  it('get returns undefined for unknown domain', () => {
+    expect(registry.get('not_registered')).toBeUndefined();
+  });
+
+  it('register rejects duplicate domains', () => {
+    registry.register({ domain: 'dup' });
+    expect(() => registry.register({ domain: 'dup' })).toThrow(/already registered/);
+  });
+
+  it('domains() lists registered keys', () => {
+    registry.register({ domain: 'a' });
+    registry.register({ domain: 'b' });
+    expect([...registry.domains()].sort()).toEqual(['a', 'b']);
+  });
+
+  it('close disposes all backends and rejects further ops', async () => {
+    registry.register({ domain: 'x' });
+    await registry.close();
+    expect(() => registry.register({ domain: 'y' })).toThrow(/is closed/);
+  });
+
+  it('close is idempotent', async () => {
+    await registry.close();
+    await expect(registry.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('SqliteMemoryRegistry shares one connection', () => {
+  it('two domains in the same registry share a DB file', async () => {
+    const reg = createSqliteMemoryRegistry(':memory:');
+    const a = reg.register<string, { kind: 'a' }>({ domain: 'shared_a' });
+    const b = reg.register<string, { kind: 'b' }>({ domain: 'shared_b' });
+    await a.write('k', { kind: 'a' });
+    await b.write('k', { kind: 'b' });
+    expect((await a.read('k'))?.kind).toBe('a');
+    expect((await b.read('k'))?.kind).toBe('b');
+    await reg.close();
+  });
+});
+
+describe('shared singleton (getMemoryRegistry / setMemoryRegistry)', () => {
+  afterEach(async () => {
+    await closeMemoryRegistry();
+  });
+
+  it('setMemoryRegistry replaces the shared instance', () => {
+    const injected = createInMemoryMemoryRegistry();
+    setMemoryRegistry(injected);
+    expect(getMemoryRegistry()).toBe(injected);
+  });
+
+  it('test-injected registry stays isolated from disk', async () => {
+    const injected = createInMemoryMemoryRegistry();
+    setMemoryRegistry(injected);
+    const backend = getMemoryRegistry().register<string, { v: number }>({
+      domain: 'iso_test',
+    });
+    await backend.write('k', { v: 1 });
+    expect(await backend.read('k')).toEqual({ v: 1 });
+  });
+});

--- a/packages/nexus-memory/src/registry.ts
+++ b/packages/nexus-memory/src/registry.ts
@@ -1,0 +1,165 @@
+/**
+ * MemoryRegistry — the single entry point for accessing memory backends.
+ *
+ * Every concept-space (experience, outcomes, beliefs, …) registers a
+ * backend; callers reach it via `registry.get('experience')` or, more
+ * commonly, the typed accessors that wrap the registry.
+ *
+ * Sharing a SQLite connection across backends keeps WAL-mode behavior
+ * coherent — one writer thread, many tables.
+ *
+ * @module nexus-memory/registry
+ */
+
+import Database, { type Database as DatabaseType } from 'better-sqlite3';
+import type { z } from 'zod';
+import { InMemoryBackend } from './backends/memory.js';
+import { SqliteBackend } from './backends/sqlite.js';
+import type { IMemoryBackend } from './types.js';
+
+export interface MemoryRegistryOptions {
+  /**
+   * SQLite file path. Use `':memory:'` for tests. When omitted, the
+   * registry creates `InMemoryBackend` instances and never touches disk
+   * — the standard test-isolation pattern (Phase 2 acceptance criterion).
+   */
+  readonly dbPath?: string;
+}
+
+export interface RegisterBackendOptions<TValue> {
+  /** Stable domain identifier. Becomes the SQLite table name. */
+  readonly domain: string;
+  /** Optional Zod schema for cold-archive validation. */
+  readonly schema?: z.ZodType<TValue>;
+}
+
+/**
+ * The registry. One per `dbPath` (or one in-memory registry per test).
+ * `MemoryRegistry.get(domain)` is `O(1)` after registration.
+ */
+export class MemoryRegistry {
+  private readonly backends = new Map<string, IMemoryBackend<unknown, unknown>>();
+  private readonly db?: DatabaseType;
+  private closed = false;
+
+  constructor(options: MemoryRegistryOptions = {}) {
+    if (options.dbPath !== undefined) {
+      this.db = new Database(options.dbPath);
+      this.db.pragma('journal_mode = WAL');
+    }
+  }
+
+  /**
+   * Register a backend for `domain`. Throws on duplicate domain.
+   *
+   * When the registry has a `dbPath`, the new backend is SQLite-backed
+   * and shares the registry's connection. Otherwise, an `InMemoryBackend`
+   * is created (used for tests).
+   */
+  register<TKey, TValue>(options: RegisterBackendOptions<TValue>): IMemoryBackend<TKey, TValue> {
+    this.assertOpen();
+    if (this.backends.has(options.domain)) {
+      throw new Error(`nexus-memory: domain "${options.domain}" already registered`);
+    }
+    const backend: IMemoryBackend<TKey, TValue> =
+      this.db !== undefined
+        ? new SqliteBackend<TKey, TValue>({
+            domain: options.domain,
+            dbPath: '<shared>', // unused when db is supplied
+            db: this.db,
+            ...(options.schema !== undefined && { schema: options.schema }),
+          })
+        : new InMemoryBackend<TKey, TValue>({
+            domain: options.domain,
+            ...(options.schema !== undefined && { schema: options.schema }),
+          });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- TypeScript narrows the union type here, but the Map needs the lifted IMemoryBackend<unknown, unknown>; the assertion documents the variance and survives future contract changes.
+    this.backends.set(options.domain, backend as IMemoryBackend<unknown, unknown>);
+    return backend;
+  }
+
+  /**
+   * Get a previously-registered backend. Returns `undefined` if the
+   * domain isn't registered — callers should treat that as "not yet
+   * migrated to the unified contract."
+   */
+  get<TKey, TValue>(domain: string): IMemoryBackend<TKey, TValue> | undefined {
+    this.assertOpen();
+    const backend = this.backends.get(domain);
+    return backend as IMemoryBackend<TKey, TValue> | undefined;
+  }
+
+  /** List all registered domains. Useful for `memory_stats`-style readers. */
+  domains(): readonly string[] {
+    return [...this.backends.keys()];
+  }
+
+  /**
+   * Close every registered backend and the shared SQLite handle. After
+   * `close()` the registry rejects all further operations.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    for (const backend of this.backends.values()) {
+      await backend.close();
+    }
+    this.backends.clear();
+    if (this.db !== undefined) this.db.close();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('nexus-memory: registry is closed');
+    }
+  }
+}
+
+// ============================================================================
+// Singleton accessor
+// ============================================================================
+
+let sharedRegistry: MemoryRegistry | null = null;
+
+/**
+ * Get the process-wide shared registry. Initializes on first call with
+ * `dbPath` from `NEXUS_DATA_DIR` (defaults to `~/.nexus-agents/memory/memory.db`)
+ * unless `setMemoryRegistry` was called first.
+ *
+ * Test code should call `setMemoryRegistry(createInMemoryMemoryRegistry())`
+ * in `beforeEach` — this matches the existing `setOutcomeStore` pattern.
+ */
+export function getMemoryRegistry(): MemoryRegistry {
+  if (sharedRegistry === null) {
+    // Default path resolution happens here, NOT at module load — so tests
+    // that call `setMemoryRegistry` before any `getMemoryRegistry` see
+    // their in-memory instance, not a side-effectful production path.
+    const dbPath = resolveDefaultDbPath();
+    sharedRegistry = new MemoryRegistry({ dbPath });
+  }
+  return sharedRegistry;
+}
+
+/**
+ * Inject a registry. Used by tests to swap in `InMemoryBackend`-backed
+ * registries. After test, call again with `null` to reset, or call
+ * `closeMemoryRegistry()` to dispose.
+ */
+export function setMemoryRegistry(registry: MemoryRegistry | null): void {
+  sharedRegistry = registry;
+}
+
+/** Close + null out the shared registry. Idempotent. */
+export async function closeMemoryRegistry(): Promise<void> {
+  if (sharedRegistry !== null) {
+    await sharedRegistry.close();
+    sharedRegistry = null;
+  }
+}
+
+function resolveDefaultDbPath(): string {
+  // Match `nexus-agents`'s `nexusDataPath` convention without importing it
+  // (keep nexus-memory free of inter-package deps for nexus-eval-* reuse).
+  const root = process.env['NEXUS_DATA_DIR'] ?? `${process.env['HOME'] ?? '/tmp'}/.nexus-agents`;
+  return `${root}/memory/memory.db`;
+}

--- a/packages/nexus-memory/src/telemetry.test.ts
+++ b/packages/nexus-memory/src/telemetry.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Telemetry tests — aggregated counters + opt-in audit mode (Phase 2 vote).
+ *
+ * @module nexus-memory/telemetry.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryBackend } from './backends/memory.js';
+import {
+  getMemoryEventCounters,
+  resetMemoryTelemetry,
+  subscribeToMemoryEvents,
+} from './telemetry.js';
+import type { MemoryEvent } from './types.js';
+
+describe('memory telemetry', () => {
+  let originalAuditMode: string | undefined;
+
+  beforeEach(() => {
+    resetMemoryTelemetry();
+    originalAuditMode = process.env['NEXUS_MEMORY_AUDIT_MODE'];
+    delete process.env['NEXUS_MEMORY_AUDIT_MODE'];
+  });
+
+  afterEach(() => {
+    if (originalAuditMode !== undefined) {
+      process.env['NEXUS_MEMORY_AUDIT_MODE'] = originalAuditMode;
+    } else {
+      delete process.env['NEXUS_MEMORY_AUDIT_MODE'];
+    }
+  });
+
+  it('write increments counters per (domain, op)', async () => {
+    const backend = new InMemoryBackend<string, { v: number }>({ domain: 'tel_a' });
+    await backend.write('k1', { v: 1 });
+    await backend.write('k2', { v: 2 });
+    await backend.read('k1');
+    const counters = getMemoryEventCounters();
+    const writeCounter = counters.find((c) => c.domain === 'tel_a' && c.op === 'write');
+    const readCounter = counters.find((c) => c.domain === 'tel_a' && c.op === 'read');
+    expect(writeCounter?.count).toBe(2);
+    expect(readCounter?.count).toBe(1);
+    expect(readCounter?.hitCount).toBe(1);
+  });
+
+  it('read miss increments count but not hitCount', async () => {
+    const backend = new InMemoryBackend<string, { v: number }>({ domain: 'tel_miss' });
+    await backend.read('missing');
+    const counter = getMemoryEventCounters().find(
+      (c) => c.domain === 'tel_miss' && c.op === 'read'
+    );
+    expect(counter?.count).toBe(1);
+    expect(counter?.hitCount).toBe(0);
+  });
+
+  it('subscribers receive events for every op', async () => {
+    const received: MemoryEvent[] = [];
+    const unsubscribe = subscribeToMemoryEvents((e) => {
+      received.push(e);
+    });
+    const backend = new InMemoryBackend<string, { v: number }>({ domain: 'tel_sub' });
+    await backend.write('k', { v: 1 });
+    await backend.read('k');
+    unsubscribe();
+    await backend.write('k2', { v: 2 });
+    expect(received.length).toBe(2);
+    expect(received[0]?.op).toBe('write');
+    expect(received[1]?.op).toBe('read');
+  });
+
+  it('subscriber error does not break the operation', async () => {
+    subscribeToMemoryEvents(() => {
+      throw new Error('listener exploded');
+    });
+    const backend = new InMemoryBackend<string, { v: number }>({ domain: 'tel_err' });
+    await expect(backend.write('k', { v: 1 })).resolves.toBeUndefined();
+    expect(await backend.read('k')).toEqual({ v: 1 });
+  });
+
+  // Phase 2 vote mitigation #2 — catfish concern about losing context.
+  it('audit mode populates keySummary + payloadSummary', async () => {
+    process.env['NEXUS_MEMORY_AUDIT_MODE'] = 'audit';
+    const received: MemoryEvent[] = [];
+    subscribeToMemoryEvents((e) => {
+      received.push(e);
+    });
+    const backend = new InMemoryBackend<string, { text: string }>({ domain: 'tel_audit' });
+    await backend.write('hello', { text: 'world' });
+    const event = received[0];
+    expect(event?.keySummary).toBe('hello');
+    expect(event?.payloadSummary).toContain('world');
+  });
+
+  it('default mode does NOT populate summaries', async () => {
+    // Audit mode left unset → counter-only.
+    const received: MemoryEvent[] = [];
+    subscribeToMemoryEvents((e) => {
+      received.push(e);
+    });
+    const backend = new InMemoryBackend<string, { text: string }>({ domain: 'tel_noaudit' });
+    await backend.write('hello', { text: 'world' });
+    const event = received[0];
+    expect(event?.keySummary).toBeUndefined();
+    expect(event?.payloadSummary).toBeUndefined();
+  });
+
+  it('audit mode summaries are truncated', async () => {
+    process.env['NEXUS_MEMORY_AUDIT_MODE'] = 'audit';
+    const received: MemoryEvent[] = [];
+    subscribeToMemoryEvents((e) => {
+      received.push(e);
+    });
+    const backend = new InMemoryBackend<string, { blob: string }>({ domain: 'tel_trunc' });
+    const longString = 'x'.repeat(500);
+    await backend.write('k', { blob: longString });
+    const event = received[0];
+    // Truncation limit is ~240 chars + ellipsis.
+    expect(event?.payloadSummary?.length).toBeLessThanOrEqual(241);
+    expect(event?.payloadSummary?.endsWith('…')).toBe(true);
+  });
+
+  it('resetMemoryTelemetry clears counters and subscribers', async () => {
+    const backend = new InMemoryBackend<string, { v: number }>({ domain: 'tel_reset' });
+    await backend.write('k', { v: 1 });
+    expect(getMemoryEventCounters().length).toBeGreaterThan(0);
+    resetMemoryTelemetry();
+    expect(getMemoryEventCounters()).toHaveLength(0);
+  });
+});

--- a/packages/nexus-memory/src/telemetry.ts
+++ b/packages/nexus-memory/src/telemetry.ts
@@ -1,0 +1,137 @@
+/**
+ * Memory telemetry — aggregated counters (default) + opt-in full-audit mode.
+ *
+ * Phase 2 vote (#2768) settled on **C**: per-`{domain, op}` counters in
+ * steady state, full per-event payloads when `NEXUS_MEMORY_AUDIT_MODE=audit`.
+ *
+ * The catfish-mitigation requirement is honored: audit mode emits
+ * `{ op, keySummary, payloadSummary, resultSummary, cli, durationMs, hit }`
+ * — not just counters — so an incident replay can reconstruct individual
+ * ops. Summaries are truncated to keep emission cheap.
+ *
+ * @module nexus-memory/telemetry
+ */
+
+import type { MemoryEvent, MemoryEventCounters, MemoryEventListener } from './types.js';
+
+const KEY_SUMMARY_LIMIT = 120;
+const PAYLOAD_SUMMARY_LIMIT = 240;
+
+/** Per-`{domain, op}` rolling counters. */
+const counters = new Map<string, MemoryEventCounters>();
+const listeners = new Set<MemoryEventListener>();
+
+/** Audit mode is opt-in via env. Checked once per emission so the env
+ * can be toggled at runtime by tests via `process.env`. */
+function isAuditMode(): boolean {
+  return process.env['NEXUS_MEMORY_AUDIT_MODE'] === 'audit';
+}
+
+function counterKey(domain: string, op: MemoryEvent['op']): string {
+  return `${domain}::${op}`;
+}
+
+function truncate(value: unknown, limit: number): string {
+  let s: string;
+  if (typeof value === 'string') {
+    s = value;
+  } else if (value === undefined) {
+    s = '<undefined>';
+  } else if (value === null) {
+    s = '<null>';
+  } else {
+    try {
+      s = JSON.stringify(value);
+    } catch {
+      s = '<unserializable>';
+    }
+  }
+  return s.length > limit ? `${s.slice(0, limit - 1)}…` : s;
+}
+
+interface RecordedEvent extends Omit<
+  MemoryEvent,
+  'keySummary' | 'payloadSummary' | 'resultSummary'
+> {
+  readonly key?: unknown;
+  readonly payload?: unknown;
+  readonly result?: unknown;
+}
+
+function updateCounter(event: RecordedEvent): void {
+  const ck = counterKey(event.domain, event.op);
+  const existing = counters.get(ck);
+  const hitDelta = event.hit === true ? 1 : 0;
+  counters.set(ck, {
+    domain: event.domain,
+    op: event.op,
+    count: (existing?.count ?? 0) + 1,
+    hitCount: (existing?.hitCount ?? 0) + hitDelta,
+    totalDurationMs: (existing?.totalDurationMs ?? 0) + event.durationMs,
+    maxDurationMs: Math.max(existing?.maxDurationMs ?? 0, event.durationMs),
+  });
+}
+
+function buildPublicEvent(event: RecordedEvent, audit: boolean): MemoryEvent {
+  return {
+    domain: event.domain,
+    op: event.op,
+    durationMs: event.durationMs,
+    ...(event.cli !== undefined && { cli: event.cli }),
+    ...(event.hit !== undefined && { hit: event.hit }),
+    ...(audit &&
+      event.key !== undefined && {
+        keySummary: truncate(event.key, KEY_SUMMARY_LIMIT),
+      }),
+    ...(audit &&
+      event.payload !== undefined && {
+        payloadSummary: truncate(event.payload, PAYLOAD_SUMMARY_LIMIT),
+      }),
+    ...(audit &&
+      event.result !== undefined && {
+        resultSummary: truncate(event.result, PAYLOAD_SUMMARY_LIMIT),
+      }),
+  };
+}
+
+/**
+ * Record a memory operation. Updates counters always; emits the event
+ * to subscribers always (subscribers get the full event in audit mode,
+ * the aggregate-only event otherwise).
+ *
+ * Implementation note: the `op` argument is the typed `MemoryEvent['op']`
+ * literal — backends never pass an unknown string here.
+ */
+export function recordMemoryEvent(event: RecordedEvent): void {
+  updateCounter(event);
+  const publicEvent = buildPublicEvent(event, isAuditMode());
+  for (const listener of listeners) {
+    try {
+      listener(publicEvent);
+    } catch {
+      // Subscriber failures must never affect memory operations.
+    }
+  }
+}
+
+/** Snapshot of current counters. Returned array is a copy. */
+export function getMemoryEventCounters(): readonly MemoryEventCounters[] {
+  return [...counters.values()];
+}
+
+/** Subscribe to the per-event stream. Returns an unsubscribe function. */
+export function subscribeToMemoryEvents(listener: MemoryEventListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Reset counters + drop all subscribers. Tests should call this in
+ * `beforeEach` to keep state from leaking.
+ */
+export function resetMemoryTelemetry(): void {
+  counters.clear();
+  listeners.clear();
+}

--- a/packages/nexus-memory/src/types.ts
+++ b/packages/nexus-memory/src/types.ts
@@ -1,0 +1,138 @@
+/**
+ * Core contract types for nexus-memory.
+ *
+ * Reflects the Phase 2 vote (#2766, #2768):
+ * - Schema shape **C** (hybrid hot+archive) — hot tables get domain-typed
+ *   backends; the cold archive shares one row shape with a `type` discriminator.
+ * - Telemetry **C** (aggregated counters + opt-in audit) — every operation
+ *   feeds counters; full payloads only when `NEXUS_MEMORY_AUDIT_MODE=audit`.
+ *
+ * @module nexus-memory/types
+ */
+
+import type { z } from 'zod';
+
+/** Canonical CLI identifier used for the `cli` tag column. */
+export type CliName = 'claude' | 'codex' | 'gemini' | 'opencode';
+
+/**
+ * Filter for {@link IMemoryBackend.query}. `where` is a partial subset of
+ * the backend's value shape — backends translate to a SQL `WHERE` clause
+ * over indexed columns. `limit`/`order` are advisory; backends MAY
+ * implement them via `LIMIT`/`ORDER BY`.
+ */
+export interface QueryFilter<TValue> {
+  readonly where?: Partial<TValue>;
+  readonly cli?: CliName;
+  readonly limit?: number;
+  readonly orderBy?: keyof TValue;
+  readonly orderDir?: 'asc' | 'desc';
+}
+
+/** Per-write metadata. Optional, but `cli` should be supplied where known. */
+export interface WriteMeta {
+  /** CLI that produced this row. Per-CLI tag (vote-ratified default share-by-default). */
+  readonly cli?: CliName;
+  /** Free-form source identifier (`'expert'` | `'pipeline'` | `'cli'` | etc.). */
+  readonly source?: string;
+  /** Override the default `Date.now()` timestamp. */
+  readonly timestamp?: number;
+  /** Trust tier per the input-hardening epic (#818). Cold-archive promotion may gate on this. */
+  readonly trustTier?: 1 | 2 | 3 | 4;
+}
+
+/** Per-backend statistics surfaced by {@link IMemoryBackend.stats}. */
+export interface BackendStats {
+  readonly domain: string;
+  readonly count: number;
+  readonly oldestTimestamp: number | null;
+  readonly newestTimestamp: number | null;
+}
+
+/**
+ * Every memory backend implements this contract. Each backend owns a single
+ * **domain** (e.g., `'experience'`, `'outcomes'`, `'beliefs'`). Cross-domain
+ * coordination happens in {@link MemoryRegistry}.
+ */
+export interface IMemoryBackend<TKey, TValue> {
+  /** Stable identifier; matches the table name in SQLite backends. */
+  readonly domain: string;
+
+  /** Read by primary key. Returns undefined for missing keys. */
+  read(key: TKey): Promise<TValue | undefined>;
+
+  /** Write or overwrite. `meta.cli` populates the per-CLI tag column. */
+  write(key: TKey, value: TValue, meta?: WriteMeta): Promise<void>;
+
+  /** Range/filter query. Returns rows matching {@link QueryFilter}. */
+  query(filter?: QueryFilter<TValue>): Promise<readonly TValue[]>;
+
+  /** Delete by primary key. Returns true if a row was removed. */
+  delete(key: TKey): Promise<boolean>;
+
+  /** Lightweight counts + bounds. Cheap to call. */
+  stats(): Promise<BackendStats>;
+
+  /**
+   * Close any open handles. Idempotent.
+   *
+   * `Promise<void>` so a future async backend (network-backed) can drop in.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Validation contract for the cold-archive write path (Phase 2 vote
+ * mitigation #1, security dissent). Every cold-archive backend MUST
+ * validate its payload against a Zod schema before persisting; the
+ * promotion test in `contract.test.ts` exercises both the happy and
+ * failure paths.
+ *
+ * Hot-path backends typically have stronger compile-time typing and
+ * may skip this in favor of TypeScript guarantees.
+ */
+export interface ColdArchiveSchema<TValue> {
+  /** Zod schema used to validate values before write. */
+  readonly schema: z.ZodType<TValue>;
+}
+
+/**
+ * Telemetry event emitted on every backend operation.
+ *
+ * Counter mode (default): backends increment per-`{domain, op}` counters
+ * and emit a single aggregate event per logical operation.
+ *
+ * Audit mode (`NEXUS_MEMORY_AUDIT_MODE=audit`): backends additionally
+ * include `keySummary`, `payloadSummary`, and `resultSummary` so an
+ * incident-response replay can reconstruct individual ops.
+ */
+export interface MemoryEvent {
+  readonly domain: string;
+  readonly op: 'read' | 'write' | 'query' | 'delete' | 'stats';
+  readonly cli?: CliName;
+  readonly durationMs: number;
+  /** True for `read` ops that found a row, `query` ops with non-empty result, `delete` ops that found a target. */
+  readonly hit?: boolean;
+  /** Populated only in audit mode. Truncated to ~120 chars. */
+  readonly keySummary?: string;
+  /** Populated only in audit mode. Truncated to ~240 chars. */
+  readonly payloadSummary?: string;
+  /** Populated only in audit mode. Truncated to ~240 chars. */
+  readonly resultSummary?: string;
+}
+
+/** Subscriber callback for `subscribeToMemoryEvents`. */
+export type MemoryEventListener = (event: MemoryEvent) => void;
+
+/**
+ * Aggregate counters surfaced by `getMemoryEventCounters()`. Mirrors the
+ * shape of {@link MemoryEvent} but with per-`{domain, op}` rollups.
+ */
+export interface MemoryEventCounters {
+  readonly domain: string;
+  readonly op: MemoryEvent['op'];
+  readonly count: number;
+  readonly hitCount: number;
+  readonly totalDurationMs: number;
+  readonly maxDurationMs: number;
+}

--- a/packages/nexus-memory/tsconfig.json
+++ b/packages/nexus-memory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/nexus-memory/tsup.config.ts
+++ b/packages/nexus-memory/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node22',
+  outDir: 'dist',
+  // better-sqlite3 is a native C++ addon and cannot be bundled.
+  external: ['better-sqlite3'],
+});

--- a/packages/nexus-memory/vitest.config.ts
+++ b/packages/nexus-memory/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['node_modules', 'dist'],
+    pool: 'forks',
+    isolate: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,28 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/nexus-memory:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+
   website:
     dependencies:
       '@astrojs/check':
@@ -5713,7 +5735,7 @@ snapshots:
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@astrojs/svelte@8.0.5(@types/node@25.6.0)(astro@6.1.10(@types/node@25.6.0)(jiti@2.6.1)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.7)(jiti@2.6.1)(svelte@5.55.7(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
@@ -7588,7 +7610,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -11203,7 +11225,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.13(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.3)
@@ -11232,7 +11254,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- Closes #2769 (Phase 3 of epic #2766). Scaffolds a new `packages/nexus-memory/` workspace package with the unified memory contract, registry, two backends, telemetry, importer skeleton, and contract tests.
- Bakes in every Phase 2 vote decision:
  - **Schema C** (hybrid hot+archive): each backend owns one domain/table — hot-path backends in Phase 4+ will extend `SqliteBackend` with typed columns; the scaffold provides the cold-archive shape.
  - **Telemetry C** (aggregated counters + opt-in audit): `recordMemoryEvent` updates per-`{domain, op}` counters always; `NEXUS_MEMORY_AUDIT_MODE=audit` adds `{keySummary, payloadSummary, resultSummary}`.
  - **Migration order B** (risk-first): scaffold ships first, then #2770 migrates MobiMem (Phase 4), then #2772 tool-memory (Phase 5), then #2771 OutcomeStore (Phase 6).
- Bakes in both Phase 2 mitigations:
  - **Security dissent (Ballot 1):** backends constructed with a Zod `schema` reject invalid writes via `MemoryValidationError` before storage.
  - **Catfish concern (Ballot 2):** audit mode captures truncated key/payload/result summaries — not just counters — so incident replay can reconstruct individual ops.

## Public surface

```ts
import {
  IMemoryBackend, MemoryRegistry, getMemoryRegistry, setMemoryRegistry,
  closeMemoryRegistry, createInMemoryMemoryRegistry, createSqliteMemoryRegistry,
  SqliteBackend, InMemoryBackend, MemoryValidationError,
  recordMemoryEvent, subscribeToMemoryEvents, getMemoryEventCounters,
  resetMemoryTelemetry, registerImporter, runImporters, backupSourceFile,
} from 'nexus-memory';
```

Async surface throughout (`Promise<T>`); `better-sqlite3` synchronous inside; one shared connection per registry; per-CLI tag column on every row.

## Tests
- **57 tests, 4 files.**
- `backends/contract.test.ts` — 30 tests run against both `InMemoryBackend` and `SqliteBackend(:memory:)` with identical assertions. Read/write/query/delete/stats/close + filter/limit/order/cli-tag + Zod validation.
- `registry.test.ts` — 9 tests covering register/get/duplicate-rejection/close + singleton injection.
- `telemetry.test.ts` — 10 tests covering counters, subscribers, audit-mode summaries, truncation, reset.
- `importer.test.ts` — 8 tests covering registration, marker gating, force re-run, per-importer error isolation, `backupSourceFile`.

## Verification
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (57/57)
- `pnpm build` ✓ (17KB ESM + 17KB d.ts)
- Package registered as a workspace member; `pnpm --filter nexus-memory exec node -e "import('nexus-memory').then(...)"` loads all 18 public exports.

## What's NOT here (intentional)
- No nexus-agents migrations yet — that's Phase 4 (#2770).
- No concrete importers yet — those land alongside their migration PRs.
- No `MEMORY_UNIFICATION.md` doc — that lives in Phase 1's deliverable (#2767); the scaffold's JSDoc references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
