### PR TITLE
chore(deps): bump qs override to >=6.15.2 (closes GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/.changeset/qs-ghsa-q8mj.md
+++ b/.changeset/qs-ghsa-q8mj.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**chore(deps):** bump qs override to ≥6.15.2 to close GHSA-q8mj-m7cp-5q26 (Dependabot alert 102).
+
+`qs.stringify` with `arrayFormat: 'comma'` and `encodeValuesOnly: true` throws `TypeError` on `null`/`undefined` array elements (CVE-2026-8723, medium-severity DoS). Patched in qs 6.15.2.
+
+Transitive via `@modelcontextprotocol/sdk` → `express` → `body-parser` → `qs` (and via `express-rate-limit`). The existing `qs: ">=6.14.2"` pnpm override admitted the vulnerable 6.15.1; bumped to `>=6.15.2`. `pnpm install` now resolves every qs site to 6.15.2.
+
+We don't pass `arrayFormat: 'comma'` + `encodeValuesOnly: true` from this codebase, so the practical impact was bounded — but transitive npm deps can change call patterns silently, and a patch-level pnpm-override bump is cheap.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "ip-address": ">=10.2.0",
       "@isaacs/brace-expansion": ">=5.0.1",
       "markdown-it": ">=14.1.1",
-      "qs": ">=6.14.2",
+      "qs": ">=6.15.2",
       "basic-ftp": ">=5.3.0",
       "defu": ">=6.1.5",
       "smol-toml": ">=1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   ip-address: '>=10.2.0'
   '@isaacs/brace-expansion': '>=5.0.1'
   markdown-it: '>=14.1.1'
-  qs: '>=6.14.2'
+  qs: '>=6.15.2'
   basic-ftp: '>=5.3.0'
   defu: '>=6.1.5'
   smol-toml: '>=1.6.1'
@@ -4602,8 +4602,8 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -7599,7 +7599,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -7934,7 +7934,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -8773,7 +8773,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -10307,7 +10307,7 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary

Bumps the `qs` pnpm override from `>=6.14.2` to `>=6.15.2` to close [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) / CVE-2026-8723 (Dependabot alert 102).

Transitive via `@modelcontextprotocol/sdk` → `express 5.2.1` → `body-parser 2.2.2` → `qs`. Existing override admitted vulnerable 6.15.1; `pnpm install` now resolves every qs site to 6.15.2.

## Why

`qs.stringify({ a: [null, 'b'] }, { arrayFormat: 'comma', encodeValuesOnly: true })` throws `TypeError` (medium-severity DoS). We don't pass this option combination from our code, but transitive deps can change call patterns silently and a patch-level override bump is cheap.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm why qs --recursive` confirms every site resolves to 6.15.2
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)