### PR TITLE
feat(adapters): native structured output for Gemini + SDK (#3433 phases 2+3)

### DIFF
--- a/.changeset/sdk-gemini-structured-output-3433.md
+++ b/.changeset/sdk-gemini-structured-output-3433.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+feat(adapters): native structured output for Gemini + SDK adapters (#3433 phases 2+3)
+
+`GeminiAdapter` and `SdkAdapter` now honor `CompletionRequest.responseFormat`
+instead of ignoring it:
+
+- **Gemini** sets `responseMimeType: 'application/json'` (json_object/json_schema)
+  and `responseSchema` (json_schema) on the generation config; the warn-and-ignore
+  is removed.
+- **SdkAdapter** routes `json_object`/`json_schema` through the Vercel AI SDK
+  `generateObject({schema})` (via `jsonSchema()`), returning the structured object
+  as a JSON text block; `text`/absent stays on `generateText` (unchanged), and
+  streaming remains text-only. The duck-typed `ai` exports + result shape are
+  runtime-validated (clear errors on a missing `generateObject`/`jsonSchema`
+  export; no unsafe casts).
+
+With Claude (phase 1) this means all three API adapters now produce native
+structured output — the backend for routing consensus voters off brittle regex
+extraction (remaining: voter wiring).

--- a/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
@@ -326,6 +326,98 @@ describe('GeminiAdapter', () => {
       }
     });
 
+    it('should set responseMimeType and responseSchema for json_schema (#3433)', async () => {
+      mockGenerateContent.mockResolvedValueOnce({
+        text: '{"answer":42}',
+        candidates: [{ finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+
+      const schema = {
+        type: 'object',
+        properties: { answer: { type: 'number' } },
+        required: ['answer'],
+      };
+      const adapter = new GeminiAdapter(validConfig);
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Give me the answer' }],
+        responseFormat: { type: 'json_schema', schema },
+        maxTokens: 1024,
+      });
+
+      expect(mockGenerateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            responseMimeType: 'application/json',
+            responseSchema: schema,
+          }),
+        })
+      );
+    });
+
+    it('should set only responseMimeType for json_object (#3433)', async () => {
+      mockGenerateContent.mockResolvedValueOnce({
+        text: '{"ok":true}',
+        candidates: [{ finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+
+      const adapter = new GeminiAdapter(validConfig);
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Respond in JSON' }],
+        responseFormat: { type: 'json_object' },
+        maxTokens: 1024,
+      });
+
+      const callArg = mockGenerateContent.mock.calls[0]?.[0] as {
+        config?: { responseMimeType?: string; responseSchema?: unknown };
+      };
+      expect(callArg.config?.responseMimeType).toBe('application/json');
+      expect(callArg.config?.responseSchema).toBeUndefined();
+    });
+
+    it('should not emit a warning when responseFormat is structured (#3433)', async () => {
+      mockGenerateContent.mockResolvedValueOnce({
+        text: '{"ok":true}',
+        candidates: [{ finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+
+      const adapter = new GeminiAdapter(validConfig);
+      const warnSpy = vi.spyOn(
+        (adapter as unknown as { logger: { warn: (...args: unknown[]) => void } }).logger,
+        'warn'
+      );
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Respond in JSON' }],
+        responseFormat: { type: 'json_object' },
+        maxTokens: 1024,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not set response format fields when responseFormat is text/absent (#3433)', async () => {
+      mockGenerateContent.mockResolvedValueOnce({
+        text: 'plain',
+        candidates: [{ finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+
+      const adapter = new GeminiAdapter(validConfig);
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        responseFormat: { type: 'text' },
+        maxTokens: 1024,
+      });
+
+      const callArg = mockGenerateContent.mock.calls[0]?.[0] as {
+        config?: { responseMimeType?: string; responseSchema?: unknown };
+      };
+      expect(callArg.config?.responseMimeType).toBeUndefined();
+      expect(callArg.config?.responseSchema).toBeUndefined();
+    });
+
     it('should return error for API failures', async () => {
       mockGenerateContent.mockRejectedValueOnce(new Error('API rate limit exceeded'));
 

--- a/packages/nexus-agents/src/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.ts
@@ -16,6 +16,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   ModelMetadata,
+  ResponseFormat,
   StreamChunk,
   ContentBlock,
   TokenUsage,
@@ -51,6 +52,24 @@ import { extractRequestSystemPrompt } from './prompt-utils.js';
 
 // Re-export types and constants
 export { GEMINI_MODELS, GEMINI_MODEL_ALIASES, type GeminiAdapterConfig } from './gemini-types.js';
+
+/**
+ * #3433: applies the request's responseFormat to the Gemini generation
+ * config for native structured output. json_object/json_schema set
+ * responseMimeType to 'application/json'; json_schema also forwards the
+ * schema. Gemini returns the JSON as response text, so mapResponse is
+ * unchanged. text/absent leaves the config untouched.
+ */
+function applyResponseFormat(
+  config: GeminiRequestConfig,
+  responseFormat: ResponseFormat | undefined
+): void {
+  if (responseFormat === undefined || responseFormat.type === 'text') return;
+  config.responseMimeType = 'application/json';
+  if (responseFormat.type === 'json_schema') {
+    config.responseSchema = responseFormat.schema;
+  }
+}
 
 /**
  * Gemini/Google AI model adapter.
@@ -278,19 +297,9 @@ export class GeminiAdapter extends BaseAdapter {
     // the Promise.race boundary.
     if (request.signal !== undefined) config.abortSignal = request.signal;
 
-    return config;
-  }
+    applyResponseFormat(config, request.responseFormat);
 
-  /**
-   * Logs warning when responseFormat is used with Gemini (not supported).
-   */
-  private warnIfUnsupportedFormat(request: CompletionRequest): void {
-    if (request.responseFormat !== undefined && request.responseFormat.type !== 'text') {
-      this.logger.warn('responseFormat is not supported by Gemini adapter', {
-        requestedFormat: request.responseFormat.type,
-        suggestion: 'Use tool use or prompt engineering for structured output',
-      });
-    }
+    return config;
   }
 
   /**
@@ -303,8 +312,6 @@ export class GeminiAdapter extends BaseAdapter {
 
     const params: GeminiRequestParams = { model: this.resolvedModelId, contents };
     const config = this.buildGenerationConfig(request);
-
-    this.warnIfUnsupportedFormat(request);
 
     if (Object.keys(config).length > 0) params.config = config;
     return params;

--- a/packages/nexus-agents/src/adapters/gemini-types.ts
+++ b/packages/nexus-agents/src/adapters/gemini-types.ts
@@ -170,6 +170,17 @@ export interface GeminiRequestConfig {
   tools?: Array<{ functionDeclarations: FunctionDeclaration[] }>;
   /** #3036: cancellation signal forwarded into @google/genai. */
   abortSignal?: AbortSignal;
+  /**
+   * #3433: native structured output. `'application/json'` for
+   * json_object/json_schema response formats; Gemini then returns JSON
+   * as the response text.
+   */
+  responseMimeType?: string;
+  /**
+   * #3433: JSON schema constraining the structured output. Set only for
+   * `json_schema` response formats; forwarded directly to @google/genai.
+   */
+  responseSchema?: Record<string, unknown>;
 }
 
 /**

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -8,10 +8,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SdkAdapter } from './sdk-adapter.js';
 import type { CompletionRequest } from '../../core/index.js';
 // Mock the AI SDK modules
-vi.mock('ai', () => ({
+// Full `ai` mock factory. The "missing export" tests (#3433) swap in a
+// partial module via vi.doMock + vi.resetModules; restoreAiMock() puts the
+// complete module back so later tests (stream, etc.) keep their mocks.
+const fullAiMock = (): Record<string, unknown> => ({
   generateText: vi.fn(),
   streamText: vi.fn(),
-}));
+  generateObject: vi.fn(),
+  // jsonSchema wraps a raw JSON schema; the real helper returns a Schema
+  // object. The adapter only forwards it to generateObject, so a passthrough
+  // that records the input is sufficient for assertions.
+  jsonSchema: vi.fn((schema: unknown) => ({ jsonSchema: schema })),
+});
+vi.mock('ai', () => fullAiMock());
+
+function restoreAiMock(): void {
+  vi.doMock('ai', () => fullAiMock());
+  vi.resetModules();
+}
 
 vi.mock('@ai-sdk/anthropic', () => ({
   createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
@@ -178,6 +192,156 @@ describe('SdkAdapter', () => {
       if (result.ok) {
         expect(result.value.stopReason).toBe('max_tokens');
       }
+    });
+
+    it('routes json_schema to generateObject and returns stringified object (#3433)', async () => {
+      const { generateObject, jsonSchema, generateText } = await import('ai');
+      const mockObject = vi.mocked(generateObject);
+      const mockJsonSchema = vi.mocked(jsonSchema);
+      const mockText = vi.mocked(generateText);
+      mockObject.mockResolvedValueOnce({
+        object: { answer: 42 },
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        response: { id: 'resp-1', timestamp: new Date(), modelId: 'claude-sonnet-4-6' },
+      } as unknown as Awaited<ReturnType<typeof generateObject>>);
+
+      const schema = { type: 'object', properties: { answer: { type: 'number' } } };
+      const adapter = new SdkAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const result = await adapter.complete({
+        ...TEST_REQUEST,
+        responseFormat: { type: 'json_schema', schema },
+      });
+
+      expect(mockObject).toHaveBeenCalledTimes(1);
+      expect(mockText).not.toHaveBeenCalled();
+      expect(mockJsonSchema).toHaveBeenCalledWith(schema);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.content[0]).toEqual({
+          type: 'text',
+          text: JSON.stringify({ answer: 42 }),
+        });
+        expect(result.value.usage.inputTokens).toBe(10);
+        expect(result.value.stopReason).toBe('end_turn');
+        expect(result.value.model).toBe('claude-sonnet-4-6');
+      }
+    });
+
+    it('routes json_object to generateObject with a permissive schema (#3433)', async () => {
+      const { generateObject, jsonSchema } = await import('ai');
+      const mockObject = vi.mocked(generateObject);
+      const mockJsonSchema = vi.mocked(jsonSchema);
+      mockObject.mockResolvedValueOnce({
+        object: { foo: 'bar' },
+        finishReason: 'stop',
+        usage: { inputTokens: 3, outputTokens: 2 },
+        response: { id: 'resp-1', timestamp: new Date(), modelId: 'claude-sonnet-4-6' },
+      } as unknown as Awaited<ReturnType<typeof generateObject>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const result = await adapter.complete({
+        ...TEST_REQUEST,
+        responseFormat: { type: 'json_object' },
+      });
+
+      expect(mockObject).toHaveBeenCalledTimes(1);
+      expect(mockJsonSchema).toHaveBeenCalledWith({ type: 'object' });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.content[0]).toEqual({
+          type: 'text',
+          text: JSON.stringify({ foo: 'bar' }),
+        });
+      }
+    });
+
+    it('routes text responseFormat to generateText (regression #3433)', async () => {
+      const { generateText, generateObject } = await import('ai');
+      const mockText = vi.mocked(generateText);
+      const mockObject = vi.mocked(generateObject);
+      mockText.mockResolvedValueOnce({
+        text: 'plain text',
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        response: { id: 'resp-1', timestamp: new Date(), modelId: 'claude-sonnet-4-6' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const result = await adapter.complete({
+        ...TEST_REQUEST,
+        responseFormat: { type: 'text' },
+      });
+
+      expect(mockText).toHaveBeenCalledTimes(1);
+      expect(mockObject).not.toHaveBeenCalled();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.content[0]).toEqual({ type: 'text', text: 'plain text' });
+      }
+    });
+
+    it('throws a clear error when generateObject export is missing (#3433)', async () => {
+      vi.resetModules();
+      vi.doMock('ai', () => ({
+        generateText: vi.fn(),
+        streamText: vi.fn(),
+        jsonSchema: vi.fn((schema: unknown) => ({ jsonSchema: schema })),
+        // generateObject intentionally missing
+      }));
+      const { SdkAdapter: FreshAdapter } = await import('./sdk-adapter.js');
+
+      const adapter = new FreshAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const result = await adapter.complete(TEST_REQUEST);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('generateObject');
+      }
+      restoreAiMock();
+    });
+
+    it('throws a clear error when jsonSchema export is missing (#3433)', async () => {
+      vi.resetModules();
+      vi.doMock('ai', () => ({
+        generateText: vi.fn(),
+        streamText: vi.fn(),
+        generateObject: vi.fn(),
+        // jsonSchema intentionally missing
+      }));
+      const { SdkAdapter: FreshAdapter } = await import('./sdk-adapter.js');
+
+      const adapter = new FreshAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      const result = await adapter.complete(TEST_REQUEST);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('jsonSchema');
+      }
+      restoreAiMock();
     });
   });
 

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -12,6 +12,7 @@ import type {
   CompletionRequest,
   CompletionResponse,
   ContentBlock,
+  ResponseFormat,
   StreamChunk,
   Result,
   ILogger,
@@ -53,10 +54,27 @@ interface StreamTextResult {
   textStream: AsyncIterable<string>;
 }
 
+/** AI SDK generateObject result shape (duck-typed). */
+interface GenerateObjectResult {
+  object: unknown;
+  finishReason: string;
+  usage: {
+    inputTokens: number | undefined;
+    outputTokens: number | undefined;
+    totalTokens: number | undefined;
+  };
+  response: { modelId: string };
+}
+
+/** Opaque schema handle returned by the AI SDK `jsonSchema` helper. */
+type AiSdkSchema = unknown;
+
 /** Function signatures for AI SDK entry points (loaded dynamically). */
 interface AiSdkFunctions {
   generateText: (options: Record<string, unknown>) => Promise<GenerateTextResult>;
   streamText: (options: Record<string, unknown>) => StreamTextResult;
+  generateObject: (options: Record<string, unknown>) => Promise<GenerateObjectResult>;
+  jsonSchema: (schema: Record<string, unknown>) => AiSdkSchema;
 }
 
 /** AI SDK provider factory: creates a provider instance that is callable as a model factory. */
@@ -93,16 +111,48 @@ function extractProviderFactory(
 function extractAiSdkFunctions(mod: Record<string, unknown>): AiSdkFunctions {
   const generateText = mod['generateText'];
   const streamText = mod['streamText'];
+  const generateObject = mod['generateObject'];
+  const jsonSchema = mod['jsonSchema'];
   if (typeof generateText !== 'function') {
     throw new Error("AI SDK module missing expected export: 'generateText'");
   }
   if (typeof streamText !== 'function') {
     throw new Error("AI SDK module missing expected export: 'streamText'");
   }
+  // #3433: structured output routes through generateObject + jsonSchema.
+  if (typeof generateObject !== 'function') {
+    throw new Error("AI SDK module missing expected export: 'generateObject'");
+  }
+  if (typeof jsonSchema !== 'function') {
+    throw new Error("AI SDK module missing expected export: 'jsonSchema'");
+  }
   return {
     generateText: generateText as AiSdkFunctions['generateText'],
     streamText: streamText as AiSdkFunctions['streamText'],
+    generateObject: generateObject as AiSdkFunctions['generateObject'],
+    jsonSchema: jsonSchema as AiSdkFunctions['jsonSchema'],
   };
+}
+
+/**
+ * Runtime-validates the duck-typed `generateObject` result shape (#3433).
+ *
+ * `generateObject` comes from the optional `ai` peer dependency, so its
+ * result is `unknown` to us. We narrow it here rather than casting, so a
+ * shape change in the SDK surfaces as a clear error instead of a silent
+ * `undefined` downstream.
+ */
+function isGenerateObjectResult(value: unknown): value is GenerateObjectResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  if (!('object' in record)) return false;
+  if (typeof record['finishReason'] !== 'string') return false;
+  const usage = record['usage'];
+  if (typeof usage !== 'object' || usage === null) return false;
+  const response = record['response'];
+  if (typeof response !== 'object' || response === null) return false;
+  if (typeof (response as Record<string, unknown>)['modelId'] !== 'string') return false;
+  return true;
 }
 
 /**
@@ -311,6 +361,61 @@ export class SdkAdapter extends BaseAdapter {
     return options;
   }
 
+  /**
+   * generateText path (text / absent responseFormat) — unchanged behavior.
+   */
+  private async completeText(
+    sdk: AiSdkFunctions,
+    options: Record<string, unknown>
+  ): Promise<CompletionResponse> {
+    const result = await sdk.generateText(options);
+    return {
+      content: [{ type: 'text', text: result.text }],
+      usage: {
+        inputTokens: result.usage.inputTokens ?? 0,
+        outputTokens: result.usage.outputTokens ?? 0,
+        totalTokens: result.usage.totalTokens ?? 0,
+      },
+      stopReason: mapFinishReason(result.finishReason),
+      model: result.response.modelId,
+    };
+  }
+
+  /**
+   * generateObject path (#3433) — json_object / json_schema responseFormat.
+   *
+   * Uses the AI SDK `jsonSchema` helper to build the schema handle
+   * (permissive `{ type: 'object' }` for json_object), then stringifies the
+   * returned object into a text content block so downstream parsers /
+   * extractTextFromResponse keep working unchanged.
+   */
+  private async completeStructured(
+    sdk: AiSdkFunctions,
+    options: Record<string, unknown>,
+    responseFormat: Exclude<ResponseFormat, { type: 'text' }>
+  ): Promise<CompletionResponse> {
+    const rawSchema: Record<string, unknown> =
+      responseFormat.type === 'json_schema' ? responseFormat.schema : { type: 'object' };
+    const schema = sdk.jsonSchema(rawSchema);
+    const result: unknown = await sdk.generateObject({ ...options, schema });
+    if (!isGenerateObjectResult(result)) {
+      throw new Error(
+        'AI SDK generateObject returned an unexpected result shape ' +
+          '(missing object/usage/finishReason/response.modelId)'
+      );
+    }
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result.object) }],
+      usage: {
+        inputTokens: result.usage.inputTokens ?? 0,
+        outputTokens: result.usage.outputTokens ?? 0,
+        totalTokens: result.usage.totalTokens ?? 0,
+      },
+      stopReason: mapFinishReason(result.finishReason),
+      model: result.response.modelId,
+    };
+  }
+
   async complete(request: CompletionRequest): Promise<Result<CompletionResponse, ModelError>> {
     try {
       await this.ensureInitialized();
@@ -324,18 +429,15 @@ export class SdkAdapter extends BaseAdapter {
         );
       }
       const options = this.buildSdkOptions(request);
-      const result = await sdk.generateText(options);
 
-      const response: CompletionResponse = {
-        content: [{ type: 'text', text: result.text }],
-        usage: {
-          inputTokens: result.usage.inputTokens ?? 0,
-          outputTokens: result.usage.outputTokens ?? 0,
-          totalTokens: result.usage.totalTokens ?? 0,
-        },
-        stopReason: mapFinishReason(result.finishReason),
-        model: result.response.modelId,
-      };
+      // #3433: native structured output. json_object/json_schema route
+      // through generateObject; everything else keeps the generateText path
+      // unchanged.
+      const responseFormat = request.responseFormat;
+      const response =
+        responseFormat !== undefined && responseFormat.type !== 'text'
+          ? await this.completeStructured(sdk, options, responseFormat)
+          : await this.completeText(sdk, options);
 
       this.logResponse(response);
       return ok(response);


### PR DESCRIPTION
## Context
Second increment of #3433 (epic #3317 finding #5). Makes the remaining API adapters honor `responseFormat` (Claude landed in #3435). These are independent of the vote schema — they honor `responseFormat.schema` generically.

## Changes
- **Gemini** (`gemini-adapter.ts` + `gemini-types.ts`): `applyResponseFormat` sets `responseMimeType:'application/json'` (json_object/json_schema) + `responseSchema` (json_schema) on the generation config; `warnIfUnsupportedFormat` fully removed. `mapResponse` unchanged (Gemini returns JSON as text).
- **SdkAdapter** (`sdk/sdk-adapter.ts`): `complete` splits into `completeText` (existing `generateText`, unchanged) and `completeStructured` (AI SDK `generateObject` via `jsonSchema()`), stringifying the object into a text block. `text`/absent → `generateText`; streaming stays text-only. The duck-typed `ai` exports (`generateObject`/`jsonSchema`) + `GenerateObjectResult` shape are runtime-validated (`isGenerateObjectResult`) — clear errors, no unsafe casts.

## Review (this PR)
- **QA: APPROVE** — no Critical/Important; text path provably unchanged, duck-typing guards sound. One Low note (usage-interior trusted, covered by `?? 0`).
- **Security: CLEAN** (0 findings) — schema is provider-bound data; model `.object` is stringify-only then validated downstream; custom-openai SSRF guard preserved (independent of the new path).
- **Cleanup: clean** — warn fully removed, no orphans, test mock-restoration correct.

## Testing
`pnpm vitest run src/adapters/gemini-adapter.test.ts src/adapters/sdk/sdk-adapter.test.ts` → **71 passed** (incl. text-regression + both missing-export throws). typecheck + lint clean.

Remaining #3433: voter wiring (set responseFormat + consume structured output, regex as fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)