### PR TITLE
feat(pipeline): durably persist consensus→execute policy events (#3710)

### DIFF
--- a/.changeset/policy-audit-durable-3710.md
+++ b/.changeset/policy-audit-durable-3710.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+Durably persist pipeline policy events (#3710). The dev-pipeline
+consensus→execute gate now dual-emits each `policy.evaluated` decision: the
+in-memory `IEventBus` → `TraceWriter` emit is unchanged (back-compat,
+observability-only), and when the MCP server's durable `auditLogger` is threaded
+it ALSO appends one hash-chained `policy_gate` record per violation carrying the
+enforcement `mode` (warn=soak vs block=enforce), `ruleIds`, and `stageType`. The
+durable record is the canonical source for tune/readiness aggregation and
+survives process exit; `trace.jsonl` stays per-run observability and must not be
+summed with it. The pure-CLI path threads no logger, so its behavior is
+unchanged.

--- a/docs/architecture/EVENT_BUS_BOUNDARIES.md
+++ b/docs/architecture/EVENT_BUS_BOUNDARIES.md
@@ -87,6 +87,34 @@ producers ──signal.swarm_unhealthy──▶ TuneStage ──demote──▶ 
   `intended` per CLI). Non-routing signals (`fitness_declined`, `vote_rejected`)
   always stay shadow-logged.
 
+## Pipeline policy audit: two records, one canonical source (#3710)
+
+The dev-pipeline consensus→execute policy gate
+(`pipeline/policy-evaluator.ts → evaluatePipelinePolicy`) **dual-emits** each
+`policy.evaluated` decision:
+
+| Sink                           | Path                                                                      | Lifetime                                            | Role                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Bus A (observability)**      | `IEventBus.emit` → `TraceWriter` → per-run `trace.jsonl`                  | Per-run, bounded ring buffer, dropped on no session | **Observability only.** Replay/debug a single run.                                      |
+| **Durable hash-chained audit** | `AuditTrail` → `createDurableAuditSink(auditLogger)` → `FileAuditStorage` | Immutable, process-spanning, `verify_audit_chain`   | **Canonical source** for tune/readiness aggregation (soak-vs-enforce evidence — #3653). |
+
+The durable `policy_gate` record carries `mode` (`warn`=soak vs `block`=enforce),
+`ruleIds`, and `stageType` in its metadata — exactly what the tune/readiness
+loop needs to distinguish soak evidence from enforced denials. The bus
+`policy.evaluated` event does **not** carry these and is per-run.
+
+**Aggregation rule:** sum durable `policy_gate` records **only**. The two
+records are intentional (back-compat for existing TraceWriter consumers + a
+durable sink that survives process exit) — **never sum `trace.jsonl` together
+with the durable log**, or every decision is double-counted. The durable log is
+authoritative; `trace.jsonl` is for single-run observability.
+
+The durable sink is wired only when the MCP server threads its single startup
+`auditLogger` (one `AuditTrail` built per run wrapping it, so all runs share the
+one hash chain — appends serialize on the single-threaded event loop). The
+pure-CLI path threads no logger, so it keeps only the bus emit (behavior
+unchanged).
+
 **Bounded-safety invariants** (in `core/tune-adjustment-store.ts`) — the loop is
 self-correcting, never a ratchet: demotion-only (slow a CLI, never boost it);
 floored at `0.5` (never zeroed — a sole-viable CLI stays selectable); capped at

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -239,6 +239,12 @@ interface ToolRegistrationContext {
   workflowConfig?: import('./config/index.js').WorkflowConfig;
   /** Tool allowlist from security config (Issue #740) */
   toolAllowlist?: Set<string>;
+  /**
+   * Durable, hash-chained audit logger (#3710). Threaded so `run_dev_pipeline`'s
+   * consensus→execute policy gate persists `policy.evaluated` decisions to the
+   * shared store. Optional — absent on the pure-CLI path.
+   */
+  auditLogger?: import('./audit/audit-types.js').IAuditLogger;
 }
 
 /**
@@ -474,6 +480,7 @@ function copyOptionalProps(opts: RegisterMcpToolsOptions): Partial<ToolRegistrat
   if (opts.securityConfig !== undefined) result.securityConfig = opts.securityConfig;
   if (opts.workflowConfig !== undefined) result.workflowConfig = opts.workflowConfig;
   if (opts.feedbackIntegration !== undefined) result.feedbackIntegration = opts.feedbackIntegration;
+  if (opts.auditLogger !== undefined) result.auditLogger = opts.auditLogger;
   return result;
 }
 
@@ -563,11 +570,17 @@ function buildStandardDeps(
   logger: ILogger;
   rateLimiter: ReturnType<ReturnType<typeof createToolRateLimiterFactory>['getForTool']>;
   security?: import('./config/index.js').SecurityConfig;
+  auditLogger?: import('./audit/audit-types.js').IAuditLogger;
 } {
   return {
     logger: ctx.logger,
     rateLimiter: ctx.rateLimiterFactory.getForTool(toolName),
     ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
+    // #3710: only run_dev_pipeline consumes the durable auditLogger — thread it
+    // so its consensus→execute policy gate persists decisions to the shared chain.
+    ...(toolName === 'run_dev_pipeline' && ctx.auditLogger !== undefined
+      ? { auditLogger: ctx.auditLogger }
+      : {}),
   };
 }
 

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -14,7 +14,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, getErrorMessage, formatZodError, type ILogger } from '../../core/index.js';
 import { runDevPipeline } from '../../pipeline/dev-pipeline.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
-import type { DevPipelineResult } from '../../pipeline/dev-pipeline.js';
+import type { DevPipelineResult, DevPipelineOptions } from '../../pipeline/dev-pipeline.js';
+import type { IAuditLogger } from '../../audit/audit-types.js';
 import { createAgentStages, flushPipelineMemory } from '../../pipeline/agent-executor.js';
 import { createTaskTracker, detectBackend } from '../../pipeline/task-tracker.js';
 import { getToolAnnotations } from '../tool-annotations.js';
@@ -131,6 +132,16 @@ export const DevPipelineInputSchema = z.object({
 });
 
 export type DevPipelineInput = z.infer<typeof DevPipelineInputSchema>;
+
+/**
+ * Deps for `run_dev_pipeline`. Extends the base with the server's single durable
+ * `auditLogger` (#3710) so the pipeline's consensus→execute policy gate can
+ * persist `policy.evaluated` decisions to the shared hash chain. Optional — when
+ * absent (pure-CLI path) the pipeline behaves exactly as before (no durability).
+ */
+export interface DevPipelineToolDeps extends BaseMcpToolDeps {
+  readonly auditLogger?: IAuditLogger | undefined;
+}
 
 // ============================================================================
 // Input Resolution
@@ -253,10 +264,33 @@ const RUN_DEV_PIPELINE_DESCRIPTION =
  * undefined (no caller context), the consensus→execute seam fail-closes to
  * untrusted (tier 4) — absence is never treated as trusted.
  */
+/**
+ * Build the {@link DevPipelineOptions} from validated input plus the threaded
+ * caller context. Extracted so the handler stays under the complexity cap. The
+ * `auditLogger` (#3710) is included only when the server threaded one.
+ */
+function buildPipelineOptions(
+  input: DevPipelineInput,
+  trustTier: string | undefined,
+  auditLogger: IAuditLogger | undefined
+): DevPipelineOptions {
+  return {
+    ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+    ...(input.dryRun ? { dryRun: true } : {}),
+    ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
+    ...(input.qualityGate !== 'off' ? { qualityGate: input.qualityGate } : {}),
+    ...(trustTier !== undefined ? { trustTier } : {}),
+    // #3710: thread the server's durable audit logger so the consensus→execute
+    // policy gate persists decisions to the shared hash chain.
+    ...(auditLogger !== undefined ? { auditLogger } : {}),
+  };
+}
+
 async function runDevPipelineHandler(
   args: unknown,
   logger: ILogger,
-  trustTier?: string
+  trustTier?: string,
+  auditLogger?: IAuditLogger
 ): Promise<ToolResult> {
   const parsed = DevPipelineInputSchema.safeParse(args);
   if (!parsed.success) {
@@ -273,13 +307,7 @@ async function runDevPipelineHandler(
   try {
     const taskText = await resolveTaskInput(input);
     const stages = await createStages(input);
-    const pipelineOptions = {
-      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
-      ...(input.dryRun ? { dryRun: true } : {}),
-      ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
-      ...(input.qualityGate !== 'off' ? { qualityGate: input.qualityGate } : {}),
-      ...(trustTier !== undefined ? { trustTier } : {}),
-    };
+    const pipelineOptions = buildPipelineOptions(input, trustTier, auditLogger);
     const hasOptions = Object.keys(pipelineOptions).length > 0;
     const result = await runDevPipeline(taskText, stages, hasOptions ? pipelineOptions : undefined);
     // Always flush memory session — including dry-run exits (#1716)
@@ -302,16 +330,17 @@ async function runDevPipelineHandler(
  * progress-token plumbing, and surfaced a `ZodError` on bad input as a raw
  * JSON-RPC `-32603` instead of a structured `validation` envelope.
  */
-export function registerDevPipelineTool(server: McpServer, deps: BaseMcpToolDeps): void {
+export function registerDevPipelineTool(server: McpServer, deps: DevPipelineToolDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run_dev_pipeline' });
   // 2-arg context-aware form (mirrors delegate-to-model.ts): thread the caller's
   // real RequestContext.trustTier into the consensus→execute policy snapshot
   // (#3712). createSecureHandler always supplies a HandlerContext with a derived
   // trustTier; the handler still fail-closes (tier 4) if a tier never reaches
-  // the runDevPipeline seam.
+  // the runDevPipeline seam. The server's durable auditLogger (#3710) is threaded
+  // so the gate persists policy decisions to the shared hash chain.
   const secureHandler = createSecureHandler(
     (args: unknown, ctx: HandlerContext) =>
-      runDevPipelineHandler(args, logger, ctx.requestContext.trustTier),
+      runDevPipelineHandler(args, logger, ctx.requestContext.trustTier, deps.auditLogger),
     { toolName: 'run_dev_pipeline', rateLimiter: deps.rateLimiter, logger }
   );
   const timeoutMs = getToolTimeout('run_dev_pipeline', deps.security);

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -17,6 +17,9 @@ import type { HindsightRecord } from '../context/belief-hindsight-types.js';
 import { ok, err } from '../core/result.js';
 import { MemoryError } from '../context/memory-backend-types.js';
 import type { TechniqueStatusSummary } from '../cli/research-types.js';
+import { AuditLogger, verifyChain } from '../audit/audit-logger.js';
+import { InMemoryAuditStorage } from '../audit/audit-storage.js';
+import type { AuditLogConfig } from '../audit/audit-types.js';
 
 // #3472: the dev-pipeline now recalls prior research from the registry on every
 // run. Mock it to empty by default so existing assertions (which count `- `
@@ -746,5 +749,91 @@ describe('runDevPipeline — trustTier threading into the policy snapshot (#3712
     const result = await runDevPipeline('Build feature X', stages, { trustTier: '1' });
     expect(stages.decompose).toHaveBeenCalledTimes(1);
     expect(result.completed).toBe(true);
+  });
+});
+
+// ============================================================================
+// Durable policy-audit persistence (#3710)
+// ============================================================================
+
+describe('runDevPipeline — durable policy-audit persistence (#3710)', () => {
+  function hashChainConfig(): AuditLogConfig {
+    return {
+      logDir: '/tmp/nexus-audit-3710', // unused by InMemoryAuditStorage
+      filePrefix: 'test',
+      maxFileSizeBytes: 1024,
+      maxFiles: 3,
+      flushIntervalMs: 100,
+      minSeverity: 'info',
+      enableHashChain: true,
+      enableCompression: false,
+      maxQueueDepth: 10_000,
+    };
+  }
+
+  afterEach(() => {
+    delete process.env['NEXUS_POLICY_GATE_MODE'];
+  });
+
+  it('warn-mode violation → a verifiable hash-chain entry (verifyChain passes)', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'warn';
+    const storage = new InMemoryAuditStorage();
+    const auditLogger = new AuditLogger(hashChainConfig(), storage);
+    const stages = createMockStages();
+
+    // Missing trustTier → trust-tier rule denies the execute stage (warn: continues).
+    const result = await runDevPipeline('Build feature X', stages, { auditLogger });
+    await auditLogger.flush();
+
+    expect(result.completed).toBe(true);
+    const events = storage.getAll();
+    const policyGate = events.filter((e) => e.action === 'security.policy_gate');
+    // Exactly one durable policy_gate record persisted, with mode/ruleIds/stageType.
+    expect(policyGate).toHaveLength(1);
+    expect(policyGate[0]!.metadata?.['mode']).toBe('warn');
+    expect(policyGate[0]!.metadata?.['ruleIds']).toEqual(['trust-tier']);
+    expect(policyGate[0]!.metadata?.['stageType']).toBe('execute');
+    // The persisted chain verifies.
+    expect(verifyChain(events).ok).toBe(true);
+
+    await auditLogger.close();
+  });
+
+  it('serialized appends: parallel runs sharing one logger keep verifyChain passing', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'warn';
+    const storage = new InMemoryAuditStorage();
+    const auditLogger = new AuditLogger(hashChainConfig(), storage);
+
+    // Six concurrent dev-pipeline runs share the single logger. Each fires one
+    // warn-mode violation → one durable append. The hash chain must stay valid.
+    await Promise.all(
+      Array.from({ length: 6 }, (_, i) =>
+        runDevPipeline(`Build feature ${String(i)}`, createMockStages(), { auditLogger })
+      )
+    );
+    await auditLogger.flush();
+
+    const events = storage.getAll();
+    const policyGate = events.filter((e) => e.action === 'security.policy_gate');
+    expect(policyGate).toHaveLength(6); // one per run, no drops or dupes
+    expect(verifyChain(events).ok).toBe(true);
+
+    await auditLogger.close();
+  });
+
+  it('no auditLogger: still emits policy.evaluated on the bus (TraceWriter back-compat)', async () => {
+    process.env['NEXUS_POLICY_GATE_MODE'] = 'warn';
+    const events: string[] = [];
+    const off = getPipelineEventBus().subscribe({ type: 'policy.evaluated' }, (e) => {
+      if (e.type === 'policy.evaluated') events.push(e.gateId);
+    });
+    try {
+      // No auditLogger threaded → pure-CLI path. Bus emit is unchanged.
+      const result = await runDevPipeline('Build feature X', createMockStages());
+      expect(result.completed).toBe(true);
+      expect(events.some((g) => g.startsWith('consensus-to-execute:'))).toBe(true);
+    } finally {
+      off();
+    }
   });
 });

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -38,6 +38,10 @@ import {
 } from './pipeline-checkpoint.js';
 import type { PipelineCheckpointState } from './pipeline-checkpoint.js';
 import { TraceWriter } from './trace-writer.js';
+import { createAuditTrail } from '../security/audit-trail.js';
+import type { AuditTrail } from '../security/audit-trail.js';
+import { createDurableAuditSink } from '../security/audit-bridge.js';
+import type { IAuditLogger } from '../audit/audit-types.js';
 import type { IHindsightBeliefMemory } from '../context/belief-memory-interface.js';
 import type { HindsightRecord } from '../context/belief-hindsight-types.js';
 import { getResearchInsightsForTask } from '../context/context-retriever.js';
@@ -229,6 +233,16 @@ export interface DevPipelineOptions {
    * Absence anywhere = untrusted; never infer a trusted tier from missing context.
    */
   readonly trustTier?: string | undefined;
+  /**
+   * Durable, hash-chained audit logger (#3710). When supplied (the MCP server
+   * threads its single startup `auditLogger`), the consensus→execute policy gate
+   * ALSO persists each `policy.evaluated` decision to the immutable store —
+   * carrying mode/ruleIds/stageType — so warn-mode soak evidence survives process
+   * exit and feeds the tune/readiness loop. MUST be the server's single instance,
+   * not a competing FileAuditStorage (shared hash chain). When undefined (pure-CLI
+   * path), behavior is unchanged — the in-memory bus emit is the only sink.
+   */
+  readonly auditLogger?: IAuditLogger | undefined;
 }
 
 /**
@@ -268,7 +282,7 @@ async function runDevPipelineInner(
   sid: string | undefined,
   prior: PipelineCheckpointState | null
 ): Promise<DevPipelineResult> {
-  const bm = options?.beliefMemory;
+  const { beliefMemory: bm, auditLogger, trustTier } = options ?? {};
 
   // Phases 1-2: Research + Plan/Vote
   const { planResult } = await runPlanningPhase(task, stages, prior, options);
@@ -284,7 +298,7 @@ async function runDevPipelineInner(
   // here — this seam closes that gap. Reuses evaluatePipelinePolicy (no 4th
   // evaluator); emits policy.evaluated BEFORE any throw so blocked runs are
   // audited. WARN by default (block opt-in via NEXUS_POLICY_GATE_MODE).
-  enforceConsensusExecutePolicy(sid, options?.trustTier);
+  enforceConsensusExecutePolicy(sid, trustTier, auditLogger);
 
   // Phase 3: Decompose
   const tasks = await runOrResumeDecompose(prior, planResult.plan, stages, {
@@ -343,10 +357,15 @@ async function runDevPipelineInner(
  */
 function enforceConsensusExecutePolicy(
   sessionId: string | undefined,
-  trustTier: string | undefined
+  trustTier: string | undefined,
+  auditLogger: IAuditLogger | undefined
 ): void {
   const mode = getGateEnforcementMode();
   if (mode === 'off') return;
+
+  // Build the durable trail ONCE for this gate evaluation (#3710), wrapping the
+  // server's single auditLogger. Undefined when none is threaded (pure-CLI path).
+  const auditTrail = buildPolicyAuditTrail(auditLogger);
 
   const context: PolicyContext = {
     taskId: sessionId ?? 'dev-pipeline',
@@ -359,9 +378,16 @@ function enforceConsensusExecutePolicy(
   };
 
   // evaluatePipelinePolicy emits policy.evaluated on the shared bus BEFORE it
-  // returns — so the emit precedes the throw below (#3704 cond. 1).
+  // returns — so the emit precedes the throw below (#3704 cond. 1). When a
+  // durable trail is wired (#3710), it ALSO appends one hash-chained
+  // policy_gate record per violation (dual-emit) carrying mode/ruleIds/stageType.
   const result = evaluatePipelinePolicy(
-    { engine: createDefaultPolicyEngine(), mode, eventBus: getPipelineEventBus() },
+    {
+      engine: createDefaultPolicyEngine(),
+      mode,
+      eventBus: getPipelineEventBus(),
+      ...(auditTrail !== undefined ? { auditTrail } : {}),
+    },
     context
   );
 
@@ -370,6 +396,23 @@ function enforceConsensusExecutePolicy(
   if (mode === 'block' && !result.allowed) {
     throw new PolicyBlockedError(context.stageId, result.violations);
   }
+}
+
+/**
+ * Build the durable policy AuditTrail ONCE per run (#3710). Wraps the SERVER's
+ * single `auditLogger` in a durable sink so the consensus→execute gate's
+ * `policy.evaluated` decisions are persisted to the shared hash chain — NOT a
+ * competing FileAuditStorage (chain integrity). Returns undefined when no logger
+ * is threaded (pure-CLI path), so that path stays byte-identical to before.
+ *
+ * Serialization (#3710 condition 2): the returned trail's `append` calls
+ * `auditLogger.log()` synchronously (no await between hash assignment and queue
+ * push), so concurrent dev-pipeline runs sharing one logger serialize their
+ * chain writes on the single-threaded event loop — `verifyChain()` stays valid.
+ */
+function buildPolicyAuditTrail(auditLogger: IAuditLogger | undefined): AuditTrail | undefined {
+  if (auditLogger === undefined) return undefined;
+  return createAuditTrail(createDurableAuditSink(auditLogger));
 }
 
 /** Create a TraceWriter when sessionId is available (#1719). */

--- a/packages/nexus-agents/src/pipeline/policy-evaluator.test.ts
+++ b/packages/nexus-agents/src/pipeline/policy-evaluator.test.ts
@@ -9,6 +9,9 @@ import { PolicyEngine } from './policy-engine.js';
 import { EventBus } from './event-bus.js';
 import { evaluatePipelinePolicy, getPolicyMode } from './policy-evaluator.js';
 import type { PolicyContext, PolicyRule } from './policy-engine.js';
+import { createAuditTrail } from '../security/audit-trail.js';
+import { securityAuditEventToInput } from '../security/audit-bridge.js';
+import type { AuditEvent as SecurityAuditEvent } from '../security/audit-trail.js';
 
 // ============================================================================
 // Helpers
@@ -181,6 +184,113 @@ describe('evaluatePipelinePolicy', () => {
     });
     const result = evaluatePipelinePolicy({ engine, eventBus, mode: 'block' }, ctx);
     expect(result.allowed).toBe(false);
+  });
+});
+
+describe('evaluatePipelinePolicy — durable dual-emit (#3710)', () => {
+  let engine: PolicyEngine;
+  let eventBus: EventBus;
+  const ctx = createContext({ stageType: 'execute', stageId: 'consensus-to-execute' });
+
+  beforeEach(() => {
+    engine = new PolicyEngine();
+    eventBus = new EventBus();
+  });
+
+  /** Capture every event appended to a durable trail (mirrors the production sink). */
+  function captureTrail(): {
+    trail: ReturnType<typeof createAuditTrail>;
+    events: SecurityAuditEvent[];
+  } {
+    const events: SecurityAuditEvent[] = [];
+    const trail = createAuditTrail((e) => events.push(e));
+    return { trail, events };
+  }
+
+  it('dual-emit: BOTH the in-memory bus AND the durable trail receive the violation', () => {
+    engine.registerRule(createBlockingRule('r1'));
+    const { trail, events } = captureTrail();
+
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn', auditTrail: trail }, ctx);
+
+    // Bus emit unchanged (back-compat).
+    expect(eventBus.query({ type: 'policy.evaluated' })).toHaveLength(1);
+    // Durable sink also received exactly one policy_gate event.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('policy_gate');
+  });
+
+  it('mode/ruleIds/stageType ROUND-TRIP into the persisted durable AuditEvent (warn)', () => {
+    engine.registerRule(createBlockingRule('rule-A'));
+    const { trail, events } = captureTrail();
+
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn', auditTrail: trail }, ctx);
+
+    const sec = events[0]!;
+    expect(sec.type).toBe('policy_gate');
+    if (sec.type !== 'policy_gate') throw new Error('unreachable');
+    // The security-event fields carry the soak/enforce signal + rules + stage.
+    expect(sec.mode).toBe('warn');
+    expect(sec.ruleIds).toEqual(['rule-A']);
+    expect(sec.stageType).toBe('execute');
+
+    // …and they survive the durable mapping into the persisted AuditEvent.metadata.
+    const durable = securityAuditEventToInput(sec);
+    expect(durable.metadata?.['mode']).toBe('warn');
+    expect(durable.metadata?.['ruleIds']).toEqual(['rule-A']);
+    expect(durable.metadata?.['stageType']).toBe('execute');
+  });
+
+  it('mode round-trips as block so soak(warn) is distinguishable from enforce(block)', () => {
+    engine.registerRule(createBlockingRule('rule-B'));
+    const { trail, events } = captureTrail();
+
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'block', auditTrail: trail }, ctx);
+
+    const sec = events[0]!;
+    if (sec.type !== 'policy_gate') throw new Error('unreachable');
+    expect(sec.mode).toBe('block');
+    expect(sec.allowed).toBe(false); // enforce denies
+    expect(securityAuditEventToInput(sec).metadata?.['mode']).toBe('block');
+  });
+
+  it('one-append-per-event: count parity between bus emits and durable appends', () => {
+    engine.registerRule(createBlockingRule('r1'));
+    engine.registerRule(createBlockingRule('r2'));
+    engine.registerRule(createBlockingRule('r3'));
+    const { trail, events } = captureTrail();
+
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn', auditTrail: trail }, ctx);
+
+    const busCount = eventBus.query({ type: 'policy.evaluated' }).length;
+    expect(busCount).toBe(3);
+    expect(events).toHaveLength(3); // exactly one durable record per violation
+    expect(trail.size).toBe(3); // no duplicate appends
+  });
+
+  it('no-sink path is byte-identical: omitting auditTrail produces no durable side effect', () => {
+    engine.registerRule(createBlockingRule('r1'));
+    // Reference run WITH a trail to prove the trail is the only difference.
+    const { trail, events } = captureTrail();
+    const withTrail = evaluatePipelinePolicy(
+      { engine, eventBus: new EventBus(), mode: 'warn', auditTrail: trail },
+      ctx
+    );
+    // Run WITHOUT a trail.
+    const noTrail = evaluatePipelinePolicy({ engine, eventBus: new EventBus(), mode: 'warn' }, ctx);
+
+    // Returned result is identical regardless of the sink.
+    expect(noTrail).toEqual(withTrail);
+    // The no-sink run produced no durable events at all.
+    expect(events).toHaveLength(1); // only the with-trail run appended
+  });
+
+  it('no violations: durable trail receives nothing', () => {
+    engine.registerRule(createPassingRule('ok'));
+    const { trail, events } = captureTrail();
+    evaluatePipelinePolicy({ engine, eventBus, mode: 'warn', auditTrail: trail }, ctx);
+    expect(events).toHaveLength(0);
+    expect(trail.size).toBe(0);
   });
 });
 

--- a/packages/nexus-agents/src/pipeline/policy-evaluator.ts
+++ b/packages/nexus-agents/src/pipeline/policy-evaluator.ts
@@ -20,6 +20,8 @@ import type {
   PipelineStateSnapshot,
 } from './policy-engine.js';
 import type { IEventBus, PipelineEvent } from './event-types.js';
+import type { AuditTrail } from '../security/audit-trail.js';
+import { emitPipelinePolicyEvent } from '../security/audit-trail.js';
 
 const logger = createLogger({ component: 'PolicyEvaluator' });
 
@@ -36,6 +38,14 @@ export interface PolicyEvaluatorOptions {
   readonly engine: IPolicyEngine;
   readonly eventBus?: IEventBus;
   readonly mode?: PolicyMode;
+  /**
+   * Optional DURABLE audit trail (#3710). When present, each violation is ALSO
+   * appended to the hash-chained store (dual-emit) carrying mode/ruleIds/
+   * stageType — so soak(warn)-vs-enforce(block) evidence survives process exit
+   * for the tune/readiness loop. The in-memory `eventBus` emit is unchanged
+   * (back-compat). When absent, behavior is byte-identical to before.
+   */
+  readonly auditTrail?: AuditTrail;
 }
 
 /** Result of a policy evaluation at a stage boundary. */
@@ -97,6 +107,12 @@ export interface GatePolicyEnforcement {
   /** Optional event bus; policy.evaluated events are emitted on violations. */
   readonly eventBus?: IEventBus;
   /**
+   * Optional DURABLE audit trail (#3710) — forwarded to
+   * {@link evaluatePipelinePolicy} so gate decisions are persisted to the
+   * hash-chained store in addition to the in-memory bus.
+   */
+  readonly auditTrail?: AuditTrail;
+  /**
    * Effective enforcement mode for gate nodes. WARN by default (#3177
    * condition 1): a gate with no explicit mode does NOT halt, so a stage
    * lacking trust metadata is not blocked out of the box. Block is opt-in.
@@ -147,6 +163,7 @@ export function enforceGatePolicy(
       engine: enforcement.engine,
       mode,
       ...(enforcement.eventBus !== undefined ? { eventBus: enforcement.eventBus } : {}),
+      ...(enforcement.auditTrail !== undefined ? { auditTrail: enforcement.auditTrail } : {}),
     },
     {
       taskId: target.taskId,
@@ -225,7 +242,12 @@ export function evaluatePipelinePolicy(
   }
 
   if (violations.length > 0) {
+    // Dual-emit (#3710): the in-memory bus emit is KEPT untouched (back-compat,
+    // TraceWriter-consumed). When a durable trail is wired, ALSO append one
+    // hash-chained record per violation carrying mode/ruleIds/stageType — the
+    // canonical source for tune/readiness aggregation that survives process exit.
     emitPolicyEvents(options.eventBus, context, violations);
+    emitDurablePolicyEvents(options.auditTrail, context, violations, mode);
     logViolations(context, violations, mode);
   }
 
@@ -253,6 +275,40 @@ function emitPolicyEvents(
       decision: 'deny',
     };
     eventBus.emit(event);
+  }
+}
+
+/**
+ * Appends ONE durable `policy_gate` record per violation (#3710 condition 3 —
+ * count parity with the bus emit above). Each record carries `mode` (warn/block,
+ * the soak-vs-enforce signal), `ruleIds`, and `stageType` so the persisted event
+ * round-trips the data the tune/readiness loop needs (#3710 condition 1). No-op
+ * when no trail is wired — the no-sink path stays byte-identical (condition 4).
+ *
+ * `allowed` reflects the run-level verdict the violation produced: in `warn`
+ * execution continues (allowed=true), in `block` the gate denies (allowed=false).
+ */
+function emitDurablePolicyEvents(
+  auditTrail: AuditTrail | undefined,
+  context: PolicyContext,
+  violations: readonly PolicyViolation[],
+  mode: PolicyMode
+): void {
+  if (auditTrail === undefined) return;
+  const allowed = mode === 'warn';
+  for (const v of violations) {
+    emitPipelinePolicyEvent(auditTrail, {
+      allowed,
+      requiresApproval: false,
+      // Pipeline policy is provenance/stage-driven, not user-driven; the snapshot
+      // tier (if any) lives in PolicyContext but no single tier identifies the
+      // gate decision, so the durable record uses the fail-closed default.
+      inputTrustTier: '4',
+      violationRules: [v.ruleId],
+      mode,
+      ruleIds: [v.ruleId],
+      stageType: context.stageType,
+    });
   }
 }
 

--- a/packages/nexus-agents/src/security/audit-bridge.test.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.test.ts
@@ -85,6 +85,38 @@ describe('securityAuditEventToInput (#3291)', () => {
     expect(input.severity).toBe('warning');
   });
 
+  it('round-trips pipeline-policy mode/ruleIds/stageType into the durable metadata (#3710)', () => {
+    const pipelinePolicy = {
+      ...base,
+      type: 'policy_gate' as const,
+      component: 'pipeline-policy-evaluator',
+      // No actionType — pipeline path is stage-driven, not AgentAction-driven.
+      allowed: true,
+      requiresApproval: false,
+      inputTrustTier: '4' as const,
+      violationRules: ['trust-tier'],
+      mode: 'warn' as const,
+      ruleIds: ['trust-tier'],
+      stageType: 'execute',
+    };
+    const input = securityAuditEventToInput(pipelinePolicy);
+    // The soak/enforce signal + rules + stage survive the mapping.
+    expect(input.metadata?.['mode']).toBe('warn');
+    expect(input.metadata?.['ruleIds']).toEqual(['trust-tier']);
+    expect(input.metadata?.['stageType']).toBe('execute');
+    // No actionType key when the source event has none.
+    expect(input.metadata && 'actionType' in input.metadata).toBe(false);
+    // Still schema-valid.
+    expect(AuditEventInputSchema.safeParse(input).success).toBe(true);
+  });
+
+  it('security policy_gate path keeps its actionType and omits the pipeline fields', () => {
+    const input = securityAuditEventToInput(samples.policy_gate);
+    expect(input.metadata?.['actionType']).toBe('GeneratePatchPlan');
+    expect(input.metadata && 'mode' in input.metadata).toBe(false);
+    expect(input.metadata && 'stageType' in input.metadata).toBe(false);
+  });
+
   it('flags a downgraded trust classification as a warning', () => {
     expect(securityAuditEventToInput(samples.trust_classification).severity).toBe('warning');
   });

--- a/packages/nexus-agents/src/security/audit-bridge.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.ts
@@ -65,6 +65,10 @@ function mapTrust(e: TrustEvent): AuditEventInput {
 
 function mapPolicyGate(e: PolicyEvent): AuditEventInput {
   const outcome: AuditOutcome = e.allowed ? 'success' : 'denied';
+  // #3710: the pipeline-policy path carries `mode`/`ruleIds`/`stageType` and no
+  // `actionType`; these MUST round-trip into the durable metadata so the
+  // persisted record distinguishes soak(warn) from enforce(block). The security
+  // path leaves them undefined and keeps its `actionType`-keyed shape.
   return {
     category: 'authorization',
     severity: e.allowed ? 'info' : 'warning',
@@ -75,10 +79,13 @@ function mapPolicyGate(e: PolicyEvent): AuditEventInput {
     policyDecision: e.allowed ? 'allow' : 'deny',
     ...(e.violationRules.length > 0 ? { violationType: e.violationRules.join(',') } : {}),
     metadata: {
-      actionType: e.actionType,
+      ...(e.actionType !== undefined ? { actionType: e.actionType } : {}),
       requiresApproval: e.requiresApproval,
       inputTrustTier: e.inputTrustTier,
       violationRules: e.violationRules,
+      ...(e.mode !== undefined ? { mode: e.mode } : {}),
+      ...(e.ruleIds !== undefined ? { ruleIds: e.ruleIds } : {}),
+      ...(e.stageType !== undefined ? { stageType: e.stageType } : {}),
     },
   };
 }

--- a/packages/nexus-agents/src/security/audit-trail.ts
+++ b/packages/nexus-agents/src/security/audit-trail.ts
@@ -56,11 +56,31 @@ export interface TrustClassificationEvent extends AuditEventBase {
 /** Policy gate evaluation result. */
 export interface PolicyGateEvent extends AuditEventBase {
   readonly type: 'policy_gate';
-  readonly actionType: AgentActionType;
+  /**
+   * The agent action evaluated, for the security policy-gate path
+   * (security/policy-gate.ts). Optional because the PIPELINE policy path
+   * (pipeline/policy-evaluator.ts → #3710) records stage-boundary policy
+   * decisions that have no `AgentAction` — they carry {@link stageType} +
+   * {@link mode} + {@link ruleIds} instead. Security emitters always set it.
+   */
+  readonly actionType?: AgentActionType;
   readonly allowed: boolean;
   readonly requiresApproval: boolean;
   readonly inputTrustTier: TrustTier;
   readonly violationRules: readonly string[];
+  /**
+   * Pipeline-policy fields (#3710). Carried for the dev-pipeline
+   * consensus→execute seam so the DURABLE record can distinguish soak (`warn`)
+   * from enforce (`block`) and which rules/stage fired — without these the
+   * persisted event is useless to the tune/readiness loop. Absent for the
+   * security policy-gate path.
+   */
+  /** Enforcement mode the decision was made under: `warn` (soak) or `block` (enforce). */
+  readonly mode?: 'off' | 'warn' | 'block';
+  /** IDs of the policy rules that fired (mirrors `violationRules` for the pipeline path). */
+  readonly ruleIds?: readonly string[];
+  /** Type of the stage the gate guarded (e.g. `execute`). */
+  readonly stageType?: string;
 }
 
 /** Corroboration validation result. */
@@ -327,6 +347,24 @@ export function emitPolicyEvent(
   return trail.append({
     type: 'policy_gate',
     component: 'policy-gate',
+    ...data,
+  });
+}
+
+/**
+ * Records a PIPELINE-policy gate decision (#3710) — the dev-pipeline
+ * consensus→execute seam. Distinct from {@link emitPolicyEvent} (the security
+ * policy-gate path with an `AgentAction`): this carries `mode`/`ruleIds`/
+ * `stageType` so the durable record distinguishes soak(warn) from enforce(block)
+ * and is usable by the tune/readiness loop. ONE append per call.
+ */
+export function emitPipelinePolicyEvent(
+  trail: AuditTrail,
+  data: Omit<PolicyGateEvent, 'id' | 'timestamp' | 'type' | 'component' | 'actionType'>
+): string {
+  return trail.append({
+    type: 'policy_gate',
+    component: 'pipeline-policy-evaluator',
     ...data,
   });
 }


### PR DESCRIPTION
Closes #3710. Split from #3704 (Plan B). consensus_vote (simple_majority 7/7) approved the dual-emit routing + 5 conditions; implemented exactly.

## Problem
The dev-pipeline consensus→execute policy gate emitted `policy.evaluated` only to the in-memory `IEventBus` → `TraceWriter` (per-run, bounded ring buffer, dropped on undefined sessionId, never read back). Warn-mode soak evidence (#3703/#3704) evaporated on process exit. The durable hash-chained `AuditLogger` was built at server startup but never threaded into pipelines.

## Approach (dual-emit)
Keep the bus emit untouched (back-compat). When the server's single `auditLogger` is threaded, ALSO append one hash-chained `policy_gate` record per violation via `createAuditTrail(createDurableAuditSink(auditLogger))` — the same pattern the firewall pipeline already uses. No logger threaded (pure-CLI path) ⇒ behavior byte-identical.

## Vote conditions — disposition
1. **Schema preserves mode + ruleIds + stageType (key catch):** `PolicyGateEvent` gains optional `mode`/`ruleIds`/`stageType`; `mapPolicyGate` round-trips them into the durable `AuditEvent.metadata`. Test asserts the round-trip into the persisted event.
2. **Serialized appends:** `AuditLogger.log()` is synchronous (hash assigned + queued with no intervening await), so concurrent runs sharing one logger serialize on the single-threaded event loop. Test: 6 parallel runs → `verifyChain()` passes, 6 records, no drops/dupes.
3. **One-append-per-event:** one durable record per violation; test asserts count parity with bus emits + `trail.size`.
4. **No-sink byte-identical:** omitting `auditTrail` produces no durable side effect; test compares results with/without trail.
5. **Canonical-source doc:** `EVENT_BUS_BOUNDARIES.md` — sum the durable `policy_gate` log only; never sum `trace.jsonl` (avoid double-counting the intentional dual-record).

## Threading
`cli-server.ts` auditLogger → `registerMcpTools` → `copyOptionalProps` → `ToolRegistrationContext` → `buildStandardDeps` (run_dev_pipeline only) → `registerDevPipelineTool` → handler → `runDevPipeline` → `enforceConsensusExecutePolicy`.

## Tests / gates
- New: 6 in policy-evaluator.test.ts, 3 in dev-pipeline.test.ts, 2 in audit-bridge.test.ts.
- Full `vitest run src/pipeline src/security`: 2083 passed (98 files).
- tsc --noEmit clean; eslint --no-cache clean on all changed files.
- governance:check, check-registry-coverage, generate-repo-index --check all pass.
- Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)