### PR TITLE
fix(scm): zod-validate gh CLI JSON at boundary (closes #2962 site 4)

### DIFF
--- a/.changeset/2962-github-provider-zod-schemas.md
+++ b/.changeset/2962-github-provider-zod-schemas.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+**fix(scm):** Zod-validate `gh` CLI JSON at the boundary so schema drift surfaces as `schema mismatch` instead of misleading "Failed to parse JSON" (closes #2962 site 4).
+
+`packages/nexus-agents/src/scm/github-provider.ts` had 5 parallel `JSON.parse(result.value) as Gh<X>Json` casts feeding mappers (`mapIssue`, `mapComment`, `mapPRStatus`) that dereferenced nested fields like `raw.labels.map((l) => l.name)` and `raw.author.login`. When `gh` CLI returned the JSON in an unexpected shape (rename, removed nullable, missing nested object), the deref blew up with a TypeError that the surrounding `try/catch` then rewrapped as `Failed to parse <X> JSON: …` — misleading: the JSON parsed fine; the shape mismatched. Operators debugging this chased a parser bug that didn't exist.
+
+The fix:
+
+- Added four `z.object(...)` schemas mirroring each `--json <fields>` projection: `GhIssueJsonSchema`, `GhCommentJsonSchema`, `GhPrJsonSchema`, `GhPrStatusJsonSchema`.
+- Extracted a `safeParseGhJson<T>(rawJson, schema, label)` helper that does `JSON.parse` → `schema.safeParse` and distinguishes the two failure modes:
+  - `<label>: Failed to parse JSON: …` (gh returned non-JSON — html error page, empty output)
+  - `<label>: schema mismatch — <path>: <message>` (gh returned valid JSON in an unexpected shape, with Zod's path pointing at the broken field)
+- Replaced all 5 raw casts in `getIssue`, `listIssues`, `createPR`, `getPRStatus`, `listComments`.
+
+Same Zod-validate-at-the-boundary pattern as #2932 (policy-engine), #2943 (PaperEntry), and #2962 sites 1+3 (repo-analyze + issue-command, already shipped).
+
+2 regression tests added: schema-drift surfaces the new typed error with the broken-field path; non-JSON output surfaces the parse-failure label distinctly. 15 tests pass (was 13).

--- a/packages/nexus-agents/src/scm/github-provider.test.ts
+++ b/packages/nexus-agents/src/scm/github-provider.test.ts
@@ -71,6 +71,47 @@ describe('GitHubProvider', () => {
         expect(result.error.message).toContain('gh command failed');
       }
     });
+
+    // #2962 site 4 regression: schema-drift surfaces as a typed
+    // `schema mismatch` error with a useful path, not the
+    // pre-fix misleading "Failed to parse JSON" TypeError-rewrap.
+    it('returns schema-mismatch ScmError when gh JSON shape drifts', async () => {
+      mockExecFile.mockResolvedValue({
+        stdout: JSON.stringify({
+          number: 42,
+          title: 'Test issue',
+          body: 'Description',
+          // `labels` and `author` are missing — pre-fix this hit the
+          // `raw.labels.map` deref inside mapIssue and was caught as a
+          // TypeError that got rewrapped as "Failed to parse JSON".
+          createdAt: '2026-01-01T00:00:00Z',
+        }),
+      });
+
+      const result = await provider.getIssue(42);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.platform).toBe('github');
+        expect(result.error.message).toContain('getIssue: schema mismatch');
+        // The Zod path should call out the missing field.
+        expect(result.error.message).toMatch(/labels|author/);
+      }
+    });
+
+    // #2962 site 4: a truly malformed JSON (gh returned non-JSON) is
+    // distinct from a schema mismatch — different label so debuggers
+    // know which problem to chase.
+    it('returns parse-failure ScmError when gh returns non-JSON', async () => {
+      mockExecFile.mockResolvedValue({ stdout: '<html>404</html>' });
+
+      const result = await provider.getIssue(42);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('getIssue: Failed to parse JSON');
+      }
+    });
   });
 
   describe('listIssues', () => {

--- a/packages/nexus-agents/src/scm/github-provider.ts
+++ b/packages/nexus-agents/src/scm/github-provider.ts
@@ -12,6 +12,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { z } from 'zod';
 import type { Result } from '../core/index.js';
 import { ok, err, createLogger, getErrorMessage } from '../core/index.js';
 import type {
@@ -36,39 +37,88 @@ const MAX_BUFFER = 10 * 1024 * 1024;
 const GH_TIMEOUT_MS = 30_000;
 
 // ============================================================================
-// gh CLI JSON types (internal)
+// gh CLI JSON schemas (internal — #2962 site 4)
+//
+// Each schema mirrors the `--json <fields>` projection the corresponding
+// gh call asks for. They're applied via `safeParseGhJson` so a gh-schema
+// drift (a renamed field, a missing nullable, a removed nested object)
+// surfaces as a structured ScmError('schema mismatch') instead of the
+// previous TypeError-rewrapped-as-"Failed to parse JSON" — pre-#2962, the
+// JSON parsed fine and the mapper's `raw.labels.map` / `raw.author.login`
+// deref blew up, so debuggers chased a parser bug that didn't exist.
 // ============================================================================
 
-interface GhIssueJson {
-  number: number;
-  title: string;
-  body: string | null;
-  labels: Array<{ name: string }>;
-  author: { login: string };
-  createdAt: string;
-}
+const GhIssueJsonSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  labels: z.array(z.object({ name: z.string() })),
+  author: z.object({ login: z.string() }),
+  createdAt: z.string(),
+});
+type GhIssueJson = z.infer<typeof GhIssueJsonSchema>;
 
-interface GhCommentJson {
-  id: number;
-  body: string;
-  author: { login: string };
-  createdAt: string;
-}
+const GhCommentJsonSchema = z.object({
+  id: z.number(),
+  body: z.string(),
+  author: z.object({ login: z.string() }),
+  createdAt: z.string(),
+});
+type GhCommentJson = z.infer<typeof GhCommentJsonSchema>;
 
-interface GhPrJson {
-  number: number;
-  title: string;
-  body: string | null;
-  url: string;
-  author: { login: string };
-  baseRefName: string;
-  headRefName: string;
-}
+const GhPrJsonSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  url: z.string(),
+  author: z.object({ login: z.string() }),
+  baseRefName: z.string(),
+  headRefName: z.string(),
+});
+// `createPR` consumes the parsed value inline; no GhPrJson alias needed.
 
-interface GhPrStatusJson {
-  mergeable: string;
-  statusCheckRollup: Array<{ state: string }> | null;
-  reviewDecision: string | null;
+const GhPrStatusJsonSchema = z.object({
+  mergeable: z.string(),
+  statusCheckRollup: z.array(z.object({ state: z.string() })).nullable(),
+  reviewDecision: z.string().nullable(),
+});
+type GhPrStatusJson = z.infer<typeof GhPrStatusJsonSchema>;
+
+/**
+ * Parse + Zod-validate gh CLI output. Distinguishes:
+ * - parse failure (gh returned non-JSON or empty) — \`label: Failed to parse JSON\`
+ * - schema mismatch (gh returned valid JSON in an unexpected shape) — \`label: schema mismatch\`
+ * Pre-#2962 both surfaced as the same misleading "Failed to parse" error.
+ */
+function safeParseGhJson<T>(
+  rawJson: string,
+  schema: z.ZodType<T>,
+  label: string
+): Result<T, ScmError> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (error) {
+    return err(
+      new ScmError(
+        `${label}: Failed to parse JSON: ${getErrorMessage(error)} — preview: ${rawJson.slice(0, 120)}`,
+        'github'
+      )
+    );
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return err(
+      new ScmError(
+        `${label}: schema mismatch — ${result.error.issues
+          .slice(0, 3)
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; ')} — preview: ${rawJson.slice(0, 120)}`,
+        'github'
+      )
+    );
+  }
+  return ok(result.data);
 }
 
 // ============================================================================
@@ -160,16 +210,9 @@ export class GitHubProvider implements IScmProvider {
     const result = await execGh(args, this.repo);
     if (!result.ok) return result;
 
-    try {
-      return ok(mapIssue(JSON.parse(result.value) as GhIssueJson));
-    } catch (error) {
-      return err(
-        new ScmError(
-          `Failed to parse issue JSON: ${getErrorMessage(error)} — preview: ${result.value.slice(0, 120)}`,
-          'github'
-        )
-      );
-    }
+    const parsed = safeParseGhJson(result.value, GhIssueJsonSchema, 'getIssue');
+    if (!parsed.ok) return parsed;
+    return ok(mapIssue(parsed.value));
   }
 
   async listIssues(filters?: IssueFilters): Promise<Result<readonly ScmIssue[], ScmError>> {
@@ -188,17 +231,9 @@ export class GitHubProvider implements IScmProvider {
     const result = await execGh(args, this.repo);
     if (!result.ok) return result;
 
-    try {
-      const issues = JSON.parse(result.value) as GhIssueJson[];
-      return ok(issues.map(mapIssue));
-    } catch (error) {
-      return err(
-        new ScmError(
-          `Failed to parse issues JSON: ${getErrorMessage(error)} — preview: ${result.value.slice(0, 120)}`,
-          'github'
-        )
-      );
-    }
+    const parsed = safeParseGhJson(result.value, z.array(GhIssueJsonSchema), 'listIssues');
+    if (!parsed.ok) return parsed;
+    return ok(parsed.value.map(mapIssue));
   }
 
   async addLabels(issueNumber: number, labels: readonly string[]): Promise<Result<void, ScmError>> {
@@ -231,25 +266,18 @@ export class GitHubProvider implements IScmProvider {
     const result = await execGh(args, this.repo);
     if (!result.ok) return result;
 
-    try {
-      const raw = JSON.parse(result.value) as GhPrJson;
-      return ok({
-        number: raw.number,
-        title: raw.title,
-        body: raw.body ?? '',
-        author: raw.author.login,
-        base: raw.baseRefName,
-        head: raw.headRefName,
-        url: raw.url,
-      });
-    } catch (error) {
-      return err(
-        new ScmError(
-          `Failed to parse PR JSON: ${getErrorMessage(error)} — preview: ${result.value.slice(0, 120)}`,
-          'github'
-        )
-      );
-    }
+    const parsed = safeParseGhJson(result.value, GhPrJsonSchema, 'createPR');
+    if (!parsed.ok) return parsed;
+    const raw = parsed.value;
+    return ok({
+      number: raw.number,
+      title: raw.title,
+      body: raw.body ?? '',
+      author: raw.author.login,
+      base: raw.baseRefName,
+      head: raw.headRefName,
+      url: raw.url,
+    });
   }
 
   async mergePR(prNumber: number, options?: MergePROptions): Promise<Result<void, ScmError>> {
@@ -274,16 +302,9 @@ export class GitHubProvider implements IScmProvider {
     const result = await execGh(args, this.repo);
     if (!result.ok) return result;
 
-    try {
-      return ok(mapPRStatus(JSON.parse(result.value) as GhPrStatusJson));
-    } catch (error) {
-      return err(
-        new ScmError(
-          `Failed to parse PR status JSON: ${getErrorMessage(error)} — preview: ${result.value.slice(0, 120)}`,
-          'github'
-        )
-      );
-    }
+    const parsed = safeParseGhJson(result.value, GhPrStatusJsonSchema, 'getPRStatus');
+    if (!parsed.ok) return parsed;
+    return ok(mapPRStatus(parsed.value));
   }
 
   async createIssue(
@@ -325,16 +346,8 @@ export class GitHubProvider implements IScmProvider {
     const result = await execGh(args, this.repo);
     if (!result.ok) return result;
 
-    try {
-      const comments = JSON.parse(result.value) as GhCommentJson[];
-      return ok(comments.map(mapComment));
-    } catch (error) {
-      return err(
-        new ScmError(
-          `Failed to parse comments JSON: ${getErrorMessage(error)} — preview: ${result.value.slice(0, 120)}`,
-          'github'
-        )
-      );
-    }
+    const parsed = safeParseGhJson(result.value, z.array(GhCommentJsonSchema), 'listComments');
+    if (!parsed.ok) return parsed;
+    return ok(parsed.value.map(mapComment));
   }
 }


### PR DESCRIPTION
## Summary

\`github-provider.ts\` had 5 parallel \`JSON.parse(result.value) as Gh<X>Json\` casts feeding mappers that dereferenced nested fields (\`raw.labels.map(l => l.name)\`, \`raw.author.login\`). When gh CLI returned the JSON in an unexpected shape (renamed field, removed nullable, missing nested object), the deref blew up with a TypeError that the surrounding \`try/catch\` rewrapped as \`Failed to parse <X> JSON: …\` — misleading: the JSON parsed fine; the shape mismatched. Operators debugging this chased a parser bug that didn't exist.

## Fix

- Added four Zod schemas mirroring each \`--json <fields>\` projection: \`GhIssueJsonSchema\`, \`GhCommentJsonSchema\`, \`GhPrJsonSchema\`, \`GhPrStatusJsonSchema\`.
- Extracted \`safeParseGhJson<T>(rawJson, schema, label)\` that does \`JSON.parse\` → \`schema.safeParse\` and distinguishes the two failure modes:
  - \`<label>: Failed to parse JSON: …\` (gh returned non-JSON — html error page, empty output)
  - \`<label>: schema mismatch — <path>: <msg>\` (valid JSON, wrong shape; Zod's path points at the broken field)
- Replaced all 5 raw casts in \`getIssue\`, \`listIssues\`, \`createPR\`, \`getPRStatus\`, \`listComments\`.

Same pattern as #2932 (policy-engine), #2943 (PaperEntry), and #2962 sites 1+3 (repo-analyze + issue-command — already shipped).

## Test plan

- [x] 2 new regression tests on \`getIssue\` cover schema-drift and parse-failure paths distinctly with the correct labels.
- [x] \`pnpm vitest run src/scm/github-provider.test.ts\` → 15 pass (was 13).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` on the 2 touched files clean.
- [ ] CI: full matrix.

## What's left on #2962

Sites 1 (repo-analyze), 2 (pipeline-checkpoint via #2981), 3 (issue-command) all shipped previously. This closes the last site (4 = the 5 parallel github-provider casts). #2962 will fully close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)