### PR TITLE
fix(routing): constrain LinUCB selection to the candidate set (#3111)

### DIFF
--- a/.changeset/3111-linucb-candidate-constraint.md
+++ b/.changeset/3111-linucb-candidate-constraint.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**fix(routing):** constrain LinUCB selection to the candidate set — fail-closed category overrides can no longer be bypassed (#3111).
+
+`runLinUCBStage` returned whatever `LinUCBBandit.select()` picked, but `select()` ranks over **all** registered arms and ignored the already-filtered candidate list (`topsisRanking`). So a fail-closed category override (e.g. `security_review → [codex]`) or a quality filter could be silently defeated when the bandit's learned preference favored an excluded CLI — routing a security task to a CLI the policy had removed. The stage now falls back to the TOPSIS-best candidate when the bandit's pick is not in the candidate set. Learning attribution is unaffected: `recordOutcome` keys the reward update on the routed `cliName`. Found via a proactive security audit.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -548,6 +548,23 @@ describe('runLinUCBStage', () => {
     expect(result.ucbScore).toBe(0.85);
     expect(stages).toContain('linucb-selection');
   });
+
+  it('constrains the bandit pick to the candidate set — an excluded CLI is not routed (#3111)', () => {
+    const stages: string[] = [];
+    const profile = analyzeTaskProfile(mockTask, []);
+    // Candidate set narrowed to ['codex'] (e.g. a fail-closed category
+    // override), but the bandit's learned preference is 'claude' (outside it).
+    const constrained: CliName[] = ['codex'];
+    const mockBandit = {
+      select: vi.fn().mockReturnValue({ armName: 'claude', ucbScore: 0.99 }),
+    };
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableLinUCBSelection: true },
+      linucbBandit: mockBandit as unknown as StageDependencies['linucbBandit'],
+    });
+    const result = runLinUCBStage(profile, constrained, stages, deps);
+    expect(result.selectedCli).toBe('codex'); // NOT the excluded 'claude'
+  });
 });
 
 // ============================================================================
@@ -743,23 +760,25 @@ describe('runPipeline', () => {
     }
   });
 
-  it('returns error when LinUCB returns no selection from empty ranking', async () => {
+  it('falls back to a valid candidate when LinUCB picks outside the candidate set (#3111)', async () => {
     const stages: string[] = [];
     const profile = analyzeTaskProfile(mockTask, []);
+    // Only 'claude' is a candidate (e.g. after a quality/category filter), but
+    // the bandit's learned preference is 'gemini' — outside the set. The router
+    // must constrain to the candidate, not route to the excluded CLI, and must
+    // not error (a valid candidate exists).
     const cliNames: CliName[] = ['claude'];
-    // Mock a bandit that returns undefined for selectedCli
     const mockBandit = {
-      select: vi.fn().mockReturnValue({ armName: undefined, ucbScore: undefined }),
+      select: vi.fn().mockReturnValue({ armName: 'gemini', ucbScore: 0.9 }),
     };
     const deps = makeDeps({
       config: { ...makeDeps().config, enableLinUCBSelection: true },
       linucbBandit: mockBandit as unknown as StageDependencies['linucbBandit'],
     });
     const result = await runPipeline(mockTask, profile, stages, cliNames, deps);
-    // LinUCB returned undefined -> "No candidates available" error
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.message).toContain('No candidates');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.selectedCli).toBe('claude'); // constrained, NOT 'gemini'
     }
   });
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -503,7 +503,17 @@ export function runLinUCBStage(
   const banditContext = taskProfileToBanditContext(taskProfile);
   const selection = deps.linucbBandit.select(banditContext);
   stagesExecuted.push('linucb-selection');
-  return { selectedCli: selection.armName as CliName, ucbScore: selection.ucbScore };
+  const picked = selection.armName as CliName;
+  // #3111: LinUCB.select() ranks over ALL registered arms, ignoring the
+  // already-filtered candidate set. Constrain the pick to topsisRanking so a
+  // fail-closed category override (e.g. security_review → [codex]) or a
+  // quality filter can't be bypassed by a learned preference. recordOutcome
+  // keys the reward update on the *routed* cliName, so falling back to the
+  // TOPSIS-best candidate updates the arm actually used — no learning desync.
+  if (!topsisRanking.includes(picked)) {
+    return { selectedCli: topsisRanking[0], ucbScore: selection.ucbScore };
+  }
+  return { selectedCli: picked, ucbScore: selection.ucbScore };
 }
 
 /** Runs preference routing stage. */


### PR DESCRIPTION
## What

Closes #3111 (found via a proactive security audit). `runLinUCBStage` returned `LinUCBBandit.select()`'s pick, but `select()` ranks over **all** registered arms and **ignored the filtered candidate list** (`topsisRanking`). So a fail-closed category override (e.g. `security_review → [codex]`) or a quality filter could be silently bypassed when the bandit's learned reward favored an excluded CLI — routing a security task to a CLI the policy had removed.

## Fix

`runLinUCBStage` now falls back to the TOPSIS-best candidate (`topsisRanking[0]`) when the bandit's pick is not in the candidate set. Learning attribution is unaffected — `recordOutcome` (composite-router.ts:523) keys the reward update on the *routed* `decision.cliName`, so the arm actually used is the one updated.

## Testing

- New stage unit test: bandit picks an excluded CLI → result is the candidate, not the excluded pick.
- Replaced an artificial `armName: undefined` test (impossible per the `string` return type) with a realistic pipeline-level test: out-of-set pick → falls back to the valid candidate (`ok`, not an error).
- Existing `security_review`/`architecture` `CATEGORY_CHAIN_OVERRIDES` reroute tests still pass. Targeted suite green (56), typecheck + lint clean, full suite running.