### PR TITLE
fix(governance): measure model quality not infra in the CLI performance-floor (#3620)

### DIFF
--- a/.changeset/cli-floor-exclude-infra.md
+++ b/.changeset/cli-floor-exclude-infra.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): CLI performance-floor signal measures model quality, not infra (#3620)
+
+`detectCliPerformanceFloor` divided successes by ALL outcomes, so infrastructure
+failures (adapter_unavailable, parse/empty-response, auth, rate-limit, timeout,
+connection) were counted as model-quality failures — producing a misleading
+"claude security_review 4%" critical routing signal when the genuine quality rate
+was 67% (above the floor). It now excludes infra/transport failure categories
+from the quality rate; those still surface separately via
+detectFailureCategoryConcentration (so real adapter outages aren't hidden, just
+not mislabeled as a CLI quality regression). Found via capability-loop
+dogfooding (#3540); the residual empty-response root cause is tracked in #3625
+(+ attribution gap #3624).

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
@@ -138,6 +138,70 @@ describe('detectCliPerformanceFloor', () => {
     expect(criticalSignals[0]?.severity).toBe('critical');
   });
 
+  it('excludes infra/transport failures from the quality rate (#3620)', () => {
+    // 3 successes + 7 infra failures (adapter_unavailable/parse). Raw rate = 30%
+    // (would fire critical), but quality rate = 3/3 = 100% → no signal.
+    const outcomes: TaskOutcome[] = [];
+    for (let i = 0; i < 3; i++) {
+      outcomes.push(outcome({ cli: 'claude', category: 'security_review', success: true }));
+    }
+    for (let i = 0; i < 4; i++) {
+      outcomes.push(
+        outcome({
+          cli: 'claude',
+          category: 'security_review',
+          success: false,
+          failureCategory: 'adapter_unavailable',
+        })
+      );
+    }
+    for (let i = 0; i < 3; i++) {
+      outcomes.push(
+        outcome({
+          cli: 'claude',
+          category: 'security_review',
+          success: false,
+          failureCategory: 'parse',
+        })
+      );
+    }
+    expect(detectCliPerformanceFloor(outcomes, 5, '30d')).toHaveLength(0);
+  });
+
+  it('still fires on genuine model-quality failures, excluding only infra (#3620)', () => {
+    // 2 successes + 6 execution (quality) failures + 4 adapter_unavailable (infra).
+    // Quality rate = 2/8 = 25% (< 40% → critical); infra excluded but noted.
+    const outcomes: TaskOutcome[] = [];
+    for (let i = 0; i < 2; i++) {
+      outcomes.push(outcome({ cli: 'codex', category: 'code_review', success: true }));
+    }
+    for (let i = 0; i < 6; i++) {
+      outcomes.push(
+        outcome({
+          cli: 'codex',
+          category: 'code_review',
+          success: false,
+          failureCategory: 'execution',
+        })
+      );
+    }
+    for (let i = 0; i < 4; i++) {
+      outcomes.push(
+        outcome({
+          cli: 'codex',
+          category: 'code_review',
+          success: false,
+          failureCategory: 'rate_limit',
+        })
+      );
+    }
+    const signals = detectCliPerformanceFloor(outcomes, 5, '30d');
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.severity).toBe('critical');
+    expect(signals[0]?.evidence.observedValue).toBeCloseTo(0.25, 5);
+    expect(signals[0]?.body).toContain('4 infra/transport failures excluded');
+  });
+
   it('separates by CLI × category buckets', () => {
     const outcomes: TaskOutcome[] = [];
     // claude on architecture: 0% success, 5 samples

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -152,53 +152,98 @@ export function filterByLookback(
 }
 
 /**
- * Detect CLI × category pairs whose success rate has fallen below the
- * performance floor with at least minSamples observations.
- *
- * Threshold: success rate < 60% AND samples >= minSamples.
+ * Infrastructure/transport failure categories — NOT model reasoning quality
+ * (#3620). These are excluded from the CLI performance-floor so the routing
+ * signal measures whether the MODEL does the task, not whether the adapter was
+ * reachable. Adapter outages / empty responses still surface separately via
+ * {@link detectFailureCategoryConcentration}, so excluding them here doesn't hide
+ * them — it just stops them being mislabeled as a CLI quality regression.
  */
+const INFRA_FAILURE_CATEGORIES: ReadonlySet<string> = new Set([
+  'timeout',
+  'authentication',
+  'rate_limit',
+  'connection',
+  'adapter_unavailable',
+  'parse',
+]);
+
+/**
+ * Detect CLI × category pairs whose MODEL-QUALITY success rate has fallen below
+ * the performance floor with at least minSamples observations.
+ *
+ * Threshold: quality success rate < 60% AND quality-samples >= minSamples.
+ * Infra/transport failures (adapter_unavailable, parse/empty-response, auth,
+ * rate-limit, timeout, connection) are excluded from the rate (#3620) — they are
+ * availability problems, not model quality, and surface via the failure-category
+ * concentration detector instead.
+ */
+interface QualityBucket {
+  cli: string;
+  category: string;
+  ok: number;
+  total: number;
+  infra: number;
+}
+
+/** Bucket outcomes by cli×category, separating infra failures from quality ones. */
+function accumulateQualityBuckets(outcomes: readonly TaskOutcome[]): Map<string, QualityBucket> {
+  const buckets = new Map<string, QualityBucket>();
+  for (const o of outcomes) {
+    const key = `${o.cli}::${o.category}`;
+    const b = buckets.get(key) ?? { cli: o.cli, category: o.category, ok: 0, total: 0, infra: 0 };
+    if (!o.success && INFRA_FAILURE_CATEGORIES.has(o.failureCategory ?? '')) {
+      b.infra += 1; // infra/transport failure — excluded from the quality rate
+    } else {
+      b.total += 1;
+      if (o.success) b.ok += 1;
+    }
+    buckets.set(key, b);
+  }
+  return buckets;
+}
+
+/** Build a performance-floor signal for a below-floor quality bucket. */
+function floorSignalFromBucket(
+  b: QualityBucket,
+  minSamples: number,
+  windowLabel: string
+): ImprovementSignal {
+  const rate = b.ok / b.total;
+  const ratePct = Math.round(rate * 100);
+  const infraNote =
+    b.infra > 0
+      ? ` (${String(b.infra)} infra/transport failures excluded — see failure-concentration signals)`
+      : '';
+  return {
+    category: 'routing',
+    signalKey: `routing:cli-floor:${b.cli}:${b.category}`,
+    severity: rate < 0.4 ? 'critical' : 'warning',
+    title: `routing: ${b.cli} model-quality success ${String(ratePct)}% on ${b.category} (${windowLabel})`,
+    body: [
+      `Observed model-quality performance floor breach in the ${windowLabel} window.`,
+      '',
+      `- CLI: \`${b.cli}\``,
+      `- Category: \`${b.category}\``,
+      `- Quality success rate: ${String(ratePct)}% (${String(b.ok)}/${String(b.total)})${infraNote}`,
+      `- Threshold: 60% with ≥${String(minSamples)} quality samples`,
+      '',
+      'Quality failures only (infra/transport excluded). Consider routing this category away from this CLI, or investigating the failure pattern via `weather_report` and the OutcomeStore.',
+    ].join('\n'),
+    evidence: { samples: b.total, window: windowLabel, observedValue: rate, threshold: 0.6 },
+  };
+}
+
 export function detectCliPerformanceFloor(
   outcomes: readonly TaskOutcome[],
   minSamples: number,
   windowLabel: string
 ): readonly ImprovementSignal[] {
-  const buckets = new Map<string, { cli: string; category: string; ok: number; total: number }>();
-  for (const o of outcomes) {
-    const key = `${o.cli}::${o.category}`;
-    const bucket = buckets.get(key) ?? { cli: o.cli, category: o.category, ok: 0, total: 0 };
-    bucket.total += 1;
-    if (o.success) bucket.ok += 1;
-    buckets.set(key, bucket);
-  }
-
   const signals: ImprovementSignal[] = [];
-  for (const b of buckets.values()) {
+  for (const b of accumulateQualityBuckets(outcomes).values()) {
     if (b.total < minSamples) continue;
-    const rate = b.ok / b.total;
-    if (rate >= 0.6) continue;
-    const ratePct = Math.round(rate * 100);
-    signals.push({
-      category: 'routing',
-      signalKey: `routing:cli-floor:${b.cli}:${b.category}`,
-      severity: rate < 0.4 ? 'critical' : 'warning',
-      title: `routing: ${b.cli} success rate ${String(ratePct)}% on ${b.category} (${windowLabel})`,
-      body: [
-        `Observed performance floor breach in the ${windowLabel} window.`,
-        '',
-        `- CLI: \`${b.cli}\``,
-        `- Category: \`${b.category}\``,
-        `- Success rate: ${String(ratePct)}% (${String(b.ok)}/${String(b.total)})`,
-        `- Threshold: 60% with ≥${String(minSamples)} samples`,
-        '',
-        'Consider routing this category away from this CLI, or investigating the failure pattern via `weather_report` and the OutcomeStore.',
-      ].join('\n'),
-      evidence: {
-        samples: b.total,
-        window: windowLabel,
-        observedValue: rate,
-        threshold: 0.6,
-      },
-    });
+    if (b.ok / b.total >= 0.6) continue;
+    signals.push(floorSignalFromBucket(b, minSamples, windowLabel));
   }
   return signals;
 }


### PR DESCRIPTION
Closes #3620. Found + diagnosed via capability-loop dogfooding (the loop surfaced this, the pipeline's research step diagnosed it).

## The problem
The surfaced "claude `security_review` 4% — critical routing degradation" was **largely a detector artifact**. `detectCliPerformanceFloor` computed `success / total` over **all** outcomes, so infrastructure failures counted as model-quality failures:
- 70 `adapter_unavailable` + 120 `parse`/"Model returned empty response" (both infra/transport, not claude's reasoning) dominated the failures.
- Excluding infra, claude's genuine quality rate is **67% (178/267) — above the 60% floor**. The signal would not fire.

## The fix
`detectCliPerformanceFloor` now excludes infra/transport failure categories (`adapter_unavailable`, `parse`, `authentication`, `rate_limit`, `timeout`, `connection`) from the quality rate — measuring whether the **model** did the task, not whether the **adapter** was reachable. Infra problems are NOT hidden: failure-category concentration (incl. these) still surfaces via the existing `detectFailureCategoryConcentration`, so real adapter outages stay visible — just not mislabeled as a CLI quality regression. The signal title/body now say "model-quality" and note the excluded infra count.

## Tests
Regression: infra-only failures don't fire the floor (quality 100%); genuine `execution` failures still fire (excluding infra, with the count noted). Suite 27/27; tsc + lint clean.

## Follow-ups (the residual real issue)
- #3624 — expert-delegation outcomes record placeholder `model:'expert'`/`vendor:'unknown'` (attribution gap blocking root-cause).
- #3625 — reproduce + pin the empty-response cause in expert `security_review` execution.

This is the same detector-precision theme as #3621 (the fitness artifact) — making the capability loop's signals trustworthy so it surfaces real problems, not infra noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)