### PR TITLE
chore(ci): devcontainer + docker-compose consolidation E2E test (closes #2894 #2895)

### DIFF
--- a/.changeset/2894-2895-devcontainer-consolidation.md
+++ b/.changeset/2894-2895-devcontainer-consolidation.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+**chore(ci):** `.devcontainer/` for contributor parity + a docker-compose consolidation E2E test. Closes #2894 + #2895 (epic #2887).
+
+## `.devcontainer/devcontainer.json` (#2894)
+
+A Node 22 + pnpm 9.15.0 devcontainer pinned to match CI. Contributors get a one-click CI-identical environment; `pnpm install && pnpm test` works with zero manual setup. No change to CI or anyone's existing local workflow.
+
+## Consolidation E2E test (#2895)
+
+`docker-compose.consolidation-test.yml` + `scripts/consolidation-test.sh` verify the epic-#2872 directory contract against a real filesystem in a clean container — the bug class unit tests can't catch because they mock `fs`. Two modes:
+
+- **normal** — writable homedir. Asserts per-repo subdirs land in `<repo>/.nexus-agents/`, cross-repo subdirs in `$HOME/.nexus-agents/`, `.gitignore` carries the entry, no `runs/`/`logs/`/`.nexus-pipeline/` sprawl, and per-repo subdirs do NOT leak into homedir.
+- **sandbox** — read-only homedir mount. Asserts cross-repo subdirs fall back to `<repo>/.nexus-agents/` per #2888.
+
+Wired as a required `consolidation-test` CI job (gates merge via `ci-success`). No new Dockerfile — uses `node:22` directly.
+
+## Bug caught + fixed
+
+Building the test surfaced a real bug: `initDataDirectories()` created the homedir root up-front and aborted the _whole_ operation on EROFS — so a read-only-homedir sandbox got nothing, never reaching the per-repo subdirs (which ARE writable). Fixed: dropped the explicit root `ensureDir` (recursive mkdir of each subdir creates its parent) and made per-subdir failures non-fatal. This is what makes the #2888 sandbox-fallback actually usable from `setup`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "nexus-agents",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@9.15.0 --activate && pnpm install --frozen-lockfile",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
+      "settings": {
+        "typescript.tsdk": "node_modules/typescript/lib",
+        "editor.formatOnSave": true,
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,12 @@ jobs:
 
       # dist/cli.js is TypeScript-compiled (not bundled) — it imports from
       # node_modules at runtime, so both the build AND the installed deps
-      # must be present in the read-only repo mount.
-      - name: Build nexus-agents
-        run: pnpm --filter nexus-agents build
+      # must be present in the read-only repo mount. Full `pnpm build`
+      # (not --filter nexus-agents) so the nexus-memory workspace dep is
+      # built first — a filtered build fails with "Could not resolve
+      # nexus-memory".
+      - name: Build workspace
+        run: pnpm build
 
       - name: Run consolidation test (normal homedir)
         run: docker compose -f docker-compose.consolidation-test.yml run --rm consolidation-normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,30 @@ jobs:
           name: fitness-report-${{ matrix.os }}
           path: ${{ steps.fitness.outputs.report-path }}
 
+  # Epic #2887 / #2895: end-to-end verification of the directory contract
+  # from epic #2872. Unit tests mock the filesystem; this exercises the
+  # real resolver against two scratch repos in containers — one with a
+  # writable homedir, one with a read-only homedir (the sandbox case).
+  consolidation-test:
+    name: Consolidation E2E
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-node
+
+      # dist/cli.js is TypeScript-compiled (not bundled) — it imports from
+      # node_modules at runtime, so both the build AND the installed deps
+      # must be present in the read-only repo mount.
+      - name: Build nexus-agents
+        run: pnpm --filter nexus-agents build
+
+      - name: Run consolidation test (normal homedir)
+        run: docker compose -f docker-compose.consolidation-test.yml run --rm consolidation-normal
+
+      - name: Run consolidation test (read-only homedir / sandbox)
+        run: docker compose -f docker-compose.consolidation-test.yml run --rm consolidation-sandbox
+
   model-string-drift:
     name: Model String Drift Check
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -252,7 +276,8 @@ jobs:
   # path (copy-paste from a Rust project) and skipped on every run.
   ci-success:
     name: CI Success
-    needs: [commitlint, changeset-check, lint, typecheck, build, test, fitness-audit]
+    needs:
+      [commitlint, changeset-check, lint, typecheck, build, test, fitness-audit, consolidation-test]
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     if: always()
@@ -266,6 +291,7 @@ jobs:
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
+             [[ "${{ needs.consolidation-test.result }}" != "success" ]] || \
              [[ "${{ needs.fitness-audit.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1

--- a/docker-compose.consolidation-test.yml
+++ b/docker-compose.consolidation-test.yml
@@ -1,0 +1,52 @@
+# Consolidation end-to-end test (epic #2887, issue #2895).
+#
+# Verifies the epic-#2872 directory contract holds against a real
+# filesystem in a clean container. Two services exercise the two modes
+# the resolver must handle:
+#
+#   consolidation-normal   — writable homedir. Per-repo state in
+#                            <repo>/.nexus-agents/, cross-repo in $HOME.
+#   consolidation-sandbox  — read-only homedir mount. Cross-repo subdirs
+#                            must fall back to <repo>/.nexus-agents/ (#2888).
+#
+# Usage (CI builds dist/ first):
+#   pnpm --filter nexus-agents build
+#   docker compose -f docker-compose.consolidation-test.yml run --rm consolidation-normal
+#   docker compose -f docker-compose.consolidation-test.yml run --rm consolidation-sandbox
+#
+# No new Dockerfile — uses node:22 directly. The repo (with built dist/
+# and installed node_modules) is mounted read-only; only scratch + the
+# per-mode homedir are writable.
+
+services:
+  consolidation-normal:
+    image: node:22-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383
+    working_dir: /scratch
+    environment:
+      HOME: /test-home
+      NEXUS_LOG_LEVEL: warn
+    volumes:
+      - .:/repo:ro
+      - consolidation-scratch-normal:/scratch
+      - consolidation-home-normal:/test-home
+    command: ['bash', '/repo/scripts/consolidation-test.sh', 'normal']
+
+  consolidation-sandbox:
+    image: node:22-bookworm-slim@sha256:f3a68cf41a855d227d1b0ab832bed9749469ef38cf4f58182fb8c893bc462383
+    working_dir: /scratch
+    environment:
+      HOME: /test-home
+      NEXUS_LOG_LEVEL: warn
+    volumes:
+      - .:/repo:ro
+      - consolidation-scratch-sandbox:/scratch
+      # Homedir mounted READ-ONLY — simulates a sandbox with no writable
+      # $HOME. The resolver must fall back cross-repo subdirs to the repo.
+      - consolidation-home-sandbox:/test-home:ro
+    command: ['bash', '/repo/scripts/consolidation-test.sh', 'sandbox']
+
+volumes:
+  consolidation-scratch-normal:
+  consolidation-scratch-sandbox:
+  consolidation-home-normal:
+  consolidation-home-sandbox:

--- a/packages/nexus-agents/src/cli/setup-data-dir.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.ts
@@ -53,25 +53,40 @@ export interface DataDirInitResult {
 export function initDataDirectories(dryRun: boolean = false): DataDirInitResult {
   const created: string[] = [];
   const alreadyExisted: string[] = [];
+  const failures: string[] = [];
 
-  try {
-    ensureDir(NEXUS_DATA_DIR, dryRun, created, alreadyExisted);
-
-    for (const subdir of DATA_SUBDIRECTORIES) {
-      const mode = RESTRICTED_DIRS.has(subdir) ? 0o700 : undefined;
-      // Route through nexusDataPath() so per-repo subdirs (sessions,
-      // checkpoints, audit, …) land in `<repo>/.nexus-agents/` and
-      // cross-repo subdirs in homedir. Split on '/' so the routing key
-      // is the true first segment (e.g. 'memory/beliefs' → 'memory').
-      const target = nexusDataPath(...subdir.split('/'));
+  // No explicit root ensureDir: recursive mkdir of each subdir creates
+  // its parent root. Crucially, NOT creating the homedir root up-front
+  // means a read-only-homedir sandbox doesn't abort here before the
+  // per-repo subdirs (which ARE writable) get a chance. Issue #2895.
+  for (const subdir of DATA_SUBDIRECTORIES) {
+    const mode = RESTRICTED_DIRS.has(subdir) ? 0o700 : undefined;
+    // Route through nexusDataPath() so per-repo subdirs (sessions,
+    // checkpoints, audit, …) land in `<repo>/.nexus-agents/`, cross-repo
+    // subdirs in homedir, and cross-repo subdirs fall back per-repo when
+    // homedir is unwritable (#2888). Split on '/' so the routing key is
+    // the true first segment (e.g. 'memory/beliefs' → 'memory').
+    const target = nexusDataPath(...subdir.split('/'));
+    // Per-subdir failure is non-fatal: one unwritable location must not
+    // abort the others. Genuinely-broken environments surface as a
+    // non-empty `failures` list rather than a thrown exception.
+    try {
       ensureDir(target, dryRun, created, alreadyExisted, mode);
+    } catch (error: unknown) {
+      failures.push(`${target}: ${error instanceof Error ? error.message : String(error)}`);
     }
-
-    return { success: true, rootPath: NEXUS_DATA_DIR, created, alreadyExisted, error: null };
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return { success: false, rootPath: NEXUS_DATA_DIR, created, alreadyExisted, error: msg };
   }
+
+  if (failures.length > 0) {
+    return {
+      success: false,
+      rootPath: NEXUS_DATA_DIR,
+      created,
+      alreadyExisted,
+      error: `Failed to create ${String(failures.length)} dir(s): ${failures.join('; ')}`,
+    };
+  }
+  return { success: true, rootPath: NEXUS_DATA_DIR, created, alreadyExisted, error: null };
 }
 
 /** Creates a single directory if it doesn't exist, tracking the result. */

--- a/scripts/consolidation-test.sh
+++ b/scripts/consolidation-test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Consolidation end-to-end test (epic #2887, issue #2895).
+#
+# Verifies the directory contract from epic #2872 holds when nexus-agents
+# runs against a fresh repo — the bug class that made #2872/#2887 necessary
+# (sprawl at cwd, state landing in the wrong place, sandbox-fallback
+# misfiring) is only observable against a real filesystem, not the
+# vitest-mocked unit tests.
+#
+# Two modes, selected by $1:
+#   normal   — homedir writable. Per-repo subdirs land in <repo>/.nexus-agents/,
+#              cross-repo subdirs in $HOME/.nexus-agents/.
+#   sandbox  — homedir unwritable (read-only mount). Cross-repo subdirs
+#              fall back to <repo>/.nexus-agents/ per issue #2888.
+#
+# Run via docker-compose.consolidation-test.yml. Expects:
+#   - the repo mounted read-only at /repo (dist already built by CI)
+#   - a writable scratch dir at /scratch
+#   - $HOME pointed at a per-mode mount
+set -uo pipefail
+
+MODE="${1:?usage: consolidation-test.sh <normal|sandbox>}"
+REPO_SRC="${REPO_SRC:-/repo}"
+SCRATCH="${SCRATCH:-/scratch}"
+CLI="node ${REPO_SRC}/packages/nexus-agents/dist/cli.js"
+
+pass=0
+fail=0
+check() {
+  # check "<description>" "<test expression result: 0=pass>"
+  if [ "$2" -eq 0 ]; then
+    echo "  ✓ $1"
+    pass=$((pass + 1))
+  else
+    echo "  ✗ FAIL: $1"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "=== Consolidation test — mode: ${MODE} ==="
+echo "  HOME=${HOME}"
+echo "  CLI=${CLI}"
+echo ""
+
+# --- Clean slate ----------------------------------------------------------
+# Docker named volumes persist between `compose run` invocations, so a
+# prior run's state would poison the assertions. Wipe both roots. In
+# sandbox mode $HOME is a read-only mount — the rm fails harmlessly there
+# (nothing was written anyway).
+rm -rf "${HOME}/.nexus-agents" 2>/dev/null || true
+
+# --- Fresh scratch repo ---------------------------------------------------
+# `findRepoRoot()` only needs the `.git` marker directory, not a real git
+# repo — so we mkdir it directly. node:22-bookworm-slim ships without the
+# git binary, and pulling it in just to run `git init` would be wasteful.
+REPO="${SCRATCH}/proj"
+rm -rf "${REPO}"
+mkdir -p "${REPO}/.git"
+cd "${REPO}" || exit 1
+
+# --- Run setup (creates the data-dir structure) --------------------------
+# Non-interactive; exit code is allowed to be non-zero (missing CLIs/keys
+# in a bare container produce health-gate warnings). We assert on the
+# filesystem regardless — directory creation happens before the gate.
+NEXUS_GITIGNORE_AUTO=1 ${CLI} setup --non-interactive >/tmp/setup.log 2>&1 || true
+
+echo "--- Assertions ---"
+
+# --- Per-repo subdirs land in <repo>/.nexus-agents/ ----------------------
+for sub in sessions audit checkpoints; do
+  [ -d "${REPO}/.nexus-agents/${sub}" ]
+  check "per-repo subdir ${sub}/ created under <repo>/.nexus-agents/" $?
+done
+
+# --- .gitignore carries the entry ----------------------------------------
+grep -q '\.nexus-agents/' "${REPO}/.gitignore" 2>/dev/null
+check ".nexus-agents/ present in <repo>/.gitignore" $?
+
+# --- Anti-sprawl: no stray dirs at the repo root -------------------------
+for stray in runs logs .nexus-pipeline; do
+  [ ! -e "${REPO}/${stray}" ]
+  check "no '${stray}' sprawl at repo root" $?
+done
+
+# --- Mode-specific: cross-repo routing -----------------------------------
+if [ "${MODE}" = "normal" ]; then
+  # Homedir writable → cross-repo subdirs live in $HOME/.nexus-agents/.
+  [ -d "${HOME}/.nexus-agents/learning" ]
+  check "cross-repo subdir learning/ in \$HOME/.nexus-agents/" $?
+  [ -d "${HOME}/.nexus-agents/auth" ]
+  check "cross-repo subdir auth/ in \$HOME/.nexus-agents/" $?
+  # Per-repo subdirs must NOT have leaked into homedir.
+  [ ! -d "${HOME}/.nexus-agents/sessions" ]
+  check "per-repo subdir sessions/ did NOT leak into \$HOME" $?
+else
+  # Sandbox: homedir unwritable → cross-repo subdirs fall back per-repo (#2888).
+  [ -d "${REPO}/.nexus-agents/learning" ]
+  check "cross-repo subdir learning/ fell back to <repo>/.nexus-agents/" $?
+  [ -d "${REPO}/.nexus-agents/research" ]
+  check "cross-repo subdir research/ fell back to <repo>/.nexus-agents/" $?
+fi
+
+echo ""
+echo "=== ${MODE}: ${pass} passed, ${fail} failed ==="
+if [ "${fail}" -ne 0 ]; then
+  echo "--- setup.log (last 30 lines) ---"
+  tail -30 /tmp/setup.log
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Lands #2894 + #2895 from epic #2887.

## `.devcontainer/` (#2894)

Node 22 + pnpm 9.15.0 devcontainer pinned to match CI. Contributors get a one-click CI-identical environment. Orthogonal to CI — changes nobody's existing workflow.

## Consolidation E2E test (#2895)

`docker-compose.consolidation-test.yml` + `scripts/consolidation-test.sh` verify the epic-#2872 directory contract against a **real filesystem in a clean container** — the bug class the vitest-mocked unit tests structurally cannot catch.

| Mode | Setup | Asserts |
|---|---|---|
| `normal` | writable homedir | per-repo subdirs in `<repo>/.nexus-agents/`; cross-repo in `$HOME/.nexus-agents/`; `.gitignore` carries the entry; no `runs/`/`logs/`/`.nexus-pipeline/` sprawl; per-repo subdirs do **not** leak into homedir |
| `sandbox` | read-only homedir mount | cross-repo subdirs fall back to `<repo>/.nexus-agents/` per #2888 |

New required `consolidation-test` CI job; gates merge via `ci-success`. No new Dockerfile — `node:22` directly. (`.git` is `mkdir`'d rather than `git init`'d — the slim image has no git binary, and `findRepoRoot` only needs the marker dir.)

Verified locally: **normal 10/10, sandbox 9/9.**

## Bug caught + fixed — this is the point of the test

Building the test surfaced a **real bug**: `initDataDirectories()` created the homedir root up-front and aborted the *whole* operation on EROFS — so a read-only-homedir sandbox got **nothing**, never reaching the per-repo subdirs (which ARE writable). The #2888 sandbox-fallback was effectively dead code from `setup`'s perspective.

Fix (`setup-data-dir.ts`):
- Dropped the explicit root `ensureDir` — recursive `mkdir` of each subdir creates its parent root.
- Made per-subdir failures non-fatal — collected into a `failures` list instead of throwing, so one unwritable location doesn't abort the rest.

This is exactly the kind of regression the consolidation test exists to catch. It caught one on its first run.

`setup-data-dir.ts` unit tests (5) still pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)