### PR TITLE
chore(lint): drop redundant jsdoc/no-undefined-types (#3516)

### DIFF
--- a/.changeset/jsdoc-drop-no-undefined-types.md
+++ b/.changeset/jsdoc-drop-no-undefined-types.md
@@ -1,0 +1,11 @@
+---
+---
+
+chore(lint): drop redundant jsdoc/no-undefined-types — JSDoc audit mechanical layer complete
+
+Removes jsdoc/no-undefined-types: in TypeScript, type references are
+import-resolved and enforced by the compiler, so the rule is redundant for
+accuracy; its only signal here was 10 false-positives on legitimate
+`{@link symbol}` navigation references. The JSDoc accuracy ruleset is now fully
+clean (0 violations) with all accuracy rules gating at error. Config-only.
+Epic #3516.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,9 +30,12 @@ export default defineConfig([
       'jsdoc/check-tag-names': 'error',
       'jsdoc/empty-tags': 'error',
       'jsdoc/valid-types': 'error',
-      // WARN: 10 remaining violations (mostly @link-style references); fixed in a
-      // follow-up, then promoted to error.
-      'jsdoc/no-undefined-types': 'warn',
+      // jsdoc/no-undefined-types is intentionally OMITTED: in TypeScript, type
+      // references are import-resolved and already enforced by the compiler
+      // (strictTypeChecked), so the rule is redundant for real accuracy. Its
+      // only signal here was 10 false-positives on legitimate `{@link symbol}`
+      // navigation references (which may point at any symbol, imported or not).
+      // Investigated in the #3518 follow-up — see that PR for the per-site review.
     },
   },
 


### PR DESCRIPTION
Part of epic #3516 — finishes the JSDoc audit **mechanical layer**.

## What

Removes `jsdoc/no-undefined-types` from the eslint config.

## Why (investigated all 10 sites)

Every one of the 10 warnings was a legitimate `{@link symbol}` navigation reference, not a type-annotation inaccuracy:

| File | `{@link}` target |
| --- | --- |
| `composite-router.ts` | `{@link route}` (sibling method) |
| `model-to-cli-adapter.ts` | `{@link createCliToModelAdapter}` |
| `types-capability.ts` | `{@link extractResponse}` (sibling method) |
| `openrouter-models-source.ts` | `{@link AvailableModelsCache}` |
| `tool-memory.ts` ×3 | `{@link getContextForTask}` / backends |
| `expert-bridge.ts` ×2 | `{@link cli}`, `{@link tokensUsed}` (sibling fields) |
| `audit-bridge.ts` | `{@link SecurityAuditSink}` |

In TypeScript, real type references are import-resolved and enforced by the compiler (`strictTypeChecked`), so `no-undefined-types` is **redundant for accuracy**. Its only output here was false-positives on `{@link}` references — which legitimately point at any symbol, imported or not. Keeping it (even at warn) would be 10 permanent false-positives obscuring future real issues. Rewriting 10 correct links to appease a redundant rule would be the wrong fix.

## Result

JSDoc accuracy ruleset is now **fully clean (0 violations)**, with all accuracy rules (`check-param-names`/`check-types`/`check-tag-names`/`empty-tags`/`valid-types`/`check-alignment`/`check-property-names`) gating at **error**. Config-only, no behavior change. Empty changeset.

Part of #3516 (mechanical layer complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)