### PR TITLE
fix(adapters): proxy-wrap fallback so future T methods aren't dropped (closes #2945)

### DIFF
--- a/.changeset/2945-model-not-found-fallback-typesafe.md
+++ b/.changeset/2945-model-not-found-fallback-typesafe.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**fix(adapters):** `withModelNotFoundFallbackResilient` no longer silently drops future methods on `T`. Closes #2945.
+
+Pre-fix `Object.assign(wrapped, { 5 bound methods }) as unknown as T` silently dropped any methods on a concrete `T` (e.g. a future `IResilientAdapter` subtype with `getMetrics()`) beyond the 5 explicitly re-attached. The type system claimed they were present; callers hit `TypeError: x.getMetrics is not a function` at runtime.
+
+Fix: wrap the explicit-binding object in a `Proxy` that forwards unknown property access to `inner`. The five explicit bindings are kept so existing health/lifecycle methods are pre-bound (avoids losing `this` if the caller destructures), matching prior semantics for the existing surface. New methods on `T` are now transparently available without the wrapper needing to know about them.
+
+19 tests pass against the new implementation; tsc + eslint clean.

--- a/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
+++ b/packages/nexus-agents/src/adapters/model-not-found-fallback.ts
@@ -373,13 +373,37 @@ export function wrapResilientWithFallback<T extends ResilientLike>(
   options: ModelNotFoundFallbackOptions = {}
 ): T {
   const wrapped = withModelNotFoundFallback(inner, options);
-  // Object.assign re-attaches the resilient-specific methods bound to
-  // the original adapter so health/lifecycle behaviour is unchanged.
-  return Object.assign(wrapped, {
+  // Closes #2945: pre-fix the `Object.assign(..., {5 methods}) as unknown as T`
+  // pattern silently dropped any methods on a concrete T beyond the 5
+  // explicitly re-attached. A future IResilientAdapter subtype adding
+  // `getMetrics()` would type-check but throw `TypeError: x.getMetrics
+  // is not a function` at runtime. Switched to a Proxy that forwards
+  // unknown property access to `inner`, so methods on T not anticipated
+  // by this wrapper remain transparently available.
+  //
+  // The five explicit bindings are kept so existing health/lifecycle
+  // methods are pre-bound (avoids losing `this` if the caller
+  // destructures), matching the prior semantics for the existing surface.
+  const surface = {
     getHealth: inner.getHealth.bind(inner),
     refresh: inner.refresh.bind(inner),
     setPreferredCli: inner.setPreferredCli.bind(inner),
     onFailover: inner.onFailover.bind(inner),
     dispose: inner.dispose.bind(inner),
+  };
+  const explicit: ResilientLike = Object.assign(wrapped, surface);
+  const innerAsRecord = inner as unknown as Record<PropertyKey, unknown>;
+  return new Proxy(explicit, {
+    get(target, prop, receiver): unknown {
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      // Forward unknown reads to `inner` — covers future methods on T.
+      // Bind functions so call-site `this` is the inner adapter, matching
+      // the explicit-binding behavior above.
+      const innerProp: unknown = innerAsRecord[prop];
+      if (typeof innerProp === 'function') {
+        return (innerProp as (...args: unknown[]) => unknown).bind(inner);
+      }
+      return innerProp;
+    },
   }) as unknown as T;
 }


### PR DESCRIPTION
## Summary

Pre-fix \`Object.assign(wrapped, { 5 bound methods }) as unknown as T\` silently dropped any methods on a concrete \`T\` beyond the 5 explicitly re-attached. A future \`IResilientAdapter\` subtype with \`getMetrics()\` would type-check fine, then throw \`TypeError: x.getMetrics is not a function\` at runtime.

## Fix

Wrap the explicit-binding object in a \`Proxy\` that forwards unknown property access to \`inner\`. The five explicit bindings (\`getHealth\`, \`refresh\`, \`setPreferredCli\`, \`onFailover\`, \`dispose\`) are kept so existing health/lifecycle methods are pre-bound (avoids losing \`this\` if the caller destructures). New methods on T are now transparently available.

## Test plan

- [x] 19 tests pass against the new implementation
- [x] \`tsc --noEmit\` and \`eslint\` clean

Closes #2945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)