### PR TITLE
fix(exports): restore MCP barrel parity for memory/job/improvement types (#3199)

### DIFF
--- a/.changeset/mcp-barrel-response-types.md
+++ b/.changeset/mcp-barrel-response-types.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Restore public-API parity for the MCP barrel (`exports/mcp.ts`, #3199): the memory tools' response types (`MemoryQueryResponse`, `MemoryStatsResponse`, `MemoryWriteResponse`) and the async-job + improvement-review tools (`get_job_result` / `list_jobs` / `cancel_job` / `improvement_review` — their `register*Tool`, input schemas, and `*Response`/`*Input`/`*Deps` types) were exported from the internal `mcp/index.ts` but missing from the public package barrel, so embedders had to re-declare them. All are now re-exported. Additive, no behavior change.

--- a/packages/nexus-agents/src/exports/mcp.ts
+++ b/packages/nexus-agents/src/exports/mcp.ts
@@ -261,6 +261,10 @@ export {
   registerMemoryWriteTool,
   MemoryWriteInputSchema,
   type MemoryWriteInput,
+  // Memory response types (#3199 — were missing from the public barrel; embedders need these)
+  type MemoryQueryResponse,
+  type MemoryStatsResponse,
+  type MemoryWriteResponse,
   // Weather + query trace tools (Issue #1576 Wave 9)
   registerWeatherReportTool,
   WeatherReportInputSchema,
@@ -271,4 +275,26 @@ export {
   registerRegistryImportTool,
   RegistryImportInputSchema,
   type RegistryImportInput,
+  // Async job tools (#3199 — were entirely missing from the public barrel)
+  registerGetJobResultTool,
+  GetJobResultInputSchema,
+  type GetJobResultDeps,
+  type GetJobResultInput,
+  type GetJobResultResponse,
+  registerListJobsTool,
+  ListJobsInputSchema,
+  type ListJobsDeps,
+  type ListJobsInput,
+  type ListJobsResponse,
+  registerCancelJobTool,
+  CancelJobInputSchema,
+  type CancelJobDeps,
+  type CancelJobInput,
+  type CancelJobResponse,
+  // Improvement review tool (#3199 — was entirely missing from the public barrel)
+  registerImprovementReviewTool,
+  ImprovementReviewInputSchema,
+  type ImprovementReviewDeps,
+  type ImprovementReviewInput,
+  type ImprovementReviewResponse,
 } from '../mcp/index.js';


### PR DESCRIPTION
## Summary
First item of the #3250–3269 system-review cluster sweep. Restores public-API parity for `exports/mcp.ts`.

`mcp/index.ts` (internal) exports these, but the **public** package barrel was missing them, forcing embedders to re-declare:
- Memory response types: `MemoryQueryResponse`, `MemoryStatsResponse`, `MemoryWriteResponse`
- Async-job tools (entirely absent): `get_job_result` / `list_jobs` / `cancel_job` — `register*Tool` + input schema + `*Input`/`*Deps`/`*Response`
- `improvement_review` (entirely absent): `register*Tool` + input schema + types

## Note on staleness
The original #3199 also named research response types — those were **already restored** since the 2026-05-31 review (verified), so this PR covers only the still-missing memory/job/improvement exports.

## Verification
- All 7 named response types now present in the barrel
- `tsc` + eslint clean; additive re-exports only, no behavior change

Closes #3199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)