### PR TITLE
feat(capability-loop): deterministic research adapter for auto-remediation (#3648)

### DIFF
--- a/.changeset/remediation-research-adapter.md
+++ b/.changeset/remediation-research-adapter.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): deterministic research adapter for auto-remediation (#3648)
+
+`buildRemediationPlanFromSignal` is the RESEARCH-phase adapter: it builds a strict,
+typed RemediationPlan deterministically from the signal's own typed fields
+(investigate → category-specific action → add regression test), performing NO
+fresh untrusted read — so the safest possible research step, with no injection
+surface. Downstream the dev-pipeline's plan→vote→QA stages do the real reasoning
+on this typed plan via the #3643 researchOverride. Part of the #3648 enforce-path
+adapter set.

--- a/packages/nexus-agents/src/mcp/tools/remediation-research.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-research.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the deterministic research adapter (#3648).
+ * Produces a strict, parseable typed plan from a signal — no untrusted read.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRemediationPlanFromSignal } from './remediation-research.js';
+import { parseRemediationPlan } from './improvement-remediation-capability.js';
+import type { ImprovementSignal } from './improvement-review.js';
+
+function sig(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+  return {
+    category: 'routing',
+    signalKey: 'routing:cli-floor:codex:docs',
+    severity: 'warning',
+    title: 'routing: codex 30% on docs',
+    body: 'floor breach',
+    evidence: {},
+    ...over,
+  };
+}
+
+describe('buildRemediationPlanFromSignal', () => {
+  it('produces a plan that passes the strict boundary parser', () => {
+    const plan = buildRemediationPlanFromSignal(sig());
+    expect(() => parseRemediationPlan(plan)).not.toThrow();
+    expect(plan.signalKey).toBe(sig().signalKey);
+    expect(plan.category).toBe('routing');
+  });
+
+  it('maps category → primary action (investigate → action → add-test)', () => {
+    const kinds = (c: ImprovementSignal['category']): string[] =>
+      buildRemediationPlanFromSignal(sig({ category: c })).steps.map((s) => s.kind);
+    expect(kinds('routing')).toEqual(['investigate', 'adjust-routing', 'add-test']);
+    expect(kinds('bug')).toEqual(['investigate', 'fix-bug', 'add-test']);
+    expect(kinds('tech-debt')).toEqual(['investigate', 'refactor', 'add-test']);
+    expect(kinds('security')).toEqual(['investigate', 'investigate', 'add-test']);
+    expect(kinds('consensus')).toEqual(['investigate', 'investigate', 'add-test']);
+  });
+
+  it('clips an over-long title into a schema-safe summary/description', () => {
+    const plan = buildRemediationPlanFromSignal(sig({ title: 'x'.repeat(2000) }));
+    expect(() => parseRemediationPlan(plan)).not.toThrow();
+    expect(plan.summary.length).toBeLessThanOrEqual(1000);
+    expect(plan.steps.every((s) => s.description.length <= 500)).toBe(true);
+  });
+
+  it('is deterministic (no untrusted read / randomness)', () => {
+    expect(buildRemediationPlanFromSignal(sig())).toEqual(buildRemediationPlanFromSignal(sig()));
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-research.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-research.ts
@@ -1,0 +1,71 @@
+/**
+ * Research adapter for the auto-remediation enforce path (#3540 phase 3 / #3648).
+ *
+ * The RESEARCH-phase `AutoRemediationDeps.research` implementation. v1 builds a
+ * STRICT, TYPED {@link RemediationPlan} deterministically from the signal's own
+ * typed fields — it performs NO fresh untrusted read, so the RESEARCH phase's
+ * untrusted-input capability isn't even exercised (the safest possible research
+ * step). The actual implementation reasoning happens downstream in the
+ * dev-pipeline's plan→vote→QA stages, which operate on this typed plan via the
+ * #3643 `researchOverride` (so no untrusted content ever reaches the write phase).
+ *
+ * Because the plan is derived only from the internal signal (never from external
+ * text), there is no injection surface here. A future increment may enrich this
+ * with a real (untrusted-read, RESEARCH-phase) diagnosis behind the
+ * CapabilityLedger; the deterministic version is the safe default.
+ *
+ * @module mcp/tools/remediation-research
+ */
+
+// @export-no-consumer-yet — see #3648
+// Wired into AutoRemediationDeps.research by the enforce entry point (#3648).
+
+import type { ImprovementSignal, SignalCategory } from './improvement-review.js';
+import type {
+  RemediationPlan,
+  RemediationActionKind,
+} from './improvement-remediation-capability.js';
+
+/** The primary remediation action implied by a signal category. */
+const ACTION_BY_CATEGORY: Readonly<Record<SignalCategory, RemediationActionKind>> = {
+  routing: 'adjust-routing',
+  bug: 'fix-bug',
+  'tech-debt': 'refactor',
+  security: 'investigate', // conservative — security is p0/unanimous-gated regardless
+  consensus: 'investigate',
+};
+
+/** Bound a string to a schema-safe length. */
+function clip(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Build a strict typed {@link RemediationPlan} from a signal — deterministic, no
+ * untrusted read. Always: investigate → category-specific action → add a
+ * regression test. The result passes `parseRemediationPlan` by construction.
+ */
+export function buildRemediationPlanFromSignal(signal: ImprovementSignal): RemediationPlan {
+  return {
+    signalKey: signal.signalKey,
+    category: signal.category,
+    summary: clip(`Remediate the surfaced signal: ${signal.title}`, 1000),
+    steps: [
+      {
+        kind: 'investigate',
+        description: clip(`Diagnose the root cause behind "${signal.title}".`, 500),
+      },
+      {
+        kind: ACTION_BY_CATEGORY[signal.category],
+        description: clip(
+          `Address the ${signal.category} issue per the signal's evidence; keep the change minimal.`,
+          500
+        ),
+      },
+      {
+        kind: 'add-test',
+        description: 'Add a regression test that fails without the fix and passes with it.',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Refs #3648. The RESEARCH-phase `AutoRemediationDeps.research` adapter — the safest possible version.

## What
`buildRemediationPlanFromSignal(signal)` builds a **strict, typed `RemediationPlan` deterministically** from the signal's own typed fields: `investigate → {category action} → add regression test`. It performs **no fresh untrusted read**, so the RESEARCH phase's untrusted-input capability isn't even exercised — **no injection surface**. The real implementation reasoning happens downstream in the dev-pipeline's plan→vote→QA stages, operating on this typed plan via the #3643 `researchOverride` (so untrusted content never reaches the write phase).

## Tests
4/4 — passes `parseRemediationPlan` by construction; category→action mapping; over-long title clipped to schema-safe lengths; deterministic. tsc + lint clean.

Remaining #3648 adapters: the vote adapter (wraps `consensus_vote`), the implement adapter (real dev-pipeline + `gh pr create`), and the entry point that wires all deps into `runAutoRemediation`. Then default-on after an audit-mode soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
