### PR TITLE
fix(governance): attribute expert outcomes to the real executing CLI (#3624)

### DIFF
--- a/.changeset/expert-positive-attribution.md
+++ b/.changeset/expert-positive-attribution.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): attribute expert outcomes to the real executing CLI (#3624)
+
+Completes the #3624 attribution fix (the de-noising half shipped in #3628). Expert
+execution outcomes now derive their `cli` from the model the adapter ACTUALLY
+executed (via the model registry), instead of guessing it from task content:
+
+- `TaskOutcome.cli` widened to `CliName | 'unknown'` (new `OutcomeCliSchema`) so
+  unresolvable outcomes carry an explicit `'unknown'` rather than a fabricated
+  real CLI. Minimal blast radius (2 schema lines).
+- `recordExpertOutcome` resolves cli from the executed model; vendor/family are
+  auto-resolved from `model` by `OutcomeStore.enrich` (#2548). Placeholder/
+  unresolvable models record `cli='unknown'/model='unknown'`.
+- `execute_expert` threads the executed model (`result.metadata.model`) through
+  to the recorder, so success outcomes are attributed to ground truth.
+
+Together with #3628, expert outcomes are now correctly attributed instead of
+piling onto `DEFAULT_CLI='claude'` — removing the root cause of the misleading
+"claude security_review" routing signal (#3620).

--- a/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert-recording.ts
@@ -21,7 +21,9 @@ import {
 } from '../../orchestration/outcomes/index.js';
 import { detectTaskCategory } from '../../config/task-specialization.js';
 import type { TaskCategory } from '../../config/task-specialization-types.js';
-import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
+import { CliNameSchema } from '../../config/model-capabilities-types.js';
+import { getDefaultRegistry } from '../../config/model-registry.js';
+import type { OutcomeCli } from '../../orchestration/outcomes/outcome-types.js';
 import { getToolMemory } from './tool-memory.js';
 import { getAutoCatalog } from './research-auto-catalog.js';
 import type { ILogger } from '../../core/index.js';
@@ -62,15 +64,44 @@ function resolveExpertCategory(opts: ExpertOutcomeOpts): TaskCategory {
   return detectTaskCategory(opts.task)?.category ?? 'exploration';
 }
 
-/** Records expert execution outcome to OutcomeStore. Best-effort. */
+/** Models that are placeholders, not real resolvable model ids (#3624). */
+const UNATTRIBUTED_MODELS: ReadonlySet<string> = new Set([
+  '',
+  'expert',
+  'unknown',
+  'heuristic',
+  'default',
+]);
+
+/**
+ * Resolve the real executing CLI from the EXECUTED model via the registry
+ * (#3624), instead of guessing it from task content. Returns the explicit
+ * 'unknown' sentinel when the model is a placeholder or maps to no known CLI —
+ * never a fabricated real CLI (which would skew that CLI's quality stats).
+ */
+function resolveExpertCli(model: string | undefined): OutcomeCli {
+  if (model === undefined || UNATTRIBUTED_MODELS.has(model)) return 'unknown';
+  const cliName = getDefaultRegistry().getEntry(model).cliName;
+  const parsed = cliName !== undefined ? CliNameSchema.safeParse(cliName) : undefined;
+  return parsed?.success === true ? parsed.data : 'unknown';
+}
+
+/**
+ * Records expert execution outcome to OutcomeStore. Best-effort.
+ * Attribution (#3624): cli is resolved from the EXECUTED model via the registry
+ * (vendor/family are auto-resolved from `model` by OutcomeStore.enrich); an
+ * unresolvable model records cli='unknown'/model='unknown' rather than a
+ * fabricated CLI, so it can't skew a real CLI's performance-floor signal.
+ */
 export function recordExpertOutcome(opts: ExpertOutcomeOpts): void {
   try {
-    const match = detectTaskCategory(opts.task);
+    const model =
+      opts.model !== undefined && !UNATTRIBUTED_MODELS.has(opts.model) ? opts.model : 'unknown';
     getOutcomeStore().append({
       id: `exp-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
-      cli: match?.primaryCli ?? DEFAULT_CLI,
+      cli: resolveExpertCli(opts.model),
       category: resolveExpertCategory(opts),
-      model: opts.model ?? 'expert',
+      model,
       success: opts.success,
       durationMs: opts.durationMs,
       timestamp: new Date(getTimeProvider().now()).toISOString(),

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -483,10 +483,24 @@ interface ClassifyExpertResultOpts {
   logger: ILogger | undefined;
 }
 
+/**
+ * The model id to attribute the outcome to (#3624): prefer the model the
+ * adapter ACTUALLY executed (ground truth from result metadata) over the
+ * configured preference. On failure there's no executed model — fall back to
+ * the configured preference (and ultimately 'unknown' at the recorder).
+ */
+function resolveExecutedModelId(
+  result: ClassifyExpertResultOpts['result'],
+  expert: Expert
+): string | undefined {
+  const executed = result.ok ? result.value.metadata.model : undefined;
+  return executed ?? expert.expertConfig.modelPreference?.modelId;
+}
+
 /** Classifies expert execution result, with rate-limit fallback (#1532). */
 async function classifyExpertResult(opts: ClassifyExpertResultOpts): Promise<ExpertResult> {
   const { result, expert, task, args, durationMs, logger } = opts;
-  const modelId = expert.expertConfig.modelPreference?.modelId;
+  const modelId = resolveExecutedModelId(result, expert);
   const info = {
     expertId: args.expertId,
     role: expert.role,

--- a/packages/nexus-agents/src/mcp/tools/recording-modules.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/recording-modules.test.ts
@@ -310,6 +310,42 @@ describe('execute-expert-recording', () => {
     expect(last?.failureCategory).toBe('timeout');
   });
 
+  it('attributes cli/vendor from the executed model via the registry (#3624)', async () => {
+    const { recordExpertOutcome } = await import('./execute-expert-recording.js');
+    const { getDefaultModelForCli } = await import('../../config/model-config-helpers.js');
+    const store = getOutcomeStore();
+    const model = getDefaultModelForCli('claude');
+
+    recordExpertOutcome({ task: 'Review code', success: true, durationMs: 100, model });
+
+    const last = store.query().at(-1);
+    expect(last?.cli).toBe('claude'); // resolved from model, not a content heuristic
+    expect(last?.model).toBe(model);
+    expect(last?.vendor).toBeDefined(); // auto-enriched from model by OutcomeStore
+  });
+
+  it('records unknown cli/model when the model is absent/unresolvable (#3624)', async () => {
+    const { recordExpertOutcome } = await import('./execute-expert-recording.js');
+    const store = getOutcomeStore();
+
+    recordExpertOutcome({ task: 'x', success: false, durationMs: 1, failureCategory: 'parse' });
+
+    const last = store.query().at(-1);
+    expect(last?.cli).toBe('unknown'); // not fabricated onto a real CLI
+    expect(last?.model).toBe('unknown');
+  });
+
+  it('treats the legacy "expert" placeholder model as unknown (#3624)', async () => {
+    const { recordExpertOutcome } = await import('./execute-expert-recording.js');
+    const store = getOutcomeStore();
+
+    recordExpertOutcome({ task: 'x', success: true, durationMs: 50, model: 'expert' });
+
+    const last = store.query().at(-1);
+    expect(last?.cli).toBe('unknown');
+    expect(last?.model).toBe('unknown');
+  });
+
   it('recordExpertSuccess records task and learning', async () => {
     const { recordExpertSuccess } = await import('./execute-expert-recording.js');
     recordExpertSuccess('exp-456', 'code_expert', 3000);

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
@@ -39,10 +39,20 @@ export const OutcomeFailureCategorySchema = z.enum([
   'unknown',
 ]);
 
+/**
+ * CLI attribution for an outcome. Widened beyond {@link CliNameSchema} to allow
+ * an explicit `'unknown'` (#3624) — for outcomes (e.g. expert executions) whose
+ * real executing CLI can't be resolved from the model. `'unknown'` is excluded
+ * from CLI-quality signals (detectCliPerformanceFloor) so it can't skew a real
+ * CLI, but is retained for category/failure analysis rather than fabricated.
+ */
+export const OutcomeCliSchema = z.union([CliNameSchema, z.literal('unknown')]);
+export type OutcomeCli = z.infer<typeof OutcomeCliSchema>;
+
 /** Schema for a single recorded task outcome. */
 export const TaskOutcomeSchema = z.object({
   id: z.string().min(1),
-  cli: CliNameSchema,
+  cli: OutcomeCliSchema,
   category: TaskCategorySchema,
   model: z.string().min(1),
   success: z.boolean(),
@@ -90,7 +100,7 @@ export const TaskOutcomeSchema = z.object({
 
 /** Schema for filtering outcomes. */
 export const OutcomeQuerySchema = z.object({
-  cli: CliNameSchema.optional(),
+  cli: OutcomeCliSchema.optional(),
   category: TaskCategorySchema.optional(),
   source: OutcomeSourceSchema.optional(),
   success: z.boolean().optional(),


### PR DESCRIPTION
Closes #3624. Completes the positive-attribution half of the fix (the de-noising half shipped in #3628); consensus_vote 7/7 ratified the overall approach.

## What this adds
Expert execution outcomes now carry **real attribution** derived from the model the adapter actually executed, instead of a content-heuristic `cli` + `model:'expert'` placeholder:
- **`TaskOutcome.cli` widened to `CliName | 'unknown'`** (`OutcomeCliSchema`). Unresolvable outcomes carry an explicit `'unknown'` rather than a fabricated real CLI. Blast radius was 2 schema lines (the cli field + the query filter); everything else treats cli as a string key.
- **`recordExpertOutcome`** resolves `cli` from the executed model via `getDefaultRegistry().getEntry(model).cliName` (validated against `CliNameSchema`); `vendor`/`family` are auto-resolved from `model` by the store's existing `enrich` (#2548). Placeholder/unresolvable → `cli='unknown'/model='unknown'`.
- **`execute_expert`** threads the executed model (`result.metadata.model`, ground truth) through `classifyExpertResult → handleExpertSuccess/Failure → recordExpertOutcome`, preferring it over the configured preference.

## Why it matters
With #3628 (drop creation outcomes + exclude unattributed from the floor) **and** this PR (attribute the rest correctly), expert outcomes stop piling onto `DEFAULT_CLI='claude'` — removing the root cause of the misleading "claude security_review 4%" signal (#3620). `'unknown'` outcomes are excluded from the CLI quality-floor (#3628) but retained for category/failure analysis.

## Tests
Registry-derived cli + auto-enriched vendor; `'unknown'` for absent/unresolvable model; legacy `'expert'` placeholder → `'unknown'`. Outcomes + recording suites 218/218; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)