### PR TITLE
feat(graph): add priorResults replay to executeGraph (#3534 slice 2)

### DIFF
--- a/.changeset/executor-prior-results-replay.md
+++ b/.changeset/executor-prior-results-replay.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+feat(graph): add priorResults replay to executeGraph (selective-retry slice 2)
+
+`GraphExecuteOptions.priorResults` lets a caller pass prior NodeResults; the
+executor replays any node with a `success` entry (reusing its stateUpdates so
+downstream state is faithful) instead of re-executing it, while failed/absent
+nodes run fresh. Additive/optional — no behavior change without the option.
+Foundation primitive for `retryFailed` to re-run only failed nodes (slice 3, #3534).

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
@@ -73,6 +73,44 @@ describe('executeGraph', () => {
       expect(a?.status).toBe('failed');
       expect(a?.isRetryable).toBe(false);
     });
+
+    it('replays a prior successful node instead of re-executing it (slice 2)', async () => {
+      let aRuns = 0;
+      const build = (): ReturnType<GraphBuilder['compile']> =>
+        new GraphBuilder()
+          .addState('value', overwrite(0))
+          .addNode('A', () => {
+            aRuns += 1;
+            return Promise.resolve({ value: 1 });
+          })
+          .addNode('B', (state) => Promise.resolve({ value: (state['value'] as number) + 10 }))
+          .addEdge(START, 'A')
+          .addEdge('A', 'B')
+          .addEdge('B', END)
+          .compile();
+
+      const g1 = build();
+      expect(g1.ok).toBe(true);
+      if (!g1.ok) return;
+      const r1 = await executeGraph(g1.value, {});
+      expect(r1.ok).toBe(true);
+      if (!r1.ok) return;
+      expect(aRuns).toBe(1);
+      const aResult = r1.value.nodeResults.find((r) => r.nodeId === 'A');
+      expect(aResult?.status).toBe('success');
+
+      // Re-run, replaying A via priorResults: A's handler must NOT run again,
+      // but its stateUpdates must seed so B still produces the same final state.
+      const g2 = build();
+      expect(g2.ok).toBe(true);
+      if (!g2.ok) return;
+      const prior = new Map(aResult !== undefined ? [['A', aResult]] : []);
+      const r2 = await executeGraph(g2.value, {}, { priorResults: prior });
+      expect(r2.ok).toBe(true);
+      if (!r2.ok) return;
+      expect(aRuns).toBe(1); // replayed, not re-executed
+      expect(r2.value.finalState['value']).toBe(11); // seeded A + ran B
+    });
   });
 
   describe('fan-out / fan-in', () => {

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -749,6 +749,16 @@ async function executeSingleNode(
   nodeCtx: NodeContext,
   options?: GraphExecuteOptions
 ): Promise<NodeResult> {
+  // Selective-retry (#3534): replay a prior successful result instead of
+  // re-executing, so a retry re-runs only the failed/new nodes. Only `success`
+  // is replayed — failed/skipped/interrupted prior results fall through to a
+  // fresh run.
+  const prior = options?.priorResults?.get(nodeId);
+  if (prior?.status === 'success') {
+    logger.debug('Replaying prior successful node result', { nodeId });
+    return prior;
+  }
+
   const node: GraphNode | undefined = graph.nodes.get(nodeId);
   if (node === undefined) {
     return {

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -307,6 +307,15 @@ export interface GraphExecuteOptions {
   readonly timeout?: number;
   readonly maxSteps?: number;
   readonly onNodeComplete?: (result: NodeResult) => void;
+  /**
+   * Prior NodeResults to replay instead of re-executing (#3534, selective-retry).
+   * A node with a `success` entry here is skipped — its result (including
+   * `stateUpdates`) is reused so downstream nodes still see the correct state —
+   * while nodes absent here, or present with a non-`success` status, are
+   * re-executed. Lets `retryFailed` re-run only the failed/skipped nodes while
+   * replaying the prior successes.
+   */
+  readonly priorResults?: ReadonlyMap<string, NodeResult>;
   /** Optional checkpoint store for durable execution (Issue #837). */
   readonly checkpointStore?: ICheckpointStore;
   /** Execution ID for checkpoint grouping. Required with checkpointStore. */


### PR DESCRIPTION
Selective-retry slice 2 (#3534). Builds on slice 1 (#3535, merged).

## What
Adds `GraphExecuteOptions.priorResults?: ReadonlyMap<string, NodeResult>`. In `executeSingleNode`, a node with a **`success`** entry in `priorResults` is **replayed** (its `NodeResult`, including `stateUpdates`, is returned without running the handler); failed/skipped/interrupted/absent nodes run fresh.

## Why
This is the executor primitive that makes true selective-retry possible: re-run a graph reusing prior successes so only the failed nodes (and their dependents) actually execute. Slice 3 will rewire `PipelineRunner.retryFailed` to build `priorResults` from a prior run's successes and gate which failures re-run on the `isRetryable` signal from slice 1.

## Safety
- **Additive/optional** — no behavior change unless `priorResults` is supplied.
- New test asserts a succeeded node's handler does **not** re-run on replay, yet its `stateUpdates` seed so downstream state matches a full run (`value` 11 both runs, `aRuns` stays 1).
- 166 graph tests pass; typecheck + lint clean. Patch changeset.

Part of #3531, #3534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)