### PR TITLE
fix(docs): correct count drift (closes #2840)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ repo-health-report/
 tsundoku/
 .doc-review-cursor
 .claude/scheduled_tasks.lock
+
+# Ephemeral worktrees from agent runs
+.claude/worktrees/

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,7 +20,7 @@ gh search repos --owner williamzujkowski --topic nexus-agents-companion
 
 ## Test Projects (`nexus-agents-test`)
 
-Each exercises a specific subset of the 30 MCP tools end-to-end. Intended as regression harness — if a tool's contract changes, the corresponding test repo should fail.
+Each exercises a specific subset of the 38 MCP tools end-to-end. Intended as regression harness — if a tool's contract changes, the corresponding test repo should fail.
 
 | Repo                                                                         | Tools Under Test                                                                          | Description                                              |
 | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ keywords: [documentation, index, reference, navigation, docs]
 
 # Nexus Agents Documentation
 
-**Canonical Documentation Index** | Last Updated: 2026-04-17 (18 skills, 30 MCP tools, 11 expert types, 11 workflow templates)
+**Canonical Documentation Index** | Last Updated: 2026-05-18 (31 skills, 38 MCP tools, 11 expert types, 11 workflow templates)
 
 This is the **single source of truth** for all nexus-agents documentation. All documentation must be indexed here to be considered valid.
 

--- a/docs/distribution/LISTING_SUBMISSIONS.md
+++ b/docs/distribution/LISTING_SUBMISSIONS.md
@@ -10,7 +10,7 @@ Intelligent orchestration platform for AI coding tools — routes tasks to the b
 
 ### Medium Description (for directories)
 
-nexus-agents makes your AI coding tools work together intelligently. It coordinates Claude, Codex, Gemini, and OpenCode — routing each task to the best model using data-driven algorithms (LinUCB bandit, TOPSIS scoring), validating outputs through multi-model consensus voting, and continuously improving through outcome-driven learning. 30 MCP tools, 5 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.
+nexus-agents makes your AI coding tools work together intelligently. It coordinates Claude, Codex, Gemini, and OpenCode — routing each task to the best model using data-driven algorithms (LinUCB bandit, TOPSIS scoring), validating outputs through multi-model consensus voting, and continuously improving through outcome-driven learning. 38 MCP tools, 8 memory backends, full dev pipeline with research/plan/vote/implement/QA stages.
 
 ### Awesome List Entry
 

--- a/docs/distribution/PUBLISHING_GUIDE.md
+++ b/docs/distribution/PUBLISHING_GUIDE.md
@@ -30,7 +30,7 @@ Fill in:
 
 - **Name:** nexus-agents
 - **Repository:** https://github.com/nexus-substrate/nexus-agents
-- **Description:** Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 30 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.
+- **Description:** Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus. 38 MCP tools for agent management, research, memory, consensus voting, codebase intelligence, and a full dev pipeline.
 
 The `.claude-plugin/plugin.json` is already in the repo root.
 
@@ -59,7 +59,7 @@ Visit: https://mcpservers.org/submit
 Fill in:
 
 - **Server Name:** nexus-agents
-- **Short Description:** Intelligent orchestration platform that routes tasks to the best AI model using LinUCB bandits, validates through consensus voting, and learns from outcomes. 30 MCP tools, dev pipeline, 5 memory backends.
+- **Short Description:** Intelligent orchestration platform that routes tasks to the best AI model using LinUCB bandits, validates through consensus voting, and learns from outcomes. 38 MCP tools, dev pipeline, 8 memory backends.
 - **Link:** https://github.com/nexus-substrate/nexus-agents
 - **Category:** Development
 - **Contact Email:** williamzujkowski@gmail.com

--- a/docs/v2/00-executive-summary.md
+++ b/docs/v2/00-executive-summary.md
@@ -6,7 +6,7 @@ _Nexus Agents reviewing Nexus Agents. No marketing. Evidence-backed._
 
 ## What Nexus Agents Is Today
 
-An intelligent orchestration platform for AI coding tools (650+ source files, 900+ test files) that coordinates Claude, Gemini, Codex, and OpenCode CLIs via 30 MCP tools. It routes tasks to the best model using data-driven algorithms (LinUCB bandit, TOPSIS), validates through multi-model consensus, and learns from outcomes across sessions. Users can orchestrate tasks, run consensus votes, execute a full dev pipeline (research→plan→vote→implement→QA), and run graph workflows.
+An intelligent orchestration platform for AI coding tools (650+ source files, 900+ test files) that coordinates Claude, Gemini, Codex, and OpenCode CLIs via 38 MCP tools. It routes tasks to the best model using data-driven algorithms (LinUCB bandit, TOPSIS), validates through multi-model consensus, and learns from outcomes across sessions. Users can orchestrate tasks, run consensus votes, execute a full dev pipeline (research→plan→vote→implement→QA), and run graph workflows.
 
 ## What's Wrong
 


### PR DESCRIPTION
Closes #2840. Surgical fix; the systemic drift-prevention extension to `governance:inject` is out of scope here and will be filed as a follow-up.

## Fixes

5 docs had stale counts. All now agree with canonical sources (`site-data.ts`, `CLAUDE.md` auto-gen, `/agents/*.md`):

| Doc | Was | Now |
|---|---|---|
| `docs/README.md` | 18 skills, 30 MCP tools | 31 / 38 |
| `ECOSYSTEM.md` | 30 MCP tools | 38 |
| `docs/distribution/LISTING_SUBMISSIONS.md` | 30 MCP tools, 5 memory backends | 38 / 8 |
| `docs/distribution/PUBLISHING_GUIDE.md` (×2) | 30 MCP tools / 5 memory backends | 38 / 8 |
| `docs/v2/00-executive-summary.md` | 30 MCP tools | 38 |

Also added `.claude/worktrees/` to .gitignore (ephemeral agent worktrees were not previously ignored).

## Intentionally untouched

- `docs/archive/` historical docs that document past drift on purpose
- `docs/getting-started/PLUGIN_INSTALL.md` already correct
- The 12 in 'agent mirrors' is correct — matches `ls agents/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)