### PR TITLE
feat(registry): propagate overlay updates to routing without restart (#3185)

### DIFF
--- a/.changeset/context-unavailable-observability-3180.md
+++ b/.changeset/context-unavailable-observability-3180.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+orchestration: make graph-start context retrieval observable (#3180)
+
+When `getContextForTask` fails during graph-start context population, the
+executor no longer swallows it at debug. It now logs a `warn`, emits an
+aggregatable `context_unavailable` graph event (sanitized message only — no
+stack/paths/secrets), and continues with empty context (best-effort contract
+preserved). `executionId` is threaded into `getContextForTask` for correlation,
+and the inferred task category is surfaced. Scope is the graph boundary only;
+the other `getContextForTask` call sites are tracked in #3699.

--- a/.changeset/registry-hot-reload-3185.md
+++ b/.changeset/registry-hot-reload-3185.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+Propagate model-registry / overlay updates to routing without a process restart (#3185).
+
+Two freezes are closed:
+
+- `UnifiedAdapterRegistry` no longer caches its task→CLI routing at construction. Routing is re-resolved on every `getRouting` / `getAdapter` / `getSnapshot` read (~10 categories — negligible cost), so a post-startup registry/overlay change takes effect immediately.
+- `getDefaultModelForCli` and `getInTreeCapabilitiesMatrix` now resolve through the overlay-bearing default registry (via a non-constructing `peekDefaultRegistry()` guard) instead of the frozen in-tree constants, so operator/user manifest overrides participate at runtime. A static fallback preserves the early-bootstrap path (no recursion, no forced filesystem read at module load).
+
+Adds `reloadDefaultRegistry()` — the single hot-reload entry point. It re-reads the manifest overlays (fail-closed; never throws on a malformed manifest) and atomically resets BOTH the model-registry singleton and the `UnifiedAdapterRegistry`, so there is never a state where one is fresh and the other stale. Wired into `registry refresh`, which now hot-reloads in-process and updates its message accordingly.

--- a/packages/nexus-agents/src/adapters/unified-registry.test.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.test.ts
@@ -23,6 +23,8 @@ import {
 import type { ILogger } from '../core/index.js';
 import { TASK_SPECIALIZATION_MATRIX } from '../config/task-specialization.js';
 import { DEFAULT_MODEL_CAPABILITIES } from '../config/in-tree-data.js';
+import * as modelConfigHelpers from '../config/model-config-helpers.js';
+import type { ModelId } from '../config/model-capabilities-types.js';
 
 // Silence logging in tests
 const mockLogger = {
@@ -407,5 +409,54 @@ describe('withDefaultOnRetirement — onRetirement dead-bridge wiring', () => {
     const custom = vi.fn();
     const resolved = withDefaultOnRetirement(true, { onRetirement: custom }, freshLogger());
     expect(resolved?.onRetirement).toBe(custom);
+  });
+});
+
+// ============================================================================
+// #3185 — routing is re-resolved on read; no construction-time freeze.
+// ============================================================================
+
+describe('UnifiedAdapterRegistry — routing re-resolves on read (#3185)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetGlobalRegistry();
+  });
+
+  it('getRouting reflects a post-construction default-model change (no stale cache)', () => {
+    const spy = vi
+      .spyOn(modelConfigHelpers, 'getDefaultModelForCli')
+      .mockReturnValue('claude-opus');
+    const registry = createUnifiedRegistry({ logger: mockLogger });
+
+    // 'planning' routes to claude → primaryModel resolved via the helper.
+    const before = registry.getRouting('planning');
+    expect(before?.primaryModel).toBe('claude-opus');
+
+    // Simulate a registry/overlay update that changes the resolved default.
+    spy.mockReturnValue('claude-opus-overlay' as ModelId);
+
+    // The SAME instance must reflect the change — proving no construction-time
+    // freeze of the routing table.
+    const after = registry.getRouting('planning');
+    expect(after?.primaryModel).toBe('claude-opus-overlay');
+    registry.dispose();
+  });
+
+  it('getSnapshot re-reads routing on each call', () => {
+    const spy = vi
+      .spyOn(modelConfigHelpers, 'getDefaultModelForCli')
+      .mockReturnValue('claude-opus');
+    const registry = createUnifiedRegistry({ logger: mockLogger });
+
+    const planningBefore = registry
+      .getSnapshot()
+      .taskRouting.find((r) => r.category === 'planning');
+    expect(planningBefore?.primaryModel).toBe('claude-opus');
+
+    spy.mockReturnValue('claude-opus-overlay' as ModelId);
+
+    const planningAfter = registry.getSnapshot().taskRouting.find((r) => r.category === 'planning');
+    expect(planningAfter?.primaryModel).toBe('claude-opus-overlay');
+    registry.dispose();
   });
 });

--- a/packages/nexus-agents/src/adapters/unified-registry.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.ts
@@ -126,9 +126,6 @@ export class UnifiedAdapterRegistry {
   private readonly enableMissingModelFallback: boolean;
   private readonly missingModelFallbackOptions: ModelNotFoundFallbackOptions | undefined;
 
-  /** Pre-computed task → CLI routing (immutable after construction). */
-  private readonly taskRouting: ReadonlyMap<TaskCategory, TaskRoutingEntry>;
-
   /** Per-CLI adapter cache — max 3 entries (claude/gemini/codex). */
   private readonly cliAdapters = new Map<CliName, IResilientAdapter>();
 
@@ -144,9 +141,8 @@ export class UnifiedAdapterRegistry {
       config?.missingModelFallbackOptions,
       this.logger
     );
-    this.taskRouting = this.buildTaskRouting();
     this.logger.info('UnifiedAdapterRegistry initialized', {
-      categories: this.taskRouting.size,
+      categories: TASK_SPECIALIZATION_MATRIX.length,
       models: getInTreeCapabilitiesMatrix().models.length,
       missingModelFallback: this.enableMissingModelFallback,
     });
@@ -174,11 +170,12 @@ export class UnifiedAdapterRegistry {
   }
 
   /**
-   * Get adapter for a task category. Uses pre-computed routing.
-   * Falls back to default adapter if category unknown.
+   * Get adapter for a task category. Routing is re-resolved on every read
+   * (#3185) so a post-startup overlay/registry update propagates without a
+   * restart. Falls back to default adapter if category unknown.
    */
   getAdapter(category: TaskCategory): IResilientAdapter {
-    const routing = this.taskRouting.get(category);
+    const routing = this.getRouting(category);
     if (routing === undefined) {
       this.logger.warn('Unknown task category, using default', { category });
       return this.getDefault();
@@ -289,21 +286,30 @@ export class UnifiedAdapterRegistry {
   }
 
   /**
-   * Get snapshot of registry state for observability/debugging.
+   * Get snapshot of registry state for observability/debugging. Routing is
+   * re-resolved on read (#3185) so the snapshot reflects the live registry.
    */
   getSnapshot(): RegistrySnapshot {
     return {
-      taskRouting: [...this.taskRouting.values()],
+      taskRouting: TASK_SPECIALIZATION_MATRIX.map((spec) => this.resolveRouting(spec)),
       cachedAdapters: [...this.cliAdapters.keys()],
       availableModels: getInTreeCapabilitiesMatrix().models.length,
     };
   }
 
   /**
-   * Get the pre-computed routing for a specific category.
+   * Resolve the routing for a specific category.
+   *
+   * Computed on every read (#3185) rather than cached at construction, so a
+   * post-startup model-registry / overlay update (e.g. a default-model change
+   * surfaced via `getDefaultModelForCli`) propagates to routing decisions
+   * without a process restart. The matrix is ~10 categories — the per-read
+   * resolution cost is negligible.
    */
   getRouting(category: TaskCategory): TaskRoutingEntry | undefined {
-    return this.taskRouting.get(category);
+    const spec = TASK_SPECIALIZATION_MATRIX.find((s) => s.category === category);
+    if (spec === undefined) return undefined;
+    return this.resolveRouting(spec);
   }
 
   /**
@@ -323,18 +329,17 @@ export class UnifiedAdapterRegistry {
   // Private
   // --------------------------------------------------------------------------
 
-  private buildTaskRouting(): ReadonlyMap<TaskCategory, TaskRoutingEntry> {
-    const routing = new Map<TaskCategory, TaskRoutingEntry>();
-    for (const spec of TASK_SPECIALIZATION_MATRIX) {
-      const primaryModel = resolveDefaultModel(spec.primaryCli);
-      routing.set(spec.category, {
-        category: spec.category,
-        primaryCli: spec.primaryCli,
-        secondaryCli: spec.secondaryCli,
-        primaryModel,
-      });
-    }
-    return routing;
+  /**
+   * Resolve one specialization-matrix row into a routing entry, re-reading the
+   * primary model from the (overlay-aware) model registry each call (#3185).
+   */
+  private resolveRouting(spec: (typeof TASK_SPECIALIZATION_MATRIX)[number]): TaskRoutingEntry {
+    return {
+      category: spec.category,
+      primaryCli: spec.primaryCli,
+      secondaryCli: spec.secondaryCli,
+      primaryModel: resolveDefaultModel(spec.primaryCli),
+    };
   }
 }
 

--- a/packages/nexus-agents/src/cli/registry-command.ts
+++ b/packages/nexus-agents/src/cli/registry-command.ts
@@ -25,7 +25,11 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { nexusDataPath } from '../config/nexus-data-dir.js';
 
-import { getDefaultRegistry, type EntrySource } from '../config/model-registry.js';
+import {
+  getDefaultRegistry,
+  reloadDefaultRegistry,
+  type EntrySource,
+} from '../config/model-registry.js';
 import { loadGeneratedRegistryEntries } from '../config/models-generated-loader.js';
 import {
   USER_MANIFEST_ENV_VAR,
@@ -292,11 +296,16 @@ async function refreshCommand(options: RegistryCommandOptions): Promise<Registry
 
   mkdirSync(dirname(dest), { recursive: true });
   writeFileSync(dest, artifact.body, 'utf-8');
+  // Hot-reload the in-process model registry + adapter routing so the refresh
+  // takes effect immediately, without a restart (#3185). Re-reads the overlay
+  // (fail-closed) and atomically resets both singletons.
+  await reloadDefaultRegistry();
   return {
     text: formatRefreshReport('wrote to', source, artifact, dest, [
       '',
-      'The refreshed file takes precedence over the bundled registry on the next',
-      'run. Restart any running CLI / MCP server for the change to take effect.',
+      'The in-process model registry and adapter routing were hot-reloaded — the',
+      'refresh is live now in THIS process (#3185). Other already-running CLI / MCP',
+      'server processes still need a restart (or their own refresh) to pick it up.',
     ]),
     exitCode: 0,
   };

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -28,7 +28,7 @@ import type {
   SpecialFeature,
   ToolCapability,
 } from './model-capabilities-types.js';
-import { getDefaultRegistry, type ModelEntry } from './model-registry.js';
+import { getDefaultRegistry, peekDefaultRegistry, type ModelEntry } from './model-registry.js';
 
 /**
  * Average latency estimates per CLI (ms). Returned by a function (not
@@ -125,9 +125,29 @@ export function getModelQualityScores(modelId: ModelId): QualityScores | undefin
   return lookupInTree(modelId)?.qualityScores;
 }
 
-/** Get the default (strongest) model for a given CLI tool. */
+/**
+ * Get the default (strongest) model for a given CLI tool.
+ *
+ * The per-CLI default *policy* (which model id is strongest) lives in the
+ * static `DEFAULT_MODEL_PER_CLI` map. As of #3185 the resolved id is routed
+ * through the overlay-bearing default registry so an operator overlay that
+ * renames / re-aliases the default model is honored at runtime without a
+ * process restart — the returned canonical id reflects the live registry.
+ *
+ * EARLY-BOOTSTRAP GUARD (vote condition 1): we read via `peekDefaultRegistry()`
+ * which returns the singleton ONLY if it already exists and NEVER constructs
+ * it. Module-load-time callers (e.g. gemini-adapter's top-level
+ * `DEFAULT_GEMINI_CLI_MODEL` const) therefore get the static id without forcing
+ * the filesystem-touching overlay load — dodging the TDZ / re-entrancy hazard
+ * documented for the `inTreeById()` builders above. After any consumer has
+ * built the registry (or after `reloadDefaultRegistry`), overlay-aware
+ * resolution applies. Never recurses, never throws at bootstrap.
+ */
 export function getDefaultModelForCli(cli: CliNameLiteral): ModelId {
-  return DEFAULT_MODEL_PER_CLI[cli];
+  const staticDefault = DEFAULT_MODEL_PER_CLI[cli];
+  const registry = peekDefaultRegistry();
+  if (registry === undefined) return staticDefault;
+  return registry.getEntry(staticDefault).id as ModelId;
 }
 
 /** Get the model name the CLI binary expects (e.g., 'gemini-2.5-pro'). */
@@ -381,16 +401,28 @@ export function buildModelInfo(
  * from `DEFAULT_MODEL_CAPABILITIES` because the registry doesn't
  * carry it — slice E closes that gap when the legacy module is
  * deleted entirely.
+ *
+ * OVERLAY-AWARE (#3185): when the default registry has already been
+ * constructed, each in-tree id is re-resolved through it so operator/user
+ * manifest overrides (pricing, contextWindow, etc.) are reflected without a
+ * process restart. Before the singleton exists (early bootstrap) it falls back
+ * to the static in-tree converter via `peekDefaultRegistry()` — never forcing
+ * the filesystem-touching overlay load.
  */
 export function getInTreeCapabilitiesMatrix(): {
   readonly version: number;
   readonly updatedAt: string;
   readonly models: readonly ModelCapability[];
 } {
+  const registry = peekDefaultRegistry();
+  const models =
+    registry === undefined
+      ? buildInTreeEntries().map(entryToCapability)
+      : buildInTreeEntries().map((e) => entryToCapability(registry.getEntry(e.id)));
   return {
     version: DEFAULT_MODEL_CAPABILITIES.version,
     updatedAt: DEFAULT_MODEL_CAPABILITIES.updatedAt,
-    models: buildInTreeEntries().map(entryToCapability),
+    models,
   };
 }
 

--- a/packages/nexus-agents/src/config/model-registry.test.ts
+++ b/packages/nexus-agents/src/config/model-registry.test.ts
@@ -7,10 +7,13 @@ import {
   ModelRegistry,
   deriveEntry,
   getDefaultRegistry,
+  peekDefaultRegistry,
+  reloadDefaultRegistry,
   setDefaultRegistry,
   type ModelEntry,
 } from './model-registry.js';
 import { resolveModelIdentitySync } from './model-identity.js';
+import { getDefaultModelForCli, getInTreeCapabilitiesMatrix } from './model-config-helpers.js';
 
 const sampleAuthoritative: ModelEntry = {
   id: 'claude-opus-4-1',
@@ -274,5 +277,128 @@ models:
       setDefaultRegistry(undefined);
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ============================================================================
+// #3185 — hot-reload of the model registry without a process restart.
+// ============================================================================
+
+describe('peekDefaultRegistry (#3185)', () => {
+  it('returns undefined before construction and never constructs the singleton', () => {
+    setDefaultRegistry(undefined);
+    expect(peekDefaultRegistry()).toBeUndefined();
+    // Still undefined — peek must NOT have triggered lazy construction.
+    expect(peekDefaultRegistry()).toBeUndefined();
+  });
+
+  it('returns the live singleton once getDefaultRegistry has built it', () => {
+    setDefaultRegistry(undefined);
+    const built = getDefaultRegistry();
+    expect(peekDefaultRegistry()).toBe(built);
+    setDefaultRegistry(undefined);
+  });
+});
+
+describe('getDefaultModelForCli — early-bootstrap fallback (#3185 condition 1)', () => {
+  it('returns the static default id with NO registry constructed (no recursion)', () => {
+    setDefaultRegistry(undefined);
+    // peekDefaultRegistry() is undefined here, so the static fallback fires.
+    expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+    // And it must NOT have constructed the registry as a side effect.
+    expect(peekDefaultRegistry()).toBeUndefined();
+  });
+});
+
+describe('reloadDefaultRegistry — overlay propagation without restart (#3185)', () => {
+  it('propagates a post-startup overlay edit to getInTreeCapabilitiesMatrix + getDefaultModelForCli', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
+
+    setDefaultRegistry(undefined);
+    // Build the registry with NO overlay first — baseline contextWindow.
+    const baseline = getInTreeCapabilitiesMatrix().models.find((m) => m.id === 'claude-opus');
+    expect(baseline).toBeDefined();
+    expect(baseline?.contextWindow).not.toBe(123456);
+
+    const dir = mkdtempSync(join(tmpdir(), 'reload-overlay-'));
+    const path = join(dir, 'models-manifest.yaml');
+    writeFileSync(
+      path,
+      `version: 1
+models:
+  - id: claude-opus
+    vendor: anthropic
+    family: claude-opus
+    cliName: claude
+    contextWindow: 123456
+`,
+      'utf-8'
+    );
+    const previous = process.env['NEXUS_MODELS_OVERLAY_PATH'];
+    process.env['NEXUS_MODELS_OVERLAY_PATH'] = path;
+    try {
+      // Reload WITHOUT a process restart — overlay must now win.
+      await reloadDefaultRegistry();
+      const after = getInTreeCapabilitiesMatrix().models.find((m) => m.id === 'claude-opus');
+      expect(after?.contextWindow).toBe(123456);
+      // getDefaultModelForCli still resolves to the canonical id, now via the
+      // overlay-bearing registry (it exists post-reload).
+      expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+      expect(peekDefaultRegistry()).toBeDefined();
+    } finally {
+      if (previous === undefined) delete process.env['NEXUS_MODELS_OVERLAY_PATH'];
+      else process.env['NEXUS_MODELS_OVERLAY_PATH'] = previous;
+      setDefaultRegistry(undefined);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('never throws on a malformed overlay during re-read (condition 3)', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
+
+    setDefaultRegistry(undefined);
+    const dir = mkdtempSync(join(tmpdir(), 'reload-malformed-'));
+    const path = join(dir, 'models-manifest.yaml');
+    writeFileSync(path, ':\n  - not: [valid: yaml: at all', 'utf-8');
+    const previous = process.env['NEXUS_MODELS_OVERLAY_PATH'];
+    process.env['NEXUS_MODELS_OVERLAY_PATH'] = path;
+    try {
+      // Must degrade to the in-tree floor, not throw.
+      await expect(reloadDefaultRegistry()).resolves.toBeDefined();
+      // In-tree entries still resolve.
+      expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+    } finally {
+      if (previous === undefined) delete process.env['NEXUS_MODELS_OVERLAY_PATH'];
+      else process.env['NEXUS_MODELS_OVERLAY_PATH'] = previous;
+      setDefaultRegistry(undefined);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('reloadDefaultRegistry — atomic dual-singleton reset (#3185 condition 2)', () => {
+  it('resets BOTH the model registry and the UnifiedAdapterRegistry together', async () => {
+    const { getGlobalRegistry } = await import('../adapters/unified-registry.js');
+
+    setDefaultRegistry(undefined);
+    // Construct both singletons.
+    const modelBefore = getDefaultRegistry();
+    const adapterBefore = getGlobalRegistry();
+
+    await reloadDefaultRegistry();
+
+    const modelAfter = getDefaultRegistry();
+    const adapterAfter = getGlobalRegistry();
+
+    // Both must be fresh instances — no state where one is stale + one fresh.
+    expect(modelAfter).not.toBe(modelBefore);
+    expect(adapterAfter).not.toBe(adapterBefore);
+
+    adapterAfter.dispose();
+    setDefaultRegistry(undefined);
   });
 });

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -320,6 +320,19 @@ export function getDefaultRegistry(): ModelRegistry {
   return globalRegistry;
 }
 
+/**
+ * Return the global registry ONLY if it has already been constructed; never
+ * triggers lazy construction (#3185). Used by the early-bootstrap-sensitive
+ * `getDefaultModelForCli` path so a module-load-time caller does NOT force the
+ * filesystem-touching overlay load — that is the TDZ / re-entrancy hazard the
+ * `inTreeById()` filesystem-free builders were created to dodge
+ * (model-config-helpers.ts ~L60-69). Once any consumer has built the registry
+ * (or after `reloadDefaultRegistry`), overlay-aware resolution kicks in.
+ */
+export function peekDefaultRegistry(): ModelRegistry | undefined {
+  return globalRegistry;
+}
+
 function buildDefaultRegistry(): ModelRegistry {
   const overlay = loadManifestOverlay();
   const snapshot = loadModelsDevSnapshot();
@@ -341,4 +354,36 @@ function buildDefaultRegistry(): ModelRegistry {
 /** Replace the global registry. Reserved for tests + bootstrap. */
 export function setDefaultRegistry(registry: ModelRegistry | undefined): void {
   globalRegistry = registry;
+}
+
+/**
+ * Hot-reload the global model registry WITHOUT a process restart (#3185).
+ *
+ * Re-runs {@link buildDefaultRegistry} — which re-reads the operator/user
+ * manifest overlays, the models.dev snapshot, and the generated catalog from
+ * disk — and reassigns the singleton, so overlay edits made after startup
+ * (e.g. an updated `NEXUS_MODELS_OVERLAY_PATH`) propagate to every consumer
+ * that reads through `getDefaultRegistry()`.
+ *
+ * ATOMIC DUAL-SINGLETON RESET (vote condition 2): the model registry and the
+ * `UnifiedAdapterRegistry` are two independent singletons; the latter resolves
+ * routing through the former. Refreshing only the model registry would leave
+ * the adapter registry's cached default-model strings stale. This is the ONE
+ * reload entry point — it resets BOTH together so there is never a state where
+ * one is fresh and the other stale. The adapter-registry reset is a dynamic
+ * import to avoid a static import cycle
+ * (unified-registry → model-config-helpers → model-registry).
+ *
+ * The overlay loader is fail-closed (never throws on a missing / malformed
+ * manifest — vote condition 3); a bad re-read degrades to the in-tree floor
+ * rather than throwing, exactly as first construction does.
+ */
+export async function reloadDefaultRegistry(): Promise<ModelRegistry> {
+  globalRegistry = buildDefaultRegistry();
+  // Reset the adapter-registry singleton so its routing (re-resolved on read
+  // since #3185) and any cached adapters pick up the new model registry.
+  // Dynamic import breaks the static cycle.
+  const { resetGlobalRegistry } = await import('../adapters/unified-registry.js');
+  resetGlobalRegistry();
+  return globalRegistry;
 }

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -80,6 +80,13 @@ export interface ContextRetrieverOptions {
   readonly limit?: number;
   /** Optional logger override. */
   readonly logger?: ILogger;
+  /**
+   * Optional correlation id for the calling execution (#3180). When present it
+   * is bound to a child logger so every per-backend log line for this retrieval
+   * carries the same `executionId`, making a failure traceable back to its
+   * graph run. Backward-compatible: the four existing callers omit it.
+   */
+  readonly executionId?: string;
 }
 
 /** Sensible default — small enough to embed in a prompt, large enough to be useful. */
@@ -99,7 +106,12 @@ const DEFAULT_LIMIT = 5;
  */
 export async function getContextForTask(options: ContextRetrieverOptions): Promise<UnifiedContext> {
   const limit = options.limit ?? DEFAULT_LIMIT;
-  const logger = options.logger ?? createLogger({ component: 'ContextRetriever' });
+  const baseLogger = options.logger ?? createLogger({ component: 'ContextRetriever' });
+  // Bind the correlation id to every per-backend log line for this retrieval (#3180).
+  const logger =
+    options.executionId !== undefined
+      ? baseLogger.child({ executionId: options.executionId })
+      : baseLogger;
 
   const [
     beliefs,

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -291,7 +291,31 @@ function toEventSummary(event: GraphEvent): GraphEventSummary {
   return { type: event.type, detail: formatDetail(event) };
 }
 
+type HookEvent = Extract<GraphEvent, { type: 'hook_started' | 'hook_completed' | 'hook_failed' }>;
+
+/** Type guard for the three hook lifecycle events. */
+function isHookEvent(event: GraphEvent): event is HookEvent {
+  return (
+    event.type === 'hook_started' || event.type === 'hook_completed' || event.type === 'hook_failed'
+  );
+}
+
+/** Detail string for the three hook lifecycle events (split out for complexity). */
+function formatHookDetail(event: HookEvent): string {
+  const where = `${event.hookPhase}: ${event.hookName} on ${event.nodeId}`;
+  switch (event.type) {
+    case 'hook_started':
+      return where;
+    case 'hook_completed':
+      return `${where} in ${String(event.durationMs)}ms`;
+    case 'hook_failed':
+      return `${where}: ${event.error}`;
+  }
+}
+
 function formatDetail(event: GraphEvent): string {
+  // Hook events are dispatched out-of-switch to keep complexity within budget.
+  if (isHookEvent(event)) return formatHookDetail(event);
   switch (event.type) {
     case 'node_started':
       return `Starting ${event.nodeId}`;
@@ -305,12 +329,8 @@ function formatDetail(event: GraphEvent): string {
       return `${String(event.totalSteps)} steps, ${String(event.durationMs)}ms`;
     case 'state_updated':
       return event.updatedKeys.join(', ');
-    case 'hook_started':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}`;
-    case 'hook_completed':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId} in ${String(event.durationMs)}ms`;
-    case 'hook_failed':
-      return `${event.hookPhase}: ${event.hookName} on ${event.nodeId}: ${event.error}`;
+    case 'context_unavailable':
+      return `Context unavailable for category '${event.category}': ${event.error}`;
   }
 }
 

--- a/packages/nexus-agents/src/orchestration/graph/graph-events.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-events.ts
@@ -11,6 +11,16 @@
 import { getTimeProvider } from '../../core/index.js';
 import type { NodeResult, GraphExecuteOptions } from './graph-types.js';
 
+/** Fields for a {@link emitContextUnavailable} call (#3180). */
+interface ContextUnavailableArgs {
+  /** Inferred task category whose context retrieval failed. */
+  readonly category: string;
+  /** Sanitized failure message — message string only (caller must sanitize). */
+  readonly error: string;
+  /** Correlation id when the execution carries one. */
+  readonly executionId?: string;
+}
+
 /** Minimal context needed for event emission. */
 interface StepContext {
   readonly stepsExecuted: number;
@@ -93,6 +103,27 @@ export function emitStepCompleted(
     type: 'step_completed',
     stepNumber: ctx.stepsExecuted,
     nodesExecuted,
+    timestamp: getTimeProvider().now(),
+  });
+}
+
+/**
+ * Emits a `context_unavailable` event when unified-context retrieval failed at
+ * graph start (#3180). Guards on `options?.onEvent` like the other emitters, so
+ * it is a no-op when no listener is attached. The caller is responsible for
+ * passing an already-sanitized `error` (message string only).
+ */
+export function emitContextUnavailable(
+  args: ContextUnavailableArgs,
+  options?: GraphExecuteOptions
+): void {
+  const emit = options?.onEvent;
+  if (emit === undefined) return;
+  emit({
+    type: 'context_unavailable',
+    category: args.category,
+    error: args.error,
+    ...(args.executionId !== undefined ? { executionId: args.executionId } : {}),
     timestamp: getTimeProvider().now(),
   });
 }

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.test.ts
@@ -4,9 +4,9 @@
  * (Source: Issue #831 — Graph-based workflow orchestration)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GraphBuilder, overwrite, append, customReducer, START, END } from './graph-builder.js';
-import { executeGraph } from './graph-executor.js';
+import { executeGraph, GRAPH_UNIFIED_CONTEXT_KEY } from './graph-executor.js';
 import { InMemoryCheckpointStore } from './checkpoint-store.js';
 import type { GraphState, NodeResult, GraphEvent } from './graph-types.js';
 
@@ -835,3 +835,164 @@ describe('maxTraversals (Issue #910, E2-4)', () => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const noop = () => Promise.resolve({});
+
+// ---------------------------------------------------------------------------
+// Unified-context observability at graph start (#3180)
+// ---------------------------------------------------------------------------
+
+const EMPTY_UNIFIED_CONTEXT = {
+  beliefs: [],
+  similarMemories: [],
+  recentLearnings: [],
+  experiencePatterns: [],
+  outcomes: null,
+  priorStrategies: [],
+  researchInsights: [],
+};
+
+// Controllable mock for the dynamically imported context-retriever. The real
+// inferTaskCategory is preserved so category-inference assertions exercise
+// production logic; only getContextForTask is swapped.
+const getContextForTaskMock = vi.fn();
+vi.mock('../../context/context-retriever.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../context/context-retriever.js')>();
+  return {
+    ...actual,
+    getContextForTask: (...args: unknown[]): unknown => getContextForTaskMock(...args),
+  };
+});
+
+describe('graph-start context observability (#3180)', () => {
+  beforeEach(() => {
+    getContextForTaskMock.mockReset();
+    getContextForTaskMock.mockResolvedValue(EMPTY_UNIFIED_CONTEXT);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const singleNodeGraph = () =>
+    new GraphBuilder()
+      .addState('value', overwrite(0))
+      .addNode('A', () => Promise.resolve({ value: 1 }))
+      .addEdge(START, 'A')
+      .addEdge('A', END)
+      .compile();
+
+  it('(a) retrieval throw → warn + exactly one sanitized context_unavailable event, graph still completes', async () => {
+    getContextForTaskMock.mockRejectedValue(new Error('backend exploded'));
+    // The structured logger writes to a stdout/stderr stream, not console.warn.
+    const writes: string[] = [];
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    // 'fix this security bug' → inferTaskCategory → 'security_review'
+    const result = await executeGraph(
+      graph.value,
+      { task: 'fix this security bug' },
+      { onEvent: (e) => events.push(e), executionId: 'exec-3180' }
+    );
+
+    // Graph still COMPLETES with empty context (best-effort contract).
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.finalState['value']).toBe(1);
+    expect(result.value.finalState[GRAPH_UNIFIED_CONTEXT_KEY]).toBeUndefined();
+
+    // Exactly ONE context_unavailable event with correct fields.
+    const ctxEvents = events.filter((e) => e.type === 'context_unavailable');
+    expect(ctxEvents).toHaveLength(1);
+    const evt = ctxEvents[0];
+    if (evt?.type !== 'context_unavailable') throw new Error('unreachable');
+    expect(evt.category).toBe('security_review');
+    expect(evt.executionId).toBe('exec-3180');
+    expect(evt.error).toBe('backend exploded');
+    // Sanitized: no stack trace leaked into the payload.
+    expect(evt.error).not.toContain('at ');
+    expect(typeof evt.timestamp).toBe('number');
+
+    // A WARN was logged (level + the warn message text appear in the output).
+    const logged = writes.join('');
+    expect(logged).toContain('warn');
+    expect(logged).toContain('context retrieval failed');
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('(b) success path → executionId is threaded into getContextForTask options', async () => {
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const result = await executeGraph(
+      graph.value,
+      { task: 'add a new feature' },
+      { executionId: 'exec-success' }
+    );
+    expect(result.ok).toBe(true);
+
+    expect(getContextForTaskMock).toHaveBeenCalledTimes(1);
+    const arg = getContextForTaskMock.mock.calls[0]?.[0] as {
+      task: string;
+      category: string;
+      executionId?: string;
+    };
+    expect(arg.task).toBe('add a new feature');
+    expect(arg.executionId).toBe('exec-success');
+    // 'add a new feature' → code_generation
+    expect(arg.category).toBe('code_generation');
+  });
+
+  it('(c) absent/empty task → early return: no retrieval, no event', async () => {
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    // No 'task' key in inputs at all.
+    const result = await executeGraph(graph.value, {}, { onEvent: (e) => events.push(e) });
+    expect(result.ok).toBe(true);
+
+    expect(getContextForTaskMock).not.toHaveBeenCalled();
+    expect(events.some((e) => e.type === 'context_unavailable')).toBe(false);
+  });
+
+  it('(d) per-backend partial failure that overall resolves → no event', async () => {
+    // getContextForTask never throws on a single-backend failure — it returns a
+    // (possibly empty) UnifiedContext. Model that: resolve normally → no event.
+    getContextForTaskMock.mockResolvedValue(EMPTY_UNIFIED_CONTEXT);
+
+    const graph = singleNodeGraph();
+    expect(graph.ok).toBe(true);
+    if (!graph.ok) return;
+
+    const events: GraphEvent[] = [];
+    const result = await executeGraph(
+      graph.value,
+      { task: 'investigate something' },
+      { onEvent: (e) => events.push(e) }
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(events.some((e) => e.type === 'context_unavailable')).toBe(false);
+    // Empty context was still stashed on success.
+    expect(result.value.finalState[GRAPH_UNIFIED_CONTEXT_KEY]).toEqual(EMPTY_UNIFIED_CONTEXT);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-executor.ts
@@ -38,6 +38,7 @@ import {
   emitStateUpdated,
   emitStepCompleted,
   emitExecutionComplete,
+  emitContextUnavailable,
 } from './graph-events.js';
 import { runPreconditions, runVerification } from './graph-hooks.js';
 import { categorizeOutcomeError } from '../outcomes/outcome-types.js';
@@ -79,27 +80,49 @@ const DEFAULT_TIMEOUT_MS = GRAPH_TIMEOUTS.defaultMs;
  */
 export const GRAPH_UNIFIED_CONTEXT_KEY = '__unifiedContext';
 
-async function populateUnifiedContextOnState(state: GraphState): Promise<void> {
-  try {
-    const taskCandidate = state['task'];
-    if (typeof taskCandidate !== 'string' || taskCandidate === '') return;
+/** Optional `{ executionId }` fragment, omitted when no correlation id. */
+function execIdFields(executionId?: string): { executionId?: string } {
+  return executionId !== undefined ? { executionId } : {};
+}
 
-    const { getContextForTask, inferTaskCategory } =
-      await import('../../context/context-retriever.js');
-    const ctx = await getContextForTask({
-      task: taskCandidate,
-      category: inferTaskCategory(taskCandidate),
-      logger,
-    });
+async function populateUnifiedContextOnState(
+  state: GraphState,
+  options?: GraphExecuteOptions
+): Promise<void> {
+  const taskCandidate = state['task'];
+  if (typeof taskCandidate !== 'string' || taskCandidate === '') return;
+
+  const { getContextForTask, inferTaskCategory } =
+    await import('../../context/context-retriever.js');
+  // Capture the inferred category up front so the failure path can report it.
+  const category = inferTaskCategory(taskCandidate);
+  const executionId = options?.executionId;
+  const execFields = execIdFields(executionId);
+
+  try {
+    const ctx = await getContextForTask({ task: taskCandidate, category, logger, ...execFields });
     state[GRAPH_UNIFIED_CONTEXT_KEY] = ctx;
     logger.debug('Graph start: unified memory context stashed', {
+      category,
+      ...execFields,
       beliefs: ctx.beliefs.length,
       similarMemories: ctx.similarMemories.length,
       experiencePatterns: ctx.experiencePatterns.length,
       outcomesTotal: ctx.outcomes?.totalTasks ?? 0,
     });
   } catch (error: unknown) {
-    logger.debug('Graph start: context retrieval failed', { error: getErrorMessage(error) });
+    // Best-effort contract preserved: the graph still runs with empty context.
+    // But the failure is now observable (#3180) — a warn log plus an
+    // aggregatable `context_unavailable` event through the EventBus/onEvent
+    // path — instead of a swallowed debug line. `getErrorMessage` yields a
+    // sanitized message string only (no stack/paths/secrets).
+    const message = getErrorMessage(error);
+    logger.warn('Graph start: context retrieval failed; continuing with empty context', {
+      category,
+      ...execFields,
+      error: message,
+    });
+    emitContextUnavailable({ category, error: message, ...execFields }, options);
   }
 }
 
@@ -142,7 +165,7 @@ export async function executeGraph(
   // under a well-known key so node implementations can consume it without
   // a second fetch. Best-effort: failure is logged and silently produces
   // an empty context.
-  await populateUnifiedContextOnState(initialState);
+  await populateUnifiedContextOnState(initialState, options);
 
   const ctx: ExecutionContext = {
     state: initialState,

--- a/packages/nexus-agents/src/orchestration/graph/graph-types.ts
+++ b/packages/nexus-agents/src/orchestration/graph/graph-types.ts
@@ -408,7 +408,35 @@ export type GraphEvent =
       readonly error: string;
       readonly stepNumber: number;
       readonly timestamp: number;
-    };
+    }
+  | ContextUnavailableEvent;
+
+/**
+ * Emitted when unified-memory context retrieval fails at graph start (#3180).
+ *
+ * Best-effort enrichment is preserved — the graph still runs with empty
+ * context — but the failure is now observable instead of swallowed: a
+ * `warn` log plus this event flow through the standard `onEvent`/EventBus
+ * path so a readiness/counter consumer can aggregate context-availability.
+ *
+ * Defined as a single named shape (not inlined) so the three remaining
+ * `getContextForTask` call sites (execute-expert, orchestrate,
+ * composite-router; follow-up #3699) become pure call-site wiring against
+ * one authoritative event contract (DRY).
+ *
+ * `error` carries ONLY a sanitized message (`getErrorMessage`) — never a
+ * stack trace, file-system path, prompt, secret, or token.
+ */
+export type ContextUnavailableEvent = {
+  readonly type: 'context_unavailable';
+  /** Inferred task category whose context could not be retrieved. */
+  readonly category: string;
+  /** Sanitized failure message — message string only, no stack/paths/secrets. */
+  readonly error: string;
+  /** Correlation id when the execution was given one. */
+  readonly executionId?: string;
+  readonly timestamp: number;
+};
 
 // ============================================================================
 // Builder Error


### PR DESCRIPTION
Closes #3185.

## Problem
The model registry was static at init: the `UnifiedAdapterRegistry` pre-computed its task→CLI routing once in the constructor, and `getDefaultModelForCli` / `getInTreeCapabilitiesMatrix` read the frozen in-tree constants directly — bypassing the overlay-bearing `getDefaultRegistry()`. So a manifest-overlay update applied after startup (e.g. an edited `NEXUS_MODELS_OVERLAY_PATH`) never reached routing decisions without a process restart.

## Approach (vote: simple_majority 7/7 — approach A + conditions)
1. **Drop the routing cache** — `UnifiedAdapterRegistry` no longer freezes `taskRouting` at construction. `getRouting` / `getAdapter` / `getSnapshot` re-resolve on read (~10 categories, negligible). Adapter cache (CLI-keyed) kept as-is.
2. **Overlay-aware model resolution** — `getDefaultModelForCli` + `getInTreeCapabilitiesMatrix` now resolve through the default registry via a new non-constructing `peekDefaultRegistry()`, so overlay entries participate at runtime. Static fallback preserved for early bootstrap.
3. **`reloadDefaultRegistry()`** — single hot-reload entry point: re-runs `buildDefaultRegistry()` (re-reads overlay) and atomically resets BOTH singletons. Wired into `registry refresh`; 'restart required' message updated.

## Mandatory vote conditions
1. **Early-bootstrap recursion guard** — `getDefaultModelForCli` reads via `peekDefaultRegistry()` (never constructs, never touches the filesystem at module load), dodging the documented TDZ/re-entrancy hazard. A module-load-time caller (gemini-adapter's top-level const) gets the static fallback. **Tested.**
2. **Atomic dual-singleton reset** — `reloadDefaultRegistry()` resets the model-registry singleton AND the `UnifiedAdapterRegistry` (`resetGlobalRegistry`, via dynamic import to break the cycle) together; no state where one is fresh + the other stale. **Tested (cross-singleton invariant).**
3. **Never-throw on malformed overlay** — re-read uses the same fail-closed loader; a malformed manifest degrades to the in-tree floor. **Tested.**

## Tests (TDD, failing-first)
`model-registry.test.ts` (+6): peek-no-construct (2), bootstrap static fallback (1), overlay propagation without restart (1), malformed re-read no-throw (1), atomic dual-singleton reset (1).
`unified-registry.test.ts` (+2): `getRouting` reflects post-construction change (no stale cache), `getSnapshot` re-reads on each call.

All green: 122/122 across the four touched suites; 4065 pass across config/adapters/cli-adapters; 205 across downstream consumers. `tsc --noEmit` clean; `eslint --no-cache` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
