### PR TITLE
feat(capability-loop): improvement-signal to remediation-task bridge (#3540 inc.1)

### DIFF
--- a/.changeset/improvement-remediation-bridge.md
+++ b/.changeset/improvement-remediation-bridge.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): improvement-signal → remediation-task bridge (#3540 inc.1)
+
+First, safe increment of the capability loop (#3540): a pure
+`improvementSignalsToTasks()` mapper turns the observability signals
+`improvement_review` already detects (fitness decline, CLI-floor, failure-category
+concentration, consensus rejection, self-eval) into structured remediation
+PipelineTasks, surfaced on the `improvement_review` response as `remediationTasks`.
+SUGGEST-ONLY by construction — a pure mapping that executes nothing, files
+nothing, and auto-invokes no pipeline; a reviewer decides whether to route a task
+through the dev-pipeline. The safety-critical auto-invoke gate is a deliberately
+separate, owner-gated later increment.

--- a/packages/nexus-agents/src/cli/improvement-review-command.test.ts
+++ b/packages/nexus-agents/src/cli/improvement-review-command.test.ts
@@ -33,6 +33,7 @@ const emptyResponse: ImprovementReviewResponse = {
   window: '7d',
   totalOutcomes: 0,
   signals: [],
+  remediationTasks: [],
   issuesFiled: [],
   issuesSkipped: [],
 };

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the improvement-signal → remediation-task bridge (#3540 inc.1).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  improvementSignalToTask,
+  improvementSignalsToTasks,
+  remediationTaskId,
+} from './improvement-remediation.js';
+import type { ImprovementSignal, SignalCategory } from './improvement-review.js';
+
+function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+  return {
+    category: 'tech-debt',
+    signalKey: 'fitness-floor',
+    severity: 'warning',
+    title: 'Fitness below floor',
+    body: 'Score 82 < floor 90.',
+    evidence: { observedValue: 82, threshold: 90 },
+    ...over,
+  };
+}
+
+describe('improvementSignalToTask', () => {
+  it('maps a signal to a pending, suggest-only remediation task', () => {
+    const task = improvementSignalToTask(signal());
+    expect(task.id).toBe('improvement-fitness-floor');
+    expect(task.title).toBe('Fitness below floor');
+    expect(task.status).toBe('pending');
+    expect(task.description).toContain('SUGGEST-ONLY');
+    expect(task.description).toContain('Score 82 < floor 90.');
+  });
+
+  it('routes each category to a sensible seed role', () => {
+    const cases: Array<[SignalCategory, string]> = [
+      ['security', 'security'],
+      ['bug', 'coder'],
+      ['tech-debt', 'coder'],
+      ['routing', 'researcher'],
+      ['consensus', 'researcher'],
+    ];
+    for (const [category, role] of cases) {
+      expect(improvementSignalToTask(signal({ category })).assignedTo).toBe(role);
+    }
+  });
+
+  it('derives a stable id from the signalKey', () => {
+    expect(remediationTaskId(signal({ signalKey: 'cli-floor:claude' }))).toBe(
+      'improvement-cli-floor:claude'
+    );
+  });
+});
+
+describe('improvementSignalsToTasks', () => {
+  it('preserves order and maps every signal', () => {
+    const tasks = improvementSignalsToTasks([
+      signal({ signalKey: 'a' }),
+      signal({ signalKey: 'b' }),
+    ]);
+    expect(tasks.map((t) => t.id)).toEqual(['improvement-a', 'improvement-b']);
+  });
+
+  it('dedups against existing task ids', () => {
+    const tasks = improvementSignalsToTasks(
+      [signal({ signalKey: 'a' }), signal({ signalKey: 'b' })],
+      new Set(['improvement-a'])
+    );
+    expect(tasks.map((t) => t.id)).toEqual(['improvement-b']);
+  });
+
+  it('returns [] for no signals (suggest-only, never throws)', () => {
+    expect(improvementSignalsToTasks([])).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation.ts
@@ -1,0 +1,70 @@
+/**
+ * Improvement-signal → remediation-task bridge (#3540, capability-loop increment 1).
+ *
+ * The "safe plumbing" half of the capability loop: turn the observability
+ * signals `improvement_review` already detects (fitness decline, CLI-floor,
+ * failure-category concentration, consensus rejection, self-eval findings) into
+ * structured remediation {@link PipelineTask}s, surfaced for human review.
+ *
+ * SUGGEST-ONLY by construction: this is a pure mapping. It executes nothing,
+ * files nothing, and auto-invokes no pipeline — the safety-critical auto-invoke
+ * gate is a deliberately separate, later increment (still owner-gated). A
+ * reviewer (or a future human-gated path) decides whether to route a task
+ * through the dev-pipeline.
+ *
+ * @module mcp/tools/improvement-remediation
+ */
+
+import type { PipelineTask, PipelineRole } from '../../pipeline/dev-pipeline.js';
+import type { ImprovementSignal, SignalCategory } from './improvement-review.js';
+
+/**
+ * Which pipeline role should own a remediation, by signal category. The
+ * dev-pipeline re-plans from research anyway, so this is the seed owner, not a
+ * final assignment.
+ */
+const ROLE_BY_CATEGORY: Readonly<Record<SignalCategory, PipelineRole>> = {
+  security: 'security',
+  bug: 'coder',
+  'tech-debt': 'coder',
+  routing: 'researcher',
+  consensus: 'researcher',
+};
+
+/** Stable, dedup-friendly task id for a signal (mirrors the signalKey). */
+export function remediationTaskId(signal: ImprovementSignal): string {
+  return `improvement-${signal.signalKey}`;
+}
+
+/** Maps one improvement signal to a suggest-only remediation task. */
+export function improvementSignalToTask(signal: ImprovementSignal): PipelineTask {
+  return {
+    id: remediationTaskId(signal),
+    title: signal.title,
+    description:
+      `Auto-suggested remediation from improvement_review (#3540 — SUGGEST-ONLY, nothing executed). ` +
+      `Category: ${signal.category}; severity: ${signal.severity}.\n\n${signal.body}\n\n` +
+      `If accepted, route this through the dev-pipeline (research → plan → vote → implement → QA → ` +
+      `security gate). Auto-invocation is a separate, owner-gated step.`,
+    assignedTo: ROLE_BY_CATEGORY[signal.category],
+    status: 'pending',
+  };
+}
+
+/**
+ * Maps detected improvement signals to remediation tasks for review. Preserves
+ * input order (signals arrive severity-sorted) and dedups by task id against
+ * `existingTaskIds` when provided.
+ */
+export function improvementSignalsToTasks(
+  signals: readonly ImprovementSignal[],
+  existingTaskIds?: ReadonlySet<string>
+): PipelineTask[] {
+  const tasks: PipelineTask[] = [];
+  for (const signal of signals) {
+    const task = improvementSignalToTask(signal);
+    if (existingTaskIds?.has(task.id) === true) continue;
+    tasks.push(task);
+  }
+  return tasks;
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-scheduler.test.ts
@@ -47,6 +47,7 @@ describe('improvement-review-scheduler (#3229)', () => {
       window: '7d',
       totalOutcomes: 0,
       signals: [],
+      remediationTasks: [],
       issuesFiled: [],
       issuesSkipped: [],
     });
@@ -67,6 +68,7 @@ describe('improvement-review-scheduler (#3229)', () => {
       window: '7d',
       totalOutcomes: 0,
       signals: [],
+      remediationTasks: [],
       issuesFiled: [],
       issuesSkipped: [],
     });
@@ -86,6 +88,7 @@ describe('improvement-review-scheduler (#3229)', () => {
               window: '7d',
               totalOutcomes: 0,
               signals: [],
+              remediationTasks: [],
               issuesFiled: [],
               issuesSkipped: [],
             });
@@ -109,6 +112,7 @@ describe('improvement-review-scheduler (#3229)', () => {
       window: '7d',
       totalOutcomes: 0,
       signals: [],
+      remediationTasks: [],
       issuesFiled: [],
       issuesSkipped: [],
     });

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -38,6 +38,8 @@ import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import type { VoteRejectedSignalEvent } from '../../pipeline/event-types.js';
 import { REJECTION_CATEGORIES } from '../../consensus/types-core.js';
 import { emitFitnessDeclinedSignal } from './improvement-review-signals.js';
+import { improvementSignalsToTasks } from './improvement-remediation.js';
+import type { PipelineTask } from '../../pipeline/dev-pipeline.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 const execFileAsync = promisify(execFile);
@@ -116,6 +118,12 @@ export interface ImprovementReviewResponse {
   readonly window: string;
   readonly totalOutcomes: number;
   readonly signals: readonly ImprovementSignal[];
+  /**
+   * Remediation tasks derived from {@link signals} (#3540 capability-loop
+   * increment 1) — SUGGEST-ONLY: structured tasks for a reviewer to consider
+   * routing through the dev-pipeline. Nothing here is executed or auto-invoked.
+   */
+  readonly remediationTasks: readonly PipelineTask[];
   readonly issuesFiled: readonly { readonly signalKey: string; readonly issueUrl: string }[];
   readonly issuesSkipped: readonly { readonly signalKey: string; readonly reason: string }[];
 }
@@ -670,6 +678,9 @@ export async function runImprovementReview(
     window: windowLabel,
     totalOutcomes: windowed.length,
     signals,
+    // #3540 increment 1: surface remediation tasks derived from the signals
+    // (suggest-only — composes existing detection, no auto-invocation).
+    remediationTasks: improvementSignalsToTasks(signals),
     issuesFiled,
     issuesSkipped,
   };


### PR DESCRIPTION
Part of **#3540** (close the capability loop). Owner chose **"safe plumbing first"** — this is increment 1: the gap→task bridge, with **no auto-invocation** (the safety-critical gate stays a separate, owner-gated increment).

## What
A pure `improvementSignalsToTasks()` mapper turns the observability signals `improvement_review` **already detects** (fitness decline, CLI-floor, failure-category concentration, consensus rejection, self-eval findings) into structured remediation `PipelineTask`s, surfaced on the `improvement_review` response as a new `remediationTasks` field.

- **Composition, not new machinery** (capability-bias): reuses the existing detectors; the bridge is a pure signal→task mapping (category→seed role, stable `improvement-<signalKey>` ids, optional dedup).
- **SUGGEST-ONLY by construction:** executes nothing, files nothing, auto-invokes no pipeline. A reviewer decides whether to route a task through the dev-pipeline. Co-located with the signal computation (no added latency, and no auto-execution surface).

## Why on improvement_review (not suggest_research_tasks)
`improvement_review` already does the (slow) signal detection, so deriving tasks from its signals is free + co-located — vs. re-running detection inside the latency-sensitive `suggest_research_tasks` (which I just decoupled from a slow path in #3606).

## Scope boundary (explicit)
This does **not** implement: the auto-invoke gate, blast-radius limits, or Rule-of-Two enforcement. Those are the highest-stakes autonomy decisions and remain owner-gated future increments per the #3540 acceptance.

## Tests
New mapper suite (category→role, stable id, dedup, empty); updated downstream fixtures for the new response field; affected suites 43/43; tsc + lint + orphan-gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)