### PR TITLE
feat(capability-loop): atomic single-flight lease for auto-remediation (#3648)

### DIFF
--- a/.changeset/auto-remediation-lease.md
+++ b/.changeset/auto-remediation-lease.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): atomic single-flight lease for auto-remediation (#3648)
+
+The #3618 capstone vote's one hard concurrency requirement, implemented:
+`makeGitRefLeaseAcquirer` acquires the auto-remediation lease via an ATOMIC
+GitHub git-refs create (`POST .../git/refs`, 422 if it already exists) — the
+create IS the acquisition, so there is no TOCTOU check-then-act window and
+exactly one of two concurrent CI runners wins. Fail-closed: 422 OR any transport
+error → null (not acquired) → the orchestrator aborts rather than risk a
+double-run. Release deletes the ref (best-effort; stale-lock cleanup is #3646).
+The `gh` exec is injected, so it's fully unit-tested without network. Part of the
+#3648 enforce-path wiring; consumed by the entry point still to land.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the atomic auto-remediation lease (#3648 / #3618 condition 1).
+ * The lock is acquired by an atomic ref-create; exactly one of two concurrent
+ * acquirers wins; failure is fail-closed (null).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  makeGitRefLeaseAcquirer,
+  lockRef,
+  type GhRunner,
+  type GhExecResult,
+} from './auto-remediation-lease.js';
+
+function ok(stdout = ''): GhExecResult {
+  return { exitCode: 0, stdout, stderr: '' };
+}
+function fail(stderr = 'HTTP 422: Reference already exists'): GhExecResult {
+  return { exitCode: 1, stdout: '', stderr };
+}
+
+const REPO = 'nexus-substrate/nexus-agents';
+
+describe('makeGitRefLeaseAcquirer', () => {
+  it('acquires via an atomic POST git/refs (create-if-not-exists)', async () => {
+    const gh = vi.fn<GhRunner>(async () => Promise.resolve(ok()));
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 'abc123', gh });
+
+    const lease = await acquire('auto-remediation');
+    expect(lease).not.toBeNull();
+    const call = gh.mock.calls[0]![0];
+    expect(call).toContain('POST');
+    expect(call).toContain(`repos/${REPO}/git/refs`);
+    expect(call).toContain(`ref=${lockRef('auto-remediation')}`);
+    expect(call).toContain('sha=abc123');
+    // No prior existence read — the create IS the acquisition (no TOCTOU).
+    expect(gh).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null fail-closed when the ref already exists (422)', async () => {
+    const gh = vi.fn<GhRunner>(async () => Promise.resolve(fail()));
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 'abc123', gh });
+    expect(await acquire('auto-remediation')).toBeNull();
+  });
+
+  it('returns null fail-closed on a transport error too (never proceeds unsure)', async () => {
+    const gh = vi.fn<GhRunner>(async () => Promise.resolve(fail('HTTP 503: service unavailable')));
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 'abc123', gh });
+    expect(await acquire('auto-remediation')).toBeNull();
+  });
+
+  it('two concurrent acquirers → exactly one wins (atomic create semantics)', async () => {
+    // Shared fake "remote": first create succeeds, subsequent creates 422.
+    const refs = new Set<string>();
+    const gh: GhRunner = (args) => {
+      const isPost = args.includes('POST');
+      const refArg = args.find((a) => a.startsWith('ref='))?.slice('ref='.length) ?? '';
+      if (isPost) {
+        if (refs.has(refArg)) return Promise.resolve(fail()); // already exists
+        refs.add(refArg);
+        return Promise.resolve(ok());
+      }
+      return Promise.resolve(ok());
+    };
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 's', gh });
+
+    const [a, b] = await Promise.all([acquire('auto-remediation'), acquire('auto-remediation')]);
+    const winners = [a, b].filter((x) => x !== null);
+    expect(winners).toHaveLength(1);
+  });
+
+  it('release deletes the ref (best-effort)', async () => {
+    const gh = vi.fn<GhRunner>(async () => Promise.resolve(ok()));
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 'abc', gh });
+    const lease = await acquire('auto-remediation');
+    await lease?.release();
+    const delCall = gh.mock.calls.find((c) => c[0].includes('DELETE'));
+    expect(delCall).toBeDefined();
+    expect(delCall?.[0]).toContain(`repos/${REPO}/git/refs/locks/auto-remediation`); // no leading refs/
+  });
+
+  it('release swallows errors (stale lock recovered separately, #3646)', async () => {
+    let post = true;
+    const gh: GhRunner = () => {
+      if (post) {
+        post = false;
+        return Promise.resolve(ok());
+      }
+      return Promise.resolve(fail('delete failed'));
+    };
+    const acquire = makeGitRefLeaseAcquirer({ repo: REPO, sha: 'abc', gh });
+    const lease = await acquire('auto-remediation');
+    await expect(lease?.release()).resolves.toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.ts
@@ -1,0 +1,127 @@
+/**
+ * Atomic single-flight lease for the auto-remediation enforce path (#3540 inc.2h
+ * wiring / #3648; #3618 condition 1).
+ *
+ * The #3618 capstone vote's one hard concurrency requirement: the lease must be
+ * acquired by an ATOMIC create-if-not-exists, NOT a check-then-act read (which is
+ * TOCTOU — two CI runners both see "no lock" and both proceed). This implements
+ * it via GitHub's git-refs API: `POST .../git/refs` is atomic and returns 422
+ * "Reference already exists" if the ref is already there. So the FIRST mutating
+ * action IS the lock acquisition — exactly one concurrent creator wins.
+ *
+ * Fail-closed: any non-success (422 already-held OR a transport error) yields
+ * `null` (not acquired) → the orchestrator aborts the run rather than risk a
+ * double-run. Release deletes the ref; release errors are swallowed (best-effort)
+ * since a stale lock is recovered by the cleanup story in #3646.
+ *
+ * The `gh` exec is injected so the logic is unit-tested without network/git.
+ *
+ * @module mcp/tools/auto-remediation-lease
+ */
+
+// @export-no-consumer-yet — see #3648
+// Wired into AutoRemediationDeps.acquireLease by the enforce entry point (the
+// remaining #3648 increment). Built first as the most-scrutinized condition.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { ILogger } from '../../core/index.js';
+import type { AcquiredLease } from './improvement-remediation-enforce.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Result of a `gh` invocation. */
+export interface GhExecResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Injected `gh` runner — returns the exit code rather than throwing. */
+export type GhRunner = (args: readonly string[]) => Promise<GhExecResult>;
+
+/** Options for the git-ref lease acquirer. */
+export interface GitRefLeaseOptions {
+  /** `owner/name` repo slug. */
+  readonly repo: string;
+  /** Commit SHA the lock ref points at (any real sha; the value is irrelevant). */
+  readonly sha: string;
+  /** Injected gh runner (defaults to a real, no-shell execFile of `gh`). */
+  readonly gh?: GhRunner;
+  readonly logger?: ILogger;
+}
+
+/** The git ref namespace for auto-remediation locks. */
+export function lockRef(key: string): string {
+  return `refs/locks/${key}`;
+}
+
+/** Default `gh` runner: no-shell execFile, never throws (captures exit code). */
+export const defaultGhRunner: GhRunner = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync('gh', [...args]);
+    return { exitCode: 0, stdout, stderr };
+  } catch (err: unknown) {
+    const e = err as { code?: number; stdout?: string; stderr?: string; message?: string };
+    return {
+      exitCode: typeof e.code === 'number' ? e.code : 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? e.message ?? 'gh failed',
+    };
+  }
+};
+
+/**
+ * Build an {@link AcquiredLease} acquirer that uses an atomic GitHub ref create.
+ * Returns a function matching `AutoRemediationDeps.acquireLease`: it resolves to
+ * a release handle on success, or `null` (fail-closed) when the lock is already
+ * held or the create fails.
+ */
+export function makeGitRefLeaseAcquirer(
+  opts: GitRefLeaseOptions
+): (key: string) => Promise<AcquiredLease | null> {
+  const gh = opts.gh ?? defaultGhRunner;
+  return async (key: string): Promise<AcquiredLease | null> => {
+    const ref = lockRef(key);
+    // Atomic create — 422 if the ref already exists (lock held). This IS the
+    // acquisition; there is no prior existence check (no TOCTOU window).
+    const res = await gh([
+      'api',
+      '-X',
+      'POST',
+      `repos/${opts.repo}/git/refs`,
+      '-f',
+      `ref=${ref}`,
+      '-f',
+      `sha=${opts.sha}`,
+    ]);
+    if (res.exitCode !== 0) {
+      opts.logger?.info('auto-remediation lease not acquired (held or error) — fail-closed', {
+        ref,
+        stderr: res.stderr.slice(0, 200),
+      });
+      return null;
+    }
+    return {
+      release: async (): Promise<void> => {
+        const del = await gh([
+          'api',
+          '-X',
+          'DELETE',
+          `repos/${opts.repo}/git/refs/${stripRefsPrefix(ref)}`,
+        ]);
+        if (del.exitCode !== 0) {
+          opts.logger?.warn('auto-remediation lease release failed (stale lock; see #3646)', {
+            ref,
+            stderr: del.stderr.slice(0, 200),
+          });
+        }
+      },
+    };
+  };
+}
+
+/** The GitHub refs DELETE endpoint omits the leading `refs/`. */
+function stripRefsPrefix(ref: string): string {
+  return ref.replace(/^refs\//, '');
+}


### PR DESCRIPTION
Refs #3648. Implements the #3618 capstone vote's **one hard concurrency requirement** (condition 1).

## Why
A bot remediation run must be single-flight across CI runners. A 'refuse if an auto-remediation branch exists' **check-then-act** is TOCTOU — two runners both see no lock and both proceed. The lease must be acquired by an **atomic create-if-not-exists**.

## What
`makeGitRefLeaseAcquirer({ repo, sha, gh })` → an `AutoRemediationDeps.acquireLease`:
- Acquires via **`POST repos/{repo}/git/refs`** (`refs/locks/<key>`) — atomic; returns **422** if the ref already exists. The create **is** the acquisition (no prior existence read → no TOCTOU window).
- **Fail-closed**: 422 (held) OR any transport error → `null` → the orchestrator aborts rather than risk a double-run.
- `release()` deletes the ref, best-effort (stale-lock cleanup tracked in #3646).
- The `gh` runner is injected → fully unit-tested without network/git.

## Tests
6/6 — atomic POST shape (no existence pre-read), 422 → null, transport-error → null (fail-closed), **two concurrent acquirers → exactly one wins**, release deletes the ref, release swallows errors. tsc + lint clean.

## Remaining #3648
research adapter (signal → RemediationPlan), implement adapter (runDevPipeline + gh PR), and the entry point that wires these + this lease into `runAutoRemediation` — then #3618 closes. Enforce stays owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)