### PR TITLE
fix(tune): audit routing reversals on TuneAdjustmentStore.clear() (#3452)

### DIFF
--- a/.changeset/clear-audit-reversals-3452.md
+++ b/.changeset/clear-audit-reversals-3452.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+fix(tune): audit routing reversals on TuneAdjustmentStore.clear() (#3452)
+
+`clear()` dropped all active demotions — a routing-state restore — without
+emitting `onReversal`, so a bulk clear left no `tune.reversal` audit entry. It now
+emits a `cleared`-cause reversal for each active adjustment before dropping it, so
+the "every routing mutation is on the immutable audit chain" invariant
+(#3323 criterion 1) holds unconditionally, not just for decay/supersede. `clear()`
+is currently test-only, so this is hardening against a future production reset
+path rather than a live gap.

--- a/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.test.ts
@@ -189,6 +189,33 @@ describe('TuneAdjustmentStore reversal audit hook (#3323)', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it('fires a cleared reversal for each active adjustment on clear() (#3452)', () => {
+    const store = new TuneAdjustmentStore();
+    const reversals: TuneReversal[] = [];
+    store.onReversal((r) => reversals.push(r));
+
+    store.demote('claude', 0.2, 'a'); // 0.8 active
+    store.demote('gemini', 0.1, 'b'); // 0.9 active
+    store.clear();
+
+    expect(reversals).toHaveLength(2);
+    expect(reversals.every((r) => r.cause === 'cleared' && r.restoredMultiplier === 1.0)).toBe(
+      true
+    );
+    expect(new Set(reversals.map((r) => r.cli))).toEqual(new Set(['claude', 'gemini']));
+    // Routing actually restored.
+    expect(store.effectiveMultiplier('claude')).toBe(1.0);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('clear() with no active adjustments fires nothing', () => {
+    const store = new TuneAdjustmentStore();
+    const listener = vi.fn();
+    store.onReversal(listener);
+    store.clear();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('swallows a throwing reversal listener and never corrupts routing state', () => {
     const store = new TuneAdjustmentStore();
     store.onReversal(() => {

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -51,7 +51,9 @@ export type TuneReversalCause =
   /** The decay window elapsed; routing restored to 1.0 (auto-reversible blip). */
   | 'decay_expiry'
   /** A fresh demotion overwrote the prior active adjustment for this CLI. */
-  | 'superseded';
+  | 'superseded'
+  /** All adjustments were dropped via {@link TuneAdjustmentStore.clear} (#3452). */
+  | 'cleared';
 
 /**
  * Notification that an active routing adjustment for `cli` was reversed (#3323).
@@ -251,6 +253,22 @@ export class TuneAdjustmentStore {
 
   /** Remove all adjustments and telemetry. */
   clear(): void {
+    // #3452: emit a reversal for each active adjustment BEFORE dropping it, so a
+    // bulk clear (a routing-state restore) is on the immutable audit chain too —
+    // the "every routing mutation is audited" invariant holds unconditionally,
+    // not just for decay/supersede. `effectiveMultiplier` would mutate the map
+    // (lazy eviction), so read the stored multiplier directly here.
+    const now = getTimeProvider().now();
+    for (const adjustment of this.adjustments.values()) {
+      this.emitReversal({
+        cli: adjustment.cli,
+        cause: 'cleared',
+        previousMultiplier: adjustment.multiplier,
+        restoredMultiplier: 1.0,
+        reason: adjustment.reason,
+        reversedAt: now,
+      });
+    }
     this.adjustments.clear();
     this.stats.clear();
   }


### PR DESCRIPTION
## Context
Closes #3452 (security follow-up from #3323). `TuneAdjustmentStore.clear()` empties all active demotions — a routing-state restore — but emitted no `onReversal`, so a bulk clear left no `tune.reversal` audit entry. A gap in the "every routing mutation is on the immutable chain" invariant (#3323 criterion 1). Currently latent (clear() is test-only), but worth closing.

## Change
`clear()` now emits a `cleared`-cause reversal for each active adjustment **before** dropping it (reads the stored multiplier directly — `effectiveMultiplier` would lazily evict mid-iteration). TuneStage's existing reversal-audit listener records each as a `tune.reversal` on the immutable chain. New `TuneReversalCause: 'cleared'`.

## Testing
- New: `clear()` fires a `cleared` reversal per active adjustment (restored→1.0, routing actually restored); empty-store `clear()` fires nothing.
- `tune-adjustment-store` + `tune-stage` suites → 37 passed. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)