### PR TITLE
feat(routing): activate dynamic model discovery — Phase 1 cache sources (#3404)

### DIFF
--- a/.changeset/dynamic-models-phase1.md
+++ b/.changeset/dynamic-models-phase1.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Activate dynamic model discovery — Phase 1 (#3404, epic #3403). The `AvailableModelsCache` + the CLI-level routing pre-filter already existed but the cache had **no sources registered**, so it was always empty and the pre-filter was inert. This adds a live **OpenRouter `/api/v1/models`** catalog source (`createOpenRouterModelsSource` — Zod-validated, size/timeout-bounded, fail-open) and a `registerDefaultModelSources()` helper that also wraps any adapter implementing `listModels()` (opencode + SDK adapters) as a CLI-named cache source. `createCompositeRouter` now attaches the populated global cache when dynamic discovery is enabled. Opt-in via `NEXUS_DYNAMIC_MODELS=true` (default OFF; behavior unchanged until set). Fail-open throughout: a failed probe yields `[]` and an empty cache leaves routing using all CLIs, so discovery can never wedge routing. The 429/5xx execution-time cooldown is tracked as a follow-up.

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -5,7 +5,7 @@
  * (Source: Issue #166, Epic #164)
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   CompositeRouter,
   createCompositeRouter,
@@ -13,6 +13,11 @@ import {
   CompositeRoutingError,
 } from './composite-router.js';
 import type { ICliAdapter, CliTask, CliName } from './types.js';
+import {
+  AvailableModelsCache,
+  getDefaultAvailableModelsCache,
+  setDefaultAvailableModelsCache,
+} from '../config/available-models-cache.js';
 
 /**
  * Creates a mock CLI adapter for testing.
@@ -299,6 +304,34 @@ describe('createCompositeRouter', () => {
     const adapters = createTestAdapters();
     const router = createCompositeRouter(adapters, { linucbAlpha: 2.0 });
     expect(router.getStats().totalDecisions).toBe(0);
+  });
+
+  // #3404: dynamic-discovery flag gating (the only integration logic in the PR).
+  describe('dynamic discovery flag', () => {
+    afterEach(() => {
+      delete process.env['NEXUS_DYNAMIC_MODELS'];
+      setDefaultAvailableModelsCache(null);
+    });
+
+    it('does NOT attach a cache when the flag is off (default)', () => {
+      const router = createCompositeRouter(createTestAdapters()) as CompositeRouter;
+      expect(router.getAvailableModelsCache()).toBeUndefined();
+    });
+
+    it('attaches the populated global cache when NEXUS_DYNAMIC_MODELS=true', () => {
+      process.env['NEXUS_DYNAMIC_MODELS'] = 'true';
+      const router = createCompositeRouter(createTestAdapters()) as CompositeRouter;
+      expect(router.getAvailableModelsCache()).toBe(getDefaultAvailableModelsCache());
+    });
+
+    it('preserves a caller-supplied cache even when flagged', () => {
+      process.env['NEXUS_DYNAMIC_MODELS'] = 'true';
+      const custom = new AvailableModelsCache({ sources: [] });
+      const router = createCompositeRouter(createTestAdapters(), {
+        availableModelsCache: custom,
+      }) as CompositeRouter;
+      expect(router.getAvailableModelsCache()).toBe(custom);
+    });
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -99,6 +99,11 @@ import {
   runPipeline,
   type StageDependencies,
 } from './composite-router-stages.js';
+import { getDefaultAvailableModelsCache } from '../config/available-models-cache.js';
+import {
+  isDynamicModelsEnabled,
+  registerDefaultModelSources,
+} from '../config/register-model-sources.js';
 import {
   recordBanditOutcome,
   recordPreferenceSignal,
@@ -871,8 +876,20 @@ export class CompositeRouter implements ICompositeRouter {
 /** Creates a CompositeRouter instance. */
 export function createCompositeRouter(
   adapters: Map<CliName, ICliAdapter>,
-  config?: Partial<CompositeRouterConfig>,
+  config?: Partial<CompositeRouterConfigWithPreference>,
   logger?: ILogger
 ): ICompositeRouter {
-  return new CompositeRouter(adapters, config, logger);
+  // #3404: when dynamic discovery is enabled (opt-in via NEXUS_DYNAMIC_MODELS,
+  // default OFF) and the caller didn't supply a cache, attach the global
+  // AvailableModelsCache with live sources registered, so the existing CLI
+  // pre-filter (getCandidateCliNames) finally has real data. Fail-open by
+  // construction: sources return [] on error and an empty cache leaves
+  // getCandidateCliNames returning all CLIs.
+  let resolved = config;
+  if (isDynamicModelsEnabled() && config?.availableModelsCache === undefined) {
+    const cache = getDefaultAvailableModelsCache();
+    registerDefaultModelSources(cache, adapters);
+    resolved = { ...config, availableModelsCache: cache };
+  }
+  return new CompositeRouter(adapters, resolved, logger);
 }

--- a/packages/nexus-agents/src/config/index.ts
+++ b/packages/nexus-agents/src/config/index.ts
@@ -333,3 +333,15 @@ export type {
   AvailableModel,
   AvailableModelsCacheOptions,
 } from './available-models-cache.js';
+
+// (#3404, epic #3403) Dynamic model discovery: the OpenRouter live-catalog
+// source + the registration helper that populates the AvailableModelsCache.
+export {
+  createOpenRouterModelsSource,
+  type OpenRouterModelsSourceOptions,
+} from './openrouter-models-source.js';
+export {
+  isDynamicModelsEnabled,
+  registerDefaultModelSources,
+  type RegisterModelSourcesOptions,
+} from './register-model-sources.js';

--- a/packages/nexus-agents/src/config/openrouter-models-source.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the OpenRouter live-catalog source (#3404).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { createOpenRouterModelsSource } from './openrouter-models-source.js';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('createOpenRouterModelsSource (#3404)', () => {
+  it('returns the catalog ids on a valid response', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: [{ id: 'qwen/qwen3-coder:free' }, { id: 'nvidia/nemotron-nano-9b-v2:free' }],
+        })
+      )
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(src.name).toBe('openrouter');
+    const ids = await src.listModels();
+    expect(ids.map((m) => m.id)).toEqual([
+      'qwen/qwen3-coder:free',
+      'nvidia/nemotron-nano-9b-v2:free',
+    ]);
+  });
+
+  it('fails open (empty) on a non-OK status', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse({}, false, 503))
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(await src.listModels()).toEqual([]);
+  });
+
+  it('fails open (empty) on a network/timeout error', async () => {
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('aborted'))) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(await src.listModels()).toEqual([]);
+  });
+
+  it('fails open (empty) on a schema-invalid payload (untrusted input)', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse({ data: [{ notId: 1 }, 'garbage'] }))
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(await src.listModels()).toEqual([]);
+  });
+
+  it('fails open (empty) when the body exceeds the byte cap', async () => {
+    const huge = 'x'.repeat(8_000_001);
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(huge),
+      } as unknown as Response)
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(await src.listModels()).toEqual([]);
+  });
+
+  it('caps the number of returned ids', async () => {
+    const data = Array.from({ length: 6000 }, (_, i) => ({ id: `m-${String(i)}` }));
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse({ data }))
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    const ids = await src.listModels();
+    expect(ids.length).toBe(5000);
+  });
+});

--- a/packages/nexus-agents/src/config/openrouter-models-source.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.test.ts
@@ -9,6 +9,7 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
     ok,
     status,
+    headers: { get: () => null },
     text: () => Promise.resolve(JSON.stringify(body)),
   } as unknown as Response;
 }
@@ -59,7 +60,21 @@ describe('createOpenRouterModelsSource (#3404)', () => {
       Promise.resolve({
         ok: true,
         status: 200,
+        headers: { get: () => null },
         text: () => Promise.resolve(huge),
+      } as unknown as Response)
+    ) as unknown as typeof fetch;
+    const src = createOpenRouterModelsSource({ fetchImpl });
+    expect(await src.listModels()).toEqual([]);
+  });
+
+  it('rejects (empty) before buffering when Content-Length exceeds the cap', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (h: string) => (h === 'content-length' ? '9000000' : null) },
+        text: () => Promise.reject(new Error('must not buffer')),
       } as unknown as Response)
     ) as unknown as typeof fetch;
     const src = createOpenRouterModelsSource({ fetchImpl });

--- a/packages/nexus-agents/src/config/openrouter-models-source.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.ts
@@ -48,57 +48,79 @@ export interface OpenRouterModelsSourceOptions {
  * Register it on the {@link AvailableModelsCache} (which owns TTL +
  * stale-while-revalidate + single-in-flight coalescing).
  */
+const logger = createLogger({ component: 'openrouter-models-source' });
+
+/** Validate + cap a catalog body. Returns `[]` on oversize or schema failure. */
+function parseCatalog(text: string): readonly { id: string }[] {
+  if (text.length > MAX_BYTES) {
+    logger.warn('OpenRouter catalog exceeds byte cap; ignoring', { bytes: text.length });
+    return [];
+  }
+  const parsed = OpenRouterModelsResponseSchema.safeParse(JSON.parse(text));
+  if (!parsed.success) {
+    logger.warn('OpenRouter catalog failed schema validation; treating as empty', {
+      error: parsed.error.message,
+    });
+    return [];
+  }
+  return parsed.data.data.slice(0, MAX_MODELS).map((m) => ({ id: m.id }));
+}
+
+/** Fetch + validate the catalog. Fail-OPEN: any failure returns `[]`. */
+async function fetchCatalog(
+  url: string,
+  timeoutMs: number,
+  doFetch: typeof fetch
+): Promise<readonly { id: string }[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    const res = await doFetch(url, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) {
+      logger.warn('OpenRouter catalog fetch returned non-OK; treating as empty', {
+        status: res.status,
+      });
+      return [];
+    }
+    // Pre-check Content-Length so a hostile/huge body is rejected BEFORE it is
+    // buffered. The text().length check is a backstop for servers that omit or
+    // lie about Content-Length.
+    const declaredLen = res.headers.get('content-length');
+    if (declaredLen !== null && Number(declaredLen) > MAX_BYTES) {
+      logger.warn('OpenRouter catalog Content-Length exceeds byte cap; ignoring', {
+        bytes: declaredLen,
+      });
+      return [];
+    }
+    const ids = parseCatalog(await res.text());
+    logger.debug('OpenRouter catalog loaded', { count: ids.length });
+    return ids;
+  } catch (error: unknown) {
+    // Fail-open: probe failure (network/timeout/parse) → empty list.
+    logger.warn('OpenRouter catalog fetch failed; treating as empty', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function createOpenRouterModelsSource(
   opts: OpenRouterModelsSourceOptions = {}
 ): AvailableModelsSource {
   const url = opts.url ?? OPENROUTER_MODELS_URL;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const doFetch = opts.fetchImpl ?? fetch;
-  const logger = createLogger({ component: 'openrouter-models-source' });
 
   return {
     name: 'openrouter',
     providerHint: 'openrouter',
-    async listModels(): Promise<readonly { id: string }[]> {
-      const controller = new AbortController();
-      const timer = setTimeout(() => {
-        controller.abort();
-      }, timeoutMs);
-      try {
-        const res = await doFetch(url, {
-          signal: controller.signal,
-          headers: { accept: 'application/json' },
-        });
-        if (!res.ok) {
-          logger.warn('OpenRouter catalog fetch returned non-OK; treating as empty', {
-            status: res.status,
-          });
-          return [];
-        }
-        const text = await res.text();
-        if (text.length > MAX_BYTES) {
-          logger.warn('OpenRouter catalog exceeds byte cap; ignoring', { bytes: text.length });
-          return [];
-        }
-        const parsed = OpenRouterModelsResponseSchema.safeParse(JSON.parse(text));
-        if (!parsed.success) {
-          logger.warn('OpenRouter catalog failed schema validation; treating as empty', {
-            error: parsed.error.message,
-          });
-          return [];
-        }
-        const ids = parsed.data.data.slice(0, MAX_MODELS).map((m) => ({ id: m.id }));
-        logger.debug('OpenRouter catalog loaded', { count: ids.length });
-        return ids;
-      } catch (error: unknown) {
-        // Fail-open: probe failure (network/timeout/parse) → empty list.
-        logger.warn('OpenRouter catalog fetch failed; treating as empty', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return [];
-      } finally {
-        clearTimeout(timer);
-      }
-    },
+    listModels: () => fetchCatalog(url, timeoutMs, doFetch),
   };
 }

--- a/packages/nexus-agents/src/config/openrouter-models-source.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.ts
@@ -1,0 +1,104 @@
+/**
+ * OpenRouter live-catalog AvailableModelsSource (#3404, epic #3403).
+ *
+ * Fetches the unauthenticated `GET /api/v1/models` catalog so routing/discovery
+ * can see the models OpenRouter actually offers right now (including `:free`
+ * variants) and prune stale/renamed ids — e.g. it would have caught
+ * `qwen/qwen3-coder-480b-a35b:free` → `qwen/qwen3-coder:free`.
+ *
+ * Guardrails (the catalog is untrusted external input — Epic #818, Tier 3):
+ *  - **Zod-validated** shape; anything malformed yields an empty list.
+ *  - **Size-bounded** (byte cap + max model count) so a hostile/huge payload
+ *    can't blow memory.
+ *  - **Timeout-bounded** via AbortController.
+ *  - **Fail-OPEN**: any error returns `[]`, so the AvailableModelsCache simply
+ *    keeps prior/other sources — a probe failure never wedges routing.
+ *  - **Existence only**: we read ids, never pricing/capability (those stay
+ *    authoritative in the in-tree registry).
+ *
+ * @module config/openrouter-models-source
+ */
+import { z } from 'zod';
+
+import { createLogger } from '../core/index.js';
+
+import type { AvailableModelsSource } from './available-models-cache.js';
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
+const DEFAULT_TIMEOUT_MS = 8_000;
+/** Cap on returned ids — bounds an untrusted/huge catalog. */
+const MAX_MODELS = 5_000;
+/** Byte cap on the raw response body (~8 MB) — the real catalog is well under. */
+const MAX_BYTES = 8_000_000;
+
+const OpenRouterModelSchema = z.object({ id: z.string().min(1).max(256) });
+const OpenRouterModelsResponseSchema = z.object({ data: z.array(OpenRouterModelSchema) });
+
+export interface OpenRouterModelsSourceOptions {
+  /** Override the catalog URL (tests / self-hosted gateways). */
+  readonly url?: string;
+  /** Per-fetch timeout in ms (default 8s). */
+  readonly timeoutMs?: number;
+  /** Injectable fetch for tests. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * Build an {@link AvailableModelsSource} backed by OpenRouter's live catalog.
+ * Register it on the {@link AvailableModelsCache} (which owns TTL +
+ * stale-while-revalidate + single-in-flight coalescing).
+ */
+export function createOpenRouterModelsSource(
+  opts: OpenRouterModelsSourceOptions = {}
+): AvailableModelsSource {
+  const url = opts.url ?? OPENROUTER_MODELS_URL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const logger = createLogger({ component: 'openrouter-models-source' });
+
+  return {
+    name: 'openrouter',
+    providerHint: 'openrouter',
+    async listModels(): Promise<readonly { id: string }[]> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort();
+      }, timeoutMs);
+      try {
+        const res = await doFetch(url, {
+          signal: controller.signal,
+          headers: { accept: 'application/json' },
+        });
+        if (!res.ok) {
+          logger.warn('OpenRouter catalog fetch returned non-OK; treating as empty', {
+            status: res.status,
+          });
+          return [];
+        }
+        const text = await res.text();
+        if (text.length > MAX_BYTES) {
+          logger.warn('OpenRouter catalog exceeds byte cap; ignoring', { bytes: text.length });
+          return [];
+        }
+        const parsed = OpenRouterModelsResponseSchema.safeParse(JSON.parse(text));
+        if (!parsed.success) {
+          logger.warn('OpenRouter catalog failed schema validation; treating as empty', {
+            error: parsed.error.message,
+          });
+          return [];
+        }
+        const ids = parsed.data.data.slice(0, MAX_MODELS).map((m) => ({ id: m.id }));
+        logger.debug('OpenRouter catalog loaded', { count: ids.length });
+        return ids;
+      } catch (error: unknown) {
+        // Fail-open: probe failure (network/timeout/parse) → empty list.
+        logger.warn('OpenRouter catalog fetch failed; treating as empty', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [];
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/nexus-agents/src/config/register-model-sources.test.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for default model-source registration (#3404).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { AvailableModelsCache } from './available-models-cache.js';
+import { isDynamicModelsEnabled, registerDefaultModelSources } from './register-model-sources.js';
+
+afterEach(() => {
+  delete process.env['NEXUS_DYNAMIC_MODELS'];
+});
+
+describe('isDynamicModelsEnabled (#3404)', () => {
+  it('is false by default (opt-in)', () => {
+    expect(isDynamicModelsEnabled()).toBe(false);
+  });
+
+  it('is true only for the exact string "true"', () => {
+    process.env['NEXUS_DYNAMIC_MODELS'] = 'true';
+    expect(isDynamicModelsEnabled()).toBe(true);
+    process.env['NEXUS_DYNAMIC_MODELS'] = '1';
+    expect(isDynamicModelsEnabled()).toBe(false);
+  });
+});
+
+describe('registerDefaultModelSources (#3404)', () => {
+  it('registers an adapter listModels() as a CLI-named source', async () => {
+    const cache = new AvailableModelsCache({ sources: [] });
+    const adapters = new Map<string, unknown>([
+      ['opencode', { listModels: () => Promise.resolve([{ id: 'qwen/qwen3-coder:free' }]) }],
+      ['claude', {}], // no listModels → skipped, no throw
+    ]);
+    registerDefaultModelSources(cache, adapters, { includeOpenRouter: false });
+
+    const all = await cache.getAll();
+    expect(all.some((m) => m.id === 'qwen/qwen3-coder:free' && m.source === 'opencode')).toBe(true);
+  });
+
+  it('is fail-open: one adapter throwing does not poison the others', async () => {
+    const cache = new AvailableModelsCache({ sources: [] });
+    const adapters = new Map<string, unknown>([
+      ['opencode', { listModels: () => Promise.reject(new Error('cli down')) }],
+      ['gemini', { listModels: () => Promise.resolve([{ id: 'gemini-3-pro' }]) }],
+    ]);
+    registerDefaultModelSources(cache, adapters, { includeOpenRouter: false });
+
+    const all = await cache.getAll();
+    expect(all.map((m) => m.id)).toContain('gemini-3-pro');
+  });
+
+  it('skips adapters without a listModels method', async () => {
+    const cache = new AvailableModelsCache({ sources: [] });
+    const adapters = new Map<string, unknown>([['codex', { execute: () => undefined }]]);
+    registerDefaultModelSources(cache, adapters, { includeOpenRouter: false });
+
+    expect(await cache.getAll()).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/config/register-model-sources.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.ts
@@ -4,9 +4,12 @@
  * The cache + the CLI-level routing pre-filter (`getCandidateCliNames`) and the
  * 404 fallback already exist, but in production the cache had **no sources**, so
  * it was always empty and the pre-filter was inert. This wires:
- *  - the OpenRouter live catalog (`createOpenRouterModelsSource`), and
+ *  - the OpenRouter live catalog (`createOpenRouterModelsSource`), named
+ *    `openrouter` — it feeds existence checks (`cache.has()`), the 404 fallback,
+ *    and the Phase 2 alias resolver; it does NOT drive the CLI pre-filter (its
+ *    name is not a CLI name), which is intentional, and
  *  - every adapter that implements `listModels()` (opencode + SDK adapters),
- *    named by its CLI so `getCandidateCliNames` can filter on it.
+ *    named by its CLI so `getCandidateCliNames` CAN filter on it.
  *
  * Opt-in: gated by `NEXUS_DYNAMIC_MODELS` (default OFF for the initial ship; the
  * flag flips ON in a follow-up once telemetry + QA confirm it, per the project's

--- a/packages/nexus-agents/src/config/register-model-sources.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.ts
@@ -1,0 +1,90 @@
+/**
+ * Registers live model-discovery sources onto an AvailableModelsCache (#3404).
+ *
+ * The cache + the CLI-level routing pre-filter (`getCandidateCliNames`) and the
+ * 404 fallback already exist, but in production the cache had **no sources**, so
+ * it was always empty and the pre-filter was inert. This wires:
+ *  - the OpenRouter live catalog (`createOpenRouterModelsSource`), and
+ *  - every adapter that implements `listModels()` (opencode + SDK adapters),
+ *    named by its CLI so `getCandidateCliNames` can filter on it.
+ *
+ * Opt-in: gated by `NEXUS_DYNAMIC_MODELS` (default OFF for the initial ship; the
+ * flag flips ON in a follow-up once telemetry + QA confirm it, per the project's
+ * gated default-off→on discipline). Every source is fail-OPEN — a failing probe
+ * yields `[]`, never an exception, so registration can never wedge routing.
+ *
+ * @module config/register-model-sources
+ */
+import { createLogger } from '../core/index.js';
+
+import { createOpenRouterModelsSource } from './openrouter-models-source.js';
+
+import type { AvailableModelsCache, AvailableModelsSource } from './available-models-cache.js';
+
+const logger = createLogger({ component: 'register-model-sources' });
+
+/** Whether dynamic model discovery is enabled (opt-in; default OFF). */
+export function isDynamicModelsEnabled(): boolean {
+  return process.env['NEXUS_DYNAMIC_MODELS'] === 'true';
+}
+
+/** Minimal structural view of an adapter that can list its models. */
+interface ListsModels {
+  listModels(): Promise<readonly { id: string }[]>;
+}
+
+function hasListModels(adapter: unknown): adapter is ListsModels {
+  return (
+    typeof adapter === 'object' &&
+    adapter !== null &&
+    typeof (adapter as { listModels?: unknown }).listModels === 'function'
+  );
+}
+
+/**
+ * Wrap an adapter's `listModels()` as a fail-open cache source named for its CLI
+ * (so `getCandidateCliNames` filters on it). Probe failures → `[]`.
+ */
+function adapterSource(cliName: string, adapter: ListsModels): AvailableModelsSource {
+  return {
+    name: cliName,
+    listModels: () =>
+      adapter
+        .listModels()
+        .then((models) => models.map((m) => ({ id: m.id })))
+        .catch((error: unknown) => {
+          logger.debug('adapter listModels failed; treating as empty', {
+            cli: cliName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return [];
+        }),
+  };
+}
+
+export interface RegisterModelSourcesOptions {
+  /** Include the OpenRouter live catalog source (default true). */
+  readonly includeOpenRouter?: boolean;
+}
+
+/**
+ * Register the default discovery sources onto `cache`. Idempotent per source
+ * name (the cache ignores duplicate names). `adapters` is the CLI→adapter map
+ * the router already builds; any adapter exposing `listModels()` becomes a
+ * source. Safe to call unconditionally — callers gate on
+ * {@link isDynamicModelsEnabled} for the opt-in rollout.
+ */
+export function registerDefaultModelSources(
+  cache: AvailableModelsCache,
+  adapters: ReadonlyMap<string, unknown>,
+  opts: RegisterModelSourcesOptions = {}
+): void {
+  if (opts.includeOpenRouter !== false) {
+    cache.addSource(createOpenRouterModelsSource());
+  }
+  for (const [cliName, adapter] of adapters) {
+    if (hasListModels(adapter)) {
+      cache.addSource(adapterSource(cliName, adapter));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Phase 1 of epic #3403. The `AvailableModelsCache` + CLI routing pre-filter already existed but the cache had **zero sources** in production (always empty → pre-filter inert, #3188). This populates it.

## Changes
- **`createOpenRouterModelsSource`** — live `GET /api/v1/models` source. Untrusted-input hardened: Zod-validated, byte+count bounded, AbortController timeout; **fail-open** (any error → `[]`).
- **`registerDefaultModelSources`** — registers the OpenRouter source + wraps any adapter with `listModels()` (opencode + SDK) as a CLI-named source (fail-open per source).
- **`createCompositeRouter`** attaches the populated global cache when discovery is enabled.
- **Opt-in**: `NEXUS_DYNAMIC_MODELS=true` (default **OFF** — behavior unchanged until set).

## Guardrails (from the consensus panels)
- **Fail-OPEN** — failed probe → `[]`; empty cache → routing uses all CLIs (never wedges).
- **Untrusted input (Epic #818 T3)** — catalog Zod-validated, size-bounded, existence-only.
- **Advisory** — discovery filters *candidates*; never blocks an explicit model.

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest` — 91 pass (OpenRouter source 6: valid/non-OK/network/schema/oversize/cap; registration 5: flag + fail-open + skip; composite-router + cache suites unchanged).

## Scope / follow-ups
- **429/5xx cooldown** → #3408 (needs two-sided hot-path wiring).
- Next: Phase 1b (#3405 CLI self-enumeration via models.dev), Phase 1c (#3406 MCP resource + validation tool).

Part of epic #3403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)