### PR TITLE
chore: remove orphaned mapPartToContentBlock helper (vestigial cleanup)

### DIFF
--- a/.changeset/remove-orphan-gemini-helper.md
+++ b/.changeset/remove-orphan-gemini-helper.md
@@ -1,0 +1,10 @@
+---
+"nexus-agents": patch
+---
+
+chore: remove orphaned mapPartToContentBlock helper (vestigial cleanup)
+
+`mapPartToContentBlock` in `adapters/gemini-types.ts` was exported but had zero
+importers anywhere (not in any public barrel, not tested) — a refactor leftover.
+Removed it and its now-unused imports (`ContentBlock`, `getTimeProvider`,
+`getRandomProvider`). Gemini adapter behavior unchanged; 51 gemini tests pass.

--- a/packages/nexus-agents/src/adapters/gemini-types.ts
+++ b/packages/nexus-agents/src/adapters/gemini-types.ts
@@ -5,8 +5,8 @@
  */
 
 import type { Content, Part, FunctionDeclaration } from '@google/genai';
-import type { ContentBlock, Message, ToolDefinition, StopReason } from '../core/index.js';
-import { ModelCapability, getTimeProvider, getRandomProvider } from '../core/index.js';
+import type { Message, ToolDefinition, StopReason } from '../core/index.js';
+import { ModelCapability } from '../core/index.js';
 import { findCanonicalModel, getCliModelName } from '../config/model-config-helpers.js';
 
 /**
@@ -79,24 +79,6 @@ export function mapStopReason(finishReason: string | undefined): StopReason {
     default:
       return 'end_turn';
   }
-}
-
-/**
- * Maps Gemini response parts to our ContentBlock type.
- */
-export function mapPartToContentBlock(part: Part): ContentBlock | null {
-  if (part.text !== undefined) {
-    return { type: 'text', text: part.text };
-  }
-  if (part.functionCall !== undefined) {
-    return {
-      type: 'tool_use',
-      id: `tool_${String(getTimeProvider().now())}_${getRandomProvider().random().toString(36).slice(2, 9)}`,
-      name: part.functionCall.name ?? '',
-      input: part.functionCall.args ?? {},
-    };
-  }
-  return null;
 }
 
 /**


### PR DESCRIPTION
Vestigial-cleanup pass (owner-requested). `mapPartToContentBlock` (adapters/gemini-types.ts) was exported but had **zero importers** anywhere — not in a public barrel (`src/index.ts`/`src/exports`), not tested, not used by `gemini-adapter.ts`. A refactor leftover. Removed it + the imports it solely used (`ContentBlock`, `getTimeProvider`, `getRandomProvider`). Typecheck + lint clean; 51 gemini tests pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)