### PR TITLE
fix(mcp): decouple suggest_research_tasks gap path from slow research (#3606)

### DIFF
--- a/.changeset/suggest-research-decouple.md
+++ b/.changeset/suggest-research-decouple.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): decouple suggest_research_tasks gap path from slow research (#3606)
+
+`suggest_research_tasks` awaited the external research-discovery path and the
+synchronous capability-gap path together, so a slow/failing `research_discover`
+(external APIs) timed out the whole tool and dropped the fast gap candidates too.
+Now the gap candidates compute first, and research is bounded by an internal
+budget (20s, under the MCP wrapper timeout) — on timeout or error the tool
+returns PARTIAL results (gap candidates, empty research candidates, and a
+`researchTimedOut` flag) instead of failing. Found during the 2.123.4
+e2e-validation pass.

--- a/packages/nexus-agents/src/mcp/tools/suggest-research-tasks-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/suggest-research-tasks-tool.test.ts
@@ -183,6 +183,24 @@ describe('registerSuggestResearchTasksTool — handler', () => {
     expect(result.isError).toBe(true);
     expect(mockCheckForResearchTriggers).not.toHaveBeenCalled();
   });
+
+  // #3606: the slow/failing research path must not block the fast gap path.
+  it('still returns gap candidates when the research path throws', async () => {
+    mockCheckForResearchTriggers.mockRejectedValueOnce(new Error('research_discover exploded'));
+    const gapTask: PipelineTask = {
+      id: 'gap-some-tool',
+      title: 'Build some_tool',
+      description: 'Recurring capability gap.',
+      assignedTo: 'researcher',
+      status: 'pending',
+    };
+    mockCheckForCapabilityGapTriggers.mockReturnValueOnce([gapTask]);
+
+    const res = await callHandler({});
+    expect(res.candidates).toEqual([]); // research failed → empty, not a crash
+    expect(res.gapCandidates).toEqual([gapTask]); // gap path still delivered
+    expect(res.count).toBe(1);
+  });
 });
 
 describe('registerSuggestResearchTasksTool — registration', () => {

--- a/packages/nexus-agents/src/mcp/tools/suggest-research-tasks-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/suggest-research-tasks-tool.ts
@@ -20,7 +20,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { createLogger, formatZodError, type ILogger } from '../../core/index.js';
+import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler } from '../middleware/secure-handler.js';
 import {
@@ -44,6 +44,34 @@ import type { PipelineTask } from '../../pipeline/dev-pipeline.js';
 export const SUGGEST_RESEARCH_TASKS_NOTE =
   'Suggestions derived from external research (untrusted); review before acting — ' +
   'nothing was executed or filed.';
+
+/**
+ * Internal budget for the research-discovery path (#3606). Kept well under the
+ * MCP tool-wrapper timeout so a slow/failing research call returns PARTIAL
+ * results (the synchronous gap candidates) rather than timing out the whole tool.
+ */
+const RESEARCH_BUDGET_MS = 20_000;
+
+/** Sentinel returned by {@link withResearchBudget} when the budget elapses. */
+const RESEARCH_TIMED_OUT = Symbol('research-budget-exceeded');
+
+/** Races a promise against the research budget; resolves to the sentinel on timeout. */
+async function withResearchBudget<T>(
+  p: Promise<T>,
+  ms: number
+): Promise<T | typeof RESEARCH_TIMED_OUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<typeof RESEARCH_TIMED_OUT>((resolve) => {
+    timer = setTimeout(() => {
+      resolve(RESEARCH_TIMED_OUT);
+    }, ms);
+  });
+  try {
+    return await Promise.race([p, budget]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 export const SuggestResearchTasksInputSchema = z.object({
   topic: z.string().optional().describe('Topic filter passed to research_discover. Optional.'),
@@ -77,6 +105,11 @@ export interface SuggestResearchTasksResponse {
   readonly gapCandidates: readonly PipelineTask[];
   readonly count: number;
   readonly note: string;
+  /**
+   * True when the research-discovery path exceeded its internal budget (#3606)
+   * and `candidates` is therefore empty; `gapCandidates` are still returned.
+   */
+  readonly researchTimedOut?: boolean;
 }
 
 export type SuggestResearchTasksDeps = BaseMcpToolDeps;
@@ -101,13 +134,9 @@ async function suggestResearchTasksHandler(args: unknown, logger: ILogger): Prom
     });
   }
 
-  // The engine enforces threshold/max/topic/dedup guardrails and returns []
-  // when the research expert is unavailable (graceful degradation). It builds
-  // task objects in memory only — no GitHub / execution side effects.
-  const candidates = await checkForResearchTriggers(toTriggerConfig(parsed.data));
-
   // Capability-gap-driven suggestions from the in-process ledger (#3576) — the
   // human-gated front of "gap → MetaOrchestrator". Synchronous, side-effect-free.
+  // Computed FIRST so the slow research path can never block it (#3606).
   const existingTaskIds =
     parsed.data.existingTaskIds !== undefined ? new Set(parsed.data.existingTaskIds) : undefined;
   const gapCandidates = checkForCapabilityGapTriggers({
@@ -115,9 +144,32 @@ async function suggestResearchTasksHandler(args: unknown, logger: ILogger): Prom
     ...(existingTaskIds !== undefined ? { existingTaskIds } : {}),
   });
 
+  // Research candidates hit external APIs (arXiv/GitHub/…) and can be slow. Bound
+  // them with an internal budget well under the MCP wrapper timeout so a slow or
+  // failing research path returns PARTIAL results (the gap candidates) instead of
+  // timing out the whole tool and losing them too (#3606). The engine already
+  // returns [] when the research expert is unavailable; this also covers latency.
+  const research = await withResearchBudget(
+    checkForResearchTriggers(toTriggerConfig(parsed.data)).catch((err: unknown) => {
+      logger.warn('Research trigger failed; returning gap candidates only', {
+        error: getErrorMessage(err),
+      });
+      return [] as readonly PipelineTask[];
+    }),
+    RESEARCH_BUDGET_MS
+  );
+  const researchTimedOut = research === RESEARCH_TIMED_OUT;
+  const candidates = researchTimedOut ? [] : research;
+  if (researchTimedOut) {
+    logger.warn('Research discovery exceeded budget; returning gap candidates only (#3606)', {
+      budgetMs: RESEARCH_BUDGET_MS,
+    });
+  }
+
   logger.info('Suggested research tasks', {
     count: candidates.length,
     gapCount: gapCandidates.length,
+    researchTimedOut,
   });
 
   const response: SuggestResearchTasksResponse = {
@@ -125,6 +177,7 @@ async function suggestResearchTasksHandler(args: unknown, logger: ILogger): Prom
     gapCandidates,
     count: candidates.length + gapCandidates.length,
     note: SUGGEST_RESEARCH_TASKS_NOTE,
+    ...(researchTimedOut ? { researchTimedOut: true } : {}),
   };
   return toolSuccess(JSON.stringify(response, null, 2));
 }


### PR DESCRIPTION
Closes #3606. Found during the **2.123.4 e2e-validation pass** (the periodic real-loop validation after this session's 6 fixes went live).

## Problem
`suggest_research_tasks { maxTriggers: 3 }` (no topic) timed out at 30s and returned **nothing** — not even the gap candidates. Trace: the handler awaited both result sets together:
- `candidates` ← `checkForResearchTriggers` → `research_discover` → external APIs, **slow**;
- `gapCandidates` ← `checkForCapabilityGapTriggers` → in-process ledger, **sync + fast**.

The slow path blocking on external latency killed the whole tool, including the cheap gap path (#3576's human-gated "gap → MetaOrchestrator" front).

## Fix
- Compute `gapCandidates` **first** (synchronous, can never be blocked).
- Bound the research path with an internal **20s budget** (under the 30s MCP wrapper timeout); on timeout **or** error it yields empty research candidates rather than failing.
- Return **partial results** — gap candidates always, research candidates when they arrive — plus a `researchTimedOut` flag so callers know research was skipped.

## Tests
New test: research path throws → gap candidates still delivered (`candidates: []`, no crash). Suite 15/15; tsc + lint clean.

## e2e-validation summary (this run, 2.123.4 / 8791f82)
- **Consensus #3587 — PASS:** full 7-voter `higher_order` returned **7/7, error:0** (devex+catfish recovered via fallback; was 5/7 on the stale 2.97.1 all prior session).
- **`run` / MetaOrchestrator + shadow (#3548/#3551) — PASS:** routes correctly, valid decisionId, no error.
- **Memory — PASS:** write + query round-trips (0.9 relevance).
- **Audit — PASS (tool):** `verify_audit_chain` verifies a real chain; live trail is opt-in.
- **Research/suggest — PARTIAL → this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)