### PR TITLE
feat(capability-loop): runaway-loop guard for auto-remediation (#3617)

### DIFF
--- a/.changeset/runaway-guard.md
+++ b/.changeset/runaway-guard.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): runaway-loop guard for auto-remediation (#3617)
+
+Condition 6 of the #3540 auto-invoke gate. A `RemediationGuard` that prevents the
+recursive self-trigger loop (an auto-PR perturbs fitness → emits a new signal →
+triggers another remediation → …) by bounding three axes, fail-closed:
+
+- **idempotency + cooldown** — the same `signalKey` can't re-trigger within
+  `cooldownMs` (default 6h), breaking the common same-signal re-fire;
+- **depth/generation** — a remediation chain is capped at `maxGenerations`
+  (default 1), bounding cascades across different signals;
+- **rate cap** — ≤ `maxPerWindow` (default 5, mirrors MAX_ISSUES_PER_RUN) per
+  `windowMs` (default 24h).
+
+Pure + in-memory + bounded; nothing executes. The enforce path (#3618) consults
+it before routing any remediation to the dev-pipeline.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the runaway-loop guard (#3540 inc.2g / #3617).
+ * Each axis (cooldown/idempotency, depth, rate) blocks independently, fail-closed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  RemediationGuard,
+  getRemediationGuard,
+  DEFAULT_REMEDIATION_GUARD_CONFIG,
+} from './improvement-remediation-guard.js';
+
+const T0 = 1_700_000_000_000;
+
+describe('RemediationGuard — cooldown / idempotency', () => {
+  it('allows a first attempt for a signal', () => {
+    const g = new RemediationGuard();
+    const d = g.canRemediate('tech-debt:fitness-below-floor', T0);
+    expect(d.allowed).toBe(true);
+  });
+
+  it('blocks the SAME signal again within the cooldown (the recursive-retrigger case)', () => {
+    const g = new RemediationGuard({ cooldownMs: 1000 });
+    g.recordAttempt('tech-debt:fitness-below-floor', T0);
+    const d = g.canRemediate('tech-debt:fitness-below-floor', T0 + 500);
+    expect(d.allowed).toBe(false);
+    expect(d.blockReason).toBe('cooldown');
+  });
+
+  it('allows the same signal again AFTER the cooldown elapses', () => {
+    const g = new RemediationGuard({ cooldownMs: 1000 });
+    g.recordAttempt('sig', T0);
+    expect(g.canRemediate('sig', T0 + 1001).allowed).toBe(true);
+  });
+
+  it('cooldown is per-signal — a different signal is unaffected', () => {
+    const g = new RemediationGuard({ cooldownMs: 10_000 });
+    g.recordAttempt('sig-a', T0);
+    expect(g.canRemediate('sig-b', T0 + 1).allowed).toBe(true);
+  });
+});
+
+describe('RemediationGuard — depth / generation', () => {
+  it('blocks a remediation deeper than maxGenerations (runaway chain)', () => {
+    const g = new RemediationGuard({ maxGenerations: 1 });
+    expect(g.canRemediate('sig', T0, 1).allowed).toBe(true);
+    const d = g.canRemediate('sig', T0, 2);
+    expect(d.allowed).toBe(false);
+    expect(d.blockReason).toBe('depth');
+  });
+
+  it('root (generation 0) is always within depth', () => {
+    const g = new RemediationGuard({ maxGenerations: 0 });
+    expect(g.canRemediate('sig', T0, 0).allowed).toBe(true);
+    expect(g.canRemediate('sig', T0, 1).allowed).toBe(false);
+  });
+});
+
+describe('RemediationGuard — rate cap', () => {
+  it('blocks once maxPerWindow attempts have occurred in the window', () => {
+    const g = new RemediationGuard({ maxPerWindow: 3, windowMs: 10_000, cooldownMs: 0 });
+    for (let i = 0; i < 3; i++) g.recordAttempt(`sig-${String(i)}`, T0 + i);
+    const d = g.canRemediate('sig-new', T0 + 4);
+    expect(d.allowed).toBe(false);
+    expect(d.blockReason).toBe('rate');
+  });
+
+  it('attempts outside the window do not count toward the cap', () => {
+    const g = new RemediationGuard({ maxPerWindow: 2, windowMs: 1000, cooldownMs: 0 });
+    g.recordAttempt('a', T0);
+    g.recordAttempt('b', T0 + 1);
+    // both are now older than windowMs at T0 + 2000
+    expect(g.canRemediate('c', T0 + 2000).allowed).toBe(true);
+  });
+});
+
+describe('RemediationGuard — precedence + bounds', () => {
+  it('depth is checked before cooldown/rate (fail-closed ordering is irrelevant to the verdict)', () => {
+    const g = new RemediationGuard({ maxGenerations: 0, cooldownMs: 1000 });
+    g.recordAttempt('sig', T0);
+    const d = g.canRemediate('sig', T0 + 1, 5);
+    expect(d.allowed).toBe(false);
+    expect(d.blockReason).toBe('depth');
+  });
+
+  it('bounds attempt history to maxHistory', () => {
+    const g = new RemediationGuard({ maxHistory: 2, cooldownMs: 0, maxPerWindow: 1000 });
+    for (const k of ['a', 'b', 'c']) g.recordAttempt(k, T0);
+    // 'a' was evicted, so it is allowed again despite cooldown semantics
+    expect(g.canRemediate('a', T0).allowed).toBe(true);
+  });
+
+  it('default config mirrors MAX_ISSUES_PER_RUN and is conservative', () => {
+    expect(DEFAULT_REMEDIATION_GUARD_CONFIG.maxPerWindow).toBe(5);
+    expect(DEFAULT_REMEDIATION_GUARD_CONFIG.maxGenerations).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('getRemediationGuard', () => {
+  it('is a stable process-scoped singleton', () => {
+    expect(getRemediationGuard()).toBe(getRemediationGuard());
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
@@ -26,6 +26,11 @@
  * @module mcp/tools/improvement-remediation-guard
  */
 
+// @export-no-consumer-yet — see #3618
+// This guard is one of the hard-blocker safety primitives the enforce capstone
+// (#3618) is explicitly "blocked by"; it is consumed there once all of
+// inc.2b–inc.2g have landed. Built ahead deliberately (named near-term consumer).
+
 /** Tuning for {@link RemediationGuard}. All durations in milliseconds. */
 export interface RemediationGuardConfig {
   /** Minimum time before the same signalKey may be attempted again (idempotency). */

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
@@ -1,0 +1,147 @@
+/**
+ * Runaway-loop guard for auto-remediation (#3540 increment 2g / #3617).
+ *
+ * Condition 6 of the auto-invoke gate. An auto-remediation PR perturbs the
+ * codebase → fitness/outcome metrics shift → improvement_review emits a NEW
+ * signal → which would trigger another remediation → … a recursive self-trigger
+ * loop. This guard makes that impossible by bounding three independent axes,
+ * fail-closed (any breach blocks):
+ *
+ *  1. **Idempotency + cooldown** — the SAME source signal (by `signalKey`)
+ *     cannot trigger again within `cooldownMs`. This directly breaks the common
+ *     case where a remediation re-perturbs the same metric and the same signal
+ *     (e.g. `tech-debt:fitness-below-floor`) re-fires immediately.
+ *  2. **Depth/generation** — a remediation triggered as a descendant of another
+ *     remediation carries a `generation` ≥ 1; the chain is capped at
+ *     `maxGenerations`, so a cascade across DIFFERENT signal keys still can't
+ *     recurse without bound.
+ *  3. **Rate cap** — at most `maxPerWindow` attempts per `windowMs` across all
+ *     signals (mirrors improvement_review's MAX_ISSUES_PER_RUN = 5), bounding
+ *     total volume even when individual cooldowns/depths are satisfied.
+ *
+ * Pure + in-memory + bounded. The shadow path (#3611) can consult it to record
+ * "would-block" decisions; the enforce path (#3618) enforces it before routing
+ * anything to the dev-pipeline. Nothing here executes a remediation.
+ *
+ * @module mcp/tools/improvement-remediation-guard
+ */
+
+/** Tuning for {@link RemediationGuard}. All durations in milliseconds. */
+export interface RemediationGuardConfig {
+  /** Minimum time before the same signalKey may be attempted again (idempotency). */
+  readonly cooldownMs: number;
+  /** Maximum remediation-chain depth (0 = root; a descendant is 1, etc.). */
+  readonly maxGenerations: number;
+  /** Maximum attempts allowed within {@link windowMs} across all signals. */
+  readonly maxPerWindow: number;
+  /** Sliding window for the rate cap. */
+  readonly windowMs: number;
+  /** Cap on retained attempt history (memory bound). */
+  readonly maxHistory: number;
+}
+
+/** Conservative defaults — biased toward NOT remediating (fail-closed). */
+export const DEFAULT_REMEDIATION_GUARD_CONFIG: RemediationGuardConfig = {
+  cooldownMs: 6 * 60 * 60 * 1000, // 6h between attempts on the same signal
+  maxGenerations: 1, // a remediation may not spawn a remediation that spawns another
+  maxPerWindow: 5, // mirror MAX_ISSUES_PER_RUN
+  windowMs: 24 * 60 * 60 * 1000, // per day
+  maxHistory: 500,
+};
+
+/** One recorded remediation attempt. */
+export interface RemediationAttempt {
+  readonly signalKey: string;
+  readonly timestamp: number;
+  readonly generation: number;
+}
+
+/** Why the guard allowed or blocked a remediation. */
+export type GuardBlockReason = 'cooldown' | 'depth' | 'rate';
+
+/** The guard's verdict for one prospective remediation. */
+export interface GuardDecision {
+  readonly allowed: boolean;
+  /** Set when `allowed` is false. */
+  readonly blockReason?: GuardBlockReason;
+  readonly detail: string;
+}
+
+/**
+ * Stateful, in-memory runaway guard. One instance per loop; the enforce path
+ * holds the process singleton (see {@link getRemediationGuard}).
+ */
+export class RemediationGuard {
+  private readonly config: RemediationGuardConfig;
+  private readonly attempts: RemediationAttempt[] = [];
+
+  constructor(config: Partial<RemediationGuardConfig> = {}) {
+    this.config = { ...DEFAULT_REMEDIATION_GUARD_CONFIG, ...config };
+  }
+
+  /**
+   * Decide whether a remediation for `signalKey` at `generation` may proceed at
+   * time `now`. Pure read — does not record the attempt (call
+   * {@link recordAttempt} only when the remediation actually proceeds).
+   */
+  canRemediate(signalKey: string, now: number, generation = 0): GuardDecision {
+    if (generation > this.config.maxGenerations) {
+      return {
+        allowed: false,
+        blockReason: 'depth',
+        detail: `generation ${String(generation)} exceeds maxGenerations ${String(this.config.maxGenerations)} (runaway chain)`,
+      };
+    }
+    const last = this.lastAttempt(signalKey);
+    if (last !== undefined && now - last.timestamp < this.config.cooldownMs) {
+      const waitMs = this.config.cooldownMs - (now - last.timestamp);
+      return {
+        allowed: false,
+        blockReason: 'cooldown',
+        detail: `signal '${signalKey}' attempted ${String(Math.round((now - last.timestamp) / 1000))}s ago; cooldown ${String(Math.round(this.config.cooldownMs / 1000))}s (wait ${String(Math.round(waitMs / 1000))}s)`,
+      };
+    }
+    const inWindow = this.countInWindow(now);
+    if (inWindow >= this.config.maxPerWindow) {
+      return {
+        allowed: false,
+        blockReason: 'rate',
+        detail: `${String(inWindow)} attempts in the last ${String(Math.round(this.config.windowMs / 1000))}s reaches the cap of ${String(this.config.maxPerWindow)}`,
+      };
+    }
+    return { allowed: true, detail: 'within cooldown, depth, and rate bounds' };
+  }
+
+  /** Record that a remediation proceeded. Bounded history (oldest evicted). */
+  recordAttempt(signalKey: string, now: number, generation = 0): void {
+    this.attempts.push({ signalKey, timestamp: now, generation });
+    if (this.attempts.length > this.config.maxHistory) {
+      this.attempts.splice(0, this.attempts.length - this.config.maxHistory);
+    }
+  }
+
+  /** Most-recent attempt for a signalKey, if any. */
+  private lastAttempt(signalKey: string): RemediationAttempt | undefined {
+    let found: RemediationAttempt | undefined;
+    for (const a of this.attempts) {
+      if (a.signalKey === signalKey && (found === undefined || a.timestamp > found.timestamp)) {
+        found = a;
+      }
+    }
+    return found;
+  }
+
+  /** Number of attempts within the rate window ending at `now`. */
+  private countInWindow(now: number): number {
+    const cutoff = now - this.config.windowMs;
+    return this.attempts.reduce((n, a) => (a.timestamp >= cutoff ? n + 1 : n), 0);
+  }
+}
+
+let singletonGuard: RemediationGuard | undefined;
+
+/** Process-scoped runaway guard — shared across remediation runs. */
+export function getRemediationGuard(): RemediationGuard {
+  singletonGuard ??= new RemediationGuard();
+  return singletonGuard;
+}


### PR DESCRIPTION
Closes #3617. Condition 6 of the #3540 auto-invoke gate (design ratified 7/7). A hard blocker for the enforce capstone (#3618).

## Problem
Once auto-remediation enforces, an auto-PR perturbs the codebase → fitness/outcome metrics shift → `improvement_review` emits a NEW signal → which triggers another remediation → recursive self-trigger.

## Fix
`RemediationGuard` bounds three independent axes, **fail-closed** (any breach blocks):
1. **Idempotency + cooldown** — the same `signalKey` can't re-trigger within `cooldownMs` (default 6h). Directly breaks the common case (a remediation re-perturbs the same metric → same signal re-fires).
2. **Depth/generation** — a remediation triggered as a descendant carries `generation ≥ 1`; capped at `maxGenerations` (default 1), bounding cross-signal cascades.
3. **Rate cap** — ≤ `maxPerWindow` (default 5, mirrors `MAX_ISSUES_PER_RUN`) per `windowMs` (default 24h).

Pure, in-memory, bounded history; **executes nothing**. `canRemediate()` is a read-only verdict; `recordAttempt()` is called only when a remediation actually proceeds. The enforce path (#3618) consults it before routing to the dev-pipeline; defaults are deliberately conservative.

## Tests
Each axis blocks independently (same-signal cooldown, depth cap, window rate); per-signal isolation; history bound; singleton. Suite 12/12; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)