### PR TITLE
refactor(self-eval): document confidence rubric in arch-fit + practical-value (#3245)

### DIFF
--- a/.changeset/confidence-rubric-comments.md
+++ b/.changeset/confidence-rubric-comments.md
@@ -1,0 +1,10 @@
+---
+---
+
+refactor(self-eval): document the confidence rubric in arch-fit + practical-value evaluators
+
+Bring ArchitectureFitEvaluator and PracticalValueEvaluator into line with
+CodeQualityEvaluator's self-documenting confidence calc — named locals (base,
+metricBonus) + a rationale comment instead of bare literals. Identical arithmetic,
+zero behavior change (170 self-eval tests unchanged); makes the confidence rubric
+auditable as #3245 asked. No release impact.

--- a/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.ts
@@ -45,7 +45,12 @@ export class ArchitectureFitEvaluator extends BaseEvaluator {
     this.checkNodeProtocolImports(component, metrics);
 
     const recommendation = this.scoreToRecommendation(score);
-    const confidence = 0.6 + Math.min(0.3, metrics.length * 0.05);
+    // Confidence rubric (mirrors CodeQualityEvaluator.calculateConfidence): more
+    // architectural metrics observed ⇒ higher confidence, capped at +0.3. No
+    // concern penalty — architecture fit is judged on positive signals here.
+    const base = 0.6;
+    const metricBonus = Math.min(0.3, metrics.length * 0.05);
+    const confidence = base + metricBonus;
 
     return this.createResult(component, recommendation, confidence, metrics, concerns);
   }

--- a/packages/nexus-agents/src/self-eval/practical-value-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/practical-value-evaluator.ts
@@ -42,7 +42,12 @@ export class PracticalValueEvaluator extends BaseEvaluator {
     score = this.evaluateSizeHeuristics(component, metrics, concerns, score);
 
     const recommendation = this.scoreToRecommendation(score);
-    const confidence = 0.5 + Math.min(0.4, metrics.length * 0.08);
+    // Confidence rubric (mirrors CodeQualityEvaluator.calculateConfidence): more
+    // practical-value metrics observed ⇒ higher confidence, capped at +0.4.
+    // Practical value weights evidence presence, so there's no concern penalty.
+    const base = 0.5;
+    const metricBonus = Math.min(0.4, metrics.length * 0.08);
+    const confidence = base + metricBonus;
 
     return this.createResult(component, recommendation, confidence, metrics, concerns);
   }


### PR DESCRIPTION
## What

`ArchitectureFitEvaluator` and `PracticalValueEvaluator` computed confidence as bare unexplained literals:

```ts
const confidence = 0.6 + Math.min(0.3, metrics.length * 0.05);   // arch-fit
const confidence = 0.5 + Math.min(0.4, metrics.length * 0.08);   // practical-value
```

`CodeQualityEvaluator.calculateConfidence` already uses the documented pattern (named `base`/`metricBonus`/`concernPenalty` + a rationale comment). This brings the other two in line — same arithmetic, now self-documenting.

## Why

#3245 asked to make evaluator confidence "auditable and reproducible across refactors." On inspection the formulas were **already deterministic pure functions** of metric counts (so the finding's "intuitive, not reproducible" premise was off) — the real gap was that two of the three used unexplained literals while the third documented its rubric. This closes that inconsistency and the unexplained-literals smell.

Note: I did **not** adopt the issue's suggested `(metricsCount/totalClaims)*(1 - dissent/evaluators)` formula — it was offered as an "e.g." and would change behavior arbitrarily. The deterministic-and-auditable goal is met by documenting the existing model.

## Scope / safety

- **Zero behavior change** — identical arithmetic; 170 self-eval tests pass unchanged; typecheck + lint clean.
- Empty changeset (no runtime/release impact).

Closes #3245

🤖 Generated with [Claude Code](https://claude.com/claude-code)