### PR TITLE
fix(consensus): error-policy short-circuit reports honest vote counts (#3124)

### DIFF
--- a/.changeset/3124-consensus-honest-counts.md
+++ b/.changeset/3124-consensus-honest-counts.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): error-policy short-circuit reports honest vote counts (#3124)
+
+A `consensus_vote` that short-circuits on an error policy (`fail_closed`, or the >50%-error hard floor) reported `voteCounts: {approve:0,reject:0,abstain:0}` and `approvalPercentage:0` even when most voters clearly approved — so a 6/7 approval with one timed-out voter looked like a flat rejection at 0%. `createPolicyFailedResult` now reports the TRUE breakdown of the responding (non-error) voters (e.g. `approve:6`, `approvalPercentage:100`) while the decision still fails closed, and the response carries a new `policyReason` field (e.g. `fail_closed: 1 voter(s) errored`) so callers don't mistake a policy short-circuit for a genuine rejection. The gate decision is unchanged — the contested question of whether `higher_order`/`unanimous` should _default_ to `reduce_denominator` is tracked separately (decided via consensus_vote, see #3138).

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -211,12 +211,20 @@ export interface ConsensusVoteResponse {
   durationMs: number;
   simulateVotes: boolean;
   higherOrderMetadata?: HigherOrderMetadata;
+  /**
+   * Set when an error policy short-circuited the vote (#2630/#3124). Explains a
+   * `rejected` decision that may coexist with a high `approvalPercentage` — e.g.
+   * `fail_closed: 1 voter(s) errored`. Absent on normally-tallied votes.
+   */
+  policyReason?: string;
 }
 
 /** Extended voting result with optional Higher-Order metadata. */
 export interface ExtendedVotingResult extends VotingResult {
   strategy: VotingStrategy;
   higherOrderResult?: HigherOrderVotingResult;
+  /** Reason an error policy short-circuited the vote (#3124); surfaced on the response. */
+  policyReason?: string;
 }
 
 // ============================================================================
@@ -287,6 +295,10 @@ export function buildResponse(
 
   if (input.threshold !== undefined) {
     response.threshold = input.threshold;
+  }
+
+  if (result.policyReason !== undefined) {
+    response.policyReason = result.policyReason;
   }
 
   if (result.strategy === 'higher_order' && result.higherOrderResult) {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -9,6 +9,7 @@ import { RateLimiter } from '../middleware/index.js';
 import {
   ConsensusVoteInputSchema,
   CONSENSUS_VOTE_OUTPUT_SCHEMA,
+  createPolicyFailedResult,
   type ConsensusVoteDeps,
   type AgentVoteSummary,
   type ConsensusVoteResponse,
@@ -715,6 +716,111 @@ describe('toAgentVoteSummary (Issue #815)', () => {
 
     expect(summary.rejectionCategories).toBeUndefined();
   });
+});
+
+describe('createPolicyFailedResult honest counts (#3124)', () => {
+  function vr(
+    role: AgentVoteResult['role'],
+    decision: 'approve' | 'reject' | 'abstain',
+    source: AgentVoteResult['source'] = 'llm'
+  ): AgentVoteResult {
+    return {
+      role,
+      vote: { decision, reasoning: 'r', confidence: 0.8 },
+      processingTimeMs: 10,
+      source,
+    };
+  }
+
+  it('reports the TRUE breakdown of responding voters, not all-zeros, when one errors', () => {
+    const votes: AgentVoteResult[] = [
+      vr('architect', 'approve'),
+      vr('security', 'approve'),
+      vr('devex', 'approve'),
+      vr('ai_ml', 'approve'),
+      vr('pm', 'approve'),
+      vr('catfish', 'approve'),
+      vr('scope_steward', 'abstain', 'error'), // timed out
+    ];
+    const result = createPolicyFailedResult('p', 'supermajority', 'fail_closed: 1 errored', votes);
+    // The core #3124 fix: approve is 6, NOT 0.
+    expect(result.voteCounts.approve).toBe(6);
+    expect(result.voteCounts.reject).toBe(0);
+    expect(result.voteCounts.total).toBe(6); // error excluded from the denominator
+    expect(result.approvalPercentage).toBe(100);
+    expect(result.votes.size).toBe(6); // error vote not in the map
+    // The decision still fails closed (policy short-circuit), honestly reported.
+    expect(result.outcome).toBe('rejected');
+  });
+
+  it('computes approvalPercentage over responders only (mixed decisions + >50% errors)', () => {
+    const votes: AgentVoteResult[] = [
+      vr('architect', 'approve'),
+      vr('security', 'approve'),
+      vr('devex', 'approve'),
+      vr('ai_ml', 'reject'),
+      vr('pm', 'abstain', 'error'),
+      vr('catfish', 'abstain', 'error'),
+      vr('scope_steward', 'abstain', 'error'),
+    ];
+    const result = createPolicyFailedResult('p', 'supermajority', 'errors > 50%', votes);
+    expect(result.voteCounts).toMatchObject({ approve: 3, reject: 1, abstain: 0, total: 4 });
+    expect(result.approvalPercentage).toBe(75);
+  });
+
+  it('does not divide by zero when every voter errored', () => {
+    const votes: AgentVoteResult[] = [
+      vr('architect', 'abstain', 'error'),
+      vr('security', 'abstain', 'error'),
+    ];
+    const result = createPolicyFailedResult('p', 'supermajority', 'all errored', votes);
+    expect(result.approvalPercentage).toBe(0);
+    expect(result.voteCounts.total).toBe(0);
+  });
+});
+
+describe('buildResponse surfaces policyReason (#3124)', () => {
+  it('passes policyReason through to the response when set', () => {
+    const base = makeShortCircuitResult();
+    const input = { proposal: 'Test', simulateVotes: false, quickMode: false };
+    const response = buildResponse(input, base);
+    expect(response.policyReason).toBe('fail_closed: 1 voter(s) errored');
+    // honest: 1 approve surfaced, decision still rejected
+    expect(response.voteCounts.approve).toBe(1);
+    expect(response.decision).toBe('rejected');
+  });
+
+  function makeShortCircuitResult(): ExtendedVotingResult {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 50,
+        source: 'llm',
+      },
+      {
+        role: 'security',
+        vote: { decision: 'abstain', reasoning: 'timeout', confidence: 0 },
+        processingTimeMs: 60,
+        source: 'error',
+      },
+    ];
+    return {
+      proposal: 'Test',
+      threshold: 'higher_order',
+      result: createPolicyFailedResult(
+        'Test',
+        'higher_order',
+        'fail_closed: 1 voter(s) errored',
+        votes
+      ),
+      votes,
+      totalTimeMs: 100,
+      simulateVotes: false,
+      strategy: 'higher_order',
+      policyReason: 'fail_closed: 1 voter(s) errored',
+    };
+  }
 });
 
 describe('buildResponse error counting (Issue #815)', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -152,23 +152,39 @@ function createEmptyConsensusResult(
 /**
  * Creates a synthetic ConsensusResult for an error-policy short-circuit
  * (#2630). Reused for both the hard floor (errors > 50%) and `fail_closed`.
- * Mirrors `createEmptyConsensusResult` but stamps the reason on the
- * proposal title so downstream `mapOutcomeToDecision` / `buildResponse`
- * surface a human-readable failure mode.
+ * Stamps the reason on the proposal title and, since #3124, reports the TRUE
+ * vote breakdown of the responding (non-error) voters instead of all-zeros —
+ * the outcome stays `rejected` (the policy failed closed), but the counts and
+ * `approvalPercentage` are honest (e.g. 6 approvals + 1 error → approve:6,
+ * 100%) so callers/audit can see the policy short-circuited a real consensus
+ * rather than mistake it for a genuine rejection.
  */
-function createPolicyFailedResult(
+export function createPolicyFailedResult(
   proposal: string,
   algorithm: ConsensusAlgorithm,
-  reason: string
+  reason: string,
+  votes: readonly AgentVoteResult[]
 ): ConsensusResult {
   const now = new Date().toISOString();
+  const voteMap = new Map<string, Vote>();
+  let approve = 0;
+  let reject = 0;
+  let abstain = 0;
+  for (const v of votes) {
+    if (v.source === 'error') continue; // errors surface separately, not as a decision
+    voteMap.set(v.role, v.vote);
+    if (v.vote.decision === 'approve') approve++;
+    else if (v.vote.decision === 'reject') reject++;
+    else abstain++;
+  }
+  const responding = approve + reject + abstain;
   return {
     proposalId: 'error-policy-short-circuit',
     proposal: { title: `MCP Consensus Vote — ${reason}`, description: proposal, algorithm },
     outcome: 'rejected',
-    votes: new Map<string, Vote>(),
-    voteCounts: { approve: 0, reject: 0, abstain: 0, total: 0 },
-    approvalPercentage: 0,
+    votes: voteMap,
+    voteCounts: { approve, reject, abstain, total: responding },
+    approvalPercentage: responding > 0 ? (approve / responding) * 100 : 0,
     quorumReached: false,
     startedAt: now,
     closedAt: now,
@@ -438,11 +454,14 @@ function buildPolicyShortCircuitResult(args: {
   return {
     proposal: args.input.proposal,
     threshold: args.algorithm,
-    result: createPolicyFailedResult(args.input.proposal, args.algorithm, args.reason),
+    result: createPolicyFailedResult(args.input.proposal, args.algorithm, args.reason, args.votes),
     votes: args.votes,
     totalTimeMs,
     simulateVotes: args.input.simulateVotes,
     strategy: args.strategy,
+    // #3124: surface WHY a high-approval result is still 'rejected' so callers
+    // don't mistake a fail-closed policy short-circuit for a genuine rejection.
+    policyReason: args.reason,
   };
 }
 
@@ -855,6 +874,9 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
       reasoning: z.string().max(2000),
     })
     .optional(),
+  // #3124: explains a `rejected` decision that coexists with a high
+  // approvalPercentage (an error-policy short-circuit, e.g. fail_closed).
+  policyReason: z.string().max(200).optional(),
 };
 
 /**


### PR DESCRIPTION
## What

Closes #3124. A `consensus_vote` that short-circuits on an error policy (`fail_closed`, or the >50%-error hard floor) reported `voteCounts: {approve:0,reject:0,abstain:0}` and `approvalPercentage:0` even when most voters approved — so **6/7 approvals + 1 timed-out voter looked like a flat rejection at 0%**. Any caller acting on the result would treat strong consensus as rejection.

## How

- `createPolicyFailedResult` now tallies the **true breakdown of responding (non-error) voters** — `approve:6`, `total:6`, `approvalPercentage:100` — and builds the votes map from them. Error votes (`source==='error'`) are excluded from the map and the denominator (no divide-by-zero when all error).
- The **decision is unchanged**: still `rejected` / `quorumReached:false` (fail-closed semantics preserved — this is observability-only, not a gate change).
- New optional `policyReason` field on the response (e.g. `fail_closed: 1 voter(s) errored`), threaded `buildPolicyShortCircuitResult → ExtendedVotingResult → buildResponse` and added to `CONSENSUS_VOTE_OUTPUT_SCHEMA`, so a high-approval-but-`rejected` result is explained rather than misleading.

## Decided via consensus_vote (dogfooded)

Ran a `higher_order` `consensus_vote` on the fix approach — **approved 66.7% (2/1)**. The honesty fix had **unanimous** support (Security + Scope Steward both said unconditional). The contested part — flipping the *default* policy for `higher_order`/`unanimous` to `reduce_denominator` — was **rejected by Security** (a security-default downgrade) and Scope Steward said it "must be surfaced as such, not smuggled under a bug ticket", so it's **unbundled to #3138** with the threshold-design + threat-model conditions the voters attached.

## Testing

`createPolicyFailedResult` unit tests: honest counts with one error (approve:6/100%), mixed decisions over >50% errors (3 approve/1 reject → 75%), all-errored divide-by-zero guard, decision-stays-`rejected` invariant; plus a `buildResponse` policyReason-passthrough test. typecheck · lint · full suite (5/5) green. Blind `code-reviewer`: **APPROVE**, zero blocking (confirmed the gate is not weakened — no consumer acts on `approvalPercentage` without `decision`).