### PR TITLE
feat(workflows): run_workflow phaseTimeoutMs override (closes #3017)

### DIFF
--- a/.changeset/3017-run-workflow-timeoutms.md
+++ b/.changeset/3017-run-workflow-timeoutms.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': patch
+---
+
+**feat(workflows):** `run_workflow` MCP tool now accepts an optional `timeoutMs` input to override the per-phase execution budget (closes #3017).
+
+Pre-fix, the per-phase execution timeout was always `workflow.timeout` (set in the template YAML) or the engine's `defaultTimeoutMs` — known-long templates like `security-audit` over a large repo couldn't be given a one-off larger budget without editing the template. #2931 surfaced the need: a 120s default-tripped run was un-debuggable; #3017 follows up with the ability to extend the budget for legitimately-slow workloads.
+
+### Wiring (top to bottom)
+
+- **`RunWorkflowInputSchema`** (`mcp/tools/run-workflow-types.ts`): added optional `timeoutMs: z.number().int().min(1000).max(1_800_000)` — bounded to [1s, 30min] to prevent both flapping cancellations and unbounded hangs that would defeat the timeout-mismatch telemetry.
+- **MCP tool schema** (`mcp/tools/run-workflow.ts`): added `timeoutMs` to the `inputSchema` so the field appears in the tool advertisement.
+- **`handleRunWorkflow`**: extracts `timeoutMs` from validated args and threads it into `executeWorkflow` as `{ stepTimeoutMs: timeoutMs }` (renamed to `phaseTimeoutMs` internally — see the docstring update on `IWorkflowEngine.execute`).
+- **`executeWorkflow`**: passes `{ phaseTimeoutMs }` to `workflowEngine.execute()`.
+- **`IWorkflowEngine.execute`** (`core/types/workflow.ts`): added the optional third `options?: { phaseTimeoutMs?: number }` parameter (documented as winning over both `workflow.timeout` and the engine's `defaultTimeoutMs`).
+- **`WorkflowEngine.execute` → `runExecution` → `executePhases`**: threads `phaseTimeoutMs` down to the `ExecutionOptions` builder, where it now wins over `workflow.timeout ?? this.config.defaultTimeoutMs`.
+
+### Semantic clarification
+
+This overrides the per-phase **overall** execution timeout — `executeParallel`'s `setupOverallTimeout`. It is NOT a per-step timeout (per-step uses `step.timeout` from the workflow definition, separately). The docstrings and schema descriptions explicitly say "per-phase" to avoid the same confusion that `run_dev_pipeline`'s identically-named-but-dead `timeoutMs` field already creates.
+
+### Test coverage
+
+2 new tests in `workflow-engine.test.ts`:
+
+- `threads phaseTimeoutMs option down to executePhase ExecutionOptions` — passing `{ phaseTimeoutMs: 999_999 }` wins over a template with `timeout: 5000`.
+- `falls back to workflow.timeout when phaseTimeoutMs is omitted` — omitting the option correctly uses `workflow.timeout`.
+
+26 tests pass (was 24); `tsc + eslint` clean.
+
+Closes #3017. #2931's other deferred follow-up (#3016, first-step adapter hang root cause) is separate.

--- a/packages/nexus-agents/src/core/types/workflow.ts
+++ b/packages/nexus-agents/src/core/types/workflow.ts
@@ -177,11 +177,16 @@ export interface IWorkflowEngine {
    * Execute a workflow with inputs.
    * @param workflow - Workflow definition
    * @param inputs - Input values
+   * @param options - Optional execution overrides. `phaseTimeoutMs` (#3017)
+   *   overrides the per-phase execution timeout for this run only — wins
+   *   over both `workflow.timeout` (set in the template YAML) and the
+   *   engine's `defaultTimeoutMs`.
    * @returns Result with WorkflowResult or WorkflowError
    */
   execute(
     workflow: WorkflowDefinition,
-    inputs: Record<string, unknown>
+    inputs: Record<string, unknown>,
+    options?: { phaseTimeoutMs?: number }
   ): Promise<Result<WorkflowResult, WorkflowError>>;
 
   /**

--- a/packages/nexus-agents/src/mcp/tools/run-workflow-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow-types.ts
@@ -22,6 +22,22 @@ export const RunWorkflowInputSchema = z.object({
   template: z.string().min(1).describe('Workflow template name (e.g., code-review) or file path'),
   inputs: z.record(z.string(), z.unknown()).describe('Workflow inputs as key-value pairs'),
   dryRun: z.boolean().optional().default(false).describe('Validate workflow without executing'),
+  /**
+   * Per-phase execution timeout in milliseconds (closes #3017). Wins over
+   * both `workflow.timeout` (set in the template YAML) and the engine's
+   * `defaultTimeoutMs`. Use for known-long workflow templates (e.g.,
+   * security-audit over a large repo) where the default phase budget
+   * isn't enough. Bounded to [1s, 30min] to prevent both flapping
+   * cancellations and unbounded hangs that would defeat the
+   * timeout-mismatch telemetry.
+   */
+  timeoutMs: z
+    .number()
+    .int()
+    .min(1000)
+    .max(1_800_000)
+    .optional()
+    .describe('Per-phase execution timeout in ms (overrides workflow.timeout)'),
 });
 
 export type RunWorkflowInput = z.infer<typeof RunWorkflowInputSchema>;

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -95,11 +95,14 @@ async function executeWorkflow(
   });
 
   const startTime = getTimeProvider().now();
-  const result = await workflowEngine.execute(
-    workflow,
-    inputs,
-    options?.phaseTimeoutMs !== undefined ? { phaseTimeoutMs: options.phaseTimeoutMs } : undefined
-  );
+  // Pass the third arg only when phaseTimeoutMs is set — keeps the
+  // `(workflow, inputs)` call shape for existing tests that
+  // toHaveBeenCalledWith exactly two args (vitest treats explicit
+  // `undefined` as a third arg).
+  const result =
+    options?.phaseTimeoutMs !== undefined
+      ? await workflowEngine.execute(workflow, inputs, { phaseTimeoutMs: options.phaseTimeoutMs })
+      : await workflowEngine.execute(workflow, inputs);
 
   if (!result.ok) {
     logger?.error('Workflow execution failed', result.error, {

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -83,17 +83,23 @@ export type { ToolResponse, InputValidationResult } from './run-workflow-helpers
 async function executeWorkflow(
   deps: RunWorkflowDeps,
   workflow: WorkflowDefinition,
-  inputs: Record<string, unknown>
+  inputs: Record<string, unknown>,
+  options?: { phaseTimeoutMs?: number }
 ): Promise<Result<WorkflowToolResult, WorkflowError>> {
   const { workflowEngine, logger } = deps;
 
   logger?.info('Executing workflow', {
     workflowName: workflow.name,
     inputCount: Object.keys(inputs).length,
+    ...(options?.phaseTimeoutMs !== undefined ? { phaseTimeoutMs: options.phaseTimeoutMs } : {}),
   });
 
   const startTime = getTimeProvider().now();
-  const result = await workflowEngine.execute(workflow, inputs);
+  const result = await workflowEngine.execute(
+    workflow,
+    inputs,
+    options?.phaseTimeoutMs !== undefined ? { phaseTimeoutMs: options.phaseTimeoutMs } : undefined
+  );
 
   if (!result.ok) {
     logger?.error('Workflow execution failed', result.error, {
@@ -203,8 +209,13 @@ async function handleRunWorkflow(
   deps: RunWorkflowDeps,
   args: RunWorkflowInput
 ): Promise<ToolResponse> {
-  const { template, inputs, dryRun } = args;
-  deps.logger?.debug('run_workflow called', { template, dryRun, inputKeys: Object.keys(inputs) });
+  const { template, inputs, dryRun, timeoutMs } = args;
+  deps.logger?.debug('run_workflow called', {
+    template,
+    dryRun,
+    inputKeys: Object.keys(inputs),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  });
 
   const loadResult = await loadWorkflow(deps, template);
   if (!loadResult.ok) {
@@ -222,7 +233,15 @@ async function handleRunWorkflow(
     return errorResponse(formatValidationErrors(validation));
   }
 
-  const executeResult = await executeWorkflow(deps, workflow, inputs);
+  // #3017: thread the caller-supplied timeoutMs (if any) through to the
+  // workflow engine. Wins over both `workflow.timeout` and the engine's
+  // `defaultTimeoutMs` for known-long templates.
+  const executeResult = await executeWorkflow(
+    deps,
+    workflow,
+    inputs,
+    timeoutMs !== undefined ? { phaseTimeoutMs: timeoutMs } : undefined
+  );
   if (!executeResult.ok) {
     recordWorkflowError(template, executeResult.error.message);
     return buildFailureEnvelope(workflow.name, executeResult.error);
@@ -241,6 +260,14 @@ const toolInputSchema = {
   template: z.string().min(1).describe('Workflow template name (e.g., code-review) or file path'),
   inputs: z.record(z.string().max(100), z.unknown()).describe('Workflow inputs as key-value pairs'),
   dryRun: z.boolean().optional().default(false).describe('Validate workflow without executing'),
+  // #3017
+  timeoutMs: z
+    .number()
+    .int()
+    .min(1000)
+    .max(1_800_000)
+    .optional()
+    .describe('Per-phase execution timeout in ms (overrides workflow.timeout, bound [1s, 30min])'),
 };
 
 /**

--- a/packages/nexus-agents/src/workflows/workflow-engine.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.test.ts
@@ -222,6 +222,49 @@ describe('WorkflowEngine', () => {
       // Original message preserved verbatim
       expect(result.error.message).toBe("Step 'first' failed: adapter hang");
     });
+
+    // #3017: the run_workflow MCP tool passes an optional `phaseTimeoutMs`
+    // override that should win over both `workflow.timeout` and the
+    // engine's default. Verify it threads down to ExecutionOptions.timeoutMs.
+    it('threads phaseTimeoutMs option down to executePhase ExecutionOptions (#3017)', async () => {
+      const workflow = { ...sampleWorkflow, timeout: 5000 }; // template default 5s
+      mockDeps.createExecutionPlan = vi
+        .fn()
+        .mockReturnValue(ok({ phases: [{ steps: [workflow.steps[0] as WorkflowStep] }] }));
+      const recorded: number[] = [];
+      mockDeps.executePhase = vi.fn().mockImplementation((_steps, _ctx, opts) => {
+        const t = (opts as { timeoutMs?: number }).timeoutMs;
+        if (t !== undefined) recorded.push(t);
+        return Promise.resolve(
+          ok([{ stepId: 'step1', output: 'done', durationMs: 10, status: 'success' }])
+        );
+      });
+
+      await engine.execute(workflow, { input1: 'x' }, { phaseTimeoutMs: 999_999 });
+
+      // Caller override wins over the template's 5000ms.
+      expect(recorded).toEqual([999_999]);
+    });
+
+    it('falls back to workflow.timeout when phaseTimeoutMs is omitted (#3017)', async () => {
+      const workflow = { ...sampleWorkflow, timeout: 5000 };
+      mockDeps.createExecutionPlan = vi
+        .fn()
+        .mockReturnValue(ok({ phases: [{ steps: [workflow.steps[0] as WorkflowStep] }] }));
+      const recorded: number[] = [];
+      mockDeps.executePhase = vi.fn().mockImplementation((_steps, _ctx, opts) => {
+        const t = (opts as { timeoutMs?: number }).timeoutMs;
+        if (t !== undefined) recorded.push(t);
+        return Promise.resolve(
+          ok([{ stepId: 'step1', output: 'done', durationMs: 10, status: 'success' }])
+        );
+      });
+
+      // No `phaseTimeoutMs` — should fall back to workflow.timeout (5000).
+      await engine.execute(workflow, { input1: 'x' });
+
+      expect(recorded).toEqual([5000]);
+    });
   });
 
   describe('getStatus', () => {

--- a/packages/nexus-agents/src/workflows/workflow-engine.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.ts
@@ -67,10 +67,19 @@ export class WorkflowEngine implements IWorkflowEngine {
     return this.deps.loadWorkflowFile(path);
   }
 
-  /** Execute a workflow with inputs. */
+  /**
+   * Execute a workflow with inputs.
+   *
+   * `options.phaseTimeoutMs` (added in #3017) overrides the per-phase
+   * execution timeout for this run only — wins over both `workflow.timeout`
+   * (set in the template YAML) and the engine's `defaultTimeoutMs`. Used
+   * by the `run_workflow` MCP tool to expose a caller-supplied `timeoutMs`
+   * for known-long templates (e.g. security-audit over a large repo).
+   */
   async execute(
     workflow: WorkflowDefinition,
-    inputs: Record<string, unknown>
+    inputs: Record<string, unknown>,
+    options?: { phaseTimeoutMs?: number }
   ): Promise<Result<WorkflowResult, WorkflowError>> {
     // Validate inputs and create execution plan
     const inputValidation = this.validateInputs(workflow, inputs);
@@ -96,26 +105,31 @@ export class WorkflowEngine implements IWorkflowEngine {
     this.executions.set(initResult.executionId, initResult.execution);
 
     try {
-      return await this.runExecution(
+      return await this.runExecution({
         workflow,
-        planResult.value,
-        initResult.context,
-        initResult.executionId,
-        initResult.startTime
-      );
+        plan: planResult.value,
+        context: initResult.context,
+        executionId: initResult.executionId,
+        startTime: initResult.startTime,
+        ...(options?.phaseTimeoutMs !== undefined
+          ? { phaseTimeoutMs: options.phaseTimeoutMs }
+          : {}),
+      });
     } catch (error) {
       return this.handleExecutionError(error, initResult.executionId, workflow.name);
     }
   }
 
-  private async runExecution(
-    workflow: WorkflowDefinition,
-    plan: ExecutionPlan,
-    context: ExecutionContext,
-    executionId: string,
-    startTime: number
-  ): Promise<Result<WorkflowResult, WorkflowError>> {
-    const stepResults = await this.executePhases(plan, context, workflow);
+  private async runExecution(args: {
+    workflow: WorkflowDefinition;
+    plan: ExecutionPlan;
+    context: ExecutionContext;
+    executionId: string;
+    startTime: number;
+    phaseTimeoutMs?: number;
+  }): Promise<Result<WorkflowResult, WorkflowError>> {
+    const { workflow, plan, context, executionId, startTime, phaseTimeoutMs } = args;
+    const stepResults = await this.executePhases(plan, context, workflow, phaseTimeoutMs);
     if (!stepResults.ok) {
       this.updateExecutionStatus(executionId, {
         state: 'failed',
@@ -262,7 +276,8 @@ export class WorkflowEngine implements IWorkflowEngine {
   private async executePhases(
     plan: ExecutionPlan,
     context: ExecutionContext,
-    workflow: WorkflowDefinition
+    workflow: WorkflowDefinition,
+    phaseTimeoutMs?: number
   ): Promise<Result<StepResult[], WorkflowError>> {
     const allResults: StepResult[] = [];
     const totalSteps = plan.phases.reduce((sum, p) => sum + p.steps.length, 0);
@@ -293,10 +308,12 @@ export class WorkflowEngine implements IWorkflowEngine {
       });
       if (!enforceResult.ok) return enforceResult;
 
+      // #3017: per-call `phaseTimeoutMs` from run_workflow MCP input wins
+      // over both `workflow.timeout` and `this.config.defaultTimeoutMs`.
       const options: ExecutionOptions = {
         maxConcurrency: this.config.maxConcurrency,
         failFast: true,
-        timeoutMs: workflow.timeout ?? this.config.defaultTimeoutMs,
+        timeoutMs: phaseTimeoutMs ?? workflow.timeout ?? this.config.defaultTimeoutMs,
       };
 
       const phaseResult = await this.deps.executePhase(phase.steps, context, options);


### PR DESCRIPTION
## Summary

Pre-fix, the per-phase execution timeout was always \`workflow.timeout\` (from the template YAML) or the engine's \`defaultTimeoutMs\` — known-long templates like \`security-audit\` over a large repo couldn't be given a one-off larger budget without editing the template. #2931 surfaced the need (a 120s default-tripped run was un-debuggable); this closes #3017 with the ability to extend the budget for legitimately-slow workloads.

## Wiring (top to bottom)

- \`RunWorkflowInputSchema\` (\`mcp/tools/run-workflow-types.ts\`): added optional \`timeoutMs\` bounded \`[1s, 30min]\`.
- MCP tool \`inputSchema\` (\`mcp/tools/run-workflow.ts\`): added \`timeoutMs\` so it appears in tool advertisement.
- \`handleRunWorkflow\` extracts \`timeoutMs\` from validated args, threads into \`executeWorkflow\` as \`{ phaseTimeoutMs }\`.
- \`IWorkflowEngine.execute\` (\`core/types/workflow.ts\`): added \`options?: { phaseTimeoutMs?: number }\` parameter, documented as winning over both \`workflow.timeout\` and the engine's \`defaultTimeoutMs\`.
- \`WorkflowEngine.execute → runExecution → executePhases\` plumb \`phaseTimeoutMs\` down to the \`ExecutionOptions\` builder where it now wins over \`workflow.timeout ?? this.config.defaultTimeoutMs\`.

## Semantic clarification

Overrides the per-phase **overall** execution timeout (\`setupOverallTimeout\` in \`parallel-executor.ts\`). Does NOT override per-step timeout (per-step still uses \`step.timeout\` from the workflow definition). Docstrings + schema descriptions say "per-phase" explicitly to avoid the same confusion that \`run_dev_pipeline\`'s identically-named-but-dead \`timeoutMs\` field already creates.

## Test plan

- [x] 2 new tests in \`workflow-engine.test.ts\`:
  - caller override wins over template's \`workflow.timeout\`
  - omitting the option correctly falls back to \`workflow.timeout\`
- [x] \`pnpm vitest run src/workflows/workflow-engine.test.ts\` → 26 pass (was 24).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` on 5 touched files clean.
- [ ] CI: full matrix.

## What's left on #2931

PR landing here closes #3017 (item 4). #3016 (item 1 — root-cause investigation of the first-step adapter hang) is the remaining open work; it needs adapter-level tracing best done in a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)