### PR TITLE
feat(tune): bounded routing demotion on swarm_unhealthy (#3147)

### DIFF
--- a/.changeset/tunestage-enforce.md
+++ b/.changeset/tunestage-enforce.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+feat(tune): TuneStage applies bounded routing demotions when enforced (#3147)
+
+Flips the TuneStage enforce path from a fail-closed no-op to a real bounded
+mutation: on `signal.swarm_unhealthy` it calls `TuneAdjustmentStore.demote`
+(demotion-only, floored, capped, time-decaying), audited via a structured log.
+Gated by `NEXUS_TUNE_ENFORCE` — the SAME flag the router read uses, so the loop
+is either fully live or fully shadow, never half-wired. Default off (shadow).
+Non-routing signals (fitness_declined/vote_rejected) stay shadow even when
+enforced — they belong to issue-filing/review paths, not routing. Closes the
+self-tuning loop's write side end-to-end (store + router read + this write).

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -4,9 +4,17 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import type { ILogger } from '../core/index.js';
+import { getTuneAdjustmentStore, resetTuneAdjustmentStore } from '../core/index.js';
 import { EventBus } from './event-bus.js';
 import type { PipelineEvent } from './event-types.js';
 import { createTuneStage, intendedActionFor } from './tune-stage.js';
+
+const swarmSignal: PipelineEvent = {
+  type: 'signal.swarm_unhealthy',
+  timestamp: 3,
+  agentId: 'gemini',
+  reason: 'repeated timeouts',
+};
 
 function spyLogger(): ILogger {
   return {
@@ -80,16 +88,51 @@ describe('createTuneStage shadow mode (#3147)', () => {
     expect(logger.info).not.toHaveBeenCalled();
   });
 
-  it('enabled=true fails closed (logs no-op, does NOT mutate) — PR-4 not implemented', () => {
+  it('enabled=true applies a bounded routing demotion on swarm_unhealthy (#3147)', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    const logger = spyLogger();
+    createTuneStage(bus, { logger, enabled: true });
+
+    expect(getTuneAdjustmentStore().effectiveMultiplier('gemini')).toBe(1.0); // baseline
+    bus.emit(swarmSignal);
+
+    // store mutated: gemini demoted (multiplier < 1.0, floored/capped by the store)
+    expect(getTuneAdjustmentStore().effectiveMultiplier('gemini')).toBeLessThan(1.0);
+    expect(logger.info).toHaveBeenCalledWith(
+      'TuneStage (enforce) — applied bounded routing demotion',
+      expect.objectContaining({ agentId: 'gemini', signal: 'signal.swarm_unhealthy' })
+    );
+    resetTuneAdjustmentStore();
+  });
+
+  it('enabled=true does NOT mutate routing for non-routing signals (vote_rejected stays shadow)', () => {
+    resetTuneAdjustmentStore();
     const bus = new EventBus();
     const logger = spyLogger();
     createTuneStage(bus, { logger, enabled: true });
     bus.emit(voteSignal);
-    expect(logger.warn).toHaveBeenCalledWith(
-      'TuneStage enabled but bounded mutation is not implemented yet; no-op',
+    expect(logger.info).toHaveBeenCalledWith(
+      'TuneStage (enforce) — non-routing action, shadow-only',
       expect.objectContaining({ kind: 'record_rejection' })
     );
-    expect(logger.info).not.toHaveBeenCalled();
+    // no routing mutation from a non-routing signal
+    expect(getTuneAdjustmentStore().list()).toHaveLength(0);
+    resetTuneAdjustmentStore();
+  });
+
+  it('disabled (shadow) does NOT mutate routing even on swarm_unhealthy', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    const logger = spyLogger();
+    createTuneStage(bus, { logger }); // enabled defaults false
+    bus.emit(swarmSignal);
+    expect(getTuneAdjustmentStore().effectiveMultiplier('gemini')).toBe(1.0);
+    expect(logger.info).toHaveBeenCalledWith(
+      'TuneStage (shadow) — intended action',
+      expect.objectContaining({ kind: 'downweight_agent' })
+    );
+    resetTuneAdjustmentStore();
   });
 
   it('unsubscribe stops the stage', () => {

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -16,11 +16,22 @@
  * @module pipeline/tune-stage
  */
 
-import { createLogger, getErrorMessage } from '../core/index.js';
+import { createLogger, getErrorMessage, getTuneAdjustmentStore } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
+import { parseBoolEnv } from '../config/defaults-env.js';
 import type { PipelineEvent, IEventBus, Unsubscribe } from './event-types.js';
 
 const defaultLogger = createLogger({ component: 'TuneStage' });
+
+/** Env flag gating real enforcement (shared with the router read, #3147). */
+const TUNE_ENFORCE_ENV = 'NEXUS_TUNE_ENFORCE';
+
+/**
+ * Demotion magnitude applied per `swarm_unhealthy` signal. Kept under the
+ * store's per-step cap (`TUNE_MAX_STEP`); the store also floors and time-decays
+ * it, so repeated unhealthy signals slow a CLI down gradually and reversibly.
+ */
+const TUNE_ENFORCE_DEMOTION = 0.15;
 
 /** Signal event types the TuneStage reacts to. */
 export const TUNE_SIGNAL_TYPES = [
@@ -93,10 +104,32 @@ export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}):
       const action = intendedActionFor(event);
       if (action === undefined) return;
       if (enabled) {
-        // #3147 PR-4 (human-gated) not implemented — fail closed, never mutate.
-        log.warn('TuneStage enabled but bounded mutation is not implemented yet; no-op', {
+        if (event.type === 'signal.swarm_unhealthy') {
+          // Bounded auto-enforce (#3147): apply a routing demotion via the
+          // TuneAdjustmentStore, which guarantees demotion-only, floored,
+          // capped, and time-decaying (auto-reversible). The router reads this
+          // (behind the same flag) as a scoring penalty. Audited via this log.
+          const adjustment = getTuneAdjustmentStore().demote(
+            event.agentId,
+            TUNE_ENFORCE_DEMOTION,
+            `swarm_unhealthy: ${event.reason}`
+          );
+          log.info('TuneStage (enforce) — applied bounded routing demotion', {
+            kind: action.kind,
+            signal: action.signal,
+            agentId: event.agentId,
+            reason: event.reason,
+            multiplier: adjustment?.multiplier,
+          });
+          return;
+        }
+        // Other signals' actions (flag_tech_debt / record_rejection) are not
+        // routing mutations — they belong to issue-filing / review paths, not
+        // the TuneAdjustmentStore. Keep shadow-logging until those land.
+        log.info('TuneStage (enforce) — non-routing action, shadow-only', {
           kind: action.kind,
           signal: action.signal,
+          detail: action.detail,
         });
         return;
       }
@@ -127,7 +160,11 @@ let cachedTuneUnsubscribe: Unsubscribe | null = null;
  */
 export function startTuneStage(bus: IEventBus, options?: TuneStageOptions): void {
   if (cachedTuneUnsubscribe !== null) return;
-  cachedTuneUnsubscribe = createTuneStage(bus, options);
+  // Enforcement is gated by the same flag the router read uses, so the loop is
+  // either fully live or fully shadow — never half-wired. Explicit options
+  // (tests) override the flag. Default off → shadow (#3147).
+  const enabled = options?.enabled ?? parseBoolEnv(TUNE_ENFORCE_ENV, false);
+  cachedTuneUnsubscribe = createTuneStage(bus, { ...options, enabled });
 }
 
 /** Release the server-wide TuneStage subscription. Idempotent. */


### PR DESCRIPTION
Step 3 (write side) of the self-tuning loop. `TuneStage` enforce path now calls `TuneAdjustmentStore.demote` on `signal.swarm_unhealthy` (bounded: demotion-only, floored 0.5, capped 0.2/step, time-decaying/auto-reversible), audited via structured log. Gated by `NEXUS_TUNE_ENFORCE` — the same flag the router read (#3316) uses, so the loop is fully live or fully shadow, never half-wired. Default off. Non-routing signals (fitness_declined/vote_rejected) stay shadow. With #3315 (store) + #3316 (router read), this **closes the loop end-to-end**; the `swarm_unhealthy` producer (#3223) is the final piece to make it fire. 8 tune-stage tests pass; typecheck + lint clean. Part of #3147 / epic #3313. 🤖 Generated with [Claude Code](https://claude.com/claude-code)