### PR TITLE
feat(memory): one-shot cleanup for polluted belief rows (Phase 9 of #2766)

### DIFF
--- a/.changeset/2775-belief-cleanup.md
+++ b/.changeset/2775-belief-cleanup.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+**Phase 9 of #2766** — one-shot cleanup for belief-backend rows polluted by the #2719-era arXiv feed-fallback bug. Closes #2775.
+
+Pre-#2755 the `extractEntryXml` helper fell back to the feed-level `<title>` when an arXiv query returned no entries. The feed title for a no-results query is literally `arXiv Query: search_query=...`, which then got persisted as a "belief" with the bogus title as the subject. #2755 fixed the writer; this PR ships the reader-side cleanup.
+
+New module `context/belief-cleanup.ts`:
+
+- `classifyBelief(belief) → { polluted, matchedPattern? }`: pattern-match on `subject` / `predicate` / `object`.
+- `runBeliefCleanup({ loadBeliefs, deleteBelief, markerDir, force })`: storage-aware driver. Marker file `.belief-cleanup-done` makes re-runs no-op.
+- `readBeliefCleanupMarker()`: status display helper.
+
+Storage callbacks are dependency-injected so production wires them to `HindsightBeliefMemory` and tests can inject in-memory stores.
+
+13 regression tests cover classifier positive + negative cases (real `arXiv:NNNN.NNNNN` references kept intact), idempotency marker, force re-run, async callbacks, and the samples cap.

--- a/packages/nexus-agents/src/context/belief-cleanup.test.ts
+++ b/packages/nexus-agents/src/context/belief-cleanup.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the Phase 9 belief-pollution cleanup script.
+ *
+ * Covers (1) the classifier's positive + negative cases, (2) the
+ * idempotency marker, and (3) the storage-aware driver's removal +
+ * marker-write flow.
+ *
+ * @module context/belief-cleanup.test
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  classifyBelief,
+  classifyBeliefs,
+  readBeliefCleanupMarker,
+  runBeliefCleanup,
+} from './belief-cleanup.js';
+import { BeliefConfidence, BeliefSourceType, type Belief } from './belief-core-types.js';
+
+function makeBelief(overrides: Partial<Belief> = {}): Belief {
+  return {
+    beliefId: `b-${Math.random().toString(36).slice(2, 8)}`,
+    subject: 'A real paper',
+    predicate: 'has_topic',
+    object: 'agents',
+    confidence: BeliefConfidence.MEDIUM,
+    sourceType: BeliefSourceType.OBSERVATION,
+    version: 1,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    superseded: false,
+    ...overrides,
+  };
+}
+
+describe('classifyBelief', () => {
+  it('flags rows where subject matches "arXiv Query: search_query="', () => {
+    const b = makeBelief({
+      subject: 'arXiv Query: search_query=quantum&id_list=&start=0&max_results=10',
+    });
+    const decision = classifyBelief(b);
+    expect(decision.polluted).toBe(true);
+    expect(decision.matchedPattern).toBeDefined();
+  });
+
+  it('flags rows where object carries the id_list=...max_results= pattern', () => {
+    const b = makeBelief({ object: 'id_list=2401.1234&start=0&max_results=10' });
+    const decision = classifyBelief(b);
+    expect(decision.polluted).toBe(true);
+  });
+
+  it('keeps real beliefs intact', () => {
+    const b = makeBelief();
+    expect(classifyBelief(b).polluted).toBe(false);
+  });
+
+  it("keeps beliefs whose text *mentions* arxiv but isn't a query-string", () => {
+    const b = makeBelief({
+      subject: 'arXiv:2401.12345',
+      object: 'Memory-augmented agents paper',
+    });
+    expect(classifyBelief(b).polluted).toBe(false);
+  });
+
+  it('classifyBeliefs returns one decision per input', () => {
+    const ds = classifyBeliefs([
+      makeBelief(),
+      makeBelief({ subject: 'arXiv Query: search_query=&id_list=' }),
+    ]);
+    expect(ds).toHaveLength(2);
+    expect(ds[0]?.polluted).toBe(false);
+    expect(ds[1]?.polluted).toBe(true);
+  });
+});
+
+describe('runBeliefCleanup', () => {
+  let markerDir: string;
+
+  beforeEach(() => {
+    markerDir = mkdtempSync(join(tmpdir(), 'belief-cleanup-'));
+  });
+
+  afterEach(() => {
+    rmSync(markerDir, { recursive: true, force: true });
+  });
+
+  it('removes polluted rows and keeps clean ones', async () => {
+    const beliefs = [
+      makeBelief({ beliefId: 'keep-1' }),
+      makeBelief({
+        beliefId: 'drop-1',
+        subject: 'arXiv Query: search_query=&id_list=&max_results=10',
+      }),
+      makeBelief({ beliefId: 'keep-2' }),
+    ];
+    const deleted: string[] = [];
+    const result = await runBeliefCleanup({
+      loadBeliefs: () => beliefs,
+      deleteBelief: (id) => {
+        deleted.push(id);
+      },
+      markerDir,
+    });
+    expect(result.scanned).toBe(3);
+    expect(result.removed).toBe(1);
+    expect(result.kept).toBe(2);
+    expect(deleted).toEqual(['drop-1']);
+  });
+
+  it('writes a marker file after first run', async () => {
+    await runBeliefCleanup({
+      loadBeliefs: () => [],
+      deleteBelief: () => {
+        /* noop */
+      },
+      markerDir,
+    });
+    const marker = readBeliefCleanupMarker(markerDir);
+    expect(marker).not.toBeNull();
+    expect((marker as { scanned: number }).scanned).toBe(0);
+  });
+
+  it('skips subsequent runs once the marker exists', async () => {
+    let calls = 0;
+    const load = (): Belief[] => {
+      calls++;
+      return [];
+    };
+    await runBeliefCleanup({ loadBeliefs: load, deleteBelief: () => {}, markerDir });
+    const second = await runBeliefCleanup({
+      loadBeliefs: load,
+      deleteBelief: () => {},
+      markerDir,
+    });
+    expect(calls).toBe(1);
+    expect(second.skipped).toBe(true);
+  });
+
+  it('force option overrides the marker', async () => {
+    await runBeliefCleanup({ loadBeliefs: () => [], deleteBelief: () => {}, markerDir });
+    let calls = 0;
+    const result = await runBeliefCleanup({
+      loadBeliefs: () => {
+        calls++;
+        return [];
+      },
+      deleteBelief: () => {},
+      markerDir,
+      force: true,
+    });
+    expect(calls).toBe(1);
+    expect(result.skipped).toBe(false);
+  });
+
+  it('marker captures samples of the first 3 polluted subjects', async () => {
+    const polluted = Array.from({ length: 5 }, (_, i) =>
+      makeBelief({
+        beliefId: `drop-${String(i)}`,
+        subject: `arXiv Query: search_query=topic${String(i)}&id_list=&max_results=10`,
+      })
+    );
+    const result = await runBeliefCleanup({
+      loadBeliefs: () => polluted,
+      deleteBelief: () => {},
+      markerDir,
+    });
+    expect(result.samples).toHaveLength(3);
+    expect(result.samples[0]).toContain('arXiv Query:');
+  });
+
+  it('async load + deleteBelief callbacks work', async () => {
+    const beliefs = [
+      makeBelief({
+        beliefId: 'drop',
+        subject: 'arXiv Query: search_query=x&id_list=&max_results=10',
+      }),
+    ];
+    const deleted: string[] = [];
+    const result = await runBeliefCleanup({
+      loadBeliefs: () => Promise.resolve(beliefs),
+      deleteBelief: (id) => Promise.resolve().then(() => void deleted.push(id)),
+      markerDir,
+    });
+    expect(result.removed).toBe(1);
+    expect(deleted).toEqual(['drop']);
+  });
+});
+
+describe('readBeliefCleanupMarker', () => {
+  it('returns null when marker is absent', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'belief-marker-'));
+    expect(readBeliefCleanupMarker(tmp)).toBeNull();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns parsed JSON when marker is present', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'belief-marker-'));
+    await runBeliefCleanup({
+      loadBeliefs: () => [],
+      deleteBelief: () => {},
+      markerDir: tmp,
+    });
+    const m = readBeliefCleanupMarker(tmp) as Record<string, unknown>;
+    expect(typeof m.completedAt).toBe('string');
+    rmSync(tmp, { recursive: true, force: true });
+    expect(existsSync(join(tmp, '.belief-cleanup-done'))).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/context/belief-cleanup.ts
+++ b/packages/nexus-agents/src/context/belief-cleanup.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase 9 of #2766 — one-shot cleanup script for belief-backend rows
+ * polluted by the #2719-era arXiv feed-fallback bug.
+ *
+ * Pre-#2755 the `extractEntryXml` helper fell back to the feed-level
+ * `<title>` when an arXiv query returned no entries. The feed title for
+ * a no-results query is literally `arXiv Query: search_query=...`, which
+ * then got persisted as a "belief" with the bogus title as the subject.
+ * The feed-fallback bug was fixed in #2755, but pre-fix rows still live
+ * in users' belief stores. This module flags + removes them.
+ *
+ * Idempotent: a marker file under `<nexusDataDir>/memory/` records
+ * completion; re-running after a successful pass is a no-op.
+ *
+ * @module context/belief-cleanup
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Belief } from './belief-core-types.js';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
+
+/** Regex patterns that identify a polluted belief row. */
+const POLLUTED_PATTERNS: readonly RegExp[] = [
+  /arXiv Query:\s*search_query=/i,
+  // `id_list=...max_results=` — the no-results feed-fallback URL format.
+  // Allow `&` separators between params; `[\s\S]` keeps it permissive but
+  // capped to 200 chars so it won't false-positive on long unrelated text.
+  /id_list=[\s\S]{0,200}?max_results=/i,
+];
+
+/** Marker file name used to skip re-runs of a successful cleanup. */
+export const BELIEF_CLEANUP_MARKER = '.belief-cleanup-done';
+
+/** Decision for a single belief: keep or drop. */
+export interface BeliefCleanupDecision {
+  readonly belief: Belief;
+  readonly polluted: boolean;
+  readonly matchedPattern?: string;
+}
+
+/** Summary returned by `runBeliefCleanup`. */
+export interface BeliefCleanupResult {
+  readonly scanned: number;
+  readonly removed: number;
+  readonly kept: number;
+  readonly samples: readonly string[];
+  readonly skipped: boolean;
+  readonly markerPath: string;
+}
+
+/** Inspect a single belief; return a decision. */
+export function classifyBelief(belief: Belief): BeliefCleanupDecision {
+  const haystacks = [belief.subject, belief.predicate, belief.object].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  for (const pattern of POLLUTED_PATTERNS) {
+    for (const text of haystacks) {
+      if (pattern.test(text)) {
+        return { belief, polluted: true, matchedPattern: pattern.source };
+      }
+    }
+  }
+  return { belief, polluted: false };
+}
+
+/**
+ * Run cleanup against a provided beliefs array. Returns the decisions
+ * (caller is responsible for actually removing the polluted rows from
+ * the underlying store). This separation keeps the function pure and
+ * testable; the storage-aware wrapper is below.
+ */
+export function classifyBeliefs(beliefs: readonly Belief[]): readonly BeliefCleanupDecision[] {
+  return beliefs.map(classifyBelief);
+}
+
+/**
+ * Storage-aware cleanup driver. Reads beliefs via the provided
+ * `loadBeliefs` callback, identifies polluted rows, removes them via
+ * `deleteBelief`, and writes a marker file so subsequent runs no-op.
+ *
+ * Tests inject the callbacks with in-memory stores; production wires
+ * them to `HindsightBeliefMemory.list()` + `.remove()` (or the persisted
+ * snapshot at `<nexusDataDir>/memory/belief-snapshot.json`).
+ */
+export interface RunBeliefCleanupOptions {
+  readonly loadBeliefs: () => Promise<readonly Belief[]> | readonly Belief[];
+  readonly deleteBelief: (id: string) => Promise<void> | void;
+  /** Directory to place the `.belief-cleanup-done` marker. */
+  readonly markerDir?: string;
+  /** Skip the marker check (force re-run). Tests only. */
+  readonly force?: boolean;
+}
+
+export async function runBeliefCleanup(
+  options: RunBeliefCleanupOptions
+): Promise<BeliefCleanupResult> {
+  const markerDir = options.markerDir ?? nexusDataPath('memory');
+  const markerPath = join(markerDir, BELIEF_CLEANUP_MARKER);
+
+  if (options.force !== true && existsSync(markerPath)) {
+    return {
+      scanned: 0,
+      removed: 0,
+      kept: 0,
+      samples: [],
+      skipped: true,
+      markerPath,
+    };
+  }
+
+  const beliefs = await Promise.resolve(options.loadBeliefs());
+  const decisions = classifyBeliefs(beliefs);
+  const polluted = decisions.filter((d) => d.polluted);
+  const samples = polluted.slice(0, 3).map((d) => d.belief.subject);
+
+  for (const d of polluted) {
+    await Promise.resolve(options.deleteBelief(d.belief.beliefId));
+  }
+
+  mkdirSync(dirname(markerPath), { recursive: true });
+  writeFileSync(
+    markerPath,
+    JSON.stringify(
+      {
+        completedAt: new Date().toISOString(),
+        scanned: beliefs.length,
+        removed: polluted.length,
+        samples,
+      },
+      null,
+      2
+    ),
+    'utf-8'
+  );
+
+  return {
+    scanned: beliefs.length,
+    removed: polluted.length,
+    kept: beliefs.length - polluted.length,
+    samples,
+    skipped: false,
+    markerPath,
+  };
+}
+
+/** Read an existing marker file, if any. Useful for status displays. */
+export function readBeliefCleanupMarker(markerDir: string = nexusDataPath('memory')): unknown {
+  const path = join(markerDir, BELIEF_CLEANUP_MARKER);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- **Phase 9 of #2766** — one-shot cleanup for belief-backend rows polluted by the #2719-era arXiv feed-fallback bug. Closes #2775.
- New module `context/belief-cleanup.ts` with three exports:
  - `classifyBelief(b)` — pattern-match on `subject` / `predicate` / `object`
  - `runBeliefCleanup({loadBeliefs, deleteBelief, markerDir, force})` — storage-aware driver with idempotency marker
  - `readBeliefCleanupMarker()` — status display helper
- Storage callbacks dependency-injected so production wires them to `HindsightBeliefMemory`; tests use in-memory stores.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run src/context/belief-cleanup.test.ts` → 13 tests pass
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
