### PR TITLE
feat(graph): in-graph consensus gate node + runGraphWithConsensus (#3267)

### DIFF
--- a/.changeset/consensus-gate-node-3267.md
+++ b/.changeset/consensus-gate-node-3267.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(graph): in-graph consensus gate node + `runGraphWithConsensus` (#3267)
+
+Adds a reusable in-graph consensus primitive (consensus vote, Option A): an
+injected `ConsensusVoter` runs at a `createConsensusGateNode`, writes a typed
+`ConsensusVerdict` to graph state, and **fails closed** (any voter or
+proposal-extraction error → `rejected`, never a silent pass-through). Branch on
+the verdict with `addConditionalEdge`, or use the `runGraphWithConsensus`
+one-shot convenience. The dev-pipeline `vote` stage is refactored to delegate to
+the same `runConsensusGate` core, so there is a single in-graph-consensus
+implementation. All exported from the package root; documented in
+`COMPOSITION_PATTERNS.md`.

--- a/docs/guides/COMPOSITION_PATTERNS.md
+++ b/docs/guides/COMPOSITION_PATTERNS.md
@@ -177,12 +177,55 @@ if (outcome.ok) {
 }
 ```
 
-To gate a graph node behind consensus, run the engine inside a node handler and
-branch on the result with `addConditionalEdge`. A higher-level
-`runGraphWithConsensus()` helper that auto-inserts consensus gate nodes is
-tracked in [#3267](https://github.com/nexus-substrate/nexus-agents/issues/3267)
-(it needs a design decision — in-graph gate nodes vs. a post-execution vote —
-plus voter/adapter wiring, so it is intentionally not yet a single call).
+### In-graph consensus gates (#3267)
+
+To gate a graph at an arbitrary point, use the **`createConsensusGateNode`**
+primitive: it runs an injected `ConsensusVoter` on a proposal, writes a typed
+`ConsensusVerdict` (`approved` / `rejected` + feedback) to graph state, and
+**fails closed** (any voter error → `rejected`, never a silent pass-through).
+Branch on the verdict with `addConditionalEdge`:
+
+```ts
+import { GraphBuilder, createConsensusGateNode, runGraphWithConsensus } from 'nexus-agents';
+import type { ConsensusVoter } from 'nexus-agents';
+
+// A voter wraps any decision source — a consensus panel, a single model, or the
+// dev-pipeline's vote stage. It receives only the proposal/context (no secrets).
+const voter: ConsensusVoter = async ({ proposal }) => {
+  const approved = await myPanel.review(proposal);
+  return { outcome: approved ? 'approved' : 'rejected', feedback: approved ? '' : 'needs work' };
+};
+
+// One-shot convenience: run a work node, then gate its output.
+const result = await runGraphWithConsensus({
+  produce: () => Promise.resolve({ proposal: 'the plan to review' }),
+  voter,
+});
+if (result.ok) console.log(result.value.verdict?.outcome); // 'approved' | 'rejected'
+
+// Or insert the gate into a larger graph and branch on the verdict:
+new GraphBuilder()
+  .addState('plan', overwrite(''))
+  .addState('verdict', overwrite(null))
+  .addNode('plan', planHandler)
+  .addNode(
+    'gate',
+    createConsensusGateNode({
+      voter,
+      verdictKey: 'verdict',
+      proposalFrom: (s) => ({ proposal: String(s['plan']) }),
+    })
+  )
+  .addEdge('plan', 'gate')
+  .addConditionalEdge(
+    'gate',
+    (s) => ((s['verdict'] as { outcome: string }).outcome === 'approved' ? 'implement' : END),
+    ['implement', END]
+  );
+```
+
+The dev-pipeline's `vote` stage is built on this same primitive — there is one
+in-graph-consensus implementation, not two.
 
 ---
 

--- a/packages/nexus-agents/src/exports/orchestration.ts
+++ b/packages/nexus-agents/src/exports/orchestration.ts
@@ -35,6 +35,16 @@ export {
   START,
   END,
   formatCompileError,
+  runConsensusGate,
+  createConsensusGateNode,
+  runGraphWithConsensus,
+} from '../orchestration/index.js';
+export type {
+  ConsensusVoter,
+  ConsensusVerdict,
+  ConsensusProposalInput,
+  ConsensusGateNodeOptions,
+  RunGraphWithConsensusOptions,
 } from '../orchestration/index.js';
 export type {
   StateReducer,

--- a/packages/nexus-agents/src/orchestration/graph/consensus-node.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/consensus-node.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the in-graph consensus gate primitive (#3267).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runConsensusGate,
+  createConsensusGateNode,
+  runGraphWithConsensus,
+  type ConsensusVoter,
+} from './consensus-node.js';
+
+const approveVoter: ConsensusVoter = () =>
+  Promise.resolve({ outcome: 'approved', feedback: '', detail: { approvalPercentage: 83 } });
+const rejectVoter: ConsensusVoter = () =>
+  Promise.resolve({ outcome: 'rejected', feedback: 'missing error handling' });
+
+describe('runConsensusGate', () => {
+  it('returns the voter verdict on success', async () => {
+    const v = await runConsensusGate(approveVoter, { proposal: 'plan' });
+    expect(v.outcome).toBe('approved');
+  });
+
+  it('fails CLOSED to a rejected verdict when the voter throws', async () => {
+    const throwing: ConsensusVoter = () => Promise.reject(new Error('adapter offline'));
+    const v = await runConsensusGate(throwing, { proposal: 'plan' });
+    expect(v.outcome).toBe('rejected');
+    expect(v.feedback).toContain('adapter offline');
+    expect(v.detail?.['error']).toBe('adapter offline');
+  });
+
+  it('passes only the proposal/context to the voter (no ambient state)', async () => {
+    const spy = vi.fn(approveVoter);
+    await runConsensusGate(spy, { proposal: 'p', context: 'c' });
+    expect(spy).toHaveBeenCalledWith({ proposal: 'p', context: 'c' });
+  });
+});
+
+describe('createConsensusGateNode', () => {
+  it('writes the typed verdict to the verdict key', async () => {
+    const node = createConsensusGateNode({
+      voter: rejectVoter,
+      verdictKey: 'verdict',
+      proposalFrom: (state) => ({
+        proposal: typeof state['plan'] === 'string' ? state['plan'] : '',
+      }),
+    });
+    const out = await node({ plan: 'do X' });
+    expect(out).toEqual({ verdict: { outcome: 'rejected', feedback: 'missing error handling' } });
+  });
+
+  it('fails closed when proposalFrom throws (does not crash the node)', async () => {
+    const node = createConsensusGateNode({
+      voter: approveVoter,
+      verdictKey: 'verdict',
+      proposalFrom: () => {
+        throw new Error('bad state');
+      },
+    });
+    const out = (await node({})) as { verdict: { outcome: string; feedback: string } };
+    expect(out.verdict.outcome).toBe('rejected');
+    expect(out.verdict.feedback).toContain('bad state');
+  });
+});
+
+describe('runGraphWithConsensus', () => {
+  it('runs produce → gate and returns the approved verdict', async () => {
+    const produce = (): Promise<{ proposal: string }> =>
+      Promise.resolve({ proposal: 'a sound plan' });
+    const result = await runGraphWithConsensus({ produce, voter: approveVoter });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.verdict?.outcome).toBe('approved');
+      expect(result.value.execution.finalState['consensusVerdict']).toBeDefined();
+    }
+  });
+
+  it('surfaces a rejected verdict from the gate', async () => {
+    const produce = (): Promise<{ proposal: string }> =>
+      Promise.resolve({ proposal: 'a weak plan' });
+    const result = await runGraphWithConsensus({ produce, voter: rejectVoter });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.verdict?.outcome).toBe('rejected');
+  });
+
+  it('fails the gate closed when the voter throws — verdict is rejected, not a crash', async () => {
+    const produce = (): Promise<{ proposal: string }> => Promise.resolve({ proposal: 'x' });
+    const throwing: ConsensusVoter = () => Promise.reject(new Error('boom'));
+    const result = await runGraphWithConsensus({ produce, voter: throwing });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.verdict?.outcome).toBe('rejected');
+      expect(result.value.verdict?.feedback).toContain('boom');
+    }
+  });
+});

--- a/packages/nexus-agents/src/orchestration/graph/consensus-node.ts
+++ b/packages/nexus-agents/src/orchestration/graph/consensus-node.ts
@@ -1,0 +1,167 @@
+/**
+ * Consensus gate node (#3267) — an in-graph consensus checkpoint.
+ *
+ * Generalizes the proven dev-pipeline `vote` stage pattern
+ * (`createVoteStageWrapper`) into a reusable, layer-agnostic primitive: run an
+ * injected voter on a proposal, produce a typed verdict, and let the caller
+ * branch on it (approve → continue, reject → halt/revise) via the graph's
+ * conditional edges. The voter is injected (callback), so the node is decoupled
+ * from any specific voter panel — a 7/3-role consensus panel, a single model, or
+ * the dev-pipeline's `stages.vote` can all satisfy {@link ConsensusVoter}.
+ *
+ * Both the graph adapter ({@link createConsensusGateNode}) and the pipeline
+ * `vote` stage delegate to {@link runConsensusGate}, so there is ONE
+ * consensus-gate implementation (anti-sprawl — #3267 vote condition), not two.
+ *
+ * @module orchestration/graph/consensus-node
+ * (Source: #3267)
+ */
+
+import type { GraphState, NodeHandler, GraphExecutionResult } from './graph-types.js';
+import { START, END, formatCompileError } from './graph-types.js';
+import { GraphBuilder, overwrite } from './graph-builder.js';
+import { executeGraph } from './graph-executor.js';
+import { ok, err, type Result } from '../../core/index.js';
+
+/** What a consensus voter is asked to evaluate. */
+export interface ConsensusProposalInput {
+  /** The proposal text under review (e.g. a plan). */
+  readonly proposal: string;
+  /** Optional supporting context (e.g. research) the voter may weigh. */
+  readonly context?: string;
+}
+
+/** The typed verdict a consensus round produces. */
+export interface ConsensusVerdict {
+  /** Whether the proposal cleared the consensus bar. */
+  readonly outcome: 'approved' | 'rejected';
+  /** Reviewer feedback (empty on a clean approval). */
+  readonly feedback: string;
+  /** Optional structured detail (approval %, the raw vote, …) for consumers. */
+  readonly detail?: Record<string, unknown>;
+}
+
+/** Injected voter: run a consensus round and return a verdict. */
+export type ConsensusVoter = (input: ConsensusProposalInput) => Promise<ConsensusVerdict>;
+
+/**
+ * Run the consensus gate (the single shared implementation). On any voter
+ * error/timeout this **fails CLOSED** to a `rejected` verdict — a gate must
+ * never let unreviewed work through on an error. The voter receives only the
+ * proposal/context (no secrets, no ambient state).
+ */
+export async function runConsensusGate(
+  voter: ConsensusVoter,
+  input: ConsensusProposalInput
+): Promise<ConsensusVerdict> {
+  try {
+    return await voter(input);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      outcome: 'rejected',
+      feedback: `Consensus gate failed closed (voter error): ${message}`,
+      detail: { error: message },
+    };
+  }
+}
+
+/** Options for {@link createConsensusGateNode}. */
+export interface ConsensusGateNodeOptions {
+  /** The voter to run at this gate. */
+  readonly voter: ConsensusVoter;
+  /** Graph-state key the typed verdict is written under. */
+  readonly verdictKey: string;
+  /** Derive the proposal/context from graph state (no secrets/ambient state). */
+  readonly proposalFrom: (state: Readonly<GraphState>) => ConsensusProposalInput;
+}
+
+/**
+ * Build a {@link NodeHandler} that runs a consensus gate and writes the typed
+ * verdict to `verdictKey` in graph state. Pair it with `addConditionalEdge` on
+ * `state[verdictKey].outcome` to route approve → continue, reject → halt/revise.
+ */
+export function createConsensusGateNode(options: ConsensusGateNodeOptions): NodeHandler {
+  return async (state) => {
+    let input: ConsensusProposalInput;
+    try {
+      input = options.proposalFrom(state);
+    } catch (error: unknown) {
+      // A throwing proposal extractor must also fail CLOSED — never crash the
+      // node (which would propagate as an un-gated graph failure).
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        [options.verdictKey]: {
+          outcome: 'rejected',
+          feedback: `Consensus gate failed closed (proposal extraction error): ${message}`,
+          detail: { error: message },
+        } satisfies ConsensusVerdict,
+      };
+    }
+    const verdict = await runConsensusGate(options.voter, input);
+    return { [options.verdictKey]: verdict };
+  };
+}
+
+/** Options for {@link runGraphWithConsensus}. */
+export interface RunGraphWithConsensusOptions {
+  /**
+   * Work node that produces the proposal — it must write the proposal text to
+   * `proposalKey` (default `'proposal'`) in its returned state patch.
+   */
+  readonly produce: NodeHandler;
+  /** The voter run at the gate. */
+  readonly voter: ConsensusVoter;
+  /** State key the produce node writes the proposal to. Default `'proposal'`. */
+  readonly proposalKey?: string;
+  /** State key the verdict is written to. Default `'consensusVerdict'`. */
+  readonly verdictKey?: string;
+  /** Initial graph state. */
+  readonly initialState?: GraphState;
+}
+
+/**
+ * Convenience composition (#3267): run a single work node, then a consensus
+ * gate over its output — `START → produce → consensus → END` — and return the
+ * execution result plus the typed verdict. The `proposalKey`/`verdictKey` state
+ * channels are declared automatically. For richer control flow (branch on the
+ * verdict, loop on reject, multiple gates) use {@link createConsensusGateNode}
+ * with {@link GraphBuilder} + `addConditionalEdge` directly.
+ */
+export async function runGraphWithConsensus(
+  options: RunGraphWithConsensusOptions
+): Promise<
+  Result<{ execution: GraphExecutionResult; verdict: ConsensusVerdict | undefined }, Error>
+> {
+  const proposalKey = options.proposalKey ?? 'proposal';
+  const verdictKey = options.verdictKey ?? 'consensusVerdict';
+  const gate = createConsensusGateNode({
+    voter: options.voter,
+    verdictKey,
+    proposalFrom: (state) => {
+      const raw = state[proposalKey];
+      return { proposal: typeof raw === 'string' ? raw : '' };
+    },
+  });
+  const compiled = new GraphBuilder()
+    .addState(proposalKey, overwrite(''))
+    .addState(verdictKey, overwrite<ConsensusVerdict | null>(null))
+    .addNode('produce', options.produce)
+    .addNode('consensus', gate)
+    .addEdge(START, 'produce')
+    .addEdge('produce', 'consensus')
+    .addEdge('consensus', END)
+    .compile();
+  if (!compiled.ok) {
+    return err(
+      new Error(
+        `runGraphWithConsensus: graph compile failed: ${formatCompileError(compiled.error)}`
+      )
+    );
+  }
+  const execResult = await executeGraph(compiled.value, options.initialState ?? {});
+  if (!execResult.ok) return err(execResult.error);
+  const raw = execResult.value.finalState[verdictKey];
+  const verdict = (raw ?? undefined) as ConsensusVerdict | undefined;
+  return ok({ execution: execResult.value, verdict });
+}

--- a/packages/nexus-agents/src/orchestration/graph/index.ts
+++ b/packages/nexus-agents/src/orchestration/graph/index.ts
@@ -79,3 +79,17 @@ export {
   createCheckpoint,
   createCheckpointStore,
 } from './checkpoint-store.js';
+
+// Consensus gate node — in-graph consensus checkpoints (#3267)
+export {
+  runConsensusGate,
+  createConsensusGateNode,
+  runGraphWithConsensus,
+} from './consensus-node.js';
+export type {
+  ConsensusVoter,
+  ConsensusVerdict,
+  ConsensusProposalInput,
+  ConsensusGateNodeOptions,
+  RunGraphWithConsensusOptions,
+} from './consensus-node.js';

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -40,6 +40,16 @@ export {
   START,
   END,
   formatCompileError,
+  runConsensusGate,
+  createConsensusGateNode,
+  runGraphWithConsensus,
+} from './graph/index.js';
+export type {
+  ConsensusVoter,
+  ConsensusVerdict,
+  ConsensusProposalInput,
+  ConsensusGateNodeOptions,
+  RunGraphWithConsensusOptions,
 } from './graph/index.js';
 export type {
   StateReducer,

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.test.ts
@@ -186,6 +186,19 @@ describe('Stage Wrappers', () => {
       expect(val.vote.kind).toBe('rejected');
       expect(val.feedback).toBe('Missing tests');
     });
+
+    it('fails closed (success=false, error in feedback) when stages.vote throws (#3267)', async () => {
+      // Subsumed onto runConsensusGate: a thrown voter fails CLOSED to a
+      // rejected verdict — still success=false so the pipeline iterates, with
+      // the error surfaced in feedback rather than dropped.
+      const stages = createMockStages();
+      vi.mocked(stages.vote).mockRejectedValue(new Error('voter adapter offline'));
+      const result = await createVoteStageWrapper(stages).execute(makeContext());
+
+      expect(result.success).toBe(false);
+      const val = result.value as { vote: VoteResult | undefined; feedback: string };
+      expect(val.feedback).toContain('voter adapter offline');
+    });
   });
 
   describe('createDecomposeStageWrapper', () => {

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -10,11 +10,13 @@
 
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import { parseSpec } from '../orchestration/spec-parser.js';
-import type { DevPipelineStages, PipelineTask } from './dev-pipeline.js';
+import type { DevPipelineStages, PipelineTask, VoteResult } from './dev-pipeline.js';
 import { isApproved, getVoteFeedback } from './dev-pipeline.js';
 import type { IPipelineStage, PipelineContext, StageOutput } from './stage-types.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
 import { getContextPromptPrefix } from '../context/context-retriever.js';
+import { runConsensusGate } from '../orchestration/graph/consensus-node.js';
+import type { ConsensusVoter } from '../orchestration/graph/consensus-node.js';
 
 // ============================================================================
 // Helper
@@ -116,6 +118,17 @@ export function createPlanStageWrapper(stages: DevPipelineStages): IPipelineStag
 
 /** Vote stage — consensus vote on the plan. */
 export function createVoteStageWrapper(stages: DevPipelineStages): IPipelineStage {
+  // Subsumed onto the shared consensus-gate primitive (#3267): the dev-pipeline
+  // `stages.vote` IS the injected voter; `runConsensusGate` runs it fail-closed.
+  // There is now ONE in-graph-consensus implementation, not two.
+  const voter: ConsensusVoter = async (input) => {
+    const vote = await stages.vote(input.proposal, input.context ?? '');
+    return {
+      outcome: isApproved(vote) ? 'approved' : 'rejected',
+      feedback: isApproved(vote) ? '' : getVoteFeedback(vote),
+      detail: { vote },
+    };
+  };
   return {
     id: 'vote',
     name: 'Vote',
@@ -124,19 +137,18 @@ export function createVoteStageWrapper(stages: DevPipelineStages): IPipelineStag
       const plan = typeof ctx.state[K.PLAN] === 'string' ? (ctx.state[K.PLAN] as string) : '';
       const research =
         typeof ctx.state[K.RESEARCH] === 'string' ? (ctx.state[K.RESEARCH] as string) : '';
-      try {
-        const vote = await stages.vote(plan, research);
-        const ms = getTimeProvider().now() - start;
-        const feedback = isApproved(vote) ? '' : getVoteFeedback(vote);
-        return {
-          stateKey: K.VOTE_RESULT,
-          value: { vote, feedback },
-          durationMs: ms,
-          success: isApproved(vote),
-        };
-      } catch (e) {
-        return failOutput(K.VOTE_RESULT, getErrorMessage(e), getTimeProvider().now() - start);
-      }
+      const verdict = await runConsensusGate(voter, { proposal: plan, context: research });
+      // Preserve the existing VOTE_RESULT shape: `{ vote, feedback }`, success
+      // iff approved. On a voter error the gate fails closed to `rejected` with
+      // the error in `feedback` (vote undefined) — still success=false, so the
+      // pipeline's iterate-on-rejection behavior is unchanged.
+      const vote = verdict.detail?.['vote'] as VoteResult | undefined;
+      return {
+        stateKey: K.VOTE_RESULT,
+        value: { vote, feedback: verdict.feedback },
+        durationMs: getTimeProvider().now() - start,
+        success: verdict.outcome === 'approved',
+      };
     },
   };
 }


### PR DESCRIPTION
## Context
Closes #3267 — implements the **consensus-approved plan** (approach 5–0, plan 5–0: *Option A — in-graph consensus gate nodes, subsuming the existing vote stage*), with the two-layer refinement I recorded on the issue.

## Change
- **`orchestration/graph/consensus-node.ts`** (new): `ConsensusVoter` / `ConsensusVerdict` / `ConsensusProposalInput` types; **`runConsensusGate`** (shared core — **fail-closed**: any voter error → `rejected`, never a silent pass); **`createConsensusGateNode`** (NodeHandler that writes a typed verdict, also fail-closed if `proposalFrom` throws); **`runGraphWithConsensus`** (produce → gate convenience). The voter is **injected** and receives only the proposal/context (no secrets/ambient state) — it wraps a 7/3-role panel, a single model, or the dev-pipeline vote.
- **Subsumption (the vote's load-bearing anti-sprawl condition):** `createVoteStageWrapper` now **delegates** to `runConsensusGate` with `stages.vote` as the voter — **one** in-graph-consensus implementation, not two. Behavior-preserving on approve/reject; a thrown voter now fails closed to `rejected` (success=false, error in feedback) — `VOTE_RESULT`'s downstream consumers read `value`/`success`, unaffected (verified: the graph executor only reads `output.value`).
- Exported from the **package root** (graph/index → orchestration/index → exports/orchestration); **`COMPOSITION_PATTERNS.md`** Pattern 3 now documents it (replacing the "tracked in #3267" stub).

## Review (combined QA + security — APPROVE)
Behavior-preserving subsumption confirmed (graph executor ignores `success`/`error`); fail-closed verified (no path yields `approved` on error); voter isolation clean. One [LOW] the reviewer found — `proposalFrom` throwing *outside* the gate's try/catch — is **fixed** (the node now fails closed on extraction errors too, with a test).

## Testing
`consensus-node.test.ts` (8: success/fail-closed-voter/fail-closed-proposalFrom/isolation/gate-node/runGraphWithConsensus×3) + a vote-stage throw-path test. Full `orchestration/graph/` + `pipeline/` + export-contracts → **807 passed**. typecheck + lint + markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)