### PR TITLE
feat(security): add post-mortem query dimensions to AuditQuery (#3197)

### DIFF
--- a/.changeset/audit-query-dimensions.md
+++ b/.changeset/audit-query-dimensions.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Extend the security `AuditQuery` interface with post-mortem dimensions (#3197): `actionType` (PolicyGate/Corroboration events), `actor` (username on Trust/Reputation events), and `violationRule` (PolicyGate `violationRules` membership). These enable security forensics like "which Tier-3 events tripped RULE_OF_TWO?" and combine with the existing `trustTier`/`type`/time filters. The new filters narrow to events that actually carry the field (events lacking it are excluded). The original ask's `resource` and `policyName` were intentionally dropped — no `AuditEvent` records them, so those filters would be dead config; the policy-rule intent is served by `violationRule`.

--- a/packages/nexus-agents/src/security/audit-trail.test.ts
+++ b/packages/nexus-agents/src/security/audit-trail.test.ts
@@ -220,12 +220,54 @@ describe('AuditTrail', () => {
       expect(limited[1]?.type).toBe('policy_gate');
     });
 
+    // #3197: post-mortem query dimensions — narrow to events that actually
+    // carry the field (unlike trustTier's legacy keep-non-applicable behavior).
+    it('filters by actionType (policy_gate / corroboration only)', () => {
+      const draft = trail.query({ actionType: 'DraftReply' });
+      expect(draft).toHaveLength(1);
+      expect(draft[0]?.type).toBe('policy_gate');
+
+      const propose = trail.query({ actionType: 'ProposeLabels' });
+      expect(propose).toHaveLength(1);
+    });
+
+    it('filters by actor (username on trust / reputation events)', () => {
+      const owner = trail.query({ actor: 'owner' });
+      expect(owner).toHaveLength(1);
+      expect(owner[0]?.type).toBe('trust_classification');
+
+      const stranger = trail.query({ actor: 'stranger' });
+      expect(stranger).toHaveLength(1);
+
+      // An actor that never appears returns nothing — events lacking a
+      // username are excluded, not kept.
+      expect(trail.query({ actor: 'ghost' })).toHaveLength(0);
+    });
+
+    it('filters by violationRule (policy_gate violationRules membership)', () => {
+      const ruleOfTwo = trail.query({ violationRule: 'RULE_OF_TWO' });
+      expect(ruleOfTwo).toHaveLength(1);
+      expect(ruleOfTwo[0]?.type).toBe('policy_gate');
+      if (ruleOfTwo[0]?.type === 'policy_gate') {
+        expect(ruleOfTwo[0].allowed).toBe(false);
+      }
+
+      expect(trail.query({ violationRule: 'NONEXISTENT_RULE' })).toHaveLength(0);
+    });
+
     it('combines filters', () => {
       const result = trail.query({ type: 'policy_gate', trustTier: '3' });
       expect(result).toHaveLength(1);
       if (result[0]?.type === 'policy_gate') {
         expect(result[0].allowed).toBe(false);
       }
+    });
+
+    it('combines new post-mortem filters (Tier-3 actor + violation)', () => {
+      // "which Tier-3 events carry the RULE_OF_TWO violation?"
+      const result = trail.query({ trustTier: '3', violationRule: 'RULE_OF_TWO' });
+      expect(result).toHaveLength(1);
+      expect(result[0]?.type).toBe('policy_gate');
     });
   });
 

--- a/packages/nexus-agents/src/security/audit-trail.ts
+++ b/packages/nexus-agents/src/security/audit-trail.ts
@@ -117,12 +117,29 @@ export interface GraphExecutionAuditEvent extends AuditEventBase {
   readonly detail: string;
 }
 
-/** Query filter for retrieving audit events. */
+/**
+ * Query filter for retrieving audit events.
+ *
+ * The post-mortem dimensions (#3197) — `actionType`, `actor`, `violationRule`
+ * — NARROW to events that actually carry the field (events lacking it are
+ * excluded), unlike `trustTier`'s legacy keep-non-applicable behavior. Only
+ * dimensions backed by a real event field are offered: `resource` and
+ * `policyName` from the original ask were dropped because no AuditEvent
+ * records them (a filter with no backing field would be dead config); the
+ * policy-rule intent is served by `violationRule` (PolicyGateEvent's
+ * `violationRules`).
+ */
 export interface AuditQuery {
   readonly type?: AuditEvent['type'];
   readonly since?: string;
   readonly until?: string;
   readonly trustTier?: TrustTier;
+  /** Match PolicyGate/Corroboration events by their `actionType`. */
+  readonly actionType?: AgentActionType;
+  /** Match Trust/Reputation events by `username` (the acting/assessed user). */
+  readonly actor?: string;
+  /** Match PolicyGate events whose `violationRules` include this rule name. */
+  readonly violationRule?: string;
   readonly limit?: number;
 }
 
@@ -193,6 +210,18 @@ export class AuditTrail {
       results = filterByTrustTier(results, filter.trustTier);
     }
 
+    if (filter.actionType !== undefined) {
+      results = filterByActionType(results, filter.actionType);
+    }
+
+    if (filter.actor !== undefined) {
+      results = filterByActor(results, filter.actor);
+    }
+
+    if (filter.violationRule !== undefined) {
+      results = filterByViolationRule(results, filter.violationRule);
+    }
+
     const limit = filter.limit ?? results.length;
     return results.slice(-limit);
   }
@@ -236,6 +265,38 @@ function filterByTrustTier(events: readonly AuditEvent[], tier: TrustTier): read
     if (e.type === 'reputation') return e.effectiveTier === tier;
     return true;
   });
+}
+
+/**
+ * Narrow to events carrying the given `actionType` (#3197). Only PolicyGate and
+ * Corroboration events have one; all others are excluded.
+ */
+function filterByActionType(
+  events: readonly AuditEvent[],
+  actionType: AgentActionType
+): readonly AuditEvent[] {
+  return events.filter(
+    (e) => (e.type === 'policy_gate' || e.type === 'corroboration') && e.actionType === actionType
+  );
+}
+
+/**
+ * Narrow to events for the given actor (#3197), matched on `username`. Only
+ * Trust-classification and Reputation events carry a username; others are
+ * excluded so an actor filter never returns unrelated rows.
+ */
+function filterByActor(events: readonly AuditEvent[], actor: string): readonly AuditEvent[] {
+  return events.filter(
+    (e) => (e.type === 'trust_classification' || e.type === 'reputation') && e.username === actor
+  );
+}
+
+/**
+ * Narrow to PolicyGate events whose `violationRules` include the given rule
+ * name (#3197) — the security post-mortem "who tripped rule X" query.
+ */
+function filterByViolationRule(events: readonly AuditEvent[], rule: string): readonly AuditEvent[] {
+  return events.filter((e) => e.type === 'policy_gate' && e.violationRules.includes(rule));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Closes #3197. Extends the security `AuditQuery` (`security/audit-trail.ts`) with three post-mortem dimensions so security forensics are answerable:
- **`actionType`** — PolicyGate / Corroboration events
- **`actor`** — `username` on Trust-classification / Reputation events
- **`violationRule`** — PolicyGate `violationRules` membership

These combine with the existing `type` / `trustTier` / time filters, e.g. *"which Tier-3 events tripped `RULE_OF_TWO`?"* → `query({ trustTier: '3', violationRule: 'RULE_OF_TWO' })`.

## Scope decision (4-point gate)
The issue also asked for `resource` and `policyName`. **Dropped both** — no `AuditEvent` records those fields, so the filters would be dead config (can't filter on data that isn't captured). The policy-rule intent is covered by `violationRule`. Documented in the `AuditQuery` docstring.

## Semantics
The new filters **narrow** to events that actually carry the field (events lacking it are excluded), so an `actor`/`actionType`/`violationRule` filter never returns unrelated rows. (This differs intentionally from `trustTier`'s legacy keep-non-applicable behavior, which is unchanged.)

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest src/security/audit-trail.test.ts` — **22 pass** (4 new: actionType, actor (incl. miss→empty), violationRule (incl. miss→empty), combined Tier-3+violation).
- `AuditQuery` is publicly exported (`SecurityAuditQuery`), so the dimensions are SDK-reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)