### PR TITLE
feat(consensus): voters request native structured output (#3433 phase 4)

### DIFF
--- a/.changeset/voter-structured-output-3433.md
+++ b/.changeset/voter-structured-output-3433.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+feat(consensus): voters request native structured output (#3433 phase 4)
+
+`executeSingleVoteAttempt` now sets `responseFormat: {type:'json_schema', schema:
+VOTE_JSON_SCHEMA}` on the vote request, so voters backed by Claude (tool_use),
+OpenAI/SDK (generateObject), or Gemini (json mode) return a schema-valid vote
+object natively instead of prose-wrapped JSON — the brittle regex extraction that
+caused intermittent voter parse failures. Adapters that don't honor
+responseFormat ignore it and the existing `extractTextFromResponse` +
+`parseVoteResponse` (regex + Zod) path is the unchanged fallback, so no backend
+regresses. Completes #3433 (epic #3317 finding #5).

--- a/packages/nexus-agents/src/cli/voter-execution.test.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.test.ts
@@ -438,6 +438,54 @@ describe('voter-execution', () => {
       expect(request.maxTokens).toBeLessThanOrEqual(8000);
     });
 
+    it('requests native structured output via responseFormat=json_schema (#3433)', async () => {
+      const mockResponse: MockCompletionResult = {
+        ok: true,
+        value: {
+          content: [{ type: 'text', text: VALID_VOTE_JSON }],
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          stopReason: 'end_turn',
+          model: 'test-model',
+        },
+      };
+      vi.mocked(mockAdapter.complete).mockResolvedValue(mockResponse);
+
+      await executeSingleVoteAttempt('devex', 'Test proposal', mockAdapter, 5000);
+
+      const request = vi.mocked(mockAdapter.complete).mock.calls[0]?.[0] as {
+        responseFormat?: { type?: string; schema?: unknown };
+      };
+      expect(request.responseFormat?.type).toBe('json_schema');
+      expect(request.responseFormat?.schema).toBeDefined();
+    });
+
+    it('still parses a structured-output vote object the same as prose JSON (fallback parity)', async () => {
+      // Whether the vote arrives via native structured output or the regex
+      // fallback, the content is JSON text and parses identically (#3433).
+      const mockResponse: MockCompletionResult = {
+        ok: true,
+        value: {
+          content: [{ type: 'text', text: VALID_VOTE_JSON }],
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          stopReason: 'tool_use',
+          model: 'test-model',
+        },
+      };
+      vi.mocked(mockAdapter.complete).mockResolvedValue(mockResponse);
+
+      const result = await executeSingleVoteAttempt(
+        'architect',
+        'Test proposal',
+        mockAdapter,
+        5000
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.vote.decision).toBe('approve');
+      }
+    });
+
     it('should return error on adapter failure', async () => {
       const mockResponse: MockCompletionResult = {
         ok: false,

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -13,7 +13,12 @@ import type { IModelAdapter, CompletionRequest, ILogger } from '../core/index.js
 import { getRandomProvider } from '../core/index.js';
 import { delay, withTimeout } from '../utils/async-utils.js';
 import { VOTER_SYSTEM_PROMPTS, SIMULATED_VOTE_REASONING } from './voter-prompts.js';
-import { buildVotePrompt, parseVoteResponse, SyntheticVoteError } from './voter-response.js';
+import {
+  buildVotePrompt,
+  parseVoteResponse,
+  SyntheticVoteError,
+  VOTE_JSON_SCHEMA,
+} from './voter-response.js';
 
 // Import timeout constants from canonical source (Issue #984)
 import {
@@ -253,6 +258,12 @@ export async function executeSingleVoteAttempt(
     // refine per use case if needed.
     maxTokens: 2000,
     temperature: 0.3, // Low temperature for consistent evaluations
+    // #3433: request native structured output (Claude tool_use / OpenAI+Gemini
+    // json mode) so the vote arrives as a schema-valid JSON object instead of
+    // prose-wrapped JSON. Adapters that don't honor responseFormat ignore it and
+    // the existing extractTextFromResponse + parseVoteResponse regex/Zod path
+    // below is the fallback — no behavior change for those backends.
+    responseFormat: { type: 'json_schema', schema: VOTE_JSON_SCHEMA },
     // Thread the vote's budget into the adapter so its shorter standard CLI
     // timeout doesn't fire first and surface as an MCP -32001 on slow voters
     // (e.g. the Security role on complex proposals) (#3304).


### PR DESCRIPTION
## Context
Final increment of #3433 (epic #3317 finding #5) — wires the voter path to use the native structured output the adapters now support (Claude #3435, Gemini+SDK #3436).

## Change
`executeSingleVoteAttempt` (cli/voter-execution.ts) sets `responseFormat: {type:'json_schema', schema: VOTE_JSON_SCHEMA}` on the vote request. Voters backed by Claude (tool_use), OpenAI/SDK (generateObject), or Gemini (json mode) now return a schema-valid vote object **natively** instead of prose-wrapped JSON — eliminating the brittle regex extraction behind intermittent voter parse failures.

**Fallback preserved:** adapters that don't honor `responseFormat` (CLI subprocess) ignore it; the existing `extractTextFromResponse` + `parseVoteResponse` (regex + Zod) path is unchanged, so no backend regresses. This also gives `VOTE_JSON_SCHEMA` (added in #3435) its production consumer.

## Testing
- New: request carries `responseFormat.type==='json_schema'` + schema; structured-output vote (`stopReason:'tool_use'`) parses identically to prose JSON (fallback parity).
- `pnpm vitest run src/cli/voter-execution.test.ts` → 59 passed. typecheck + lint clean.

Self-reviewed (2-line production change): fallback unchanged; schema is the internal constant; no new logging. Completes #3433 / epic #3317 finding #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)