### PR TITLE
feat(pipeline): shadow-mode TuneStage consumer core (#3147)

### DIFF
--- a/.changeset/p2-shadow-tune-stage.md
+++ b/.changeset/p2-shadow-tune-stage.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+feat(pipeline): shadow-mode TuneStage closes the signal loop (consumer core, #3147)
+
+Adds `signal.fitness_declined` / `signal.swarm_unhealthy` / `signal.vote_rejected`
+to the typed `PipelineEvent` union and a `createTuneStage` consumer that maps each
+signal to its bounded intended action. Ships dry-run first: it logs the intended
+action and mutates nothing; `enabled=true` fails closed (no-op) because the
+human-gated mutation path (#3147 PR-4) is not implemented and must not reuse the
+LinUCB real-outcome channel. Producers are wired after the event-bus unification
+(#3289). Unlike the removed #3022 learning.\* types, these ship WITH their consumer.

--- a/packages/nexus-agents/src/pipeline/event-types.ts
+++ b/packages/nexus-agents/src/pipeline/event-types.ts
@@ -35,6 +35,12 @@ export const PIPELINE_EVENT_TYPES = [
   'tool.completed',
   'wave.started',
   'wave.completed',
+  // Signal events (#3147 P2 — close the loop). Push-only producers (fitness
+  // audit, swarm health, consensus) emit these; the TuneStage consumes them.
+  // Unlike the #3022 learning.* types, these ship WITH their consumer.
+  'signal.fitness_declined',
+  'signal.swarm_unhealthy',
+  'signal.vote_rejected',
 ] as const;
 
 export type PipelineEventType = (typeof PIPELINE_EVENT_TYPES)[number];
@@ -167,6 +173,34 @@ interface RoutingDecisionEvent extends BaseEvent {
   readonly decisionPath?: readonly string[];
 }
 
+/** Signal events (#3147 P2 — close the loop). Consumed by the TuneStage. */
+interface FitnessDeclinedSignalEvent extends BaseEvent {
+  readonly type: 'signal.fitness_declined';
+  /** Current fitness score (0-100). */
+  readonly score: number;
+  /** Governance floor the score fell below. */
+  readonly floor: number;
+  /** Fitness dimension that declined, when attributable. */
+  readonly dimension?: string;
+}
+
+interface SwarmUnhealthySignalEvent extends BaseEvent {
+  readonly type: 'signal.swarm_unhealthy';
+  /** Agent/CLI whose health degraded. */
+  readonly agentId: string;
+  /** Human-readable degradation reason. */
+  readonly reason: string;
+}
+
+interface VoteRejectedSignalEvent extends BaseEvent {
+  readonly type: 'signal.vote_rejected';
+  readonly proposalId: string;
+  /** Approval percentage of the rejected vote (0-100). */
+  readonly approvalPercentage: number;
+  /** Rejection rule categories surfaced by voters. */
+  readonly rejectionRules?: readonly string[];
+}
+
 // `LearningThresholdUpdatedEvent` and `LearningTrendDetectedEvent`
 // (Issue #901 Phase 4) were removed in #3022 — the emit helpers
 // (`emitThresholdUpdate`, `emitTrendDetected`) never had a producer and
@@ -232,7 +266,10 @@ export type PipelineEvent =
   | ToolInvokedEvent
   | ToolCompletedEvent
   | WaveStartedEvent
-  | WaveCompletedEvent;
+  | WaveCompletedEvent
+  | FitnessDeclinedSignalEvent
+  | SwarmUnhealthySignalEvent
+  | VoteRejectedSignalEvent;
 
 // ============================================================================
 // Event Bus Interface

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the shadow-mode TuneStage (#3147, epic #3143 P2).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ILogger } from '../core/index.js';
+import { EventBus } from './event-bus.js';
+import type { PipelineEvent } from './event-types.js';
+import { createTuneStage, intendedActionFor } from './tune-stage.js';
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+const fitnessSignal: PipelineEvent = {
+  type: 'signal.fitness_declined',
+  timestamp: 1,
+  score: 62,
+  floor: 90,
+  dimension: 'security_review',
+};
+const voteSignal: PipelineEvent = {
+  type: 'signal.vote_rejected',
+  timestamp: 2,
+  proposalId: 'p-1',
+  approvalPercentage: 30,
+};
+
+describe('intendedActionFor (#3147)', () => {
+  it('maps each signal to its bounded action kind', () => {
+    expect(intendedActionFor(fitnessSignal)?.kind).toBe('flag_tech_debt');
+    expect(
+      intendedActionFor({
+        type: 'signal.swarm_unhealthy',
+        timestamp: 3,
+        agentId: 'gemini',
+        reason: 'timeouts',
+      })?.kind
+    ).toBe('downweight_agent');
+    expect(intendedActionFor(voteSignal)?.kind).toBe('record_rejection');
+  });
+
+  it('returns undefined for non-signal events', () => {
+    expect(
+      intendedActionFor({ type: 'task.created', timestamp: 4 } as PipelineEvent)
+    ).toBeUndefined();
+  });
+});
+
+describe('createTuneStage shadow mode (#3147)', () => {
+  it('logs the intended action and mutates nothing when a signal is emitted (default = shadow)', () => {
+    const bus = new EventBus();
+    const logger = spyLogger();
+    createTuneStage(bus, { logger });
+
+    bus.emit(fitnessSignal);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'TuneStage (shadow) — intended action',
+      expect.objectContaining({ kind: 'flag_tech_debt', signal: 'signal.fitness_declined' })
+    );
+    // shadow mode performs no mutating action — only an info log
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-signal events', () => {
+    const bus = new EventBus();
+    const logger = spyLogger();
+    createTuneStage(bus, { logger });
+    bus.emit({ type: 'task.created', timestamp: 9 } as PipelineEvent);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('enabled=true fails closed (logs no-op, does NOT mutate) — PR-4 not implemented', () => {
+    const bus = new EventBus();
+    const logger = spyLogger();
+    createTuneStage(bus, { logger, enabled: true });
+    bus.emit(voteSignal);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'TuneStage enabled but bounded mutation is not implemented yet; no-op',
+      expect.objectContaining({ kind: 'record_rejection' })
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe stops the stage', () => {
+    const bus = new EventBus();
+    const logger = spyLogger();
+    const unsub = createTuneStage(bus, { logger });
+    unsub();
+    bus.emit(fitnessSignal);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -1,0 +1,112 @@
+/**
+ * TuneStage — the consumer side of the closed loop (#3147, epic #3143 P2).
+ *
+ * Subscribes to the `signal.*` `PipelineEvent`s emitted by push-only producers
+ * (fitness audit, swarm health, consensus) and computes the BOUNDED tuning
+ * action each signal implies. It ships **shadow/dry-run first**: it only LOGS
+ * the intended action and mutates nothing. Actual parameter mutation (e.g.
+ * routing downweights) is a separate, human-gated step (#3147 PR-4) and must
+ * NOT reuse the LinUCB real-outcome channel (per the ratifying-vote dissent) —
+ * it needs a provenance-tagged mechanism, which is why this stage is dry-run
+ * only for now.
+ *
+ * Mirrors the proven `feedback-subscriber` pattern: a single `subscribe` over
+ * a typed filter, errors caught and logged, an `Unsubscribe` returned.
+ *
+ * @module pipeline/tune-stage
+ */
+
+import { createLogger, getErrorMessage } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+import type { PipelineEvent, IEventBus, Unsubscribe } from './event-types.js';
+
+const defaultLogger = createLogger({ component: 'TuneStage' });
+
+/** Signal event types the TuneStage reacts to. */
+export const TUNE_SIGNAL_TYPES = [
+  'signal.fitness_declined',
+  'signal.swarm_unhealthy',
+  'signal.vote_rejected',
+] as const;
+
+/** A bounded tuning action the loop WOULD take for a signal (described, not applied). */
+export interface IntendedTuneAction {
+  /** Action kind (stable key for audit/telemetry). */
+  readonly kind: 'flag_tech_debt' | 'downweight_agent' | 'record_rejection';
+  /** Human-readable description of the bounded action. */
+  readonly detail: string;
+  /** The signal type that triggered it. */
+  readonly signal: PipelineEvent['type'];
+}
+
+export interface TuneStageOptions {
+  /**
+   * When false (default), the stage is in SHADOW/dry-run mode: it logs the
+   * intended action and mutates nothing. `true` is reserved for the
+   * human-gated mutation path (#3147 PR-4), which is not implemented yet — so
+   * enabled mode currently fails closed (logs and no-ops) rather than acting.
+   */
+  readonly enabled?: boolean;
+  /** Injectable logger (defaults to the module logger). */
+  readonly logger?: ILogger;
+}
+
+/**
+ * Compute the bounded tuning action a signal implies. Pure — no side effects.
+ * Returns undefined for events the TuneStage doesn't act on.
+ */
+export function intendedActionFor(event: PipelineEvent): IntendedTuneAction | undefined {
+  switch (event.type) {
+    case 'signal.fitness_declined':
+      return {
+        kind: 'flag_tech_debt',
+        detail: `fitness ${String(event.score)} below floor ${String(event.floor)}${event.dimension !== undefined ? ` (dimension: ${event.dimension})` : ''} — would surface a tech-debt remediation signal`,
+        signal: event.type,
+      };
+    case 'signal.swarm_unhealthy':
+      return {
+        kind: 'downweight_agent',
+        detail: `agent ${event.agentId} unhealthy (${event.reason}) — would downweight it for routing (bounded, never zeroed)`,
+        signal: event.type,
+      };
+    case 'signal.vote_rejected':
+      return {
+        kind: 'record_rejection',
+        detail: `proposal ${event.proposalId} rejected at ${String(event.approvalPercentage)}% — would record a rejection signal for review`,
+        signal: event.type,
+      };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Subscribe the TuneStage to the signal events on `bus`. Returns an
+ * `Unsubscribe`. Shadow/dry-run by default — logs intended actions, mutates
+ * nothing.
+ */
+export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}): Unsubscribe {
+  const enabled = options.enabled ?? false;
+  const log = options.logger ?? defaultLogger;
+  return bus.subscribe({ type: [...TUNE_SIGNAL_TYPES] }, (event) => {
+    try {
+      const action = intendedActionFor(event);
+      if (action === undefined) return;
+      if (enabled) {
+        // #3147 PR-4 (human-gated) not implemented — fail closed, never mutate.
+        log.warn('TuneStage enabled but bounded mutation is not implemented yet; no-op', {
+          kind: action.kind,
+          signal: action.signal,
+        });
+        return;
+      }
+      log.info('TuneStage (shadow) — intended action', {
+        kind: action.kind,
+        signal: action.signal,
+        detail: action.detail,
+      });
+    } catch (e) {
+      log.warn('TuneStage handler error', { error: getErrorMessage(e) });
+    }
+  });
+}

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -85,6 +85,9 @@ export function intendedActionFor(event: PipelineEvent): IntendedTuneAction | un
  * `Unsubscribe`. Shadow/dry-run by default — logs intended actions, mutates
  * nothing.
  */
+// @export-no-consumer-yet — see #3147 (consumer core lands ahead of its
+// instantiation; the producers + bootstrap wiring are sequenced AFTER the
+// event-bus unification #3289, per the ratified consolidation program #3288).
 export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}): Unsubscribe {
   const enabled = options.enabled ?? false;
   const log = options.logger ?? defaultLogger;


### PR DESCRIPTION
## What

The consumer side of the closed loop (epic #3143 P2, #3147). Adds three `signal.*` types to the typed `PipelineEvent` union and a `createTuneStage` consumer that maps each signal to its bounded intended action.

- `signal.fitness_declined` → `flag_tech_debt`
- `signal.swarm_unhealthy` → `downweight_agent`
- `signal.vote_rejected` → `record_rejection`

## Safety posture (dry-run first)

- **Shadow mode (default):** logs the intended action, **mutates nothing**.
- `enabled=true` **fails closed** — logs a no-op warning, never mutates — because the human-gated mutation path (#3147 PR-4) is not built and must NOT reuse the LinUCB real-outcome channel (per the ratifying-vote dissent on provenance).
- Errors in the handler are caught + logged; `Unsubscribe` returned.

## Why ship the consumer before producers

Unlike the #3022 `learning.*` types (deleted because no subscriber ever landed), these ship **with** their consumer. Producers (fitness audit / swarm health / consensus emitting `signal.*`) are wired **after** the event-bus unification (#3289), which is the keystone consolidation item. This stage already subscribes to the canonical typed pipeline bus, so the bus decision does not invalidate it.

## Tests

`tune-stage.test.ts` — 6 tests: action mapping, shadow-logs-only, ignores non-signals, enabled-fails-closed, unsubscribe. Typecheck + lint clean.

Closes part of #3147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)