### PR TITLE
fix(security): match triage verdicts to findings by id (closes #2933)

### DIFF
--- a/.changeset/2933-security-gate-triage-index.md
+++ b/.changeset/2933-security-gate-triage-index.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(security):** match triage verdicts to findings by id, not array position. Closes #2933 (P1 security).
+
+`security-gate.ts`'s `getConfirmedBlockingFindings` filtered blocking findings using `verdicts[i]` — but `triageFindings` sorts findings by severity and may skip parse-failed verdicts, so position `i` in `verdicts` did not refer to the same finding as `blocking[i]`. A high-severity finding whose triage parse failed would be matched against a downstream verdict (often a low-severity finding's `confirmed: false`) and **silently dropped from the blocking set**.
+
+`triageFindings` now returns `TriagedFinding[]` (each entry is `{ finding, verdict }` — pairing intrinsic, not positional). `getConfirmedBlockingFindings` and `recordTriageLifecycle` look up by `finding.id`. The duplicate `TriagedFinding` type in `severity-consensus.ts` was consolidated into `finding-triage.ts` (its natural producer) and re-exported.
+
+Regression test exercises the exact bug: three findings (2 high + 1 low), the second high's triage response fails to parse — pre-fix the gate returned 1 confirmed blocking; post-fix it correctly returns 2 (the unverdicted high is kept under the existing fail-safe).

--- a/packages/nexus-agents/src/pipeline/security-gate.test.ts
+++ b/packages/nexus-agents/src/pipeline/security-gate.test.ts
@@ -82,4 +82,86 @@ describe('checkSecurityScan', () => {
     const result = await check();
     expect(result.verdict).toBe('skip');
   });
+
+  // #2933 regression: triageFindings sorts by severity and may skip
+  // parse-failed verdicts, so the returned list does not align positionally
+  // with `findings.filter(BLOCKING)`. Pre-fix, getConfirmedBlockingFindings
+  // indexed verdicts as `verdicts[i]` against blocking — a high-severity
+  // finding whose triage parse failed would match against a downstream
+  // verdict (often a low's `confirmed: false`) and be silently dropped.
+  it('keeps a high-severity finding when its triage verdict fails to parse (#2933)', async () => {
+    mockScan.mockResolvedValue({
+      scanner: 'semgrep',
+      totalFindings: 3,
+      // Order matters — `blocking` iterates in original order, so blocking[0]
+      // is high_a and blocking[1] is high_b. Pre-fix, high_b would be matched
+      // against verdicts[1] = the low's confirmed:false → silently dropped.
+      findings: [
+        {
+          id: 'high_a',
+          scanner: 'semgrep',
+          rule: 'sqli',
+          severity: 'high',
+          message: 'SQLi A',
+          file: 'a.ts',
+          startLine: 1,
+          cweIds: ['CWE-89'],
+          confidence: 0.9,
+        },
+        {
+          id: 'high_b',
+          scanner: 'semgrep',
+          rule: 'sqli',
+          severity: 'high',
+          message: 'SQLi B',
+          file: 'b.ts',
+          startLine: 2,
+          cweIds: ['CWE-89'],
+          confidence: 0.9,
+        },
+        {
+          id: 'low_1',
+          scanner: 'semgrep',
+          rule: 'r1',
+          severity: 'low',
+          message: 'low',
+          file: 'c.ts',
+          startLine: 3,
+          cweIds: [],
+          confidence: 0.4,
+        },
+      ],
+      errors: [],
+    });
+
+    // triageFindings sorts ascending by severity → [high_a, high_b, low_1].
+    // We confirm high_a, fail-to-parse high_b, and reject low_1.
+    const triageFn = vi
+      .fn<(p: string) => Promise<string>>()
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          confirmed: true,
+          confidence: 0.9,
+          reasoning: 'tainted user input',
+          suggestedSeverity: 'high',
+        })
+      )
+      .mockResolvedValueOnce('NOT JSON — parse fails, triageFinding returns null')
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          confirmed: false,
+          confidence: 0.8,
+          reasoning: 'false positive',
+          suggestedSeverity: 'info',
+        })
+      );
+
+    const check = checkSecurityScan('/tmp/test', ['p/default'], { triageFn, enableOsv: false });
+    const result = await check();
+
+    // BOTH highs must survive — high_a because triage confirmed it, high_b
+    // because its verdict went missing (fail-safe). Pre-#2933 the count was 1.
+    expect(result.verdict).toBe('fail');
+    expect(result.details).toContain('2 confirmed blocking');
+  });
 });

--- a/packages/nexus-agents/src/pipeline/security-gate.ts
+++ b/packages/nexus-agents/src/pipeline/security-gate.ts
@@ -17,7 +17,7 @@ import {
 } from '../security/finding-lifecycle.js';
 import type { FindingLifecycleEntry } from '../security/finding-lifecycle.js';
 import { triageFindings } from '../security/finding-triage.js';
-import type { TriageVerdict } from '../security/finding-triage.js';
+import type { TriagedFinding } from '../security/finding-triage.js';
 import { queryOsvBatch } from '../security/osv-lookup.js';
 import type { OsvVulnerability } from '../security/osv-lookup.js';
 import type { SecurityFinding } from '../security/sarif-types.js';
@@ -29,8 +29,8 @@ const logger = createLogger({ component: 'security-gate' });
 let lastScanLifecycle: readonly FindingLifecycleEntry[] = [];
 /** Last OSV vulnerabilities found. */
 let lastOsvVulnerabilities: readonly OsvVulnerability[] = [];
-/** Last triage verdicts. */
-let lastTriageVerdicts: readonly TriageVerdict[] = [];
+/** Last triage verdicts (paired with their finding IDs — see #2933). */
+let lastTriageVerdicts: readonly TriagedFinding[] = [];
 
 /** Get lifecycle entries from the most recent security gate scan. */
 export function getLastScanLifecycle(): readonly FindingLifecycleEntry[] {
@@ -42,8 +42,8 @@ export function getLastOsvVulnerabilities(): readonly OsvVulnerability[] {
   return lastOsvVulnerabilities;
 }
 
-/** Get triage verdicts from the most recent scan. */
-export function getLastTriageVerdicts(): readonly TriageVerdict[] {
+/** Get triage verdicts from the most recent scan (each paired with its finding id, #2933). */
+export function getLastTriageVerdicts(): readonly TriagedFinding[] {
   return lastTriageVerdicts;
 }
 
@@ -132,7 +132,7 @@ async function runTriagePipeline(
     minConfidence: 0.5,
   });
   lastTriageVerdicts = triageResult.triaged;
-  recordTriageLifecycle(sarifResult.findings, triageResult.triaged, lifecycleEntries);
+  recordTriageLifecycle(triageResult.triaged, lifecycleEntries);
 
   // Step 3: OSV dependency check (#1773)
   const osvVulns = await runOsvCheck(targetDir, config.enableOsv ?? true);
@@ -168,18 +168,20 @@ async function runTriagePipeline(
 // Helpers
 // ============================================================================
 
-/** Record triage verdicts in lifecycle tracker (#1775). */
+/**
+ * Record triage verdicts in lifecycle tracker (#1775).
+ *
+ * Pre-#2933 this paired `findings[i]` with `verdicts[i]` positionally — wrong,
+ * because `triageFindings` sorts by severity and may skip parse-failed verdicts,
+ * so position-i in each array refers to different findings. Each TriagedFinding
+ * now carries its own finding object, so the pairing is intrinsic.
+ */
 function recordTriageLifecycle(
-  findings: readonly SecurityFinding[],
-  verdicts: readonly TriageVerdict[],
+  verdicts: readonly TriagedFinding[],
   entries: FindingLifecycleEntry[]
 ): void {
-  for (let i = 0; i < verdicts.length && i < findings.length; i++) {
-    const finding = findings[i];
-    const verdict = verdicts[i];
-    if (finding !== undefined && verdict !== undefined) {
-      recordTriaged(finding, verdict, (entry) => entries.push(entry));
-    }
+  for (const triaged of verdicts) {
+    recordTriaged(triaged.finding, triaged.verdict, (entry) => entries.push(entry));
   }
 }
 
@@ -209,17 +211,25 @@ async function runOsvCheck(targetDir: string, enabled: boolean): Promise<OsvVuln
   }
 }
 
-/** Filter to confirmed blocking findings (triage-aware) (#1770). */
+/**
+ * Filter to confirmed blocking findings (triage-aware) (#1770).
+ *
+ * Verdicts are matched to findings by **id**, not array position — see #2933.
+ * Pre-#2933 the filter used `verdicts[i]` where `i` indexed `blocking` in
+ * original order, but `verdicts` was in severity-sorted-then-truncated order,
+ * so a high-severity finding could get matched against a verdict for a
+ * different (often lower-severity) finding and be silently dropped.
+ */
 function getConfirmedBlockingFindings(
   findings: readonly SecurityFinding[],
-  verdicts: readonly TriageVerdict[]
+  verdicts: readonly TriagedFinding[]
 ): SecurityFinding[] {
   const blocking = findings.filter((f) => BLOCKING_SEVERITIES.has(f.severity));
   if (verdicts.length === 0) return [...blocking]; // No triage — all block (fail-safe)
 
-  // Only block on findings that triage confirmed
-  return blocking.filter((f, i) => {
-    const verdict = verdicts[i];
+  const verdictById = new Map(verdicts.map((t) => [t.finding.id, t.verdict]));
+  return blocking.filter((f) => {
+    const verdict = verdictById.get(f.id);
     return verdict === undefined || verdict.confirmed; // Unknown = confirmed (fail-safe)
   });
 }

--- a/packages/nexus-agents/src/security/finding-triage.ts
+++ b/packages/nexus-agents/src/security/finding-triage.ts
@@ -26,6 +26,21 @@ export const TriageVerdictSchema = z.object({
 
 export type TriageVerdict = z.infer<typeof TriageVerdictSchema>;
 
+/**
+ * A finding paired with its triage verdict.
+ *
+ * `triageFindings` sorts findings by severity and may skip ones whose LLM
+ * response failed to parse, so the returned list is in a different order —
+ * and possibly shorter — than the input findings. Consumers MUST treat each
+ * entry as a self-contained pair (or look up by `finding.id`); never index
+ * by array position against the original findings (issue #2933 — earlier
+ * positional indexing let high-severity findings silently bypass the gate).
+ */
+export interface TriagedFinding {
+  readonly finding: SecurityFinding;
+  readonly verdict: TriageVerdict;
+}
+
 /** Configuration for triage. */
 export interface TriageConfig {
   maxFindings: number;
@@ -171,17 +186,18 @@ export async function triageFindings(
   findings: SecurityFinding[],
   delegateFn: (prompt: string) => Promise<string>,
   config: TriageConfig = DEFAULT_CONFIG
-): Promise<{ original: SecurityFinding[]; triaged: TriageVerdict[] }> {
+): Promise<{ original: SecurityFinding[]; triaged: TriagedFinding[] }> {
   const sorted = [...findings].sort(
     (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
   );
   const toTriaged = sorted.slice(0, config.maxFindings);
 
-  const results: TriageVerdict[] = [];
+  const results: TriagedFinding[] = [];
   for (const finding of toTriaged) {
     const verdict = await triageFinding(finding, delegateFn, config);
     if (verdict !== null) {
-      results.push(verdict);
+      // Pair the verdict with its finding — see TriagedFinding doc (#2933).
+      results.push({ finding, verdict });
     }
   }
 

--- a/packages/nexus-agents/src/security/severity-consensus.ts
+++ b/packages/nexus-agents/src/security/severity-consensus.ts
@@ -9,7 +9,8 @@
 
 import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
-import type { TriageVerdict } from './finding-triage.js';
+import type { TriageVerdict, TriagedFinding } from './finding-triage.js';
+export type { TriagedFinding } from './finding-triage.js';
 
 // ============================================================================
 // Types
@@ -33,12 +34,6 @@ export interface SeverityConsensusConfig {
 export const DEFAULT_SEVERITY_CONSENSUS_CONFIG: SeverityConsensusConfig = {
   maxFindings: 5,
 };
-
-/** A finding paired with its triage verdict for consensus input. */
-export interface TriagedFinding {
-  readonly finding: SecurityFinding;
-  readonly verdict: TriageVerdict;
-}
 
 /** Function that runs consensus vote and returns approval + percentage. */
 export type ConsensusFn = (proposal: string) => Promise<{


### PR DESCRIPTION
## Summary

**P1 security.** `security-gate.ts`'s `getConfirmedBlockingFindings` filtered blocking findings using `verdicts[i]` indexed against `blocking` in original order — but `triageFindings` sorts findings by severity AND may skip parse-failed verdicts, so position `i` in `verdicts` does **not** refer to the same finding as `blocking[i]`. A high-severity finding whose triage parse failed would be matched against a downstream verdict (often a low's `confirmed: false`) and **silently dropped from the blocking set.**

## The bug, concrete

3 findings — `high_a`, `high_b`, `low_1`:
1. `triageFindings` sorts ascending → `[high_a, high_b, low_1]`.
2. Triage parses for `high_a` + `low_1`, **fails** for `high_b` → `results` has only 2 entries: `[{verdict for high_a, confirmed:true}, {verdict for low_1, confirmed:false}]`.
3. `blocking = [high_a, high_b]` (original order, severity filter).
4. Old positional filter:
   - `i=0`: `blocking[0]=high_a`, `verdicts[0]=high_a's confirmed:true` → KEPT ✓
   - `i=1`: `blocking[1]=high_b`, `verdicts[1]=LOW_1's confirmed:false` → **DROPPED ✗**
5. `high_b` silently bypasses the gate despite no real triage rejection.

## Fix

- `triageFindings` returns `TriagedFinding[]` where each entry is `{ finding, verdict }` — **pairing is intrinsic, not positional.**
- The duplicate `TriagedFinding` interface in `severity-consensus.ts` (same shape, downstream consumer) was consolidated into `finding-triage.ts` (its natural producer) and re-exported.
- `getConfirmedBlockingFindings` + `recordTriageLifecycle` look up via `Map<finding.id, verdict>`. Existing fail-safe semantics preserved — unknown `findingId` means "kept" (verdict treated as confirmed-by-default).

## Test plan

- [x] Regression test exercises the exact bug above (3 findings, `high_b`'s triage fails) — pre-fix `confirmed: 1`, post-fix `confirmed: 2`
- [x] 21 tests pass across `finding-triage`, `security-gate`, `severity-consensus`
- [x] `eslint` 0, `tsc --noEmit` 0

Closes #2933 (filed during the 2026-05-23 post-#2824 system review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)