### PR TITLE
fix(pipeline): preserve error context in stage execution (#3176)

### DIFF
--- a/.changeset/3176-stage-error-context.md
+++ b/.changeset/3176-stage-error-context.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(pipeline): preserve error context in stage execution (#3176, #3144 P0)
+
+Stage-execution catch blocks used `String(e)`, which mangles non-Error throws to `"[object Object]"` and drops the real message. Replaced with `getErrorMessage(e)` across the 9 stage wrappers (`stage-wrappers.ts`) plus the orchestration CLI-plan-parse and triangulated-review error paths, so a thrown object/string surfaces its actual message in `StageOutput.error` and logs.

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -247,7 +247,9 @@ function parsePlan(text: string): CliPlan | null {
       summary: typeof obj.summary === 'string' ? obj.summary : '',
     };
   } catch (e: unknown) {
-    moduleLogger.warn('Failed to parse CLI plan output as JSON; discarding', { error: String(e) });
+    moduleLogger.warn('Failed to parse CLI plan output as JSON; discarding', {
+      error: getErrorMessage(e),
+    });
     return null;
   }
 }

--- a/packages/nexus-agents/src/orchestration/triangulated-review.ts
+++ b/packages/nexus-agents/src/orchestration/triangulated-review.ts
@@ -272,7 +272,7 @@ function parseFindings(text: string, cli: CliName): ReviewFinding[] {
   } catch (e: unknown) {
     moduleLogger.warn('Failed to parse CLI review findings as JSON; discarding', {
       cli,
-      error: String(e),
+      error: getErrorMessage(e),
     });
     return [];
   }

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
@@ -85,6 +85,20 @@ describe('Stage Wrappers', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Timeout');
     });
+
+    it('preserves the message when a stage throws a non-Error value (#3176)', async () => {
+      const stages = createMockStages();
+      // A thrown non-Error object previously stringified to "[object Object]",
+      // losing all context. getErrorMessage extracts the real message.
+      vi.mocked(stages.research).mockRejectedValue({ message: 'adapter exploded', code: 'E_BOOM' });
+      const wrapper = createResearchStageWrapper(stages);
+
+      const result = await wrapper.execute(makeContext());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('adapter exploded');
+      expect(result.error).not.toContain('[object Object]');
+    });
   });
 
   describe('createPlanStageWrapper', () => {

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -8,7 +8,7 @@
  * @module pipeline/stage-wrappers
  */
 
-import { getTimeProvider } from '../core/index.js';
+import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import { parseSpec } from '../orchestration/spec-parser.js';
 import type { DevPipelineStages, PipelineTask } from './dev-pipeline.js';
 import { isApproved, getVoteFeedback } from './dev-pipeline.js';
@@ -73,7 +73,7 @@ export function createResearchStageWrapper(stages: DevPipelineStages): IPipeline
         const result = await stages.research(enrichedTask);
         return output(K.RESEARCH, result, getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.RESEARCH, String(e), getTimeProvider().now() - start);
+        return failOutput(K.RESEARCH, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -102,7 +102,7 @@ export function createPlanStageWrapper(stages: DevPipelineStages): IPipelineStag
         const result = await stages.plan(ctx.task, enrichedResearch, feedback);
         return output(K.PLAN, result, getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.PLAN, String(e), getTimeProvider().now() - start);
+        return failOutput(K.PLAN, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -127,7 +127,7 @@ export function createVoteStageWrapper(stages: DevPipelineStages): IPipelineStag
           success: isApproved(vote),
         };
       } catch (e) {
-        return failOutput(K.VOTE_RESULT, String(e), getTimeProvider().now() - start);
+        return failOutput(K.VOTE_RESULT, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -145,7 +145,7 @@ export function createDecomposeStageWrapper(stages: DevPipelineStages): IPipelin
         const tasks = await stages.decompose(plan);
         return output(K.TASKS, tasks, getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.TASKS, String(e), getTimeProvider().now() - start);
+        return failOutput(K.TASKS, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -172,7 +172,7 @@ export function createImplementStageWrapper(stages: DevPipelineStages): IPipelin
         // through ctx.state with a documented PIPELINE_STATE_KEYS entry.
         return output(K.IMPLEMENTATIONS, results, getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.IMPLEMENTATIONS, String(e), getTimeProvider().now() - start);
+        return failOutput(K.IMPLEMENTATIONS, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -194,7 +194,7 @@ export function createQaStageWrapper(stages: DevPipelineStages): IPipelineStage 
         const allPass = reviews.every((r) => r.verdict === 'pass');
         return output(K.QA_ITERATIONS, reviews, getTimeProvider().now() - start, allPass);
       } catch (e) {
-        return failOutput(K.QA_ITERATIONS, String(e), getTimeProvider().now() - start);
+        return failOutput(K.QA_ITERATIONS, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -216,7 +216,7 @@ export function createSecurityStageWrapper(stages: DevPipelineStages): IPipeline
           result.passed
         );
       } catch (e) {
-        return failOutput(K.SECURITY_PASSED, String(e), getTimeProvider().now() - start);
+        return failOutput(K.SECURITY_PASSED, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -351,7 +351,7 @@ export function createAnalyzeStageWrapper(): IPipelineStage {
         const summary = `Language: ${String(analysis.language)}, Framework: ${String(analysis.framework)}, CI: ${String(analysis.ciProvider)}, Security: ${analysis.securityTooling.join(', ') || 'none'}`;
         return output(K.RESEARCH, summary, getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.RESEARCH, String(e), getTimeProvider().now() - start);
+        return failOutput(K.RESEARCH, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };
@@ -377,7 +377,7 @@ export function createScanStageWrapper(): IPipelineStage {
         }
         return output(K.FINDINGS, 'No repository to scan', getTimeProvider().now() - start, true);
       } catch (e) {
-        return failOutput(K.FINDINGS, String(e), getTimeProvider().now() - start);
+        return failOutput(K.FINDINGS, getErrorMessage(e), getTimeProvider().now() - start);
       }
     },
   };


### PR DESCRIPTION
Closes #3176 (epic #3143 P0). Stage-execution catch blocks used `String(e)` → `"[object Object]"` for non-Error throws, dropping the real message. Replaced with `getErrorMessage(e)` across the 9 `stage-wrappers.ts` wrappers + the consensus-plan and triangulated-review orchestration error paths. New test: a non-Error throw now surfaces its real message. Also closed #3248 (broken doc link) as not-reproducible — all FIRST_TASK.md links verified to resolve. Full suite green. Refs #3143, #3144.