### PR TITLE
feat(memory): wire ContextRetriever into router, orchestrate, and graph (Phase 3 of #2792)

### DIFF
--- a/.changeset/2795-wire-entry-points.md
+++ b/.changeset/2795-wire-entry-points.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2795. Phase 3 of #2792 (cross-cutting memory access).**
+
+Wires `getContextForTask` into three high-leverage entry points so every task starts informed by accumulated memory:
+
+- **`CompositeRouter.route`** — consults the unified context before routing; stashes the result on `lastUnifiedContext` for observability. Fire-and-forget for now; later phases plumb the signal into routing stages.
+- **`orchestrate` MCP tool** — fetches context at the top of `runOrchestratePipeline`, logs the shape. When `NEXUS_CONTEXT_RETRIEVER_INJECT=1`, stashes `priorMemorySummary` on `input.context` for downstream stages.
+- **`executeGraph`** — fetches context at graph start, stashes the typed `UnifiedContext` under `state[GRAPH_UNIFIED_CONTEXT_KEY]` so node implementations can consume it without a second fetch.
+
+All three call sites are best-effort: failure to read memory never blocks the work.
+
+Two new helpers:
+
+- `inferTaskCategory(task)` — keyword-based fallback mapper from free-text to `TaskCategory`. Used by the entry-point wiring when the caller doesn't carry a structured category. Returns `'exploration'` when nothing matches.
+- `summarizeContextForPrompt(ctx)` — compact human-readable rendering for prepending to system prompts. Skips empty sections so the prefix never wastes tokens on "no signal."
+
+Both exported from `nexus-agents` via `context/index.ts`.
+
+14 new tests cover the helpers; the wiring is exercised by the existing 569 entry-point tests passing without regression. Phase 5 (#2797) populates `priorStrategies`; Phase 6 (#2798) feeds more signal into the substrate.

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -146,6 +146,15 @@ export class CompositeRouter implements ICompositeRouter {
   private linucbBandit?: LinUCBBandit;
   private latencyTracker?: LatencyTracker;
   private routingMemory?: RoutingMemory;
+  /**
+   * Most recently consulted unified memory context (Phase 3 of #2792).
+   * Set on every {@link route} call so tests + telemetry can inspect what
+   * the router saw at decision time. Typed as `unknown` here to avoid
+   * pulling the typed surface into this module's circular-dep zone — the
+   * field is for observability; callers that need typed reads should call
+   * `getContextForTask` directly.
+   */
+  private lastUnifiedContext?: unknown;
   /** Metrics collector for routing observability (Issue #559) */
   private metricsCollector?: IRoutingMetricsCollector;
   /** Orchestration observer for routing decision tracking (Issue #587) */
@@ -394,12 +403,48 @@ export class CompositeRouter implements ICompositeRouter {
   }
 
   async route(task: CliTask): Promise<Result<CompositeRoutingDecision, CompositeRoutingError>> {
+    // Phase 3 of #2792 — read accumulated memory before routing decides.
+    // Fire-and-forget for now: the call exercises the read path so beliefs,
+    // similar memories, recent learnings, and prior outcomes all get loaded
+    // and logged. Subsequent phases plumb the context into the routing
+    // stages as a quality signal.
+    void this.consultUnifiedContext(task);
+
     const result = await this.executeRouting(task, getTimeProvider().now());
     // Emit routing.decision to pipeline event bus for trace persistence (#1687)
     if (result.ok) {
       this.emitRoutingDecision(result.value, task.content);
     }
     return result;
+  }
+
+  /**
+   * Read the unified memory context for this task. Best-effort, never
+   * throws. Sets `this.lastUnifiedContext` so external observers (tests,
+   * telemetry) can inspect what the router consulted at decision time.
+   */
+  private async consultUnifiedContext(task: CliTask): Promise<void> {
+    try {
+      const { getContextForTask, inferTaskCategory } =
+        await import('../context/context-retriever.js');
+      const ctx = await getContextForTask({
+        task: task.content,
+        category: inferTaskCategory(task.content),
+        logger: this.logger,
+      });
+      this.lastUnifiedContext = ctx;
+      this.logger.debug('CompositeRouter: unified memory context', {
+        beliefs: ctx.beliefs.length,
+        similarMemories: ctx.similarMemories.length,
+        recentLearnings: ctx.recentLearnings.length,
+        experiencePatterns: ctx.experiencePatterns.length,
+        outcomesTotal: ctx.outcomes?.totalTasks ?? 0,
+      });
+    } catch (error: unknown) {
+      this.logger.debug('CompositeRouter: context retrieval failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/packages/nexus-agents/src/context/context-retriever-helpers.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever-helpers.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the entry-point helpers (Phase 3 of #2792 / closes #2795):
+ *  - `inferTaskCategory` — keyword-based fallback classifier.
+ *  - `summarizeContextForPrompt` — compact human-readable rendering.
+ *
+ * @module context/context-retriever-helpers.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { inferTaskCategory, summarizeContextForPrompt } from './context-retriever.js';
+import type { UnifiedContext } from './context-retriever.js';
+import { BeliefConfidence, BeliefSourceType } from './belief-core-types.js';
+
+describe('inferTaskCategory', () => {
+  it.each<[string, ReturnType<typeof inferTaskCategory>]>([
+    ['Find SQL injection vulnerabilities in auth.ts', 'security_review'],
+    ['Draft an ADR for the routing rewrite', 'architecture'],
+    ['Add Vitest coverage for the memory module', 'testing'],
+    ['Review this PR for performance regressions', 'code_review'],
+    ['Update the README with the new install steps', 'documentation'],
+    ['Plan the epic breakdown for memory unification', 'planning'],
+    ['Research Zettelkasten approaches in agents', 'research'],
+    ['Deploy the new image via Kubernetes', 'devops'],
+    ['Implement the new feature flag', 'code_generation'],
+    ['Just some random text with no signal', 'exploration'],
+  ])('classifies %j as %s', (task, expected) => {
+    expect(inferTaskCategory(task)).toBe(expected);
+  });
+});
+
+describe('summarizeContextForPrompt', () => {
+  const emptyCtx: UnifiedContext = {
+    beliefs: [],
+    similarMemories: [],
+    recentLearnings: [],
+    experiencePatterns: [],
+    outcomes: null,
+    priorStrategies: [],
+  };
+
+  it('returns an empty string when nothing is known', () => {
+    expect(summarizeContextForPrompt(emptyCtx)).toBe('');
+  });
+
+  it('renders only the sections with data', () => {
+    const ctx: UnifiedContext = {
+      ...emptyCtx,
+      beliefs: [
+        {
+          beliefId: 'b1',
+          subject: 'arXiv:2502.12110',
+          predicate: 'has_topic',
+          object: 'agentic memory',
+          confidence: BeliefConfidence.HIGH,
+          sourceType: BeliefSourceType.OBSERVATION,
+          version: 1,
+          createdAt: new Date('2026-01-01'),
+          updatedAt: new Date('2026-01-01'),
+          superseded: false,
+        },
+      ],
+    };
+    const summary = summarizeContextForPrompt(ctx);
+    expect(summary).toContain('## Prior Context (Nexus Memory)');
+    expect(summary).toContain('### Beliefs');
+    expect(summary).toContain('arXiv:2502.12110');
+    expect(summary).not.toContain('### Similar prior work'); // empty section skipped
+    expect(summary).not.toContain('### Observed patterns');
+    expect(summary).not.toContain('### Outcomes for this category');
+  });
+
+  it('includes outcomes only when there are observed tasks', () => {
+    const withOutcomes: UnifiedContext = {
+      ...emptyCtx,
+      outcomes: {
+        totalTasks: 12,
+        successRate: 0.75,
+        avgDurationMs: 1234,
+        byCli: new Map(),
+        byCategory: new Map(),
+      },
+    };
+    const summary = summarizeContextForPrompt(withOutcomes);
+    expect(summary).toContain('### Outcomes for this category');
+    expect(summary).toContain('12 prior tasks');
+    expect(summary).toContain('75% success');
+  });
+
+  it('caps each section at a small number of entries to keep the prefix small', () => {
+    const many: UnifiedContext = {
+      ...emptyCtx,
+      beliefs: Array.from({ length: 20 }, (_, i) => ({
+        beliefId: `b${String(i)}`,
+        subject: `subj-${String(i)}`,
+        predicate: 'p',
+        object: 'o',
+        confidence: BeliefConfidence.MEDIUM,
+        sourceType: BeliefSourceType.OBSERVATION,
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        superseded: false,
+      })),
+    };
+    const summary = summarizeContextForPrompt(many);
+    expect(summary).toContain('subj-0');
+    expect(summary).toContain('subj-4');
+    expect(summary).not.toContain('subj-10');
+  });
+});

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -192,3 +192,71 @@ function fetchOutcomes(
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/**
+ * Best-effort {@link TaskCategory} inference from free-text task content.
+ * Used by entry-point wiring (Phase 3 / #2795) when the caller doesn't
+ * carry a structured category. Keyword-based; if nothing matches,
+ * returns `'exploration'` (which scopes the outcomes summary to the
+ * broadest historical baseline).
+ *
+ * Intentionally simple — this is a *fallback*, not a classifier. Real
+ * classification happens at routing time via `cli-adapters/task-classifier`.
+ */
+export function inferTaskCategory(task: string): TaskCategory {
+  const t = task.toLowerCase();
+  if (/security|vulnerab|cve|threat|owasp|injection|xss/.test(t)) return 'security_review';
+  if (/architect|design doc|rfc|adr|system design/.test(t)) return 'architecture';
+  if (/test|spec|coverage|vitest|jest|pytest/.test(t)) return 'testing';
+  if (/review|audit|critique|feedback/.test(t)) return 'code_review';
+  if (/docs|documentation|readme|tutorial|guide/.test(t)) return 'documentation';
+  if (/plan|roadmap|epic|sprint|breakdown/.test(t)) return 'planning';
+  if (/research|investigate|explore|survey|analyze/.test(t)) return 'research';
+  if (/deploy| ci |\bcd\b|pipeline|kubernetes|docker|infra|terraform/.test(t)) return 'devops';
+  if (/implement|build|create|add|refactor|fix|bug|feature/.test(t)) return 'code_generation';
+  return 'exploration';
+}
+
+/**
+ * Project a {@link UnifiedContext} into a compact human-readable block
+ * suitable for prepending to a system prompt. Skips empty sections so
+ * the prefix never wastes tokens on \"no signal.\"
+ *
+ * Phase 3 of #2792 — used by `orchestrate` and graph workflow start to
+ * surface accumulated memory at the entry point.
+ */
+export function summarizeContextForPrompt(ctx: UnifiedContext): string {
+  const sections: string[] = [];
+
+  if (ctx.beliefs.length > 0) {
+    const lines = ctx.beliefs
+      .slice(0, 5)
+      .map((b) => `- ${b.subject} ${b.predicate} ${b.object} (confidence: ${b.confidence})`);
+    sections.push(`### Beliefs\n${lines.join('\n')}`);
+  }
+
+  if (ctx.similarMemories.length > 0) {
+    const lines = ctx.similarMemories
+      .slice(0, 3)
+      .map((m) => `- ${m.attributes.contextDescription}`);
+    sections.push(`### Similar prior work\n${lines.join('\n')}`);
+  }
+
+  if (ctx.experiencePatterns.length > 0) {
+    const lines = ctx.experiencePatterns
+      .slice(0, 3)
+      .map(
+        (p) =>
+          `- ${p.taskType}: ${(p.successRate * 100).toFixed(0)}% success over ${String(p.attemptCount)} attempts`
+      );
+    sections.push(`### Observed patterns\n${lines.join('\n')}`);
+  }
+
+  if (ctx.outcomes !== null && ctx.outcomes.totalTasks > 0) {
+    sections.push(
+      `### Outcomes for this category\n- ${String(ctx.outcomes.totalTasks)} prior tasks, ${(ctx.outcomes.successRate * 100).toFixed(0)}% success`
+    );
+  }
+
+  return sections.length === 0 ? '' : `## Prior Context (Nexus Memory)\n${sections.join('\n\n')}`;
+}

--- a/packages/nexus-agents/src/context/index.ts
+++ b/packages/nexus-agents/src/context/index.ts
@@ -265,9 +265,12 @@ export {
 } from './context-pressure-types.js';
 
 // ContextRetriever — unified read surface across every shared memory backend.
-// Phase 2 of #2792 (closes #2794).
+// Phase 2 of #2792 (closes #2794). Phase 3 (#2795) adds inferTaskCategory +
+// summarizeContextForPrompt for entry-point wiring.
 export {
   getContextForTask,
+  inferTaskCategory,
+  summarizeContextForPrompt,
   type ContextRetrieverOptions,
   type UnifiedContext,
 } from './context-retriever.js';

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -24,6 +24,11 @@ import {
 } from '../../pipeline/v2-orchestrate.js';
 import { resolveV2Config } from '../../pipeline/v2-config.js';
 import {
+  getContextForTask,
+  inferTaskCategory,
+  summarizeContextForPrompt,
+} from '../../context/context-retriever.js';
+import {
   ok,
   err,
   createLogger,
@@ -984,6 +989,13 @@ async function runOrchestratePipeline(params: {
   const v2Config = resolveV2Config();
   if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(input, logger);
 
+  // Phase 3 of #2792 — every entry point reads accumulated memory before
+  // dispatching work. Gated behind NEXUS_CONTEXT_RETRIEVER_INJECT (default
+  // off) for the bake period; the call always runs so the read path is
+  // exercised, but the prompt-augmentation step is opt-in until we measure
+  // the effect on prompt size and downstream behavior.
+  await injectMemoryContextForOrchestrate(input, logger);
+
   const agentPlan = v2Config.aorchestraEnabled ? computeAgentPlan(input.task, logger) : undefined;
   const workerDispatchResult = await tryWorkerDispatch(
     agentPlan,
@@ -1008,6 +1020,46 @@ async function runOrchestratePipeline(params: {
     durationMs: getTimeProvider().now() - startMs,
   });
   return assembleOrchestrateOutput(result.value, agentPlan, workerDispatchResult);
+}
+
+/**
+ * Phase 3 of #2792 — read the unified memory context at the orchestration
+ * entry point so every task starts informed by everything we've learned.
+ * The fetch always runs (so the read path is exercised even when nothing
+ * downstream consumes the result); prompt augmentation is gated behind
+ * `NEXUS_CONTEXT_RETRIEVER_INJECT=1` for the bake period.
+ *
+ * Mutates `input.context` with `priorMemorySummary` when the flag is set
+ * so downstream stages can read it without a second fetch.
+ */
+async function injectMemoryContextForOrchestrate(
+  input: OrchestrateInput,
+  logger: ILogger
+): Promise<void> {
+  try {
+    const ctx = await getContextForTask({
+      task: input.task,
+      category: inferTaskCategory(input.task),
+      logger,
+    });
+    const summary = summarizeContextForPrompt(ctx);
+    logger.debug('orchestrate: unified memory context', {
+      beliefs: ctx.beliefs.length,
+      similarMemories: ctx.similarMemories.length,
+      recentLearnings: ctx.recentLearnings.length,
+      experiencePatterns: ctx.experiencePatterns.length,
+      outcomesTotal: ctx.outcomes?.totalTasks ?? 0,
+      summaryChars: summary.length,
+    });
+    if (process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'] === '1' && summary !== '') {
+      // Stash on input.context for downstream stages.
+      const mutable = input as { context?: Record<string, unknown> };
+      mutable.context = { ...(mutable.context ?? {}), priorMemorySummary: summary };
+    }
+  } catch (error: unknown) {
+    // Never block orchestration on a memory read failure.
+    logger.debug('orchestrate: context retrieval failed', { error: getErrorMessage(error) });
+  }
 }
 
 function createOrchestrateHandler(deps: OrchestrateDeps) {

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -49,6 +49,39 @@ import { GRAPH_TIMEOUTS } from '../../config/timeouts.js';
 const DEFAULT_MAX_STEPS = GRAPH_TIMEOUTS.maxSteps;
 const DEFAULT_TIMEOUT_MS = GRAPH_TIMEOUTS.defaultMs;
 
+/**
+ * Well-known key under which {@link executeGraph} stashes the unified
+ * memory context (Phase 3 of #2792). Node implementations may read
+ * `state[GRAPH_UNIFIED_CONTEXT_KEY]` to access beliefs, similar memories,
+ * recent learnings, observed patterns, and outcomes for the task type
+ * inferred from the graph's initial inputs.
+ */
+export const GRAPH_UNIFIED_CONTEXT_KEY = '__unifiedContext';
+
+async function populateUnifiedContextOnState(state: GraphState): Promise<void> {
+  try {
+    const taskCandidate = state['task'];
+    if (typeof taskCandidate !== 'string' || taskCandidate === '') return;
+
+    const { getContextForTask, inferTaskCategory } =
+      await import('../../context/context-retriever.js');
+    const ctx = await getContextForTask({
+      task: taskCandidate,
+      category: inferTaskCategory(taskCandidate),
+      logger,
+    });
+    state[GRAPH_UNIFIED_CONTEXT_KEY] = ctx;
+    logger.debug('Graph start: unified memory context stashed', {
+      beliefs: ctx.beliefs.length,
+      similarMemories: ctx.similarMemories.length,
+      experiencePatterns: ctx.experiencePatterns.length,
+      outcomesTotal: ctx.outcomes?.totalTasks ?? 0,
+    });
+  } catch (error: unknown) {
+    logger.debug('Graph start: context retrieval failed', { error: getErrorMessage(error) });
+  }
+}
+
 /** Mutable execution context threaded through the super-step loop. */
 interface ExecutionContext {
   state: GraphState;
@@ -83,6 +116,13 @@ export async function executeGraph(
 ): Promise<Result<GraphExecutionResult, Error>> {
   const startTime = getTimeProvider().now();
   const initialState = initializeState(graph, initialInputs);
+
+  // Phase 3 of #2792 — read unified memory context at graph start and stash
+  // under a well-known key so node implementations can consume it without
+  // a second fetch. Best-effort: failure is logged and silently produces
+  // an empty context.
+  await populateUnifiedContextOnState(initialState);
+
   const ctx: ExecutionContext = {
     state: initialState,
     allResults: [],


### PR DESCRIPTION
## Summary

**Closes #2795. Phase 3 of #2792 (cross-cutting memory access).**

Wires `getContextForTask` into three high-leverage entry points so every task starts informed by accumulated memory.

### Wiring

| Entry point | Behavior |
|---|---|
| `CompositeRouter.route` | Consults unified context before routing; stashes on `lastUnifiedContext` for observability. Fire-and-forget; later phases plumb the signal into routing stages. |
| `orchestrate` MCP tool | Fetches at the top of `runOrchestratePipeline`, logs the shape. When `NEXUS_CONTEXT_RETRIEVER_INJECT=1`, stashes `priorMemorySummary` on `input.context` for downstream stages. |
| `executeGraph` | Fetches at graph start, stashes typed `UnifiedContext` under `state[GRAPH_UNIFIED_CONTEXT_KEY]` so node implementations consume without a second fetch. |

All three call sites are best-effort: failure to read memory never blocks the work.

### Two new helpers (exported)

- `inferTaskCategory(task)` — keyword-based fallback mapper from free-text to `TaskCategory`. Returns `'exploration'` on no match.
- `summarizeContextForPrompt(ctx)` — compact human-readable rendering for prepending to system prompts. Skips empty sections so the prefix never wastes tokens on \"no signal.\"

### Why this matters

Before this PR, even after #2794 shipped `ContextRetriever`, **nothing called it**. Now every routing decision, every `orchestrate` invocation, and every graph workflow start exercises the read path. The silos visibly converge.

### Bake plan

Prompt augmentation on orchestrate is gated by `NEXUS_CONTEXT_RETRIEVER_INJECT=1` so we can land the wiring first and measure the effect on prompt size before flipping default-on. The context retrieval itself always runs.

Phase 5 (#2797) populates `priorStrategies`; Phase 6 (#2798) feeds more signal into the substrate.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/context src/mcp/tools src/cli-adapters src/orchestration` — 6274 tests pass, none regressed
- [x] 14 new tests on the helpers (`context-retriever-helpers.test.ts`)
- [x] Existing 569 entry-point tests continue to pass (the wiring is fire-and-forget, doesn't break legacy code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)