### PR TITLE
fix(sprawl): redirect 3 hardcoded paths to getNexusDataDir() (closes #2873 #2874 #2875)

### DIFF
--- a/.changeset/2872-redirect-hardcoded-paths.md
+++ b/.changeset/2872-redirect-hardcoded-paths.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(sprawl):** redirect three hardcoded relative paths so runtime artifacts land under `getNexusDataDir()` instead of sprawling at `cwd`. Closes #2873, #2874, #2875 (epic #2872).
+
+- **`./runs/` → `getNexusDataDir()/runs/`** (`pipeline-runner.ts`). The previous `DEFAULT_RUNS_DIR = './runs'` const is replaced with `getDefaultRunsDir()` so trace output for every `PipelineRunner` execution lands under the centralized data dir. Function form (not const) so `NEXUS_DATA_DIR` env changes are honored at call time. Was the single biggest sprawl source (1063 entries observed in one example checkout).
+- **`./.nexus-pipeline/` → `getNexusDataDir()/pipeline/`** (`task-tracker.ts`). The `JsonTaskTracker` JSON-fallback default no longer drops a `.nexus-pipeline/` directory at the repo root.
+- **`./logs/run_evaluation/` default removed** (`cli-types.ts`). The only consumer of `--output-dir` (`handleSweBenchCommand`) is a deprecation shim that ignores the value, so the default was advertising a sprawl-creating fallback for no reason. Live callers should pass an explicit path or resolve through `getNexusDataDir()` at use time.
+
+No behavior change for callers that pass `runsDir` / `outputDir` / `--output-dir` explicitly. Tests added covering the new defaults + the call-time env resolution.

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -347,7 +347,11 @@ export const PARSE_ARGS_CONFIG = {
     },
     'output-dir': {
       type: 'string' as const,
-      default: './logs/run_evaluation',
+      // No default: the only consumer (handleSweBenchCommand) is a
+      // deprecation shim that ignores it. Live callers should pass an
+      // explicit path or resolve through getNexusDataDir() at use time.
+      // Removed the './logs/run_evaluation' default per epic #2872 to
+      // stop the parser from advertising a sprawl-creating fallback.
     },
     // ATBench command options (#1981)
     fixture: {

--- a/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/query-trace-tool.ts
@@ -12,7 +12,7 @@ import { join, resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
-import { DEFAULT_RUNS_DIR } from '../../pipeline/pipeline-runner.js';
+import { getDefaultRunsDir } from '../../pipeline/pipeline-runner.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -137,7 +137,7 @@ export async function queryTraceFromDisk(
   input: QueryTraceInput,
   runsDir?: string
 ): Promise<QueryTraceResponse> {
-  const dir = runsDir ?? DEFAULT_RUNS_DIR;
+  const dir = runsDir ?? getDefaultRunsDir();
   const tracePath = join(dir, input.runId, 'trace.jsonl');
 
   // Path traversal guard: resolved path must stay within runs directory.

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -32,7 +32,7 @@ export { compilePlan, type PlanCompileOptions } from './plan-compiler.js';
 
 export {
   PipelineRunner,
-  DEFAULT_RUNS_DIR,
+  getDefaultRunsDir,
   type CompiledPipeline,
   type PipelineResult,
   type PipelineExecuteOptions,

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
@@ -383,3 +383,43 @@ describe('PipelineRunner.retryFailed', () => {
     }
   });
 });
+
+// Epic #2872: the default runs dir must resolve through getNexusDataDir(),
+// not the historical hardcoded `./runs`, so trace output lands under the
+// centralized data dir instead of sprawling at cwd.
+describe('getDefaultRunsDir', () => {
+  it('resolves under NEXUS_DATA_DIR/runs', async () => {
+    const { getDefaultRunsDir } = await import('./pipeline-runner.js');
+    const tempDataDir = await mkdtemp(join(tmpdir(), 'nexus-runs-default-'));
+    const prev = process.env['NEXUS_DATA_DIR'];
+    process.env['NEXUS_DATA_DIR'] = tempDataDir;
+    try {
+      expect(getDefaultRunsDir()).toBe(join(tempDataDir, 'runs'));
+    } finally {
+      if (prev === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prev;
+      await rm(tempDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads NEXUS_DATA_DIR at call time, not module load time', async () => {
+    const { getDefaultRunsDir } = await import('./pipeline-runner.js');
+    const a = await mkdtemp(join(tmpdir(), 'nexus-runs-a-'));
+    const b = await mkdtemp(join(tmpdir(), 'nexus-runs-b-'));
+    const prev = process.env['NEXUS_DATA_DIR'];
+    try {
+      process.env['NEXUS_DATA_DIR'] = a;
+      const first = getDefaultRunsDir();
+      process.env['NEXUS_DATA_DIR'] = b;
+      const second = getDefaultRunsDir();
+      expect(first).toBe(join(a, 'runs'));
+      expect(second).toBe(join(b, 'runs'));
+      expect(first).not.toBe(second);
+    } finally {
+      if (prev === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prev;
+      await rm(a, { recursive: true, force: true });
+      await rm(b, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -6,8 +6,11 @@
  *
  * @module pipeline/pipeline-runner
  */
+import { join } from 'node:path';
+
 import { executeGraph } from '../orchestration/graph/graph-executor.js';
 import { createLogger } from '../core/index.js';
+import { getNexusDataDir } from '../config/nexus-data-dir.js';
 
 import { compilePlan } from './plan-compiler.js';
 import type { PlanCompileOptions } from './plan-compiler.js';
@@ -54,8 +57,15 @@ export interface StepOutcome {
   readonly error?: string | undefined;
 }
 
-/** Default directory for trace output (shared with query-trace-tool). */
-export const DEFAULT_RUNS_DIR = './runs';
+/**
+ * Default directory for trace output, resolved through `getNexusDataDir()`
+ * so runs land under the centralized data dir instead of sprawling at cwd.
+ * Function rather than const so `NEXUS_DATA_DIR` env changes are honored
+ * at call time (matters for tests that mock the env). See epic #2872.
+ */
+export function getDefaultRunsDir(): string {
+  return join(getNexusDataDir(), 'runs');
+}
 
 /** Pipeline execution options. */
 export interface PipelineExecuteOptions {
@@ -67,7 +77,7 @@ export interface PipelineExecuteOptions {
   readonly continueOnFailure?: boolean;
   /** EventBus for trace persistence. When provided, creates a TraceWriter. */
   readonly eventBus?: IEventBus;
-  /** Override base directory for trace output (default: ./runs). */
+  /** Override base directory for trace output (default: `<getNexusDataDir()>/runs`). */
   readonly runsDir?: string;
 }
 
@@ -265,7 +275,7 @@ function createTraceContext(task: TaskContract, options?: PipelineExecuteOptions
   const writer =
     bus !== undefined
       ? new TraceWriter(bus, {
-          runsDir: options?.runsDir ?? DEFAULT_RUNS_DIR,
+          runsDir: options?.runsDir ?? getDefaultRunsDir(),
           runId: task.id,
         })
       : undefined;

--- a/packages/nexus-agents/src/pipeline/task-tracker.test.ts
+++ b/packages/nexus-agents/src/pipeline/task-tracker.test.ts
@@ -66,4 +66,22 @@ describe('JsonTaskTracker', () => {
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
+
+  // Epic #2872: the JSON tracker default must land under getNexusDataDir(),
+  // not the historical hardcoded '.nexus-pipeline/' at cwd.
+  it('defaults outputDir to getNexusDataDir()/pipeline when not provided', async () => {
+    const tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-tracker-default-'));
+    const prev = process.env['NEXUS_DATA_DIR'];
+    process.env['NEXUS_DATA_DIR'] = tempDataDir;
+    try {
+      const tracker = createTaskTracker({ backend: 'json' });
+      await tracker.createTask('Default-path test', 'Body');
+      const expected = path.join(tempDataDir, 'pipeline', 'tasks.json');
+      expect(fs.existsSync(expected)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prev;
+      fs.rmSync(tempDataDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/nexus-agents/src/pipeline/task-tracker.ts
+++ b/packages/nexus-agents/src/pipeline/task-tracker.ts
@@ -9,6 +9,7 @@
  */
 
 import { createLogger } from '../core/index.js';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -158,7 +159,9 @@ class JsonTaskTracker implements ITaskTracker {
   private readonly outputPath: string;
 
   constructor(config: TaskTrackerConfig) {
-    const dir = config.outputDir ?? '.nexus-pipeline';
+    // Default lands under getNexusDataDir()/pipeline so the JSON tracker
+    // doesn't sprawl a .nexus-pipeline/ dir at cwd. See epic #2872.
+    const dir = config.outputDir ?? nexusDataPath('pipeline');
     this.outputPath = path.resolve(dir, 'tasks.json');
     fs.mkdirSync(path.dirname(this.outputPath), { recursive: true });
   }


### PR DESCRIPTION
Lands the three independent hardcoded-path fixes from epic #2872. Each is a one-line default change that redirects writes from `cwd` into `getNexusDataDir()`. Bundling because each is one-file-disjoint and tiny — three trivial PRs would be more review friction than value.

## Changes

| # | File | Before | After |
|---|---|---|---|
| #2873 | `pipeline-runner.ts` | `export const DEFAULT_RUNS_DIR = './runs'` | `export function getDefaultRunsDir(): string` returning `getNexusDataDir()/runs` |
| #2874 | `task-tracker.ts:161` | `config.outputDir ?? '.nexus-pipeline'` | `config.outputDir ?? nexusDataPath('pipeline')` |
| #2875 | `cli-types.ts:350` | `default: './logs/run_evaluation'` | (removed; consumer is a deprecation shim) |

#2873 is a function rather than a const so `NEXUS_DATA_DIR` env mutations are honored at call time (matters for tests and programmatic env changes). Two consumers updated (`pipeline-runner.ts:278`, `query-trace-tool.ts:140`), plus the re-export from `pipeline/index.ts`.

#2875 is a removal rather than a redirect: the only consumer of `--output-dir` is `handleSweBenchCommand`, which is a deprecation shim that exits without reading args. The literal default was advertising a sprawl-creating fallback for nothing. Type surface is intact so any future live consumer can resolve through `getNexusDataDir()` at use time.

## Impact

The user-reported sprawl ('1063 entries in `runs/`' was the largest source) goes away. Running `nexus-agents` in a fresh repo will no longer create `runs/`, `.nexus-pipeline/`, or `logs/run_evaluation/` at cwd — all that state lands under the existing `getNexusDataDir()` instead.

No behavior change for callers that pass `runsDir` / `outputDir` / `--output-dir` explicitly (all existing tests do).

## Tests

- 2 new tests in `pipeline-runner.test.ts` pin the default resolution + the call-time-env-read behavior (prevents the const regression).
- 1 new test in `task-tracker.test.ts` confirms the new default lands under `getNexusDataDir()/pipeline/`.
- All 22 existing tests across both files still pass.
- 24 query-trace-tool tests still pass (import-rename only).

## Scope note

This PR covers ~95% of the visible sprawl. The remaining epic work (#2876 design vote on default resolution, #2877 config move, #2878 CI gate, #2879 migrate command) is independent and tracked separately. Recovers the user-visible problem without waiting on the vote outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)