### PR TITLE
feat(routing): resolve difficulty tier to concrete model at route time (#3394)

### DIFF
--- a/.changeset/route-model-selection-3394.md
+++ b/.changeset/route-model-selection-3394.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): resolve difficulty tier to a concrete model at route time (#3394)
+
+`CompositeRouter.route()` can now return a concrete `model` alongside `cliName`,
+chosen from the in-tree registry by a tier-appropriate quality dimension
+(`powerful`→reasoning, `balanced`→codeGeneration, `fast`→speed). Opt-in behind
+`NEXUS_ROUTE_MODEL_SELECTION=true` (default OFF). Pure, deterministic, and
+synchronous — no probe on the hot path. Consumers (`orchestrate`,
+`delegate_to_model`) prefer `decision.model` and fall back to the CLI default
+when absent or the flag is off. Builds on the live-discovery enumeration from
+epic #3403.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -164,6 +164,12 @@ export interface CompositeRoutingDecision {
   readonly adapter: ICliAdapter;
   /** Selected CLI name */
   readonly cliName: CliName;
+  /**
+   * Concrete model selected by difficulty tier (#3394). Present only when
+   * route-time model selection is enabled (NEXUS_ROUTE_MODEL_SELECTION).
+   * Consumers should use `decision.model ?? getDefaultModelForCli(cliName)`.
+   */
+  readonly model?: string | undefined;
   /** Overall confidence in decision (0-1) */
   readonly confidence: number;
   /** Human-readable explanation */

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -205,6 +205,39 @@ describe('CompositeRouter', () => {
     });
   });
 
+  // #3394: route-time concrete-model selection (opt-in, default OFF).
+  describe('route-time model selection (#3394)', () => {
+    afterEach(() => {
+      delete process.env['NEXUS_ROUTE_MODEL_SELECTION'];
+    });
+
+    it('omits decision.model when the flag is off (default)', async () => {
+      const task: CliTask = { content: 'Design a microservices architecture' };
+      const result = await router.route(task);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.model).toBeUndefined();
+      }
+    });
+
+    it('populates decision.model from the difficulty tier when enabled', async () => {
+      process.env['NEXUS_ROUTE_MODEL_SELECTION'] = 'true';
+      const task: CliTask = { content: 'Design a microservices architecture' };
+      const result = await router.route(task);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // When a tier was computed, the resolver returns a concrete model id for
+        // the selected CLI; when no tier, model stays undefined (fail-safe).
+        if (result.value.difficultyTier !== undefined) {
+          expect(typeof result.value.model).toBe('string');
+          expect(result.value.model).not.toBe('');
+        } else {
+          expect(result.value.model).toBeUndefined();
+        }
+      }
+    });
+  });
+
   describe('route with disabled stages', () => {
     it('should skip budget filter when disabled', async () => {
       const noBudgetRouter = new CompositeRouter(adapters, { enableBudgetFilter: false });

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -104,6 +104,7 @@ import {
   isDynamicModelsEnabled,
   registerDefaultModelSources,
 } from '../config/register-model-sources.js';
+import { resolveModelForTier, isRouteModelSelectionEnabled } from './resolve-model-for-tier.js';
 import {
   recordBanditOutcome,
   recordPreferenceSignal,
@@ -713,9 +714,18 @@ export class CompositeRouter implements ICompositeRouter {
     this.updateStats(params.selectedCli, decisionTimeMs);
     const { confidence, reason, alternatives } = buildDecisionFields({ ...params, decisionTimeMs });
 
+    // #3394: pick a concrete model from the difficulty tier (opt-in, default
+    // OFF). Registry-only + synchronous — no probe on the hot path. Consumers
+    // fall back to getDefaultModelForCli when absent.
+    const model =
+      isRouteModelSelectionEnabled() && params.difficultyTier !== undefined
+        ? resolveModelForTier(params.selectedCli, params.difficultyTier)
+        : undefined;
+
     return ok({
       adapter: selectedAdapter,
       cliName: params.selectedCli,
+      ...(model !== undefined ? { model } : {}),
       confidence,
       reason,
       stagesExecuted: params.stagesExecuted,

--- a/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for tier→model resolution (#3394).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { resolveModelForTier, TIER_QUALITY_DIMENSION } from './resolve-model-for-tier.js';
+import { findInTreeByCli, getDefaultModelForCli } from '../config/model-config-helpers.js';
+
+describe('resolveModelForTier (#3394)', () => {
+  it('maps each tier to its quality dimension (table-driven)', () => {
+    expect(TIER_QUALITY_DIMENSION).toEqual({
+      powerful: 'reasoning',
+      balanced: 'codeGeneration',
+      fast: 'speed',
+    });
+  });
+
+  it('picks the highest-reasoning claude model for the powerful tier', () => {
+    const claudeModels = findInTreeByCli('claude');
+    const best = claudeModels
+      .filter((m) => typeof m.qualityScores?.reasoning === 'number')
+      .sort((a, b) => (b.qualityScores?.reasoning ?? 0) - (a.qualityScores?.reasoning ?? 0))[0];
+    expect(resolveModelForTier('claude', 'powerful')).toBe(best?.id);
+  });
+
+  it('picks the highest-speed model for the fast tier', () => {
+    const models = findInTreeByCli('claude');
+    const best = models
+      .filter((m) => typeof m.qualityScores?.speed === 'number')
+      .sort((a, b) => (b.qualityScores?.speed ?? 0) - (a.qualityScores?.speed ?? 0))[0];
+    expect(resolveModelForTier('claude', 'fast')).toBe(best?.id);
+  });
+
+  it('returns the CLI default when no candidate is in the live set', () => {
+    // No registry model id is in this live set → registry-only filter empties →
+    // fall back to the CLI default.
+    const result = resolveModelForTier('claude', 'powerful', {
+      liveModelIds: new Set(['some/unrelated-model']),
+    });
+    expect(result).toBe(getDefaultModelForCli('claude'));
+  });
+
+  it('honours the live set when it contains a real model', () => {
+    const models = findInTreeByCli('claude');
+    const someId = models[0]?.id ?? '';
+    const result = resolveModelForTier('claude', 'powerful', {
+      liveModelIds: new Set([someId]),
+    });
+    // Only one model is live → it must be the result.
+    expect(result).toBe(someId);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(resolveModelForTier('gemini', 'balanced')).toBe(
+      resolveModelForTier('gemini', 'balanced')
+    );
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.ts
+++ b/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.ts
@@ -1,0 +1,100 @@
+/**
+ * Tier→concrete-model resolution at route time (#3394, epic #3403 / #3150 P4).
+ *
+ * ZeroRouter computes a difficulty tier (fast/balanced/powerful) but nothing used
+ * it to pick a concrete MODEL — the model was resolved late in the adapter. This
+ * resolves the tier to the best in-tree model for the selected CLI, ranked by a
+ * tier-appropriate quality dimension, so `route()` can return a (CLI, model) pair.
+ *
+ * Pure + deterministic. Conservative + fail-safe (per the consensus refinements):
+ *  - **Table-driven** tier→dimension mapping (one constant, unit-testable).
+ *  - Models **missing the tier's qualityScore are skipped** — never NaN-sorted to
+ *    the top.
+ *  - When `liveModelIds` is supplied (a READ of the AvailableModelsCache — never a
+ *    hot-path probe), only live models are eligible; an empty/undefined set means
+ *    "registry-only" (fail-open).
+ *  - Falls back to `getDefaultModelForCli` when nothing qualifies.
+ *
+ * @module cli-adapters/resolve-model-for-tier
+ */
+import { findInTreeByCli, getDefaultModelForCli } from '../config/model-config-helpers.js';
+
+import type { ModelTier } from './zero-router-types.js';
+import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+
+type QualityDimension = 'reasoning' | 'codeGeneration' | 'speed' | 'cost';
+
+/** Whether route-time concrete-model selection is enabled (opt-in; default OFF). */
+export function isRouteModelSelectionEnabled(): boolean {
+  return process.env['NEXUS_ROUTE_MODEL_SELECTION'] === 'true';
+}
+
+/** Which quality dimension each difficulty tier optimizes. Table-driven. */
+export const TIER_QUALITY_DIMENSION: Readonly<Record<ModelTier, QualityDimension>> = {
+  powerful: 'reasoning',
+  balanced: 'codeGeneration',
+  fast: 'speed',
+};
+
+export interface ResolveModelForTierOptions {
+  /**
+   * Live model ids (a snapshot READ of the AvailableModelsCache — this function
+   * never probes). When provided, only candidates whose `id` or `cliModelName`
+   * is in the set are eligible. Undefined/empty → registry-only (fail-open).
+   */
+  readonly liveModelIds?: ReadonlySet<string>;
+}
+
+/**
+ * Best in-tree model for `(cliName, tier)`, or the CLI default when none
+ * qualifies. Pure; safe to call on the routing hot path (in-memory registry
+ * read only).
+ */
+interface Scored {
+  readonly id: string;
+  readonly score: number;
+  readonly cost: number;
+}
+
+/** Eligible = no live filter, or the model's id/cliModelName is in the live set. */
+function isEligible(
+  m: { id: string; cliModelName?: string | undefined },
+  live: ReadonlySet<string> | undefined
+): boolean {
+  return live === undefined || live.has(m.id) || live.has(m.cliModelName ?? '');
+}
+
+/** Best-first: tier score, then cheaper, then lexicographic (deterministic). */
+function compareScored(a: Scored, b: Scored): number {
+  if (b.score !== a.score) return b.score - a.score;
+  if (b.cost !== a.cost) return b.cost - a.cost;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** Collect the eligible, tier-scored candidates for a CLI. */
+function collectScored(
+  cliName: CliNameLiteral,
+  dimension: QualityDimension,
+  live: ReadonlySet<string> | undefined
+): Scored[] {
+  const scored: Scored[] = [];
+  for (const m of findInTreeByCli(cliName)) {
+    if (!isEligible(m, live)) continue;
+    const score = m.qualityScores?.[dimension];
+    // Skip models without the tier's quality dimension — never NaN-sort.
+    if (typeof score !== 'number') continue;
+    scored.push({ id: m.id, score, cost: m.qualityScores?.cost ?? 0 });
+  }
+  return scored;
+}
+
+export function resolveModelForTier(
+  cliName: CliNameLiteral,
+  tier: ModelTier,
+  opts: ResolveModelForTierOptions = {}
+): string {
+  const scored = collectScored(cliName, TIER_QUALITY_DIMENSION[tier], opts.liveModelIds);
+  if (scored.length === 0) return getDefaultModelForCli(cliName);
+  scored.sort(compareScored);
+  return scored[0]?.id ?? getDefaultModelForCli(cliName);
+}

--- a/packages/nexus-agents/src/cli/orchestrate-command.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-command.ts
@@ -53,8 +53,15 @@ async function runWithAdapter(
   startTime: number
 ): Promise<OrchestrationResult> {
   const time = getTimeProvider();
-  logger.info('Executing task...', { model: decision.cliName });
-  const execResult = await decision.adapter.execute(task);
+  // #3394: when route-time model selection chose a concrete model, run with it —
+  // unless the task already pins one. Default-off behaviour: decision.model is
+  // undefined and effectiveTask === task.
+  const effectiveTask =
+    decision.model !== undefined && task.model === undefined
+      ? { ...task, model: decision.model }
+      : task;
+  logger.info('Executing task...', { model: decision.model ?? decision.cliName });
+  const execResult = await decision.adapter.execute(effectiveTask);
 
   if (!execResult.ok) {
     return {

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.test.ts
@@ -78,6 +78,20 @@ describe('mapCompositeDecisionToOutput', () => {
     expect(output.estimated_tokens).toBe(500);
   });
 
+  it('prefers decision.model over the CLI default when present (#3394)', () => {
+    const decision = makeDecision({ model: 'claude-sonnet' });
+    const output = mapCompositeDecisionToOutput(decision, 500);
+
+    expect(output.recommended_model).toBe('claude-sonnet');
+  });
+
+  it('falls back to the CLI default when decision.model is absent (#3394)', () => {
+    const decision = makeDecision();
+    const output = mapCompositeDecisionToOutput(decision, 500);
+
+    expect(output.recommended_model).toBe('claude-opus');
+  });
+
   it('includes capabilities from MODEL_CAPABILITIES', () => {
     const decision = makeDecision();
     const output = mapCompositeDecisionToOutput(decision, 100);

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
@@ -41,7 +41,9 @@ export function mapCompositeDecisionToOutput(
   decision: CompositeRoutingDecision,
   estimatedTokens: number
 ): DelegateOutput {
-  const modelName = cliNameToModel(decision.cliName);
+  // #3394: prefer the route-time tier-selected model when present (opt-in);
+  // otherwise fall back to the CLI default. Default-off → decision.model undefined.
+  const modelName = decision.model ?? cliNameToModel(decision.cliName);
   const caps = MODEL_CAPABILITIES[modelName] ?? DEFAULT_CAPABILITIES;
 
   return {


### PR DESCRIPTION
## Context

Closes #3394 (epic #3403 / #3150 P4). ZeroRouter computes a `fast`/`balanced`/`powerful` difficulty tier, but nothing consumed it to pick a concrete **model** — selection happened late, inside the adapter. This wires the tier through to a concrete model at route time, completing the (CLI, model) routing pair the dynamic-discovery work (epic #3403) made possible.

## What changed

- **New** `resolve-model-for-tier.ts` — pure, deterministic resolver. Maps tier → quality dimension (`powerful`→reasoning, `balanced`→codeGeneration, `fast`→speed), ranks in-tree models for the selected CLI, falls back to `getDefaultModelForCli`. Optional `liveModelIds` snapshot narrows eligibility (fail-open on empty/undefined). Skips models missing the tier's score (never NaN-sorts).
- `CompositeRoutingDecision.model?: string` — populated at the single decision-build point when enabled.
- Opt-in behind **`NEXUS_ROUTE_MODEL_SELECTION`** (default OFF). Registry-only, synchronous — no probe on the hot path.
- Consumers (`orchestrate-command`, `delegate-to-model-router`) prefer `decision.model`, fall back to the CLI default. An explicitly pinned `task.model` is never overridden.

## Testing

- 6 resolver unit tests (tier→dimension map, powerful→reasoning, fast→speed, live-set fallback, live-set honored, determinism).
- Router decision tests (flag off → `model` undefined; flag on → concrete string when a tier exists).
- Consumer tests (prefer `decision.model`; fall back when absent).
- Full package suite: 2422 passed, 0 regressions. typecheck + lint clean.

## Security / QA

- `decision.model` is sourced only from the trusted in-tree registry — no untrusted input reaches the `--model` arg.
- Default-OFF, fail-safe; pure + deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)