### PR TITLE
feat(config): connect the 1071-entry generated catalog to ModelRegistry (#3293)

### DIFF
--- a/.changeset/connect-generated-registry.md
+++ b/.changeset/connect-generated-registry.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': minor
+---
+
+feat(config): connect the 1071-entry generated catalog to ModelRegistry (#3293)
+
+Ingests `model-registry.generated.json` (the broad LiteLLM/models.dev catalog,
+~1071 entries) into `ModelRegistry` as a LOWEST-priority breadth tier. Each
+record is converted to a full `ModelEntry` (behavior fields derived from the
+id's identity, then the catalog's context window / pricing / display name
+overlaid). In-tree, manifest, and models-dev tiers all still win; the breadth
+tier only fills the long tail, so unknown/new models resolve to real catalog
+data instead of a bare derived default.
+
+This is the non-destructive "connect, don't drop" step toward the
+CapabilityDiscovery → ModelRegistry consolidation (#3293) — it preserves the
+coverage the legacy T2 tier provided (parity test asserts zero context-window
+mismatches across all catalog ids). The CapabilityDiscovery removal stays gated
+behind the binding confirmation vote and remains a follow-up.

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -245,6 +245,11 @@ export class ModelRegistry {
       if (entry.aliases !== undefined) {
         for (const alias of entry.aliases) {
           this.byAlias.set(alias, entry.id);
+          // Tiers load lowest-priority first, so a direct `byId` entry under
+          // this alias key can only come from a lower tier (e.g. the generated
+          // breadth catalog). An authoritative alias must win: drop the shadow
+          // so `lookupExact` resolves the alias to its canonical entry (#3293).
+          if (alias !== entry.id) this.byId.delete(alias);
         }
       }
     }

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -39,6 +39,7 @@ import { buildInTreeEntries } from './in-tree-entries.js';
 import { loadManifestOverlay } from './manifest-overlay.js';
 import { DEFAULT_ENTRY, deriveEntry } from './model-derivation.js';
 import { loadModelsDevSnapshot } from './models-dev-snapshot-loader.js';
+import { loadGeneratedRegistryEntries } from './models-generated-loader.js';
 import type {
   InputModality,
   OutputModality,
@@ -75,7 +76,7 @@ export type PromptCachingMode = 'none' | 'ephemeral' | 'aggressive';
  * Where this entry came from. Higher-priority sources override lower
  * ones field-by-field; `derived` is always the fallback floor.
  */
-export type EntrySource = 'in-tree' | 'models-dev' | 'manifest' | 'derived';
+export type EntrySource = 'in-tree' | 'models-dev' | 'manifest' | 'derived' | 'generated';
 
 /**
  * One model's full metadata. Combines what was previously split
@@ -158,6 +159,13 @@ export interface ModelRegistryOptions {
   readonly modelsDevEntries?: readonly ModelEntry[];
   /** Operator manifest entries. Higher priority than in-tree. */
   readonly manifestEntries?: readonly ModelEntry[];
+  /**
+   * Broad generated-catalog (LiteLLM) breadth entries. LOWEST priority —
+   * overwritten by every other tier; provides long-tail coverage so unknown
+   * models resolve to real catalog data instead of a bare derived default
+   * (#3293, preserving the legacy CapabilityDiscovery T2 breadth).
+   */
+  readonly generatedEntries?: readonly ModelEntry[];
 }
 
 /**
@@ -170,6 +178,9 @@ export class ModelRegistry {
 
   constructor(options: ModelRegistryOptions = {}) {
     // Load order: lowest priority first; later sources overwrite.
+    if (options.generatedEntries !== undefined) {
+      this.loadEntries(options.generatedEntries);
+    }
     if (options.modelsDevEntries !== undefined) {
       this.loadEntries(options.modelsDevEntries);
     }
@@ -187,7 +198,12 @@ export class ModelRegistry {
    */
   getEntry(modelId: string, hints?: ModelHints): ModelEntry {
     const direct = this.lookupExact(modelId);
-    if (direct !== undefined && direct.source !== 'models-dev') return direct;
+    // 'models-dev' and 'generated' are catalog breadth tiers: merge their data
+    // with derivation rather than returning blindly (in-tree/manifest are
+    // authoritative and return directly). (#3293)
+    if (direct !== undefined && direct.source !== 'models-dev' && direct.source !== 'generated') {
+      return direct;
+    }
 
     const identity = resolveModelIdentitySync(modelId, augmentHints(hints, direct));
     const derived = deriveEntry(modelId, identity);
@@ -297,6 +313,7 @@ export function getDefaultRegistry(): ModelRegistry {
 function buildDefaultRegistry(): ModelRegistry {
   const overlay = loadManifestOverlay();
   const snapshot = loadModelsDevSnapshot();
+  const generated = loadGeneratedRegistryEntries();
   const inTree = buildInTreeEntries();
   const options: ModelRegistryOptions = { inTreeEntries: inTree };
   if (overlay.status === 'loaded' && overlay.entries.length > 0) {
@@ -304,6 +321,9 @@ function buildDefaultRegistry(): ModelRegistry {
   }
   if (snapshot.status === 'loaded' && snapshot.entries.length > 0) {
     (options as { modelsDevEntries?: readonly ModelEntry[] }).modelsDevEntries = snapshot.entries;
+  }
+  if (generated.status === 'loaded' && generated.entries.length > 0) {
+    (options as { generatedEntries?: readonly ModelEntry[] }).generatedEntries = generated.entries;
   }
   return new ModelRegistry(options);
 }

--- a/packages/nexus-agents/src/config/models-generated-loader.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.ts
@@ -1,0 +1,115 @@
+/**
+ * Loader for the bundled generated model registry (#3293).
+ *
+ * `model-registry.generated.json` is the broad (~1071-entry) LiteLLM/models.dev
+ * catalog that the legacy `CapabilityDiscovery` T2 tier resolved against. To
+ * complete the CapabilityDiscovery → ModelRegistry consolidation WITHOUT losing
+ * that breadth (owner decision: "connect the 1071, don't drop it"), the registry
+ * ingests these entries as a LOWEST-priority breadth tier: anything also present
+ * in-tree / manifest / models-dev wins; otherwise the registry now has real
+ * (litellm-sourced) context-window + pricing for the long tail instead of a bare
+ * derived default.
+ *
+ * Each raw record is converted to a full `ModelEntry` by deriving the behavior
+ * fields (`deriveEntry`) from the id's identity, then overlaying the catalog's
+ * concrete data (displayName, contextWindow, maxOutputTokens, pricing). The
+ * loader is fail-soft: a missing/malformed file yields no entries.
+ *
+ * @module config/models-generated-loader
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLogger } from '../core/index.js';
+import { resolveModelIdentitySync } from './model-identity.js';
+import { deriveEntry } from './model-derivation.js';
+import type { ModelEntry } from './model-registry.js';
+
+/** Shape of a record in `model-registry.generated.json`'s `entries` array. */
+interface GeneratedRecord {
+  readonly id?: unknown;
+  readonly displayName?: unknown;
+  readonly contextWindow?: unknown;
+  readonly maxOutputTokens?: unknown;
+  readonly pricing?: { readonly inputPer1M?: unknown; readonly outputPer1M?: unknown };
+}
+
+interface GeneratedShape {
+  readonly version?: unknown;
+  readonly entries?: unknown;
+}
+
+export interface GeneratedLoadResult {
+  readonly entries: readonly ModelEntry[];
+  readonly path: string;
+  readonly status: 'loaded' | 'missing' | 'malformed';
+}
+
+function defaultGeneratedPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, 'model-registry.generated.json');
+}
+
+/** Convert one raw catalog record into a `ModelEntry` (derived base + overlay). */
+function toModelEntry(rec: GeneratedRecord): ModelEntry | undefined {
+  if (typeof rec.id !== 'string' || rec.id === '') return undefined;
+  const id = rec.id;
+  const base = deriveEntry(id, resolveModelIdentitySync(id));
+  const pricing =
+    rec.pricing !== undefined &&
+    typeof rec.pricing.inputPer1M === 'number' &&
+    typeof rec.pricing.outputPer1M === 'number'
+      ? { inputPer1M: rec.pricing.inputPer1M, outputPer1M: rec.pricing.outputPer1M }
+      : undefined;
+  return {
+    ...base,
+    source: 'generated',
+    ...(typeof rec.displayName === 'string' ? { displayName: rec.displayName } : {}),
+    ...(typeof rec.contextWindow === 'number' ? { contextWindow: rec.contextWindow } : {}),
+    ...(typeof rec.maxOutputTokens === 'number' ? { maxOutputTokens: rec.maxOutputTokens } : {}),
+    ...(pricing !== undefined ? { pricing } : {}),
+  };
+}
+
+/**
+ * Load the generated catalog as `ModelEntry[]`. Fail-soft: missing/malformed →
+ * empty (logged at warn). Records without a string `id` are skipped.
+ */
+export function loadGeneratedRegistryEntries(options?: {
+  readonly path?: string;
+}): GeneratedLoadResult {
+  const logger = createLogger({ component: 'models-generated' });
+  const path = options?.path ?? defaultGeneratedPath();
+
+  let exists = false;
+  try {
+    exists = existsSync(path);
+  } catch {
+    return { entries: [], path, status: 'missing' };
+  }
+  if (!exists) return { entries: [], path, status: 'missing' };
+
+  let parsed: GeneratedShape;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as GeneratedShape;
+  } catch (e: unknown) {
+    logger.warn('generated registry parse failure; skipping', {
+      path,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return { entries: [], path, status: 'malformed' };
+  }
+
+  if (!Array.isArray(parsed.entries)) {
+    logger.warn('generated registry missing entries array; skipping', { path });
+    return { entries: [], path, status: 'malformed' };
+  }
+
+  const entries: ModelEntry[] = [];
+  for (const raw of parsed.entries as readonly GeneratedRecord[]) {
+    const entry = toModelEntry(raw);
+    if (entry !== undefined) entries.push(entry);
+  }
+  return { entries, path, status: 'loaded' };
+}

--- a/packages/nexus-agents/src/config/registry-generated-coverage.test.ts
+++ b/packages/nexus-agents/src/config/registry-generated-coverage.test.ts
@@ -58,6 +58,20 @@ describe('registry breadth coverage (#3293)', () => {
     expect(opus.source).toBe('in-tree');
   });
 
+  it('does NOT shadow an in-tree ALIAS with a colliding generated id (#3293 QA)', () => {
+    // A catalog id can collide with an in-tree alias; the authoritative alias
+    // must win, not the lowest-tier generated direct entry.
+    const aliasedInTree = buildInTreeEntries().filter((e) => (e.aliases?.length ?? 0) > 0);
+    const generatedIds = new Set(generated.entries.map((e) => e.id));
+    for (const e of aliasedInTree) {
+      for (const alias of e.aliases ?? []) {
+        if (generatedIds.has(alias)) {
+          expect(reg.getEntry(alias).source).toBe('in-tree'); // alias wins over generated
+        }
+      }
+    }
+  });
+
   it('still returns a usable derived entry for a completely unknown id (never throws)', () => {
     const unknown = reg.getEntry('totally-made-up-model-xyz');
     expect(unknown.source).toBe('derived');

--- a/packages/nexus-agents/src/config/registry-generated-coverage.test.ts
+++ b/packages/nexus-agents/src/config/registry-generated-coverage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Coverage/parity tests for the generated-catalog breadth tier (#3293).
+ *
+ * Proves the "connect the 1071, don't drop it" step: after ingesting
+ * `model-registry.generated.json` as a lowest-priority breadth tier, the
+ * ModelRegistry covers every catalog id with its real (litellm) data — the
+ * coverage the legacy CapabilityDiscovery T2 tier provided — WITHOUT regressing
+ * the authoritative in-tree / models-dev tiers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ModelRegistry } from './model-registry.js';
+import { loadGeneratedRegistryEntries } from './models-generated-loader.js';
+import { buildInTreeEntries } from './in-tree-entries.js';
+
+const generated = loadGeneratedRegistryEntries();
+
+describe('loadGeneratedRegistryEntries (#3293)', () => {
+  it('loads the full catalog as ModelEntry records tagged source=generated', () => {
+    expect(generated.status).toBe('loaded');
+    expect(generated.entries.length).toBeGreaterThan(1000); // ~1071
+    for (const e of generated.entries.slice(0, 50)) {
+      expect(e.source).toBe('generated');
+      expect(typeof e.id).toBe('string');
+      // behavior fields are present (derived), so it's a valid ModelEntry
+      expect(typeof e.profileId).toBe('string');
+    }
+  });
+
+  it('carries real context windows from the catalog (not bare defaults)', () => {
+    const withCtx = generated.entries.filter((e) => typeof e.contextWindow === 'number');
+    expect(withCtx.length).toBeGreaterThan(500);
+  });
+});
+
+describe('registry breadth coverage (#3293)', () => {
+  // A registry built exactly like the default, so the test is hermetic.
+  const reg = new ModelRegistry({
+    inTreeEntries: buildInTreeEntries(),
+    generatedEntries: generated.entries,
+  });
+
+  it('resolves EVERY generated id to its catalog context window (coverage preserved)', () => {
+    let mismatches = 0;
+    for (const e of generated.entries) {
+      if (typeof e.contextWindow !== 'number') continue;
+      const resolved = reg.getEntry(e.id);
+      if (resolved.contextWindow !== e.contextWindow) mismatches++;
+    }
+    // The breadth tier must surface the catalog's context window for every id
+    // it has one for — zero mismatches = full parity with the old T2 coverage.
+    expect(mismatches).toBe(0);
+  });
+
+  it('does NOT shadow authoritative in-tree entries', () => {
+    // claude-opus is in-tree; the generated tier (lowest priority) must not win.
+    const opus = reg.getEntry('claude-opus');
+    expect(opus.source).toBe('in-tree');
+  });
+
+  it('still returns a usable derived entry for a completely unknown id (never throws)', () => {
+    const unknown = reg.getEntry('totally-made-up-model-xyz');
+    expect(unknown.source).toBe('derived');
+    expect(typeof unknown.profileId).toBe('string'); // a complete ModelEntry
+  });
+});


### PR DESCRIPTION
## What

Step 1 of #3293, the **non-destructive "connect, don't drop"** half (owner decision): make `ModelRegistry` cover the full ~1071-entry LiteLLM catalog that the legacy `CapabilityDiscovery` T2 tier provided, **before** any removal — so the consolidation loses zero new-model breadth.

- New `models-generated-loader.ts` reads `model-registry.generated.json` and converts each record to a full `ModelEntry`: behavior fields **derived** from the id's identity (`deriveEntry`), then the catalog's `contextWindow` / `maxOutputTokens` / `pricing` / `displayName` overlaid. `Pricing` is a 1:1 match with the catalog shape.
- Registered as a **lowest-priority breadth tier** (`generatedEntries`, loaded first; overwritten by models-dev → in-tree → manifest). New `EntrySource` value `'generated'`, treated like `models-dev` in `getEntry` (merge-with-derivation, not blindly authoritative).
- Fail-soft loader (missing/malformed → no entries).

## Why this way

Naive consolidation would drop the registry from 1071→324 model coverage — regressing automatic new-model handling. This preserves it.

## Tests (the binding-condition parity artifact)

`registry-generated-coverage.test.ts`: **zero context-window mismatches across all ~1071 catalog ids** (full parity with the old T2 coverage); in-tree entries **not shadowed**; unknown ids still derive cleanly. **4335** cli-adapters/config/core tests pass — no resolution-core regression. Typecheck + lint clean.

## Scope boundary

This PR **removes nothing**. The `CapabilityDiscovery` deletion (single call site in `registry-command.ts` doctor, the legacy class + overlays + the redundant JSON) stays gated behind the **binding confirmation vote** and is a follow-up — now de-risked because the registry already covers the breadth.

Part of epic #3288 / #3143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)