### PR TITLE
docs: spike typedoc-plugin-markdown → Astro for one module (#3686)

### DIFF
--- a/.changeset/spike-typedoc-astro-3686.md
+++ b/.changeset/spike-typedoc-astro-3686.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore: spike typedoc-plugin-markdown → Astro for one module (#3686)
+
+Docs-tooling spike only — no runtime/`src` change, no release impact. Adds a
+second TypeDoc config (`typedoc.markdown.json`) + `docs:api:md` script that emits
+Markdown (with Astro-compatible frontmatter) for `src/core/result.ts` into the
+`docs/api` Astro content collection. Proves the generation pipeline before the
+full cutover (#3688).

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,409 @@
+---
+title: 'API: nexus-agents API'
+description: Generated API reference for nexus-agents API.
+tier: 2
+---
+
+# nexus-agents API
+
+## Type Aliases
+
+### Result
+
+```ts
+type Result<T, E> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      error: E;
+      ok: false;
+    };
+```
+
+Defined in: [result.ts:13](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L13)
+
+A discriminated union representing either success (Ok) or failure (Err).
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The error value type
+
+## Functions
+
+### err()
+
+```ts
+function err<E>(error): Result<never, E>;
+```
+
+Defined in: [result.ts:49](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L49)
+
+Creates a failed Result containing the given error.
+
+#### Type Parameters
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### error
+
+`E`
+
+The error value
+
+#### Returns
+
+[`Result`](#result)\<`never`, `E`\>
+
+A Result in the Err state
+
+#### Example
+
+```typescript
+const result = err(new Error('not found'));
+if (!result.ok) {
+  console.error(result.error.message); // "not found"
+}
+```
+
+---
+
+### isErr()
+
+```ts
+function isErr<T, E>(result): result is { error: E; ok: false };
+```
+
+Defined in: [result.ts:73](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L73)
+
+Type guard to check if a Result is in the Err state.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to check
+
+#### Returns
+
+`result is { error: E; ok: false }`
+
+True if the Result is Err
+
+---
+
+### isOk()
+
+```ts
+function isOk<T, E>(result): result is { ok: true; value: T };
+```
+
+Defined in: [result.ts:60](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L60)
+
+Type guard to check if a Result is in the Ok state.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to check
+
+#### Returns
+
+`result is { ok: true; value: T }`
+
+True if the Result is Ok
+
+---
+
+### map()
+
+```ts
+function map<T, U, E>(result, fn): Result<U, E>;
+```
+
+Defined in: [result.ts:88](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L88)
+
+Transforms the success value of a Result using the provided function.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The original success value type
+
+##### U
+
+`U`
+
+The transformed success value type
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to transform
+
+##### fn
+
+(`value`) => `U`
+
+The transformation function
+
+#### Returns
+
+[`Result`](#result)\<`U`, `E`\>
+
+A new Result with the transformed value
+
+---
+
+### mapErr()
+
+```ts
+function mapErr<T, E, F>(result, fn): Result<T, F>;
+```
+
+Defined in: [result.ts:104](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L104)
+
+Transforms the error value of a Result using the provided function.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The original error value type
+
+##### F
+
+`F`
+
+The transformed error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to transform
+
+##### fn
+
+(`error`) => `F`
+
+The transformation function
+
+#### Returns
+
+[`Result`](#result)\<`T`, `F`\>
+
+A new Result with the transformed error
+
+---
+
+### ok()
+
+```ts
+function ok<T>(value): Result<T, never>;
+```
+
+Defined in: [result.ts:31](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L31)
+
+Creates a successful Result containing the given value.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+#### Parameters
+
+##### value
+
+`T`
+
+The success value
+
+#### Returns
+
+[`Result`](#result)\<`T`, `never`\>
+
+A Result in the Ok state
+
+#### Example
+
+```typescript
+const result = ok(42);
+if (result.ok) {
+  console.log(result.value); // 42
+}
+```
+
+---
+
+### unwrap()
+
+```ts
+function unwrap<T, E>(result): T;
+```
+
+Defined in: [result.ts:119](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L119)
+
+Extracts the success value from a Result.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to unwrap
+
+#### Returns
+
+`T`
+
+The success value
+
+#### Throws
+
+Throws an Error wrapping the error value if the Result is Err
+
+---
+
+### unwrapOr()
+
+```ts
+function unwrapOr<T, E>(result, defaultValue): T;
+```
+
+Defined in: [result.ts:144](https://github.com/nexus-substrate/nexus-agents/blob/1d670e00cd7a23db56cea7f42a471808703c9794/packages/nexus-agents/src/core/result.ts#L144)
+
+Extracts the success value from a Result, or returns a default value.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+The success value type
+
+##### E
+
+`E`
+
+The error value type
+
+#### Parameters
+
+##### result
+
+[`Result`](#result)\<`T`, `E`\>
+
+The Result to unwrap
+
+##### defaultValue
+
+`T`
+
+The default value to return if Err
+
+#### Returns
+
+`T`
+
+The success value or the default value
+
+#### Example
+
+```typescript
+const result = err(new Error('failed'));
+const value = unwrapOr(result, 'fallback');
+console.log(value); // "fallback"
+```

--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -69,6 +69,7 @@
     "typecheck": "tsc --noEmit",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
+    "docs:api:md": "typedoc --options typedoc.markdown.json",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "pnpm run build"
   },
@@ -102,6 +103,8 @@
     "nexus-memory": "workspace:*",
     "tsup": "^8.5.1",
     "typedoc": "0.28.19",
+    "typedoc-plugin-frontmatter": "1.3.1",
+    "typedoc-plugin-markdown": "4.12.0",
     "vitest": "4.1.8"
   },
   "peerDependencies": {

--- a/packages/nexus-agents/scripts/typedoc-astro-title.mjs
+++ b/packages/nexus-agents/scripts/typedoc-astro-title.mjs
@@ -1,0 +1,29 @@
+// @ts-check
+/**
+ * Local TypeDoc plugin (spike #3686): inject an Astro-compatible `title` into the
+ * frontmatter of every generated Markdown page.
+ *
+ * The Astro `docs` content collection (website/src/pages/docs/[...slug].astro)
+ * only renders entries whose frontmatter has a `title`. typedoc-plugin-frontmatter
+ * emits frontmatter but no per-page title, so we add one here from the page model.
+ *
+ * Runs alongside typedoc-plugin-markdown + typedoc-plugin-frontmatter (load order
+ * matters: this listens on MarkdownPageEvent.BEGIN and writes page.frontmatter,
+ * which the frontmatter plugin then serializes).
+ */
+import { MarkdownPageEvent } from 'typedoc-plugin-markdown';
+
+/**
+ * @param {import('typedoc-plugin-markdown').MarkdownApplication} app
+ */
+export function load(app) {
+  app.renderer.on(MarkdownPageEvent.BEGIN, (page) => {
+    const name = page.model?.name ?? page.url ?? 'API Reference';
+    const title = name === 'index' || !name ? 'nexus-agents API' : `API: ${name}`;
+    page.frontmatter = {
+      title,
+      description: `Generated API reference for ${name}.`,
+      ...page.frontmatter,
+    };
+  });
+}

--- a/packages/nexus-agents/typedoc.markdown.json
+++ b/packages/nexus-agents/typedoc.markdown.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/core/result.ts"],
+  "tsconfig": "tsconfig.docs.json",
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/*.fuzz.test.ts"],
+  "out": "../../docs/api",
+  "name": "nexus-agents API",
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./scripts/typedoc-astro-title.mjs"
+  ],
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "readme": "none",
+  "githubPages": false,
+  "hideBreadcrumbs": true,
+  "hidePageHeader": true,
+  "useCodeBlocks": true,
+  "expandObjects": true,
+  "outputFileStrategy": "modules",
+  "entryFileName": "index",
+  "frontmatterGlobals": {
+    "tier": 2
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,9 +183,15 @@ importers:
       typedoc:
         specifier: 0.28.19
         version: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-frontmatter:
+        specifier: 1.3.1
+        version: 1.3.1(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)))
+      typedoc-plugin-markdown:
+        specifier: 4.12.0
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/nexus-memory:
     dependencies:
@@ -207,7 +213,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
   website:
     dependencies:
@@ -5172,6 +5178,17 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typedoc-plugin-frontmatter@1.3.1:
+    resolution: {integrity: sha512-wXKnhpiOuG3lY9GGKiKcXNrhKbPYm/jA5wbzGE/kKdwlSu8++ZbEuKA0K2dvIna3F+5EQrv+3AeObHkS1QP7JA==}
+    peerDependencies:
+      typedoc-plugin-markdown: '>=4.9.0'
+
+  typedoc-plugin-markdown@4.12.0:
+    resolution: {integrity: sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
   typedoc@0.28.19:
     resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -7670,7 +7687,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -11125,6 +11142,15 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typedoc-plugin-frontmatter@1.3.1(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3))):
+    dependencies:
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
+      yaml: 2.9.0
+
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)):
+    dependencies:
+      typedoc: 0.28.19(typescript@6.0.3)
 
   typedoc@0.28.19(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Spike #3686 (epic #3532) — VERDICT: CLEAN (minor friction, resolved)

Proves the single-source docs pipeline on **one** module: `typedoc-plugin-markdown` → Astro `docs` content collection → rendered HTML. End-to-end works.

### What was wired
- `typedoc-plugin-markdown@4.12.0` + `typedoc-plugin-frontmatter@1.3.1` (dev deps; both pin to the `typedoc 0.28.x` peer range — current repo typedoc is 0.28.19).
- `packages/nexus-agents/typedoc.markdown.json` — a SECOND typedoc config that emits **Markdown** (not HTML) for `src/core/result.ts` only, into `out: ../../docs/api`.
- `packages/nexus-agents/scripts/typedoc-astro-title.mjs` — tiny local typedoc plugin (see friction below).
- `docs:api:md` script in `packages/nexus-agents/package.json`.
- Generated `docs/api/index.md` committed as the proof artifact.

### Why `docs/api` (not `website/src/content/`)
The Astro `docs` collection (`website/src/content.config.ts`) loads `**/*.md` from `../../docs` — i.e. the repo's top-level `docs/` dir, not `website/src/content/`. So generated markdown must land under `docs/` to be consumed. No content.config change needed.

### Build proof
```
cd website && pnpm build   # 54 pages, Complete!
dist/docs/api/index.html  →  <title>API: nexus-agents API …</title>
                              "discriminated union", "Creates a successful Result"  (JSDoc rendered)
```
The JSDoc on `result.ts` flows source → markdown → Astro → HTML with no manual editing.

### Friction encountered (and resolved)
**Frontmatter `title` is required.** `website/src/pages/docs/[...slug].astro` filters `getStaticPaths` to entries with `data.title` — pages without one are silently dropped. `typedoc-plugin-frontmatter` emits frontmatter but no per-page `title`. Resolved with a ~25-line local typedoc plugin that sets `title`/`description` on `MarkdownPageEvent.BEGIN`. The full cutover will want a more deliberate title/slug scheme.

### What the full cutover (#3688) needs
1. **Multi-module entry points** — this spike uses one entry file (`outputFileStrategy: modules`, one `index.md`). Real cutover expands to `src/index.ts`, producing many files + an Astro nav/sidebar story for the generated tree.
2. **Title/slug strategy** — formalize the local title plugin into the shared config (per-symbol titles, stable slugs, sidebar grouping). Decide nesting under `docs/api/`.
3. **Link rewriting** — typedoc emits GitHub `blob/<sha>` source links + cross-page relative links; verify they survive the site's `remark-rewrite-links` plugin.
4. **Drift gate (#3689)** — once committed-and-current is the contract, add the CI assertion that `docs:api:md` output is up to date (the spike intentionally omits this).
5. **Decide commit-vs-ignore** for `docs/api/` (currently committed; `.gitignore` has it commented to allow committing).

### Out of scope (per issue)
No ENTRYPOINTS/README cutover (#3688), no drift gate (#3689), no full tool reference (#3687). No `src/` runtime change. Changeset is empty (docs tooling, no release impact).

**Do not merge** — spike for the epic to proceed informed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)