### PR TITLE
refactor(pipeline): explicit PluginRegistry dependency seam via resolvePipelineDeps (#3175)

### DIFF
--- a/.changeset/pipeline-deps-seam.md
+++ b/.changeset/pipeline-deps-seam.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Make the pipeline engine's PluginRegistry dependency explicit (#3175). `PipelineRunner.compile()` previously reached for the process-global `getPipelinePluginRegistry()` singleton inline — an implicit dependency. It now resolves through a small, tested seam: the new `resolvePipelineDeps(deps)` + `PipelineDeps` bundle (exported from the pipeline barrel), where an injected `pluginRegistry` wins and an omitted one falls back to the documented global default. Behavior is unchanged when nothing is injected; the seam is the extension point the injectable-OutcomeStore work (#3145) builds on. Verified scope note: the EventBus is already injected via `PipelineExecuteOptions.eventBus` (global fallback already centralized in `pipeline-observability.resolveBus`), and the ArtifactStore is unconsumed by the runner — so this pass intentionally covers only the one dependency the engine actually resolved implicitly.

--- a/packages/nexus-agents/src/exports/pipeline.ts
+++ b/packages/nexus-agents/src/exports/pipeline.ts
@@ -27,6 +27,10 @@ export {
   // Plan compiler
   compilePlan,
   type PlanCompileOptions,
+  // Pipeline dependency seam (#3175)
+  resolvePipelineDeps,
+  type PipelineDeps,
+  type ResolvedPipelineDeps,
   // Pipeline runner
   PipelineRunner,
   type CompiledPipeline,

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -31,6 +31,12 @@ export {
 export { compilePlan, type PlanCompileOptions } from './plan-compiler.js';
 
 export {
+  resolvePipelineDeps,
+  type PipelineDeps,
+  type ResolvedPipelineDeps,
+} from './pipeline-deps.js';
+
+export {
   PipelineRunner,
   getDefaultRunsDir,
   type CompiledPipeline,

--- a/packages/nexus-agents/src/pipeline/pipeline-deps.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-deps.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for resolvePipelineDeps — the explicit pipeline dependency seam (#3175).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { resolvePipelineDeps } from './pipeline-deps.js';
+import { getPipelinePluginRegistry, resetPipelinePluginRegistry } from './core-plugins.js';
+import { PluginRegistry } from './plugin-registry.js';
+
+afterEach(() => {
+  // Keep the global registry isolated between cases.
+  resetPipelinePluginRegistry();
+});
+
+describe('resolvePipelineDeps (#3175)', () => {
+  it('falls back to the global PluginRegistry when none is injected', () => {
+    const resolved = resolvePipelineDeps();
+    // Identity: the resolved registry IS the process-global singleton, so behavior
+    // is unchanged when nothing is injected.
+    expect(resolved.pluginRegistry).toBe(getPipelinePluginRegistry());
+  });
+
+  it('falls back to the global default when the bundle omits pluginRegistry', () => {
+    const resolved = resolvePipelineDeps({});
+    expect(resolved.pluginRegistry).toBe(getPipelinePluginRegistry());
+  });
+
+  it('passes an injected pluginRegistry through untouched', () => {
+    const injected = new PluginRegistry();
+    const resolved = resolvePipelineDeps({ pluginRegistry: injected });
+    expect(resolved.pluginRegistry).toBe(injected);
+    // And it must NOT be the global singleton — the injection wins.
+    expect(resolved.pluginRegistry).not.toBe(getPipelinePluginRegistry());
+  });
+
+  it('resolves a fresh global after the singleton is reset (no stale capture)', () => {
+    const first = resolvePipelineDeps().pluginRegistry;
+    resetPipelinePluginRegistry();
+    const second = resolvePipelineDeps().pluginRegistry;
+    expect(second).not.toBe(first);
+    expect(second).toBe(getPipelinePluginRegistry());
+  });
+});

--- a/packages/nexus-agents/src/pipeline/pipeline-deps.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-deps.ts
@@ -1,0 +1,52 @@
+/**
+ * PipelineDeps — explicit dependency seam for the pipeline engine (#3175).
+ *
+ * The reusable engine (`PipelineRunner`) previously reached for the process-global
+ * `PluginRegistry` singleton inline (`getPipelinePluginRegistry()`) — an *implicit*
+ * dependency that made independent in-process pipelines and test isolation awkward.
+ * This module makes that dependency *explicit*: callers pass a `PipelineDeps` bundle
+ * and any unset field falls back to its documented global default. Behavior is
+ * unchanged when nothing is injected (the resolved value IS the singleton).
+ *
+ * Scope note (verified for #3175): the `EventBus` is already injected via
+ * `PipelineExecuteOptions.eventBus`, and its global fallback already lives in one
+ * authority — `pipeline-observability.resolveBus()`. The `ArtifactStore` is not
+ * consumed by the runner today; an injectable `ArtifactStore`/`OutcomeStore` lands
+ * with #3145 and will extend this same bundle. So this seam intentionally covers
+ * only the one dependency the engine actually resolves implicitly today — the
+ * `PluginRegistry` — rather than introduce unconsumed fields.
+ *
+ * @module pipeline/pipeline-deps
+ */
+import { getPipelinePluginRegistry } from './core-plugins.js';
+
+import type { IPluginRegistry } from './plugin-types.js';
+
+/**
+ * Injectable pipeline dependencies. Every field is optional; an unset field
+ * falls back to its documented process-global default at resolve time.
+ */
+export interface PipelineDeps {
+  /**
+   * Plugin registry for resolving stage handlers. Defaults to the global
+   * pipeline registry (`getPipelinePluginRegistry()`) when unset.
+   */
+  readonly pluginRegistry?: IPluginRegistry;
+}
+
+/** Fully-resolved pipeline dependencies — every field concrete. */
+export interface ResolvedPipelineDeps {
+  readonly pluginRegistry: IPluginRegistry;
+}
+
+/**
+ * Resolves a {@link PipelineDeps} bundle, filling any unset field from its
+ * documented global default. An injected field is returned untouched; an omitted
+ * field returns the process-global default. The only side effect is the lazy,
+ * idempotent creation of the global registry inside `getPipelinePluginRegistry()`.
+ */
+export function resolvePipelineDeps(deps?: PipelineDeps): ResolvedPipelineDeps {
+  return {
+    pluginRegistry: deps?.pluginRegistry ?? getPipelinePluginRegistry(),
+  };
+}

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -13,7 +13,7 @@ import { nexusDataPath } from '../config/nexus-data-dir.js';
 import { compilePlan } from './plan-compiler.js';
 import type { PlanCompileOptions } from './plan-compiler.js';
 import { TraceWriter } from './trace-writer.js';
-import { getPipelinePluginRegistry } from './core-plugins.js';
+import { resolvePipelineDeps } from './pipeline-deps.js';
 
 import type {
   CompiledGraph,
@@ -101,9 +101,10 @@ type ExecuteResult =
 export class PipelineRunner {
   /** Compiles a PlanContract into a CompiledPipeline. */
   compile(plan: PlanContract, options?: PlanCompileOptions): CompileResult {
-    const compileOpts: PlanCompileOptions = {
-      pluginRegistry: options?.pluginRegistry ?? getPipelinePluginRegistry(),
-    };
+    // Resolve deps through the explicit seam (#3175): an injected registry wins,
+    // otherwise the documented global default is used — behavior unchanged.
+    const { pluginRegistry } = resolvePipelineDeps(options);
+    const compileOpts: PlanCompileOptions = { pluginRegistry };
     const graphResult = compilePlan(plan, compileOpts);
     if (!graphResult.ok) {
       return { ok: false, error: graphResult.error };


### PR DESCRIPTION
## Summary
Closes #3175. `PipelineRunner.compile()` reached for the process-global `getPipelinePluginRegistry()` singleton inline — the implicit dependency the 2026-05-31 system review flagged as breaking composability. This makes it explicit and tested via a small `resolvePipelineDeps(deps)` + `PipelineDeps` bundle, exported from the pipeline barrel.

## Approach (6-1 `consensus_vote`, higher_order)
The panel approved "DI-lite" but the **Contrarian's dissent was decisive** and the conditional approvals all converged on it: *don't add unconsumed fields*. Verifying the actual code confirmed the issue's framing was broader than reality:

| Singleton | Verified state | Action |
|-----------|----------------|--------|
| **EventBus** | Already injected (`PipelineExecuteOptions.eventBus`); global fallback already centralized in `pipeline-observability.resolveBus()` | No change needed |
| **PluginRegistry** | One implicit `getPipelinePluginRegistry()` reach in `compile()` (line 105); no production caller injects | **Fixed** — explicit seam |
| **ArtifactStore** | Not consumed by the runner at all | Deferred to #3145 (extends this bundle) |

So this pass covers **only the one dependency the engine actually resolved implicitly** — no dead seam.

## Changes
- `pipeline/pipeline-deps.ts` (new) — `PipelineDeps` bundle + pure `resolvePipelineDeps()` resolver.
- `pipeline/pipeline-deps.test.ts` (new) — inject-wins, omit→global-default identity, fresh-after-reset (4 tests).
- `pipeline/pipeline-runner.ts` — `compile()` resolves through the seam; dropped the direct singleton import.
- `pipeline/index.ts` + `exports/pipeline.ts` — export the seam (public wiring primitive; #3145 extends it).

## Verification
- `pnpm typecheck` clean (incl. `exactOptionalPropertyTypes`).
- `pnpm vitest` — new 4 + pipeline-runner 18 + dev-pipeline 15 + export-contracts 61 all green.
- `eslint` clean on all changed files.
- Behavior-preserving: when nothing is injected the resolved registry **is** the singleton (identity-asserted).

## Follow-up
Remaining real work — injectable `OutcomeStore`/`ArtifactStore`, persistent backend — is **#3145**, which grows this same `PipelineDeps` bundle. I'll post a scope-correction note on #3175 and #3145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)