### PR TITLE
chore(mcp): derive tool counts from REGISTERED_TOOL_NAMES.length (Phase 1, #3564)

### DIFF
--- a/.changeset/derive-tool-counts.md
+++ b/.changeset/derive-tool-counts.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+chore(mcp): derive MCP tool counts from REGISTERED_TOOL_NAMES.length
+
+Removes the hardcoded `45` tool-count literal from the test suite so adding or removing a tool no longer requires bumping a number in multiple files. `mcp/tools/index.test.ts` and `tool-annotations.test.ts` now cross-check their registries against `REGISTERED_TOOL_NAMES.length`; the redundant count assertion in `cli-server-tools.test.ts` (which asserted the canonical list's own length — a tautology) is replaced with structural invariants (unique, non-empty names). Also corrects the stale "all 20 registered MCP tools" comment on `TOOL_TIER_MAP`. Phase 1 of the tool-registry centralization epic (#3563).

--- a/packages/nexus-agents/src/cli-server-tools.test.ts
+++ b/packages/nexus-agents/src/cli-server-tools.test.ts
@@ -406,8 +406,14 @@ function makeDefaultOptions(overrides: Record<string, unknown> = {}) {
 // ============================================================================
 
 describe('REGISTERED_TOOLS', () => {
-  it('should contain exactly 45 tool names', () => {
-    expect(REGISTERED_TOOLS).toHaveLength(45);
+  // REGISTERED_TOOLS is the canonical list, so a count literal would be a
+  // tautology and a maintenance tax. Assert structural invariants instead:
+  // non-empty, unique, no blank names. Count drift is caught where a *parallel*
+  // registry is cross-checked against this length (annotations, index, etc.).
+  it('contains unique, non-empty tool names', () => {
+    expect(REGISTERED_TOOLS.length).toBeGreaterThan(0);
+    expect(new Set(REGISTERED_TOOLS).size).toBe(REGISTERED_TOOLS.length);
+    expect(REGISTERED_TOOLS.every((name) => name.trim().length > 0)).toBe(true);
   });
 
   it('should include all expected tool names', () => {

--- a/packages/nexus-agents/src/mcp/gateway/tier-classifier.ts
+++ b/packages/nexus-agents/src/mcp/gateway/tier-classifier.ts
@@ -30,7 +30,9 @@ export enum RequestTier {
 export type TierOverrides = Record<string, RequestTier>;
 
 /**
- * Default tier assignment for all 20 registered MCP tools.
+ * Default tier assignment for registered MCP tools. This is an intentional
+ * subset/override map (not every tool needs an explicit tier); the Phase 2
+ * consistency test (#3565) asserts no-orphan-keys against REGISTERED_TOOL_NAMES.
  * Tier 1: read-only, no model invocation needed.
  * Tier 2: requires model selection or expert creation.
  * Tier 3: requires full orchestration, decomposition, or consensus.

--- a/packages/nexus-agents/src/mcp/tools/index.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   registerTools,
+  REGISTERED_TOOL_NAMES,
   toolSuccess,
   toolSuccessStructured,
   toolError,
@@ -69,7 +70,8 @@ import {
   RepoSecurityPlanInputSchema,
 } from './index.js';
 
-const EXPECTED_TOOL_COUNT = 45;
+// Derived from the canonical list — registering a tool needs no edit here.
+const EXPECTED_TOOL_COUNT = REGISTERED_TOOL_NAMES.length;
 
 const EXPECTED_TOOL_NAMES = [
   'orchestrate',

--- a/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
@@ -35,8 +35,8 @@ describe('tool-annotations', () => {
       }
     });
 
-    it('has exactly 45 tool entries', () => {
-      expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(45);
+    it('has one entry per registered tool (count derived from the canonical list)', () => {
+      expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(REGISTERED_TOOLS.length);
     });
 
     it('every entry has valid annotations shape', () => {


### PR DESCRIPTION
Closes #3564. Phase 1 of epic #3563 (centralize MCP tool registry).

## What

Adding/removing a tool no longer requires bumping a hardcoded `45` count:
- `mcp/tools/index.test.ts`: `EXPECTED_TOOL_COUNT = REGISTERED_TOOL_NAMES.length` (cross-checks live `registerTools()` output vs the canonical list — still meaningful).
- `tool-annotations.test.ts`: annotations count derived from `REGISTERED_TOOLS.length`.
- `cli-server-tools.test.ts`: the `toHaveLength(45)` on `REGISTERED_TOOLS` itself was a tautology (it *is* the canonical list) — replaced with structural invariants (unique, non-empty names).
- `tier-classifier.ts`: fixed the stale "all 20 registered MCP tools" comment; noted `TOOL_TIER_MAP` is an intentional subset (Phase 2 will assert no-orphan-keys).

`pnpm governance:inject` already owns the doc/config counts (CLAUDE.md/README/ENTRYPOINTS/server.json) — verified no regeneration needed.

## Why first

This lands before the `run` entry-point registration so that PR needs **zero count edits** — only the registries themselves. Phase 2 (#3565, consolidated consistency test) and Phase 3 (#3566, single manifest) follow.

## Tests

121 tests pass across the three touched test files; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)