### PR TITLE
fix(mcp): register pr_review + supply_chain_tradeoff_panel tools (closes #2967)

### DIFF
--- a/.changeset/2967-register-advertised-mcp-tools.md
+++ b/.changeset/2967-register-advertised-mcp-tools.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+**fix(mcp):** register `pr_review` and `supply_chain_tradeoff_panel` MCP tools; sync `REGISTERED_TOOLS` allowlist with the actual STANDALONE_TOOLS table. Closes #2967.
+
+Two MCP tools were advertised in `server.json`, `README.md`, `docs/ENTRYPOINTS.md`, and shipped tool-annotations + tool-prerequisites — but never registered with the MCP server. Any client calling `tools/call { name: "pr_review", ... }` or `{ name: "supply_chain_tradeoff_panel", ... }` got `MethodNotFound`. The README v5 evaluation results for `pr_review` (100% bug-catch on 10 PRs) referred to a tool no MCP client could reach.
+
+Root cause: `mcp/tools/index.ts` `REGISTERED_TOOL_NAMES` (the source `inject-governance.ts` uses to write `server.json`) listed both tools, but the actual registration path in `cli-server-tools.ts` (`STANDALONE_TOOLS` table + `REGISTERED_TOOLS` audit allowlist) had drifted behind. The lockstep promised in the comment at `mcp/tools/index.ts:497-500` was only between `REGISTERED_TOOL_NAMES` and `server.json` — not between what was advertised and what was actually wired.
+
+Fix:
+
+- Added `registerPrReviewTool` + `registerSupplyChainTradeoffPanelTool` to the `STANDALONE_TOOLS` table in `cli-server-tools.ts`.
+- Re-exported `registerSupplyChainTradeoffPanelTool` from `mcp/index.ts` (the barrel `cli-server-tools.ts` imports from). `registerPrReviewTool` was already re-exported.
+- Synced `REGISTERED_TOOLS` allowlist (28 → 38 entries) with the actual set registered via `STANDALONE_TOOLS` + category helpers. Adds the 10 names that had drifted: `pr_review`, `supply_chain_tradeoff_panel`, `research_add_source`, `research_synthesize`, `query_task_state`, `verify_audit_chain`, `extract_symbols`, `search_codebase`, `run_dev_pipeline`, `run_pipeline`. This fixes the `logToolRegistration` audit log lying about which tools are blocked when an operator configures `securityConfig.toolAllowlist`.
+- Updated `cli-server-tools.test.ts` to mock the 2 new register functions and assert `REGISTERED_TOOLS.length === 38` against the new expected list.
+
+Behavior change: clients can now `tools/list` the 2 tools and call them. No effect on existing tools.

--- a/packages/nexus-agents/src/cli-server-tools.test.ts
+++ b/packages/nexus-agents/src/cli-server-tools.test.ts
@@ -46,6 +46,8 @@ const {
   mockRegisterMemoryWriteTool,
   mockRegisterWeatherReportTool,
   mockRegisterImprovementReviewTool,
+  mockRegisterPrReviewTool,
+  mockRegisterSupplyChainTradeoffPanelTool,
   mockRegisterRegistryImportTool,
   mockRegisterIssueTriageTool,
   mockRegisterRunGraphWorkflowTool,
@@ -98,6 +100,8 @@ const {
   mockRegisterMemoryWriteTool: vi.fn(),
   mockRegisterWeatherReportTool: vi.fn(),
   mockRegisterImprovementReviewTool: vi.fn(),
+  mockRegisterPrReviewTool: vi.fn(),
+  mockRegisterSupplyChainTradeoffPanelTool: vi.fn(),
   mockRegisterRegistryImportTool: vi.fn(),
   mockRegisterIssueTriageTool: vi.fn(),
   mockRegisterRunGraphWorkflowTool: vi.fn(),
@@ -164,6 +168,8 @@ vi.mock('./mcp/index.js', () => ({
   registerMemoryWriteTool: mockRegisterMemoryWriteTool,
   registerWeatherReportTool: mockRegisterWeatherReportTool,
   registerImprovementReviewTool: mockRegisterImprovementReviewTool,
+  registerPrReviewTool: mockRegisterPrReviewTool,
+  registerSupplyChainTradeoffPanelTool: mockRegisterSupplyChainTradeoffPanelTool,
   registerRegistryImportTool: mockRegisterRegistryImportTool,
   registerIssueTriageTool: mockRegisterIssueTriageTool,
   registerRunGraphWorkflowTool: mockRegisterRunGraphWorkflowTool,
@@ -336,8 +342,8 @@ function makeDefaultOptions(overrides: Record<string, unknown> = {}) {
 // ============================================================================
 
 describe('REGISTERED_TOOLS', () => {
-  it('should contain exactly 28 tool names', () => {
-    expect(REGISTERED_TOOLS).toHaveLength(28);
+  it('should contain exactly 38 tool names', () => {
+    expect(REGISTERED_TOOLS).toHaveLength(38);
   });
 
   it('should include all expected tool names', () => {
@@ -352,9 +358,11 @@ describe('REGISTERED_TOOLS', () => {
       'consensus_vote',
       'research_query',
       'research_add',
+      'research_add_source',
       'research_discover',
       'research_analyze',
       'research_catalog_review',
+      'research_synthesize',
       'survey_oss_landscape',
       'vendor_publishing_audit',
       'compare_data_feeds',
@@ -367,9 +375,17 @@ describe('REGISTERED_TOOLS', () => {
       'execute_spec',
       'registry_import',
       'query_trace',
+      'query_task_state',
+      'verify_audit_chain',
+      'extract_symbols',
+      'search_codebase',
+      'run_dev_pipeline',
+      'run_pipeline',
       'repo_analyze',
       'repo_security_plan',
       'improvement_review',
+      'pr_review',
+      'supply_chain_tradeoff_panel',
     ];
     expect([...REGISTERED_TOOLS]).toEqual(expected);
   });

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -36,6 +36,8 @@ import {
   registerMemoryWriteTool,
   registerWeatherReportTool,
   registerImprovementReviewTool,
+  registerPrReviewTool,
+  registerSupplyChainTradeoffPanelTool,
   registerRegistryImportTool,
   registerRepoAnalyzeTool,
   registerRepoSecurityPlanTool,
@@ -143,9 +145,11 @@ export const REGISTERED_TOOLS = [
   'consensus_vote',
   'research_query',
   'research_add',
+  'research_add_source',
   'research_discover',
   'research_analyze',
   'research_catalog_review',
+  'research_synthesize',
   'survey_oss_landscape',
   'vendor_publishing_audit',
   'compare_data_feeds',
@@ -158,9 +162,17 @@ export const REGISTERED_TOOLS = [
   'execute_spec',
   'registry_import',
   'query_trace',
+  'query_task_state',
+  'verify_audit_chain',
+  'extract_symbols',
+  'search_codebase',
+  'run_dev_pipeline',
+  'run_pipeline',
   'repo_analyze',
   'repo_security_plan',
   'improvement_review',
+  'pr_review',
+  'supply_chain_tradeoff_panel',
 ] as const;
 
 /**
@@ -592,6 +604,8 @@ const STANDALONE_TOOLS: ReadonlyArray<{
   { name: 'search_codebase', register: registerSearchCodebaseTool },
   { name: 'run_dev_pipeline', register: registerDevPipelineTool },
   { name: 'run_pipeline', register: registerPipelineTool },
+  { name: 'pr_review', register: registerPrReviewTool },
+  { name: 'supply_chain_tradeoff_panel', register: registerSupplyChainTradeoffPanelTool },
 ];
 
 /** Registers tool categories, skipping those blocked by allowlist. (Issue #740) */

--- a/packages/nexus-agents/src/mcp/index.ts
+++ b/packages/nexus-agents/src/mcp/index.ts
@@ -275,6 +275,9 @@ export {
   type ImprovementReviewResponse,
   type ImprovementSignal,
   type SignalCategory,
+  // Supply-chain tradeoff panel (#2294)
+  registerSupplyChainTradeoffPanelTool,
+  type SupplyChainTradeoffPanelDeps,
   // Registry import tool (Issue #889)
   registerRegistryImportTool,
   type RegistryImportDeps,

--- a/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
@@ -31,8 +31,8 @@ describe('tool-annotations', () => {
       }
     });
 
-    it('has exactly 28 tool entries', () => {
-      expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(28);
+    it('has exactly 38 tool entries', () => {
+      expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(38);
     });
 
     it('every entry has valid annotations shape', () => {

--- a/packages/nexus-agents/src/mcp/tools/tool-annotations.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-annotations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Cohesive central registry: per-tool annotation entries grow with REGISTERED_TOOLS (governance: 400-600 OK if cohesive). */
 /**
  * MCP Tool Annotations Registry
  *
@@ -406,6 +407,153 @@ export const TOOL_ANNOTATIONS: Readonly<Record<string, ToolSideEffectsEntry>> = 
         description: 'Fetches repository metadata from GitHub API via gh CLI',
       },
       { category: 'implicit', description: 'Consumes rate limit quota' },
+    ],
+  },
+  research_add_source: {
+    annotations: {
+      title: 'Research Add Source',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    sideEffects: [
+      { category: 'explicit', description: 'Adds a non-paper source to the research registry' },
+      { category: 'coupling', description: 'New entries affect research_discover/research_query' },
+    ],
+  },
+  research_synthesize: {
+    annotations: {
+      title: 'Research Synthesize',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    sideEffects: [{ category: 'implicit', description: 'Reads research catalog + alignment map' }],
+  },
+  query_task_state: {
+    annotations: {
+      title: 'Query Task State',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    sideEffects: [
+      { category: 'implicit', description: 'Reads the structured task-state log (#2278)' },
+    ],
+  },
+  verify_audit_chain: {
+    annotations: {
+      title: 'Verify Audit Chain',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    sideEffects: [
+      {
+        category: 'implicit',
+        description: 'Reads the immutable audit log and verifies the hash chain',
+      },
+    ],
+  },
+  extract_symbols: {
+    annotations: {
+      title: 'Extract Symbols',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    sideEffects: [{ category: 'implicit', description: 'Reads source files and walks their ASTs' }],
+  },
+  search_codebase: {
+    annotations: {
+      title: 'Search Codebase',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    sideEffects: [
+      {
+        category: 'implicit',
+        description: 'Reads source files and builds an in-memory symbol index',
+      },
+    ],
+  },
+  run_dev_pipeline: {
+    annotations: {
+      title: 'Run Dev Pipeline',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    sideEffects: [
+      {
+        category: 'explicit',
+        description: 'Executes the V2 dev pipeline (delegates to CLI adapters)',
+      },
+      {
+        category: 'implicit',
+        description: 'Consumes API tokens; persists outcomes and checkpoints',
+      },
+      {
+        category: 'coupling',
+        description: 'Writes routing/learning state consumed by future runs',
+      },
+    ],
+  },
+  run_pipeline: {
+    annotations: {
+      title: 'Run Pipeline',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    sideEffects: [
+      { category: 'explicit', description: 'Executes a generic V2 pipeline TaskContract' },
+      { category: 'implicit', description: 'Consumes API tokens; emits pipeline events' },
+      { category: 'coupling', description: 'Writes policy/audit state consumed by other tools' },
+    ],
+  },
+  pr_review: {
+    annotations: {
+      title: 'PR Review',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    sideEffects: [
+      {
+        category: 'explicit',
+        description: 'Runs multi-voter PR review with verification gate (#2233)',
+      },
+      { category: 'implicit', description: 'Consumes API tokens across voter CLIs' },
+      { category: 'coupling', description: 'Records voter outcomes for weather report' },
+    ],
+  },
+  supply_chain_tradeoff_panel: {
+    annotations: {
+      title: 'Supply-chain Tradeoff Panel',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    sideEffects: [
+      {
+        category: 'explicit',
+        description:
+          'Runs per-axis tradeoff vote (build_time_determinism / supply_chain_risk / update_cadence) (#2294)',
+      },
+      { category: 'implicit', description: 'Consumes API tokens across voter CLIs' },
+      { category: 'coupling', description: 'Records voter outcomes for weather report' },
     ],
   },
 };


### PR DESCRIPTION
## Summary

Two MCP tools were advertised in `server.json`, `README.md`, and `docs/ENTRYPOINTS.md` (with documented v5 evaluation results) but **never wired into the MCP server**. `tools/list` omitted them; `tools/call` returned `MethodNotFound`. This PR registers them and syncs the audit allowlist.

| Tool | Was | Now |
|---|---|---|
| `pr_review` | Advertised in 4 places, register fn shipped, never imported by registration path → `MethodNotFound` | Registered via `STANDALONE_TOOLS` |
| `supply_chain_tradeoff_panel` | Same — advertised but never wired | Registered via `STANDALONE_TOOLS` |
| `REGISTERED_TOOLS` allowlist | 28 entries while the registration path actually wired 36; `logToolRegistration` audit log lied about 8 tools when `securityConfig.toolAllowlist` was set | 38 entries (matches `REGISTERED_TOOL_NAMES` in `mcp/tools/index.ts:502`) |

## Root cause

`REGISTERED_TOOL_NAMES` in `mcp/tools/index.ts:502` (the source `inject-governance.ts` reads to write `server.json`) drifted ahead of the actual registration in `cli-server-tools.ts`. The lockstep contract documented in the comment at `mcp/tools/index.ts:497-500` was only between `REGISTERED_TOOL_NAMES` and `server.json` — not between what's advertised and what's actually wired.

## Test plan

- [x] `cli-server-tools.test.ts`: 32 tests pass (updated mocks for the 2 new register functions; expected array expanded from 28 to 38 names)
- [x] `pr-review-tool.test.ts`: 33 tests still pass
- [x] `supply-chain-tradeoff-panel.test.ts`: 34 tests still pass
- [x] `tsc --noEmit` and `eslint` clean
- [x] `scripts/inject-governance.ts --check` reports 38 MCP tools (matches `server.json`)

Closes #2967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)