### PR TITLE
feat(security): durable audit bridge for security decisions — #3291 Phase 1

### DIFF
--- a/.changeset/audit-convergence-phase1.md
+++ b/.changeset/audit-convergence-phase1.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(security): durable audit bridge — mirror security decisions to the hash-chained log (#3291)
+
+Phase 1 of AuditLogger convergence (epic #3288 item 3). The security `AuditTrail`
+was in-memory-only, so trust/policy/reputation/sanitization decisions were lost on
+exit. Adds `security/audit-bridge.ts` mapping each security `AuditEvent` into the
+durable `AuditEventInput` schema (`action: security.*`, `source` via category) and
+a `createDurableAuditSink(auditLogger)`. `AuditTrail` gains an optional durable
+sink (default-off — zero behavior change); `FirewallConfig.auditLogger` opts a
+firewall into durable mirroring. Per the #3291 vote (fold-in over a separate
+SecurityAuditLogger). Phase 2 threads the logger from server init + retires
+`AuditTrail.append`.

--- a/packages/nexus-agents/src/security/audit-bridge.test.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the security → durable audit bridge (#3291, epic #3288 item 3).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { securityAuditEventToInput, createDurableAuditSink } from './audit-bridge.js';
+import { AuditTrail } from './audit-trail.js';
+import type { AuditEvent as SecurityAuditEvent } from './audit-trail.js';
+import type { AuditEventInput, IAuditLogger } from '../audit/audit-types.js';
+import { AuditEventInputSchema } from '../audit/audit-types.js';
+
+const base = { id: 'audit-1', timestamp: '2026-06-01T00:00:00Z', component: 'firewall' };
+
+const samples: Record<SecurityAuditEvent['type'], SecurityAuditEvent> = {
+  trust_classification: {
+    ...base,
+    type: 'trust_classification',
+    username: 'alice',
+    assignedTier: '3',
+    userRole: 'contributor',
+    isAllowlisted: false,
+    wasDowngraded: true,
+    reason: 'unknown user',
+  },
+  policy_gate: {
+    ...base,
+    type: 'policy_gate',
+    actionType: 'GeneratePatchPlan',
+    allowed: false,
+    requiresApproval: true,
+    inputTrustTier: '3',
+    violationRules: ['rule_of_two', 'write_requires_t1'],
+  },
+  corroboration: {
+    ...base,
+    type: 'corroboration',
+    actionType: 'GeneratePatchPlan',
+    satisfied: false,
+    sourceCount: 1,
+    missingRequirements: ['second_source'],
+  },
+  reputation: {
+    ...base,
+    type: 'reputation',
+    username: 'bob',
+    reputationScore: 0.2,
+    isSuspicious: true,
+    effectiveTier: '4',
+    signalCount: 5,
+  },
+  sanitization: {
+    ...base,
+    type: 'sanitization',
+    source: 'github-issue',
+    wasModified: true,
+    strippedCount: 2,
+    injectionFlagCount: 1,
+    strippedElements: [{ tag: '<script>', reason: 'injection vector' }],
+  },
+  graph_execution: {
+    ...base,
+    type: 'graph_execution',
+    graphEvent: 'node_start',
+    nodeId: 'n1',
+    stepNumber: 3,
+    detail: 'executing node n1',
+  },
+};
+
+describe('securityAuditEventToInput (#3291)', () => {
+  it('maps every security event type to a schema-valid durable AuditEventInput', () => {
+    for (const event of Object.values(samples)) {
+      const input = securityAuditEventToInput(event);
+      const parsed = AuditEventInputSchema.safeParse(input);
+      expect(parsed.success, `${event.type} should map to a valid input`).toBe(true);
+      expect(input.action).toBe(`security.${event.type}`);
+    }
+  });
+
+  it('maps a denied policy_gate to outcome=denied with the violation rules', () => {
+    const input = securityAuditEventToInput(samples.policy_gate);
+    expect(input.outcome).toBe('denied');
+    expect(input.policyDecision).toBe('deny');
+    expect(input.violationType).toContain('rule_of_two');
+    expect(input.severity).toBe('warning');
+  });
+
+  it('flags a downgraded trust classification as a warning', () => {
+    expect(securityAuditEventToInput(samples.trust_classification).severity).toBe('warning');
+  });
+
+  it('flags suspicious reputation + injection sanitization as warnings', () => {
+    expect(securityAuditEventToInput(samples.reputation).severity).toBe('warning');
+    expect(securityAuditEventToInput(samples.sanitization).severity).toBe('warning');
+  });
+
+  it('carries the user identity into the actor for user-scoped events', () => {
+    expect(securityAuditEventToInput(samples.trust_classification).actor).toMatchObject({
+      type: 'user',
+      id: 'alice',
+    });
+    expect(securityAuditEventToInput(samples.reputation).actor).toMatchObject({
+      type: 'user',
+      id: 'bob',
+    });
+  });
+});
+
+function captureLogger(logImpl?: (i: AuditEventInput) => void): {
+  logger: IAuditLogger;
+  logged: AuditEventInput[];
+} {
+  const logged: AuditEventInput[] = [];
+  const logger: IAuditLogger = {
+    log: (i: AuditEventInput) => {
+      if (logImpl) logImpl(i);
+      logged.push(i);
+    },
+    logToolInvocation: vi.fn(),
+    logPolicyDecision: vi.fn(),
+    logSecurityEvent: vi.fn(),
+    logRateLimitViolation: vi.fn(),
+    flush: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
+  return { logger, logged };
+}
+
+describe('createDurableAuditSink (#3291)', () => {
+  it('forwards a mapped input to the durable logger', () => {
+    const { logger, logged } = captureLogger();
+    createDurableAuditSink(logger)(samples.policy_gate);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.action).toBe('security.policy_gate');
+  });
+
+  it('swallows logger errors (durable mirroring must not break the pipeline)', () => {
+    const { logger } = captureLogger(() => {
+      throw new Error('disk full');
+    });
+    const sink = createDurableAuditSink(logger);
+    expect(() => {
+      sink(samples.reputation);
+    }).not.toThrow();
+  });
+});
+
+describe('AuditTrail → durable sink end-to-end parity (#3291)', () => {
+  it('keeps the in-memory trail AND mirrors every appended decision to the durable sink', () => {
+    const { logger, logged } = captureLogger();
+    const trail = new AuditTrail(createDurableAuditSink(logger));
+
+    // append() takes Omit<AuditEvent,'id'|'timestamp'>; passing the full sample
+    // is fine (the extra id/timestamp are reassigned inside append).
+    trail.append(samples.policy_gate);
+
+    // in-memory unchanged
+    expect(trail.query({ type: 'policy_gate' })).toHaveLength(1);
+    // durably mirrored, mapped to the converged schema
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatchObject({ action: 'security.policy_gate', outcome: 'denied' });
+  });
+
+  it('a trail with no sink is in-memory only (default behavior unchanged)', () => {
+    const { logger, logged } = captureLogger();
+    const trail = new AuditTrail();
+    trail.append(samples.reputation);
+    expect(trail.query()).toHaveLength(1);
+    expect(logged).toHaveLength(0);
+    expect(logger.log).toBeDefined();
+  });
+});

--- a/packages/nexus-agents/src/security/audit-bridge.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.ts
@@ -1,0 +1,189 @@
+/**
+ * Security → durable audit bridge (#3291, epic #3288 item 3).
+ *
+ * The security `AuditTrail` (audit-trail.ts) is in-memory-only, so every
+ * trust/policy/reputation/sanitization decision is lost on process exit. The
+ * durable `AuditLogger` (audit/) persists with a tamper-evident hash chain but
+ * lacks these rich security event types. This bridge maps each security
+ * `AuditEvent` (the discriminated union) into a durable `AuditEventInput` and
+ * forwards it to an `IAuditLogger`, so security decisions become durable and
+ * hash-verifiable — satisfying CLAUDE.md's "immutable audit" mandate.
+ *
+ * Per the #3291 confirmation vote (fold-in design): security events are folded
+ * into the durable schema with `category`/`action` distinguishing them
+ * (queryable by `action: 'security.*'`), rather than standing up a parallel
+ * SecurityAuditLogger.
+ *
+ * @module security/audit-bridge
+ */
+
+import { createLogger, getErrorMessage } from '../core/index.js';
+import type { AuditEvent as SecurityAuditEvent, DurableAuditSink } from './audit-trail.js';
+import type {
+  AuditEventInput,
+  AuditActor,
+  AuditOutcome,
+  AuditSeverity,
+  IAuditLogger,
+} from '../audit/audit-types.js';
+
+const logger = createLogger({ component: 'SecurityAuditBridge' });
+
+function systemActor(id: string, name?: string): AuditActor {
+  return name !== undefined ? { type: 'system', id, name } : { type: 'system', id };
+}
+
+function userActor(username: string): AuditActor {
+  return { type: 'user', id: username };
+}
+
+type TrustEvent = Extract<SecurityAuditEvent, { type: 'trust_classification' }>;
+type PolicyEvent = Extract<SecurityAuditEvent, { type: 'policy_gate' }>;
+type CorroborationEvt = Extract<SecurityAuditEvent, { type: 'corroboration' }>;
+type ReputationEvt = Extract<SecurityAuditEvent, { type: 'reputation' }>;
+type SanitizationEvt = Extract<SecurityAuditEvent, { type: 'sanitization' }>;
+type GraphEvt = Extract<SecurityAuditEvent, { type: 'graph_execution' }>;
+
+function mapTrust(e: TrustEvent): AuditEventInput {
+  const severity: AuditSeverity = e.wasDowngraded ? 'warning' : 'info';
+  return {
+    category: 'authorization',
+    severity,
+    outcome: 'success',
+    action: 'security.trust_classification',
+    actor: userActor(e.username),
+    description: e.reason,
+    metadata: {
+      assignedTier: e.assignedTier,
+      userRole: e.userRole,
+      isAllowlisted: e.isAllowlisted,
+      wasDowngraded: e.wasDowngraded,
+      component: e.component,
+    },
+  };
+}
+
+function mapPolicyGate(e: PolicyEvent): AuditEventInput {
+  const outcome: AuditOutcome = e.allowed ? 'success' : 'denied';
+  return {
+    category: 'authorization',
+    severity: e.allowed ? 'info' : 'warning',
+    outcome,
+    action: 'security.policy_gate',
+    actor: systemActor(e.component),
+    policyName: 'security.policy_gate',
+    policyDecision: e.allowed ? 'allow' : 'deny',
+    ...(e.violationRules.length > 0 ? { violationType: e.violationRules.join(',') } : {}),
+    metadata: {
+      actionType: e.actionType,
+      requiresApproval: e.requiresApproval,
+      inputTrustTier: e.inputTrustTier,
+      violationRules: e.violationRules,
+    },
+  };
+}
+
+function mapCorroboration(e: CorroborationEvt): AuditEventInput {
+  return {
+    category: 'security',
+    severity: e.satisfied ? 'info' : 'warning',
+    outcome: e.satisfied ? 'success' : 'denied',
+    action: 'security.corroboration',
+    actor: systemActor(e.component),
+    metadata: {
+      actionType: e.actionType,
+      sourceCount: e.sourceCount,
+      missingRequirements: e.missingRequirements,
+    },
+  };
+}
+
+function mapReputation(e: ReputationEvt): AuditEventInput {
+  return {
+    category: 'security',
+    severity: e.isSuspicious ? 'warning' : 'info',
+    outcome: 'success',
+    action: 'security.reputation',
+    actor: userActor(e.username),
+    metadata: {
+      reputationScore: e.reputationScore,
+      isSuspicious: e.isSuspicious,
+      effectiveTier: e.effectiveTier,
+      signalCount: e.signalCount,
+      component: e.component,
+    },
+  };
+}
+
+function mapSanitization(e: SanitizationEvt): AuditEventInput {
+  return {
+    category: 'security',
+    severity: e.injectionFlagCount > 0 ? 'warning' : 'info',
+    outcome: 'success',
+    action: 'security.sanitization',
+    actor: systemActor(e.component, e.source),
+    metadata: {
+      source: e.source,
+      wasModified: e.wasModified,
+      strippedCount: e.strippedCount,
+      injectionFlagCount: e.injectionFlagCount,
+      strippedElements: e.strippedElements,
+    },
+  };
+}
+
+function mapGraphExecution(e: GraphEvt): AuditEventInput {
+  return {
+    category: 'system',
+    severity: 'info',
+    outcome: 'success',
+    action: 'security.graph_execution',
+    actor: systemActor(e.component),
+    description: e.detail,
+    metadata: {
+      graphEvent: e.graphEvent,
+      ...(e.nodeId !== undefined ? { nodeId: e.nodeId } : {}),
+      stepNumber: e.stepNumber,
+    },
+  };
+}
+
+/**
+ * Map a security `AuditEvent` (discriminated union) to a durable
+ * `AuditEventInput`. Pure — no side effects. The durable logger assigns
+ * id/timestamp/hash, so those are omitted here.
+ */
+export function securityAuditEventToInput(event: SecurityAuditEvent): AuditEventInput {
+  switch (event.type) {
+    case 'trust_classification':
+      return mapTrust(event);
+    case 'policy_gate':
+      return mapPolicyGate(event);
+    case 'corroboration':
+      return mapCorroboration(event);
+    case 'reputation':
+      return mapReputation(event);
+    case 'sanitization':
+      return mapSanitization(event);
+    case 'graph_execution':
+      return mapGraphExecution(event);
+  }
+}
+
+/**
+ * Build a {@link SecurityAuditSink} that maps security events into the durable
+ * schema and writes them through `auditLogger`. Errors are swallowed and logged
+ * — durable mirroring must never break the security pipeline.
+ */
+export function createDurableAuditSink(auditLogger: IAuditLogger): DurableAuditSink {
+  return (event: SecurityAuditEvent) => {
+    try {
+      auditLogger.log(securityAuditEventToInput(event));
+    } catch (error) {
+      logger.warn('Failed to mirror security event to durable audit log', {
+        type: event.type,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+}

--- a/packages/nexus-agents/src/security/audit-trail.ts
+++ b/packages/nexus-agents/src/security/audit-trail.ts
@@ -134,9 +134,19 @@ export interface AuditQuery {
  * Append-only audit trail for security pipeline decisions.
  * Events are bounded by MAX_EVENTS to prevent unbounded growth.
  */
+/**
+ * Optional durable sink: receives every fully-formed event appended to the
+ * trail, so security decisions can be mirrored to a persistent, hash-chained
+ * store (see security/audit-bridge.ts). Default-off — when absent, the trail
+ * behaves exactly as before (#3291).
+ */
+export type DurableAuditSink = (event: AuditEvent) => void;
+
 export class AuditTrail {
   private events: AuditEvent[] = [];
   private nextId = 1;
+
+  constructor(private readonly durableSink?: DurableAuditSink) {}
 
   /** Appends an event to the trail. Returns the assigned event ID. */
   append(event: Omit<AuditEvent, 'id' | 'timestamp'>): string {
@@ -149,6 +159,17 @@ export class AuditTrail {
 
     this.events.push(fullEvent);
     this.enforceLimit();
+
+    // Mirror to the durable store when wired (#3291). Best-effort: a sink
+    // failure must never break the in-memory security pipeline.
+    if (this.durableSink !== undefined) {
+      try {
+        this.durableSink(fullEvent);
+      } catch {
+        // Sink implementations already swallow+log; this is belt-and-suspenders.
+      }
+    }
+
     return id;
   }
 
@@ -351,7 +372,11 @@ function formatGraphEventDetail(event: {
   }
 }
 
-/** Creates a new AuditTrail instance. */
-export function createAuditTrail(): AuditTrail {
-  return new AuditTrail();
+/**
+ * Creates a new AuditTrail instance. Pass a {@link DurableAuditSink} (e.g. from
+ * `createDurableAuditSink(auditLogger)`) to mirror appended security decisions
+ * to a durable, hash-chained store (#3291). Default: in-memory only.
+ */
+export function createAuditTrail(durableSink?: DurableAuditSink): AuditTrail {
+  return new AuditTrail(durableSink);
 }

--- a/packages/nexus-agents/src/security/firewall/firewall-pipeline.ts
+++ b/packages/nexus-agents/src/security/firewall/firewall-pipeline.ts
@@ -22,6 +22,7 @@ import {
   MAX_STRIPPED_ELEMENTS_PER_EVENT,
   emitTrustEvent,
 } from '../audit-trail.js';
+import { createDurableAuditSink } from '../audit-bridge.js';
 import { sanitizeInput } from '../input-sanitizer.js';
 import type { ReputationAssessment, GitHubUserMetadata } from '../reputation-model.js';
 import { assessReputation, ReputationCache, reconcileTrustTier } from '../reputation-model.js';
@@ -104,7 +105,11 @@ export class HostileInputFirewall {
     this.maxInputLength = validated.maxInputLength;
     this.adapter = config.adapter;
     this.reputationCache = new ReputationCache();
-    this.auditTrail = createAuditTrail();
+    // Mirror security decisions to the durable, hash-chained audit log when a
+    // logger is provided; otherwise stay in-memory only (#3291).
+    this.auditTrail = createAuditTrail(
+      config.auditLogger !== undefined ? createDurableAuditSink(config.auditLogger) : undefined
+    );
     this.context = validated.context;
   }
 

--- a/packages/nexus-agents/src/security/firewall/firewall-types.ts
+++ b/packages/nexus-agents/src/security/firewall/firewall-types.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from 'zod';
+import type { IAuditLogger } from '../../audit/audit-types.js';
 
 // ============================================================================
 // Source Adapter Interface
@@ -98,6 +99,12 @@ export interface FirewallConfig {
     readonly hasWriteAccess?: boolean;
     readonly hasSecretAccess?: boolean;
   };
+  /**
+   * Optional durable audit logger. When provided, every security decision the
+   * firewall records is mirrored to this persistent, hash-chained store via
+   * the audit bridge (#3291). When absent, decisions are in-memory only.
+   */
+  readonly auditLogger?: IAuditLogger;
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Phase 1 of AuditLogger convergence (epic #3288 item 3, plan approved 2-0 in the #3291 confirmation vote). Verified gap: the security `AuditTrail` is in-memory-only, so every trust/policy/reputation/sanitization decision is **lost on process exit** — violating CLAUDE.md's "immutable audit." The durable `AuditLogger` persists with a tamper-evident hash chain.

- **`security/audit-bridge.ts`** — `securityAuditEventToInput(event)` maps each of the 6 security `AuditEvent` variants into the durable `AuditEventInput` schema (`action: 'security.*'`, category-tagged for segregated queries — the panel's condition); `createDurableAuditSink(auditLogger)` forwards mapped events, swallowing+logging errors so mirroring never breaks the pipeline.
- **`AuditTrail`** — optional durable sink via constructor; `append()` forwards each fully-formed event. **Default-off → zero behavior change** when no sink is wired.
- **`FirewallConfig.auditLogger?`** — opt-in: when provided, the firewall's security decisions are mirrored durably. (Threading the logger from server init is Phase 2.)

## Design (per #3291 vote)

Fold-in over a separate `SecurityAuditLogger`: one hash chain = one tamper-evident, `verifyChain`-able log; the `action: security.*` namespace + category give logical segregation without a second chain. The bridge is a thin pure mapper + sink — no buffering/policy logic.

## Tests (TDD)

`audit-bridge.test.ts` (9): all 6 types → schema-valid durable input; denied policy_gate → `outcome: denied` + violation rules; severity flags; user-actor identity; sink forwarding + error-swallowing; **end-to-end parity** (a decision appended to a trail-with-sink stays in-memory queryable AND is durably mirrored to the converged schema); default-off = in-memory only. Typecheck, lint, new-export gate clean. **54 tests pass.**

## Follow-up (Phase 2, tracked on #3291)

Thread the `AuditLogger` from `cli-server` → firewall/run-graph-workflow; migrate the remaining `createAuditTrail` site; retire `AuditTrail.append` once all decisions flow durably.

Part of #3291 / epic #3288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)