### PR TITLE
feat(memory): skill promotion bridge to shared belief store (Phase 6 of #2792)

### DIFF
--- a/.changeset/2798-skill-promotion-bridge.md
+++ b/.changeset/2798-skill-promotion-bridge.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+**Closes #2798. Phase 6 of #2792 (cross-cutting memory access).**
+
+Per-instance memory backends stay per-instance; the **signal they produce** now reaches the shared substrate via promotion bridges.
+
+### What ships
+
+- **`SkillLibrary` → shared beliefs (wired)**. New optional `SkillLibraryConfig.skillPromoter` callback. When a skill crosses `minSuccessesForPromotion` (default 5 successful executions), the bridge fires once with `{skillId, name, category, successRate, executionCount}`. The production global library in `cli-server-skills.ts` wires this to `getToolMemory().recordBelief('skill:{name}', 'is_reliable_for', '{category}', 'high'|'medium')` so every later `getContextForTask` call sees the learning regardless of which agent ran the skill.
+
+- **`SicaVersionManager` and `MemoryState` → documented templates**. AGENTS.md grows a new sub-section (`Per-instance → shared-substrate promotion`) with a table describing the signal/target/wiring shape for each backend. SICA and MemoryState bridges are not wired today — the template shows how to add them when a concrete need materializes (mirror the SkillLibrary pattern: optional config field + dynamic-import promoter in the per-singleton wiring point + dedicated test).
+
+### Design choices
+
+- **Fire once, not on every event.** Promotion is gated by a "just-crossed-threshold" check using the previous + updated metrics. Re-firing on every subsequent success would flood the belief store.
+- **Defensive isolation.** Throws and promise rejections from the promoter are caught inside `SkillLibrary.maybePromote` so a broken bridge never breaks local skill bookkeeping.
+- **Dynamic import in production wiring.** `cli-server-skills.ts` reaches `getToolMemory` via `await import(...)` to avoid a hard module-load circular dep with `mcp/tools/`.
+
+6 new tests cover: threshold crossing, no-re-fire, no-fire-on-failure, throw isolation, async-rejection isolation, event payload shape.
+
+This closes the autonomous loop for the full #2792 epic: outcomes → distilled rules → skill-promoted beliefs → `ContextRetriever` → every entry point.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,18 @@ The unified `MemoryRegistry` (Phase 3+) is the discovery + telemetry surface for
 
 Each backend MUST still persist via its existing storage path (no parallel layouts) and SHOULD expose a `count()` (or equivalent) for ad-hoc inspection. Future Phase 7.1+ work can fold them in once a clear cross-process consumer needs them. Until then, treat the `MemoryRegistry` as covering the **shared-singleton subset** of in-tree memory.
 
+### Per-instance → shared-substrate promotion (#2792 Phase 6)
+
+Per-instance backends stay per-instance, but the _signal they produce_ should reach the shared substrate so other agents/tasks benefit. The pattern: when a per-instance backend observes a stabilized signal, it fires an optional promoter callback that writes a `Belief`/outcome/distilled-rule to the shared store.
+
+| Backend                             | Signal                                                                               | Promotion target                                                                                                                      | Wired?                                                                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SkillLibrary`                      | Skill crosses `minSuccessesForPromotion` (default 5 successful executions)           | Belief: `subject="skill:{name}"`, `predicate="is_reliable_for"`, `object="{category}"`                                                | ✅ via `SkillLibraryConfig.skillPromoter`; wired in `cli-server-skills.ts`                                                                                                                          |
+| `SicaVersionManager`                | New version's `successCount / executionCount` exceeds parent's by a sustained margin | Outcome record under category `"sica_evolution"` with `wasRetried: true` semantics — flows through routing's regular outcome pipeline | ⏳ template: add a `versionPromoter` callback in `SicaConfig` mirroring `skillPromoter`; fire from `recordExecution` when the active version's metrics surpass parent's by ≥10% over ≥10 executions |
+| `MemoryState` (agent exec patterns) | Recurring pattern across multiple `{agentId, role}` instances                        | StrategyDistiller candidate rule via `OutcomeStore.append` (the distiller picks it up on next pass)                                   | ⏳ template: extract `MemoryState` pattern summarization into a `memoryStatePromoter` hook; fire from `recordPattern` or equivalent                                                                 |
+
+The "⏳ template" rows describe how to add the bridge when a concrete use case materializes — they follow the same shape as the `SkillLibrary` bridge (optional config field + dynamic-import promoter in the per-singleton wiring point + dedicated test). Implement on demand, not speculatively.
+
 ## Track all work — deferring is fine, untracked is not
 
 Every piece of identified work — even work you're explicitly deferring — needs a **GitHub issue**. Memory notes, PR-description "follow-up" bullets, code TODOs, and conversation summaries are NOT tracking. They get forgotten. If the work isn't in an issue, it won't get done.

--- a/packages/nexus-agents/src/agents/skills/skill-library.test.ts
+++ b/packages/nexus-agents/src/agents/skills/skill-library.test.ts
@@ -184,6 +184,113 @@ describe('SkillLibrary', () => {
     });
   });
 
+  // ==========================================================================
+  // Phase 6 of #2792 — skill promotion bridge to shared belief store
+  // ==========================================================================
+
+  describe('skill promotion (Phase 6 of #2792)', () => {
+    it('fires the promoter once the success threshold is crossed', () => {
+      const events: Array<{ skillId: string; name: string; category: string }> = [];
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 3,
+        skillPromoter: (e) => {
+          events.push({ skillId: e.skillId, name: e.name, category: e.category });
+        },
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      expect(events).toHaveLength(0); // 1 success, threshold is 3
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      expect(events).toHaveLength(0); // 2 successes, still below
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      expect(events).toHaveLength(1); // 3 successes — promote
+      expect(events[0]?.name).toBe(skill.name);
+    });
+
+    it('does not re-promote on subsequent successes past the threshold', () => {
+      const events: unknown[] = [];
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 2,
+        skillPromoter: (e) => {
+          events.push(e);
+        },
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      expect(events).toHaveLength(1);
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      expect(events).toHaveLength(1);
+    });
+
+    it('does not fire on failures', () => {
+      const events: unknown[] = [];
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 1,
+        skillPromoter: (e) => {
+          events.push(e);
+        },
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      promotingLibrary.recordExecution(skill.id, 'failure', {}, undefined, 'boom');
+      promotingLibrary.recordExecution(skill.id, 'failure', {}, undefined, 'boom');
+      expect(events).toHaveLength(0);
+    });
+
+    it('catches throws from the promoter without breaking skill bookkeeping', () => {
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 1,
+        skillPromoter: () => {
+          throw new Error('promotion bridge exploded');
+        },
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      expect(() => {
+        promotingLibrary.recordExecution(skill.id, 'success', {});
+      }).not.toThrow();
+      // Metrics still updated.
+      expect(promotingLibrary.getSkill(skill.id)?.metrics.successCount).toBe(1);
+    });
+
+    it('catches rejections from an async promoter', async () => {
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 1,
+        skillPromoter: () => Promise.reject(new Error('async fail')),
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      // Allow the rejected promise's catch handler to settle.
+      await new Promise((r) => setTimeout(r, 5));
+      // No throw → bookkeeping intact.
+      expect(promotingLibrary.getSkill(skill.id)?.metrics.successCount).toBe(1);
+    });
+
+    it('passes successRate and executionCount in the event', () => {
+      const captures: Array<{ successRate: number; executionCount: number }> = [];
+      const promotingLibrary = new SkillLibrary({
+        minSuccessesForPromotion: 2,
+        skillPromoter: (e) => {
+          captures.push({ successRate: e.successRate, executionCount: e.executionCount });
+        },
+      });
+      const skill = promotingLibrary.addSkill(sampleSkill);
+
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      promotingLibrary.recordExecution(skill.id, 'failure', {}, undefined, 'meh');
+      promotingLibrary.recordExecution(skill.id, 'success', {});
+      // 2 successes out of 3 → 0.667; threshold crossed at this call.
+      expect(captures).toHaveLength(1);
+      expect(captures[0]?.executionCount).toBe(3);
+      expect(captures[0]?.successRate).toBeCloseTo(2 / 3, 2);
+    });
+  });
+
   describe('findRelevantSkills', () => {
     beforeEach(() => {
       library.addSkill(sampleSkill);

--- a/packages/nexus-agents/src/agents/skills/skill-library.ts
+++ b/packages/nexus-agents/src/agents/skills/skill-library.ts
@@ -294,6 +294,56 @@ export class SkillLibrary {
     this.store.metrics.set(skillId, updated);
 
     this.evaluateRetention(skillId);
+    this.maybePromote(skillId, current, updated);
+  }
+
+  /**
+   * Phase 6 of #2792 — promote a stabilized skill to the shared belief
+   * store so future tasks (executed by other agents) see the signal.
+   *
+   * Fires exactly once per skill, when the successful-execution count
+   * crosses {@link SkillLibraryConfig.minSuccessesForPromotion}. The
+   * `previousMetrics → updatedMetrics` comparison guards against
+   * re-promoting on every subsequent execution.
+   *
+   * Best-effort: a throwing/rejecting promoter is caught here so a
+   * broken promotion bridge never breaks the local skill bookkeeping.
+   */
+  private maybePromote(
+    skillId: string,
+    previousMetrics: { successCount: number },
+    updatedMetrics: { successCount: number; successRate: number; executionCount: number }
+  ): void {
+    if (this.config.skillPromoter === undefined) return;
+    const threshold = this.config.minSuccessesForPromotion;
+    const justCrossed =
+      previousMetrics.successCount < threshold && updatedMetrics.successCount >= threshold;
+    if (!justCrossed) return;
+    const skill = this.store.skills.get(skillId);
+    if (skill === undefined) return;
+
+    try {
+      const maybePromise = this.config.skillPromoter({
+        skillId,
+        name: skill.name,
+        category: skill.category,
+        successRate: updatedMetrics.successRate,
+        executionCount: updatedMetrics.executionCount,
+      });
+      if (maybePromise instanceof Promise) {
+        maybePromise.catch((error: unknown) => {
+          this.logger.debug('Skill promotion rejected', {
+            skillId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+    } catch (error: unknown) {
+      this.logger.debug('Skill promotion threw', {
+        skillId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/packages/nexus-agents/src/agents/skills/skill-types.ts
+++ b/packages/nexus-agents/src/agents/skills/skill-types.ts
@@ -277,6 +277,29 @@ export interface InputBinding {
 }
 
 /**
+ * Promotion bridge from a per-instance skill library to the shared
+ * memory substrate (Phase 6 of #2792). Called when a skill has
+ * accumulated enough successful executions to be considered reliable.
+ * The implementation typically writes a belief of the form
+ * `subject = "skill:{name}"`, `predicate = "is_reliable_for"`,
+ * `object = "{category}"` so future `getContextForTask` calls surface
+ * the learning across all agents — not just the one that ran it.
+ *
+ * Best-effort: promoter implementations MUST NOT throw out of this
+ * callback. SkillLibrary catches errors defensively, but cleaner not
+ * to throw in the first place.
+ */
+export interface SkillPromotionEvent {
+  readonly skillId: string;
+  readonly name: string;
+  readonly category: string;
+  readonly successRate: number;
+  readonly executionCount: number;
+}
+
+export type SkillPromoter = (event: SkillPromotionEvent) => void | Promise<void>;
+
+/**
  * Configuration for the skill library.
  */
 export interface SkillLibraryConfig {
@@ -292,6 +315,19 @@ export interface SkillLibraryConfig {
   readonly trackExecutionHistory: boolean;
   /** Maximum execution history entries per skill */
   readonly maxHistoryPerSkill: number;
+  /**
+   * Minimum successful executions before promoting the skill as a
+   * belief into the shared substrate (Phase 6 of #2792). Default 5.
+   * Skills below this threshold are still tracked locally; promotion
+   * only fires once the signal stabilizes.
+   */
+  readonly minSuccessesForPromotion: number;
+  /**
+   * Optional promotion bridge to the shared belief store. When set,
+   * SkillLibrary fires the callback whenever a skill crosses the
+   * `minSuccessesForPromotion` threshold. Default: undefined (no-op).
+   */
+  readonly skillPromoter?: SkillPromoter;
 }
 
 /**
@@ -304,6 +340,7 @@ export const DEFAULT_SKILL_LIBRARY_CONFIG: SkillLibraryConfig = {
   enablePruning: true,
   trackExecutionHistory: true,
   maxHistoryPerSkill: 100,
+  minSuccessesForPromotion: 5,
 };
 
 /**

--- a/packages/nexus-agents/src/cli-server-skills.ts
+++ b/packages/nexus-agents/src/cli-server-skills.ts
@@ -49,6 +49,7 @@ export interface SkillsInitResult {
 function adaptConfigToLibrary(
   config: SkillLibraryConfig
 ): Parameters<typeof createSkillLibrary>[0] {
+  const promoter = createBeliefPromoter();
   return {
     maxSkills: config.maxSkills,
     minSuccessRateForRetention: config.minSuccessRateForRetention,
@@ -56,6 +57,35 @@ function adaptConfigToLibrary(
     enablePruning: config.enablePruning,
     trackExecutionHistory: config.trackExecutionHistory,
     maxHistoryPerSkill: config.maxHistoryPerSkill,
+    ...(promoter !== undefined && { skillPromoter: promoter }),
+  };
+}
+
+/**
+ * Phase 6 of #2792 — the production promoter that turns "this skill has
+ * been reliably successful" signal from the {@link SkillLibrary} into a
+ * persistent belief in the shared substrate. Future entry points calling
+ * `getContextForTask` will see the belief regardless of which agent ran
+ * the original executions.
+ *
+ * Best-effort: the bridge is async (belief writes are async) but the
+ * SkillLibrary catches throws/rejections so a transient memory outage
+ * never breaks skill bookkeeping.
+ */
+function createBeliefPromoter(): NonNullable<
+  Parameters<typeof createSkillLibrary>[0]
+>['skillPromoter'] {
+  return async (event) => {
+    // Dynamic import keeps cli-server-skills free of a hard dep on
+    // mcp/tools (which would create a circular import at module load).
+    const { getToolMemory } = await import('./mcp/tools/tool-memory.js');
+    const tm = getToolMemory();
+    await tm.recordBelief(
+      `skill:${event.name}`,
+      'is_reliable_for',
+      event.category,
+      event.successRate >= 0.8 ? 'high' : 'medium'
+    );
   };
 }
 


### PR DESCRIPTION
## Summary

**Closes #2798. Phase 6 of #2792 (cross-cutting memory access).**

Per-instance memory backends stay per-instance; the **signal they produce** now reaches the shared substrate via promotion bridges.

### What ships

**`SkillLibrary` → shared beliefs (wired)**. New optional `SkillLibraryConfig.skillPromoter` callback fires once when a skill crosses `minSuccessesForPromotion` (default 5 successful executions) with `{skillId, name, category, successRate, executionCount}`. The production global library in `cli-server-skills.ts` wires this to:

```ts
getToolMemory().recordBelief(
  `skill:${event.name}`,
  'is_reliable_for',
  event.category,
  event.successRate >= 0.8 ? 'high' : 'medium'
)
```

Every later `getContextForTask` call sees the learning regardless of which agent ran the skill.

**`SicaVersionManager` and `MemoryState` → documented templates**. `AGENTS.md` grows a new `Per-instance → shared-substrate promotion` sub-section with a table describing signal/target/wiring shape for each backend. SICA and MemoryState bridges are not wired today — the templates show how to add them when a concrete need materializes.

### Design choices

- **Fire once, not on every event.** Promotion is gated by a "just-crossed-threshold" check using previous + updated metrics. Re-firing on every subsequent success would flood the belief store.
- **Defensive isolation.** Throws and promise rejections from the promoter are caught inside `SkillLibrary.maybePromote` so a broken bridge never breaks local skill bookkeeping.
- **Dynamic import in production wiring.** `cli-server-skills.ts` reaches `getToolMemory` via `await import(...)` to avoid a hard module-load circular dep with `mcp/tools/`.

### This closes the epic loop

| | |
|---|---|
| outcomes → distilled rules | Phase 5 (#2797) |
| distilled rules → ContextRetriever.priorStrategies | Phase 5 (#2797) |
| skill execution → beliefs | This PR (Phase 6) |
| beliefs → ContextRetriever.beliefs | Phase 2 (#2794) |
| ContextRetriever → every entry point | Phase 3 (#2795) |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run src/agents/skills` — 355 tests pass (6 new)
- [x] `pnpm lint` — clean
- [x] 6 new tests cover: threshold crossing, no-re-fire, no-fire-on-failure, throw isolation, async-rejection isolation, event payload shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)