### PR TITLE
fix(mcp): harden stdin-lifecycle monitor — three parent-death signals (closes #2905)

### DIFF
--- a/.changeset/2905-mcp-server-leak.md
+++ b/.changeset/2905-mcp-server-leak.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+**fix(mcp):** harden the stdin-lifecycle monitor so `--mode=server` processes don't leak as zombies. Closes #2905.
+
+The #810 fix used a single signal — `process.stdin.once('end')` — to detect parent death. That misses SIGKILLed parents and abrupt pipe death, where `'end'` never cleanly emits. A process sweep found **134 leaked `nexus-agents --mode=server` processes** aged up to 17 days.
+
+`StdinLifecycleMonitor` now watches three independent signals, firing the shutdown callbacks exactly once whichever arrives first:
+
+1. stdin `'end'` — clean parent exit (unchanged).
+2. stdin `'close'` — the stdin fd closed; covers abrupt death `'end'` misses.
+3. **ppid change** — polls the parent pid; if it differs from the value captured at `start()`, the original parent died and the process was reparented. This is the catch-all for SIGKILLed parents that the stream events can't see. The poll timer is `unref()`'d so it never keeps the process alive.
+
+The monitor is constructable with `{ getPpid, ppidPollMs }` overrides so the ppid path is unit-testable without real reparenting. 9 tests cover all three signals, fire-once semantics, throwing-callback isolation, and interval cleanup.

--- a/packages/nexus-agents/src/adapters/stdin-lifecycle.test.ts
+++ b/packages/nexus-agents/src/adapters/stdin-lifecycle.test.ts
@@ -2,52 +2,181 @@
  * Tests for Stdin Lifecycle Monitor
  *
  * @module adapters/stdin-lifecycle.test
- * (Source: Issue #810 - Zombie MCP server processes)
+ * (Source: Issue #810 — zombie MCP server processes; hardened in #2905)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StdinLifecycleMonitor } from './stdin-lifecycle.js';
 
+/**
+ * Captures the handlers `start()` registers on `process.stdin` so tests
+ * can invoke them directly — there's no portable way to make the real
+ * stdin emit `'end'` / `'close'` in a unit test.
+ */
+function spyStdin(): {
+  handlers: Map<string, () => void>;
+  restore: () => void;
+} {
+  const handlers = new Map<string, () => void>();
+  const onceSpy = vi
+    .spyOn(process.stdin, 'once')
+    .mockImplementation((event: string | symbol, handler: (...args: unknown[]) => void) => {
+      handlers.set(String(event), handler);
+      return process.stdin;
+    });
+  const resumeSpy = vi.spyOn(process.stdin, 'resume').mockImplementation(() => process.stdin);
+  return {
+    handlers,
+    restore: () => {
+      onceSpy.mockRestore();
+      resumeSpy.mockRestore();
+    },
+  };
+}
+
 describe('StdinLifecycleMonitor', () => {
-  let monitor: StdinLifecycleMonitor;
+  let stdin: ReturnType<typeof spyStdin>;
 
   beforeEach(() => {
-    monitor = new StdinLifecycleMonitor();
+    stdin = spyStdin();
   });
 
-  it('fires onClose callbacks when stdin ends', () => {
-    const callback = vi.fn();
-    monitor.onClose(callback);
-
-    // start() attaches to process.stdin — we can't easily trigger 'end'
-    // in unit tests, so verify the callback set management
-    expect(callback).not.toHaveBeenCalled();
+  afterEach(() => {
+    stdin.restore();
+    vi.useRealTimers();
   });
 
-  it('accepts multiple callbacks', () => {
+  it('start() is idempotent — attaches stdin listeners only once', () => {
+    const monitor = new StdinLifecycleMonitor();
+    monitor.start();
+    monitor.start();
+    monitor.start();
+    // One 'end' + one 'close' from the single effective start().
+    expect(stdin.handlers.size).toBe(2);
+    expect(stdin.handlers.has('end')).toBe(true);
+    expect(stdin.handlers.has('close')).toBe(true);
+  });
+
+  it('fires onClose callbacks when stdin emits "end"', async () => {
+    const monitor = new StdinLifecycleMonitor();
+    const cb = vi.fn();
+    monitor.onClose(cb);
+    monitor.start();
+
+    stdin.handlers.get('end')?.();
+    await vi.waitFor(() => {
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('fires onClose callbacks when stdin emits "close" (abrupt parent death)', async () => {
+    // #2905: 'end' alone missed SIGKILLed parents; 'close' covers them.
+    const monitor = new StdinLifecycleMonitor();
+    const cb = vi.fn();
+    monitor.onClose(cb);
+    monitor.start();
+
+    stdin.handlers.get('close')?.();
+    await vi.waitFor(() => {
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('fires callbacks exactly once even when multiple signals arrive', async () => {
+    const monitor = new StdinLifecycleMonitor();
+    const cb = vi.fn();
+    monitor.onClose(cb);
+    monitor.start();
+
+    stdin.handlers.get('end')?.();
+    stdin.handlers.get('close')?.();
+    stdin.handlers.get('end')?.();
+    await vi.waitFor(() => {
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+    // Give any stray async path a tick to (not) double-fire.
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs every registered callback', async () => {
+    const monitor = new StdinLifecycleMonitor();
     const cb1 = vi.fn();
     const cb2 = vi.fn();
     monitor.onClose(cb1);
     monitor.onClose(cb2);
-    // No error — callbacks registered successfully
+    monitor.start();
+
+    stdin.handlers.get('end')?.();
+    await vi.waitFor(() => {
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('start() is idempotent', () => {
-    // Calling start() multiple times should not throw
-    // Note: In test env, stdin.resume() may not work as expected,
-    // but the idempotency guard should prevent double-attach
-    const stdinOnceSpy = vi.spyOn(process.stdin, 'once').mockImplementation(() => process.stdin);
-    const stdinResumeSpy = vi
-      .spyOn(process.stdin, 'resume')
-      .mockImplementation(() => process.stdin);
-
-    monitor.start();
+  it('a throwing callback does not block the others', async () => {
+    const monitor = new StdinLifecycleMonitor();
+    const throwing = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const healthy = vi.fn();
+    monitor.onClose(throwing);
+    monitor.onClose(healthy);
     monitor.start();
 
-    // Only attached once
-    expect(stdinOnceSpy).toHaveBeenCalledTimes(1);
+    stdin.handlers.get('end')?.();
+    await vi.waitFor(() => {
+      expect(healthy).toHaveBeenCalledTimes(1);
+    });
+  });
 
-    stdinOnceSpy.mockRestore();
-    stdinResumeSpy.mockRestore();
+  it('fires when the parent pid changes — signal 3, the SIGKILL catch-all', async () => {
+    // #2905: simulate reparenting (parent died → ppid changes).
+    vi.useFakeTimers();
+    let ppid = 4242;
+    const monitor = new StdinLifecycleMonitor({
+      getPpid: () => ppid,
+      ppidPollMs: 1000,
+    });
+    const cb = vi.fn();
+    monitor.onClose(cb);
+    monitor.start();
+
+    // Parent alive — poll fires, no callback.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Parent dies — ppid reparents to init.
+    ppid = 1;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire while the parent pid is stable', async () => {
+    vi.useFakeTimers();
+    const monitor = new StdinLifecycleMonitor({
+      getPpid: () => 9999,
+      ppidPollMs: 500,
+    });
+    const cb = vi.fn();
+    monitor.onClose(cb);
+    monitor.start();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('stops the ppid poll after firing (no leaked interval)', async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    let ppid = 100;
+    const monitor = new StdinLifecycleMonitor({ getPpid: () => ppid, ppidPollMs: 100 });
+    monitor.onClose(vi.fn());
+    monitor.start();
+
+    ppid = 1;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
   });
 });

--- a/packages/nexus-agents/src/adapters/stdin-lifecycle.ts
+++ b/packages/nexus-agents/src/adapters/stdin-lifecycle.ts
@@ -1,11 +1,30 @@
 /**
  * Stdin Lifecycle Monitor
  *
- * Detects when the parent process closes stdin (e.g., Claude Code exits)
- * and triggers graceful shutdown to prevent zombie MCP server processes.
+ * Detects when the parent process (Claude Code, an editor, any MCP client)
+ * goes away and triggers graceful shutdown so `nexus-agents --mode=server`
+ * processes don't leak as zombies.
+ *
+ * Three independent signals — any one fires the shutdown callbacks exactly
+ * once. Belt-and-suspenders because no single signal is reliable across
+ * clean exit / SIGKILL / pipe-yank:
+ *
+ *   1. stdin `'end'`   — clean parent exit; EOF once buffered data drains.
+ *   2. stdin `'close'` — the stdin fd closed; covers abrupt death where
+ *                        `'end'` never cleanly emits.
+ *   3. ppid change     — the parent pid differs from what it was at
+ *                        `start()`. A SIGKILLed parent leaves the child
+ *                        reparented (to init); this poll catches every
+ *                        case the stream events miss. The timer is
+ *                        `unref()`'d so it never keeps the process alive.
+ *
+ * Issue #810 shipped only signal 1 (`process.stdin.once('end')`). That
+ * misses SIGKILLed parents and abrupt pipe death — a sweep found 134
+ * leaked server processes aged up to 17 days. Signals 2 + 3 close the
+ * gap (issue #2905).
  *
  * @module adapters/stdin-lifecycle
- * (Source: Issue #810 - Zombie MCP server processes)
+ * (Source: Issue #810; hardened in #2905)
  */
 
 import { createLogger } from '../core/index.js';
@@ -14,32 +33,88 @@ const logger = createLogger({ component: 'StdinLifecycleMonitor' });
 
 type StdinCallback = () => void | Promise<void>;
 
+/** Default interval for the parent-pid poll (signal 3). */
+const DEFAULT_PPID_POLL_MS = 30_000;
+
 /**
- * Monitors process.stdin for closure, indicating the parent process died.
+ * Construction options. All optional — the defaults are the production
+ * configuration; the overrides exist so the ppid poll is unit-testable
+ * without actually reparenting a process.
+ */
+export interface StdinLifecycleOptions {
+  /** Source of the current parent pid. Default: `() => process.ppid`. */
+  readonly getPpid?: () => number;
+  /** Parent-pid poll interval in ms. Default: 30000. */
+  readonly ppidPollMs?: number;
+}
+
+/**
+ * Monitors for parent-process death and fires registered shutdown
+ * callbacks exactly once when it's detected.
  */
 export class StdinLifecycleMonitor {
   private readonly callbacks: Set<StdinCallback> = new Set();
   private started = false;
+  private fired = false;
+  private ppidTimer: NodeJS.Timeout | undefined;
+  private readonly getPpid: () => number;
+  private readonly ppidPollMs: number;
+
+  constructor(options: StdinLifecycleOptions = {}) {
+    this.getPpid = options.getPpid ?? ((): number => process.ppid);
+    this.ppidPollMs = options.ppidPollMs ?? DEFAULT_PPID_POLL_MS;
+  }
 
   /**
-   * Begin monitoring stdin for closure.
-   * Safe to call multiple times — only attaches listener once.
+   * Begin monitoring. Safe to call multiple times — only the first call
+   * attaches listeners.
    */
   start(): void {
     if (this.started) return;
     this.started = true;
 
+    // Signals 1 + 2: stdin EOF and fd close.
     process.stdin.once('end', () => {
-      void this.fireCallbacks();
+      void this.trigger('stdin-end');
     });
-
-    // Ensure stdin doesn't keep the event loop alive on its own
+    process.stdin.once('close', () => {
+      void this.trigger('stdin-close');
+    });
+    // Flowing mode so 'end' can be reached; resume() doesn't, by itself,
+    // keep the event loop alive.
     process.stdin.resume();
+
+    // Signal 3: parent-pid change. Capture the startup parent; if the
+    // observed ppid ever differs, the original parent died and we were
+    // reparented — orphaned.
+    const startupPpid = this.getPpid();
+    this.ppidTimer = setInterval(() => {
+      if (this.getPpid() !== startupPpid) {
+        void this.trigger('ppid-changed');
+      }
+    }, this.ppidPollMs);
+    // The poll must never be the reason the process stays alive.
+    this.ppidTimer.unref();
   }
 
-  /** Register a callback to fire when stdin closes. */
+  /** Register a callback to fire when parent death is detected. */
   onClose(cb: StdinCallback): void {
     this.callbacks.add(cb);
+  }
+
+  /**
+   * Fire shutdown callbacks exactly once, whichever signal arrives first.
+   * Idempotent — later signals are no-ops.
+   */
+  private async trigger(reason: string): Promise<void> {
+    if (this.fired) return;
+    this.fired = true;
+    if (this.ppidTimer !== undefined) {
+      clearInterval(this.ppidTimer);
+      this.ppidTimer = undefined;
+    }
+    logger.warn('Parent process gone — shutting down MCP server', { reason });
+    await this.fireCallbacks();
   }
 
   private async fireCallbacks(): Promise<void> {


### PR DESCRIPTION
Fixes #2905 — the MCP server zombie leak.

## The bug

#810 shipped `StdinLifecycleMonitor` to kill `nexus-agents --mode=server` processes when their MCP client disconnects. It used a single signal: `process.stdin.once('end')`. That misses:

- **SIGKILLed parents** — the editor/Claude process is force-killed; the pipe dies without a clean `'end'`.
- **Abrupt pipe death** — `'end'` requires the readable stream to reach EOF with buffered data drained; that doesn't always happen.

Result: a process sweep found **134 leaked server processes** aged up to 17 days.

## The fix

`StdinLifecycleMonitor` now watches **three independent signals**, firing the shutdown callbacks exactly once whichever arrives first:

| Signal | Catches |
|---|---|
| stdin `'end'` | clean parent exit (unchanged) |
| stdin `'close'` | abrupt death where `'end'` never cleanly emits |
| **ppid change** (poll) | SIGKILLed parent — process reparents to init; `process.ppid` differs from the value captured at `start()` |

The ppid poll is the real catch-all — it's the only signal that doesn't depend on the stdin stream behaving. Its timer is `unref()`'d so it never keeps the process alive on its own, and it's cleared once the monitor fires.

`trigger()` is idempotent — later signals are no-ops.

## Testability

The constructor now accepts `{ getPpid, ppidPollMs }` overrides, so the ppid path is unit-testable without actually reparenting a process. `cli-server.ts` wiring is unchanged — it already calls `start()` + `onClose(() => process.exit(0))`; the monitor itself was the broken part.

## Tests

9 tests in `stdin-lifecycle.test.ts`: all three signals individually, fire-once across multiple simultaneous signals, every-callback execution, throwing-callback isolation, ppid-stable non-fire, and interval cleanup after fire. All pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)