### PR TITLE
fix: markdown-fenced JSON + parallel-tool outcome drain (closes #2862 #2864)

### DIFF
--- a/.changeset/2862-2864-audit-bundle.md
+++ b/.changeset/2862-2864-audit-bundle.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** two correctness bugs from the #2824 code-review audit. Closes #2862 and #2864.
+
+**#2862 — `decomposeTask` crashed on markdown-fenced JSON.** The Orchestrator's `decomposeTask()` called `JSON.parse()` directly on the LLM response. LLMs routinely wrap the JSON array in a ` ```json … ``` ` fence; the fence made `JSON.parse` throw and `decomposeTask` silently fell back to heuristic decomposition — discarding the model's actual plan. It now strips the fence first via the existing `extractCodeBlock()` helper (the same path `parseJson()` already uses).
+
+**#2864 — parallel tool calls dropped sibling outcomes on the first error.** `processToolCallsParallel()` used `Promise.all` (a single rejection aborts collection) and its reduction loop `return`ed on the first `stop-tool-error` outcome — so when one tool in a parallel batch failed, the turns from the _other_ tools (which ran fine) were never recorded in history. Now uses `Promise.allSettled` and drains _every_ outcome into `state.turns` before deciding to stop. A rejected promise (an unexpected escape from `invokeToolForParallel`'s own try/catch) is logged and treated as a stop signal without losing the siblings.
+
+Tests: a markdown-fence decomposition test in `tech-lead.test.ts`, and a mid-batch-error parallel-drain test in `agentic-adapter.test.ts` asserting both tool turns are recorded.

--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.test.ts
@@ -156,6 +156,51 @@ describe('AgenticAdapter', () => {
     expect(result.value.turns[0]?.toolResult.content).toContain('database is down');
   });
 
+  it('parallel tools: a mid-batch tool error still drains every sibling turn (#2864)', async () => {
+    // Two tool_use blocks in one turn → the parallel path runs both.
+    // claude-opus-4-1 resolves a profile with parallelToolCalls: true.
+    const model = makeMockModel(
+      [
+        {
+          content: [
+            { type: 'tool_use', id: 'tu-1', name: 'lookup', input: {} },
+            { type: 'tool_use', id: 'tu-2', name: 'lookup', input: {} },
+          ] as ContentBlock[],
+          stopReason: 'tool_use',
+        },
+      ],
+      'anthropic',
+      'claude-opus-4-1'
+    );
+    const adapter = new AgenticAdapter(model);
+    expect(adapter.getProfile().parallelToolCalls).toBe(true);
+
+    const result = await adapter.runAgent({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      tools: TOOLS,
+      turnBudget: 5,
+      onToolCall: (call: ToolCall): Promise<ToolResult> => {
+        // First tool errors, second succeeds. Pre-#2864 the reduction
+        // loop returned on tu-1's stop-tool-error and tu-2's turn was
+        // never recorded.
+        if (call.id === 'tu-1') throw new Error('tu-1 backend down');
+        return Promise.resolve({ content: 'tu-2 ok' });
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stopReason).toBe('tool-error');
+    // BOTH tool turns drained into history — the sibling was not dropped.
+    expect(result.value.turns).toHaveLength(2);
+    const ids = result.value.turns.map((t) => t.toolCall.id);
+    expect(ids).toContain('tu-1');
+    expect(ids).toContain('tu-2');
+    const tu2 = result.value.turns.find((t) => t.toolCall.id === 'tu-2');
+    expect(tu2?.toolResult.content).toBe('tu-2 ok');
+  });
+
   it('cancelled: AbortSignal fires between turns → cancellation captured', async () => {
     const ac = new AbortController();
     const model = makeMockModel([

--- a/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
+++ b/packages/nexus-agents/src/agents/agentic/agentic-adapter.ts
@@ -25,7 +25,7 @@
  * @module agents/agentic/agentic-adapter
  */
 
-import { ok, err } from '../../core/index.js';
+import { ok, err, createLogger } from '../../core/index.js';
 import type {
   CompletionRequest,
   CompletionResponse,
@@ -91,6 +91,8 @@ export interface AgenticAdapterOptions {
    */
   readonly registry?: ModelRegistry;
 }
+
+const logger = createLogger({ component: 'AgenticAdapter' });
 
 export class AgenticAdapter implements IAgenticAdapter {
   readonly providerId: string;
@@ -357,24 +359,62 @@ export class AgenticAdapter implements IAgenticAdapter {
     const promises = toolUses.map((toolUse, offset) =>
       this.invokeToolForParallel(args, toolUse, response, modelLatencyMs, startIndex + offset)
     );
-    const outcomes = await Promise.all(promises);
+    // allSettled, not all: a single rejected promise must not abort
+    // collection and lose every sibling tool's outcome (#2864).
+    const settled = await Promise.allSettled(promises);
 
-    // Order-stable record + announce.
+    // Order-stable record + announce. DRAIN every outcome's turn into
+    // history before deciding to stop — a mid-batch tool error must not
+    // drop the sibling tools' turns (#2864). The previous early `return`
+    // on the first stop-tool-error skipped recording the rest.
     const toolResultBlocks: Extract<ContentBlock, { type: 'tool_result' }>[] = [];
-    for (const outcome of outcomes) {
-      if (outcome.kind === 'stop-tool-error') {
-        state.turns.push(outcome.turn);
-        args.onTurn?.(outcome.turn);
-        return { kind: 'stop', reason: 'tool-error' };
+    let stopForToolError = false;
+    for (let i = 0; i < settled.length; i++) {
+      const result = settled[i];
+      if (result === undefined) continue;
+      if (this.drainParallelOutcome(result, toolUses[i], state, args, toolResultBlocks)) {
+        stopForToolError = true;
       }
-      state.turns.push(outcome.turn);
-      args.onTurn?.(outcome.turn);
-      toolResultBlocks.push(outcome.toolResultBlock);
     }
-    if (toolResultBlocks.length > 0) {
+    // Only feed tool results into the next turn when actually continuing —
+    // matches the pre-#2864 behavior (the early return on a tool error
+    // skipped the messages push).
+    if (!stopForToolError && toolResultBlocks.length > 0) {
       state.messages.push({ role: 'user', content: toolResultBlocks });
     }
-    return { kind: 'continue' };
+    return stopForToolError ? { kind: 'stop', reason: 'tool-error' } : { kind: 'continue' };
+  }
+
+  /**
+   * Records one settled parallel-tool outcome into history. Mutates
+   * `state.turns` / `toolResultBlocks` in place and returns `true` when
+   * the outcome signals a tool error (the caller stops *after* draining
+   * every outcome — #2864). Extracted from `processToolCallsParallel`
+   * to keep that method's cyclomatic complexity under the gate.
+   */
+  private drainParallelOutcome(
+    result: PromiseSettledResult<ParallelToolOutcome>,
+    toolUse: Extract<ContentBlock, { type: 'tool_use' }> | undefined,
+    state: LoopState,
+    args: ResolvedRunAgentArgs,
+    toolResultBlocks: Extract<ContentBlock, { type: 'tool_result' }>[]
+  ): boolean {
+    if (result.status === 'rejected') {
+      // invokeToolForParallel catches its own errors — a rejection here
+      // is an unexpected escape (e.g. buildTurn itself throwing). Record
+      // it; do NOT abort the sibling tools.
+      logger.warn('Parallel tool invocation rejected unexpectedly', {
+        toolUseId: toolUse?.id,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+      return true;
+    }
+    const outcome = result.value;
+    state.turns.push(outcome.turn);
+    args.onTurn?.(outcome.turn);
+    if (outcome.kind === 'stop-tool-error') return true;
+    toolResultBlocks.push(outcome.toolResultBlock);
+    return false;
   }
 
   /**

--- a/packages/nexus-agents/src/agents/tech-lead.test.ts
+++ b/packages/nexus-agents/src/agents/tech-lead.test.ts
@@ -437,6 +437,52 @@ describe('Orchestrator', () => {
       }
     });
 
+    it('parses LLM output wrapped in a markdown code fence (#2862)', async () => {
+      // LLMs commonly return the JSON array inside ```json … ```.
+      // Pre-#2862 JSON.parse threw on the fence and decomposeTask
+      // silently fell back to heuristic decomposition.
+      const task = createTestTask();
+      const llmSubtask = {
+        id: 'sub-llm-1',
+        parentTaskId: task.id,
+        description: 'LLM-decomposed subtask',
+        expectedOutput: 'a parsed result',
+        dependencies: [],
+        priority: 'high',
+        status: 'pending',
+        complexity: 5,
+        requiredCapabilities: [],
+      };
+      const mockAdapter = createMockAdapter();
+      mockAdapter.completeResult = ok({
+        content: [{ type: 'text', text: '```json\n' + JSON.stringify([llmSubtask]) + '\n```' }],
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        stopReason: 'end_turn',
+        model: 'test-model',
+      });
+      const orchestrator = new Orchestrator({ adapter: mockAdapter });
+      const analysis: TaskAnalysis = {
+        taskId: task.id,
+        complexity: 6,
+        taskType: 'implementation',
+        requirements: [],
+        risks: [],
+        needsDecomposition: true,
+        approach: 'Test approach',
+        estimatedEffort: 8,
+      };
+
+      const result = await orchestrator.decomposeTask(task, analysis);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // The fenced subtask was parsed — NOT the heuristic fallback,
+        // which would synthesize different ids/descriptions.
+        expect(result.value[0]?.id).toBe('sub-llm-1');
+        expect(result.value[0]?.description).toBe('LLM-decomposed subtask');
+      }
+    });
+
     it('should decompose architecture task differently', async () => {
       const orchestrator = new Orchestrator();
       const task = createTestTask({

--- a/packages/nexus-agents/src/agents/tech-lead.ts
+++ b/packages/nexus-agents/src/agents/tech-lead.ts
@@ -336,7 +336,13 @@ export class Orchestrator extends BaseAgent {
     if (!result.ok) return err(result.error);
 
     try {
-      const parsed = JSON.parse(extractTextContent(result.value.content)) as unknown[];
+      // LLMs frequently wrap the JSON array in a markdown code fence
+      // (```json … ```). Strip it before parsing — same pattern parseJson()
+      // uses. Without this a fenced response throws and silently falls
+      // back to heuristic decomposition. Issue #2862.
+      const rawText = extractTextContent(result.value.content);
+      const fenced = extractCodeBlock(rawText);
+      const parsed = JSON.parse(fenced?.[1] ?? rawText) as unknown[];
       const subtasks = parsed
         .map((item) => SubTaskSchema.safeParse(item))
         .filter((r) => r.success)


### PR DESCRIPTION
Two verified correctness bugs from the #2824 code-review audit. Bundled — each is one-area-disjoint and surgical, with its own test.

## #2862 — `decomposeTask` crashed on markdown-fenced JSON

`Orchestrator.decomposeTask()` called `JSON.parse()` directly on the LLM response. LLMs routinely wrap the JSON array in a ` ```json … ``` ` fence — the fence made `JSON.parse` **throw**, and `decomposeTask` silently fell back to heuristic decomposition, **discarding the model's actual plan**.

Fix: strip the fence first via the existing `extractCodeBlock()` helper — the same path the class's own `parseJson()` already uses. One-pattern consistency, no new helper.

## #2864 — parallel tool calls dropped sibling outcomes on first error

`processToolCallsParallel()` had two coupled bugs:
1. `Promise.all` — a single rejected promise aborts collection, losing every sibling outcome.
2. The reduction loop `return`ed on the **first** `stop-tool-error` outcome — so when one tool in a parallel batch failed, the turns from the *other* tools (which ran fine) were never recorded in `state.turns`.

Fix: `Promise.allSettled` + drain **every** outcome into history before deciding to stop. A rejected promise — an unexpected escape from `invokeToolForParallel`'s own try/catch — is logged (`warn`) and treated as a stop signal without losing siblings. Per-outcome handling extracted to `drainParallelOutcome()` to keep `processToolCallsParallel` under the complexity gate.

## Tests

- `tech-lead.test.ts` — `decomposeTask` parses a ` ```json `-fenced array; asserts the LLM subtask (`sub-llm-1`) comes through, not the heuristic fallback.
- `agentic-adapter.test.ts` — a parallel batch where tool 1 errors and tool 2 succeeds; asserts **both** tool turns land in `result.value.turns` (the sibling isn't dropped) and `stopReason === 'tool-error'`.
- Full files green: 81 (`tech-lead`) + 28 (`agentic-adapter`) tests. Lint + typecheck clean.

## Remaining #2824 audit bullets

Still open, verified-real by the same investigation: #2861 (consensus `expansionInFlight` race), #2863 (vote-command shell-quoting), #2865 (subprocess env-var allowlist). #2867 (audit-trail provenance) is a design-improvement, lower priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)