### PR TITLE
fix(website): remove ClientRouter view-transitions (closes #3051 + #3056)

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,5 +1,11 @@
 ---
-import { ClientRouter } from 'astro:transitions';
+// ClientRouter (Astro View Transitions) removed in #3058 (closes #3051 + #3056).
+// Bisect confirmed it was wedging the Chrome renderer for ≥30s after every
+// internal navigation in both dev mode AND the prod build, regardless of
+// whether the target was a 200 or a 404. Site is 49 static pages — full-page
+// navigation cost is ~50ms, the view-transition aesthetic isn't worth a 30s
+// renderer freeze. Re-introduce only with a verified fix for the renderer
+// contention (ClientRouter + prefetch race against the page's other scripts).
 import { NEXUS_AGENTS_VERSION } from '../data/site-data';
 
 interface Props {
@@ -78,7 +84,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       rel="stylesheet"
     />
 
-    <ClientRouter />
   </head>
   <body>
     <nav class="masthead" aria-label="Primary">


### PR DESCRIPTION
## Summary

Closes #3051 (404 \`InvalidStateError\` in dev) AND #3056 (prod-build renderer wedges Chrome for ≥30s on every internal navigation). Bisect on \`investigate/3056-renderer-freeze\` confirmed both symptoms are caused by Astro's \`<ClientRouter />\` (view transitions).

## Bisect procedure (verified end-to-end with Chrome MCP plugin)

1. **Baseline** (ClientRouter in BaseLayout): \`pnpm build && pnpm preview --port 4321\`, fresh tab → navigate to any docs page → CDP \`screenshot\` times out after 30s. Reproduces with and without prior navigations, on 200s and 404s.
2. **Treatment** (ClientRouter removed): comment out, rebuild, restart preview, fresh tab → same navigation → screenshot succeeds in <1s.
3. **Stress test:** with ClientRouter still removed, navigate \`/\` → \`/docs/readme/\` → \`/docs/getting-started/installation/\` → \`/docs/this-does-not-exist/\` (404) → back to \`/docs/getting-started/installation/\`. Every navigation completes cleanly. No renderer wedge. 404 page renders the styled "Page not found." view without ceremony.

## Why fully remove (vs. workarounds)

| Alternative | Why declined |
|---|---|
| Opt 404 page out of view transitions | Only addresses #3051's narrow case; #3056 still fires on 200 navigations |
| \`data-astro-reload\` on every internal link | Reintroduces full-page nav everywhere — same end-state as removal but with the contention surface still loaded |
| Disable Astro prefetch | Untested; might or might not fix the contention. ClientRouter alone is already the smoking gun. |
| Wait for Astro upstream fix | The symptom (5-30s freeze after every nav) is too painful to leave for users while we wait |

Site is 49 static pages. Full-page navigation cost is ~50ms. The view-transition aesthetic isn't worth the freeze. If Astro fixes the underlying contention upstream (probably a ClientRouter + prefetch + page-script race), we can reintroduce \`<ClientRouter />\` with regression testing — file separately.

## Verification

- \`pnpm build\`: 48 pages built (no count regression).
- \`grep -c "ClientRouter\\|view-transitions" dist/index.html\`: **0** (was 4+).
- \`astro check\`: 0 errors / 0 warnings.
- Chrome MCP plugin: 5 consecutive navigations (homepage / docs index / installation / 404 / back to installation) all rendered cleanly, no CDP screenshot timeout.

## Test plan

- [x] \`pnpm --filter nexus-agents-website build\` — succeeds
- [x] No ClientRouter refs in built HTML
- [x] \`pnpm --filter nexus-agents-website check\` — clean
- [x] Chrome MCP plugin can capture screenshots after navigation (was the original repro)
- [ ] Post-merge: confirm GitHub Pages deploy doesn't show the freeze on real users
- [ ] Optional follow-up: file Astro upstream issue with the bisect data

🤖 Generated with [Claude Code](https://claude.com/claude-code)