### PR TITLE
fix(mcp): route pipeline tools through secure-handler chain (#2824 P1)

### DIFF
--- a/.changeset/2824-mcp-pipeline-secure-handler.md
+++ b/.changeset/2824-mcp-pipeline-secure-handler.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(mcp):** route `run_pipeline` / `run_dev_pipeline` through the standard secure-handler chain. Part of #2824 (audit P1).
+
+Both pipeline tools registered a bare `server.registerTool()` callback, bypassing the `createSecureHandler → wrapToolWithTimeout → toSdkCallback` chain every other MCP tool uses. Consequences: no rate-limiting, no abort-signal or progress-token plumbing (the very tools that need it most, being long-running), and `schema.parse(args)` ran outside any try/catch — so a `ZodError` on bad input surfaced as a raw JSON-RPC `-32603` internal error instead of a structured `validation` envelope.
+
+Both tools now use the standard chain: input is validated with `safeParse` inside the handler and a bad payload returns a `toolStructuredError({ errorCategory: 'validation' })`. `run_pipeline` and `run_dev_pipeline` are added to `MCP_TIMEOUTS.perTool` at 15 min so the newly-applied `wrapToolWithTimeout` does not kill these multi-stage pipelines at the 60s default.

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -104,6 +104,8 @@ export const MCP_TIMEOUTS = {
     consensus_vote: 600_000, // 10 min — 5-6 agents voting in parallel via Promise.all
     execute_expert: 900_000, // 15 min — complex expert reasoning tasks
     run_workflow: 900_000, // 15 min — multi-step workflow execution
+    run_pipeline: 900_000, // 15 min — multi-stage pipeline orchestration (#2824)
+    run_dev_pipeline: 900_000, // 15 min — multi-agent dev pipeline (#2824)
   } as Readonly<Record<string, number>>,
 } as const;
 

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -2,8 +2,43 @@
  * run_dev_pipeline MCP Tool Tests (#1684)
  */
 
-import { describe, it, expect } from 'vitest';
-import { DevPipelineInputSchema } from './dev-pipeline-tool.js';
+import { describe, it, expect, vi } from 'vitest';
+
+// Pass-through the secure-handler / timeout chain so the registered callback
+// is the bare handler — lets the tests invoke it directly (#2824).
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler: (fn: unknown) => fn,
+}));
+
+import { DevPipelineInputSchema, registerDevPipelineTool } from './dev-pipeline-tool.js';
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
+  let captured: ((args: unknown) => Promise<CapturedToolResult>) | undefined;
+  let registeredName: string | undefined;
+  const mockServer = {
+    registerTool: (name: string, _schema: unknown, handler: unknown) => {
+      registeredName = name;
+      captured = handler as (args: unknown) => Promise<CapturedToolResult>;
+    },
+  };
+  registerDevPipelineTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  expect(registeredName).toBe('run_dev_pipeline');
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
 
 describe('DevPipelineInputSchema', () => {
   it('accepts direct task instructions', () => {
@@ -52,5 +87,24 @@ describe('DevPipelineInputSchema', () => {
       workingDir: '/home/user/project',
     });
     expect(parsed.workingDir).toBe('/home/user/project');
+  });
+});
+
+// #2824: run_dev_pipeline used to register a bare callback that called
+// `schema.parse(args)` outside any try/catch — a ZodError on bad input
+// escaped as a raw JSON-RPC -32603 instead of a structured `validation`
+// envelope. It now routes through the standard secure-handler chain.
+describe('registerDevPipelineTool', () => {
+  it('registers under the run_dev_pipeline name', () => {
+    // captureHandler asserts the registered name internally.
+    expect(captureHandler()).toBeTypeOf('function');
+  });
+
+  it('returns a structured validation error for invalid input, not a thrown ZodError', async () => {
+    const handler = captureHandler();
+    // task must be a string; maxVoteIterations max is 5 — both invalid here.
+    const result = await handler({ task: 12345, maxVoteIterations: 99 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Invalid input');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -11,16 +11,21 @@ import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, getErrorMessage } from '../../core/index.js';
+import { createLogger, getErrorMessage, formatZodError, type ILogger } from '../../core/index.js';
 import { runDevPipeline } from '../../pipeline/dev-pipeline.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
 import type { DevPipelineResult } from '../../pipeline/dev-pipeline.js';
 import { createAgentStages, flushPipelineMemory } from '../../pipeline/agent-executor.js';
 import { createTaskTracker, detectBackend } from '../../pipeline/task-tracker.js';
-// toolSuccessStructured not used directly — registerTool callback expects a CallToolResult-shaped value
-import type {} from '../../pipeline/task-tracker.js';
 import { getToolAnnotations } from '../tool-annotations.js';
-import { toolStructuredError } from './tool-result.js';
+import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
+import { createSecureHandler } from '../middleware/secure-handler.js';
+import {
+  toolStructuredError,
+  toolSuccessStructured,
+  type BaseMcpToolDeps,
+  type ToolResult,
+} from './tool-result.js';
 
 // ============================================================================
 // Input Schema
@@ -196,11 +201,59 @@ function buildStructuredOutput(result: DevPipelineResult): Record<string, unknow
 const RUN_DEV_PIPELINE_DESCRIPTION =
   'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).';
 
-/** Register the run_dev_pipeline MCP tool. */
-export function registerDevPipelineTool(
-  server: McpServer,
-  _deps: { logger: unknown; rateLimiter: unknown }
-): void {
+/** Validates input, runs the dev pipeline, and shapes the result. */
+async function runDevPipelineHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
+  const parsed = DevPipelineInputSchema.safeParse(args);
+  if (!parsed.success) {
+    return toolStructuredError({
+      errorCategory: 'validation',
+      message: `Invalid input: ${formatZodError(parsed.error)}`,
+    });
+  }
+  const input = parsed.data;
+  if (input.simulateVotes) {
+    warnIfSimulatedOutsideTests('run_dev_pipeline', logger);
+  }
+
+  try {
+    const taskText = await resolveTaskInput(input);
+    const stages = await createStages(input);
+    const pipelineOptions = {
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+      ...(input.dryRun ? { dryRun: true } : {}),
+      ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
+    };
+    const hasOptions = Object.keys(pipelineOptions).length > 0;
+    const result = await runDevPipeline(taskText, stages, hasOptions ? pipelineOptions : undefined);
+    // Always flush memory session — including dry-run exits (#1716)
+    flushPipelineMemory();
+    return toolSuccessStructured(buildStructuredOutput(result));
+  } catch (error: unknown) {
+    return toolStructuredError({
+      errorCategory: 'internal',
+      message: `Pipeline error: ${getErrorMessage(error)}`,
+    });
+  }
+}
+
+/**
+ * Register the run_dev_pipeline MCP tool.
+ *
+ * Routed through the standard `createSecureHandler → wrapToolWithTimeout →
+ * toSdkCallback` chain like every other tool (#2824): the bare-callback
+ * registration it used before had no rate-limiting, no abort-signal /
+ * progress-token plumbing, and surfaced a `ZodError` on bad input as a raw
+ * JSON-RPC `-32603` instead of a structured `validation` envelope.
+ */
+export function registerDevPipelineTool(server: McpServer, deps: BaseMcpToolDeps): void {
+  const logger = deps.logger ?? createLogger({ tool: 'run_dev_pipeline' });
+  const secureHandler = createSecureHandler(
+    (args: unknown) => runDevPipelineHandler(args, logger),
+    { toolName: 'run_dev_pipeline', rateLimiter: deps.rateLimiter, logger }
+  );
+  const timeoutMs = getToolTimeout('run_dev_pipeline', deps.security);
+  const wrapped = wrapToolWithTimeout('run_dev_pipeline', secureHandler, { timeoutMs, logger });
+
   server.registerTool(
     'run_dev_pipeline',
     {
@@ -208,44 +261,7 @@ export function registerDevPipelineTool(
       inputSchema: DevPipelineInputSchema.shape,
       annotations: getToolAnnotations('run_dev_pipeline'),
     },
-    async (args) => {
-      const input = DevPipelineInputSchema.parse(args);
-      if (input.simulateVotes) {
-        warnIfSimulatedOutsideTests('run_dev_pipeline', createLogger({ tool: 'run_dev_pipeline' }));
-      }
-
-      try {
-        const taskText = await resolveTaskInput(input);
-        const stages = await createStages(input);
-        const pipelineOptions = {
-          ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
-          ...(input.dryRun ? { dryRun: true } : {}),
-          ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
-        };
-        const hasOptions = Object.keys(pipelineOptions).length > 0;
-        const result = await runDevPipeline(
-          taskText,
-          stages,
-          hasOptions ? pipelineOptions : undefined
-        );
-        // Always flush memory session — including dry-run exits (#1716)
-        flushPipelineMemory();
-        const structured = buildStructuredOutput(result);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
-          structuredContent: structured,
-        };
-      } catch (error: unknown) {
-        // Spread into a fresh literal — this callback is registered
-        // directly (no toSdkCallback adapter), so the SDK return type
-        // needs an index signature that the named ToolResult type lacks.
-        return {
-          ...toolStructuredError({
-            errorCategory: 'internal',
-            message: `Pipeline error: ${getErrorMessage(error)}`,
-          }),
-        };
-      }
-    }
+    toSdkCallback(wrapped)
   );
+  logger.info('Registered run_dev_pipeline tool');
 }

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
@@ -1,0 +1,89 @@
+/**
+ * run_pipeline MCP Tool Tests (#1736)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Pass-through the secure-handler / timeout chain so the registered callback
+// is the bare handler — lets the tests invoke it directly (#2824).
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler: (fn: unknown) => fn,
+}));
+
+import { PipelineInputSchema, registerPipelineTool } from './pipeline-tool.js';
+
+describe('PipelineInputSchema', () => {
+  it('accepts a valid task with defaults', () => {
+    const parsed = PipelineInputSchema.parse({ task: 'Build a login form' });
+    expect(parsed.task).toBe('Build a login form');
+    expect(parsed.dryRun).toBe(false);
+    expect(parsed.quickMode).toBe(false);
+    expect(parsed.simulateVotes).toBe(false);
+  });
+
+  it('rejects a task shorter than the 5-char minimum', () => {
+    expect(PipelineInputSchema.safeParse({ task: 'hi' }).success).toBe(false);
+  });
+
+  it('rejects a timeoutMs outside the 30s-600s range', () => {
+    expect(PipelineInputSchema.safeParse({ task: 'valid task', timeoutMs: 5_000 }).success).toBe(
+      false
+    );
+  });
+
+  it('accepts an explicit template override and dryRun', () => {
+    const parsed = PipelineInputSchema.parse({
+      task: 'audit this',
+      template: 'audit',
+      dryRun: true,
+    });
+    expect(parsed.template).toBe('audit');
+    expect(parsed.dryRun).toBe(true);
+  });
+});
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
+  let captured: ((args: unknown) => Promise<CapturedToolResult>) | undefined;
+  let registeredName: string | undefined;
+  const mockServer = {
+    registerTool: (name: string, _schema: unknown, handler: unknown) => {
+      registeredName = name;
+      captured = handler as (args: unknown) => Promise<CapturedToolResult>;
+    },
+  };
+  registerPipelineTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  expect(registeredName).toBe('run_pipeline');
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
+
+// #2824: run_pipeline used to register a bare callback that called
+// `schema.parse(args)` outside any try/catch — a ZodError on bad input
+// escaped as a raw JSON-RPC -32603 instead of a structured `validation`
+// envelope. It now routes through the standard secure-handler chain.
+describe('registerPipelineTool', () => {
+  it('registers under the run_pipeline name', () => {
+    expect(captureHandler()).toBeTypeOf('function');
+  });
+
+  it('returns a structured validation error for invalid input, not a thrown ZodError', async () => {
+    const handler = captureHandler();
+    // task is below the 5-char minimum.
+    const result = await handler({ task: 'no' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Invalid input');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, getErrorMessage } from '../../core/index.js';
+import { createLogger, getErrorMessage, formatZodError, type ILogger } from '../../core/index.js';
 import { runAdaptiveOrchestrator, classifyTask } from '../../pipeline/adaptive-orchestrator.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
 import type { AdaptiveOrchestratorResult } from '../../pipeline/adaptive-orchestrator.js';
@@ -24,7 +24,14 @@ import {
 } from '../../pipeline/stage-wrappers.js';
 import { listTemplateIds } from '../../pipeline/templates.js';
 import { getToolAnnotations } from '../tool-annotations.js';
-import { toolStructuredError } from './tool-result.js';
+import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
+import { createSecureHandler } from '../middleware/secure-handler.js';
+import {
+  toolStructuredError,
+  toolSuccessStructured,
+  type BaseMcpToolDeps,
+  type ToolResult,
+} from './tool-result.js';
 
 // ============================================================================
 // Input Schema
@@ -164,11 +171,63 @@ function selectStageRegistry(
 // 4-template list).
 const RUN_PIPELINE_DESCRIPTION = `Single unified entry point for all pipeline templates (${listTemplateIds().join('/')}). Auto-detects template from task content or accepts an explicit override.`;
 
-/** Register the run_pipeline MCP tool. */
-export function registerPipelineTool(
-  server: McpServer,
-  _deps: { logger: unknown; rateLimiter: unknown }
-): void {
+/** Validates input, runs the adaptive orchestrator, and shapes the result. */
+async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
+  const parsed = PipelineInputSchema.safeParse(args);
+  if (!parsed.success) {
+    return toolStructuredError({
+      errorCategory: 'validation',
+      message: `Invalid input: ${formatZodError(parsed.error)}`,
+    });
+  }
+  const input = parsed.data;
+  if (input.simulateVotes) {
+    warnIfSimulatedOutsideTests('run_pipeline', logger);
+  }
+
+  try {
+    const task = await resolveTask(input.task, input.specFile);
+    const agentStages = createAgentStages({
+      simulateVotes: input.simulateVotes,
+      votingStrategy: input.votingStrategy,
+      quickMode: input.quickMode,
+    });
+    const stages = selectStageRegistry(input.template, task, agentStages);
+
+    const result = await runAdaptiveOrchestrator(task, {
+      stages,
+      templateId: input.template,
+      dryRun: input.dryRun,
+    });
+
+    return toolSuccessStructured(buildOutput(result));
+  } catch (error: unknown) {
+    return toolStructuredError({
+      errorCategory: 'internal',
+      message: `Pipeline error: ${getErrorMessage(error)}`,
+    });
+  }
+}
+
+/**
+ * Register the run_pipeline MCP tool.
+ *
+ * Routed through the standard `createSecureHandler → wrapToolWithTimeout →
+ * toSdkCallback` chain like every other tool (#2824): the bare-callback
+ * registration it used before had no rate-limiting, no abort-signal /
+ * progress-token plumbing, and surfaced a `ZodError` on bad input as a raw
+ * JSON-RPC `-32603` instead of a structured `validation` envelope.
+ */
+export function registerPipelineTool(server: McpServer, deps: BaseMcpToolDeps): void {
+  const logger = deps.logger ?? createLogger({ tool: 'run_pipeline' });
+  const secureHandler = createSecureHandler((args: unknown) => runPipelineHandler(args, logger), {
+    toolName: 'run_pipeline',
+    rateLimiter: deps.rateLimiter,
+    logger,
+  });
+  const timeoutMs = getToolTimeout('run_pipeline', deps.security);
+  const wrapped = wrapToolWithTimeout('run_pipeline', secureHandler, { timeoutMs, logger });
+
   server.registerTool(
     'run_pipeline',
     {
@@ -176,43 +235,7 @@ export function registerPipelineTool(
       inputSchema: PipelineInputSchema.shape,
       annotations: getToolAnnotations('run_pipeline'),
     },
-    async (args) => {
-      const input = PipelineInputSchema.parse(args);
-      if (input.simulateVotes) {
-        warnIfSimulatedOutsideTests('run_pipeline', createLogger({ tool: 'run_pipeline' }));
-      }
-
-      try {
-        const task = await resolveTask(input.task, input.specFile);
-        const agentStages = createAgentStages({
-          simulateVotes: input.simulateVotes,
-          votingStrategy: input.votingStrategy,
-          quickMode: input.quickMode,
-        });
-        const stages = selectStageRegistry(input.template, task, agentStages);
-
-        const result = await runAdaptiveOrchestrator(task, {
-          stages,
-          templateId: input.template,
-          dryRun: input.dryRun,
-        });
-
-        const structured = buildOutput(result);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(structured, null, 2) }],
-          structuredContent: structured,
-        };
-      } catch (error: unknown) {
-        // Spread into a fresh literal — this callback is registered
-        // directly (no toSdkCallback adapter), so the SDK return type
-        // needs an index signature that the named ToolResult type lacks.
-        return {
-          ...toolStructuredError({
-            errorCategory: 'internal',
-            message: `Pipeline error: ${getErrorMessage(error)}`,
-          }),
-        };
-      }
-    }
+    toSdkCallback(wrapped)
   );
+  logger.info('Registered run_pipeline tool');
 }


### PR DESCRIPTION
## Summary

#2824 audit P1. `run_pipeline` and `run_dev_pipeline` registered **bare** `server.registerTool()` callbacks, bypassing the `createSecureHandler → wrapToolWithTimeout → toSdkCallback` chain that the other ~36 MCP tools use.

Consequences:
- No rate-limiting, no abort-signal or progress-token plumbing — and these long-running multi-stage pipelines are exactly the tools that need cancellation and progress.
- `schema.parse(args)` ran **outside** the try/catch, so a `ZodError` on bad input escaped as a raw JSON-RPC `-32603` internal error instead of a structured `validation` envelope.

## Fix

- Both tools now route through the standard chain. Input is validated with `safeParse` inside the handler; a bad payload returns `toolStructuredError({ errorCategory: 'validation' })`.
- Handler bodies extracted to module-level functions (`runPipelineHandler` / `runDevPipelineHandler`) to keep the register functions under the 50-line lint cap.
- `run_pipeline` and `run_dev_pipeline` added to `MCP_TIMEOUTS.perTool` at `900_000` (15 min). **Required** — without it the newly-applied `wrapToolWithTimeout` would impose the 60s default and kill these multi-stage pipelines mid-run. 900_000 matches `orchestrate` / `run_workflow`, the comparable multi-step tools.

## Test plan

- [x] New `pipeline-tool.test.ts` — schema validation + registration + the invalid-input → `validation` envelope regression
- [x] `dev-pipeline-tool.test.ts` gains the same registration coverage
- [x] 73 tool tests + 99 server-registration tests (`cli-server-tools`, `mcp/tools/index`, `config/timeouts`) pass
- [x] `eslint` 0, `tsc --noEmit` 0

Part of #2824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)