### PR TITLE
fix(adapters): retry transient MODEL_UNAVAILABLE + drop empty stream deltas (#3317 #7/#8)

### DIFF
--- a/.changeset/retry-stream-findings-3317.md
+++ b/.changeset/retry-stream-findings-3317.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): retry transient MODEL_UNAVAILABLE + drop empty stream deltas (#3317 #7/#8)
+
+Two small api-mode parity findings from the #3317 audit:
+
+- **#7** `isRetryableError` now treats `MODEL_UNAVAILABLE` (transient 503/overloaded)
+  as retryable, matching HTTP 503. `MODEL_NOT_FOUND` stays non-retryable (retry
+  won't help).
+- **#8** the SDK streaming adapter skips empty-string (`''`) `text_delta` chunks —
+  the AI SDK can emit zero-length keepalive/boundary chunks that are noise for
+  downstream re-assemblers.

--- a/packages/nexus-agents/src/adapters/retry.test.ts
+++ b/packages/nexus-agents/src/adapters/retry.test.ts
@@ -246,6 +246,20 @@ describe('retry', () => {
         });
         expect(isRetryableError(error)).toBe(true);
       });
+
+      it('NexusError with MODEL_UNAVAILABLE code (transient 503/overloaded) (#3317 #7)', () => {
+        const error = new NexusError('Model temporarily unavailable', {
+          code: ErrorCode.MODEL_UNAVAILABLE,
+        });
+        expect(isRetryableError(error)).toBe(true);
+      });
+    });
+
+    it('keeps MODEL_NOT_FOUND non-retryable (retry will not help) (#3317 #7)', () => {
+      const error = new NexusError('Model not found', {
+        code: ErrorCode.MODEL_NOT_FOUND,
+      });
+      expect(isRetryableError(error)).toBe(false);
     });
   });
 

--- a/packages/nexus-agents/src/adapters/retry.ts
+++ b/packages/nexus-agents/src/adapters/retry.ts
@@ -250,6 +250,9 @@ export function isRetryableError(error: unknown): boolean {
       ErrorCode.MODEL_TIMEOUT,
       ErrorCode.TIMEOUT_ERROR,
       ErrorCode.RATE_LIMIT_ERROR,
+      // #3317 finding #7: a model temporarily unavailable (503/overloaded) is
+      // transient — retry. (MODEL_NOT_FOUND stays non-retryable: retry won't help.)
+      ErrorCode.MODEL_UNAVAILABLE,
     ];
     return retryableCodes.includes(error.code);
   }

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -238,6 +238,40 @@ describe('SdkAdapter', () => {
       });
       expect(chunks[7]).toEqual({ type: 'message_stop' });
     });
+
+    it('skips empty-string deltas (#3317 #8)', async () => {
+      const { streamText } = await import('ai');
+      const mockStream = vi.mocked(streamText);
+
+      // The SDK can emit zero-length chunks (keepalives/segment boundaries).
+      function* fakeTextIterGen(): Generator<string> {
+        yield 'Hello';
+        yield '';
+        yield ' world';
+        yield '';
+      }
+      const iter = fakeTextIterGen();
+      const textStream = Object.assign(new ReadableStream<string>(), {
+        [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve(iter.next()) }),
+      });
+      mockStream.mockReturnValueOnce({ textStream } as unknown as ReturnType<typeof streamText>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const deltas: string[] = [];
+      for await (const chunk of adapter.stream(TEST_REQUEST)) {
+        if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+          deltas.push(chunk.delta.text);
+        }
+      }
+
+      // Only the two non-empty chunks survive; no empty text_delta is emitted.
+      expect(deltas).toEqual(['Hello', ' world']);
+    });
   });
 
   describe('validateConfig', () => {

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -370,6 +370,10 @@ export class SdkAdapter extends BaseAdapter {
     yield { type: 'content_block_start', index, contentBlock: { type: 'text', text: '' } };
 
     for await (const text of result.textStream) {
+      // #3317 finding #8: skip empty-string deltas — the SDK can emit zero-length
+      // chunks (keepalives/segment boundaries); a `text_delta` with `text: ''` is
+      // noise that downstream re-assemblers must otherwise special-case.
+      if (text === '') continue;
       yield {
         type: 'content_block_delta',
         index,


### PR DESCRIPTION
## Context
Two small api-mode parity findings from the #3317 audit (findings #7 and #8).

## Changes
- **#7 — `adapters/retry.ts`:** `isRetryableError` now treats `ErrorCode.MODEL_UNAVAILABLE` as retryable (a model temporarily unavailable / 503 / overloaded is transient — matches HTTP 503 handling). `MODEL_NOT_FOUND` stays non-retryable (retry won't help). Verified gap: only RATE_LIMITED/TIMEOUT codes were retryable before.
- **#8 — `adapters/sdk/sdk-adapter.ts`:** `stream()` skips empty-string (`''`) `text_delta` chunks. The AI SDK can emit zero-length keepalive/segment-boundary chunks; an empty `text_delta` is noise downstream re-assemblers must special-case.

## Testing
- retry: MODEL_UNAVAILABLE retryable + MODEL_NOT_FOUND non-retryable assertions.
- stream: a sequence with interleaved empties yields only the non-empty deltas.
- `pnpm vitest run src/adapters/retry.test.ts src/adapters/sdk/sdk-adapter.test.ts` → 64 passed. typecheck + lint clean.

Advances epic #3317 (findings #5 responseFormat remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)