### PR TITLE
docs(guides): parallel-agent worktree isolation guide + reference hooks (#3060)

### DIFF
--- a/.changeset/3060-worktree-isolation.md
+++ b/.changeset/3060-worktree-isolation.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**docs(guides):** parallel-agent git-worktree isolation guide + reference hooks (#3060).
+
+Adds `docs/guides/PARALLEL_AGENT_WORKTREES.md` documenting how to run multiple Claude Code `general-purpose` agents in parallel against one checkout without git/build/test contention, via `isolation: "worktree"` + custom `WorktreeCreate`/`WorktreeRemove` hooks. Captures the **empirical hook stdin contract** (which is undocumented upstream: the hook receives `session_id`/`cwd`/`name` and must mint the worktree path + base branch itself — it does NOT receive `worktree_path`/`base_branch`/`worktree_name`) and the multi-worktree gotchas (Playwright `reuseExistingServer`, `NODE_ENV` bundle-size skew, inherited test artifacts).
+
+Ships dry-run-verified reference hooks `scripts/hooks/worktree-create.sh` + `worktree-remove.sh` (bash/git/jq; detached worktrees under `/tmp/claude-worktrees/<session>-<agent>/`, session-prefix teardown, opportunistic age sweep scoped to the worktree root). Indexed in `docs/README.md`. #3060's per-agent-cleanup + random-preview-port suggestions remain tracked there.

--- a/docs/README.md
+++ b/docs/README.md
@@ -155,17 +155,18 @@ Detailed technical documentation:
 
 #### Guides
 
-| Document                                                          | Description                                                        |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [MCP_INTEGRATION.md](./guides/MCP_INTEGRATION.md)                 | MCP server configuration                                           |
-| [WORKFLOW_TEMPLATES.md](./guides/WORKFLOW_TEMPLATES.md)           | Creating YAML workflows                                            |
-| [CUSTOM_ENDPOINT_SETUP.md](./guides/CUSTOM_ENDPOINT_SETUP.md)     | Custom OpenAI-compatible gateway (direct SDK + OpenCode paths)     |
-| [CLOUD_PROVIDERS.md](./guides/CLOUD_PROVIDERS.md)                 | Bedrock/Vertex/Azure via OpenRouter / LiteLLM / custom-gateway     |
-| [PR_REVIEW_LOCAL.md](./guides/PR_REVIEW_LOCAL.md)                 | Run pr_review on your machine using subscription CLI auth          |
-| [HARNESS_COMPATIBILITY.md](./guides/HARNESS_COMPATIBILITY.md)     | Wire nexus-agents from OpenCode/Codex/Cursor/Aider/Cline           |
-| [RULE_PRECEDENCE.md](./guides/RULE_PRECEDENCE.md)                 | Per-adapter rule-loading precedence (Claude/Codex/Gemini/OpenCode) |
-| [DEBUGGING_OBSERVABILITY.md](./guides/DEBUGGING_OBSERVABILITY.md) | Debug logging, tracing                                             |
-| [Claude Code Observability](./guides/claude-code-observability/)  | Hooks, status line, MCP logging for Claude Code                    |
+| Document                                                            | Description                                                                                                  |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [MCP_INTEGRATION.md](./guides/MCP_INTEGRATION.md)                   | MCP server configuration                                                                                     |
+| [WORKFLOW_TEMPLATES.md](./guides/WORKFLOW_TEMPLATES.md)             | Creating YAML workflows                                                                                      |
+| [CUSTOM_ENDPOINT_SETUP.md](./guides/CUSTOM_ENDPOINT_SETUP.md)       | Custom OpenAI-compatible gateway (direct SDK + OpenCode paths)                                               |
+| [CLOUD_PROVIDERS.md](./guides/CLOUD_PROVIDERS.md)                   | Bedrock/Vertex/Azure via OpenRouter / LiteLLM / custom-gateway                                               |
+| [PR_REVIEW_LOCAL.md](./guides/PR_REVIEW_LOCAL.md)                   | Run pr_review on your machine using subscription CLI auth                                                    |
+| [HARNESS_COMPATIBILITY.md](./guides/HARNESS_COMPATIBILITY.md)       | Wire nexus-agents from OpenCode/Codex/Cursor/Aider/Cline                                                     |
+| [RULE_PRECEDENCE.md](./guides/RULE_PRECEDENCE.md)                   | Per-adapter rule-loading precedence (Claude/Codex/Gemini/OpenCode)                                           |
+| [DEBUGGING_OBSERVABILITY.md](./guides/DEBUGGING_OBSERVABILITY.md)   | Debug logging, tracing                                                                                       |
+| [Claude Code Observability](./guides/claude-code-observability/)    | Hooks, status line, MCP logging for Claude Code                                                              |
+| [PARALLEL_AGENT_WORKTREES.md](./guides/PARALLEL_AGENT_WORKTREES.md) | Safe parallel agents via `isolation: "worktree"` + the empirical WorktreeCreate/WorktreeRemove hook contract |
 
 #### Reference
 

--- a/docs/guides/PARALLEL_AGENT_WORKTREES.md
+++ b/docs/guides/PARALLEL_AGENT_WORKTREES.md
@@ -1,0 +1,188 @@
+---
+title: 'Parallel-Agent Git-Worktree Isolation'
+description: Run multiple Claude Code general-purpose Agent invocations in parallel against one checkout without git/build/test contention, using isolation "worktree" plus custom WorktreeCreate/WorktreeRemove hooks.
+tier: 2
+keywords:
+  [
+    parallel-agents,
+    worktree,
+    git-worktree,
+    isolation,
+    WorktreeCreate,
+    WorktreeRemove,
+    hooks,
+    claude-code,
+    contention,
+    subagent-coordination,
+  ]
+---
+
+# Parallel-Agent Git-Worktree Isolation
+
+How to safely run multiple Claude Code `general-purpose` Agent invocations in parallel against a single git checkout. The mechanism is the Agent tool's `isolation: "worktree"` parameter backed by custom `WorktreeCreate` / `WorktreeRemove` hooks. This guide documents the empirical hook contract — which is not documented elsewhere — and the build/test gotchas that surface once agents stop sharing one working directory.
+
+## When to use this
+
+Use worktree isolation when **two or more agents will run concurrently and any of them touches git state, `node_modules`, `dist/`, or a test server**. Concretely:
+
+- A wave of `general-purpose` agents each implementing a different child issue.
+- One agent building/testing while another edits unrelated files.
+- Any fan-out where agents independently run `git checkout`/`switch`, `npm ci`, `pnpm build`, or Playwright.
+
+Skip it when agents are strictly read-only (use `Explore`), or when you serialize the work so only one agent mutates the tree at a time. Isolation has a cost: each worktree is a full checkout, and cross-worktree coordination (who merges, in what order) becomes your problem instead of git's.
+
+## The contention problem
+
+Without worktrees, parallel agents share one `cwd` and one `.git`. They collide on every stateful operation. From a real multi-day session (issue #3060), this was the single highest coordination cost — lost work was recovered from `reflog` twice before isolation was adopted.
+
+| Shared operation                   | Failure mode when run concurrently                                                                                                  |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `git checkout` / `git switch`      | One agent's branch switch overwrites another agent's _uncommitted_ working-tree edits. Silent data loss; only `reflog` recovers it. |
+| `git stash`                        | Stashes pile up across agents; pop order is ambiguous and an agent pops another's stash.                                            |
+| `npm ci` / `npm install`           | Concurrent writes to `node_modules/` interleave and corrupt the tree; later commands fail with missing/half-written modules.        |
+| Playwright (`reuseExistingServer`) | A second agent silently reuses the _first_ agent's preview server and tests the wrong bundle. Green run, wrong code.                |
+| `pnpm build` / `dist/` output      | Concurrent builds interleave file writes in `dist/`; the resulting bundle is a mix of two agents' source.                           |
+
+The common thread: these operations assume a single writer. Parallel agents violate that assumption, and the failures are mostly _silent_ — the wrong thing succeeds rather than erroring.
+
+## The fix: `isolation: "worktree"`
+
+The Agent tool accepts an `isolation` parameter. Setting it to `"worktree"` gives each agent its own `git worktree` — a separate working directory backed by the same object store, with its own branch, index, and untracked files. Two agents in two worktrees cannot clobber each other's working tree, and each can build, install, and switch branches independently.
+
+```text
+Agent(subagent_type="general-purpose", isolation="worktree", prompt="implement #3061")
+Agent(subagent_type="general-purpose", isolation="worktree", prompt="implement #3062")
+```
+
+### Why you need custom hooks
+
+`isolation: "worktree"` fails out of the box with:
+
+```text
+Cannot create agent worktree: not in a git repository and no WorktreeCreate hooks are configured
+```
+
+This error fires **even when `cwd` is a git repository.** The harness's built-in repo detection checks a parent path that does not match a per-repo or nested checkout, so it concludes "not a git repo" and refuses. Configuring custom `WorktreeCreate` / `WorktreeRemove` hooks in `~/.claude/settings.json` bypasses that detection entirely: when the hooks exist, the harness delegates worktree lifecycle to them and skips its own check.
+
+### The empirical hook contract
+
+This is the load-bearing part of the guide, because it is not documented upstream. The contract below was established by logging every hook invocation and inspecting stdin.
+
+**On `WorktreeCreate`, Claude Code passes this JSON on stdin:**
+
+```json
+{
+  "session_id": "abc123...",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/home/you/git/your-repo",
+  "hook_event_name": "WorktreeCreate",
+  "name": "general-purpose-<agent-identifier>"
+}
+```
+
+It does **not** pass `worktree_path`, `base_branch`, or `worktree_name`. This is the common misconception — hooks that read those fields get `undefined` and silently misbehave. **The hook must mint the path and resolve the base branch itself.**
+
+**The hook returns the worktree's absolute path on stdout and exits 0.** That path is what the agent runs in. Any nonzero exit, or empty stdout, aborts the agent.
+
+**`WorktreeRemove` fires on _session exit_, not per-agent.** There is no per-agent teardown signal. A single session that spawned ten agents fires `WorktreeRemove` once, at the end. This is why cleanup has to be opportunistic (see below) rather than relying on a remove event per worktree.
+
+### What the `WorktreeCreate` hook must do
+
+1. **Resolve the repo.** Walk up from `cwd` looking for `.git` (file or directory). That directory is the repo root to add a worktree to — do not trust the harness's notion of the repo.
+2. **Mint a unique path** namespaced by _both_ session and agent, so two agents in the same session and the same agent across sessions never collide:
+   `/tmp/claude-worktrees/<session_id[:8]>-<agent_name last 12 chars>/`
+3. **Resolve the base branch** with `git symbolic-ref --short HEAD`, falling back to the raw `HEAD` SHA if detached.
+4. **Create the worktree detached:** `git worktree add --detach <path> <base>`. Detached so the agent is free to create its own branch without colliding with the checked-out branch (git refuses to check out a branch already checked out in another worktree).
+5. **Opportunistic cleanup** — prune temp worktrees older than ~6h. Because `WorktreeRemove` only fires at session exit, stale worktrees from crashed or killed sessions accumulate; clean them on the way in. The sweep is scoped to the worktree root only, so it never touches your repo's real worktrees.
+6. **Log every invocation** (stdin payload + minted path + exit). The contract is undocumented; logging is how you confirm it has not changed under you.
+
+### What the `WorktreeRemove` hook must do
+
+Remove the worktree(s) for the exiting session: `git worktree remove --force <path>` then prune. Because it fires once per session rather than per agent, removing by session prefix (`<session_id[:8]>-*`) is the reliable approach. Keep the same opportunistic age-based sweep here too.
+
+## Hook scripts
+
+Reference implementations live in this repo (deps: `bash`, `git`, `jq`):
+
+- [`scripts/hooks/worktree-create.sh`](../../scripts/hooks/worktree-create.sh)
+- [`scripts/hooks/worktree-remove.sh`](../../scripts/hooks/worktree-remove.sh)
+
+They implement the contract above and are dry-run verified: the create hook mints a detached worktree under `/tmp/claude-worktrees/<session>-<agent>/` whose object store points back to the main `.git` (so no disk bloat), prints the absolute path on stdout, and is idempotent on retry; the remove hook tears down by session prefix plus the age sweep. Tunables via env: `CLAUDE_WORKTREE_ROOT`, `CLAUDE_WORKTREE_LOG`, `CLAUDE_WORKTREE_MAX_AGE_MIN`.
+
+> **Safety:** point `CLAUDE_WORKTREE_ROOT` at a _dedicated_ directory (the default `/tmp/claude-worktrees` is one). The opportunistic age sweep deletes stale entries under that root — but only ones that are actually git worktrees (it checks for a `.git` file), so a misconfigured root pointing at a shared/populated directory still won't delete unrelated data.
+
+Wire them in `~/.claude/settings.json` (use **absolute** paths — hooks do not resolve repo-relative):
+
+```json
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/abs/path/to/nexus-agents/scripts/hooks/worktree-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/abs/path/to/nexus-agents/scripts/hooks/worktree-remove.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The exact `settings.json` hook envelope is defined by your Claude Code version — confirm against its hooks documentation if the event name or shape differs. The invariant is the command's I/O: read the JSON payload on stdin, print the worktree's absolute path on stdout, exit 0. After wiring, `Agent(..., isolation: "worktree")` succeeds and each agent runs in its own worktree. Verify quickly:
+
+```bash
+echo '{"session_id":"t","cwd":"'"$PWD"'","hook_event_name":"WorktreeCreate","name":"probe"}' \
+  | scripts/hooks/worktree-create.sh   # prints a /tmp/claude-worktrees/... path
+```
+
+## Gotchas
+
+These surface specifically because each agent now has its own checkout. They do not appear in the single-cwd setup.
+
+### Playwright `reuseExistingServer` reuses the wrong server
+
+```ts
+reuseExistingServer: !process.env.CI;
+```
+
+This is dangerous in a multi-worktree setup. Each worktree starts its preview server on the same default port, sees a server already listening (the first worktree's), and **reuses it** — so the agent tests the first worktree's bundle, not its own. Green run, wrong code.
+
+_Fix:_ assign a unique port per worktree (derive it from the worktree path or a counter) and do not reuse across worktrees. If you must keep `reuseExistingServer`, gate it on a per-worktree port so "existing" means "this worktree's own server".
+
+### `NODE_ENV=development` inflates local bundle-size numbers
+
+A worktree that builds with `NODE_ENV=development` skips minification. Bundle-size figures measured locally will be much larger than CI's, which builds with `NODE_ENV=production`. Do not compare local dev bundle sizes against CI thresholds — build production-mode locally before trusting the number.
+
+### Inherited test artifacts confuse the linter
+
+`git worktree add` produces a clean tracked tree, but agents generate `playwright-report/` and `test-results/` during runs, and these can be picked up by ESLint in a fresh worktree and produce spurious lint errors.
+
+_Fix:_ `rm -rf playwright-report test-results` before linting in each worktree.
+
+## Relevance to nexus-agents
+
+nexus-agents orchestrates multi-agent work by design — waves of `general-purpose` agents, consensus voting across 7 voter roles, cross-CLI delegation (`.rules/subagent-coordination.md`). Every one of those flows can put multiple agents against one checkout, which means it inherits exactly the contention failures in the table above: branch-switch clobbering, `node_modules` corruption, wrong-bundle test passes.
+
+Worktree isolation is the structural fix, and the hook contract documented here is what makes `isolation: "worktree"` usable. Two open improvements remain:
+
+- **Per-agent cleanup.** `WorktreeRemove` firing only at session exit means a long autonomous run accumulates worktrees for its whole lifetime. A per-agent teardown signal (or a tighter opportunistic age threshold) would bound disk use.
+- **Random preview ports.** The Playwright `reuseExistingServer` hazard is best removed by allocating a random free port per worktree rather than relying on a derived-port convention that can still collide.
+
+Both are tracked as follow-up work in #3060; neither blocks using the hooks today.
+
+## See also
+
+- [CONTEXT_LOAD_BALANCING.md](../architecture/CONTEXT_LOAD_BALANCING.md) — cross-CLI agent routing.
+- `.rules/subagent-coordination.md` — wave execution, scope bounding, output budgets.

--- a/scripts/hooks/worktree-create.sh
+++ b/scripts/hooks/worktree-create.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# WorktreeCreate hook for Claude Code Agent `isolation: "worktree"` (#3060).
+#
+# Reads the hook payload on stdin, mints an isolated git worktree for the
+# agent, and prints the worktree's ABSOLUTE PATH on stdout (exit 0). Any
+# nonzero exit or empty stdout aborts the agent.
+#
+# Wire it in ~/.claude/settings.json — see
+# docs/guides/PARALLEL_AGENT_WORKTREES.md for the contract + wiring.
+#
+# Deps: bash, git, jq.
+set -euo pipefail
+
+ROOT="${CLAUDE_WORKTREE_ROOT:-/tmp/claude-worktrees}"
+LOG="${CLAUDE_WORKTREE_LOG:-$ROOT/hook.log}"
+MAX_AGE_MIN="${CLAUDE_WORKTREE_MAX_AGE_MIN:-360}" # opportunistic prune > 6h
+mkdir -p "$ROOT"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG" 2>/dev/null || true; }
+
+payload="$(cat)"
+log "WorktreeCreate stdin: $payload"
+
+jqget() { printf '%s' "$payload" | jq -r "$1 // empty" 2>/dev/null || true; }
+cwd="$(jqget '.cwd')"
+session="$(jqget '.session_id')"
+name="$(jqget '.name')"
+[ -n "$cwd" ] || cwd="$PWD"
+[ -n "$session" ] || session="nosession"
+[ -n "$name" ] || name="agent"
+
+# 1. Resolve the repo root: walk up from cwd for a .git, then fall back to
+#    git's own discovery. Do NOT trust the harness's repo detection.
+repo="$cwd"
+while [ "$repo" != "/" ] && [ ! -e "$repo/.git" ]; do repo="$(dirname "$repo")"; done
+if [ ! -e "$repo/.git" ]; then
+  repo="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo '')"
+fi
+if [ -z "$repo" ] || [ ! -e "$repo/.git" ]; then
+  log "ERROR: no git repo resolved from cwd=$cwd"
+  echo "not a git repository" >&2
+  exit 1
+fi
+
+# 5. Opportunistic cleanup BEFORE creating ours: prune temp worktrees older
+#    than MAX_AGE_MIN (WorktreeRemove only fires at session exit, so crashed
+#    sessions leak worktrees).
+while IFS= read -r old; do
+  [ -n "$old" ] || continue
+  # SAFETY: only ever delete actual git worktrees (a linked worktree has a
+  # `.git` *file*, not a dir). This bounds the destructive sweep even if
+  # CLAUDE_WORKTREE_ROOT is misconfigured to a populated/shared directory.
+  [ -f "$old/.git" ] || { log "skip non-worktree dir in root: $old"; continue; }
+  git -C "$repo" worktree remove --force "$old" 2>/dev/null || rm -rf "$old" 2>/dev/null || true
+  log "pruned stale worktree: $old"
+done < <(find "$ROOT" -maxdepth 1 -mindepth 1 -type d -mmin "+$MAX_AGE_MIN" 2>/dev/null || true)
+git -C "$repo" worktree prune 2>/dev/null || true
+
+# 2. Mint a path namespaced by BOTH session and agent so concurrent agents
+#    (and the same agent across sessions) never collide.
+sess8="$(printf '%s' "$session" | cut -c1-8)"
+name12="$(printf '%s' "$name" | tr -c 'A-Za-z0-9_.-' '-' | tail -c 12)"
+wt="$ROOT/${sess8}-${name12}"
+
+# 3. Resolve the base ref (branch name, else detached HEAD SHA).
+base="$(git -C "$repo" symbolic-ref --short HEAD 2>/dev/null || git -C "$repo" rev-parse HEAD 2>/dev/null || echo '')"
+if [ -z "$base" ]; then
+  log "ERROR: could not resolve base ref in $repo"
+  echo "no base ref" >&2
+  exit 1
+fi
+
+# 4. Create the worktree detached (so the agent can make its own branch; git
+#    refuses to check out a branch already checked out elsewhere). Reuse if
+#    the path already exists (idempotent on retry).
+if [ -d "$wt" ]; then
+  log "reusing existing worktree: $wt"
+elif git -C "$repo" worktree add --detach "$wt" "$base" >>"$LOG" 2>&1; then
+  log "created worktree: $wt @ $base"
+else
+  log "ERROR: worktree add failed for $wt @ $base"
+  echo "worktree add failed" >&2
+  exit 1
+fi
+
+# Output contract: absolute path on stdout, exit 0.
+echo "$wt"

--- a/scripts/hooks/worktree-remove.sh
+++ b/scripts/hooks/worktree-remove.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# WorktreeRemove hook for Claude Code Agent `isolation: "worktree"` (#3060).
+#
+# IMPORTANT: this fires on SESSION exit, NOT per-agent. A session that spawned
+# N agents fires this once. So remove by session prefix and keep the same
+# opportunistic age sweep the create hook does.
+#
+# Wire it in ~/.claude/settings.json — see
+# docs/guides/PARALLEL_AGENT_WORKTREES.md.
+#
+# Deps: bash, git, jq.
+set -euo pipefail
+
+ROOT="${CLAUDE_WORKTREE_ROOT:-/tmp/claude-worktrees}"
+LOG="${CLAUDE_WORKTREE_LOG:-$ROOT/hook.log}"
+MAX_AGE_MIN="${CLAUDE_WORKTREE_MAX_AGE_MIN:-360}"
+mkdir -p "$ROOT"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG" 2>/dev/null || true; }
+
+payload="$(cat)"
+log "WorktreeRemove stdin: $payload"
+
+jqget() { printf '%s' "$payload" | jq -r "$1 // empty" 2>/dev/null || true; }
+cwd="$(jqget '.cwd')"
+session="$(jqget '.session_id')"
+[ -n "$cwd" ] || cwd="$PWD"
+
+repo="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo '')"
+
+remove_one() {
+  local wt="$1"
+  [ -d "$wt" ] || return 0
+  if [ -n "$repo" ]; then
+    git -C "$repo" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt" 2>/dev/null || true
+  else
+    rm -rf "$wt" 2>/dev/null || true
+  fi
+  log "removed worktree: $wt"
+}
+
+# Remove this session's worktrees (prefix match on the 8-char session id).
+sess8="$(printf '%s' "$session" | cut -c1-8)"
+if [ -n "$sess8" ]; then
+  for wt in "$ROOT/${sess8}-"*; do
+    [ -e "$wt" ] && remove_one "$wt"
+  done
+fi
+
+# Opportunistic age sweep (crashed sessions leak worktrees). SAFETY: only
+# touch actual git worktrees (`.git` *file*), so a misconfigured
+# CLAUDE_WORKTREE_ROOT pointing at a populated dir can't cause data loss.
+while IFS= read -r old; do
+  [ -n "$old" ] && [ -f "$old/.git" ] && remove_one "$old"
+done < <(find "$ROOT" -maxdepth 1 -mindepth 1 -type d -mmin "+$MAX_AGE_MIN" 2>/dev/null || true)
+
+[ -n "$repo" ] && git -C "$repo" worktree prune 2>/dev/null || true
+exit 0


### PR DESCRIPTION
## What

Closes the documentation core of #3060. Adds `docs/guides/PARALLEL_AGENT_WORKTREES.md` + two reference Claude Code hook scripts so multiple `general-purpose` agents can run in parallel against one checkout without git/build/test contention.

## Why

Without isolation, parallel agents sharing one `cwd`/`.git` clobber each other: branch-switch wipes uncommitted edits, `node_modules` corruption, Playwright `reuseExistingServer` testing the wrong bundle. `isolation: "worktree"` fixes it but needs `WorktreeCreate`/`WorktreeRemove` hooks — and the hook stdin contract is **undocumented upstream**.

## Delivers

- **Guide**: the empirical hook contract (hook gets `session_id`/`cwd`/`name`, must mint the worktree path + base branch itself — does **not** receive `worktree_path`/`base_branch`/`worktree_name`), settings.json wiring (hedged for version-dependent schema), and the multi-worktree gotchas.
- **Reference hooks** `scripts/hooks/worktree-create.sh` + `worktree-remove.sh` (bash/git/jq): detached worktrees under `/tmp/claude-worktrees/<session>-<agent>/`, shared object store, session-prefix teardown, opportunistic age sweep.
- Indexed in `docs/README.md`.

## Verification

- Scripts **dry-run verified** end-to-end (create mints a detached worktree whose `git-common-dir` points back to main `.git`; remove tears it down; list clean) and **shellcheck-clean**; markdownlint 0 errors.
- **Blind pre-merge review** (dogfooding the new reviewing-code pass): APPROVE, no BLOCKER. Addressed its one WARN — hardened the age sweep to only delete dirs that are *actually git worktrees* (`.git` file present), so a misconfigured `CLAUDE_WORKTREE_ROOT` can't cause data loss; added a matching safety note.

Refs #3060 (per-agent-cleanup + random-preview-port suggestions remain tracked there).