### PR TITLE
fix: bundle 4 trivial fixes from epic #2982 (closes #2971 #2972 #2974 #2976)

### DIFF
--- a/.changeset/trivial-bundle-2971-2972-2974-2976.md
+++ b/.changeset/trivial-bundle-2971-2972-2974-2976.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** bundle 4 trivial single-file fixes from the 2026-05-23 system-review epic (#2982).
+
+Each fix follows a pattern already established elsewhere in the codebase — none introduces new concepts.
+
+- **Closes #2971** — `pipeline/agent-executor.ts:190`: `routingMemoryCache` lost-init race. Added `routingMemoryInitPromise` coalescing so concurrent `recordRoutingExperience` calls share one `createRoutingMemory()` instance. Mirrors the `memoryInitPromise ??=` pattern 70 lines above. Without this, N concurrent expert dispatches each built their own `RoutingMemory` and the loser's events landed in an orphaned instance that may leak handles or duplicate-write outcomes.
+- **Closes #2972** — `learning/strategy-distiller-persistence.ts:147`: `saveSnapshot` wrote to a non-PID-suffixed `.tmp` file. Two processes calling `distill()` against the same `rules.json` could race the rename and clobber each other's content. One-token change to match the convention in `consensus/correlation-persistence.ts:184` and `cli/research-auto-catalog.ts:99`.
+- **Closes #2974** — `cli-orchestrator.ts:64-77`: REPL hang on `orchestrateCommand` rejection. The `void (async () => { await ...; rl.prompt() })()` had no `.catch`, so any rejection became an unhandled promise and the prompt never returned. Extracted the body into `executeReplTask` with `try`/`catch`/`finally rl.prompt()` so the prompt always recovers and the user sees a useful error.
+- **Closes #2976** — `agents/collaboration/agent-message-router.ts:333`, `orchestration/parallel-exploration.ts:236`, `orchestration/triangulated-review.ts:232`: the three `Promise.race([cliCall(), createTimeout(...)])` helpers left un-`.unref()`'d `setTimeout` handles. When the CLI call resolved first, the timer kept the event loop alive for up to `perCliTimeoutMs` (commonly 300 s) — so `nexus-agents` CLI commands hung at the end of orchestration subcommands. `.unref()` on each `setTimeout` lets the process exit as soon as the user's work is done.
+
+91 tests pass across the 5 changed-file tests. No behavior change in the happy path; observable improvement on the cold-start race, multi-process write, REPL recovery, and CLI shutdown latency paths.

--- a/packages/nexus-agents/src/agents/collaboration/agent-message-router.ts
+++ b/packages/nexus-agents/src/agents/collaboration/agent-message-router.ts
@@ -330,9 +330,11 @@ export class AgentMessageRouter implements IAgentMessageRouter {
     targetId: string
   ): Promise<Result<AgentResponse, AgentError>> {
     return new Promise((resolve) => {
+      // .unref() so a winning fast-path doesn't keep the event loop alive waiting
+      // on this ghost timer. Closes #2976.
       setTimeout(() => {
         resolve(err(new AgentError(`Message delivery timeout to agent: ${targetId}`)));
-      }, timeout);
+      }, timeout).unref();
     });
   }
 

--- a/packages/nexus-agents/src/cli-orchestrator.ts
+++ b/packages/nexus-agents/src/cli-orchestrator.ts
@@ -34,6 +34,36 @@ export interface OrchestratorModeOptions {
  * Reads tasks from stdin and processes them one at a time.
  * (Source: Issue #446 - Implement orchestrator mode)
  */
+async function executeReplTask(
+  task: string,
+  options: OrchestratorModeOptions,
+  logger: ReturnType<typeof createLogger>,
+  rl: readline.Interface
+): Promise<void> {
+  // try/catch + finally re-prompt closes #2974: if orchestrateCommand rejects
+  // (adapter init failure, dispose throw, network error) the REPL must still
+  // recover. Without it the rejection became an unhandled promise and the
+  // prompt never returned — REPL hangs silently.
+  try {
+    await orchestrateCommand({
+      task,
+      verbose: options.verbose,
+      format: options.format,
+      model: options.model,
+      dryRun: options.dryRun,
+      maxTokens: options.maxTokens,
+      maxCostUsd: options.maxCostUsd,
+    });
+  } catch (error: unknown) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('REPL task failed', err);
+    process.stderr.write(`Error: ${err.message}\n`);
+  } finally {
+    process.stdout.write('\n');
+    rl.prompt();
+  }
+}
+
 function runOrchestratorRepl(
   options: OrchestratorModeOptions,
   logger: ReturnType<typeof createLogger>
@@ -59,22 +89,7 @@ function runOrchestratorRepl(
         rl.prompt();
         return;
       }
-
-      // Execute task asynchronously
-      void (async () => {
-        const orchestrateOptions: OrchestrateOptions = {
-          task,
-          verbose: options.verbose,
-          format: options.format,
-          model: options.model,
-          dryRun: options.dryRun,
-          maxTokens: options.maxTokens,
-          maxCostUsd: options.maxCostUsd,
-        };
-        await orchestrateCommand(orchestrateOptions);
-        process.stdout.write('\n');
-        rl.prompt();
-      })();
+      void executeReplTask(task, options, logger, rl);
     });
 
     rl.on('close', () => {

--- a/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
+++ b/packages/nexus-agents/src/learning/strategy-distiller-persistence.ts
@@ -144,7 +144,10 @@ export class PersistentStrategyDistiller extends StrategyDistiller {
       rules: rules as DistilledRule[],
     };
 
-    const tmpPath = this.filePath + '.tmp';
+    // PID-suffixed temp path so two processes saving concurrently don't truncate each
+    // other's temp file mid-renameSync. Matches the convention in correlation-persistence.ts
+    // and research-auto-catalog.ts. Closes #2972.
+    const tmpPath = `${this.filePath}.tmp.${String(process.pid)}`;
     try {
       // Ensure parent directory exists
       ensureLearningDir(dirname(this.filePath));

--- a/packages/nexus-agents/src/orchestration/parallel-exploration.ts
+++ b/packages/nexus-agents/src/orchestration/parallel-exploration.ts
@@ -233,9 +233,11 @@ async function dispatchPartitions(
 /** Creates a timeout promise that rejects after ms. */
 function createTimeout(ms: number, cli: CliName): Promise<never> {
   return new Promise((_, reject) => {
+    // .unref() so a winning fast CLI doesn't keep the event loop alive waiting
+    // on this ghost timer (perCliTimeoutMs can be 300s+). Closes #2976.
     setTimeout(() => {
       reject(new Error(`Timeout after ${String(ms)}ms for ${cli}`));
-    }, ms);
+    }, ms).unref();
   });
 }
 

--- a/packages/nexus-agents/src/orchestration/triangulated-review.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.ts
@@ -229,9 +229,11 @@ async function dispatchReviews(
 
 function createTimeout(ms: number, cli: CliName): Promise<never> {
   return new Promise((_, reject) => {
+    // .unref() so a winning fast review doesn't keep the event loop alive waiting
+    // on this ghost timer. Closes #2976.
     setTimeout(() => {
       reject(new Error(`Review timeout after ${String(ms)}ms for ${cli}`));
-    }, ms);
+    }, ms).unref();
   });
 }
 

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -188,6 +188,11 @@ export function flushPipelineMemory(): void {
 
 // Cached RoutingMemory — lazy-initialized, one per process
 let routingMemoryCache: unknown = null;
+// Coalesces concurrent init under cold-start fan-out (closes #2971). Without this,
+// N concurrent recordRoutingExperience calls each enter the dynamic-import path and
+// each build their own RoutingMemory, leaking handles / double-counting events.
+// Mirrors the memoryInitPromise pattern above (line 120).
+let routingMemoryInitPromise: Promise<unknown> | null = null;
 
 /** Record to RoutingMemory after expert calls (#1716). Fire-and-forget, cached. */
 function recordRoutingExperience(category: string, success: boolean, durationMs: number): void {
@@ -201,17 +206,22 @@ function recordRoutingExperience(category: string, success: boolean, durationMs:
     callRecord(routingMemoryCache);
     return;
   }
-  void import('../context/routing-memory.js')
+  routingMemoryInitPromise ??= import('../context/routing-memory.js')
     .then(({ createRoutingMemory }) => {
-      routingMemoryCache = createRoutingMemory();
-      callRecord(routingMemoryCache);
+      routingMemoryCache ??= createRoutingMemory();
+      return routingMemoryCache;
     })
     .catch((error: unknown) => {
       // Best-effort: routing-memory is optional persistence; log so we
       // can diagnose if it silently stops recording.
+      routingMemoryInitPromise = null; // allow retry on next call
       const msg = error instanceof Error ? error.message : String(error);
       logger.debug('Routing memory init failed; continuing without it', { error: msg });
+      return null;
     });
+  void routingMemoryInitPromise.then((rm) => {
+    if (rm !== null) callRecord(rm);
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Bundle of 4 trivial single-file fixes from the 2026-05-23 system-review epic (#2982). Each follows a pattern already established elsewhere in the codebase.

| Issue | File | Fix |
|---|---|---|
| #2971 | \`pipeline/agent-executor.ts:190\` | Added \`routingMemoryInitPromise\` coalescing so concurrent \`recordRoutingExperience\` calls share one \`createRoutingMemory()\` instance. Mirrors the \`memoryInitPromise ??=\` pattern 70 lines above. |
| #2972 | \`learning/strategy-distiller-persistence.ts:147\` | One-token: \`.tmp\` → \`.tmp.\${pid}\`. Prevents two processes calling \`saveSnapshot()\` from clobbering \`rules.json\` via the tmp/rename race. |
| #2974 | \`cli-orchestrator.ts:64-77\` | Extracted REPL line-handler body into \`executeReplTask\` with \`try\`/\`catch\`/\`finally rl.prompt()\`. \`orchestrateCommand\` rejection no longer hangs the prompt. |
| #2976 | 3 \`createTimeout\` sites | Added \`.unref()\` to each \`setTimeout\` so a winning fast-path doesn't leave a ghost timer keeping the event loop alive for up to \`perCliTimeoutMs\` (default 300 s). |

## Test plan

- [x] 91 tests pass across the 5 affected test files (agent-executor, strategy-distiller-persistence, agent-message-router, parallel-exploration, triangulated-review)
- [x] \`tsc --noEmit\` and \`eslint\` clean on all 6 touched files

Closes #2971. Closes #2972. Closes #2974. Closes #2976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)