### PR TITLE
chore(npm): strip publishConfig.provenance from nexus-memory manifest

### DIFF
--- a/.changeset/2807-strip-nexus-memory-provenance.md
+++ b/.changeset/2807-strip-nexus-memory-provenance.md
@@ -1,0 +1,7 @@
+---
+'nexus-memory': patch
+---
+
+Remove `publishConfig.provenance: true` from the manifest. Manifest-level provenance enforcement blocked local bootstrap publishes because Sigstore signing requires an OIDC token (only available in CI/GitHub Actions). The `nexus-agents` Release workflow already sets `NPM_CONFIG_PROVENANCE: true` env-var, so Sigstore provenance attestation is preserved on every CI-driven publish — the manifest setting was redundant + harmful for the v0.1.0 bootstrap.
+
+Refs #2807.

--- a/packages/nexus-memory/package.json
+++ b/packages/nexus-memory/package.json
@@ -19,8 +19,7 @@
   ],
   "author": "William Zujkowski",
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Removes `publishConfig.provenance: true` from `packages/nexus-memory/package.json`. Manifest-level provenance enforcement blocked the local bootstrap publish of `nexus-memory@0.1.0` because Sigstore signing requires an OIDC token (only available in CI/GitHub Actions).

CI publishes still get Sigstore provenance — the `nexus-agents` Release workflow sets `NPM_CONFIG_PROVENANCE: true` env-var, so the attestation is preserved without the manifest enforcement.

### State

- `nexus-memory@0.1.0` is now on npm — verified via `npm view nexus-memory version` → `0.1.0`
- Local manual publish at 2026-05-16T17:21Z used the (now-committed) provenance-stripped manifest
- The nexus-agents Release loop will catch up automatically on the next release-PR merge (nexus-memory is published as part of `pnpm release` whenever the package's version changes)

Closes #2807.