### PR TITLE
feat(pipeline): propagate adapter token usage through expert bridge (#3396)

### DIFF
--- a/.changeset/propagate-token-usage.md
+++ b/.changeset/propagate-token-usage.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Propagate adapter token usage through the expert bridge (#3396). `CliResponse.usage` was produced upstream (SDK adapters report `TokenUsage`; CLI adapters extract it best-effort) but silently dropped across `expert-bridge.ts`'s result-mapping hops, so `agent-executor` recorded `tokensUsed: 0`. Now `ExpertBridgeResult` carries an optional `tokensUsed` (total tokens, preferring the reported `totalTokens`, falling back to input+output, left undefined when no usage was reported), and the routing-experience metric records the real value instead of zero. This is the shared prerequisite for token-based budget enforcement (#3395), `model.called` attribution (#3387), and routing-time cost scoring (#3394).

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -222,8 +222,13 @@ let routingMemoryCache: unknown = null;
 let routingMemoryInitPromise: Promise<unknown> | null = null;
 
 /** Record to RoutingMemory after expert calls (#1716). Fire-and-forget, cached. */
-function recordRoutingExperience(category: string, success: boolean, durationMs: number): void {
-  const metrics = { durationMs, tokensUsed: 0 };
+function recordRoutingExperience(
+  category: string,
+  success: boolean,
+  durationMs: number,
+  tokensUsed = 0
+): void {
+  const metrics = { durationMs, tokensUsed };
   const callRecord = (rm: unknown): void => {
     (
       rm as { recordExperience: (w: string, m: string[], s: boolean, met: typeof metrics) => void }
@@ -522,7 +527,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
         success: r.success,
         durationMs: r.durationMs,
       });
-      recordRoutingExperience('code_generation', r.success, r.durationMs);
+      recordRoutingExperience('code_generation', r.success, r.durationMs, r.tokensUsed);
       await postProgress(config, `Code [${task.id}]`, `Done (${r.durationMs}ms)`);
       return r.text || `[Implementation failed: ${r.error}]`;
     },

--- a/packages/nexus-agents/src/pipeline/expert-bridge.test.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for expert-bridge token-usage propagation (#3396).
+ *
+ * The full executeExpert path depends on a cached global router built from live
+ * CLI adapters, so it's exercised in integration. Here we unit-test the pure
+ * usage→total reducer that decides what `ExpertBridgeResult.tokensUsed` carries.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { totalTokensFromUsage } from './expert-bridge.js';
+
+describe('totalTokensFromUsage (#3396)', () => {
+  it('returns undefined when no usage was reported', () => {
+    // CLI-subprocess paths whose extractUsage() returns null land here — the
+    // caller must distinguish "unknown" from a real (never-zero) call.
+    expect(totalTokensFromUsage(undefined)).toBeUndefined();
+  });
+
+  it('prefers the reported totalTokens when present', () => {
+    expect(totalTokensFromUsage({ inputTokens: 100, outputTokens: 50, totalTokens: 160 })).toBe(
+      160
+    );
+  });
+
+  it('falls back to input + output when totalTokens is absent', () => {
+    expect(totalTokensFromUsage({ inputTokens: 100, outputTokens: 50 })).toBe(150);
+  });
+
+  it('honours a reported totalTokens of 0 (does not fall back)', () => {
+    // An explicit 0 total is respected; only a missing total triggers the sum.
+    expect(totalTokensFromUsage({ inputTokens: 0, outputTokens: 0, totalTokens: 0 })).toBe(0);
+  });
+
+  it('returns undefined when input+output sum to zero (no real signal)', () => {
+    expect(totalTokensFromUsage({ inputTokens: 0, outputTokens: 0 })).toBeUndefined();
+  });
+
+  it('treats missing input/output fields as zero', () => {
+    expect(totalTokensFromUsage({ outputTokens: 42 })).toBe(42);
+    expect(totalTokensFromUsage({ inputTokens: 7 })).toBe(7);
+  });
+});

--- a/packages/nexus-agents/src/pipeline/expert-bridge.ts
+++ b/packages/nexus-agents/src/pipeline/expert-bridge.ts
@@ -48,6 +48,14 @@ export interface ExpertBridgeResult {
    * a cli — see #2823 (#1154 regression).
    */
   readonly cli?: CliNameLiteral;
+  /**
+   * Total tokens (input + output) the underlying CLI/adapter reported for this
+   * call, when available (#3396). Best-effort: `CliResponse.usage` is optional
+   * — CLI-subprocess paths whose `extractUsage` returns null leave this
+   * undefined. Consumers (budget enforcement #3395, model.called attribution
+   * #3387, routing-experience metrics) must tolerate `undefined`.
+   */
+  readonly tokensUsed?: number;
 }
 
 /**
@@ -64,7 +72,7 @@ export interface ExpertBridgeResult {
 interface RouterLike {
   executeTask(task: { content: string; options?: Record<string, unknown> | undefined }): Promise<{
     ok: boolean;
-    value: { text: string; cli?: CliNameLiteral };
+    value: { text: string; cli?: CliNameLiteral; tokensUsed?: number };
     error: { message: string };
   }>;
 }
@@ -141,6 +149,21 @@ let cachedCircuitBreaker: {
  * If CliResponse renames `.text` → `.output` (or similar), this adapter
  * breaks at compile time instead of silently returning wrong data (#1921).
  */
+/**
+ * Total tokens from a best-effort `CliResponse.usage` record (#3396). Prefers
+ * the reported `totalTokens`; falls back to input+output; returns undefined
+ * when no usage was reported (so callers can distinguish "0 tokens" — which
+ * never happens for a real call — from "unknown").
+ */
+export function totalTokensFromUsage(
+  usage: { totalTokens?: number; inputTokens?: number; outputTokens?: number } | undefined
+): number | undefined {
+  if (usage === undefined) return undefined;
+  if (typeof usage.totalTokens === 'number') return usage.totalTokens;
+  const total = (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+  return total > 0 ? total : undefined;
+}
+
 function adaptCompositeRouter(
   compositeRouter: import('../cli-adapters/composite-router.js').ICompositeRouter
 ): RouterLike {
@@ -164,9 +187,18 @@ function adaptCompositeRouter(
         // cli stays undefined and downstream code can skip the record
         // rather than lie.
         const cli = resolveCliFromModelString(result.value.model);
+        // #3396: surface token usage (best-effort) so budget enforcement,
+        // attribution, and routing-experience metrics get real numbers instead
+        // of zeros. `usage` is optional and `totalTokens` may be absent — fall
+        // back to input+output, and leave undefined when no usage was reported.
+        const tokensUsed = totalTokensFromUsage(result.value.usage);
         return {
           ok: true,
-          value: { text: result.value.text, ...(cli !== undefined && { cli }) },
+          value: {
+            text: result.value.text,
+            ...(cli !== undefined && { cli }),
+            ...(tokensUsed !== undefined && { tokensUsed }),
+          },
           error: { message: '' },
         };
       }
@@ -247,6 +279,7 @@ async function dispatchWithRateLimitRetry(
         expertType,
         durationMs,
         ...(result.value.cli !== undefined && { cli: result.value.cli }),
+        ...(result.value.tokensUsed !== undefined && { tokensUsed: result.value.tokensUsed }),
       };
     }
 


### PR DESCRIPTION
## Summary
Closes #3396. Token usage was produced upstream (`CliResponse.usage` — SDK adapters report `TokenUsage`, CLI adapters `extractUsage` best-effort) but **silently dropped** across `expert-bridge.ts`'s result-mapping hops, so `agent-executor` recorded `tokensUsed: 0`. This threads it through.

## Changes
- `totalTokensFromUsage()` (new, exported, tested) — reduces a best-effort `usage` record to a total: prefers reported `totalTokens`, falls back to `input+output`, returns `undefined` when nothing was reported (so consumers distinguish "unknown" from a never-zero real call).
- `RouterLike` value + `ExpertBridgeResult` now carry optional `tokensUsed`; `adaptCompositeRouter` populates it from `CliResponse.usage`.
- `recordRoutingExperience` records the real `tokensUsed` instead of a hardcoded `0`.

## Why (shared prerequisite)
Unblocks the cost/attribution cluster surfaced during the #3395 vote:
- **#3395** token-based `BudgetCircuitBreaker` enforcement
- **#3387** `model.called` attribution (`tokensIn`/`tokensOut`)
- **#3394** routing-time cost scoring

Standalone value: routing-experience metrics get real token counts instead of zeros.

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest expert-bridge.test.ts agent-executor.test.ts` — **23 pass** (6 new covering totalTokens-present / absent→sum / explicit-0 / sum-0→undefined / undefined-usage / partial fields).
- Best-effort by design: `usage` is optional; everything tolerates `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)