### PR TITLE
docs(tune): correct stale TuneStageOptions JSDoc — loop is default-ON (#3323)

### DIFF
--- a/.changeset/tune-jsdoc-accuracy-3323.md
+++ b/.changeset/tune-jsdoc-accuracy-3323.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+docs(tune): correct stale TuneStageOptions JSDoc (loop is default-ON) (#3323)
+
+The `TuneStageOptions.enabled` JSDoc still said "When false (default), SHADOW
+mode", but `startTuneStage` derives the default from `NEXUS_TUNE_ENFORCE` which
+defaults to `true` (enforce) since v2.96 — production runs the self-tuning loop
+default-ON. Corrected the comment so a maintainer isn't misled into thinking the
+loop is shadow-by-default. (CONFIGURATION.md already documents the default-ON
+behavior + opt-out accurately.)

--- a/packages/nexus-agents/src/pipeline/tune-stage.ts
+++ b/packages/nexus-agents/src/pipeline/tune-stage.ts
@@ -58,11 +58,16 @@ export interface IntendedTuneAction {
 
 export interface TuneStageOptions {
   /**
-   * When false (default), the stage is in SHADOW mode: it logs the intended
-   * action and mutates nothing. When true, a `signal.swarm_unhealthy` applies a
-   * bounded routing demotion via the `TuneAdjustmentStore` (and audits it);
-   * non-routing signals remain shadow-logged. Defaults from `NEXUS_TUNE_ENFORCE`
-   * in `startTuneStage`; explicit values (tests) override the flag.
+   * Whether the stage ENFORCES (mutates routing) or runs in SHADOW (logs the
+   * intended action and mutates nothing). When enforcing, a
+   * `signal.swarm_unhealthy` applies a bounded routing demotion via the
+   * `TuneAdjustmentStore` (and audits it); non-routing signals remain
+   * shadow-logged either way.
+   *
+   * When omitted, `startTuneStage` derives this from `NEXUS_TUNE_ENFORCE`, which
+   * **defaults to `true` (enforce) since v2.96** (#3323) — so production is
+   * default-ON; set `NEXUS_TUNE_ENFORCE=false` to opt into shadow. An explicit
+   * value here (tests) overrides the env flag.
    */
   readonly enabled?: boolean;
   /** Injectable logger (defaults to the module logger). */


### PR DESCRIPTION
## Context
While auditing #3323's exit criteria (verify-before-implement), I found the self-tuning loop is **already default-ON** — `startTuneStage` defaults `NEXUS_TUNE_ENFORCE` to `true` on both the write and read sides (since v2.96, #3147). But the `TuneStageOptions.enabled` JSDoc still claimed "When false (default), SHADOW mode", which would mislead a maintainer.

## Change
Doc-only: correct the JSDoc to state the production default is **enforce (ON)**, with `NEXUS_TUNE_ENFORCE=false` as the shadow opt-out. CONFIGURATION.md already documents this accurately.

## Why this closes out #3323
Verify-before-implement found **all exit criteria already met** — the tracker's checklist was stale:
- ✅ Durable audit — `tune.demote` (#3325) + `tune.reversal` (#3453)
- ✅ E2E integration test — #3324 + the shadow-gate negative (#3454)
- ✅ Floor-safety/never-starve test — `tune-loop-e2e.test.ts`
- ✅ Demotion observability — `health` command (`applied` vs `intended`) + CONFIGURATION.md
- ✅ Kill switch — `NEXUS_TUNE_ENFORCE=false` (both sides honor it)
- ✅ Rollout — default-ON since v2.96; documented
- ✅ Docs — CONFIGURATION.md §"self-tuning routing loop" (bounds, audit, opt-out, observability)

The owner directive ("enable the loop by default once built out completely") is **satisfied**. This PR fixes the last inaccuracy; #3323 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)