### PR TITLE
docs(.rules/mcp): document tool-to-tool composition contract (#3201)

### DIFF
--- a/.changeset/tool-to-tool-composition-doc.md
+++ b/.changeset/tool-to-tool-composition-doc.md
@@ -1,0 +1,9 @@
+---
+---
+
+docs(.rules/mcp): document tool-to-tool composition (engines in-process, envelopes across the tool boundary)
+
+Clarifies the two composition boundaries for MCP tools (#3201): in-process
+handlers call canonical domain engines directly (ConsensusEngine, PipelineRunner,
+CompositeRouter), while cross-tool consumers parse the ToolErrorEnvelope and
+branch on isRetryable. No shipped code changes (.rules/ is not in the package).

--- a/.rules/mcp.md
+++ b/.rules/mcp.md
@@ -87,6 +87,31 @@ projection from the 11-value taxonomy to the 5-value one — never the reverse.
 **`detail` is not output-sanitized.** Never put secrets, credentials,
 absolute filesystem paths, or raw `Error`/response objects in `detail`.
 
+### Tool-to-tool composition (#3201)
+
+There are two distinct composition boundaries — pick by **where the caller runs**, not by convenience:
+
+- **In-process (one tool's handler needs another concern's logic):** call the
+  canonical **domain engine** directly — `ConsensusEngine`, `PipelineRunner`,
+  `CompositeRouter`, `Orchestrator` — exactly as the Canonical Paths table
+  mandates. Do **not** re-invoke a peer MCP tool's handler to get at its logic;
+  the MCP wrapper is a transport/validation shell, and routing it back through
+  `_meta`-envelope parsing in-process is strictly more coupling, not less.
+  `consensus-vote.ts` calling `ConsensusEngine` is correct by design, not the
+  coupling smell it can look like from the outside.
+- **Cross-tool (an agent or the autonomous loop chains tools at the MCP
+  boundary):** the consumer only ever sees the `ToolResult`. On `isError`,
+  `parseToolErrorEnvelope(result._meta)` and branch on the result: retry only
+  when `isRetryable` (i.e. category `transient`); on `validation` fix the args
+  and re-call; on `permission`/`business`/`internal` stop and surface — never
+  blind-retry. This is the only supported way for tool output to feed tool
+  input, and it is exactly why the envelope is "caller-facing" above.
+
+Rule of thumb: **engines compose inside the package; envelopes compose across
+the tool boundary.** If you find a tool importing `pipeline/` or `agents/`
+internals that are _not_ a canonical engine, that is the real coupling to fix —
+route it through the engine, not through a peer tool.
+
 `toolError(msg)` remains as a back-compat alias mapping to a non-retryable
 `internal` envelope — acceptable for the legacy migration sweep, but new code
 should call `toolStructuredError` with the correct category.


### PR DESCRIPTION
## What

Adds a **Tool-to-tool composition** subsection to `.rules/mcp.md`, under the Error Envelope Contract, clarifying the two distinct composition boundaries for MCP tools:

- **In-process** — a tool handler needing another concern's logic calls the canonical **domain engine** directly (`ConsensusEngine`, `PipelineRunner`, `CompositeRouter`, `Orchestrator`), per the Canonical Paths table. It does **not** re-invoke a peer MCP tool's handler.
- **Cross-tool** — an agent or the autonomous loop chaining tools at the MCP boundary consumes the `ToolResult`; on error it calls `parseToolErrorEnvelope(result._meta)` and branches on `isRetryable`/category (retry only `transient`).

Rule of thumb: **engines compose inside the package; envelopes compose across the tool boundary.**

## Why

#3201 flagged that `orchestrate-dispatch.ts` / `consensus-vote.ts` / `pipeline-tool.ts` import `pipeline/` and `agents/` internals and asked for a tool-to-tool composition guide. Verifying against the Canonical Paths rule showed the finding's premise is partly a misframing: calling `ConsensusEngine` from `consensus-vote.ts` is **correct by design**, not a coupling smell — re-invoking a peer tool's envelope in-process would be *more* coupling. The doc resolves the real question (which boundary to use when) and names the actual coupling to fix (importing non-engine internals).

## Scope

Docs-only, in the canonical `.rules/mcp.md` (chosen over a new file to avoid composability-doc sprawl). `governance:check` passes — frontmatter untouched, so the generated CLAUDE.md rules table is unchanged. markdownlint + prettier clean. Empty changeset (`.rules/` is not in the published package `files`).

Closes #3201

🤖 Generated with [Claude Code](https://claude.com/claude-code)