### PR TITLE
feat(pipeline): non-blocking local QA gate stage in run_dev_pipeline (#3356 Step 2)

### DIFF
--- a/.changeset/dev-pipeline-qa-gate.md
+++ b/.changeset/dev-pipeline-qa-gate.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': minor
+---
+
+Wire the local QA gate into `run_dev_pipeline` as a pre-ship stage (#3356 Step 2). A new `qualityGate` option (`'off' | 'advisory' | 'blocking'`, default `'off'`) runs the same `runQualityGate` engine (typecheck/lint/tests) after implement, before the security scan: `advisory` records feedback without failing the pipeline, `blocking` fails the phase on a red gate (same posture as a blocking security finding), and `off` (the default — safe for repos lacking standard build/test scripts) skips it. The stage is a thin caller over the one canonical engine (no new check logic), and is an optional `DevPipelineStages` method so existing consumers are unaffected. Completes the consensus-ratified wiring begun with the `run_quality_gate` MCP tool.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -112,6 +112,13 @@ export const DevPipelineInputSchema = z.object({
     .describe(
       "'autonomous': full pipeline. 'harness': stops after decompose, returns tasks for caller to implement."
     ),
+  /** Local pre-ship quality gate (typecheck/lint/tests) mode (#3356). */
+  qualityGate: z
+    .enum(['off', 'advisory', 'blocking'])
+    .default('off')
+    .describe(
+      "Pre-ship local quality gate. 'off' (default): skip. 'advisory': run + record feedback, never fail. 'blocking': a red gate fails the pipeline."
+    ),
 });
 
 export type DevPipelineInput = z.infer<typeof DevPipelineInputSchema>;
@@ -226,6 +233,7 @@ async function runDevPipelineHandler(args: unknown, logger: ILogger): Promise<To
       ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
       ...(input.dryRun ? { dryRun: true } : {}),
       ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
+      ...(input.qualityGate !== 'off' ? { qualityGate: input.qualityGate } : {}),
     };
     const hasOptions = Object.keys(pipelineOptions).length > 0;
     const result = await runDevPipeline(taskText, stages, hasOptions ? pipelineOptions : undefined);

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -13,6 +13,7 @@
 import { createLogger, getTimeProvider } from '../core/index.js';
 import type { DevPipelineStages, PipelineTask, QaReviewResult } from './dev-pipeline.js';
 import { checkSecurityScan } from './security-gate.js';
+import { runQualityGate, checkTypeCheck, checkLint, checkTests } from '../security/quality-gate.js';
 import type { ITaskTracker } from './task-tracker.js';
 import { executeExpert } from './expert-bridge.js';
 import { getOutcomeStore, getOutcomeSummaryText } from '../orchestration/outcomes/outcome-store.js';
@@ -529,6 +530,35 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       }
       await postProgress(config, `QA [${task.id}]`, review.verdict);
       return review;
+    },
+
+    qualityGate: async () => {
+      emitStageEvent('quality-gate', 'started');
+      const start = getTimeProvider().now();
+      const target = config.scanTarget ?? process.cwd();
+      await postProgress(config, 'QualityGate', `Typecheck/lint/tests on ${target}...`);
+      // Reuse the canonical #1684 engine + check factories — no new check logic.
+      const result = await runQualityGate('qa', [
+        checkTypeCheck(target),
+        checkLint(target),
+        checkTests(target),
+      ]);
+      const passed = result.verdict !== 'fail';
+      const ms = getTimeProvider().now() - start;
+      emitStageEvent('quality-gate', passed ? 'completed' : 'failed', { durationMs: ms });
+      recordOutcome({
+        taskId: 'quality-gate',
+        category: 'code_review',
+        cli: undefined,
+        success: passed,
+        durationMs: ms,
+      });
+      await postProgress(
+        config,
+        'QualityGate',
+        passed ? 'Passed' : `Gate failed: ${result.feedback}`
+      );
+      return { passed, feedback: result.feedback };
     },
 
     securityScan: async () => {

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -39,6 +39,7 @@ function createMockStages(overrides?: Partial<DevPipelineStages>): DevPipelineSt
       issues: [],
     } satisfies QaReviewResult),
     securityScan: vi.fn().mockResolvedValue({ passed: true, feedback: 'No findings' }),
+    qualityGate: vi.fn().mockResolvedValue({ passed: true, feedback: 'All checks passed.' }),
     ...overrides,
   };
 }
@@ -188,5 +189,82 @@ describe('runDevPipeline', () => {
     expect(stages.implement).not.toHaveBeenCalled();
     expect(stages.qaReview).not.toHaveBeenCalled();
     expect(stages.securityScan).not.toHaveBeenCalled();
+  });
+});
+
+describe('runDevPipeline — quality gate (#3356)', () => {
+  it("does NOT run the quality gate when mode is 'off' (default)", async () => {
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages);
+
+    expect(stages.qualityGate).not.toHaveBeenCalled();
+    // Off must not affect ship outcome — security still gates as before.
+    expect(result.completed).toBe(true);
+    expect(result.securityPassed).toBe(true);
+  });
+
+  it("does NOT run the quality gate when explicitly 'off'", async () => {
+    const stages = createMockStages({
+      qualityGate: vi.fn().mockResolvedValue({ passed: false, feedback: 'tsc failed' }),
+    });
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'off' });
+
+    expect(stages.qualityGate).not.toHaveBeenCalled();
+    expect(result.completed).toBe(true);
+  });
+
+  it("runs the gate but does NOT fail the pipeline on a red gate in 'advisory' mode", async () => {
+    const stages = createMockStages({
+      qualityGate: vi.fn().mockResolvedValue({ passed: false, feedback: '2 check(s) failed' }),
+    });
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'advisory' });
+
+    expect(stages.qualityGate).toHaveBeenCalledTimes(1);
+    // Advisory: red gate recorded but does not block — security still runs and passes.
+    expect(stages.securityScan).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+    expect(result.securityPassed).toBe(true);
+  });
+
+  it("runs the gate and ships when it passes in 'advisory' mode", async () => {
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'advisory' });
+
+    expect(stages.qualityGate).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+
+  it("fails the phase on a red gate in 'blocking' mode and skips security", async () => {
+    const stages = createMockStages({
+      qualityGate: vi.fn().mockResolvedValue({ passed: false, feedback: 'lint failed' }),
+    });
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'blocking' });
+
+    expect(stages.qualityGate).toHaveBeenCalledTimes(1);
+    // Blocking red gate short-circuits before the security scan, like a security block.
+    expect(stages.securityScan).not.toHaveBeenCalled();
+    expect(result.completed).toBe(false);
+    expect(result.securityPassed).toBe(false);
+    // Implementations still happened before the gate.
+    expect(result.tasks).toHaveLength(2);
+  });
+
+  it("proceeds to ship on a green gate in 'blocking' mode", async () => {
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'blocking' });
+
+    expect(stages.qualityGate).toHaveBeenCalledTimes(1);
+    expect(stages.securityScan).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+
+  it("skips the gate gracefully when stages.qualityGate is absent even if mode is 'blocking'", async () => {
+    const stages = createMockStages();
+    delete stages.qualityGate;
+    const result = await runDevPipeline('Build feature X', stages, { qualityGate: 'blocking' });
+
+    // No gate supplied → skipped → does not block ship.
+    expect(stages.securityScan).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -132,6 +132,14 @@ export interface DevPipelineStages {
   implement(task: PipelineTask): Promise<string>;
   /** QA expert reviews implementation. */
   qaReview(task: PipelineTask, implementation: string): Promise<QaReviewResult>;
+  /**
+   * Local QA quality gate (typecheck/lint/tests/build) run before ship (#3356).
+   * Optional: pipelines that don't supply it simply skip the gate. Returns
+   * `passed` plus actionable `feedback` from the underlying `runQualityGate`
+   * engine. Whether a red gate fails the phase is governed by the
+   * `qualityGate` mode in {@link DevPipelineOptions}, not this method.
+   */
+  qualityGate?(): Promise<{ passed: boolean; feedback: string }>;
   /** Security scan. Returns true if passed. */
   securityScan(): Promise<{ passed: boolean; feedback: string }>;
 }
@@ -147,6 +155,16 @@ const MAX_QA_ITERATIONS = 3;
 /** Pipeline execution mode. */
 export type PipelineMode = 'autonomous' | 'harness';
 
+/**
+ * Local quality-gate mode (#3356). Controls the pre-ship typecheck/lint/tests/build gate:
+ * - 'off' (default): the gate is never run. Safe for repos lacking standard scripts.
+ * - 'advisory': the gate runs and its feedback is recorded, but a red gate does
+ *   NOT fail the pipeline.
+ * - 'blocking': a red gate fails the phase, the same way a blocking security
+ *   scan does.
+ */
+export type QualityGateMode = 'off' | 'advisory' | 'blocking';
+
 /** Options for pipeline execution. */
 export interface DevPipelineOptions {
   /** Session ID for checkpoint/resume. Omit for no persistence. */
@@ -159,6 +177,13 @@ export interface DevPipelineOptions {
    * - 'harness': stops after decompose, returns tasks for external implementation
    */
   readonly mode?: PipelineMode | undefined;
+  /**
+   * Local pre-ship quality-gate mode (#3356). Default 'off' so the pipeline
+   * never wedges repos that lack standard build/test scripts. See
+   * {@link QualityGateMode}. Requires `stages.qualityGate` to be supplied;
+   * if the stage is absent the gate is skipped regardless of mode.
+   */
+  readonly qualityGate?: QualityGateMode | undefined;
   /** Optional BeliefMemory for hindsight updates after plan outcomes (#1720). */
   readonly beliefMemory?: IHindsightBeliefMemory | undefined;
 }
@@ -228,8 +253,14 @@ async function runDevPipelineInner(
     return buildHarnessResult(planResult, tasks);
   }
 
-  // Phases 4-5: Implement + Security
-  const result = await runImplSecurityPhase(planResult, tasks, stages, sid);
+  // Phases 4-5: Implement + Quality Gate + Security
+  const result = await runImplSecurityPhase(
+    planResult,
+    tasks,
+    stages,
+    sid,
+    options?.qualityGate ?? 'off'
+  );
 
   // Apply hindsight with actual pipeline outcome (#1720)
   applyPipelineHindsight(bm, task, sid, result);
@@ -418,16 +449,32 @@ function buildHarnessResult(
   };
 }
 
-/** Phases 4-5: Implement/QA + Security with checkpoint support. */
+/** Phases 4-5: Implement/QA + Quality Gate + Security with checkpoint support. */
 async function runImplSecurityPhase(
   planResult: { plan: string; iterations: number },
   tasks: PipelineTask[],
   stages: DevPipelineStages,
-  sid: string | undefined
+  sid: string | undefined,
+  qualityGateMode: QualityGateMode
 ): Promise<DevPipelineResult> {
   const implResult = await implementQaLoop(tasks, stages);
   if (sid !== undefined)
     saveStageCheckpoint(sid, 'implement', { type: 'implement', tasks: implResult.completedTasks });
+
+  // Local pre-ship quality gate (#3356). In 'blocking' mode a red gate fails
+  // the phase before the security scan even runs — same posture as a blocking
+  // security finding. In 'advisory' mode we record feedback but never fail.
+  const qaGate = await runQualityGateStage(stages, qualityGateMode);
+  if (qualityGateMode === 'blocking' && !qaGate.passed) {
+    return {
+      completed: false,
+      plan: planResult.plan,
+      tasks: implResult.completedTasks.length > 0 ? implResult.completedTasks : tasks,
+      voteIterations: planResult.iterations,
+      qaIterations: implResult.totalIterations,
+      securityPassed: false,
+    };
+  }
 
   const security = await withStep(
     { name: 'security-scan', kind: 'pipeline.stage' },
@@ -450,6 +497,45 @@ async function runImplSecurityPhase(
     qaIterations: implResult.totalIterations,
     securityPassed: security.passed,
   };
+}
+
+/** Result of the optional pre-ship quality gate (#3356). */
+interface QualityGateOutcome {
+  readonly passed: boolean;
+  readonly feedback: string;
+}
+
+/**
+ * Run the local quality gate (#3356) when enabled and supplied.
+ *
+ * Skips entirely when mode is 'off' or `stages.qualityGate` is absent — the
+ * gate must never wedge repos that lack standard build/test scripts. Wraps the
+ * call in `withStep` so it participates in the same EventBus/trace plumbing the
+ * security scan uses. In 'advisory' mode a red gate is reported but treated as a
+ * non-blocking outcome by the caller.
+ */
+async function runQualityGateStage(
+  stages: DevPipelineStages,
+  mode: QualityGateMode
+): Promise<QualityGateOutcome> {
+  if (mode === 'off' || stages.qualityGate === undefined) {
+    return { passed: true, feedback: 'Quality gate skipped' };
+  }
+  const runGate = stages.qualityGate.bind(stages);
+  return withStep(
+    { name: 'quality-gate', kind: 'pipeline.stage', attrs: { mode } },
+    async (ctx) => {
+      const r = await runGate();
+      const advisory = mode === 'advisory' && !r.passed;
+      ctx.setSummary(r.passed ? 'passed' : advisory ? 'FAILED (advisory)' : 'FAILED');
+      if (advisory) {
+        logger.warn('Quality gate failed (advisory — not blocking)', {
+          feedback: r.feedback.slice(0, 200),
+        });
+      }
+      return r;
+    }
+  );
 }
 
 /** Run stage or return cached result from checkpoint. */


### PR DESCRIPTION
## Summary
Step 2 of #3356 (consensus-ratified, 7/7). `run_dev_pipeline` now runs the same local QA gate (typecheck/lint/tests) as the `run_quality_gate` MCP tool (#3357, shipped in 2.99.0), as a pre-ship stage — closing the gap where the orchestrated pipeline declared work "done" with no local quality gate.

## Change
- New option `qualityGate: 'off' | 'advisory' | 'blocking'` (default **`'off'`**):
  - `off` / absent stage → skipped (safe for repos lacking standard build/test scripts)
  - `advisory` → gate runs, feedback recorded + logged, **does not** fail the pipeline
  - `blocking` → a red gate fails the phase before the security scan (same posture as a blocking security finding)
- Thin caller over the ONE canonical `runQualityGate` engine + check factories (no new check logic); wrapped in `withStep` for EventBus/trace parity with `securityScan`.
- `qualityGate()` is an **optional** `DevPipelineStages` method → existing mocks/consumers unaffected. Threaded through `dev-pipeline-tool` options.

Flow: `implement/QA → qualityGate → securityScan → ship`.

## Verification
- 7 new tests (off/advisory/blocking × pass/red, absent-stage skip); full pipeline suite **534 pass**
- `tsc` clean, eslint clean, governance-drift check clean

Completes the consensus-ratified wiring of `runQualityGate`. Closes #3356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)