### PR TITLE
docs(research): evaluate Anthropic defending-code-reference-harness (#3574)

### DIFF
--- a/.changeset/defending-code-harness-eval.md
+++ b/.changeset/defending-code-harness-eval.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+docs(research): evaluate Anthropic defending-code-reference-harness (#3574)
+
+Adds a research-spike findings doc evaluating the (unmaintained) Anthropic defending-code-reference-harness against nexus-agents across five overlap areas, with adopt/adapt/skip + trigger per area (capability-bias gated). Net: two genuine borrows deferred behind triggers — execution-verified findings (stronger than our reasoning-only Discovered-Issues gate) and the generate→validate→iterate patch loop (a model for the #3540 auto-implementation frontier); the rest is shape we already have (consensus/Workflow verify-dedupe, sandbox #2500 + ClawGuard). Reference only — extract patterns, do not vendor.

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,7 @@ Detailed technical documentation:
 | [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug    | Canonical |
 | [mcp-tool-distinctness-v1.md](./research/mcp-tool-distinctness-v1.md)               | MCP tool-description pairwise similarity report (#2650)                    | Canonical |
 | [fitness-stratified-v1.md](./research/fitness-stratified-v1.md)                     | Stratified runtime-outcome report — per adapter / task-type / role (#2662) | Canonical |
+| [defending-code-harness-eval.md](./research/defending-code-harness-eval.md)         | Eval of Anthropic defending-code-reference-harness (#3574)                 | Canonical |
 | [fork-session-spike.md](./research/fork-session-spike.md)                           | Spike: fork_session / branch-comparison on the graph builder (#2665)       | Canonical |
 
 ### Tier 3: Supporting (Reference as Needed)

--- a/docs/research/defending-code-harness-eval.md
+++ b/docs/research/defending-code-harness-eval.md
@@ -1,0 +1,116 @@
+# Evaluation: Anthropic `defending-code-reference-harness`
+
+**Status:** research spike (#3574). **Source:** <https://github.com/anthropics/defending-code-reference-harness>
+— Anthropic reference harness, _"Skills for threat modeling, scanning, triage, patching, plus an
+autonomous scanning harness you can /customize."_ **Unmaintained / not accepting contributions** —
+treat as a design reference to learn from, not a dependency. Anthropic's productized alternative is
+the managed [Claude Security](https://claude.com/product/claude-security) offering.
+
+This doc evaluates what, if anything, to incorporate into nexus-agents. Each area gets an
+**adopt / adapt / skip** call with the trigger that would justify acting, gated by the Mission's
+capability-bias bar (build only when a named nexus-agents loop will measurably use it).
+
+## What the harness is
+
+An end-to-end **autonomous vulnerability discovery + remediation** pipeline on Claude, in two
+surfaces: (a) interactive Claude Code skills (`/quickstart`, `/threat-model`, `/vuln-scan`,
+`/triage`, `/patch`, `/customize`); (b) a reference autonomous harness. Python (~93%), Docker/ASAN
+build targets, gVisor sandbox. 7-stage pipeline:
+
+> **Build** (Docker + ASAN) → **Recon** (partition attack surface) → **Find** (parallel agents craft
+> malformed inputs, hunt crashes) → **Verify** (separate grader reproduces the crash in a fresh
+> container) → **Dedupe** (judge agent: unique vs duplicate) → **Report** (exploitability) →
+> **Patch** (generate + validate fix).
+
+It is narrow by design (memory-safety bugs in C/C++ via fuzzing-style input crafting + ASAN), where
+nexus-agents is a general governance/orchestration substrate. The value to us is the **pipeline
+shape and verification discipline**, not the C/C++ specifics.
+
+## Area-by-area
+
+### 1. Execution-verified findings — **ADAPT** (highest-value idea)
+
+Their **Find → Verify-in-fresh-container** loop reproduces each candidate crash in a clean container
+before it counts. That is a stronger version of our **Discovered-Issues 4-point gate**
+(`.rules/discovered-issues.md`, which is reasoning-based: re-read, trace reachability, name the
+observable failure) and our security pipeline (`src/security/`).
+
+- **We have:** reasoning-based reachability/false-positive gating; `pr_review`'s verification gate.
+- **Gap:** we don't _execute_ a reproduction to confirm a finding.
+- **Adapt:** add an optional **execution-verification step** to the security gate for findings that
+  carry a concrete repro (a failing test / input), run in our existing sandbox (see area 5). Don't
+  build a fuzzing/ASAN harness — adapt the "separate grader reproduces in a fresh env" principle to
+  our finding types (e.g. run the failing assertion the gate names).
+- **Trigger:** when a security/finding loop produces findings with machine-runnable repros and the
+  false-positive rate justifies the sandbox cost. Until then the 4-point gate stays the bar.
+
+### 2. Find → Verify → Dedupe → Patch staging — **SKIP (already have the shape)**
+
+This is the same adversarial-generate → independent-verify → judge-dedupe shape nexus-agents already
+runs via `consensus_vote` (multi-role, independent verification) and the Workflow adversarial-verify
+patterns. The dedupe-by-judge step maps to our consensus aggregation.
+
+- **Skip wholesale adoption** — no new staging engine. **One borrowing:** their explicit
+  **separate-grader** separation (the agent that finds a bug never verifies it) is a clean rule worth
+  making explicit in our verification steps where the same agent currently both finds and confirms.
+- **Trigger:** fold the "finder ≠ verifier" rule into the security gate / pr_review docs if an audit
+  shows a self-verification path. (Low effort, file as a follow-up only if found.)
+
+### 3. Patch generation + validation — **ADAPT → feeds #3540**
+
+Their **Patch** stage generates a fix and **validates** it (re-run, confirm the crash is gone, no
+regressions). This is concretely the "implement" half of the **#3540 auto-implementation frontier**
+and our just-shipped `run execute:true` → MetaOrchestrator dispatch.
+
+- **We have:** `run` can already execute dev-pipeline/pipeline strategies for a goal; the gap-ledger
+  surfaces what to build; #3540 is scoped with human-gate-on-implement.
+- **Adapt:** when #3540 advances, model the **generate-then-validate-then-iterate** loop on their
+  patch stage — a fix isn't "done" until a validation step (tests/repro) passes, with bounded
+  retries. We already have selective-retry + outcome recording to build on.
+- **Trigger:** #3540 implementation start. This is the strongest conceptual borrow for our frontier.
+
+### 4. Skills parity — **ADAPT (small, gap-check)**
+
+Their `/threat-model`, `/vuln-scan`, `/triage`, `/patch` vs our `security-scanning` and
+`security-advisory-response` skills (`skills/`).
+
+- **We have:** `security-scanning`, `security-advisory-response`, plus `repo_security_plan` /
+  `repo_analyze` MCP tools.
+- **Gap:** no dedicated **threat-model** skill (theirs structures attack-surface enumeration before
+  scanning); our triage is folded into advisory-response rather than standalone.
+- **Adapt:** consider a `threat-model` skill (attack-surface enumeration → prioritized scan targets)
+  if a consumer wants it; otherwise skip — don't add skills speculatively (capability-bias).
+- **Trigger:** a security review asks "what should we even scan?" often enough to warrant the skill.
+
+### 5. gVisor isolation — **SKIP / note (we have an equivalent)**
+
+Their autonomous agents run inside **gVisor** containers with egress restricted to the Claude API.
+We already have **sandbox mode** (`NEXUS_SANDBOX` / `NEXUS_SANDBOX_ROOT`, epic #2500) and **ClawGuard**
+access policy (`NEXUS_ACCESS_POLICY_MODE`: off/audit/confirm_risky/enforce).
+
+- **Skip** adopting gVisor specifically. **Note for area 1:** if we add execution-verification, run
+  it under the existing sandbox + an egress-restricted profile — borrow their **egress-allowlist**
+  posture (network restricted to the model API only) as a sandbox hardening option, not a new runtime.
+- **Trigger:** execution-verification (area 1) landing — at which point document/enforce an
+  egress-restricted sandbox profile for untrusted-code execution.
+
+## Summary
+
+| Area                                | Call                                   | Why                                                                         |
+| ----------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
+| 1. Execution-verified findings      | **ADAPT**                              | Strongest gap vs our reasoning-only 4-point gate; run repros in our sandbox |
+| 2. Find→verify→dedupe→patch staging | **SKIP** (borrow finder≠verifier rule) | We already have the shape via consensus/Workflow                            |
+| 3. Patch generate+validate          | **ADAPT → #3540**                      | Direct model for the auto-implementation "implement+validate" loop          |
+| 4. Skills parity                    | **ADAPT** (gap-check threat-model)     | Small; only if a consumer wants it                                          |
+| 5. gVisor isolation                 | **SKIP/note**                          | We have sandbox #2500 + ClawGuard; borrow egress-allowlist posture          |
+
+**Net:** no wholesale adoption. Two genuine borrows — **execution-verified findings** (area 1) and
+the **generate-then-validate patch loop** (area 3, feeding #3540) — both deferred behind their named
+triggers per capability-bias. The rest is shape we already have or speculative. Reference only;
+extract patterns, do not vendor (unmaintained).
+
+## Follow-ups (file if/when triggered)
+
+- Execution-verification step in the security gate (area 1) — design-gate + sandbox/egress profile.
+- `threat-model` skill (area 4) — only with a named consumer.
+- Model #3540's implement stage on the generate→validate→iterate loop (area 3).


### PR DESCRIPTION
Closes #3574. Research spike (owner-requested) — non-code findings doc.

## What

`docs/research/defending-code-harness-eval.md` evaluates the (unmaintained) Anthropic `defending-code-reference-harness` against nexus-agents across the 5 overlap areas, each with an **adopt / adapt / skip + trigger**, capability-bias gated:

| Area | Call |
| --- | --- |
| Execution-verified findings | **ADAPT** (strongest gap vs our reasoning-only Discovered-Issues gate) |
| Find→verify→dedupe→patch staging | **SKIP** (we have the shape; borrow finder≠verifier rule) |
| Patch generate+validate | **ADAPT → feeds #3540** (model for the auto-implementation implement-loop) |
| Skills parity | **ADAPT** (gap-check a threat-model skill, only with a consumer) |
| gVisor isolation | **SKIP/note** (we have sandbox #2500 + ClawGuard; borrow egress-allowlist) |

**Net:** no wholesale adoption. Two genuine borrows (execution-verified findings; generate→validate patch loop) deferred behind named triggers. Reference only — extract patterns, don't vendor (managed Claude Security is the productized alternative).

Indexed in `docs/README.md`. Follow-ups are listed in the doc and intentionally **not filed as issues yet** (trigger-conditional / YAGNI until their trigger fires).

## Checks

lint:md + governance:check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)