### PR TITLE
fix(docs): correct two PipelineRunner JSDoc inaccuracies (#3519 pilot)

### DIFF
--- a/.changeset/pipeline-runner-jsdoc-accuracy.md
+++ b/.changeset/pipeline-runner-jsdoc-accuracy.md
@@ -1,0 +1,10 @@
+---
+---
+
+fix(docs): correct two JSDoc inaccuracies in PipelineRunner — JSDoc audit Phase 2 pilot
+
+Fixes `PipelineExecuteOptions.runsDir` (documented default was `getNexusDataDir()/runs`,
+the exact pre-#2889 bug; actual default is `getDefaultRunsDir()` = `nexusDataPath('runs')`)
+and `retryFailed` (doc claimed "re-executes only the failed/skipped steps" but the code
+re-runs the full pipeline with continueOnFailure — the inline comment confirms it).
+JSDoc-only, no behavior change. Epic #3516 / #3519.

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -77,7 +77,11 @@ export interface PipelineExecuteOptions {
   readonly continueOnFailure?: boolean;
   /** EventBus for trace persistence. When provided, creates a TraceWriter. */
   readonly eventBus?: IEventBus;
-  /** Override base directory for trace output (default: `<getNexusDataDir()>/runs`). */
+  /**
+   * Override base directory for trace output. Default: `getDefaultRunsDir()`,
+   * i.e. `nexusDataPath('runs')` — per-repo aware. NOT `getNexusDataDir()/runs`,
+   * which bypassed per-repo routing (#2889).
+   */
   readonly runsDir?: string;
 }
 
@@ -149,8 +153,14 @@ export class PipelineRunner {
   }
 
   /**
-   * Re-executes only the failed/skipped steps from a previous result.
-   * Requires the original pipeline and a result with stepResults.
+   * Retries a previous run that had failed or skipped steps by re-executing the
+   * pipeline with `continueOnFailure` enabled, returning the combined result.
+   * Returns `previousResult` unchanged when it has no `stepResults` or nothing
+   * failed/skipped.
+   *
+   * NOTE: the underlying graph executor re-runs **all** nodes, not only the
+   * failed ones — selective per-step retry is not yet modeled. The failed/skipped
+   * ids are used only to decide *whether* to retry, not *which* steps run.
    */
   async retryFailed(
     pipeline: CompiledPipeline,


### PR DESCRIPTION
Part of epic #3516 — **Phase 2 semantic-accuracy pilot** (#3519) on one canonical module (`pipeline/pipeline-runner.ts`).

## Findings (both adversarially verified)

**1. `PipelineExecuteOptions.runsDir` default was wrong (and was the documented bug).**
Doc said the default is `<getNexusDataDir()>/runs`. The actual default is `getDefaultRunsDir()` → `nexusDataPath('runs')` (per-repo aware). The documented value is the *exact pre-#2889 behavior* that #2889 fixed — the sibling `getDefaultRunsDir` JSDoc explicitly says it is **not** `join(getNexusDataDir(), 'runs')`. Corrected.

**2. `retryFailed` doc overstated selectivity.**
Doc: "Re-executes only the failed/skipped steps." Code: re-runs the **full pipeline** via `this.execute(..., { continueOnFailure: true })` — the inline comment confirms "the graph executor will re-run all nodes." The `failedIds` set is used only to decide *whether* to retry, not *which* steps run. Clarified to describe actual behavior + the not-yet-modeled selective retry.

## Method (the Phase 2 pattern, validated)

Read the module, compared each JSDoc claim to the implementation, kept only mismatches I could verify by re-reading the cited lines and tracing the code. The pilot found **2 real prose-level inaccuracies in a 347-line module** — the kind the linter can't catch — which calibrates the fan-out: worth doing across the shipped surface, ~1-2 findings per canonical module.

JSDoc-only, no behavior change; lint clean (accuracy rules at error).

Part of #3516 / #3519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)