### PR TITLE
feat(context): surface prior research in UnifiedContext (#3148)

### DIFF
--- a/.changeset/research-into-context-3148.md
+++ b/.changeset/research-into-context-3148.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(context): surface prior research in UnifiedContext (#3148)
+
+Closes the research→context half of the knowledge loop. The research registry
+accumulated findings, but `ContextRetriever` (the canonical pre-task read used by
+`orchestrate` and graph workflows) had no field for them, so planners couldn't
+reuse research. `getContextForTask` now returns `researchInsights` — research
+techniques whose name/topic is relevant to the task, with their status
+(implemented / rejected / planned) — and `summarizeContextForPrompt` renders a
+"Prior research on this topic" block into the planner prompt. The read is
+fail-soft (missing/failed registry → no insights, context assembly never
+breaks) and uses the lightweight registry status read, not full synthesis, so
+it stays cheap on the per-task fan-out.

--- a/packages/nexus-agents/src/context/context-retriever-helpers.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever-helpers.test.ts
@@ -36,6 +36,7 @@ describe('summarizeContextForPrompt', () => {
     experiencePatterns: [],
     outcomes: null,
     priorStrategies: [],
+    researchInsights: [],
   };
 
   it('returns an empty string when nothing is known', () => {

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -14,9 +14,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { closeMemoryRegistry, createInMemoryMemoryRegistry, setMemoryRegistry } from 'nexus-memory';
-import { getContextForTask } from './context-retriever.js';
+import {
+  getContextForTask,
+  selectRelevantResearch,
+  summarizeContextForPrompt,
+  type UnifiedContext,
+} from './context-retriever.js';
 import { resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import type { DistilledRule } from '../learning/strategy-distiller-types.js';
+import type { TechniqueStatusSummary } from '../cli/research-types.js';
 
 describe('getContextForTask', () => {
   let dataDir: string;
@@ -252,5 +258,91 @@ describe('getContextForTask', () => {
       limit: 3,
     });
     expect(ctx.priorStrategies.length).toBe(3);
+  });
+});
+
+// ============================================================================
+// selectRelevantResearch — research→context relevance filter (#3148)
+// ============================================================================
+
+function makeTechnique(over: Partial<TechniqueStatusSummary>): TechniqueStatusSummary {
+  return {
+    id: over.id ?? 't-1',
+    name: over.name ?? 'Some Technique',
+    status: over.status ?? 'planned',
+    priority: over.priority ?? 'P2',
+    topic: over.topic ?? 'general',
+    implementationIssue: over.implementationIssue ?? null,
+  };
+}
+
+describe('selectRelevantResearch', () => {
+  it('returns empty when there are no techniques', () => {
+    expect(selectRelevantResearch([], 'speculative decoding', 5)).toEqual([]);
+  });
+
+  it('returns empty when the task has no discriminating (≥4-char) tokens', () => {
+    const techs = [makeTechnique({ topic: 'caching' })];
+    expect(selectRelevantResearch(techs, 'a to do it', 5)).toEqual([]);
+  });
+
+  it('matches techniques sharing a word with the task topic/name', () => {
+    const techs = [
+      makeTechnique({ id: 'a', name: 'Speculative Decoding', topic: 'inference' }),
+      makeTechnique({ id: 'b', name: 'Prompt Caching', topic: 'caching' }),
+    ];
+    // "decoding" overlaps the first technique's name; the second shares nothing.
+    const result = selectRelevantResearch(techs, 'add speculative decoding to the runtime', 5);
+    expect(result.map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('respects the limit and preserves registry order', () => {
+    const techs = [
+      makeTechnique({ id: 'a', topic: 'routing' }),
+      makeTechnique({ id: 'b', topic: 'routing' }),
+      makeTechnique({ id: 'c', topic: 'routing' }),
+    ];
+    const result = selectRelevantResearch(techs, 'improve routing decisions', 2);
+    expect(result.map((t) => t.id)).toEqual(['a', 'b']);
+  });
+
+  it('ignores short shared tokens that are too generic to anchor relevance', () => {
+    const techs = [makeTechnique({ id: 'a', name: 'API', topic: 'web' })];
+    // "api"/"web" are <4 chars → no match even though the word appears.
+    expect(selectRelevantResearch(techs, 'design the api for web', 5)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// summarizeContextForPrompt — research section rendering (#3148)
+// ============================================================================
+
+function emptyContext(over: Partial<UnifiedContext> = {}): UnifiedContext {
+  return {
+    beliefs: [],
+    similarMemories: [],
+    recentLearnings: [],
+    experiencePatterns: [],
+    outcomes: null,
+    priorStrategies: [],
+    researchInsights: [],
+    ...over,
+  };
+}
+
+describe('summarizeContextForPrompt — research insights', () => {
+  it('renders a Prior research section with name, status, and topic', () => {
+    const ctx = emptyContext({
+      researchInsights: [
+        makeTechnique({ name: 'Speculative Decoding', status: 'rejected', topic: 'inference' }),
+      ],
+    });
+    const out = summarizeContextForPrompt(ctx);
+    expect(out).toContain('### Prior research on this topic');
+    expect(out).toContain('- Speculative Decoding (rejected) — inference');
+  });
+
+  it('omits the research section entirely when there are no insights', () => {
+    expect(summarizeContextForPrompt(emptyContext())).toBe('');
   });
 });

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -36,6 +36,8 @@ import { createLogger } from '../core/logger.js';
 import { getToolMemory } from '../mcp/tools/tool-memory.js';
 import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import { loadPersistedRules } from '../learning/strategy-distiller-persistence.js';
+import { getResearchStatus } from '../cli/research-helpers.js';
+import type { TechniqueStatusSummary } from '../cli/research-types.js';
 
 /**
  * What we know about a task, derived from every shared memory backend.
@@ -58,6 +60,14 @@ export interface UnifiedContext {
   readonly outcomes: PerformanceSummary | null;
   /** Distilled routing rules — populated once #2797 lands; empty until then. */
   readonly priorStrategies: readonly DistilledRule[];
+  /**
+   * Prior research techniques from the research registry whose topic/name is
+   * relevant to the task (#3148 / #2792 research→context loop). Surfaces what
+   * we have already investigated — and its status (implemented / rejected /
+   * planned) — so planning reuses research instead of re-proposing settled or
+   * already-rejected approaches. Empty when nothing matches or no registry.
+   */
+  readonly researchInsights: readonly TechniqueStatusSummary[];
 }
 
 /** Options accepted by {@link getContextForTask}. */
@@ -91,14 +101,21 @@ export async function getContextForTask(options: ContextRetrieverOptions): Promi
   const limit = options.limit ?? DEFAULT_LIMIT;
   const logger = options.logger ?? createLogger({ component: 'ContextRetriever' });
 
-  const [beliefs, similarMemories, recentLearnings, experiencePatterns, outcomes] =
-    await Promise.all([
-      fetchBeliefs(options.task, limit, logger),
-      fetchSimilarMemories(options.task, limit, logger),
-      fetchRecentLearnings(options.task, limit, logger),
-      fetchExperiencePatterns(options.task, limit, logger),
-      fetchOutcomes(options.category, logger),
-    ]);
+  const [
+    beliefs,
+    similarMemories,
+    recentLearnings,
+    experiencePatterns,
+    outcomes,
+    researchInsights,
+  ] = await Promise.all([
+    fetchBeliefs(options.task, limit, logger),
+    fetchSimilarMemories(options.task, limit, logger),
+    fetchRecentLearnings(options.task, limit, logger),
+    fetchExperiencePatterns(options.task, limit, logger),
+    fetchOutcomes(options.category, logger),
+    fetchResearchInsights(options.task, limit, logger),
+  ]);
 
   const priorStrategies = fetchPriorStrategies(options.category, limit, logger);
 
@@ -109,7 +126,75 @@ export async function getContextForTask(options: ContextRetrieverOptions): Promi
     experiencePatterns,
     outcomes,
     priorStrategies,
+    researchInsights,
   };
+}
+
+/** Tokens shorter than this are too generic to anchor research relevance. */
+const MIN_RELEVANCE_TOKEN = 4;
+
+/**
+ * Pure relevance filter: select research techniques whose `topic` or `name`
+ * shares a meaningful word (≥{@link MIN_RELEVANCE_TOKEN} chars) with the task
+ * text. Order-preserving; returns at most `limit`. Exported for direct unit
+ * testing of the matching logic (the network/registry read is wrapped
+ * separately in {@link fetchResearchInsights}).
+ */
+export function selectRelevantResearch(
+  techniques: readonly TechniqueStatusSummary[],
+  task: string,
+  limit: number
+): readonly TechniqueStatusSummary[] {
+  const taskTokens = tokenize(task);
+  if (taskTokens.size === 0) return [];
+  const matches: TechniqueStatusSummary[] = [];
+  for (const t of techniques) {
+    const fieldTokens = tokenize(`${t.name} ${t.topic}`);
+    let hit = false;
+    for (const tok of fieldTokens) {
+      if (taskTokens.has(tok)) {
+        hit = true;
+        break;
+      }
+    }
+    if (hit) {
+      matches.push(t);
+      if (matches.length >= limit) break;
+    }
+  }
+  return matches;
+}
+
+/** Lowercase word set, keeping only tokens long enough to be discriminating. */
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length >= MIN_RELEVANCE_TOKEN) tokens.add(raw);
+  }
+  return tokens;
+}
+
+/**
+ * Read research-registry techniques relevant to the task. Fail-soft: a missing
+ * registry, a failed status read, or any throw yields `[]` so context assembly
+ * never breaks on the research backend. Uses the lightweight status read (not
+ * full synthesis) so it stays cheap enough for the per-task context fan-out.
+ */
+async function fetchResearchInsights(
+  task: string,
+  limit: number,
+  logger: ILogger
+): Promise<readonly TechniqueStatusSummary[]> {
+  try {
+    const result = await getResearchStatus({ status: 'all', format: 'json' });
+    if (!result.success) return [];
+    return selectRelevantResearch(result.techniques, task, limit);
+  } catch (error: unknown) {
+    logger.debug('ContextRetriever: research insights fetch failed', {
+      error: formatError(error),
+    });
+    return [];
+  }
 }
 
 /**
@@ -289,6 +374,13 @@ export function summarizeContextForPrompt(ctx: UnifiedContext): string {
     sections.push(
       `### Outcomes for this category\n- ${String(ctx.outcomes.totalTasks)} prior tasks, ${(ctx.outcomes.successRate * 100).toFixed(0)}% success`
     );
+  }
+
+  if (ctx.researchInsights.length > 0) {
+    const lines = ctx.researchInsights
+      .slice(0, 5)
+      .map((r) => `- ${r.name} (${r.status}) — ${r.topic}`);
+    sections.push(`### Prior research on this topic\n${lines.join('\n')}`);
   }
 
   return sections.length === 0 ? '' : `## Prior Context (Nexus Memory)\n${sections.join('\n\n')}`;


### PR DESCRIPTION
## Context
Closes #3148 (epic #2792 research→context loop; the highest-value remaining gap from the #3143 self-tuning audit). The research substrate was **write-only**: the technique registry and `research_synthesize` accumulated findings, but `ContextRetriever` — the canonical "what do we already know about this task" read that `orchestrate` and graph workflows call — had **no field** for research. So planning could re-propose already-rejected or already-implemented approaches.

## Change
`getContextForTask` now fans out a fail-soft research read and returns `researchInsights`: registry techniques whose name/topic is relevant to the task, with their status (implemented / rejected / planned). `summarizeContextForPrompt` renders a **"Prior research on this topic"** section (`- name (status) — topic`) into the planner prompt prefix.

- **`selectRelevantResearch`** — pure, exported token-overlap filter (tokens ≥4 chars to avoid generic noise; order-preserving; limit-bounded). Unit-tested directly.
- **`fetchResearchInsights`** — fail-soft wrapper around the lightweight registry **status** read (not full synthesis, so it stays cheap on the per-task fan-out); any throw / failed read → `[]`, context assembly never breaks.
- Verified the only literal `UnifiedContext` construction (and the one helper-test literal) were updated for the new required field.

## Review (QA + security — both APPROVE, all findings LOW)
- **QA:** limit logic exact (no off-by-one), order preserved, all edge cases (empty task / empty techniques / all-short-tokens / limit / no-match) covered and passing; fan-out safe (throw caught *inside* the fetch, can't reject the `Promise.all`); wiring complete; perf parallels the existing `loadPersistedRules()` disk read.
- **Security:** registry source is **T1 repo-controlled** (`techniques.yaml`, human-CLI writes only — `research_add` writes papers, not techniques), so #818 isn't triggered; the verbatim render matches the pre-existing beliefs/memories pattern (no new trust boundary); `split(/[^a-z0-9]+/)` has no ReDoS.

## Follow-ups filed
- **#3471** — harden all `summarizeContextForPrompt` sections (strip newlines + cap per field); pre-existing pattern, do before any technique-write path lands.
- **#3472** — wire `researchInsights` into the dev-pipeline plan/vote context (separate consumer; #3257 seam).

## Testing
`context-retriever.test.ts` + `context-retriever-helpers.test.ts` → 31 passed (5 new selector + 2 render). typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)