### PR TITLE
fix(consensus): thread the vote budget into the voter's adapter call (#3304)

### DIFF
--- a/.changeset/voter-adapter-timeout.md
+++ b/.changeset/voter-adapter-timeout.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): thread the vote budget into the voter's adapter call (#3304)
+
+Adds an optional `timeoutMs` to `CompletionRequest`; `CliToModelAdapter.complete`
+now uses `request.timeoutMs ?? defaultTimeoutMs`, and the voter passes its
+per-vote budget (300s). Previously the adapter fell back to its shorter standard
+CLI timeout (120-180s), which fired first on slow voters (e.g. the Security role
+on complex proposals) and surfaced as an `MCP -32001` — dropping that voter.
+Now the slow voter completes within the vote budget and its input is counted.

--- a/packages/nexus-agents/src/cli-adapters/cli-to-model-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-to-model-adapter.test.ts
@@ -93,6 +93,33 @@ describe('CliToModelAdapter.complete', () => {
     expect(cli.execute).toHaveBeenCalledOnce();
   });
 
+  it('uses request.timeoutMs over the construction-time default (#3304)', async () => {
+    const cli = makeMockCliAdapter();
+    const adapter = new CliToModelAdapter(cli, { defaultTimeoutMs: 120_000 });
+
+    await adapter.complete({
+      messages: [{ role: 'user', content: 'Hello' }],
+      timeoutMs: 300_000,
+    });
+
+    const opts = (cli.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      timeoutMs?: number;
+    };
+    expect(opts.timeoutMs).toBe(300_000);
+  });
+
+  it('falls back to the default timeout when request.timeoutMs is absent (#3304)', async () => {
+    const cli = makeMockCliAdapter();
+    const adapter = new CliToModelAdapter(cli, { defaultTimeoutMs: 120_000 });
+
+    await adapter.complete({ messages: [{ role: 'user', content: 'Hello' }] });
+
+    const opts = (cli.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      timeoutMs?: number;
+    };
+    expect(opts.timeoutMs).toBe(120_000);
+  });
+
   it('converts string messages to CLI task content', async () => {
     const cli = makeMockCliAdapter();
     const adapter = new CliToModelAdapter(cli);

--- a/packages/nexus-agents/src/cli-adapters/cli-to-model-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-to-model-adapter.ts
@@ -138,8 +138,12 @@ export class CliToModelAdapter implements IModelAdapter {
    */
   async complete(request: CompletionRequest): Promise<Result<CompletionResponse, ModelError>> {
     const task = this.toCliTask(request);
+    // Per-request timeout (#3304) takes precedence over the construction-time
+    // default, so a long-budget caller (e.g. a consensus vote) isn't cut off by
+    // the adapter's shorter standard CLI timeout.
+    const effectiveTimeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
     const opts: ExecutionOptions | undefined =
-      this.defaultTimeoutMs !== undefined ? { timeoutMs: this.defaultTimeoutMs } : undefined;
+      effectiveTimeoutMs !== undefined ? { timeoutMs: effectiveTimeoutMs } : undefined;
     const result = await this.cliAdapter.execute(task, opts);
 
     if (!result.ok) {

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -253,6 +253,10 @@ export async function executeSingleVoteAttempt(
     // refine per use case if needed.
     maxTokens: 2000,
     temperature: 0.3, // Low temperature for consistent evaluations
+    // Thread the vote's budget into the adapter so its shorter standard CLI
+    // timeout doesn't fire first and surface as an MCP -32001 on slow voters
+    // (e.g. the Security role on complex proposals) (#3304).
+    timeoutMs,
   };
 
   const timeoutResult = await withTimeout(

--- a/packages/nexus-agents/src/core/types/model.ts
+++ b/packages/nexus-agents/src/core/types/model.ts
@@ -80,6 +80,14 @@ export interface CompletionRequest {
   temperature?: number;
   /** Maximum tokens to generate */
   maxTokens?: number;
+  /**
+   * Per-request timeout override in milliseconds. When set, adapters that
+   * support it use this instead of their construction-time default — lets a
+   * long-running caller (e.g. a consensus vote with a 300s budget) prevent the
+   * adapter's shorter standard timeout from firing first (#3304). Adapters that
+   * don't support per-request timeouts ignore it.
+   */
+  timeoutMs?: number;
   /** Tools available for the model */
   tools?: ToolDefinition[];
   /**


### PR DESCRIPTION
## What

Half 2 of the approved #3304 fix (half 1 = the policy flip in #3310). The voter's per-vote budget (300s) now reaches the adapter, so the adapter's shorter **standard CLI timeout (120-180s)** no longer fires first.

- `CompletionRequest` gains an optional **`timeoutMs`**.
- `CliToModelAdapter.complete` uses `request.timeoutMs ?? this.defaultTimeoutMs`.
- `voter-execution.ts` sets `timeoutMs` on the request to the vote's budget.

## Why

Root cause from the #3304 diagnosis: the vote wraps `adapter.complete()` in a 300s `withTimeout`, but the request carried no timeout, so the adapter used its own standard CLI timeout (120-180s). On slow voters (Security role on complex proposals, avg ~315s per #1640) that inner timeout fired first → `MCP -32001` → the voter was dropped. Now it completes within the budget and its vote is counted.

Complements #3310: #3310 ensures a dropped voter doesn't fail-close the vote; this ensures the slow voter isn't dropped in the first place (so its input — important for security-sensitive votes — is actually heard).

## Tests

New: `request.timeoutMs` overrides the construction default; falls back when absent. 23 cli-to-model-adapter tests + 57 voter-execution tests pass; typecheck + lint clean. Optional field — existing adapters/callers unaffected.

Closes #3304 (with #3310).

🤖 Generated with [Claude Code](https://claude.com/claude-code)