### PR TITLE
docs: complete the ENTRYPOINTS MCP tools table (38 → 42, #3334)

### DIFF
--- a/.changeset/entrypoints-tool-table.md
+++ b/.changeset/entrypoints-tool-table.md
@@ -1,0 +1,11 @@
+---
+"nexus-agents": patch
+---
+
+docs: complete the ENTRYPOINTS MCP tools table (38 → 42, #3334)
+
+The prose tool table in `docs/ENTRYPOINTS.md` was missing four registered tools
+(`get_job_result`, `list_jobs`, `cancel_job`, `ci_health_check`); added them with
+descriptions matching the README, so the human-facing enumeration now lists all
+42. The stale machine-parseable YAML block (still 20/42) and a generator to
+prevent future drift remain tracked in #3334.

--- a/.changeset/entrypoints-tool-table.md
+++ b/.changeset/entrypoints-tool-table.md
@@ -2,10 +2,12 @@
 "nexus-agents": patch
 ---
 
-docs: complete the ENTRYPOINTS MCP tools table (38 → 42, #3334)
+docs: complete both ENTRYPOINTS MCP tool enumerations (38/20 → 42, #3334)
 
-The prose tool table in `docs/ENTRYPOINTS.md` was missing four registered tools
-(`get_job_result`, `list_jobs`, `cancel_job`, `ci_health_check`); added them with
-descriptions matching the README, so the human-facing enumeration now lists all
-42. The stale machine-parseable YAML block (still 20/42) and a generator to
-prevent future drift remain tracked in #3334.
+`docs/ENTRYPOINTS.md` had two stale tool enumerations: the prose table listed
+38 of 42 registered tools, and the machine-parseable `mcp_tools:` YAML block only
+20. Both now list all 42 (regenerated from `REGISTERED_TOOL_NAMES`), with the
+prose descriptions matching the README and per-tool `auth` (run_dev_pipeline =
+optional, rest = none). Automating these via the governance injector (the
+markers exist but inject-governance doesn't yet target ENTRYPOINTS) + a drift
+gate remains tracked in #3334.

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -1328,7 +1328,7 @@ cli_commands:
 
 ```yaml
 mcp_tools:
-  rate_limiting: shared token bucket (capacity: 100, refill: 10/sec)
+  rate_limiting: 'shared token bucket (capacity: 100, refill: 10/sec)'
   tools:
     - name: orchestrate
       auth: none

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -352,6 +352,10 @@ nexus-agents hooks stop --check-tasks
 | `survey_oss_landscape`        | Transient OSS project search (license, stars, last-commit) via GitHub                                          | None (local) | Shared bucket |
 | `vendor_publishing_audit`     | Look up a vendor's signing infrastructure (GPG keys, URL patterns)                                             | None (local) | Shared bucket |
 | `improvement_review`          | Threshold-gated observability loop — surfaces routing/tech-debt/bug/security signals from outcome+fitness data | None (local) | Shared bucket |
+| `get_job_result`              | Read result of an async-mode dispatch by jobId                                                                 | None (local) | Shared bucket |
+| `list_jobs`                   | List async-mode jobs across all tools — cross-session discovery                                                | None (local) | Shared bucket |
+| `cancel_job`                  | Mark an async-mode job as cancelled (idempotent)                                                               | None (local) | Shared bucket |
+| `ci_health_check`             | CI infrastructure health — GitHub status + recent-runs activity                                                | None (local) | Shared bucket |
 
 **Rate limiting:** All tools share a single token bucket rate limiter (capacity: 100 tokens, refill: 10 tokens/sec). Each tool call consumes one token.
 

--- a/docs/ENTRYPOINTS.md
+++ b/docs/ENTRYPOINTS.md
@@ -1340,15 +1340,17 @@ mcp_tools:
       auth: none
     - name: delegate_to_model
       auth: none
-    - name: consensus_vote
-      auth: none
     - name: list_experts
       auth: none
     - name: list_workflows
       auth: none
+    - name: consensus_vote
+      auth: none
     - name: research_query
       auth: none
     - name: research_add
+      auth: none
+    - name: research_add_source
       auth: none
     - name: research_discover
       auth: none
@@ -1356,19 +1358,61 @@ mcp_tools:
       auth: none
     - name: research_catalog_review
       auth: none
+    - name: research_synthesize
+      auth: none
+    - name: survey_oss_landscape
+      auth: none
+    - name: vendor_publishing_audit
+      auth: none
+    - name: compare_data_feeds
+      auth: none
     - name: memory_query
       auth: none
     - name: memory_stats
+      auth: none
+    - name: memory_write
+      auth: none
+    - name: weather_report
       auth: none
     - name: issue_triage
       auth: none
     - name: run_graph_workflow
       auth: none
-    - name: weather_report
-      auth: none
     - name: execute_spec
       auth: none
     - name: registry_import
+      auth: none
+    - name: query_trace
+      auth: none
+    - name: query_task_state
+      auth: none
+    - name: get_job_result
+      auth: none
+    - name: list_jobs
+      auth: none
+    - name: cancel_job
+      auth: none
+    - name: ci_health_check
+      auth: none
+    - name: verify_audit_chain
+      auth: none
+    - name: repo_analyze
+      auth: none
+    - name: repo_security_plan
+      auth: none
+    - name: extract_symbols
+      auth: none
+    - name: search_codebase
+      auth: none
+    - name: run_dev_pipeline
+      auth: optional
+    - name: run_pipeline
+      auth: none
+    - name: pr_review
+      auth: none
+    - name: supply_chain_tradeoff_panel
+      auth: none
+    - name: improvement_review
       auth: none
 ```
 


### PR DESCRIPTION
Partial fix for #3334. The prose tool table in `docs/ENTRYPOINTS.md` listed only 38 of the 42 registered tools — added the 4 missing (`get_job_result`, `list_jobs`, `cancel_job`, `ci_health_check`) with README-matched descriptions, column-aligned. The human-facing enumeration now matches `REGISTERED_TOOL_NAMES` (42). markdownlint clean.

**Remaining on #3334:** the machine-parseable YAML block (still 20/42) + a generator/CI-check to keep both enumerations in sync from `REGISTERED_TOOL_NAMES` (the proper drift fix — needs a central tool-description source). 🤖 Generated with [Claude Code](https://claude.com/claude-code)