### PR TITLE
feat(capability-loop): fail-closed untrusted-input boundary in the dev-pipeline (#3643)

### DIFF
--- a/.changeset/implement-phase-boundary.md
+++ b/.changeset/implement-phase-boundary.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): fail-closed untrusted-input boundary in the dev-pipeline (#3643)
+
+Closes the Rule-of-Two hole the #3618 capstone vote surfaced: running the
+dev-pipeline inside the IMPLEMENT phase (write+secrets) would let its research
+stage perform a fresh untrusted read, coinciding all three legs. The dev-pipeline
+now takes two opt-in `DevPipelineOptions` (default behavior unchanged):
+
+- `untrustedInputGuard` — called at the RESEARCH chokepoint (the untrusted-read
+  site); the enforce path wires it to `CapabilityLedger.assertCapability('untrusted-input')`
+  so a fresh read in the IMPLEMENT phase throws `RuleOfTwoViolation` (fail-closed);
+- `researchOverride` — runs the pipeline plan-only from the typed RemediationPlan
+  with no untrusted read.
+
+Glue helpers `untrustedInputGuardFor(ledger)` and `renderPlanAsResearch(plan)`
+connect the #3613 ledger to these hooks. Ship-blocking test: an IMPLEMENT-phase
+ledger fail-closes a dev-pipeline untrusted read. Unblocks #3618.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
@@ -13,6 +13,8 @@ import {
   assertPhaseCapabilitiesSound,
   parseRemediationPlan,
   RemediationPlanSchema,
+  untrustedInputGuardFor,
+  renderPlanAsResearch,
   type RemediationPlan,
 } from './improvement-remediation-capability.js';
 
@@ -112,5 +114,37 @@ describe('RemediationPlanSchema (strict boundary artifact)', () => {
   it('rejects unknown keys inside a step', () => {
     const bad = { ...valid, steps: [{ kind: 'fix-bug', description: 'x', patch: 'diff…' }] };
     expect(() => parseRemediationPlan(bad)).toThrow(RuleOfTwoViolation);
+  });
+});
+
+describe('dev-pipeline boundary glue (#3643)', () => {
+  const plan: RemediationPlan = {
+    signalKey: 'routing:cli-floor:codex:docs',
+    category: 'routing',
+    summary: 'Route docs away from the underperforming CLI.',
+    steps: [
+      {
+        kind: 'adjust-routing',
+        description: 'lower codex weight for docs',
+        targetPath: 'src/x.ts',
+      },
+      { kind: 'add-test', description: 'assert routing change' },
+    ],
+  };
+
+  it('untrustedInputGuardFor throws in IMPLEMENT, passes in RESEARCH', () => {
+    const led = new CapabilityLedger();
+    led.enterPhase('implement');
+    expect(untrustedInputGuardFor(led)).toThrow(RuleOfTwoViolation);
+    led.enterPhase('research');
+    expect(untrustedInputGuardFor(led)).not.toThrow();
+  });
+
+  it('renderPlanAsResearch produces inert text containing the plan content', () => {
+    const text = renderPlanAsResearch(plan);
+    expect(text).toContain(plan.signalKey);
+    expect(text).toContain(plan.summary);
+    expect(text).toContain('[adjust-routing]');
+    expect(text).toContain('target: src/x.ts');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
@@ -174,3 +174,36 @@ export function parseRemediationPlan(raw: unknown): RemediationPlan {
   }
   return result.data;
 }
+
+// ============================================================================
+// Dev-pipeline boundary glue (#3643) — wires the ledger + plan into the
+// dev-pipeline's untrusted-input chokepoint hooks (DevPipelineOptions).
+// ============================================================================
+
+/**
+ * Build the dev-pipeline `untrustedInputGuard` from a ledger (#3643). When the
+ * IMPLEMENT-phase ledger is active (no untrusted-input grant), invoking the
+ * returned guard at the research chokepoint throws {@link RuleOfTwoViolation} —
+ * fail-closed, so a fresh untrusted read inside IMPLEMENT cannot proceed.
+ */
+export function untrustedInputGuardFor(ledger: CapabilityLedger): () => void {
+  return () => {
+    ledger.assertCapability('untrusted-input');
+  };
+}
+
+/**
+ * Render a typed {@link RemediationPlan} as plan-only research text (#3643), so
+ * the IMPLEMENT phase can run the dev-pipeline from the plan with NO fresh
+ * untrusted read (passed as `DevPipelineOptions.researchOverride`). All content
+ * is inert plan data — never re-fetched.
+ */
+export function renderPlanAsResearch(plan: RemediationPlan): string {
+  const steps = plan.steps
+    .map((s, i) => {
+      const target = s.targetPath !== undefined ? ` (target: ${s.targetPath})` : '';
+      return `${String(i + 1)}. [${s.kind}] ${s.description}${target}`;
+    })
+    .join('\n');
+  return `Remediation plan for signal '${plan.signalKey}' (category: ${plan.category}).\n\n${plan.summary}\n\nSteps:\n${steps}`;
+}

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -480,3 +480,98 @@ describe('runDevPipeline — quality gate (#3356)', () => {
     expect(result.completed).toBe(true);
   });
 });
+
+// ============================================================================
+// #3643 — fail-closed untrusted-input boundary for the IMPLEMENT phase.
+// ============================================================================
+
+describe('runDevPipeline — untrusted-input boundary (#3643)', () => {
+  it('calls the guard before research; a throwing guard aborts and never reads untrusted input', async () => {
+    const stages = createMockStages();
+    const guard = vi.fn(() => {
+      throw new Error('untrusted-input denied in this phase');
+    });
+
+    await expect(
+      runDevPipeline('Remediate X', stages, { untrustedInputGuard: guard })
+    ).rejects.toThrow(/untrusted-input denied/);
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(stages.research).not.toHaveBeenCalled(); // fail-closed: no untrusted read
+  });
+
+  it('researchOverride runs plan-only — research stage is never called, guard not tripped', async () => {
+    const stages = createMockStages();
+    const guard = vi.fn();
+
+    const result = await runDevPipeline('Remediate X', stages, {
+      researchOverride: 'Plan-only research seeded from the typed RemediationPlan.',
+      untrustedInputGuard: guard,
+    });
+
+    expect(stages.research).not.toHaveBeenCalled(); // no fresh untrusted read
+    expect(guard).not.toHaveBeenCalled(); // override path skips the chokepoint
+    expect(result.completed).toBe(true);
+  });
+
+  it('does not affect normal runs (no guard, no override)', async () => {
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages);
+    expect(stages.research).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+});
+
+describe('runDevPipeline — CapabilityLedger integration (#3643 ship-blocking)', () => {
+  it('IMPLEMENT-phase ledger fail-closes a fresh untrusted read in the dev-pipeline', async () => {
+    const { CapabilityLedger, untrustedInputGuardFor, RuleOfTwoViolation } =
+      await import('../mcp/tools/improvement-remediation-capability.js');
+    const ledger = new CapabilityLedger();
+    ledger.enterPhase('implement'); // write+secrets, NO untrusted-input
+    const stages = createMockStages();
+
+    await expect(
+      runDevPipeline('Remediate X', stages, {
+        untrustedInputGuard: untrustedInputGuardFor(ledger),
+      })
+    ).rejects.toBeInstanceOf(RuleOfTwoViolation);
+    expect(stages.research).not.toHaveBeenCalled();
+  });
+
+  it('IMPLEMENT phase runs plan-only via renderPlanAsResearch with no untrusted read', async () => {
+    const { CapabilityLedger, untrustedInputGuardFor, renderPlanAsResearch, parseRemediationPlan } =
+      await import('../mcp/tools/improvement-remediation-capability.js');
+    const ledger = new CapabilityLedger();
+    ledger.enterPhase('implement');
+    const plan = parseRemediationPlan({
+      signalKey: 'tech-debt:fitness-below-floor',
+      category: 'tech-debt',
+      summary: 'Restore the regressed dimension.',
+      steps: [{ kind: 'add-test', description: 'cover the regressed path' }],
+    });
+    const stages = createMockStages();
+
+    const result = await runDevPipeline('Remediate X', stages, {
+      researchOverride: renderPlanAsResearch(plan),
+      untrustedInputGuard: untrustedInputGuardFor(ledger),
+    });
+
+    expect(stages.research).not.toHaveBeenCalled();
+    expect(result.completed).toBe(true);
+  });
+
+  it('RESEARCH-phase ledger permits the untrusted read', async () => {
+    const { CapabilityLedger, untrustedInputGuardFor } =
+      await import('../mcp/tools/improvement-remediation-capability.js');
+    const ledger = new CapabilityLedger();
+    ledger.enterPhase('research'); // untrusted-input + secrets granted
+    const stages = createMockStages();
+
+    const result = await runDevPipeline('Diagnose X', stages, {
+      untrustedInputGuard: untrustedInputGuardFor(ledger),
+    });
+
+    expect(stages.research).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -193,6 +193,23 @@ export interface DevPipelineOptions {
   readonly qualityGate?: QualityGateMode | undefined;
   /** Optional BeliefMemory for hindsight updates after plan outcomes (#1720). */
   readonly beliefMemory?: IHindsightBeliefMemory | undefined;
+  /**
+   * Fail-closed guard invoked at the RESEARCH stage — the untrusted-read
+   * chokepoint (#3643). The auto-remediation enforce path (#3618) wires this to
+   * `CapabilityLedger.assertCapability('untrusted-input')`, so running the
+   * untrusted research stage inside the write+secrets IMPLEMENT phase throws
+   * (Rule-of-Two). Not called when {@link researchOverride} is set (no untrusted
+   * read happens). Default: undefined (no guard — normal pipeline behavior).
+   */
+  readonly untrustedInputGuard?: (() => void) | undefined;
+  /**
+   * Pre-seeded research text (#3643). When set, the RESEARCH stage uses this
+   * instead of calling `stages.research()` — so the IMPLEMENT phase can run the
+   * pipeline plan-only (from the typed RemediationPlan) with NO fresh untrusted
+   * read, while {@link untrustedInputGuard} still fail-closes any code path that
+   * forgets to seed it.
+   */
+  readonly researchOverride?: string | undefined;
 }
 
 /**
@@ -235,7 +252,7 @@ async function runDevPipelineInner(
   const bm = options?.beliefMemory;
 
   // Phases 1-2: Research + Plan/Vote
-  const { planResult } = await runPlanningPhase(task, stages, sid, prior, bm);
+  const { planResult } = await runPlanningPhase(task, stages, prior, options);
 
   // DRY RUN: stop after plan+vote, return partial result (#1717)
   if (options?.dryRun === true) {
@@ -532,12 +549,41 @@ function buildDryRunResult(planResult: {
 }
 
 /** Phases 1-2: Research + Plan/Vote with checkpoint support. */
+/**
+ * Resolve the RESEARCH stage output (#3643). When `researchOverride` is set, use
+ * it plan-only (no untrusted read). Otherwise the `untrustedInputGuard` is the
+ * fail-closed chokepoint: it runs immediately before the untrusted research
+ * stage, so an active IMPLEMENT-phase ledger throws rather than read.
+ */
+async function resolveResearch(
+  prior: PipelineCheckpointState | null,
+  task: string,
+  stages: DevPipelineStages,
+  options: DevPipelineOptions | undefined
+): Promise<string> {
+  return runOrResume(prior, 'research', () =>
+    withStep(
+      { name: 'research', kind: 'pipeline.stage', attrs: { task: task.slice(0, 100) } },
+      async (ctx) => {
+        const override = options?.researchOverride;
+        if (override !== undefined) {
+          ctx.setSummary(`override: ${String(override.length)} chars`);
+          return override;
+        }
+        options?.untrustedInputGuard?.();
+        const r = await stages.research(task);
+        ctx.setSummary(`${String(r.length)} chars`);
+        return r;
+      }
+    )
+  );
+}
+
 async function runPlanningPhase(
   task: string,
   stages: DevPipelineStages,
-  sid: string | undefined,
   prior: PipelineCheckpointState | null,
-  bm: IHindsightBeliefMemory | undefined
+  options: DevPipelineOptions | undefined
 ): Promise<{
   planResult: {
     plan: string;
@@ -547,16 +593,9 @@ async function runPlanningPhase(
     caveats: readonly string[];
   };
 }> {
-  const research = await runOrResume(prior, 'research', () =>
-    withStep(
-      { name: 'research', kind: 'pipeline.stage', attrs: { task: task.slice(0, 100) } },
-      async (ctx) => {
-        const r = await stages.research(task);
-        ctx.setSummary(`${String(r.length)} chars`);
-        return r;
-      }
-    )
-  );
+  const sid = options?.sessionId;
+  const bm = options?.beliefMemory;
+  const research = await resolveResearch(prior, task, stages, options);
   if (sid !== undefined) saveStageCheckpoint(sid, 'research', { type: 'research', text: research });
 
   const planContext = await assemblePlanContext(research, task, sid, bm);


### PR DESCRIPTION
Closes #3643. Unblocks the #3618 capstone. Closes the Rule-of-Two hole the capstone design vote surfaced (4–3).

## Problem (from the #3618 vote)
Running the existing dev-pipeline inside the IMPLEMENT phase (write+secrets) would let its RESEARCH stage perform a fresh untrusted read — coinciding all three Rule-of-Two legs, bypassing the #3613 ledger (which only guards instrumented call sites).

## Fix — instrument the chokepoint, fail-closed
Two opt-in `DevPipelineOptions` (default pipeline behavior unchanged):
- **`untrustedInputGuard: () => void`** — invoked at the RESEARCH chokepoint (right before `stages.research()`, the untrusted-read site). The enforce path wires it to `CapabilityLedger.assertCapability('untrusted-input')`, so a fresh read while the IMPLEMENT ledger is active throws `RuleOfTwoViolation`.
- **`researchOverride: string`** — runs the pipeline **plan-only** from the typed RemediationPlan, with no untrusted read (and thus no guard trip). If the enforce path forgets the override, the guard still fail-closes.

Glue (in the #3613 capability module): `untrustedInputGuardFor(ledger)` and `renderPlanAsResearch(plan)` connect the ledger + typed plan to these hooks.

## Tests (ship-blocking included)
- Guard called before research; a throwing guard aborts and `stages.research` is never called.
- `researchOverride` → research stage never called; guard not tripped.
- **CapabilityLedger integration:** IMPLEMENT-phase ledger fail-closes a dev-pipeline untrusted read (`RuleOfTwoViolation`); plan-only via `renderPlanAsResearch` runs with no untrusted read; RESEARCH-phase ledger permits it.
- Normal runs unaffected.
Suite 43/43 (incl. all prior dev-pipeline tests); tsc + lint clean.

## Next
Re-vote the #3618 capstone (folding in the secondary conditions: single pre-loop readiness check, cross-process lock, off/audit/enforce ladder, outcome capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)