### PR TITLE
feat(capability-loop): pre-push secret scan for auto-remediation diffs (#3669)

### DIFF
--- a/.changeset/diff-secret-scan.md
+++ b/.changeset/diff-secret-scan.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): pre-push secret scan for auto-remediation diffs (#3669)
+
+Closes THE gap the #3618/#3648 votes flagged: `gh pr create` publishes the branch,
+so a secret in a remediation diff leaks the instant it's pushed — before any
+merge-time guard fires, irreversibly in git history. `scanForSecrets` is an
+in-tree, dependency-free, fail-closed regex scanner (private keys, AWS/GitHub/
+Slack/Google/OpenAI/Anthropic keys, JWTs, generic credential assignments). The
+Option B/A implement adapters run it BEFORE push and abort on any finding;
+findings report pattern + line only, never the secret value.

--- a/packages/nexus-agents/src/mcp/tools/diff-secret-scan.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/diff-secret-scan.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the pre-push secret scan (#3669). Fail-closed; value-free findings.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { scanForSecrets, describeSecretFindings } from './diff-secret-scan.js';
+
+describe('scanForSecrets', () => {
+  it('clean text has zero findings', () => {
+    const r = scanForSecrets('# Remediation plan\n\n1. adjust routing weight for docs\n');
+    expect(r.clean).toBe(true);
+    expect(r.findings).toEqual([]);
+  });
+
+  it('catches common secret shapes (fail-closed)', () => {
+    const cases: Array<[string, string]> = [
+      ['-----BEGIN OPENSSH PRIVATE KEY-----', 'private-key-block'],
+      ['AKIAIOSFODNN7EXAMPLE', 'aws-access-key-id'],
+      ['ghp_' + 'a'.repeat(36), 'github-token'],
+      ['xoxb-123456789012-abcdefghABCD', 'slack-token'],
+      ['sk-ant-' + 'a'.repeat(24), 'anthropic-key'],
+      ['const apiKey = "ABCDEFGHIJKLMNOP1234"', 'generic-credential-assignment'],
+    ];
+    for (const [text, expected] of cases) {
+      const r = scanForSecrets(text);
+      expect(r.clean, `should flag: ${text}`).toBe(false);
+      expect(r.findings.map((f) => f.pattern)).toContain(expected);
+    }
+  });
+
+  it('reports the line number, never the secret value', () => {
+    const r = scanForSecrets(`line one\nAKIAIOSFODNN7EXAMPLE\nline three`);
+    expect(r.findings[0]?.line).toBe(2);
+    expect(describeSecretFindings(r)).toBe('aws-access-key-id@L2');
+    // value-free: the summary must not contain the secret
+    expect(describeSecretFindings(r)).not.toContain('AKIA');
+  });
+
+  it('describeSecretFindings on a clean scan', () => {
+    expect(describeSecretFindings(scanForSecrets('all good'))).toBe('no secrets detected');
+  });
+
+  it('does not flag ordinary prose / short tokens', () => {
+    expect(
+      scanForSecrets('the token bus carries events; api key rotation is documented').clean
+    ).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
+++ b/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
@@ -1,0 +1,77 @@
+/**
+ * Pre-push secret scan for auto-remediation diffs (#3540 phase 3 / #3669).
+ *
+ * The #3618/#3648 consensus votes flagged THE gap the merge-time safeguards miss:
+ * `gh pr create` PUBLISHES the branch, so a secret a remediation writes into the
+ * diff is leaked the instant it's pushed — before never-auto-merge / CODEOWNERS /
+ * the breaker ever fire, and irreversibly in git history. So the auto-remediation
+ * implement adapters MUST scan the staged content BEFORE push and fail closed.
+ *
+ * This is an in-tree, dependency-free regex scanner (gitleaks/trufflehog can be
+ * layered on top later). Fail-closed: any match → not clean → the adapter aborts
+ * the push.
+ *
+ * @module mcp/tools/diff-secret-scan
+ */
+
+// @export-no-consumer-yet — see #3669
+// The Option B / Option A implement adapters call scanForSecrets before push.
+
+/** A known secret shape. */
+interface SecretPattern {
+  readonly name: string;
+  readonly re: RegExp;
+}
+
+/** High-signal secret patterns (kept conservative to limit false positives). */
+const SECRET_PATTERNS: readonly SecretPattern[] = [
+  { name: 'private-key-block', re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  { name: 'aws-access-key-id', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'github-token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/ },
+  { name: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { name: 'google-api-key', re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: 'openai-key', re: /\bsk-[A-Za-z0-9]{32,}\b/ },
+  { name: 'anthropic-key', re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/ },
+  { name: 'jwt', re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
+  // Generic `secret/token/password/api_key = "long-value"` assignments.
+  {
+    name: 'generic-credential-assignment',
+    re: /(?:api[_-]?key|secret|token|password|passwd|credential)\s*[:=]\s*["'][A-Za-z0-9/+_-]{16,}["']/i,
+  },
+];
+
+/** One secret finding (the matched pattern + a redacted locator). */
+export interface SecretFinding {
+  readonly pattern: string;
+  /** 1-based line number within the scanned text. */
+  readonly line: number;
+}
+
+/** Scan result. `clean` is true only when there are zero findings. */
+export interface SecretScanResult {
+  readonly clean: boolean;
+  readonly findings: readonly SecretFinding[];
+}
+
+/**
+ * Scan text (e.g. a unified diff or a file's contents) for secrets. Fail-closed:
+ * the caller treats `clean === false` as "do not push". Findings report the
+ * pattern name + line only — never the secret value.
+ */
+export function scanForSecrets(text: string): SecretScanResult {
+  const findings: SecretFinding[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    for (const { name, re } of SECRET_PATTERNS) {
+      if (re.test(line)) findings.push({ pattern: name, line: i + 1 });
+    }
+  }
+  return { clean: findings.length === 0, findings };
+}
+
+/** Human-readable, value-free summary of a scan result. */
+export function describeSecretFindings(result: SecretScanResult): string {
+  if (result.clean) return 'no secrets detected';
+  return result.findings.map((f) => `${f.pattern}@L${String(f.line)}`).join(', ');
+}


### PR DESCRIPTION
Refs #3669. Closes **the one gap** the #3618 and #3648 consensus votes both flagged.

## The gap
`gh pr create` **publishes** the branch. A secret a remediation writes into the diff is leaked the **instant it's pushed** — before never-auto-merge / CODEOWNERS / the breaker ever fire, and **irreversibly** in git history. None of the merge-time safeguards cover it.

## Fix
`scanForSecrets(text)` — in-tree, dependency-free, **fail-closed** regex scanner: private-key blocks, AWS/GitHub/Slack/Google/OpenAI/Anthropic keys, JWTs, and generic `secret/token/password/api_key = "…"` assignments. The Option B/A implement adapters run it on the staged diff **before push** and abort on any finding. Findings report **pattern + line only — never the secret value**. (gitleaks/trufflehog can be layered later; this is the always-available floor.)

## Tests
5/5 — clean text; each secret shape flagged; line-numbered value-free findings; ordinary prose not flagged. tsc + lint clean.

First piece of #3669 (Option B proposal-PR adapter); the git-worktree + commit + `gh pr create` machinery follows, using this scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
