### PR TITLE
chore(docs): move SANDBOXED-USAGE to guides; demote CLAUDE.md from user surfaces (closes #2844, #2846)

### DIFF
--- a/.changeset/sandboxed-usage-path-update.md
+++ b/.changeset/sandboxed-usage-path-update.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**Closes #2844 and #2846.** docs: relocate SANDBOXED-USAGE.md to docs/guides/; demote CLAUDE.md from new-user surfaces
+
+`docs/getting-started/SANDBOXED-USAGE.md` moves to `docs/guides/` (it's ops material, not new-user onboarding). The runtime messages in `cli-server-gateway.ts`, `portable-mode.ts`, and `sandbox-factory.ts` were updated to print the new path so the auto-detected portable-mode banner and the sandbox-factory error message both point to the file's new home.
+
+No behavior change; only the printed string changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Most-used env vars:
 | `NEXUS_ACCESS_POLICY_MODE`                                                          | ClawGuard: `off` / `audit` (default) / `confirm_risky` / `enforce`.      |
 | `NEXUS_SANDBOX` / `NEXUS_SANDBOX_ROOT`                                              | Sandbox mode (epic #2500).                                               |
 
-Full list in [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md). Install: [INSTALLATION.md](./docs/getting-started/INSTALLATION.md). Sandboxed: [SANDBOXED-USAGE.md](./docs/getting-started/SANDBOXED-USAGE.md).
+Full list in [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md). Install: [INSTALLATION.md](./docs/getting-started/INSTALLATION.md). Sandboxed: [SANDBOXED-USAGE.md](./docs/guides/SANDBOXED-USAGE.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,12 +15,13 @@ This is the **single source of truth** for all nexus-agents documentation. All d
 
 ## Quick Start by Role
 
-| Role               | Start Here                         | Then Read                                           |
-| ------------------ | ---------------------------------- | --------------------------------------------------- |
-| **New User**       | [Quick Start](../QUICK_START.md)   | [Installation](./getting-started/INSTALLATION.md)   |
-| **Contributor**    | [Contributing](../CONTRIBUTING.md) | [Development Guide](./development/README.md)        |
-| **Operator**       | [ENTRYPOINTS.md](./ENTRYPOINTS.md) | [Configuration](./getting-started/CONFIGURATION.md) |
-| **Agent (Claude)** | [CLAUDE.md](../CLAUDE.md)          | This index                                          |
+| Role            | Start Here                         | Then Read                                           |
+| --------------- | ---------------------------------- | --------------------------------------------------- |
+| **New User**    | [Quick Start](../QUICK_START.md)   | [Installation](./getting-started/INSTALLATION.md)   |
+| **Contributor** | [Contributing](../CONTRIBUTING.md) | [Development Guide](./development/README.md)        |
+| **Operator**    | [ENTRYPOINTS.md](./ENTRYPOINTS.md) | [Configuration](./getting-started/CONFIGURATION.md) |
+
+> **AI agents working in this repo** (Claude Code, Cursor, etc.) — see [CLAUDE.md](../CLAUDE.md) for project instructions, governance protocols, and canonical paths. CLAUDE.md is the rule book the agents follow, not a user-facing surface.
 
 ---
 
@@ -68,12 +69,12 @@ Detailed technical documentation:
 
 #### Getting Started
 
-| Document                                                   | Description                                      | Status    |
-| ---------------------------------------------------------- | ------------------------------------------------ | --------- |
-| [INSTALLATION.md](./getting-started/INSTALLATION.md)       | Platform installation guide                      | Canonical |
-| [CONFIGURATION.md](./getting-started/CONFIGURATION.md)     | YAML and env configuration                       | Canonical |
-| [PLUGIN_INSTALL.md](./getting-started/PLUGIN_INSTALL.md)   | Install nexus-agents as a Claude Code plugin     | Canonical |
-| [SANDBOXED-USAGE.md](./getting-started/SANDBOXED-USAGE.md) | Docker / restricted-FS / team-distribution flows | Canonical |
+| Document                                                 | Description                                      | Status    |
+| -------------------------------------------------------- | ------------------------------------------------ | --------- |
+| [INSTALLATION.md](./getting-started/INSTALLATION.md)     | Platform installation guide                      | Canonical |
+| [CONFIGURATION.md](./getting-started/CONFIGURATION.md)   | YAML and env configuration                       | Canonical |
+| [PLUGIN_INSTALL.md](./getting-started/PLUGIN_INSTALL.md) | Install nexus-agents as a Claude Code plugin     | Canonical |
+| [SANDBOXED-USAGE.md](./guides/SANDBOXED-USAGE.md)        | Docker / restricted-FS / team-distribution flows | Canonical |
 
 #### Architecture
 

--- a/docs/architecture/SECURITY.md
+++ b/docs/architecture/SECURITY.md
@@ -164,7 +164,7 @@ All agent-executed code runs through the sandbox system.
 
 ### Real isolation: out-of-process via OpenCode sandbox bootstrap (#2500)
 
-Nexus-agents is **sandbox-compatible, not a sandbox-builder**. The in-process Docker / Deno executors were deleted in [#2551](https://github.com/nexus-substrate/nexus-agents/issues/2551) — they were dead code masquerading as security boundary. For real isolation, set the `NEXUS_SANDBOX` environment variable and run nexus-agents inside an OpenCode-managed Docker sandbox; see [docs/getting-started/SANDBOXED-USAGE.md](../getting-started/SANDBOXED-USAGE.md).
+Nexus-agents is **sandbox-compatible, not a sandbox-builder**. The in-process Docker / Deno executors were deleted in [#2551](https://github.com/nexus-substrate/nexus-agents/issues/2551) — they were dead code masquerading as security boundary. For real isolation, set the `NEXUS_SANDBOX` environment variable and run nexus-agents inside an OpenCode-managed Docker sandbox; see [docs/guides/SANDBOXED-USAGE.md](../guides/SANDBOXED-USAGE.md).
 
 The `container` and `deno` modes are kept in the `SandboxMode` config union so existing config files don't fail validation, but the factory resolves both to `policy` mode at runtime with a warning. New deployments wanting container-level isolation should use the OpenCode bootstrap.
 

--- a/docs/guides/SANDBOXED-USAGE.md
+++ b/docs/guides/SANDBOXED-USAGE.md
@@ -30,7 +30,7 @@ Inside most container / sandbox environments, **nexus-agents auto-detects and an
 
 ```text
 [portable-mode] Sandbox detected (container-env). Using /work/.nexus-agents for all nexus-agents data.
-                Set NEXUS_PORTABLE_MODE=0 to override; see docs/getting-started/SANDBOXED-USAGE.md
+                Set NEXUS_PORTABLE_MODE=0 to override; see docs/guides/SANDBOXED-USAGE.md
 ```
 
 If you see this on stderr, the auto-detection worked and your nexus-agents data lives in `<cwd>/.nexus-agents/`. No action needed.

--- a/packages/nexus-agents/src/cli-server-gateway.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.ts
@@ -74,7 +74,7 @@ function handleMissingEnv(logger: ILogger, sandboxActive: boolean): void {
     logger.error(
       'Sandbox mode active but NEXUS_OPENAI_COMPAT_URL / NEXUS_OPENAI_COMPAT_KEY are not set. ' +
         'Configure the gateway in your launch env or opencode.json. ' +
-        'See docs/getting-started/SANDBOXED-USAGE.md.',
+        'See docs/guides/SANDBOXED-USAGE.md.',
       new Error('Missing gateway configuration in sandbox mode')
     );
     process.exit(EXIT_CODES.SERVER_START_FAILED);

--- a/packages/nexus-agents/src/config/portable-mode.ts
+++ b/packages/nexus-agents/src/config/portable-mode.ts
@@ -133,7 +133,7 @@ export function applyPortableMode(cwd: string = process.cwd()): void {
   if (result.reason === 'home-unwritable' || result.reason === 'container-env') {
     process.stderr.write(
       `[portable-mode] Sandbox detected (${result.reason}). Using ${result.dataDir} for all nexus-agents data.\n` +
-        `                Set NEXUS_PORTABLE_MODE=0 to override; see docs/getting-started/SANDBOXED-USAGE.md\n`
+        `                Set NEXUS_PORTABLE_MODE=0 to override; see docs/guides/SANDBOXED-USAGE.md\n`
     );
   }
 

--- a/packages/nexus-agents/src/security/sandbox/sandbox-factory.ts
+++ b/packages/nexus-agents/src/security/sandbox/sandbox-factory.ts
@@ -132,7 +132,7 @@ function createDeprecatedModeFallback(
     requestedMode,
     actualMode: 'policy',
     reason:
-      'In-process Docker/Deno executors were deleted in #2551. Use the OpenCode sandbox bootstrap for real isolation (NEXUS_SANDBOX environment variable, see docs/getting-started/SANDBOXED-USAGE.md).',
+      'In-process Docker/Deno executors were deleted in #2551. Use the OpenCode sandbox bootstrap for real isolation (NEXUS_SANDBOX environment variable, see docs/guides/SANDBOXED-USAGE.md).',
   });
 
   const executor = new PolicySandboxExecutor(policyConfig);


### PR DESCRIPTION
Two small backlog items from epic #2837.

## #2844 — relocate `SANDBOXED-USAGE.md`

Moved from `docs/getting-started/` to `docs/guides/`. It's ops material (Docker / restricted-FS / OpenCode bootstrap), not new-user onboarding. New users in install mode shouldn't trip over OpenCode-in-Docker key-proxy architecture.

Updated 6 references — 3 source files (`cli-server-gateway`, `portable-mode`, `sandbox-factory`) where the runtime prints the path, 2 docs (`docs/README`, `architecture/SECURITY`), and the file's own self-reference inside its 'portable-mode auto-detect' code-block sample.

## #2846 — demote CLAUDE.md from new-user surfaces

`docs/README.md`'s 'Quick Start by Role' table previously listed CLAUDE.md under 'Agent (Claude)' alongside New User / Contributor / Operator. CLAUDE.md is project instructions for AI agents working IN this repo, not for humans evaluating the project. Moved it to a callout below the table that names its actual audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)