### PR TITLE
docs(skills): add branch-safety guard to pre-push-parity (#3072)

### DIFF
--- a/.changeset/3072-branch-safety.md
+++ b/.changeset/3072-branch-safety.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**docs(skills):** add a branch-safety guard to the `pre-push-parity` skill (#3072).
+
+The harness can silently switch an agent's working branch mid-session — a long run can end up on `main` carrying another branch's uncommitted edits, risking lost work or an accidental push to `main`. The skill's pre-push one-shot now gates on `git branch --show-current` being a non-empty, non-`main`/`master` branch (`PARITY OK (<branch>)`), and a new "Branch safety" section documents the STOP-and-recover habit. This is the in-repo agent-side mitigation; the underlying harness branch-switch bug (#3072) is upstream.

--- a/skills/pre-push-parity/SKILL.md
+++ b/skills/pre-push-parity/SKILL.md
@@ -78,13 +78,30 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm build \
   && npx tsx scripts/check-new-unused-exports.ts origin/main \
   && pnpm check:model-drift \
   && npx commitlint --from origin/main --to HEAD \
-  && test -z "$(git status --porcelain)" && echo "PARITY OK"
+  && test -z "$(git status --porcelain)" \
+  && br="$(git branch --show-current)" && [ -n "$br" ] && [ "$br" != "main" ] && [ "$br" != "master" ] \
+  && echo "PARITY OK ($br)"
 ```
 
 > The pre-commit hook already runs `gitleaks` + lint-staged `eslint --fix` +
 > `prettier`, so a successful commit covers formatting/secrets. This skill adds
 > the gates the hook does **not** cover (typecheck, full test, build, changeset,
 > unused-exports, model-drift, commitlint, clean-tree).
+
+## Branch safety (before push)
+
+The harness can silently switch the working branch mid-session (#3072): a long
+run can end up on `main` carrying another branch's uncommitted edits — risking
+lost work or an accidental push to `main`. Before every push, confirm you are
+on the branch you intend (the one-shot above already gates on this):
+
+```bash
+git branch --show-current   # must be your feature branch — never empty (detached) or main/master
+```
+
+If it is `main`/`master` or empty (detached HEAD), **STOP — do not push.** Find
+your work (`git reflog`, `git stash list`), check out / re-create the intended
+feature branch, then re-run the gates before pushing.
 
 ## Step 3 — Checks you can NOT run locally (residual risk)
 


### PR DESCRIPTION
## What

Addresses the **in-repo, agent-side mitigation** for #3072 (the harness can silently switch an agent's working branch mid-session → lost edits / accidental push to `main`). The harness bug itself is upstream; this codifies the defensive habit in the `pre-push-parity` skill.

## Changes

- The pre-push one-shot now gates on `git branch --show-current` being non-empty and not `main`/`master` before printing `PARITY OK (<branch>)` — so the check can't silently push from `main` or a detached HEAD.
- New **"Branch safety"** section: STOP-and-recover habit (`git reflog` / `git stash list`, re-checkout the intended branch) when you find yourself on the wrong branch.

Verified: the guard correctly blocks when run on `main`; markdownlint 0 errors.

Refs #3072 (harness branch-switch bug remains upstream).