### PR TITLE
fix(security): issue-triage reputation uses real account age (#3121, epic #3118 Phase 3)

### DIFF
--- a/.changeset/3121-real-account-age.md
+++ b/.changeset/3121-real-account-age.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+**fix(security):** issue-triage reputation uses the author's real account age (#3121, Phase 3 of epic #3118).
+
+`estimateAccountAge()` was a stub that ignored its argument and always returned `365` — so every author looked like an established account and the `new_account` reputation signal **never fired**, leaving Phase 0's gating unable to act on account age (the same dead-signal class Phase 1 fixed in the firewall).
+
+`fetchIssueData` now fetches the author's real account creation date via the existing `provider.fetchUserMetadata()` and derives `accountAgeDays`, threaded into `assessAuthorReputation`. Best-effort: on fetch failure or an unparseable date the value is **omitted**, so the engine **skips** the `new_account` signal (per #3106's optional fields) — never fabricated, and triage never blocks on the lookup. The `estimateAccountAge`/`DEFAULT_ACCOUNT_AGE_DAYS` stub is deleted. Tests: `new_account` fires for a recent account, not for an established one, and is omitted on fetch failure.

--- a/packages/nexus-agents/src/dogfooding/issue-triage.test.ts
+++ b/packages/nexus-agents/src/dogfooding/issue-triage.test.ts
@@ -11,12 +11,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ok, err } from '../core/index.js';
 import { ScmError } from '../scm/types.js';
-import type { ScmIssueDetail, ScmCommentDetail } from '../scm/types.js';
+import type { ScmIssueDetail, ScmCommentDetail, ScmUserMetadata } from '../scm/types.js';
 
 // Mock SCM provider traits
 const mockGetIssueDetail = vi.fn();
 const mockListCommentDetails = vi.fn();
+const mockFetchUserMetadata = vi.fn();
 const mockCreateFullGitHubProvider = vi.fn();
+
+/** Builds ScmUserMetadata; defaults to an established (old) account. */
+function userMeta(overrides: Partial<ScmUserMetadata> = {}): ScmUserMetadata {
+  return {
+    login: 'testuser',
+    name: null,
+    company: null,
+    followers: 0,
+    following: 0,
+    publicRepos: 0,
+    createdAt: '2020-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
 
 vi.mock('../scm/github-provider-traits.js', () => ({
   createFullGitHubProvider: (...args: unknown[]): unknown => mockCreateFullGitHubProvider(...args),
@@ -76,10 +91,11 @@ describe('IssueTriage', () => {
       repo: 'owner/repo',
       getIssueDetail: mockGetIssueDetail,
       listCommentDetails: mockListCommentDetails,
-      fetchUserMetadata: vi.fn(),
+      fetchUserMetadata: mockFetchUserMetadata,
     });
     mockGetIssueDetail.mockResolvedValue(ok(createMockIssueDetail()));
     mockListCommentDetails.mockResolvedValue(ok(createMockCommentDetails()));
+    mockFetchUserMetadata.mockResolvedValue(ok(userMeta())); // established account by default
   });
 
   afterEach(() => {
@@ -154,6 +170,44 @@ describe('IssueTriage', () => {
           .map((a) => a.type);
         expect(withRep).toEqual(without); // identical: reputation changed nothing for T1
       }
+    });
+  });
+
+  describe('account-age reputation via real fetch (#3121)', () => {
+    const URL = 'https://github.com/owner/repo/issues/42';
+
+    async function signals(): Promise<readonly string[]> {
+      const result = await new IssueTriage({ enableReputation: true }).triageIssue(URL);
+      if (!result.ok) throw result.error;
+      return result.value.trustAssessment.suspiciousSignals;
+    }
+
+    it('fires new_account when the fetched account is recent', async () => {
+      mockGetIssueDetail.mockResolvedValue(
+        ok(createMockIssueDetail({ author: 'newbie', authorAssociation: 'NONE' }))
+      );
+      const recent = new Date(Date.now() - 5 * 86_400_000).toISOString();
+      mockFetchUserMetadata.mockResolvedValue(ok(userMeta({ login: 'newbie', createdAt: recent })));
+      expect(await signals()).toContain('new_account');
+    });
+
+    it('does not fire new_account for an established account', async () => {
+      mockGetIssueDetail.mockResolvedValue(
+        ok(createMockIssueDetail({ author: 'veteran', authorAssociation: 'NONE' }))
+      );
+      mockFetchUserMetadata.mockResolvedValue(
+        ok(userMeta({ login: 'veteran', createdAt: '2015-01-01T00:00:00Z' }))
+      );
+      expect(await signals()).not.toContain('new_account');
+    });
+
+    it('omits new_account (no fabrication) when the user-metadata fetch fails', async () => {
+      mockGetIssueDetail.mockResolvedValue(
+        ok(createMockIssueDetail({ author: 'ghost', authorAssociation: 'NONE' }))
+      );
+      mockFetchUserMetadata.mockResolvedValue(err(new ScmError('gh api unavailable', 'github')));
+      // Triage still completes; account-age signal is simply skipped.
+      expect(await signals()).not.toContain('new_account');
     });
   });
 

--- a/packages/nexus-agents/src/dogfooding/issue-triage.ts
+++ b/packages/nexus-agents/src/dogfooding/issue-triage.ts
@@ -34,6 +34,7 @@ import type { ReputationAssessment, GitHubUserMetadata } from '../security/reput
 import type { AgentAction, SourceCitation } from '../security/action-schema.js';
 import { parseIssueUrl } from '../scm/url-parsers.js';
 import { createFullGitHubProvider } from '../scm/github-provider-traits.js';
+import type { ScmUserMetadata } from '../scm/types.js';
 import { categorizeIssue, extractLabelsFromBody } from './issue-triage-helpers.js';
 import type {
   IssueMetadata,
@@ -88,7 +89,7 @@ export class IssueTriage {
     const fetchResult = await this.fetchIssueData(owner, repo, issueNumber);
     if (!fetchResult.ok) return fetchResult;
 
-    const { issue: issueResult, comments } = fetchResult.value;
+    const { issue: issueResult, comments, accountAgeDays } = fetchResult.value;
 
     // Sanitize untrusted content (Issue #828 — input-sanitizer wiring)
     const safeTitle = this.sanitizeContent(issueResult.title, issueResult.author);
@@ -96,7 +97,7 @@ export class IssueTriage {
 
     // Classify trust + assess reputation (Issue #828 — new wiring)
     const trustResult = this.classifyAuthor(issueResult);
-    const reputation = this.assessAuthorReputation(issueResult, comments);
+    const reputation = this.assessAuthorReputation(issueResult, comments, accountAgeDays);
 
     // Generate and validate actions
     const actions = this.generateActions(safeTitle, safeBody, issueResult, trustResult);
@@ -156,15 +157,20 @@ export class IssueTriage {
    */
   private assessAuthorReputation(
     issue: IssueMetadata,
-    comments: readonly IssueComment[]
+    comments: readonly IssueComment[],
+    accountAgeDays: number | undefined
   ): ReputationAssessment | undefined {
     if (!this.config.enableReputation) return undefined;
 
     const sanitizeResult = sanitizeInput(issue.body, 'unknown', issue.author);
 
+    // #3121: accountAgeDays is the author's REAL account age (fetched in
+    // fetchIssueData) or undefined when the lookup failed. When undefined it is
+    // OMITTED so the engine skips the new_account signal (#3106) — never
+    // fabricated. priorContributions/recentCommentCount use real comment data.
     const metadata: GitHubUserMetadata = {
       username: issue.author,
-      accountAgeDays: estimateAccountAge(issue.createdAt),
+      ...(accountAgeDays !== undefined ? { accountAgeDays } : {}),
       priorContributions: countAuthorComments(issue.author, comments),
       recentCommentCount: countRecentComments(issue.author, comments),
       recentCommentWindowMinutes: 10,
@@ -319,7 +325,9 @@ export class IssueTriage {
     owner: string,
     repo: string,
     issueNumber: number
-  ): Promise<Result<{ issue: IssueMetadata; comments: IssueComment[] }, Error>> {
+  ): Promise<
+    Result<{ issue: IssueMetadata; comments: IssueComment[]; accountAgeDays?: number }, Error>
+  > {
     const provider = createFullGitHubProvider(`${owner}/${repo}`);
 
     const detailResult = await provider.getIssueDetail(issueNumber);
@@ -351,29 +359,43 @@ export class IssueTriage {
         }))
       : [];
 
-    return ok({ issue, comments });
+    // #3121: fetch the author's REAL account age (their account creation date,
+    // not the issue date). Best-effort — on failure or an unparseable date we
+    // omit it, so the reputation engine SKIPS the new_account signal (#3106)
+    // rather than fabricating a value. Reputation must not block on this.
+    const accountAgeDays = await this.fetchAccountAgeDays(provider, detail.author);
+
+    return ok(
+      accountAgeDays !== undefined ? { issue, comments, accountAgeDays } : { issue, comments }
+    );
+  }
+
+  /**
+   * Best-effort lookup of a GitHub user's account age in days. Returns
+   * `undefined` if the user-metadata fetch fails or the creation date can't be
+   * parsed (#3121) — callers must treat absence as "unknown", not "benign".
+   */
+  private async fetchAccountAgeDays(
+    provider: { fetchUserMetadata: (u: string) => Promise<Result<ScmUserMetadata, Error>> },
+    username: string
+  ): Promise<number | undefined> {
+    try {
+      const result = await provider.fetchUserMetadata(username);
+      if (!result.ok) return undefined;
+      const createdMs = Date.parse(result.value.createdAt);
+      if (!Number.isFinite(createdMs)) return undefined;
+      return Math.floor((getTimeProvider().now() - createdMs) / 86_400_000);
+    } catch {
+      // Truly best-effort: even an unexpected rejection (token resolution,
+      // transport) must not break triage — fall back to "unknown" age.
+      return undefined;
+    }
   }
 }
 
 // ============================================================================
 // Private Helpers
 // ============================================================================
-
-/**
- * Returns a safe default account age when the actual user creation date
- * is unavailable. The triage pipeline only has issue.createdAt (the date
- * the issue was filed), NOT the user's account creation date. Using the
- * issue date would make recently filed issues appear to come from new
- * accounts, incorrectly triggering the new_account signal.
- *
- * Default: 365 days — assumes an established account unless the GitHub
- * user profile is fetched to provide the real value.
- */
-const DEFAULT_ACCOUNT_AGE_DAYS = 365;
-
-function estimateAccountAge(_createdAt: string): number {
-  return DEFAULT_ACCOUNT_AGE_DAYS;
-}
 
 /** Counts how many comments the author has made on the issue. */
 function countAuthorComments(author: string, comments: readonly IssueComment[]): number {


### PR DESCRIPTION
## What

**Phase 3 of epic #3118.** Closes #3121. `estimateAccountAge()` was a **stub that ignored its argument and always returned `365`** — so every author looked like an established account and the `new_account` reputation signal **never fired**, leaving Phase 0's gating unable to act on account age (the same dead-signal class Phase 1 fixed in the firewall).

## Fix

`fetchIssueData` now fetches the author's **real account creation date** via the existing `provider.fetchUserMetadata()` → `created_at` → `accountAgeDays`, threaded into `assessAuthorReputation` (`GitHubUserMetadata.accountAgeDays`, optional per #3106). **Best-effort**: on fetch failure, an unparseable date, *or an unexpected rejection* (wrapped in `try/catch`), `accountAgeDays` is `undefined` → **omitted** → the engine **skips** `new_account` (no fabrication), and triage never blocks. The `estimateAccountAge`/`DEFAULT_ACCOUNT_AGE_DAYS` stub is deleted.

## Testing

3 new tests: `new_account` fires for a recent account (real-clock, 5 days ago), not for an established one (2015), and is omitted on fetch failure. Existing tests unaffected (default mock = established account). typecheck · lint · 28 issue-triage tests green. Blind `code-reviewer`: **APPROVE** (applied its one WARN — added the `try/catch` so best-effort is airtight).

## Known follow-up (not blocking)

`fetchUserMetadata` adds one `gh api users/<login>` call per triage. Acceptable at current (per-issue) volume; a user-metadata TTL cache is a small future optimization if triage volume grows.

Refs #3118.