### PR TITLE
refactor(pipeline): rename evaluatePolicy to evaluatePipelinePolicy (#3194)

### DIFF
--- a/.changeset/rename-pipeline-evaluate-policy.md
+++ b/.changeset/rename-pipeline-evaluate-policy.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+refactor(pipeline): name the pipeline policy fn evaluatePipelinePolicy at source (#3194)
+
+The pipeline `policy-evaluator` function was named `evaluatePolicy`, colliding with
+the unrelated MCP-middleware `evaluatePolicy`. The public `exports/pipeline.ts`
+already aliased it to `evaluatePipelinePolicy` to dodge the clash; this renames the
+source function so the alias hack is gone and the symbol is unambiguous in-tree.
+No public API change (the exported name is unchanged).

--- a/packages/nexus-agents/src/exports/pipeline.ts
+++ b/packages/nexus-agents/src/exports/pipeline.ts
@@ -97,7 +97,7 @@ export {
   type EventBusBridgeOptions,
   type PipelineBridgeResult,
   // Policy evaluator (Issue #923, Phase D)
-  evaluatePolicy as evaluatePipelinePolicy, // Renamed: mcp.ts exports evaluatePolicy
+  evaluatePipelinePolicy, // distinct from mcp.ts's evaluatePolicy (source fn now explicitly named, #3194)
   getPolicyMode,
   type PolicyMode as PipelinePolicyMode, // Renamed: mcp.ts exports PolicyMode
   type PolicyEvaluatorOptions,

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -132,7 +132,7 @@ export {
 } from './event-bus-bridge.js';
 
 export {
-  evaluatePolicy,
+  evaluatePipelinePolicy,
   getPolicyMode,
   type PolicyMode,
   type PolicyEvaluatorOptions,

--- a/packages/nexus-agents/src/pipeline/policy-evaluator.test.ts
+++ b/packages/nexus-agents/src/pipeline/policy-evaluator.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { PolicyEngine } from './policy-engine.js';
 import { EventBus } from './event-bus.js';
-import { evaluatePolicy, getPolicyMode } from './policy-evaluator.js';
+import { evaluatePipelinePolicy, getPolicyMode } from './policy-evaluator.js';
 import type { PolicyContext, PolicyRule } from './policy-engine.js';
 
 // ============================================================================
@@ -44,7 +44,7 @@ function createPassingRule(id: string): PolicyRule {
 // Tests
 // ============================================================================
 
-describe('evaluatePolicy', () => {
+describe('evaluatePipelinePolicy', () => {
   let engine: PolicyEngine;
   let eventBus: EventBus;
   const ctx = createContext();
@@ -57,14 +57,14 @@ describe('evaluatePolicy', () => {
   it('returns allowed with no violations when all rules pass', () => {
     engine.registerRule(createPassingRule('r1'));
     engine.registerRule(createPassingRule('r2'));
-    const result = evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
     expect(result.allowed).toBe(true);
     expect(result.violations).toHaveLength(0);
   });
 
   it('WARN mode: returns allowed=true even with violations', () => {
     engine.registerRule(createBlockingRule('r1'));
-    const result = evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
     expect(result.allowed).toBe(true);
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0]!.ruleId).toBe('r1');
@@ -72,7 +72,7 @@ describe('evaluatePolicy', () => {
 
   it('BLOCK mode: returns allowed=false on violations', () => {
     engine.registerRule(createBlockingRule('r1'));
-    const result = evaluatePolicy({ engine, eventBus, mode: 'block' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'block' }, ctx);
     expect(result.allowed).toBe(false);
     expect(result.violations).toHaveLength(1);
   });
@@ -80,7 +80,7 @@ describe('evaluatePolicy', () => {
   it('OFF mode: skips evaluation entirely', () => {
     const spy = vi.fn(() => ({ allow: true as const }));
     engine.registerRule({ id: 'spy-rule', priority: 50, evaluate: spy });
-    const result = evaluatePolicy({ engine, eventBus, mode: 'off' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'off' }, ctx);
     expect(result.allowed).toBe(true);
     expect(result.violations).toHaveLength(0);
     expect(spy).not.toHaveBeenCalled();
@@ -90,7 +90,7 @@ describe('evaluatePolicy', () => {
     engine.registerRule(createBlockingRule('r1'));
     engine.registerRule(createBlockingRule('r2'));
     engine.registerRule(createPassingRule('r3'));
-    const result = evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
     expect(result.violations).toHaveLength(2);
     const ids = result.violations.map((v) => v.ruleId);
     expect(ids).toContain('r1');
@@ -99,7 +99,7 @@ describe('evaluatePolicy', () => {
 
   it('emits policy.evaluated events on violations', () => {
     engine.registerRule(createBlockingRule('r1'));
-    evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
     const events = eventBus.query({ type: 'policy.evaluated' });
     expect(events).toHaveLength(1);
     const event = events[0]!;
@@ -108,13 +108,13 @@ describe('evaluatePolicy', () => {
 
   it('does not emit events when no violations', () => {
     engine.registerRule(createPassingRule('r1'));
-    evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
     expect(eventBus.query({ type: 'policy.evaluated' })).toHaveLength(0);
   });
 
   it('works without eventBus', () => {
     engine.registerRule(createBlockingRule('r1'));
-    const result = evaluatePolicy({ engine, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, mode: 'warn' }, ctx);
     expect(result.allowed).toBe(true);
     expect(result.violations).toHaveLength(1);
   });
@@ -125,14 +125,14 @@ describe('evaluatePolicy', () => {
       priority: 50,
       evaluate: () => ({ allow: false, reason: 'needs user', escalateTo: 'user' }),
     });
-    const result = evaluatePolicy({ engine, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, mode: 'warn' }, ctx);
     expect(result.violations[0]!.escalateTo).toBe('user');
   });
 
   it('returns correct mode in result', () => {
-    const r1 = evaluatePolicy({ engine, mode: 'warn' }, ctx);
-    const r2 = evaluatePolicy({ engine, mode: 'block' }, ctx);
-    const r3 = evaluatePolicy({ engine, mode: 'off' }, ctx);
+    const r1 = evaluatePipelinePolicy({ engine, mode: 'warn' }, ctx);
+    const r2 = evaluatePipelinePolicy({ engine, mode: 'block' }, ctx);
+    const r3 = evaluatePipelinePolicy({ engine, mode: 'off' }, ctx);
     expect(r1.mode).toBe('warn');
     expect(r2.mode).toBe('block');
     expect(r3.mode).toBe('off');
@@ -148,7 +148,7 @@ describe('evaluatePolicy', () => {
     });
     engine.registerRule(createPassingRule('passes'));
 
-    const result = evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
 
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0]!.ruleId).toBe('throws');
@@ -166,7 +166,7 @@ describe('evaluatePolicy', () => {
     });
     engine.registerRule({ id: 'later', priority: 50, evaluate: laterRule });
 
-    evaluatePolicy({ engine, eventBus, mode: 'warn' }, ctx);
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn' }, ctx);
 
     expect(laterRule).toHaveBeenCalledOnce();
   });
@@ -179,7 +179,7 @@ describe('evaluatePolicy', () => {
         throw new Error('boom');
       },
     });
-    const result = evaluatePolicy({ engine, eventBus, mode: 'block' }, ctx);
+    const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'block' }, ctx);
     expect(result.allowed).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/pipeline/policy-evaluator.ts
+++ b/packages/nexus-agents/src/pipeline/policy-evaluator.ts
@@ -65,7 +65,7 @@ export function getPolicyMode(): PolicyMode {
  * In BLOCK mode, violations halt the pipeline.
  * In OFF mode, evaluation is skipped entirely.
  */
-export function evaluatePolicy(
+export function evaluatePipelinePolicy(
   options: PolicyEvaluatorOptions,
   context: PolicyContext
 ): PolicyEvalResult {

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -18,7 +18,7 @@ import { createLogger } from '../core/index.js';
 import { PipelineRunner } from './pipeline-runner.js';
 import { getPipelineEventBus } from './event-bus.js';
 import { createDefaultPolicyEngine, type PipelineStateSnapshot } from './policy-engine.js';
-import { evaluatePolicy, getPolicyMode } from './policy-evaluator.js';
+import { evaluatePipelinePolicy, getPolicyMode } from './policy-evaluator.js';
 
 /**
  * Narrows the untyped `task.metadata` bag into the policy engine's typed
@@ -178,7 +178,7 @@ export function checkPipelinePolicy(task: TaskContract, stageType: string): Poli
     pipelineState: toPipelineStateSnapshot(task.metadata),
   };
 
-  const result = evaluatePolicy({ engine, mode }, context);
+  const result = evaluatePipelinePolicy({ engine, mode }, context);
   if (!result.allowed) {
     logger.warn('Pipeline blocked by policy', {
       taskId: task.id,


### PR DESCRIPTION
## What

Consolidation quick-win (#3194, epic #3288). The pipeline `policy-evaluator` exported `evaluatePolicy`, which collides by name with the unrelated MCP-middleware `evaluatePolicy`. `exports/pipeline.ts` already aliased it (`evaluatePolicy as evaluatePipelinePolicy`) to dodge the clash — this renames the **source** function so the alias hack disappears and the in-tree symbol is unambiguous.

## Blast radius (internal only)

`policy-evaluator.ts` (def) · `v2-delegate.ts` (caller) · `pipeline/index.ts` (barrel) · `policy-evaluator.test.ts` · drops the alias in `exports/pipeline.ts`. **No public API change** — the exported name was already `evaluatePipelinePolicy`.

## Verify

Typecheck clean · 17 policy-evaluator tests pass · lint clean.

Part of epic #3288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)