### PR TITLE
fix(consensus): guard vote() against double quorum expansion (closes #2861)

### DIFF
--- a/.changeset/2861-consensus-expansion-race.md
+++ b/.changeset/2861-consensus-expansion-race.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+**fix(consensus):** guard `ConsensusEngine.vote()` against double quorum expansion. Closes #2861.
+
+`vote()` is `async` and `await`s the expansion callback inside `tryExpandQuorum()` — and `tryExpandQuorum()` mutates `state.proposal.requiredVoters` / `expansionRounds` _after_ that await. Two `vote()` calls that both observe a complete quorum across the await gap would each start an expansion: the callback fires twice and the second expansion clobbers the first's voter list (and `expansionRounds` undercounts).
+
+Fix: a per-proposal `expansionInFlight` flag on `ProposalState`. `vote()` sets it before `await tryExpandQuorum`, clears it in a `finally`, and a concurrent `vote()` that sees it set returns `ok` immediately (its vote is already recorded — the in-flight expansion handles the quorum decision). The flag is per-proposal, so independent proposals never block each other.
+
+Severity note: the current production caller (`mcp/tools/consensus-vote.ts`) submits votes in a sequential `for await` loop, so the race is **latent** today — but `ConsensusEngine.vote()` is a public `async` method and any concurrent caller would hit it. This hardens the public contract.
+
+Regression test in `incremental-quorum.test.ts` fires two `vote()` calls racing the final voter and asserts the expansion callback runs exactly once (verified to fail without the guard).

--- a/packages/nexus-agents/src/consensus/engine.ts
+++ b/packages/nexus-agents/src/consensus/engine.ts
@@ -220,7 +220,23 @@ export class ConsensusEngine implements IConsensusEngine {
 
     // All required voters voted — check for incremental quorum expansion
     if (this.allRequiredVotersVoted(state)) {
-      const expanded = await this.tryExpandQuorum(proposalId, state);
+      // Re-entry guard (#2861): `tryExpandQuorum` awaits its callback and
+      // then mutates `state.proposal.requiredVoters` / `expansionRounds`.
+      // A concurrent `vote()` that also sees `allRequiredVotersVoted`
+      // must NOT start a second expansion — that would invoke the
+      // expansion callback twice and clobber the first expansion's
+      // voter list. This vote is already recorded; return ok and let
+      // the in-flight expansion settle.
+      if (state.expansionInFlight === true) {
+        return Promise.resolve(ok(undefined));
+      }
+      state.expansionInFlight = true;
+      let expanded: boolean;
+      try {
+        expanded = await this.tryExpandQuorum(proposalId, state);
+      } finally {
+        state.expansionInFlight = false;
+      }
       if (!expanded) {
         return this.closeInternal(proposalId).then((r) => (r.ok ? ok(undefined) : err(r.error)));
       }

--- a/packages/nexus-agents/src/consensus/incremental-quorum.test.ts
+++ b/packages/nexus-agents/src/consensus/incremental-quorum.test.ts
@@ -131,6 +131,56 @@ describe('ConsensusEngine incremental quorum', () => {
     expect(expansionCallback).toHaveBeenCalledWith(pid, 5, 2);
   });
 
+  it('does not double-expand when two vote() calls race the final voter (#2861)', async () => {
+    // vote() is async and awaits the expansion callback between the
+    // allRequiredVotersVoted() check and the requiredVoters mutation.
+    // Two vote() calls that both observe a complete quorum across that
+    // await must not each start an expansion.
+    const expansionCallback = vi.fn<VoterExpansionCallback>(() =>
+      Promise.resolve(['extra-1', 'extra-2'])
+    );
+    const engine = createConsensusEngine({
+      defaultTimeout: 60000,
+      incrementalQuorum: {
+        enabled: true,
+        maxExpansionRounds: 2,
+        votersPerExpansion: 2,
+        confidenceThreshold: 0.6,
+        ambiguityBand: 0.2,
+      },
+    });
+    engine.setVoterExpansionCallback(expansionCallback);
+
+    const result = await engine.propose({
+      title: 'Race proposal',
+      description: 'concurrent final votes',
+      algorithm: 'simple_majority',
+      requiredVoters: ['a1', 'a2', 'a3', 'a4', 'a5'],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const pid = result.value;
+
+    // Four voters in — 2-2 split, ambiguous, quorum not yet complete.
+    await engine.vote(pid, 'a1', makeVote('approve'));
+    await engine.vote(pid, 'a2', makeVote('reject'));
+    await engine.vote(pid, 'a3', makeVote('approve'));
+    await engine.vote(pid, 'a4', makeVote('reject'));
+
+    // Two near-simultaneous submissions for the final voter (a re-vote
+    // racing the expansion). Both run their synchronous prologue while
+    // requiredVoters is still [a1..a5], so both see allRequiredVotersVoted
+    // === true. The re-entry guard must let only ONE start an expansion.
+    await Promise.all([
+      engine.vote(pid, 'a5', makeVote('approve')),
+      engine.vote(pid, 'a5', makeVote('approve')),
+    ]);
+
+    // Exactly one expansion — pre-#2861 this fired twice and the second
+    // expansion clobbered the first's voter list.
+    expect(expansionCallback).toHaveBeenCalledTimes(1);
+  });
+
   it('caps expansion at maxExpansionRounds', async () => {
     let callCount = 0;
     const expansionCallback = vi.fn<VoterExpansionCallback>(() => {

--- a/packages/nexus-agents/src/consensus/types-core.ts
+++ b/packages/nexus-agents/src/consensus/types-core.ts
@@ -334,6 +334,13 @@ export interface ProposalState {
   timeoutId?: ReturnType<typeof setTimeout>;
   /** Number of incremental quorum expansions applied (Issue #1408). */
   expansionRounds?: number;
+  /**
+   * True while a quorum expansion is awaiting its callback for this
+   * proposal. Concurrent `vote()` calls check this to avoid double-
+   * expanding across the `await` gap (Issue #2861). Per-proposal so
+   * independent proposals never block each other.
+   */
+  expansionInFlight?: boolean;
 }
 
 /**


### PR DESCRIPTION
#2824 audit, Wave B. Verified-real (with a severity caveat — see below).

## The bug

`ConsensusEngine.vote()` is `async`. When all required voters have voted it does:

```ts
if (this.allRequiredVotersVoted(state)) {
  const expanded = await this.tryExpandQuorum(proposalId, state);
  ...
}
```

`tryExpandQuorum()` `await`s the expansion callback, and **after** that await mutates `state.proposal.requiredVoters` and `state.expansionRounds`. Two `vote()` calls that both run their synchronous prologue while `requiredVoters` is still the un-expanded list both see `allRequiredVotersVoted() === true` and both enter `tryExpandQuorum()`:

- the expansion callback fires **twice** (2× voters spawned/registered),
- the second expansion's `requiredVoters = [...required, ...newVoters]` is built from a stale `required`, **clobbering the first expansion's added voters**,
- `expansionRounds` undercounts (each call read the stale low value).

## The fix

A per-proposal `expansionInFlight` flag on `ProposalState`. `vote()` sets it before `await tryExpandQuorum`, clears it in a `finally`, and a concurrent `vote()` that sees it set returns `ok` immediately — its vote is already recorded, and the in-flight expansion makes the quorum decision. Per-proposal, so independent proposals never block each other.

## Severity — honest caveat

The current production caller, `mcp/tools/consensus-vote.ts:242`, submits votes in a **sequential `for await` loop** — so this race is **latent, not actively firing** today. But `ConsensusEngine.vote()` is a public `async` method that mutates shared state across an `await`; any concurrent caller (a future harness, a different submission path) would hit it. This is correctness hardening of the public contract, which the #2824 audit flagged and triaged as worth doing.

## Test

`incremental-quorum.test.ts` — fires two `vote()` calls racing the final voter via `Promise.all`, asserts the expansion callback runs **exactly once**. **Verified**: the test fails (callback fires twice) when the guard is reverted, passes with it. All 12 tests in the file green; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)