### PR TITLE
fix(pipeline): fail closed on vote-execution error (closes #2951)

### DIFF
--- a/.changeset/2951-iterative-consensus-fail-closed.md
+++ b/.changeset/2951-iterative-consensus-fail-closed.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(pipeline):** `iterative-consensus` fails closed on vote-execution error. Closes #2951.
+
+`executeSingleVote` previously caught any exception from the consensus-vote tool (subprocess crash, JSON parse failure, network error, rate limit) and returned `{ kind: 'approved', approvalPercentage: 0 }` — **auto-approving on infrastructure failure inverts the gate's purpose.** The dev pipeline would log "vote approved, proceeding to implement" when zero votes were physically cast.
+
+Now returns `{ kind: 'rejected', feedback: 'Vote infrastructure failed — no consensus produced: <message>', approvalPercentage: 0 }`. `runIterativeConsensus` counts this against `maxIterations`, the operator sees the failure, and an unverified plan never proceeds because the vote couldn't run.

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
@@ -120,13 +120,21 @@ describe('runIterativeConsensus', () => {
     expect(call?.[0].proposal).toHaveLength(100);
   });
 
-  it('auto-approves on vote execution error', async () => {
+  it('fails closed when vote execution throws (#2951 — was auto-approve, inverted the gate)', async () => {
+    // Pre-#2951 this returned { kind: 'approved' } — auto-approving on
+    // infrastructure failure inverts the gate's purpose. A vote that
+    // physically didn't happen is NOT consensus to proceed; the rejected
+    // verdict carries the error message in feedback so the operator sees it.
     mockExecuteVoting.mockRejectedValueOnce(new Error('Timeout'));
 
-    const result = await runIterativeConsensus('Plan', vi.fn());
+    const result = await runIterativeConsensus('Plan', vi.fn(), { maxIterations: 1 });
 
-    expect(result.vote.kind).toBe('approved');
+    expect(result.vote.kind).toBe('rejected');
     expect(result.vote.approvalPercentage).toBe(0);
+    if (result.vote.kind === 'rejected') {
+      expect(result.vote.feedback).toContain('Vote infrastructure failed');
+      expect(result.vote.feedback).toContain('Timeout');
+    }
     expect(result.iterations).toBe(1);
   });
 

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.ts
@@ -187,9 +187,18 @@ async function executeSingleVote(
     const result = await executeVoting(input, log);
     return parseVotingResult(result);
   } catch (error) {
+    // Pre-#2951 this returned { kind: 'approved', approvalPercentage: 0 } —
+    // auto-approving on infrastructure failure inverts the gate's purpose.
+    // A vote that physically didn't happen is NOT consensus to proceed.
+    // Returning rejected lets runIterativeConsensus count this against
+    // maxIterations and surface the failure to the operator.
     const msg = error instanceof Error ? error.message : String(error);
-    log.warn('Vote execution failed, auto-approving', { error: msg });
-    return { kind: 'approved', approvalPercentage: 0 };
+    log.warn('Vote execution failed, treating as rejected', { error: msg });
+    return {
+      kind: 'rejected',
+      feedback: `Vote infrastructure failed — no consensus produced: ${msg}`,
+      approvalPercentage: 0,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

**P1 bug.** `executeSingleVote` in `iterative-consensus.ts` caught any exception from the consensus-vote tool and returned `{ kind: 'approved', approvalPercentage: 0 }` — **auto-approving on infrastructure failure inverts the gate's purpose.** The dev pipeline would log *"vote approved, proceeding to implement"* when zero votes were physically cast.

## Fix

Returns `{ kind: 'rejected', feedback: 'Vote infrastructure failed — no consensus produced: <message>', approvalPercentage: 0 }`. `runIterativeConsensus` counts this against `maxIterations`, the operator sees the failure surface in feedback, and an unverified plan is correctly held back.

## Test plan

- [x] Existing test was pinning the buggy auto-approve behavior — updated to assert the new fail-closed semantics + that the error message reaches the `feedback` field
- [x] 8 iterative-consensus tests pass; `eslint` 0, `tsc --noEmit` 0

Closes #2951 (filed during the 2026-05-23 third-pass system review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)