### PR TITLE
feat(capability-loop): auto-remediation cycle entry point - audit-runnable (#3671)

### DIFF
--- a/.changeset/auto-remediation-cycle.md
+++ b/.changeset/auto-remediation-cycle.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): auto-remediation cycle entry point — audit-runnable (#3671)
+
+`runAutoRemediationCycle` is the surface a CLI / MCP tool / scheduled job calls:
+resolve the env mode (NEXUS_AUTO_REMEDIATE), and — unless off — collect
+improvement_review signals and run them through runAutoRemediation. OFF-BY-DEFAULT
+(short-circuits before even collecting signals when unset). In `audit` it produces
+the vote/plan soak data end-to-end with zero writes (deps' implement fail-closed
+until #3669); `enforce` stays structurally unavailable until the Option B adapter
+
+- real readiness land. Signal source + deps are injectable for tests.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the auto-remediation cycle entry point (#3671).
+ * Off-by-default short-circuit; audit drives the full path on injected signals/deps.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runAutoRemediationCycle } from './auto-remediation-cycle.js';
+import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
+import type { ImprovementSignal } from './improvement-review.js';
+
+function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+  return {
+    category: 'routing',
+    signalKey: 'routing:cli-floor:codex:docs',
+    severity: 'warning',
+    title: 'routing: codex 30% on docs',
+    body: 'floor breach',
+    evidence: {},
+    ...over,
+  };
+}
+
+describe('runAutoRemediationCycle', () => {
+  it('off mode is a complete no-op — never collects signals', async () => {
+    const collectSignals = vi.fn(async () => Promise.resolve([signal()]));
+    const r = await runAutoRemediationCycle({ mode: 'off' }, { collectSignals });
+    expect(r.mode).toBe('off');
+    expect(collectSignals).not.toHaveBeenCalled();
+  });
+
+  it('audit mode collects signals and runs the path (zero writes)', async () => {
+    const collectSignals = vi.fn(async () => Promise.resolve([signal()]));
+    const deps = buildAutoRemediationDeps({
+      voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+    });
+    const r = await runAutoRemediationCycle({ mode: 'audit' }, { collectSignals, deps });
+    expect(collectSignals).toHaveBeenCalledTimes(1);
+    expect(r.mode).toBe('audit');
+    expect(r.plans).toHaveLength(1); // research+vote ran
+    expect(r.remediated).toEqual([]); // audit writes nothing
+  });
+
+  it('forwards every collected signal to the run', async () => {
+    const signals = [signal({ signalKey: 'a' }), signal({ signalKey: 'b' })];
+    const deps = buildAutoRemediationDeps({
+      voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+    });
+    const r = await runAutoRemediationCycle(
+      { mode: 'audit' },
+      { collectSignals: async () => Promise.resolve(signals), deps }
+    );
+    expect(r.considered).toBe(2);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
@@ -1,0 +1,101 @@
+/**
+ * Auto-remediation entry point (#3540 phase 3 / #3671).
+ *
+ * One cycle: collect the improvement_review signals → assemble deps → run the
+ * env-gated {@link runAutoRemediation}. This is the surface a CLI command / MCP
+ * tool / scheduled job calls. OFF-BY-DEFAULT: with `NEXUS_AUTO_REMEDIATE` unset
+ * it short-circuits before even collecting signals. In `audit` it produces the
+ * vote/plan SOAK data with zero writes (the deps' implement is fail-closed until
+ * #3669); `enforce` is structurally unavailable until the Option B adapter +
+ * real readiness evidence are wired.
+ *
+ * @module mcp/tools/auto-remediation-cycle
+ */
+
+// @export-no-consumer-yet — see #3671
+// Invoked by the CLI/MCP/scheduled surface; the thin registration follows.
+
+import { createLogger, type ILogger } from '../../core/index.js';
+import type { ImprovementSignal } from './improvement-review.js';
+import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';
+import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
+import {
+  runAutoRemediation,
+  resolveAutoRemediateMode,
+  AUTO_REMEDIATE_ENV,
+  type AutoRemediationResult,
+  type AutoRemediateMode,
+  type AutoRemediationDeps,
+} from './improvement-remediation-enforce.js';
+
+/** Cycle configuration. */
+export interface AutoRemediationCycleConfig {
+  /** Override the env-derived mode (tests / explicit runs). */
+  readonly mode?: AutoRemediateMode;
+  /** Repo slug for the lease / PRs (enforce). */
+  readonly repo?: string;
+  /** Commit SHA for the lease ref (enforce). */
+  readonly sha?: string;
+  /** Lookback window (days) for signal collection. */
+  readonly lookbackDays?: number;
+  readonly logger?: ILogger;
+}
+
+/** Injectable collaborators (real defaults; fakes in tests). */
+export interface AutoRemediationCycleInject {
+  readonly collectSignals?: () => Promise<readonly ImprovementSignal[]>;
+  readonly deps?: AutoRemediationDeps;
+}
+
+function offResult(): AutoRemediationResult {
+  return { mode: 'off', considered: 0, skipped: [], plans: [], remediated: [] };
+}
+
+/**
+ * Run one auto-remediation cycle. Resolves the mode from {@link AUTO_REMEDIATE_ENV}
+ * (or config), and — unless `off` — collects improvement_review signals and runs
+ * them through {@link runAutoRemediation}.
+ */
+export async function runAutoRemediationCycle(
+  config: AutoRemediationCycleConfig = {},
+  inject: AutoRemediationCycleInject = {}
+): Promise<AutoRemediationResult> {
+  const logger = config.logger ?? createLogger({ tool: 'auto-remediation' });
+  const mode = config.mode ?? resolveAutoRemediateMode(process.env[AUTO_REMEDIATE_ENV]);
+  if (mode === 'off') {
+    logger.debug('auto-remediation off (NEXUS_AUTO_REMEDIATE unset/off) — no-op');
+    return offResult();
+  }
+
+  const signals = await collectCycleSignals(inject, config, logger);
+  const deps = resolveCycleDeps(inject, config, logger);
+  logger.info(`auto-remediation cycle: ${mode} over ${String(signals.length)} signals`);
+  return runAutoRemediation(signals, deps, { mode });
+}
+
+/** Collect signals via the injected source, or the real improvement_review aggregator. */
+async function collectCycleSignals(
+  inject: AutoRemediationCycleInject,
+  config: AutoRemediationCycleConfig,
+  logger: ILogger
+): Promise<readonly ImprovementSignal[]> {
+  if (inject.collectSignals) return inject.collectSignals();
+  const input = ImprovementReviewInputSchema.parse(
+    config.lookbackDays !== undefined ? { lookbackDays: config.lookbackDays } : {}
+  );
+  return (await runImprovementReview(input, { logger })).signals;
+}
+
+/** Resolve deps via the injected set, or assemble the real ones. */
+function resolveCycleDeps(
+  inject: AutoRemediationCycleInject,
+  config: AutoRemediationCycleConfig,
+  logger: ILogger
+): AutoRemediationDeps {
+  if (inject.deps) return inject.deps;
+  return buildAutoRemediationDeps({
+    ...(config.repo !== undefined ? { repo: config.repo } : {}),
+    ...(config.sha !== undefined ? { sha: config.sha } : {}),
+    logger,
+  });
+}


### PR DESCRIPTION
Refs #3671. The entry surface that makes the system runnable.

## What
`runAutoRemediationCycle(config, inject?)`: resolve the env mode → (unless `off`) collect `improvement_review` signals via the existing aggregator → `buildAutoRemediationDeps` → `runAutoRemediation`.
- **Off-by-default**: with `NEXUS_AUTO_REMEDIATE` unset it short-circuits **before collecting signals** (no cost).
- **`audit`**: runs research → consensus vote end-to-end on real signals, **zero writes** (deps' implement is fail-closed until #3669) — this is the soak.
- **`enforce`**: structurally unavailable until the Option B adapter + real readiness evidence are wired.
- Signal source + deps are injectable, so the cycle is unit-tested without live voters / the OutcomeStore.

## Tests
3/3 — off is a no-op (never collects); audit collects + runs the path (zero writes); every collected signal is forwarded. tsc + lint clean.

Remaining #3671: a thin CLI command / MCP tool that calls `runAutoRemediationCycle` (so `NEXUS_AUTO_REMEDIATE=audit` can start the soak). Then #3669 (Option B implement) → enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
