### PR TITLE
feat(capability-loop): protected-path / self-modification guard (#3653)

### DIFF
--- a/.changeset/protected-paths-guard.md
+++ b/.changeset/protected-paths-guard.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): protected-path / self-modification guard (#3653)
+
+The loop may never autonomously weaken its own safety rails or touch
+auth/secrets/access-control/CI (consensus-vote condition 2). Two layers:
+`isProtectedPath`/`planTouchesProtectedPath` let the enforce path proactively
+refuse a plan that declares a protected target (the loop's own remediation/
+consensus/review modules, .rules, security/auth/secrets, CI workflows), and
+CODEOWNERS is extended to require human review on consensus/ and .rules/ (on top
+of the existing security/pipeline/mcp/workflows coverage) — the hard merge-time
+attestation.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,13 @@
 # MCP server and tool registration
 /packages/nexus-agents/src/mcp/ @williamzujkowski
 
+# Consensus / voter configuration — the loop's own judge (#3653 self-mod guard)
+/packages/nexus-agents/src/consensus/ @williamzujkowski
+
+# Governance rules — Rule-of-Two, untrusted-input, etc. (#3653 self-mod guard)
+/.rules/ @williamzujkowski
+
 # Project governance
 /CLAUDE.md @williamzujkowski
+/AGENTS.md @williamzujkowski
 /CODEOWNERS @williamzujkowski

--- a/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the protected-path / self-modification guard (#3653 condition 2).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isProtectedPath, planTouchesProtectedPath } from './remediation-protected-paths.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+
+describe('isProtectedPath', () => {
+  it('protects the loop’s own safety rails', () => {
+    expect(
+      isProtectedPath('packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts')
+    ).toBe(true);
+    expect(isProtectedPath('src/mcp/tools/remediation-circuit-breaker.ts')).toBe(true);
+    expect(isProtectedPath('src/mcp/tools/auto-remediation-lease.ts')).toBe(true);
+    expect(isProtectedPath('src/mcp/tools/improvement-review.ts')).toBe(true);
+  });
+
+  it('protects consensus/voter config, governance, CI, security/auth/secrets', () => {
+    expect(isProtectedPath('packages/nexus-agents/src/consensus/engine.ts')).toBe(true);
+    expect(isProtectedPath('.rules/untrusted-input.md')).toBe(true);
+    expect(isProtectedPath('.github/workflows/ci.yml')).toBe(true);
+    expect(isProtectedPath('src/security/access-constraint-deriver/index.ts')).toBe(true);
+    expect(isProtectedPath('src/scm/token-resolver.ts')).toBe(true);
+    expect(isProtectedPath('CODEOWNERS')).toBe(true);
+    expect(isProtectedPath('CLAUDE.md')).toBe(true);
+  });
+
+  it('allows ordinary source paths', () => {
+    expect(isProtectedPath('packages/nexus-agents/src/cli/weather.ts')).toBe(false);
+    expect(isProtectedPath('docs/README.md')).toBe(false);
+    expect(isProtectedPath('src/pipeline/templates.ts')).toBe(false);
+  });
+
+  it('matches regardless of slashes / case / leading ./', () => {
+    expect(isProtectedPath('.\\src\\consensus\\Engine.ts')).toBe(true);
+    expect(isProtectedPath('./.RULES/Security.md'.replace('RULES', 'rules'))).toBe(true);
+  });
+});
+
+describe('planTouchesProtectedPath', () => {
+  function plan(targets: (string | undefined)[]): RemediationPlan {
+    return {
+      signalKey: 'k',
+      category: 'tech-debt',
+      summary: 's',
+      steps: targets.map((t) => ({
+        kind: 'refactor' as const,
+        description: 'x',
+        ...(t !== undefined ? { targetPath: t } : {}),
+      })),
+    };
+  }
+
+  it('flags a plan that targets a protected path', () => {
+    const r = planTouchesProtectedPath(plan(['src/x.ts', 'src/consensus/engine.ts']));
+    expect(r.protected).toBe(true);
+    expect(r.paths).toEqual(['src/consensus/engine.ts']);
+  });
+
+  it('passes a plan with only ordinary targets', () => {
+    expect(planTouchesProtectedPath(plan(['src/cli/x.ts', undefined])).protected).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.ts
@@ -1,0 +1,86 @@
+/**
+ * Protected-path / self-modification guard for autonomous remediation
+ * (#3540 phase 3 / #3653, consensus-vote condition 2).
+ *
+ * The loop must NEVER autonomously weaken its own safety rails (runaway guard,
+ * lease, capability boundary, consensus/voter config, the enforce path itself)
+ * or touch auth / secrets / access-control / CI. Two layers enforce this:
+ *
+ *  1. **CODEOWNERS** (the hard human attestation at merge): PRs touching these
+ *     paths require @owner review regardless — see /CODEOWNERS.
+ *  2. **This proactive guard**: the enforce orchestrator checks the typed plan's
+ *     declared targets BEFORE implementing and refuses to auto-remediate one that
+ *     touches a protected path (fail-closed → leaves it for a human). Defense in
+ *     depth on top of CODEOWNERS, since the plan's targets are known up front.
+ *
+ * Pure + dependency-free.
+ *
+ * @module mcp/tools/remediation-protected-paths
+ */
+
+// @export-no-consumer-yet — see #3648
+// The enforce entry point (#3648) calls planTouchesProtectedPath before IMPLEMENT
+// to refuse self-modifying/secret-touching remediations. Built ahead for it.
+
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+
+/**
+ * Path fragments that may NOT be autonomously remediated. Matched as
+ * case-insensitive substrings of a normalized path, so they catch the file
+ * wherever it lives. Covers: the loop's own safety rails, consensus/voter config,
+ * governance rules, CI, and auth/secrets/access-control.
+ */
+export const PROTECTED_PATH_FRAGMENTS: readonly string[] = [
+  // The capability-loop's own machinery (no self-modification).
+  'improvement-remediation',
+  'remediation-priority',
+  'remediation-circuit-breaker',
+  'remediation-protected-paths',
+  'auto-remediation-lease',
+  'improvement-enforce-readiness',
+  'improvement-review',
+  // Consensus / voter configuration (can't weaken its own judge).
+  'src/consensus/',
+  // Governance rules (Rule-of-Two, untrusted-input, etc.).
+  '.rules/',
+  'claude.md',
+  'agents.md',
+  'codeowners',
+  // CI / supply chain (secret exposure).
+  '.github/workflows/',
+  // Security + auth + secrets + access-control.
+  'src/security/',
+  'token-resolver',
+  'access-constraint',
+  'secret',
+  'credential',
+];
+
+/** Normalize a path for matching (forward slashes, lowercase, no leading ./). */
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
+}
+
+/** True if `path` is a protected safety-rail / auth / secrets / CI / governance path. */
+export function isProtectedPath(path: string): boolean {
+  const p = normalize(path);
+  return PROTECTED_PATH_FRAGMENTS.some((frag) => p.includes(frag));
+}
+
+/** Whether a remediation plan declares any protected target, and which. */
+export interface ProtectedPathCheck {
+  readonly protected: boolean;
+  readonly paths: readonly string[];
+}
+
+/**
+ * Inspect a typed {@link RemediationPlan}'s declared step targets for protected
+ * paths. Fail-closed at the enforce path: a true result means "do not
+ * auto-remediate — requires human attestation".
+ */
+export function planTouchesProtectedPath(plan: RemediationPlan): ProtectedPathCheck {
+  const hits = plan.steps
+    .map((s) => s.targetPath)
+    .filter((t): t is string => t !== undefined && isProtectedPath(t));
+  return { protected: hits.length > 0, paths: hits };
+}


### PR DESCRIPTION
Refs #3653 — the vote's condition 2: the loop must never autonomously weaken its own safety rails or touch auth/secrets/access-control/CI.

## Two layers
1. **Proactive plan guard** (this module): `isProtectedPath` / `planTouchesProtectedPath` let the enforce path refuse — fail-closed, leave for a human — any plan whose declared targets hit a protected fragment: the loop's own machinery (improvement-remediation*, remediation-*, auto-remediation-lease, improvement-review/enforce-readiness), `src/consensus/`, `.rules/`, `.github/workflows/`, `src/security/`, token-resolver/access-constraint/secret/credential, CODEOWNERS/CLAUDE.md/AGENTS.md.
2. **CODEOWNERS** (hard merge-time attestation): extended to require @owner review on `src/consensus/` and `.rules/` (on top of the existing security/pipeline/mcp/workflows/CLAUDE.md coverage). Even if a PR is opened, a human must approve protected-path changes.

So the loop can't vote to remove its own guards: the plan guard blocks it up front, and CODEOWNERS blocks the merge.

## Tests
6/6 — rails/consensus/governance/CI/security/auth all protected; ordinary source paths allowed; slash/case-insensitive; plan-target detection.

Next on #3653: the #3648 implement adapter (wires lease + research + implement + vote + breaker + protected-paths into the entry point), then default-on after soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
