### PR TITLE
docs(memory): document per-instance backends as registry-scope (Phase 7 of #2766)

### DIFF
--- a/.changeset/2773-remaining-backends-design.md
+++ b/.changeset/2773-remaining-backends-design.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**Phase 7 of #2766** — document remaining backends as intentionally per-instance. Closes #2773 (minimum-viable scope).
+
+`SICA SicaVersionManager`, `SkillLibrary`, `StrategyDistiller`, `MemoryState` (agent execution patterns), and `SharedMemoryStore` (pipeline scratch) don't have process-wide singletons. They're constructed on-demand per agent/run/instance. Forcing them into a global `MemoryRegistry` would require either (a) tracking N concurrent instances under generated keys or (b) rewriting their lifecycles to be singleton-owned — both of which exceed the architectural value at this stage.
+
+AGENTS.md `Canonical paths` section now:
+
+- Lists `MemoryRegistry` alongside the other canonical registries.
+- Adds a `Memory contract scope` subsection explicitly documenting the per-instance backends as **out of registry scope by design**, with rationale and the Phase 7.1+ follow-up condition ("once a clear cross-process consumer needs them").
+
+This closes the architectural piece of #2773. Phase 7.1 (deferred) would fold these in once there's demonstrated cross-process demand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,11 +109,24 @@ Do not create parallel implementations — modify existing files at these canoni
 | MCP tools         | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
 | Model registry    | `ModelRegistry` + `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`) |
 | Adapter registry  | `UnifiedAdapterRegistry` — `src/adapters/unified-registry.ts`                                                  |
+| Memory registry   | `MemoryRegistry` + `getMemoryRegistry()` — `packages/nexus-memory/src/registry.ts`                             |
 | Graph workflows   | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
 | Pipeline runner   | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
 | Security pipeline | `src/security/index.ts`                                                                                        |
 
 All task routing goes through: `Task → BudgetRouter → ZeroRouter → PreferenceRouter → TopsisRouter → LinUCB → Selected Model`. Do NOT directly instantiate stage routers — use `CompositeRouter.route(task)`.
+
+### Memory contract scope (#2766)
+
+The unified `MemoryRegistry` (Phase 3+) is the discovery + telemetry surface for memory concept-spaces that have a process-wide singleton. As of Phase 7 (#2773) the following backends are **intentionally per-instance** and out of registry scope:
+
+- **SICA `SicaVersionManager`** — per-agent version history; lives inside each SICA agent instance and disposes with it.
+- **`SkillLibrary`** — per-agent skill set; constructed on demand by skill consumers.
+- **`StrategyDistiller`** — derived rules over OutcomeStore; one instance per learning loop.
+- **`MemoryState` (agent execution patterns)** — per-`{agentId, role}` snapshot owned by the base-agent.
+- **`SharedMemoryStore` (pipeline scratch)** — in-process, scoped to a single pipeline run by design (#2766 Phase 7 acceptance).
+
+Each backend MUST still persist via its existing storage path (no parallel layouts) and SHOULD expose a `count()` (or equivalent) for ad-hoc inspection. Future Phase 7.1+ work can fold them in once a clear cross-process consumer needs them. Until then, treat the `MemoryRegistry` as covering the **shared-singleton subset** of in-tree memory.
 
 ## Track all work — deferring is fine, untracked is not
 


### PR DESCRIPTION
## Summary
- **Phase 7 of #2766** — documents the remaining backends (SICA / SkillLibrary / StrategyDistiller / MemoryState / SharedMemoryStore) as intentionally **per-instance** and out of `MemoryRegistry` scope by design. Closes #2773 (minimum-viable scope).
- AGENTS.md `Canonical paths` section now lists `MemoryRegistry` alongside the other canonical registries and adds a new `Memory contract scope` subsection explaining the per-instance backends.
- Phase 7.1+ (deferred) would fold them in once there's demonstrated cross-process demand.

## Rationale
These backends are constructed on-demand per agent / run / instance. Forcing them into a global registry would either require tracking N concurrent instances under generated keys or rewriting their lifecycles to be singleton-owned — both exceed the architectural value at this stage.

## Test plan
- [x] `pnpm governance:check` passes
- [x] AGENTS.md changes render correctly (table column alignment)
- [x] Changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
