### PR TITLE
test(routing): full-chain shadow assertion for the self-tuning loop (#3323 criterion 2)

### DIFF
--- a/.changeset/tune-e2e-shadow-3323.md
+++ b/.changeset/tune-e2e-shadow-3323.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+test(routing): full-chain shadow assertion for the self-tuning loop (#3323 criterion 2)
+
+Strengthens the tune-loop e2e proof (the enforce-on producer→store→router
+selection-change test already existed, #3324): adds the shadow-mode producer-side
+gate assertion — firing a `signal.swarm_unhealthy` through a SHADOW `TuneStage`
+records the intended demotion (telemetry `intended++`) but does NOT apply it
+(`applied=0`, `effectiveMultiplier=1.0`, routing/rank unchanged). Proves the
+`NEXUS_TUNE_ENFORCE` gate sits exactly between record and apply. Satisfies
+exit-criterion 2 of #3323.

--- a/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/tune-loop-e2e.test.ts
@@ -120,6 +120,51 @@ describe('self-tuning loop end-to-end (#3323)', () => {
     if (!after.ok) return;
     expect(after.value.cliName).toBe(winner); // unchanged — enforce gates the read
   });
+
+  it('shadow chain RECORDS the intended demotion but does NOT apply it to routing', async () => {
+    // The same producer→consumer path as the enforce test, but with a SHADOW
+    // TuneStage (enabled:false) and the router read gated off. Proves the
+    // NEXUS_TUNE_ENFORCE gate sits PRECISELY between "record" and "apply": the
+    // loop observes what it WOULD do (intended-counter bumped) while routing,
+    // the effective multiplier, AND the applied-counter all stay untouched.
+    process.env['NEXUS_TUNE_ENFORCE'] = 'false'; // shadow on both sides of the loop
+    const router = deterministicRouter(['claude', 'gemini', 'codex']);
+
+    const baseline = await router.route(TASK);
+    expect(baseline.ok).toBe(true);
+    if (!baseline.ok) return;
+    const winner = baseline.value.cliName;
+    const baselineRank = [winner, ...baseline.value.alternatives].indexOf(winner); // 0
+
+    // Drive the producer signal through a SHADOW TuneStage (enabled:false).
+    const bus = new EventBus();
+    createTuneStage(bus, { enabled: false });
+    const SIGNALS = 8;
+    for (let i = 0; i < SIGNALS; i++) {
+      bus.emit({
+        type: 'signal.swarm_unhealthy',
+        timestamp: i,
+        agentId: winner,
+        reason: 'repeated failures',
+      } satisfies PipelineEvent);
+    }
+
+    const store = getTuneAdjustmentStore();
+    // Loop OBSERVED the would-be demotion: the intended counter is bumped...
+    const stat = store.demotionStats().find((s) => s.cli === winner);
+    expect(stat?.intended).toBe(SIGNALS);
+    // ...but NOTHING was applied — no routing-biasing demotion was written.
+    expect(stat?.applied ?? 0).toBe(0);
+    expect(store.effectiveMultiplier(winner)).toBe(1.0); // store unchanged
+
+    // ...and routing is identical: same winner, same rank. The gate held.
+    const after = await router.route(TASK);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.value.cliName).toBe(winner);
+    const afterRank = [after.value.cliName, ...after.value.alternatives].indexOf(winner);
+    expect(afterRank).toBe(baselineRank); // 0 → 0, unchanged
+  });
 });
 
 describe('floor-safety / never-starve (#3323)', () => {


### PR DESCRIPTION
## Context
Advances **#3323** by satisfying **exit-criterion 2 — end-to-end integration test** (loop measurably affects routing). Verify-before-implement found the enforce-on direction already proven (`tune-loop-e2e.test.ts`, #3324): a `signal.swarm_unhealthy` fired through a real enforce-enabled `TuneStage` → shared `TuneAdjustmentStore` → `CompositeRouter.route()` measurably worsens the demoted CLI's rank (de-selected + strictly lower). The wiring is real (`getTuneAdjustmentScores()` in `aggregateStageScores`, gated by `NEXUS_TUNE_ENFORCE`).

## Change (test-only)
Adds the missing **shadow-mode producer-gate** negative: the same producer signal through a SHADOW `TuneStage` (`enabled:false`) increments the `intended` telemetry counter (loop observed the would-be demotion) but `applied=0`, `effectiveMultiplier(winner)=1.0`, and routed CLI + rank are unchanged. Proves the gate sits precisely between **record** and **apply** — both sides of the chain now covered.

## Determinism
LinUCB disabled → deterministic TOPSIS scoring (which carries the tune penalty); `resetTuneAdjustmentStore()` per test; monotonic timestamps. No production code changed; no wiring gaps found.

## Testing
`pnpm vitest run src/cli-adapters/tune-loop-e2e.test.ts src/cli-adapters/composite-router.test.ts` → **81 passed**. typecheck + lint clean.

Remaining #3323 criteria: floor-safety guarantee+test, shadow soak + demotion observability surface, clean kill switch, rollout decision, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)