### PR TITLE
fix(setup): refuse to configure hooks when existing settings can't be parsed (closes #2975)

### DIFF
--- a/.changeset/2975-setup-mcp-hooks-parse-failure.md
+++ b/.changeset/2975-setup-mcp-hooks-parse-failure.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(setup):** `configureHooks` no longer silently overwrites user hooks when the claude CLI returns malformed JSON. Closes #2975.
+
+`getExistingHooks()` collapsed three distinct outcomes — "no hooks set," "the CLI errored," "the response was malformed" — into `undefined`. Downstream `mergeHookConfigs(undefined, nexus)` returns `nexus` only, and `configureHooks` then called `claude config set hooks` with that as the new total. Net effect: any user with their own `PreToolUse` / `Stop` hooks could lose them all after a claude-cli version bump that changed the JSON shape. The original #420 fix only covered the happy path; this regresses on the parse-failure path.
+
+Added `readExistingHooks()` that returns a discriminated union `{ kind: 'absent' | 'present' | 'unreadable' | 'parse_failed' }`. `configureHooks` now branches on `kind === 'parse_failed'` and returns a structured error asking the operator to inspect `claude config get hooks` and resolve manually — instead of overwriting. `getExistingHooks()` stays as a thin compat wrapper that maps any non-present to `undefined` so existing callers and tests are unchanged.
+
+6 new tests: 4 cover the `readExistingHooks` discriminated outcomes; 2 cover the `configureHooks` parse-failure guard (asserts `execFileSync` is NOT called on parse failure — the load-bearing safety invariant). 52 tests in the file pass; tsc + eslint clean.

--- a/packages/nexus-agents/src/cli/setup-mcp.test.ts
+++ b/packages/nexus-agents/src/cli/setup-mcp.test.ts
@@ -20,6 +20,7 @@ import {
   generateHookConfig,
   areHooksConfigured,
   getExistingHooks,
+  readExistingHooks,
   mergeHookConfigs,
   configureHooks,
   generateHookSnippet,
@@ -461,6 +462,93 @@ describe('getExistingHooks', () => {
     mockedExecSync.mockReturnValue('not-json{{{');
 
     expect(getExistingHooks()).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// readExistingHooks (#2975 — distinguishes parse failure from absence)
+// ============================================================================
+
+describe('readExistingHooks (#2975)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns kind=present with parsed hooks for valid JSON', () => {
+    const hookData = { PreToolUse: [{ hooks: [{ type: 'command', command: 'lint' }] }] };
+    mockedExecSync.mockReturnValue(JSON.stringify(hookData));
+
+    const result = readExistingHooks();
+
+    expect(result).toEqual({ kind: 'present', hooks: hookData });
+  });
+
+  it('returns kind=absent for empty/null/undefined CLI output', () => {
+    for (const output of ['', '   \n  ', 'null', 'undefined']) {
+      mockedExecSync.mockReturnValue(output);
+      expect(readExistingHooks()).toEqual({ kind: 'absent' });
+    }
+  });
+
+  it('returns kind=unreadable when the CLI throws', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('claude CLI not on PATH');
+    });
+
+    const result = readExistingHooks();
+    expect(result.kind).toBe('unreadable');
+    if (result.kind === 'unreadable') {
+      expect(result.reason).toContain('claude CLI not on PATH');
+    }
+  });
+
+  it('returns kind=parse_failed (NOT absent) for malformed JSON', () => {
+    mockedExecSync.mockReturnValue('not-json{{{');
+
+    const result = readExistingHooks();
+    expect(result.kind).toBe('parse_failed');
+    if (result.kind === 'parse_failed') {
+      expect(result.raw).toBe('not-json{{{');
+      expect(result.reason).toMatch(/JSON|parse/i);
+    }
+  });
+});
+
+// ============================================================================
+// configureHooks parse-failure guard (#2975)
+// ============================================================================
+
+describe('configureHooks parse-failure guard (#2975)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedHomedir.mockReturnValue('/mock/home');
+  });
+
+  it('refuses to configure when existing hooks fail to parse — does not call config set', () => {
+    // First execSync = `claude config get hooks` → returns malformed JSON.
+    // areHooksConfigured() also calls execSync; return malformed for any call.
+    mockedExecSync.mockReturnValue('not-json{{{');
+
+    const result = configureHooks(/* force */ true);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/Refusing to configure hooks/);
+    expect(result.message).toMatch(/parse error/i);
+    // Critical: never reached the destructive write.
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when existing hooks parse cleanly', () => {
+    mockedExecSync.mockReturnValue(JSON.stringify({}));
+
+    const result = configureHooks(true);
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'claude',
+      expect.arrayContaining(['config', 'set', 'hooks']),
+      expect.anything()
+    );
   });
 });
 

--- a/packages/nexus-agents/src/cli/setup-mcp.ts
+++ b/packages/nexus-agents/src/cli/setup-mcp.ts
@@ -272,23 +272,55 @@ export function areHooksConfigured(): boolean {
 }
 
 /**
- * Reads existing hooks from Claude CLI settings.
- * Returns parsed hooks object or undefined if no hooks exist or parse fails.
+ * Detailed result of reading existing hooks. Distinguishes "no hooks set" from
+ * "the claude CLI returned content we couldn't parse" — they look the same to
+ * `getExistingHooks()` (both undefined) but mean very different things to the
+ * caller. Closes #2975: collapsing both into undefined caused `configureHooks`
+ * to silently overwrite the user's existing hooks when the claude CLI's JSON
+ * shape drifted (regressed #420 on the parse-failure path).
  */
-export function getExistingHooks(): HookSettingsConfig['hooks'] | undefined {
+export type ReadHooksResult =
+  | { kind: 'absent' }
+  | { kind: 'present'; hooks: HookSettingsConfig['hooks'] }
+  | { kind: 'unreadable'; reason: string }
+  | { kind: 'parse_failed'; reason: string; raw: string };
+
+/**
+ * Reads existing hooks from Claude CLI settings with full result detail.
+ * Callers should branch on `kind` before deciding whether to merge or abort.
+ */
+export function readExistingHooks(): ReadHooksResult {
+  let raw: string;
   try {
-    const result = execSync('claude config get hooks', {
+    raw = execSync('claude config get hooks', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    const trimmed = result.trim();
-    if (!trimmed || trimmed === 'null' || trimmed === 'undefined') {
-      return undefined;
-    }
-    return JSON.parse(trimmed) as HookSettingsConfig['hooks'];
-  } catch {
-    return undefined;
+  } catch (error) {
+    return { kind: 'unreadable', reason: getErrorMessage(error) };
   }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === 'null' || trimmed === 'undefined') {
+    return { kind: 'absent' };
+  }
+  try {
+    return { kind: 'present', hooks: JSON.parse(trimmed) as HookSettingsConfig['hooks'] };
+  } catch (error) {
+    return { kind: 'parse_failed', reason: getErrorMessage(error), raw: trimmed };
+  }
+}
+
+/**
+ * Reads existing hooks from Claude CLI settings.
+ *
+ * Returns parsed hooks object or undefined if no hooks exist, the CLI call
+ * fails, or the response cannot be parsed. Loses the distinction between
+ * those cases — for the merge-vs-abort decision in `configureHooks` use
+ * `readExistingHooks()` directly. Kept for backward compatibility.
+ */
+export function getExistingHooks(): HookSettingsConfig['hooks'] | undefined {
+  const result = readExistingHooks();
+  return result.kind === 'present' ? result.hooks : undefined;
 }
 
 /**
@@ -359,9 +391,25 @@ export function configureHooks(force: boolean = false): HookConfigResult {
 
   const nexusHookConfig = generateHookConfig();
 
+  // Read existing hooks first to merge (Issue #420). Closes #2975: on
+  // parse_failed we MUST NOT proceed — silently overwriting an unparseable
+  // response is exactly how user hooks got wiped after claude-cli JSON-shape
+  // drifts. Surface the problem so the operator can fix the underlying
+  // condition (or pass --force after backing up their hooks).
+  const existing = readExistingHooks();
+  if (existing.kind === 'parse_failed') {
+    return {
+      success: false,
+      alreadyConfigured: false,
+      message:
+        'Refusing to configure hooks: existing hooks could not be parsed. ' +
+        'Overwriting would wipe your current settings. ' +
+        `Inspect with \`claude config get hooks\` and resolve manually. (parse error: ${existing.reason})`,
+    };
+  }
+  const existingHooks = existing.kind === 'present' ? existing.hooks : undefined;
+
   try {
-    // Read existing hooks first to merge (Issue #420)
-    const existingHooks = getExistingHooks();
     const mergedHooks = mergeHookConfigs(existingHooks, nexusHookConfig.hooks);
 
     // Use claude config set with merged hooks


### PR DESCRIPTION
## Summary

\`configureHooks\` silently overwrote the user's existing \`PreToolUse\`/\`Stop\` hooks when the claude CLI returned malformed JSON for \`config get hooks\`. \`getExistingHooks()\` collapsed three outcomes — "no hooks set," "CLI errored," "malformed response" — into the same \`undefined\`, and the downstream merge → \`config set\` overwrote the user's settings. The original #420 fix covered the happy path; this regresses on the parse-failure path.

## Fix

Add \`readExistingHooks()\` returning a discriminated union:

\`\`\`ts
type ReadHooksResult =
  | { kind: 'absent' }
  | { kind: 'present'; hooks }
  | { kind: 'unreadable'; reason }
  | { kind: 'parse_failed'; reason; raw };
\`\`\`

\`configureHooks\` now branches on \`kind === 'parse_failed'\` and returns a structured error asking the operator to resolve manually — instead of destructively overwriting. \`getExistingHooks()\` stays as a thin compat wrapper so existing callers / tests are unchanged.

## Test plan

- [x] 6 new tests: 4 cover the discriminated outcomes; 2 cover the \`configureHooks\` parse-failure guard — load-bearing assertion is that \`execFileSync\` is NOT called when parse fails
- [x] 52 tests in \`setup-mcp.test.ts\` pass (up from 46)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)