### PR TITLE
feat(routing): make API adapters first-class bandit arms (#3422)

### DIFF
--- a/.changeset/api-routing-arms-3422.md
+++ b/.changeset/api-routing-arms-3422.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): make API adapters first-class bandit arms (#3422, epic #3317)
+
+Direct-API adapters (Anthropic/OpenAI/Google/custom-OpenAI) are now first-class
+routing/bandit arms (`api:<vendor>`), scored **distinctly** from the four CLI
+slots — so the self-tuning loop learns CLI-vs-API performance separately instead
+of dropping API outcomes (the silent data loss audited in #3317).
+
+- New `RoutingArmId = CliName | ApiArmId` arm space; a `ModelToCliAdapter` shim
+  bridges `IModelAdapter` into the router's `ICliAdapter` surface; a
+  `wrapApiSelectionForRouter`/`collectApiRoutingArms` factory enumerates
+  key-present vendors.
+- The ranking/selection pipeline carries the distinct arm end-to-end; only the
+  **bandit outcome** stays distinct, while registry/pricing lookups, telemetry,
+  and secondary learners collapse to the display slot (`routingArmDisplaySlot`).
+  `decisionsPerCli` stays slot-keyed.
+- Wiring is gated: `createAllAdapters` appends API arms **only** when
+  `NEXUS_BILLING_MODE=api` and the vendor key is present — default plan mode is
+  CLIs-only, no surprise API spend.
+
+Reviewed: QA (one trace-attribution collapse fixed), security (clean — keys
+never logged/echoed, SSRF guard intact), cleanup (orphan export removed).
+Follow-ups: #3424 (tier-stage participation), #3425 (model-source key collapse),
+#3426 (connect-time SSRF check).

--- a/packages/nexus-agents/src/adapters/auto-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.test.ts
@@ -4,8 +4,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { AutoAdapterConfig } from './auto-adapter.js';
-import { createAutoAdapter, getAvailableAdapters } from './auto-adapter.js';
+import type { AutoAdapterConfig, AdapterSelection } from './auto-adapter.js';
+import {
+  createAutoAdapter,
+  getAvailableAdapters,
+  wrapApiSelectionForRouter,
+} from './auto-adapter.js';
+import { ok, type IModelAdapter } from '../core/index.js';
 
 // ============================================================================
 // Mocks
@@ -380,5 +385,56 @@ describe('getAvailableAdapters', () => {
     process.env.ANTHROPIC_API_KEY = '';
     const result = await getAvailableAdapters();
     expect(result.hasAnthropicKey).toBe(false);
+  });
+});
+
+describe('wrapApiSelectionForRouter (#3422)', () => {
+  function apiSelection(name: string, modelId = 'claude-opus'): AdapterSelection {
+    const modelAdapter = {
+      providerId: name,
+      modelId,
+      capabilities: [],
+      complete: vi.fn(),
+      stream: vi.fn(),
+      countTokens: vi.fn(),
+      validateConfig: vi.fn().mockReturnValue(ok(undefined)),
+    } as unknown as IModelAdapter;
+    return { adapter: modelAdapter, source: 'api', name, reason: 'test' };
+  }
+
+  it('maps each vendor to a distinct api:<vendor> arm id with its display slot', () => {
+    const cases: ReadonlyArray<[string, string, string]> = [
+      ['anthropic', 'api:anthropic', 'claude'],
+      ['openai', 'api:openai', 'codex'],
+      ['google', 'api:google', 'gemini'],
+      ['custom-openai', 'api:custom-openai', 'opencode'],
+    ];
+    for (const [vendor, armId, slot] of cases) {
+      const wrapped = wrapApiSelectionForRouter(apiSelection(vendor));
+      expect(wrapped?.armId).toBe(armId);
+      // Display name is the attribution slot, NOT the arm id (telemetry stays split).
+      expect(wrapped?.adapter.name).toBe(slot);
+    }
+  });
+
+  it('returns an ICliAdapter whose arm id never collides with a CLI slot', () => {
+    const wrapped = wrapApiSelectionForRouter(apiSelection('anthropic'));
+    // api:anthropic is distinct from the 'claude' CLI slot — separate bandit arms.
+    expect(wrapped?.armId).toBe('api:anthropic');
+    expect(wrapped?.armId).not.toBe('claude');
+  });
+
+  it('returns null for a CLI selection (router gets those from createAllAdapters)', () => {
+    const sel: AdapterSelection = {
+      adapter: apiSelection('anthropic').adapter,
+      source: 'cli',
+      name: 'claude',
+      reason: 'test',
+    };
+    expect(wrapApiSelectionForRouter(sel)).toBeNull();
+  });
+
+  it('returns null for an unrecognized vendor', () => {
+    expect(wrapApiSelectionForRouter(apiSelection('mystery-vendor'))).toBeNull();
   });
 });

--- a/packages/nexus-agents/src/adapters/auto-adapter.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.ts
@@ -284,6 +284,83 @@ export function wrapApiSelectionForRouter(
   return { armId: apiArmId(resolved.vendor), adapter };
 }
 
+/**
+ * Build an `AdapterSelection{source:'api'}` for a single vendor when its key(s)
+ * are present, else null. Reuses the same adapter constructors as
+ * {@link tryApiAdapter} but is key-presence-only and never calls out (#3422).
+ */
+function buildApiSelectionForVendor(vendor: ApiVendor, logger: ILogger): AdapterSelection | null {
+  switch (vendor) {
+    case 'anthropic': {
+      const key = resolveApiKeyFromEnv(undefined, 'ANTHROPIC_API_KEY');
+      if (key === undefined) return null;
+      const modelId = getCliModelName(getDefaultModelForCli('claude'));
+      return {
+        adapter: createClaudeAdapter({ modelId, apiKey: key }),
+        source: 'api',
+        name: 'anthropic',
+        reason: `Using Anthropic API (native adapter, model: ${modelId})`,
+      };
+    }
+    case 'openai': {
+      const key = resolveApiKeyFromEnv(undefined, 'OPENAI_API_KEY');
+      if (key === undefined) return null;
+      const modelId = getCliModelName(getDefaultModelForCli('codex'));
+      return {
+        adapter: new SdkAdapter({ providerId: 'openai', modelId, apiKey: key }),
+        source: 'api',
+        name: 'openai',
+        reason: `Using OpenAI API via AI SDK (model: ${modelId})`,
+      };
+    }
+    case 'google': {
+      const key = resolveApiKeyFromEnv(undefined, 'GOOGLE_AI_API_KEY');
+      if (key === undefined) return null;
+      const modelId = getCliModelName(getDefaultModelForCli('gemini'));
+      return {
+        adapter: new SdkAdapter({ providerId: 'google', modelId, apiKey: key }),
+        source: 'api',
+        name: 'google',
+        reason: `Using Google AI API via AI SDK (model: ${modelId})`,
+      };
+    }
+    case 'custom-openai':
+      return tryCustomOpenAiAdapter(logger);
+    default: {
+      const exhaustive: never = vendor;
+      throw new Error(`Unknown API vendor: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/** API vendors enumerated in routing-arm order (#3422). */
+const API_ROUTING_VENDORS: readonly ApiVendor[] = [
+  'anthropic',
+  'openai',
+  'google',
+  'custom-openai',
+];
+
+/**
+ * Enumerate the direct-API routing arms whose keys are present in the
+ * environment, each wrapped as an `ICliAdapter` keyed by its distinct
+ * `api:<vendor>` arm id (#3422). Key-presence-only and deterministic: a vendor
+ * is included iff its required env var(s) are set; keys are never validated by
+ * calling out. Used by `createAllAdapters` under `NEXUS_BILLING_MODE=api`.
+ */
+export function collectApiRoutingArms(
+  logger: ILogger = defaultLogger
+): Array<{ armId: ApiArmId; adapter: ICliAdapter }> {
+  const arms: Array<{ armId: ApiArmId; adapter: ICliAdapter }> = [];
+  for (const vendor of API_ROUTING_VENDORS) {
+    const selection = buildApiSelectionForVendor(vendor, logger);
+    if (selection === null) continue;
+    const wrapped = wrapApiSelectionForRouter(selection);
+    if (wrapped !== null) arms.push(wrapped);
+  }
+  return arms;
+}
+
 /** Try CLI first, then API as fallback. */
 async function selectCliFirst(
   config: AutoAdapterConfig,

--- a/packages/nexus-agents/src/adapters/auto-adapter.ts
+++ b/packages/nexus-agents/src/adapters/auto-adapter.ts
@@ -16,9 +16,12 @@ import type { IModelAdapter, ILogger } from '../core/index.js';
 import { createLogger } from '../core/index.js';
 import { createCliAdapter, isCliAvailable, getAvailableClis } from '../cli-adapters/factory.js';
 import { createCliToModelAdapter } from '../cli-adapters/cli-to-model-adapter.js';
+import { createModelToCliAdapter } from '../cli-adapters/model-to-cli-adapter.js';
 import { createClaudeAdapter } from './claude-adapter.js';
 import { SdkAdapter } from './sdk/index.js';
-import type { CliName } from '../cli-adapters/types.js';
+import type { CliName, ICliAdapter, ApiVendor, ApiArmId } from '../cli-adapters/types.js';
+import { apiArmId } from '../cli-adapters/types.js';
+import { buildCliCapabilityProfiles } from '../config/model-config-helpers.js';
 import type { ICliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
 import { createCliDetectionCache } from '../cli-adapters/cli-detection-cache.js';
 import { CUSTOM_API_DEFAULT_MODEL } from '../config/defaults.js';
@@ -237,6 +240,48 @@ function tryCustomOpenAiAdapter(logger: ILogger): AdapterSelection | null {
     name: 'custom-openai',
     reason: `Using custom OpenAI-compatible gateway at ${customBaseUrl} (model: ${customModelId})`,
   };
+}
+
+/**
+ * Resolve an API-vendor name to its `{vendor, slot}` pair (#3422). `slot` is the
+ * *attribution* CLI slot (`getModelInfo`, capability profile) — NOT the routing
+ * arm id, which stays distinct (`api:<vendor>`) so CLI and API telemetry never
+ * merge. Exhaustive switch (concrete literals, no index-access undefined).
+ */
+function resolveApiVendor(name: string): { vendor: ApiVendor; slot: CliName } | undefined {
+  switch (name) {
+    case 'anthropic':
+      return { vendor: 'anthropic', slot: 'claude' };
+    case 'openai':
+      return { vendor: 'openai', slot: 'codex' };
+    case 'google':
+      return { vendor: 'google', slot: 'gemini' };
+    case 'custom-openai':
+      return { vendor: 'custom-openai', slot: 'opencode' };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Wrap an `AdapterSelection{source:'api'}` for insertion into a CompositeRouter's
+ * `Map<RoutingArmId, ICliAdapter>` (#3317 step 1 / #3422). Returns the distinct
+ * routing arm id (`api:<vendor>`) and an `ICliAdapter` view of the IModelAdapter
+ * (via {@link createModelToCliAdapter}). Returns null for CLI selections (the
+ * router already gets those from `createAllAdapters` under their slot key) or an
+ * unrecognized vendor.
+ */
+export function wrapApiSelectionForRouter(
+  selection: AdapterSelection
+): { armId: ApiArmId; adapter: ICliAdapter } | null {
+  if (selection.source !== 'api') return null;
+  const resolved = resolveApiVendor(selection.name);
+  if (resolved === undefined) return null;
+  const adapter = createModelToCliAdapter(selection.adapter, {
+    name: resolved.slot,
+    capabilities: buildCliCapabilityProfiles()[resolved.slot],
+  });
+  return { armId: apiArmId(resolved.vendor), adapter };
 }
 
 /** Try CLI first, then API as fallback. */

--- a/packages/nexus-agents/src/cli-adapters/budget-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.ts
@@ -23,10 +23,10 @@ import type {
   CliTask,
   CliResponse,
   CliError,
-  CliName,
+  RoutingArmId,
   ICliAdapter,
 } from './types.js';
-import { DEFAULT_CAPABILITIES } from './types.js';
+import { DEFAULT_CAPABILITIES, routingArmDisplaySlot } from './types.js';
 import { estimateTokens, estimateCost } from './budget-utils.js';
 import { generateBudgetWarnings } from './budget-warnings.js';
 import { createBudgetExceededError } from './budget-errors.js';
@@ -60,14 +60,14 @@ const DEFAULT_OPTIONS: Required<BudgetRouterOptions> = {
  * Implements budget-aware routing with session tracking and enforcement.
  */
 export class BudgetRouter implements IBudgetRouter {
-  private readonly adapters: Map<CliName, ICliAdapter>;
+  private readonly adapters: Map<RoutingArmId, ICliAdapter>;
   private readonly options: Required<BudgetRouterOptions>;
   private tokensUsed = 0;
   private costSpentUsd = 0;
   private sessionStartedAt: Date;
   private resetTimer?: ReturnType<typeof setTimeout>;
 
-  constructor(adapters: Map<CliName, ICliAdapter>, options?: BudgetRouterOptions) {
+  constructor(adapters: Map<RoutingArmId, ICliAdapter>, options?: BudgetRouterOptions) {
     this.adapters = adapters;
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.sessionStartedAt = new Date(getTimeProvider().now());
@@ -323,16 +323,19 @@ export class BudgetRouter implements IBudgetRouter {
     budget: BudgetConstraint,
     estimatedTokens: number
   ): ICliAdapter | null {
-    // Sort adapters by cost efficiency (higher = cheaper)
+    // Sort adapters by cost efficiency (higher = cheaper). Capabilities and
+    // pricing are slot-level (DEFAULT_CAPABILITIES keyed by CliName); an api:*
+    // arm uses its display slot's profile (#3422).
     const sortedAdapters = [...this.adapters].sort((a, b) => {
-      const capA = DEFAULT_CAPABILITIES[a[0]];
-      const capB = DEFAULT_CAPABILITIES[b[0]];
+      const capA = DEFAULT_CAPABILITIES[routingArmDisplaySlot(a[0])];
+      const capB = DEFAULT_CAPABILITIES[routingArmDisplaySlot(b[0])];
       return capB.cost - capA.cost; // Prefer cheaper models
     });
 
     for (const [name, adapter] of sortedAdapters) {
-      const estimatedCost = estimateCost(name, estimatedTokens / 2, estimatedTokens / 2);
-      const caps = DEFAULT_CAPABILITIES[name];
+      const slot = routingArmDisplaySlot(name);
+      const estimatedCost = estimateCost(slot, estimatedTokens / 2, estimatedTokens / 2);
+      const caps = DEFAULT_CAPABILITIES[slot];
 
       // Check if adapter can handle the task within budget
       const withinTokenBudget =
@@ -393,7 +396,7 @@ export class BudgetRouter implements IBudgetRouter {
 
 /** Create a budget router instance. */
 export function createBudgetRouter(
-  adapters: Map<CliName, ICliAdapter>,
+  adapters: Map<RoutingArmId, ICliAdapter>,
   opts?: BudgetRouterOptions
 ): IBudgetRouter {
   return new BudgetRouter(adapters, opts);

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -9,7 +9,8 @@
 
 import type { Task } from '../core/types/agent.js';
 import { getTimeProvider, type TaskProfile } from '../core/index.js';
-import type { CliName, CliTask, BudgetConstraint } from './types.js';
+import type { CliName, RoutingArmId, CliTask, BudgetConstraint } from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type { BanditContext } from './budget-router-types.js';
 import type { TopsisModelProfile, TopsisResult } from './topsis-types.js';
 import {
@@ -77,7 +78,7 @@ export function calculateConfidence(
  * Options for building routing reason.
  */
 export interface BuildReasonOptions {
-  selectedCli: CliName;
+  selectedCli: RoutingArmId;
   stages: string[];
   topsisScore?: number;
   ucbScore?: number;
@@ -106,14 +107,19 @@ export function buildReason(options: BuildReasonOptions): string {
 /**
  * Filters CLI candidates based on preference tier.
  */
-export function filterByPreferenceTier(candidates: CliName[], tier: 'strong' | 'weak'): CliName[] {
+export function filterByPreferenceTier(
+  candidates: RoutingArmId[],
+  tier: 'strong' | 'weak'
+): RoutingArmId[] {
   // Strong models: claude (opus, sonnet)
   // Weak models: gemini (flash), codex
+  // Tier membership is slot-level; collapse an api:* arm to its display slot
+  // (#3422) so a wrapped API arm inherits its vendor slot's tier.
   const strongModels: CliName[] = ['claude'];
   const weakModels: CliName[] = ['gemini', 'codex'];
 
   const preferred = tier === 'strong' ? strongModels : weakModels;
-  const filtered = candidates.filter((c) => preferred.includes(c));
+  const filtered = candidates.filter((c) => preferred.includes(routingArmDisplaySlot(c)));
 
   // Return filtered if any match, otherwise return all candidates
   return filtered.length > 0 ? filtered : candidates;
@@ -134,7 +140,7 @@ export function cliTaskToTask(cliTask: CliTask): Task {
  * Budget filter result.
  */
 export interface BudgetFilterResult {
-  eligible: CliName[];
+  eligible: RoutingArmId[];
   withinBudget: boolean;
 }
 
@@ -143,7 +149,7 @@ export interface BudgetFilterResult {
  */
 export function applyBudgetFilter(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   budgetRouter: BudgetRouter | undefined,
   config: CompositeRouterConfig
 ): BudgetFilterResult {
@@ -171,7 +177,7 @@ export function applyBudgetFilter(
  * TOPSIS ranking result.
  */
 export interface TopsisRankingResult {
-  ranking: CliName[];
+  ranking: RoutingArmId[];
   topScore: number;
   /** Number of candidates within the tolerance band of the top score. */
   toleranceBandSize?: number;
@@ -311,10 +317,14 @@ export interface TopsisRankingOptions {
 /** Builds adjusted TOPSIS profiles from task, stage scores, and performance data. */
 function buildAdjustedProfiles(
   taskProfile: TaskProfile,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   options?: TopsisRankingOptions
 ): TopsisModelProfile[] {
-  const profiles = DEFAULT_MODEL_PROFILES.filter((p) => candidates.includes(p.cliName));
+  // TOPSIS profiles are slot-level (DEFAULT_MODEL_PROFILES keyed by CliName).
+  // Collapse arms to their display slot so an api:* arm reuses its vendor
+  // slot's profile (#3422).
+  const candidateSlots = new Set(candidates.map(routingArmDisplaySlot));
+  const profiles = DEFAULT_MODEL_PROFILES.filter((p) => candidateSlots.has(p.cliName));
   let adjusted = profiles.map((p) => adjustProfileForTask(p, taskProfile));
   if (options?.stageScores !== undefined && options.stageScores.size > 0) {
     adjusted = adjustProfileWithStageScores(adjusted, options.stageScores);
@@ -332,7 +342,7 @@ function buildAdjustedProfiles(
  */
 export function applyTopsisRanking(
   taskProfile: TaskProfile,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   topsisRouter: TopsisRouter | undefined,
   options?: TopsisRankingOptions
 ): TopsisRankingResult {
@@ -345,13 +355,17 @@ export function applyTopsisRanking(
   const adjustedProfiles = buildAdjustedProfiles(taskProfile, candidates, options);
   const result: TopsisResult = router.selectModel({ profiles: adjustedProfiles });
 
+  // Scores are slot-keyed; an api:* candidate inherits its display slot's
+  // closeness score so it ranks alongside its vendor's CLI slot (#3422).
   const scoreMap = new Map(result.scores.map((s) => [s.cliName, s.closenessScore]));
-  const ranking = [...candidates].sort((a, b) => (scoreMap.get(b) ?? 0) - (scoreMap.get(a) ?? 0));
-  const topScore = scoreMap.get(ranking[0] ?? 'claude') ?? 1.0;
+  const scoreOf = (arm: RoutingArmId): number => scoreMap.get(routingArmDisplaySlot(arm)) ?? 0;
+  const ranking = [...candidates].sort((a, b) => scoreOf(b) - scoreOf(a));
+  const topArm = ranking[0];
+  const topScore = topArm !== undefined ? scoreOf(topArm) : 1.0;
 
   // Tolerance band: count how many candidates are within TOLERANCE_BAND_PERCENT of top
   const threshold = topScore * (1 - TOPSIS_TOLERANCE_BAND_PERCENT);
-  const toleranceBandSize = ranking.filter((c) => (scoreMap.get(c) ?? 0) >= threshold).length;
+  const toleranceBandSize = ranking.filter((c) => scoreOf(c) >= threshold).length;
 
   return { ranking, topScore, toleranceBandSize };
 }
@@ -362,13 +376,13 @@ export function applyTopsisRanking(
 export interface PreferenceStageResult {
   preferenceScore: number | undefined;
   preferenceTier: 'strong' | 'weak' | undefined;
-  preferredCandidates: CliName[];
+  preferredCandidates: RoutingArmId[];
 }
 
 /**
  * Default preference stage result when preference routing is disabled.
  */
-export function defaultPreferenceStageResult(candidates: CliName[]): PreferenceStageResult {
+export function defaultPreferenceStageResult(candidates: RoutingArmId[]): PreferenceStageResult {
   return {
     preferenceScore: undefined,
     preferenceTier: undefined,
@@ -382,13 +396,13 @@ export function defaultPreferenceStageResult(candidates: CliName[]): PreferenceS
 export interface ZeroRouterStageResult {
   difficultyEstimate: DifficultyEstimate | undefined;
   difficultyTier: ModelTier | undefined;
-  filteredCandidates: CliName[];
+  filteredCandidates: RoutingArmId[];
 }
 
 /**
  * Default ZeroRouter stage result when ZeroRouter is disabled.
  */
-export function defaultZeroRouterStageResult(candidates: CliName[]): ZeroRouterStageResult {
+export function defaultZeroRouterStageResult(candidates: RoutingArmId[]): ZeroRouterStageResult {
   return {
     difficultyEstimate: undefined,
     difficultyTier: undefined,
@@ -400,7 +414,10 @@ export function defaultZeroRouterStageResult(candidates: CliName[]): ZeroRouterS
  * Maps model tier to preferred CLI order.
  * Fast tier prefers gemini/codex, Powerful tier prefers claude.
  */
-export function filterByDifficultyTier(candidates: CliName[], tier: ModelTier): CliName[] {
+export function filterByDifficultyTier(
+  candidates: RoutingArmId[],
+  tier: ModelTier
+): RoutingArmId[] {
   // Tier mappings aligned with ZeroRouter DEFAULT_TIER_TO_CLIS
   const tierPreferences: Record<ModelTier, CliName[]> = {
     fast: ['gemini', 'codex', 'claude'],
@@ -409,10 +426,11 @@ export function filterByDifficultyTier(candidates: CliName[], tier: ModelTier): 
   };
 
   const preferred = tierPreferences[tier];
-  // Sort candidates by tier preference order
+  // Sort candidates by tier preference order. Tier preference is slot-level;
+  // an api:* arm sorts by its display slot's position (#3422).
   const sortedCandidates = [...candidates].sort((a, b) => {
-    const aIndex = preferred.indexOf(a);
-    const bIndex = preferred.indexOf(b);
+    const aIndex = preferred.indexOf(routingArmDisplaySlot(a));
+    const bIndex = preferred.indexOf(routingArmDisplaySlot(b));
     // If not in preference list, put at end
     const aPos = aIndex === -1 ? preferred.length : aIndex;
     const bPos = bIndex === -1 ? preferred.length : bIndex;
@@ -427,14 +445,16 @@ export function filterByDifficultyTier(candidates: CliName[], tier: ModelTier): 
  */
 export function applyZeroRouterFilter(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   zeroRouter: IZeroRouter | undefined
 ): ZeroRouterStageResult {
   if (zeroRouter === undefined || candidates.length === 0) {
     return defaultZeroRouterStageResult(candidates);
   }
 
-  const decision = zeroRouter.routeByDifficulty(task, candidates);
+  // Difficulty estimation is slot-level; collapse arms to their display slot
+  // for the ZeroRouter call (we only read difficulty + tier back) (#3422).
+  const decision = zeroRouter.routeByDifficulty(task, candidates.map(routingArmDisplaySlot));
   const difficultyEstimate = decision.difficulty;
   const difficultyTier = decision.tier;
 
@@ -472,9 +492,9 @@ export function buildDifficultyOutcome(
  * Creates the routing decision result object.
  */
 export interface BuildDecisionContext {
-  selectedCli: CliName;
-  candidates: CliName[];
-  topsisRanking: CliName[];
+  selectedCli: RoutingArmId;
+  candidates: RoutingArmId[];
+  topsisRanking: RoutingArmId[];
   stagesExecuted: string[];
   decisionTimeMs: number;
   withinBudget: boolean | undefined;
@@ -493,7 +513,7 @@ export interface BuildDecisionContext {
 export function buildDecisionFields(ctx: BuildDecisionContext): {
   confidence: number;
   reason: string;
-  alternatives: CliName[];
+  alternatives: RoutingArmId[];
 } {
   const confidence = calculateConfidence(ctx.topsisScore, ctx.ucbScore, ctx.candidates.length);
   const reason = buildReason({
@@ -553,9 +573,9 @@ import type { CapacityStatus, ICliAdapter } from './types.js';
  * Returns a map of CLI name to capacity status.
  */
 export async function fetchCapacityData(
-  adapters: Map<CliName, ICliAdapter>
-): Promise<Map<CliName, CapacityStatus>> {
-  const result = new Map<CliName, CapacityStatus>();
+  adapters: Map<RoutingArmId, ICliAdapter>
+): Promise<Map<RoutingArmId, CapacityStatus>> {
+  const result = new Map<RoutingArmId, CapacityStatus>();
   const entries = [...adapters];
   const settled = await Promise.allSettled(entries.map(([, a]) => a.getCapacity()));
   for (const [idx, entry] of entries.entries()) {

--- a/packages/nexus-agents/src/cli-adapters/composite-router-metrics.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-metrics.ts
@@ -11,6 +11,7 @@
 import type { ILogger } from '../core/index.js';
 import { getTimeProvider, getRandomProvider } from '../core/index.js';
 import type { CliName } from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type {
   CompositeRoutingDecision,
   IRoutingMetricsCollector,
@@ -50,11 +51,15 @@ export function recordDecisionToMetrics(
 ): void {
   if (deps.metricsCollector === undefined) return;
 
+  // RoutingMetrics is slot-level; collapse the distinct arm (and its
+  // alternatives) to their display slots (#3422).
+  const selectedModel = routingArmDisplaySlot(decision.cliName);
+
   deps.metricsCollector.recordDecision({
     timestamp: getTimeProvider().nowIso(),
     traceId,
-    selectedModel: decision.cliName,
-    alternativeModels: decision.alternatives,
+    selectedModel,
+    alternativeModels: decision.alternatives.map(routingArmDisplaySlot),
     isExploration: decision.ucbScore !== undefined && decision.ucbScore > 0.5,
     taskType: decision.taskProfile.taskType,
     contextTokens: decision.taskProfile.contextRequired,
@@ -63,7 +68,7 @@ export function recordDecisionToMetrics(
 
   deps.logger.debug('Recorded routing decision to metrics', {
     traceId,
-    selectedModel: decision.cliName,
+    selectedModel,
   });
 }
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
@@ -10,7 +10,8 @@ import {
   taskAnalysisResultToBanditContext,
   getTimeProvider,
 } from '../core/index.js';
-import type { CliName, CliTask } from './types.js';
+import type { CliName, CliTask, RoutingArmId } from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type { LinUCBBandit } from './linucb-bandit.js';
 import type { PreferenceRouter } from './preference-router.js';
 import type { IZeroRouter } from './zero-router.js';
@@ -24,23 +25,23 @@ const sharedAnalyzer = createSharedTaskAnalyzer();
 /** Last routed task info for difficulty outcome recording. */
 export interface LastRoutedTaskInfo {
   task: CliTask;
-  selectedCli: CliName;
+  selectedCli: RoutingArmId;
   difficulty: number;
 }
 
 /** Dependencies required for outcome recording. */
 export interface OutcomeDependencies {
   logger: ILogger;
-  cliNames: CliName[];
+  cliNames: RoutingArmId[];
   linucbBandit: LinUCBBandit | undefined;
   preferenceRouter: PreferenceRouter | undefined;
   zeroRouter: IZeroRouter | undefined;
   lastRoutedTask: LastRoutedTaskInfo | undefined;
 }
 
-/** Records a bandit outcome for the given CLI. */
+/** Records a bandit outcome for the given routing arm (CLI slot or api:* arm). */
 export function recordBanditOutcome(
-  cliName: CliName,
+  cliName: RoutingArmId,
   task: CliTask,
   reward: number,
   deps: OutcomeDependencies
@@ -82,7 +83,7 @@ export function recordPreferenceSignal(
 export function getDifficultyInfo(
   task: CliTask,
   deps: OutcomeDependencies
-): { difficulty: number; selectedCli: CliName } {
+): { difficulty: number; selectedCli: RoutingArmId } {
   if (deps.lastRoutedTask?.task.content === task.content) {
     return {
       difficulty: deps.lastRoutedTask.difficulty,
@@ -111,7 +112,9 @@ export function recordZeroRouterOutcome(
   const outcome = buildDifficultyOutcome(
     task.content,
     difficulty,
-    selectedCli,
+    // Difficulty calibration is slot-level; collapse an api:* arm to its
+    // display slot here (the bandit retains the distinct arm). (#3422)
+    routingArmDisplaySlot(selectedCli),
     success,
     qualityScore
   );

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -15,7 +15,8 @@ import {
   getTuneAdjustmentStore,
 } from '../core/index.js';
 import { parseBoolEnv } from '../config/defaults-env.js';
-import type { CliName, CliTask } from './types.js';
+import type { CliName, RoutingArmId, CliTask } from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type { BudgetRouter } from './budget-router.js';
 import type { TopsisRouter } from './topsis-router.js';
 import type { LinUCBBandit } from './linucb-bandit.js';
@@ -58,11 +59,34 @@ import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 /** Module-level singleton — SharedTaskAnalyzer is stateless, no need to re-instantiate per call. */
 const sharedAnalyzer = createSharedTaskAnalyzer();
 
+/**
+ * Collapse a routing-arm candidate set to its unique display CLI slots (#3422).
+ * The RoutingContext-based stages (confidence-cascade, capability-match,
+ * quality-constraint, etc.) score/filter at slot granularity, so an api:* arm
+ * is represented by its vendor slot. De-duplicated to avoid double-scoring when
+ * both a CLI slot and its API arm are present.
+ */
+function armsToSlots(candidates: readonly RoutingArmId[]): CliName[] {
+  return [...new Set(candidates.map(routingArmDisplaySlot))];
+}
+
+/**
+ * Filter an arm candidate set down to those whose display slot survived a
+ * slot-level filter (#3422). Preserves the distinct api:* arms.
+ */
+function keepArmsForSlots(
+  candidates: readonly RoutingArmId[],
+  survivingSlots: readonly CliName[]
+): RoutingArmId[] {
+  const slotSet = new Set(survivingSlots);
+  return candidates.filter((arm) => slotSet.has(routingArmDisplaySlot(arm)));
+}
+
 /** Dependencies required for pipeline stage execution. */
 export interface StageDependencies {
   config: CompositeRouterConfigWithPreference;
   logger: ILogger;
-  cliNames: CliName[];
+  cliNames: RoutingArmId[];
   budgetRouter: BudgetRouter | undefined;
   zeroRouter: ZeroRouter | undefined;
   preferenceRouter: PreferenceRouter | undefined;
@@ -86,7 +110,7 @@ export interface StageDependencies {
 
 /** Result from budget stage including rejection tracking. */
 export interface BudgetStageResult {
-  candidates: CliName[];
+  candidates: RoutingArmId[];
   withinBudget: boolean | undefined;
   rejected: boolean;
 }
@@ -102,10 +126,13 @@ export function analyzeTaskProfile(task: CliTask, stagesExecuted: string[]): Tas
 /** Runs budget filtering stage. */
 export function runBudgetStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
-): Result<{ candidates: CliName[]; withinBudget: boolean | undefined }, CompositeRoutingError> {
+): Result<
+  { candidates: RoutingArmId[]; withinBudget: boolean | undefined },
+  CompositeRoutingError
+> {
   if (!deps.config.enableBudgetFilter || deps.budgetRouter === undefined) {
     return ok({ candidates, withinBudget: undefined });
   }
@@ -185,7 +212,7 @@ const DEFAULT_CASCADE_RESULT: ConfidenceCascadeStageResult = {
 /** Runs confidence cascade stage. (Issue #755, #1350) */
 export async function runConfidenceCascadeStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<ConfidenceCascadeStageResult> {
@@ -193,7 +220,7 @@ export async function runConfidenceCascadeStage(
     return DEFAULT_CASCADE_RESULT;
   }
 
-  const ctx = createRoutingContext(task.content, candidates);
+  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   const result = await deps.confidenceCascadeStage.route(ctx);
   stagesExecuted.push('confidence-cascade');
 
@@ -232,7 +259,7 @@ const DEFAULT_CAPABILITY_RESULT: CapabilityMatchStageResult = {
 /** Runs capability match stage. (Issue #755, #1350) */
 export async function runCapabilityMatchStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<CapabilityMatchStageResult> {
@@ -240,7 +267,7 @@ export async function runCapabilityMatchStage(
     return DEFAULT_CAPABILITY_RESULT;
   }
 
-  const ctx = createRoutingContext(task.content, candidates);
+  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   const result = await deps.capabilityMatchStage.route(ctx);
   stagesExecuted.push('capability-match');
 
@@ -264,14 +291,14 @@ export async function runCapabilityMatchStage(
 
 /** Quality constraint stage result. (Issue #755) */
 export interface QualityConstraintStageResult {
-  eligible: CliName[];
+  eligible: RoutingArmId[];
   filtered: Map<CliName, string>;
   usedFallback: boolean;
 }
 
 /** Runs quality constraint stage. (Issue #755, #1350) */
 export async function runQualityConstraintStage(
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<QualityConstraintStageResult> {
@@ -279,7 +306,9 @@ export async function runQualityConstraintStage(
     return { eligible: candidates, filtered: new Map(), usedFallback: false };
   }
 
-  const ctx = createRoutingContext('', candidates);
+  // Quality constraints are slot-level; collapse to slots for the stage, then
+  // keep the arms whose slot survived (#3422).
+  const ctx = createRoutingContext('', armsToSlots(candidates));
   const result = await deps.qualityConstraintStage.route(ctx);
   stagesExecuted.push('quality-constraint');
 
@@ -298,8 +327,8 @@ export async function runQualityConstraintStage(
     usedFallback,
   });
 
-  // If all candidates filtered, fall back to original set
-  const eligible = remaining.length > 0 ? remaining : candidates;
+  // If all slots filtered, fall back to original set
+  const eligible = remaining.length > 0 ? keepArmsForSlots(candidates, remaining) : candidates;
   return { eligible, filtered, usedFallback: remaining.length === 0 || usedFallback };
 }
 
@@ -320,7 +349,7 @@ const DEFAULT_RESOURCE_RESULT: ResourceStrategyStageResult = {
 /** Runs resource strategy stage. (Issue #998, #1350) */
 export async function runResourceStrategyStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<ResourceStrategyStageResult> {
@@ -328,7 +357,7 @@ export async function runResourceStrategyStage(
     return DEFAULT_RESOURCE_RESULT;
   }
 
-  const ctx = createRoutingContext(task.content, candidates);
+  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   const result = await deps.resourceStrategyStage.route(ctx);
   stagesExecuted.push('resource-strategy');
 
@@ -354,7 +383,7 @@ export interface DistilledRuleStageResult {
 /** Runs distilled rule stage. (Issue #999, #1350) */
 export async function runDistilledRuleStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<DistilledRuleStageResult> {
@@ -362,7 +391,7 @@ export async function runDistilledRuleStage(
     return { scores: new Map(), rulesApplied: 0 };
   }
 
-  const ctx = createRoutingContext(task.content, candidates);
+  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   const result = await deps.distilledRuleStage.route(ctx);
   stagesExecuted.push('distilled-rule');
 
@@ -388,7 +417,7 @@ export interface KnnRoutingStageResult {
 /** Runs KNN experience-based routing stage. (arXiv:2505.12601) */
 export async function runKnnRoutingStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<KnnRoutingStageResult> {
@@ -396,7 +425,7 @@ export async function runKnnRoutingStage(
     return { scores: new Map(), hasExperience: false };
   }
 
-  const ctx = createRoutingContext(task.content, candidates);
+  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   const result = await deps.knnRoutingStage.route(ctx);
   stagesExecuted.push('knn-routing');
 
@@ -416,7 +445,7 @@ export async function runKnnRoutingStage(
 /** Runs ZeroRouter difficulty estimation stage. */
 export function runZeroRouterStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): ZeroRouterStageResult {
@@ -470,14 +499,14 @@ function getPerformanceDataForCategory(taskContent: string): Map<CliName, Perfor
  * When performance floor data is available, penalizes underperforming CLIs. (#1401) */
 export function runTopsisStage(
   taskProfile: TaskProfile,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies,
   options?: {
     stageScores?: ReadonlyMap<CliName, number>;
     performanceData?: ReadonlyMap<CliName, PerformanceFloorEntry>;
   }
-): { ranking: CliName[]; score: number | undefined } {
+): { ranking: RoutingArmId[]; score: number | undefined } {
   if (!deps.config.enableTopsisRanking || deps.topsisRouter === undefined) {
     return { ranking: candidates, score: undefined };
   }
@@ -495,17 +524,18 @@ export function runTopsisStage(
 /** Runs LinUCB bandit selection stage. */
 export function runLinUCBStage(
   taskProfile: TaskProfile,
-  topsisRanking: CliName[],
+  topsisRanking: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
-): { selectedCli: CliName | undefined; ucbScore: number | undefined } {
+): { selectedCli: RoutingArmId | undefined; ucbScore: number | undefined } {
   if (!deps.config.enableLinUCBSelection || deps.linucbBandit === undefined) {
     return { selectedCli: topsisRanking[0], ucbScore: undefined };
   }
   const banditContext = taskProfileToBanditContext(taskProfile);
   const selection = deps.linucbBandit.select(banditContext);
   stagesExecuted.push('linucb-selection');
-  const picked = selection.armName as CliName;
+  // armName is the routing arm id — a CLI slot or a distinct api:* arm (#3422).
+  const picked = selection.armName as RoutingArmId;
   // #3111: LinUCB.select() ranks over ALL registered arms, ignoring the
   // already-filtered candidate set. Constrain the pick to topsisRanking so a
   // fail-closed category override (e.g. security_review → [codex]) or a
@@ -521,7 +551,7 @@ export function runLinUCBStage(
 /** Runs preference routing stage. */
 export function runPreferenceStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): PreferenceStageResult {
@@ -553,12 +583,12 @@ export function runPreferenceStage(
 /** Latency scoring stage result. (Issue #361) */
 export interface LatencyStageResult {
   latencyScore: number | undefined;
-  latencyAdjustedRanking: CliName[];
+  latencyAdjustedRanking: RoutingArmId[];
 }
 
 /** Runs latency scoring stage. (Issue #361) */
 export function runLatencyStage(
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): LatencyStageResult {
@@ -566,17 +596,21 @@ export function runLatencyStage(
     return { latencyScore: undefined, latencyAdjustedRanking: candidates };
   }
 
-  const scores = deps.latencyTracker.getScores(candidates);
+  // Latency is tracked per slot; collapse arms and let an api:* arm sort by
+  // its display slot's latency score (#3422).
+  const scores = deps.latencyTracker.getScores(armsToSlots(candidates));
   stagesExecuted.push('latency-scoring');
+  const scoreOf = (arm: RoutingArmId): number =>
+    scores.find((s) => s.cli === routingArmDisplaySlot(arm))?.score ?? 0;
 
   // Sort candidates by latency score (higher is better/faster)
-  const sortedCandidates = [...candidates].sort((a, b) => {
-    const scoreA = scores.find((s) => s.cli === a)?.score ?? 0;
-    const scoreB = scores.find((s) => s.cli === b)?.score ?? 0;
-    return scoreB - scoreA;
-  });
+  const sortedCandidates = [...candidates].sort((a, b) => scoreOf(b) - scoreOf(a));
 
-  const topScore = scores.find((s) => s.cli === sortedCandidates[0])?.score;
+  const topArm = sortedCandidates[0];
+  const topScore =
+    topArm !== undefined
+      ? scores.find((s) => s.cli === routingArmDisplaySlot(topArm))?.score
+      : undefined;
 
   deps.logger.debug('Latency scoring applied', {
     scores: scores.map((s) => ({
@@ -602,7 +636,7 @@ export interface RoutingMemoryStageResult {
 /** Runs routing memory stage to get learned recommendation. (Issue #489) */
 export function runRoutingMemoryStage(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): RoutingMemoryStageResult {
@@ -611,10 +645,12 @@ export function runRoutingMemoryStage(
   }
 
   const taskType = inferTaskTypeFromContent(task.content);
+  // Routing memory is a slot-level secondary learner; its recommendation is a
+  // CLI slot, matched against the candidates' display slots (#3422).
   const recommendation = deps.routingMemory.getRecommendation(taskType);
   stagesExecuted.push('routing-memory');
 
-  if (recommendation !== undefined && candidates.includes(recommendation)) {
+  if (recommendation !== undefined && armsToSlots(candidates).includes(recommendation)) {
     deps.logger.debug('Routing memory recommendation', {
       taskType,
       recommended: recommendation,
@@ -666,7 +702,7 @@ function mergeScoreMaps(
 /** Runs scoring stages (priorities 10-55) and returns intermediate results. */
 async function runScoringStages(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<{
@@ -678,7 +714,7 @@ async function runScoringStages(
   distilledResult: DistilledRuleStageResult;
   prefResult: PreferenceStageResult;
   resourceResult: ResourceStrategyStageResult;
-  candidates: CliName[];
+  candidates: RoutingArmId[];
 }> {
   const cascadeResult = await runConfidenceCascadeStage(task, candidates, stagesExecuted, deps);
   const memoryResult = runRoutingMemoryStage(task, candidates, stagesExecuted, deps);
@@ -707,9 +743,10 @@ async function runScoringStages(
 function aggregateStageScores(
   scoring: Awaited<ReturnType<typeof runScoringStages>>,
   taskContent: string,
-  candidates: readonly CliName[]
+  candidates: readonly RoutingArmId[]
 ): Map<CliName, number> {
   const weatherScores = getWeatherBonusForTask(taskContent);
+  // Tune adjustments are slot-keyed; collapse arms to display slots (#3422).
   return mergeScoreMaps(
     scoring.cascadeResult.scores,
     scoring.capResult.scores,
@@ -717,7 +754,7 @@ function aggregateStageScores(
     scoring.distilledResult.scores,
     scoring.resourceResult.scores,
     weatherScores,
-    getTuneAdjustmentScores(candidates)
+    getTuneAdjustmentScores(armsToSlots([...candidates]))
   );
 }
 
@@ -768,12 +805,12 @@ function getWeatherBonusForTask(taskContent: string): Map<CliName, number> {
 
 /** Apply quality constraints and return filtered candidates or error (#1686). */
 async function applyQualityConstraints(
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[],
   deps: StageDependencies
 ): Promise<
   Result<
-    { candidates: CliName[]; qualityResult: QualityConstraintStageResult },
+    { candidates: RoutingArmId[]; qualityResult: QualityConstraintStageResult },
     CompositeRoutingError
   >
 > {
@@ -808,16 +845,22 @@ async function applyQualityConstraints(
  */
 function applyCategoryOverride(
   task: CliTask,
-  candidates: CliName[],
+  candidates: RoutingArmId[],
   stagesExecuted: string[]
-): Result<CliName[], CompositeRoutingError> {
+): Result<RoutingArmId[], CompositeRoutingError> {
   const match = detectTaskCategory(task.content);
   if (match === null) return ok(candidates);
   const override = CATEGORY_CHAIN_OVERRIDES[match.category];
   if (override === undefined) return ok(candidates);
 
-  const candidateSet = new Set(candidates);
-  const filtered = override.filter((cli) => candidateSet.has(cli));
+  // Override chains are slot-level (#3422). Keep arms whose display slot is in
+  // the override chain, preserving the chain's slot order (an api:* arm follows
+  // its vendor slot's position).
+  const overrideSet = new Set(override);
+  const orderIndex = (arm: RoutingArmId): number => override.indexOf(routingArmDisplaySlot(arm));
+  const filtered = candidates
+    .filter((arm) => overrideSet.has(routingArmDisplaySlot(arm)))
+    .sort((a, b) => orderIndex(a) - orderIndex(b));
 
   if (filtered.length === 0) {
     if (isCategoryFailClosed(match.category)) {
@@ -844,16 +887,18 @@ function applyCategoryOverride(
 
 /** Override LinUCB selection if the chosen CLI is below performance floor (#1790). */
 function applyLinUCBFloorOverride(
-  linucbCli: CliName,
-  topsisRanking: CliName[],
+  linucbCli: RoutingArmId,
+  topsisRanking: RoutingArmId[],
   opts: {
     perfData?: ReadonlyMap<CliName, PerformanceFloorEntry> | undefined;
     taskType: string;
     stagesExecuted: string[];
   }
-): CliName {
+): RoutingArmId {
   if (opts.perfData === undefined) return linucbCli;
-  const cliPerf = opts.perfData.get(linucbCli);
+  // Performance-floor data is slot-keyed; an api:* arm is judged on its
+  // display slot's success rate (#3422).
+  const cliPerf = opts.perfData.get(routingArmDisplaySlot(linucbCli));
   if (cliPerf === undefined || cliPerf.sampleCount < 20 || cliPerf.successRate >= 0.5) {
     return linucbCli;
   }
@@ -869,10 +914,10 @@ export async function runPipeline(
   task: CliTask,
   taskProfile: TaskProfile,
   stagesExecuted: string[],
-  cliNames: CliName[],
+  cliNames: RoutingArmId[],
   deps: StageDependencies
 ): Promise<Result<PipelineResult, CompositeRoutingError>> {
-  let candidates: CliName[] = [...cliNames];
+  let candidates: RoutingArmId[] = [...cliNames];
   if (candidates.length === 0) {
     return err(new CompositeRoutingError('No CLI adapters available', 'initialization'));
   }
@@ -945,12 +990,12 @@ interface PipelineResultParams {
   qualityResult: QualityConstraintStageResult;
   zeroResult: ZeroRouterStageResult;
   prefResult: PreferenceStageResult;
-  topsisResult: { ranking: CliName[]; score: number | undefined };
+  topsisResult: { ranking: RoutingArmId[]; score: number | undefined };
   linucbResult: { ucbScore: number | undefined };
   latencyResult: LatencyStageResult;
   memoryResult: RoutingMemoryStageResult;
   withinBudget: boolean | undefined;
-  selectedCli: CliName;
+  selectedCli: RoutingArmId;
 }
 
 /** Assemble PipelineResult from stage outputs, including async stage scores. */
@@ -992,10 +1037,10 @@ function buildPipelineResult(p: PipelineResultParams): PipelineResult {
 
 /** Select CLI with optional memory influence. (Issue #489) */
 function selectWithMemoryInfluence(
-  linucbSelection: CliName,
+  linucbSelection: RoutingArmId,
   memoryResult: RoutingMemoryStageResult,
   deps: StageDependencies
-): CliName {
+): RoutingArmId {
   // If routing memory has a high-confidence recommendation, use it.
   // Threshold must exceed the default memoryConfidence (0.8) to prevent
   // routing memory from always overriding LinUCB learning. (#1171)

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -8,7 +8,7 @@
  */
 
 import { z } from 'zod';
-import type { ICliAdapter, CliName } from './types.js';
+import type { ICliAdapter, CliName, RoutingArmId } from './types.js';
 import type { TaskProfile } from '../core/index.js';
 import type { PreferenceRouterConfig } from './preference-router-types.js';
 import type { ZeroRouterConfig, DifficultyEstimate, ModelTier } from './zero-router-types.js';
@@ -162,8 +162,8 @@ export const DEFAULT_COMPOSITE_CONFIG: CompositeRouterConfig = {
 export interface CompositeRoutingDecision {
   /** Selected CLI adapter */
   readonly adapter: ICliAdapter;
-  /** Selected CLI name */
-  readonly cliName: CliName;
+  /** Selected routing arm — a CLI slot or a distinct `api:*` arm (#3422). */
+  readonly cliName: RoutingArmId;
   /**
    * Concrete model selected by difficulty tier (#3394). Present only when
    * route-time model selection is enabled (NEXUS_ROUTE_MODEL_SELECTION).
@@ -195,7 +195,7 @@ export interface CompositeRoutingDecision {
   /** Latency score (if latency tracking enabled) (Issue #361) */
   readonly latencyScore?: number | undefined;
   /** Alternative adapters in ranked order */
-  readonly alternatives: readonly CliName[];
+  readonly alternatives: readonly RoutingArmId[];
   /** Task analysis used for routing */
   readonly taskProfile: TaskProfile;
 }
@@ -248,19 +248,19 @@ export interface CompositeRouterStats {
  * Internal pipeline result type.
  */
 export interface PipelineResult {
-  candidates: CliName[];
+  candidates: RoutingArmId[];
   withinBudget: boolean | undefined;
   difficultyEstimate: DifficultyEstimate | undefined;
   difficultyTier: ModelTier | undefined;
   preferenceScore: number | undefined;
   preferenceTier: 'strong' | 'weak' | undefined;
-  topsisRanking: CliName[];
+  topsisRanking: RoutingArmId[];
   topsisScore: number | undefined;
-  selectedCli: CliName;
+  selectedCli: RoutingArmId;
   ucbScore: number | undefined;
   latencyScore: number | undefined;
   /** Routing memory recommendation (Issue #489) */
-  memoryRecommendation: CliName | undefined;
+  memoryRecommendation: RoutingArmId | undefined;
   /** Routing memory confidence (Issue #489) */
   memoryConfidence: number | undefined;
   /** Aggregated scores from async routing stages (Issue #1350) */
@@ -282,9 +282,9 @@ export interface PipelineResult {
  */
 export interface BuildDecisionParams {
   taskProfile: TaskProfile;
-  selectedCli: CliName;
-  candidates: CliName[];
-  topsisRanking: CliName[];
+  selectedCli: RoutingArmId;
+  candidates: RoutingArmId[];
+  topsisRanking: RoutingArmId[];
   stagesExecuted: string[];
   startTime: number;
   withinBudget: boolean | undefined;

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -365,6 +365,25 @@ describe('CompositeRouter distinct API routing arms (#3422)', () => {
     expect(pullCount(after, 'claude')).toBe(claudeBefore);
   });
 
+  it('selects an api:* arm end-to-end and returns it as decision.cliName', async () => {
+    // A single registered arm forces the pipeline to select it — proving the
+    // api:* arm survives the full ranking/selection round-trip (TOPSIS ranking +
+    // LinUCB `armName`) as decision.cliName, not just direct recordOutcome.
+    const adapters = new Map<RoutingArmId, ICliAdapter>([['api:anthropic', createArmAdapter()]]);
+    const router = new CompositeRouter(adapters);
+
+    const result = await router.route({ content: 'Implement a feature' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.cliName).toBe('api:anthropic');
+    }
+    // Stats still collapse to the display slot — no api:* key leaks in.
+    const stats = router.getStats();
+    expect(Object.keys(stats.decisionsPerCli)).not.toContain('api:anthropic');
+    expect(stats.decisionsPerCli.claude).toBe(1);
+  });
+
   it('keeps decisionsPerCli slot-keyed (no api:* key leaks in)', async () => {
     const adapters = new Map<RoutingArmId, ICliAdapter>([
       ['claude', createArmAdapter()],

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -12,7 +12,7 @@ import {
   CompositeRouterConfigSchema,
   CompositeRoutingError,
 } from './composite-router.js';
-import type { ICliAdapter, CliTask, CliName } from './types.js';
+import type { ICliAdapter, CliTask, CliName, RoutingArmId } from './types.js';
 import {
   AvailableModelsCache,
   getDefaultAvailableModelsCache,
@@ -323,6 +323,65 @@ describe('CompositeRouter', () => {
         stats.decisionsPerCli.claude + stats.decisionsPerCli.gemini + stats.decisionsPerCli.codex;
       expect(totalPerCli).toBe(3);
     });
+  });
+});
+
+describe('CompositeRouter distinct API routing arms (#3422)', () => {
+  /**
+   * Mock adapter for a routing arm. Its display `name` is always a CLI slot
+   * (api:anthropic's adapter displays as `claude`), matching ModelToCliAdapter;
+   * the DISTINCT arm id lives in the router's adapter-Map key, not here.
+   */
+  function createArmAdapter(): ICliAdapter {
+    return { ...createMockAdapter('claude'), name: 'claude' };
+  }
+
+  function pullCount(stats: ReturnType<CompositeRouter['getStats']>, arm: RoutingArmId): number {
+    return stats.banditStats.find((s) => s.name === arm)?.pullCount ?? 0;
+  }
+
+  it('records an api:* outcome on a DISTINCT bandit arm, leaving the CLI slot untouched', () => {
+    const adapters = new Map<RoutingArmId, ICliAdapter>([
+      ['claude', createArmAdapter()],
+      ['api:anthropic', createArmAdapter()],
+    ]);
+    const router = new CompositeRouter(adapters);
+    const task: CliTask = { content: 'Implement a feature' };
+
+    const before = router.getStats();
+    const claudeBefore = pullCount(before, 'claude');
+    const apiBefore = pullCount(before, 'api:anthropic');
+
+    // Both arms are registered distinctly in the bandit.
+    expect(before.banditStats.map((s) => s.name)).toEqual(
+      expect.arrayContaining(['claude', 'api:anthropic'])
+    );
+
+    router.recordOutcome('api:anthropic', task, 0.9);
+
+    const after = router.getStats();
+    // The api:* arm learned distinctly; the claude CLI arm is unaffected.
+    expect(pullCount(after, 'api:anthropic')).toBe(apiBefore + 1);
+    expect(pullCount(after, 'claude')).toBe(claudeBefore);
+  });
+
+  it('keeps decisionsPerCli slot-keyed (no api:* key leaks in)', async () => {
+    const adapters = new Map<RoutingArmId, ICliAdapter>([
+      ['claude', createArmAdapter()],
+      ['api:anthropic', createArmAdapter()],
+    ]);
+    const router = new CompositeRouter(adapters);
+    await router.route({ content: 'Test task' });
+
+    const stats = router.getStats();
+    expect(Object.keys(stats.decisionsPerCli)).not.toContain('api:anthropic');
+    // Exactly one decision recorded, attributed to a CLI slot.
+    const total =
+      stats.decisionsPerCli.claude +
+      stats.decisionsPerCli.gemini +
+      stats.decisionsPerCli.codex +
+      stats.decisionsPerCli.opencode;
+    expect(total).toBe(1);
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -37,7 +37,15 @@ import {
 } from '../core/index.js';
 
 import type { ILogger } from '../core/index.js';
-import type { ICliAdapter, CliName, CliTask, CliResponse, CliError } from './types.js';
+import type {
+  ICliAdapter,
+  CliName,
+  RoutingArmId,
+  CliTask,
+  CliResponse,
+  CliError,
+} from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type {
   IOrchestrationObserver,
   RoutingDecision,
@@ -142,7 +150,8 @@ const DEFAULT_TOKEN_ESTIMATE = 1000;
 export interface ICompositeRouter {
   route(task: CliTask): Promise<Result<CompositeRoutingDecision, CompositeRoutingError>>;
   executeTask(task: CliTask): Promise<Result<CliResponse, CliError | CompositeRoutingError>>;
-  recordOutcome(cliName: CliName, task: CliTask, reward: number): void;
+  /** Record a bandit outcome for a distinct routing arm (CLI slot or api:* arm) (#3422). */
+  recordOutcome(cliName: RoutingArmId, task: CliTask, reward: number): void;
   recordPreference(
     query: string,
     strongPreferred: boolean,
@@ -158,15 +167,15 @@ export interface ICompositeRouter {
   getMetricsCollector(): IRoutingMetricsCollector | undefined;
   /** Get the orchestration observer (if configured) (Issue #587) */
   getOrchestrationObserver(): IOrchestrationObserver | undefined;
-  /** Get capacity status for all registered CLIs (Issue #807) */
-  getCapacityDashboard(): Promise<Map<CliName, import('./types.js').CapacityStatus>>;
+  /** Get capacity status for all registered routing arms (Issue #807, #3422) */
+  getCapacityDashboard(): Promise<Map<RoutingArmId, import('./types.js').CapacityStatus>>;
 }
 
 /** CompositeRouter implementation. */
 export class CompositeRouter implements ICompositeRouter {
   private readonly config: CompositeRouterConfig;
   private readonly logger: ILogger;
-  private readonly adapters: Map<CliName, ICliAdapter>;
+  private readonly adapters: Map<RoutingArmId, ICliAdapter>;
   private budgetRouter?: BudgetRouter;
   private zeroRouter?: ZeroRouter;
   private preferenceRouter?: PreferenceRouter;
@@ -201,7 +210,7 @@ export class CompositeRouter implements ICompositeRouter {
   private knnRoutingStage?: KnnRoutingStage;
   /** Strategy distiller instance (Issue #999) */
   private strategyDistiller?: StrategyDistiller;
-  private readonly cliNames: CliName[];
+  private readonly cliNames: RoutingArmId[];
   /**
    * (#2540 PR 7) Optional harness-driven availability gate. When set,
    * `executeRouting` filters the candidate CLI list to only those with
@@ -227,7 +236,7 @@ export class CompositeRouter implements ICompositeRouter {
   private lastTraceId?: string;
 
   constructor(
-    adapters: Map<CliName, ICliAdapter>,
+    adapters: Map<RoutingArmId, ICliAdapter>,
     config?: Partial<CompositeRouterConfigWithPreference>,
     logger?: ILogger
   ) {
@@ -281,7 +290,7 @@ export class CompositeRouter implements ICompositeRouter {
   }
 
   private initializeCoreRouters(
-    adapters: Map<CliName, ICliAdapter>,
+    adapters: Map<RoutingArmId, ICliAdapter>,
     preferenceConfig?: Partial<PreferenceRouterConfig>,
     zeroConfig?: Partial<ZeroRouterConfig>,
     latencyConfig?: Partial<LatencyTrackerConfig>
@@ -524,16 +533,22 @@ export class CompositeRouter implements ICompositeRouter {
     success: boolean,
     durationMs: number
   ): void {
+    // The bandit learns the DISTINCT arm; everything slot-level (quality
+    // reward, latency, routing memory, metrics) collapses to the display
+    // slot so CLI and API telemetry stay attributed to the vendor (#3422).
+    const arm = decision.cliName;
+    const slot = routingArmDisplaySlot(arm);
+
     // Record bandit outcome with quality-enriched reward (Issue #929)
-    const reward = computeQualityReward(decision.cliName, success, durationMs);
-    this.recordOutcome(decision.cliName, task, reward);
+    const reward = computeQualityReward(slot, success, durationMs);
+    this.recordOutcome(arm, task, reward);
 
     // Record difficulty outcome for ZeroRouter learning
     this.recordDifficultyOutcome(task, success);
 
     // Record latency for latency-based routing (Issue #361)
     if (this.latencyTracker !== undefined) {
-      this.latencyTracker.record(decision.cliName, durationMs, success);
+      this.latencyTracker.record(slot, durationMs, success);
     }
 
     // Record performance in routing memory for learned routing (Issue #463)
@@ -546,7 +561,7 @@ export class CompositeRouter implements ICompositeRouter {
         avgTokens: task.maxTokens ?? DEFAULT_TOKEN_ESTIMATE,
         observations: 1,
       };
-      this.routingMemory.storePreference(decision.cliName, taskType, performance);
+      this.routingMemory.storePreference(slot, taskType, performance);
     }
 
     // Record outcome to metrics collector (Issue #559)
@@ -554,7 +569,7 @@ export class CompositeRouter implements ICompositeRouter {
       recordOutcomeToMetrics(
         {
           traceId: this.lastTraceId,
-          cliName: decision.cliName,
+          cliName: slot,
           success,
           reward,
           qualityScore: success ? decision.confidence : FAILURE_QUALITY_SCORE,
@@ -565,7 +580,7 @@ export class CompositeRouter implements ICompositeRouter {
     }
 
     this.logger.debug('Auto-recorded feedback', {
-      cli: decision.cliName,
+      cli: arm,
       success,
       durationMs,
       reward,
@@ -641,13 +656,17 @@ export class CompositeRouter implements ICompositeRouter {
    *     so the router never wedges on a transient cache miss.
    *   - Errors in the cache do not block routing — log and fall through.
    */
-  private async getCandidateCliNames(): Promise<CliName[]> {
+  private async getCandidateCliNames(): Promise<RoutingArmId[]> {
     if (this.availableModelsCache === undefined) return this.cliNames;
     try {
       const all = await this.availableModelsCache.getAll();
       if (all.length === 0) return this.cliNames;
       const sourcesWithModels = new Set(all.map((m) => m.source));
-      const filtered = this.cliNames.filter((name) => sourcesWithModels.has(name));
+      // Availability is tracked per CLI source/slot; an api:* arm is gated on
+      // its display slot's source (#3422).
+      const filtered = this.cliNames.filter((name) =>
+        sourcesWithModels.has(routingArmDisplaySlot(name))
+      );
       // Guard against fully empty filter — never let the gate wedge routing.
       return filtered.length > 0 ? filtered : this.cliNames;
     } catch (e: unknown) {
@@ -717,9 +736,11 @@ export class CompositeRouter implements ICompositeRouter {
     // #3394: pick a concrete model from the difficulty tier (opt-in, default
     // OFF). Registry-only + synchronous — no probe on the hot path. Consumers
     // fall back to getDefaultModelForCli when absent.
+    // Concrete model resolution is registry/slot-level; collapse an api:* arm
+    // to its display slot for the lookup (#3422).
     const model =
       isRouteModelSelectionEnabled() && params.difficultyTier !== undefined
-        ? resolveModelForTier(params.selectedCli, params.difficultyTier)
+        ? resolveModelForTier(routingArmDisplaySlot(params.selectedCli), params.difficultyTier)
         : undefined;
 
     return ok({
@@ -743,9 +764,11 @@ export class CompositeRouter implements ICompositeRouter {
     });
   }
 
-  private updateStats(selectedCli: CliName, decisionTimeMs: number): void {
+  private updateStats(selectedCli: RoutingArmId, decisionTimeMs: number): void {
     this.totalDecisions++;
-    this.decisionsPerCli[selectedCli]++;
+    // decisionsPerCli stays slot-keyed; an api:* arm increments its display
+    // slot's counter so no api:* key ever enters the record (#3422).
+    this.decisionsPerCli[routingArmDisplaySlot(selectedCli)]++;
     this.totalDecisionTimeMs += decisionTimeMs;
   }
 
@@ -757,16 +780,18 @@ export class CompositeRouter implements ICompositeRouter {
       return;
     }
 
-    // Convert CompositeRoutingDecision to RoutingDecision for observer
+    // Convert CompositeRoutingDecision to RoutingDecision for observer.
+    // The observer is slot-level; collapse the distinct arm + alternatives to
+    // their display slots (#3422).
     const routingDecision: RoutingDecision = {
       timestamp: new Date().toISOString(),
       taskId: `task-${getRandomProvider().uuid()}`,
       taskDescription:
         task.content.length > 100 ? task.content.substring(0, 100) + '...' : task.content,
-      selectedCli: decision.cliName,
+      selectedCli: routingArmDisplaySlot(decision.cliName),
       confidence: decision.confidence,
       reason: decision.reason,
-      alternatives: decision.alternatives,
+      alternatives: decision.alternatives.map(routingArmDisplaySlot),
       stagesExecuted: decision.stagesExecuted,
       decisionTimeMs: decision.decisionTimeMs,
       withinBudget: decision.withinBudget,
@@ -790,7 +815,7 @@ export class CompositeRouter implements ICompositeRouter {
     return err(new CompositeRoutingError(msg, stage, error instanceof Error ? error : undefined));
   }
 
-  recordOutcome(cliName: CliName, task: CliTask, reward: number): void {
+  recordOutcome(cliName: RoutingArmId, task: CliTask, reward: number): void {
     recordBanditOutcome(cliName, task, reward, this.getOutcomeDependencies());
   }
 
@@ -848,7 +873,7 @@ export class CompositeRouter implements ICompositeRouter {
   /**
    * Get capacity status for all registered CLIs (Issue #807).
    */
-  async getCapacityDashboard(): Promise<Map<CliName, import('./types.js').CapacityStatus>> {
+  async getCapacityDashboard(): Promise<Map<RoutingArmId, import('./types.js').CapacityStatus>> {
     return fetchCapacityData(this.adapters);
   }
 
@@ -885,7 +910,7 @@ export class CompositeRouter implements ICompositeRouter {
 
 /** Creates a CompositeRouter instance. */
 export function createCompositeRouter(
-  adapters: Map<CliName, ICliAdapter>,
+  adapters: Map<RoutingArmId, ICliAdapter>,
   config?: Partial<CompositeRouterConfigWithPreference>,
   logger?: ILogger
 ): ICompositeRouter {

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -303,6 +303,10 @@ export class CompositeRouter implements ICompositeRouter {
       this.preferenceRouter = new PreferenceRouter(preferenceConfig);
     if (this.config.enableTopsisRanking) this.topsisRouter = new TopsisRouter();
     if (this.config.enableLinUCBSelection && this.cliNames.length > 0) {
+      // Arms include distinct api:* arms (#3422). Persisted outcomes/priors are
+      // slot-attributed, so api:* arms start cold and gain no warm-start credit
+      // by design — do NOT collapse the arm names here, that would destroy the
+      // CLI-vs-API distinct learning this migration exists to enable.
       this.linucbBandit = new LinUCBBandit(this.cliNames, { alpha: this.config.linucbAlpha });
       this.warmStartBandit();
     }
@@ -369,7 +373,9 @@ export class CompositeRouter implements ICompositeRouter {
       type: 'routing.decision',
       timestamp: getTimeProvider().now(),
       taskId: taskDescription.slice(0, 100),
-      selectedModel: decision.cliName,
+      // Trace attribution is slot-level; collapse the api:* arm (#3422) so this
+      // sink matches every other telemetry sink (the bandit keeps the arm).
+      selectedModel: routingArmDisplaySlot(decision.cliName),
       reasoning: decision.reason,
       decisionPath: decision.stagesExecuted,
     });

--- a/packages/nexus-agents/src/cli-adapters/factory.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.test.ts
@@ -4,7 +4,7 @@
  * Verifies factory functions create correct adapter types.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { createCliAdapter, createAllAdapters } from './factory.js';
 import { ClaudeCliAdapter } from './adapters/claude-adapter.js';
 import { GeminiCliAdapter } from './adapters/gemini-adapter.js';
@@ -131,6 +131,49 @@ describe('createAllAdapters', () => {
     const adapters = createAllAdapters(undefined);
 
     expect(adapters.size).toBe(CLI_NAMES.length);
+  });
+
+  // #3422: direct-API adapters become distinct routing arms only in api
+  // billing mode with the vendor key present.
+  describe('API routing arms (#3422)', () => {
+    const prevBilling = process.env['NEXUS_BILLING_MODE'];
+    const prevKey = process.env['ANTHROPIC_API_KEY'];
+
+    afterEach(() => {
+      if (prevBilling === undefined) delete process.env['NEXUS_BILLING_MODE'];
+      else process.env['NEXUS_BILLING_MODE'] = prevBilling;
+      if (prevKey === undefined) delete process.env['ANTHROPIC_API_KEY'];
+      else process.env['ANTHROPIC_API_KEY'] = prevKey;
+    });
+
+    it('includes api:anthropic when NEXUS_BILLING_MODE=api and ANTHROPIC_API_KEY is set', () => {
+      process.env['NEXUS_BILLING_MODE'] = 'api';
+      process.env['ANTHROPIC_API_KEY'] = 'sk-test-key';
+
+      const adapters = createAllAdapters();
+      expect(adapters.has('api:anthropic')).toBe(true);
+      // CLI slots still present alongside the API arm.
+      for (const cli of CLI_NAMES) {
+        expect(adapters.has(cli)).toBe(true);
+      }
+    });
+
+    it('omits api:anthropic in default (plan) mode even with the key set', () => {
+      delete process.env['NEXUS_BILLING_MODE'];
+      process.env['ANTHROPIC_API_KEY'] = 'sk-test-key';
+
+      const adapters = createAllAdapters();
+      expect(adapters.has('api:anthropic')).toBe(false);
+      expect(adapters.size).toBe(CLI_NAMES.length);
+    });
+
+    it('omits api:anthropic in api mode when the key is absent', () => {
+      process.env['NEXUS_BILLING_MODE'] = 'api';
+      delete process.env['ANTHROPIC_API_KEY'];
+
+      const adapters = createAllAdapters();
+      expect(adapters.has('api:anthropic')).toBe(false);
+    });
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/factory.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.ts
@@ -9,8 +9,9 @@
  * (Source: Issue #165 - CLI detection cache)
  */
 
-import type { ICliAdapter, CliName, CliTransport } from './types.js';
+import type { ICliAdapter, CliName, RoutingArmId, CliTransport } from './types.js';
 import { getTimeProvider } from '../core/index.js';
+import { collectApiRoutingArms } from '../adapters/auto-adapter.js';
 import { ClaudeCliAdapter } from './adapters/claude-adapter.js';
 import { GeminiCliAdapter } from './adapters/gemini-adapter.js';
 import { CodexCliAdapter } from './adapters/codex-adapter.js';
@@ -94,24 +95,38 @@ function createCodexAdapter(
 }
 
 /**
- * Creates all available CLI adapters.
+ * Creates all available routing-arm adapters.
  * Uses MCP transport for Codex by default (preferred).
+ *
+ * The four CLI slots are always registered under their slot key. When
+ * `NEXUS_BILLING_MODE=api`, the direct-API adapters whose keys are present are
+ * ALSO appended as distinct `api:<vendor>` routing arms (#3422) so the router /
+ * bandit can score them separately from the CLI slots. DEFAULT (plan) mode
+ * returns CLIs only — never surprise API spend. Key-presence-only and
+ * deterministic; keys are never validated by calling out.
  *
  * @param logger - Optional shared logger
  * @param codexTransport - Transport for Codex (default: 'mcp')
- * @returns Map of CLI name to adapter
+ * @returns Map of routing arm id to adapter
  */
 export function createAllAdapters(
   logger?: ILogger,
   codexTransport: CliTransport = 'mcp'
-): Map<CliName, ICliAdapter> {
-  const adapters = new Map<CliName, ICliAdapter>();
+): Map<RoutingArmId, ICliAdapter> {
+  const adapters = new Map<RoutingArmId, ICliAdapter>();
   const options = logger !== undefined ? { logger } : undefined;
 
   adapters.set('claude', new ClaudeCliAdapter(options));
   adapters.set('gemini', new GeminiCliAdapter(options));
   adapters.set('codex', createCodexAdapter(codexTransport, options ?? {}));
   adapters.set('opencode', new OpenCodeCliAdapter(options));
+
+  // API arms enter the router only in explicit api billing mode (#3422).
+  if (process.env['NEXUS_BILLING_MODE'] === 'api') {
+    for (const { armId, adapter } of collectApiRoutingArms(logger)) {
+      adapters.set(armId, adapter);
+    }
+  }
 
   return adapters;
 }

--- a/packages/nexus-agents/src/cli-adapters/index.ts
+++ b/packages/nexus-agents/src/cli-adapters/index.ts
@@ -27,9 +27,13 @@ export type {
   ICliAdapter,
   ICliResponseParser,
   VersionRequirements,
+  ApiVendor,
+  ApiArmId,
+  RoutingArmId,
 } from './types.js';
 
 export { CLI_VERSION_REQUIREMENTS, DEFAULT_CAPABILITIES } from './types.js';
+export { apiArmId, isApiArmId, routingArmDisplaySlot } from './types.js';
 
 // Base adapter
 export { BaseCliAdapter } from './base-adapter.js';

--- a/packages/nexus-agents/src/cli-adapters/index.ts
+++ b/packages/nexus-agents/src/cli-adapters/index.ts
@@ -33,7 +33,7 @@ export type {
 } from './types.js';
 
 export { CLI_VERSION_REQUIREMENTS, DEFAULT_CAPABILITIES } from './types.js';
-export { apiArmId, isApiArmId, routingArmDisplaySlot } from './types.js';
+export { apiArmId, routingArmDisplaySlot } from './types.js';
 
 // Base adapter
 export { BaseCliAdapter } from './base-adapter.js';

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the Model→CLI adapter bridge (#3422).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { createModelToCliAdapter } from './model-to-cli-adapter.js';
+import { ok, err, ModelError, type IModelAdapter, type CompletionResponse } from '../core/index.js';
+
+function makeModelAdapter(overrides: Partial<IModelAdapter> = {}): IModelAdapter {
+  return {
+    providerId: 'anthropic',
+    modelId: 'claude-opus',
+    capabilities: [],
+    complete: vi.fn(),
+    stream: vi.fn(),
+    countTokens: vi.fn().mockResolvedValue(10),
+    validateConfig: vi.fn().mockReturnValue(ok(undefined)),
+    ...overrides,
+  };
+}
+
+const COMPLETION: CompletionResponse = {
+  content: [{ type: 'text', text: 'hello from the api' }],
+  usage: { inputTokens: 120, outputTokens: 80, totalTokens: 200 },
+  stopReason: 'end_turn',
+  model: 'claude-opus',
+};
+
+describe('ModelToCliAdapter (#3422)', () => {
+  it('exposes the configured display CLI slot as name (not the arm id)', () => {
+    const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
+    expect(adapter.name).toBe('claude');
+  });
+
+  it('maps a successful complete() to a CliResponse with text/usage/model', async () => {
+    const complete = vi.fn().mockResolvedValue(ok(COMPLETION));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'claude' });
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.text).toBe('hello from the api');
+      expect(result.value.usage).toEqual({ inputTokens: 120, outputTokens: 80, totalTokens: 200 });
+      expect(result.value.model).toBe('claude-opus');
+    }
+  });
+
+  it('forwards systemPrompt, maxTokens, and a per-call timeout into the request', async () => {
+    const complete = vi.fn().mockResolvedValue(ok(COMPLETION));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'codex' });
+
+    await adapter.execute(
+      { content: 'hi', systemPrompt: 'be terse', maxTokens: 256 },
+      { timeoutMs: 9000 }
+    );
+
+    const req = complete.mock.calls[0]?.[0];
+    expect(req).toMatchObject({
+      messages: [{ role: 'user', content: 'hi' }],
+      systemPrompt: 'be terse',
+      maxTokens: 256,
+      timeoutMs: 9000,
+    });
+  });
+
+  it('maps a rate-limit ModelError to a retryable RATE_LIMITED CliError', async () => {
+    const complete = vi.fn().mockResolvedValue(err(new ModelError('429 rate limit exceeded')));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'gemini' });
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('RATE_LIMITED');
+      expect(result.error.retryable).toBe(true);
+      expect(result.error.cli).toBe('gemini');
+    }
+  });
+
+  it('maps a generic ModelError to a non-retryable EXECUTION_ERROR CliError', async () => {
+    const complete = vi.fn().mockResolvedValue(err(new ModelError('upstream 500')));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'claude' });
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('EXECUTION_ERROR');
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+
+  it('reports healthy when the model adapter config validates', async () => {
+    const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
+    const health = await adapter.healthCheck();
+    expect(health.healthy).toBe(true);
+  });
+
+  it('reports non-exhausted capacity (API rate limits surface via execute)', async () => {
+    const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
+    const cap = await adapter.getCapacity();
+    expect(cap.exhausted).toBe(false);
+  });
+
+  it('delegates listModels to the model adapter when present', async () => {
+    const listModels = vi.fn().mockResolvedValue([{ id: 'claude-opus', ownedBy: 'anthropic' }]);
+    const adapter = createModelToCliAdapter(makeModelAdapter({ listModels }), { name: 'claude' });
+
+    const models = await adapter.listModels();
+
+    expect(models).toEqual([{ id: 'claude-opus', provider: 'anthropic' }]);
+  });
+
+  it('returns an empty model list when the adapter has no listModels surface', async () => {
+    const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
+    expect(await adapter.listModels()).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
@@ -1,0 +1,213 @@
+/**
+ * Model-to-CLI Adapter Bridge (#3422)
+ *
+ * The inverse of {@link createCliToModelAdapter}: wraps an `IModelAdapter`
+ * (direct-API adapter — Anthropic/OpenAI/Google/custom-OpenAI) to implement
+ * `ICliAdapter`, so a CompositeRouter — which operates on `Map<_, ICliAdapter>`
+ * — can route to API adapters and record their bandit outcomes on a *distinct*
+ * arm (epic #3317 step 1, Option C). The routing arm id is the Map key
+ * (`api:<vendor>`), kept separate from this adapter's display `name` (a CLI
+ * slot), so CLI and API telemetry are never merged.
+ *
+ * @module cli-adapters/model-to-cli-adapter
+ */
+
+import type {
+  Result,
+  IModelAdapter,
+  CompletionRequest,
+  CompletionResponse,
+} from '../core/index.js';
+import { ok, err, ModelError } from '../core/index.js';
+import { isRateLimitText } from '../adapters/rate-limit-detector.js';
+import type {
+  ICliAdapter,
+  CliTask,
+  CliResponse,
+  CliError,
+  CliErrorCode,
+  CliModelInfo,
+  CliName,
+  CliTransport,
+  CapabilityProfile,
+  ExecutionOptions,
+  ModelInfo,
+  HealthStatus,
+  CapacityStatus,
+} from './types.js';
+
+/** Configuration for {@link ModelToCliAdapter}. */
+export interface ModelToCliAdapterConfig {
+  /**
+   * Display CLI slot for attribution/`getModelInfo` (e.g. `claude` for the
+   * Anthropic API). This is NOT the routing arm id — the router indexes arms by
+   * the adapter Map key (`api:<vendor>`), so the display name can be the slot
+   * without merging CLI and API telemetry.
+   */
+  readonly name: CliName;
+  /**
+   * Routing capability profile (TOPSIS/preference scoring). Supply the
+   * display slot's registry profile; falls back to a neutral mid profile.
+   */
+  readonly capabilities?: CapabilityProfile;
+}
+
+/** Default context window when the model adapter exposes no capability hint. */
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+/** Neutral mid capability profile used when the caller supplies none. */
+const NEUTRAL_CAPABILITIES: CapabilityProfile = {
+  reasoning: 7,
+  contextWindow: DEFAULT_CONTEXT_WINDOW,
+  codeGeneration: 7,
+  speed: 7,
+  cost: 5,
+};
+
+/** Direct-API calls are outbound requests; tag them as the subprocess-style transport. */
+const API_TRANSPORT: CliTransport = 'subprocess';
+
+/**
+ * Bridge adapter that wraps `IModelAdapter` to implement `ICliAdapter`.
+ */
+export class ModelToCliAdapter implements ICliAdapter {
+  readonly name: CliName;
+  readonly transport: CliTransport = API_TRANSPORT;
+  readonly capabilities: CapabilityProfile;
+
+  private readonly modelAdapter: IModelAdapter;
+
+  constructor(modelAdapter: IModelAdapter, config: ModelToCliAdapterConfig) {
+    this.modelAdapter = modelAdapter;
+    this.name = config.name;
+    this.capabilities = config.capabilities ?? NEUTRAL_CAPABILITIES;
+  }
+
+  /** Build a single-turn CompletionRequest from a CliTask. */
+  private toCompletionRequest(task: CliTask, options?: ExecutionOptions): CompletionRequest {
+    const request: CompletionRequest = {
+      messages: [{ role: 'user', content: task.content }],
+    };
+    if (task.systemPrompt !== undefined) {
+      (request as { systemPrompt: string }).systemPrompt = task.systemPrompt;
+    }
+    if (task.maxTokens !== undefined) {
+      (request as { maxTokens: number }).maxTokens = task.maxTokens;
+    }
+    if (options?.timeoutMs !== undefined) {
+      (request as { timeoutMs: number }).timeoutMs = options.timeoutMs;
+    }
+    return request;
+  }
+
+  /** Flatten a CompletionResponse's content blocks to plain text. */
+  private toText(response: CompletionResponse): string {
+    return response.content
+      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+  }
+
+  /** Convert a CompletionResponse to a CliResponse. */
+  private toCliResponse(response: CompletionResponse): CliResponse {
+    return {
+      text: this.toText(response),
+      usage: {
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+        totalTokens: response.usage.totalTokens,
+      },
+      model: response.model,
+    };
+  }
+
+  /**
+   * Convert a ModelError to a CliError. Rate-limit text → RATE_LIMITED
+   * (retryable); everything else → EXECUTION_ERROR (non-retryable) so the
+   * routing/circuit layers see a real, typed failure.
+   */
+  private toCliError(error: ModelError): CliError {
+    const rateLimited = isRateLimitText(error.message);
+    const code: CliErrorCode = rateLimited ? 'RATE_LIMITED' : 'EXECUTION_ERROR';
+    const base: CliError = {
+      code,
+      message: error.message,
+      cli: this.name,
+      retryable: rateLimited,
+    };
+    return error.cause instanceof Error ? { ...base, cause: error.cause } : base;
+  }
+
+  async execute(task: CliTask, options?: ExecutionOptions): Promise<Result<CliResponse, CliError>> {
+    const result = await this.modelAdapter.complete(this.toCompletionRequest(task, options));
+    if (!result.ok) {
+      return err(this.toCliError(result.error));
+    }
+    return ok(this.toCliResponse(result.value));
+  }
+
+  /** Health is derived from the model adapter's config validation. */
+  async healthCheck(): Promise<HealthStatus> {
+    const valid = this.modelAdapter.validateConfig();
+    return Promise.resolve({
+      healthy: valid.ok,
+      version: 'api',
+      versionStatus: 'supported',
+      lastChecked: new Date(0),
+      ...(valid.ok ? {} : { message: valid.error.message }),
+    });
+  }
+
+  /**
+   * API adapters don't expose subprocess-style rate windows; report
+   * non-exhausted capacity. Real rate-limit signals surface via execute()'s
+   * RATE_LIMITED error, which the resilience layer acts on.
+   */
+  getCapacity(): Promise<CapacityStatus> {
+    return Promise.resolve({
+      remainingTokens: Number.POSITIVE_INFINITY,
+      remainingRequests: Number.POSITIVE_INFINITY,
+      resetTime: new Date(0),
+      utilizationPercent: 0,
+      exhausted: false,
+    });
+  }
+
+  getVersion(): Promise<string> {
+    return Promise.resolve('api');
+  }
+
+  getModelInfo(): ModelInfo {
+    return {
+      id: this.modelAdapter.modelId,
+      name: this.modelAdapter.modelId,
+      contextWindow: DEFAULT_CONTEXT_WINDOW,
+    };
+  }
+
+  /** Delegate to the model adapter's listModels surface when present (#2529). */
+  async listModels(): Promise<readonly CliModelInfo[]> {
+    if (this.modelAdapter.listModels === undefined) return [];
+    const models = await this.modelAdapter.listModels();
+    return models.map((m) => ({
+      id: m.id,
+      ...(m.ownedBy !== undefined ? { provider: m.ownedBy } : {}),
+    }));
+  }
+
+  initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** Creates an ICliAdapter from an IModelAdapter (direct-API adapter). */
+export function createModelToCliAdapter(
+  modelAdapter: IModelAdapter,
+  config: ModelToCliAdapterConfig
+): ModelToCliAdapter {
+  return new ModelToCliAdapter(modelAdapter, config);
+}

--- a/packages/nexus-agents/src/cli-adapters/pipeline-e2e.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/pipeline-e2e.test.ts
@@ -18,6 +18,7 @@ import { OutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import { LinUCBBandit } from './linucb-bandit.js';
 import { computeQualityReward } from './composite-router-outcome.js';
 import type { ICliAdapter, CliName, CliTask } from './types.js';
+import { routingArmDisplaySlot } from './types.js';
 import type { BanditContext } from './budget-router-types.js';
 import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 
@@ -129,7 +130,7 @@ describe('E2E Pipeline Integration', () => {
       expect(routeResult.ok).toBe(true);
 
       if (routeResult.ok) {
-        const adapter = adapters.get(routeResult.value.cliName);
+        const adapter = adapters.get(routingArmDisplaySlot(routeResult.value.cliName));
         expect(adapter).toBeDefined();
 
         const execResult = await adapter!.execute(task);
@@ -239,7 +240,8 @@ describe('E2E Pipeline Integration', () => {
       expect(routeResult.ok).toBe(true);
       if (!routeResult.ok) return;
 
-      const selectedCli = routeResult.value.cliName;
+      // CLI-only setup: the routed arm collapses to its CLI slot (#3422).
+      const selectedCli = routingArmDisplaySlot(routeResult.value.cliName);
 
       // Step 3: Execute
       const adapter = adapters.get(selectedCli);
@@ -284,7 +286,7 @@ describe('E2E Pipeline Integration', () => {
         if (!routeResult.ok) continue;
 
         // Reward the target CLI, penalize others
-        const selectedCli = routeResult.value.cliName;
+        const selectedCli = routingArmDisplaySlot(routeResult.value.cliName);
         const success = selectedCli === targetCli;
         const reward = computeQualityReward(selectedCli, success, success ? 300 : 5000);
         router.recordOutcome(selectedCli, task, reward);

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -38,11 +38,6 @@ export function apiArmId(vendor: ApiVendor): ApiArmId {
   return `api:${vendor}`;
 }
 
-/** Narrow a routing arm id to a distinct API arm (vs. a CLI slot). */
-export function isApiArmId(id: RoutingArmId): id is ApiArmId {
-  return id.startsWith('api:');
-}
-
 /**
  * Map a routing arm id to its display CLI slot (#3422) — identity for CLI
  * slots, vendor→slot for API arms. Used where a feature is intrinsically

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -16,6 +16,56 @@ import type { CliNameLiteral } from '../config/model-capabilities-types.js';
 export type CliName = CliNameLiteral;
 
 /**
+ * API-vendor identifiers an `AdapterSelection{source:'api'}` reports (#3422).
+ * Distinct from the four CLI slots: a direct vendor API and the same vendor's
+ * CLI binary have different latency/failure profiles, so they must NOT share a
+ * routing/bandit arm (would pollute the learned model).
+ */
+export type ApiVendor = 'anthropic' | 'openai' | 'google' | 'custom-openai';
+
+/** Prefixed routing arm id for a direct-API adapter, e.g. `api:anthropic` (#3422). */
+export type ApiArmId = `api:${ApiVendor}`;
+
+/**
+ * A LinUCB/routing arm id — either a canonical CLI slot or a distinct API arm
+ * (#3317 step 1 / #3422). Confined to the router/bandit/outcome surface so the
+ * exhaustive `Record<CliName, …>` maps elsewhere stay narrow and untouched.
+ */
+export type RoutingArmId = CliName | ApiArmId;
+
+/** Build the routing arm id for an API vendor. */
+export function apiArmId(vendor: ApiVendor): ApiArmId {
+  return `api:${vendor}`;
+}
+
+/** Narrow a routing arm id to a distinct API arm (vs. a CLI slot). */
+export function isApiArmId(id: RoutingArmId): id is ApiArmId {
+  return id.startsWith('api:');
+}
+
+/**
+ * Map a routing arm id to its display CLI slot (#3422) — identity for CLI
+ * slots, vendor→slot for API arms. Used where a feature is intrinsically
+ * slot-level (e.g. ZeroRouter difficulty calibration) and must collapse the
+ * distinct API arm to its attribution slot. The bandit keeps the distinct arm;
+ * only slot-level surfaces collapse.
+ */
+export function routingArmDisplaySlot(armId: RoutingArmId): CliName {
+  switch (armId) {
+    case 'api:anthropic':
+      return 'claude';
+    case 'api:openai':
+      return 'codex';
+    case 'api:google':
+      return 'gemini';
+    case 'api:custom-openai':
+      return 'opencode';
+    default:
+      return armId;
+  }
+}
+
+/**
  * Transport type for CLI communication.
  * - 'mcp': Uses Model Context Protocol (most stable)
  * - 'subprocess': Spawns CLI process with JSON output

--- a/packages/nexus-agents/src/cli-adapters/types.ts
+++ b/packages/nexus-agents/src/cli-adapters/types.ts
@@ -22,7 +22,13 @@ export type {
   VersionStatus,
   HealthStatus,
   CapacityStatus,
+  ApiVendor,
+  ApiArmId,
+  RoutingArmId,
 } from './types-core.js';
+
+// Routing arm id helpers (#3422)
+export { apiArmId, isApiArmId, routingArmDisplaySlot } from './types-core.js';
 
 // Capability types
 export type {

--- a/packages/nexus-agents/src/cli-adapters/types.ts
+++ b/packages/nexus-agents/src/cli-adapters/types.ts
@@ -28,7 +28,7 @@ export type {
 } from './types-core.js';
 
 // Routing arm id helpers (#3422)
-export { apiArmId, isApiArmId, routingArmDisplaySlot } from './types-core.js';
+export { apiArmId, routingArmDisplaySlot } from './types-core.js';
 
 // Capability types
 export type {

--- a/packages/nexus-agents/src/cli/orchestrate-command.test.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-command.test.ts
@@ -12,6 +12,17 @@ vi.mock('../cli-adapters/index.js', () => ({
   getAvailableClis: vi.fn(),
   createAllAdapters: vi.fn(),
   createCompositeRouter: vi.fn(),
+  // #3422: orchestrate-dry-run collapses routing arms to display slots; this is
+  // a pure mapping (identity for CLI slots), so a real passthrough is correct.
+  routingArmDisplaySlot: (arm: string): string =>
+    arm.startsWith('api:')
+      ? ({
+          'api:anthropic': 'claude',
+          'api:openai': 'codex',
+          'api:google': 'gemini',
+          'api:custom-openai': 'opencode',
+        }[arm] ?? arm)
+      : arm,
 }));
 
 // Import mocked modules

--- a/packages/nexus-agents/src/cli/orchestrate-command.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-command.ts
@@ -21,6 +21,7 @@ import {
   type CompositeRoutingDecision,
   type CliResponse,
   type CliName,
+  type RoutingArmId,
   type CliTask,
 } from '../cli-adapters/index.js';
 import { getConfig, adaptRoutingConfig } from '../config/index.js';
@@ -87,7 +88,7 @@ async function runWithAdapter(
  */
 async function executeWithRouting(
   task: CliTask,
-  adapters: Map<CliName, ICliAdapter>,
+  adapters: Map<RoutingArmId, ICliAdapter>,
   options: OrchestrateOptions,
   logger: ILogger
 ): Promise<OrchestrationResult> {
@@ -143,7 +144,7 @@ async function executeWithRouting(
 async function executeWithModel(
   task: CliTask,
   model: CliName,
-  adapters: Map<CliName, ICliAdapter>,
+  adapters: Map<RoutingArmId, ICliAdapter>,
   logger: ILogger
 ): Promise<OrchestrationResult> {
   const time = getTimeProvider();

--- a/packages/nexus-agents/src/cli/orchestrate-dry-run.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-dry-run.ts
@@ -11,6 +11,7 @@
 
 import type { CliTask } from '../cli-adapters/index.js';
 import type { CompositeRoutingDecision } from '../cli-adapters/index.js';
+import { routingArmDisplaySlot } from '../cli-adapters/index.js';
 import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
 import { calculateCost } from '../core/index.js';
 import { getCliModelName, getDefaultModelForCli } from '../config/model-config-helpers.js';
@@ -56,7 +57,8 @@ export function buildDryRunReport(task: CliTask, decision: CompositeRoutingDecis
   const estimatedInputTokens = analyzer.estimateTokens(task.content);
   const estimatedOutputTokens = Math.round(estimatedInputTokens * DEFAULT_OUTPUT_RATIO);
 
-  const modelId = getCliModelName(getDefaultModelForCli(decision.cliName));
+  // Registry model lookup is slot-level; collapse an api:* arm to its slot (#3422).
+  const modelId = getCliModelName(getDefaultModelForCli(routingArmDisplaySlot(decision.cliName)));
   const costUsd = calculateCost(modelId, estimatedInputTokens, estimatedOutputTokens);
   const inputCostUsd = calculateCost(modelId, estimatedInputTokens, 0);
   const outputCostUsd = calculateCost(modelId, 0, estimatedOutputTokens);

--- a/packages/nexus-agents/src/cli/orchestrate-puppeteer.ts
+++ b/packages/nexus-agents/src/cli/orchestrate-puppeteer.ts
@@ -16,7 +16,8 @@ import {
   type PolicyParameters,
 } from '../agents/orchestration/index.js';
 import type { IAgent, Task as AgentTask } from '../core/types/agent.js';
-import type { CliName, ICliAdapter } from '../cli-adapters/index.js';
+import type { RoutingArmId, ICliAdapter } from '../cli-adapters/index.js';
+import { routingArmDisplaySlot } from '../cli-adapters/index.js';
 import type { OrchestrateOptions, PuppeteerOrchestrationResult } from './orchestrate-types.js';
 import { CliAdapterAgent } from './cli-adapter-agent.js';
 import { INTERNAL_TIMEOUTS } from '../config/timeouts.js';
@@ -62,10 +63,12 @@ export function savePolicyParameters(
 /**
  * Create agents from CLI adapters.
  */
-export function createAgentsFromAdapters(adapters: Map<CliName, ICliAdapter>): IAgent[] {
+export function createAgentsFromAdapters(adapters: Map<RoutingArmId, ICliAdapter>): IAgent[] {
   const agents: IAgent[] = [];
   for (const [name, adapter] of adapters) {
-    agents.push(new CliAdapterAgent(name, adapter));
+    // The puppeteer engine identifies agents by CLI slot; an api:* arm collapses
+    // to its display slot here (no distinct-arm learning in this path) (#3422).
+    agents.push(new CliAdapterAgent(routingArmDisplaySlot(name), adapter));
   }
   return agents;
 }
@@ -166,7 +169,7 @@ export function buildPuppeteerResult(
  */
 export async function executeWithPuppeteer(
   taskContent: string,
-  adapters: Map<CliName, ICliAdapter>,
+  adapters: Map<RoutingArmId, ICliAdapter>,
   options: OrchestrateOptions,
   logger: ILogger
 ): Promise<PuppeteerOrchestrationResult> {

--- a/packages/nexus-agents/src/learning/feedback-integration.ts
+++ b/packages/nexus-agents/src/learning/feedback-integration.ts
@@ -12,7 +12,8 @@ import { randomUUID } from 'node:crypto';
 import { createLogger, getTimeProvider } from '../core/index.js';
 import type { ILogger } from '../core/logger.js';
 import type { StepResult } from '../core/types/workflow.js';
-import type { CliName } from '../cli-adapters/types.js';
+import type { RoutingArmId } from '../cli-adapters/types.js';
+import { routingArmDisplaySlot } from '../cli-adapters/types.js';
 import type {
   CompositeRoutingDecision,
   ICompositeRouter,
@@ -149,7 +150,12 @@ function serializeTaskProfile(profile: TaskProfile): Record<string, unknown> {
  * Entry in the decision map with timestamp for TTL eviction.
  */
 interface DecisionEntry {
-  readonly cliName: CliName;
+  /**
+   * The DISTINCT routing arm (CLI slot or api:* arm) — kept un-collapsed so
+   * `compositeRouter.recordOutcome(cliName, …)` updates the right bandit arm
+   * (#3422). Telemetry sinks collapse to the display slot at write time.
+   */
+  readonly cliName: RoutingArmId;
   readonly task: string;
   readonly createdAt: number;
 }
@@ -234,8 +240,9 @@ export class FeedbackIntegration implements IFeedbackIntegration {
         traceId: trace,
         timestamp: getTimeProvider().nowIso(),
         routerType: getDecisiveRouterType(decision),
-        selectedModel: decision.cliName,
-        alternativeModels: decision.alternatives,
+        // Persisted telemetry is slot-level; collapse the distinct arm (#3422).
+        selectedModel: routingArmDisplaySlot(decision.cliName),
+        alternativeModels: decision.alternatives.map(routingArmDisplaySlot),
         confidence: decision.confidence,
         reason: decision.reason,
         taskProfile: serializeTaskProfile(decision.taskProfile),

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
@@ -14,6 +14,7 @@ import type { CapabilityProfile, DelegateOutput } from './delegate-to-model-type
 import { MODEL_CAPABILITIES } from './delegate-to-model-types.js';
 import { getDefaultModelForCli } from '../../config/model-config-helpers.js';
 import type { CliNameLiteral } from '../../config/model-capabilities-types.js';
+import { routingArmDisplaySlot } from '../../cli-adapters/types.js';
 
 /**
  * Maps CLI name to default model ID for output.
@@ -43,7 +44,9 @@ export function mapCompositeDecisionToOutput(
 ): DelegateOutput {
   // #3394: prefer the route-time tier-selected model when present (opt-in);
   // otherwise fall back to the CLI default. Default-off → decision.model undefined.
-  const modelName = decision.model ?? cliNameToModel(decision.cliName);
+  // Model lookup is registry/slot-level; collapse api:* arms to their display
+  // slot for the default-model resolution (#3422).
+  const modelName = decision.model ?? cliNameToModel(routingArmDisplaySlot(decision.cliName));
   const caps = MODEL_CAPABILITIES[modelName] ?? DEFAULT_CAPABILITIES;
 
   return {
@@ -52,7 +55,7 @@ export function mapCompositeDecisionToOutput(
     capabilities: caps,
     estimated_tokens: estimatedTokens,
     alternatives: decision.alternatives.slice(0, 3).map((alt) => ({
-      model: cliNameToModel(alt),
+      model: cliNameToModel(routingArmDisplaySlot(alt)),
       score: decision.topsisScore ?? 0.7,
       tradeoff: 'alternative option',
     })),


### PR DESCRIPTION
## Context

Closes #3422 (epic #3317 step 1, Option C). Direct-API adapters (Anthropic/OpenAI/Google/custom-OpenAI) previously ran *outside* the CompositeRouter via the ResilientAdapter fallback, so their outcomes were silently dropped (`recordBanditOutcome` `indexOf === -1`) and the bandit never learned in api-mode. This makes them **first-class routing/bandit arms** — scored distinctly from the four CLI slots so CLI-vs-API performance is learned separately (not aliased, which would pollute the bandit — the telemetry-pollution fork resolved by the consensus panel on #3317).

## Design — the arm/slot rule

- **Ranking/selection pipeline carries the distinct arm** (`RoutingArmId = CliName | ApiArmId`) end-to-end, so an `api:*` arm is selectable and learned distinctly.
- **Only the bandit outcome stays distinct.** Registry/pricing lookups, telemetry, and secondary learners (latency, routing-memory, metrics, trace, observer, dry-run, delegate, feedback) collapse to the display slot via `routingArmDisplaySlot`. `decisionsPerCli` stays slot-keyed (guarded).
- New `ModelToCliAdapter` shim bridges `IModelAdapter`→`ICliAdapter`; `wrapApiSelectionForRouter`/`collectApiRoutingArms` enumerate key-present vendors.
- **Wiring gated:** `createAllAdapters` appends API arms **only** when `NEXUS_BILLING_MODE=api` + vendor key present. Default plan mode = CLIs only, **no surprise API spend**.

## Review (this PR)

- **QA (code-reviewer):** found one telemetry sink (`emitRoutingDecision`) that escaped the slot-collapse — **fixed**; added a selected-api-arm end-to-end test proving the arm survives TOPSIS+LinUCB as `decision.cliName`.
- **Security (security-auditor): CLEAN** (0 crit/high/med) — keys never logged/echoed, key-presence-only detection, custom-openai SSRF guard intact, no surprise spend.
- **Cleanup:** removed orphaned `isApiArmId` export (Orphan-Detection gate); DRY confirmed (single vendor→slot mapping).
- Follow-ups filed: #3424 (tier-stage participation), #3425 (model-source key collapse), #3426 (connect-time SSRF check).

## Testing

- New: model→cli shim (9), wrap factory (5), distinct-arm + selected-arm + no-leak router tests, factory gate (3 billing-mode branches).
- Full affected suites: **2437 passed** / 8 skipped. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)