### PR TITLE
feat(capability-loop): add Rule-of-Two capability boundary primitives (#3613)

### DIFF
--- a/.changeset/rule-of-two-boundary.md
+++ b/.changeset/rule-of-two-boundary.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): Rule-of-Two capability boundary primitives for auto-remediation (#3613)
+
+Condition 2 (the load-bearing security hole) of the #3540 auto-invoke gate;
+design ratified 7/7. Ships the fail-closed boundary primitives:
+
+- a typed phase machine (`PHASE_CAPABILITIES`) where RESEARCH holds
+  {untrusted-input, secrets} (no write) and IMPLEMENT holds {repo-write, secrets}
+  (no fresh untrusted input) — neither phase holds all three Rule-of-Two legs;
+- `CapabilityLedger.assertCapability`, a fail-closed chokepoint guard that throws
+  `RuleOfTwoViolation` if a capability isn't granted by the active phase (and
+  denies everything before any phase is entered);
+- a strict typed `RemediationPlanSchema` (`.strict()`, allowlisted action kinds,
+  bounded inert fields) — the ONLY artifact allowed across RESEARCH→IMPLEMENT, so
+  untrusted content can't smuggle into the write-capable phase.
+
+The enforce capstone (#3618) wires these at every chokepoint, physically
+surrenders capabilities at the boundary (per-phase adapter lifecycle), and
+reconciles with ClawGuard; OS process isolation is tracked follow-up.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the Rule-of-Two capability boundary primitives (#3540 inc.2c / #3613).
+ * Fail-closed: capabilities denied unless a phase grants them; no phase holds all 3;
+ * the plan artifact is strict (no smuggling across the boundary).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CapabilityLedger,
+  RuleOfTwoViolation,
+  PHASE_CAPABILITIES,
+  RULE_OF_TWO_LEGS,
+  assertPhaseCapabilitiesSound,
+  parseRemediationPlan,
+  RemediationPlanSchema,
+  type RemediationPlan,
+} from './improvement-remediation-capability.js';
+
+describe('PHASE_CAPABILITIES invariant', () => {
+  it('no phase declares all three Rule-of-Two legs', () => {
+    for (const caps of Object.values(PHASE_CAPABILITIES)) {
+      expect(RULE_OF_TWO_LEGS.every((leg) => caps.has(leg))).toBe(false);
+    }
+  });
+
+  it('assertPhaseCapabilitiesSound passes for the shipped config', () => {
+    expect(() => {
+      assertPhaseCapabilitiesSound();
+    }).not.toThrow();
+  });
+
+  it('research has no write; implement has no untrusted-input', () => {
+    expect(PHASE_CAPABILITIES.research.has('repo-write')).toBe(false);
+    expect(PHASE_CAPABILITIES.implement.has('untrusted-input')).toBe(false);
+  });
+});
+
+describe('CapabilityLedger (fail-closed)', () => {
+  /** Wrap a void assertCapability call so the arrow isn't a void-returning shorthand. */
+  const cap =
+    (led: CapabilityLedger, c: Parameters<CapabilityLedger['assertCapability']>[0]) => (): void => {
+      led.assertCapability(c);
+    };
+
+  it('denies every capability before any phase is entered', () => {
+    const led = new CapabilityLedger();
+    expect(cap(led, 'secrets')).toThrow(RuleOfTwoViolation);
+    expect(cap(led, 'repo-write')).toThrow(RuleOfTwoViolation);
+    expect(cap(led, 'untrusted-input')).toThrow(RuleOfTwoViolation);
+  });
+
+  it('RESEARCH grants untrusted-input + secrets, denies repo-write', () => {
+    const led = new CapabilityLedger();
+    led.enterPhase('research');
+    expect(cap(led, 'untrusted-input')).not.toThrow();
+    expect(cap(led, 'secrets')).not.toThrow();
+    expect(cap(led, 'repo-write')).toThrow(RuleOfTwoViolation);
+  });
+
+  it('IMPLEMENT grants repo-write + secrets, denies untrusted-input', () => {
+    const led = new CapabilityLedger();
+    led.enterPhase('implement');
+    expect(cap(led, 'repo-write')).not.toThrow();
+    expect(cap(led, 'secrets')).not.toThrow();
+    expect(cap(led, 'untrusted-input')).toThrow(RuleOfTwoViolation);
+  });
+
+  it('the forbidden third leg is always denied in whatever phase is active', () => {
+    // Whichever phase we are in, at most two legs are grantable; the third throws.
+    const research = new CapabilityLedger();
+    research.enterPhase('research');
+    expect(cap(research, 'repo-write')).toThrow(); // write denied during untrusted-read phase
+    const implement = new CapabilityLedger();
+    implement.enterPhase('implement');
+    expect(cap(implement, 'untrusted-input')).toThrow(); // fresh untrusted denied during write phase
+  });
+});
+
+describe('RemediationPlanSchema (strict boundary artifact)', () => {
+  const valid: RemediationPlan = {
+    signalKey: 'tech-debt:fitness-below-floor',
+    category: 'tech-debt',
+    summary: 'Restore fitness by addressing the failing dimension.',
+    steps: [{ kind: 'add-test', description: 'cover the regressed path' }],
+  };
+
+  it('accepts a valid typed plan', () => {
+    expect(() => parseRemediationPlan(valid)).not.toThrow();
+    expect(parseRemediationPlan(valid).signalKey).toBe(valid.signalKey);
+  });
+
+  it('rejects unknown keys (no free-form smuggling across the boundary)', () => {
+    const smuggled = { ...valid, shellCommand: 'rm -rf /' };
+    expect(() => parseRemediationPlan(smuggled)).toThrow(RuleOfTwoViolation);
+    expect(RemediationPlanSchema.safeParse(smuggled).success).toBe(false);
+  });
+
+  it('rejects an unknown action kind', () => {
+    const bad = { ...valid, steps: [{ kind: 'exec-arbitrary', description: 'x' }] };
+    expect(() => parseRemediationPlan(bad)).toThrow(RuleOfTwoViolation);
+  });
+
+  it('rejects an over-long (free-form overflow) description', () => {
+    const bad = { ...valid, steps: [{ kind: 'refactor', description: 'x'.repeat(501) }] };
+    expect(() => parseRemediationPlan(bad)).toThrow(RuleOfTwoViolation);
+  });
+
+  it('rejects empty steps (a plan must propose at least one typed action)', () => {
+    expect(() => parseRemediationPlan({ ...valid, steps: [] })).toThrow(RuleOfTwoViolation);
+  });
+
+  it('rejects unknown keys inside a step', () => {
+    const bad = { ...valid, steps: [{ kind: 'fix-bug', description: 'x', patch: 'diff…' }] };
+    expect(() => parseRemediationPlan(bad)).toThrow(RuleOfTwoViolation);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
@@ -1,0 +1,176 @@
+/**
+ * Rule-of-Two capability boundary for the auto-remediation path (#3540 inc.2c / #3613).
+ *
+ * Condition 2 — the load-bearing security hole. When the auto-invoke gate
+ * enforces, a naive run would hold all three Rule-of-Two legs at once: it ingests
+ * UNTRUSTED external content (research), WRITES a PR, and holds SECRETS (adapter
+ * keys). Per .rules/untrusted-input.md that conjunction is disallowed.
+ *
+ * This module is the FAIL-CLOSED runtime primitive (design ratified 7/7, see
+ * #3613): a typed phase machine + a {@link CapabilityLedger} that throws if the
+ * active capability set ever contains all three legs, plus the strict typed
+ * {@link RemediationPlanSchema} artifact that is the ONLY thing allowed to cross
+ * the RESEARCH→IMPLEMENT boundary (so untrusted content can't ride into the
+ * write-capable phase as data).
+ *
+ * Per the vote's conditions, full enforcement also requires (wired in the
+ * enforce capstone #3618, where the real RESEARCH/IMPLEMENT execution lives):
+ *  - calling {@link CapabilityLedger.assertCapability} at EVERY chokepoint
+ *    (each untrusted-read / write / secret-read), not only at phase transitions;
+ *  - PHYSICALLY surrendering capabilities at the boundary (per-phase adapter
+ *    lifecycle / no write token in RESEARCH, no fetch in IMPLEMENT) so the
+ *    ledger is a tripwire over a real split, not the split itself;
+ *  - reconciling with ClawGuard / NEXUS_ACCESS_POLICY_MODE rather than forking.
+ * OS-level process isolation is tracked as stronger follow-up hardening.
+ *
+ * This file ships the pure, unit-testable boundary primitives.
+ *
+ * @module mcp/tools/improvement-remediation-capability
+ */
+
+import { z } from 'zod';
+
+// @export-no-consumer-yet — see #3618
+// These boundary primitives are consumed by the enforce capstone (#3618), which
+// is explicitly "blocked by" this increment. Built ahead for that named consumer.
+
+/** The three Rule-of-Two legs. No single phase may hold all three. */
+export type Capability = 'untrusted-input' | 'repo-write' | 'secrets';
+
+/** Phases of a remediation run. */
+export type RemediationPhase = 'research' | 'implement';
+
+/**
+ * Declared capability set per phase. By construction NEITHER phase holds all
+ * three legs: RESEARCH reads untrusted content + uses secrets but cannot write;
+ * IMPLEMENT writes + uses secrets but ingests no fresh untrusted input.
+ */
+export const PHASE_CAPABILITIES: Readonly<Record<RemediationPhase, ReadonlySet<Capability>>> = {
+  research: new Set<Capability>(['untrusted-input', 'secrets']),
+  implement: new Set<Capability>(['repo-write', 'secrets']),
+};
+
+/** The forbidden conjunction — holding all of these at once violates Rule-of-Two. */
+export const RULE_OF_TWO_LEGS: readonly Capability[] = ['untrusted-input', 'repo-write', 'secrets'];
+
+/** Thrown when a capability is requested that would violate the boundary. Aborts the run. */
+export class RuleOfTwoViolation extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RuleOfTwoViolation';
+  }
+}
+
+/**
+ * Static invariant: no declared phase may contain all three legs. Guards against
+ * config drift in {@link PHASE_CAPABILITIES}. Call once at startup; throws on drift.
+ */
+export function assertPhaseCapabilitiesSound(): void {
+  for (const [phase, caps] of Object.entries(PHASE_CAPABILITIES)) {
+    if (RULE_OF_TWO_LEGS.every((leg) => caps.has(leg))) {
+      throw new RuleOfTwoViolation(
+        `phase '${phase}' declares all three Rule-of-Two legs (config drift)`
+      );
+    }
+  }
+}
+
+/**
+ * Fail-closed capability ledger. Call {@link assertCapability} at every
+ * chokepoint (untrusted-read / write / secret-read) before performing it. With
+ * no phase entered, every capability is denied (fail-closed).
+ */
+export class CapabilityLedger {
+  private phase: RemediationPhase | undefined;
+
+  /** Enter a phase, setting its declared capability set as active. */
+  enterPhase(phase: RemediationPhase): void {
+    this.phase = phase;
+  }
+
+  /** The active phase, or undefined if none entered. */
+  currentPhase(): RemediationPhase | undefined {
+    return this.phase;
+  }
+
+  /**
+   * Assert that `capability` is permitted right now. Throws {@link RuleOfTwoViolation}
+   * (fail-closed) if no phase is active or the active phase doesn't grant it —
+   * which structurally prevents the forbidden three-leg conjunction, since no
+   * phase grants more than two legs.
+   */
+  assertCapability(capability: Capability): void {
+    if (this.phase === undefined) {
+      throw new RuleOfTwoViolation(
+        `capability '${capability}' requested before any remediation phase was entered (fail-closed)`
+      );
+    }
+    const allowed = PHASE_CAPABILITIES[this.phase];
+    if (!allowed.has(capability)) {
+      throw new RuleOfTwoViolation(
+        `capability '${capability}' is not permitted in phase '${this.phase}' (allowed: ${[...allowed].join(', ')})`
+      );
+    }
+  }
+}
+
+// ============================================================================
+// RemediationPlan — the ONLY artifact allowed to cross RESEARCH → IMPLEMENT.
+// Strict + typed-action allowlist: no free-form/executable/passthrough fields,
+// so untrusted research content cannot ride into the write-capable phase.
+// ============================================================================
+
+/** Allowlisted, non-executable remediation action kinds. */
+export const RemediationActionKindSchema = z.enum([
+  'investigate',
+  'adjust-routing',
+  'add-test',
+  'refactor',
+  'update-docs',
+  'fix-bug',
+]);
+export type RemediationActionKind = z.infer<typeof RemediationActionKindSchema>;
+
+/** One planned step — bounded, inert data (treated as data, never as instructions). */
+export const RemediationStepSchema = z
+  .object({
+    kind: RemediationActionKindSchema,
+    description: z.string().min(1).max(500),
+    /** Optional path hint; bounded inert string, validated for traversal at use. */
+    targetPath: z.string().min(1).max(300).optional(),
+  })
+  .strict();
+export type RemediationStep = z.infer<typeof RemediationStepSchema>;
+
+/**
+ * The typed plan crossing the boundary. `.strict()` rejects unknown keys so no
+ * extra free-form field can smuggle untrusted/executable content across.
+ */
+export const RemediationPlanSchema = z
+  .object({
+    /** Source signal key (mirrors ImprovementSignal.signalKey). */
+    signalKey: z.string().min(1).max(200),
+    /** Signal category (mirrors SignalCategory). */
+    category: z.enum(['routing', 'tech-debt', 'bug', 'security', 'consensus']),
+    summary: z.string().min(1).max(1000),
+    steps: z.array(RemediationStepSchema).min(1).max(20),
+  })
+  .strict();
+export type RemediationPlan = z.infer<typeof RemediationPlanSchema>;
+
+/**
+ * Parse + validate a plan crossing the boundary. Fail-closed: throws
+ * {@link RuleOfTwoViolation} on any schema violation (unknown key, free-form
+ * overflow, bad action kind), so malformed/smuggled plans never reach IMPLEMENT.
+ */
+export function parseRemediationPlan(raw: unknown): RemediationPlan {
+  const result = RemediationPlanSchema.safeParse(raw);
+  if (!result.success) {
+    throw new RuleOfTwoViolation(
+      `RemediationPlan failed strict validation at the RESEARCH→IMPLEMENT boundary: ${result.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ')}`
+    );
+  }
+  return result.data;
+}


### PR DESCRIPTION
Closes #3613. Condition 2 — the load-bearing security hole — of the #3540 auto-invoke gate. Design **ratified 7/7** (higher_order); full condition list recorded on the issue.

## What ships (pure, fail-closed boundary primitives)
- **Typed phase machine** `PHASE_CAPABILITIES`: RESEARCH = {untrusted-input, secrets} (no write); IMPLEMENT = {repo-write, secrets} (no fresh untrusted input). **Neither phase holds all three** Rule-of-Two legs; `assertPhaseCapabilitiesSound()` guards config drift.
- **`CapabilityLedger.assertCapability`** — fail-closed chokepoint guard: throws `RuleOfTwoViolation` if the capability isn't granted by the active phase; denies everything before any phase is entered.
- **Strict `RemediationPlanSchema`** — `.strict()`, allowlisted action kinds, bounded inert fields. The only artifact across RESEARCH→IMPLEMENT, so untrusted content can't smuggle into the write phase. `parseRemediationPlan` fails closed.

## Deferred to the enforce capstone (#3618), per the vote
Guard at **every** chokepoint; **physically** surrender capabilities at the boundary (per-phase adapter lifecycle — ledger as tripwire over a real split); reconcile with ClawGuard/NEXUS_ACCESS_POLICY_MODE. OS process isolation = tracked follow-up.

## Tests
13/13 — no phase holds all 3 legs; ledger fail-closed before/per phase; strict schema rejects unknown keys (incl. in steps), bad kinds, overflow, empty steps. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)