### PR TITLE
docs: README 60-sec smoke + setup table + ENTRYPOINTS persona grouping (closes #2842, #2847, #2848)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,70 @@ See [docs/getting-started/PLUGIN_INSTALL.md](docs/getting-started/PLUGIN_INSTALL
 nexus-agents doctor
 ```
 
-### 3. Use
+Prints a health table — Node version, configured CLIs (claude / codex / gemini / opencode), API keys missing vs present. Read-only; safe to run any time.
 
-**With Claude Code (recommended):**
+### 3. See what success looks like (60-second smoke task — no API keys needed)
 
 ```bash
-nexus-agents setup   # Auto-configures MCP server
+nexus-agents vote --quick --proposal "Use SQLite over JSON files for the outcome store"
 ```
 
-Then in Claude: `"orchestrate: Review this PR for issues"`
+You should see:
 
-**Standalone CLI:**
+```
+Nexus Agents Consensus Vote
+============================
+
+Collecting votes from 3 agents (timeout: 60s each)...
+
+Proposal: Use SQLite over JSON files for the outcome store
+
+Votes
+
+  ✓ Software Architect: APPROVE (86%)
+  ✓ Security Engineer:  APPROVE (74%)
+  ✓ Scope Steward:      APPROVE (91%)
+
+Summary
+
+  Approve:  3
+  Reject:   0
+  Abstain:  0
+  Approval: 100.0%
+  Threshold: simple_majority
+
+Result: APPROVED
+
+Completed in ~30s
+```
+
+Three voter roles deliberate via whichever local CLIs you have (Claude, Codex, Gemini) — no API keys required. Per-voter reasoning is recorded; the terminal prints the verdict. Mixed outcomes (some approve / some reject) and graceful error handling are demonstrated on the [project site hero](https://nexus-substrate.github.io/nexus-agents/) with a real 7-voter run.
+
+### 4. Wire into your editor
+
+```bash
+nexus-agents setup   # Auto-configures MCP server in Claude Code, Cursor, etc.
+```
+
+Restart your editor. The 38 MCP tools (`orchestrate`, `consensus_vote`, `research_synthesize`, `verify_audit_chain`, …) become available to whatever agent you're already using.
+
+#### What `setup` configures
+
+By default, `setup` writes/updates up to seven things in your environment. Each can be skipped with the corresponding `--skip-*` flag if you don't want it.
+
+| Configured                       | Where written                                        | Opt-out flag      |
+| -------------------------------- | ---------------------------------------------------- | ----------------- |
+| MCP server registration (Claude) | `~/.claude/mcp.json` / Claude Desktop config         | `--skip-mcp`      |
+| Project rules                    | `.cursor/rules/` and/or `.claude/rules/`             | `--skip-rules`    |
+| Session hooks                    | `~/.claude/hooks/` (session-start / pre-tool / etc.) | `--skip-hooks`    |
+| OpenCode MCP config              | `~/.config/opencode/opencode.json`                   | `--skip-opencode` |
+| Gemini MCP config                | `~/.gemini/mcp.json`                                 | `--skip-gemini`   |
+| Codex MCP config                 | `~/.codex/config.toml`                               | `--skip-codex`    |
+| Project config file              | `./nexus-agents.yaml`                                | `--skip-config`   |
+
+Run with `--interactive` (the default) for a per-step confirm flow, or `--no-interactive` to accept all defaults.
+
+### 5. Standalone usage (no editor required)
 
 ```bash
 export ANTHROPIC_API_KEY=your-key
@@ -125,7 +178,7 @@ nexus-agents orchestrate "Explain the architecture of this codebase"
 | **Audit Trail**                | Structured logging for every tool call, voter decision, and routing choice. Hash-chained immutable storage; integrity verifiable via `verify_audit_chain` MCP tool (#2281, #2289)                                                                                                           |
 | **Closed-Loop Telemetry**      | `OutcomeStore` records production results; LinUCB bandit + TOPSIS scoring + adaptive routing bonuses adjust based on what actually worked. No other framework closes this loop                                                                                                              |
 | **Security Pipeline**          | Sandboxing (Docker/policy), trust-tiered input handling, SARIF parsing, red-team patterns, ClawGuard access policies (audit/enforce)                                                                                                                                                        |
-| **Multi-Expert Orchestration** | 12 built-in expert types coordinated by Orchestrator. Roles bind prompt + tools + memory                                                                                                                                                                                                    |
+| **Multi-Expert Orchestration** | 11 built-in expert types coordinated by Orchestrator. Roles bind prompt + tools + memory                                                                                                                                                                                                    |
 | **Development Pipeline**       | Research → Plan → Vote → Decompose → Implement → QA → Security. Three modes: autonomous, harness (caller implements), dry-run                                                                                                                                                               |
 | **Memory & Learning**          | 5 user-facing backends (session, belief, agentic, adaptive, typed). Cross-session persistence feeds routing decisions                                                                                                                                                                       |
 | **Research System**            | 9 discovery sources (arXiv, GitHub, Semantic Scholar, etc). Auto-catalog, quality scoring, synthesis into topic clusters                                                                                                                                                                    |

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -47,47 +47,57 @@ Most commonly used commands:
 
 **Entry Point:** `nexus-agents [command] [options]`
 
-| Command                | Subcommand                    | Description                                                                                                                                                                             | Mode         |
-| ---------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `(default)`            | -                             | Start MCP server                                                                                                                                                                        | server       |
-| `--help`               | -                             | Display help text                                                                                                                                                                       | any          |
-| `--version`            | -                             | Display version                                                                                                                                                                         | any          |
-| `doctor`               | -                             | Check CLI health and dependencies                                                                                                                                                       | any          |
-| `config`               | `init`                        | Generate starter configuration file                                                                                                                                                     | any          |
-| `expert`               | `list`                        | List available experts (built-in + custom)                                                                                                                                              | any          |
-| `workflow`             | `list`                        | List available workflow templates                                                                                                                                                       | any          |
-| `workflow`             | `run <name>`                  | Execute a workflow template                                                                                                                                                             | orchestrator |
-| `server`               | -                             | Start MCP server (explicit)                                                                                                                                                             | server       |
-| `server`               | `--interactive`               | Start interactive REPL mode                                                                                                                                                             | server       |
-| `review`               | `<url>`                       | Review a GitHub PR                                                                                                                                                                      | orchestrator |
-| `routing-audit`        | `<task>`                      | Debug routing decisions (dry-run)                                                                                                                                                       | any          |
-| `orchestrate`          | `<task>`                      | Execute task standalone                                                                                                                                                                 | orchestrator |
-| `system-review`        | -                             | Run 5-phase system review                                                                                                                                                               | any          |
-| `vote`                 | `--proposal`                  | Consensus voting with 6 agents                                                                                                                                                          | any          |
-| `research`             | `status`                      | Show technique implementation status                                                                                                                                                    | any          |
-| `research`             | `overlap`                     | Find overlapping techniques                                                                                                                                                             | any          |
-| `research`             | `add`                         | Add new paper from arXiv                                                                                                                                                                | any          |
-| `research`             | `discover`                    | Discover papers/repos from external sources                                                                                                                                             | any          |
-| `research`             | `review`                      | Discover, score, and rank research findings                                                                                                                                             | any          |
-| `research`             | `prioritize`                  | Rank actionable techniques by priority                                                                                                                                                  | any          |
-| `verify`               | -                             | Quick verification check                                                                                                                                                                | any          |
-| `review-demo`          | -                             | PR review demo with wizard UX                                                                                                                                                           | orchestrator |
-| `validation-dashboard` | -                             | A/B testing and validation dashboard                                                                                                                                                    | any          |
-| `swe-bench`            | `run` / `evaluate` / `status` | **Deprecated** — harness extracted to [`nexus-eval-swebench`](https://github.com/nexus-substrate/nexus-eval-swebench) (epic #2514). In-tree commands stub out with a migration message. | any          |
-| `setup`                | -                             | Configure Claude CLI integration                                                                                                                                                        | any          |
-| `learning-metrics`     | -                             | Show learning metrics dashboard                                                                                                                                                         | any          |
-| `index`                | `generate`                    | Generate codebase index                                                                                                                                                                 | any          |
-| `index`                | `check`                       | Validate index freshness                                                                                                                                                                | any          |
-| `index`                | `diagram`                     | Generate Mermaid dependency diagram                                                                                                                                                     | any          |
-| `hooks`                | `session-start`               | Handle SessionStart hook events                                                                                                                                                         | any          |
-| `hooks`                | `session-end`                 | Handle SessionEnd hook events                                                                                                                                                           | any          |
-| `hooks`                | `pre-tool`                    | Handle PreToolUse hook events                                                                                                                                                           | any          |
-| `hooks`                | `post-tool`                   | Handle PostToolUse hook events                                                                                                                                                          | any          |
-| `hooks`                | `stop`                        | Handle Stop hook events                                                                                                                                                                 | any          |
-| `init`                 | `--portable`                  | Bootstrap workspace-local `.nexus-agents/`                                                                                                                                              | any          |
-| `init`                 | `--portable --mcp-config`     | …and emit `.mcp.json` for Claude Code                                                                                                                                                   | any          |
-| `init`                 | `--portable --install`        | …and install nexus-agents into `cli/` + bin shim                                                                                                                                        | any          |
-| `init`                 | `--portable --uninstall`      | Remove portable install (preserves data dir)                                                                                                                                            | any          |
+Commands are grouped by user persona. **Daily use** is what you'll type during a normal session; **setup & inspection** runs at install / config time; **debug & observe** is for when something looks off; **server / internal** is called by hooks, CI, and editor MCP clients — not usually directly.
+
+### Daily use
+
+| Command       | Subcommand                                   | Description                                        | Mode         |
+| ------------- | -------------------------------------------- | -------------------------------------------------- | ------------ |
+| `orchestrate` | `<task>`                                     | Execute a task standalone (routes to the best CLI) | orchestrator |
+| `vote`        | `--proposal "..."`                           | Consensus voting (7 agents; `--quick` runs 3)      | any          |
+| `review`      | `<url>`                                      | Adversarial review of a GitHub PR                  | orchestrator |
+| `workflow`    | `run <name>`                                 | Execute a workflow template                        | orchestrator |
+| `research`    | `add` / `discover` / `review` / `prioritize` | Add papers, discover new ones, rank by impact      | any          |
+
+### Setup & inspection
+
+| Command     | Subcommand                                                    | Description                                                | Mode |
+| ----------- | ------------------------------------------------------------- | ---------------------------------------------------------- | ---- |
+| `doctor`    | -                                                             | Check CLI health and dependencies (read-only)              | any  |
+| `setup`     | `[--skip-mcp\|rules\|hooks\|opencode\|gemini\|codex\|config]` | Configure MCP server + hooks + per-CLI configs in one shot | any  |
+| `config`    | `init`                                                        | Generate a starter `nexus-agents.yaml`                     | any  |
+| `expert`    | `list`                                                        | List available experts (built-in + custom)                 | any  |
+| `workflow`  | `list`                                                        | List available workflow templates                          | any  |
+| `init`      | `--portable [--mcp-config] [--install] [--uninstall]`         | Bootstrap workspace-local `.nexus-agents/` install         | any  |
+| `--help`    | -                                                             | Display help text                                          | any  |
+| `--version` | -                                                             | Display version                                            | any  |
+
+### Debug & observe
+
+| Command                | Subcommand           | Description                                                          | Mode         |
+| ---------------------- | -------------------- | -------------------------------------------------------------------- | ------------ |
+| `routing-audit`        | `<task>`             | Show the routing decision for a task without executing it (dry-run)  | any          |
+| `system-review`        | -                    | Run a 5-phase introspection of the local install                     | any          |
+| `verify`               | -                    | Quick post-install verification                                      | any          |
+| `validation-dashboard` | -                    | A/B testing and validation dashboard                                 | any          |
+| `learning-metrics`     | -                    | Show the learning-metrics dashboard                                  | any          |
+| `research`             | `status` / `overlap` | Inspect technique-implementation status; find overlapping techniques | any          |
+| `review-demo`          | -                    | PR review demo with wizard UX                                        | orchestrator |
+
+### Server & internal (rarely typed directly)
+
+| Command     | Subcommand                                                          | Description                                               | Mode   |
+| ----------- | ------------------------------------------------------------------- | --------------------------------------------------------- | ------ |
+| `(default)` | -                                                                   | Start the MCP server (what editors call)                  | server |
+| `server`    | `[--interactive]`                                                   | Start MCP server explicitly; `--interactive` opens a REPL | server |
+| `hooks`     | `session-start` / `session-end` / `pre-tool` / `post-tool` / `stop` | Handle Claude Code hook events                            | any    |
+| `index`     | `generate` / `check` / `diagram`                                    | Generate / validate codebase index; emit Mermaid graph    | any    |
+
+### Deprecated
+
+| Command     | Description                                                                                                                                                                            |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `swe-bench` | Harness extracted to [`nexus-substrate/nexus-eval-swebench`](https://github.com/nexus-substrate/nexus-eval-swebench) (epic #2514). In-tree commands stub out with a migration message. |
 
 ### Mode Selection
 


### PR DESCRIPTION
Three small backlog items bundled from epic #2837.

## Closes #2842 — 60-second smoke task in README

New section after `doctor` that shows the literal `vote --quick` command + expected output (real 3-voter transcript). Links to the website hero for the richer 7-voter mixed-outcome run.

## Closes #2847 — document what setup configures

New 'What setup configures' table — all seven actions (MCP server registration, project rules, hooks, OpenCode MCP, Gemini MCP, Codex MCP, project config) with target file + opt-out flag for each. Sourced from the actual `--skip-*` flags in `setup-command.ts`.

## Closes #2848 — ENTRYPOINTS.md grouped by user persona

Replaces the flat 37-row CLI table with five persona-grouped tables: Daily use, Setup & inspection, Debug & observe, Server & internal, Deprecated. A new user can scan the 5-command Daily-use table without scrolling past 30 internal hook handlers.

## Drive-by

Fixed 'Multi-Expert Orchestration | 12 built-in expert types' → '11' (real `BUILT_IN_EXPERTS` is 11; follow-on count fix from #2840).

🤖 Generated with [Claude Code](https://claude.com/claude-code)