### PR TITLE
fix(registry): stream refresh download with early abort (#3354)

### DIFF
--- a/.changeset/refresh-streaming-cap.md
+++ b/.changeset/refresh-streaming-cap.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+`registry refresh` now enforces its 5 MiB download cap via streaming with early abort, instead of buffering the entire body before checking the size (#3354). It rejects on an over-cap `Content-Length` before reading a byte, and otherwise reads the body through a running byte counter that cancels the stream the moment the cap is exceeded — so a compromised or mistyped mirror serving a multi-gigabyte (or undeclared-length) body can no longer exhaust process memory before the guard fires.

--- a/packages/nexus-agents/src/cli/registry-command.test.ts
+++ b/packages/nexus-agents/src/cli/registry-command.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -186,6 +186,52 @@ describe('registry refresh', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.text).toMatch(/SHA256 mismatch/);
+  });
+
+  it('rejects a payload whose Content-Length exceeds the cap before reading the body (#3354)', async () => {
+    const source = 'https://example.com/model-registry.json';
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response('x', {
+          status: 200,
+          headers: { 'content-length': String(6 * 1024 * 1024) },
+        })
+      )
+    ) as unknown as typeof fetch;
+    const dest = join(tempDir, 'too-big.json');
+
+    const result = await registryCommand('refresh', { source, fetchImpl, destPath: dest });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.text).toMatch(/exceeds cap/);
+    expect(existsSync(dest)).toBe(false);
+  });
+
+  it('aborts a stream that exceeds the cap when Content-Length is absent (#3354)', async () => {
+    const source = 'https://example.com/model-registry.json';
+    // 6 × 1 MiB chunks (> 5 MiB cap); a ReadableStream Response carries no
+    // Content-Length, so this exercises the running-cap streaming path.
+    let emitted = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted >= 6) {
+          controller.close();
+          return;
+        }
+        emitted++;
+        controller.enqueue(new Uint8Array(1024 * 1024));
+      },
+    });
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(stream, { status: 200 }))
+    ) as unknown as typeof fetch;
+    const dest = join(tempDir, 'streamed-too-big.json');
+
+    const result = await registryCommand('refresh', { source, fetchImpl, destPath: dest });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.text).toMatch(/stream aborted|exceeds cap/);
+    expect(existsSync(dest)).toBe(false);
   });
 
   it('reports fetch failure without writing', async () => {

--- a/packages/nexus-agents/src/cli/registry-command.ts
+++ b/packages/nexus-agents/src/cli/registry-command.ts
@@ -305,24 +305,66 @@ interface FetchResult {
   readonly error?: string;
 }
 
+const overCapError = (bytes: number | null): FetchResult => ({
+  ok: false,
+  error:
+    bytes === null
+      ? `payload exceeds cap ${String(MAX_REFRESH_BYTES)} bytes (stream aborted)`
+      : `payload ${String(bytes)} bytes exceeds cap ${String(MAX_REFRESH_BYTES)}`,
+});
+
 async function fetchWithCap(url: string, fetchImpl: typeof fetch): Promise<FetchResult> {
   try {
     const response = await fetchImpl(url, { signal: AbortSignal.timeout(30_000) });
     if (!response.ok) {
       return { ok: false, error: `HTTP ${String(response.status)}` };
     }
-    const body = await response.text();
-    if (body.length > MAX_REFRESH_BYTES) {
-      return {
-        ok: false,
-        error: `payload ${String(body.length)} bytes exceeds cap ${String(MAX_REFRESH_BYTES)}`,
-      };
+
+    // Reject on the declared size before reading a single byte (#3354). A
+    // compromised/typo'd mirror could otherwise stream gigabytes; the old
+    // `response.text()` buffered the whole body before checking the cap and
+    // could exhaust memory first.
+    const declared = Number(response.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_REFRESH_BYTES) {
+      return overCapError(declared);
     }
-    return { ok: true, body };
+
+    // No declared length we can trust: stream with a running cap and abort
+    // the moment the accumulated bytes exceed it, so an undeclared or lying
+    // Content-Length can't OOM the process.
+    if (response.body === null) {
+      const body = await response.text();
+      return body.length > MAX_REFRESH_BYTES ? overCapError(body.length) : { ok: true, body };
+    }
+    return await readStreamWithCap(response.body);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };
   }
+}
+
+/**
+ * Read a response body stream, aborting the moment the accumulated bytes
+ * exceed {@link MAX_REFRESH_BYTES} (#3354). Keeps a hostile mirror with an
+ * undeclared/lying Content-Length from buffering unbounded data into memory.
+ */
+async function readStreamWithCap(stream: ReadableStream<Uint8Array>): Promise<FetchResult> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let body = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_REFRESH_BYTES) {
+      await reader.cancel();
+      return overCapError(null);
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  body += decoder.decode();
+  return { ok: true, body };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes the LOW security finding from the #3352 review. `registry refresh` enforced its 5 MiB cap *after* `response.text()` had buffered the entire body — a compromised or mistyped `--source` mirror serving a multi-GB stream could exhaust process memory before the guard fired.

## Change (`registry-command.ts` `fetchWithCap`)
- **Reject up front** if the response's `Content-Length` already exceeds the cap — no bytes read.
- Otherwise **stream** the body through `readStreamWithCap` (extracted helper), accumulating `byteLength` and **cancelling the stream** the instant the running total exceeds the cap — so an undeclared or lying length can't OOM us.
- The 30s `AbortSignal.timeout` already bounded slow-loris; this bounds fast/large bodies.

## Verification
- New tests: over-cap `Content-Length` rejected before reading; undeclared-length `ReadableStream` aborted past the cap; neither writes to disk.
- 13 registry-command tests pass; `tsc` + eslint clean.

Closes #3354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)