### PR TITLE
feat(pipeline): thread real trustTier into consensus→execute policy snapshot (#3712)

### DIFF
--- a/.changeset/trusttier-threading-3712.md
+++ b/.changeset/trusttier-threading-3712.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+pipeline: thread the caller's real content-provenance trustTier into the consensus→execute policy snapshot (#3712)
+
+`enforceConsensusExecutePolicy` previously fed an empty `pipelineState`, so the trust-tier rule always saw untrusted (tier 4) — block mode would have halted every dev-pipeline run. `DevPipelineOptions` now carries an optional `trustTier`; the MCP `run_dev_pipeline` handler and the `run` entry point thread the caller's real `RequestContext.trustTier` into it. This closes the run-path hole where a possibly-untrusted goal ran a real research stage with no tier. Trust here is content provenance, not caller identity: absence still fail-closes to tier 4. `NEXUS_POLICY_GATE_MODE=block` remains opt-in and is not enabled by this change.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -2,7 +2,7 @@
  * run_dev_pipeline MCP Tool Tests (#1684)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Pass-through the secure-handler / timeout chain so the registered callback
 // is the bare handler — lets the tests invoke it directly (#2824).
@@ -15,21 +15,56 @@ vi.mock('../middleware/secure-handler.js', () => ({
   createSecureHandler: (fn: unknown) => fn,
 }));
 
+// #3712: capture the options (esp. trustTier) handed to runDevPipeline so we can
+// assert the consensus→execute snapshot is fed the caller's real trust tier.
+const PIPELINE_RESULT = {
+  completed: true,
+  plan: 'plan',
+  tasks: [],
+  voteIterations: 1,
+  qaIterations: 1,
+  securityPassed: true,
+};
+const runDevPipelineMock = vi.fn(
+  (_task: string, _stages: unknown, _options?: { trustTier?: string }) =>
+    Promise.resolve(PIPELINE_RESULT)
+);
+vi.mock('../../pipeline/dev-pipeline.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../pipeline/dev-pipeline.js')>();
+  return {
+    ...actual,
+    runDevPipeline: (task: string, stages: unknown, options?: { trustTier?: string }) =>
+      runDevPipelineMock(task, stages, options),
+  };
+});
+
 import { DevPipelineInputSchema, registerDevPipelineTool } from './dev-pipeline-tool.js';
+
+interface HandlerCtx {
+  requestContext: { trustTier: string };
+}
+type CtxHandler = (args: unknown, ctx: HandlerCtx) => Promise<CapturedToolResult>;
 
 interface CapturedToolResult {
   isError?: boolean;
   content: Array<{ type: string; text: string }>;
 }
 
-/** Registers the tool against a mock server and returns the captured callback. */
-function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
-  let captured: ((args: unknown) => Promise<CapturedToolResult>) | undefined;
+/** A stdio-tier (trusted) context, the production default for a local CLI caller. */
+const STDIO_CTX: HandlerCtx = { requestContext: { trustTier: '1' } };
+
+/**
+ * Registers the tool against a mock server and returns the captured callback.
+ * The secure-handler is mocked to identity (top of file), so the captured value
+ * is the bare 2-arg `(args, ctx)` handler — tests must pass a HandlerCtx (#3712).
+ */
+function captureHandler(): CtxHandler {
+  let captured: CtxHandler | undefined;
   let registeredName: string | undefined;
   const mockServer = {
     registerTool: (name: string, _schema: unknown, handler: unknown) => {
       registeredName = name;
-      captured = handler as (args: unknown) => Promise<CapturedToolResult>;
+      captured = handler as CtxHandler;
     },
   };
   registerDevPipelineTool(mockServer as never, {
@@ -118,8 +153,25 @@ describe('registerDevPipelineTool', () => {
   it('returns a structured validation error for invalid input, not a thrown ZodError', async () => {
     const handler = captureHandler();
     // task must be a string; maxVoteIterations max is 5 — both invalid here.
-    const result = await handler({ task: 12345, maxVoteIterations: 99 });
+    const result = await handler({ task: 12345, maxVoteIterations: 99 }, STDIO_CTX);
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toContain('Invalid input');
+  });
+});
+
+describe('registerDevPipelineTool — trustTier threading (#3712)', () => {
+  beforeEach(() => runDevPipelineMock.mockClear());
+
+  it('threads the real RequestContext.trustTier into runDevPipeline options', async () => {
+    const handler = captureHandler();
+    await handler({ task: 'Build feature X' }, { requestContext: { trustTier: '1' } });
+    expect(runDevPipelineMock).toHaveBeenCalledTimes(1);
+    expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBe('1');
+  });
+
+  it("forwards an untrusted tier '3' unchanged (not silently downgraded to trusted)", async () => {
+    const handler = captureHandler();
+    await handler({ task: 'Build feature X' }, { requestContext: { trustTier: '3' } });
+    expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBe('3');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -19,7 +19,7 @@ import { createAgentStages, flushPipelineMemory } from '../../pipeline/agent-exe
 import { createTaskTracker, detectBackend } from '../../pipeline/task-tracker.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
-import { createSecureHandler } from '../middleware/secure-handler.js';
+import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
   toolStructuredError,
   toolSuccessStructured,
@@ -206,10 +206,18 @@ async function createStages(
  * the `dev-pipeline` strategy (#3575). Wires real agents via {@link createStages};
  * never simulates votes (schema default `simulateVotes: false`).
  */
-export async function runDevPipelineForGoal(goal: string): Promise<DevPipelineResult> {
+export async function runDevPipelineForGoal(
+  goal: string,
+  trustTier?: string
+): Promise<DevPipelineResult> {
   const input = DevPipelineInputSchema.parse({ task: goal });
   const stages = await createStages(input);
-  return runDevPipeline(goal, stages);
+  // #3712: thread the caller's real content-provenance trust tier into the
+  // consensus→execute policy snapshot. Undefined ⇒ seam fail-closes to tier 4
+  // (never infer trust from absence). The `run` entry point passes the caller's
+  // real RequestContext.trustTier here — closing the run-path hole where a
+  // possibly-untrusted goal ran a real research stage with an absent tier.
+  return runDevPipeline(goal, stages, trustTier !== undefined ? { trustTier } : undefined);
 }
 
 // ============================================================================
@@ -237,8 +245,19 @@ function buildStructuredOutput(result: DevPipelineResult): Record<string, unknow
 const RUN_DEV_PIPELINE_DESCRIPTION =
   'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).';
 
-/** Validates input, runs the dev pipeline, and shapes the result. */
-async function runDevPipelineHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
+/**
+ * Validates input, runs the dev pipeline, and shapes the result.
+ *
+ * `trustTier` is the caller's real content-provenance tier, threaded from
+ * `RequestContext.trustTier` by the registered 2-arg handler (#3712). When
+ * undefined (no caller context), the consensus→execute seam fail-closes to
+ * untrusted (tier 4) — absence is never treated as trusted.
+ */
+async function runDevPipelineHandler(
+  args: unknown,
+  logger: ILogger,
+  trustTier?: string
+): Promise<ToolResult> {
   const parsed = DevPipelineInputSchema.safeParse(args);
   if (!parsed.success) {
     return toolStructuredError({
@@ -259,6 +278,7 @@ async function runDevPipelineHandler(args: unknown, logger: ILogger): Promise<To
       ...(input.dryRun ? { dryRun: true } : {}),
       ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
       ...(input.qualityGate !== 'off' ? { qualityGate: input.qualityGate } : {}),
+      ...(trustTier !== undefined ? { trustTier } : {}),
     };
     const hasOptions = Object.keys(pipelineOptions).length > 0;
     const result = await runDevPipeline(taskText, stages, hasOptions ? pipelineOptions : undefined);
@@ -284,8 +304,14 @@ async function runDevPipelineHandler(args: unknown, logger: ILogger): Promise<To
  */
 export function registerDevPipelineTool(server: McpServer, deps: BaseMcpToolDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run_dev_pipeline' });
+  // 2-arg context-aware form (mirrors delegate-to-model.ts): thread the caller's
+  // real RequestContext.trustTier into the consensus→execute policy snapshot
+  // (#3712). createSecureHandler always supplies a HandlerContext with a derived
+  // trustTier; the handler still fail-closes (tier 4) if a tier never reaches
+  // the runDevPipeline seam.
   const secureHandler = createSecureHandler(
-    (args: unknown) => runDevPipelineHandler(args, logger),
+    (args: unknown, ctx: HandlerContext) =>
+      runDevPipelineHandler(args, logger, ctx.requestContext.trustTier),
     { toolName: 'run_dev_pipeline', rateLimiter: deps.rateLimiter, logger }
   );
   const timeoutMs = getToolTimeout('run_dev_pipeline', deps.security);

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -6,9 +6,28 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+// #3712: capture the trustTier handed to runDevPipelineForGoal through the
+// run → dev-pipeline executor path (the "hole" — a real RequestContext that ran
+// a real research stage on a possibly-untrusted goal with an absent tier).
+const runDevPipelineForGoalMock = vi.fn((_goal: string, _trustTier?: string) =>
+  Promise.resolve({
+    completed: true,
+    plan: 'plan',
+    tasks: [],
+    voteIterations: 1,
+    qaIterations: 1,
+    securityPassed: true,
+  })
+);
+vi.mock('./dev-pipeline-tool.js', () => ({
+  runDevPipelineForGoal: (goal: string, trustTier?: string) =>
+    runDevPipelineForGoalMock(goal, trustTier),
+}));
+
 import {
   routeGoal,
   executeGoal,
+  buildDefaultExecutors,
   isShadowTrainEnabled,
   RunInputSchema,
   STRATEGY_ENTRYPOINT_TOOL,
@@ -134,6 +153,49 @@ describe('executeGoal (run increment B, #3575)', () => {
       }
     );
     expect(sink.getOutcomes()[0]?.failureReason).toContain('pipeline blew up');
+  });
+});
+
+describe('run-path trustTier threading (#3712) — the run→dev-pipeline hole', () => {
+  beforeEach(() => runDevPipelineForGoalMock.mockClear());
+
+  it("preserves a tier-'3' caller through run→runDevPipelineForGoal (NOT downgraded to '1')", async () => {
+    await executeGoal(
+      { goal: 'implement the feature', forceStrategy: 'dev-pipeline', execute: true },
+      { trustTier: '3' }
+    );
+    expect(runDevPipelineForGoalMock).toHaveBeenCalledTimes(1);
+    expect(runDevPipelineForGoalMock.mock.calls[0]?.[1]).toBe('3');
+  });
+
+  it("threads a trusted tier-'1' caller through unchanged", async () => {
+    await executeGoal(
+      { goal: 'implement the feature', forceStrategy: 'dev-pipeline', execute: true },
+      { trustTier: '1' }
+    );
+    expect(runDevPipelineForGoalMock.mock.calls[0]?.[1]).toBe('1');
+  });
+
+  it('resolves to undefined tier when no caller tier is supplied (seam fail-closes to 4)', async () => {
+    await executeGoal({
+      goal: 'implement the feature',
+      forceStrategy: 'dev-pipeline',
+      execute: true,
+    });
+    expect(runDevPipelineForGoalMock.mock.calls[0]?.[1]).toBeUndefined();
+  });
+
+  it('regression: an untrusted-origin goal resolves to tier>=3 (not silently trusted)', async () => {
+    // A goal arriving over an unauthenticated transport derives tier '3'; the run
+    // path MUST carry that through so the consensus→execute seam sees untrusted.
+    const executors = buildDefaultExecutors('3');
+    await executeGoal(
+      { goal: 'untrusted external goal text', forceStrategy: 'dev-pipeline', execute: true },
+      { executors }
+    );
+    const threaded = runDevPipelineForGoalMock.mock.calls[0]?.[1];
+    expect(threaded).toBeDefined();
+    expect(Number(threaded)).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -25,7 +25,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { createLogger, formatZodError, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
-import { createSecureHandler } from '../middleware/secure-handler.js';
+import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
   toolStructuredError,
   toolSuccess,
@@ -193,13 +193,24 @@ export function routeGoal(input: RunInput, logger?: ILogger): RunResponse {
  *   doesn't carry; use the `orchestrate` tool directly.
  * - `single-shot`: `delegate_to_model` recommends a model, it doesn't execute.
  */
-const DEFAULT_EXECUTORS: StrategyExecutorMap = {
-  'dev-pipeline': (_decision, metaInput: MetaOrchestratorInput) =>
-    runDevPipelineForGoal(metaInput.goal),
-  pipeline: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
-  research: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
-  consensus: (_decision, metaInput: MetaOrchestratorInput) => runConsensusForGoal(metaInput.goal),
-};
+/**
+ * Build the default inline executors, threading the caller's content-provenance
+ * `trustTier` into the dev-pipeline executor (#3712). This closes the run-path
+ * hole: `run` carries a real `RequestContext` AND runs a real research stage on
+ * a possibly-untrusted goal, so the dev-pipeline's consensus→execute seam MUST
+ * see the CALLER's real tier — never a hardcoded trusted '1'. `undefined` (no
+ * tier threaded) leaves the seam to fail-close to untrusted (tier 4). Only the
+ * dev-pipeline executor consumes the tier; the others don't reach that seam.
+ */
+export function buildDefaultExecutors(trustTier?: string): StrategyExecutorMap {
+  return {
+    'dev-pipeline': (_decision, metaInput: MetaOrchestratorInput) =>
+      runDevPipelineForGoal(metaInput.goal, trustTier),
+    pipeline: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
+    research: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
+    consensus: (_decision, metaInput: MetaOrchestratorInput) => runConsensusForGoal(metaInput.goal),
+  };
+}
 
 /** Result of an inline `execute: true` run. */
 export interface RunExecuteResponse {
@@ -255,12 +266,18 @@ export async function executeGoal(
     readonly executors?: StrategyExecutorMap | undefined;
     readonly outcomeSink?: MetaOutcomeSink | undefined;
     readonly onOutcome?: MetaOutcomeObserver | undefined;
+    /**
+     * Caller's content-provenance trust tier (#3712), threaded into the default
+     * dev-pipeline executor so the consensus→execute seam sees the real tier
+     * instead of fail-closing. Ignored when `executors` is supplied explicitly.
+     */
+    readonly trustTier?: string | undefined;
   } = {}
 ): Promise<RunExecuteResponse> {
   const decision = selectDecision(input, opts.logger);
   const onOutcome = opts.onOutcome ?? buildShadowTrainObserver(opts.logger);
   const dispatcher = createMetaDispatcher({
-    executors: opts.executors ?? DEFAULT_EXECUTORS,
+    executors: opts.executors ?? buildDefaultExecutors(opts.trustTier),
     ...(opts.logger !== undefined ? { logger: opts.logger } : {}),
     ...(opts.outcomeSink !== undefined ? { outcomeSink: opts.outcomeSink } : {}),
     ...(onOutcome !== undefined ? { onOutcome } : {}),
@@ -276,7 +293,7 @@ export async function executeGoal(
   };
 }
 
-async function runHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
+async function runHandler(args: unknown, logger: ILogger, trustTier?: string): Promise<ToolResult> {
   const parsed = RunInputSchema.safeParse(args);
   if (!parsed.success) {
     return toolStructuredError({
@@ -287,7 +304,13 @@ async function runHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
 
   if (parsed.data.execute === true) {
     try {
-      const exec = await executeGoal(parsed.data, { logger });
+      // #3712: thread the caller's real RequestContext.trustTier into the
+      // dev-pipeline executor's consensus→execute seam. undefined ⇒ seam
+      // fail-closes to untrusted (4); never infer trust from absence.
+      const exec = await executeGoal(parsed.data, {
+        logger,
+        ...(trustTier !== undefined ? { trustTier } : {}),
+      });
       logger.info('run: executed goal', {
         decisionId: exec.decisionId,
         strategy: exec.strategy,
@@ -326,11 +349,18 @@ const DESCRIPTION =
 export function registerRunTool(server: McpServer, deps: BaseMcpToolDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run' });
 
-  const secureHandler = createSecureHandler((args: unknown) => runHandler(args, logger), {
-    toolName: 'run',
-    rateLimiter: deps.rateLimiter,
-    logger,
-  });
+  // 2-arg context-aware form (mirrors delegate-to-model.ts / run_dev_pipeline):
+  // thread the caller's real RequestContext.trustTier so the run→dev-pipeline
+  // consensus→execute seam sees the real tier (#3712) — this closes the hole
+  // where a possibly-untrusted goal ran a real research stage with no tier.
+  const secureHandler = createSecureHandler(
+    (args: unknown, ctx: HandlerContext) => runHandler(args, logger, ctx.requestContext.trustTier),
+    {
+      toolName: 'run',
+      rateLimiter: deps.rateLimiter,
+      logger,
+    }
+  );
 
   const timeoutMs = getToolTimeout('run', deps.security);
   const wrappedHandler = wrapToolWithTimeout('run', secureHandler, { timeoutMs, logger });

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -708,3 +708,43 @@ describe('runDevPipeline — consensus→execute policy gate (#3704)', () => {
     }
   });
 });
+
+describe('runDevPipeline — trustTier threading into the policy snapshot (#3712)', () => {
+  afterEach(() => {
+    delete process.env['NEXUS_POLICY_GATE_MODE'];
+  });
+
+  it('absent trustTier (undefined) under block mode → THROWS (fail-closed, tier 4)', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const stages = createMockStages();
+    // No trustTier option → seam behaves as before (#3704): untrusted default.
+    await expect(runDevPipeline('Build feature X', stages)).rejects.toBeInstanceOf(
+      PolicyBlockedError
+    );
+    expect(stages.decompose).not.toHaveBeenCalled();
+  });
+
+  it("trusted trustTier '1' under block mode → COMPLETES (rule allows tier 1)", async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages, { trustTier: '1' });
+    expect(stages.decompose).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+
+  it("untrusted trustTier '3' under block mode → THROWS (rule blocks tier>=3 on execute)", async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'block';
+    const stages = createMockStages();
+    await expect(
+      runDevPipeline('Build feature X', stages, { trustTier: '3' })
+    ).rejects.toBeInstanceOf(PolicyBlockedError);
+    expect(stages.decompose).not.toHaveBeenCalled();
+  });
+
+  it("trusted trustTier '1' under WARN default → completes without halting", async () => {
+    const stages = createMockStages();
+    const result = await runDevPipeline('Build feature X', stages, { trustTier: '1' });
+    expect(stages.decompose).toHaveBeenCalledTimes(1);
+    expect(result.completed).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -217,6 +217,18 @@ export interface DevPipelineOptions {
    * forgets to seed it.
    */
   readonly researchOverride?: string | undefined;
+  /**
+   * Content-provenance trust tier ('1'–'4') threaded into the consensus→execute
+   * policy snapshot (#3712). Trust here is about the PROVENANCE of the content
+   * that reached this run (the goal/research), not the caller's identity. The MCP
+   * `run_dev_pipeline` handler and the `run` entry point thread the caller's real
+   * `RequestContext.trustTier`; the auto-remediation IMPLEMENT path may pass `'1'`
+   * only because #3643's typed RemediationPlan + CapabilityLedger confine
+   * untrusted input upstream. **When undefined the seam behaves as before
+   * (#3704): the engine defaults the missing tier to untrusted (4), fail-closed.**
+   * Absence anywhere = untrusted; never infer a trusted tier from missing context.
+   */
+  readonly trustTier?: string | undefined;
 }
 
 /**
@@ -272,7 +284,7 @@ async function runDevPipelineInner(
   // here — this seam closes that gap. Reuses evaluatePipelinePolicy (no 4th
   // evaluator); emits policy.evaluated BEFORE any throw so blocked runs are
   // audited. WARN by default (block opt-in via NEXUS_POLICY_GATE_MODE).
-  enforceConsensusExecutePolicy(sid);
+  enforceConsensusExecutePolicy(sid, options?.trustTier);
 
   // Phase 3: Decompose
   const tasks = await runOrResumeDecompose(prior, planResult.plan, stages, {
@@ -321,12 +333,18 @@ async function runDevPipelineInner(
  * (#3704 cond. 1).
  *
  * Mode resolves via `getGateEnforcementMode()`: WARN by default, block/off
- * opt-in via `NEXUS_POLICY_GATE_MODE`. trustTier is absent from dev-pipeline
- * metadata, so the engine defaults the missing tier to untrusted (fail-closed);
- * under WARN that logs + continues (cond. 3), under block it throws
+ * opt-in via `NEXUS_POLICY_GATE_MODE`. The `trustTier` is the content-provenance
+ * tier threaded from the caller (#3712) — the MCP handler and `run` entry point
+ * pass the real `RequestContext.trustTier`. **When undefined (no caller threaded
+ * a tier), the snapshot stays empty, so the engine defaults the missing tier to
+ * untrusted (4), fail-closed** — never infer a trusted tier from absence. Under
+ * WARN a violation logs + continues (cond. 3); under block it throws
  * {@link PolicyBlockedError} and aborts the run (cond. 2).
  */
-function enforceConsensusExecutePolicy(sessionId: string | undefined): void {
+function enforceConsensusExecutePolicy(
+  sessionId: string | undefined,
+  trustTier: string | undefined
+): void {
   const mode = getGateEnforcementMode();
   if (mode === 'off') return;
 
@@ -334,9 +352,10 @@ function enforceConsensusExecutePolicy(sessionId: string | undefined): void {
     taskId: sessionId ?? 'dev-pipeline',
     stageId: 'consensus-to-execute',
     stageType: 'execute',
-    // No trustTier in dev-pipeline metadata → engine defaults missing tier to
-    // untrusted (fail-closed). Safe under WARN (the default); block is opt-in.
-    pipelineState: {},
+    // Inline narrowing of the threaded tier into the typed snapshot (#3712):
+    // only a real string tier populates it; undefined keeps the snapshot empty
+    // so the engine fail-closes to untrusted (4). Absence = untrusted.
+    pipelineState: typeof trustTier === 'string' ? { trustTier } : {},
   };
 
   // evaluatePipelinePolicy emits policy.evaluated on the shared bus BEFORE it


### PR DESCRIPTION
Closes #3712.

## What

The consensus→execute policy seam (`enforceConsensusExecutePolicy` in `dev-pipeline.ts`) previously fed an empty `pipelineState`, so the trust-tier rule always saw untrusted (tier 4). Under WARN that just emitted soak events; under `block` it would have halted **every** dev-pipeline run. This threads the caller's real content-provenance `trustTier` into the snapshot.

Per the #3712 vote (higher_order, 6-1, option B-WITH-PROVENANCE): **trust = content provenance, not caller identity**. Absence anywhere = untrusted (fail-closed to tier 4); we never infer a trusted tier from missing context.

## How each caller resolves its tier

| Caller | Resolution |
| --- | --- |
| `run_dev_pipeline` MCP handler | 2-arg context form → `ctx.requestContext.trustTier` → `DevPipelineOptions.trustTier` (mirrors `delegate-to-model.ts`) |
| `run` / MetaOrchestrator path | `ctx.requestContext.trustTier` → `executeGoal({ trustTier })` → `buildDefaultExecutors(tier)` → `runDevPipelineForGoal(goal, tier)` — **closes the hole** (a possibly-untrusted goal ran a real research stage with no tier) |
| auto-remediation IMPLEMENT | **No live `runDevPipeline` caller exists** (Option B implement adapter only writes a plan doc to a PR), so no explicit `'1'` is assigned — fail-closed default stands, per the vote's verify-guards refinement |
| Anywhere else / absent | `trustTier` undefined → empty snapshot → engine fail-closes to tier 4 (#3704 behavior preserved) |

## Tests (TDD, red→green)

- `dev-pipeline.test.ts` (+4): undefined→throws(block), `'1'`→completes, `'3'`→throws(block), `'1'`→completes(warn). Includes the simulate-block-mode case.
- `dev-pipeline-tool.test.ts` (+2): threads real tier `'1'`; forwards untrusted `'3'` unchanged.
- `run-tool.test.ts` (+4): **tier-`'3'` preserved through run→runDevPipelineForGoal (not downgraded to `'1'`)**, `'1'` threaded, undefined→undefined, **regression: untrusted-origin goal resolves tier≥3**.

Full `vitest run src/pipeline`: **43 files / 612 tests pass**. The 3 changed test files: **72 pass**.

## Gates

- tsc --noEmit: clean
- eslint --no-cache (6 files): clean
- governance:check: pass (46 tools / 12 experts / 33 skills)
- check-registry-coverage: no violations
- Changeset: `.changeset/trusttier-threading-3712.md` (patch)

`NEXUS_POLICY_GATE_MODE=block` is **not** enabled by this change — #3712 is the prerequisite only. Stale "trustTier is absent" doc comments updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)