### PR TITLE
refactor(types): drop as-unknown-as cast on OrchestratorFactoryConfig.techLead (closes #2944)

### DIFF
--- a/.changeset/2944-orchestrator-agent-types.md
+++ b/.changeset/2944-orchestrator-agent-types.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**refactor(types):** drop the `as unknown as` cast around `OrchestratorFactoryConfig.techLead`.
+
+`cli-server-tools.ts:createOrchestratorForOrchestration` cast a real `Orchestrator` instance to `{ execute: (task: unknown) => Promise<Result<unknown, unknown>> }` because `OrchestratorFactoryConfig.techLead` and `orchestratorAgent` had that wide shape. The cast hid two type-safety regressions:
+
+- **Input widening to `unknown`** — if any caller ever wired a non-`Task` value into the factory, `BaseAgent.execute` would surface opaque Zod/structural failures from inside the agent instead of a compile-time error.
+- **Error erasure** — discriminating `AgentError` codes at catch sites was impossible because the surfaced error type was `unknown`.
+
+Introduced `OrchestratorAgentLike = { execute(task: Task): Promise<Result<unknown, unknown>> }` (exported from `orchestrator-adapters.ts` — the same module that already used this exact shape internally on `OrchestratorAdapter.setOrchestrator`). Used it for both `techLead` and `orchestratorAgent` config fields. `puppeteerOrchestrator` stays `{ execute(task: unknown) => ... }` — Puppeteer takes arbitrary policy-shaped tasks, not the core `Task` type. `Result<TaskResult, AgentError>` → `Result<unknown, unknown>` is sound by covariance; kept the error wide because `orchestrator-adapters.test.ts` covers `err('string-error')` (non-`Error` failures the adapter is intentionally resilient to).
+
+The cast and the now-unused `Result` import in `cli-server-tools.ts` are gone. Closes #2944.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -59,7 +59,7 @@ import { registerPipelineTool } from './mcp/tools/pipeline-tool.js';
 
 import type { Expert } from './agents/index.js';
 import { createRealWorkflowEngine } from './workflows/index.js';
-import type { IModelAdapter, Result, WorkflowDefinition } from './core/index.js';
+import type { IModelAdapter, WorkflowDefinition } from './core/index.js';
 import { getErrorMessage, NexusError, ErrorCode } from './core/index.js';
 
 import { Orchestrator } from './agents/index.js';
@@ -168,11 +168,12 @@ function createOrchestratorForOrchestration(
 ): IOrchestrator {
   if (modelAdapter !== undefined) {
     const orchestratorAgent = new Orchestrator({ adapter: modelAdapter, logger });
+    // Cast removed in #2944 — `OrchestratorFactoryConfig.techLead` is now
+    // `OrchestratorAgentLike`, which `Orchestrator.execute(task: Task)`
+    // satisfies directly via Result-covariance.
     const factory = new OrchestratorFactory({
       logger,
-      techLead: orchestratorAgent as unknown as {
-        execute: (task: unknown) => Promise<Result<unknown, unknown>>;
-      },
+      techLead: orchestratorAgent,
     });
     return factory.create('orchestrator');
   }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -218,8 +218,8 @@ function createMockTaskExecutor(): ITechLead {
 /** Creates a mock orchestrator for testing (Issue #595). */
 export function createMockOrchestrator(): IOrchestrator {
   const mockExecutor = createMockTaskExecutor();
-  const factory = new OrchestratorFactory({
-    techLead: mockExecutor as { execute: (task: unknown) => Promise<Result<unknown, unknown>> },
-  });
+  // Cast no longer needed (#2944) — factory `techLead` is now
+  // `OrchestratorAgentLike`, which `ITechLead` satisfies by covariance.
+  const factory = new OrchestratorFactory({ techLead: mockExecutor });
   return factory.create('orchestrator');
 }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -260,10 +260,9 @@ function createOrchestratorFromDeps(
 ): IOrchestrator {
   if (deps.orchestrator !== undefined) return deps.orchestrator;
   const techLead = createOrchestratorWithSica(logger, deps.modelAdapter);
-  const factory = new OrchestratorFactory({
-    logger,
-    techLead: techLead as { execute: (task: unknown) => Promise<Result<unknown, unknown>> },
-  });
+  // Cast no longer needed (#2944) — factory `techLead` is now
+  // `OrchestratorAgentLike`, which `ITechLead` satisfies by covariance.
+  const factory = new OrchestratorFactory({ logger, techLead });
   return factory.create(orchestratorType ?? 'orchestrator');
 }
 

--- a/packages/nexus-agents/src/orchestration/orchestrator-adapters.ts
+++ b/packages/nexus-agents/src/orchestration/orchestrator-adapters.ts
@@ -25,6 +25,18 @@ import { OrchestratorError } from '../core/types/orchestrator.js';
 // Shared utilities per ADR-0013
 import { generateHyphenId } from '../utils/id-utils.js';
 
+/**
+ * Narrow shape of an agent that the OrchestratorAdapter (and the factory
+ * config that wires one in) needs. Narrows the input to `Task` so the
+ * concrete `Orchestrator` instance can be passed without an `as unknown
+ * as` cast (#2944). Keeps the `Result` payload+error wide because the
+ * adapter is intentionally resilient to non-`AgentError` failures
+ * (see orchestrator-adapters.test.ts "fails with non-Error" coverage).
+ */
+export interface OrchestratorAgentLike {
+  execute(task: Task): Promise<Result<unknown, unknown>>;
+}
+
 // Use shared utility for ID generation
 function generateId(prefix: string): string {
   return generateHyphenId(prefix, 6);
@@ -107,13 +119,13 @@ export class OrchestratorAdapter implements IOrchestrator {
   private readonly executions = new Map<string, ExecutionStatus>();
   private readonly history: OrchestratorResult[] = [];
   private readonly logger: ILogger;
-  private agent: { execute: (task: Task) => Promise<Result<unknown, unknown>> } | null = null;
+  private agent: OrchestratorAgentLike | null = null;
 
   constructor(logger?: ILogger) {
     this.logger = logger ?? createLogger({ component: 'OrchestratorAdapter' });
   }
 
-  setOrchestrator(agent: { execute: (task: Task) => Promise<Result<unknown, unknown>> }): void {
+  setOrchestrator(agent: OrchestratorAgentLike): void {
     this.agent = agent;
   }
 

--- a/packages/nexus-agents/src/orchestration/orchestrator-factory.ts
+++ b/packages/nexus-agents/src/orchestration/orchestrator-factory.ts
@@ -35,7 +35,11 @@ import {
   createProductionWorkflowEngine,
   type WorkflowEngineFactoryConfig,
 } from '../workflows/workflow-engine-factory.js';
-import { OrchestratorAdapter, PuppeteerAdapter } from './orchestrator-adapters.js';
+import {
+  OrchestratorAdapter,
+  PuppeteerAdapter,
+  type OrchestratorAgentLike,
+} from './orchestrator-adapters.js';
 
 /** Max execution map entries before eviction of completed/cancelled entries. */
 const MAX_EXECUTION_MAP_SIZE = 200;
@@ -259,12 +263,21 @@ export interface OrchestratorFactoryConfig {
   modelAdapter?: IModelAdapter;
   /** Workflow engine config */
   workflowConfig?: WorkflowEngineFactoryConfig;
-  /** Pre-created orchestrator agent instance for orchestrator adapter */
-  techLead?: { execute: (task: unknown) => Promise<Result<unknown, unknown>> };
+  /**
+   * Pre-created orchestrator agent instance for orchestrator adapter.
+   * Narrowed from `(task: unknown)` to `OrchestratorAgentLike` so a real
+   * `Orchestrator` instance can be passed without an `as unknown as` cast
+   * (#2944). Task-input contract matches `OrchestratorAdapter.setOrchestrator`.
+   */
+  techLead?: OrchestratorAgentLike;
   /** Alias for techLead (preferred, Issue #759) */
-  orchestratorAgent?: { execute: (task: unknown) => Promise<Result<unknown, unknown>> };
-  /** Pre-created PuppeteerOrchestrator instance */
-  puppeteerOrchestrator?: { execute: (task: unknown) => Promise<Result<unknown, unknown>> };
+  orchestratorAgent?: OrchestratorAgentLike;
+  /**
+   * Pre-created PuppeteerOrchestrator instance. Input stays `unknown`
+   * because Puppeteer accepts arbitrary policy-shaped tasks, not the
+   * core `Task` type that the regular agent path requires.
+   */
+  puppeteerOrchestrator?: { execute(task: unknown): Promise<Result<unknown, unknown>> };
 }
 
 /**


### PR DESCRIPTION
## Summary

`cli-server-tools.ts:createOrchestratorForOrchestration` (line ~173) cast a real `Orchestrator` instance through `as unknown as { execute: (task: unknown) => Promise<Result<unknown, unknown>> }` because the factory config field demanded that wide shape. The cast hid two type-safety regressions:

- **Input widening** — non-`Task` values wired into the factory would only fail at runtime inside `BaseAgent.execute`, not at compile time.
- **Error erasure** — catch sites couldn't discriminate `AgentError` codes because the surfaced error type was `unknown`.

Introduced `OrchestratorAgentLike = { execute(task: Task): Promise<Result<unknown, unknown>> }`, exported from `orchestrator-adapters.ts` — the same module that already used this exact shape on `OrchestratorAdapter.setOrchestrator`. Used it for both `techLead` and `orchestratorAgent` config fields. `puppeteerOrchestrator` stays `(task: unknown)` because Puppeteer takes arbitrary policy-shaped tasks, not the core `Task` type.

`Result<TaskResult, AgentError>` is assignable to `Result<unknown, unknown>` by covariance. Kept the Result error wide because `orchestrator-adapters.test.ts` covers `err('string-error')` — the adapter is intentionally resilient to non-`Error` failures.

The cast and the now-unused `Result` import in `cli-server-tools.ts` are gone.

## Test plan

- [x] `pnpm vitest run src/orchestration/orchestrator-adapters.test.ts src/orchestration/orchestrator-factory.test.ts src/cli-server-tools.test.ts` → 83 pass.
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm eslint` on the 3 touched files clean.
- [ ] CI: full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)