### PR TITLE
perf(routing): cache the per-cli quality-reward scan (#3261)

### DIFF
--- a/.changeset/quality-reward-cache.md
+++ b/.changeset/quality-reward-cache.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+perf(routing): cache the per-CLI quality-reward scan (#3261)
+
+`computeQualityReward` ran an O(N) `OutcomeStore.query({cli})` scan on every
+`executeTask`; with persistence default-on the store grows, so this was a
+per-task hot-path cost. The per-CLI success rate is now cached with a short TTL
+(15s) — a smoothed historical signal tolerates that staleness. Adds
+`resetQualityRewardCache()` for tests. (Verify-first note: persistence itself was
+already enabled by default — `NEXUS_PERSIST_LEARNING` — so #3261's "no
+persistence" premise was stale; the real cost was the uncached scan.)

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
@@ -15,6 +15,7 @@ import {
   recordZeroRouterOutcome,
   hasMinimumPreferenceData,
   computeQualityReward,
+  resetQualityRewardCache,
   type LastRoutedTaskInfo,
   type OutcomeDependencies,
 } from './composite-router-outcome.js';
@@ -338,6 +339,7 @@ describe('composite-router-outcome', () => {
   describe('computeQualityReward (Issue #929)', () => {
     beforeEach(() => {
       resetOutcomeStore();
+      resetQualityRewardCache();
     });
 
     it('returns 0.1 for failure regardless of history', () => {
@@ -378,6 +380,46 @@ describe('composite-router-outcome', () => {
     it('clamps reward to [0, 1] range', () => {
       expect(computeQualityReward('codex', true, 100_000)).toBeGreaterThanOrEqual(0);
       expect(computeQualityReward('codex', true, 0)).toBeLessThanOrEqual(1);
+    });
+
+    it('caches the per-CLI success rate — avoids re-scanning the store every call (#3261)', () => {
+      const store = getOutcomeStore();
+      for (let i = 0; i < 10; i++) {
+        store.append({
+          id: `c-${String(i)}`,
+          cli: 'claude',
+          category: 'code_generation',
+          model: 'claude-opus',
+          success: true,
+          durationMs: 500,
+          timestamp: new Date().toISOString(),
+          source: 'delegate',
+        });
+      }
+      const querySpy = vi.spyOn(store, 'query');
+      computeQualityReward('claude', true, 0); // miss → scans once
+      computeQualityReward('claude', true, 0); // hit → no scan
+      computeQualityReward('claude', true, 0); // hit → no scan
+      expect(querySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('reset clears the cache so a fresh store is re-scanned (#3261)', () => {
+      const store = getOutcomeStore();
+      store.append({
+        id: 'r-1',
+        cli: 'claude',
+        category: 'code_generation',
+        model: 'claude-opus',
+        success: true,
+        durationMs: 500,
+        timestamp: new Date().toISOString(),
+        source: 'delegate',
+      });
+      const high = computeQualityReward('claude', true, 0); // rate 1.0 → 0.8
+      resetOutcomeStore();
+      resetQualityRewardCache();
+      const base = computeQualityReward('claude', true, 0); // no history → 0.5 base
+      expect(high).toBeGreaterThan(base);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
@@ -8,6 +8,7 @@ import {
   createLogger,
   createSharedTaskAnalyzer,
   taskAnalysisResultToBanditContext,
+  getTimeProvider,
 } from '../core/index.js';
 import type { CliName, CliTask } from './types.js';
 import type { LinUCBBandit } from './linucb-bandit.js';
@@ -139,11 +140,51 @@ const QUALITY_HISTORY_LIMIT = 20;
 const MAX_LATENCY_MS = 30_000;
 
 /**
+ * TTL for the per-CLI success-rate cache (#3261). `computeQualityReward` runs
+ * on every `executeTask`, and `OutcomeStore.query({cli})` is an O(N) scan over
+ * the (now persistent, growing) store. The success rate is a smoothed historical
+ * signal, so a short TTL trades negligible freshness for avoiding the per-task
+ * scan. New outcomes are reflected within one TTL window.
+ */
+const QUALITY_RATE_CACHE_TTL_MS = 15_000;
+
+interface CachedRate {
+  readonly rate: number;
+  readonly computedAt: number;
+}
+
+const qualityRateCache = new Map<CliName, CachedRate>();
+
+/**
+ * Per-CLI success rate over the recent window, cached with a short TTL to avoid
+ * the O(N) OutcomeStore scan on every task. Returns undefined when there is no
+ * history (caller leaves the base reward unadjusted). (#3261)
+ */
+function getCachedCliSuccessRate(cli: CliName): number | undefined {
+  const now = getTimeProvider().now();
+  const cached = qualityRateCache.get(cli);
+  if (cached !== undefined && now - cached.computedAt < QUALITY_RATE_CACHE_TTL_MS) {
+    return cached.rate;
+  }
+  const recent = getOutcomeStore().query({ cli, limit: QUALITY_HISTORY_LIMIT });
+  if (recent.length === 0) return undefined;
+  const rate = recent.filter((o) => o.success).length / recent.length;
+  qualityRateCache.set(cli, { rate, computedAt: now });
+  return rate;
+}
+
+/** Clears the per-CLI success-rate cache. For tests (#3261). */
+export function resetQualityRewardCache(): void {
+  qualityRateCache.clear();
+}
+
+/**
  * Computes a quality-enriched reward using OutcomeStore history.
  *
  * Instead of binary 1/0 rewards, produces continuous rewards (0.1-0.8)
  * that incorporate historical success rate and latency. This enables
- * LinUCB to learn more nuanced model preferences.
+ * LinUCB to learn more nuanced model preferences. The per-CLI success rate
+ * is cached with a short TTL (#3261) so this stays O(1) on the hot path.
  *
  * @param cli - CLI that executed the task
  * @param success - Whether the task succeeded
@@ -156,9 +197,8 @@ export function computeQualityReward(cli: CliName, success: boolean, durationMs:
   let reward = 0.5;
 
   try {
-    const recent = getOutcomeStore().query({ cli, limit: QUALITY_HISTORY_LIMIT });
-    if (recent.length > 0) {
-      const rate = recent.filter((o) => o.success).length / recent.length;
+    const rate = getCachedCliSuccessRate(cli);
+    if (rate !== undefined) {
       reward += rate * 0.3;
     }
   } catch (error: unknown) {


### PR DESCRIPTION
First PR of the self-tuning-loop data plane (epic #3313). `computeQualityReward` (every `executeTask`) ran an O(N) `OutcomeStore.query({cli})` scan; now the per-CLI success rate is cached with a 15s TTL (smoothed signal tolerates it). `resetQualityRewardCache()` for tests.

**Verify-first:** #3261's 'no persistence' premise was stale — persistence is default-on (`NEXUS_PERSIST_LEARNING`); the real cost was the uncached scan.

31 tests pass (2 new: cache-hit avoids re-scan; reset re-scans). Typecheck + lint clean. Part of #3261 / epic #3313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)