### PR TITLE
fix(pipeline): cleanup expert-bridge MCP-config tempdir on shutdown (closes #2946)

### DIFF
--- a/.changeset/2946-expert-bridge-tmpdir-cleanup.md
+++ b/.changeset/2946-expert-bridge-tmpdir-cleanup.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(pipeline):** cleanup the cached MCP-config tempdir on shutdown. Closes #2946.
+
+`expert-bridge.getMcpConfigPath` cached the path returned by `generateMcpConfig` but threw away the `cleanup` function that came with it, so the parent `mkdtemp` (`<tmpdir>/nexus-mcp-XXXXXX/`) accumulated one entry per daemon lifetime. Per-process not per-call (caching limits the blast radius), but stale tempdirs piled up across `nexus-agents --mode=server` restarts.
+
+Fix: store the cleanup alongside the cached path; expose `shutdownExpertBridge()`; wire it into `cli-server.ts:createShutdownCleanup` next to `shutdownToolMemory()`. Cleanup is idempotent, never throws (failures log + swallow).
+
+89 tests pass across the affected test files (cli-server, agent-executor, pipeline-eval-edge, research-trigger); tsc + eslint clean.

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -49,6 +49,7 @@ import { initializeSica } from './cli-server-sica.js';
 import { initializeFeedbackIntegration } from './cli-server-feedback.js';
 import { initializeAuth } from './cli-server-auth.js';
 import { shutdownToolMemory } from './mcp/tools/tool-memory.js';
+import { shutdownExpertBridge } from './pipeline/expert-bridge.js';
 import {
   initializeAuditLogger,
   shutdownAuditLogger,
@@ -228,6 +229,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Persist tool memory session to disk (Issue #690)
     shutdownToolMemory();
+
+    // Cleanup the cached MCP-config tempdir (closes #2946)
+    await shutdownExpertBridge();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/pipeline/expert-bridge.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.ts
@@ -74,6 +74,12 @@ let cachedRouter: RouterLike | null = null;
 
 // Cached MCP config — generated once, reused across expert calls (#1708)
 let cachedMcpConfigPath: string | null = null;
+// Cached cleanup for the cached config's tempdir (closes #2946). Previously
+// the cleanup returned by `generateMcpConfig` was thrown away, so
+// `/tmp/nexus-mcp-XXXXXX/` accumulated one entry per MCP server lifetime.
+// Stored here + invoked by `shutdownExpertBridge()` from the server's
+// graceful-shutdown path.
+let cachedMcpConfigCleanup: (() => Promise<void>) | null = null;
 // Coalesces concurrent init under voter fan-out (closes #2969). consensus_vote
 // fans out N=7 callers on cold start; without this each one ran the full init
 // including a mkdtemp() that the loser N-1 instances never cleaned up.
@@ -87,6 +93,7 @@ async function getMcpConfigPath(): Promise<string | null> {
       const { generateMcpConfig } = await import('../cli-adapters/child-mcp-config.js');
       const config = await generateMcpConfig();
       cachedMcpConfigPath = config.configPath;
+      cachedMcpConfigCleanup = config.cleanup;
       return cachedMcpConfigPath;
     } catch {
       mcpConfigInitPromise = null; // allow retry on next call
@@ -94,6 +101,27 @@ async function getMcpConfigPath(): Promise<string | null> {
     }
   })();
   return mcpConfigInitPromise;
+}
+
+/**
+ * Removes the cached MCP-config tempdir (closes #2946). Invoke from the
+ * server's graceful-shutdown path so stale nexus-mcp-* tempdirs (under
+ * the OS tmpdir, see child-mcp-config.ts) don't accumulate across daemon
+ * restarts. Idempotent; safe to call multiple times. Never throws —
+ * cleanup failures are logged and swallowed.
+ */
+export async function shutdownExpertBridge(): Promise<void> {
+  const cleanup = cachedMcpConfigCleanup;
+  if (cleanup === null) return;
+  cachedMcpConfigCleanup = null;
+  cachedMcpConfigPath = null;
+  mcpConfigInitPromise = null;
+  try {
+    await cleanup();
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.debug('Expert-bridge MCP-config cleanup failed', { error: msg });
+  }
 }
 
 /** Cached circuit breaker for health monitoring (#1766). */


### PR DESCRIPTION
## Summary

\`expert-bridge.getMcpConfigPath\` cached the path returned by \`generateMcpConfig\` but threw away the \`cleanup\` function that came with it. The parent \`mkdtemp\` accumulated one entry per daemon lifetime — stale \`nexus-mcp-*\` tempdirs piled up across server restarts.

## Fix

- Store \`cleanup\` alongside the cached path in \`expert-bridge.ts\`
- Expose \`shutdownExpertBridge()\` (idempotent, never throws)
- Wire into \`cli-server.ts:createShutdownCleanup\` next to \`shutdownToolMemory()\`

## Test plan

- [x] 89 tests pass across cli-server, agent-executor, pipeline-eval-edge, research-trigger
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)