### PR TITLE
feat(capability-loop): secret-less CI for auto-remediation branches (#3614)

### DIFF
--- a/.changeset/secret-less-ci-3614.md
+++ b/.changeset/secret-less-ci-3614.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): secret-less CI for auto-remediation branches (#3614)
+
+Condition 3 of the #3540 auto-invoke gate. A bot-authored remediation branch
+triggering secret-bearing CI would re-introduce the third Rule-of-Two leg
+(secrets) through CI. Establishes the `auto-remediation/` branch convention
+(single source of truth `AUTO_REMEDIATION_BRANCH_PREFIX` +
+`autoRemediationBranchName`, with ref-injection-safe slugging) and gates the
+secret-bearing CI jobs to skip it: the model-API-key `pr-review` job and the
+`CODECOV_TOKEN` upload step now exclude `auto-remediation/` head branches. The
+enforce path (#3618) names branches via the shared convention.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,12 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
+        # #3614: don't expose CODECOV_TOKEN to auto-remediation bot branches
+        # (secret-less CI for the auto-PR path). Prefix kept in sync with
+        # AUTO_REMEDIATION_BRANCH_PREFIX in src/mcp/tools/auto-remediation-branch.ts.
+        if: >-
+          github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' &&
+          !startsWith(github.head_ref, 'auto-remediation/')
         with:
           files: ./packages/nexus-agents/coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -45,7 +45,13 @@ jobs:
     name: Multi-voter PR review
     # OPT-IN: only runs when the `pr-review-ci` label is added.
     # Default is local-mode via scripts/pr-review-local.ts (subscription auth).
-    if: contains(github.event.pull_request.labels.*.name, 'pr-review-ci')
+    # #3614: never run on auto-remediation bot branches — model-API-key secrets
+    # must not be exposed to a bot-authored remediation PR (Rule-of-Two third leg
+    # via CI). Prefix kept in sync with AUTO_REMEDIATION_BRANCH_PREFIX in
+    # src/mcp/tools/auto-remediation-branch.ts.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'pr-review-ci') &&
+      !startsWith(github.event.pull_request.head.ref, 'auto-remediation/')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the auto-remediation branch convention (#3540 inc.2d / #3614).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AUTO_REMEDIATION_BRANCH_PREFIX,
+  isAutoRemediationBranch,
+  autoRemediationBranchName,
+} from './auto-remediation-branch.js';
+
+describe('isAutoRemediationBranch', () => {
+  it('recognizes auto-remediation branches (bare and refs/heads form)', () => {
+    expect(isAutoRemediationBranch('auto-remediation/tech-debt-fitness')).toBe(true);
+    expect(isAutoRemediationBranch('refs/heads/auto-remediation/x')).toBe(true);
+  });
+
+  it('does not match normal branches', () => {
+    expect(isAutoRemediationBranch('main')).toBe(false);
+    expect(isAutoRemediationBranch('feat/some-feature')).toBe(false);
+    expect(isAutoRemediationBranch('fix/auto-remediation-lookalike')).toBe(false);
+  });
+});
+
+describe('autoRemediationBranchName', () => {
+  it('prefixes and slugifies the signal key', () => {
+    const name = autoRemediationBranchName('routing:cli-floor:claude:security_review');
+    expect(name.startsWith(AUTO_REMEDIATION_BRANCH_PREFIX)).toBe(true);
+    expect(isAutoRemediationBranch(name)).toBe(true);
+    expect(name).toMatch(/^auto-remediation\/[a-z0-9._-]+$/);
+  });
+
+  it('strips characters that could enable ref/option injection', () => {
+    const name = autoRemediationBranchName('  --upload-pack=evil ; rm -rf / ');
+    expect(name).toMatch(/^auto-remediation\/[a-z0-9._-]+$/);
+    expect(name).not.toContain(' ');
+    expect(name).not.toContain(';');
+    expect(name).not.toContain('--upload-pack=evil'); // '=' and spaces collapsed
+  });
+
+  it('falls back to a stable name when the key slugs to empty', () => {
+    expect(autoRemediationBranchName('!!!')).toBe('auto-remediation/signal');
+  });
+
+  it('bounds the slug length', () => {
+    const name = autoRemediationBranchName('a'.repeat(500));
+    expect(name.length).toBeLessThanOrEqual(AUTO_REMEDIATION_BRANCH_PREFIX.length + 100);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.ts
@@ -1,0 +1,45 @@
+/**
+ * Auto-remediation branch convention (#3540 inc.2d / #3614).
+ *
+ * Condition 3 of the auto-invoke gate. When the enforce path (#3618) opens a
+ * remediation PR, its branch must be recognizable so CI can run it SECRET-LESS —
+ * a bot-authored branch triggering secret-bearing workflows would re-introduce
+ * the third Rule-of-Two leg (secrets) through CI (#3613 covers the in-process
+ * legs; this covers the CI leg).
+ *
+ * This module is the single source of truth for the branch prefix. The enforce
+ * path (#3618) names branches via {@link autoRemediationBranchName}; CI workflows
+ * gate secret-bearing jobs with the SAME literal prefix (see
+ * `.github/workflows/*.yml` — kept in sync with `AUTO_REMEDIATION_BRANCH_PREFIX`,
+ * since GitHub Actions `if:` expressions can't import TypeScript).
+ *
+ * @module mcp/tools/auto-remediation-branch
+ */
+
+// @export-no-consumer-yet — see #3618
+// The enforce capstone (#3618) creates remediation branches with this convention;
+// built ahead for that named consumer. CI workflows already gate on the literal.
+
+/** Canonical prefix for branches the auto-remediation enforce path creates. */
+export const AUTO_REMEDIATION_BRANCH_PREFIX = 'auto-remediation/';
+
+/** True if `ref` is an auto-remediation branch (accepts bare names or refs/heads/…). */
+export function isAutoRemediationBranch(ref: string): boolean {
+  const name = ref.replace(/^refs\/heads\//, '');
+  return name.startsWith(AUTO_REMEDIATION_BRANCH_PREFIX);
+}
+
+/**
+ * Build the remediation branch name for a source signal. Sanitizes the signalKey
+ * to a git-ref-safe slug (the signalKey is internally generated, but we keep the
+ * ref strictly `[a-z0-9._-]` so it can never produce option-injection or path
+ * traversal in a branch name).
+ */
+export function autoRemediationBranchName(signalKey: string): string {
+  const slug = signalKey
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
+  return `${AUTO_REMEDIATION_BRANCH_PREFIX}${slug || 'signal'}`;
+}


### PR DESCRIPTION
Closes #3614. Condition 3 of the #3540 auto-invoke gate — the CI-level companion to #3613's in-process Rule-of-Two boundary.

## Problem
When the enforce path opens a remediation PR, a bot-authored branch triggering secret-bearing CI workflows would re-introduce the third Rule-of-Two leg (**secrets**) *through CI* — undermining the in-process boundary (#3613).

## Fix
- **Branch convention** (`auto-remediation-branch.ts`): single source of truth `AUTO_REMEDIATION_BRANCH_PREFIX = 'auto-remediation/'`, `isAutoRemediationBranch()`, and `autoRemediationBranchName(signalKey)` with ref-injection-safe slugging (strips spaces/`;`/`--opts`, bounded length, stable fallback). The enforce path (#3618) names branches via this.
- **CI guards**: the secret-bearing jobs now exclude `auto-remediation/` head branches —
  - `pr-review.yml` (ANTHROPIC/OPENAI/GOOGLE/OPENROUTER API keys) — already label-gated; now also `!startsWith(head.ref, 'auto-remediation/')`.
  - `ci.yml` coverage upload (`CODECOV_TOKEN`) — same exclusion.
  YAML `if:` can't import TS, so the literal prefix is kept in sync with the constant (commented in both).

Normal PRs are unaffected (they don't match the prefix). 

## Tests
Convention predicate (bare + refs/heads, non-matches), injection-safe slugging, empty-key fallback, length bound — 6/6. YAML validated. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)