### PR TITLE
perf(context): cache RoutingMemory.getPreferences per taskType (closes #2955 site 4)

### DIFF
--- a/.changeset/2955-routing-memory-cache.md
+++ b/.changeset/2955-routing-memory-cache.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+**perf(context):** `RoutingMemory.getPreferences` caches per-taskType results (closes #2955 site 4).
+
+Pre-fix, every `getPreferences(taskType)` call did N=`CLI_NAMES.length` MobiMem profile lookups followed by an in-place sort, on every `CompositeRouter.route()` invocation. With `enableRoutingMemory=true` (default with persistence on), most calls produced empty results after the N lookups — pure waste on the routing hot path.
+
+### Fix
+
+- Added `preferencesCache: Map<string, readonly ModelPreference[]>` on `RoutingMemory`.
+- `getPreferences` returns the cached entry on hit (O(1)); on miss, does the original full `CLI_NAMES` sweep, freezes the sorted result, caches it, and returns. The CLI_NAMES sweep is preserved on cache miss so MobiMem data written by another `RoutingMemory` instance or a prior session (shared singleton from #2719) is still observed on first read.
+- `storePreference` invalidates the per-taskType cache entry (O(1) `Map.delete`) so the next read rebuilds with the new observation included.
+
+### Why the cache is safe
+
+The cache is correct within a single `RoutingMemory` instance's lifetime, which matches `CompositeRouter`'s usage pattern (process-singleton via `getGlobalRegistry()`). Cross-instance writes to the shared MobiMem aren't detected, but in practice no second instance writes to it during normal operation. If that changes, the cache can be invalidated externally by calling `storePreference` with any value, or replaced with a TTL-bounded variant.
+
+### Test coverage
+
+3 new tests (`routing-memory.test.ts`):
+
+- Second read returns the **same reference** (cache hit confirmed).
+- `storePreference` to a cached taskType invalidates and the rebuilt result reflects the new observation (different reference + higher strength).
+- Cache invalidation is **scoped to the modified taskType** — writing to `task-y` does not invalidate `task-x`'s cache.
+
+28 tests pass (was 25); `tsc + eslint` clean.
+
+Closes #2955 site 4. Sites 1, 2, and 3 (partial) shipped in #3005.

--- a/packages/nexus-agents/src/context/routing-memory.test.ts
+++ b/packages/nexus-agents/src/context/routing-memory.test.ts
@@ -162,6 +162,77 @@ describe('RoutingMemory', () => {
       expect(prefs[0]?.model).toBe('claude'); // Higher quality/success
       expect(prefs[0]?.strength).toBeGreaterThan(prefs[1]?.strength ?? 0);
     });
+
+    // #2955 site 4: per-taskType cache + invalidation on storePreference.
+    // Verifies the hot-path optimization preserves the observable contract.
+    it('caches per-taskType results — second read returns same reference (#2955)', () => {
+      const perf: ModelPerformance = {
+        avgQuality: 0.9,
+        successRate: 0.95,
+        avgLatencyMs: 500,
+        avgTokens: 1000,
+        observations: 10,
+      };
+      for (let i = 0; i < 5; i++) routingMemory.storePreference('claude', 'cached-task', perf);
+
+      const first = routingMemory.getPreferences('cached-task');
+      const second = routingMemory.getPreferences('cached-task');
+      expect(second).toBe(first); // identical reference — cache hit
+    });
+
+    it('invalidates the cache when storePreference writes the same taskType (#2955)', () => {
+      const lowPerf: ModelPerformance = {
+        avgQuality: 0.5,
+        successRate: 0.6,
+        avgLatencyMs: 1000,
+        avgTokens: 2000,
+        observations: 10,
+      };
+      const highPerf: ModelPerformance = {
+        avgQuality: 0.95,
+        successRate: 0.98,
+        avgLatencyMs: 100,
+        avgTokens: 500,
+        observations: 10,
+      };
+
+      for (let i = 0; i < 5; i++) routingMemory.storePreference('claude', 'task-a', lowPerf);
+      const beforeUpgrade = routingMemory.getPreferences('task-a');
+      const claudeBefore = beforeUpgrade[0]?.strength;
+      expect(claudeBefore).toBeDefined();
+
+      // Upgrade claude's performance — cache must invalidate so next read
+      // sees the new (higher) strength.
+      for (let i = 0; i < 5; i++) routingMemory.storePreference('claude', 'task-a', highPerf);
+      const afterUpgrade = routingMemory.getPreferences('task-a');
+      expect(afterUpgrade).not.toBe(beforeUpgrade); // different reference — cache rebuilt
+      expect(afterUpgrade[0]?.strength).toBeGreaterThan(claudeBefore ?? 0);
+    });
+
+    it('cache invalidation is scoped to the modified taskType (#2955)', () => {
+      const perf: ModelPerformance = {
+        avgQuality: 0.9,
+        successRate: 0.95,
+        avgLatencyMs: 500,
+        avgTokens: 1000,
+        observations: 10,
+      };
+      for (let i = 0; i < 5; i++) {
+        routingMemory.storePreference('claude', 'task-x', perf);
+        routingMemory.storePreference('gemini', 'task-y', perf);
+      }
+
+      const xBefore = routingMemory.getPreferences('task-x');
+      const yBefore = routingMemory.getPreferences('task-y');
+
+      // Write to task-y only — task-x cache should survive.
+      routingMemory.storePreference('codex', 'task-y', perf);
+
+      const xAfter = routingMemory.getPreferences('task-x');
+      const yAfter = routingMemory.getPreferences('task-y');
+      expect(xAfter).toBe(xBefore); // task-x cache untouched
+      expect(yAfter).not.toBe(yBefore); // task-y cache rebuilt
+    });
   });
 
   describe('recordExperience', () => {

--- a/packages/nexus-agents/src/context/routing-memory.ts
+++ b/packages/nexus-agents/src/context/routing-memory.ts
@@ -174,6 +174,24 @@ export class RoutingMemory implements IRoutingMemory {
   private cacheMisses = 0;
   private recommendationsMade = 0;
 
+  /**
+   * Per-taskType cache of `getPreferences()` results (#2955 site 4).
+   *
+   * Pre-fix, every `getPreferences()` call did N=`CLI_NAMES.length`
+   * MobiMem profile lookups followed by an in-place sort, on every
+   * CompositeRouter `route()` invocation. With `enableRoutingMemory=true`
+   * (default with persistence on), most calls produced empty results
+   * after the N lookups — pure waste on the routing hot path.
+   *
+   * The cache stores the sorted preference array per taskType and is
+   * invalidated by `storePreference(_, taskType, _)` writes. MobiMem
+   * mutations performed by other RoutingMemory instances or prior
+   * sessions are not detected; the cache is only correct within a
+   * single instance's lifetime, which matches CompositeRouter's
+   * usage pattern (singleton per process).
+   */
+  private preferencesCache = new Map<string, readonly ModelPreference[]>();
+
   constructor(config?: Partial<RoutingMemoryConfig>, mobimem?: MobiMem) {
     this.config = { ...DEFAULT_ROUTING_MEMORY_CONFIG, ...config };
     this.logger = this.config.logger ?? createLogger({ component: 'RoutingMemory' });
@@ -201,6 +219,11 @@ export class RoutingMemory implements IRoutingMemory {
       updatedAt: getTimeProvider().nowIso(),
     });
 
+    // #2955 site 4: invalidate the per-taskType preferences cache so the
+    // next getPreferences() call rebuilds with the new observation
+    // included. Cheap O(1) delete; no need to recompute eagerly.
+    this.preferencesCache.delete(taskType);
+
     this.logger.debug('Stored model preference', {
       model,
       taskType,
@@ -210,6 +233,15 @@ export class RoutingMemory implements IRoutingMemory {
   }
 
   getPreferences(taskType: string): readonly ModelPreference[] {
+    // #2955 site 4: cache the sorted preference array per taskType so
+    // subsequent calls skip the N MobiMem lookups + sort. Invalidation
+    // happens in storePreference. On a cache miss, do the original full
+    // CLI_NAMES sweep so MobiMem data written by another RoutingMemory
+    // instance (or a prior session — shared singleton from #2719) is
+    // still observed correctly on first read.
+    const cached = this.preferencesCache.get(taskType);
+    if (cached !== undefined) return cached;
+
     const preferenceKey = `model_preference:${taskType}`;
     const preferences: ModelPreference[] = [];
 
@@ -232,8 +264,11 @@ export class RoutingMemory implements IRoutingMemory {
       }
     }
 
-    // Sort by strength (descending)
-    return preferences.sort((a, b) => b.strength - a.strength);
+    // Sort by strength (descending) and freeze for cache safety.
+    preferences.sort((a, b) => b.strength - a.strength);
+    const result: readonly ModelPreference[] = Object.freeze([...preferences]);
+    this.preferencesCache.set(taskType, result);
+    return result;
   }
 
   recordExperience(


### PR DESCRIPTION
## Summary

Pre-fix, every \`RoutingMemory.getPreferences(taskType)\` call did N=\`CLI_NAMES.length\` MobiMem profile lookups followed by an in-place sort, on every \`CompositeRouter.route()\` invocation. With \`enableRoutingMemory=true\` (default with persistence on), most cold-start calls produced empty results after the N lookups — pure waste on the routing hot path.

## Fix

- Added \`preferencesCache: Map<string, readonly ModelPreference[]>\` on \`RoutingMemory\`.
- \`getPreferences\` returns the cached entry on hit (O(1)); on miss, does the original full \`CLI_NAMES\` sweep, freezes the sorted result, caches it, and returns. The CLI_NAMES sweep is preserved on cache miss so MobiMem data written by another instance or a prior session (shared singleton from #2719) is still observed on first read.
- \`storePreference\` invalidates the per-taskType cache entry (O(1) \`Map.delete\`) so the next read rebuilds with the new observation included.

## Cache correctness

Correct within a single \`RoutingMemory\` instance's lifetime, which matches \`CompositeRouter\`'s usage pattern (process-singleton via \`getGlobalRegistry()\`). Cross-instance writes to the shared MobiMem aren't detected; in practice no second instance writes to it during normal operation. If that changes, switch to a TTL-bounded variant.

## Test plan

- [x] 3 new tests in \`routing-memory.test.ts\`:
  - Second read returns the **same reference** (cache hit confirmed).
  - \`storePreference\` to a cached taskType invalidates and the rebuilt result reflects the new observation (different reference + higher strength).
  - Cache invalidation is **scoped to the modified taskType** — writing to \`task-y\` does not invalidate \`task-x\`'s cache.
- [x] \`pnpm vitest run src/context/routing-memory.test.ts\` → 28 pass (was 25).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` clean.
- [ ] CI: full matrix.

## What's left on #2955

Sites 1, 2, and 3 (partial) shipped in #3005. This closes site 4. **#2955 will fully close on merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)