### PR TITLE
fix(observability): subprocess timing logs carry requestId (closes #2963 site 3)

### DIFF
--- a/.changeset/2963-subprocess-taskid-correlation.md
+++ b/.changeset/2963-subprocess-taskid-correlation.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+**fix(observability):** subprocess timing logs now carry a `requestId` for correlation (closes #2963 site 3).
+
+`subprocess-adapter.ts:logTimingBreakdown` emits `'Subprocess timing'` at `info` level on every subprocess close, with the explicit goal (per JSDoc) of _"group by cli + provider + model and surface tail-latency outliers."_ Pre-fix the log had no per-call correlation key — multiple subprocesses for the same CLI run concurrently in pipelines and consensus votes, so the timing entries for the same CLI couldn't be disambiguated. Identifying which timing row belonged to which `executeTask` call was impossible from the logs alone.
+
+The fix generates a per-`executeTask` `requestId = generateHyphenId('cli-req', 8)` and threads it through:
+
+- `executeTask` → `spawnSubprocess` (initial attempt)
+- `executeTask` → `retryTransient` → `spawnSubprocess` (every retry uses the same `requestId` so retries-of-the-same-call group together)
+- `spawnSubprocess` → `setupChildProcessHandlers` (refactored to an opts-object to stay under the 5-param cap) → the `child.on('close')` handler
+- `logTimingBreakdown(state, startTime, code, requestId)` — emits `requestId` alongside the existing `cli` / `totalMs` / `spawnLatencyMs` / etc.
+
+`requestId` also appears in the `'Retrying transient error'` debug log so all log lines for a single call (initial attempt + retries + final timing) carry the same correlation key.
+
+The ID is adapter-internal — it doesn't propagate up to MCP. CliTask's contract is unchanged.
+
+37 existing tests pass; tsc + eslint clean. Added a `/* eslint-disable max-lines */` to the file header since the threading bumped the line count just past the 400-line cap (the file is one cohesive base-adapter class, governance allows 400-600 for cohesive files).
+
+Closes #2963 site 3. (Sites 1, 2, 4 shipped in #3002.)

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Cohesive subprocess adapter base class; governance 400-600 OK if cohesive */
 /**
  * nexus-agents/cli-adapters - Subprocess Adapter
  *
@@ -26,6 +27,7 @@ import { buildChildEnv } from './subprocess-env.js';
 import { sanitizeOutput } from '../security/output-sanitizer.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
 import { parseCliErrorEnvelope } from './cli-error-envelope.js';
+import { generateHyphenId } from '../utils/id-utils.js';
 
 /** Minimum length for plaintext fallback to kick in.
  * Lowered from 100→30 to recover short but valid CLI responses (#1401). */
@@ -270,11 +272,18 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     task: CliTask,
     options: Required<ExecutionOptions>
   ): Promise<Result<CliResponse, CliError>> {
-    const result = await this.spawnSubprocess(task, options);
+    // #2963 site 3: per-execute request ID for log correlation. CliTask
+    // doesn't carry a task-id field; generate one here so every
+    // log-line for this invocation (including the per-retry timing
+    // breakdown emitted by `logTimingBreakdown`) can be grouped by a
+    // single ID. Doesn't propagate up to MCP — it's purely an
+    // adapter-internal correlation key.
+    const requestId = generateHyphenId('cli-req', 8);
+    const result = await this.spawnSubprocess(task, options, requestId);
     if (result.ok || !this.transientRetry.enabled) return result;
     if (!isTransientError(result.error.code)) return result;
 
-    return this.retryTransient(task, options, result, 0);
+    return this.retryTransient(task, options, result, 0, requestId);
   }
 
   /**
@@ -284,7 +293,8 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     task: CliTask,
     options: Required<ExecutionOptions>,
     lastResult: Result<CliResponse, CliError>,
-    attempt: number
+    attempt: number,
+    requestId: string
   ): Promise<Result<CliResponse, CliError>> {
     const isParseError = !lastResult.ok && lastResult.error.code === 'PARSE_ERROR';
     const maxRetries = isParseError ? MAX_PARSE_RETRIES : MAX_TRANSIENT_RETRIES;
@@ -295,6 +305,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     const isTimeout = !lastResult.ok && lastResult.error.code === 'TIMEOUT';
     subprocessLogger.debug('Retrying transient error', {
       cli: this.name,
+      requestId,
       attempt: attempt + 1,
       delayMs,
       errorCode: !lastResult.ok ? lastResult.error.code : undefined,
@@ -306,19 +317,27 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     const retryOptions = isTimeout
       ? { ...options, timeoutMs: Math.round(options.timeoutMs * TIMEOUT_RETRY_MULTIPLIER) }
       : options;
-    const result = await this.spawnSubprocess(task, retryOptions);
+    const result = await this.spawnSubprocess(task, retryOptions, requestId);
     if (result.ok) return result;
     if (!isTransientError(result.error.code)) return result;
 
-    return this.retryTransient(task, retryOptions, result, attempt + 1);
+    return this.retryTransient(task, retryOptions, result, attempt + 1, requestId);
   }
 
   /**
    * Spawns a single subprocess execution (no retry).
+   *
+   * `requestId` (#2963 site 3) correlates the timing-breakdown log emitted
+   * on subprocess close back to the parent `executeTask` invocation —
+   * essential when multiple subprocesses for the same CLI run concurrently
+   * (pipelines, votes) and the JSDoc's stated goal ("group by cli + provider
+   * + model and surface tail-latency outliers") requires a way to
+   * disambiguate which timing row belongs to which call.
    */
   private spawnSubprocess(
     task: CliTask,
-    options: Required<ExecutionOptions>
+    options: Required<ExecutionOptions>,
+    requestId: string
   ): Promise<Result<CliResponse, CliError>> {
     const cmdConfig = this.getCommand(task);
     const startTime = getTimeProvider().now();
@@ -355,13 +374,14 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
       });
 
       const onProgress = options.onProgress;
-      const state = this.setupChildProcessHandlers(
+      const state = this.setupChildProcessHandlers({
         child,
         startTime,
-        options.timeoutMs,
+        timeoutMs: options.timeoutMs,
         resolve,
-        onProgress
-      );
+        requestId,
+        ...(onProgress !== undefined ? { onProgress } : {}),
+      });
 
       // Write stdin content if provided and close stdin
       if (cmdConfig.stdin !== undefined) {
@@ -377,13 +397,15 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
   /**
    * Sets up child process event handlers for output collection and error handling.
    */
-  private setupChildProcessHandlers(
-    child: ReturnType<typeof spawn>,
-    startTime: number,
-    timeoutMs: number,
-    resolve: (result: Result<CliResponse, CliError>) => void,
-    onProgress?: () => void
-  ): BufferState {
+  private setupChildProcessHandlers(args: {
+    child: ReturnType<typeof spawn>;
+    startTime: number;
+    timeoutMs: number;
+    resolve: (result: Result<CliResponse, CliError>) => void;
+    requestId: string;
+    onProgress?: () => void;
+  }): BufferState {
+    const { child, startTime, timeoutMs, resolve, requestId, onProgress } = args;
     const state: BufferState = {
       stdout: '',
       stderr: '',
@@ -415,7 +437,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
 
     child.on('close', (code: number | null) => {
       clearTimeout(timeoutId);
-      this.logTimingBreakdown(state, startTime, code);
+      this.logTimingBreakdown(state, startTime, code, requestId);
       resolveOnce(this.classifyCloseResult(code, state, startTime));
     });
 
@@ -458,13 +480,19 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    * Structured fields chosen so existing query_trace tooling can group by
    * cli + provider + model and surface tail-latency outliers.
    */
-  private logTimingBreakdown(state: BufferState, startTime: number, code: number | null): void {
+  private logTimingBreakdown(
+    state: BufferState,
+    startTime: number,
+    code: number | null,
+    requestId: string
+  ): void {
     const now = getTimeProvider().now();
     const totalMs = now - startTime;
     const spawnLatencyMs = state.firstByteTime === null ? null : state.firstByteTime - startTime;
     const streamingMs = state.firstByteTime === null ? null : now - state.firstByteTime;
     this.logger.info('Subprocess timing', {
       cli: this.name,
+      requestId,
       totalMs,
       spawnLatencyMs,
       streamingMs,


### PR DESCRIPTION
## Summary

\`subprocess-adapter.ts:logTimingBreakdown\` emits \`'Subprocess timing'\` at info level on every subprocess close. JSDoc states the goal as *"group by cli + provider + model and surface tail-latency outliers"* — but pre-fix there was no per-call correlation key, so multiple subprocesses for the same CLI running concurrently in pipelines and consensus votes couldn't be disambiguated in the logs.

## Fix

Generate a per-\`executeTask\` \`requestId = generateHyphenId('cli-req', 8)\` and thread through:

- \`executeTask → spawnSubprocess\` (initial attempt)
- \`executeTask → retryTransient → spawnSubprocess\` (retries use the same \`requestId\` so retries-of-same-call group together)
- \`spawnSubprocess → setupChildProcessHandlers\` (refactored to opts-object to stay under the 5-param cap) → \`child.on('close')\`
- \`logTimingBreakdown(state, startTime, code, requestId)\` emits \`requestId\` alongside existing \`cli\` / \`totalMs\` / \`spawnLatencyMs\` / \`stdoutBytes\` / etc.

\`requestId\` also threads into the \`'Retrying transient error'\` debug log so all log lines for a single call (initial attempt + retries + final timing) share the same key.

ID is adapter-internal — no contract change to \`CliTask\` or MCP.

## Test plan

- [x] \`pnpm vitest run src/cli-adapters/subprocess-adapter.test.ts\` → 37 pass (unchanged).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` clean.
- [ ] CI: full matrix.

## File-size note

Added \`/* eslint-disable max-lines */\` to the file header — the threading bumped the line count from 391 to 408, just past the 400-line cap. The file is one cohesive base-adapter class; governance allows 400-600 LOC for cohesive files (memory note \`ESLint Gotchas\`).

## What's left on #2963

This closes site 3 (subprocess-adapter taskId correlation). Sites 1 (raw-task-prompt-in-debug-logs), 2 (sensitive-file-access-at-info), and 4 (sessionId in plan-loop logs) shipped earlier in #3002. **#2963 will fully close on merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)