### PR TITLE
feat(orchestration): shadow-logged learned strategy selection (#3551)

### DIFF
--- a/.changeset/meta-shadow-selection.md
+++ b/.changeset/meta-shadow-selection.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): shadow-logged learned strategy selection (#3551)
+
+MetaOrchestrator step 3 of epic #3548. Adds a learned selector that, given the
+same task signals as the rule-based selection, predicts an `ExecutionStrategy`
+and logs its would-be choice alongside the executed rule-based choice — SHADOW
+MODE only; the learned choice is never acted on (that is step 4 / #3552). It
+reuses the existing `LinUCBBandit` (arms = strategies) rather than forking a
+second learning stack, and exposes `summarizeShadowAgreement()` as the
+would-select-vs-selected comparison surface (overall + per task class) for
+offline policy evaluation. Shadow logging is wired default-on into the `run`
+entry point via process-scoped singletons; the executed path is unchanged.

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -39,6 +39,7 @@ import {
   type MetaDecision,
   type MetaOrchestratorInput,
 } from '../../orchestration/meta-orchestrator.js';
+import { getShadowSelector, getShadowSink } from '../../orchestration/meta-shadow-selector.js';
 import {
   createMetaDispatcher,
   MetaDispatchError,
@@ -144,7 +145,14 @@ function toMetaInput(
 
 /** Selects a strategy for a goal via the MetaOrchestrator. */
 function selectDecision(input: RunInput, logger?: ILogger): MetaDecision {
-  const meta = createMetaOrchestrator(logger !== undefined ? { logger } : undefined);
+  // Shadow-mode learned selection (#3551): the process-scoped selector + sink
+  // log a would-be learned choice alongside the executed rule-based choice.
+  // Never alters what runs; builds the comparison surface for offline eval.
+  const meta = createMetaOrchestrator({
+    ...(logger !== undefined ? { logger } : {}),
+    shadowSelector: getShadowSelector(),
+    shadowSink: getShadowSink(),
+  });
   return meta.select(toMetaInput(input));
 }
 

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -20,6 +20,11 @@ import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.j
 import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
 import { createCapabilityGapLedger } from '../core/task-analysis/capability-gap-ledger.js';
 import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
+import {
+  createLearnedStrategySelector,
+  createRecordingShadowSink,
+  SHADOW_STRATEGY_ARMS,
+} from './meta-shadow-selector.js';
 
 describe('strategyFromPattern', () => {
   const cases: ReadonlyArray<
@@ -267,5 +272,50 @@ describe('MetaOrchestrator.select — capability gap ledger wiring (#3555)', () 
   it('does not require a ledger (default absent, no throw)', () => {
     const meta = createMetaOrchestrator();
     expect(() => meta.select({ goal: 'implement the feature' })).not.toThrow();
+  });
+});
+
+describe('MetaOrchestrator.select — shadow-mode learned selection (#3551)', () => {
+  it('logs a shadow comparison without changing the executed decision', () => {
+    const shadowSink = createRecordingShadowSink();
+    const meta = createMetaOrchestrator({
+      shadowSelector: createLearnedStrategySelector(),
+      shadowSink,
+    });
+    const d = meta.select({
+      goal: 'should we adopt approach A or B',
+      signals: { requiresConsensus: true },
+    });
+    // Executed path is the rule-based choice, unchanged by shadow logging.
+    expect(d.strategy).toBe('consensus');
+
+    const records = shadowSink.getRecords();
+    expect(records).toHaveLength(1);
+    const rec = records[0];
+    expect(rec?.decisionId).toBe(d.decisionId);
+    expect(rec?.ruleStrategy).toBe('consensus');
+    expect(SHADOW_STRATEGY_ARMS).toContain(rec?.learnedStrategy);
+    expect(rec?.agree).toBe(rec?.learnedStrategy === 'consensus');
+    expect(rec?.taskClass).toBe(d.analysis.taskType);
+  });
+
+  it('does not log when only one of selector/sink is provided', () => {
+    const shadowSink = createRecordingShadowSink();
+    const meta = createMetaOrchestrator({ shadowSink }); // no selector
+    meta.select({ goal: 'implement the feature' });
+    expect(shadowSink.getRecords()).toHaveLength(0);
+  });
+
+  it('swallows a shadow-selector failure (selection still succeeds)', () => {
+    const shadowSink = createRecordingShadowSink();
+    const throwingSelector = {
+      predict: () => {
+        throw new Error('boom');
+      },
+      recordOutcome: () => {},
+    };
+    const meta = createMetaOrchestrator({ shadowSelector: throwingSelector, shadowSink });
+    expect(() => meta.select({ goal: 'implement the feature' })).not.toThrow();
+    expect(shadowSink.getRecords()).toHaveLength(0);
   });
 });

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -19,8 +19,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { createLogger, getTimeProvider } from '../core/index.js';
+import { createLogger, getTimeProvider, getErrorMessage } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
+import type { ILearnedStrategySelector, MetaShadowSink } from './meta-shadow-selector.js';
 import { classifyTask } from '../pipeline/adaptive-orchestrator.js';
 import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
 import { createWorkflowRouter } from './workflow-router.js';
@@ -399,16 +400,54 @@ function toRecord(
  *   decision's capability gaps are recorded for the self-directed build backlog
  *   (#3555). Default absent — no gap recording, no behavior change.
  */
+/**
+ * Computes the learned would-be strategy and logs it alongside the rule-based
+ * decision (#3551). Shadow only — never alters the executed decision. Best-effort:
+ * a selector/sink failure is logged and swallowed so selection never breaks.
+ */
+function recordShadow(
+  shadowSelector: ILearnedStrategySelector,
+  shadowSink: MetaShadowSink,
+  decision: MetaDecision,
+  timestamp: string,
+  logger: ILogger
+): void {
+  try {
+    const learned = shadowSelector.predict(decision);
+    shadowSink.record({
+      decisionId: decision.decisionId,
+      timestamp,
+      ruleStrategy: decision.strategy,
+      learnedStrategy: learned.strategy,
+      agree: learned.strategy === decision.strategy,
+      taskClass: decision.analysis.taskType,
+      learnedScore: learned.score,
+    });
+  } catch (err) {
+    logger.warn('Shadow selection failed (non-fatal)', { error: getErrorMessage(err) });
+  }
+}
+
 export function createMetaOrchestrator(options?: {
   readonly logger?: ILogger | undefined;
   readonly router?: IWorkflowRouter | undefined;
   readonly sink?: MetaDecisionSink | undefined;
   readonly gapLedger?: ICapabilityGapLedger | undefined;
+  /**
+   * Optional learned selector (#3551). When provided WITH a shadowSink, its
+   * would-be strategy is computed and logged alongside the rule-based choice —
+   * SHADOW MODE: the learned choice is never executed. Default absent.
+   */
+  readonly shadowSelector?: ILearnedStrategySelector | undefined;
+  /** Sink for shadow comparisons; required for shadow logging to run. */
+  readonly shadowSink?: MetaShadowSink | undefined;
 }): IMetaOrchestrator {
   const logger = options?.logger ?? createLogger({ component: 'MetaOrchestrator' });
   const router = options?.router ?? createWorkflowRouter({ logger });
   const sink = options?.sink ?? createAuditLogSink(logger);
   const gapLedger = options?.gapLedger;
+  const shadowSelector = options?.shadowSelector;
+  const shadowSink = options?.shadowSink;
 
   return {
     select(input: MetaOrchestratorInput): MetaDecision {
@@ -425,6 +464,9 @@ export function createMetaOrchestrator(options?: {
 
       const timestamp = new Date(getTimeProvider().now()).toISOString();
       sink.record(toRecord(decision, input.goal, forced, timestamp));
+      if (shadowSelector !== undefined && shadowSink !== undefined) {
+        recordShadow(shadowSelector, shadowSink, decision, timestamp, logger);
+      }
       if (gapLedger !== undefined && decision.capabilityGaps !== undefined) {
         gapLedger.record(decision.capabilityGaps, {
           goal: input.goal,

--- a/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the shadow-mode learned strategy selector (#3551). The selector
+ * reuses LinUCB; these tests cover the context mapping, prediction, training,
+ * the bounded recording sink, and the offline agreement summary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SHADOW_STRATEGY_ARMS,
+  createLearnedStrategySelector,
+  createRecordingShadowSink,
+  toBanditContext,
+  summarizeShadowAgreement,
+  getShadowSelector,
+  getShadowSink,
+  type MetaShadowRecord,
+} from './meta-shadow-selector.js';
+import type { MetaDecision, ExecutionStrategy } from './meta-orchestrator.js';
+import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
+
+function analysis(over: Partial<TaskAnalysisResult> = {}): TaskAnalysisResult {
+  return {
+    reasoningType: 'knowledge',
+    reasoningConfidence: 0.5,
+    complexity: 'moderate',
+    complexityScore: 0.5,
+    taskType: 'general',
+    taskTypeConfidence: 0.5,
+    capabilities: {} as TaskAnalysisResult['capabilities'],
+    estimatedTokens: 5000,
+    matchedSignals: [],
+    ambiguityScore: 0,
+    constraints: {} as TaskAnalysisResult['constraints'],
+    requiredCapabilities: {} as TaskAnalysisResult['requiredCapabilities'],
+    ...over,
+  };
+}
+
+function decision(over: Partial<MetaDecision> = {}): MetaDecision {
+  return {
+    decisionId: 'd1',
+    strategy: 'pipeline',
+    reasoning: 'r',
+    confidence: 0.6,
+    alternatives: [],
+    needsShaping: false,
+    pattern: 'sequential',
+    pipelineType: 'general',
+    analysis: analysis(),
+    ...over,
+  };
+}
+
+describe('toBanditContext', () => {
+  it('maps analysis fields onto the 6 bandit features', () => {
+    const ctx = toBanditContext(
+      decision({
+        analysis: analysis({
+          complexityScore: 0.8,
+          estimatedTokens: 50000,
+          taskType: 'code_implementation',
+          reasoningType: 'reasoning',
+          reasoningConfidence: 0.9,
+        }),
+      })
+    );
+    expect(ctx.taskComplexity).toBe(0.8);
+    expect(ctx.contextLengthNormalized).toBeCloseTo(0.5); // 50000 / 100000
+    expect(ctx.isCodeTask).toBe(1);
+    expect(ctx.isReasoningTask).toBeCloseTo(0.9);
+  });
+
+  it('clamps out-of-range / NaN and marks non-code tasks', () => {
+    const ctx = toBanditContext(
+      decision({
+        analysis: analysis({
+          complexityScore: 5,
+          estimatedTokens: 1_000_000,
+          taskType: 'documentation',
+          reasoningType: 'knowledge',
+        }),
+      })
+    );
+    expect(ctx.taskComplexity).toBe(1);
+    expect(ctx.contextLengthNormalized).toBe(1);
+    expect(ctx.isCodeTask).toBe(0);
+    expect(ctx.isReasoningTask).toBe(0);
+  });
+});
+
+describe('createLearnedStrategySelector', () => {
+  it('predicts a strategy from the known arm set', () => {
+    const selector = createLearnedStrategySelector();
+    const { strategy, score } = selector.predict(decision());
+    expect(SHADOW_STRATEGY_ARMS).toContain(strategy);
+    expect(typeof score).toBe('number');
+  });
+
+  it('training shifts preference toward the rewarded strategy for a context', () => {
+    const selector = createLearnedStrategySelector();
+    const d = decision({
+      analysis: analysis({ taskType: 'code_implementation', complexityScore: 0.9 }),
+    });
+    // Reward 'consensus' repeatedly for this context; penalize everything else.
+    for (let i = 0; i < 40; i++) {
+      selector.recordOutcome('consensus', d, true);
+      for (const arm of SHADOW_STRATEGY_ARMS) {
+        if (arm !== 'consensus') selector.recordOutcome(arm, d, false);
+      }
+    }
+    expect(selector.predict(d).strategy).toBe('consensus');
+  });
+
+  it('recordOutcome ignores an unknown strategy without throwing', () => {
+    const selector = createLearnedStrategySelector();
+    expect(() => {
+      selector.recordOutcome('not-a-strategy' as ExecutionStrategy, decision(), true);
+    }).not.toThrow();
+  });
+});
+
+describe('createRecordingShadowSink', () => {
+  it('buffers records and evicts oldest past the cap', () => {
+    const sink = createRecordingShadowSink(2);
+    const mk = (id: string): MetaShadowRecord => ({
+      decisionId: id,
+      timestamp: 't',
+      ruleStrategy: 'pipeline',
+      learnedStrategy: 'pipeline',
+      agree: true,
+      taskClass: 'general',
+      learnedScore: 0,
+    });
+    sink.record(mk('a'));
+    sink.record(mk('b'));
+    sink.record(mk('c'));
+    expect(sink.getRecords().map((r) => r.decisionId)).toEqual(['b', 'c']);
+  });
+});
+
+describe('summarizeShadowAgreement', () => {
+  it('computes overall and per-task-class agreement rates', () => {
+    const rec = (taskClass: string, agree: boolean): MetaShadowRecord => ({
+      decisionId: 'x',
+      timestamp: 't',
+      ruleStrategy: 'pipeline',
+      learnedStrategy: agree ? 'pipeline' : 'consensus',
+      agree,
+      taskClass,
+      learnedScore: 0,
+    });
+    const summary = summarizeShadowAgreement([
+      rec('code_implementation', true),
+      rec('code_implementation', false),
+      rec('general', true),
+    ]);
+    expect(summary.total).toBe(3);
+    expect(summary.agreements).toBe(2);
+    expect(summary.agreementRate).toBeCloseTo(2 / 3);
+    expect(summary.perTaskClass.code_implementation).toEqual({ total: 2, agree: 1, rate: 0.5 });
+    expect(summary.perTaskClass.general).toEqual({ total: 1, agree: 1, rate: 1 });
+  });
+
+  it('returns a zero summary for no records', () => {
+    expect(summarizeShadowAgreement([])).toEqual({
+      total: 0,
+      agreements: 0,
+      agreementRate: 0,
+      perTaskClass: {},
+    });
+  });
+});
+
+describe('process-scoped singletons', () => {
+  it('return stable instances', () => {
+    expect(getShadowSelector()).toBe(getShadowSelector());
+    expect(getShadowSink()).toBe(getShadowSink());
+  });
+});

--- a/packages/nexus-agents/src/orchestration/meta-shadow-selector.ts
+++ b/packages/nexus-agents/src/orchestration/meta-shadow-selector.ts
@@ -1,0 +1,205 @@
+/**
+ * MetaOrchestrator step 3 (#3551): shadow-logged learned strategy selection.
+ *
+ * A learned selector that, given the same task signals the rule-based
+ * MetaOrchestrator sees, predicts the best {@link ExecutionStrategy} from
+ * accumulated outcomes — run in SHADOW MODE only: its would-be choice is logged
+ * alongside the rule-based choice the system actually executes. No action is
+ * taken on the learned choice (acting on it is step 4 / #3552, gated behind the
+ * shadow-agreement data this layer produces).
+ *
+ * It REUSES {@link LinUCBBandit} (arms = the ExecutionStrategy values) rather
+ * than forking a second learning stack — mirroring CompositeRouter's bandit.
+ *
+ * Process-scoped singletons ({@link getShadowSelector} / {@link getShadowSink})
+ * let the shadow layer accumulate predictions + a comparison surface across
+ * `run` calls within a process. Cross-process persistence and feeding live
+ * dispatch outcomes into {@link ILearnedStrategySelector.recordOutcome} are
+ * tracked follow-ups (the bridge to step 4 enforcement).
+ *
+ * @module orchestration/meta-shadow-selector
+ * (Source: Issue #3551 — MetaOrchestrator step 3)
+ */
+
+import { LinUCBBandit } from '../cli-adapters/linucb-bandit.js';
+import type { BanditContext } from '../cli-adapters/budget-router-types.js';
+import type { ExecutionStrategy, MetaDecision } from './meta-orchestrator.js';
+
+/** The strategies the learned selector chooses among — the bandit's arms. */
+export const SHADOW_STRATEGY_ARMS: readonly ExecutionStrategy[] = [
+  'single-shot',
+  'dev-pipeline',
+  'pipeline',
+  'graph-workflow',
+  'orchestrate',
+  'consensus',
+  'spec',
+  'research',
+];
+
+/** Reward for a strategy that led to a successful outcome (mirrors LinUCB). */
+const SUCCESS_REWARD = 0.7;
+/** Reward for a strategy that led to a failed outcome (mirrors LinUCB). */
+const FAILURE_REWARD = 0.1;
+/** Token count that normalizes to full context utilization (1.0). */
+const CONTEXT_TOKEN_NORMALIZER = 100_000;
+/** Fallback strategy if the bandit returns an unrecognized arm (defensive). */
+const FALLBACK_STRATEGY: ExecutionStrategy = 'pipeline';
+
+/** One shadow comparison: the rule choice vs the would-be learned choice. */
+export interface MetaShadowRecord {
+  /** Matches {@link MetaDecision.decisionId} — the join key to the rule decision. */
+  readonly decisionId: string;
+  /** ISO timestamp of the comparison. */
+  readonly timestamp: string;
+  /** Strategy the system actually executed (rule-based). */
+  readonly ruleStrategy: ExecutionStrategy;
+  /** Strategy the learned selector WOULD have chosen (not executed). */
+  readonly learnedStrategy: ExecutionStrategy;
+  /** Whether the two agree. */
+  readonly agree: boolean;
+  /** Task class (taskType) for per-class offline policy evaluation. */
+  readonly taskClass: string;
+  /** UCB score the learned selector assigned its choice. */
+  readonly learnedScore: number;
+}
+
+/** A sink that receives every shadow comparison. Must not throw. */
+export interface MetaShadowSink {
+  record(record: MetaShadowRecord): void;
+}
+
+/** A {@link MetaShadowSink} that also exposes its buffered records. */
+export interface IRecordingMetaShadowSink extends MetaShadowSink {
+  getRecords(): readonly MetaShadowRecord[];
+}
+
+/** Default cap for the in-memory recording sink, matching the decision sink. */
+const DEFAULT_MAX_RECORDS = 200;
+
+/** Creates an in-memory shadow sink with a bounded buffer (oldest evicted). */
+export function createRecordingShadowSink(
+  maxRecords = DEFAULT_MAX_RECORDS
+): IRecordingMetaShadowSink {
+  const records: MetaShadowRecord[] = [];
+  return {
+    record(record: MetaShadowRecord): void {
+      records.push(record);
+      if (records.length > maxRecords) {
+        records.splice(0, records.length - maxRecords);
+      }
+    },
+    getRecords(): readonly MetaShadowRecord[] {
+      return records;
+    },
+  };
+}
+
+/** The learned selector: predict a strategy + learn from outcomes. */
+export interface ILearnedStrategySelector {
+  /** Predict the best strategy for a decision's signals (shadow — not executed). */
+  predict(decision: MetaDecision): { strategy: ExecutionStrategy; score: number };
+  /** Train: record whether `strategy` succeeded for a decision's context. */
+  recordOutcome(strategy: ExecutionStrategy, decision: MetaDecision, success: boolean): void;
+}
+
+/** Clamps a value to [0, 1]; NaN → 0. */
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+/** Maps a decision's task analysis onto the 6-feature bandit context. */
+export function toBanditContext(decision: MetaDecision): BanditContext {
+  const a = decision.analysis;
+  const isCode =
+    a.taskType === 'code_implementation' ||
+    a.taskType === 'code_review' ||
+    a.taskType === 'test_generation' ||
+    a.taskType === 'security_review';
+  return {
+    taskComplexity: clamp01(a.complexityScore),
+    contextLengthNormalized: clamp01(a.estimatedTokens / CONTEXT_TOKEN_NORMALIZER),
+    isCodeTask: isCode ? 1 : 0,
+    isReasoningTask: a.reasoningType === 'reasoning' ? clamp01(a.reasoningConfidence) : 0,
+    // No budget/urgency signal is available at selection time; left neutral.
+    budgetUtilization: 0,
+    timePressure: 0,
+  };
+}
+
+/** Creates a learned strategy selector backed by a fresh LinUCB bandit. */
+export function createLearnedStrategySelector(): ILearnedStrategySelector {
+  const bandit = new LinUCBBandit(SHADOW_STRATEGY_ARMS);
+  return {
+    predict(decision: MetaDecision): { strategy: ExecutionStrategy; score: number } {
+      const { armName, ucbScore } = bandit.select(toBanditContext(decision));
+      const strategy = SHADOW_STRATEGY_ARMS.includes(armName as ExecutionStrategy)
+        ? (armName as ExecutionStrategy)
+        : FALLBACK_STRATEGY;
+      return { strategy, score: ucbScore };
+    },
+    recordOutcome(strategy: ExecutionStrategy, decision: MetaDecision, success: boolean): void {
+      const idx = SHADOW_STRATEGY_ARMS.indexOf(strategy);
+      if (idx < 0) return;
+      bandit.update(idx, toBanditContext(decision), success ? SUCCESS_REWARD : FAILURE_REWARD);
+    },
+  };
+}
+
+/** Per-class agreement breakdown for offline policy evaluation. */
+export interface TaskClassAgreement {
+  readonly total: number;
+  readonly agree: number;
+  readonly rate: number;
+}
+
+/** Offline policy-evaluation summary: agreement overall + per task class. */
+export interface ShadowAgreementSummary {
+  readonly total: number;
+  readonly agreements: number;
+  readonly agreementRate: number;
+  readonly perTaskClass: Readonly<Record<string, TaskClassAgreement>>;
+}
+
+/**
+ * Summarizes how often the learned (shadow) choice matched the executed
+ * rule-based choice, overall and per task class — the comparison surface for
+ * offline policy evaluation before step 4 acts on the learned choice.
+ */
+export function summarizeShadowAgreement(
+  records: readonly MetaShadowRecord[]
+): ShadowAgreementSummary {
+  const perTaskClass: Record<string, { total: number; agree: number; rate: number }> = {};
+  let agreements = 0;
+  for (const r of records) {
+    if (r.agree) agreements++;
+    const cur = perTaskClass[r.taskClass] ?? { total: 0, agree: 0, rate: 0 };
+    cur.total++;
+    if (r.agree) cur.agree++;
+    cur.rate = cur.agree / cur.total;
+    perTaskClass[r.taskClass] = cur;
+  }
+  const total = records.length;
+  return {
+    total,
+    agreements,
+    agreementRate: total === 0 ? 0 : agreements / total,
+    perTaskClass,
+  };
+}
+
+let singletonSelector: ILearnedStrategySelector | undefined;
+let singletonSink: IRecordingMetaShadowSink | undefined;
+
+/** Process-scoped learned selector — accumulates across `run` calls. */
+export function getShadowSelector(): ILearnedStrategySelector {
+  singletonSelector ??= createLearnedStrategySelector();
+  return singletonSelector;
+}
+
+/** Process-scoped shadow sink — the queryable comparison surface. */
+export function getShadowSink(): IRecordingMetaShadowSink {
+  singletonSink ??= createRecordingShadowSink();
+  return singletonSink;
+}


### PR DESCRIPTION
Closes #3551 — MetaOrchestrator step 3 of epic #3548.

## What
A **learned selector** that, given the same task signals as the rule-based MetaOrchestrator, predicts an `ExecutionStrategy` and logs its would-be choice **alongside** the executed rule-based choice — **shadow mode only**: the learned choice is never acted on (acting on it is step 4 / #3552).

- **Reuses, does not fork, the learning stack:** wraps the existing `LinUCBBandit` (arms = the 8 strategies), mapping `TaskAnalysisResult` → the 6-feature `BanditContext`.
- **Comparison surface:** `summarizeShadowAgreement()` returns would-select-vs-selected agreement overall and **per task class** — the offline policy-evaluation surface that gates step 4.
- **Wired default-on into `run`** via process-scoped singletons (`getShadowSelector` / `getShadowSink`), so shadow data accumulates within a process. The **executed path is unchanged**; shadow logging is best-effort (a selector failure is logged and swallowed).

## Acceptance (#3551)
- ✅ Tests assert the shadow choice is logged + comparable to the rule choice; the executed decision is unchanged.
- ✅ A comparison surface (would-select vs selected, per task class) for offline policy evaluation.
- ✅ Phase gate honored — shadow only; cold-start until outcomes accumulate. Acting on the learned choice stays in #3552.

## Tests
`meta-shadow-selector.test.ts` (context mapping incl. clamp/NaN, predict, training shifts preference, bounded sink, agreement summary, singletons) + `meta-orchestrator.test.ts` shadow block (record emitted with matching decisionId, executed decision unchanged, only-one-of-selector/sink no-ops, selector failure swallowed). Full `src/orchestration` suite: 1038 pass.

## Follow-up
#3593 — feed live dispatch outcomes into `recordOutcome` + persist/seed the bandit across processes (the data-accumulation half of the gate before #3552 enforce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)