### PR TITLE
refactor: centralize duplicated consensus + model-fallback constants (#3571)

### DIFF
--- a/.changeset/centralize-fallbacks.md
+++ b/.changeset/centralize-fallbacks.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+refactor: centralize duplicated consensus + model-fallback constants (#3571)
+
+Tier C of #3568 (vote-approved). Two single-source constants replace drift-prone
+duplicated literals: `SUPERMAJORITY_THRESHOLD` (the 2/3 governance threshold,
+previously a bare `0.67` across six consensus sites) and
+`FALLBACK_CONTEXT_WINDOW`/`FALLBACK_MAX_OUTPUT` (the unknown-model fallback,
+previously duplicated across the Claude/OpenCode CLI adapters,
+model-to-cli-adapter, and delegate-to-model-router). Behavior is unchanged
+(values identical). Per a verify-before-acting audit, the 8192-vs-200000
+unknown-context defaults were left distinct (context-appropriate, not drift),
+and adapter-specific pricing / provider-specific DEFAULT_MAX_TOKENS were left
+per-source rather than collapsed into a wrong global.

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.ts
@@ -24,6 +24,8 @@ import {
   getCliModelName,
   buildModelInfo,
   findInTreeByCli,
+  FALLBACK_CONTEXT_WINDOW,
+  FALLBACK_MAX_OUTPUT,
 } from '../../config/model-config-helpers.js';
 
 /**
@@ -98,8 +100,8 @@ export class ClaudeCliAdapter extends SubprocessCliAdapter {
     return {
       id: this.model,
       name: this.model,
-      contextWindow: 200_000,
-      maxOutput: 64_000,
+      contextWindow: FALLBACK_CONTEXT_WINDOW,
+      maxOutput: FALLBACK_MAX_OUTPUT,
       costPerMillionInput: UNKNOWN_MODEL_DEFAULT_INPUT_COST,
       costPerMillionOutput: UNKNOWN_MODEL_DEFAULT_OUTPUT_COST,
     };

--- a/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/opencode-adapter.ts
@@ -35,6 +35,8 @@ import {
   getCliModelName,
   buildModelInfo,
   findInTreeByCli,
+  FALLBACK_CONTEXT_WINDOW,
+  FALLBACK_MAX_OUTPUT,
 } from '../../config/model-config-helpers.js';
 import { createLogger } from '../../core/index.js';
 
@@ -168,8 +170,9 @@ export class OpenCodeCliAdapter extends SubprocessCliAdapter {
     return {
       id: this.model,
       name: `OpenCode (${this.model})`,
-      contextWindow: 200_000,
-      maxOutput: 64_000,
+      contextWindow: FALLBACK_CONTEXT_WINDOW,
+      maxOutput: FALLBACK_MAX_OUTPUT,
+      // OpenCode pricing fallback is adapter-specific (not the Claude 5/25).
       costPerMillionInput: 3.0,
       costPerMillionOutput: 15.0,
     };

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
@@ -19,6 +19,7 @@ import type {
   CompletionResponse,
 } from '../core/index.js';
 import { ok, err, ModelError } from '../core/index.js';
+import { FALLBACK_CONTEXT_WINDOW } from '../config/model-config-helpers.js';
 import { isRateLimitText } from '../adapters/rate-limit-detector.js';
 import type {
   ICliAdapter,
@@ -53,7 +54,7 @@ export interface ModelToCliAdapterConfig {
 }
 
 /** Default context window when the model adapter exposes no capability hint. */
-const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_CONTEXT_WINDOW = FALLBACK_CONTEXT_WINDOW;
 
 /** Neutral mid capability profile used when the caller supplies none. */
 const NEUTRAL_CAPABILITIES: CapabilityProfile = {

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -95,8 +95,25 @@ export function getModelDisplayName(modelId: ModelId): string {
  * removed; ModelRegistry is the single resolver).
  */
 export function getModelContextWindow(modelId: ModelId): number {
+  // 8_192 is the CONSERVATIVE default for a *truly unknown* model id (generic
+  // catalog lookup miss). This is intentionally distinct from
+  // FALLBACK_CONTEXT_WINDOW below (200_000), which CLI adapters use when an
+  // unknown model is known to be a Claude-class CLI model — #3571 verified the
+  // two are context-appropriate and must NOT be reconciled to one value.
   return lookupInTree(modelId)?.contextWindow ?? 8_192;
 }
+
+/**
+ * Fallback context window for an unknown model that a CLI adapter (Claude /
+ * OpenCode) or a capability profile assumes is Claude-class. Single source
+ * (#3571) — referenced wherever an unknown-model spec previously hardcoded
+ * `200_000`. Distinct from the conservative 8_192 generic default in
+ * {@link getModelContextWindow}; see that note for the rationale.
+ */
+export const FALLBACK_CONTEXT_WINDOW = 200_000;
+
+/** Fallback max-output tokens for an unknown CLI model (#3571 single source). */
+export const FALLBACK_MAX_OUTPUT = 64_000;
 
 /** Get max output tokens for a model, or undefined if not set. */
 export function getModelMaxOutput(modelId: ModelId): number | undefined {

--- a/packages/nexus-agents/src/consensus/quorum-validator.ts
+++ b/packages/nexus-agents/src/consensus/quorum-validator.ts
@@ -10,6 +10,7 @@
 
 import { createLogger, formatPercentage, type ILogger } from '../core/index.js';
 import type { ConsensusAlgorithm, Vote, VoteCounts, WeightedVoteCounts } from './types-core.js';
+import { SUPERMAJORITY_THRESHOLD } from './types-core.js';
 
 // ============================================================================
 // Types
@@ -130,12 +131,13 @@ export const DEFAULT_QUORUM_THRESHOLDS: Readonly<
   Record<ConsensusAlgorithm | 'weighted_byzantine', number>
 > = {
   simple_majority: 0.5,
-  supermajority: 0.67,
+  supermajority: SUPERMAJORITY_THRESHOLD,
   unanimous: 1.0,
   proof_of_learning: 0.5,
   opinion_wise: 0.5,
   higher_order: 0.5,
-  weighted_byzantine: 0.67,
+  // Byzantine fault tolerance also requires 2/3 — the same supermajority.
+  weighted_byzantine: SUPERMAJORITY_THRESHOLD,
 };
 
 const DEFAULT_MIN_TRUST = 0.3;

--- a/packages/nexus-agents/src/consensus/supermajority-threshold.test.ts
+++ b/packages/nexus-agents/src/consensus/supermajority-threshold.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Parity test for the centralized supermajority threshold (#3571).
+ *
+ * `SUPERMAJORITY_THRESHOLD` (types-core.ts) is the single source for the 2/3
+ * governance threshold. This asserts every consumer resolves to it — so the
+ * threshold can never silently drift between consensus modules again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SUPERMAJORITY_THRESHOLD, VOTING_THRESHOLDS } from './types-core.js';
+import { DEFAULT_QUORUM_THRESHOLDS } from './quorum-validator.js';
+import {
+  DEFAULT_VOTING_PROTOCOL_CONFIG,
+  VotingProtocolConfigSchema,
+} from './types-voting-protocol.js';
+import {
+  DEFAULT_WEIGHTED_VOTING_CONFIG,
+  WeightedVotingConfigSchema,
+} from './types-weighted-voting.js';
+
+describe('SUPERMAJORITY_THRESHOLD centralization (#3571)', () => {
+  it('pins the governance value at 2/3', () => {
+    expect(SUPERMAJORITY_THRESHOLD).toBe(0.67);
+  });
+
+  it('VOTING_THRESHOLDS.supermajority resolves to the constant', () => {
+    expect(VOTING_THRESHOLDS.supermajority).toBe(SUPERMAJORITY_THRESHOLD);
+  });
+
+  it('DEFAULT_QUORUM_THRESHOLDS supermajority + weighted_byzantine resolve to the constant', () => {
+    expect(DEFAULT_QUORUM_THRESHOLDS.supermajority).toBe(SUPERMAJORITY_THRESHOLD);
+    expect(DEFAULT_QUORUM_THRESHOLDS.weighted_byzantine).toBe(SUPERMAJORITY_THRESHOLD);
+  });
+
+  it('voting-protocol agreement default (object + Zod) resolves to the constant', () => {
+    expect(DEFAULT_VOTING_PROTOCOL_CONFIG.agreementThreshold).toBe(SUPERMAJORITY_THRESHOLD);
+    expect(VotingProtocolConfigSchema.parse({}).agreementThreshold).toBe(SUPERMAJORITY_THRESHOLD);
+  });
+
+  it('weighted-voting quorum default (object + Zod) resolves to the constant', () => {
+    expect(DEFAULT_WEIGHTED_VOTING_CONFIG.quorumThreshold).toBe(SUPERMAJORITY_THRESHOLD);
+    expect(WeightedVotingConfigSchema.parse({}).quorumThreshold).toBe(SUPERMAJORITY_THRESHOLD);
+  });
+});

--- a/packages/nexus-agents/src/consensus/types-core.ts
+++ b/packages/nexus-agents/src/consensus/types-core.ts
@@ -311,11 +311,21 @@ export const DEFAULT_CONSENSUS_CONFIG: ConsensusEngineConfig = {
 };
 
 /**
+ * The 2/3 supermajority agreement threshold — the governance constant for
+ * "supermajority" / Byzantine (2-of-3) quorum. SINGLE SOURCE (#3571): every
+ * consensus site that needs a supermajority references this instead of a bare
+ * `0.67` literal, so the governance threshold cannot silently drift between
+ * modules. (Per-algorithm values like 0.5/1.0 are intentionally NOT centralized
+ * — 0.5 is semantically overloaded across several algorithms.)
+ */
+export const SUPERMAJORITY_THRESHOLD = 0.67;
+
+/**
  * Voting thresholds for each algorithm.
  */
 export const VOTING_THRESHOLDS: Record<ConsensusAlgorithm, number> = {
   simple_majority: 0.5,
-  supermajority: 0.67,
+  supermajority: SUPERMAJORITY_THRESHOLD,
   unanimous: 1.0,
   proof_of_learning: 0.5, // Uses weighted voting
   opinion_wise: 0.5, // Uses correlation-aware Bayesian aggregation (Issue #333)

--- a/packages/nexus-agents/src/consensus/types-voting-protocol.ts
+++ b/packages/nexus-agents/src/consensus/types-voting-protocol.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import type { Vote } from './types-core.js';
+import { SUPERMAJORITY_THRESHOLD } from './types-core.js';
 
 /**
  * Voting round phases.
@@ -93,7 +94,7 @@ export const VotingProtocolConfigSchema = z.object({
   committeeSize: z.number().int().min(2).max(7).default(3),
   maxRounds: z.number().int().min(1).max(5).default(3),
   roundTimeoutMs: z.number().int().positive().default(60000),
-  agreementThreshold: z.number().min(0.5).max(1).default(0.67),
+  agreementThreshold: z.number().min(0.5).max(1).default(SUPERMAJORITY_THRESHOLD),
   enableAntiSycophancy: z.boolean().default(true),
   sycophancyThreshold: z.number().min(0).max(1).default(0.8),
 });
@@ -102,7 +103,8 @@ export const DEFAULT_VOTING_PROTOCOL_CONFIG: VotingProtocolConfig = {
   committeeSize: 3,
   maxRounds: 3,
   roundTimeoutMs: 60000,
-  agreementThreshold: 0.67,
+  // Default agreement level IS the supermajority (2/3) — single source (#3571).
+  agreementThreshold: SUPERMAJORITY_THRESHOLD,
   enableAntiSycophancy: true,
   sycophancyThreshold: 0.8,
 };

--- a/packages/nexus-agents/src/consensus/types-weighted-voting.ts
+++ b/packages/nexus-agents/src/consensus/types-weighted-voting.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import type { Vote } from './types-core.js';
+import { SUPERMAJORITY_THRESHOLD } from './types-core.js';
 
 /**
  * Task outcome STATUS for tracking agent performance — a 4-state vote status,
@@ -92,7 +93,7 @@ export const WeightedVotingConfigSchema = z.object({
   minTrustScore: z.number().min(0).max(1).default(0.3),
   byzantineFlagThreshold: z.number().int().positive().default(3),
   initialWeight: z.number().min(0).max(1).default(0.5),
-  quorumThreshold: z.number().min(0.5).max(1).default(0.67),
+  quorumThreshold: z.number().min(0.5).max(1).default(SUPERMAJORITY_THRESHOLD),
 });
 
 export const DEFAULT_WEIGHTED_VOTING_CONFIG: WeightedVotingConfig = {
@@ -103,7 +104,8 @@ export const DEFAULT_WEIGHTED_VOTING_CONFIG: WeightedVotingConfig = {
   minTrustScore: 0.3,
   byzantineFlagThreshold: 3,
   initialWeight: 0.5,
-  quorumThreshold: 0.67,
+  // Default quorum IS the supermajority (2/3) — single source (#3571).
+  quorumThreshold: SUPERMAJORITY_THRESHOLD,
 };
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -29,6 +29,7 @@ import {
   type BaseMcpToolDeps,
 } from './tool-result.js';
 import type { ConsensusAlgorithm, Vote, ConsensusResult, Proposal } from '../../consensus/types.js';
+import { SUPERMAJORITY_THRESHOLD } from '../../consensus/types-core.js';
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { createConsensusEngine } from '../../consensus/engine.js';
@@ -224,7 +225,7 @@ export function createPolicyFailedResult(
 /** Thresholds per algorithm for cascade detection. */
 const CASCADE_THRESHOLDS: Record<string, number> = {
   majority: 0.5,
-  supermajority: 0.67,
+  supermajority: SUPERMAJORITY_THRESHOLD,
   unanimous: 1.0,
 };
 

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.ts
@@ -12,7 +12,10 @@ import type { IFeedbackIntegration } from '../../learning/feedback-integration.j
 // Import directly from types to avoid circular dependency with delegate-to-model.ts
 import type { CapabilityProfile, DelegateOutput } from './delegate-to-model-types.js';
 import { MODEL_CAPABILITIES } from './delegate-to-model-types.js';
-import { getDefaultModelForCli } from '../../config/model-config-helpers.js';
+import {
+  getDefaultModelForCli,
+  FALLBACK_CONTEXT_WINDOW,
+} from '../../config/model-config-helpers.js';
 import type { CliNameLiteral } from '../../config/model-capabilities-types.js';
 import { routingArmDisplaySlot } from '../../cli-adapters/types.js';
 
@@ -29,7 +32,7 @@ export function cliNameToModel(cliName: CliNameLiteral): string {
  */
 const DEFAULT_CAPABILITIES: CapabilityProfile = {
   reasoning: 8,
-  contextWindow: 200_000,
+  contextWindow: FALLBACK_CONTEXT_WINDOW,
   codeGeneration: 8,
   speed: 7,
   cost: 6,


### PR DESCRIPTION
Closes #3571 (Tier C of #3568). Vote: `consensus_vote` higher_order, **approved 5/5** valid voters. Scope was **corrected by a verify-before-acting audit** (recorded on the issue) — several of the issue's premises didn't hold.

## What changed (2 single-source constants)
1. **`SUPERMAJORITY_THRESHOLD`** (`consensus/types-core.ts`) — the 2/3 governance threshold, previously a bare `0.67` at six sites: `VOTING_THRESHOLDS`, `DEFAULT_QUORUM_THRESHOLDS` (supermajority + weighted_byzantine), `CASCADE_THRESHOLDS`, and the `agreementThreshold`/`quorumThreshold` defaults (object + Zod) in the voting-protocol and weighted-voting configs. Parity test asserts every consumer resolves to it.
2. **`FALLBACK_CONTEXT_WINDOW` / `FALLBACK_MAX_OUTPUT`** (`config/model-config-helpers.ts`) — the unknown-model fallback (`200_000`/`64_000`), previously duplicated in claude-adapter, opencode-adapter, model-to-cli-adapter, and delegate-to-model-router.

## What the audit deliberately left alone (and why)
- **8192-vs-200000 NOT reconciled** — `getModelContextWindow`'s `8_192` is the conservative default for a *truly unknown* model; `FALLBACK_CONTEXT_WINDOW` (200_000) is the CLI-adapter Claude-class assumption. They're context-appropriate, not drift. The two now sit adjacent with a comment documenting the distinction (every voter flagged collapsing them as a behavior-change risk).
- **Pricing left adapter-specific** — claude 5.0/25.0 vs opencode 3.0/15.0 are *different*, not duplicated (the issue's "5.0/25.0 duplicated" premise was stale).
- **`DEFAULT_MAX_TOKENS` left provider-specific** — claude/openai 4096, ollama 2048, gemini 8192 are real per-provider limits, not a global.

## Behavior
Unchanged — every centralized value is identical to what it replaced. Pure DRY + drift-proofing.

## Tests
New `supermajority-threshold.test.ts` parity suite; full consensus suite (612) + affected adapter/config suites (143) green. tsc + lint clean. No import cycles (constants live in leaf-ish config/consensus-core modules already depended on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)