### PR TITLE
fix(mcp): correct ci_health_check annotation — not read-only/idempotent (#3530)

### DIFF
--- a/.changeset/ci-health-annotation.md
+++ b/.changeset/ci-health-annotation.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): correct ci_health_check annotation — not read-only/idempotent
+
+`ci_health_check` appends a CI-health telemetry event on every call (`appendCiHealthEvent`), so its MCP annotation claiming `readOnlyHint: true` + `idempotentHint: true` was inaccurate (#3530). Sets both to false and documents the per-call telemetry append in `sideEffects`. Because the tool is now non-read-only, the `check:tool-prerequisites` gate requires it to be classified — added to `NO_PREREQUISITE` (it has no world-state precondition). No behavior change; the annotation now matches reality.

--- a/packages/nexus-agents/src/mcp/middleware/tool-prerequisites.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-prerequisites.ts
@@ -140,6 +140,8 @@ export const NO_PREREQUISITE: Record<string, string> = {
   run_dev_pipeline: 'pipeline execution is self-contained; stage tools carry their own gates',
   execute_spec: 'spec execution is self-contained; stage tools carry their own gates',
   consensus_vote: 'voter-CLI availability is handled by per-voter fallback, not a pre-gate',
+  ci_health_check:
+    'reads upstream CI status + appends a telemetry event (#3530); no world-state precondition to gate',
   supply_chain_tradeoff_panel: 'wraps consensus_vote; same per-voter fallback applies',
   pr_review: 'wraps consensus_vote; same per-voter fallback applies',
   research_add:

--- a/packages/nexus-agents/src/mcp/tools/tool-annotations.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-annotations.ts
@@ -547,10 +547,14 @@ export const TOOL_ANNOTATIONS: Readonly<Record<string, ToolSideEffectsEntry>> = 
   },
   ci_health_check: {
     annotations: {
+      // #3530: NOT read-only / idempotent — every call appends a CI-health
+      // telemetry event (appendCiHealthEvent in ci-health-check-tool.ts), which
+      // both writes local state and accumulates per call. The check itself only
+      // reads upstream, but the per-call telemetry append is a real side effect.
       title: 'CI Health Check',
-      readOnlyHint: true,
+      readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       // Outbound network to githubstatus.com + GitHub API.
       openWorldHint: true,
     },
@@ -559,6 +563,10 @@ export const TOOL_ANNOTATIONS: Readonly<Record<string, ToolSideEffectsEntry>> = 
         category: 'implicit',
         description:
           'Fetches GitHub status-page + repo actions/runs to assess CI infrastructure health (#3076)',
+      },
+      {
+        category: 'implicit',
+        description: 'Appends a local CI-health telemetry event per call for observability (#3530)',
       },
     ],
   },


### PR DESCRIPTION
Closes #3530.

## What

`ci_health_check`'s MCP annotation claimed `readOnlyHint: true` + `idempotentHint: true`, but the handler calls `appendCiHealthEvent(...)` on **every** invocation (a per-call telemetry write — the tool's own module comment already noted "so it is NOT [read-only]"). Fixed the annotation to match reality:
- `readOnlyHint: false`, `idempotentHint: false`.
- Documented the per-call telemetry append in `sideEffects`.

## Downstream (the consistency guards working)

Making it non-read-only tripped the `check:tool-prerequisites` gate (every non-read-only tool must be classified) — added `ci_health_check` to `NO_PREREQUISITE` (no world-state precondition to gate). The Phase-2 consolidated registry-consistency test (#3565) confirms no orphan key.

## Checks

40 + 15 tests pass; tsc + lint + governance:check clean. Verified the append-per-call behavior in code before acting (the annotation was genuinely wrong, not a false finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)