### PR TITLE
docs(orchestration): clarify WorkflowRouter outcome-recording scope (#2824 P2)

### DIFF
--- a/.changeset/2824-workflow-router-outcome-scope.md
+++ b/.changeset/2824-workflow-router-outcome-scope.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**docs(orchestration):** clarify `WorkflowRouter` outcome-recording scope. Part of #2824 (audit P2).
+
+Audit #2824 flagged `workflow-router.ts` `PatternOutcome` history as per-instance, suggesting it be wired through `OutcomeStore` for cross-process learning. Verified: `route()` is a deterministic rule-based classifier that never reads recorded outcomes — there is no per-instance learning to lose and nothing to aggregate across processes. `recordOutcome` / `getMetrics` are an observability surface only. Added doc comments on `createWorkflowRouter` and `IWorkflowRouter` stating this explicitly, so a future maintainer who wants cross-process pattern metrics knows to add a dedicated `OutcomeStore` consumer rather than widening the router. Closes the audit bullet via its sanctioned "document explicitly" option — no behavior change.

--- a/packages/nexus-agents/src/orchestration/workflow-router.ts
+++ b/packages/nexus-agents/src/orchestration/workflow-router.ts
@@ -50,6 +50,15 @@ type RoutingRule = (signals: TaskSignals, analysis: TaskAnalysisResult) => RuleR
  *
  * Analyzes task characteristics and selects the optimal orchestration
  * pattern using a rule-based classification system.
+ *
+ * Scope of `recordOutcome` / `getMetrics` (#2824): the recorded
+ * `PatternOutcome`s live in a buffer owned by this router instance.
+ * `route()` is a deterministic, rule-based classifier — it does NOT
+ * consume recorded outcomes, so there is no per-instance learning to
+ * "lose", and nothing to aggregate across processes. The pair is an
+ * observability surface only. If cross-process pattern metrics are
+ * ever needed, add a dedicated consumer that writes to a shared
+ * `OutcomeStore` rather than widening this router's responsibility.
  */
 export function createWorkflowRouter(options?: {
   readonly logger?: ILogger | undefined;
@@ -76,9 +85,12 @@ export function createWorkflowRouter(options?: {
 export interface IWorkflowRouter {
   /** Routes a task to the optimal workflow pattern. */
   route(signals: TaskSignals, options?: WorkflowRouterOptions): RoutingDecision;
-  /** Records an execution outcome for performance tracking. */
+  /**
+   * Records an execution outcome into this router instance's buffer.
+   * Observability only — `route()` never reads it back (#2824).
+   */
   recordOutcome(outcome: PatternOutcome): void;
-  /** Gets aggregated metrics, optionally filtered by pattern. */
+  /** Aggregates this instance's recorded outcomes, optionally filtered by pattern. */
   getMetrics(pattern?: WorkflowPattern): readonly PatternMetrics[];
 }
 


### PR DESCRIPTION
## Summary

#2824 audit P2. The audit flagged `workflow-router.ts` `PatternOutcome` history as per-instance and suggested wiring it through `OutcomeStore` for cross-process learning.

**Verified the actual behavior:** `route()` is a deterministic, rule-based classifier (`ROUTING_RULES`, first-match-wins) — it never reads recorded outcomes. `recordOutcome`/`getMetrics` operate on a buffer owned by the router instance, `getMetrics` has zero production consumers, and `createWorkflowRouter` is instantiated per `orchestrate` call. So there is no per-instance learning to "lose" and nothing to aggregate across processes — the pair is an observability surface, not a feedback loop.

## Change

Resolved via the audit's sanctioned **"document explicitly"** option: doc comments on `createWorkflowRouter` and `IWorkflowRouter` now state that `route()` does not consume outcomes, and that cross-process pattern metrics — if ever needed — belong in a dedicated `OutcomeStore` consumer rather than this router. **No behavior change** (comments only).

## Test plan

- [x] Docs-only — no behavior change, no test impact
- [x] `eslint` / `tsc` unaffected (comment-only edits)

Part of #2824 (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)