### PR TITLE
feat(server): warn at startup when running a stale version (#3283)

### DIFF
--- a/.changeset/version-drift-warning.md
+++ b/.changeset/version-drift-warning.md
@@ -1,0 +1,14 @@
+---
+"nexus-agents": minor
+---
+
+feat(server): warn at startup when running a stale version (#3283)
+
+A long-lived MCP server can drift many versions behind the published package and
+silently serve old code (47 stale `--mode=server` processes pinned at v2.76.0
+were found in the wild — which is what let an already-fixed `consensus_vote` bug
+reappear). The server now does a best-effort check at startup and logs a
+prominent WARN if the running build is behind the latest published version, with
+the fix command. Fail-soft and non-blocking: any network/timeout/parse failure
+is swallowed, it never gates startup, and it auto-skips dev builds + CI. One
+outbound npm-registry call; opt out with `NEXUS_VERSION_CHECK=0`.

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -180,6 +180,7 @@ All configuration can be overridden with environment variables:
 | `NEXUS_GITIGNORE_AUTO`           | `0` silences the auto-append of `.nexus-agents/` to the repo's `.gitignore`                                                                   | `1`                       |
 | `NEXUS_NO_SCAFFOLD`              | `1` disables scaffolding of missing `docs/` registry files on read                                                                            | unset                     |
 | `NEXUS_CONTEXT_RETRIEVER_INJECT` | Inject `priorMemorySummary` from `ContextRetriever` into `orchestrate` inputs (#2792, #2921)                                                  | `0`                       |
+| `NEXUS_VERSION_CHECK`            | Startup warning if the build lags the latest published version (#3283); one npm-registry call. `0` disables; skips dev + CI                   | `1`                       |
 
 ### Model Provider Keys
 

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -22,6 +22,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, type ILogger } from './core/index.js';
 import { VERSION } from './version.js';
+import { warnIfVersionStale } from './cli/version-check.js';
 import { detectMode, type ServerMode, type ModeDetectionResult } from './cli/index.js';
 import { EXIT_CODES } from './cli-types.js';
 import {
@@ -567,6 +568,11 @@ export async function startServer(
 
   const detectionResult = detectMode({ explicitMode: modeWasExplicit ? mode : undefined });
   logStartupInfo(logger, detectionResult, verbose);
+
+  // Surface stale long-lived servers (#3283): best-effort, non-blocking warn if
+  // the running build is behind the latest published version. Fire-and-forget —
+  // never gates startup; fail-soft on offline/CI/dev.
+  void warnIfVersionStale(logger);
 
   // Load and validate configuration (Issue #472)
   const configResult = loadAndLogConfig(logger);

--- a/packages/nexus-agents/src/cli/version-check.test.ts
+++ b/packages/nexus-agents/src/cli/version-check.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the startup version-drift check (#3283). No real network — fetch is injected.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import type { ILogger } from '../core/index.js';
+import { checkVersionDrift, warnIfVersionStale } from './version-check.js';
+
+function fetchReturning(version: unknown, ok = true): typeof fetch {
+  return vi.fn(() =>
+    Promise.resolve({ ok, json: () => Promise.resolve({ version }) } as unknown as Response)
+  );
+}
+
+function spyLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(function (this: ILogger) {
+      return this;
+    }),
+    setLevel: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  delete process.env['NEXUS_VERSION_CHECK'];
+  vi.restoreAllMocks();
+});
+
+describe('checkVersionDrift (#3283)', () => {
+  it('flags stale when running version is behind latest', async () => {
+    const drift = await checkVersionDrift({
+      currentVersion: '2.76.0',
+      fetchImpl: fetchReturning('2.96.0'),
+    });
+    expect(drift).toEqual({ current: '2.76.0', latest: '2.96.0', stale: true });
+  });
+
+  it('not stale when running version equals latest', async () => {
+    const drift = await checkVersionDrift({
+      currentVersion: '2.96.0',
+      fetchImpl: fetchReturning('2.96.0'),
+    });
+    expect(drift?.stale).toBe(false);
+  });
+
+  it('not stale when running version is AHEAD of latest', async () => {
+    const drift = await checkVersionDrift({
+      currentVersion: '2.97.0',
+      fetchImpl: fetchReturning('2.96.0'),
+    });
+    expect(drift?.stale).toBe(false);
+  });
+
+  it('returns null for a dev/non-semver build (nothing to compare)', async () => {
+    const drift = await checkVersionDrift({
+      currentVersion: 'dev',
+      fetchImpl: fetchReturning('2.96.0'),
+    });
+    expect(drift).toBeNull();
+  });
+
+  it('returns null on a network error (fail-soft)', async () => {
+    const drift = await checkVersionDrift({
+      currentVersion: '2.76.0',
+      fetchImpl: vi.fn(() => Promise.reject(new Error('offline'))) as unknown as typeof fetch,
+    });
+    expect(drift).toBeNull();
+  });
+
+  it('returns null on a non-ok response or unparseable version', async () => {
+    expect(
+      await checkVersionDrift({ currentVersion: '2.76.0', fetchImpl: fetchReturning('2.96.0', false) })
+    ).toBeNull();
+    expect(
+      await checkVersionDrift({ currentVersion: '2.76.0', fetchImpl: fetchReturning(undefined) })
+    ).toBeNull();
+  });
+});
+
+describe('warnIfVersionStale (#3283)', () => {
+  // warnIfVersionStale skips when CI is set; neutralize it so the logic is testable.
+  let savedCI: string | undefined;
+  beforeEach(() => {
+    savedCI = process.env['CI'];
+    delete process.env['CI'];
+  });
+  afterEach(() => {
+    if (savedCI !== undefined) process.env['CI'] = savedCI;
+  });
+
+  it('warns once when stale', async () => {
+    const logger = spyLogger();
+    await warnIfVersionStale(logger, { currentVersion: '2.76.0', fetchImpl: fetchReturning('2.96.0') });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stale version'),
+      expect.objectContaining({ running: '2.76.0', latestPublished: '2.96.0' })
+    );
+  });
+
+  it('does NOT warn when up to date', async () => {
+    const logger = spyLogger();
+    await warnIfVersionStale(logger, { currentVersion: '2.96.0', fetchImpl: fetchReturning('2.96.0') });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn when disabled via NEXUS_VERSION_CHECK=0', async () => {
+    process.env['NEXUS_VERSION_CHECK'] = '0';
+    const logger = spyLogger();
+    await warnIfVersionStale(logger, { currentVersion: '2.76.0', fetchImpl: fetchReturning('2.96.0') });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/cli/version-check.ts
+++ b/packages/nexus-agents/src/cli/version-check.ts
@@ -1,0 +1,97 @@
+/**
+ * Startup version-drift check (#3283).
+ *
+ * A long-lived MCP server can drift many versions behind the published package
+ * (47 stale `--mode=server` processes pinned at v2.76.0 were found in the wild),
+ * silently serving old code so already-fixed bugs reappear. This module makes
+ * that visible: at startup the server best-effort-checks the latest published
+ * version and logs a prominent WARN if the running build is behind.
+ *
+ * Fail-soft and non-blocking by design: any network/timeout/parse failure is
+ * swallowed (returns null), it never gates startup, it skips local `dev` builds
+ * and CI, and it can be disabled with `NEXUS_VERSION_CHECK=0`.
+ *
+ * @module cli/version-check
+ */
+
+import semver from 'semver';
+import { VERSION } from '../version.js';
+import type { ILogger } from '../core/index.js';
+import { parseBoolEnv } from '../config/defaults-env.js';
+
+const REGISTRY_LATEST_URL = 'https://registry.npmjs.org/nexus-agents/latest';
+const DEFAULT_TIMEOUT_MS = 1500;
+const ENV_FLAG = 'NEXUS_VERSION_CHECK';
+
+export interface VersionDrift {
+  readonly current: string;
+  readonly latest: string;
+  readonly stale: boolean;
+}
+
+export interface VersionCheckOptions {
+  readonly timeoutMs?: number;
+  /** Injectable fetch (tests). Defaults to global fetch. */
+  readonly fetchImpl?: typeof fetch;
+  /** Override the running version (tests). Defaults to the build-injected VERSION. */
+  readonly currentVersion?: string;
+}
+
+/**
+ * Best-effort check of how the running version compares to the latest published.
+ * Returns `null` on any failure or for a non-releasable build (`dev`/invalid
+ * semver) — callers treat `null` as "don't warn".
+ */
+/** Fetch the latest published version string, or null on any failure. */
+async function fetchLatestVersion(doFetch: typeof fetch, timeoutMs: number): Promise<string | null> {
+  try {
+    const res = await doFetch(REGISTRY_LATEST_URL, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    const latest = typeof body.version === 'string' ? body.version : null;
+    return latest !== null && semver.valid(latest) !== null ? latest : null;
+  } catch {
+    // Offline, timeout, DNS, parse — all non-fatal. Stay silent.
+    return null;
+  }
+}
+
+export async function checkVersionDrift(
+  options?: VersionCheckOptions
+): Promise<VersionDrift | null> {
+  const current = options?.currentVersion ?? VERSION;
+  if (semver.valid(current) === null) return null; // 'dev' / local build — nothing to compare
+  const doFetch = options?.fetchImpl ?? globalThis.fetch;
+  if (typeof doFetch !== 'function') return null;
+  const latest = await fetchLatestVersion(doFetch, options?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  if (latest === null) return null;
+  return { current, latest, stale: semver.lt(current, latest) };
+}
+
+/**
+ * Log a prominent warning if the running build is behind the latest published
+ * version. No-op when disabled (`NEXUS_VERSION_CHECK=0`), in CI, on a dev build,
+ * or when the check can't complete. Never throws.
+ */
+export async function warnIfVersionStale(
+  logger: ILogger,
+  options?: VersionCheckOptions
+): Promise<void> {
+  if (!parseBoolEnv(ENV_FLAG, true)) return; // explicit opt-out
+  if (process.env['CI'] !== undefined && process.env['CI'] !== '') return; // skip CI
+  try {
+    const drift = await checkVersionDrift(options);
+    if (drift?.stale === true) {
+      logger.warn(
+        'nexus-agents is running a stale version — you may be serving old code (#3283)',
+        {
+          running: drift.current,
+          latestPublished: drift.latest,
+          fix: 'npm i -g nexus-agents@latest, then restart the MCP server',
+        }
+      );
+    }
+  } catch {
+    // Defensive: warning must never break startup.
+  }
+}


### PR DESCRIPTION
## What

Addresses the core of #3283: a long-lived MCP server can drift many versions behind the published package and **silently serve old code** — 47 stale `--mode=server` processes pinned at **v2.76.0** were found in the wild, and that's exactly what let an already-fixed `consensus_vote` bug (and the auth-aware CLI exclusion) silently *not run* in a recent session.

The server now does a **best-effort startup check** vs the latest published version and logs a prominent `WARN` with the fix command when it's behind:
> nexus-agents is running a stale version — you may be serving old code (#3283) · running 2.76.0 · latestPublished 2.96.0 · fix: npm i -g nexus-agents@latest, then restart the MCP server

## Safety / behavior

- **Fail-soft + non-blocking**: `void warnIfVersionStale(logger)` after `logStartupInfo` — any network/timeout/parse failure is swallowed (returns `null`), it never gates startup.
- **Auto-skips** dev builds (non-semver `VERSION`) and CI; **opt out** with `NEXUS_VERSION_CHECK=0`.
- **One outbound call** to a fixed URL (`registry.npmjs.org/nexus-agents/latest`) — no user input (no SSRF), 1.5s timeout. Documented in CONFIGURATION.md so it's not a surprise.

## Tests

9 tests (injectable fetch, no real network): stale / equal / ahead / dev-build / network-error / non-ok / unparseable / disabled-via-env / warns-once. Typecheck + eslint + markdownlint clean.

## Follow-ups (still under #3283)

Process **reaping** (exit-on-parent-disconnect / idle self-exit) so servers don't accumulate — separate, needs a repro. This PR covers the visibility half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)