### PR TITLE
feat(orchestrate): async-mode writes results to StructuredTaskState (#3091 writer half)

### DIFF
--- a/.changeset/3091-orchestrate-writer.md
+++ b/.changeset/3091-orchestrate-writer.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+**feat(orchestrate):** async-mode writes results to StructuredTaskState (#3091, writer half of the #3069 sidecar→Stage-2 migration).
+
+`orchestrate({ mode: 'async' })` now records its result into the canonical Stage-2 task-state log, so `get_job_result` resolves directly from it once `NEXUS_JOB_RESULT_SOURCE=task_state` (default still sidecar — see #3094). Completes the reader+writer pair: the dual-read is now activatable end-to-end.
+
+What changed:
+
+- **`jobId === taskId`.** Async dispatch now mints the jobId via the orchestration's own `generateTaskId()` and threads it through the pipeline, so the job's result lands in the task-state log keyed identically. **User-visible:** the async-mode `jobId` format changes from `job-orch-<uuid>` to `orch-<ts>-<rand>`. Callers that treat the jobId as an opaque token (the documented contract) are unaffected; only code that parsed the `job-orch-` prefix would need updating.
+- **Terminal failures record stage `'failed'`** (the new stage from #3094) instead of the recoverable `'blocked'`, at both `executeOrchestration` failure sites. This applies to sync orchestrate too — its task-state log now shows `'failed'` on a hard failure (observability only; nothing gates on the prior `'blocked'`). The blocker entry (carrying the message) is unchanged.
+- On completion the background run mirrors the result into task-state via `appendResult`; throws escaping the pipeline record a `'failed'` terminal stage so pollers never see a stuck `'pending'`.
+
+Fast-path (simple) async tasks skip task-state recording and remain resolvable via the sidecar fallback. Deferred: `run_workflow`/`consensus_vote` writers (#3092), `list_jobs` dual-read (#3090), sidecar deletion (#3093).

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-job-result.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-job-result.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration tests for the #3091 async orchestrate writer: the background
+ * run must record its result into the Stage-2 task-state log keyed by
+ * jobId (== taskId), so the #3090 dual-read reader can resolve it.
+ *
+ * Drives the (test-exported) `runOrchestrateInBackground` directly so the
+ * fire-and-forget run is awaitable and deterministic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  runOrchestrateInBackground,
+  createMockOrchestrator,
+  type OrchestrateDeps,
+  type OrchestrateInput,
+} from './orchestrate.js';
+import { NOOP_NOTIFIER } from '../mcp-notifier.js';
+import { resolveJobResult, readJobResultFromTaskState } from '../jobs/task-state-source.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
+import { createLogger } from '../../core/index.js';
+import { RateLimiter } from '../middleware/index.js';
+
+const logger = createLogger({ component: 'test-orch-job-result' });
+
+function testRateLimiter(): RateLimiter {
+  return new RateLimiter({ capacity: 1000, refillRate: 1000, refillIntervalMs: 1000 });
+}
+
+// A task loaded with HIGH_COMPLEXITY_KEYWORDS (refactor, distributed,
+// architecture, optimize, security, performance, concurrent, trade-off,
+// decision, migrate, legacy) so the SharedTaskAnalyzer scores it non-'simple'
+// — otherwise the fast-path short-circuits and skips task-state recording.
+const COMPLEX_TASK =
+  'Refactor the distributed authentication architecture to optimize security ' +
+  'and performance under concurrent load, analyze the trade-off decisions, ' +
+  'and migrate the legacy session services.';
+
+function depsWith(orchestrator: NonNullable<OrchestrateDeps['orchestrator']>): OrchestrateDeps {
+  return { orchestrator, logger, rateLimiter: testRateLimiter() };
+}
+
+function taskInput(task: string): OrchestrateInput {
+  return { task, maxIterations: 10 };
+}
+
+function bgParams(
+  input: OrchestrateInput,
+  deps: OrchestrateDeps
+): {
+  input: OrchestrateInput;
+  deps: OrchestrateDeps;
+  notifier: typeof NOOP_NOTIFIER;
+  logger: typeof logger;
+} {
+  return { input, deps, notifier: NOOP_NOTIFIER, logger };
+}
+
+describe('async orchestrate writer → task-state (#3091)', () => {
+  let tmpDir: string;
+  const origData = process.env['NEXUS_DATA_DIR'];
+  const origSrc = process.env['NEXUS_JOB_RESULT_SOURCE'];
+  const origTs = process.env['NEXUS_TASK_STATE_ENABLED'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-orch-jr-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    process.env['NEXUS_JOB_RESULT_SOURCE'] = 'task_state';
+    delete process.env['NEXUS_TASK_STATE_ENABLED']; // default ON
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (origData === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = origData;
+    if (origSrc === undefined) delete process.env['NEXUS_JOB_RESULT_SOURCE'];
+    else process.env['NEXUS_JOB_RESULT_SOURCE'] = origSrc;
+    if (origTs === undefined) delete process.env['NEXUS_TASK_STATE_ENABLED'];
+    else process.env['NEXUS_TASK_STATE_ENABLED'] = origTs;
+    resetNexusDataDirCache();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('records the result into the task-state log under jobId=taskId', async () => {
+    const jobId = 'orch-itest-success';
+    await runOrchestrateInBackground(
+      jobId,
+      bgParams(taskInput(COMPLEX_TASK), depsWith(createMockOrchestrator()))
+    );
+
+    // The task-state branch must have run (non-simple task → full pipeline),
+    // proving the taskId threaded all the way to executeOrchestration.
+    const fromState = readJobResultFromTaskState(jobId);
+    expect(fromState).not.toBeNull();
+    expect(fromState?.status).toBe('complete');
+    expect(fromState?.result).toBeDefined();
+    expect(fromState?.toolName).toBe('orchestrate');
+
+    // Dual-read resolves it, and the sidecar got the same terminal status.
+    expect(resolveJobResult(jobId)?.status).toBe('complete');
+    expect(readJobResult(jobId)?.status).toBe('complete');
+  });
+
+  it('records a terminal failed stage when the orchestrator fails', async () => {
+    const jobId = 'orch-itest-failure';
+    const failing = {
+      execute: () => Promise.reject(new Error('mock orchestrator boom')),
+    } as unknown as NonNullable<OrchestrateDeps['orchestrator']>;
+
+    await runOrchestrateInBackground(jobId, bgParams(taskInput(COMPLEX_TASK), depsWith(failing)));
+
+    const fromState = readJobResultFromTaskState(jobId);
+    expect(fromState).not.toBeNull();
+    expect(fromState?.status).toBe('failed');
+    // error is sourced from the recorded blocker
+    expect(typeof fromState?.error).toBe('string');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -92,14 +92,18 @@ import {
 // Structured task state (#2033, integration from #2043). Enabled by
 // default from v2.50+; set NEXUS_TASK_STATE_ENABLED=0 to opt out.
 // When disabled, helpers no-op silently.
-import { initTaskState, updateStage, appendBlocker } from '../../context/structured-task-state.js';
+import {
+  initTaskState,
+  updateStage,
+  appendBlocker,
+  appendResult,
+} from '../../context/structured-task-state.js';
 import type { StructuredTaskState } from '../../context/structured-task-state-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 // #3042 / epic #2631: async-mode dispatch + sidecar job-result store.
 import { writeJobPending, writeJobComplete, writeJobFailed } from '../jobs/job-result-store.js';
 import { tryAcquire, release, suggestRetryAfterMs } from '../jobs/job-concurrency.js';
 import { shortCircuitOrFreshJobId, registerIdempotentJob } from '../jobs/job-idempotency.js';
-import { randomUUID } from 'node:crypto';
 
 // Re-export types and values for consumers
 export {
@@ -612,15 +616,24 @@ function handleOrchestratorSuccess(ctx: {
   return ok(output);
 }
 
+interface ExecuteOrchestrationOpts {
+  readonly router?: IWorkflowRouter;
+  readonly snapshot?: OrchestrationStateSnapshot;
+  readonly trustTier?: string;
+  // #3091: async-mode threads a pre-minted taskId so it equals the jobId the
+  // caller polls with (`get_job_result` → task-state). Sync mode omits it and
+  // a fresh id is generated, preserving prior behavior.
+  readonly taskId?: string;
+}
+
 async function executeOrchestration(
   input: OrchestrateInput,
   deps: OrchestrateDeps,
-  router?: IWorkflowRouter,
-  snapshot?: OrchestrationStateSnapshot,
-  trustTier?: string
+  opts: ExecuteOrchestrationOpts = {}
 ): Promise<Result<OrchestrateOutput, OrchestrationError>> {
+  const { router, snapshot, trustTier, taskId: providedTaskId } = opts;
   const { workflowRouter, decision, orchestrator, logger } = routeAndPrepare(input, deps, router);
-  const taskId = generateTaskId();
+  const taskId = providedTaskId ?? generateTaskId();
   const startTime = getTimeProvider().now();
   // Snapshot: routing decision available once routeAndPrepare returns (#2111)
   if (snapshot !== undefined) setRouting(snapshot, buildRoutingInfo(decision));
@@ -657,7 +670,10 @@ async function executeOrchestration(
     });
   } catch (error) {
     recordTaskStateBlocker(taskId, error instanceof Error ? error.message : String(error), logger);
-    recordTaskStateStage(taskId, 'blocked', logger);
+    // #3091: terminal failure → 'failed' (not the recoverable 'blocked'), so
+    // the job-result reader maps it to a terminal `failed` status rather than
+    // leaving pollers waiting on a `pending`.
+    recordTaskStateStage(taskId, 'failed', logger);
     return handleOrchestrationException(error, taskId, input.task, logger);
   } finally {
     hb.cleanup();
@@ -681,7 +697,8 @@ async function runOrchestratorWithStateTracking(params: {
   const result = await withAccessPolicy(policy, () => orchestrator.execute(definition, {}));
   if (!result.ok) {
     recordTaskStateBlocker(taskId, result.error.message, logger);
-    recordTaskStateStage(taskId, 'blocked', logger);
+    // #3091: see executeOrchestration — terminal failure stage is 'failed'.
+    recordTaskStateStage(taskId, 'failed', logger);
     return handleOrchestratorFailure({
       error: result.error,
       taskId,
@@ -771,6 +788,32 @@ function recordTaskStateBlocker(taskId: string, blocker: string, logger: ILogger
       error: result.error.message,
     });
   }
+}
+
+/**
+ * Record the async job's result payload into the Stage-2 task-state log
+ * (#3091). Best-effort + gated, like the other recorders. The terminal
+ * stage was already set by the pipeline; this stores the same payload the
+ * sidecar holds so `get_job_result`'s dual-read returns an identical record.
+ */
+function recordTaskStateResult(taskId: string, result: unknown, logger: ILogger): void {
+  if (!isTaskStateEnabled()) return;
+  const r = appendResult(taskId, result, getTimeProvider().nowIso());
+  if (!r.ok) {
+    logger.warn('task-state: result record failed', { taskId, error: r.error.message });
+  }
+}
+
+/**
+ * Record a terminal failure for an async job (#3091): a blocker carrying the
+ * message + the `'failed'` stage, so the dual-read reader maps it to a
+ * terminal `failed` status. Used by the background wrapper for throws that
+ * escape the pipeline (which otherwise wouldn't have set a terminal stage).
+ */
+function recordTaskStateFailure(taskId: string, message: string, logger: ILogger): void {
+  if (!isTaskStateEnabled()) return;
+  recordTaskStateBlocker(taskId, message, logger);
+  recordTaskStateStage(taskId, 'failed', logger);
 }
 
 /**
@@ -1034,19 +1077,25 @@ async function executeOrchestrationWithDeadline(params: {
   readonly notifier: ReturnType<typeof createMcpNotifier>;
   readonly logger: ILogger;
   readonly trustTier?: string;
+  /** #3091: pre-minted taskId (async mode) so jobId === taskId. */
+  readonly taskId?: string;
 }): Promise<Result<OrchestrateOutput, OrchestrationError>> {
-  const { input, deps, notifier, logger, trustTier } = params;
+  const { input, deps, notifier, logger, trustTier, taskId } = params;
   const overallDeadlineMs = getMcpSafeDeadlineMs(
     MCP_TIMEOUTS.perTool['orchestrate'] ?? MCP_TIMEOUTS.defaultMs,
     'orchestrate'
   );
-  const timeoutTaskId = generateTaskId();
+  const timeoutTaskId = taskId ?? generateTaskId();
   // Shared snapshot: executeOrchestration fills it as sub-steps complete; the
   // timeout handler reads it to produce a richer partial result (#2111).
   const snapshot = createOrchestrationStateSnapshot(getTimeProvider().now());
   return raceAgainstDeadline(
     withProgressHeartbeat('orchestrate', notifier, () =>
-      executeOrchestration(input, deps, undefined, snapshot, trustTier)
+      executeOrchestration(input, deps, {
+        snapshot,
+        ...(trustTier !== undefined ? { trustTier } : {}),
+        ...(taskId !== undefined ? { taskId } : {}),
+      })
     ),
     overallDeadlineMs,
     (elapsedMs) => {
@@ -1072,8 +1121,10 @@ async function runOrchestratePipeline(params: {
   readonly notifier: ReturnType<typeof createMcpNotifier>;
   readonly logger: ILogger;
   readonly trustTier?: string;
+  /** #3091: pre-minted taskId (async mode) so jobId === taskId. */
+  readonly taskId?: string;
 }): Promise<ToolResult> {
-  const { input, deps, notifier, logger, trustTier } = params;
+  const { input, deps, notifier, logger, trustTier, taskId } = params;
   logger.debug('Starting orchestration', { taskLength: input.task.length });
   notifier.info('orchestrate', { event: 'orchestrate_start', taskLength: input.task.length });
   const startMs = getTimeProvider().now();
@@ -1105,6 +1156,7 @@ async function runOrchestratePipeline(params: {
     notifier,
     logger,
     ...(trustTier !== undefined ? { trustTier } : {}),
+    ...(taskId !== undefined ? { taskId } : {}),
   });
   if (!result.ok) {
     return toolStructuredError({
@@ -1251,7 +1303,11 @@ function dispatchAsyncOrchestrate(params: {
     tool: 'orchestrate',
     idempotencyKey: params.input.idempotencyKey,
     inputs: params.input,
-    freshJobId: () => `job-orch-${randomUUID()}`,
+    // #3091: jobId === taskId. The async job's id IS the orchestration's
+    // taskId, so get_job_result(jobId) resolves directly from the task-state
+    // log (orch-<ts>-<rand>) under the Stage-2 reader. Replaces the former
+    // opaque `job-orch-<uuid>` id.
+    freshJobId: () => generateTaskId(),
     replayEnvelope: buildReplayEnvelope,
     collisionEnvelope: buildCollisionEnvelope,
   });
@@ -1293,7 +1349,11 @@ function recordPendingAndRegister(jobId: string, key: string | undefined, inputs
  * complete/failed recording + slot release. Extracted from
  * `dispatchAsyncOrchestrate` so the dispatcher stays under the 50-line cap.
  */
-async function runOrchestrateInBackground(
+/**
+ * @internal Exported for integration tests (#3091) — drives the async
+ * background run deterministically (awaitable) instead of fire-and-forget.
+ */
+export async function runOrchestrateInBackground(
   jobId: string,
   params: {
     readonly input: OrchestrateInput;
@@ -1303,6 +1363,9 @@ async function runOrchestrateInBackground(
     readonly trustTier?: string;
   }
 ): Promise<void> {
+  // #3091: jobId === taskId — thread it into the pipeline so the task-state
+  // log is keyed identically and get_job_result can resolve from it.
+  const taskId = jobId;
   try {
     const result = await withDepthGuard('orchestrate', () =>
       runOrchestratePipeline({
@@ -1310,14 +1373,24 @@ async function runOrchestrateInBackground(
         deps: params.deps,
         notifier: params.notifier,
         logger: params.logger,
+        taskId,
         ...(params.trustTier !== undefined ? { trustTier: params.trustTier } : {}),
       })
     );
     writeJobComplete(jobId, 'orchestrate', result);
+    // #3091: mirror the result payload into the Stage-2 task-state log. The
+    // terminal stage (complete | failed) was set inside the pipeline; this
+    // records the same payload the sidecar stored so the dual-read reader
+    // returns an identical record. Best-effort, gated, never throws.
+    recordTaskStateResult(taskId, result, params.logger);
   } catch (err: unknown) {
     const errObj = err instanceof Error ? err : new Error(String(err));
     params.logger.error('Async orchestrate dispatch failed', errObj, { jobId });
     writeJobFailed(jobId, 'orchestrate', errObj.message);
+    // #3091: a throw escaping the pipeline (e.g. depth-guard) may leave the
+    // task-state log without a terminal stage — record one so the reader
+    // doesn't report a stuck 'pending'.
+    recordTaskStateFailure(taskId, errObj.message, params.logger);
   } finally {
     release('orchestrate');
   }


### PR DESCRIPTION
## What

Writer half of the #3069 sidecar→Stage-2 migration (child #3091). Completes the reader+writer pair started in #3094 — `orchestrate({ mode: 'async' })` now records its result into the canonical Stage-2 task-state log, so `get_job_result` resolves from it once `NEXUS_JOB_RESULT_SOURCE=task_state` (default still sidecar → no behavior change).

## Changes

- **`jobId === taskId`** — async dispatch mints the jobId via the orchestration's own `generateTaskId()` and threads it through `runOrchestratePipeline → executeOrchestrationWithDeadline → executeOrchestration` (refactored its trailing optionals into an options bag to stay under max-params). The result lands in the task-state log keyed identically.
  - ⚠️ **User-visible:** async-mode `jobId` format changes from `job-orch-<uuid>` → `orch-<ts>-<rand>`. Opaque to callers per the documented polling contract; only code parsing the `job-orch-` prefix would care.
- **Terminal failures record stage `'failed'`** (the #3094 stage) instead of recoverable `'blocked'` at both `executeOrchestration` failure sites — so the dual-read reader maps a failed job to a terminal `failed` status, not a stuck `pending`. Applies to sync orchestrate too (observability only; no consumer gates on the prior `'blocked'`). Blocker entry (the message) unchanged.
- Background run mirrors the result via `appendResult` on completion; throws escaping the pipeline record a `'failed'` terminal stage.
- Fast-path (simple) async tasks skip task-state and resolve via the sidecar fallback (unchanged).

## Testing

- 2 new integration tests (`orchestrate-job-result.test.ts`) drive `runOrchestrateInBackground` deterministically — a keyword-loaded task forces the full pipeline (not the fast-path): success round-trips `complete`+result via task-state (+ sidecar parity); failure records `'failed'`.
- ✅ typecheck · lint · new-unused-exports gate (#3024) · **full suite 25,240 passed / 16 skipped** (140 affected tests incl. orchestrate 42 / dispatch 26 — no regression).
- Adversarial `code-reviewer`: **APPROVE**, zero confirmed findings (threading, blocked→failed, failure-path mapping, fast-path fallback all verified).

## Follow-ups (tracked)

- `list_jobs` dual-read — remaining in #3090.
- `run_workflow` / `consensus_vote` writers — #3092.
- Delete sidecar `job-result-store.ts` — #3093.

Refs #3069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)