### PR TITLE
fix(docops): escape backslashes before pipes in ENTRYPOINTS generator (CodeQL)

### DIFF
--- a/.changeset/codeql-incomplete-sanitization.md
+++ b/.changeset/codeql-incomplete-sanitization.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+fix(docops): escape backslashes before pipes in the ENTRYPOINTS table generator
+
+Resolves a HIGH `js/incomplete-sanitization` CodeQL alert in
+`entrypointsToolDescription` (#3334): it escaped `|` for markdown-table safety but
+not backslashes first, so a description containing a backslash could smuggle a
+half-escaped pipe past the escaping. Now escapes `\` → `\\` before `|` → `\|`.
+Behavior-preserving (the curated tool descriptions contain no backslashes;
+inject output is unchanged).

--- a/scripts/inject-governance.ts
+++ b/scripts/inject-governance.ts
@@ -506,8 +506,9 @@ function entrypointsAuth(name: string): { prose: string; yaml: string } {
  * `TOOL_DESCRIPTIONS` corpus the CLAUDE.md / README surfaces use, collapsed
  * to its first sentence so the table cell stays scannable. Throws if a
  * registered tool has no description — the prose table must never emit a
- * blank row (#3334). `|` is escaped so a description can't break the markdown
- * column.
+ * blank row (#3334). Backslashes are escaped FIRST, then `|`, so a description
+ * can't break the markdown column or smuggle a half-escaped pipe past the
+ * escaping (CodeQL js/incomplete-sanitization).
  */
 function entrypointsToolDescription(t: ToolMetadata): string {
   const raw = TOOL_DESCRIPTIONS[t.name];
@@ -517,7 +518,7 @@ function entrypointsToolDescription(t: ToolMetadata): string {
         `add one in scripts/tool-descriptions-data.ts before generating ENTRYPOINTS (#3334).`
     );
   }
-  return firstSentence(raw).replace(/\|/g, '\\|');
+  return firstSentence(raw).replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
 /**

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -68,6 +68,8 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 
 <!-- PIPELINE NOTE: inject-governance.ts now GENERATES CLAUDE.md from AGENTS.md (#3446 Phases 2+3, 2026-06-05). extractAgnosticBody() slices AGENTS.md between AGNOSTIC:BODY:START/END markers; injectClaudeAgnosticBlock() injects that slice into CLAUDE.md between GENERATED:FROM_AGENTS markers; checkClaudeAgnosticBlock() (added to checkGovernance()) fails CI when the block is hand-edited or AGENTS.md was edited without re-inject. AGENTS.md is now the single canonical source for the ~75% harness-neutral guidance (mechanism C, generation — picked over  because it reuses this inject infra + is CI-drift-gated); CLAUDE.md = authored header + GENERATED:FROM_AGENTS block + a Claude-specific overlay (Agent/subagent_type table, plugin skills, the existing GOVERNANCE:* tool/model/version markers). checkCanonicalPaths() repointed from CLAUDE.md to AGENTS.md (its authoritative table now) and canonicalPathCandidates() checks EVERY backticked path in a row (was: last only). extractAgnosticBody fails loud on reordered/duplicate markers so a malformed AGENTS.md can never silently erase CLAUDE.md (#3446 QA). Phase 4 (GEMINI.md redirect) pending. -->
 
+<!-- PIPELINE NOTE: entrypointsToolDescription in inject-governance.ts now escapes backslashes before pipes (\\ then \|), resolving a HIGH js/incomplete-sanitization CodeQL alert from #3334 (2026-06-05). Escaping | for markdown-cell safety without escaping \ first let a backslash-bearing tool description smuggle a half-escaped pipe past the sanitization. Behavior-preserving — the curated TOOL_DESCRIPTIONS corpus has no backslashes, so inject output is unchanged + idempotent. -->
+
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 
 ---


### PR DESCRIPTION
## Context
Resolves a **HIGH-severity** `js/incomplete-sanitization` CodeQL alert at `scripts/inject-governance.ts:520` (`entrypointsToolDescription`, introduced in #3334). The function escaped `|` → `\|` for markdown-table cell safety but did **not** escape backslashes first — so a description containing a backslash could smuggle a half-escaped pipe past the escaping ("This does not escape backslash characters in the input").

## Change
Escape `\` → `\\` **before** `|` → `\|` (the canonical fix for this CodeQL pattern).

## Risk / behavior
Low actual risk — the input is the curated `TOOL_DESCRIPTIONS` corpus (trusted T1 repo data, no user input, currently no backslashes). The fix is **behavior-preserving**: `inject` produces no output change and remains idempotent; `inject-governance.ts check` passes; lint clean. CodeQL re-scan on this PR should clear the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)