### PR TITLE
fix(governance): stop fabricated expert outcomes polluting routing signals (#3624)

### DIFF
--- a/.changeset/expert-outcome-denoise.md
+++ b/.changeset/expert-outcome-denoise.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): stop fabricated expert outcomes polluting routing signals (#3624)
+
+Two de-noising fixes so the OutcomeStore (which feeds routing/learning + the
+improvement signals) isn't skewed by fabricated attribution:
+
+- **Drop expert-CREATION outcomes** — create_expert recorded creation success/
+  failure as a model-execution outcome (`cli: DEFAULT_CLI='claude', model:'expert'`)
+  even though creating an expert runs no model, polluting per-cli×category quality
+  stats. Creation telemetry stays in session memory only.
+- **Exclude unattributed outcomes from the CLI performance-floor** — outcomes
+  whose cli/model is a placeholder (`unknown`/`expert`/`heuristic`/`default`)
+  can't attribute a real executing CLI, so they no longer drive the routing
+  quality signal (preventing the skew from landing on a real CLI).
+
+consensus_vote (higher_order, 7/7) ratified the approach incl. DROP-over-TAG.
+Positive registry-derived attribution (deriving cli/vendor/family from the
+executed model) remains tracked in #3624.

--- a/packages/nexus-agents/src/mcp/tools/create-expert-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/create-expert-recording.ts
@@ -8,20 +8,8 @@
  * (Source: Issue #1174 — Add observability to dark MCP tools)
  */
 
-import {
-  createLogger,
-  getErrorMessage,
-  getTimeProvider,
-  getRandomProvider,
-} from '../../core/index.js';
+import { createLogger, getErrorMessage } from '../../core/index.js';
 import { getToolMemory } from './tool-memory.js';
-import {
-  getOutcomeStore,
-  categorizeOutcomeErrorMessage,
-} from '../../orchestration/outcomes/index.js';
-import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
-import type { TaskCategory } from '../../config/task-specialization-types.js';
-import { ROLE_TO_TASK_CATEGORY } from './create-expert-routing.js';
 
 const logger = createLogger({ tool: 'create-expert' });
 
@@ -59,38 +47,9 @@ export function recordExpertError(role: string, errorMessage: string): void {
   }
 }
 
-/** Resolves expert role to task category for accurate outcome attribution. */
-function resolveCategory(role: string): TaskCategory {
-  return ROLE_TO_TASK_CATEGORY[role] ?? 'code_generation';
-}
-
-/** Records expert creation outcome for adaptive routing. */
-export function recordExpertOutcome(
-  role: string,
-  success: boolean,
-  durationMs: number,
-  error?: string
-): void {
-  try {
-    const store = getOutcomeStore();
-    const errorMsg = error ?? 'expert creation failed';
-    store.append({
-      id: `expert-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
-      cli: DEFAULT_CLI,
-      category: resolveCategory(role),
-      model: 'expert',
-      success,
-      durationMs,
-      timestamp: new Date().toISOString(),
-      source: 'manual',
-      ...(!success
-        ? {
-            failureCategory: categorizeOutcomeErrorMessage(errorMsg),
-            errorMessage: errorMsg.slice(0, 500),
-          }
-        : {}),
-    });
-  } catch (error: unknown) {
-    logger.debug('Best-effort expert outcome recording failed', { error: getErrorMessage(error) });
-  }
-}
+// #3624: expert CREATION is not a model execution, so it is NO LONGER recorded
+// to the OutcomeStore (it polluted per-cli×category model-quality stats with
+// fabricated cli=DEFAULT_CLI/model='expert' rows — consensus_vote DROP, 7/7).
+// Creation telemetry still lives in session memory via recordExpertCreated /
+// recordExpertError above; if creation reliability needs metrics, use a
+// dedicated counter, not the model-execution OutcomeStore.

--- a/packages/nexus-agents/src/mcp/tools/create-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/create-expert.ts
@@ -35,11 +35,7 @@ import {
   resolveAdapterForModelPreference,
   resolveAdapterForRole,
 } from './create-expert-routing.js';
-import {
-  recordExpertCreated,
-  recordExpertError,
-  recordExpertOutcome,
-} from './create-expert-recording.js';
+import { recordExpertCreated, recordExpertError } from './create-expert-recording.js';
 
 /**
  * Input schema for create_expert tool.
@@ -265,13 +261,11 @@ function createCreateExpertHandler(deps: CreateExpertDeps) {
     }
 
     // Execute tool logic (now async for CLI detection - Issue #747)
-    const startMs = Date.now();
     const result = await handleCreateExpert(deps, validationResult.data);
-    const durationMs = Date.now() - startMs;
 
     if (!result.ok) {
       recordExpertError(validationResult.data.role, result.error);
-      recordExpertOutcome(validationResult.data.role, false, durationMs, result.error);
+      // #3624: creation is not a model execution — no OutcomeStore row.
       return toolStructuredError({
         errorCategory: 'internal',
         message: `Failed to create expert: ${result.error}`,
@@ -279,7 +273,6 @@ function createCreateExpertHandler(deps: CreateExpertDeps) {
     }
 
     recordExpertCreated(result.value.role, result.value.expertId);
-    recordExpertOutcome(result.value.role, true, durationMs);
 
     ctx.logger.info('Expert created', {
       expertId: result.value.expertId,

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.test.ts
@@ -138,6 +138,18 @@ describe('detectCliPerformanceFloor', () => {
     expect(criticalSignals[0]?.severity).toBe('critical');
   });
 
+  it('excludes unattributed-model outcomes from the floor (#3624)', () => {
+    // 8 outcomes all failing, but model='expert' (placeholder — can't attribute a
+    // real executing CLI). The floor must not fire on fabricated attribution.
+    const outcomes: TaskOutcome[] = [];
+    for (let i = 0; i < 8; i++) {
+      outcomes.push(
+        outcome({ cli: 'claude', category: 'security_review', success: false, model: 'expert' })
+      );
+    }
+    expect(detectCliPerformanceFloor(outcomes, 5, '30d')).toHaveLength(0);
+  });
+
   it('excludes infra/transport failures from the quality rate (#3620)', () => {
     // 3 successes + 7 infra failures (adapter_unavailable/parse). Raw rate = 30%
     // (would fire critical), but quality rate = 3/3 = 100% → no signal.

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -186,10 +186,25 @@ interface QualityBucket {
   infra: number;
 }
 
+/**
+ * Models/clis that don't identify a real executor (#3624) — outcomes with these
+ * can't be attributed to a CLI's quality, so they're excluded from the floor
+ * (else the skew just moves from a real CLI onto an `unknown`/placeholder one).
+ */
+const UNATTRIBUTED_VALUES: ReadonlySet<string> = new Set([
+  '',
+  'unknown',
+  'expert',
+  'heuristic',
+  'default',
+]);
+
 /** Bucket outcomes by cli×category, separating infra failures from quality ones. */
 function accumulateQualityBuckets(outcomes: readonly TaskOutcome[]): Map<string, QualityBucket> {
   const buckets = new Map<string, QualityBucket>();
   for (const o of outcomes) {
+    // Skip outcomes that can't attribute a real executing CLI (#3624).
+    if (UNATTRIBUTED_VALUES.has(o.cli) || UNATTRIBUTED_VALUES.has(o.model)) continue;
     const key = `${o.cli}::${o.category}`;
     const b = buckets.get(key) ?? { cli: o.cli, category: o.category, ok: 0, total: 0, infra: 0 };
     if (!o.success && INFRA_FAILURE_CATEGORIES.has(o.failureCategory ?? '')) {

--- a/packages/nexus-agents/src/mcp/tools/recording-modules.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/recording-modules.test.ts
@@ -252,55 +252,16 @@ describe('create-expert-recording', () => {
     );
   });
 
-  it('recordExpertOutcome records to OutcomeStore', async () => {
-    const { recordExpertOutcome } = await import('./create-expert-recording.js');
-    const store = getOutcomeStore();
-    const initialSize = store.size;
-
-    recordExpertOutcome('testing_expert', true, 500);
-    expect(store.size).toBe(initialSize + 1);
-
-    const entries = store.query();
-    const last = entries[entries.length - 1];
-    expect(last?.success).toBe(true);
-    expect(last?.durationMs).toBe(500);
-    expect(last?.category).toBe('testing');
-  });
-
-  it('recordExpertOutcome maps role to correct category (#1402)', async () => {
-    const { recordExpertOutcome } = await import('./create-expert-recording.js');
-    const store = getOutcomeStore();
-
-    recordExpertOutcome('security_expert', true, 100);
-    const entries = store.query();
-    const last = entries[entries.length - 1];
-    expect(last?.category).toBe('security_review');
-  });
-
-  it('recordExpertOutcome records failures', async () => {
-    const { recordExpertOutcome } = await import('./create-expert-recording.js');
-    const store = getOutcomeStore();
-    const initialSize = store.size;
-
-    recordExpertOutcome('arch_expert', false, 0);
-    expect(store.size).toBe(initialSize + 1);
-
-    const entries = store.query();
-    const last = entries[entries.length - 1];
-    expect(last?.success).toBe(false);
-  });
-
-  it('recordExpertOutcome captures errorMessage on failure (#1516)', async () => {
-    const { recordExpertOutcome } = await import('./create-expert-recording.js');
-    const store = getOutcomeStore();
-
-    recordExpertOutcome('security_expert', false, 100, 'Model adapter unavailable');
-
-    const entries = store.query();
-    const last = entries[entries.length - 1];
-    expect(last?.success).toBe(false);
-    expect(last?.errorMessage).toBe('Model adapter unavailable');
-    expect(last?.failureCategory).toBeDefined();
+  // #3624: expert CREATION is no longer recorded to the OutcomeStore (it isn't a
+  // model execution; the fabricated cli/model rows polluted per-cli×category
+  // quality stats — consensus_vote DROP). The create-expert recordExpertOutcome
+  // function was removed; creation telemetry stays in session memory only.
+  it('create-expert-recording no longer exports recordExpertOutcome (#3624 DROP)', async () => {
+    const mod = await import('./create-expert-recording.js');
+    expect((mod as Record<string, unknown>).recordExpertOutcome).toBeUndefined();
+    // The session-memory recorders remain.
+    expect(typeof mod.recordExpertCreated).toBe('function');
+    expect(typeof mod.recordExpertError).toBe('function');
   });
 });
 


### PR DESCRIPTION
Part of #3624. consensus_vote (higher_order) **7/7** ratified the approach (DROP-over-TAG). This PR ships the **de-noising** half (type-clean); positive registry attribution is the tracked remainder.

## Problem (capability-loop dogfooding root cause)
The OutcomeStore — which feeds routing/learning + the improvement signals — was skewed by **fabricated attribution**:
- `create_expert` recorded **creation** success/failure as a model-execution outcome with `cli: DEFAULT_CLI ('claude'), model: 'expert'` — but creating an expert runs no model. This polluted per-cli×category quality stats (the `manual` rows behind the misleading #3620 "claude security_review" signal).
- Expert executions record `model: 'expert'` placeholders + a content-heuristic `cli`, so unattributed rows pile onto a real CLI.

## This PR (ratified de-noising)
- **DROP creation outcomes** — `create_expert` no longer writes to the OutcomeStore (session-memory telemetry via `recordExpertCreated`/`recordExpertError` is unchanged). Audited: no consumer keys on `model==='expert'`.
- **Exclude unattributed outcomes from `detectCliPerformanceFloor`** — outcomes whose `cli`/`model` is a placeholder (`unknown`/`expert`/`heuristic`/`default`) can't attribute a real executing CLI, so they no longer drive the routing quality signal (prevents the skew relocating onto a placeholder/real CLI — the panel's load-bearing condition 1).

## Deferred to #3624's remainder (positive attribution)
Deriving real `cli`/`vendor`/`family` from the executed model's registry entry + threading the executed model needs `TaskOutcome.cli` widened to allow an explicit `'unknown'` (today it's a strict `CliName` union) — a typed change worth its own focused PR. Until then, unattributed outcomes are *excluded* (this PR) rather than *correctly attributed*.

## Historical note (panel condition 2)
Pre-existing polluted rows remain in the store but age out of the trailing windows the detectors use; no live-data purge (it's the user's OutcomeStore).

## Tests
create-expert no longer exports the OutcomeStore recorder; floor excludes unattributed (model='expert') outcomes; #3620 infra-exclusion intact. Suites 82/82; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)