### PR TITLE
feat(harness): redirect Gemini CLI to AGENTS.md — complete #3446 model-agnostic refactor

### DIFF
--- a/.changeset/gemini-redirect-3446-p4.md
+++ b/.changeset/gemini-redirect-3446-p4.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+feat(harness): add GEMINI.md redirect to AGENTS.md (#3446 Phase 4)
+
+Completes the model-agnostic governance refactor: adds a root-level `GEMINI.md`
+that redirects to AGENTS.md (the Gemini CLI reads `GEMINI.md` natively, or can be
+pointed at `AGENTS.md` via `context.fileName`), and registers it in the
+harness-alignment CI gate (`doctor-harness-alignment.ts`) so it can't silently
+stop referencing AGENTS.md. Updates the AGENT_COMPATIBILITY matrix (Gemini row +
+notes CLAUDE.md is now generated from AGENTS.md).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,7 @@
+# Federated to AGENTS.md
+
+This repo follows the [AGENTS.md](./AGENTS.md) federation (#2764 / #3446): **AGENTS.md is the single source of truth** for project conventions, rules, and agent guidance. It's the canonical, harness-neutral superset; harness-specific entry points redirect to it rather than duplicating content.
+
+**For the Gemini CLI:** load [AGENTS.md](./AGENTS.md) as the project context. You can also point Gemini at it directly by setting `context.fileName` to `AGENTS.md` in your Gemini settings, instead of relying on this redirect. Keyword-scoped per-topic rules live in [`.rules/`](./.rules/) and are indexed from AGENTS.md.
+
+See [docs/architecture/AGENT_COMPATIBILITY.md](./docs/architecture/AGENT_COMPATIBILITY.md) for the federation rationale and the per-harness compatibility matrix. (Claude Code's `CLAUDE.md` is generated from AGENTS.md's agnostic body plus a Claude-specific overlay — see `scripts/inject-governance.ts`.)

--- a/docs/architecture/AGENT_COMPATIBILITY.md
+++ b/docs/architecture/AGENT_COMPATIBILITY.md
@@ -14,6 +14,7 @@ keywords:
   - opencode
   - claude-code
   - codex-cli
+  - gemini-cli
 ---
 
 # Agent Harness Compatibility Matrix
@@ -31,6 +32,7 @@ AGENTS.md is the convergence point. As of Q2 2026 it has explicit support in:
 - Aider (added in v0.69+)
 - Cline / Roo Code (project-context discovery)
 - Continue (rule sources can point at `AGENTS.md`)
+- Gemini CLI (reads `GEMINI.md`; `context.fileName` can point directly at `AGENTS.md`)
 - Goose (project conventions discovery)
 - OpenCode (`opencode.json` `instructions` can reference `AGENTS.md`)
 
@@ -40,7 +42,8 @@ Maintaining one document with thin shims into each harness gives full coverage f
 
 | Harness                   | Discovery file(s)                                                                 | Discovery scope                                | Loading model                                                                      | Native instruction format                                  |
 | ------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Anthropic Claude Code** | `CLAUDE.md` (primary), `AGENTS.md` (fallback)                                     | Project root + walking up to `$HOME`           | Auto-loaded into every session's system prompt                                     | Markdown with optional `<system-reminder>` tags            |
+| **Anthropic Claude Code** | `CLAUDE.md` (primary — **generated** from `AGENTS.md` + a Claude overlay, #3446)  | Project root + walking up to `$HOME`           | Auto-loaded into every session's system prompt                                     | Markdown with optional `<system-reminder>` tags            |
+| **Google Gemini CLI**     | `GEMINI.md` (redirect), or `context.fileName: AGENTS.md`                          | Project root + global at `~/.gemini/GEMINI.md` | Auto-loaded as context at session start                                            | Markdown                                                   |
 | **OpenAI Codex CLI**      | `AGENTS.md` (canonical, since launch)                                             | Project root + global at `~/.codex/AGENTS.md`  | Auto-loaded at session start                                                       | Markdown                                                   |
 | **Cursor**                | `.cursor/rules/*.mdc`, `.cursorrules` (legacy), `AGENTS.md`                       | Project root                                   | Rule files matched by `globs` + `description`; AGENTS.md loaded as project context | MDC (Cursor's markdown-with-frontmatter) or plain markdown |
 | **Windsurf**              | `.windsurfrules`, `.windsurf/rules/*.md`, `AGENTS.md`                             | Project root                                   | Cascade indexes all rule sources                                                   | Markdown                                                   |
@@ -52,17 +55,17 @@ Maintaining one document with thin shims into each harness gives full coverage f
 
 ## What nexus-agents ships today
 
-| File                                      | Role                                                                   | Status                                                                 |
-| ----------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `AGENTS.md`                               | Canonical surface; harness-neutral                                     | **Source of truth**                                                    |
-| `CLAUDE.md`                               | Claude Code-specific entry point with plugin/skill integration details | Kept; cross-references AGENTS.md and adds Claude-Code-only sections    |
-| `skills/index.yaml` + `skills/*/SKILL.md` | Anthropic Agent Skills spec (#1828)                                    | Discovered by harnesses that support skills; documented from AGENTS.md |
-| `.rules/*.md`                             | Per-rule files auto-loaded by Claude Code; referenced from AGENTS.md   | Kept; AGENTS.md indexes them                                           |
-| `docs/ENTRYPOINTS.md`                     | CLI + MCP tool reference                                               | Referenced from AGENTS.md                                              |
+| File                                      | Role                                                                   | Status                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `AGENTS.md`                               | Canonical surface; harness-neutral                                     | **Source of truth**                                                     |
+| `CLAUDE.md`                               | Claude Code-specific entry point with plugin/skill integration details | **Generated** from AGENTS.md's agnostic body + a Claude overlay (#3446) |
+| `skills/index.yaml` + `skills/*/SKILL.md` | Anthropic Agent Skills spec (#1828)                                    | Discovered by harnesses that support skills; documented from AGENTS.md  |
+| `.rules/*.md`                             | Per-rule files auto-loaded by Claude Code; referenced from AGENTS.md   | Kept; AGENTS.md indexes them                                            |
+| `docs/ENTRYPOINTS.md`                     | CLI + MCP tool reference                                               | Referenced from AGENTS.md                                               |
 
-## What's missing today (Phase 2 of #2805 closes this)
+## Harness redirect shims
 
-These harness files don't exist yet in the repo. Phase 2 adds them as one-line redirects:
+These root/harness-config files exist as one-line redirects to AGENTS.md (added in #2805 Phase 2 + #3446 Phase 4). The `Harness Alignment Drift` CI gate (`scripts/check-harness-alignment.ts`) fails if any present file stops referencing `AGENTS.md`:
 
 | File                        | Harness  | Content shape                                                      |
 | --------------------------- | -------- | ------------------------------------------------------------------ |
@@ -71,6 +74,7 @@ These harness files don't exist yet in the repo. Phase 2 adds them as one-line r
 | `.aider.conf.yml`           | Aider    | `read: [AGENTS.md, CLAUDE.md]`                                     |
 | `.continue/rules/agents.md` | Continue | Markdown redirect                                                  |
 | `.clinerules/agents.md`     | Cline    | Markdown redirect                                                  |
+| `GEMINI.md`                 | Gemini   | Markdown redirect (root-level; Gemini CLI reads it natively)       |
 
 `opencode.json` and Goose `recipe.yaml` are project-config files with broader concerns than just instruction surfacing — those stay out of scope unless we ship an OpenCode/Goose adapter directly.
 

--- a/packages/nexus-agents/src/cli/doctor-harness-alignment.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-harness-alignment.test.ts
@@ -64,18 +64,19 @@ describe('checkHarnessAlignment', () => {
     expect(check.missingCount).toBeGreaterThanOrEqual(1);
   });
 
-  it('aggregates counts across all 5 known harnesses', () => {
+  it('aggregates counts across all 6 known harnesses', () => {
     writeAt('AGENTS.md', '# AGENTS.md');
     writeAt('.cursor/rules/agents.mdc', 'See AGENTS.md');
     writeAt('.windsurf/rules/agents.md', 'See AGENTS.md');
     writeAt('.aider.conf.yml', 'read: [AGENTS.md]');
     writeAt('.continue/rules/agents.md', 'See AGENTS.md');
     writeAt('.clinerules/agents.md', 'See AGENTS.md');
+    writeAt('GEMINI.md', 'Federated to AGENTS.md'); // #3446 Phase 4
 
     const check = checkHarnessAlignment(root);
 
-    expect(check.files).toHaveLength(5);
-    expect(check.alignedCount).toBe(5);
+    expect(check.files).toHaveLength(6);
+    expect(check.alignedCount).toBe(6);
     expect(check.driftCount).toBe(0);
     expect(check.missingCount).toBe(0);
   });
@@ -83,12 +84,12 @@ describe('checkHarnessAlignment', () => {
   it('handles mixed alignment + drift + missing in one tree', () => {
     writeAt('.cursor/rules/agents.mdc', 'See AGENTS.md'); // aligned
     writeAt('.windsurf/rules/agents.md', 'Some unrelated content'); // drift
-    // Aider, Continue, Cline absent → missing
+    // Aider, Continue, Cline, Gemini absent → missing
 
     const check = checkHarnessAlignment(root);
     expect(check.alignedCount).toBe(1);
     expect(check.driftCount).toBe(1);
-    expect(check.missingCount).toBe(3);
+    expect(check.missingCount).toBe(4);
   });
 
   it('does not throw on unreadable files (filesystem race)', () => {

--- a/packages/nexus-agents/src/cli/doctor-harness-alignment.ts
+++ b/packages/nexus-agents/src/cli/doctor-harness-alignment.ts
@@ -57,6 +57,9 @@ const HARNESS_FILES: ReadonlyArray<{ harness: string; path: string }> = [
   { harness: 'Aider', path: '.aider.conf.yml' },
   { harness: 'Continue', path: '.continue/rules/agents.md' },
   { harness: 'Cline', path: '.clinerules/agents.md' },
+  // Gemini CLI reads a root-level GEMINI.md natively (unlike the .rules/-dir
+  // harnesses); it redirects to AGENTS.md per the federation (#3446 Phase 4).
+  { harness: 'Gemini', path: 'GEMINI.md' },
 ];
 
 /**


### PR DESCRIPTION
## Context
Final phase of epic #3446 (model-agnostic governance). With CLAUDE.md now generated from AGENTS.md (Phases 2+3), this adds the last native-harness entry point.

## Change
- **`GEMINI.md`** (new, root-level): one-line redirect to AGENTS.md. Gemini CLI reads `GEMINI.md` natively; also notes `context.fileName: AGENTS.md` as a direct option.
- **`doctor-harness-alignment.ts`**: register `{ harness: 'Gemini', path: 'GEMINI.md' }` so the `Harness Alignment Drift` CI gate enforces it keeps referencing AGENTS.md (6 harnesses now). Tests updated (5→6).
- **`AGENT_COMPATIBILITY.md`**: Gemini row in the discovery matrix + redirect-shim table; note CLAUDE.md is now **generated** from AGENTS.md; fixed the stale "what's missing" framing (the redirects all exist now, CI-gated).

## Testing
`doctor-harness-alignment.test.ts` → 8 passed; `check-harness-alignment.ts` → "6 aligned, 0 absent"; `inject-governance.ts check` passes; markdownlint clean.

## Epic #3446 — COMPLETE
- Mechanism C (generation) ✅
- Phase 1 (AGENTS.md superset) ✅ #3458
- Phases 2+3 (CLAUDE.md generated + drift-gate) ✅ #3460
- Phase 4 (GEMINI.md redirect) ✅ this PR

AGENTS.md is now the single canonical source of harness-neutral guidance; every harness reaches it (Claude via generation, Gemini/Codex/Cursor/Aider/etc. via native read or redirect) with zero content duplication, CI-gated against drift — exactly the model-agnostic system you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)