### PR TITLE
feat(memory): ContextRetriever.getContextForTask unified read surface (Phase 2 of #2792)

### DIFF
--- a/.changeset/2794-context-retriever.md
+++ b/.changeset/2794-context-retriever.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2794. Phase 2 of #2792 (cross-cutting memory access).**
+
+Adds `getContextForTask({ task, category, limit? })` — the single function every entry point will call to learn what we already know about a task. Fans out across the shared backends in parallel, tolerates individual backend failures (never throws), and returns a typed `UnifiedContext`.
+
+```ts
+import { getContextForTask } from 'nexus-agents';
+
+const ctx = await getContextForTask({ task, category: 'code_generation' });
+// ctx.beliefs            — Belief[] from HindsightBeliefMemory.recallBySubject
+// ctx.similarMemories    — AgenticMemoryEntry[] from A-MEM searchAgentic
+// ctx.recentLearnings    — ScoredMemoryEntry[] from adaptive retrieveByPriority
+// ctx.experiencePatterns — ExperienceEntry[] from MobiMem findPatterns
+// ctx.outcomes           — PerformanceSummary | null (category-scoped)
+// ctx.priorStrategies    — DistilledRule[] (empty until #2797 lands)
+```
+
+**Design choice:** typed singletons over registry fan-out. Phase 1 (#2793) made `IMemoryBackend.query()` real, so registry-level `Promise.all(...domains.map(d => d.query(...)))` works — but the result type is `unknown[]` per domain, which loses the typed shapes consumers want. Reaching into `getToolMemory()` and `getOutcomeStore()` directly is cleaner for typed reads. The registry-level fan-out remains the right path for opaque/observability consumers like `memory_stats`.
+
+New public accessors on `ToolMemoryManager`: `getBeliefMemory()`, `getAgenticMemoryBackend()`, `getAdaptiveMemoryBackend()` — so cross-cutting consumers can perform typed reads without reconstructing backends or routing through MCP tools.
+
+Phase 3 (#2795) wires `getContextForTask` into `CompositeRouter.route`, `orchestrate`, and graph workflow start — that's where the consumer-side benefit shows up.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for ContextRetriever (Phase 2 of #2792 / closes #2794).
+ *
+ * Exercises the unified read surface with real shared singletons —
+ * boots `ToolMemoryManager` in-process, writes beliefs, and verifies the
+ * retriever returns them. Backend failure tolerance is exercised by
+ * forcing one branch to throw via a substituted backend.
+ *
+ * @module context/context-retriever.test
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { closeMemoryRegistry, createInMemoryMemoryRegistry, setMemoryRegistry } from 'nexus-memory';
+import { getContextForTask } from './context-retriever.js';
+import { resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+
+describe('getContextForTask', () => {
+  let dataDir: string;
+  let prevDataDir: string | undefined;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'context-retriever-'));
+    prevDataDir = process.env['NEXUS_DATA_DIR'];
+    process.env['NEXUS_DATA_DIR'] = dataDir;
+    setMemoryRegistry(createInMemoryMemoryRegistry());
+    resetOutcomeStore();
+  });
+
+  afterEach(async () => {
+    await closeMemoryRegistry();
+    if (prevDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = prevDataDir;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty UnifiedContext shape when no backends have data', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    const ctx = await getContextForTask({
+      task: 'some unknown task',
+      category: 'code_generation',
+    });
+
+    expect(ctx.beliefs).toEqual([]);
+    expect(ctx.similarMemories).toEqual([]);
+    expect(ctx.recentLearnings).toEqual([]);
+    expect(ctx.experiencePatterns).toEqual([]);
+    expect(ctx.priorStrategies).toEqual([]);
+    // outcomes is a summary type — always present, just zeroed.
+    expect(ctx.outcomes).not.toBeUndefined();
+    expect(ctx.outcomes?.totalTasks).toBe(0);
+  });
+
+  it('returns matching beliefs after recordBelief writes', async () => {
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+
+    await tm.recordBelief('arXiv:2502.12110', 'has_topic', 'agentic memory', 'high');
+    await tm.recordBelief('arXiv:2310.08560', 'has_topic', 'adaptive memory', 'high');
+
+    const ctx = await getContextForTask({
+      task: 'arXiv:2502.12110',
+      category: 'research',
+    });
+
+    expect(ctx.beliefs.length).toBeGreaterThanOrEqual(1);
+    expect(ctx.beliefs.some((b) => b.subject === 'arXiv:2502.12110')).toBe(true);
+  });
+
+  it('honors limit', async () => {
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+
+    for (let i = 0; i < 10; i++) {
+      await tm.recordBelief(`subj-${String(i)}`, 'has_topic', 'shared topic', 'medium');
+    }
+
+    const ctx = await getContextForTask({
+      task: 'subj-0',
+      category: 'code_generation',
+      limit: 3,
+    });
+
+    expect(ctx.beliefs.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns empty results without throwing when a backend errors', async () => {
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+
+    // Substitute a belief backend that throws on every call.
+    type BeliefMem = ReturnType<typeof tm.getBeliefMemory>;
+    const exploding = {
+      recallBySubject: (): Promise<never> => Promise.reject(new Error('boom')),
+    };
+    vi.spyOn(tm, 'getBeliefMemory').mockReturnValue(exploding as unknown as BeliefMem);
+
+    const ctx = await getContextForTask({
+      task: 'anything',
+      category: 'code_generation',
+    });
+
+    expect(ctx.beliefs).toEqual([]);
+    // Other branches still resolve.
+    expect(ctx.outcomes).not.toBeUndefined();
+  });
+
+  it('outcomes summary scopes to the requested category', async () => {
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    const { getOutcomeStore } = await import('../orchestration/outcomes/outcome-store.js');
+    shutdownToolMemory();
+    getToolMemory();
+
+    const store = getOutcomeStore();
+    store.append({
+      id: 'o1',
+      cli: 'claude',
+      category: 'code_generation',
+      model: 'claude-opus',
+      success: true,
+      durationMs: 100,
+      timestamp: new Date().toISOString(),
+      source: 'delegate',
+    });
+    store.append({
+      id: 'o2',
+      cli: 'claude',
+      category: 'research',
+      model: 'claude-opus',
+      success: false,
+      durationMs: 200,
+      timestamp: new Date().toISOString(),
+      source: 'delegate',
+    });
+
+    const ctx = await getContextForTask({
+      task: 'irrelevant',
+      category: 'code_generation',
+    });
+
+    expect(ctx.outcomes?.totalTasks).toBe(1);
+    expect(ctx.outcomes?.successRate).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -1,0 +1,194 @@
+/**
+ * ContextRetriever — the unified read surface every entry point should call
+ * to learn what we already know about a task.
+ *
+ * Phase 2 of #2792. Before this module, each entry point (routing, orchestration,
+ * graph workflow, expert creation) reinvented memory access — or, more commonly,
+ * skipped it entirely. That made every backend write-only in practice.
+ *
+ * `getContextForTask({ task, category })` is the one function every entry point
+ * calls. It fans out across the shared backends in parallel, tolerates
+ * individual failures (never throws), and returns a typed `UnifiedContext`
+ * the consumer can either use directly or summarize into a prompt.
+ *
+ * **Implementation choice — typed singletons, not registry fan-out.**
+ * Phase 1 (#2793) made `IMemoryBackend.query()` real on every attached
+ * domain, so a registry-level `Promise.all(...domains.map(d => d.query()))`
+ * would now work. But the result type is `unknown[]` per domain, which
+ * loses the typed shapes consumers want. For typed reads, reaching into
+ * `getToolMemory()` and `getOutcomeStore()` directly is cleaner. The
+ * registry-level fan-out remains the right path for opaque/observability
+ * consumers like `memory_stats`.
+ *
+ * @module context/context-retriever
+ * (Source: #2792 / #2794)
+ */
+
+import type { Belief } from './belief-core-types.js';
+import type { AgenticMemoryEntry } from './agentic-memory.js';
+import type { ScoredMemoryEntry } from './adaptive-memory-types.js';
+import type { ExperienceEntry } from './mobimem-types.js';
+import type { PerformanceSummary } from '../orchestration/outcomes/outcome-types.js';
+import type { TaskCategory } from '../config/task-specialization-types.js';
+import type { DistilledRule } from '../learning/strategy-distiller-types.js';
+import type { ILogger } from '../core/logger.js';
+import { createLogger } from '../core/logger.js';
+import { getToolMemory } from '../mcp/tools/tool-memory.js';
+import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+
+/**
+ * What we know about a task, derived from every shared memory backend.
+ *
+ * Every field is `readonly` and may be empty — consumers should treat
+ * absence as "no signal," not failure. Errors fetching any single backend
+ * are logged and produce empty results for that field; the function as a
+ * whole never throws.
+ */
+export interface UnifiedContext {
+  /** Beliefs whose subject matches the task text. */
+  readonly beliefs: readonly Belief[];
+  /** A-MEM Zettelkasten entries similar to the task. */
+  readonly similarMemories: readonly AgenticMemoryEntry[];
+  /** Adaptive priority-scored entries ranked by relevance + recency + importance. */
+  readonly recentLearnings: readonly ScoredMemoryEntry[];
+  /** MobiMem patterns observed for the task type. */
+  readonly experiencePatterns: readonly ExperienceEntry[];
+  /** Performance summary scoped to the requested category. */
+  readonly outcomes: PerformanceSummary | null;
+  /** Distilled routing rules — populated once #2797 lands; empty until then. */
+  readonly priorStrategies: readonly DistilledRule[];
+}
+
+/** Options accepted by {@link getContextForTask}. */
+export interface ContextRetrieverOptions {
+  /** Free-text description of the task. Used as the search term. */
+  readonly task: string;
+  /** Canonical category for outcome scoping. */
+  readonly category: TaskCategory;
+  /** Per-backend cap on returned rows. Defaults to 5. */
+  readonly limit?: number;
+  /** Optional logger override. */
+  readonly logger?: ILogger;
+}
+
+/** Sensible default — small enough to embed in a prompt, large enough to be useful. */
+const DEFAULT_LIMIT = 5;
+
+/**
+ * The canonical "what do we already know about this task" read.
+ *
+ * Wire this at the top of every entry point: `CompositeRouter.route`,
+ * `orchestrate`, graph workflow start, `create_expert`. Even if the
+ * consumer initially just logs the result, every backend's read path
+ * gets exercised and the silos visibly converge.
+ *
+ * Latency: O(slowest individual backend). Each backend's call is wrapped
+ * so a slow/failing one doesn't block the others. No caching in this
+ * version — if a hot caller emerges, layer a TTL cache on top.
+ */
+export async function getContextForTask(options: ContextRetrieverOptions): Promise<UnifiedContext> {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const logger = options.logger ?? createLogger({ component: 'ContextRetriever' });
+
+  const [beliefs, similarMemories, recentLearnings, experiencePatterns, outcomes] =
+    await Promise.all([
+      fetchBeliefs(options.task, limit, logger),
+      fetchSimilarMemories(options.task, limit, logger),
+      fetchRecentLearnings(options.task, limit, logger),
+      fetchExperiencePatterns(options.task, limit, logger),
+      fetchOutcomes(options.category, logger),
+    ]);
+
+  return {
+    beliefs,
+    similarMemories,
+    recentLearnings,
+    experiencePatterns,
+    outcomes,
+    // priorStrategies stays empty until #2797 wires StrategyDistiller persistence.
+    priorStrategies: [],
+  };
+}
+
+async function fetchBeliefs(
+  task: string,
+  limit: number,
+  logger: ILogger
+): Promise<readonly Belief[]> {
+  try {
+    const tm = getToolMemory(logger);
+    const beliefs = tm.getBeliefMemory();
+    const result = await beliefs.recallBySubject(task, limit);
+    return result.ok ? result.value : [];
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: belief fetch failed', { error: formatError(error) });
+    return [];
+  }
+}
+
+async function fetchSimilarMemories(
+  task: string,
+  limit: number,
+  logger: ILogger
+): Promise<readonly AgenticMemoryEntry[]> {
+  try {
+    const tm = getToolMemory(logger);
+    const agentic = tm.getAgenticMemoryBackend();
+    if (agentic === null) return [];
+    const result = await agentic.searchAgentic(task, limit);
+    return result.ok ? result.value : [];
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: agentic search failed', { error: formatError(error) });
+    return [];
+  }
+}
+
+async function fetchRecentLearnings(
+  task: string,
+  limit: number,
+  logger: ILogger
+): Promise<readonly ScoredMemoryEntry[]> {
+  try {
+    const tm = getToolMemory(logger);
+    const adaptive = tm.getAdaptiveMemoryBackend();
+    if (adaptive === null) return [];
+    const result = await adaptive.retrieveByPriority({ query: task, limit });
+    return result.ok ? result.value : [];
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: adaptive fetch failed', { error: formatError(error) });
+    return [];
+  }
+}
+
+function fetchExperiencePatterns(
+  task: string,
+  limit: number,
+  logger: ILogger
+): Promise<readonly ExperienceEntry[]> {
+  try {
+    const tm = getToolMemory(logger);
+    const mobimem = tm.getMobiMem();
+    if (mobimem === null) return Promise.resolve([]);
+    return Promise.resolve(mobimem.experience.findPatterns(task, limit));
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: mobimem fetch failed', { error: formatError(error) });
+    return Promise.resolve([]);
+  }
+}
+
+function fetchOutcomes(
+  category: TaskCategory,
+  logger: ILogger
+): Promise<PerformanceSummary | null> {
+  try {
+    const store = getOutcomeStore();
+    return Promise.resolve(store.summarize({ category }));
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: outcomes fetch failed', { error: formatError(error) });
+    return Promise.resolve(null);
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/nexus-agents/src/context/index.ts
+++ b/packages/nexus-agents/src/context/index.ts
@@ -263,3 +263,11 @@ export {
   type PressureEvent,
   type PressureStats,
 } from './context-pressure-types.js';
+
+// ContextRetriever — unified read surface across every shared memory backend.
+// Phase 2 of #2792 (closes #2794).
+export {
+  getContextForTask,
+  type ContextRetrieverOptions,
+  type UnifiedContext,
+} from './context-retriever.js';

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -803,6 +803,35 @@ export class ToolMemoryManager {
   }
 
   /**
+   * Get the shared {@link HindsightBeliefMemory} singleton.
+   *
+   * Public accessor used by {@link getContextForTask} (Phase 2 of #2792)
+   * so cross-cutting consumers can perform typed reads without
+   * reconstructing a backend or routing through MCP tools.
+   */
+  getBeliefMemory(): HindsightBeliefMemory {
+    return this.beliefs;
+  }
+
+  /**
+   * Get the shared {@link AgenticMemoryBackend} singleton, or `null` if
+   * SQLite init failed and the backend is unavailable. Public accessor
+   * used by {@link getContextForTask} (Phase 2 of #2792).
+   */
+  getAgenticMemoryBackend(): AgenticMemoryBackend | null {
+    return this.agentic;
+  }
+
+  /**
+   * Get the shared {@link AdaptiveMemoryBackend} singleton, or `null` if
+   * SQLite init failed and the backend is unavailable. Public accessor
+   * used by {@link getContextForTask} (Phase 2 of #2792).
+   */
+  getAdaptiveMemoryBackend(): AdaptiveMemoryBackend | null {
+    return this.adaptive;
+  }
+
+  /**
    * Run MobiMem maintenance (eviction and cleanup).
    * Safe to call even if MobiMem is unavailable.
    */


### PR DESCRIPTION
## Summary

**Closes #2794. Phase 2 of #2792 (cross-cutting memory access).**

Adds the single function every entry point will call to learn what we already know about a task. Fans out across the shared backends in parallel, tolerates individual backend failures (never throws), and returns a typed `UnifiedContext`.

```ts
import { getContextForTask } from 'nexus-agents';

const ctx = await getContextForTask({ task, category: 'code_generation' });
// ctx.beliefs            — Belief[]
// ctx.similarMemories    — AgenticMemoryEntry[]
// ctx.recentLearnings    — ScoredMemoryEntry[]
// ctx.experiencePatterns — ExperienceEntry[]
// ctx.outcomes           — PerformanceSummary | null (category-scoped)
// ctx.priorStrategies    — DistilledRule[] (empty until #2797 lands)
```

### Design choice — typed singletons over registry fan-out

Phase 1 (#2793) made `IMemoryBackend.query()` real on every attached domain, so a registry-level `Promise.all(...domains.map(d => d.query(...)))` would now work. But the result type is `unknown[]` per domain, which loses the typed shapes consumers want. Reaching into `getToolMemory()` and `getOutcomeStore()` directly gives consumers the typed reads they need. The registry-level fan-out remains the right path for opaque/observability consumers like `memory_stats`.

### New public accessors

`ToolMemoryManager` grows three accessors so cross-cutting consumers can perform typed reads without reconstructing backends or routing through MCP tools:

- `getBeliefMemory(): HindsightBeliefMemory`
- `getAgenticMemoryBackend(): AgenticMemoryBackend | null`
- `getAdaptiveMemoryBackend(): AdaptiveMemoryBackend | null`

### What's still empty after this PR

`priorStrategies` returns `[]` until #2797 wires `StrategyDistiller` persistence. The field is in the contract so consumers can write against it now; the value flips on once Phase 5 lands.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/context src/mcp/tools` — 2756 tests pass
- [x] 5 new tests covering: empty registry, real belief recall after writes, limit honoring, backend-failure tolerance, outcomes category scoping.

Next: #2795 wires `getContextForTask` into `CompositeRouter.route`, `orchestrate`, and graph workflow start — that's where the consumer-side benefit shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)