### PR TITLE
docs(routing): update composite-router stage list — 5 → 12 actual stages (closes #2947)

### DIFF
--- a/.changeset/2947-composite-router-actual-stages.md
+++ b/.changeset/2947-composite-router-actual-stages.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+**docs(routing):** update `composite-router` @module + 2 architecture docs to list the actual pipeline stages. Closes #2947.
+
+The pre-2026 docstring claimed the pipeline was 5 stages (`Budget → ZeroRouter → Preference → TOPSIS → LinUCB`), pre-dating #755 / #1350 / #1686 / #1790 / #2414. The real pipeline `composite-router-stages.ts:runPipeline` has ~12 stages, including two that can **short-circuit** routing (`QualityConstraint`, `CategoryOverride`). A maintainer debugging "why was my model rejected?" reading the old 5-stage line would never find them.
+
+Updated:
+
+- `cli-adapters/composite-router.ts` module docstring — full 8-step ordered list with short-circuit notes
+- `docs/architecture/ROUTING_SYSTEM.md` overview diagram — full pipeline + the same short-circuit callout
+- `docs/design/components.md` CompositeRouter line — full stage list + link to `ROUTING_SYSTEM.md` for rationale
+
+Docs-only change; 68 routing tests pass unchanged.

--- a/docs/architecture/ROUTING_SYSTEM.md
+++ b/docs/architecture/ROUTING_SYSTEM.md
@@ -21,12 +21,28 @@ related_files:
 
 ## Overview
 
-The routing system intelligently selects the optimal CLI/model for each task through a multi-stage pipeline:
+The routing system intelligently selects the optimal CLI/model for each task through a multi-stage pipeline. The full executed order in `composite-router-stages.ts:runPipeline` is:
 
 ```
-Task → BudgetRouter → ZeroRouter → PreferenceRouter → TopsisRouter → LinUCB → Selected Model
-       (filter)        (fallback)   (preference)        (rank)         (learn)
+Task
+  → Budget                              (filter — eliminate over-budget CLIs)
+  → Scoring (parallel)                  (ConfidenceCascade, CapabilityMatch,
+                                         KnnRouting, DistilledRule,
+                                         ResourceStrategy, ZeroRouter, Preference)
+  → QualityConstraint                   (constraint-first; can short-circuit, #1686)
+  → CategoryOverride                    (CATEGORY_CHAIN_OVERRIDES per category;
+                                         can short-circuit on sensitive cats,
+                                         #2414/#2417)
+  → TOPSIS                              (rank, with stage-score-adjusted profiles
+                                         and performance-floor penalties, #1354/#1401)
+  → LinUCB                              (bandit selection from ranked candidates)
+  → PerfFloorOverride                   (reject LinUCB pick if CLI < 50% success at
+                                         ≥20 samples; promote TOPSIS top, #1790)
+  → Latency                             (record per-CLI latency for feedback loop)
+  → Selected Model
 ```
+
+The simpler legacy "Budget → ZeroRouter → Preference → TOPSIS → LinUCB" 5-stage diagram pre-dated #755/#1350/#2414. The constraint and category-override stages **can short-circuit** routing without ever reaching TOPSIS — omitting them gives the wrong mental model when debugging "why was my model rejected?" (#2947).
 
 Use `CompositeRouter.route(task)` — do NOT directly instantiate stage routers.
 

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -132,7 +132,7 @@ CLI subprocess adapters and the canonical routing pipeline.
 
 - **CLI Adapters**: ClaudeCliAdapter, GeminiCliAdapter, CodexCliAdapter, CodexMcpAdapter — invoke CLI tools as subprocesses
 - **Adapter Factory** (`cli-adapters/factory.ts`): `createAllAdapters()` — detects available CLIs
-- **CompositeRouter** (`cli-adapters/composite-router.ts`, Issue #166): Canonical routing pipeline. Stages: BudgetRouter -> ZeroRouter -> PreferenceRouter -> TopsisRouter -> LinUCB
+- **CompositeRouter** (`cli-adapters/composite-router.ts`, Issue #166): Canonical routing pipeline. Stages: Budget → Scoring (parallel: ConfidenceCascade, CapabilityMatch, KnnRouting, DistilledRule, ResourceStrategy, ZeroRouter, Preference) → QualityConstraint → CategoryOverride → TOPSIS → LinUCB → PerfFloorOverride → Latency. See [ROUTING_SYSTEM.md](../architecture/ROUTING_SYSTEM.md) for the full per-stage rationale; updated in #2947.
 - **Circuit Breaker** (`cli-adapters/circuit-breaker.ts`, Issue #359): Per-adapter circuit breakers with registry
 - **Response Cache** (`cli-adapters/response-cache.ts`, Issue #358): LRU caching for identical requests
 - **Capacity Tracker** (`cli-adapters/capacity-tracker.ts`, Issue #456): Real rate limit tracking

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -1,6 +1,28 @@
 /* eslint-disable max-lines */
 /**
- * CompositeRouter: Chains Budget -> ZeroRouter -> Preference -> TOPSIS -> LinUCB.
+ * CompositeRouter — chains the full routing pipeline.
+ *
+ * Stage order (executed by `composite-router-stages.ts:runPipeline`):
+ *   1. Budget — eliminate CLIs that exceed session token/cost budget
+ *   2. Scoring (parallel) — ConfidenceCascade / CapabilityMatch / KnnRouting /
+ *      DistilledRule / ResourceStrategy / ZeroRouter / Preference
+ *   3. QualityConstraint — constraint-first filter; can short-circuit (#1686)
+ *   4. CategoryOverride — `CATEGORY_CHAIN_OVERRIDES` per task category; can
+ *      short-circuit for sensitive categories whose override chain is
+ *      exhausted (#2414, #2417)
+ *   5. TOPSIS — multi-criteria ranking; quality profiles adjusted by stage-2
+ *      scores and penalized by performance-floor data (#1354, #1401)
+ *   6. LinUCB — bandit selection from TOPSIS ranking
+ *   7. PerfFloorOverride — reject LinUCB pick if CLI is below 50% success at
+ *      ≥20 samples; promote TOPSIS top-ranked alternative (#1790)
+ *   8. Latency — record per-CLI latency for the recommended-mapping feedback loop
+ *
+ * The pre-2026 docstring claimed 5 stages (Budget → ZeroRouter → Preference →
+ * TOPSIS → LinUCB), pre-dating #755 / #1350 / #1686 / #1790 / #2414. A
+ * maintainer debugging "why was my model rejected?" reading that line would
+ * never have found the constraint/override stages that actually short-circuit.
+ * Updated in #2947.
+ *
  * @module cli-adapters/composite-router
  * (Source: Issue #166, Epic #164, Issue #347, arXiv:2509.07571)
  */


### PR DESCRIPTION
## Summary

The pre-2026 docstring claimed \`Budget → ZeroRouter → Preference → TOPSIS → LinUCB\` (5 stages), pre-dating #755 / #1350 / #1686 / #1790 / #2414. The real pipeline has ~12 stages, including two that can **short-circuit** routing without ever reaching TOPSIS (\`QualityConstraint\`, \`CategoryOverride\`).

## Updated

- \`packages/nexus-agents/src/cli-adapters/composite-router.ts\` module docstring — full 8-step ordered list with short-circuit notes
- \`docs/architecture/ROUTING_SYSTEM.md\` overview diagram — full pipeline + the same short-circuit callout
- \`docs/design/components.md\` CompositeRouter line — full stage list + link to ROUTING_SYSTEM.md

## Test plan

- [x] Docs-only change; 68 routing tests pass unchanged

Closes #2947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)