### PR TITLE
fix(subprocess): sigkill escalation on timeout (closes #3026 finding 1)

### DIFF
--- a/.changeset/3026-finding-1-sigkill-escalation.md
+++ b/.changeset/3026-finding-1-sigkill-escalation.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+**fix(subprocess):** SIGKILL escalation when child ignores SIGTERM on timeout (closes #3026 finding 1).
+
+The subprocess timeout path fired SIGTERM and resolved the parent promise immediately so callers don't wait on a hung child. But if the child ignored SIGTERM — Node CLIs that install graceful-shutdown handlers can hang on a broken stream, or spawn subprocesses of their own that keep stdio open — the `'close'` event never fired and the process accumulated as a zombie. Under sustained timeout pressure (long consensus votes with rate-limited backends), zombie Node CLI processes pile up holding file descriptors, API session tokens, and PIDs — eventually exhausting OS limits in ways operators can't trace back to nexus-agents.
+
+The fix:
+
+- Added `SIGKILL_GRACE_MS = 5_000` constant. Five seconds gives well-behaved children time to flush state and exit cleanly while bounding zombie-process accumulation when the child ignores SIGTERM.
+- Extracted a `scheduleTimeoutWithSigkillEscalation` helper from `setupChildProcessHandlers` (the latter was at the 50-line cap). The escalation timer fires after the grace window, checks `child.exitCode === null && child.signalCode === null` (still running), and force-reaps with `child.kill('SIGKILL')`. Logs a warn before escalating so operators can correlate the resource cleanup.
+- The escalation timer is `.unref()`'d so it doesn't keep the Node event loop alive — process shutdown wins over the escalation wait.
+- Both the primary timeout and the escalation timer are cleared from the `'close'` handler, so a child that exits within the grace window doesn't see the second signal.
+
+2 regression tests in `subprocess-adapter.test.ts`:
+
+- SIGKILL fires after the grace window when child ignores SIGTERM (`exitCode` and `signalCode` both stay `null`).
+- SIGKILL does NOT fire when the child exits cleanly within the grace window (`exitCode = 143` set on close).
+
+39 tests pass (was 37); `tsc + eslint` clean.
+
+#3026 finding 2 (AbortSignal threading through `ICliAdapter.execute` so race-loser subprocesses get cancelled cleanly) is the larger half of PR 2 — still pending, will land separately as a contract change touching all 5 concrete adapters + 3 call sites.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -12,7 +12,7 @@ import { Writable, Readable } from 'node:stream';
 
 import type { CliTask, ExecutionOptions, ICliResponseParser } from './types.js';
 import type { CommandConfig } from './subprocess-adapter.js';
-import { SubprocessCliAdapter } from './subprocess-adapter.js';
+import { SubprocessCliAdapter, SIGKILL_GRACE_MS } from './subprocess-adapter.js';
 
 // Mock node:child_process
 vi.mock('node:child_process', async (importOriginal) => {
@@ -47,6 +47,13 @@ function createMockChildProcess() {
     stderr,
     kill: vi.fn(),
     pid: 1234,
+    // exitCode/signalCode are read by #3026 finding 1's SIGKILL escalation
+    // path (only fires when both are still null after the SIGTERM grace
+    // period — meaning the child has not exited). Default to null so the
+    // mock matches a still-running child; tests that simulate a child
+    // exiting cleanly should `close` the emitter before the grace timer.
+    exitCode: null as number | null,
+    signalCode: null as string | null,
   }) as unknown as ChildProcess;
 
   return { mockChild, stdin, stdout, stderr };
@@ -358,6 +365,82 @@ describe('SubprocessCliAdapter', () => {
         expect(result.error.code).toBe('TIMEOUT');
         expect(result.error.message).toBe('Execution timed out');
       }
+
+      vi.useRealTimers();
+    });
+
+    // #3026 finding 1: SIGTERM-only timeout could leave zombie subprocesses
+    // when the child ignores SIGTERM. The escalation path fires SIGKILL
+    // after SIGKILL_GRACE_MS if the child still hasn't exited.
+    it('escalates to SIGKILL when child ignores SIGTERM (#3026 finding 1)', async () => {
+      vi.useFakeTimers();
+
+      adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
+      const task: CliTask = { content: 'test' };
+      const options: Required<ExecutionOptions> = {
+        timeoutMs: 1000,
+        allowRetry: true,
+        maxRetries: 1,
+        trackUsage: true,
+        onProgress: undefined,
+      };
+
+      const { mockChild } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const promise = adapter.executeTask(task, options);
+
+      // Fast-forward past the primary timeout → SIGTERM fires.
+      vi.advanceTimersByTime(1001);
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(mockChild.kill).toHaveBeenCalledTimes(1);
+
+      // Child ignores SIGTERM (exitCode/signalCode stay null). Fast-forward
+      // past the SIGKILL grace window — SIGKILL should now fire.
+      vi.advanceTimersByTime(SIGKILL_GRACE_MS + 1);
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(mockChild.kill).toHaveBeenCalledTimes(2);
+
+      // Once the OS force-reaps, the close handler fires.
+      mockChild.emit('close', null);
+      const result = await promise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe('TIMEOUT');
+
+      vi.useRealTimers();
+    });
+
+    it('does NOT escalate to SIGKILL when child exits cleanly within grace window (#3026 finding 1)', async () => {
+      vi.useFakeTimers();
+
+      adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
+      const task: CliTask = { content: 'test' };
+      const options: Required<ExecutionOptions> = {
+        timeoutMs: 1000,
+        allowRetry: true,
+        maxRetries: 1,
+        trackUsage: true,
+        onProgress: undefined,
+      };
+
+      const { mockChild } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const promise = adapter.executeTask(task, options);
+      vi.advanceTimersByTime(1001);
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+      // Child responds to SIGTERM and exits within the grace window —
+      // the SIGKILL timer fires but the exitCode === null check fails so
+      // no second kill() call happens.
+      (mockChild as unknown as { exitCode: number }).exitCode = 143;
+      mockChild.emit('close', 143);
+      await promise;
+
+      // Advance well past grace; SIGKILL should NOT have been called.
+      vi.advanceTimersByTime(SIGKILL_GRACE_MS * 2);
+      expect(mockChild.kill).toHaveBeenCalledTimes(1);
+      expect(mockChild.kill).not.toHaveBeenCalledWith('SIGKILL');
 
       vi.useRealTimers();
     });

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -138,6 +138,14 @@ export const MAX_PARSE_RETRIES = 1;
 export const TIMEOUT_RETRY_MULTIPLIER = 1.5;
 
 /**
+ * Grace period before escalating SIGTERM to SIGKILL on timeout (#3026
+ * finding 1). 5s gives well-behaved children time to flush state and
+ * exit cleanly while bounding zombie-process accumulation when a child
+ * ignores SIGTERM. Exported so tests can assert against the threshold.
+ */
+export const SIGKILL_GRACE_MS = 5_000;
+
+/**
  * Checks whether a CliErrorCode represents a transient failure.
  * Timeout, rate_limit, connection, and parse errors are transient.
  * Parse errors get fewer retries (MAX_PARSE_RETRIES) than others (#1533).
@@ -430,18 +438,62 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
       resolveOnce(this.handleSubprocessError(error));
     });
 
-    const timeoutId = setTimeout(() => {
-      child.kill('SIGTERM');
-      resolveOnce(err(this.createError('TIMEOUT', 'Execution timed out')));
-    }, timeoutMs);
+    const timers = this.scheduleTimeoutWithSigkillEscalation({
+      child,
+      timeoutMs,
+      requestId,
+      resolveOnce,
+    });
 
     child.on('close', (code: number | null) => {
-      clearTimeout(timeoutId);
+      clearTimeout(timers.timeoutId);
+      if (timers.sigkillTimerId !== undefined) clearTimeout(timers.sigkillTimerId);
       this.logTimingBreakdown(state, startTime, code, requestId);
       resolveOnce(this.classifyCloseResult(code, state, startTime));
     });
 
     return state;
+  }
+
+  /**
+   * Schedules the SIGTERM-on-timeout + SIGKILL-on-grace escalation
+   * (#3026 finding 1).
+   *
+   * The primary timer fires SIGTERM and resolves the caller's promise
+   * immediately so it doesn't wait on a hung child. The escalation
+   * timer (`SIGKILL_GRACE_MS` later) checks whether the child actually
+   * exited and force-reaps it with SIGKILL if not — preventing
+   * zombie accumulation when a child ignores SIGTERM (Node CLIs that
+   * install graceful-shutdown handlers can hang on a broken stream).
+   * Both timers are cleared from the `'close'` handler so a child
+   * that exits within the grace window doesn't see the second signal.
+   */
+  private scheduleTimeoutWithSigkillEscalation(opts: {
+    child: ReturnType<typeof spawn>;
+    timeoutMs: number;
+    requestId: string;
+    resolveOnce: (result: Result<CliResponse, CliError>) => void;
+  }): { timeoutId: NodeJS.Timeout; sigkillTimerId: NodeJS.Timeout | undefined } {
+    const { child, timeoutMs, requestId, resolveOnce } = opts;
+    const timers: { timeoutId: NodeJS.Timeout; sigkillTimerId: NodeJS.Timeout | undefined } = {
+      timeoutId: setTimeout(() => {
+        child.kill('SIGTERM');
+        resolveOnce(err(this.createError('TIMEOUT', 'Execution timed out')));
+        timers.sigkillTimerId = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            this.logger.warn('Child ignored SIGTERM, escalating to SIGKILL', {
+              cli: this.name,
+              requestId,
+              sigkillGraceMs: SIGKILL_GRACE_MS,
+            });
+            child.kill('SIGKILL');
+          }
+        }, SIGKILL_GRACE_MS);
+        timers.sigkillTimerId.unref();
+      }, timeoutMs),
+      sigkillTimerId: undefined,
+    };
+    return timers;
   }
 
   /** Attach stdout/stderr data handlers + capture first-byte time (#2472). */


### PR DESCRIPTION
## Summary

The subprocess timeout path fired SIGTERM and resolved the parent promise immediately so callers don't wait on a hung child. But if the child ignored SIGTERM — Node CLIs that install graceful-shutdown handlers can hang on a broken stream, or spawn subprocesses of their own that keep stdio open — the \`'close'\` event never fired and the process accumulated as a zombie. Under sustained timeout pressure (long consensus votes with rate-limited backends), zombie Node CLI processes pile up holding file descriptors, API session tokens, and PIDs.

## Fix

- Added \`SIGKILL_GRACE_MS = 5_000\` constant — gives well-behaved children time to flush state and exit cleanly while bounding zombie accumulation.
- Extracted \`scheduleTimeoutWithSigkillEscalation\` helper from \`setupChildProcessHandlers\` (the latter was at the 50-line cap). The escalation timer fires after the grace window, checks \`child.exitCode === null && child.signalCode === null\` (still running), and force-reaps with \`child.kill('SIGKILL')\`. Logs a warn before escalating so operators can correlate the resource cleanup.
- Escalation timer is \`.unref()\`'d so it doesn't keep the Node event loop alive — process shutdown wins over the escalation wait.
- Both the primary timeout and the escalation timer are cleared from the \`'close'\` handler, so a child that exits within the grace window doesn't see the second signal.

## Test plan

- [x] 2 new regression tests in \`subprocess-adapter.test.ts\`:
  - SIGKILL fires after the grace window when child ignores SIGTERM (\`exitCode\` and \`signalCode\` both stay \`null\`).
  - SIGKILL does NOT fire when the child exits cleanly within the grace window (\`exitCode = 143\` set on close).
- [x] \`pnpm vitest run src/cli-adapters/subprocess-adapter.test.ts\` → **39 pass** (was 37).
- [x] \`pnpm tsc --noEmit\` + \`pnpm eslint\` clean.
- [ ] CI: full matrix.

## What's left on #3026

Finding 2 (AbortSignal threading through \`ICliAdapter.execute\` so race-loser subprocesses get cancelled cleanly) is the larger half of PR 2 — a contract change touching all 5 concrete adapters + 3 call sites (parallel-exploration, watchdog, consensus-plan). Deserves its own focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)