### PR TITLE
feat(capability-loop): fail-closed security classification for auto-remediation (#3615)

### DIFF
--- a/.changeset/fail-closed-security-classifier.md
+++ b/.changeset/fail-closed-security-classifier.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+safety(capability-loop): fail-closed security classification for auto-remediation (#3615)
+
+Condition 4 of the #3540 auto-invoke gate. The hard exclusion "security signals
+are always human-gated" only holds if classification is correct — a security
+issue mislabeled by a detector (e.g. as `bug` or `routing`) would silently bypass
+the gate. `evaluateRemediationShadow` now treats a signal as security if EITHER
+its declared category is `security` OR any keyword from the canonical
+`SECURITY_KEYWORDS` appears in its key/title/body (uncertain → security →
+human-gated). Exposed as `isSecuritySignal` for the future enforce path (#3618)
+to reuse, so shadow and enforce decide identically.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.test.ts
@@ -10,6 +10,7 @@ import {
   createRemediationShadowSink,
   summarizeRemediationShadow,
   getRemediationShadowSink,
+  isSecuritySignal,
   type RemediationShadowRecord,
 } from './improvement-remediation-shadow.js';
 import type { ImprovementSignal, SignalCategory } from './improvement-review.js';
@@ -38,6 +39,60 @@ describe('evaluateRemediationShadow', () => {
     const rec = evaluateRemediationShadow(signal({ category: 'security', signalKey: 'sec-1' }));
     expect(rec.wouldAutoRemediate).toBe(false);
     expect(rec.reason).toMatch(/security-category — always human-gated/);
+  });
+
+  // #3615: fail-closed — a security issue mislabeled by a detector (category !==
+  // 'security') must STILL be human-gated if its text reveals it's security.
+  it('fail-closes a mis-categorized security signal (keyword match → human-gate)', () => {
+    const rec = evaluateRemediationShadow(
+      signal({
+        category: 'bug', // detector got the category wrong
+        signalKey: 'bug:failure-concentration:auth',
+        title: 'bug: 70% of failures share category `authentication`',
+        body: 'A possible credentials/injection vulnerability surfaced.',
+      })
+    );
+    expect(rec.wouldAutoRemediate).toBe(false);
+    expect(rec.reason).toMatch(/security-related \(keyword match/);
+  });
+
+  it('does NOT gate a genuinely non-security signal', () => {
+    const rec = evaluateRemediationShadow(
+      signal({
+        category: 'routing',
+        signalKey: 'routing:cli-floor:codex:documentation',
+        title: 'routing: codex model-quality success 30% on documentation',
+        body: 'Observed model-quality performance floor breach.',
+      })
+    );
+    expect(rec.wouldAutoRemediate).toBe(true);
+  });
+});
+
+describe('isSecuritySignal (fail-closed classifier #3615)', () => {
+  it('true for declared security category', () => {
+    expect(isSecuritySignal(signal({ category: 'security' }))).toBe(true);
+  });
+
+  it('true when a security keyword appears in any field, despite non-security category', () => {
+    expect(isSecuritySignal(signal({ category: 'bug', title: 'XSS in render path' }))).toBe(true);
+    expect(isSecuritySignal(signal({ category: 'tech-debt', body: 'leaks credentials' }))).toBe(
+      true
+    );
+    expect(isSecuritySignal(signal({ category: 'routing', signalKey: 'auth-floor' }))).toBe(true);
+  });
+
+  it('false for a clearly non-security signal', () => {
+    expect(
+      isSecuritySignal(
+        signal({
+          category: 'routing',
+          signalKey: 'routing:cli-floor:x',
+          title: 'slow docs',
+          body: 'latency',
+        })
+      )
+    ).toBe(false);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
@@ -22,6 +22,24 @@
 import { getTimeProvider } from '../../core/index.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { remediationTaskId } from './improvement-remediation.js';
+import { SECURITY_KEYWORDS } from '../gateway/gateway-keywords.js';
+
+/**
+ * Fail-closed security classification (#3540 inc.2e / #3615). The hard
+ * exclusion "security signals are always human-gated" only holds if
+ * classification is correct — a security issue mislabeled by a detector (e.g. as
+ * `bug` or `routing`) would otherwise silently bypass the gate. So we treat a
+ * signal as security if EITHER its declared category is `security` OR any
+ * security keyword appears in its key/title/body. Uncertain → security →
+ * human-gated. This is intentionally over-inclusive (false positives only cost a
+ * human review; a false negative auto-remediates a security issue unreviewed),
+ * and is reused by the future enforce path (#3618) so both decide identically.
+ */
+export function isSecuritySignal(signal: ImprovementSignal): boolean {
+  if (signal.category === 'security') return true;
+  const haystack = `${signal.signalKey}\n${signal.title}\n${signal.body}`.toLowerCase();
+  return SECURITY_KEYWORDS.some((kw) => haystack.includes(kw));
+}
 
 /** One shadow decision: would the gate auto-route this remediation? (Logged only.) */
 export interface RemediationShadowRecord {
@@ -45,7 +63,9 @@ export interface RemediationShadowRecord {
  * would-remediate=true (no execution happens regardless).
  */
 export function evaluateRemediationShadow(signal: ImprovementSignal): RemediationShadowRecord {
-  const isSecurity = signal.category === 'security';
+  // Fail-closed (#3615): category==='security' OR any security keyword → gate.
+  const isSecurity = isSecuritySignal(signal);
+  const gatedByKeyword = isSecurity && signal.category !== 'security';
   return {
     timestamp: new Date(getTimeProvider().now()).toISOString(),
     signalKey: signal.signalKey,
@@ -53,9 +73,11 @@ export function evaluateRemediationShadow(signal: ImprovementSignal): Remediatio
     category: signal.category,
     severity: signal.severity,
     wouldAutoRemediate: !isSecurity,
-    reason: isSecurity
-      ? 'security-category — always human-gated, never auto-remediated'
-      : 'shadow: would route to the dev-pipeline for remediation (not executed)',
+    reason: gatedByKeyword
+      ? `security-related (keyword match, declared category '${signal.category}') — fail-closed human-gated`
+      : isSecurity
+        ? 'security-category — always human-gated, never auto-remediated'
+        : 'shadow: would route to the dev-pipeline for remediation (not executed)',
   };
 }
 


### PR DESCRIPTION
Closes #3615. Condition 4 of the #3540 auto-invoke gate (design ratified 7/7). Part of the safety prerequisites that gate the enforce capstone (#3618).

## Problem
The shadow selector's hard exclusion — "security signals are always human-gated" — only holds if classification is correct. A security issue **mislabeled by a detector** (e.g. as `bug` or `routing`) would silently bypass the gate and, under a future enforce path, get auto-remediated unreviewed.

## Fix (fail-closed)
`evaluateRemediationShadow` now treats a signal as security if **EITHER** its declared category is `security` **OR** any keyword from the canonical `SECURITY_KEYWORDS` (gateway-keywords.ts, reused — DRY) appears in its `signalKey`/`title`/`body`. Uncertain → security → human-gated. Intentionally over-inclusive: a false positive only costs a human review; a false negative auto-remediates a security issue unreviewed.

Exposed as **`isSecuritySignal`** so the future enforce path (#3618) reuses the exact same classification — shadow and enforce decide identically.

## Tests
Mis-categorized security signal (category `bug`, security keywords) → human-gated; genuine non-security signal → not gated; `isSecuritySignal` unit coverage across fields. Suite 12/12; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)