### PR TITLE
feat(skills): codify blind pre-merge-review pass in reviewing-code (#3074)

### DIFF
--- a/.changeset/3074-pre-merge-review.md
+++ b/.changeset/3074-pre-merge-review.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**feat(skills):** codify the blind pre-merge-review pass in `reviewing-code` (#3074).
+
+Adds a "Pre-merge blind-reviewer pass" section to the existing `reviewing-code` skill (extended, not a new skill — per a 3/3 `consensus_vote` on anti-sprawl): after local gates are green and before merging, spawn a fresh `code-reviewer`/`Explore` subagent on the diff, blind to the author's reasoning, returning BLOCKER/WARN/NIT findings that map onto the skill's existing Critical/Important/Suggestion categories. The pattern caught a real merge-blocking bug on 6 of 22 PRs (27%) in a prior autonomous session.
+
+The section references the existing five-axis framework + 4-point Verification Gate (no restatement) and primes the reviewer on bug-shape _classes_ (accessibility/semantics drift, test brittleness, double-emitted output, layout/state clobbering, contract drift) rather than a frozen list, to avoid overfitting. Discoverability added via "pre-merge review" / "blind reviewer" / "before merge" trigger keywords. #3074 proposals #2 (ship-velocity signal) and #3 (failure-mode memory pre-loading) remain tracked in that issue.

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -343,8 +343,10 @@ skills:
     description: |-
       Review code changes following project standards and security guidelines.
       Checks for lint compliance, type safety, test coverage, and security issues.
-      Use when reviewing PRs, auditing code, or checking implementation quality.
-      Triggers on "review code", "code review", "check this", "audit", "PR review".
+      Use when reviewing PRs, auditing code, checking implementation quality, or
+      running a blind pre-merge review pass before merging your own change.
+      Triggers on "review code", "code review", "check this", "audit", "PR review",
+      "pre-merge review", "blind reviewer", "before merge".
     path: skills/reviewing-code/SKILL.md
     triggers:
       - review code
@@ -352,6 +354,9 @@ skills:
       - check this
       - audit
       - pr review
+      - pre-merge review
+      - blind reviewer
+      - before merge
       - reviewing prs
   - name: security-advisory-response
     description: >-

--- a/skills/reviewing-code/SKILL.md
+++ b/skills/reviewing-code/SKILL.md
@@ -3,8 +3,10 @@ name: reviewing-code
 description: |
   Review code changes following project standards and security guidelines.
   Checks for lint compliance, type safety, test coverage, and security issues.
-  Use when reviewing PRs, auditing code, or checking implementation quality.
-  Triggers on "review code", "code review", "check this", "audit", "PR review".
+  Use when reviewing PRs, auditing code, checking implementation quality, or
+  running a blind pre-merge review pass before merging your own change.
+  Triggers on "review code", "code review", "check this", "audit", "PR review",
+  "pre-merge review", "blind reviewer", "before merge".
 allowed-tools: Read, Grep, Glob, Bash, LSP
 ---
 
@@ -80,6 +82,51 @@ pnpm lint && pnpm typecheck && pnpm test
 pnpm test:coverage
 ```
 
+## Pre-merge blind-reviewer pass
+
+For any non-trivial PR, run **one blind review by a fresh subagent** after the
+local gates are green and **before** you merge — including when merging your
+own change. "Blind" = the reviewer gets the diff and the repo, **not** your
+reasoning for writing it; that's what catches the bugs your own mental model is
+blind to. In a 22-PR autonomous session this caught a real, merge-blocking bug
+on **6 of 22 PRs (27%)** that green gates plus author self-review had missed
+(#3074).
+
+**Trigger:** `pnpm lint && pnpm typecheck && pnpm test` green → before `gh pr merge`.
+
+**Mechanism:**
+
+1. Spawn a `code-reviewer` (or `Explore`) subagent scoped to the diff
+   (`git diff --stat <base>` for the file list, then the changed files in full).
+   Give it the intended **contract**, not your implementation rationale.
+2. Have it apply the five-axis framework and the 4-point Verification Gate below
+   (blind ≠ sloppy — it does not get to skip the gate), returning findings
+   tagged **BLOCKER / WARN / NIT**, each with a `file:line` and the observable
+   failure. Bound its output (≤ ~400 words) so it triages rather than dumps.
+3. Map its tags onto this skill's existing categories: **BLOCKER → Critical**
+   (do not merge), **WARN → Important** (fix or file a tracked follow-up before
+   merge), **NIT → Suggestion** (optional).
+4. Confirmed BLOCKERs gate the merge. Fix, re-run gates, re-review the fix.
+
+**Bug-shape classes to prime the reviewer on** — shapes, not a frozen list; the
+specific instance varies by stack. Prime with the class, let the reviewer find
+the instance (a checklist of last session's bugs overfits and misses the next):
+
+- **Accessibility / semantics drift** — label/role/name regression, contrast, or
+  assistive-tech breakage introduced by a component swap.
+- **Test brittleness** — tests coupled to incidental ordering, time, or
+  window-slice boundaries that pass now and flake later.
+- **Redundant / double-emitted output** — the same signal announced twice (logs,
+  UI, telemetry) after a refactor.
+- **Layout / state clobbering** — a change that silently overwrites a sibling's
+  position, style, or state.
+- **Contract drift** — a public surface (API, schema, CLI flag, return shape)
+  changed without its callers/tests updated.
+
+> This pass is the _same rubric_ as the rest of this skill, run by fresh eyes at
+> the merge boundary — not a second taxonomy. Every finding it returns still
+> passes the Verification Gate before it blocks anything.
+
 ## Verification Gate — MANDATORY for every finding
 
 > A 2026-04-25 audit (#2225) found a 100% false-positive rate in
@@ -139,7 +186,7 @@ If you tag everything Critical, nothing is Critical. Three or more Critical find
 
 - [ ] Issue at `file:line`
 
-### Major (Should Fix)
+### Important (Should Fix)
 
 - [ ] Issue
 


### PR DESCRIPTION
## What

Implements #3074 proposal #1 — codifies the **blind pre-merge-review** pattern (caught a real merge-blocking bug on 6/22 PRs = 27% in a prior autonomous session).

**Decision:** *extended* the existing `reviewing-code` skill rather than creating a new `pre-merge-review` skill — `consensus_vote` (quick panel: architect/security/scope_steward) **3/3 approve** on anti-sprawl grounds (a pre-merge gate is the same review *rubric* at a different trigger, not a new concern; `self-critique` stays separate because it's author-side pre-emit).

## Changes

- New **"Pre-merge blind-reviewer pass"** section in `skills/reviewing-code/SKILL.md`: trigger (gates green → before merge), mechanism (spawn a blind `code-reviewer`/`Explore` subagent on the diff, bounded output, blind to author rationale), BLOCKER/WARN/NIT → Critical/Important/Suggestion mapping.
- Honors the vote's conditions: **references** the existing five-axis framework + Verification Gate (no restatement, DRY) and primes on bug-shape **classes** (a11y/semantics drift, test brittleness, double-emitted output, layout/state clobbering, contract drift) — not a frozen list.
- Added pre-merge trigger keywords; regenerated `skills/index.yaml` (still 32 skills).
- Fixed a pre-existing template inconsistency ("Major" → "Important" to match the defined categories).

## Verification (dogfooded)

Ran the **new skill on its own change** — a blind `code-reviewer` subagent returned **APPROVE**, all checks pass (DRY, command accuracy, category mapping, index freshness, classes-not-list). `governance:check` exit 0 · markdownlint 0 errors.

Refs #3074 (proposals #2 ship-velocity + #3 memory-preload remain tracked there).