### PR TITLE
feat(orchestration): MetaOrchestrator decision logging (step 2, #3550)

### DIFF
--- a/.changeset/meta-orchestrator-step2-logging.md
+++ b/.changeset/meta-orchestrator-step2-logging.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): log MetaOrchestrator selection decisions (step 2)
+
+Every MetaOrchestrator selection now emits a `MetaSelectionRecord` (decision id, goal, chosen strategy, confidence, pattern, pipeline type, alternatives, shaping flag, forced flag, timestamp) to a configurable `MetaDecisionSink`. The default sink writes a structured audit log line; `createRecordingSink()` provides an in-memory bounded buffer for inspection. `MetaDecision` now carries a `decisionId` — the join key a later task outcome references (mirrors `TaskOutcome.routingDecisionId`), the substrate that learned selection (step 3) will mine. Observability only: selection behavior is unchanged. This record type is intentionally distinct from the model-centric `RoutingDecision` in the learning module (strategy selection vs model selection).

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -107,6 +107,8 @@ export type {
 
 export {
   createMetaOrchestrator,
+  createAuditLogSink,
+  createRecordingSink,
   strategyFromPattern,
   strategyFromPipelineType,
 } from './meta-orchestrator.js';
@@ -115,6 +117,9 @@ export type {
   MetaOrchestratorInput,
   MetaDecision,
   ExecutionStrategy,
+  MetaSelectionRecord,
+  MetaDecisionSink,
+  IRecordingMetaDecisionSink,
 } from './meta-orchestrator.js';
 
 // Spec Parser (Issue #847)

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -8,10 +8,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   createMetaOrchestrator,
+  createRecordingSink,
   strategyFromPattern,
   strategyFromPipelineType,
   type ExecutionStrategy,
   type IMetaOrchestrator,
+  type MetaSelectionRecord,
 } from './meta-orchestrator.js';
 import type { IWorkflowRouter } from './workflow-router.js';
 import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
@@ -182,5 +184,59 @@ describe('MetaOrchestrator.select — shaping escalation', () => {
     });
     expect(d.needsShaping).toBe(false);
     expect(d.shapingQuestions).toBeUndefined();
+  });
+});
+
+describe('MetaOrchestrator.select — decision logging (step 2, #3550)', () => {
+  it('emits one record per selection to the configured sink', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    meta.select({ goal: 'implement the feature', signals: { dependencyStructure: 'dag' } });
+    meta.select({ goal: 'research and compare alternative approaches and evaluate the landscape' });
+    expect(sink.getRecords()).toHaveLength(2);
+  });
+
+  it('records the decision id, strategy, signals, and forced flag', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    const d = meta.select({
+      goal: 'implement the feature',
+      signals: { dependencyStructure: 'dag' },
+    });
+    const rec = sink.getRecords()[0] as MetaSelectionRecord;
+    expect(rec.decisionId).toBe(d.decisionId);
+    expect(rec.strategy).toBe(d.strategy);
+    expect(rec.pattern).toBe(d.pattern);
+    expect(rec.pipelineType).toBe(d.pipelineType);
+    expect(rec.alternatives).toEqual(d.alternatives);
+    expect(rec.needsShaping).toBe(d.needsShaping);
+    expect(rec.forced).toBe(false);
+    expect(rec.goal).toBe('implement the feature');
+    expect(() => new Date(rec.timestamp).toISOString()).not.toThrow();
+  });
+
+  it('flags forced=true in the record when the strategy is forced', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    meta.select({ goal: 'anything', forceStrategy: 'spec' });
+    expect(sink.getRecords()[0]?.forced).toBe(true);
+  });
+
+  it('assigns a unique decisionId per selection', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    const a = meta.select({ goal: 'implement the feature' });
+    const b = meta.select({ goal: 'implement the feature' });
+    expect(a.decisionId).not.toBe(b.decisionId);
+    expect(a.decisionId).toBeTruthy();
+  });
+
+  it('bounds the recording buffer to its max', () => {
+    const sink = createRecordingSink(3);
+    const meta = createMetaOrchestrator({ sink });
+    for (let i = 0; i < 5; i++) meta.select({ goal: `implement feature ${String(i)}` });
+    expect(sink.getRecords()).toHaveLength(3);
+    // Oldest evicted — last goal retained.
+    expect(sink.getRecords().at(-1)?.goal).toBe('implement feature 4');
   });
 });

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -18,7 +18,8 @@
  * (Source: Issue #3549 — MetaOrchestrator step 1)
  */
 
-import { createLogger } from '../core/index.js';
+import { randomUUID } from 'node:crypto';
+import { createLogger, getTimeProvider } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
 import { classifyTask } from '../pipeline/adaptive-orchestrator.js';
 import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
@@ -67,6 +68,12 @@ export interface MetaOrchestratorInput {
  * the decision is observable (and, in later steps, loggable + learnable).
  */
 export interface MetaDecision {
+  /**
+   * Unique id for this selection decision. The join key a later task outcome
+   * references (mirrors `TaskOutcome.routingDecisionId`) so selection can be
+   * correlated with results when learned selection lands (epic #3548 step 3+).
+   */
+  readonly decisionId: string;
   /** The selected execution strategy. */
   readonly strategy: ExecutionStrategy;
   /** Human-readable explanation of why this strategy was selected. */
@@ -95,8 +102,89 @@ export interface MetaDecision {
 
 /** Public interface for the MetaOrchestrator. */
 export interface IMetaOrchestrator {
-  /** Selects an execution strategy for a goal. Pure — no side effects, no execution. */
+  /**
+   * Selects an execution strategy for a goal. Selection itself is deterministic;
+   * as of epic #3548 step 2 it also emits a {@link MetaSelectionRecord} to the
+   * configured {@link MetaDecisionSink} for observability (the substrate learned
+   * selection mines). It does not execute the strategy.
+   */
   select(input: MetaOrchestratorInput): MetaDecision;
+}
+
+/**
+ * An observability record of one selection decision. Distinct from the
+ * model-routing `RoutingDecision` in the learning module — that captures which
+ * *model* a stage router picked; this captures which *strategy* the
+ * MetaOrchestrator picked. Logging it (not the outcome) is step 2's deliverable;
+ * the decision→outcome correlation lands once dispatch wiring exists.
+ */
+export interface MetaSelectionRecord {
+  /** Matches the {@link MetaDecision.decisionId} of the decision it records. */
+  readonly decisionId: string;
+  /** ISO timestamp of the decision. */
+  readonly timestamp: string;
+  /** The goal that was routed. */
+  readonly goal: string;
+  /** The selected strategy. */
+  readonly strategy: ExecutionStrategy;
+  /** Confidence in the selection (0-1). */
+  readonly confidence: number;
+  /** The underlying workflow pattern. */
+  readonly pattern: WorkflowPattern;
+  /** The underlying pipeline template. */
+  readonly pipelineType: PipelineType;
+  /** Alternatives that were considered. */
+  readonly alternatives: readonly ExecutionStrategy[];
+  /** Whether the decision was flagged for a shape-the-work escalation. */
+  readonly needsShaping: boolean;
+  /** Whether the strategy was forced by the caller (vs selected). */
+  readonly forced: boolean;
+}
+
+/** A sink that receives every selection decision for observability. */
+export interface MetaDecisionSink {
+  /** Records one selection decision. Must not throw (observability is best-effort). */
+  record(record: MetaSelectionRecord): void;
+}
+
+/** A {@link MetaDecisionSink} that also exposes its buffered records for inspection. */
+export interface IRecordingMetaDecisionSink extends MetaDecisionSink {
+  /** Returns the buffered records, oldest first. */
+  getRecords(): readonly MetaSelectionRecord[];
+}
+
+/** Default cap for the in-memory recording sink, matching WorkflowRouter's buffer. */
+const DEFAULT_MAX_RECORDS = 200;
+
+/**
+ * Creates a sink that emits each decision as a structured audit log line.
+ * This is the MetaOrchestrator's default sink.
+ */
+export function createAuditLogSink(logger: ILogger): MetaDecisionSink {
+  return {
+    record(record: MetaSelectionRecord): void {
+      logger.info('MetaOrchestrator selection decision', { ...record });
+    },
+  };
+}
+
+/**
+ * Creates an in-memory recording sink with a bounded buffer (oldest evicted).
+ * The queryable observability surface that learned selection (step 3) reads.
+ */
+export function createRecordingSink(maxRecords = DEFAULT_MAX_RECORDS): IRecordingMetaDecisionSink {
+  const records: MetaSelectionRecord[] = [];
+  return {
+    record(record: MetaSelectionRecord): void {
+      records.push(record);
+      if (records.length > maxRecords) {
+        records.splice(0, records.length - maxRecords);
+      }
+    },
+    getRecords(): readonly MetaSelectionRecord[] {
+      return records;
+    },
+  };
 }
 
 /**
@@ -247,7 +335,7 @@ function buildForcedDecision(
   forced: ExecutionStrategy,
   routing: RoutingDecision,
   classification: TaskClassification
-): MetaDecision {
+): Omit<MetaDecision, 'decisionId'> {
   return {
     strategy: forced,
     reasoning: `Strategy forced by caller: ${forced}`,
@@ -261,7 +349,7 @@ function buildForcedDecision(
 function buildSelectedDecision(
   routing: RoutingDecision,
   classification: TaskClassification
-): MetaDecision {
+): Omit<MetaDecision, 'decisionId'> {
   const core = decideStrategy(routing, classification);
   const needsShaping = routing.needsClarification === true;
   return {
@@ -277,19 +365,44 @@ function buildSelectedDecision(
   };
 }
 
+/** Maps a finished decision to its observability record. */
+function toRecord(
+  decision: MetaDecision,
+  goal: string,
+  forced: boolean,
+  timestamp: string
+): MetaSelectionRecord {
+  return {
+    decisionId: decision.decisionId,
+    timestamp,
+    goal,
+    strategy: decision.strategy,
+    confidence: decision.confidence,
+    pattern: decision.pattern,
+    pipelineType: decision.pipelineType,
+    alternatives: decision.alternatives,
+    needsShaping: decision.needsShaping,
+    forced,
+  };
+}
+
 /**
  * Creates a MetaOrchestrator. Selection is deterministic and reuses the
- * existing routing/classification logic rather than duplicating it (DRY).
+ * existing routing/classification logic rather than duplicating it (DRY). Each
+ * selection is emitted to the decision sink for observability (step 2, #3550).
  *
  * @param options.logger - optional logger.
  * @param options.router - optional workflow router (injectable for tests).
+ * @param options.sink - optional decision sink (default: audit-log sink).
  */
 export function createMetaOrchestrator(options?: {
   readonly logger?: ILogger | undefined;
   readonly router?: IWorkflowRouter | undefined;
+  readonly sink?: MetaDecisionSink | undefined;
 }): IMetaOrchestrator {
   const logger = options?.logger ?? createLogger({ component: 'MetaOrchestrator' });
   const router = options?.router ?? createWorkflowRouter({ logger });
+  const sink = options?.sink ?? createAuditLogSink(logger);
 
   return {
     select(input: MetaOrchestratorInput): MetaDecision {
@@ -297,18 +410,24 @@ export function createMetaOrchestrator(options?: {
       const routing = router.route(signals);
       const classification = classifyTask(input.goal);
 
-      const decision =
+      const forced = input.forceStrategy !== undefined;
+      const base =
         input.forceStrategy !== undefined
           ? buildForcedDecision(input.forceStrategy, routing, classification)
           : buildSelectedDecision(routing, classification);
+      const decision: MetaDecision = { ...base, decisionId: randomUUID() };
+
+      const timestamp = new Date(getTimeProvider().now()).toISOString();
+      sink.record(toRecord(decision, input.goal, forced, timestamp));
 
       logger.info('MetaOrchestrator strategy selected', {
+        decisionId: decision.decisionId,
         strategy: decision.strategy,
         confidence: decision.confidence,
         pattern: decision.pattern,
         pipelineType: decision.pipelineType,
         needsShaping: decision.needsShaping,
-        forced: input.forceStrategy !== undefined,
+        forced,
       });
       return decision;
     },


### PR DESCRIPTION
Closes #3550. Part of epic #3548.

## What

Makes MetaOrchestrator selection **observable** before making it learned.

- New `MetaSelectionRecord` — decision id, goal, strategy, confidence, pattern, pipelineType, alternatives, needsShaping, forced, timestamp.
- New `MetaDecisionSink` interface; `select()` emits one record per decision.
  - Default sink: `createAuditLogSink(logger)` — a structured audit log line.
  - `createRecordingSink(max?)` — in-memory bounded buffer with `getRecords()`, the queryable surface step 3 reads.
- `MetaDecision` gains `decisionId` — the join key a later `TaskOutcome` references (mirrors `TaskOutcome.routingDecisionId`).

## Design note

This record type is **intentionally distinct** from the learning module's `RoutingDecision`, which is model-centric (`selectedModel` required, `routerType` a closed enum of model-stage routers). Strategy selection is an orthogonal dimension; folding it into the model-routing type would pollute that learning loop. The decision→outcome correlation (writing a `TaskOutcome` to the OutcomeStore) lands with dispatch wiring, since there is no execution outcome to record until the MetaOrchestrator actually dispatches — tracked for step 3 (#3551).

## Tests

25 tests pass (20 step-1 regression + 5 new: one-record-per-select, field fidelity, forced flag, unique ids, bounded buffer). Observability only — no selection-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)