### PR TITLE
feat(outcomes): feedback→routing TaskOutcome mapper (#3146 P1)

### DIFF
--- a/.changeset/3146-pr2-feedback-outcome-mapper.md
+++ b/.changeset/3146-pr2-feedback-outcome-mapper.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+feat(outcomes): feedback→routing TaskOutcome mapper (#3146, epic #3143 P1)
+
+Adds `feedbackToRoutingOutcome(feedback, context)` (new `learning/feedback-outcome-mapper.ts`) — a one-way, pure mapper converting a feedback-layer `TaskOutcome` into a routing-layer one, so feedback outcomes can be recorded into the routing OutcomeStore for unified analysis. The feedback `traceId` is carried through (lands in the optional routing `traceId` from PR-1/#3281), giving cross-layer correlation. The two `TaskOutcome` types stay separately exported (no symbol collapse). Lossy by design: the feedback `qualitySignals`/`qualityScore` have no routing-schema home and are dropped; `errorMessage` is clipped to the schema's 500-char max. Output is schema-valid. Additive — no existing code paths changed.

--- a/packages/nexus-agents/src/learning/feedback-outcome-mapper.test.ts
+++ b/packages/nexus-agents/src/learning/feedback-outcome-mapper.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the feedback→routing TaskOutcome mapper (#3146, epic #3143 P1).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  feedbackToRoutingOutcome,
+  failureCategoryFromOutcomeClass,
+  type RoutingOutcomeContext,
+} from './feedback-outcome-mapper.js';
+import type { TaskOutcome as FeedbackTaskOutcome } from './outcome-feedback-types.js';
+import { TaskOutcomeSchema } from '../orchestration/outcomes/outcome-types.js';
+
+function feedback(overrides: Partial<FeedbackTaskOutcome> = {}): FeedbackTaskOutcome {
+  return {
+    routingDecisionId: '11111111-1111-1111-1111-111111111111',
+    timestamp: '2026-06-01T10:00:00Z',
+    outcomeClass: 'success',
+    success: true,
+    qualityScore: 0.9,
+    durationMs: 1200,
+    tokenUsage: 800,
+    qualitySignals: { completionRatio: 1, retryCount: 0, coherenceScore: 0.9 },
+    traceId: 'trace-xyz',
+    ...overrides,
+  };
+}
+
+const ctx: RoutingOutcomeContext = {
+  cli: 'claude',
+  category: 'code_generation',
+  model: 'claude-sonnet-4-6',
+};
+
+describe('feedbackToRoutingOutcome (#3146)', () => {
+  it('produces a schema-valid routing TaskOutcome from a successful feedback outcome', () => {
+    const out = feedbackToRoutingOutcome(feedback(), ctx);
+    const parsed = TaskOutcomeSchema.safeParse(out);
+    expect(parsed.success).toBe(true);
+    expect(out).toMatchObject({
+      id: '11111111-1111-1111-1111-111111111111',
+      cli: 'claude',
+      category: 'code_generation',
+      model: 'claude-sonnet-4-6',
+      success: true,
+      source: 'delegate',
+    });
+    expect(out.failureCategory).toBeUndefined(); // no failureCategory on success
+  });
+
+  it('carries the feedback traceId into the routing outcome (cross-layer correlation)', () => {
+    expect(feedbackToRoutingOutcome(feedback({ traceId: 'corr-42' }), ctx).traceId).toBe('corr-42');
+  });
+
+  it('maps outcomeClass → failureCategory for failures', () => {
+    expect(failureCategoryFromOutcomeClass('timeout')).toBe('timeout');
+    expect(failureCategoryFromOutcomeClass('error')).toBe('execution');
+    expect(failureCategoryFromOutcomeClass('failure')).toBe('generic');
+    expect(failureCategoryFromOutcomeClass('success')).toBeUndefined();
+    expect(failureCategoryFromOutcomeClass('partial')).toBeUndefined();
+  });
+
+  it('sets failureCategory on a failed outcome and stays schema-valid', () => {
+    const out = feedbackToRoutingOutcome(
+      feedback({ success: false, outcomeClass: 'timeout', errorMessage: 'timed out' }),
+      ctx
+    );
+    expect(out.failureCategory).toBe('timeout');
+    expect(out.errorMessage).toBe('timed out');
+    expect(TaskOutcomeSchema.safeParse(out).success).toBe(true);
+  });
+
+  it('clips an over-long errorMessage to the routing schema max (500)', () => {
+    const out = feedbackToRoutingOutcome(
+      feedback({ success: false, outcomeClass: 'error', errorMessage: 'x'.repeat(900) }),
+      ctx
+    );
+    expect(out.errorMessage?.length).toBe(500);
+    expect(TaskOutcomeSchema.safeParse(out).success).toBe(true);
+  });
+
+  it('honours an explicit source', () => {
+    expect(feedbackToRoutingOutcome(feedback(), { ...ctx, source: 'consensus' }).source).toBe(
+      'consensus'
+    );
+  });
+});

--- a/packages/nexus-agents/src/learning/feedback-outcome-mapper.ts
+++ b/packages/nexus-agents/src/learning/feedback-outcome-mapper.ts
@@ -1,0 +1,81 @@
+/**
+ * Maps a feedback-layer `TaskOutcome` (learning) into a routing-layer
+ * `TaskOutcome` (orchestration/outcomes) so feedback outcomes can be recorded
+ * into the routing OutcomeStore for unified analysis (#3146, epic #3143 P1).
+ *
+ * The two `TaskOutcome` shapes are intentionally distinct layers and stay
+ * separately exported (see #3146 — no symbol collapse). This is a ONE-WAY,
+ * pure mapper: feedback outcomes carry no CLI/category/model, so those come
+ * from the routing decision via `RoutingOutcomeContext`. The feedback
+ * `traceId` is carried through, giving cross-layer correlation (it lands in
+ * the routing schema's optional `traceId` field added in PR-1 / #3281).
+ *
+ * @module learning/feedback-outcome-mapper
+ */
+
+import type { TaskOutcome as FeedbackTaskOutcome } from './outcome-feedback-types.js';
+import type {
+  TaskOutcome as RoutingTaskOutcome,
+  OutcomeFailureCategory,
+} from '../orchestration/outcomes/outcome-types.js';
+
+/** Routing-decision context the feedback outcome lacks (cli/category/model). */
+export interface RoutingOutcomeContext {
+  readonly cli: RoutingTaskOutcome['cli'];
+  readonly category: RoutingTaskOutcome['category'];
+  readonly model: string;
+  /** Outcome source; defaults to `delegate`. */
+  readonly source?: RoutingTaskOutcome['source'];
+}
+
+/**
+ * Map the feedback `outcomeClass` to a routing `failureCategory`. Returns
+ * undefined for non-failures (success/partial) — the routing schema omits
+ * `failureCategory` on successful outcomes.
+ */
+export function failureCategoryFromOutcomeClass(
+  outcomeClass: FeedbackTaskOutcome['outcomeClass']
+): OutcomeFailureCategory | undefined {
+  switch (outcomeClass) {
+    case 'timeout':
+      return 'timeout';
+    case 'error':
+      return 'execution';
+    case 'failure':
+      return 'generic';
+    case 'success':
+    case 'partial':
+      return undefined;
+  }
+}
+
+/**
+ * Convert a feedback `TaskOutcome` + routing context into a routing
+ * `TaskOutcome`. The result is schema-valid (`TaskOutcomeSchema`). Lossy by
+ * design: the feedback `qualitySignals` object and `qualityScore` have no
+ * routing-schema home and are dropped (routing `qualitySignals` is a string
+ * tag list, semantically different) — correlation is preserved via `traceId`.
+ */
+export function feedbackToRoutingOutcome(
+  feedback: FeedbackTaskOutcome,
+  context: RoutingOutcomeContext
+): RoutingTaskOutcome {
+  const failureCategory = feedback.success
+    ? undefined
+    : failureCategoryFromOutcomeClass(feedback.outcomeClass);
+  return {
+    id: feedback.routingDecisionId,
+    cli: context.cli,
+    category: context.category,
+    model: context.model,
+    success: feedback.success,
+    durationMs: feedback.durationMs,
+    timestamp: feedback.timestamp,
+    source: context.source ?? 'delegate',
+    traceId: feedback.traceId,
+    ...(failureCategory !== undefined ? { failureCategory } : {}),
+    ...(feedback.errorMessage !== undefined
+      ? { errorMessage: feedback.errorMessage.slice(0, 500) }
+      : {}),
+  };
+}


### PR DESCRIPTION
Second additive PR of the ratified P1 durable-substrate plan (epic #3143; re-ratified **7/7** after the MCP server rebuild to v2.92.4). Adds a pure one-way `feedbackToRoutingOutcome(feedback, context)` mapper in `learning/` so feedback outcomes can be recorded into the routing OutcomeStore for unified analysis — **carries `traceId` for cross-layer correlation** (uses PR-1/#3281's optional routing field). Two `TaskOutcome` types stay separately exported (no symbol collapse). Lossy fields documented; `errorMessage` clipped to schema max; output verified schema-valid. Placed in `learning/` to match the existing import direction (no cycle). Additive — no existing paths changed; consumer wiring is a follow-on. 6 tests; full suite green. Refs #3143, #3146.