### PR TITLE
feat(tune): durable audit trail for routing demotions (#3323)

### DIFF
--- a/.changeset/tune-audit-trail.md
+++ b/.changeset/tune-audit-trail.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(tune): durable audit trail for self-tuning routing demotions (#3323)
+
+Each enforced routing demotion now appends a tamper-evident `tune.demote` record
+to the immutable AuditLogger (category `configuration`, queryable via
+`verify_audit_chain`), in addition to the structured log. The record carries the
+CLI, magnitude, resulting multiplier, reason, provenance, and timestamp. The
+audit sink is optional/injectable (omitted in shadow/unit contexts) and wired
+from the server through `initV2PipelineSubsystems` → `startTuneStage`. Audit
+failures never break the tune path. Satisfies a default-on exit criterion for
+the self-tuning loop (#3323): a default-on auto-mutating router must leave an
+auditable trail.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -135,6 +135,8 @@ export interface RegisterMcpToolsOptions {
   workflowConfig?: import('./config/index.js').WorkflowConfig;
   /** FeedbackIntegration for closed-loop learning (Issue #490) */
   feedbackIntegration?: import('./learning/feedback-integration.js').IFeedbackIntegration;
+  /** Immutable audit sink for self-tuning routing mutations (#3323) */
+  auditLogger?: import('./audit/audit-types.js').IAuditLogger;
   /** Enable STPA safety analysis during tool registration (Issue #530) */
   enableStpaSafetyAnalysis?: boolean;
   /** Fail registration if high-severity hazards are found (Issue #530) */
@@ -610,7 +612,10 @@ function registerToolCategories(ctx: ToolRegistrationContext): void {
 }
 
 /** Initializes V2 Pipeline OS subsystems and logs summary. (Phases B-C, Issues #921-#922) */
-function initV2PipelineSubsystems(logger: ILogger): void {
+function initV2PipelineSubsystems(
+  logger: ILogger,
+  auditLogger?: import('./audit/audit-types.js').IAuditLogger
+): void {
   const pluginRegistry = getPipelinePluginRegistry();
   const pipelineEventBus = getPipelineEventBus();
   const bridge = createEventBusBridge({ source: pipelineEventBus });
@@ -623,8 +628,9 @@ function initV2PipelineSubsystems(logger: ILogger): void {
   // Close the self-tuning loop's consumer side: the shadow TuneStage subscribes
   // to signal.* events on the same typed bus (#3147; #3289 Option 2). Shadow
   // mode — logs intended actions, mutates nothing. Paired with
-  // shutdownTuneStage() in cli-server.ts:createShutdownCleanup.
-  startTuneStage(pipelineEventBus);
+  // shutdownTuneStage() in cli-server.ts:createShutdownCleanup. The audit sink
+  // (#3323) records each enforced routing demotion to the immutable log.
+  startTuneStage(pipelineEventBus, auditLogger !== undefined ? { auditLogger } : undefined);
   // Close the loop's final producer: poll SwarmObserver health and emit
   // signal.swarm_unhealthy for CLI-attributable bottlenecks onto the same bus
   // (#3223). Paired with shutdownSwarmHealthSignals() in
@@ -675,7 +681,7 @@ export function registerMcpTools(options: RegisterMcpToolsOptions): void {
   });
   setGlobalToolRateLimiterFactory(rateLimiterFactory);
 
-  initV2PipelineSubsystems(logger);
+  initV2PipelineSubsystems(logger, options.auditLogger);
 
   const gatewayOptions = { ...options, server: observableServer };
   const ctx = createToolContext(gatewayOptions, toolInfra, rateLimiterFactory);

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -371,8 +371,14 @@ async function initializeAndRegisterTools(
   logger: ILogger,
   policyFirewall: import('./mcp/middleware/index.js').IPolicyFirewall,
   config: import('./config/index.js').AppConfig,
-  feedbackIntegration?: import('./learning/feedback-integration.js').IFeedbackIntegration
+  deps?: {
+    feedbackIntegration?:
+      | import('./learning/feedback-integration.js').IFeedbackIntegration
+      | undefined;
+    auditLogger?: AuditLogger | null;
+  }
 ): Promise<void> {
+  const { feedbackIntegration, auditLogger } = deps ?? {};
   logger.info('Loading built-in workflow templates');
   const builtInTemplates = await initializeBuiltInTemplates();
   logger.info('Loaded built-in templates', { count: builtInTemplates.size });
@@ -403,6 +409,7 @@ async function initializeAndRegisterTools(
     ...(securityConfig !== undefined && { securityConfig }),
     ...(workflowConfig !== undefined && { workflowConfig }),
     ...(feedbackIntegration !== undefined && { feedbackIntegration }),
+    ...(auditLogger !== null && auditLogger !== undefined && { auditLogger }),
   };
   registerMcpTools(toolsOptions);
 }
@@ -498,13 +505,10 @@ async function initializeSubsystems(
   // auth state is wired into the request pipeline inside initializeAuth.
   initializeAuth(config, serverLogger);
   // Pass FeedbackIntegration to tools for closed-loop learning (Issue #490)
-  await initializeAndRegisterTools(
-    server,
-    serverLogger,
-    policyFirewall,
-    config,
-    feedbackResult.feedbackIntegration
-  );
+  await initializeAndRegisterTools(server, serverLogger, policyFirewall, config, {
+    feedbackIntegration: feedbackResult.feedbackIntegration,
+    auditLogger,
+  });
 
   return { server, serverLogger, observer, eventBusBridge, auditLogger };
 }

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -143,6 +143,25 @@ describe('createTuneStage shadow mode (#3147)', () => {
     resetTuneAdjustmentStore();
   });
 
+  it('caps an over-long reason entering the audit log (#3323 QA — provider error bloat)', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    const auditLog = vi.fn();
+    createTuneStage(bus, { enabled: true, auditLogger: { log: auditLog } });
+
+    bus.emit({
+      type: 'signal.swarm_unhealthy',
+      timestamp: 7,
+      agentId: 'codex',
+      reason: 'x'.repeat(5000), // simulate an unbounded provider lastError
+    });
+
+    expect(auditLog).toHaveBeenCalledTimes(1);
+    const record = auditLog.mock.calls[0]?.[0] as { metadata: { reason: string } };
+    expect(record.metadata.reason.length).toBeLessThanOrEqual(512);
+    resetTuneAdjustmentStore();
+  });
+
   it('does NOT write an audit record for non-routing signals or in shadow mode (#3323)', () => {
     resetTuneAdjustmentStore();
     const auditLog = vi.fn();

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -121,6 +121,47 @@ describe('createTuneStage shadow mode (#3147)', () => {
     resetTuneAdjustmentStore();
   });
 
+  it('enabled=true writes a tune.demote audit record when an audit sink is wired (#3323)', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    const auditLog = vi.fn();
+    const auditLogger = { log: auditLog };
+    createTuneStage(bus, { enabled: true, auditLogger });
+
+    bus.emit(swarmSignal);
+
+    expect(auditLog).toHaveBeenCalledTimes(1);
+    expect(auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'configuration',
+        action: 'tune.demote',
+        outcome: 'success',
+        actor: expect.objectContaining({ type: 'system' }),
+        metadata: expect.objectContaining({ cli: 'gemini', provenance: 'signal.swarm_unhealthy' }),
+      })
+    );
+    resetTuneAdjustmentStore();
+  });
+
+  it('does NOT write an audit record for non-routing signals or in shadow mode (#3323)', () => {
+    resetTuneAdjustmentStore();
+    const auditLog = vi.fn();
+    const auditLogger = { log: auditLog };
+
+    // non-routing signal under enforce → no audit
+    const bus1 = new EventBus();
+    createTuneStage(bus1, { enabled: true, auditLogger });
+    bus1.emit(voteSignal);
+    expect(auditLog).not.toHaveBeenCalled();
+
+    // routing signal in shadow (disabled) → no audit
+    const bus2 = new EventBus();
+    createTuneStage(bus2, { enabled: false, auditLogger });
+    bus2.emit(swarmSignal);
+    expect(auditLog).not.toHaveBeenCalled();
+    resetTuneAdjustmentStore();
+  });
+
   it('disabled (shadow) does NOT mutate routing even on swarm_unhealthy', () => {
     resetTuneAdjustmentStore();
     const bus = new EventBus();

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -34,6 +34,9 @@ const TUNE_ENFORCE_ENV = 'NEXUS_TUNE_ENFORCE';
  */
 const TUNE_ENFORCE_DEMOTION = 0.15;
 
+/** Max length of the reason string written to the immutable audit log (#3323 QA). */
+const AUDIT_REASON_MAX = 512;
+
 /** Signal event types the TuneStage reacts to. */
 export const TUNE_SIGNAL_TYPES = [
   'signal.fitness_declined',
@@ -113,6 +116,13 @@ function auditDemotion(
   log: ILogger
 ): void {
   if (auditLogger === undefined || adjustment === undefined) return;
+  // Bound the reason entering the immutable chain — a producer reason can embed
+  // provider-returned `lastError` text of unbounded length (#3321). Cap it so a
+  // pathological error string can't bloat the append-only audit log (#3323 QA).
+  const reason =
+    adjustment.reason.length > AUDIT_REASON_MAX
+      ? adjustment.reason.slice(0, AUDIT_REASON_MAX)
+      : adjustment.reason;
   try {
     auditLogger.log({
       category: 'configuration',
@@ -125,7 +135,7 @@ function auditDemotion(
         cli: agentId,
         magnitude: TUNE_ENFORCE_DEMOTION,
         multiplier: adjustment.multiplier,
-        reason: adjustment.reason,
+        reason,
         provenance: 'signal.swarm_unhealthy',
         appliedAt: adjustment.appliedAt,
       },

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -3,12 +3,14 @@
  *
  * Subscribes to the `signal.*` `PipelineEvent`s emitted by push-only producers
  * (fitness audit, swarm health, consensus) and computes the BOUNDED tuning
- * action each signal implies. It ships **shadow/dry-run first**: it only LOGS
- * the intended action and mutates nothing. Actual parameter mutation (e.g.
- * routing downweights) is a separate, human-gated step (#3147 PR-4) and must
- * NOT reuse the LinUCB real-outcome channel (per the ratifying-vote dissent) —
- * it needs a provenance-tagged mechanism, which is why this stage is dry-run
- * only for now.
+ * action each signal implies. **Shadow by default**: it logs the intended
+ * action and mutates nothing. When `NEXUS_TUNE_ENFORCE` is set (#3147), a
+ * `signal.swarm_unhealthy` applies a bounded routing demotion via the
+ * provenance-tagged `TuneAdjustmentStore` (demotion-only, floored, capped,
+ * time-decaying — never the LinUCB real-outcome channel, per the ratifying-vote
+ * dissent) and records a tamper-evident `tune.demote` audit entry (#3323). The
+ * router reads the store behind the same flag, so the loop is fully live or
+ * fully shadow. Non-routing signals (fitness/vote) stay shadow-logged.
  *
  * Mirrors the proven `feedback-subscriber` pattern: a single `subscribe` over
  * a typed filter, errors caught and logged, an `Unsubscribe` returned.
@@ -56,10 +58,11 @@ export interface IntendedTuneAction {
 
 export interface TuneStageOptions {
   /**
-   * When false (default), the stage is in SHADOW/dry-run mode: it logs the
-   * intended action and mutates nothing. `true` is reserved for the
-   * human-gated mutation path (#3147 PR-4), which is not implemented yet — so
-   * enabled mode currently fails closed (logs and no-ops) rather than acting.
+   * When false (default), the stage is in SHADOW mode: it logs the intended
+   * action and mutates nothing. When true, a `signal.swarm_unhealthy` applies a
+   * bounded routing demotion via the `TuneAdjustmentStore` (and audits it);
+   * non-routing signals remain shadow-logged. Defaults from `NEXUS_TUNE_ENFORCE`
+   * in `startTuneStage`; explicit values (tests) override the flag.
    */
   readonly enabled?: boolean;
   /** Injectable logger (defaults to the module logger). */

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -19,6 +19,7 @@
 import { createLogger, getErrorMessage, getTuneAdjustmentStore } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
 import { parseBoolEnv } from '../config/defaults-env.js';
+import type { IAuditLogger } from '../audit/audit-types.js';
 import type { PipelineEvent, IEventBus, Unsubscribe } from './event-types.js';
 
 const defaultLogger = createLogger({ component: 'TuneStage' });
@@ -60,6 +61,15 @@ export interface TuneStageOptions {
   readonly enabled?: boolean;
   /** Injectable logger (defaults to the module logger). */
   readonly logger?: ILogger;
+  /**
+   * Optional immutable audit sink (#3323). When enforcement applies a routing
+   * demotion, a tamper-evident `tune.demote` record is appended here in addition
+   * to the structured log — required before the loop can be enabled by default.
+   * Omitted in unit tests / shadow contexts that have no audit backend.
+   * Typed as the `log`-only slice of `IAuditLogger` — TuneStage appends records
+   * but never queries/verifies, so it needs nothing more.
+   */
+  readonly auditLogger?: Pick<IAuditLogger, 'log'>;
 }
 
 /**
@@ -92,6 +102,68 @@ export function intendedActionFor(event: PipelineEvent): IntendedTuneAction | un
 }
 
 /**
+ * Append a tamper-evident `tune.demote` audit record for a routing demotion
+ * (#3323). No-op when no sink is wired or no demotion applied. Audit failures
+ * are swallowed and logged — the demotion has already taken effect.
+ */
+function auditDemotion(
+  auditLogger: Pick<IAuditLogger, 'log'> | undefined,
+  agentId: string,
+  adjustment: { multiplier: number; reason: string; appliedAt: number } | undefined,
+  log: ILogger
+): void {
+  if (auditLogger === undefined || adjustment === undefined) return;
+  try {
+    auditLogger.log({
+      category: 'configuration',
+      severity: 'warning',
+      outcome: 'success',
+      action: 'tune.demote',
+      actor: { type: 'system', id: 'tune-stage' },
+      description: `Bounded routing demotion applied to ${agentId} (swarm_unhealthy)`,
+      metadata: {
+        cli: agentId,
+        magnitude: TUNE_ENFORCE_DEMOTION,
+        multiplier: adjustment.multiplier,
+        reason: adjustment.reason,
+        provenance: 'signal.swarm_unhealthy',
+        appliedAt: adjustment.appliedAt,
+      },
+    });
+  } catch (auditError) {
+    log.warn('TuneStage — audit log failed (demotion still applied)', {
+      error: getErrorMessage(auditError),
+    });
+  }
+}
+
+/**
+ * Apply the bounded routing demotion for a `swarm_unhealthy` signal (#3147):
+ * a demotion-only, floored, capped, time-decaying adjustment the router reads
+ * as a scoring penalty, plus structured + durable-audit trails (#3323).
+ */
+function enforceSwarmDemotion(
+  event: Extract<PipelineEvent, { type: 'signal.swarm_unhealthy' }>,
+  action: IntendedTuneAction,
+  auditLogger: Pick<IAuditLogger, 'log'> | undefined,
+  log: ILogger
+): void {
+  const adjustment = getTuneAdjustmentStore().demote(
+    event.agentId,
+    TUNE_ENFORCE_DEMOTION,
+    `swarm_unhealthy: ${event.reason}`
+  );
+  log.info('TuneStage (enforce) — applied bounded routing demotion', {
+    kind: action.kind,
+    signal: action.signal,
+    agentId: event.agentId,
+    reason: event.reason,
+    multiplier: adjustment?.multiplier,
+  });
+  auditDemotion(auditLogger, event.agentId, adjustment, log);
+}
+
+/**
  * Subscribe the TuneStage to the signal events on `bus`. Returns an
  * `Unsubscribe`. Shadow/dry-run by default — logs intended actions, mutates
  * nothing.
@@ -99,28 +171,14 @@ export function intendedActionFor(event: PipelineEvent): IntendedTuneAction | un
 export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}): Unsubscribe {
   const enabled = options.enabled ?? false;
   const log = options.logger ?? defaultLogger;
+  const auditLogger = options.auditLogger;
   return bus.subscribe({ type: [...TUNE_SIGNAL_TYPES] }, (event) => {
     try {
       const action = intendedActionFor(event);
       if (action === undefined) return;
       if (enabled) {
         if (event.type === 'signal.swarm_unhealthy') {
-          // Bounded auto-enforce (#3147): apply a routing demotion via the
-          // TuneAdjustmentStore, which guarantees demotion-only, floored,
-          // capped, and time-decaying (auto-reversible). The router reads this
-          // (behind the same flag) as a scoring penalty. Audited via this log.
-          const adjustment = getTuneAdjustmentStore().demote(
-            event.agentId,
-            TUNE_ENFORCE_DEMOTION,
-            `swarm_unhealthy: ${event.reason}`
-          );
-          log.info('TuneStage (enforce) — applied bounded routing demotion', {
-            kind: action.kind,
-            signal: action.signal,
-            agentId: event.agentId,
-            reason: event.reason,
-            multiplier: adjustment?.multiplier,
-          });
+          enforceSwarmDemotion(event, action, auditLogger, log);
           return;
         }
         // Other signals' actions (flag_tech_debt / record_rejection) are not


### PR DESCRIPTION
## What

Closes a default-on exit criterion from #3323: a default-on auto-mutating router must leave a **tamper-evident** trail. Today the TuneStage enforce path emitted *structured logs only*.

Each enforced routing demotion now also appends a `tune.demote` record to the immutable `AuditLogger` (category `configuration`, queryable via `verify_audit_chain`), carrying `cli`, `magnitude`, resulting `multiplier`, `reason`, `provenance` (`signal.swarm_unhealthy`), and `appliedAt`.

## Design

- **Hook in TuneStage, not the store** — `TuneAdjustmentStore` stays a pure state holder; the audit write lives at the enforcement boundary where the sink is already available.
- **Optional / injectable** — `auditLogger?: Pick<IAuditLogger, 'log'>` on `TuneStageOptions` (TuneStage only appends, never queries — interface-segregated). Omitted in shadow/unit contexts that have no backend.
- **Threaded from the server** — `cli-server.ts` → `initV2PipelineSubsystems` → `startTuneStage`, reusing the single `AuditLogger` instance (one hash chain).
- **Never breaks the tune path** — audit failures are caught + logged; the demotion has already taken effect. Decay/expiry is automatic (not operator-initiated) so it is intentionally **not** audited.
- Extracted `enforceSwarmDemotion` + `auditDemotion` helpers to stay within complexity/length limits.

## Tests

10 tune-stage tests (incl. new: audit record written on enforced swarm_unhealthy with correct category/action/metadata; **no** audit for non-routing signals or in shadow mode; works when sink omitted) + 32 cli-server-tools tests pass. Typecheck + lint clean.

## #3323 progress

Done: e2e + floor-safety tests (#3324), **durable audit (this PR)**. Remaining: shadow-soak demotion telemetry, docs. Rollout decided (owner): minor + NOTABLE changelog, `NEXUS_TUNE_ENFORCE` default false→true with opt-out preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)