### PR TITLE
feat(config): flip NEXUS_REPO_PREFERRED default to ON + auto-gitignore (epic #2872 finale)

### DIFF
--- a/.changeset/2872-flip-default-repo-preferred.md
+++ b/.changeset/2872-flip-default-repo-preferred.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+**feat(config):** repo-preferred data directory is now the default behavior — runtime artifacts for per-repo work land in `<repo>/.nexus-agents/` automatically. Final piece of epic #2872 (vote #2876).
+
+When nexus-agents runs inside a git repo, per-repo state (sessions, checkpoints, traces, runs, audit, pipeline, tasks) now lands in `<repo-root>/.nexus-agents/<subdir>/` instead of `~/.nexus-agents/`. Cross-repo state (learning, voting, memory, weather, research, auth, usage) still goes to `~/.nexus-agents/` so the cross-project learning loop from #1389 / #1407 stays intact — vote #2876 made this state-category split a hard condition.
+
+## Auto-gitignore
+
+On first resolution per process per repo, `.nexus-agents/` is auto-appended to `<repo>/.gitignore` (idempotent — won't duplicate). This is the fail-closed behavior required by the security review in vote #2876.
+
+## Escape hatches preserved
+
+- `NEXUS_REPO_PREFERRED=0` — fully opt out; behaves like the previous homedir-default release.
+- `NEXUS_DATA_DIR=~/.nexus-agents` — explicit override wins over the tier AND the categorization both. Users with cross-repo workflows can pin to homedir for everything.
+- `NEXUS_GITIGNORE_AUTO=0` — silences the auto-gitignore append (useful on CI runners with a frozen working tree).
+
+## Migration
+
+If you have existing state in `~/.nexus-agents/` you want to keep working with, run `nexus-agents migrate` (shipped in the previous release via #2879) **before** running any other nexus-agents command in your repo. The migrate command copies per-repo subdirs from homedir → `<repo>/.nexus-agents/` (source untouched, cross-repo subdirs skipped, destination conflicts skipped).
+
+Users with multi-repo cross-pollination workflows who want to keep the old behavior should add `export NEXUS_DATA_DIR=$HOME/.nexus-agents` to their shell rc.
+
+Closes the final piece of epic #2872. After this lands, running `nexus-agents` in a fresh repo produces one new top-level entry — `.nexus-agents/`, auto-gitignored, containing every per-repo runtime artifact. Removing that one directory fully resets the repo's state.

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ tsundoku/
 
 # Ephemeral worktrees from agent runs
 .claude/worktrees/
+.nexus-agents/

--- a/packages/nexus-agents/src/config/nexus-data-dir.test.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.test.ts
@@ -105,16 +105,24 @@ describe('getNexusDataDir', () => {
 
 describe('nexusDataPath', () => {
   let originalEnv: string | undefined;
+  let originalRepoPreferred: string | undefined;
 
   beforeEach(() => {
     originalEnv = process.env['NEXUS_DATA_DIR'];
+    originalRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
     delete process.env['NEXUS_DATA_DIR'];
+    // This block tests the homedir base — disable the now-default
+    // repo-preferred tier so per-repo subdir names ('audit') still
+    // resolve to homedir. Vote #2876 flipped the default to ON.
+    process.env['NEXUS_REPO_PREFERRED'] = '0';
     resetNexusDataDirCache();
   });
 
   afterEach(() => {
     if (originalEnv === undefined) delete process.env['NEXUS_DATA_DIR'];
     else process.env['NEXUS_DATA_DIR'] = originalEnv;
+    if (originalRepoPreferred === undefined) delete process.env['NEXUS_REPO_PREFERRED'];
+    else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPreferred;
     resetNexusDataDirCache();
   });
 
@@ -139,11 +147,12 @@ describe('nexusDataPath', () => {
 // category split per vote #2876 — per-repo subdirs (sessions, checkpoints,
 // traces, runs, audit, pipeline, tasks) route to <repo>/.nexus-agents/
 // when NEXUS_REPO_PREFERRED=1; cross-repo subdirs always go to homedir.
-describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
+describe('NEXUS_REPO_PREFERRED routing (epic #2872, default-ON via vote #2876)', () => {
   let originalCwd: string;
   let originalNexusDataDir: string | undefined;
   let originalRepoPreferred: string | undefined;
   let originalSandbox: string | undefined;
+  let originalGitignoreAuto: string | undefined;
   let tempRepo: string;
 
   beforeEach(async () => {
@@ -151,14 +160,21 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     originalNexusDataDir = process.env['NEXUS_DATA_DIR'];
     originalRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
     originalSandbox = process.env['NEXUS_SANDBOX'];
+    originalGitignoreAuto = process.env['NEXUS_GITIGNORE_AUTO'];
     delete process.env['NEXUS_DATA_DIR'];
     delete process.env['NEXUS_REPO_PREFERRED'];
     delete process.env['NEXUS_SANDBOX'];
+    // Silence the auto-gitignore side-effect by default — tests that want
+    // to exercise it re-enable per-test.
+    process.env['NEXUS_GITIGNORE_AUTO'] = '0';
 
     const { mkdtempSync, mkdirSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
     tempRepo = mkdtempSync(join(tmpdir(), 'nexus-repo-preferred-'));
     mkdirSync(join(tempRepo, '.git'));
+
+    const { _resetGitignoreMemoForTests } = await import('./nexus-data-dir.js');
+    _resetGitignoreMemoForTests();
   });
 
   afterEach(async () => {
@@ -169,31 +185,32 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPreferred;
     if (originalSandbox === undefined) delete process.env['NEXUS_SANDBOX'];
     else process.env['NEXUS_SANDBOX'] = originalSandbox;
+    if (originalGitignoreAuto === undefined) delete process.env['NEXUS_GITIGNORE_AUTO'];
+    else process.env['NEXUS_GITIGNORE_AUTO'] = originalGitignoreAuto;
     const { rmSync } = await import('node:fs');
     rmSync(tempRepo, { recursive: true, force: true });
   });
 
-  it('returns null from getNexusRepoDir when NEXUS_REPO_PREFERRED is unset', async () => {
+  it('returns <repo>/.nexus-agents from getNexusRepoDir by default (no env set) inside a repo', async () => {
     const { getNexusRepoDir } = await import('./nexus-data-dir.js');
-    process.chdir(tempRepo);
-    expect(getNexusRepoDir()).toBe(null);
-  });
-
-  it('returns <repo>/.nexus-agents from getNexusRepoDir when enabled inside a repo', async () => {
-    const { getNexusRepoDir } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     const { realpathSync } = await import('node:fs');
     expect(getNexusRepoDir()).toBe(join(realpathSync(tempRepo), '.nexus-agents'));
   });
 
-  it('returns null when enabled but cwd is not in a repo', async () => {
+  it('returns null when NEXUS_REPO_PREFERRED=0 (explicit opt-out, even inside a repo)', async () => {
+    const { getNexusRepoDir } = await import('./nexus-data-dir.js');
+    process.env['NEXUS_REPO_PREFERRED'] = '0';
+    process.chdir(tempRepo);
+    expect(getNexusRepoDir()).toBe(null);
+  });
+
+  it('returns null when cwd is not in a repo (homedir fallback)', async () => {
     const { getNexusRepoDir } = await import('./nexus-data-dir.js');
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
     const nonRepo = mkdtempSync(join(tmpdir(), 'nexus-no-repo-'));
     try {
-      process.env['NEXUS_REPO_PREFERRED'] = '1';
       process.chdir(nonRepo);
       expect(getNexusRepoDir()).toBe(null);
     } finally {
@@ -202,17 +219,15 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     }
   });
 
-  it('NEXUS_DATA_DIR explicit override wins over NEXUS_REPO_PREFERRED', async () => {
+  it('NEXUS_DATA_DIR explicit override wins over the repo-preferred default', async () => {
     const { getNexusRepoDir } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.env['NEXUS_DATA_DIR'] = '/tmp/explicit-override';
     process.chdir(tempRepo);
     expect(getNexusRepoDir()).toBe(null);
   });
 
-  it('routes per-repo subdir (sessions) to <repo> when enabled', async () => {
+  it('routes per-repo subdir (sessions) to <repo> by default inside a repo', async () => {
     const { nexusDataPath } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     const { realpathSync } = await import('node:fs');
     expect(nexusDataPath('sessions', 'journal-x.jsonl')).toBe(
@@ -220,9 +235,8 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     );
   });
 
-  it('routes cross-repo subdir (learning) to homedir even when enabled inside a repo', async () => {
+  it('routes cross-repo subdir (learning) to homedir even by default', async () => {
     const { nexusDataPath } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     expect(nexusDataPath('learning', 'outcomes.jsonl')).toBe(
       join(homedir(), '.nexus-agents', 'learning', 'outcomes.jsonl')
@@ -231,7 +245,6 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
 
   it('routes every cross-repo subdir to homedir (regression guard)', async () => {
     const { nexusDataPath } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     for (const subdir of ['learning', 'voting', 'memory', 'weather', 'research', 'auth', 'usage']) {
       expect(nexusDataPath(subdir, 'x.json')).toBe(
@@ -242,7 +255,6 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
 
   it('routes every per-repo subdir to the repo (regression guard)', async () => {
     const { nexusDataPath } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     const { realpathSync } = await import('node:fs');
     const repoBase = join(realpathSync(tempRepo), '.nexus-agents');
@@ -259,17 +271,48 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     }
   });
 
-  it('routes per-repo subdir to HOMEDIR when NEXUS_REPO_PREFERRED is unset (backward compat)', async () => {
+  it('routes per-repo subdir to HOMEDIR when NEXUS_REPO_PREFERRED=0 (opt-out)', async () => {
     const { nexusDataPath } = await import('./nexus-data-dir.js');
+    process.env['NEXUS_REPO_PREFERRED'] = '0';
     process.chdir(tempRepo);
     expect(nexusDataPath('sessions', 'foo.jsonl')).toBe(
       join(homedir(), '.nexus-agents', 'sessions', 'foo.jsonl')
     );
   });
 
+  it('auto-appends .nexus-agents/ to <repo>/.gitignore on first resolution', async () => {
+    const { getNexusRepoDir } = await import('./nexus-data-dir.js');
+    const { readFileSync } = await import('node:fs');
+    // Re-enable the auto-gitignore side-effect for this test only.
+    delete process.env['NEXUS_GITIGNORE_AUTO'];
+    process.chdir(tempRepo);
+    expect(getNexusRepoDir()).not.toBe(null);
+    const ignoreContents = readFileSync(join(tempRepo, '.gitignore'), 'utf-8');
+    expect(ignoreContents).toContain('.nexus-agents/');
+  });
+
+  it('honors NEXUS_GITIGNORE_AUTO=0 — does not create .gitignore even when resolving', async () => {
+    const { getNexusRepoDir } = await import('./nexus-data-dir.js');
+    const { existsSync } = await import('node:fs');
+    process.env['NEXUS_GITIGNORE_AUTO'] = '0';
+    process.chdir(tempRepo);
+    expect(getNexusRepoDir()).not.toBe(null);
+    expect(existsSync(join(tempRepo, '.gitignore'))).toBe(false);
+  });
+
+  it('does not duplicate .nexus-agents/ in an existing .gitignore (idempotent)', async () => {
+    const { getNexusRepoDir } = await import('./nexus-data-dir.js');
+    const { writeFileSync, readFileSync } = await import('node:fs');
+    delete process.env['NEXUS_GITIGNORE_AUTO'];
+    writeFileSync(join(tempRepo, '.gitignore'), 'node_modules/\n.nexus-agents/\n', 'utf-8');
+    process.chdir(tempRepo);
+    expect(getNexusRepoDir()).not.toBe(null);
+    const lines = readFileSync(join(tempRepo, '.gitignore'), 'utf-8').split('\n').filter(Boolean);
+    expect(lines.filter((l) => l === '.nexus-agents/')).toHaveLength(1);
+  });
+
   it('nexusSharedPath always returns homedir even for per-repo subdir names', async () => {
     const { nexusSharedPath } = await import('./nexus-data-dir.js');
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(tempRepo);
     expect(nexusSharedPath('sessions', 'foo.jsonl')).toBe(
       join(homedir(), '.nexus-agents', 'sessions', 'foo.jsonl')
@@ -281,7 +324,6 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, issue #2882)', () => {
     const { mkdirSync, realpathSync } = await import('node:fs');
     const deep = join(tempRepo, 'src', 'feature');
     mkdirSync(deep, { recursive: true });
-    process.env['NEXUS_REPO_PREFERRED'] = '1';
     process.chdir(deep);
     expect(nexusDataPath('runs', 'r1.jsonl')).toBe(
       join(realpathSync(tempRepo), '.nexus-agents', 'runs', 'r1.jsonl')

--- a/packages/nexus-agents/src/config/nexus-data-dir.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.ts
@@ -20,25 +20,31 @@
  *    `${NEXUS_SANDBOX_ROOT ?? '/'}/.nexus-agents`. Sandboxed deployments
  *    typically mount a multi-repo root; state goes there, shared across
  *    repo subfolders rather than buried inside one.
- * 3. Per-repo subdirs (when `NEXUS_REPO_PREFERRED=1` is set AND
- *    `findRepoRoot(cwd)` succeeds): `<repo-root>/.nexus-agents/<subdir>/`.
- * 4. `<homedir>/.nexus-agents` (default for both categories without
- *    NEXUS_REPO_PREFERRED, and cross-repo state always).
+ * 3. Per-repo subdirs (when `findRepoRoot(cwd)` succeeds AND
+ *    `NEXUS_REPO_PREFERRED` is not explicitly `'0'`):
+ *    `<repo-root>/.nexus-agents/<subdir>/`. Auto-adds `.nexus-agents/`
+ *    to the repo's `.gitignore` on first resolution (fail-closed).
+ * 4. `<homedir>/.nexus-agents` (cross-repo state, plus everything when
+ *    not in a git repo or when `NEXUS_REPO_PREFERRED=0`).
  *
- * `NEXUS_REPO_PREFERRED` defaults OFF in this release — the new tier is
- * opt-in so users with months of homedir state aren't silently orphaned.
- * `nexus-agents migrate` (#2879) is the explicit path to relocate state
- * before flipping the flag. A follow-up minor release will flip the
- * default per the vote ratification.
+ * `NEXUS_REPO_PREFERRED` defaults **ON** as of this release per vote
+ * #2876. Escape hatches preserved:
+ *   - `NEXUS_REPO_PREFERRED=0` — fully opt out (homedir for everything).
+ *   - `NEXUS_DATA_DIR=~/.nexus-agents` — explicit override wins over
+ *     the tier and the categorization both.
+ *   - `nexus-agents migrate` (#2879) — relocate existing homedir state
+ *     into `<repo>/.nexus-agents/` before flipping in production.
  *
  * @module config/nexus-data-dir
  */
 
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { detectSandbox } from './sandbox-detection.js';
 import { findRepoRoot } from './repo-root-detection.js';
+import { ensureGitignored } from './portable-mode.js';
 
 /**
  * Subdirs scoped to a single repo's work (per the epic #2872 vote).
@@ -86,22 +92,58 @@ export function resetNexusDataDirCache(): void {
 }
 
 /**
+ * Tracks per-process state for the auto-gitignore wiring: we only need
+ * to (a) probe + append to `.gitignore` once per repo, and (b) bail
+ * cleanly if the operator has explicitly silenced the auto-add via
+ * `NEXUS_GITIGNORE_AUTO=0`. Reset in tests via the helper below.
+ */
+const gitignoredRoots = new Set<string>();
+
+/** Test helper — clears the auto-gitignore "already did this" memo. */
+export function _resetGitignoreMemoForTests(): void {
+  gitignoredRoots.clear();
+}
+
+/**
  * Returns the repo-scoped `.nexus-agents/` directory if all of the
- * following hold: `NEXUS_REPO_PREFERRED=1` is set, `NEXUS_DATA_DIR` is
- * NOT explicitly set (explicit override always wins), no sandbox is
- * active, and `findRepoRoot(cwd)` finds an ancestor `.git`.
+ * following hold: `NEXUS_REPO_PREFERRED` is NOT explicitly `'0'` (it
+ * defaults ON as of vote #2876), `NEXUS_DATA_DIR` is not explicitly set
+ * (explicit override always wins), no sandbox is active, and
+ * `findRepoRoot(cwd)` finds an ancestor `.git`.
  *
- * Otherwise returns `null` and callers should fall back to the homedir
- * resolution (i.e. `getNexusDataDir()`).
+ * Side effect: on the first successful resolution per process per repo,
+ * appends `.nexus-agents/` to the repo's `.gitignore` if not already
+ * present. The operator can silence this with `NEXUS_GITIGNORE_AUTO=0`
+ * (e.g. on CI runners with a frozen working tree).
+ *
+ * Returns `null` when any precondition fails; callers fall back to
+ * `getNexusDataDir()` (homedir).
  */
 export function getNexusRepoDir(): string | null {
-  if (process.env['NEXUS_REPO_PREFERRED'] !== '1') return null;
+  if (process.env['NEXUS_REPO_PREFERRED'] === '0') return null;
   const fromEnv = process.env['NEXUS_DATA_DIR']?.trim();
   if (fromEnv !== undefined && fromEnv !== '') return null;
   if (detectSandbox().active) return null;
   const root = findRepoRoot(process.cwd());
   if (root === null) return null;
+  maybeAutoGitignore(root);
   return join(root, '.nexus-agents');
+}
+
+/**
+ * Best-effort fail-closed wiring: once per process per repo, ensure
+ * `.nexus-agents/` is in `<repo>/.gitignore`. Silenced via
+ * `NEXUS_GITIGNORE_AUTO=0`. Failures are non-fatal — the helper logs
+ * to stderr and continues.
+ */
+function maybeAutoGitignore(repoRoot: string): void {
+  if (process.env['NEXUS_GITIGNORE_AUTO'] === '0') return;
+  if (gitignoredRoots.has(repoRoot)) return;
+  gitignoredRoots.add(repoRoot);
+  // Only attempt when the repo root looks real — avoid spamming stderr
+  // from temp-dir test fixtures that race the lifecycle.
+  if (!existsSync(repoRoot)) return;
+  ensureGitignored(repoRoot, '.nexus-agents/');
 }
 
 /**

--- a/packages/nexus-agents/src/config/portable-mode.ts
+++ b/packages/nexus-agents/src/config/portable-mode.ts
@@ -155,9 +155,11 @@ function isInsideGitRepo(cwd: string): boolean {
 
 /**
  * Append `entry` to `<cwd>/.gitignore` if not already present. Stderr
- * announce on the first append.
+ * announce on the first append. Exported because the repo-preferred
+ * resolver in `nexus-data-dir.ts` reuses the same auto-gitignore behavior
+ * when `<repo>/.nexus-agents/` becomes the active data dir (epic #2872).
  */
-function ensureGitignored(cwd: string, entry: string): void {
+export function ensureGitignored(cwd: string, entry: string): void {
   const path = join(cwd, '.gitignore');
   try {
     const existing = existsSync(path) ? readFileSync(path, 'utf-8') : '';


### PR DESCRIPTION
**Final piece of epic #2872** (vote #2876 Option B ratified 85.7%). With this landed, running `nexus-agents` in a fresh repo produces **one** new top-level entry — `.nexus-agents/`, auto-gitignored, containing every per-repo runtime artifact.

## What changes

When nexus-agents runs inside a git repo, per-repo state (`sessions`, `checkpoints`, `traces`, `runs`, `audit`, `pipeline`, `tasks`) now lands in `<repo-root>/.nexus-agents/<subdir>/` by default. Cross-repo state (`learning`, `voting`, `memory`, `weather`, `research`, `auth`, `usage`) still goes to `~/.nexus-agents/` — preserves the cross-project learning loop from #1389 / #1407 per the state-split contract that 5/7 voters made a hard condition.

## Auto-gitignore (security review condition)

On first resolution per process per repo, `.nexus-agents/` is auto-appended to `<repo>/.gitignore`. Idempotent — won't duplicate. Reuses `ensureGitignored()` from `portable-mode.ts` (now exported for reuse). Vote #2876 security-review made this fail-closed behavior a hard condition.

This PR itself adds `.nexus-agents/` to *this* repo's `.gitignore` (the auto-add ran when I executed the test suite locally — natural dogfooding).

## Escape hatches preserved (per vote conditions)

| Variable | Effect |
|---|---|
| `NEXUS_REPO_PREFERRED=0` | Fully opt out; identical to previous homedir-default behavior |
| `NEXUS_DATA_DIR=~/.nexus-agents` | Explicit override wins over the tier AND the categorization both |
| `NEXUS_GITIGNORE_AUTO=0` | Silence the auto-gitignore append (CI runners with frozen working trees) |
| `nexus-agents migrate` (#2879) | Relocate existing homedir state into `<repo>/.nexus-agents/` before adopting |

## Mechanism

- **Gate flipped:** `getNexusRepoDir()` returns `null` **only when** `NEXUS_REPO_PREFERRED === '0'` (explicit opt-out). Unset or any other value = default-ON.
- **Auto-gitignore wired** via `maybeAutoGitignore()` — once per process per repo, memo'd in module-scoped Set. `_resetGitignoreMemoForTests()` exported for test isolation.
- **`ensureGitignored()` exported** from `portable-mode.ts` (was private) so the resolver and the existing sandbox-init code share the same auto-add helper.

## Tests

- 14 routing tests in `nexus-data-dir.test.ts` updated to reflect default-ON: previously-unset cases now expect repo path, explicit `'=0'` variants added for opt-out.
- **3 new auto-gitignore tests:** appends on first resolution, honors `NEXUS_GITIGNORE_AUTO=0`, idempotent on existing `.nexus-agents/` entry.
- Original `nexusDataPath()` base-behavior tests fenced with `NEXUS_REPO_PREFERRED=0` to test the homedir path specifically.
- All 52 tests across `nexus-data-dir` + `repo-root-detection` + `migrate-command` pass.
- Lint + typecheck clean.

## Migration coordination (from vote #2876)

Per the PM + Catfish dissent gate: this PR ships **after** #2885 (`nexus-agents migrate`) landed (commit `b77b7be`-vicinity). Users with months of homedir state can run `nexus-agents migrate` before flipping. Release notes in the changeset call this out.

## Closes epic #2872

| # | Status |
|---|---|
| #2873 (runs/ redirect) | ✅ |
| #2874 (.nexus-pipeline/ redirect) | ✅ |
| #2875 (logs/run_evaluation/ redirect) | ✅ |
| #2876 (design vote) | ✅ |
| #2877 (config in dotdir) | ✅ |
| #2878 (CI gate) | ✅ |
| #2879 (migrate command) | ✅ |
| #2882 (repo-preferred resolver, gated) | ✅ |
| **This PR** (default flip + auto-gitignore) | 🟡 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)