### PR TITLE
fix(adapters): default logging onRetirement when missing-model fallback enabled (#3144 P0)

### DIFF
--- a/.changeset/onretirement-default-logging.md
+++ b/.changeset/onretirement-default-logging.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): default a logging onRetirement callback when missing-model fallback is enabled (#3144 P0)
+
+The model-not-found fallback's `onRetirement` callback was declared but never wired in production, so model retirements were silent. `UnifiedAdapterRegistry` now defaults `onRetirement` to a `logger.warn` when `enableMissingModelFallback` is on (callers can still override it), making retirements observable. Extracted as the exported, testable `withDefaultOnRetirement` helper.

--- a/packages/nexus-agents/src/adapters/unified-registry.test.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.test.ts
@@ -18,7 +18,9 @@ import {
   createUnifiedRegistry,
   getGlobalRegistry,
   resetGlobalRegistry,
+  withDefaultOnRetirement,
 } from './unified-registry.js';
+import type { ILogger } from '../core/index.js';
 import { TASK_SPECIALIZATION_MATRIX } from '../config/task-specialization.js';
 import { DEFAULT_MODEL_CAPABILITIES } from '../config/in-tree-data.js';
 
@@ -366,5 +368,44 @@ describe('UnifiedAdapterRegistry enableMissingModelFallback (#2549)', () => {
     const second = registry.getAdapterForCli('claude');
     expect(first).toBe(second);
     registry.dispose();
+  });
+});
+
+describe('withDefaultOnRetirement — onRetirement dead-bridge wiring', () => {
+  const freshLogger = (): ILogger => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    setLevel: vi.fn(),
+  });
+
+  it('returns options unchanged when the fallback is disabled', () => {
+    const opts = {};
+    expect(withDefaultOnRetirement(false, opts, freshLogger())).toBe(opts);
+    expect(withDefaultOnRetirement(false, undefined, freshLogger())).toBeUndefined();
+  });
+
+  it('wires a default logging onRetirement when enabled and none was provided', () => {
+    const logger = freshLogger();
+    const resolved = withDefaultOnRetirement(true, undefined, logger);
+    expect(resolved?.onRetirement).toBeDefined();
+    resolved!.onRetirement!({
+      retiredModelId: 'claude-opus-4-6',
+      fallbackModelId: 'claude-opus',
+    } as never);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Model retired via not-found fallback',
+      expect.objectContaining({
+        retirement: expect.objectContaining({ retiredModelId: 'claude-opus-4-6' }),
+      })
+    );
+  });
+
+  it('preserves a caller-supplied onRetirement (no override)', () => {
+    const custom = vi.fn();
+    const resolved = withDefaultOnRetirement(true, { onRetirement: custom }, freshLogger());
+    expect(resolved?.onRetirement).toBe(custom);
   });
 });

--- a/packages/nexus-agents/src/adapters/unified-registry.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.ts
@@ -97,6 +97,29 @@ export interface RegistrySnapshot {
  * const adapter3 = registry.getDefault();                 // → best available
  * ```
  */
+
+/**
+ * Defaults `onRetirement` to a logging callback when the fallback is enabled, so
+ * model retirements are observable rather than silent (the callback was a
+ * declared-but-unwired bridge — system review). Callers can still override it.
+ * Returns the options unchanged when the fallback is disabled.
+ */
+export function withDefaultOnRetirement(
+  enabled: boolean,
+  options: ModelNotFoundFallbackOptions | undefined,
+  logger: ILogger
+): ModelNotFoundFallbackOptions | undefined {
+  if (!enabled) return options;
+  return {
+    ...options,
+    onRetirement:
+      options?.onRetirement ??
+      ((info): void => {
+        logger.warn('Model retired via not-found fallback', { retirement: info });
+      }),
+  };
+}
+
 export class UnifiedAdapterRegistry {
   private readonly logger: ILogger;
   private readonly defaultCliTimeoutMs: number | undefined;
@@ -116,7 +139,11 @@ export class UnifiedAdapterRegistry {
     this.logger = config?.logger ?? createLogger({ component: 'unified-registry' });
     this.defaultCliTimeoutMs = config?.defaultCliTimeoutMs;
     this.enableMissingModelFallback = config?.enableMissingModelFallback ?? false;
-    this.missingModelFallbackOptions = config?.missingModelFallbackOptions;
+    this.missingModelFallbackOptions = withDefaultOnRetirement(
+      this.enableMissingModelFallback,
+      config?.missingModelFallbackOptions,
+      this.logger
+    );
     this.taskRouting = this.buildTaskRouting();
     this.logger.info('UnifiedAdapterRegistry initialized', {
       categories: this.taskRouting.size,


### PR DESCRIPTION
Wires a previously-dead bridge from the system review (P0, epic #3143). The model-not-found fallback's `onRetirement` callback was declared but never supplied in production, so model retirements were silent. `UnifiedAdapterRegistry` now defaults it to a `logger.warn` when `enableMissingModelFallback` is on (callers can still override). Extracted the exported, testable `withDefaultOnRetirement` helper (constructor complexity kept under cap); 3 unit tests. Full suite green. Refs #3143, #3144.