### PR TITLE
fix(website): read version from package.json (closes #3049)

### DIFF
--- a/website/src/data/site-data.ts
+++ b/website/src/data/site-data.ts
@@ -9,6 +9,18 @@
  * with the codebase (export contract tests catch drift).
  */
 
+import pkg from '../../../packages/nexus-agents/package.json' with { type: 'json' };
+
+/**
+ * Released nexus-agents version, read at build time from
+ * `packages/nexus-agents/package.json`. Rendered in the hero metadata
+ * pill and the footer colophon. Avoids the hardcoded `v2.79.3` lag
+ * that drifted four releases ahead of the website (#3049).
+ *
+ * The `v` prefix is added here so call sites don't have to remember.
+ */
+export const NEXUS_AGENTS_VERSION: string = `v${pkg.version}`;
+
 /** MCP tools registered in src/mcp/tools/index.ts registerTools() */
 export const MCP_TOOL_COUNT = 39;
 

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import { ClientRouter } from 'astro:transitions';
+import { NEXUS_AGENTS_VERSION } from '../data/site-data';
 
 interface Props {
   title: string;
@@ -120,7 +121,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         </div>
         <div class="colophon-right">
           <p class="colophon-label">Version</p>
-          <p class="colophon-version">v2.79.3</p>
+          <p class="colophon-version">{NEXUS_AGENTS_VERSION}</p>
         </div>
       </div>
     </footer>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,6 +10,7 @@ import {
   MEMORY_BACKEND_COUNT,
   DISCOVERY_SOURCE_COUNT,
   PAPER_COUNT,
+  NEXUS_AGENTS_VERSION,
 } from '../data/site-data';
 ---
 
@@ -20,7 +21,7 @@ import {
   <!-- ─── Hero ─── -->
   <header class="hero">
     <p class="hero-eyebrow">
-      <span class="hero-version">v2.79.3</span>
+      <span class="hero-version">{NEXUS_AGENTS_VERSION}</span>
       <span class="hero-sep" aria-hidden="true">·</span>
       <span>MIT-licensed</span>
       <span class="hero-sep" aria-hidden="true">·</span>


### PR DESCRIPTION
## Summary

Closes #3049. Hero pill + footer colophon were hardcoded to \`v2.79.3\` — four point releases behind the current \`v2.83.2\` (and five pending changesets). Visitors saw a stale version next to the auto-updated \"39 MCP tools\" capability count, undermining the credibility of the messaging.

## Fix

Adds \`NEXUS_AGENTS_VERSION\` to \`website/src/data/site-data.ts\` (the existing single-source-of-truth for capability counts that's already imported by every page). The constant reads \`packages/nexus-agents/package.json\` at build time via Astro's \`with: { type: 'json' }\` import syntax. Hero + footer import the constant.

This puts version into the same regen-free path that keeps \`MCP_TOOL_COUNT\` in sync — every release bumps \`package.json\`, the next website build picks up the new value automatically, no manual website edit needed.

## Verification

\`pnpm build\` of \`website/\`: 48 pages built, no errors. Grep of \`dist/index.html\` confirms both surfaces render \`v2.83.2\` (from current \`package.json\`):

\`\`\`
<span class="hero-version">v2.83.2</span>
<p class="colophon-version">v2.83.2</p>
\`\`\`

\`pnpm check\` (astro check): 0 errors / 0 warnings.

## Test plan

- [x] \`pnpm --filter nexus-agents-website build\` — succeeds
- [x] Built \`dist/index.html\` renders current \`package.json\` version
- [x] \`pnpm --filter nexus-agents-website check\` — clean
- [ ] Spot-check the deployed site post-merge to confirm v2.83.2 shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)