### PR TITLE
fix(subprocess): env-var allowlist for spawned CLI subprocesses (closes #2865)

### DIFF
--- a/.changeset/2865-subprocess-env-allowlist.md
+++ b/.changeset/2865-subprocess-env-allowlist.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+**harden(subprocess):** env-var allowlist for spawned CLI subprocesses. Closes #2865 (#2824 audit).
+
+`spawnSubprocess()` passed the entire `process.env` to every spawned CLI (claude / gemini / codex / opencode) — only `CLAUDECODE` was stripped. That leaked cross-vendor secrets: the **gemini** CLI received `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`; the **codex** CLI received `GOOGLE_AI_API_KEY`; every CLI also saw unrelated secrets like `AWS_SECRET_ACCESS_KEY` and `GITHUB_TOKEN`.
+
+New `cli-adapters/subprocess-env.ts` builds a curated child environment via `buildChildEnv(cliName)`:
+
+- **Base infrastructure** every CLI needs — `PATH`, `HOME`, locale (`LANG`, `LC_*`), proxy (`HTTP_PROXY`/…), `NODE_*`, TLS cert vars, `npm_config_*`, and `NEXUS_*` (config + nested-run credentials).
+- **Only the spawned CLI's own vendor key(s)** — gemini gets the Google keys, codex gets `OPENAI_API_KEY`, claude gets `ANTHROPIC_API_KEY`, opencode (routes to any provider) gets the full set. Cross-vendor keys are dropped.
+
+`CLAUDECODE` is still never forwarded. Escape hatch: `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` restores the pre-#2865 full-passthrough behavior — a field un-break if the allowlist ever drops a var a CLI needs.
+
+10 tests in `subprocess-env.test.ts` cover per-CLI vendor-key isolation, base-infra passthrough, prefix families, unrelated-secret stripping, `CLAUDECODE` removal, and the escape hatch. The 35 existing `subprocess-adapter` tests still pass.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -22,6 +22,7 @@ import type {
   ICliResponseParser,
 } from './types.js';
 import { BaseCliAdapter } from './base-adapter.js';
+import { buildChildEnv } from './subprocess-env.js';
 import { sanitizeOutput } from '../security/output-sanitizer.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
 import { parseCliErrorEnvelope } from './cli-error-envelope.js';
@@ -329,9 +330,11 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
         runCleanup();
         resolveOuter(result);
       };
-      // Strip CLAUDECODE env var to allow nested CLI sessions (SWE-bench, etc.)
-      const childEnv = { ...process.env };
-      delete childEnv['CLAUDECODE'];
+      // Curated child env: base infrastructure vars + only this CLI's
+      // own vendor credentials, so cross-vendor API keys don't leak
+      // into the spawned CLI (#2865). Also drops CLAUDECODE — a nested
+      // CLI must not believe it's already inside Claude Code.
+      const childEnv = buildChildEnv(this.name);
 
       const child = spawn(cmdConfig.command, cmdConfig.args, {
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the subprocess env-var allowlist (#2865).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { buildChildEnv, getCliVendorKeys } from './subprocess-env.js';
+
+describe('buildChildEnv (#2865)', () => {
+  /** Env keys the tests touch — cleared before each test for a known slate. */
+  const MANAGED = [
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'GOOGLE_AI_API_KEY',
+    'GEMINI_API_KEY',
+    'OPENROUTER_API_KEY',
+    'AWS_SECRET_ACCESS_KEY',
+    'GITHUB_TOKEN',
+    'CLAUDECODE',
+    'LC_CUSTOMTEST',
+    'NEXUS_CUSTOMTEST',
+    'NEXUS_SUBPROCESS_ENV_ALLOWLIST',
+    'npm_config_registry',
+    'SOME_RANDOM_UNLISTED_VAR',
+  ];
+
+  beforeEach(() => {
+    // vi.stubEnv with a function call is lint-clean (no dynamic `delete`);
+    // undefined removes the var. CI may have real API keys set, so clear
+    // every managed key for a deterministic slate.
+    for (const k of MANAGED) vi.stubEnv(k, undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('passes the base infra vars through (PATH, HOME)', () => {
+    vi.stubEnv('PATH', '/usr/bin');
+    vi.stubEnv('HOME', '/home/test');
+    const env = buildChildEnv('gemini');
+    expect(env['PATH']).toBe('/usr/bin');
+    expect(env['HOME']).toBe('/home/test');
+  });
+
+  it('gives gemini only Google keys — strips Anthropic + OpenAI', () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-secret');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai-secret');
+    vi.stubEnv('GOOGLE_AI_API_KEY', 'goog-key');
+    const env = buildChildEnv('gemini');
+    expect(env['GOOGLE_AI_API_KEY']).toBe('goog-key');
+    expect(env['ANTHROPIC_API_KEY']).toBeUndefined();
+    expect(env['OPENAI_API_KEY']).toBeUndefined();
+  });
+
+  it('gives codex only the OpenAI key — strips Anthropic + Google', () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-secret');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai-secret');
+    vi.stubEnv('GOOGLE_AI_API_KEY', 'goog-key');
+    const env = buildChildEnv('codex');
+    expect(env['OPENAI_API_KEY']).toBe('sk-openai-secret');
+    expect(env['ANTHROPIC_API_KEY']).toBeUndefined();
+    expect(env['GOOGLE_AI_API_KEY']).toBeUndefined();
+  });
+
+  it('gives the claude CLI its own Anthropic key (it is subprocess-spawned)', () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-secret');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai-secret');
+    const env = buildChildEnv('claude');
+    expect(env['ANTHROPIC_API_KEY']).toBe('sk-ant-secret');
+    expect(env['OPENAI_API_KEY']).toBeUndefined();
+  });
+
+  it('gives opencode every vendor key (it routes to any provider)', () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'a');
+    vi.stubEnv('OPENAI_API_KEY', 'o');
+    vi.stubEnv('GOOGLE_AI_API_KEY', 'g');
+    vi.stubEnv('OPENROUTER_API_KEY', 'r');
+    const env = buildChildEnv('opencode');
+    expect(env['ANTHROPIC_API_KEY']).toBe('a');
+    expect(env['OPENAI_API_KEY']).toBe('o');
+    expect(env['GOOGLE_AI_API_KEY']).toBe('g');
+    expect(env['OPENROUTER_API_KEY']).toBe('r');
+  });
+
+  it('drops unrelated secrets that no CLI needs (AWS, GitHub token)', () => {
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws-secret');
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_secret');
+    vi.stubEnv('SOME_RANDOM_UNLISTED_VAR', 'x');
+    const env = buildChildEnv('gemini');
+    expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+    expect(env['GITHUB_TOKEN']).toBeUndefined();
+    expect(env['SOME_RANDOM_UNLISTED_VAR']).toBeUndefined();
+  });
+
+  it('never forwards CLAUDECODE (would break nested CLI sessions)', () => {
+    vi.stubEnv('CLAUDECODE', '1');
+    expect(buildChildEnv('codex')['CLAUDECODE']).toBeUndefined();
+  });
+
+  it('passes prefix-matched families: LC_*, NEXUS_*, npm_config_*', () => {
+    vi.stubEnv('LC_CUSTOMTEST', 'en_US.UTF-8');
+    vi.stubEnv('NEXUS_CUSTOMTEST', 'cfg');
+    vi.stubEnv('npm_config_registry', 'https://registry.example');
+    const env = buildChildEnv('codex');
+    expect(env['LC_CUSTOMTEST']).toBe('en_US.UTF-8');
+    expect(env['NEXUS_CUSTOMTEST']).toBe('cfg');
+    expect(env['npm_config_registry']).toBe('https://registry.example');
+  });
+
+  it('escape hatch: NEXUS_SUBPROCESS_ENV_ALLOWLIST=0 restores full passthrough (minus CLAUDECODE)', () => {
+    vi.stubEnv('NEXUS_SUBPROCESS_ENV_ALLOWLIST', '0');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant');
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws');
+    vi.stubEnv('CLAUDECODE', '1');
+    const env = buildChildEnv('gemini');
+    // Full passthrough — cross-vendor key NOT stripped.
+    expect(env['ANTHROPIC_API_KEY']).toBe('sk-ant');
+    expect(env['AWS_SECRET_ACCESS_KEY']).toBe('aws');
+    // CLAUDECODE still stripped even under the escape hatch.
+    expect(env['CLAUDECODE']).toBeUndefined();
+  });
+
+  it('vendor-key map covers every CliName with non-empty keys', () => {
+    const map = getCliVendorKeys();
+    for (const cli of ['claude', 'gemini', 'codex', 'opencode'] as const) {
+      expect(map[cli].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
@@ -1,0 +1,118 @@
+/**
+ * Environment-variable allowlist for spawned CLI subprocesses (#2865).
+ *
+ * `spawnSubprocess` previously passed the entire `process.env` to every
+ * spawned CLI (claude / gemini / codex / opencode) — only `CLAUDECODE`
+ * was stripped. That leaked cross-vendor API keys: the gemini CLI
+ * received `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`, the codex CLI
+ * received `GOOGLE_AI_API_KEY`, and so on. A buggy or malicious CLI
+ * could exfiltrate keys it has no business seeing.
+ *
+ * `buildChildEnv()` constructs a curated child environment instead:
+ * base infrastructure vars that every CLI needs, plus ONLY the spawned
+ * CLI's own vendor credential(s).
+ *
+ * @module cli-adapters/subprocess-env
+ */
+
+import type { CliName } from './types.js';
+
+/** Exact-match infrastructure vars every spawned CLI legitimately needs. */
+const BASE_ENV_EXACT: readonly string[] = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'LANG',
+  'TERM',
+  'TZ',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'all_proxy',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'NODE_ENV',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+];
+
+/** Prefix-match infrastructure var families. */
+const BASE_ENV_PREFIXES: readonly string[] = [
+  'LC_', // locale: LC_ALL, LC_CTYPE, …
+  'NEXUS_', // nexus-agents config + nested-run credentials (a child may be a nested nexus-agents)
+  'npm_config_', // npm/node resolution config: registry, proxy, …
+];
+
+/**
+ * Per-CLI vendor credentials. The spawned CLI gets ONLY its own
+ * vendor's key(s) — not every vendor's. `opencode` can route to any
+ * provider via its config, so it gets the full set.
+ */
+const CLI_VENDOR_KEYS: Record<CliName, readonly string[]> = {
+  claude: ['ANTHROPIC_API_KEY'],
+  gemini: ['GOOGLE_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+  codex: ['OPENAI_API_KEY'],
+  opencode: [
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'GOOGLE_AI_API_KEY',
+    'GEMINI_API_KEY',
+    'GOOGLE_API_KEY',
+    'OPENROUTER_API_KEY',
+  ],
+};
+
+/** True if `key` is permitted for a CLI whose vendor keys are `vendorKeys`. */
+function isAllowed(key: string, vendorKeys: readonly string[]): boolean {
+  if (BASE_ENV_EXACT.includes(key)) return true;
+  if (vendorKeys.includes(key)) return true;
+  return BASE_ENV_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Builds the environment for a spawned CLI subprocess: base
+ * infrastructure vars plus only `cliName`'s own vendor credentials.
+ * Cross-vendor API keys are dropped (#2865).
+ *
+ * `CLAUDECODE` is never forwarded — a nested CLI seeing it would
+ * believe it's already inside Claude Code, breaking nested sessions
+ * (the pre-#2865 behavior also stripped it explicitly).
+ *
+ * Escape hatch: `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` restores the
+ * pre-#2865 full-passthrough behavior (minus `CLAUDECODE`) — a
+ * field un-break if the allowlist ever drops a var a CLI needs.
+ */
+export function buildChildEnv(cliName: CliName): NodeJS.ProcessEnv {
+  const source = process.env;
+  const childEnv: NodeJS.ProcessEnv = {};
+
+  if (source['NEXUS_SUBPROCESS_ENV_ALLOWLIST'] === '0') {
+    for (const [key, value] of Object.entries(source)) {
+      if (value !== undefined && key !== 'CLAUDECODE') childEnv[key] = value;
+    }
+    return childEnv;
+  }
+
+  const vendorKeys = CLI_VENDOR_KEYS[cliName];
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (key === 'CLAUDECODE') continue;
+    if (isAllowed(key, vendorKeys)) childEnv[key] = value;
+  }
+  return childEnv;
+}
+
+/** Test/introspection accessor for the per-CLI vendor-key map. */
+export function getCliVendorKeys(): Readonly<Record<CliName, readonly string[]>> {
+  return CLI_VENDOR_KEYS;
+}


### PR DESCRIPTION
## Summary

`spawnSubprocess()` passed the entire `process.env` to every spawned CLI (claude / gemini / codex / opencode) — only `CLAUDECODE` was stripped. That leaked **cross-vendor secrets**: the gemini CLI received `ANTHROPIC_API_KEY` + `OPENAI_API_KEY`, codex received `GOOGLE_AI_API_KEY`, and every CLI also saw unrelated secrets like `AWS_SECRET_ACCESS_KEY` and `GITHUB_TOKEN`. A buggy or compromised CLI could exfiltrate keys it has no business seeing.

New `cli-adapters/subprocess-env.ts` — `buildChildEnv(cliName)` builds a curated child environment:

- **Base infrastructure** every CLI needs: `PATH`, `HOME`, locale (`LANG`, `LC_*`), proxy vars, `NODE_*`, TLS cert vars, `npm_config_*`, `NEXUS_*`.
- **Only the spawned CLI's own vendor key(s)**: gemini → Google keys, codex → `OPENAI_API_KEY`, claude → `ANTHROPIC_API_KEY`, opencode → full set (it routes to any provider). Cross-vendor keys dropped.

`CLAUDECODE` is still never forwarded (pre-#2865 behavior — a nested CLI must not believe it's already inside Claude Code). Escape hatch: `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` restores full passthrough — a field un-break if the allowlist ever drops a var a CLI needs.

`claude` is included with `ANTHROPIC_API_KEY` because `ClaudeCliAdapter` also extends `SubprocessCliAdapter`; the audit's draft design had `claude:[]`, which would have broken the claude subprocess path.

## Test plan

- [x] `subprocess-env.test.ts` — 10 tests: per-CLI vendor-key isolation, base-infra passthrough, prefix families, unrelated-secret stripping, `CLAUDECODE` removal, escape hatch
- [x] 35 existing `subprocess-adapter` tests still pass (wiring `buildChildEnv` didn't change adapter behavior)
- [x] `eslint` 0 errors, `tsc --noEmit` 0 errors

Closes #2865. Part of the #2824 audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)