### PR TITLE
fix(logging): 3 hygiene issues from #2963 (secret leaks + sessionId)

### DIFF
--- a/.changeset/2963-logging-hygiene.md
+++ b/.changeset/2963-logging-hygiene.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(logging):** three of four hygiene issues from #2963. Site 3 (subprocess-adapter taskId correlation) deferred — requires `CliTask` shape change.
+
+- **Site 1 (MEDIUM) — `cli/hooks/handlers/session-end.ts:134`.** `logger.debug('Session metrics', metrics)` was leaking `metrics.tasks[].task`, which is the raw user-task prompt string. A user pasting `"deploy with API_KEY=sk-…"` would land their key in debug logs. Added `summarizeMetricsForDebug()` that emits only `id`, `status`, `durationMs`, `tokensUsed` per task — the load-bearing observables. Full metrics still written to the operator-requested `--export` file (no behavior change there).
+- **Site 2 (MEDIUM) — `cli/hooks/handlers/pre-tool.ts:122`.** `logger.info('Sensitive file access', { filePath, warning })` was emitting at always-on `info` for every `Edit`/`Write` touching `.env`/`id_rsa`/AWS-cred paths — aggregated in log services this built a map of where secrets live. Dropped to `debug`; added `toolUseId` correlation field already present in the sibling `validateBashTool` call.
+- **Site 4 (LOW) — `pipeline/dev-pipeline.ts:567,572,575`.** The plan-iteration loop's "Plan approved" / "Plan rejected, iterating" / "Max vote iterations reached" lines lacked the `sessionId` that's in scope at the caller. Threaded `sessionId` through `runPlanOrResume` → `planVoteLoop` so plan-loop post-mortems can correlate to checkpointed sessions on disk.
+
+53 tests pass across the 3 affected test files; tsc + eslint clean.

--- a/packages/nexus-agents/src/cli/hooks/handlers/pre-tool.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/pre-tool.ts
@@ -119,7 +119,16 @@ function logSensitiveFileAccess(input: PreToolUseInput): void {
   const warning = checkSensitiveFile(filePath);
 
   if (warning !== null) {
-    logger.info('Sensitive file access', { filePath, warning });
+    // Closes #2963 site 2: pre-fix this emitted at `info` (always-on)
+    // with the full path of every .env/.ssh/AWS-cred touch — aggregated
+    // in log services it built a map of where secrets live. Dropped to
+    // `debug`; added `toolUseId` correlation field present in the
+    // sibling `validateBashTool` call.
+    logger.debug('Sensitive file access', {
+      filePath,
+      warning,
+      toolUseId: input.tool_use_id,
+    });
   }
 }
 

--- a/packages/nexus-agents/src/cli/hooks/handlers/session-end.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/session-end.ts
@@ -131,11 +131,42 @@ async function exportSessionMetrics(
       await writeFile(exportPath, JSON.stringify(metrics, null, 2));
       logger.info('Metrics exported', { path: exportPath });
     } else {
-      logger.debug('Session metrics', metrics);
+      // Closes #2963 site 1: pre-fix `metrics.tasks[].task` is the raw
+      // user-task prompt. A user pasting `"deploy with API_KEY=sk-…"`
+      // would land their key in debug logs (many ops setups capture
+      // debug in staging/dev). Redact to summary fields only.
+      logger.debug('Session metrics', summarizeMetricsForDebug(metrics));
     }
   } catch (error) {
     logger.error('Failed to export metrics', new Error(getErrorMessage(error)));
   }
+}
+
+/**
+ * Strips potentially sensitive fields from the metrics object for debug
+ * logging (#2963 site 1). The full `metrics` is still written to the
+ * operator-requested export file; this is just for the always-on log
+ * stream.
+ */
+function summarizeMetricsForDebug(metrics: Record<string, unknown>): Record<string, unknown> {
+  const tasks = Array.isArray(metrics['tasks']) ? metrics['tasks'] : [];
+  return {
+    sessionId: metrics['sessionId'],
+    createdAt: metrics['createdAt'],
+    updatedAt: metrics['updatedAt'],
+    status: metrics['status'],
+    taskCount: metrics['taskCount'],
+    tasks: tasks.map((t: unknown) => {
+      const obj = (t ?? {}) as Record<string, unknown>;
+      return {
+        id: obj['id'],
+        status: obj['status'],
+        durationMs: obj['durationMs'],
+        tokensUsed: obj['tokensUsed'],
+        // `task` field deliberately omitted — user prompts may contain secrets.
+      };
+    }),
+  };
 }
 
 /** Builds the metrics export object. */

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -378,7 +378,7 @@ async function runPlanningPhase(
   );
   if (sid !== undefined) saveStageCheckpoint(sid, 'research', { type: 'research', text: research });
 
-  const planResult = await runPlanOrResume(prior, task, research, stages);
+  const planResult = await runPlanOrResume(prior, task, research, stages, sid);
   if (sid !== undefined) {
     saveStageCheckpoint(sid, 'plan', {
       type: 'plan',
@@ -470,7 +470,8 @@ async function runPlanOrResume(
   prior: PipelineCheckpointState | null,
   task: string,
   research: string,
-  stages: DevPipelineStages
+  stages: DevPipelineStages,
+  sessionId: string | undefined
 ): Promise<{
   plan: string;
   iterations: number;
@@ -479,7 +480,7 @@ async function runPlanOrResume(
   caveats: readonly string[];
 }> {
   if (prior?.plan !== undefined) {
-    logger.info('Resuming from checkpoint', { stage: 'plan' });
+    logger.info('Resuming from checkpoint', { stage: 'plan', sessionId });
     return {
       plan: prior.plan,
       iterations: prior.voteIterations ?? 0,
@@ -488,7 +489,7 @@ async function runPlanOrResume(
       caveats: prior.voteCaveats ?? [],
     };
   }
-  return planVoteLoop(task, research, stages);
+  return planVoteLoop(task, research, stages, sessionId);
 }
 
 /** Conditional vote metadata for task annotation. */
@@ -542,7 +543,8 @@ function extractConditionalMeta(vote: VoteResult): ConditionalMeta {
 async function planVoteLoop(
   task: string,
   research: string,
-  stages: DevPipelineStages
+  stages: DevPipelineStages,
+  sessionId: string | undefined
 ): Promise<{ plan: string; iterations: number } & ConditionalMeta> {
   let feedback: string | undefined;
   let plan = '';
@@ -564,17 +566,30 @@ async function planVoteLoop(
       }
     );
 
+    // Closes #2963 site 4: include sessionId so plan-loop post-mortems
+    // can correlate to checkpointed sessions on disk. The variable
+    // was already in scope at the caller (#dev-pipeline runDevPipeline);
+    // threaded through runPlanOrResume → planVoteLoop here.
     if (isApproved(vote)) {
       const meta = extractConditionalMeta(vote);
-      logger.info('Plan approved', { iteration: i, approval: vote.approvalPercentage, ...meta });
+      logger.info('Plan approved', {
+        iteration: i,
+        approval: vote.approvalPercentage,
+        sessionId,
+        ...meta,
+      });
       return { plan, iterations: i, ...meta };
     }
 
     feedback = getVoteFeedback(vote);
-    logger.warn('Plan rejected, iterating', { iteration: i, feedback: feedback.slice(0, 200) });
+    logger.warn('Plan rejected, iterating', {
+      iteration: i,
+      feedback: feedback.slice(0, 200),
+      sessionId,
+    });
   }
 
-  logger.warn('Max vote iterations reached, proceeding with last plan');
+  logger.warn('Max vote iterations reached, proceeding with last plan', { sessionId });
   return { plan, iterations: MAX_VOTE_ITERATIONS, conditional: false, conditions: [], caveats: [] };
 }
 


### PR DESCRIPTION
## Summary

Three of four sites from #2963. Site 3 (subprocess-adapter taskId correlation) is deferred — requires \`CliTask\` shape change across many callers.

| Site | Severity | File | Fix |
|---|---|---|---|
| 1 | MEDIUM | \`cli/hooks/handlers/session-end.ts\` | Debug log was leaking raw user prompts (\`metrics.tasks[].task\`). Added \`summarizeMetricsForDebug()\` that omits the prompt field; full metrics still written to \`--export\` file. |
| 2 | MEDIUM | \`cli/hooks/handlers/pre-tool.ts\` | Sensitive-file path emitted at always-on \`info\` for every Edit/Write — aggregated in log services this built a map of where secrets live. Dropped to \`debug\`; added \`toolUseId\` correlation field. |
| 4 | LOW | \`pipeline/dev-pipeline.ts\` | Plan-loop log lines (Plan approved / rejected / max iterations) lacked \`sessionId\` for correlation. Threaded through \`runPlanOrResume\` → \`planVoteLoop\`. |

## Test plan

- [x] 53 tests pass across the 3 affected test files (session-end, pre-tool, dev-pipeline)
- [x] \`tsc --noEmit\` and \`eslint\` clean

Partial fix for #2963. Site 3 (subprocess-adapter timing log lacks taskId/requestId correlation) deferred to follow-up because \`CliTask\` needs an optional \`taskId\` field threaded through multiple callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)