### PR TITLE
feat(tune): shadow-soak demotion telemetry (#3323)

### DIFF
--- a/.changeset/tune-demotion-telemetry.md
+++ b/.changeset/tune-demotion-telemetry.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(tune): shadow-soak demotion telemetry for the self-tuning loop (#3323)
+
+Adds inspectable per-CLI demotion counters to `TuneAdjustmentStore` — `applied`
+(demotions that biased routing in enforce mode) and `intended` (demotions the
+loop WOULD have applied while shadow). The new `recordIntended()` increments the
+shadow counter WITHOUT touching routing, so an operator can observe what enabling
+the loop would do during a soak while `effectiveMultiplier` stays 1.0. Counters
+survive decay/eviction (bounded by CLI cardinality; reason capped at 512 chars).
+TuneStage records intended demotions in shadow mode; the `health` command now
+surfaces a "Self-Tuning Demotions" section (table + JSON). A default-on exit
+criterion for #3323.

--- a/packages/nexus-agents/src/cli/health-command.ts
+++ b/packages/nexus-agents/src/cli/health-command.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ParsedCliArgs } from '../cli-types.js';
+import { getTuneAdjustmentStore, type TuneDemotionStat } from '../core/index.js';
 import { colors, symbols } from './ansi-output.js';
 import { generateWeatherReport } from '../mcp/tools/weather-report.js';
 import type {
@@ -41,6 +42,8 @@ export interface HealthResult {
   readonly failureBreakdown: readonly FailureBreakdownEntry[];
   readonly cliCount: number;
   readonly cliHealth: readonly CliHealthSummary[];
+  /** Self-tuning loop demotion telemetry (#3323) — applied vs intended per CLI. */
+  readonly tuneAdjustments: readonly TuneDemotionStat[];
   readonly timestamp: string;
 }
 
@@ -61,6 +64,7 @@ export function collectHealth(): HealthResult {
     failureBreakdown: report.failureBreakdown ?? [],
     cliCount: report.cliWeather.length,
     cliHealth: report.cliWeather.map(toCliSummary),
+    tuneAdjustments: getTuneAdjustmentStore().demotionStats(),
     timestamp: new Date().toISOString(),
   };
 }
@@ -185,6 +189,26 @@ function renderTable(health: HealthResult): void {
 
   // Failure breakdown
   renderFailureBreakdown(w, health.failureBreakdown);
+
+  // Self-tuning loop demotion telemetry (#3323)
+  renderTuneAdjustments(w, health.tuneAdjustments);
+}
+
+function renderTuneAdjustments(
+  w: (s: string) => boolean,
+  stats: readonly TuneDemotionStat[]
+): void {
+  if (stats.length === 0) return;
+  const c = colors;
+  w(
+    `  ${c.bold}Self-Tuning Demotions${c.reset} ${c.dim}(applied = enforced, intended = shadow)${c.reset}\n`
+  );
+  for (const stat of stats) {
+    w(
+      `  ${stat.cli.padEnd(10)} applied: ${c.cyan}${String(stat.applied)}${c.reset}  intended: ${c.cyan}${String(stat.intended)}${c.reset}  ${c.dim}${stat.lastReason}${c.reset}\n`
+    );
+  }
+  w('\n');
 }
 
 function renderJson(health: HealthResult): void {

--- a/packages/nexus-agents/src/core/index.ts
+++ b/packages/nexus-agents/src/core/index.ts
@@ -25,6 +25,7 @@ export {
   TUNE_MAX_STEP,
   TUNE_DECAY_WINDOW_MS,
   type TuneAdjustment,
+  type TuneDemotionStat,
 } from './tune-adjustment-store.js';
 
 // Step event vocabulary + `withStep` wrapper (#1930 — human console notifications)

--- a/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
@@ -78,3 +78,57 @@ describe('TuneAdjustmentStore (#3147)', () => {
     expect(store.effectiveMultiplier('gemini')).toBe(1.0);
   });
 });
+
+describe('TuneAdjustmentStore demotion telemetry (#3323)', () => {
+  it('counts applied demotions and survives decay/eviction', () => {
+    const clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+    try {
+      const store = new TuneAdjustmentStore();
+      store.demote('gemini', 0.2, 'swarm_unhealthy: a');
+      store.demote('gemini', 0.2, 'swarm_unhealthy: b');
+      // Advance past the decay window so the active adjustment is evicted...
+      clock.advance(TUNE_DECAY_WINDOW_MS + 1);
+      expect(store.effectiveMultiplier('gemini')).toBe(1.0); // adjustment gone
+      // ...but the cumulative stat persists.
+      const stats = store.demotionStats();
+      expect(stats).toHaveLength(1);
+      expect(stats[0]).toMatchObject({ cli: 'gemini', applied: 2, intended: 0 });
+      expect(stats[0]?.lastReason).toBe('swarm_unhealthy: b');
+    } finally {
+      resetTimeProvider();
+    }
+  });
+
+  it('recordIntended counts WITHOUT affecting routing (shadow soak)', () => {
+    const store = new TuneAdjustmentStore();
+    store.recordIntended('codex', 'swarm_unhealthy: would-demote');
+    store.recordIntended('codex', 'swarm_unhealthy: again');
+    // Routing is untouched — the loop is still shadow.
+    expect(store.effectiveMultiplier('codex')).toBe(1.0);
+    expect(store.list()).toHaveLength(0);
+    // But the intended counter accrues for soak observability.
+    const stat = store.demotionStats().find((s) => s.cli === 'codex');
+    expect(stat).toMatchObject({ applied: 0, intended: 2 });
+  });
+
+  it('recordIntended ignores an empty reason (no-op)', () => {
+    const store = new TuneAdjustmentStore();
+    store.recordIntended('gemini', '');
+    expect(store.demotionStats()).toHaveLength(0);
+  });
+
+  it('clear() also resets telemetry', () => {
+    const store = new TuneAdjustmentStore();
+    store.demote('gemini', 0.2, 'x');
+    store.recordIntended('codex', 'y');
+    store.clear();
+    expect(store.demotionStats()).toHaveLength(0);
+  });
+
+  it('caps the retained reason length', () => {
+    const store = new TuneAdjustmentStore();
+    store.recordIntended('gemini', 'r'.repeat(5000));
+    expect(store.demotionStats()[0]?.lastReason.length).toBeLessThanOrEqual(512);
+  });
+});

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -46,8 +46,50 @@ export interface TuneAdjustment {
   readonly reason: string;
 }
 
+/** Max length of a stat's retained reason string (#3323 telemetry). */
+const STAT_REASON_MAX = 512;
+
+/**
+ * Cumulative per-CLI demotion telemetry (#3323) — survives decay/eviction so a
+ * shadow soak can show what the loop is (or WOULD be) doing before the loop is
+ * enabled by default. `applied` counts demotions that actually biased routing
+ * (enforce mode); `intended` counts demotions the loop WOULD have applied while
+ * shadow (enforcement off) — recorded WITHOUT touching routing.
+ */
+export interface TuneDemotionStat {
+  readonly cli: string;
+  readonly applied: number;
+  readonly intended: number;
+  /** Most recent reason recorded (capped to {@link STAT_REASON_MAX}). */
+  readonly lastReason: string;
+  /** Timestamp of the most recent record (applied or intended). */
+  readonly lastAt: number;
+}
+
+interface MutableDemotionStat {
+  cli: string;
+  applied: number;
+  intended: number;
+  lastReason: string;
+  lastAt: number;
+}
+
 export class TuneAdjustmentStore {
   private readonly adjustments = new Map<string, TuneAdjustment>();
+  /** Cumulative telemetry — never evicted (bounded by CLI cardinality). */
+  private readonly stats = new Map<string, MutableDemotionStat>();
+
+  /** Increment a CLI's cumulative demotion counter. Pure telemetry. */
+  private bumpStat(cli: string, kind: 'applied' | 'intended', reason: string): void {
+    let stat = this.stats.get(cli);
+    if (stat === undefined) {
+      stat = { cli, applied: 0, intended: 0, lastReason: '', lastAt: 0 };
+      this.stats.set(cli, stat);
+    }
+    stat[kind] += 1;
+    stat.lastReason = reason.length > STAT_REASON_MAX ? reason.slice(0, STAT_REASON_MAX) : reason;
+    stat.lastAt = getTimeProvider().now();
+  }
 
   /**
    * Apply a bounded demotion to `cli`. `magnitude` is the requested reduction
@@ -67,7 +109,20 @@ export class TuneAdjustmentStore {
       reason,
     };
     this.adjustments.set(cli, adjustment);
+    this.bumpStat(cli, 'applied', reason);
     return adjustment;
+  }
+
+  /**
+   * Record a demotion the loop WOULD have applied, for shadow-soak telemetry
+   * (#3323) — increments the `intended` counter ONLY and does NOT touch the
+   * routing adjustments. Lets an operator observe what enabling the loop would
+   * do (via {@link demotionStats}) while `effectiveMultiplier` stays 1.0 and
+   * routing is untouched. Non-empty `reason` required; otherwise a no-op.
+   */
+  recordIntended(cli: string, reason: string): void {
+    if (reason === '') return;
+    this.bumpStat(cli, 'intended', reason);
   }
 
   /**
@@ -93,9 +148,18 @@ export class TuneAdjustmentStore {
     return [...this.adjustments.values()];
   }
 
-  /** Remove all adjustments. */
+  /**
+   * Cumulative demotion telemetry per CLI (#3323) — survives decay, so a shadow
+   * soak shows how often each CLI is (or would be) demoted. Read-only snapshot.
+   */
+  demotionStats(): readonly TuneDemotionStat[] {
+    return [...this.stats.values()].map((s) => ({ ...s }));
+  }
+
+  /** Remove all adjustments and telemetry. */
   clear(): void {
     this.adjustments.clear();
+    this.stats.clear();
   }
 }
 

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -153,7 +153,10 @@ export class TuneAdjustmentStore {
    * soak shows how often each CLI is (or would be) demoted. Read-only snapshot.
    */
   demotionStats(): readonly TuneDemotionStat[] {
-    return [...this.stats.values()].map((s) => ({ ...s }));
+    // Sorted by CLI for deterministic output (stable health table/JSON + tests).
+    return [...this.stats.values()]
+      .map((s) => ({ ...s }))
+      .sort((a, b) => a.cli.localeCompare(b.cli));
   }
 
   /** Remove all adjustments and telemetry. */

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -181,6 +181,21 @@ describe('createTuneStage shadow mode (#3147)', () => {
     resetTuneAdjustmentStore();
   });
 
+  it('shadow mode records an INTENDED demotion for soak telemetry without mutating routing (#3323)', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    createTuneStage(bus, { logger: spyLogger() }); // shadow (enabled defaults false)
+    bus.emit(swarmSignal);
+
+    const store = getTuneAdjustmentStore();
+    // Routing untouched — still shadow.
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0);
+    // But the intended counter accrued, so a soak can observe it.
+    const stat = store.demotionStats().find((s) => s.cli === 'gemini');
+    expect(stat).toMatchObject({ applied: 0, intended: 1 });
+    resetTuneAdjustmentStore();
+  });
+
   it('disabled (shadow) does NOT mutate routing even on swarm_unhealthy', () => {
     resetTuneAdjustmentStore();
     const bus = new EventBus();

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -181,6 +181,19 @@ describe('createTuneStage shadow mode (#3147)', () => {
     resetTuneAdjustmentStore();
   });
 
+  it('enforce mode increments the APPLIED counter exactly once per swarm signal (#3323)', () => {
+    resetTuneAdjustmentStore();
+    const bus = new EventBus();
+    createTuneStage(bus, { enabled: true, logger: spyLogger() });
+    bus.emit(swarmSignal);
+
+    const stat = getTuneAdjustmentStore()
+      .demotionStats()
+      .find((s) => s.cli === 'gemini');
+    expect(stat).toMatchObject({ applied: 1, intended: 0 });
+    resetTuneAdjustmentStore();
+  });
+
   it('shadow mode records an INTENDED demotion for soak telemetry without mutating routing (#3323)', () => {
     resetTuneAdjustmentStore();
     const bus = new EventBus();

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -204,6 +204,12 @@ export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}):
         });
         return;
       }
+      // Shadow soak telemetry (#3323): record the demotion the loop WOULD have
+      // applied to routing — counter only, no routing effect — so an operator
+      // can observe the loop's would-be behavior before flipping it default-on.
+      if (event.type === 'signal.swarm_unhealthy') {
+        getTuneAdjustmentStore().recordIntended(event.agentId, `swarm_unhealthy: ${event.reason}`);
+      }
       log.info('TuneStage (shadow) — intended action', {
         kind: action.kind,
         signal: action.signal,


### PR DESCRIPTION
## What

Closes a default-on exit criterion from #3323: make the self-tuning loop's effect **inspectable** during a shadow soak, so an operator can confirm which CLIs get demoted (and how often) before flipping `NEXUS_TUNE_ENFORCE` default-on.

- **Distinct counters** on `TuneAdjustmentStore`: `applied` (demotions that biased routing in enforce mode) vs `intended` (demotions the loop *would* have applied while shadow). Distinct rather than merged so soak data is unambiguous.
- **`recordIntended(cli, reason)`** — increments the `intended` counter ONLY; does **not** touch routing (`effectiveMultiplier` stays 1.0, `list()` empty). This is the crux of "shadow soak": observe the would-be behavior without mutating routing.
- Counters **survive decay/eviction** (the active adjustment decays, but the cumulative stat persists), bounded by CLI cardinality; `lastReason` capped at 512 chars.
- **TuneStage** records an intended demotion on `signal.swarm_unhealthy` while shadow; the enforce path already records `applied` via `demote()`.
- **`health` command** surfaces a "Self-Tuning Demotions" section (table + JSON via `HealthResult.tuneAdjustments`).

## Tests

Store: applied count survives decay; `recordIntended` leaves multiplier 1.0 + empty `list()`; empty-reason no-op; `clear()` resets telemetry; reason cap. TuneStage: shadow records intended without mutating routing. 60 tests pass across store/tune-stage/health. Typecheck + lint clean.

## #3323 progress

Done: e2e + floor-safety (#3324), durable audit (#3325), **shadow-soak telemetry (this PR)**. Remaining: **docs** (then the flip). Rollout decided: minor + NOTABLE changelog, default false→true with opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)