### PR TITLE
feat(security): policy-gate emits decisions to optional audit trail (#3191)

### DIFF
--- a/.changeset/3191-policy-gate-audit-emission.md
+++ b/.changeset/3191-policy-gate-audit-emission.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+feat(security): policy-gate can emit decisions to an audit trail (#3191, #3144 P0)
+
+`evaluatePolicy` accepts an optional `auditTrail` and, when supplied, emits a `policy_gate` audit event (actionType, allowed, requiresApproval, inputTrustTier, violationRules) via the existing `emitPolicyEvent`. Previously policy decisions left no audit record. Optional + additive — pure callers pass no trail and incur zero side effects; existing call sites are unchanged. Foundation for the durable audit/tune substrate (#3146).

--- a/packages/nexus-agents/src/security/policy-gate.test.ts
+++ b/packages/nexus-agents/src/security/policy-gate.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import type { SourceCitation } from './action-schema.js';
 import type { ActionContext } from './policy-gate.js';
 import { evaluatePolicy, canProceed } from './policy-gate.js';
+import { createAuditTrail } from './audit-trail.js';
 
 // ============================================================================
 // Test Helpers - Source Citations
@@ -308,5 +309,35 @@ describe('canProceed', () => {
   it('allows safety actions at tier 4', () => {
     expect(canProceed('RequestHumanApproval', '4')).toBe(true);
     expect(canProceed('RefuseAction', '4')).toBe(true);
+  });
+});
+
+describe('evaluatePolicy audit emission (#3191)', () => {
+  it('emits a policy_gate audit event when an audit trail is supplied', () => {
+    const trail = createAuditTrail();
+    const decision = evaluatePolicy(makePropose([maintainerSource]), makeContext('1'), trail);
+    const events = trail.query();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'policy_gate',
+      allowed: decision.allowed,
+      requiresApproval: decision.requiresApproval,
+      inputTrustTier: '1',
+    });
+  });
+
+  it('emits nothing and stays pure when no audit trail is supplied', () => {
+    const decision = evaluatePolicy(makeSummarize([repoSource]), makeContext('1'));
+    expect(decision.allowed).toBe(true); // no trail arg → no side effect, same result
+  });
+
+  it('records violation rules in the event for a blocked action', () => {
+    const trail = createAuditTrail();
+    evaluatePolicy(makeSummarize([]), makeContext('1'), trail); // missing citation → block
+    const events = trail.query();
+    expect(events[0]).toMatchObject({ type: 'policy_gate', allowed: false });
+    expect(
+      (events[0] as unknown as { violationRules: readonly string[] }).violationRules
+    ).toContain('REQUIRE_CITATION');
   });
 });

--- a/packages/nexus-agents/src/security/policy-gate.ts
+++ b/packages/nexus-agents/src/security/policy-gate.ts
@@ -18,6 +18,8 @@ import { isMutatingAction, isReadOnlyAction, requiresCitation } from './action-s
 import type { TrustTier } from './trust-types.js';
 import { TRUST_TIER_NUMERIC } from './trust-types.js';
 import { getRequiredTrustTier, canInfluenceDecisions } from './trust-classifier.js';
+import type { AuditTrail } from './audit-trail.js';
+import { emitPolicyEvent } from './audit-trail.js';
 
 // ============================================================================
 // Types
@@ -193,7 +195,11 @@ function checkSourceTrustTiers(action: AgentAction): Violation | undefined {
  * @param context - The current execution context.
  * @returns PolicyDecision with violations and approval requirements.
  */
-export function evaluatePolicy(action: AgentAction, context: ActionContext): PolicyDecision {
+export function evaluatePolicy(
+  action: AgentAction,
+  context: ActionContext,
+  auditTrail?: AuditTrail
+): PolicyDecision {
   const violations: Violation[] = [];
 
   const checks = [
@@ -214,12 +220,27 @@ export function evaluatePolicy(action: AgentAction, context: ActionContext): Pol
   const hasBlockingViolation = violations.some((v) => v.severity === 'block');
   const needsApproval = !hasBlockingViolation && isMutatingAction(action.type);
 
-  return {
+  const decision: PolicyDecision = {
     allowed: !hasBlockingViolation,
     requiresApproval: needsApproval,
     violations,
     evaluatedAt: new Date().toISOString(),
   };
+
+  // #3191: when an audit trail is supplied, record the decision so policy
+  // outcomes are part of the durable audit record (the gate previously emitted
+  // nothing). Optional — pure callers pass no trail and incur no side effect.
+  if (auditTrail !== undefined) {
+    emitPolicyEvent(auditTrail, {
+      actionType: action.type,
+      allowed: decision.allowed,
+      requiresApproval: decision.requiresApproval,
+      inputTrustTier: context.inputTrustTier,
+      violationRules: violations.map((v) => v.rule),
+    });
+  }
+
+  return decision;
 }
 
 /**


### PR DESCRIPTION
Closes #3191 (epic #3143 P0). `evaluatePolicy` gains an optional `auditTrail` param; when supplied it emits a `policy_gate` audit event (actionType, allowed, requiresApproval, inputTrustTier, violationRules). Previously policy decisions left no audit record. Additive + optional — pure callers pass no trail and are byte-for-byte unchanged. Foundation for the durable audit/tune substrate (#3146). 3 tests; full suite green. Refs #3143, #3144.