### PR TITLE
refactor(security): single canonical FINDING_SEVERITY_LEVELS (#3570)

### DIFF
--- a/.changeset/finding-severity-levels.md
+++ b/.changeset/finding-severity-levels.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+refactor(security): single canonical FINDING_SEVERITY_LEVELS source
+
+Extracts `FINDING_SEVERITY_LEVELS` (`['critical','high','medium','low','info'] as const`) in `security/sarif-types.ts` as the single source of truth for the 5-value finding-severity vocabulary. The five previously-inline `z.enum([...])` re-declarations (severity-consensus, finding-triage, agents/output-schemas ×2, expert-types VulnerabilitySeverity) + the pr-review `minSeverity` enum + `ReviewSeverity` type now derive from it, and both `SEVERITY_ORDER` maps derive their keys from the tuple (sarif ascending; pr-review keeps its intentionally-inverted descending direction — only the key set is unified). No behavior change; the #3570/#3579 lockstep guard stays green and now structurally can't drift. Scoped to the 5-value family only — the distinct 4-value and major/minor/suggestion vocabularies are untouched. consensus_vote 5/0.

--- a/packages/nexus-agents/src/agents/experts/expert-types.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-types.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import { FINDING_SEVERITY_LEVELS } from '../../security/sarif-types.js';
 import type { AgentCapability, AgentRole } from '../../core/index.js';
 
 // Re-export base types for backward compatibility
@@ -258,7 +259,7 @@ export const ExpertOutputSchema = z.object({
 /**
  * Vulnerability severity schema.
  */
-export const VulnerabilitySeveritySchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
+export const VulnerabilitySeveritySchema = z.enum(FINDING_SEVERITY_LEVELS);
 
 /**
  * Vulnerability schema.

--- a/packages/nexus-agents/src/agents/output-schemas/index.ts
+++ b/packages/nexus-agents/src/agents/output-schemas/index.ts
@@ -13,13 +13,14 @@
  */
 
 import { z } from 'zod';
+import { FINDING_SEVERITY_LEVELS } from '../../security/sarif-types.js';
 import type { BuiltInExpertType } from '../experts/expert-config.js';
 
 /**
  * Security audit finding schema.
  */
 export const SecurityFindingSchema = z.object({
-  severity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+  severity: z.enum(FINDING_SEVERITY_LEVELS),
   title: z.string(),
   location: z.string().optional(),
   description: z.string(),
@@ -43,7 +44,7 @@ export const SecurityAuditOutputSchema = z.object({
  */
 export const CodeReviewItemSchema = z.object({
   category: z.enum(['bug', 'security', 'performance', 'style', 'suggestion']),
-  severity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+  severity: z.enum(FINDING_SEVERITY_LEVELS),
   file: z.string().optional(),
   line: z.number().optional(),
   description: z.string(),

--- a/packages/nexus-agents/src/dogfooding/pr-review-types.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-review-types.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import type { FullCapableProvider } from '../scm/types.js';
+import { FINDING_SEVERITY_LEVELS } from '../security/sarif-types.js';
 
 /**
  * Pull request file change information.
@@ -70,7 +71,7 @@ export interface PRMetadata {
 /**
  * Review severity levels.
  */
-export type ReviewSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+export type ReviewSeverity = (typeof FINDING_SEVERITY_LEVELS)[number];
 
 /**
  * Review category for organizing findings.
@@ -263,7 +264,7 @@ export const PRReviewConfigSchema = z.object({
     .default(['security', 'code_quality', 'testing']),
   maxDebateRounds: z.number().int().min(1).max(10).default(3),
   consensusThreshold: z.number().min(0).max(1).default(0.7),
-  minSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']).default('low'),
+  minSeverity: z.enum(FINDING_SEVERITY_LEVELS).default('low'),
   enableInlineComments: z.boolean().default(true),
   dryRun: z.boolean().default(false),
   enableReputation: z.boolean().default(true),
@@ -277,15 +278,14 @@ export const PRReviewConfigSchema = z.object({
 });
 
 /**
- * Severity order for comparison.
+ * Severity order for comparison. INVERTED vs sarif-types' SEVERITY_ORDER by
+ * design (higher = more severe here, for descending sort); only the KEY SET is
+ * shared. Derived from the canonical {@link FINDING_SEVERITY_LEVELS} so the keys
+ * can't drift (#3570): critical→5 … info→1.
  */
-export const SEVERITY_ORDER: Record<ReviewSeverity, number> = {
-  critical: 5,
-  high: 4,
-  medium: 3,
-  low: 2,
-  info: 1,
-};
+export const SEVERITY_ORDER: Record<ReviewSeverity, number> = Object.fromEntries(
+  FINDING_SEVERITY_LEVELS.map((level, index) => [level, FINDING_SEVERITY_LEVELS.length - index])
+) as Record<ReviewSeverity, number>;
 
 /**
  * Category display names.

--- a/packages/nexus-agents/src/security/finding-triage.ts
+++ b/packages/nexus-agents/src/security/finding-triage.ts
@@ -9,6 +9,7 @@
 
 import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
+import { FINDING_SEVERITY_LEVELS } from './sarif-types.js';
 import { SEVERITY_ORDER } from './sarif-types.js';
 import { readFileSync } from 'node:fs';
 import { resolveInsideRoot } from './safe-path.js';
@@ -21,7 +22,7 @@ export const TriageVerdictSchema = z.object({
   confirmed: z.boolean(),
   confidence: z.number().min(0).max(1),
   reasoning: z.string().max(1000),
-  suggestedSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+  suggestedSeverity: z.enum(FINDING_SEVERITY_LEVELS),
 });
 
 export type TriageVerdict = z.infer<typeof TriageVerdictSchema>;

--- a/packages/nexus-agents/src/security/sarif-types.ts
+++ b/packages/nexus-agents/src/security/sarif-types.ts
@@ -15,8 +15,17 @@ import { z } from 'zod';
 // Unified Security Finding Schema
 // ============================================================================
 
+/**
+ * Canonical 5-value finding-severity vocabulary (CVSS-aligned), most→least
+ * severe. THE single source of truth — every 5-value finding-severity zod enum
+ * (severity-consensus, finding-triage, agents/output-schemas, expert-types
+ * VulnerabilitySeverity) and both SEVERITY_ORDER maps derive from this (#3570).
+ * Tuple order is authoritative: SEVERITY_ORDER below maps it to ascending ranks.
+ */
+export const FINDING_SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low', 'info'] as const;
+
 /** Severity levels aligned with CVSS and common scanner output. */
-export const FindingSeveritySchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
+export const FindingSeveritySchema = z.enum(FINDING_SEVERITY_LEVELS);
 export type FindingSeverity = z.infer<typeof FindingSeveritySchema>;
 
 /** A normalized security finding from any SARIF-compatible scanner. */
@@ -73,11 +82,10 @@ export const SARIF_LEVEL_MAP: Readonly<Record<string, FindingSeverity>> = {
   none: 'info',
 };
 
-/** Severity order for sorting (lower = more severe). */
-export const SEVERITY_ORDER: Readonly<Record<FindingSeverity, number>> = {
-  critical: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-  info: 4,
-};
+/**
+ * Severity order for sorting (lower = more severe). Derived from the canonical
+ * tuple so it can never drift from {@link FINDING_SEVERITY_LEVELS} (#3570).
+ */
+export const SEVERITY_ORDER: Readonly<Record<FindingSeverity, number>> = Object.fromEntries(
+  FINDING_SEVERITY_LEVELS.map((level, index) => [level, index])
+) as Record<FindingSeverity, number>;

--- a/packages/nexus-agents/src/security/severity-consensus.ts
+++ b/packages/nexus-agents/src/security/severity-consensus.ts
@@ -9,6 +9,7 @@
 
 import { z } from 'zod';
 import type { SecurityFinding } from './sarif-types.js';
+import { FINDING_SEVERITY_LEVELS } from './sarif-types.js';
 import type { TriageVerdict, TriagedFinding } from './finding-triage.js';
 export type { TriagedFinding } from './finding-triage.js';
 
@@ -17,8 +18,8 @@ export type { TriagedFinding } from './finding-triage.js';
 // ============================================================================
 
 export const SeverityVerdictSchema = z.object({
-  originalSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
-  consensusSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+  originalSeverity: z.enum(FINDING_SEVERITY_LEVELS),
+  consensusSeverity: z.enum(FINDING_SEVERITY_LEVELS),
   approved: z.boolean(),
   approvalPercentage: z.number().min(0).max(100),
   reasoning: z.string().max(500),


### PR DESCRIPTION
Closes #3570. **consensus_vote (higher_order): 5/0 approved.** Follows the #3579 guard (Tier B of evergreen epic #3568).

## What

One canonical `FINDING_SEVERITY_LEVELS = ['critical','high','medium','low','info'] as const` in `security/sarif-types.ts`; everything in the 5-value finding-severity family derives from it:
- `FindingSeveritySchema`, `VulnerabilitySeveritySchema`, `severity-consensus` (×2), `finding-triage`, `agents/output-schemas` (×2), pr-review `minSeverity` → `z.enum(FINDING_SEVERITY_LEVELS)`.
- `ReviewSeverity` type → `(typeof FINDING_SEVERITY_LEVELS)[number]`.
- Both `SEVERITY_ORDER` maps derive keys from the tuple; **sarif ascending, pr-review keeps its intentionally-inverted descending direction** (only the key set is unified — verified, not flattened).

## Scope discipline

5-value family ONLY. The distinct 4-value severity (voter-response/types-core, no `info`) and the `critical|major|minor|suggestion` review-comment vocabulary are untouched.

## Proof

No behavior change. The #3579 lockstep guard stays green — and now the enums *structurally* derive from one const, so they can't drift. **2285 tests pass** across security/agents/dogfooding; tsc + lint + governance:check clean. No import cycle (sarif-types is a zod-only leaf; verified consumers → leaf is one-directional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)