### PR TITLE
refactor(pipeline): remove SharedMemoryStore integration (closes #2937)

### DIFF
--- a/.changeset/2937-remove-sharedmemorystore-integration.md
+++ b/.changeset/2937-remove-sharedmemorystore-integration.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+**cleanup(pipeline):** remove the write-only `SharedMemoryStore` integration with `PipelineContext`.
+
+Six pipeline stages (`research`, `plan`, `implement` × 2, `analyze`, `scan`) wrote to `ctx.sharedMemory` with comments like _"for downstream stages"_. Tree-wide grep finds zero `.read()` / `.readFromStage()` callers. The `SharedMemoryStore` was instantiated in `graph-pipeline-runner.ts:107` and threaded through `PipelineContext.sharedMemory`, but no consumer ever closed the loop. Same activate-or-delete YAGNI call as #2921 and #2938 (`createFeedbackSubscriber` advertised-not-wired).
+
+**Removed (the dead integration):**
+
+- `PipelineContext.sharedMemory` field (stage-types.ts) and the `SHARED_MEMORY` entry from `PIPELINE_STATE_KEYS`.
+- All 6 `ctx.sharedMemory.write(...)` calls in `stage-wrappers.ts`.
+- The `extractSymbolsForTask` helper — its only consumer was the now-removed implement-stage write, and the function had no other side effects.
+- `classifyImplementationTrust` — same story; was solely a sharedMemory writer.
+- `SharedMemoryStore` instantiation in `pipeline-graph.ts:createNodeHandler` and `graph-pipeline-runner.ts:runGraphPipeline`.
+- The corresponding test sections in `pipeline-eval-stages.test.ts`, `pipeline-eval.test.ts`, `pipeline-integration.test.ts`, `stage-wrappers.test.ts` that exercised propagation through `PipelineContext.sharedMemory`.
+
+**Preserved (the standalone utility):**
+
+- `SharedMemoryStore` class itself + its `pipeline/index.ts` and `exports/pipeline.ts` exports. It's a small tagged in-memory store that's useful on its own; future cross-stage handoff should route through `PipelineContext.state` with a documented `PIPELINE_STATE_KEYS` entry.
+- Direct-class coverage in `phase4.test.ts` (17 tests) and `pipeline-eval-edge.test.ts` (44 tests) untouched.
+- The `Pipeline Eval — SharedMemoryStore Performance` block in `pipeline-eval.test.ts` (now exercises the standalone class only).
+
+122 tests across the 6 affected test files still pass. Closes #2937.

--- a/packages/nexus-agents/src/exports/pipeline.ts
+++ b/packages/nexus-agents/src/exports/pipeline.ts
@@ -188,7 +188,8 @@ export {
   filterBySeverity,
   type IncompleteResult,
   type IncompleteSeverity,
-  // Shared Memory (#1737 Phase 4)
+  // Shared Memory — standalone tagged in-memory store. Pipeline integration
+  // removed in #2937 (write-only); class kept as a standalone utility.
   SharedMemoryStore,
   type SharedMemoryEntry,
   type SharedMemoryTag,

--- a/packages/nexus-agents/src/pipeline/graph-pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/graph-pipeline-runner.ts
@@ -9,7 +9,6 @@
  */
 
 import { createLogger, getTimeProvider } from '../core/index.js';
-import { SharedMemoryStore } from './shared-memory.js';
 import { executeGraph } from '../orchestration/graph/graph-executor.js';
 import type { CompiledGraph } from '../orchestration/graph/graph-types.js';
 import { compilePipelineGraph } from './pipeline-graph.js';
@@ -103,12 +102,12 @@ async function executeAndReport(
 
   emitPipelineStageEvent(template.id, 'pipeline', 'started');
 
-  // Create SharedMemoryStore for cross-stage context sharing (#1764)
-  const sharedMemory = new SharedMemoryStore();
-
+  // Pre-#2937 a SharedMemoryStore was threaded through graph state under
+  // PIPELINE_STATE_KEYS.SHARED_MEMORY. Removed because no stage ever
+  // read it — cross-stage handoff flows through `state` only.
   const result = await executeGraph(
     graph,
-    { [K.TASK]: task, [K.SHARED_MEMORY]: sharedMemory },
+    { [K.TASK]: task },
     {
       maxSteps: options?.maxSteps ?? DEFAULT_MAX_STEPS,
     }

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -288,7 +288,11 @@ export {
 } from './incomplete-result.js';
 export type { IncompleteResult, IncompleteSeverity } from './incomplete-result.js';
 
-// Shared Memory — cross-stage knowledge propagation (#1737 Phase 4)
+// Shared Memory — standalone in-memory tagged store. Originally threaded
+// through PipelineContext for cross-stage discovery handoff (#1737 Phase 4 /
+// #1764), but the integration was write-only and removed in #2937. The
+// class itself is still useful as a standalone tagged in-memory store, so
+// the export stays for direct consumers.
 export { SharedMemoryStore } from './shared-memory.js';
 export type { SharedMemoryEntry, SharedMemoryTag } from './shared-memory.js';
 

--- a/packages/nexus-agents/src/pipeline/pipeline-eval-stages.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-eval-stages.test.ts
@@ -1,17 +1,21 @@
 /**
  * Pipeline Eval — Stage Wrapper Failure Modes
  *
- * Verifies SharedMemoryStore integrity and failure contract:
- * - Failed stages do NOT leak entries into shared memory
- * - Successful stages write exactly the expected entry
- * - Stage re-runs accumulate entries (no silent dedup)
- * - Failed stages return success=false and a real error message
+ * Verifies the stage-wrapper failure / success contract:
+ * - Failed stages return success=false with a real error message
+ * - Successful stages return success=true and the right state key
+ * - Failed stages still return the expected `stateKey` (no swapping on failure)
+ *
+ * Note: pre-#2937 this file also verified `SharedMemoryStore` propagation
+ * (every successful stage wrote a discovery/decision entry, and a failed
+ * stage left the store untouched). The propagation channel was removed
+ * because no downstream stage ever read it — see #2937. The class itself
+ * still exists as a standalone utility (covered by `phase4.test.ts`).
  *
  * Run: pnpm vitest run src/pipeline/pipeline-eval-stages.test.ts
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { SharedMemoryStore } from './shared-memory.js';
 import {
   createResearchStageWrapper,
   createPlanStageWrapper,
@@ -27,16 +31,12 @@ import type {
   QaReviewResult,
 } from './dev-pipeline.js';
 
-function ctx(
-  sharedMemory = new SharedMemoryStore(),
-  state: Record<string, unknown> = {}
-): PipelineContext {
+function ctx(state: Record<string, unknown> = {}): PipelineContext {
   return {
     executionId: 'eval',
     task: 'Test task',
     templateId: 'dev',
     state: { [K.TASK]: 'Test task', ...state },
-    sharedMemory,
   };
 }
 
@@ -58,30 +58,26 @@ function stagesWith(overrides: Partial<DevPipelineStages>): DevPipelineStages {
 }
 
 // ============================================================================
-// Failure contract — no shared memory leak on throw
+// Failure contract — success=false, error has the underlying message
 // ============================================================================
 
 describe('Pipeline Eval — Failure Contract', () => {
-  it('research failure leaves shared memory untouched', async () => {
-    const mem = new SharedMemoryStore();
+  it('research failure returns success=false', async () => {
     const stages = stagesWith({
       research: vi.fn<(t: string) => Promise<string>>().mockRejectedValue(new Error('boom')),
     });
-    const res = await createResearchStageWrapper(stages).execute(ctx(mem));
+    const res = await createResearchStageWrapper(stages).execute(ctx());
     expect(res.success).toBe(false);
-    expect(mem.read('discovery')).toEqual([]);
   });
 
-  it('plan failure leaves shared memory untouched', async () => {
-    const mem = new SharedMemoryStore();
+  it('plan failure returns success=false', async () => {
     const stages = stagesWith({
       plan: vi
         .fn<(t: string, r: string, f?: string) => Promise<string>>()
         .mockRejectedValue(new Error('plan fail')),
     });
-    const res = await createPlanStageWrapper(stages).execute(ctx(mem, { [K.RESEARCH]: 'data' }));
+    const res = await createPlanStageWrapper(stages).execute(ctx({ [K.RESEARCH]: 'data' }));
     expect(res.success).toBe(false);
-    expect(mem.read('decision')).toEqual([]);
   });
 
   it('failed stage surfaces error message in error field', async () => {
@@ -97,17 +93,12 @@ describe('Pipeline Eval — Failure Contract', () => {
     expect(String(res.error)).toContain('specific message');
   });
 
-  it('vote failure preserves state of prior stages', async () => {
-    const mem = new SharedMemoryStore();
-    mem.write('plan', 'decision', 'existing-plan');
+  it('vote failure returns success=false without crashing', async () => {
     const stages = stagesWith({
       vote: vi.fn<(p: string) => Promise<VoteResult>>().mockRejectedValue(new Error('vote crash')),
     });
-    const res = await createVoteStageWrapper(stages).execute(ctx(mem, { [K.PLAN]: 'p' }));
+    const res = await createVoteStageWrapper(stages).execute(ctx({ [K.PLAN]: 'p' }));
     expect(res.success).toBe(false);
-    // Prior plan decision still intact
-    expect(mem.read('decision').length).toBe(1);
-    expect(mem.read('decision')[0]?.content).toBe('existing-plan');
   });
 
   it('decompose failure returns empty tasks array via failOutput', async () => {
@@ -116,47 +107,8 @@ describe('Pipeline Eval — Failure Contract', () => {
         .fn<(p: string) => Promise<PipelineTask[]>>()
         .mockRejectedValue(new Error('decompose failed')),
     });
-    const res = await createDecomposeStageWrapper(stages).execute(
-      ctx(undefined, { [K.PLAN]: 'p' })
-    );
+    const res = await createDecomposeStageWrapper(stages).execute(ctx({ [K.PLAN]: 'p' }));
     expect(res.success).toBe(false);
-  });
-});
-
-// ============================================================================
-// Success contract — exactly one entry, right tag, right stage
-// ============================================================================
-
-describe('Pipeline Eval — Success Contract', () => {
-  it('research writes exactly one discovery entry', async () => {
-    const mem = new SharedMemoryStore();
-    await createResearchStageWrapper(stagesWith({})).execute(ctx(mem));
-    const entries = mem.read('discovery');
-    expect(entries.length).toBe(1);
-    expect(entries[0]?.sourceStage).toBe('research');
-  });
-
-  it('plan writes exactly one decision entry', async () => {
-    const mem = new SharedMemoryStore();
-    await createPlanStageWrapper(stagesWith({})).execute(ctx(mem, { [K.RESEARCH]: 'r' }));
-    const entries = mem.read('decision');
-    expect(entries.length).toBe(1);
-    expect(entries[0]?.sourceStage).toBe('plan');
-  });
-
-  it('vote success does NOT write to shared memory (not a discovery)', async () => {
-    const mem = new SharedMemoryStore();
-    await createVoteStageWrapper(stagesWith({})).execute(ctx(mem, { [K.PLAN]: 'p' }));
-    // Vote results live in state, not shared memory — by design
-    expect(mem.read().length).toBe(0);
-  });
-
-  it('re-running research accumulates entries (no silent dedup)', async () => {
-    const mem = new SharedMemoryStore();
-    const wrapper = createResearchStageWrapper(stagesWith({}));
-    await wrapper.execute(ctx(mem));
-    await wrapper.execute(ctx(mem));
-    expect(mem.read('discovery').length).toBe(2);
   });
 });
 
@@ -171,9 +123,7 @@ describe('Pipeline Eval — State Key Contract', () => {
   });
 
   it('plan success writes to K.PLAN', async () => {
-    const res = await createPlanStageWrapper(stagesWith({})).execute(
-      ctx(undefined, { [K.RESEARCH]: 'r' })
-    );
+    const res = await createPlanStageWrapper(stagesWith({})).execute(ctx({ [K.RESEARCH]: 'r' }));
     expect(res.stateKey).toBe(K.PLAN);
   });
 

--- a/packages/nexus-agents/src/pipeline/pipeline-eval.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-eval.test.ts
@@ -3,11 +3,17 @@
  *
  * Instrumented tests that measure real pipeline component performance:
  * - Classification accuracy across diverse tasks
- * - SharedMemoryStore propagation and timing
+ * - SharedMemoryStore standalone-class timing (write/read/eviction)
  * - Vote cascade detection logic
  * - Stage wrapper execution timing
  * - Template registry completeness
  * - Cross-template behavior comparison
+ *
+ * Note: pre-#2937 this file also exercised SharedMemoryStore propagation
+ * through PipelineContext.sharedMemory — that integration channel was
+ * removed because no downstream stage ever read it. The class itself is
+ * still a public standalone utility and its direct-use performance
+ * characteristics are still tested below.
  *
  * Run with: pnpm vitest run src/pipeline/pipeline-eval.test.ts
  */
@@ -15,40 +21,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { classifyTask } from './adaptive-orchestrator.js';
 import { SharedMemoryStore } from './shared-memory.js';
-import {
-  createResearchStageWrapper,
-  createPlanStageWrapper,
-  createImplementStageWrapper,
-  createDevStageRegistry,
-  createAuditStageRegistry,
-} from './stage-wrappers.js';
+import { createDevStageRegistry, createAuditStageRegistry } from './stage-wrappers.js';
 import { PIPELINE_TEMPLATES, getTemplate, listTemplateIds } from './templates.js';
-import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
-import type { PipelineContext } from './stage-types.js';
 import type {
   DevPipelineStages,
   PipelineTask,
   VoteResult,
   QaReviewResult,
 } from './dev-pipeline.js';
-
-// ============================================================================
-// Test Helpers
-// ============================================================================
-
-function makeContext(
-  overrides?: Partial<PipelineContext>,
-  stateOverrides?: Record<string, unknown>
-): PipelineContext {
-  return {
-    executionId: 'eval-test',
-    task: overrides?.task ?? 'Evaluate pipeline performance',
-    templateId: 'dev',
-    state: { [K.TASK]: 'Evaluate pipeline performance', ...stateOverrides },
-    sharedMemory: overrides?.sharedMemory ?? new SharedMemoryStore(),
-    ...overrides,
-  };
-}
 
 function createMockStages(): DevPipelineStages {
   return {
@@ -169,39 +149,10 @@ describe('Pipeline Eval — SharedMemoryStore Performance', () => {
     expect(store.read()[0]?.content as string).toBe('E 5');
   });
 
-  it('propagates across research → plan → implement stages', async () => {
-    const stages = createMockStages();
-    const sharedMemory = new SharedMemoryStore();
-    const ctx = makeContext({ sharedMemory });
-
-    await createResearchStageWrapper(stages).execute(ctx);
-    await createPlanStageWrapper(stages).execute({
-      ...ctx,
-      state: { ...ctx.state, [K.RESEARCH]: 'data' },
-    });
-    await createImplementStageWrapper(stages).execute({
-      ...ctx,
-      state: {
-        ...ctx.state,
-        [K.TASKS]: [
-          {
-            id: 't1',
-            title: 'T',
-            description: 'D',
-            assignedTo: 'coder' as const,
-            status: 'pending' as const,
-          },
-        ],
-      },
-    });
-
-    const all = sharedMemory.read();
-    expect(all.length).toBeGreaterThanOrEqual(3);
-    const sources = [...new Set(all.map((e) => e.sourceStage))];
-    expect(sources).toContain('research');
-    expect(sources).toContain('plan');
-    expect(sources).toContain('implement');
-  });
+  // Cross-stage propagation test removed in #2937. The
+  // PipelineContext.sharedMemory channel was write-only; the stage wrappers
+  // no longer touch SharedMemoryStore. The class itself is still a
+  // standalone utility — direct usage is covered above.
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/pipeline/pipeline-graph.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-graph.ts
@@ -117,13 +117,11 @@ function createNodeHandler(
   stage: IPipelineStage,
   template: PipelineTemplate
 ): (state: Readonly<Record<string, unknown>>) => Promise<Partial<Record<string, unknown>>> {
+  // The pre-#2937 implementation reused a SharedMemoryStore across stages
+  // by stashing it under PIPELINE_STATE_KEYS.SHARED_MEMORY in graph state.
+  // Removed along with the rest of the write-only SharedMemoryStore
+  // plumbing — cross-stage data flows through `ctx.state` only now.
   return async (state) => {
-    // Extract or create SharedMemoryStore from graph state (#1764)
-    const existingStore = state[PIPELINE_STATE_KEYS.SHARED_MEMORY];
-    const { SharedMemoryStore } = await import('./shared-memory.js');
-    const sharedMemory =
-      existingStore instanceof SharedMemoryStore ? existingStore : new SharedMemoryStore();
-
     const context: PipelineContext = {
       executionId: `${template.id}-${stage.id}`,
       task:
@@ -132,7 +130,6 @@ function createNodeHandler(
           : '',
       templateId: template.id,
       state,
-      sharedMemory,
     };
 
     const output = await stage.execute(context);

--- a/packages/nexus-agents/src/pipeline/pipeline-integration.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-integration.test.ts
@@ -1,24 +1,20 @@
 /**
  * Pipeline Integration Tests — End-to-end validation of pipeline wiring.
  *
- * Verifies that SharedMemoryStore, vote cascading, input sanitization,
- * trust classification, and codebase intelligence compose correctly
- * across pipeline stages.
+ * Verifies that vote cascading, input sanitization, trust classification,
+ * and codebase intelligence compose correctly across pipeline stages.
+ *
+ * Note: pre-#2937 this file also covered `SharedMemoryStore` propagation
+ * through `PipelineContext.sharedMemory`. That field (and the writes from
+ * every stage) was removed in #2937 because no downstream stage ever read
+ * from the store. The class itself still ships as a standalone utility —
+ * see `phase4.test.ts` for direct-class coverage.
  *
  * (Source: Pipeline Validation Wave — post-Tier 1-3 wiring)
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import {
-  createResearchStageWrapper,
-  createPlanStageWrapper,
-  createImplementStageWrapper,
-  createDevStageRegistry,
-  createAuditStageRegistry,
-} from './stage-wrappers.js';
-import { SharedMemoryStore } from './shared-memory.js';
-import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
-import type { PipelineContext } from './stage-types.js';
+import { createDevStageRegistry, createAuditStageRegistry } from './stage-wrappers.js';
 import type {
   DevPipelineStages,
   PipelineTask,
@@ -31,25 +27,6 @@ import { PIPELINE_TEMPLATES, getTemplate, listTemplateIds } from './templates.js
 // ============================================================================
 // Helpers
 // ============================================================================
-
-function makeContext(
-  overrides?: Partial<PipelineContext>,
-  stateOverrides?: Record<string, unknown>
-): PipelineContext {
-  return {
-    executionId: 'integration-test',
-    task: overrides?.task ?? 'Implement a user authentication module',
-    templateId: 'dev',
-    state: {
-      [K.TASK]: 'Implement a user authentication module',
-      [K.RESEARCH]: 'Prior research on auth patterns',
-      [K.PLAN]: 'Step 1: Create auth service\nStep 2: Add middleware',
-      ...stateOverrides,
-    },
-    sharedMemory: overrides?.sharedMemory ?? new SharedMemoryStore(),
-    ...overrides,
-  };
-}
 
 function createMockStages(): DevPipelineStages {
   return {
@@ -85,82 +62,11 @@ function createMockStages(): DevPipelineStages {
 // Integration Tests
 // ============================================================================
 
-describe('Pipeline Integration — SharedMemoryStore propagation', () => {
-  it('research stage writes discoveries to shared memory', async () => {
-    const stages = createMockStages();
-    const sharedMemory = new SharedMemoryStore();
-    const ctx = makeContext({ sharedMemory });
-
-    const wrapper = createResearchStageWrapper(stages);
-    await wrapper.execute(ctx);
-
-    const discoveries = sharedMemory.read('discovery');
-    expect(discoveries.length).toBeGreaterThanOrEqual(1);
-    expect(discoveries[0]?.sourceStage).toBe('research');
-  });
-
-  it('plan stage writes decisions to shared memory', async () => {
-    const stages = createMockStages();
-    const sharedMemory = new SharedMemoryStore();
-    const ctx = makeContext({ sharedMemory });
-
-    const wrapper = createPlanStageWrapper(stages);
-    await wrapper.execute(ctx);
-
-    const decisions = sharedMemory.read('decision');
-    expect(decisions.length).toBeGreaterThanOrEqual(1);
-    expect(decisions[0]?.sourceStage).toBe('plan');
-  });
-
-  it('implement stage writes trust risk to shared memory', async () => {
-    const stages = createMockStages();
-    const sharedMemory = new SharedMemoryStore();
-    const ctx = makeContext(
-      { sharedMemory },
-      {
-        [K.TASKS]: [
-          {
-            id: 't1',
-            title: 'Task',
-            description: 'Do it',
-            assignedTo: 'coder',
-            status: 'pending' as const,
-          },
-        ],
-      }
-    );
-
-    const wrapper = createImplementStageWrapper(stages);
-    await wrapper.execute(ctx);
-
-    const risks = sharedMemory.read('risk');
-    expect(risks.length).toBeGreaterThanOrEqual(1);
-    const riskData = risks[0]?.content as Record<string, unknown>;
-    expect(riskData['requiresReview']).toBe(true);
-  });
-
-  it('shared memory entries accumulate across stages', async () => {
-    const stages = createMockStages();
-    const sharedMemory = new SharedMemoryStore();
-
-    // Run research
-    const researchCtx = makeContext({ sharedMemory });
-    const research = createResearchStageWrapper(stages);
-    await research.execute(researchCtx);
-
-    // Run plan
-    const planCtx = makeContext({ sharedMemory });
-    const plan = createPlanStageWrapper(stages);
-    await plan.execute(planCtx);
-
-    // Both should be in memory
-    const allEntries = sharedMemory.read();
-    expect(allEntries.length).toBeGreaterThanOrEqual(2);
-    const stages2 = allEntries.map((e) => e.sourceStage);
-    expect(stages2).toContain('research');
-    expect(stages2).toContain('plan');
-  });
-});
+// Pipeline Integration — SharedMemoryStore propagation tests removed in
+// #2937. The propagation channel (PipelineContext.sharedMemory + the writes
+// in every stage wrapper) was dead — nothing ever read it. Direct
+// SharedMemoryStore coverage lives in phase4.test.ts and pipeline-eval*.test.ts;
+// cross-stage data now flows through PipelineContext.state.
 
 describe('Pipeline Integration — Task classification', () => {
   it('review tasks classify as audit', () => {

--- a/packages/nexus-agents/src/pipeline/stage-types.ts
+++ b/packages/nexus-agents/src/pipeline/stage-types.ts
@@ -19,10 +19,14 @@ export interface PipelineContext {
   readonly task: string;
   /** Pipeline template being executed. */
   readonly templateId: string;
-  /** Accumulated state from prior stages. */
+  /**
+   * Accumulated state from prior stages. The only cross-stage handoff
+   * channel — `sharedMemory` (the #1764 SharedMemoryStore) was removed
+   * in #2937 after being write-only since introduction. If you need
+   * structured cross-stage data, add a well-known key to
+   * `PIPELINE_STATE_KEYS` and write/read through `state`.
+   */
   readonly state: Readonly<Record<string, unknown>>;
-  /** Cross-stage knowledge store for discoveries, decisions, constraints (#1764). */
-  readonly sharedMemory: import('./shared-memory.js').SharedMemoryStore;
 }
 
 /** Result of executing a single pipeline stage. */
@@ -99,5 +103,4 @@ export const PIPELINE_STATE_KEYS = {
   PARSED_SPEC: 'parsedSpec',
   SCAFFOLD_OUTPUT: 'scaffoldOutput',
   COMPLETED: 'completed',
-  SHARED_MEMORY: '__sharedMemory__',
 } as const;

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
@@ -15,7 +15,6 @@ import {
 import type { DevPipelineStages, VoteResult, QaReviewResult } from './dev-pipeline.js';
 import type { PipelineContext } from './stage-types.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
-import { SharedMemoryStore } from './shared-memory.js';
 
 // ============================================================================
 // Helpers
@@ -32,7 +31,6 @@ function makeContext(stateOverrides?: Record<string, unknown>): PipelineContext 
       [K.PLAN]: 'Implementation plan',
       ...stateOverrides,
     },
-    sharedMemory: new SharedMemoryStore(),
   };
 }
 

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -71,8 +71,6 @@ export function createResearchStageWrapper(stages: DevPipelineStages): IPipeline
           enrichedTask = `${enrichedTask}\n\n## Codebase Context\n${codeContext}`;
         }
         const result = await stages.research(enrichedTask);
-        // Write research findings to shared memory for downstream stages (#1764)
-        ctx.sharedMemory.write('research', 'discovery', result);
         return output(K.RESEARCH, result, getTimeProvider().now() - start, true);
       } catch (e) {
         return failOutput(K.RESEARCH, String(e), getTimeProvider().now() - start);
@@ -102,8 +100,6 @@ export function createPlanStageWrapper(stages: DevPipelineStages): IPipelineStag
             ? `${research}\n\n## Prior Art (Research Registry)\n${priorArt}`
             : research;
         const result = await stages.plan(ctx.task, enrichedResearch, feedback);
-        // Write plan decisions to shared memory for downstream stages (#1764)
-        ctx.sharedMemory.write('plan', 'decision', result);
         return output(K.PLAN, result, getTimeProvider().now() - start, true);
       } catch (e) {
         return failOutput(K.PLAN, String(e), getTimeProvider().now() - start);
@@ -164,14 +160,16 @@ export function createImplementStageWrapper(stages: DevPipelineStages): IPipelin
       const start = getTimeProvider().now();
       const tasks = Array.isArray(ctx.state[K.TASKS]) ? (ctx.state[K.TASKS] as PipelineTask[]) : [];
       try {
-        // Inject symbol context before implementation (#1777)
-        const symbolContext = await extractSymbolsForTask(ctx.task);
-        if (symbolContext !== null && symbolContext !== '') {
-          ctx.sharedMemory.write('implement', 'context', symbolContext);
-        }
+        // #1777 symbol-context injection: pre-#2937 the resolved symbol
+        // summaries were written to ctx.sharedMemory for downstream
+        // stages — but no stage ever read them. Both the write and the
+        // upstream `extractSymbolsForTask` resolver are gone now.
         const results = await Promise.all(tasks.map((t) => stages.implement(t)));
-        // Post-implement trust gate: classify generated output trust level (#1784)
-        classifyImplementationTrust(results, ctx);
+        // #1784 post-implement trust gate: pre-#2937 the trust assessment
+        // was written to ctx.sharedMemory for downstream stages — but no
+        // stage ever read it. The classifier (and its dead write) are
+        // gone now. If a real trust-gate consumer lands later, route it
+        // through ctx.state with a documented PIPELINE_STATE_KEYS entry.
         return output(K.IMPLEMENTATIONS, results, getTimeProvider().now() - start, true);
       } catch (e) {
         return failOutput(K.IMPLEMENTATIONS, String(e), getTimeProvider().now() - start);
@@ -272,33 +270,6 @@ async function searchCodebaseForTask(task: string): Promise<string | null> {
   }
 }
 
-/** Extract symbols from files referenced in the task (#1777). */
-async function extractSymbolsForTask(task: string): Promise<string | null> {
-  try {
-    // Look for file paths in the task
-    const fileRefs = task.match(/(?:src|lib|packages)\/[^\s,)]+\.ts/g);
-    if (fileRefs === null || fileRefs.length === 0) return null;
-    const { extractSymbols } = await import('../indexer/symbol-extractor.js');
-    const path = await import('node:path');
-    const summaries: string[] = [];
-    for (const ref of fileRefs.slice(0, 3)) {
-      try {
-        const resolved = path.resolve(ref);
-        const result = await extractSymbols(resolved);
-        const exported = result.symbols.filter((s) => s.exported);
-        if (exported.length > 0) {
-          summaries.push(`${ref}: ${exported.map((s) => `${s.kind} ${s.name}`).join(', ')}`);
-        }
-      } catch {
-        // File not found — skip
-      }
-    }
-    return summaries.length > 0 ? summaries.join('\n') : null;
-  } catch {
-    return null;
-  }
-}
-
 /** Query research registry for techniques relevant to the task (#1783). */
 async function queryResearchRegistry(task: string): Promise<string | null> {
   try {
@@ -316,23 +287,6 @@ async function queryResearchRegistry(task: string): Promise<string | null> {
     return `Relevant themes: ${themes.join(', ')}`;
   } catch {
     return null; // Research registry not available — continue without
-  }
-}
-
-/** Classify trust of generated implementations (#1784). */
-function classifyImplementationTrust(results: unknown[], ctx: PipelineContext): void {
-  try {
-    // Record trust assessment — fire-and-forget, never blocks pipeline
-    const implCount = results.length;
-    const trustLevel = implCount > 0 ? 'semi-trusted' : 'unknown';
-    ctx.sharedMemory.write('implement', 'risk', {
-      trustLevel,
-      source: 'pipeline-agent',
-      requiresReview: true,
-      count: implCount,
-    });
-  } catch {
-    // Trust classification failure must never block the pipeline
   }
 }
 
@@ -395,7 +349,6 @@ export function createAnalyzeStageWrapper(): IPipelineStage {
         const { analyzeGitHubRepo } = await import('../mcp/tools/repo-analyze.js');
         const analysis = await analyzeGitHubRepo({ repo: slug, depth: 'deep' });
         const summary = `Language: ${String(analysis.language)}, Framework: ${String(analysis.framework)}, CI: ${String(analysis.ciProvider)}, Security: ${analysis.securityTooling.join(', ') || 'none'}`;
-        ctx.sharedMemory.write('analyze', 'discovery', { slug, analysis: summary });
         return output(K.RESEARCH, summary, getTimeProvider().now() - start, true);
       } catch (e) {
         return failOutput(K.RESEARCH, String(e), getTimeProvider().now() - start);
@@ -420,7 +373,6 @@ export function createScanStageWrapper(): IPipelineStage {
             .slice(0, 5)
             .map((r) => `${r.priority}: ${r.displayName} (${r.category})`)
             .join('; ');
-          ctx.sharedMemory.write('scan', 'decision', { recommendations: recs });
           return output(K.FINDINGS, recs, getTimeProvider().now() - start, true);
         }
         return output(K.FINDINGS, 'No repository to scan', getTimeProvider().now() - start, true);


### PR DESCRIPTION
## Summary

Six pipeline stages (`research`, `plan`, `implement` × 2, `analyze`, `scan`) wrote to `ctx.sharedMemory` with comments like *"for downstream stages."* Tree-wide grep finds zero `.read()` / `.readFromStage()` callers. `SharedMemoryStore` was instantiated in `graph-pipeline-runner.ts` and threaded through `PipelineContext.sharedMemory`, but no consumer ever closed the loop. Same activate-or-delete YAGNI call as #2921 and the sibling #2938 (PR #3011 — `createFeedbackSubscriber` advertised-not-wired).

## Removed

The dead integration:

- `PipelineContext.sharedMemory` field (`stage-types.ts`) + `SHARED_MEMORY` entry from `PIPELINE_STATE_KEYS`.
- All 6 `ctx.sharedMemory.write(...)` calls in `stage-wrappers.ts`.
- `extractSymbolsForTask` — its only consumer was the now-removed implement-stage write; no other side effects.
- `classifyImplementationTrust` — solely a sharedMemory writer.
- `SharedMemoryStore` instantiation in `pipeline-graph.ts:createNodeHandler` and `graph-pipeline-runner.ts:runGraphPipeline`.
- Propagation test sections in `pipeline-eval-stages.test.ts`, `pipeline-eval.test.ts`, `pipeline-integration.test.ts`, `stage-wrappers.test.ts`.

## Preserved

The standalone utility:

- `SharedMemoryStore` class + the `pipeline/index.ts` and `exports/pipeline.ts` exports. It's a useful tagged in-memory store on its own.
- Direct-class tests in `phase4.test.ts` (17 tests) and `pipeline-eval-edge.test.ts` (44 tests) — unchanged.
- `Pipeline Eval — SharedMemoryStore Performance` block in `pipeline-eval.test.ts` (now exercises the standalone class only).

Future cross-stage handoff should route through `PipelineContext.state` with a documented `PIPELINE_STATE_KEYS` entry.

## Test plan

- [x] `pnpm vitest run` across the 6 affected test files → **122 pass**.
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm eslint` on the 10 touched files clean.
- [ ] CI: full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)