### PR TITLE
test(routing): end-to-end + floor-safety for the self-tuning loop (#3323)

### DIFF
--- a/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
@@ -67,6 +67,8 @@ describe('self-tuning loop end-to-end (#3323)', () => {
     expect(baseline.ok).toBe(true);
     if (!baseline.ok) return;
     const winner = baseline.value.cliName;
+    // Full score-ordered ranking (best→worst): selected first, then alternatives.
+    const baselineRank = [winner, ...baseline.value.alternatives].indexOf(winner); // 0
 
     // Drive the loop the real way: emit signal.swarm_unhealthy for the winning
     // CLI through the (enabled) TuneStage, which demotes the shared store.
@@ -86,8 +88,20 @@ describe('self-tuning loop end-to-end (#3323)', () => {
     const afterDemotion = await router.route(TASK);
     expect(afterDemotion.ok).toBe(true);
     if (!afterDemotion.ok) return;
-    // The loop changed routing: the demoted CLI is no longer selected.
+    // The loop changed routing: the demoted CLI is no longer selected...
     expect(afterDemotion.value.cliName).not.toBe(winner);
+    // ...and — the stronger causal assertion — the demoted CLI's position in the
+    // score-ordered ranking strictly WORSENED. A weaker `not.toBe(winner)` alone
+    // would also pass if a regression flipped to some other CLI for an unrelated
+    // reason; a worsened rank ties the change directly to the tune penalty.
+    // (Paired with the shadow test below — same store state, enforce off — to
+    // prove causation, not coincidence.) We assert rank-worsened rather than
+    // ranks-LAST because an intrinsically lower-scored peer can still sit below
+    // the penalized CLI.
+    const afterRank = [afterDemotion.value.cliName, ...afterDemotion.value.alternatives].indexOf(
+      winner
+    );
+    expect(afterRank).toBeGreaterThan(baselineRank);
   });
 
   it('does NOT change routing when enforce is off (shadow) even after signals', async () => {

--- a/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
@@ -1,0 +1,139 @@
+/**
+ * End-to-end + floor-safety tests for the self-tuning loop (#3323, epic #3143).
+ *
+ * The per-component pieces are unit-tested elsewhere (TuneStage write,
+ * TuneAdjustmentStore bounds, getTuneAdjustmentScores penalty math). These tests
+ * close two exit-criteria for enabling the loop by default:
+ *
+ *  1. **Integration** — a `signal.swarm_unhealthy` emitted through the TuneStage
+ *     (the producer-consumer path) flows through the SHARED TuneAdjustmentStore
+ *     into `CompositeRouter.route()` and measurably changes which CLI is
+ *     selected — proving the loop affects real routing, not just the unit pieces.
+ *  2. **Floor-safety / never-starve** — a CLI driven to the demotion floor that
+ *     is the ONLY viable candidate is still selected. The bounded penalty must
+ *     never exclude, zero, or NaN-out the sole option.
+ *
+ * LinUCB is disabled so the deterministic stage scores (which include the tune
+ * penalty) decide the winner — the loop's effect is what we assert, not bandit
+ * exploration.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CompositeRouter } from './composite-router.js';
+import type { ICliAdapter, CliTask, CliName } from './types.js';
+import { getTuneAdjustmentStore, resetTuneAdjustmentStore } from '../core/index.js';
+import { EventBus } from '../pipeline/event-bus.js';
+import { createTuneStage } from '../pipeline/tune-stage.js';
+import type { PipelineEvent } from '../pipeline/event-types.js';
+
+function createMockAdapter(name: CliName): ICliAdapter {
+  return {
+    name,
+    transport: 'subprocess',
+    capabilities: { reasoning: 8, contextWindow: 200000, codeGeneration: 8, speed: 8, cost: 5 },
+    execute: vi.fn().mockResolvedValue({ ok: true, value: { text: 'mock' } }),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, version: '1.0.0' }),
+    getVersion: vi.fn().mockResolvedValue('1.0.0'),
+    getCapacity: vi.fn().mockResolvedValue({ remainingTokens: 100000 }),
+    getModelInfo: vi.fn().mockReturnValue({ id: name, name }),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ICliAdapter;
+}
+
+/** Router with LinUCB disabled → deterministic stage-score selection. */
+function deterministicRouter(names: CliName[]): CompositeRouter {
+  const adapters = new Map<CliName, ICliAdapter>();
+  for (const n of names) adapters.set(n, createMockAdapter(n));
+  return new CompositeRouter(adapters, { enableLinUCBSelection: false });
+}
+
+const TASK: CliTask = { content: 'Help me write a function' };
+
+describe('self-tuning loop end-to-end (#3323)', () => {
+  beforeEach(() => {
+    resetTuneAdjustmentStore();
+    process.env['NEXUS_TUNE_ENFORCE'] = 'true';
+  });
+  afterEach(() => {
+    resetTuneAdjustmentStore();
+    delete process.env['NEXUS_TUNE_ENFORCE'];
+  });
+
+  it('a swarm_unhealthy signal through the TuneStage changes the routed CLI', async () => {
+    const router = deterministicRouter(['claude', 'gemini', 'codex']);
+
+    const baseline = await router.route(TASK);
+    expect(baseline.ok).toBe(true);
+    if (!baseline.ok) return;
+    const winner = baseline.value.cliName;
+
+    // Drive the loop the real way: emit signal.swarm_unhealthy for the winning
+    // CLI through the (enabled) TuneStage, which demotes the shared store.
+    const bus = new EventBus();
+    createTuneStage(bus, { enabled: true });
+    for (let i = 0; i < 8; i++) {
+      bus.emit({
+        type: 'signal.swarm_unhealthy',
+        timestamp: i,
+        agentId: winner,
+        reason: 'repeated failures',
+      } satisfies PipelineEvent);
+    }
+    // The shared store now reflects a (floored) demotion for the winner.
+    expect(getTuneAdjustmentStore().effectiveMultiplier(winner)).toBeLessThan(1.0);
+
+    const afterDemotion = await router.route(TASK);
+    expect(afterDemotion.ok).toBe(true);
+    if (!afterDemotion.ok) return;
+    // The loop changed routing: the demoted CLI is no longer selected.
+    expect(afterDemotion.value.cliName).not.toBe(winner);
+  });
+
+  it('does NOT change routing when enforce is off (shadow) even after signals', async () => {
+    delete process.env['NEXUS_TUNE_ENFORCE']; // shadow
+    const router = deterministicRouter(['claude', 'gemini', 'codex']);
+    const baseline = await router.route(TASK);
+    expect(baseline.ok).toBe(true);
+    if (!baseline.ok) return;
+    const winner = baseline.value.cliName;
+
+    // Even directly demoting the store has no routing effect while shadow.
+    for (let i = 0; i < 8; i++) getTuneAdjustmentStore().demote(winner, 0.2, 'unhealthy');
+
+    const after = await router.route(TASK);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.value.cliName).toBe(winner); // unchanged — enforce gates the read
+  });
+});
+
+describe('floor-safety / never-starve (#3323)', () => {
+  beforeEach(() => {
+    resetTuneAdjustmentStore();
+    process.env['NEXUS_TUNE_ENFORCE'] = 'true';
+  });
+  afterEach(() => {
+    resetTuneAdjustmentStore();
+    delete process.env['NEXUS_TUNE_ENFORCE'];
+  });
+
+  it('still selects a sole candidate driven to the demotion floor', async () => {
+    const router = deterministicRouter(['claude']);
+    const store = getTuneAdjustmentStore();
+    // Drive well past the floor — the store clamps at TUNE_DEMOTION_FLOOR (0.5).
+    for (let i = 0; i < 20; i++) store.demote('claude', 0.2, 'sustained failures');
+    expect(store.effectiveMultiplier('claude')).toBeGreaterThanOrEqual(0.5);
+
+    const result = await router.route(TASK);
+    // Bounded penalty must never exclude / zero the only option.
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.cliName).toBe('claude');
+  });
+
+  it('keeps the demotion bounded — multiplier never below the floor', () => {
+    const store = getTuneAdjustmentStore();
+    for (let i = 0; i < 50; i++) store.demote('gemini', 0.2, 'sustained');
+    expect(store.effectiveMultiplier('gemini')).toBeGreaterThanOrEqual(0.5);
+  });
+});


### PR DESCRIPTION
## What

Closes two of the default-on exit criteria from #3323 (owner directive: enable the loop by default once built out completely). Test-only — no production behavior change.

1. **End-to-end integration** — emits `signal.swarm_unhealthy` through the *enabled* `TuneStage` (the real producer→consumer path), which demotes the **shared** `TuneAdjustmentStore`; `CompositeRouter.route()` then measurably **flips the selected CLI** away from the demoted one. A companion test confirms **shadow mode** (enforce off) leaves routing unchanged — proving the `NEXUS_TUNE_ENFORCE` gate works at the route level.
2. **Floor-safety / never-starve** — a sole candidate driven well past the demotion floor is **still selected** by `route()` (the bounded penalty never excludes/zeros/NaNs the only option), and the multiplier never drops below `0.5`.

LinUCB is disabled so deterministic stage scores (which include the tune penalty) decide the winner — we assert the loop's effect, not bandit exploration. Observed: baseline winner `gemini` → 8 signals → floor `0.5` → winner flips to `codex`.

## Remaining #3323 criteria (separate PRs)

Durable `AuditLogger` trail for demote/decay; shadow-soak demotion telemetry; docs. Rollout decided: minor + NOTABLE changelog, `NEXUS_TUNE_ENFORCE` default false→true with opt-out preserved.

Part of epic #3143 / keystone #3147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)