### PR TITLE
fix(research): mirror ResearchPaper rigor fields on PaperEntry (closes #2943)

### DIFF
--- a/.changeset/2943-paperentry-rigor-fields.md
+++ b/.changeset/2943-paperentry-rigor-fields.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(research):** `PaperEntry` now mirrors `ResearchPaper`'s rigor fields; drops the unsafe cast. Closes #2943.
+
+`research-helpers-registry.ts` cast each `PaperEntry` to `ResearchPaper` via `as unknown as ResearchPaper` before scoring — but `PaperEntry` was a strict subset, missing `rigor_tags`, `citation_count`, `has_code`, `code_url`, `quality_notes`, `last_quality_check`. `computeEvidenceTier`'s high-tier branch reads `rigor_tags`, so at runtime `new Set(undefined)` produced an empty set and the path was unreachable for anything flowing through that cast.
+
+`PaperEntry` now carries the rigor fields as optional. A typed `paperEntryToResearchPaper` helper replaces the cast, copying the readonly arrays to mutable ones (Zod-inferred shape). Behavior is unchanged for arXiv ingest (which still leaves rigor empty), but the high-evidence-tier path is now reachable when a maintainer populates `rigor_tags` on a paper — and the type system enforces it instead of silently stripping the field.

--- a/packages/nexus-agents/src/cli/research-helpers-registry.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-registry.test.ts
@@ -9,11 +9,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   generateRegistryEntry,
+  paperEntryToResearchPaper,
   paperExistsInRegistry,
   addPaperToRegistry,
   getCurrentDate,
   type AddPaperOptions,
 } from './research-helpers-registry.js';
+import { computeEvidenceTier } from '../research/research-quality.js';
 import type { ArxivMetadata, PapersRegistry, PaperEntry } from './research-types.js';
 import * as ioHelpers from './research-helpers-io.js';
 import { ParseError } from '../core/types/workflow.js';
@@ -490,5 +492,50 @@ describe('YAML format verification', () => {
         expect(result.value.publication_date).toBe(testCase.expected);
       }
     }
+  });
+});
+
+// #2943: PaperEntry pre-fix had no `rigor_tags` field, so the
+// `as unknown as ResearchPaper` cast hid that the field was missing on the
+// runtime value. `computeEvidenceTier`'s high-tier branch (which reads
+// `rigor_tags`) was unreachable for anything flowing through that cast. The
+// field is now part of PaperEntry and survives the typed conversion.
+describe('paperEntryToResearchPaper (#2943)', () => {
+  const baseEntry: PaperEntry = {
+    title: 'Test',
+    authors: ['A'],
+    source: 'arxiv',
+    arxiv_id: '2501.99999',
+    url: 'https://arxiv.org/abs/2501.99999',
+    publication_date: '2025-01',
+    venue: null,
+    topics: ['t'],
+    tags: ['x'],
+    reviewed_date: '2026-05-23',
+    reviewed_in: '',
+    summary: '',
+    key_findings: [],
+    relevance: 'medium',
+    techniques_extracted: [],
+    related_issues: [],
+    implementation_status: 'not-started',
+  };
+
+  it('preserves rigor_tags so the high-evidence tier becomes reachable', () => {
+    const entry: PaperEntry = {
+      ...baseEntry,
+      rigor_tags: ['peer-reviewed', 'has-code', 'has-baselines'],
+    };
+    const research = paperEntryToResearchPaper(entry);
+
+    expect(research.rigor_tags).toEqual(['peer-reviewed', 'has-code', 'has-baselines']);
+    expect(computeEvidenceTier(research)).toBe('high');
+  });
+
+  it('defaults rigor_tags to [] when the entry omits them (arXiv ingest case)', () => {
+    const research = paperEntryToResearchPaper(baseEntry);
+    expect(research.rigor_tags).toEqual([]);
+    // Without rigor signals AND with a low score, the tier correctly stays low.
+    expect(computeEvidenceTier({ ...research, quality_score: 1 })).toBe('low');
   });
 });

--- a/packages/nexus-agents/src/cli/research-helpers-registry.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-registry.ts
@@ -176,6 +176,46 @@ function createRegistryError(
 }
 
 /**
+ * Convert a `PaperEntry` into the Zod-derived `ResearchPaper` shape expected
+ * by the quality helpers (#2943). PaperEntry now mirrors all of ResearchPaper's
+ * rigor fields, so the conversion is a straightforward typed mapping — no
+ * `as unknown as` required. The readonly array fields are copied to mutable
+ * arrays because ResearchPaper's Zod inference yields mutable types.
+ */
+export function paperEntryToResearchPaper(entry: PaperEntry): ResearchPaper {
+  return {
+    title: entry.title,
+    authors: [...entry.authors],
+    source: entry.source,
+    arxiv_id: entry.arxiv_id,
+    url: entry.url,
+    publication_date: entry.publication_date,
+    venue: entry.venue,
+    topics: [...entry.topics],
+    tags: [...entry.tags],
+    reviewed_date: entry.reviewed_date,
+    reviewed_in: entry.reviewed_in,
+    summary: entry.summary,
+    key_findings: [...entry.key_findings],
+    relevance: entry.relevance,
+    techniques_extracted: [...entry.techniques_extracted],
+    related_issues: [...entry.related_issues],
+    implementation_status: entry.implementation_status,
+    rigor_tags: entry.rigor_tags ? [...entry.rigor_tags] : [],
+    ...(entry.venue_tier !== undefined ? { venue_tier: entry.venue_tier } : {}),
+    ...(entry.quality_score !== undefined ? { quality_score: entry.quality_score } : {}),
+    ...(entry.evidence_tier !== undefined ? { evidence_tier: entry.evidence_tier } : {}),
+    ...(entry.citation_count !== undefined ? { citation_count: entry.citation_count } : {}),
+    ...(entry.has_code !== undefined ? { has_code: entry.has_code } : {}),
+    ...(entry.code_url !== undefined ? { code_url: entry.code_url } : {}),
+    ...(entry.quality_notes !== undefined ? { quality_notes: entry.quality_notes } : {}),
+    ...(entry.last_quality_check !== undefined
+      ? { last_quality_check: entry.last_quality_check }
+      : {}),
+  };
+}
+
+/**
  * Generate a PaperEntry from arXiv metadata.
  *
  * @param metadata - The arXiv paper metadata
@@ -227,7 +267,12 @@ export function generateRegistryEntry(
   // At ingestion: venue=null, no citations, no code — but recency IS available.
   // computeQualityScore handles undefined fields gracefully.
   // Preprint cap (isPreprintOnly) applies automatically via computeQualityScore.
-  const paperForScoring = entry as unknown as ResearchPaper;
+  //
+  // #2943: PaperEntry now mirrors ResearchPaper's optional rigor fields, so
+  // a typed coercion replaces the prior `as unknown as ResearchPaper` cast.
+  // The conversion is read-only on `entry`; we make the array fields mutable
+  // copies because the Zod-derived ResearchPaper infers mutable arrays.
+  const paperForScoring = paperEntryToResearchPaper(entry);
   const qualityScore = computeQualityScore(paperForScoring);
   const evidenceTier = computeEvidenceTier({ ...paperForScoring, quality_score: qualityScore });
 

--- a/packages/nexus-agents/src/cli/research-types.ts
+++ b/packages/nexus-agents/src/cli/research-types.ts
@@ -62,10 +62,27 @@ export interface PaperEntry {
   readonly related_issues: readonly number[];
   readonly implementation_status: PaperImplementationStatus;
 
-  // Quality assessment (Issue #1571)
+  // Quality assessment (#1571 + #2943).
+  // #2943: extended so PaperEntry is a true subset of the Zod-derived
+  // ResearchPaper — the registry pipeline can then drop its unsafe
+  // `as unknown as ResearchPaper` cast. arXiv ingest leaves the rigor
+  // fields undefined; once someone populates them on a paper, the
+  // high-evidence tier branch in `computeEvidenceTier` becomes reachable.
   readonly venue_tier?: number;
   readonly quality_score?: number;
   readonly evidence_tier?: 'high' | 'medium' | 'low';
+  readonly citation_count?: number;
+  readonly has_code?: boolean;
+  readonly code_url?: string;
+  readonly rigor_tags?: readonly (
+    | 'has-code'
+    | 'has-dataset'
+    | 'has-baselines'
+    | 'peer-reviewed'
+    | 'single-model-eval'
+  )[];
+  readonly quality_notes?: string;
+  readonly last_quality_check?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

`research-helpers-registry.ts` cast `PaperEntry` to `ResearchPaper` via `as unknown as ResearchPaper` before scoring. The cast hid a real schema drift: `PaperEntry` was a **strict subset**, missing `rigor_tags`, `citation_count`, `has_code`, `code_url`, `quality_notes`, `last_quality_check`. `computeEvidenceTier`'s high-tier branch reads `rigor_tags` — at runtime `new Set(undefined)` was an empty `Set`, so the *"peer-reviewed + has-code + has-baselines → high"* path was unreachable for anything flowing through that cast.

For arXiv ingest, the rigor data isn't available anyway, so the observed behavior was *correct* — but **correct by accident, not by the type system**. A maintainer populating `rigor_tags` on a `PaperEntry` manually would have had it silently stripped because the field didn't exist on the type.

## Fix

- `PaperEntry` carries the 6 missing rigor fields as `optional readonly`. The interface is now a true subset of `ResearchPaper`.
- New `paperEntryToResearchPaper()` helper replaces the cast. Copies readonly arrays to mutable ones (Zod-inferred shape) and spreads the optional fields only when defined (respecting `exactOptionalPropertyTypes`).

Behavior is **unchanged for arXiv ingest**. The high-evidence-tier path is now reachable when `rigor_tags` is populated — and the type system enforces the field exists.

## Test plan

- [x] 2 new regression tests: `rigor_tags` populated → tier `high`; `rigor_tags` omitted → defaults to `[]` with the low-score-low-tier path correct
- [x] 27 research-registry tests pass; 89 across the affected files
- [x] `eslint` 0, `tsc --noEmit` 0

Closes #2943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)