### PR TITLE
fix(docs): correct JSDoc param-name inaccuracies + gate accuracy rules (#3518)

### DIFF
--- a/.changeset/jsdoc-param-names-fixes.md
+++ b/.changeset/jsdoc-param-names-fixes.md
@@ -1,0 +1,12 @@
+---
+---
+
+fix(docs): correct JSDoc param-name inaccuracies + gate jsdoc accuracy rules — audit Phase 1b
+
+Fixes the 7 genuine @param mismatches the Phase 1 baseline surfaced (e.g.
+`@param error`→`issue`, `config`→`_config`, removed a stale `category`, documented
+omitted params in 4 functions) plus `@typeParam`→`@template` and two `@internal`
+tags carrying stray text. Flips the now-clean accuracy rules (check-param-names,
+check-types, check-tag-names, empty-tags, valid-types, check-alignment,
+check-property-names) from warn to error; `no-undefined-types` stays warn (10
+remaining, follow-up). JSDoc-only — no runtime/behavior change. #3516 / #3518.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,14 +18,21 @@ export default defineConfig([
     ignores: ['**/*.test.ts', '**/*.spec.ts', '**/test/**', '**/__tests__/**'],
     plugins: { jsdoc },
     rules: {
-      'jsdoc/check-param-names': 'warn',
-      'jsdoc/check-property-names': 'warn',
-      'jsdoc/check-types': 'warn',
+      // ERROR (baseline clean as of #3518): these fire only on existing-but-wrong
+      // JSDoc and are now at zero across non-test source, so they gate going
+      // forward. checkDestructured:false keeps check-param-names focused on
+      // genuine name mismatches rather than demanding a @param line for every
+      // nested destructured property (coverage — a separate decision, #3518).
+      'jsdoc/check-param-names': ['error', { checkDestructured: false }],
+      'jsdoc/check-property-names': 'error',
+      'jsdoc/check-types': 'error',
+      'jsdoc/check-alignment': 'error',
+      'jsdoc/check-tag-names': 'error',
+      'jsdoc/empty-tags': 'error',
+      'jsdoc/valid-types': 'error',
+      // WARN: 10 remaining violations (mostly @link-style references); fixed in a
+      // follow-up, then promoted to error.
       'jsdoc/no-undefined-types': 'warn',
-      'jsdoc/check-alignment': 'warn',
-      'jsdoc/check-tag-names': 'warn',
-      'jsdoc/empty-tags': 'warn',
-      'jsdoc/valid-types': 'warn',
     },
   },
 

--- a/packages/nexus-agents/src/agents/context-manager-helpers.ts
+++ b/packages/nexus-agents/src/agents/context-manager-helpers.ts
@@ -199,9 +199,8 @@ export interface BudgetCheckResult {
 /**
  * Check if adding tokens would exceed category budget.
  *
- * @param category - Category to check
- * @param tokenCount - Tokens to add
  * @param currentCategoryTokens - Current tokens in category
+ * @param tokenCount - Tokens to add
  * @param maxTokens - Max context tokens
  * @param budgetAllocation - Budget allocation for category (0-1)
  * @returns Budget check result

--- a/packages/nexus-agents/src/cli/setup-mcp.ts
+++ b/packages/nexus-agents/src/cli/setup-mcp.ts
@@ -106,6 +106,8 @@ function addMcpServer(useNpx: boolean, scope: 'user' | 'project' = 'user'): McpC
  * Configures nexus-agents MCP server using Claude CLI.
  *
  * Uses `claude mcp add-json` to register the server.
+ * @param useNpx - Register via `npx -y nexus-agents` instead of a global binary
+ * @param force - Overwrite an existing nexus-agents MCP server entry
  * @param scope - 'user' for global (~/.claude/mcp.json), 'project' for local (.mcp.json)
  */
 export function configureMcpServer(

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -123,7 +123,8 @@ export interface OutcomeExplainCtx {
  *      didn't return a decision in time).
  *   3. Quorum reached but the supermajority/unanimous threshold wasn't met.
  *
- * @internal — exported for tests only.
+ * Exported for tests only.
+ * @internal
  */
 export function explainOutcome(ctx: OutcomeExplainCtx): string {
   if (ctx.outcome !== 'rejected') return '';

--- a/packages/nexus-agents/src/consensus/correlation-persistence.ts
+++ b/packages/nexus-agents/src/consensus/correlation-persistence.ts
@@ -146,7 +146,7 @@ function ensureVotingDirectory(): Result<void, Error> {
  * read-merge-rename race possible because we never read or rename.
  *
  * @param proposals - Array of proposals with their votes and outcomes to persist
- * @param config - Higher-order voting config (only `maxProposals` is consulted
+ * @param _config - Higher-order voting config (only `maxProposals` is consulted
  *                 on read; this writer is fully append-only)
  * @returns Result indicating success or failure
  */

--- a/packages/nexus-agents/src/core/types/prune-strategy.ts
+++ b/packages/nexus-agents/src/core/types/prune-strategy.ts
@@ -68,7 +68,7 @@ export interface PruneResult<T> {
  * All pruning mechanisms in the system should implement this interface
  * to ensure consistent behavior and enable composition.
  *
- * @typeParam T - Type of items being pruned
+ * @template T - Type of items being pruned
  *
  * @example
  * ```typescript

--- a/packages/nexus-agents/src/core/zod-helpers.ts
+++ b/packages/nexus-agents/src/core/zod-helpers.ts
@@ -67,7 +67,7 @@ export function formatZodIssuesAsArray(error: ZodError): string[] {
 /**
  * Formats Zod issues with "root" as fallback for empty paths.
  *
- * @param error - The Zod error to format
+ * @param issue - The Zod issue to format
  * @returns A formatted string with each issue on its own
  *
  * @example

--- a/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-cli-extractor.ts
@@ -242,6 +242,10 @@ function buildCommandSpec(
  * `cli-commands.ts` via ts-morph. Option bindings come from
  * `PARSE_ARGS_CONFIG` in `cli-types.ts`.
  *
+ * @param project - ts-morph Project providing the parsed source files
+ * @param packageRoot - Absolute path to the package root
+ * @param cliCommandsPath - Path to `cli-commands.ts` (handler locations)
+ * @param cliTypesPath - Path to `cli-types.ts` (`PARSE_ARGS_CONFIG` bindings)
  * @param warnings - Optional sink for non-fatal diagnostics (#2153).
  */
 export function extractCliCommands(

--- a/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
+++ b/packages/nexus-agents/src/indexer/entrypoint-mcp-extractor.ts
@@ -82,6 +82,9 @@ function extractZodParameters(schemaObj: Node): ParameterSpec[] {
 /**
  * Extracts MCP tools from the tools directory.
  *
+ * @param project - ts-morph Project providing the parsed source files
+ * @param packageRoot - Absolute path to the package root
+ * @param mcpToolsPath - Path to the MCP tools directory to scan
  * @param warnings - Optional sink for non-fatal diagnostics (e.g. the tools
  *   directory glob matched zero files — a repeat-offender silent-failure
  *   class that shipped the `cli_commands: []` regression for 3 months before

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -1348,10 +1348,10 @@ function recordPendingAndRegister(jobId: string, key: string | undefined, inputs
  * Fire-and-forget background run. Wraps the depth-guarded pipeline with
  * complete/failed recording + slot release. Extracted from
  * `dispatchAsyncOrchestrate` so the dispatcher stays under the 50-line cap.
- */
-/**
- * @internal Exported for integration tests (#3091) — drives the async
- * background run deterministically (awaitable) instead of fire-and-forget.
+ *
+ * Exported for integration tests (#3091) — drives the async background run
+ * deterministically (awaitable) instead of fire-and-forget.
+ * @internal
  */
 export async function runOrchestrateInBackground(
   jobId: string,

--- a/packages/nexus-agents/src/testing/adapters/mock-adapter.ts
+++ b/packages/nexus-agents/src/testing/adapters/mock-adapter.ts
@@ -335,6 +335,7 @@ export function createFailingAdapter(name: CliName = 'claude'): MockCliAdapter {
 
 /**
  * Creates a mock adapter configured for latency testing.
+ * @param name - CLI name the mock impersonates
  * @param latencyMs - Simulated response latency
  */
 export function createSlowAdapter(name: CliName = 'claude', latencyMs: number): MockCliAdapter {


### PR DESCRIPTION
Part of epic #3516. **Phase 1b — fix high-signal accuracy bugs + flip to error.**

## Fixes (12 genuine JSDoc inaccuracies from the Phase 1 baseline)

**Wrong/stale `@param` names (7):**
- `core/zod-helpers.ts` — `@param error` → `issue` (param is `issue: $ZodIssue`; also "error"→"issue" in the description).
- `consensus/correlation-persistence.ts` — `@param config` → `_config` (matches the `_config` signature).
- `agents/context-manager-helpers.ts` — removed a stale `@param category` (no such param) and reordered to match the signature.
- `testing/adapters/mock-adapter.ts`, `cli/setup-mcp.ts`, `indexer/entrypoint-cli-extractor.ts`, `indexer/entrypoint-mcp-extractor.ts` — documented params that existed in the signature but were omitted from JSDoc.

**Tags (3):**
- `core/types/prune-strategy.ts` — `@typeParam` → `@template` (plugin-preferred tag).
- `cli/vote-command.ts`, `mcp/tools/orchestrate.ts` — `@internal` carried stray text; made it a bare modifier (merged orchestrate's two adjacent JSDoc blocks).

## Gating

Flips the now-zero accuracy rules to **error**: `check-param-names` (with `checkDestructured:false`), `check-types`, `check-tag-names`, `empty-tags`, `valid-types`, `check-alignment`, `check-property-names`. `no-undefined-types` stays **warn** (10 remaining — mostly `{@link}`-style refs — fixed in a follow-up, then promoted).

## Safety

- JSDoc-only — **no runtime/behavior change**. Lint confirms **0 errors / 10 warnings**.
- Empty changeset (no release impact).

Closes #3518. Part of #3516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)