### PR TITLE
fix(routing): vendor-slot fallback so api-mode + new models record outcomes (#3317/#3293)

### DIFF
--- a/.changeset/model-slot-fallback.md
+++ b/.changeset/model-slot-fallback.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+fix(routing): resolve any model to a CliName slot so api-mode + new models are recorded (#3317, #3293)
+
+`resolveCliFromModelString` returned undefined for any model not in the curated
+`MODEL_IDS` list, and `recordOutcome` skips an undefined-cli outcome — so a
+brand-new release (gpt-5.5, claude-4.8) or an API/openrouter model not yet in
+the registry had its routing outcomes silently dropped, breaking LinUCB learning
+and tune signals in api-mode. New `resolveCliSlot(model)` resolves known models
+to their exact slot and falls back to a vendor-derived slot for unknown models
+(anthropic→claude, openai→codex, google→gemini, others→opencode), so the
+routing/outcome/tune pipeline records and learns regardless of CLI-vs-API
+backing or model novelty. Additive — known models keep their exact slot.

--- a/packages/nexus-agents/src/config/model-availability.test.ts
+++ b/packages/nexus-agents/src/config/model-availability.test.ts
@@ -14,6 +14,7 @@ import {
   getAvailabilityCache,
   resetAvailabilityCache,
   filterAvailableModels,
+  resolveCliSlot,
 } from './model-availability.js';
 import type { ProbeResult } from './model-availability.js';
 import type { ModelId } from './model-capabilities-types.js';
@@ -262,5 +263,30 @@ describe('filterAvailableModels', () => {
     const result = filterAvailableModels(ids, cache);
     expect(result.available).toEqual(['claude-sonnet']);
     expect(result.removed).toHaveLength(2);
+  });
+});
+
+describe('resolveCliSlot (#3317/#3293 — slot for any model, incl. new/API)', () => {
+  it('resolves a known curated model to its exact slot', () => {
+    expect(resolveCliSlot('claude-opus')).toBe(getCliForModelId('claude-opus'));
+    expect(resolveCliSlot('gemini-3-pro')).toBe(getCliForModelId('gemini-3-pro'));
+  });
+
+  it('falls back to the vendor slot for UNKNOWN models (the api-mode/new-release gap)', () => {
+    // brand-new releases not yet in the registry
+    expect(resolveCliSlot('claude-5-ultra')).toBe('claude'); // anthropic → claude
+    expect(resolveCliSlot('gpt-6-turbo')).toBe('codex'); // openai → codex
+    expect(resolveCliSlot('gemini-4-pro')).toBe('gemini'); // google → gemini
+  });
+
+  it('routes non-big-3 / unknown vendors to the opencode catch-all slot', () => {
+    expect(resolveCliSlot('qwen-max-9')).toBe('opencode');
+    expect(resolveCliSlot('deepseek-v9')).toBe('opencode');
+    expect(resolveCliSlot('some-totally-unknown-model')).toBe('opencode');
+  });
+
+  it('returns undefined only when no model is present (no execution to attribute)', () => {
+    expect(resolveCliSlot(undefined)).toBeUndefined();
+    expect(resolveCliSlot('')).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/config/model-availability.ts
+++ b/packages/nexus-agents/src/config/model-availability.ts
@@ -11,7 +11,9 @@
 
 import { getTimeProvider } from '../core/index.js';
 import type { ModelId, CliNameLiteral } from './model-capabilities-types.js';
+import { MODEL_IDS } from './model-capabilities-types.js';
 import { DEFAULT_MODEL_PER_CLI } from './in-tree-data.js';
+import { resolveModelIdentitySync, type ModelVendor } from './model-identity.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -179,6 +181,37 @@ export function getCliForModelId(modelId: ModelId): CliNameLiteral | undefined {
     if (defaultModel === modelId) return cli as CliNameLiteral;
   }
   return undefined;
+}
+
+/**
+ * Vendor → canonical `CliName` slot, for models NOT in the curated registry
+ * (brand-new releases, or API/openrouter models). Keeps the routing/outcome/
+ * tune pipeline keyed on a real slot instead of dropping the outcome (#3317 /
+ * #3293). `opencode` is the multi-model catch-all slot for non-big-3 vendors.
+ */
+const VENDOR_TO_CLI_SLOT: Partial<Record<ModelVendor, CliNameLiteral>> = {
+  anthropic: 'claude',
+  google: 'gemini',
+  openai: 'codex',
+};
+
+/**
+ * Resolve a model string to a canonical `CliName` slot for routing/outcome
+ * recording. Known models resolve to their exact curated slot; **unknown**
+ * models (new releases, API/openrouter models not yet in the registry) fall
+ * back to the vendor-derived slot — so the routing/outcome/tune pipeline still
+ * records and learns instead of silently dropping the outcome with an
+ * undefined cli (#3317 / #3293). Returns undefined only for an absent model
+ * (no execution happened).
+ */
+export function resolveCliSlot(model: string | undefined): CliNameLiteral | undefined {
+  if (model === undefined || model === '') return undefined;
+  if ((MODEL_IDS as readonly string[]).includes(model)) {
+    const exact = getCliForModelId(model as ModelId);
+    if (exact !== undefined) return exact;
+  }
+  const { vendor } = resolveModelIdentitySync(model);
+  return VENDOR_TO_CLI_SLOT[vendor] ?? 'opencode';
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/nexus-agents/src/pipeline/expert-bridge.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.ts
@@ -12,20 +12,20 @@
 import { createLogger, getTimeProvider } from '../core/index.js';
 import type { BuiltInExpertType } from '../agents/experts/expert-config.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
-import { getCliForModelId } from '../config/model-availability.js';
-import { MODEL_IDS } from '../config/model-capabilities-types.js';
-import type { CliNameLiteral, ModelId } from '../config/model-capabilities-types.js';
+import { resolveCliSlot } from '../config/model-availability.js';
+import type { CliNameLiteral } from '../config/model-capabilities-types.js';
 
 /**
- * Resolves a CLI from a possibly-unknown model string returned by a CLI
- * response. Returns undefined if the model string isn't in the registry —
- * caller treats undefined as "don't know which CLI ran" rather than
- * fabricating a default (#2823).
+ * Resolves a CLI slot from the model string a (CLI or API) adapter returned.
+ * Known models resolve to their exact slot; **unknown** models — new releases
+ * or API/openrouter models not in the curated registry — fall back to the
+ * vendor-derived slot (#3317 / #3293) so the outcome is recorded against a real
+ * slot instead of being dropped with an undefined cli (the api-mode gap).
+ * Returns undefined only when no model is present (the bridge failed before
+ * dispatch — no execution to attribute).
  */
 function resolveCliFromModelString(model: string | undefined): CliNameLiteral | undefined {
-  if (model === undefined) return undefined;
-  if (!(MODEL_IDS as readonly string[]).includes(model)) return undefined;
-  return getCliForModelId(model as ModelId);
+  return resolveCliSlot(model);
 }
 
 const logger = createLogger({ component: 'expert-bridge' });


### PR DESCRIPTION
## What

The precise, verified root cause behind the owner's api-mode + rapid-new-model concerns. `resolveCliFromModelString` returned **undefined** for any model not in the curated `MODEL_IDS` list, and `recordOutcome` **skips** an undefined-cli outcome — so:
- a **brand-new release** (gpt-5.5, claude-4.8) not yet curated, or
- an **API/openrouter model** not in the registry

had its routing outcomes **silently dropped** → LinUCB never learned, tune signals never fired, for those models in api-mode.

`resolveCliSlot(model)`: known models → exact curated slot; **unknown** models → **vendor-derived slot** (anthropic→claude, openai→codex, google→gemini, all others incl. qwen/deepseek/openrouter→opencode). So the routing/outcome/tune pipeline records and learns regardless of CLI-vs-API backing or model novelty.

## Why this (not the audit's bigger fix)

Verify-first showed the slot-abstraction otherwise holds (factory + UnifiedAdapterRegistry key by `CliName` slot; outcome cli is resolved from the model string, not the raw providerId). The audit's "14 gaps / not first-class" was overstated — **this single strict-membership check was the real gap**, and it unifies #3317 (api parity) with #3293 (rapid new models). The structural two-adapter-plane item (#3183) remains a separate, non-blocking cleanup.

## Safety

**Additive** — known models keep their exact slot (strict lookup wins); only previously-**dropped** unknown models now resolve to a slot. No regression. 34 model-availability tests pass (4 new); typecheck + lint + gate clean.

Closes the functional half of #3317; advances #3293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)