### PR TITLE
fix(security): warn on coercion of invalid security-mode env vars (#3130)

### DIFF
--- a/.changeset/3130-env-mode-coercion-warn.md
+++ b/.changeset/3130-env-mode-coercion-warn.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): warn on coercion of invalid security-mode env vars (#3130)
+
+`NEXUS_ACCESS_POLICY_MODE` (ClawGuard) and `NEXUS_REPUTATION_GATING` (reputation gating) previously **silently** coerced an invalid/typo'd value (e.g. `enfroce`) to their default, so a misconfigured `enforce` degraded to a less-strict mode with no signal. Both now route through a shared `resolveEnvMode` helper that emits a one-line `warn` on coercion of a non-empty invalid value (unset/empty stays silent — absence is normal), while keeping the never-throw, never-fatal coercion a security layer requires. Extracting the shared helper also guarantees the two flags coerce identically.

--- a/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/config.ts
@@ -13,6 +13,7 @@
  */
 
 import { AccessPolicyModeSchema, type AccessPolicyMode } from './types.js';
+import { resolveEnvMode } from '../env-mode.js';
 
 /** Default mode when the env var is unset. Flipped from `off` → `audit`
  * in v2.50+ to surface telemetry by default. */
@@ -22,13 +23,16 @@ export const DEFAULT_ACCESS_POLICY_MODE: AccessPolicyMode = 'audit';
  * Resolves the current access-policy mode from the environment.
  *
  * Returns `DEFAULT_ACCESS_POLICY_MODE` (currently `audit`) if the env var
- * is unset, empty, or invalid. Invalid values are silently coerced — they
- * are never a fatal startup error, because this is a security layer and
- * production must not fail-closed on a misconfiguration.
+ * is unset, empty, or invalid. Invalid values are coerced (never a fatal
+ * startup error — a security layer must not fail-closed on a misconfiguration),
+ * but a non-empty invalid value now emits a `warn` so the typo is observable
+ * (#3130), via the shared `resolveEnvMode`.
  */
 export function resolveAccessPolicyMode(env: NodeJS.ProcessEnv = process.env): AccessPolicyMode {
-  const raw = env['NEXUS_ACCESS_POLICY_MODE'];
-  if (typeof raw !== 'string' || raw.length === 0) return DEFAULT_ACCESS_POLICY_MODE;
-  const parsed = AccessPolicyModeSchema.safeParse(raw.toLowerCase());
-  return parsed.success ? parsed.data : DEFAULT_ACCESS_POLICY_MODE;
+  return resolveEnvMode(
+    env['NEXUS_ACCESS_POLICY_MODE'],
+    AccessPolicyModeSchema,
+    DEFAULT_ACCESS_POLICY_MODE,
+    'NEXUS_ACCESS_POLICY_MODE'
+  );
 }

--- a/packages/nexus-agents/src/security/env-mode.test.ts
+++ b/packages/nexus-agents/src/security/env-mode.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the shared security-mode env resolver (#3130).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import type { ILogger } from '../core/index.js';
+import { resolveEnvMode } from './env-mode.js';
+
+const Schema = z.enum(['off', 'audit', 'enforce']);
+const VAR = 'NEXUS_TEST_MODE';
+
+/** Minimal logger spy. */
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+describe('resolveEnvMode (#3130)', () => {
+  it('returns the parsed value for a valid (case-insensitive) input — no warning', () => {
+    const logger = spyLogger();
+    expect(resolveEnvMode('ENFORCE', Schema, 'audit', VAR, logger)).toBe('enforce');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns the fallback for unset/empty WITHOUT warning (absence is normal)', () => {
+    const logger = spyLogger();
+    expect(resolveEnvMode(undefined, Schema, 'audit', VAR, logger)).toBe('audit');
+    expect(resolveEnvMode('', Schema, 'audit', VAR, logger)).toBe('audit');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('coerces an invalid NON-EMPTY value to the fallback AND warns (#3130)', () => {
+    const logger = spyLogger();
+    expect(resolveEnvMode('enfroce', Schema, 'audit', VAR, logger)).toBe('audit');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(VAR),
+      expect.objectContaining({ raw: 'enfroce', default: 'audit' })
+    );
+  });
+
+  it('never throws on any input', () => {
+    const logger = spyLogger();
+    expect(() => resolveEnvMode('garbage', Schema, 'off', VAR, logger)).not.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/security/env-mode.ts
+++ b/packages/nexus-agents/src/security/env-mode.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared resolver for `off`/`audit`/`enforce`-style security-mode env vars
+ * (#3130). Both `resolveAccessPolicyMode` (ClawGuard, #1977) and
+ * `resolveReputationGatingMode` (reputation gating, #3122) parse an enum env
+ * var, coerce an invalid value to a safe default, and must NEVER throw — a
+ * security layer must not fail-closed on a misconfiguration at startup.
+ *
+ * Previously the coercion was silent: a typo'd `enforce` (`enfroce`) degraded
+ * to the default with no signal. This helper keeps the never-throw coercion but
+ * emits a one-line `warn` so the misconfiguration is observable, and guarantees
+ * both flags behave identically.
+ *
+ * @module security/env-mode
+ */
+
+import type { ZodType } from 'zod';
+import { createLogger } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+
+const defaultLogger = createLogger({ component: 'env-mode' });
+
+/**
+ * Resolve an enum-valued env var to one of its allowed values, coercing an
+ * invalid/typo'd value to `fallback`. Unset or empty → `fallback` silently
+ * (absence is normal, not a misconfiguration). A non-empty value that fails to
+ * parse → `fallback` plus a `warn` (an explicit-but-invalid value is an operator
+ * error worth surfacing). Never throws.
+ *
+ * @param raw     The raw env value (e.g. `process.env['NEXUS_X']`).
+ * @param schema  Zod enum schema for the allowed values.
+ * @param fallback Default returned when `raw` is absent/empty/invalid.
+ * @param varName Env var name, for the warning message.
+ * @param logger  Injectable for testing (defaults to the module logger).
+ */
+export function resolveEnvMode<T extends string>(
+  raw: string | undefined,
+  schema: ZodType<T>,
+  fallback: T,
+  varName: string,
+  logger: ILogger = defaultLogger
+): T {
+  if (typeof raw !== 'string' || raw.length === 0) return fallback;
+  const parsed = schema.safeParse(raw.toLowerCase());
+  if (parsed.success) return parsed.data;
+  logger.warn(`Invalid ${varName} value — coercing to default`, { raw, default: fallback });
+  return fallback;
+}

--- a/packages/nexus-agents/src/security/reputation-model.ts
+++ b/packages/nexus-agents/src/security/reputation-model.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 
 import { getTimeProvider } from '../core/index.js';
+import { resolveEnvMode } from './env-mode.js';
 import type { TrustTier, GitHubUserRole, InjectionFlag } from './trust-types.js';
 import { TRUST_TIER_NUMERIC, ROLE_DEFAULT_TRUST } from './trust-types.js';
 
@@ -377,14 +378,20 @@ export type ReputationGatingMode = z.infer<typeof ReputationGatingModeSchema>;
 /** Default when `NEXUS_REPUTATION_GATING` is unset/invalid — audit (telemetry, no block). */
 export const DEFAULT_REPUTATION_GATING_MODE: ReputationGatingMode = 'audit';
 
-/** Resolve the gating mode from the environment (invalid → default, never throws). */
+/**
+ * Resolve the gating mode from the environment (invalid → default + warn, never
+ * throws — #3130). Delegates to the shared `resolveEnvMode` so this flag and
+ * `NEXUS_ACCESS_POLICY_MODE` coerce identically.
+ */
 export function resolveReputationGatingMode(
   env: NodeJS.ProcessEnv = process.env
 ): ReputationGatingMode {
-  const raw = env['NEXUS_REPUTATION_GATING'];
-  if (typeof raw !== 'string' || raw.length === 0) return DEFAULT_REPUTATION_GATING_MODE;
-  const parsed = ReputationGatingModeSchema.safeParse(raw.toLowerCase());
-  return parsed.success ? parsed.data : DEFAULT_REPUTATION_GATING_MODE;
+  return resolveEnvMode(
+    env['NEXUS_REPUTATION_GATING'],
+    ReputationGatingModeSchema,
+    DEFAULT_REPUTATION_GATING_MODE,
+    'NEXUS_REPUTATION_GATING'
+  );
 }
 
 /** Outcome of applying the gating mode to a reputation assessment. */


### PR DESCRIPTION
## What

Closes #3130 (follow-up from #3122's review). `NEXUS_ACCESS_POLICY_MODE` (ClawGuard) and `NEXUS_REPUTATION_GATING` (reputation gating) **silently** coerced an invalid/typo'd value (e.g. `enfroce`) to their default — so a misconfigured `enforce` quietly degraded to a less-strict mode with no signal.

## How

- New shared `resolveEnvMode` helper (`src/security/env-mode.ts`) — the single coercion path for `off`/`audit`/`enforce`-style security-mode env vars. Emits a one-line `warn` on coercion of a **non-empty invalid** value; unset/empty stays silent (absence is normal). Keeps the never-throw, never-fatal coercion a security layer requires. Logger is injectable for testing.
- Both `resolveAccessPolicyMode` and `resolveReputationGatingMode` now delegate to it — so the two flags coerce **identically** (the issue's explicit "don't diverge the sibling flags" requirement).

## Behavior

Byte-for-byte identical to before on every input (unset/empty/valid/invalid all return the same value, never throw) — the **only** new behavior is the warn on non-empty-invalid. Default direction unchanged (`audit`); case-insensitivity (`toLowerCase`) retained.

## Testing

4 `resolveEnvMode` tests (valid→no warn, unset/empty→no warn, non-empty-invalid→coerce + warn once with `{raw, default}`, never-throws); existing resolver tests unchanged. typecheck · lint · full suite (5/5) green. Blind `code-reviewer`: **APPROVE** (confirmed behavior preservation + no hot-path log spam — warn is unreachable for valid/unset).