### PR TITLE
fix(security): policy derivation fails closed under enforce/confirm_risky (partial #2993)

### DIFF
--- a/.changeset/2993-policy-derivation-fail-closed.md
+++ b/.changeset/2993-policy-derivation-fail-closed.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+**fix(security):** access-policy derivation failures now fail closed under active enforcement. Partial fix for #2993.
+
+Pre-fix: in both `mcp/tools/orchestrate.ts` (`deriveOrchestratePolicy`) and `mcp/tools/execute-expert.ts` (`deriveExpertAccessPolicy`), the `catch (error)` branch fell back to a wildcard policy with `mode: 'off'`. Any exception in LLM derivation — a transient API failure, a Zod schema drift, an adapter bug — converted to a security bypass. Even operators running `NEXUS_ACCESS_POLICY_MODE=enforce` ended up with `allowedTools: '*'` and `allowedOperations: '*'` enforcement disabled, contradicting their explicit configuration.
+
+Fix: the fallback now preserves the operator's configured mode in the returned policy and restricts to empty allow-lists (`allowedTools: []`, `allowedOperations: []`, `allowedPathPatterns: []`) when the mode is `confirm_risky` or `enforce`. For `off` and `audit` modes the permissive fallback is preserved (operators in those modes have either opted out entirely or accepted log-only semantics, both of which would be surprised by a sudden block). The warn log now includes `failClosed: boolean` so the operator can correlate.
+
+68 tests pass across the two changed files. `tsc + eslint` clean.
+
+**Still open** (the multi-file half of #2993): the hardcoded `trustTier: '1'` in the same two functions. Threading `requestContext.trustTier` from `secure-handler` through both tools' deps needs careful audit of the entire call graph — deferred to a follow-up so this fail-closed half ships immediately.

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -294,9 +294,26 @@ async function deriveExpertAccessPolicy(
     }
     return policy;
   } catch (error) {
-    logger?.warn('access-policy: derivation failed, falling back to off (expert)', {
+    // Fail closed under active enforcement, fail safe under audit/off.
+    // See `orchestrate.ts:deriveOrchestratePolicy` for the full rationale
+    // (#2993). Mirror the behavior here so the two MCP entry points to
+    // policy derivation don't diverge.
+    logger?.warn('access-policy: derivation failed (expert)', {
+      mode,
       error: getErrorMessage(error),
+      failClosed: mode === 'enforce' || mode === 'confirm_risky',
     });
+    if (mode === 'enforce' || mode === 'confirm_risky') {
+      return {
+        allowedTools: [],
+        allowedPathPatterns: [],
+        allowedOperations: [],
+        objectiveHash: 'derivation-failed',
+        derivedAt: getTimeProvider().nowIso(),
+        source: 'bypass',
+        mode,
+      };
+    }
     return {
       allowedTools: '*',
       allowedPathPatterns: [],
@@ -304,7 +321,7 @@ async function deriveExpertAccessPolicy(
       objectiveHash: 'derivation-failed',
       derivedAt: getTimeProvider().nowIso(),
       source: 'bypass',
-      mode: 'off',
+      mode,
     };
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -801,9 +801,29 @@ async function deriveOrchestratePolicy(
     }
     return policy;
   } catch (error) {
-    logger.warn('access-policy: derivation failed, falling back to off', {
+    // Fail closed under active enforcement, fail safe under audit/off.
+    // Pre-fix #2993 this fell back to a wildcard `mode: 'off'` policy on
+    // ANY derivation exception — turning a derivation bug into a security
+    // bypass even for operators running `enforce`. Now: preserve the
+    // operator's configured mode; restrict to empty allow-lists when
+    // enforcement is active; keep the permissive policy only when the
+    // operator already opted out (`off`) or accepted log-only (`audit`).
+    logger.warn('access-policy: derivation failed', {
+      mode,
       error: getErrorMessage(error),
+      failClosed: mode === 'enforce' || mode === 'confirm_risky',
     });
+    if (mode === 'enforce' || mode === 'confirm_risky') {
+      return {
+        allowedTools: [],
+        allowedPathPatterns: [],
+        allowedOperations: [],
+        objectiveHash: 'derivation-failed',
+        derivedAt: getTimeProvider().nowIso(),
+        source: 'bypass',
+        mode,
+      };
+    }
     return {
       allowedTools: '*',
       allowedPathPatterns: [],
@@ -811,7 +831,7 @@ async function deriveOrchestratePolicy(
       objectiveHash: 'derivation-failed',
       derivedAt: getTimeProvider().nowIso(),
       source: 'bypass',
-      mode: 'off',
+      mode,
     };
   }
 }


### PR DESCRIPTION
## Summary

Closes the **fail-OPEN half** of #2993. The hardcoded \`trustTier: '1'\` half (multi-file, needs careful call-graph audit) is deferred to a follow-up so this critical-severity fix ships immediately.

## Bug

Pre-fix, both \`deriveOrchestratePolicy\` (orchestrate.ts) and \`deriveExpertAccessPolicy\` (execute-expert.ts) had a \`catch (error)\` branch that returned:

\`\`\`ts
{
  allowedTools: '*',
  allowedPathPatterns: [],
  allowedOperations: '*',
  ...
  mode: 'off',   // ← turns the policy enforcement layer OFF
}
\`\`\`

Any exception in LLM derivation — a transient API failure, a Zod drift, an adapter bug — became a security bypass. Operators running \`NEXUS_ACCESS_POLICY_MODE=enforce\` ended up with their configured enforcement disabled.

## Fix

The fallback now:
- Preserves the operator's configured \`mode\` in the returned policy (was hardcoded to \`'off'\`).
- Restricts to empty allow-lists (\`allowedTools: []\`, \`allowedOperations: []\`, \`allowedPathPatterns: []\`) when \`mode\` is \`'confirm_risky'\` or \`'enforce'\`.
- Keeps the permissive fallback for \`'off'\` (operator already opted out) and \`'audit'\` (log-only — a sudden block would change documented mode semantics).
- The warn log now includes \`failClosed: boolean\` so operators can correlate.

## Test plan

- [x] 68 tests pass across \`orchestrate.test.ts\` (38) + \`execute-expert.test.ts\` (30)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Partial fix for #2993 (fail-OPEN half closed; trustTier half open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)