### PR TITLE
docs(core): document IAgent.handleMessage delivery semantics (#3222)

### DIFF
--- a/.changeset/handlemessage-semantics-doc.md
+++ b/.changeset/handlemessage-semantics-doc.md
@@ -1,0 +1,10 @@
+---
+---
+
+docs(core): document IAgent.handleMessage delivery semantics (#3222)
+
+Specifies that handleMessage is a direct awaited request/response call (not the
+fire-and-forget event bus): ordering is caller-sequenced, there is no automatic
+retry/redelivery, and errors surface as Result.err. JSDoc-only on the IAgent
+contract — no behavior or API-shape change. The finding's MessageQueueConfig /
+persistence layer is declined as speculative (no consumer).

--- a/packages/nexus-agents/src/core/types/agent.ts
+++ b/packages/nexus-agents/src/core/types/agent.ts
@@ -230,9 +230,24 @@ export interface IAgent {
   execute(task: Task, options?: { signal?: AbortSignal }): Promise<Result<TaskResult, AgentError>>;
 
   /**
-   * Handle an inter-agent message.
+   * Handle an inter-agent message and return a response.
+   *
+   * **Delivery semantics (#3222).** This is a *direct, awaited request/response*
+   * call: the caller invokes it and holds the returned promise. It is NOT a
+   * queued or broadcast channel — that is the collaboration event bus
+   * (`agents/collaboration/event-bus.ts`), a fire-and-forget pub/sub with its
+   * own semantics. For this method specifically:
+   * - **Ordering** is the caller's responsibility. Sequential `await`s are
+   *   handled in call order; concurrent calls carry no cross-message ordering
+   *   guarantee.
+   * - **Delivery** is exactly the method invocation — there is **no automatic
+   *   retry or redelivery**. A returned `err(...)` is the caller's signal to
+   *   decide whether to retry; the agent does not re-queue the message.
+   * - **Errors** surface as `Result.err`, not as a throw for expected
+   *   conditions; the caller branches on the `Result`.
+   *
    * @param msg - Message to handle
-   * @returns Result with AgentResponse or AgentError
+   * @returns Result with AgentResponse, or AgentError on failure (not retried)
    */
   handleMessage(msg: AgentMessage): Promise<Result<AgentResponse, AgentError>>;
 


### PR DESCRIPTION
## What

Expands the JSDoc on `IAgent.handleMessage` (`core/types/agent.ts`) to specify its delivery semantics:

- It is a **direct, awaited request/response** call — not a queued or broadcast channel (that's the separate `agents/collaboration/event-bus.ts` fire-and-forget pub/sub).
- **Ordering** is the caller's responsibility (sequential `await`s; no cross-message guarantee for concurrent calls).
- **No automatic retry/redelivery** — a returned `err(...)` is the caller's signal to decide; the agent doesn't re-queue.
- **Errors** surface as `Result.err`, not throws.

## Why

#3222 correctly flagged that `handleMessage`'s contract didn't specify ordering / delivery / error semantics, so callers couldn't tell whether messages are retried or ordered. This documents the actual behavior on the canonical contract.

The finding's other half — a `MessageQueueConfig` (ordering/retries/deadletter) + persistence layer — is **declined as speculative**: `grep` finds no such config and no consumer needs at-least-once/persistent delivery today. Documenting the real (no-guarantee) semantics is the correct, DRY resolution; building a queue for a hypothetical need is YAGNI. If a critical multi-turn flow later needs durable ordered delivery, that's a separate design with a concrete consumer.

## Scope / safety

JSDoc-only on the `IAgent` interface — zero behavior or API-shape change; typecheck + lint clean. Empty changeset.

Closes #3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)