### PR TITLE
fix(adapters): version check uses execFile, not shell exec (#3116)

### DIFF
--- a/.changeset/3116-base-adapter-execfile.md
+++ b/.changeset/3116-base-adapter-execfile.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+**security(adapters):** version check uses `execFile` instead of shell `exec` (#3116).
+
+`base-adapter.ts` fetched the CLI version via `promisify(exec)` (a shell) with `` `${this.name} --version` ``. `this.name` is a compile-time `CliName` literal, so this was not exploitable — but it was the one shell call escaping the adapters' no-shell invariant (`injection-prevention.test.ts`). Switched to `execFile(this.name, ['--version'])` (no shell, argv array), removing the latent injection foot-gun and completing the invariant. Surfaced by a proactive CLI-adapter security audit.

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -9,7 +9,7 @@
  * (Source: cli-project_plan.md v2.1.0)
  */
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import semver from 'semver';
 import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
@@ -41,7 +41,10 @@ import { getTimeoutForTaskAuto } from './cli-timeout-profiles.js';
 import { CapacityTracker, createCapacityTracker } from './capacity-tracker.js';
 import { executeCliRetryLoop } from './cli-retry-loop.js';
 
-const execAsync = promisify(exec);
+// #3116: execFile (no shell) — `this.name` is a compile-time CliName literal
+// today, but using execFile keeps the adapters' no-shell invariant complete
+// and removes the latent injection foot-gun if `name` ever becomes dynamic.
+const execFileAsync = promisify(execFile);
 
 /**
  * Fallback capacity (in tokens) when capacity tracker is uninitialized.
@@ -245,7 +248,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
     }
 
     try {
-      const { stdout } = await execAsync(`${this.name} --version`, {
+      const { stdout } = await execFileAsync(this.name, ['--version'], {
         timeout: CLI_SUBPROCESS_TIMEOUTS.spawnMs,
       });
 


### PR DESCRIPTION
## What

Closes #3116. `base-adapter.ts` fetched the CLI version via `promisify(exec)` — a **shell** — with `` `${this.name} --version` ``. `this.name` is a compile-time `CliName` literal (not caller-controlled), so this was **not exploitable**, but it was the one shell call escaping the adapters' no-shell invariant (`injection-prevention.test.ts`).

## Fix

`execFile(this.name, ['--version'], { timeout })` — no shell, argv array. Removes the latent injection foot-gun (a future change making `name` dynamic would otherwise become command-injectable) and completes the no-shell invariant. Behavioral equivalent — same stdout parsing.

Surfaced by a proactive CLI-adapter security audit (reported as a latent note, not a live vuln). typecheck + lint clean, 38 base-adapter tests green, full suite running.