### PR TITLE
feat(pipeline): opt-in per-run token-budget enforcement for the dev-pipeline (#3395)

### DIFF
--- a/.changeset/budget-guard-dev-pipeline.md
+++ b/.changeset/budget-guard-dev-pipeline.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Add opt-in per-run token-budget enforcement to the dev-pipeline (#3395, the first half of #3150 P4). A new `BudgetGuard` wraps the existing, tested `BudgetCircuitBreaker` and meters every expert call in `agent-executor`: it records the real `tokensUsed` (now available via #3396) and, once cumulative usage crosses the configured ceiling, short-circuits further expert calls to a failure result — stopping token spend without aborting the pipeline mid-flight (hard-stop, not silent model downgrade; graceful fallback was deferred to #3394 by the consensus_vote). Strictly opt-in: absent `AgentExecutorConfig.budget` → a no-op guard → behavior is byte-for-byte unchanged. This is the per-task safety mechanism for unattended multi-day operation that #3150's cost-enforcement stage called for.

--- a/packages/nexus-agents/src/pipeline/agent-executor-budget.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor-budget.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for runExpert's budget short-circuit (#3395) — the safety-critical
+ * property is that an exhausted guard must NOT call executeExpert (no more spend).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./expert-bridge.js', () => ({
+  executeExpert: vi.fn(() =>
+    Promise.resolve({
+      success: true,
+      text: 'ok',
+      expertType: 'architecture',
+      durationMs: 5,
+      tokensUsed: 10,
+    })
+  ),
+}));
+
+import { runExpert } from './agent-executor.js';
+import { createBudgetGuard } from './budget-guard.js';
+import { executeExpert } from './expert-bridge.js';
+
+beforeEach(() => {
+  vi.mocked(executeExpert).mockClear();
+});
+
+describe('runExpert budget short-circuit (#3395)', () => {
+  it('executes and records usage when the guard is not exhausted', async () => {
+    const guard = createBudgetGuard({ maxTokens: 1000 });
+    const r = await runExpert(guard, 'architecture', 'prompt');
+    expect(r.success).toBe(true);
+    expect(executeExpert).toHaveBeenCalledOnce();
+  });
+
+  it('passes through transparently with the default (no-budget) guard', async () => {
+    const guard = createBudgetGuard(); // default-off
+    await runExpert(guard, 'architecture', 'prompt');
+    expect(executeExpert).toHaveBeenCalledOnce();
+  });
+
+  it('skips executeExpert once the budget is exhausted — no further spend', async () => {
+    const guard = createBudgetGuard({ maxTokens: 10, criticalThreshold: 0.5 });
+    guard.record(10); // crosses 50% of 10 → circuit opens
+    expect(guard.isExhausted()).toBe(true);
+
+    const r = await runExpert(guard, 'architecture', 'prompt');
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Budget exhausted');
+    expect(executeExpert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -15,7 +15,9 @@ import type { DevPipelineStages, PipelineTask, QaReviewResult } from './dev-pipe
 import { checkSecurityScan } from './security-gate.js';
 import { runQualityGate, checkTypeCheck, checkLint, checkTests } from '../security/quality-gate.js';
 import type { ITaskTracker } from './task-tracker.js';
-import { executeExpert } from './expert-bridge.js';
+import { executeExpert, type ExpertBridgeResult } from './expert-bridge.js';
+import { createBudgetGuard, type BudgetGuard, type AgentBudgetConfig } from './budget-guard.js';
+import type { BuiltInExpertType } from '../agents/experts/expert-config.js';
 import { getOutcomeStore, getOutcomeSummaryText } from '../orchestration/outcomes/outcome-store.js';
 import { detectTrend } from '../orchestration/outcomes/adaptive-thresholds.js';
 import { emitPipelineStageEvent } from './pipeline-observability.js';
@@ -130,6 +132,37 @@ export interface AgentExecutorConfig {
   readonly tracker?: ITaskTracker | undefined;
   readonly issueNumber?: number | undefined;
   readonly repo?: string | undefined;
+  /**
+   * Opt-in per-run token budget (#3395). When set, expert calls are metered
+   * through a {@link BudgetGuard}: once cumulative usage crosses the ceiling,
+   * further expert calls short-circuit to a failure result (stopping spend)
+   * rather than aborting mid-pipeline. Absent → no enforcement (default).
+   */
+  readonly budget?: AgentBudgetConfig | undefined;
+}
+
+/**
+ * Run an expert through the per-run budget guard (#3395): skip (and return a
+ * failure result) once the budget is exhausted, otherwise execute and record
+ * the tokens consumed. A no-budget guard makes this a transparent passthrough.
+ */
+export async function runExpert(
+  guard: BudgetGuard,
+  expertType: BuiltInExpertType,
+  prompt: string
+): Promise<ExpertBridgeResult> {
+  if (guard.isExhausted()) {
+    return {
+      success: false,
+      text: '',
+      expertType,
+      durationMs: 0,
+      error: 'Budget exhausted — expert call skipped (#3395)',
+    };
+  }
+  const result = await executeExpert(expertType, prompt);
+  guard.record(result.tokensUsed);
+  return result;
 }
 
 // ============================================================================
@@ -359,17 +392,21 @@ function getTrendContext(): string {
 // ============================================================================
 
 export function createAgentStages(config: AgentExecutorConfig = {}): DevPipelineStages {
+  // Per-run budget guard (#3395). No-op unless config.budget is set.
+  const guard = createBudgetGuard(config.budget);
   return {
     research: async (task) => {
       emitStageEvent('research', 'started');
       await postProgress(config, 'Research', 'Querying memory + research tools...');
       // Seed with prior learnings from memory (#1716)
       const memoryCtx = await getMemoryContext(task);
-      const discover = await executeExpert(
+      const discover = await runExpert(
+        guard,
         'research',
         `Use research_discover to find papers and repos related to:\n\n${task}${memoryCtx}`
       );
-      const analyze = await executeExpert(
+      const analyze = await runExpert(
+        guard,
         'research',
         `Use research_analyze focus=gaps to identify what is missing for:\n\n${task}`
       );
@@ -410,7 +447,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
           ? `Revise plan.\n\nFeedback: ${feedback}\n\nTask: ${task}\n\n${contextBlock}`
           : `Create implementation plan for:\n\n${task}\n\n${contextBlock}`;
       await postProgress(config, 'Plan', feedback !== undefined ? 'Revising...' : 'Planning...');
-      const r = await executeExpert('architecture', prompt);
+      const r = await runExpert(guard, 'architecture', prompt);
       emitStageEvent('plan', r.success ? 'completed' : 'failed', { durationMs: r.durationMs });
       recordOutcome({
         taskId: 'plan',
@@ -492,7 +529,8 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     decompose: async (plan) => {
       emitStageEvent('decompose', 'started');
       await postProgress(config, 'PM', 'PM expert decomposing...');
-      const r = await executeExpert(
+      const r = await runExpert(
+        guard,
         'pm',
         `Decompose into tasks.\nReturn JSON: [{id,title,description,assignedTo}]\n\n${plan}`
       );
@@ -513,7 +551,8 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       emitStageEvent(`impl-${task.id}`, 'started');
       await postProgress(config, `Code [${task.id}]`, task.title);
       const fb = task.feedback !== undefined ? `\n\nQA feedback: ${task.feedback}` : '';
-      const r = await executeExpert(
+      const r = await runExpert(
+        guard,
         'code',
         `Implement:\n\n${task.title}\n${task.description}${fb}`
       );
@@ -535,7 +574,8 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     qaReview: async (task, implementation) => {
       emitStageEvent(`qa-${task.id}`, 'started');
       await postProgress(config, `QA [${task.id}]`, 'QA expert reviewing...');
-      const r = await executeExpert(
+      const r = await runExpert(
+        guard,
         'qa',
         `QA:\n\nTask: ${task.title}\n\nImpl:\n${implementation.slice(0, 3000)}\n\nVerdict: PASS/NEEDS_WORK/REJECT`
       );

--- a/packages/nexus-agents/src/pipeline/budget-guard.test.ts
+++ b/packages/nexus-agents/src/pipeline/budget-guard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for BudgetGuard — per-run token-budget enforcement (#3395).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { BudgetGuard, createBudgetGuard } from './budget-guard.js';
+
+describe('BudgetGuard (#3395)', () => {
+  it('a no-budget guard never reports exhaustion and ignores records', () => {
+    const guard = createBudgetGuard(); // default-off
+    expect(guard.enforced).toBe(false);
+    guard.record(1_000_000);
+    expect(guard.isExhausted()).toBe(false);
+  });
+
+  it('opens once recorded usage crosses the critical threshold', () => {
+    const guard = createBudgetGuard({ maxTokens: 100, criticalThreshold: 0.9 });
+    expect(guard.enforced).toBe(true);
+    expect(guard.isExhausted()).toBe(false);
+
+    guard.record(80); // 80% < 90% → still closed
+    expect(guard.isExhausted()).toBe(false);
+
+    guard.record(15); // 95% >= 90% → opens
+    expect(guard.isExhausted()).toBe(true);
+  });
+
+  it('stays closed while under the threshold', () => {
+    const guard = createBudgetGuard({ maxTokens: 1000, criticalThreshold: 0.95 });
+    guard.record(100);
+    guard.record(200);
+    guard.record(300);
+    expect(guard.isExhausted()).toBe(false); // 60% < 95%
+  });
+
+  it('ignores undefined and non-positive token counts', () => {
+    const guard = createBudgetGuard({ maxTokens: 10, criticalThreshold: 0.5 });
+    guard.record(undefined); // CLI-subprocess path with no usage
+    guard.record(0);
+    guard.record(-5);
+    expect(guard.isExhausted()).toBe(false);
+  });
+
+  it('a bare BudgetGuard (no breaker) is a safe no-op', () => {
+    const guard = new BudgetGuard();
+    expect(guard.enforced).toBe(false);
+    expect(guard.isExhausted()).toBe(false);
+    expect(() => {
+      guard.record(999);
+    }).not.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/pipeline/budget-guard.ts
+++ b/packages/nexus-agents/src/pipeline/budget-guard.ts
@@ -1,0 +1,67 @@
+/**
+ * BudgetGuard — per-run token-budget enforcement for the agent pipeline (#3395).
+ *
+ * Wraps the existing, tested `BudgetCircuitBreaker` (the single budget authority
+ * — see #3150 / #3177) and exposes the two operations the stage path needs:
+ * `record(tokensUsed)` after each expert call and `isExhausted()` before the
+ * next one. When no budget is configured the guard is a no-op (`isExhausted()`
+ * always false, `record()` does nothing), so the default path is byte-for-byte
+ * unchanged — enforcement is strictly opt-in.
+ *
+ * Behaviour on overrun is a graceful short-circuit, NOT a thrown abort: once the
+ * breaker opens, subsequent expert calls return a failure result (the stages
+ * already degrade on failure), which stops further token spend without unwinding
+ * the pipeline mid-flight. Hard-stop, not silent model downgrade — the
+ * consensus_vote on #3395 deferred graceful fallback to #3394.
+ *
+ * @module pipeline/budget-guard
+ */
+import { createBudgetCircuitBreaker } from '../workflows/budget-circuit-breaker.js';
+import type { BudgetCircuitBreaker } from '../workflows/budget-circuit-breaker.js';
+
+/** Opt-in per-run budget configuration (absent → enforcement off). */
+export interface AgentBudgetConfig {
+  /** Hard token ceiling for the whole run. */
+  readonly maxTokens: number;
+  /** Fraction of `maxTokens` at which the circuit opens (default 0.95). */
+  readonly criticalThreshold?: number;
+}
+
+/** Per-run token-budget guard. A no-budget guard never reports exhaustion. */
+export class BudgetGuard {
+  private readonly breaker: BudgetCircuitBreaker | undefined;
+
+  constructor(breaker?: BudgetCircuitBreaker) {
+    this.breaker = breaker;
+  }
+
+  /** Record tokens consumed by a completed call (best-effort; undefined ignored). */
+  record(tokensUsed: number | undefined): void {
+    if (this.breaker === undefined || tokensUsed === undefined || tokensUsed <= 0) return;
+    this.breaker.recordUsage(tokensUsed);
+  }
+
+  /** True once the budget circuit has opened — callers should stop spending. */
+  isExhausted(): boolean {
+    return this.breaker?.getState() === 'open';
+  }
+
+  /** Whether a budget is actually being enforced (vs the no-op default). */
+  get enforced(): boolean {
+    return this.breaker !== undefined;
+  }
+}
+
+/**
+ * Build a {@link BudgetGuard} from optional config. Returns a no-op guard when
+ * `budget` is undefined, so callers can construct unconditionally.
+ */
+export function createBudgetGuard(budget?: AgentBudgetConfig): BudgetGuard {
+  if (budget === undefined) return new BudgetGuard();
+  const breaker = createBudgetCircuitBreaker(budget.maxTokens, {
+    ...(budget.criticalThreshold !== undefined
+      ? { criticalThreshold: budget.criticalThreshold }
+      : {}),
+  });
+  return new BudgetGuard(breaker);
+}


### PR DESCRIPTION
## Summary
First increment of #3395 (decomposed from #3150 P4). Wires the existing, tested `BudgetCircuitBreaker` into the dev-pipeline's expert path via a new `BudgetGuard`, giving per-run token-budget enforcement — the safety mechanism for unattended multi-day operation. **6-1 `consensus_vote` approved** the approach.

## Design
- `BudgetGuard` (new, tested) wraps `BudgetCircuitBreaker` — the **single** budget authority (reuse, not a fork, per panel condition). `record(tokensUsed)` after each call; `isExhausted()` before the next.
- `runExpert(guard, type, prompt)` meters every `executeExpert` in `agent-executor`: records the real `tokensUsed` (now available via #3396) and, once the circuit opens, **short-circuits to a failure result** — stopping spend without aborting mid-pipeline. Hard-stop, not silent model downgrade (graceful fallback deferred to #3394 by the vote).
- **Strictly opt-in / default-off:** no `AgentExecutorConfig.budget` → no-op guard → behavior byte-for-byte unchanged.

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest` — 40 pass across guard/agent-executor/dev-pipeline, incl. the **safety-critical property** that an exhausted guard does **not** call `executeExpert` (no further spend), and that the default guard is a transparent passthrough.

## Scope / follow-ups (panel endorsed incremental per-path)
This covers the **dev-pipeline path**. Tracked follow-ups:
- Wire the breaker into the **orchestrate** path.
- **Retire the #3177 no-op** policy-engine budget gate (the panel's "single authority" condition — it's currently a dead no-op, so no active conflict, but should be removed).
- Expose `budget` via the **dev-pipeline MCP tool** so unattended runs can set a ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)