### PR TITLE
fix(consensus): cascade math mirrors strategy denominator — wrong-winner with abstains (#2822)

### DIFF
--- a/.changeset/2822-consensus-cascade-denominator.md
+++ b/.changeset/2822-consensus-cascade-denominator.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+**Closes #2822.** fix(consensus): canCascadeEarly uses wrong denominator vs strategy — wrong-winner with abstains
+
+The agreement-based cascade in `ConsensusEngine.canCascadeEarly` computed approval rates against `totalExpected = requiredVoters.length` and compared against `VOTING_THRESHOLDS[algorithm]` directly. Every voting strategy (`SimpleMajorityStrategy`, `SupermajorityStrategy`, `UnanimousStrategy`, `ProofOfLearningStrategy`) uses `approve + reject` as its denominator — abstains explicitly excluded.
+
+Pre-fix concrete failure: 5-voter `supermajority` with `[approve, abstain, abstain, abstain, pending]`. Cascade computed max approval = `(1+1)/5 = 0.40 < 0.67` → cascade-reject. Strategy at close (last approves): 2 approve / 0 reject / 3 abstain → 2/2 = 1.0 ≥ 0.67 → APPROVE. Different winners. Cascade also used strict `>` while supermajority/unanimous strategies use `>=`, mismatching at the exact threshold.
+
+The fix delegates to the strategy itself: build a best-case (all pending voters approve) and worst-case (all pending voters reject) hypothetical vote map, call `strategy.calculateOutcome` on each, and cascade only when both extremes yield the same outcome. This guarantees parity with the strategy's denominator semantics and inequality operator by construction — including correct behavior for `higher_order`/`opinion_wise` (whose `IVotingStrategy.calculateOutcome` falls back to simple-vote aggregation; the Bayesian correlation path is invoked separately and is unaffected).
+
+Three new regression tests cover (a) supermajority + abstain wrong-winner scenario, (b) cascade-fires-early when both extremes agree (no abstain confusion), (c) supermajority `>=` boundary semantics. All 520 consensus tests pass; typecheck + lint clean.

--- a/packages/nexus-agents/src/consensus/agreement-cascade.test.ts
+++ b/packages/nexus-agents/src/consensus/agreement-cascade.test.ts
@@ -169,6 +169,99 @@ describe('Agreement-based cascading', () => {
     }
   });
 
+  // #2822 regression cases — pre-fix the cascade used `approvals / totalExpected`
+  // as its denominator while strategies use `approve + reject` (abstains
+  // excluded). With abstains present the two diverged.
+  it('respects strategy denominator with abstains in supermajority (#2822)', async () => {
+    // 5-voter supermajority with [approve, abstain, abstain, abstain, pending].
+    // Pre-fix: cascade computed max approval = (1+1)/5 = 0.40 < 0.67 → reject.
+    // Strategy at close (last approves): 2 approve / 0 reject / 3 abstain →
+    // votingVotes = 2 → 2/2 = 1.0 ≥ 0.67 → APPROVE. Different winners.
+    // Post-fix: cascade probes the strategy directly, sees that
+    // best-case (last approves) → approve and worst-case (last rejects) →
+    // reject, so it does NOT cascade — waits for the last voter.
+    const engine = new ConsensusEngine();
+    const result = await engine.propose({
+      title: 'Supermajority + abstains regression',
+      description: 'Cascade math must mirror strategy denominator (excludes abstains)',
+      algorithm: 'supermajority',
+      requiredVoters: ['a1', 'a2', 'a3', 'a4', 'a5'],
+    });
+    if (!result.ok) throw new Error('propose failed');
+    const pid = result.value;
+
+    await engine.vote(pid, 'a1', makeVote('approve'));
+    await engine.vote(pid, 'a2', makeVote('abstain'));
+    await engine.vote(pid, 'a3', makeVote('abstain'));
+    await engine.vote(pid, 'a4', makeVote('abstain'));
+
+    // Should still be pending — outcome hinges on a5
+    let outcome = await engine.getResult(pid);
+    if (!outcome.ok) throw new Error('getResult failed');
+    expect(outcome.value.voteCounts.total).toBe(4); // not closed early
+
+    // Last voter approves → strategy approves (2 approve / 0 reject = 100%)
+    await engine.vote(pid, 'a5', makeVote('approve'));
+    outcome = await engine.getResult(pid);
+    if (!outcome.ok) throw new Error('getResult failed');
+    expect(outcome.value.outcome).toBe('approved');
+  });
+
+  it('cascades early when both extremes yield the same outcome with abstains (#2822)', async () => {
+    // 5-voter simple_majority. After [approve, approve, approve] (with a4, a5
+    // pending) the strategy probes show: best-case (both approve) → 5/5 → approve;
+    // worst-case (both reject) → 3 approve / 2 reject = 3/5 = 60% > 50% → approve.
+    // Both extremes approve → cascade-approve at the 3rd vote. Abstains added
+    // later don't change anything since strategies exclude them from the
+    // denominator. The abstain case is set up to confirm cascade works post-#2822
+    // without the wrong-denominator regression.
+    const engine = new ConsensusEngine();
+    const result = await engine.propose({
+      title: 'Cascade with abstain — both extremes agree',
+      description: 'Strategy probes confirm approval regardless of remaining votes',
+      algorithm: 'simple_majority',
+      requiredVoters: ['a1', 'a2', 'a3', 'a4', 'a5'],
+    });
+    if (!result.ok) throw new Error('propose failed');
+    const pid = result.value;
+
+    await engine.vote(pid, 'a1', makeVote('approve'));
+    await engine.vote(pid, 'a2', makeVote('approve'));
+    await engine.vote(pid, 'a3', makeVote('approve'));
+
+    // Should cascade-approve at vote 3 — both extremes for a4/a5 yield approve
+    const outcome = await engine.getResult(pid);
+    if (!outcome.ok) throw new Error('getResult failed');
+    expect(outcome.value.outcome).toBe('approved');
+    expect(outcome.value.voteCounts.total).toBe(3);
+  });
+
+  it('matches supermajority `>=` boundary semantics (#2822)', async () => {
+    // 3-voter supermajority where the strategy uses `>=` (strategies.ts:158).
+    // Votes: 2 approve + 1 pending. Best-case (last approves): 3/3 = 100% → approve.
+    // Worst-case (last rejects): 2/3 = 66.67% → strategy `>= 0.67` is FALSE
+    // (2/3 ≈ 0.6667, threshold is exactly 0.67) → reject. Different outcomes,
+    // so cascade should NOT fire. Pre-#2822 used strict `>` so could have
+    // disagreed; now we delegate so we get strategy semantics by construction.
+    const engine = new ConsensusEngine();
+    const result = await engine.propose({
+      title: 'Supermajority boundary check',
+      description: 'Cascade decision must match the strategy at the threshold',
+      algorithm: 'supermajority',
+      requiredVoters: ['a1', 'a2', 'a3'],
+    });
+    if (!result.ok) throw new Error('propose failed');
+    const pid = result.value;
+
+    await engine.vote(pid, 'a1', makeVote('approve'));
+    await engine.vote(pid, 'a2', makeVote('approve'));
+
+    // Best/worst disagree at this threshold — must NOT cascade
+    const outcome = await engine.getResult(pid);
+    if (!outcome.ok) throw new Error('getResult failed');
+    expect(outcome.value.voteCounts.total).toBe(2); // still open
+  });
+
   it('does not cascade when no requiredVoters are set', async () => {
     const engine = new ConsensusEngine();
     const result = await engine.propose({

--- a/packages/nexus-agents/src/consensus/engine.ts
+++ b/packages/nexus-agents/src/consensus/engine.ts
@@ -80,6 +80,24 @@ interface ProposalCacheEntry {
  * Default proposal cache configuration.
  * Enabled by default to improve determinism (fitness audit recommendation).
  */
+/**
+ * Hypothetical-vote stand-ins used by {@link ConsensusEngine.canCascadeEarly}
+ * to probe the strategy's outcome under best/worst-case pending votes.
+ * The actual `confidence` and `reasoning` fields are never inspected by
+ * `IVotingStrategy.calculateOutcome` (all strategies count by `decision`),
+ * but must satisfy `VoteSchema` (confidence in [0,1], reasoning non-empty).
+ */
+const HYPOTHETICAL_APPROVE: Vote = {
+  decision: 'approve',
+  confidence: 0.5,
+  reasoning: 'hypothetical-cascade-probe',
+};
+const HYPOTHETICAL_REJECT: Vote = {
+  decision: 'reject',
+  confidence: 0.5,
+  reasoning: 'hypothetical-cascade-probe',
+};
+
 const DEFAULT_PROPOSAL_CACHE_CONFIG: ProposalCacheConfig = {
   enabled: true,
   ttlMs: 3600000, // 1 hour
@@ -432,55 +450,53 @@ export class ConsensusEngine implements IConsensusEngine {
 
   /**
    * Agreement-based cascading: close early when outcome is mathematically determined.
-   * If approvals already exceed the threshold even if all remaining voters reject,
-   * or rejections make approval impossible, the proposal can be decided early.
+   *
+   * #2822: the prior implementation computed approval rates against
+   * `totalExpected = requiredVoters.length` and compared against
+   * `VOTING_THRESHOLDS[algorithm]` directly. Every voting strategy
+   * (`SimpleMajorityStrategy`, `SupermajorityStrategy`, `UnanimousStrategy`,
+   * `ProofOfLearningStrategy`) uses `approve + reject` as its denominator —
+   * abstains are explicitly excluded. The two diverged whenever abstains
+   * were present, producing wrong-winner cascades (e.g. 5-voter supermajority
+   * with [approve, abstain, abstain, abstain, pending] cascade-rejected even
+   * though the strategy would approve at close).
+   *
+   * The fix delegates to the strategy itself: build a best-case (all pending
+   * voters approve) and worst-case (all pending voters reject) hypothetical
+   * vote map, call `strategy.calculateOutcome` on each, and cascade only
+   * when both extremes yield the same outcome. This guarantees parity with
+   * the strategy's denominator semantics by construction.
    */
   private canCascadeEarly(state: ProposalState): boolean {
     const required = state.proposal.requiredVoters;
     if (required === undefined || required.length === 0) return false;
+    if (state.votes.size === 0) return false;
 
-    const totalExpected = required.length;
-    const votesCast = state.votes.size;
-    const remaining = totalExpected - votesCast;
-    if (remaining <= 0) return false; // All voted — handled by allRequiredVotersVoted
+    const pending = required.filter((voter) => !state.votes.has(voter));
+    if (pending.length === 0) return false; // All voted — handled by allRequiredVotersVoted
 
-    const threshold = VOTING_THRESHOLDS[state.proposal.algorithm];
+    const strategy = this.strategyFactory.getStrategy(state.proposal.algorithm);
 
-    let approvals = 0;
-    let rejections = 0;
-    for (const vote of state.votes.values()) {
-      if (vote.decision === 'approve') approvals++;
-      else if (vote.decision === 'reject') rejections++;
+    const bestCase = new Map<string, Vote>(state.votes);
+    const worstCase = new Map<string, Vote>(state.votes);
+    for (const voter of pending) {
+      bestCase.set(voter, HYPOTHETICAL_APPROVE);
+      worstCase.set(voter, HYPOTHETICAL_REJECT);
     }
 
-    // Can approve even if all remaining reject?
-    const minApprovalRate = approvals / totalExpected;
-    if (minApprovalRate > threshold) {
-      this.logger.info('Agreement cascade: early approval', {
-        proposalId: state.proposal.id,
-        approvals,
-        totalExpected,
-        threshold,
-        remaining,
-      });
-      return true;
-    }
+    const bestOutcome = strategy.calculateOutcome(bestCase, state.voteWeights);
+    const worstOutcome = strategy.calculateOutcome(worstCase, state.voteWeights);
 
-    // Can never reach threshold even if all remaining approve?
-    const maxPossibleApprovals = approvals + remaining;
-    const maxApprovalRate = maxPossibleApprovals / totalExpected;
-    if (maxApprovalRate < threshold) {
-      this.logger.info('Agreement cascade: early rejection', {
-        proposalId: state.proposal.id,
-        rejections,
-        totalExpected,
-        threshold,
-        remaining,
-      });
-      return true;
-    }
+    if (bestOutcome.approved !== worstOutcome.approved) return false;
 
-    return false;
+    this.logger.info('Agreement cascade: outcome determined', {
+      proposalId: state.proposal.id,
+      outcome: bestOutcome.approved ? 'approve' : 'reject',
+      votesCast: state.votes.size,
+      pending: pending.length,
+      algorithm: state.proposal.algorithm,
+    });
+    return true;
   }
 
   private allRequiredVotersVoted(state: ProposalState): boolean {


### PR DESCRIPTION
## Summary

**Closes #2822.** The agreement-based cascade in `ConsensusEngine.canCascadeEarly` computed approval rates against `totalExpected = requiredVoters.length` and compared against `VOTING_THRESHOLDS[algorithm]` directly. Every voting strategy uses `approve + reject` as its denominator — abstains explicitly excluded. With abstains present, cascade and strategy diverged on the winner.

## Concrete wrong-winner case

5-voter `supermajority` with `[approve, abstain, abstain, abstain, pending]`:

- **Cascade math (pre-fix):** max approval = `(1+1)/5 = 0.40 < 0.67` → cascade-reject early.
- **Strategy at close (if last approves):** 2 approve / 0 reject / 3 abstain → 2/2 = 1.0 ≥ 0.67 → APPROVE.

Different winners. Cascade fires every `vote()` call (engine.ts:199), so this is on the hot path.

Also: pre-fix cascade used strict `>` while `SupermajorityStrategy`/`UnanimousStrategy` use `>=` (strategies.ts:158,196). Boundary mismatch.

## Fix

Delegate to the strategy:

1. Build best-case (all pending voters approve) and worst-case (all pending voters reject) hypothetical vote maps
2. Call `strategy.calculateOutcome` on each
3. Cascade only when both extremes yield the same outcome

This guarantees parity with the strategy's denominator semantics and inequality operator by construction. Higher-order/opinion-wise `IVotingStrategy.calculateOutcome` falls back to simple-vote aggregation (the Bayesian correlation path is invoked separately via `aggregateWithCorrelation`), so this approach is sound for all algorithms.

## Tests

- 3 new regression cases in `agreement-cascade.test.ts`:
  - **supermajority + abstain wrong-winner** — verifies cascade no longer fires when abstains would mislead it
  - **cascade-fires-early when both extremes agree** — verifies cascade still works for genuine deterministic cases
  - **supermajority `>=` boundary semantics** — verifies cascade matches strategy at the threshold
- All 7 pre-existing cascade tests still pass
- All 520 consensus tests + typecheck + lint clean

## Related

- #2821 (closed via PR #2825)
- #2823 (closed via PR #2827)
- #2824 (tracking epic) — P1/P2 bundle includes a follow-up on `engine.ts:443` (votesCast counts non-required voters) and the cascade race at `engine.ts:204-210`

🤖 Generated with [Claude Code](https://claude.com/claude-code)