### PR TITLE
fix(exports): export UnifiedAdapterRegistry from the public barrel (#3184, #3268)

### DIFF
--- a/.changeset/export-unified-registry.md
+++ b/.changeset/export-unified-registry.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Export `UnifiedAdapterRegistry` (+ `createUnifiedRegistry`, `getGlobalRegistry`, `resetGlobalRegistry`, and the `UnifiedRegistryConfig`/`TaskRoutingEntry`/`RegistrySnapshot` types) from the public package barrel (#3184, #3268). CLAUDE.md's Canonical Paths names `UnifiedAdapterRegistry` (via `getGlobalRegistry()`) as the canonical way to access adapters, but it was only exported from the internal `adapters/index.ts` — not reachable by package consumers. It's now part of the public API, so operators can build custom routing on the documented primitive without reaching into internals.

--- a/packages/nexus-agents/src/exports/adapters.ts
+++ b/packages/nexus-agents/src/exports/adapters.ts
@@ -88,4 +88,15 @@ export {
   type ModelNotFoundFallbackOptions,
   type RetirementInfo,
   type ResilientLike,
+  // Unified adapter registry (#1149) — the canonical adapter-access primitive
+  // named in CLAUDE.md's Canonical Paths, now reachable from the public barrel
+  // so operators can build custom routing without reaching into internals
+  // (#3184/#3268).
+  UnifiedAdapterRegistry,
+  createUnifiedRegistry,
+  getGlobalRegistry,
+  resetGlobalRegistry,
+  type UnifiedRegistryConfig,
+  type TaskRoutingEntry,
+  type RegistrySnapshot,
 } from '../adapters/index.js';


### PR DESCRIPTION
## Summary
Resolves **#3184** and **#3268** (same gap, both in the system-review cluster). CLAUDE.md's Canonical Paths names `UnifiedAdapterRegistry` (via `getGlobalRegistry()`) as the canonical adapter-access primitive, but it was only exported from the internal `adapters/index.ts` — **not reachable from the package's public API**, so the documented building block was unusable by consumers.

## Change
Re-export from `exports/adapters.ts` (which `src/index.ts` already does `export *` from): `UnifiedAdapterRegistry`, `createUnifiedRegistry`, `getGlobalRegistry`, `resetGlobalRegistry`, and the `UnifiedRegistryConfig` / `TaskRoutingEntry` / `RegistrySnapshot` types.

Note: `createUnifiedRegistry` already existed, so the issue's "add a factory" suggestion was a no-op — the real gap was purely the missing public export.

## Verification
- `tsc` clean — confirms no export-name collisions in the combined public API.
- eslint clean; additive re-exports only.

Closes #3184, closes #3268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)