### PR TITLE
feat(capability-loop): priority->consensus-rigor policy for autonomous remediation (#3653)

### DIFF
--- a/.changeset/remediation-priority.md
+++ b/.changeset/remediation-priority.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): priority→consensus-rigor policy for autonomous remediation (#3653)
+
+The pure policy core of the owner-directed, consensus-ratified (7/7) on-by-default
+autonomy work: classify every signal/gap into p0–p4 (security is always p0,
+fail-closed) and map each tier to the consensus rigor required before
+auto-remediation — p0 unanimous + mandatory dry-run, p1 supermajority, p2
+higher_order, p3 simple_majority, p4 file-only. Single authoritative mapping
+(maps to canonical ConsensusAlgorithm values); consumed next by the p0–p4
+auto-filer and the enforce orchestrator's consensus gating.

--- a/packages/nexus-agents/src/mcp/tools/remediation-priority.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-priority.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the priority → consensus-rigor policy (#3653).
+ * Security is always p0; the requirement table maps each tier to a real
+ * ConsensusAlgorithm; p4 is file-only; p0 requires a dry-run.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifySignalPriority,
+  consensusFor,
+  priorityLabel,
+  REMEDIATION_PRIORITIES,
+} from './remediation-priority.js';
+import type { ImprovementSignal } from './improvement-review.js';
+
+function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+  return {
+    category: 'routing',
+    signalKey: 'routing:cli-floor:codex:docs',
+    severity: 'warning',
+    title: 'routing: codex 30% on docs',
+    body: 'floor breach',
+    evidence: {},
+    ...over,
+  };
+}
+
+describe('classifySignalPriority', () => {
+  it('classifies any security signal as p0 (declared category)', () => {
+    expect(classifySignalPriority(signal({ category: 'security', signalKey: 'sec-1' }))).toBe('p0');
+  });
+
+  it('classifies a keyword-detected security signal as p0 (fail-closed via #3615)', () => {
+    expect(
+      classifySignalPriority(
+        signal({ category: 'bug', title: 'authentication bypass / injection' })
+      )
+    ).toBe('p0');
+  });
+
+  it('classifies a critical non-security signal as p0', () => {
+    expect(classifySignalPriority(signal({ severity: 'critical' }))).toBe('p0');
+  });
+
+  it('classifies warning → p2, info → p3', () => {
+    expect(classifySignalPriority(signal({ severity: 'warning' }))).toBe('p2');
+    expect(classifySignalPriority(signal({ severity: 'info' }))).toBe('p3');
+  });
+});
+
+describe('consensusFor', () => {
+  it('p0 = unanimous + dry-run', () => {
+    expect(consensusFor('p0')).toEqual({
+      autoRemediate: true,
+      algorithm: 'unanimous',
+      requiresDryRun: true,
+    });
+  });
+
+  it('rigor relaxes monotonically p0→p3, then p4 is file-only', () => {
+    expect(consensusFor('p1').algorithm).toBe('supermajority');
+    expect(consensusFor('p2').algorithm).toBe('higher_order');
+    expect(consensusFor('p3').algorithm).toBe('simple_majority');
+    expect(consensusFor('p4').autoRemediate).toBe(false);
+    expect(consensusFor('p4').algorithm).toBeUndefined();
+  });
+
+  it('only p0 requires a dry-run', () => {
+    const withDryRun = REMEDIATION_PRIORITIES.filter((p) => consensusFor(p).requiresDryRun);
+    expect(withDryRun).toEqual(['p0']);
+  });
+
+  it('every auto-remediating tier names a real consensus algorithm', () => {
+    for (const p of REMEDIATION_PRIORITIES) {
+      const req = consensusFor(p);
+      expect(req.autoRemediate ? req.algorithm !== undefined : req.algorithm === undefined).toBe(
+        true
+      );
+    }
+  });
+});
+
+describe('priorityLabel', () => {
+  it('labels are the literal tier names', () => {
+    for (const p of REMEDIATION_PRIORITIES) {
+      expect(priorityLabel(p)).toBe(p);
+    }
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-priority.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-priority.ts
@@ -1,0 +1,85 @@
+/**
+ * Priority → consensus-rigor policy for autonomous remediation (#3540 phase 3 / #3653).
+ *
+ * Owner-directed, consensus-ratified (higher_order 7/7): every surfaced gap/idea/
+ * signal is tagged p0–p4 (priority = severity × blast-radius), and the priority
+ * selects the consensus rigor required before the loop may auto-remediate it.
+ * Higher blast-radius ⇒ stricter algorithm + (for p0) a mandatory dry-run; the
+ * lowest tier is file-only (backlog, never auto-remediated).
+ *
+ * This is the pure policy core — the auto-filer (labels), the enforce
+ * orchestrator (gating), and the issue-triage surface all read from here so the
+ * mapping has a single authoritative representation (DRY).
+ *
+ * @module mcp/tools/remediation-priority
+ */
+
+// @export-no-consumer-yet — see #3653
+// The p0–p4 auto-filer (labels) and the enforce orchestrator (consensus gating)
+// consume this policy next; it is the shared authoritative mapping built first.
+
+import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
+import type { ImprovementSignal } from './improvement-review.js';
+import { isSecuritySignal } from './improvement-remediation-shadow.js';
+
+/** Priority tiers, p0 (most critical) → p4 (trivial/idea). */
+export type RemediationPriority = 'p0' | 'p1' | 'p2' | 'p3' | 'p4';
+
+/** All tiers, strictest first. */
+export const REMEDIATION_PRIORITIES: readonly RemediationPriority[] = [
+  'p0',
+  'p1',
+  'p2',
+  'p3',
+  'p4',
+];
+
+/** The GitHub label applied to an auto-filed issue at a given priority. */
+export function priorityLabel(priority: RemediationPriority): string {
+  return priority; // labels are literally `p0`…`p4`
+}
+
+/** The consensus rigor required before auto-remediating a tier. */
+export interface ConsensusRequirement {
+  /** Whether the tier is eligible for auto-remediation at all (p4 = file-only). */
+  readonly autoRemediate: boolean;
+  /** Consensus algorithm to require (undefined when not auto-remediated). */
+  readonly algorithm?: ConsensusAlgorithm;
+  /** p0 additionally requires a green audit-mode dry-run before a PR is opened. */
+  readonly requiresDryRun: boolean;
+}
+
+/**
+ * Priority → consensus requirement. p0 is unanimous + dry-run (security/breaking);
+ * tiers relax down to file-only at p4. Uses the canonical {@link ConsensusAlgorithm}
+ * values so the enforce path passes them straight to `consensus_vote`.
+ */
+const REQUIREMENT_BY_PRIORITY: Readonly<Record<RemediationPriority, ConsensusRequirement>> = {
+  p0: { autoRemediate: true, algorithm: 'unanimous', requiresDryRun: true },
+  p1: { autoRemediate: true, algorithm: 'supermajority', requiresDryRun: false },
+  p2: { autoRemediate: true, algorithm: 'higher_order', requiresDryRun: false },
+  p3: { autoRemediate: true, algorithm: 'simple_majority', requiresDryRun: false },
+  p4: { autoRemediate: false, requiresDryRun: false },
+};
+
+/** Resolve the consensus requirement for a priority tier. */
+export function consensusFor(priority: RemediationPriority): ConsensusRequirement {
+  return REQUIREMENT_BY_PRIORITY[priority];
+}
+
+/**
+ * Classify an improvement signal's priority. Security is ALWAYS p0 (fail-closed,
+ * via {@link isSecuritySignal} which is itself keyword-fail-closed, #3615);
+ * otherwise severity drives the tier. Returns the strictest applicable tier.
+ */
+export function classifySignalPriority(signal: ImprovementSignal): RemediationPriority {
+  if (isSecuritySignal(signal)) return 'p0';
+  switch (signal.severity) {
+    case 'critical':
+      return 'p0';
+    case 'warning':
+      return 'p2';
+    default:
+      return 'p3';
+  }
+}


### PR DESCRIPTION
Refs #3653 (phase-3 epic). The pure policy core of the **on-by-default, consensus-gated** autonomy direction — owner-directed, ratified by consensus_vote (higher_order **7/7**).

## What
- `classifySignalPriority(signal)` → p0–p4. **Security is always p0** (fail-closed via `isSecuritySignal`, #3615); else severity-driven (critical→p0, warning→p2, info→p3).
- `consensusFor(priority)` → the rigor required before auto-remediation, using canonical `ConsensusAlgorithm` values:
  - **p0** unanimous **+ mandatory dry-run** · **p1** supermajority · **p2** higher_order · **p3** simple_majority · **p4** file-only (never auto-remediated).
- Single authoritative mapping (DRY) consumed next by the p0–p4 auto-filer and the enforce orchestrator's consensus gating (replacing the human gates).

## Tests
9/9 — security→p0 (declared + keyword), critical→p0, warning→p2, info→p3; rigor relaxes p0→p4; only p0 requires dry-run; every auto-remediating tier names a real algorithm. tsc + lint clean.

Part of the #3653 roadmap (consensus-gated admission, auto-filer, circuit-breaker, self-mod guard, then default-on after soak). Enforce stays off until the wiring lands + soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)