### PR TITLE
test(security): finding-severity vocabulary consistency guard (Tier B guard, #3570)

### DIFF
--- a/.changeset/severity-consistency-guard.md
+++ b/.changeset/severity-consistency-guard.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+test(security): add finding-severity vocabulary consistency guard
+
+Adds a lockstep test pinning `FindingSeveritySchema` (security/sarif-types.ts) as the canonical 5-value finding-severity vocabulary (`critical|high|medium|low|info`) and asserting the other importable members of that family stay in sync: `VulnerabilitySeveritySchema`, and the key sets of both `SEVERITY_ORDER` maps (sarif-types + dogfooding/pr-review-types). A severity added to one but not another now fails CI instead of drifting silently. The two order maps' values are intentionally inverted (opposite sort directions) so only their key sets are compared. Distinct vocabularies (4-value no-info, major/minor/suggestion, failure/error/audit/hazard) are explicitly out of scope. Tier B (guard step) of evergreen DRY epic #3568; the extract-and-derive consolidation of inline copies is a vote-gated follow-up.

--- a/packages/nexus-agents/src/security/severity-consistency.test.ts
+++ b/packages/nexus-agents/src/security/severity-consistency.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Severity-vocabulary consistency guard (#3570, evergreen DRY epic #3568).
+ *
+ * The 5-value "finding severity" vocabulary (`critical|high|medium|low|info`)
+ * is declared in several places. This test pins `FindingSeveritySchema`
+ * (security/sarif-types.ts) as the canonical source and asserts the other
+ * independently-declared members of that SAME family stay in lockstep — so a
+ * severity added to one but not another fails CI instead of drifting silently.
+ *
+ * Deliberately OUT of scope (distinct vocabularies — do NOT fold in):
+ * - 4-value severity without `info` (voter-response, consensus/types-core).
+ * - `critical|major|minor|suggestion` review-comment severity (voting-protocol).
+ * - failure / error / audit / hazard severities (different domains + values).
+ *
+ * Inline `z.enum([...])` copies (severity-consensus, finding-triage,
+ * output-schemas, triangulated-review, cli severity arrays) are not separately
+ * importable, so they can only be unified by the vote-gated extract-and-derive
+ * follow-up; this guard covers every member that IS importable today.
+ *
+ * Mirrors the gold-standard `config/model-ids-invariant.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FindingSeveritySchema, SEVERITY_ORDER as SARIF_SEVERITY_ORDER } from './sarif-types.js';
+import { SEVERITY_ORDER as PR_REVIEW_SEVERITY_ORDER } from '../dogfooding/pr-review-types.js';
+import { VulnerabilitySeveritySchema } from '../agents/experts/expert-types.js';
+
+const CANONICAL = [...FindingSeveritySchema.options].sort();
+
+describe('finding-severity vocabulary consistency (#3570)', () => {
+  it('canonical FindingSeveritySchema is the 5-value finding family', () => {
+    expect(CANONICAL).toEqual(['critical', 'high', 'info', 'low', 'medium']);
+  });
+
+  it('VulnerabilitySeveritySchema stays in lockstep with the canonical family', () => {
+    expect([...VulnerabilitySeveritySchema.options].sort()).toEqual(CANONICAL);
+  });
+
+  it('sarif SEVERITY_ORDER ranks exactly the canonical severities', () => {
+    expect(Object.keys(SARIF_SEVERITY_ORDER).sort()).toEqual(CANONICAL);
+  });
+
+  it('pr-review SEVERITY_ORDER ranks the same severity set as the canonical', () => {
+    // NOTE: only the KEY SET is asserted, not the values — the two maps use
+    // intentionally INVERTED conventions (sarif: lower = more severe; pr-review:
+    // higher = more severe) for opposite sort directions. Don't "fix" them to match.
+    expect(Object.keys(PR_REVIEW_SEVERITY_ORDER).sort()).toEqual(CANONICAL);
+  });
+
+  it('each SEVERITY_ORDER map is a valid total order (distinct ranks per severity)', () => {
+    for (const map of [SARIF_SEVERITY_ORDER, PR_REVIEW_SEVERITY_ORDER]) {
+      const ranks = Object.values(map);
+      expect(new Set(ranks).size).toBe(ranks.length);
+      expect(ranks.length).toBe(CANONICAL.length);
+    }
+  });
+});


### PR DESCRIPTION
Part of epic #3568 (Tier B — guard step). The extract-and-derive consolidation is a vote-gated follow-up (noted below).

## What

A lockstep consistency test pinning `FindingSeveritySchema` (security/sarif-types.ts) as the canonical 5-value finding-severity vocabulary (`critical|high|medium|low|info`) and asserting the **importable** members of that family stay in sync:
- `VulnerabilitySeveritySchema` (agents/experts) — separately declared, must match.
- Key sets of **both** `SEVERITY_ORDER` maps (security/sarif-types + dogfooding/pr-review-types).

A severity added to one but not another now fails CI instead of drifting silently. Mirrors the gold-standard `config/model-ids-invariant.test.ts`.

## Verified, not blindly applied

- The two `SEVERITY_ORDER` maps' **values are intentionally inverted** (sarif: `critical:0`, lower = more severe; pr-review: `critical:5`, higher = more severe — opposite sort directions). The test asserts only their **key sets**, not values — the subagent's "maps disagree" was a deliberate convention difference, not drift.
- **Out of scope (distinct vocabularies, not folded in):** 4-value severity without `info` (voter-response, consensus/types-core), `critical|major|minor|suggestion` review-comment severity, and failure/error/audit/hazard severities.
- Inline `z.enum([...])` copies (severity-consensus, finding-triage, output-schemas, triangulated-review, cli arrays) aren't separately importable, so they can only be unified by the **vote-gated extract-and-derive follow-up** — this guard covers every member importable today.

## Tests

5 new tests pass; tsc + lint clean. Test-only — no source/count/doc changes.

## Follow-up (vote-gated)

Extract a canonical `FINDING_SEVERITY_LEVELS as const` in sarif-types, derive the inline zod enums from it, and dedup the second SEVERITY_ORDER — architecture change, needs `consensus_vote` per governance. Tracked under #3570 / epic #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)