### PR TITLE
feat(orchestration): MetaDispatcher with decision-keyed outcome recording (#3559)

### DIFF
--- a/.changeset/meta-dispatcher.md
+++ b/.changeset/meta-dispatcher.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): add MetaDispatcher with decision-keyed outcome recording
+
+Adds `createMetaDispatcher()` — executes the strategy a `MetaDecision` selected and records the result as a dedicated `MetaOutcomeRecord` keyed by `decisionId`. The dispatcher takes an injected per-strategy executor map so the orchestration core stays free of the engine/MCP dependency graph (cycle-safe); real engine executors are wired in later by the outward-facing entry point. Strategy-level outcomes get their own record type rather than reusing the orchestration/learning `TaskOutcome` types (both of which require CLI/model fields a strategy spanning many CLIs cannot supply) — joining selection records with these by `decisionId` gives learned selection an uncontaminated dataset. Fails closed: a missing executor or a throwing executor records a failure outcome and rejects with a typed `MetaDispatchError` (never silent). Includes audit-log and in-memory recording outcome sinks.

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -122,6 +122,23 @@ export type {
   IRecordingMetaDecisionSink,
 } from './meta-orchestrator.js';
 
+export {
+  createMetaDispatcher,
+  createAuditLogOutcomeSink,
+  createRecordingOutcomeSink,
+  MetaDispatchError,
+} from './meta-dispatcher.js';
+export type {
+  IMetaDispatcher,
+  StrategyExecutor,
+  StrategyExecutorMap,
+  MetaOutcomeRecord,
+  MetaOutcomeSink,
+  IRecordingMetaOutcomeSink,
+  DispatchResult,
+  MetaDispatchErrorCode,
+} from './meta-dispatcher.js';
+
 // Spec Parser (Issue #847)
 export { parseSpec } from './spec-parser.js';
 export type {

--- a/packages/nexus-agents/src/orchestration/meta-dispatcher.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-dispatcher.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the MetaDispatcher (#3559).
+ *
+ * Uses fake executors and a recording outcome sink — deterministic, no live
+ * adapters. Decisions come from the real MetaOrchestrator so the join key
+ * (`decisionId`) is exercised end to end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createMetaDispatcher,
+  createRecordingOutcomeSink,
+  MetaDispatchError,
+  type StrategyExecutorMap,
+} from './meta-dispatcher.js';
+import { createMetaOrchestrator, type MetaDecision } from './meta-orchestrator.js';
+
+function decisionFor(
+  goal: string,
+  signals?: Parameters<ReturnType<typeof createMetaOrchestrator>['select']>[0]['signals']
+): MetaDecision {
+  return createMetaOrchestrator().select({ goal, ...(signals ? { signals } : {}) });
+}
+
+describe('MetaDispatcher.dispatch', () => {
+  it('runs the matching executor and returns its result', async () => {
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const executors: StrategyExecutorMap = {
+      [decision.strategy]: () => Promise.resolve({ ok: true }),
+    };
+    const sink = createRecordingOutcomeSink();
+    const dispatcher = createMetaDispatcher({ executors, outcomeSink: sink });
+
+    const result = await dispatcher.dispatch(decision, { goal: 'implement the feature' });
+    expect(result.result).toEqual({ ok: true });
+    expect(result.strategy).toBe(decision.strategy);
+    expect(result.decisionId).toBe(decision.decisionId);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records exactly one success outcome keyed by decisionId', async () => {
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const executors: StrategyExecutorMap = { [decision.strategy]: () => Promise.resolve('done') };
+    const sink = createRecordingOutcomeSink();
+    const dispatcher = createMetaDispatcher({ executors, outcomeSink: sink });
+
+    await dispatcher.dispatch(decision, { goal: 'implement the feature' });
+    const outcomes = sink.getOutcomes();
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]?.decisionId).toBe(decision.decisionId);
+    expect(outcomes[0]?.success).toBe(true);
+    expect(outcomes[0]?.strategy).toBe(decision.strategy);
+    expect(outcomes[0]?.failureReason).toBeUndefined();
+  });
+
+  it('fails closed with a typed error when no executor is registered', async () => {
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const sink = createRecordingOutcomeSink();
+    const dispatcher = createMetaDispatcher({ executors: {}, outcomeSink: sink });
+
+    await expect(
+      dispatcher.dispatch(decision, { goal: 'implement the feature' })
+    ).rejects.toBeInstanceOf(MetaDispatchError);
+    const outcomes = sink.getOutcomes();
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]?.success).toBe(false);
+    expect(outcomes[0]?.failureReason).toContain('No executor');
+  });
+
+  it('sets the no_executor error code', async () => {
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const dispatcher = createMetaDispatcher({ executors: {} });
+    await dispatcher.dispatch(decision, { goal: 'implement the feature' }).then(
+      () => expect.fail('should have thrown'),
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(MetaDispatchError);
+        expect((err as MetaDispatchError).code).toBe('no_executor');
+        expect((err as MetaDispatchError).decisionId).toBe(decision.decisionId);
+      }
+    );
+  });
+
+  it('records a failure outcome and rethrows when the executor throws', async () => {
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const executors: StrategyExecutorMap = {
+      [decision.strategy]: () => Promise.reject(new Error('engine exploded')),
+    };
+    const sink = createRecordingOutcomeSink();
+    const dispatcher = createMetaDispatcher({ executors, outcomeSink: sink });
+
+    await dispatcher.dispatch(decision, { goal: 'implement the feature' }).then(
+      () => expect.fail('should have thrown'),
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(MetaDispatchError);
+        expect((err as MetaDispatchError).code).toBe('executor_failed');
+      }
+    );
+    const outcomes = sink.getOutcomes();
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]?.success).toBe(false);
+    expect(outcomes[0]?.failureReason).toContain('engine exploded');
+  });
+
+  it('bounds the recording outcome buffer', async () => {
+    const sink = createRecordingOutcomeSink(2);
+    const decision = decisionFor('implement the feature', { dependencyStructure: 'dag' });
+    const executors: StrategyExecutorMap = { [decision.strategy]: () => Promise.resolve(1) };
+    const dispatcher = createMetaDispatcher({ executors, outcomeSink: sink });
+
+    for (let i = 0; i < 4; i++)
+      await dispatcher.dispatch(decision, { goal: 'implement the feature' });
+    expect(sink.getOutcomes()).toHaveLength(2);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/meta-dispatcher.ts
+++ b/packages/nexus-agents/src/orchestration/meta-dispatcher.ts
@@ -1,0 +1,215 @@
+/**
+ * nexus-agents/orchestration - MetaDispatcher
+ *
+ * Executes the strategy a {@link MetaDecision} selected and records the result.
+ * Kept separate from the MetaOrchestrator on purpose: the orchestrator stays a
+ * thin, pure selector; the dispatcher owns execution. To stay free of the MCP
+ * tool dependency graph (and the init-time cycle it would create), the
+ * dispatcher does NOT import the engine handlers — the caller injects a
+ * per-strategy executor map. Real engine executors are wired in by the
+ * outward-facing entry point (a separate, owner-approved sub-step of #3548).
+ *
+ * Outcomes are recorded as a dedicated {@link MetaOutcomeRecord} keyed by
+ * `decisionId` rather than reusing the orchestration/learning `TaskOutcome`
+ * types — both of those require CLI/model fields that a strategy-level outcome
+ * (which may span many CLIs/models) cannot supply. Joining selection records
+ * (#3550) with these outcome records by `decisionId` gives step 3 an
+ * uncontaminated dataset.
+ *
+ * @module orchestration/meta-dispatcher
+ * (Source: Issue #3559 — MetaOrchestrator dispatch wiring)
+ */
+
+import { createLogger, getTimeProvider } from '../core/index.js';
+import type { ILogger } from '../core/index.js';
+import type {
+  ExecutionStrategy,
+  MetaDecision,
+  MetaOrchestratorInput,
+} from './meta-orchestrator.js';
+
+/**
+ * Executes one strategy. Receives the decision and the original input; returns
+ * whatever the underlying engine produces. May throw — the dispatcher records
+ * the failure and rethrows a {@link MetaDispatchError}.
+ */
+export type StrategyExecutor = (
+  decision: MetaDecision,
+  input: MetaOrchestratorInput
+) => Promise<unknown>;
+
+/** Per-strategy executor map. Strategies without an executor fail closed. */
+export type StrategyExecutorMap = Partial<Record<ExecutionStrategy, StrategyExecutor>>;
+
+/** An observability record of one strategy execution, keyed by decision id. */
+export interface MetaOutcomeRecord {
+  /** Matches {@link MetaDecision.decisionId}. */
+  readonly decisionId: string;
+  /** ISO timestamp of when the outcome was recorded. */
+  readonly timestamp: string;
+  /** The strategy that was executed. */
+  readonly strategy: ExecutionStrategy;
+  /** Whether execution succeeded. */
+  readonly success: boolean;
+  /** Wall-clock execution duration in milliseconds. */
+  readonly durationMs: number;
+  /** Failure reason when {@link success} is false. */
+  readonly failureReason?: string;
+}
+
+/** A sink that receives every execution outcome. */
+export interface MetaOutcomeSink {
+  /** Records one outcome. Must not throw (observability is best-effort). */
+  recordOutcome(record: MetaOutcomeRecord): void;
+}
+
+/** A {@link MetaOutcomeSink} that also exposes its buffered outcomes. */
+export interface IRecordingMetaOutcomeSink extends MetaOutcomeSink {
+  /** Returns the buffered outcomes, oldest first. */
+  getOutcomes(): readonly MetaOutcomeRecord[];
+}
+
+/** Result of a successful dispatch. */
+export interface DispatchResult {
+  /** The decision that was dispatched. */
+  readonly decisionId: string;
+  /** The strategy that executed. */
+  readonly strategy: ExecutionStrategy;
+  /** Execution duration in milliseconds. */
+  readonly durationMs: number;
+  /** The raw result returned by the strategy executor. */
+  readonly result: unknown;
+}
+
+/** Reason codes for a dispatch failure. */
+export type MetaDispatchErrorCode = 'no_executor' | 'executor_failed';
+
+/** Typed error thrown when dispatch fails. An outcome is always recorded first. */
+export class MetaDispatchError extends Error {
+  readonly code: MetaDispatchErrorCode;
+  readonly strategy: ExecutionStrategy;
+  readonly decisionId: string;
+
+  constructor(
+    code: MetaDispatchErrorCode,
+    strategy: ExecutionStrategy,
+    decisionId: string,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'MetaDispatchError';
+    this.code = code;
+    this.strategy = strategy;
+    this.decisionId = decisionId;
+  }
+}
+
+const DEFAULT_MAX_OUTCOMES = 200;
+
+/** Creates a sink that emits each outcome as a structured audit log line. */
+export function createAuditLogOutcomeSink(logger: ILogger): MetaOutcomeSink {
+  return {
+    recordOutcome(record: MetaOutcomeRecord): void {
+      logger.info('MetaDispatcher execution outcome', { ...record });
+    },
+  };
+}
+
+/** Creates an in-memory recording outcome sink with a bounded buffer. */
+export function createRecordingOutcomeSink(
+  maxOutcomes = DEFAULT_MAX_OUTCOMES
+): IRecordingMetaOutcomeSink {
+  const outcomes: MetaOutcomeRecord[] = [];
+  return {
+    recordOutcome(record: MetaOutcomeRecord): void {
+      outcomes.push(record);
+      if (outcomes.length > maxOutcomes) {
+        outcomes.splice(0, outcomes.length - maxOutcomes);
+      }
+    },
+    getOutcomes(): readonly MetaOutcomeRecord[] {
+      return outcomes;
+    },
+  };
+}
+
+/** Public interface for the MetaDispatcher. */
+export interface IMetaDispatcher {
+  /**
+   * Executes the decision's strategy via its injected executor, recording an
+   * outcome keyed by `decisionId`. Resolves with a {@link DispatchResult} on
+   * success; rejects with a {@link MetaDispatchError} on failure (after the
+   * failure outcome is recorded — fail closed, never silent).
+   */
+  dispatch(decision: MetaDecision, input: MetaOrchestratorInput): Promise<DispatchResult>;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Creates a MetaDispatcher.
+ *
+ * @param options.executors - per-strategy executor map (injected; required).
+ * @param options.outcomeSink - outcome sink (default: audit-log sink).
+ * @param options.logger - optional logger.
+ */
+export function createMetaDispatcher(options: {
+  readonly executors: StrategyExecutorMap;
+  readonly outcomeSink?: MetaOutcomeSink | undefined;
+  readonly logger?: ILogger | undefined;
+}): IMetaDispatcher {
+  const logger = options.logger ?? createLogger({ component: 'MetaDispatcher' });
+  const outcomeSink = options.outcomeSink ?? createAuditLogOutcomeSink(logger);
+  const { executors } = options;
+
+  return {
+    async dispatch(decision: MetaDecision, input: MetaOrchestratorInput): Promise<DispatchResult> {
+      const { strategy, decisionId } = decision;
+      const start = getTimeProvider().now();
+
+      const record = (success: boolean, failureReason?: string): void => {
+        outcomeSink.recordOutcome({
+          decisionId,
+          timestamp: new Date(getTimeProvider().now()).toISOString(),
+          strategy,
+          success,
+          durationMs: Math.max(0, getTimeProvider().now() - start),
+          ...(failureReason !== undefined ? { failureReason } : {}),
+        });
+      };
+
+      const executor = executors[strategy];
+      if (executor === undefined) {
+        const reason = `No executor registered for strategy "${strategy}"`;
+        record(false, reason);
+        logger.error('MetaDispatcher dispatch failed', undefined, { decisionId, strategy, reason });
+        throw new MetaDispatchError('no_executor', strategy, decisionId, reason);
+      }
+
+      try {
+        const result = await executor(decision, input);
+        record(true);
+        return {
+          decisionId,
+          strategy,
+          durationMs: Math.max(0, getTimeProvider().now() - start),
+          result,
+        };
+      } catch (err) {
+        const reason = errorMessage(err);
+        record(false, reason);
+        logger.error(
+          'MetaDispatcher strategy executor threw',
+          err instanceof Error ? err : undefined,
+          { decisionId, strategy, reason }
+        );
+        throw new MetaDispatchError('executor_failed', strategy, decisionId, reason, {
+          cause: err,
+        });
+      }
+    },
+  };
+}


### PR DESCRIPTION
Closes #3559. Part of epic #3548. Prerequisite for step 3 shadow-learning (#3551).

## What

`createMetaDispatcher()` executes the strategy a `MetaDecision` selected and records the result.

- **Injected executors.** Takes a `StrategyExecutorMap` (`Partial<Record<ExecutionStrategy, StrategyExecutor>>`) — the orchestration core never imports engine handlers, so no init-time cycle. Real executors are supplied later by the entry point.
- **Dedicated outcome record.** `MetaOutcomeRecord` keyed by `decisionId` (success, durationMs, failureReason?). Neither existing `TaskOutcome` fits a strategy-level outcome — the orchestration one requires `cli`+`model`, the learning one is model-routing-centric, and a `graph-workflow` strategy spans many CLIs/models. Joining selection records (#3550) with these by `decisionId` is the uncontaminated dataset step 3 mines.
- **Fails closed.** Missing executor or a throwing executor → records a failure outcome, then rejects with a typed `MetaDispatchError` (codes `no_executor` / `executor_failed`). Never silent.
- Audit-log + in-memory recording outcome sinks provided.

## Tests

6 tests, deterministic with fake executors + recording sink: success path + result, single success outcome keyed by decisionId, fail-closed on missing executor (+ error code), failure recorded + rethrown on executor throw, bounded buffer. Decisions come from the real MetaOrchestrator so the `decisionId` join is exercised end to end.

(Found + fixed a real bug mid-TDD: `ILogger.error`'s 2nd arg is an `Error`, not a context object — the failing tests caught it.)

## Out of scope (owner-approved sub-step)

The outward-facing MCP `run` tool that injects the real engine executors and becomes the default entry point — the "one pipeline" surface change. Will confirm before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)