### PR TITLE
feat(capability-loop): consensus vote adapter for auto-remediation (#3648)

### DIFF
--- a/.changeset/remediation-vote-adapter.md
+++ b/.changeset/remediation-vote-adapter.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): consensus vote adapter for auto-remediation (#3648)
+
+`makeVoteAdapter` is the `AutoRemediationDeps.vote` implementation — it runs a
+REAL consensus vote (live voters, `simulateVotes` hard-forced false per #2319) at
+the priority-required algorithm via the canonical `executeVoting` path, mapping
+the result to `{ approved, approvalPercentage }`. The voter proposal is the strict
+typed plan rendering (#3613). `buildVoteInput` (exported, tested) guarantees
+no-simulation + correct strategy; the runner is injectable for unit tests.

--- a/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the consensus vote adapter (#3648).
+ * Forces real voters (no simulation); maps outcome → {approved, approvalPercentage}.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { makeVoteAdapter, buildVoteInput, type VoteRunner } from './remediation-vote-adapter.js';
+
+describe('buildVoteInput', () => {
+  it('forces real voters (simulateVotes false) and the requested strategy', () => {
+    const input = buildVoteInput('remediate X', 'unanimous');
+    expect(input.simulateVotes).toBe(false);
+    expect(input.strategy).toBe('unanimous');
+    expect(input.proposal).toBe('remediate X');
+  });
+
+  it('passes through each priority algorithm as the strategy', () => {
+    expect(buildVoteInput('p', 'supermajority').strategy).toBe('supermajority');
+    expect(buildVoteInput('p', 'higher_order').strategy).toBe('higher_order');
+    expect(buildVoteInput('p', 'simple_majority').strategy).toBe('simple_majority');
+  });
+});
+
+describe('makeVoteAdapter', () => {
+  it('forwards proposal + algorithm to the runner and returns its verdict', async () => {
+    const runner = vi.fn<VoteRunner>(async () =>
+      Promise.resolve({ approved: true, approvalPercentage: 100 })
+    );
+    const vote = makeVoteAdapter(runner);
+    const r = await vote({ proposal: 'fix the floor', algorithm: 'higher_order' });
+    expect(r).toEqual({ approved: true, approvalPercentage: 100 });
+    expect(runner).toHaveBeenCalledWith('fix the floor', 'higher_order');
+  });
+
+  it('surfaces a rejection verdict', async () => {
+    const vote = makeVoteAdapter(async () =>
+      Promise.resolve({ approved: false, approvalPercentage: 42 })
+    );
+    expect(await vote({ proposal: 'p', algorithm: 'unanimous' })).toEqual({
+      approved: false,
+      approvalPercentage: 42,
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
@@ -1,0 +1,66 @@
+/**
+ * Consensus vote adapter for the auto-remediation enforce path (#3540 phase 3 / #3648).
+ *
+ * The `AutoRemediationDeps.vote` implementation — it runs a REAL consensus vote
+ * (live voters, never simulated) at the priority-required algorithm (#3653) via
+ * the canonical {@link executeVoting} path, and maps the result to the orchestrator's
+ * `{ approved, approvalPercentage }` shape. The proposal handed to voters is the
+ * strict typed plan rendering (#3613) — no untrusted free-form text.
+ *
+ * `simulateVotes` is hard-forced to false here: auto-remediation must never gate
+ * on random simulated votes (CLAUDE.md / #2319).
+ *
+ * @module mcp/tools/remediation-vote-adapter
+ */
+
+// @export-no-consumer-yet — see #3648
+// Wired into AutoRemediationDeps.vote by the enforce entry point (#3648).
+
+import { createLogger, type ILogger } from '../../core/index.js';
+import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
+import { executeVoting, ConsensusVoteInputSchema } from './consensus-vote.js';
+import type { AutoRemediationDeps } from './improvement-remediation-enforce.js';
+
+/** A runnable vote — abstracted so the adapter is unit-testable without live voters. */
+export type VoteRunner = (
+  proposal: string,
+  algorithm: ConsensusAlgorithm
+) => Promise<{ approved: boolean; approvalPercentage: number }>;
+
+/**
+ * Build the consensus-vote input for a remediation proposal. Forces real voters
+ * (`simulateVotes: false`) and the priority-required strategy. Exported for tests.
+ */
+export function buildVoteInput(
+  proposal: string,
+  algorithm: ConsensusAlgorithm
+): ReturnType<typeof ConsensusVoteInputSchema.parse> {
+  return ConsensusVoteInputSchema.parse({
+    proposal,
+    strategy: algorithm,
+    simulateVotes: false, // never gate auto-remediation on simulated votes
+  });
+}
+
+/** Default runner — the real, live-voter consensus path. */
+function makeDefaultRunner(logger: ILogger): VoteRunner {
+  return async (proposal, algorithm) => {
+    const { result } = await executeVoting(buildVoteInput(proposal, algorithm), logger);
+    return {
+      approved: result.outcome === 'approved',
+      approvalPercentage: result.approvalPercentage,
+    };
+  };
+}
+
+/**
+ * Build the {@link AutoRemediationDeps.vote} adapter. Defaults to the real
+ * live-voter path; tests inject a fake {@link VoteRunner}.
+ */
+export function makeVoteAdapter(
+  runner?: VoteRunner,
+  logger: ILogger = createLogger({ tool: 'auto-remediation-vote' })
+): AutoRemediationDeps['vote'] {
+  const run = runner ?? makeDefaultRunner(logger);
+  return (input) => run(input.proposal, input.algorithm);
+}


### PR DESCRIPTION
Refs #3648. The `AutoRemediationDeps.vote` adapter — the live consensus gate behind the priority-driven admission.

## What
`makeVoteAdapter` runs a **real** consensus vote (live voters) at the priority-required algorithm via the canonical `executeVoting` path, mapping the result to `{ approved, approvalPercentage }`.
- **`simulateVotes` is hard-forced `false`** — auto-remediation must never gate on random simulated votes (#2319 / CLAUDE.md).
- The voter proposal is the **strict typed plan rendering** (#3613), so no untrusted free-form text reaches the voter context.
- `buildVoteInput` (exported, tested) guarantees no-simulation + correct strategy; the runner is injectable so the adapter is unit-tested without spinning up live voters.

## Tests
4/4 — `buildVoteInput` forces `simulateVotes:false` + maps each algorithm to the strategy; adapter forwards proposal/algorithm + surfaces approve/reject verdicts. tsc + lint clean.

Remaining #3648: the implement adapter (real dev-pipeline + `gh pr create`) and the entry point that wires lease + research + vote + implement + breaker + protected-paths into `runAutoRemediation`. Then default-on after an audit-mode soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
