### PR TITLE
fix(memory): wire phase 9 cleanup + real counts + registry-backed memory_stats

### DIFF
--- a/.changeset/2766-phase-5-9-followups.md
+++ b/.changeset/2766-phase-5-9-followups.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': minor
+---
+
+**Follow-ups to Phases 5, 7, and 9 of epic #2766** (memory unification). Closes review findings from the post-merge code review.
+
+- **Phase 9 cleanup is now actually invoked.** `runBeliefCleanup` is wired into `ToolMemoryManager`'s constructor and runs once on first startup (marker-file gated). Previously the cleanup logic existed and was fully tested but had zero production callers, so polluted arXiv rows never got removed.
+- **`memory_stats` reads the unified `MemoryRegistry`.** Adds a `registry` array to the response with one entry per attached domain (`belief`, `agentic`, `adaptive`, `typed`, `mobimem`, `outcomes`). This delivers the Phase 5 architectural goal — discoverability through one canonical fan-out — that the per-backend `is*Available()` calls left undone.
+- **Real counts on `agentic` + `adaptive`.** Both now expose `count()` (delegating to the shared `HybridMemoryBackend`) and the registry attachments report actual row totals instead of the hardcoded `0` placeholder.
+- **`HindsightBeliefMemory.forget(id)` is a public API.** Removes a single belief and cleans up index entries; used by the cleanup driver and available for future tooling.
+- Polish: drift-gate probes use boundary-aware regex (`new Database(?!\w)` etc.) so `new DatabaseAdapter(...)` and `new MobiMemAdapter(...)` no longer false-positive. `RunBeliefCleanupOptions` callbacks are async-only — production wiring always returns promises, and the tighter contract surfaces sync-vs-async confusion at type-check time.

--- a/packages/nexus-agents/src/context/adaptive-memory.test.ts
+++ b/packages/nexus-agents/src/context/adaptive-memory.test.ts
@@ -77,6 +77,8 @@ function createMockRun(
 function createMockGet(store: MockStore, sql: string): (...params: unknown[]) => unknown {
   return (...params: unknown[]): unknown => {
     if (sql.includes('COUNT') && sql.includes('memories')) {
+      // Param-less `SELECT COUNT(*) FROM memories` → total row count.
+      if (params.length === 0) return { count: store.memories.size };
       const [key] = params as [string];
       return { count: store.memories.has(key) ? 1 : 0 };
     }
@@ -420,6 +422,20 @@ describe('initialization', () => {
 
   it('initializes with database', () => {
     expect(mockDb.store).toBeDefined();
+  });
+
+  it('count() delegates to base and returns row total', async () => {
+    mockDb.store.memories.set('a', createMockEntry('a', 'first', 'high', new Date()));
+    mockDb.store.memories.set('b', createMockEntry('b', 'second', 'low', new Date()));
+    const result = await backend.count();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe(2);
+  });
+
+  it('count() returns 0 on empty store', async () => {
+    const result = await backend.count();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe(0);
   });
 });
 

--- a/packages/nexus-agents/src/context/adaptive-memory.ts
+++ b/packages/nexus-agents/src/context/adaptive-memory.ts
@@ -150,6 +150,10 @@ export class AdaptiveMemoryBackend implements IAdaptiveMemory {
     return this.base.prune(olderThan);
   }
 
+  count(): Promise<Result<number, MemoryError>> {
+    return this.base.count();
+  }
+
   // =========================================================================
   // IAdaptiveMemory Methods
   // =========================================================================

--- a/packages/nexus-agents/src/context/agentic-memory.test.ts
+++ b/packages/nexus-agents/src/context/agentic-memory.test.ts
@@ -104,6 +104,8 @@ function createMockGet(store: MockStore, sql: string): (...params: unknown[]) =>
   // eslint-disable-next-line complexity -- test mock with multiple SQL patterns
   return (...params: unknown[]): unknown => {
     if (sql.includes('COUNT') && sql.includes('memories')) {
+      // Param-less `SELECT COUNT(*) FROM memories` → total row count.
+      if (params.length === 0) return { count: store.memories.size };
       const [key] = params as [string];
       return { count: store.memories.has(key) ? 1 : 0 };
     }
@@ -552,6 +554,36 @@ describe('AgenticMemoryBackend', () => {
 
   afterEach(() => {
     backend.close();
+  });
+
+  describe('count', () => {
+    it('delegates to base and returns row total', async () => {
+      mockDb.store.memories.set('a', {
+        key: 'a',
+        value: '"v1"',
+        metadata: '{}',
+        created_at: Date.now(),
+        accessed_at: Date.now(),
+        expires_at: null,
+      });
+      mockDb.store.memories.set('b', {
+        key: 'b',
+        value: '"v2"',
+        metadata: '{}',
+        created_at: Date.now(),
+        accessed_at: Date.now(),
+        expires_at: null,
+      });
+      const result = await backend.count();
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBe(2);
+    });
+
+    it('returns 0 on empty store', async () => {
+      const result = await backend.count();
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBe(0);
+    });
   });
 
   describe('storeWithAttributes', () => {

--- a/packages/nexus-agents/src/context/agentic-memory.ts
+++ b/packages/nexus-agents/src/context/agentic-memory.ts
@@ -192,6 +192,9 @@ export class AgenticMemoryBackend implements IAgenticMemory {
   prune(olderThan: Date): Promise<Result<number, MemoryError>> {
     return this.base.prune(olderThan);
   }
+  count(): Promise<Result<number, MemoryError>> {
+    return this.base.count();
+  }
 
   // IAgenticMemory Methods
   async storeWithAttributes(

--- a/packages/nexus-agents/src/context/belief-cleanup.test.ts
+++ b/packages/nexus-agents/src/context/belief-cleanup.test.ts
@@ -19,6 +19,7 @@ import {
   runBeliefCleanup,
 } from './belief-cleanup.js';
 import { BeliefConfidence, BeliefSourceType, type Belief } from './belief-core-types.js';
+import { HindsightBeliefMemory } from './belief-memory.js';
 
 function makeBelief(overrides: Partial<Belief> = {}): Belief {
   return {
@@ -98,9 +99,10 @@ describe('runBeliefCleanup', () => {
     ];
     const deleted: string[] = [];
     const result = await runBeliefCleanup({
-      loadBeliefs: () => beliefs,
+      loadBeliefs: () => Promise.resolve(beliefs),
       deleteBelief: (id) => {
         deleted.push(id);
+        return Promise.resolve();
       },
       markerDir,
     });
@@ -112,10 +114,8 @@ describe('runBeliefCleanup', () => {
 
   it('writes a marker file after first run', async () => {
     await runBeliefCleanup({
-      loadBeliefs: () => [],
-      deleteBelief: () => {
-        /* noop */
-      },
+      loadBeliefs: () => Promise.resolve([]),
+      deleteBelief: () => Promise.resolve(),
       markerDir,
     });
     const marker = readBeliefCleanupMarker(markerDir);
@@ -125,14 +125,18 @@ describe('runBeliefCleanup', () => {
 
   it('skips subsequent runs once the marker exists', async () => {
     let calls = 0;
-    const load = (): Belief[] => {
+    const load = (): Promise<readonly Belief[]> => {
       calls++;
-      return [];
+      return Promise.resolve([]);
     };
-    await runBeliefCleanup({ loadBeliefs: load, deleteBelief: () => {}, markerDir });
+    await runBeliefCleanup({
+      loadBeliefs: load,
+      deleteBelief: () => Promise.resolve(),
+      markerDir,
+    });
     const second = await runBeliefCleanup({
       loadBeliefs: load,
-      deleteBelief: () => {},
+      deleteBelief: () => Promise.resolve(),
       markerDir,
     });
     expect(calls).toBe(1);
@@ -140,14 +144,18 @@ describe('runBeliefCleanup', () => {
   });
 
   it('force option overrides the marker', async () => {
-    await runBeliefCleanup({ loadBeliefs: () => [], deleteBelief: () => {}, markerDir });
+    await runBeliefCleanup({
+      loadBeliefs: () => Promise.resolve([]),
+      deleteBelief: () => Promise.resolve(),
+      markerDir,
+    });
     let calls = 0;
     const result = await runBeliefCleanup({
       loadBeliefs: () => {
         calls++;
-        return [];
+        return Promise.resolve([]);
       },
-      deleteBelief: () => {},
+      deleteBelief: () => Promise.resolve(),
       markerDir,
       force: true,
     });
@@ -163,8 +171,8 @@ describe('runBeliefCleanup', () => {
       })
     );
     const result = await runBeliefCleanup({
-      loadBeliefs: () => polluted,
-      deleteBelief: () => {},
+      loadBeliefs: () => Promise.resolve(polluted),
+      deleteBelief: () => Promise.resolve(),
       markerDir,
     });
     expect(result.samples).toHaveLength(3);
@@ -189,6 +197,68 @@ describe('runBeliefCleanup', () => {
   });
 });
 
+describe('runBeliefCleanup against a real HindsightBeliefMemory', () => {
+  let markerDir: string;
+
+  beforeEach(() => {
+    markerDir = mkdtempSync(join(tmpdir(), 'belief-cleanup-integration-'));
+  });
+
+  afterEach(() => {
+    rmSync(markerDir, { recursive: true, force: true });
+  });
+
+  it('removes polluted rows from HindsightBeliefMemory via forget()', async () => {
+    const beliefs = new HindsightBeliefMemory();
+    // Two clean retains + one polluted (the bug shape).
+    await beliefs.retain({
+      subject: 'Real paper title',
+      predicate: 'has_topic',
+      object: 'agents',
+      confidence: BeliefConfidence.MEDIUM,
+      sourceType: BeliefSourceType.OBSERVATION,
+    });
+    await beliefs.retain({
+      subject: 'arXiv Query: search_query=quantum&id_list=&max_results=10',
+      predicate: 'pollution',
+      object: 'feed-fallback bug pre-#2755',
+      confidence: BeliefConfidence.LOW,
+      sourceType: BeliefSourceType.OBSERVATION,
+    });
+    await beliefs.retain({
+      subject: 'Another real one',
+      predicate: 'has_topic',
+      object: 'memory',
+      confidence: BeliefConfidence.HIGH,
+      sourceType: BeliefSourceType.OBSERVATION,
+    });
+
+    const result = await runBeliefCleanup({
+      loadBeliefs: async () => {
+        const q = await beliefs.query({ includeSuperseded: true });
+        return q.ok ? q.value : [];
+      },
+      deleteBelief: async (id) => {
+        await beliefs.forget(id);
+      },
+      markerDir,
+    });
+
+    expect(result.scanned).toBe(3);
+    expect(result.removed).toBe(1);
+    expect(result.kept).toBe(2);
+
+    const remaining = await beliefs.query({ includeSuperseded: true });
+    expect(remaining.ok).toBe(true);
+    if (remaining.ok) {
+      expect(remaining.value).toHaveLength(2);
+      for (const b of remaining.value) {
+        expect(b.subject).not.toMatch(/arXiv Query/i);
+      }
+    }
+  });
+});
+
 describe('readBeliefCleanupMarker', () => {
   it('returns null when marker is absent', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'belief-marker-'));
@@ -199,8 +269,8 @@ describe('readBeliefCleanupMarker', () => {
   it('returns parsed JSON when marker is present', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'belief-marker-'));
     await runBeliefCleanup({
-      loadBeliefs: () => [],
-      deleteBelief: () => {},
+      loadBeliefs: () => Promise.resolve([]),
+      deleteBelief: () => Promise.resolve(),
       markerDir: tmp,
     });
     const m = readBeliefCleanupMarker(tmp) as Record<string, unknown>;

--- a/packages/nexus-agents/src/context/belief-cleanup.ts
+++ b/packages/nexus-agents/src/context/belief-cleanup.ts
@@ -80,12 +80,16 @@ export function classifyBeliefs(beliefs: readonly Belief[]): readonly BeliefClea
  * `deleteBelief`, and writes a marker file so subsequent runs no-op.
  *
  * Tests inject the callbacks with in-memory stores; production wires
- * them to `HindsightBeliefMemory.list()` + `.remove()` (or the persisted
+ * them to `HindsightBeliefMemory.query()` + `.forget()` (or the persisted
  * snapshot at `<nexusDataDir>/memory/belief-snapshot.json`).
+ *
+ * Callbacks are async-only: every real implementation is async (the
+ * belief store returns `Promise<Result<...>>`), and tests can wrap
+ * sync data with `Promise.resolve`.
  */
 export interface RunBeliefCleanupOptions {
-  readonly loadBeliefs: () => Promise<readonly Belief[]> | readonly Belief[];
-  readonly deleteBelief: (id: string) => Promise<void> | void;
+  readonly loadBeliefs: () => Promise<readonly Belief[]>;
+  readonly deleteBelief: (id: string) => Promise<void>;
   /** Directory to place the `.belief-cleanup-done` marker. */
   readonly markerDir?: string;
   /** Skip the marker check (force re-run). Tests only. */
@@ -109,13 +113,13 @@ export async function runBeliefCleanup(
     };
   }
 
-  const beliefs = await Promise.resolve(options.loadBeliefs());
+  const beliefs = await options.loadBeliefs();
   const decisions = classifyBeliefs(beliefs);
   const polluted = decisions.filter((d) => d.polluted);
   const samples = polluted.slice(0, 3).map((d) => d.belief.subject);
 
   for (const d of polluted) {
-    await Promise.resolve(options.deleteBelief(d.belief.beliefId));
+    await options.deleteBelief(d.belief.beliefId);
   }
 
   mkdirSync(dirname(markerPath), { recursive: true });

--- a/packages/nexus-agents/src/context/belief-memory.test.ts
+++ b/packages/nexus-agents/src/context/belief-memory.test.ts
@@ -1073,6 +1073,38 @@ describe('HindsightBeliefMemory', () => {
       }
     });
   });
+
+  describe('forget', () => {
+    it('removes the belief and reports true', async () => {
+      const { memory } = createTestMemory();
+      const belief = await createTestBelief(memory);
+
+      const result = await memory.forget(belief.beliefId);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBe(true);
+
+      const recall = await memory.recall(belief.beliefId);
+      expect(recall.ok).toBe(true);
+      if (recall.ok) expect(recall.value).toBeNull();
+    });
+
+    it('returns false for unknown belief IDs without erroring', async () => {
+      const { memory } = createTestMemory();
+      const result = await memory.forget('does-not-exist');
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value).toBe(false);
+    });
+
+    it('clears index entries so the belief no longer surfaces via recallBySubject', async () => {
+      const { memory } = createTestMemory();
+      const belief = await createTestBelief(memory);
+
+      await memory.forget(belief.beliefId);
+      const recall = await memory.recallBySubject(belief.subject);
+      expect(recall.ok).toBe(true);
+      if (recall.ok) expect(recall.value).toHaveLength(0);
+    });
+  });
 });
 
 describe('BeliefConfidenceEnum', () => {

--- a/packages/nexus-agents/src/context/belief-memory.ts
+++ b/packages/nexus-agents/src/context/belief-memory.ts
@@ -335,6 +335,25 @@ export class HindsightBeliefMemory implements IHindsightBeliefMemory {
     );
   }
 
+  /**
+   * Forget a belief by ID. Removes the row and all index entries.
+   * Returns `ok(true)` if the row existed and was removed; `ok(false)`
+   * if it was never present. Used by the Phase 9 cleanup driver to
+   * remove rows polluted by the pre-#2755 arXiv feed-fallback bug.
+   */
+  forget(beliefId: string): Promise<Result<boolean, MemoryError>> {
+    try {
+      const had = this.beliefs.has(beliefId);
+      this.removeBelief(beliefId);
+      return Promise.resolve(ok(had));
+    } catch (error) {
+      const causeError = error instanceof Error ? error : new Error(String(error));
+      return Promise.resolve(
+        err(new MemoryError('Failed to forget belief', { cause: causeError }))
+      );
+    }
+  }
+
   // =========================================================================
   // Persistence (Issue #714 Phase 3)
   // =========================================================================

--- a/packages/nexus-agents/src/mcp/tools/memory-stats.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-stats.test.ts
@@ -39,6 +39,18 @@ vi.mock('./tool-memory.js', () => ({
   }),
 }));
 
+// Mock nexus-memory registry so we can control the per-domain fan-out
+// without instantiating real backends in this test.
+const mockRegistryDomains = vi.fn<() => readonly string[]>();
+const mockRegistryGet = vi.fn<(domain: string) => { stats(): Promise<unknown> } | undefined>();
+
+vi.mock('nexus-memory', () => ({
+  getMemoryRegistry: () => ({
+    domains: mockRegistryDomains,
+    get: mockRegistryGet,
+  }),
+}));
+
 // ============================================================================
 // Schema Tests
 // ============================================================================
@@ -114,6 +126,8 @@ describe('memory-stats', () => {
       mockIsMobiMemAvailable.mockReturnValue(false);
       mockIsDecayManagerAvailable.mockReturnValue(false);
       mockGetBeliefCount.mockReturnValue(0);
+      mockRegistryDomains.mockReturnValue([]);
+      mockRegistryGet.mockReturnValue(undefined);
 
       const mockServer = {
         registerTool: (_name: string, _schema: unknown, handler: SdkCallback) => {
@@ -208,6 +222,75 @@ describe('memory-stats', () => {
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0]!.text);
       expect(parsed.session.learningsCount).toBe(3);
+    });
+
+    // ========================================================================
+    // Registry fan-out (Phase 5 of #2766 — see memory-stats.ts collectRegistryStats)
+    // ========================================================================
+
+    it('emits an empty registry array when no domain is attached', async () => {
+      mockRegistryDomains.mockReturnValue([]);
+
+      const result = await registeredHandler({}, {});
+
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed.registry).toEqual([]);
+    });
+
+    it('surfaces counts from every attached registry domain', async () => {
+      mockRegistryDomains.mockReturnValue(['belief', 'agentic', 'outcomes']);
+      mockRegistryGet.mockImplementation((domain) => {
+        const counts: Record<string, number> = { belief: 5, agentic: 12, outcomes: 87 };
+        return {
+          stats: () =>
+            Promise.resolve({
+              domain,
+              count: counts[domain],
+              oldestTimestamp: null,
+              newestTimestamp: null,
+            }),
+        };
+      });
+
+      const result = await registeredHandler({}, {});
+
+      type RegistryRow = { domain: string; count: number | null; error: string | null };
+      type ParsedResponse = { registry: readonly RegistryRow[] };
+      const parsed = JSON.parse(result.content[0]!.text) as ParsedResponse;
+      expect(parsed.registry).toHaveLength(3);
+      const byDomain = new Map<string, { count: number | null; error: string | null }>(
+        parsed.registry.map((r) => [r.domain, { count: r.count, error: r.error }])
+      );
+      expect(byDomain.get('belief')).toEqual({ count: 5, error: null });
+      expect(byDomain.get('agentic')).toEqual({ count: 12, error: null });
+      expect(byDomain.get('outcomes')).toEqual({ count: 87, error: null });
+    });
+
+    it('captures errors from a misbehaving backend without failing other domains', async () => {
+      mockRegistryDomains.mockReturnValue(['belief', 'broken']);
+      mockRegistryGet.mockImplementation((domain) => {
+        if (domain === 'broken') {
+          return { stats: () => Promise.reject(new Error('database unreachable')) };
+        }
+        return {
+          stats: () =>
+            Promise.resolve({ domain, count: 7, oldestTimestamp: null, newestTimestamp: null }),
+        };
+      });
+
+      const result = await registeredHandler({}, {});
+
+      type RegistryRow = { domain: string; count: number | null; error: string | null };
+      type ParsedResponse = { registry: readonly RegistryRow[] };
+      const parsed = JSON.parse(result.content[0]!.text) as ParsedResponse;
+      const broken = parsed.registry.find((r) => r.domain === 'broken');
+      const belief = parsed.registry.find((r) => r.domain === 'belief');
+      expect(broken).toBeDefined();
+      expect(belief).toBeDefined();
+      expect(broken?.count).toBeNull();
+      expect(broken?.error).toBe('database unreachable');
+      expect(belief?.count).toBe(7);
+      expect(belief?.error).toBeNull();
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/memory-stats.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-stats.ts
@@ -23,6 +23,7 @@ import {
 } from './tool-result.js';
 import { getToolMemory } from './tool-memory.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+import { getMemoryRegistry } from 'nexus-memory';
 
 // ============================================================================
 // Schema & Types
@@ -80,6 +81,21 @@ interface BackendStatus {
 }
 
 /**
+ * Per-domain row from the unified MemoryRegistry (Phase 5 of #2766).
+ * Surfaces every backend that registered itself with `getMemoryRegistry()`
+ * so future consumers can iterate one canonical source instead of the
+ * hand-maintained per-backend fields above.
+ */
+export interface RegistryDomainStats {
+  /** Domain name (e.g., 'belief', 'agentic', 'outcomes'). */
+  domain: string;
+  /** Row count, or null if the backend's stats() rejected. */
+  count: number | null;
+  /** Error message when the backend's stats() rejected. */
+  error: string | null;
+}
+
+/**
  * Response from memory_stats tool.
  */
 export interface MemoryStatsResponse {
@@ -95,6 +111,11 @@ export interface MemoryStatsResponse {
   mobimem: Record<string, unknown> | null;
   /** Decay stats (if available and requested) */
   decay: Record<string, unknown> | null;
+  /**
+   * Per-domain stats from the unified MemoryRegistry (Phase 5 of #2766).
+   * One entry per attached backend; empty when no backend has registered.
+   */
+  registry: readonly RegistryDomainStats[];
   /** Timestamp of stats collection */
   collectedAt: string;
 }
@@ -157,7 +178,8 @@ async function collectMemoryStats(
     decay: toolMemory.isDecayManagerAvailable(),
   };
 
-  logger.debug('Memory stats collected', { backends });
+  const registry = await collectRegistryStats(logger);
+  logger.debug('Memory stats collected', { backends, registryDomains: registry.length });
 
   return {
     backends,
@@ -167,8 +189,34 @@ async function collectMemoryStats(
     mobimem:
       mobimemStats !== undefined ? (mobimemStats as unknown as Record<string, unknown>) : null,
     decay: decayStats,
+    registry,
     collectedAt: new Date().toISOString(),
   };
+}
+
+/**
+ * Iterate every domain registered with the unified MemoryRegistry and
+ * call its `stats()` method. Phase 5 of #2766 attached `belief`, `agentic`,
+ * `adaptive`, `typed`, `mobimem`, and `outcomes`; this is the consumer
+ * side the epic was building toward — one canonical fan-out instead of
+ * the per-backend `toolMemory.is*Available()` calls above.
+ */
+async function collectRegistryStats(logger: ILogger): Promise<readonly RegistryDomainStats[]> {
+  const registry = getMemoryRegistry();
+  const rows: RegistryDomainStats[] = [];
+  for (const domain of registry.domains()) {
+    const backend = registry.get(domain);
+    if (backend === undefined) continue;
+    try {
+      const s = await backend.stats();
+      rows.push({ domain, count: s.count, error: null });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug('Registry domain stats failed', { domain, error: message });
+      rows.push({ domain, count: null, error: message });
+    }
+  }
+  return rows;
 }
 
 /**
@@ -232,6 +280,7 @@ export function registerMemoryStatsTool(server: McpServer, deps: MemoryStatsDeps
     typed: z.unknown().optional(),
     mobimem: z.unknown().optional(),
     decay: z.unknown().optional(),
+    registry: z.array(z.unknown()).optional(),
     collectedAt: z.string().optional(),
   };
 

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -27,6 +27,7 @@ import type {
 import { HindsightBeliefMemory } from '../../context/belief-memory.js';
 import { BeliefConfidence, BeliefSourceType } from '../../context/belief-core-types.js';
 import type { Belief } from '../../context/belief-core-types.js';
+import { runBeliefCleanup } from '../../context/belief-cleanup.js';
 import { AgenticMemoryBackend } from '../../context/agentic-memory.js';
 import { AdaptiveMemoryBackend } from '../../context/adaptive-memory.js';
 import type { MemoryMetadata, MemoryImportance } from '../../context/memory-backend-types.js';
@@ -197,6 +198,10 @@ export class ToolMemoryManager {
         return stats.ok ? stats.value.totalBeliefs : 0;
       },
     });
+    // Phase 9 of #2766: drop belief rows polluted by the pre-#2755
+    // arXiv feed-fallback bug. Marker-file gated so subsequent runs
+    // no-op. Best-effort — never block startup on cleanup errors.
+    void this.runBeliefCleanupOnce(beliefs);
 
     // Auto-start session
     const sessionId = `mcp-${String(getTimeProvider().now())}`;
@@ -227,6 +232,34 @@ export class ToolMemoryManager {
     this.initDecayManager();
   }
 
+  /**
+   * Phase 9 of #2766: idempotent one-shot cleanup of belief rows polluted
+   * by the pre-#2755 arXiv feed-fallback bug. Marker-file gated. Best-effort
+   * — failures don't block startup.
+   */
+  private async runBeliefCleanupOnce(beliefs: HindsightBeliefMemory): Promise<void> {
+    try {
+      const result = await runBeliefCleanup({
+        loadBeliefs: async () => {
+          const q = await beliefs.query({ includeSuperseded: true });
+          return q.ok ? q.value : [];
+        },
+        deleteBelief: async (id: string) => {
+          await beliefs.forget(id);
+        },
+      });
+      if (!result.skipped && result.removed > 0) {
+        this.log.info('Belief cleanup removed polluted rows', {
+          scanned: result.scanned,
+          removed: result.removed,
+          samples: result.samples,
+        });
+      }
+    } catch (error: unknown) {
+      this.log.debug('Belief cleanup failed', { error: getErrorMessage(error) });
+    }
+  }
+
   /** Initialize AgenticMemory (Phase 2). */
   private async initAgenticMemory(): Promise<void> {
     try {
@@ -237,10 +270,12 @@ export class ToolMemoryManager {
       const result = await backend.initialize();
       if (result.ok) {
         this.agentic = backend;
-        // Phase 5: AgenticMemoryBackend doesn't expose a direct count()
-        // surface today — `memory_stats` will still surface availability
-        // via the existing path. A Phase 5.1 follow-up wires the count.
-        attachToRegistry('agentic', { count: () => 0 });
+        attachToRegistry('agentic', {
+          count: async () => {
+            const res = await backend.count();
+            return res.ok ? res.value : 0;
+          },
+        });
         this.log.info('AgenticMemory activated (Phase 2)');
       } else {
         this.log.info('AgenticMemory unavailable', { reason: result.error.message });
@@ -262,8 +297,12 @@ export class ToolMemoryManager {
       const result = await backend.initialize();
       if (result.ok) {
         this.adaptive = backend;
-        // Phase 5: same as agentic — count surface deferred to Phase 5.1.
-        attachToRegistry('adaptive', { count: () => 0 });
+        attachToRegistry('adaptive', {
+          count: async () => {
+            const res = await backend.count();
+            return res.ok ? res.value : 0;
+          },
+        });
         this.log.info('AdaptiveMemory activated (Phase 2)');
       } else {
         this.log.info('AdaptiveMemory unavailable', { reason: result.error.message });

--- a/scripts/check-memory-contract.test.ts
+++ b/scripts/check-memory-contract.test.ts
@@ -88,6 +88,26 @@ describe('scanFile', () => {
     expect(findings[0]?.line).toBe(2);
     expect(findings[1]?.line).toBe(3);
   });
+
+  it('does NOT flag `new DatabaseAdapter(` (boundary-aware probe)', () => {
+    const file = join(tmpDir, 'sibling-class.ts');
+    writeFileSync(
+      file,
+      [
+        'class DatabaseAdapter {}',
+        'class DatabaseHelper {}',
+        'const a = new DatabaseAdapter();',
+        'const b = new DatabaseHelper();',
+      ].join('\n')
+    );
+    expect(scanFile(file)).toHaveLength(0);
+  });
+
+  it('does NOT flag `new MobiMemAdapter(` (boundary-aware probe)', () => {
+    const file = join(tmpDir, 'sibling-mobimem.ts');
+    writeFileSync(file, 'class MobiMemAdapter {}\nconst m = new MobiMemAdapter();\n');
+    expect(scanFile(file)).toHaveLength(0);
+  });
 });
 
 describe('newOffenders', () => {

--- a/scripts/check-memory-contract.ts
+++ b/scripts/check-memory-contract.ts
@@ -36,12 +36,14 @@ interface ProbePattern {
 const PROBES: readonly ProbePattern[] = [
   {
     id: 'better-sqlite3-direct',
-    regex: /\bnew\s+Database\s*\(/,
+    // `\b` before `Database` boundary-checks both ends so `new DatabaseAdapter(`
+    // and `new DatabaseHelper(` no longer false-positive.
+    regex: /\bnew\s+Database(?!\w)\s*\(/,
     description: 'Direct `new Database(...)` from better-sqlite3 — use `MemoryRegistry` instead.',
   },
   {
     id: 'mobimem-direct-construct',
-    regex: /\bnew\s+MobiMem\s*\(/,
+    regex: /\bnew\s+MobiMem(?!\w)\s*\(/,
     description: 'Direct `new MobiMem()` — use `getSharedMobiMem()` (#2719 fix).',
   },
   {


### PR DESCRIPTION
## Summary

Three post-merge fixes from the code review of epic #2766 phases 5/7/9:

1. **Phase 9 belief-cleanup is now actually invoked.** `runBeliefCleanup` is wired into `ToolMemoryManager`'s constructor (marker-file gated, fire-and-forget). The cleanup logic was fully tested but had zero production callers — polluted arXiv rows from the pre-#2755 feed-fallback bug were never being removed.
2. **`memory_stats` reads the unified `MemoryRegistry`.** Adds a `registry` array to the response with one row per attached domain (`belief`, `agentic`, `adaptive`, `typed`, `mobimem`, `outcomes`). Delivers the Phase 5 architectural goal — discoverability through one canonical fan-out — that the per-backend `is*Available()` calls left undone.
3. **Real counts on `agentic` + `adaptive`.** Both expose `count()` (delegating to `HybridMemoryBackend`); the registry attachments report actual row totals instead of the hardcoded `0` placeholder.

`HindsightBeliefMemory.forget(id)` is a new public API (used by the cleanup driver, available for future tooling).

### Polish (per the original review)

- Drift-gate probes use boundary-aware regex (`new Database(?!\\w)` etc.) so `new DatabaseAdapter(...)` and `new MobiMemAdapter(...)` no longer false-positive.
- `RunBeliefCleanupOptions` callbacks are async-only — production wiring always returns promises, so the previous `T | Promise<T>` union hid sync-vs-async confusion at type-check time.

### Why now (vs. waiting for the full Phase 4.1/5.1/6.1 follow-ups)

The follow-up issues (#2787 / #2788 / #2789) defer the large structural migrations — those triggers haven't fired. These three fixes are different: they close gaps in what Phase 5/9 *already shipped* (Phase 9 just doesn't run; memory_stats doesn't actually read the registry; counts say zero). Cheap to fix, no architectural risk.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/context/agentic-memory src/context/adaptive-memory src/context/belief- src/mcp/tools/tool-memory src/mcp/tools/memory-stats src/orchestration/outcomes` — 714 tests pass
- [x] `pnpm vitest run scripts/check-memory-contract.test.ts` — 11 tests pass (2 new — boundary-aware probe)
- [x] `npx tsx scripts/check-memory-contract.ts` — 10 known sites, no new offenders
- [x] New tests cover: `count()` delegation on both wrappers (4 tests), `forget()` on HindsightBeliefMemory (3 tests), integration test exercising the full cleanup path through a real belief store (1 test), `memory_stats` registry section happy-path + error capture + empty (3 tests), regex boundary-awareness (2 tests).

Closes the code-review findings on #2766 phases 5, 7, and 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)