### PR TITLE
fix(security): redact all secret matches in tool output, not just first (#3109)

### DIFF
--- a/.changeset/3109-redact-all-secrets.md
+++ b/.changeset/3109-redact-all-secrets.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**fix(security):** redact ALL secret matches in tool output, not just the first (#3109).
+
+`sanitizeOutput` (secure-handler) used non-global `SECRET_PATTERNS` with a `pattern.test()`-then-`replace()` loop, so `String.replace` substituted only the **first** match per pattern. Tool output (or a thrown error's text) containing two or more secrets of the same shape — e.g. a rotated old+new API key, or two `Bearer` tokens in one stack trace — leaked every secret after the first to the MCP caller. Patterns are now global and the redaction replaces unconditionally (dropping the `test()` guard, which would advance a global regex's `lastIndex` and skip earlier matches). Found via a proactive security audit.

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
@@ -1222,6 +1222,21 @@ describe('SecureHandler', () => {
       expect(result.content[0]?.text).not.toContain('MyS3cretP@ss');
     });
 
+    it('redacts ALL occurrences of a repeated secret pattern, not just the first (#3109)', async () => {
+      // Two AWS-style keys in one output: the non-global regex bug redacted
+      // only the first, leaking the second to the caller.
+      const twoKeys = 'old AKIAIOSFODNN7EXAMPLE rotated to AKIA1234567890ABCDEF now';
+      const handler: ToolHandler = vi.fn(() =>
+        Promise.resolve({ content: [{ type: 'text' as const, text: twoKeys }] })
+      );
+      const secureHandler = createSecureHandler(handler, { toolName: 'multi_secret_tool' });
+      const result = await secureHandler({});
+      const text = result.content[0]?.text ?? '';
+      expect(text).not.toContain('AKIAIOSFODNN7EXAMPLE');
+      expect(text).not.toContain('AKIA1234567890ABCDEF');
+      expect(text.match(/\[REDACTED\]/g)?.length).toBe(2);
+    });
+
     it('should handle slow handler execution', async () => {
       const slowHandler: ToolHandler = vi.fn(async () => {
         await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
@@ -130,29 +130,38 @@ const MAX_INPUT_SIZE_BYTES = 10 * 1024 * 1024;
  * Patterns that indicate leaked secrets in tool output.
  * Each pattern is tested against tool response text.
  */
+// #3109: every pattern is GLOBAL so `replace` redacts ALL matches, not just
+// the first — two secrets of the same shape (e.g. a rotated old+new key) must
+// both be redacted before the result reaches the MCP caller.
 const SECRET_PATTERNS: readonly RegExp[] = [
   // API keys with common prefixes
-  /\b(sk-[a-zA-Z0-9]{20,})\b/,
-  /\b(pk-[a-zA-Z0-9]{20,})\b/,
+  /\b(sk-[a-zA-Z0-9]{20,})\b/g,
+  /\b(pk-[a-zA-Z0-9]{20,})\b/g,
   // AWS-style keys
-  /\b(AKIA[A-Z0-9]{16})\b/,
+  /\b(AKIA[A-Z0-9]{16})\b/g,
   // Bearer tokens in output
-  /Bearer\s+[a-zA-Z0-9_\-.~+/]+=*/,
+  /Bearer\s+[a-zA-Z0-9_\-.~+/]+=*/g,
   // Generic long hex secrets (40+ chars)
-  /\b[0-9a-f]{40,}\b/i,
+  /\b[0-9a-f]{40,}\b/gi,
   // password= or token= in output
-  /(?:password|token|secret|apikey|api_key)\s*[=:]\s*\S{8,}/i,
+  /(?:password|token|secret|apikey|api_key)\s*[=:]\s*\S{8,}/gi,
 ];
 
 /** Redact detected secrets from tool output text. */
 function sanitizeOutput(text: string, logger: ILogger): string {
   let sanitized = text;
   for (const pattern of SECRET_PATTERNS) {
-    if (pattern.test(sanitized)) {
+    // #3109: replace unconditionally — do NOT guard with pattern.test(), which
+    // advances a global regex's lastIndex and makes replace() skip earlier
+    // matches. `String.replace` with a global regex redacts every occurrence
+    // and resets lastIndex to 0 on completion, so the shared pattern stays
+    // safe across calls. Detect a redaction via a before/after compare.
+    const before = sanitized;
+    sanitized = sanitized.replace(pattern, '[REDACTED]');
+    if (sanitized !== before) {
       logger.warn('Potential secret detected in tool output, redacting', {
         pattern: pattern.source.slice(0, 30),
       });
-      sanitized = sanitized.replace(pattern, '[REDACTED]');
     }
   }
   return sanitized;


### PR DESCRIPTION
## What

Closes #3109 (found via a proactive security audit). `sanitizeOutput` in `secure-handler.ts` redacts secrets from every MCP tool result/error, but used **non-global** `SECRET_PATTERNS` with a `pattern.test()`-then-`replace()` loop — so `String.replace` substituted only the **first** match per pattern. Output (or a thrown error) containing two+ secrets of the same shape — a rotated old+new key, two `Bearer` tokens in one stack trace — leaked everything after the first to the caller.

## Fix

- All `SECRET_PATTERNS` are now **global** (`/g`, preserving `/i` where present).
- The loop **replaces unconditionally** and detects a redaction via a before/after compare for the warn log. The `pattern.test()` guard is removed because, with a global regex, `.test()` advances `lastIndex` and would make the subsequent `.replace()` skip earlier matches. (A global `String.replace` resets `lastIndex` to 0 on completion, so the shared module-level patterns stay safe across calls.)

## Testing

Added a test feeding two AWS-style keys in one output and asserting **both** are redacted (2× `[REDACTED]`, neither key leaks) — it fails on the old non-global code. Full secure-handler suite green (68 tests), typecheck + lint clean, full suite running.