### PR TITLE
feat(improvement-review): route recurring vote rejections into improvement signals (#3259)

### DIFF
--- a/.changeset/vote-rejection-improvement-3259.md
+++ b/.changeset/vote-rejection-improvement-3259.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(improvement-review): route recurring vote rejections into improvement signals (#3259)
+
+`consensus_vote` buffers a `signal.vote_rejected` event (carrying the ADR-0016
+`rejectionRules`) on the pipeline bus for every rejected plan, but no consumer
+read it — rejection reasons stayed local to each proposal. `improvement_review`
+now reads the buffered rejections (window-filtered, fail-soft) and surfaces a new
+`consensus`-category signal when a single rule (`DRY_VIOLATION`,
+`OVER_ENGINEERING`, …) recurs across ≥3 rejected plans, closing the feedback loop
+the 2026-05-31 system review flagged as missing. Recurring rejection for the same
+reason is a systemic planning gap, surfaced once instead of plan-by-plan. The
+recalled rule is re-validated against the canonical ADR-0016 allowlist
+(defense-in-depth) before it can reach an issue title/body.

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
@@ -13,9 +13,11 @@ import {
   detectCliPerformanceFloor,
   detectFailureCategoryConcentration,
   detectFitnessSignals,
+  detectConsensusRejectionSignals,
 } from './improvement-review.js';
 import type { TaskOutcome } from '../../orchestration/outcomes/outcome-types.js';
 import type { FitnessAudit } from '../../governance/fitness-score.js';
+import type { VoteRejectedSignalEvent } from '../../pipeline/event-types.js';
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -261,5 +263,71 @@ describe('detectFitnessSignals', () => {
     );
     expect(criticalFindings).toHaveLength(1);
     expect(criticalFindings[0]?.signalKey).toBe('tech-debt:fitness-critical:layerSeparation');
+  });
+});
+
+// ============================================================================
+// detectConsensusRejectionSignals (#3259)
+// ============================================================================
+
+function rejection(over: Partial<VoteRejectedSignalEvent> = {}): VoteRejectedSignalEvent {
+  return {
+    type: 'signal.vote_rejected',
+    timestamp: NOW,
+    proposalId: over.proposalId ?? `prop-${Math.random().toString(36).slice(2, 8)}`,
+    approvalPercentage: over.approvalPercentage ?? 33,
+    ...over,
+  };
+}
+
+describe('detectConsensusRejectionSignals', () => {
+  it('returns no signals for an empty event list', () => {
+    expect(detectConsensusRejectionSignals([], '7d')).toHaveLength(0);
+  });
+
+  it('does not fire below the recurrence threshold (≥3 rejections sharing a rule)', () => {
+    const events = [
+      rejection({ rejectionRules: ['DRY_VIOLATION'] }),
+      rejection({ rejectionRules: ['DRY_VIOLATION'] }),
+    ];
+    expect(detectConsensusRejectionSignals(events, '7d')).toHaveLength(0);
+  });
+
+  it('fires a consensus signal when one rule recurs across ≥3 rejected plans', () => {
+    const events = [
+      rejection({ rejectionRules: ['OVER_ENGINEERING'] }),
+      rejection({ rejectionRules: ['OVER_ENGINEERING', 'SCOPE_CREEP'] }),
+      rejection({ rejectionRules: ['OVER_ENGINEERING'] }),
+    ];
+    const signals = detectConsensusRejectionSignals(events, '7d');
+    const overEng = signals.find(
+      (s) => s.signalKey === 'consensus:rejection-pattern:OVER_ENGINEERING'
+    );
+    expect(overEng).toBeDefined();
+    expect(overEng?.category).toBe('consensus');
+    expect(overEng?.evidence.samples).toBe(3);
+    // SCOPE_CREEP appeared only once → below threshold → no signal.
+    expect(signals.some((s) => s.signalKey.endsWith('SCOPE_CREEP'))).toBe(false);
+  });
+
+  it('escalates severity from info to warning at 2× the threshold', () => {
+    const six = Array.from({ length: 6 }, () => rejection({ rejectionRules: ['DRY_VIOLATION'] }));
+    const three = Array.from({ length: 3 }, () => rejection({ rejectionRules: ['DRY_VIOLATION'] }));
+    expect(detectConsensusRejectionSignals(six, '7d')[0]?.severity).toBe('warning');
+    expect(detectConsensusRejectionSignals(three, '7d')[0]?.severity).toBe('info');
+  });
+
+  it('ignores events with no rejectionRules (un-categorized rejections)', () => {
+    const events = [rejection({}), rejection({}), rejection({})];
+    expect(detectConsensusRejectionSignals(events, '7d')).toHaveLength(0);
+  });
+
+  it('drops rules outside the ADR-0016 allowlist (defense-in-depth)', () => {
+    // A poisoned/free-form rule that is NOT one of the 7 canonical categories
+    // must never reach a signal (and thus never an issue title/body).
+    const events = Array.from({ length: 4 }, () =>
+      rejection({ rejectionRules: ['NOT_A_REAL_RULE; rm -rf'] })
+    );
+    expect(detectConsensusRejectionSignals(events, '7d')).toHaveLength(0);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -35,6 +35,8 @@ import { getOutcomeStore } from '../../orchestration/outcomes/outcome-store.js';
 import type { TaskOutcome } from '../../orchestration/outcomes/outcome-types.js';
 import { calculateFitnessScore, type FitnessAudit } from '../../governance/fitness-score.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
+import type { VoteRejectedSignalEvent } from '../../pipeline/event-types.js';
+import { REJECTION_CATEGORIES } from '../../consensus/types-core.js';
 import { emitFitnessDeclinedSignal } from './improvement-review-signals.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
@@ -89,7 +91,7 @@ export const ImprovementReviewInputSchema = z.object({
 
 export type ImprovementReviewInput = z.infer<typeof ImprovementReviewInputSchema>;
 
-export type SignalCategory = 'routing' | 'tech-debt' | 'bug' | 'security';
+export type SignalCategory = 'routing' | 'tech-debt' | 'bug' | 'security' | 'consensus';
 
 export interface ImprovementSignal {
   readonly category: SignalCategory;
@@ -186,6 +188,77 @@ export function detectCliPerformanceFloor(
         window: windowLabel,
         observedValue: rate,
         threshold: 0.6,
+      },
+    });
+  }
+  return signals;
+}
+
+/**
+ * Minimum number of rejected plans citing the same ADR-0016 rule before a
+ * recurring-rejection pattern is worth surfacing. Two is coincidence; three is
+ * a systemic planning gap (mirrors the DRY "third occurrence" rule).
+ */
+const MIN_REJECTION_PATTERN = 3;
+
+/**
+ * Detect recurring consensus-rejection patterns (#3259): a single ADR-0016
+ * rejection rule (`DRY_VIOLATION`, `OVER_ENGINEERING`, `SCOPE_CREEP`, …) cited
+ * across ≥{@link MIN_REJECTION_PATTERN} rejected plans in the window. The
+ * `signal.vote_rejected` events are produced by `consensus_vote` on rejection
+ * (consensus-vote-signals.ts) and buffered on the pipeline event bus; this
+ * detector closes the loop the system review flagged as missing — recurring
+ * rejection for the same reason means the planner keeps making the same class
+ * of mistake, which the next improvement cycle should name explicitly.
+ *
+ * Events with no `rejectionRules` (un-categorized rejections) contribute no
+ * pattern signal — there is nothing actionable to aggregate on.
+ */
+export function detectConsensusRejectionSignals(
+  events: readonly VoteRejectedSignalEvent[],
+  windowLabel: string
+): readonly ImprovementSignal[] {
+  if (events.length === 0) return [];
+
+  // Defense-in-depth allowlist: the only producer (consensus-vote-signals.ts)
+  // sources rules from the Zod-validated ADR-0016 enum, so a free-form/poisoned
+  // rule cannot reach here today. Re-validating against REJECTION_CATEGORIES
+  // makes that safety local — an unexpected rule string never reaches an issue
+  // title/body — instead of relying on cross-file inference (#3259 review).
+  const allowed = new Set<string>(REJECTION_CATEGORIES);
+  const byRule = new Map<string, number>();
+  for (const e of events) {
+    for (const rule of e.rejectionRules ?? []) {
+      if (!allowed.has(rule)) continue;
+      byRule.set(rule, (byRule.get(rule) ?? 0) + 1);
+    }
+  }
+
+  const signals: ImprovementSignal[] = [];
+  for (const [rule, count] of byRule) {
+    if (count < MIN_REJECTION_PATTERN) continue;
+    signals.push({
+      category: 'consensus',
+      signalKey: `consensus:rejection-pattern:${rule}`,
+      severity: count >= MIN_REJECTION_PATTERN * 2 ? 'warning' : 'info',
+      title: `consensus: ${String(count)} plans rejected for \`${rule}\` in ${windowLabel}`,
+      body: [
+        `Recurring consensus-rejection pattern in the ${windowLabel} window.`,
+        '',
+        `- Rejection rule: \`${rule}\` (ADR-0016 category)`,
+        `- Occurrences: ${String(count)} rejected plans`,
+        `- Threshold: ≥${String(MIN_REJECTION_PATTERN)} plans citing the same rule`,
+        '',
+        'The planner keeps producing plans that voters reject for the same reason. ' +
+          'Feed this back into plan generation (e.g. a planning guardrail or a ' +
+          'targeted prompt note) rather than rejecting plan-by-plan. Inspect the ' +
+          'rejected proposals via `query_trace` / the consensus audit chain.',
+      ].join('\n'),
+      evidence: {
+        samples: count,
+        window: windowLabel,
+        observedValue: count,
+        threshold: MIN_REJECTION_PATTERN,
       },
     });
   }
@@ -522,6 +595,28 @@ async function fileSignalsAsIssues(
 }
 
 /**
+ * Read `signal.vote_rejected` events from the pipeline bus's buffered history,
+ * narrowed to the lookback window. Returns `[]` if the bus is empty or every
+ * event predates the window. Fail-soft: never throws into the review run.
+ *
+ * The bus is a per-process module singleton (event-bus.ts), so this only sees
+ * rejections emitted by `consensus_vote` *in the same process* — i.e. a
+ * long-lived MCP server where both tools share the buffer. In separate
+ * CLI invocations the buffer starts empty and this correctly yields no signals
+ * (the loop degrades to "no consensus data" rather than misreporting).
+ */
+function readBufferedVoteRejections(
+  now: number,
+  lookbackDays: number
+): readonly VoteRejectedSignalEvent[] {
+  const cutoff = now - lookbackDays * DAY_MS;
+  return getPipelineEventBus()
+    .query({ type: 'signal.vote_rejected' })
+    .filter((e): e is VoteRejectedSignalEvent => e.type === 'signal.vote_rejected')
+    .filter((e) => e.timestamp >= cutoff);
+}
+
+/**
  * Context-free runner exposed for both the MCP handler and the
  * `nexus-agents improvement-review` CLI subcommand (#2444). Pure dependencies
  * — pass a logger and an OutcomeStore-query result if you want to inject test
@@ -547,10 +642,17 @@ export async function runImprovementReview(
       ? await loadSelfEvalSignals(selfEvalReportPath, windowLabel, logger)
       : [];
 
+  // Recurring consensus-rejection patterns (#3259). `consensus_vote` buffers a
+  // `signal.vote_rejected` event per rejected plan on the pipeline bus; read the
+  // buffered history (not a live subscription — this is a one-shot tool) and
+  // window-filter by event timestamp before aggregating.
+  const rejectionEvents = readBufferedVoteRejections(now, lookbackDays);
+
   const signals: ImprovementSignal[] = [
     ...detectCliPerformanceFloor(windowed, minSampleSize, windowLabel),
     ...detectFailureCategoryConcentration(windowed, windowLabel),
     ...detectFitnessSignals(audit, fitnessFloor),
+    ...detectConsensusRejectionSignals(rejectionEvents, windowLabel),
     ...selfEvalSignals,
   ];
   signals.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);

--- a/packages/nexus-agents/src/pipeline/event-types.ts
+++ b/packages/nexus-agents/src/pipeline/event-types.ts
@@ -192,7 +192,7 @@ interface SwarmUnhealthySignalEvent extends BaseEvent {
   readonly reason: string;
 }
 
-interface VoteRejectedSignalEvent extends BaseEvent {
+export interface VoteRejectedSignalEvent extends BaseEvent {
   readonly type: 'signal.vote_rejected';
   readonly proposalId: string;
   /** Approval percentage of the rejected vote (0-100). */


### PR DESCRIPTION
## Context
Closes #3259 (2026-05-31 system-review finding; epic #3143). `consensus_vote` already buffers a `signal.vote_rejected` event — carrying the ADR-0016 `rejectionRules` — on the pipeline bus for every rejected plan (`consensus-vote-signals.ts`). But **nothing consumed it**: the `TuneStage` shadow-logs it without acting, and `improvement_review` didn't subscribe at all. Rejection reasons stayed local to each proposal, so the planner could keep getting rejected for the same reason with no feedback loop.

## Change
`improvement_review` now reads the buffered rejections and surfaces a new **`consensus`** signal when one rule (`DRY_VIOLATION`, `OVER_ENGINEERING`, …) recurs across **≥3 rejected plans** in the window — naming the systemic planning gap once instead of plan-by-plan.

- **`detectConsensusRejectionSignals`** — pure aggregator over `rejectionRules`; severity escalates `info → warning` at 2× the threshold. Guarded by an **ADR-0016 allowlist** (`REJECTION_CATEGORIES`) so an unexpected/poisoned rule string can never reach an issue title/body (defense-in-depth; the producer is already Zod-enum-constrained, this makes the safety local).
- **`readBufferedVoteRejections`** — fail-soft bus-history reader, window-filtered by event timestamp; documents the per-process-singleton visibility boundary (sees rejections emitted in the same long-lived MCP server process).
- Exported `VoteRejectedSignalEvent`; created the `consensus` + `routing` GitHub labels so the opt-in issue-filing path no longer fail-soft-skips those categories.

## Review (QA + security — both APPROVE)
- **QA:** aggregation/threshold/severity logic matches tests; `Map` iteration safe; wiring complete (only category dispatch is the issue-label map — `consensus` handled). Flagged the cross-process visibility boundary (now documented) and the missing labels (now created).
- **Security:** traced producer → consumer; `rejectionRules` is Zod-enum-constrained at the source, `gh` is invoked via `execFile` argv (no shell), label derives from the fixed category not the rule, and signals are bounded by the 7-value enum + `MAX_ISSUES_PER_RUN`. No injection/DoS path. Recommended the allowlist (added).

## Testing
`improvement-review.test.ts` → 24 passed (6 new: empty / below-threshold / fires-at-3 / 2×-severity / no-rules / allowlist-drops-poisoned-rule). typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)