### PR TITLE
fix(memory): mobimem persists to sqlite, closes #2719 (Phase 4 of #2766)

### DIFF
--- a/.changeset/2770-mobimem-sqlite-persistence.md
+++ b/.changeset/2770-mobimem-sqlite-persistence.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2719**: MobiMem now persists to SQLite. Phase 4 of #2766.
+
+Pre-Phase 4, MobiMem's `dbPath` config was a dead surface — the impl classes used pure `Map<string, Entry>` and `dbPath` was passed in but never opened. The result was a triple-disconnect:
+
+1. `routing-memory.ts:179` `new MobiMem()` → in-memory only, died on process exit.
+2. `pipeline/agent-executor.ts:163` `persistMobiMemState` → saved an empty MobiMem to `mobimem-state.json` (stats only, no data).
+3. `tool-memory.ts:270` `new MobiMem({ dbPath })` → opened a SQLite file that nobody wrote to.
+
+KnnRoutingStage (`composite-router.ts:282`) had nothing to retrieve and the opt-in `enableKnnRouting` feature literally couldn't work.
+
+**Fix:**
+
+- New `mobimem-persistence.ts` — tiny synchronous SQLite mirror keyed by domain (`mobimem_profile` / `mobimem_experience` / `mobimem_action`). When MobiMem is constructed with a real `dbPath`, every write to the in-memory Map is mirrored to SQLite; on construction the Map is hydrated from SQLite first.
+- `mobimem.ts:MobiMem` ctor actually opens `dbPath` (when not `:memory:`) and threads the handle through the three impls.
+- New `getSharedMobiMem()` singleton — process-wide instance backed by `~/.nexus-agents/memory/mobimem.db`. `RoutingMemory` ctor now defaults to it (was `new MobiMem()`). `tool-memory.ts` routes through it via `setSharedMobiMemDbPathResolver`.
+- `agent-executor.ts:persistMobiMemState` deleted — SQLite mirror handles persistence inline.
+- `MobiMem.save()` JSON path deleted — it only persisted stats, not data.
+
+The architectural goal (`MobiMem` flowing through `nexus-memory`'s `IMemoryBackend`) is deferred to a future Phase 4.1. The async contract on `IMemoryBackend` would require an async ripple across `KnnRoutingStage` / `StrategyDistiller` / `routing-context-store-impl`; this synchronous side-channel closes #2719 with minimum blast radius and lets the routing pipeline see real cross-session learning today.
+
+**Tests:**
+
+- 6 new persistence regression tests in `mobimem-persistence.test.ts`. Pin the core invariant: writes through one MobiMem instance are visible to a fresh instance opened against the same `dbPath`. Date fields survive the JSON round-trip via `hydrateDates`.
+- 1094 existing tests pass (40 test files in the broader `context/` + `pipeline/` sweep).

--- a/packages/nexus-agents/src/context/mobimem-impl.ts
+++ b/packages/nexus-agents/src/context/mobimem-impl.ts
@@ -8,6 +8,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+type DatabaseType = InstanceType<typeof Database>;
 import { getTimeProvider } from '../core/index.js';
 import type {
   IProfileMemory,
@@ -29,6 +31,22 @@ import {
   countUnique,
   computeAverage,
 } from './mobimem-impl-helpers.js';
+import { MobiMemPersistence } from './mobimem-persistence.js';
+
+/**
+ * JSON.stringify drops the `Date` constructor; entries written before a
+ * process restart and reloaded from SQLite come back with `string`
+ * timestamps where the runtime expects `Date`. Re-hydrate the named keys
+ * so downstream `entry.expiresAt < now` style comparisons keep working.
+ */
+function hydrateDates<T>(value: T, dateKeys: readonly (keyof T)[]): T {
+  const out = value as unknown as Record<string, unknown>;
+  for (const key of dateKeys) {
+    const v = out[key as string];
+    if (typeof v === 'string') out[key as string] = new Date(v);
+  }
+  return value;
+}
 
 /**
  * Profile Memory implementation.
@@ -37,9 +55,15 @@ import {
 export class ProfileMemoryImpl implements IProfileMemory {
   private readonly entries: Map<string, ProfileEntry> = new Map();
   private readonly config: MobiMemConfig;
+  private readonly persist: MobiMemPersistence<ProfileEntry>;
 
-  constructor(config: MobiMemConfig) {
+  constructor(config: MobiMemConfig, db: DatabaseType | null = null) {
     this.config = config;
+    this.persist = new MobiMemPersistence<ProfileEntry>({ db, domain: 'mobimem_profile' });
+    // Hydrate from SQLite when active (#2719 fix: process-boundary persistence).
+    for (const [k, v] of this.persist.load()) {
+      this.entries.set(k, hydrateDates<ProfileEntry>(v, ['createdAt', 'updatedAt']));
+    }
   }
 
   observe(
@@ -62,6 +86,7 @@ export class ProfileMemoryImpl implements IProfileMemory {
         updatedAt: now,
       };
       this.entries.set(key, updated);
+      this.persist.upsert(key, updated);
       return updated;
     }
 
@@ -79,6 +104,7 @@ export class ProfileMemoryImpl implements IProfileMemory {
 
     this.enforceLimit(entityId);
     this.entries.set(key, entry);
+    this.persist.upsert(key, entry);
     return entry;
   }
 
@@ -108,6 +134,7 @@ export class ProfileMemoryImpl implements IProfileMemory {
     for (const [key, entry] of this.entries) {
       if (entry.entityId === entityId) {
         this.entries.delete(key);
+        this.persist.delete(key);
         count++;
       }
     }
@@ -133,6 +160,7 @@ export class ProfileMemoryImpl implements IProfileMemory {
       if (toRemove !== undefined) {
         const key = `${entityId}:${toRemove.preferenceKey}`;
         this.entries.delete(key);
+        this.persist.delete(key);
       }
     }
   }
@@ -145,9 +173,14 @@ export class ProfileMemoryImpl implements IProfileMemory {
 export class ExperienceMemoryImpl implements IExperienceMemory {
   private readonly patterns: Map<string, ExperienceEntry> = new Map();
   private readonly config: MobiMemConfig;
+  private readonly persist: MobiMemPersistence<ExperienceEntry>;
 
-  constructor(config: MobiMemConfig) {
+  constructor(config: MobiMemConfig, db: DatabaseType | null = null) {
     this.config = config;
+    this.persist = new MobiMemPersistence<ExperienceEntry>({ db, domain: 'mobimem_experience' });
+    for (const [k, v] of this.persist.load()) {
+      this.patterns.set(k, hydrateDates<ExperienceEntry>(v, ['createdAt', 'lastUsedAt']));
+    }
   }
 
   recordExecution(
@@ -173,6 +206,7 @@ export class ExperienceMemoryImpl implements IExperienceMemory {
         lastUsedAt: now,
       };
       this.patterns.set(patternKey, updated);
+      this.persist.upsert(patternKey, updated);
       return updated;
     }
 
@@ -191,6 +225,7 @@ export class ExperienceMemoryImpl implements IExperienceMemory {
 
     this.enforceLimit(taskType);
     this.patterns.set(patternKey, entry);
+    this.persist.upsert(patternKey, entry);
     return entry;
   }
 
@@ -233,11 +268,13 @@ export class ExperienceMemoryImpl implements IExperienceMemory {
     for (const [key, entry] of this.patterns) {
       if (entry.id === patternId) {
         const metrics = computeUpdatedMetrics(entry.successCount, entry.attemptCount, success);
-        this.patterns.set(key, {
+        const updated: ExperienceEntry = {
           ...entry,
           ...metrics,
           lastUsedAt: new Date(getTimeProvider().now()),
-        });
+        };
+        this.patterns.set(key, updated);
+        this.persist.upsert(key, updated);
         return;
       }
     }
@@ -263,6 +300,7 @@ export class ExperienceMemoryImpl implements IExperienceMemory {
         for (const [key, entry] of this.patterns) {
           if (entry.id === toRemove.id) {
             this.patterns.delete(key);
+            this.persist.delete(key);
             break;
           }
         }
@@ -278,11 +316,19 @@ export class ExperienceMemoryImpl implements IExperienceMemory {
 export class ActionCacheImpl implements IActionCache {
   private readonly entries: Map<string, ActionCacheEntry> = new Map();
   private readonly config: MobiMemConfig;
+  private readonly persist: MobiMemPersistence<ActionCacheEntry>;
   private totalHits = 0;
   private totalRequests = 0;
 
-  constructor(config: MobiMemConfig) {
+  constructor(config: MobiMemConfig, db: DatabaseType | null = null) {
     this.config = config;
+    this.persist = new MobiMemPersistence<ActionCacheEntry>({ db, domain: 'mobimem_action' });
+    for (const [k, v] of this.persist.load()) {
+      this.entries.set(
+        k,
+        hydrateDates<ActionCacheEntry>(v, ['cachedAt', 'lastAccessedAt', 'expiresAt'])
+      );
+    }
   }
 
   cache(input: unknown, result: unknown, durationMs: number): ActionCacheEntry {
@@ -304,6 +350,7 @@ export class ActionCacheImpl implements IActionCache {
 
     this.enforceLimit();
     this.entries.set(inputHash, entry);
+    this.persist.upsert(inputHash, entry);
     return entry;
   }
 
@@ -316,6 +363,7 @@ export class ActionCacheImpl implements IActionCache {
 
     if (entry.expiresAt < new Date(getTimeProvider().now())) {
       this.entries.delete(inputHash);
+      this.persist.delete(inputHash);
       return null;
     }
 
@@ -333,6 +381,7 @@ export class ActionCacheImpl implements IActionCache {
           lastAccessedAt: new Date(getTimeProvider().now()),
         };
         this.entries.set(hash, updated);
+        this.persist.upsert(hash, updated);
         return;
       }
     }
@@ -345,6 +394,7 @@ export class ActionCacheImpl implements IActionCache {
     for (const [hash, entry] of this.entries) {
       if (entry.expiresAt < now) {
         this.entries.delete(hash);
+        this.persist.delete(hash);
         evicted++;
       }
     }
@@ -355,6 +405,7 @@ export class ActionCacheImpl implements IActionCache {
   clear(): number {
     const count = this.entries.size;
     this.entries.clear();
+    this.persist.clear();
     this.totalHits = 0;
     this.totalRequests = 0;
     return count;
@@ -374,6 +425,7 @@ export class ActionCacheImpl implements IActionCache {
     };
   }
 
+  /** Drop one entry to stay under the cache limit. SQLite mirror updated. */
   private enforceLimit(): void {
     if (this.entries.size >= this.config.maxActionCacheEntries) {
       this.evictExpired();
@@ -385,6 +437,7 @@ export class ActionCacheImpl implements IActionCache {
         const toRemove = sorted[0];
         if (toRemove !== undefined) {
           this.entries.delete(toRemove[0]);
+          this.persist.delete(toRemove[0]);
         }
       }
     }

--- a/packages/nexus-agents/src/context/mobimem-persistence.test.ts
+++ b/packages/nexus-agents/src/context/mobimem-persistence.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Persistence-focused tests for MobiMem (#2719).
+ *
+ * These pin the fix for the triple-disconnect: a write through one
+ * MobiMem instance must be visible to a freshly-opened MobiMem instance
+ * pointing at the same `dbPath`. Pre-Phase 4 this assertion failed —
+ * `dbPath` was a dead config field — and `KnnRoutingStage` had nothing
+ * to retrieve. Post-Phase 4 the SQLite mirror in `mobimem-persistence.ts`
+ * carries writes across instance boundaries.
+ *
+ * @module context/mobimem-persistence.test
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MobiMem,
+  getSharedMobiMem,
+  resetSharedMobiMem,
+  setSharedMobiMemDbPathResolver,
+} from './mobimem.js';
+
+describe('MobiMem SQLite persistence (#2719)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mobimem-persist-'));
+    dbPath = join(tmpDir, 'mobimem.db');
+  });
+
+  afterEach(() => {
+    resetSharedMobiMem();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('profile.observe persists across MobiMem instances', () => {
+    const a = new MobiMem({ dbPath });
+    a.profile.observe('agent-1', 'agent', 'preferred_model', 'claude');
+    a.close();
+
+    const b = new MobiMem({ dbPath });
+    const restored = b.profile.getPreference('agent-1', 'preferred_model');
+    expect(restored?.preferenceValue).toBe('claude');
+    b.close();
+  });
+
+  it('experience.recordExecution persists across MobiMem instances', () => {
+    const actionSequence = [
+      {
+        index: 0,
+        actionType: 'model_route',
+        parameters: { model: 'claude' },
+        durationMs: 100,
+        success: true,
+      },
+    ];
+    const outcome = { success: true, totalDurationMs: 100, tokensUsed: 500 };
+
+    const a = new MobiMem({ dbPath });
+    a.experience.recordExecution('arch-task', actionSequence, outcome, 'claude');
+    a.close();
+
+    const b = new MobiMem({ dbPath });
+    const patterns = b.experience.findPatterns('arch-task');
+    expect(patterns.length).toBeGreaterThanOrEqual(1);
+    expect(patterns[0]?.taskType).toBe('arch-task');
+    b.close();
+  });
+
+  it('action.cache persists with Date types intact', () => {
+    const a = new MobiMem({ dbPath, actionCacheTtlMs: 60_000 });
+    a.action.cache({ op: 'list', target: 'files' }, ['a.ts'], 200);
+    a.close();
+
+    const b = new MobiMem({ dbPath, actionCacheTtlMs: 60_000 });
+    const cached = b.action.get({ op: 'list', target: 'files' });
+    expect(cached).not.toBeNull();
+    // hydrateDates ensures Date fields aren't strings after JSON round-trip.
+    expect(cached?.expiresAt).toBeInstanceOf(Date);
+    expect(cached?.cachedAt).toBeInstanceOf(Date);
+    b.close();
+  });
+
+  it('in-memory mode (:memory:) keeps test isolation', () => {
+    const a = new MobiMem({ dbPath: ':memory:' });
+    a.profile.observe('agent-1', 'agent', 'k', 'v');
+    a.close();
+    // Second instance with same `:memory:` literal gets its own fresh DB.
+    const b = new MobiMem({ dbPath: ':memory:' });
+    expect(b.profile.getEntryCount()).toBe(0);
+    b.close();
+  });
+});
+
+describe('getSharedMobiMem singleton', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mobimem-shared-'));
+    dbPath = join(tmpDir, 'mobimem.db');
+    resetSharedMobiMem();
+    setSharedMobiMemDbPathResolver(() => dbPath);
+  });
+
+  afterEach(() => {
+    resetSharedMobiMem();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the same instance on repeat calls', () => {
+    const a = getSharedMobiMem();
+    const b = getSharedMobiMem();
+    expect(a).toBe(b);
+  });
+
+  it('shared instance persists writes to the resolver path', () => {
+    const shared = getSharedMobiMem();
+    shared.profile.observe('agent-x', 'agent', 'k', 'v');
+    resetSharedMobiMem();
+    // New singleton, same path → must see the write.
+    const next = getSharedMobiMem();
+    expect(next.profile.getPreference('agent-x', 'k')?.preferenceValue).toBe('v');
+  });
+});

--- a/packages/nexus-agents/src/context/mobimem-persistence.ts
+++ b/packages/nexus-agents/src/context/mobimem-persistence.ts
@@ -1,0 +1,120 @@
+/**
+ * nexus-agents/context — MobiMem SQLite persistence helper.
+ *
+ * Closes #2719 (mobimem triple-disconnect). Pre-Phase 4 MobiMem's
+ * `dbPath` config was a dead surface — the impl classes used pure
+ * `Map<string, Entry>` and the `dbPath` was passed in but never opened.
+ * `memory_stats` therefore read an empty SQLite file that nobody wrote
+ * to, while routing-memory wrote to in-memory MobiMems that died on
+ * process exit.
+ *
+ * This helper provides a tiny synchronous persistence side-channel: when
+ * the impl class is constructed with a `better-sqlite3` Database, the
+ * helper auto-creates a domain-specific table and exposes
+ * `load`/`upsert`/`delete`/`clear`. Without a DB (default test mode),
+ * every method is a no-op — the impl falls back to in-memory Maps.
+ *
+ * Why not route through `nexus-memory`'s `IMemoryBackend` directly:
+ * `IMemoryBackend` is async per the Phase 2 vote, but MobiMem's existing
+ * callers (`RoutingMemory.storePreference`, `recordExperience`, …) are
+ * sync, and `KnnRoutingStage` (the consumer this fix unblocks) is sync
+ * too. A sync side-channel that targets the same SQLite file `memory_stats`
+ * reads from is the minimum-scope fix that closes #2719 without forcing
+ * an async ripple across the routing pipeline.
+ *
+ * Phase 5+ migrations route their concept-spaces through the full
+ * `IMemoryBackend` contract.
+ *
+ * @module context/mobimem-persistence
+ */
+
+import type Database from 'better-sqlite3';
+type DatabaseType = InstanceType<typeof Database>;
+// Statement type is namespace-scoped in better-sqlite3 7.x; reach it via the
+// instance's `prepare` return type to keep the surface narrow.
+type Statement = ReturnType<DatabaseType['prepare']>;
+
+export interface MobiMemPersistenceOptions {
+  /** SQLite handle. Pass `null` for in-memory-only mode (tests). */
+  readonly db: DatabaseType | null;
+  /** Domain identifier — becomes the SQLite table name. Validated against `[a-z_]`. */
+  readonly domain: string;
+}
+
+/**
+ * Tiny CRUD helper backing a single MobiMem impl's Map cache. JSON-serializes
+ * values; every column other than `key`/`value` is for forward-compat with
+ * the broader memory-events scheme.
+ */
+export class MobiMemPersistence<TValue> {
+  readonly active: boolean;
+  private readonly db: DatabaseType | null;
+  private readonly domain: string;
+  private readonly stmts: {
+    upsert: Statement;
+    delete: Statement;
+    clear: Statement;
+    selectAll: Statement;
+  } | null;
+
+  constructor(options: MobiMemPersistenceOptions) {
+    this.db = options.db;
+    this.domain = options.domain;
+    this.active = options.db !== null;
+    if (!/^[a-z][a-z0-9_]{0,63}$/i.test(options.domain)) {
+      throw new Error(
+        `mobimem-persistence: invalid domain "${options.domain}" — must match [a-zA-Z][a-zA-Z0-9_]{0,63}`
+      );
+    }
+    if (this.active && this.db !== null) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS ${options.domain} (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          timestamp INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS ${options.domain}_timestamp ON ${options.domain}(timestamp);
+      `);
+      this.stmts = {
+        upsert: this.db.prepare(
+          `INSERT INTO ${options.domain} (key, value, timestamp) VALUES (@key, @value, @timestamp)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value, timestamp = excluded.timestamp`
+        ),
+        delete: this.db.prepare(`DELETE FROM ${options.domain} WHERE key = ?`),
+        clear: this.db.prepare(`DELETE FROM ${options.domain}`),
+        selectAll: this.db.prepare(`SELECT key, value FROM ${options.domain}`),
+      };
+    } else {
+      this.stmts = null;
+    }
+  }
+
+  /** Hydrate the impl's Map cache from SQLite. No-op when inactive. */
+  load(): readonly [string, TValue][] {
+    if (this.stmts === null) return [];
+    const rows = this.stmts.selectAll.all() as { key: string; value: string }[];
+    return rows.map((r) => [r.key, JSON.parse(r.value) as TValue]);
+  }
+
+  /** Upsert a single row. No-op when inactive. */
+  upsert(key: string, value: TValue): void {
+    if (this.stmts === null) return;
+    this.stmts.upsert.run({
+      key,
+      value: JSON.stringify(value),
+      timestamp: Date.now(),
+    });
+  }
+
+  /** Delete a single row. No-op when inactive. */
+  delete(key: string): void {
+    if (this.stmts === null) return;
+    this.stmts.delete.run(key);
+  }
+
+  /** Wipe the table. No-op when inactive. */
+  clear(): void {
+    if (this.stmts === null) return;
+    this.stmts.clear.run();
+  }
+}

--- a/packages/nexus-agents/src/context/mobimem.ts
+++ b/packages/nexus-agents/src/context/mobimem.ts
@@ -13,6 +13,11 @@
  * (Source: Issue #149, arXiv:2512.15784)
  */
 
+import Database from 'better-sqlite3';
+import { dirname } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+type DatabaseType = InstanceType<typeof Database>;
 import { createLogger } from '../core/logger.js';
 import type { IMobiMem, MobiMemConfig, MobiMemStats } from './mobimem-types.js';
 import { DEFAULT_MOBIMEM_CONFIG, MobiMemConfigSchema } from './mobimem-types.js';
@@ -45,14 +50,34 @@ export class MobiMem implements IMobiMem {
   readonly experience: ExperienceMemoryImpl;
   readonly action: ActionCacheImpl;
   private readonly config: MobiMemConfig;
+  private readonly db: DatabaseType | null;
 
   constructor(config: Partial<MobiMemConfig> = {}) {
     const validated = MobiMemConfigSchema.parse({ ...DEFAULT_MOBIMEM_CONFIG, ...config });
     this.config = validated;
-    this.profile = new ProfileMemoryImpl(this.config);
-    this.experience = new ExperienceMemoryImpl(this.config);
-    this.action = new ActionCacheImpl(this.config);
+    // #2719: actually open the SQLite handle when `dbPath` is a real file
+    // path. Pre-Phase 4 the `dbPath` config was a dead surface — `tool-
+    // memory.ts:270` passed it but the impl classes ignored it, so
+    // `memory_stats` read an empty DB while routing-memory wrote to
+    // in-memory Maps that died on exit. WAL mode keeps concurrent
+    // MCP-server + CLI readers coherent.
+    if (validated.dbPath === ':memory:' || validated.dbPath === '') {
+      this.db = null;
+    } else {
+      mkdirSync(dirname(validated.dbPath), { recursive: true });
+      const db = new Database(validated.dbPath);
+      // WAL mode for concurrent MCP-server + CLI readers. The narrowed
+      // `ISQLiteDatabase` interface used elsewhere in nexus-agents doesn't
+      // expose `pragma`, but the better-sqlite3 default export does.
+      (db as unknown as { pragma(s: string): void }).pragma('journal_mode = WAL');
+      this.db = db;
+    }
+    this.profile = new ProfileMemoryImpl(this.config, this.db);
+    this.experience = new ExperienceMemoryImpl(this.config, this.db);
+    this.action = new ActionCacheImpl(this.config, this.db);
     logger.info('MobiMem initialized', {
+      dbPath: validated.dbPath,
+      persisted: this.db !== null,
       maxProfileEntries: this.config.maxProfileEntries,
       maxExperiencePatterns: this.config.maxExperiencePatterns,
       maxActionCacheEntries: this.config.maxActionCacheEntries,
@@ -92,41 +117,63 @@ export class MobiMem implements IMobiMem {
   }
 
   close(): void {
+    if (this.db !== null) this.db.close();
     logger.info('MobiMem closed');
   }
-
-  /** Export MobiMem state for disk persistence (#1782). */
-  exportData(): MobiMemSnapshot {
-    return {
-      stats: this.getStats(),
-      exportedAt: new Date().toISOString(),
-    };
-  }
-
-  /** Save MobiMem state to disk (#1782). */
-  async save(filePath: string): Promise<void> {
-    try {
-      const fs = await import('node:fs/promises');
-      const path = await import('node:path');
-      await fs.mkdir(path.dirname(filePath), { recursive: true });
-      const data = JSON.stringify(this.exportData(), null, 2);
-      await fs.writeFile(filePath, data, 'utf-8');
-      logger.debug('MobiMem state saved', { path: filePath });
-    } catch (error) {
-      logger.warn('Failed to save MobiMem state', { error: String(error) });
-    }
-  }
-}
-
-/** Snapshot of MobiMem state for persistence (#1782). */
-export interface MobiMemSnapshot {
-  readonly stats: MobiMemStats;
-  readonly exportedAt: string;
 }
 
 /**
- * Create a MobiMem instance.
+ * Create a MobiMem instance. Test code should pass `{ dbPath: ':memory:' }`
+ * explicitly; production code should prefer {@link getSharedMobiMem} so
+ * routing-memory, agent-executor, and the `memory_stats` MCP reader all
+ * see the same data (#2719).
  */
 export function createMobiMem(config?: Partial<MobiMemConfig>): MobiMem {
   return new MobiMem(config);
+}
+
+// ============================================================================
+// Shared singleton (#2719)
+// ============================================================================
+
+let sharedInstance: MobiMem | null = null;
+let resolveSharedDbPath: () => string = defaultSharedDbPath;
+
+/**
+ * Process-wide MobiMem singleton. First call lazy-initializes with the
+ * canonical SQLite path; subsequent calls return the same instance.
+ *
+ * This is the production entry point — `RoutingMemory.constructor`
+ * (`routing-memory.ts:179`), `tool-memory.ts:270`, and any other caller
+ * that wants to share state should use this function.
+ *
+ * Tests should call {@link setSharedMobiMem} with an in-memory instance
+ * in `beforeEach` and {@link resetSharedMobiMem} in `afterEach`.
+ */
+export function getSharedMobiMem(): MobiMem {
+  sharedInstance ??= new MobiMem({ dbPath: resolveSharedDbPath() });
+  return sharedInstance;
+}
+
+/** Inject an alternate instance for tests. */
+export function setSharedMobiMem(instance: MobiMem | null): void {
+  sharedInstance = instance;
+}
+
+/** Close + null out the singleton. Idempotent. */
+export function resetSharedMobiMem(): void {
+  if (sharedInstance !== null) {
+    sharedInstance.close();
+    sharedInstance = null;
+  }
+}
+
+/** Override how `getSharedMobiMem` resolves its dbPath. Tests only. */
+export function setSharedMobiMemDbPathResolver(resolver: () => string): void {
+  resolveSharedDbPath = resolver;
+}
+
+function defaultSharedDbPath(): string {
+  const root = process.env['NEXUS_DATA_DIR'] ?? `${process.env['HOME'] ?? '/tmp'}/.nexus-agents`;
+  return `${root}/memory/mobimem.db`;
 }

--- a/packages/nexus-agents/src/context/routing-memory.ts
+++ b/packages/nexus-agents/src/context/routing-memory.ts
@@ -17,6 +17,7 @@ import type { CliName } from '../cli-adapters/types.js';
 import { CLI_NAMES } from '../config/model-capabilities-types.js';
 import {
   MobiMem,
+  getSharedMobiMem,
   type ExperienceEntry,
   type ActionStep,
   type ExecutionOutcome,
@@ -176,7 +177,11 @@ export class RoutingMemory implements IRoutingMemory {
   constructor(config?: Partial<RoutingMemoryConfig>, mobimem?: MobiMem) {
     this.config = { ...DEFAULT_ROUTING_MEMORY_CONFIG, ...config };
     this.logger = this.config.logger ?? createLogger({ component: 'RoutingMemory' });
-    this.mobimem = mobimem ?? new MobiMem();
+    // #2719 fix: default to the shared singleton instead of `new MobiMem()`
+    // (which used `:memory:` and lost data on process exit, leaving
+    // KnnRoutingStage with no patterns to retrieve). Callers can still
+    // inject an instance for tests.
+    this.mobimem = mobimem ?? getSharedMobiMem();
 
     this.logger.info('RoutingMemory initialized', {
       minObservations: this.config.minObservations,

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -41,7 +41,11 @@ import type {
   MemoryType,
 } from '../../context/memory-types.js';
 import type { AgentRole } from '../../core/types/agent.js';
-import { MobiMem } from '../../context/mobimem.js';
+import {
+  MobiMem,
+  getSharedMobiMem,
+  setSharedMobiMemDbPathResolver,
+} from '../../context/mobimem.js';
 import type { MobiMemStats } from '../../context/mobimem-types.js';
 import {
   MemoryPromoter,
@@ -264,13 +268,15 @@ export class ToolMemoryManager {
     }
   }
 
-  /** Initialize MobiMem (Phase 2 #746 - post-deployment learning). */
+  /** Initialize MobiMem (Phase 2 #746 - post-deployment learning).
+   *  #2719: routes through the process-wide singleton so this tool-memory
+   *  instance, RoutingMemory, and any other caller share state. The
+   *  shared singleton uses the same MOBIMEM_DB_PATH this tool used to
+   *  pass directly. */
   private initMobiMem(): void {
     try {
-      this.mobimem = new MobiMem({
-        dbPath: MOBIMEM_DB_PATH,
-        autoEviction: true,
-      });
+      setSharedMobiMemDbPathResolver(() => MOBIMEM_DB_PATH);
+      this.mobimem = getSharedMobiMem();
       this.log.info('MobiMem activated (Phase 2 #746)');
     } catch (error: unknown) {
       this.log.debug('MobiMem init failed', {

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -146,26 +146,14 @@ function recordMemoryError(error: string, solution: string): void {
   void getPipelineMemoryAsync().then((m) => m?.recordError({ error, solution }));
 }
 
-/** Flush pipeline memory session + persist MobiMem state (#1782). */
+/** Flush pipeline memory session. */
 export function flushPipelineMemory(): void {
   void getPipelineMemoryAsync().then((m) => m?.flush());
-  // Persist MobiMem/RoutingMemory to disk if enabled (#1782)
-  void persistMobiMemState();
-}
-
-/** Save MobiMem state to disk for cross-session learning (#1782). */
-async function persistMobiMemState(): Promise<void> {
-  try {
-    const { isPersistenceEnabled } = await import('../config/learning-persistence.js');
-    if (!isPersistenceEnabled()) return;
-    const { nexusDataPath } = await import('../config/nexus-data-dir.js');
-    const { createMobiMem } = await import('../context/mobimem.js');
-    const mobimem = createMobiMem();
-    const savePath = nexusDataPath('memory', 'mobimem-state.json');
-    await mobimem.save(savePath);
-  } catch {
-    // MobiMem persistence failure must never block pipeline completion
-  }
+  // #2719 / Phase 4: persistence is now handled by MobiMem's SQLite
+  // mirror in mobimem-impl.ts — every `observe`/`recordExecution`/`cache`
+  // call writes through to mobimem.db inline. The old persistMobiMemState
+  // path created a fresh empty MobiMem and saved its stats to JSON, which
+  // didn't actually preserve any data. Removed.
 }
 
 // Cached RoutingMemory — lazy-initialized, one per process


### PR DESCRIPTION
## Summary
- **Closes #2719** (mobimem triple-disconnect). Phase 4 of epic #2766.
- MobiMem's `dbPath` config is no longer dead code — when set to a real file path, every `profile.observe` / `experience.recordExecution` / `action.cache` write mirrors to SQLite synchronously via the new `mobimem-persistence.ts` helper. Pre-fix all data lived in process-local `Map<string, Entry>` and died on exit.
- New `getSharedMobiMem()` singleton routes routing-memory + tool-memory + (future) agent-executor through a single instance pointing at `~/.nexus-agents/memory/mobimem.db` — the same file `memory_stats` already reads.
- `persistMobiMemState` (agent-executor) and `MobiMem.save()` (the JSON-stats path) deleted. Both were dead architecture that did the wrong thing.

## Smoke

After this lands, an actual cross-process round-trip works:

```ts
// process 1
const a = new MobiMem({ dbPath: '/tmp/mobimem.db' });
a.profile.observe('agent-1', 'agent', 'preferred_model', 'claude');
a.close();

// process 2
const b = new MobiMem({ dbPath: '/tmp/mobimem.db' });
b.profile.getPreference('agent-1', 'preferred_model')?.preferenceValue
// → 'claude'  (was undefined pre-fix)
```

Pinned by 6 new regression tests in `mobimem-persistence.test.ts`.

## Architectural deferral

Routing MobiMem through `nexus-memory`'s `IMemoryBackend` (the Phase 3 async contract) would require an async ripple across `KnnRoutingStage` / `StrategyDistiller` / `routing-context-store-impl`. This sync side-channel closes #2719 with minimum blast radius. A future Phase 4.1 can fold MobiMem into `IMemoryBackend` when the async migration is in scope.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/context src/pipeline/agent-executor.test.ts` → **1094 tests pass across 40 files**
- [x] 6 new persistence regression tests pin the cross-instance invariant + Date hydration + singleton semantics
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
