### PR TITLE
fix(routing): log INFO when the model-availability cache falls back to all CLIs (#3188)

### DIFF
--- a/.changeset/routing-cache-fallback-observability-3188.md
+++ b/.changeset/routing-cache-fallback-observability-3188.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): log INFO when the model-availability cache falls back to all CLIs (#3188)
+
+`CompositeRouter`'s availability gate had two silent fallback-to-all paths (empty
+cache union; fully-filtered-out set) — so an operator relying on
+`AvailableModelsCache` couldn't tell when the gate had degraded to a no-op (only
+the cache-error path logged). Both now log at INFO with the candidate count.
+Behavior-preserving (routing still never wedges); the events are just observable.

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -1038,20 +1038,31 @@ describe('CompositeRouter ZeroRouter integration (Issue #347)', () => {
       expect(r.getAvailableModelsCache()).toBeUndefined();
     });
 
-    it('falls back to all CLIs when the cache reports zero models', async () => {
+    it('falls back to all CLIs (and logs INFO) when the cache reports zero models (#3188)', async () => {
       const cache = makeMockCache([]);
-      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      const log = makeSpyLogger();
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache }, log);
       const result = await r.route({ content: 'hello' });
       expect(result.ok).toBe(true);
+      // The silent fallback is now observable.
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringContaining('returned no models; falling back to all CLIs'),
+        expect.any(Object)
+      );
     });
 
-    it('falls back to all CLIs when the filtered set would be empty', async () => {
+    it('falls back to all CLIs (and logs INFO) when the filtered set would be empty (#3188)', async () => {
       // Cache only knows a CLI we don't have an adapter for.
       const cache = makeMockCache(['unknown-cli:foo']);
-      const r = new CompositeRouter(adapters, { availableModelsCache: cache });
+      const log = makeSpyLogger();
+      const r = new CompositeRouter(adapters, { availableModelsCache: cache }, log);
       const result = await r.route({ content: 'hello' });
       expect(result.ok).toBe(true);
       // Without the empty-filter guard the router would error on selection.
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringContaining('filtered out all CLIs; falling back to all'),
+        expect.any(Object)
+      );
     });
 
     it('does not block routing when the cache throws', async () => {
@@ -1069,6 +1080,16 @@ describe('CompositeRouter ZeroRouter integration (Issue #347)', () => {
  * Tiny mock for AvailableModelsCache covering only the interface the
  * router uses. Each entry is `source:id`.
  */
+/** Minimal spy logger for asserting on log calls. */
+function makeSpyLogger(): import('../core/index.js').ILogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as import('../core/index.js').ILogger;
+}
+
 function makeMockCache(
   entries: string[]
 ): import('../config/available-models-cache.js').AvailableModelsCache {

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -666,7 +666,17 @@ export class CompositeRouter implements ICompositeRouter {
     if (this.availableModelsCache === undefined) return this.cliNames;
     try {
       const all = await this.availableModelsCache.getAll();
-      if (all.length === 0) return this.cliNames;
+      if (all.length === 0) {
+        // The cache is wired but reports zero models — cold start, or all
+        // sources unavailable. Fall back to all CLIs so routing never wedges,
+        // but log at INFO so operators who rely on the cache can see the gate
+        // is currently a no-op (#3188).
+        this.logger.info(
+          'AvailableModelsCache returned no models; falling back to all CLIs (cold start or all sources unavailable)',
+          { candidateCount: this.cliNames.length }
+        );
+        return this.cliNames;
+      }
       const sourcesWithModels = new Set(all.map((m) => m.source));
       // Availability is tracked per CLI source/slot; an api:* arm is gated on
       // its display slot's source (#3422).
@@ -674,7 +684,14 @@ export class CompositeRouter implements ICompositeRouter {
         sourcesWithModels.has(routingArmDisplaySlot(name))
       );
       // Guard against fully empty filter — never let the gate wedge routing.
-      return filtered.length > 0 ? filtered : this.cliNames;
+      if (filtered.length === 0) {
+        this.logger.info(
+          'AvailableModelsCache filtered out all CLIs; falling back to all (possible stale/misconfigured cache)',
+          { cacheSources: [...sourcesWithModels], candidateCount: this.cliNames.length }
+        );
+        return this.cliNames;
+      }
+      return filtered;
     } catch (e: unknown) {
       this.logger.warn('AvailableModelsCache query failed; falling back to all CLIs', {
         error: e instanceof Error ? e.message : String(e),


### PR DESCRIPTION
## Context
Closes #3188 (the observability part). `CompositeRouter.getCandidateCliNames` had **two silent fallback-to-all paths** — an empty cache union (cold start / all sources down) and a fully-filtered-out set (stale/misconfigured cache). Only the cache-*throws* path logged, so an operator relying on `AvailableModelsCache` to gate routing couldn't tell when the gate had silently degraded to a no-op.

## Change
Both fallback paths now log at **INFO** with the candidate count (plus the cache sources for the filtered-out case). **Behavior-preserving** — routing still falls back to all CLIs so it never wedges; the events are just observable now.

The issue's optional **strict-mode** (fail routing when a configured cache returns empty) is deliberately **not** added — it can wedge routing on a transient cache miss; left as the issue's residual.

## Testing
`composite-router.test.ts` → 76 passed; the two existing fallback tests now also assert the INFO log fires (via an injected spy logger). typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)