### PR TITLE
fix(pipeline): activate the createFeedbackSubscriber bridge (closes #2938)

### DIFF
--- a/.changeset/2938-wire-feedback-subscriber.md
+++ b/.changeset/2938-wire-feedback-subscriber.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+**fix(pipeline):** wire the `createFeedbackSubscriber` bridge so the advertised feedback loop actually runs.
+
+`feedback-subscriber.ts`'s module docstring claimed it _"closes the feedback loop: execution → events → outcomes → routing"_ — but the only consumers were the unit test and two re-exports. No `PipelineRunner` or graph runner ever subscribed the bridge, so `EventBus` `model.called` / `stage.failed` events never reached `OutcomeStore` via this path.
+
+Added `startFeedbackSubscriber` / `shutdownFeedbackSubscriber` lifecycle wrappers around the existing `createFeedbackSubscriber` (kept that function intact for test-suite use). Wired into:
+
+- `cli-server-tools.ts:initV2PipelineSubsystems` — starts the subscription once on server init, paired with the EventBus bridge wiring.
+- `cli-server.ts:createShutdownCleanup` — releases the subscription on SIGTERM teardown (same lifecycle slot as `shutdownExpertBridge` from #2946).
+
+Both start and shutdown are idempotent. 4 new regression tests cover: subscription wires correctly, idempotency on repeated start, shutdown releases the subscription, double-shutdown does not throw. Closes #2938.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -68,6 +68,8 @@ import { runStpaSafetyAnalysis, StpaSafetyError } from './cli-server-stpa.js';
 import { getPipelinePluginRegistry } from './pipeline/core-plugins.js';
 import { getPipelineEventBus } from './pipeline/event-bus.js';
 import { createEventBusBridge } from './pipeline/event-bus-bridge.js';
+import { startFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
+import { getOutcomeStore } from './orchestration/outcomes/index.js';
 import { createDefaultPolicyEngine } from './pipeline/policy-engine.js';
 import { resolveV2Config } from './pipeline/v2-config.js';
 import { UpstreamClientManager } from './mcp/gateway/upstream-client.js';
@@ -597,11 +599,18 @@ function initV2PipelineSubsystems(logger: ILogger): void {
   const pluginRegistry = getPipelinePluginRegistry();
   const pipelineEventBus = getPipelineEventBus();
   const bridge = createEventBusBridge({ source: pipelineEventBus });
+  // Wire the EventBus → OutcomeStore feedback loop advertised by
+  // `feedback-subscriber.ts`. Pre-#2938 the module existed but nothing
+  // called it, so `model.called` / `stage.failed` events never reached
+  // OutcomeStore via this path. Cleanup runs in
+  // cli-server.ts:createShutdownCleanup via `shutdownFeedbackSubscriber()`.
+  startFeedbackSubscriber(pipelineEventBus, getOutcomeStore());
   const policyEngine = createDefaultPolicyEngine();
   const v2Config = resolveV2Config();
   logger.info('V2 Pipeline OS initialized', {
     plugins: pluginRegistry.listEnabled().length,
     bridged: bridge.forwarded(),
+    feedbackSubscriber: 'active',
     policyRules: policyEngine.listRules().length,
     v2Mode: v2Config.mode,
     policyMode: v2Config.policyMode,

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -50,6 +50,7 @@ import { initializeFeedbackIntegration } from './cli-server-feedback.js';
 import { initializeAuth } from './cli-server-auth.js';
 import { shutdownToolMemory } from './mcp/tools/tool-memory.js';
 import { shutdownExpertBridge } from './pipeline/expert-bridge.js';
+import { shutdownFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
 import {
   initializeAuditLogger,
   shutdownAuditLogger,
@@ -232,6 +233,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Cleanup the cached MCP-config tempdir (closes #2946)
     await shutdownExpertBridge();
+
+    // Release the EventBus → OutcomeStore feedback subscription (closes #2938)
+    shutdownFeedbackSubscriber();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/pipeline/feedback-subscriber.test.ts
+++ b/packages/nexus-agents/src/pipeline/feedback-subscriber.test.ts
@@ -6,7 +6,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { EventBus } from './event-bus.js';
-import { createFeedbackSubscriber } from './feedback-subscriber.js';
+import {
+  createFeedbackSubscriber,
+  startFeedbackSubscriber,
+  shutdownFeedbackSubscriber,
+} from './feedback-subscriber.js';
 import { OutcomeStore, resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import type { PipelineEvent } from './event-types.js';
 
@@ -127,5 +131,82 @@ describe('createFeedbackSubscriber', () => {
     }
 
     expect(store.size).toBe(5);
+  });
+});
+
+// Server-wide lifecycle (Issue #2938) — pre-2938, nothing ever subscribed
+// the bridge so the feedback loop the module advertised didn't exist.
+// cli-server-tools.ts:initV2PipelineSubsystems now calls
+// startFeedbackSubscriber once at server init, paired with
+// shutdownFeedbackSubscriber in cli-server.ts:createShutdownCleanup.
+describe('startFeedbackSubscriber / shutdownFeedbackSubscriber lifecycle', () => {
+  beforeEach(() => {
+    // Make sure no prior test left a subscription wired to a different bus.
+    shutdownFeedbackSubscriber();
+  });
+
+  it('wires the EventBus → OutcomeStore bridge for the process lifetime', () => {
+    startFeedbackSubscriber(bus, store);
+
+    bus.emit({
+      type: 'model.called',
+      executionId: 'exec-lifecycle',
+      cli: 'claude',
+      model: 'claude-sonnet',
+      tokensIn: 100,
+      tokensOut: 50,
+      durationMs: 100,
+      timestamp: Date.now(),
+    });
+
+    expect(store.size).toBe(1);
+    shutdownFeedbackSubscriber();
+  });
+
+  it('is idempotent — repeated start calls do not double-subscribe', () => {
+    startFeedbackSubscriber(bus, store);
+    startFeedbackSubscriber(bus, store);
+    startFeedbackSubscriber(bus, store);
+
+    bus.emit({
+      type: 'model.called',
+      executionId: 'exec-idem',
+      cli: 'gemini',
+      model: 'gemini-pro',
+      tokensIn: 100,
+      tokensOut: 50,
+      durationMs: 100,
+      timestamp: Date.now(),
+    });
+
+    // Subscribed exactly once — the event records exactly one outcome.
+    expect(store.size).toBe(1);
+    shutdownFeedbackSubscriber();
+  });
+
+  it('shutdown releases the subscription so further events are not recorded', () => {
+    startFeedbackSubscriber(bus, store);
+    shutdownFeedbackSubscriber();
+
+    bus.emit({
+      type: 'model.called',
+      executionId: 'exec-post-shutdown',
+      cli: 'codex',
+      model: 'codex-5.3',
+      tokensIn: 10,
+      tokensOut: 5,
+      durationMs: 20,
+      timestamp: Date.now(),
+    });
+
+    expect(store.size).toBe(0);
+  });
+
+  it('shutdown is idempotent — calling twice does not throw', () => {
+    startFeedbackSubscriber(bus, store);
+    expect(() => {
+      shutdownFeedbackSubscriber();
+      shutdownFeedbackSubscriber();
+    }).not.toThrow();
   });
 });

--- a/packages/nexus-agents/src/pipeline/feedback-subscriber.ts
+++ b/packages/nexus-agents/src/pipeline/feedback-subscriber.ts
@@ -26,6 +26,10 @@ const VALID_CLIS: ReadonlySet<string> = new Set<string>(CLI_NAMES);
  * Listens for `model.called` and `stage.failed` events and records
  * them as TaskOutcome entries in the OutcomeStore.
  *
+ * Returns an Unsubscribe handle for callers that manage their own
+ * subscription lifecycle (e.g. tests). For the server-wide singleton
+ * subscription, use `startFeedbackSubscriber` / `shutdownFeedbackSubscriber`.
+ *
  * @returns Unsubscribe function to stop the bridge.
  */
 export function createFeedbackSubscriber(bus: IEventBus, store: OutcomeStore): Unsubscribe {
@@ -37,6 +41,46 @@ export function createFeedbackSubscriber(bus: IEventBus, store: OutcomeStore): U
       logger.warn('Feedback subscriber error', { error: msg });
     }
   });
+}
+
+// ============================================================================
+// Server-wide lifecycle (Issue #2938)
+//
+// The "feedback loop: execution → events → outcomes → routing" advertised
+// in the module docstring requires *someone* to subscribe the bridge once
+// at server init and unsubscribe at shutdown. Pre-#2938 nothing wired the
+// subscription so the loop never ran. cli-server-tools.ts now calls
+// startFeedbackSubscriber() inside `initV2PipelineSubsystems`, paired
+// with shutdownFeedbackSubscriber() in cli-server.ts:createShutdownCleanup
+// (same lifecycle slot as `shutdownExpertBridge` from #2946).
+// ============================================================================
+
+let cachedFeedbackUnsubscribe: Unsubscribe | null = null;
+
+/**
+ * Wire the EventBus → OutcomeStore bridge for the process lifetime.
+ *
+ * Idempotent — repeated calls are no-ops, so the test-suite and cli-server
+ * paths can both call it safely. Caller must invoke
+ * `shutdownFeedbackSubscriber()` on server shutdown to release the
+ * subscription.
+ */
+export function startFeedbackSubscriber(bus: IEventBus, store: OutcomeStore): void {
+  if (cachedFeedbackUnsubscribe !== null) return;
+  cachedFeedbackUnsubscribe = createFeedbackSubscriber(bus, store);
+}
+
+/**
+ * Release the server-wide feedback subscription. Idempotent.
+ *
+ * Called from cli-server.ts:createShutdownCleanup so SIGTERM teardown
+ * releases the EventBus listener.
+ */
+export function shutdownFeedbackSubscriber(): void {
+  if (cachedFeedbackUnsubscribe !== null) {
+    cachedFeedbackUnsubscribe();
+    cachedFeedbackUnsubscribe = null;
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

`pipeline/feedback-subscriber.ts`'s module docstring claimed it *"closes the feedback loop: execution → events → outcomes → routing"* — but tree-wide grep found only the unit test and two re-exports. No `PipelineRunner` or graph runner ever subscribed it, so `model.called` / `stage.failed` events never reached `OutcomeStore` via this path. The advertised loop didn't exist.

Added `startFeedbackSubscriber` / `shutdownFeedbackSubscriber` lifecycle wrappers around the existing `createFeedbackSubscriber` (kept that function intact for test-suite callers). Wired into:

- `cli-server-tools.ts:initV2PipelineSubsystems` — starts the subscription once on server init, alongside the existing EventBus bridge.
- `cli-server.ts:createShutdownCleanup` — releases the subscription on SIGTERM teardown (same lifecycle slot as `shutdownExpertBridge` from #2946).

Both `start` and `shutdown` are idempotent.

## Behavior change

After this PR, every `model.called` event (emitted from delegate / orchestrate paths) and every `stage.failed` event will record a `TaskOutcome` in the in-memory `OutcomeStore`. The composite router already reads from that store (`computeQualityReward`, `weather_report`, etc.) — so the feedback loop becomes real, and the adaptive routing has more data to work from. Note that the persistent outcome store factory is already side-effect-registered, so once a `getOutcomeStore()` consumer triggers persistence, the events get persisted too.

## Test plan

- [x] `pnpm vitest run src/pipeline/feedback-subscriber.test.ts` → 9 pass (was 5). 4 new tests cover lifecycle.
- [x] `pnpm vitest run src/cli-server-tools.test.ts` → 32 pass (init wiring did not regress test fixtures).
- [x] `pnpm tsc --noEmit` + `pnpm eslint` on the 4 touched files clean.
- [ ] CI: full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)