### PR TITLE
feat(tune): durable audit for routing-demotion reversals (#3323 criterion 1)

### DIFF
--- a/.changeset/tune-durable-audit-3323.md
+++ b/.changeset/tune-durable-audit-3323.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': minor
+---
+
+feat(tune): durable audit for routing-demotion reversals (#3323 criterion 1)
+
+The self-tuning loop's routing mutations are now fully recorded on the immutable
+`AuditLogger` chain (verifiable via `verify_audit_chain`): the demotion
+(`tune.demote`, shipped in #3325) AND its reversal (`tune.reversal`) when an
+adjustment decays/expires (`cause: decay_expiry`) or is superseded by a fresh
+demotion (`cause: superseded`). `TuneAdjustmentStore` gains a state-only
+`onReversal` hook; `TuneStage` records the audit entry via the existing canonical
+audit sink, gated identically to the demotion audit (enforce + audit-sink wired;
+shadow mode records nothing). Best-effort/fail-safe at both the store and stage
+layers so auditing never throws on the router hot-read path or gates a mutation.
+
+Satisfies exit-criterion 1 (durable audit) of the tune-loop default-on bar
+(#3323); the other criteria remain open. No defaults changed.

--- a/packages/nexus-agents/src/core/index.ts
+++ b/packages/nexus-agents/src/core/index.ts
@@ -26,6 +26,9 @@ export {
   TUNE_DECAY_WINDOW_MS,
   type TuneAdjustment,
   type TuneDemotionStat,
+  type TuneReversal,
+  type TuneReversalCause,
+  type TuneReversalListener,
 } from './tune-adjustment-store.js';
 
 // Step event vocabulary + `withStep` wrapper (#1930 — human console notifications)

--- a/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
@@ -2,12 +2,13 @@
  * Tests for the bounded, time-decaying TuneAdjustmentStore (#3147, epic #3313).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   TuneAdjustmentStore,
   TUNE_DEMOTION_FLOOR,
   TUNE_MAX_STEP,
   TUNE_DECAY_WINDOW_MS,
+  type TuneReversal,
 } from './tune-adjustment-store.js';
 import { setTimeProvider, resetTimeProvider, FixedTimeProvider } from './time-provider.js';
 
@@ -130,5 +131,83 @@ describe('TuneAdjustmentStore demotion telemetry (#3323)', () => {
     const store = new TuneAdjustmentStore();
     store.recordIntended('gemini', 'r'.repeat(5000));
     expect(store.demotionStats()[0]?.lastReason.length).toBeLessThanOrEqual(512);
+  });
+});
+
+describe('TuneAdjustmentStore reversal audit hook (#3323)', () => {
+  let clock: FixedTimeProvider;
+
+  beforeEach(() => {
+    clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+  });
+  afterEach(() => {
+    resetTimeProvider();
+  });
+
+  it('fires a decay_expiry reversal when a fully-decayed adjustment is evicted', () => {
+    const store = new TuneAdjustmentStore();
+    const reversals: TuneReversal[] = [];
+    store.onReversal((r) => reversals.push(r));
+
+    store.demote('gemini', 0.2, 'swarm_unhealthy: blip'); // multiplier 0.8 at t=0
+    clock.advance(TUNE_DECAY_WINDOW_MS + 1); // past the window → eviction
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0); // restored
+
+    expect(reversals).toHaveLength(1);
+    expect(reversals[0]).toMatchObject({
+      cli: 'gemini',
+      cause: 'decay_expiry',
+      previousMultiplier: 0.8,
+      restoredMultiplier: 1.0,
+      reason: 'swarm_unhealthy: blip',
+    });
+  });
+
+  it('fires a superseded reversal when a fresh demotion overwrites an active one', () => {
+    const store = new TuneAdjustmentStore();
+    const reversals: TuneReversal[] = [];
+    store.onReversal((r) => reversals.push(r));
+
+    store.demote('codex', 0.2, 'first'); // 0.8, active
+    store.demote('codex', 0.2, 'second'); // supersedes → 0.6
+
+    expect(reversals).toHaveLength(1);
+    expect(reversals[0]).toMatchObject({
+      cli: 'codex',
+      cause: 'superseded',
+      reason: 'first',
+    });
+    expect(store.effectiveMultiplier('codex')).toBeCloseTo(0.6, 5);
+  });
+
+  it('does NOT fire a reversal for a first demotion (nothing to reverse)', () => {
+    const store = new TuneAdjustmentStore();
+    const listener = vi.fn();
+    store.onReversal(listener);
+    store.demote('gemini', 0.2, 'only');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('swallows a throwing reversal listener and never corrupts routing state', () => {
+    const store = new TuneAdjustmentStore();
+    store.onReversal(() => {
+      throw new Error('audit sink down');
+    });
+    store.demote('gemini', 0.2, 'blip');
+    clock.advance(TUNE_DECAY_WINDOW_MS + 1);
+    // The eviction (reversal) still completes despite the throwing sink.
+    expect(() => store.effectiveMultiplier('gemini')).not.toThrow();
+    expect(store.effectiveMultiplier('gemini')).toBe(1.0);
+  });
+
+  it('onReversal(undefined) clears the listener', () => {
+    const store = new TuneAdjustmentStore();
+    const listener = vi.fn();
+    store.onReversal(listener);
+    store.onReversal(undefined);
+    store.demote('gemini', 0.2, 'a');
+    store.demote('gemini', 0.2, 'b'); // would supersede
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -64,7 +64,13 @@ export type TuneReversalCause =
 export interface TuneReversal {
   readonly cli: string;
   readonly cause: TuneReversalCause;
-  /** Multiplier the reversed adjustment was holding at reversal time. */
+  /**
+   * Multiplier the reversed adjustment was holding at reversal time. Note the
+   * semantics differ by cause: `decay_expiry` reports the adjustment's *stored*
+   * multiplier (the value it expired from); `superseded` reports the *decayed
+   * effective* value at the moment a fresh demotion overwrote it. Either way
+   * `restoredMultiplier` is the value routing actually returns to.
+   */
   readonly previousMultiplier: number;
   /** Multiplier routing returns to after reversal (1.0 for decay_expiry). */
   readonly restoredMultiplier: number;

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -46,6 +46,36 @@ export interface TuneAdjustment {
   readonly reason: string;
 }
 
+/** Why an active adjustment was reversed (cleared back toward 1.0). */
+export type TuneReversalCause =
+  /** The decay window elapsed; routing restored to 1.0 (auto-reversible blip). */
+  | 'decay_expiry'
+  /** A fresh demotion overwrote the prior active adjustment for this CLI. */
+  | 'superseded';
+
+/**
+ * Notification that an active routing adjustment for `cli` was reversed (#3323).
+ * Emitted when a fully-decayed adjustment is evicted (`decay_expiry`) or when a
+ * new demotion overwrites a still-active one (`superseded`). Carries enough to
+ * reconstruct the routing-state change for the immutable audit chain: the CLI,
+ * the multiplier in effect just before reversal, the value routing is restored
+ * to, and the reason the reversed adjustment carried.
+ */
+export interface TuneReversal {
+  readonly cli: string;
+  readonly cause: TuneReversalCause;
+  /** Multiplier the reversed adjustment was holding at reversal time. */
+  readonly previousMultiplier: number;
+  /** Multiplier routing returns to after reversal (1.0 for decay_expiry). */
+  readonly restoredMultiplier: number;
+  /** Provenance reason the reversed adjustment carried. */
+  readonly reason: string;
+  readonly reversedAt: number;
+}
+
+/** Listener invoked when an active adjustment is reversed. */
+export type TuneReversalListener = (reversal: TuneReversal) => void;
+
 /** Max length of a stat's retained reason string (#3323 telemetry). */
 const STAT_REASON_MAX = 512;
 
@@ -78,6 +108,34 @@ export class TuneAdjustmentStore {
   private readonly adjustments = new Map<string, TuneAdjustment>();
   /** Cumulative telemetry — never evicted (bounded by CLI cardinality). */
   private readonly stats = new Map<string, MutableDemotionStat>();
+  /**
+   * Optional reversal listener (#3323). The store stays state-only — it does
+   * NOT know about the audit chain. The caller (TuneStage) registers a listener
+   * that appends a `tune.reversal` record to the immutable log, so a routing
+   * restore is durably audited just like the demotion that preceded it. A
+   * throwing listener never corrupts store state (errors are swallowed).
+   */
+  private reversalListener: TuneReversalListener | undefined;
+
+  /**
+   * Register (or clear, with `undefined`) the reversal listener. Replaces any
+   * prior listener — a single sink, mirroring the singleton-store pattern.
+   */
+  onReversal(listener: TuneReversalListener | undefined): void {
+    this.reversalListener = listener;
+  }
+
+  /** Best-effort fire of the reversal listener — a throwing sink is swallowed. */
+  private emitReversal(reversal: TuneReversal): void {
+    if (this.reversalListener === undefined) return;
+    try {
+      this.reversalListener(reversal);
+    } catch {
+      // Auditing is observability, not a gate (#3323): a failed reversal append
+      // must never corrupt routing state or throw out of effectiveMultiplier
+      // (a hot router-read path). The reversal has already taken effect.
+    }
+  }
 
   /** Increment a CLI's cumulative demotion counter. Pure telemetry. */
   private bumpStat(cli: string, kind: 'applied' | 'intended', reason: string): void {
@@ -101,15 +159,29 @@ export class TuneAdjustmentStore {
     if (magnitude <= 0) return undefined;
     const step = Math.min(TUNE_MAX_STEP, magnitude);
     const current = this.effectiveMultiplier(cli);
+    // If a still-active (not-yet-decayed) adjustment exists, the new demotion
+    // supersedes it — audit that reversal before overwriting (#3323).
+    const prior = this.adjustments.get(cli);
     const next = Math.max(TUNE_DEMOTION_FLOOR, current - step);
+    const now = getTimeProvider().now();
     const adjustment: TuneAdjustment = {
       cli,
       multiplier: next,
-      appliedAt: getTimeProvider().now(),
+      appliedAt: now,
       reason,
     };
     this.adjustments.set(cli, adjustment);
     this.bumpStat(cli, 'applied', reason);
+    if (prior !== undefined) {
+      this.emitReversal({
+        cli,
+        cause: 'superseded',
+        previousMultiplier: current,
+        restoredMultiplier: next,
+        reason: prior.reason,
+        reversedAt: now,
+      });
+    }
     return adjustment;
   }
 
@@ -134,9 +206,21 @@ export class TuneAdjustmentStore {
   effectiveMultiplier(cli: string): number {
     const adjustment = this.adjustments.get(cli);
     if (adjustment === undefined) return 1.0;
-    const elapsed = getTimeProvider().now() - adjustment.appliedAt;
+    const now = getTimeProvider().now();
+    const elapsed = now - adjustment.appliedAt;
     if (elapsed >= TUNE_DECAY_WINDOW_MS || elapsed < 0) {
       this.adjustments.delete(cli);
+      // The adjustment has fully decayed — routing is restored to 1.0. Audit
+      // this reversal so the full lifecycle (demote → decay/expiry) is durable
+      // and reconstructable from the immutable chain (#3323).
+      this.emitReversal({
+        cli,
+        cause: 'decay_expiry',
+        previousMultiplier: adjustment.multiplier,
+        restoredMultiplier: 1.0,
+        reason: adjustment.reason,
+        reversedAt: now,
+      });
       return 1.0;
     }
     const decayFraction = elapsed / TUNE_DECAY_WINDOW_MS;

--- a/packages/nexus-agents/src/pipeline/tune-stage.test.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.test.ts
@@ -2,9 +2,11 @@
  * Tests for the shadow-mode TuneStage (#3147, epic #3143 P2).
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { ILogger } from '../core/index.js';
 import { getTuneAdjustmentStore, resetTuneAdjustmentStore } from '../core/index.js';
+import { setTimeProvider, resetTimeProvider, FixedTimeProvider } from '../core/time-provider.js';
+import { TUNE_DECAY_WINDOW_MS } from '../core/tune-adjustment-store.js';
 import { EventBus } from './event-bus.js';
 import type { PipelineEvent } from './event-types.js';
 import { createTuneStage, intendedActionFor } from './tune-stage.js';
@@ -230,5 +232,101 @@ describe('createTuneStage shadow mode (#3147)', () => {
     unsub();
     bus.emit(fitnessSignal);
     expect(logger.info).not.toHaveBeenCalled();
+  });
+});
+
+describe('createTuneStage reversal audit (#3323 — durable audit criterion)', () => {
+  afterEach(() => {
+    resetTuneAdjustmentStore();
+    resetTimeProvider();
+    // Drop any registered reversal listener so it can't leak across tests.
+    getTuneAdjustmentStore().onReversal(undefined);
+  });
+
+  it('writes a tune.reversal audit record when an enforced demotion decays/expires', () => {
+    resetTuneAdjustmentStore();
+    const clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+    const bus = new EventBus();
+    const auditLog = vi.fn();
+    createTuneStage(bus, { enabled: true, auditLogger: { log: auditLog } });
+
+    bus.emit(swarmSignal); // demote gemini → tune.demote
+    auditLog.mockClear();
+
+    // Advance past the decay window, then read → lazy eviction fires reversal.
+    clock.advance(TUNE_DECAY_WINDOW_MS + 1);
+    expect(getTuneAdjustmentStore().effectiveMultiplier('gemini')).toBe(1.0);
+
+    expect(auditLog).toHaveBeenCalledTimes(1);
+    expect(auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'configuration',
+        action: 'tune.reversal',
+        outcome: 'success',
+        actor: expect.objectContaining({ type: 'system' }),
+        metadata: expect.objectContaining({
+          cli: 'gemini',
+          cause: 'decay_expiry',
+          restoredMultiplier: 1.0,
+        }),
+      })
+    );
+  });
+
+  it('writes a tune.reversal audit record when a fresh demotion supersedes an active one', () => {
+    resetTuneAdjustmentStore();
+    const clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+    const bus = new EventBus();
+    const auditLog = vi.fn();
+    createTuneStage(bus, { enabled: true, auditLogger: { log: auditLog } });
+
+    bus.emit(swarmSignal); // first demotion (no reversal)
+    bus.emit({ ...swarmSignal, reason: 'more timeouts' }); // supersedes
+
+    const reversalCalls = auditLog.mock.calls.filter(
+      (c) => (c[0] as { action: string }).action === 'tune.reversal'
+    );
+    expect(reversalCalls).toHaveLength(1);
+    expect(reversalCalls[0]?.[0]).toMatchObject({
+      action: 'tune.reversal',
+      metadata: expect.objectContaining({ cli: 'gemini', cause: 'superseded' }),
+    });
+  });
+
+  it('a throwing reversal audit sink does NOT throw out of the mutation path', () => {
+    resetTuneAdjustmentStore();
+    const clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+    const bus = new EventBus();
+    const auditLog = vi.fn().mockImplementation(() => {
+      throw new Error('audit backend down');
+    });
+    createTuneStage(bus, { enabled: true, auditLogger: { log: auditLog } });
+
+    expect(() => {
+      bus.emit(swarmSignal);
+    }).not.toThrow(); // demote audit throws internally
+    clock.advance(TUNE_DECAY_WINDOW_MS + 1);
+    // Reading triggers the reversal audit, which throws — must be swallowed.
+    expect(() => getTuneAdjustmentStore().effectiveMultiplier('gemini')).not.toThrow();
+    expect(getTuneAdjustmentStore().effectiveMultiplier('gemini')).toBe(1.0);
+  });
+
+  it('does NOT register a reversal audit listener in shadow mode (no auditLogger or disabled)', () => {
+    resetTuneAdjustmentStore();
+    const clock = new FixedTimeProvider(0);
+    setTimeProvider(clock);
+    const bus = new EventBus();
+    const auditLog = vi.fn();
+    // disabled (shadow) with an audit sink → listener must NOT be registered
+    createTuneStage(bus, { enabled: false, auditLogger: { log: auditLog } });
+
+    // Manually drive a demote+decay on the store; no listener should fire.
+    getTuneAdjustmentStore().demote('gemini', 0.2, 'manual');
+    clock.advance(TUNE_DECAY_WINDOW_MS + 1);
+    getTuneAdjustmentStore().effectiveMultiplier('gemini');
+    expect(auditLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -19,7 +19,7 @@
  */
 
 import { createLogger, getErrorMessage, getTuneAdjustmentStore } from '../core/index.js';
-import type { ILogger } from '../core/index.js';
+import type { ILogger, TuneReversal } from '../core/index.js';
 import { parseBoolEnv } from '../config/defaults-env.js';
 import type { IAuditLogger } from '../audit/audit-types.js';
 import type { PipelineEvent, IEventBus, Unsubscribe } from './event-types.js';
@@ -151,6 +151,47 @@ function auditDemotion(
 }
 
 /**
+ * Append a tamper-evident `tune.reversal` audit record when an active routing
+ * demotion is reversed — either it fully decayed back to 1.0 (`decay_expiry`)
+ * or a fresh demotion superseded it (`superseded`) (#3323). Closes the audit
+ * lifecycle: every routing-state change (demote AND restore) is durable. Audit
+ * failures are swallowed (the reversal already took effect); the store's own
+ * listener guard also swallows, so this is best-effort twice over.
+ */
+function auditReversal(
+  auditLogger: Pick<IAuditLogger, 'log'>,
+  reversal: TuneReversal,
+  log: ILogger
+): void {
+  const reason =
+    reversal.reason.length > AUDIT_REASON_MAX
+      ? reversal.reason.slice(0, AUDIT_REASON_MAX)
+      : reversal.reason;
+  try {
+    auditLogger.log({
+      category: 'configuration',
+      severity: 'info',
+      outcome: 'success',
+      action: 'tune.reversal',
+      actor: { type: 'system', id: 'tune-stage' },
+      description: `Routing demotion reversed for ${reversal.cli} (${reversal.cause}); restored multiplier ${String(reversal.restoredMultiplier)}`,
+      metadata: {
+        cli: reversal.cli,
+        cause: reversal.cause,
+        previousMultiplier: reversal.previousMultiplier,
+        restoredMultiplier: reversal.restoredMultiplier,
+        reason,
+        reversedAt: reversal.reversedAt,
+      },
+    });
+  } catch (auditError) {
+    log.warn('TuneStage — reversal audit log failed (reversal still applied)', {
+      error: getErrorMessage(auditError),
+    });
+  }
+}
+
+/**
  * Apply the bounded routing demotion for a `swarm_unhealthy` signal (#3147):
  * a demotion-only, floored, capped, time-decaying adjustment the router reads
  * as a scoring penalty, plus structured + durable-audit trails (#3323).
@@ -185,7 +226,20 @@ export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}):
   const enabled = options.enabled ?? false;
   const log = options.logger ?? defaultLogger;
   const auditLogger = options.auditLogger;
-  return bus.subscribe({ type: [...TUNE_SIGNAL_TYPES] }, (event) => {
+
+  // Durable-audit the FULL routing-mutation lifecycle (#3323): a demotion is
+  // audited at apply-time below; its eventual reversal (decay/expiry or
+  // supersede) is audited via a store listener. Register it only under the same
+  // gate as the demotion audit — enforcement on AND an audit sink wired — so a
+  // shadow-mode store (no routing effect) emits nothing. The listener guard in
+  // the store swallows throws, so a bad sink never breaks a router read.
+  if (enabled && auditLogger !== undefined) {
+    getTuneAdjustmentStore().onReversal((reversal) => {
+      auditReversal(auditLogger, reversal, log);
+    });
+  }
+
+  const unsubscribe = bus.subscribe({ type: [...TUNE_SIGNAL_TYPES] }, (event) => {
     try {
       const action = intendedActionFor(event);
       if (action === undefined) return;
@@ -219,6 +273,15 @@ export function createTuneStage(bus: IEventBus, options: TuneStageOptions = {}):
       log.warn('TuneStage handler error', { error: getErrorMessage(e) });
     }
   });
+
+  return () => {
+    unsubscribe();
+    // Release the reversal-audit listener so a later (e.g. shadow) stage doesn't
+    // keep firing audits through a stale logger. Only clear if we registered.
+    if (enabled && auditLogger !== undefined) {
+      getTuneAdjustmentStore().onReversal(undefined);
+    }
+  };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Context
Advances **#3323** (tune-loop auto-enforce default-on) by satisfying its **first exit criterion — durable audit**. The loop's routing mutations were structured-logs-only; the repo's "immutable audit" principle requires a default-on auto-mutating system to leave a tamper-evident trail. **No defaults are flipped** — this is the prerequisite, not the flip.

## Change
The demotion audit (`tune.demote`) already shipped (#3325). This adds the missing half — the **reversal**:
- `TuneAdjustmentStore` gains a state-only `onReversal(listener)` hook, fired at the two reversal sites: `effectiveMultiplier()` lazy decay/eviction (`cause: decay_expiry`) and `demote()` overwriting a still-active adjustment (`cause: superseded`). Carries cli, previous→restored multiplier, cause, reason, timestamp.
- `TuneStage` records a `tune.reversal` entry via the **same canonical `IAuditLogger`/FileAuditStorage chain** as `tune.demote`, so `verify_audit_chain` sees a coherent demote→reverse pair. Gated identically (`enabled && auditLogger`); shadow mode records nothing.
- **Fail-safe (two layers):** the store swallows a throwing listener (protects the router hot-read path), and `auditReversal` independently try/catches + warns. Auditing never throws or gates a mutation.

## Review
- **QA: APPROVE** — hot-path safe (mutation completes before emit; no reentrancy hazard; JS single-threaded), precise triggers (decay vs superseded vs first-demote-no-fire), valid entry shape, gating correct.
- **Security: CLEAN** (0 crit/high/med) — every real routing reversal now on the chain; fail-open logs (never silently drops); reason capped at 512; no secrets/injection/flooding. One LOW filed as #3452 (`clear()` is test-only; latent).

## Testing
43 tests across the 4 tune files green (store: decay/superseded/first-demote/throwing-listener/clear-listener; stage: decay-record/superseded-record/throwing-sink-swallow/no-register-in-shadow). typecheck + lint clean.

Follow-up: #3452 (clear() audit gap). Remaining #3323 criteria (e2e test, floor-safety, soak+observability, kill switch, rollout, docs) stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)