### PR TITLE
fix(catalog): add init to COMMAND_CATALOG (closes #2936)

### DIFF
--- a/.changeset/2936-init-in-command-catalog.md
+++ b/.changeset/2936-init-in-command-catalog.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**fix(catalog):** add `init` to `COMMAND_CATALOG` so it appears in `nexus-agents --help`.
+
+`init` is a real CLI command — in the `CliCommand` type union, in `VALID_COMMANDS`, and dispatched via `ASYNC_COMMAND_HANDLERS` — but it had no entry in `COMMAND_CATALOG`, so `nexus-agents --help` and `nexus-agents --help --all` both omitted it and the catalog-driven extractors (`repo-index` + `entrypoints.yaml`) under-reported the command surface. Added an `advanced`-audience entry covering the `--portable`/`--install`/`--uninstall`/`--mcp-config`/`--opencode` flag set introduced across #2305 / #2308 / #2311 / #2504. Closes #2936.

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -171,6 +171,12 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     audience: 'advanced',
   },
   {
+    command: 'init',
+    description:
+      'Initialize portable nexus-agents config in a repo. Flags: --portable (#2305/#2308/#2311), --install / --uninstall (#2311), --gitignore, --mcp-config, --opencode <path> (#2504), --force, --dry-run.',
+    audience: 'advanced',
+  },
+  {
     command: 'review',
     description: 'Review a GitHub PR (dogfooding helper)',
     audience: 'advanced',


### PR DESCRIPTION
## Summary

`init` is a real CLI command — present in the `CliCommand` type union, `VALID_COMMANDS`, and dispatched via `ASYNC_COMMAND_HANDLERS` — but it had no entry in `COMMAND_CATALOG`. As a result, `nexus-agents --help` and `nexus-agents --help --all` both omitted it entirely, and the catalog-driven extractors (`artifacts/repo-index.json`, `entrypoints.yaml`) under-reported the command surface.

Added an `advanced`-audience entry covering the `--portable` / `--install` / `--uninstall` / `--mcp-config` / `--opencode` flag set introduced across #2305, #2308, #2311, and #2504.

## Test plan

- [x] `pnpm vitest run src/cli-command-catalog.test.ts` → 19 pass (existing duplicate-name and audience-coverage invariants still hold).
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm eslint src/cli-command-catalog.ts` clean.
- [ ] CI: full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)