### PR TITLE
fix: release-notes vacuous output + pipeline-checkpoint silent JSONL drop (closes #2980 #2981)

### DIFF
--- a/.changeset/bundle-2980-2981.md
+++ b/.changeset/bundle-2980-2981.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** two more error-handling fixes from epic #2982.
+
+- **Closes #2980** — `cli/release-notes-helpers.ts:48-64`: `getCommitsBetween` collapsed git failures into `[]`, which downstream `release-notes-command` mapped to `{ success: true, content: 'No commits found in range.' }`. Operator running `release-notes --from=v0.5.99` (typo, tag doesn't exist) got a "successful" empty release notes file. CI without git in container generated a blog post claiming "0 changes." Added `tryGetCommitsBetween` returning a `CommitsResult` discriminated union (`'ok' | 'invalid_ref' | 'git_failed'`); legacy `getCommitsBetween` stays as a thin compat wrapper. `release-notes-command` now surfaces ref-validation + git-execution failures explicitly; `release-announce-command` emits a `console.warn` when stats can't be computed so the operator notices before posting.
+- **Closes #2981** — `pipeline/pipeline-checkpoint.ts:144-163`: `rebuildState` did `JSON.parse(line) as PipelineCheckpointEntry` and silently dropped malformed lines via bare `catch {}`. The cast accepted any successfully-parsed JSON (`null`, `42`, `{}`), so `applyEntry` could read undefined fields and poison the recovered state. Added `PipelineCheckpointEntrySchema` (Zod, mirrors the type exactly) and validate every line; skipped lines are counted and reported at `warn` level so corrupt checkpoints surface in operator logs.
+
+90 tests pass across the affected files (release-notes-helpers, release-notes-command, release-announce-command, pipeline-checkpoint); tsc + eslint clean.

--- a/packages/nexus-agents/src/cli/release-announce-command.test.ts
+++ b/packages/nexus-agents/src/cli/release-announce-command.test.ts
@@ -30,6 +30,7 @@ vi.mock('./ansi-output.js', () => ({
 vi.mock('./release-notes-helpers.js', () => ({
   getLatestTag: vi.fn(),
   getCommitsBetween: vi.fn(),
+  tryGetCommitsBetween: vi.fn().mockReturnValue({ kind: 'ok', commits: [] }),
   parseConventionalCommit: vi.fn(),
   groupCommitsByCategory: vi.fn(),
 }));

--- a/packages/nexus-agents/src/cli/release-announce-command.ts
+++ b/packages/nexus-agents/src/cli/release-announce-command.ts
@@ -28,7 +28,7 @@ import {
 } from './release-announce-types.js';
 import {
   getLatestTag,
-  getCommitsBetween,
+  tryGetCommitsBetween,
   parseConventionalCommit,
   groupCommitsByCategory,
 } from './release-notes-helpers.js';
@@ -87,9 +87,24 @@ function generateBlogPost(options: ReleaseAnnounceOptions): string {
   const highlights = options.highlights || extractHighlightsFromChangelog(options.version);
   const today = new Date().toISOString().split('T')[0] ?? new Date().toISOString().slice(0, 10);
 
-  // Get commit stats
+  // Get commit stats. Closes #2980 (announce-command path): if git fails or
+  // the ref is bad, fall back to an empty stat panel rather than silently
+  // generating a blog post claiming "0 new features." The blog post still
+  // generates because the announce-command's main purpose (creating a
+  // template the operator hand-edits) doesn't depend on commit stats being
+  // populated — but we leave a comment trail so they notice.
   const fromRef = getLatestTag() || 'HEAD~50';
-  const commits = getCommitsBetween(fromRef, 'HEAD');
+  const commitsResult = tryGetCommitsBetween(fromRef, 'HEAD');
+  const commits = commitsResult.kind === 'ok' ? commitsResult.commits : [];
+  if (commitsResult.kind !== 'ok') {
+    const detail =
+      commitsResult.kind === 'invalid_ref'
+        ? `invalid ref: ${commitsResult.ref}`
+        : commitsResult.reason;
+    console.warn(
+      `[release-announce] git log failed for ${fromRef}..HEAD (${detail}); commit stats will be zero.`
+    );
+  }
   const parsedCommits = commits.map((line) => {
     const spaceIndex = line.indexOf(' ');
     return parseConventionalCommit(line.substring(0, spaceIndex), line.substring(spaceIndex + 1));

--- a/packages/nexus-agents/src/cli/release-notes-command.test.ts
+++ b/packages/nexus-agents/src/cli/release-notes-command.test.ts
@@ -23,6 +23,9 @@ const mockCategory: ReleaseNotesCategory = {
 vi.mock('./release-notes-helpers.js', () => ({
   getLatestTag: vi.fn().mockReturnValue('v2.5.0'),
   getCommitsBetween: vi.fn().mockReturnValue(['abc1234 feat: add new feature']),
+  tryGetCommitsBetween: vi
+    .fn()
+    .mockReturnValue({ kind: 'ok', commits: ['abc1234 feat: add new feature'] }),
   parseConventionalCommit: vi.fn().mockReturnValue({
     hash: 'abc1234',
     type: 'feat',
@@ -74,6 +77,7 @@ import {
 import {
   getLatestTag,
   getCommitsBetween,
+  tryGetCommitsBetween,
   parseConventionalCommit,
   groupCommitsByCategory,
   suggestNextVersion,
@@ -85,6 +89,10 @@ import {
 function resetHelperMocks(): void {
   vi.mocked(getLatestTag).mockReturnValue('v2.5.0');
   vi.mocked(getCommitsBetween).mockReturnValue(['abc1234 feat: add new feature']);
+  vi.mocked(tryGetCommitsBetween).mockReturnValue({
+    kind: 'ok',
+    commits: ['abc1234 feat: add new feature'],
+  });
   vi.mocked(parseConventionalCommit).mockReturnValue(mockCommit);
   vi.mocked(groupCommitsByCategory).mockReturnValue([mockCategory]);
   vi.mocked(suggestNextVersion).mockReturnValue('2.6.0');
@@ -109,7 +117,7 @@ describe('runReleaseNotes', () => {
   });
 
   it('should return empty result when no commits found', async () => {
-    vi.mocked(getCommitsBetween).mockReturnValue([]);
+    vi.mocked(tryGetCommitsBetween).mockReturnValue({ kind: 'ok', commits: [] });
 
     const result = await runReleaseNotes();
 
@@ -122,7 +130,7 @@ describe('runReleaseNotes', () => {
   it('should use latest tag as fromRef', async () => {
     await runReleaseNotes();
 
-    expect(getCommitsBetween).toHaveBeenCalledWith('v2.5.0', 'HEAD');
+    expect(tryGetCommitsBetween).toHaveBeenCalledWith('v2.5.0', 'HEAD');
   });
 
   it('should fall back to HEAD~50 when no tag exists', async () => {
@@ -130,13 +138,13 @@ describe('runReleaseNotes', () => {
 
     await runReleaseNotes();
 
-    expect(getCommitsBetween).toHaveBeenCalledWith('HEAD~50', 'HEAD');
+    expect(tryGetCommitsBetween).toHaveBeenCalledWith('HEAD~50', 'HEAD');
   });
 
   it('should use custom from/to references', async () => {
     await runReleaseNotes({ from: 'v1.0.0', to: 'v2.0.0' });
 
-    expect(getCommitsBetween).toHaveBeenCalledWith('v1.0.0', 'v2.0.0');
+    expect(tryGetCommitsBetween).toHaveBeenCalledWith('v1.0.0', 'v2.0.0');
   });
 
   it('should use changelog format by default', async () => {
@@ -277,7 +285,7 @@ describe('releaseNotesCommand', () => {
       options: { from: 'v1.0.0', to: 'v2.0.0' },
     });
 
-    expect(getCommitsBetween).toHaveBeenCalledWith('v1.0.0', 'v2.0.0');
+    expect(tryGetCommitsBetween).toHaveBeenCalledWith('v1.0.0', 'v2.0.0');
   });
 
   it('should default format to changelog', async () => {

--- a/packages/nexus-agents/src/cli/release-notes-command.ts
+++ b/packages/nexus-agents/src/cli/release-notes-command.ts
@@ -24,7 +24,7 @@ import {
 } from './release-notes-types.js';
 import {
   getLatestTag,
-  getCommitsBetween,
+  tryGetCommitsBetween,
   parseConventionalCommit,
   groupCommitsByCategory,
   generateChangelogFormat,
@@ -62,8 +62,37 @@ export async function runReleaseNotes(
     console.log(`${colors.dim}Analyzing commits from ${fromRef} to ${toRef}...${colors.reset}`);
   }
 
-  // Get commits
-  const commitLines = getCommitsBetween(fromRef, toRef);
+  // Get commits. Closes #2980: distinguish "valid range with no commits" from
+  // "git command failed" so a typo'd --from or a missing git binary surfaces
+  // as a failure instead of a "successful" empty release notes file.
+  const commitsResult = tryGetCommitsBetween(fromRef, toRef);
+  if (commitsResult.kind === 'invalid_ref') {
+    return {
+      success: false,
+      content: `Invalid git ref: "${commitsResult.ref}". Refs may only contain [a-zA-Z0-9._\\-/~^].`,
+      version: 'unknown',
+      fromRef,
+      toRef,
+      commitCount: 0,
+      categories: [],
+      usedConsensus: false,
+      durationMs: Date.now() - startTime,
+    };
+  }
+  if (commitsResult.kind === 'git_failed') {
+    return {
+      success: false,
+      content: `git log failed for ${fromRef}..${toRef}: ${commitsResult.reason}`,
+      version: 'unknown',
+      fromRef,
+      toRef,
+      commitCount: 0,
+      categories: [],
+      usedConsensus: false,
+      durationMs: Date.now() - startTime,
+    };
+  }
+  const commitLines = commitsResult.commits;
 
   if (commitLines.length === 0) {
     return {

--- a/packages/nexus-agents/src/cli/release-notes-helpers.ts
+++ b/packages/nexus-agents/src/cli/release-notes-helpers.ts
@@ -46,20 +46,44 @@ export function getLatestTag(): string | undefined {
  * @returns Array of commit lines
  */
 export function getCommitsBetween(from: string, to = 'HEAD'): string[] {
+  const result = tryGetCommitsBetween(from, to);
+  return result.kind === 'ok' ? result.commits : [];
+}
+
+/**
+ * Result type for `tryGetCommitsBetween` — distinguishes "no commits found"
+ * (an empty but valid range) from "git command failed" (invalid ref, missing
+ * binary, corrupt repo, timeout). Closes #2980: the legacy `getCommitsBetween`
+ * collapsed both into `[]`, which downstream `release-notes-command` mapped to
+ * `{ success: true, content: 'No commits found in range.' }` — producing a
+ * "successful" empty release notes file on a typo'd `--from`.
+ */
+export type CommitsResult =
+  | { kind: 'ok'; commits: string[] }
+  | { kind: 'invalid_ref'; ref: string }
+  | { kind: 'git_failed'; reason: string };
+
+/**
+ * Fetches commits between two git refs, distinguishing absence from failure.
+ * Use this in any path where "no commits" and "couldn't run git" should
+ * behave differently (release notes, release announcements, changelog
+ * generation). Prefer over `getCommitsBetween` in new code.
+ */
+export function tryGetCommitsBetween(from: string, to = 'HEAD'): CommitsResult {
   // Validate git refs to prevent command injection (security audit 2026-04-10)
   const SAFE_REF = /^[a-zA-Z0-9._\-/~^]+$/;
-  if (!SAFE_REF.test(from) || !SAFE_REF.test(to)) {
-    return [];
-  }
+  if (!SAFE_REF.test(from)) return { kind: 'invalid_ref', ref: from };
+  if (!SAFE_REF.test(to)) return { kind: 'invalid_ref', ref: to };
   try {
     const result = execFileSync('git', ['log', `${from}..${to}`, '--oneline', '--format=%h %s'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
     }).trim();
-    return result ? result.split('\n').filter(Boolean) : [];
-  } catch {
-    return [];
+    return { kind: 'ok', commits: result ? result.split('\n').filter(Boolean) : [] };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { kind: 'git_failed', reason };
   }
 }
 

--- a/packages/nexus-agents/src/pipeline/pipeline-checkpoint.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-checkpoint.ts
@@ -12,6 +12,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
 import { createLogger } from '../core/index.js';
 import { ensureCheckpointDir } from '../agents/wave-checkpoint-persistence.js';
 import type { PipelineTask, DevPipelineResult } from './dev-pipeline.js';
@@ -140,7 +141,53 @@ export function loadCheckpointState(
   }
 }
 
-/** Rebuild pipeline state from JSONL entries. */
+/**
+ * Zod schema for `PipelineCheckpointEntry`. Closes #2981: previously
+ * `rebuildState` did `JSON.parse(line) as PipelineCheckpointEntry`, which
+ * silently accepted any successfully-parsed JSON (`null`, `42`, `{}`,
+ * arbitrary objects). `applyEntry` then read undefined fields and poisoned
+ * the recovered state. Validate every line through this schema and skip
+ * (counting + warning) anything that doesn't match.
+ *
+ * The schema mirrors `PipelineStage` + `PipelineStageData` exactly — keep
+ * in lockstep if either type changes.
+ */
+const PipelineStageSchema = z.enum([
+  'research',
+  'plan',
+  'vote',
+  'decompose',
+  'implement',
+  'security',
+]);
+
+const PipelineStageDataSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('research'), text: z.string() }),
+  z.object({ type: z.literal('plan'), text: z.string(), iterations: z.number() }),
+  z.object({
+    type: z.literal('vote'),
+    approved: z.boolean(),
+    conditional: z.boolean(),
+    conditions: z.array(z.string()).optional(),
+    caveats: z.array(z.string()).optional(),
+    iterations: z.number(),
+  }),
+  // PipelineTask shape is loose at the persistence layer — capture as
+  // `z.unknown()` and trust the downstream consumer's narrower validation.
+  z.object({ type: z.literal('decompose'), tasks: z.array(z.unknown()) }),
+  z.object({ type: z.literal('implement'), tasks: z.array(z.unknown()) }),
+  z.object({ type: z.literal('security'), passed: z.boolean() }),
+]);
+
+const PipelineCheckpointEntrySchema = z.object({
+  sessionId: z.string(),
+  stage: PipelineStageSchema,
+  timestamp: z.string(),
+  data: PipelineStageDataSchema,
+});
+
+/** Rebuild pipeline state from JSONL entries. Skipped malformed lines are
+ *  counted and reported at warn level (closes #2981 — was previously silent). */
 function rebuildState(lines: string[]): PipelineCheckpointState {
   const state: {
     research?: string;
@@ -152,13 +199,36 @@ function rebuildState(lines: string[]): PipelineCheckpointState {
     lastCompletedStage?: PipelineStage;
   } = {};
 
+  let skippedCount = 0;
+  let firstSkipReason: string | undefined;
+
   for (const line of lines) {
+    let parsed: unknown;
     try {
-      const entry = JSON.parse(line) as PipelineCheckpointEntry;
-      applyEntry(state, entry);
-    } catch {
-      // Skip malformed lines
+      parsed = JSON.parse(line);
+    } catch (error) {
+      skippedCount++;
+      firstSkipReason ??= `JSON.parse failed: ${error instanceof Error ? error.message : String(error)}`;
+      continue;
     }
+    const result = PipelineCheckpointEntrySchema.safeParse(parsed);
+    if (!result.success) {
+      skippedCount++;
+      firstSkipReason ??= `schema validation failed: ${result.error.message}`;
+      continue;
+    }
+    // Cast tasks[] back to readonly PipelineTask[] — the schema captured them
+    // as unknown[] because the persistence layer doesn't narrow them.
+    applyEntry(state, result.data as unknown as PipelineCheckpointEntry);
+  }
+
+  if (skippedCount > 0) {
+    logger.warn('Skipped malformed checkpoint lines during state rebuild', {
+      skippedCount,
+      totalLines: lines.length,
+      firstSkipReason,
+      recovered: state.lastCompletedStage,
+    });
   }
 
   return state;


### PR DESCRIPTION
## Summary

Two error-handling fixes from epic #2982.

| Issue | File | Fix |
|---|---|---|
| #2980 | \`cli/release-notes-helpers.ts\` | Added \`tryGetCommitsBetween\` returning a \`CommitsResult\` discriminated union (\`'ok' \\| 'invalid_ref' \\| 'git_failed'\`). \`release-notes-command\` surfaces ref-validation + git-execution failures explicitly; \`release-announce-command\` emits a \`console.warn\` when stats can't be computed so the operator notices before posting. |
| #2981 | \`pipeline/pipeline-checkpoint.ts\` | Added \`PipelineCheckpointEntrySchema\` (Zod). \`rebuildState\` validates every line; skipped lines are counted + reported at \`warn\` level instead of silently dropped. Closes the type-cast hole where \`null\`/\`42\`/\`{}\` could poison the recovered state. |

## Test plan

- [x] 90 tests pass across the affected test files (release-notes-helpers, release-notes-command, release-announce-command, pipeline-checkpoint)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2980. Closes #2981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)