### PR TITLE
fix(docs): give PLUGIN_INSTALL.md frontmatter so it routes on-site (closes #3050)

### DIFF
--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -1,3 +1,10 @@
+---
+title: 'Claude Code Plugin Install'
+description: Install nexus-agents as a Claude Code plugin — exposes 39 MCP tools, 31 skills, 12 agent mirrors, and governance hooks
+tier: 2
+keywords: [plugin, claude-code, installation, marketplace, mcp, getting-started]
+---
+
 # Installing nexus-agents as a Claude Code plugin
 
 **Status:** Canonical

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -16,6 +16,7 @@ const nav = [
     links: [
       { label: 'Installation', href: `${base}/getting-started/installation/` },
       { label: 'Configuration', href: `${base}/getting-started/configuration/` },
+      { label: 'Plugin Install', href: `${base}/getting-started/plugin_install/` },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Closes #3050. \`docs/getting-started/PLUGIN_INSTALL.md\` was missing the YAML frontmatter that two pipelines depend on:

1. **\`website/src/pages/docs/[...slug].astro\`** filters \`allDocs.filter((entry) => entry.data.title)\` — without a \`title:\` field, the docs collection silently drops the entry. No routable slug gets generated.
2. **\`website/src/plugins/remark-rewrite-links.ts\`** \`hasPublishedFrontmatter()\` checks the same \`title:\` field when rewriting MD→MD links. When absent, falls back to the GitHub blob URL instead of the on-site path.

Both pipelines silently degrade to "GitHub fallback" without an error. So FIRST_TASK.md's \`[PLUGIN_INSTALL.md](./PLUGIN_INSTALL.md)\` link bounced readers off the docs site mid-tutorial while two sibling links (with proper frontmatter) stayed on-site — the inconsistency #3050 caught.

## Changes

- Add title/description/tier/keywords frontmatter to PLUGIN_INSTALL.md (same shape as INSTALLATION.md / CONFIGURATION.md siblings).
- Add "Plugin Install" to the sidebar nav under "Getting Started" in \`DocsLayout.astro\` so the page is discoverable, not just reachable by direct link.

## Verification

Clean rebuild (\`rm -rf dist .astro && pnpm build\`):

- ✅ Page count 48 → 49 — \`/docs/getting-started/plugin_install/index.html\` now built
- ✅ FIRST_TASK link rewrites to \`/nexus-agents/docs/getting-started/plugin_install/\` (was \`https://github.com/.../blob/main/docs/getting-started/PLUGIN_INSTALL.md\`)
- ✅ Sidebar shows "Plugin Install" under "Getting Started"
- ✅ \`astro check\` clean: 0 errors / 0 warnings

## Why two pipelines silently degraded

The Astro docs-collection filter and the link rewriter both treat "missing frontmatter" as "this doc isn't site-publishable" — which is correct for in-tree-only docs (like \`docs/distribution/LISTING_SUBMISSIONS.md\` which IS marketplace prep, not docs site content). But there's no failure signal when a doc that SHOULD be published lacks the frontmatter. Worth a follow-up issue to add a lint that catches "MD file linked from a published doc, but the link target has no frontmatter → likely accidental omission."

🤖 Generated with [Claude Code](https://claude.com/claude-code)