### PR TITLE
feat(capability-loop): quantified shadow->enforce exit criterion (#3612)

### DIFF
--- a/.changeset/enforce-readiness.md
+++ b/.changeset/enforce-readiness.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): quantified shadow→enforce exit criterion (#3612)
+
+Condition 1 of the #3540 auto-invoke gate. `evaluateEnforceReadiness` defines a
+FALSIFIABLE numeric gate for promoting auto-remediation from shadow (#3611) to
+enforce (#3618), replacing the unfalsifiable "shows sound selection". Mirrors the
+tune-loop's explicit exit criteria (#3323): five independently-checkable
+conditions, ALL required (fail-closed):
+
+- **volume** — ≥ minShadowSelections observed,
+- **judged-coverage** — ≥ minJudgedRate reviewed,
+- **soundness** — ≥ minSoundnessRate of reviewed judged sound (fails closed on zero reviews),
+- **named-evaluator** and **named-owner** sign-off.
+
+Pure evaluation; flips no flag. The enforce path (#3618) refuses to enable
+enforcement unless `ready` is true.

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the shadow→enforce exit criterion (#3540 inc.2b / #3612).
+ * Falsifiable, fail-closed: ready only when EVERY criterion passes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateEnforceReadiness,
+  DEFAULT_ENFORCE_READINESS_CONFIG,
+  type EnforceReadinessEvidence,
+} from './improvement-enforce-readiness.js';
+
+/** Evidence that satisfies every default criterion. */
+function readyEvidence(over: Partial<EnforceReadinessEvidence> = {}): EnforceReadinessEvidence {
+  return {
+    shadowSelections: 25,
+    judgedSelections: 22, // 88% ≥ 80%
+    judgedSound: 21, // 95% ≥ 90%
+    evaluator: 'security-reviewer@example',
+    owner: 'williamzujkowski',
+    ...over,
+  };
+}
+
+describe('evaluateEnforceReadiness', () => {
+  it('is ready when every criterion is met', () => {
+    const r = evaluateEnforceReadiness(readyEvidence());
+    expect(r.ready).toBe(true);
+    expect(r.blockers).toEqual([]);
+  });
+
+  it('blocks on insufficient volume', () => {
+    const r = evaluateEnforceReadiness(
+      readyEvidence({ shadowSelections: 5, judgedSelections: 5, judgedSound: 5 })
+    );
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toContain('volume');
+  });
+
+  it('blocks on insufficient judged coverage', () => {
+    const r = evaluateEnforceReadiness(
+      readyEvidence({ shadowSelections: 25, judgedSelections: 10 })
+    );
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toContain('judged-coverage');
+  });
+
+  it('blocks on insufficient soundness rate', () => {
+    const r = evaluateEnforceReadiness(readyEvidence({ judgedSelections: 22, judgedSound: 10 }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toContain('soundness');
+  });
+
+  it('soundness fails closed when there are zero reviews (no divide-by-zero pass)', () => {
+    const r = evaluateEnforceReadiness(
+      readyEvidence({ shadowSelections: 25, judgedSelections: 0, judgedSound: 0 })
+    );
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(expect.arrayContaining(['judged-coverage', 'soundness']));
+  });
+
+  it('blocks on missing named evaluator', () => {
+    // Omit evaluator entirely (exactOptionalPropertyTypes — no explicit undefined).
+    const r = evaluateEnforceReadiness({
+      shadowSelections: 25,
+      judgedSelections: 22,
+      judgedSound: 21,
+      owner: 'williamzujkowski',
+    });
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toContain('named-evaluator');
+  });
+
+  it('blocks on missing / blank named owner', () => {
+    const missing = evaluateEnforceReadiness({
+      shadowSelections: 25,
+      judgedSelections: 22,
+      judgedSound: 21,
+      evaluator: 'rev@example',
+    });
+    expect(missing.blockers).toContain('named-owner');
+    expect(evaluateEnforceReadiness(readyEvidence({ owner: '   ' })).blockers).toContain(
+      'named-owner'
+    );
+  });
+
+  it('honors relaxed config (evaluator/owner not required)', () => {
+    const r = evaluateEnforceReadiness(
+      { shadowSelections: 25, judgedSelections: 22, judgedSound: 21 },
+      {
+        ...DEFAULT_ENFORCE_READINESS_CONFIG,
+        requireNamedEvaluator: false,
+        requireNamedOwner: false,
+      }
+    );
+    expect(r.ready).toBe(true);
+  });
+
+  it('default config is a high, conservative bar', () => {
+    expect(DEFAULT_ENFORCE_READINESS_CONFIG.minSoundnessRate).toBeGreaterThanOrEqual(0.9);
+    expect(DEFAULT_ENFORCE_READINESS_CONFIG.requireNamedEvaluator).toBe(true);
+    expect(DEFAULT_ENFORCE_READINESS_CONFIG.requireNamedOwner).toBe(true);
+  });
+
+  it('reports every criterion with a human-readable detail', () => {
+    const r = evaluateEnforceReadiness(readyEvidence());
+    expect(r.criteria.map((c) => c.name)).toEqual([
+      'volume',
+      'judged-coverage',
+      'soundness',
+      'named-evaluator',
+      'named-owner',
+    ]);
+    expect(r.criteria.every((c) => c.detail.length > 0)).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
@@ -1,0 +1,140 @@
+/**
+ * Quantified shadow→enforce exit criterion (#3540 increment 2b / #3612).
+ *
+ * Condition 1 of the auto-invoke gate. Promotion from shadow (observe-only,
+ * #3611) to enforce (#3618) must turn on a FALSIFIABLE numeric gate, not an
+ * unfalsifiable "shows sound selection". Mirrors the tune-loop's explicit exit
+ * criteria (#3323): a fixed set of conditions, each independently checkable,
+ * ALL required (fail-closed — any unmet condition blocks enforce).
+ *
+ * The criteria, per the design vote:
+ *  1. **Volume** — at least `minShadowSelections` shadow would-remediate
+ *     decisions observed (enough data to judge).
+ *  2. **Judged coverage** — at least `minJudgedRate` of those selections have
+ *     actually been reviewed by the evaluator (you can't certify what you didn't
+ *     look at).
+ *  3. **Soundness** — at least `minSoundnessRate` of the *judged* selections
+ *     were assessed sound (the loop picks the right remediations).
+ *  4. **Named evaluator** — a specific person/role signed the soundness review.
+ *  5. **Named owner** — a specific owner accepts turning enforcement on.
+ *
+ * This module only EVALUATES readiness against supplied data; it flips no flag
+ * and runs no remediation. The enforce path (#3618) calls it and refuses to
+ * enable enforcement unless `ready` is true. Soundness/evaluator/owner data is
+ * supplied by the operational review of shadow records (selection counts come
+ * from {@link summarizeRemediationShadow}).
+ *
+ * @module mcp/tools/improvement-enforce-readiness
+ */
+
+// @export-no-consumer-yet — see #3618
+// The enforce capstone (#3618) is explicitly "blocked by" this exit criterion and
+// consumes it to gate enforcement. Built ahead deliberately (named consumer).
+
+/** Tuning for {@link evaluateEnforceReadiness}. */
+export interface EnforceReadinessConfig {
+  /** Minimum shadow would-remediate decisions before enforce can be considered. */
+  readonly minShadowSelections: number;
+  /** Minimum fraction of selections that must have been reviewed by the evaluator. */
+  readonly minJudgedRate: number;
+  /** Minimum fraction of JUDGED selections that must be assessed sound. */
+  readonly minSoundnessRate: number;
+  /** Whether a named evaluator is required. */
+  readonly requireNamedEvaluator: boolean;
+  /** Whether a named owner sign-off is required. */
+  readonly requireNamedOwner: boolean;
+}
+
+/** Conservative defaults — high bar, fail-closed. */
+export const DEFAULT_ENFORCE_READINESS_CONFIG: EnforceReadinessConfig = {
+  minShadowSelections: 20,
+  minJudgedRate: 0.8,
+  minSoundnessRate: 0.9,
+  requireNamedEvaluator: true,
+  requireNamedOwner: true,
+};
+
+/** The operational evidence the exit criterion is evaluated against. */
+export interface EnforceReadinessEvidence {
+  /** Count of shadow would-remediate decisions observed (from the shadow sink). */
+  readonly shadowSelections: number;
+  /** How many of those selections the evaluator actually reviewed. */
+  readonly judgedSelections: number;
+  /** How many reviewed selections were assessed SOUND. */
+  readonly judgedSound: number;
+  /** Named evaluator who performed the soundness review (undefined = none). */
+  readonly evaluator?: string;
+  /** Named owner accepting enforcement (undefined = none). */
+  readonly owner?: string;
+}
+
+/** One checked condition of the exit criterion. */
+export interface ReadinessCriterion {
+  readonly name: string;
+  readonly met: boolean;
+  readonly detail: string;
+}
+
+/** Full readiness verdict. `ready` is true iff every criterion is met. */
+export interface EnforceReadinessReport {
+  readonly ready: boolean;
+  readonly criteria: readonly ReadinessCriterion[];
+  /** Names of the unmet criteria (empty when ready). */
+  readonly blockers: readonly string[];
+}
+
+function pct(n: number, d: number): number {
+  return d === 0 ? 0 : n / d;
+}
+
+/** Build a "named X is present" criterion (evaluator/owner), keeping the main fn simple. */
+function presenceCriterion(
+  name: string,
+  label: string,
+  value: string,
+  required: boolean
+): ReadinessCriterion {
+  const present = value !== '';
+  return {
+    name,
+    met: !required || present,
+    detail: present ? `${label}: ${value}` : `no named ${label}`,
+  };
+}
+
+/**
+ * Evaluate whether shadow→enforce promotion criteria are met. Pure; supply the
+ * operational evidence. Never returns `ready: true` unless ALL criteria pass.
+ */
+export function evaluateEnforceReadiness(
+  evidence: EnforceReadinessEvidence,
+  config: EnforceReadinessConfig = DEFAULT_ENFORCE_READINESS_CONFIG
+): EnforceReadinessReport {
+  const judgedRate = pct(evidence.judgedSelections, evidence.shadowSelections);
+  const soundnessRate = pct(evidence.judgedSound, evidence.judgedSelections);
+  const evaluator = evidence.evaluator?.trim() ?? '';
+  const owner = evidence.owner?.trim() ?? '';
+
+  const criteria: ReadinessCriterion[] = [
+    {
+      name: 'volume',
+      met: evidence.shadowSelections >= config.minShadowSelections,
+      detail: `${String(evidence.shadowSelections)} shadow selections (need ≥ ${String(config.minShadowSelections)})`,
+    },
+    {
+      name: 'judged-coverage',
+      met: judgedRate >= config.minJudgedRate,
+      detail: `${String(Math.round(judgedRate * 100))}% reviewed (need ≥ ${String(Math.round(config.minJudgedRate * 100))}%)`,
+    },
+    {
+      name: 'soundness',
+      met: evidence.judgedSelections > 0 && soundnessRate >= config.minSoundnessRate,
+      detail: `${String(Math.round(soundnessRate * 100))}% of reviewed judged sound (need ≥ ${String(Math.round(config.minSoundnessRate * 100))}%, with reviews present)`,
+    },
+    presenceCriterion('named-evaluator', 'evaluator', evaluator, config.requireNamedEvaluator),
+    presenceCriterion('named-owner', 'owner', owner, config.requireNamedOwner),
+  ];
+
+  const blockers = criteria.filter((c) => !c.met).map((c) => c.name);
+  return { ready: blockers.length === 0, criteria, blockers };
+}


### PR DESCRIPTION
Closes #3612. Condition 1 of the #3540 auto-invoke gate (design ratified 7/7). A hard blocker for the enforce capstone (#3618).

## Problem
The promotion from shadow (observe-only) to enforce needs a **falsifiable** gate. "Shows sound selection" is unfalsifiable — there must be explicit numbers and a named sign-off, mirroring the tune-loop's exit criteria (#3323).

## Fix
`evaluateEnforceReadiness(evidence, config)` checks five independent criteria, **ALL required** (fail-closed — any unmet blocks):
1. **volume** — ≥ `minShadowSelections` (default 20) shadow would-remediate decisions observed.
2. **judged-coverage** — ≥ `minJudgedRate` (default 80%) of selections actually reviewed.
3. **soundness** — ≥ `minSoundnessRate` (default 90%) of *reviewed* selections judged sound; **fails closed on zero reviews** (no divide-by-zero pass).
4. **named-evaluator** — a specific reviewer signed the soundness review.
5. **named-owner** — a specific owner accepts enabling enforcement.

Pure evaluation — flips no flag, runs no remediation. Returns `{ ready, criteria[], blockers[] }`. The enforce path (#3618) refuses enforcement unless `ready`. Selection counts come from the shadow sink (#3611); soundness/evaluator/owner from the operational review.

## Tests
Each criterion blocks independently; zero-review fails closed; relaxed config; conservative defaults; full criterion reporting. Suite 10/10; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)