### PR TITLE
feat(orchestration): feed capability-gap ledger from live routing traffic (#3555)

### DIFF
--- a/.changeset/gap-ledger-live-wiring.md
+++ b/.changeset/gap-ledger-live-wiring.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): feed the capability-gap ledger from live routing traffic
+
+Adds a process-wide `getGapLedger()` singleton (mirroring `getOutcomeStore()`) plus a `recordRoutingGaps()` helper, and wires the live `orchestrate` tool to record the capability gaps its routing decision already computes (`workflow-router.ts` had been discarding them). The gap ledger (#3555) now accumulates real signal from production routing traffic — no longer dependent on the (owner-gated) unified entry point — turning recurring "tool/expert needed but missing" gaps into a frequency-ranked, self-directed build backlog. No-op when a decision satisfied every required capability.

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
@@ -2,8 +2,14 @@
  * Tests for the Capability Gap Ledger (#3555).
  */
 
-import { describe, it, expect } from 'vitest';
-import { createCapabilityGapLedger } from './capability-gap-ledger.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  createCapabilityGapLedger,
+  getGapLedger,
+  setGapLedger,
+  resetGapLedger,
+  recordRoutingGaps,
+} from './capability-gap-ledger.js';
 import type { CapabilityGapReport } from './capability-gap-detector.js';
 
 function report(
@@ -93,5 +99,57 @@ describe('CapabilityGapLedger', () => {
     const names = ledger.summarize().map((s) => s.name);
     expect(names).toContain('gap4'); // newest retained
     expect(names).not.toContain('gap0'); // oldest evicted
+  });
+});
+
+describe('gap ledger singleton', () => {
+  afterEach(() => {
+    resetGapLedger();
+  });
+
+  it('returns the same instance across calls', () => {
+    expect(getGapLedger()).toBe(getGapLedger());
+  });
+
+  it('setGapLedger overrides and resetGapLedger clears', () => {
+    const custom = createCapabilityGapLedger();
+    setGapLedger(custom);
+    expect(getGapLedger()).toBe(custom);
+    resetGapLedger();
+    expect(getGapLedger()).not.toBe(custom);
+  });
+});
+
+describe('recordRoutingGaps', () => {
+  it('records gaps from a decision to the given ledger', () => {
+    const ledger = createCapabilityGapLedger();
+    recordRoutingGaps(
+      { capabilityGaps: report({ type: 'tool', name: 'deploy' }) },
+      { goal: 'ship it' },
+      ledger
+    );
+    expect(ledger.summarize()[0]).toMatchObject({ name: 'deploy', count: 1 });
+    expect(ledger.summarize()[0]?.exampleGoals).toContain('ship it');
+  });
+
+  it('is a no-op when all capabilities are satisfied', () => {
+    const ledger = createCapabilityGapLedger();
+    recordRoutingGaps({ capabilityGaps: report() }, { goal: 'g' }, ledger);
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('is a no-op when no capability gap report is present', () => {
+    const ledger = createCapabilityGapLedger();
+    recordRoutingGaps({}, { goal: 'g' }, ledger);
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('defaults to the shared singleton ledger', () => {
+    resetGapLedger();
+    recordRoutingGaps(
+      { capabilityGaps: report({ type: 'expert', name: 'ml_expert' }) },
+      { goal: 'g' }
+    );
+    expect(getGapLedger().size()).toBe(1);
   });
 });

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
@@ -140,3 +140,43 @@ export function createCapabilityGapLedger(maxEntries = DEFAULT_MAX_ENTRIES): ICa
     },
   };
 }
+
+// ============================================================================
+// Process-wide singleton — the shared surface live routing producers feed.
+// Mirrors getOutcomeStore() (orchestration/outcomes/outcome-store.ts).
+// ============================================================================
+
+let singletonLedger: ICapabilityGapLedger | undefined;
+
+/** Returns the process-wide gap ledger, creating it on first use. */
+export function getGapLedger(): ICapabilityGapLedger {
+  singletonLedger ??= createCapabilityGapLedger();
+  return singletonLedger;
+}
+
+/** Replaces the process-wide ledger (tests / custom wiring). */
+export function setGapLedger(ledger: ICapabilityGapLedger): void {
+  singletonLedger = ledger;
+}
+
+/** Clears the process-wide ledger (test isolation). */
+export function resetGapLedger(): void {
+  singletonLedger = undefined;
+}
+
+/**
+ * Records a routing/selection decision's capability gaps to a ledger (the
+ * shared singleton by default). No-op when the decision satisfied every
+ * required capability or carried no gap report — keeps the live call sites a
+ * single guarded line (DRY across orchestrate tool + CLI).
+ */
+export function recordRoutingGaps(
+  source: { readonly capabilityGaps?: CapabilityGapReport | undefined },
+  context: GapContext,
+  ledger: ICapabilityGapLedger = getGapLedger()
+): void {
+  const report = source.capabilityGaps;
+  if (report !== undefined && !report.allSatisfied) {
+    ledger.record(report, context);
+  }
+}

--- a/packages/nexus-agents/src/core/task-analysis/index.ts
+++ b/packages/nexus-agents/src/core/task-analysis/index.ts
@@ -52,7 +52,13 @@ export {
 } from './capability-gap-detector.js';
 
 // Capability gap ledger — aggregates discarded gap reports into a build backlog (#3555)
-export { createCapabilityGapLedger } from './capability-gap-ledger.js';
+export {
+  createCapabilityGapLedger,
+  getGapLedger,
+  setGapLedger,
+  resetGapLedger,
+  recordRoutingGaps,
+} from './capability-gap-ledger.js';
 export type { ICapabilityGapLedger, GapSummary, GapContext } from './capability-gap-ledger.js';
 
 // Task profile adapter for legacy compatibility (Issue #586)

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -55,6 +55,7 @@ import type { ExecutionPlan } from '../../agents/index.js';
 import { createOrchestratorWithSica } from './orchestrate-sica.js';
 import { OrchestratorFactory } from '../../orchestration/orchestrator-factory.js';
 import { createWorkflowRouter, type IWorkflowRouter } from '../../orchestration/workflow-router.js';
+import { recordRoutingGaps } from '../../core/task-analysis/capability-gap-ledger.js';
 import { getToolMemory } from './tool-memory.js';
 import { getAutoCatalog } from './research-auto-catalog.js';
 import { computeAgentPlan } from './orchestrate-aorchestra.js';
@@ -446,6 +447,9 @@ function routeAndPrepare(
   const logger = deps.logger ?? createLogger({ tool: 'orchestrate' });
   const workflowRouter = router ?? createWorkflowRouter({ logger });
   const decision = workflowRouter.route({ description: input.task });
+  // Feed the capability-gap ledger from live routing traffic (#3555): the
+  // decision already computed these gaps; without this they are discarded.
+  recordRoutingGaps(decision, { goal: input.task });
   const orchType = mapPatternToOrchestratorType(decision.pattern);
   logger.info('Workflow pattern selected', {
     pattern: decision.pattern,


### PR DESCRIPTION
Part of epic #3555 (increment 2). Builds on #3561.

## What

Gives the capability-gap ledger **real signal today**, without waiting on the owner-gated unified entry point.

- `getGapLedger()` / `setGapLedger()` / `resetGapLedger()` — process-wide singleton, mirroring `getOutcomeStore()`.
- `recordRoutingGaps(decision, context, ledger?)` — DRY helper; records a decision's `capabilityGaps` to the ledger (default singleton), no-op when `allSatisfied` or no report.
- Wired into the live `orchestrate` tool (`orchestrate.ts:448`): the routing decision already computes `capabilityGaps` and discarded them — now they feed the ledger on every real call.

The CLI `orchestrate-command.ts` was checked and is **not** a producer (it uses the CompositeRouter for model routing, which carries no `capabilityGaps`).

## Why this is the right increment

Per the epic, the gap ledger's value depends on real signal. `orchestrate` is live production traffic today, so this is non-speculative — unlike learned-selection (steps 3-4) which remain held pending the entry point. Now accurate after #3553 fixed the stale registry (false gaps would have polluted it).

## Tests

15 ledger tests (singleton identity/override/reset; `recordRoutingGaps` records / no-ops on satisfied / no-ops on absent / defaults to singleton). **175 orchestrate tests pass — no regression.** Typecheck + lint clean.

## Still held for owner

The outward-facing MCP `run` entry point and learned-selection steps 3-4 — see epic #3548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)