### PR TITLE
fix(pipeline): provenance() walks inputRefs transitively (closes #2867)

### DIFF
--- a/.changeset/2867-recursive-provenance.md
+++ b/.changeset/2867-recursive-provenance.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(pipeline):** `ArtifactStore.provenance()` walks `inputRefs` transitively. Closes #2867 (#2824 audit P2).
+
+`provenance()` previously returned only the queried artifact's direct entry — the `inputRefs` ancestors were never followed, so the "provenance chain" was one link long. It now does an iterative DFS over `inputRefs`, returning the artifact plus every transitively reachable ancestor. A `visited` set makes it safe against cycles and diamond/multi-parent DAGs (each artifact appears once); a FIFO-evicted ancestor truncates the chain rather than throwing.
+
+Also corrected two stale docs: the store does **FIFO** eviction (insertion order), not LRU — header comments said "LRU". And the class docstring now states this is a bounded in-memory working cache, not the durable audit substrate — for retained, tamper-evident history use the on-disk Merkle audit log via `verify_audit_chain`. This resolves the audit's FIFO-vs-"audit trail" concern: the cache is correctly bounded; the durable audit lives elsewhere.

--- a/packages/nexus-agents/src/pipeline/artifact-store.test.ts
+++ b/packages/nexus-agents/src/pipeline/artifact-store.test.ts
@@ -1,7 +1,7 @@
 /**
  * ArtifactStore tests (Issue #912, Phase 4-3)
  *
- * Tests put, get, query, provenance, bounds, and LRU eviction.
+ * Tests put, get, query, provenance, bounds, and FIFO eviction.
  */
 import { describe, it, expect } from 'vitest';
 
@@ -116,6 +116,57 @@ describe('ArtifactStore', () => {
     it('returns empty for missing artifact', () => {
       const store = new ArtifactStore();
       expect(store.provenance({ id: 'nope', type: 'code' })).toHaveLength(0);
+    });
+
+    it('walks inputRefs transitively (#2867)', () => {
+      const store = new ArtifactStore();
+      store.put(makeArtifact({ id: 'a', inputRefs: [] }));
+      store.put(makeArtifact({ id: 'b', inputRefs: [{ id: 'a', type: 'code' }] }));
+      store.put(makeArtifact({ id: 'c', inputRefs: [{ id: 'b', type: 'code' }] }));
+
+      const chain = store.provenance({ id: 'c', type: 'code' });
+      expect(chain.map((e) => e.artifactId)).toEqual(['c', 'b', 'a']);
+    });
+
+    it('terminates on a cycle without infinite-looping (#2867)', () => {
+      const store = new ArtifactStore();
+      store.put(makeArtifact({ id: 'a', inputRefs: [{ id: 'b', type: 'code' }] }));
+      store.put(makeArtifact({ id: 'b', inputRefs: [{ id: 'a', type: 'code' }] }));
+
+      const chain = store.provenance({ id: 'a', type: 'code' });
+      expect(chain).toHaveLength(2);
+    });
+
+    it('visits a multi-parent diamond DAG node once (#2867)', () => {
+      const store = new ArtifactStore();
+      store.put(makeArtifact({ id: 'a', inputRefs: [] }));
+      store.put(makeArtifact({ id: 'b', inputRefs: [{ id: 'a', type: 'code' }] }));
+      store.put(makeArtifact({ id: 'c', inputRefs: [{ id: 'a', type: 'code' }] }));
+      store.put(
+        makeArtifact({
+          id: 'd',
+          inputRefs: [
+            { id: 'b', type: 'code' },
+            { id: 'c', type: 'code' },
+          ],
+        })
+      );
+
+      const chain = store.provenance({ id: 'd', type: 'code' });
+      // a, b, c, d — `a` exactly once despite two paths to it.
+      expect(chain).toHaveLength(4);
+      expect(chain.filter((e) => e.artifactId === 'a')).toHaveLength(1);
+    });
+
+    it('truncates the chain at a FIFO-evicted ancestor (#2867)', () => {
+      const store = new ArtifactStore({ maxArtifacts: 2 });
+      store.put(makeArtifact({ id: 'a', inputRefs: [] }));
+      store.put(makeArtifact({ id: 'b', inputRefs: [{ id: 'a', type: 'code' }] }));
+      // Putting 'c' evicts 'a' (oldest).
+      store.put(makeArtifact({ id: 'c', inputRefs: [{ id: 'b', type: 'code' }] }));
+
+      const chain = store.provenance({ id: 'c', type: 'code' });
+      expect(chain.map((e) => e.artifactId)).toEqual(['c', 'b']);
     });
   });
 

--- a/packages/nexus-agents/src/pipeline/artifact-store.ts
+++ b/packages/nexus-agents/src/pipeline/artifact-store.ts
@@ -1,7 +1,7 @@
 /**
  * ArtifactStore — V2 Pipeline Artifact Storage (Issue #912, Phase 4-3)
  *
- * In-memory artifact store with bounded capacity and LRU eviction.
+ * In-memory artifact store with bounded capacity and FIFO eviction.
  * Tracks provenance chains for artifact traceability.
  *
  * @see docs/v2/08-observability-eventing.md
@@ -126,8 +126,15 @@ export interface ArtifactStoreOptions {
 /**
  * In-memory artifact store with bounded capacity.
  *
- * When the store exceeds maxArtifacts, the oldest artifacts
- * are evicted (FIFO). Content size is validated on put().
+ * When the store exceeds maxArtifacts, the oldest artifacts are evicted
+ * (FIFO — insertion order, never reordered on `get()`). Content size is
+ * validated on put().
+ *
+ * This is a bounded in-memory working cache, NOT the durable audit
+ * substrate (#2867): once `maxArtifacts` is reached, old artifacts and
+ * their provenance are dropped. For tamper-evident, retained audit
+ * history use the on-disk Merkle audit log via the `verify_audit_chain`
+ * MCP tool.
  */
 export class ArtifactStore implements IArtifactStore {
   private readonly artifacts = new Map<string, Artifact>();
@@ -175,17 +182,40 @@ export class ArtifactStore implements IArtifactStore {
     return refs;
   }
 
+  /**
+   * Returns the full provenance chain for an artifact — the artifact
+   * itself plus every ancestor transitively reachable via `inputRefs`
+   * (#2867). Iterative DFS; the `visited` set makes it safe against
+   * cycles and diamond/multi-parent DAGs (each artifact appears once).
+   *
+   * Entries are in reachability (start-node-first DFS) order, not
+   * topological order. An ancestor that has been FIFO-evicted from the
+   * store is silently skipped — the chain truncates there rather than
+   * throwing. A missing root returns `[]`.
+   */
   provenance(ref: ArtifactRef): readonly ProvenanceEntry[] {
-    const artifact = this.artifacts.get(ref.id);
-    if (artifact === undefined) return [];
-    return [
-      {
+    const entries: ProvenanceEntry[] = [];
+    const visited = new Set<string>();
+    const stack: string[] = [ref.id];
+
+    while (stack.length > 0) {
+      const id = stack.pop();
+      if (id === undefined || visited.has(id)) continue;
+      visited.add(id);
+
+      const artifact = this.artifacts.get(id);
+      if (artifact === undefined) continue; // FIFO-evicted ancestor — truncate
+
+      entries.push({
         artifactId: artifact.id,
         plugin: artifact.createdBy,
         timestamp: artifact.createdAt,
         inputArtifacts: artifact.inputRefs.map((r) => r.id),
-      },
-    ];
+      });
+      for (const r of artifact.inputRefs) stack.push(r.id);
+    }
+
+    return entries;
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

#2824 audit P2. `ArtifactStore.provenance()` returned only the queried artifact's **direct** entry — the `inputRefs` ancestors were never followed, so the "provenance chain" was always one link long, defeating the point of artifact traceability.

## Change

`provenance()` now does an **iterative DFS** over `inputRefs`, returning the artifact plus every transitively reachable ancestor:
- A `visited` set keeps it safe — cycles terminate, and diamond / multi-parent DAGs list each artifact exactly once.
- A FIFO-evicted ancestor truncates the chain (skipped, not thrown).
- Iterative, so a deep chain can't blow the stack; `visited` bounds the walk to the store size.

Also corrected two stale docs flagged by the same audit bullet:
- The store evicts **FIFO** (insertion order, never reordered on `get()`) — header comments mislabeled it "LRU".
- The class docstring now states this is a bounded in-memory working cache, **not** the durable audit substrate. Retained, tamper-evident history lives in the on-disk Merkle audit log (`verify_audit_chain`). That resolves the audit's FIFO-vs-"audit trail" concern.

`audit-trail.ts` needed no change — the issue text's `audit-trail.ts:191` pointer was wrong (that line is `enforceLimit()`; `AuditEvent` has no causal-link field).

## Test plan

- [x] 4 new `provenance()` regressions: transitive walk, cycle termination, diamond-DAG dedup, eviction truncation
- [x] 35 `artifact-store` tests pass; `eslint` 0, `tsc --noEmit` 0

Closes #2867. Part of #2824 (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)