### PR TITLE
fix(research): arXiv discovery OR-joins terms + relevance sort (#3543)

### DIFF
--- a/.changeset/arxiv-or-query.md
+++ b/.changeset/arxiv-or-query.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+fix(research): arXiv discovery OR-joins topic terms + sorts by relevance (#3543)
+
+`buildArxivUrl` AND-joined every topic term (`(ti:w1 OR abs:w1) AND (ti:w2 OR abs:w2) …`),
+requiring all terms to co-occur in one paper — so multi-word topics returned 0 arXiv
+results. Now OR-joins terms (any may match) and sorts `sortBy=relevance` (so the fetched
+set is on-topic rather than merely recent); the coverage-based relevance filter (#3542)
+refines downstream. Completes the research_discover repair started in #3542 (the #3543
+arXiv sub-finding split from #3541).

--- a/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
@@ -15,6 +15,7 @@ import {
   discoverArxiv,
   fetchSource,
   scoreRelevance,
+  buildArxivUrl,
 } from './research-helpers-sources.js';
 
 // Mock global fetch
@@ -257,7 +258,7 @@ describe('discoverArxiv', () => {
     expect(calledUrl).not.toContain('all%3A');
   });
 
-  it('should AND-join multi-word topics for keyword matching', async () => {
+  it('should OR-join multi-word topic terms and sort by relevance (#3543)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       text: () => Promise.resolve('<feed></feed>'),
@@ -265,11 +266,13 @@ describe('discoverArxiv', () => {
     await discoverArxiv('agent memory consolidation', 5);
     const calledUrl = mockFetch.mock.calls[0]?.[0] as string;
     const decoded = decodeURIComponent(calledUrl);
-    // Multi-word topics use AND-joined keywords (not phrase matching)
-    expect(decoded).toContain('(ti:agent OR abs:agent)');
-    expect(decoded).toContain('(ti:memory OR abs:memory)');
-    expect(decoded).toContain('(ti:consolidation OR abs:consolidation)');
-    expect(decoded).toContain(' AND ');
+    // Multi-word topics OR-join terms (any may match); coverage-based relevance
+    // scoring refines downstream. AND-joining every term returned 0 results (#3543).
+    expect(decoded).toContain('ti:agent OR abs:agent');
+    expect(decoded).toContain('ti:memory OR abs:memory');
+    expect(decoded).toContain('ti:consolidation OR abs:consolidation');
+    expect(decoded).not.toContain(') AND (ti:');
+    expect(decoded).toContain('sortBy=relevance');
   });
 
   it('should not quote single-word topics', async () => {
@@ -369,4 +372,27 @@ describe('arXiv-based providers', () => {
       });
     });
   }
+
+  describe('buildArxivUrl (#3543)', () => {
+    it('OR-joins multi-word topic terms and sorts by relevance', () => {
+      const url = buildArxivUrl({
+        topic: 'self healing software repair agents',
+        authorFilter: '',
+        maxResults: 8,
+      });
+      const q = new URL(url).searchParams.get('search_query') ?? '';
+      expect(q).toContain('ti:self');
+      expect(q).toContain(' OR ');
+      // Regression: AND-joining the topic terms required all to co-occur and
+      // returned 0 results for normal multi-word topics (#3543).
+      expect(q).not.toContain(') AND (ti:');
+      expect(url).toContain('sortBy=relevance');
+    });
+
+    it('keeps a single-word topic as a ti/abs OR query', () => {
+      const url = buildArxivUrl({ topic: 'agents', authorFilter: '', maxResults: 5 });
+      const q = new URL(url).searchParams.get('search_query') ?? '';
+      expect(q).toBe('(ti:agents OR abs:agents)');
+    });
+  });
 });

--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -222,16 +222,20 @@ interface ArxivQueryOptions {
  * Builds an arXiv API search URL with targeted field queries.
  * Uses ti: (title) and abs: (abstract) instead of all: for better relevance.
  * Optionally adds a submittedDate range filter when sinceDate is provided.
+ *
+ * Exported for testability.
  */
-function buildArxivUrl(opts: ArxivQueryOptions): string {
-  // Use AND-joined keywords for multi-word queries instead of exact phrase matching.
-  // Exact phrases like "multi-agent orchestration consensus voting" rarely appear in papers,
-  // but individual keywords joined with AND return relevant results.
+export function buildArxivUrl(opts: ArxivQueryOptions): string {
+  // OR-join keywords for multi-word queries and let arXiv rank by relevance;
+  // the caller's coverage-based relevance filter (#3542) refines the set.
+  // AND-joining every term required all of them to co-occur in one paper, which
+  // returned 0 results for normal multi-word topics (#3543); and pairing OR with
+  // a date sort would fetch recent-but-off-topic papers, so we sort by relevance.
   const words = opts.topic.split(/\s+/).filter((w) => w.length > 0);
   const topicQuery =
     words.length <= 1
       ? `(ti:${opts.topic} OR abs:${opts.topic})`
-      : `(${words.map((w) => `(ti:${w} OR abs:${w})`).join(' AND ')})`;
+      : `(${words.map((w) => `ti:${w} OR abs:${w}`).join(' OR ')})`;
   let fullQuery = opts.authorFilter !== '' ? `${topicQuery} AND ${opts.authorFilter}` : topicQuery;
 
   // Add date range filter if sinceDate provided (format: YYYYMMDD)
@@ -242,7 +246,7 @@ function buildArxivUrl(opts: ArxivQueryOptions): string {
   }
 
   const encoded = encodeURIComponent(fullQuery);
-  return `https://export.arxiv.org/api/query?search_query=${encoded}&start=0&max_results=${String(opts.maxResults)}&sortBy=submittedDate&sortOrder=descending`;
+  return `https://export.arxiv.org/api/query?search_query=${encoded}&start=0&max_results=${String(opts.maxResults)}&sortBy=relevance&sortOrder=descending`;
 }
 
 /**


### PR DESCRIPTION
Closes #3543 (arXiv sub-finding split from #3541; the relevance-filter half was fixed in #3542). Together these restore `research_discover` for the self-improvement loop.

## Root cause
`buildArxivUrl` (research-helpers-sources.ts) built, for multi-word topics:
```
(ti:w1 OR abs:w1) AND (ti:w2 OR abs:w2) AND … AND (ti:wN OR abs:wN)
```
Requiring **every** term to co-occur in one paper → `totalFound: 0` for normal topics (e.g. "self-healing software automated program repair agents").

## Fix
```
(ti:w1 OR abs:w1 OR ti:w2 OR abs:w2 OR …)   + sortBy=relevance
```
- **OR-join** terms — any may match (mirrors the github query's "let terms drive matching, relevance handles it"). The coverage-based relevance filter (#3542) refines the set.
- **sortBy=relevance** (was `submittedDate`) — with OR, a date sort would fetch recent-but-off-topic papers and the filter would drop them back to ~0; relevance sort fetches the on-topic set. `sinceDate` still bounds recency when callers want it.

## Verification
- Exported `buildArxivUrl`; updated the existing `AND-join` test to the new OR semantics + relevance sort, and added 2 tests (multi-word OR + regression guard against the old `) AND (ti:` pattern; single-word ti/abs).
- 43 sources tests pass; typecheck + lint clean. Patch.

Closes #3543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)