### PR TITLE
refactor(core): extract BoundedLRUCache, adopt in PolicyCache (#3292)

### DIFF
--- a/.changeset/bounded-lru-cache.md
+++ b/.changeset/bounded-lru-cache.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+refactor(core): extract canonical BoundedLRUCache; adopt in PolicyCache (#3292)
+
+First step of the cache consolidation (epic #3288 item 4, scoped by verify-first):
+adds `core/BoundedLRUCache<K,V>` — the single size-bound LRU implementation that
+was hand-rolled across several caches — and adopts it behind `PolicyCache`'s
+existing interface (dropping its unused `insertedAt` field). Behavior-preserving:
+the existing PolicyCache tests pass unchanged. The TTL-bearing and domain-specific
+caches stay separate (per the #3292 scoping).

--- a/packages/nexus-agents/src/core/bounded-lru-cache.test.ts
+++ b/packages/nexus-agents/src/core/bounded-lru-cache.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the shared BoundedLRUCache (#3292, epic #3288 item 4).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BoundedLRUCache } from './bounded-lru-cache.js';
+
+describe('BoundedLRUCache', () => {
+  it('stores and retrieves values', () => {
+    const c = new BoundedLRUCache<string, number>(3);
+    c.set('a', 1);
+    expect(c.get('a')).toBe(1);
+    expect(c.size).toBe(1);
+  });
+
+  it('returns undefined for a missing key', () => {
+    expect(new BoundedLRUCache<string, number>(3).get('nope')).toBeUndefined();
+  });
+
+  it('evicts the oldest entry when at capacity (FIFO insertion order)', () => {
+    const c = new BoundedLRUCache<string, number>(2);
+    c.set('a', 1);
+    c.set('b', 2);
+    c.set('c', 3); // evicts 'a'
+    expect(c.has('a')).toBe(false);
+    expect(c.get('b')).toBe(2);
+    expect(c.get('c')).toBe(3);
+    expect(c.size).toBe(2);
+  });
+
+  it('get() bumps LRU recency so the bumped key survives eviction', () => {
+    const c = new BoundedLRUCache<string, number>(2);
+    c.set('a', 1);
+    c.set('b', 2);
+    c.get('a'); // 'a' is now most-recently-used; 'b' is oldest
+    c.set('c', 3); // evicts 'b', not 'a'
+    expect(c.has('a')).toBe(true);
+    expect(c.has('b')).toBe(false);
+    expect(c.has('c')).toBe(true);
+  });
+
+  it('re-setting an existing key refreshes recency and updates the value', () => {
+    const c = new BoundedLRUCache<string, number>(2);
+    c.set('a', 1);
+    c.set('b', 2);
+    c.set('a', 10); // updates value + bumps recency; 'b' is now oldest
+    c.set('c', 3); // evicts 'b'
+    expect(c.get('a')).toBe(10);
+    expect(c.has('b')).toBe(false);
+    expect(c.has('c')).toBe(true);
+  });
+
+  it('delete removes a key and reports whether it existed', () => {
+    const c = new BoundedLRUCache<string, number>(3);
+    c.set('a', 1);
+    expect(c.delete('a')).toBe(true);
+    expect(c.delete('a')).toBe(false);
+    expect(c.has('a')).toBe(false);
+  });
+
+  it('clear empties the cache', () => {
+    const c = new BoundedLRUCache<string, number>(3);
+    c.set('a', 1);
+    c.set('b', 2);
+    c.clear();
+    expect(c.size).toBe(0);
+    expect(c.get('a')).toBeUndefined();
+  });
+
+  it('rejects a capacity below 1', () => {
+    expect(() => new BoundedLRUCache<string, number>(0)).toThrow();
+  });
+});

--- a/packages/nexus-agents/src/core/bounded-lru-cache.ts
+++ b/packages/nexus-agents/src/core/bounded-lru-cache.ts
@@ -1,0 +1,75 @@
+/**
+ * BoundedLRUCache — a fixed-capacity least-recently-used cache (#3292).
+ *
+ * O(1) get/set/delete with insertion-order LRU eviction, backed by a `Map`
+ * (which preserves insertion order, so the first key is always the oldest).
+ * `get` and re-`set` bump a key's recency; at capacity, `set` evicts the
+ * least-recently-used entry.
+ *
+ * Extracted as the single canonical implementation of the LRU bound that was
+ * re-written across several security/config caches (PolicyCache, ReputationCache,
+ * …). Pure size-bound LRU — no TTL (TTL-bearing caches use a separate variant).
+ *
+ * @module core/bounded-lru-cache
+ */
+
+export class BoundedLRUCache<K, V> {
+  private readonly entries = new Map<K, V>();
+
+  /**
+   * @param capacity Maximum entries retained before LRU eviction (>= 1).
+   * @throws Error if capacity < 1.
+   */
+  constructor(private readonly capacity: number) {
+    if (capacity < 1) {
+      throw new Error('BoundedLRUCache capacity must be at least 1');
+    }
+  }
+
+  /** Number of entries currently held. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** True if `key` is present (does not affect recency). */
+  has(key: K): boolean {
+    return this.entries.has(key);
+  }
+
+  /**
+   * Get the value for `key`, or undefined. Side effect: bumps `key` to
+   * most-recently-used.
+   */
+  get(key: K): V | undefined {
+    const value = this.entries.get(key);
+    if (value === undefined && !this.entries.has(key)) return undefined;
+    // Re-insert to refresh LRU position (Map keeps insertion order).
+    this.entries.delete(key);
+    this.entries.set(key, value as V);
+    return value;
+  }
+
+  /**
+   * Store `value` under `key`, bumping recency. Evicts the least-recently-used
+   * entry when at capacity.
+   */
+  set(key: K, value: V): void {
+    if (this.entries.has(key)) {
+      this.entries.delete(key);
+    } else if (this.entries.size >= this.capacity) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+    this.entries.set(key, value);
+  }
+
+  /** Remove `key`. Returns true if it was present. */
+  delete(key: K): boolean {
+    return this.entries.delete(key);
+  }
+
+  /** Remove all entries. */
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/packages/nexus-agents/src/core/index.ts
+++ b/packages/nexus-agents/src/core/index.ts
@@ -13,6 +13,9 @@ export { extractJsonArray, extractJsonObject } from './json-extract.js';
 // Circular Buffer — O(1) bounded collection (Source: Issue #407; relocated to core #3288)
 export { CircularBuffer } from './circular-buffer.js';
 
+// Bounded LRU cache — canonical size-bound LRU (#3292)
+export { BoundedLRUCache } from './bounded-lru-cache.js';
+
 // Step event vocabulary + `withStep` wrapper (#1930 — human console notifications)
 export type {
   StepKind,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/cache.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/cache.ts
@@ -12,51 +12,42 @@
  * @module security/access-constraint-deriver/cache
  */
 
-import { getTimeProvider } from '../../core/index.js';
+import { BoundedLRUCache } from '../../core/index.js';
 import type { TaskAccessPolicy } from './types.js';
 
 /** Max number of policies retained in the cache before LRU eviction. */
 const DEFAULT_MAX_ENTRIES = 256;
 
-interface CacheEntry {
-  readonly policy: TaskAccessPolicy;
-  readonly insertedAt: number;
-}
-
+/**
+ * LRU cache of derived access policies, keyed by objectiveHash. A thin wrapper
+ * over the canonical {@link BoundedLRUCache} (#3292) — the same size-bound LRU
+ * semantics previously hand-rolled here (the unused `insertedAt` field was
+ * dropped; this cache has no TTL).
+ */
 export class PolicyCache {
-  private readonly entries = new Map<string, CacheEntry>();
+  private readonly cache: BoundedLRUCache<string, TaskAccessPolicy>;
 
-  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {}
+  constructor(maxEntries: number = DEFAULT_MAX_ENTRIES) {
+    this.cache = new BoundedLRUCache(maxEntries);
+  }
 
   /** Gets a cached policy or undefined. Side effect: bumps LRU position. */
   get(objectiveHash: string): TaskAccessPolicy | undefined {
-    const entry = this.entries.get(objectiveHash);
-    if (entry === undefined) return undefined;
-    // Re-insert to refresh LRU position
-    this.entries.delete(objectiveHash);
-    this.entries.set(objectiveHash, entry);
-    return entry.policy;
+    return this.cache.get(objectiveHash);
   }
 
-  /** Stores a policy. Evicts the oldest entry if at capacity. */
+  /** Stores a policy. Evicts the least-recently-used entry if at capacity. */
   set(objectiveHash: string, policy: TaskAccessPolicy): void {
-    if (this.entries.has(objectiveHash)) {
-      this.entries.delete(objectiveHash);
-    } else if (this.entries.size >= this.maxEntries) {
-      // Map preserves insertion order; the first key is the oldest.
-      const oldest = this.entries.keys().next().value;
-      if (oldest !== undefined) this.entries.delete(oldest);
-    }
-    this.entries.set(objectiveHash, { policy, insertedAt: getTimeProvider().now() });
+    this.cache.set(objectiveHash, policy);
   }
 
   /** Clears all entries. Useful for tests. */
   clear(): void {
-    this.entries.clear();
+    this.cache.clear();
   }
 
   get size(): number {
-    return this.entries.size;
+    return this.cache.size;
   }
 }
 


### PR DESCRIPTION
## What

First vertical slice of the cache consolidation (epic #3288 item 4), scoped narrow by the #3292 verify-first fan-out.

- **`core/BoundedLRUCache<K,V>`** — the single canonical size-bound LRU (Map-backed, O(1) get/set/delete, insertion-order eviction, `get`/re-`set` bump recency). This is the bound that was re-written across PolicyCache, ReputationCache, and others.
- **`PolicyCache` adopts it** behind its existing interface, dropping the **unused `insertedAt`/`CacheEntry`** (vestigial — it had no TTL) and the now-needless `getTimeProvider` import.

## Parity (the binding condition)

Behavior-preserving: the **existing `cache.test.ts` (9 tests) passes unchanged** against the refactored `PolicyCache`, proving identical LRU/eviction semantics. Plus 8 new `BoundedLRUCache` tests (eviction order, recency bump on get + re-set, delete/clear, capacity guard). **126 tests pass** across the suite; typecheck, lint, new-export gate clean.

## Scope discipline (#3292)

Only PolicyCache in this PR. The other genuinely-similar caches (ReputationCache, CliDetectionCache, AvailabilityCache) follow as separate adopters; the 6 distinct structures (ResponseCache dual-bound, AvailableModelsCache stale-while-revalidate, voting ledgers, CircularBuffer-backed buffers) stay separate per the verify-first scoping.

Part of #3292 / epic #3288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)