### PR TITLE
feat(orchestration): MetaOrchestrator selection tier (step 1, #3549)

### DIFF
--- a/.changeset/meta-orchestrator-step1.md
+++ b/.changeset/meta-orchestrator-step1.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): add MetaOrchestrator selection tier (step 1)
+
+Introduces `createMetaOrchestrator()` — a thin, deterministic selection tier that, given a goal, picks one `ExecutionStrategy` among the existing specialized pipelines (single-shot / dev-pipeline / pipeline / graph-workflow / orchestrate / consensus / spec / research). It reuses the existing `SharedTaskAnalyzer`, `WorkflowRouter`, and `classifyTask` brains rather than duplicating their logic, and returns a transparent `MetaDecision` (strategy + reasoning + confidence + alternatives + shaping flag + underlying signals) with a `forceStrategy` power-user override. This is the "routing" pattern (select once per task), not a runtime-switching mega-pipeline. Dispatch wiring, decision logging, and learned selection follow in later steps of the epic.

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -105,6 +105,18 @@ export type {
   PatternMetrics,
 } from './workflow-router-types.js';
 
+export {
+  createMetaOrchestrator,
+  strategyFromPattern,
+  strategyFromPipelineType,
+} from './meta-orchestrator.js';
+export type {
+  IMetaOrchestrator,
+  MetaOrchestratorInput,
+  MetaDecision,
+  ExecutionStrategy,
+} from './meta-orchestrator.js';
+
 // Spec Parser (Issue #847)
 export { parseSpec } from './spec-parser.js';
 export type {

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the MetaOrchestrator selection tier (#3549).
+ *
+ * Two layers: pure unit tests of the strategy-mapping helpers, and integration
+ * tests of `select()` driven through the real WorkflowRouter + classifier.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createMetaOrchestrator,
+  strategyFromPattern,
+  strategyFromPipelineType,
+  type ExecutionStrategy,
+  type IMetaOrchestrator,
+} from './meta-orchestrator.js';
+import type { IWorkflowRouter } from './workflow-router.js';
+import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
+import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
+
+describe('strategyFromPattern', () => {
+  const cases: ReadonlyArray<
+    [WorkflowPattern, 'simple' | 'moderate' | 'complex' | 'expert', ExecutionStrategy]
+  > = [
+    ['consensus', 'moderate', 'consensus'],
+    ['graph', 'moderate', 'graph-workflow'],
+    ['wave', 'moderate', 'orchestrate'],
+    ['aflow', 'complex', 'orchestrate'],
+    ['puppeteer', 'moderate', 'orchestrate'],
+    ['sequential', 'simple', 'single-shot'],
+    ['sequential', 'moderate', 'dev-pipeline'],
+    ['sequential', 'expert', 'dev-pipeline'],
+  ];
+  it.each(cases)('pattern %s @ %s → %s', (pattern, complexity, expected) => {
+    expect(strategyFromPattern(pattern, complexity)).toBe(expected);
+  });
+});
+
+describe('strategyFromPipelineType', () => {
+  it('maps each pipeline template to its strategy', () => {
+    expect(strategyFromPipelineType('greenfield')).toBe('spec');
+    expect(strategyFromPipelineType('research')).toBe('research');
+    expect(strategyFromPipelineType('audit')).toBe('pipeline');
+    expect(strategyFromPipelineType('dev')).toBe('dev-pipeline');
+    expect(strategyFromPipelineType('general')).toBe('pipeline');
+  });
+});
+
+/**
+ * A fake router that runs the real analyzer for the `analysis` field but lets a
+ * test pin the pattern / clarification flags deterministically.
+ */
+function fakeRouter(
+  decision: { pattern: WorkflowPattern } & Partial<RoutingDecision>
+): IWorkflowRouter {
+  const analyzer = createSharedTaskAnalyzer();
+  return {
+    route: (signals) => ({
+      pattern: decision.pattern,
+      reasoning: decision.reasoning ?? 'fake',
+      confidence: decision.confidence ?? 0.8,
+      matchedRules: decision.matchedRules ?? ['fake'],
+      alternatives: decision.alternatives ?? [],
+      analysis: decision.analysis ?? analyzer.analyze(signals.description),
+      ...(decision.needsClarification !== undefined
+        ? { needsClarification: decision.needsClarification }
+        : {}),
+      ...(decision.suggestedQuestions !== undefined
+        ? { suggestedQuestions: decision.suggestedQuestions }
+        : {}),
+    }),
+    recordOutcome: () => {},
+    getMetrics: () => [],
+  };
+}
+
+describe('MetaOrchestrator.select — integration via real router', () => {
+  const meta: IMetaOrchestrator = createMetaOrchestrator();
+
+  it('routes an explicit consensus requirement to the consensus strategy', () => {
+    const d = meta.select({
+      goal: 'should we adopt approach A or approach B',
+      signals: { requiresConsensus: true },
+    });
+    expect(d.strategy).toBe('consensus');
+    expect(d.pattern).toBe('consensus');
+  });
+
+  it('routes greenfield scaffolding to the spec strategy', () => {
+    const d = meta.select({ goal: 'scaffold a new cli project from scratch' });
+    expect(d.strategy).toBe('spec');
+    expect(d.pipelineType).toBe('greenfield');
+  });
+
+  it('routes research-heavy work to the research strategy', () => {
+    const d = meta.select({
+      goal: 'research and compare alternative approaches and evaluate the landscape',
+    });
+    expect(d.strategy).toBe('research');
+    expect(d.pipelineType).toBe('research');
+  });
+
+  it('upgrades a sequential audit task to the templated pipeline', () => {
+    const d = meta.select({
+      goal: 'perform a security audit and vulnerability scan',
+      signals: { dependencyStructure: 'linear' },
+    });
+    expect(d.pipelineType).toBe('audit');
+    expect(d.pattern).toBe('sequential');
+    expect(d.strategy).toBe('pipeline');
+  });
+
+  it('routes a DAG dev task to the graph-workflow strategy', () => {
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'dag' },
+    });
+    expect(d.pattern).toBe('graph');
+    expect(d.strategy).toBe('graph-workflow');
+  });
+
+  it('routes independent dev subtasks to the orchestrate strategy', () => {
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'independent' },
+    });
+    expect(d.pattern).toBe('wave');
+    expect(d.strategy).toBe('orchestrate');
+  });
+
+  it('always returns a transparent decision (reasoning + bounded confidence)', () => {
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'dag' },
+    });
+    expect(d.reasoning).toBeTruthy();
+    expect(d.confidence).toBeGreaterThan(0);
+    expect(d.confidence).toBeLessThanOrEqual(1);
+    expect(d.analysis).toBeDefined();
+  });
+
+  it('produces alternatives that are unique and exclude the chosen strategy', () => {
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'dag' },
+    });
+    expect(d.alternatives).not.toContain(d.strategy);
+    expect(new Set(d.alternatives).size).toBe(d.alternatives.length);
+  });
+});
+
+describe('MetaOrchestrator.select — force override', () => {
+  it('honors forceStrategy with full confidence and no shaping', () => {
+    const meta = createMetaOrchestrator();
+    const d = meta.select({ goal: 'literally anything', forceStrategy: 'spec' });
+    expect(d.strategy).toBe('spec');
+    expect(d.confidence).toBe(1);
+    expect(d.needsShaping).toBe(false);
+    expect(d.reasoning).toContain('forced');
+    expect(d.alternatives).not.toContain('spec');
+  });
+});
+
+describe('MetaOrchestrator.select — shaping escalation', () => {
+  it('surfaces needsShaping + questions when the router asks to clarify', () => {
+    const meta = createMetaOrchestrator({
+      router: fakeRouter({
+        pattern: 'sequential',
+        needsClarification: true,
+        suggestedQuestions: ['What quality level is needed?'],
+      }),
+    });
+    const d = meta.select({ goal: 'make it better somehow' });
+    expect(d.needsShaping).toBe(true);
+    expect(d.shapingQuestions).toEqual(['What quality level is needed?']);
+  });
+
+  it('does not flag shaping for a well-specified task', () => {
+    const meta = createMetaOrchestrator();
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'dag' },
+    });
+    expect(d.needsShaping).toBe(false);
+    expect(d.shapingQuestions).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -1,0 +1,316 @@
+/**
+ * nexus-agents/orchestration - MetaOrchestrator (adaptive selection tier)
+ *
+ * One adaptive entry point that, given a goal, SELECTS the right execution
+ * strategy among the existing specialized pipelines — it routes once per task,
+ * it does NOT switch patterns mid-flight and it does NOT execute anything
+ * itself. This is the "routing" pattern (Anthropic, Building Effective Agents):
+ * classify → dispatch to a specialized pipeline, rather than a generalist
+ * mega-pipeline.
+ *
+ * Step 1 (#3549) is a pure, deterministic selection function. It reuses the
+ * existing selection brains — `SharedTaskAnalyzer` (signals), `WorkflowRouter`
+ * (execution pattern), and `classifyTask` (pipeline template) — and maps their
+ * combined output to a single {@link ExecutionStrategy}. Dispatch wiring,
+ * decision logging, and learned selection are later steps of epic #3548.
+ *
+ * @module orchestration/meta-orchestrator
+ * (Source: Issue #3549 — MetaOrchestrator step 1)
+ */
+
+import { createLogger } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+import { classifyTask } from '../pipeline/adaptive-orchestrator.js';
+import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
+import { createWorkflowRouter } from './workflow-router.js';
+import type { IWorkflowRouter } from './workflow-router.js';
+import type { TaskSignals, RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
+import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
+import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
+
+/**
+ * Execution strategies the MetaOrchestrator can select. Each maps to an
+ * existing entry point / engine — the MetaOrchestrator does not introduce a
+ * new execution path, it chooses among the ones that already exist.
+ */
+export type ExecutionStrategy =
+  /** Trivial single-step task → `delegate_to_model`. */
+  | 'single-shot'
+  /** Code change with the dev gate (test/lint/typecheck) → `run_dev_pipeline`. */
+  | 'dev-pipeline'
+  /** Multi-stage templated work (audit/general) → `run_pipeline`. */
+  | 'pipeline'
+  /** DAG / conditional-edge workflow → `run_graph_workflow`. */
+  | 'graph-workflow'
+  /** Pattern-based multi-agent orchestration (wave/aflow/puppeteer) → `orchestrate`. */
+  | 'orchestrate'
+  /** Multi-perspective decision → `consensus_vote`. */
+  | 'consensus'
+  /** Greenfield project from a spec → `execute_spec`. */
+  | 'spec'
+  /** Research-heavy work → the research pipeline. */
+  | 'research';
+
+/** Input to a MetaOrchestrator selection. */
+export interface MetaOrchestratorInput {
+  /** Natural-language goal. */
+  readonly goal: string;
+  /** Optional structural hints forwarded to the workflow router. */
+  readonly signals?: Omit<TaskSignals, 'description'> | undefined;
+  /** Power-user override — bypass selection and force a strategy. */
+  readonly forceStrategy?: ExecutionStrategy | undefined;
+}
+
+/**
+ * The selection result. Always transparent: it carries the chosen strategy
+ * plus the reasoning, confidence, alternatives, and the underlying signals so
+ * the decision is observable (and, in later steps, loggable + learnable).
+ */
+export interface MetaDecision {
+  /** The selected execution strategy. */
+  readonly strategy: ExecutionStrategy;
+  /** Human-readable explanation of why this strategy was selected. */
+  readonly reasoning: string;
+  /** Confidence in the selection (0-1). */
+  readonly confidence: number;
+  /** Other strategies that were plausible, best-first, excluding the chosen one. */
+  readonly alternatives: readonly ExecutionStrategy[];
+  /**
+   * Whether the goal is ambiguous/novel enough to warrant a research→vote
+   * "shape-the-work" phase before executing. The strategy is still selected;
+   * this flags that the selection is low-confidence and escalation is advised.
+   */
+  readonly needsShaping: boolean;
+  /** Clarification questions surfaced when {@link needsShaping} is true. */
+  readonly shapingQuestions?: readonly string[];
+  /** The execution pattern chosen by the workflow router (sub-signal). */
+  readonly pattern: WorkflowPattern;
+  /** The pipeline template chosen by the classifier (sub-signal). */
+  readonly pipelineType: PipelineType;
+  /** Full task analysis from SharedTaskAnalyzer (shared signal). */
+  readonly analysis: TaskAnalysisResult;
+  /** Capability gap report — what's available vs needed. */
+  readonly capabilityGaps?: CapabilityGapReport;
+}
+
+/** Public interface for the MetaOrchestrator. */
+export interface IMetaOrchestrator {
+  /** Selects an execution strategy for a goal. Pure — no side effects, no execution. */
+  select(input: MetaOrchestratorInput): MetaDecision;
+}
+
+/**
+ * Maps a workflow pattern (+ complexity) to the execution strategy that engine
+ * fronts. `sequential` collapses to the lightest engine that fits the
+ * complexity.
+ */
+export function strategyFromPattern(
+  pattern: WorkflowPattern,
+  complexity: TaskAnalysisResult['complexity']
+): ExecutionStrategy {
+  switch (pattern) {
+    case 'consensus':
+      return 'consensus';
+    case 'graph':
+      return 'graph-workflow';
+    case 'wave':
+    case 'aflow':
+    case 'puppeteer':
+      return 'orchestrate';
+    case 'sequential':
+      return complexity === 'simple' ? 'single-shot' : 'dev-pipeline';
+    default: {
+      // Exhaustiveness guard — a new pattern must be mapped explicitly.
+      const _exhaustive: never = pattern;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Maps a pipeline template to the execution strategy that fronts it. */
+export function strategyFromPipelineType(pipelineType: PipelineType): ExecutionStrategy {
+  switch (pipelineType) {
+    case 'greenfield':
+      return 'spec';
+    case 'research':
+      return 'research';
+    case 'audit':
+      return 'pipeline';
+    case 'dev':
+      return 'dev-pipeline';
+    case 'general':
+      return 'pipeline';
+    default: {
+      const _exhaustive: never = pipelineType;
+      return _exhaustive;
+    }
+  }
+}
+
+interface SelectionCore {
+  readonly strategy: ExecutionStrategy;
+  readonly reasoning: string;
+  readonly confidence: number;
+}
+
+/**
+ * The core selection rule. Distinctive pipeline templates (greenfield,
+ * research) and an explicit consensus requirement take precedence over the
+ * structural pattern; otherwise the structural pattern drives the choice, with
+ * the audit template upgrading a plain sequential default to the templated
+ * pipeline.
+ */
+function decideStrategy(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): SelectionCore {
+  const { pattern, analysis } = routing;
+  const { pipelineType } = classification;
+
+  if (pattern === 'consensus') {
+    return {
+      strategy: 'consensus',
+      reasoning: `Consensus pattern selected (${routing.reasoning}) — routing to a multi-perspective vote`,
+      confidence: routing.confidence,
+    };
+  }
+  if (pipelineType === 'greenfield') {
+    return {
+      strategy: 'spec',
+      reasoning: 'Greenfield work detected — routing to a spec-driven build',
+      confidence: classification.confidence,
+    };
+  }
+  if (pipelineType === 'research') {
+    return {
+      strategy: 'research',
+      reasoning: 'Research-heavy work detected — routing to the research pipeline',
+      confidence: classification.confidence,
+    };
+  }
+
+  const patternStrategy = strategyFromPattern(pattern, analysis.complexity);
+  // The audit template is more specific than a plain sequential default.
+  if (
+    pipelineType === 'audit' &&
+    (patternStrategy === 'dev-pipeline' || patternStrategy === 'single-shot')
+  ) {
+    return {
+      strategy: 'pipeline',
+      reasoning: 'Audit work detected — routing to the templated audit pipeline',
+      confidence: classification.confidence,
+    };
+  }
+  return {
+    strategy: patternStrategy,
+    reasoning: `Pattern "${pattern}" → ${patternStrategy} (${routing.reasoning})`,
+    confidence: routing.confidence,
+  };
+}
+
+/** Builds the best-first alternatives list, excluding the chosen strategy. */
+function buildAlternatives(
+  chosen: ExecutionStrategy,
+  routing: RoutingDecision,
+  classification: TaskClassification
+): ExecutionStrategy[] {
+  const candidates: ExecutionStrategy[] = [
+    strategyFromPattern(routing.pattern, routing.analysis.complexity),
+    strategyFromPipelineType(classification.pipelineType),
+    'orchestrate',
+  ];
+  const seen = new Set<ExecutionStrategy>([chosen]);
+  const alternatives: ExecutionStrategy[] = [];
+  for (const c of candidates) {
+    if (!seen.has(c)) {
+      seen.add(c);
+      alternatives.push(c);
+    }
+  }
+  return alternatives;
+}
+
+/** Common sub-signal fields shared by every decision. */
+function subSignals(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): Pick<MetaDecision, 'pattern' | 'pipelineType' | 'analysis' | 'capabilityGaps'> {
+  return {
+    pattern: routing.pattern,
+    pipelineType: classification.pipelineType,
+    analysis: routing.analysis,
+    ...(routing.capabilityGaps !== undefined ? { capabilityGaps: routing.capabilityGaps } : {}),
+  };
+}
+
+function buildForcedDecision(
+  forced: ExecutionStrategy,
+  routing: RoutingDecision,
+  classification: TaskClassification
+): MetaDecision {
+  return {
+    strategy: forced,
+    reasoning: `Strategy forced by caller: ${forced}`,
+    confidence: 1.0,
+    alternatives: buildAlternatives(forced, routing, classification),
+    needsShaping: false,
+    ...subSignals(routing, classification),
+  };
+}
+
+function buildSelectedDecision(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): MetaDecision {
+  const core = decideStrategy(routing, classification);
+  const needsShaping = routing.needsClarification === true;
+  return {
+    strategy: core.strategy,
+    reasoning: core.reasoning,
+    confidence: core.confidence,
+    alternatives: buildAlternatives(core.strategy, routing, classification),
+    needsShaping,
+    ...(needsShaping && routing.suggestedQuestions !== undefined
+      ? { shapingQuestions: routing.suggestedQuestions }
+      : {}),
+    ...subSignals(routing, classification),
+  };
+}
+
+/**
+ * Creates a MetaOrchestrator. Selection is deterministic and reuses the
+ * existing routing/classification logic rather than duplicating it (DRY).
+ *
+ * @param options.logger - optional logger.
+ * @param options.router - optional workflow router (injectable for tests).
+ */
+export function createMetaOrchestrator(options?: {
+  readonly logger?: ILogger | undefined;
+  readonly router?: IWorkflowRouter | undefined;
+}): IMetaOrchestrator {
+  const logger = options?.logger ?? createLogger({ component: 'MetaOrchestrator' });
+  const router = options?.router ?? createWorkflowRouter({ logger });
+
+  return {
+    select(input: MetaOrchestratorInput): MetaDecision {
+      const signals: TaskSignals = { description: input.goal, ...input.signals };
+      const routing = router.route(signals);
+      const classification = classifyTask(input.goal);
+
+      const decision =
+        input.forceStrategy !== undefined
+          ? buildForcedDecision(input.forceStrategy, routing, classification)
+          : buildSelectedDecision(routing, classification);
+
+      logger.info('MetaOrchestrator strategy selected', {
+        strategy: decision.strategy,
+        confidence: decision.confidence,
+        pattern: decision.pattern,
+        pipelineType: decision.pipelineType,
+        needsShaping: decision.needsShaping,
+        forced: input.forceStrategy !== undefined,
+      });
+      return decision;
+    },
+  };
+}


### PR DESCRIPTION
Closes #3549. Part of epic #3548.

## What

A thin, deterministic `MetaOrchestrator` (`src/orchestration/meta-orchestrator.ts`) that, given a goal, selects **one** `ExecutionStrategy` among the existing specialized pipelines — the "routing" pattern (route once per task), **not** a runtime-switching mega-pipeline.

- Reuses `SharedTaskAnalyzer` + `WorkflowRouter` + `classifyTask` (no duplicated routing logic — DRY).
- Returns a transparent `MetaDecision`: `{ strategy, reasoning, confidence, alternatives, needsShaping, shapingQuestions?, pattern, pipelineType, analysis, capabilityGaps }`.
- `forceStrategy` power-user override (confidence 1.0).
- `needsShaping` flag surfaces when the router asks to clarify — the hook for the research→vote "shape-the-work" escalation wired in a later step.
- Pure selection function: **no execution logic, no pattern-switching** (honors the consensus-vote conditions).

## Tests

20 tests, deterministic, no live adapters: full pattern/pipeline-type mapping matrix (unit), plus integration through the real router for consensus/greenfield/research/audit/graph/wave, force override, alternatives invariants, and shaping passthrough.

## Out of scope (later epic steps)

Dispatch wiring to engines (#3549 follow-up), decision logging to OutcomeStore (#3550), shadow-logged learned selection (#3551), enforce (#3552).

## Design provenance

Approved by `consensus_vote` (higher_order, 5/5 voters that ran). Honors: keep it thin, MetaOrchestrator becomes the default + others demoted to force-paths, phase-gate the bandit, transparent selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)