### PR TITLE
feat(adapters): key-free CLI model enumeration via models.dev — Phase 1b (#3405)

### DIFF
--- a/.changeset/dynamic-models-phase1b.md
+++ b/.changeset/dynamic-models-phase1b.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Key-free CLI model enumeration via models.dev — Phase 1b (#3405, epic #3403). The claude/codex/gemini CLI adapters now implement `listModels()`, backed by the committed, CI-refreshed models.dev snapshot filtered by vendor (`anthropic`/`openai`/`google`) — no API key needed (their OAuth tokens can't call the vendor `/v1/models` REST endpoints; only opencode has a native list command). New `config/models-dev-by-vendor.ts` exposes `listModelsForCli(cli)` / `listModelsByVendor(vendor)` (fail-open: a missing/malformed snapshot yields `[]`). With this, `registerDefaultModelSources` (#3404) now populates the AvailableModelsCache with all four transports, so the CLI routing pre-filter finally sees real per-CLI model sets. Existence only — the in-tree registry stays authoritative for pricing/capability.

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
@@ -17,6 +17,8 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { ClaudeResponseParser } from '../parsers/claude-parser.js';
+import type { CliModelInfo } from '../types-capability.js';
+import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import {
   getDefaultModelForCli,
   getCliModelName,
@@ -68,6 +70,15 @@ export class ClaudeCliAdapter extends SubprocessCliAdapter {
   constructor(options?: BaseAdapterOptions) {
     super(options?.logger);
     this.model = options?.model ?? getCliModelName(getDefaultModelForCli('claude'));
+  }
+
+  /**
+   * Key-free model enumeration (#3405): the claude CLI has no list-models
+   * command and its OAuth token can't call /v1/models, so we enumerate the
+   * vendor's models from the models.dev snapshot. Existence only.
+   */
+  listModels(): Promise<readonly CliModelInfo[]> {
+    return Promise.resolve(listModelsForCli(this.name));
   }
 
   /**

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.ts
@@ -24,6 +24,8 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { CodexResponseParser } from '../parsers/codex-parser.js';
+import type { CliModelInfo } from '../types-capability.js';
+import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import { CODEX_LEGACY_DEFAULTS } from './codex-adapter-helpers.js';
 import {
   getDefaultModelForCli,
@@ -52,6 +54,11 @@ export class CodexCliAdapter extends SubprocessCliAdapter {
   constructor(options?: BaseAdapterOptions) {
     super(options?.logger);
     this.model = options?.model ?? getCliModelName(getDefaultModelForCli('codex'));
+  }
+
+  /** Key-free model enumeration via the models.dev snapshot (#3405). */
+  listModels(): Promise<readonly CliModelInfo[]> {
+    return Promise.resolve(listModelsForCli(this.name));
   }
 
   /**

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -30,6 +30,8 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { ResilientGeminiParser } from '../parsers/gemini-parser-resilient.js';
+import type { CliModelInfo } from '../types-capability.js';
+import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import {
   getTimeoutForTask,
   estimateTaskComplexity,
@@ -120,6 +122,11 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
     } else {
       this.circuitBreaker = null;
     }
+  }
+
+  /** Key-free model enumeration via the models.dev snapshot (#3405). */
+  listModels(): Promise<readonly CliModelInfo[]> {
+    return Promise.resolve(listModelsForCli(this.name));
   }
 
   /**

--- a/packages/nexus-agents/src/config/index.ts
+++ b/packages/nexus-agents/src/config/index.ts
@@ -345,3 +345,10 @@ export {
   registerDefaultModelSources,
   type RegisterModelSourcesOptions,
 } from './register-model-sources.js';
+// (#3405) Key-free CLI model enumeration via the models.dev snapshot, by vendor.
+export {
+  listModelsByVendor,
+  listModelsForCli,
+  resetModelsDevByVendorCache,
+  CLI_TO_MODELSDEV_VENDOR,
+} from './models-dev-by-vendor.js';

--- a/packages/nexus-agents/src/config/models-dev-by-vendor.test.ts
+++ b/packages/nexus-agents/src/config/models-dev-by-vendor.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for key-free CLI model enumeration via models.dev (#3405).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+
+import {
+  listModelsByVendor,
+  listModelsForCli,
+  resetModelsDevByVendorCache,
+  CLI_TO_MODELSDEV_VENDOR,
+} from './models-dev-by-vendor.js';
+
+afterEach(() => {
+  resetModelsDevByVendorCache();
+});
+
+describe('models-dev-by-vendor (#3405)', () => {
+  it('lists anthropic models for the claude CLI (incl. a claude id)', () => {
+    const models = listModelsForCli('claude');
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every((m) => m.provider === 'anthropic')).toBe(true);
+    expect(models.some((m) => m.id.startsWith('claude-'))).toBe(true);
+  });
+
+  it('lists openai models for codex and google models for gemini', () => {
+    expect(listModelsForCli('codex').length).toBeGreaterThan(0);
+    expect(listModelsForCli('codex').every((m) => m.provider === 'openai')).toBe(true);
+    expect(listModelsForCli('gemini').length).toBeGreaterThan(0);
+    expect(listModelsForCli('gemini').every((m) => m.provider === 'google')).toBe(true);
+  });
+
+  it('returns [] for a CLI without a vendor mapping (e.g. opencode)', () => {
+    expect(listModelsForCli('opencode')).toEqual([]);
+    expect(listModelsForCli('unknown-cli')).toEqual([]);
+  });
+
+  it('filters strictly by vendor', () => {
+    const anthropic = listModelsByVendor('anthropic');
+    const google = listModelsByVendor('google');
+    const ids = new Set(anthropic.map((m) => m.id));
+    expect(google.some((m) => ids.has(m.id))).toBe(false);
+  });
+
+  it('maps every known CLI to a real vendor key present in the snapshot', () => {
+    for (const vendor of Object.values(CLI_TO_MODELSDEV_VENDOR)) {
+      expect(listModelsByVendor(vendor).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/nexus-agents/src/config/models-dev-by-vendor.ts
+++ b/packages/nexus-agents/src/config/models-dev-by-vendor.ts
@@ -1,0 +1,72 @@
+/**
+ * Key-free model enumeration for CLI-subprocess adapters via models.dev (#3405).
+ *
+ * claude/codex/gemini CLIs have no `list-models` command, and their OAuth tokens
+ * can't call the vendor `/v1/models` REST endpoints (inference-only). So we
+ * enumerate from the committed, CI-refreshed **models.dev snapshot** filtered by
+ * vendor — a current, comprehensive, *key-free* catalog. This is EXISTENCE only
+ * (liveness is handled reactively by the 404 fallback); the in-tree registry
+ * stays authoritative for pricing/capability.
+ *
+ * Fail-OPEN: a missing/malformed snapshot yields `[]`, never throws.
+ *
+ * @module config/models-dev-by-vendor
+ */
+import { createLogger } from '../core/index.js';
+
+import { loadModelsDevSnapshot } from './models-dev-snapshot-loader.js';
+
+const logger = createLogger({ component: 'models-dev-by-vendor' });
+
+/**
+ * CLI name → models.dev vendor key. opencode is intentionally absent — it has a
+ * native `opencode models` probe (wired separately).
+ */
+export const CLI_TO_MODELSDEV_VENDOR: Readonly<Record<string, string>> = {
+  claude: 'anthropic',
+  codex: 'openai',
+  gemini: 'google',
+};
+
+interface VendoredId {
+  readonly id: string;
+  readonly vendor: string;
+}
+
+let cached: readonly VendoredId[] | null = null;
+
+function loadEntries(): readonly VendoredId[] {
+  if (cached !== null) return cached;
+  try {
+    const { entries } = loadModelsDevSnapshot();
+    cached = entries.map((e) => ({ id: e.id, vendor: (e as { vendor?: string }).vendor ?? '' }));
+  } catch (error: unknown) {
+    logger.debug('models.dev snapshot load failed; enumeration empty', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    cached = [];
+  }
+  return cached;
+}
+
+/** Reset the in-process snapshot cache (tests). */
+export function resetModelsDevByVendorCache(): void {
+  cached = null;
+}
+
+/** All model ids the models.dev snapshot lists for `vendor`. */
+export function listModelsByVendor(vendor: string): readonly { id: string }[] {
+  return loadEntries()
+    .filter((e) => e.vendor === vendor)
+    .map((e) => ({ id: e.id }));
+}
+
+/**
+ * Model ids for a CLI, mapped via {@link CLI_TO_MODELSDEV_VENDOR}. Returns `[]`
+ * for CLIs without a vendor mapping (e.g. opencode, which enumerates natively).
+ */
+export function listModelsForCli(cliName: string): readonly { id: string; provider: string }[] {
+  const vendor = CLI_TO_MODELSDEV_VENDOR[cliName];
+  if (vendor === undefined) return [];
+  return listModelsByVendor(vendor).map((m) => ({ id: m.id, provider: vendor }));
+}

--- a/packages/nexus-agents/src/config/models-dev-by-vendor.ts
+++ b/packages/nexus-agents/src/config/models-dev-by-vendor.ts
@@ -39,7 +39,9 @@ function loadEntries(): readonly VendoredId[] {
   if (cached !== null) return cached;
   try {
     const { entries } = loadModelsDevSnapshot();
-    cached = entries.map((e) => ({ id: e.id, vendor: (e as { vendor?: string }).vendor ?? '' }));
+    // `vendor` is a required ModelEntry field; a non-matching/absent value simply
+    // fails the equality filter below, so no defensive fallback is needed.
+    cached = entries.map((e) => ({ id: e.id, vendor: e.vendor }));
   } catch (error: unknown) {
     logger.debug('models.dev snapshot load failed; enumeration empty', {
       error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
Phase 1b of epic #3403. The claude/codex/gemini CLI adapters now implement `listModels()` — **key-free**, backed by the committed models.dev snapshot filtered by vendor (`anthropic`/`openai`/`google`). Their OAuth tokens can't call the vendor `/v1/models` REST endpoints and the CLIs have no list-models command, so models.dev is the enumeration source (opencode keeps its native probe).

## Changes
- `config/models-dev-by-vendor.ts` (new) — `listModelsForCli(cli)` / `listModelsByVendor(vendor)`, snapshot-backed, cached, **fail-open** (missing/malformed snapshot → `[]`). Existence only.
- `listModels()` added to `ClaudeCliAdapter` / `CodexCliAdapter` / `GeminiCliAdapter`.
- `registerDefaultModelSources` (#3404) now auto-picks-up these `listModels()` → the cache reflects all four transports.

## Verification
- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest` — 87 pass (5 new enum tests against the real snapshot: per-CLI vendor mapping, strict vendor filter, unmapped-CLI → `[]`; adapter suites unchanged).

Part of epic #3403. Next: Phase 1c (#3406 — MCP resource + the callable validation tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)