### PR TITLE
fix(research): coverage-based relevance scoring (#3541)

### DIFF
--- a/.changeset/research-discover-relevance-fix.md
+++ b/.changeset/research-discover-relevance-fix.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+fix(research): relevance scoring no longer filters out all results for long topics (#3541)
+
+`computeRelevanceScore` normalized by `keywords.length * 3` (requiring every keyword
+in both title AND description), so long/compound topics drove every candidate below
+the 0.3 threshold — `research_discover` returned nothing on the default path, breaking
+the loop's research stage. Now scores by keyword **coverage** (`0.8·matched/keywords +
+0.2·titleHits/keywords`, distinct keywords), preserving title-weighting while keeping
+clearly-relevant items above threshold. (The separate arXiv-returns-0 sub-finding in
+#3541 needs live-API investigation and is not addressed here.)

--- a/packages/nexus-agents/src/mcp/tools/research-discover-relevance.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover-relevance.test.ts
@@ -59,6 +59,19 @@ describe('computeRelevanceScore', () => {
     expect(score).toBeGreaterThan(0.5);
   });
 
+  it('keeps clearly-relevant items above threshold for long/compound topics (#3541)', () => {
+    const item = makeItem(
+      'Self-Healing Software Agents for Automated Code Remediation',
+      'A human-in-the-loop system for safe automated remediation with blast-radius control.'
+    );
+    const topic =
+      'autonomous self-healing software agents: safe automated code remediation, human-in-the-loop gating, blast-radius control';
+    const score = computeRelevanceScore(item, topic);
+    // Regression: the old `weightedMatches / (keywords.length * 3)` drove every
+    // result below the 0.3 default for long topics, filtering them all out.
+    expect(score).toBeGreaterThanOrEqual(0.3);
+  });
+
   it('should return 0 when no keywords match title or description', () => {
     const item = makeItem('Quantum Computing Algorithms', 'Novel approaches to qubit entanglement');
 

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -288,29 +288,38 @@ async function discoverFromExtendedSource(
  * Exported for testability.
  */
 export function computeRelevanceScore(item: DiscoveredItem, topic: string): number {
-  const keywords = topic
-    .toLowerCase()
-    .split(/[\s,;+\-/]+/)
-    .filter((w) => w.length >= 3);
+  // Distinct keywords ≥3 chars. Dedupe so a repeated word doesn't skew the denominator.
+  const keywords = [
+    ...new Set(
+      topic
+        .toLowerCase()
+        .split(/[\s,;+\-/]+/)
+        .filter((w) => w.length >= 3)
+    ),
+  ];
 
   if (keywords.length === 0) return 1.0; // No keywords to filter against
 
   const titleLower = item.title.toLowerCase();
   const descLower = item.description.toLowerCase();
 
-  let titleMatches = 0;
-  let descMatches = 0;
+  let matched = 0; // keyword present in title OR description
+  let titleHits = 0; // keyword present in title
 
   for (const keyword of keywords) {
-    if (titleLower.includes(keyword)) titleMatches++;
-    if (descLower.includes(keyword)) descMatches++;
+    const inTitle = titleLower.includes(keyword);
+    if (inTitle || descLower.includes(keyword)) matched++;
+    if (inTitle) titleHits++;
   }
 
-  // Title matches worth 2x, description matches worth 1x
-  const weightedMatches = titleMatches * 2 + descMatches;
-  const maxPossible = keywords.length * 3; // 2 (title) + 1 (desc) per keyword
-
-  return Math.min(1.0, weightedMatches / maxPossible);
+  // Score by COVERAGE — the fraction of distinct topic keywords present — rather
+  // than the old `weightedMatches / (keywords.length * 3)`, which required every
+  // keyword in both title AND description and so drove every item below
+  // threshold for long/compound topics (#3541). Title hits get a bounded bonus
+  // so title matches still outrank description-only matches.
+  const coverage = matched / keywords.length;
+  const titleFraction = titleHits / keywords.length;
+  return Math.min(1.0, coverage * 0.8 + titleFraction * 0.2);
 }
 
 /** Scores and filters items by relevance, returning sorted results. Exported for testability. */


### PR DESCRIPTION
Fixes #3541 (found via live e2e-validation while researching #3540).

## Root cause
`computeRelevanceScore` (research-discover.ts) used:
```
score = (titleMatches*2 + descMatches) / (keywords.length * 3)
```
The denominator assumes **every** topic keyword appears in **both** title and description — impossible — so each added keyword *lowers* the ceiling for every item. A 12-keyword topic caps even a strong match (~half the keywords) at ~0.25, below the **0.3 default threshold** → `research_discover` filtered **all** results (`totalFound: 8, filteredByRelevance: 8, items: []`). The loop's research stage was effectively dead on the default path.

## Fix
Score by keyword **coverage** instead:
```
score = 0.8 * (matched / keywords) + 0.2 * (titleHits / keywords)   // distinct keywords
```
- `matched` = keyword present in title OR description → "fraction of topic concepts found."
- Title hits keep a bounded 0.2 bonus, so title matches still outrank description-only (existing test preserved).
- Long/compound topics no longer self-penalize.

## Verification
- New regression test: the exact long topic that filtered 8/8 now scores ≥ 0.3 for a clearly-relevant item.
- All existing relevance tests pass (they used relative assertions — `>0.5`, `=0`, `=1.0`, title>desc — all preserved). 26 tests pass; typecheck + lint clean.

## Not in scope
The second #3541 sub-finding (arXiv `totalFound: 0` for a simple topic) is a separate query-mapping issue needing live-API investigation — left open on #3541.

Patch. Restores the research stage that #3540 and the research→context loop depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)