### PR TITLE
fix(memory): remove dead retrieveAdaptiveMemory bridge (Phase 4 of #2792)

### DIFF
--- a/.changeset/2796-remove-dead-adaptive-bridge.md
+++ b/.changeset/2796-remove-dead-adaptive-bridge.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**Closes #2796. Phase 4 of #2792 (cross-cutting memory access).**
+
+Remove the dead `retrieveAdaptiveMemory` bridge from `pipeline/stage-wrappers.ts`. It was constructing a fresh `AdaptiveMemoryBackend` instance (not the shared one) and looking up `task.slice(0, 50)` as a literal key — writers use UUIDs, so the lookup never matched. Net effect: a false bottom that hid the cross-cutting gap.
+
+Cross-cutting memory enrichment for the Research stage will return via `getContextForTask` (Phase 2 #2794) once Phase 3 (#2795) wires it into the pipeline entry points.

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -59,13 +59,14 @@ export function createResearchStageWrapper(stages: DevPipelineStages): IPipeline
     async execute(ctx: PipelineContext): Promise<StageOutput> {
       const start = getTimeProvider().now();
       try {
-        // Inject adaptive memory context (#1781) + codebase context (#1778)
-        const priorContext = await retrieveAdaptiveMemory(ctx.task);
+        // Codebase context (#1778). Adaptive-memory context was previously
+        // injected here (#1781) but the bridge was provably broken — it
+        // used `task.slice(0, 50)` as a literal key against a backend
+        // whose writers use UUIDs, so the lookup never matched. Removed
+        // in #2796; cross-cutting memory enrichment will return via
+        // `getContextForTask` once #2795 (Phase 3 of #2792) lands.
         const codeContext = await searchCodebaseForTask(ctx.task);
         let enrichedTask = ctx.task;
-        if (priorContext !== null) {
-          enrichedTask = `${enrichedTask}\n\n## Prior Context (Adaptive Memory)\n${priorContext}`;
-        }
         if (codeContext !== null && codeContext !== '') {
           enrichedTask = `${enrichedTask}\n\n## Codebase Context\n${codeContext}`;
         }
@@ -295,28 +296,6 @@ async function extractSymbolsForTask(task: string): Promise<string | null> {
     return summaries.length > 0 ? summaries.join('\n') : null;
   } catch {
     return null;
-  }
-}
-
-/** Retrieve relevant prior context from AdaptiveMemory (#1781). */
-async function retrieveAdaptiveMemory(task: string): Promise<string | null> {
-  try {
-    const { AdaptiveMemoryBackend } = await import('../context/adaptive-memory.js');
-    const path = await import('node:path');
-    const { nexusDataPath } = await import('../config/nexus-data-dir.js');
-    const baseDir = nexusDataPath('memory');
-    const memory = new AdaptiveMemoryBackend({
-      dbPath: path.join(baseDir, 'adaptive.db'),
-      markdownDir: path.join(baseDir, 'adaptive-md'),
-    });
-    // Use first 50 chars of task as retrieval key
-    const key = task.slice(0, 50).replace(/\s+/g, '-').toLowerCase();
-    const result = await memory.retrieve(key);
-    if (!result.ok) return null;
-    const value = result.value;
-    return typeof value === 'string' && value.length > 0 ? value : null;
-  } catch {
-    return null; // Adaptive memory not available — continue without
   }
 }
 


### PR DESCRIPTION
## Summary

**Closes #2796. Phase 4 of #2792 (cross-cutting memory access).**

Remove the dead bridge in `pipeline/stage-wrappers.ts`. It was constructing a fresh `AdaptiveMemoryBackend` instance (not the shared one) and looking up `task.slice(0, 50)` as a literal key — writers use UUIDs, so the lookup never matched. Net effect: a false bottom that hid the cross-cutting gap motivating #2792.

### Why this is small but worth its own PR

Doing this early in the epic surfaces the gap honestly. Leaving it in tells future readers \"memory is consulted at the research stage\" when in reality it isn't.

### Why not rewrite using shared backend now?

Phase 3 (#2795) wires `getContextForTask` (#2794) into the pipeline entry points — that's the right re-introduction point. Rewriting here with a half-version would just have to be undone.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run src/pipeline` — 524 tests pass, none regressed
- [x] `grep -r retrieveAdaptiveMemory` — confirms no remaining references in src or tests

This PR is independent of #2799 and #2800; no merge order required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)