### PR TITLE
docs(rules): codified CI-outage wait-pattern (#3076 primitive #2)

### DIFF
--- a/.changeset/3076-codified-wait-pattern.md
+++ b/.changeset/3076-codified-wait-pattern.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+**docs(rules):** codified CI-outage wait-pattern in `.rules/autonomous.md` (#3076 primitive #2).
+
+Follow-up to PR #3078 (which shipped `ci_health_check` as #3076 primitive #1). This change codifies the behavior — when CI fires unexplained / cross-PR failures (status checks not queuing, `workflow_dispatch` HTTP 5xx, codeload 404), the agent should diagnose with `ci_health_check` BEFORE retriggering, and pivot to non-CI work during confirmed outages.
+
+## Why
+
+The failure mode this addresses: during the 2026-05-26 outage (#3070), my session spent 90+ min retriggering via close+reopen and empty-commit pushes before recognizing the outage was global — every retrigger was wasted cycles because webhook delivery itself was broken. The user's #3076 documented the same pattern on a parallel session.
+
+## What the rule says
+
+When CI exhibits outage symptoms:
+
+1. **Diagnose first** — `ci_health_check` or manual status-page + recent-runs check.
+2. **When `status === 'outage'`**: pause the PR (no retriggers), pivot to non-CI work (docs, design, local-test verification), file an outage tracking issue, schedule a 30-min wakeup.
+3. **When status resolves to `healthy`**: push a `chore(ci): kick after recovery` commit and resume.
+4. **CI outages are NOT a hard stop** — the autonomous directive's "keep working" clause covers "work elsewhere and come back."
+
+## Closes
+
+Partial close on #3076 — primitive #2 (codified wait-pattern) shipped. Primitives #3 (CI-down merge clause) and #4 (outage frequency telemetry) remain open.

--- a/.rules/autonomous.md
+++ b/.rules/autonomous.md
@@ -36,6 +36,40 @@ At every step, file issues for tangential findings rather than sidetracking. "Se
 
 If genuinely unsure which of two or three backlog items to pick, run `consensus_vote` with `quickMode: true, strategy: simple_majority`. The vote result **is** the decision. Do not route ambiguity back to the user as "what do you want me to work on" — the user's autonomous directive already resolved that: whatever the vote picks.
 
+## CI infrastructure outages — wait, don't retrigger (#3076)
+
+When CI fires unexplained / cross-PR failures (codeload 404, status checks not queuing, `workflow_dispatch` HTTP 5xx, `gh pr view ... --json statusCheckRollup` returns empty despite recent push events), **do not retrigger via close+reopen / empty commits / `gh workflow run`** until you've checked health. Retriggering during an infrastructure outage burns cycles for no signal — the failure mode I (and #3076) hit was 90+ min of silent retries before recognizing the outage.
+
+### Diagnose first
+
+Run [`ci_health_check`](../packages/nexus-agents/src/mcp/tools/ci-health-check-tool.ts) (shipped in PR #3078) with the repo:
+
+```ts
+ci_health_check({ repo: 'owner/repo', activityWindowMinutes: 30 });
+```
+
+Or manually:
+
+1. Fetch https://www.githubstatus.com/api/v2/components.json — check the `GitHub Actions` component's `status`. `degraded_performance` / `partial_outage` / `major_outage` means stop.
+2. `gh run list --workflow=ci.yml --limit 10 --json status,createdAt` — if zero runs in the last 30 min despite recent push events, the local queue is wedged.
+
+### When `status === 'outage'`
+
+- Pause the affected PR — do not push more commits, do not retrigger, do not close+reopen.
+- Pivot to non-CI work: docs, planning, design discussion, local-test verification of already-shipped code.
+- File an outage tracking issue (template: `ops: GitHub Actions ... <date>`) so the next agent session has a breadcrumb.
+- Schedule a wakeup ~30 min out. GitHub status-page incidents typically resolve in tens of minutes.
+- When the wakeup fires and `ci_health_check` returns `healthy`, push an empty `chore(ci): kick after recovery` commit to re-trigger the missed workflow events.
+
+### When `status === 'degraded'` (status page healthy + repo wedge)
+
+- Same playbook: don't retrigger; pivot; recheck.
+- If the wedge persists past one wakeup cycle, file an issue against the specific workflow (the repo may have a local config problem the status-page can't see).
+
+### What does NOT change
+
+The hard-stop list below is exhaustive — CI outages are not a hard stop. They're a "work elsewhere and come back" condition, fully covered by the autonomous directive's "keep working" clause.
+
 ## Hard stop conditions (only these)
 
 Genuinely pause and surface to the user ONLY when:


### PR DESCRIPTION
## Summary

Closes partial scope of **#3076** — ships primitive #2 of 4 (codified wait-pattern rule). Follow-up to PR #3078 which shipped \`ci_health_check\` as primitive #1.

The rule codifies what to DO when CI fires outage-shaped failures: diagnose first with \`ci_health_check\`, pivot to non-CI work when status reports outage/degraded, schedule a wakeup, retrigger only after recovery. The autonomous directive's "keep working" clause already covers the broad case; this section makes the specific CI-outage playbook explicit so the next agent doesn't have to re-derive it.

## Why

The failure mode this addresses: during the 2026-05-26 outage (#3070), my session spent 90+ min retriggering via close+reopen and empty-commit pushes before recognizing the outage was global. Every retrigger was wasted cycles because webhook delivery itself was broken. User's #3076 documented the same pattern on a parallel session.

## What changed

\`.rules/autonomous.md\` gains a new section between "Tie-break via consensus_vote" and "Hard stop conditions":

- **Diagnose first** — \`ci_health_check\` call OR manual status-page + recent-runs fallback.
- **When status === outage** — pause PR, pivot, file tracking issue, schedule 30-min wakeup, kick after recovery.
- **When status === degraded** (status page healthy + repo wedge) — same playbook, escalate after one wakeup cycle.
- **What does NOT change** — CI outages are not a hard stop; the existing "keep working" clause covers "work elsewhere and come back."

## Test plan

- [x] Docs-only change. No code touched.
- [x] No new files outside \`.rules/autonomous.md\` + \`.changeset/3076-codified-wait-pattern.md\`.

## Closes

Partial close on #3076 — primitive #2 of 4 shipped. Primitives #3 (CI-down merge clause), #4 (outage frequency telemetry) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)