### PR TITLE
fix(governance): stop improvement_review firing a spurious 0/100 fitness signal (#3621)

### DIFF
--- a/.changeset/fitness-auditable-flag.md
+++ b/.changeset/fitness-auditable-flag.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): stop improvement_review firing a spurious 0/100 fitness signal (#3621)
+
+`fitness-audit` returns a deliberate "could not audit" sentinel (score 0, one
+info finding) when run outside the source tree — e.g. from the global npm
+install, where the bundled `src/` lacks `cli-adapters/`. The MCP server IS that
+global install, so `improvement_review` was misreading the sentinel's meaningless
+score-0 as a _critical tech-debt: fitness below floor_ signal on every run.
+
+Adds an explicit `auditable` flag to `FitnessAudit` (false for the sentinel,
+true for a real audit); `detectFitnessSignals` now skips a non-auditable result
+instead of emitting a below-floor signal. Found via the capability-loop
+verify-before-acting pass (#3540) — exactly the kind of detector artifact that
+would otherwise pollute the improvement-signal stream.

--- a/packages/nexus-agents/src/governance/fitness-score.ts
+++ b/packages/nexus-agents/src/governance/fitness-score.ts
@@ -131,6 +131,15 @@ export interface FitnessAudit {
   readonly timestamp: string;
   /** Version/commit reference */
   readonly version: string;
+  /**
+   * Whether the audit actually ran against the nexus-agents source tree (#3621).
+   * `false` is the "could not audit from here" sentinel (e.g. run from the global
+   * npm install, where the bundled `src/` lacks `cli-adapters/`): the score is a
+   * meaningless 0, NOT a real low-fitness result. Consumers (e.g.
+   * improvement_review) MUST NOT treat a `false` audit's score as a signal.
+   * Absent/`true` → a genuine audit.
+   */
+  readonly auditable?: boolean;
 }
 
 /**
@@ -258,6 +267,7 @@ export class FitnessScoreCalculator {
       findings,
       timestamp: new Date().toISOString(),
       version,
+      auditable: true,
     };
   }
 
@@ -294,6 +304,7 @@ export class FitnessScoreCalculator {
       findings: [finding],
       timestamp: new Date().toISOString(),
       version,
+      auditable: false,
     };
   }
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
@@ -217,6 +217,7 @@ describe('detectFitnessSignals', () => {
       findings: overrides.findings ?? [],
       timestamp: overrides.timestamp ?? new Date(NOW).toISOString(),
       version: overrides.version ?? 'test',
+      ...(overrides.auditable !== undefined ? { auditable: overrides.auditable } : {}),
     };
   }
 
@@ -237,6 +238,25 @@ describe('detectFitnessSignals', () => {
     const signals = detectFitnessSignals(audit, 90);
     const floorSig = signals.find((s) => s.signalKey === 'tech-debt:fitness-below-floor');
     expect(floorSig?.severity).toBe('critical');
+  });
+
+  // #3621: the not-source-repo sentinel (auditable:false, score 0) is "could not
+  // audit", not "fitness is low" — it must NOT emit a spurious below-floor signal.
+  it('does NOT fire for a non-auditable result even at score 0', () => {
+    const audit = makeAudit({
+      score: 0,
+      auditable: false,
+      findings: [
+        {
+          dimension: 'governanceIntegration',
+          severity: 'info',
+          description: 'not source repo',
+          pointsDeducted: 0,
+        },
+      ],
+    });
+    const signals = detectFitnessSignals(audit, 90);
+    expect(signals).toEqual([]);
   });
 
   it('fires per-finding for each critical finding', () => {

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -370,6 +370,10 @@ export function detectFitnessSignals(
   fitnessFloor: number
 ): readonly ImprovementSignal[] {
   const signals: ImprovementSignal[] = [];
+  // #3621: a non-auditable result (e.g. run from the global npm install) has a
+  // meaningless score of 0 — it is "could not audit", not "fitness is low". Do
+  // not emit a spurious below-floor tech-debt signal for it.
+  if (audit.auditable === false) return signals;
   if (audit.score < fitnessFloor) signals.push(buildFloorSignal(audit, fitnessFloor));
   for (const finding of audit.findings) {
     if (finding.severity === 'critical') signals.push(buildCriticalFindingSignal(finding));


### PR DESCRIPTION
Closes #3621. Owner chose "fix the detector first" — clean the improvement-signal stream before acting on signals.

## Root cause (not a scorer bug)
`fitness-audit` has a deliberate **not-source-repo sentinel** (`notSourceRepoResult`): when run where the bundled `src/` lacks `cli-adapters/` — i.e. the **global npm install** — it correctly bails with score 0 + one *info* finding ("must run against the source repo", `pointsDeducted: 0`). That's exactly the observed `0/100, governanceIntegration -0`.

The MCP server **is** the global install, so `improvement_review.detectFitnessSignals` was reading the sentinel's meaningless score-0 as a **critical `tech-debt:fitness-below-floor`** signal on every run — pure noise that would mislead the capability loop.

## Fix
- Add an explicit `auditable` flag to `FitnessAudit` — `false` for the sentinel, `true` for a real audit (optional field; absent treated as auditable, so no downstream breakage).
- `detectFitnessSignals` returns early (no signal) when `auditable === false`.

## Tests
Regression: a non-auditable result at score 0 emits no signal; genuine low scores still fire. `improvement-review` + `fitness-score` suites 45/45; tsc + lint clean.

## Provenance
Surfaced + verified by the capability-loop pass (#3540 / #3620). This is the detector-correctness half of the two artifacts that pass surfaced — fixing it stops the spurious signal from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)