### PR TITLE
fix(consensus): retry voter vote without responseFormat on tool-use 404 (#3497)

### DIFF
--- a/.changeset/defending-code-harness-eval.md
+++ b/.changeset/defending-code-harness-eval.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+docs(research): evaluate Anthropic defending-code-reference-harness (#3574)
+
+Adds a research-spike findings doc evaluating the (unmaintained) Anthropic defending-code-reference-harness against nexus-agents across five overlap areas, with adopt/adapt/skip + trigger per area (capability-bias gated). Net: two genuine borrows deferred behind triggers — execution-verified findings (stronger than our reasoning-only Discovered-Issues gate) and the generate→validate→iterate patch loop (a model for the #3540 auto-implementation frontier); the rest is shape we already have (consensus/Workflow verify-dedupe, sandbox #2500 + ClawGuard). Reference only — extract patterns, do not vendor.

--- a/.changeset/voter-tool-use-404-retry.md
+++ b/.changeset/voter-tool-use-404-retry.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): retry voter completion without responseFormat on tool-use 404
+
+Restores the 2/7 voters (OpenRouter-backed devex/catfish) that failed every vote with `404 "No endpoints found that support tool use"`. Root cause: the vote request asks for native structured output via `responseFormat: json_schema`, which OpenRouter implements through provider tool-use — a provider without tool-use endpoints returns a hard 404 instead of ignoring the field, silently shrinking a 7-role panel to 5. The fix retries the completion once without `responseFormat` on that specific error (the existing prose-JSON parse path handles a response without it), keeping the panel at full strength. Generic errors are unaffected (no retry). Fixes #3497.

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,7 @@ Detailed technical documentation:
 | [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug    | Canonical |
 | [mcp-tool-distinctness-v1.md](./research/mcp-tool-distinctness-v1.md)               | MCP tool-description pairwise similarity report (#2650)                    | Canonical |
 | [fitness-stratified-v1.md](./research/fitness-stratified-v1.md)                     | Stratified runtime-outcome report — per adapter / task-type / role (#2662) | Canonical |
+| [defending-code-harness-eval.md](./research/defending-code-harness-eval.md)         | Eval of Anthropic defending-code-reference-harness (#3574)                 | Canonical |
 | [fork-session-spike.md](./research/fork-session-spike.md)                           | Spike: fork_session / branch-comparison on the graph builder (#2665)       | Canonical |
 
 ### Tier 3: Supporting (Reference as Needed)

--- a/docs/research/defending-code-harness-eval.md
+++ b/docs/research/defending-code-harness-eval.md
@@ -1,0 +1,116 @@
+# Evaluation: Anthropic `defending-code-reference-harness`
+
+**Status:** research spike (#3574). **Source:** <https://github.com/anthropics/defending-code-reference-harness>
+— Anthropic reference harness, _"Skills for threat modeling, scanning, triage, patching, plus an
+autonomous scanning harness you can /customize."_ **Unmaintained / not accepting contributions** —
+treat as a design reference to learn from, not a dependency. Anthropic's productized alternative is
+the managed [Claude Security](https://claude.com/product/claude-security) offering.
+
+This doc evaluates what, if anything, to incorporate into nexus-agents. Each area gets an
+**adopt / adapt / skip** call with the trigger that would justify acting, gated by the Mission's
+capability-bias bar (build only when a named nexus-agents loop will measurably use it).
+
+## What the harness is
+
+An end-to-end **autonomous vulnerability discovery + remediation** pipeline on Claude, in two
+surfaces: (a) interactive Claude Code skills (`/quickstart`, `/threat-model`, `/vuln-scan`,
+`/triage`, `/patch`, `/customize`); (b) a reference autonomous harness. Python (~93%), Docker/ASAN
+build targets, gVisor sandbox. 7-stage pipeline:
+
+> **Build** (Docker + ASAN) → **Recon** (partition attack surface) → **Find** (parallel agents craft
+> malformed inputs, hunt crashes) → **Verify** (separate grader reproduces the crash in a fresh
+> container) → **Dedupe** (judge agent: unique vs duplicate) → **Report** (exploitability) →
+> **Patch** (generate + validate fix).
+
+It is narrow by design (memory-safety bugs in C/C++ via fuzzing-style input crafting + ASAN), where
+nexus-agents is a general governance/orchestration substrate. The value to us is the **pipeline
+shape and verification discipline**, not the C/C++ specifics.
+
+## Area-by-area
+
+### 1. Execution-verified findings — **ADAPT** (highest-value idea)
+
+Their **Find → Verify-in-fresh-container** loop reproduces each candidate crash in a clean container
+before it counts. That is a stronger version of our **Discovered-Issues 4-point gate**
+(`.rules/discovered-issues.md`, which is reasoning-based: re-read, trace reachability, name the
+observable failure) and our security pipeline (`src/security/`).
+
+- **We have:** reasoning-based reachability/false-positive gating; `pr_review`'s verification gate.
+- **Gap:** we don't _execute_ a reproduction to confirm a finding.
+- **Adapt:** add an optional **execution-verification step** to the security gate for findings that
+  carry a concrete repro (a failing test / input), run in our existing sandbox (see area 5). Don't
+  build a fuzzing/ASAN harness — adapt the "separate grader reproduces in a fresh env" principle to
+  our finding types (e.g. run the failing assertion the gate names).
+- **Trigger:** when a security/finding loop produces findings with machine-runnable repros and the
+  false-positive rate justifies the sandbox cost. Until then the 4-point gate stays the bar.
+
+### 2. Find → Verify → Dedupe → Patch staging — **SKIP (already have the shape)**
+
+This is the same adversarial-generate → independent-verify → judge-dedupe shape nexus-agents already
+runs via `consensus_vote` (multi-role, independent verification) and the Workflow adversarial-verify
+patterns. The dedupe-by-judge step maps to our consensus aggregation.
+
+- **Skip wholesale adoption** — no new staging engine. **One borrowing:** their explicit
+  **separate-grader** separation (the agent that finds a bug never verifies it) is a clean rule worth
+  making explicit in our verification steps where the same agent currently both finds and confirms.
+- **Trigger:** fold the "finder ≠ verifier" rule into the security gate / pr_review docs if an audit
+  shows a self-verification path. (Low effort, file as a follow-up only if found.)
+
+### 3. Patch generation + validation — **ADAPT → feeds #3540**
+
+Their **Patch** stage generates a fix and **validates** it (re-run, confirm the crash is gone, no
+regressions). This is concretely the "implement" half of the **#3540 auto-implementation frontier**
+and our just-shipped `run execute:true` → MetaOrchestrator dispatch.
+
+- **We have:** `run` can already execute dev-pipeline/pipeline strategies for a goal; the gap-ledger
+  surfaces what to build; #3540 is scoped with human-gate-on-implement.
+- **Adapt:** when #3540 advances, model the **generate-then-validate-then-iterate** loop on their
+  patch stage — a fix isn't "done" until a validation step (tests/repro) passes, with bounded
+  retries. We already have selective-retry + outcome recording to build on.
+- **Trigger:** #3540 implementation start. This is the strongest conceptual borrow for our frontier.
+
+### 4. Skills parity — **ADAPT (small, gap-check)**
+
+Their `/threat-model`, `/vuln-scan`, `/triage`, `/patch` vs our `security-scanning` and
+`security-advisory-response` skills (`skills/`).
+
+- **We have:** `security-scanning`, `security-advisory-response`, plus `repo_security_plan` /
+  `repo_analyze` MCP tools.
+- **Gap:** no dedicated **threat-model** skill (theirs structures attack-surface enumeration before
+  scanning); our triage is folded into advisory-response rather than standalone.
+- **Adapt:** consider a `threat-model` skill (attack-surface enumeration → prioritized scan targets)
+  if a consumer wants it; otherwise skip — don't add skills speculatively (capability-bias).
+- **Trigger:** a security review asks "what should we even scan?" often enough to warrant the skill.
+
+### 5. gVisor isolation — **SKIP / note (we have an equivalent)**
+
+Their autonomous agents run inside **gVisor** containers with egress restricted to the Claude API.
+We already have **sandbox mode** (`NEXUS_SANDBOX` / `NEXUS_SANDBOX_ROOT`, epic #2500) and **ClawGuard**
+access policy (`NEXUS_ACCESS_POLICY_MODE`: off/audit/confirm_risky/enforce).
+
+- **Skip** adopting gVisor specifically. **Note for area 1:** if we add execution-verification, run
+  it under the existing sandbox + an egress-restricted profile — borrow their **egress-allowlist**
+  posture (network restricted to the model API only) as a sandbox hardening option, not a new runtime.
+- **Trigger:** execution-verification (area 1) landing — at which point document/enforce an
+  egress-restricted sandbox profile for untrusted-code execution.
+
+## Summary
+
+| Area                                | Call                                   | Why                                                                         |
+| ----------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
+| 1. Execution-verified findings      | **ADAPT**                              | Strongest gap vs our reasoning-only 4-point gate; run repros in our sandbox |
+| 2. Find→verify→dedupe→patch staging | **SKIP** (borrow finder≠verifier rule) | We already have the shape via consensus/Workflow                            |
+| 3. Patch generate+validate          | **ADAPT → #3540**                      | Direct model for the auto-implementation "implement+validate" loop          |
+| 4. Skills parity                    | **ADAPT** (gap-check threat-model)     | Small; only if a consumer wants it                                          |
+| 5. gVisor isolation                 | **SKIP/note**                          | We have sandbox #2500 + ClawGuard; borrow egress-allowlist posture          |
+
+**Net:** no wholesale adoption. Two genuine borrows — **execution-verified findings** (area 1) and
+the **generate-then-validate patch loop** (area 3, feeding #3540) — both deferred behind their named
+triggers per capability-bias. The rest is shape we already have or speculative. Reference only;
+extract patterns, do not vendor (unmaintained).
+
+## Follow-ups (file if/when triggered)
+
+- Execution-verification step in the security gate (area 1) — design-gate + sandbox/egress profile.
+- `threat-model` skill (area 4) — only with a named consumer.
+- Model #3540's implement stage on the generate→validate→iterate loop (area 3).

--- a/packages/nexus-agents/src/cli/voter-execution.test.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.test.ts
@@ -459,6 +459,47 @@ describe('voter-execution', () => {
       expect(request.responseFormat?.schema).toBeDefined();
     });
 
+    it('retries WITHOUT responseFormat on a tool-use-unsupported 404 and succeeds (#3497)', async () => {
+      const toolUse404: MockCompletionResult = {
+        ok: false,
+        error: new ModelError('No endpoints found that support tool use. Try disabling "bash".'),
+      };
+      const success: MockCompletionResult = {
+        ok: true,
+        value: {
+          content: [{ type: 'text', text: VALID_VOTE_JSON }],
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          stopReason: 'end_turn',
+          model: 'test-model',
+        },
+      };
+      vi.mocked(mockAdapter.complete)
+        .mockResolvedValueOnce(toolUse404)
+        .mockResolvedValueOnce(success);
+
+      const result = await executeSingleVoteAttempt('devex', 'Test proposal', mockAdapter, 5000);
+
+      expect(result.ok).toBe(true);
+      const calls = vi.mocked(mockAdapter.complete).mock.calls;
+      expect(calls).toHaveLength(2);
+      // First attempt asks for structured output; the retry omits it.
+      expect((calls[0]?.[0] as { responseFormat?: unknown }).responseFormat).toBeDefined();
+      expect((calls[1]?.[0] as { responseFormat?: unknown }).responseFormat).toBeUndefined();
+    });
+
+    it('does NOT retry on a non-tool-use error (#3497)', async () => {
+      const genericError: MockCompletionResult = {
+        ok: false,
+        error: new ModelError('Rate limit exceeded (429)'),
+      };
+      vi.mocked(mockAdapter.complete).mockResolvedValue(genericError);
+
+      const result = await executeSingleVoteAttempt('catfish', 'Test proposal', mockAdapter, 5000);
+
+      expect(result.ok).toBe(false);
+      expect(vi.mocked(mockAdapter.complete).mock.calls).toHaveLength(1);
+    });
+
     it('still parses a structured-output vote object the same as prose JSON (fallback parity)', async () => {
       // Whether the vote arrives via native structured output or the regex
       // fallback, the content is JSON text and parses identically (#3433).

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -240,76 +240,89 @@ export function extractTextFromResponse(content: unknown): string {
  * This ensures we only get real LLM votes, not synthetic fallbacks.
  * (Source: Issue #512 - Fail-safe voting)
  */
+/**
+ * Builds the vote completion request. `withResponseFormat` toggles the native
+ * structured-output ask (#3433): on for the first attempt, off for the #3497
+ * retry against backends that route `json_schema` through provider tool-use.
+ * The `parseVoteResponse` regex/Zod path below accepts prose-wrapped JSON, so
+ * omitting `responseFormat` is safe — it just loses the schema-enforced shape.
+ */
+function buildVoteRequest(
+  role: VoterRole,
+  proposal: string,
+  timeoutMs: number,
+  withResponseFormat: boolean
+): CompletionRequest {
+  const base: CompletionRequest = {
+    messages: [
+      { role: 'system', content: VOTER_SYSTEM_PROMPTS[role] },
+      { role: 'user', content: buildVotePrompt(proposal) },
+    ],
+    // 2000 (#2245): JSON envelope + reasoning + YAML findings exceed the old 500.
+    maxTokens: 2000,
+    temperature: 0.3, // Low temperature for consistent evaluations
+    // Thread the vote budget so the CLI timeout doesn't fire first (#3304); pass
+    // signal too for CLI-vs-API cancellation parity (#3036/#3304).
+    timeoutMs,
+    signal: AbortSignal.timeout(timeoutMs),
+  };
+  return withResponseFormat
+    ? { ...base, responseFormat: { type: 'json_schema', schema: VOTE_JSON_SCHEMA } }
+    : base;
+}
+
+/**
+ * #3497: some backends don't silently ignore an unsupported `responseFormat`.
+ * OpenRouter implements `json_schema` via provider tool-use, so a role routed to
+ * a provider without tool-use returns a hard 404 "No endpoints found that
+ * support tool use" instead of ignoring the field — silently shrinking the panel
+ * (observed on devex/catfish). Detect it so the caller retries without it.
+ */
+function isStructuredOutputUnsupported(errorMessage: string): boolean {
+  return /support tool use/i.test(errorMessage);
+}
+
+/** One completion attempt: build → complete (timeout-bounded) → extract text. */
+async function runVoteCompletion(
+  role: VoterRole,
+  proposal: string,
+  adapter: IModelAdapter,
+  timeoutMs: number,
+  withResponseFormat: boolean
+): Promise<{ ok: true; output: string } | { ok: false; error: string }> {
+  const request = buildVoteRequest(role, proposal, timeoutMs, withResponseFormat);
+  const timeoutResult = await withTimeout(
+    adapter.complete(request),
+    timeoutMs,
+    `Vote timeout after ${String(timeoutMs)}ms for role: ${role}`
+  );
+  if (!timeoutResult.ok) return { ok: false, error: timeoutResult.error };
+  const response = timeoutResult.value;
+  if (!response.ok) return { ok: false, error: response.error.message };
+  return { ok: true, output: extractTextFromResponse(response.value.content) };
+}
+
 export async function executeSingleVoteAttempt(
   role: VoterRole,
   proposal: string,
   adapter: IModelAdapter,
   timeoutMs: number
 ): Promise<{ ok: true; vote: Vote; output: string } | { ok: false; error: string }> {
-  const request: CompletionRequest = {
-    messages: [
-      { role: 'system', content: VOTER_SYSTEM_PROMPTS[role] },
-      { role: 'user', content: buildVotePrompt(proposal) },
-    ],
-    // 500 was correct for short proposal-style votes but caused mid-string
-    // truncation ("Unterminated string in JSON at position N") in #2241 v3
-    // when voters review code diffs — the JSON envelope + reasoning + YAML
-    // findings block routinely exceed 500 tokens. Bumped to 2000 (#2245);
-    // refine per use case if needed.
-    maxTokens: 2000,
-    temperature: 0.3, // Low temperature for consistent evaluations
-    // #3433: request native structured output (Claude tool_use / OpenAI+Gemini
-    // json mode) so the vote arrives as a schema-valid JSON object instead of
-    // prose-wrapped JSON. When an adapter DOES honor it, the
-    // extractTextFromResponse + parseVoteResponse regex/Zod path below still
-    // accepts the result, so it's also the fallback for prose-returning backends.
-    //
-    // CAVEAT (#3497): not every backend "silently ignores" an unsupported
-    // responseFormat. OpenRouter implements `json_schema` via provider tool-use,
-    // so a role routed to a provider without tool-use returns a hard
-    // 404 "No endpoints found that support tool use" rather than ignoring the
-    // field. Those voters then error → abstain (the panel degrades to the
-    // succeeding voters). The real fix — gate `responseFormat` on a model
-    // structured-output capability, or retry-without-it on that 404 — is tracked
-    // in #3497; this comment no longer claims a universal "no behavior change".
-    responseFormat: { type: 'json_schema', schema: VOTE_JSON_SCHEMA },
-    // Thread the vote's budget into the adapter so its shorter standard CLI
-    // timeout doesn't fire first and surface as an MCP -32001 on slow voters
-    // (e.g. the Security role on complex proposals) (#3304).
-    timeoutMs,
-    // CLI adapters honor `timeoutMs`; API adapters honor `signal` (#3036). Pass
-    // both so the slow voter is cancelled cleanly at the vote budget regardless
-    // of backing (CLI subprocess SIGTERM'd via #3026, API SDK call aborted) —
-    // CLI-vs-API parity for the vote timeout (#3304).
-    signal: AbortSignal.timeout(timeoutMs),
-  };
-
-  const timeoutResult = await withTimeout(
-    adapter.complete(request),
-    timeoutMs,
-    `Vote timeout after ${String(timeoutMs)}ms for role: ${role}`
-  );
-
-  if (!timeoutResult.ok) {
-    return { ok: false, error: timeoutResult.error };
+  let completion = await runVoteCompletion(role, proposal, adapter, timeoutMs, true);
+  // #3497: retry once WITHOUT responseFormat when the backend rejects the
+  // tool-use-backed structured-output ask, so the panel keeps full strength.
+  if (!completion.ok && isStructuredOutputUnsupported(completion.error)) {
+    completion = await runVoteCompletion(role, proposal, adapter, timeoutMs, false);
   }
-
-  const response = timeoutResult.value;
-
-  if (!response.ok) {
-    return { ok: false, error: response.error.message };
-  }
-
-  const output = extractTextFromResponse(response.value.content);
+  if (!completion.ok) return { ok: false, error: completion.error };
 
   try {
-    // parseVoteResponse throws SyntheticVoteError by default if parsing fails
-    // This ensures we only accept real LLM votes, not synthetic fallbacks
-    const vote = parseVoteResponse(output, role);
-    return { ok: true, vote, output };
+    // parseVoteResponse throws SyntheticVoteError if parsing fails — we only
+    // accept real LLM votes, not synthetic fallbacks.
+    const vote = parseVoteResponse(completion.output, role);
+    return { ok: true, vote, output: completion.output };
   } catch (error) {
     if (error instanceof SyntheticVoteError) {
-      // Parsing failed - return error to trigger retry
       return { ok: false, error: `Vote parsing failed: ${error.message}` };
     }
     throw error; // Re-throw unexpected errors


### PR DESCRIPTION
Closes #3497. Restores the 2/7 voters (OpenRouter-backed devex/catfish) that errored on **every** vote — a bug I reproduced first-hand in every `consensus_vote` this session.

## Root cause

The vote request asks for native structured output via `responseFormat: { type: 'json_schema' }` (#3433). OpenRouter implements `json_schema` through **provider tool-use**, so a role routed to a provider without tool-use endpoints returns a hard `404 "No endpoints found that support tool use"` instead of ignoring the field — silently shrinking a 7-role panel to 5. (The code already had a `#3497` comment naming this.)

## Fix

Retry the completion **once without `responseFormat`** on that specific error — the existing `parseVoteResponse` regex/Zod path already accepts prose-wrapped JSON, so the retry succeeds and the panel keeps full strength. Generic errors (e.g. 429) don't trigger the retry. Refactored the inline request build into `buildVoteRequest` + `runVoteCompletion` to support the two-attempt flow cleanly (each helper under the line cap).

Aligns with Rule-of-Two too: a vote needs no tool access.

## Tests

61 pass, incl. 2 new: retry-without-responseFormat-on-404 (asserts 2 calls; first has `responseFormat`, retry omits it) and no-retry-on-generic-error. tsc + lint clean.

## Follow-up

Issue part 3 (panel-degradation warning when fewer than N voters return) filed as **#3587** — a separate observability enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)