### PR TITLE
feat(mcp): expose per-run token budget via run_dev_pipeline (#3395)

### DIFF
--- a/.changeset/expose-budget-mcp.md
+++ b/.changeset/expose-budget-mcp.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Expose the per-run token budget via the `run_dev_pipeline` MCP tool (#3395 follow-up). A new optional `maxBudgetTokens` input threads through to the dev-pipeline's `BudgetGuard`: when set, expert calls stop once cumulative token usage crosses the ceiling — a hard-stop safety cap for unattended/multi-day runs. Omitted by default (enforcement off). This makes the budget mechanism (shipped in 2.102.6) reachable by MCP clients rather than programmatic-only.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -88,6 +88,21 @@ describe('DevPipelineInputSchema', () => {
     });
     expect(parsed.workingDir).toBe('/home/user/project');
   });
+
+  it('accepts an opt-in maxBudgetTokens ceiling (#3395)', () => {
+    const parsed = DevPipelineInputSchema.parse({ task: 'test', maxBudgetTokens: 50_000 });
+    expect(parsed.maxBudgetTokens).toBe(50_000);
+  });
+
+  it('leaves maxBudgetTokens undefined by default (enforcement off)', () => {
+    const parsed = DevPipelineInputSchema.parse({ task: 'test' });
+    expect(parsed.maxBudgetTokens).toBeUndefined();
+  });
+
+  it('rejects a non-positive maxBudgetTokens', () => {
+    expect(() => DevPipelineInputSchema.parse({ task: 'test', maxBudgetTokens: 0 })).toThrow();
+    expect(() => DevPipelineInputSchema.parse({ task: 'test', maxBudgetTokens: -100 })).toThrow();
+  });
 });
 
 // #2824: run_dev_pipeline used to register a bare callback that called

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -119,6 +119,15 @@ export const DevPipelineInputSchema = z.object({
     .describe(
       "Pre-ship local quality gate. 'off' (default): skip. 'advisory': run + record feedback, never fail. 'blocking': a red gate fails the pipeline."
     ),
+  /** Opt-in per-run token budget — a safety cap for unattended runs (#3395). */
+  maxBudgetTokens: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Per-run token ceiling (#3395). When set, expert calls stop (returning failures) once cumulative usage crosses it — a hard-stop safety cap for unattended/multi-day runs. Omit to disable (default).'
+    ),
 });
 
 export type DevPipelineInput = z.infer<typeof DevPipelineInputSchema>;
@@ -184,6 +193,10 @@ async function createStages(
     issueNumber: input.issueNumber,
     repo: input.repo,
     tracker,
+    // #3395: thread the opt-in per-run token ceiling through to the budget guard.
+    ...(input.maxBudgetTokens !== undefined && {
+      budget: { maxTokens: input.maxBudgetTokens },
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
#3395 follow-up. Makes the per-run token budget (the `BudgetGuard` shipped in 2.102.6) reachable by MCP clients via a new optional `maxBudgetTokens` input on `run_dev_pipeline`.

## Changes
- `DevPipelineInputSchema.maxBudgetTokens` — optional positive int; threaded to `createAgentStages({ budget: { maxTokens } })`.
- When set, the dev-pipeline `BudgetGuard` stops expert calls once cumulative usage crosses the ceiling (hard-stop safety cap for unattended/multi-day runs). Omitted → enforcement off (default; behavior unchanged).

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest` — dev-pipeline-tool 12 pass (3 new: accepts ceiling / default-undefined / rejects non-positive); cli-server-tools + tools/index + simulation-guard 105 pass (optional field is backward-compatible).
- No doc drift (the `RESEARCH_PIPELINE.md` param list is a different `runResearchPipeline` interface).

## #3395 progress
- [x] dev-pipeline budget mechanism (2.102.6)
- [x] **expose via dev-pipeline MCP tool (this PR)**
- [ ] orchestrate-path wiring
- [ ] retire #3177 no-op gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)