### PR TITLE
fix(ci): exempt mechanical action bumps from DocOps skill-sync gate (#3363)

### DIFF
--- a/scripts/check-docops-skill.test.ts
+++ b/scripts/check-docops-skill.test.ts
@@ -18,7 +18,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-import { getCommitMessagesForEscapeHatch } from './check-docops-skill.js';
+import {
+  getCommitMessagesForEscapeHatch,
+  isMechanicalActionBumpDiff,
+} from './check-docops-skill.js';
 
 interface RepoCtx {
   dir: string;
@@ -108,5 +111,59 @@ describe('getCommitMessagesForEscapeHatch (#2411)', () => {
     const out = getCommitMessagesForEscapeHatch(ctx.dir);
 
     expect(out).toContain('[skip-docops]');
+  });
+});
+
+describe('isMechanicalActionBumpDiff (#3363)', () => {
+  it('treats a pure actions/checkout version bump as mechanical', () => {
+    const diff = [
+      'diff --git a/.github/workflows/docs-check.yml b/.github/workflows/docs-check.yml',
+      '--- a/.github/workflows/docs-check.yml',
+      '+++ b/.github/workflows/docs-check.yml',
+      '@@ -10,7 +10,7 @@ jobs:',
+      '       - uses: actions/checkout@aaaaaaa # v6.0.2',
+      '+      - uses: actions/checkout@bbbbbbb # v6.0.3',
+      '-      - uses: actions/checkout@aaaaaaa # v6.0.2',
+    ].join('\n');
+    // Reconstruct a realistic +/- pair (context line above is unchanged).
+    const realistic = [
+      '@@ -10,7 +10,7 @@',
+      '-      - uses: actions/checkout@aaaaaaa # v6.0.2',
+      '+      - uses: actions/checkout@bbbbbbb # v6.0.3',
+    ].join('\n');
+    expect(isMechanicalActionBumpDiff(diff)).toBe(true);
+    expect(isMechanicalActionBumpDiff(realistic)).toBe(true);
+  });
+
+  it('handles multiple action bumps in one file', () => {
+    const diff = [
+      '-      - uses: actions/checkout@aaa # v6.0.2',
+      '+      - uses: actions/checkout@bbb # v6.0.3',
+      '-      - uses: actions/setup-node@ccc # v5.0.0',
+      '+      - uses: actions/setup-node@ddd # v5.0.1',
+    ].join('\n');
+    expect(isMechanicalActionBumpDiff(diff)).toBe(true);
+  });
+
+  it('is NOT mechanical when a non-uses line changes (real pipeline edit)', () => {
+    const diff = [
+      '-      - uses: actions/checkout@aaa # v6.0.2',
+      '+      - uses: actions/checkout@bbb # v6.0.3',
+      '+        with:',
+      '+          fetch-depth: 0',
+    ].join('\n');
+    expect(isMechanicalActionBumpDiff(diff)).toBe(false);
+  });
+
+  it('is NOT mechanical when a run step changes', () => {
+    const diff = [
+      '-          npx tsx scripts/check-docops-skill.ts',
+      '+          npx tsx scripts/check-docops-skill.ts --verbose',
+    ].join('\n');
+    expect(isMechanicalActionBumpDiff(diff)).toBe(false);
+  });
+
+  it('returns false for an empty diff (no detectable change)', () => {
+    expect(isMechanicalActionBumpDiff('')).toBe(false);
   });
 });

--- a/scripts/check-docops-skill.ts
+++ b/scripts/check-docops-skill.ts
@@ -89,6 +89,44 @@ function getChangedFiles(): string[] {
 }
 
 /**
+ * True when a unified-diff for a pipeline file contains ONLY mechanical
+ * GitHub Action version bumps — `uses: <action>@<ref>` lines (e.g. Dependabot
+ * bumping `actions/checkout@<sha> # v6.0.2` → `@<sha> # v6.0.3`). Such bumps
+ * change no step logic and need no Documentation Management skill update
+ * (#3363). Conservative: any non-`uses:` added/removed line → not mechanical,
+ * so the gate still fires for real pipeline changes.
+ */
+export function isMechanicalActionBumpDiff(diff: string): boolean {
+  const changeLines = diff
+    .split('\n')
+    .filter(
+      (l) =>
+        (l.startsWith('+') || l.startsWith('-')) && !l.startsWith('+++') && !l.startsWith('---')
+    );
+  if (changeLines.length === 0) return false;
+  // After dropping the leading +/-, every change line must be a `uses:`
+  // reference to a pinned action (`<owner>/<repo>@<ref>` or `<action>@<ref>`).
+  const usesRef = /^\s*(?:-\s*)?uses:\s*\S+@\S+/;
+  return changeLines.every((l) => usesRef.test(l.slice(1)));
+}
+
+/** Diff a single changed pipeline file against the PR base; mechanical-bump check (#3363). */
+function isMechanicalActionBump(file: string): boolean {
+  try {
+    const baseRef = process.env['GITHUB_BASE_REF'];
+    const base = baseRef !== undefined && baseRef !== '' ? `origin/${baseRef}...HEAD` : 'HEAD~1';
+    const diff = execSync(
+      `git diff ${base} -- "${file}" 2>/dev/null || git diff HEAD~1 -- "${file}"`,
+      { cwd: REPO_ROOT, encoding: 'utf-8' }
+    );
+    return isMechanicalActionBumpDiff(diff);
+  } catch {
+    // Can't determine the diff → treat as substantive so the gate still fires.
+    return false;
+  }
+}
+
+/**
  * Get commit messages for the escape-hatch check.
  *
  * On GitHub Actions PR events, actions/checkout creates a merge ref so
@@ -208,7 +246,16 @@ function performCheck(_verbose: boolean): CheckResult {
     (f) => result.manifest?.pipeline_files.includes(f) ?? false
   );
 
-  // No pipeline changes = success
+  // Exempt pipeline files whose diff is purely a mechanical action-version
+  // bump (e.g. Dependabot `uses:` SHA bumps) — they change no step logic and
+  // need no skill update (#3363). Keeps the gate green for those PRs instead
+  // of forcing an unjustified skill edit or a [skip-docops] commit Dependabot
+  // won't add.
+  result.changedPipelineFiles = result.changedPipelineFiles.filter(
+    (f) => !isMechanicalActionBump(f)
+  );
+
+  // No substantive pipeline changes = success
   if (result.changedPipelineFiles.length === 0) {
     result.success = true;
     return result;


### PR DESCRIPTION
## Summary
The `DocOps Skill Sync` gate false-fires on **every** dependabot PR that bumps a GitHub Action used in a docs-pipeline workflow (e.g. `actions/checkout` in `docs-check.yml`/`link-check.yml`). A `uses:` version bump changes no step logic, but the gate's "pipeline file changed → update the Documentation Management skill" rule flagged it — blocking the PR behind a red check that needs an unjustified skill edit or a `[skip-docops]` commit dependabot won't add. Hit live on #3343 (and #3344).

## Fix (`scripts/check-docops-skill.ts`)
Diff each changed pipeline file and **exempt** those whose only added/removed lines are `uses: <action>@<ref>` references (`isMechanicalActionBumpDiff`). 
- **Author-agnostic** — a human doing a pure action bump is exempted too (correct).
- **Conservative** — any non-`uses:` change (`with:`, `run:`, a new step, etc.) is still flagged, so the gate keeps protecting real pipeline edits.
- Keeps the check **green** (not skipped) → branch protection isn't tripped.

## Verification
- 5 new unit tests on the pure parser: single + multi action bump → mechanical; `with:`/`run:` change → not mechanical; empty diff → false.
- All 9 `check-docops-skill` tests pass; eslint clean; script runs cleanly.
- scripts-only change → no changeset required (`SHIPPABLE` is `packages/nexus-agents/src/**`).

Closes #3363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)