### PR TITLE
docs(rules): admin-merge clause for CI outages (#3076 primitive #3)

### DIFF
--- a/.changeset/3076-admin-merge-clause.md
+++ b/.changeset/3076-admin-merge-clause.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+**docs(rules):** admin-merge clause for CI outages in `.rules/autonomous.md` (#3076 primitive #3).
+
+Follow-up to PR #3078 (primitive #1, `ci_health_check`) and PR #3080 (primitive #2, codified wait-pattern). This addition codifies WHEN admin-merge is acceptable during a CI infrastructure outage — five clauses that ALL must hold.
+
+## Why
+
+During the 2026-05-26 outage (#3070), I admin-merged 7 PRs once the local quality gates were green and the CI failures were confirmed to be infrastructure-wide (not per-PR). The pattern worked but wasn't codified — the next agent session would have to re-derive when admin-merge is appropriate vs. when to keep waiting. This change makes the bypass conditions explicit so the audit chain stays clean.
+
+## What the rule says
+
+`gh pr merge --admin` is allowed during outages ONLY when all five clauses hold:
+
+1. `ci_health_check` returned `outage` or `degraded` AND the failure is confirmed global.
+2. Local quality gates green on the branch.
+3. Change is mechanical or well-tested (no untested new features).
+4. An outage tracking issue exists with a link to the PR.
+5. PR was waiting >30 min with no progress, OR crosses a release boundary.
+
+Plus: state the bypass reason in the merge commit body, comment on the outage issue. Audit chain over convenience.
+
+## Closes
+
+Partial close on #3076 — primitive #3 of 4 shipped. Primitive #4 (outage frequency telemetry via `outcome_store` tagging) remains.

--- a/.rules/autonomous.md
+++ b/.rules/autonomous.md
@@ -70,6 +70,20 @@ Or manually:
 
 The hard-stop list below is exhaustive — CI outages are not a hard stop. They're a "work elsewhere and come back" condition, fully covered by the autonomous directive's "keep working" clause.
 
+## Admin-merge during CI outages (#3076 primitive #3)
+
+`gh pr merge --admin` bypasses the "required CI checks" branch protection. It is the established pattern for this repo's owner work (most squash-merges on `main` were admin-merges by `@williamzujkowski`; PR #3064 is a representative example). During CI infrastructure outages, the agent may admin-merge a PR ONLY when **every** clause holds:
+
+1. **`ci_health_check` returned `'outage'` or `'degraded'`** at PR creation OR the workflow runs cannot complete despite manual retriggers, AND the agent has verified the failure is global / cross-PR (not local to this PR's code).
+2. **Local quality gates green** on the PR's branch — `pnpm typecheck`, `pnpm lint`, `pnpm test` (or the affected-subset), `pnpm governance:check` if governance touched.
+3. **Change is mechanical or well-tested** — bug fix with regression test, version-bump, dep-bump with no API change, docs-only, generated-artifact regen. Multi-PR refactors or new features without test coverage do NOT qualify.
+4. **An outage tracking issue exists** that links the PR (so the bypass has an audit breadcrumb).
+5. **PR was waiting in CI for >30 min** with no progress, OR the wait would cross a release boundary (don't let a release PR sit during the freeze the outage created).
+
+If ANY clause fails, wait it out — auto-merge with the existing required-CI gate is still the default.
+
+When admin-merging, **state the bypass reason** in the merge commit body and add a comment on the outage issue noting which PR was admin-merged and why. The audit chain matters more than the convenience.
+
 ## Hard stop conditions (only these)
 
 Genuinely pause and surface to the user ONLY when:


### PR DESCRIPTION
## Summary

Closes partial scope of **#3076** — ships primitive #3 of 4 (admin-merge clause). Follow-up to PR #3078 (primitive #1, \`ci_health_check\`) and PR #3080 (primitive #2, codified wait-pattern).

## What changed

\`.rules/autonomous.md\` gains an "Admin-merge during CI outages" section between the wait-pattern and hard-stop sections. Codifies WHEN \`gh pr merge --admin\` is acceptable during a CI infrastructure outage — five clauses ALL must hold:

1. \`ci_health_check\` returned \`outage\` or \`degraded\` AND failure is confirmed global.
2. Local quality gates green on the branch.
3. Change is mechanical or well-tested (no untested new features).
4. Outage tracking issue exists with a link to the PR.
5. PR was waiting >30 min with no progress, OR crosses a release boundary.

Plus: bypass reason in merge commit body + comment on outage issue. Audit chain over convenience.

## Why now

During the 2026-05-26 outage (#3070), I admin-merged 7 PRs once local gates were green and failures were confirmed infrastructure-wide. The pattern worked, but the next agent would have to re-derive when admin-merge is appropriate vs. when to keep waiting. This makes the bypass conditions explicit so the audit chain stays clean.

## Test plan

- [x] Docs-only change. No code touched.
- [x] No new files outside \`.rules/autonomous.md\` + \`.changeset/3076-admin-merge-clause.md\`.

## Closes

Partial close on #3076 — primitive #3 of 4 shipped. Primitive #4 (outage frequency telemetry via \`outcome_store\` tagging) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)