### PR TITLE
docs(index): hide ADR/V2/design/proposal tables behind maintainer fold (closes #2845)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,9 @@ Detailed technical documentation:
 
 ### Tier 3: Supporting (Reference as Needed)
 
+<details>
+<summary><strong>For maintainers — ADRs, V2 architecture artifacts, design proposals</strong> (expand if you're editing the codebase)</summary>
+
 #### Architecture Decision Records (ADRs)
 
 | ADR                                                      | Title                              | Status     |
@@ -239,6 +242,8 @@ _No active plan documents. Historical plans have been archived._
 | Document                                                                   | Description        | Status   |
 | -------------------------------------------------------------------------- | ------------------ | -------- |
 | [cli-pr-review-workflow.md](./archive/proposals/cli-pr-review-workflow.md) | PR review workflow | Archived |
+
+</details>
 
 #### Workflows
 


### PR DESCRIPTION
Closes #2845. The docs index previously surfaced 16 ADRs, 21 V2-rearchitecture artifacts, design docs, and proposals in the front-page table of contents — a new user shouldn't scroll past ADR-0006 to get to 'Getting Started'.

Wraps the ADRs / Plans / Design Documents / V2 Rearchitecture / Proposals sections in a single `<details>` fold labeled 'For maintainers'. The fold defaults to closed; expand to see the deep-internal material. Workflows / Operational / Root-Level Documents / Deprecated / Machine-Parseable Index / Governance Rules stay visible because they're useful for operators and contributors.

No content deleted — only the table of contents got restructured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)