### PR TITLE
fix(security): pr-reviewer reputation uses real account age (#3133)

### DIFF
--- a/.changeset/3133-pr-account-age.md
+++ b/.changeset/3133-pr-account-age.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): pr-reviewer reputation uses real account age (#3133)
+
+`pr-reviewer` now fetches the PR author's real account age (via the provider's `fetchUserMetadata` → `createdAt`) and feeds it into the reputation assessment, so the `new_account` signal actually fires in the PR-review path — the Phase-3 equivalent of #3121 for `issue_triage`. Best-effort: on fetch failure, an unparseable date, or an unexpected rejection, `accountAgeDays` is omitted (never fabricated) and the review never blocks. The review result's `trustAssessment` now also surfaces `suspiciousSignals` (parity with `issue_triage`). The reputation-gating orchestration was consolidated into `pr-reviewer-helpers` (`gatePRAuthor`, `assessPRReputation`, `fetchAccountAgeDays`). Closes #3133.

--- a/packages/nexus-agents/src/cli/review-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-command.test.ts
@@ -52,6 +52,7 @@ describe('review-command', () => {
       trustTier: '3',
       userRole: 'unknown',
       isAllowlisted: false,
+      suspiciousSignals: [],
       isSuspicious: false,
     },
     findingsBySeverity: {

--- a/packages/nexus-agents/src/cli/review-demo-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-demo-command.test.ts
@@ -116,6 +116,7 @@ function makeReviewResult(overrides: Partial<PRReviewResult> = {}) {
       trustTier: '3',
       userRole: 'unknown',
       isAllowlisted: false,
+      suspiciousSignals: [],
       isSuspicious: false,
     },
     ...overrides,

--- a/packages/nexus-agents/src/dogfooding/pr-review-types.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-review-types.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import type { FullCapableProvider } from '../scm/types.js';
 
 /**
  * Pull request file change information.
@@ -149,6 +150,8 @@ export interface PRTrustAssessment {
   readonly isAllowlisted: boolean;
   /** Reputation score (0-100) when reputation is enabled. */
   readonly reputationScore?: number | undefined;
+  /** Suspicious signals detected (e.g. `new_account`, `injection_patterns_detected`). */
+  readonly suspiciousSignals: readonly string[];
   /** Whether the author is flagged as suspicious. */
   readonly isSuspicious: boolean;
   /** Tier the policy gate ACTUALLY enforced (== trustTier under audit/off). */
@@ -157,6 +160,16 @@ export interface PRTrustAssessment {
   readonly reputationReconciledTier?: string | undefined;
   /** Reputation-gating rollout mode applied: `off` | `audit` | `enforce`. */
   readonly gatingMode?: string | undefined;
+}
+
+/**
+ * Result of fetching PR data plus best-effort author signals (#3133).
+ */
+export interface PRFetchData {
+  readonly metadata: PRMetadata;
+  readonly provider: FullCapableProvider;
+  /** Author's real account age in days, when the lookup succeeded (#3133). */
+  readonly accountAgeDays?: number;
 }
 
 export interface PRReviewResult {

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
@@ -772,6 +772,7 @@ function createMockPRReviewResult(overrides: Partial<PRReviewResult> = {}): PRRe
       trustTier: '3',
       userRole: 'unknown',
       isAllowlisted: false,
+      suspiciousSignals: [],
       isSuspicious: false,
     },
     ...overrides,

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
@@ -8,6 +8,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import type { Result } from '../core/index.js';
+import { getTimeProvider, createLogger } from '../core/index.js';
+import type { ScmUserMetadata } from '../scm/types.js';
 import type {
   PRMetadata,
   PRReviewResult,
@@ -25,7 +28,11 @@ import {
   DECISION_EMOJI,
 } from './pr-review-types.js';
 import { sanitizeInput } from '../security/input-sanitizer.js';
-import { assessReputation } from '../security/reputation-model.js';
+import {
+  assessReputation,
+  gateWithReputation,
+  resolveReputationGatingMode,
+} from '../security/reputation-model.js';
 import type {
   ReputationCache,
   ReputationGateDecision,
@@ -34,21 +41,46 @@ import type {
 } from '../security/reputation-model.js';
 import type { ClassifyResult } from '../security/trust-classifier.js';
 
+const repLogger = createLogger({ component: 'PRReviewer.reputation' });
+
 // =============================================================================
 // Reputation Gating Helpers (#3123, epic #3118 Phase 5)
 // =============================================================================
 
 /**
+ * Best-effort account-age lookup for a PR author (#3133, Phase-3 equivalent for
+ * the PR path). Returns the author's real account age in days via the provider's
+ * `fetchUserMetadata`, or `undefined` on any failure (err Result, unparseable
+ * `createdAt`, or an unexpected rejection) — never fabricated, never throws, so
+ * the review is never blocked by this lookup.
+ */
+export async function fetchAccountAgeDays(
+  provider: { fetchUserMetadata: (u: string) => Promise<Result<ScmUserMetadata, Error>> },
+  username: string
+): Promise<number | undefined> {
+  try {
+    const result = await provider.fetchUserMetadata(username);
+    if (!result.ok) return undefined;
+    const createdMs = Date.parse(result.value.createdAt);
+    if (!Number.isFinite(createdMs)) return undefined;
+    return Math.floor((getTimeProvider().now() - createdMs) / 86_400_000);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Assesses the PR author's reputation from the signals available in the PR
- * event: author association + injection flags from the (sanitized) PR body.
- * Account-age / contribution signals are NOT fetched here yet — OMITTED, never
- * fabricated, so the engine skips those signals. Returns undefined when
- * reputation is disabled.
+ * event: author association + injection flags from the (sanitized) PR body, plus
+ * the author's real account age when it was fetched (#3133). `accountAgeDays` is
+ * OMITTED when the lookup failed — never fabricated, so the engine skips the
+ * `new_account` signal. Returns undefined when reputation is disabled.
  */
 export function assessPRReputation(
   pr: PRMetadata,
   cache: ReputationCache,
-  enableReputation: boolean
+  enableReputation: boolean,
+  accountAgeDays: number | undefined
 ): ReputationAssessment | undefined {
   if (!enableReputation) return undefined;
   // Only `injectionFlags` is consumed here, and injection detection is
@@ -57,6 +89,7 @@ export function assessPRReputation(
   const sanitizeResult = sanitizeInput(pr.body, 'unknown', pr.author);
   const metadata: GitHubUserMetadata = {
     username: pr.author,
+    ...(accountAgeDays !== undefined ? { accountAgeDays } : {}),
     authorAssociation: pr.authorAssociation,
     injectionFlags: sanitizeResult.injectionFlags,
   };
@@ -76,10 +109,44 @@ export function buildPRTrustAssessment(
     userRole: trustResult.userRole,
     isAllowlisted: trustResult.isAllowlisted,
     reputationScore: reputation?.reputationScore,
+    suspiciousSignals: isTier1 ? [] : (reputation?.suspiciousSignals ?? []),
     isSuspicious: isTier1 ? false : (reputation?.isSuspicious ?? false),
     enforcedTrustTier: gateDecision.enforcedTier,
     reputationReconciledTier: gateDecision.reconciledTier,
     gatingMode: gateDecision.mode,
+  };
+}
+
+/**
+ * Assesses the PR author's reputation and applies the gating rollout mode
+ * (#3123). Returns the gate decision (for the policy gate) and the assessment
+ * surfaced on the result. A suppressed demotion (audit/off) is logged.
+ */
+export function gatePRAuthor(
+  pr: PRMetadata,
+  trustResult: ClassifyResult,
+  accountAgeDays: number | undefined,
+  cache: ReputationCache,
+  enableReputation: boolean
+): { gateDecision: ReputationGateDecision; trustAssessment: PRTrustAssessment } {
+  const reputation = assessPRReputation(pr, cache, enableReputation, accountAgeDays);
+  const gateDecision = gateWithReputation(
+    trustResult.trustTier,
+    reputation,
+    resolveReputationGatingMode()
+  );
+  if (gateDecision.demotionSuppressed) {
+    repLogger.warn('Reputation demotion suppressed by gating mode (would block under enforce)', {
+      prNumber: pr.number,
+      author: pr.author,
+      mode: gateDecision.mode,
+      classifierTier: trustResult.trustTier,
+      reconciledTier: gateDecision.reconciledTier,
+    });
+  }
+  return {
+    gateDecision,
+    trustAssessment: buildPRTrustAssessment(trustResult, reputation, gateDecision),
   };
 }
 

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ok, err } from '../core/index.js';
 import { ScmError } from '../scm/types.js';
-import type { ScmPullRequestDetail } from '../scm/types.js';
+import type { ScmPullRequestDetail, ScmUserMetadata } from '../scm/types.js';
 import { parsePRUrl } from '../scm/url-parsers.js';
 import type { PRReviewResult } from './pr-review-types.js';
 
@@ -19,6 +19,21 @@ import type { PRReviewResult } from './pr-review-types.js';
 const mockGetPullRequestDetail = vi.fn();
 const mockCreateReview = vi.fn();
 const mockCreateFullGitHubProvider = vi.fn();
+const mockFetchUserMetadata = vi.fn();
+
+/** Builds a mock SCM user metadata record (default: established 2015 account). */
+function userMeta(overrides: Partial<ScmUserMetadata> = {}): ScmUserMetadata {
+  return {
+    login: 'testuser',
+    name: null,
+    company: null,
+    followers: 0,
+    following: 0,
+    publicRepos: 0,
+    createdAt: '2015-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
 
 vi.mock('../scm/github-provider-traits.js', () => ({
   createFullGitHubProvider: (...args: unknown[]): unknown => mockCreateFullGitHubProvider(...args),
@@ -97,10 +112,11 @@ describe('PRReviewer', () => {
       createReview: mockCreateReview,
       getIssueDetail: vi.fn(),
       listCommentDetails: vi.fn(),
-      fetchUserMetadata: vi.fn(),
+      fetchUserMetadata: mockFetchUserMetadata,
     });
     mockGetPullRequestDetail.mockResolvedValue(ok(createMockPRDetail()));
     mockCreateReview.mockResolvedValue(ok(undefined));
+    mockFetchUserMetadata.mockResolvedValue(ok(userMeta())); // established account by default
   });
 
   afterEach(() => {
@@ -185,6 +201,45 @@ describe('PRReviewer', () => {
       expect(v.trustAssessment.reputationScore).toBeUndefined();
       // With reputation off, the gate falls back to the classifier tier.
       expect(v.trustAssessment.enforcedTrustTier).toBe(v.trustAssessment.trustTier);
+    });
+  });
+
+  describe('account-age reputation via real fetch (#3133)', () => {
+    const URL = 'https://github.com/owner/repo/pull/123';
+
+    async function signals(): Promise<readonly string[]> {
+      const { PRReviewer } = await import('./pr-reviewer.js');
+      const r = await new PRReviewer({ dryRun: true, enableReputation: true }).reviewPR(URL);
+      if (!r.ok) throw r.error;
+      return r.value.trustAssessment.suspiciousSignals;
+    }
+
+    it('fires new_account when the fetched author account is recent', async () => {
+      const recent = new Date(Date.now() - 5 * 86_400_000).toISOString();
+      mockGetPullRequestDetail.mockResolvedValue(
+        ok({ ...createMockPRDetail(), author: 'newbie', authorAssociation: 'NONE', body: 'hi' })
+      );
+      mockFetchUserMetadata.mockResolvedValue(ok(userMeta({ login: 'newbie', createdAt: recent })));
+      expect(await signals()).toContain('new_account');
+    });
+
+    it('does not fire new_account for an established account', async () => {
+      mockGetPullRequestDetail.mockResolvedValue(
+        ok({ ...createMockPRDetail(), author: 'veteran', authorAssociation: 'NONE', body: 'hi' })
+      );
+      mockFetchUserMetadata.mockResolvedValue(
+        ok(userMeta({ login: 'veteran', createdAt: '2015-01-01T00:00:00Z' }))
+      );
+      expect(await signals()).not.toContain('new_account');
+    });
+
+    it('omits new_account (no fabrication) when the user-metadata fetch fails', async () => {
+      mockGetPullRequestDetail.mockResolvedValue(
+        ok({ ...createMockPRDetail(), author: 'ghost', authorAssociation: 'NONE', body: 'hi' })
+      );
+      mockFetchUserMetadata.mockResolvedValue(err(new ScmError('gh api unavailable', 'github')));
+      // Review still completes; the account-age signal is simply skipped.
+      expect(await signals()).not.toContain('new_account');
     });
   });
 

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
@@ -14,11 +14,7 @@ import { classifyTrust } from '../security/trust-classifier.js';
 import type { ClassifyResult } from '../security/trust-classifier.js';
 import { evaluatePolicy } from '../security/policy-gate.js';
 import type { ActionContext } from '../security/policy-gate.js';
-import {
-  ReputationCache,
-  gateWithReputation,
-  resolveReputationGatingMode,
-} from '../security/reputation-model.js';
+import { ReputationCache } from '../security/reputation-model.js';
 import type { ReputationGateDecision } from '../security/reputation-model.js';
 import { createSecurityExpert } from '../agents/experts/security-expert.js';
 import { createCodeExpert } from '../agents/experts/code-expert.js';
@@ -29,6 +25,7 @@ import type {
   PRReviewConfig,
   PRReviewResult,
   PRTrustAssessment,
+  PRFetchData,
   ExpertReviewResult,
   ReviewCategory,
 } from './pr-review-types.js';
@@ -47,8 +44,8 @@ import {
   sumFindings,
   generateSummary,
   createFailedReview,
-  assessPRReputation,
-  buildPRTrustAssessment,
+  gatePRAuthor,
+  fetchAccountAgeDays,
 } from './pr-reviewer-helpers.js';
 
 // Re-export for convenience
@@ -89,7 +86,7 @@ export class PRReviewer {
     const fetchResult = await this.fetchPRData(owner, repo, prNumber);
     if (!fetchResult.ok) return fetchResult;
 
-    const { metadata: prMetadata, provider } = fetchResult.value;
+    const { metadata: prMetadata, provider, accountAgeDays } = fetchResult.value;
 
     // Classify PR author trust tier (Issue #828 — defense-in-depth)
     const trustResult = this.classifyPRAuthor(prMetadata);
@@ -104,7 +101,13 @@ export class PRReviewer {
     // #3123: assess reputation and apply the gating rollout mode (off/audit/
     // enforce), mirroring issue_triage — closes the PR-path equivalent of the
     // #828/#3106 dead-end (reputation was classified but never gated here).
-    const { gateDecision, trustAssessment } = this.gatePRAuthor(prMetadata, trustResult);
+    const { gateDecision, trustAssessment } = gatePRAuthor(
+      prMetadata,
+      trustResult,
+      accountAgeDays,
+      this.reputationCache,
+      this.config.enableReputation
+    );
 
     const expertReviews = await this.runExpertReviews(prMetadata, traceId);
     const result = this.aggregateReviews(prMetadata, expertReviews, startTime, trustAssessment);
@@ -222,36 +225,6 @@ export class PRReviewer {
       username: pr.author,
       authorAssociation: pr.authorAssociation,
     });
-  }
-
-  /**
-   * Assesses the PR author's reputation and applies the gating rollout mode
-   * (#3123). Returns the gate decision (for the policy gate) and the assessment
-   * surfaced on the result. A suppressed demotion (audit/off) is logged.
-   */
-  private gatePRAuthor(
-    pr: PRMetadata,
-    trustResult: ClassifyResult
-  ): { gateDecision: ReputationGateDecision; trustAssessment: PRTrustAssessment } {
-    const reputation = assessPRReputation(pr, this.reputationCache, this.config.enableReputation);
-    const gateDecision = gateWithReputation(
-      trustResult.trustTier,
-      reputation,
-      resolveReputationGatingMode()
-    );
-    if (gateDecision.demotionSuppressed) {
-      logger.warn('Reputation demotion suppressed by gating mode (would block under enforce)', {
-        prNumber: pr.number,
-        author: pr.author,
-        mode: gateDecision.mode,
-        classifierTier: trustResult.trustTier,
-        reconciledTier: gateDecision.reconciledTier,
-      });
-    }
-    return {
-      gateDecision,
-      trustAssessment: buildPRTrustAssessment(trustResult, reputation, gateDecision),
-    };
   }
 
   /**
@@ -468,13 +441,19 @@ Provide a structured review with:
     owner: string,
     repo: string,
     prNumber: number
-  ): Promise<Result<{ metadata: PRMetadata; provider: FullCapableProvider }, Error>> {
+  ): Promise<Result<PRFetchData, Error>> {
     const provider = createFullGitHubProvider(`${owner}/${repo}`);
 
     const detailResult = await provider.getPullRequestDetail(prNumber);
     if (!detailResult.ok) return err(detailResult.error);
 
     const detail = detailResult.value;
+    // #3133: best-effort real account age for the new_account reputation signal.
+    // Skip the lookup entirely when reputation is disabled — the value would be
+    // discarded by assessPRReputation's early-return anyway.
+    const accountAgeDays = this.config.enableReputation
+      ? await fetchAccountAgeDays(provider, detail.author)
+      : undefined;
     const metadata: PRMetadata = {
       number: detail.number,
       title: detail.title,
@@ -501,7 +480,11 @@ Provide a structured review with:
       deletions: detail.deletions,
     };
 
-    return ok({ metadata, provider });
+    return ok({
+      metadata,
+      provider,
+      ...(accountAgeDays !== undefined ? { accountAgeDays } : {}),
+    });
   }
 
   /**


### PR DESCRIPTION
## What

Closes #3133 (follow-up from epic #3118 Phase 5). `pr-reviewer` assessed reputation from author association + injection flags but **never fetched account age**, so the `new_account` signal never fired in the PR-review path — the PR-side gap that #3121 fixed for `issue_triage`.

## How

- `fetchAccountAgeDays(provider, username)` (in `pr-reviewer-helpers`) gets the author's real account age via `fetchUserMetadata().createdAt`. **Best-effort**: err Result, unparseable date, or unexpected rejection → `undefined` → `accountAgeDays` **omitted** (never fabricated) → engine skips `new_account` → review never blocks.
- Threaded through `fetchPRData` → `gatePRAuthor` → `assessPRReputation`. The fetch is **skipped when reputation is disabled** (the value would be discarded anyway).
- The reputation orchestration (`gatePRAuthor`) was consolidated from a class method into a pure helper alongside `assessPRReputation`/`buildPRTrustAssessment`, keeping `pr-reviewer.ts` under the complexity caps.
- `trustAssessment` now surfaces `suspiciousSignals` (parity with `issue_triage`'s assessment).

## Testing

3 new tests (new_account fires for a recent account, not for an established one, omitted on fetch failure) — direct parity with #3121. 4 fixtures updated for the new `suspiciousSignals` field. typecheck · lint · full suite (5/5) green. Blind `code-reviewer`: **APPROVE**, zero blocking/WARN (applied its efficiency NIT — skip the fetch when reputation is off; left the benign clock-skew NIT for parity with the twin #3121 helper).

Refs #3118.