### PR TITLE
fix(vote): pipe vote comment to gh via stdin, not inline --body (closes #2863)

### DIFF
--- a/.changeset/2863-vote-comment-stdin.md
+++ b/.changeset/2863-vote-comment-stdin.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(vote):** record vote comments via `gh ... --body-file -` stdin. Closes #2863 (#2824 audit bullet 10).
+
+`recordVoteToGitHub` embedded the markdown comment body directly in the command string as `gh issue comment N --body '<comment>'`. The sandbox `validateArgs` gate rejects any argument containing shell metacharacters (`/[;&|`$()]/`), and every vote comment from `formatVoteComment` contains a markdown table (`|`) plus a `(NN% approval)`parenthetical — so the body token always matched a denied pattern and`safeExecSandboxed`returned`null`. Result: **every** vote comment was silently dropped with "command denied or failed", regardless of the proposal text.
+
+The body is now piped to `gh` over stdin via `--body-file -`, so it never touches the shell. `escapeForShell` is removed (no longer needed). `SandboxExecOptions` gains an optional `stdin` field, wired into `safeExecSandboxed`/`execSandboxed` as `execSync`'s `input` option.

--- a/packages/nexus-agents/src/cli/sandbox-exec.test.ts
+++ b/packages/nexus-agents/src/cli/sandbox-exec.test.ts
@@ -173,6 +173,59 @@ describe('sandbox-exec', () => {
 
       expect(result).toBe('buffer output');
     });
+
+    it('should pass stdin as the execSync input option (#2863)', () => {
+      vi.mocked(execSync).mockReturnValue('commented');
+
+      safeExecSandboxed('gh issue comment 1 --body-file -', {
+        context: 'gh',
+        stdin: 'multi-line\nbody | with | pipes',
+      });
+
+      expect(execSync).toHaveBeenCalledWith(
+        'gh issue comment 1 --body-file -',
+        expect.objectContaining({ input: 'multi-line\nbody | with | pipes' })
+      );
+    });
+
+    it('should omit the input option when no stdin is given', () => {
+      vi.mocked(execSync).mockReturnValue('ok');
+
+      safeExecSandboxed('git status', { context: 'git' });
+
+      const passedOptions = vi.mocked(execSync).mock.calls[0]?.[1];
+      expect(passedOptions).not.toHaveProperty('input');
+    });
+  });
+
+  // Regression for #2863 (audit #2824 bullet 10): vote-command embedded the
+  // markdown comment body in the command string as `--body '<comment>'`. Every
+  // vote comment contains a markdown table (`|`) and a `(NN% approval)`
+  // parenthetical, so the body token always matched a denied shell pattern and
+  // the comment was silently dropped. The fix pipes the body via stdin.
+  describe('vote-comment recording (#2863)', () => {
+    // A realistic formatVoteComment() body: markdown table + parens.
+    const voteBody = [
+      '## Consensus Vote Result',
+      '| Agent | Decision | Confidence |',
+      '| ----- | -------- | ---------- |',
+      '| Architect | APPROVE | 90% |',
+      '**Summary:** Approve: 4, Reject: 1 (80.0% approval)',
+    ].join('\n');
+
+    it('denies the old --body inline form (proves the bug)', () => {
+      const violation = validateCommandWithPolicy(`gh issue comment 1 --body '${voteBody}'`, {
+        context: 'gh',
+      });
+      expect(violation).not.toBeNull();
+    });
+
+    it('allows the --body-file - stdin form (proves the fix)', () => {
+      const violation = validateCommandWithPolicy('gh issue comment 1 --body-file -', {
+        context: 'gh',
+      });
+      expect(violation).toBeNull();
+    });
   });
 
   describe('execSandboxed', () => {

--- a/packages/nexus-agents/src/cli/sandbox-exec.ts
+++ b/packages/nexus-agents/src/cli/sandbox-exec.ts
@@ -36,6 +36,13 @@ export interface SandboxExecOptions {
   readonly context?: ExecContext;
   /** Custom policy (overrides context-based selection). */
   readonly policy?: SandboxPolicy;
+  /**
+   * Data to pipe to the child process's stdin (#2863). Lets callers
+   * pass large or shell-unsafe payloads (e.g. a markdown comment body)
+   * without embedding them in the command string — where chars like
+   * `| ( ) ; &` would be rejected by `validateArgs`.
+   */
+  readonly stdin?: string;
 }
 
 /** Parser state for command string tokenization. */
@@ -167,6 +174,9 @@ export function safeExecSandboxed(
     if (options.cwd !== undefined) {
       execOptions.cwd = options.cwd;
     }
+    if (options.stdin !== undefined) {
+      execOptions.input = options.stdin;
+    }
 
     const result = execSync(commandString, execOptions);
     return typeof result === 'string' ? result.trim() : result.toString('utf-8').trim();
@@ -205,6 +215,9 @@ export function execSandboxed(commandString: string, options: SandboxExecOptions
 
   if (options.cwd !== undefined) {
     execOptions.cwd = options.cwd;
+  }
+  if (options.stdin !== undefined) {
+    execOptions.input = options.stdin;
   }
 
   const result = execSync(commandString, execOptions);

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -3,11 +3,20 @@
  * (Source: Issue #227)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { VotingResult } from './vote-types.js';
 import type { ConsensusResult, Vote } from '../consensus/types.js';
-import { formatVoteComment, formatVoteRow, explainOutcome } from './vote-command.js';
 import type { AgentVoteResult } from './voter-agents.js';
+
+const { safeExecSandboxedMock } = vi.hoisted(() => ({ safeExecSandboxedMock: vi.fn() }));
+vi.mock('./sandbox-exec.js', () => ({ safeExecSandboxed: safeExecSandboxedMock }));
+
+import {
+  formatVoteComment,
+  formatVoteRow,
+  explainOutcome,
+  recordVoteToGitHub,
+} from './vote-command.js';
 
 function createMockConsensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
   return {
@@ -271,5 +280,39 @@ describe('explainOutcome (#2441 + #2442)', () => {
     );
     expect(explained).toContain('unanimous threshold not met');
     expect(explained).toContain('80.0%');
+  });
+});
+
+// #2863 (audit #2824 bullet 10): the comment body must be piped to `gh` via
+// stdin, never embedded in the command string — every vote comment contains a
+// markdown table (`|`) and a `(NN% approval)` parenthetical, which the sandbox
+// `validateArgs` gate rejects, silently dropping the comment.
+describe('recordVoteToGitHub', () => {
+  beforeEach(() => {
+    safeExecSandboxedMock.mockReset();
+  });
+
+  it('pipes the comment via --body-file - stdin, not an inline --body arg', () => {
+    safeExecSandboxedMock.mockReturnValue('commented');
+
+    recordVoteToGitHub(42, createMockVotingResult());
+
+    expect(safeExecSandboxedMock).toHaveBeenCalledWith(
+      'gh issue comment 42 --body-file -',
+      expect.objectContaining({
+        context: 'gh',
+        stdin: expect.stringContaining('## Consensus Vote Result') as string,
+      })
+    );
+  });
+
+  it('keeps shell-unsafe characters out of the command string', () => {
+    safeExecSandboxedMock.mockReturnValue('commented');
+
+    recordVoteToGitHub(7, createMockVotingResult());
+
+    const commandString = safeExecSandboxedMock.mock.calls[0]?.[0] as string;
+    // The body (which contains `|`, `(`, `)`) lives in stdin, not the command.
+    expect(commandString).not.toMatch(/[|()]/);
   });
 });

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -163,13 +163,6 @@ function validateGitHubIssue(issueNumber: number): boolean {
 }
 
 /**
- * Escapes special characters for shell command.
- */
-function escapeForShell(text: string): string {
-  return text.replace(/'/g, "'\\''");
-}
-
-/**
  * Formats vote result as markdown comment.
  */
 export function formatVoteComment(result: VotingResult): string {
@@ -215,15 +208,22 @@ ${voteRows}
 
 /**
  * Records vote result to GitHub issue.
+ *
+ * The comment body is piped to `gh` via stdin (`--body-file -`) rather
+ * than embedded in the command string (#2863). The previous `--body
+ * '<comment>'` form was rejected by the sandbox `validateArgs` gate for
+ * every vote: `formatVoteComment` always emits a markdown table (`|`)
+ * and a `(NN% approval)` parenthetical, both of which match the denied
+ * shell-metacharacter pattern. Piping keeps the body off the shell
+ * entirely — no escaping, no injection surface.
  */
-function recordVoteToGitHub(issueNumber: number, result: VotingResult): void {
+export function recordVoteToGitHub(issueNumber: number, result: VotingResult): void {
   const comment = formatVoteComment(result);
-  const escapedComment = escapeForShell(comment);
 
-  const output = safeExecSandboxed(
-    `gh issue comment ${String(issueNumber)} --body '${escapedComment}'`,
-    { context: 'gh' }
-  );
+  const output = safeExecSandboxed(`gh issue comment ${String(issueNumber)} --body-file -`, {
+    context: 'gh',
+    stdin: comment,
+  });
 
   if (output !== null) {
     writeLine(


### PR DESCRIPTION
## Summary

#2824 audit bullet 10 — **verified the audit was right**, not a false positive.

`recordVoteToGitHub` built `gh issue comment N --body '<comment>'` with the markdown body embedded in the command string. `safeExecSandboxed` tokenizes that string and runs `validateArgs`, which denies any argument matching `/[;&|\`$()]/`. Every `formatVoteComment` body contains a markdown table (`|`) and a `(NN% approval)` parenthetical — so the body token **always** matched a denied pattern. `safeExecSandboxed` returned `null` and the comment was silently dropped with "command denied or failed", regardless of proposal text. `recordVoteToGitHub` never worked.

## Fix

Pass the body over stdin via `gh issue comment N --body-file -`. The command string now has only clean tokens; the body never touches the shell — no escaping, no injection surface.

- `sandbox-exec.ts`: `SandboxExecOptions` gains an optional `stdin` field, wired into `safeExecSandboxed`/`execSandboxed` as `execSync`'s `input` option.
- `vote-command.ts`: `recordVoteToGitHub` uses `--body-file -` + `stdin`; `escapeForShell` removed (dead code). `recordVoteToGitHub` exported for the regression test.

## Test plan

- [x] `sandbox-exec.test.ts` — stdin passthrough to `execSync.input`; the inline `--body` form is denied (proves the bug); the `--body-file -` form is allowed (proves the fix)
- [x] `vote-command.test.ts` — `recordVoteToGitHub` pipes via stdin and keeps shell-unsafe chars out of the command string
- [x] 57 tests pass; `eslint` 0, `tsc --noEmit` 0

Closes #2863. Part of the #2824 audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)