### PR TITLE
fix(workflows): thread AbortSignal through step-executor (#3016, #3040)

### DIFF
--- a/.changeset/3016-abortsignal-threading.md
+++ b/.changeset/3016-abortsignal-threading.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': patch
+---
+
+**fix(workflows):** thread AbortSignal through step-executor → BaseAgent → CompletionRequest (#3016, #3040).
+
+Closes #3016 and #3040. Step-executor's `Promise.race` was dropping the race-loser — when the step timer fired at 120s, the in-flight model call kept running to its own 10-minute SDK timeout, surfacing as the "first-step adapter hang" from #2931.
+
+## What changed
+
+- `IAgent.execute` accepts an optional second arg `{ signal?: AbortSignal }`. Optional so existing callers don't break.
+- `BaseAgent.execute` stashes the caller's signal in a per-task instance field (`currentExecutionSignal`), cleared in `finally`.
+- `BaseAgent.complete` forwards `currentExecutionSignal` onto `CompletionRequest.signal` unless the caller already set one.
+- `runTaskWithTimeout` takes optional `externalSignal`, wires it into the existing internal `AbortController` so a single signal covers both heartbeat expiry and caller-initiated cancellation.
+- `StepExecutor.runExpertWithTimeout` creates an `AbortController`, passes the signal to `expert.execute(task, { signal })`, and aborts in `finally`. Abort fires for both arms of the race — clean resolution OR timeout — so the SDK call always cancels.
+
+## Why this is a patch, not minor
+
+The IAgent interface change adds an optional second arg; every existing `agent.execute(task)` call site keeps working. No subclass needs to override the new signature unless it wants to honor the signal. SimpleAgent, Expert, Orchestrator, and all expert subclasses inherit the signal-forwarding behavior from `BaseAgent.complete`.
+
+## Tests
+
+- New: `runTaskWithTimeout` external signal cancels in-flight task.
+- New: pre-aborted external signal settles task immediately.
+- New: step-executor passes a signal into `expert.execute` and aborts it after the race resolves.
+- 148 pre-existing tests in `base-agent.test.ts`, `base-agent-execute-flow.test.ts`, `base-agent-task-helpers.test.ts`, and `step-executor.test.ts` continue to pass unchanged.
+
+## Out of scope (deferred)
+
+- `IModelAdapter.complete` already honors `request.signal` (#3036/PR #3038). Vendor SDKs (Anthropic, OpenAI, Google) wire `request.signal` into their respective HTTP client abort paths.
+- Per-call timeout knob on `adapter.complete` is tracked separately as #2931 item 4.
+- Whether the upstream model legitimately blocks for 120s vs wedges on bad network state needs repro via `query_trace(runId=<real id>)` enabled (now possible after PR #3015 — failure-envelope debuggability).

--- a/packages/nexus-agents/src/agents/base-agent-execute-flow.test.ts
+++ b/packages/nexus-agents/src/agents/base-agent-execute-flow.test.ts
@@ -264,4 +264,45 @@ describe('runTaskWithTimeout', () => {
       expect(result.error.message).toContain('timed out');
     }
   });
+
+  // Regression for #3016/#3040 — caller's external AbortSignal must abort
+  // the in-flight task so model calls cancel when the caller's deadline
+  // wins a race (e.g., the workflow step-executor's 120s step timer).
+  it('cancels via abort when external signal fires', async () => {
+    const task = makeTask();
+    const executeTask = vi.fn().mockReturnValue(new Promise(() => {}));
+    const controller = new AbortController();
+
+    const promise = runTaskWithTimeout(task, 'agent-ext', executeTask, {
+      externalSignal: controller.signal,
+    });
+    // Fire external abort — should propagate into internal controller and
+    // settle the task as cancelled without waiting for the 900s heartbeat cap.
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('cancelled');
+    }
+  });
+
+  it('honors pre-aborted external signal immediately', async () => {
+    const task = makeTask();
+    const executeTask = vi.fn().mockReturnValue(new Promise(() => {}));
+    const controller = new AbortController();
+    controller.abort();
+
+    const promise = runTaskWithTimeout(task, 'agent-pre-abort', executeTask, {
+      externalSignal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('cancelled');
+    }
+  });
 });

--- a/packages/nexus-agents/src/agents/base-agent-execute-flow.ts
+++ b/packages/nexus-agents/src/agents/base-agent-execute-flow.ts
@@ -83,16 +83,43 @@ export function setupExecute(ctx: ExecuteFlowContext, task: Task): ExecuteSetupR
 }
 
 /**
+ * Wires an external AbortSignal into the internal controller so a single
+ * abort path covers both heartbeat expiry and caller-initiated cancellation
+ * (#3016/#3040). Returns the listener so it can be removed in `finally`.
+ */
+function wireExternalAbort(
+  externalSignal: AbortSignal | undefined,
+  controller: AbortController
+): (() => void) | undefined {
+  if (externalSignal === undefined) return undefined;
+  if (externalSignal.aborted) {
+    controller.abort();
+    return undefined;
+  }
+  const listener = (): void => {
+    controller.abort();
+  };
+  externalSignal.addEventListener('abort', listener, { once: true });
+  return listener;
+}
+
+/**
  * Runs task with configured timeout and heartbeat-aware cancellation.
  *
  * Phase 2 (Issue #1088): Integrates HeartbeatMonitor for session tracking
  * and AbortController for cooperative cancellation when session expires.
  * The safety-cap timeout in executeWithTimeout remains as a fallback.
+ *
+ * #3016/#3040: Optional `externalSignal` lets a caller (e.g., the workflow
+ * step-executor) cancel the task when its own deadline wins a race. The
+ * caller's signal is forwarded to executeWithTimeout in addition to the
+ * internal heartbeat signal — either firing settles the task.
  */
 export async function runTaskWithTimeout(
   task: Task,
   agentId: string,
-  executeTask: (task: Task) => Promise<Result<TaskResult, AgentError>>
+  executeTask: (task: Task) => Promise<Result<TaskResult, AgentError>>,
+  options?: { externalSignal?: AbortSignal | undefined }
 ): Promise<Result<TaskResult, AgentError>> {
   const maxDuration = task.constraints?.maxDuration ?? HEARTBEAT_TIMEOUTS.absoluteMaxMs;
 
@@ -100,6 +127,11 @@ export async function runTaskWithTimeout(
   const controller = new AbortController();
   const monitor = getHeartbeatMonitor();
   const sessionId = monitor.startSession(agentId);
+
+  // Forward caller's external abort into the internal controller so the
+  // single signal threaded into executeWithTimeout fires for either reason.
+  const externalSignal = options?.externalSignal;
+  const externalAbortListener = wireExternalAbort(externalSignal, controller);
 
   // Periodic health check — log transitions, abort on expiry (Phase 4)
   const healthCheckTimer = setInterval(() => {
@@ -130,6 +162,9 @@ export async function runTaskWithTimeout(
   } finally {
     clearInterval(healthCheckTimer);
     monitor.endSession(sessionId);
+    if (externalSignal !== undefined && externalAbortListener !== undefined) {
+      externalSignal.removeEventListener('abort', externalAbortListener);
+    }
   }
 }
 

--- a/packages/nexus-agents/src/agents/base-agent.ts
+++ b/packages/nexus-agents/src/agents/base-agent.ts
@@ -118,6 +118,14 @@ export abstract class BaseAgent implements IAgent {
   private readonly memoryConfig: ResolvedMemoryConfig;
   private memoryState: AgentMemoryState | null = null;
   private relevantMemories: readonly TypedMemoryEntry[] = [];
+  /**
+   * AbortSignal set by `execute()` when the caller passes one. `complete()`
+   * forwards it onto `CompletionRequest.signal` so the in-flight model call
+   * cancels when the caller's deadline wins a race (#3016/#3040). Set only
+   * for the duration of one execute() and cleared in finally — the field is
+   * single-task scoped and never crosses tasks.
+   */
+  private currentExecutionSignal: AbortSignal | undefined = undefined;
 
   constructor(options: BaseAgentOptions) {
     const validation = BaseAgentOptionsSchema.safeParse(options);
@@ -208,7 +216,10 @@ export abstract class BaseAgent implements IAgent {
     return ok(undefined);
   }
 
-  async execute(task: Task): Promise<Result<TaskResult, AgentError>> {
+  async execute(
+    task: Task,
+    options?: { signal?: AbortSignal }
+  ): Promise<Result<TaskResult, AgentError>> {
     const execCtx = buildExecuteFlowContext(this.contextState);
     const setup = setupExecute(execCtx, task);
     if (!setup.valid && setup.error !== undefined) return err(setup.error);
@@ -217,8 +228,14 @@ export abstract class BaseAgent implements IAgent {
     this.budgetTracker.startTask(task.id);
     this.logger.info('Executing task', { taskId: task.id, priority: task.priority });
     const taskMemCtx = buildTaskMemoryContext(this.contextState);
+    // Make caller's AbortSignal visible to `complete()` so model calls cancel
+    // when the caller's deadline wins (#3016/#3040). Cleared in finally to
+    // avoid leaking the signal into a later, unrelated execute() call.
+    this.currentExecutionSignal = options?.signal;
     try {
-      const result = await runTaskWithTimeout(task, this.id, (t) => this.executeTask(t));
+      const result = await runTaskWithTimeout(task, this.id, (t) => this.executeTask(t), {
+        externalSignal: options?.signal,
+      });
       if (!result.ok) return handleExecFailure(task, result, execCtx);
       this.memoryState = await finalizeExec(
         task,
@@ -237,6 +254,8 @@ export abstract class BaseAgent implements IAgent {
       );
       this.memoryState = updatedMemoryState;
       return err(agentError);
+    } finally {
+      this.currentExecutionSignal = undefined;
     }
   }
 
@@ -295,7 +314,13 @@ export abstract class BaseAgent implements IAgent {
       logger: this.logger,
       newState: 'acting',
     });
-    const result = await runModelCompletion(ctx, adapterResult.value, request);
+    // Thread caller's AbortSignal into the model call unless the caller
+    // already supplied one on the request (#3016/#3040).
+    const requestWithSignal: CompletionRequest =
+      request.signal === undefined && this.currentExecutionSignal !== undefined
+        ? { ...request, signal: this.currentExecutionSignal }
+        : request;
+    const result = await runModelCompletion(ctx, adapterResult.value, requestWithSignal);
     transitionToState({
       stateMachine: this.stateMachine,
       logger: this.logger,

--- a/packages/nexus-agents/src/core/types/agent.ts
+++ b/packages/nexus-agents/src/core/types/agent.ts
@@ -221,9 +221,13 @@ export interface IAgent {
   /**
    * Execute a task.
    * @param task - Task to execute
+   * @param options - Optional execution options (#3016/#3040).
+   *   `signal` cancels the in-flight model call when the caller's deadline
+   *   wins a race; without it, the SDK keeps running to its own 10-minute
+   *   timeout after the caller has already discarded the result.
    * @returns Result with TaskResult or AgentError
    */
-  execute(task: Task): Promise<Result<TaskResult, AgentError>>;
+  execute(task: Task, options?: { signal?: AbortSignal }): Promise<Result<TaskResult, AgentError>>;
 
   /**
    * Handle an inter-agent message.

--- a/packages/nexus-agents/src/workflows/step-executor.test.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.test.ts
@@ -699,6 +699,55 @@ describe('StepExecutor', () => {
         expect(result.error.message).toContain('cancelled');
       }
     });
+
+    // Regression for #3016/#3040 — step-executor must pass an AbortSignal
+    // into expert.execute and abort it when the race resolves. Without this,
+    // the race-loser (in-flight model call) keeps running to its own
+    // 10-minute SDK timeout after the step timer has fired at 120s.
+    it('passes a signal to expert.execute and aborts it on resolution', async () => {
+      let receivedSignal: AbortSignal | undefined;
+      const captureFactory: IExpertFactory = {
+        createForRole: () => {
+          const expert = createMockExpert({});
+          (expert as unknown as { execute: typeof expert.execute }).execute = vi.fn(
+            (
+              _task: Task,
+              options?: { signal?: AbortSignal }
+            ): Promise<Result<TaskResult, AgentError>> => {
+              receivedSignal = options?.signal;
+              return Promise.resolve(
+                ok({
+                  taskId: 'test-task',
+                  output: { result: 'success' },
+                  metadata: {
+                    durationMs: 1,
+                    tokensUsed: 0,
+                    toolsUsed: [],
+                    model: 'test-model',
+                  },
+                })
+              );
+            }
+          );
+          return ok(expert);
+        },
+      };
+      const captureExecutor = createStepExecutor({ expertFactory: captureFactory });
+      const step: WorkflowStep = {
+        id: 'step1',
+        agent: 'code_expert',
+        action: 'analyze',
+        inputs: {},
+      };
+
+      const result = await captureExecutor.execute(step, context);
+
+      expect(result.ok).toBe(true);
+      expect(receivedSignal).toBeInstanceOf(AbortSignal);
+      // After the race resolves the executor must abort the signal so any
+      // in-flight model call honors it.
+      expect(receivedSignal?.aborted).toBe(true);
+    });
   });
 
   describe('error handling', () => {

--- a/packages/nexus-agents/src/workflows/step-executor.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.ts
@@ -288,9 +288,13 @@ export class StepExecutor {
     timeoutMs: number,
     startTime: number
   ): Promise<Result<StepResult, WorkflowError>> {
+    // Pair Promise.race's external timeout with an AbortSignal so the
+    // race-LOSER (in-flight model call) cancels when the timer wins —
+    // otherwise the SDK keeps running to its own 10-minute timeout (#3016).
+    const controller = new AbortController();
     try {
       const taskResult = await Promise.race([
-        expert.execute(task),
+        expert.execute(task, { signal: controller.signal }),
         createTimeout(timeoutMs, step.id),
       ]);
 
@@ -311,6 +315,10 @@ export class StepExecutor {
       });
     } catch (error) {
       return this.handleExecutionError(error, step, timeoutMs);
+    } finally {
+      // Always abort: settles any in-flight model call regardless of which
+      // arm of the race resolved. Safe to call after a clean resolution.
+      controller.abort();
     }
   }
 


### PR DESCRIPTION
## Summary

- Closes #3016 and #3040. Step-executor's `Promise.race` dropped the race-loser — the 120s step timer settled the outer race but the in-flight model call kept running to its own 10-minute SDK timeout. That manifested as the "first-step adapter hang" from #2931.
- Adds optional `{ signal?: AbortSignal }` to `IAgent.execute`. `BaseAgent.execute` stashes the caller's signal in a per-task instance field, `BaseAgent.complete` forwards it onto `CompletionRequest.signal` so vendor SDKs (already wired via #3036/PR #3038) cancel the HTTP call.
- `runTaskWithTimeout` merges external + heartbeat signals so a single abort path covers both. `StepExecutor.runExpertWithTimeout` creates a controller and aborts in `finally` so the race-loser cancels regardless of which arm won.

## Backward compatibility

The IAgent change adds an optional second arg — every existing `agent.execute(task)` caller works unchanged. No subclass needs to override the new signature unless it wants to honor the signal. SimpleAgent, Expert, Orchestrator, and all expert subclasses inherit the signal-forwarding via `BaseAgent.complete`.

Changeset is patch (no public API break).

## Test plan

- [x] `runTaskWithTimeout` regression: external signal cancels in-flight task.
- [x] `runTaskWithTimeout` regression: pre-aborted external signal settles task immediately.
- [x] `step-executor.test.ts` regression: signal passed into `expert.execute` and aborted after race resolution.
- [x] 148 pre-existing tests in `base-agent.test.ts`, `base-agent-execute-flow.test.ts`, `base-agent-task-helpers.test.ts`, and `step-executor.test.ts` still pass.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean.

## Closes

- Closes #3016
- Closes #3040

🤖 Generated with [Claude Code](https://claude.com/claude-code)