### PR TITLE
feat(memory): real IMemoryBackend.query() on StatsOnlyAdapter (Phase 1 of #2792)

### DIFF
--- a/.changeset/2793-real-query-statsonly-adapter.md
+++ b/.changeset/2793-real-query-statsonly-adapter.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2793. Phase 1 of #2792 (cross-cutting memory access).**
+
+`StatsOnlyAdapter.query()` now delegates to the underlying backend's native search instead of returning `[]`. This unblocks the registry-level fan-out that the rest of #2792 builds on.
+
+- `CountableBackend` grows an optional `search(query, limit): Promise<readonly unknown[]>` callback.
+- `StatsOnlyAdapter.query()` reads the free-text term from the conventional `filter.where.text`, dispatches to `backend.search()`, falls back to `[]` on missing callback / missing text / search failure (the consumer relies on `query()` never throwing).
+- `tool-memory.ts` attaches each backend's idiomatic search call to its registry entry:
+  - `belief` → `recallBySubject(text, limit)`
+  - `agentic` → `searchAgentic(text, limit)` (A-MEM attribute-rich entries)
+  - `adaptive` → `retrieveByPriority({ query, limit })` (priority-scored)
+  - `typed` → underlying `HybridMemoryBackend.search(query, limit)`
+  - `mobimem` → `experience.findPatterns(query, limit)`
+
+`OutcomeStoreAdapter.query()` is unchanged — it already supports structured `where` (cli, category, success, baselineId) which is the appropriate API for that domain.
+
+Verified end-to-end: `scripts/e2e-memory-validation.ts` exercises the new fan-out and confirms `registry.get('belief').query({ where: { text: '...' } })` returns matching beliefs from a real `HindsightBeliefMemory`.
+
+Next: #2794 (`ContextRetriever.getContextForTask()`) builds on this.

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
@@ -59,9 +59,59 @@ describe('StatsOnlyAdapter', () => {
     await expect(adapter.write('k', 'v')).rejects.toThrow(/stats-only/);
   });
 
-  it('query returns empty array', async () => {
+  it('query returns empty array when no search callback is provided', async () => {
     const adapter = new StatsOnlyAdapter('test_query', { count: () => 0 });
     expect(await adapter.query()).toEqual([]);
+  });
+
+  it('query returns empty array when no search text is provided', async () => {
+    const adapter = new StatsOnlyAdapter('test_query_no_text', {
+      count: () => 0,
+      search: () => Promise.resolve(['should not see me']),
+    });
+    expect(await adapter.query()).toEqual([]);
+    expect(await adapter.query({ where: {} })).toEqual([]);
+  });
+
+  it('query delegates to backend.search when where.text is a string', async () => {
+    const seen: Array<{ query: string; limit: number }> = [];
+    const adapter = new StatsOnlyAdapter('test_query_delegate', {
+      count: () => 0,
+      search: (query, limit) => {
+        seen.push({ query, limit });
+        return Promise.resolve([{ id: 1, content: `match for ${query}` }]);
+      },
+    });
+    const result = await adapter.query({
+      where: { text: 'find this' } as unknown as Partial<unknown>,
+      limit: 7,
+    });
+    expect(seen).toEqual([{ query: 'find this', limit: 7 }]);
+    expect(result).toEqual([{ id: 1, content: 'match for find this' }]);
+  });
+
+  it('query honors default limit when filter.limit is absent', async () => {
+    let seenLimit = -1;
+    const adapter = new StatsOnlyAdapter('test_query_default_limit', {
+      count: () => 0,
+      search: (_q, limit) => {
+        seenLimit = limit;
+        return Promise.resolve([]);
+      },
+    });
+    await adapter.query({ where: { text: 'q' } as unknown as Partial<unknown> });
+    expect(seenLimit).toBe(10);
+  });
+
+  it('query returns empty array when backend.search throws', async () => {
+    const adapter = new StatsOnlyAdapter('test_query_throws', {
+      count: () => 0,
+      search: () => Promise.reject(new Error('backend exploded')),
+    });
+    const result = await adapter.query({
+      where: { text: 'anything' } as unknown as Partial<unknown>,
+    });
+    expect(result).toEqual([]);
   });
 
   it('delete returns false', async () => {
@@ -84,5 +134,58 @@ describe('StatsOnlyAdapter', () => {
   it('close is a no-op when the underlying backend lacks close()', async () => {
     const adapter = new StatsOnlyAdapter('test_no_close', { count: () => 0 });
     await expect(adapter.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('registry-level fan-out (#2792 Phase 1)', () => {
+  beforeEach(() => {
+    setMemoryRegistry(createInMemoryMemoryRegistry());
+  });
+
+  afterEach(async () => {
+    await closeMemoryRegistry();
+  });
+
+  it('a consumer can fan out over registry.domains() and get real results per domain', async () => {
+    const { getMemoryRegistry } = await import('nexus-memory');
+    const registry = getMemoryRegistry();
+
+    registry.attach(
+      'domain-a',
+      new StatsOnlyAdapter('domain-a', {
+        count: () => 2,
+        search: (q) => Promise.resolve([`a:${q}:1`, `a:${q}:2`]),
+      })
+    );
+    registry.attach(
+      'domain-b',
+      new StatsOnlyAdapter('domain-b', {
+        count: () => 0,
+        search: (q, limit) => Promise.resolve([{ from: 'b', q, limit }] as readonly unknown[]),
+      })
+    );
+
+    interface DomainRows {
+      domain: string;
+      rows: readonly unknown[];
+    }
+    const fanOut: Array<Promise<DomainRows>> = [];
+    for (const domain of registry.domains()) {
+      const backend = registry.get(domain);
+      if (backend === undefined) continue;
+      fanOut.push(
+        backend
+          .query({
+            where: { text: 'task' } as unknown as Partial<unknown>,
+            limit: 3,
+          })
+          .then((rows) => ({ domain, rows }))
+      );
+    }
+    const results = await Promise.all(fanOut);
+
+    const byDomain = new Map(results.map((r) => [r.domain, r.rows]));
+    expect(byDomain.get('domain-a')).toEqual(['a:task:1', 'a:task:2']);
+    expect(byDomain.get('domain-b')).toEqual([{ from: 'b', q: 'task', limit: 3 }]);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
@@ -15,12 +15,39 @@
 
 import type { BackendStats, CliName, IMemoryBackend, QueryFilter, WriteMeta } from 'nexus-memory';
 
+/** Default cap when a consumer omits `limit` in `query()`. */
+const DEFAULT_SEARCH_LIMIT = 10;
+
+/**
+ * Pull the free-text search term out of a {@link QueryFilter}. Returns
+ * `null` when the filter doesn't carry one, so callers can skip the search
+ * dispatch entirely. The convention is `filter.where.text` — see
+ * docs/architecture/memory-context-retrieval.md (Phase 1 of #2792).
+ */
+function extractSearchText(filter?: QueryFilter<unknown>): string | null {
+  const where: unknown = filter?.where;
+  if (where === null || where === undefined || typeof where !== 'object') return null;
+  if (!('text' in where)) return null;
+  const candidate = where.text;
+  return typeof candidate === 'string' && candidate !== '' ? candidate : null;
+}
+
 /** Minimal "count + close" shape every tool-memory backend implements. */
 export interface CountableBackend {
   /** Returns total row count (the heart of `memory_stats`). */
   count(): unknown;
   /** Idempotent close. */
   close?(): Promise<void> | void;
+  /**
+   * Optional native search surface used by {@link StatsOnlyAdapter.query}
+   * (Phase 1 of #2792). When attached from `tool-memory.ts`, each backend
+   * wires this to its idiomatic search call — `recallBySubject` for
+   * beliefs, `searchAgentic` for A-MEM, `retrieveByPriority` for adaptive,
+   * etc. Returns a flat array; the adapter is responsible for unwrapping
+   * Result types and projecting to a useful shape (typically the raw
+   * entry object, since consumers will project further).
+   */
+  search?(query: string, limit: number): Promise<readonly unknown[]>;
 }
 
 /**
@@ -54,8 +81,24 @@ export class StatsOnlyAdapter implements IMemoryBackend<string, unknown> {
     );
   }
 
-  query(_filter?: QueryFilter<unknown>): Promise<readonly unknown[]> {
-    return Promise.resolve([]);
+  /**
+   * Phase 1 of #2792: real query fan-out via the backend's native search.
+   * Honors the free-text convention `filter.where.text`. Without a search
+   * callback on the underlying backend (or without a text term), returns
+   * `[]` — consumers that need full coverage must wire `search()` on every
+   * backend they attach. Search exceptions are swallowed; the registry's
+   * `memory_stats` consumer relies on `query()` never throwing.
+   */
+  async query(filter?: QueryFilter<unknown>): Promise<readonly unknown[]> {
+    if (this.backend.search === undefined) return [];
+    const text = extractSearchText(filter);
+    if (text === null) return [];
+    const limit = filter?.limit ?? DEFAULT_SEARCH_LIMIT;
+    try {
+      return await this.backend.search(text, limit);
+    } catch {
+      return [];
+    }
   }
 
   delete(_key: string): Promise<boolean> {

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -124,7 +124,13 @@ let sharedInstance: ToolMemoryManager | null = null;
  * today. Safe to call multiple times — the registry rejects duplicate
  * domains, and that's silently caught so re-init doesn't break.
  */
-function attachToRegistry(domain: string, backend: { count(): unknown }): void {
+function attachToRegistry(
+  domain: string,
+  backend: {
+    count(): unknown;
+    search?(query: string, limit: number): Promise<readonly unknown[]>;
+  }
+): void {
   try {
     getMemoryRegistry().attach(domain, new StatsOnlyAdapter(domain, backend));
   } catch {
@@ -196,6 +202,11 @@ export class ToolMemoryManager {
       count: async () => {
         const stats = await beliefs.getStats();
         return stats.ok ? stats.value.totalBeliefs : 0;
+      },
+      // Phase 1 of #2792 — text search delegates to recallBySubject.
+      search: async (query, limit) => {
+        const res = await beliefs.recallBySubject(query, limit);
+        return res.ok ? res.value : [];
       },
     });
     // Phase 9 of #2766: drop belief rows polluted by the pre-#2755
@@ -275,6 +286,11 @@ export class ToolMemoryManager {
             const res = await backend.count();
             return res.ok ? res.value : 0;
           },
+          // Phase 1 of #2792 — A-MEM text search returns attribute-rich entries.
+          search: async (query, limit) => {
+            const res = await backend.searchAgentic(query, limit);
+            return res.ok ? res.value : [];
+          },
         });
         this.log.info('AgenticMemory activated (Phase 2)');
       } else {
@@ -301,6 +317,11 @@ export class ToolMemoryManager {
           count: async () => {
             const res = await backend.count();
             return res.ok ? res.value : 0;
+          },
+          // Phase 1 of #2792 — adaptive memory returns priority-scored entries.
+          search: async (query, limit) => {
+            const res = await backend.retrieveByPriority({ query, limit });
+            return res.ok ? res.value : [];
           },
         });
         this.log.info('AdaptiveMemory activated (Phase 2)');
@@ -331,6 +352,11 @@ export class ToolMemoryManager {
             const res = await backend.count();
             return res.ok ? res.value : 0;
           },
+          // Phase 1 of #2792 — typed search uses the underlying hybrid backend.
+          search: async (query, limit) => {
+            const res = await backend.search(query, limit);
+            return res.ok ? res.value : [];
+          },
         });
         this.log.info('TypedMemory activated (Phase 1 #746)');
       } else {
@@ -355,6 +381,10 @@ export class ToolMemoryManager {
       const mobimem = this.mobimem;
       attachToRegistry('mobimem', {
         count: () => mobimem.profile.getEntryCount(),
+        // Phase 1 of #2792 — MobiMem exposes patterns by task type. Text
+        // query is interpreted as the task type (best-effort; consumers
+        // can pre-normalize).
+        search: (query, limit) => Promise.resolve(mobimem.experience.findPatterns(query, limit)),
       });
       this.log.info('MobiMem activated (Phase 2 #746)');
     } catch (error: unknown) {

--- a/scripts/e2e-memory-validation.ts
+++ b/scripts/e2e-memory-validation.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env tsx
+
+/* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+// Diagnostic validation script — the linear narrative is the point.
+// `main` is a single sequential probe of every phase; splitting it would
+// fragment the readout. `!` assertions reach into the JSON result envelope
+// where we know the shape from the just-called handler.
+/**
+ * End-to-end validation of the memory pipeline on a clean data dir.
+ *
+ * Exercises the production code paths modified in PR #2791:
+ *   1. Boot ToolMemoryManager (triggers Phase 5 registry attaches +
+ *      Phase 9 cleanup-on-startup).
+ *   2. Verify the cleanup marker was written by the constructor.
+ *   3. Record real beliefs through `recordBelief()` (3 clean, 1 polluted).
+ *   4. Confirm memory_stats reports belief count = 4 with all 5 backends
+ *      attached and reporting real numbers (not the old `() => 0` placeholder).
+ *   5. Force a second cleanup pass against the live store.
+ *   6. Verify polluted row is gone (count = 3, polluted subject not in store).
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dataDir = mkdtempSync(join(tmpdir(), 'nexus-e2e-'));
+process.env['NEXUS_DATA_DIR'] = dataDir;
+
+async function main(): Promise<void> {
+  process.stdout.write(`E2E memory validation — NEXUS_DATA_DIR=${dataDir}\n\n`);
+
+  // Imports after NEXUS_DATA_DIR is set.
+  const toolMemoryModule = await import('../packages/nexus-agents/src/mcp/tools/tool-memory.ts');
+  const memoryStatsModule = await import('../packages/nexus-agents/src/mcp/tools/memory-stats.ts');
+  const cleanupModule = await import('../packages/nexus-agents/src/context/belief-cleanup.ts');
+  const outcomeStoreModule =
+    await import('../packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts');
+  // Trigger lazy attach by getting the singleton.
+  outcomeStoreModule.getOutcomeStore();
+  type ToolMemoryAPI = {
+    getToolMemory: () => {
+      recordBelief: (
+        s: string,
+        p: string,
+        o: string,
+        c?: 'high' | 'medium' | 'low'
+      ) => Promise<void>;
+      getBeliefCount: () => number;
+      queryBeliefs: (q: { subject?: string }) => Promise<unknown>;
+    };
+    shutdownToolMemory: () => void;
+  };
+  const { getToolMemory, shutdownToolMemory } = toolMemoryModule as unknown as ToolMemoryAPI;
+  const { registerMemoryStatsTool } = memoryStatsModule;
+  const { runBeliefCleanup } = cleanupModule;
+
+  // ─── Step 1: Boot ToolMemoryManager ─────────────────────────────────────
+  const tm = getToolMemory();
+  process.stdout.write('[1/6] ToolMemoryManager bootstrapped\n');
+
+  // Allow async SQLite init + Phase 9 cleanup to settle.
+  await new Promise((r) => setTimeout(r, 2000));
+  process.stdout.write('[2/6] async init settled\n');
+
+  // ─── Step 2: Verify cleanup marker was written ──────────────────────────
+  const markerPath = join(dataDir, 'memory', '.belief-cleanup-done');
+  const markerExisted = existsSync(markerPath);
+  let markerContent: { scanned?: number; removed?: number; completedAt?: string } = {};
+  if (markerExisted) {
+    markerContent = JSON.parse(readFileSync(markerPath, 'utf-8')) as typeof markerContent;
+  }
+  process.stdout.write(
+    `[3/6] cleanup marker: ${markerExisted ? 'EXISTS' : 'MISSING'} (scanned=${String(markerContent.scanned)})\n`
+  );
+
+  // ─── Step 3: Record real beliefs through the production API ─────────────
+  await tm.recordBelief('arXiv:2502.12110', 'has_topic', 'agentic memory', 'high');
+  await tm.recordBelief('arXiv:2310.08560', 'has_topic', 'adaptive memory', 'high');
+  await tm.recordBelief('SqliteBackend', 'is_part_of', 'nexus-memory', 'medium');
+  // The polluted shape — matches the pre-#2755 feed-fallback bug.
+  await tm.recordBelief(
+    'arXiv Query: search_query=quantum&id_list=&max_results=10',
+    'pollution',
+    'feed-fallback bug pre-#2755',
+    'low'
+  );
+  process.stdout.write('[4/6] recorded 3 clean + 1 polluted belief\n');
+
+  // ─── Step 4: Call memory_stats end-to-end ───────────────────────────────
+  type Handler = (
+    args: unknown,
+    extra: unknown
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+  let handler!: Handler;
+  const mockServer = {
+    registerTool: (_n: string, _s: unknown, h: Handler) => {
+      handler = h;
+    },
+  };
+  const rateLimiter = {
+    tryAcquire: () => true,
+    getState: () => ({ remaining: 99, nextTokenMs: 0 }),
+  };
+  registerMemoryStatsTool(mockServer as never, { rateLimiter: rateLimiter as never });
+
+  type RegistryRow = { domain: string; count: number | null; error: string | null };
+  type Response = {
+    backends: { session: boolean; belief: boolean; agentic: boolean };
+    belief: { beliefsCount: number };
+    registry: readonly RegistryRow[];
+  };
+  const r1 = await handler({}, {});
+  if (r1.isError === true) throw new Error(`memory_stats error: ${r1.content[0]!.text}`);
+  const before = JSON.parse(r1.content[0]!.text) as Response;
+  process.stdout.write('[5/6] memory_stats called (before cleanup re-run)\n');
+
+  const beliefRowBefore = before.registry.find((row) => row.domain === 'belief');
+
+  // ─── Step 5: Force a second cleanup pass against the live store ─────────
+  // Use the same store the manager holds. The cleanup driver doesn't know
+  // about the manager directly, but the production wiring uses
+  // `beliefs.query` and `beliefs.forget` — exposing the manager-internal
+  // beliefs through the same callbacks here.
+  type ToolMemoryManagerInternal = {
+    beliefs: {
+      query: (q: { includeSuperseded?: boolean }) => Promise<{
+        ok: boolean;
+        value?: readonly unknown[];
+      }>;
+      forget: (id: string) => Promise<unknown>;
+    };
+  };
+  const internal = tm as unknown as ToolMemoryManagerInternal;
+  const cleanupResult = await runBeliefCleanup({
+    loadBeliefs: async () => {
+      const q = await internal.beliefs.query({ includeSuperseded: true });
+      return (q.ok && q.value !== undefined ? q.value : []) as never;
+    },
+    deleteBelief: async (id) => {
+      await internal.beliefs.forget(id);
+    },
+    markerDir: join(dataDir, 'memory'),
+    force: true,
+  });
+  process.stdout.write(
+    `[6/6] forced cleanup re-run: scanned=${String(cleanupResult.scanned)} removed=${String(cleanupResult.removed)}\n`
+  );
+
+  // Call memory_stats again to verify counts shifted.
+  let handler2!: Handler;
+  const mockServer2 = {
+    registerTool: (_n: string, _s: unknown, h: Handler) => {
+      handler2 = h;
+    },
+  };
+  registerMemoryStatsTool(mockServer2 as never, { rateLimiter: rateLimiter as never });
+  const r2 = await handler2({}, {});
+  const after = JSON.parse(r2.content[0]!.text) as Response;
+  const beliefRowAfter = after.registry.find((row) => row.domain === 'belief');
+
+  // ─── Validation checks ──────────────────────────────────────────────────
+  process.stdout.write('\n══ validation ══\n\n');
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+
+  checks.push({
+    name: 'Phase 9 cleanup ran on startup (marker file)',
+    ok: markerExisted,
+    detail: `marker at ${markerPath}`,
+  });
+  checks.push({
+    name: 'cleanup marker reports scanned=0 on empty boot',
+    ok: markerContent.scanned === 0,
+    detail: `marker.scanned=${String(markerContent.scanned)}`,
+  });
+  checks.push({
+    name: 'registry attaches all 5 expected tool-memory domains',
+    ok: ['belief', 'agentic', 'adaptive', 'typed', 'mobimem'].every((d) =>
+      before.registry.some((row) => row.domain === d)
+    ),
+    detail: `domains: ${before.registry.map((row) => row.domain).join(', ')}`,
+  });
+  checks.push({
+    name: 'no registry domain returned an error',
+    ok: before.registry.every((row) => row.error === null),
+    detail: 'all stats() resolved cleanly',
+  });
+  checks.push({
+    name: 'belief.count reflects 4 retains via memory_stats registry',
+    ok: beliefRowBefore?.count === 4,
+    detail: `belief.count=${String(beliefRowBefore?.count)} (expected 4)`,
+  });
+  checks.push({
+    name: 'all registry counts are real numbers (not () => 0 placeholder)',
+    ok: before.registry.every((row) => typeof row.count === 'number'),
+    detail: before.registry.map((row) => `${row.domain}=${String(row.count)}`).join(', '),
+  });
+  checks.push({
+    name: 'forced cleanup pass scanned the live store',
+    ok: cleanupResult.scanned === 4,
+    detail: `scanned=${String(cleanupResult.scanned)} (expected 4)`,
+  });
+  checks.push({
+    name: 'forced cleanup pass removed the polluted row',
+    ok: cleanupResult.removed === 1,
+    detail: `removed=${String(cleanupResult.removed)} (expected 1)`,
+  });
+  checks.push({
+    name: 'belief.count dropped after cleanup',
+    ok: beliefRowAfter?.count === 3,
+    detail: `belief.count=${String(beliefRowAfter?.count)} (expected 3)`,
+  });
+  // Verify the polluted subject is actually gone (not just count math).
+  const q = await internal.beliefs.query({ includeSuperseded: true });
+  const remaining = (q.ok && q.value !== undefined ? q.value : []) as readonly {
+    subject: string;
+  }[];
+  const stillPolluted = remaining.some((b) => /arXiv Query:/i.test(b.subject));
+  checks.push({
+    name: 'no polluted-shape belief survives in the store',
+    ok: !stillPolluted,
+    detail: `remaining subjects: ${remaining.map((b) => b.subject.slice(0, 40)).join(' | ')}`,
+  });
+
+  // ─── Phase 1 of #2792: registry-level search fan-out ────────────────────
+  // Resolve nexus-memory the same way tool-memory.ts does so we share the
+  // singleton (importing via absolute path creates a fresh module instance
+  // and loses the production registry).
+  const nm =
+    await import('/home/william/git/nexus-agents/packages/nexus-agents/node_modules/nexus-memory/dist/index.js');
+  const registry = nm.getMemoryRegistry();
+  const beliefBackend = registry.get('belief');
+  if (beliefBackend !== undefined) {
+    const hits = (await beliefBackend.query({
+      where: { text: 'arXiv:2502.12110' } as unknown as Partial<unknown>,
+      limit: 5,
+    })) as readonly { subject?: string }[];
+    checks.push({
+      name: 'registry.belief.query({ where: { text } }) returns matching belief',
+      ok: hits.length >= 1 && hits.some((h) => h.subject === 'arXiv:2502.12110'),
+      detail: `hits=${String(hits.length)} subjects: ${hits
+        .map((h) => h.subject ?? '?')
+        .slice(0, 3)
+        .join(' | ')}`,
+    });
+  } else {
+    checks.push({
+      name: 'registry.belief.query fan-out',
+      ok: false,
+      detail: 'belief backend not in registry — wiring broken',
+    });
+  }
+
+  let passed = 0;
+  let failed = 0;
+  for (const c of checks) {
+    process.stdout.write(`  ${c.ok ? '✓' : '✗'} ${c.name}\n      ${c.detail}\n`);
+    if (c.ok) passed++;
+    else failed++;
+  }
+  process.stdout.write(`\n${String(passed)} passed, ${String(failed)} failed\n\n`);
+
+  process.stdout.write('Registry section (after cleanup):\n');
+  process.stdout.write(JSON.stringify(after.registry, null, 2));
+  process.stdout.write('\n');
+
+  shutdownToolMemory();
+  rmSync(dataDir, { recursive: true, force: true });
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e: unknown) => {
+  process.stderr.write(`\nE2E failed: ${e instanceof Error ? e.message : String(e)}\n`);
+  if (e instanceof Error && e.stack !== undefined) process.stderr.write(`${e.stack}\n`);
+  rmSync(dataDir, { recursive: true, force: true });
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

**Closes #2793. Phase 1 of #2792 (cross-cutting memory access).**

`StatsOnlyAdapter.query()` now delegates to the underlying backend's native search instead of returning `[]`. This unblocks the registry-level fan-out the rest of #2792 builds on.

### What changed

- `CountableBackend` grows an optional `search(query, limit): Promise<readonly unknown[]>` callback.
- `StatsOnlyAdapter.query()` reads the free-text term from the conventional `filter.where.text`, dispatches to `backend.search()`, falls back to `[]` on missing callback / missing text / search failure (the consumer relies on `query()` never throwing).
- `tool-memory.ts` attaches each backend's idiomatic search call:
  - `belief` → `recallBySubject(text, limit)`
  - `agentic` → `searchAgentic(text, limit)` (A-MEM attribute-rich entries)
  - `adaptive` → `retrieveByPriority({ query, limit })` (priority-scored)
  - `typed` → underlying `HybridMemoryBackend.search(query, limit)`
  - `mobimem` → `experience.findPatterns(query, limit)`

`OutcomeStoreAdapter.query()` is unchanged — it already supports structured `where` (cli, category, success, baselineId) which is the appropriate API for that domain.

### Why this is small

The native search surfaces already exist on each backend; the work was the adapter translation, not new query logic. ~40 LOC of production code + ~80 LOC of tests + an extended E2E.

### Why this unblocks #2792

The whole \"unified read\" idea hinges on a single function that can fan out across registered domains. That function can't exist if `.query()` is stubbed on 5 of 6 domains.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/mcp/tools src/context src/orchestration/outcomes` — 2950 tests pass
- [x] `pnpm vitest run src/mcp/tools/tool-memory-registry-adapters.test.ts` — 15 tests (6 new for query behavior + 1 registry-level fan-out integration)
- [x] **E2E (`scripts/e2e-memory-validation.ts`) on a fresh data dir** — 11/11 checks pass including the new \"registry.belief.query({ where: { text } }) returns matching belief\" probe against a real `HindsightBeliefMemory` after `recordBelief()` writes.

Next: #2794 (`ContextRetriever.getContextForTask()`) builds directly on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)