### PR TITLE
chore(release): node 24 LTS on publish path for OIDC trusted publishing

### DIFF
--- a/.changeset/release-node24-oidc.md
+++ b/.changeset/release-node24-oidc.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**ci(release):** Bump the publish-path Node version from 22 to 24 LTS so npm 11.x is available for OIDC trusted publishing. Node 22 LTS ships npm 10.9.x, which silently emits `E404 'not in this registry'` on OIDC-authenticated publishes — diagnosed during `nexus-eval-atbench` v0.1.0–0.1.3 attempts (#2524). The CI composite default stays at 22; only the two publish-path `setup-node` calls in `release.yml` (changesets/action step + manual-publish step) override to 24.
+
+Unblocks OIDC publishes for `nexus-agents` and `nexus-memory` (the latter's bootstrap `0.1.0` was a local publish via the granular `NPM_TOKEN`; subsequent versions need OIDC because the token is being retired — see #2814).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
 
       - uses: ./.github/actions/setup-node
         with:
+          # Node 24 LTS ships with npm 11.x, which natively supports OIDC
+          # trusted publishing. Node 22 LTS ships npm 10.9.x which silently
+          # emits `E404 'not in this registry'` on OIDC publishes — diagnosed
+          # via nexus-eval-atbench v0.1.0–0.1.3 attempts (#2524). The CI
+          # composite default is 22; the publish path overrides to 24.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       # Bidirectional skew detection. The `Detect publish-race version skew`
@@ -264,6 +270,8 @@ jobs:
 
       - uses: ./.github/actions/setup-node
         with:
+          # Node 24 — see comment on the publish-job setup-node above (#2524).
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Build all packages


### PR DESCRIPTION
## Summary

- Override `setup-node` composite to `node-version: '24'` on both publish-path call sites in `release.yml`
- CI composite default stays at 22 for the rest of the workflows (only the publish path needs npm 11.x)

## Why

`nexus-eval-atbench` v0.1.0–0.1.3 OIDC publishes hit `E404 'not in this registry'` from `npm publish --provenance`. Root cause: npm 10.9.x (Node 22 LTS default) doesn't natively support OIDC trusted publishing. npm 11.x (Node 24 LTS default) does — confirmed end-to-end with `nexus-eval-atbench@0.1.4` published successfully on 2026-05-16.

Companion to:
- nexus-eval-swebench/pull/7 (Node 24 + SHA pin + dependabot + repository field)
- nexus-eval-atbench/pull/9 (SHA pin + Node 24 in CI + dependabot)
- nexus-eval-swebench-pro/pull/N (Node 24 + SHA pin + dependabot + repository field)

Closes the last outstanding piece of #2814 (granular `NPM_TOKEN` retire). Once this merges and a release runs successfully, the `NPM_TOKEN` GitHub secret can be deleted.

## Test plan

- [ ] CI green on this branch
- [ ] After merge, next `Version Packages` PR + release runs cleanly via OIDC
- [ ] `npm view nexus-agents version` bumps to the new patch
- [ ] `npm view nexus-memory version` bumps to `0.1.2`
- [ ] Sigstore transparency log entries for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)