### PR TITLE
fix(pipeline): remove dead reinforcePlanBeliefs no-op (#3465)

### DIFF
--- a/.changeset/remove-dead-reinforce-3465.md
+++ b/.changeset/remove-dead-reinforce-3465.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+fix(pipeline): remove the dead `reinforcePlanBeliefs` no-op (#3465)
+
+`reinforcePlanBeliefs` (#1720) reinforced/weakened a `plan-approach:<task>` belief
+that was never `retain`ed, so the call had been a silent no-op since it landed.
+Removed it: the functional plan-learning channel is `HindsightRecord`s (written by
+`applyPipelineHindsight`, read into plan/vote by #3257), making the never-wired,
+task-specific belief path redundant dead code. No behavior change.

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -237,9 +237,6 @@ async function runDevPipelineInner(
   // Phases 1-2: Research + Plan/Vote
   const { planResult } = await runPlanningPhase(task, stages, sid, prior, bm);
 
-  // Reinforce/weaken beliefs based on vote outcome (#1720)
-  reinforcePlanBeliefs(bm, task, planResult.iterations);
-
   // DRY RUN: stop after plan+vote, return partial result (#1717)
   if (options?.dryRun === true) {
     logger.info('Dry run — stopping after plan+vote');
@@ -299,35 +296,6 @@ async function flushTraceWriter(writer: TraceWriter | null): Promise<void> {
     logger.warn('Failed to flush execution trace', { error: String(error) });
   } finally {
     writer.stop();
-  }
-}
-
-/**
- * Reinforce or weaken beliefs based on plan vote outcome (#1720).
- * First-iteration approval → reinforce. Multiple iterations → weaken.
- * Fire-and-forget — pipeline does not block on belief updates.
- */
-function reinforcePlanBeliefs(
-  bm: IHindsightBeliefMemory | undefined,
-  task: string,
-  iterations: number
-): void {
-  if (bm === undefined) return;
-  const beliefId = `plan-approach:${task.slice(0, 80)}`;
-  // Fire-and-forget: belief memory is optional persistence. Log on failure
-  // so we notice if the belief store silently stops receiving updates.
-  const logBmError = (op: string) => (error: unknown) => {
-    const msg = error instanceof Error ? error.message : String(error);
-    logger.debug(`Belief-memory ${op} failed`, { beliefId, error: msg });
-  };
-  if (iterations <= 1) {
-    void bm
-      .reinforce(beliefId, 'Plan approved on first vote iteration')
-      .catch(logBmError('reinforce'));
-  } else {
-    void bm
-      .weaken(beliefId, `Plan required ${String(iterations)} vote iterations before approval`)
-      .catch(logBmError('weaken'));
   }
 }
 


### PR DESCRIPTION
## Context
Closes #3465 (discovered during #3257). `reinforcePlanBeliefs` (#1720) called `reinforce`/`weaken` on a `plan-approach:<task>` `beliefId` that is **never `retain`ed** — no `Belief` with that id is created anywhere — so `adjustConfidenceInternal` always returned "Belief not found" and the call has been a **silent no-op** since it landed in #1749.

## Decision: remove (option b), not wire (option a)
The issue offered two fixes. I chose removal because:
- The belief was **task-specific** (`plan-approach:<task>`), so even if retained it would only ever match the *identical* task — low value.
- The **functional** plan-learning channel already exists: `HindsightRecord`s, written by `applyPipelineHindsight` and read into plan/vote by #3257 (and now research insights by #3472). A second, never-functional, redundant channel is dead weight (YAGNI).

`reinforce`/`weaken` remain on `IHindsightBeliefMemory` for their live consumers (e.g. the `SkillLibrary` promoter) — only the dead dev-pipeline usage is removed.

## Verification
Verified dead via grep (`plan-approach` never retained/recorded) and git history (single-commit #1749 feature whose `retain` step never existed). No behavior change — the path was already a no-op. No test asserted the call (the `reinforce`/`weaken` mocks in `dev-pipeline.test.ts` are bare interface stubs). `dev-pipeline.test.ts` → 22 passed; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)