### PR TITLE
feat(observability): emit signal.swarm_unhealthy from adapter failovers (#3321)

### DIFF
--- a/.changeset/failover-signal-producer.md
+++ b/.changeset/failover-signal-producer.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': minor
+---
+
+feat(observability): emit signal.swarm_unhealthy from adapter failovers (#3321)
+
+Adds a second, higher-reliability `signal.swarm_unhealthy` producer alongside
+the SwarmObserver-bottleneck poll (#3223). `ResilientAdapter` emits
+`adapter.failover` events on the collaboration bus whose payload carries the
+exact `CliName` and health state on circuit-breaker trips / failovers. This
+producer subscribes to that bus and re-emits `signal.swarm_unhealthy` on the
+typed pipeline bus when an adapter degrades or becomes unavailable — directly
+CLI-attributable, no `confidentCliSlot` guesswork. A per-CLI cooldown absorbs
+breaker flapping. `api`-source and healthy events are ignored. The
+shadow-by-default TuneStage consumes it; under `NEXUS_TUNE_ENFORCE` it applies a
+bounded, decaying routing demotion. Bus direction is B→A, preserving the
+observability/messaging boundary.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -74,7 +74,11 @@ import { getPipelineEventBus } from './pipeline/event-bus.js';
 import { createEventBusBridge } from './pipeline/event-bus-bridge.js';
 import { startFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
 import { startTuneStage } from './pipeline/tune-stage.js';
-import { getSwarmObserver, startSwarmHealthSignals } from './observability/index.js';
+import {
+  getSwarmObserver,
+  startSwarmHealthSignals,
+  startFailoverSignals,
+} from './observability/index.js';
 import { getOutcomeStore } from './orchestration/outcomes/index.js';
 import { createDefaultPolicyEngine } from './pipeline/policy-engine.js';
 import { resolveV2Config } from './pipeline/v2-config.js';
@@ -626,6 +630,10 @@ function initV2PipelineSubsystems(logger: ILogger): void {
   // (#3223). Paired with shutdownSwarmHealthSignals() in
   // cli-server.ts:createShutdownCleanup.
   startSwarmHealthSignals(getSwarmObserver(), pipelineEventBus);
+  // Second, higher-reliability producer: re-emit adapter.failover events (which
+  // carry the exact CliName) from bus B as signal.swarm_unhealthy on bus A
+  // (#3321). Paired with shutdownFailoverSignals() in cli-server.ts.
+  startFailoverSignals({ pipelineBus: pipelineEventBus });
   const policyEngine = createDefaultPolicyEngine();
   const v2Config = resolveV2Config();
   logger.info('V2 Pipeline OS initialized', {

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -24,7 +24,11 @@ import { createLogger, type ILogger } from './core/index.js';
 import { VERSION } from './version.js';
 import { detectMode, type ServerMode, type ModeDetectionResult } from './cli/index.js';
 import { EXIT_CODES } from './cli-types.js';
-import { SwarmObserver, shutdownSwarmHealthSignals } from './observability/index.js';
+import {
+  SwarmObserver,
+  shutdownSwarmHealthSignals,
+  shutdownFailoverSignals,
+} from './observability/index.js';
 import { initializeSandbox, getSandboxMode } from './security/sandbox/index.js';
 import {
   initializeSwarmObserver,
@@ -243,6 +247,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Release the swarm-health signal poll timer (#3223)
     shutdownSwarmHealthSignals();
+
+    // Release the adapter-failover signal subscription (#3321)
+    shutdownFailoverSignals();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/observability/failover-signals.test.ts
+++ b/packages/nexus-agents/src/observability/failover-signals.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the adapter-failover → pipeline-bus signal producer (#3321).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus as CollaborationBus, createEvent } from '../core/event-bus.js';
+import { EventBus as PipelineBus } from '../pipeline/event-bus.js';
+import type { PipelineEvent } from '../pipeline/event-types.js';
+import type { AdapterHealthInfo } from '../adapters/resilient-adapter-types.js';
+import {
+  unhealthyCliFrom,
+  startFailoverSignals,
+  shutdownFailoverSignals,
+} from './failover-signals.js';
+
+function healthInfo(over: Partial<AdapterHealthInfo>): AdapterHealthInfo {
+  return {
+    source: 'gemini',
+    state: 'degraded',
+    selectedAt: new Date('2026-06-01T00:00:00.000Z'),
+    failoverCount: 2,
+    ...over,
+  };
+}
+
+function captureSignals(bus: PipelineBus): PipelineEvent[] {
+  const seen: PipelineEvent[] = [];
+  bus.subscribe({ type: ['signal.swarm_unhealthy'] }, (e) => seen.push(e));
+  return seen;
+}
+
+describe('unhealthyCliFrom (#3321)', () => {
+  it('maps a degraded/unavailable CLI adapter to an unhealthy signal payload', () => {
+    expect(unhealthyCliFrom(healthInfo({ source: 'codex', state: 'unavailable' }))).toMatchObject({
+      cli: 'codex',
+    });
+    const r = unhealthyCliFrom(
+      healthInfo({ source: 'gemini', state: 'degraded', lastError: 'timeout' })
+    );
+    expect(r?.cli).toBe('gemini');
+    expect(r?.reason).toContain('timeout');
+  });
+
+  it('returns undefined for a healthy adapter', () => {
+    expect(unhealthyCliFrom(healthInfo({ state: 'healthy' }))).toBeUndefined();
+  });
+
+  it('returns undefined when the source is api (not a routing slot)', () => {
+    expect(unhealthyCliFrom(healthInfo({ source: 'api', state: 'unavailable' }))).toBeUndefined();
+  });
+
+  it('returns undefined for malformed payloads', () => {
+    expect(unhealthyCliFrom(undefined)).toBeUndefined();
+    expect(unhealthyCliFrom(null)).toBeUndefined();
+    expect(unhealthyCliFrom('nope')).toBeUndefined();
+    expect(unhealthyCliFrom({ source: 'not-a-cli', state: 'degraded' })).toBeUndefined();
+  });
+});
+
+describe('startFailoverSignals / shutdownFailoverSignals (#3321)', () => {
+  function emitFailover(bus: CollaborationBus, info: AdapterHealthInfo): void {
+    bus.emit(createEvent('adapter.failover', info));
+  }
+
+  it('re-emits adapter.failover as signal.swarm_unhealthy on bus A', () => {
+    const sourceBus = new CollaborationBus();
+    const pipelineBus = new PipelineBus();
+    const seen = captureSignals(pipelineBus);
+    try {
+      startFailoverSignals({ sourceBus, pipelineBus });
+      emitFailover(sourceBus, healthInfo({ source: 'gemini', state: 'unavailable' }));
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({ type: 'signal.swarm_unhealthy', agentId: 'gemini' });
+    } finally {
+      shutdownFailoverSignals();
+    }
+  });
+
+  it('does not emit for healthy or api failover events', () => {
+    const sourceBus = new CollaborationBus();
+    const pipelineBus = new PipelineBus();
+    const seen = captureSignals(pipelineBus);
+    try {
+      startFailoverSignals({ sourceBus, pipelineBus });
+      emitFailover(sourceBus, healthInfo({ state: 'healthy' }));
+      emitFailover(sourceBus, healthInfo({ source: 'api', state: 'unavailable' }));
+      expect(seen).toHaveLength(0);
+    } finally {
+      shutdownFailoverSignals();
+    }
+  });
+
+  it('applies a per-CLI cooldown to absorb breaker flapping', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T00:00:00.000Z'));
+    const sourceBus = new CollaborationBus();
+    const pipelineBus = new PipelineBus();
+    const seen = captureSignals(pipelineBus);
+    try {
+      startFailoverSignals({ sourceBus, pipelineBus, cooldownMs: 30_000 });
+      emitFailover(sourceBus, healthInfo({ source: 'codex', state: 'degraded' }));
+      emitFailover(sourceBus, healthInfo({ source: 'codex', state: 'unavailable' }));
+      expect(seen).toHaveLength(1); // second within cooldown is suppressed
+
+      vi.advanceTimersByTime(30_001);
+      emitFailover(sourceBus, healthInfo({ source: 'codex', state: 'unavailable' }));
+      expect(seen).toHaveLength(2); // after cooldown, emits again
+
+      // a different CLI is tracked independently
+      emitFailover(sourceBus, healthInfo({ source: 'gemini', state: 'degraded' }));
+      expect(seen).toHaveLength(3);
+    } finally {
+      shutdownFailoverSignals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('is idempotent on start and clean on shutdown', () => {
+    const sourceBus = new CollaborationBus();
+    const pipelineBus = new PipelineBus();
+    const seen = captureSignals(pipelineBus);
+    startFailoverSignals({ sourceBus, pipelineBus });
+    startFailoverSignals({ sourceBus, pipelineBus }); // no second subscription
+    emitFailover(sourceBus, healthInfo({ source: 'claude', state: 'degraded' }));
+    expect(seen).toHaveLength(1);
+
+    shutdownFailoverSignals();
+    emitFailover(sourceBus, healthInfo({ source: 'claude', state: 'unavailable' }));
+    expect(seen).toHaveLength(1); // no emissions after shutdown
+  });
+});

--- a/packages/nexus-agents/src/observability/failover-signals.ts
+++ b/packages/nexus-agents/src/observability/failover-signals.ts
@@ -1,0 +1,127 @@
+/**
+ * Adapter-failover → pipeline-bus signal producer (#3321, epic #3143 P2).
+ *
+ * A second, higher-reliability `signal.swarm_unhealthy` producer alongside the
+ * SwarmObserver-bottleneck poll (#3223). `ResilientAdapter.emitFailover()` emits
+ * an `adapter.failover` `DomainEvent` on the collaboration bus (bus B) whose
+ * payload (`AdapterHealthInfo`) carries the **exact `CliName`** and health state
+ * on circuit-breaker trips / failovers. That is directly CLI-attributable — no
+ * `confidentCliSlot` guesswork needed — so it fires reliably on real CLI
+ * failures.
+ *
+ * This producer subscribes to bus B and re-emits `signal.swarm_unhealthy` on the
+ * typed pipeline bus (bus A) when an adapter degrades or becomes unavailable.
+ * The (shadow-by-default) TuneStage consumes it; under `NEXUS_TUNE_ENFORCE` it
+ * applies a bounded, decaying routing demotion. A short per-CLI cooldown stops a
+ * flapping breaker from spamming signals (the TuneAdjustmentStore also caps and
+ * decays the resulting effect).
+ *
+ * Bus direction is B→A here (the reverse of `pipeline/event-bus-bridge.ts`),
+ * preserving the `A = observability / B = messaging` boundary: the adapter never
+ * touches bus A directly.
+ *
+ * @module observability/failover-signals
+ */
+
+import { createLogger, getErrorMessage, getTimeProvider } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+import { getGlobalEventBus } from '../core/event-bus.js';
+import type { DomainEvent, Subscription } from '../core/event-bus.js';
+import { CLI_NAMES } from '../config/model-capabilities-types.js';
+import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+import type { AdapterHealthInfo } from '../adapters/resilient-adapter-types.js';
+import { getPipelineEventBus } from '../pipeline/event-bus.js';
+import type { IEventBus } from '../pipeline/event-types.js';
+
+const defaultLogger = createLogger({ component: 'FailoverSignals' });
+
+/** Health states that warrant a routing signal (a `healthy` adapter does not). */
+const UNHEALTHY_STATES = new Set<string>(['degraded', 'unavailable']);
+
+/** Minimum gap between signals for the same CLI, to absorb breaker flapping. */
+const FAILOVER_SIGNAL_COOLDOWN_MS = 30_000;
+
+const CLI_NAME_SET = new Set<string>(CLI_NAMES);
+
+/** Narrow an `adapter.failover` payload to a CLI-attributable unhealthy health-info. */
+function unhealthyCliFrom(payload: unknown): { cli: CliNameLiteral; reason: string } | undefined {
+  if (payload === null || typeof payload !== 'object') return undefined;
+  const info = payload as Partial<AdapterHealthInfo>;
+  if (typeof info.source !== 'string' || !CLI_NAME_SET.has(info.source)) return undefined;
+  if (typeof info.state !== 'string' || !UNHEALTHY_STATES.has(info.state)) return undefined;
+  const lastError = typeof info.lastError === 'string' ? info.lastError : undefined;
+  const count = typeof info.failoverCount === 'number' ? info.failoverCount : 0;
+  const reason = `adapter ${info.state} (failovers: ${String(count)})${lastError !== undefined ? `: ${lastError}` : ''}`;
+  return { cli: info.source as CliNameLiteral, reason };
+}
+
+// ============================================================================
+// Server-wide lifecycle (#3321) — mirrors swarm-health-signals.ts start/shutdown.
+//
+// cli-server-tools.ts:initV2PipelineSubsystems calls startFailoverSignals() at
+// server init, and cli-server.ts:createShutdownCleanup calls
+// shutdownFailoverSignals().
+// ============================================================================
+
+export interface FailoverSignalsOptions {
+  /** Injectable bus B (collaboration). Defaults to the global event bus. */
+  readonly sourceBus?: {
+    subscribe: (pattern: string, listener: (e: DomainEvent) => void) => Subscription;
+  };
+  /** Injectable bus A (pipeline). Defaults to the pipeline event bus. */
+  readonly pipelineBus?: IEventBus;
+  /** Per-CLI cooldown in ms. Default 30_000. */
+  readonly cooldownMs?: number;
+  /** Injectable logger. */
+  readonly logger?: ILogger;
+}
+
+let failoverSubscription: Subscription | undefined;
+
+/**
+ * Subscribe to `adapter.failover` events on bus B and re-emit
+ * `signal.swarm_unhealthy` on bus A for degraded/unavailable CLIs. Idempotent —
+ * repeated calls are no-ops while a subscription is active. Caller must invoke
+ * `shutdownFailoverSignals()` on server shutdown.
+ */
+export function startFailoverSignals(options?: FailoverSignalsOptions): void {
+  if (failoverSubscription !== undefined) return;
+  const logger = options?.logger ?? defaultLogger;
+  const sourceBus = options?.sourceBus ?? getGlobalEventBus();
+  const pipelineBus = options?.pipelineBus ?? getPipelineEventBus();
+  const cooldownMs = options?.cooldownMs ?? FAILOVER_SIGNAL_COOLDOWN_MS;
+  const lastEmitByCli = new Map<CliNameLiteral, number>();
+
+  failoverSubscription = sourceBus.subscribe('adapter.failover', (event: DomainEvent) => {
+    try {
+      const unhealthy = unhealthyCliFrom(event.payload);
+      if (unhealthy === undefined) return;
+      const now = getTimeProvider().now();
+      const last = lastEmitByCli.get(unhealthy.cli);
+      if (last !== undefined && now - last < cooldownMs) return; // within cooldown
+      lastEmitByCli.set(unhealthy.cli, now);
+
+      pipelineBus.emit({
+        type: 'signal.swarm_unhealthy',
+        timestamp: now,
+        agentId: unhealthy.cli,
+        reason: unhealthy.reason,
+      });
+    } catch (error) {
+      logger.warn('Failed to emit signal.swarm_unhealthy from failover', {
+        error: getErrorMessage(error),
+      });
+    }
+  });
+}
+
+/** Release the adapter-failover signal subscription. Idempotent. */
+export function shutdownFailoverSignals(): void {
+  if (failoverSubscription !== undefined) {
+    failoverSubscription.unsubscribe();
+    failoverSubscription = undefined;
+  }
+}
+
+/** Exposed for unit tests: the pure failover-payload → unhealthy-CLI mapping. */
+export { unhealthyCliFrom };

--- a/packages/nexus-agents/src/observability/index.ts
+++ b/packages/nexus-agents/src/observability/index.ts
@@ -61,6 +61,14 @@ export {
 } from './swarm-health-signals.js';
 export type { SwarmHealthSignalsOptions } from './swarm-health-signals.js';
 
+// Adapter-failover → pipeline-bus signal producer (#3321)
+export {
+  startFailoverSignals,
+  shutdownFailoverSignals,
+  unhealthyCliFrom,
+} from './failover-signals.js';
+export type { FailoverSignalsOptions } from './failover-signals.js';
+
 // Dashboard Types
 export type {
   DashboardFormat,


### PR DESCRIPTION
## What

A second, **higher-reliability** `signal.swarm_unhealthy` producer, complementing the SwarmObserver-bottleneck poll from #3223. `ResilientAdapter.emitFailover()` already emits `adapter.failover` `DomainEvent`s on the collaboration bus whose payload (`AdapterHealthInfo`) carries the **exact `CliName`** and health state on circuit-breaker trips / failovers — so unlike the bottleneck poll (which must skip non-CLI-attributable agent ids), this fires reliably on real CLI failures.

This producer subscribes to that bus (B) and re-emits `signal.swarm_unhealthy` on the typed pipeline bus (A) when an adapter is `degraded`/`unavailable`. Bus direction is **B→A** (the reverse of `pipeline/event-bus-bridge.ts`), preserving the `A = observability / B = messaging` boundary — the adapter never touches bus A directly.

## Safety / correctness

- **`api`-source and `healthy` events are ignored** — `api` isn't a routing slot; healthy adapters aren't unhealthy.
- **Defensive payload narrowing** — the `DomainEvent` payload is `unknown`; `unhealthyCliFrom` validates shape + allowlists `source` against `CLI_NAMES` before emitting.
- **Per-CLI cooldown (30s)** absorbs breaker flapping; the `TuneAdjustmentStore` additionally caps/decays the resulting effect.
- Consumed by the shadow-by-default TuneStage; only mutates routing under `NEXUS_TUNE_ENFORCE`.

## Tests

8 tests: pure mapping (degraded/unavailable→signal, healthy/api/malformed→none), B→A re-emit, cooldown (suppress within window, re-emit after, independent per-CLI), idempotent start + clean shutdown. 1990 interacting observability + tune-stage tests pass. Typecheck + lint clean.

Closes #3321. Part of epic #3143 (close the loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)