### PR TITLE
feat(orchestration): enforce policy at the consensus→execute seam in dev-pipeline (#3704)

### DIFF
--- a/.changeset/consensus-execute-policy-3704.md
+++ b/.changeset/consensus-execute-policy-3704.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+Enforce policy at the consensus→execute seam in the legacy dev-pipeline (#3704).
+
+`runDevPipeline` orchestrates via stage callbacks and never traverses the graph
+PipelineRunner, so the #3177 graph gates never fired for it — leaving the
+consensus→execute boundary unguarded. A policy check now runs after the approved
+plan-vote loop (and the dry-run short-circuit) and before decompose, reusing the
+existing `evaluatePipelinePolicy` evaluator (no new evaluator path). Mode resolves
+via `getGateEnforcementMode()` (WARN by default; block/off opt-in via
+`NEXUS_POLICY_GATE_MODE`). `policy.evaluated` is emitted on the shared pipeline
+event bus before any block-mode `PolicyBlockedError` throw, so blocked runs are
+audited. WARN logs and continues; block throws and aborts the run.

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -2,8 +2,10 @@
  * Multi-Agent Development Pipeline Tests (#1684)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { runDevPipeline } from './dev-pipeline.js';
+import { getPipelineEventBus } from './event-bus.js';
+import { PolicyBlockedError } from './policy-evaluator.js';
 import type {
   DevPipelineStages,
   PipelineTask,
@@ -573,5 +575,136 @@ describe('runDevPipeline — CapabilityLedger integration (#3643 ship-blocking)'
 
     expect(stages.research).toHaveBeenCalledTimes(1);
     expect(result.completed).toBe(true);
+  });
+});
+
+// ============================================================================
+// Consensus → execute policy gate (#3704)
+// ============================================================================
+
+describe('runDevPipeline — consensus→execute policy gate (#3704)', () => {
+  /** Captures policy.evaluated gate ids emitted on the shared pipeline bus. */
+  function capturePolicyEvents(): { events: string[]; off: () => void } {
+    const events: string[] = [];
+    const off = getPipelineEventBus().subscribe({ type: 'policy.evaluated' }, (e) => {
+      if (e.type === 'policy.evaluated') events.push(e.gateId);
+    });
+    return { events, off };
+  }
+
+  afterEach(() => {
+    delete process.env['NEXUS_POLICY_GATE_MODE'];
+  });
+
+  it('(a) WARN default + missing-trustTier violation: emits policy.evaluated then PROCEEDS to decompose', async () => {
+    // No NEXUS_POLICY_GATE_MODE → defaults to WARN. The default engine's
+    // trust-tier rule denies an execute stage with no trustTier (fail-closed).
+    const cap = capturePolicyEvents();
+    const stages = createMockStages();
+    try {
+      const result = await runDevPipeline('Build feature X', stages);
+      // Execution proceeds despite the violation (WARN never halts).
+      expect(stages.decompose).toHaveBeenCalledTimes(1);
+      expect(result.completed).toBe(true);
+      // The violation was emitted for audit.
+      expect(cap.events.some((g) => g.startsWith('consensus-to-execute:'))).toBe(true);
+    } finally {
+      cap.off();
+    }
+  });
+
+  it('(b) block mode + untrusted: emits policy.evaluated, then THROWS PolicyBlockedError; decompose NOT called', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const cap = capturePolicyEvents();
+    const stages = createMockStages();
+    try {
+      await expect(runDevPipeline('Build feature X', stages)).rejects.toBeInstanceOf(
+        PolicyBlockedError
+      );
+      expect(stages.decompose).not.toHaveBeenCalled();
+      expect(cap.events.some((g) => g.startsWith('consensus-to-execute:'))).toBe(true);
+    } finally {
+      cap.off();
+    }
+  });
+
+  it('(e) emit-before-throw: in block mode the policy.evaluated event is captured BEFORE the throw is observed', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const stages = createMockStages();
+    // Record whether the audit event had already been emitted at the instant
+    // the PolicyBlockedError surfaces. If emit ran AFTER the throw, this would
+    // be false — the assertion pins the ordering, not just eventual presence.
+    let emittedBeforeThrow = false;
+    const off = getPipelineEventBus().subscribe({ type: 'policy.evaluated' }, () => {
+      emittedBeforeThrow = true;
+    });
+    try {
+      await runDevPipeline('Build feature X', stages);
+      throw new Error('expected PolicyBlockedError');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(PolicyBlockedError);
+      expect(emittedBeforeThrow).toBe(true);
+    } finally {
+      off();
+    }
+  });
+
+  it('(c) off mode: skips evaluation entirely — no policy.evaluated, proceeds', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'off';
+    const cap = capturePolicyEvents();
+    const stages = createMockStages();
+    try {
+      const result = await runDevPipeline('Build feature X', stages);
+      expect(stages.decompose).toHaveBeenCalledTimes(1);
+      expect(result.completed).toBe(true);
+      expect(cap.events).toHaveLength(0);
+    } finally {
+      cap.off();
+    }
+  });
+
+  it('(d) clean plan (no violations): proceeds to decompose, no policy.evaluated emitted', async () => {
+    // Stub the default engine to one with no denying rules so the verdict is a
+    // genuine allow (the built-in trust-tier rule always denies a tier-less
+    // execute stage, so an empty rule set models a clean plan).
+    const mod = await import('./policy-engine.js');
+    const spy = vi.spyOn(mod, 'createDefaultPolicyEngine').mockReturnValue(new mod.PolicyEngine());
+    const cap = capturePolicyEvents();
+    const stages = createMockStages();
+    try {
+      const result = await runDevPipeline('Build feature X', stages);
+      expect(stages.decompose).toHaveBeenCalledTimes(1);
+      expect(result.completed).toBe(true);
+      expect(cap.events).toHaveLength(0);
+    } finally {
+      cap.off();
+      spy.mockRestore();
+    }
+  });
+
+  it('(f) missing-trustTier under WARN continues (does NOT halt)', async () => {
+    // Explicit WARN — the gate evaluates, the trust-tier rule denies (no
+    // trustTier in dev-pipeline metadata), yet the run completes.
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'warn';
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages);
+    expect(stages.decompose).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+
+  it('(g) dry run short-circuits BEFORE the gate (no policy.evaluated)', async () => {
+    // The gate sits after the dryRun short-circuit, so a dry run never evaluates
+    // policy and never reaches decompose.
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const cap = capturePolicyEvents();
+    const stages = createMockStages();
+    try {
+      const result = await runDevPipeline('Build feature X', stages, { dryRun: true });
+      expect(stages.decompose).not.toHaveBeenCalled();
+      expect(result.completed).toBe(false);
+      expect(cap.events).toHaveLength(0);
+    } finally {
+      cap.off();
+    }
   });
 });

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -24,6 +24,13 @@ import { runQaLoop } from '../orchestration/qa-loop.js';
 
 import { createLogger, getTimeProvider, withStep } from '../core/index.js';
 import { getPipelineEventBus } from './event-bus.js';
+import { createDefaultPolicyEngine } from './policy-engine.js';
+import type { PolicyContext } from './policy-engine.js';
+import {
+  evaluatePipelinePolicy,
+  getGateEnforcementMode,
+  PolicyBlockedError,
+} from './policy-evaluator.js';
 import {
   saveStageCheckpoint,
   loadCheckpointState,
@@ -260,6 +267,13 @@ async function runDevPipelineInner(
     return buildDryRunResult(planResult);
   }
 
+  // CONSENSUS → EXECUTE policy gate (#3704). The legacy dev-pipeline does not
+  // run through the graph PipelineRunner, so the #3177 graph gates never fire
+  // here — this seam closes that gap. Reuses evaluatePipelinePolicy (no 4th
+  // evaluator); emits policy.evaluated BEFORE any throw so blocked runs are
+  // audited. WARN by default (block opt-in via NEXUS_POLICY_GATE_MODE).
+  enforceConsensusExecutePolicy(sid);
+
   // Phase 3: Decompose
   const tasks = await runOrResumeDecompose(prior, planResult.plan, stages, {
     conditional: planResult.conditional,
@@ -287,6 +301,56 @@ async function runDevPipelineInner(
   applyPipelineHindsight(bm, task, sid, result);
 
   return result;
+}
+
+/**
+ * Enforces policy at the consensus→execute seam (#3704).
+ *
+ * Sits after the approved plan-vote loop (and the dryRun short-circuit) and
+ * before decompose, so a plan that passed consensus is still policy-checked
+ * before any execution work begins. This closes the legacy dev-pipeline gap:
+ * unlike the graph path (#3177 gates), `runDevPipeline` orchestrates via the
+ * `stages` callbacks and never instantiates the graph PipelineRunner — so a
+ * dev-pipeline run only ever traverses THIS seam, not the graph gates. The two
+ * paths are disjoint, so no double-evaluation guard is needed (#3704 cond. 4).
+ *
+ * Reuses the #3177 evaluator (`evaluatePipelinePolicy`) rather than forking a
+ * new one. The evaluator emits `policy.evaluated` events on the shared pipeline
+ * event bus BEFORE returning, so the emit happens BEFORE the block-mode throw
+ * below — blocked runs (the ones we most want audited) are never silently lost
+ * (#3704 cond. 1).
+ *
+ * Mode resolves via `getGateEnforcementMode()`: WARN by default, block/off
+ * opt-in via `NEXUS_POLICY_GATE_MODE`. trustTier is absent from dev-pipeline
+ * metadata, so the engine defaults the missing tier to untrusted (fail-closed);
+ * under WARN that logs + continues (cond. 3), under block it throws
+ * {@link PolicyBlockedError} and aborts the run (cond. 2).
+ */
+function enforceConsensusExecutePolicy(sessionId: string | undefined): void {
+  const mode = getGateEnforcementMode();
+  if (mode === 'off') return;
+
+  const context: PolicyContext = {
+    taskId: sessionId ?? 'dev-pipeline',
+    stageId: 'consensus-to-execute',
+    stageType: 'execute',
+    // No trustTier in dev-pipeline metadata → engine defaults missing tier to
+    // untrusted (fail-closed). Safe under WARN (the default); block is opt-in.
+    pipelineState: {},
+  };
+
+  // evaluatePipelinePolicy emits policy.evaluated on the shared bus BEFORE it
+  // returns — so the emit precedes the throw below (#3704 cond. 1).
+  const result = evaluatePipelinePolicy(
+    { engine: createDefaultPolicyEngine(), mode, eventBus: getPipelineEventBus() },
+    context
+  );
+
+  // Decision 1 = THROW (not the graceful completed:false path) so a policy
+  // denial aborts the run, consistent with the graph gate path (#3704 cond. 2).
+  if (mode === 'block' && !result.allowed) {
+    throw new PolicyBlockedError(context.stageId, result.violations);
+  }
 }
 
 /** Create a TraceWriter when sessionId is available (#1719). */


### PR DESCRIPTION
Closes #3704 (Plan A only — enforcement). Audit-sink convergence is split to #3710 and is **not** in this PR.

## What
Inserts a policy check at the consensus→execute seam in `runDevPipelineInner` (`src/pipeline/dev-pipeline.ts`) — after the approved plan-vote loop + the `dryRun` short-circuit, before `runOrResumeDecompose`. The graph pipeline already enforces via the #3177 gates; this closes the legacy dev-pipeline gap that #3194 named.

## How
- Reuses the #3177 path — `evaluatePipelinePolicy` + `createDefaultPolicyEngine` + `PolicyBlockedError`. No new evaluator.
- Mode from `getGateEnforcementMode()`: **WARN by default**, block/off opt-in via `NEXUS_POLICY_GATE_MODE`.
- PolicyContext: `stageType: 'execute'`, `stageId: 'consensus-to-execute'`, `taskId` from the session id, empty `pipelineState` (no trustTier in dev-pipeline metadata).

## Vote-condition disposition
1. **emit-before-throw** — `evaluatePipelinePolicy` emits `policy.evaluated` on the shared bus *before* it returns, so the emit precedes the block-mode throw. Pinned by a dedicated ordering test.
2. **Decision 1 = THROW** — block + `!allowed` throws `PolicyBlockedError` (aborts the run), consistent with the graph path. Not the graceful `completed:false` path.
3. **WARN default; block not enabled** — trustTier is absent → engine fail-closes to untrusted → WARN logs + continues; block stays opt-in. Tested.
4. **Double-guard** — dev-pipeline has **zero** `PipelineRunner`/`compilePlan`/graph refs; it orchestrates via stage callbacks only, so a run traverses **only** this seam, never the graph gates. Disjoint paths → no idempotency guard needed (documented in code).
5. **Audit convergence (durable sink) is OUT** — #3710. Emits on the existing `IEventBus` only.

## Tests (7, all green)
`dev-pipeline.test.ts` describe `consensus→execute policy gate (#3704)`: (a) WARN default + violation → emitted + proceeds to decompose; (b) block + untrusted → emits then throws, decompose not called; (c) off → no eval/no emit; (d) clean plan → proceeds, no emit; (e) emit-before-throw ordering; (f) missing-trustTier under WARN continues; (g) dry-run short-circuits before the gate.

## Verification
- `tsc --noEmit`: clean
- `eslint --no-cache` (changed files): clean
- targeted vitest: 7 passed
- full pipeline suite (`vitest run src/pipeline`): 43 files / 608 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)