### PR TITLE
fix(pipeline): drop dead model.called branch from feedback subscriber (#3179)

### DIFF
--- a/.changeset/drop-dead-model-called.md
+++ b/.changeset/drop-dead-model-called.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Drop the dead `model.called` branch from the EventBus→OutcomeStore feedback subscriber (#3179). The bridge now subscribes to `stage.failed` only — its sole event with a producer. `model.called` was in the event vocabulary (#912) with consumers here and in trace-writer (#952), but no code ever emitted it, so the branch never fired; had a producer been added it would have double-counted against the cli-attributed outcomes `agent-executor.recordOutcome()` already writes directly. The `ModelCalledEvent` type and trace-writer handler are retained as valid vocabulary. Emitting `model.called` with real model/token attribution (the originally-intended #952 observability) is tracked in #3387. Also corrects the now-stale "auto-feedback never wired" framing of #3179 — #2938 already auto-wires the subscriber at server startup.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -626,9 +626,10 @@ function initV2PipelineSubsystems(
   const bridge = createEventBusBridge({ source: pipelineEventBus });
   // Wire the EventBus → OutcomeStore feedback loop advertised by
   // `feedback-subscriber.ts`. Pre-#2938 the module existed but nothing
-  // called it, so `model.called` / `stage.failed` events never reached
-  // OutcomeStore via this path. Cleanup runs in
-  // cli-server.ts:createShutdownCleanup via `shutdownFeedbackSubscriber()`.
+  // called it, so `stage.failed` events never reached OutcomeStore via this
+  // path. (#3179 dropped the dead `model.called` branch — that event has no
+  // producer.) Cleanup runs in cli-server.ts:createShutdownCleanup via
+  // `shutdownFeedbackSubscriber()`.
   startFeedbackSubscriber(pipelineEventBus, getOutcomeStore());
   // Close the self-tuning loop's consumer side: the shadow TuneStage subscribes
   // to signal.* events on the same typed bus (#3147; #3289 Option 2). Shadow

--- a/packages/nexus-agents/src/pipeline/feedback-subscriber.test.ts
+++ b/packages/nexus-agents/src/pipeline/feedback-subscriber.test.ts
@@ -1,7 +1,9 @@
 /**
- * FeedbackSubscriber tests (Issue #915, Phase 7-1)
+ * FeedbackSubscriber tests (Issue #915, Phase 7-1; #3179 scope cleanup)
  *
- * Tests automatic wiring of EventBus → OutcomeStore.
+ * Tests automatic wiring of EventBus → OutcomeStore. The bridge listens for
+ * `stage.failed` only — the former `model.called` branch was dead (no producer)
+ * and was removed in #3179.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -21,6 +23,17 @@ import type { PipelineEvent } from './event-types.js';
 let bus: EventBus;
 let store: OutcomeStore;
 
+/** A representative stage.failed event — the bridge's only live input. */
+function stageFailed(executionId: string, error = 'boom'): PipelineEvent {
+  return {
+    type: 'stage.failed',
+    executionId,
+    stageId: 'analyze',
+    error,
+    timestamp: Date.now(),
+  };
+}
+
 beforeEach(() => {
   resetOutcomeStore();
   bus = new EventBus();
@@ -32,10 +45,24 @@ beforeEach(() => {
 // ============================================================================
 
 describe('createFeedbackSubscriber', () => {
-  it('records model.called events as outcomes', () => {
+  it('records stage.failed events as failed outcomes', () => {
     createFeedbackSubscriber(bus, store);
 
-    const event: PipelineEvent = {
+    bus.emit(stageFailed('exec-2'));
+
+    expect(store.size).toBe(1);
+    const outcomes = store.query({});
+    expect(outcomes[0]?.success).toBe(false);
+    expect(outcomes[0]?.failureCategory).toBeDefined();
+  });
+
+  it('ignores model.called events — that event has no producer (#3179)', () => {
+    // The bridge no longer subscribes to model.called. Even if some future
+    // producer emitted one, outcome-writing stays on agent-executor's direct
+    // recordOutcome path to avoid double-counting.
+    createFeedbackSubscriber(bus, store);
+
+    bus.emit({
       type: 'model.called',
       executionId: 'exec-1',
       cli: 'claude',
@@ -44,32 +71,9 @@ describe('createFeedbackSubscriber', () => {
       tokensOut: 500,
       durationMs: 250,
       timestamp: Date.now(),
-    };
-    bus.emit(event);
+    });
 
-    expect(store.size).toBe(1);
-    const outcomes = store.query({});
-    expect(outcomes[0]?.cli).toBe('claude');
-    expect(outcomes[0]?.model).toBe('claude-sonnet');
-    expect(outcomes[0]?.success).toBe(true);
-    expect(outcomes[0]?.durationMs).toBe(250);
-  });
-
-  it('records stage.failed events as failed outcomes', () => {
-    createFeedbackSubscriber(bus, store);
-
-    const event: PipelineEvent = {
-      type: 'stage.failed',
-      executionId: 'exec-2',
-      stageId: 'analyze',
-      error: 'boom',
-      timestamp: Date.now(),
-    };
-    bus.emit(event);
-
-    expect(store.size).toBe(1);
-    const outcomes = store.query({});
-    expect(outcomes[0]?.success).toBe(false);
+    expect(store.size).toBe(0);
   });
 
   it('ignores unrelated event types', () => {
@@ -87,30 +91,12 @@ describe('createFeedbackSubscriber', () => {
   it('returns unsubscribe function', () => {
     const unsub = createFeedbackSubscriber(bus, store);
 
-    bus.emit({
-      type: 'model.called',
-      executionId: 'exec-1',
-      cli: 'gemini',
-      model: 'gemini-pro',
-      tokensIn: 100,
-      tokensOut: 50,
-      durationMs: 100,
-      timestamp: Date.now(),
-    });
+    bus.emit(stageFailed('exec-1'));
     expect(store.size).toBe(1);
 
     unsub();
 
-    bus.emit({
-      type: 'model.called',
-      executionId: 'exec-2',
-      cli: 'codex',
-      model: 'codex-o3',
-      tokensIn: 100,
-      tokensOut: 50,
-      durationMs: 100,
-      timestamp: Date.now(),
-    });
+    bus.emit(stageFailed('exec-2'));
     expect(store.size).toBe(1);
   });
 
@@ -118,16 +104,7 @@ describe('createFeedbackSubscriber', () => {
     createFeedbackSubscriber(bus, store);
 
     for (let i = 0; i < 5; i++) {
-      bus.emit({
-        type: 'model.called',
-        executionId: `exec-${String(i)}`,
-        cli: 'claude',
-        model: 'claude-sonnet',
-        tokensIn: 100,
-        tokensOut: 50,
-        durationMs: 100,
-        timestamp: Date.now(),
-      });
+      bus.emit(stageFailed(`exec-${String(i)}`));
     }
 
     expect(store.size).toBe(5);
@@ -148,16 +125,7 @@ describe('startFeedbackSubscriber / shutdownFeedbackSubscriber lifecycle', () =>
   it('wires the EventBus → OutcomeStore bridge for the process lifetime', () => {
     startFeedbackSubscriber(bus, store);
 
-    bus.emit({
-      type: 'model.called',
-      executionId: 'exec-lifecycle',
-      cli: 'claude',
-      model: 'claude-sonnet',
-      tokensIn: 100,
-      tokensOut: 50,
-      durationMs: 100,
-      timestamp: Date.now(),
-    });
+    bus.emit(stageFailed('exec-lifecycle'));
 
     expect(store.size).toBe(1);
     shutdownFeedbackSubscriber();
@@ -168,16 +136,7 @@ describe('startFeedbackSubscriber / shutdownFeedbackSubscriber lifecycle', () =>
     startFeedbackSubscriber(bus, store);
     startFeedbackSubscriber(bus, store);
 
-    bus.emit({
-      type: 'model.called',
-      executionId: 'exec-idem',
-      cli: 'gemini',
-      model: 'gemini-pro',
-      tokensIn: 100,
-      tokensOut: 50,
-      durationMs: 100,
-      timestamp: Date.now(),
-    });
+    bus.emit(stageFailed('exec-idem'));
 
     // Subscribed exactly once — the event records exactly one outcome.
     expect(store.size).toBe(1);
@@ -188,16 +147,7 @@ describe('startFeedbackSubscriber / shutdownFeedbackSubscriber lifecycle', () =>
     startFeedbackSubscriber(bus, store);
     shutdownFeedbackSubscriber();
 
-    bus.emit({
-      type: 'model.called',
-      executionId: 'exec-post-shutdown',
-      cli: 'codex',
-      model: 'codex-5.3',
-      tokensIn: 10,
-      tokensOut: 5,
-      durationMs: 20,
-      timestamp: Date.now(),
-    });
+    bus.emit(stageFailed('exec-post-shutdown'));
 
     expect(store.size).toBe(0);
   });

--- a/packages/nexus-agents/src/pipeline/feedback-subscriber.ts
+++ b/packages/nexus-agents/src/pipeline/feedback-subscriber.ts
@@ -4,6 +4,19 @@
  * Subscribes to pipeline events and records outcomes automatically.
  * Closes the feedback loop: execution → events → outcomes → routing.
  *
+ * Scope note (#3179): this bridge listens for `stage.failed` only. It used to
+ * also subscribe to `model.called`, but that event has **no producer** anywhere
+ * in the codebase — `ModelCalledEvent` was added to the event vocabulary (#912)
+ * with consumers here and in trace-writer (#952), but the emitter was never
+ * built. So the `model.called` branch was dead (it never fired) and, had a
+ * producer been added, it would have double-counted against the cli-attributed
+ * outcomes that `agent-executor.recordOutcome()` already writes directly. The
+ * 3-0 consensus (#3179) was to drop the dead branch and keep outcome-writing on
+ * the single direct path. Emitting `model.called` with real model/token
+ * attribution (the originally-intended #952 observability) is deferred to a
+ * focused follow-up; it needs adapter-level token plumbing and is built only
+ * if/when query_trace model-call attribution is actually needed.
+ *
  * @see docs/v2/08-observability-eventing.md (Feedback Loop section)
  * @module pipeline/feedback-subscriber
  */
@@ -13,18 +26,15 @@ import type { PipelineEvent, Unsubscribe, IEventBus } from './event-types.js';
 import type { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 import { categorizeOutcomeErrorMessage } from '../orchestration/outcomes/outcome-types.js';
-import { CLI_NAMES, DEFAULT_CLI } from '../config/model-capabilities-types.js';
-import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+import { DEFAULT_CLI } from '../config/model-capabilities-types.js';
 
 const logger = createLogger({ component: 'FeedbackSubscriber' });
-
-const VALID_CLIS: ReadonlySet<string> = new Set<string>(CLI_NAMES);
 
 /**
  * Creates a subscriber that bridges EventBus events to OutcomeStore.
  *
- * Listens for `model.called` and `stage.failed` events and records
- * them as TaskOutcome entries in the OutcomeStore.
+ * Listens for `stage.failed` events and records them as failed TaskOutcome
+ * entries in the OutcomeStore.
  *
  * Returns an Unsubscribe handle for callers that manage their own
  * subscription lifecycle (e.g. tests). For the server-wide singleton
@@ -33,7 +43,7 @@ const VALID_CLIS: ReadonlySet<string> = new Set<string>(CLI_NAMES);
  * @returns Unsubscribe function to stop the bridge.
  */
 export function createFeedbackSubscriber(bus: IEventBus, store: OutcomeStore): Unsubscribe {
-  return bus.subscribe({ type: ['model.called', 'stage.failed'] }, (event) => {
+  return bus.subscribe({ type: ['stage.failed'] }, (event) => {
     try {
       handleEvent(event, store);
     } catch (error: unknown) {
@@ -88,31 +98,9 @@ export function shutdownFeedbackSubscriber(): void {
 // ============================================================================
 
 function handleEvent(event: PipelineEvent, store: OutcomeStore): void {
-  if (event.type === 'model.called') {
-    recordModelCall(event, store);
-  } else if (event.type === 'stage.failed') {
+  if (event.type === 'stage.failed') {
     recordStageFailed(event, store);
   }
-}
-
-function recordModelCall(
-  event: PipelineEvent & { type: 'model.called' },
-  store: OutcomeStore
-): void {
-  const cli = normalizeCli(event.cli);
-  if (cli === undefined) return;
-
-  const outcome: TaskOutcome = {
-    id: `fb-${event.executionId}-${String(event.timestamp)}`,
-    cli,
-    category: 'code_generation',
-    model: event.model,
-    success: true,
-    durationMs: event.durationMs,
-    timestamp: new Date(event.timestamp).toISOString(),
-    source: 'delegate',
-  };
-  store.append(outcome);
 }
 
 function recordStageFailed(
@@ -132,12 +120,4 @@ function recordStageFailed(
     errorMessage: event.error.slice(0, 500),
   };
   store.append(outcome);
-}
-
-function normalizeCli(cli: string): CliNameLiteral | undefined {
-  if (VALID_CLIS.has(cli)) {
-    return cli as CliNameLiteral;
-  }
-  logger.warn('Unknown CLI in event', { cli });
-  return undefined;
 }


### PR DESCRIPTION
## Summary
Closes #3179. The EventBus→OutcomeStore feedback subscriber subscribed to `model.called` + `stage.failed`, but **`model.called` has no producer** anywhere in the codebase — verified via grep + git history. The `recordModelCall` branch was dead code.

## Research → vote (3-0, simple_majority)
- **Stale premise:** #3179's "auto-feedback bridge is manual/never-wired" is false — #2938 already auto-wires the subscriber at server startup.
- **Real defect:** `ModelCalledEvent` (vocabulary from #912) has two consumers (this subscriber #915, trace-writer attribution #952) and **zero emitters** → `query_trace`'s `model.called` filter is permanently empty and the branch never fires.
- **Cost discovery:** emitting a *meaningful* `model.called` needs `model`+`tokensIn`+`tokensOut` plumbed from the adapter layer (out of scope); successful-call outcomes are already captured by `agent-executor.recordOutcome` (direct, cli-attributed) — so a subscriber write would double-count.
- **Decision (Option B):** drop the dead branch, keep the type + trace-writer handler, defer the real emitter to **#3387**.

## Changes
- `feedback-subscriber.ts` — subscribe to `stage.failed` only; remove `recordModelCall` + now-unused `normalizeCli`/`VALID_CLIS`/`CLI_NAMES`/`CliNameLiteral` imports. Docstring explains the no-producer rationale.
- `feedback-subscriber.test.ts` — replace `model.called` cases with `stage.failed`; **add an explicit "ignores model.called (no producer)" assertion**.
- `cli-server-tools.ts` — fix the now-stale `model.called` wiring comment.
- Changeset (patch).

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest` — feedback-subscriber 9 + export-contracts 61 green.
- Behavior-preserving for the live path: `stage.failed` → failed outcome unchanged; the removed branch never fired, so no runtime regression possible.

## Follow-up
**#3387** — emit `model.called` with real model/token attribution (the originally-intended #952 observability), built if/when query_trace model-call attribution is actually needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)