### PR TITLE
fix(mcp): bound search_codebase index cache + coalesce inflight (closes #2970)

### DIFF
--- a/.changeset/2970-search-codebase-race-cache.md
+++ b/.changeset/2970-search-codebase-race-cache.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**fix(mcp):** `search_codebase` no longer races on cold-start, evicts stale indexes, and bounds retention. Closes #2970.
+
+The previous module-level `cachedIndex` / `cachedDir` pair had two coupled bugs:
+
+1. **Singleton-init race.** Two concurrent MCP `search_codebase` calls both missed the cache and each `await index.index(4)` (a seconds-long tree-walk + AST extraction over every TS/JS file). The loser's work was wasted.
+2. **Unbounded retention with stale results.** `CodebaseIndex` (~50,000 symbols × ~200 bytes for this repo) was kept for the life of the MCP server with no TTL, no LRU, no file-watcher invalidation. Memory grew + search results went stale after the user's first `git pull` / file edit.
+
+Fix: replace the pair with a small bounded cache (`MAX_CACHED_DIRS = 3`, `INDEX_TTL_MS = 15 minutes`) plus an `inflightIndex` `Map<dir, Promise<CodebaseIndex>>` that coalesces concurrent indexing of the same directory. LRU eviction uses `Map` insertion order: cache hits delete-then-reinsert the entry, demoting LRU candidates to the head. Mirrors the `PolicyCache` pattern in `security/access-constraint-deriver/cache.ts`. TTL is computed via `getTimeProvider()` so seeded tests reproduce.
+
+5 new tests cover: race coalescing (one constructor call on two concurrent calls), LRU eviction past 3 dirs, LRU refresh on cache hit, TTL expiry past 15 min, `clearIndexCache()` clearing inflight promises. The 3 existing cache tests (#2159) still pass against the new implementation. 24 tests in the file; tsc + eslint clean.

--- a/packages/nexus-agents/src/mcp/tools/search-codebase-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-codebase-tool.test.ts
@@ -154,6 +154,86 @@ describe('search-codebase-tool (#2159)', () => {
     });
   });
 
+  describe('index cache: race coalescing + bounded retention (#2970)', () => {
+    it('coalesces concurrent indexing of the same dir into one constructor call', async () => {
+      // Slow the index build so both calls race the inflight promise.
+      mocks.indexInstance.index.mockImplementationOnce(() => new Promise((r) => setTimeout(r, 20)));
+
+      const [r1, r2] = await Promise.all([
+        searchCodebaseHandler({ query: 'foo', directory: './src' }, makeCtx()),
+        searchCodebaseHandler({ query: 'bar', directory: './src' }, makeCtx()),
+      ]);
+
+      expect(r1.isError).toBeFalsy();
+      expect(r2.isError).toBeFalsy();
+      // Without coalescing both callers would each build a fresh index.
+      expect(mocks.ctor).toHaveBeenCalledTimes(1);
+    });
+
+    it('evicts the LRU directory once more than MAX_CACHED_DIRS (3) are in use', async () => {
+      // 4 distinct dirs → 4 builds; the first dir gets evicted.
+      await searchCodebaseHandler({ query: 'q', directory: './a' }, makeCtx());
+      await searchCodebaseHandler({ query: 'q', directory: './b' }, makeCtx());
+      await searchCodebaseHandler({ query: 'q', directory: './c' }, makeCtx());
+      await searchCodebaseHandler({ query: 'q', directory: './d' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(4);
+
+      // Re-hit './b' — still in cache (it's MRU of the three retained).
+      await searchCodebaseHandler({ query: 'q', directory: './b' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(4);
+
+      // Re-hit './a' — was evicted → rebuild.
+      await searchCodebaseHandler({ query: 'q', directory: './a' }, makeCtx());
+      expect(mocks.ctor).toHaveBeenCalledTimes(5);
+    });
+
+    it('treats cache hit as LRU refresh: re-hitting an entry promotes it to MRU', async () => {
+      // Fill cache to capacity in order a, b, c. './a' is the oldest.
+      await searchCodebaseHandler({ query: 'q', directory: './a' }, makeCtx());
+      await searchCodebaseHandler({ query: 'q', directory: './b' }, makeCtx());
+      await searchCodebaseHandler({ query: 'q', directory: './c' }, makeCtx());
+      expect(_testing.getCachedDirs()).toEqual([resolve('./a'), resolve('./b'), resolve('./c')]);
+
+      // Re-hit './a' → promote to MRU. Order is now b, c, a.
+      await searchCodebaseHandler({ query: 'q', directory: './a' }, makeCtx());
+      expect(_testing.getCachedDirs()).toEqual([resolve('./b'), resolve('./c'), resolve('./a')]);
+
+      // Add './d' → evicts the LRU ('./b'), not './a'.
+      await searchCodebaseHandler({ query: 'q', directory: './d' }, makeCtx());
+      expect(_testing.getCachedDirs()).toEqual([resolve('./c'), resolve('./a'), resolve('./d')]);
+    });
+
+    it('expires entries past the TTL', async () => {
+      vi.useFakeTimers();
+      try {
+        await searchCodebaseHandler({ query: 'q', directory: './src' }, makeCtx());
+        expect(mocks.ctor).toHaveBeenCalledTimes(1);
+
+        // Just under TTL → cache hit.
+        vi.advanceTimersByTime(15 * 60 * 1000 - 1);
+        await searchCodebaseHandler({ query: 'q', directory: './src' }, makeCtx());
+        expect(mocks.ctor).toHaveBeenCalledTimes(1);
+
+        // Past TTL → rebuild.
+        vi.advanceTimersByTime(2);
+        await searchCodebaseHandler({ query: 'q', directory: './src' }, makeCtx());
+        expect(mocks.ctor).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clearIndexCache also clears inflight promises', async () => {
+      mocks.indexInstance.index.mockImplementationOnce(() => new Promise((r) => setTimeout(r, 20)));
+
+      const p1 = searchCodebaseHandler({ query: 'q', directory: './src' }, makeCtx());
+      expect(_testing.getInflightDirs()).toContain(resolve('./src'));
+      clearIndexCache();
+      expect(_testing.getInflightDirs()).toHaveLength(0);
+      await p1;
+    });
+  });
+
   describe('mode dispatch', () => {
     it('search mode: reports zero results cleanly', async () => {
       mocks.indexInstance.search.mockReturnValue([]);

--- a/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
@@ -11,7 +11,7 @@
 import { resolve } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError } from '../../core/index.js';
+import { createLogger, formatZodError, getTimeProvider } from '../../core/index.js';
 import { CodebaseIndex } from '../../indexer/codebase-search.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
@@ -46,21 +46,77 @@ export type SearchCodebaseInput = z.infer<typeof SearchCodebaseInputSchema>;
 export type SearchCodebaseDeps = BaseMcpToolDeps;
 
 // ============================================================================
-// Index Cache (reuse across calls for same directory)
+// Index Cache (closes #2970 — race + unbounded retention)
 // ============================================================================
+//
+// Previously this was a single `cachedIndex` / `cachedDir` pair. Two bugs:
+//
+// 1. Race: two concurrent MCP `search_codebase` calls both missed the cache
+//    and each `await index.index(4)` — a seconds-long tree-walk + AST
+//    extraction over every TS/JS file. The loser's work was thrown away.
+//
+// 2. Unbounded retention with stale results: the index (~50,000 symbols ×
+//    ~200 bytes) was kept for the life of the MCP server with no TTL, no
+//    LRU, no file-watcher invalidation. Memory grew + search results went
+//    stale after the user's first `git pull` / file edit.
+//
+// Replaced with a small LRU+TTL bounded by directory count, plus an inflight
+// map that coalesces concurrent indexing of the same dir.
 
-let cachedIndex: CodebaseIndex | undefined;
-let cachedDir = '';
+/** Max number of indexed directories retained simultaneously. */
+const MAX_CACHED_DIRS = 3;
+/** Cached indexes expire after this many ms; next call re-indexes from disk. */
+const INDEX_TTL_MS = 15 * 60 * 1000;
+
+interface CachedIndexEntry {
+  readonly index: CodebaseIndex;
+  readonly expiresAt: number;
+}
+
+const indexCache = new Map<string, CachedIndexEntry>();
+const inflightIndex = new Map<string, Promise<CodebaseIndex>>();
+
+function getFromCache(dir: string): CodebaseIndex | undefined {
+  const entry = indexCache.get(dir);
+  if (entry === undefined) return undefined;
+  if (entry.expiresAt <= getTimeProvider().now()) {
+    indexCache.delete(dir);
+    return undefined;
+  }
+  // Refresh LRU position: delete then re-insert moves it to MRU.
+  indexCache.delete(dir);
+  indexCache.set(dir, entry);
+  return entry.index;
+}
+
+function putInCache(dir: string, index: CodebaseIndex): void {
+  indexCache.set(dir, { index, expiresAt: getTimeProvider().now() + INDEX_TTL_MS });
+  while (indexCache.size > MAX_CACHED_DIRS) {
+    // Map iteration is insertion order, so the first key is the LRU candidate.
+    const lruKey = indexCache.keys().next().value;
+    if (lruKey === undefined) break;
+    indexCache.delete(lruKey);
+  }
+}
 
 async function getIndex(dir: string): Promise<CodebaseIndex> {
-  if (cachedIndex !== undefined && cachedDir === dir) {
-    return cachedIndex;
-  }
-  const index = new CodebaseIndex(dir);
-  await index.index(4);
-  cachedIndex = index;
-  cachedDir = dir;
-  return index;
+  const cached = getFromCache(dir);
+  if (cached !== undefined) return cached;
+
+  // Coalesce: if another caller is already indexing this dir, await their result.
+  const inflight = inflightIndex.get(dir);
+  if (inflight !== undefined) return inflight;
+
+  const promise = (async (): Promise<CodebaseIndex> => {
+    const index = new CodebaseIndex(dir);
+    await index.index(4);
+    putInCache(dir, index);
+    return index;
+  })().finally(() => {
+    inflightIndex.delete(dir);
+  });
+  inflightIndex.set(dir, promise);
+  return promise;
 }
 
 // ============================================================================
@@ -161,11 +217,15 @@ export const _testing = {
   searchCodebaseHandler,
   /** Exposes the shared dir-validation + resolution logic. */
   resolveSearchDir,
-  /** Clears the module-level index cache so tests can start fresh. */
+  /** Clears the LRU index cache and any inflight promises so tests can start fresh. */
   clearIndexCache: (): void => {
-    cachedIndex = undefined;
-    cachedDir = '';
+    indexCache.clear();
+    inflightIndex.clear();
   },
+  /** Inspect the LRU for tests. */
+  getCachedDirs: (): readonly string[] => [...indexCache.keys()],
+  /** Inspect inflight indexing for tests. */
+  getInflightDirs: (): readonly string[] => [...inflightIndex.keys()],
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Two coupled bugs in `mcp/tools/search-codebase-tool.ts`:

1. **Singleton-init race.** Two concurrent `search_codebase` calls both missed the cache and each `await index.index(4)` — a seconds-long tree-walk + AST extraction over every TS/JS file. The loser's work was wasted.
2. **Unbounded retention with stale results.** \`CodebaseIndex\` (~50,000 symbols × ~200 bytes for this repo ≈ 10–50 MB) was held for the life of the MCP server with no TTL, no LRU, no file-watcher invalidation. Memory grew + search results went stale on the first \`git pull\` or file edit.

## Fix

- Replace \`cachedIndex\` / \`cachedDir\` with a bounded LRU map (\`MAX_CACHED_DIRS = 3\`).
- Add \`INDEX_TTL_MS = 15 minutes\` so stale indexes expire instead of accumulating.
- Add \`inflightIndex: Map<dir, Promise<CodebaseIndex>>\` to coalesce concurrent indexing of the same directory.
- LRU eviction uses \`Map\` insertion order: cache hits do \`delete\` + re-insert to refresh MRU position; new entries past the cap evict the LRU.
- TTL uses \`getTimeProvider()\` so seeded tests reproduce.

Pattern mirrors \`security/access-constraint-deriver/cache.ts\` (PolicyCache).

## Test plan

- [x] 5 new tests: race coalescing (1 ctor call on 2 concurrent), LRU eviction past 3 dirs, LRU refresh on hit, TTL expiry past 15min, \`clearIndexCache\` also clearing inflight
- [x] 3 existing #2159 cache tests still pass against the new implementation
- [x] 24 tests total in file pass; \`tsc --noEmit\` and \`eslint\` clean

Closes #2970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)