### PR TITLE
fix(cli-adapters): thread AbortSignal through ICliAdapter (closes #3026 finding 2)

### DIFF
--- a/.changeset/3026-finding-2-abortsignal-adapter.md
+++ b/.changeset/3026-finding-2-abortsignal-adapter.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': patch
+---
+
+**fix(cli-adapters):** thread AbortSignal through `ICliAdapter.execute` so race-loser subprocesses get cancelled (closes #3026 finding 2).
+
+Callers that bounded adapter latency with `Promise.race([adapter.execute(task), timeout])` had no way to tell the adapter "the timeout won, stop running." When timeout won, `adapter.execute` kept executing — the subprocess kept running to completion, then posted its result into OutcomeStore and LinUCB state for a task whose decision was already recorded. Symptoms: late outcome rows attributing success/failure to the wrong (already-discarded) candidate, LinUCB feature updates from stale CLI calls, and orphan subprocess fan-out under sustained timeout pressure.
+
+The fix:
+
+- Added `signal?: AbortSignal | undefined` to `ExecutionOptions`. Typed as `AbortSignal | undefined` (not `AbortSignal?`) so the pervasive internal `Required<ExecutionOptions>` shape keeps working under `exactOptionalPropertyTypes`.
+- Added `ResolvedExecutionOptions = Required<Omit<ExecutionOptions, 'signal'>> & Pick<ExecutionOptions, 'signal'>` — the internal resolved-options shape used by adapters and tests. `signal` stays optional because it's a per-call hook, not a defaultable value.
+- `SubprocessCliAdapter.spawnSubprocess` now:
+  - Fast-fails with `TIMEOUT: Aborted before spawn` if `signal.aborted === true` (saves a child process start when an upstream wave/loop has already moved on).
+  - Attaches an abort listener that SIGTERMs the child mid-execution if `signal` aborts. SIGKILL escalation from #3026 finding 1 still applies if the child ignores SIGTERM.
+  - Removes the abort listener on `'close'` so it doesn't leak across child lifetimes.
+- Three orchestration call sites pass `signal: controller.signal` and abort the controller in `finally`:
+  - `orchestration/parallel-exploration.ts` (per-CLI partition timeout)
+  - `orchestration/consensus-plan.ts` (per-CLI plan timeout)
+  - `orchestration/triangulated-review.ts` (per-CLI review timeout)
+
+Three regression tests in `subprocess-adapter.test.ts`:
+
+- `signal.aborted === true` before call → fast-fails without spawning.
+- Signal aborts mid-execution → SIGTERMs child, returns `TIMEOUT: Aborted by caller signal`.
+- Signal aborts after child already exited → no SIGTERM (listener detached on `'close'`).
+
+42 tests pass (was 39); 50 orchestration tests pass; `tsc + eslint` clean.
+
+`orchestration/aorchestra/watchdog.ts` also races a generic `task: () => Promise<T>` against a timeout, but its callback is opaque to the watchdog so threading AbortSignal through requires a signature change at every caller — tracked as a follow-up.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
@@ -7,7 +7,7 @@
  * (Source: cli-project_plan.md v2.1.0, Issue #90)
  */
 
-import type { ExecutionOptions, CliError, CliName } from '../types.js';
+import type { ResolvedExecutionOptions, CliError, CliName } from '../types.js';
 import { CODEX_MCP_TIMEOUTS } from '../../config/timeouts.js';
 import {
   createCliError as sharedCreateCliError,
@@ -21,7 +21,7 @@ export { CODEX_LEGACY_DEFAULTS } from './codex-adapter-helpers.js';
  * Default execution options for Codex MCP.
  * Timeout and retry values derived from config/timeouts.ts (#1220).
  */
-export const DEFAULT_CODEX_MCP_OPTIONS: Required<ExecutionOptions> = {
+export const DEFAULT_CODEX_MCP_OPTIONS: ResolvedExecutionOptions = {
   timeoutMs: CODEX_MCP_TIMEOUTS.defaultMs,
   allowRetry: true,
   maxRetries: CODEX_MCP_TIMEOUTS.maxRetries,

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
@@ -19,7 +19,7 @@ import type {
   CliResponse,
   CliError,
   ModelInfo,
-  ExecutionOptions,
+  ResolvedExecutionOptions,
   BaseAdapterOptions,
 } from '../types.js';
 import type { Result } from '../../core/index.js';
@@ -118,7 +118,7 @@ export class CodexMcpAdapter extends BaseCliAdapter {
    */
   async executeTask(
     _task: CliTask,
-    options: Required<ExecutionOptions>
+    options: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>> {
     const startTime = getTimeProvider().now();
 

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -25,6 +25,7 @@ import type {
   ModelInfo,
   CliName,
   ExecutionOptions,
+  ResolvedExecutionOptions,
   BaseAdapterOptions,
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
@@ -259,7 +260,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
   private buildExecutionOptions(
     taskContent: string,
     options?: ExecutionOptions
-  ): Required<ExecutionOptions> {
+  ): ResolvedExecutionOptions {
     const complexity = estimateTaskComplexity(taskContent);
     const timeoutMs = options?.timeoutMs ?? getTimeoutForTask(this.name, complexity);
 
@@ -296,7 +297,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
 
   private async executeWithRetryTracking(
     task: CliTask,
-    options: Required<ExecutionOptions>
+    options: ResolvedExecutionOptions
   ): Promise<Result<{ response: CliResponse; retryCount: number }, CliError>> {
     return executeCliRetryLoop(() => this.executeTask(task, options), {
       maxRetries: options.maxRetries,

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
@@ -9,7 +9,7 @@ import type { CliName, CliTransport, CliTask, ModelInfo } from './types.js';
 import { BaseCliAdapter } from './base-adapter.js';
 import type { Result } from '../core/index.js';
 import { ok, err } from '../core/index.js';
-import type { CliResponse, CliError, ExecutionOptions } from './types.js';
+import type { CliResponse, CliError, ResolvedExecutionOptions } from './types.js';
 
 /**
  * Concrete test implementation of BaseCliAdapter
@@ -27,7 +27,7 @@ class TestCliAdapter extends BaseCliAdapter {
 
   executeTask(
     _task: CliTask,
-    _options: Required<ExecutionOptions>
+    _options: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>> {
     this.executeCalled++;
     if (this.mockResult) {

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -32,6 +32,7 @@ import type {
   ModelInfo,
   CapabilityProfile,
   ExecutionOptions,
+  ResolvedExecutionOptions,
   VersionStatus,
   TokenUsage,
 } from './types.js';
@@ -56,7 +57,7 @@ export const DEFAULT_CAPACITY_FALLBACK = 100_000;
  * Timeout reduced from 120s to 60s per Issue #280 to prevent
  * cascading timeouts in multi-agent voting scenarios.
  */
-const DEFAULT_OPTIONS: Required<ExecutionOptions> = {
+const DEFAULT_OPTIONS: ResolvedExecutionOptions = {
   timeoutMs: 60_000, // 1 minute (reduced from 2 minutes per Issue #280)
   allowRetry: true,
   maxRetries: 1, // Reduced from 2 to prevent 3+ minute total wait
@@ -103,7 +104,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
    */
   abstract executeTask(
     task: CliTask,
-    options: Required<ExecutionOptions>
+    options: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>>;
 
   /**
@@ -166,7 +167,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
    * the outer loop when their own transient-retry layer is active, so the
    * two layers do not nest into multiplied spawns (#2824).
    */
-  protected shouldOuterRetry(opts: Required<ExecutionOptions>): boolean {
+  protected shouldOuterRetry(opts: ResolvedExecutionOptions): boolean {
     return opts.allowRetry;
   }
 
@@ -175,7 +176,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
    */
   private async executeWithRetry(
     task: CliTask,
-    opts: Required<ExecutionOptions>
+    opts: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>> {
     const result = await executeCliRetryLoop(() => this.executeTask(task, opts), {
       maxRetries: opts.maxRetries,

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
 import { Writable, Readable } from 'node:stream';
 
-import type { CliTask, ExecutionOptions, ICliResponseParser } from './types.js';
+import type { CliTask, ResolvedExecutionOptions, ICliResponseParser } from './types.js';
 import type { CommandConfig } from './subprocess-adapter.js';
 import { SubprocessCliAdapter, SIGKILL_GRACE_MS } from './subprocess-adapter.js';
 
@@ -169,7 +169,7 @@ describe('SubprocessCliAdapter', () => {
     it('should spawn command and return ok result', async () => {
       adapter.setCommandConfig({ command: 'echo', args: ['hello'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -203,7 +203,7 @@ describe('SubprocessCliAdapter', () => {
     it('should handle multiple stdout chunks', async () => {
       adapter.setCommandConfig({ command: 'cat', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -235,7 +235,7 @@ describe('SubprocessCliAdapter', () => {
     it('should include durationMs in response', async () => {
       adapter.setCommandConfig({ command: 'echo', args: ['test'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -273,7 +273,7 @@ describe('SubprocessCliAdapter', () => {
       });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -304,7 +304,7 @@ describe('SubprocessCliAdapter', () => {
     it('should close stdin even when no stdin content provided', async () => {
       adapter.setCommandConfig({ command: 'echo', args: ['test'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -336,7 +336,7 @@ describe('SubprocessCliAdapter', () => {
 
       adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 1000,
         allowRetry: true,
         maxRetries: 1,
@@ -377,7 +377,7 @@ describe('SubprocessCliAdapter', () => {
 
       adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 1000,
         allowRetry: true,
         maxRetries: 1,
@@ -415,7 +415,7 @@ describe('SubprocessCliAdapter', () => {
 
       adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 1000,
         allowRetry: true,
         maxRetries: 1,
@@ -450,7 +450,7 @@ describe('SubprocessCliAdapter', () => {
 
       adapter.setCommandConfig({ command: 'echo', args: ['fast'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -479,11 +479,110 @@ describe('SubprocessCliAdapter', () => {
     });
   });
 
+  // #3026 finding 2: callers that use Promise.race + timeout to bound
+  // adapter calls (parallel-exploration, consensus-plan,
+  // triangulated-review) need a way to cancel the still-running
+  // subprocess when the race timeout wins, otherwise the orphaned
+  // process keeps writing outcomes for a decision that has already
+  // been made.
+  describe('executeTask() - AbortSignal (#3026 finding 2)', () => {
+    it('fast-fails before spawn when signal is already aborted', async () => {
+      adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
+      const task: CliTask = { content: 'test' };
+      const controller = new AbortController();
+      controller.abort();
+
+      const options: ResolvedExecutionOptions = {
+        timeoutMs: 5000,
+        allowRetry: false,
+        maxRetries: 0,
+        trackUsage: true,
+        onProgress: undefined,
+        signal: controller.signal,
+      };
+
+      const result = await adapter.executeTask(task, options);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('TIMEOUT');
+        expect(result.error.message).toContain('Aborted before spawn');
+      }
+    });
+
+    it('SIGTERMs the child when signal aborts mid-execution', async () => {
+      adapter.setCommandConfig({ command: 'sleep', args: ['10'] });
+      const task: CliTask = { content: 'test' };
+      const controller = new AbortController();
+
+      const options: ResolvedExecutionOptions = {
+        timeoutMs: 60_000,
+        allowRetry: false,
+        maxRetries: 0,
+        trackUsage: true,
+        onProgress: undefined,
+        signal: controller.signal,
+      };
+
+      const { mockChild } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const promise = adapter.executeTask(task, options);
+
+      // Abort after spawn — should SIGTERM the running child.
+      await Promise.resolve();
+      controller.abort();
+
+      const result = await promise;
+
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('TIMEOUT');
+        expect(result.error.message).toContain('Aborted by caller signal');
+      }
+    });
+
+    it('does NOT SIGTERM when signal aborts after child already exited', async () => {
+      adapter.setCommandConfig({ command: 'echo', args: ['done'] });
+      const task: CliTask = { content: 'test' };
+      const controller = new AbortController();
+
+      const options: ResolvedExecutionOptions = {
+        timeoutMs: 5000,
+        allowRetry: false,
+        maxRetries: 0,
+        trackUsage: true,
+        onProgress: undefined,
+        signal: controller.signal,
+      };
+
+      const { mockChild, stdout } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const promise = adapter.executeTask(task, options);
+      setImmediate(() => {
+        stdout.emit('data', Buffer.from('done\n'));
+        (mockChild as unknown as { exitCode: number }).exitCode = 0;
+        mockChild.emit('close', 0);
+      });
+
+      const result = await promise;
+      expect(result.ok).toBe(true);
+
+      // Aborting after the child has already closed must be a no-op:
+      // attachAbortSignal's 'close' listener detaches the abort handler.
+      controller.abort();
+      expect(mockChild.kill).not.toHaveBeenCalled();
+    });
+  });
+
   describe('executeTask() - error handling', () => {
     it('should return NOT_FOUND error for ENOENT', async () => {
       adapter.setCommandConfig({ command: 'nonexistent', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -512,7 +611,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return EXECUTION_ERROR for non-zero exit with stderr', async () => {
       adapter.setCommandConfig({ command: 'false', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -544,7 +643,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return EXECUTION_ERROR for non-zero exit without stderr', async () => {
       adapter.setCommandConfig({ command: 'false', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -586,7 +685,7 @@ describe('SubprocessCliAdapter', () => {
       failingAdapter.setCommandConfig({ command: 'echo', args: ['test'] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -631,7 +730,7 @@ describe('SubprocessCliAdapter', () => {
       failingAdapter.setCommandConfig({ command: 'echo', args: ['test'] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -676,7 +775,7 @@ describe('SubprocessCliAdapter', () => {
       failingAdapter.setCommandConfig({ command: 'echo', args: ['test'] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -706,7 +805,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return EXECUTION_ERROR for non-zero exit with error stderr and partial stdout (#1402)', async () => {
       adapter.setCommandConfig({ command: 'opencode', args: ['run'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -741,7 +840,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return EXECUTION_ERROR when stderr only', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -772,7 +871,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return CONNECTION_ERROR for EADDRINUSE in stderr (#1401)', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -801,7 +900,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return CONNECTION_ERROR for "address already in use" in stderr (#1401)', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -848,7 +947,7 @@ describe('SubprocessCliAdapter', () => {
       usageAdapter.setCommandConfig({ command: 'echo', args: ['test'] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -895,7 +994,7 @@ describe('SubprocessCliAdapter', () => {
       sessionAdapter.setCommandConfig({ command: 'echo', args: ['test'] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -945,7 +1044,7 @@ describe('SubprocessCliAdapter', () => {
       failingAdapter.setCommandConfig({ command: 'test', args: [] });
 
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -987,7 +1086,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return TIMEOUT for ETIMEDOUT error', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -1015,7 +1114,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return TIMEOUT for timeout message', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -1042,7 +1141,7 @@ describe('SubprocessCliAdapter', () => {
     it('should return EXECUTION_ERROR for generic Error', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -1070,7 +1169,7 @@ describe('SubprocessCliAdapter', () => {
     it('should handle non-Error objects', async () => {
       adapter.setCommandConfig({ command: 'test', args: [] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -1101,7 +1200,7 @@ describe('SubprocessCliAdapter', () => {
       adapter.setCommandConfig({ command: 'echo', args: ['test'] });
       const task: CliTask = { content: 'test' };
       const onProgress = vi.fn();
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,
@@ -1129,7 +1228,7 @@ describe('SubprocessCliAdapter', () => {
     it('should not throw when onProgress is undefined', async () => {
       adapter.setCommandConfig({ command: 'echo', args: ['test'] });
       const task: CliTask = { content: 'test' };
-      const options: Required<ExecutionOptions> = {
+      const options: ResolvedExecutionOptions = {
         timeoutMs: 5000,
         allowRetry: true,
         maxRetries: 1,

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -9,6 +9,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import type { Result } from '../core/index.js';
 import { ok, err, getTimeProvider, createLogger } from '../core/index.js';
@@ -19,7 +20,7 @@ import type {
   CliResponse,
   CliError,
   CliErrorCode,
-  ExecutionOptions,
+  ResolvedExecutionOptions,
   ICliResponseParser,
 } from './types.js';
 import { BaseCliAdapter } from './base-adapter.js';
@@ -260,7 +261,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    * (#2824). The outer loop still runs once, so circuit-breaker failure
    * recording is unaffected.
    */
-  protected override shouldOuterRetry(opts: Required<ExecutionOptions>): boolean {
+  protected override shouldOuterRetry(opts: ResolvedExecutionOptions): boolean {
     return opts.allowRetry && !this.transientRetry.enabled;
   }
 
@@ -271,6 +272,48 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
   protected abstract getCommand(task: CliTask): CommandConfig;
 
   /**
+   * Invokes the optional cleanup hook supplied by getCommand(). Sync
+   * throws are swallowed (warn-only) and async rejections are caught
+   * so cleanup failures never bubble up and mask the real subprocess
+   * result.
+   */
+  private runSubprocessCleanup(cleanup: CommandConfig['cleanup']): void {
+    if (cleanup === undefined) return;
+    try {
+      const r = cleanup();
+      if (r instanceof Promise) {
+        r.catch((e: unknown) => {
+          this.logger.warn('Subprocess cleanup failed', { error: String(e) });
+        });
+      }
+    } catch (e: unknown) {
+      this.logger.warn('Subprocess cleanup threw', { error: String(e) });
+    }
+  }
+
+  /**
+   * #3026 finding 2: SIGTERM the child when the caller's AbortSignal
+   * aborts mid-execution. Listener auto-detaches on `'close'` so we
+   * don't leak across child lifetimes.
+   */
+  private attachAbortSignal(
+    child: ChildProcess,
+    signal: AbortSignal,
+    resolve: (r: Result<CliResponse, CliError>) => void
+  ): void {
+    const onAbort = (): void => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGTERM');
+      }
+      resolve(err(this.createError('TIMEOUT', 'Aborted by caller signal')));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    child.once('close', () => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  }
+
+  /**
    * Executes a task via subprocess, with optional transient-error retry.
    * When `transientRetry.enabled` is true, transient errors (timeout,
    * rate_limit, connection, parse) are retried with exponential backoff
@@ -278,7 +321,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    */
   async executeTask(
     task: CliTask,
-    options: Required<ExecutionOptions>
+    options: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>> {
     // #2963 site 3: per-execute request ID for log correlation. CliTask
     // doesn't carry a task-id field; generate one here so every
@@ -299,7 +342,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    */
   private async retryTransient(
     task: CliTask,
-    options: Required<ExecutionOptions>,
+    options: ResolvedExecutionOptions,
     lastResult: Result<CliResponse, CliError>,
     attempt: number,
     requestId: string
@@ -344,30 +387,23 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    */
   private spawnSubprocess(
     task: CliTask,
-    options: Required<ExecutionOptions>,
+    options: ResolvedExecutionOptions,
     requestId: string
   ): Promise<Result<CliResponse, CliError>> {
     const cmdConfig = this.getCommand(task);
     const startTime = getTimeProvider().now();
 
-    const cleanup = cmdConfig.cleanup;
-    const runCleanup = (): void => {
-      if (cleanup === undefined) return;
-      try {
-        const r = cleanup();
-        if (r instanceof Promise) {
-          r.catch((e: unknown) => {
-            this.logger.warn('Subprocess cleanup failed', { error: String(e) });
-          });
-        }
-      } catch (e: unknown) {
-        this.logger.warn('Subprocess cleanup threw', { error: String(e) });
-      }
-    };
+    // #3026 finding 2: fast-fail if the caller already aborted before we
+    // bothered to spawn. Saves a child process start when an upstream
+    // wave/loop has already moved on.
+    const signal = options.signal;
+    if (signal?.aborted === true) {
+      return Promise.resolve(err(this.createError('TIMEOUT', 'Aborted before spawn')));
+    }
 
     return new Promise((resolveOuter) => {
       const resolve = (result: Result<CliResponse, CliError>): void => {
-        runCleanup();
+        this.runSubprocessCleanup(cmdConfig.cleanup);
         resolveOuter(result);
       };
       // Curated child env: base infrastructure vars + only this CLI's
@@ -390,6 +426,10 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
         requestId,
         ...(onProgress !== undefined ? { onProgress } : {}),
       });
+
+      if (signal !== undefined) {
+        this.attachAbortSignal(child, signal, resolve);
+      }
 
       // Write stdin content if provided and close stdin
       if (cmdConfig.stdin !== undefined) {

--- a/packages/nexus-agents/src/cli-adapters/subprocess-retry.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-retry.test.ts
@@ -16,7 +16,7 @@ import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
 import { Writable, Readable } from 'node:stream';
 
-import type { CliName, CliTask, ExecutionOptions, ICliResponseParser } from './types.js';
+import type { CliName, CliTask, ResolvedExecutionOptions, ICliResponseParser } from './types.js';
 import type { CommandConfig, TransientRetryConfig } from './subprocess-adapter.js';
 import {
   SubprocessCliAdapter,
@@ -157,7 +157,7 @@ class StrictJsonAdapter extends SubprocessCliAdapter {
   }
 }
 
-const DEFAULT_OPTS: Required<ExecutionOptions> = {
+const DEFAULT_OPTS: ResolvedExecutionOptions = {
   timeoutMs: 5000,
   allowRetry: true,
   maxRetries: 1,
@@ -396,7 +396,7 @@ describe('SubprocessCliAdapter transient retry', () => {
   it('should extend timeout by 1.5x when retrying a TIMEOUT error', async () => {
     const adapter = new RetryAdapter();
     const task: CliTask = { content: 'test' };
-    const opts: Required<ExecutionOptions> = { ...DEFAULT_OPTS, timeoutMs: 10000 };
+    const opts: ResolvedExecutionOptions = { ...DEFAULT_OPTS, timeoutMs: 10000 };
 
     const c0 = createMockChildProcess();
     const c1 = createMockChildProcess();

--- a/packages/nexus-agents/src/cli-adapters/types-capability.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-capability.ts
@@ -85,6 +85,16 @@ export interface CliTask {
 }
 
 /**
+ * Internal resolved-options shape — every "default-able" field is
+ * required, but `signal` stays optional because it's a per-call hook,
+ * not a value with a default. Used by adapter internals (subprocess,
+ * codex-mcp) and tests as the "resolved" execution options. Public
+ * callers should keep using `ExecutionOptions` (everything optional).
+ */
+export type ResolvedExecutionOptions = Required<Omit<ExecutionOptions, 'signal'>> &
+  Pick<ExecutionOptions, 'signal'>;
+
+/**
  * Execution options for CLI adapters.
  */
 export interface ExecutionOptions {
@@ -98,6 +108,23 @@ export interface ExecutionOptions {
   readonly trackUsage?: boolean;
   /** Progress callback invoked on subprocess stdout activity (Issue #1087). */
   readonly onProgress?: (() => void) | undefined;
+  /**
+   * Cancellation signal (#3026 finding 2). When the signal aborts, the
+   * adapter must cancel the in-flight execution promptly — for
+   * subprocess adapters that means SIGTERM (with SIGKILL escalation
+   * per #3026 finding 1). Without this, callers that use
+   * `Promise.race([adapter.execute(task), timeout])` for cancellation
+   * leak orphan subprocesses on race-loser: the timeout promise wins
+   * the race but the adapter call keeps running, posting late results
+   * into OutcomeStore + LinUCB state for a task whose decision has
+   * already been recorded.
+   *
+   * Typed as `AbortSignal | undefined` (not `AbortSignal?`) so
+   * `Required<ExecutionOptions>` — used pervasively by adapter
+   * internals + tests as a resolved-options shape — keeps accepting
+   * `signal: undefined` under `exactOptionalPropertyTypes`.
+   */
+  readonly signal?: AbortSignal | undefined;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/types.ts
+++ b/packages/nexus-agents/src/cli-adapters/types.ts
@@ -31,6 +31,7 @@ export type {
   CapabilityProfile,
   CliTask,
   ExecutionOptions,
+  ResolvedExecutionOptions,
   ICliAdapter,
   ICliResponseParser,
   VersionRequirements,

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -174,10 +174,13 @@ async function dispatchPlans(
   const promises = selectedClis.map(async ({ cli, adapter }): Promise<CliPlanPartition> => {
     const startTime = getTimeProvider().now();
     const prompt = buildPlanPrompt(task, cli);
+    // #3026 finding 2: cancel the adapter call when the race timeout
+    // wins so the subprocess doesn't keep running past its decision.
+    const controller = new AbortController();
 
     try {
       const result: Result<CliResponse, CliError> = await Promise.race([
-        adapter.execute({ content: prompt }),
+        adapter.execute({ content: prompt }, { signal: controller.signal }),
         createPlanTimeout(config.perCliTimeoutMs, cli),
       ]);
 
@@ -207,6 +210,8 @@ async function dispatchPlans(
       const message = getErrorMessage(error);
       logger.warn('Plan CLI threw', { cli, error: message });
       return { cli, success: false, plan: null, rawOutput: '', durationMs, error: message };
+    } finally {
+      controller.abort();
     }
   });
 

--- a/packages/nexus-agents/src/orchestration/parallel-exploration.ts
+++ b/packages/nexus-agents/src/orchestration/parallel-exploration.ts
@@ -200,10 +200,13 @@ async function dispatchPartitions(
   const promises = selectedClis.map(async ({ cli, adapter }): Promise<PartitionResult> => {
     const startTime = getTimeProvider().now();
     const cliTask = buildCliTask(task, cli, category);
+    // #3026 finding 2: cancel the adapter call when the race timeout
+    // wins so the subprocess doesn't keep running past its decision.
+    const controller = new AbortController();
 
     try {
       const result: Result<CliResponse, CliError> = await Promise.race([
-        adapter.execute(cliTask),
+        adapter.execute(cliTask, { signal: controller.signal }),
         createTimeout(config.perCliTimeoutMs, cli),
       ]);
 
@@ -224,6 +227,8 @@ async function dispatchPartitions(
       const message = getErrorMessage(error);
       logger.warn('CLI partition threw', { cli, error: message });
       return { cli, success: false, output: '', durationMs, error: message };
+    } finally {
+      controller.abort();
     }
   });
 

--- a/packages/nexus-agents/src/orchestration/triangulated-review.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.ts
@@ -188,10 +188,13 @@ async function dispatchReviews(
   const promises = selectedClis.map(async ({ cli, adapter }): Promise<CliReviewPartition> => {
     const startTime = getTimeProvider().now();
     const prompt = buildReviewPrompt(diff, cli);
+    // #3026 finding 2: cancel the adapter call when the race timeout
+    // wins so the subprocess doesn't keep running past its decision.
+    const controller = new AbortController();
 
     try {
       const result: Result<CliResponse, CliError> = await Promise.race([
-        adapter.execute({ content: prompt }),
+        adapter.execute({ content: prompt }, { signal: controller.signal }),
         createTimeout(config.perCliTimeoutMs, cli),
       ]);
 
@@ -221,6 +224,8 @@ async function dispatchReviews(
       const message = getErrorMessage(error);
       logger.warn('Review CLI threw', { cli, error: message });
       return { cli, success: false, findings: [], summary: '', durationMs, error: message };
+    } finally {
+      controller.abort();
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds optional `signal?: AbortSignal | undefined` to `ExecutionOptions`. `SubprocessCliAdapter` fast-fails if already aborted and SIGTERMs the child mid-execution on abort (SIGKILL escalation from #3034 still applies).
- Three orchestration call sites — `parallel-exploration`, `consensus-plan`, `triangulated-review` — now create an `AbortController` and abort in `finally` so race-loser subprocesses get cancelled cleanly instead of running to completion and posting late results into `OutcomeStore`/`LinUCB`.
- Introduces internal `ResolvedExecutionOptions = Required<Omit<ExecutionOptions, 'signal'>> & Pick<ExecutionOptions, 'signal'>` so adapter internals keep their "everything defaulted" shape while `signal` stays a per-call hook.

## Why

Before #3034 the timeout path didn't escalate to SIGKILL; this PR closes the other half of #3026. Without it, `Promise.race([adapter.execute(task), timeout])` left the adapter running after the timeout won — the subprocess kept executing, completed, then wrote into `OutcomeStore` and updated `LinUCB` features for a candidate whose decision had already been recorded. Under sustained timeout pressure (long consensus votes with rate-limited backends), that bled into ghost outcome rows, stale arm updates, and orphan subprocess fan-out.

## Out of scope (follow-up)

`orchestration/aorchestra/watchdog.ts` races a generic `task: () => Promise<T>` against a timeout. Threading AbortSignal through requires extending the watchdog's callback shape to `(signal: AbortSignal) => Promise<T>` and updating every caller. Tracked separately.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run src/cli-adapters/subprocess-adapter.test.ts` — 42/42 pass (3 new tests for the AbortSignal contract)
- [x] `pnpm vitest run src/cli-adapters/subprocess-retry.test.ts src/cli-adapters/base-adapter.test.ts` — pass
- [x] `pnpm vitest run src/orchestration/parallel-exploration.test.ts src/orchestration/consensus-plan.test.ts src/orchestration/triangulated-review.test.ts` — 50/50 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)