### PR TITLE
fix(consensus): correctness edges on higher-order voting path (#3144 P0)

### DIFF
--- a/.changeset/3144-consensus-correctness.md
+++ b/.changeset/3144-consensus-correctness.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): correctness edges on the higher-order voting path (#3144 P0)
+
+- `opinion_wise` now shares `higher_order`'s `fail_closed` default error policy instead of silently diverging to `reduce_denominator` (#3167) — it is an alias of higher_order.
+- `OWVoting.algorithm` is constructor-configurable (defaults to `simple_majority`); `HigherOrderVotingStrategy` sets `opinion_wise` via the constructor so the label is correct whether built directly or via a factory (#3168).
+- Correlation recording no longer drops ALL data on a mixed-source panel — it records the real (LLM) votes and logs the excluded count, instead of leaving the correlation matrix permanently stale when one voter simulated/errored (#3170).
+- Added the missing tests for these paths (#3171).
+
+Investigated and **rejected** #3172 (a "restore uniform weights when all collapse to the floor" guard): equal downweighting of equally-correlated agents is correct, and the Bayesian weighted-average is invariant under equal scaling, so all-at-floor is not degenerate — restoring uniform would wrongly treat correlated agents as independent (guarded by the existing "all perfectly correlated" test).

--- a/packages/nexus-agents/src/consensus/higher-order-helpers.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-helpers.ts
@@ -110,6 +110,15 @@ export function computeEffectiveWeights(
     }
   }
 
+  // NOTE (#3172, investigated + rejected): a "restore uniform weights when all
+  // collapse to the floor" guard was considered but is incorrect. When agents
+  // are equally correlated, equal downweighting is the CORRECT behavior (they
+  // are equally redundant), and because the Bayesian aggregate is a weighted
+  // average, scaling all weights equally is invariant — all-at-floor yields the
+  // same posterior as uniform, so it is not degenerate. Restoring uniform would
+  // wrongly treat correlated agents as independent and inflate the effective
+  // vote count (guarded by the "all perfectly correlated" test).
+
   return weights;
 }
 

--- a/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
@@ -952,3 +952,18 @@ describe('HigherOrderVotingStrategy', () => {
     expect(outcome.voteCounts.reject).toBe(1);
   });
 });
+
+describe('OWVoting.algorithm label (#3168)', () => {
+  it('defaults to simple_majority when constructed directly', () => {
+    expect(new OWVoting().algorithm).toBe('simple_majority');
+  });
+
+  it('is constructor-configurable', () => {
+    expect(new OWVoting({ algorithm: 'opinion_wise' }).algorithm).toBe('opinion_wise');
+  });
+
+  it('HigherOrderVotingStrategy reports opinion_wise however it is created', () => {
+    expect(new HigherOrderVotingStrategy().algorithm).toBe('opinion_wise');
+    expect(createHigherOrderVotingStrategy().algorithm).toBe('opinion_wise');
+  });
+});

--- a/packages/nexus-agents/src/consensus/higher-order-voting.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.ts
@@ -42,6 +42,12 @@ const logger = createLogger({ component: 'higher-order-voting' });
 /** Options for creating OWVoting instance. */
 export interface OWVotingOptions {
   readonly config?: Partial<HigherOrderVotingConfig>;
+  /**
+   * Algorithm label this instance reports (#3168). Defaults to `simple_majority`
+   * for backward compatibility; `HigherOrderVotingStrategy` sets `opinion_wise`.
+   * Keeps the label consistent whether constructed directly or via a factory.
+   */
+  readonly algorithm?: ConsensusAlgorithm;
 }
 
 /**
@@ -49,12 +55,15 @@ export interface OWVotingOptions {
  * Uses Bayesian aggregation with correlation awareness.
  */
 export class OWVoting implements IHigherOrderVoting, IVotingStrategy {
-  readonly algorithm: ConsensusAlgorithm = 'simple_majority';
+  readonly algorithm: ConsensusAlgorithm;
   private readonly config: HigherOrderVotingConfig;
 
   constructor(options: OWVotingOptions = {}) {
     this.config = { ...DEFAULT_HIGHER_ORDER_CONFIG, ...options.config };
-    logger.info('OWVoting initialized', { config: this.config });
+    // #3168: configurable so the label is correct whether built directly or via
+    // a factory; defaults to simple_majority for backward compatibility.
+    this.algorithm = options.algorithm ?? 'simple_majority';
+    logger.info('OWVoting initialized', { config: this.config, algorithm: this.algorithm });
   }
 
   /** IVotingStrategy implementation for integration with ConsensusEngine. */
@@ -251,10 +260,10 @@ export function createOWVoting(options?: OWVotingOptions): IHigherOrderVoting {
  * Wraps OWVoting to provide IVotingStrategy interface.
  */
 export class HigherOrderVotingStrategy extends OWVoting implements IVotingStrategy {
-  override readonly algorithm: ConsensusAlgorithm = 'opinion_wise';
-
   constructor(options: OWVotingOptions = {}) {
-    super(options);
+    // #3168: set the algorithm label via the constructor so it survives
+    // regardless of how the instance is created (no field-override divergence).
+    super({ ...options, algorithm: options.algorithm ?? 'opinion_wise' });
   }
 }
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -95,12 +95,14 @@ export const ERROR_FLOOR_FRACTION = 0.5;
 
 /**
  * Default error policy per voting strategy. Strict strategies (unanimous,
- * higher_order) default to `fail_closed`; others default to
- * `reduce_denominator`. Callers can override with the `errorPolicy` input
- * field.
+ * higher_order, and its alias opinion_wise) default to `fail_closed`; others
+ * default to `reduce_denominator`. Callers can override with the `errorPolicy`
+ * input field. (#3167: opinion_wise must match its higher_order alias.)
  */
 export function getDefaultErrorPolicy(strategy: VotingStrategy): ErrorPolicy {
-  if (strategy === 'unanimous' || strategy === 'higher_order') return 'fail_closed';
+  if (strategy === 'unanimous' || strategy === 'higher_order' || strategy === 'opinion_wise') {
+    return 'fail_closed';
+  }
   return 'reduce_denominator';
 }
 
@@ -113,7 +115,7 @@ export const ConsensusVoteInputSchema = z.object({
     'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order (Bayesian-optimal)'
   ),
   errorPolicy: ErrorPolicySchema.optional().describe(
-    'How to treat voters that errored or timed out (#2630). Default: fail_closed for unanimous/higher_order, reduce_denominator otherwise. Regardless of policy, errors > 50% always fails.'
+    'How to treat voters that errored or timed out (#2630). Default: fail_closed for unanimous/higher_order/opinion_wise, reduce_denominator otherwise. Regardless of policy, errors > 50% always fails.'
   ),
   quickMode: z
     .boolean()

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -16,7 +16,11 @@ import {
   type VoteDecisionStatus,
 } from './consensus-vote.js';
 import { z } from 'zod';
-import { toAgentVoteSummary, buildResponse } from './consensus-vote-types.js';
+import {
+  toAgentVoteSummary,
+  buildResponse,
+  getDefaultErrorPolicy,
+} from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ExtendedVotingResult } from './consensus-vote-types.js';
 
@@ -1095,5 +1099,20 @@ describe('CONSENSUS_VOTE_OUTPUT_SCHEMA validation (Issue #1246)', () => {
     const parsed = outputValidator.safeParse(response);
     expect(parsed.success).toBe(true);
     expect(response.threshold).toBe('supermajority');
+  });
+});
+
+describe('getDefaultErrorPolicy (#3167)', () => {
+  it('strict strategies default to fail_closed — incl. opinion_wise (the higher_order alias)', () => {
+    expect(getDefaultErrorPolicy('unanimous')).toBe('fail_closed');
+    expect(getDefaultErrorPolicy('higher_order')).toBe('fail_closed');
+    expect(getDefaultErrorPolicy('opinion_wise')).toBe('fail_closed');
+    // opinion_wise must match its alias rather than silently diverging
+    expect(getDefaultErrorPolicy('opinion_wise')).toBe(getDefaultErrorPolicy('higher_order'));
+  });
+
+  it('non-strict strategies default to reduce_denominator', () => {
+    expect(getDefaultErrorPolicy('simple_majority')).toBe('reduce_denominator');
+    expect(getDefaultErrorPolicy('supermajority')).toBe('reduce_denominator');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -289,24 +289,30 @@ function runHigherOrderVoting(
 
 function recordVotesToTracker(
   votes: readonly AgentVoteResult[],
-  voteMap: Map<string, Vote>,
   outcome: 'approved' | 'rejected',
   logger: ILogger
 ): void {
-  const allVotesReal = votes.every((v) => v.source === 'llm');
-  if (!allVotesReal) {
-    logger.warn('Skipping correlation recording due to non-LLM votes', {
-      count: votes.filter((v) => v.source !== 'llm').length,
+  // #3170: record the REAL (LLM) votes even when the panel is mixed-source,
+  // rather than dropping ALL correlation data because one voter simulated/errored.
+  // Recording the accurate LLM-only subset beats leaving the matrix permanently stale.
+  const llmVotes = votes.filter((v) => v.source === 'llm');
+  if (llmVotes.length < votes.length) {
+    logger.warn('Recording only LLM votes to correlation tracker; excluding non-LLM votes', {
+      recorded: llmVotes.length,
+      excluded: votes.length - llmVotes.length,
     });
-    return;
   }
+  if (llmVotes.length === 0) return; // nothing real to record
+  const llmVoteMap = new Map<string, Vote>();
+  for (const v of llmVotes) llmVoteMap.set(v.role, v.vote);
+
   const tracker = getOrCreateCorrelationTracker();
   const id = `consensus-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 9)}`;
-  tracker.recordProposalVotes(id, voteMap, outcome);
+  tracker.recordProposalVotes(id, llmVoteMap, outcome);
   logger.debug('Recorded votes to tracker', { proposalId: id, outcome });
 
   try {
-    const persisted = createPersistedProposal(id, voteMap, outcome);
+    const persisted = createPersistedProposal(id, llmVoteMap, outcome);
     const saveResult = saveCorrelationData([persisted]);
     if (!saveResult.ok) {
       logger.warn('Failed to persist correlation data', { error: saveResult.error.message });
@@ -539,16 +545,18 @@ export async function executeVoting(
   }
 
   // Check for early cascade and process votes (#1765)
-  const { engineResult, voteMap, higherOrderResult, outcome, cascaded } =
-    await processVotesWithCascade(policyDecision.engineVotes, {
+  const { engineResult, higherOrderResult, outcome, cascaded } = await processVotesWithCascade(
+    policyDecision.engineVotes,
+    {
       totalRoles: roles.length,
       proposal: input.proposal,
       algorithm,
       strategy,
       log: logger,
-    });
+    }
+  );
 
-  recordVotesToTracker(votes, voteMap, outcome, logger);
+  recordVotesToTracker(votes, outcome, logger);
 
   const escalated = await maybeEscalateContrarian(input, outcome, logger, opts);
   if (escalated !== undefined) return escalated;


### PR DESCRIPTION
First slice of **P0** (epic #3143). Closes #3167, #3168, #3170, #3171.

- **#3167** — `opinion_wise` shares `higher_order`'s `fail_closed` default error policy (it's an alias) instead of silently diverging to `reduce_denominator`.
- **#3168** — `OWVoting.algorithm` is constructor-configurable (default `simple_majority`); `HigherOrderVotingStrategy` sets `opinion_wise` via `super({...})` so the label is correct whether built directly or via a factory.
- **#3170** — correlation recording no longer drops ALL data on a mixed-source panel; it records the real LLM votes and logs the excluded count (all-LLM path provably unchanged).
- **#3171** — added tests for these paths.

**Rejected #3172** after investigation (closed as not-planned with analysis): a "restore uniform weights when all collapse to the floor" guard is wrong — equal downweighting of equally-correlated agents is correct, and the Bayesian weighted-average is scale-invariant, so all-at-floor is not degenerate; the existing "all perfectly correlated" test guards this.

**Filed #3271** (blind-review finding): `opinion_wise` skips higher-order Bayesian aggregation despite the alias — out of scope here, tracked separately.

typecheck · lint · full suite (5/5) green. Blind `code-reviewer`: **APPROVE** (NITs applied: schema description + comment wording).

Refs #3143.