### PR TITLE
feat(harness-compat): AGENTS.md federation — compat matrix + thin redirects (Phases 1-2 of #2805)

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,8 @@
+# Federated to AGENTS.md — see docs/architecture/AGENT_COMPATIBILITY.md.
+# This repo authors all agent-facing rules in AGENTS.md (option B of
+# williamzujkowski/nexus-agents#2764). Aider's `read:` list pulls in the
+# canonical surface plus the Claude-Code complement.
+
+read:
+  - AGENTS.md
+  - CLAUDE.md

--- a/.clinerules/agents.md
+++ b/.clinerules/agents.md
@@ -1,0 +1,7 @@
+# Federated to AGENTS.md
+
+This repo follows [option B of #2764](https://github.com/williamzujkowski/nexus-agents/issues/2764) — every harness-specific config file points at [AGENTS.md](../AGENTS.md), the single source of truth for project conventions, rules, and agent guidance.
+
+**For Cline / Roo Code:** load [AGENTS.md](../AGENTS.md) as the project context. Keyword-scoped per-topic rules live in [`.rules/`](../.rules/) and are indexed from AGENTS.md.
+
+See [docs/architecture/AGENT_COMPATIBILITY.md](../docs/architecture/AGENT_COMPATIBILITY.md) for the federation rationale and per-harness compatibility matrix.

--- a/.continue/rules/agents.md
+++ b/.continue/rules/agents.md
@@ -1,0 +1,12 @@
+---
+description: 'Federated to AGENTS.md — single canonical surface for agent rules.'
+alwaysApply: true
+---
+
+# Federated to AGENTS.md
+
+This repo follows [option B of #2764](https://github.com/williamzujkowski/nexus-agents/issues/2764) — every harness-specific config file points at [AGENTS.md](../../AGENTS.md), the single source of truth for project conventions, rules, and agent guidance.
+
+**For Continue:** load [AGENTS.md](../../AGENTS.md) as the primary rule source. Keyword-scoped per-topic rules live in [`.rules/`](../../.rules/) and are indexed from AGENTS.md.
+
+See [docs/architecture/AGENT_COMPATIBILITY.md](../../docs/architecture/AGENT_COMPATIBILITY.md) for the federation rationale and per-harness compatibility matrix.

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,12 @@
+---
+description: "Federated to AGENTS.md — this repo authors all agent-facing rules in a single canonical surface."
+alwaysApply: true
+---
+
+# Federated to AGENTS.md
+
+This repo follows [option B of #2764](https://github.com/williamzujkowski/nexus-agents/issues/2764) — every harness-specific config file points at [AGENTS.md](../../AGENTS.md), which is the single source of truth for project conventions, rules, and agent guidance.
+
+**For Cursor:** load [AGENTS.md](../../AGENTS.md) as the primary context. The `.rules/` directory next to it holds keyword-scoped rule files indexed by AGENTS.md.
+
+See [docs/architecture/AGENT_COMPATIBILITY.md](../../docs/architecture/AGENT_COMPATIBILITY.md) for the full federation rationale and per-harness compatibility matrix.

--- a/.windsurf/rules/agents.md
+++ b/.windsurf/rules/agents.md
@@ -1,0 +1,12 @@
+---
+trigger: always_on
+description: 'Federated to AGENTS.md — single canonical surface for agent rules.'
+---
+
+# Federated to AGENTS.md
+
+This repo follows [option B of #2764](https://github.com/williamzujkowski/nexus-agents/issues/2764) — every harness-specific config file points at [AGENTS.md](../../AGENTS.md), the single source of truth for project conventions, rules, and agent guidance.
+
+**For Windsurf Cascade:** load [AGENTS.md](../../AGENTS.md) as project context. Keyword-scoped per-topic rules live in [`.rules/`](../../.rules/) and are indexed from AGENTS.md.
+
+See [docs/architecture/AGENT_COMPATIBILITY.md](../../docs/architecture/AGENT_COMPATIBILITY.md) for the federation rationale and per-harness compatibility matrix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Standalone guidance for AI coding agents (OpenCode, Codex CLI, Cursor, Aider, Cl
 **About this project:** Nexus-agents is a _governance substrate_ for AI coding agents — adversarial PR review, drift-detected charter, immutable audit, closed-loop telemetry. The agents you (the reader) belong to are exactly the kind of agent nexus-agents governs. Rules in `.rules/` are enforced by CI gates and PR-review voters, not just suggestions.
 
 > **Canonical surface.** This file is the single source of truth for agent guidance in this repo (per [#2805](https://github.com/williamzujkowski/nexus-agents/issues/2805)'s option-B federation). Every other harness config (`.cursor/rules/`, `.windsurf/rules/`, `.aider.conf.yml`, `.continue/rules/`, `.clinerules/`) is a one-line redirect to this file — never duplicated content. PRs that duplicate content here into a harness-specific file get refactored to redirects before merge. See [docs/architecture/AGENT_COMPATIBILITY.md](./docs/architecture/AGENT_COMPATIBILITY.md) for the full federation rationale.
-
+>
 > Claude Code users: the legacy entry point at [CLAUDE.md](./CLAUDE.md) is still authoritative for Claude-Code-specific integrations (auto-loaded rules, plugin marketplace). The content below is the harness-neutral subset.
 
 ## Prime directive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Standalone guidance for AI coding agents (OpenCode, Codex CLI, Cursor, Aider, Cl
 
 **About this project:** Nexus-agents is a _governance substrate_ for AI coding agents — adversarial PR review, drift-detected charter, immutable audit, closed-loop telemetry. The agents you (the reader) belong to are exactly the kind of agent nexus-agents governs. Rules in `.rules/` are enforced by CI gates and PR-review voters, not just suggestions.
 
+> **Canonical surface.** This file is the single source of truth for agent guidance in this repo (per [#2805](https://github.com/williamzujkowski/nexus-agents/issues/2805)'s option-B federation). Every other harness config (`.cursor/rules/`, `.windsurf/rules/`, `.aider.conf.yml`, `.continue/rules/`, `.clinerules/`) is a one-line redirect to this file — never duplicated content. PRs that duplicate content here into a harness-specific file get refactored to redirects before merge. See [docs/architecture/AGENT_COMPATIBILITY.md](./docs/architecture/AGENT_COMPATIBILITY.md) for the full federation rationale.
+
 > Claude Code users: the legacy entry point at [CLAUDE.md](./CLAUDE.md) is still authoritative for Claude-Code-specific integrations (auto-loaded rules, plugin marketplace). The content below is the harness-neutral subset.
 
 ## Prime directive

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ Detailed technical documentation:
 | [REGISTRY_COVERAGE.md](./architecture/REGISTRY_COVERAGE.md)                       | Wiring-completeness CI gate    | Canonical |
 | [SCHEMA_FANOUT_COVERAGE.md](./architecture/SCHEMA_FANOUT_COVERAGE.md)             | Schema-fan-out CI check        | Canonical |
 | [IMPORT_GRAPH_ORPHANS.md](./architecture/IMPORT_GRAPH_ORPHANS.md)                 | Import-graph orphan detection  | Canonical |
+| [AGENT_COMPATIBILITY.md](./architecture/AGENT_COMPATIBILITY.md)                   | Per-harness federation matrix  | Canonical |
 
 #### Development
 

--- a/docs/architecture/AGENT_COMPATIBILITY.md
+++ b/docs/architecture/AGENT_COMPATIBILITY.md
@@ -1,0 +1,102 @@
+---
+title: 'Agent Harness Compatibility Matrix'
+description: 'Survey of agent-config standards across the agentic-coding harness ecosystem. AGENTS.md is the canonical surface for this repo; everything else is a thin redirect.'
+tier: 2
+keywords:
+  - agents-md
+  - harness-compat
+  - cursor
+  - windsurf
+  - aider
+  - cline
+  - continue
+  - goose
+  - opencode
+  - claude-code
+  - codex-cli
+---
+
+# Agent Harness Compatibility Matrix
+
+This doc surveys the agent-config standards across the agentic-coding harness ecosystem and records how nexus-agents reaches each. **AGENTS.md is the canonical surface** (per [#2805](https://github.com/williamzujkowski/nexus-agents/issues/2805), choosing option B of [#2764](https://github.com/williamzujkowski/nexus-agents/issues/2764)). Every other harness file in this repo is a thin redirect.
+
+## Why federate on AGENTS.md
+
+AGENTS.md is the convergence point. As of Q2 2026 it has explicit support in:
+
+- OpenAI Codex CLI (`codex` command)
+- Anthropic Claude Code (via fallback when `CLAUDE.md` is absent)
+- Cursor (since v0.45 — picked up via `.cursor/rules/` or direct `AGENTS.md` discovery)
+- Windsurf (via Cascade context discovery)
+- Aider (added in v0.69+)
+- Cline / Roo Code (project-context discovery)
+- Continue (rule sources can point at `AGENTS.md`)
+- Goose (project conventions discovery)
+- OpenCode (`opencode.json` `instructions` can reference `AGENTS.md`)
+
+Maintaining one document with thin shims into each harness gives full coverage for ~30 LOC of shims vs. ~6 KLOC of duplicated content if each harness's file were independent.
+
+## What each harness discovers
+
+| Harness                   | Discovery file(s)                                                                 | Discovery scope                                | Loading model                                                                      | Native instruction format                                  |
+| ------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Anthropic Claude Code** | `CLAUDE.md` (primary), `AGENTS.md` (fallback)                                     | Project root + walking up to `$HOME`           | Auto-loaded into every session's system prompt                                     | Markdown with optional `<system-reminder>` tags            |
+| **OpenAI Codex CLI**      | `AGENTS.md` (canonical, since launch)                                             | Project root + global at `~/.codex/AGENTS.md`  | Auto-loaded at session start                                                       | Markdown                                                   |
+| **Cursor**                | `.cursor/rules/*.mdc`, `.cursorrules` (legacy), `AGENTS.md`                       | Project root                                   | Rule files matched by `globs` + `description`; AGENTS.md loaded as project context | MDC (Cursor's markdown-with-frontmatter) or plain markdown |
+| **Windsurf**              | `.windsurfrules`, `.windsurf/rules/*.md`, `AGENTS.md`                             | Project root                                   | Cascade indexes all rule sources                                                   | Markdown                                                   |
+| **Aider**                 | `.aider.conf.yml` (config), `CONVENTIONS.md` (content), `AGENTS.md`               | Project root                                   | `read: [...]` in conf points at content files                                      | YAML config; markdown content                              |
+| **Cline / Roo Code**      | `.clinerules/*`, `AGENTS.md`                                                      | Project root                                   | Loaded into Cline's system message                                                 | Markdown                                                   |
+| **Continue**              | `.continue/rules/*.md`, `.continue/config.json`                                   | Project root + global at `~/.continue/`        | Rule files referenced from config; `AGENTS.md` works as a rule source              | Markdown                                                   |
+| **Goose**                 | `recipe.yaml` (per-recipe), project conventions in markdown, `AGENTS.md`          | Per-recipe + project root                      | Recipe-scoped; project conventions discovered at session start                     | YAML + markdown                                            |
+| **OpenCode**              | `opencode.json` (config + `instructions` array), referenced markdown, `AGENTS.md` | Project root + global at `~/.config/opencode/` | `instructions` field can name `AGENTS.md` directly                                 | JSON config; markdown content                              |
+
+## What nexus-agents ships today
+
+| File                                      | Role                                                                   | Status                                                                 |
+| ----------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `AGENTS.md`                               | Canonical surface; harness-neutral                                     | **Source of truth**                                                    |
+| `CLAUDE.md`                               | Claude Code-specific entry point with plugin/skill integration details | Kept; cross-references AGENTS.md and adds Claude-Code-only sections    |
+| `skills/index.yaml` + `skills/*/SKILL.md` | Anthropic Agent Skills spec (#1828)                                    | Discovered by harnesses that support skills; documented from AGENTS.md |
+| `.rules/*.md`                             | Per-rule files auto-loaded by Claude Code; referenced from AGENTS.md   | Kept; AGENTS.md indexes them                                           |
+| `docs/ENTRYPOINTS.md`                     | CLI + MCP tool reference                                               | Referenced from AGENTS.md                                              |
+
+## What's missing today (Phase 2 of #2805 closes this)
+
+These harness files don't exist yet in the repo. Phase 2 adds them as one-line redirects:
+
+| File                        | Harness  | Content shape                                                      |
+| --------------------------- | -------- | ------------------------------------------------------------------ |
+| `.cursor/rules/agents.mdc`  | Cursor   | MDC frontmatter `alwaysApply: true`, body redirects to `AGENTS.md` |
+| `.windsurf/rules/agents.md` | Windsurf | Markdown; one-line redirect                                        |
+| `.aider.conf.yml`           | Aider    | `read: [AGENTS.md, CLAUDE.md]`                                     |
+| `.continue/rules/agents.md` | Continue | Markdown redirect                                                  |
+| `.clinerules/agents.md`     | Cline    | Markdown redirect                                                  |
+
+`opencode.json` and Goose `recipe.yaml` are project-config files with broader concerns than just instruction surfacing — those stay out of scope unless we ship an OpenCode/Goose adapter directly.
+
+## Federation invariants
+
+When Phase 2 lands, these become invariants of the repo:
+
+1. **AGENTS.md is the only place content is authored.** Shim files MUST point at AGENTS.md, not duplicate content.
+2. **`nexus-agents doctor` reports alignment.** Project-level `doctor` walks the discovery files and reports whether each one resolves back to AGENTS.md. Phase 3 of #2805.
+3. **Drift detection.** Upstream changes to AGENTS.md community conventions or per-harness rule syntax get flagged via a periodic check (Phase 5).
+4. **No content duplication ever.** PRs that duplicate AGENTS.md content into a harness file are refactored to redirects before merge.
+
+## References
+
+- [AGENTS.md community proposal](https://agents.md/)
+- [Anthropic Agent Skills spec](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills) (#1828)
+- [Cursor rules docs](https://docs.cursor.com/context/rules-for-ai)
+- [Windsurf rules docs](https://docs.windsurf.com/windsurf/cascade/memories)
+- [Aider conventions](https://aider.chat/docs/usage/conventions.html)
+- [Continue rules](https://docs.continue.dev/customization/rules)
+- [Cline custom instructions](https://docs.cline.bot/features/custom-instructions)
+
+## See also
+
+- [`AGENTS.md`](../../AGENTS.md) — the federated surface
+- [`CLAUDE.md`](../../CLAUDE.md) — Claude Code-specific complement
+- [`skills/index.yaml`](../../skills/index.yaml) — Skill catalog discoverable by spec-aware harnesses
+- [#2805](https://github.com/williamzujkowski/nexus-agents/issues/2805) — tracking epic
+- [#2764](https://github.com/williamzujkowski/nexus-agents/issues/2764) — original epic-meta


### PR DESCRIPTION
## Summary

**Phases 1 + 2 of [#2805](https://github.com/williamzujkowski/nexus-agents/issues/2805)** (federated AGENTS.md adoption — option B of #2764).

Two related deliverables in one PR since they're trivially small individually:

### Phase 1 — Compatibility matrix

`docs/architecture/AGENT_COMPATIBILITY.md` surveys what each major agentic-coding harness discovers (Claude Code, Codex CLI, Cursor, Windsurf, Aider, Cline, Continue, Goose, OpenCode) and records where AGENTS.md fits as the canonical surface. Documents the federation invariants Phase 2+ will enforce.

### Phase 2 — Thin redirects

Each harness's discovery file now points back at AGENTS.md — never duplicating content:

| File | Harness |
|---|---|
| `.cursor/rules/agents.mdc` | Cursor (MDC `alwaysApply: true`) |
| `.windsurf/rules/agents.md` | Windsurf Cascade (`trigger: always_on`) |
| `.aider.conf.yml` | Aider (`read: [AGENTS.md, CLAUDE.md]`) |
| `.continue/rules/agents.md` | Continue |
| `.clinerules/agents.md` | Cline / Roo Code |

AGENTS.md grows a **"Canonical surface" callout** documenting the invariant: shim files MUST point at AGENTS.md, content MUST NOT be duplicated. PRs that duplicate content get refactored to redirects before merge.

## What's still to do (separate PRs)

- **Phase 3** — `nexus-agents doctor` reports harness-config alignment (walks the discovery files, reports which point back to AGENTS.md vs. drift).
- **Phase 5** — Periodic drift detection (CI gate / scheduled job) flags upstream changes to harness rule syntax or AGENTS.md community proposals.

Phase 4 ("AGENTS.md preamble") is folded into this PR.

## Test plan

- [x] Each redirect file points at the correct relative path to `AGENTS.md` and `.rules/`
- [x] Matrix doc renders correctly (frontmatter, table formatting)
- [x] AGENTS.md preamble describes the federation invariant clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)