### PR TITLE
feat(core): bounded time-decaying TuneAdjustmentStore (#3147 keystone step 1)

### DIFF
--- a/.changeset/tune-adjustment-store.md
+++ b/.changeset/tune-adjustment-store.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+feat(core): bounded, time-decaying TuneAdjustmentStore for the self-tuning loop (#3147)
+
+Adds the provenance-tagged routing-adjustment channel the closed-loop Tune stage
+needs — separate from the LinUCB real-outcome channel (per the P2 ratifying-vote
+dissent). Hard safety bounds: demotion-only (≤1.0), floored (never below 0.5 —
+a CLI is never zeroed out by tuning), capped per step (≤0.2), and time-decaying
+linearly back to 1.0 over 30min so a transient blip auto-reverses. The
+CompositeRouter read (apply the multiplier in TOPSIS scoring) and the TuneStage
+write (enforce path) land in the immediately-following PRs.

--- a/packages/nexus-agents/src/core/index.ts
+++ b/packages/nexus-agents/src/core/index.ts
@@ -16,6 +16,17 @@ export { CircularBuffer } from './circular-buffer.js';
 // Bounded LRU cache — canonical size-bound LRU (#3292)
 export { BoundedLRUCache } from './bounded-lru-cache.js';
 
+// Tune adjustment store — bounded/decaying routing-demotion channel (#3147)
+export {
+  TuneAdjustmentStore,
+  getTuneAdjustmentStore,
+  resetTuneAdjustmentStore,
+  TUNE_DEMOTION_FLOOR,
+  TUNE_MAX_STEP,
+  TUNE_DECAY_WINDOW_MS,
+  type TuneAdjustment,
+} from './tune-adjustment-store.js';
+
 // Step event vocabulary + `withStep` wrapper (#1930 — human console notifications)
 export type {
   StepKind,

--- a/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the bounded, time-decaying TuneAdjustmentStore (#3147, epic #3313).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  TuneAdjustmentStore,
+  TUNE_DEMOTION_FLOOR,
+  TUNE_MAX_STEP,
+  TUNE_DECAY_WINDOW_MS,
+} from './tune-adjustment-store.js';
+import { setTimeProvider, resetTimeProvider, FixedTimeProvider } from './time-provider.js';
+
+describe('TuneAdjustmentStore (#3147)', () => {
+  let clock: FixedTimeProvider;
+
+  beforeEach(() => {
+    clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+  });
+  afterEach(() => {
+    resetTimeProvider();
+  });
+
+  it('defaults to a 1.0 multiplier (no adjustment = no effect)', () => {
+    const store = new TuneAdjustmentStore();
+    expect(store.effectiveMultiplier('claude')).toBe(1.0);
+  });
+
+  it('demotes by a bounded step (demotion-only, ≤ 1.0)', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.2, 'unhealthy');
+    expect(store.effectiveMultiplier('gemini')).toBeCloseTo(0.8, 5);
+  });
+
+  it('caps a single demotion at TUNE_MAX_STEP', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.9, 'big'); // requested 0.9, capped to MAX_STEP
+    expect(store.effectiveMultiplier('gemini')).toBeCloseTo(1.0 - TUNE_MAX_STEP, 5);
+  });
+
+  it('never demotes below the floor, even when compounded', () => {
+    const store = new TuneAdjustmentStore();
+    for (let i = 0; i < 20; i++) store.demote('codex', TUNE_MAX_STEP, 'repeat');
+    expect(store.effectiveMultiplier('codex')).toBeGreaterThanOrEqual(TUNE_DEMOTION_FLOOR);
+    expect(store.effectiveMultiplier('codex')).toBe(TUNE_DEMOTION_FLOOR);
+  });
+
+  it('decays linearly back to 1.0 over the decay window (auto-reversible)', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.2, 'blip'); // multiplier 0.8 at t=0
+    clock.setTime(TUNE_DECAY_WINDOW_MS / 2); // halfway
+    // 0.8 + (1.0 - 0.8) * 0.5 = 0.9
+    expect(store.effectiveMultiplier('gemini')).toBeCloseTo(0.9, 5);
+    clock.setTime(TUNE_DECAY_WINDOW_MS); // fully decayed
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0);
+  });
+
+  it('records provenance (reason) for the active adjustment', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.1, 'swarm_unhealthy: timeouts');
+    const active = store.list();
+    expect(active).toHaveLength(1);
+    expect(active[0]).toMatchObject({ cli: 'gemini', reason: 'swarm_unhealthy: timeouts' });
+  });
+
+  it('clear() removes all adjustments', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.2, 'x');
+    store.clear();
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0);
+  });
+
+  it('ignores non-positive magnitudes (no-op)', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0, 'noop');
+    store.demote('gemini', -0.5, 'noop');
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0);
+  });
+});

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -1,0 +1,113 @@
+/**
+ * TuneAdjustmentStore — the bounded, time-decaying routing-adjustment channel
+ * for the self-tuning loop (#3147, epic #3313).
+ *
+ * The closed-loop Tune stage needs to nudge routing in response to signals
+ * (e.g. `signal.swarm_unhealthy` → demote an unhealthy CLI). Per the P2
+ * ratifying-vote dissent, that nudge must NOT reuse the LinUCB real-outcome
+ * channel — it needs a SEPARATE, provenance-tagged mechanism with hard safety
+ * bounds. This store is that mechanism:
+ *
+ * - **demotion-only** — multipliers are always ≤ 1.0 (we slow a CLI down, never
+ *   boost it past its measured performance).
+ * - **floored** — never below {@link TUNE_DEMOTION_FLOOR}, so a CLI is never
+ *   zeroed out of routing by tuning alone.
+ * - **capped** — a single demotion moves at most {@link TUNE_MAX_STEP}.
+ * - **time-decaying** — each adjustment decays linearly back to 1.0 over
+ *   {@link TUNE_DECAY_WINDOW_MS}, so a transient health blip auto-reverses
+ *   (the loop is self-correcting, not a ratchet).
+ * - **provenance-tagged** — every adjustment carries a `reason`.
+ *
+ * The store holds state only; the caller (TuneStage) is responsible for the
+ * `NEXUS_TUNE_ENFORCE` gate and for auditing each `demote()` to the durable log.
+ * `CompositeRouter` reads `effectiveMultiplier()` to bias candidate scores.
+ *
+ * @module core/tune-adjustment-store
+ */
+
+// @export-no-consumer-yet — see #3147 (keystone step 1: the bounded adjustment
+// mechanism lands first; the CompositeRouter read + TuneStage write are the
+// immediately-following PRs, careful about TOPSIS scoring blast radius).
+import { getTimeProvider } from './time-provider.js';
+
+/** Lowest multiplier tuning can drive a CLI to — never zeroes it out. */
+export const TUNE_DEMOTION_FLOOR = 0.5;
+/** Maximum demotion applied by a single `demote()` call. */
+export const TUNE_MAX_STEP = 0.2;
+/** Time over which an adjustment decays linearly back to 1.0. */
+export const TUNE_DECAY_WINDOW_MS = 30 * 60_000;
+
+/** An active routing demotion with provenance. */
+export interface TuneAdjustment {
+  readonly cli: string;
+  /** Multiplier at `appliedAt` (in [TUNE_DEMOTION_FLOOR, 1.0]). */
+  readonly multiplier: number;
+  readonly appliedAt: number;
+  readonly reason: string;
+}
+
+export class TuneAdjustmentStore {
+  private readonly adjustments = new Map<string, TuneAdjustment>();
+
+  /**
+   * Apply a bounded demotion to `cli`. `magnitude` is the requested reduction
+   * (capped to {@link TUNE_MAX_STEP}); compounds on any current (decayed) value
+   * but never below {@link TUNE_DEMOTION_FLOOR}. Non-positive magnitudes are a
+   * no-op. Returns the resulting adjustment (or undefined for a no-op).
+   */
+  demote(cli: string, magnitude: number, reason: string): TuneAdjustment | undefined {
+    if (magnitude <= 0) return undefined;
+    const step = Math.min(TUNE_MAX_STEP, magnitude);
+    const current = this.effectiveMultiplier(cli);
+    const next = Math.max(TUNE_DEMOTION_FLOOR, current - step);
+    const adjustment: TuneAdjustment = {
+      cli,
+      multiplier: next,
+      appliedAt: getTimeProvider().now(),
+      reason,
+    };
+    this.adjustments.set(cli, adjustment);
+    return adjustment;
+  }
+
+  /**
+   * Current effective multiplier for `cli` — the stored multiplier decayed
+   * linearly back toward 1.0 over {@link TUNE_DECAY_WINDOW_MS}. Returns 1.0
+   * (no effect) when there is no active adjustment. Fully-decayed entries are
+   * evicted lazily.
+   */
+  effectiveMultiplier(cli: string): number {
+    const adjustment = this.adjustments.get(cli);
+    if (adjustment === undefined) return 1.0;
+    const elapsed = getTimeProvider().now() - adjustment.appliedAt;
+    if (elapsed >= TUNE_DECAY_WINDOW_MS || elapsed < 0) {
+      this.adjustments.delete(cli);
+      return 1.0;
+    }
+    const decayFraction = elapsed / TUNE_DECAY_WINDOW_MS;
+    return adjustment.multiplier + (1.0 - adjustment.multiplier) * decayFraction;
+  }
+
+  /** Snapshot of active (non-evicted) adjustments — for observability/audit. */
+  list(): readonly TuneAdjustment[] {
+    return [...this.adjustments.values()];
+  }
+
+  /** Remove all adjustments. */
+  clear(): void {
+    this.adjustments.clear();
+  }
+}
+
+let singleton: TuneAdjustmentStore | undefined;
+
+/** Process-wide TuneAdjustmentStore (lazily created). */
+export function getTuneAdjustmentStore(): TuneAdjustmentStore {
+  singleton ??= new TuneAdjustmentStore();
+  return singleton;
+}
+
+/** Reset the singleton (tests). */
+export function resetTuneAdjustmentStore(): void {
+  singleton = undefined;
+}


### PR DESCRIPTION
Step 1 of the TuneStage bounded-enforce keystone (epic #3313). Adds the provenance-tagged routing-demotion channel (separate from LinUCB per the P2 vote): **demotion-only** (≤1.0), **floored** at 0.5 (never zeroes a CLI), **capped** per step (0.2), **time-decaying** linearly back to 1.0 over 30min (auto-reversible), provenance-tagged. State-only; the `NEXUS_TUNE_ENFORCE` gate + audit live with the caller. Carries the `@export-no-consumer-yet` marker — the CompositeRouter read (TOPSIS stageScores) + TuneStage write land in the next PRs (split out: router-scoring has real blast radius). Default-off → zero behavior change. 8 tests pass; typecheck/lint/gate clean. Part of #3147 / epic #3313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)