### PR TITLE
fix(memory): reconcile Markdown sidecars on prune/expire (#3112)

### DIFF
--- a/.changeset/3112-memory-markdown-reconcile.md
+++ b/.changeset/3112-memory-markdown-reconcile.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**fix(memory):** reconcile Markdown sidecars on prune/expire — no more orphaned-file disk growth (#3112).
+
+Only the explicit `delete(key)` path removed a memory's `.md` sidecar; `prune`, `expireAll`, and auto-expire deleted SQLite rows but left the Markdown files behind. With `MemoryDecayManager` running prune on a timer, the markdown dir grew without bound. Added `MemoryMarkdownHelper.reconcile(liveKeys)` (forward-maps every live key to its filename and removes any `.md` not in that set) and call it from the backend's `prune`/`expireAll`, covering every row-deletion path uniformly. Best-effort, never throws. Found via a proactive audit.

--- a/packages/nexus-agents/src/context/memory-backend.ts
+++ b/packages/nexus-agents/src/context/memory-backend.ts
@@ -288,12 +288,36 @@ export class HybridMemoryBackend implements IMemoryBackend {
 
   prune(olderThan: Date): Promise<Result<number, MemoryError>> {
     this.ensureInitialized();
-    return Promise.resolve(pruneOldEntries(this.getDatabase(), olderThan, this.logger));
+    const result = pruneOldEntries(this.getDatabase(), olderThan, this.logger);
+    // #3112: prune deletes SQLite rows but not their Markdown sidecars; clean
+    // up orphaned files so the markdown dir stays bounded under decay.
+    if (result.ok && result.value > 0) this.reconcileMarkdown();
+    return Promise.resolve(result);
   }
 
   expireAll(): Promise<Result<number, MemoryError>> {
     this.ensureInitialized();
-    return Promise.resolve(expireAllEntries(this.getDatabase(), this.logger));
+    const result = expireAllEntries(this.getDatabase(), this.logger);
+    if (result.ok && result.value > 0) this.reconcileMarkdown();
+    return Promise.resolve(result);
+  }
+
+  /**
+   * Remove Markdown sidecars whose key no longer exists in SQLite (#3112).
+   * Covers every row-deletion path (prune / expire / auto-expire) uniformly,
+   * not just the explicit `delete()`. Best-effort.
+   */
+  private reconcileMarkdown(): void {
+    try {
+      const rows = this.getDatabase().prepare('SELECT key FROM memories').all() as Array<{
+        key: string;
+      }>;
+      this.markdown.reconcile(rows.map((r) => r.key));
+    } catch (error) {
+      this.logger.warn('Markdown reconcile query failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   delete(key: string): Promise<Result<boolean, MemoryError>> {

--- a/packages/nexus-agents/src/context/memory-markdown.test.ts
+++ b/packages/nexus-agents/src/context/memory-markdown.test.ts
@@ -25,6 +25,7 @@ vi.mock('node:fs', async () => {
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
     unlinkSync: vi.fn(),
+    readdirSync: vi.fn(),
     promises: {
       ...actual.promises,
       writeFile: vi.fn(),
@@ -494,6 +495,40 @@ describe('MemoryMarkdownHelper', () => {
       expect(content).not.toContain('**Tags:**');
       expect(content).not.toContain('**Expires:**');
       expect(content).toContain('simple string');
+    });
+  });
+
+  describe('reconcile (#3112)', () => {
+    it('deletes orphaned .md files, keeps live ones, ignores non-md', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'live-key.md',
+        'orphan-key.md',
+        'notes.txt',
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+
+      const removed = helper.reconcile(['live-key']);
+
+      expect(removed).toBe(1);
+      expect(fs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(fs.unlinkSync).toHaveBeenCalledWith(path.join(testDir, 'orphan-key.md'));
+      expect(fs.unlinkSync).not.toHaveBeenCalledWith(path.join(testDir, 'live-key.md'));
+    });
+
+    it('deletes nothing when every file maps to a live key', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue(['a.md', 'b.md'] as unknown as ReturnType<
+        typeof fs.readdirSync
+      >);
+
+      expect(helper.reconcile(['a', 'b'])).toBe(0);
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 without reading when the markdown dir is absent', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(helper.reconcile(['x'])).toBe(0);
+      expect(fs.readdirSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/nexus-agents/src/context/memory-markdown.ts
+++ b/packages/nexus-agents/src/context/memory-markdown.ts
@@ -71,6 +71,38 @@ export class MemoryMarkdownHelper {
   }
 
   /**
+   * Delete orphaned Markdown files whose key no longer exists in the store
+   * (#3112). Markdown is only cleaned on the explicit `delete()` path; the
+   * `prune` / `expireAll` / auto-expire paths delete SQLite rows without it,
+   * so the directory grows unbounded. Reconcile by forward-mapping every live
+   * key to its filename and removing any `.md` file not in that set (the
+   * forward map is lossy, but a collision only keeps a file a live key still
+   * needs). Best-effort — never throws. Returns the number of files removed.
+   */
+  reconcile(liveKeys: readonly string[]): number {
+    let removed = 0;
+    try {
+      if (!fs.existsSync(this.markdownDir)) return 0;
+      const expected = new Set(liveKeys.map((k) => this.keyToFilename(k)));
+      for (const file of fs.readdirSync(this.markdownDir)) {
+        if (!file.endsWith('.md') || expected.has(file)) continue;
+        try {
+          fs.unlinkSync(path.join(this.markdownDir, file));
+          removed++;
+        } catch (error) {
+          this.logger.warn('Failed to delete orphaned Markdown file', { file, error });
+        }
+      }
+      if (removed > 0) {
+        this.logger.debug('Reconciled Markdown dir', { removed, live: liveKeys.length });
+      }
+    } catch (error) {
+      this.logger.warn('Markdown reconcile failed', { error });
+    }
+    return removed;
+  }
+
+  /**
    * Convert a memory key to a safe filename.
    */
   private keyToFilename(key: string): string {


### PR DESCRIPTION
## What

Closes #3112 (found via a proactive audit). Only the explicit `delete(key)` path removed a memory's `.md` sidecar; `prune`, `expireAll`, and auto-expire deleted SQLite rows but left the Markdown files. With `MemoryDecayManager` running `prune` on a timer, the markdown directory grew **without bound** (SQLite `count()` → 0 while the dir kept N files).

## Fix

- New `MemoryMarkdownHelper.reconcile(liveKeys)` — forward-maps every live key to its filename and removes any `.md` file not in that set (the lossy forward map is safe: a collision only keeps a file a live key still needs). Best-effort, never throws.
- `MemoryBackend.prune` / `expireAll` now call a private `reconcileMarkdown()` (which reads `SELECT key FROM memories`) after a deletion — covering **every** row-deletion path uniformly (prune, expire, auto-expire-on-read), not just `delete()`.

## Testing

3 unit tests: orphan `.md` removed + live kept + non-`.md` ignored; all-live → no-op; dir-absent → no-op without reading. 29 markdown tests green, typecheck + lint clean, full suite running.