### PR TITLE
fix(consensus): opinion_wise gets higher-order aggregation like its alias (#3271)

### DIFF
--- a/.changeset/opinion-wise-higher-order.md
+++ b/.changeset/opinion-wise-higher-order.md
@@ -1,0 +1,14 @@
+---
+"nexus-agents": patch
+---
+
+fix(consensus): opinion_wise now gets higher-order Bayesian aggregation (#3271)
+
+`opinion_wise` is documented as an alias of `higher_order`, but the Bayesian/
+correlation-aware aggregation was gated on the literal `'higher_order'` in two
+places — so an `opinion_wise` vote silently fell through to the plain engine
+with no `higherOrderMetadata` in the response. Added a shared
+`isHigherOrderStrategy()` helper and used it at both the `runHigherOrderVoting`
+gate and the `higherOrderMetadata` serialization, so `opinion_wise` is a true
+alias. Tests assert `opinion_wise` produces `higherOrderMetadata` like
+`higher_order`.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -44,6 +44,16 @@ export const VotingStrategySchema = z.enum([
   'opinion_wise',
 ]);
 
+/**
+ * Whether a strategy uses higher-order (Bayesian, correlation-aware) aggregation.
+ * `opinion_wise` is a documented alias of `higher_order` (#333), so both must
+ * take the higher-order path — gating on the literal `'higher_order'` silently
+ * dropped opinion_wise to the plain engine with no higherOrderMetadata (#3271).
+ */
+export function isHigherOrderStrategy(strategy: VotingStrategy): boolean {
+  return strategy === 'higher_order' || strategy === 'opinion_wise';
+}
+
 // ============================================================================
 // Input / Output Schemas
 // ============================================================================
@@ -309,7 +319,7 @@ export function buildResponse(
     response.policyReason = result.policyReason;
   }
 
-  if (result.strategy === 'higher_order' && result.higherOrderResult) {
+  if (isHigherOrderStrategy(result.strategy) && result.higherOrderResult) {
     response.higherOrderMetadata = {
       posteriorApproval: result.higherOrderResult.posteriorApproval,
       posteriorRejection: result.higherOrderResult.posteriorRejection,

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -20,7 +20,9 @@ import {
   toAgentVoteSummary,
   buildResponse,
   getDefaultErrorPolicy,
+  isHigherOrderStrategy,
 } from './consensus-vote-types.js';
+import type { VotingStrategy } from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ExtendedVotingResult } from './consensus-vote-types.js';
 
@@ -825,6 +827,64 @@ describe('buildResponse surfaces policyReason (#3124)', () => {
       policyReason: 'fail_closed: 1 voter(s) errored',
     };
   }
+});
+
+describe('opinion_wise is treated as a higher_order alias (#3271)', () => {
+  it('isHigherOrderStrategy: true for higher_order + opinion_wise, false otherwise', () => {
+    expect(isHigherOrderStrategy('higher_order')).toBe(true);
+    expect(isHigherOrderStrategy('opinion_wise')).toBe(true);
+    expect(isHigherOrderStrategy('simple_majority')).toBe(false);
+    expect(isHigherOrderStrategy('unanimous')).toBe(false);
+    expect(isHigherOrderStrategy('proof_of_learning')).toBe(false);
+  });
+
+  function makeResult(strategy: VotingStrategy): ExtendedVotingResult {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 10,
+        source: 'llm',
+      },
+    ];
+    const higherOrderResult = {
+      decision: 'approve',
+      method: 'bayesian',
+      posteriorApproval: 0.8,
+      posteriorRejection: 0.2,
+      effectiveVoteCount: 1,
+      usedCorrelationData: false,
+      improvementOverBaseline: 0.1,
+      downweightedAgents: [],
+      reasoning: 'test',
+    } as unknown as NonNullable<ExtendedVotingResult['higherOrderResult']>;
+    return {
+      proposal: 'Test',
+      threshold: strategy,
+      result: createPolicyFailedResult('Test', strategy, 'x', votes),
+      votes,
+      totalTimeMs: 10,
+      simulateVotes: false,
+      strategy,
+      higherOrderResult,
+    };
+  }
+
+  const input = { proposal: 'Test', simulateVotes: false, quickMode: false };
+
+  it('opinion_wise surfaces higherOrderMetadata (the bug: it was silently skipped)', () => {
+    const r = buildResponse(input, makeResult('opinion_wise'));
+    expect(r.higherOrderMetadata).toBeDefined();
+    expect(r.higherOrderMetadata?.method).toBe('bayesian');
+  });
+
+  it('higher_order still surfaces higherOrderMetadata (regression guard)', () => {
+    expect(buildResponse(input, makeResult('higher_order')).higherOrderMetadata).toBeDefined();
+  });
+
+  it('simple_majority does NOT surface higherOrderMetadata', () => {
+    expect(buildResponse(input, makeResult('simple_majority')).higherOrderMetadata).toBeUndefined();
+  });
 });
 
 describe('buildResponse error counting (Issue #815)', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -49,6 +49,7 @@ import {
   ConsensusVoteInputSchema,
   buildResponse,
   getDefaultErrorPolicy,
+  isHigherOrderStrategy,
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import { recordVoteSuccess, recordVoteError } from './consensus-vote-recording.js';
@@ -277,7 +278,7 @@ function runHigherOrderVoting(
   voteMap: Map<string, Vote>,
   logger: ILogger
 ): HigherOrderVotingResult | undefined {
-  if (strategy !== 'higher_order') return undefined;
+  if (!isHigherOrderStrategy(strategy)) return undefined;
   const hovStrategy = new HigherOrderVotingStrategy();
   const tracker = getOrCreateCorrelationTracker();
   const result = hovStrategy.aggregate(voteMap, tracker);


### PR DESCRIPTION
## What

Closes #3271. `opinion_wise` is documented as an alias of `higher_order` (and #3167 already aligned its error-policy default), but the Bayesian / correlation-aware aggregation was gated on the **literal** `'higher_order'` in two places:

- `consensus-vote.ts:280` — `runHigherOrderVoting` returned `undefined` for `opinion_wise` → fell through to the plain engine.
- `consensus-vote-types.ts:311` — the `higherOrderMetadata` serialization guard.

So an `opinion_wise` caller silently got plain simple-majority behavior with **no `higherOrderMetadata`** — different from `higher_order` despite the documented alias. (`HigherOrderVoting` itself even labels its own algorithm `opinion_wise`, confirming the intent.)

## Fix

Added a shared `isHigherOrderStrategy(strategy)` helper (DRY) and used it at **both** gates, so `opinion_wise` takes the higher-order path identically.

## Tests

4 new: `isHigherOrderStrategy` truth table; `opinion_wise` surfaces `higherOrderMetadata` (the bug); `higher_order` still does (regression guard); `simple_majority` does not. 75 consensus-vote tests pass; typecheck + lint clean.

Part of epic #3143 (consensus domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)