### PR TITLE
fix(security): harden MCP — path traversal, secret leak, env leak

### DIFF
--- a/.changeset/security-wave3-mcp-traversal-leaks.md
+++ b/.changeset/security-wave3-mcp-traversal-leaks.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+**fix(security):** three MCP-surface hardening fixes from the 2026-05-24 wave-3 audit.
+
+These are exploitable from untrusted MCP input that operators routinely route through nexus-agents (issue bodies, PR comments, third-party MCP servers wired into the gateway). Marked minor because the secret-redaction change to tool-error responses can clip legitimate strings that happen to match the secret patterns.
+
+- **Path traversal — sibling-prefix bypass in 5 MCP tools.** `mcp/tools/dev-pipeline-tool.ts`, `pipeline-tool.ts`, `compare-data-feeds.ts`, `search-codebase-tool.ts`, `extract-symbols-tool.ts` all checked `resolved.startsWith(cwdRoot)` without a trailing separator. From cwd `/home/u/proj`, a caller passing `directory: "../projEVIL/secret.txt"` resolves to `/home/u/projEVIL/secret.txt`, which passes the bare `startsWith` check. Fixed to match the convention in `security/safe-path.ts` and `mcp/tools/query-trace-tool.ts`: `(resolved === cwdRoot || resolved.startsWith(cwdRoot + sep))`.
+- **Secret leak in tool-error responses.** `mcp/middleware/secure-handler.ts:460-472`: success-branch `ToolResult` went through `sanitizeToolResult` (which redacts AWS keys, Bearer tokens, hex secrets, `password=`/`token=`/`api_key=` patterns), but the `catch (error)` branch returned the raw `error.message` to the MCP client. Adapter SDKs commonly echo offending credentials in their error messages (Anthropic's `AuthenticationError` carries `sk-ant-api03-…` substrings; fetch wrappers echo `Authorization` headers). The exception path now runs the same `sanitizeOutput`.
+- **Supply-chain env leak in MCP gateway.** `mcp/gateway/upstream-client.ts` previously spread full `process.env` into spawned upstream subprocesses — every API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`, `OPENROUTER_API_KEY`, etc.) leaked to whatever third-party MCP server the operator wired up, contradicting the schema comment "use `{env:VAR}` references, not plaintext secrets" (`schemas-gateway.ts:37`). Now passes only `UPSTREAM_BASELINE_KEYS` (`PATH`, `HOME`, `USER`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TMPDIR`, `TZ`, `PWD`, `SHELL`, `TERM`) plus the operator's explicit `env` mappings.
+
+144 tests pass across the 7 affected test files. Two remaining wave-3 findings (#2993 hardcoded `trustTier=1` + fail-open in orchestrate/execute-expert, #2994 V2 delegate strips `trustTier`) need multi-file changes and are filed for separate PRs.

--- a/packages/nexus-agents/src/mcp/gateway/upstream-client.ts
+++ b/packages/nexus-agents/src/mcp/gateway/upstream-client.ts
@@ -32,6 +32,35 @@ function resolveEnv(env: Record<string, string> | undefined): Record<string, str
   return resolved;
 }
 
+/**
+ * Minimal env baseline forwarded to upstream MCP subprocesses. Closes the
+ * supply-chain leak in the prior `{ ...process.env, ... }` pattern — keys
+ * like ANTHROPIC_API_KEY, OPENAI_API_KEY, GITHUB_TOKEN are no longer handed
+ * to third-party servers the operator wired into the gateway.
+ */
+const UPSTREAM_BASELINE_KEYS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TMPDIR',
+  'TZ',
+  'PWD',
+  'SHELL',
+  'TERM',
+] as const;
+
+function buildUpstreamEnv(configEnv: Record<string, string> | undefined): Record<string, string> {
+  const baseline: Record<string, string> = {};
+  for (const key of UPSTREAM_BASELINE_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) baseline[key] = value;
+  }
+  return { ...baseline, ...resolveEnv(configEnv) };
+}
+
 /** State of an upstream connection. */
 type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'failed';
 
@@ -60,16 +89,10 @@ export class UpstreamClient {
 
     this.state = 'connecting';
     try {
-      const resolvedEnv = resolveEnv(this.config.env);
-      // Filter out undefined values from process.env for StdioServerParameters compatibility
-      const baseEnv: Record<string, string> = {};
-      for (const [k, v] of Object.entries(process.env)) {
-        if (v !== undefined) baseEnv[k] = v;
-      }
       this.transport = new StdioClientTransport({
         command: this.config.command,
         args: [...this.config.args],
-        env: { ...baseEnv, ...resolvedEnv },
+        env: buildUpstreamEnv(this.config.env),
       });
       this.client = new Client(
         { name: `nexus-upstream-${this.name}`, version: '1.0.0' },

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
@@ -458,7 +458,7 @@ async function executeAndAudit(
     }
     return result;
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const rawMessage = error instanceof Error ? error.message : 'Unknown error';
     requestLogger.error('Tool execution failed', error instanceof Error ? error : undefined);
     if (config.auditLogger) {
       emitToolAuditException(
@@ -468,7 +468,13 @@ async function executeAndAudit(
         getTimeProvider().now() - execStartTime
       );
     }
-    return internalError(message, requestContext.requestId);
+    // Closes a secret-leak path: adapter SDKs commonly echo offending
+    // credentials in their error messages (e.g. Anthropic's
+    // AuthenticationError carries `sk-ant-api03-…` substrings; fetch
+    // wrappers can echo Authorization headers). The success branch above
+    // runs sanitizeToolResult; the exception path must too.
+    const sanitized = sanitizeOutput(rawMessage, requestLogger);
+    return internalError(sanitized, requestContext.requestId);
   }
 }
 

--- a/packages/nexus-agents/src/mcp/tools/compare-data-feeds.ts
+++ b/packages/nexus-agents/src/mcp/tools/compare-data-feeds.ts
@@ -279,8 +279,11 @@ function buildSummary(
 
 function loadFeed(feedPath: string): unknown[] {
   const resolved = path.resolve(feedPath);
+  // Path traversal guard. The `+ path.sep` is load-bearing: a sibling
+  // directory whose name starts with the cwd basename bypasses a bare
+  // startsWith. Match security/safe-path.ts.
   const cwdRoot = path.resolve('.');
-  if (!resolved.startsWith(cwdRoot)) {
+  if (resolved !== cwdRoot && !resolved.startsWith(cwdRoot + path.sep)) {
     throw new Error(`Path traversal denied: ${feedPath} must be within ${cwdRoot}`);
   }
   if (!fs.existsSync(resolved)) {

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -132,9 +132,13 @@ async function resolveTaskInput(input: DevPipelineInput): Promise<string> {
   }
   if (input.planFile !== undefined) {
     const resolved = path.resolve(input.planFile);
-    // Path traversal guard — restrict to cwd subtree (security audit 2026-04-10)
+    // Path traversal guard — restrict to cwd subtree (security audit 2026-04-10).
+    // The `+ path.sep` is load-bearing: without it, a sibling directory whose
+    // name starts with the cwd basename (e.g. `/home/u/projEVIL` when cwd is
+    // `/home/u/proj`) bypasses the check. Match the convention in
+    // security/safe-path.ts and query-trace-tool.ts.
     const cwdRoot = path.resolve('.');
-    if (!resolved.startsWith(cwdRoot)) {
+    if (resolved !== cwdRoot && !resolved.startsWith(cwdRoot + path.sep)) {
       throw new Error(`Path traversal denied: planFile must be within ${cwdRoot}`);
     }
     try {

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
@@ -8,7 +8,7 @@
  * @module mcp/tools/extract-symbols-tool
  */
 
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
@@ -86,9 +86,12 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
   const { filePath, mode } = parsed.data;
   const resolvedPath = resolve(filePath);
 
-  // Path traversal guard — restrict to cwd subtree (security audit 2026-04-10)
+  // Path traversal guard — restrict to cwd subtree. The `+ sep` is
+  // load-bearing: a sibling directory whose name starts with the cwd
+  // basename (`/home/u/projEVIL` for cwd `/home/u/proj`) bypasses a bare
+  // startsWith. Match security/safe-path.ts.
   const cwdRoot = resolve('.');
-  if (!resolvedPath.startsWith(cwdRoot)) {
+  if (resolvedPath !== cwdRoot && !resolvedPath.startsWith(cwdRoot + sep)) {
     return toolStructuredError({
       errorCategory: 'permission',
       message: `Path traversal denied: path must be within ${cwdRoot}`,

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -128,9 +128,12 @@ function buildOutput(result: AdaptiveOrchestratorResult): Record<string, unknown
 async function resolveTask(task: string, specFile: string | undefined): Promise<string> {
   if (specFile === undefined) return task;
   const resolved = path.resolve(specFile);
-  // Path traversal guard — restrict to cwd subtree (security audit 2026-04-10)
+  // Path traversal guard — restrict to cwd subtree. The `+ path.sep` is
+  // load-bearing: a sibling whose name starts with the cwd basename
+  // (`/home/u/projEVIL` for cwd `/home/u/proj`) bypasses a bare startsWith.
+  // Match the convention in security/safe-path.ts.
   const cwdRoot = path.resolve('.');
-  if (!resolved.startsWith(cwdRoot)) {
+  if (resolved !== cwdRoot && !resolved.startsWith(cwdRoot + path.sep)) {
     throw new Error(`Path traversal denied: specFile must be within ${cwdRoot}`);
   }
   try {

--- a/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-codebase-tool.ts
@@ -8,7 +8,7 @@
  * @module mcp/tools/search-codebase-tool
  */
 
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError, getTimeProvider } from '../../core/index.js';
@@ -126,8 +126,11 @@ async function getIndex(dir: string): Promise<CodebaseIndex> {
 /** Resolve and validate directory against path traversal. */
 function resolveSearchDir(directory: string | undefined): { dir: string } | { error: string } {
   const dir = resolve(directory ?? process.cwd());
+  // The `+ sep` is load-bearing: a sibling directory whose name starts with
+  // the cwd basename (`/home/u/projEVIL` for cwd `/home/u/proj`) bypasses a
+  // bare startsWith. Match security/safe-path.ts.
   const cwdRoot = resolve('.');
-  if (!dir.startsWith(cwdRoot)) {
+  if (dir !== cwdRoot && !dir.startsWith(cwdRoot + sep)) {
     return { error: `Path traversal denied: directory must be within ${cwdRoot}` };
   }
   return { dir };


### PR DESCRIPTION
## Summary

Three exploitable issues from the 2026-05-24 wave-3 security audit, all single-file fixes bundled together because all are exploitable from untrusted MCP input.

| # | File | Issue |
|---|---|---|
| 1 | 5 MCP tools (\`dev-pipeline-tool\`, \`pipeline-tool\`, \`compare-data-feeds\`, \`search-codebase-tool\`, \`extract-symbols-tool\`) | **Path traversal sibling-prefix bypass.** \`resolved.startsWith(cwdRoot)\` without trailing separator accepts \`/home/u/projEVIL/secret\` when cwd is \`/home/u/proj\`. Fixed to \`(resolved === cwdRoot \\|\\| resolved.startsWith(cwdRoot + sep))\` matching \`security/safe-path.ts\`. |
| 2 | \`mcp/middleware/secure-handler.ts:460-472\` | **Secret leak in tool-error responses.** Success branch ran \`sanitizeToolResult\`; catch branch returned raw \`error.message\`. Adapter SDKs commonly echo offending credentials (Anthropic \`AuthenticationError\` carries \`sk-ant-api03-…\`; fetch wrappers echo \`Authorization\` headers). Exception path now runs the same \`sanitizeOutput\`. |
| 3 | \`mcp/gateway/upstream-client.ts\` | **Supply-chain env leak.** Spread full \`process.env\` into upstream subprocesses — every API key leaked to whatever third-party MCP server the operator wired up, contradicting the schema comment "use \`{env:VAR}\` references, not plaintext secrets." Now passes only \`UPSTREAM_BASELINE_KEYS\` (\`PATH\`, \`HOME\`, \`USER\`, \`LANG\`, locale, \`TMPDIR\`, \`TZ\`, \`PWD\`, \`SHELL\`, \`TERM\`) + operator's explicit \`env\`. |

## Test plan

- [x] 144 tests pass across 7 affected test files (\`search-codebase-tool\`, \`extract-symbols-tool\`, \`compare-data-feeds\`, \`dev-pipeline-tool\`, \`pipeline-tool\`, \`secure-handler\`, \`upstream-client\`)
- [x] \`tsc --noEmit\` and \`eslint\` clean on all 7 source files
- [x] Verified each path-traversal pattern was the bare-\`startsWith\` bug (not the safe sibling pattern already in use elsewhere)
- [x] Verified \`sanitizeOutput\` redacts AWS keys, Bearer tokens, hex secrets, \`password=\`/\`token=\`/\`api_key=\` (already covered in existing secret patterns)
- [x] Verified \`UPSTREAM_BASELINE_KEYS\` includes everything an upstream MCP needs for command resolution (PATH/HOME) and locale (LANG/LC_*) but excludes anything beginning \`*_KEY\`, \`*_TOKEN\`, \`*_SECRET\`

## Follow-ups

Two remaining wave-3 findings need multi-file changes and are filed separately:
- **#2993** — Hardcoded \`trustTier=1\` in \`orchestrate.ts\` + \`execute-expert.ts\` bypasses access-policy gate; derivation-failure fails OPEN to wildcard.
- **#2994** — \`delegateInputToTaskContract\` strips \`trustTier\` → V2 policy engine's only built-in rule defaults to allow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)