### PR TITLE
docs: periodic end-to-end validation methodology + e2e-validation skill

### DIFF
--- a/.changeset/e2e-validation-methodology.md
+++ b/.changeset/e2e-validation-methodology.md
@@ -1,0 +1,12 @@
+---
+---
+
+docs: add periodic end-to-end validation methodology + e2e-validation skill
+
+Establishes running the real loops (research → vote → plan → dev-pipeline →
+graph → memory → audit) on a cadence with live adapters to validate that fixes,
+docs, and claims hold in actual usage — catching what unit tests miss (live
+voter-panel auth, adapter routing, pipeline stage wiring, audit integrity).
+Adds a methodology section to AGENTS.md (injected into CLAUDE.md) and a new
+`e2e-validation` skill as the executable runbook (skills 32 → 33). No shipped
+code (skills/, AGENTS.md not in the package `files`).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "source": "github",
         "repo": "williamzujkowski/nexus-agents"
       },
-      "description": "Intelligent orchestration platform for AI coding tools — 45 MCP tools (orchestrate, consensus voting, research, pipelines), 32 skills, 12 expert agents, governance hooks.",
+      "description": "Intelligent orchestration platform for AI coding tools — 45 MCP tools (orchestrate, consensus voting, research, pipelines), 33 skills, 12 expert agents, governance hooks.",
       "keywords": ["orchestration", "mcp", "consensus", "pipelines", "multi-agent"]
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,26 @@ Before completing ANY implementation task:
 - [ ] **Downstream tests updated** — if config values, scoring weights, or model data changed, all dependent assertions identified and updated before running tests.
 - [ ] Discoveries logged — bugs noticed outside scope captured as tracked issues per the Discovered-Issues protocol.
 
+## Periodic end-to-end validation
+
+Unit tests prove functions; they do **not** prove the real loops work. Validate the
+substrate by **running it** on a cadence — a real end-to-end pass that exercises all
+nexus-agents feature families against a genuine task and compares observed behavior
+to what the code, docs, and recent "fixed" claims assert.
+
+- **Cadence:** after every release, weekly, once ≥3 behavior-affecting fixes have
+  landed since the last run, or on demand when a claim is in doubt.
+- **The loop, for real:** `research_discover`/`research_synthesize` → `consensus_vote`
+  (both `--quick` 3-voter and full 7-voter) → plan → `run_dev_pipeline` (dryRun then
+  real) → `run_pipeline`/`run_graph_workflow` → `memory_write`/`memory_query` →
+  `verify_audit_chain`. Use **live adapters only** — never `simulateVotes`/mocks
+  (#2319); they prove nothing. If no live adapter, record `BLOCKED`, don't fabricate a pass.
+- **Capture actual output** at each step and judge it against the claim. Where reality
+  diverges (a "fixed" bug that reproduces, a dead voter, a missing stage, a doc that
+  lies), file a tracked issue per the Discovered-Issues gate — scrubbing gov/org refs.
+- This catches what unit tests miss: live voter-panel auth, adapter routing, pipeline
+  stage wiring, audit-chain integrity. Full runbook: the `e2e-validation` skill.
+
 ## Rules index
 
 <!-- GOVERNANCE:RULES_INDEX:START -->
@@ -110,7 +130,7 @@ _Auto-generated from `.rules/*.md` frontmatter by `scripts/inject-governance.ts`
 
 Workflow playbooks live at `skills/<name>/SKILL.md` (canonical per the Anthropic Agent Skills spec, which OpenCode and others are adopting).
 
-- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 32 skills.
+- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 33 skills.
 - When a user request matches a skill's triggers, read the full `SKILL.md` at the listed path and follow its workflow.
 - `skills/index.yaml` is regenerated via `scripts/generate-skills-index.ts` and gated in CI. Never edit it by hand.
 - **Codex Skills (#2660):** Codex's Skills primitive uses the same `SKILL.md` filename + the same required frontmatter (`name`, `description`) as the Anthropic spec — these skills are already cross-vendor compatible, no translation layer needed. Codex discovers skills under `.agents/skills/` or via `[[skills.config]]` path entries in the agent config; point either at this repo's `skills/` directory. The `name`/`description` validation in `generate-skills-index.ts` is the enforced cross-vendor contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,26 @@ Before completing ANY implementation task:
 - [ ] **Downstream tests updated** — if config values, scoring weights, or model data changed, all dependent assertions identified and updated before running tests.
 - [ ] Discoveries logged — bugs noticed outside scope captured as tracked issues per the Discovered-Issues protocol.
 
+## Periodic end-to-end validation
+
+Unit tests prove functions; they do **not** prove the real loops work. Validate the
+substrate by **running it** on a cadence — a real end-to-end pass that exercises all
+nexus-agents feature families against a genuine task and compares observed behavior
+to what the code, docs, and recent "fixed" claims assert.
+
+- **Cadence:** after every release, weekly, once ≥3 behavior-affecting fixes have
+  landed since the last run, or on demand when a claim is in doubt.
+- **The loop, for real:** `research_discover`/`research_synthesize` → `consensus_vote`
+  (both `--quick` 3-voter and full 7-voter) → plan → `run_dev_pipeline` (dryRun then
+  real) → `run_pipeline`/`run_graph_workflow` → `memory_write`/`memory_query` →
+  `verify_audit_chain`. Use **live adapters only** — never `simulateVotes`/mocks
+  (#2319); they prove nothing. If no live adapter, record `BLOCKED`, don't fabricate a pass.
+- **Capture actual output** at each step and judge it against the claim. Where reality
+  diverges (a "fixed" bug that reproduces, a dead voter, a missing stage, a doc that
+  lies), file a tracked issue per the Discovered-Issues gate — scrubbing gov/org refs.
+- This catches what unit tests miss: live voter-panel auth, adapter routing, pipeline
+  stage wiring, audit-chain integrity. Full runbook: the `e2e-validation` skill.
+
 ## Rules index
 
 <!-- GOVERNANCE:RULES_INDEX:START -->
@@ -169,7 +189,7 @@ _Auto-generated from `.rules/*.md` frontmatter by `scripts/inject-governance.ts`
 
 Workflow playbooks live at `skills/<name>/SKILL.md` (canonical per the Anthropic Agent Skills spec, which OpenCode and others are adopting).
 
-- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 32 skills.
+- **Discovery for all harnesses:** read [`skills/index.yaml`](./skills/index.yaml) — `{name, description, triggers, path}` for all 33 skills.
 - When a user request matches a skill's triggers, read the full `SKILL.md` at the listed path and follow its workflow.
 - `skills/index.yaml` is regenerated via `scripts/generate-skills-index.ts` and gated in CI. Never edit it by hand.
 - **Codex Skills (#2660):** Codex's Skills primitive uses the same `SKILL.md` filename + the same required frontmatter (`name`, `description`) as the Anthropic spec — these skills are already cross-vendor compatible, no translation layer needed. Codex discovers skills under `.agents/skills/` or via `[[skills.config]]` path entries in the agent config; point either at this repo's `skills/` directory. The `name`/`description` validation in `generate-skills-index.ts` is the enforced cross-vendor contract.
@@ -385,11 +405,11 @@ If any check raises "wait, actually..." — drop the finding. Max 5 auto-filed i
 
 ## Workflows (via Skills)
 
-**32 skills registered.** Each skill's detailed steps and trigger keywords live in `skills/<name>/SKILL.md` (Anthropic Agent Skills spec, #1828). Non-Claude agents discover via [`skills/index.yaml`](./skills/index.yaml) referenced from [AGENTS.md](./AGENTS.md).
+**33 skills registered.** Each skill's detailed steps and trigger keywords live in `skills/<name>/SKILL.md` (Anthropic Agent Skills spec, #1828). Non-Claude agents discover via [`skills/index.yaml`](./skills/index.yaml) referenced from [AGENTS.md](./AGENTS.md).
 
-`api-and-interface-design`, `browser-testing-with-devtools`, `bug-fix`, `code-simplification`, `codex-delegator`, `context-engineering`, `deprecation-and-migration`, `dev-pipeline`, `docs-chart`, `docs-image`, `docs-mermaid`, `docs-review`, `docs-rewrite`, `documentation-management`, `dogfooding-issues`, `gemini-delegator`, `hotfix`, `implement-feature`, `infrastructure-management`, `performance-optimization`, `pre-push-parity`, `release`, `requirements-gathering`, `research-and-vote`, `reviewing-code`, `security-advisory-response`, `security-scanning`, `self-critique`, `system-review`, `test-driven-development`, `ui-ux-design`, `version-check`
+`api-and-interface-design`, `browser-testing-with-devtools`, `bug-fix`, `code-simplification`, `codex-delegator`, `context-engineering`, `deprecation-and-migration`, `dev-pipeline`, `docs-chart`, `docs-image`, `docs-mermaid`, `docs-review`, `docs-rewrite`, `documentation-management`, `dogfooding-issues`, `e2e-validation`, `gemini-delegator`, `hotfix`, `implement-feature`, `infrastructure-management`, `performance-optimization`, `pre-push-parity`, `release`, `requirements-gathering`, `research-and-vote`, `reviewing-code`, `security-advisory-response`, `security-scanning`, `self-critique`, `system-review`, `test-driven-development`, `ui-ux-design`, `version-check`
 
-_Auto-generated from `skills/index.yaml`. 32 skills._
+_Auto-generated from `skills/index.yaml`. 33 skills._
 
 <!-- GOVERNANCE:WORKFLOW_INDEX:END -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,7 +460,7 @@ _Auto-generated from source. 45 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-04_
+_Governance Version: 2026-06-06_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -13,7 +13,7 @@ keywords: [plugin, claude-code, installation, marketplace, mcp, getting-started]
 Nexus-agents ships as a Claude Code plugin. Installing it exposes:
 
 - 45 MCP tools (`orchestrate`, `consensus_vote`, `research_*`, `run_*`, etc.)
-- 32 skills (research-and-vote, implement-feature, bug-fix, …)
+- 33 skills (research-and-vote, implement-feature, bug-fix, …)
 - 12 agent mirrors (security, architecture, code, research, testing experts)
 - 2 governance hooks (fitness-gate, secret-scan)
 
@@ -41,7 +41,7 @@ After install, confirm the 45 MCP tools are reachable:
 /mcp
 ```
 
-You should see `nexus-agents` listed with tools like `orchestrate`, `consensus_vote`, `run_pipeline`. The 32 skills appear in `/skills`, and the 12 agents in `/agents`.
+You should see `nexus-agents` listed with tools like `orchestrate`, `consensus_vote`, `run_pipeline`. The 33 skills appear in `/skills`, and the 12 agents in `/agents`.
 
 ## What gets installed
 

--- a/skills/e2e-validation/SKILL.md
+++ b/skills/e2e-validation/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: e2e-validation
+description: |
+  Periodically exercise ALL nexus-agents feature families end-to-end against a
+  real task — research → synthesize → vote → plan → dev-pipeline → graph workflow
+  → memory → audit — capturing ACTUAL outputs to validate that fixes, docs, and
+  claims hold in real usage (the things unit tests miss: live voter panels,
+  adapter routing, pipeline stage wiring, audit chains). Use after a release,
+  weekly, when several fixes have landed since the last run, or on demand.
+  Triggers on "e2e validation", "end-to-end validation", "dogfood the loops",
+  "validate end to end", "real usage test", "periodic validation run",
+  "full-loop validation".
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task, WebSearch, WebFetch
+---
+
+# End-to-End Validation Skill
+
+Unit tests prove a function does what its test says. They do **not** prove the
+real loops work: that the live voter panel actually returns 7 votes, that
+`run_dev_pipeline` wires every stage, that routing picks a reachable adapter,
+that the audit chain verifies. This skill runs the **real** loops with live
+adapters and compares observed behavior against what the code, docs, and recent
+"fixed" claims assert. Where reality diverges, it files a tracked issue.
+
+> Why this exists: this is dogfooding for **validation**, not implementation.
+> `dogfooding-issues` implements open issues; `dev-pipeline` runs one pipeline;
+> `system-review` is a static health check. This skill is the periodic _real-usage
+> smoke test of the whole substrate_.
+
+## When to run
+
+- **After every release** (a published version is a claim that the loops work).
+- **Weekly**, or once **≥3 behavior-affecting fixes** have landed since the last run.
+- **On demand** when a claim is in doubt (e.g., "the voter race is fixed").
+
+Record the trigger in the report. One run per trigger is enough — don't loop it.
+
+## Preconditions (fail closed)
+
+1. **Live adapter required.** Confirm at least one real CLI/model adapter is
+   authenticated (`nexus-agents doctor`). This skill validates _real_ behavior —
+   **never** use `consensus_vote { simulateVotes: true }` (random output, #2319)
+   or any simulate/mock path. If no live adapter is available, record every step
+   as `BLOCKED` and stop — do not fabricate a pass.
+2. **Cost awareness.** Real loops spend tokens. If work is cost-gated, note it and
+   get authorization before the full run; a reduced run (e.g. `--quick` votes,
+   `dryRun` pipelines) is an acceptable partial — label it as such.
+3. **Note the versions.** Capture the installed `nexus-agents` version and git SHA
+   so the report is reproducible.
+
+## The loop — exercise every feature family
+
+Pick one **real, non-trivial seed task** (a genuine backlog item works best, so the
+run produces real value). Drive it through the families below, capturing the
+**actual** tool output each step. Don't paraphrase success — paste/observe the real
+result and judge it.
+
+| #   | Family        | Tools to exercise                                                                                  | What "real" validates                                                                 |
+| --- | ------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Research      | `research_discover`, `research_synthesize`, `research_query`                                       | discovery returns results; synthesis preserves provenance                             |
+| 2   | Consensus     | `consensus_vote` (run BOTH `--quick` 3-voter AND full 7-voter, `higher_order` + `simple_majority`) | **all** voters return — catches dead/404 voters (e.g. #3497), OAuth races, escalation |
+| 3   | Planning/exec | `orchestrate`, `execute_expert`, `delegate_to_model`                                               | adapter routing picks a reachable model; expert personas resolve                      |
+| 4   | Pipelines     | `run_dev_pipeline` (dryRun → real), `run_pipeline`, `run_graph_workflow`                           | every stage wired; no missing-stage / template-resolution gaps                        |
+| 5   | Memory        | `memory_write`, `memory_query`, `memory_stats`                                                     | writes persist and read back; counts move                                             |
+| 6   | Audit/health  | `verify_audit_chain`, `ci_health_check`, `query_trace`                                             | the run left a verifiable audit trail; traces resolve                                 |
+| 7   | Repo/analysis | `repo_analyze`, `search_codebase`, `extract_symbols`                                               | analysis tools run against this repo                                                  |
+
+Adapt the set to what changed since the last run — but a full periodic run should
+touch all seven families at least once.
+
+## Capture protocol
+
+For each step record: **what you ran**, the **actual output** (or error), the
+**claimed/expected** behavior (from code/docs/changelog), and a verdict —
+`PASS` / `FAIL` / `BLOCKED` / `PARTIAL`. A vague "seemed to work" is a FAIL of the
+capture, not a PASS of the step.
+
+On a real failure, follow the orchestrator-fallback rule (one retry max, then treat
+as a blocker — never silently retry past it) and apply the **Q Protocol** to triage.
+
+## On mismatch → file a tracked issue
+
+When observed behavior contradicts a claim (a "fixed" bug that reproduces, a doc that
+lies, a dead voter, a missing stage), file a GitHub issue per the Discovered-Issues
+4-point gate — this is canonical tracking, not a memory note.
+
+- **OPSEC:** scrub `USAi` / government / org references from titles, bodies, and
+  pasted output; generalize to "the configured provider" / "an upstream provider".
+  Keep the technical content.
+- Cite the run (version + SHA), paste the real evidence, and link the claim it
+  contradicts (changelog line, doc, or issue that declared it fixed).
+
+## Output — a short validation report
+
+Close with a report (post to the tracking issue and/or `docs/ops/`):
+
+```
+E2E Validation — <date> — nexus-agents <version> (<sha>)
+Trigger: <release | weekly | N fixes | on-demand>
+Coverage: 7/7 families  | Adapters live: <which>
+Result: <PASS n> / <FAIL n> / <BLOCKED n> / <PARTIAL n>
+Issues filed: #.... , #....
+Notes: <one or two lines on anything surprising>
+```
+
+Keep it to ~10 lines. The value is the issues filed and the honest verdict, not prose.

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -215,6 +215,26 @@ skills:
       - self-development
       - process issues
       - working on open issues
+  - name: e2e-validation
+    description: |-
+      Periodically exercise ALL nexus-agents feature families end-to-end against a
+      real task — research → synthesize → vote → plan → dev-pipeline → graph workflow
+      → memory → audit — capturing ACTUAL outputs to validate that fixes, docs, and
+      claims hold in real usage (the things unit tests miss: live voter panels,
+      adapter routing, pipeline stage wiring, audit chains). Use after a release,
+      weekly, when several fixes have landed since the last run, or on demand.
+      Triggers on "e2e validation", "end-to-end validation", "dogfood the loops",
+      "validate end to end", "real usage test", "periodic validation run",
+      "full-loop validation".
+    path: skills/e2e-validation/SKILL.md
+    triggers:
+      - e2e validation
+      - end-to-end validation
+      - dogfood the loops
+      - validate end to end
+      - real usage test
+      - periodic validation run
+      - full-loop validation
   - name: gemini-delegator
     description: |-
       Delegate large context and multimodal tasks to Gemini CLI.


### PR DESCRIPTION
## What

Adds a **periodic end-to-end validation** discipline to the methodology, so fixes/docs/claims get validated by *real usage*, not just unit tests.

- **`AGENTS.md` → "Periodic end-to-end validation"** (regenerated into CLAUDE.md): cadence + the real loop + capture/file-issue protocol. Harness-neutral, so all adapters see it.
- **New `e2e-validation` skill** (`skills/e2e-validation/SKILL.md`) — the executable runbook: run the real loops with **live adapters** (never `simulateVotes`, #2319), exercise all 7 feature families (research → consensus → plan/exec → pipelines → memory → audit → repo-analysis), capture actual output, and file tracked issues where reality diverges from claims (gov refs scrubbed).
- Regenerated `skills/index.yaml` (32 → 33), governance counts, and the plugin marketplace/install docs.

## Why

This session repeatedly showed the gap: many epic-#3143 findings were OBE/incorrect on inspection, and "fixed" claims (e.g. the #3497 voter-panel 404s — 2/7 voters dead) are exactly the kind of thing only a **real vote run** surfaces. Unit tests prove functions; they don't prove the live voter panel returns 7 votes, that `run_dev_pipeline` wires every stage, or that routing picks a reachable adapter. Running the substrate on a cadence and comparing observed behavior to claims closes that loop.

## Scope / safety

- Docs + one skill. No shipped code (`skills/`, `AGENTS.md`, `docs/` are not in the package `files`) — empty changeset.
- `governance:check` passes (CLAUDE.md FROM_AGENTS block synced, counts updated); skills index regenerated by the gated generator (not hand-edited); markdownlint + prettier clean.
- First scheduled run tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)