### PR TITLE
test(routing): lock api:* arm participation in tier stages (#3424)

### DIFF
--- a/.changeset/api-arms-tier-stages-3424.md
+++ b/.changeset/api-arms-tier-stages-3424.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+test(routing): lock api:\* arm participation in tier stages (#3424)
+
+Verify-before-implement found #3424 already resolved by the #3422 migration:
+`filterByPreferenceTier` and `filterByDifficultyTier` collapse an `api:*` arm to
+its display slot (`routingArmDisplaySlot`) for tier membership/ordering, so a
+wrapped API arm inherits its vendor slot's tier and is never dropped. Adds
+regression tests pinning that behavior (api:anthropic → strong/powerful as
+claude; api:openai → weak as codex; arms preserved, not filtered out).

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { TaskProfile } from '../core/index.js';
-import type { CliName, CliTask } from './types.js';
+import type { CliName, CliTask, RoutingArmId } from './types.js';
 import type { TopsisModelProfile } from './topsis-types.js';
 import type {} from './zero-router-types.js';
 import {
@@ -276,6 +276,15 @@ describe('filterByPreferenceTier', () => {
     const result = filterByPreferenceTier(['codex'] as CliName[], 'strong');
     expect(result).toEqual(['codex']);
   });
+
+  it('includes an api:* arm by its display slot tier (#3424)', () => {
+    // api:anthropic collapses to the `claude` slot → eligible for the strong
+    // tier; api:openai collapses to `codex` → weak. The arm id is preserved.
+    expect(filterByPreferenceTier(['api:anthropic', 'api:openai'], 'strong')).toEqual([
+      'api:anthropic',
+    ]);
+    expect(filterByPreferenceTier(['api:anthropic', 'api:openai'], 'weak')).toEqual(['api:openai']);
+  });
 });
 
 // ============================================================================
@@ -539,6 +548,15 @@ describe('filterByDifficultyTier', () => {
     const result = filterByDifficultyTier(candidates, 'fast');
     expect(result).toHaveLength(3);
     expect(new Set(result)).toEqual(new Set(candidates));
+  });
+
+  it('keeps api:* arms and sorts them by display slot (#3424)', () => {
+    // api:anthropic sorts as `claude` → first in the powerful tier; the distinct
+    // arm id is never dropped (the gap #3424 worried about does not exist).
+    const withApi: RoutingArmId[] = ['api:openai', 'api:anthropic'];
+    const result = filterByDifficultyTier(withApi, 'powerful');
+    expect(result[0]).toBe('api:anthropic');
+    expect(new Set(result)).toEqual(new Set(withApi));
   });
 });
 


### PR DESCRIPTION
## Context
Closes #3424 (epic #3317 follow-up). **Verify-before-implement found the gap already closed** by the #3422 migration: `filterByPreferenceTier` and `filterByDifficultyTier` (composite-router-helpers.ts) already collapse an `api:*` arm to its display slot via `routingArmDisplaySlot()` for tier membership/ordering. So `api:anthropic` is eligible for the strong/powerful tier (as `claude`) and is never dropped — the concern raised when filing #3424 was based on pre-migration code.

## Change
Test-only: regression tests pinning the behavior so it can't silently regress —
- `filterByPreferenceTier(['api:anthropic','api:openai'],'strong')` → `['api:anthropic']`; `'weak'` → `['api:openai']`.
- `filterByDifficultyTier` keeps api arms and sorts `api:anthropic` first in the powerful tier (as `claude`).

## Testing
`pnpm vitest run src/cli-adapters/composite-router-helpers.test.ts` → 69 passed. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)