### PR TITLE
feat(consensus): close the self-tuning loop for rejected votes (#3147)

### DIFF
--- a/.changeset/signal-vote-rejected-producer.md
+++ b/.changeset/signal-vote-rejected-producer.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(consensus): close the self-tuning loop for rejected votes (#3147)
+
+Wires the first `signal.*` producer onto the typed pipeline bus per the #3289
+narrow-merge scope: when a `consensus_vote` resolves to `rejected`, the MCP
+handler emits `signal.vote_rejected` (proposalId, approvalPercentage, distinct
+rejectionRules) via the new `consensus-vote-signals` emitter. The shadow
+`TuneStage` is now instantiated at server init (`startTuneStage`, paired with
+`shutdownTuneStage`), so the loop is closed end-to-end in shadow mode (logs the
+intended `record_rejection` action, mutates nothing). The emitter lives at the
+MCP layer to keep the consensus engine decoupled from the pipeline bus
+(A=observability / B=messaging boundary, documented in EVENT_BUS_BOUNDARIES.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ Detailed technical documentation:
 | [CONTEXT_LOAD_BALANCING.md](./architecture/CONTEXT_LOAD_BALANCING.md)             | Claude/Gemini/Codex routing    | Canonical |
 | [SECURITY.md](./architecture/SECURITY.md)                                         | Security model, sandboxing     | Canonical |
 | [MCP_PROTOCOL.md](./architecture/MCP_PROTOCOL.md)                                 | MCP integration details        | Canonical |
+| [EVENT_BUS_BOUNDARIES.md](./architecture/EVENT_BUS_BOUNDARIES.md)                 | Observability vs messaging bus | Canonical |
 | [ORCHESTRATOR_WORKFLOW_ENGINE.md](./architecture/ORCHESTRATOR_WORKFLOW_ENGINE.md) | Orchestrator vs WorkflowEngine | Canonical |
 | [ICTM_PATTERN.md](./architecture/ICTM_PATTERN.md)                                 | Dynamic sub-agent creation     | Canonical |
 | [UNTRUSTED_INPUT_HARDENING.md](./architecture/UNTRUSTED_INPUT_HARDENING.md)       | Input trust & sanitization     | Canonical |

--- a/docs/architecture/EVENT_BUS_BOUNDARIES.md
+++ b/docs/architecture/EVENT_BUS_BOUNDARIES.md
@@ -1,0 +1,59 @@
+# Event Bus Boundaries
+
+Nexus-agents has **two** event bus implementations, kept deliberately separate.
+This document records that boundary as an intentional architectural decision
+(consolidation epic #3288, item #3289, scope Option 2) so the two are not
+mistaken for redundant implementations to be merged.
+
+## The two buses
+
+| Bus                   | Module                                                    | Role                                     | Semantics                                                                                                                                        |
+| --------------------- | --------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **A — Observability** | `pipeline/event-bus.ts` (`getPipelineEventBus`)           | Typed pipeline telemetry, query, metrics | Discriminated-union `PipelineEvent`, **synchronous** emit, bounded `CircularBuffer` history, typed-filter query. No topics, wildcards, or async. |
+| **B — Messaging**     | `agents/collaboration/event-bus.ts` (`getGlobalEventBus`) | Agent-to-agent pub/sub coordination      | `DomainEvent` envelope, **topic-pattern + wildcard** subscription, `emitAsync`, correlation IDs, history.                                        |
+
+`core/event-bus.ts` is a **pure re-export** of bus B under a stable import path
+— not a third bus. Two bridges (`pipeline/event-bus-bridge.ts`,
+`mcp/eventbus-bridge.ts`) translate between A and B where a cross-layer hop is
+genuinely required.
+
+## Why they stay separate
+
+They serve different concerns. A is a **typed observability surface**:
+producers emit strongly-typed events that consumers query for metrics and
+self-tuning. B is a **messaging substrate**: agents subscribe to topic
+patterns and receive asynchronous, correlated domain events.
+
+A full merge was evaluated and rejected for the near term (the #3289
+confirmation vote came back 12-0 substantive across two runs):
+
+- Bus B has 27 consumers that depend on topic-wildcard subscription,
+  `emitAsync`, and the `DomainEvent` envelope — none of which bus A provides.
+  Forcing them onto A would be a capability regression, not a consolidation.
+- Physically relocating B's implementation is already **v3.0-gated** (a soft
+  dependency from `event-bus-events.ts` on `collaboration-types.ts` must be
+  decoupled first).
+
+A full unification therefore remains a separately-votable, v3.0-gated item.
+
+## The authority rule
+
+**Bus A is authoritative for observability signals.** When a subsystem needs to
+surface an observability signal (for example the `signal.*` events that close
+the self-tuning loop — see epic #3143 P2 / #3147), it emits onto bus A. Do
+**not** pull bus B's messaging semantics (topics, async, `DomainEvent`) into
+bus A to make this work — that would be a merge by stealth. Keep observability
+narrow and typed.
+
+## Signal events on bus A
+
+The self-tuning loop routes its signals through bus A as typed events:
+
+- `signal.fitness_declined` — emitted when a fitness score falls below floor.
+- `signal.swarm_unhealthy` — emitted when an agent/CLI's health degrades.
+- `signal.vote_rejected` — emitted from the `consensus_vote` MCP handler when a
+  vote resolves to `rejected` (see `mcp/tools/consensus-vote-signals.ts`).
+
+The shadow `TuneStage` (`pipeline/tune-stage.ts`) subscribes to these and logs
+the bounded action each implies. It is wired at server init
+(`cli-server-tools.ts`) and released at shutdown (`cli-server.ts`).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -32,6 +32,7 @@ related_files:
 | Input Hardening | This file | [UNTRUSTED_INPUT_HARDENING.md](./UNTRUSTED_INPUT_HARDENING.md) |
 | MCP             | This file | [MCP_PROTOCOL.md](./MCP_PROTOCOL.md)                           |
 | Observability   | This file | [SWARM_OBSERVER_DESIGN.md](./SWARM_OBSERVER_DESIGN.md)         |
+| Event Buses     | This file | [EVENT_BUS_BOUNDARIES.md](./EVENT_BUS_BOUNDARIES.md)           |
 | SWE-Bench       | This file | [SWE_BENCH_HARNESS.md](./SWE_BENCH_HARNESS.md)                 |
 | ICTM Pattern    | This file | [ICTM_PATTERN.md](./ICTM_PATTERN.md)                           |
 | Multi-Repo      | This file | [MULTI_REPO_ORCHESTRATION.md](./MULTI_REPO_ORCHESTRATION.md)   |

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -73,6 +73,7 @@ import { getPipelinePluginRegistry } from './pipeline/core-plugins.js';
 import { getPipelineEventBus } from './pipeline/event-bus.js';
 import { createEventBusBridge } from './pipeline/event-bus-bridge.js';
 import { startFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
+import { startTuneStage } from './pipeline/tune-stage.js';
 import { getOutcomeStore } from './orchestration/outcomes/index.js';
 import { createDefaultPolicyEngine } from './pipeline/policy-engine.js';
 import { resolveV2Config } from './pipeline/v2-config.js';
@@ -614,6 +615,11 @@ function initV2PipelineSubsystems(logger: ILogger): void {
   // OutcomeStore via this path. Cleanup runs in
   // cli-server.ts:createShutdownCleanup via `shutdownFeedbackSubscriber()`.
   startFeedbackSubscriber(pipelineEventBus, getOutcomeStore());
+  // Close the self-tuning loop's consumer side: the shadow TuneStage subscribes
+  // to signal.* events on the same typed bus (#3147; #3289 Option 2). Shadow
+  // mode — logs intended actions, mutates nothing. Paired with
+  // shutdownTuneStage() in cli-server.ts:createShutdownCleanup.
+  startTuneStage(pipelineEventBus);
   const policyEngine = createDefaultPolicyEngine();
   const v2Config = resolveV2Config();
   logger.info('V2 Pipeline OS initialized', {

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -51,6 +51,7 @@ import { initializeAuth } from './cli-server-auth.js';
 import { shutdownToolMemory } from './mcp/tools/tool-memory.js';
 import { shutdownExpertBridge } from './pipeline/expert-bridge.js';
 import { shutdownFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
+import { shutdownTuneStage } from './pipeline/tune-stage.js';
 import {
   initializeAuditLogger,
   shutdownAuditLogger,
@@ -236,6 +237,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Release the EventBus → OutcomeStore feedback subscription (closes #2938)
     shutdownFeedbackSubscriber();
+
+    // Release the shadow TuneStage signal subscription (#3147)
+    shutdownTuneStage();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-signals.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-signals.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the consensus → pipeline-bus signal emitter (#3147, epic #3143 P2;
+ * scope per #3289 Option 2 — observability signals route through the typed bus).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ILogger } from '../../core/index.js';
+import type { ConsensusResult } from '../../consensus/types.js';
+import type { Vote } from '../../consensus/types.js';
+import type {
+  PipelineEvent,
+  IEventBus,
+  EventFilter,
+  EventHandler,
+} from '../../pipeline/event-types.js';
+import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
+import { EventBus } from '../../pipeline/event-bus.js';
+import { startTuneStage, shutdownTuneStage } from '../../pipeline/tune-stage.js';
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+/** Minimal capturing bus. */
+function captureBus(emitImpl?: (e: PipelineEvent) => void): {
+  bus: IEventBus;
+  emitted: PipelineEvent[];
+} {
+  const emitted: PipelineEvent[] = [];
+  const bus: IEventBus = {
+    emit: (e: PipelineEvent) => {
+      if (emitImpl) emitImpl(e);
+      emitted.push(e);
+    },
+    subscribe: (_f: EventFilter, _h: EventHandler) => () => undefined,
+    query: () => [],
+    get totalEmitted() {
+      return emitted.length;
+    },
+    get bufferSize() {
+      return emitted.length;
+    },
+  };
+  return { bus, emitted };
+}
+
+function vote(decision: Vote['decision'], rejectionCategories?: Vote['rejectionCategories']): Vote {
+  return {
+    decision,
+    reasoning: 'because',
+    confidence: 0.8,
+    ...(rejectionCategories !== undefined ? { rejectionCategories } : {}),
+  };
+}
+
+function makeResult(
+  outcome: ConsensusResult['outcome'],
+  votes: Map<string, Vote> = new Map()
+): ConsensusResult {
+  return {
+    proposalId: 'prop-1',
+    proposal: { title: 't', description: 'd', algorithm: 'simple_majority' },
+    outcome,
+    votes,
+    voteCounts: { approve: 0, reject: 1, abstain: 0, total: 1 },
+    approvalPercentage: 25,
+    quorumReached: true,
+    startedAt: '2026-06-01T00:00:00Z',
+    closedAt: '2026-06-01T00:00:01Z',
+    durationMs: 1000,
+  };
+}
+
+describe('emitVoteRejectedSignal (#3147)', () => {
+  it('emits signal.vote_rejected with proposalId + approvalPercentage when outcome is rejected', () => {
+    const { bus, emitted } = captureBus();
+    emitVoteRejectedSignal(makeResult('rejected'), bus, spyLogger());
+    expect(emitted).toHaveLength(1);
+    const ev = emitted[0];
+    expect(ev?.type).toBe('signal.vote_rejected');
+    if (ev?.type === 'signal.vote_rejected') {
+      expect(ev.proposalId).toBe('prop-1');
+      expect(ev.approvalPercentage).toBe(25);
+    }
+  });
+
+  it('collects distinct rejectionRules from the reject votes', () => {
+    const votes = new Map<string, Vote>([
+      ['a', vote('reject', ['SCOPE_CREEP', 'SECURITY_RISK'])],
+      ['b', vote('reject', ['SCOPE_CREEP'])],
+      ['c', vote('approve')],
+    ]);
+    const { emitted, bus } = captureBus();
+    emitVoteRejectedSignal(makeResult('rejected', votes), bus, spyLogger());
+    const ev = emitted[0];
+    if (ev?.type === 'signal.vote_rejected') {
+      expect(ev.rejectionRules).toEqual(expect.arrayContaining(['SCOPE_CREEP', 'SECURITY_RISK']));
+      expect(ev.rejectionRules).toHaveLength(2); // distinct
+    } else {
+      throw new Error('expected signal.vote_rejected');
+    }
+  });
+
+  it('is a no-op when the outcome is not rejected', () => {
+    const { emitted, bus } = captureBus();
+    emitVoteRejectedSignal(makeResult('approved'), bus, spyLogger());
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('swallows + logs a bus.emit error (emission must never break the vote path)', () => {
+    const logger = spyLogger();
+    const { bus } = captureBus(() => {
+      throw new Error('bus boom');
+    });
+    expect(() => {
+      emitVoteRejectedSignal(makeResult('rejected'), bus, logger);
+    }).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to emit signal.vote_rejected',
+      expect.objectContaining({ error: expect.stringContaining('bus boom') })
+    );
+  });
+});
+
+describe('end-to-end: rejected vote → signal → shadow TuneStage (#3147 loop closure)', () => {
+  afterEach(() => {
+    shutdownTuneStage(); // release the module-level subscription between tests
+  });
+
+  it('a rejected vote emitted on the typed bus is consumed by the wired TuneStage in shadow mode', () => {
+    const bus = new EventBus();
+    const tuneLogger = spyLogger();
+    startTuneStage(bus, { logger: tuneLogger });
+
+    emitVoteRejectedSignal(makeResult('rejected'), bus, spyLogger());
+
+    expect(tuneLogger.info).toHaveBeenCalledWith(
+      'TuneStage (shadow) — intended action',
+      expect.objectContaining({ kind: 'record_rejection', signal: 'signal.vote_rejected' })
+    );
+  });
+
+  it('startTuneStage is idempotent and shutdownTuneStage releases the subscription', () => {
+    const bus = new EventBus();
+    const tuneLogger = spyLogger();
+    startTuneStage(bus, { logger: tuneLogger });
+    startTuneStage(bus, { logger: tuneLogger }); // second call is a no-op (still one subscription)
+    expect(bus.subscriptionCount).toBe(1);
+
+    shutdownTuneStage();
+    emitVoteRejectedSignal(makeResult('rejected'), bus, spyLogger());
+    expect(tuneLogger.info).not.toHaveBeenCalled(); // unsubscribed → no consumption
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-signals.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-signals.ts
@@ -1,0 +1,54 @@
+/**
+ * Consensus → pipeline-bus signal emitter (#3147, epic #3143 P2).
+ *
+ * Emits the `signal.vote_rejected` observability signal onto the typed pipeline
+ * event bus when a consensus vote resolves to `rejected`, closing the
+ * self-tuning loop (the shadow TuneStage consumes it). Lives at the MCP
+ * integration layer ON PURPOSE: the pure `ConsensusEngine` stays decoupled from
+ * the pipeline bus, preserving the `A = observability / B = messaging` boundary
+ * adopted for #3289 (scope Option 2 — observability signals route through bus A,
+ * the collaboration messaging bus is untouched).
+ *
+ * @module mcp/tools/consensus-vote-signals
+ */
+
+import { getErrorMessage, getTimeProvider } from '../../core/index.js';
+import type { ILogger } from '../../core/index.js';
+import type { ConsensusResult } from '../../consensus/types.js';
+import type { IEventBus } from '../../pipeline/event-types.js';
+
+/** Distinct rejection categories across the reject votes, or undefined if none. */
+function rejectionRulesFrom(result: ConsensusResult): readonly string[] | undefined {
+  const rules = new Set<string>();
+  for (const vote of result.votes.values()) {
+    if (vote.decision === 'reject' && vote.rejectionCategories !== undefined) {
+      for (const category of vote.rejectionCategories) rules.add(category);
+    }
+  }
+  return rules.size > 0 ? [...rules] : undefined;
+}
+
+/**
+ * Emit `signal.vote_rejected` onto `bus` when `result.outcome === 'rejected'`.
+ * No-op for any other outcome. Emission errors are swallowed and logged —
+ * observability signalling must never break the vote path.
+ */
+export function emitVoteRejectedSignal(
+  result: ConsensusResult,
+  bus: IEventBus,
+  logger: ILogger
+): void {
+  if (result.outcome !== 'rejected') return;
+  try {
+    const rejectionRules = rejectionRulesFrom(result);
+    bus.emit({
+      type: 'signal.vote_rejected',
+      timestamp: getTimeProvider().now(),
+      proposalId: result.proposalId,
+      approvalPercentage: result.approvalPercentage,
+      ...(rejectionRules !== undefined ? { rejectionRules } : {}),
+    });
+  } catch (error) {
+    logger.warn('Failed to emit signal.vote_rejected', { error: getErrorMessage(error) });
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -52,6 +52,8 @@ import {
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import { recordVoteSuccess, recordVoteError } from './consensus-vote-recording.js';
+import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
+import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 // #3045 / epic #2631 Stage 4 — async-mode dispatch + concurrency cap.
@@ -638,6 +640,9 @@ async function handleConsensusVote(
       result.totalTimeMs,
       result.votes
     );
+    // Close the self-tuning loop: a rejected vote emits signal.vote_rejected
+    // onto the typed pipeline bus for the shadow TuneStage (#3147; #3289 Option 2).
+    emitVoteRejectedSignal(result.result, getPipelineEventBus(), logger);
     return { ok: true, value: buildResponse(args, result) };
   } catch (error) {
     const message = getErrorMessage(error);

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -85,9 +85,6 @@ export function intendedActionFor(event: PipelineEvent): IntendedTuneAction | un
  * `Unsubscribe`. Shadow/dry-run by default — logs intended actions, mutates
  * nothing.
  */
-// @export-no-consumer-yet — see #3147 (consumer core lands ahead of its
-// instantiation; the producers + bootstrap wiring are sequenced AFTER the
-// event-bus unification #3289, per the ratified consolidation program #3288).
 export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}): Unsubscribe {
   const enabled = options.enabled ?? false;
   const log = options.logger ?? defaultLogger;
@@ -112,4 +109,31 @@ export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}):
       log.warn('TuneStage handler error', { error: getErrorMessage(e) });
     }
   });
+}
+
+// ============================================================================
+// Server-wide lifecycle (#3147) — mirrors feedback-subscriber.ts start/shutdown
+//
+// cli-server-tools.ts:initV2PipelineSubsystems calls startTuneStage() at server
+// init, paired with shutdownTuneStage() in cli-server.ts:createShutdownCleanup.
+// ============================================================================
+
+let cachedTuneUnsubscribe: Unsubscribe | null = null;
+
+/**
+ * Wire the shadow TuneStage to the pipeline bus for the process lifetime.
+ * Idempotent — repeated calls are no-ops. Caller must invoke
+ * `shutdownTuneStage()` on server shutdown to release the subscription.
+ */
+export function startTuneStage(bus: IEventBus, options?: TuneStageOptions): void {
+  if (cachedTuneUnsubscribe !== null) return;
+  cachedTuneUnsubscribe = createTuneStage(bus, options);
+}
+
+/** Release the server-wide TuneStage subscription. Idempotent. */
+export function shutdownTuneStage(): void {
+  if (cachedTuneUnsubscribe !== null) {
+    cachedTuneUnsubscribe();
+    cachedTuneUnsubscribe = null;
+  }
 }


### PR DESCRIPTION
## What

First `signal.*` **producer** wired per the #3289 narrow-merge scope (epic #3143 P2, #3147). Closes the self-tuning loop end-to-end for rejected votes, in shadow mode.

- **Producer:** new `mcp/tools/consensus-vote-signals.ts` — `emitVoteRejectedSignal(result, bus, logger)` emits `signal.vote_rejected` (`proposalId`, `approvalPercentage`, distinct `rejectionRules` from reject votes) when a `consensus_vote` resolves to `rejected`. Called from `handleConsensusVote` after `recordVoteSuccess`.
- **Consumer wired:** the shadow `TuneStage` is now instantiated at server init via `startTuneStage` (`cli-server-tools.ts`), released via `shutdownTuneStage` (`cli-server.ts`) — mirroring the feedback-subscriber lifecycle. This **retires the `@export-no-consumer-yet` marker** from #3301.
- **Boundary doc:** `docs/architecture/EVENT_BUS_BOUNDARIES.md` documents `A=observability / B=messaging` as an intentional, v3.0-gated boundary (panel condition).

## Honoring the #3289 panel conditions

- **Emitter at the MCP layer** keeps the pure `ConsensusEngine` decoupled from the pipeline bus — no "merge by stealth" of messaging semantics into bus A.
- **Shadow mode only** — `TuneStage` logs the intended `record_rejection` action, mutates nothing. Emission errors are swallowed + logged (never breaks the vote path).
- **Authority rule** documented: bus A is authoritative for observability signals.
- One signal per step — `signal.fitness_declined` and `signal.swarm_unhealthy` follow as separate PRs (see #3147).

## Tests (TDD)

`consensus-vote-signals.test.ts` (6): emit-on-rejected, distinct rejectionRules, no-op-on-approved, error-swallowing, **end-to-end** (rejected vote → signal on typed bus → wired TuneStage logs `record_rejection`), start/shutdown idempotency. The 70 existing `consensus-vote.test.ts` tests still pass (non-breaking wiring). Typecheck + lint + markdownlint + new-export gate all clean. **82 tests pass.**

Part of #3147 / epic #3143 / epic #3288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)