### PR TITLE
feat(orchestration): make context retrieval failures observable (#3180)

### DIFF
--- a/.changeset/context-unavailable-observability-3180.md
+++ b/.changeset/context-unavailable-observability-3180.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+orchestration: make graph-start context retrieval observable (#3180)
+
+When `getContextForTask` fails during graph-start context population, the
+executor no longer swallows it at debug. It now logs a `warn`, emits an
+aggregatable `context_unavailable` graph event (sanitized message only — no
+stack/paths/secrets), and continues with empty context (best-effort contract
+preserved). `executionId` is threaded into `getContextForTask` for correlation,
+and the inferred task category is surfaced. Scope is the graph boundary only;
+the other `getContextForTask` call sites are tracked in #3699.

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -80,6 +80,13 @@ export interface ContextRetrieverOptions {
   readonly limit?: number;
   /** Optional logger override. */
   readonly logger?: ILogger;
+  /**
+   * Optional correlation id for the calling execution (#3180). When present it
+   * is bound to a child logger so every per-backend log line for this retrieval
+   * carries the same `executionId`, making a failure traceable back to its
+   * graph run. Backward-compatible: the four existing callers omit it.
+   */
+  readonly executionId?: string;
 }
 
 /** Sensible default — small enough to embed in a prompt, large enough to be useful. */
@@ -99,7 +106,12 @@ const DEFAULT_LIMIT = 5;
  */
 export async function getContextForTask(options: ContextRetrieverOptions): Promise<UnifiedContext> {
   const limit = options.limit ?? DEFAULT_LIMIT;
-  const logger = options.logger ?? createLogger({ component: 'ContextRetriever' });
+  const baseLogger = options.logger ?? createLogger({ component: 'ContextRetriever' });
+  // Bind the correlation id to every per-backend log line for this retrieval (#3180).
+  const logger =
+    options.executionId !== undefined
+      ? baseLogger.child({ executionId: options.executionId })
+      : baseLogger;
 
   const [
     beliefs,

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -291,7 +291,31 @@ function toEventSummary(event: GraphEvent): GraphEventSummary {
   return { type: event.type, detail: formatDetail(event) };
 }
 
+type HookEvent = Extract<GraphEvent, { type: 'hook_started' | 'hook_completed' | 'hook_failed' }>;
+
+/** Type guard for the three hook lifecycle events. */
+function isHookEvent(event: GraphEvent): event is HookEvent {
+  return (
+    event.type === 'hook_started' || event.type === 'hook_completed' || event.type === 'hook_failed'
+  );
+}
+
+/** Detail string for the three hook lifecycle events (split out for complexity). */
+function formatHookDetail(event: HookEvent): string {
+  const where = `${event.hookPhase}: ${event.hookName} on ${event.nodeId}`;
+  switch (event.type) {
+    case 'hook_started':
+      return where;
+    case 'hook_completed':
+      return `${where} in ${String(event.durationMs)}ms`;
+    case 'hook_failed':
+      return `${where}: ${event.error}`;
+  }
+}
+
 function formatDetail(event: GraphEvent): string {
+  // Hook events are dispatched out-of-switch to keep complexity within budget.
+  if (isHookEvent(event)) return formatHookDetail(event);
   switch (event.type) {
     case 'node_started':
       return `Starting ${event.nodeId}`;
@@ -305,12 +329,8 @@ function formatDetail(event: GraphEvent): string {
       return `${String(event.totalSteps)} steps, ${String(event.durationMs)}ms`;
     case 'state_updated':
       return event.updatedKeys.join(', ');
-    case 'hook_started':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}`;
-    case 'hook_completed':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId} in ${String(event.durationMs)}ms`;
-    case 'hook_failed':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}: ${event.error}`;
+    case 'context_unavailable':
+      return `Context unavailable for category '${event.category}': ${event.error}`;
   }
 }
 

--- a/packages/nexus-agents/src/orchestration/graph/graph-events.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-events.ts
@@ -11,6 +11,16 @@
 import { getTimeProvider } from '../../core/index.js';
 import type { NodeResult, GraphExecuteOptions } from './graph-types.js';
 
+/** Fields for a {@link emitContextUnavailable} call (#3180). */
+interface ContextUnavailableArgs {
+  /** Inferred task category whose context retrieval failed. */
+  readonly category: string;
+  /** Sanitized failure message — message string only (caller must sanitize). */
+  readonly error: string;
+  /** Correlation id when the execution carries one. */
+  readonly executionId?: string;
+}
+
 /** Minimal context needed for event emission. */
 interface StepContext {
   readonly stepsExecuted: number;
@@ -93,6 +103,27 @@ export function emitStepCompleted(
     type: 'step_completed',
     stepNumber: ctx.stepsExecuted,
     nodesExecuted,
+    timestamp: getTimeProvider().now(),
+  });
+}
+
+/**
+ * Emits a `context_unavailable` event when unified-context retrieval failed at
+ * graph start (#3180). Guards on `options?.onEvent` like the other emitters, so
+ * it is a no-op when no listener is attached. The caller is responsible for
+ * passing an already-sanitized `error` (message string only).
+ */
+export function emitContextUnavailable(
+  args: ContextUnavailableArgs,
+  options?: GraphExecuteOptions
+): void {
+  const emit = options?.onEvent;
+  if (emit === undefined) return;
+  emit({
+    type: 'context_unavailable',
+    category: args.category,
+    error: args.error,
+    ...(args.executionId !== undefined ? { executionId: args.executionId } : {}),
     timestamp: getTimeProvider().now(),
   });
 }

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
@@ -4,9 +4,9 @@
  * (Source: Issue #831 — Graph-based workflow orchestration)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GraphBuilder, overwrite, append, customReducer, START, END } from './graph-builder.js';
-import { executeGraph } from './graph-executor.js';
+import { executeGraph, GRAPH_UNIFIED_CONTEXT_KEY } from './graph-executor.js';
 import { InMemoryCheckpointStore } from './checkpoint-store.js';
 import type { GraphState, NodeResult, GraphEvent } from './graph-types.js';
 
@@ -835,3 +835,164 @@ describe('maxTraversals (Issue #910, E2-4)', () => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const noop = () => Promise.resolve({});
+
+// ---------------------------------------------------------------------------
+// Unified-context observability at graph start (#3180)
+// ---------------------------------------------------------------------------
+
+const EMPTY_UNIFIED_CONTEXT = {
+  beliefs: [],
+  similarMemories: [],
+  recentLearnings: [],
+  experiencePatterns: [],
+  outcomes: null,
+  priorStrategies: [],
+  researchInsights: [],
+};
+
+// Controllable mock for the dynamically imported context-retriever. The real
+// inferTaskCategory is preserved so category-inference assertions exercise
+// production logic; only getContextForTask is swapped.
+const getContextForTaskMock = vi.fn();
+vi.mock('../../context/context-retriever.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../context/context-retriever.js')>();
+  return {
+    ...actual,
+    getContextForTask: (...args: unknown[]): unknown => getContextForTaskMock(...args),
+  };
+});
+
+describe('graph-start context observability (#3180)', () => {
+  beforeEach(() => {
+    getContextForTaskMock.mockReset();
+    getContextForTaskMock.mockResolvedValue(EMPTY_UNIFIED_CONTEXT);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const singleNodeGraph = () =>
+    new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }))
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+  it('(a) retrieval throw → warn + exactly one sanitized context_unavailable event, graph still completes', async () => {
+    getContextForTaskMock.mockRejectedValue(new Error('backend exploded'));
+    // The structured logger writes to a stdout/stderr stream, not console.warn.
+    const writes: string[] = [];
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    // 'fix this security bug' → inferTaskCategory → 'security_review'
+    const result = await executeGraph(
+      graph.value,
+      { task: 'fix this security bug' },
+      { onEvent: (e) => events.push(e), executionId: 'exec-3180' }
+    );
+
+    // Graph still COMPLETES with empty context (best-effort contract).
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.finalState['value']).toBe(1);
+    expect(result.value.finalState[GRAPH_UNIFIED_CONTEXT_KEY]).toBeUndefined();
+
+    // Exactly ONE context_unavailable event with correct fields.
+    const ctxEvents = events.filter((e) => e.type === 'context_unavailable');
+    expect(ctxEvents).toHaveLength(1);
+    const evt = ctxEvents[0];
+    if (evt?.type !== 'context_unavailable') throw new Error('unreachable');
+    expect(evt.category).toBe('security_review');
+    expect(evt.executionId).toBe('exec-3180');
+    expect(evt.error).toBe('backend exploded');
+    // Sanitized: no stack trace leaked into the payload.
+    expect(evt.error).not.toContain('at ');
+    expect(typeof evt.timestamp).toBe('number');
+
+    // A WARN was logged (level + the warn message text appear in the output).
+    const logged = writes.join('');
+    expect(logged).toContain('warn');
+    expect(logged).toContain('context retrieval failed');
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('(b) success path → executionId is threaded into getContextForTask options', async () => {
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const result = await executeGraph(
+      graph.value,
+      { task: 'add a new feature' },
+      { executionId: 'exec-success' }
+    );
+    expect(result.ok).toBe(true);
+
+    expect(getContextForTaskMock).toHaveBeenCalledTimes(1);
+    const arg = getContextForTaskMock.mock.calls[0]?.[0] as {
+      task: string;
+      category: string;
+      executionId?: string;
+    };
+    expect(arg.task).toBe('add a new feature');
+    expect(arg.executionId).toBe('exec-success');
+    // 'add a new feature' → code_generation
+    expect(arg.category).toBe('code_generation');
+  });
+
+  it('(c) absent/empty task → early return: no retrieval, no event', async () => {
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    // No 'task' key in inputs at all.
+    const result = await executeGraph(graph.value, {}, { onEvent: (e) => events.push(e) });
+    expect(result.ok).toBe(true);
+
+    expect(getContextForTaskMock).not.toHaveBeenCalled();
+    expect(events.some((e) => e.type === 'context_unavailable')).toBe(false);
+  });
+
+  it('(d) per-backend partial failure that overall resolves → no event', async () => {
+    // getContextForTask never throws on a single-backend failure — it returns a
+    // (possibly empty) UnifiedContext. Model that: resolve normally → no event.
+    getContextForTaskMock.mockResolvedValue(EMPTY_UNIFIED_CONTEXT);
+
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    const result = await executeGraph(
+      graph.value,
+      { task: 'investigate something' },
+      { onEvent: (e) => events.push(e) }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(events.some((e) => e.type === 'context_unavailable')).toBe(false);
+    // Empty context was still stashed on success.
+    expect(result.value.finalState[GRAPH_UNIFIED_CONTEXT_KEY]).toEqual(EMPTY_UNIFIED_CONTEXT);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -38,6 +38,7 @@ import {
   emitStateUpdated,
   emitStepCompleted,
   emitExecutionComplete,
+  emitContextUnavailable,
 } from './graph-events.js';
 import { runPreconditions, runVerification } from './graph-hooks.js';
 import { categorizeOutcomeError } from '../outcomes/outcome-types.js';
@@ -79,27 +80,49 @@ const DEFAULT_TIMEOUT_MS = GRAPH_TIMEOUTS.defaultMs;
  */
 export const GRAPH_UNIFIED_CONTEXT_KEY = '__unifiedContext';
 
-async function populateUnifiedContextOnState(state: GraphState): Promise<void> {
-  try {
-    const taskCandidate = state['task'];
-    if (typeof taskCandidate !== 'string' || taskCandidate === '') return;
+/** Optional `{ executionId }` fragment, omitted when no correlation id. */
+function execIdFields(executionId?: string): { executionId?: string } {
+  return executionId !== undefined ? { executionId } : {};
+}
 
-    const { getContextForTask, inferTaskCategory } =
-      await import('../../context/context-retriever.js');
-    const ctx = await getContextForTask({
-      task: taskCandidate,
-      category: inferTaskCategory(taskCandidate),
-      logger,
-    });
+async function populateUnifiedContextOnState(
+  state: GraphState,
+  options?: GraphExecuteOptions
+): Promise<void> {
+  const taskCandidate = state['task'];
+  if (typeof taskCandidate !== 'string' || taskCandidate === '') return;
+
+  const { getContextForTask, inferTaskCategory } =
+    await import('../../context/context-retriever.js');
+  // Capture the inferred category up front so the failure path can report it.
+  const category = inferTaskCategory(taskCandidate);
+  const executionId = options?.executionId;
+  const execFields = execIdFields(executionId);
+
+  try {
+    const ctx = await getContextForTask({ task: taskCandidate, category, logger, ...execFields });
     state[GRAPH_UNIFIED_CONTEXT_KEY] = ctx;
     logger.debug('Graph start: unified memory context stashed', {
+      category,
+      ...execFields,
       beliefs: ctx.beliefs.length,
       similarMemories: ctx.similarMemories.length,
       experiencePatterns: ctx.experiencePatterns.length,
       outcomesTotal: ctx.outcomes?.totalTasks ?? 0,
     });
   } catch (error: unknown) {
-    logger.debug('Graph start: context retrieval failed', { error: getErrorMessage(error) });
+    // Best-effort contract preserved: the graph still runs with empty context.
+    // But the failure is now observable (#3180) — a warn log plus an
+    // aggregatable `context_unavailable` event through the EventBus/onEvent
+    // path — instead of a swallowed debug line. `getErrorMessage` yields a
+    // sanitized message string only (no stack/paths/secrets).
+    const message = getErrorMessage(error);
+    logger.warn('Graph start: context retrieval failed; continuing with empty context', {
+      category,
+      ...execFields,
+      error: message,
+    });
+    emitContextUnavailable({ category, error: message, ...execFields }, options);
   }
 }
 
@@ -142,7 +165,7 @@ export async function executeGraph(
   // under a well-known key so node implementations can consume it without
   // a second fetch. Best-effort: failure is logged and silently produces
   // an empty context.
-  await populateUnifiedContextOnState(initialState);
+  await populateUnifiedContextOnState(initialState, options);
 
   const ctx: ExecutionContext = {
     state: initialState,

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -408,7 +408,35 @@ export type GraphEvent =
       readonly error: string;
       readonly stepNumber: number;
       readonly timestamp: number;
-    };
+    }
+  | ContextUnavailableEvent;
+
+/**
+ * Emitted when unified-memory context retrieval fails at graph start (#3180).
+ *
+ * Best-effort enrichment is preserved — the graph still runs with empty
+ * context — but the failure is now observable instead of swallowed: a
+ * `warn` log plus this event flow through the standard `onEvent`/EventBus
+ * path so a readiness/counter consumer can aggregate context-availability.
+ *
+ * Defined as a single named shape (not inlined) so the three remaining
+ * `getContextForTask` call sites (execute-expert, orchestrate,
+ * composite-router; follow-up #3699) become pure call-site wiring against
+ * one authoritative event contract (DRY).
+ *
+ * `error` carries ONLY a sanitized message (`getErrorMessage`) — never a
+ * stack trace, file-system path, prompt, secret, or token.
+ */
+export type ContextUnavailableEvent = {
+  readonly type: 'context_unavailable';
+  /** Inferred task category whose context could not be retrieved. */
+  readonly category: string;
+  /** Sanitized failure message — message string only, no stack/paths/secrets. */
+  readonly error: string;
+  /** Correlation id when the execution was given one. */
+  readonly executionId?: string;
+  readonly timestamp: number;
+};
 
 // ============================================================================
 // Builder Error


### PR DESCRIPTION
Closes #3180.

## Behavior (ratified option b)
When `getContextForTask` fails during `populateUnifiedContextOnState` at graph start, the executor no longer swallows it at `debug`. It now:
- **WARN-logs** the failure (with category + executionId + sanitized message),
- **emits an observable `context_unavailable` graph event** through the existing `onEvent`/EventBus path,
- **continues with empty context** — the best-effort enrichment contract is preserved (graph still completes, not failed).

It also threads `executionId` into `getContextForTask` (bound to a child logger for correlation) and surfaces the inferred task category (debug on success, in the event on failure).

## Conditions from the consensus_vote (all met)
1. **Scope = graph boundary only** — only the graph-executor call site changed. The other three `getContextForTask` callers (execute-expert, orchestrate, composite-router) are untouched; tracked in #3699.
2. **Sanitized error payload** — the event/log carry `getErrorMessage(error)` (message string only), never stack traces, secrets, fs paths, prompts, or tokens.
3. **Shared event shape (DRY)** — `ContextUnavailableEvent` is defined once in `graph-types.ts` so #3699 is pure call-site wiring.
4. **Aggregatable** — the event flows through the existing `onEvent`/EventBus path (not a dead end), so a counter/readiness consumer can later read it.

## Files changed
- `graph-types.ts` — `context_unavailable` variant + `ContextUnavailableEvent` shared shape.
- `graph-events.ts` — `emitContextUnavailable()` (guards on `options.onEvent`).
- `context-retriever.ts` — optional `executionId`, bound to a child logger. Backward-compatible.
- `graph-executor.ts` — thread executionId/category, warn + emit on failure, debug category on success.
- `run-graph-workflow.ts` — handle the new event variant in `formatDetail`.

## Tests (graph-executor.test.ts, all green)
- (a) retrieval throw → graph completes with empty context, WARN logged, exactly ONE `context_unavailable` event with correct category + executionId + sanitized error.
- (b) success path → `executionId` propagated into `getContextForTask` options (+ correct inferred category).
- (c) absent/empty task → early return, no retrieval, no event.
- (d) partial-backend failure that overall resolves → no event, empty context stashed.

`tsc --noEmit` clean, `eslint --no-cache` clean (0 errors), affected vitest suites pass (graph-executor 36, run-graph-workflow 25, context-retriever 21, audit-trail 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)