### PR TITLE
fix(mcp): timeout hint reflects client-side SDK abort, not server budget

### DIFF
--- a/.changeset/2631-timeout-hint-fix.md
+++ b/.changeset/2631-timeout-hint-fix.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**fix(mcp):** `execute_expert` timeout hint now reflects the client-side SDK abort, not the server-side budget.
+
+The previous hint told callers to "omit `timeoutMs` to use auto-detected timeout (300-600s)" when the MCP client SDK timed out the request. That advice was misleading because the kill happens client-side (typically 60s SDK default), not at our configured server budget — so omitting `timeoutMs` has no effect on the outcome. The new hint reports the actual measured duration, names the underlying spec-compliance issue (most MCP clients don't honor server-side progress extensions), and gives two real workarounds plus a link to the tracking epic #2631.

--- a/docs/getting-started/INSTALLATION.md
+++ b/docs/getting-started/INSTALLATION.md
@@ -528,6 +528,6 @@ sudo usermod -aG docker $USER
 ## Related Documentation
 
 - [Configuration](./CONFIGURATION.md) - Set up models, experts, and routing
-- [Sandboxed Usage](./SANDBOXED-USAGE.md) - Docker / restricted-FS / team-distribution flows
+- [Sandboxed Usage](../guides/SANDBOXED-USAGE.md) - Docker / restricted-FS / team-distribution flows
 - [Quick Start](../../QUICK_START.md) - Try your first orchestration
 - [CLI Usage](../ENTRYPOINTS.md) - Learn all CLI commands

--- a/docs/guides/SANDBOXED-USAGE.md
+++ b/docs/guides/SANDBOXED-USAGE.md
@@ -305,8 +305,8 @@ This shows the proposed merge without writing. Drop `--dry-run` to commit. The m
 
 ## Related
 
-- [Installation](./INSTALLATION.md) — initial install path
-- [Configuration](./CONFIGURATION.md) — env vars, config files, model selection
+- [Installation](../getting-started/INSTALLATION.md) — initial install path
+- [Configuration](../getting-started/CONFIGURATION.md) — env vars, config files, model selection
 - [#2467 epic](https://github.com/nexus-substrate/nexus-agents/issues/2467) — the umbrella for OpenAI-compat gateway support, sandbox-safe operation, and reliability hardening
 - [#2500 epic](https://github.com/nexus-substrate/nexus-agents/issues/2500) — MCP-in-sandbox: full functionality with OpenCode + OpenAI-compat gateway
 - [`Dockerfile.sandbox`](../../Dockerfile.sandbox) — the canonical image for the OpenCode-in-Docker scenario

--- a/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
@@ -169,8 +169,13 @@ export function handleExpertFailure(
   });
   const durationSec = Math.round(durationMs / 1000);
   const model = expert.modelId ?? 'default';
+  // The "MCP error -32001: Request timed out" string comes from the client-side
+  // SDK aborting the request, not from our server-side budget. Most MCP clients
+  // default to 60s and don't honor server-side progress extensions, so a 300-900s
+  // server budget is unreachable. Telling the caller to "omit timeoutMs" doesn't
+  // help — that knob is on our side of the transport. See #2631.
   const timeoutHint = errorMsg.includes('timed out')
-    ? ' Hint: omit timeoutMs to use auto-detected timeout (300-600s).'
+    ? ` Hint: client MCP timed out at ${String(durationSec)}s (typically the 60s SDK default). Server budget can be 300-900s but most clients don't honor progress extensions — see #2631. Workaround: use a client with longer default (Claude Desktop, mcp-inspector --timeout) or shorten the task.`
     : '';
   return {
     ok: false,


### PR DESCRIPTION
Closes the misleading `Hint: omit timeoutMs to use auto-detected timeout (300-600s)` message that fires on every `execute_expert` MCP timeout.

## Why it was wrong

The hint pointed at a knob on the wrong side of the transport. The "Request timed out" error in question comes from the MCP **client SDK** aborting the request (typically 60s default), not from our **server-side** budget. So omitting `timeoutMs` doesn't help — the kill happens before our budget is ever consulted.

The [2026-05-16 field repro on #2631](https://github.com/nexus-substrate/nexus-agents/issues/2631#issuecomment-…) showed the exact failure mode:

1. Caller passes explicit `timeoutMs: 300000` → killed at 60s.
2. Hint suggests "omit `timeoutMs`" → omitted → killed at 60s again.

## What the new hint says

```text
Hint: client MCP timed out at 61s (typically the 60s SDK default).
Server budget can be 300-900s but most clients don't honor progress
extensions — see #2631. Workaround: use a client with longer default
(Claude Desktop, mcp-inspector --timeout) or shorten the task.
```

Reports the actual measured duration so callers can see "killed at 61s, not 300s" and recognize the SDK-default fingerprint. Names the underlying spec-compliance issue. Gives two real workarounds plus a tracking link.

## Why this is a hint fix, not the #2631 fix

The structural solution — async-mode/job-style invocation that decouples transport deadline from work deadline — is still gated on 7+ days of correlation-keyed telemetry per the epic's own deferral criteria. This PR just stops the diagnostic from lying to operators while we wait for evidence.

## Tests

`recording-modules.test.ts` pins `'Hint:'` substring, not the full message — passes without modification. All 24 tests in that file still green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)