### PR TITLE
chore(test): derive governance-entity counts from canonical sources (Tier A, #3569)

### DIFF
--- a/.changeset/derive-entity-counts.md
+++ b/.changeset/derive-entity-counts.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+chore(test): derive governance-entity counts from canonical sources
+
+Removes hardcoded count literals from the test suite for built-in experts (12), evaluation tasks (15), and failure categories, deriving them from their canonical sources (`BuiltInExpertTypeSchema.options.length`, `EVALUATION_TASKS.length`, `OutcomeFailureCategorySchema.options.length`) so adding/removing one no longer requires bumping a number across multiple files. The canonical lists' own count assertions are replaced with structural invariants (non-empty, unique ids); consumer/registry assertions cross-check against the canonical length. Also couples the supply-chain `FULL_PANEL` to the voter-role count and fixes a stale "10 built-in experts" comment. Tier A of the evergreen DRY epic (#3568).

--- a/packages/nexus-agents/src/cli/expert-list.test.ts
+++ b/packages/nexus-agents/src/cli/expert-list.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runExpertList, printExpertListResult, expertListCommand } from './expert-list.js';
+import { BuiltInExpertTypeSchema } from '../agents/index.js';
 
 describe('expert-list', () => {
   let stdoutWriteMock: ReturnType<typeof vi.fn>;
@@ -31,9 +32,9 @@ describe('expert-list', () => {
       const result = runExpertList();
 
       expect(result.success).toBe(true);
-      // Was 9 pre-#2341; #2341 added research, qa, data-visualization to bring
-      // DEFAULT_EXPERTS in lockstep with the BuiltInExpertType union (12 entries).
-      expect(result.builtIn.length).toBe(12);
+      // DEFAULT_EXPERTS stays in lockstep with the BuiltInExpertType union;
+      // derive the count so adding an expert needs no edit here (#3569).
+      expect(result.builtIn.length).toBe(BuiltInExpertTypeSchema.options.length);
     });
 
     it('should return empty custom experts by default', () => {

--- a/packages/nexus-agents/src/mcp/error-envelope.test.ts
+++ b/packages/nexus-agents/src/mcp/error-envelope.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { OutcomeFailureCategory } from '../orchestration/outcomes/outcome-types.js';
+import { OutcomeFailureCategorySchema } from '../orchestration/outcomes/outcome-types.js';
 import {
   ErrorCategorySchema,
   ToolErrorEnvelopeSchema,
@@ -110,10 +111,11 @@ describe('coarsenFailureCategory', () => {
     }
   });
 
-  it('covers all 11 OutcomeFailureCategory values', () => {
-    // Guards against the map silently going stale if a 12th routing
-    // category is added without extending FAILURE_CATEGORY_COARSENING.
-    expect(cases).toHaveLength(11);
+  it('covers every OutcomeFailureCategory value', () => {
+    // Guards against the coarsening map silently going stale when a routing
+    // category is added without extending FAILURE_CATEGORY_COARSENING. Count
+    // derived from the canonical enum so the guard auto-targets the real total.
+    expect(cases).toHaveLength(OutcomeFailureCategorySchema.options.length);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/mcp-prompts-resources.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-prompts-resources.test.ts
@@ -12,6 +12,10 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
 import { createServer, connectTransport } from './server.js';
 import { registerPrompts } from './prompts/index.js';
+import { BuiltInExpertTypeSchema } from '../agents/index.js';
+
+/** Canonical built-in expert count — derive so adding an expert needs no edit here. */
+const EXPERT_COUNT = BuiltInExpertTypeSchema.options.length;
 import { registerResources } from './resources/index.js';
 import { registerTools } from './tools/index.js';
 
@@ -214,8 +218,8 @@ describe('resources/read - experts', () => {
       expertCount: number;
       experts: Array<{ role: string; name: string }>;
     };
-    expect(data.expertCount).toBe(12);
-    expect(data.experts.length).toBe(12);
+    expect(data.expertCount).toBe(EXPERT_COUNT);
+    expect(data.experts.length).toBe(EXPERT_COUNT);
   });
 
   it('includes expected expert roles', async () => {

--- a/packages/nexus-agents/src/mcp/tools/create-expert.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/create-expert.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ILogger } from '../../core/index.js';
-import { Expert, type BuiltInExpertType } from '../../agents/index.js';
+import { Expert, BuiltInExpertTypeSchema, type BuiltInExpertType } from '../../agents/index.js';
 import { RateLimiter } from '../middleware/index.js';
 import {
   CreateExpertInputSchema,
@@ -360,7 +360,7 @@ describe('getAvailableRoles', () => {
     expect(roles).toContain('infrastructure_expert');
     expect(roles).toContain('data_visualization_expert');
     expect(roles).toContain('qa_expert');
-    expect(roles).toHaveLength(12);
+    expect(roles).toHaveLength(BuiltInExpertTypeSchema.options.length);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/list-experts.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/list-experts.test.ts
@@ -8,6 +8,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerListExpertsTool, type ListExpertsDeps } from './list-experts.js';
 import { RateLimiter } from '../middleware/rate-limiter.js';
+import { BuiltInExpertTypeSchema } from '../../agents/index.js';
+
+/** Canonical built-in expert count — derive so adding an expert needs no edit here. */
+const EXPERT_COUNT = BuiltInExpertTypeSchema.options.length;
 
 // Mock McpServer
 interface MockServer {
@@ -90,7 +94,7 @@ describe('list_experts tool', () => {
 
       expect(parsed.count).toBeGreaterThan(0);
       expect(parsed.experts).toBeInstanceOf(Array);
-      expect(parsed.experts.length).toBe(12); // 10 built-in experts
+      expect(parsed.experts.length).toBe(EXPERT_COUNT);
 
       // Check structure
       const expert = parsed.experts[0];
@@ -135,7 +139,7 @@ describe('list_experts tool', () => {
       const result = await handler({ format: 'names' });
       const parsed = JSON.parse(result.content[0]?.text ?? '{}');
 
-      expect(parsed.experts.length).toBe(12);
+      expect(parsed.experts.length).toBe(EXPERT_COUNT);
       const expert = parsed.experts[0];
       expect(expert.role).toBeDefined();
       expect(expert.name).toBeDefined();

--- a/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.test.ts
@@ -20,7 +20,7 @@ import {
   type AxisVerdict,
   type PanelVote,
 } from './supply-chain-tradeoff-panel.js';
-import type { VoterRole } from '../../cli/vote-types.js';
+import { VOTER_ROLES, type VoterRole } from '../../cli/vote-types.js';
 
 describe('supply_chain_tradeoff_panel', () => {
   describe('DEFAULT_AXES', () => {
@@ -34,8 +34,8 @@ describe('supply_chain_tradeoff_panel', () => {
   });
 
   describe('panels', () => {
-    it('full panel has 7 voters including scope_steward', () => {
-      expect(FULL_PANEL).toHaveLength(7);
+    it('full panel covers every voter role including scope_steward', () => {
+      expect(FULL_PANEL).toHaveLength(Object.keys(VOTER_ROLES).length);
       expect(new Set(FULL_PANEL).has('scope_steward')).toBe(true);
     });
 

--- a/packages/nexus-agents/src/testing/tasks/task-registry.test.ts
+++ b/packages/nexus-agents/src/testing/tasks/task-registry.test.ts
@@ -10,8 +10,12 @@ import type { EvaluationTask, TaskCategory, TaskDifficulty } from './task-types.
 import type { CliName } from '../types.js';
 
 describe('EVALUATION_TASKS', () => {
-  it('should contain exactly 15 tasks', () => {
-    expect(EVALUATION_TASKS).toHaveLength(15);
+  it('contains unique, non-empty task ids', () => {
+    // EVALUATION_TASKS is the canonical list, so a count literal would be a
+    // tautology + a maintenance tax. Assert structural invariants; consumer
+    // tests below cross-check registry output against EVALUATION_TASKS.length.
+    expect(EVALUATION_TASKS.length).toBeGreaterThan(0);
+    expect(new Set(EVALUATION_TASKS.map((t) => t.id)).size).toBe(EVALUATION_TASKS.length);
   });
 
   it('should have unique task IDs', () => {
@@ -20,8 +24,8 @@ describe('EVALUATION_TASKS', () => {
     expect(uniqueIds.size).toBe(ids.length);
   });
 
-  it('should have sequential task IDs from task-001 to task-015', () => {
-    for (let i = 0; i < 15; i++) {
+  it('should have sequential task IDs (task-001, task-002, …)', () => {
+    for (let i = 0; i < EVALUATION_TASKS.length; i++) {
       const expectedId = `task-${String(i + 1).padStart(3, '0')}`;
       expect(EVALUATION_TASKS[i]?.id).toBe(expectedId);
     }
@@ -132,7 +136,7 @@ describe('TaskRegistry', () => {
 
   describe('constructor', () => {
     it('should initialize with default tasks', () => {
-      expect(registry.getTaskCount()).toBe(15);
+      expect(registry.getTaskCount()).toBe(EVALUATION_TASKS.length);
     });
 
     it('should accept custom tasks', () => {
@@ -174,7 +178,7 @@ describe('TaskRegistry', () => {
   describe('getAllTasks', () => {
     it('should return all tasks', () => {
       const tasks = registry.getAllTasks();
-      expect(tasks).toHaveLength(15);
+      expect(tasks).toHaveLength(EVALUATION_TASKS.length);
     });
 
     it('should return a frozen array', () => {
@@ -358,7 +362,7 @@ describe('TaskRegistry', () => {
 
     it('should return all tasks for empty tags array', () => {
       const tasks = registry.getTasksByTags([]);
-      expect(tasks).toHaveLength(15);
+      expect(tasks).toHaveLength(EVALUATION_TASKS.length);
     });
   });
 
@@ -372,7 +376,7 @@ describe('TaskRegistry', () => {
         expect(count).toBeGreaterThan(0);
         total += count;
       }
-      expect(total).toBe(15);
+      expect(total).toBe(EVALUATION_TASKS.length);
     });
   });
 
@@ -386,13 +390,13 @@ describe('TaskRegistry', () => {
         expect(count).toBeGreaterThan(0);
         total += count;
       }
-      expect(total).toBe(15);
+      expect(total).toBe(EVALUATION_TASKS.length);
     });
   });
 
   describe('getTaskCount', () => {
     it('should return 15 for default registry', () => {
-      expect(registry.getTaskCount()).toBe(15);
+      expect(registry.getTaskCount()).toBe(EVALUATION_TASKS.length);
     });
   });
 });
@@ -501,7 +505,9 @@ describe('CLI Distribution', () => {
     expect(geminiTasks.length).toBeGreaterThan(0);
 
     // Total should be 15
-    expect(claudeTasks.length + codexTasks.length + geminiTasks.length).toBe(15);
+    expect(claudeTasks.length + codexTasks.length + geminiTasks.length).toBe(
+      EVALUATION_TASKS.length
+    );
   });
 
   it('should have each CLI able to handle multiple tasks', () => {


### PR DESCRIPTION
Closes #3569. Tier A of epic #3568 (evergreen DRY sweep). Same pattern as the tool-count fix (#3564), applied to the other governance entities — **after verifying each citation** (the subagent's list was ~half coincidental numbers).

## Converted (genuine entity-count assertions → derive)

- **Experts (12):** create-expert, list-experts (×2, + fixed stale "10 built-in experts" comment), mcp-prompts-resources (×2), expert-list → `BuiltInExpertTypeSchema.options.length`.
- **Eval tasks (15):** task-registry consumer/registry/sum assertions → `EVALUATION_TASKS.length`; the canonical's own-length + the `i < 15` loop → structural / derived; the canonical-list count test replaced with non-empty + unique-ids invariants.
- **Failure categories:** error-envelope drift guard → `OutcomeFailureCategorySchema.options.length` (auto-targets the real total; still forces the coarsening map to be extended).
- **Voters:** `FULL_PANEL` (a real parallel list) → `Object.keys(VOTER_ROLES).length`.

## Verified coincidental — intentionally LEFT (no false coupling)

- `createProgressSteps()` returns 7 — UI progress steps, not voters (×2 files).
- `DEV_PIPELINE_TEMPLATE.stages` = 7 — pipeline stages.
- `DEFAULT_QUORUM_THRESHOLDS` keys = 7 — quorum threshold types.
- weather-report `results` = 12 — outcome fixtures, not experts.
- consensus-vote `normalRoles` — a hardcoded fixture asserting its own length (near-tautology); deriving adds no real coverage, so left as-is.
- visualize-command `call[0]` lengths (7, 11) — unverified mock-arg shapes; left rather than risk a false canonical link.

## Tests

183 tests across the 7 touched files pass; tsc + lint clean. No count *values* changed, so no doc/generator regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)