### PR TITLE
feat(graph): add errorCategory + isRetryable to failed NodeResults (#3534 slice 1)

### DIFF
--- a/.changeset/noderesult-retryability.md
+++ b/.changeset/noderesult-retryability.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(graph): classify failed NodeResults with errorCategory + isRetryable (selective-retry foundation)
+
+Failed `NodeResult`s now carry an optional `errorCategory` (5-value taxonomy) and
+derived `isRetryable` (only `transient` is retry-safe by default). The executor
+classifies thrown node errors via `categorizeOutcomeError` → `coarsenFailureCategory`;
+node-not-found → internal, post-step verification failure → business (both
+non-retryable). Additive/optional — no behavior change for existing consumers.
+This is slice 1 of selective-retry (#3534): gives retry logic a safe signal so
+only transient failures are re-run. Part of #3531.

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
@@ -34,6 +34,47 @@ describe('executeGraph', () => {
     });
   });
 
+  describe('failure classification for selective-retry (#3534)', () => {
+    it('marks a transient node failure as retryable', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.reject(new Error('connection timed out')))
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const a = result.value.nodeResults.find((r) => r.nodeId === 'A');
+      expect(a?.status).toBe('failed');
+      expect(a?.errorCategory).toBe('transient');
+      expect(a?.isRetryable).toBe(true);
+    });
+
+    it('marks a non-transient node failure as not retryable', async () => {
+      const graph = new GraphBuilder()
+        .addState('value', overwrite(0))
+        .addNode('A', () => Promise.reject(new Error('permission denied: forbidden')))
+        .addEdge(START, 'A')
+        .addEdge('A', END)
+        .compile();
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const result = await executeGraph(graph.value, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const a = result.value.nodeResults.find((r) => r.nodeId === 'A');
+      expect(a?.status).toBe('failed');
+      expect(a?.isRetryable).toBe(false);
+    });
+  });
+
   describe('fan-out / fan-in', () => {
     it('executes parallel nodes and merges state', async () => {
       const graph = new GraphBuilder()

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -40,8 +40,19 @@ import {
   emitExecutionComplete,
 } from './graph-events.js';
 import { runPreconditions, runVerification } from './graph-hooks.js';
+import { categorizeOutcomeError } from '../outcomes/outcome-types.js';
+import { coarsenFailureCategory, defaultRetryable } from '../../mcp/error-envelope.js';
+import type { ErrorCategory } from '../../mcp/error-envelope.js';
 
 const logger = createLogger({ component: 'GraphExecutor' });
+
+/** Build the retryability fields for a failed NodeResult (#3534). */
+function failureClassification(category: ErrorCategory): {
+  errorCategory: ErrorCategory;
+  isRetryable: boolean;
+} {
+  return { errorCategory: category, isRetryable: defaultRetryable(category) };
+}
 
 // Canonical source: config/timeouts.ts (Issue #1046)
 import { GRAPH_TIMEOUTS } from '../../config/timeouts.js';
@@ -716,6 +727,8 @@ async function executeWithVerification(args: ExecVerifyArgs): Promise<NodeResult
       durationMs: getTimeProvider().now() - startTime,
       status: 'failed',
       error: `Verification failed: ${verifyResult.error ?? 'unknown'}`,
+      // Post-step verification is a domain check — re-running won't change it.
+      ...failureClassification('business'),
     };
   }
 
@@ -744,6 +757,8 @@ async function executeSingleNode(
       durationMs: 0,
       status: 'failed',
       error: `Node '${nodeId}' not found`,
+      // Missing node is a graph-construction bug, not a transient failure.
+      ...failureClassification('internal'),
     };
   }
 
@@ -758,12 +773,16 @@ async function executeSingleNode(
   } catch (error: unknown) {
     const message = getErrorMessage(error);
     logger.warn('Node execution failed', { nodeId, error: message });
+    // Classify the thrown error so selective-retry can gate on it (#3534):
+    // transient (timeout/network/rate-limit) → retryable; others → not.
+    const category = coarsenFailureCategory(categorizeOutcomeError(error));
     return {
       nodeId,
       stateUpdates: {},
       durationMs: getTimeProvider().now() - startTime,
       status: 'failed',
       error: message,
+      ...failureClassification(category),
     };
   }
 }

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 
 import type { Result } from '../../core/index.js';
 import type { ICheckpointStore } from './checkpoint-types.js';
+import type { ErrorCategory } from '../../mcp/error-envelope.js';
 
 // ============================================================================
 // Node Hooks (Issue #994 + #997)
@@ -255,6 +256,17 @@ export interface NodeResult {
   readonly durationMs: number;
   readonly status: 'success' | 'failed' | 'skipped' | 'interrupted';
   readonly error?: string;
+  /**
+   * Coarse failure category for a `failed` result (#3534, selective-retry).
+   * Classifies the failure so retry logic can gate on it; only set on failure.
+   */
+  readonly errorCategory?: ErrorCategory;
+  /**
+   * Whether re-running this failed node is safe (derived from `errorCategory`;
+   * only `transient` is retry-safe by default, #3534). Selective-retry uses
+   * this to re-run transient failures and leave permanent ones alone.
+   */
+  readonly isRetryable?: boolean;
   /** Set when the node returned an Interrupt envelope (#1895). */
   readonly interrupt?: Interrupt;
   /**


### PR DESCRIPTION
First approved capability build under the new mission (#3531 / #3534 slice 1). Selective-retry foundation.

## What
Failed `NodeResult`s now carry two optional fields:
- `errorCategory?: ErrorCategory` — the 5-value taxonomy (`transient`/`validation`/`permission`/`business`/`internal`).
- `isRetryable?: boolean` — derived via `defaultRetryable` (only `transient` is retry-safe by default).

The executor classifies each failure site: thrown-error path → `coarsenFailureCategory(categorizeOutcomeError(error))` (reusing the existing taxonomy + the `ToolErrorEnvelope` retry contract); node-not-found → `internal`; post-step verification failure → `business`.

## Why
Selective-retry (#3534) must only re-run failures that are *safe* to re-run — re-running a permission/validation/business failure just loops or double-acts. This gives the retry logic a principled signal, reusing the same `isRetryable` contract documented for tool errors rather than inventing a new one. Slices 2 (executor skip-succeeded) and 3 (rewire `retryFailed` to be selective + gated) build on this.

## Safety
- **Additive/optional** fields — zero behavior change for existing consumers.
- 165 graph tests pass; **2 new tests** assert transient→retryable and permission→not-retryable through the real executor path.
- typecheck + lint clean. Patch changeset.

Part of #3531, #3534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)