### PR TITLE
feat(pipeline): enforce policy at stage boundary (#3177)

### DIFF
--- a/.changeset/policy-gate-enforcement-3177.md
+++ b/.changeset/policy-gate-enforcement-3177.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+feat(pipeline): enforce policy at the stage boundary (#3177)
+
+Wire the previously no-op policy gate handler (`plan-compiler.createGateHandler`) to
+the canonical `evaluatePipelinePolicy` evaluator. When a `PlanCompileOptions.policyEnforcement`
+bundle is supplied, each gate node now evaluates its rules at runtime:
+
+- WARN mode (the gate-enforcement default) logs violations + emits a `policy.evaluated`
+  event but does not halt — a stage with no trust metadata is not blocked out of the box.
+- BLOCK mode (opt-in via `NEXUS_POLICY_GATE_MODE=block` or an explicit `mode`) throws a
+  new, exported `PolicyBlockedError` (carries the gate id + violations) on denial.
+- OFF mode skips evaluation entirely.
+
+A policy block is a terminal, non-retryable `permission` failure: the executor flags the
+failed node `policyBlocked`, and `PipelineRunner.toResult` halts the pipeline even under
+`continueOnFailure`. `escalate` gates are treated as `block` (fail-closed); true HITL
+escalation is deferred to a follow-up. Gates remain no-op passes when no enforcement bundle
+is provided (back-compat).

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -46,6 +46,16 @@ import type { ErrorCategory } from '../../mcp/error-envelope.js';
 
 const logger = createLogger({ component: 'GraphExecutor' });
 
+/**
+ * Structural guard for a `PolicyBlockedError` thrown by a policy gate node
+ * (#3177). Name-based rather than `instanceof` to avoid a layering cycle:
+ * `pipeline/*` (where the error class lives) already imports from
+ * `orchestration/graph`, so importing the class back here would be circular.
+ */
+function isPolicyBlockedError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'PolicyBlockedError';
+}
+
 /** Build the retryability fields for a failed NodeResult (#3534). */
 function failureClassification(category: ErrorCategory): {
   errorCategory: ErrorCategory;
@@ -741,6 +751,37 @@ async function executeWithVerification(args: ExecVerifyArgs): Promise<NodeResult
   };
 }
 
+/**
+ * Builds a `failed` NodeResult from a thrown error. A policy gate denial
+ * (#3177) is a terminal `permission` failure flagged `policyBlocked` so the
+ * runner halts even under continueOnFailure; all other errors are classified
+ * via the routing taxonomy so selective-retry can gate on retryability (#3534).
+ */
+function failedNodeResult(nodeId: string, error: unknown, startTime: number): NodeResult {
+  const message = getErrorMessage(error);
+  logger.warn('Node execution failed', { nodeId, error: message });
+  if (isPolicyBlockedError(error)) {
+    return {
+      nodeId,
+      stateUpdates: {},
+      durationMs: getTimeProvider().now() - startTime,
+      status: 'failed',
+      error: message,
+      policyBlocked: true,
+      ...failureClassification('permission'),
+    };
+  }
+  const category = coarsenFailureCategory(categorizeOutcomeError(error));
+  return {
+    nodeId,
+    stateUpdates: {},
+    durationMs: getTimeProvider().now() - startTime,
+    status: 'failed',
+    error: message,
+    ...failureClassification(category),
+  };
+}
+
 /** Executes a single node with preconditions, timeout, verification, and error handling. */
 async function executeSingleNode(
   graph: CompiledGraph,
@@ -781,19 +822,7 @@ async function executeSingleNode(
   try {
     return await executeWithVerification({ node, nodeId, state, startTime, nodeCtx, options });
   } catch (error: unknown) {
-    const message = getErrorMessage(error);
-    logger.warn('Node execution failed', { nodeId, error: message });
-    // Classify the thrown error so selective-retry can gate on it (#3534):
-    // transient (timeout/network/rate-limit) → retryable; others → not.
-    const category = coarsenFailureCategory(categorizeOutcomeError(error));
-    return {
-      nodeId,
-      stateUpdates: {},
-      durationMs: getTimeProvider().now() - startTime,
-      status: 'failed',
-      error: message,
-      ...failureClassification(category),
-    };
+    return failedNodeResult(nodeId, error, startTime);
   }
 }
 

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -267,6 +267,13 @@ export interface NodeResult {
    * this to re-run transient failures and leave permanent ones alone.
    */
   readonly isRetryable?: boolean;
+  /**
+   * Set when the node failed because a policy gate denied the stage boundary
+   * (#3177). A policy block is terminal and non-retryable: it halts the
+   * pipeline even under `continueOnFailure` (unlike an ordinary failed node,
+   * which continue-mode tolerates).
+   */
+  readonly policyBlocked?: boolean;
   /** Set when the node returned an Interrupt envelope (#1895). */
   readonly interrupt?: Interrupt;
   /**

--- a/packages/nexus-agents/src/pipeline/index.ts
+++ b/packages/nexus-agents/src/pipeline/index.ts
@@ -140,10 +140,15 @@ export {
 export {
   evaluatePipelinePolicy,
   getPolicyMode,
+  enforceGatePolicy,
+  getGateEnforcementMode,
+  PolicyBlockedError,
   type PolicyMode,
   type PolicyEvaluatorOptions,
   type PolicyEvalResult,
   type PolicyViolation,
+  type GatePolicyEnforcement,
+  type GateEnforceTarget,
 } from './policy-evaluator.js';
 
 export { orchestrateInputToTaskContract, executeOrchestratePipeline } from './v2-orchestrate.js';

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.test.ts
@@ -12,7 +12,8 @@ import { PipelineRunner } from './pipeline-runner.js';
 import type { PipelineResult } from './pipeline-runner.js';
 import type { NodeResult } from '../orchestration/graph/graph-types.js';
 import { EventBus } from './event-bus.js';
-import type { PlanContract, StageSpec, TaskContract } from './task-contract.js';
+import { createDefaultPolicyEngine } from './policy-engine.js';
+import type { PlanContract, StageSpec, TaskContract, PolicyGateSpec } from './task-contract.js';
 
 // ============================================================================
 // Fixtures
@@ -489,5 +490,65 @@ describe('getDefaultRunsDir', () => {
       // No retryable failure → returns the previous result unchanged (no re-run).
       expect(result.value).toBe(previousResult);
     });
+  });
+});
+
+// ============================================================================
+// Policy gate enforcement halts even under continueOnFailure (#3177, condition 3)
+// ============================================================================
+
+const TRUST_GATE: PolicyGateSpec = {
+  id: 'gate-trust',
+  afterStage: 'analyze',
+  beforeStage: 'execute',
+  rules: ['trust-tier'],
+  onFail: 'block',
+};
+
+function makeGatedPlan(): PlanContract {
+  return makePlan({
+    stages: [
+      makeStage({ id: 'analyze', type: 'analyze' }),
+      makeStage({ id: 'execute', type: 'execute', dependencies: ['analyze'] }),
+    ],
+    policyGates: [TRUST_GATE],
+  });
+}
+
+describe('PipelineRunner policy block (#3177)', () => {
+  it('(g) policy block halts even under continueOnFailure', async () => {
+    const runner = new PipelineRunner();
+    const compiled = runner.compile(makeGatedPlan(), {
+      policyEnforcement: {
+        engine: createDefaultPolicyEngine(),
+        mode: 'block',
+        pipelineState: {}, // missing trust → untrusted → blocked
+      },
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+
+    const result = await runner.execute(compiled.value, makeTask(), {
+      continueOnFailure: true,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // A policy block is non-retryable and must halt the pipeline even though
+    // continueOnFailure is enabled.
+    expect(result.value.success).toBe(false);
+    const executeStep = result.value.stepResults?.find((s) => s.stepId === 'execute');
+    expect(executeStep).toBeUndefined();
+  });
+
+  it('(a) runner throw-to-halt: a policy-blocked gate fails the run by default-off (no enforcement)', async () => {
+    // Without policyEnforcement, the gate stays a no-op pass (back-compat).
+    const runner = new PipelineRunner();
+    const compiled = runner.compile(makeGatedPlan());
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await runner.execute(compiled.value, makeTask());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.success).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/pipeline/pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-runner.ts
@@ -119,7 +119,14 @@ export class PipelineRunner {
     // Resolve deps through the explicit seam (#3175): an injected registry wins,
     // otherwise the documented global default is used — behavior unchanged.
     const { pluginRegistry } = resolvePipelineDeps(options);
-    const compileOpts: PlanCompileOptions = { pluginRegistry };
+    const compileOpts: PlanCompileOptions = {
+      pluginRegistry,
+      // Thread stage-boundary policy enforcement through to the gate handlers
+      // (#3177). Unset → gates remain no-op passes (back-compat).
+      ...(options?.policyEnforcement !== undefined
+        ? { policyEnforcement: options.policyEnforcement }
+        : {}),
+    };
     const graphResult = compilePlan(plan, compileOpts);
     if (!graphResult.ok) {
       return { ok: false, error: graphResult.error };
@@ -284,6 +291,9 @@ function toResult(
 ): PipelineResult {
   const durationMs = Date.now() - startTime;
   const hasFailure = graphResult.nodeResults.some((r) => r.status === 'failed');
+  // A policy gate denial (#3177 condition 3) is terminal and non-retryable: it
+  // halts the pipeline even in continue-mode, unlike an ordinary failed node.
+  const policyBlockedNode = graphResult.nodeResults.find((r) => r.policyBlocked === true);
 
   const stepResults: StepOutcome[] = graphResult.nodeResults.map((r) => ({
     stepId: r.nodeId,
@@ -291,6 +301,10 @@ function toResult(
     durationMs: r.durationMs,
     ...(r.error !== undefined ? { error: r.error } : {}),
   }));
+
+  if (policyBlockedNode !== undefined) {
+    return policyBlockedResult(graphResult, durationMs, continueOnFailure, stepResults);
+  }
 
   if (hasFailure && !continueOnFailure) {
     const failedNode = graphResult.nodeResults.find((r) => r.status === 'failed');
@@ -316,6 +330,28 @@ function toResult(
     ...(!allOk && continueOnFailure
       ? { error: `${String(succeeded)}/${String(total)} steps succeeded` }
       : {}),
+  };
+}
+
+/**
+ * Builds the halt result for a policy-blocked pipeline (#3177 condition 3).
+ * A policy denial halts even under continueOnFailure; `stepResults` is still
+ * surfaced in continue-mode so callers see the per-step breakdown.
+ */
+function policyBlockedResult(
+  graphResult: GraphExecutionResult,
+  durationMs: number,
+  continueOnFailure: boolean,
+  stepResults: readonly StepOutcome[]
+): PipelineResult {
+  const blocked = graphResult.nodeResults.find((r) => r.policyBlocked === true);
+  return {
+    success: false,
+    stepsExecuted: graphResult.stepsExecuted,
+    durationMs,
+    error: blocked?.error ?? 'Policy gate blocked the pipeline',
+    nodeResults: graphResult.nodeResults,
+    ...(continueOnFailure ? { stepResults } : {}),
   };
 }
 

--- a/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
@@ -7,7 +7,18 @@ import { describe, it, expect } from 'vitest';
 
 import { compilePlan } from './plan-compiler.js';
 import { createCorePluginRegistry } from './core-plugins.js';
-import type { PlanContract, StageSpec } from './task-contract.js';
+import { createDefaultPolicyEngine } from './policy-engine.js';
+import {
+  PolicyBlockedError,
+  enforceGatePolicy,
+  type GatePolicyEnforcement,
+} from './policy-evaluator.js';
+import { EventBus } from './event-bus.js';
+import { executeGraph } from '../orchestration/graph/graph-executor.js';
+import type { GraphExecutionResult } from '../orchestration/graph/graph-types.js';
+import type { Result } from '../core/index.js';
+import type { PlanContract, StageSpec, PolicyGateSpec } from './task-contract.js';
+import type { PipelineStateSnapshot } from './policy-engine.js';
 
 // ============================================================================
 // Fixtures
@@ -168,5 +179,178 @@ describe('compilePlan', () => {
     });
     const result = compilePlan(plan, { pluginRegistry: registry });
     expect(result.ok).toBe(true);
+  });
+});
+
+// ============================================================================
+// Policy Gate Enforcement Tests (#3177)
+// ============================================================================
+
+const TRUST_GATE: PolicyGateSpec = {
+  id: 'gate-trust',
+  afterStage: 'analyze',
+  beforeStage: 'execute',
+  rules: ['trust-tier'],
+  onFail: 'block',
+};
+
+/** Plan with an analyze→[gate]→execute(execute-type) shape. */
+function makeGatedPlan(): PlanContract {
+  return makePlan({
+    stages: [
+      makeStage({ id: 'analyze', type: 'analyze' }),
+      makeStage({ id: 'execute', type: 'execute', dependencies: ['analyze'] }),
+    ],
+    policyGates: [TRUST_GATE],
+  });
+}
+
+function enforcement(
+  overrides: Partial<GatePolicyEnforcement> & { pipelineState?: PipelineStateSnapshot }
+): GatePolicyEnforcement {
+  return {
+    engine: createDefaultPolicyEngine(),
+    pipelineState: {},
+    ...overrides,
+  };
+}
+
+async function runGatedPlan(opts: {
+  mode?: 'off' | 'warn' | 'block';
+  pipelineState: PipelineStateSnapshot;
+}): Promise<Result<GraphExecutionResult, Error>> {
+  const plan = makeGatedPlan();
+  const compiled = compilePlan(plan, {
+    policyEnforcement: enforcement({
+      ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+      pipelineState: opts.pipelineState,
+    }),
+  });
+  if (!compiled.ok) throw new Error(`compile failed: ${compiled.error}`);
+  return executeGraph(compiled.value, {}, { timeout: 5000 });
+}
+
+describe('policy gate enforcement (#3177)', () => {
+  it('(a) throw-to-halt: a gate handler that throws → node marked failed', async () => {
+    // Pins the executor contract: a thrown error inside a node handler must
+    // surface as a failed NodeResult, so a future refactor cannot silently
+    // disable gate enforcement.
+    const plan = makeGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: enforcement({
+        mode: 'block',
+        pipelineState: {}, // missing trust → untrusted → blocked
+      }),
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-trust');
+    expect(gateNode?.status).toBe('failed');
+  });
+
+  it('(b) block mode + untrusted → throws PolicyBlockedError → halts', async () => {
+    const result = await runGatedPlan({ mode: 'block', pipelineState: {} });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-trust');
+    expect(gateNode?.status).toBe('failed');
+    // execute stage downstream of the gate must NOT have run.
+    const executeNode = result.value.nodeResults.find((r) => r.nodeId === 'execute');
+    expect(executeNode).toBeUndefined();
+  });
+
+  it('(b) PolicyBlockedError carries gate id + violations', () => {
+    const engine = createDefaultPolicyEngine();
+    let thrown: unknown;
+    try {
+      // Direct unit: evaluate then enforce.
+      enforceGatePolicy(
+        { engine, mode: 'block', pipelineState: {} },
+        { gateId: 'gate-trust', taskId: 't', stageType: 'execute' }
+      );
+    } catch (e: unknown) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(PolicyBlockedError);
+    if (thrown instanceof PolicyBlockedError) {
+      expect(thrown.gateId).toBe('gate-trust');
+      expect(thrown.violations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('(c) block mode + trusted (tier 1) → gate passes, execute runs', async () => {
+    const result = await runGatedPlan({ mode: 'block', pipelineState: { trustTier: '1' } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-trust');
+    expect(gateNode?.status).toBe('success');
+    const executeNode = result.value.nodeResults.find((r) => r.nodeId === 'execute');
+    expect(executeNode?.status).toBe('success');
+  });
+
+  it('(d) warn mode → continues, gate marked warned, violation event emitted', async () => {
+    const bus = new EventBus();
+    const plan = makeGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: enforcement({
+        mode: 'warn',
+        pipelineState: {}, // untrusted, but warn mode → no halt
+        eventBus: bus,
+      }),
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-trust');
+    expect(gateNode?.status).toBe('success'); // continues
+    const executeNode = result.value.nodeResults.find((r) => r.nodeId === 'execute');
+    expect(executeNode?.status).toBe('success');
+    const events = bus.query({}).map((e) => e.type);
+    expect(events).toContain('policy.evaluated');
+  });
+
+  it('(e) off mode → evaluator not called (gate passes regardless of trust)', async () => {
+    let evaluated = false;
+    const engine = createDefaultPolicyEngine();
+    const wrapped = {
+      registerRule: engine.registerRule.bind(engine),
+      evaluate: engine.evaluate.bind(engine),
+      listRules: () => {
+        evaluated = true;
+        return engine.listRules();
+      },
+    };
+    const plan = makeGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: { engine: wrapped, mode: 'off', pipelineState: {} },
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    expect(evaluated).toBe(false);
+  });
+
+  it('(f) default mode (no explicit setting) + missing trust → does NOT throw', async () => {
+    // Condition 1: warn-by-default. A stage with no trust metadata must not
+    // halt out of the box.
+    const plan = makeGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: { engine: createDefaultPolicyEngine(), pipelineState: {} }, // no `mode`
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-trust');
+    expect(gateNode?.status).toBe('success'); // did NOT throw / halt
+    const executeNode = result.value.nodeResults.find((r) => r.nodeId === 'execute');
+    expect(executeNode?.status).toBe('success');
   });
 });

--- a/packages/nexus-agents/src/pipeline/plan-compiler.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.ts
@@ -14,6 +14,8 @@ import { formatCompileError } from '../orchestration/graph/graph-types.js';
 import type { CompiledGraph, GraphState } from '../orchestration/graph/graph-types.js';
 import type { PlanContract, StageSpec, PolicyGateSpec } from './task-contract.js';
 import type { IPluginRegistry } from './plugin-types.js';
+import { enforceGatePolicy } from './policy-evaluator.js';
+import type { GatePolicyEnforcement } from './policy-evaluator.js';
 
 /** Result of plan compilation. */
 type CompileResult =
@@ -25,6 +27,13 @@ export interface PlanCompileOptions {
   /** Plugin registry for resolving stage handlers. When provided, stages with
    *  a registered pluginId will use the plugin's execute() method. */
   readonly pluginRegistry?: IPluginRegistry;
+  /**
+   * Policy enforcement for gate nodes (#3177). When provided, each policy gate
+   * node evaluates `evaluatePipelinePolicy` at runtime — denying (in BLOCK
+   * mode) by throwing `PolicyBlockedError`, which halts the pipeline. When
+   * absent, gate nodes remain no-op passes (back-compat).
+   */
+  readonly policyEnforcement?: GatePolicyEnforcement;
 }
 
 // ============================================================================
@@ -61,7 +70,7 @@ export function compilePlan(plan: PlanContract, options?: PlanCompileOptions): C
   const builder = new GraphBuilder();
   addPipelineState(builder);
   addStageNodes(builder, plan.stages, options?.pluginRegistry);
-  addGateNodes(builder, plan.policyGates);
+  addGateNodes(builder, plan.policyGates, plan, options?.policyEnforcement);
   addEdges(builder, plan.stages, plan.policyGates);
 
   const result = builder.compile();
@@ -114,15 +123,43 @@ function createStageHandler(
     });
 }
 
-/** Creates a handler for a policy gate node. */
+/**
+ * Creates a handler for a policy gate node (#3177).
+ *
+ * When `enforcement` is provided, the gate evaluates policy at the stage
+ * boundary via `enforceGatePolicy`:
+ *  - BLOCK mode + denial → throws `PolicyBlockedError` (the executor marks the
+ *    node `failed`, which halts the pipeline — non-retryable, so it halts even
+ *    under `continueOnFailure`).
+ *  - WARN mode → continues; the gate is recorded `warned` and a policy.evaluated
+ *    event is emitted by the evaluator.
+ *  - OFF mode → evaluation skipped.
+ *
+ * When `enforcement` is absent the gate stays a no-op pass (back-compat).
+ */
 function createGateHandler(
-  gate: PolicyGateSpec
+  gate: PolicyGateSpec,
+  taskId: string,
+  stageType: string,
+  enforcement?: GatePolicyEnforcement
 ): (state: Readonly<GraphState>) => Promise<Partial<GraphState>> {
-  return (_state: Readonly<GraphState>) =>
-    Promise.resolve({
+  if (enforcement === undefined) {
+    return (_state: Readonly<GraphState>) =>
+      Promise.resolve({
+        currentStage: gate.id,
+        stageResults: [{ gateId: gate.id, status: 'passed' }],
+      });
+  }
+  return (_state: Readonly<GraphState>) => {
+    // enforceGatePolicy throws PolicyBlockedError on block+denial; the executor
+    // catches it and marks the node failed. WARN/OFF return a verdict instead.
+    const verdict = enforceGatePolicy(enforcement, { gateId: gate.id, taskId, stageType });
+    const status = verdict.allowed ? 'passed' : 'warned';
+    return Promise.resolve({
       currentStage: gate.id,
-      stageResults: [{ gateId: gate.id, status: 'passed' }],
+      stageResults: [{ gateId: gate.id, status }],
     });
+  };
 }
 
 /** Adds stage nodes to the graph builder. */
@@ -137,9 +174,19 @@ function addStageNodes(
 }
 
 /** Adds policy gate nodes to the graph builder. */
-function addGateNodes(builder: GraphBuilder, gates: readonly PolicyGateSpec[]): void {
+function addGateNodes(
+  builder: GraphBuilder,
+  gates: readonly PolicyGateSpec[],
+  plan: PlanContract,
+  enforcement?: GatePolicyEnforcement
+): void {
+  // Map each stage id to its type so a gate can report the type of the stage
+  // it guards (its `beforeStage`) to the policy rules (the trust-tier rule
+  // only blocks `execute`-type stages).
+  const stageTypeById = new Map(plan.stages.map((s) => [s.id, s.type]));
   for (const gate of gates) {
-    builder.addNode(gate.id, createGateHandler(gate));
+    const stageType = stageTypeById.get(gate.beforeStage) ?? 'gate';
+    builder.addNode(gate.id, createGateHandler(gate, plan.taskId, stageType, enforcement));
   }
 }
 

--- a/packages/nexus-agents/src/pipeline/policy-evaluator.ts
+++ b/packages/nexus-agents/src/pipeline/policy-evaluator.ts
@@ -13,7 +13,12 @@
 import { createLogger } from '../core/index.js';
 
 import { resolveV2Config } from './v2-config.js';
-import type { PolicyEngine, PolicyDecision, PolicyContext } from './policy-engine.js';
+import type {
+  IPolicyEngine,
+  PolicyDecision,
+  PolicyContext,
+  PipelineStateSnapshot,
+} from './policy-engine.js';
 import type { IEventBus, PipelineEvent } from './event-types.js';
 
 const logger = createLogger({ component: 'PolicyEvaluator' });
@@ -27,7 +32,8 @@ export type PolicyMode = 'off' | 'warn' | 'block';
 
 /** Options for PolicyEvaluator. */
 export interface PolicyEvaluatorOptions {
-  readonly engine: PolicyEngine;
+  /** Only `listRules()` is consumed, so the interface — not the class — suffices. */
+  readonly engine: IPolicyEngine;
   readonly eventBus?: IEventBus;
   readonly mode?: PolicyMode;
 }
@@ -44,6 +50,118 @@ export interface PolicyViolation {
   readonly ruleId: string;
   readonly reason: string;
   readonly escalateTo?: string;
+}
+
+// ============================================================================
+// Stage-boundary gate enforcement (#3177)
+// ============================================================================
+
+/**
+ * Dedicated error thrown when a policy gate denies a stage boundary in BLOCK
+ * mode. Distinct from a generic `Error` so retry/telemetry can recognize a
+ * policy denial: it is non-retryable (a re-run with the same inputs will fail
+ * identically) and carries the offending gate id + the violations that fired.
+ *
+ * The executor catches this in `executeSingleNode`; the failure category
+ * coarsens to `permission`, which `defaultRetryable` marks non-retryable —
+ * so a policy block halts even under `continueOnFailure` (#3177 condition 3).
+ */
+export class PolicyBlockedError extends Error {
+  readonly gateId: string;
+  readonly violations: readonly PolicyViolation[];
+
+  constructor(gateId: string, violations: readonly PolicyViolation[]) {
+    const summary = violations.map((v) => v.ruleId).join(', ');
+    super(`Policy gate '${gateId}' blocked stage boundary (rules: ${summary || 'none'})`);
+    this.name = 'PolicyBlockedError';
+    this.gateId = gateId;
+    this.violations = violations;
+  }
+}
+
+/**
+ * Policy-enforcement bundle threaded to a compiled gate node (#3177).
+ *
+ * When attached to `PlanCompileOptions`, each policy gate node evaluates
+ * `evaluatePipelinePolicy` at runtime instead of being a no-op pass. When
+ * absent, gates stay no-op passes (back-compat).
+ */
+export interface GatePolicyEnforcement {
+  /** Engine whose rules are evaluated at the gate boundary. */
+  readonly engine: IPolicyEngine;
+  /**
+   * Snapshot of pipeline state available to policy rules (carries `trustTier`).
+   * Captured at compile time from the TaskContract metadata by the caller.
+   */
+  readonly pipelineState: PipelineStateSnapshot;
+  /** Optional event bus; policy.evaluated events are emitted on violations. */
+  readonly eventBus?: IEventBus;
+  /**
+   * Effective enforcement mode for gate nodes. WARN by default (#3177
+   * condition 1): a gate with no explicit mode does NOT halt, so a stage
+   * lacking trust metadata is not blocked out of the box. Block is opt-in.
+   */
+  readonly mode?: PolicyMode;
+}
+
+/** Identifies the gate boundary being enforced. */
+export interface GateEnforceTarget {
+  readonly gateId: string;
+  readonly taskId: string;
+  /** Type of the stage the gate guards (its `beforeStage`). */
+  readonly stageType: string;
+}
+
+/**
+ * Resolves the enforcement mode for a gate node. WARN by default (#3177
+ * condition 1) — NOT `block`, even though the V2 umbrella `getPolicyMode()`
+ * defaults to `block` in full mode. Block is opt-in via `NEXUS_POLICY_GATE_MODE`
+ * (or an explicit per-gate `mode`). This keeps legitimate stages from halting
+ * on missing trust metadata out of the box.
+ */
+export function getGateEnforcementMode(): PolicyMode {
+  const env = process.env['NEXUS_POLICY_GATE_MODE'];
+  if (env === 'off' || env === 'warn' || env === 'block') return env;
+  return 'warn';
+}
+
+/**
+ * Evaluates policy at a gate boundary and enforces the verdict (#3177).
+ *
+ * - OFF mode: skips evaluation entirely (no `listRules` call).
+ * - WARN mode (default): evaluates, emits/logs violations, but does NOT throw.
+ * - BLOCK mode + `!allowed`: throws {@link PolicyBlockedError}.
+ *
+ * `escalate` is treated as `block` (fail-closed) — there is no grounded
+ * gate-boundary HITL approval path that feeds a verdict back into policy
+ * re-evaluation today (#3177 condition 4 follow-up).
+ */
+export function enforceGatePolicy(
+  enforcement: GatePolicyEnforcement,
+  target: GateEnforceTarget
+): PolicyEvalResult {
+  const mode = enforcement.mode ?? getGateEnforcementMode();
+
+  const result = evaluatePipelinePolicy(
+    {
+      engine: enforcement.engine,
+      mode,
+      ...(enforcement.eventBus !== undefined ? { eventBus: enforcement.eventBus } : {}),
+    },
+    {
+      taskId: target.taskId,
+      stageId: target.gateId,
+      stageType: target.stageType,
+      pipelineState: enforcement.pipelineState,
+    }
+  );
+
+  // Only throw when the mode resolves to `block` AND the verdict denies
+  // (#3177 condition 2). In `warn`/`off` modes execution continues.
+  if (mode === 'block' && !result.allowed) {
+    throw new PolicyBlockedError(target.gateId, result.violations);
+  }
+  return result;
 }
 
 // ============================================================================


### PR DESCRIPTION
## What
Closes #3177. Wires the previously hardcoded no-op policy gate handler
(`plan-compiler.createGateHandler`) to the canonical `evaluatePipelinePolicy`
evaluator, so policy gates actually enforce at the pipeline stage boundary.

## Approach (ratified by 7/7 higher_order vote)
- New `GatePolicyEnforcement` bundle on `PlanCompileOptions` (engine + pipelineState
  snapshot + optional eventBus + mode). Threaded through `PipelineRunner.compile`.
- `enforceGatePolicy` calls the existing `evaluatePipelinePolicy`; gate nodes report
  `passed`/`warned` or throw on block.
- Did NOT unify the three policy APIs (that's #3194, out of scope).

## Conditions met
1. **WARN by default, block opt-in.** Gate-enforcement mode resolves via new
   `getGateEnforcementMode()` which defaults to `warn` (NOT the V2 umbrella's `block`).
   Block is opt-in via `NEXUS_POLICY_GATE_MODE=block` or an explicit `mode`. Test (f)
   proves a stage with no trust metadata does not throw under the default.
2. **Typed error.** New exported `PolicyBlockedError` carries `gateId` + `violations`;
   thrown only when mode resolves to `block` AND verdict `!allowed`.
3. **Overrides continueOnFailure.** Executor flags the failed node `policyBlocked`
   (terminal `permission` category, non-retryable); `PipelineRunner.toResult` halts
   even in continue-mode. Test (g) pins this.
4. **Escalate→HITL: verified.** The graph executor's `Interrupt` mechanism is a
   pause-for-input primitive with no approval→re-evaluation return path, so wiring
   `escalate→interrupt` would be a dead branch. Per the vote, `escalate` is treated as
   `block` (fail-closed). Follow-up filed: #3697.

## Tests (TDD, red→green; 100 pass in the touched suites)
plan-compiler.test.ts: (a) throw-to-halt executor contract, (b) block+untrusted →
PolicyBlockedError + halt + carries gate id/violations, (c) block+trusted → passes,
(d) warn → continues + event emitted, (e) off → evaluator not called, (f) default mode
+ missing trust → no throw. pipeline-runner.test.ts: (g) block overrides continueOnFailure,
plus back-compat (no enforcement → no-op pass).

`tsc --noEmit` clean; `eslint --no-cache` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)