### PR TITLE
feat(capability-loop): add Option B proposal-PR implement adapter (#3669)

### DIFF
--- a/.changeset/proposal-pr-adapter.md
+++ b/.changeset/proposal-pr-adapter.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): Option B proposal-PR implement adapter (#3669)
+
+The v1 `AutoRemediationDeps.implement` (per the #3648 vote, B→soak→A): commits the
+consensus-approved typed plan as a reviewable `remediation-plans/<slug>.md` doc on
+an `auto-remediation/<slug>` branch and opens a DRAFT PR — never auto-merged, no
+autonomous code edits. Safety: the doc is **secret-scanned before any push**
+(#3669 fail-closed), all writes happen in an **isolated git worktree** removed in
+`finally`, and it asserts the IMPLEMENT-phase repo-write capability (fail-closed
+out of phase). Orchestration is injectable + unit-tested; real git/gh impls
+(`makeGitWorktreeOps`, `makeGhPrCreator`) ship for the enforce path (owner-gated).

--- a/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the Option B proposal-PR adapter (#3669).
+ * Secret-scan before any side effect (fail-closed); isolated worktree; cleanup in finally.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  makeProposalPrImplementAdapter,
+  buildProposalDoc,
+  type WorktreeOps,
+  type PrCreator,
+} from './remediation-proposal-pr.js';
+import { CapabilityLedger } from './improvement-remediation-capability.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+
+function plan(over: Partial<RemediationPlan> = {}): RemediationPlan {
+  return {
+    signalKey: 'routing:cli-floor:codex:docs',
+    category: 'routing',
+    summary: 'Route docs away from the underperformer.',
+    steps: [{ kind: 'adjust-routing', description: 'lower codex docs weight' }],
+    ...over,
+  };
+}
+
+function implementLedger(): CapabilityLedger {
+  const l = new CapabilityLedger();
+  l.enterPhase('implement');
+  return l;
+}
+
+function fakeOps(): { ops: WorktreeOps; calls: string[] } {
+  const calls: string[] = [];
+  const ops: WorktreeOps = {
+    addWorktree: vi.fn(async (b: string) => {
+      calls.push(`add:${b}`);
+      return Promise.resolve(`/wt/${b.replace(/\//g, '_')}`);
+    }),
+    writeFileIn: vi.fn(async (_wt: string, rel: string) => {
+      calls.push(`write:${rel}`);
+      return Promise.resolve();
+    }),
+    commitAll: vi.fn(async () => {
+      calls.push('commit');
+      return Promise.resolve();
+    }),
+    pushBranch: vi.fn(async (_wt: string, b: string) => {
+      calls.push(`push:${b}`);
+      return Promise.resolve();
+    }),
+    removeWorktree: vi.fn(async () => {
+      calls.push('remove');
+      return Promise.resolve();
+    }),
+  };
+  return { ops, calls };
+}
+
+const okPr: PrCreator = { createDraftPr: vi.fn(async () => Promise.resolve('https://pr/9')) };
+
+describe('buildProposalDoc', () => {
+  it('renders an inert markdown proposal containing the plan', () => {
+    const doc = buildProposalDoc(plan());
+    expect(doc).toContain(plan().signalKey);
+    expect(doc).toContain('proposal');
+    expect(doc).toContain('[adjust-routing]');
+  });
+});
+
+describe('makeProposalPrImplementAdapter', () => {
+  it('worktree → write → commit → push → PR → cleanup, in order', async () => {
+    const { ops, calls } = fakeOps();
+    const implement = makeProposalPrImplementAdapter({ ops, pr: okPr });
+    const r = await implement(plan(), implementLedger());
+    expect(r.prUrl).toBe('https://pr/9');
+    expect(r.branch).toBe('auto-remediation/routing-cli-floor-codex-docs');
+    expect(calls).toEqual([
+      'add:auto-remediation/routing-cli-floor-codex-docs',
+      'write:remediation-plans/routing-cli-floor-codex-docs.md',
+      'commit',
+      'push:auto-remediation/routing-cli-floor-codex-docs',
+      'remove',
+    ]);
+  });
+
+  it('aborts BEFORE any side effect when the plan doc trips the secret scan', async () => {
+    const { ops, calls } = fakeOps();
+    const implement = makeProposalPrImplementAdapter({
+      ops,
+      pr: okPr,
+      scan: () => ({ clean: false, findings: [{ pattern: 'github-token', line: 3 }] }),
+    });
+    await expect(implement(plan(), implementLedger())).rejects.toThrow(/secrets in plan doc/);
+    expect(calls).toEqual([]); // no worktree, no push
+  });
+
+  it('removes the worktree even if push fails', async () => {
+    const { ops, calls } = fakeOps();
+    (ops.pushBranch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('push boom'));
+    const implement = makeProposalPrImplementAdapter({ ops, pr: okPr });
+    await expect(implement(plan(), implementLedger())).rejects.toThrow('push boom');
+    expect(calls).toContain('remove'); // finally cleanup ran
+  });
+
+  it('fail-closes if invoked outside the IMPLEMENT phase (no repo-write capability)', async () => {
+    const { ops } = fakeOps();
+    const researchLedger = new CapabilityLedger();
+    researchLedger.enterPhase('research'); // no repo-write
+    const implement = makeProposalPrImplementAdapter({ ops, pr: okPr });
+    await expect(implement(plan(), researchLedger)).rejects.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.ts
@@ -1,0 +1,193 @@
+/**
+ * Option B implement adapter — consensus-approved PROPOSAL PR (#3540 phase 3 / #3669).
+ *
+ * The v1 `AutoRemediationDeps.implement`, per the #3648 vote (B→soak→A). It does
+ * NOT autonomously edit code; it commits the consensus-approved typed plan as a
+ * reviewable `remediation-plans/<slug>.md` doc on an `auto-remediation/<slug>`
+ * branch and opens a draft PR (never auto-merged). A human/coder implements.
+ *
+ * Safety (vote conditions): the plan doc is **secret-scanned before any push**
+ * (#3669 fail-closed — the one gap merge-time guards miss); all writes happen in
+ * an **isolated git worktree** (never the live checkout), removed in `finally`
+ * so a failed run can't corrupt working state. Orchestration is injectable
+ * ({@link WorktreeOps} / {@link PrCreator}) so it's unit-tested without real git.
+ *
+ * @module mcp/tools/remediation-proposal-pr
+ */
+
+// @export-no-consumer-yet — see #3648
+// Wired as AutoRemediationDeps.implement by the enforce entry point once Option B
+// is enabled (still owner-gated by NEXUS_AUTO_REMEDIATE=enforce + readiness).
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { createLogger, type ILogger } from '../../core/index.js';
+import type {
+  AutoRemediationDeps,
+  RemediationPrResult,
+} from './improvement-remediation-enforce.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+import { renderPlanAsResearch, CapabilityLedger } from './improvement-remediation-capability.js';
+import { autoRemediationBranchName } from './auto-remediation-branch.js';
+import {
+  scanForSecrets,
+  describeSecretFindings,
+  type SecretScanResult,
+} from './diff-secret-scan.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Isolated-worktree git operations (injected; real impl uses execFile git). */
+export interface WorktreeOps {
+  /** Create an isolated worktree on a NEW branch off `baseBranch`; returns its path. */
+  addWorktree(branch: string, baseBranch: string): Promise<string>;
+  /** Write `relPath` (under the worktree) with `content`. */
+  writeFileIn(worktreePath: string, relPath: string, content: string): Promise<void>;
+  /** Stage all + commit in the worktree. */
+  commitAll(worktreePath: string, message: string): Promise<void>;
+  /** Push `branch` to origin from the worktree. */
+  pushBranch(worktreePath: string, branch: string): Promise<void>;
+  /** Remove the worktree (best-effort cleanup). */
+  removeWorktree(worktreePath: string): Promise<void>;
+}
+
+/** PR creation (injected; real impl uses `gh pr create`). */
+export interface PrCreator {
+  createDraftPr(input: {
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body: string;
+  }): Promise<string>;
+}
+
+/** Render the proposal doc (markdown) from the typed plan. Inert; no untrusted text. */
+export function buildProposalDoc(plan: RemediationPlan): string {
+  return (
+    `# Auto-remediation proposal — \`${plan.signalKey}\`\n\n` +
+    `> Consensus-approved remediation **proposal** (not auto-implemented). A human ` +
+    `or coder implements the steps below; this PR is the reviewable plan.\n\n` +
+    `${renderPlanAsResearch(plan)}\n`
+  );
+}
+
+function planSlug(signalKey: string): string {
+  return autoRemediationBranchName(signalKey).replace(/^auto-remediation\//, '');
+}
+
+/** Options for the proposal-PR adapter. */
+export interface ProposalPrAdapterOptions {
+  readonly baseBranch?: string;
+  readonly ops: WorktreeOps;
+  readonly pr: PrCreator;
+  /** Secret scanner (default {@link scanForSecrets}). */
+  readonly scan?: (text: string) => SecretScanResult;
+  readonly logger?: ILogger;
+}
+
+/**
+ * Build the Option B {@link AutoRemediationDeps.implement} adapter. Secret-scans
+ * the plan doc BEFORE any push (fail-closed), writes it in an isolated worktree,
+ * commits, pushes, opens a draft PR, and removes the worktree in `finally`.
+ */
+export function makeProposalPrImplementAdapter(
+  opts: ProposalPrAdapterOptions
+): AutoRemediationDeps['implement'] {
+  const scan = opts.scan ?? scanForSecrets;
+  const baseBranch = opts.baseBranch ?? 'main';
+  const logger = opts.logger ?? createLogger({ tool: 'auto-remediation-pr' });
+
+  return async (plan: RemediationPlan, ledger: CapabilityLedger): Promise<RemediationPrResult> => {
+    ledger.assertCapability('repo-write'); // IMPLEMENT phase — fail-closed if wrong phase
+    const branch = autoRemediationBranchName(plan.signalKey);
+    const doc = buildProposalDoc(plan);
+
+    // Pre-push secret scan (#3669) — abort before ANY worktree/push side effect.
+    const result = scan(doc);
+    if (!result.clean) {
+      throw new Error(
+        `proposal PR aborted — secrets in plan doc: ${describeSecretFindings(result)}`
+      );
+    }
+
+    const worktree = await opts.ops.addWorktree(branch, baseBranch);
+    try {
+      await opts.ops.writeFileIn(worktree, `remediation-plans/${planSlug(plan.signalKey)}.md`, doc);
+      await opts.ops.commitAll(worktree, `chore(auto-remediation): proposal for ${plan.signalKey}`);
+      await opts.ops.pushBranch(worktree, branch);
+      const prUrl = await opts.pr.createDraftPr({
+        branch,
+        baseBranch,
+        title: `auto-remediation proposal: ${plan.signalKey}`,
+        body: doc,
+      });
+      logger.info('auto-remediation proposal PR opened', { branch, prUrl });
+      return { branch, prUrl };
+    } finally {
+      await opts.ops.removeWorktree(worktree).catch((err: unknown) => {
+        logger.warn('worktree cleanup failed (non-fatal)', {
+          worktree,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  };
+}
+
+// ============================================================================
+// Real git/gh implementations (execFile, no shell). Side-effecting — not
+// unit-tested; the orchestration above is. Used only under enforce (owner-gated).
+// ============================================================================
+
+/** Real worktree ops via `git` (no shell). `repoRoot` is the live checkout. */
+export function makeGitWorktreeOps(repoRoot: string): WorktreeOps {
+  const git = async (args: readonly string[], cwd: string): Promise<void> => {
+    await execFileAsync('git', [...args], { cwd });
+  };
+  return {
+    async addWorktree(branch, baseBranch) {
+      const path = join(repoRoot, '.nexus-worktrees', branch.replace(/\//g, '_'));
+      await git(['worktree', 'add', '-b', branch, path, baseBranch], repoRoot);
+      return path;
+    },
+    async writeFileIn(worktreePath, relPath, content) {
+      const abs = join(worktreePath, relPath);
+      await mkdir(dirname(abs), { recursive: true });
+      await writeFile(abs, content, 'utf8');
+    },
+    async commitAll(worktreePath, message) {
+      await git(['add', '-A'], worktreePath);
+      await git(['commit', '-m', message], worktreePath);
+    },
+    async pushBranch(worktreePath, branch) {
+      await git(['push', '-u', 'origin', branch], worktreePath);
+    },
+    async removeWorktree(worktreePath) {
+      await git(['worktree', 'remove', worktreePath, '--force'], repoRoot);
+    },
+  };
+}
+
+/** Real PR creation via `gh pr create --draft` (no shell). */
+export function makeGhPrCreator(): PrCreator {
+  return {
+    async createDraftPr({ branch, baseBranch, title, body }) {
+      const { stdout } = await execFileAsync('gh', [
+        'pr',
+        'create',
+        '--draft',
+        '--head',
+        branch,
+        '--base',
+        baseBranch,
+        '--title',
+        title,
+        '--body',
+        body,
+      ]);
+      return stdout.trim();
+    },
+  };
+}


### PR DESCRIPTION
Refs #3669. The v1 `AutoRemediationDeps.implement`, per the #3648 vote (B→soak→A).

## What
`makeProposalPrImplementAdapter`: commits the consensus-approved **typed plan** as a `remediation-plans/<slug>.md` doc on an `auto-remediation/<slug>` branch + opens a **draft PR** (never auto-merged). No autonomous code edits — a human implements; the PR is the reviewable vote-approved plan.

## Safety (vote conditions)
- **Secret-scan before any push** (fail-closed) — aborts before worktree/push if the doc trips `scanForSecrets`.
- **Isolated git worktree**, removed in `finally` — a failed run can't corrupt working state.
- Asserts the IMPLEMENT-phase `repo-write` capability (fail-closed out of phase).
- Injectable orchestration (`WorktreeOps`/`PrCreator`) → unit-tested without real git; real impls ship for the enforce path.

## Tests
5/5 — order; secret-scan aborts before side effects; cleanup-on-push-failure; fail-closed out of phase. tsc + lint clean.

Option B complete. Next: wire it into the deps builder so enforce is runnable, then audit soak → readiness vote → Option A (#3670) / default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
