### PR TITLE
docs(governance): codify dependency-blocked work tracking

### DIFF
--- a/.changeset/codify-blocked-work-tracking.md
+++ b/.changeset/codify-blocked-work-tracking.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+docs(governance): codify dependency-blocked work tracking
+
+Strengthens the "track all work" discipline (AGENTS.md + `.rules/track-deferred-work.md`) to explicitly cover the most-forgotten case: work deferred _because it depends on another deliverable_ ("do after X lands", "increment B once A merges"). Such work must get an issue the moment it's named — not when the blocker clears — with the blocking dependency and unblock trigger recorded. Adds a "when a blocker clears, surface its dependents" step (search `gh issue list --search "#<id>"` / walk the epic's children) so a completed dependency surfaces the next work instead of relying on memory. Clarifies that a prose "Phase 3 / increment B will…" in an epic body is a description, not a tracked task — every step needs its own issue.

--- a/.rules/track-deferred-work.md
+++ b/.rules/track-deferred-work.md
@@ -16,6 +16,11 @@ Auto-loaded. Every piece of identified work — including work you're choosing t
 - **Discovered bugs you're choosing NOT to fix inline** — file even if you won't touch them today (per the Discovered Issues protocol in `.rules/discovered-issues.md`).
 - **Migration / refactor work you've identified as worth doing** — file before deferring; document the trigger condition that should unblock it.
 - **Cleanup work surfaced by audits** — vestigial code, dead exports, stale comments — file the cleanup issue, even if you're not going to delete it this turn.
+- **Dependency-blocked / sequenced work — the most-forgotten case.** Anything deferred _because it depends on another deliverable_ ("do after X lands", "increment B once A merges", "wait until the entry point feeds real data"). File it **the moment you name it, not when the blocker clears** — deferring the _filing_ until the dependency is done is precisely how the work gets dropped. Record the blocking dependency + unblock trigger in the body and link it (`blocked by #N`). A multi-step epic is only tracked if **every** step has its own issue — a prose "Phase 3 / increment B will…" in the epic body is a description, not a tracked task.
+
+## When a blocker clears, surface its dependents
+
+Tracking only prevents loss if something _reads_ the tracker. When you complete or merge a deliverable, search for work blocked on it (`gh issue list --search "#<id>"`, or walk the epic's children) and pick up or re-prioritize whatever the completion just unblocked. A finished dependency should surface its dependents; don't rely on remembering them.
 
 ## This does NOT apply to
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,11 +221,13 @@ The "⏳ template" rows describe how to add the bridge when a concrete use case 
 
 Every piece of identified work — even work you're explicitly deferring — needs a **GitHub issue**. Memory notes, PR-description "follow-up" bullets, code TODOs, and conversation summaries are NOT tracking. They get forgotten. If the work isn't in an issue, it won't get done.
 
-Applies to: deferred follow-ups identified during a merged PR; scope cuts during planning; discovered bugs you're choosing not to fix inline; migrations / refactors / cleanup you've decided are worth doing but not right now.
+Applies to: deferred follow-ups identified during a merged PR; scope cuts during planning; discovered bugs you're choosing not to fix inline; migrations / refactors / cleanup you've decided are worth doing but not right now; **and — the most-forgotten case — dependency-blocked / sequenced work** ("do this once X lands", "increment B after increment A merges", "wait until the entry point feeds real data"). File blocked work the moment you name it, **not when the blocker clears** — waiting to file is exactly how it gets dropped. Record the blocking dependency and the unblock trigger in the body, and link it (e.g. "blocked by #N").
 
 Does NOT apply to: findings that fail the Discovered-Issues 4-point gate; speculative "what if" thinking with no concrete trigger (YAGNI); work the user explicitly told you to skip.
 
 Issue shape: title says what; body explains why it was identified, what would change, and the trigger condition that should unblock pickup. Memory notes can mirror but the issue is canonical.
+
+**Close the loop on unblock.** When you complete or merge a deliverable, search for work that was blocked on it (`gh issue list --search "#<id>"`, or the epic's child list) and pick up or re-prioritize whatever the completion just unblocked. The unblock trigger recorded in each blocked issue is the handoff — a finished dependency should _surface_ its dependents, not rely on you remembering them. A multi-step epic is only "tracked" if every step (including the not-yet-startable ones) has its own issue, not just a prose mention in the epic body.
 
 ## Autonomous operation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,11 +280,13 @@ The "⏳ template" rows describe how to add the bridge when a concrete use case 
 
 Every piece of identified work — even work you're explicitly deferring — needs a **GitHub issue**. Memory notes, PR-description "follow-up" bullets, code TODOs, and conversation summaries are NOT tracking. They get forgotten. If the work isn't in an issue, it won't get done.
 
-Applies to: deferred follow-ups identified during a merged PR; scope cuts during planning; discovered bugs you're choosing not to fix inline; migrations / refactors / cleanup you've decided are worth doing but not right now.
+Applies to: deferred follow-ups identified during a merged PR; scope cuts during planning; discovered bugs you're choosing not to fix inline; migrations / refactors / cleanup you've decided are worth doing but not right now; **and — the most-forgotten case — dependency-blocked / sequenced work** ("do this once X lands", "increment B after increment A merges", "wait until the entry point feeds real data"). File blocked work the moment you name it, **not when the blocker clears** — waiting to file is exactly how it gets dropped. Record the blocking dependency and the unblock trigger in the body, and link it (e.g. "blocked by #N").
 
 Does NOT apply to: findings that fail the Discovered-Issues 4-point gate; speculative "what if" thinking with no concrete trigger (YAGNI); work the user explicitly told you to skip.
 
 Issue shape: title says what; body explains why it was identified, what would change, and the trigger condition that should unblock pickup. Memory notes can mirror but the issue is canonical.
+
+**Close the loop on unblock.** When you complete or merge a deliverable, search for work that was blocked on it (`gh issue list --search "#<id>"`, or the epic's child list) and pick up or re-prioritize whatever the completion just unblocked. The unblock trigger recorded in each blocked issue is the handoff — a finished dependency should _surface_ its dependents, not rely on you remembering them. A multi-step epic is only "tracked" if every step (including the not-yet-startable ones) has its own issue, not just a prose mention in the epic body.
 
 ## Autonomous operation
 


### PR DESCRIPTION
## Why

Owner request: ensure work we defer "until something else completes" never gets dropped because we were waiting on a dependency and forgot. The existing "track all work" rule covered deferred follow-ups / scope cuts / discovered bugs, but did not name the **dependency-blocked / sequenced** case — the most-forgotten one.

## What

`AGENTS.md` (agnostic body) + `.rules/track-deferred-work.md` (canonical) now state:
- **File dependency-blocked work the moment you name it, not when the blocker clears** — deferring the *filing* is exactly how it's lost. Record the blocking dependency + unblock trigger; link `blocked by #N`.
- **When a blocker clears, surface its dependents** — search `gh issue list --search "#<id>"` / walk the epic's children and pick up what the completion unblocked, rather than relying on memory.
- A prose "Phase 3 / increment B will…" in an epic body is a **description, not a tracked task** — every step needs its own issue.

`governance:inject` regenerated the CLAUDE.md `FROM_AGENTS` block. `governance:check` passes (fixed an italic-style mismatch — AGENTS.md must use `_underscore_` italics to match prettier's normalization of the generated CLAUDE.md block).

## Companion: audit done

Verified every deferral from this session's work has an issue; filed the two that were only in epic prose — #3575 (run increment B: inline execution + demote tools) and #3576 (gap-ledger increment 3: suggest_research_tasks feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)