### PR TITLE
fix(cli-adapters): classify OpenCode error-only streams instead of PARSE_ERROR (#3485)

### DIFF
--- a/.changeset/opencode-error-only-classification-3485.md
+++ b/.changeset/opencode-error-only-classification-3485.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): classify OpenCode error-only streams instead of PARSE_ERROR (#3485)
+
+An error-only OpenCode NDJSON stream (e.g. an upstream 401 → `{"type":"error",…}`
+with no assistant content) was misclassified as `PARSE_ERROR`, masking the real
+cause and dropping the remediation hint. The subprocess adapter now consumes the
+parser's extracted error message via a new optional
+`ICliResponseParser.extractErrorMessage`, classifying it through the shared
+`classifyExtractedError` (rate-limit → auth → generic). An upstream 401 now
+surfaces as `NOT_AUTHENTICATED: … → Re-authenticate: run \`opencode auth login\``
+instead of "Failed to parse response". The optional parser method lets other CLI
+adapters opt into the same handling for their error-only streams.

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseCliErrorEnvelope, authRemediation } from './cli-error-envelope.js';
+import {
+  parseCliErrorEnvelope,
+  authRemediation,
+  classifyExtractedError,
+} from './cli-error-envelope.js';
 
 describe('parseCliErrorEnvelope (#2440)', () => {
   // Real-world example from the round-14 audit report.
@@ -222,6 +226,43 @@ describe('parseCliErrorEnvelope (#2440)', () => {
 
     it('authRemediation returns null for an unknown CLI name even on an auth error', () => {
       expect(authRemediation(refreshTokenMsg, 'totally-unknown-cli')).toBeNull();
+    });
+  });
+
+  describe('classifyExtractedError (error-only stream classification)', () => {
+    it('classifies an upstream 401 as NOT_AUTHENTICATED with a login hint', () => {
+      // The exact message an OpenCode error-only NDJSON event surfaces.
+      const result = classifyExtractedError(
+        'Unauthorized: {"detail":"Not authenticated"}',
+        'opencode'
+      );
+      expect(result.code).toBe('NOT_AUTHENTICATED');
+      expect(result.hint).toContain('opencode auth login');
+    });
+
+    it('classifies a rate-limit message as RATE_LIMITED (no auth hint)', () => {
+      const result = classifyExtractedError(
+        '429 Too Many Requests: rate limit exceeded',
+        'opencode'
+      );
+      expect(result.code).toBe('RATE_LIMITED');
+      expect(result.hint).toBeUndefined();
+    });
+
+    it('falls back to EXECUTION_ERROR for an unclassifiable message', () => {
+      const result = classifyExtractedError('the model produced an internal error', 'opencode');
+      expect(result.code).toBe('EXECUTION_ERROR');
+      expect(result.hint).toBeUndefined();
+    });
+
+    it('classifies auth but omits the hint for an unknown CLI name', () => {
+      const result = classifyExtractedError('Unauthorized', 'totally-unknown-cli');
+      expect(result.code).toBe('NOT_AUTHENTICATED');
+      expect(result.hint).toBeUndefined();
+    });
+
+    it('trims surrounding whitespace from the message', () => {
+      expect(classifyExtractedError('  Unauthorized  ', 'opencode').message).toBe('Unauthorized');
     });
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-envelope.ts
@@ -19,6 +19,7 @@
  */
 
 import type { CliErrorCode, CliName } from './types.js';
+import { isRateLimitText } from '../adapters/rate-limit-detector.js';
 
 /**
  * Result of unwrapping a CLI's structured error envelope. `null` when the
@@ -136,6 +137,29 @@ export function authRemediation(message: string, cliName: string): string | null
   const cli = resolveCliName(cliName);
   if (cli === null) return null;
   return `Re-authenticate: run \`${LOGIN_HINTS[cli]}\` (the ${cli} CLI's stored OAuth token is stale).`;
+}
+
+/**
+ * Classify an error message a CLI's response parser already extracted from an
+ * error-only stream (e.g. OpenCode's NDJSON `{"type":"error",...}` event,
+ * surfaced via `ICliResponseParser.extractErrorMessage`). Unlike
+ * {@link parseCliErrorEnvelope} this takes the *already-unwrapped* message — the
+ * parser did the format-specific extraction — and only classifies it, mirroring
+ * the recovery order in `subprocess-adapter.handleUnparseableOutput`:
+ * rate-limit → auth → generic execution error. `cliName` may be prefixed
+ * (`cli-opencode`) — resolved internally for the remediation hint.
+ */
+export function classifyExtractedError(message: string, cliName: string): ParsedCliError {
+  const trimmed = message.trim();
+  if (isRateLimitText(trimmed)) {
+    return { message: trimmed, code: 'RATE_LIMITED' };
+  }
+  const { code, auth } = classifyMessage(trimmed);
+  if (auth) {
+    const hint = authRemediation(trimmed, cliName);
+    return hint !== null ? { message: trimmed, code, hint } : { message: trimmed, code };
+  }
+  return { message: trimmed, code };
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/parsers/opencode-parser.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/opencode-parser.test.ts
@@ -588,6 +588,28 @@ describe('OpenCodeResponseParser', () => {
       expect(result?.sessionId).toBe('ses_123');
     });
 
+    it('extractErrorMessage surfaces an error-only 401 so it can be classified (#3485)', () => {
+      // The reproduction: an upstream 401 produces an error-only NDJSON stream.
+      // extractResponse returns null (no content), but extractErrorMessage now
+      // exposes the message so the adapter classifies NOT_AUTHENTICATED instead
+      // of PARSE_ERROR.
+      const raw = createNdjson({
+        type: 'error',
+        sessionID: 'ses_x',
+        error: {
+          name: 'APIError',
+          data: { message: 'Unauthorized: {"detail":"Not authenticated"}', statusCode: 401 },
+        },
+      });
+      expect(parser.extractResponse(raw)).toBeNull();
+      expect(parser.extractErrorMessage(raw)).toContain('Unauthorized');
+    });
+
+    it('extractErrorMessage returns null for a normal text stream', () => {
+      const raw = createNdjson({ type: 'text', text: 'hello' });
+      expect(parser.extractErrorMessage(raw)).toBeNull();
+    });
+
     it('should expose error name in errorMessage when only name is set (#2821)', () => {
       const raw = createNdjson({
         type: 'error',

--- a/packages/nexus-agents/src/cli-adapters/parsers/opencode-parser.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/opencode-parser.ts
@@ -203,6 +203,18 @@ export class OpenCodeResponseParser implements ICliResponseParser<OpenCodeCliRes
   }
 
   /**
+   * Surfaces the error message from an error-only NDJSON stream (a
+   * `{"type":"error",...}` event with no text content). The subprocess adapter
+   * consumes this when {@link extractResponse} returns `null`, so an upstream
+   * 401 / rate-limit is classified by its message (NOT_AUTHENTICATED /
+   * RATE_LIMITED with a remediation hint) instead of falling through to a
+   * generic PARSE_ERROR.
+   */
+  extractErrorMessage(raw: string): string | null {
+    return this.parse(raw)?.errorMessage ?? null;
+  }
+
+  /**
    * Extracts token usage from response.
    */
   extractUsage(raw: string): TokenUsage | null {

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -714,6 +714,51 @@ describe('SubprocessCliAdapter', () => {
       }
     });
 
+    it('classifies an error-only stream by its message instead of PARSE_ERROR (#3485)', async () => {
+      // Repro: an upstream 401 yields an error-only stream — extractResponse
+      // returns null but extractErrorMessage exposes the auth message. The
+      // adapter must classify NOT_AUTHENTICATED (with a login hint), not mask
+      // it as PARSE_ERROR.
+      class ErrorOnlyParserAdapter extends TestSubprocessAdapter {
+        protected override readonly parser: ICliResponseParser = {
+          name: 'error-only-parser',
+          supportedVersionRange: '>=1.0.0',
+          parse: () => null,
+          extractResponse: () => null,
+          extractErrorMessage: () => 'Unauthorized: {"detail":"Not authenticated"}',
+          extractUsage: () => null,
+          extractSessionId: () => null,
+        };
+      }
+
+      const adapter2 = new ErrorOnlyParserAdapter();
+      adapter2.setCommandConfig({ command: 'echo', args: ['test'] });
+      const task: CliTask = { content: 'test' };
+      const options: ResolvedExecutionOptions = {
+        timeoutMs: 5000,
+        allowRetry: false,
+        maxRetries: 0,
+        trackUsage: true,
+        onProgress: undefined,
+      };
+
+      const { mockChild, stdout } = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+      const promise = adapter2.executeTask(task, options);
+      setImmediate(() => {
+        stdout.emit('data', Buffer.from('{"type":"error"}\n'));
+        mockChild.emit('close', 0);
+      });
+      const result = await promise;
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('NOT_AUTHENTICATED');
+        expect(result.error.message).toContain('Not authenticated');
+        expect(result.error.message).not.toContain('Failed to parse response');
+      }
+    });
+
     it('should include stderr hint in PARSE_ERROR when stderr present (#1402)', async () => {
       class FailingParserAdapter extends TestSubprocessAdapter {
         protected override readonly parser: ICliResponseParser = {

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -27,7 +27,7 @@ import { BaseCliAdapter } from './base-adapter.js';
 import { buildChildEnv } from './subprocess-env.js';
 import { sanitizeOutput } from '../security/output-sanitizer.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
-import { parseCliErrorEnvelope } from './cli-error-envelope.js';
+import { parseCliErrorEnvelope, classifyExtractedError } from './cli-error-envelope.js';
 import { generateHyphenId } from '../utils/id-utils.js';
 
 /** Minimum length for plaintext fallback to kick in.
@@ -642,6 +642,11 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
 
     const text = this.parser.extractResponse(stdout);
     if (text === null) {
+      // Error-only stream (e.g. OpenCode NDJSON `{"type":"error"}`): the parser
+      // surfaced an `errorMessage` but no usable content. Classify it before
+      // the generic PARSE_ERROR path, which would mask the real cause.
+      const errorOnly = this.classifyErrorOnlyStream(stdout);
+      if (errorOnly !== null) return errorOnly;
       return this.handleUnparseableOutput(stdout, stderr, startTime);
     }
 
@@ -655,6 +660,26 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
         ...(sessionId !== null && { sessionId }),
       })
     );
+  }
+
+  /**
+   * Classify an error-only stream — one where the parser surfaced an
+   * `errorMessage` but no usable content (so `extractResponse` returned null).
+   * Returns a typed error (NOT_AUTHENTICATED / RATE_LIMITED with a remediation
+   * hint, or EXECUTION_ERROR) so an upstream 401 / 429 isn't masked as
+   * PARSE_ERROR. Returns `null` when the parser exposes no error message (no
+   * `extractErrorMessage`, or empty) — the caller then falls back to the
+   * generic unparseable-output recovery.
+   */
+  private classifyErrorOnlyStream(stdout: string): Result<CliResponse, CliError> | null {
+    const errorMessage = this.parser.extractErrorMessage?.(stdout) ?? null;
+    if (errorMessage === null || errorMessage === '') return null;
+    const classified = classifyExtractedError(errorMessage, this.name);
+    const msg =
+      classified.hint !== undefined
+        ? `${classified.message}\n  → ${classified.hint}`
+        : classified.message;
+    return err(this.createError(classified.code, msg));
   }
 
   /**

--- a/packages/nexus-agents/src/cli-adapters/types-capability.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-capability.ts
@@ -235,6 +235,20 @@ export interface ICliResponseParser<T = unknown> {
   extractResponse(raw: string): string | null;
 
   /**
+   * Extracts an error-only message from a failure stream — when the CLI
+   * surfaced an error event but no usable assistant content (so
+   * {@link extractResponse} returns `null`). Optional: parsers that don't
+   * distinguish error-only streams omit it, and the caller falls back to the
+   * generic unparseable-output recovery. OpenCode's NDJSON `{"type":"error"}`
+   * events are the motivating case — without this the message is misclassified
+   * as PARSE_ERROR instead of NOT_AUTHENTICATED / RATE_LIMITED.
+   *
+   * @param raw - Raw CLI output
+   * @returns The extracted error message, or `null` if none / not applicable
+   */
+  extractErrorMessage?(raw: string): string | null;
+
+  /**
    * Extracts token usage (may not be present).
    *
    * @param raw - Raw CLI output


### PR DESCRIPTION
## Context
Closes #3485. An error-only OpenCode NDJSON stream (e.g. an upstream **401** → `{"type":"error","error":{"name":"APIError","data":{"message":"Unauthorized: …","statusCode":401}}}` with no assistant content) was misclassified as `PARSE_ERROR`. `OpenCodeResponseParser` already captured the message into `errorMessage` (#2821), but `extractResponse` returns null when content is empty, so `handleSubprocessOutput` discarded it and fell through to the generic parse-error path — masking the real cause and dropping the remediation hint.

## Fix
Consume the parser's already-extracted error message before the generic fallback:
- **`ICliResponseParser.extractErrorMessage(raw)`** — new **optional** method. OpenCode implements it (via its existing `parse().errorMessage`); other parsers omit it and behave exactly as before. The same masking can affect any adapter with error-only streams, so the seam is general.
- **`classifyExtractedError(message, cli)`** — new shared helper in `cli-error-envelope.ts`. Classifies the *already-unwrapped* message (rate-limit → auth → generic, mirroring `handleUnparseableOutput`'s recovery order) and reuses the existing `NOT_AUTH_PATTERNS` + `authRemediation` (no duplication).
- **`handleSubprocessOutput`** classifies the error-only stream when `extractResponse` returns null (extracted into `classifyErrorOnlyStream` to stay under the complexity cap).

Result: an upstream 401 now surfaces as
```
NOT_AUTHENTICATED: Unauthorized: {"detail":"Not authenticated"}
  → Re-authenticate: run `opencode auth login` (the opencode CLI's stored OAuth token is stale).
```
instead of `PARSE_ERROR: Failed to parse response: {…}`.

## Testing
- `cli-error-envelope.test.ts`: `classifyExtractedError` — 401→NOT_AUTHENTICATED+hint, 429→RATE_LIMITED, generic→EXECUTION_ERROR, unknown-CLI→no hint, trim.
- `opencode-parser.test.ts`: `extractErrorMessage` surfaces the 401 (while `extractResponse` stays null); returns null for normal streams.
- `subprocess-adapter.test.ts`: end-to-end — an error-only stream yields `NOT_AUTHENTICATED`, not `PARSE_ERROR`.
- Full `src/cli-adapters/` suite: **2428 passed**. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)