### PR TITLE
fix(workflows): thread real executionId+durationMs through failure envelope (#2931)

### DIFF
--- a/.changeset/2931-workflow-failure-envelope.md
+++ b/.changeset/2931-workflow-failure-envelope.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+**fix(workflows):** `run_workflow` failure envelope is now queryable — real `executionId` + `durationMs` instead of `'unknown'`/`0`.
+
+Pre-fix, every timed-out or failed `run_workflow` MCP call returned `{ executionId: 'unknown', durationMs: 0, ... }`. The two values are queried by clients via `query_trace(runId=...)` and weather-report dashboards — so a hung run was effectively un-debuggable from the client side. (See #2931 for the original repro: 4 of 5 substantive calls hit the 120s step timer with `executionId: 'unknown'`.)
+
+Root cause was a missing wire between two layers:
+
+- `parallel-executor.ts:createStepError` builds a `WorkflowError` with `{ stepId, error }` context — the step's diagnostic, but no run-level id.
+- `workflow-engine.ts:runExecution` returned that inner error as-is when steps failed, so `executionId` never reached the caller.
+- `mcp/tools/run-workflow-helpers.ts:createFailedResult` hardcoded `'unknown'` and `0` for both fields.
+
+The fix:
+
+1. **`workflow-engine.ts:runExecution`** now wraps the inner step-failure error to enrich the context with `executionId` + elapsed `durationMs` (preserving the original message + the per-step `stepId` for diagnostic continuity).
+2. **`createFailedResult`** accepts optional `{ executionId, durationMs }` opts and keeps the legacy sentinels as defaults for backwards compatibility with any other caller.
+3. **`run-workflow.ts:handleRunWorkflow`** extracts both from the enriched error context via a `buildFailureEnvelope` helper (split out to keep complexity under the 10-cap).
+
+Out of scope (filed as follow-up for #2931): item 1 (root-cause investigation of the first-step adapter hang) and item 4 (per-call `timeoutMs` parameter). Those need a separate PR — this one closes the debuggability gap so the root cause can actually be traced via `query_trace` next time.
+
+5 regression tests added (1 in `workflow-engine.test.ts` for the enrichment, 4 in `run-workflow-helpers.test.ts` for envelope shape across opt combinations).

--- a/packages/nexus-agents/src/mcp/tools/run-workflow-helpers.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow-helpers.test.ts
@@ -14,6 +14,7 @@ import {
   getAllowedWorkflowDirs,
   validateInputType,
   validateWorkflowInputs,
+  createFailedResult,
 } from './run-workflow-helpers.js';
 import type { WorkflowDefinition } from '../../core/index.js';
 import type { RunWorkflowDeps } from './run-workflow-types.js';
@@ -308,5 +309,52 @@ describe('validateWorkflowInputs', () => {
     const result = validateWorkflowInputs(workflow, { target: 'src/main.ts' });
 
     expect(result.valid).toBe(true);
+  });
+});
+
+// #2931: pre-fix the failure envelope hardcoded `executionId: 'unknown'`
+// and `durationMs: 0`, leaving timed-out runs un-debuggable via
+// `query_trace`. The fix threads real values from the engine's
+// enriched WorkflowError.context.
+describe('createFailedResult (#2931)', () => {
+  function parseEnvelope(resp: ReturnType<typeof createFailedResult>): Record<string, unknown> {
+    const textContent = (resp.content as ReadonlyArray<{ type: string; text: string }>)[0];
+    expect(textContent?.type).toBe('text');
+    return JSON.parse(textContent?.text ?? '{}') as Record<string, unknown>;
+  }
+
+  it('falls back to legacy sentinels when no opts supplied (backwards compat)', () => {
+    const resp = createFailedResult('my-workflow', 'something broke');
+    expect(resp.isError).toBe(true);
+    const body = parseEnvelope(resp);
+    expect(body['executionId']).toBe('unknown');
+    expect(body['durationMs']).toBe(0);
+    expect(body['workflowName']).toBe('my-workflow');
+    expect(body['status']).toBe('failed');
+    expect(body['error']).toBe('something broke');
+  });
+
+  it('uses the supplied executionId + durationMs from the run-workflow path', () => {
+    const resp = createFailedResult('my-workflow', 'step timeout', {
+      executionId: 'wf-abc-123',
+      durationMs: 4523,
+    });
+    const body = parseEnvelope(resp);
+    expect(body['executionId']).toBe('wf-abc-123');
+    expect(body['durationMs']).toBe(4523);
+  });
+
+  it('accepts only executionId (durationMs falls back to 0)', () => {
+    const resp = createFailedResult('w', 'e', { executionId: 'wf-x' });
+    const body = parseEnvelope(resp);
+    expect(body['executionId']).toBe('wf-x');
+    expect(body['durationMs']).toBe(0);
+  });
+
+  it('accepts only durationMs (executionId falls back to "unknown")', () => {
+    const resp = createFailedResult('w', 'e', { durationMs: 100 });
+    const body = parseEnvelope(resp);
+    expect(body['executionId']).toBe('unknown');
+    expect(body['durationMs']).toBe(100);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/run-workflow-helpers.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow-helpers.ts
@@ -370,15 +370,33 @@ export function errorResponse(message: string): ToolResponse {
   return toolError(message);
 }
 
-/** Create a failed workflow result */
-export function createFailedResult(workflowName: string, errorMessage: string): ToolResponse {
+/**
+ * Create a failed workflow result.
+ *
+ * Pre-#2931 this hardcoded `executionId: 'unknown'` and `durationMs: 0`
+ * because the run-workflow handler never received the underlying engine's
+ * executionId or elapsed time. With #2931 wiring, `workflow-engine.ts:
+ * runExecution` now enriches the inner `WorkflowError.context` with
+ * `executionId` and `durationMs`, and `handleRunWorkflow` extracts those
+ * and threads them here — so failure envelopes are now queryable via
+ * `query_trace(runId=...)` instead of being un-debuggable.
+ *
+ * Both opts default to the pre-#2931 sentinel/zero so the symbol stays
+ * back-compat for the (few) other callers, but the run-workflow path
+ * always supplies real values now.
+ */
+export function createFailedResult(
+  workflowName: string,
+  errorMessage: string,
+  opts: { executionId?: string; durationMs?: number } = {}
+): ToolResponse {
   const result = {
-    executionId: 'unknown',
+    executionId: opts.executionId ?? 'unknown',
     workflowName,
     status: 'failed',
     stepResults: [],
     output: null,
-    durationMs: 0,
+    durationMs: opts.durationMs ?? 0,
     error: errorMessage,
   };
   return toolStructuredError({

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -174,6 +174,25 @@ function recordWorkflowError(template: string, errorMessage: string): void {
 }
 
 /**
+ * Build the failure envelope, threading `executionId` + `durationMs` from
+ * the engine-enriched WorkflowError context so timed-out runs are
+ * queryable via `query_trace` (#2931). Falls back to the legacy
+ * 'unknown'/0 shape only when an upstream path didn't enrich the error.
+ */
+function buildFailureEnvelope(
+  workflowName: string,
+  error: { message: string; context?: Record<string, unknown> | undefined }
+): ToolResponse {
+  const ctx = error.context;
+  const executionId = typeof ctx?.['executionId'] === 'string' ? ctx['executionId'] : undefined;
+  const durationMs = typeof ctx?.['durationMs'] === 'number' ? ctx['durationMs'] : undefined;
+  return createFailedResult(workflowName, error.message, {
+    ...(executionId !== undefined ? { executionId } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+  });
+}
+
+/**
  * Handle tool execution and format response.
  *
  * @param deps - Tool dependencies
@@ -206,7 +225,7 @@ async function handleRunWorkflow(
   const executeResult = await executeWorkflow(deps, workflow, inputs);
   if (!executeResult.ok) {
     recordWorkflowError(template, executeResult.error.message);
-    return createFailedResult(workflow.name, executeResult.error.message);
+    return buildFailureEnvelope(workflow.name, executeResult.error);
   }
 
   recordWorkflowSuccess(

--- a/packages/nexus-agents/src/workflows/workflow-engine.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.test.ts
@@ -186,6 +186,42 @@ describe('WorkflowEngine', () => {
 
       expect(result.ok).toBe(false);
     });
+
+    // #2931: workflow engine must enrich step-failure errors with the
+    // run's executionId and elapsed durationMs so the run-workflow MCP
+    // tool can return a queryable failure envelope instead of the
+    // pre-#2931 `executionId: 'unknown'` / `durationMs: 0` shape.
+    it('enriches step-failure WorkflowError with executionId and durationMs (#2931)', async () => {
+      const workflow = { ...sampleWorkflow };
+      mockDeps.createExecutionPlan = vi
+        .fn()
+        .mockReturnValue(ok({ phases: [{ steps: [workflow.steps[0] as WorkflowStep] }] }));
+      // Inner error from parallel-executor carries stepId in context; the
+      // engine must preserve it AND add executionId + durationMs.
+      mockDeps.executePhase = vi.fn().mockResolvedValue(
+        err(
+          new WorkflowError("Step 'first' failed: adapter hang", {
+            context: { stepId: 'first', error: 'adapter hang' },
+          })
+        )
+      );
+
+      const result = await engine.execute(workflow, { input1: 'test' });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const ctx = result.error.context;
+      expect(ctx).toBeDefined();
+      // Original context preserved
+      expect(ctx?.['stepId']).toBe('first');
+      // New #2931 enrichment
+      expect(typeof ctx?.['executionId']).toBe('string');
+      expect(String(ctx?.['executionId']).length).toBeGreaterThan(0);
+      expect(typeof ctx?.['durationMs']).toBe('number');
+      expect(ctx?.['durationMs']).toBeGreaterThanOrEqual(0);
+      // Original message preserved verbatim
+      expect(result.error.message).toBe("Step 'first' failed: adapter hang");
+    });
   });
 
   describe('getStatus', () => {

--- a/packages/nexus-agents/src/workflows/workflow-engine.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.ts
@@ -121,7 +121,18 @@ export class WorkflowEngine implements IWorkflowEngine {
         state: 'failed',
         error: stepResults.error.message,
       });
-      return stepResults;
+      // #2931: enrich the inner error's context with `executionId` and
+      // `durationMs` so the run-workflow MCP tool can surface a real,
+      // queryable id + elapsed time in the failure envelope instead of
+      // the previous `executionId: "unknown"` / `durationMs: 0` shape.
+      // Preserves the original message + existing context (stepId, etc.)
+      // so parallel-executor's per-step diagnostic stays intact.
+      const elapsedMs = getTimeProvider().now() - startTime;
+      const innerErr = stepResults.error;
+      const enriched = new WorkflowError(innerErr.message, {
+        context: { ...(innerErr.context ?? {}), executionId, durationMs: elapsedMs },
+      });
+      return err(enriched);
     }
     const result: WorkflowResult = {
       executionId,


### PR DESCRIPTION
## Summary

Pre-fix, every timed-out or failed `run_workflow` MCP call returned `{ executionId: 'unknown', durationMs: 0, ... }`. Both fields are queried by clients via `query_trace(runId=...)` and weather-report dashboards — so a hung run was effectively un-debuggable from the client side. (#2931 reported 4 of 5 substantive calls hitting the 120s step timer with `executionId: 'unknown'`.)

Root cause was a missing wire between two layers:

- `parallel-executor.ts:createStepError` builds a `WorkflowError` with only `{ stepId, error }` context — the step's diagnostic, but no run-level id.
- `workflow-engine.ts:runExecution` returned that inner error as-is, so the executionId it had on hand never reached the caller.
- `run-workflow-helpers.ts:createFailedResult` hardcoded `'unknown'` and `0`.

## Fix

1. **`runExecution`** now wraps the inner step-failure error to enrich the context with `executionId` + elapsed `durationMs` (preserving the original message + per-step `stepId` for diagnostic continuity).
2. **`createFailedResult`** accepts optional `{ executionId, durationMs }` opts. Legacy sentinels remain as defaults for backwards-compatibility with any other caller.
3. **`handleRunWorkflow`** extracts both from the enriched error context via a new `buildFailureEnvelope` helper (extracted to keep complexity under the 10-cap).

## Out of scope — deferred to follow-ups for #2931

- **Item 1** (root-cause investigation of the first-step adapter hang): needs adapter-side tracing. This PR closes the debuggability gap so the root cause can actually be traced via `query_trace` next time.
- **Item 4** (per-call `timeoutMs` parameter): same as `run_dev_pipeline`, a clean follow-up.

## Test plan

- [x] 5 new regression tests:
  - `workflow-engine.test.ts` — engine enriches step-failure error with `executionId` + `durationMs` while preserving original message and per-step `stepId` context.
  - `run-workflow-helpers.test.ts` (4 tests) — `createFailedResult` envelope shape across opt combinations (no opts → sentinels, both opts → real values, executionId-only → durationMs falls back to 0, durationMs-only → executionId falls back to 'unknown').
- [x] `pnpm vitest run src/workflows/workflow-engine.test.ts src/mcp/tools/run-workflow-helpers.test.ts` → 60 pass (was 55).
- [x] `pnpm tsc --noEmit` + `pnpm eslint` on the 5 touched files clean.
- [ ] CI: full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)