### PR TITLE
fix(config): route sessions.db per-repo with one-time migration (closes #2902)

### DIFF
--- a/.changeset/2902-sessions-db-per-repo.md
+++ b/.changeset/2902-sessions-db-per-repo.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(config):** route `sessions.db` per-repo, with a one-time legacy migration. Closes #2902.
+
+The session database resolved via `nexusDataPath('sessions.db')`. Because the data-dir router (epic #2872) keys on the first path segment and `sessions.db` is not in `PER_REPO_SUBDIRS`, the DB landed cross-repo at `~/.nexus-agents/sessions.db` — while the session journals directory `sessions/` correctly routed per-repo. A session DB started in repo A was visible when working in repo B.
+
+Resolved per consensus vote on #2902 (approved 3/3): the session DB is per-repo episodic data and belongs in the `sessions/` bucket alongside the journals (vote #2876 categorized `sessions/` as per-repo). New canonical `sessionsDbPath()` in `config/nexus-data-dir.ts` resolves `nexusDataPath('sessions', 'sessions.db')`; both `getDefaultDbPath()` helpers delegate to it.
+
+On first resolution per process, a guarded one-time migration relocates any pre-existing legacy DB (and its SQLite sidecars) from the old cross-repo path to the new per-repo path — so existing session history is preserved, not silently orphaned (the gating condition all three voters flagged). The move is best-effort: cross-filesystem moves fall back to copy+unlink, and any failure leaves the legacy DB untouched for manual recovery. `NEXUS_DATA_DIR` / `NEXUS_REPO_PREFERRED` / `NEXUS_SESSIONS_DB` overrides are unaffected.

--- a/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.test.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.test.ts
@@ -7,9 +7,10 @@
  * (Source: Issue #417 - CLI hooks test coverage)
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { homedir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
 import {
   getDefaultDbPath,
   getNexusDataDir,
@@ -23,14 +24,19 @@ import {
 
 describe('handler-utils', () => {
   describe('getDefaultDbPath', () => {
-    it('should return path in home directory', () => {
-      // `sessions.db` is a top-level FILE — distinct from the per-repo
-      // `sessions/` directory. The epic #2872 router keys on the first
-      // path segment, and `sessions.db` is not in PER_REPO_SUBDIRS, so
-      // it resolves cross-repo (homedir). This is intentional, not a bug.
-      const result = getDefaultDbPath();
-
-      expect(result).toBe(join(homedir(), '.nexus-agents', 'sessions.db'));
+    it('resolves under the per-repo sessions/ bucket (#2902)', () => {
+      // #2902: the session DB co-locates with the session journals in the
+      // per-repo `sessions/` bucket — `sessions/sessions.db`, not a
+      // top-level sibling. NEXUS_DATA_DIR isolates the resolver (and its
+      // one-time legacy migration) to an empty temp dir for this test.
+      const tmp = mkdtempSync(join(tmpdir(), 'nexus-dbpath-'));
+      vi.stubEnv('NEXUS_DATA_DIR', tmp);
+      try {
+        expect(getDefaultDbPath()).toBe(join(tmp, 'sessions', 'sessions.db'));
+      } finally {
+        vi.unstubAllEnvs();
+        rmSync(tmp, { recursive: true, force: true });
+      }
     });
   });
 
@@ -101,13 +107,18 @@ describe('handler-utils', () => {
 
   describe('getDbPathFromEnv', () => {
     const originalEnv = process.env;
+    let tmp: string;
 
     beforeEach(() => {
-      process.env = { ...originalEnv };
+      // Isolate NEXUS_DATA_DIR so getDefaultDbPath()'s resolver + one-time
+      // legacy migration operate in an empty temp dir, not real ~/.nexus-agents.
+      tmp = mkdtempSync(join(tmpdir(), 'nexus-dbenv-'));
+      process.env = { ...originalEnv, NEXUS_DATA_DIR: tmp };
     });
 
     afterEach(() => {
       process.env = originalEnv;
+      rmSync(tmp, { recursive: true, force: true });
     });
 
     it('should return env value when set', () => {

--- a/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.ts
@@ -9,15 +9,17 @@
 
 import {
   getNexusDataDir as resolveNexusDataDir,
-  nexusDataPath,
+  sessionsDbPath,
 } from '../../../config/nexus-data-dir.js';
 
 /**
  * Default database path for session storage.
- * Resolves to `<NEXUS_DATA_DIR>/sessions.db` (#2302).
+ *
+ * Resolves to the per-repo `sessions/sessions.db` (#2902) and performs
+ * the one-time legacy-DB relocation — see `sessionsDbPath`.
  */
 export function getDefaultDbPath(): string {
-  return nexusDataPath('sessions.db');
+  return sessionsDbPath();
 }
 
 /**

--- a/packages/nexus-agents/src/cli/session-commands.ts
+++ b/packages/nexus-agents/src/cli/session-commands.ts
@@ -9,7 +9,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { nexusDataPath } from '../config/nexus-data-dir.js';
+import { sessionsDbPath } from '../config/nexus-data-dir.js';
 import type { Result } from '../core/result.js';
 import { ok, err } from '../core/result.js';
 import type { ILogger } from '../core/logger.js';
@@ -60,9 +60,9 @@ export interface SessionPruneOptions extends SessionCommandOptions {
 // Helpers
 // ============================================================================
 
-/** Get default database path. */
+/** Get default database path — per-repo `sessions/sessions.db` (#2902). */
 export function getDefaultDbPath(): string {
-  return nexusDataPath('sessions.db');
+  return sessionsDbPath();
 }
 
 function ensureDbDirectory(dbPath: string): void {

--- a/packages/nexus-agents/src/config/nexus-data-dir.test.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.test.ts
@@ -546,3 +546,98 @@ describe('nexusDataPathEnsure (issue #2890)', () => {
     }).not.toThrow();
   });
 });
+
+describe('sessionsDbPath (#2902)', () => {
+  let originalEnv: string | undefined;
+  let originalRepoPref: string | undefined;
+  let tmp: string;
+
+  beforeEach(async () => {
+    const { mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { _resetSessionsDbMigrationMemoForTests } = await import('./nexus-data-dir.js');
+    originalEnv = process.env['NEXUS_DATA_DIR'];
+    originalRepoPref = process.env['NEXUS_REPO_PREFERRED'];
+    tmp = mkdtempSync(join(tmpdir(), 'nexus-sessdb-'));
+    // NEXUS_DATA_DIR isolates resolution to the temp dir; resetting the
+    // per-process memo lets each test exercise the one-time migration.
+    process.env['NEXUS_DATA_DIR'] = tmp;
+    delete process.env['NEXUS_REPO_PREFERRED'];
+    _resetSessionsDbMigrationMemoForTests();
+  });
+
+  afterEach(async () => {
+    const { rmSync } = await import('node:fs');
+    if (originalEnv === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalEnv;
+    if (originalRepoPref === undefined) delete process.env['NEXUS_REPO_PREFERRED'];
+    else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPref;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('resolves the session DB inside the per-repo sessions/ bucket', async () => {
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    expect(sessionsDbPath()).toBe(join(tmp, 'sessions', 'sessions.db'));
+  });
+
+  it('relocates a legacy cross-repo sessions.db to the new path', async () => {
+    const { writeFileSync, existsSync, readFileSync } = await import('node:fs');
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    const legacy = join(tmp, 'sessions.db');
+    writeFileSync(legacy, 'legacy-db-bytes');
+
+    const resolved = sessionsDbPath();
+
+    expect(existsSync(legacy)).toBe(false); // moved, not copied
+    expect(existsSync(resolved)).toBe(true);
+    expect(readFileSync(resolved, 'utf8')).toBe('legacy-db-bytes');
+  });
+
+  it('does not overwrite an existing new-location DB', async () => {
+    const { writeFileSync, existsSync, readFileSync, mkdirSync } = await import('node:fs');
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    const legacy = join(tmp, 'sessions.db');
+    const target = join(tmp, 'sessions', 'sessions.db');
+    writeFileSync(legacy, 'legacy');
+    mkdirSync(join(tmp, 'sessions'), { recursive: true });
+    writeFileSync(target, 'current');
+
+    sessionsDbPath();
+
+    // Guard holds: new DB untouched, legacy left in place for manual recovery.
+    expect(readFileSync(target, 'utf8')).toBe('current');
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  it('is a no-op when no legacy DB exists', async () => {
+    const { existsSync } = await import('node:fs');
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    sessionsDbPath();
+    expect(existsSync(join(tmp, 'sessions', 'sessions.db'))).toBe(false);
+  });
+
+  it('moves SQLite sidecar files alongside the main DB', async () => {
+    const { writeFileSync, existsSync } = await import('node:fs');
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    writeFileSync(join(tmp, 'sessions.db'), 'db');
+    writeFileSync(join(tmp, 'sessions.db-wal'), 'wal');
+
+    sessionsDbPath();
+
+    expect(existsSync(join(tmp, 'sessions', 'sessions.db'))).toBe(true);
+    expect(existsSync(join(tmp, 'sessions', 'sessions.db-wal'))).toBe(true);
+    expect(existsSync(join(tmp, 'sessions.db-wal'))).toBe(false);
+  });
+
+  it('migrates at most once per process (memoized)', async () => {
+    const { writeFileSync, existsSync } = await import('node:fs');
+    const { sessionsDbPath } = await import('./nexus-data-dir.js');
+    sessionsDbPath(); // first call — memoizes, no legacy present
+
+    // A legacy DB appearing after the memo is set is not picked up.
+    writeFileSync(join(tmp, 'sessions.db'), 'late');
+    sessionsDbPath();
+    expect(existsSync(join(tmp, 'sessions.db'))).toBe(true); // not migrated
+    expect(existsSync(join(tmp, 'sessions', 'sessions.db'))).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/config/nexus-data-dir.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.ts
@@ -44,7 +44,15 @@
  * @module config/nexus-data-dir
  */
 
-import { accessSync, constants as fsConstants, existsSync, mkdirSync } from 'node:fs';
+import {
+  accessSync,
+  constants as fsConstants,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -286,4 +294,71 @@ export function nexusSharedPath(...segments: string[]): string {
  */
 export function getPerRepoSubdirs(): ReadonlySet<string> {
   return PER_REPO_SUBDIRS;
+}
+
+/** Per-process memo — the legacy session-DB relocation runs at most once. */
+let legacySessionsDbMigrated = false;
+
+/** Test helper — clears the session-DB migration "already did this" memo. */
+export function _resetSessionsDbMigrationMemoForTests(): void {
+  legacySessionsDbMigrated = false;
+}
+
+/** SQLite sidecar suffixes that must travel with the main DB file. */
+const SQLITE_SIDECAR_SUFFIXES = ['', '-wal', '-shm', '-journal'] as const;
+
+/**
+ * Resolves the session-database path, performing a one-time relocation
+ * of any pre-#2902 database on the first call per process.
+ *
+ * The session DB is per-repo episodic state and belongs in the
+ * `sessions/` bucket alongside the session journals — vote #2876
+ * categorized `sessions/` as per-repo, and issue #2902 (consensus
+ * 3/3) extended that to the DB. Before #2902 the DB resolved via
+ * `nexusDataPath('sessions.db')`; because `sessions.db` is not a
+ * per-repo first segment, that landed cross-repo at
+ * `~/.nexus-agents/sessions.db`, so a DB started in one repo leaked
+ * into every other repo.
+ *
+ * If a legacy DB exists at the old location and none exists at the
+ * new one, the legacy file (and any SQLite sidecars) is moved so
+ * existing session history is preserved rather than silently
+ * orphaned. The move is best-effort: a failure leaves the legacy DB
+ * untouched for manual recovery and the caller gets a fresh DB at the
+ * new path. `NEXUS_DATA_DIR` / `NEXUS_REPO_PREFERRED` / the
+ * `NEXUS_SESSIONS_DB` override all sit upstream of this resolver.
+ */
+export function sessionsDbPath(): string {
+  const target = nexusDataPath('sessions', 'sessions.db');
+  if (!legacySessionsDbMigrated) {
+    legacySessionsDbMigrated = true;
+    migrateLegacySessionsDb(target);
+  }
+  return target;
+}
+
+/** One-time relocation of a pre-#2902 session DB. Best-effort — see `sessionsDbPath`. */
+function migrateLegacySessionsDb(target: string): void {
+  const legacy = nexusDataPath('sessions.db'); // pre-#2902 resolution
+  if (legacy === target || !existsSync(legacy) || existsSync(target)) return;
+  try {
+    mkdirSync(dirname(target), { recursive: true });
+    for (const suffix of SQLITE_SIDECAR_SUFFIXES) {
+      const from = `${legacy}${suffix}`;
+      if (existsSync(from)) moveFile(from, `${target}${suffix}`);
+    }
+  } catch {
+    // Best-effort — a migration failure must never break session storage.
+  }
+}
+
+/** Moves a file, falling back to copy+unlink across a filesystem boundary. */
+function moveFile(from: string, to: string): void {
+  try {
+    renameSync(from, to);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    copyFileSync(from, to);
+    unlinkSync(from);
+  }
 }


### PR DESCRIPTION
## Summary

The session database resolved via `nexusDataPath('sessions.db')`. The epic #2872 data-dir router keys on the first path segment, and `sessions.db` is not in `PER_REPO_SUBDIRS` — so the DB landed **cross-repo** at `~/.nexus-agents/sessions.db`, while the session journals directory `sessions/` correctly routed **per-repo**. A session DB started in repo A was visible when working in repo B.

Resolved per the **consensus vote on #2902 (approved 3/3** — architect, security, scope_steward): the session DB is per-repo episodic data and belongs in the `sessions/` bucket alongside the journals (vote #2876 categorized `sessions/` as per-repo).

## Change

- New canonical `sessionsDbPath()` in `config/nexus-data-dir.ts` resolves `nexusDataPath('sessions', 'sessions.db')`. Both `getDefaultDbPath()` helpers (`handler-utils`, `session-commands`) now delegate to it — the duplicated resolver logic is gone.
- On first resolution per process, a **guarded one-time migration** relocates any pre-existing legacy DB (+ SQLite sidecars) from the old cross-repo path to the new per-repo path. This is the gating condition all three voters flagged — *a migration note is not a migration*; without the move, existing session history is silently orphaned.
- Best-effort: cross-filesystem moves fall back to copy+unlink (`EXDEV`); any failure leaves the legacy DB untouched for manual recovery. Memoized per process; never throws.
- `NEXUS_DATA_DIR` / `NEXUS_REPO_PREFERRED` / `NEXUS_SESSIONS_DB` overrides are unaffected. `nexus-agents migrate` needs no change — once `sessions.db` lives under `sessions/` it's covered by the existing per-repo `sessions/` relocation.

## Test plan

- [x] 6 new `sessionsDbPath`/migration regressions: per-repo resolution, legacy relocation, no-overwrite guard, no-op when absent, sidecar move, per-process memoization
- [x] `handler-utils.test.ts` `getDefaultDbPath`/`getDbPathFromEnv` tests updated to the new path + `NEXUS_DATA_DIR`-isolated so the migration never touches a real `~/.nexus-agents`
- [x] 213 tests pass across affected files (hook handlers, session-commands, nexus-data-dir); `eslint` 0, `tsc --noEmit` 0

Closes #2902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)