### PR TITLE
fix: 3 small bugs from deep audit (#3026 findings 3-5)

### DIFF
--- a/.changeset/3026-small-bug-trio.md
+++ b/.changeset/3026-small-bug-trio.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': patch
+---
+
+**fix:** 3 small isolated bugs surfaced by the deep audit (#3026 findings 3–5).
+
+PR 1 of #3026 — three independent fixes, each < 30 LOC + a regression test, no contract changes.
+
+### Finding 5 — circuit breaker `failureCount` grows monotonically across recoveries
+
+`packages/nexus-agents/src/cli-adapters/circuit-breaker.ts:212-227`. `transitionTo('open',…)` only zeroed failure/success counts when going to `'closed'`. After a `half-open → open → half-open` cycle, `failureCount` carried over — under flaky failure patterns (intermittent rate-limit + recovery), `getSnapshot().failureCount` and `CircuitStateChangeEvent.failureCount` grew without bound across cycles, even though each cycle's failures had already served their threshold purpose. Operator dashboards / alerts triggered on absolute failure count saw misleading inflation. **Fix:** reset `failureCount = 0` on transitions to `'half-open'`.
+
+### Finding 4 — capacity tracker over-counts requests; sliding window vs tumbling reset mismatch
+
+`packages/nexus-agents/src/cli-adapters/capacity-tracker.ts:122-216`. `usageHistory` was slide-pruned (entries older than `now - windowMs` shifted off), but `requestCount` was only reset by the "tumbling" branch (`windowStart < cutoff`), which fires whenever the _earliest_ request is older than `windowMs` — even though more-recent requests are still inside the sliding window. Result: continuous traffic across a window boundary triggered a mass-prune that incorrectly dropped current-window requests, making `remainingRequests === 0` exhaustion fire prematurely (or too late) depending on burst pattern. Upstream routing (`composite-router-helpers.fetchCapacityData`) then re-routed away from a CLI that actually had capacity.
+
+**Fix:** added a parallel `requestTimestamps: number[]` array that is slide-pruned identically to `usageHistory`; `requestCount` is now derived from `.length` after pruning. Dropped the tumbling-reset branch in `pruneOldEntries` — both arrays now use pure sliding-window semantics. `windowStart` is rebased to the earliest remaining entry (used by `resetTime` reporting), falling back to `now` when both arrays are empty.
+
+### Finding 3 — stagger delay compounds with bounded concurrency
+
+`packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts:485-488`. The stagger delay applied `taskIndex * staggerDelayMs` (absolute index), but `executeWithConcurrencyLimit` only runs `maxConcurrency` workers in parallel — tasks beyond that already wait naturally for a slot to free, then _additionally_ slept `taskIndex * staggerDelayMs`. For a wave of 10 with `maxConcurrency=3` and 500ms stagger, `tasks[9]` slept 4500ms AFTER waiting for `tasks[0-6]` to complete, defeating the rate-limit-burst-prevention goal (by the time `tasks[9]` ran, the API burst window had long since cleared).
+
+**Fix:** modulo by `maxConcurrency` so the stagger applies within each concurrency slot without compounding across them.
+
+### Test coverage
+
+3 new regression tests (1 per finding): failureCount reset across recovery cycles, sliding-window request counting across a boundary, stagger non-compounding with `maxConcurrency=2` + 5-task wave. 150 tests pass across the 3 affected test files (was 147).
+
+### What's left on #3026
+
+PR 2 will tackle findings 1+2 together — the SIGKILL escalation + AbortSignal threading through `ICliAdapter.execute`. That's a contract change touching all 5 concrete adapters + 3 call sites (parallel-exploration, watchdog, consensus-plan); deserves its own focused review.

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
@@ -159,12 +159,45 @@ describe('CapacityTracker', () => {
       let capacity = tracker.getCapacity();
       expect(capacity.remainingTokens).toBe(5000);
 
-      // Advance to t=61s (first entry should be pruned)
+      // Advance to t=61s: the t=0 entry is outside the 60s sliding
+      // window and should be pruned; the t=30s entry (within the
+      // [1s, 61s] window) must remain. Pre-#3026 finding 4 fix, the
+      // tumbling-reset branch incorrectly dropped both — see the
+      // sibling test for the request-count side of the same bug.
       vi.advanceTimersByTime(31000);
 
       capacity = tracker.getCapacity();
-      // After full window reset, should be back to full capacity
-      expect(capacity.remainingTokens).toBe(10000);
+      expect(capacity.remainingTokens).toBe(8000); // 10000 - 2000 from t=30s entry
+    });
+
+    // #3026 finding 4: pre-fix, `requestCount` only reset via the
+    // tumbling-window branch ("windowStart < cutoff"), which dropped
+    // requests that were still inside the *sliding* window. With one
+    // request at t=0 and another at t=61s, the t=0 request should have
+    // pruned out individually (it's outside [1, 61s]), but the
+    // tumbling-reset branch also dropped the t=30s request that should
+    // still count. After the fix, request counting follows the same
+    // sliding-window semantics as token counting.
+    it('counts requests via sliding window, not tumbling reset (#3026 finding 4)', () => {
+      // Burst 5 requests at t=0
+      for (let i = 0; i < 5; i++) {
+        tracker.recordUsage({ inputTokens: 100, outputTokens: 100, totalTokens: 200 });
+      }
+      expect(tracker.getCapacity().remainingRequests).toBe(95);
+
+      // Advance to t=30s, record 3 more requests
+      vi.advanceTimersByTime(30000);
+      for (let i = 0; i < 3; i++) {
+        tracker.recordUsage({ inputTokens: 100, outputTokens: 100, totalTokens: 200 });
+      }
+      // All 8 are still inside the window
+      expect(tracker.getCapacity().remainingRequests).toBe(92);
+
+      // Advance to t=61s — the 5 requests at t=0 are now outside the
+      // 60s window; the 3 requests at t=30s should still count.
+      // Pre-fix, the tumbling-reset branch dropped ALL 8.
+      vi.advanceTimersByTime(31000);
+      expect(tracker.getCapacity().remainingRequests).toBe(97); // 100 - 3
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
@@ -109,10 +109,31 @@ export class CapacityTracker {
   private requestCount: number;
   private windowStart: number;
 
+  /**
+   * Timestamps of every recorded request (#3026 finding 4).
+   *
+   * Pre-fix, `requestCount` was a plain counter reset only by the
+   * tumbling-window branch of `pruneOldEntries`. Under continuous
+   * traffic across a window boundary, that branch drops requests that
+   * are still inside the *sliding* window — e.g. with windowMs=60s, a
+   * request at t=59s followed by one at t=61s would tumbling-reset
+   * the counter to 1 even though the t=59s request is still inside
+   * the [1s, 61s] window. The downstream `remainingRequests === 0`
+   * exhaustion check fired prematurely (or too late) depending on
+   * burst patterns.
+   *
+   * Counting via a per-request timestamp array that's pruned the same
+   * way as `usageHistory` keeps the two views consistent. Every
+   * `recordUsage` pushes here; `requestCount` is derived from
+   * `.length` after pruning.
+   */
+  private requestTimestamps: number[];
+
   constructor(config: CapacityTrackerConfig) {
     this.config = config;
     this.usageHistory = [];
     this.requestCount = 0;
+    this.requestTimestamps = [];
     this.windowStart = getTimeProvider().now();
   }
 
@@ -123,7 +144,8 @@ export class CapacityTracker {
     const now = getTimeProvider().now();
     this.pruneOldEntries(now);
 
-    this.requestCount++;
+    this.requestTimestamps.push(now);
+    this.requestCount = this.requestTimestamps.length;
 
     if (usage !== undefined) {
       const tokens = usage.totalTokens ?? usage.inputTokens + usage.outputTokens;
@@ -175,6 +197,7 @@ export class CapacityTracker {
    */
   reset(): void {
     this.usageHistory.length = 0;
+    this.requestTimestamps.length = 0;
     this.requestCount = 0;
     this.windowStart = getTimeProvider().now();
   }
@@ -199,19 +222,34 @@ export class CapacityTracker {
   private pruneOldEntries(now: number): void {
     const cutoff = now - this.config.windowMs;
 
-    // If window has fully elapsed, reset everything
-    if (this.windowStart < cutoff) {
-      this.usageHistory.length = 0;
-      this.requestCount = 0;
-      this.windowStart = now;
-      return;
-    }
-
-    // Remove old entries from history
-    let firstEntry = this.usageHistory[0];
-    while (firstEntry !== undefined && firstEntry.timestamp < cutoff) {
+    // Sliding-window prune (#3026 finding 4):
+    // Pre-fix, this used a "tumbling reset" branch — when `windowStart`
+    // (the time of the FIRST request) was older than the cutoff, the
+    // whole structure was zeroed. Under continuous traffic, that condition
+    // fires whenever the earliest tracked request is older than windowMs
+    // ago — even though more recent requests are still inside the
+    // sliding window. The result was a periodic mass-prune that incorrectly
+    // dropped current-window requests, making `remainingRequests === 0`
+    // fire prematurely (or too late) depending on burst pattern.
+    //
+    // Now both arrays are slide-pruned individually: drop entries with
+    // `timestamp < cutoff`, leave the rest. `windowStart` is rebased to
+    // the earliest remaining entry (used by `resetTime` reporting),
+    // falling back to `now` when both arrays are empty.
+    while (this.usageHistory[0] !== undefined && this.usageHistory[0].timestamp < cutoff) {
       this.usageHistory.shift();
-      firstEntry = this.usageHistory[0];
+    }
+    while (this.requestTimestamps[0] !== undefined && this.requestTimestamps[0] < cutoff) {
+      this.requestTimestamps.shift();
+    }
+    this.requestCount = this.requestTimestamps.length;
+
+    const earliestRequest = this.requestTimestamps[0];
+    const earliestUsage = this.usageHistory[0]?.timestamp;
+    if (earliestRequest === undefined && earliestUsage === undefined) {
+      this.windowStart = now;
+    } else {
+      this.windowStart = Math.min(earliestRequest ?? Infinity, earliestUsage ?? Infinity);
     }
   }
 }

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
@@ -178,6 +178,33 @@ describe('CliCircuitBreaker', () => {
       expect(breaker.getState()).toBe('open');
     });
 
+    // #3026 finding 5: pre-fix, `failureCount` carried over across
+    // half-open→open→half-open recovery cycles. transitionTo('open',…)
+    // only zeroed counts on 'closed', so a flaky pattern grew
+    // `failureCount` monotonically — operator dashboards / alerts
+    // triggered on absolute failure count saw misleading inflation.
+    it('resets failureCount on half-open transition (#3026 finding 5)', async () => {
+      expect(breaker.getState()).toBe('half-open');
+      // After opening + waiting + transitioning to half-open, the
+      // failure count should be 0 — those failures served their
+      // threshold purpose when the circuit opened.
+      expect(breaker.getSnapshot().failureCount).toBe(0);
+
+      // Cycle: half-open → open (one failure trips it back) → half-open.
+      // The failureCount should reset on each half-open re-entry, not
+      // grow monotonically.
+      await breaker.execute(() => Promise.reject(new Error('flake')));
+      expect(breaker.getState()).toBe('open');
+      const afterFirstOpen = breaker.getSnapshot().failureCount;
+
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+      // Probe via getState() to trigger the timer-based open→half-open
+      // transition. After this, failureCount should be 0 again.
+      expect(breaker.getState()).toBe('half-open');
+      expect(breaker.getSnapshot().failureCount).toBe(0);
+      expect(afterFirstOpen).toBeGreaterThan(0); // sanity: count was non-zero before reset
+    });
+
     it('should reject requests beyond half-open limit', async () => {
       expect(breaker.getState()).toBe('half-open');
 

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
@@ -219,6 +219,14 @@ export class CliCircuitBreaker implements ICircuitBreaker {
       this.successCount = 0;
       this.halfOpenRequests = 0;
     } else if (newState === 'half-open') {
+      // #3026 finding 5: pre-fix `failureCount` carried over across
+      // recovery cycles. transitionTo('open',…) only zeroes counts on
+      // 'closed', so a half-open→open→half-open flaky pattern grew
+      // `failureCount` monotonically across cycles. The count served
+      // its threshold purpose when we opened the circuit; resetting on
+      // 'half-open' restores the documented per-cycle semantic that
+      // operator dashboards / alerts read from `getSnapshot()`.
+      this.failureCount = 0;
       this.successCount = 0;
       this.halfOpenRequests = 0;
     }

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.test.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.test.ts
@@ -678,6 +678,64 @@ describe('dispatchWorkers', () => {
     }
   });
 
+  // #3026 finding 3: pre-fix, the stagger delay was computed from the
+  // absolute `taskIndex` even though only `maxConcurrency` workers run
+  // in parallel. Tasks beyond that already wait for a slot to free, then
+  // ALSO slept `taskIndex * staggerDelayMs` — for a wave of 5 with
+  // maxConcurrency=2 and 100ms stagger, tasks[4] slept 400ms AFTER
+  // waiting for tasks[0-2] to complete. Now the stagger uses
+  // `taskIndex % maxConcurrency` so it applies within each concurrency
+  // slot without compounding.
+  it('does not compound stagger across concurrency slots (#3026 finding 3)', async () => {
+    const launchOffsets: Array<{ role: string; offsetMs: number }> = [];
+    const startTime = Date.now();
+
+    const trackedExecute: WorkerDispatchOptions['executeWorker'] = vi
+      .fn()
+      .mockImplementation((entry: AgentPlanEntry): Promise<WorkerResult> => {
+        launchOffsets.push({ role: entry.role, offsetMs: Date.now() - startTime });
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              role: entry.role,
+              subTask: entry.subTask,
+              output: `result from ${entry.role}`,
+              status: 'success' as const,
+              durationMs: 50,
+            });
+          }, 50);
+        });
+      });
+
+    const entries = [
+      makeEntry('code', 1, 1),
+      makeEntry('testing', 1, 2),
+      makeEntry('security', 1, 3),
+      makeEntry('documentation', 1, 4),
+      makeEntry('infrastructure', 1, 5),
+    ];
+
+    await dispatchWorkers(entries, {
+      executeWorker: trackedExecute,
+      maxConcurrency: 2,
+      staggerDelayMs: 100,
+    });
+
+    expect(launchOffsets).toHaveLength(5);
+    // With maxConcurrency=2 and modulo-based stagger:
+    // slot 0 → tasks[0,2,4] sleep 0
+    // slot 1 → tasks[1,3]   sleep 100ms within their slot
+    // Pre-fix (absolute index), tasks[4] would have slept 400ms before
+    // its 50ms work — total elapsed > 450ms. With the fix, tasks[4]
+    // launches as soon as a slot frees (~50ms) + 0ms stagger.
+    const last = launchOffsets[4];
+    expect(last).toBeDefined();
+    if (last !== undefined) {
+      // Generous bound to dodge runner noise — pre-fix would be > 400ms.
+      expect(last.offsetMs).toBeLessThan(300);
+    }
+  });
+
   it('skips stagger delay when staggerDelayMs is 0', async () => {
     const launchOrder: string[] = [];
 

--- a/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
+++ b/packages/nexus-agents/src/orchestration/aorchestra/worker-dispatcher.ts
@@ -481,8 +481,20 @@ function createWorkerTask(
         error: 'Role auto-disabled after consecutive failures',
       };
     }
-    // Stagger delay: offset each worker launch to avoid API burst (#1501)
-    const staggerMs = taskIndex * opts.staggerDelayMs;
+    // Stagger delay: offset each worker launch to avoid API burst (#1501).
+    //
+    // #3026 finding 3: pre-fix this multiplied the stagger by the absolute
+    // `taskIndex` even though `executeWithConcurrencyLimit` only runs
+    // `maxConcurrency` workers in parallel — tasks beyond that already
+    // wait naturally for a slot to free, then ALSO slept
+    // `taskIndex * staggerDelayMs`. For a wave of 10 with maxConcurrency=3
+    // and 500ms stagger, tasks[9] slept 4500ms AFTER waiting for tasks[0-6]
+    // to complete, defeating the burst-prevention goal (by the time tasks[9]
+    // ran, the API burst window had long since cleared). Modulo by
+    // `maxConcurrency` so the stagger applies within each concurrency slot
+    // without compounding across them.
+    const staggerSlot = taskIndex % opts.maxConcurrency;
+    const staggerMs = staggerSlot * opts.staggerDelayMs;
     if (staggerMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, staggerMs));
     }


### PR DESCRIPTION
## Summary

PR 1 of #3026 — three isolated fixes surfaced by the deep audit, each < 30 LOC + a regression test, no contract changes.

### Finding 5 — circuit breaker \`failureCount\` grows across recoveries

\`circuit-breaker.ts:212-227\`. \`transitionTo('open',…)\` only zeroed failure/success counts when going to \`'closed'\`. After a \`half-open → open → half-open\` cycle, \`failureCount\` carried over — under flaky failure patterns, \`getSnapshot().failureCount\` and \`CircuitStateChangeEvent.failureCount\` grew without bound across cycles. Operator dashboards alerting on absolute failure count saw misleading inflation. **Fix:** reset on transitions to \`'half-open'\`.

### Finding 4 — capacity tracker over-counts requests (sliding vs tumbling mismatch)

\`capacity-tracker.ts:122-216\`. \`usageHistory\` was slide-pruned but \`requestCount\` was only reset by the tumbling branch (\`windowStart < cutoff\`), which fires whenever the *earliest* request is older than \`windowMs\` — even though more-recent requests are still inside the sliding window. Continuous traffic across a window boundary triggered a mass-prune that dropped current-window requests, making \`remainingRequests === 0\` fire prematurely. Upstream routing (\`composite-router-helpers.fetchCapacityData\`) then re-routed away from a CLI that actually had capacity.

**Fix:** parallel \`requestTimestamps\` array slide-pruned identically to \`usageHistory\`; dropped the tumbling-reset branch; rebased \`windowStart\` to earliest remaining entry.

### Finding 3 — stagger delay compounds with bounded concurrency

\`worker-dispatcher.ts:485-488\`. Stagger applied \`taskIndex * staggerDelayMs\` (absolute index), but \`executeWithConcurrencyLimit\` only runs \`maxConcurrency\` workers in parallel — tasks beyond that wait for a slot AND additionally slept. For wave of 10 with maxConcurrency=3 + 500ms stagger, tasks[9] slept 4500ms AFTER waiting for tasks[0-6] to complete, defeating burst-prevention. **Fix:** modulo by \`maxConcurrency\`.

## Test plan

- [x] 3 new regression tests, one per finding:
  - Circuit breaker: failureCount reset across half-open recovery cycles
  - Capacity tracker: sliding-window request counting across a 60s boundary (5 requests at t=0 + 3 at t=30s + check at t=61s; only the 3 within-window requests should count)
  - Worker dispatcher: stagger non-compounding (5 tasks, maxConcurrency=2, 100ms stagger; tasks[4] launches < 300ms not > 400ms)
- [x] \`pnpm vitest run\` across 3 affected test files → 150 pass (was 147).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` on 6 touched files clean.
- [x] One pre-existing test updated: \`prunes old entries from sliding window\` previously asserted the bug (\`remainingTokens === 10000\` after a tumbling reset that incorrectly dropped a within-window entry); now correctly asserts 8000.
- [ ] CI: full matrix.

## What's left on #3026

PR 2 will tackle findings 1 + 2 together — SIGKILL escalation in \`SubprocessCliAdapter\` and \`AbortSignal\` threading through the \`ICliAdapter.execute\` contract. That's a bigger refactor touching all 5 concrete adapters + 3 call sites (parallel-exploration, watchdog, consensus-plan); deserves its own focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)