### PR TITLE
fix(pipeline): fall back to a runnable template instead of failing on unimplemented stages (#3487)

### DIFF
--- a/.changeset/runnable-template-fallback-3487.md
+++ b/.changeset/runnable-template-fallback-3487.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+fix(pipeline): fall back to a runnable template instead of failing on unimplemented stages (#3487)
+
+A research-shaped task auto-classified to the `research` pipeline template, whose
+`investigate`/`synthesize` stages have no implementation in any registry, so
+`run_pipeline` hard-failed with "Missing stage implementations". The orchestrator
+now validates the resolved template against the stage registry and substitutes a
+satisfiable built-in template (general → dev) when stages are missing, so the
+research/plan/vote workflow runs end-to-end instead of erroring. The fallback
+compile error is also now actionable — naming the template, the missing stages,
+and the available stages — so an unimplemented-stage failure is distinguishable
+from an auth or transport error.

--- a/packages/nexus-agents/src/pipeline/adaptive-orchestrator.test.ts
+++ b/packages/nexus-agents/src/pipeline/adaptive-orchestrator.test.ts
@@ -172,4 +172,20 @@ describe('runAdaptiveOrchestrator', () => {
     expect(result.templateId).toBe('dev');
     expect(result.success).toBe(true);
   });
+
+  it('falls back to a runnable template when the chosen one needs unimplemented stages (#3487)', async () => {
+    // The `research` template references investigate/synthesize, which the dev
+    // registry does not implement. Instead of hard-failing with "Missing stage
+    // implementations", the orchestrator substitutes a satisfiable template.
+    const stages = createDevStageRegistry(createMockStages());
+
+    const result = await runAdaptiveOrchestrator('Survey the landscape', {
+      stages,
+      templateId: 'research',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.templateId).not.toBe('research');
+    expect(['general', 'dev']).toContain(result.templateId);
+  });
 });

--- a/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
+++ b/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
@@ -18,6 +18,7 @@ import type { GraphPipelineOptions, GraphPipelineResult } from './graph-pipeline
 import { getTemplate, PIPELINE_TEMPLATES } from './templates.js';
 import type { PipelineTemplate } from './stage-types.js';
 import type { StageRegistry } from './pipeline-graph.js';
+import { findMissingStages } from './pipeline-graph.js';
 
 const logger = createLogger({ component: 'adaptive-orchestrator' });
 
@@ -345,7 +346,11 @@ export async function runAdaptiveOrchestrator(
   // Template selection: explicit override or auto-detected
   const templateId = options.templateId ?? classification.pipelineType;
   const selectionMethod = options.templateId !== undefined ? 'explicit' : 'auto-detected';
-  const template = resolveTemplate(templateId);
+  // The auto-classified template may reference stages the selected registry
+  // doesn't implement (e.g. the `research` template's investigate/synthesize
+  // are unimplemented). Fall back to a runnable template so the task executes
+  // instead of hard-failing with "Missing stage implementations" (#3487).
+  const template = ensureRunnableTemplate(resolveTemplate(templateId), options.stages);
 
   logger.info('Adaptive orchestrator routing', {
     templateId: template.id,
@@ -381,4 +386,44 @@ function resolveTemplate(templateId: string): PipelineTemplate {
 
   // Absolute fallback — should never happen
   return { id: 'dev', name: 'Development', stages: [] };
+}
+
+/** Preference order for the runnability fallback — most general first (#3487). */
+const RUNNABLE_FALLBACK_TEMPLATES = ['general', 'dev'] as const;
+
+/**
+ * Guarantee the chosen template can actually run against the provided stage
+ * registry. If it references unimplemented stages (e.g. the `research`
+ * template's investigate/synthesize), substitute the first built-in template
+ * the registry fully satisfies (general → dev). Returns the original template
+ * when it's already runnable, or when nothing satisfiable exists (the compile
+ * step then surfaces the actionable "Missing stage implementations" error).
+ */
+function ensureRunnableTemplate(
+  template: PipelineTemplate,
+  stages: StageRegistry
+): PipelineTemplate {
+  const missing = findMissingStages(template, stages);
+  if (missing.length === 0) return template;
+
+  for (const id of RUNNABLE_FALLBACK_TEMPLATES) {
+    const candidate = PIPELINE_TEMPLATES.get(id);
+    if (candidate !== undefined && findMissingStages(candidate, stages).length === 0) {
+      logger.warn('Selected template is not runnable in this registry — falling back', {
+        requested: template.id,
+        missingStages: missing,
+        fallback: id,
+      });
+      return candidate;
+    }
+  }
+
+  logger.warn(
+    'No runnable fallback template for this registry; compile will report missing stages',
+    {
+      requested: template.id,
+      missingStages: missing,
+    }
+  );
+  return template;
 }

--- a/packages/nexus-agents/src/pipeline/pipeline-graph.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-graph.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { compilePipelineGraph } from './pipeline-graph.js';
+import { compilePipelineGraph, findMissingStages } from './pipeline-graph.js';
 import type { IPipelineStage, PipelineTemplate, StageOutput } from './stage-types.js';
 import { PIPELINE_STATE_KEYS } from './stage-types.js';
 import {
@@ -131,17 +131,34 @@ describe('compilePipelineGraph', () => {
     expect(result.graph).toBeDefined();
   });
 
-  it('reports missing stage implementations', () => {
+  it('findMissingStages lists template stages absent from the registry (#3487)', () => {
+    // The real failure: the `research` template needs investigate/synthesize,
+    // which the dev registry (research/plan/vote/decompose/implement/qa/security)
+    // doesn't implement.
+    const devRegistry = makeStageRegistry(DEV_PIPELINE_TEMPLATE.stages);
+    const missing = findMissingStages(RESEARCH_PIPELINE_TEMPLATE, devRegistry);
+    expect(missing).toContain('investigate');
+    expect(missing).toContain('synthesize');
+    // And it's empty when the registry satisfies the template.
+    expect(findMissingStages(DEV_PIPELINE_TEMPLATE, devRegistry)).toHaveLength(0);
+  });
+
+  it('reports missing stage implementations with an actionable message (#3487)', () => {
     const template: PipelineTemplate = {
-      id: 'test',
-      name: 'Test',
+      id: 'sample',
+      name: 'Sample',
       stages: ['step1', 'missing_step'],
     };
     const stages = makeStageRegistry(['step1']);
     const result = compilePipelineGraph(template, stages);
 
     expect(result.ok).toBe(false);
+    // Names the template, the missing stage, and the available stages so the
+    // failure reads as "unimplemented stage" not an auth/transport error.
+    expect(result.error).toContain("template 'sample'");
     expect(result.error).toContain('missing_step');
+    expect(result.error).toContain('Available stages: step1');
+    expect(result.error).toContain('Pick a different');
   });
 
   it('compiles the dev pipeline template', () => {

--- a/packages/nexus-agents/src/pipeline/pipeline-graph.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-graph.ts
@@ -47,7 +47,15 @@ export function compilePipelineGraph(
 ): PipelineGraphResult {
   const missing = findMissingStages(template, stages);
   if (missing.length > 0) {
-    return { ok: false, error: `Missing stage implementations: ${missing.join(', ')}` };
+    const available = [...stages.keys()].sort().join(', ');
+    return {
+      ok: false,
+      error:
+        `Pipeline template '${template.id}' references stage(s) with no implementation ` +
+        `in the selected registry: ${missing.join(', ')}. ` +
+        `Available stages: ${available || '(none)'}. ` +
+        `Pick a different \`template\` whose stages are all implemented, or implement the missing stage(s).`,
+    };
   }
 
   const builder = new GraphBuilder();
@@ -73,8 +81,15 @@ export function compilePipelineGraph(
 // Helpers
 // ============================================================================
 
-/** Check for stages in template that have no implementation. */
-function findMissingStages(template: PipelineTemplate, stages: StageRegistry): string[] {
+/**
+ * Stage IDs a template references that the registry doesn't implement. Empty
+ * when the registry can run the whole template. Exported so the orchestrator
+ * can pre-check runnability and fall back to a satisfiable template (#3487).
+ */
+export function findMissingStages(
+  template: PipelineTemplate,
+  stages: StageRegistry
+): readonly string[] {
   return template.stages.filter((id) => !stages.has(id));
 }
 


### PR DESCRIPTION
## Context
Addresses **failure 2** of #3487 (`run_pipeline` → "Missing stage implementations: investigate, synthesize, scaffold"). Root cause: a research-shaped task auto-classifies to the `research` template, whose `investigate`/`synthesize` stages **no registry implements**, and `selectStageRegistry` has no `research` branch (falls back to `dev`). So the research/plan/vote workflow was unusable.

## Change
`runAdaptiveOrchestrator` now validates the resolved template against the stage registry (`findMissingStages`, newly exported) and, when it references unimplemented stages, substitutes the first built-in template the registry fully satisfies (**general → dev**). A research task now runs the general pipeline (research → plan → vote → implement → qa → security) instead of hard-failing — restoring a working research/planning path (#3487 acceptance criterion 2).

When nothing is satisfiable, the compile error is now **actionable** — it names the template, the missing stages, and the available stages, so the failure reads as "unimplemented stage", distinct from an auth or transport error (#3487 acceptance criterion 3).

## Scope
This restores a working path and clarifies the error. The `research` template is still structurally non-functional (its stages are unimplemented and its order is incoherent) — implementing real `investigate`/`synthesize` stages or formally retiring the template is tracked in **#3488**.

The other #3487 modes: failure 3 (401) is fixed by #3485/#3486; failure 1 (consensus_vote MCP timeout) is being handled separately.

## Testing
- `pipeline-graph.test.ts`: `findMissingStages` (research vs dev registry → investigate/synthesize missing); actionable compile error (names template + available + "Pick a different").
- `adaptive-orchestrator.test.ts`: an explicit `research` template against the dev registry now succeeds on a fallback template (`general`/`dev`), not a missing-stage error.
- Full `src/pipeline/` suite: **573 passed**. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)