### PR TITLE
feat(outcomes): optional traceId/requestId correlation on routing TaskOutcome (#3146 P1)

### DIFF
--- a/.changeset/3146-pr1-traceid-correlation.md
+++ b/.changeset/3146-pr1-traceid-correlation.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+feat(outcomes): optional traceId/requestId correlation on routing TaskOutcome (#3146, epic #3143 P1)
+
+Adds optional `traceId?`/`requestId?` to the routing `TaskOutcomeSchema` so outcomes can be correlated across the pipeline/audit substrate. Zod-optional and backward-compatible — older JSONL records without the fields hydrate unchanged. First additive PR of the ratified P1 durable-substrate plan; the feedback-side `StoredTaskOutcome` already carries `traceId`.

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store.test.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store.test.ts
@@ -64,6 +64,26 @@ describe('TaskOutcomeSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts optional traceId/requestId correlation fields (#3146)', () => {
+    const result = TaskOutcomeSchema.safeParse(
+      makeOutcome({ traceId: 'trace-abc', requestId: 'req_123' })
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.traceId).toBe('trace-abc');
+      expect(result.data.requestId).toBe('req_123');
+    }
+  });
+
+  it('stays backward-compatible: records without traceId/requestId still parse (#3146)', () => {
+    const result = TaskOutcomeSchema.safeParse(makeOutcome());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.traceId).toBeUndefined();
+      expect(result.data.requestId).toBeUndefined();
+    }
+  });
+
   it('rejects invalid cli name', () => {
     const result = TaskOutcomeSchema.safeParse(makeOutcome({ cli: 'invalid' as 'claude' }));
     expect(result.success).toBe(false);

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
@@ -79,6 +79,13 @@ export const TaskOutcomeSchema = z.object({
    * node's `executionId` or `taskId`.
    */
   baselineId: z.string().min(1).max(64).optional(),
+  /**
+   * Distributed trace id correlating this outcome across the pipeline (#3146).
+   * Optional + backward-compatible: older JSONL records without it hydrate fine.
+   */
+  traceId: z.string().min(1).max(128).optional(),
+  /** Request id correlating this outcome to its originating invocation (#3146). */
+  requestId: z.string().min(1).max(128).optional(),
 });
 
 /** Schema for filtering outcomes. */


### PR DESCRIPTION
First additive PR of the ratified **P1 durable-substrate** plan (epic #3143, plan ratified 6/7 — see epic comment). Adds optional `traceId?`/`requestId?` to the routing `TaskOutcomeSchema` for cross-pipeline/audit correlation. **Zod-optional + backward-compatible** — older JSONL records hydrate unchanged; the feedback-side `StoredTaskOutcome` already has `traceId`. 2 tests (with-fields + backward-compat). Full suite green. Refs #3143, #3146.