### PR TITLE
fix(resilience): record API ModelError failures to the circuit breaker (#3423)

### DIFF
--- a/.changeset/api-circuit-breaker-3423.md
+++ b/.changeset/api-circuit-breaker-3423.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': minor
+---
+
+fix(resilience): record API ModelError failures to the circuit breaker (#3423, epic #3317)
+
+Direct-API adapters (`ResilientAdapter`) previously recorded only rate-limit
+events — an API `ModelError` never opened a circuit breaker or triggered
+failover, so a degrading API endpoint had no degradation/failover learning (the
+CLI subprocess path already did). `ResilientAdapter.complete()` now maps a
+`ModelError` to a `FailureCategory` (`mapModelErrorToCategory`) and records it to
+the current adapter's breaker, reusing the existing open→failover wiring.
+
+Rate limits are skipped here (checked via BOTH the mapped category and
+`isRateLimitLikeError`, whose pattern lists differ) so they aren't double-counted
+against the telemetry branch. The recorded payload is a `FailureCategory` enum
+and the log carries only `{provider, category}` — no credentials, message, or
+request ever reach the breaker, logs, or events.

--- a/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
@@ -640,5 +640,60 @@ describe('ResilientAdapter', () => {
       expect(recordFailureSpy).not.toHaveBeenCalled();
       expect(breaker.getSnapshot().failureCount).toBe(0);
     });
+
+    it('does not double-count a code-less rate-limit MODEL_ERROR (pattern divergence)', async () => {
+      // A MODEL_ERROR whose message is rate-limit-like to `isRateLimitLikeError`
+      // ("quota exceeded") but NOT to `categorizeError` would map to `unknown`
+      // and slip past a category-only guard — double-counting against the
+      // telemetry branch. The guard also checks `isRateLimitLikeError` (#3423).
+      const registry = new CircuitBreakerRegistry();
+      const breaker = registry.getBreaker('claude');
+      const recordFailureSpy = vi.spyOn(breaker, 'recordFailure');
+      const failingAdapter = new ResilientAdapter();
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      const quotaError = new ModelError('quota exceeded for this org', {
+        code: ErrorCode.MODEL_ERROR,
+      });
+      mockComplete.mockReturnValue(Promise.resolve(err(quotaError)));
+      vi.mocked(isRateLimitLikeError).mockReturnValue(true);
+      vi.mocked(toRateLimitError).mockReturnValue({
+        message: 'quota exceeded for this org',
+        retryAfterMs: 30000,
+      } as unknown as ReturnType<typeof toRateLimitError>);
+
+      await failingAdapter.complete({ messages: [] });
+
+      expect(recordFailureSpy).not.toHaveBeenCalled();
+      expect(breaker.getSnapshot().failureCount).toBe(0);
+    });
+
+    it('never leaks a secret carried in error.cause into the logged payload', async () => {
+      // Hardening (#3423 security review): the secret lives in `error.cause`,
+      // not `.message`. The recording path logs only {provider, category}, so a
+      // cause-borne credential must never surface either.
+      const registry = new CircuitBreakerRegistry();
+      const logger = makeLogger();
+      const failingAdapter = new ResilientAdapter({ logger });
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      const causeError = new ModelError('upstream failed', {
+        code: ErrorCode.MODEL_UNAVAILABLE,
+        cause: new Error('auth header Bearer sk-SECRET-cause99'),
+      });
+      mockComplete.mockReturnValue(Promise.resolve(err(causeError)));
+
+      await failingAdapter.complete({ messages: [] });
+
+      const allLogCalls = [
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.debug).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+      for (const call of allLogCalls) {
+        expect(JSON.stringify(call)).not.toContain('sk-SECRET');
+      }
+    });
   });
 });

--- a/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
@@ -9,9 +9,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AdapterSelection } from './auto-adapter.js';
 import type {} from '../core/types/model.js';
 import { ok, err } from '../core/result.js';
-import { ModelError } from '../core/errors.js';
+import { ModelError, ErrorCode } from '../core/errors.js';
+import type { ILogger } from '../core/index.js';
 import type { CircuitStateChangeEvent } from '../cli-adapters/circuit-breaker-types.js';
-import type { CircuitBreakerRegistry } from '../cli-adapters/circuit-breaker.js';
+import {
+  CircuitBreakerRegistry,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+} from '../cli-adapters/circuit-breaker.js';
 
 // ============================================================================
 // Mocks — vi.mock is hoisted, so use inline factories only
@@ -502,6 +506,139 @@ describe('ResilientAdapter', () => {
     it('is safe to call multiple times', () => {
       adapter.dispose();
       adapter.dispose();
+    });
+  });
+
+  describe('API failure → circuit breaker (#3423)', () => {
+    function makeLogger(): ILogger {
+      const logger: ILogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(() => logger),
+        setLevel: vi.fn(),
+      };
+      return logger;
+    }
+
+    it('opens the breaker after repeated API ModelError failures', async () => {
+      const registry = new CircuitBreakerRegistry();
+      const failingAdapter = new ResilientAdapter();
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      mockComplete.mockReturnValue(
+        Promise.resolve(err(new ModelError('upstream failed', { code: ErrorCode.MODEL_ERROR })))
+      );
+
+      const threshold = DEFAULT_CIRCUIT_BREAKER_CONFIG.failureThreshold;
+      for (let i = 0; i < threshold; i++) {
+        await failingAdapter.complete({ messages: [] });
+      }
+
+      expect(registry.getBreaker('claude').getState()).toBe('open');
+    });
+
+    it('clears the cached adapter and re-detects (failover) once the breaker opens', async () => {
+      const registry = new CircuitBreakerRegistry();
+      const failingAdapter = new ResilientAdapter();
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      const onFailover = vi.fn();
+      failingAdapter.onFailover(onFailover);
+
+      mockComplete.mockReturnValue(
+        Promise.resolve(err(new ModelError('upstream failed', { code: ErrorCode.MODEL_ERROR })))
+      );
+
+      const threshold = DEFAULT_CIRCUIT_BREAKER_CONFIG.failureThreshold;
+      // First call detects the 'claude' adapter; reaching the threshold opens
+      // the breaker, whose open event clears the cached adapter.
+      for (let i = 0; i < threshold; i++) {
+        await failingAdapter.complete({ messages: [] });
+      }
+      expect(createAutoAdapter).toHaveBeenCalledTimes(1);
+      expect(failingAdapter.getHealth()?.state).toBe('degraded');
+
+      // Next call re-detects (failover) — a different adapter name confirms
+      // the failover path fired.
+      vi.mocked(createAutoAdapter).mockResolvedValueOnce(makeSelection('gemini'));
+      mockComplete.mockReturnValueOnce(
+        Promise.resolve(
+          ok({
+            content: [{ type: 'text', text: 'ok' }],
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            stopReason: 'end_turn',
+            model: 'mock-model',
+          })
+        )
+      );
+      await failingAdapter.complete({ messages: [] });
+
+      expect(createAutoAdapter).toHaveBeenCalledTimes(2);
+      expect(onFailover).toHaveBeenCalledTimes(1);
+      expect(failingAdapter.getHealth()?.failoverCount).toBe(1);
+    });
+
+    it('never leaks credential-bearing error content into the logged payload', async () => {
+      const registry = new CircuitBreakerRegistry();
+      const breaker = registry.getBreaker('claude');
+      const recordFailureSpy = vi.spyOn(breaker, 'recordFailure');
+      const logger = makeLogger();
+      const failingAdapter = new ResilientAdapter({ logger });
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      // Use a code that maps deterministically (MODEL_UNAVAILABLE → connection)
+      // so the secret in the message cannot influence the category.
+      const secretError = new ModelError('failed for key sk-SECRET-deadbeef', {
+        code: ErrorCode.MODEL_UNAVAILABLE,
+      });
+      mockComplete.mockReturnValue(Promise.resolve(err(secretError)));
+
+      await failingAdapter.complete({ messages: [] });
+
+      // recordFailure received only a FailureCategory string, never the error.
+      expect(recordFailureSpy).toHaveBeenCalledTimes(1);
+      expect(recordFailureSpy).toHaveBeenCalledWith('connection');
+      const recordedArg = recordFailureSpy.mock.calls[0]?.[0];
+      expect(typeof recordedArg).toBe('string');
+
+      // No logged call's serialized args contain the secret.
+      const allLogCalls = [
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.debug).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ];
+      for (const call of allLogCalls) {
+        expect(JSON.stringify(call)).not.toContain('sk-SECRET');
+      }
+    });
+
+    it('does not double-count rate-limit failures against the breaker', async () => {
+      const registry = new CircuitBreakerRegistry();
+      const breaker = registry.getBreaker('claude');
+      const recordFailureSpy = vi.spyOn(breaker, 'recordFailure');
+      const failingAdapter = new ResilientAdapter();
+      failingAdapter.attachCircuitBreakerRegistry(registry);
+
+      const rateLimitError = new ModelError('Rate limit exceeded', {
+        code: ErrorCode.MODEL_RATE_LIMITED,
+      });
+      mockComplete.mockReturnValue(Promise.resolve(err(rateLimitError)));
+      vi.mocked(isRateLimitLikeError).mockReturnValue(true);
+      vi.mocked(toRateLimitError).mockReturnValue({
+        message: 'Rate limit exceeded',
+        retryAfterMs: 30000,
+      } as unknown as ReturnType<typeof toRateLimitError>);
+
+      await failingAdapter.complete({ messages: [] });
+
+      // The rate-limit telemetry branch fired...
+      expect(recordRateLimitEvent).toHaveBeenCalledTimes(1);
+      // ...but the breaker path skipped recordFailure to avoid double-count.
+      expect(recordFailureSpy).not.toHaveBeenCalled();
+      expect(breaker.getSnapshot().failureCount).toBe(0);
     });
   });
 });

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -296,9 +296,14 @@ export class ResilientAdapter implements IResilientAdapter {
     }
 
     const category = mapModelErrorToCategory(error);
-    if (category === 'rate_limit') {
-      // Already accounted for by the rate-limit telemetry branch; skip to avoid
-      // double-counting against the breaker's failure threshold.
+    // Skip rate limits: already accounted for by the rate-limit telemetry branch
+    // (and the breaker counts them by default). Check BOTH the mapped category
+    // AND the telemetry predicate — their rate-limit pattern lists differ
+    // (`isRateLimitLikeError` matches "quota exceeded"/"throttl"/… that
+    // `categorizeError` does not), so a code-less MODEL_ERROR could otherwise
+    // fire the telemetry branch yet fall through to a counted failure here,
+    // double-counting against the threshold (#3423 review).
+    if (category === 'rate_limit' || isRateLimitLikeError(error)) {
       return;
     }
 

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -40,6 +40,7 @@ import type {
 } from './resilient-adapter-types.js';
 import type { CircuitStateChangeEvent } from '../cli-adapters/circuit-breaker-types.js';
 import type { CircuitBreakerRegistry } from '../cli-adapters/circuit-breaker.js';
+import { mapModelErrorToCategory } from '../cli-adapters/circuit-breaker.js';
 import { getGlobalEventBus } from '../core/event-bus.js';
 
 // ============================================================================
@@ -110,17 +111,20 @@ export class ResilientAdapter implements IResilientAdapter {
       return err(new ModelError('No model adapter available'));
     }
     const result = await adapter.complete(request);
-    if (!result.ok && isRateLimitLikeError(result.error)) {
-      const rlError = toRateLimitError(result.error, adapter.providerId);
-      recordRateLimitEvent({
-        provider: adapter.providerId,
-        timestamp: getTimeProvider().now(),
-        retryAfterMs: rlError.retryAfterMs,
-      });
-      this.logger.warn('Rate limit detected', {
-        provider: adapter.providerId,
-        retryAfterMs: rlError.retryAfterMs,
-      });
+    if (!result.ok) {
+      if (isRateLimitLikeError(result.error)) {
+        const rlError = toRateLimitError(result.error, adapter.providerId);
+        recordRateLimitEvent({
+          provider: adapter.providerId,
+          timestamp: getTimeProvider().now(),
+          retryAfterMs: rlError.retryAfterMs,
+        });
+        this.logger.warn('Rate limit detected', {
+          provider: adapter.providerId,
+          retryAfterMs: rlError.retryAfterMs,
+        });
+      }
+      this.recordBreakerFailure(adapter, result.error);
     }
     return result;
   }
@@ -267,6 +271,45 @@ export class ResilientAdapter implements IResilientAdapter {
     if (isFailover) {
       this.emitFailover();
     }
+  }
+
+  /**
+   * Record a direct-API failure to the circuit breaker so API adapters get the
+   * same degradation/failover learning that CLI subprocess failures get (#3423).
+   *
+   * The breaker key is `currentSelection.name` — distinct from the `api:<vendor>`
+   * arm key used by the ModelToCliAdapter path (#3422), so the two paths never
+   * double-count the same failure.
+   *
+   * Rate-limit failures are deliberately skipped here: they are already recorded
+   * by the `recordRateLimitEvent` telemetry branch in `complete()`, and the
+   * breaker counts rate limits as failures by default
+   * (`countRateLimitsAsFailures`), so recording them again would double-count.
+   *
+   * Security (#3422 constraint): the logged payload carries only `provider` and
+   * `category` — never `error.message`, the request, or the ModelError object,
+   * any of which could embed credentials.
+   */
+  private recordBreakerFailure(adapter: IModelAdapter, error: ModelError): void {
+    if (this.circuitBreakerRegistry === undefined || this.currentSelection === undefined) {
+      return;
+    }
+
+    const category = mapModelErrorToCategory(error);
+    if (category === 'rate_limit') {
+      // Already accounted for by the rate-limit telemetry branch; skip to avoid
+      // double-counting against the breaker's failure threshold.
+      return;
+    }
+
+    this.circuitBreakerRegistry
+      .getBreaker(this.currentSelection.name as CliName)
+      .recordFailure(category);
+
+    this.logger.warn('API failure recorded to circuit breaker', {
+      provider: adapter.providerId,
+      category,
+    });
   }
 
   private handleCircuitStateChange(event: CircuitStateChangeEvent): void {

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
@@ -12,9 +12,11 @@ import {
   CircuitErrorCode,
   DEFAULT_CIRCUIT_BREAKER_CONFIG,
   mapCliErrorToCategory,
+  mapModelErrorToCategory,
   categorizeError,
   type CircuitStateChangeEvent,
 } from './circuit-breaker.js';
+import { ErrorCode, ModelError } from '../core/errors.js';
 
 describe('CliCircuitBreaker', () => {
   let breaker: CliCircuitBreaker;
@@ -693,6 +695,62 @@ describe('mapCliErrorToCategory', () => {
     expect(mapCliErrorToCategory('EXECUTION_ERROR')).toBe('unknown');
     expect(mapCliErrorToCategory('UNSUPPORTED_VERSION')).toBe('unknown');
     expect(mapCliErrorToCategory('UNKNOWN')).toBe('unknown');
+  });
+});
+
+describe('mapModelErrorToCategory', () => {
+  it('should map MODEL_TIMEOUT to timeout', () => {
+    expect(mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.MODEL_TIMEOUT }))).toBe(
+      'timeout'
+    );
+  });
+
+  it('should map TIMEOUT_ERROR to timeout', () => {
+    expect(mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.TIMEOUT_ERROR }))).toBe(
+      'timeout'
+    );
+  });
+
+  it('should map UNAUTHORIZED to authentication', () => {
+    expect(mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.UNAUTHORIZED }))).toBe(
+      'authentication'
+    );
+  });
+
+  it('should map MODEL_RATE_LIMITED to rate_limit', () => {
+    expect(
+      mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.MODEL_RATE_LIMITED }))
+    ).toBe('rate_limit');
+  });
+
+  it('should map RATE_LIMIT_ERROR to rate_limit', () => {
+    expect(mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.RATE_LIMIT_ERROR }))).toBe(
+      'rate_limit'
+    );
+  });
+
+  it('should map MODEL_UNAVAILABLE to connection', () => {
+    expect(
+      mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.MODEL_UNAVAILABLE }))
+    ).toBe('connection');
+  });
+
+  it('should map MODEL_NOT_FOUND to connection', () => {
+    expect(mapModelErrorToCategory(new ModelError('x', { code: ErrorCode.MODEL_NOT_FOUND }))).toBe(
+      'connection'
+    );
+  });
+
+  it('should map plain MODEL_ERROR to unknown when message is uninformative', () => {
+    expect(mapModelErrorToCategory(new ModelError('something went wrong'))).toBe('unknown');
+  });
+
+  it('should fall back to message-pattern categorization for MODEL_ERROR', () => {
+    // A generic MODEL_ERROR whose message is connection-ish should categorize
+    // as `connection` via the categorizeError fallback, not `unknown`.
+    expect(mapModelErrorToCategory(new ModelError('ECONNREFUSED: connection refused'))).toBe(
+      'connection'
+    );
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
@@ -412,6 +412,9 @@ export function mapModelErrorToCategory(error: ModelError): FailureCategory {
       return 'rate_limit';
     case ErrorCode.MODEL_UNAVAILABLE:
     case ErrorCode.MODEL_NOT_FOUND:
+      // Intentional reuse of `connection`: there is no dedicated "endpoint gone /
+      // model retired" category, and `connection` is a counted, failover-driving
+      // category — the right behaviour for an unavailable/missing model.
       return 'connection';
     default:
       // MODEL_ERROR and any other code: fall back to message-pattern matching.

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
@@ -11,6 +11,8 @@
 import type { Result } from '../core/index.js';
 import { getErrorMessage, err, ok, getTimeProvider } from '../core/index.js';
 
+import { ErrorCode, type ModelError } from '../core/errors.js';
+
 import type { CliName, CliErrorCode } from './types.js';
 import {
   CircuitError,
@@ -384,6 +386,37 @@ export function mapCliErrorToCategory(errorCode: CliErrorCode): FailureCategory 
     CONNECTION_ERROR: 'connection',
   };
   return mapping[errorCode] ?? 'unknown';
+}
+
+/**
+ * Maps a direct-API {@link ModelError} to a circuit-breaker failure category.
+ *
+ * Mirrors {@link mapCliErrorToCategory} for the IModelAdapter layer (#3423):
+ * API failures must drive the same breaker degradation/failover learning that
+ * CLI subprocess failures already get. Maps by the structured `error.code`
+ * first, then falls back to message-pattern categorization via
+ * {@link categorizeError} (which returns `'unknown'` if nothing matches).
+ *
+ * The fallback is what turns a generic `MODEL_ERROR` whose message reads
+ * "connection refused" into a `connection` category instead of `unknown`.
+ */
+export function mapModelErrorToCategory(error: ModelError): FailureCategory {
+  switch (error.code) {
+    case ErrorCode.MODEL_TIMEOUT:
+    case ErrorCode.TIMEOUT_ERROR:
+      return 'timeout';
+    case ErrorCode.UNAUTHORIZED:
+      return 'authentication';
+    case ErrorCode.MODEL_RATE_LIMITED:
+    case ErrorCode.RATE_LIMIT_ERROR:
+      return 'rate_limit';
+    case ErrorCode.MODEL_UNAVAILABLE:
+    case ErrorCode.MODEL_NOT_FOUND:
+      return 'connection';
+    default:
+      // MODEL_ERROR and any other code: fall back to message-pattern matching.
+      return categorizeError(error);
+  }
 }
 
 // `createCircuitBreakerRegistryWithMetrics` and the


### PR DESCRIPTION
## Context

Closes #3423 (epic #3317 finding #4). `ResilientAdapter` recorded only rate-limit telemetry — an API `ModelError` never opened a circuit breaker or triggered failover, so a degrading direct-API endpoint got no degradation/failover learning (CLI subprocess failures already did, via `CliCircuitBreakerIntegration`).

## Change

- `mapModelErrorToCategory(error)` (circuit-breaker.ts): code-first, message-fallback mapping → `FailureCategory` (timeout / authentication / rate_limit / connection / unknown).
- `ResilientAdapter.complete()` records the mapped category to the current adapter's breaker (`currentSelection.name`), reusing the existing open→failover wiring (`handleCircuitStateChange`). No new failover code.
- **Layer choice:** recorded at the `IModelAdapter` layer (ResilientAdapter) — it owns the breaker registry, knows the key, and wires failover. Distinct breaker key from #3422's `api:<vendor>` router arms → no cross-path double-count.

## Review (this PR)

- **QA (code-reviewer): APPROVE** — caught a rate-limit **pattern-divergence double-count** (`isRateLimitLikeError` has 9 patterns vs `categorizeError`'s 3; a code-less `MODEL_ERROR` "quota exceeded" could double-count). **Fixed**: the guard now also short-circuits on `isRateLimitLikeError(error)`; added a regression test.
- **Security (security-auditor): CLEAN** (0 crit/high/med/low) — breaker receives only a `FailureCategory` enum; log carries only `{provider, category}`; type system makes leaking a message a compile error. Added a hardening test for a secret in `error.cause`.

## Testing

- `mapModelErrorToCategory` table test; breaker-opens, real failover, no-credential-leak (message + cause), no-double-count (typed + code-less rate-limit).
- `pnpm vitest run src/adapters/resilient-adapter.test.ts src/cli-adapters/circuit-breaker.test.ts` → **108 passed**. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)