### PR TITLE
fix(routing): cold-start warmStart filters e2e-eval outcomes (#2824 bullet)

### DIFF
--- a/.changeset/composite-router-cold-start-filter.md
+++ b/.changeset/composite-router-cold-start-filter.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**Closes one bullet of #2824.** fix(routing): cold-start LinUCB warmStart ingests e2e-eval outcomes
+
+`CompositeRouter.initializeLinucbBandit` has two `getOutcomeStore().query()` paths:
+
+- 30-day lookback (composite-router.ts:353) — already filters `excludeQualitySignals: ['e2e-eval']` to keep synthetic test outcomes out of the routing learner
+- Cold-start fallback (composite-router.ts:374) — pre-fix queried with **no filter**, replaying any e2e-eval outcomes that survived from prior test runs into LinUCB
+
+The cold-start path activated on fresh checkouts against an existing `nexus-data/` directory, or after restarts where the 30-day window happened to be empty. A handful of e2e-eval rows could measurably skew early routing decisions.
+
+One-line fix: mirror the 30-day filter on line 374. No new tests — existing 248 composite-router tests still pass.

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -371,7 +371,12 @@ export class CompositeRouter implements ICompositeRouter {
       if (replayed === 0) {
         const result = runWarmUp(this.logger);
         if (!result.skipped) {
-          const outcomes = getOutcomeStore().query();
+          // Mirror the 30-day path's filter (#2824 bullet) — pre-fix this
+          // cold-start fallback queried with no filter, replaying any
+          // e2e-eval synthetic outcomes that survived from prior test
+          // runs into LinUCB. The 30-day branch above carefully excludes
+          // them; the fallback didn't.
+          const outcomes = getOutcomeStore().query({ excludeQualitySignals: ['e2e-eval'] });
           this.linucbBandit.warmStart(outcomes);
         }
         this.logger.info('LinUCB cold-start seeded from specialization matrix', {


### PR DESCRIPTION
## Summary

Closes one P1 bullet of the #2824 tracking epic. `CompositeRouter.initializeLinucbBandit` has two `getOutcomeStore().query()` paths:

| Path | Filter (pre-fix) | Behavior |
|---|---|---|
| 30-day lookback (line 353) | `excludeQualitySignals: ['e2e-eval']` | ✅ correct |
| Cold-start fallback (line 374) | **none** | ❌ replays e2e-eval outcomes into LinUCB |

The cold-start path activates on fresh checkouts against an existing `nexus-data/` directory, or after restarts where the 30-day window happens to be empty. A handful of e2e-eval rows could measurably skew early routing decisions.

One-line fix: mirror the 30-day filter on line 374.

## Tests

All 248 composite-router tests pass; typecheck clean. No new tests — the bug surface (different query filters between two branches) is now uniform and would be caught by any test that exercises the cold-start path with e2e-eval rows in the OutcomeStore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)