### PR TITLE
feat(routing): CompositeRouter applies bounded tune demotions (#3147 keystone step 2)

### DIFF
--- a/.changeset/router-applies-tune.md
+++ b/.changeset/router-applies-tune.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): CompositeRouter applies bounded tune demotions (#3147 keystone step 2)
+
+The router now reads the TuneAdjustmentStore and folds each demoted CLI's
+multiplier into TOPSIS stage scoring as an additive penalty (`-(1 - multiplier)
+
+- 10`, consistent with the distilled penalize/-5 scale; bounded by the store's
+floor to ≈ -5 max). Gated by `NEXUS_TUNE_ENFORCE` — empty/no-op by default, so
+  zero behavior change until the Tune loop is switched on. Completes the read side
+  of the self-tuning loop; the TuneStage write/enforce path is the next step.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -12,7 +12,9 @@ import {
   createSharedTaskAnalyzer,
   taskAnalysisResultToTaskProfile,
   type TaskProfile,
+  getTuneAdjustmentStore,
 } from '../core/index.js';
+import { parseBoolEnv } from '../config/defaults-env.js';
 import type { CliName, CliTask } from './types.js';
 import type { BudgetRouter } from './budget-router.js';
 import type { TopsisRouter } from './topsis-router.js';
@@ -704,7 +706,8 @@ async function runScoringStages(
 /** Aggregates scores from scoring stages + weather bonuses for TOPSIS. (#1354, #1389) */
 function aggregateStageScores(
   scoring: Awaited<ReturnType<typeof runScoringStages>>,
-  taskContent: string
+  taskContent: string,
+  candidates: readonly CliName[]
 ): Map<CliName, number> {
   const weatherScores = getWeatherBonusForTask(taskContent);
   return mergeScoreMaps(
@@ -713,8 +716,35 @@ function aggregateStageScores(
     scoring.knnResult.scores,
     scoring.distilledResult.scores,
     scoring.resourceResult.scores,
-    weatherScores
+    weatherScores,
+    getTuneAdjustmentScores(candidates)
   );
+}
+
+/**
+ * Env flag (#3147): when enabled, the self-tuning loop's bounded routing
+ * demotions are applied as a scoring penalty here. Default off → no-op.
+ */
+const TUNE_ENFORCE_ENV = 'NEXUS_TUNE_ENFORCE';
+
+/**
+ * Translates the bounded TuneAdjustmentStore multiplier into an additive
+ * routing penalty consistent with the stage-score scale (distilled
+ * penalize=-5, avoid=-10). A max demotion (multiplier 0.5) maps to ≈ -5; the
+ * store guarantees the multiplier never drops below its floor, so the penalty
+ * is bounded. Gated by `NEXUS_TUNE_ENFORCE` — empty map (no-op) when disabled.
+ */
+export function getTuneAdjustmentScores(candidates: readonly CliName[]): Map<CliName, number> {
+  const scores = new Map<CliName, number>();
+  if (!parseBoolEnv(TUNE_ENFORCE_ENV, false)) return scores;
+  const store = getTuneAdjustmentStore();
+  for (const cli of candidates) {
+    const multiplier = store.effectiveMultiplier(cli);
+    if (multiplier < 1.0) {
+      scores.set(cli, -(1.0 - multiplier) * 10);
+    }
+  }
+  return scores;
 }
 
 /** Best-effort weather bonus lookup for a task. */
@@ -865,7 +895,7 @@ export async function runPipeline(
   if (!overrideResult.ok) return overrideResult;
   candidates = overrideResult.value;
 
-  const stageScores = aggregateStageScores(scoring, task.content);
+  const stageScores = aggregateStageScores(scoring, task.content, candidates);
   const topsisOpts: Parameters<typeof runTopsisStage>[4] = {
     performanceData: getPerformanceDataForCategory(task.content),
   };

--- a/packages/nexus-agents/src/cli-adapters/tune-routing-penalty.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/tune-routing-penalty.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the tune-demotion → routing-penalty translation (#3147 keystone
+ * step 2). Verifies the CompositeRouter applies the bounded TuneAdjustmentStore
+ * demotion as a scoring penalty, gated by NEXUS_TUNE_ENFORCE.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { CliName } from './types.js';
+import { getTuneAdjustmentScores } from './composite-router-stages.js';
+import { getTuneAdjustmentStore, resetTuneAdjustmentStore } from '../core/index.js';
+
+const CANDIDATES: CliName[] = ['claude', 'gemini', 'codex'];
+
+describe('getTuneAdjustmentScores (#3147 step 2)', () => {
+  beforeEach(() => {
+    resetTuneAdjustmentStore();
+    delete process.env['NEXUS_TUNE_ENFORCE'];
+  });
+  afterEach(() => {
+    resetTuneAdjustmentStore();
+    delete process.env['NEXUS_TUNE_ENFORCE'];
+  });
+
+  it('is a no-op (empty map) when NEXUS_TUNE_ENFORCE is off — default', () => {
+    getTuneAdjustmentStore().demote('gemini', 0.2, 'unhealthy');
+    expect(getTuneAdjustmentScores(CANDIDATES).size).toBe(0);
+  });
+
+  it('applies a bounded negative penalty for a demoted CLI when enforce is on', () => {
+    process.env['NEXUS_TUNE_ENFORCE'] = 'true';
+    getTuneAdjustmentStore().demote('gemini', 0.2, 'unhealthy'); // multiplier 0.8
+    const scores = getTuneAdjustmentScores(CANDIDATES);
+    // -(1 - 0.8) * 10 = -2
+    expect(scores.get('gemini')).toBeCloseTo(-2, 5);
+    // undemoted CLIs get no entry (multiplier 1.0)
+    expect(scores.has('claude')).toBe(false);
+    expect(scores.has('codex')).toBe(false);
+  });
+
+  it('caps the penalty at the floor demotion (never stronger than ~-5)', () => {
+    process.env['NEXUS_TUNE_ENFORCE'] = 'true';
+    const store = getTuneAdjustmentStore();
+    for (let i = 0; i < 10; i++) store.demote('codex', 0.2, 'repeat'); // drives to floor 0.5
+    const penalty = getTuneAdjustmentScores(CANDIDATES).get('codex');
+    // floor 0.5 → -(1 - 0.5) * 10 = -5; never beyond
+    expect(penalty).toBeCloseTo(-5, 5);
+    expect(penalty).toBeGreaterThanOrEqual(-5);
+  });
+});


### PR DESCRIPTION
Step 2 of the TuneStage bounded-enforce keystone (epic #3313). The router reads `TuneAdjustmentStore` and folds each demoted CLI's multiplier into TOPSIS `stageScores` as an additive penalty: `-(1 - multiplier) * 10` — consistent with the existing additive score scale (distilled penalize `-5`, avoid `-10`), and bounded to ≈ -5 by the store's floor. Gated by `NEXUS_TUNE_ENFORCE` (default off → empty map → **zero behavior change**).

Completes the **read** side of the loop (step 1 store #3315 + this). Next: the TuneStage **write/enforce** path (demote on `signal.swarm_unhealthy`) + the swarm_unhealthy producer (#3223).

254 router tests pass (existing unchanged when flag off); 3 new tests (no-op when off, bounded penalty when on, floor-capped). Typecheck + lint clean. Part of #3147 / epic #3313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)