### PR TITLE
fix(adapters): cleanup tempdir parent, not just file (#2824 bullet)

### DIFF
--- a/.changeset/eval-adapter-tempdir-leak.md
+++ b/.changeset/eval-adapter-tempdir-leak.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**Closes one bullet of #2824.** fix(adapters/codex,gemini): cleanup removes the tempdir parent, not just the file
+
+`CodexCliAdapter.getCommand` and `GeminiCliAdapter.getCommand` created a `mkdtempSync` tempdir per call when a `systemPrompt` was provided, dropped an `instructions.md`/`policy.md` into it, then on cleanup unlinked only the file. The empty `/tmp/nexus-codex-sysprompt-XXXXXX` and `/tmp/nexus-gemini-sysprompt-XXXXXX` parent dirs were leaked, waiting for the OS reaper.
+
+Long-running MCP daemons and CI workers that fan out many subagent calls accumulated thousands of empty dirs, eventually hitting inode/disk limits. Fix is one-line per adapter: switch `unlinkSync(file)` → `rmSync(dir, { recursive: true, force: true })`.
+
+Two new regression tests cover the post-cleanup state — both the file AND parent dir must be gone. Pre-fix only the file was unlinked.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
@@ -350,6 +350,39 @@ describe('CodexCliAdapter (Subprocess)', () => {
       expect(cVal).toMatch(/^model_instructions_file=.+instructions\.md$/);
     });
 
+    it('cleans up tempdir parent after systemPrompt run (#2824 — file + dir, not just file)', async () => {
+      const ndjsonResponse = [
+        JSON.stringify({ type: 'thread.started', thread_id: 'thread-tempdir' }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: { id: 'item-1', type: 'agent_message', text: 'ok' },
+        }),
+        JSON.stringify({ type: 'turn.completed' }),
+      ].join('\n');
+      const mockProcess = createMockProcess(ndjsonResponse);
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      const task: CliTask = {
+        content: 'whatever',
+        systemPrompt: 'You are a strict reviewer.',
+      };
+      await adapter.execute(task);
+
+      // Locate the tempdir from the spawned args, then confirm BOTH the
+      // file AND the parent dir are gone post-cleanup. Pre-fix the file
+      // was unlinked but the empty parent dir was leaked.
+      const args = vi.mocked(spawn).mock.calls.at(-1)?.[1] as string[];
+      const cIdx = args.indexOf('-c');
+      const cVal = args[cIdx + 1] as string;
+      const match = cVal.match(/^model_instructions_file=(.+\/instructions\.md)$/);
+      expect(match).not.toBeNull();
+      const file = match![1] as string;
+      const dir = file.replace(/\/instructions\.md$/, '');
+      const { existsSync } = await import('node:fs');
+      expect(existsSync(file)).toBe(false);
+      expect(existsSync(dir)).toBe(false);
+    });
+
     it('omits -c model_instructions_file when systemPrompt is empty', async () => {
       const ndjsonResponse = [
         JSON.stringify({ type: 'thread.started', thread_id: 'thread-123' }),

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.ts
@@ -12,7 +12,7 @@
  * User task content is passed as a single argv element (no shell interpolation).
  */
 
-import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type {
@@ -105,8 +105,12 @@ export class CodexCliAdapter extends SubprocessCliAdapter {
       writeFileSync(file, task.systemPrompt, { encoding: 'utf8', mode: 0o600 });
       args.push('-c', `model_instructions_file=${file}`);
       cleanup = (): void => {
+        // Recursive rm so we drop the parent tempdir, not just the file
+        // inside it. Pre-fix every codex call with a systemPrompt leaked
+        // one empty `/tmp/nexus-codex-sysprompt-XXXXXX` dir until the OS
+        // reaper ran — exhausting inodes on long-running MCP daemons.
         try {
-          unlinkSync(file);
+          rmSync(dir, { recursive: true, force: true });
         } catch {
           // best-effort; tempdir auto-cleanup will eventually reap it
         }

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
@@ -246,6 +246,29 @@ describe('GeminiCliAdapter systemPrompt (#1886)', () => {
     expect(cmd.args).not.toContain('--policy');
     expect(cmd.cleanup).toBeUndefined();
   });
+
+  it('cleanup removes parent tempdir, not just file (#2824)', async () => {
+    const adapter = new GeminiCliAdapter();
+    const cmd = (
+      adapter as unknown as { getCommand: (t: unknown) => { args: string[]; cleanup?: () => void } }
+    ).getCommand({ content: 'test prompt', systemPrompt: 'You are strict.' });
+    const policyIdx = cmd.args.indexOf('--policy');
+    const file = cmd.args[policyIdx + 1] as string;
+    const dir = file.replace(/\/policy\.md$/, '');
+
+    // Sanity check pre-cleanup
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(file)).toBe(true);
+    expect(existsSync(dir)).toBe(true);
+
+    if (cmd.cleanup !== undefined) cmd.cleanup();
+
+    // Post-cleanup: both file AND parent tempdir gone. Pre-fix only the
+    // file was unlinked, leaking an empty `nexus-gemini-sysprompt-XXXXXX`
+    // dir on every call.
+    expect(existsSync(file)).toBe(false);
+    expect(existsSync(dir)).toBe(false);
+  });
 });
 
 describe('GeminiCliAdapter resilient parsing', () => {

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -12,7 +12,7 @@
  * (Source: Issue #389 - Merged enhanced adapter back to canonical)
  */
 
-import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Result, ILogger } from '../../core/index.js';
@@ -229,8 +229,12 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
       writeFileSync(file, task.systemPrompt, { encoding: 'utf8', mode: 0o600 });
       args.push('--policy', file);
       cleanup = (): void => {
+        // Recursive rm so we drop the parent tempdir, not just the file
+        // inside it. Pre-fix every gemini call with a systemPrompt leaked
+        // one empty `/tmp/nexus-gemini-sysprompt-XXXXXX` dir until the OS
+        // reaper ran.
         try {
-          unlinkSync(file);
+          rmSync(dir, { recursive: true, force: true });
         } catch {
           // best-effort; tempdir auto-cleanup will eventually reap it
         }


### PR DESCRIPTION
## Summary

Closes one P1 bullet of the #2824 tracking epic. `CodexCliAdapter.getCommand` and `GeminiCliAdapter.getCommand` were leaking empty tempdirs:

```ts
const dir = mkdtempSync(join(tmpdir(), 'nexus-codex-sysprompt-'));
const file = join(dir, 'instructions.md');
// ...
cleanup = () => unlinkSync(file);  // file gone, dir stays
```

Long-running MCP daemons and fan-out CI workers accumulated thousands of empty `/tmp/nexus-{codex,gemini}-sysprompt-XXXXXX` dirs. Eventually hits inode/disk limits.

## Fix

One-line per adapter: `unlinkSync(file)` → `rmSync(dir, { recursive: true, force: true })`.

## Tests

Two new regression tests (one per adapter) assert that **both** the file AND the parent tempdir are gone after `cleanup()` runs. Sanity-checked pre-cleanup state too.

All 59 codex+gemini adapter tests pass. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)