### PR TITLE
fix(adapters): stream() errors on no-adapter instead of silent-empty (#3105)

### DIFF
--- a/.changeset/3105-resilient-stream-error.md
+++ b/.changeset/3105-resilient-stream-error.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(adapters):** `ResilientAdapter.stream()` errors instead of silently yielding empty when no adapter is available (#3105).
+
+`stream()` did a bare `return` when adapter detection produced nothing, emitting a clean empty stream — while the sibling `complete()` returns `err(ModelError('No model adapter available'))` for the same condition. The `streamWithFallback` consumer only falls back on a thrown error, so a silent-empty stream masked "no adapter available" as a legitimately-empty completion. `stream()` now throws `ModelError` to match `complete()`'s contract. (`countTokens()` returning `0` is left as-is: no error channel, and a 0 estimate is benign.)
+
+Found via a proactive security/QA audit.

--- a/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
@@ -323,13 +323,19 @@ describe('ResilientAdapter', () => {
   });
 
   describe('stream() when adapter unavailable', () => {
-    it('yields nothing when no adapter detected', async () => {
+    it('throws instead of silently yielding nothing — matches complete() error semantics', async () => {
+      // #3105: a bare `return` made an unavailable adapter look like a clean
+      // empty stream, so streamWithFallback could not tell failure from a
+      // legitimately-empty completion. stream() now errors like complete().
       vi.mocked(createAutoAdapter).mockRejectedValueOnce(new Error('No CLIs'));
-      const chunks: unknown[] = [];
-      for await (const chunk of adapter.stream({ messages: [] })) {
-        chunks.push(chunk);
-      }
-      expect(chunks).toEqual([]);
+      const drain = (async () => {
+        const chunks: unknown[] = [];
+        for await (const chunk of adapter.stream({ messages: [] })) {
+          chunks.push(chunk);
+        }
+        return chunks;
+      })();
+      await expect(drain).rejects.toThrow('No model adapter available');
     });
   });
 

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -128,7 +128,11 @@ export class ResilientAdapter implements IResilientAdapter {
   async *stream(request: CompletionRequest): AsyncIterable<StreamChunk> {
     const adapter = await this.ensureAdapter();
     if (adapter === undefined) {
-      return;
+      // #3105: error like complete() rather than yielding an empty stream — a
+      // silent-empty stream masks "no adapter available" as a clean empty
+      // completion, so streamWithFallback can't tell failure from a
+      // legitimately-empty result.
+      throw new ModelError('No model adapter available');
     }
     yield* adapter.stream(request);
   }


### PR DESCRIPTION
## What

Closes #3105 (found via a proactive security/QA audit). `ResilientAdapter.stream()` did a bare `return` when adapter detection produced nothing — emitting a **clean empty stream** — while the sibling `complete()` returns `err(ModelError('No model adapter available'))` for the same condition. `streamWithFallback` only falls back on a thrown error, so the silent-empty stream masked "no adapter available" as a legitimately-empty completion.

## Fix

`stream()` now `throw`s `ModelError('No model adapter available')` when no adapter is available, matching `complete()`'s contract. `countTokens()` is intentionally left returning `0` (it has no error channel and a 0 estimate is a benign degraded default, not a masked completion).

## Testing

Flipped the pre-existing `stream() when adapter unavailable` test — which had codified the bug by asserting `chunks` `toEqual([])` — to assert it throws. Targeted suite green (29 tests), typecheck + lint clean, full suite running.