### PR TITLE
fix(docs): correct CLI/routing-arm + allEntries JSDoc drift (#3519 wave 1)

### DIFF
--- a/.changeset/jsdoc-wave1-router-registry.md
+++ b/.changeset/jsdoc-wave1-router-registry.md
@@ -1,0 +1,11 @@
+---
+---
+
+fix(docs): correct CLI-vs-routing-arm JSDoc drift in CompositeRouter + allEntries tier list in ModelRegistry (#3519)
+
+CompositeRouter: getCapacityDashboard and getCandidateCliNames docs said "CLIs"
+but both return RoutingArmId (= CliName | ApiArmId, i.e. CLI slots + api:\* arms,
+#3422) — getCapacityDashboard's impl doc had gone stale vs its ITaskRouter
+interface doc. ModelRegistry: allEntries() doc said "in-tree + models.dev +
+manifest (authoritative)" but returns ALL tiers incl. generated, and isn't
+filtered to authoritative. JSDoc-only, no behavior change. Epic #3516 / #3519.

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -651,14 +651,16 @@ export class CompositeRouter implements ICompositeRouter {
   }
 
   /**
-   * (#2540 PR 7) Returns the CLI candidate set for the routing pipeline,
-   * filtered by harness-driven availability when the cache is wired.
+   * (#2540 PR 7) Returns the candidate routing-arm set for the routing pipeline
+   * (`RoutingArmId[]` = CLI slots plus any `api:*` arms, #3422), filtered by
+   * harness-driven availability when the cache is wired. (Name retained for
+   * history; the set is routing arms, not only CLIs.)
    *
    * Filtering rules:
-   *   - No cache configured → return all registered CLI names (prior behaviour).
-   *   - Cache configured → query getAll(); a CLI is excluded only if the
+   *   - No cache configured → return all registered arms (prior behaviour).
+   *   - Cache configured → query getAll(); an arm is excluded only if the
    *     cache reports zero models for it. If the cache returns an empty union
-   *     (cold start, all sources failing), fall back to all registered CLIs
+   *     (cold start, all sources failing), fall back to all registered arms
    *     so the router never wedges on a transient cache miss.
    *   - Errors in the cache do not block routing — log and fall through.
    */
@@ -894,7 +896,9 @@ export class CompositeRouter implements ICompositeRouter {
   }
 
   /**
-   * Get capacity status for all registered CLIs (Issue #807).
+   * Get capacity status for all registered routing arms — CLI slots plus any
+   * `api:*` arms (Issue #807, #3422). Matches the `ITaskRouter` interface doc;
+   * the return key is `RoutingArmId` (`CliName | ApiArmId`), not just CLIs.
    */
   async getCapacityDashboard(): Promise<Map<RoutingArmId, import('./types.js').CapacityStatus>> {
     return fetchCapacityData(this.adapters);

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -221,7 +221,12 @@ export class ModelRegistry {
     return this.lookupExact(modelId) !== undefined;
   }
 
-  /** All authoritative entries (in-tree + models.dev + manifest, deduped). */
+  /**
+   * All loaded entries across every tier (generated + models.dev + in-tree +
+   * manifest), deduped by id (later sources overwrite earlier). This is NOT
+   * filtered to authoritative entries — `models-dev`/`generated` are
+   * catalog-breadth tiers; use `hasAuthoritative()` to tell them apart.
+   */
   allEntries(): readonly ModelEntry[] {
     return [...this.byId.values()];
   }


### PR DESCRIPTION
Part of epic #3516 — **Phase 2 semantic review, wave 1** (#3519). Fanned out across 3 canonical modules; each candidate finding re-verified against the code before fixing.

## Findings (3 confirmed, 2 modules)

**CompositeRouter** (`RoutingArmId = CliName | ApiArmId` — CLI slots + `api:*` arms since #3422):
1. `getCapacityDashboard` (impl ~897) — doc said "all registered **CLIs**" but returns `Map<RoutingArmId, …>`. The `ITaskRouter` interface doc was already corrected to "routing arms (#3422)"; the **impl doc had drifted**. Fixed to match.
2. `getCandidateCliNames` (~654) — doc said "CLI candidate set" / "all registered CLI names" but returns `RoutingArmId[]`. Clarified to routing arms (kept the legacy method name, noted in the doc).

**ModelRegistry**:
3. `allEntries` (~224) — doc said "All **authoritative** entries (in-tree + models.dev + manifest, deduped)" but the constructor also loads `generatedEntries` into `byId` (line 182) and `allEntries()` returns all of `byId`. `getEntry` itself treats `models-dev`/`generated` as non-authoritative breadth tiers. Corrected: returns all tiers (incl. generated), not authoritative-filtered; use `hasAuthoritative()` for that distinction.

**ConsensusEngine** (`consensus/engine.ts`): reviewed (16 public methods/exports traced) — **JSDoc accurate, no findings**.

## Method note

3 subagents read the modules and returned candidates; I verified each against the actual code (`RoutingArmId` union def, `byId` load order, the `getEntry` source-tier logic) before fixing — one candidate count from a subagent was internally inconsistent, which is why findings are re-checked, not trusted.

JSDoc-only, no behavior change; lint clean (accuracy rules at error). Empty changeset.

Part of #3516 / #3519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)