### PR TITLE
feat(capability-loop): auto-remediation deps assembly — audit-ready (#3671)

### DIFF
--- a/.changeset/auto-remediation-deps.md
+++ b/.changeset/auto-remediation-deps.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): auto-remediation deps assembly — audit-ready (#3671)
+
+`buildAutoRemediationDeps` wires the merged adapters (deterministic research,
+live-voter vote, atomic lease, audit logging) into a single AutoRemediationDeps
+for runAutoRemediation. AUDIT-READY now: an audit run executes research →
+consensus vote and stops before IMPLEMENT, producing the soak data the readiness
+gate needs — using only merged pieces. ENFORCE stays fail-closed: `implement` is
+a stub until the Option B proposal-PR adapter (#3669), the lease is null without
+a configured repo/sha, and readiness defaults to not-ready.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the auto-remediation deps assembly (#3671).
+ * Audit-ready (research+vote wired); enforce fail-closed (stub implement,
+ * not-ready readiness, null lease when unconfigured).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
+import { runAutoRemediation } from './improvement-remediation-enforce.js';
+import { RemediationGuard } from './improvement-remediation-guard.js';
+import { parseRemediationPlan, CapabilityLedger } from './improvement-remediation-capability.js';
+import type { ImprovementSignal } from './improvement-review.js';
+
+function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+  return {
+    category: 'routing',
+    signalKey: 'routing:cli-floor:codex:docs',
+    severity: 'warning',
+    title: 'routing: codex 30% on docs',
+    body: 'floor breach',
+    evidence: {},
+    ...over,
+  };
+}
+
+describe('buildAutoRemediationDeps', () => {
+  it('research produces a strict, parseable typed plan', async () => {
+    const deps = buildAutoRemediationDeps();
+    const raw = await deps.research(signal(), new CapabilityLedger());
+    expect(() => parseRemediationPlan(raw)).not.toThrow();
+  });
+
+  it('implement is fail-closed until the Option B adapter lands (#3669)', async () => {
+    const deps = buildAutoRemediationDeps();
+    await expect(
+      deps.implement(
+        parseRemediationPlan(await deps.research(signal(), new CapabilityLedger())),
+        new CapabilityLedger()
+      )
+    ).rejects.toThrow(/not wired yet/);
+  });
+
+  it('lease is null (fail-closed) without a configured repo/sha', async () => {
+    const deps = buildAutoRemediationDeps();
+    expect(await deps.acquireLease('auto-remediation')).toBeNull();
+  });
+
+  it('readiness defaults to not-ready (enforce blocked until evidence is wired)', async () => {
+    const deps = buildAutoRemediationDeps();
+    const ev = await deps.readinessEvidence();
+    expect(ev.shadowSelections).toBe(0);
+  });
+
+  it('drives a full AUDIT run end-to-end on built pieces (soak data, zero writes)', async () => {
+    // audit: research + vote, stop before implement. Inject an approving vote runner.
+    const deps = buildAutoRemediationDeps({
+      voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+    });
+    const implementSpy = vi.spyOn(deps, 'implement');
+    const r = await runAutoRemediation([signal()], deps, {
+      mode: 'audit',
+      now: 0,
+      guard: new RemediationGuard(),
+    });
+    expect(r.mode).toBe('audit');
+    expect(r.plans).toHaveLength(1); // research+vote ran
+    expect(r.remediated).toEqual([]); // no writes in audit
+    expect(implementSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
@@ -1,0 +1,82 @@
+/**
+ * Dependency assembly for the auto-remediation entry point (#3540 phase 3 / #3671).
+ *
+ * Wires the built adapters into a single {@link AutoRemediationDeps} for
+ * {@link runAutoRemediation}. AUDIT-READY NOW: in `audit` mode the orchestrator
+ * runs research → consensus vote and stops before IMPLEMENT, so this assembly
+ * produces the vote/plan SOAK data the readiness gate needs using only merged
+ * pieces. ENFORCE is intentionally NOT yet runnable — `implement` is a
+ * fail-closed stub until the Option B proposal-PR adapter lands (#3669), and
+ * readiness defaults to not-ready until real evidence is supplied.
+ *
+ * @module mcp/tools/auto-remediation-deps
+ */
+
+// @export-no-consumer-yet — see #3671
+// The CLI/MCP entry point (#3671) calls buildAutoRemediationDeps + runAutoRemediation.
+
+import { createLogger, type ILogger } from '../../core/index.js';
+import type { AutoRemediationDeps } from './improvement-remediation-enforce.js';
+import { buildRemediationPlanFromSignal } from './remediation-research.js';
+import { makeVoteAdapter, type VoteRunner } from './remediation-vote-adapter.js';
+import { makeGitRefLeaseAcquirer } from './auto-remediation-lease.js';
+import type { EnforceReadinessEvidence } from './improvement-enforce-readiness.js';
+
+/** Options for assembling the deps. */
+export interface AutoRemediationDepsOptions {
+  /** `owner/name` repo slug — required for the lease (and, later, PRs). */
+  readonly repo?: string;
+  /** Commit SHA the lease ref points at. */
+  readonly sha?: string;
+  /** Supplies readiness evidence (enforce gate). Default: not-ready (enforce blocked). */
+  readonly readiness?: () => Promise<EnforceReadinessEvidence>;
+  /** Inject a vote runner (tests); default is the real live-voter path. */
+  readonly voteRunner?: VoteRunner;
+  readonly logger?: ILogger;
+}
+
+/** Evidence that fails the readiness gate — the safe default until real data is wired. */
+const NOT_READY: EnforceReadinessEvidence = {
+  shadowSelections: 0,
+  judgedSelections: 0,
+  judgedSound: 0,
+};
+
+/**
+ * Assemble {@link AutoRemediationDeps} from the merged adapters. Audit-ready;
+ * enforce stays fail-closed (stub `implement`, not-ready readiness, null lease
+ * when `repo`/`sha` are absent) until the Option B adapter (#3669) + real
+ * readiness evidence are wired.
+ */
+export function buildAutoRemediationDeps(
+  opts: AutoRemediationDepsOptions = {}
+): AutoRemediationDeps {
+  const logger = opts.logger ?? createLogger({ tool: 'auto-remediation' });
+  const acquireLease =
+    opts.repo !== undefined && opts.sha !== undefined
+      ? makeGitRefLeaseAcquirer({ repo: opts.repo, sha: opts.sha, logger })
+      : // Fail-closed: without a configured repo/sha we can't take the cross-process
+        // lease, so enforce must not proceed. (Audit never calls this.)
+        async (): Promise<null> => Promise.resolve(null);
+
+  return {
+    research: (signal) => Promise.resolve(buildRemediationPlanFromSignal(signal)),
+    vote: makeVoteAdapter(opts.voteRunner, logger),
+    acquireLease,
+    readinessEvidence:
+      opts.readiness ?? ((): Promise<EnforceReadinessEvidence> => Promise.resolve(NOT_READY)),
+    implement: (): Promise<never> =>
+      Promise.reject(
+        new Error(
+          'auto-remediation implement adapter not wired yet (Option B, #3669) — enforce unavailable'
+        )
+      ),
+    audit: (event): void => {
+      logger.info(`[auto-remediation] ${event.step}`, {
+        ...(event.signalKey !== undefined ? { signalKey: event.signalKey } : {}),
+        detail: event.detail,
+      });
+    },
+    logger,
+  };
+}


### PR DESCRIPTION
Refs #3671. Wires the merged adapters into a single `AutoRemediationDeps` for `runAutoRemediation`.

## Audit-ready now
`buildAutoRemediationDeps` assembles: deterministic research (typed plan, #3665), live-voter vote (#3666), atomic lease (#3651), audit logging. An **audit** run executes research → consensus vote and stops before IMPLEMENT — producing the **vote/plan soak data** the readiness gate needs, using only merged pieces. So the soak can begin (`NEXUS_AUTO_REMEDIATE=audit`) once the thin entry-point surface lands.

## Enforce stays fail-closed
- `implement` is a stub that **rejects** until the Option B proposal-PR adapter lands (#3669).
- `acquireLease` returns **null** without a configured repo/sha (can't take the cross-process lease → enforce won't proceed).
- `readinessEvidence` defaults to **not-ready**.

So enforce is structurally unavailable until its real deps + evidence are wired — exactly the staged, evidence-gated path.

## Tests
5/5 — research → parseable plan; implement rejects (fail-closed); lease null unconfigured; readiness not-ready; **full end-to-end audit run** (research+vote, zero writes, implement never called). tsc + lint clean.

Remaining #3671: the thin CLI/MCP entry surface (get improvement_review signals → `runAutoRemediation`). Then #3669 (Option B implement) enables enforce after the soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
