### PR TITLE
refactor(mcp): single TOOL_MANIFEST as canonical tool-name source (#3566)

### DIFF
--- a/.changeset/tool-manifest.md
+++ b/.changeset/tool-manifest.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+refactor(mcp): single TOOL_MANIFEST as the canonical tool-name source (#3566)
+
+Introduces `mcp/tools/tool-manifest.ts` — a pure-data leaf module whose
+`TOOL_MANIFEST` array is the single source of truth for which MCP tools exist
+and their registration order. `REGISTERED_TOOL_NAMES` is now a derived
+re-export, the capability-gap detector's `AVAILABLE_TOOLS` derives directly from
+the manifest (replacing a 46-line hand-maintained copy that was kept in lockstep
+by a freshness test), and `scripts/inject-governance.ts` parses the manifest.
+Because the manifest imports nothing, core modules can derive from it without
+pulling in the MCP tool dependency graph — no import cycle. Parity tests assert
+`REGISTERED_TOOL_NAMES`, `TOOL_ANNOTATIONS` keys, and the gap-detector list all
+match the manifest, so adding/removing a tool is a one-array edit.
+
+Annotation-data folding (so `TOOL_ANNOTATIONS` also derives) and the AST-parser
+upgrade are tracked as follow-ups.

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -474,16 +474,21 @@ jobs:
       - name: Guard against MCP_TOOL_COUNT drift (#2107)
         run: |
           set -e
-          TOOLS_SRC=packages/nexus-agents/src/mcp/tools/index.ts
+          # #3566: canonical tool-name list is the leaf TOOL_MANIFEST array.
+          TOOLS_SRC=packages/nexus-agents/src/mcp/tools/tool-manifest.ts
           SITE_DATA=website/src/data/site-data.ts
           SERVER_JSON=packages/nexus-agents/server.json
           README=README.md
 
           # 1. Authoritative count: lines of the form `    'tool_name',` between
-          #    `REGISTERED_TOOL_NAMES = [` (or legacy `tools: [`) and the next `]`.
-          #    Grep is robust to reformatting; awk fallback handles older checkouts.
-          src_count=$(awk '/REGISTERED_TOOL_NAMES\s*=\s*\[/,/\]\s*as const/' "$TOOLS_SRC" \
+          #    `TOOL_MANIFEST = [` (or pre-#3566 `REGISTERED_TOOL_NAMES = [`, or
+          #    legacy `tools: [`) and the next `]`. awk handles older checkouts.
+          src_count=$(awk '/TOOL_MANIFEST\s*=\s*\[/,/\]\s*as const/' "$TOOLS_SRC" \
             | grep -cE "^\s+'[a-z_]+'," || true)
+          if [ "$src_count" -eq 0 ]; then
+            src_count=$(awk '/REGISTERED_TOOL_NAMES\s*=\s*\[/,/\]\s*as const/' "$TOOLS_SRC" \
+              | grep -cE "^\s+'[a-z_]+'," || true)
+          fi
           if [ "$src_count" -eq 0 ]; then
             src_count=$(awk '/tools: \[/,/\]/' "$TOOLS_SRC" \
               | grep -cE "^\s+'[a-z_]+'," || true)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ _Auto-generated from source. 46 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-06_
+_Governance Version: 2026-06-07_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-06-07T06:26:05.344Z",
+  "generated": "2026-06-07T08:50:37.363Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.123.0",
   "cli": {

--- a/docs/ops/registry-coverage-manifest.json
+++ b/docs/ops/registry-coverage-manifest.json
@@ -12,12 +12,12 @@
         "packages/nexus-agents/src/mcp/tools/list-experts.ts",
         "packages/nexus-agents/src/agents/experts/expert-defaults.test.ts"
       ],
-      "rationale": "Receipts: #2344, #2347 — every entry added requires updating BuiltInExpertTypeSchema, list_experts MCP tool, and the count assertion test."
+      "rationale": "Receipts: #2344, #2347 \u2014 every entry added requires updating BuiltInExpertTypeSchema, list_experts MCP tool, and the count assertion test."
     },
     {
       "name": "REGISTERED_TOOL_NAMES",
-      "source": "packages/nexus-agents/src/mcp/tools/index.ts",
-      "marker": "REGISTERED_TOOL_NAMES",
+      "source": "packages/nexus-agents/src/mcp/tools/tool-manifest.ts",
+      "marker": "TOOL_MANIFEST",
       "peer_files": [
         "packages/nexus-agents/src/cli-server-tools.ts",
         "packages/nexus-agents/src/cli-server-tools.test.ts",
@@ -27,14 +27,16 @@
         "scripts/inject-governance.ts",
         "skills/documentation-management/SKILL.md"
       ],
-      "rationale": "Receipts: #2358 — every new MCP tool requires updating STANDALONE_TOOLS, count tests, annotations, governance script, and SKILL.md PIPELINE NOTE."
+      "rationale": "Receipts: #2358 \u2014 every new MCP tool requires updating STANDALONE_TOOLS, count tests, annotations, governance script, and SKILL.md PIPELINE NOTE.",
+      "moved_from": "packages/nexus-agents/src/mcp/tools/index.ts",
+      "moved_from_marker": "REGISTERED_TOOL_NAMES"
     },
     {
       "name": "NEXUS_ENV_VARS",
       "source": "packages/nexus-agents/src/config/env-schema.ts",
       "marker": "NEXUS_",
       "peer_files": ["CLAUDE.md", "docs/getting-started/CONFIGURATION.md"],
-      "rationale": "Receipts: #2315 — env-var rollouts (NEXUS_DATA_DIR) miss callsites and docs. This catches the declaration drift; runtime callsite drift is a separate problem (#2407)."
+      "rationale": "Receipts: #2315 \u2014 env-var rollouts (NEXUS_DATA_DIR) miss callsites and docs. This catches the declaration drift; runtime callsite drift is a separate problem (#2407)."
     }
   ]
 }

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-06-07T06:26:05.344Z
+**Generated:** 2026-06-07T08:50:37.363Z
 **Package Version:** 2.123.0
 **Generator:** `scripts/generate-repo-index.ts`
 

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
@@ -10,6 +10,7 @@
  */
 
 import type { RequiredCapabilities } from './task-analysis-advocate.js';
+import { TOOL_MANIFEST } from '../../mcp/tools/tool-manifest.js';
 
 // ============================================================================
 // Types
@@ -49,63 +50,14 @@ export interface CapabilityGap {
 // ============================================================================
 
 /**
- * All registered MCP tool names.
- *
- * Kept in lockstep with the canonical `REGISTERED_TOOL_NAMES`
- * (`src/mcp/tools/index.ts`); a drift here produces false capability gaps.
- * Enforced by the freshness assertions in `capability-gap-detector.test.ts`
- * (#3553), which import the canonical list and fail if this set falls behind.
- * Held as a local literal (not a direct import) to keep this hot-path,
- * low-level analyzer module free of the MCP tool dependency graph.
+ * All registered MCP tool names — derived directly from the canonical
+ * {@link TOOL_MANIFEST} (#3566). Previously a hand-maintained copy guarded by a
+ * freshness test (#3553); now a one-way derivation. `tool-manifest.ts` is a
+ * pure-data leaf (imports nothing), so deriving from it keeps this hot-path,
+ * low-level analyzer module free of the MCP tool dependency graph — no cycle.
+ * Drift is impossible by construction.
  */
-const AVAILABLE_TOOLS: ReadonlySet<string> = new Set([
-  'orchestrate',
-  'create_expert',
-  'execute_expert',
-  'run_workflow',
-  'delegate_to_model',
-  'list_experts',
-  'list_workflows',
-  'consensus_vote',
-  'research_query',
-  'research_add',
-  'research_add_source',
-  'research_discover',
-  'research_analyze',
-  'research_catalog_review',
-  'research_synthesize',
-  'survey_oss_landscape',
-  'vendor_publishing_audit',
-  'compare_data_feeds',
-  'memory_query',
-  'memory_stats',
-  'memory_write',
-  'weather_report',
-  'issue_triage',
-  'run_graph_workflow',
-  'execute_spec',
-  'registry_import',
-  'query_trace',
-  'query_task_state',
-  'get_job_result',
-  'list_jobs',
-  'cancel_job',
-  'ci_health_check',
-  'verify_audit_chain',
-  'repo_analyze',
-  'repo_security_plan',
-  'extract_symbols',
-  'search_codebase',
-  'run_dev_pipeline',
-  'run_pipeline',
-  'pr_review',
-  'supply_chain_tradeoff_panel',
-  'improvement_review',
-  'run_quality_gate',
-  'suggest_research_tasks',
-  'list_available_models',
-  'run',
-]);
+const AVAILABLE_TOOLS: ReadonlySet<string> = new Set(TOOL_MANIFEST);
 
 /**
  * All built-in expert role names (`{type}_expert`).

--- a/packages/nexus-agents/src/mcp/tools/index.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.ts
@@ -13,6 +13,7 @@ import type { ILogger } from '../../core/index.js';
 
 import { createMcpLogger } from '../middleware/logging.js';
 import { RateLimiter, createDefaultRateLimiter } from '../middleware/rate-limiter.js';
+import { TOOL_MANIFEST, type RegisteredToolName } from './tool-manifest.js';
 
 // Tool implementations
 export {
@@ -572,61 +573,14 @@ export interface ToolRegistrationResult {
 /**
  * Authoritative list of registered MCP tools, in registration order.
  *
- * `inject-governance.ts syncServerJson` reads this list (via the
- * `extractMcpTools` parser) and writes it to `packages/nexus-agents/server.json`
- * so the MCP-spec registry stays in lockstep — see PR #2362 for the auto-sync.
- *
- * Exported so `cli-server-tools.ts` can alias it as `REGISTERED_TOOLS`
- * — kills the duplicate hand-maintained array (Issue #2935).
+ * Derived from the canonical {@link TOOL_MANIFEST} (single source of truth,
+ * #3566) and re-exported under this historical name so existing importers
+ * (`cli-server-tools.ts`, `mcp/index.ts`, `tier-classifier.ts`) keep working.
+ * `inject-governance.ts` now parses `tool-manifest.ts` directly.
  */
-export const REGISTERED_TOOL_NAMES = [
-  'orchestrate',
-  'create_expert',
-  'execute_expert',
-  'run_workflow',
-  'delegate_to_model',
-  'list_experts',
-  'list_workflows',
-  'consensus_vote',
-  'research_query',
-  'research_add',
-  'research_add_source',
-  'research_discover',
-  'research_analyze',
-  'research_catalog_review',
-  'research_synthesize',
-  'survey_oss_landscape',
-  'vendor_publishing_audit',
-  'compare_data_feeds',
-  'memory_query',
-  'memory_stats',
-  'memory_write',
-  'weather_report',
-  'issue_triage',
-  'run_graph_workflow',
-  'execute_spec',
-  'registry_import',
-  'query_trace',
-  'query_task_state',
-  'get_job_result',
-  'list_jobs',
-  'cancel_job',
-  'ci_health_check',
-  'verify_audit_chain',
-  'repo_analyze',
-  'repo_security_plan',
-  'extract_symbols',
-  'search_codebase',
-  'run_dev_pipeline',
-  'run_pipeline',
-  'pr_review',
-  'supply_chain_tradeoff_panel',
-  'improvement_review',
-  'run_quality_gate',
-  'suggest_research_tasks',
-  'list_available_models',
-  'run',
-] as const;
+export { TOOL_MANIFEST };
+export type { RegisteredToolName };
+export const REGISTERED_TOOL_NAMES = TOOL_MANIFEST;
 
 export function registerTools(
   server: McpServer,

--- a/packages/nexus-agents/src/mcp/tools/tool-manifest.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-manifest.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Parity tests for the canonical TOOL_MANIFEST (#3566). These are the lockstep
+ * guards the refactor relies on: every other tool-name list derives from or is
+ * validated against the manifest, so drift fails loudly here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TOOL_MANIFEST } from './tool-manifest.js';
+import { REGISTERED_TOOL_NAMES, TOOL_ANNOTATIONS } from './index.js';
+import { getAvailableToolCount } from '../../core/task-analysis/capability-gap-detector.js';
+
+describe('TOOL_MANIFEST (canonical tool list)', () => {
+  it('has no duplicate names', () => {
+    expect(new Set(TOOL_MANIFEST).size).toBe(TOOL_MANIFEST.length);
+  });
+
+  it('is the exact source of REGISTERED_TOOL_NAMES (same order)', () => {
+    // REGISTERED_TOOL_NAMES is a derived re-export of the manifest.
+    expect([...REGISTERED_TOOL_NAMES]).toEqual([...TOOL_MANIFEST]);
+  });
+
+  it('matches TOOL_ANNOTATIONS keys exactly (no annotation drift)', () => {
+    // Every manifest tool has an annotation entry and vice-versa.
+    expect(new Set(Object.keys(TOOL_ANNOTATIONS))).toEqual(new Set(TOOL_MANIFEST));
+  });
+
+  it('is the basis for the capability-gap detector AVAILABLE_TOOLS', () => {
+    // gap-detector derives AVAILABLE_TOOLS = new Set(TOOL_MANIFEST).
+    expect(getAvailableToolCount()).toBe(TOOL_MANIFEST.length);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
@@ -1,0 +1,83 @@
+/**
+ * Canonical MCP tool manifest (#3566, Phase 3 of #3563).
+ *
+ * THE single source of truth for *which* MCP tools exist and their registration
+ * order. Everything that needs the tool-name list derives from this one array:
+ * - `REGISTERED_TOOL_NAMES` (re-exported from `tools/index.ts`),
+ * - the capability-gap detector's `AVAILABLE_TOOLS` (derives directly — see below),
+ * - `scripts/inject-governance.ts` (parses this file to sync `server.json`, docs,
+ *   and the MCP-tool-count guard).
+ *
+ * **Pure-data leaf — DO NOT add imports.** This module imports nothing so any
+ * layer can derive from it without pulling in the MCP tool dependency graph.
+ * That is what lets `core/task-analysis/capability-gap-detector.ts` import the
+ * list directly (one-way edge, no cycle) instead of keeping a hand-maintained
+ * copy guarded by a freshness test (#3553). Keep it import-free or that property
+ * breaks.
+ *
+ * Per-tool annotation/side-effect data lives in `tool-annotations.ts`, keyed by
+ * these names; a parity test asserts its keys match this manifest so the two
+ * cannot drift. Folding that annotation data into manifest entries (so
+ * `TOOL_ANNOTATIONS` derives too) is tracked as the next increment.
+ *
+ * Adding/removing a tool: edit THIS array. The drift guards and `inject-governance`
+ * follow automatically.
+ *
+ * @module mcp/tools/tool-manifest
+ */
+
+/**
+ * Registered MCP tools, in registration order. The order is significant — it is
+ * written to `server.json` so the MCP-spec registry stays in lockstep.
+ */
+export const TOOL_MANIFEST = [
+  'orchestrate',
+  'create_expert',
+  'execute_expert',
+  'run_workflow',
+  'delegate_to_model',
+  'list_experts',
+  'list_workflows',
+  'consensus_vote',
+  'research_query',
+  'research_add',
+  'research_add_source',
+  'research_discover',
+  'research_analyze',
+  'research_catalog_review',
+  'research_synthesize',
+  'survey_oss_landscape',
+  'vendor_publishing_audit',
+  'compare_data_feeds',
+  'memory_query',
+  'memory_stats',
+  'memory_write',
+  'weather_report',
+  'issue_triage',
+  'run_graph_workflow',
+  'execute_spec',
+  'registry_import',
+  'query_trace',
+  'query_task_state',
+  'get_job_result',
+  'list_jobs',
+  'cancel_job',
+  'ci_health_check',
+  'verify_audit_chain',
+  'repo_analyze',
+  'repo_security_plan',
+  'extract_symbols',
+  'search_codebase',
+  'run_dev_pipeline',
+  'run_pipeline',
+  'pr_review',
+  'supply_chain_tradeoff_panel',
+  'improvement_review',
+  'run_quality_gate',
+  'suggest_research_tasks',
+  'list_available_models',
+  'run',
+] as const;
+
+/** A registered MCP tool name, derived from {@link TOOL_MANIFEST}. */
+export type RegisteredToolName = (typeof TOOL_MANIFEST)[number];

--- a/scripts/check-registry-coverage.test.ts
+++ b/scripts/check-registry-coverage.test.ts
@@ -120,6 +120,36 @@ describe('isRegistryChanged structural-equivalence exemption', () => {
   });
 });
 
+describe('isRegistryChanged moved_from relocation exemption (#3566)', () => {
+  // Registry relocated: list moved from old.ts (marker OLD_REG) to new.ts
+  // (marker NEW_REG), contents unchanged. The new source has no base.
+  const registry = {
+    name: 'RELOCATED',
+    source: 'src/new.ts',
+    marker: 'NEW_REG',
+    peer_files: ['src/peer.ts'],
+    rationale: 'test',
+    moved_from: 'src/old.ts',
+    moved_from_marker: 'OLD_REG',
+  };
+  const diffOf = (): string =>
+    ['--- /dev/null', '+++ b/src/new.ts', '@@ -0,0 +1 @@', '+export const NEW_REG = ['].join('\n');
+
+  it('exempts a no-op relocation (same entries under the old marker at base)', () => {
+    const baseOf = (p: string): string | null =>
+      p === 'src/old.ts' ? `const OLD_REG = ['a', 'b', 'c'] as const;` : null; // new.ts absent at base
+    const currentOf = (): string => `export const NEW_REG = ['a', 'b', 'c'] as const;`;
+    expect(isRegistryChanged(registry, ['src/new.ts'], diffOf, baseOf, currentOf)).toBe(false);
+  });
+
+  it('still fires when the relocation also changed entries', () => {
+    const baseOf = (p: string): string | null =>
+      p === 'src/old.ts' ? `const OLD_REG = ['a', 'b'] as const;` : null;
+    const currentOf = (): string => `export const NEW_REG = ['a', 'b', 'c'] as const;`;
+    expect(isRegistryChanged(registry, ['src/new.ts'], diffOf, baseOf, currentOf)).toBe(true);
+  });
+});
+
 describe('extractMarkerEntries', () => {
   it('extracts a sorted, de-duplicated list', () => {
     const content = `const FOO = ['c', 'a', 'b', 'a'] as const;`;

--- a/scripts/check-registry-coverage.ts
+++ b/scripts/check-registry-coverage.ts
@@ -36,6 +36,17 @@ interface RegistryEntry {
   readonly marker: string;
   readonly peer_files: readonly string[];
   readonly rationale: string;
+  /**
+   * Registry relocation (#3566): when the marker list MOVED here from another
+   * file, the structural-equivalence exemption can't compare against this
+   * source's base (it didn't exist at base). If set, the exemption compares the
+   * current list against the marker list at the BASE of `moved_from` instead, so
+   * a pure no-op relocation doesn't falsely demand peer-file updates. Only used
+   * while `source` is absent at base (i.e. the relocation PR itself).
+   */
+  readonly moved_from?: string;
+  /** Marker name at the `moved_from` location, if it differed (default: `marker`). */
+  readonly moved_from_marker?: string;
 }
 
 interface RegistryManifest {
@@ -251,10 +262,21 @@ function structurallyEquivalent(
   baseOf: (path: string) => string | null,
   currentOf: (path: string) => string | null
 ): boolean {
-  const oldContent = baseOf(registry.source);
   const newContent = currentOf(registry.source);
-  if (oldContent === null || newContent === null) return false;
-  const before = extractMarkerEntries(oldContent, registry.marker);
+  if (newContent === null) return false;
+
+  // Normal case: compare against this source's base. Relocation case (#3566):
+  // if the source didn't exist at base, compare against the base of the file the
+  // list moved from, using its pre-move marker name.
+  let oldContent = baseOf(registry.source);
+  let oldMarker = registry.marker;
+  if (oldContent === null && registry.moved_from !== undefined) {
+    oldContent = baseOf(registry.moved_from);
+    oldMarker = registry.moved_from_marker ?? registry.marker;
+  }
+  if (oldContent === null) return false;
+
+  const before = extractMarkerEntries(oldContent, oldMarker);
   const after = extractMarkerEntries(newContent, registry.marker);
   if (before === null || after === null) return false;
   return arraysEqual(before, after);

--- a/scripts/generate-docs-content.ts
+++ b/scripts/generate-docs-content.ts
@@ -25,7 +25,8 @@ import { join } from 'node:path';
 import { ROOT, SRC_ROOT, DOCS_ROOT } from './script-paths.js';
 
 const CHECK_MODE = process.argv.includes('--check');
-const TOOLS_INDEX = join(SRC_ROOT, 'mcp/tools/index.ts');
+// #3566: canonical tool-name list is the leaf TOOL_MANIFEST array.
+const TOOLS_INDEX = join(SRC_ROOT, 'mcp/tools/tool-manifest.ts');
 const TEMPLATE_TYPES = join(SRC_ROOT, 'workflows/template-types.ts');
 const AGENT_TYPES = join(SRC_ROOT, 'core/types/agent.ts');
 const ADR_DIR = join(DOCS_ROOT, 'adr');
@@ -48,10 +49,10 @@ const drifts: DriftReport[] = [];
  */
 function extractMcpToolCount(): number {
   const src = readFileSync(TOOLS_INDEX, 'utf-8');
-  // Source of truth is the module-level `REGISTERED_TOOL_NAMES` const
-  // (extracted out of `registerTools()` to fit the max-lines-per-function
-  // gate). Fall back to the inline `tools: [...]` shape for older checkouts.
+  // Source of truth is the leaf `TOOL_MANIFEST` const (#3566); fall back to the
+  // pre-#3566 `REGISTERED_TOOL_NAMES` and legacy `tools: [...]` shapes.
   const arrayMatch =
+    src.match(/TOOL_MANIFEST\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     src.match(/REGISTERED_TOOL_NAMES\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     src.match(/tools:\s*\[([\s\S]*?)\]/);
   if (!arrayMatch) return 0;

--- a/scripts/generate-repo-index.ts
+++ b/scripts/generate-repo-index.ts
@@ -27,7 +27,11 @@ import { catalogForExtractors } from '../packages/nexus-agents/src/cli-command-c
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 const CLI_COMMANDS_FILE = path.join(REPO_ROOT, 'packages/nexus-agents/src/cli-commands.ts');
-const MCP_TOOLS_INDEX = path.join(REPO_ROOT, 'packages/nexus-agents/src/mcp/tools/index.ts');
+// #3566: canonical tool-name list is the leaf TOOL_MANIFEST array.
+const MCP_TOOLS_INDEX = path.join(
+  REPO_ROOT,
+  'packages/nexus-agents/src/mcp/tools/tool-manifest.ts'
+);
 const WORKFLOWS_DIR = path.join(REPO_ROOT, 'packages/nexus-agents/src/workflows/templates');
 const PACKAGE_JSON = path.join(REPO_ROOT, 'packages/nexus-agents/package.json');
 
@@ -176,10 +180,11 @@ function extractMCPTools(): MCPTool[] {
   // (extracted out of `registerTools()` to fit the max-lines-per-function
   // gate). Fall back to the inline `tools: [...]` shape for older checkouts.
   const toolsMatch =
+    content.match(/TOOL_MANIFEST\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     content.match(/REGISTERED_TOOL_NAMES\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     content.match(/tools:\s*\[([\s\S]*?)\]/);
   if (toolsMatch?.[1] === undefined) {
-    console.error('Could not parse tools array from MCP tools index');
+    console.error('Could not parse tools array from MCP tool manifest');
     return [];
   }
 

--- a/scripts/inject-governance.test.ts
+++ b/scripts/inject-governance.test.ts
@@ -1166,10 +1166,13 @@ describe('inject-governance ENTRYPOINTS tool enumerations (#3334)', () => {
     };
   }
 
-  /** Registered tool names from REGISTERED_TOOL_NAMES (the source of truth). */
+  /** Registered tool names from the canonical TOOL_MANIFEST (source of truth, #3566). */
   function registeredTools(): string[] {
-    const src = readFileSync(join(ROOT, 'packages/nexus-agents/src/mcp/tools/index.ts'), 'utf-8');
-    const m = /REGISTERED_TOOL_NAMES\s*=\s*\[([\s\S]*?)\]\s*as const/.exec(src);
+    const src = readFileSync(
+      join(ROOT, 'packages/nexus-agents/src/mcp/tools/tool-manifest.ts'),
+      'utf-8'
+    );
+    const m = /TOOL_MANIFEST\s*=\s*\[([\s\S]*?)\]\s*as const/.exec(src);
     expect(m).not.toBeNull();
     return m![1]!
       .split('\n')

--- a/scripts/inject-governance.ts
+++ b/scripts/inject-governance.ts
@@ -42,6 +42,9 @@ const README_PATH = join(ROOT, 'README.md');
 // registry + TOOL_DESCRIPTIONS corpus as the CLAUDE.md / README surfaces.
 const ENTRYPOINTS_PATH = join(ROOT, 'docs/ENTRYPOINTS.md');
 const TOOLS_INDEX = join(ROOT, 'packages/nexus-agents/src/mcp/tools/index.ts');
+// #3566: the canonical tool-name list is now the leaf `TOOL_MANIFEST` array;
+// `REGISTERED_TOOL_NAMES` is a derived re-export, so the parser reads the manifest.
+const TOOL_MANIFEST_FILE = join(ROOT, 'packages/nexus-agents/src/mcp/tools/tool-manifest.ts');
 const EXPERT_CONFIG = join(ROOT, 'packages/nexus-agents/src/agents/experts/expert-config.ts');
 const TEMPLATE_TYPES = join(ROOT, 'packages/nexus-agents/src/workflows/template-types.ts');
 const SKILLS_DIR = join(ROOT, 'skills');
@@ -182,22 +185,27 @@ interface WorkflowRow {
  * matches against curated descriptions.
  */
 function extractMcpTools(): ToolMetadata[] {
-  if (!existsSync(TOOLS_INDEX)) {
-    console.error('MCP tools index not found: ' + TOOLS_INDEX);
+  // #3566: source of truth is the leaf `TOOL_MANIFEST` array in tool-manifest.ts.
+  // Fall back to tools/index.ts (`REGISTERED_TOOL_NAMES`) for pre-#3566 checkouts.
+  const manifestExists = existsSync(TOOL_MANIFEST_FILE);
+  const sourceFile = manifestExists ? TOOL_MANIFEST_FILE : TOOLS_INDEX;
+  if (!existsSync(sourceFile)) {
+    console.error('MCP tool manifest/index not found: ' + sourceFile);
     return [];
   }
 
-  const content = readFileSync(TOOLS_INDEX, 'utf-8');
+  const content = readFileSync(sourceFile, 'utf-8');
 
-  // Extract the tools array. Source of truth is the module-level
-  // `REGISTERED_TOOL_NAMES` const (extracted out of `registerTools()` to fit
-  // the max-lines-per-function gate). Fall back to the inline `tools: [...]`
-  // shape for older checkouts that haven't migrated yet.
+  // Extract the tools array. Source of truth is the module-level `TOOL_MANIFEST`
+  // const (or, pre-#3566, `REGISTERED_TOOL_NAMES`); both are literal `[...] as
+  // const` arrays of `'name'` strings. Fall back to the inline `tools: [...]`
+  // shape for very old checkouts.
   const toolsMatch =
+    content.match(/TOOL_MANIFEST\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     content.match(/REGISTERED_TOOL_NAMES\s*=\s*\[([\s\S]*?)\]\s*as const/) ??
     content.match(/tools:\s*\[([\s\S]*?)\]/);
   if (toolsMatch?.[1] === undefined) {
-    console.error('Could not parse tools array from index.ts');
+    console.error('Could not parse tools array from ' + sourceFile);
     return [];
   }
 

--- a/skills/documentation-management/SKILL.md
+++ b/skills/documentation-management/SKILL.md
@@ -70,6 +70,8 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Task
 
 <!-- PIPELINE NOTE: entrypointsToolDescription in inject-governance.ts now escapes backslashes before pipes (\\ then \|), resolving a HIGH js/incomplete-sanitization CodeQL alert from #3334 (2026-06-05). Escaping | for markdown-cell safety without escaping \ first let a backslash-bearing tool description smuggle a half-escaped pipe past the sanitization. Behavior-preserving — the curated TOOL_DESCRIPTIONS corpus has no backslashes, so inject output is unchanged + idempotent. -->
 
+<!-- PIPELINE NOTE: the canonical MCP tool-name list is now the leaf `TOOL_MANIFEST` array in src/mcp/tools/tool-manifest.ts (#3566, 2026-06-07). `REGISTERED_TOOL_NAMES` is a derived re-export; capability-gap-detector's AVAILABLE_TOOLS derives from the manifest (was a hand-copy + freshness test). ALL four tool-list parsers were retargeted to match `TOOL_MANIFEST = [...]` first (REGISTERED_TOOL_NAMES + legacy `tools:` kept as fallbacks): inject-governance.ts extractMcpTools(), generate-docs-content.ts extractMcpToolCount(), generate-repo-index.ts extractMCPTools(), and the docs-check.yml MCP_TOOL_COUNT awk guard. The registry-coverage manifest's REGISTERED_TOOL_NAMES entry repointed source→tool-manifest.ts/marker→TOOL_MANIFEST and gained a `moved_from` affordance so the structural-equivalence exemption recognizes a no-op registry relocation (new check-registry-coverage.ts feature). Annotation-data fold (#3597) + AST parser upgrade (#3596) are follow-ups. -->
+
 **Full specification:** [docops-spec.md](../../docs/ops/docops-spec.md)
 
 ---


### PR DESCRIPTION
Part of #3566 (Phase 3 of #3563) — **increment 1**. Vote: `consensus_vote` higher_order, **approved 5/5** valid voters.

## What
Introduces `mcp/tools/tool-manifest.ts` — a **pure-data leaf** (`TOOL_MANIFEST`) that is the single source of truth for which MCP tools exist and their registration order. Three previously hand-maintained copies of the 46 names now key off it:
- `REGISTERED_TOOL_NAMES` → derived re-export from `tools/index.ts` (all existing importers unchanged).
- gap-detector `AVAILABLE_TOOLS` → `new Set(TOOL_MANIFEST)`, **replacing a 46-line literal** that was kept in lockstep by a freshness test (#3553).
- `scripts/inject-governance.ts` → parses the manifest (regex unchanged, just retargeted; index.ts fallback kept).

## Honoring the vote's conditions
- **No import cycle / god-object (panel's #1 risk):** the manifest **imports nothing**, so `core/task-analysis/capability-gap-detector.ts` derives from it without pulling in the MCP tool dependency graph — exactly the concern the old hand-copy was avoiding, now resolved by a one-way edge.
- **Parser (AST vs literal):** kept the existing regex parser (retargeted at the manifest literal); the AST upgrade is split out as **#3596**.
- **Incremental + parity-tested:** this increment does the *name* list only — `tool-manifest.test.ts` asserts `REGISTERED_TOOL_NAMES`, `TOOL_ANNOTATIONS` keys, and the gap-detector list all match the manifest. Folding annotation *data* in (so `TOOL_ANNOTATIONS` derives too) is **#3597** — deferred deliberately because relocating 46 richly-valued entries is value-transcription risk that deserves its own review.

## Why no `register` field in the manifest
There is no uniform register dispatch table to consolidate: each `register*Tool` takes different per-tool deps and is invoked separately at the wiring site. Putting `register` in the manifest would be the god-object the panel warned against — so the manifest carries data, not behavior.

## Verification
- `governance:inject` → **no doc drift** (parser reads the manifest correctly; 46 tools unchanged).
- Tests: tool-manifest (4), capability-gap-detector (13), inject-governance (244), exports + mcp index (128), the 3 re-export importers (71). tsc + lint + orphan-gate clean.

Follow-ups: #3597 (annotation-data fold), #3596 (AST parser), #3528 (description-source unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)