### PR TITLE
fix(audit): flush storage on timer + bound eventQueue (closes #2979)

### DIFF
--- a/.changeset/2979-audit-storage-flush.md
+++ b/.changeset/2979-audit-storage-flush.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+**fix(audit):** flush storage on every timer tick and bound the in-memory queue. Closes #2979.
+
+Two coupled bugs in `AuditLogger`/`FileAuditStorage` could indefinitely buffer audit events in memory under sustained load, with disk only catching up at shutdown:
+
+1. The flush timer called `flushQueue()` — which drained the in-memory `eventQueue` into `storage.write()` — but never called `storage.flush()`. `FileAuditStorage.write()` only appends to its `writeBuffer` (no disk I/O), so events accumulated until `close()`. As a side-effect, `currentFileSize` was incremented optimistically, triggering phantom rotation that abandoned un-pushed buffer contents.
+2. `flushQueue()` ran serially via `await` in a for-loop, and the interval kept firing while a flush was already in flight. Overlapping flushes plus no cap on `eventQueue` length meant unbounded memory growth under backpressure.
+
+Fix:
+
+- `audit-logger.ts:startFlushTimer` now calls `this.flush()` (which drains the queue **and** flushes storage) instead of `this.flushQueue()`.
+- `flush()` coalesces concurrent callers into a single in-flight promise via `inFlightFlush` — overlapping timer ticks or callers wait on the existing drain instead of spawning a parallel one.
+- `log()` enforces a new `maxQueueDepth` config (default `10_000`) with a drop-oldest policy when the cap is exceeded; a `warn` log fires the first time the cap is hit and once per `1_000` further drops to avoid log spam.
+- `audit-types.ts:AuditLogConfigSchema` adds `maxQueueDepth: z.number().positive().optional().default(10_000)`.
+- `cli-server-audit.ts` passes the default explicitly when wiring the production audit logger.
+- New tests cover all three behaviors: timer-tick storage flush (regression for bug 1), concurrent-flush coalescing, and drop-oldest backpressure.
+
+Behavior change: existing callers that don't set `maxQueueDepth` get the `10_000`-event cap automatically. Disk writes now happen on every flush interval (default 1s) instead of only at shutdown.

--- a/packages/nexus-agents/src/audit/audit-logger-storage.test.ts
+++ b/packages/nexus-agents/src/audit/audit-logger-storage.test.ts
@@ -34,6 +34,7 @@ function createTestConfig(logDir: string): AuditLogConfig {
     minSeverity: 'info',
     enableHashChain: false,
     enableCompression: false,
+    maxQueueDepth: 10_000,
   };
 }
 
@@ -597,6 +598,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
           allowedRoot,
         };
 
@@ -620,6 +622,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
         minSeverity: 'info',
         enableHashChain: false,
         enableCompression: false,
+        maxQueueDepth: 10_000,
         allowedRoot,
       };
 
@@ -643,6 +646,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
           allowedRoot: tempRoot,
         };
 
@@ -670,6 +674,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
           allowedRoot: tempRoot,
         };
 
@@ -697,6 +702,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
         };
 
         expect(() => new FileAuditStorage(config)).toThrow(SecurityError);
@@ -714,6 +720,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
         };
 
         expect(() => new FileAuditStorage(config)).toThrow(SecurityError);
@@ -733,6 +740,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
         };
 
         expect(() => new FileAuditStorage(config)).toThrow(SecurityError);
@@ -751,6 +759,7 @@ describe('FileAuditStorage Path Traversal Prevention', () => {
           minSeverity: 'info',
           enableHashChain: false,
           enableCompression: false,
+          maxQueueDepth: 10_000,
         };
 
         const storage = new FileAuditStorage(config);

--- a/packages/nexus-agents/src/audit/audit-logger.test.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.test.ts
@@ -35,6 +35,7 @@ function makeConfig(overrides?: Partial<AuditLogConfig>) {
     enableHashChain: false,
     enableCompression: false,
     flushIntervalMs: 1000,
+    maxQueueDepth: 10_000,
     minSeverity: 'info' as const,
     ...overrides,
   };
@@ -387,6 +388,82 @@ describe('AuditLogger', () => {
       const l = new AuditLogger(makeConfig({ flushIntervalMs: 100 }), s);
       l.log(ev('test'));
       expect(() => vi.advanceTimersByTime(200)).not.toThrow();
+    });
+  });
+
+  describe('flush timer drains storage buffer (#2979)', () => {
+    it('calls storage.flush() on each interval tick — not just storage.write()', async () => {
+      const l = new AuditLogger(makeConfig({ flushIntervalMs: 100 }), s);
+      l.log(ev('drain-me'));
+      // Advance just past one tick, letting the queued microtasks from the
+      // async timer callback settle without re-firing the timer indefinitely.
+      await vi.advanceTimersByTimeAsync(150);
+      expect(s.write).toHaveBeenCalledTimes(1);
+      expect(s.flush).toHaveBeenCalled();
+    });
+  });
+
+  describe('concurrent flush coalescing (#2979)', () => {
+    it('coalesces concurrent flush() calls into a single in-flight promise', async () => {
+      const resolvers: Array<() => void> = [];
+      s.write.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvers.push(resolve);
+          })
+      );
+      const l = new AuditLogger(makeConfig(), s);
+      l.log(ev('coalesce-1'));
+      l.log(ev('coalesce-2'));
+
+      // Kick off two concurrent flushes while the first storage.write() is in flight.
+      const p1 = l.flush();
+      const p2 = l.flush();
+      // Drain in-flight write, then resolve.
+      expect(resolvers).toHaveLength(1);
+      resolvers[0]?.();
+      await Promise.all([p1, p2]);
+
+      // Both events should have been written exactly once (no double-drain) and
+      // storage.flush should have been called once for the coalesced batch.
+      expect(s.write).toHaveBeenCalledTimes(2);
+      expect(s.flush).toHaveBeenCalledTimes(1);
+    });
+
+    it('serializes a follow-up flush after the in-flight one completes', async () => {
+      const l = new AuditLogger(makeConfig(), s);
+      l.log(ev('first'));
+      await l.flush();
+      l.log(ev('second'));
+      await l.flush();
+      expect(s.write).toHaveBeenCalledTimes(2);
+      expect(s.flush).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('maxQueueDepth backpressure (#2979)', () => {
+    it('drops oldest events when queue exceeds maxQueueDepth', async () => {
+      const l = new AuditLogger(makeConfig({ maxQueueDepth: 3 }), s);
+      l.log(ev('oldest'));
+      l.log(ev('second'));
+      l.log(ev('third'));
+      l.log(ev('fourth')); // should evict 'oldest'
+      l.log(ev('fifth')); // should evict 'second'
+      await l.flush();
+
+      expect(s.write).toHaveBeenCalledTimes(3);
+      const actions = (s.write.mock.calls as unknown[][]).map(
+        (call) => (call[0] as AuditEvent).action
+      );
+      expect(actions).toEqual(['third', 'fourth', 'fifth']);
+    });
+
+    it('uses a sane default maxQueueDepth when not configured', async () => {
+      // The default cap should be well above this small batch.
+      const l = new AuditLogger(makeConfig(), s);
+      for (let i = 0; i < 50; i++) l.log(ev('e' + String(i)));
+      await l.flush();
+      expect(s.write).toHaveBeenCalledTimes(50);
     });
   });
 });

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -155,17 +155,26 @@ const SYSTEM_ACTOR: AuditActor = {
 // Audit Logger Implementation
 // ============================================================================
 
+/**
+ * One warn() per N dropped events to avoid log spam when the queue cap is
+ * saturated under sustained load. Picked so a 10k/s drop rate emits ~1 warn/s.
+ */
+const DROP_WARN_INTERVAL = 1000;
+
 export class AuditLogger implements IAuditLogger {
   private readonly storage: IAuditStorage;
   private readonly logger: ILogger;
   private readonly enableHashChain: boolean;
   private readonly minSeverity: 'info' | 'warning' | 'critical';
   private readonly categories?: readonly string[] | undefined;
+  private readonly maxQueueDepth: number;
   private lastHash: string | null = null;
   private eventQueue: AuditEvent[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
   private readonly flushIntervalMs: number;
   private closed = false;
+  private inFlightFlush: Promise<void> | null = null;
+  private droppedEventCount = 0;
 
   constructor(config: AuditLogConfig, storage?: IAuditStorage, logger?: ILogger) {
     const validated = AuditLogConfigSchema.safeParse(config);
@@ -181,6 +190,7 @@ export class AuditLogger implements IAuditLogger {
     this.minSeverity = validated.data.minSeverity;
     this.categories = validated.data.categories;
     this.flushIntervalMs = validated.data.flushIntervalMs;
+    this.maxQueueDepth = validated.data.maxQueueDepth;
     this.storage = storage ?? new FileAuditStorage(validated.data, this.logger);
 
     this.startFlushTimer();
@@ -188,8 +198,11 @@ export class AuditLogger implements IAuditLogger {
   }
 
   private startFlushTimer(): void {
+    // NOTE: `flush()` (not `flushQueue()`) — the in-memory queue must drain to
+    // storage AND storage's own buffer must drain to disk on each tick.
+    // See #2979.
     this.flushTimer = setInterval(() => {
-      this.flushQueue().catch((err: unknown) => {
+      this.flush().catch((err: unknown) => {
         this.logger.error('Audit flush failed', err instanceof Error ? err : undefined);
       });
     }, this.flushIntervalMs);
@@ -252,6 +265,24 @@ export class AuditLogger implements IAuditLogger {
 
     const event = this.createEvent(input);
     this.eventQueue.push(event);
+
+    if (this.eventQueue.length > this.maxQueueDepth) {
+      // Drop-oldest: under sustained pressure, recent events are more useful
+      // for correlation than the oldest unflushed ones. See #2979.
+      const dropCount = this.eventQueue.length - this.maxQueueDepth;
+      this.eventQueue.splice(0, dropCount);
+      const priorDropped = this.droppedEventCount;
+      this.droppedEventCount += dropCount;
+      const crossedThreshold =
+        Math.floor(this.droppedEventCount / DROP_WARN_INTERVAL) >
+        Math.floor(priorDropped / DROP_WARN_INTERVAL);
+      if (priorDropped === 0 || crossedThreshold) {
+        this.logger.warn('Audit event queue full; dropping oldest events', {
+          maxQueueDepth: this.maxQueueDepth,
+          totalDropped: this.droppedEventCount,
+        });
+      }
+    }
 
     this.logger.debug('Audit event queued', {
       id: event.id,
@@ -347,18 +378,31 @@ export class AuditLogger implements IAuditLogger {
     });
   }
 
-  private async flushQueue(): Promise<void> {
-    if (this.eventQueue.length === 0) return;
-
-    const events = this.eventQueue.splice(0, this.eventQueue.length);
-    for (const event of events) {
-      await this.storage.write(event);
+  private async drainAndFlushOnce(): Promise<void> {
+    if (this.eventQueue.length > 0) {
+      const events = this.eventQueue.splice(0, this.eventQueue.length);
+      for (const event of events) {
+        await this.storage.write(event);
+      }
     }
+    await this.storage.flush();
   }
 
+  /**
+   * Drain the in-memory queue to storage AND flush the storage's own buffer
+   * to disk. Concurrent calls are coalesced into a single in-flight promise
+   * so an overlapping flush-timer tick cannot spawn parallel drains (see
+   * #2979). A caller arriving while a flush is already running awaits the
+   * existing promise; their newly-queued events, if any, are picked up by
+   * the next flush.
+   */
   async flush(): Promise<void> {
-    await this.flushQueue();
-    await this.storage.flush();
+    if (this.inFlightFlush !== null) return this.inFlightFlush;
+    const drain = this.drainAndFlushOnce().finally(() => {
+      this.inFlightFlush = null;
+    });
+    this.inFlightFlush = drain;
+    return drain;
   }
 
   async close(): Promise<void> {

--- a/packages/nexus-agents/src/audit/audit-storage.test.ts
+++ b/packages/nexus-agents/src/audit/audit-storage.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides?: Partial<AuditLogConfig>) {
     enableHashChain: false,
     enableCompression: false,
     flushIntervalMs: 1000,
+    maxQueueDepth: 10_000,
     minSeverity: 'info' as const,
     ...overrides,
   };

--- a/packages/nexus-agents/src/audit/audit-types.ts
+++ b/packages/nexus-agents/src/audit/audit-types.ts
@@ -183,6 +183,13 @@ export const AuditLogConfigSchema = z.object({
   enableCompression: z.boolean().optional().default(false),
   flushIntervalMs: z.number().positive().optional().default(1000),
 
+  /**
+   * Maximum in-memory event queue depth before drop-oldest backpressure
+   * engages. Bounds memory under load when storage.write is slow or the flush
+   * timer is overlapping; see #2979.
+   */
+  maxQueueDepth: z.number().positive().optional().default(10_000),
+
   // Filtering
   minSeverity: AuditSeveritySchema.optional().default('info'),
   categories: z.array(AuditCategorySchema).optional(),

--- a/packages/nexus-agents/src/cli-server-audit.ts
+++ b/packages/nexus-agents/src/cli-server-audit.ts
@@ -43,6 +43,7 @@ export function initializeAuditLogger(
       filePrefix: 'audit',
       enableCompression: false,
       flushIntervalMs: 1000,
+      maxQueueDepth: 10_000,
     },
     undefined,
     logger


### PR DESCRIPTION
## Summary

Fixes two coupled bugs in the audit pipeline that caused unbounded in-memory event accumulation:

- **Bug 1 (data-loss/latency):** The flush timer called `flushQueue()` which drained the in-memory `eventQueue` into `storage.write()` but never called `storage.flush()`. Since `FileAuditStorage.write()` only appends to its `writeBuffer` (no disk I/O), audit events sat in RAM until `close()`. A phantom `currentFileSize` increment also triggered rotation that abandoned un-pushed buffer contents.
- **Bug 2 (memory):** `flushQueue()` ran serially with `await` in a for-loop. The timer kept firing while a flush was in flight, so overlapping drains were possible. Combined with no cap on `eventQueue` length, this grew linearly toward OOM under sustained load.

## Fix

- `audit-logger.ts:startFlushTimer` now calls `this.flush()` (drains queue **and** flushes storage) instead of `this.flushQueue()`. Smallest-diff path for bug 1.
- `flush()` coalesces concurrent callers into a single in-flight promise via `inFlightFlush` — overlapping ticks/callers await the existing drain.
- `log()` enforces a new `maxQueueDepth` config (default `10_000`) with drop-oldest backpressure; emits a `warn` on first hit and once per `1_000` further drops to avoid log spam.
- `AuditLogConfigSchema` gains `maxQueueDepth: z.number().positive().optional().default(10_000)`. `cli-server-audit.ts` passes the default explicitly.

## Test plan

- [x] New failing-first tests added for: (a) `storage.flush()` is called on each timer tick, (b) concurrent `flush()` calls coalesce into one in-flight promise + one `storage.flush()` call, (c) `eventQueue` enforces `maxQueueDepth` with drop-oldest ordering.
- [x] `pnpm vitest run src/audit/` — 171/171 passing.
- [x] `pnpm vitest run src/cli-server-audit.test.ts` — 4/4 passing.
- [x] `pnpm tsc --noEmit` — no new errors (pre-existing `nexus-memory` import errors unchanged).
- [x] `pnpm eslint <changed files>` — clean.
- [ ] CI green on origin.

Closes #2979.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>