### PR TITLE
feat(mcp): CI-outage frequency telemetry (#3084)

### DIFF
--- a/.changeset/3084-ci-outage-telemetry.md
+++ b/.changeset/3084-ci-outage-telemetry.md
@@ -1,0 +1,47 @@
+---
+'nexus-agents': minor
+---
+
+**feat(mcp):** CI-outage frequency telemetry — log + query primitive (#3084 / closes #3076 primitive #4).
+
+The final primitive from #3076. Every `ci_health_check` call now appends one record to `<NEXUS_DATA_DIR>/ci-health/events.jsonl`, and `getCiOutageFrequency()` returns a rolling-N-day aggregate so callers (primarily `improvement_review`) can surface frequency-based signals.
+
+## Surface
+
+- **`appendCiHealthEvent({ status, signals, repo? })`** — best-effort write. Failures are logged but never thrown; the diagnostic surface (`ci_health_check`) must not block on telemetry. Wired into `ci_health_check` itself — no caller-side opt-in needed.
+- **`getCiOutageFrequency(days = 30)`** — returns `{ events, outages, degraded, degradedRatio, windowDays, windowStart }`. `degradedRatio = (outages + degraded) / events`; both states are operator-relevant.
+- **`pruneOlderThan(keepDays)`** — idempotent log compaction. Periodic-caller concern; not on every append.
+
+## Record shape
+
+```ts
+{
+  v: 1,
+  ts: '<iso>',
+  status: 'healthy' | 'degraded' | 'outage' | 'unknown',
+  repo?: 'owner/name',
+  signals: [{ source, status, evidence }, ...],
+}
+```
+
+## Storage
+
+Per-repo under `<NEXUS_DATA_DIR>/ci-health/` (`ci-health` added to `PER_REPO_SUBDIRS`). Outages reported via `ci_health_check({ repo })` are repo-correlated; a wedge on repo A's queue doesn't predict repo B's health, so cross-repo aggregation would be misleading.
+
+## Tests (15 new cases in `ci-health-log.test.ts`)
+
+- Append: line shape, ordering preserved, optional `repo` field round-trips.
+- Query: empty log returns zeros; status discrimination; window exclusion (40-day-old events ignored from 30-day window); custom window; non-positive `days` throws.
+- Prune: no-op when nothing old; correctly drops + reports counts.
+- `eventFromCheck` adapter: optional repo handling, signal-field stripping.
+- Integration: malformed JSON lines tolerated (skipped, not fatal) — pre-existing corruption shouldn't break new queries.
+
+## What this is NOT (yet)
+
+- **`improvement_review` integration** — surface a frequency-threshold signal. Recommended next iteration but separate concern (touches `improvement_review`'s threshold table); deferring to the follow-up.
+- **Cross-session anonymized aggregation** — would need an opt-in upload surface; design discussion explicitly out of scope per #3084.
+- **Auto-polling `ci_health_check`** — only writes happen on explicit caller invocation, by design. False-positive outage signals from network blips would pollute the telemetry.
+
+## Closes
+
+Closes #3084 (the scoped primitive #4 issue). #3076 is already closed.

--- a/packages/nexus-agents/src/config/nexus-data-dir.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.ts
@@ -84,6 +84,10 @@ const PER_REPO_SUBDIRS: ReadonlySet<string> = new Set([
   // in a specific codebase — a job dispatched on repo A shouldn't be
   // polled-against on repo B, which would happen if jobs/ were homedir-scoped.
   'jobs',
+  // CI health-check events (#3076 / #3084). Per-repo because outages
+  // reported via `ci_health_check({ repo })` are repo-correlated; a wedge
+  // on repo A's queue does not predict repo B's health.
+  'ci-health',
 ]);
 
 /** Returns the absolute path to the nexus-agents data directory. */

--- a/packages/nexus-agents/src/mcp/tools/ci-health-check-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-check-tool.ts
@@ -40,6 +40,7 @@ import {
   type ToolResult,
 } from './tool-result.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+import { appendCiHealthEvent, eventFromCheck } from './ci-health-log.js';
 
 /** Combined health verdict. `degraded` means partial — operator can still ship with caution. */
 export const CiHealthStatusSchema = z.enum(['healthy', 'degraded', 'outage', 'unknown']);
@@ -244,6 +245,12 @@ async function ciHealthCheckHandler(args: unknown, logger: ILogger): Promise<Too
     checkedAt: new Date().toISOString(),
     signals,
   };
+  // Telemetry append (#3084 / #3076 primitive #4). Best-effort — the log
+  // writer swallows its own failures so the diagnostic surface above is
+  // never blocked by a telemetry write error.
+  appendCiHealthEvent(
+    eventFromCheck({ status: response.status, signals, ...(repo !== undefined ? { repo } : {}) })
+  );
   return toolSuccess(JSON.stringify(response, null, 2));
 }
 

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for ci-health-log (#3076 primitive #4 / #3084).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  appendCiHealthEvent,
+  eventFromCheck,
+  getCiOutageFrequency,
+  pruneOlderThan,
+} from './ci-health-log.js';
+import { resetNexusDataDirCache, nexusDataPath } from '../../config/nexus-data-dir.js';
+
+describe('ci-health-log', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-cihealth-test-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Read the on-disk jsonl as parsed records. */
+  function readLog(): unknown[] {
+    const path = nexusDataPath('ci-health', 'events.jsonl');
+    const raw = readFileSync(path, 'utf-8');
+    return raw
+      .split('\n')
+      .filter((l) => l !== '')
+      .map((l) => JSON.parse(l) as unknown);
+  }
+
+  describe('appendCiHealthEvent', () => {
+    it('writes one line per call with v=1 and ISO ts', () => {
+      appendCiHealthEvent({
+        status: 'healthy',
+        signals: [
+          {
+            source: 'github-status',
+            status: 'healthy',
+            evidence: 'operational',
+          },
+        ],
+      });
+      const records = readLog();
+      expect(records).toHaveLength(1);
+      const r = records[0] as { v: number; ts: string; status: string };
+      expect(r.v).toBe(1);
+      expect(r.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(r.status).toBe('healthy');
+    });
+
+    it('appends in order — second call adds a second line, first preserved', () => {
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      appendCiHealthEvent({ status: 'outage', signals: [] });
+      const records = readLog();
+      expect(records).toHaveLength(2);
+      expect((records[0] as { status: string }).status).toBe('healthy');
+      expect((records[1] as { status: string }).status).toBe('outage');
+    });
+
+    it('persists optional repo field when present', () => {
+      appendCiHealthEvent({ status: 'degraded', signals: [], repo: 'a/b' });
+      const r = readLog()[0] as { repo?: string };
+      expect(r.repo).toBe('a/b');
+    });
+
+    it('omits repo field when not provided', () => {
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      const r = readLog()[0] as { repo?: string };
+      expect(r.repo).toBeUndefined();
+    });
+  });
+
+  describe('getCiOutageFrequency', () => {
+    it('returns zeros when log is empty', () => {
+      const r = getCiOutageFrequency(30);
+      expect(r.events).toBe(0);
+      expect(r.outages).toBe(0);
+      expect(r.degraded).toBe(0);
+      expect(r.degradedRatio).toBe(0);
+      expect(r.windowDays).toBe(30);
+    });
+
+    it('counts events in window, distinguishing outage vs degraded vs healthy', () => {
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      appendCiHealthEvent({ status: 'degraded', signals: [] });
+      appendCiHealthEvent({ status: 'outage', signals: [] });
+
+      const r = getCiOutageFrequency(30);
+      expect(r.events).toBe(4);
+      expect(r.outages).toBe(1);
+      expect(r.degraded).toBe(1);
+      // (1 outage + 1 degraded) / 4 events = 0.5
+      expect(r.degradedRatio).toBe(0.5);
+    });
+
+    it('ignores events older than the window', () => {
+      const path = nexusDataPath('ci-health', 'events.jsonl');
+      // Manually write a backdated event (40 days ago) + a fresh one
+      const oldTs = new Date(Date.now() - 40 * 86_400_000).toISOString();
+      const oldEvent = {
+        v: 1,
+        ts: oldTs,
+        status: 'outage',
+        signals: [],
+      };
+      const freshEvent = {
+        v: 1,
+        ts: new Date().toISOString(),
+        status: 'healthy',
+        signals: [],
+      };
+      // Pre-create the dir via a no-op append, then overwrite with our test data
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      writeFileSync(path, `${JSON.stringify(oldEvent)}\n${JSON.stringify(freshEvent)}\n`);
+
+      const r = getCiOutageFrequency(30);
+      // Old outage outside window, fresh healthy inside
+      expect(r.events).toBe(1);
+      expect(r.outages).toBe(0);
+      expect(r.degradedRatio).toBe(0);
+    });
+
+    it('respects custom window days', () => {
+      appendCiHealthEvent({ status: 'outage', signals: [] });
+      const r = getCiOutageFrequency(7);
+      expect(r.windowDays).toBe(7);
+      expect(r.events).toBe(1);
+    });
+
+    it('throws on non-positive window days', () => {
+      expect(() => getCiOutageFrequency(0)).toThrow(/must be > 0/);
+      expect(() => getCiOutageFrequency(-1)).toThrow(/must be > 0/);
+    });
+  });
+
+  describe('pruneOlderThan', () => {
+    it('returns 0 removed when nothing to prune', () => {
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      const { kept, removed } = pruneOlderThan(30);
+      expect(kept).toBe(1);
+      expect(removed).toBe(0);
+    });
+
+    it('drops entries older than keepDays, preserves newer ones', () => {
+      const path = nexusDataPath('ci-health', 'events.jsonl');
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      const oldEvent = {
+        v: 1,
+        ts: new Date(Date.now() - 100 * 86_400_000).toISOString(),
+        status: 'outage',
+        signals: [],
+      };
+      const freshEvent = {
+        v: 1,
+        ts: new Date().toISOString(),
+        status: 'healthy',
+        signals: [],
+      };
+      writeFileSync(path, `${JSON.stringify(oldEvent)}\n${JSON.stringify(freshEvent)}\n`);
+
+      const { kept, removed } = pruneOlderThan(30);
+      expect(kept).toBe(1);
+      expect(removed).toBe(1);
+
+      // Verify the surviving entry is the fresh one
+      const r = getCiOutageFrequency(30);
+      expect(r.events).toBe(1);
+      expect(r.outages).toBe(0);
+    });
+  });
+
+  describe('eventFromCheck', () => {
+    it('omits the repo field when undefined', () => {
+      const e = eventFromCheck({
+        status: 'healthy',
+        signals: [{ source: 'github-status', status: 'healthy', evidence: 'ok' }],
+      });
+      expect(e).not.toHaveProperty('repo');
+    });
+
+    it('includes the repo field when provided', () => {
+      const e = eventFromCheck({
+        status: 'degraded',
+        signals: [],
+        repo: 'a/b',
+      });
+      expect(e.repo).toBe('a/b');
+    });
+
+    it('drops extra fields from input signals — keeps only source/status/evidence', () => {
+      const e = eventFromCheck({
+        status: 'healthy',
+        signals: [
+          {
+            source: 'github-status',
+            status: 'healthy',
+            evidence: 'ok',
+          },
+        ],
+      });
+      expect(e.signals[0]).toEqual({
+        source: 'github-status',
+        status: 'healthy',
+        evidence: 'ok',
+      });
+    });
+  });
+
+  describe('integration: round-trip with malformed lines', () => {
+    it('tolerates one malformed line without breaking later reads', () => {
+      const path = nexusDataPath('ci-health', 'events.jsonl');
+      appendCiHealthEvent({ status: 'healthy', signals: [] });
+      // Inject a corrupt line between two valid records
+      const corrupt = 'this is not json\n';
+      const valid = `${JSON.stringify({
+        v: 1,
+        ts: new Date().toISOString(),
+        status: 'outage',
+        signals: [],
+      })}\n`;
+      const existing = readFileSync(path, 'utf-8');
+      writeFileSync(path, existing + corrupt + valid);
+
+      const r = getCiOutageFrequency(30);
+      // 2 valid records, corrupt line skipped
+      expect(r.events).toBe(2);
+      expect(r.outages).toBe(1);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
@@ -1,0 +1,176 @@
+/**
+ * CI health-event log (#3076 primitive #4 / #3084).
+ *
+ * Append-only per-repo JSONL at `<NEXUS_DATA_DIR>/ci-health/events.jsonl`.
+ * Each `ci_health_check` call appends one entry. `getCiOutageFrequency`
+ * windows the log to give callers (primarily `improvement_review`) a
+ * rolling-N-day view of CI infrastructure health.
+ *
+ * ## Design notes
+ *
+ * - **Per-repo storage** — outages reported via `ci_health_check({ repo })`
+ *   are repo-correlated; a wedge on one repo's queue doesn't predict
+ *   another's. See `PER_REPO_SUBDIRS` (#2872 / #3084).
+ * - **Append-only** — no in-place rewrites. Reader trims by `ts` window;
+ *   on-disk pruning is a separate caller concern (see `pruneOlderThan`).
+ * - **Failure-resilient writes** — if the write itself fails (disk full,
+ *   permission), log a warn and continue. The TELEMETRY surface must not
+ *   block the diagnostic surface (`ci_health_check`'s primary job is to
+ *   return a status, not to durably log it).
+ *
+ * @module mcp/tools/ci-health-log
+ */
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+import { z } from 'zod';
+
+import { createLogger } from '../../core/index.js';
+import { nexusDataPathEnsure } from '../../config/nexus-data-dir.js';
+import { CiHealthStatusSchema, type CiHealthSignal } from './ci-health-check-tool.js';
+
+const logger = createLogger({ component: 'ci-health-log' });
+
+/** One on-disk health-event record. Versioned for forward-compat. */
+export const CiHealthEventSchema = z.object({
+  v: z.literal(1),
+  ts: z.iso.datetime(),
+  status: CiHealthStatusSchema,
+  repo: z.string().optional(),
+  signals: z.array(
+    z.object({
+      source: z.enum(['github-status', 'repo-activity-window']),
+      status: CiHealthStatusSchema,
+      evidence: z.string(),
+    })
+  ),
+});
+export type CiHealthEvent = z.infer<typeof CiHealthEventSchema>;
+
+/** Aggregate window output for `getCiOutageFrequency`. */
+export interface CiOutageFrequency {
+  /** Total events in window. */
+  readonly events: number;
+  /** Subset where `status === 'outage'`. */
+  readonly outages: number;
+  /** Subset where `status === 'degraded'`. */
+  readonly degraded: number;
+  /** `(outages + degraded) / events`. 0 when `events === 0`. */
+  readonly degradedRatio: number;
+  /** Window size in days. */
+  readonly windowDays: number;
+  /** ISO timestamp at the start of the window. */
+  readonly windowStart: string;
+}
+
+function logFilePath(): string {
+  return nexusDataPathEnsure('ci-health', 'events.jsonl');
+}
+
+/**
+ * Append one event. Best-effort: failures are logged but never thrown —
+ * the caller (`ci_health_check`) must not block on telemetry success.
+ */
+export function appendCiHealthEvent(event: Omit<CiHealthEvent, 'v' | 'ts'>): void {
+  const record: CiHealthEvent = {
+    v: 1,
+    ts: new Date().toISOString(),
+    ...event,
+  };
+  try {
+    appendFileSync(logFilePath(), `${JSON.stringify(record)}\n`);
+  } catch (err) {
+    logger.warn('Failed to append ci-health event', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Read all events from the log. Tolerates per-line parse failures —
+ * a corrupt line is skipped, not fatal (future-schema or partial write).
+ */
+function readAllEvents(): CiHealthEvent[] {
+  const path = logFilePath();
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    logger.warn('Failed to read ci-health log', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+  const out: CiHealthEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (line === '') continue;
+    try {
+      const parsed = CiHealthEventSchema.safeParse(JSON.parse(line) as unknown);
+      if (parsed.success) out.push(parsed.data);
+    } catch {
+      // Skip malformed lines without logging — pre-existing corruption
+      // shouldn't spam logs on every query.
+    }
+  }
+  return out;
+}
+
+/**
+ * Aggregate outage frequency over a rolling window. Default 30 days.
+ * Window bounds: `[now - days, now]`; events outside the window are
+ * ignored. `degradedRatio` combines `outage` + `degraded` because both
+ * are signals the operator should care about (a steady drumbeat of
+ * degraded is as informative as a single outage).
+ */
+export function getCiOutageFrequency(days = 30): CiOutageFrequency {
+  if (days <= 0) {
+    throw new Error(`getCiOutageFrequency: days must be > 0 (got ${String(days)})`);
+  }
+  const now = Date.now();
+  const startMs = now - days * 86_400_000;
+  const events = readAllEvents().filter((e) => Date.parse(e.ts) >= startMs);
+  const outages = events.filter((e) => e.status === 'outage').length;
+  const degraded = events.filter((e) => e.status === 'degraded').length;
+  return {
+    events: events.length,
+    outages,
+    degraded,
+    degradedRatio: events.length === 0 ? 0 : (outages + degraded) / events.length,
+    windowDays: days,
+    windowStart: new Date(startMs).toISOString(),
+  };
+}
+
+/**
+ * Rewrite the log keeping only entries within the last `keepDays`. Idempotent.
+ * Intended for periodic cleanup (e.g., from `improvement_review` or a cron),
+ * not on every append.
+ */
+export function pruneOlderThan(keepDays: number): { kept: number; removed: number } {
+  const all = readAllEvents();
+  const cutoffMs = Date.now() - keepDays * 86_400_000;
+  const kept = all.filter((e) => Date.parse(e.ts) >= cutoffMs);
+  const removed = all.length - kept.length;
+  if (removed > 0) {
+    writeFileSync(logFilePath(), kept.map((e) => `${JSON.stringify(e)}\n`).join(''));
+  }
+  return { kept: kept.length, removed };
+}
+
+/** Internal: shape conversion from `CiHealthSignal` (re-used by ci-health-check-tool). */
+export function eventFromCheck(params: {
+  status: import('./ci-health-check-tool.js').CiHealthStatus;
+  signals: readonly CiHealthSignal[];
+  repo?: string;
+}): Omit<CiHealthEvent, 'v' | 'ts'> {
+  return {
+    status: params.status,
+    signals: params.signals.map((s) => ({
+      source: s.source,
+      status: s.status,
+      evidence: s.evidence,
+    })),
+    ...(params.repo !== undefined ? { repo: params.repo } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Closes **#3084** — the final primitive (#4) from the now-closed #3076 epic. Wires telemetry into \`ci_health_check\` so operators can answer "how often does CI break?" without scraping individual run logs.

## Surface

- **\`appendCiHealthEvent({ status, signals, repo? })\`** — best-effort write; failures are logged but never thrown. The diagnostic surface (\`ci_health_check\`) must not block on telemetry.
- **\`getCiOutageFrequency(days = 30)\`** — returns \`{ events, outages, degraded, degradedRatio, windowDays, windowStart }\`. Combines \`outage\` + \`degraded\` in the ratio since both are operator-relevant.
- **\`pruneOlderThan(keepDays)\`** — idempotent log compaction. Periodic-caller concern.

## Storage

Per-repo \`<NEXUS_DATA_DIR>/ci-health/events.jsonl\`. \`ci-health\` added to \`PER_REPO_SUBDIRS\` — outages reported via \`ci_health_check({ repo })\` are repo-correlated; cross-repo aggregation would be misleading.

## Test plan

- [x] 15 unit tests cover append (shape, ordering, optional repo round-trip), query (empty, status discrimination, window exclusion, custom window, negative-days guard), prune (no-op + drop), \`eventFromCheck\` adapter, malformed-line tolerance.
- [x] \`ci-health-check-tool.test.ts\` (18 tests) still passes — telemetry wiring is additive.
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean.

## Out of scope (deferred)

- **\`improvement_review\` integration** — surface a frequency-threshold signal. Touches improvement_review's threshold table; separate concern.
- **Cross-session anonymized aggregation** — would need an opt-in upload surface; design discussion explicitly out of scope per #3084.
- **Auto-polling \`ci_health_check\`** — only writes on explicit caller invocation, by design. False-positive outage signals from network blips would pollute the telemetry.

## Closes

Closes #3084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)