### PR TITLE
feat(cli): nexus-agents migrate — relocate homedir state per-repo (closes #2879)

### DIFF
--- a/.changeset/2879-migrate-command.md
+++ b/.changeset/2879-migrate-command.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': minor
+---
+
+**feat(cli):** `nexus-agents migrate` relocates homedir state into `<repo>/.nexus-agents/` for users adopting the repo-preferred resolver. Closes #2879 (epic #2872).
+
+Required companion to #2882 — without this, opting into `NEXUS_REPO_PREFERRED=1` silently orphans users' existing homedir state. Vote #2876 made this an explicit gate (PM + Catfish dissent: "shipping #2882 without migrate orphans existing users' homedir state").
+
+## Behavior
+
+```bash
+nexus-agents migrate            # copy per-repo state from ~/.nexus-agents to <repo>/.nexus-agents
+nexus-agents migrate --dry-run  # report the plan without writing
+nexus-agents migrate --input <path>   # custom source (default: ~/.nexus-agents)
+nexus-agents migrate --output <path>  # custom target (default: <repo>/.nexus-agents)
+```
+
+Source is never modified (uses `cpSync`, not move). Cross-repo subdirs (`learning`, `voting`, `memory`, `weather`, `research`, `auth`, `usage`) are SKIPPED with an explicit status — they stay homedir-scoped per the #2882 state-split contract. Target subdirs that already contain state are SKIPPED (no merge, no overwrite). Empty source subdirs are SKIPPED.
+
+The per-repo allowlist is read from `getPerRepoSubdirs()` (single source of truth in `nexus-data-dir.ts`) so the migration mirror always matches the resolver.
+
+## Tests
+
+11 tests in `migrate-command.test.ts` covering: empty source (no-op), per-repo copy, cross-repo skip, existing-target skip, empty-source skip, dry-run (writes nothing), missing-repo failure, explicit `--to` override outside a repo, mixed source (copies per-repo and skips every cross-repo subdir), and formatter output for success/dry-run/failure states.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-05-18T08:56:50.155Z",
+  "generated": "2026-05-19T08:07:05.274Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.79.4",
   "cli": {
@@ -130,6 +130,12 @@
         "name": "memory-eval",
         "type": "sync",
         "handler": "handleMemoryEvalCommand",
+        "file": "src/cli-commands-handlers.ts"
+      },
+      {
+        "name": "migrate",
+        "type": "async",
+        "handler": "handleMigrateCommand",
         "file": "src/cli-commands-handlers.ts"
       },
       {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-05-18T08:56:50.155Z
+**Generated:** 2026-05-19T08:07:05.274Z
 **Package Version:** 2.79.4
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CLI Commands (47)
+## CLI Commands (48)
 
 Binary: `nexus-agents`
 
@@ -36,6 +36,7 @@ Binary: `nexus-agents`
 | `login` | async | `handleLoginCommand` | `src/cli-commands-handlers.ts` |
 | `memory-benchmark` | async | `handleMemoryBenchmarkCommand` | `src/cli-commands-handlers.ts` |
 | `memory-eval` | sync | `handleMemoryEvalCommand` | `src/cli-commands-handlers.ts` |
+| `migrate` | async | `handleMigrateCommand` | `src/cli-commands-handlers.ts` |
 | `orchestrate` | async | `handleOrchestrateCommand` | `src/cli-commands-handlers.ts` |
 | `registry` | async | `handleRegistryCommand` | `src/cli-commands-handlers.ts` |
 | `release-announce` | async | `handleReleaseAnnounceCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -159,6 +159,12 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     audience: 'advanced',
   },
   {
+    command: 'migrate',
+    description:
+      'Relocate homedir state (sessions, checkpoints, traces, runs, audit, pipeline, tasks) into <repo>/.nexus-agents/ for users adopting NEXUS_REPO_PREFERRED=1. Cross-repo state stays homedir. --dry-run for a no-op plan. Epic #2872.',
+    audience: 'advanced',
+  },
+  {
     command: 'review',
     description: 'Review a GitHub PR (dogfooding helper)',
     audience: 'advanced',

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -126,6 +126,8 @@ import { handleLoginCommand } from './cli/login-command.js';
 import { handleUsageCommand } from './cli/usage-command.js';
 // Issue #2444: nexus-agents improvement-review — observability-driven improvement loop CLI surface
 import { handleImprovementReviewCommand } from './cli/improvement-review-command.js';
+// Issue #2879 / epic #2872: nexus-agents migrate — relocate homedir state per-repo
+import { handleMigrateCommand } from './cli/migrate-command.js';
 // Issue #637: Release Automation Suite
 import {
   handleReleaseNotesCommand,
@@ -252,6 +254,8 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
     usage: handleUsageCommand,
     // Issue #2444: improvement-review command (observability-driven improvement loop)
     'improvement-review': handleImprovementReviewCommand,
+    // Issue #2879 / epic #2872: migrate command (relocate homedir state per-repo)
+    migrate: handleMigrateCommand,
     // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)
     init: handleInitCommand,
     demo: handleDemoCommand, // Made async for live CLI execution

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -78,6 +78,7 @@ export type CliCommand =
   | 'registry'
   | 'login'
   | 'usage'
+  | 'migrate'
   | 'improvement-review';
 
 /**
@@ -538,6 +539,7 @@ const VALID_COMMANDS: readonly CliCommand[] = [
   'login',
   'usage',
   'improvement-review',
+  'migrate',
 ];
 
 /**

--- a/packages/nexus-agents/src/cli/migrate-command.test.ts
+++ b/packages/nexus-agents/src/cli/migrate-command.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the `nexus-agents migrate` command (#2879, epic #2872).
+ *
+ * Uses real temp directories rather than fs mocks because the migration
+ * exercises actual `cpSync` / `existsSync` semantics and the per-repo
+ * vs cross-repo split is the contract under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { formatMigrationResult, runMigrate } from './migrate-command.js';
+
+describe('runMigrate (#2879)', () => {
+  let workspace: string;
+  let homedirState: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'nexus-migrate-test-'));
+    homedirState = join(workspace, 'home-nexus-agents');
+    repoRoot = join(workspace, 'project');
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(join(repoRoot, '.git'));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  function seed(subdir: string, files: Record<string, string>): void {
+    const dir = join(homedirState, subdir);
+    mkdirSync(dir, { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(join(dir, name), body);
+    }
+  }
+
+  it('returns success with empty plan when source homedir is missing', () => {
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+    expect(result.success).toBe(true);
+    expect(result.subdirs).toHaveLength(0);
+    expect(result.summary).toContain('Nothing to migrate');
+  });
+
+  it('copies a per-repo subdir (sessions) to <repo>/.nexus-agents/', () => {
+    seed('sessions', { 'journal-1.jsonl': '{"x":1}\n' });
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+
+    expect(result.success).toBe(true);
+    const sessions = result.subdirs.find((s) => s.subdir === 'sessions');
+    expect(sessions?.status).toBe('copied');
+    expect(sessions?.itemsCopied).toBe(1);
+    expect(existsSync(join(repoRoot, '.nexus-agents', 'sessions', 'journal-1.jsonl'))).toBe(true);
+    // Source untouched
+    expect(existsSync(join(homedirState, 'sessions', 'journal-1.jsonl'))).toBe(true);
+  });
+
+  it('skips cross-repo subdirs (learning) with explicit status', () => {
+    seed('learning', { 'outcomes.jsonl': '{"y":2}\n' });
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+
+    const learning = result.subdirs.find((s) => s.subdir === 'learning');
+    expect(learning?.status).toBe('skipped-not-per-repo');
+    // Cross-repo subdir is NEVER copied — confirms the state-split contract.
+    expect(existsSync(join(repoRoot, '.nexus-agents', 'learning'))).toBe(false);
+  });
+
+  it('skips per-repo subdirs that already have state at the destination', () => {
+    seed('checkpoints', { 'cp-1.jsonl': '{}\n' });
+    const targetSub = join(repoRoot, '.nexus-agents', 'checkpoints');
+    mkdirSync(targetSub, { recursive: true });
+    writeFileSync(join(targetSub, 'existing.jsonl'), '{"existing":true}\n');
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+
+    const cp = result.subdirs.find((s) => s.subdir === 'checkpoints');
+    expect(cp?.status).toBe('skipped-exists');
+    // Existing file preserved, no merge attempted.
+    expect(readFileSync(join(targetSub, 'existing.jsonl'), 'utf-8')).toBe('{"existing":true}\n');
+    expect(existsSync(join(targetSub, 'cp-1.jsonl'))).toBe(false);
+  });
+
+  it('skips empty per-repo subdirs', () => {
+    mkdirSync(join(homedirState, 'traces'), { recursive: true });
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+
+    const traces = result.subdirs.find((s) => s.subdir === 'traces');
+    expect(traces?.status).toBe('skipped-empty');
+    expect(existsSync(join(repoRoot, '.nexus-agents', 'traces'))).toBe(false);
+  });
+
+  it('dry-run writes nothing but reports the plan', () => {
+    seed('runs', { 'r-1.jsonl': '{"r":1}\n' });
+    seed('checkpoints', { 'c-1.jsonl': '{}\n' });
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot, dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.summary).toContain('Dry run');
+    expect(result.subdirs.filter((s) => s.status === 'copied')).toHaveLength(2);
+    // Nothing actually written
+    expect(existsSync(join(repoRoot, '.nexus-agents'))).toBe(false);
+  });
+
+  it('fails when no repo can be detected and --to is absent', () => {
+    seed('sessions', { 'x.jsonl': '{}\n' });
+    const nonRepoCwd = mkdtempSync(join(tmpdir(), 'nexus-migrate-no-repo-'));
+    try {
+      const result = runMigrate({ from: homedirState, cwd: nonRepoCwd });
+      expect(result.success).toBe(false);
+      expect(result.summary).toContain('No git repo detected');
+      expect(result.subdirs).toHaveLength(0);
+    } finally {
+      rmSync(nonRepoCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('respects explicit --to override even outside a repo', () => {
+    seed('sessions', { 's-1.jsonl': '{}\n' });
+    const explicitTarget = join(workspace, 'explicit-target');
+    const nonRepoCwd = mkdtempSync(join(tmpdir(), 'nexus-migrate-no-repo-'));
+    try {
+      const result = runMigrate({
+        from: homedirState,
+        cwd: nonRepoCwd,
+        to: explicitTarget,
+      });
+      expect(result.success).toBe(true);
+      expect(existsSync(join(explicitTarget, 'sessions', 's-1.jsonl'))).toBe(true);
+    } finally {
+      rmSync(nonRepoCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('copies every per-repo subdir but no cross-repo subdir in a mixed source', () => {
+    // Per-repo subdirs: should be copied
+    seed('sessions', { 's.jsonl': '{}' });
+    seed('checkpoints', { 'c.jsonl': '{}' });
+    seed('traces', { 't.jsonl': '{}' });
+    seed('runs', { 'r.jsonl': '{}' });
+    // Cross-repo subdirs: should NOT be copied
+    seed('learning', { 'l.jsonl': '{}' });
+    seed('voting', { 'v.json': '{}' });
+    seed('memory', { 'm.json': '{}' });
+    seed('research', { 'rs.json': '{}' });
+
+    const result = runMigrate({ from: homedirState, cwd: repoRoot });
+
+    const copied = result.subdirs.filter((s) => s.status === 'copied').map((s) => s.subdir);
+    const skipped = result.subdirs
+      .filter((s) => s.status === 'skipped-not-per-repo')
+      .map((s) => s.subdir);
+
+    expect(copied.sort()).toEqual(['checkpoints', 'runs', 'sessions', 'traces']);
+    expect(skipped.sort()).toEqual(['learning', 'memory', 'research', 'voting']);
+  });
+});
+
+describe('formatMigrationResult', () => {
+  it('formats a successful copy with checkmark + next-steps hint', () => {
+    const output = formatMigrationResult({
+      fromBase: '/home/u/.nexus-agents',
+      toBase: '/repo/.nexus-agents',
+      dryRun: false,
+      subdirs: [
+        {
+          subdir: 'sessions',
+          status: 'copied',
+          source: '/home/u/.nexus-agents/sessions',
+          target: '/repo/.nexus-agents/sessions',
+          itemsCopied: 3,
+        },
+      ],
+      success: true,
+      summary: 'Copied 1 per-repo subdir(s) from /home/u/.nexus-agents → /repo/.nexus-agents.',
+    });
+    expect(output).toContain('✓ sessions (3 item(s))');
+    expect(output).toContain('export NEXUS_REPO_PREFERRED=1');
+  });
+
+  it('formats a dry-run without the next-steps hint', () => {
+    const output = formatMigrationResult({
+      fromBase: '/a',
+      toBase: '/b',
+      dryRun: true,
+      subdirs: [
+        {
+          subdir: 'runs',
+          status: 'copied',
+          source: '/a/runs',
+          target: '/b/runs',
+          itemsCopied: 1,
+        },
+      ],
+      success: true,
+      summary: 'Dry run: would copy 1 per-repo subdir(s) from /a → /b.',
+    });
+    expect(output).toContain('Dry run');
+    expect(output).not.toContain('export NEXUS_REPO_PREFERRED=1');
+  });
+
+  it('formats a failure case with the summary verbatim', () => {
+    const output = formatMigrationResult({
+      fromBase: '/x',
+      toBase: '',
+      dryRun: false,
+      subdirs: [],
+      success: false,
+      summary: 'No git repo detected from cwd.',
+    });
+    expect(output).toContain('migrate: No git repo detected');
+  });
+});

--- a/packages/nexus-agents/src/cli/migrate-command.ts
+++ b/packages/nexus-agents/src/cli/migrate-command.ts
@@ -1,0 +1,260 @@
+/**
+ * `nexus-agents migrate` — relocate homedir state into <repo>/.nexus-agents/
+ * for users adopting the repo-preferred resolver from #2882.
+ *
+ * Copies (not moves) per-repo categorized subdirectories from
+ * `~/.nexus-agents/` into `<repo>/.nexus-agents/`. Cross-repo state stays
+ * homedir-scoped per the state-split contract codified in #2882's
+ * `PER_REPO_SUBDIRS` allowlist — that's the source of truth, this command
+ * reads from it via `getPerRepoSubdirs()` so the two stay in sync.
+ *
+ * Source: epic #2872, issue #2879, ratified by vote #2876.
+ *
+ * @module cli/migrate-command
+ */
+
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { createLogger } from '../core/index.js';
+import { getPerRepoSubdirs } from '../config/nexus-data-dir.js';
+import { findRepoRoot } from '../config/repo-root-detection.js';
+
+const logger = createLogger({ component: 'migrate-command' });
+
+const HOMEDIR_DEFAULT_BASE = join(homedir(), '.nexus-agents');
+
+/** Result of a single subdir migration. */
+export interface SubdirMigration {
+  readonly subdir: string;
+  readonly status: 'copied' | 'skipped-empty' | 'skipped-exists' | 'skipped-not-per-repo';
+  readonly source: string;
+  readonly target: string;
+  readonly itemsCopied: number;
+}
+
+/** Overall migration result. */
+export interface MigrationResult {
+  readonly fromBase: string;
+  readonly toBase: string;
+  readonly dryRun: boolean;
+  readonly subdirs: readonly SubdirMigration[];
+  readonly success: boolean;
+  /** Human-readable summary line for stderr. */
+  readonly summary: string;
+}
+
+/** Options accepted by `runMigrate`. */
+export interface MigrateOptions {
+  /** Override the source base (default: `~/.nexus-agents`). */
+  readonly from?: string;
+  /** Override the destination base (default: `<repo-root>/.nexus-agents`). */
+  readonly to?: string;
+  /** Override cwd (test injection). Default: `process.cwd()`. */
+  readonly cwd?: string;
+  /** Report the plan without writing. */
+  readonly dryRun?: boolean;
+}
+
+/** Recursive count of leaf entries in a directory. Used for reporting. */
+function countItems(dir: string): number {
+  if (!existsSync(dir)) return 0;
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    let n = 0;
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        n += countItems(p);
+      } else {
+        n += 1;
+      }
+    }
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Plans + executes the migration. Returns a structured result for the
+ * CLI handler to format and the test suite to inspect.
+ *
+ * Safety:
+ *   - Source is never modified (uses `cpSync` with default behavior).
+ *   - Target subdirs that already contain state are SKIPPED (we don't
+ *     merge or overwrite — that's a recipe for silent state corruption).
+ *   - Empty source subdirs are SKIPPED.
+ *   - Cross-repo subdirs in the source are SKIPPED with an explicit
+ *     status so the operator can see what stayed in homedir.
+ */
+export function runMigrate(options: MigrateOptions = {}): MigrationResult {
+  const fromBase = options.from ?? HOMEDIR_DEFAULT_BASE;
+  const cwd = options.cwd ?? process.cwd();
+  const dryRun = options.dryRun ?? false;
+  const toBase = options.to ?? resolveDefaultTarget(cwd);
+
+  const earlyExit = checkEarlyExits(fromBase, toBase, dryRun);
+  if (earlyExit !== null) return earlyExit;
+
+  const perRepoSet = getPerRepoSubdirs();
+  const sourceEntries = readdirSync(fromBase, { withFileTypes: true });
+  const subdirs: SubdirMigration[] = [];
+
+  for (const entry of sourceEntries) {
+    if (!entry.isDirectory()) continue;
+    subdirs.push(planAndExecuteEntry(entry.name, fromBase, toBase as string, perRepoSet, dryRun));
+  }
+
+  const copied = subdirs.filter((s) => s.status === 'copied').length;
+  const summary = dryRun
+    ? `Dry run: would copy ${String(copied)} per-repo subdir(s) from ${fromBase} → ${String(toBase)}.`
+    : `Copied ${String(copied)} per-repo subdir(s) from ${fromBase} → ${String(toBase)}.`;
+
+  logger.info('Migration complete', { dryRun, copied, fromBase, toBase });
+
+  return { fromBase, toBase: toBase as string, dryRun, subdirs, success: true, summary };
+}
+
+/**
+ * Pre-loop validation: returns a `MigrationResult` for the no-op cases
+ * (no target dir resolvable, source absent) and `null` to indicate the
+ * main loop should proceed.
+ */
+function checkEarlyExits(
+  fromBase: string,
+  toBase: string | null,
+  dryRun: boolean
+): MigrationResult | null {
+  if (toBase === null) {
+    return {
+      fromBase,
+      toBase: '',
+      dryRun,
+      subdirs: [],
+      success: false,
+      summary:
+        'No git repo detected from cwd. Run from inside a repo or pass --to <path> to choose an explicit destination.',
+    };
+  }
+  if (!existsSync(fromBase)) {
+    return {
+      fromBase,
+      toBase,
+      dryRun,
+      subdirs: [],
+      success: true,
+      summary: `No source state at ${fromBase}. Nothing to migrate.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Classifies and (if applicable) executes the migration of a single
+ * source subdirectory. Returns the structured per-subdir result so
+ * `runMigrate()` is a pure aggregator.
+ */
+function planAndExecuteEntry(
+  name: string,
+  fromBase: string,
+  toBase: string,
+  perRepoSet: ReadonlySet<string>,
+  dryRun: boolean
+): SubdirMigration {
+  const source = join(fromBase, name);
+  const target = join(toBase, name);
+
+  if (!perRepoSet.has(name)) {
+    return { subdir: name, status: 'skipped-not-per-repo', source, target: '', itemsCopied: 0 };
+  }
+  const items = countItems(source);
+  if (items === 0) {
+    return { subdir: name, status: 'skipped-empty', source, target, itemsCopied: 0 };
+  }
+  if (existsSync(target) && readdirSync(target).length > 0) {
+    return { subdir: name, status: 'skipped-exists', source, target, itemsCopied: 0 };
+  }
+  if (!dryRun) {
+    mkdirSync(toBase, { recursive: true });
+    cpSync(source, target, { recursive: true, errorOnExist: false });
+  }
+  return { subdir: name, status: 'copied', source, target, itemsCopied: items };
+}
+
+/**
+ * Resolves the default migration target: `<repo-root>/.nexus-agents/`
+ * by walking upward from `cwd` for an ancestor `.git`. Returns `null`
+ * when not inside a repo and `--to` wasn't provided.
+ */
+function resolveDefaultTarget(cwd: string): string | null {
+  const repoRoot = findRepoRoot(cwd);
+  if (repoRoot === null) return null;
+  return join(repoRoot, '.nexus-agents');
+}
+
+/**
+ * Formats the migration result for stderr output.
+ * Kept pure so the test suite can assert against the rendered string.
+ */
+export function formatMigrationResult(result: MigrationResult): string {
+  if (!result.success) {
+    return `migrate: ${result.summary}\n`;
+  }
+  const lines: string[] = [];
+  lines.push(result.summary);
+  if (result.subdirs.length === 0) {
+    return `${lines.join('\n')}\n`;
+  }
+  lines.push('');
+  for (const s of result.subdirs) {
+    const tag = s.status === 'copied' ? '✓' : '·';
+    const detail =
+      s.status === 'copied'
+        ? `(${String(s.itemsCopied)} item(s))`
+        : s.status === 'skipped-not-per-repo'
+          ? '(cross-repo — kept in homedir)'
+          : s.status === 'skipped-exists'
+            ? '(destination already has state — skipped)'
+            : '(empty source — skipped)';
+    lines.push(`  ${tag} ${s.subdir} ${detail}`);
+  }
+  if (!result.dryRun && result.subdirs.some((s) => s.status === 'copied')) {
+    lines.push('');
+    lines.push('Next: export NEXUS_REPO_PREFERRED=1 to start using the per-repo data dir.');
+    lines.push(
+      'See: https://github.com/nexus-substrate/nexus-agents/issues/2872 for the full epic.'
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * CLI entry point. Reads `--dry-run` from args; honors `--from <path>`
+ * and `--to <path>` overrides via the parsed args' generic `input` /
+ * `output` slots (both flags are reused rather than adding bespoke
+ * parser fields for a once-per-machine command).
+ */
+export async function handleMigrateCommand(args: {
+  readonly options: {
+    readonly dryRun?: boolean;
+    readonly input?: string;
+    readonly output?: string;
+  };
+}): Promise<void> {
+  const opts: MigrateOptions = {
+    ...(args.options.input !== undefined ? { from: args.options.input } : {}),
+    ...(args.options.output !== undefined ? { to: args.options.output } : {}),
+    ...(args.options.dryRun !== undefined ? { dryRun: args.options.dryRun } : {}),
+  };
+  const result = runMigrate(opts);
+  process.stderr.write(formatMigrationResult(result));
+  await Promise.resolve();
+  if (!result.success) {
+    process.exit(1);
+  }
+}
+
+/** Re-export for the migrate command's CLI surface area. */
+export { findRepoRoot };


### PR DESCRIPTION
Lands #2879 from epic #2872. Stacked on #2884 (depends on `getPerRepoSubdirs()` + `findRepoRoot()` from that PR).

## Why this PR exists

Vote #2876 made this command an explicit gate before flipping the `NEXUS_REPO_PREFERRED` default: *"shipping #2882 without migrate orphans existing users' homedir state silently"* (PM + Catfish dissent). With this in place, users can opt into the new resolver without losing continuity on their existing sessions/checkpoints/traces.

## Behavior

```bash
nexus-agents migrate                  # copy per-repo state from
                                       # ~/.nexus-agents to <repo>/.nexus-agents
nexus-agents migrate --dry-run        # report the plan, write nothing
nexus-agents migrate --input <path>   # custom source
nexus-agents migrate --output <path>  # custom target
```

The per-repo allowlist is read from `getPerRepoSubdirs()` (single source of truth in `nexus-data-dir.ts`) so this mirrors the #2882 resolver exactly. No drift possible.

## Safety contract

- Source is never modified — uses `cpSync`, not move. Users can re-run if interrupted; their homedir state stays intact.
- Cross-repo subdirs (`learning`, `voting`, `memory`, `weather`, `research`, `auth`, `usage`) are SKIPPED with status `skipped-not-per-repo` — they stay homedir-scoped per the #2882 state-split contract.
- Target subdirs that already contain state are SKIPPED with status `skipped-exists` — **no merge, no overwrite, no silent state corruption**. The operator decides what to do with conflicts.
- Empty source subdirs are SKIPPED with status `skipped-empty`.
- Fails when no repo can be detected AND no explicit `--to` is provided.

## Wiring

- New `cli/migrate-command.ts` module: `runMigrate`, `formatMigrationResult`, `handleMigrateCommand`. Split into `runMigrate` + `checkEarlyExits` + `planAndExecuteEntry` to keep each function under the 50-line / complexity-10 governance gates.
- Registered in `cli-types.ts` `CliCommand` union and `VALID_COMMANDS` array.
- Registered in `cli-commands.ts` `ASYNC_COMMAND_HANDLERS` dispatch table.
- Reuses existing `--dry-run` / `--input` / `--output` flag parsing (no bespoke parser fields for a once-per-machine command).

## Tests

12 tests in `migrate-command.test.ts` covering: empty source (no-op), per-repo copy, cross-repo skip, existing-target skip, empty-source skip, dry-run (writes nothing), missing-repo failure, explicit `--to` override outside a repo, mixed source (copies every per-repo + skips every cross-repo), and formatter output for success/dry-run/failure states.

## Next: flip the default

Once this + #2884 are both merged, a small follow-up PR flips `NEXUS_REPO_PREFERRED` default to ON. That PR will also wire the auto-gitignore for `.nexus-agents/` and the release-note copy with the migration command as the recommended pre-step. Tracked as the final piece of epic #2872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)