### PR TITLE
feat(observability): surface self-eval findings as improvement signals (#3224)

### DIFF
--- a/.changeset/self-eval-signals.md
+++ b/.changeset/self-eval-signals.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(observability): surface self-eval findings as improvement_review signals (#3224)
+
+Closes the gap where self-evaluation produced recommendations that never drove
+any action. `improvement_review` gains an opt-in `selfEvalReportPath` input: when
+set, it reads a `self-eval --json` report and converts **high-confidence,
+unanimous** `deprecate`/`refactor` findings (confidence ≥ 0.8, no dissent) into
+`tech-debt` signals that flow through the SAME deduped + rate-limited GitHub-issue
+path as the other detectors. This is the safe, non-behavioral path: it surfaces a
+human decision point (a candidate issue), never an automatic routing change.
+Fail-soft — an absent/unreadable/malformed report yields no signals (logged), and
+absent input leaves behavior unchanged.

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-self-eval.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-self-eval.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for self-eval → tech-debt signal surfacing in improvement_review (#3224).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createLogger } from '../../core/index.js';
+import { detectSelfEvalSignals, loadSelfEvalSignals } from './improvement-review.js';
+
+const logger = createLogger({ component: 'test' });
+
+interface SelfEvalEntry {
+  component: string;
+  finalRecommendation: string;
+  confidence: number;
+  dissent: unknown[];
+  evidenceQuality?: number;
+}
+
+function result(over: Partial<SelfEvalEntry> = {}): SelfEvalEntry {
+  return {
+    component: 'src/foo.ts',
+    finalRecommendation: 'deprecate',
+    confidence: 0.95,
+    dissent: [],
+    ...over,
+  };
+}
+
+describe('detectSelfEvalSignals (#3224)', () => {
+  it('surfaces a high-confidence unanimous deprecate finding as a tech-debt signal', () => {
+    const signals = detectSelfEvalSignals({ results: [result({})] }, '7d');
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toMatchObject({
+      category: 'tech-debt',
+      severity: 'warning',
+      signalKey: 'tech-debt:self-eval:src/foo.ts:deprecate',
+    });
+  });
+
+  it('surfaces refactor at lower (info) severity', () => {
+    const signals = detectSelfEvalSignals(
+      { results: [result({ finalRecommendation: 'refactor' })] },
+      '7d'
+    );
+    expect(signals[0]?.severity).toBe('info');
+  });
+
+  it('ignores non-actionable recommendations (retain/review)', () => {
+    const signals = detectSelfEvalSignals(
+      {
+        results: [
+          result({ finalRecommendation: 'retain' }),
+          result({ finalRecommendation: 'review' }),
+        ],
+      },
+      '7d'
+    );
+    expect(signals).toHaveLength(0);
+  });
+
+  it('ignores findings with dissent (not unanimous)', () => {
+    const signals = detectSelfEvalSignals(
+      { results: [result({ dissent: [{ agent: 'code-quality' }] })] },
+      '7d'
+    );
+    expect(signals).toHaveLength(0);
+  });
+
+  it('ignores low-confidence findings (below the 0.8 floor)', () => {
+    const signals = detectSelfEvalSignals({ results: [result({ confidence: 0.7 })] }, '7d');
+    expect(signals).toHaveLength(0);
+  });
+});
+
+describe('loadSelfEvalSignals (#3224 — fail-soft)', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'nexus-selfeval-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reads a valid report and returns signals', async () => {
+    const path = join(dir, 'report.json');
+    await writeFile(path, JSON.stringify({ results: [result({})] }));
+    const signals = await loadSelfEvalSignals(path, '7d', logger);
+    expect(signals).toHaveLength(1);
+  });
+
+  it('returns no signals for a missing file (never throws)', async () => {
+    const signals = await loadSelfEvalSignals(join(dir, 'nope.json'), '7d', logger);
+    expect(signals).toEqual([]);
+  });
+
+  it('returns no signals for malformed JSON', async () => {
+    const path = join(dir, 'bad.json');
+    await writeFile(path, '{ not json');
+    expect(await loadSelfEvalSignals(path, '7d', logger)).toEqual([]);
+  });
+
+  it('returns no signals for a schema-mismatched report', async () => {
+    const path = join(dir, 'wrong.json');
+    await writeFile(path, JSON.stringify({ results: [{ component: 123 }] }));
+    expect(await loadSelfEvalSignals(path, '7d', logger)).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-self-eval.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-self-eval.test.ts
@@ -6,7 +6,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createLogger } from '../../core/index.js';
+import {
+  createLogger,
+  getTuneAdjustmentStore,
+  resetTuneAdjustmentStore,
+} from '../../core/index.js';
 import { detectSelfEvalSignals, loadSelfEvalSignals } from './improvement-review.js';
 
 const logger = createLogger({ component: 'test' });
@@ -72,6 +76,16 @@ describe('detectSelfEvalSignals (#3224)', () => {
   it('ignores low-confidence findings (below the 0.8 floor)', () => {
     const signals = detectSelfEvalSignals({ results: [result({ confidence: 0.7 })] }, '7d');
     expect(signals).toHaveLength(0);
+  });
+
+  it('is non-behavioral — surfacing a finding never touches routing (#3224 core guarantee)', () => {
+    resetTuneAdjustmentStore();
+    detectSelfEvalSignals({ results: [result({ finalRecommendation: 'deprecate' })] }, '7d');
+    // The whole point of #3224's safe path: self-eval surfaces a human decision
+    // point (an issue), it must NOT auto-demote any CLI in routing.
+    expect(getTuneAdjustmentStore().demotionStats()).toHaveLength(0);
+    expect(getTuneAdjustmentStore().list()).toHaveLength(0);
+    resetTuneAdjustmentStore();
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -399,13 +399,17 @@ export async function loadSelfEvalSignals(
  */
 async function existingIssueForSignal(signalKey: string): Promise<string | null> {
   try {
+    // Strip double-quotes from the search term so a quote in the signalKey
+    // (e.g. an oddly-named self-eval component path, #3224) can't break the
+    // `"..." in:body` phrase query and silently defeat dedup → refiling.
+    const searchTerm = signalKey.replace(/"/g, '');
     const { stdout } = await execFileAsync('gh', [
       'issue',
       'list',
       '--state',
       'open',
       '--search',
-      `"${signalKey}" in:body`,
+      `"${searchTerm}" in:body`,
       '--json',
       'number,url',
       '--limit',

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -16,11 +16,12 @@
  */
 
 import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 /* eslint-disable max-lines */
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError } from '../../core/index.js';
+import { createLogger, formatZodError, getErrorMessage } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { withPrerequisite } from '../middleware/tool-prerequisites.js';
@@ -75,6 +76,15 @@ export const ImprovementReviewInputSchema = z.object({
     .optional()
     .default(90)
     .describe('Fitness score below this threshold triggers a tech-debt signal.'),
+  selfEvalReportPath: z
+    .string()
+    .optional()
+    .describe(
+      'Optional path to a self-eval JSON report (from `self-eval --json`). When set, ' +
+        'high-confidence unanimous deprecate/refactor findings are surfaced as tech-debt ' +
+        'signals through the same deduped/rate-limited issue path (#3224). Unreadable/malformed ' +
+        'reports are skipped (no signal). Absent → no self-eval signals.'
+    ),
 });
 
 export type ImprovementReviewInput = z.infer<typeof ImprovementReviewInputSchema>;
@@ -287,6 +297,98 @@ export function detectFitnessSignals(
 }
 
 // ============================================================================
+// Self-eval findings → tech-debt signals (#3224)
+// ============================================================================
+
+/** Minimum confidence for a self-eval finding to surface as a signal. */
+const SELF_EVAL_CONFIDENCE_FLOOR = 0.8;
+
+/**
+ * Minimal, defensive schema for the `self-eval --json` report. We only read the
+ * fields needed to surface a finding; unknown extras are ignored so the parse
+ * tolerates schema drift in the (externally produced) artifact.
+ */
+const SelfEvalReportSchema = z.object({
+  results: z.array(
+    z.object({
+      component: z.string(),
+      finalRecommendation: z.string(),
+      confidence: z.number(),
+      dissent: z.array(z.unknown()).optional().default([]),
+      evidenceQuality: z.number().optional(),
+    })
+  ),
+});
+
+/**
+ * Convert a parsed self-eval report into tech-debt `ImprovementSignal`s.
+ *
+ * Only **actionable, high-confidence, unanimous** findings surface (#3224): a
+ * `deprecate`/`refactor` recommendation with NO dissent and confidence at/above
+ * {@link SELF_EVAL_CONFIDENCE_FLOOR}. This is a pure transform — it surfaces a
+ * human decision point (a candidate issue), never an automatic routing change.
+ */
+export function detectSelfEvalSignals(
+  report: z.infer<typeof SelfEvalReportSchema>,
+  windowLabel: string
+): readonly ImprovementSignal[] {
+  const signals: ImprovementSignal[] = [];
+  for (const r of report.results) {
+    const actionable =
+      r.finalRecommendation === 'deprecate' || r.finalRecommendation === 'refactor';
+    if (!actionable || r.dissent.length > 0 || r.confidence < SELF_EVAL_CONFIDENCE_FLOOR) continue;
+    signals.push({
+      category: 'tech-debt',
+      signalKey: `tech-debt:self-eval:${r.component}:${r.finalRecommendation}`,
+      severity: r.finalRecommendation === 'deprecate' ? 'warning' : 'info',
+      title: `tech-debt: self-eval recommends ${r.finalRecommendation} for ${r.component}`,
+      body: [
+        `All self-eval evaluators agreed (no dissent) on **${r.finalRecommendation}** for \`${r.component}\``,
+        `with confidence ${(r.confidence * 100).toFixed(0)}%${r.evidenceQuality !== undefined ? ` (evidence quality ${(r.evidenceQuality * 100).toFixed(0)}%)` : ''}.`,
+        '',
+        'This is a RECOMMENDATION surfaced for human review — not an automatic change.',
+      ].join('\n'),
+      evidence: {
+        observedValue: r.confidence,
+        threshold: SELF_EVAL_CONFIDENCE_FLOOR,
+        window: windowLabel,
+      },
+    });
+  }
+  return signals;
+}
+
+/**
+ * Read + parse a self-eval JSON report and convert it to signals. Fail-soft:
+ * an unreadable or malformed report yields NO signals (logged at warn) rather
+ * than breaking the review.
+ */
+export async function loadSelfEvalSignals(
+  reportPath: string,
+  windowLabel: string,
+  logger: ReturnType<typeof createLogger>
+): Promise<readonly ImprovementSignal[]> {
+  try {
+    const raw = await readFile(reportPath, 'utf8');
+    const parsed = SelfEvalReportSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      logger.warn('Self-eval report ignored — schema mismatch', {
+        reportPath,
+        error: formatZodError(parsed.error),
+      });
+      return [];
+    }
+    return detectSelfEvalSignals(parsed.data, windowLabel);
+  } catch (error) {
+    logger.warn('Self-eval report ignored — unreadable/invalid JSON', {
+      reportPath,
+      error: getErrorMessage(error),
+    });
+    return [];
+  }
+}
+
+// ============================================================================
 // Issue filing (gated, dedup-checked, command-injection-safe)
 // ============================================================================
 
@@ -426,7 +528,7 @@ export async function runImprovementReview(
   deps: { readonly logger?: ReturnType<typeof createLogger> } = {}
 ): Promise<ImprovementReviewResponse> {
   const logger = deps.logger ?? createLogger({ component: 'improvement_review' });
-  const { lookbackDays, fileIssues, minSampleSize, fitnessFloor } = input;
+  const { lookbackDays, fileIssues, minSampleSize, fitnessFloor, selfEvalReportPath } = input;
   const now = Date.now();
   const windowLabel = `${String(lookbackDays)}d`;
 
@@ -434,10 +536,18 @@ export async function runImprovementReview(
   const windowed = filterByLookback(allOutcomes, lookbackDays, now);
   const audit = safeFitnessAudit(now, { logger } as HandlerContext);
 
+  // Surface high-confidence unanimous self-eval findings as tech-debt signals
+  // (#3224) — opt-in via selfEvalReportPath, fail-soft (no path / bad file → none).
+  const selfEvalSignals =
+    selfEvalReportPath !== undefined
+      ? await loadSelfEvalSignals(selfEvalReportPath, windowLabel, logger)
+      : [];
+
   const signals: ImprovementSignal[] = [
     ...detectCliPerformanceFloor(windowed, minSampleSize, windowLabel),
     ...detectFailureCategoryConcentration(windowed, windowLabel),
     ...detectFitnessSignals(audit, fitnessFloor),
+    ...selfEvalSignals,
   ];
   signals.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
 
@@ -512,6 +622,13 @@ const TOOL_INPUT_SCHEMA = {
     .max(100)
     .optional()
     .describe('Fitness score below this threshold triggers a tech-debt signal (default 90).'),
+  selfEvalReportPath: z
+    .string()
+    .optional()
+    .describe(
+      'Optional path to a self-eval JSON report. High-confidence unanimous ' +
+        'deprecate/refactor findings surface as tech-debt signals (#3224).'
+    ),
 };
 
 /** @category MCP */


### PR DESCRIPTION
## What

Closes #3224: self-evaluation produced recommendations that **never drove any action** — `AggregatedResult`s were printed and discarded. This wires the **safe, non-behavioral path** (the issue's option B): `improvement_review` gains an opt-in `selfEvalReportPath` input. When set, it reads a `self-eval --json` report and converts **high-confidence, unanimous** `deprecate`/`refactor` findings (confidence ≥ 0.8, no dissent) into `tech-debt` `ImprovementSignal`s that flow through the **same deduped + rate-limited** GitHub-issue path as the existing detectors.

It surfaces a **human decision point** (a candidate issue) — never an automatic routing/strategy change (the issue's option A, auto-demote, was deliberately not taken; higher risk, not required to close the gap).

## Safety

- **Opt-in** — absent `selfEvalReportPath` → behavior unchanged.
- **Non-behavioral** — pure `AggregatedResult → ImprovementSignal` transform; no routing mutation.
- **Fail-soft** — missing / unreadable / malformed / schema-mismatched report → no signals (logged at warn), never throws. Defensive zod schema for the external JSON.
- **Reuses existing guards** — the shared `fileSignalsAsIssues` dedup (`signalKey`) + `MAX_ISSUES_PER_RUN=5`.
- Producer/consumer split preserved: self-eval stays the CLI producer; improvement_review is the consumer (no heavy in-process scan added).

## Tests

9 tests (pure transform: deprecate/refactor→signal at warning/info, retain/review/dissent/low-confidence→none; loader fail-soft: valid/missing/malformed/schema-mismatch). 3271 interacting mcp/cli-server tests pass. Typecheck + eslint clean.

Part of epic #3143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)