### PR TITLE
feat(self-eval): persist aggregated results to OutcomeStore (#3219, #3235, #3241)

### DIFF
--- a/.changeset/self-eval-outcomestore.md
+++ b/.changeset/self-eval-outcomestore.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Persist self-eval results to the OutcomeStore so the eval -> log -> tune loop closes.
+
+`nexus-agents evaluate` now maps each aggregated component evaluation to a `TaskOutcome` (via the new `aggregatedResultToOutcome` adapter) and appends it to `getOutcomeStore()`, so self-eval output feeds `improvement_review` / tuning instead of being discarded. Outcomes use a stable `self-eval-<component-path>` id (re-runs upsert rather than pile up), carry the recommendation in `qualitySignals`, and map `retain` -> `success: true`. Persistence is guarded: a store failure is logged and skipped, never crashing the eval run.
+
+Closes #3219, #3235, #3241.

--- a/packages/nexus-agents/src/cli/self-eval.test.ts
+++ b/packages/nexus-agents/src/cli/self-eval.test.ts
@@ -5,7 +5,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
-import { parseOptions, evaluateCommand } from './self-eval.js';
+import { parseOptions, evaluateCommand, type OutcomeSink } from './self-eval.js';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 
 /** Absolute path to the package root (resolves CWD ambiguity in Vitest). */
 const PACKAGE_ROOT = join(import.meta.dirname, '..', '..');
@@ -281,6 +282,58 @@ describe('output formatting', () => {
       for (const result of parsed.results) {
         expect(result.isRecommendation).toBe(true);
       }
+    }
+  );
+});
+
+// ============================================================================
+// OutcomeStore Persistence (#3219, #3235, #3241)
+// ============================================================================
+
+describe('outcome persistence', () => {
+  it(
+    'appends one outcome per result to the injected store',
+    { timeout: INTEGRATION_TIMEOUT },
+    async () => {
+      const appended: TaskOutcome[] = [];
+      const store: OutcomeSink = {
+        append: (o) => {
+          appended.push(o);
+        },
+      };
+
+      await evaluateCommand(['--target', SELF_EVAL_TARGET, '--json', '--timeout', '15000'], store);
+
+      // One outcome per result reported in the JSON output.
+      const parsed = JSON.parse(mockStdout.join('')) as { results: unknown[] };
+      expect(appended.length).toBe(parsed.results.length);
+      expect(appended.length).toBeGreaterThan(0);
+      // Every appended outcome is a self-eval-sourced record.
+      for (const outcome of appended) {
+        expect(outcome.id.startsWith('self-eval-')).toBe(true);
+        expect(outcome.source).toBe('manual');
+        expect(outcome.qualitySignals).toContain('self-eval');
+      }
+    }
+  );
+
+  it(
+    'does not crash the eval when the store throws',
+    { timeout: INTEGRATION_TIMEOUT },
+    async () => {
+      const store: OutcomeSink = {
+        append: () => {
+          throw new Error('store unavailable');
+        },
+      };
+
+      const exitCode = await evaluateCommand(
+        ['--target', SELF_EVAL_TARGET, '--timeout', '15000'],
+        store
+      );
+
+      // Eval still completes (0 = pass, 1 = deprecations found).
+      expect([0, 1]).toContain(exitCode);
     }
   );
 });

--- a/packages/nexus-agents/src/cli/self-eval.ts
+++ b/packages/nexus-agents/src/cli/self-eval.ts
@@ -11,7 +11,9 @@
 import { scanComponents } from '../self-eval/component-scanner.js';
 import { evaluateComponent } from '../self-eval/evaluation-agents.js';
 import { createAggregator, type AggregatedResult } from '../self-eval/aggregation-logic.js';
-import { getTimeProvider, getErrorMessage } from '../core/index.js';
+import { aggregatedResultToOutcome } from '../self-eval/outcome-adapter.js';
+import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
+import { getTimeProvider, getErrorMessage, createLogger } from '../core/index.js';
 import type { ComponentInfo } from '../self-eval/component-scanner.js';
 import type { EvaluationResult } from '../self-eval/evaluation-agents.js';
 import type {
@@ -34,11 +36,42 @@ export type {
 // ============================================================================
 
 /**
+ * Minimal append-only sink for self-eval outcomes. Matches the surface of
+ * `OutcomeStore.append` so tests can inject a mock without constructing a
+ * full store (#3219).
+ */
+export interface OutcomeSink {
+  append(outcome: import('../orchestration/outcomes/outcome-types.js').TaskOutcome): void;
+}
+
+/**
+ * Persist aggregated self-eval results to the OutcomeStore so the
+ * eval -> log -> tune loop closes (#3219, #3235). Each result is mapped via
+ * the #3241 adapter and appended under a stable id (re-runs upsert rather
+ * than pile up). A store failure is logged and skipped — persistence is a
+ * side channel and must never crash the eval run.
+ */
+function persistResults(results: readonly AggregatedResult[], store: OutcomeSink): void {
+  const log = createLogger({ component: 'self-eval' });
+  for (const result of results) {
+    try {
+      store.append(aggregatedResultToOutcome(result));
+    } catch (error) {
+      log.warn('Failed to persist self-eval outcome', {
+        component: result.component,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+}
+
+/**
  * Evaluate all components in a directory.
  */
 async function evaluateDirectory(
   target: string,
-  timeoutMs: number
+  timeoutMs: number,
+  store: OutcomeSink = getOutcomeStore()
 ): Promise<{
   results: readonly AggregatedResult[];
   componentsScanned: number;
@@ -82,6 +115,10 @@ async function evaluateDirectory(
   // Sort by severity (deprecate first, then refactor, review, retain)
   const priority = { deprecate: 0, refactor: 1, review: 2, retain: 3 };
   results.sort((a, b) => priority[a.finalRecommendation] - priority[b.finalRecommendation]);
+
+  // Persist to the OutcomeStore so self-eval feeds improvement_review /
+  // tuning. Guarded so a store failure never crashes the eval (#3219).
+  persistResults(results, store);
 
   return {
     results,
@@ -186,14 +223,18 @@ export function parseOptions(args: readonly string[]): EvaluateOptions {
  * Run the evaluate command.
  * Returns exit code (0 = success, 1 = issues found, 2 = error).
  */
-export async function evaluateCommand(args: readonly string[] = []): Promise<number> {
+export async function evaluateCommand(
+  args: readonly string[] = [],
+  store: OutcomeSink = getOutcomeStore()
+): Promise<number> {
   const options = parseOptions(args);
   const startTime = getTimeProvider().now();
 
   try {
     const { results, componentsScanned, totalLines, timedOut } = await evaluateDirectory(
       options.target,
-      options.timeout
+      options.timeout,
+      store
     );
 
     const summary = calculateSummary(results);

--- a/packages/nexus-agents/src/self-eval/outcome-adapter.test.ts
+++ b/packages/nexus-agents/src/self-eval/outcome-adapter.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the self-eval -> TaskOutcome adapter.
+ * (Source: Issues #3219, #3235, #3241)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  aggregatedResultToOutcome,
+  selfEvalOutcomeId,
+  SELF_EVAL_MARKER,
+} from './outcome-adapter.js';
+import { TaskOutcomeSchema } from '../orchestration/outcomes/outcome-types.js';
+import type { AggregatedResult } from './aggregation-logic.js';
+import type { Recommendation } from './evaluation-agents.js';
+
+function makeResult(overrides: Partial<AggregatedResult> = {}): AggregatedResult {
+  return {
+    component: 'src/foo/bar.ts',
+    finalRecommendation: 'retain',
+    confidence: 0.8,
+    votes: [],
+    dissent: [],
+    auditTrail: [],
+    evidenceQuality: 0.5,
+    isRecommendation: true,
+    timestamp: new Date('2026-06-03T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('selfEvalOutcomeId', () => {
+  it('derives a stable id from the component path', () => {
+    expect(selfEvalOutcomeId('src/foo/bar.ts')).toBe('self-eval-src/foo/bar.ts');
+  });
+
+  it('is deterministic across calls (re-run upsert semantics)', () => {
+    expect(selfEvalOutcomeId('src/a.ts')).toBe(selfEvalOutcomeId('src/a.ts'));
+  });
+
+  it('sanitizes unexpected characters', () => {
+    expect(selfEvalOutcomeId('src/weird name!.ts')).toBe('self-eval-src/weird_name_.ts');
+  });
+});
+
+describe('aggregatedResultToOutcome', () => {
+  it('maps retain -> success=true with no error note', () => {
+    const outcome = aggregatedResultToOutcome(makeResult({ finalRecommendation: 'retain' }));
+    expect(outcome.success).toBe(true);
+    expect(outcome.errorMessage).toBeUndefined();
+  });
+
+  it.each<Recommendation>(['review', 'refactor', 'deprecate'])(
+    'maps %s -> success=false and carries the recommendation as a note',
+    (rec) => {
+      const outcome = aggregatedResultToOutcome(makeResult({ finalRecommendation: rec }));
+      expect(outcome.success).toBe(false);
+      expect(outcome.errorMessage).toContain(rec);
+    }
+  );
+
+  it('carries the recommendation + marker in qualitySignals', () => {
+    const outcome = aggregatedResultToOutcome(makeResult({ finalRecommendation: 'refactor' }));
+    expect(outcome.qualitySignals).toContain(SELF_EVAL_MARKER);
+    expect(outcome.qualitySignals).toContain('recommendation:refactor');
+  });
+
+  it('derives a stable id from the component path', () => {
+    const outcome = aggregatedResultToOutcome(makeResult({ component: 'src/x.ts' }));
+    expect(outcome.id).toBe('self-eval-src/x.ts');
+  });
+
+  it('produces a schema-valid TaskOutcome', () => {
+    const outcome = aggregatedResultToOutcome(makeResult());
+    expect(() => TaskOutcomeSchema.parse(outcome)).not.toThrow();
+  });
+
+  it('uses the aggregation timestamp as an ISO string', () => {
+    const outcome = aggregatedResultToOutcome(
+      makeResult({ timestamp: new Date('2026-06-03T00:00:00.000Z') })
+    );
+    expect(outcome.timestamp).toBe('2026-06-03T00:00:00.000Z');
+  });
+});

--- a/packages/nexus-agents/src/self-eval/outcome-adapter.ts
+++ b/packages/nexus-agents/src/self-eval/outcome-adapter.ts
@@ -1,0 +1,81 @@
+/**
+ * Adapter mapping self-evaluation aggregated results into TaskOutcome
+ * records so the eval -> log -> tune loop closes: self-eval output now
+ * feeds the OutcomeStore (and thereby improvement_review / tuning).
+ *
+ * All self-eval outputs are RECOMMENDATIONS, not decisions — this adapter
+ * preserves that semantic by carrying the recommendation in qualitySignals
+ * and (for non-retain results) a human-readable note.
+ *
+ * @module self-eval/outcome-adapter
+ * (Source: Issues #3219, #3235, #3241 — self-eval -> OutcomeStore wiring)
+ */
+
+import type { AggregatedResult } from './aggregation-logic.js';
+import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+
+/**
+ * Marker quality signal stamped on every self-eval-sourced outcome.
+ * Lets downstream consumers (and idempotency checks) recognize and, if
+ * desired, exclude self-eval recommendations from routing reward signals.
+ */
+export const SELF_EVAL_MARKER = 'self-eval';
+
+/**
+ * Derive a stable, deterministic outcome id from a component path so that
+ * re-running self-eval over the same tree upserts (replaces on persistence
+ * load / dedupes) rather than piling up duplicate rows. Mirrors the
+ * `synthetic-<cli>-<category>` / `e2e-<i>-<cli>-<category>` id schemes used
+ * by warm-up.ts / e2e-eval.ts.
+ */
+export function selfEvalOutcomeId(componentPath: string): string {
+  const sanitized = componentPath.replace(/[^a-zA-Z0-9._/-]/g, '_');
+  return `self-eval-${sanitized}`;
+}
+
+/**
+ * Map one self-eval `AggregatedResult` to a `TaskOutcome`.
+ *
+ * Mapping:
+ * - component path        -> stable id (`self-eval-<path>`)
+ * - finalRecommendation   -> success (`retain` => true; review/refactor/
+ *                            deprecate => false) + carried in qualitySignals
+ *                            and (for non-retain) `errorMessage` note
+ * - confidence/evidence   -> carried as quality signals for traceability
+ * - category              -> `code_review` (self-eval is a code assessment)
+ * - cli/model             -> `claude` / `claude-default` (harness identity)
+ * - source                -> `manual`
+ */
+export function aggregatedResultToOutcome(result: AggregatedResult): TaskOutcome {
+  const success = result.finalRecommendation === 'retain';
+
+  const qualitySignals = [
+    SELF_EVAL_MARKER,
+    `recommendation:${result.finalRecommendation}`,
+    `confidence:${result.confidence.toFixed(2)}`,
+    `evidence:${result.evidenceQuality.toFixed(2)}`,
+  ];
+
+  const outcome: TaskOutcome = {
+    id: selfEvalOutcomeId(result.component),
+    cli: 'claude',
+    category: 'code_review',
+    model: 'claude-default',
+    success,
+    durationMs: 0,
+    timestamp: result.timestamp.toISOString(),
+    qualitySignals,
+    source: 'manual',
+  };
+
+  // Surface the recommendation as a failure note when the component is not
+  // a clean "retain" — gives downstream tuning/triage a reason string.
+  if (!success) {
+    return {
+      ...outcome,
+      errorMessage: `self-eval recommendation: ${result.finalRecommendation}`,
+    };
+  }
+
+  return outcome;
+}


### PR DESCRIPTION
## Summary
Closes #3219, #3235, #3241 (same work, from the system-review cluster). `self-eval` aggregated component evaluations but **never persisted them to the OutcomeStore**, so self-eval output never reached `improvement_review` / tuning — a hole in the log→tune loop. Now wired.

## Change
- **New `self-eval/outcome-adapter.ts` (#3241):** `aggregatedResultToOutcome()` maps `AggregatedResult` → `TaskOutcome`:
  - `finalRecommendation === 'retain'` → `success: true`; otherwise `false` + `errorMessage`
  - `confidence` / `evidenceQuality` / `recommendation` carried in `qualitySignals`; `category: 'code_review'`; `SELF_EVAL_MARKER` stamped
  - Stable id `selfEvalOutcomeId(path)` so re-runs upsert rather than pile up (mirrors warm-up / e2e-eval id schemes)
- **`self-eval.ts` (#3219/#3235):** `persistResults()` appends each result to a dependency-injected OutcomeStore (defaults to `getOutcomeStore()`), **failure-guarded** — a store error logs + continues, never crashes the eval.

## Verification
- Unit tests for the adapter mapping; persistence test (append once per result via injected store; store-throws doesn't crash).
- self-eval suites pass; `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)