### PR TITLE
fix(config): route per-repo subdir writes through nexusDataPath (closes #2889)

### DIFF
--- a/.changeset/2889-routing-bypass.md
+++ b/.changeset/2889-routing-bypass.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**fix(config):** route per-repo subdir writes through `nexusDataPath()` so the epic-#2872 state-split actually fires. Closes #2889 (epic #2887).
+
+Two callers joined a per-repo subdir directly under `getNexusDataDir()` instead of going through `nexusDataPath()`. The manual join bypassed the per-repo routing — so the state landed in homedir even with `NEXUS_REPO_PREFERRED` ON, partly defeating the consolidation epic #2872 shipped.
+
+- **`pipeline-runner.ts` — `getDefaultRunsDir()`** did `join(getNexusDataDir(), 'runs')`. `runs` is a per-repo subdir, so pipeline trace output went to `~/.nexus-agents/runs/` instead of `<repo>/.nexus-agents/runs/`. Now `nexusDataPath('runs')`.
+- **`setup-data-dir.ts` — `initDataDirectories()`** did `join(NEXUS_DATA_DIR, subdir)` for every subdir in `DATA_SUBDIRECTORIES`, pre-creating `sessions/`, `checkpoints/`, `audit/` (all per-repo) in homedir. Now each subdir routes through `nexusDataPath(...subdir.split('/'))` so per-repo subdirs land in `<repo>/.nexus-agents/` and cross-repo subdirs in homedir.
+
+No behavior change when `NEXUS_DATA_DIR` is explicitly set or `NEXUS_REPO_PREFERRED=0` — both paths still resolve identically. The fix only matters when the repo-preferred default is active, which is where it was silently not working.
+
+Tests: a per-repo-routing test added to each of `pipeline-runner.test.ts` and `setup-data-dir.test.ts`; existing homedir-path tests fenced with `NEXUS_REPO_PREFERRED=0` to keep testing the homedir branch explicitly.

--- a/packages/nexus-agents/src/cli/setup-data-dir.test.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, existsSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 
 // Must hoist the mock so NEXUS_DATA_DIR picks up the mocked homedir at import time
@@ -15,15 +15,30 @@ vi.mock('node:os', async () => {
 
 describe('initDataDirectories (#1249)', () => {
   let dataDirPath: string;
+  let originalRepoPreferred: string | undefined;
+  let originalGitignoreAuto: string | undefined;
 
   beforeEach(async () => {
     // Import after mock is in place
     const os = await import('node:os');
     dataDirPath = os.homedir();
     mkdirSync(dataDirPath, { recursive: true });
+
+    // These tests exercise the homedir-creation path. Disable the
+    // repo-preferred tier so per-repo subdirs (sessions, audit, …) still
+    // resolve under the mocked homedir. The per-repo routing has its
+    // own dedicated test below. Issue #2889 / epic #2887.
+    originalRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
+    originalGitignoreAuto = process.env['NEXUS_GITIGNORE_AUTO'];
+    process.env['NEXUS_REPO_PREFERRED'] = '0';
+    process.env['NEXUS_GITIGNORE_AUTO'] = '0';
   });
 
   afterEach(() => {
+    if (originalRepoPreferred === undefined) delete process.env['NEXUS_REPO_PREFERRED'];
+    else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPreferred;
+    if (originalGitignoreAuto === undefined) delete process.env['NEXUS_GITIGNORE_AUTO'];
+    else process.env['NEXUS_GITIGNORE_AUTO'] = originalGitignoreAuto;
     if (existsSync(dataDirPath)) {
       rmSync(dataDirPath, { recursive: true, force: true });
     }
@@ -36,7 +51,7 @@ describe('initDataDirectories (#1249)', () => {
     expect(result.created.length).toBeGreaterThan(0);
     expect(result.error).toBeNull();
 
-    // Verify key subdirs exist
+    // Verify key subdirs exist (NEXUS_REPO_PREFERRED=0 → all under homedir)
     const root = join(dataDirPath, '.nexus-agents');
     expect(existsSync(root)).toBe(true);
     expect(existsSync(join(root, 'memory'))).toBe(true);
@@ -68,5 +83,40 @@ describe('initDataDirectories (#1249)', () => {
     const result = initDataDirectories();
     expect(result.rootPath).toBe(NEXUS_DATA_DIR);
     expect(result.rootPath).toContain('.nexus-agents');
+  });
+
+  // Issue #2889: per-repo subdirs (sessions, checkpoints, audit, …) must
+  // land in `<repo>/.nexus-agents/`, NOT homedir, when inside a git repo.
+  // Before the fix, initDataDirectories() did `join(NEXUS_DATA_DIR, subdir)`
+  // which bypassed the per-repo router entirely.
+  it('routes per-repo subdirs to the repo and cross-repo subdirs to homedir', async () => {
+    const originalCwd = process.cwd();
+    const tempRepo = mkdtempSync(join(dataDirPath, '..', 'nexus-setup-repo-'));
+    mkdirSync(join(tempRepo, '.git'), { recursive: true });
+    // Default-ON repo-preferred (the production default since #2886).
+    delete process.env['NEXUS_REPO_PREFERRED'];
+    try {
+      process.chdir(tempRepo);
+      const { initDataDirectories } = await import('./setup-data-dir.js');
+      const result = initDataDirectories();
+      expect(result.success).toBe(true);
+
+      // Per-repo subdirs land in the repo.
+      expect(existsSync(join(tempRepo, '.nexus-agents', 'sessions'))).toBe(true);
+      expect(existsSync(join(tempRepo, '.nexus-agents', 'audit'))).toBe(true);
+      expect(existsSync(join(tempRepo, '.nexus-agents', 'checkpoints'))).toBe(true);
+
+      // Cross-repo subdirs stay in the (mocked) homedir.
+      const home = join(dataDirPath, '.nexus-agents');
+      expect(existsSync(join(home, 'learning'))).toBe(true);
+      expect(existsSync(join(home, 'auth'))).toBe(true);
+      expect(existsSync(join(home, 'research'))).toBe(true);
+
+      // Per-repo subdirs must NOT have been created in homedir.
+      expect(existsSync(join(home, 'sessions'))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(tempRepo, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/nexus-agents/src/cli/setup-data-dir.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.ts
@@ -9,12 +9,11 @@
  */
 
 import { mkdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
 import { DATA_SUBDIRECTORIES } from './doctor.js';
-import { getNexusDataDir } from '../config/nexus-data-dir.js';
+import { getNexusDataDir, nexusDataPath } from '../config/nexus-data-dir.js';
 
 /**
- * Root data directory path.
+ * Homedir/cross-repo root data directory path.
  *
  * Resolves to `$NEXUS_DATA_DIR` when set, else `<homedir>/.nexus-agents`.
  * See `src/config/nexus-data-dir.ts` for resolution rules (#2302).
@@ -22,6 +21,11 @@ import { getNexusDataDir } from '../config/nexus-data-dir.js';
  * Evaluated at module-import time. Tests that mutate `NEXUS_DATA_DIR`
  * mid-process should call `resetNexusDataDirCache()` and re-import, or
  * call `getNexusDataDir()` directly.
+ *
+ * NOTE: this is the cross-repo root ONLY. Per-repo subdirs (sessions,
+ * checkpoints, audit, …) resolve to `<repo>/.nexus-agents/`;
+ * `initDataDirectories()` routes each subdir through `nexusDataPath()`
+ * so the per-repo split from epic #2872 is honored. Issue #2889.
  */
 export const NEXUS_DATA_DIR = getNexusDataDir();
 
@@ -55,7 +59,12 @@ export function initDataDirectories(dryRun: boolean = false): DataDirInitResult 
 
     for (const subdir of DATA_SUBDIRECTORIES) {
       const mode = RESTRICTED_DIRS.has(subdir) ? 0o700 : undefined;
-      ensureDir(join(NEXUS_DATA_DIR, subdir), dryRun, created, alreadyExisted, mode);
+      // Route through nexusDataPath() so per-repo subdirs (sessions,
+      // checkpoints, audit, …) land in `<repo>/.nexus-agents/` and
+      // cross-repo subdirs in homedir. Split on '/' so the routing key
+      // is the true first segment (e.g. 'memory/beliefs' → 'memory').
+      const target = nexusDataPath(...subdir.split('/'));
+      ensureDir(target, dryRun, created, alreadyExisted, mode);
     }
 
     return { success: true, rootPath: NEXUS_DATA_DIR, created, alreadyExisted, error: null };

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
@@ -422,4 +422,35 @@ describe('getDefaultRunsDir', () => {
       await rm(b, { recursive: true, force: true });
     }
   });
+
+  // Issue #2889: getDefaultRunsDir() must route through nexusDataPath()
+  // so `runs` (a per-repo subdir) lands in `<repo>/.nexus-agents/runs/`.
+  // The previous `join(getNexusDataDir(), 'runs')` bypassed the router
+  // and traces went to homedir even with NEXUS_REPO_PREFERRED ON.
+  it('routes to <repo>/.nexus-agents/runs when inside a git repo (no NEXUS_DATA_DIR override)', async () => {
+    const { getDefaultRunsDir } = await import('./pipeline-runner.js');
+    const { realpathSync, mkdirSync } = await import('node:fs');
+    const repo = await mkdtemp(join(tmpdir(), 'nexus-runs-repo-'));
+    mkdirSync(join(repo, '.git'));
+    const originalCwd = process.cwd();
+    const prevDataDir = process.env['NEXUS_DATA_DIR'];
+    const prevRepoPref = process.env['NEXUS_REPO_PREFERRED'];
+    const prevGitignore = process.env['NEXUS_GITIGNORE_AUTO'];
+    delete process.env['NEXUS_DATA_DIR'];
+    delete process.env['NEXUS_REPO_PREFERRED'];
+    process.env['NEXUS_GITIGNORE_AUTO'] = '0';
+    try {
+      process.chdir(repo);
+      expect(getDefaultRunsDir()).toBe(join(realpathSync(repo), '.nexus-agents', 'runs'));
+    } finally {
+      process.chdir(originalCwd);
+      if (prevDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prevDataDir;
+      if (prevRepoPref === undefined) delete process.env['NEXUS_REPO_PREFERRED'];
+      else process.env['NEXUS_REPO_PREFERRED'] = prevRepoPref;
+      if (prevGitignore === undefined) delete process.env['NEXUS_GITIGNORE_AUTO'];
+      else process.env['NEXUS_GITIGNORE_AUTO'] = prevGitignore;
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -6,11 +6,9 @@
  *
  * @module pipeline/pipeline-runner
  */
-import { join } from 'node:path';
-
 import { executeGraph } from '../orchestration/graph/graph-executor.js';
 import { createLogger } from '../core/index.js';
-import { getNexusDataDir } from '../config/nexus-data-dir.js';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 
 import { compilePlan } from './plan-compiler.js';
 import type { PlanCompileOptions } from './plan-compiler.js';
@@ -58,13 +56,15 @@ export interface StepOutcome {
 }
 
 /**
- * Default directory for trace output, resolved through `getNexusDataDir()`
- * so runs land under the centralized data dir instead of sprawling at cwd.
- * Function rather than const so `NEXUS_DATA_DIR` env changes are honored
- * at call time (matters for tests that mock the env). See epic #2872.
+ * Default directory for trace output. Resolved through `nexusDataPath()`
+ * — NOT `join(getNexusDataDir(), 'runs')` — because `runs` is a per-repo
+ * subdir: the manual join bypassed the per-repo routing entirely, so
+ * traces landed in homedir even with `NEXUS_REPO_PREFERRED` ON. Issue
+ * #2889. Function rather than const so env changes are honored at call
+ * time (matters for tests that mock the env). See epic #2872 / #2887.
  */
 export function getDefaultRunsDir(): string {
-  return join(getNexusDataDir(), 'runs');
+  return nexusDataPath('runs');
 }
 
 /** Pipeline execution options. */


### PR DESCRIPTION
Lands #2889 from epic #2887 — the highest-impact finding from the audit. The epic #2872 state-split was **partly not firing in practice** because two callers bypassed the router.

## The bypass

`nexusDataPath('sessions', ...)` routes per-repo subdirs to `<repo>/.nexus-agents/`. But `path.join(getNexusDataDir(), 'sessions', ...)` skips the router entirely — it always returns the homedir path. The audit found two callers doing exactly that:

| Caller | Bypass | Effect |
|---|---|---|
| `pipeline-runner.ts` `getDefaultRunsDir()` | `join(getNexusDataDir(), 'runs')` | Pipeline traces went to `~/.nexus-agents/runs/` instead of `<repo>/.nexus-agents/runs/` |
| `setup-data-dir.ts` `initDataDirectories()` | `join(NEXUS_DATA_DIR, subdir)` per `DATA_SUBDIRECTORIES` entry | `nexus-agents setup` pre-created `sessions/`, `checkpoints/`, `audit/` (all per-repo) in homedir |

`getDefaultRunsDir()` is ironic — it was *introduced by epic #2872's own #2873* to fix the `./runs` sprawl, but used `join(getNexusDataDir(), 'runs')` rather than `nexusDataPath('runs')`, so it moved the sprawl from cwd to homedir instead of to the repo.

## The fix

- `getDefaultRunsDir()` → `nexusDataPath('runs')`
- `initDataDirectories()` → `nexusDataPath(...subdir.split('/'))` per subdir (split so the routing key is the true first segment, e.g. `memory/beliefs` → `memory`)

## No behavior change for...

Callers with `NEXUS_DATA_DIR` explicitly set or `NEXUS_REPO_PREFERRED=0` — both paths resolve identically. The fix only changes behavior when the repo-preferred default is active, which is exactly where it was silently broken.

## Tests

- New per-repo-routing test in `pipeline-runner.test.ts`: `getDefaultRunsDir()` returns `<repo>/.nexus-agents/runs` inside a git repo.
- New per-repo-routing test in `setup-data-dir.test.ts`: `initDataDirectories()` creates `sessions/audit/checkpoints` in the repo and `learning/auth/research` in homedir, and asserts per-repo subdirs are NOT created in homedir.
- Existing homedir-path tests fenced with `NEXUS_REPO_PREFERRED=0` so they keep testing the homedir branch explicitly.
- All 23 tests across both files pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)