### PR TITLE
feat(cli): actionable recovery guidance for CLI detection errors (#3213)

### DIFF
--- a/.changeset/detection-error-recovery-3213.md
+++ b/.changeset/detection-error-recovery-3213.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+feat(cli): actionable recovery guidance for CLI detection errors (#3213)
+
+CLI detection failures now carry a class-specific, runnable recovery step (via
+`detectionRecoveryHint` / `DETECTION_ERROR_SOLUTIONS`) with a
+`docs/TROUBLESHOOTING.md` pointer — e.g. permission → `chmod +x "$(command -v
+<cli>)"`, timeout → check PATH for hung mounts / re-run with `--verbose`,
+not-found → install + PATH guidance. `nexus-agents setup` prints the hint beneath
+each unavailable CLI's status line instead of just a terse cause phrase.

--- a/packages/nexus-agents/src/cli/cli-detection-error.test.ts
+++ b/packages/nexus-agents/src/cli/cli-detection-error.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyExecError,
   DETECTION_ERROR_MESSAGES,
+  DETECTION_ERROR_SOLUTIONS,
+  detectionRecoveryHint,
   type DetectionError,
 } from './cli-detection-error.js';
 
@@ -67,5 +69,33 @@ describe('classifyExecError (#2152)', () => {
       expect(DETECTION_ERROR_MESSAGES[err]).toBeDefined();
       expect(DETECTION_ERROR_MESSAGES[err].length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('detectionRecoveryHint (#3213)', () => {
+  const all: DetectionError[] = ['not-found', 'timeout', 'permission', 'other'];
+
+  it('has an actionable solution for every detection-error class', () => {
+    for (const err of all) {
+      expect(typeof DETECTION_ERROR_SOLUTIONS[err]).toBe('function');
+      expect(DETECTION_ERROR_SOLUTIONS[err]('opencode').length).toBeGreaterThan(10);
+    }
+  });
+
+  it('embeds the binary name in a runnable command for the permission case', () => {
+    const hint = detectionRecoveryHint('claude', 'permission');
+    expect(hint).toContain('chmod +x');
+    expect(hint).toContain('command -v claude');
+    expect(hint).toContain('TROUBLESHOOTING.md');
+  });
+
+  it('defaults to not-found guidance when the class is undefined', () => {
+    const hint = detectionRecoveryHint('gemini');
+    expect(hint).toContain('Install gemini');
+    expect(hint).toContain('INSTALLATION.md');
+  });
+
+  it('gives a verbose-logs next step for timeout', () => {
+    expect(detectionRecoveryHint('codex', 'timeout')).toContain('--verbose');
   });
 });

--- a/packages/nexus-agents/src/cli/cli-detection-error.ts
+++ b/packages/nexus-agents/src/cli/cli-detection-error.ts
@@ -56,6 +56,32 @@ export function formatDetectionMessage(cliName: string, detectionError?: Detecti
 }
 
 /**
+ * Actionable recovery step for each detection-error class (#3213). Each takes
+ * the CLI's **binary** name (e.g. `opencode`, not the display name) so the
+ * suggested command is runnable verbatim. Intended to be shown alongside the
+ * `formatDetectionMessage` line on setup/doctor failures.
+ */
+export const DETECTION_ERROR_SOLUTIONS: Record<DetectionError, (cliBinary: string) => string> = {
+  'not-found': (cli) =>
+    `Install ${cli} and make sure it is on your PATH — see docs/getting-started/INSTALLATION.md.`,
+  permission: (cli) =>
+    `The ${cli} binary is present but not executable. Run: chmod +x "$(command -v ${cli})"`,
+  timeout: (cli) =>
+    `${cli} detection timed out. Check PATH for hung mounts (e.g. NFS); re-run with --verbose to see where detection hangs.`,
+  other: (cli) => `Re-run with --verbose for detailed ${cli} detection logs.`,
+};
+
+/**
+ * One-line actionable recovery hint for a detection error, with a docs pointer.
+ * `cliBinary` is the runnable binary name (e.g. `gemini`); defaults the class to
+ * `not-found` when unclassified.
+ */
+export function detectionRecoveryHint(cliBinary: string, detectionError?: DetectionError): string {
+  const cls: DetectionError = detectionError ?? 'not-found';
+  return `${DETECTION_ERROR_SOLUTIONS[cls](cliBinary)} (more: docs/TROUBLESHOOTING.md)`;
+}
+
+/**
  * Classifies a thrown error from `execFileSync('which'|'where', ...)` or
  * `execFileSync(cli, ['--version'])`.
  *

--- a/packages/nexus-agents/src/cli/setup-command.ts
+++ b/packages/nexus-agents/src/cli/setup-command.ts
@@ -36,7 +36,7 @@ import { runConfigInitSync } from './setup-config.js';
 import { detectOpenCodeCli, configureOpenCode } from './setup-opencode.js';
 import { detectGeminiCli, configureGemini } from './setup-gemini.js';
 import { detectCodexCli, configureCodex } from './setup-codex.js';
-import { formatDetectionMessage } from './cli-detection-error.js';
+import { formatDetectionMessage, detectionRecoveryHint } from './cli-detection-error.js';
 import { VERSION } from '../version.js';
 import { runWizard } from './setup-wizard.js';
 import { generatePermissionsSnippet, buildPermissionsBanner } from './setup-permissions.js';
@@ -445,7 +445,7 @@ function runOpenCodeStep(options: SetupOptions): SetupStep {
     return {
       name: 'OpenCode MCP',
       status: 'skipped',
-      message: formatDetectionMessage('OpenCode CLI', cliInfo.detectionError),
+      message: `${formatDetectionMessage('OpenCode CLI', cliInfo.detectionError)}\n  → ${detectionRecoveryHint('opencode', cliInfo.detectionError)}`,
       durationMs: getTimeProvider().now() - startTime,
     };
   }
@@ -476,7 +476,7 @@ function runGeminiStep(options: SetupOptions): SetupStep {
     return {
       name: 'Gemini MCP',
       status: 'skipped',
-      message: formatDetectionMessage('Gemini CLI', cliInfo.detectionError),
+      message: `${formatDetectionMessage('Gemini CLI', cliInfo.detectionError)}\n  → ${detectionRecoveryHint('gemini', cliInfo.detectionError)}`,
       durationMs: getTimeProvider().now() - startTime,
     };
   }
@@ -532,7 +532,7 @@ function runCodexStep(options: SetupOptions): SetupStep {
     return {
       name: 'Codex MCP',
       status: 'skipped',
-      message: formatDetectionMessage('Codex CLI', cliInfo.detectionError),
+      message: `${formatDetectionMessage('Codex CLI', cliInfo.detectionError)}\n  → ${detectionRecoveryHint('codex', cliInfo.detectionError)}`,
       durationMs: getTimeProvider().now() - startTime,
     };
   }


### PR DESCRIPTION
## Context
Closes #3213. When a CLI fails detection (not-found / permission / timeout / other), the setup output showed only a terse cause phrase ("binary not on PATH") with **no next step** — the finding asked for per-class recovery guidance.

## Change
- **`DETECTION_ERROR_SOLUTIONS`** + **`detectionRecoveryHint(cliBinary, error)`** in `cli-detection-error.ts`: a runnable, class-specific recovery step with a `docs/TROUBLESHOOTING.md` pointer. The binary name is threaded so the command is copy-pasteable:
  - **permission** → `chmod +x "$(command -v <cli>)"`
  - **timeout** → check PATH for hung mounts (NFS); re-run with `--verbose`
  - **not-found** → install + ensure on PATH (INSTALLATION.md)
  - **other** → re-run with `--verbose`
- `nexus-agents setup` now prints the hint beneath each unavailable CLI's status line (opencode/gemini/codex).

## Testing
`cli-detection-error.test.ts` (+4: a solution for every class, runnable permission command with the binary name, not-found default, timeout `--verbose`) + setup-command suite → all pass. typecheck + lint clean. Verified `docs/TROUBLESHOOTING.md` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)