### PR TITLE
feat(config): nexus-agents.yaml lives in .nexus-agents/ by default (closes #2877)

### DIFF
--- a/.changeset/2877-config-in-dotdir.md
+++ b/.changeset/2877-config-in-dotdir.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+**feat(config):** `nexus-agents.yaml` now lives in `.nexus-agents/` by default. Closes #2877 (epic #2872).
+
+The config-loader checks `.nexus-agents/nexus-agents.yaml` ahead of the legacy root-level location, and `nexus-agents setup` / `nexus-agents config init` write new configs to the dotdir. Existing root-level configs keep working without action — both writers and the loader fall back to them transparently. The migrate command (#2879) is the explicit way to relocate.
+
+Locations checked in order:
+
+1. `NEXUS_CONFIG_PATH` env (unchanged)
+2. **NEW:** `<cwd>/.nexus-agents/nexus-agents.yaml`
+3. **NEW:** `<cwd>/.nexus-agents/nexus-agents.yml`
+4. `<cwd>/nexus-agents.yaml` (legacy root, still works)
+5. `<cwd>/nexus-agents.yml` (legacy root, still works)
+6. `<getNexusDataDir()>/nexus-agents.yaml` (global fallback, unchanged)
+
+Touches: `config/config-loader.ts` (lookup), `cli/setup-config.ts` (writer), `cli/config-init.ts` (writer), `cli/doctor.ts` (probe), `cli-commands-handlers.ts` (first-run hint), `cli/setup-environment.ts` (env probe). 4 new tests in `config-loader.test.ts` pin the precedence + NEXUS_CONFIG_PATH dominance.

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -169,7 +169,11 @@ function printFirstRunHint(): void {
   const isTTY = process.stderr.isTTY;
   if (!isTTY) return;
   const dataDir = getNexusDataDir();
-  const hasConfig = existsSync('./nexus-agents.yaml') || existsSync('./nexus-agents.yml');
+  const hasConfig =
+    existsSync('./.nexus-agents/nexus-agents.yaml') ||
+    existsSync('./.nexus-agents/nexus-agents.yml') ||
+    existsSync('./nexus-agents.yaml') ||
+    existsSync('./nexus-agents.yml');
   if (existsSync(dataDir) || hasConfig) return;
   process.stderr.write(
     '\n\x1b[36mnexus-agents\x1b[0m: First time? Run \x1b[1mnexus-agents setup\x1b[0m to configure.\n\n'

--- a/packages/nexus-agents/src/cli/config-init.ts
+++ b/packages/nexus-agents/src/cli/config-init.ts
@@ -34,10 +34,17 @@ export interface ConfigInitResult {
   readonly created: boolean;
 }
 
-/**
- * Default configuration file name.
- */
+/** Default configuration file name. */
 const DEFAULT_CONFIG_FILE = 'nexus-agents.yaml';
+
+/**
+ * Path `config init` writes new configs to (epic #2872). The config loader
+ * checks `.nexus-agents/nexus-agents.yaml` ahead of the legacy root-level
+ * location, so writing here is forward-compatible. If a legacy root-level
+ * config already exists, we keep editing it in place rather than silently
+ * moving the user's file — see `resolveOutputPath()` for the precedence.
+ */
+const DEFAULT_CONFIG_REL_PATH = `.nexus-agents/${DEFAULT_CONFIG_FILE}`;
 
 /**
  * Bucket models into fast / balanced / powerful tiers using the canonical
@@ -264,7 +271,13 @@ function resolveOutputPath(output?: string): string {
   if (output !== undefined && output !== '') {
     return resolve(process.cwd(), output);
   }
-  return resolve(process.cwd(), DEFAULT_CONFIG_FILE);
+  // Honor a pre-existing legacy root-level config — don't silently move it.
+  // New installs land in the dotdir. See epic #2872 / issue #2877.
+  const legacyPath = resolve(process.cwd(), DEFAULT_CONFIG_FILE);
+  if (existsSync(legacyPath)) {
+    return legacyPath;
+  }
+  return resolve(process.cwd(), DEFAULT_CONFIG_REL_PATH);
 }
 
 /**

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -43,8 +43,17 @@ const REQUIRED_NODE_MAJOR = 22;
 /** API key environment variable names. */
 const API_KEY_VARS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_AI_API_KEY'] as const;
 
-/** Configuration file paths to check (in order of priority). */
-const CONFIG_FILE_PATHS = ['./nexus-agents.yaml', './nexus-agents.yml'] as const;
+/**
+ * Configuration file paths to check (in order of priority). Per epic #2872
+ * the dotdir-scoped variants are preferred over the legacy root-level
+ * locations — must match the order in `config-loader.ts:CONFIG_LOOKUP_PATHS`.
+ */
+const CONFIG_FILE_PATHS = [
+  './.nexus-agents/nexus-agents.yaml',
+  './.nexus-agents/nexus-agents.yml',
+  './nexus-agents.yaml',
+  './nexus-agents.yml',
+] as const;
 
 /**
  * Check result for a single CLI.

--- a/packages/nexus-agents/src/cli/setup-config.test.ts
+++ b/packages/nexus-agents/src/cli/setup-config.test.ts
@@ -22,14 +22,26 @@ describe('runConfigInitSync (#1252)', () => {
     }
   });
 
-  it('creates nexus-agents.yaml in fresh directory', () => {
+  it('creates .nexus-agents/nexus-agents.yaml in fresh directory (epic #2872)', () => {
     const result = runConfigInitSync(testDir, false, false);
     expect(result.success).toBe(true);
     expect(result.created).toBe(true);
-    expect(existsSync(join(testDir, 'nexus-agents.yaml'))).toBe(true);
-    const content = readFileSync(join(testDir, 'nexus-agents.yaml'), 'utf-8');
+    // Fresh repo → config lands in the dotdir, not at root.
+    const dotdirPath = join(testDir, '.nexus-agents', 'nexus-agents.yaml');
+    expect(existsSync(dotdirPath)).toBe(true);
+    expect(existsSync(join(testDir, 'nexus-agents.yaml'))).toBe(false);
+    const content = readFileSync(dotdirPath, 'utf-8');
     expect(content).toContain('models:');
     expect(content).toContain('experts:');
+  });
+
+  it('edits legacy root-level config in place when one exists (epic #2872)', () => {
+    // Pre-existing root-level file → setup honors it, doesn't silently move.
+    writeFileSync(join(testDir, 'nexus-agents.yaml'), 'legacy: true\n', 'utf-8');
+    const result = runConfigInitSync(testDir, true, false);
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(join(testDir, 'nexus-agents.yaml'));
+    expect(existsSync(join(testDir, '.nexus-agents'))).toBe(false);
   });
 
   it('skips if config already exists', () => {

--- a/packages/nexus-agents/src/cli/setup-config.ts
+++ b/packages/nexus-agents/src/cli/setup-config.ts
@@ -8,12 +8,20 @@
  * (Source: Issue #1252 - Setup auto-generates nexus-agents.yaml)
  */
 
-import { copyFileSync, existsSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { getErrorMessage } from '../core/index.js';
 
 /** Default configuration file name. */
 const DEFAULT_CONFIG_FILE = 'nexus-agents.yaml';
+
+/**
+ * Path setup writes new configs to (epic #2872). The config loader checks
+ * `.nexus-agents/nexus-agents.yaml` ahead of the legacy root-level location,
+ * so writing here is forward-compatible. Existing root-level configs keep
+ * working without action (loader still falls back to them).
+ */
+const DEFAULT_CONFIG_REL_PATH = `.nexus-agents/${DEFAULT_CONFIG_FILE}`;
 
 /** Result of the config generation step. */
 export interface ConfigStepResult {
@@ -55,7 +63,14 @@ export function runConfigInitSync(
   force: boolean,
   dryRun: boolean
 ): ConfigStepResult {
-  const outputPath = resolve(projectRoot, DEFAULT_CONFIG_FILE);
+  // Prefer the dotdir location for new configs. Per #2877: if a legacy
+  // root-level nexus-agents.yaml already exists, keep editing it in place
+  // rather than silently moving the user's config — the migrate command
+  // (#2879) is the explicit way to relocate. New installs land in the dotdir.
+  const legacyPath = resolve(projectRoot, DEFAULT_CONFIG_FILE);
+  const outputPath = existsSync(legacyPath)
+    ? legacyPath
+    : resolve(projectRoot, DEFAULT_CONFIG_REL_PATH);
 
   if (existsSync(outputPath) && !force) {
     return {
@@ -79,6 +94,9 @@ export function runConfigInitSync(
   if ('error' in backup) return backup.error;
 
   try {
+    // Ensure parent dir exists — needed for the new dotdir location since
+    // .nexus-agents/ may not yet exist on a fresh repo.
+    mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, SETUP_CONFIG_TEMPLATE, 'utf-8');
     const message =
       backup.path !== undefined

--- a/packages/nexus-agents/src/cli/setup-environment.ts
+++ b/packages/nexus-agents/src/cli/setup-environment.ts
@@ -172,7 +172,10 @@ export function detectProjectInfo(root: string): ProjectInfo {
     // legacy `.claude/rules/` path so detection doesn't break on repos that
     // haven't migrated yet.
     hasClaudeRules: existsSync(join(root, '.rules')) || existsSync(join(root, '.claude', 'rules')),
-    hasNexusConfig: existsSync(join(root, 'nexus-agents.yaml')),
+    // Check dotdir-scoped location first (epic #2872), then legacy root.
+    hasNexusConfig:
+      existsSync(join(root, '.nexus-agents', 'nexus-agents.yaml')) ||
+      existsSync(join(root, 'nexus-agents.yaml')),
     projectType: detectProjectType(root),
     packageName: packageName ?? basename(root),
   };

--- a/packages/nexus-agents/src/config/config-loader.test.ts
+++ b/packages/nexus-agents/src/config/config-loader.test.ts
@@ -276,4 +276,76 @@ describe('config-loader', () => {
       expect((merged['nested'] as Record<string, unknown>)['y']).toBe('keep');
     });
   });
+
+  // Epic #2872 / Issue #2877: the loader must prefer the dotdir-scoped
+  // config locations over the legacy root-level ones, with the root-level
+  // paths still working as a fallback for backward compatibility.
+  describe('config-file lookup order (issue #2877)', () => {
+    function setupYamlParsed(): void {
+      mockReadFileSync.mockReturnValue('models: {}\n');
+      mockYamlParse.mockReturnValue({ models: {} });
+    }
+
+    it('prefers .nexus-agents/nexus-agents.yaml over root-level nexus-agents.yaml', () => {
+      // Both exist; loader must pick the dotdir one.
+      mockExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        return s.endsWith('.nexus-agents/nexus-agents.yaml') || s.endsWith('/nexus-agents.yaml');
+      });
+      setupYamlParsed();
+
+      const result = loadConfig();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.configPath).toMatch(/\.nexus-agents[/\\]nexus-agents\.yaml$/);
+      }
+    });
+
+    it('falls back to root-level nexus-agents.yaml when dotdir is absent', () => {
+      mockExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        // Dotdir absent; root present (allow either .yaml or .yml at root)
+        if (s.includes('.nexus-agents/')) return false;
+        return s.endsWith('/nexus-agents.yaml');
+      });
+      setupYamlParsed();
+
+      const result = loadConfig();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.configPath).toMatch(/\/nexus-agents\.yaml$/);
+        expect(result.value.configPath).not.toMatch(/\.nexus-agents/);
+      }
+    });
+
+    it('falls back to .nexus-agents/nexus-agents.yml (alternate extension) before root', () => {
+      mockExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        // Only the dotdir .yml exists.
+        return s.endsWith('.nexus-agents/nexus-agents.yml');
+      });
+      setupYamlParsed();
+
+      const result = loadConfig();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.configPath).toMatch(/\.nexus-agents[/\\]nexus-agents\.yml$/);
+      }
+    });
+
+    it('NEXUS_CONFIG_PATH env var still wins over both locations', () => {
+      process.env['NEXUS_CONFIG_PATH'] = 'custom/path/cfg.yaml';
+      mockExistsSync.mockReturnValue(true);
+      setupYamlParsed();
+      try {
+        const result = loadConfig();
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.configPath).toMatch(/custom\/path\/cfg\.yaml$/);
+        }
+      } finally {
+        delete process.env['NEXUS_CONFIG_PATH'];
+      }
+    });
+  });
 });

--- a/packages/nexus-agents/src/config/config-loader.ts
+++ b/packages/nexus-agents/src/config/config-loader.ts
@@ -19,15 +19,25 @@ import { ok, err, formatZodIssuesAsArray } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
 import { createLogger } from '../core/logger.js';
 
-/**
- * Default config file name.
- */
+/** Default config file name. */
 const DEFAULT_CONFIG_FILE = 'nexus-agents.yaml';
 
-/**
- * Alternate config file name.
- */
+/** Alternate config file name. */
 const ALTERNATE_CONFIG_FILE = 'nexus-agents.yml';
+
+/**
+ * Preferred config-file locations, checked in order. Per epic #2872 the
+ * dotdir-scoped variant wins over the root-level legacy locations so new
+ * installs land their config under `.nexus-agents/` instead of cluttering
+ * the repo root. Existing root-level files keep working without action
+ * (backward compat); they're picked up by the fallback tier.
+ */
+const CONFIG_LOOKUP_PATHS: readonly string[] = [
+  `.nexus-agents/${DEFAULT_CONFIG_FILE}`,
+  `.nexus-agents/${ALTERNATE_CONFIG_FILE}`,
+  DEFAULT_CONFIG_FILE,
+  ALTERNATE_CONFIG_FILE,
+];
 
 /**
  * Result of loading configuration.
@@ -105,16 +115,12 @@ function findConfigPath(cwd: string): string | undefined {
     }
   }
 
-  // Check current directory for .yaml
-  const yamlPath = resolve(cwd, DEFAULT_CONFIG_FILE);
-  if (existsSync(yamlPath)) {
-    return yamlPath;
-  }
-
-  // Check current directory for .yml
-  const ymlPath = resolve(cwd, ALTERNATE_CONFIG_FILE);
-  if (existsSync(ymlPath)) {
-    return ymlPath;
+  // Probe each lookup path in order — dotdir wins over root-level legacy.
+  for (const rel of CONFIG_LOOKUP_PATHS) {
+    const abs = resolve(cwd, rel);
+    if (existsSync(abs)) {
+      return abs;
+    }
   }
 
   // Check global config directory (resolved data dir) as fallback (#1265 + #2316)


### PR DESCRIPTION
Lands #2877 from epic #2872. New installs write `nexus-agents.yaml` to `.nexus-agents/nexus-agents.yaml` instead of the repo root. Existing root-level configs keep working transparently — both writers and the loader fall back to them.

## Loader changes (`config-loader.ts`)

Replaced the two-step yaml/yml probe with `CONFIG_LOOKUP_PATHS` checked in order:

| Order | Path |
|---|---|
| 1 | `NEXUS_CONFIG_PATH` env (unchanged) |
| 2 | **NEW:** `<cwd>/.nexus-agents/nexus-agents.yaml` |
| 3 | **NEW:** `<cwd>/.nexus-agents/nexus-agents.yml` |
| 4 | `<cwd>/nexus-agents.yaml` (legacy root, still works) |
| 5 | `<cwd>/nexus-agents.yml` (legacy root, still works) |
| 6 | `<getNexusDataDir()>/nexus-agents.yaml` (global fallback, unchanged) |

## Writer changes (`setup-config.ts`, `config-init.ts`)

Both writers honor a pre-existing legacy root-level file (edit in place — don't silently move the user's config; the migrate command #2879 will be the explicit relocator). Fresh installs land in the dotdir. `setup-config` creates the parent dir as needed.

## Probe changes (`doctor.ts`, `cli-commands-handlers.ts`, `setup-environment.ts`)

Three "is there a nexus config?" checks now look at both the dotdir and the legacy root paths so the first-run hint, doctor output, and env probe all see new-location installs.

## Tests

- 4 new tests in `config-loader.test.ts` pin the precedence + `NEXUS_CONFIG_PATH` dominance.
- 1 updated test in `setup-config.test.ts`: fresh-dir writes to dotdir, not root.
- 1 new test in `setup-config.test.ts`: legacy root file edited in place (no silent move).
- All 20 config-loader + 9 setup-config tests pass locally.

## Scope note

Depends conceptually on #2876 (Option B ratified) but does not depend on #2882 (the resolution-order tier) — this PR is just the config-file location, not the overall data-dir default. Stackable with #2880 and #2881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)