### PR TITLE
fix(consensus): higher_order no longer fail-closes on a single voter error (#3138/#3304)

### DIFF
--- a/.changeset/fail-policy-error-vs-reject.md
+++ b/.changeset/fail-policy-error-vs-reject.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+fix(consensus): higher_order no longer fail-closes on a single voter error (#3138, #3304)
+
+`getDefaultErrorPolicy` now returns `fail_closed` only for `unanimous` (where a
+missing voter genuinely breaks the guarantee). `higher_order` and its
+`opinion_wise` alias default to `reduce_denominator`: Bayesian/weighted
+aggregation over the non-error voters is well-defined, so one voter's infra
+timeout (e.g. the slow Security voter's adapter transport) no longer voids an
+otherwise-unanimous result. The >50% `ERROR_FLOOR_FRACTION` hard floor still
+voids any vote where most voters errored. Callers can still pass an explicit
+`errorPolicy` override.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-error-policy.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-error-policy.ts
@@ -15,7 +15,7 @@
  *   votes. Pragmatic for operational decisions.
  * - `count_as_abstain`: errors reach the engine as abstain. Conservative
  *   — error voter is treated as having withheld approval.
- * - `fail_closed` (default for unanimous / higher_order): any error
+ * - `fail_closed` (default for unanimous only, #3138): any error
  *   short-circuits to vote-void.
  *
  * Hard floor: if errors > `ERROR_FLOOR_FRACTION` of total voters, the

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -94,13 +94,19 @@ export type VoteThreshold = z.infer<typeof VoteThresholdSchema>;
 export const ERROR_FLOOR_FRACTION = 0.5;
 
 /**
- * Default error policy per voting strategy. Strict strategies (unanimous,
- * higher_order, and its alias opinion_wise) default to `fail_closed`; others
- * default to `reduce_denominator`. Callers can override with the `errorPolicy`
- * input field. (#3167: opinion_wise must match its higher_order alias.)
+ * Default error policy per voting strategy.
+ *
+ * Only `unanimous` defaults to `fail_closed`: a missing/errored voter genuinely
+ * breaks the unanimity guarantee, so the vote must void. Every other strategy —
+ * including `higher_order` and its `opinion_wise` alias — defaults to
+ * `reduce_denominator`: Bayesian/weighted aggregation over the *non-error*
+ * voters is well-defined, so a single infra timeout (e.g. one slow voter's
+ * adapter transport, #3304) should NOT fail-close an otherwise-unanimous result
+ * (#3138). The >50% `ERROR_FLOOR_FRACTION` hard floor still voids any vote where
+ * most voters errored. Callers can override via the `errorPolicy` input.
  */
 export function getDefaultErrorPolicy(strategy: VotingStrategy): ErrorPolicy {
-  if (strategy === 'unanimous' || strategy === 'higher_order' || strategy === 'opinion_wise') {
+  if (strategy === 'unanimous') {
     return 'fail_closed';
   }
   return 'reduce_denominator';
@@ -115,7 +121,7 @@ export const ConsensusVoteInputSchema = z.object({
     'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order (Bayesian-optimal)'
   ),
   errorPolicy: ErrorPolicySchema.optional().describe(
-    'How to treat voters that errored or timed out (#2630). Default: fail_closed for unanimous/higher_order/opinion_wise, reduce_denominator otherwise. Regardless of policy, errors > 50% always fails.'
+    'How to treat voters that errored or timed out (#2630). Default: fail_closed for unanimous only; reduce_denominator for all other strategies incl. higher_order/opinion_wise (#3138 — a single infra timeout should not void an otherwise-unanimous vote). Regardless of policy, errors > 50% always fails.'
   ),
   quickMode: z
     .boolean()

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -1103,11 +1103,14 @@ describe('CONSENSUS_VOTE_OUTPUT_SCHEMA validation (Issue #1246)', () => {
 });
 
 describe('getDefaultErrorPolicy (#3167)', () => {
-  it('strict strategies default to fail_closed — incl. opinion_wise (the higher_order alias)', () => {
+  it('only unanimous defaults to fail_closed (a missing voter breaks unanimity)', () => {
     expect(getDefaultErrorPolicy('unanimous')).toBe('fail_closed');
-    expect(getDefaultErrorPolicy('higher_order')).toBe('fail_closed');
-    expect(getDefaultErrorPolicy('opinion_wise')).toBe('fail_closed');
-    // opinion_wise must match its alias rather than silently diverging
+  });
+
+  it('higher_order + opinion_wise default to reduce_denominator (#3138 — infra timeout must not void a unanimous vote)', () => {
+    expect(getDefaultErrorPolicy('higher_order')).toBe('reduce_denominator');
+    expect(getDefaultErrorPolicy('opinion_wise')).toBe('reduce_denominator');
+    // opinion_wise must match its higher_order alias rather than silently diverging
     expect(getDefaultErrorPolicy('opinion_wise')).toBe(getDefaultErrorPolicy('higher_order'));
   });
 


### PR DESCRIPTION
## What

Resolves the recurring fail-close that blocked otherwise-unanimous `higher_order` votes all session (#3138 / #3304). `getDefaultErrorPolicy`:

- **`unanimous`** → `fail_closed` (unchanged — a missing/errored voter genuinely breaks the unanimity guarantee).
- **`higher_order` + `opinion_wise`** → **`reduce_denominator`** (was `fail_closed`). Bayesian/weighted aggregation over the *non-error* voters is well-defined, so a single voter's infra timeout (the slow Security voter's adapter transport, #3304) no longer voids the vote.
- All other strategies → `reduce_denominator` (unchanged).

The `>50%` `ERROR_FLOOR_FRACTION` hard floor still voids any vote where most voters errored ("all CLIs down ≠ consensus"). Callers can still pass an explicit `errorPolicy`.

## Why

Observed live this session: 7-voter `higher_order` votes returned 6 approve / 0 reject / 1 error (Security voter transport timeout) yet resolved `rejected` via `fail_closed` — a false negative on a unanimous result. This is the #3138 question, answered: flip higher_order's default.

## Tests

`getDefaultErrorPolicy` tests updated (unanimous=fail_closed; higher_order/opinion_wise=reduce_denominator); `applyErrorPolicy` behavior tests unchanged (the policies themselves are intact). **82 tests pass**; typecheck clean.

Follow-up (half 2 of the approved fix): raise the voter model-adapter transport timeout so the slow voter *completes* (gets its input counted) rather than being dropped — tracked on #3304.

Closes #3138. Part of #3304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)