### PR TITLE
fix(ci-health): bound telemetry log growth + surface corrupted lines (#3089)

### DIFF
--- a/.changeset/3089-ci-health-pruning.md
+++ b/.changeset/3089-ci-health-pruning.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': patch
+---
+
+**fix(ci-health):** bound telemetry log growth + surface corrupted lines (#3089).
+
+The CI-health event log (`ci-health-log.ts`, shipped in #3084) had two reliability gaps that this fixes:
+
+- **Unbounded growth.** `appendCiHealthEvent` runs on every `ci_health_check`, and `getCiOutageFrequency` reads the whole file each call — so an autonomous polling loop grew the log (and every read) without limit. `pruneOlderThan` existed but was never wired, and being age-based it can't bound a burst of _recent_ events anyway. Appends now opportunistically cap the file to the most recent lines that fit within `NEXUS_CI_HEALTH_MAX_BYTES` (default 2 MiB), gated by a cheap `statSync` so the O(n) rewrite only runs when the cap is actually exceeded. Best-effort — telemetry never blocks or throws.
+- **Silent corruption.** `readAllEvents` dropped unparseable lines with no signal, so a partial write or tampered line made aggregates under-count invisibly. It now logs a `warn` with the skipped-line count.

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
@@ -242,4 +242,47 @@ describe('ci-health-log', () => {
       expect(r.outages).toBe(1);
     });
   });
+
+  describe('size cap / growth bound (#3089)', () => {
+    const originalMax = process.env['NEXUS_CI_HEALTH_MAX_BYTES'];
+
+    afterEach(() => {
+      if (originalMax === undefined) delete process.env['NEXUS_CI_HEALTH_MAX_BYTES'];
+      else process.env['NEXUS_CI_HEALTH_MAX_BYTES'] = originalMax;
+    });
+
+    function appendFor(repo: string): void {
+      appendCiHealthEvent(
+        eventFromCheck({
+          status: 'healthy',
+          signals: [{ source: 'github-status', status: 'healthy', evidence: 'ok' }],
+          repo,
+        })
+      );
+    }
+
+    it('does not prune while under the cap', () => {
+      // Default 2 MiB cap — a handful of events stays intact.
+      for (let i = 0; i < 5; i++) appendFor(`o/r${String(i)}`);
+      expect(readLog().length).toBe(5);
+    });
+
+    it('bounds the log to the most recent events once the byte cap is exceeded', () => {
+      process.env['NEXUS_CI_HEALTH_MAX_BYTES'] = '600'; // tiny cap for the test
+      for (let i = 0; i < 50; i++) appendFor(`o/r${String(i)}`);
+
+      const records = readLog() as Array<{ repo?: string }>;
+      // Far fewer than 50 retained — growth is bounded, not unbounded.
+      expect(records.length).toBeGreaterThan(0);
+      expect(records.length).toBeLessThan(50);
+      // Newest retained, oldest dropped (tail-retention).
+      expect(records.at(-1)?.repo).toBe('o/r49');
+      expect(records.some((r) => r.repo === 'o/r0')).toBe(false);
+
+      // On-disk size respects the cap (plus at most one always-kept newest line).
+      const path = nexusDataPath('ci-health', 'events.jsonl');
+      const bytes = Buffer.byteLength(readFileSync(path, 'utf-8'), 'utf-8');
+      expect(bytes).toBeLessThanOrEqual(600 + 256);
+    });
+  });
 });

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
@@ -21,7 +21,7 @@
  * @module mcp/tools/ci-health-log
  */
 
-import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 
 import { z } from 'zod';
 
@@ -68,6 +68,71 @@ function logFilePath(): string {
 }
 
 /**
+ * Default on-disk size cap for the log, in bytes (#3089). Bounds the
+ * disk + read cost of an unbounded append loop — `getCiOutageFrequency`
+ * reads the whole file, so growth degrades reads too. Age-based pruning
+ * (`pruneOlderThan`) can't bound a burst of *recent* events within the
+ * retention window; this size cap can. Overridable via
+ * `NEXUS_CI_HEALTH_MAX_BYTES` (ops tuning + test injection).
+ */
+const DEFAULT_CI_HEALTH_MAX_BYTES = 2_097_152; // 2 MiB
+
+function maxLogBytes(): number {
+  const raw = process.env['NEXUS_CI_HEALTH_MAX_BYTES'];
+  if (raw === undefined || raw === '') return DEFAULT_CI_HEALTH_MAX_BYTES;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_CI_HEALTH_MAX_BYTES;
+}
+
+/**
+ * Bound the log to the most recent lines that fit within `maxLogBytes()`
+ * (#3089). Cheap `statSync` pre-check so the O(n) rewrite only runs when
+ * the file actually exceeds the cap — after a rewrite the size drops and
+ * won't re-trigger until it regrows, keeping append amortized-cheap. The
+ * newest line is always retained even if it alone exceeds the cap.
+ * Post-condition: on-disk size <= `maxLogBytes()`, except the degenerate
+ * case of a single retained line larger than the cap.
+ * Best-effort: failures are logged, never thrown.
+ */
+function capLogSize(path: string): void {
+  const max = maxLogBytes();
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return; // file vanished / unreadable — nothing to cap
+  }
+  if (size <= max) return;
+  try {
+    const lines = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter((l) => l !== '');
+    const kept: string[] = [];
+    let bytes = 0;
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i] as string;
+      const lineBytes = Buffer.byteLength(`${line}\n`, 'utf-8');
+      // Always keep the newest line; otherwise stop once the cap is hit.
+      if (kept.length > 0 && bytes + lineBytes > max) break;
+      kept.push(line);
+      bytes += lineBytes;
+    }
+    kept.reverse();
+    writeFileSync(path, kept.length > 0 ? `${kept.join('\n')}\n` : '');
+    logger.warn('ci-health log exceeded size cap — dropped oldest events', {
+      maxBytes: max,
+      previousBytes: size,
+      droppedEvents: lines.length - kept.length,
+      keptEvents: kept.length,
+    });
+  } catch (err) {
+    logger.warn('Failed to cap ci-health log size', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * Append one event. Best-effort: failures are logged but never thrown —
  * the caller (`ci_health_check`) must not block on telemetry success.
  */
@@ -78,7 +143,11 @@ export function appendCiHealthEvent(event: Omit<CiHealthEvent, 'v' | 'ts'>): voi
     ...event,
   };
   try {
-    appendFileSync(logFilePath(), `${JSON.stringify(record)}\n`);
+    const path = logFilePath();
+    appendFileSync(path, `${JSON.stringify(record)}\n`);
+    // #3089: opportunistically bound growth so an autonomous polling loop
+    // can't grow the log (and thus every read) without limit.
+    capLogSize(path);
   } catch (err) {
     logger.warn('Failed to append ci-health event', {
       error: err instanceof Error ? err.message : String(err),
@@ -103,15 +172,22 @@ function readAllEvents(): CiHealthEvent[] {
     return [];
   }
   const out: CiHealthEvent[] = [];
+  let skipped = 0;
   for (const line of raw.split('\n')) {
     if (line === '') continue;
     try {
       const parsed = CiHealthEventSchema.safeParse(JSON.parse(line) as unknown);
       if (parsed.success) out.push(parsed.data);
+      else skipped++;
     } catch {
-      // Skip malformed lines without logging — pre-existing corruption
-      // shouldn't spam logs on every query.
+      skipped++;
     }
+  }
+  // #3089: surface corruption rather than dropping lines silently. A
+  // partial write or tampered line would otherwise make aggregates
+  // under-count with zero signal to the operator.
+  if (skipped > 0) {
+    logger.warn('ci-health log: skipped malformed lines', { skipped, kept: out.length });
   }
   return out;
 }


### PR DESCRIPTION
## What

Closes #3089 — two reliability gaps in the CI-health telemetry log (`ci-health-log.ts`, shipped #3084).

## Changes

- **Bounds unbounded growth.** `appendCiHealthEvent` runs per `ci_health_check` and `getCiOutageFrequency` reads the whole file each call, so an autonomous polling loop grew the log (and every read) without limit. The pre-existing `pruneOlderThan` was never wired and — being age-based — can't bound a burst of *recent* events anyway. Appends now opportunistically cap the file to the most recent lines fitting within `NEXUS_CI_HEALTH_MAX_BYTES` (default 2 MiB), gated by a cheap `statSync` so the O(n) rewrite only fires past the cap (amortized-cheap, no O(n²)). Best-effort — telemetry never throws.
- **Surfaces silent corruption.** `readAllEvents` dropped unparseable lines with zero signal; it now logs a `warn` with the skipped-line count, so a partial write / tampered line is detectable instead of silently under-counting aggregates.

## Testing

- 2 new tests: under-cap (no prune) + over-cap (tail-retention: newest `o/r49` kept, oldest `o/r0` dropped, count `<50`, on-disk bytes bounded). Deterministic via `NEXUS_CI_HEALTH_MAX_BYTES` injection. Existing malformed-line round-trip covers the skip path.
- ✅ typecheck · lint · new-unused-exports gate · **full suite green** · `code-reviewer` **APPROVE** (no Critical/Important; verified DoS fix is real, append cost amortized, best-effort preserved).