### PR TITLE
fix(plugin): marketplace.json schema compliance (closes #2983)

### DIFF
--- a/.changeset/2983-marketplace-json-schema.md
+++ b/.changeset/2983-marketplace-json-schema.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+**fix(plugin):** marketplace.json now passes `claude plugin validate` (closes #2983).
+
+Two schema violations the validator reported:
+
+1. **Missing top-level `owner`** — the schema referenced by the `$schema` URL requires an `owner` object alongside `name`/`description`/`plugins`. Added with `name` + `url` pointing at the maintainer GitHub profile.
+
+2. **`plugins[0].source` shape** — pre-fix used the `{ type: 'github', owner: 'williamzujkowski', repo: 'nexus-agents' }` triple. Schema-accepted form is `{ source: 'github', repo: 'williamzujkowski/nexus-agents' }` (single `repo` field with `owner/repo` slug, `source` key instead of `type`).
+
+Both fixes are mechanical — values are derived from the existing data; no behavior change beyond the validator now passing.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,13 +2,16 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "williamzujkowski",
   "description": "William Zujkowski's Claude Code plugin marketplace — hosts nexus-agents.",
+  "owner": {
+    "name": "William Zujkowski",
+    "url": "https://github.com/williamzujkowski"
+  },
   "plugins": [
     {
       "name": "nexus-agents",
       "source": {
-        "type": "github",
-        "owner": "williamzujkowski",
-        "repo": "nexus-agents"
+        "source": "github",
+        "repo": "williamzujkowski/nexus-agents"
       },
       "description": "Intelligent orchestration platform for AI coding tools — 38 MCP tools (orchestrate, consensus voting, research, pipelines), 31 skills, 12 expert agents, governance hooks.",
       "keywords": ["orchestration", "mcp", "consensus", "pipelines", "multi-agent"]


### PR DESCRIPTION
## Summary

\`claude plugin validate .\` was failing against \`.claude-plugin/marketplace.json\` with two schema violations the validator reported in #2983.

### Fix 1 — Missing top-level \`owner\`

The marketplace schema referenced by the \`\$schema\` URL requires an \`owner\` object alongside \`name\`/\`description\`/\`plugins\`. Added:

\`\`\`json
"owner": {
  "name": "William Zujkowski",
  "url": "https://github.com/williamzujkowski"
}
\`\`\`

### Fix 2 — \`plugins[0].source\` shape

Pre-fix used a three-field source: \`{ type: 'github', owner: '...', repo: '...' }\`.
Schema-accepted form: \`{ source: 'github', repo: '<owner>/<repo>' }\` (single \`repo\` field with owner/repo slug, \`source\` key instead of \`type\`).

## Test plan

- [x] \`node -e \"JSON.parse(...)\"\` confirms JSON still parses.
- [ ] CI: full matrix.
- [ ] Out-of-band verification by the user with \`claude plugin validate .\` (I don't have the \`claude plugin\` CLI in this environment, but applied the exact accepted shape from the issue body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)