### PR TITLE
fix(consensus): restore full voter panel + warn on degradation (#3587)

### DIFF
--- a/.changeset/voter-panel-fallback.md
+++ b/.changeset/voter-panel-fallback.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): restore full voter panel + warn on degradation (#3587)
+
+Two fixes for silent panel shrinkage. (1) Root cause: a voter round-robined onto
+a diverse CLI backed by an OpenRouter model without tool-use hard-fails ("no
+endpoints that support tool use") and the responseFormat retry can't help (the
+CLI sends bash tools regardless) — so that voter silently dropped. The voter
+launcher now retries once on the known-good fallback adapter when a diverse
+adapter fails (non-deadline), keeping the panel at full strength while preserving
+CLI diversity when it works. (2) Observability (#3587 scope): the consensus
+response now carries a `panelWarning` when some-but-not-all voters errored, so a
+degraded panel is visible rather than passing silently on the survivors.

--- a/packages/nexus-agents/src/cli/voter-agents-deadline.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents-deadline.test.ts
@@ -180,4 +180,81 @@ describe('launchVotesWithOverallDeadline (Issue #1871)', () => {
 
     expect(results.map((r) => r.role)).toEqual([...roles]);
   });
+
+  it('retries on the fallback adapter when a diverse adapter hard-fails (#3587)', async () => {
+    // architect lands on a bad CLI (OpenRouter tool-use 404 class); the
+    // fallback CLI is healthy. The voter must end up with a real vote.
+    const roleAdapters = new Map<VoterRole, IModelAdapter>([
+      ['architect', makeCliAdapter('badcli')],
+    ]);
+    const seen: string[] = [];
+    const voteFn = (
+      role: VoterRole,
+      _p: string,
+      adapter: IModelAdapter
+    ): Promise<AgentVoteResult> => {
+      const name = (adapter as { name?: string }).name ?? adapter.providerId;
+      seen.push(name);
+      if (name === 'badcli') {
+        return Promise.resolve({
+          role,
+          error: 'No endpoints found that support tool use',
+          processingTimeMs: 5,
+          source: 'error',
+          cli: name,
+        } as AgentVoteResult);
+      }
+      return Promise.resolve(makeOkVote(role));
+    };
+
+    const results = await launchVotesWithOverallDeadline({
+      roles: ['architect'],
+      proposal: 'test',
+      roleAdapters,
+      fallbackAdapter: makeCliAdapter('goodcli'),
+      logger: silentLogger,
+      voteOptions: { timeoutMs: 1_000, maxRetries: 0, allowSimulation: false },
+      interDelay: 0,
+      overallDeadlineMs: 1_000,
+      voteFn,
+    });
+
+    expect(results[0]?.source).toBe('llm'); // recovered via fallback
+    expect(seen).toEqual(['badcli', 'goodcli']); // tried diverse, then fallback
+  });
+
+  it('does not retry when the failing adapter IS the fallback (no loop)', async () => {
+    // architect uses the fallback directly; a failure must not re-invoke it.
+    const fallback = makeCliAdapter('only');
+    const seen: string[] = [];
+    const voteFn = (
+      role: VoterRole,
+      _p: string,
+      adapter: IModelAdapter
+    ): Promise<AgentVoteResult> => {
+      seen.push((adapter as { name?: string }).name ?? adapter.providerId);
+      return Promise.resolve({
+        role,
+        error: 'No endpoints found that support tool use',
+        processingTimeMs: 5,
+        source: 'error',
+        cli: 'only',
+      } as AgentVoteResult);
+    };
+
+    const results = await launchVotesWithOverallDeadline({
+      roles: ['architect'],
+      proposal: 'test',
+      roleAdapters: new Map([['architect', fallback]]),
+      fallbackAdapter: fallback,
+      logger: silentLogger,
+      voteOptions: { timeoutMs: 1_000, maxRetries: 0, allowSimulation: false },
+      interDelay: 0,
+      overallDeadlineMs: 1_000,
+      voteFn,
+    });
+
+    expect(results[0]?.source).toBe('error');
+    expect(seen).toEqual(['only']); // exactly one attempt — no fallback loop
+  });
 });

--- a/packages/nexus-agents/src/cli/voter-agents-deadline.ts
+++ b/packages/nexus-agents/src/cli/voter-agents-deadline.ts
@@ -45,6 +45,23 @@ export interface LaunchVotesInput {
 
 const DEADLINE_MESSAGE = 'overall consensus deadline exceeded';
 
+/**
+ * Should a failed vote be retried on the fallback adapter? Only when the diverse
+ * adapter produced a genuine error (not the overall-deadline filler, which means
+ * there's no time left) AND it wasn't already the fallback (#3587).
+ */
+function shouldRetryOnFallback(
+  result: AgentVoteResult,
+  used: IModelAdapter,
+  fallback: IModelAdapter
+): boolean {
+  return (
+    result.source === 'error' &&
+    result.error !== DEADLINE_MESSAGE &&
+    adapterCliKey(used) !== adapterCliKey(fallback)
+  );
+}
+
 /** Stable per-CLI key for an adapter; CLI adapters carry the CLI name. */
 function adapterCliKey(adapter: IModelAdapter): string {
   return (adapter as { name?: string }).name ?? adapter.providerId;
@@ -114,21 +131,36 @@ export async function launchVotesWithOverallDeadline(
   const startedAt = Date.now();
   const serialize = createKeyedSerializer();
 
-  const wrapped = roles.map(async (role, i) => {
-    if (i > 0 && interDelay > 0) await delay(interDelay);
-    const adapter = roleAdapters.get(role) ?? fallbackAdapter;
+  // One serialized, deadline-bounded vote attempt on a specific adapter.
+  const voteOnAdapter = (role: VoterRole, adapter: IModelAdapter): Promise<AgentVoteResult> =>
     // Serialize per CLI so concurrent same-CLI calls don't race that CLI's
     // OAuth refresh (#3348). The deadline is measured when the vote actually
     // starts, so a queued role still gets a correct remaining budget.
-    return serialize(adapterCliKey(adapter), () => {
-      const elapsed = Date.now() - startedAt;
-      const remaining = Math.max(1, overallDeadlineMs - elapsed);
+    serialize(adapterCliKey(adapter), () => {
+      const remaining = Math.max(1, overallDeadlineMs - (Date.now() - startedAt));
       return raceWithDeadline(
         voteFn(role, proposal, adapter, logger, voteOptions),
         role,
         remaining
       );
     });
+
+  const wrapped = roles.map(async (role, i): Promise<AgentVoteResult> => {
+    if (i > 0 && interDelay > 0) await delay(interDelay);
+    const adapter = roleAdapters.get(role) ?? fallbackAdapter;
+    const primary = await voteOnAdapter(role, adapter);
+    // #3587: a voter routed to a diverse CLI that hard-fails (e.g. an OpenRouter
+    // model without tool-use → "no endpoints that support tool use", which the
+    // responseFormat retry can't fix) would silently shrink the panel. Retry
+    // once on the known-good fallback adapter so one bad CLI can't drop a voter.
+    if (!shouldRetryOnFallback(primary, adapter, fallbackAdapter)) return primary;
+    logger.warn('Voter failed on diverse adapter; retrying on fallback (#3587)', {
+      role,
+      failedCli: adapterCliKey(adapter),
+      fallbackCli: adapterCliKey(fallbackAdapter),
+      error: primary.error,
+    });
+    return voteOnAdapter(role, fallbackAdapter);
   });
 
   const results = await Promise.all(wrapped);

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -270,6 +270,13 @@ export interface ConsensusVoteResponse {
    * `fail_closed: 1 voter(s) errored`. Absent on normally-tallied votes.
    */
   policyReason?: string;
+  /**
+   * Set when the panel was DEGRADED (#3587): some voters errored, so the
+   * decision rests on fewer than the requested number of voters. Surfaces a
+   * silently-shrunk panel so the result isn't read as a full-strength consensus.
+   * Absent when every requested voter returned a real vote.
+   */
+  panelWarning?: string;
 }
 
 /** Extended voting result with optional Higher-Order metadata. */
@@ -314,6 +321,20 @@ export function mapOutcomeToDecision(outcome: string): VoteDecisionStatus {
   }
 }
 
+/**
+ * #3587: partial panel degradation — some (but not all) voters errored, so the
+ * decision rests on fewer voters than requested. Returns a warning string, or
+ * undefined when the panel is full or entirely errored (the latter is already a
+ * structured error elsewhere).
+ */
+function panelDegradationWarning(errorCount: number, total: number): string | undefined {
+  if (errorCount <= 0 || errorCount >= total) return undefined;
+  return (
+    `Panel degraded: ${String(errorCount)} of ${String(total)} voters errored; ` +
+    `decision rests on ${String(total - errorCount)} voter(s).`
+  );
+}
+
 /** Builds the response from voting result. */
 export function buildResponse(
   input: ConsensusVoteInput,
@@ -354,18 +375,28 @@ export function buildResponse(
     response.policyReason = result.policyReason;
   }
 
+  const panelWarning = panelDegradationWarning(errorCount, result.votes.length);
+  if (panelWarning !== undefined) {
+    response.panelWarning = panelWarning;
+  }
+
   if (isHigherOrderStrategy(result.strategy) && result.higherOrderResult) {
-    response.higherOrderMetadata = {
-      posteriorApproval: result.higherOrderResult.posteriorApproval,
-      posteriorRejection: result.higherOrderResult.posteriorRejection,
-      effectiveVoteCount: result.higherOrderResult.effectiveVoteCount,
-      method: result.higherOrderResult.method,
-      usedCorrelationData: result.higherOrderResult.usedCorrelationData,
-      improvementOverBaseline: result.higherOrderResult.improvementOverBaseline,
-      downweightedAgents: result.higherOrderResult.downweightedAgents,
-      reasoning: result.higherOrderResult.reasoning,
-    };
+    response.higherOrderMetadata = toHigherOrderMetadata(result.higherOrderResult);
   }
 
   return response;
+}
+
+/** Maps a HigherOrderVotingResult to the response's metadata shape. */
+function toHigherOrderMetadata(r: HigherOrderVotingResult): HigherOrderMetadata {
+  return {
+    posteriorApproval: r.posteriorApproval,
+    posteriorRejection: r.posteriorRejection,
+    effectiveVoteCount: r.effectiveVoteCount,
+    method: r.method,
+    usedCorrelationData: r.usedCorrelationData,
+    improvementOverBaseline: r.improvementOverBaseline,
+    downweightedAgents: r.downweightedAgents,
+    reasoning: r.reasoning,
+  };
 }

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -991,6 +991,52 @@ describe('buildResponse error counting (Issue #815)', () => {
     expect(response.votes[0]!.error).toBe(false);
   });
 
+  it('surfaces a panelWarning on partial panel degradation (#3587)', () => {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 50,
+        source: 'llm',
+      },
+      {
+        role: 'security',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.8 },
+        processingTimeMs: 60,
+        source: 'llm',
+      },
+      {
+        role: 'devex',
+        vote: { decision: 'abstain', reasoning: 'err', confidence: 0 },
+        processingTimeMs: 10,
+        source: 'error',
+      },
+    ];
+    const input = { proposal: 'Test', simulateVotes: false, quickMode: false };
+    const response = buildResponse(input, makeVotingResult(votes));
+    expect(response.panelWarning).toMatch(/Panel degraded: 1 of 3 voters errored/);
+  });
+
+  it('omits panelWarning when every voter returns a real vote', () => {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 50,
+        source: 'llm',
+      },
+      {
+        role: 'security',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.8 },
+        processingTimeMs: 60,
+        source: 'llm',
+      },
+    ];
+    const input = { proposal: 'Test', simulateVotes: false, quickMode: false };
+    const response = buildResponse(input, makeVotingResult(votes));
+    expect(response.panelWarning).toBeUndefined();
+  });
+
   it('should report all errors when every vote errored', () => {
     const votes: AgentVoteResult[] = [
       {


### PR DESCRIPTION
Closes #3587. Owner-selected direction (restore the full 7-voter panel).

## Root cause (the part the issue's premise missed)
#3587 assumed the tool-use-404 root cause was fixed in #3497. It isn't, for **devex + catfish**, which errored on **every** `consensus_vote` this session. Trace:
- `resolveDiverseAdapters` round-robins voter roles across available CLIs.
- A voter landing on a CLI backed by an **OpenRouter model without tool-use** gets a hard 404 ("No endpoints found that support tool use. Try disabling bash").
- The #3497 responseFormat retry **can't help** here — the subprocess CLI sends its own bash tools regardless of `responseFormat`, so the retry hits the same 404. The voter silently drops → panel runs on 5/7.

## Fix 1 — restore the panel (root cause)
`launchVotesWithOverallDeadline` now retries a failed voter **once on the known-good fallback adapter** when the diverse adapter produced a genuine (non-deadline) error and wasn't already the fallback. Full panel strength restored; CLI diversity preserved when healthy; no retry loop when the failing adapter *is* the fallback.

## Fix 2 — #3587's ratified scope (observability)
The consensus response now carries a **`panelWarning`** when some-but-not-all voters errored (e.g. *"Panel degraded: 1 of 3 voters errored; decision rests on 2 voter(s)."*), so a shrunk panel is visible rather than silently passing on the survivors — covering degradation causes the fallback can't fix (auth, deadline, fallback-also-fails).

## Tests
- voter-agents-deadline: retry-on-fallback recovers a hard-failing diverse adapter; no-loop when the failure is on the fallback itself.
- consensus-vote: `panelWarning` set on partial degradation, absent on a full panel.
- Full voter + consensus suite (724) green; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)