### PR TITLE
fix(cli-adapters): collapse nested subprocess retry layers (#2824 P1)

### DIFF
--- a/.changeset/2824-collapse-nested-retry.md
+++ b/.changeset/2824-collapse-nested-retry.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(cli-adapters):** collapse nested retry layers for subprocess CLIs. Part of #2824 (audit P1).
+
+Subprocess CLI adapters had two independent retry layers on the same call path: the inner `retryTransient` in `SubprocessCliAdapter` (1 initial + 2 transient retries) and the shared outer `executeCliRetryLoop` (`maxRetries: 1` → 2 attempts). On a persistent transient error (TIMEOUT / RATE_LIMITED / CONNECTION_ERROR) they multiplied — outer × inner = up to **6 subprocess spawns**, and because the inner layer extends the timeout by 1.5× on every TIMEOUT retry, a stuck call could hang ~9–10 minutes before finally failing.
+
+New `BaseCliAdapter.shouldOuterRetry()` hook decides whether the outer loop may retry. `SubprocessCliAdapter` overrides it to return `false` whenever its own `transientRetry` layer is enabled (the default), making the inner layer the single retry authority. The outer loop still runs once, so circuit-breaker failure recording is unchanged. Applies to the claude/codex/opencode adapters (via `BaseCliAdapter`) and the gemini adapter (via its circuit-breaker-coupled `executeWithRetryTracking`). Non-subprocess adapters are unaffected.

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -300,7 +300,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
   ): Promise<Result<{ response: CliResponse; retryCount: number }, CliError>> {
     return executeCliRetryLoop(() => this.executeTask(task, options), {
       maxRetries: options.maxRetries,
-      allowRetry: options.allowRetry,
+      allowRetry: this.shouldOuterRetry(options),
       baseDelayMs: this.baseDelayMs,
       maxDelayMs: this.maxDelayMs,
       circuitBreaker: this.circuitBreaker,

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -160,6 +160,17 @@ export abstract class BaseCliAdapter implements ICliAdapter {
   }
 
   /**
+   * Whether the shared outer retry loop ({@link executeCliRetryLoop}) is
+   * allowed to retry this adapter's failures. The base adapter honors the
+   * caller's `allowRetry`. Subprocess adapters override this to suppress
+   * the outer loop when their own transient-retry layer is active, so the
+   * two layers do not nest into multiplied spawns (#2824).
+   */
+  protected shouldOuterRetry(opts: Required<ExecutionOptions>): boolean {
+    return opts.allowRetry;
+  }
+
+  /**
    * Executes task with retry logic via shared retry loop.
    */
   private async executeWithRetry(
@@ -168,7 +179,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
   ): Promise<Result<CliResponse, CliError>> {
     const result = await executeCliRetryLoop(() => this.executeTask(task, opts), {
       maxRetries: opts.maxRetries,
-      allowRetry: opts.allowRetry,
+      allowRetry: this.shouldOuterRetry(opts),
       baseDelayMs: 1_000,
       maxDelayMs: 16_000,
       cli: this.name,

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -1138,3 +1138,67 @@ describe('SubprocessCliAdapter', () => {
     });
   });
 });
+
+/**
+ * Regression for #2824: the inner `retryTransient` layer and the shared
+ * outer `executeCliRetryLoop` used to both retry transient failures. On a
+ * persistent transient error that meant outer-attempts × inner-attempts
+ * subprocess spawns. `shouldOuterRetry` now suppresses the outer loop when
+ * the inner transient layer is active, so the inner layer is the single
+ * retry authority.
+ */
+describe('SubprocessCliAdapter - nested retry layers (#2824)', () => {
+  /** Adapter with the real default `transientRetry.enabled = true`, plus an
+   *  instant `delay` so retry backoff does not slow the test. */
+  class RetryEnabledAdapter extends TestSubprocessAdapter {
+    protected override readonly transientRetry = { enabled: true };
+    protected override delay(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+
+  /** Makes every spawn emit `close` with the given exit code once the
+   *  adapter has attached its listeners (next microtask). Exit 137 is a
+   *  signal kill → classified CONNECTION_ERROR (transient, retryable). */
+  function spawnAlwaysExits(code: number): void {
+    mockSpawn.mockImplementation(() => {
+      const { mockChild, stdout, stderr } = createMockChildProcess();
+      queueMicrotask(() => {
+        stdout.push(null);
+        stderr.push(null);
+        mockChild.emit('close', code);
+      });
+      return mockChild;
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not multiply spawns: a persistent transient error retries only the inner layer', async () => {
+    const adapter = new RetryEnabledAdapter();
+    spawnAlwaysExits(137); // CONNECTION_ERROR every attempt
+
+    const result = await adapter.execute({ content: 'test' });
+
+    expect(result.ok).toBe(false);
+    // Inner retryTransient: 1 initial + MAX_TRANSIENT_RETRIES(2) = 3 spawns.
+    // The outer loop is suppressed (would have made it 6 before #2824).
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-transient error at either layer', async () => {
+    const adapter = new RetryEnabledAdapter();
+    mockSpawn.mockImplementation(() => {
+      const { mockChild } = createMockChildProcess();
+      queueMicrotask(() => mockChild.emit('error', new Error('spawn nonexistent ENOENT')));
+      return mockChild;
+    });
+
+    const result = await adapter.execute({ content: 'test' });
+
+    expect(result.ok).toBe(false);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -242,6 +242,19 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
   protected readonly transientRetry: TransientRetryConfig = { enabled: true };
 
   /**
+   * The inner {@link retryTransient} layer is the single retry authority
+   * for subprocess CLIs. When it is enabled (the default), the shared
+   * outer retry loop must not also retry: nesting both meant up to 6
+   * subprocess spawns and ~10-minute hangs on a persistent TIMEOUT, since
+   * the inner layer's timeout extension compounds on every outer attempt
+   * (#2824). The outer loop still runs once, so circuit-breaker failure
+   * recording is unaffected.
+   */
+  protected override shouldOuterRetry(opts: Required<ExecutionOptions>): boolean {
+    return opts.allowRetry && !this.transientRetry.enabled;
+  }
+
+  /**
    * Gets CLI command and arguments for execution.
    * If stdin is provided, it will be written to the process stdin.
    */


### PR DESCRIPTION
## Summary

#2824 audit P1. Subprocess CLI adapters ran **two independent retry layers** on the same call path:

- **inner** — `SubprocessCliAdapter.retryTransient`: 1 initial spawn + `MAX_TRANSIENT_RETRIES`(2) = 3 spawns. Transient-error-aware, with 1.5× timeout extension per TIMEOUT retry (#1401).
- **outer** — `executeCliRetryLoop`: `maxRetries: 1` → 2 attempts. Generic.

Both retry the same TIMEOUT / RATE_LIMITED / CONNECTION_ERROR classes, so on a persistent transient failure they multiplied: outer 2 × inner 3 = **up to 6 subprocess spawns**. Worse, the inner layer's compounding timeout extension stretched a stuck call to **~9–10 minutes** wall-clock before it finally failed.

## Fix

New `BaseCliAdapter.shouldOuterRetry()` hook decides whether the outer loop may retry. `SubprocessCliAdapter` overrides it to return `false` whenever its `transientRetry` layer is enabled (the default) — the inner layer becomes the single retry authority. The outer loop still runs once (`maxAttempts = 1`), so circuit-breaker failure recording is unchanged (and arguably more correct — one logical failure now records one breaker failure, not two).

Covers claude/codex/opencode (via `BaseCliAdapter.executeWithRetry`) and gemini (via its circuit-breaker-coupled `executeWithRetryTracking`, now also routed through `shouldOuterRetry`). Non-subprocess adapters (codex-mcp, sdk) keep the base behavior.

## Test plan

- [x] `subprocess-adapter.test.ts` — 2 regressions: a persistent transient error spawns **exactly 3 times** (not 6); a non-transient error spawns exactly once
- [x] 116 adjacent adapter tests (base / subprocess / gemini / claude / cli-retry-loop) still pass
- [x] `eslint` 0, `tsc --noEmit` 0

Part of #2824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)