### PR TITLE
docs: fix two contradicted defaults caught in the system review

### DIFF
--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -368,7 +368,7 @@ nexus-agents hooks stop --check-tasks
     "properties": {
       "task": { "type": "string", "description": "Task description" },
       "context": { "type": "object", "description": "Optional context" },
-      "maxIterations": { "type": "number", "default": 3 }
+      "maxIterations": { "type": "number", "default": 10 }
     },
     "required": ["task"]
   }

--- a/docs/architecture/ROUTING_SYSTEM.md
+++ b/docs/architecture/ROUTING_SYSTEM.md
@@ -44,12 +44,12 @@ interface ICompositeRouter {
 }
 
 interface CompositeRoutingDecision {
-  readonly cliName: 'claude' | 'gemini' | 'codex';
+  readonly cliName: 'claude' | 'gemini' | 'codex' | 'opencode';
   readonly reason: string;
   readonly confidence: number;
   readonly topsisScore?: number;
   readonly linucbExploration?: number;
-  readonly alternatives: readonly ('claude' | 'gemini' | 'codex')[];
+  readonly alternatives: readonly ('claude' | 'gemini' | 'codex' | 'opencode')[];
   readonly stagesExecuted: readonly string[];
 }
 ```
@@ -126,7 +126,7 @@ interface RoutingDecision {
   readonly decisionTimeMs: number;
 }
 
-type CliName = 'claude' | 'gemini' | 'codex';
+type CliName = 'claude' | 'gemini' | 'codex' | 'opencode';
 type CliTransport = 'mcp' | 'subprocess';
 ```
 


### PR DESCRIPTION
Pure docs — two contradictions surfaced by the 2026-05-23 second-pass system review.

| Doc | Old | Correct |
|---|---|---|
| `docs/ENTRYPOINTS.md:371` (orchestrate.maxIterations) | `default: 3` | `default: 10` (matches `OrchestrateInputSchema.maxIterations.default(10)`) |
| `docs/architecture/ROUTING_SYSTEM.md:47, 52` (CompositeRoutingDecision.cliName) | `'claude' \| 'gemini' \| 'codex'` | `'claude' \| 'gemini' \| 'codex' \| 'opencode'` |

A maintainer trusting either doc would write a budget at ~3× the real cap, or an exhaustive switch that silently drops opencode results.

Larger doc-drift finding from the review — the composite-router `@module` + 3 architecture docs claim 5 stages but the code runs ~12 — is tracked separately in #2947 (touches more files).

No behavior change. No tests, no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)