### PR TITLE
fix(consensus): 'run <cli> login' remediation on stale-token voter errors (#3350)

### DIFF
--- a/.changeset/voter-reauth-remediation.md
+++ b/.changeset/voter-reauth-remediation.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+When a consensus voter fails because a CLI's stored OAuth token is stale (e.g. codex's "your refresh token was already used. Please log out and sign in again"), the voter's error now includes an actionable remediation — ``Re-authenticate: run `codex login` …`` — instead of surfacing the raw provider error as a silent fail-closed vote (#3350). Extends the existing `cli-error-envelope` auth classifier to recognize the refresh-token-rotation error class and reuses its per-CLI login-hint map; vote semantics are unchanged (still an error/abstain vote, just with a clearer message).

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseCliErrorEnvelope } from './cli-error-envelope.js';
+import { parseCliErrorEnvelope, authRemediation } from './cli-error-envelope.js';
 
 describe('parseCliErrorEnvelope (#2440)', () => {
   // Real-world example from the round-14 audit report.
@@ -189,6 +189,39 @@ describe('parseCliErrorEnvelope (#2440)', () => {
       const result = parseCliErrorEnvelope(env, 'claude');
       expect(result?.code).toBe('EXECUTION_ERROR');
       expect(result?.hint).toBeUndefined();
+    });
+  });
+
+  // #3350: stale-OAuth refresh-token rotation must classify as auth and yield
+  // a `<cli> login` remediation, not a raw fail-closed error string.
+  describe('stale OAuth refresh-token rotation (#3350)', () => {
+    const refreshTokenMsg =
+      'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.';
+
+    it('classifies the codex refresh-token-rotation error as NOT_AUTHENTICATED', () => {
+      const env = JSON.stringify({ error: refreshTokenMsg });
+      const result = parseCliErrorEnvelope(env, 'codex');
+      expect(result?.code).toBe('NOT_AUTHENTICATED');
+      expect(result?.hint).toContain('codex login');
+    });
+
+    it('authRemediation returns a codex-login remediation for the refresh-token error', () => {
+      const remediation = authRemediation(refreshTokenMsg, 'codex');
+      expect(remediation).not.toBeNull();
+      expect(remediation).toContain('codex login');
+    });
+
+    it('authRemediation normalizes a "cli-codex" providerId form', () => {
+      const remediation = authRemediation(refreshTokenMsg, 'cli-codex');
+      expect(remediation).toContain('codex login');
+    });
+
+    it('authRemediation returns null for a benign (non-auth) error', () => {
+      expect(authRemediation('rate limit exceeded', 'codex')).toBeNull();
+    });
+
+    it('authRemediation returns null for an unknown CLI name even on an auth error', () => {
+      expect(authRemediation(refreshTokenMsg, 'totally-unknown-cli')).toBeNull();
     });
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
@@ -91,6 +91,14 @@ const NOT_AUTH_PATTERNS: readonly RegExp[] = [
   // "unauthorized" — some upstreams emit "Token expired. Please re-auth."
   // without the unauthorized keyword.
   /token (?:expired|revoked)/i,
+  // #3350: OAuth refresh-token rotation. The codex CLI emits "Your access
+  // token could not be refreshed because your refresh token was already used.
+  // Please log out and sign in again." This previously fell through to a raw
+  // fail-closed voter error with no `<cli> login` signal for the operator.
+  /refresh token .*already used/i,
+  /could not be refreshed/i,
+  /log ?out and sign in/i,
+  /sign in again/i,
 ];
 
 function classifyMessage(message: string): { code: CliErrorCode; auth: boolean } {
@@ -98,6 +106,36 @@ function classifyMessage(message: string): { code: CliErrorCode; auth: boolean }
     if (re.test(message)) return { code: 'NOT_AUTHENTICATED', auth: true };
   }
   return { code: 'EXECUTION_ERROR', auth: false };
+}
+
+/**
+ * Resolve a bare CLI name from a possibly-prefixed identifier. `IModelAdapter`
+ * exposes `providerId` as `cli-codex`/`cli-claude` (see `CliToModelAdapter`),
+ * so callers can pass either form. Returns `null` when the name is not a known
+ * CLI — the remediation map can't produce a hint we'd vouch for.
+ */
+function resolveCliName(cliName: string): CliName | null {
+  const bare = cliName.startsWith('cli-') ? cliName.slice('cli-'.length) : cliName;
+  return bare in LOGIN_HINTS ? (bare as CliName) : null;
+}
+
+/**
+ * #3350: one-line operator remediation for a stale-auth voter failure.
+ *
+ * Returns `null` when `message` is not an authentication error (callers leave
+ * the error text untouched), or when `cliName` is not a recognized CLI.
+ * Otherwise returns a single line reusing {@link LOGIN_HINTS}, e.g.
+ *
+ *   Re-authenticate: run `codex login` (the codex CLI's stored OAuth token is stale).
+ *
+ * Reuses {@link classifyMessage} + {@link LOGIN_HINTS} — does not duplicate the
+ * pattern list or the per-CLI command map (DRY).
+ */
+export function authRemediation(message: string, cliName: string): string | null {
+  if (!classifyMessage(message).auth) return null;
+  const cli = resolveCliName(cliName);
+  if (cli === null) return null;
+  return `Re-authenticate: run \`${LOGIN_HINTS[cli]}\` (the ${cli} CLI's stored OAuth token is stale).`;
 }
 
 /**

--- a/packages/nexus-agents/src/cli/voter-agents.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.test.ts
@@ -433,6 +433,51 @@ That's my vote.`;
       expect(result.error).toBe('Persistent failure');
     });
 
+    // #3350: a stale-OAuth voter failure must surface a `<cli> login`
+    // remediation in the error text instead of a raw fail-closed string.
+    it('appends a re-auth remediation when the failure is a stale-OAuth error', async () => {
+      const adapter: IModelAdapter = {
+        ...createMockAdapter({
+          response: {
+            ok: false,
+            error: new Error(
+              'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+            ),
+          },
+        }),
+        providerId: 'cli-codex',
+      };
+
+      const result = await executeAgentVote('architect', 'Test proposal', adapter, logger, {
+        timeoutMs: 5000,
+        maxRetries: 0,
+        allowSimulation: false,
+      });
+
+      expect(result.vote.decision).toBe('abstain');
+      expect(result.error).toContain('refresh token was already used');
+      expect(result.error).toContain('codex login');
+    });
+
+    it('leaves a non-auth failure error unchanged (no remediation appended)', async () => {
+      const adapter: IModelAdapter = {
+        ...createMockAdapter({
+          response: { ok: false, error: new Error('rate limit exceeded') },
+        }),
+        providerId: 'cli-codex',
+      };
+
+      const result = await executeAgentVote('architect', 'Test proposal', adapter, logger, {
+        timeoutMs: 5000,
+        maxRetries: 0,
+        allowSimulation: false,
+      });
+
+      expect(result.vote.decision).toBe('abstain');
+      expect(result.error).toBe('rate limit exceeded');
+      expect(result.error).not.toContain('login');
+    });
+
     it('should fall back to simulation only when explicitly allowed', async () => {
       const adapter = createMockAdapter({
         response: { ok: false, error: new Error('Failure') },

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -22,6 +22,7 @@ import type { IModelAdapter, ILogger } from '../core/index.js';
 import { createLogger, getTimeProvider, getErrorMessage } from '../core/index.js';
 import { getGlobalRegistry } from '../adapters/unified-registry.js';
 import { getAvailableClis } from '../cli-adapters/factory.js';
+import { authRemediation } from '../cli-adapters/cli-error-envelope.js';
 import type { CliName } from '../cli-adapters/types.js';
 import { checkCodexConcurrency } from '../cli-adapters/codex-limits.js';
 
@@ -170,7 +171,13 @@ export async function executeAgentVote(
     return createSimulationVoteResult(role, proposal, processingTimeMs, result.error);
   }
 
-  return createErrorVoteResult(role, result.error, processingTimeMs);
+  // #3350: a stale-OAuth failure (e.g. codex "refresh token already used")
+  // surfaces here as a raw fail-closed error with no operator signal. Append a
+  // one-line `<cli> login` remediation when the error is an auth error. Vote
+  // semantics are unchanged — this is still an error (abstain) vote.
+  const remediation = authRemediation(result.error, adapter.providerId);
+  const errorText = remediation === null ? result.error : `${result.error}\n\n${remediation}`;
+  return createErrorVoteResult(role, errorText, processingTimeMs);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Completes the #3350 hardening. The recursion guard (shipped in 2.98.0) prevents the codex↔nexus loop that corrupted the token; this adds the **operator-facing remediation** so that if any CLI's stored OAuth token goes stale, the voter error says what to do instead of surfacing a cryptic raw error as a silent fail-closed vote.

## Change
- **`cli-error-envelope.ts`**: extend `NOT_AUTH_PATTERNS` to recognize the refresh-token-rotation error class (`refresh token … already used`, `could not be refreshed`, `log out and sign in`, `sign in again`) — the codex message had no `unauthorized`/`expired` keyword so it previously slipped through. Export `authRemediation(message, cliName)` that returns ``Re-authenticate: run `codex login` …`` for auth errors (null otherwise), reusing the existing `classifyMessage` + `LOGIN_HINTS` map (DRY) and normalizing the `cli-` providerId prefix.
- **`voter-agents.ts`**: append the remediation to the voter's error text when it's an auth failure (`cli = adapter.providerId`). Vote semantics unchanged (still an error/abstain vote).

## Verification
133 tests pass (cli-error-envelope, voter-agents, voter-execution); typecheck + eslint clean. New tests cover: codex refresh-token msg → auth + `codex login` hint; benign error → null; voter error gains the remediation; non-auth voter error unchanged.

Closes the remaining #3350 scope (cross-process refresh file-lock remains optional/deferred there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)