### PR TITLE
fix(task-analysis): sync capability-gap-detector registry with canonical sources (#3553)

### DIFF
--- a/.changeset/fix-capability-gap-registry.md
+++ b/.changeset/fix-capability-gap-registry.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(task-analysis): sync capability-gap-detector registry with canonical sources
+
+The `capability-gap-detector` static registries had drifted: the tool set listed 21 names (doc-comment claimed "20") against 45 actually registered, and the expert set listed 10 against 12. A task requiring a real-but-unlisted tool/expert (e.g. `search_codebase`, `pr_review`, `qa_expert`) would be falsely reported as a capability gap. This was latent today (the routing path only requires a small fixed subset) but becomes a real defect as required-capability inference expands or as the capability-gap ledger (#3555) consumes these reports. Synced both sets to the canonical `REGISTERED_TOOL_NAMES` and `BuiltInExpertTypeSchema`, corrected the misleading doc-comments, and added freshness tests that import the canonical sources and fail CI on future drift.

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.test.ts
@@ -8,6 +8,11 @@ import {
   getAvailableToolCount,
   getAvailableExpertCount,
 } from './capability-gap-detector.js';
+import { REGISTERED_TOOL_NAMES } from '../../mcp/tools/index.js';
+import { BuiltInExpertTypeSchema } from '../../agents/experts/expert-config.js';
+
+/** Canonical expert role names, derived as `{type}_expert` from the type union. */
+const CANONICAL_EXPERT_ROLES = BuiltInExpertTypeSchema.options.map((t) => `${t}_expert`);
 
 // ============================================================================
 // detectCapabilityGaps
@@ -96,64 +101,37 @@ describe('detectCapabilityGaps', () => {
     expect(report.available.experts).toHaveLength(0);
   });
 
-  it('recognizes all 21 MCP tools', () => {
-    const allTools = [
-      'orchestrate',
-      'create_expert',
-      'execute_expert',
-      'run_workflow',
-      'delegate_to_model',
-      'list_experts',
-      'list_workflows',
-      'consensus_vote',
-      'research_query',
-      'research_add',
-      'research_discover',
-      'research_analyze',
-      'research_catalog_review',
-      'memory_query',
-      'memory_stats',
-      'weather_report',
-      'issue_triage',
-      'run_graph_workflow',
-      'execute_spec',
-      'registry_import',
-      'query_trace',
-    ];
-    const report = detectCapabilityGaps({ tools: allTools, experts: [] });
+  it('recognizes a real tool that was previously missing from the registry (#3553)', () => {
+    // `search_codebase` is a registered tool that the stale literal omitted —
+    // it must not be falsely reported as a gap.
+    const report = detectCapabilityGaps({ tools: ['search_codebase', 'pr_review'], experts: [] });
     expect(report.allSatisfied).toBe(true);
-    expect(report.available.tools).toHaveLength(21);
-  });
-
-  it('recognizes all 10 expert roles', () => {
-    const allExperts = [
-      'code_expert',
-      'architecture_expert',
-      'security_expert',
-      'documentation_expert',
-      'testing_expert',
-      'devops_expert',
-      'research_expert',
-      'pm_expert',
-      'ux_expert',
-      'infrastructure_expert',
-    ];
-    const report = detectCapabilityGaps({ tools: [], experts: allExperts });
-    expect(report.allSatisfied).toBe(true);
-    expect(report.available.experts).toHaveLength(10);
+    expect(report.gaps).toHaveLength(0);
   });
 });
 
 // ============================================================================
-// Registry counts
+// Registry freshness — derived from canonical sources, fails on drift (#3553)
 // ============================================================================
 
-describe('registry counts', () => {
-  it('has 21 available tools', () => {
-    expect(getAvailableToolCount()).toBe(21);
+describe('registry freshness vs canonical sources', () => {
+  it('recognizes every registered MCP tool', () => {
+    const report = detectCapabilityGaps({ tools: [...REGISTERED_TOOL_NAMES], experts: [] });
+    expect(report.allSatisfied).toBe(true);
+    expect(report.available.tools).toHaveLength(REGISTERED_TOOL_NAMES.length);
   });
 
-  it('has 10 available experts', () => {
-    expect(getAvailableExpertCount()).toBe(10);
+  it('recognizes every built-in expert role', () => {
+    const report = detectCapabilityGaps({ tools: [], experts: CANONICAL_EXPERT_ROLES });
+    expect(report.allSatisfied).toBe(true);
+    expect(report.available.experts).toHaveLength(CANONICAL_EXPERT_ROLES.length);
+  });
+
+  it('available tool count matches the canonical registry', () => {
+    expect(getAvailableToolCount()).toBe(REGISTERED_TOOL_NAMES.length);
+  });
+
+  it('available expert count matches the canonical expert types', () => {
+    expect(getAvailableExpertCount()).toBe(CANONICAL_EXPERT_ROLES.length);
   });
 });

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
@@ -48,7 +48,16 @@ export interface CapabilityGap {
 // Static Registries — kept in sync with canonical sources
 // ============================================================================
 
-/** All 20 registered MCP tools */
+/**
+ * All registered MCP tool names.
+ *
+ * Kept in lockstep with the canonical `REGISTERED_TOOL_NAMES`
+ * (`src/mcp/tools/index.ts`); a drift here produces false capability gaps.
+ * Enforced by the freshness assertions in `capability-gap-detector.test.ts`
+ * (#3553), which import the canonical list and fail if this set falls behind.
+ * Held as a local literal (not a direct import) to keep this hot-path,
+ * low-level analyzer module free of the MCP tool dependency graph.
+ */
 const AVAILABLE_TOOLS: ReadonlySet<string> = new Set([
   'orchestrate',
   'create_expert',
@@ -60,20 +69,49 @@ const AVAILABLE_TOOLS: ReadonlySet<string> = new Set([
   'consensus_vote',
   'research_query',
   'research_add',
+  'research_add_source',
   'research_discover',
   'research_analyze',
   'research_catalog_review',
+  'research_synthesize',
+  'survey_oss_landscape',
+  'vendor_publishing_audit',
+  'compare_data_feeds',
   'memory_query',
   'memory_stats',
+  'memory_write',
   'weather_report',
   'issue_triage',
   'run_graph_workflow',
   'execute_spec',
   'registry_import',
   'query_trace',
+  'query_task_state',
+  'get_job_result',
+  'list_jobs',
+  'cancel_job',
+  'ci_health_check',
+  'verify_audit_chain',
+  'repo_analyze',
+  'repo_security_plan',
+  'extract_symbols',
+  'search_codebase',
+  'run_dev_pipeline',
+  'run_pipeline',
+  'pr_review',
+  'supply_chain_tradeoff_panel',
+  'improvement_review',
+  'run_quality_gate',
+  'suggest_research_tasks',
+  'list_available_models',
 ]);
 
-/** All 10 expert role names */
+/**
+ * All built-in expert role names (`{type}_expert`).
+ *
+ * Kept in lockstep with `BuiltInExpertTypeSchema` (`src/agents/experts/expert-config.ts`);
+ * enforced by the freshness assertions in `capability-gap-detector.test.ts` (#3553).
+ */
 const AVAILABLE_EXPERTS: ReadonlySet<string> = new Set([
   'code_expert',
   'architecture_expert',
@@ -85,6 +123,8 @@ const AVAILABLE_EXPERTS: ReadonlySet<string> = new Set([
   'pm_expert',
   'ux_expert',
   'infrastructure_expert',
+  'qa_expert',
+  'data-visualization_expert',
 ]);
 
 /** Suggestions for common gaps */


### PR DESCRIPTION
Closes #3553. Unblocks epic #3555 (capability-gap ledger).

## Problem

`capability-gap-detector.ts` hardcoded static registries that had drifted:
- Tools: doc-comment said "All 20", literal listed 21, **45** are actually registered.
- Experts: doc-comment said "All 10", actual is **12** (missing `qa_expert`, `data-visualization_expert`).

`detectCapabilityGaps()` feeds `RoutingDecision.capabilityGaps` (and the pipeline `task-contract`). A task requiring a real-but-unlisted tool/expert would be **falsely reported as a gap**. Latent on today's routing path (it only requires a small fixed subset, all present) but a real defect the moment required-capability inference expands — or the moment the #3555 gap ledger aggregates these reports as a build backlog.

## Fix

- Synced `AVAILABLE_TOOLS` (→ 45) and `AVAILABLE_EXPERTS` (→ 12) to the canonical `REGISTERED_TOOL_NAMES` and `BuiltInExpertTypeSchema`.
- Corrected the misleading doc-comments (per the JSDoc-accuracy rule — they were stale claims).
- Kept local literals rather than importing the heavy MCP/expert modules into this low-level hot-path analyzer (a direct import risks an init-time cycle: detector → mcp/tools/index → core/index → task-analysis → detector). Instead, **freshness tests** import the canonical sources and fail CI if the literals fall behind — same guarantee as the skills/agents index gates.

## Tests

13 tests pass (TDD: added 5 failing freshness/regression tests first, including one proving `search_codebase`/`pr_review` are no longer false gaps). Workflow-router consumer tests pass 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)