### PR TITLE
feat(pipeline): activate #3177 stage-boundary policy enforcement (default WARN, #3703)

### DIFF
--- a/.changeset/activate-policy-enforcement-3703.md
+++ b/.changeset/activate-policy-enforcement-3703.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+feat(pipeline): activate #3177 stage-boundary policy enforcement in production (default WARN, #3703)
+
+The v2-delegate pipeline now compiles with a real policy gate (`gate-delegate-entry`)
+on the START boundary before the route stage, and supplies a **default-WARN**
+`policyEnforcement` bundle into its own compile call. Stage-boundary policy is now
+actually evaluated in production: WARN mode logs + emits one `policy.evaluated` event
+per violation and never throws or blocks, generating the autonomy-soak evidence #3653
+needs. Block mode stays opt-in via `NEXUS_POLICY_GATE_MODE=block`.
+
+The shared `compilePlan` / `PlanCompileOptions` default is unchanged — enforcement is
+threaded only from v2-delegate's compile call, so every other `compilePlan` caller is
+unaffected (gates remain no-op passes). The plan compiler also now interposes an entry
+gate (`afterStage === START`) on the START edge of a no-dependency stage.

--- a/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
@@ -15,6 +15,7 @@ import {
 } from './policy-evaluator.js';
 import { EventBus } from './event-bus.js';
 import { executeGraph } from '../orchestration/graph/graph-executor.js';
+import { START } from '../orchestration/graph/graph-types.js';
 import type { GraphExecutionResult } from '../orchestration/graph/graph-types.js';
 import type { Result } from '../core/index.js';
 import type { PlanContract, StageSpec, PolicyGateSpec } from './task-contract.js';
@@ -352,5 +353,61 @@ describe('policy gate enforcement (#3177)', () => {
     expect(gateNode?.status).toBe('success'); // did NOT throw / halt
     const executeNode = result.value.nodeResults.find((r) => r.nodeId === 'execute');
     expect(executeNode?.status).toBe('success');
+  });
+});
+
+// ============================================================================
+// START-boundary gate interposition (#3703)
+// ============================================================================
+
+/** Gate guarding a single no-dependency entry stage at the START boundary. */
+const ENTRY_GATE: PolicyGateSpec = {
+  id: 'gate-entry',
+  afterStage: START,
+  beforeStage: 'route-model',
+  rules: ['trust-tier'],
+  onFail: 'warn',
+};
+
+/** Single-stage plan with an entry gate at START → route-model (#3703). */
+function makeEntryGatedPlan(): PlanContract {
+  return makePlan({
+    taskId: 'task-entry',
+    stages: [makeStage({ id: 'route-model', type: 'route', dependencies: [] })],
+    policyGates: [ENTRY_GATE],
+  });
+}
+
+describe('START-boundary gate interposition (#3703)', () => {
+  it('interposes an entry gate on the START edge of a no-dependency stage', async () => {
+    const plan = makeEntryGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: enforcement({ mode: 'warn', pipelineState: {} }),
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    // The gate node exists and is reachable (START → gate → route-model).
+    expect(compiled.value.nodes.has('gate-entry')).toBe(true);
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gateNode = result.value.nodeResults.find((r) => r.nodeId === 'gate-entry');
+    expect(gateNode?.status).toBe('success');
+    const stageNode = result.value.nodeResults.find((r) => r.nodeId === 'route-model');
+    expect(stageNode?.status).toBe('success');
+  });
+
+  it('entry gate runs BEFORE the stage it guards', async () => {
+    const plan = makeEntryGatedPlan();
+    const compiled = compilePlan(plan, {
+      policyEnforcement: enforcement({ mode: 'warn', pipelineState: {} }),
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const order = result.value.nodeResults.map((r) => r.nodeId);
+    expect(order.indexOf('gate-entry')).toBeLessThan(order.indexOf('route-model'));
   });
 });

--- a/packages/nexus-agents/src/pipeline/plan-compiler.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.ts
@@ -182,7 +182,8 @@ function addGateNodes(
 ): void {
   // Map each stage id to its type so a gate can report the type of the stage
   // it guards (its `beforeStage`) to the policy rules (the trust-tier rule
-  // only blocks `execute`-type stages).
+  // only blocks `execute`-type stages). An entry gate (`afterStage === START`)
+  // guards a no-dependency stage and still reports that stage's real type.
   const stageTypeById = new Map(plan.stages.map((s) => [s.id, s.type]));
   for (const gate of gates) {
     const stageType = stageTypeById.get(gate.beforeStage) ?? 'gate';
@@ -196,7 +197,8 @@ function addGateNodes(
  * Logic:
  * 1. If a gate exists afterStage→beforeStage, insert gate node between
  * 2. Otherwise, add direct dependency edge
- * 3. Stages with no dependencies get START→stage edges
+ * 3. Stages with no dependencies get START→stage edges — or START→gate→stage
+ *    when an entry gate (`afterStage === START`) guards that stage (#3703)
  * 4. Stages with no dependents get stage→END edges
  */
 function addEdges(
@@ -228,10 +230,20 @@ function addEdges(
     }
   }
 
-  // Stages with no dependencies → START edges
+  // Stages with no dependencies → START edges. An entry gate keyed
+  // `START→stage` (#3703) is interposed so the boundary is policy-evaluated
+  // before the entry stage runs; otherwise a direct START→stage edge.
   for (const stage of stages) {
     if (stage.dependencies.length === 0) {
-      builder.addEdge(START, stage.id);
+      const gateKey = `${START}→${stage.id}`;
+      const gate = gateMap.get(gateKey);
+      if (gate !== undefined) {
+        builder.addEdge(START, gate.id);
+        builder.addEdge(gate.id, stage.id);
+        gateMap.delete(gateKey); // consumed
+      } else {
+        builder.addEdge(START, stage.id);
+      }
     }
   }
 

--- a/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
@@ -15,6 +15,7 @@ import {
 } from './v2-delegate.js';
 import type { DelegateInputLike } from './v2-delegate.js';
 import type { TaskContract } from './task-contract.js';
+import type { IPolicyEngine } from './policy-engine.js';
 
 // ============================================================================
 // Fixtures
@@ -253,5 +254,153 @@ describe('executeDelegatePipeline — policy enforcement', () => {
     const metrics = await executeDelegatePipeline(contract);
     expect(metrics.policyBlocked).toBeUndefined();
     expect(metrics.compiled).toBe(true);
+  });
+});
+
+// ============================================================================
+// Activation: stage-boundary policy enforcement in production (#3703)
+// ============================================================================
+
+describe('createDelegatePipeline — policy gate activation (#3703)', () => {
+  const savedGateMode = process.env['NEXUS_POLICY_GATE_MODE'];
+
+  afterEach(() => {
+    if (savedGateMode !== undefined) process.env['NEXUS_POLICY_GATE_MODE'] = savedGateMode;
+    else delete process.env['NEXUS_POLICY_GATE_MODE'];
+  });
+
+  it('(a) produces a plan with a non-empty policy gate guarding the route stage', () => {
+    const result = createDelegatePipeline(makeTask());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.plan.policyGates.length).toBeGreaterThan(0);
+    const gate = result.value.plan.policyGates[0]!;
+    expect(gate.beforeStage).toBe('route-model');
+    expect(gate.rules.length).toBeGreaterThan(0);
+    // The gate node is compiled into the graph (not a dangling spec).
+    expect(result.value.graph.nodes.has(gate.id)).toBe(true);
+  });
+
+  it('(a) the compiled gate runs in default WARN mode (gate node executes, passes)', async () => {
+    delete process.env['NEXUS_POLICY_GATE_MODE']; // default warn
+    const pipeline = createDelegatePipeline(makeTask());
+    expect(pipeline.ok).toBe(true);
+    if (!pipeline.ok) return;
+    const { PipelineRunner } = await import('./pipeline-runner.js');
+    const result = await new PipelineRunner().execute(pipeline.value, makeTask());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.success).toBe(true);
+  });
+
+  it('(b) WARN mode never throws + emits a policy event even when a rule denies', async () => {
+    // Inject an always-denying engine through the enforcement bundle and run the
+    // compiled gate in warn mode. WARN must NOT throw and MUST emit one event.
+    const { compilePlan } = await import('./plan-compiler.js');
+    const { executeGraph } = await import('../orchestration/graph/graph-executor.js');
+    const { EventBus } = await import('./event-bus.js');
+    const { buildDelegatePlan, buildWarnPolicyEnforcement } = await import('./v2-delegate.js');
+
+    const bus = new EventBus();
+    const denyDecision = { allow: false as const, reason: 'denied for test' };
+    const denyEngine: IPolicyEngine = {
+      registerRule: () => {},
+      evaluate: () => denyDecision,
+      listRules: () => [{ id: 'always-deny', priority: 0, evaluate: () => denyDecision }],
+    };
+    const plan = buildDelegatePlan(makeTask());
+    const compiled = compilePlan(plan, {
+      policyEnforcement: buildWarnPolicyEnforcement(makeTask(), {
+        engine: denyEngine,
+        eventBus: bus,
+      }),
+    });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Gate did NOT halt the pipeline (warn) — route stage still ran.
+    const stageNode = result.value.nodeResults.find((r) => r.nodeId === 'route-model');
+    expect(stageNode?.status).toBe('success');
+    // Exactly one event per denying rule per gate run — bounded, non-flooding.
+    const policyEvents = bus.query({}).filter((e) => e.type === 'policy.evaluated');
+    expect(policyEvents).toHaveLength(1);
+  });
+
+  it('(d) BLOCK mode (opt-in) still throws on a denying rule (regression of #3177)', async () => {
+    const { enforceGatePolicy, PolicyBlockedError } = await import('./policy-evaluator.js');
+    const { buildWarnPolicyEnforcement } = await import('./v2-delegate.js');
+    const denyDecision = { allow: false as const, reason: 'denied' };
+    const denyEngine: IPolicyEngine = {
+      registerRule: () => {},
+      evaluate: () => denyDecision,
+      listRules: () => [{ id: 'always-deny', priority: 0, evaluate: () => denyDecision }],
+    };
+    const bundle = {
+      ...buildWarnPolicyEnforcement(makeTask(), { engine: denyEngine }),
+      mode: 'block' as const,
+    };
+    expect(() =>
+      enforceGatePolicy(bundle, { gateId: 'g', taskId: 't', stageType: 'route' })
+    ).toThrow(PolicyBlockedError);
+  });
+});
+
+// ============================================================================
+// Blast-radius: a non-v2-delegate compilePlan caller is UNAFFECTED (#3703)
+// ============================================================================
+
+describe('blast radius — compilePlan default unchanged (#3703)', () => {
+  it('(c) compilePlan without policyEnforcement → gate node is a no-op pass', async () => {
+    const { compilePlan } = await import('./plan-compiler.js');
+    const { executeGraph } = await import('../orchestration/graph/graph-executor.js');
+
+    // A gated plan compiled with NO policyEnforcement (the shared default for
+    // every non-v2-delegate caller). The gate must stay a no-op pass — it does
+    // not call the evaluator, emit events, or throw.
+    const plan = {
+      taskId: 'other-caller',
+      stages: [
+        {
+          id: 'analyze',
+          type: 'analyze' as const,
+          pluginId: 'nexus:x',
+          inputArtifacts: [],
+          outputArtifacts: [],
+          dependencies: [],
+          config: {},
+        },
+        {
+          id: 'execute',
+          type: 'execute' as const,
+          pluginId: 'nexus:y',
+          inputArtifacts: [],
+          outputArtifacts: [],
+          dependencies: ['analyze'],
+          config: {},
+        },
+      ],
+      policyGates: [
+        {
+          id: 'g1',
+          afterStage: 'analyze',
+          beforeStage: 'execute',
+          rules: ['trust-tier'],
+          onFail: 'warn' as const,
+        },
+      ],
+      estimatedCost: { totalTokensIn: 0, totalTokensOut: 0, estimatedCostUsd: 0, modelCalls: 0 },
+      approvalRequired: false,
+      maxIterations: 1,
+      timeoutMs: 30_000,
+    };
+    const compiled = compilePlan(plan); // <-- no policyEnforcement
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const gate = result.value.nodeResults.find((r) => r.nodeId === 'g1');
+    expect(gate?.status).toBe('success'); // no-op pass, did not throw/evaluate
   });
 });

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -18,7 +18,12 @@ import { createLogger } from '../core/index.js';
 import { PipelineRunner } from './pipeline-runner.js';
 import { getPipelineEventBus } from './event-bus.js';
 import { createDefaultPolicyEngine, type PipelineStateSnapshot } from './policy-engine.js';
-import { evaluatePipelinePolicy, getPolicyMode } from './policy-evaluator.js';
+import {
+  evaluatePipelinePolicy,
+  getPolicyMode,
+  getGateEnforcementMode,
+} from './policy-evaluator.js';
+import { START } from '../orchestration/graph/graph-types.js';
 
 /**
  * Narrows the untyped `task.metadata` bag into the policy engine's typed
@@ -32,9 +37,14 @@ function toPipelineStateSnapshot(metadata: Record<string, unknown>): PipelineSta
 import { buildBaseTaskContract } from './task-contract-builders.js';
 
 import type { CompiledPipeline } from './pipeline-runner.js';
-import type { TaskContract, PlanContract } from './task-contract.js';
-import type { PolicyContext } from './policy-engine.js';
-import type { PolicyEvalResult, PolicyViolation } from './policy-evaluator.js';
+import type { TaskContract, PlanContract, PolicyGateSpec } from './task-contract.js';
+import type { IPolicyEngine, PolicyContext } from './policy-engine.js';
+import type {
+  GatePolicyEnforcement,
+  PolicyEvalResult,
+  PolicyViolation,
+} from './policy-evaluator.js';
+import type { IEventBus } from './event-types.js';
 
 const logger = createLogger({ component: 'V2Delegate' });
 
@@ -50,14 +60,44 @@ type DelegatePipelineResult =
 /**
  * Creates a compiled V2 pipeline for delegate_to_model from a TaskContract.
  *
- * The pipeline has a single 'route' stage that selects the optimal model.
- * This is intentionally minimal — the routing logic lives in the stage
- * handler (placeholder here, real handler injected by the MCP tool).
+ * The pipeline has a single 'route' stage guarded by an entry policy gate.
+ * Routing logic lives in the stage handler (placeholder here, real handler
+ * injected by the MCP tool).
+ *
+ * Activation (#3703): the compile call now supplies a **default-WARN**
+ * `policyEnforcement` bundle, so the entry gate evaluates real policy at the
+ * stage boundary in production. WARN mode never throws and never blocks — it
+ * only logs + emits `policy.evaluated` events on a violation, generating the
+ * autonomy-soak evidence #3653 needs. This is scoped to v2-delegate's own
+ * compile call: the shared `compilePlan` default (no enforcement) is
+ * unchanged, so every other `compilePlan` caller is unaffected.
  */
 export function createDelegatePipeline(task: TaskContract): DelegatePipelineResult {
-  const plan = buildPlan(task);
+  const plan = buildDelegatePlan(task);
   const runner = new PipelineRunner();
-  return runner.compile(plan);
+  return runner.compile(plan, { policyEnforcement: buildWarnPolicyEnforcement(task) });
+}
+
+/**
+ * Builds the default-WARN policy-enforcement bundle for the v2-delegate entry
+ * gate (#3703). The mode resolves via `getGateEnforcementMode()` (warn by
+ * default; block/off opt-in via `NEXUS_POLICY_GATE_MODE`), so this is safe to
+ * activate in production — warn never throws.
+ *
+ * `overrides` exists for tests (inject a denying engine / capture events); the
+ * production call passes none, getting the default engine + the shared pipeline
+ * event bus.
+ */
+export function buildWarnPolicyEnforcement(
+  task: TaskContract,
+  overrides: { engine?: IPolicyEngine; eventBus?: IEventBus } = {}
+): GatePolicyEnforcement {
+  return {
+    engine: overrides.engine ?? createDefaultPolicyEngine(),
+    pipelineState: toPipelineStateSnapshot(task.metadata),
+    eventBus: overrides.eventBus ?? getPipelineEventBus(),
+    mode: getGateEnforcementMode(),
+  };
 }
 
 // ============================================================================
@@ -208,15 +248,37 @@ function formatViolation(v: PolicyViolation): string {
 }
 
 // ============================================================================
-// Internal
+// Plan construction
 // ============================================================================
 
-function buildPlan(task: TaskContract): PlanContract {
+/** Id of the entry stage the policy gate guards. */
+const ROUTE_STAGE_ID = 'route-model';
+
+/**
+ * Entry gate for the v2-delegate pipeline (#3703). Sits on the START boundary
+ * before the route stage so policy is evaluated before any routing work runs.
+ * `onFail: 'warn'` documents intent — the effective runtime mode is resolved by
+ * the enforcement bundle (warn by default; block opt-in via env).
+ */
+const ENTRY_GATE: PolicyGateSpec = {
+  id: 'gate-delegate-entry',
+  afterStage: START,
+  beforeStage: ROUTE_STAGE_ID,
+  rules: ['trust-tier'],
+  onFail: 'warn',
+};
+
+/**
+ * Builds the v2-delegate PlanContract: a single route stage guarded by the
+ * entry policy gate. Exported so the activation path and tests share one
+ * canonical plan shape (#3703).
+ */
+export function buildDelegatePlan(task: TaskContract): PlanContract {
   return {
     taskId: task.id,
     stages: [
       {
-        id: 'route-model',
+        id: ROUTE_STAGE_ID,
         type: 'route',
         pluginId: 'nexus:model-router',
         inputArtifacts: [],
@@ -228,7 +290,7 @@ function buildPlan(task: TaskContract): PlanContract {
         },
       },
     ],
-    policyGates: [],
+    policyGates: [ENTRY_GATE],
     estimatedCost: {
       totalTokensIn: 0,
       totalTokensOut: 0,


### PR DESCRIPTION
Closes #3703 (child of #3194). consensus_vote (higher_order 7/7) APPROVED with strict conditions — all satisfied below.

## What
Wires the dormant #3177 enforcement mechanism into production. #3177 shipped `enforceGatePolicy`/`evaluatePipelinePolicy` + `PolicyBlockedError` + the `GatePolicyEnforcement` (warn/block/off) bundle, consumed by `createGateHandler` — but no production caller supplied `policyEnforcement` and `v2-delegate.ts` emitted `policyGates: []`, so it never ran.

Now:
- `buildDelegatePlan` (was `buildPlan`) carries a real entry gate `gate-delegate-entry` on the `START` boundary before the `route-model` stage.
- `createDelegatePipeline` supplies a **default-WARN** `policyEnforcement` bundle (`buildWarnPolicyEnforcement`) into its own `runner.compile` call. Mode resolves via `getGateEnforcementMode()` — warn by default; block/off opt-in via `NEXUS_POLICY_GATE_MODE`.
- `plan-compiler` interposes an entry gate (`afterStage === START`) on the START edge of a no-dependency stage.

Stage-boundary policy now actually runs in production. WARN logs + emits one `policy.evaluated` event per violation, never throws/blocks — the autonomy-soak evidence #3653 needs.

## Vote conditions
1. **Shelf-ware re-verified at HEAD** — confirmed `policyGates: []` + no production caller supplied `policyEnforcement` before this change.
2. **Blast radius — narrowly scoped.** The shared `compilePlan`/`PlanCompileOptions` default is unchanged; enforcement is threaded only from v2-delegate's compile call. Sweep: `compilePlan` is called only from `PipelineRunner.compile`, which is called in non-test code only from `createDelegatePipeline` (used by v2-delegate + v2-orchestrate). All other gated plans still get no-op-pass gates. Full pipeline suite green, including `v2-orchestrate.test.ts` (shared path) and `audit-trail.test.ts`.
3. **WARN provably non-throwing + non-flooding** — `enforceGatePolicy` only throws in `block` mode; new tests assert WARN does not throw even when a rule denies, and emits exactly one event per denying rule per gate run.

## Tests
- `plan-compiler.test.ts`: +2 (START-gate interposition; gate runs before guarded stage) → 18 total.
- `v2-delegate.test.ts`: +5 (gate present + compiled; default-WARN gate runs; WARN no-throw + 1 event on deny; BLOCK opt-in still throws; blast-radius no-op pass for unenforced caller) → 23 total.
- Full `src/pipeline` suite: **43 files / 601 tests passed**. `tsc --noEmit` clean. eslint `--no-cache` clean.

Scope note: does NOT implement the consensus→execute seam (#3704) or audit convergence — activation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)