### PR TITLE
feat(cli): doctor reports per-subdir data paths grouped by state-split (closes #2892)

### DIFF
--- a/.changeset/2892-doctor-paths.md
+++ b/.changeset/2892-doctor-paths.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+**feat(cli):** `nexus-agents doctor` reports per-subdir data paths grouped by the state-split. Closes #2892 (epic #2887).
+
+Before, `doctor` reported a single `~/.nexus-agents/` root and `checkDataDirectory()` did `join(getNexusDataDir(), name)` — which (like #2889) bypassed the per-repo router, so the _reported_ paths were wrong after the epic #2872 flip.
+
+`checkDataDirectory()` now resolves each subdir through `nexusDataPath()` (the real location), tags it `per-repo` or `cross-repo`, and exposes `repoRoot`. The doctor output groups accordingly:
+
+```
+✓ Data directory layout:
+  Per-repo — /repo/.nexus-agents (5/7)
+    ✓ sessions     /repo/.nexus-agents/sessions
+    ✓ audit        /repo/.nexus-agents/audit
+    · pipeline     /repo/.nexus-agents/pipeline  (missing — created on first use)
+    …
+  Cross-repo — /home/u/.nexus-agents (7/7)
+    ✓ learning     /home/u/.nexus-agents/learning
+    ✓ auth         /home/u/.nexus-agents/auth
+    …
+```
+
+`DataSubdirStatus` gains a `scope` field; `DataDirectoryCheck` gains `repoRoot`. Tests added covering scope tagging + the `repoRoot` field.

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -161,6 +161,7 @@ describe('doctor-formatting', () => {
     dataDirectory: {
       rootExists: true,
       rootPath: '/home/test/.nexus-agents',
+      repoRoot: null,
       subdirectories: [],
     },
     sandbox: {

--- a/packages/nexus-agents/src/cli/doctor-formatting.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.ts
@@ -267,37 +267,56 @@ function printSqliteCheck(check: SqliteCheck): void {
   }
 }
 
+/** Prints one scope group of data subdirs with per-subdir resolved paths. */
+function printDataDirGroup(
+  label: string,
+  rootHint: string,
+  subdirs: readonly DataDirectoryCheck['subdirectories'][number][]
+): void {
+  if (subdirs.length === 0) return;
+  const existCount = subdirs.filter((d) => d.exists).length;
+  writeLine(
+    `  ${colors.dim}${label} — ${rootHint} (${String(existCount)}/${String(subdirs.length)})${colors.reset}`
+  );
+  for (const dir of subdirs) {
+    let marker: string;
+    if (!dir.exists) marker = `${colors.dim}·${colors.reset}`;
+    else if (!dir.writable) marker = `${colors.yellow}!${colors.reset}`;
+    else marker = `${colors.green}✓${colors.reset}`;
+    const note = !dir.exists
+      ? ` ${colors.dim}(missing — created on first use)${colors.reset}`
+      : !dir.writable
+        ? ` ${colors.yellow}(not writable)${colors.reset}`
+        : '';
+    writeLine(`    ${marker} ${dir.name}  ${colors.dim}${dir.path}${colors.reset}${note}`);
+  }
+}
+
 /**
- * Prints data directory health check (#1249).
+ * Prints data directory health check (#1249, extended #2892).
+ * Groups subdirs by the epic #2872 state-split so the operator sees
+ * exactly where per-repo vs cross-repo state lives.
  */
 function printDataDirectory(check: DataDirectoryCheck): void {
-  if (check.rootExists) {
-    const existCount = check.subdirectories.filter((d) => d.exists).length;
-    const totalCount = check.subdirectories.length;
-    const allExist = existCount === totalCount;
-    const allWritable = check.subdirectories.every((d) => !d.exists || d.writable);
-    const healthy = allExist && allWritable;
-    writeLine(
-      `${formatStatus(healthy, !healthy)} Data directory: ${check.rootPath} (${String(existCount)}/${String(totalCount)} subdirs)`
-    );
-    if (!allExist) {
-      const missing = check.subdirectories.filter((d) => !d.exists);
-      for (const dir of missing) {
-        writeLine(`  ${colors.dim}Missing: ${dir.name}/${colors.reset}`);
-      }
-      writeLine(`  ${colors.dim}Fix: nexus-agents setup${colors.reset}`);
-    }
-    if (!allWritable) {
-      const readonly_ = check.subdirectories.filter((d) => d.exists && !d.writable);
-      for (const dir of readonly_) {
-        writeLine(`  ${colors.yellow}Not writable: ${dir.name}/${colors.reset}`);
-      }
-    }
+  const allExist = check.subdirectories.every((d) => d.exists);
+  const allWritable = check.subdirectories.every((d) => !d.exists || d.writable);
+  const healthy = check.rootExists && allWritable;
+
+  writeLine(`${formatStatus(healthy, !healthy)} Data directory layout:`);
+
+  const perRepo = check.subdirectories.filter((d) => d.scope === 'per-repo');
+  const crossRepo = check.subdirectories.filter((d) => d.scope === 'cross-repo');
+
+  if (check.repoRoot !== null) {
+    printDataDirGroup('Per-repo', check.repoRoot, perRepo);
   } else {
-    writeLine(
-      `${formatStatus(false, true)} Data directory: ${colors.yellow}Not created${colors.reset}`
-    );
-    writeLine(`  ${colors.dim}Run: nexus-agents setup${colors.reset}`);
+    // Repo-preferred tier inactive — per-repo subdirs also live in homedir.
+    printDataDirGroup('Per-repo (homedir — repo-preferred off)', check.rootPath, perRepo);
+  }
+  printDataDirGroup('Cross-repo', check.rootPath, crossRepo);
+
+  if (!allExist) {
+    writeLine(`  ${colors.dim}Fix: nexus-agents setup${colors.reset}`);
   }
 }
 

--- a/packages/nexus-agents/src/cli/doctor-persistence.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-persistence.test.ts
@@ -130,4 +130,28 @@ describe('Doctor learning persistence check (Issue #1017)', () => {
     expect(typeof result.dataDirectory.rootPath).toBe('string');
     expect(Array.isArray(result.dataDirectory.subdirectories)).toBe(true);
   });
+
+  // Issue #2892: checkDataDirectory() tags each subdir with its
+  // per-repo / cross-repo scope and resolves the real path.
+  it('checkDataDirectory tags subdir scope and exposes repoRoot (#2892)', async () => {
+    const { checkDataDirectory } = await import('./doctor.js');
+    const check = checkDataDirectory();
+
+    expect(check).toHaveProperty('repoRoot');
+    // repoRoot is either a string (repo-preferred active) or null.
+    expect(check.repoRoot === null || typeof check.repoRoot === 'string').toBe(true);
+
+    // Every subdir is tagged with a valid scope.
+    for (const sub of check.subdirectories) {
+      expect(['per-repo', 'cross-repo']).toContain(sub.scope);
+    }
+
+    // Known per-repo subdirs (sessions, audit) are tagged per-repo;
+    // known cross-repo subdirs (learning, auth) are tagged cross-repo.
+    const byName = new Map(check.subdirectories.map((s) => [s.name, s.scope]));
+    expect(byName.get('sessions')).toBe('per-repo');
+    expect(byName.get('audit')).toBe('per-repo');
+    expect(byName.get('learning')).toBe('cross-repo');
+    expect(byName.get('auth')).toBe('cross-repo');
+  });
 });

--- a/packages/nexus-agents/src/cli/doctor.test.ts
+++ b/packages/nexus-agents/src/cli/doctor.test.ts
@@ -110,6 +110,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
     dataDirectory: {
       rootExists: true,
       rootPath: '/home/test/.nexus-agents',
+      repoRoot: null,
       subdirectories: [],
     },
     sandbox: {

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -17,8 +17,12 @@ import {
   accessSync,
   constants as fsConstants,
 } from 'node:fs';
-import { join } from 'node:path';
-import { getNexusDataDir } from '../config/nexus-data-dir.js';
+import {
+  getNexusDataDir,
+  getNexusRepoDir,
+  getPerRepoSubdirs,
+  nexusDataPath,
+} from '../config/nexus-data-dir.js';
 import { detectSandbox } from '../config/sandbox-detection.js';
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import {
@@ -142,12 +146,19 @@ export interface SqliteCheck {
 }
 
 /**
- * Data directory health check (#1249).
- * Reports status of ~/.nexus-agents/ and its subdirectories.
+ * Data directory health check (#1249, extended #2892).
+ * Reports the resolved location of every data subdirectory — per-repo
+ * subdirs under `<repo>/.nexus-agents/`, cross-repo subdirs under
+ * `~/.nexus-agents/` — so the operator can see where state actually
+ * lives after the epic #2872 state-split.
  */
 export interface DataDirectoryCheck {
+  /** True if the homedir/cross-repo root exists. */
   readonly rootExists: boolean;
+  /** The homedir/cross-repo root path. */
   readonly rootPath: string;
+  /** `<repo>/.nexus-agents` when the repo-preferred tier is active, else null. */
+  readonly repoRoot: string | null;
   readonly subdirectories: readonly DataSubdirStatus[];
 }
 
@@ -156,7 +167,10 @@ export interface DataDirectoryCheck {
  */
 export interface DataSubdirStatus {
   readonly name: string;
+  /** Actual resolved path (per-repo or homedir, per the #2872 split). */
   readonly path: string;
+  /** Which side of the state-split this subdir belongs to. */
+  readonly scope: 'per-repo' | 'cross-repo';
   readonly exists: boolean;
   readonly writable: boolean;
 }
@@ -589,7 +603,11 @@ export async function checkSqlite(): Promise<SqliteCheck> {
 }
 
 /**
- * Checks the ~/.nexus-agents/ data directory health (#1249).
+ * Checks the nexus-agents data directory health (#1249, extended #2892).
+ *
+ * Resolves each subdir through `nexusDataPath()` so the reported path is
+ * the REAL location after the epic #2872 state-split — per-repo subdirs
+ * land in `<repo>/.nexus-agents/`, cross-repo subdirs in `~/.nexus-agents/`.
  *
  * Exported so `verify` (#2136) can reuse it without running the full doctor
  * pipeline.
@@ -597,14 +615,20 @@ export async function checkSqlite(): Promise<SqliteCheck> {
 export function checkDataDirectory(): DataDirectoryCheck {
   const rootPath = getNexusDataDir();
   const rootExists = existsSync(rootPath);
+  const repoRoot = getNexusRepoDir();
+  const perRepoSet = getPerRepoSubdirs();
 
   const subdirectories: DataSubdirStatus[] = DATA_SUBDIRECTORIES.map((name) => {
-    const fullPath = join(rootPath, name);
+    const segments = name.split('/');
+    const fullPath = nexusDataPath(...segments);
     const exists = existsSync(fullPath);
-    return { name, path: fullPath, exists, writable: exists && isWritable(fullPath) };
+    const scope: 'per-repo' | 'cross-repo' = perRepoSet.has(segments[0] ?? '')
+      ? 'per-repo'
+      : 'cross-repo';
+    return { name, path: fullPath, scope, exists, writable: exists && isWritable(fullPath) };
   });
 
-  return { rootExists, rootPath, subdirectories };
+  return { rootExists, rootPath, repoRoot, subdirectories };
 }
 
 /** Checks if a directory is writable by the current user. */

--- a/packages/nexus-agents/src/cli/validate-command.test.ts
+++ b/packages/nexus-agents/src/cli/validate-command.test.ts
@@ -83,7 +83,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
       error: null,
     },
     sqliteCheck: { available: true, error: null },
-    dataDirectory: { rootExists: true, rootPath: '/tmp', subdirectories: [] },
+    dataDirectory: { rootExists: true, rootPath: '/tmp', repoRoot: null, subdirectories: [] },
     sandbox: {
       active: false,
       flavor: undefined,


### PR DESCRIPTION
Lands #2892 from epic #2887.

## What was wrong

`nexus-agents doctor` reported a single `~/.nexus-agents/` root. After epic #2872's state-split, that's misleading — and `checkDataDirectory()` did `join(getNexusDataDir(), name)`, the **same router-bypass bug as #2889**, so the reported paths were flat-out wrong for per-repo subdirs.

## What this does

`checkDataDirectory()` now:
- Resolves each subdir through `nexusDataPath()` — the **real** location.
- Tags each subdir `per-repo` / `cross-repo` via `getPerRepoSubdirs()`.
- Exposes `repoRoot` (the `<repo>/.nexus-agents` path when the repo-preferred tier is active, else `null`).

Doctor output now groups by scope:

```
✓ Data directory layout:
  Per-repo — /repo/.nexus-agents (5/7)
    ✓ sessions     /repo/.nexus-agents/sessions
    ✓ audit        /repo/.nexus-agents/audit
    · pipeline     /repo/.nexus-agents/pipeline  (missing — created on first use)
  Cross-repo — /home/u/.nexus-agents (7/7)
    ✓ learning     /home/u/.nexus-agents/learning
    ✓ auth         /home/u/.nexus-agents/auth
```

An operator can now see exactly where every piece of state lives.

## Type changes

- `DataSubdirStatus` gains `scope: 'per-repo' | 'cross-repo'`
- `DataDirectoryCheck` gains `repoRoot: string | null`

Test fixtures in `doctor.test.ts`, `doctor-formatting.test.ts`, `validate-command.test.ts` updated for the new field. New test in `doctor-persistence.test.ts` pins scope tagging + `repoRoot`. All 55 doctor-suite + 6 validate-command tests pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)