### PR TITLE
security(custom-api): resolve-time SSRF guard for custom-openai gateway (#3426)

### DIFF
--- a/.changeset/ssrf-resolve-time-guard-3426.md
+++ b/.changeset/ssrf-resolve-time-guard-3426.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': patch
+---
+
+Add a DNS-resolve-time SSRF guard for the custom-openai gateway (#3426). A public
+DNS name that resolves to a private/loopback/link-local/metadata IP is now rejected
+before the first outbound request, closing the documented gap in the string-level
+`classifyPrivateHost` check. Fail-open on transient DNS errors; bypassed by
+`NEXUS_CUSTOM_API_ALLOW_PRIVATE=1`. Resolve-time only — a TOCTOU/DNS-rebinding
+window remains pending a socket-layer `lookup` hook.

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { validateCustomApiBaseUrl } from './custom-api-validation.js';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import {
+  validateCustomApiBaseUrl,
+  assertCustomApiHostResolvesPublic,
+} from './custom-api-validation.js';
 import { CUSTOM_API_ALLOW_PRIVATE_ENV } from './types.js';
+
+// Mock the DNS promises API so resolve-time tests don't hit a real resolver.
+const lookupMock = vi.hoisted(() => vi.fn());
+vi.mock('node:dns/promises', () => ({
+  lookup: lookupMock,
+}));
 
 // Restore the original env var on every teardown so tests that flip
 // NEXUS_CUSTOM_API_ALLOW_PRIVATE don't leak into siblings.
@@ -175,6 +184,115 @@ describe('validateCustomApiBaseUrl', () => {
       process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = 'yes';
       const result = validateCustomApiBaseUrl('http://localhost/');
       expect(result.ok).toBe(false);
+    });
+  });
+});
+
+describe('assertCustomApiHostResolvesPublic (DNS-resolve-time SSRF guard, #3426)', () => {
+  const originalEnv = process.env[CUSTOM_API_ALLOW_PRIVATE_ENV];
+
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      Reflect.deleteProperty(process.env, 'NEXUS_CUSTOM_API_ALLOW_PRIVATE');
+    } else {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = originalEnv;
+    }
+  });
+
+  describe('public name resolving to a private IP is rejected', () => {
+    it('rejects a public name that resolves to 10.0.0.5 (RFC 1918)', async () => {
+      lookupMock.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+      const result = await assertCustomApiHostResolvesPublic('gateway.evil.test');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/private/i);
+      expect(result.error.message).toMatch(/gateway\.evil\.test/);
+    });
+
+    it('rejects a public name that resolves to 127.0.0.1 (loopback)', async () => {
+      lookupMock.mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+      const result = await assertCustomApiHostResolvesPublic('localhost-rebind.test');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/loopback/i);
+    });
+
+    it('rejects a public name that resolves to 169.254.169.254 (AWS IMDS link-local)', async () => {
+      lookupMock.mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }]);
+      const result = await assertCustomApiHostResolvesPublic('imds.evil.test');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/link.?local/i);
+    });
+
+    it('rejects a public name that resolves to ::1 (IPv6 loopback)', async () => {
+      lookupMock.mockResolvedValueOnce([{ address: '::1', family: 6 }]);
+      const result = await assertCustomApiHostResolvesPublic('v6-loopback.test');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/loopback/i);
+    });
+
+    it('rejects if ANY of multiple resolved addresses is private (fail-closed)', async () => {
+      lookupMock.mockResolvedValueOnce([
+        { address: '93.184.216.34', family: 4 }, // public
+        { address: '192.168.1.1', family: 4 }, // private — must trip the guard
+      ]);
+      const result = await assertCustomApiHostResolvesPublic('multi.test');
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('public name resolving to a public IP is allowed', () => {
+    it('accepts a public name that resolves to a public IP', async () => {
+      lookupMock.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+      const result = await assertCustomApiHostResolvesPublic('gateway.example.com');
+      expect(result.ok).toBe(true);
+      expect(lookupMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('IP literals skip DNS (handled by the sync guard at construction)', () => {
+    it('does not call dns.lookup for an IPv4 literal', async () => {
+      const result = await assertCustomApiHostResolvesPublic('93.184.216.34');
+      expect(result.ok).toBe(true);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call dns.lookup for a bracket-stripped IPv6 literal', async () => {
+      const result = await assertCustomApiHostResolvesPublic('[2606:2800:220:1::1]');
+      expect(result.ok).toBe(true);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('allowPrivate bypass performs no lookup', () => {
+    it('bypasses (no lookup) when allowPrivate=true is passed', async () => {
+      const result = await assertCustomApiHostResolvesPublic('gateway.evil.test', {
+        allowPrivate: true,
+      });
+      expect(result.ok).toBe(true);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('bypasses (no lookup) when NEXUS_CUSTOM_API_ALLOW_PRIVATE=1', async () => {
+      process.env[CUSTOM_API_ALLOW_PRIVATE_ENV] = '1';
+      const result = await assertCustomApiHostResolvesPublic('gateway.evil.test');
+      expect(result.ok).toBe(true);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fail-open on lookup error (additive defense-in-depth)', () => {
+    it('returns ok when dns.lookup throws (does not break legit gateways)', async () => {
+      lookupMock.mockRejectedValueOnce(new Error('ENOTFOUND transient'));
+      const result = await assertCustomApiHostResolvesPublic('flaky-resolver.example.com');
+      expect(result.ok).toBe(true);
+      expect(lookupMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
@@ -207,6 +207,9 @@ export async function assertCustomApiHostResolvesPublic(
     return ok(undefined);
   }
 
+  // Only `address` is read; the resolver's `family` is intentionally NOT
+  // trusted — `classifyIpAddress` re-derives v4/v6 from the address string, so
+  // a mislabeled family in the lookup result cannot let a private IP slip past.
   let addresses: ReadonlyArray<{ readonly address: string }>;
   try {
     addresses = await dnsLookup(hostname, { all: true });

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
@@ -14,8 +14,11 @@
  */
 
 import { isIPv4, isIPv6 } from 'node:net';
-import { ConfigError, ok, err, type Result } from '../../core/index.js';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { ConfigError, ok, err, createLogger, type Result } from '../../core/index.js';
 import { CUSTOM_API_ALLOW_PRIVATE_ENV } from './types.js';
+
+const logger = createLogger({ module: 'custom-api-validation' });
 
 /**
  * Why a given URL was rejected. Machine-readable so error messages can
@@ -99,24 +102,17 @@ function resolveAllowPrivateFromEnv(): boolean {
  *
  * Note: this is a string-level check. It does NOT perform DNS resolution,
  * so a public DNS name that secretly resolves to a private IP will pass.
- * Callers who need that level of defense should add a runtime connect
- * check and validate the socket peer address.
+ * For that level of defense, callers should additionally run
+ * {@link assertCustomApiHostResolvesPublic}, which performs a DNS lookup
+ * and classifies each resolved address with the same range tables below.
  */
 function classifyPrivateHost(hostname: string): RejectionDetail | null {
-  // URL.hostname wraps IPv6 literals in brackets (e.g. "[::1]"); strip them
-  // before the net-module checks, which expect bare forms.
-  const stripped =
-    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
-  const normalized = stripped.toLowerCase();
+  const normalized = normalizeHost(hostname);
 
-  // Literal IPv4 loopback or private-range address
-  if (isIPv4(normalized)) {
-    return classifyIPv4(normalized);
-  }
-
-  // Literal IPv6 loopback (::1), link-local (fe80::/10), unique-local (fc00::/7)
-  if (isIPv6(normalized)) {
-    return classifyIPv6(normalized);
+  // Literal IP addresses — classify directly against the range tables.
+  const literal = classifyIpAddress(normalized);
+  if (literal !== 'not_an_ip') {
+    return literal;
   }
 
   // Hostname literals that resolve to loopback without needing DNS
@@ -131,6 +127,127 @@ function classifyPrivateHost(hostname: string): RejectionDetail | null {
     };
   }
 
+  return null;
+}
+
+/**
+ * Strips IPv6 bracket wrapping (URL.hostname yields "[::1]") and lowercases,
+ * giving the bare form the `node:net` checks expect. Shared by the sync and
+ * async guards so the normalization rule lives in one place.
+ */
+function normalizeHost(hostname: string): string {
+  const stripped =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  return stripped.toLowerCase();
+}
+
+/**
+ * Classifies a single (already normalized, bracket-stripped) address string.
+ * Returns:
+ *  - a {@link RejectionDetail} if it is a private/loopback/link-local/reserved IP,
+ *  - `null` if it is a public IP literal (safe),
+ *  - the sentinel `'not_an_ip'` if the string is not an IP literal at all.
+ *
+ * This is the shared per-address classifier reused by both the sync
+ * string-level guard ({@link classifyPrivateHost}) and the async
+ * DNS-resolve-time guard ({@link assertCustomApiHostResolvesPublic}), so the
+ * IPv4/IPv6 range tables live in exactly one place.
+ */
+function classifyIpAddress(normalized: string): RejectionDetail | null | 'not_an_ip' {
+  if (isIPv4(normalized)) {
+    return classifyIPv4(normalized);
+  }
+  if (isIPv6(normalized)) {
+    return classifyIPv6(normalized);
+  }
+  return 'not_an_ip';
+}
+
+/**
+ * DNS-resolve-time SSRF guard for the custom-openai gateway.
+ *
+ * The sync {@link validateCustomApiBaseUrl} only inspects the hostname as a
+ * string, so a PUBLIC DNS name that resolves to a PRIVATE/loopback/link-local
+ * IP (e.g. an attacker-controlled `gateway.evil.test` pointing at
+ * `169.254.169.254`) slips past it. This function closes that gap: it resolves
+ * the hostname and runs the EXISTING IP classification against every returned
+ * address, failing closed if ANY of them is private.
+ *
+ * Behaviour:
+ *  - `allowPrivate` (opt or env) → bypass, returns `ok` (matches the sync guard).
+ *  - hostname is already an IP literal → no DNS needed; the sync guard already
+ *    classified literals at construction, so return `ok`.
+ *  - otherwise `dns.lookup(hostname, { all: true })` and classify each address.
+ *    If ANY resolves private → `err(ConfigError)`.
+ *  - on a `dns.lookup` THROW (transient/NXDOMAIN/network error) → log debug and
+ *    return `ok`. Failing closed here is too aggressive: it would break legit
+ *    gateways on a flaky resolver, and this is additive defense-in-depth layered
+ *    on top of the sync string guard that already ran at construction. We only
+ *    REJECT on a SUCCESSFUL resolution to a private address.
+ *
+ * Residual risk (TOCTOU): this is RESOLVE-time, not socket-connect-time. A name
+ * that passes here could rebind to a private IP before the actual connect
+ * (DNS rebinding). A full fix needs a custom `fetch` `lookup` hook validating
+ * the peer address at the socket layer — out of scope for this LOW
+ * defense-in-depth pass (#3426).
+ */
+export async function assertCustomApiHostResolvesPublic(
+  hostname: string,
+  opts: { readonly allowPrivate?: boolean } = {}
+): Promise<Result<void, ConfigError>> {
+  const allowPrivate = opts.allowPrivate === true || resolveAllowPrivateFromEnv();
+  if (allowPrivate) {
+    return ok(undefined);
+  }
+
+  const normalized = normalizeHost(hostname);
+
+  // IP literals are already handled by the sync guard at construction; no DNS.
+  if (isIPv4(normalized) || isIPv6(normalized)) {
+    return ok(undefined);
+  }
+
+  let addresses: ReadonlyArray<{ readonly address: string }>;
+  try {
+    addresses = await dnsLookup(hostname, { all: true });
+  } catch (error) {
+    // Fail OPEN: transient/NXDOMAIN/network errors must not break legit
+    // gateways. The sync string guard already ran; this is additive only.
+    logger.debug('custom-api SSRF resolve check: DNS lookup failed, skipping (fail-open)', {
+      hostname,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return ok(undefined);
+  }
+
+  const rejection = firstPrivateAddress(addresses);
+  if (rejection !== null) {
+    return err(
+      new ConfigError(
+        `Custom API base URL rejected (SSRF resolve guard, reason="${rejection.reason}"): ` +
+          `hostname "${hostname}" resolved to ${rejection.message}. ` +
+          `Set ${CUSTOM_API_ALLOW_PRIVATE_ENV}=1 to bypass if the gateway runs on a trusted internal host.`
+      )
+    );
+  }
+
+  return ok(undefined);
+}
+
+/**
+ * Returns the {@link RejectionDetail} for the first resolved address that
+ * classifies as private/loopback/link-local/reserved, or `null` if every
+ * address is public. Fail-closed: any single private hit trips the guard.
+ */
+function firstPrivateAddress(
+  addresses: ReadonlyArray<{ readonly address: string }>
+): RejectionDetail | null {
+  for (const { address } of addresses) {
+    const rejection = classifyIpAddress(address.toLowerCase());
+    if (rejection !== null && rejection !== 'not_an_ip') {
+      return rejection;
+    }
+  }
   return null;
 }
 

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -478,6 +478,35 @@ describe('SdkAdapter', () => {
       expect(dnsLookupMock).toHaveBeenCalledTimes(1);
     });
 
+    it('does NOT cache a rejection — a retry re-runs the guard (#3426 QA)', async () => {
+      // First resolution is private (rejected); the flag must stay unset so a
+      // retry re-checks instead of silently skipping the guard.
+      dnsLookupMock.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+      const { generateText } = await import('ai');
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'gpt-4o' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'custom-openai',
+        modelId: 'gpt-4o',
+        apiKey: 'test-key',
+        baseUrl: 'https://gateway.flaky.test/v1',
+      });
+
+      const rejected = await adapter.complete(TEST_REQUEST);
+      expect(rejected.ok).toBe(false);
+
+      // Retry: now resolves public → re-checked (lookup called again) and passes.
+      dnsLookupMock.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+      const retried = await adapter.complete(TEST_REQUEST);
+      expect(retried.ok).toBe(true);
+      expect(dnsLookupMock).toHaveBeenCalledTimes(2);
+    });
+
     it('allows a gateway hostname that resolves to a public IP', async () => {
       dnsLookupMock.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
       const { generateText } = await import('ai');

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -39,6 +39,13 @@ vi.mock('@ai-sdk/google', () => ({
   createGoogleGenerativeAI: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
+// DNS-resolve-time SSRF guard (#3426): mock node:dns/promises so the
+// custom-openai resolve check is deterministic and never hits a real resolver.
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsLookupMock,
+}));
+
 const TEST_REQUEST: CompletionRequest = {
   messages: [
     {
@@ -447,6 +454,91 @@ describe('SdkAdapter', () => {
       });
       const result = adapter.validateConfig();
       expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('custom-openai DNS-resolve-time SSRF guard (#3426)', () => {
+    beforeEach(() => {
+      dnsLookupMock.mockReset();
+    });
+
+    it('rejects when the gateway hostname resolves to a private IP', async () => {
+      dnsLookupMock.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+      const adapter = new SdkAdapter({
+        providerId: 'custom-openai',
+        modelId: 'gpt-4o',
+        apiKey: 'test-key',
+        baseUrl: 'https://gateway.evil.test/v1',
+      });
+
+      const result = await adapter.complete(TEST_REQUEST);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/SSRF/i);
+      expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a gateway hostname that resolves to a public IP', async () => {
+      dnsLookupMock.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+      const { generateText } = await import('ai');
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'gpt-4o' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'custom-openai',
+        modelId: 'gpt-4o',
+        apiKey: 'test-key',
+        baseUrl: 'https://gateway.example.com/v1',
+      });
+
+      const result = await adapter.complete(TEST_REQUEST);
+      expect(result.ok).toBe(true);
+    });
+
+    it('resolves once and caches across multiple requests', async () => {
+      dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      const { generateText } = await import('ai');
+      vi.mocked(generateText).mockResolvedValue({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'gpt-4o' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'custom-openai',
+        modelId: 'gpt-4o',
+        apiKey: 'test-key',
+        baseUrl: 'https://gateway.example.com/v1',
+      });
+
+      await adapter.complete(TEST_REQUEST);
+      await adapter.complete(TEST_REQUEST);
+      // Cached: hostname resolved exactly once despite two requests.
+      expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('never resolves for non-custom providers', async () => {
+      const { generateText } = await import('ai');
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'claude-sonnet-4-6' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet-4-6',
+        apiKey: 'test-key',
+      });
+
+      await adapter.complete(TEST_REQUEST);
+      expect(dnsLookupMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -30,7 +30,10 @@ import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
-import { validateCustomApiBaseUrl } from './custom-api-validation.js';
+import {
+  validateCustomApiBaseUrl,
+  assertCustomApiHostResolvesPublic,
+} from './custom-api-validation.js';
 
 /** Minimal AI SDK model interface (duck-typed for optional dependency). */
 interface AiSdkModel {
@@ -231,6 +234,12 @@ export class SdkAdapter extends BaseAdapter {
   private readonly customBaseUrl: string | undefined;
   /** Inflight init promise for coalescing concurrent calls (Issue #1438). */
   private initPromise: Promise<void> | undefined;
+  /**
+   * Cached result of the DNS-resolve-time SSRF check for custom-openai
+   * (#3426). Resolved once on first init so we don't re-resolve the gateway
+   * hostname on every request. `undefined` until the check has run.
+   */
+  private resolveSsrfChecked = false;
 
   constructor(config: SdkAdapterConfig, logger?: ILogger) {
     const apiKey = resolveApiKey(config.providerId, config.apiKey);
@@ -283,6 +292,36 @@ export class SdkAdapter extends BaseAdapter {
     // AI SDK is an optional peer dependency — validate shape at runtime
     const aiModule = await import('ai');
     this.sdkFunctions = extractAiSdkFunctions(aiModule);
+
+    // DNS-resolve-time SSRF guard for custom-openai gateways (#3426). The
+    // construction-time guard is string-level only; this resolves the gateway
+    // hostname and rejects if it points at a private/loopback/link-local IP.
+    // Runs once (cached) before the first outbound request.
+    await this.ensureCustomHostResolvesPublic();
+  }
+
+  /**
+   * For custom-openai only: run the DNS-resolve-time SSRF check exactly once
+   * and throw if the gateway hostname resolves to a private address (#3426).
+   * Cached via `resolveSsrfChecked` so the hostname is not re-resolved on
+   * every request. No-op for non-custom providers (built-in endpoints are
+   * trusted) and when no custom base URL is configured.
+   */
+  private async ensureCustomHostResolvesPublic(): Promise<void> {
+    if (this.resolveSsrfChecked) return;
+    if (this.sdkProviderId !== 'custom-openai' || this.customBaseUrl === undefined) {
+      this.resolveSsrfChecked = true;
+      return;
+    }
+    const hostname = new URL(this.customBaseUrl).hostname;
+    const result = await assertCustomApiHostResolvesPublic(hostname);
+    // Mark checked only after a non-throwing classification so a transient
+    // resolver failure inside the guard (which returns ok) doesn't get cached
+    // as a permanent pass any more eagerly than the guard itself intends.
+    this.resolveSsrfChecked = true;
+    if (!result.ok) {
+      throw result.error;
+    }
   }
 
   /**

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -285,6 +285,14 @@ export class SdkAdapter extends BaseAdapter {
       });
     }
 
+    // DNS-resolve-time SSRF guard for custom-openai gateways (#3426). The
+    // construction-time guard is string-level only; this resolves the gateway
+    // hostname and rejects if it points at a private/loopback/link-local IP.
+    // Run BEFORE any model state is set so a rejection leaves the adapter
+    // uninitialized — a retry re-runs the guard rather than skipping it via the
+    // `this.model !== undefined` short-circuit in ensureInitialized().
+    await this.ensureCustomHostResolvesPublic();
+
     // Dynamic import — AI SDK is an optional peer dependency
     const providerModule = await this.loadProvider(apiKey);
     this.model = providerModule.model;
@@ -292,12 +300,6 @@ export class SdkAdapter extends BaseAdapter {
     // AI SDK is an optional peer dependency — validate shape at runtime
     const aiModule = await import('ai');
     this.sdkFunctions = extractAiSdkFunctions(aiModule);
-
-    // DNS-resolve-time SSRF guard for custom-openai gateways (#3426). The
-    // construction-time guard is string-level only; this resolves the gateway
-    // hostname and rejects if it points at a private/loopback/link-local IP.
-    // Runs once (cached) before the first outbound request.
-    await this.ensureCustomHostResolvesPublic();
   }
 
   /**
@@ -315,13 +317,15 @@ export class SdkAdapter extends BaseAdapter {
     }
     const hostname = new URL(this.customBaseUrl).hostname;
     const result = await assertCustomApiHostResolvesPublic(hostname);
-    // Mark checked only after a non-throwing classification so a transient
-    // resolver failure inside the guard (which returns ok) doesn't get cached
-    // as a permanent pass any more eagerly than the guard itself intends.
-    this.resolveSsrfChecked = true;
     if (!result.ok) {
+      // Do NOT cache a rejection (#3426 QA): leaving the flag false means a
+      // retry re-runs the guard rather than silently skipping it via the
+      // early-return above. The guard itself fails OPEN on transient resolver
+      // errors, so a flaky-DNS host still proceeds; only a confirmed private
+      // resolution throws here.
       throw result.error;
     }
+    this.resolveSsrfChecked = true;
   }
 
   /**


### PR DESCRIPTION
## Context
Closes #3426 (epic #3317 final follow-up). The custom-openai SSRF guard (`custom-api-validation.ts`) was string-level only — a public DNS name resolving to a private/loopback/link-local/metadata IP passed. This adds a **DNS-resolve-time** check as additive defense-in-depth.

## Change
- **`assertCustomApiHostResolvesPublic(hostname)`** (async): resolves via `dns.lookup({all:true})` and rejects if ANY resolved address is private (reusing the existing `classifyIPv4`/`classifyIPv6` range tables — refactored into a shared `classifyIpAddress`, no duplication). IP literals skip DNS (handled by the sync guard); `allowPrivate`/env bypasses; **fails OPEN on lookup error** (transient DNS must not break legit gateways — additive only).
- **SdkAdapter**: runs the check once (cached) in `doInitialize`, **before** model state is set, for custom-openai only.

## Review (this PR)
- **Security (implementer)**: `family` from the resolver is re-derived not trusted; fail-open documented; rejects only on confirmed private resolution.
- **QA (code-reviewer): APPROVE** — caught that the check ran *after* `this.model` was set, so a rejection cached the model and a retry skipped the guard. **Fixed**: moved the check before model init; cache flag only on success; added a retry regression test.

## Residual (documented)
This is resolve-time, not socket-connect-time — a TOCTOU/DNS-rebinding window remains. A full fix needs a custom `fetch` `lookup` hook validating the peer address at the socket layer (out of scope for this LOW defense-in-depth pass).

## Testing
`pnpm vitest run src/adapters/sdk/custom-api-validation.test.ts src/adapters/sdk/sdk-adapter.test.ts` → **58 passed**. typecheck + lint clean.

Completes epic #3317 (all findings #1–#8 + follow-ups #3424/#3425/#3426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)