### PR TITLE
feat(consensus): posterior-confidence escalation for higher_order quickMode (#3174)

### DIFF
--- a/.changeset/posterior-confidence-escalation.md
+++ b/.changeset/posterior-confidence-escalation.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(consensus): escalate borderline higher_order quickMode approvals to the full panel (#3174)
+
+`quickMode` approvals now escalate to the full 7-voter panel when a
+`higher_order`/`opinion_wise` vote approves with a borderline Bayesian
+posterior (`posteriorApproval` below `HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR`,
+0.65). Previously escalation fired only via the contrarian-agent check, which
+ignored the posterior — a low-confidence Bayesian approval looked identical to a
+clean one. The posterior check runs first, so a borderline approval escalates
+without spending a contrarian call. New pure predicate `shouldEscalateLowPosterior`
+in `consensus-vote-types.ts` (unit-tested); non-higher-order strategies,
+rejections, and full-panel votes are unaffected.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -54,6 +54,41 @@ export function isHigherOrderStrategy(strategy: VotingStrategy): boolean {
   return strategy === 'higher_order' || strategy === 'opinion_wise';
 }
 
+/**
+ * Posterior-approval floor below which a `higher_order` quickMode *approval* is
+ * escalated to the full voter panel (#3174). For Bayesian aggregation the
+ * posterior is a first-class confidence signal: an approval whose posterior sits
+ * near 0.5 means the 3-voter quick panel was barely decisive, which is exactly
+ * the case where the extra voters are worth their cost. Mirrors the bare-constant
+ * style of `CONTRARIAN_ESCALATION_THRESHOLD`. Set above any real posterior to
+ * always escalate, or — since the gate also requires `posterior < floor` — a
+ * floor of `0` disables posterior-based escalation entirely.
+ */
+export const HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR = 0.65;
+
+/**
+ * Whether a quickMode approval should escalate to the full panel purely on a
+ * borderline Bayesian posterior (#3174). Independent of the contrarian-agent
+ * check — this catches low-confidence higher_order approvals that a clean
+ * outcome string hides. Only fires for higher_order/opinion_wise (the strategies
+ * with a meaningful posterior), on approvals, in quickMode, when the posterior
+ * is known and below the floor.
+ */
+export function shouldEscalateLowPosterior(
+  strategy: VotingStrategy,
+  outcome: 'approved' | 'rejected',
+  quickMode: boolean,
+  posteriorApproval: number | undefined
+): boolean {
+  return (
+    quickMode &&
+    outcome === 'approved' &&
+    isHigherOrderStrategy(strategy) &&
+    posteriorApproval !== undefined &&
+    posteriorApproval < HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR
+  );
+}
+
 // ============================================================================
 // Input / Output Schemas
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -21,6 +21,8 @@ import {
   buildResponse,
   getDefaultErrorPolicy,
   isHigherOrderStrategy,
+  shouldEscalateLowPosterior,
+  HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR,
 } from './consensus-vote-types.js';
 import type { VotingStrategy } from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
@@ -827,6 +829,33 @@ describe('buildResponse surfaces policyReason (#3124)', () => {
       policyReason: 'fail_closed: 1 voter(s) errored',
     };
   }
+});
+
+describe('shouldEscalateLowPosterior (#3174)', () => {
+  const floor = HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR;
+  it('escalates a borderline higher_order quickMode approval', () => {
+    expect(shouldEscalateLowPosterior('higher_order', 'approved', true, floor - 0.05)).toBe(true);
+  });
+  it('treats opinion_wise as a higher_order alias', () => {
+    expect(shouldEscalateLowPosterior('opinion_wise', 'approved', true, floor - 0.1)).toBe(true);
+  });
+  it('does NOT escalate when the posterior is at/above the floor', () => {
+    expect(shouldEscalateLowPosterior('higher_order', 'approved', true, floor)).toBe(false);
+    expect(shouldEscalateLowPosterior('higher_order', 'approved', true, 0.9)).toBe(false);
+  });
+  it('does NOT escalate outside quickMode (full panel already ran)', () => {
+    expect(shouldEscalateLowPosterior('higher_order', 'approved', false, 0.5)).toBe(false);
+  });
+  it('does NOT escalate on a rejection (escalation gate is approvals only)', () => {
+    expect(shouldEscalateLowPosterior('higher_order', 'rejected', true, 0.5)).toBe(false);
+  });
+  it('does NOT escalate for non-higher-order strategies (no Bayesian posterior signal)', () => {
+    expect(shouldEscalateLowPosterior('simple_majority', 'approved', true, 0.5)).toBe(false);
+    expect(shouldEscalateLowPosterior('supermajority', 'approved', true, 0.5)).toBe(false);
+  });
+  it('does NOT escalate when the posterior is unavailable', () => {
+    expect(shouldEscalateLowPosterior('higher_order', 'approved', true, undefined)).toBe(false);
+  });
 });
 
 describe('opinion_wise is treated as a higher_order alias (#3271)', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -50,6 +50,7 @@ import {
   buildResponse,
   getDefaultErrorPolicy,
   isHigherOrderStrategy,
+  shouldEscalateLowPosterior,
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import { recordVoteSuccess, recordVoteError } from './consensus-vote-recording.js';
@@ -500,21 +501,37 @@ function buildPolicyShortCircuitResult(args: {
 }
 
 /**
- * Contrarian-escalation gate for `quickMode` approvals (#1799).
+ * Escalation gate for `quickMode` approvals. Two independent triggers, both
+ * re-running `executeVoting` with the full voter panel:
  *
- * When `quickMode` voted approve, run a single contrarian agent to
- * catch YAGNI / SECURITY_RISK / SCOPE_CREEP. If it rejects with high
- * confidence, escalate by re-running `executeVoting` with the full
- * voter panel. Returns the escalated result, or `undefined` to signal
- * "no escalation, continue with the quickMode result."
+ * 1. Posterior-confidence (#3174): for `higher_order`/`opinion_wise`, a borderline
+ *    Bayesian posterior (below `HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR`) means the
+ *    3-voter quick panel was barely decisive — escalate without spending a
+ *    contrarian call. Checked first so a borderline posterior short-circuits it.
+ * 2. Contrarian agent (#1799): run a single contrarian to catch
+ *    YAGNI / SECURITY_RISK / SCOPE_CREEP; escalate if it rejects with high
+ *    confidence.
+ *
+ * Returns the escalated result, or `undefined` for "no escalation, continue
+ * with the quickMode result."
  */
 async function maybeEscalateContrarian(
   input: ConsensusVoteInput,
   outcome: 'approved' | 'rejected',
+  ctx: { strategy: VotingStrategy; posteriorApproval: number | undefined },
   logger: ILogger,
   opts?: { voteTimeoutMs?: number }
 ): Promise<ExtendedVotingResult | undefined> {
   if (!input.quickMode || outcome !== 'approved' || input.simulateVotes) return undefined;
+
+  if (shouldEscalateLowPosterior(ctx.strategy, outcome, input.quickMode, ctx.posteriorApproval)) {
+    logger.warn('Posterior-confidence escalation: re-running with full vote (#3174)', {
+      strategy: ctx.strategy,
+      posteriorApproval: ctx.posteriorApproval,
+    });
+    return executeVoting({ ...input, quickMode: false }, logger, opts);
+  }
+
   const escalation = await runContrarianCheck(input.proposal, logger);
   if (!escalation.shouldEscalate) return undefined;
   logger.warn('Contrarian escalation: re-running with full vote', {
@@ -586,7 +603,13 @@ export async function executeVoting(
 
   recordVotesToTracker(votes, outcome, logger);
 
-  const escalated = await maybeEscalateContrarian(input, outcome, logger, opts);
+  const escalated = await maybeEscalateContrarian(
+    input,
+    outcome,
+    { strategy, posteriorApproval: higherOrderResult?.posteriorApproval },
+    logger,
+    opts
+  );
   if (escalated !== undefined) return escalated;
 
   return finalizeVotingResult({


### PR DESCRIPTION
## What

Adds a second escalation trigger to `maybeEscalateContrarian` (consensus-vote): a **`quickMode` `higher_order`/`opinion_wise` approval with a borderline Bayesian posterior** (`posteriorApproval < 0.65`) now re-runs with the full 7-voter panel — independent of the contrarian-agent check.

- New pure, unit-tested predicate `shouldEscalateLowPosterior(strategy, outcome, quickMode, posteriorApproval)` in `consensus-vote-types.ts`, alongside `isHigherOrderStrategy` (so `opinion_wise` is treated as a `higher_order` alias).
- Named constant `HIGHER_ORDER_ESCALATION_POSTERIOR_FLOOR = 0.65` with rationale (mirrors the existing bare-constant `CONTRARIAN_ESCALATION_THRESHOLD`). A floor of `0` disables posterior escalation.
- The posterior check runs **before** the contrarian LLM call, so a borderline approval escalates without spending a contrarian vote.

## Why

Before this, a `quickMode` `higher_order` approval escalated only when the contrarian agent rejected — the **Bayesian posterior was ignored**. An approval whose posterior sits near 0.5 (the 3-voter panel was barely decisive) looked identical to a clean 0.9 approval. For Bayesian aggregation the posterior is a first-class confidence signal; a borderline one is exactly the case where the extra voters are worth their cost. Fail-safe direction: this only *adds* scrutiny. Closes #3174.

## Scope / safety

- Behavior change is bounded to `quickMode && approved && higher_order/opinion_wise && posterior < 0.65`. Non-higher-order strategies, rejections, and full-panel votes are untouched (covered by the predicate's unit tests).
- TDD: 7 new predicate tests (red→green); full consensus-vote suite green (82 + error-policy 11 + signals 6 = 99 passing); typecheck + eslint clean.

Closes #3174

🤖 Generated with [Claude Code](https://claude.com/claude-code)