### PR TITLE
feat(security): firewall policyEnforcement stage surfaces Rule-of-Two (#3198)

### DIFF
--- a/.changeset/3198-firewall-rule-of-two.md
+++ b/.changeset/3198-firewall-rule-of-two.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+feat(security): firewall policyEnforcement stage surfaces Rule-of-Two (#3198, #3144 P0)
+
+The firewall's `policyEnforcement` stage was declared (default on) but never read — Rule-of-Two was only checked in `policy-gate`, not during firewall composition. `HostileInputFirewall.process()` now evaluates Rule-of-Two against the effective (reputation-reconciled) trust tier + the configured `context` (write/secret access) and **surfaces** a `ruleOfTwoViolation` on `FirewallResult` (signal-only — the firewall is a library; the consumer enforces; no hard block, so no breaking behavior). `checkRuleOfTwo` is exported from `policy-gate` to avoid duplicating the predicate. Tier-1/allowlisted authors are immune.

--- a/packages/nexus-agents/src/security/firewall/firewall-pipeline.test.ts
+++ b/packages/nexus-agents/src/security/firewall/firewall-pipeline.test.ts
@@ -335,3 +335,46 @@ describe('HostileInputFirewall', () => {
     });
   });
 });
+
+describe('policyEnforcement stage — Rule of Two (#3198)', () => {
+  it('surfaces a Rule-of-Two violation for untrusted input with write + secret access', () => {
+    const fw = createFirewall({ context: { hasWriteAccess: true, hasSecretAccess: true } });
+    const result = fw.process(issueInput()); // NONE author → untrusted tier
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(Number(result.value.effectiveTrustTier)).toBeGreaterThanOrEqual(3);
+      expect(result.value.ruleOfTwoViolation?.rule).toBe('RULE_OF_TWO');
+      expect(result.value.ruleOfTwoViolation?.severity).toBe('block');
+    }
+  });
+
+  it('no violation when the context lacks write OR secret access', () => {
+    const fw = createFirewall({ context: { hasWriteAccess: true, hasSecretAccess: false } });
+    const result = fw.process(issueInput());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.ruleOfTwoViolation).toBeUndefined();
+  });
+
+  it('no violation for an allowlisted (Tier-1) author even with write + secret', () => {
+    const fw = createFirewall({
+      allowlistedMaintainers: ['trusteduser'],
+      context: { hasWriteAccess: true, hasSecretAccess: true },
+    });
+    const result = fw.process(issueInput({ username: 'trusteduser' }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.effectiveTrustTier).toBe('1');
+      expect(result.value.ruleOfTwoViolation).toBeUndefined();
+    }
+  });
+
+  it('does not evaluate Rule of Two when the policyEnforcement stage is disabled', () => {
+    const fw = createFirewall({
+      stages: { policyEnforcement: false },
+      context: { hasWriteAccess: true, hasSecretAccess: true },
+    });
+    const result = fw.process(issueInput());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.ruleOfTwoViolation).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/security/firewall/firewall-pipeline.ts
+++ b/packages/nexus-agents/src/security/firewall/firewall-pipeline.ts
@@ -37,6 +37,11 @@ import type {
   SourceMetadata,
 } from './firewall-types.js';
 import { FirewallConfigSchema } from './firewall-types.js';
+import { checkRuleOfTwo } from '../policy-gate.js';
+import type { Violation } from '../policy-gate.js';
+import { createLogger } from '../../core/index.js';
+
+const logger = createLogger({ component: 'HostileInputFirewall' });
 
 // ============================================================================
 // Firewall Result
@@ -58,6 +63,14 @@ export interface FirewallResult {
    */
   readonly effectiveTrustTier: TrustTier;
   readonly atl: string;
+  /**
+   * Rule-of-Two assessment surfaced by the `policyEnforcement` stage (#3198):
+   * present (with `severity: 'block'`) when the effective tier is untrusted AND
+   * the configured context has both write and secret access. The firewall is a
+   * signal provider — it SURFACES this for the consumer to enforce; it does not
+   * hard-block. `undefined` when the stage is disabled or the rule holds.
+   */
+  readonly ruleOfTwoViolation?: Violation;
   readonly auditEvents: readonly { readonly id: string; readonly type: string }[];
   readonly durationMs: number;
 }
@@ -77,6 +90,7 @@ export class HostileInputFirewall {
   private readonly adapter: FirewallConfig['adapter'];
   private readonly reputationCache: ReputationCache;
   private readonly auditTrail: AuditTrail;
+  private readonly context: { readonly hasWriteAccess: boolean; readonly hasSecretAccess: boolean };
 
   constructor(config: FirewallConfig) {
     const validated = FirewallConfigSchema.parse({
@@ -91,6 +105,7 @@ export class HostileInputFirewall {
     this.adapter = config.adapter;
     this.reputationCache = new ReputationCache();
     this.auditTrail = createAuditTrail();
+    this.context = validated.context;
   }
 
   /**
@@ -123,6 +138,24 @@ export class HostileInputFirewall {
     // Stage 5: Generate ATL (labelled with the enforced tier)
     const atl = this.buildATL(meta, effectiveTrustTier, sanitized, reputation);
 
+    // Stage 6: Rule-of-Two policy enforcement (#3198) — evaluate + surface the
+    // violation during firewall composition (previously the policyEnforcement
+    // stage was declared but never read). Signal only: the consumer enforces.
+    const ruleOfTwoViolation = this.stages.policyEnforcement
+      ? checkRuleOfTwo({
+          inputTrustTier: effectiveTrustTier,
+          hasWriteAccess: this.context.hasWriteAccess,
+          hasSecretAccess: this.context.hasSecretAccess,
+        })
+      : undefined;
+    if (ruleOfTwoViolation !== undefined) {
+      logger.warn('Firewall surfaced a Rule-of-Two violation', {
+        user: meta.username,
+        effectiveTrustTier,
+        rule: ruleOfTwoViolation.rule,
+      });
+    }
+
     // Collect audit events
     const auditEvents = this.auditTrail.query().map((e) => ({ id: e.id, type: e.type }));
 
@@ -132,6 +165,7 @@ export class HostileInputFirewall {
       ...(reputation !== undefined ? { reputation } : {}),
       effectiveTrustTier,
       atl,
+      ...(ruleOfTwoViolation !== undefined ? { ruleOfTwoViolation } : {}),
       auditEvents,
       durationMs: Date.now() - start,
     });

--- a/packages/nexus-agents/src/security/policy-gate.ts
+++ b/packages/nexus-agents/src/security/policy-gate.ts
@@ -121,8 +121,11 @@ function checkInfluenceBlock(action: AgentAction, context: ActionContext): Viola
 /**
  * Enforce the Rule of Two: no agent may simultaneously
  * (a) process untrusted input, (b) have write access, AND (c) access secrets.
+ *
+ * Exported (#3198) so the firewall's `policyEnforcement` stage can surface the
+ * same assessment during input composition without duplicating the predicate.
  */
-function checkRuleOfTwo(context: ActionContext): Violation | undefined {
+export function checkRuleOfTwo(context: ActionContext): Violation | undefined {
   const isUntrusted = TRUST_TIER_NUMERIC[context.inputTrustTier] >= 3;
   if (isUntrusted && context.hasWriteAccess && context.hasSecretAccess) {
     return {


### PR DESCRIPTION
Closes #3198 (epic #3143 P0). The firewall's `policyEnforcement` stage (default on) was declared but never read; `process()` now evaluates `checkRuleOfTwo` against the effective (reputation-reconciled) trust tier + configured context and **surfaces** `ruleOfTwoViolation` on `FirewallResult` — signal-only (no hard block → no breaking change; the firewall is a library, the consumer enforces). `checkRuleOfTwo` exported from policy-gate (no duplication). Tier-1/allowlisted immune. 4 tests; full suite green; blind code-reviewer **APPROVE** (purely additive, correct tier, no fatal consumers). Refs #3143, #3144.