### PR TITLE
feat(capability-loop): wire Option B proposal-PR adapter into the deps builder (#3669)

### DIFF
--- a/.changeset/wire-option-b-deps.md
+++ b/.changeset/wire-option-b-deps.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(capability-loop): wire Option B proposal-PR adapter into the deps builder (#3669)
+
+`buildAutoRemediationDeps` now wires the real `implement` to the Option B
+proposal-PR adapter (isolated worktree + secret-scan + draft PR) when both a
+`repo` slug and a `repoRoot` (live checkout) are configured. Otherwise `implement`
+stays a rejecting stub — so enforce is fail-closed until deliberately configured.
+Completes #3669: the auto-remediation path can now produce consensus-approved
+proposal PRs under `NEXUS_AUTO_REMEDIATE=enforce` (still owner-gated + readiness-
+gated). The audit soak remains the next operational step.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
@@ -30,14 +30,25 @@ describe('buildAutoRemediationDeps', () => {
     expect(() => parseRemediationPlan(raw)).not.toThrow();
   });
 
-  it('implement is fail-closed until the Option B adapter lands (#3669)', async () => {
-    const deps = buildAutoRemediationDeps();
+  it('implement is fail-closed when repo/repoRoot are not configured (#3669)', async () => {
+    const deps = buildAutoRemediationDeps(); // no repoRoot
     await expect(
       deps.implement(
         parseRemediationPlan(await deps.research(signal(), new CapabilityLedger())),
         new CapabilityLedger()
       )
-    ).rejects.toThrow(/not wired yet/);
+    ).rejects.toThrow(/not wired/);
+  });
+
+  it('wires the Option B proposal-PR adapter when repo + repoRoot are configured', async () => {
+    const deps = buildAutoRemediationDeps({ repo: 'o/n', repoRoot: '/repo', sha: 'abc' });
+    // It's no longer the rejecting stub — calling would attempt real git, so just
+    // assert the fail-closed stub message is gone (a real adapter is wired).
+    const ledger = new CapabilityLedger();
+    ledger.enterPhase('research'); // wrong phase → the real adapter fail-closes on capability
+    await expect(
+      deps.implement(parseRemediationPlan(await deps.research(signal(), ledger)), ledger)
+    ).rejects.toThrow(/capability|not permitted/);
   });
 
   it('lease is null (fail-closed) without a configured repo/sha', async () => {

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
@@ -20,14 +20,23 @@ import type { AutoRemediationDeps } from './improvement-remediation-enforce.js';
 import { buildRemediationPlanFromSignal } from './remediation-research.js';
 import { makeVoteAdapter, type VoteRunner } from './remediation-vote-adapter.js';
 import { makeGitRefLeaseAcquirer } from './auto-remediation-lease.js';
+import {
+  makeProposalPrImplementAdapter,
+  makeGitWorktreeOps,
+  makeGhPrCreator,
+} from './remediation-proposal-pr.js';
 import type { EnforceReadinessEvidence } from './improvement-enforce-readiness.js';
 
 /** Options for assembling the deps. */
 export interface AutoRemediationDepsOptions {
-  /** `owner/name` repo slug — required for the lease (and, later, PRs). */
+  /** `owner/name` repo slug — required for the lease + PRs. */
   readonly repo?: string;
   /** Commit SHA the lease ref points at. */
   readonly sha?: string;
+  /** Live checkout root — required to wire the Option B proposal-PR implement adapter. */
+  readonly repoRoot?: string;
+  /** Base branch for proposal PRs (default 'main'). */
+  readonly baseBranch?: string;
   /** Supplies readiness evidence (enforce gate). Default: not-ready (enforce blocked). */
   readonly readiness?: () => Promise<EnforceReadinessEvidence>;
   /** Inject a vote runner (tests); default is the real live-voter path. */
@@ -59,18 +68,30 @@ export function buildAutoRemediationDeps(
         // lease, so enforce must not proceed. (Audit never calls this.)
         async (): Promise<null> => Promise.resolve(null);
 
+  // Option B proposal-PR adapter — wired only when a live checkout (repoRoot) AND
+  // repo slug are configured. Otherwise enforce stays fail-closed (rejecting stub).
+  const implement: AutoRemediationDeps['implement'] =
+    opts.repoRoot !== undefined && opts.repo !== undefined
+      ? makeProposalPrImplementAdapter({
+          ops: makeGitWorktreeOps(opts.repoRoot),
+          pr: makeGhPrCreator(),
+          ...(opts.baseBranch !== undefined ? { baseBranch: opts.baseBranch } : {}),
+          logger,
+        })
+      : (): Promise<never> =>
+          Promise.reject(
+            new Error(
+              'auto-remediation implement not wired — set repo + repoRoot to enable Option B (#3669)'
+            )
+          );
+
   return {
     research: (signal) => Promise.resolve(buildRemediationPlanFromSignal(signal)),
     vote: makeVoteAdapter(opts.voteRunner, logger),
     acquireLease,
     readinessEvidence:
       opts.readiness ?? ((): Promise<EnforceReadinessEvidence> => Promise.resolve(NOT_READY)),
-    implement: (): Promise<never> =>
-      Promise.reject(
-        new Error(
-          'auto-remediation implement adapter not wired yet (Option B, #3669) — enforce unavailable'
-        )
-      ),
+    implement,
     audit: (event): void => {
       logger.info(`[auto-remediation] ${event.step}`, {
         ...(event.signalKey !== undefined ? { signalKey: event.signalKey } : {}),


### PR DESCRIPTION
Closes #3669. The final wire — `enforce` can now produce proposal PRs.

## What
`buildAutoRemediationDeps` wires the real `implement` to the Option B proposal-PR adapter (isolated worktree + pre-push secret-scan + draft PR) **only when both `repo` and `repoRoot` (live checkout) are configured**. Otherwise `implement` stays a rejecting stub.

So enforce remains **fail-closed by configuration** (no repoRoot → can't implement), on top of the existing gates (env exact-match, readiness, atomic lease, breaker, protected-paths, p0 dry-run).

## Tests
6/6 — no-config implement rejects (fail-closed); configured → the real Option B adapter is wired (fail-closes on wrong phase, proving it's the capability-checked adapter not the stub); audit run unaffected. tsc + lint clean.

## State — the staged path is fully wired
1. `NEXUS_AUTO_REMEDIATE=audit nexus-agents auto-remediate` → soak (zero writes).
2. Readiness vote on soak evidence → flip Option B `enforce` (proposal PRs).
3. #3670 Option A (code PRs) — after soak, own enable vote.
4. Default-on — last.

Enforce stays owner-gated throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
