### PR TITLE
feat(skills): add pre-push-parity skill (#3073)

### DIFF
--- a/.changeset/3073-pre-push-parity-skill.md
+++ b/.changeset/3073-pre-push-parity-skill.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+**feat(skills):** add `pre-push-parity` skill (#3073).
+
+Agents kept discovering CI-only checks one failure at a time — push, wait ~3 min, parse logs, fix, repeat — for gates not in the local quality gate (the #3073 incident: `ruff format --check` and a `gitleaks` false-positive). CI is a strict superset of any local gate; this skill runs that superset locally first.
+
+The skill (1) enumerates the repo's CI checks from `.github/workflows/`, (2) runs the locally-runnable subset in CI's order via a fail-fast one-shot (typecheck, lint, test, build, changeset presence, producer/consumer #3024, model-drift, commitlint, clean-tree, gitleaks), (3) names the checks that _can't_ run locally (CodeQL, Scorecard, Semgrep, Socket, docker consolidation) as residual risk, and (4) prompts writing a `ci-vs-local-gate-*` memory the first time in a repo so the delta isn't rediscovered. Includes the gitleaks test-fixture hygiene tip.
+
+Brings the registered skill count to 32 (index + governance docs regenerated).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "source": "github",
         "repo": "williamzujkowski/nexus-agents"
       },
-      "description": "Intelligent orchestration platform for AI coding tools — 42 MCP tools (orchestrate, consensus voting, research, pipelines), 31 skills, 12 expert agents, governance hooks.",
+      "description": "Intelligent orchestration platform for AI coding tools — 42 MCP tools (orchestrate, consensus voting, research, pipelines), 32 skills, 12 expert agents, governance hooks.",
       "keywords": ["orchestration", "mcp", "consensus", "pipelines", "multi-agent"]
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ _Auto-generated from `.rules/*.md` frontmatter by `scripts/inject-governance.ts`
 
 Workflow playbooks live at `skills/<name>/SKILL.md` (canonical per the Anthropic Agent Skills spec, which OpenCode and others are adopting).
 
-- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 31 skills.
+- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 32 skills.
 - When a user request matches a skill's triggers, read the full `SKILL.md` at the listed path and follow its workflow.
 - `skills/index.yaml` is regenerated via `scripts/generate-skills-index.ts` and gated in CI. Never edit it by hand.
 - **Codex Skills (#2660):** Codex's Skills primitive uses the same `SKILL.md` filename + the same required frontmatter (`name`, `description`) as the Anthropic spec — these skills are already cross-vendor compatible, no translation layer needed. Codex discovers skills under `.agents/skills/` or via `[[skills.config]]` path entries in the agent config; point either at this repo's `skills/` directory. The `name`/`description` validation in `generate-skills-index.ts` is the enforced cross-vendor contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,11 +219,11 @@ Full rules — trust-tier definitions, the 6 non-negotiable invariants (comments
 
 ## Workflows (via Skills)
 
-**31 skills registered.** Each skill's detailed steps and trigger keywords live in `skills/<name>/SKILL.md` (Anthropic Agent Skills spec, #1828). Non-Claude agents discover via [`skills/index.yaml`](./skills/index.yaml) referenced from [AGENTS.md](./AGENTS.md).
+**32 skills registered.** Each skill's detailed steps and trigger keywords live in `skills/<name>/SKILL.md` (Anthropic Agent Skills spec, #1828). Non-Claude agents discover via [`skills/index.yaml`](./skills/index.yaml) referenced from [AGENTS.md](./AGENTS.md).
 
-`api-and-interface-design`, `browser-testing-with-devtools`, `bug-fix`, `code-simplification`, `codex-delegator`, `context-engineering`, `deprecation-and-migration`, `dev-pipeline`, `docs-chart`, `docs-image`, `docs-mermaid`, `docs-review`, `docs-rewrite`, `documentation-management`, `dogfooding-issues`, `gemini-delegator`, `hotfix`, `implement-feature`, `infrastructure-management`, `performance-optimization`, `release`, `requirements-gathering`, `research-and-vote`, `reviewing-code`, `security-advisory-response`, `security-scanning`, `self-critique`, `system-review`, `test-driven-development`, `ui-ux-design`, `version-check`
+`api-and-interface-design`, `browser-testing-with-devtools`, `bug-fix`, `code-simplification`, `codex-delegator`, `context-engineering`, `deprecation-and-migration`, `dev-pipeline`, `docs-chart`, `docs-image`, `docs-mermaid`, `docs-review`, `docs-rewrite`, `documentation-management`, `dogfooding-issues`, `gemini-delegator`, `hotfix`, `implement-feature`, `infrastructure-management`, `performance-optimization`, `pre-push-parity`, `release`, `requirements-gathering`, `research-and-vote`, `reviewing-code`, `security-advisory-response`, `security-scanning`, `self-critique`, `system-review`, `test-driven-development`, `ui-ux-design`, `version-check`
 
-_Auto-generated from `skills/index.yaml`. 31 skills._
+_Auto-generated from `skills/index.yaml`. 32 skills._
 
 <!-- GOVERNANCE:WORKFLOW_INDEX:END -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ keywords: [documentation, index, reference, navigation, docs]
 
 # Nexus Agents Documentation
 
-**Canonical Documentation Index** | Last Updated: 2026-05-25 (31 skills, 42 MCP tools, 11 expert types, 11 workflow templates)
+**Canonical Documentation Index** | Last Updated: 2026-05-30 (32 skills, 42 MCP tools, 12 expert types, 11 workflow templates)
 
 This is the **single source of truth** for all nexus-agents documentation. All documentation must be indexed here to be considered valid.
 

--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -1,6 +1,6 @@
 ---
 title: 'Claude Code Plugin Install'
-description: Install nexus-agents as a Claude Code plugin — exposes 42 MCP tools, 31 skills, 12 agent mirrors, and governance hooks
+description: Install nexus-agents as a Claude Code plugin — exposes 42 MCP tools, 32 skills, 12 agent mirrors, and governance hooks
 tier: 2
 keywords: [plugin, claude-code, installation, marketplace, mcp, getting-started]
 ---
@@ -13,7 +13,7 @@ keywords: [plugin, claude-code, installation, marketplace, mcp, getting-started]
 Nexus-agents ships as a Claude Code plugin. Installing it exposes:
 
 - 42 MCP tools (`orchestrate`, `consensus_vote`, `research_*`, `run_*`, etc.)
-- 31 skills (research-and-vote, implement-feature, bug-fix, …)
+- 32 skills (research-and-vote, implement-feature, bug-fix, …)
 - 12 agent mirrors (security, architecture, code, research, testing experts)
 - 2 governance hooks (fitness-gate, secret-scan)
 
@@ -41,7 +41,7 @@ After install, confirm the 42 MCP tools are reachable:
 /mcp
 ```
 
-You should see `nexus-agents` listed with tools like `orchestrate`, `consensus_vote`, `run_pipeline`. The 31 skills appear in `/skills`, and the 12 agents in `/agents`.
+You should see `nexus-agents` listed with tools like `orchestrate`, `consensus_vote`, `run_pipeline`. The 32 skills appear in `/skills`, and the 12 agents in `/agents`.
 
 ## What gets installed
 

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -283,6 +283,25 @@ skills:
       - bottleneck
       - core web vitals
       - regression
+  - name: pre-push-parity
+    description: |-
+      Run the CI gates locally before pushing, so failures surface in seconds
+      instead of one CI cycle at a time. Enumerates the checks in
+      .github/workflows/, runs the locally-runnable subset in CI's order, and
+      pins the local-vs-CI delta as a memory the first time you work in a repo.
+      Use before `git push` / opening a PR, or when CI just failed on something
+      your local gate missed.
+      Triggers on "pre-push", "before push", "ci parity", "will ci pass",
+      "local gate", "prepush", "pre-push check".
+    path: skills/pre-push-parity/SKILL.md
+    triggers:
+      - pre-push
+      - before push
+      - ci parity
+      - will ci pass
+      - local gate
+      - prepush
+      - pre-push check
   - name: release
     description: |-
       Execute a release following project standards.

--- a/skills/pre-push-parity/SKILL.md
+++ b/skills/pre-push-parity/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: pre-push-parity
+description: |
+  Run the CI gates locally before pushing, so failures surface in seconds
+  instead of one CI cycle at a time. Enumerates the checks in
+  .github/workflows/, runs the locally-runnable subset in CI's order, and
+  pins the local-vs-CI delta as a memory the first time you work in a repo.
+  Use before `git push` / opening a PR, or when CI just failed on something
+  your local gate missed.
+  Triggers on "pre-push", "before push", "ci parity", "will ci pass",
+  "local gate", "prepush", "pre-push check".
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# Pre-Push Parity Skill
+
+<!--
+  CANONICAL SOURCES:
+  - .github/workflows/ci.yml (the gate list this mirrors)
+  - Motivating incident: #3073 (agents rediscover CI-only checks one failure at a time)
+-->
+
+## Why
+
+CI runs a **strict superset** of any local quality gate. When the local gate
+(`pnpm test`, a `make verify`, etc.) is green but CI is red, the agent burns a
+full ~3-minute cycle per discovery — push, wait, parse logs, fix, push — for a
+check it could have run locally in seconds. On a multi-PR session that's hours.
+The fix is to run the superset locally **before** `git push`.
+
+Real failures that motivated this (#3073): `ruff format --check` (local gate
+only ran `ruff check`) and a `gitleaks` false-positive on a `*-Key-N` test
+fixture — neither was in the local gate, both cost CI cycles.
+
+## Principle
+
+> Whatever CI can fail you on, run it locally first. For the checks you _can't_
+> run locally (SaaS / GitHub-native), know they exist and that they're the
+> residual risk — don't be surprised by them.
+
+## Step 1 — Enumerate the repo's CI checks (do this first time in a repo)
+
+```bash
+# Job names + the commands each step runs:
+grep -rEn 'name:|run:' .github/workflows/*.yml | grep -iv 'uses:'
+```
+
+Compare that list to your local gate. Anything CI runs that you don't is a
+parity gap. **Write a memory** pinning the delta so the next session starts
+informed (don't rediscover it):
+
+> `ci-vs-local-gate-<repo>` — CI runs these checks the local gate doesn't: X, Y, Z.
+> Run them via `<commands>` before push. Z (CodeQL/Scorecard/Socket) can't run
+> locally — residual risk.
+
+## Step 2 — Run the locally-runnable gates (nexus-agents)
+
+In CI's order, fastest-feedback-first. Stop at the first failure, fix, restart.
+
+| CI gate                    | Local command                                                   |
+| -------------------------- | --------------------------------------------------------------- |
+| Type Check                 | `pnpm typecheck`                                                |
+| Lint                       | `pnpm lint`                                                     |
+| Test                       | `pnpm test` (CI uses `pnpm test:coverage`)                      |
+| Build                      | `pnpm build`                                                    |
+| Changeset Presence         | `npx tsx scripts/check-changeset.ts origin/main`                |
+| Producer/Consumer (#3024)  | `npx tsx scripts/check-new-unused-exports.ts origin/main`       |
+| Model String Drift         | `pnpm check:model-drift`                                        |
+| Commit Messages            | `npx commitlint --from origin/main --to HEAD`                   |
+| Working-tree clean (#2872) | `git status --porcelain` (must be empty)                        |
+| Secret scan                | `gitleaks detect --no-banner` (runs in the pre-commit hook too) |
+
+One-shot (mirrors CI, fails fast):
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test && pnpm build \
+  && npx tsx scripts/check-changeset.ts origin/main \
+  && npx tsx scripts/check-new-unused-exports.ts origin/main \
+  && pnpm check:model-drift \
+  && npx commitlint --from origin/main --to HEAD \
+  && test -z "$(git status --porcelain)" && echo "PARITY OK"
+```
+
+> The pre-commit hook already runs `gitleaks` + lint-staged `eslint --fix` +
+> `prettier`, so a successful commit covers formatting/secrets. This skill adds
+> the gates the hook does **not** cover (typecheck, full test, build, changeset,
+> unused-exports, model-drift, commitlint, clean-tree).
+
+## Step 3 — Checks you can NOT run locally (residual risk)
+
+These are GitHub-native or third-party SaaS — note them, don't be surprised:
+
+- **CodeQL** (`codeql.yml`), **OpenSSF Scorecard** (`scorecard.yml`),
+  **Semgrep** (`semgrep.yml`), **Socket Security** — security scanners.
+- **Consolidation E2E** (`docker compose ...`) — needs Docker; run it locally
+  only if you touched the data-dir / consolidation path.
+- **Link Check**, **Documentation Gate / DocOps Skill Sync** — run
+  `pnpm link-check` and `pnpm governance:check` if you touched docs/skills.
+
+## Step 4 — gitleaks fixture hygiene
+
+The `generic-api-key` rule false-positives on test fixtures containing the
+literal word `key` with entropy (e.g. `Idempotency-Key-1`). When the test
+doesn't need the literal word, use a neutral fixture (`dash-shaped-value-7`).
+If a real fixture must trip it, add a scoped `.gitleaksignore` entry — never a
+blanket disable.
+
+## Done when
+
+- The Step-2 one-shot prints `PARITY OK`, **or** every failure it surfaced is
+  fixed and re-run green.
+- For a first-time repo: a `ci-vs-local-gate-*` memory records the delta.
+- You've consciously accepted the Step-3 residual (can't-run-locally) checks.


### PR DESCRIPTION
## What

Closes #3073. Adds a `pre-push-parity` skill so agents stop rediscovering CI-only checks one ~3-minute cycle at a time. CI is a strict superset of any local quality gate; the skill runs that superset locally **before** `git push`.

Motivating incident (#3073, from a cf-knowledge-kiln session): three PRs failed CI on `ruff format --check` and a `gitleaks` false-positive — neither was in the local gate, each cost CI cycles.

## The skill

1. **Enumerate** the repo's CI checks from `.github/workflows/` (`grep` one-liner).
2. **Run** the locally-runnable subset in CI's order via a fail-fast one-shot: `typecheck → lint → test → build → changeset-presence → producer/consumer (#3024) → model-drift → commitlint → clean-tree → gitleaks`.
3. **Name** the checks that *can't* run locally (CodeQL, Scorecard, Semgrep, Socket, docker consolidation) as residual risk.
4. **Pin** a `ci-vs-local-gate-*` memory the first time in a repo, so the delta isn't rediscovered.
5. Includes the gitleaks test-fixture hygiene tip (`*-Key-N` → neutral fixture).

## Housekeeping

- Regenerated `skills/index.yaml` + governance docs (CLAUDE.md/AGENTS.md/marketplace) → **32 skills**.
- Fixed two hand-maintained count lines (`docs/README.md`, `PLUGIN_INSTALL.md` frontmatter), including a pre-existing `11 → 12 expert types` drift in the docs index.

## Verification

`governance:check` exit 0 · markdownlint 0 errors (skill + changed docs) · gitleaks clean · commitlint pass (1 non-blocking footer warning). No TS source touched.