### PR TITLE
fix(codex-adapter): guard against recursive codex↔nexus MCP spawn loop (#3350)

### DIFF
--- a/.changeset/codex-mcp-recursion-guard.md
+++ b/.changeset/codex-mcp-recursion-guard.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Add a recursion guard to the Codex MCP adapter (#3350). nexus launches `codex mcp-server` as the codex adapter; if codex is configured to launch `nexus-agents --mode=server` as one of its own MCP servers, this forms a recursive spawn loop that leaks dozens of half-initialized servers, all racing the shared codex OAuth refresh-token rotation — which corrupts the on-disk token ("refresh token already used") and degrades consensus votes. The adapter now stamps each spawned `codex mcp-server` child with `NEXUS_MCP_DEPTH` and refuses to spawn when already nested, breaking the cycle after the first level. No effect on normal (non-nested) usage.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.test.ts
@@ -17,6 +17,9 @@ import {
   createCliError,
   determineErrorCode,
   parseVersionFromOutput,
+  readMcpDepth,
+  nextCodexMcpDepthOrThrow,
+  NEXUS_MCP_DEPTH_ENV,
 } from './codex-mcp-adapter-helpers.js';
 
 // ============================================================================
@@ -185,5 +188,37 @@ describe('parseVersionFromOutput', () => {
 
   it('handles whitespace', () => {
     expect(parseVersionFromOutput('  3.1.4  ')).toBe('3.1.4');
+  });
+});
+
+// ============================================================================
+// Recursion guard (#3350)
+// ============================================================================
+
+describe('readMcpDepth', () => {
+  it('returns 0 when the env var is absent', () => {
+    expect(readMcpDepth({})).toBe(0);
+  });
+
+  it('reads a positive depth', () => {
+    expect(readMcpDepth({ [NEXUS_MCP_DEPTH_ENV]: '2' })).toBe(2);
+  });
+
+  it('clamps junk / negative values to 0', () => {
+    expect(readMcpDepth({ [NEXUS_MCP_DEPTH_ENV]: 'nope' })).toBe(0);
+    expect(readMcpDepth({ [NEXUS_MCP_DEPTH_ENV]: '-3' })).toBe(0);
+  });
+});
+
+describe('nextCodexMcpDepthOrThrow', () => {
+  it('allows spawning at top level and returns the incremented depth', () => {
+    expect(nextCodexMcpDepthOrThrow({})).toBe('1');
+  });
+
+  it('throws when already nested (depth > max), citing #3350', () => {
+    expect(() => nextCodexMcpDepthOrThrow({ [NEXUS_MCP_DEPTH_ENV]: '1' })).toThrow(/#3350/);
+    expect(() => nextCodexMcpDepthOrThrow({ [NEXUS_MCP_DEPTH_ENV]: '5' })).toThrow(
+      /recursive codex.*nexus MCP spawn loop/i
+    );
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
@@ -29,6 +29,51 @@ export const DEFAULT_CODEX_MCP_OPTIONS: ResolvedExecutionOptions = {
   onProgress: undefined,
 };
 
+// ---------------------------------------------------------------------------
+// Recursion guard for `codex mcp-server` spawning (#3350)
+// ---------------------------------------------------------------------------
+
+/**
+ * Env var stamped on the `codex mcp-server` child nexus spawns, marking how
+ * deep we are in the nexus→codex-mcp spawn nesting. Inherited by anything the
+ * codex MCP server itself spawns (including a nested `nexus-agents
+ * --mode=server` if codex is misconfigured to launch one).
+ */
+export const NEXUS_MCP_DEPTH_ENV = 'NEXUS_MCP_DEPTH';
+
+/**
+ * Highest nesting depth at which nexus will spawn `codex mcp-server`. `0`
+ * means only the top-level nexus process spawns it; any deeper attempt is the
+ * recursive codex↔nexus loop and is refused.
+ */
+export const MAX_CODEX_MCP_SPAWN_DEPTH = 0;
+
+/** Read the current nesting depth from an env bag; clamps missing/junk to 0. */
+export function readMcpDepth(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number.parseInt(env[NEXUS_MCP_DEPTH_ENV] ?? '0', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+/**
+ * Recursion guard (#3350). Returns the depth string to stamp on the spawned
+ * `codex mcp-server` child, or throws if we are already nested — which would
+ * re-enter the codex↔nexus MCP spawn loop that corrupted the codex OAuth
+ * token (dozens of leaked servers racing the shared refresh-token rotation).
+ */
+export function nextCodexMcpDepthOrThrow(env: NodeJS.ProcessEnv = process.env): string {
+  const depth = readMcpDepth(env);
+  if (depth > MAX_CODEX_MCP_SPAWN_DEPTH) {
+    throw new Error(
+      `Refusing to spawn 'codex mcp-server': already nested inside a ` +
+        `nexus-spawned codex MCP context (${NEXUS_MCP_DEPTH_ENV}=${String(depth)}). ` +
+        `This breaks the recursive codex↔nexus MCP spawn loop (#3350). If you ` +
+        `intentionally configured codex to launch nexus-agents as an MCP ` +
+        `server, remove that '[mcp_servers.nexus-agents]' entry from ~/.codex/config.toml.`
+    );
+  }
+  return String(depth + 1);
+}
+
 /**
  * MCP tool call result structure.
  */

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
@@ -145,6 +145,39 @@ describe('CodexMcpAdapter', () => {
       // Client should only be created once
       expect(Client).toHaveBeenCalledTimes(1);
     });
+
+    describe('recursion guard (#3350)', () => {
+      const prev = process.env.NEXUS_MCP_DEPTH;
+      afterEach(() => {
+        if (prev === undefined) delete process.env.NEXUS_MCP_DEPTH;
+        else process.env.NEXUS_MCP_DEPTH = prev;
+      });
+
+      it('stamps the spawned codex child with NEXUS_MCP_DEPTH=1 at top level', async () => {
+        delete process.env.NEXUS_MCP_DEPTH;
+        await adapter.initialize();
+
+        expect(mocks.mockTransport).toHaveBeenCalledWith(
+          expect.objectContaining({
+            command: 'codex',
+            args: ['mcp-server'],
+            env: { NEXUS_MCP_DEPTH: '1' },
+          })
+        );
+      });
+
+      it('refuses to spawn codex mcp-server when already nested (breaks the loop)', async () => {
+        process.env.NEXUS_MCP_DEPTH = '1';
+        const nested = new CodexMcpAdapter();
+
+        await expect(nested.initialize()).rejects.toThrow(
+          /recursive codex.*nexus MCP spawn loop|#3350/i
+        );
+        // No transport spawned — the cycle is cut before any `codex mcp-server`.
+        expect(mocks.mockTransport).not.toHaveBeenCalled();
+        await nested.dispose();
+      });
+    });
   });
 
   describe('execute()', () => {

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
@@ -32,6 +32,8 @@ import {
   extractTextFromContent,
   createTimeout,
   determineErrorCode,
+  NEXUS_MCP_DEPTH_ENV,
+  nextCodexMcpDepthOrThrow,
 } from './codex-mcp-adapter-helpers.js';
 import {
   getDefaultModelForCli,
@@ -92,11 +94,18 @@ export class CodexMcpAdapter extends BaseCliAdapter {
     this.initCapacityTracker();
     this.logger.debug('Initializing Codex MCP connection');
 
+    // Recursion guard (#3350): refuse to spawn `codex mcp-server` if we're
+    // already nested inside a nexus-spawned codex MCP context, and stamp the
+    // child with the incremented depth so it (and anything it spawns) inherits
+    // the marker. Throws before any spawn when nested — breaking the loop.
+    const childDepth = nextCodexMcpDepthOrThrow();
+
     try {
       this.mcpTransport = new StdioClientTransport({
         command: 'codex',
         args: ['mcp-server'],
         stderr: 'pipe',
+        env: { [NEXUS_MCP_DEPTH_ENV]: childDepth },
       });
 
       this.client = new Client({ name: 'nexus-agents', version: '2.0.0' }, { capabilities: {} });


### PR DESCRIPTION
## Summary

Defense-in-depth fix for the root cause behind the codex OAuth token corruption that disrupted consensus voting (#3350).

nexus launches `codex mcp-server` as its codex adapter. If codex's own config (`~/.codex/config.toml`) lists `nexus-agents --mode=server` as an MCP server, codex re-spawns nexus → which re-spawns codex → … a **recursive spawn loop** that leaks dozens of half-initialized servers, all racing the shared codex OAuth **refresh-token rotation**. That persistently corrupts `~/.codex/auth.json` ("refresh token already used") and silently drops codex-routed voters from every consensus run.

The user-config trigger was already removed manually; this makes nexus **immune** to it regardless of codex config.

## Change

- The codex adapter stamps each spawned `codex mcp-server` child with `NEXUS_MCP_DEPTH` (incremented), inherited by anything that child spawns.
- Before spawning, it **refuses** if `NEXUS_MCP_DEPTH` is already set (nested) — throwing a clear, actionable error that points the operator at the offending `[mcp_servers.nexus-agents]` config entry. This cuts the cycle after the first level.
- Normal, non-nested usage is unchanged (top-level depth 0 spawns exactly as before).

New unit-tested helpers: `readMcpDepth`, `nextCodexMcpDepthOrThrow`, `NEXUS_MCP_DEPTH_ENV`, `MAX_CODEX_MCP_SPAWN_DEPTH`. The adapter passes `env: { NEXUS_MCP_DEPTH }` to `StdioClientTransport` (the MCP SDK merges it over `getDefaultEnvironment()`).

## Verification
- 222 adapter + helper tests pass (incl. new guard tests: env-stamping at top level; refusal + no-spawn when nested)
- `tsc -p packages/nexus-agents --noEmit` clean; eslint clean

## Scope
Closes the recursion-loop portion of #3350. Remaining defense-in-depth tracked on #3350: surface a "run `codex login`" remediation on the "refresh token already used" error class (instead of a silent fail-closed voter), and an optional cross-process per-CLI refresh lock.

Refs #3350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)