### PR TITLE
feat(security): wire RequestContext.trustTier end-to-end (closes #2957 #2993 #2994)

### DIFF
--- a/.changeset/2957-trust-tier-wiring.md
+++ b/.changeset/2957-trust-tier-wiring.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': minor
+---
+
+**feat(security):** wire `RequestContext.trustTier` end-to-end into V2 pipelines and access-policy derivation. Closes #2957, #2993, #2994.
+
+Three coupled security gaps converged on one missing wire — the caller's trust tier never reached the gates that needed it. This PR plumbs the value through:
+
+### Producers
+
+- `pipeline/v2-orchestrate.ts:orchestrateInputToTaskContract` and `pipeline/v2-delegate.ts:delegateInputToTaskContract` both gained an `opts.trustTier?: string` parameter that, when provided, writes `metadata.trustTier` onto the constructed `TaskContract`. Pre-fix, neither producer wrote this field, so the V2 policy engine's only built-in rule (`trust-tier`) could not gate anything — it silently allowed every execute stage regardless of caller (#2994).
+
+### Callers
+
+- `mcp/tools/orchestrate.ts`: `createOrchestrateHandler` now threads `ctx.requestContext.trustTier` through `runOrchestratePipeline` → `executeOrchestrationWithDeadline` → `executeOrchestration` → `deriveOrchestratePolicy` and into `instrumentV2Orchestrate` → `orchestrateInputToTaskContract`.
+- `mcp/tools/delegate-to-model.ts`: similar — `createDelegateHandler` passes `ctx.requestContext.trustTier` into `instrumentV2Pipeline` → `delegateInputToTaskContract`.
+- `mcp/tools/execute-expert.ts`: runs through MCP's native task handler (not the `ContextAwareHandler` chain), so `RequestContext` is not directly available there. `deriveExpertAccessPolicy` now takes the trustTier as an explicit param; the call site currently passes `undefined`, which defaults to `'4'` (untrusted) — defensive default until proper end-to-end wiring lands as a follow-up.
+
+### Gates
+
+- `mcp/tools/orchestrate.ts:deriveOrchestratePolicy` and `mcp/tools/execute-expert.ts:deriveExpertAccessPolicy`: the hardcoded `trustTier: '1'` (#2993) is replaced with the threaded value, defaulting to `'4'` when missing. Pre-fix, every untrusted caller's input was treated as fully trusted by the LLM derivation, which would consistently produce a permissive policy regardless of actual caller risk.
+- `pipeline/policy-engine.ts:trustTierRule`: missing or non-numeric `pipelineState.trustTier` now defaults to `4` (untrusted) instead of the prior fail-open `undefined → allow`. With producer wiring in place, the only paths that hit the default are buggy producers or test fixtures — both should fail closed.
+
+### Tests
+
+- `pipeline/policy-engine.test.ts`: updated the two "allows when trustTier is missing/invalid" tests to assert blocks-execute behavior; added "still allows non-execute stages" to confirm the default doesn't break planning paths.
+- 137 tests pass across the 6 affected test files (policy-engine, v2-orchestrate, v2-delegate, orchestrate, execute-expert, delegate-to-model). `tsc + eslint` clean.
+
+### Migration / behavior change
+
+- Operators running V2 pipelines (`NEXUS_V2_ORCHESTRATE=true`, `NEXUS_V2_DELEGATE=true`, etc.) previously had no policy enforcement at all (the bug). Post-fix: legitimate callers via `orchestrate` and `delegate_to_model` get their real trust tier and pass through; programmatic callers that bypass `secure-handler` (or test fixtures that don't populate `pipelineState.trustTier`) now block at execute stages. This is the correct new behavior — the rule is finally doing its job.
+- The hardcoded `trustTier: '1'` removal means LLM-derived access policies may now be more restrictive for the same input under tier `'4'`. This is a real behavioral change but matches the documented intent of the trust-classification system.
+
+### Follow-ups
+
+- Properly thread `RequestContext` (or equivalent caller info) into `execute-expert`'s background task handler path so its `trustTier` isn't always defaulted to `'4'`.
+- Audit producers other than orchestrate/delegate (none in current production code paths, but defensive coverage).

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
@@ -153,9 +153,17 @@ function enrichWithGovernance(
   };
 }
 
-/** Fire-and-forget V2 pipeline instrumentation (Phase A, Issue #920). */
-function instrumentV2Pipeline(input: { task: string }, logger: ILogger): void {
-  const tc = delegateInputToTaskContract(input);
+/** Fire-and-forget V2 pipeline instrumentation (Phase A, Issue #920).
+ * `trustTier` threaded in so the V2 policy-engine's `trust-tier` rule
+ * actually gates the delegate pipeline (#2957). Pre-#2957 the V2 delegate
+ * path had zero policy enforcement because the producer never wrote
+ * trustTier into metadata. */
+function instrumentV2Pipeline(
+  input: { task: string },
+  logger: ILogger,
+  trustTier: string | undefined
+): void {
+  const tc = delegateInputToTaskContract(input, trustTier !== undefined ? { trustTier } : {});
   // #2960: catch rejections so an instrumentation-path failure logs
   // instead of becoming an unhandled rejection. Mirrors the sibling
   // pattern at `mcp/tools/orchestrate.ts:822-826`.
@@ -240,7 +248,11 @@ function createDelegateHandler(
     notifier.info('delegate', { event: 'routing_start', taskLength: input.task.length });
     ctx.logger.info('Analyzing task for model routing', { taskLength: input.task.length });
     const governance = classifyDelegateGovernance(input, ctx.logger);
-    if (resolveV2Config().delegateEnabled) instrumentV2Pipeline(input, ctx.logger);
+    if (resolveV2Config().delegateEnabled) {
+      // Thread requestContext.trustTier so the V2 policy-engine actually
+      // gates the pipeline (#2957).
+      instrumentV2Pipeline(input, ctx.logger, ctx.requestContext.trustTier);
+    }
     const baseOpts: NotifyRecordOpts = {
       notifier,
       task: input.task,

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -278,13 +278,17 @@ function observeExpertContextIfOk(
  */
 async function deriveExpertAccessPolicy(
   task: Task,
-  logger: ILogger | undefined
+  logger: ILogger | undefined,
+  trustTier: string | undefined
 ): Promise<Awaited<ReturnType<typeof deriveAccessPolicy>>> {
   const mode = resolveAccessPolicyMode();
   try {
+    // Closes #2993 (expert path): trustTier was hardcoded to '1' regardless
+    // of caller. Now threaded from secure-handler RequestContext; missing
+    // defaults to '4' so derivation runs at the strictest tier.
     const policy = await deriveAccessPolicy(task.description, {
       mode,
-      trustTier: '1',
+      trustTier: (trustTier ?? '4') as '1' | '2' | '3' | '4',
     });
     if (mode !== 'off') {
       logger?.info('access-policy: derived (expert)', {
@@ -501,7 +505,13 @@ async function runExpertTask(
 
       let result;
       try {
-        const policy = await deriveExpertAccessPolicy(task, deps.logger);
+        // execute-expert runs through MCP's native task handler (not the
+        // ContextAwareHandler chain), so HandlerContext / RequestContext
+        // isn't directly available here. Pass undefined so the deriver
+        // defaults to '4' (untrusted). Proper end-to-end trust-tier
+        // wiring for execute-expert is filed as a follow-up — see #2993
+        // (multi-file half) and the new follow-up issue.
+        const policy = await deriveExpertAccessPolicy(task, deps.logger, undefined);
         result = await withAccessPolicy(policy, () => expert.execute(task));
       } finally {
         clearInterval(heartbeatTimer);

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -612,7 +612,8 @@ async function executeOrchestration(
   input: OrchestrateInput,
   deps: OrchestrateDeps,
   router?: IWorkflowRouter,
-  snapshot?: OrchestrationStateSnapshot
+  snapshot?: OrchestrationStateSnapshot,
+  trustTier?: string
 ): Promise<Result<OrchestrateOutput, OrchestrationError>> {
   const { workflowRouter, decision, orchestrator, logger } = routeAndPrepare(input, deps, router);
   const taskId = generateTaskId();
@@ -637,7 +638,7 @@ async function executeOrchestration(
   const task = await createTaskFromInput(input, taskId);
   const definition: OrchestratorDefinition = { type: 'task', task };
   const hb = startHeartbeatTracking(`orchestrate-${taskId}`, logger);
-  const policy = await deriveOrchestratePolicy(input.task, deps, logger);
+  const policy = await deriveOrchestratePolicy(input.task, deps, logger, trustTier);
   try {
     return await runOrchestratorWithStateTracking({
       taskId,
@@ -782,13 +783,19 @@ function recordTaskStateBlocker(taskId: string, blocker: string, logger: ILogger
 async function deriveOrchestratePolicy(
   taskText: string,
   deps: OrchestrateDeps,
-  logger: ILogger
+  logger: ILogger,
+  trustTier: string | undefined
 ): Promise<Awaited<ReturnType<typeof deriveAccessPolicy>>> {
   const mode = resolveAccessPolicyMode();
   try {
+    // Closes #2993: pre-fix trustTier was hardcoded to '1' (max trust)
+    // regardless of caller. Now thread it from the request context; if
+    // missing (older test harnesses that don't populate it) default to '4'
+    // so derivation runs at the strictest tier rather than falsely
+    // permissive.
     const opts: Parameters<typeof deriveAccessPolicy>[1] = {
       mode,
-      trustTier: '1',
+      trustTier: (trustTier ?? '4') as '1' | '2' | '3' | '4',
       ...(deps.modelAdapter !== undefined ? { adapter: deps.modelAdapter } : {}),
     };
     const policy = await deriveAccessPolicy(taskText, opts);
@@ -836,9 +843,16 @@ async function deriveOrchestratePolicy(
   }
 }
 
-/** Fire-and-forget V2 pipeline instrumentation (Phase E, Issue #924). */
-function instrumentV2Orchestrate(input: { task: string }, logger: ILogger): void {
-  const tc = orchestrateInputToTaskContract(input);
+/** Fire-and-forget V2 pipeline instrumentation (Phase E, Issue #924).
+ * `trustTier` is threaded in so the V2 policy-engine's `trust-tier` rule
+ * actually gates the pipeline (#2957). Pre-#2957 this defaulted to undefined
+ * which bypassed enforcement. */
+function instrumentV2Orchestrate(
+  input: { task: string },
+  logger: ILogger,
+  trustTier: string | undefined
+): void {
+  const tc = orchestrateInputToTaskContract(input, trustTier !== undefined ? { trustTier } : {});
   void executeOrchestratePipeline(tc)
     .then((m) => {
       logger.info('V2 orchestrate pipeline', { ...m });
@@ -1015,8 +1029,9 @@ async function executeOrchestrationWithDeadline(params: {
   readonly deps: OrchestrateDeps;
   readonly notifier: ReturnType<typeof createMcpNotifier>;
   readonly logger: ILogger;
+  readonly trustTier?: string;
 }): Promise<Result<OrchestrateOutput, OrchestrationError>> {
-  const { input, deps, notifier, logger } = params;
+  const { input, deps, notifier, logger, trustTier } = params;
   const overallDeadlineMs = getMcpSafeDeadlineMs(
     MCP_TIMEOUTS.perTool['orchestrate'] ?? MCP_TIMEOUTS.defaultMs,
     'orchestrate'
@@ -1027,7 +1042,7 @@ async function executeOrchestrationWithDeadline(params: {
   const snapshot = createOrchestrationStateSnapshot(getTimeProvider().now());
   return raceAgainstDeadline(
     withProgressHeartbeat('orchestrate', notifier, () =>
-      executeOrchestration(input, deps, undefined, snapshot)
+      executeOrchestration(input, deps, undefined, snapshot, trustTier)
     ),
     overallDeadlineMs,
     (elapsedMs) => {
@@ -1052,13 +1067,14 @@ async function runOrchestratePipeline(params: {
   readonly deps: OrchestrateDeps;
   readonly notifier: ReturnType<typeof createMcpNotifier>;
   readonly logger: ILogger;
+  readonly trustTier?: string;
 }): Promise<ToolResult> {
-  const { input, deps, notifier, logger } = params;
+  const { input, deps, notifier, logger, trustTier } = params;
   logger.debug('Starting orchestration', { taskLength: input.task.length });
   notifier.info('orchestrate', { event: 'orchestrate_start', taskLength: input.task.length });
   const startMs = getTimeProvider().now();
   const v2Config = resolveV2Config();
-  if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(input, logger);
+  if (v2Config.orchestrateEnabled) instrumentV2Orchestrate(input, logger, trustTier);
 
   // Phase 3 of #2792 — every entry point reads accumulated memory before
   // dispatching work. The fetch always runs; the prompt-augmentation step
@@ -1079,7 +1095,13 @@ async function runOrchestratePipeline(params: {
   recordAndReflect(workerDispatchResult, input.task, deps);
 
   // Wall-clock safeguard (sub-issue B of #2104): see helper doc.
-  const result = await executeOrchestrationWithDeadline({ input, deps, notifier, logger });
+  const result = await executeOrchestrationWithDeadline({
+    input,
+    deps,
+    notifier,
+    logger,
+    ...(trustTier !== undefined ? { trustTier } : {}),
+  });
   if (!result.ok) {
     return toolStructuredError({
       errorCategory: 'internal',
@@ -1156,6 +1178,8 @@ function createOrchestrateHandler(deps: OrchestrateDeps) {
           deps,
           notifier,
           logger: ctx.logger,
+          // Threaded from the secure-handler RequestContext (#2957).
+          trustTier: ctx.requestContext.trustTier,
         })
       );
     } catch (depthError: unknown) {

--- a/packages/nexus-agents/src/pipeline/policy-engine.test.ts
+++ b/packages/nexus-agents/src/pipeline/policy-engine.test.ts
@@ -191,21 +191,32 @@ describe('PolicyEngine', () => {
       }
     });
 
-    it('allows when trustTier is missing (the typed-snapshot default — see #2932)', () => {
-      // The typed PipelineStateSnapshot makes `trustTier?: string` —
-      // upstream extractors (v2-delegate's toPipelineStateSnapshot) drop
-      // non-string producer values, so the rule never sees garbage. When
-      // the field is absent the rule fails open (same as pre-#2932).
+    it('blocks execute stages when trustTier is missing (#2957/#2994 fail-closed default)', () => {
+      // Pre-#2957 a missing trustTier fell open. With the producer-side
+      // wiring landing in the same PR, callers MUST now set
+      // metadata.trustTier — anything that doesn't is treated as
+      // tier '4' (untrusted) and blocked at execute.
       const result = trustTierRule?.evaluate(
         makeContext({ stageType: 'execute', pipelineState: {} })
       );
-      expect(result?.allow).toBe(true);
+      expect(result?.allow).toBe(false);
+      if (result?.allow === false) {
+        expect(result.reason).toMatch(/Missing or invalid trustTier|untrusted/i);
+      }
     });
 
-    it('allows when trustTier is a non-numeric string', () => {
+    it('blocks execute stages when trustTier is a non-numeric string', () => {
+      // Non-numeric string fails Number.isFinite; defaults to 4 just like missing.
       const result = trustTierRule?.evaluate(
         makeContext({ stageType: 'execute', pipelineState: { trustTier: 'abc' } })
       );
+      expect(result?.allow).toBe(false);
+    });
+
+    it('still allows non-execute stages when trustTier is missing', () => {
+      // The default-to-untrusted only blocks `execute`; planning / analysis
+      // stages continue to allow so the pipeline can reach the boundary.
+      const result = trustTierRule?.evaluate(makeContext({ stageType: 'plan', pipelineState: {} }));
       expect(result?.allow).toBe(true);
     });
   });

--- a/packages/nexus-agents/src/pipeline/policy-engine.ts
+++ b/packages/nexus-agents/src/pipeline/policy-engine.ts
@@ -156,13 +156,27 @@ const trustTierRule: PolicyRule = {
   id: 'trust-tier',
   priority: 100,
   evaluate(context): PolicyDecision {
+    // Closes #2994 (with producer-side wiring from #2957):
+    // pre-fix, a missing or non-numeric pipelineState.trustTier was
+    // tolerated via "tier === undefined → allow", so any V2 pipeline path
+    // whose producer forgot to write trustTier silently bypassed this —
+    // the only built-in policy rule. Now: missing / invalid trustTier
+    // defaults to 4 (untrusted), so the gate fails closed.
+    //
+    // Producers must write `metadata.trustTier` (a TrustTier string
+    // '1'..'4') onto the TaskContract. The two current producers wire it
+    // through `orchestrateInputToTaskContract` and
+    // `delegateInputToTaskContract`'s `opts.trustTier`.
     const tierVal = context.pipelineState.trustTier;
     const numericTier = tierVal === undefined ? Number.NaN : Number(tierVal);
-    const tier = Number.isFinite(numericTier) ? numericTier : undefined;
-    if (tier !== undefined && tier >= 3 && context.stageType === 'execute') {
+    const tier = Number.isFinite(numericTier) ? numericTier : 4;
+    if (tier >= 3 && context.stageType === 'execute') {
       return {
         allow: false,
-        reason: 'Untrusted input cannot trigger execute stages',
+        reason:
+          tierVal === undefined || !Number.isFinite(numericTier)
+            ? `Missing or invalid trustTier on pipeline state; defaulting to untrusted (4). Producer must set TaskContract.metadata.trustTier (#2957).`
+            : 'Untrusted input cannot trigger execute stages',
         escalateTo: 'user',
       };
     }

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -82,11 +82,20 @@ export interface PipelineMetrics {
   readonly policyViolations?: readonly string[];
 }
 
+/** Optional contract-construction options (#2957). */
+export interface DelegateContractOpts {
+  /** Caller trust tier from RequestContext (`'1'..'4'`). */
+  readonly trustTier?: string;
+}
+
 /**
  * Converts delegate_to_model input into a V2 TaskContract.
  * Input fields are preserved in metadata for downstream pipeline stages.
  */
-export function delegateInputToTaskContract(input: DelegateInputLike): TaskContract {
+export function delegateInputToTaskContract(
+  input: DelegateInputLike,
+  opts: DelegateContractOpts = {}
+): TaskContract {
   const metadata: Record<string, unknown> = { source: 'delegate_to_model' };
   if (input.preferred_capability !== undefined) {
     metadata['preferredCapability'] = input.preferred_capability;
@@ -97,6 +106,11 @@ export function delegateInputToTaskContract(input: DelegateInputLike): TaskContr
   if (input.billing_mode !== undefined) {
     metadata['billingMode'] = input.billing_mode;
   }
+  // Closes #2957: producer-side wiring of caller trust tier. With this in
+  // place the V2 policy-engine's `trust-tier` rule actually gates the V2
+  // delegate pipeline; missing trustTier defaults to '4' (untrusted) in
+  // policy-engine.ts so the gate fails closed.
+  if (opts.trustTier !== undefined) metadata['trustTier'] = opts.trustTier;
   // estimate_tokens flag removed (#2723) — was never read downstream.
   return buildBaseTaskContract({
     idPrefix: 'delegate',

--- a/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
@@ -36,11 +36,25 @@ export interface OrchestrateInputLike {
 // Conversion
 // ============================================================================
 
+/** Optional contract-construction options (#2957). */
+export interface OrchestrateContractOpts {
+  /** Caller trust tier from RequestContext (`'1'..'4'`). */
+  readonly trustTier?: string;
+}
+
 /** Converts orchestrate input to a TaskContract. */
-export function orchestrateInputToTaskContract(input: OrchestrateInputLike): TaskContract {
+export function orchestrateInputToTaskContract(
+  input: OrchestrateInputLike,
+  opts: OrchestrateContractOpts = {}
+): TaskContract {
   const metadata: Record<string, unknown> = { source: 'orchestrate' };
   if (input.context !== undefined) metadata['context'] = input.context;
   if (input.maxIterations !== undefined) metadata['maxIterations'] = input.maxIterations;
+  // Closes #2957: producer-side wiring of caller trust tier so the V2
+  // policy-engine's `trust-tier` rule has the input it needs. Callers
+  // thread `ctx.requestContext.trustTier` here; when omitted the
+  // policy-engine defaults to `'4'` (untrusted) so the gate fails closed.
+  if (opts.trustTier !== undefined) metadata['trustTier'] = opts.trustTier;
   return buildBaseTaskContract({
     idPrefix: 'orchestrate',
     task: input.task,


### PR DESCRIPTION
## Summary

Three coupled security gaps converged on one missing wire — the caller's trust tier never reached the gates that needed it. This PR plumbs the value through producers, callers, and gates.

| Site | Before | After |
|---|---|---|
| \`v2-orchestrate.ts:orchestrateInputToTaskContract\` | never wrote \`metadata.trustTier\` | accepts \`opts.trustTier\`, writes when provided |
| \`v2-delegate.ts:delegateInputToTaskContract\` | never wrote \`metadata.trustTier\` | accepts \`opts.trustTier\`, writes when provided |
| \`orchestrate.ts:createOrchestrateHandler\` | passed nothing | threads \`ctx.requestContext.trustTier\` to runOrchestratePipeline → ... → deriveOrchestratePolicy AND to instrumentV2Orchestrate → orchestrateInputToTaskContract |
| \`delegate-to-model.ts:createDelegateHandler\` | passed nothing | threads \`ctx.requestContext.trustTier\` to instrumentV2Pipeline → delegateInputToTaskContract |
| \`execute-expert.ts:deriveExpertAccessPolicy\` | hardcoded \`'1'\` | takes trustTier param, defaults to \`'4'\` (untrusted) when undefined. Call site currently passes undefined — proper wiring filed as follow-up. |
| \`orchestrate.ts:deriveOrchestratePolicy\` | hardcoded \`'1'\` | takes trustTier from threaded ctx, defaults to \`'4'\` when undefined |
| \`policy-engine.ts:trustTierRule\` | missing/invalid trustTier → allow (fail-OPEN) | missing/invalid → defaults to 4 → blocks execute (fail-CLOSED) |

## What this closes

- **#2957** — producer-side wiring (the root cause of the other two)
- **#2993** — hardcoded \`trustTier='1'\` in orchestrate + execute-expert
- **#2994** — \`delegateInputToTaskContract\` strips trustTier → policy engine defaults to allow

## Behavior change

V2 pipelines (\`NEXUS_V2_ORCHESTRATE=true\`, \`NEXUS_V2_DELEGATE=true\`) previously had **zero** policy enforcement because trustTier never reached the rule. Post-fix:
- Legitimate callers via the MCP \`orchestrate\` and \`delegate_to_model\` handlers get their real trust tier and pass through normally
- Programmatic callers that bypass \`secure-handler\` (or test fixtures that don't populate \`pipelineState.trustTier\`) block at execute stages

The hardcoded \`trustTier='1'\` removal means LLM-derived access policies may now be more restrictive for the same input under tier \`'4'\` — this matches the documented trust-classification design.

## Test plan

- [x] 137 tests pass across the 6 affected test files (policy-engine, v2-orchestrate, v2-delegate, orchestrate, execute-expert, delegate-to-model)
- [x] Updated 2 \`policy-engine.test.ts\` tests that pinned the pre-fix fail-open default to assert the new fail-closed behavior + added a non-execute-stage test
- [x] \`tsc --noEmit\` and \`eslint\` clean on all 7 source files

## Follow-up

- **Thread \`RequestContext\` through execute-expert's background task handler path** so its trustTier isn't always defaulted to \`'4'\`. Currently the MCP-native task handler at \`registerExecuteExpertTool\` doesn't have access to the secure-handler ctx.

Closes #2957. Closes #2993. Closes #2994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)