### PR TITLE
fix: expert-bridge cold-start race + parallel-executor abort-listener leak (closes #2969 #2978)

### DIFF
--- a/.changeset/bundle-2969-2978.md
+++ b/.changeset/bundle-2969-2978.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** two more single-file fixes from epic #2982.
+
+- **Closes #2969** — `pipeline/expert-bridge.ts:79,143`: `getMcpConfigPath` + `getRouter` cold-start race. `consensus_vote` fans out N=7 callers on cold start; both helpers used the unguarded `if (cached !== null) return; await init(); cached = result` pattern, so each caller ran the full init. `getMcpConfigPath` leaked N-1 mcp-config temp dirs via `mkdtemp` (no cleanup path). `getRouter` ran `createAllAdapters()` N times (N sets of CLI probe subprocesses). Added `mcpConfigInitPromise` and `routerInitPromise` coalescing — same `??=` pattern that the rest of the codebase uses (`scanner-registry-fetcher.ts`, `workflow-engine-factory.ts`, `agent-executor.ts`).
+- **Closes #2978** — `workflows/parallel-executor.ts:282-292`: replaced two manual `addEventListener('abort', ...)` calls per step with `AbortSignal.any([signal, state.abortController.signal])`. The manual approach accumulated 2 listeners per step on two long-lived shared signals, never removing them — a 50-step plan exceeded Node's default `MaxListeners=10` after step 5 and spammed `MaxListenersExceededWarning` to stderr. `AbortSignal.any` (Node 20+) composes signals natively and the resulting signal is GC'd as soon as the step's promise resolves.
+
+65 tests pass across the test files that exercise these paths (research-trigger, agent-executor, pipeline-eval-edge, parallel-executor). No behavior change in the happy path.

--- a/packages/nexus-agents/src/pipeline/expert-bridge.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.ts
@@ -74,18 +74,26 @@ let cachedRouter: RouterLike | null = null;
 
 // Cached MCP config — generated once, reused across expert calls (#1708)
 let cachedMcpConfigPath: string | null = null;
+// Coalesces concurrent init under voter fan-out (closes #2969). consensus_vote
+// fans out N=7 callers on cold start; without this each one ran the full init
+// including a mkdtemp() that the loser N-1 instances never cleaned up.
+let mcpConfigInitPromise: Promise<string | null> | null = null;
 
 /** Get or create cached MCP config path for expert CLI sessions (#1708). */
 async function getMcpConfigPath(): Promise<string | null> {
   if (cachedMcpConfigPath !== null) return cachedMcpConfigPath;
-  try {
-    const { generateMcpConfig } = await import('../cli-adapters/child-mcp-config.js');
-    const config = await generateMcpConfig();
-    cachedMcpConfigPath = config.configPath;
-    return cachedMcpConfigPath;
-  } catch {
-    return null; // MCP config not available — experts run without tools
-  }
+  mcpConfigInitPromise ??= (async (): Promise<string | null> => {
+    try {
+      const { generateMcpConfig } = await import('../cli-adapters/child-mcp-config.js');
+      const config = await generateMcpConfig();
+      cachedMcpConfigPath = config.configPath;
+      return cachedMcpConfigPath;
+    } catch {
+      mcpConfigInitPromise = null; // allow retry on next call
+      return null; // MCP config not available — experts run without tools
+    }
+  })();
+  return mcpConfigInitPromise;
 }
 
 /** Cached circuit breaker for health monitoring (#1766). */
@@ -139,28 +147,39 @@ function adaptCompositeRouter(
   };
 }
 
+// Coalesces concurrent router init the same way mcpConfigInitPromise does
+// (closes #2969). N=7 voter fan-out previously ran createAllAdapters() N times
+// — N sets of CLI probe subprocesses, all but one discarded.
+let routerInitPromise: Promise<RouterLike | null> | null = null;
+
 /** Get or create a cached CompositeRouter with circuit breaker monitoring. */
 async function getRouter(): Promise<RouterLike | null> {
   if (cachedRouter !== null) return cachedRouter;
-  const { createAllAdapters } = await import('../cli-adapters/factory.js');
-  const { createCompositeRouter } = await import('../cli-adapters/composite-router.js');
-  const adapters = createAllAdapters();
-  if (adapters.size === 0) return null;
-  cachedRouter = adaptCompositeRouter(createCompositeRouter(adapters));
+  routerInitPromise ??= (async (): Promise<RouterLike | null> => {
+    const { createAllAdapters } = await import('../cli-adapters/factory.js');
+    const { createCompositeRouter } = await import('../cli-adapters/composite-router.js');
+    const adapters = createAllAdapters();
+    if (adapters.size === 0) {
+      routerInitPromise = null; // allow retry once adapters become available
+      return null;
+    }
+    cachedRouter = adaptCompositeRouter(createCompositeRouter(adapters));
 
-  // Initialize circuit breaker monitoring (#1766)
-  try {
-    const { createCliCircuitBreakerIntegration } =
-      await import('../cli-adapters/cli-circuit-breaker.js');
-    cachedCircuitBreaker = createCliCircuitBreakerIntegration([...adapters.values()]);
-  } catch (error: unknown) {
-    // Circuit breaker not available — continue without it. Log so we can
-    // notice if initialization silently stops working (#1913 Class B).
-    const msg = error instanceof Error ? error.message : String(error);
-    logger.debug('Circuit breaker init failed; continuing without it', { error: msg });
-  }
+    // Initialize circuit breaker monitoring (#1766)
+    try {
+      const { createCliCircuitBreakerIntegration } =
+        await import('../cli-adapters/cli-circuit-breaker.js');
+      cachedCircuitBreaker = createCliCircuitBreakerIntegration([...adapters.values()]);
+    } catch (error: unknown) {
+      // Circuit breaker not available — continue without it. Log so we can
+      // notice if initialization silently stops working (#1913 Class B).
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.debug('Circuit breaker init failed; continuing without it', { error: msg });
+    }
 
-  return cachedRouter;
+    return cachedRouter;
+  })();
+  return routerInitPromise;
 }
 
 /** Check CLI health before dispatch (#1766). */

--- a/packages/nexus-agents/src/workflows/parallel-executor.ts
+++ b/packages/nexus-agents/src/workflows/parallel-executor.ts
@@ -281,14 +281,15 @@ async function executeStepInQueue(
 ): Promise<StepResult> {
   try {
     const result = await state.queue.add((signal) => {
-      const combined = new AbortController();
-      signal.addEventListener('abort', () => {
-        combined.abort();
-      });
-      state.abortController.signal.addEventListener('abort', () => {
-        combined.abort();
-      });
-      return executeStepWithTimeout(step, context, stepExecutor, combined.signal);
+      // Closes #2978. Previously we did `addEventListener('abort', ...)` twice
+      // per step on the two long-lived shared signals (queue's and state's),
+      // never removing them. A 50-step plan exceeded Node's default
+      // MaxListeners=10 after step 5 and spammed MaxListenersExceededWarning
+      // to stderr; heap retained a closure per listener until executeParallel
+      // returned. `AbortSignal.any` composes signals natively (Node 20+) and
+      // the resulting signal is GC'd as soon as the step's promise resolves.
+      const combined = AbortSignal.any([signal, state.abortController.signal]);
+      return executeStepWithTimeout(step, context, stepExecutor, combined);
     });
 
     state.results.push(result);


### PR DESCRIPTION
## Summary

Two more single-file fixes from epic #2982. Both follow patterns already established elsewhere in the codebase.

| Issue | File | Fix |
|---|---|---|
| #2969 | \`pipeline/expert-bridge.ts:79,143\` | \`getMcpConfigPath\` + \`getRouter\` cold-start race. \`consensus_vote\` fans out N=7 callers on cold start; each ran the full init (N \`mkdtemp\` temp dirs, N CLI-probe subprocess sets). Added \`mcpConfigInitPromise\` + \`routerInitPromise\` coalescing with the same \`??=\` pattern the rest of the codebase already uses. |
| #2978 | \`workflows/parallel-executor.ts:282\` | Replaced two manual \`addEventListener('abort', ...)\` calls per step with \`AbortSignal.any([signal, state.abortController.signal])\`. The manual approach exceeded Node's \`MaxListeners=10\` after step 5 on a 50-step plan and spammed \`MaxListenersExceededWarning\` to stderr. |

## Test plan

- [x] 65 tests pass across the test files that exercise these paths (research-trigger, agent-executor, pipeline-eval-edge, parallel-executor)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2969. Closes #2978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)