### PR TITLE
feat(pipeline): wire accumulated context into run_pipeline research stage (#2795)

### DIFF
--- a/.changeset/stage-wrappers-context-2795.md
+++ b/.changeset/stage-wrappers-context-2795.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+feat(pipeline): wire accumulated context into the run_pipeline research stage (#2795)
+
+Closes the long-standing `#2795` TODO in `stage-wrappers.ts`: the research stage
+of the `run_pipeline` MCP tool now prepends accumulated memory context
+(beliefs, prior research, outcomes) to the task, completing the #2792 Phase-3
+entry-point wiring for that path. Adds a shared `getContextPromptPrefix` helper
+in `context-retriever.ts` that centralizes the `NEXUS_CONTEXT_RETRIEVER_INJECT`
+rollout gate (default-off) and the fetch→summarize sequence reused by
+orchestrate / execute_expert / stage-wrappers. Fail-soft and behavior-preserving
+until the bake-in flips the flag on.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -18,6 +18,7 @@ import {
   getContextForTask,
   selectRelevantResearch,
   summarizeContextForPrompt,
+  getContextPromptPrefix,
   type UnifiedContext,
 } from './context-retriever.js';
 import { resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
@@ -372,5 +373,27 @@ describe('summarizeContextForPrompt — research insights', () => {
     // 200-char cap → the rendered topic run is bounded, not 500 chars.
     expect(out).not.toContain('x'.repeat(201));
     expect(out).toContain('x'.repeat(200));
+  });
+});
+
+// ============================================================================
+// getContextPromptPrefix — shared flag-gated entry-point helper (#2795)
+// ============================================================================
+
+describe('getContextPromptPrefix', () => {
+  const prev = process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'];
+  afterEach(() => {
+    if (prev === undefined) delete process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'];
+    else process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'] = prev;
+  });
+
+  it('returns undefined when the rollout flag is unset (default-off)', async () => {
+    delete process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'];
+    expect(await getContextPromptPrefix('any task')).toBeUndefined();
+  });
+
+  it('returns undefined when the flag is a non-1 value', async () => {
+    process.env['NEXUS_CONTEXT_RETRIEVER_INJECT'] = 'true';
+    expect(await getContextPromptPrefix('any task')).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -411,3 +411,34 @@ export function summarizeContextForPrompt(ctx: UnifiedContext): string {
 
   return sections.length === 0 ? '' : `## Prior Context (Nexus Memory)\n${sections.join('\n\n')}`;
 }
+
+/** Rollout gate for injecting unified context into entry-point prompts (#2921). */
+const CONTEXT_INJECT_FLAG = 'NEXUS_CONTEXT_RETRIEVER_INJECT';
+
+/**
+ * One-call helper for entry points that want to prepend accumulated context to a
+ * prompt: returns the {@link summarizeContextForPrompt} block for `task`, or
+ * `undefined` when the rollout flag is unset or there is no signal.
+ *
+ * Centralizes the `NEXUS_CONTEXT_RETRIEVER_INJECT` gate (#2921) and the
+ * fetch→summarize sequence so each consumer (orchestrate, execute_expert,
+ * pipeline stage-wrappers …) doesn't re-implement it. Default-off and fail-soft:
+ * any retrieval error yields `undefined`. Callers whose prompt also feeds a
+ * security decision (e.g. an access policy) must still treat the block as
+ * untrusted — the underlying memory backends are writable via `memory_write`.
+ */
+export async function getContextPromptPrefix(
+  task: string,
+  logger?: ILogger
+): Promise<string | undefined> {
+  if (process.env[CONTEXT_INJECT_FLAG] !== '1') return undefined;
+  const log = logger ?? createLogger({ component: 'ContextRetriever' });
+  try {
+    const ctx = await getContextForTask({ task, category: inferTaskCategory(task), logger: log });
+    const summary = summarizeContextForPrompt(ctx);
+    return summary === '' ? undefined : summary;
+  } catch (error: unknown) {
+    log.debug('context prompt prefix failed', { error: formatError(error) });
+    return undefined;
+  }
+}

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
@@ -16,6 +16,16 @@ import type { DevPipelineStages, VoteResult, QaReviewResult } from './dev-pipeli
 import type { PipelineContext } from './stage-types.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
 
+// #2795: the research stage prepends accumulated context (flag-gated). Mock the
+// helper to `undefined` by default so existing tests are deterministic
+// regardless of env/registry; one test overrides it to assert the prepend.
+const contextPrefixMock = vi.fn<() => Promise<string | undefined>>(() =>
+  Promise.resolve(undefined)
+);
+vi.mock('../context/context-retriever.js', () => ({
+  getContextPromptPrefix: (): Promise<string | undefined> => contextPrefixMock(),
+}));
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -98,6 +108,23 @@ describe('Stage Wrappers', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe('adapter exploded');
       expect(result.error).not.toContain('[object Object]');
+    });
+
+    it('passes the bare task to research when no memory prefix is available (#2795)', async () => {
+      contextPrefixMock.mockResolvedValueOnce(undefined);
+      const stages = createMockStages();
+      await createResearchStageWrapper(stages).execute(makeContext());
+      // Gate off / no signal → research sees the task unprefixed.
+      expect(vi.mocked(stages.research)).toHaveBeenCalledWith('Build feature X');
+    });
+
+    it('prepends the memory prefix ahead of the task when available (#2795)', async () => {
+      contextPrefixMock.mockResolvedValueOnce('## Prior Context (Nexus Memory)\n### Beliefs\n- x');
+      const stages = createMockStages();
+      await createResearchStageWrapper(stages).execute(makeContext());
+      const arg = vi.mocked(stages.research).mock.calls[0]?.[0] ?? '';
+      expect(arg.startsWith('## Prior Context (Nexus Memory)')).toBe(true);
+      expect(arg).toContain('Build feature X');
     });
   });
 

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -14,6 +14,7 @@ import type { DevPipelineStages, PipelineTask } from './dev-pipeline.js';
 import { isApproved, getVoteFeedback } from './dev-pipeline.js';
 import type { IPipelineStage, PipelineContext, StageOutput } from './stage-types.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
+import { getContextPromptPrefix } from '../context/context-retriever.js';
 
 // ============================================================================
 // Helper
@@ -63,12 +64,17 @@ export function createResearchStageWrapper(stages: DevPipelineStages): IPipeline
         // injected here (#1781) but the bridge was provably broken — it
         // used `task.slice(0, 50)` as a literal key against a backend
         // whose writers use UUIDs, so the lookup never matched. Removed
-        // in #2796; cross-cutting memory enrichment will return via
-        // `getContextForTask` once #2795 (Phase 3 of #2792) lands.
+        // in #2796; cross-cutting memory enrichment returns here via
+        // `getContextPromptPrefix` (#2795, Phase 3 of #2792) — flag-gated
+        // behind NEXUS_CONTEXT_RETRIEVER_INJECT (default-off), fail-soft.
         const codeContext = await searchCodebaseForTask(ctx.task);
         let enrichedTask = ctx.task;
         if (codeContext !== null && codeContext !== '') {
           enrichedTask = `${enrichedTask}\n\n## Codebase Context\n${codeContext}`;
+        }
+        const memoryPrefix = await getContextPromptPrefix(ctx.task);
+        if (memoryPrefix !== undefined) {
+          enrichedTask = `${memoryPrefix}\n\n${enrichedTask}`;
         }
         const result = await stages.research(enrichedTask);
         return output(K.RESEARCH, result, getTimeProvider().now() - start, true);


### PR DESCRIPTION
## Context
Closes the long-standing `#2795` TODO in `stage-wrappers.ts:67`. The research stage of the **`run_pipeline`** MCP tool (an active, registered tool) had a placeholder where cross-cutting memory enrichment was meant to return. The prior bridge here (#1781) was **provably broken** — it used `task.slice(0,50)` as a literal key against a UUID-keyed backend, so the lookup never matched — and was removed in #2796. This is the correct re-introduction via `getContextForTask`.

## Change
The research stage now prepends accumulated memory context (beliefs, prior research, outcomes) to the task, completing the #2792 Phase-3 entry-point wiring for this path.

**Rule-of-three extraction:** orchestrate, execute_expert (#3238), and now stage-wrappers all need the same "flag-gated fetch → summarize" step, so I added a shared **`getContextPromptPrefix(task, logger?)`** helper in `context-retriever.ts`. It centralizes the `NEXUS_CONTEXT_RETRIEVER_INJECT` rollout gate (#2921, **default-off**) and is fail-soft (any error → `undefined` → research runs with the bare task). No behavior change until the bake-in flips the flag.

Unlike execute_expert, the research-stage prompt has no access-policy flow, so it follows orchestrate's lighter treatment (the `summarizeContextForPrompt` `oneLine`-hardening + "informational" framing) — no extra sanitization needed.

## Testing
`stage-wrappers.test.ts` + `context-retriever.test.ts` → 38 passed (new: prefix-prepended-when-available, bare-task-when-absent, and the `getContextPromptPrefix` flag gate unset/non-`1`). Verified `run_pipeline` consumer suites (pipeline-tool + graph-pipeline-runner, 11 passed) — no regression with the flag unset. typecheck + lint clean.

## Adoption status (#3238)
With this, `getContextForTask`/prefix is wired into routing ✓, orchestrate ✓, graph ✓, execute_expert ✓, and run_pipeline research ✓. Remaining gap: consensus-voting (low value — voters need the proposal, not task memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)