### PR TITLE
docs(tune): document the self-tuning loop and NEXUS_TUNE_ENFORCE (#3323)

### DIFF
--- a/.changeset/document-self-tuning-loop.md
+++ b/.changeset/document-self-tuning-loop.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+docs(tune): document the self-tuning loop and NEXUS_TUNE_ENFORCE (#3323)
+
+Adds a `NEXUS_TUNE_ENFORCE` entry to CONFIGURATION.md (shadow default vs enforce,
+the bounded-safety invariants, the `health` "Self-Tuning Demotions" telemetry,
+and the opt-out) and a "The self-tuning loop (#3143)" architecture section in
+EVENT_BUS_BOUNDARIES.md (producers → TuneStage → store → router, end-to-end,
+replacing the stale shadow-only description). The last default-on exit criterion
+from #3323.

--- a/docs/architecture/EVENT_BUS_BOUNDARIES.md
+++ b/docs/architecture/EVENT_BUS_BOUNDARIES.md
@@ -50,10 +50,46 @@ narrow and typed.
 The self-tuning loop routes its signals through bus A as typed events:
 
 - `signal.fitness_declined` — emitted when a fitness score falls below floor.
-- `signal.swarm_unhealthy` — emitted when an agent/CLI's health degrades.
+- `signal.swarm_unhealthy` — emitted when an agent/CLI's health degrades, from
+  two producers: the SwarmObserver bottleneck poll
+  (`observability/swarm-health-signals.ts`, #3223) and adapter circuit-breaker
+  failovers (`observability/failover-signals.ts`, #3321, which carry the exact
+  `CliName`).
 - `signal.vote_rejected` — emitted from the `consensus_vote` MCP handler when a
   vote resolves to `rejected` (see `mcp/tools/consensus-vote-signals.ts`).
 
-The shadow `TuneStage` (`pipeline/tune-stage.ts`) subscribes to these and logs
-the bounded action each implies. It is wired at server init
-(`cli-server-tools.ts`) and released at shutdown (`cli-server.ts`).
+The `TuneStage` (`pipeline/tune-stage.ts`) subscribes to these. It is wired at
+server init (`cli-server-tools.ts`) and released at shutdown (`cli-server.ts`).
+
+## The self-tuning loop (#3143)
+
+The loop closes `signal → tune → route` end-to-end, gated by the single
+`NEXUS_TUNE_ENFORCE` flag (default off):
+
+```
+producers ──signal.swarm_unhealthy──▶ TuneStage ──demote──▶ TuneAdjustmentStore ──penalty──▶ CompositeRouter
+(swarm health,                        (consumer)            (bounded, decaying)             (reads multiplier
+ adapter failover)                                                                           into candidate score)
+```
+
+- **Shadow (default, `NEXUS_TUNE_ENFORCE` unset/false):** the `TuneStage` logs
+  the demotion it _would_ apply and records it to the `intended` counter
+  (`TuneAdjustmentStore.recordIntended` — counter only, **routing untouched**).
+  Observe via `nexus-agents health` → "Self-Tuning Demotions" (`applied` vs
+  `intended` per CLI). Non-routing signals (`fitness_declined`, `vote_rejected`)
+  always stay shadow-logged.
+- **Enforce (`NEXUS_TUNE_ENFORCE=true`):** a `signal.swarm_unhealthy` applies a
+  bounded demotion via `TuneAdjustmentStore.demote`; the `CompositeRouter` reads
+  `effectiveMultiplier` as an additive scoring penalty. The same flag gates both
+  the write and the read, so the loop is **fully live or fully shadow, never
+  half-wired**. Each demotion is appended to the immutable audit log as
+  `tune.demote` (`verify_audit_chain`).
+
+**Bounded-safety invariants** (in `core/tune-adjustment-store.ts`) — the loop is
+self-correcting, never a ratchet: demotion-only (slow a CLI, never boost it);
+floored at `0.5` (never zeroed — a sole-viable CLI stays selectable); capped at
+`0.2` per step; time-decaying linearly back to neutral over 30 minutes (a
+transient blip auto-reverses). This is a **separate** channel from the LinUCB
+real-outcome bandit (per the #3147 ratifying-vote dissent). Operator control is
+the single `NEXUS_TUNE_ENFORCE` flag; see
+[CONFIGURATION.md](../getting-started/CONFIGURATION.md#learning--memory-variables).

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -228,8 +228,16 @@ All configuration can be overridden with environment variables:
 | `NEXUS_PERSIST_LEARNING`  | Cross-session routing persistence                         | `true`   |
 | `NEXUS_REFLECTIVE_MEMORY` | Reflective memory retrieval (`shadow`/`true`/`false`)     | `shadow` |
 | `NEXUS_BILLING_MODE`      | Cost mode (`plan`=strongest model wins, `api`=cost-aware) | `plan`   |
+| `NEXUS_TUNE_ENFORCE`      | Self-tuning loop: apply bounded routing demotions         | `false`  |
 
 Outcomes and distilled routing rules persist to `~/.nexus-agents/learning/` — this is **cross-repo** state (shared across all your projects) and is not affected by the per-repo data dir (epic #2872). When persistence is enabled, `routingMemory`, `strategyDistillation`, and `preferenceRouting` also auto-enable (no separate config needed). Opt out with `NEXUS_PERSIST_LEARNING=false`.
+
+**`NEXUS_TUNE_ENFORCE` — the self-tuning routing loop (epic #3143 / #3147).** The loop reacts to health signals (`signal.swarm_unhealthy` from SwarmObserver bottlenecks and adapter circuit-breaker failovers) by **demoting** an unhealthy CLI in routing. The same flag gates both the write (the `TuneStage` applies the demotion) and the read (the `CompositeRouter` folds it into candidate scoring), so the loop is **either fully live or fully shadow — never half-wired**.
+
+- `false` (**shadow**, default) — the loop logs the demotion it _would_ apply and records it to the `intended` counter, but **routing is untouched**. Inspect the would-be behavior with `nexus-agents health` (the "Self-Tuning Demotions" section shows `applied` vs `intended` per CLI). This mirrors the `audit`-mode philosophy of the governance variables below: collect telemetry before flipping.
+- `true` (**enforce**) — a `signal.swarm_unhealthy` applies a **bounded** routing demotion via the provenance-tagged `TuneAdjustmentStore`. Every demotion is recorded to the immutable audit log as a `tune.demote` event (verify with `verify_audit_chain`).
+
+The demotion is bounded by hard safety invariants so the loop is self-correcting, never a ratchet: **demotion-only** (a CLI is slowed, never boosted), **floored** at `0.5` (never zeroed out of routing — a sole-viable CLI is always still selectable), **capped** at `0.2` per step, and **time-decaying** linearly back to neutral over 30 minutes (a transient health blip auto-reverses). The channel is separate from the LinUCB real-outcome bandit. See [Self-Tuning Loop](../architecture/EVENT_BUS_BOUNDARIES.md#the-self-tuning-loop-3143).
 
 Files stored:
 


### PR DESCRIPTION
## What

The final default-on exit criterion from #3323. Documents the self-tuning routing loop and its single operator control:

- **CONFIGURATION.md** — a `NEXUS_TUNE_ENFORCE` entry in the Learning & Memory variables, following the existing `audit→enforce` graduation-path style: shadow (default) logs + accrues the `intended` counter without touching routing; enforce applies the bounded demotion + audit. Documents the bounded-safety invariants (demotion-only / floored 0.5 / capped 0.2 / 30-min decay), the `health` "Self-Tuning Demotions" telemetry as the soak mechanism, and the opt-out.
- **EVENT_BUS_BOUNDARIES.md** — a "The self-tuning loop (#3143)" section with the end-to-end flow (two `swarm_unhealthy` producers → TuneStage → store → CompositeRouter), replacing the now-stale "shadow TuneStage … logs" description. Cross-linked with CONFIGURATION.md.

Docs-only; markdownlint clean; cross-doc anchors verified.

## #3323 status

With this, **all exit criteria are met**: e2e + floor-safety (#3324), durable audit (#3325), shadow-soak telemetry (#3328), rollout decision (minor + NOTABLE changelog), and docs (this PR). The loop is ready for the default-on flip as a separate, clearly-marked release change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)