### PR TITLE
fix(pipeline): outcome recording threads actual cli — regression of #1154 (#2823)

### DIFF
--- a/.changeset/2823-pipeline-cli-claude-regression.md
+++ b/.changeset/2823-pipeline-cli-claude-regression.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+**Closes #2823.** fix(pipeline): outcome recording hardcodes cli='claude' — regression of #1154
+
+`pipeline/agent-executor.ts` and `pipeline/adaptive-orchestrator.ts` both wrote to `OutcomeStore` with `cli: 'claude' as const` — a regression of the bug #1154 fixed elsewhere. Every pipeline-executed task (research / plan / vote / decompose / code_gen / review / security) was credited to claude regardless of which CLI actually ran, poisoning weather-report visualizations and the LinUCB cold-start `warmStart()` (composite-router.ts:353/374).
+
+**Fix:**
+
+1. `ExpertBridgeResult` now carries the resolved `cli?: CliNameLiteral`. The expert-bridge derives it from `CliResponse.model` via the canonical `getCliForModelId` registry mapping — guards against unknown model strings rather than fabricating a default.
+2. `recordOutcome` in `agent-executor.ts` now takes a `RecordOutcomeArgs` options bundle including `cli: CliNameLiteral | undefined`. When `cli` is undefined (bridge failed before dispatch, or non-CLI stage like local security scan / consensus vote), the helper **skips the record** rather than fabricating a wrong attribution. Stage events still emit; only the cli-attributed outcome that would poison the routing learner is suppressed.
+3. All 9 call sites (research / plan / vote / decompose / implement / qaReview / securityScan) updated. Sub-call stages with multiple expert calls (research) pick whichever sub-call actually reached a CLI.
+4. `recordPipelineOutcome` in `adaptive-orchestrator.ts` removed entirely — it duplicated the per-stage records, fabricated `cli: 'claude'` for pipeline-level data, hardcoded `category: 'code_generation'` regardless of classification, and had no downstream consumer.
+
+**Tests:** 3 new regression cases in `agent-executor.test.ts` assert (a) the threaded cli wins over any hardcoded value, (b) `undefined cli` skips the record entirely, (c) different stages can have different cli attributions. All 719 pipeline + parser tests pass; typecheck + lint clean.

--- a/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
+++ b/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
@@ -18,7 +18,6 @@ import type { GraphPipelineOptions, GraphPipelineResult } from './graph-pipeline
 import { getTemplate, PIPELINE_TEMPLATES } from './templates.js';
 import type { PipelineTemplate } from './stage-types.js';
 import type { StageRegistry } from './pipeline-graph.js';
-import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 
 const logger = createLogger({ component: 'adaptive-orchestrator' });
 
@@ -356,11 +355,13 @@ export async function runAdaptiveOrchestrator(
     confidence: classification.confidence,
   });
 
-  // Execute via graph pipeline runner
+  // Execute via graph pipeline runner. Per-stage outcomes are recorded by
+  // agent-executor.recordOutcome with the actual CLI that ran each stage.
+  // #2823: removed the pipeline-level recordPipelineOutcome — it duplicated
+  // the per-stage records, fabricated a `cli: 'claude'` for non-CLI data,
+  // hardcoded category as 'code_generation' regardless of classification,
+  // and had no downstream consumer.
   const result = await runGraphPipeline(cleanTask, template, options.stages, options);
-
-  // Record outcome for future routing adjustments
-  recordPipelineOutcome(template.id, classification, result.success);
 
   return { ...result, selectionMethod, taskClassification: classification };
 }
@@ -380,26 +381,4 @@ function resolveTemplate(templateId: string): PipelineTemplate {
 
   // Absolute fallback — should never happen
   return { id: 'dev', name: 'Development', stages: [] };
-}
-
-/** Record pipeline outcome for self-reflection. */
-function recordPipelineOutcome(
-  templateId: string,
-  classification: TaskClassification,
-  success: boolean
-): void {
-  try {
-    getOutcomeStore().append({
-      id: `pipeline-${templateId}-${String(Date.now())}`,
-      cli: 'claude' as const,
-      category: 'code_generation' as const,
-      model: `pipeline-${templateId}`,
-      success,
-      durationMs: 0,
-      timestamp: new Date().toISOString(),
-      source: 'delegate' as const,
-    });
-  } catch {
-    // Non-critical — don't fail pipeline on outcome recording error
-  }
 }

--- a/packages/nexus-agents/src/pipeline/agent-executor.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.test.ts
@@ -364,4 +364,98 @@ describe('createAgentStages — central workflow hub', () => {
       expect(mockRecordError).toHaveBeenCalled();
     });
   });
+
+  // #2823: regression coverage. recordOutcome used to hardcode `cli: 'claude'`,
+  // poisoning the OutcomeStore + LinUCB cold-start warmStart on every run.
+  // The threaded `cli` now comes from `r.cli` (executeExpert's resolved CLI);
+  // when undefined (bridge failed before dispatch, or non-CLI stage like
+  // local security scan) the record is skipped rather than fabricated.
+  describe('recordOutcome cli threading (#2823)', () => {
+    it('writes the actual cli from executeExpert, never hardcoded claude', async () => {
+      const appendSpy = vi.fn();
+      mockGetOutcomeStore.mockReturnValue({
+        append: appendSpy,
+        query: vi.fn().mockReturnValue([]),
+      });
+      mockExecuteExpert.mockResolvedValue({
+        success: true,
+        text: 'Plan v1',
+        durationMs: 200,
+        expertType: 'architecture',
+        cli: 'gemini',
+      });
+
+      const stages = createAgentStages();
+      await stages.plan('build feature A', '');
+
+      const planRecord = appendSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as { id?: string }).id?.startsWith('pipeline-plan-') === true
+      );
+      expect(planRecord).toBeDefined();
+      expect((planRecord![0] as { cli: string }).cli).toBe('gemini');
+    });
+
+    it('skips the record when cli is undefined (bridge failed before dispatch)', async () => {
+      const appendSpy = vi.fn();
+      mockGetOutcomeStore.mockReturnValue({
+        append: appendSpy,
+        query: vi.fn().mockReturnValue([]),
+      });
+      // No `cli` field — bridge failed before any CLI ran (no adapter / circuit-open).
+      mockExecuteExpert.mockResolvedValue({
+        success: false,
+        text: '',
+        durationMs: 5,
+        expertType: 'architecture',
+        error: 'No adapters available',
+      });
+
+      const stages = createAgentStages();
+      await stages.plan('build feature A', '');
+
+      const planRecord = appendSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as { id?: string }).id?.startsWith('pipeline-plan-') === true
+      );
+      // The whole point of #2823: no append at all, rather than a fabricated
+      // `cli: 'claude'` record polluting routing learner.
+      expect(planRecord).toBeUndefined();
+    });
+
+    it('threads each CLI distinctly across stages (#2823)', async () => {
+      const appendSpy = vi.fn();
+      mockGetOutcomeStore.mockReturnValue({
+        append: appendSpy,
+        query: vi.fn().mockReturnValue([]),
+      });
+      // Decompose returns codex; implement returns claude.
+      mockExecuteExpert
+        .mockResolvedValueOnce({
+          success: true,
+          text: '[{"id":"t1","title":"x","description":"y","assignedTo":"dev"}]',
+          durationMs: 80,
+          expertType: 'pm',
+          cli: 'codex',
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          text: 'implementation done',
+          durationMs: 1200,
+          expertType: 'code',
+          cli: 'claude',
+        });
+
+      const stages = createAgentStages();
+      const tasks = await stages.decompose('plan');
+      await stages.implement(tasks[0]!);
+
+      const decomposeRecord = appendSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as { id?: string }).id?.startsWith('pipeline-decompose-') === true
+      );
+      const implRecord = appendSpy.mock.calls.find(
+        (c: unknown[]) => (c[0] as { id?: string }).id?.startsWith('pipeline-t1-') === true
+      );
+      expect((decomposeRecord![0] as { cli: string }).cli).toBe('codex');
+      expect((implRecord![0] as { cli: string }).cli).toBe('claude');
+    });
+  });
 });

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -18,6 +18,7 @@ import { executeExpert } from './expert-bridge.js';
 import { getOutcomeStore, getOutcomeSummaryText } from '../orchestration/outcomes/outcome-store.js';
 import { detectTrend } from '../orchestration/outcomes/adaptive-thresholds.js';
 import { emitPipelineStageEvent } from './pipeline-observability.js';
+import type { CliNameLiteral } from '../config/model-capabilities-types.js';
 
 const logger = createLogger({ component: 'agent-executor' });
 
@@ -30,28 +31,54 @@ function emitStageEvent(
   emitPipelineStageEvent('dev-pipeline', stage, status, details);
 }
 
-function recordOutcome(
-  taskId: string,
-  category: string,
-  success: boolean,
-  durationMs: number,
-  extra?: { routingStage?: string; retryCount?: number }
-): void {
+/** Options bundle for {@link recordOutcome} (collapses to satisfy max-params). */
+interface RecordOutcomeArgs {
+  taskId: string;
+  category: string;
+  /**
+   * CLI that actually executed the stage. Pre-#2823 this helper hardcoded
+   * `cli: 'claude'`, which was a regression of the bug #1154 fixed elsewhere
+   * and silently corrupted weather-report + LinUCB cold-start warmStart()
+   * with false `claude` credit on every pipeline run.
+   *
+   * When `undefined` (the bridge failed before dispatch — no adapter,
+   * circuit-open, rate-limit cap — or the stage is non-CLI, like local
+   * security scan) we *skip the record* rather than lie. The stage event
+   * is still emitted; only the cli-attributed outcome that would poison
+   * the routing learner is suppressed.
+   */
+  cli: CliNameLiteral | undefined;
+  success: boolean;
+  durationMs: number;
+  routingStage?: string;
+  retryCount?: number;
+}
+
+/** Record a pipeline-stage outcome to the OutcomeStore. See {@link RecordOutcomeArgs}. */
+function recordOutcome(args: RecordOutcomeArgs): void {
+  if (args.cli === undefined) {
+    logger.debug('Skipping outcome record — no cli (bridge failed or non-CLI stage)', {
+      taskId: args.taskId,
+      category: args.category,
+      success: args.success,
+    });
+    return;
+  }
   try {
     getOutcomeStore().append({
-      id: `pipeline-${taskId}-${String(Date.now())}`,
-      cli: 'claude' as const,
-      category: category as 'code_generation',
+      id: `pipeline-${args.taskId}-${String(Date.now())}`,
+      cli: args.cli,
+      category: args.category as 'code_generation',
       model: 'pipeline',
-      success,
-      durationMs,
+      success: args.success,
+      durationMs: args.durationMs,
       timestamp: new Date().toISOString(),
       source: 'delegate' as const,
-      routingStage: extra?.routingStage,
-      retryCount: extra?.retryCount,
+      routingStage: args.routingStage,
+      retryCount: args.retryCount,
     });
   } catch (error) {
-    logger.debug('Failed to record outcome', { taskId, error: String(error) });
+    logger.debug('Failed to record outcome', { taskId: args.taskId, error: String(error) });
   }
 }
 
@@ -304,8 +331,17 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       const combined = [discover.text, analyze.text].filter(Boolean).join('\n\n');
       const totalMs = discover.durationMs + analyze.durationMs;
       const success = discover.success || analyze.success;
+      // Pick whichever sub-call actually reached a CLI; both should agree
+      // when routing is healthy, but discover.cli wins on tie.
+      const researchCli = discover.cli ?? analyze.cli;
       emitStageEvent('research', success ? 'completed' : 'failed', { durationMs: totalMs });
-      recordOutcome('research', 'research', success, totalMs);
+      recordOutcome({
+        taskId: 'research',
+        category: 'research',
+        cli: researchCli,
+        success,
+        durationMs: totalMs,
+      });
       // Write-back: persist research findings to memory (#1716)
       if (success && combined.length > 50) {
         recordLearning(
@@ -331,7 +367,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       await postProgress(config, 'Plan', feedback !== undefined ? 'Revising...' : 'Planning...');
       const r = await executeExpert('architecture', prompt);
       emitStageEvent('plan', r.success ? 'completed' : 'failed', { durationMs: r.durationMs });
-      recordOutcome('plan', 'architecture', r.success, r.durationMs);
+      recordOutcome({
+        taskId: 'plan',
+        category: 'architecture',
+        cli: r.cli,
+        success: r.success,
+        durationMs: r.durationMs,
+      });
       await postProgress(config, 'Plan', `Done (${r.text.length} chars, ${r.durationMs}ms)`);
       return r.text || prompt;
     },
@@ -367,7 +409,17 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
           .join('\n');
         const ms = getTimeProvider().now() - start;
         emitStageEvent('vote', 'completed', { durationMs: ms });
-        recordOutcome('vote', 'planning', approved, ms);
+        // Vote is itself a consensus result, not a single CLI's output;
+        // skip the cli-attributed record — consensus_vote's executeVoting
+        // already records its own voter-role-stratified outcomes via the
+        // canonical consensus path (#2662).
+        recordOutcome({
+          taskId: 'vote',
+          category: 'planning',
+          cli: undefined,
+          success: approved,
+          durationMs: ms,
+        });
         await postProgress(
           config,
           'Vote',
@@ -380,7 +432,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         emitStageEvent('vote', 'failed', { error: msg });
-        recordOutcome('vote', 'planning', false, getTimeProvider().now() - start);
+        recordOutcome({
+          taskId: 'vote',
+          category: 'planning',
+          cli: undefined,
+          success: false,
+          durationMs: getTimeProvider().now() - start,
+        });
         await postProgress(config, 'Vote', `Error (auto-approved): ${msg.slice(0, 200)}`);
         return { kind: 'approved' as const, approvalPercentage: 0 };
       }
@@ -395,7 +453,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       );
       const tasks = parseTasksFromResponse(r.text, plan);
       emitStageEvent('decompose', 'completed', { durationMs: r.durationMs });
-      recordOutcome('decompose', 'planning', r.success, r.durationMs);
+      recordOutcome({
+        taskId: 'decompose',
+        category: 'planning',
+        cli: r.cli,
+        success: r.success,
+        durationMs: r.durationMs,
+      });
       await postProgress(config, 'PM', `${tasks.length} task(s)`);
       return tasks;
     },
@@ -411,7 +475,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       emitStageEvent(`impl-${task.id}`, r.success ? 'completed' : 'failed', {
         durationMs: r.durationMs,
       });
-      recordOutcome(task.id, 'code_generation', r.success, r.durationMs);
+      recordOutcome({
+        taskId: task.id,
+        category: 'code_generation',
+        cli: r.cli,
+        success: r.success,
+        durationMs: r.durationMs,
+      });
       recordRoutingExperience('code_generation', r.success, r.durationMs);
       await postProgress(config, `Code [${task.id}]`, `Done (${r.durationMs}ms)`);
       return r.text || `[Implementation failed: ${r.error}]`;
@@ -428,7 +498,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       emitStageEvent(`qa-${task.id}`, review.verdict === 'pass' ? 'completed' : 'failed', {
         durationMs: r.durationMs,
       });
-      recordOutcome(task.id, 'code_review', review.verdict === 'pass', r.durationMs);
+      recordOutcome({
+        taskId: task.id,
+        category: 'code_review',
+        cli: r.cli,
+        success: review.verdict === 'pass',
+        durationMs: r.durationMs,
+      });
       // Write-back: persist QA outcomes to memory (#1716)
       if (review.verdict === 'pass') {
         recordLearning(`Task "${task.title}" passed QA`, 0.8, 'pipeline-qa');
@@ -452,7 +528,15 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       const passed = result.verdict !== 'fail';
       const ms = getTimeProvider().now() - start;
       emitStageEvent('security', passed ? 'completed' : 'failed', { durationMs: ms });
-      recordOutcome('security', 'security_review', passed, ms);
+      // security scan is a deterministic local check (no CLI dispatch),
+      // so it has no `cli` to attribute the outcome to. Skip the record.
+      recordOutcome({
+        taskId: 'security',
+        category: 'security_review',
+        cli: undefined,
+        success: passed,
+        durationMs: ms,
+      });
       await postProgress(config, 'Security', passed ? 'Passed' : `BLOCKED: ${result.details}`);
       // Flush pipeline memory session at end of run
       flushPipelineMemory();

--- a/packages/nexus-agents/src/pipeline/expert-bridge.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.ts
@@ -12,6 +12,21 @@
 import { createLogger, getTimeProvider } from '../core/index.js';
 import type { BuiltInExpertType } from '../agents/experts/expert-config.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
+import { getCliForModelId } from '../config/model-availability.js';
+import { MODEL_IDS } from '../config/model-capabilities-types.js';
+import type { CliNameLiteral, ModelId } from '../config/model-capabilities-types.js';
+
+/**
+ * Resolves a CLI from a possibly-unknown model string returned by a CLI
+ * response. Returns undefined if the model string isn't in the registry —
+ * caller treats undefined as "don't know which CLI ran" rather than
+ * fabricating a default (#2823).
+ */
+function resolveCliFromModelString(model: string | undefined): CliNameLiteral | undefined {
+  if (model === undefined) return undefined;
+  if (!(MODEL_IDS as readonly string[]).includes(model)) return undefined;
+  return getCliForModelId(model as ModelId);
+}
 
 const logger = createLogger({ component: 'expert-bridge' });
 
@@ -25,6 +40,14 @@ export interface ExpertBridgeResult {
   readonly expertType: BuiltInExpertType;
   readonly durationMs: number;
   readonly error?: string;
+  /**
+   * CLI that actually executed the task, resolved from the underlying
+   * `CliResponse.model` via `getCliForModelId`. Undefined when the bridge
+   * failed before dispatch (no adapters / circuit-open / rate-limit cap).
+   * Callers writing to OutcomeStore should use this rather than hardcoding
+   * a cli — see #2823 (#1154 regression).
+   */
+  readonly cli?: CliNameLiteral;
 }
 
 /**
@@ -39,10 +62,11 @@ export interface ExpertBridgeResult {
  */
 /** Minimal router interface for the bridge. */
 interface RouterLike {
-  executeTask(task: {
-    content: string;
-    options?: Record<string, unknown> | undefined;
-  }): Promise<{ ok: boolean; value: { text: string }; error: { message: string } }>;
+  executeTask(task: { content: string; options?: Record<string, unknown> | undefined }): Promise<{
+    ok: boolean;
+    value: { text: string; cli?: CliNameLiteral };
+    error: { message: string };
+  }>;
 }
 
 // Cached router — lazily initialized, reused across calls within a session
@@ -87,7 +111,7 @@ function adaptCompositeRouter(
   return {
     async executeTask(task): Promise<{
       ok: boolean;
-      value: { text: string };
+      value: { text: string; cli?: CliNameLiteral };
       error: { message: string };
     }> {
       const cliTask: import('../cli-adapters/types.js').CliTask = {
@@ -96,7 +120,19 @@ function adaptCompositeRouter(
       };
       const result = await compositeRouter.executeTask(cliTask);
       if (result.ok) {
-        return { ok: true, value: { text: result.value.text }, error: { message: '' } };
+        // #2823: surface which CLI actually executed so callers writing to
+        // OutcomeStore don't have to hardcode 'claude' (the bug #1154 fixed
+        // and that regressed into the pipeline/ tree). Derive via the
+        // canonical model→cli mapping in the registry — if the underlying
+        // adapter didn't set `model` or the model isn't in the registry,
+        // cli stays undefined and downstream code can skip the record
+        // rather than lie.
+        const cli = resolveCliFromModelString(result.value.model);
+        return {
+          ok: true,
+          value: { text: result.value.text, ...(cli !== undefined && { cli }) },
+          error: { message: '' },
+        };
       }
       return { ok: false, value: { text: '' }, error: { message: result.error.message } };
     },
@@ -153,8 +189,18 @@ async function dispatchWithRateLimitRetry(
     const durationMs = getTimeProvider().now() - start;
 
     if (result.ok) {
-      logger.info('Expert executed successfully', { expertType, durationMs });
-      return { success: true, text: result.value.text, expertType, durationMs };
+      logger.info('Expert executed successfully', {
+        expertType,
+        durationMs,
+        cli: result.value.cli,
+      });
+      return {
+        success: true,
+        text: result.value.text,
+        expertType,
+        durationMs,
+        ...(result.value.cli !== undefined && { cli: result.value.cli }),
+      };
     }
 
     const isRateLimit = isRateLimitText(result.error.message);


### PR DESCRIPTION
## Summary

**Closes #2823.** `pipeline/agent-executor.ts` and `pipeline/adaptive-orchestrator.ts` wrote to OutcomeStore with `cli: 'claude' as const` — a regression of the bug #1154 fixed elsewhere. Every pipeline-executed task (research / plan / vote / decompose / code_gen / review / security) was credited to claude regardless of which CLI actually ran. The bad data fed straight into weather-report and LinUCB cold-start `warmStart()` (composite-router.ts:353,374).

## Fix

1. **`ExpertBridgeResult.cli?: CliNameLiteral`** — the expert-bridge now resolves the actual CLI from `CliResponse.model` via the canonical `getCliForModelId` registry mapping. Guards against unknown model strings (returns `undefined` rather than fabricating a default).

2. **`recordOutcome(args: RecordOutcomeArgs)`** in `agent-executor.ts` — now takes an options bundle including `cli: CliNameLiteral | undefined`. When `cli` is undefined (bridge failed before dispatch, or non-CLI stage like local security scan / consensus vote), the helper **skips the record** rather than fabricating a wrong attribution. Stage events still emit; only the cli-attributed outcome that would poison the routing learner is suppressed.

3. **All 9 call sites updated** to thread `r.cli` (or `undefined` for non-CLI stages). Sub-call stages with multiple expert calls (research → discover + analyze) pick whichever sub-call actually reached a CLI.

4. **`recordPipelineOutcome` deleted entirely** in `adaptive-orchestrator.ts` — it duplicated the per-stage records, fabricated `cli: 'claude'` for pipeline-level data, hardcoded `category: 'code_generation'` regardless of classification, and had no downstream consumer.

## Tests

- 3 new regression cases in `agent-executor.test.ts`:
  - threaded cli (`gemini`) wins over any hardcoded value
  - `undefined cli` skips the record entirely (vs. fabricating)
  - per-stage distinct attribution (`codex` for decompose, `claude` for implement) propagates correctly
- All 719 pipeline + parser tests pass
- Typecheck + lint clean

## Related

- #1154 (closed): the original fix in `orchestrate.ts:222` / `execute-expert.ts:183`. This PR fixes the same bug class that re-appeared in the `pipeline/` tree.
- #2821 / PR #2825 (just merged): companion OIDC-publish-era fix to `cli-adapters/parsers/opencode-parser.ts` — error events now surface as failure instead of polluting consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)