### PR TITLE
feat(task-analysis): CapabilityGapLedger — aggregate discarded gap reports into a build backlog (#3555)

### DIFF
--- a/.changeset/capability-gap-ledger.md
+++ b/.changeset/capability-gap-ledger.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(task-analysis): add CapabilityGapLedger — aggregate discarded gap reports into a build backlog
+
+Adds `createCapabilityGapLedger()`, which aggregates the `CapabilityGapReport`s produced on every routing / MetaOrchestrator decision (currently computed and thrown away) into a frequency-ranked, deduplicated summary of the tools and experts the system keeps wanting but lacks — the substrate for a self-directed build backlog (#3555). `record()` ingests a report with optional `{goal, decisionId}` context; `summarize()` returns distinct gaps ranked by observation count (with a bounded sample of example goals); storage is bounded. `createMetaOrchestrator()` gains an optional `gapLedger` injectable that records each decision's gaps when provided (default absent — no behavior change). Later increments aggregate this and feed `suggest_research_tasks`.

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the Capability Gap Ledger (#3555).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createCapabilityGapLedger } from './capability-gap-ledger.js';
+import type { CapabilityGapReport } from './capability-gap-detector.js';
+
+function report(
+  ...gaps: Array<{ type: 'tool' | 'expert'; name: string; suggestion?: string }>
+): CapabilityGapReport {
+  return {
+    available: { tools: [], experts: [] },
+    gaps: gaps.map((g) => ({
+      type: g.type,
+      name: g.name,
+      suggestion: g.suggestion ?? 'use orchestrate',
+    })),
+    allSatisfied: gaps.length === 0,
+  };
+}
+
+describe('CapabilityGapLedger', () => {
+  it('starts empty', () => {
+    const ledger = createCapabilityGapLedger();
+    expect(ledger.size()).toBe(0);
+    expect(ledger.summarize()).toEqual([]);
+  });
+
+  it('records each gap in a report', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report({ type: 'tool', name: 'deploy' }, { type: 'expert', name: 'ml_expert' }));
+    expect(ledger.size()).toBe(2);
+  });
+
+  it('ignores reports with no gaps', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report());
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('aggregates and ranks distinct gaps by observation count', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report({ type: 'tool', name: 'deploy' }));
+    ledger.record(report({ type: 'tool', name: 'deploy' }));
+    ledger.record(report({ type: 'expert', name: 'ml_expert' }));
+    const summary = ledger.summarize();
+    expect(summary).toHaveLength(2);
+    expect(summary[0]).toMatchObject({ name: 'deploy', count: 2 });
+    expect(summary[1]).toMatchObject({ name: 'ml_expert', count: 1 });
+  });
+
+  it('dedups by type+name (same name, different type is distinct)', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report({ type: 'tool', name: 'review' }));
+    ledger.record(report({ type: 'expert', name: 'review' }));
+    const summary = ledger.summarize();
+    expect(summary).toHaveLength(2);
+    expect(summary.every((s) => s.count === 1)).toBe(true);
+  });
+
+  it('collects a bounded sample of example goals', () => {
+    const ledger = createCapabilityGapLedger();
+    for (const goal of ['g1', 'g2', 'g3', 'g4']) {
+      ledger.record(report({ type: 'tool', name: 'deploy' }), { goal });
+    }
+    const top = ledger.summarize()[0];
+    expect(top?.count).toBe(4);
+    expect(top?.exampleGoals).toHaveLength(3); // capped
+    expect(top?.exampleGoals.every((g) => ['g1', 'g2', 'g3', 'g4'].includes(g))).toBe(true);
+  });
+
+  it('dedups example goals (same goal recorded twice counts once in examples)', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report({ type: 'tool', name: 'deploy' }), { goal: 'same' });
+    ledger.record(report({ type: 'tool', name: 'deploy' }), { goal: 'same' });
+    const top = ledger.summarize()[0];
+    expect(top?.count).toBe(2);
+    expect(top?.exampleGoals).toEqual(['same']);
+  });
+
+  it('breaks count ties by name ascending for deterministic ordering', () => {
+    const ledger = createCapabilityGapLedger();
+    ledger.record(report({ type: 'tool', name: 'zebra' }, { type: 'tool', name: 'alpha' }));
+    const names = ledger.summarize().map((s) => s.name);
+    expect(names).toEqual(['alpha', 'zebra']);
+  });
+
+  it('bounds retained occurrences, evicting oldest', () => {
+    const ledger = createCapabilityGapLedger(3);
+    for (let i = 0; i < 5; i++) ledger.record(report({ type: 'tool', name: `gap${String(i)}` }));
+    expect(ledger.size()).toBe(3);
+    const names = ledger.summarize().map((s) => s.name);
+    expect(names).toContain('gap4'); // newest retained
+    expect(names).not.toContain('gap0'); // oldest evicted
+  });
+});

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
@@ -1,0 +1,142 @@
+/**
+ * Capability Gap Ledger (#3555)
+ *
+ * Aggregates the {@link CapabilityGapReport}s produced on every routing /
+ * MetaOrchestrator decision — which are otherwise computed and discarded — into
+ * a queryable, frequency-ranked summary of the tools and experts the system
+ * keeps wanting but lacks. This is the substrate for a self-directed build
+ * backlog: a gap that recurs is a capability worth adding. Later increments feed
+ * this summary into the research-trigger / `suggest_research_tasks` surface.
+ *
+ * Deterministic and in-process; no external calls. Bounded storage mirrors the
+ * MetaOrchestrator's recording sink.
+ *
+ * @module core/task-analysis/capability-gap-ledger
+ */
+
+import { getTimeProvider } from '../time-provider.js';
+import type { CapabilityGapReport, CapabilityGap } from './capability-gap-detector.js';
+
+/** Context attached to a recorded gap, for traceability and examples. */
+export interface GapContext {
+  /** The goal/task whose routing surfaced the gap. */
+  readonly goal?: string | undefined;
+  /** The decision id this gap was attached to (joins to a selection record). */
+  readonly decisionId?: string | undefined;
+}
+
+/** One recorded gap occurrence. */
+interface GapEntry {
+  readonly type: CapabilityGap['type'];
+  readonly name: string;
+  readonly suggestion: string;
+  readonly goal?: string | undefined;
+  readonly timestamp: string;
+}
+
+/** A frequency-ranked summary of one distinct gap. */
+export interface GapSummary {
+  /** Whether the missing capability is a tool or an expert. */
+  readonly type: CapabilityGap['type'];
+  /** The missing capability's name. */
+  readonly name: string;
+  /** How many times this gap was observed. */
+  readonly count: number;
+  /** The suggestion recorded for it (most recent). */
+  readonly suggestion: string;
+  /** A bounded sample of distinct goals that surfaced this gap. */
+  readonly exampleGoals: readonly string[];
+}
+
+/** The ledger interface (the injection seam for producers). */
+export interface ICapabilityGapLedger {
+  /** Records every gap in a report, tagged with optional context. */
+  record(report: CapabilityGapReport, context?: GapContext): void;
+  /** Returns distinct gaps ranked by observation count (desc), then name (asc). */
+  summarize(): readonly GapSummary[];
+  /** Total number of gap occurrences currently retained. */
+  size(): number;
+}
+
+const DEFAULT_MAX_ENTRIES = 500;
+const MAX_EXAMPLE_GOALS = 3;
+
+/** Stable composite key for a distinct gap. */
+function gapKey(type: string, name: string): string {
+  return `${type}:${name}`;
+}
+
+interface GapGroup {
+  type: CapabilityGap['type'];
+  name: string;
+  count: number;
+  suggestion: string;
+  goals: Set<string>;
+}
+
+/** Groups raw entries into frequency-ranked distinct-gap summaries. */
+function summarizeEntries(entries: readonly GapEntry[]): readonly GapSummary[] {
+  const groups = new Map<string, GapGroup>();
+  for (const e of entries) {
+    const key = gapKey(e.type, e.name);
+    const group = groups.get(key);
+    if (group === undefined) {
+      groups.set(key, {
+        type: e.type,
+        name: e.name,
+        count: 1,
+        suggestion: e.suggestion,
+        goals: new Set(e.goal !== undefined ? [e.goal] : []),
+      });
+    } else {
+      group.count += 1;
+      group.suggestion = e.suggestion; // most recent wins
+      if (e.goal !== undefined) group.goals.add(e.goal);
+    }
+  }
+
+  return [...groups.values()]
+    .map((g) => ({
+      type: g.type,
+      name: g.name,
+      count: g.count,
+      suggestion: g.suggestion,
+      exampleGoals: [...g.goals].slice(0, MAX_EXAMPLE_GOALS),
+    }))
+    .sort((a, b) => (b.count !== a.count ? b.count - a.count : a.name.localeCompare(b.name)));
+}
+
+/**
+ * Creates a capability-gap ledger.
+ *
+ * @param maxEntries - cap on retained occurrences (oldest evicted first).
+ */
+export function createCapabilityGapLedger(maxEntries = DEFAULT_MAX_ENTRIES): ICapabilityGapLedger {
+  const entries: GapEntry[] = [];
+
+  return {
+    record(report: CapabilityGapReport, context?: GapContext): void {
+      const timestamp = new Date(getTimeProvider().now()).toISOString();
+      for (const gap of report.gaps) {
+        entries.push({
+          type: gap.type,
+          name: gap.name,
+          suggestion: gap.suggestion,
+          goal: context?.goal,
+          timestamp,
+        });
+      }
+      if (entries.length > maxEntries) {
+        entries.splice(0, entries.length - maxEntries);
+      }
+    },
+
+    summarize(): readonly GapSummary[] {
+      return summarizeEntries(entries);
+    },
+
+    size(): number {
+      return entries.length;
+    },
+  };
+}

--- a/packages/nexus-agents/src/core/task-analysis/index.ts
+++ b/packages/nexus-agents/src/core/task-analysis/index.ts
@@ -51,6 +51,10 @@ export {
   getAvailableExpertCount,
 } from './capability-gap-detector.js';
 
+// Capability gap ledger — aggregates discarded gap reports into a build backlog (#3555)
+export { createCapabilityGapLedger } from './capability-gap-ledger.js';
+export type { ICapabilityGapLedger, GapSummary, GapContext } from './capability-gap-ledger.js';
+
 // Task profile adapter for legacy compatibility (Issue #586)
 export type { TaskProfile, BanditContext } from './task-profile-adapter.js';
 export {

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -18,6 +18,8 @@ import {
 import type { IWorkflowRouter } from './workflow-router.js';
 import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
 import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
+import { createCapabilityGapLedger } from '../core/task-analysis/capability-gap-ledger.js';
+import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
 
 describe('strategyFromPattern', () => {
   const cases: ReadonlyArray<
@@ -69,6 +71,7 @@ function fakeRouter(
       ...(decision.suggestedQuestions !== undefined
         ? { suggestedQuestions: decision.suggestedQuestions }
         : {}),
+      ...(decision.capabilityGaps !== undefined ? { capabilityGaps: decision.capabilityGaps } : {}),
     }),
     recordOutcome: () => {},
     getMetrics: () => [],
@@ -238,5 +241,31 @@ describe('MetaOrchestrator.select — decision logging (step 2, #3550)', () => {
     expect(sink.getRecords()).toHaveLength(3);
     // Oldest evicted — last goal retained.
     expect(sink.getRecords().at(-1)?.goal).toBe('implement feature 4');
+  });
+});
+
+describe('MetaOrchestrator.select — capability gap ledger wiring (#3555)', () => {
+  const gapReport: CapabilityGapReport = {
+    available: { tools: [], experts: [] },
+    gaps: [{ type: 'tool', name: 'deploy', suggestion: 'use run_graph_workflow' }],
+    allSatisfied: false,
+  };
+
+  it('records the decision capability gaps to an injected ledger', () => {
+    const ledger = createCapabilityGapLedger();
+    const meta = createMetaOrchestrator({
+      router: fakeRouter({ pattern: 'sequential', capabilityGaps: gapReport }),
+      gapLedger: ledger,
+    });
+    meta.select({ goal: 'ship it to prod' });
+    const summary = ledger.summarize();
+    expect(summary).toHaveLength(1);
+    expect(summary[0]).toMatchObject({ type: 'tool', name: 'deploy', count: 1 });
+    expect(summary[0]?.exampleGoals).toContain('ship it to prod');
+  });
+
+  it('does not require a ledger (default absent, no throw)', () => {
+    const meta = createMetaOrchestrator();
+    expect(() => meta.select({ goal: 'implement the feature' })).not.toThrow();
   });
 });

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -28,6 +28,7 @@ import type { IWorkflowRouter } from './workflow-router.js';
 import type { TaskSignals, RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
 import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
 import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
+import type { ICapabilityGapLedger } from '../core/task-analysis/capability-gap-ledger.js';
 
 /**
  * Execution strategies the MetaOrchestrator can select. Each maps to an
@@ -394,15 +395,20 @@ function toRecord(
  * @param options.logger - optional logger.
  * @param options.router - optional workflow router (injectable for tests).
  * @param options.sink - optional decision sink (default: audit-log sink).
+ * @param options.gapLedger - optional capability-gap ledger; when provided, each
+ *   decision's capability gaps are recorded for the self-directed build backlog
+ *   (#3555). Default absent — no gap recording, no behavior change.
  */
 export function createMetaOrchestrator(options?: {
   readonly logger?: ILogger | undefined;
   readonly router?: IWorkflowRouter | undefined;
   readonly sink?: MetaDecisionSink | undefined;
+  readonly gapLedger?: ICapabilityGapLedger | undefined;
 }): IMetaOrchestrator {
   const logger = options?.logger ?? createLogger({ component: 'MetaOrchestrator' });
   const router = options?.router ?? createWorkflowRouter({ logger });
   const sink = options?.sink ?? createAuditLogSink(logger);
+  const gapLedger = options?.gapLedger;
 
   return {
     select(input: MetaOrchestratorInput): MetaDecision {
@@ -419,6 +425,12 @@ export function createMetaOrchestrator(options?: {
 
       const timestamp = new Date(getTimeProvider().now()).toISOString();
       sink.record(toRecord(decision, input.goal, forced, timestamp));
+      if (gapLedger !== undefined && decision.capabilityGaps !== undefined) {
+        gapLedger.record(decision.capabilityGaps, {
+          goal: input.goal,
+          decisionId: decision.decisionId,
+        });
+      }
 
       logger.info('MetaOrchestrator strategy selected', {
         decisionId: decision.decisionId,


### PR DESCRIPTION
Part of epic #3555 (increment 1). Unblocked by #3553 (registry accuracy).

## What

Every routing / MetaOrchestrator decision computes a `CapabilityGapReport` (missing tools/experts) via `detectCapabilityGaps()` — and **discards it**. This adds the queryable surface that turns those discarded signals into a self-directed build backlog.

- `createCapabilityGapLedger()`: `record(report, {goal?, decisionId?})` ingests gaps; `summarize()` returns distinct gaps **ranked by observation count** (dedup by `type+name`, most-recent suggestion, bounded sample of example goals); `size()` + bounded storage (mirrors the recording-sink pattern).
- `createMetaOrchestrator({ gapLedger })`: optional injectable — records each decision's gaps when provided. **Default absent = no behavior change.** First real producer.

## Why now (not speculative)

The signal exists today: `workflow-router.ts:127` computes gaps on every decision. This is the missing persistence. Now accurate after #3553 fixed the stale registry (false gaps would have polluted the ledger).

## Tests

36 pass (9 ledger: empty/record/ignore-clean/rank/dedup-by-type+name/example-goal cap+dedup/tie-break/bounded-eviction; + MetaOrchestrator wiring: records to injected ledger with example goal, works without one). Deterministic.

## Next increments (this epic)

Aggregate the ledger and feed `suggest_research_tasks` by **extending** `checkForResearchTriggers` (`src/pipeline/research-trigger.ts`) — not forking. Surface the ranked backlog via an MCP/CLI read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)