### PR TITLE
fix(sprint): create sprint epics via gh --body-file - stdin (closes #2913)

### DIFF
--- a/.changeset/2913-sprint-command-stdin.md
+++ b/.changeset/2913-sprint-command-stdin.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(sprint):** create sprint epics via `gh ... --body-file -` stdin. Closes #2913 (#2824 audit bullet 10, sprint half).
+
+`createSprintIssue` embedded the markdown proposal body in the command string as `gh issue create --body '<body>'`. The body has a markdown table (`|`) and `(effort)` parentheticals, so the sandbox `validateArgs` gate denied the argument and `safeExecSandboxed` returned `null` — every sprint epic silently failed to create. The title was also affected: `generateSprintTitle` produced `sprint: MM/DD/YYYY (duration)`, and the `(duration)` parentheses tripped the gate on the inline `--title` argument.
+
+The body is now piped to `gh` over stdin (`--body-file -`), so it never touches the shell. `generateSprintTitle` uses `sprint: MM/DD/YYYY - duration` (dash, no parentheses) so the title stays a metacharacter-free inline `--title` argument. This completes audit bullet 10 — the `vote-command` half shipped in #2863.

--- a/packages/nexus-agents/src/cli/sprint-command.test.ts
+++ b/packages/nexus-agents/src/cli/sprint-command.test.ts
@@ -3,7 +3,13 @@
  * (Source: Issue #230, Epic #225)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./sandbox-exec.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./sandbox-exec.js')>()),
+  safeExecSandboxed: vi.fn(),
+}));
+
 import {
   extractPriority,
   extractIssueType,
@@ -15,8 +21,15 @@ import {
   generateGoals,
   generateProposal,
   generateProposalBody,
+  createSprintIssue,
 } from './sprint-command.js';
-import type { SprintIssue, GitHubIssueRaw, SprintCommandOptions } from './sprint-types.js';
+import { safeExecSandboxed } from './sandbox-exec.js';
+import type {
+  SprintIssue,
+  GitHubIssueRaw,
+  SprintCommandOptions,
+  SprintProposal,
+} from './sprint-types.js';
 
 // ============================================================================
 // Test Fixtures
@@ -211,12 +224,19 @@ describe('sprint-command', () => {
     it('should generate title with duration', () => {
       const title = generateSprintTitle('1 week');
       expect(title).toContain('sprint:');
-      expect(title).toContain('(1 week)');
+      expect(title).toContain('- 1 week');
     });
 
     it('should include date in MM/DD/YYYY format', () => {
       const title = generateSprintTitle('2 weeks');
       expect(title).toMatch(/sprint: \d{2}\/\d{2}\/\d{4}/);
+    });
+
+    it('contains no shell metacharacters — it is passed to gh --title (#2913)', () => {
+      // The title is an inline `gh issue create --title` argument; the sandbox
+      // gate rejects `( ) ; & |` etc. Parentheses around the duration used to
+      // make every sprint-issue creation fail.
+      expect(generateSprintTitle('1 week')).not.toMatch(/[;&|`$()<>]/);
     });
   });
 
@@ -334,7 +354,7 @@ describe('sprint-command', () => {
 
       const proposal = generateProposal(issues, { ...defaultOptions, duration: '2 weeks' });
 
-      expect(proposal.title).toContain('(2 weeks)');
+      expect(proposal.title).toContain('- 2 weeks');
     });
 
     it('should handle empty issues list', () => {
@@ -344,5 +364,51 @@ describe('sprint-command', () => {
       expect(proposal.p2Issues).toHaveLength(0);
       expect(proposal.goals).toContain('Complete prioritized backlog items');
     });
+  });
+});
+
+// #2913 (audit #2824 bullet 10): createSprintIssue embedded the markdown
+// proposal body in the command string as `--body '<body>'`. The body has a
+// markdown table (`|`) and `(effort)` parentheticals, so the sandbox
+// `validateArgs` gate denied it and every sprint epic silently failed to
+// create. The body is now piped via stdin.
+describe('createSprintIssue', () => {
+  const mockExec = vi.mocked(safeExecSandboxed);
+
+  function makeProposal(): SprintProposal {
+    return {
+      title: generateSprintTitle('1 week'),
+      goals: ['Ship the thing'],
+      p1Issues: [],
+      p2Issues: [],
+      p3Issues: [],
+      p4Issues: [],
+      body: '## Goals\n\n| Item | Priority |\n| ---- | -------- |\n- [ ] #1 - thing (small)',
+    };
+  }
+
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  it('pipes the body via --body-file - stdin, not an inline --body arg', () => {
+    mockExec.mockReturnValue('https://github.com/o/r/issues/42');
+
+    const num = createSprintIssue(makeProposal());
+
+    expect(num).toBe(42);
+    const call = mockExec.mock.calls[0];
+    expect(call?.[0]).toContain('--body-file -');
+    expect(call?.[0]).not.toContain("--body '");
+    expect((call?.[1] as { stdin?: string } | undefined)?.stdin).toContain('| Item | Priority |');
+  });
+
+  it('keeps shell metacharacters out of the command string', () => {
+    mockExec.mockReturnValue('https://github.com/o/r/issues/7');
+
+    createSprintIssue(makeProposal());
+
+    // Title + flags only — the body (with `|`, `(`, `)`) lives in stdin.
+    expect(mockExec.mock.calls[0]?.[0]).not.toMatch(/[|()]/);
   });
 });

--- a/packages/nexus-agents/src/cli/sprint-command.ts
+++ b/packages/nexus-agents/src/cli/sprint-command.ts
@@ -54,7 +54,10 @@ export function generateSprintTitle(duration: string): string {
     month: '2-digit',
     day: '2-digit',
   });
-  return `sprint: ${dateStr} (${duration})`;
+  // Dash, not parentheses, around the duration: this title is passed to
+  // `gh issue create --title` and the sandbox `validateArgs` gate rejects
+  // any argument containing `( )` (#2913 — audit #2824 bullet 10).
+  return `sprint: ${dateStr} - ${duration}`;
 }
 
 /**
@@ -182,15 +185,22 @@ export function generateProposal(
 
 /**
  * Create sprint issue on GitHub.
+ *
+ * The proposal body is piped to `gh` via stdin (`--body-file -`) rather than
+ * embedded in the command string (#2913 — audit #2824 bullet 10). The body is
+ * markdown — tables (`|`) and `(effort)` parentheticals — and the sandbox
+ * `validateArgs` gate rejects any argument containing shell metacharacters, so
+ * the previous `--body '<body>'` form made every sprint-issue creation fail
+ * silently. The title is metacharacter-free by construction (see
+ * `generateSprintTitle`), so it stays an inline `--title` argument.
  */
 export function createSprintIssue(proposal: SprintProposal): number | null {
   try {
     const escapedTitle = proposal.title.replace(/'/g, "'\\''");
-    const escapedBody = proposal.body.replace(/'/g, "'\\''");
 
     const output = safeExecSandboxed(
-      `gh issue create --title '${escapedTitle}' --body '${escapedBody}' --label 'epic'`,
-      { context: 'gh' }
+      `gh issue create --title '${escapedTitle}' --body-file - --label epic`,
+      { context: 'gh', stdin: proposal.body }
     );
 
     if (output === null) {


### PR DESCRIPTION
## Summary

#2824 audit bullet 10, **sprint half** — the `vote-command` half shipped in #2863.

`createSprintIssue` built `gh issue create --title '...' --body '<body>' --label epic` with the markdown proposal body embedded in the command string. `safeExecSandboxed` tokenizes the string and runs `validateArgs`, which denies any token matching `/[;&|\`$()]/`. The body from `generateProposalBody` contains a markdown table (`|`) and `(effort)` parentheticals — so the body token **always** matched. `safeExecSandboxed` returned `null` and every sprint epic silently failed to create.

The title was affected too: `generateSprintTitle` produced `sprint: MM/DD/YYYY (duration)`, and the `(duration)` parens tripped the gate on the inline `--title` argument.

## Fix

- Body piped to `gh` over stdin via `--body-file -` — never touches the shell, no escaping, no injection surface.
- `generateSprintTitle` uses `sprint: MM/DD/YYYY - duration` (dash, no parens) so the title stays a metacharacter-free `--title` argument. `gh` has no `--title-file`, so the title must remain inline.

## Test plan

- [x] `createSprintIssue` regression — pipes via `--body-file -` + `stdin`; no shell metacharacters in the command string
- [x] `generateSprintTitle` metacharacter-free assertion; two downstream title-format assertions updated
- [x] 50 sprint-command tests pass; `eslint` 0, `tsc --noEmit` 0

Closes #2913. Completes #2824 bullet 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)