### PR TITLE
feat(observability): scheduled improvement_review producer (#3229)

### DIFF
--- a/.changeset/scheduled-improvement-review.md
+++ b/.changeset/scheduled-improvement-review.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(observability): scheduled improvement_review producer (#3229)
+
+Adds an opt-in server-side scheduler that periodically runs `improvement_review`
+so its `signal.fitness_declined` fires automatically, closing the
+observability→action gap (a human previously had to invoke the tool by hand).
+Mirrors the swarm-health-signals lifecycle (idempotent start + paired shutdown,
+unref'd timer, errors swallowed, concurrency-guarded). **Disabled by default**
+(`NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS=0`); a conservative 6h is suggested when
+opting in. Auto-filing GitHub issues stays a SEPARATE opt-in
+(`NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES`, default false) so the timer never spams
+issues. Analysis-only by default.

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -221,6 +221,15 @@ All configuration can be overridden with environment variables:
 | `NEXUS_MAX_CONCURRENT_EXPERTS`   | Expert pool semaphore capacity             | `6`     |
 | `NEXUS_ALLOW_MOCK_ORCHESTRATION` | Allow mock orchestration (test/CI only)    | `false` |
 
+**Scheduled `improvement_review` (#3229).** Periodically runs `improvement_review` server-side so its `signal.fitness_declined` fires without manual invocation, feeding the self-tuning loop:
+
+| Variable                               | Description                                                                   | Default   |
+| -------------------------------------- | ----------------------------------------------------------------------------- | --------- |
+| `NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS` | Poll interval in ms. `0`/unset disables. Suggested opt-in: `21600000` (6h)    | `0` (off) |
+| `NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES` | Whether the scheduled run files GitHub issues (separate opt-in — avoids spam) | `false`   |
+
+The scheduled run is **analysis-only by default** (emits signals, files no issues); `NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES=true` is a deliberate, separate opt-in (the tool's 5-issues/run rate-limit + open-issue dedup are backstops, not the primary guard).
+
 ### Learning & Memory Variables
 
 | Variable                  | Description                                               | Default  |

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -79,6 +79,7 @@ import {
   startSwarmHealthSignals,
   startFailoverSignals,
 } from './observability/index.js';
+import { startImprovementReviewScheduler } from './mcp/tools/improvement-review-scheduler.js';
 import { getOutcomeStore } from './orchestration/outcomes/index.js';
 import { createDefaultPolicyEngine } from './pipeline/policy-engine.js';
 import { resolveV2Config } from './pipeline/v2-config.js';
@@ -640,6 +641,11 @@ function initV2PipelineSubsystems(
   // carry the exact CliName) from bus B as signal.swarm_unhealthy on bus A
   // (#3321). Paired with shutdownFailoverSignals() in cli-server.ts.
   startFailoverSignals({ pipelineBus: pipelineEventBus });
+  // Scheduled improvement_review (#3229): periodically runs the review so its
+  // signal.fitness_declined fires without manual invocation. Disabled by
+  // default (NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS); issue-filing is a separate
+  // opt-in. Paired with shutdownImprovementReviewScheduler() in cli-server.ts.
+  startImprovementReviewScheduler();
   const policyEngine = createDefaultPolicyEngine();
   const v2Config = resolveV2Config();
   logger.info('V2 Pipeline OS initialized', {

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -56,6 +56,7 @@ import { shutdownToolMemory } from './mcp/tools/tool-memory.js';
 import { shutdownExpertBridge } from './pipeline/expert-bridge.js';
 import { shutdownFeedbackSubscriber } from './pipeline/feedback-subscriber.js';
 import { shutdownTuneStage } from './pipeline/tune-stage.js';
+import { shutdownImprovementReviewScheduler } from './mcp/tools/improvement-review-scheduler.js';
 import {
   initializeAuditLogger,
   shutdownAuditLogger,
@@ -250,6 +251,9 @@ function createShutdownCleanup(options: ShutdownCleanupOptions): () => Promise<v
 
     // Release the adapter-failover signal subscription (#3321)
     shutdownFailoverSignals();
+
+    // Release the scheduled improvement_review timer (#3229)
+    shutdownImprovementReviewScheduler();
 
     const closeResult = await closeServer(server, serverLogger);
     if (!closeResult.ok) {

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the scheduled improvement_review runner (#3229).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ILogger } from '../../core/index.js';
+import {
+  startImprovementReviewScheduler,
+  shutdownImprovementReviewScheduler,
+} from './improvement-review-scheduler.js';
+import * as reviewModule from './improvement-review.js';
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+describe('improvement-review-scheduler (#3229)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    shutdownImprovementReviewScheduler();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    delete process.env['NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS'];
+    delete process.env['NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES'];
+  });
+
+  it('is DISABLED by default — no run, no timer', () => {
+    const run = vi.spyOn(reviewModule, 'runImprovementReview');
+    startImprovementReviewScheduler({ logger: spyLogger() }); // no interval → off
+    vi.advanceTimersByTime(60_000);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('runs on the interval when enabled, with fileIssues OFF by default', async () => {
+    const run = vi.spyOn(reviewModule, 'runImprovementReview').mockResolvedValue({
+      window: '7d',
+      totalOutcomes: 0,
+      signals: [],
+      issuesFiled: [],
+      issuesSkipped: [],
+    });
+
+    startImprovementReviewScheduler({ intervalMs: 1000, logger: spyLogger() });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    // fileIssues must default to false — the timer never auto-files issues.
+    expect(run.mock.calls[0]?.[0]).toMatchObject({ fileIssues: false });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes fileIssues: true only when explicitly opted in', async () => {
+    const run = vi.spyOn(reviewModule, 'runImprovementReview').mockResolvedValue({
+      window: '7d',
+      totalOutcomes: 0,
+      signals: [],
+      issuesFiled: [],
+      issuesSkipped: [],
+    });
+
+    startImprovementReviewScheduler({ intervalMs: 1000, fileIssues: true, logger: spyLogger() });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(run.mock.calls[0]?.[0]).toMatchObject({ fileIssues: true });
+  });
+
+  it('does not overlap runs — skips while a previous run is in flight', async () => {
+    let resolveRun: (() => void) | undefined;
+    const run = vi.spyOn(reviewModule, 'runImprovementReview').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRun = () => {
+            resolve({
+              window: '7d',
+              totalOutcomes: 0,
+              signals: [],
+              issuesFiled: [],
+              issuesSkipped: [],
+            });
+          };
+        })
+    );
+
+    startImprovementReviewScheduler({ intervalMs: 1000, logger: spyLogger() });
+    await vi.advanceTimersByTimeAsync(1000); // first run starts, stays pending
+    await vi.advanceTimersByTimeAsync(1000); // tick again while still running
+    expect(run).toHaveBeenCalledTimes(1); // second tick skipped
+
+    resolveRun?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000); // now free to run again
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent on start and clean on shutdown', async () => {
+    const run = vi.spyOn(reviewModule, 'runImprovementReview').mockResolvedValue({
+      window: '7d',
+      totalOutcomes: 0,
+      signals: [],
+      issuesFiled: [],
+      issuesSkipped: [],
+    });
+
+    startImprovementReviewScheduler({ intervalMs: 1000, logger: spyLogger() });
+    startImprovementReviewScheduler({ intervalMs: 1000, logger: spyLogger() }); // no 2nd timer
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    shutdownImprovementReviewScheduler();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(run).toHaveBeenCalledTimes(1); // no runs after shutdown
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
@@ -1,0 +1,91 @@
+/**
+ * Scheduled `improvement_review` runner (#3229, epic #3143).
+ *
+ * Closes the observability→action gap: `improvement_review` already emits
+ * `signal.fitness_declined` onto the pipeline bus on every run (see
+ * `improvement-review-signals.ts`), but nothing invoked it on a schedule — a
+ * human had to run the MCP tool by hand. This module polls it on an interval so
+ * the signal fires automatically, feeding the self-tuning loop.
+ *
+ * Mirrors the `observability/swarm-health-signals.ts` lifecycle: an idempotent
+ * `start` + paired `shutdown`, an `.unref()`'d timer, and errors swallowed so a
+ * failed run never breaks the poll.
+ *
+ * **Disabled by default.** Set `NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS` to a
+ * positive value to enable (a conservative 6h = `21600000` is recommended for
+ * analysis-only signal emission). Issue filing stays a SEPARATE opt-in:
+ * `NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES=true` — never enabled by the timer
+ * alone, since auto-filing GitHub issues on a schedule risks issue spam.
+ *
+ * @module mcp/tools/improvement-review-scheduler
+ */
+
+import { createLogger, getErrorMessage } from '../../core/index.js';
+import type { ILogger } from '../../core/index.js';
+import { parseIntEnv, parseBoolEnv } from '../../config/defaults-env.js';
+import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';
+
+const defaultLogger = createLogger({ component: 'ImprovementReviewScheduler' });
+
+/** Poll interval (ms). Default 0 = disabled. */
+const INTERVAL_ENV = 'NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS';
+/** Separate opt-in for auto-filing GitHub issues on the scheduled run. */
+const FILE_ISSUES_ENV = 'NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES';
+
+export interface ImprovementReviewSchedulerOptions {
+  /** Poll interval in ms. `<= 0` (default) disables the scheduler. */
+  readonly intervalMs?: number;
+  /** Whether scheduled runs file GitHub issues. Default false (signals only). */
+  readonly fileIssues?: boolean;
+  /** Injectable logger. */
+  readonly logger?: ILogger;
+}
+
+let schedulerTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Start the scheduled `improvement_review` poll. Idempotent — repeated calls are
+ * no-ops while active. Disabled (returns immediately) when the resolved interval
+ * is non-positive. Caller must invoke `shutdownImprovementReviewScheduler()` on
+ * server shutdown to release the timer.
+ */
+export function startImprovementReviewScheduler(options?: ImprovementReviewSchedulerOptions): void {
+  if (schedulerTimer !== undefined) return;
+  const logger = options?.logger ?? defaultLogger;
+  const intervalMs = options?.intervalMs ?? parseIntEnv(INTERVAL_ENV, 0);
+  if (intervalMs <= 0) return; // disabled by default
+  const fileIssues = options?.fileIssues ?? parseBoolEnv(FILE_ISSUES_ENV, false);
+
+  let running = false; // guard against overlapping runs (the review is async)
+  schedulerTimer = setInterval(() => {
+    if (running) {
+      logger.debug('Scheduled improvement_review skipped — previous run still in progress');
+      return;
+    }
+    running = true;
+    const input = ImprovementReviewInputSchema.parse({ fileIssues });
+    runImprovementReview(input, { logger })
+      .then((result) => {
+        logger.info('Scheduled improvement_review complete', {
+          signals: result.signals.length,
+          issuesFiled: result.issuesFiled.length,
+        });
+      })
+      .catch((error: unknown) => {
+        logger.warn('Scheduled improvement_review failed', { error: getErrorMessage(error) });
+      })
+      .finally(() => {
+        running = false;
+      });
+  }, intervalMs);
+  schedulerTimer.unref();
+  logger.info('Scheduled improvement_review enabled', { intervalMs, fileIssues });
+}
+
+/** Release the scheduled improvement_review timer. Idempotent. */
+export function shutdownImprovementReviewScheduler(): void {
+  if (schedulerTimer !== undefined) {
+    clearInterval(schedulerTimer);
+    schedulerTimer = undefined;
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
@@ -46,8 +46,9 @@ let schedulerTimer: ReturnType<typeof setInterval> | undefined;
 /**
  * Start the scheduled `improvement_review` poll. Idempotent — repeated calls are
  * no-ops while active. Disabled (returns immediately) when the resolved interval
- * is non-positive. Caller must invoke `shutdownImprovementReviewScheduler()` on
- * server shutdown to release the timer.
+ * is non-positive. The first run fires after one full interval (not eagerly at
+ * start), so frequent server restarts don't trigger a burst of reviews. Caller
+ * must invoke `shutdownImprovementReviewScheduler()` on server shutdown.
  */
 export function startImprovementReviewScheduler(options?: ImprovementReviewSchedulerOptions): void {
   if (schedulerTimer !== undefined) return;
@@ -56,6 +57,11 @@ export function startImprovementReviewScheduler(options?: ImprovementReviewSched
   if (intervalMs <= 0) return; // disabled by default
   const fileIssues = options?.fileIssues ?? parseBoolEnv(FILE_ISSUES_ENV, false);
 
+  // Parse once at start (fileIssues is fixed for the scheduler's lifetime) — so
+  // a validation throw surfaces at startup, never mid-tick where it could wedge
+  // the `running` guard (#3229 QA).
+  const input = ImprovementReviewInputSchema.parse({ fileIssues });
+
   let running = false; // guard against overlapping runs (the review is async)
   schedulerTimer = setInterval(() => {
     if (running) {
@@ -63,7 +69,6 @@ export function startImprovementReviewScheduler(options?: ImprovementReviewSched
       return;
     }
     running = true;
-    const input = ImprovementReviewInputSchema.parse({ fileIssues });
     runImprovementReview(input, { logger })
       .then((result) => {
         logger.info('Scheduled improvement_review complete', {

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.ts
@@ -23,7 +23,12 @@
 import { createLogger, getErrorMessage } from '../../core/index.js';
 import type { ILogger } from '../../core/index.js';
 import { parseIntEnv, parseBoolEnv } from '../../config/defaults-env.js';
-import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';
+// NOTE: `improvement-review.js` is imported LAZILY inside the timer (not
+// statically) on purpose — it pulls in a heavy dependency chain (fitness audit,
+// gh issue filing, outcome store). A static import here would drag all of that
+// into `cli-server.ts`'s module graph (this module is wired there for
+// start/shutdown), bloating load and breaking partial-mock test setups. The
+// scheduler is default-off, so the heavy module loads only when actually enabled.
 
 const defaultLogger = createLogger({ component: 'ImprovementReviewScheduler' });
 
@@ -57,31 +62,34 @@ export function startImprovementReviewScheduler(options?: ImprovementReviewSched
   if (intervalMs <= 0) return; // disabled by default
   const fileIssues = options?.fileIssues ?? parseBoolEnv(FILE_ISSUES_ENV, false);
 
-  // Parse once at start (fileIssues is fixed for the scheduler's lifetime) — so
-  // a validation throw surfaces at startup, never mid-tick where it could wedge
-  // the `running` guard (#3229 QA).
-  const input = ImprovementReviewInputSchema.parse({ fileIssues });
-
   let running = false; // guard against overlapping runs (the review is async)
+  // The whole run lives in one async fn so the lazy import, the (cheap) input
+  // parse, and the review all share a single try/finally — a throw anywhere is
+  // caught and `running` is always reset, never wedged (#3229 QA).
+  const runOnce = async (): Promise<void> => {
+    try {
+      const { runImprovementReview, ImprovementReviewInputSchema } =
+        await import('./improvement-review.js');
+      const input = ImprovementReviewInputSchema.parse({ fileIssues });
+      const result = await runImprovementReview(input, { logger });
+      logger.info('Scheduled improvement_review complete', {
+        signals: result.signals.length,
+        issuesFiled: result.issuesFiled.length,
+      });
+    } catch (error: unknown) {
+      logger.warn('Scheduled improvement_review failed', { error: getErrorMessage(error) });
+    } finally {
+      running = false;
+    }
+  };
+
   schedulerTimer = setInterval(() => {
     if (running) {
       logger.debug('Scheduled improvement_review skipped — previous run still in progress');
       return;
     }
     running = true;
-    runImprovementReview(input, { logger })
-      .then((result) => {
-        logger.info('Scheduled improvement_review complete', {
-          signals: result.signals.length,
-          issuesFiled: result.issuesFiled.length,
-        });
-      })
-      .catch((error: unknown) => {
-        logger.warn('Scheduled improvement_review failed', { error: getErrorMessage(error) });
-      })
-      .finally(() => {
-        running = false;
-      });
+    void runOnce();
   }, intervalMs);
   schedulerTimer.unref();
   logger.info('Scheduled improvement_review enabled', { intervalMs, fileIssues });


### PR DESCRIPTION
## What

Closes #3229: `improvement_review` already emits `signal.fitness_declined` on every run, but nothing invoked it on a schedule — a human had to run the MCP tool by hand. This adds an **opt-in server-side scheduler** so the signal fires automatically, feeding the self-tuning loop (epic #3143).

Mirrors the proven `observability/swarm-health-signals.ts` lifecycle: idempotent `start` + paired `shutdown`, `.unref()`'d timer, errors swallowed (a failed run never breaks the poll), wired into `initV2PipelineSubsystems` + shutdown.

## Safety (the blast-radius part)

The issue's suggested fix named `CronCreate`/`PushNotification` — Claude Code harness tools the MCP server can't call — and auto-filing issues on a timer. I deliberately scoped it conservatively:

- **Disabled by default** — `NEXUS_IMPROVEMENT_REVIEW_INTERVAL_MS=0`. Suggested opt-in: 6h.
- **Analysis-only by default** — issue filing is a *separate* opt-in (`NEXUS_IMPROVEMENT_REVIEW_FILE_ISSUES=false`), so the timer never auto-files GitHub issues / risks spam. The tool's 5/run rate-limit + open-issue dedup are backstops, not the primary guard.
- **Concurrency-guarded** — overlapping runs are skipped (the review is async, unlike the sync swarm poll).

## Tests

5 tests: disabled by default; runs on interval with `fileIssues:false`; `fileIssues:true` only when opted in; no overlap while a run is in flight; idempotent start + clean shutdown. Typecheck + eslint + markdownlint clean. Docs: two new env vars in CONFIGURATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)