### PR TITLE
docs: establish run as the default MCP entry point (#3575 slice d)

### DIFF
--- a/.changeset/run-default-entry-point.md
+++ b/.changeset/run-default-entry-point.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+docs: establish `run` as the default MCP entry point
+
+Documents `run` as THE default way to drive nexus-agents (give a goal → MetaOrchestrator selects, and with `execute: true` runs, the right strategy) and frames the specialized pipeline tools (`run_dev_pipeline`, `run_pipeline`, `run_graph_workflow`, `orchestrate`, `execute_spec`, `consensus_vote`, `delegate_to_model`) as advanced force-strategy paths — de-emphasized but fully callable. Completes the demotion condition from the MetaOrchestrator design vote. Increment B slice (d) / closes the functional scope of the run entry point (#3575).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,8 @@ Twelve expert-role prompts ship at `agents/<name>-expert.md` (security, architec
 
 ## MCP server
 
+**Default entry point: `run`.** Give it a goal and the MetaOrchestrator selects the right strategy automatically (and, with `execute: true`, runs it). Reach for `run` first instead of hand-picking a pipeline tool. The specialized tools (`run_dev_pipeline`, `run_pipeline`, `run_graph_workflow`, `orchestrate`, `execute_spec`, `consensus_vote`, `delegate_to_model`) remain fully available as advanced **force-strategy** paths for when you want to pin a specific one.
+
 Nexus-agents exposes 46 MCP tools via stdio. From any MCP-aware agent:
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ Twelve expert-role prompts ship at `agents/<name>-expert.md` (security, architec
 
 ## MCP server
 
+**Default entry point: `run`.** Give it a goal and the MetaOrchestrator selects the right strategy automatically (and, with `execute: true`, runs it). Reach for `run` first instead of hand-picking a pipeline tool. The specialized tools (`run_dev_pipeline`, `run_pipeline`, `run_graph_workflow`, `orchestrate`, `execute_spec`, `consensus_vote`, `delegate_to_model`) remain fully available as advanced **force-strategy** paths for when you want to pin a specific one.
+
 Nexus-agents exposes 46 MCP tools via stdio. From any MCP-aware agent:
 
 ```

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ See [docs/ENTRYPOINTS.md](./docs/ENTRYPOINTS.md) for the complete CLI reference 
 
 ## MCP Tools
 
-When running as an MCP server, the following tools are available:
+When running as an MCP server, the following tools are available. **Start with `run`** — the default entry point: give it a goal and the MetaOrchestrator picks (and, with `execute: true`, runs) the right strategy. The other pipeline tools are advanced force-strategy paths for pinning a specific one.
 
 <!-- Auto-generated below — do not hand-edit between markers. Run `pnpm governance:inject` to update from `packages/nexus-agents/src/mcp/tools/index.ts`. See #2269. -->
 


### PR DESCRIPTION
Part of #3575 (increment B, slice d — the demotion) / epic #3548. The owner-approved Scope-Steward condition: make `run` the default so it *unifies* rather than becoming a 7th orphan entry point.

## What

Docs-only. Establishes `run` as THE default MCP entry point and de-emphasizes the specialized pipeline tools to advanced force-strategy paths (kept fully callable):
- `AGENTS.md` MCP server section (propagates to `CLAUDE.md` via `governance:inject`).
- `README.md` MCP Tools section intro.

No code change; the specialized tools remain registered and usable for pinning a specific strategy.

## Checks

`governance:check` PASS, markdownlint clean, tool count stays 46. Used `**bold**` + backticks (no asterisk-italics — avoids the AGENTS.md→CLAUDE.md italic-normalization gotcha).

## Increment B status

With slices (a)–(d): `run` selects + (execute:true) runs 4 wired strategies (dev-pipeline, pipeline, research, consensus), fails closed on the rest, records outcomes, and is the documented default. Increment B functionally complete. Remaining on epic #3548: learned-selection (steps 3-4), which stays HELD until `run` accumulates real outcome data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)