### PR TITLE
chore(ci): working-tree-clean gate after pnpm test (closes #2878)

### DIFF
--- a/.changeset/2878-working-tree-clean-gate.md
+++ b/.changeset/2878-working-tree-clean-gate.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**ci(sprawl):** working-tree-clean gate after `pnpm test:coverage`. Closes #2878 (epic #2872).
+
+CI now fails if tests leave files matching the sprawl-pattern paths from the epic-#2872 audit (`runs/`, `logs/`, `.nexus-pipeline/`, `.nexus-agents/`, `predictions.jsonl`, `coverage.json`, `.test-*`). The check runs unconditionally (`if: always()`) so it catches leaks even when tests pass.
+
+The audit found the test suite is already clean — every test uses `mkdtempSync(tmpdir(), ...)` with `afterEach` cleanup. This gate locks that discipline in so a future test that writes to `cwd` without cleanup gets caught at PR time rather than discovered later as accumulated sprawl.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,28 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
+      # Epic #2872: catch tests that accidentally leak artifacts into the
+      # working tree. Allow the legitimate outputs (coverage/, dist/, generated
+      # docs) — fail on the sprawl-pattern paths from the audit. Issue #2878.
+      - name: Working-tree clean check (epic #2872)
+        if: always()
+        run: |
+          set -u
+          leaks=$(git status --porcelain --untracked-files=all 2>/dev/null \
+            | awk '{print $2}' \
+            | grep -E '^(runs/|logs/|\.nexus-pipeline/|\.nexus-agents/|predictions\.jsonl$|coverage\.json$|\.test-)' \
+            || true)
+          if [ -n "$leaks" ]; then
+            echo "::error::Tests left sprawl artifacts in the working tree:"
+            echo "$leaks" | sed 's/^/  - /'
+            echo ""
+            echo "Per epic #2872, runtime artifacts must land under getNexusDataDir(),"
+            echo "and test temp dirs must use os.tmpdir() + mkdtempSync() with cleanup."
+            echo "See packages/nexus-agents/src/cli/init-portable.test.ts for the pattern."
+            exit 1
+          fi
+          echo "✓ Working tree clean after tests"
+
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Lands the CI gate from epic #2872. Adds a single step after `pnpm test:coverage` that fails the build if tests leak files matching the sprawl-pattern paths from the audit.

## What it checks

After `pnpm test:coverage` (Ubuntu, `if: always()` so it runs even on test failure):

\`\`\`bash
git status --porcelain --untracked-files=all \\
  | awk '{print $2}' \\
  | grep -E '^(runs/|logs/|\\.nexus-pipeline/|\\.nexus-agents/|predictions\\.jsonl$|coverage\\.json$|\\.test-)'
\`\`\`

If any matches, the step fails with a pointer to the canonical test pattern.

## Why this matters

The audit for epic #2872 found the test suite is already clean — every test uses `mkdtempSync(tmpdir(), ...)` with `afterEach` cleanup. This gate locks that discipline in so a future test that writes to cwd without cleanup gets caught at PR time rather than discovered later as accumulated sprawl.

Pattern was sanity-checked locally:
- Matches: `runs/foo`, `logs/bar`, `.nexus-pipeline/x`, `.nexus-agents/y`, `predictions.jsonl`, `coverage.json`, `.test-export.json`
- Does NOT match: `coverage/lcov.info`, `dist/foo.js`, `packages/x/coverage/y` (legitimate outputs)

## Independence

Independent of #2880 (the hardcoded-path redirects) and #2876 (the resolution-order vote). Lands on its own so the gate is active before any future epic work might accidentally introduce a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)