### PR TITLE
feat(pipeline): make retryFailed selective + retryability-gated (#3534 slice 3)

### DIFF
--- a/.changeset/retryfailed-selective.md
+++ b/.changeset/retryfailed-selective.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(pipeline): make retryFailed selective + retryability-gated (selective-retry slice 3)
+
+`PipelineRunner.retryFailed` now replays prior successful nodes (via the slice-2
+`priorResults` executor option) so only the failed nodes and their dependents
+re-run, and it only retries when at least one failure is `isRetryable` (transient)
+— permanent failures (validation/permission/business/internal) no longer trigger
+a pointless re-run. `PipelineResult` gains optional `nodeResults` (the raw results,
+carrying the retryability signal). Back-compat: a result without `nodeResults`
+falls back to the prior whole-pipeline retry. Completes #3534 (#3531).

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
@@ -9,6 +9,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { PipelineRunner } from './pipeline-runner.js';
+import type { PipelineResult } from './pipeline-runner.js';
+import type { NodeResult } from '../orchestration/graph/graph-types.js';
 import { EventBus } from './event-bus.js';
 import type { PlanContract, StageSpec, TaskContract } from './task-contract.js';
 
@@ -452,5 +454,40 @@ describe('getDefaultRunsDir', () => {
       else process.env['NEXUS_GITIGNORE_AUTO'] = prevGitignore;
       await rm(repo, { recursive: true, force: true });
     }
+  });
+
+  describe('retryFailed selective + retryability-gated (#3534)', () => {
+    it('does not retry when every failure is non-retryable', async () => {
+      const runner = new PipelineRunner();
+      const compiled = runner.compile(makePlan());
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) return;
+
+      const nodeResults: NodeResult[] = [
+        { nodeId: 'a', stateUpdates: {}, durationMs: 1, status: 'success' },
+        {
+          nodeId: 'b',
+          stateUpdates: {},
+          durationMs: 1,
+          status: 'failed',
+          error: 'invalid input',
+          errorCategory: 'validation',
+          isRetryable: false,
+        },
+      ];
+      const previousResult: PipelineResult = {
+        success: false,
+        stepsExecuted: 2,
+        durationMs: 2,
+        error: 'invalid input',
+        nodeResults,
+      };
+
+      const result = await runner.retryFailed(compiled.value, previousResult, makeTask());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // No retryable failure → returns the previous result unchanged (no re-run).
+      expect(result.value).toBe(previousResult);
+    });
   });
 });

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -45,6 +45,12 @@ export interface PipelineResult {
   readonly error?: string;
   /** Per-step breakdown when continueOnFailure is enabled. */
   readonly stepResults?: readonly StepOutcome[] | undefined;
+  /**
+   * Raw per-node results from the run (#3534). Retained so `retryFailed` can
+   * replay prior successes and re-run only the failed nodes; carries the
+   * `isRetryable` signal used to gate the retry.
+   */
+  readonly nodeResults?: readonly NodeResult[] | undefined;
 }
 
 /** Outcome of a single pipeline step. */
@@ -75,6 +81,11 @@ export interface PipelineExecuteOptions {
   readonly onStageComplete?: (stageId: string) => void;
   /** When true, continue executing independent steps after a failure. */
   readonly continueOnFailure?: boolean;
+  /**
+   * Prior NodeResults to replay (#3534) — succeeded nodes are reused instead of
+   * re-executed. Set by `retryFailed` so a retry re-runs only the failed nodes.
+   */
+  readonly priorResults?: ReadonlyMap<string, NodeResult>;
   /** EventBus for trace persistence. When provided, creates a TraceWriter. */
   readonly eventBus?: IEventBus;
   /**
@@ -153,16 +164,51 @@ export class PipelineRunner {
   }
 
   /**
-   * Retries a previous run that had failed or skipped steps by re-executing the
-   * pipeline with `continueOnFailure` enabled, returning the combined result.
-   * Returns `previousResult` unchanged when it has no `stepResults` or nothing
-   * failed/skipped.
+   * Retries a previous run's failures **selectively** (#3534): prior successful
+   * nodes are replayed (not re-executed) via `priorResults`, so only the failed
+   * nodes and their dependents run again.
    *
-   * NOTE: the underlying graph executor re-runs **all** nodes, not only the
-   * failed ones — selective per-step retry is not yet modeled. The failed/skipped
-   * ids are used only to decide *whether* to retry, not *which* steps run.
+   * Gated on retryability: retries only when at least one *failed* node is
+   * `isRetryable` (transient). If every failure is permanent
+   * (validation/permission/business/internal) it returns `previousResult`
+   * unchanged rather than looping on errors that won't clear.
+   *
+   * Back-compat: a `previousResult` without `nodeResults` (e.g. an older caller)
+   * falls back to the prior whole-pipeline retry gated on `stepResults`.
+   *
+   * NOTE: non-retryable failures that coexist with a retryable one still re-run
+   * (and re-fail) under `continueOnFailure`; pinning them as terminal is a
+   * future refinement.
    */
   async retryFailed(
+    pipeline: CompiledPipeline,
+    previousResult: PipelineResult,
+    task: TaskContract,
+    options?: PipelineExecuteOptions
+  ): Promise<ExecuteResult> {
+    const nodeResults = previousResult.nodeResults;
+    if (nodeResults === undefined) {
+      return this.retryFailedLegacy(pipeline, previousResult, task, options);
+    }
+
+    const anyRetryableFailure = nodeResults.some(
+      (r) => r.status === 'failed' && r.isRetryable === true
+    );
+    if (!anyRetryableFailure) {
+      // Nothing safely retryable — don't loop on permanent failures.
+      return okResult(previousResult);
+    }
+
+    // Replay prior successes; the executor re-runs everything else (the failed
+    // nodes and their dependents).
+    const priorResults = new Map<string, NodeResult>(
+      nodeResults.filter((r) => r.status === 'success').map((r) => [r.nodeId, r])
+    );
+    return this.execute(pipeline, task, { ...options, continueOnFailure: true, priorResults });
+  }
+
+  /** Pre-#3534 whole-pipeline retry, kept for results lacking `nodeResults`. */
+  private async retryFailedLegacy(
     pipeline: CompiledPipeline,
     previousResult: PipelineResult,
     task: TaskContract,
@@ -172,17 +218,10 @@ export class PipelineRunner {
     if (steps === undefined || steps.length === 0) {
       return okResult(previousResult);
     }
-
-    const failedIds = new Set(
-      steps.filter((s) => s.status === 'failed' || s.status === 'skipped').map((s) => s.stepId)
-    );
-
-    if (failedIds.size === 0) {
+    const anyFailed = steps.some((s) => s.status === 'failed' || s.status === 'skipped');
+    if (!anyFailed) {
       return okResult(previousResult);
     }
-
-    // Re-execute the full pipeline with continueOnFailure
-    // The graph executor will re-run all nodes; we report combined results
     return this.execute(pipeline, task, { ...options, continueOnFailure: true });
   }
 }
@@ -199,26 +238,42 @@ function failedResult(startTime: number, error: string): PipelineResult {
   return { success: false, stepsExecuted: 0, durationMs: Date.now() - startTime, error };
 }
 
+/** Builds the per-node-complete callback (extracted to keep buildGraphOptions simple). */
+function makeOnNodeComplete(
+  onStage: ((stageId: string) => void) | undefined,
+  bus: IEventBus | undefined,
+  execId: string
+): (r: NodeResult) => void {
+  return (r) => {
+    onStage?.(r.nodeId);
+    emitStageEvent(bus, execId, r);
+  };
+}
+
+/** Optional GraphExecuteOptions fields, included only when defined (exactOptional-safe). */
+function optionalGraphFields(options?: PipelineExecuteOptions): Partial<GraphExecuteOptions> {
+  const signal = options?.signal;
+  const maxSteps = options?.maxSteps;
+  const priorResults = options?.priorResults;
+  return {
+    ...(signal !== undefined ? { signal } : {}),
+    ...(maxSteps !== undefined ? { maxSteps } : {}),
+    ...(priorResults !== undefined ? { priorResults } : {}),
+  };
+}
+
 function buildGraphOptions(
   pipeline: CompiledPipeline,
   options?: PipelineExecuteOptions
 ): GraphExecuteOptions {
-  const base: GraphExecuteOptions = {
-    timeout: options?.timeout ?? pipeline.plan.timeoutMs,
-  };
-  const signal = options?.signal;
-  const maxSteps = options?.maxSteps;
-  const onStage = options?.onStageComplete;
-  const bus = options?.eventBus;
-  const execId = pipeline.plan.taskId;
   return {
-    ...base,
-    ...(signal !== undefined ? { signal } : {}),
-    ...(maxSteps !== undefined ? { maxSteps } : {}),
-    onNodeComplete: (r) => {
-      onStage?.(r.nodeId);
-      emitStageEvent(bus, execId, r);
-    },
+    timeout: options?.timeout ?? pipeline.plan.timeoutMs,
+    ...optionalGraphFields(options),
+    onNodeComplete: makeOnNodeComplete(
+      options?.onStageComplete,
+      options?.eventBus,
+      pipeline.plan.taskId
+    ),
   };
 }
 
@@ -244,6 +299,7 @@ function toResult(
       stepsExecuted: graphResult.stepsExecuted,
       durationMs,
       error: failedNode?.error ?? 'Stage execution failed',
+      nodeResults: graphResult.nodeResults,
     };
   }
 
@@ -255,6 +311,7 @@ function toResult(
     success: allOk,
     stepsExecuted: graphResult.stepsExecuted,
     durationMs,
+    nodeResults: graphResult.nodeResults,
     ...(continueOnFailure ? { stepResults } : {}),
     ...(!allOk && continueOnFailure
       ? { error: `${String(succeeded)}/${String(total)} steps succeeded` }


### PR DESCRIPTION
**Completes selective-retry (#3534).** Builds on slice 1 (#3535, retryability on NodeResult) + slice 2 (#3537, executor `priorResults` replay).

## What
`PipelineRunner.retryFailed` is now genuinely selective + safe:
- **Selective:** builds `priorResults` from the prior run's *successful* nodes and re-runs with `continueOnFailure` — the executor replays the successes and only the failed nodes (and their dependents) actually run.
- **Gated:** retries only when at least one *failed* node is `isRetryable` (transient). If every failure is permanent (validation/permission/business/internal), it returns `previousResult` unchanged — no more looping on errors that won't clear.
- `PipelineResult` gains optional `nodeResults` (the raw results, carrying the retryability signal `retryFailed` needs).
- **Back-compat:** a `previousResult` without `nodeResults` falls back to the prior whole-pipeline retry (`retryFailedLegacy`).

This replaces the old behavior the JSDoc audit flagged (#3525): the doc claimed "only the failed steps" while the code re-ran everything. Now the doc is true.

## Safety
- 185 pipeline + graph tests pass; new gating test asserts an all-non-retryable failure does **not** re-run.
- typecheck + lint clean (extracted `optionalGraphFields`/`makeOnNodeComplete` to keep complexity in bounds).
- Additive `PipelineResult.nodeResults`; documented limitation: a non-retryable failure coexisting with a retryable one still re-runs under `continueOnFailure` (pinning permanents as terminal is a noted future refinement).

Closes #3534. Part of #3531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)