### PR TITLE
fix: 4 silent catch blocks now log the swallowed error (closes #2952)

### DIFF
--- a/.changeset/2952-silent-catch-blocks.md
+++ b/.changeset/2952-silent-catch-blocks.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** four silent `catch {}` sites now log the swallowed error. Closes #2952.
+
+Each pre-fix collapsed a real failure mode (subprocess error, DB lock, schema mismatch, import error) into a sentinel value with no log trail — operators saw degraded behavior with no way to diagnose.
+
+- `cli-adapters/factory.ts:167` — `isCliAvailable` catch dropped probe exceptions; "unavailable" gave no clue whether the binary was missing, probe timed out, or auth failed. Now the cached `message` field carries the error string. Extracted `cacheHealthCheckFailure` helper to keep the function under the complexity-10 cap.
+- `mcp/tools/consensus-vote.ts:399` — `runContrarianCheck` catch silently disabled the escalation guardrail on `executeExpert` failure, JSON parse failure, or expert-bridge import error. Now logs at `warn` with the error message; the default "no escalation" envelope is preserved.
+- `cli-adapters/composite-router-stages.ts:453, 716` — `getPerformanceDataForCategory` and `getWeatherBonusForTask` catches silently disabled the performance-floor penalty and weather bonus on OutcomeStore read failures. Empty-Map fallback is the right behavior (no data → no signal), but now the debug log gives operators a trail when something stops working.
+
+135 tests pass across the 3 affected test files; tsc + eslint clean.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -450,7 +450,15 @@ function getPerformanceDataForCategory(taskContent: string): Map<CliName, Perfor
       });
     }
     return result;
-  } catch {
+  } catch (error: unknown) {
+    // Closes #2952 (low): pre-fix the bare `catch {}` silently disabled
+    // the performance-floor penalty on OutcomeStore read failures (DB
+    // lock, schema mismatch). Log at debug — the empty Map fallback is
+    // the right behavior (no data → no penalty) but operators benefit
+    // from a trail when something stops working.
+    logger.debug('Performance-floor outcome-store read failed; skipping penalty', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return new Map();
   }
 }
@@ -705,7 +713,14 @@ function getWeatherBonusForTask(taskContent: string): Map<CliName, number> {
     const match = detectTaskCategory(taskContent);
     if (match === null) return new Map();
     return getWeatherBonusScores(match.category);
-  } catch {
+  } catch (error: unknown) {
+    // Closes #2952 (low): pre-fix the bare `catch {}` silently disabled
+    // the weather bonus on outcome-store read failures. Log at debug —
+    // empty Map is the correct fallback (no data → no bonus), but a log
+    // trail helps operators see when this silently stops working.
+    logger.debug('Weather bonus outcome-store read failed; skipping bonus', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return new Map();
   }
 }

--- a/packages/nexus-agents/src/cli-adapters/factory.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.ts
@@ -164,19 +164,31 @@ export async function isCliAvailable(cli: CliName, cache?: ICliDetectionCache): 
     }
 
     return available;
-  } catch {
-    // Store negative result in cache
-    if (cache !== undefined) {
-      cache.set(cli, {
-        healthy: false,
-        version: 'unknown',
-        versionStatus: 'unsupported',
-        checkedAt: new Date(getTimeProvider().now()),
-        message: 'Health check failed',
-      });
-    }
+  } catch (error: unknown) {
+    // Closes #2952 (medium): pre-fix the bare `catch {}` dropped the error
+    // entirely — operators saw `<cli>: unavailable` with no way to tell
+    // whether the binary was missing, the probe timed out, or some other
+    // failure occurred. Now include the message in the cached entry.
+    cacheHealthCheckFailure(cache, cli, error);
     return false;
   }
+}
+
+/** Records a health-check exception in the cache with the error message preserved. */
+function cacheHealthCheckFailure(
+  cache: ICliDetectionCache | undefined,
+  cli: CliName,
+  error: unknown
+): void {
+  if (cache === undefined) return;
+  const message = error instanceof Error ? error.message : String(error);
+  cache.set(cli, {
+    healthy: false,
+    version: 'unknown',
+    versionStatus: 'unsupported',
+    checkedAt: new Date(getTimeProvider().now()),
+    message: `Health check failed: ${message}`,
+  });
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -396,7 +396,15 @@ async function runContrarianCheck(
     }
 
     return { shouldEscalate: false, reason: '', confidence };
-  } catch {
+  } catch (error: unknown) {
+    // Closes #2952 (medium): pre-fix the bare `catch {}` swallowed
+    // `executeExpert` failures, JSON parse errors, and expert-bridge
+    // import errors identically — the escalation guardrail silently
+    // disabled itself with no log trail. Log + return the default
+    // "no escalation" envelope so a contrarian-check infrastructure
+    // bug is at least visible in operator logs.
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn('Contrarian check failed; defaulting to no escalation', { error: message });
     return { shouldEscalate: false, reason: '', confidence: 0 };
   }
 }


### PR DESCRIPTION
## Summary

Four \`catch {}\` sites that swallowed errors silently, all collapsing real failure modes (subprocess error, DB lock, schema mismatch, import error) into a sentinel value with no log trail.

| File | Fix |
|---|---|
| \`cli-adapters/factory.ts:167\` | \`isCliAvailable\` — cached \`message\` now carries the error string. Extracted helper to satisfy complexity-10 cap. |
| \`mcp/tools/consensus-vote.ts:399\` | \`runContrarianCheck\` — warn-log the failure; preserve the default "no escalation" envelope so call-site behavior is unchanged. |
| \`cli-adapters/composite-router-stages.ts:453\` | \`getPerformanceDataForCategory\` — debug-log the outcome-store read failure; empty-Map fallback preserved. |
| \`cli-adapters/composite-router-stages.ts:716\` | \`getWeatherBonusForTask\` — same pattern. |

## Test plan

- [x] 135 tests pass across the 3 affected test files (factory, consensus-vote, composite-router-stages)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)