### PR TITLE
fix(consensus): serialize voter calls per-CLI to stop OAuth refresh race (#3348)

### DIFF
--- a/.changeset/serialize-voter-oauth-refresh.md
+++ b/.changeset/serialize-voter-oauth-refresh.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): serialize voter calls per-CLI to stop OAuth refresh race (#3348)
+
+The 7-role consensus panel round-robins onto available CLIs, so the busiest CLI
+gets 3 of 7 roles. `launchVotesWithOverallDeadline` fanned those out via
+`Promise.all` with only a 2s stagger, so same-CLI subprocess calls overlapped.
+When a CLI's access token was expired, concurrent calls each triggered an OAuth
+refresh; with refresh-token rotation the first rotated the token and the rest
+failed with "refresh token already used" — dropping ~2 voters per run (varying
+roles) and fail-closing real governance votes.
+
+Votes are now serialized per CLI (keyed by adapter CLI name): at most one
+same-CLI call is in flight at a time, so the cold-start refresh completes before
+the next same-CLI call begins. Cross-CLI parallelism is preserved. Deadline-safe
+within the existing 600s `consensus_vote` MCP wrapper.

--- a/packages/nexus-agents/src/cli/voter-agents-deadline.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents-deadline.test.ts
@@ -28,6 +28,11 @@ const stubAdapter: IModelAdapter = {
   providerId: 'stub',
 } as unknown as IModelAdapter;
 
+/** A CLI-named adapter — the `.name` field is what carries the CLI identity. */
+function makeCliAdapter(name: string): IModelAdapter {
+  return { modelId: name, providerId: name, name } as unknown as IModelAdapter;
+}
+
 function makeOkVote(role: VoterRole): AgentVoteResult {
   return {
     role,
@@ -94,6 +99,60 @@ describe('launchVotesWithOverallDeadline (Issue #1871)', () => {
 
     expect(results).toHaveLength(2);
     for (const r of results) expect(r.source).toBe('llm');
+  });
+
+  it('serializes votes that share a CLI while running distinct CLIs concurrently (#3348)', async () => {
+    // Two roles on "claude", two on "gemini". Concurrent same-CLI subprocess
+    // calls race the CLI's OAuth refresh-token rotation ("refresh token already
+    // used"). Per-CLI serialization must keep at most one same-CLI call in
+    // flight, while still letting different CLIs overlap (no global serialization).
+    const roles: readonly VoterRole[] = ['architect', 'security', 'devex', 'ai_ml'];
+    const roleAdapters = new Map<VoterRole, IModelAdapter>([
+      ['architect', makeCliAdapter('claude')],
+      ['security', makeCliAdapter('claude')],
+      ['devex', makeCliAdapter('gemini')],
+      ['ai_ml', makeCliAdapter('gemini')],
+    ]);
+
+    const inFlight = new Map<string, number>();
+    const maxByName = new Map<string, number>();
+    let crossCliOverlapSeen = false;
+
+    const voteFn = async (
+      role: VoterRole,
+      _proposal: string,
+      adapter: IModelAdapter
+    ): Promise<AgentVoteResult> => {
+      const name = (adapter as { name?: string }).name ?? 'default';
+      const cur = (inFlight.get(name) ?? 0) + 1;
+      inFlight.set(name, cur);
+      maxByName.set(name, Math.max(maxByName.get(name) ?? 0, cur));
+      const distinctActive = [...inFlight.values()].filter((n) => n > 0).length;
+      if (distinctActive >= 2) crossCliOverlapSeen = true;
+      await new Promise((r) => setTimeout(r, 30));
+      inFlight.set(name, (inFlight.get(name) ?? 1) - 1);
+      return makeOkVote(role);
+    };
+
+    const results = await launchVotesWithOverallDeadline({
+      roles,
+      proposal: 'test',
+      roleAdapters,
+      fallbackAdapter: stubAdapter,
+      logger: silentLogger,
+      voteOptions: { timeoutMs: 1_000, maxRetries: 0, allowSimulation: false },
+      interDelay: 0,
+      overallDeadlineMs: 1_000,
+      voteFn,
+    });
+
+    expect(results).toHaveLength(4);
+    for (const r of results) expect(r.source).toBe('llm');
+    // No concurrent same-CLI calls → no concurrent OAuth refresh.
+    expect(maxByName.get('claude')).toBe(1);
+    expect(maxByName.get('gemini')).toBe(1);
+    // But distinct CLIs still overlap — we did not serialize globally.
+    expect(crossCliOverlapSeen).toBe(true);
   });
 
   it('preserves role order in the returned results', async () => {

--- a/packages/nexus-agents/src/cli/voter-agents-deadline.ts
+++ b/packages/nexus-agents/src/cli/voter-agents-deadline.ts
@@ -45,6 +45,41 @@ export interface LaunchVotesInput {
 
 const DEADLINE_MESSAGE = 'overall consensus deadline exceeded';
 
+/** Stable per-CLI key for an adapter; CLI adapters carry the CLI name. */
+function adapterCliKey(adapter: IModelAdapter): string {
+  return (adapter as { name?: string }).name ?? adapter.providerId;
+}
+
+/**
+ * Per-key serializer (#3348). Returns a `run(key, fn)` that chains each fn
+ * behind the previous fn for the same key, so at most one runs per key at a
+ * time. Different keys run concurrently.
+ *
+ * Why: when several voter roles round-robin onto the SAME CLI, concurrent
+ * subprocesses each trigger that CLI's OAuth access-token refresh. With
+ * refresh-token rotation the first call rotates the token and the rest fail
+ * with "refresh token already used". Serializing per CLI lets the cold-start
+ * refresh complete before the next same-CLI call begins. Cross-CLI parallelism
+ * is preserved (claude/gemini/codex still overlap).
+ */
+function createKeyedSerializer(): <T>(key: string, fn: () => Promise<T>) => Promise<T> {
+  const tails = new Map<string, Promise<unknown>>();
+  return <T>(key: string, fn: () => Promise<T>): Promise<T> => {
+    const prev = tails.get(key) ?? Promise.resolve();
+    // Run fn whether the previous same-key call resolved or rejected.
+    const run = prev.then(fn, fn);
+    // Chain on a never-rejecting tail so one failure can't break ordering.
+    tails.set(
+      key,
+      run.then(
+        () => undefined,
+        () => undefined
+      )
+    );
+    return run;
+  };
+}
+
 function raceWithDeadline(
   p: Promise<AgentVoteResult>,
   role: VoterRole,
@@ -77,13 +112,23 @@ export async function launchVotesWithOverallDeadline(
   } = input;
 
   const startedAt = Date.now();
+  const serialize = createKeyedSerializer();
 
   const wrapped = roles.map(async (role, i) => {
     if (i > 0 && interDelay > 0) await delay(interDelay);
     const adapter = roleAdapters.get(role) ?? fallbackAdapter;
-    const elapsed = Date.now() - startedAt;
-    const remaining = Math.max(1, overallDeadlineMs - elapsed);
-    return raceWithDeadline(voteFn(role, proposal, adapter, logger, voteOptions), role, remaining);
+    // Serialize per CLI so concurrent same-CLI calls don't race that CLI's
+    // OAuth refresh (#3348). The deadline is measured when the vote actually
+    // starts, so a queued role still gets a correct remaining budget.
+    return serialize(adapterCliKey(adapter), () => {
+      const elapsed = Date.now() - startedAt;
+      const remaining = Math.max(1, overallDeadlineMs - elapsed);
+      return raceWithDeadline(
+        voteFn(role, proposal, adapter, logger, voteOptions),
+        role,
+        remaining
+      );
+    });
   });
 
   const results = await Promise.all(wrapped);


### PR DESCRIPTION
## Problem

Every recent full-panel `consensus_vote` (higher_order, 7 roles) lost **exactly 2 voters per run** to the underlying CLI's OAuth error: `"Your access token could not be refreshed because your refresh token was already used."` The errored roles **varied each run** — ruling out revoked credentials and pointing at a **concurrency race**. This fail-closed real governance votes, including the #3293 removal vote (held twice on this).

## Root cause

The error string is not in our source — it comes from the CLI subprocess's OAuth layer. `resolveDiverseAdapters` round-robins the 7 roles across available CLIs, so the busiest CLI gets **3 of 7 roles**. `launchVotesWithOverallDeadline` fanned them out via `Promise.all` with only a 2s stagger, so same-CLI calls **overlap in duration**. When that CLI's access token is expired (intermittent — only before the first refresh of a session lands), two concurrent calls both `POST /oauth2/token` with the same on-disk refresh token; with rotation, the first wins and the rest get "already used." That matches the intermittent, 2-per-run, role-varying signature exactly.

## Fix

A per-key serializer in `launchVotesWithOverallDeadline`, keyed by adapter CLI name: at most one same-CLI call in flight at a time, so the cold-start refresh completes before the next same-CLI call begins. **Cross-CLI parallelism is preserved** (claude/gemini/codex still overlap). The per-vote deadline is now measured when the vote actually starts, so a queued role still gets a correct remaining budget.

**Deadline-safe:** the `consensus_vote` MCP wrapper is 600s and the computed internal deadline (~372s) is unclamped; the busiest CLI's 3 serial calls (~120–280s in practice; normal votes run ~45–94s) stay within budget.

## Test

Red/green: a new test asserts same-CLI calls **never overlap** (max concurrency 1 per CLI name) while **distinct CLIs do overlap** (no global serialization). Failed before (`expected 2 to be 1`), passes after. Full `voter-agents` + `voter-agents-deadline` suites green (53 tests); tsc + eslint clean.

## Verification plan

Acceptance is a live re-run of the #3293 vote showing **0 auth errors / clean 7/7** once this lands in the running MCP server.

Closes #3348. Unblocks a clean re-run of the #3293 consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)