### PR TITLE
fix(routing): collapse api:* arm keys in model-source registration (#3425)

### DIFF
--- a/.changeset/model-source-key-collapse-3425.md
+++ b/.changeset/model-source-key-collapse-3425.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): collapse api:\* arm keys in model-source registration (#3425)
+
+After #3422, the router's adapter map can be keyed by `api:<vendor>` arm ids.
+`buildDefaultModelSources`/`registerDefaultModelSources` iterated those keys and
+would register an availability source under the literal `api:anthropic` name.
+Harmless today (the candidate filter gates on the display slot), but a future
+model-source consumer iterating raw keys could see an `api:*` key where a CLI
+slot is expected. Sources are now named by the display slot
+(`routingArmDisplaySlot`); the cache de-dups by name, so a CLI slot and its api
+arm collapse to one slot-named source.

--- a/packages/nexus-agents/src/config/register-model-sources.test.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.test.ts
@@ -82,4 +82,19 @@ describe('buildDefaultModelSources (#3406)', () => {
     expect(names).not.toContain('openrouter');
     expect(names).toEqual([]);
   });
+
+  it('collapses an api:* arm key to its display slot — no api:* leaks into source names (#3425)', () => {
+    // The router's adapter map can be keyed by api:* arm ids (#3422). The source
+    // must be named for the display CLI slot, never the raw arm id.
+    const adapters = new Map<string, unknown>([
+      ['api:anthropic', { listModels: () => Promise.resolve([{ id: 'claude-opus' }]) }],
+      ['api:openai', { listModels: () => Promise.resolve([{ id: 'gpt-5' }]) }],
+    ]);
+    const names = buildDefaultModelSources(adapters, { includeOpenRouter: false }).map(
+      (s) => s.name
+    );
+    expect(names).toContain('claude');
+    expect(names).toContain('codex');
+    expect(names.some((n) => n.startsWith('api:'))).toBe(false);
+  });
 });

--- a/packages/nexus-agents/src/config/register-model-sources.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.ts
@@ -21,6 +21,8 @@
 import { createLogger } from '../core/index.js';
 
 import { createOpenRouterModelsSource } from './openrouter-models-source.js';
+import { routingArmDisplaySlot } from '../cli-adapters/types.js';
+import type { RoutingArmId } from '../cli-adapters/types.js';
 
 import type { AvailableModelsCache, AvailableModelsSource } from './available-models-cache.js';
 
@@ -84,9 +86,14 @@ export function buildDefaultModelSources(
   if (opts.includeOpenRouter !== false) {
     sources.push(createOpenRouterModelsSource());
   }
-  for (const [cliName, adapter] of adapters) {
+  for (const [key, adapter] of adapters) {
     if (hasListModels(adapter)) {
-      sources.push(adapterSource(cliName, adapter));
+      // #3425: the router's adapter map can be keyed by api:* arm ids (#3422).
+      // Register the source under the display CLI slot so no api:* literal leaks
+      // into the model-source registry; the cache de-dups by name, so when both
+      // a CLI slot and its api arm are present the CLI source wins.
+      const slot = routingArmDisplaySlot(key as RoutingArmId);
+      sources.push(adapterSource(slot, adapter));
     }
   }
   return sources;


### PR DESCRIPTION
## Context
Closes #3425 (follow-up from #3422). The router's adapter map can now be keyed by `api:<vendor>` arm ids. `buildDefaultModelSources`/`registerDefaultModelSources` iterated those keys and would register an availability source under the literal `api:anthropic` name — harmless today (`getCandidateCliNames` gates on the display slot) but a latent trap for any future consumer iterating raw source keys.

## Change
Sources are named by the display CLI slot via `routingArmDisplaySlot(key)` instead of the raw map key. The cache de-dups by name, so a CLI slot and its api arm collapse to one slot-named source. Added a test asserting no `api:*` name reaches the source list.

## Testing
`pnpm vitest run src/config/register-model-sources.test.ts` → 8 passed. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)