### PR TITLE
refactor(consensus): extract evaluateThreshold helper (#2824 P2)

### DIFF
--- a/.changeset/2824-strategies-threshold-dedup.md
+++ b/.changeset/2824-strategies-threshold-dedup.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**refactor(consensus):** extract `evaluateThreshold` — dedup voting-strategy threshold math. Part of #2824 (audit P2).
+
+`SimpleMajorityStrategy`, `SupermajorityStrategy` and `ProofOfLearningStrategy` each repeated the same approval-ratio math: `approvalPercentage = (approve / total) * 100` and `approved = approve / total {>|>=} threshold`. The three copies are now a single `evaluateThreshold(approveCount, votingTotal, threshold, inclusive)` helper. `inclusive` selects `>=` (supermajority) vs strict `>` (simple-majority, proof-of-learning). Behavior is unchanged — the 34 existing strategy tests pass.

--- a/packages/nexus-agents/src/consensus/strategies.ts
+++ b/packages/nexus-agents/src/consensus/strategies.ts
@@ -35,6 +35,28 @@ export interface VotingOutcome {
 }
 
 /**
+ * Evaluates an approval ratio against a threshold — the shared math behind
+ * the simple-majority, supermajority and proof-of-learning strategies.
+ *
+ * `inclusive` selects the comparison: `>=` for supermajority (67% passes at
+ * exactly 67%), strict `>` for simple-majority and proof-of-learning (a tie
+ * at the threshold is not enough). Callers apply their own zero-denominator
+ * guard before calling this.
+ */
+function evaluateThreshold(
+  approveCount: number,
+  votingTotal: number,
+  threshold: number,
+  inclusive: boolean
+): { approved: boolean; approvalPercentage: number } {
+  const ratio = approveCount / votingTotal;
+  return {
+    approved: inclusive ? ratio >= threshold : ratio > threshold,
+    approvalPercentage: ratio * 100,
+  };
+}
+
+/**
  * Base voting strategy with common functionality.
  */
 abstract class BaseVotingStrategy implements IVotingStrategy {
@@ -120,8 +142,12 @@ export class SimpleMajorityStrategy extends BaseVotingStrategy {
       };
     }
 
-    const approvalPercentage = (counts.approve / votingVotes) * 100;
-    const approved = counts.approve / votingVotes > threshold;
+    const { approved, approvalPercentage } = evaluateThreshold(
+      counts.approve,
+      votingVotes,
+      threshold,
+      false
+    );
 
     return {
       approved,
@@ -154,8 +180,12 @@ export class SupermajorityStrategy extends BaseVotingStrategy {
       };
     }
 
-    const approvalPercentage = (counts.approve / votingVotes) * 100;
-    const approved = counts.approve / votingVotes >= threshold;
+    const { approved, approvalPercentage } = evaluateThreshold(
+      counts.approve,
+      votingVotes,
+      threshold,
+      true
+    );
 
     return {
       approved,
@@ -242,8 +272,12 @@ export class ProofOfLearningStrategy extends BaseVotingStrategy {
       };
     }
 
-    const approvalPercentage = (weightedCounts.approve / votingWeight) * 100;
-    const approved = weightedCounts.approve / votingWeight > threshold;
+    const { approved, approvalPercentage } = evaluateThreshold(
+      weightedCounts.approve,
+      votingWeight,
+      threshold,
+      false
+    );
 
     return {
       approved,


### PR DESCRIPTION
## Summary

#2824 audit P2. `SimpleMajorityStrategy`, `SupermajorityStrategy` and `ProofOfLearningStrategy` each repeated the same approval-ratio math:

```
approvalPercentage = (approve / total) * 100
approved = approve / total {> | >=} threshold
```

Three occurrences — the DRY extraction threshold is met.

## Change

Extracted to a single module-level `evaluateThreshold(approveCount, votingTotal, threshold, inclusive)` helper. `inclusive` selects `>=` (supermajority — 67% passes at exactly 67%) vs strict `>` (simple-majority and proof-of-learning — a tie at the threshold fails). Callers keep their own zero-denominator guards and reason strings, which genuinely differ.

## Test plan

- [x] Behavior-preserving — the 34 existing `strategies.test.ts` tests pass unchanged
- [x] `eslint` 0, `tsc --noEmit` 0

Part of #2824 (P2 refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)