### PR TITLE
feat(cli): setup auto-gitignores .nexus-agents/ + data-layout hint (closes #2891)

### DIFF
--- a/.changeset/2891-setup-gitignore.md
+++ b/.changeset/2891-setup-gitignore.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**feat(cli):** `nexus-agents setup` auto-gitignores `.nexus-agents/` + prints a data-layout hint. Closes #2891 (epic #2887).
+
+The auto-gitignore landed in `getNexusRepoDir()` (epic #2872) but only fired lazily on the first resolver call — a user who ran `setup` and read its output had no idea where state would live. Setup now, at the end of a successful run:
+
+- Calls `ensureGitignored(repoRoot, '.nexus-agents/')` explicitly so the entry is present immediately (idempotent — won't duplicate).
+- Prints a "Data layout" section explaining per-repo (`.nexus-agents/`) vs cross-project (`~/.nexus-agents/`) state and pointing at `nexus-agents doctor` for the full picture.
+
+Skipped on `--dry-run` (nothing was installed) and when not inside a git repo. Both the interactive and non-interactive setup paths are covered.
+
+4 tests in `setup-command.test.ts`: appends the entry, idempotent on an existing entry, no-op on dry-run, no-op outside a repo.

--- a/packages/nexus-agents/src/cli/setup-command.test.ts
+++ b/packages/nexus-agents/src/cli/setup-command.test.ts
@@ -8,8 +8,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from 'node:fs';
-import { runSetup, printSetupResult, setupCommand } from './setup-command.js';
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync, rmSync, readFileSync } from 'node:fs';
+import {
+  runSetup,
+  printSetupResult,
+  setupCommand,
+  ensureRepoGitignoredAndHint,
+} from './setup-command.js';
 import {
   detectClaudeCli,
   detectMcpConfig,
@@ -739,6 +744,57 @@ describe('Setup Command', () => {
       // Should just have the new nexus-agents hooks
       expect(result.SessionStart).toHaveLength(1);
       expect(result.SessionStart?.[0]?.hooks[0]?.command).toContain('nexus-agents');
+    });
+  });
+
+  // Issue #2891: setup auto-gitignores .nexus-agents/ in the repo so the
+  // user doesn't have to run a workflow first to get the entry.
+  describe('ensureRepoGitignoredAndHint (#2891)', () => {
+    let originalCwd: string;
+    let tempRepo: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      tempRepo = mkdtempSync(join(tmpdir(), 'nexus-setup-gitignore-'));
+      mkdirSync(join(tempRepo, '.git'));
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      rmSync(tempRepo, { recursive: true, force: true });
+    });
+
+    it('appends .nexus-agents/ to the repo .gitignore', () => {
+      process.chdir(tempRepo);
+      ensureRepoGitignoredAndHint(false);
+      const ignore = readFileSync(join(tempRepo, '.gitignore'), 'utf-8');
+      expect(ignore).toContain('.nexus-agents/');
+    });
+
+    it('is idempotent — does not duplicate an existing entry', () => {
+      writeFileSync(join(tempRepo, '.gitignore'), 'node_modules/\n.nexus-agents/\n', 'utf-8');
+      process.chdir(tempRepo);
+      ensureRepoGitignoredAndHint(false);
+      const lines = readFileSync(join(tempRepo, '.gitignore'), 'utf-8').split('\n').filter(Boolean);
+      expect(lines.filter((l) => l === '.nexus-agents/')).toHaveLength(1);
+    });
+
+    it('does nothing on a dry run', () => {
+      process.chdir(tempRepo);
+      ensureRepoGitignoredAndHint(true);
+      expect(existsSync(join(tempRepo, '.gitignore'))).toBe(false);
+    });
+
+    it('does nothing when not inside a git repo', () => {
+      const nonRepo = mkdtempSync(join(tmpdir(), 'nexus-setup-no-repo-'));
+      try {
+        process.chdir(nonRepo);
+        ensureRepoGitignoredAndHint(false);
+        expect(existsSync(join(nonRepo, '.gitignore'))).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+        rmSync(nonRepo, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -45,6 +45,9 @@ import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-perm
 // dirs) inline at the end of setup, with copy-pasteable remediation.
 import { runVerify } from './verify-command.js';
 import { colors, symbols } from './ansi-output.js';
+// #2891: auto-gitignore + first-run layout hint at the end of setup.
+import { ensureGitignored } from '../config/portable-mode.js';
+import { findRepoRoot } from '../config/repo-root-detection.js';
 
 // ============================================================================
 // Output Helpers
@@ -830,6 +833,37 @@ function printGettingStartedBanner(mcpConfigured: boolean): void {
 }
 
 /**
+ * Ensures `.nexus-agents/` is gitignored in the current repo and prints a
+ * first-run hint about the per-repo / cross-repo data layout (#2891).
+ *
+ * Runs once at the end of setup. The auto-gitignore also fires lazily on
+ * the first `getNexusRepoDir()` call, but doing it here means the setup
+ * output explicitly tells the user where state will live — they don't
+ * have to run a workflow first to discover it. Skipped on a dry-run
+ * (nothing was installed) and when not inside a git repo.
+ */
+export function ensureRepoGitignoredAndHint(dryRun: boolean): void {
+  if (dryRun) return;
+  const repoRoot = findRepoRoot(process.cwd());
+  if (repoRoot === null) return;
+
+  ensureGitignored(repoRoot, '.nexus-agents/');
+
+  writeEmptyLine();
+  writeLine(formatHeader('Data layout'));
+  writeLine('─'.repeat(40));
+  writeLine(
+    `  Per-repo state (sessions, traces, runs, audit) → ${colors.dim}.nexus-agents/${colors.reset}`
+  );
+  writeLine(
+    `  Cross-project state (routing memory, model registry) → ${colors.dim}~/.nexus-agents/${colors.reset}`
+  );
+  writeLine(
+    `  ${colors.dim}.nexus-agents/ is gitignored. Run 'nexus-agents doctor' for the full layout.${colors.reset}`
+  );
+}
+
+/**
  * Runs the post-setup health gate (#2137).
  *
  * After setup writes its files, this runs the verify checks and prints a
@@ -937,6 +971,8 @@ async function runInteractiveSetup(options: SetupCommandOptions): Promise<number
   printSetupResult(result, mergedOptions.verbose ?? false);
   const healthOk = await runPostSetupHealthGate(mergedOptions.dryRun ?? false);
   if (result.success && !(mergedOptions.dryRun ?? false)) {
+    // Inside the !dryRun branch — pass false explicitly.
+    ensureRepoGitignoredAndHint(false);
     printGettingStartedBanner(result.mcpConfigured === true);
   }
   return result.success && healthOk ? 0 : 1;
@@ -951,6 +987,8 @@ export async function setupCommandAsync(options: SetupCommandOptions = {}): Prom
   const setupResult = runSetupAndPrint(options);
   const healthOk = await runPostSetupHealthGate(options.dryRun ?? false);
   if (setupResult.exitCode === 0 && !(options.dryRun ?? false)) {
+    // Inside the !dryRun branch — pass false explicitly.
+    ensureRepoGitignoredAndHint(false);
     printGettingStartedBanner(setupResult.mcpConfigured);
   }
   // Hard health failures override a successful setup; warnings don't.


### PR DESCRIPTION
Lands #2891 from epic #2887.

## What's missing today

Epic #2872 wired the auto-gitignore into `getNexusRepoDir()` — but it only fires *lazily* on the first resolver call. A user who runs `nexus-agents setup` and reads its output has no idea where state will live or that `.nexus-agents/` will be gitignored. They'd have to run a workflow first to discover it.

## What this adds

At the end of a successful, non-dry-run `setup` inside a git repo:

1. **Explicit auto-gitignore** — `ensureGitignored(repoRoot, '.nexus-agents/')`, idempotent.
2. **A "Data layout" section** in the setup output:

```
Data layout
────────────────────────────────────────
  Per-repo state (sessions, traces, runs, audit) → .nexus-agents/
  Cross-project state (routing memory, model registry) → ~/.nexus-agents/
  .nexus-agents/ is gitignored. Run 'nexus-agents doctor' for the full layout.
```

Wired into both the interactive (`runInteractiveSetup`) and non-interactive (`setupCommandAsync`) paths. Skipped on `--dry-run` and when not inside a git repo.

## Tests

`ensureRepoGitignoredAndHint()` is exported for direct testing. 4 tests in `setup-command.test.ts`: appends the entry, idempotent on an existing entry, no-op on dry-run, no-op outside a repo. All 64 tests in the file pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)