### PR TITLE
feat(improvement-review): emit signal.fitness_declined (#3147)

### DIFF
--- a/.changeset/signal-fitness-declined-producer.md
+++ b/.changeset/signal-fitness-declined-producer.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+feat(improvement-review): emit signal.fitness_declined to close the tune loop (#3147)
+
+Second `signal.*` producer per the #3289 narrow-merge scope: when the
+`improvement_review` MCP tool's fitness audit falls below the governance floor,
+it emits `signal.fitness_declined` (score, floor, worst-offending dimension)
+onto the typed pipeline bus, where the shadow TuneStage consumes it
+(`flag_tech_debt`). Emitter lives at the MCP layer (server context, live
+consumer) to keep `governance/fitness-score` decoupled from the bus
+(A=observability / B=messaging).

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-signals.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-signals.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the improvement_review → pipeline-bus fitness signal emitter
+ * (#3147, epic #3143 P2; scope per #3289 Option 2 — observability signals route
+ * through the typed pipeline bus).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ILogger } from '../../core/index.js';
+import type { FitnessAudit, FitnessFinding } from '../../governance/fitness-score.js';
+import type {
+  PipelineEvent,
+  IEventBus,
+  EventFilter,
+  EventHandler,
+} from '../../pipeline/event-types.js';
+import { emitFitnessDeclinedSignal } from './improvement-review-signals.js';
+import { EventBus } from '../../pipeline/event-bus.js';
+import { startTuneStage, shutdownTuneStage } from '../../pipeline/tune-stage.js';
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+function captureBus(emitImpl?: (e: PipelineEvent) => void): {
+  bus: IEventBus;
+  emitted: PipelineEvent[];
+} {
+  const emitted: PipelineEvent[] = [];
+  const bus: IEventBus = {
+    emit: (e: PipelineEvent) => {
+      if (emitImpl) emitImpl(e);
+      emitted.push(e);
+    },
+    subscribe: (_f: EventFilter, _h: EventHandler) => () => undefined,
+    query: () => [],
+    get totalEmitted() {
+      return emitted.length;
+    },
+    get bufferSize() {
+      return emitted.length;
+    },
+  };
+  return { bus, emitted };
+}
+
+function audit(score: number, findings: readonly FitnessFinding[] = []): FitnessAudit {
+  return {
+    score,
+    dimensions: {
+      canonicalPaths: 20,
+      explicitBehavior: 15,
+      determinism: 15,
+      observability: 15,
+      configSimplicity: 10,
+      layerSeparation: 10,
+      operatorErgonomics: 10,
+      governanceIntegration: 5,
+    },
+    findings,
+    timestamp: '2026-06-01T00:00:00Z',
+    version: 'test',
+  };
+}
+
+function finding(dimension: FitnessFinding['dimension'], pointsDeducted: number): FitnessFinding {
+  return { dimension, severity: 'warning', description: 'd', pointsDeducted };
+}
+
+describe('emitFitnessDeclinedSignal (#3147)', () => {
+  it('emits signal.fitness_declined with score + floor when score is below floor', () => {
+    const { bus, emitted } = captureBus();
+    emitFitnessDeclinedSignal(audit(62), 90, bus, spyLogger());
+    expect(emitted).toHaveLength(1);
+    const ev = emitted[0];
+    if (ev?.type === 'signal.fitness_declined') {
+      expect(ev.score).toBe(62);
+      expect(ev.floor).toBe(90);
+    } else {
+      throw new Error('expected signal.fitness_declined');
+    }
+  });
+
+  it('attributes the worst-offending dimension (max points deducted)', () => {
+    const { emitted, bus } = captureBus();
+    emitFitnessDeclinedSignal(
+      audit(60, [finding('observability', 3), finding('layerSeparation', 8)]),
+      90,
+      bus,
+      spyLogger()
+    );
+    const ev = emitted[0];
+    if (ev?.type === 'signal.fitness_declined') {
+      expect(ev.dimension).toBe('layerSeparation');
+    } else {
+      throw new Error('expected signal.fitness_declined');
+    }
+  });
+
+  it('omits dimension when there are no findings', () => {
+    const { emitted, bus } = captureBus();
+    emitFitnessDeclinedSignal(audit(80), 90, bus, spyLogger());
+    const ev = emitted[0];
+    if (ev?.type === 'signal.fitness_declined') {
+      expect(ev.dimension).toBeUndefined();
+    } else {
+      throw new Error('expected signal.fitness_declined');
+    }
+  });
+
+  it('is a no-op when score is at or above floor', () => {
+    const { emitted, bus } = captureBus();
+    emitFitnessDeclinedSignal(audit(90), 90, bus, spyLogger());
+    emitFitnessDeclinedSignal(audit(95), 90, bus, spyLogger());
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('swallows + logs a bus.emit error (emission must never break the review path)', () => {
+    const logger = spyLogger();
+    const { bus } = captureBus(() => {
+      throw new Error('bus boom');
+    });
+    expect(() => {
+      emitFitnessDeclinedSignal(audit(50), 90, bus, logger);
+    }).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to emit signal.fitness_declined',
+      expect.objectContaining({ error: expect.stringContaining('bus boom') })
+    );
+  });
+});
+
+describe('end-to-end: declined fitness → signal → shadow TuneStage (#3147)', () => {
+  afterEach(() => {
+    shutdownTuneStage();
+  });
+
+  it('a below-floor audit emitted on the typed bus is consumed by the wired TuneStage', () => {
+    const bus = new EventBus();
+    const tuneLogger = spyLogger();
+    startTuneStage(bus, { logger: tuneLogger });
+
+    emitFitnessDeclinedSignal(audit(62, [finding('determinism', 10)]), 90, bus, spyLogger());
+
+    expect(tuneLogger.info).toHaveBeenCalledWith(
+      'TuneStage (shadow) — intended action',
+      expect.objectContaining({ kind: 'flag_tech_debt', signal: 'signal.fitness_declined' })
+    );
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-signals.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-signals.ts
@@ -1,0 +1,54 @@
+/**
+ * improvement_review → pipeline-bus signal emitter (#3147, epic #3143 P2).
+ *
+ * Emits `signal.fitness_declined` onto the typed pipeline event bus when the
+ * fitness audit score falls below the governance floor. Runs in the
+ * `improvement_review` MCP tool (server context), so the live shadow TuneStage
+ * consumes it. Lives at the MCP layer to keep `governance/fitness-score`
+ * decoupled from the pipeline bus, preserving the `A = observability /
+ * B = messaging` boundary adopted for #3289 (scope Option 2).
+ *
+ * @module mcp/tools/improvement-review-signals
+ */
+
+import { getErrorMessage, getTimeProvider } from '../../core/index.js';
+import type { ILogger } from '../../core/index.js';
+import type { FitnessAudit } from '../../governance/fitness-score.js';
+import type { IEventBus } from '../../pipeline/event-types.js';
+
+/** The dimension of the finding that deducted the most points, if any. */
+function worstDimension(audit: FitnessAudit): string | undefined {
+  let worst: { dimension: string; pointsDeducted: number } | undefined;
+  for (const finding of audit.findings) {
+    if (worst === undefined || finding.pointsDeducted > worst.pointsDeducted) {
+      worst = { dimension: finding.dimension, pointsDeducted: finding.pointsDeducted };
+    }
+  }
+  return worst?.dimension;
+}
+
+/**
+ * Emit `signal.fitness_declined` onto `bus` when `audit.score < fitnessFloor`.
+ * No-op at or above floor. Emission errors are swallowed and logged — signalling
+ * must never break the improvement-review path.
+ */
+export function emitFitnessDeclinedSignal(
+  audit: FitnessAudit,
+  fitnessFloor: number,
+  bus: IEventBus,
+  logger: ILogger
+): void {
+  if (audit.score >= fitnessFloor) return;
+  try {
+    const dimension = worstDimension(audit);
+    bus.emit({
+      type: 'signal.fitness_declined',
+      timestamp: getTimeProvider().now(),
+      score: audit.score,
+      floor: fitnessFloor,
+      ...(dimension !== undefined ? { dimension } : {}),
+    });
+  } catch (error) {
+    logger.warn('Failed to emit signal.fitness_declined', { error: getErrorMessage(error) });
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -33,6 +33,8 @@ import {
 import { getOutcomeStore } from '../../orchestration/outcomes/outcome-store.js';
 import type { TaskOutcome } from '../../orchestration/outcomes/outcome-types.js';
 import { calculateFitnessScore, type FitnessAudit } from '../../governance/fitness-score.js';
+import { getPipelineEventBus } from '../../pipeline/event-bus.js';
+import { emitFitnessDeclinedSignal } from './improvement-review-signals.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 const execFileAsync = promisify(execFile);
@@ -438,6 +440,11 @@ export async function runImprovementReview(
     ...detectFitnessSignals(audit, fitnessFloor),
   ];
   signals.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+
+  // Close the self-tuning loop: a below-floor fitness audit emits
+  // signal.fitness_declined onto the typed pipeline bus for the shadow
+  // TuneStage (#3147; #3289 Option 2 — observability signals route through bus A).
+  emitFitnessDeclinedSignal(audit, fitnessFloor, getPipelineEventBus(), logger);
 
   const { issuesFiled, issuesSkipped } = fileIssues
     ? await fileSignalsAsIssues(signals, { logger } as HandlerContext)


### PR DESCRIPTION
## What

Second `signal.*` **producer** per the #3289 narrow-merge scope (epic #3143 P2, #3147), following #3305 (vote_rejected).

- **Producer:** new `mcp/tools/improvement-review-signals.ts` — `emitFitnessDeclinedSignal(audit, floor, bus, logger)` emits `signal.fitness_declined` (`score`, `floor`, worst-offending `dimension`) when the fitness audit is below the governance floor. Wired into `runImprovementReview` after the signal set is built.
- **Server context:** `improvement_review` is an MCP tool, so the live shadow `TuneStage` (wired at server init in #3305) consumes it → `flag_tech_debt`.

## Boundary discipline (#3289)

Emitter at the MCP layer keeps `governance/fitness-score` decoupled from the pipeline bus — no messaging semantics pulled into bus A. Emission errors are swallowed + logged (never breaks the review path). `getTimeProvider().now()` for the timestamp (determinism mandate).

## Tests (TDD)

`improvement-review-signals.test.ts` (6): emit-below-floor, worst-dimension attribution, omit-dimension-when-no-findings, no-op-at/above-floor, error-swallowing, **end-to-end** (below-floor audit → signal on typed bus → wired TuneStage logs `flag_tech_debt`). The 18 existing `improvement-review.test.ts` tests still pass (**24 total**). Typecheck, lint, new-export gate clean.

Part of #3147 / epic #3143. Next: `signal.swarm_unhealthy` (SwarmObserver — a cross-bus case, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)