### PR TITLE
feat(observability): emit signal.swarm_unhealthy from swarm health (#3223)

### DIFF
--- a/.changeset/swarm-unhealthy-producer.md
+++ b/.changeset/swarm-unhealthy-producer.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(observability): emit signal.swarm_unhealthy from SwarmObserver health (#3223)
+
+Adds the final producer that makes the self-tuning loop fire end-to-end. A
+server-lifecycle poll reads `SwarmObserver.getHealthMetrics()` and emits
+`signal.swarm_unhealthy` onto the typed pipeline bus for CLI-attributable
+severe (high/critical) bottlenecks. The (shadow-by-default) TuneStage consumes
+it; under `NEXUS_TUNE_ENFORCE` it applies a bounded, decaying routing demotion.
+Attribution is conservative — a bottleneck only signals when its agentId
+confidently resolves to a canonical CLI slot (CLI-name literal or curated model
+id); role names / trace ids are skipped (debug-logged), never mis-attributed to
+the opencode catch-all. Closes the observability→routing gap (#3223): rich swarm
+health was previously write-only for dashboards.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -74,6 +74,7 @@ import { getPipelineEventBus } from './pipeline/event-bus.js';
 import { createEventBusBridge } from './pipeline/event-bus-bridge.js';
 import { startFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
 import { startTuneStage } from './pipeline/tune-stage.js';
+import { getSwarmObserver, startSwarmHealthSignals } from './observability/index.js';
 import { getOutcomeStore } from './orchestration/outcomes/index.js';
 import { createDefaultPolicyEngine } from './pipeline/policy-engine.js';
 import { resolveV2Config } from './pipeline/v2-config.js';
@@ -620,6 +621,11 @@ function initV2PipelineSubsystems(logger: ILogger): void {
   // mode — logs intended actions, mutates nothing. Paired with
   // shutdownTuneStage() in cli-server.ts:createShutdownCleanup.
   startTuneStage(pipelineEventBus);
+  // Close the loop's final producer: poll SwarmObserver health and emit
+  // signal.swarm_unhealthy for CLI-attributable bottlenecks onto the same bus
+  // (#3223). Paired with shutdownSwarmHealthSignals() in
+  // cli-server.ts:createShutdownCleanup.
+  startSwarmHealthSignals(getSwarmObserver(), pipelineEventBus);
   const policyEngine = createDefaultPolicyEngine();
   const v2Config = resolveV2Config();
   logger.info('V2 Pipeline OS initialized', {

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -24,7 +24,7 @@ import { createLogger, type ILogger } from './core/index.js';
 import { VERSION } from './version.js';
 import { detectMode, type ServerMode, type ModeDetectionResult } from './cli/index.js';
 import { EXIT_CODES } from './cli-types.js';
-import { SwarmObserver } from './observability/index.js';
+import { SwarmObserver, shutdownSwarmHealthSignals } from './observability/index.js';
 import { initializeSandbox, getSandboxMode } from './security/sandbox/index.js';
 import {
   initializeSwarmObserver,
@@ -240,6 +240,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Release the shadow TuneStage signal subscription (#3147)
     shutdownTuneStage();
+
+    // Release the swarm-health signal poll timer (#3223)
+    shutdownSwarmHealthSignals();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/observability/index.ts
+++ b/packages/nexus-agents/src/observability/index.ts
@@ -52,6 +52,15 @@ export {
   setSwarmObserver,
 } from './swarm-observer.js';
 
+// SwarmObserver → pipeline-bus signal producer (#3223)
+export {
+  emitSwarmUnhealthySignals,
+  confidentCliSlot,
+  startSwarmHealthSignals,
+  shutdownSwarmHealthSignals,
+} from './swarm-health-signals.js';
+export type { SwarmHealthSignalsOptions } from './swarm-health-signals.js';
+
 // Dashboard Types
 export type {
   DashboardFormat,

--- a/packages/nexus-agents/src/observability/swarm-health-signals.test.ts
+++ b/packages/nexus-agents/src/observability/swarm-health-signals.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the SwarmObserver → pipeline-bus signal producer (#3223).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ILogger } from '../core/index.js';
+import { EventBus } from '../pipeline/event-bus.js';
+import type { PipelineEvent } from '../pipeline/event-types.js';
+import type { BottleneckInfo, SwarmHealthMetrics } from './swarm-observer-types.js';
+import {
+  confidentCliSlot,
+  emitSwarmUnhealthySignals,
+  startSwarmHealthSignals,
+  shutdownSwarmHealthSignals,
+} from './swarm-health-signals.js';
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+function bottleneck(over: Partial<BottleneckInfo>): BottleneckInfo {
+  return {
+    agentId: 'claude',
+    queuedMessages: 12,
+    avgWaitTimeMs: 500,
+    blockedAgents: 3,
+    severity: 'high',
+    ...over,
+  };
+}
+
+function metrics(bottlenecks: BottleneckInfo[]): SwarmHealthMetrics {
+  return {
+    totalAgents: 4,
+    activeAgents: 4,
+    errorAgents: 0,
+    totalInteractions: 100,
+    successRate: 0.8,
+    avgLatencyMs: 200,
+    bottlenecks,
+    clusters: [],
+    calculatedAt: '2026-06-01T00:00:00.000Z',
+  };
+}
+
+function capture(bus: EventBus): PipelineEvent[] {
+  const seen: PipelineEvent[] = [];
+  bus.subscribe({ type: ['signal.swarm_unhealthy'] }, (e) => seen.push(e));
+  return seen;
+}
+
+describe('confidentCliSlot (#3223)', () => {
+  it('resolves CLI-name literals to themselves', () => {
+    expect(confidentCliSlot('claude')).toBe('claude');
+    expect(confidentCliSlot('gemini')).toBe('gemini');
+    expect(confidentCliSlot('codex')).toBe('codex');
+    expect(confidentCliSlot('opencode')).toBe('opencode');
+  });
+
+  it('resolves curated model ids to their slot', () => {
+    expect(confidentCliSlot('claude-opus')).toBe('claude');
+    expect(confidentCliSlot('gemini-3-pro')).toBe('gemini');
+  });
+
+  it('returns undefined for non-CLI-attributable ids (no mis-attribution)', () => {
+    expect(confidentCliSlot('architect')).toBeUndefined();
+    expect(confidentCliSlot('voter-7')).toBeUndefined();
+    expect(confidentCliSlot('mcp-server')).toBeUndefined();
+    expect(confidentCliSlot('trace-abc123')).toBeUndefined();
+  });
+});
+
+describe('emitSwarmUnhealthySignals (#3223)', () => {
+  it('emits a signal for a severe, CLI-attributable bottleneck', () => {
+    const bus = new EventBus();
+    const seen = capture(bus);
+    const n = emitSwarmUnhealthySignals(
+      metrics([bottleneck({ agentId: 'gemini', severity: 'critical' })]),
+      bus,
+      spyLogger()
+    );
+    expect(n).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      type: 'signal.swarm_unhealthy',
+      agentId: 'gemini',
+    });
+    expect((seen[0] as { reason: string }).reason).toContain('severity critical');
+  });
+
+  it('ignores non-severe (low/medium) bottlenecks', () => {
+    const bus = new EventBus();
+    const seen = capture(bus);
+    const n = emitSwarmUnhealthySignals(
+      metrics([
+        bottleneck({ agentId: 'claude', severity: 'low' }),
+        bottleneck({ agentId: 'codex', severity: 'medium' }),
+      ]),
+      bus,
+      spyLogger()
+    );
+    expect(n).toBe(0);
+    expect(seen).toHaveLength(0);
+  });
+
+  it('skips non-CLI-attributable agents with a debug log, never mis-attributing', () => {
+    const bus = new EventBus();
+    const seen = capture(bus);
+    const logger = spyLogger();
+    const n = emitSwarmUnhealthySignals(
+      metrics([bottleneck({ agentId: 'architect', severity: 'critical' })]),
+      bus,
+      logger
+    );
+    expect(n).toBe(0);
+    expect(seen).toHaveLength(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Skipping non-CLI-attributable bottleneck',
+      expect.objectContaining({ agentId: 'architect' })
+    );
+  });
+
+  it('dedups to at most one signal per CLI slot', () => {
+    const bus = new EventBus();
+    const seen = capture(bus);
+    const n = emitSwarmUnhealthySignals(
+      metrics([
+        bottleneck({ agentId: 'claude', severity: 'high', queuedMessages: 20 }),
+        bottleneck({ agentId: 'claude', severity: 'critical', queuedMessages: 30 }),
+      ]),
+      bus,
+      spyLogger()
+    );
+    expect(n).toBe(1);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('emits nothing for an empty bottleneck list', () => {
+    const bus = new EventBus();
+    const seen = capture(bus);
+    expect(emitSwarmUnhealthySignals(metrics([]), bus, spyLogger())).toBe(0);
+    expect(seen).toHaveLength(0);
+  });
+});
+
+describe('startSwarmHealthSignals / shutdownSwarmHealthSignals (#3223)', () => {
+  it('polls the observer and emits, then stops cleanly on shutdown', () => {
+    vi.useFakeTimers();
+    try {
+      const bus = new EventBus();
+      const seen = capture(bus);
+      const getHealthMetrics = vi.fn(() =>
+        metrics([bottleneck({ agentId: 'codex', severity: 'critical' })])
+      );
+      // Minimal ISwarmObserver stand-in: only getHealthMetrics is exercised.
+      const observer = { getHealthMetrics } as unknown as Parameters<
+        typeof startSwarmHealthSignals
+      >[0];
+
+      startSwarmHealthSignals(observer, bus, { intervalMs: 1000, logger: spyLogger() });
+      // Idempotent: a second start does not add a second timer.
+      startSwarmHealthSignals(observer, bus, { intervalMs: 1000, logger: spyLogger() });
+
+      vi.advanceTimersByTime(1000);
+      expect(getHealthMetrics).toHaveBeenCalledTimes(1);
+      expect(seen).toHaveLength(1);
+
+      vi.advanceTimersByTime(1000);
+      expect(seen).toHaveLength(2);
+
+      shutdownSwarmHealthSignals();
+      vi.advanceTimersByTime(5000);
+      expect(seen).toHaveLength(2); // no further emissions after shutdown
+    } finally {
+      shutdownSwarmHealthSignals();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/nexus-agents/src/observability/swarm-health-signals.ts
+++ b/packages/nexus-agents/src/observability/swarm-health-signals.ts
@@ -1,0 +1,147 @@
+/**
+ * SwarmObserver → pipeline-bus signal producer (#3223, epic #3143 P2).
+ *
+ * Closes the long-standing observability→routing gap: the SwarmObserver
+ * collected rich agent-health metrics (bottlenecks, error agents, success rate)
+ * that were write-only for dashboards and never fed back into routing. This
+ * module polls the observer's health metrics and emits `signal.swarm_unhealthy`
+ * onto the typed pipeline event bus for CLI-attributable bottlenecks. The
+ * (shadow-by-default) TuneStage consumes the signal and — when
+ * `NEXUS_TUNE_ENFORCE` is set — applies a bounded, decaying routing demotion via
+ * the TuneAdjustmentStore. This is the final producer that makes the closed
+ * loop fire end-to-end.
+ *
+ * Lives at the observability layer and PUSHES to bus A on a timer, mirroring the
+ * `consensus-vote-signals` / `improvement-review-signals` producers: the
+ * SwarmObserver stays decoupled from the pipeline bus, preserving the
+ * `A = observability / B = messaging` boundary (#3289 scope Option 2).
+ *
+ * Attribution is deliberately conservative: a bottleneck only produces a signal
+ * when its `agentId` confidently resolves to one of the four canonical CLI slots
+ * (a CLI-name literal, or a curated model id). Arbitrary agent identifiers
+ * (role names, trace ids, voter ids) are skipped with a debug log rather than
+ * mis-attributed to the `opencode` catch-all — demoting the wrong CLI is worse
+ * than not demoting at all. Broader agent→CLI attribution is tracked separately.
+ *
+ * @module observability/swarm-health-signals
+ */
+
+import { createLogger, getErrorMessage } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+import { CLI_NAMES } from '../config/model-capabilities-types.js';
+import type { CliNameLiteral, ModelId } from '../config/model-capabilities-types.js';
+import { getCliForModelId } from '../config/model-availability.js';
+import type { IEventBus } from '../pipeline/event-types.js';
+import type { ISwarmObserver, SwarmHealthMetrics } from './swarm-observer-types.js';
+
+const defaultLogger = createLogger({ component: 'SwarmHealthSignals' });
+
+/** Bottleneck severities severe enough to warrant a routing signal. */
+const SEVERE_BOTTLENECK = new Set<string>(['high', 'critical']);
+
+/** Default poll interval for health → signal emission. */
+const DEFAULT_HEALTH_SIGNAL_INTERVAL_MS = 60_000;
+
+const CLI_NAME_SET = new Set<string>(CLI_NAMES);
+
+/**
+ * Resolve an arbitrary SwarmObserver `agentId` to a canonical CLI slot, but
+ * ONLY when the mapping is confident: the id is already a CLI-name literal, or
+ * it is a curated model id. Returns undefined for anything else — we never guess
+ * a slot for a role name / trace id, which would mis-attribute the demotion.
+ */
+export function confidentCliSlot(agentId: string): CliNameLiteral | undefined {
+  if (CLI_NAME_SET.has(agentId)) return agentId as CliNameLiteral;
+  return getCliForModelId(agentId as ModelId);
+}
+
+/**
+ * Emit `signal.swarm_unhealthy` for each CLI-attributable severe bottleneck in
+ * `metrics`. At most one signal per CLI slot per call (deduped). Non-attributable
+ * bottlenecks are skipped with a debug log. Returns the number of signals
+ * emitted. Emission errors are swallowed and logged — observability signalling
+ * must never break the caller.
+ */
+export function emitSwarmUnhealthySignals(
+  metrics: SwarmHealthMetrics,
+  bus: IEventBus,
+  logger: ILogger = defaultLogger
+): number {
+  const emittedSlots = new Set<CliNameLiteral>();
+  try {
+    for (const bottleneck of metrics.bottlenecks) {
+      if (!SEVERE_BOTTLENECK.has(bottleneck.severity)) continue;
+
+      const slot = confidentCliSlot(bottleneck.agentId);
+      if (slot === undefined) {
+        logger.debug('Skipping non-CLI-attributable bottleneck', {
+          agentId: bottleneck.agentId,
+          severity: bottleneck.severity,
+        });
+        continue;
+      }
+      if (emittedSlots.has(slot)) continue;
+      emittedSlots.add(slot);
+
+      bus.emit({
+        type: 'signal.swarm_unhealthy',
+        timestamp: Date.parse(metrics.calculatedAt),
+        agentId: slot,
+        reason: `bottleneck: ${String(bottleneck.queuedMessages)} queued, ${String(bottleneck.blockedAgents)} blocked (severity ${bottleneck.severity})`,
+      });
+    }
+  } catch (error) {
+    logger.warn('Failed to emit signal.swarm_unhealthy', { error: getErrorMessage(error) });
+  }
+  return emittedSlots.size;
+}
+
+// ============================================================================
+// Server-wide lifecycle (#3223) — mirrors tune-stage.ts start/shutdown.
+//
+// cli-server-tools.ts:initV2PipelineSubsystems calls startSwarmHealthSignals()
+// at server init (paired with the TuneStage consumer), and cli-server.ts:
+// createShutdownCleanup calls shutdownSwarmHealthSignals().
+// ============================================================================
+
+export interface SwarmHealthSignalsOptions {
+  /** Poll interval in ms. Default 60_000. */
+  readonly intervalMs?: number;
+  /** Injectable logger. */
+  readonly logger?: ILogger;
+}
+
+let healthSignalTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Poll the SwarmObserver's health metrics on an interval and emit
+ * `signal.swarm_unhealthy` for CLI-attributable bottlenecks. Idempotent —
+ * repeated calls are no-ops while a timer is active. Caller must invoke
+ * `shutdownSwarmHealthSignals()` on server shutdown to release the timer.
+ */
+export function startSwarmHealthSignals(
+  observer: ISwarmObserver,
+  bus: IEventBus,
+  options?: SwarmHealthSignalsOptions
+): void {
+  if (healthSignalTimer !== undefined) return;
+  const logger = options?.logger ?? defaultLogger;
+  const intervalMs = options?.intervalMs ?? DEFAULT_HEALTH_SIGNAL_INTERVAL_MS;
+  healthSignalTimer = setInterval(() => {
+    try {
+      emitSwarmUnhealthySignals(observer.getHealthMetrics(), bus, logger);
+    } catch (error) {
+      logger.debug('Swarm health poll failed', { error: getErrorMessage(error) });
+    }
+  }, intervalMs);
+  // Do not keep the process alive solely for the health poll.
+  healthSignalTimer.unref();
+}
+
+/** Release the server-wide swarm-health signal timer. Idempotent. */
+export function shutdownSwarmHealthSignals(): void {
+  if (healthSignalTimer !== undefined) {
+    clearInterval(healthSignalTimer);
+    healthSignalTimer = undefined;
+  }
+}


### PR DESCRIPTION
## What

The **final producer** that makes the self-tuning loop (epic #3143 / #3147) fire end-to-end. Closes the observability→routing gap called out in #3223: `SwarmObserver` collected rich agent-health metrics that were **write-only for dashboards** and never fed back into routing.

A server-lifecycle poll (`startSwarmHealthSignals`, paired with `shutdownSwarmHealthSignals`, mirroring the TuneStage consumer wiring in `initV2PipelineSubsystems`) reads `SwarmObserver.getHealthMetrics()` and emits `signal.swarm_unhealthy` onto the typed pipeline bus for **severe (high/critical) bottlenecks**. The shadow-by-default `TuneStage` consumes it; under `NEXUS_TUNE_ENFORCE` it applies a bounded, floored, decaying routing demotion via `TuneAdjustmentStore`.

## Conservative attribution (no mis-demotion)

A bottleneck only produces a signal when its `agentId` **confidently** resolves to a canonical CLI slot — a CLI-name literal (`claude`/`gemini`/`codex`/`opencode`) or a curated model id. Arbitrary identifiers (role names, voter ids, trace ids) are **skipped with a debug log**, never mapped to the `opencode` catch-all. Demoting the wrong CLI is worse than not demoting — per the verify-first / #2225 discipline. errorAgents/successRate are swarm-wide (not CLI-attributable), so bottlenecks are the per-agent source.

## The loop, now firing end-to-end (behind `NEXUS_TUNE_ENFORCE`)

producer **(this PR, #3223)** → `signal.swarm_unhealthy` on bus A → TuneStage write (#3319) → `TuneAdjustmentStore` (#3315) → CompositeRouter read (#3316). Default off = full shadow.

## Tests

9 producer tests (confident-slot mapping incl. the skip-no-mis-attribute case; severity filter; per-slot dedup; empty; fake-timer poll + idempotent start + clean shutdown). 1994 interacting observability + signal-loop tests pass. Typecheck + lint clean.

## Follow-up (tracked separately)

`adapter.failover` events from `ResilientAdapter` already carry the exact `CliName` — a second, more-reliable producer mapping those to `signal.swarm_unhealthy` would make the loop fire on real CLI circuit-breaker trips. Will file as a follow-up issue.

Closes #3223. Part of epic #3143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)