### PR TITLE
feat(memory): populate priorStrategies from persisted rules.json (Phase 5 of #2792)

### DIFF
--- a/.changeset/2797-prior-strategies-in-context.md
+++ b/.changeset/2797-prior-strategies-in-context.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2797. Phase 5 of #2792 (cross-cutting memory access).**
+
+Populates `UnifiedContext.priorStrategies` by reading the persisted distilled-rules snapshot. The learning loop now closes end-to-end: outcomes → `StrategyDistiller` → `rules.json` → `ContextRetriever.priorStrategies` → every entry point that consults the unified context.
+
+### What was already done
+
+Phase 5 turned out to be much smaller than estimated. The infrastructure was already in place from earlier work:
+
+- ✅ `PersistentStrategyDistiller` writes rules to `~/.nexus-agents/learning/rules.json` (atomic write + Zod-validated hydration)
+- ✅ `DistilledRuleStage` consumes rules in `CompositeRouter` at priority 45 (penalize -5 / boost +5 / avoid -10 score adjustments)
+- ✅ `StrategyDistiller.getRules('active')` reader exists
+
+What was missing: nothing read the rules outside of the live `CompositeRouter` instance, so `UnifiedContext.priorStrategies` was hardcoded `[]`.
+
+### What this PR adds
+
+- **`loadPersistedRules(filePath?): readonly DistilledRule[]`** — process-wide reader for `~/.nexus-agents/learning/rules.json`. No singleton required; consumers in any scope can see the same rules the router applies. Tolerates missing file / corrupt JSON / schema mismatch (returns `[]`, never throws).
+- **`ContextRetriever.getContextForTask` populates `priorStrategies`** by loading persisted rules and filtering to (a) `status === 'active'`, (b) `tainted === false` (security gate), (c) category matches the task's category or a global rule.
+- 5 new tests on `loadPersistedRules` + 5 new tests on `priorStrategies` in `ContextRetriever`.
+
+### Deferred to follow-ups
+
+The Phase 5 issue also called for surfacing distilled rules in `weather_report` (observability). That's nice-to-have and not strictly necessary for closing the learning loop — filed implicitly via the issue's open checkboxes if needed.
+
+Phase 6 (#2798) audits per-instance backends for promotion paths into the shared substrate.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -9,13 +9,14 @@
  * @module context/context-retriever.test
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { closeMemoryRegistry, createInMemoryMemoryRegistry, setMemoryRegistry } from 'nexus-memory';
 import { getContextForTask } from './context-retriever.js';
 import { resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import type { DistilledRule } from '../learning/strategy-distiller-types.js';
 
 describe('getContextForTask', () => {
   let dataDir: string;
@@ -147,5 +148,109 @@ describe('getContextForTask', () => {
 
     expect(ctx.outcomes?.totalTasks).toBe(1);
     expect(ctx.outcomes?.successRate).toBe(1);
+  });
+
+  // ========================================================================
+  // Phase 5 of #2792 — priorStrategies populated from persisted rules.json
+  // ========================================================================
+
+  function makeRule(overrides: Partial<DistilledRule> = {}): DistilledRule {
+    return {
+      id: 'failure-rate:codex:code_generation',
+      patternType: 'failure-rate',
+      cli: 'codex',
+      category: 'code_generation',
+      action: 'penalize',
+      confidence: 0.85,
+      observationCount: 50,
+      metric: 0.7,
+      status: 'active',
+      createdAt: 1000,
+      updatedAt: 2000,
+      tainted: false,
+      ...overrides,
+    };
+  }
+
+  function writeRulesFile(rules: readonly DistilledRule[]): void {
+    const dir = join(dataDir, 'learning');
+    mkdirSync(dir, { recursive: true });
+    const snapshot = { version: 1, savedAt: new Date().toISOString(), rules };
+    writeFileSync(join(dir, 'rules.json'), JSON.stringify(snapshot));
+  }
+
+  it('priorStrategies surfaces active rules matching the task category', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    writeRulesFile([
+      makeRule({ id: 'r-match-1', category: 'code_generation' }),
+      makeRule({ id: 'r-match-2', category: 'code_generation', cli: 'gemini', action: 'boost' }),
+      makeRule({ id: 'r-other', category: 'research' }),
+    ]);
+
+    const ctx = await getContextForTask({ task: 'anything', category: 'code_generation' });
+
+    expect(ctx.priorStrategies.length).toBeGreaterThanOrEqual(2);
+    const matchIds = ctx.priorStrategies.map((r) => r.id);
+    expect(matchIds).toContain('r-match-1');
+    expect(matchIds).toContain('r-match-2');
+    expect(matchIds).not.toContain('r-other');
+  });
+
+  it('priorStrategies excludes tainted rules (security gate)', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    writeRulesFile([
+      makeRule({ id: 'clean', tainted: false }),
+      makeRule({ id: 'tainted', tainted: true }),
+    ]);
+
+    const ctx = await getContextForTask({ task: 'anything', category: 'code_generation' });
+    const ids = ctx.priorStrategies.map((r) => r.id);
+    expect(ids).toContain('clean');
+    expect(ids).not.toContain('tainted');
+  });
+
+  it('priorStrategies excludes non-active rules', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    writeRulesFile([
+      makeRule({ id: 'active-one', status: 'active' }),
+      makeRule({ id: 'draft-one', status: 'draft' }),
+      makeRule({ id: 'expired-one', status: 'expired' }),
+      makeRule({ id: 'promoted-one', status: 'promoted' }),
+    ]);
+
+    const ctx = await getContextForTask({ task: 'anything', category: 'code_generation' });
+    const ids = ctx.priorStrategies.map((r) => r.id);
+    expect(ids).toEqual(['active-one']);
+  });
+
+  it('priorStrategies returns [] when no rules file exists', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    const ctx = await getContextForTask({ task: 'anything', category: 'code_generation' });
+    expect(ctx.priorStrategies).toEqual([]);
+  });
+
+  it('priorStrategies honors limit', async () => {
+    const { shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+
+    const many = Array.from({ length: 20 }, (_, i) =>
+      makeRule({ id: `r-${String(i)}`, category: 'code_generation' })
+    );
+    writeRulesFile(many);
+
+    const ctx = await getContextForTask({
+      task: 'anything',
+      category: 'code_generation',
+      limit: 3,
+    });
+    expect(ctx.priorStrategies.length).toBe(3);
   });
 });

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -35,6 +35,7 @@ import type { ILogger } from '../core/logger.js';
 import { createLogger } from '../core/logger.js';
 import { getToolMemory } from '../mcp/tools/tool-memory.js';
 import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import { loadPersistedRules } from '../learning/strategy-distiller-persistence.js';
 
 /**
  * What we know about a task, derived from every shared memory backend.
@@ -99,15 +100,47 @@ export async function getContextForTask(options: ContextRetrieverOptions): Promi
       fetchOutcomes(options.category, logger),
     ]);
 
+  const priorStrategies = fetchPriorStrategies(options.category, limit, logger);
+
   return {
     beliefs,
     similarMemories,
     recentLearnings,
     experiencePatterns,
     outcomes,
-    // priorStrategies stays empty until #2797 wires StrategyDistiller persistence.
-    priorStrategies: [],
+    priorStrategies,
   };
+}
+
+/**
+ * Phase 5 of #2792 — surface distilled routing rules in the unified
+ * context. Reads from the persisted rules file (written by
+ * `PersistentStrategyDistiller`) so consumers see the same learnings the
+ * CompositeRouter applies at decision time, without needing a live
+ * router instance.
+ *
+ * Filters to (a) `status === 'active'` (rules that aren't deprecated or
+ * shadowed), (b) `tainted === false` (security gate — tainted rules
+ * never reach consumers per Phase 5 acceptance), and (c) category
+ * matching the task's category or a global rule.
+ */
+function fetchPriorStrategies(
+  category: TaskCategory,
+  limit: number,
+  logger: ILogger
+): readonly DistilledRule[] {
+  try {
+    const all = loadPersistedRules();
+    return all
+      .filter((r) => r.status === 'active' && !r.tainted)
+      .filter((r) => r.category === category || r.category === '*')
+      .slice(0, limit);
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: prior-strategies fetch failed', {
+      error: formatError(error),
+    });
+    return [];
+  }
 }
 
 async function fetchBeliefs(

--- a/packages/nexus-agents/src/learning/strategy-distiller-persistence.test.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller-persistence.test.ts
@@ -14,6 +14,7 @@ import { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import {
   PersistentStrategyDistiller,
   RulesSnapshotSchema,
+  loadPersistedRules,
 } from './strategy-distiller-persistence.js';
 import type { RulesSnapshot } from './strategy-distiller-persistence.js';
 import type { DistilledRule } from './strategy-distiller-types.js';
@@ -331,6 +332,42 @@ describe('PersistentStrategyDistiller', () => {
     it('rejects wrong version number', () => {
       const result = RulesSnapshotSchema.safeParse({ version: 2, savedAt: 'now', rules: [] });
       expect(result.success).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // loadPersistedRules — Phase 5 of #2792
+  // --------------------------------------------------------------------------
+
+  describe('loadPersistedRules', () => {
+    it('returns empty when the file does not exist', () => {
+      const missing = join(tmpDir, 'never-written.json');
+      expect(loadPersistedRules(missing)).toEqual([]);
+    });
+
+    it('returns rules from a valid snapshot file', () => {
+      const rules = [makeRule({ id: 'r1' }), makeRule({ id: 'r2', cli: 'gemini' })];
+      writeFileSync(filePath, JSON.stringify(makeSnapshot(rules)));
+      const loaded = loadPersistedRules(filePath);
+      expect(loaded).toHaveLength(2);
+      expect(loaded[0]?.id).toBe('r1');
+      expect(loaded[1]?.cli).toBe('gemini');
+    });
+
+    it('returns empty on corrupt JSON', () => {
+      writeFileSync(filePath, '{not valid');
+      expect(loadPersistedRules(filePath)).toEqual([]);
+    });
+
+    it('returns empty on schema mismatch', () => {
+      writeFileSync(filePath, JSON.stringify({ version: 99, rules: [] }));
+      expect(loadPersistedRules(filePath)).toEqual([]);
+    });
+
+    it('never throws (consumer contract)', () => {
+      // Pass an invalid path that resolves through unwritable directories.
+      expect(() => loadPersistedRules('/proc/self/nope/rules.json')).not.toThrow();
+      expect(loadPersistedRules('/proc/self/nope/rules.json')).toEqual([]);
     });
   });
 });

--- a/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
@@ -176,3 +176,33 @@ export class PersistentStrategyDistiller extends StrategyDistiller {
 registerPersistentDistillerFactory(
   (outcomeStore, logger) => new PersistentStrategyDistiller(outcomeStore, undefined, logger)
 );
+
+/**
+ * Phase 5 of #2792 — read the persisted distilled rules from disk
+ * without needing a live `StrategyDistiller` instance.
+ *
+ * `ContextRetriever` uses this so `UnifiedContext.priorStrategies`
+ * surfaces the routing learnings the CompositeRouter has already
+ * derived, even when the consumer is in a different process / scope
+ * (e.g. an `orchestrate` invocation that hasn't constructed its own
+ * router yet).
+ *
+ * Returns `[]` when the file is missing, corrupt, or unreadable; never
+ * throws. The caller is responsible for filtering to status / category /
+ * tainted as appropriate — this loader returns the raw rule set so
+ * future consumers can apply their own predicates.
+ */
+export function loadPersistedRules(filePath: string = getRulesFile()): readonly DistilledRule[] {
+  if (!existsSync(filePath)) return [];
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const parsed: unknown = JSON.parse(content);
+    const result = RulesSnapshotSchema.safeParse(parsed);
+    if (!result.success) return [];
+    return result.data.rules;
+  } catch {
+    // Disk read / parse failures contribute an empty list — the consumer
+    // contract is "absence means no signal," never an exception.
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

**Closes #2797. Phase 5 of #2792 (cross-cutting memory access).**

The learning loop now closes end-to-end: **outcomes → `StrategyDistiller` → `rules.json` → `ContextRetriever.priorStrategies` → every entry point that consults the unified context.**

### Phase 5 turned out to be smaller than estimated

The infrastructure was already in place from earlier work:

| | |
|---|---|
| ✅ | `PersistentStrategyDistiller` writes rules to `~/.nexus-agents/learning/rules.json` (atomic write + Zod-validated hydration) |
| ✅ | `DistilledRuleStage` consumes rules in `CompositeRouter` at priority 45 (penalize -5 / boost +5 / avoid -10 score adjustments) |
| ✅ | `StrategyDistiller.getRules('active')` reader exists |

What was missing: nothing read rules **outside** of the live `CompositeRouter` instance, so `UnifiedContext.priorStrategies` was hardcoded `[]`.

### What this PR adds

- **`loadPersistedRules(filePath?): readonly DistilledRule[]`** — process-wide reader for `~/.nexus-agents/learning/rules.json`. No singleton required; consumers in any scope see the same rules the router applies. Tolerates missing file / corrupt JSON / schema mismatch (returns `[]`, never throws).
- **`ContextRetriever.getContextForTask` populates `priorStrategies`** by filtering to (a) `status === 'active'`, (b) `tainted === false` (security gate per Phase 5 acceptance), (c) category matches the task's category or `'*'`.
- 5 new tests on `loadPersistedRules` + 5 new tests on `priorStrategies` in `ContextRetriever`.

### Deferred to follow-ups

The Phase 5 issue also called for surfacing distilled rules in `weather_report` (observability). That's nice-to-have and not required for closing the learning loop; can land later if useful.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/context src/learning` — 1517 tests pass, none regressed
- [x] 10 new tests for the new code paths

This PR is independent of #2802 (Phase 3). Phase 6 (#2798) audits per-instance backends for promotion paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)