### PR TITLE
feat(jobs): shared runAsJob helper + run_dev_pipeline async mode (#3726)

### DIFF
--- a/.changeset/run-as-job-async-3726.md
+++ b/.changeset/run-as-job-async-3726.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+feat(jobs): shared `runAsJob` async-job helper + `run_dev_pipeline` async mode (#3726, epic #3729)
+
+Extract the async-job dispatcher that orchestrate, run_workflow, and consensus_vote
+implemented verbatim (idempotency resolve → concurrency cap → pending record →
+detached run with complete/failed + slot release → pending envelope) into a single
+`runAsJob` helper (`src/mcp/jobs/run-as-job.ts`). The three tools now delegate to it
+with no behavior change (existing suites green).
+
+`run_dev_pipeline` gains an opt-in `dispatch: 'async'` mode (default `sync`): a real
+run can exceed the 900s synchronous MCP request timeout, so async returns a
+`{ status: 'pending', jobId }` envelope immediately and runs the pipeline in the
+background (poll `get_job_result`). `dryRun` always stays sync. When a `sessionId` is
+provided the jobId is that sessionId (task-state resume); reusing it with different
+inputs surfaces the existing idempotency collision envelope instead of silently
+returning another run's data. Added `run_dev_pipeline` to the per-tool job caps (2)
+and the jobId-prefix→toolName map (`dp`).
+
+Interim mitigation (#3729): `pr_review`, `supply_chain_tradeoff_panel`, `execute_spec`,
+and `run` were on the 60s default MCP timeout and failed at 60s; bumped to the 900s
+per-tool ceiling until durable async migration lands (#3730-3732). Sync long-running
+tools now append a discoverability hint pointing at async mode when they time out.

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -91,6 +91,22 @@ describe('Centralized Timeout Configuration', () => {
       expect(MCP_TIMEOUTS.perTool['run_workflow']).toBe(900_000);
     });
 
+    it('grants the 60s-wrapper long-running tools a 900s cap (#3729 interim)', () => {
+      // These wrap their own multi-LLM/pipeline work but lacked a perTool
+      // override, so the 60s defaultMs killed them at 60s before async lands.
+      expect(MCP_TIMEOUTS.perTool['pr_review']).toBe(900_000);
+      expect(MCP_TIMEOUTS.perTool['supply_chain_tradeoff_panel']).toBe(900_000);
+      expect(MCP_TIMEOUTS.perTool['execute_spec']).toBe(900_000);
+      expect(MCP_TIMEOUTS.perTool['run']).toBe(900_000);
+    });
+
+    it('exposes a run_dev_pipeline async-mode timeout hint (#3726)', () => {
+      const hint = MCP_TIMEOUTS.perToolTimeoutHint['run_dev_pipeline'];
+      expect(hint).toBeDefined();
+      expect(hint).toContain("dispatch: 'async'");
+      expect(hint).toContain('get_job_result');
+    });
+
     it('exposes a safety buffer for internal deadlines', () => {
       expect(MCP_TIMEOUTS.perToolSafetyBufferMs).toBeGreaterThan(0);
       // Must be much smaller than the smallest per-tool cap so clamping

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -106,7 +106,27 @@ export const MCP_TIMEOUTS = {
     run_workflow: 900_000, // 15 min — multi-step workflow execution
     run_pipeline: 900_000, // 15 min — multi-stage pipeline orchestration (#2824)
     run_dev_pipeline: 900_000, // 15 min — multi-agent dev pipeline (#2824)
+    // #3729 interim mitigation: these long-running tools (multi-LLM voters /
+    // pipeline / spec executors) wrap their own work but were never granted a
+    // perTool override, so the 60s `defaultMs` killed them at 60s. Bump to the
+    // 900s ceiling until durable async migration lands (#3730-3732). nexus-agents
+    // uses stdio MCP transport (no proxy/LB), so the 900s interim is safe.
+    pr_review: 900_000, // 15 min — 5-7 LLM review voters in parallel
+    supply_chain_tradeoff_panel: 900_000, // 15 min — multi-voter supply-chain panel
+    execute_spec: 900_000, // 15 min — multi-stage spec execution
+    run: 900_000, // 15 min — MetaOrchestrator dispatch w/ execute:true
   } as Readonly<Record<string, number>>,
+  /**
+   * Per-tool discoverability hint (#3726) appended to the timeout error
+   * message. Lets a SYNC long-running tool that hits its perTool ceiling tell
+   * the caller how to escape it — e.g. retry in async job-mode. Generic so
+   * every async-migrated tool (#3729 children) can register one; absent →
+   * no hint appended.
+   */
+  perToolTimeoutHint: {
+    run_dev_pipeline:
+      "Retry with `dispatch: 'async'` to get a jobId immediately, then poll get_job_result({ jobId }).",
+  } as Readonly<Record<string, string>>,
 } as const;
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
@@ -36,6 +36,11 @@ describe('getJobCap', () => {
     expect(getJobCap('run_workflow')).toBe(DEFAULT_JOB_CAPS['run_workflow']);
   });
 
+  it('caps run_dev_pipeline at 2 concurrent runs (#3726)', () => {
+    expect(DEFAULT_JOB_CAPS['run_dev_pipeline']).toBe(2);
+    expect(getJobCap('run_dev_pipeline')).toBe(2);
+  });
+
   it('honors NEXUS_JOB_MAX_CONCURRENT_<TOOL> env override', () => {
     process.env['NEXUS_JOB_MAX_CONCURRENT_ORCHESTRATE'] = '7';
     expect(getJobCap('orchestrate')).toBe(7);

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
@@ -40,6 +40,10 @@ export const DEFAULT_JOB_CAPS: Readonly<Record<string, number>> = {
   run_workflow: 3,
   consensus_vote: 2,
   execute_expert: 4,
+  // #3726: run_dev_pipeline is a heavy multi-agent pipeline (plan→vote→
+  // decompose→implement→qa→security, each a live LLM call). Cap low — 2
+  // concurrent real runs already saturate adapter slots on most hosts.
+  run_dev_pipeline: 2,
 };
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the shared async-job dispatcher `runAsJob` (#3729 / epic #2631).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runAsJob, runJobInBackground } from './run-as-job.js';
+import { readJobResult } from './job-result-store.js';
+import { registerIdempotentJob, resolveIdempotency } from './job-idempotency.js';
+import { _resetForTests as resetConcurrency, getInFlight, getJobCap } from './job-concurrency.js';
+import { resetNexusDataDirCache, nexusDataPath } from '../../config/nexus-data-dir.js';
+
+interface DummyInput {
+  readonly task: string;
+}
+
+/** Parse the JSON payload out of a ToolResult text envelope. */
+function parseEnvelope(result: { content: Array<{ text: string }> }): Record<string, unknown> {
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+describe('runAsJob', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-runasjob-test-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetConcurrency();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns a pending envelope with the minted jobId', () => {
+    const result = runAsJob<DummyInput, { ok: true }>({
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => 'job-fixed-1',
+      run: () => new Promise(() => {}), // never resolves — keep it pending
+    });
+    const env = parseEnvelope(result);
+    expect(env['status']).toBe('pending');
+    expect(env['jobId']).toBe('job-fixed-1');
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('writes a pending job record + acquires a concurrency slot on dispatch', () => {
+    runAsJob<DummyInput, { ok: true }>({
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => 'job-fixed-2',
+      run: () => new Promise(() => {}),
+    });
+    expect(readJobResult('job-fixed-2')?.status).toBe('pending');
+    expect(getInFlight('orchestrate')).toBe(1);
+  });
+
+  it('returns a busy envelope when the per-tool cap is full', () => {
+    const cap = getJobCap('consensus_vote'); // 2 by default
+    for (let i = 0; i < cap; i++) {
+      runAsJob<DummyInput, { ok: true }>({
+        toolName: 'consensus_vote',
+        input: { task: `x${String(i)}` },
+        freshJobId: () => `job-cap-${String(i)}`,
+        run: () => new Promise(() => {}),
+      });
+    }
+    const result = runAsJob<DummyInput, { ok: true }>({
+      toolName: 'consensus_vote',
+      input: { task: 'overflow' },
+      freshJobId: () => 'job-cap-overflow',
+      run: () => new Promise(() => {}),
+    });
+    const env = parseEnvelope(result);
+    expect(env['status']).toBe('busy');
+    expect(typeof env['retryAfterMs']).toBe('number');
+    // Overflow dispatch must NOT have written a pending record.
+    expect(readJobResult('job-cap-overflow')).toBeNull();
+  });
+
+  it('records complete with the run result + releases the slot', async () => {
+    const params = {
+      toolName: 'orchestrate',
+      input: { task: 'ok' } as DummyInput,
+      freshJobId: () => 'job-complete-1',
+      run: () => Promise.resolve({ value: 42 }),
+    };
+    // Dispatch acquires the slot + writes pending; drive the background run
+    // deterministically rather than racing the detached promise.
+    runAsJob<DummyInput, { value: number }>({ ...params, run: () => new Promise(() => {}) });
+    await runJobInBackground('job-complete-1', params);
+    const record = readJobResult('job-complete-1');
+    expect(record?.status).toBe('complete');
+    expect(record?.result).toEqual({ value: 42 });
+    expect(getInFlight('orchestrate')).toBe(0);
+  });
+
+  it('records failed with the error message + releases the slot', async () => {
+    const params = {
+      toolName: 'orchestrate',
+      input: { task: 'boom' } as DummyInput,
+      freshJobId: () => 'job-fail-1',
+      run: () => Promise.reject(new Error('kaboom')),
+    };
+    runAsJob<DummyInput, never>({ ...params, run: () => new Promise(() => {}) });
+    await runJobInBackground('job-fail-1', params);
+    const record = readJobResult('job-fail-1');
+    expect(record?.status).toBe('failed');
+    expect(record?.error).toBe('kaboom');
+    expect(getInFlight('orchestrate')).toBe(0);
+  });
+
+  it('returns a replay envelope when an idempotency key matches a prior dispatch', () => {
+    const input: DummyInput = { task: 'idem' };
+    // Pre-seed an index entry as a prior dispatch would.
+    const resolved = resolveIdempotency('orchestrate', 'k1', input);
+    expect(resolved.kind).toBe('fresh');
+    if (resolved.kind === 'fresh') {
+      registerIdempotentJob({
+        tool: 'orchestrate',
+        idempotencyKey: 'k1',
+        inputs: input,
+        jobId: resolved.jobId,
+      });
+      const result = runAsJob<DummyInput, { ok: true }>({
+        toolName: 'orchestrate',
+        input,
+        idempotencyKey: 'k1',
+        freshJobId: () => 'should-not-be-used',
+        run: () => new Promise(() => {}),
+      });
+      const env = parseEnvelope(result);
+      expect(env['status']).toBe('replay');
+      expect(env['jobId']).toBe(resolved.jobId);
+      // Replay must NOT acquire a slot.
+      expect(getInFlight('orchestrate')).toBe(0);
+    }
+  });
+
+  it('returns a collision error envelope when a key is reused with different inputs', () => {
+    const first: DummyInput = { task: 'first' };
+    const resolved = resolveIdempotency('orchestrate', 'k2', first);
+    if (resolved.kind === 'fresh') {
+      registerIdempotentJob({
+        tool: 'orchestrate',
+        idempotencyKey: 'k2',
+        inputs: first,
+        jobId: resolved.jobId,
+      });
+    }
+    const result = runAsJob<DummyInput, { ok: true }>({
+      toolName: 'orchestrate',
+      input: { task: 'DIFFERENT' },
+      idempotencyKey: 'k2',
+      freshJobId: () => 'unused',
+      run: () => new Promise(() => {}),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Idempotency key already used');
+    expect(getInFlight('orchestrate')).toBe(0);
+    expect(nexusDataPath('jobs')).toContain(tmpDir);
+  });
+});

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
@@ -1,0 +1,207 @@
+/**
+ * Shared async-job dispatcher — `runAsJob` (#3729 / epic #2631).
+ *
+ * Three tools (orchestrate, run_workflow, consensus_vote) implemented the
+ * async-mode dispatcher VERBATIM: resolve idempotency → tryAcquire (busy
+ * envelope on cap) → writeJobPending → registerIdempotentJob → fire a
+ * detached background `run` that writes complete/failed + releases the slot
+ * in a `finally` → return a synchronous `{ status: 'pending', jobId }`
+ * envelope. This module extracts that sequence once so new long-running
+ * tools (run_dev_pipeline, run_pipeline, …) opt into async with a few lines.
+ *
+ * The dispatcher sequence is FIXED here; the only per-tool variation is the
+ * envelope shape (some tools use `ToolResult` via toolSuccess/
+ * toolStructuredError, run_workflow uses its structurally-identical
+ * `ToolResponse`). Callers that need a non-default envelope supply
+ * `toEnvelope`; the default builders reproduce the orchestrate/consensus_vote
+ * `ToolResult` envelopes byte-for-byte so faithful migration is a drop-in.
+ *
+ * @module mcp/jobs/run-as-job
+ */
+
+import type { ILogger } from '../../core/index.js';
+import { toolSuccess, toolStructuredError, type ToolResult } from '../tools/tool-result.js';
+import { writeJobComplete, writeJobFailed, writeJobPending } from './job-result-store.js';
+import { registerIdempotentJob, shortCircuitOrFreshJobId } from './job-idempotency.js';
+import { release, suggestRetryAfterMs, tryAcquire } from './job-concurrency.js';
+
+/**
+ * Per-tool envelope builders. Every async dispatcher returns the same five
+ * logical outcomes; only their wire shape differs. Supplying this lets a tool
+ * that uses a different success/error factory (e.g. run_workflow's
+ * `successResponse`/`errorResponse`) reuse the dispatcher unchanged.
+ *
+ * @template E - The tool's MCP envelope type (defaults to {@link ToolResult}).
+ */
+export interface JobEnvelopeBuilders<E> {
+  /** `{ status: 'pending', jobId, pollTool, note }` — returned synchronously after dispatch. */
+  readonly pending: (jobId: string) => E;
+  /** `{ status: 'busy', retryAfterMs, note }` — concurrency cap reached. */
+  readonly busy: (retryAfterMs: number, toolName: string) => E;
+  /** `{ status: 'replay', jobId, pollTool, note }` — idempotency key matched a prior dispatch. */
+  readonly replay: (jobId: string) => E;
+  /** Error envelope — idempotency key reused with different inputs. */
+  readonly collision: (existingJobId: string) => E;
+}
+
+/** Default pending envelope (orchestrate/consensus_vote shape). */
+export function defaultPendingEnvelope(jobId: string): ToolResult {
+  return toolSuccess(
+    JSON.stringify({
+      status: 'pending',
+      jobId,
+      pollTool: 'get_job_result',
+      note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+    })
+  );
+}
+
+/** Default busy envelope (orchestrate/consensus_vote shape). */
+export function defaultBusyEnvelope(retryAfterMs: number, toolName: string): ToolResult {
+  return toolSuccess(
+    JSON.stringify({
+      status: 'busy',
+      retryAfterMs,
+      note: `Async-mode concurrency cap reached for ${toolName}. Retry later or use mode: "sync".`,
+    })
+  );
+}
+
+/** Default replay envelope (orchestrate/consensus_vote shape). */
+export function defaultReplayEnvelope(jobId: string): ToolResult {
+  return toolSuccess(
+    JSON.stringify({
+      status: 'replay',
+      jobId,
+      pollTool: 'get_job_result',
+      note: 'Idempotency key matched a prior dispatch — poll get_job_result for current status.',
+    })
+  );
+}
+
+/** Default collision envelope (orchestrate/consensus_vote shape). */
+export function defaultCollisionEnvelope(existingJobId: string): ToolResult {
+  return toolStructuredError({
+    errorCategory: 'validation',
+    message: `Idempotency key already used with different inputs. Existing jobId: ${existingJobId}. Use a fresh key or omit it.`,
+  });
+}
+
+/** The full default ({@link ToolResult}) envelope set. */
+export const DEFAULT_JOB_ENVELOPES: JobEnvelopeBuilders<ToolResult> = {
+  pending: defaultPendingEnvelope,
+  busy: defaultBusyEnvelope,
+  replay: defaultReplayEnvelope,
+  collision: defaultCollisionEnvelope,
+};
+
+/**
+ * Parameters for {@link runAsJob}.
+ *
+ * @template I - The tool's validated input type (hashed for idempotency,
+ *   passed to `run`).
+ * @template R - The structured result `run` resolves to; recorded verbatim
+ *   via `writeJobComplete` and returned by a later `get_job_result(jobId)`.
+ * @template E - The tool's envelope type (defaults to {@link ToolResult}).
+ */
+export interface RunAsJobParams<I, R, E = ToolResult> {
+  /** MCP tool name — the idempotency / concurrency / job-store key. */
+  readonly toolName: string;
+  /** Validated tool input. Hashed for idempotency + passed to `run`. */
+  readonly input: I;
+  /** Caller-supplied idempotency key (optional). */
+  readonly idempotencyKey?: string | undefined;
+  /** Mints a fresh jobId when no idempotency short-circuit applies. */
+  readonly freshJobId: () => string;
+  /**
+   * The detached background work. Receives the resolved `jobId` (so the
+   * runner can thread it into a task-state log) and the `input`. Its
+   * resolved value is recorded as the job's `complete` result; a rejection
+   * is recorded as `failed`.
+   */
+  readonly run: (jobId: string, input: I) => Promise<R>;
+  /** Per-tool envelope builders. Defaults to the {@link ToolResult} set. */
+  readonly toEnvelope?: JobEnvelopeBuilders<E>;
+  /** Optional logger for the background failure path. */
+  readonly logger?: ILogger | undefined;
+}
+
+/**
+ * Dispatch `run` as a detached background job and return a synchronous
+ * envelope. Performs the EXACT sequence the three hand-rolled dispatchers
+ * shared:
+ *
+ * 1. Resolve idempotency BEFORE acquiring a slot — a replay/collision must
+ *    not burn capacity a live caller could use.
+ * 2. `tryAcquire(toolName)` — over-cap returns the `busy` envelope.
+ * 3. `writeJobPending` + `registerIdempotentJob` (when a key was supplied).
+ * 4. Fire-and-forget `run(jobId, input)`: on resolve `writeJobComplete`,
+ *    on reject `writeJobFailed`, `release` in a `finally`.
+ * 5. Return the `pending` envelope (`{ status: 'pending', jobId, … }`).
+ *
+ * The background promise is intentionally not awaited — async mode exists
+ * precisely because awaiting it would defeat the contract. Its rejection is
+ * caught + recorded; nothing escapes unhandled.
+ *
+ * @returns The synchronous envelope: `pending` on dispatch, `busy` on cap,
+ *   `replay`/`collision` on an idempotency match.
+ */
+export function runAsJob<I, R, E = ToolResult>(params: RunAsJobParams<I, R, E>): E {
+  const env = params.toEnvelope ?? (DEFAULT_JOB_ENVELOPES as unknown as JobEnvelopeBuilders<E>);
+
+  // Step 1: idempotency resolves BEFORE the slot acquire.
+  const idempotency = shortCircuitOrFreshJobId<E>({
+    tool: params.toolName,
+    idempotencyKey: params.idempotencyKey,
+    inputs: params.input,
+    freshJobId: params.freshJobId,
+    replayEnvelope: env.replay,
+    collisionEnvelope: env.collision,
+  });
+  if (idempotency.kind === 'shortCircuit') return idempotency.value;
+
+  // Step 2: per-tool concurrency cap. Over-cap returns busy synchronously.
+  if (!tryAcquire(params.toolName)) {
+    return env.busy(suggestRetryAfterMs(params.toolName), params.toolName);
+  }
+
+  const jobId = idempotency.jobId;
+  // Step 3: pending record + idempotency index entry.
+  writeJobPending(jobId, params.toolName);
+  if (params.idempotencyKey !== undefined && params.idempotencyKey !== '') {
+    registerIdempotentJob({
+      tool: params.toolName,
+      idempotencyKey: params.idempotencyKey,
+      inputs: params.input,
+      jobId,
+    });
+  }
+
+  // Step 4: detached background run with terminal recording + slot release.
+  void runJobInBackground(jobId, params);
+
+  // Step 5: synchronous pending envelope.
+  return env.pending(jobId);
+}
+
+/**
+ * Fire-and-forget background runner. Exported (awaitable) so integration
+ * tests can drive the dispatch deterministically instead of racing the
+ * detached promise.
+ * @internal
+ */
+export async function runJobInBackground<I, R, E>(
+  jobId: string,
+  params: RunAsJobParams<I, R, E>
+): Promise<void> {
+  try {
+    const result = await params.run(jobId, params.input);
+    writeJobComplete(jobId, params.toolName, result);
+  } catch (err: unknown) {
+    const errObj = err instanceof Error ? err : new Error(String(err));
+    params.logger?.error(`Async ${params.toolName} dispatch failed`, errObj, { jobId });
+    writeJobFailed(jobId, params.toolName, errObj.message);
+  } finally {
+    release(params.toolName);
+  }
+}

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
@@ -45,6 +45,7 @@ describe('toolNameFromJobId', () => {
     expect(toolNameFromJobId('orch-1-a')).toBe('orchestrate');
     expect(toolNameFromJobId('rwf-1-a')).toBe('run_workflow');
     expect(toolNameFromJobId('cv-1-a')).toBe('consensus_vote');
+    expect(toolNameFromJobId('dp-abc123')).toBe('run_dev_pipeline');
   });
   it('returns "unknown" for unrecognized or prefix-less ids', () => {
     expect(toolNameFromJobId('weird-1-a')).toBe('unknown');

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
@@ -38,6 +38,10 @@ const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
   orch: 'orchestrate',
   rwf: 'run_workflow',
   cv: 'consensus_vote',
+  // #3726: run_dev_pipeline async jobs mint `dp-<uuid>` ids (or reuse the
+  // caller's sessionId — which has no fixed prefix, so the dual-read reader
+  // resolves those from the sidecar via toolName recorded at writeJobPending).
+  dp: 'run_dev_pipeline',
 };
 
 /** Derive the toolName from a jobId/taskId prefix. */

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
@@ -15,6 +15,7 @@ import { validateToolInput } from './validation.js';
 import { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 import { type IPolicyFirewall, type ExecutionMode, createPolicyContext } from './policy.js';
 import { TimeoutGuard, type TimeoutGuardConfig } from './timeout-guard.js';
+import { MCP_TIMEOUTS } from '../../config/timeouts.js';
 import { createRequestContext, contextForLogging, type RequestContext } from './request-context.js';
 import { createMetricsMiddleware } from './tool-metrics.js';
 import { abortSignalStorage } from '../mcp-notifier.js';
@@ -214,8 +215,13 @@ function createTimeoutMiddleware(guard: TimeoutGuard, toolName: string): Middlew
         code: result.error.code,
         timeoutMs: result.error.timeoutMs,
       });
+      // #3726 discoverability: append the per-tool hint (e.g. "retry in async
+      // job-mode") so a sync long-running tool that hits its ceiling tells the
+      // caller how to escape it. Absent hint → message unchanged.
+      const hint = MCP_TIMEOUTS.perToolTimeoutHint[toolName];
+      const message = hint !== undefined ? `${result.error.message} ${hint}` : result.error.message;
       // Timeout — transient, a retry with more headroom may succeed.
-      return errorResult('transient', result.error.message, ctx.requestContext.requestId);
+      return errorResult('transient', message, ctx.requestContext.requestId);
     }
 
     if (result.value.nearTimeout) {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -60,9 +60,9 @@ import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 // #3045 / epic #2631 Stage 4 — async-mode dispatch + concurrency cap.
-import { writeJobPending, writeJobComplete, writeJobFailed } from '../jobs/job-result-store.js';
-import { shortCircuitOrFreshJobId, registerIdempotentJob } from '../jobs/job-idempotency.js';
-import { tryAcquire, release, suggestRetryAfterMs } from '../jobs/job-concurrency.js';
+// #3045 / epic #2631 Stage 4 — async-mode dispatch via the shared `runAsJob`
+// helper (#3729).
+import { runAsJob } from '../jobs/run-as-job.js';
 import { randomUUID } from 'node:crypto';
 import type {
   VotingStrategy,
@@ -733,99 +733,25 @@ type ConsensusVoteToolResponse = ToolResult;
  * Concurrency cap is enforced via `tryAcquire('consensus_vote')`
  * (default 2; voting is 7-fan-out so caps multiply adapter load fast).
  */
-/** Replay envelope for consensus_vote idempotency (#3042 Stage 1c). */
-function buildConsensusVoteReplayEnvelope(jobId: string): ConsensusVoteToolResponse {
-  return toolSuccess(
-    JSON.stringify({
-      status: 'replay',
-      jobId,
-      pollTool: 'get_job_result',
-      note: 'Idempotency key matched a prior dispatch — poll get_job_result for current status.',
-    })
-  );
-}
-
-/** Collision envelope for consensus_vote idempotency (#3042 Stage 1c). */
-function buildConsensusVoteCollisionEnvelope(existingJobId: string): ConsensusVoteToolResponse {
-  return toolStructuredError({
-    errorCategory: 'validation',
-    message: `Idempotency key already used with different inputs. Existing jobId: ${existingJobId}. Use a fresh key or omit it.`,
-  });
-}
-
 function dispatchAsyncConsensusVote(
   deps: ConsensusVoteDeps,
   args: import('./consensus-vote-types.js').ConsensusVoteInput
 ): ConsensusVoteToolResponse {
-  // #3042 Stage 1c: resolve idempotency BEFORE acquiring a slot — see
-  // orchestrate.ts for the full contract.
-  const idempotency = shortCircuitOrFreshJobId<ConsensusVoteToolResponse>({
-    tool: 'consensus_vote',
+  // #3729: dispatch via the shared `runAsJob` helper — the exact sequence this
+  // function used to inline. consensus_vote's only diff is the freshJobId; its
+  // pending/busy/replay/collision envelopes are byte-for-byte the helper's
+  // ToolResult defaults, so no per-tool `toEnvelope` is needed.
+  return runAsJob<
+    import('./consensus-vote-types.js').ConsensusVoteInput,
+    Awaited<ReturnType<typeof handleConsensusVote>>
+  >({
+    toolName: 'consensus_vote',
+    input: args,
     idempotencyKey: args.idempotencyKey,
-    inputs: args,
     freshJobId: () => `job-vote-${randomUUID()}`,
-    replayEnvelope: buildConsensusVoteReplayEnvelope,
-    collisionEnvelope: buildConsensusVoteCollisionEnvelope,
+    run: (_jobId, input) => handleConsensusVote(deps, input),
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });
-  if (idempotency.kind === 'shortCircuit') return idempotency.value;
-  if (!tryAcquire('consensus_vote')) {
-    return toolSuccess(
-      JSON.stringify({
-        status: 'busy',
-        retryAfterMs: suggestRetryAfterMs('consensus_vote'),
-        note: 'Async-mode concurrency cap reached for consensus_vote. Retry later or use mode: "sync".',
-      })
-    );
-  }
-  const jobId = idempotency.jobId;
-  recordConsensusVotePending(jobId, args);
-  void runConsensusVoteInBackground(jobId, deps, args);
-  return toolSuccess(
-    JSON.stringify({
-      status: 'pending',
-      jobId,
-      pollTool: 'get_job_result',
-      note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
-    })
-  );
-}
-
-/** Pending record + idempotency registration for consensus_vote (#3042 Stage 1c). */
-function recordConsensusVotePending(
-  jobId: string,
-  args: import('./consensus-vote-types.js').ConsensusVoteInput
-): void {
-  writeJobPending(jobId, 'consensus_vote');
-  if (args.idempotencyKey !== undefined && args.idempotencyKey !== '') {
-    registerIdempotentJob({
-      tool: 'consensus_vote',
-      idempotencyKey: args.idempotencyKey,
-      inputs: args,
-      jobId,
-    });
-  }
-}
-
-/**
- * Fire-and-forget consensus_vote background run. Wraps `handleConsensusVote`
- * with complete/failed recording + slot release. Extracted so dispatcher
- * stays under the 50-line cap.
- */
-async function runConsensusVoteInBackground(
-  jobId: string,
-  deps: ConsensusVoteDeps,
-  args: import('./consensus-vote-types.js').ConsensusVoteInput
-): Promise<void> {
-  try {
-    const result = await handleConsensusVote(deps, args);
-    writeJobComplete(jobId, 'consensus_vote', result);
-  } catch (err: unknown) {
-    const errObj = err instanceof Error ? err : new Error(String(err));
-    deps.logger?.error('Async consensus_vote dispatch failed', errObj, { jobId });
-    writeJobFailed(jobId, 'consensus_vote', errObj.message);
-  } finally {
-    release('consensus_vote');
-  }
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -2,7 +2,10 @@
  * run_dev_pipeline MCP Tool Tests (#1684)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // Pass-through the secure-handler / timeout chain so the registered callback
 // is the bare handler — lets the tests invoke it directly (#2824).
@@ -39,6 +42,9 @@ vi.mock('../../pipeline/dev-pipeline.js', async (importOriginal) => {
 });
 
 import { DevPipelineInputSchema, registerDevPipelineTool } from './dev-pipeline-tool.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 
 interface HandlerCtx {
   requestContext: { trustTier: string };
@@ -137,6 +143,113 @@ describe('DevPipelineInputSchema', () => {
   it('rejects a non-positive maxBudgetTokens', () => {
     expect(() => DevPipelineInputSchema.parse({ task: 'test', maxBudgetTokens: 0 })).toThrow();
     expect(() => DevPipelineInputSchema.parse({ task: 'test', maxBudgetTokens: -100 })).toThrow();
+  });
+
+  it('defaults dispatch to sync and accepts async (#3726)', () => {
+    expect(DevPipelineInputSchema.parse({ task: 'test' }).dispatch).toBe('sync');
+    expect(DevPipelineInputSchema.parse({ task: 'test', dispatch: 'async' }).dispatch).toBe(
+      'async'
+    );
+    expect(() => DevPipelineInputSchema.parse({ task: 'test', dispatch: 'bogus' })).toThrow();
+  });
+});
+
+// #3726: async dispatch mode. A real run can exceed the 900s MCP request
+// timeout, so `dispatch: 'async'` returns a jobId immediately and runs the
+// pipeline in the background (poll get_job_result).
+describe('run_dev_pipeline async dispatch (#3726)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  /** Parse the JSON envelope out of a captured tool result. */
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-dp-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    runDevPipelineMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints a dp-<uuid> id without a sessionId", async () => {
+    const handler = captureHandler();
+    const result = await handler({ task: 'Build feature X', dispatch: 'async' }, STDIO_CTX);
+    const env = envelope(result);
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^dp-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('uses the sessionId verbatim as the jobId when one is provided', async () => {
+    const handler = captureHandler();
+    const result = await handler(
+      { task: 'Build feature X', dispatch: 'async', sessionId: 'my-session-1' },
+      STDIO_CTX
+    );
+    expect(envelope(result)['jobId']).toBe('my-session-1');
+  });
+
+  it('dryRun ALWAYS stays sync even when dispatch is async', async () => {
+    const handler = captureHandler();
+    const result = await handler(
+      { task: 'Build feature X', dispatch: 'async', dryRun: true },
+      STDIO_CTX
+    );
+    // Sync path runs the (mocked) pipeline inline and returns a structured
+    // result, NOT a pending envelope.
+    expect(envelope(result)['status']).toBeUndefined();
+    expect(runDevPipelineMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the pipeline result to the sidecar when the background run completes', async () => {
+    const handler = captureHandler();
+    const result = await handler(
+      { task: 'Build feature X', dispatch: 'async', sessionId: 'sess-complete' },
+      STDIO_CTX
+    );
+    expect(envelope(result)['jobId']).toBe('sess-complete');
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult('sess-complete');
+    expect(record?.status).toBe('complete');
+  });
+
+  it('surfaces an idempotency collision when a sessionId is reused with different inputs', async () => {
+    const handler = captureHandler();
+    const first = await handler(
+      { task: 'First task', dispatch: 'async', sessionId: 'collide-1' },
+      STDIO_CTX
+    );
+    expect(envelope(first)['status']).toBe('pending');
+    // Reusing the sessionId with a DIFFERENT task must NOT silently return the
+    // first run's data — it surfaces the existing idempotency collision envelope.
+    const second = await handler(
+      { task: 'DIFFERENT task', dispatch: 'async', sessionId: 'collide-1' },
+      STDIO_CTX
+    );
+    expect(second.isError).toBe(true);
+    expect(second.content[0]?.text).toContain('Idempotency key already used');
+  });
+
+  it('sync errors carry the async-mode discoverability hint (#3726)', async () => {
+    runDevPipelineMock.mockRejectedValueOnce(new Error('stage exploded'));
+    const handler = captureHandler();
+    const result = await handler({ task: 'Build feature X' }, STDIO_CTX);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("dispatch: 'async'");
+    expect(result.content[0]?.text).toContain('get_job_result');
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, getErrorMessage, formatZodError, type ILogger } from '../../core/index.js';
 import { runDevPipeline } from '../../pipeline/dev-pipeline.js';
@@ -27,6 +28,19 @@ import {
   type BaseMcpToolDeps,
   type ToolResult,
 } from './tool-result.js';
+// #3726 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob, defaultReplayEnvelope, defaultCollisionEnvelope } from '../jobs/run-as-job.js';
+import { resolveIdempotency, registerIdempotentJob } from '../jobs/job-idempotency.js';
+
+/**
+ * Discoverability hint (#3726) prepended to sync run_dev_pipeline error/timeout
+ * envelopes. A real autonomous run can exceed the 900s MCP request timeout;
+ * async mode is the durable escape hatch.
+ */
+const DEV_PIPELINE_ASYNC_HINT =
+  'A full run_dev_pipeline run can exceed the 900s synchronous MCP timeout. ' +
+  "Retry with `dispatch: 'async'` to get a jobId immediately, then poll " +
+  'get_job_result({ jobId }) for the result.';
 
 // ============================================================================
 // Input Schema
@@ -112,6 +126,20 @@ export const DevPipelineInputSchema = z.object({
     .default('autonomous')
     .describe(
       "'autonomous': full pipeline. 'harness': stops after decompose, returns tasks for caller to implement."
+    ),
+  /**
+   * Dispatch mode (#3726). `sync` (default) runs the pipeline inline and
+   * returns the result — but a real autonomous run can exceed the 900s MCP
+   * request timeout. `async` returns a `{ status: 'pending', jobId }`
+   * envelope immediately and runs the pipeline in the background; poll
+   * `get_job_result({ jobId })` for the result. Ignored when `dryRun` is
+   * true (plan+vote completes fast, so dry runs always stay sync).
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3726). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result). Ignored for dryRun."
     ),
   /** Local pre-ship quality gate (typecheck/lint/tests) mode (#3356). */
   qualityGate: z
@@ -286,6 +314,24 @@ function buildPipelineOptions(
   };
 }
 
+/**
+ * Run the pipeline body + shape the structured success envelope. The
+ * sync handler awaits this inline; the async dispatcher backgrounds it via
+ * {@link runAsJob}. `taskText` + `stages` + `pipelineOptions` are resolved by
+ * the sync prelude in {@link runDevPipelineHandler} so only the (long) pipeline
+ * body runs in the background (#3726).
+ */
+async function executeDevPipelineBody(
+  taskText: string,
+  stages: Awaited<ReturnType<typeof createStages>>,
+  pipelineOptions: DevPipelineOptions | undefined
+): Promise<ToolResult> {
+  const result = await runDevPipeline(taskText, stages, pipelineOptions);
+  // Always flush memory session — including dry-run exits (#1716)
+  flushPipelineMemory();
+  return toolSuccessStructured(buildStructuredOutput(result));
+}
+
 async function runDevPipelineHandler(
   args: unknown,
   logger: ILogger,
@@ -305,20 +351,93 @@ async function runDevPipelineHandler(
   }
 
   try {
+    // Sync prelude — fast: input resolution + stage wiring + option build.
+    // Only the pipeline BODY backgrounds in async mode (#3726).
     const taskText = await resolveTaskInput(input);
     const stages = await createStages(input);
     const pipelineOptions = buildPipelineOptions(input, trustTier, auditLogger);
     const hasOptions = Object.keys(pipelineOptions).length > 0;
-    const result = await runDevPipeline(taskText, stages, hasOptions ? pipelineOptions : undefined);
-    // Always flush memory session — including dry-run exits (#1716)
-    flushPipelineMemory();
-    return toolSuccessStructured(buildStructuredOutput(result));
+    const resolvedOptions = hasOptions ? pipelineOptions : undefined;
+
+    // #3726: async dispatch for real (non-dryRun) runs — a full pipeline can
+    // exceed the 900s MCP request timeout. dryRun ALWAYS stays sync (plan+vote
+    // completes fast). Returns `{ status: 'pending', jobId }` immediately.
+    if (input.dispatch === 'async' && !input.dryRun) {
+      return dispatchAsyncDevPipeline(input, taskText, stages, resolvedOptions, logger);
+    }
+
+    return await executeDevPipelineBody(taskText, stages, resolvedOptions);
   } catch (error: unknown) {
+    // #3726 discoverability: a sync run that times out (or otherwise fails
+    // mid-pipeline) should point the caller at async mode — the durable fix
+    // for runs that exceed the 900s request timeout.
     return toolStructuredError({
       errorCategory: 'internal',
-      message: `Pipeline error: ${getErrorMessage(error)}`,
+      message: `${DEV_PIPELINE_ASYNC_HINT} Pipeline error: ${getErrorMessage(error)}`,
     });
   }
+}
+
+/**
+ * Async-mode dispatcher (#3726). jobId === sessionId ONLY when the caller
+ * explicitly supplies one (enables task-state resume); otherwise a fresh
+ * `dp-<uuid>` is minted. A reused sessionId surfaces via the EXISTING
+ * idempotency envelope (replay/collision) — it NEVER silently returns another
+ * run's data. The background runner writes the result to the SIDECAR
+ * regardless of jobId (the Stage-2 task-state reader is flag-gated off by
+ * default), so `get_job_result({ jobId })` always resolves.
+ *
+ * Why the manual idempotency pre-check (vs `runAsJob`'s built-in key path):
+ * the shared helper's keyed path derives an opaque `job-<tool>-<hash>` jobId,
+ * but #3726 needs the jobId to BE the sessionId so a resumed run polls the
+ * same key. So we resolve idempotency here with the jobId PINNED to the
+ * sessionId, then dispatch through `runAsJob` keyless (freshJobId === the
+ * sessionId, used verbatim).
+ */
+function dispatchAsyncDevPipeline(
+  input: DevPipelineInput,
+  taskText: string,
+  stages: Awaited<ReturnType<typeof createStages>>,
+  pipelineOptions: DevPipelineOptions | undefined,
+  logger: ILogger
+): ToolResult {
+  const run = (): Promise<ToolResult> => executeDevPipelineBody(taskText, stages, pipelineOptions);
+
+  // No sessionId → mint a fresh dp-<uuid>; no idempotency surface to track.
+  if (input.sessionId === undefined) {
+    return runAsJob<DevPipelineInput, ToolResult>({
+      toolName: 'run_dev_pipeline',
+      input,
+      freshJobId: () => `dp-${randomUUID()}`,
+      run,
+      logger,
+    });
+  }
+
+  // sessionId provided → jobId === sessionId, with collision-surfacing.
+  const sessionId = input.sessionId;
+  const resolution = resolveIdempotency('run_dev_pipeline', sessionId, input, () => sessionId);
+  if (resolution.kind === 'replay') {
+    return defaultReplayEnvelope(resolution.jobId);
+  }
+  if (resolution.kind === 'collision') {
+    return defaultCollisionEnvelope(resolution.existingJobId);
+  }
+  // Fresh dispatch: pin the index entry to jobId === sessionId so a rerun
+  // replays/collides against it, then dispatch keyless on that jobId.
+  registerIdempotentJob({
+    tool: 'run_dev_pipeline',
+    idempotencyKey: sessionId,
+    inputs: input,
+    jobId: sessionId,
+  });
+  return runAsJob<DevPipelineInput, ToolResult>({
+    toolName: 'run_dev_pipeline',
+    input,
+    freshJobId: () => sessionId,
+    run,
+    logger,
+  });
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -101,10 +101,15 @@ import {
 } from '../../context/structured-task-state.js';
 import type { StructuredTaskState } from '../../context/structured-task-state-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
-// #3042 / epic #2631: async-mode dispatch + sidecar job-result store.
-import { writeJobPending, writeJobComplete, writeJobFailed } from '../jobs/job-result-store.js';
-import { tryAcquire, release, suggestRetryAfterMs } from '../jobs/job-concurrency.js';
-import { shortCircuitOrFreshJobId, registerIdempotentJob } from '../jobs/job-idempotency.js';
+// #3042 / epic #2631: async-mode dispatch via the shared `runAsJob` helper
+// (#3729). Orchestrate keeps its own freshJobId (jobId === taskId) + replay/
+// collision envelopes; the dispatcher sequence itself is now shared.
+import {
+  runAsJob,
+  runJobInBackground,
+  defaultPendingEnvelope,
+  defaultBusyEnvelope,
+} from '../jobs/run-as-job.js';
 
 // Re-export types and values for consumers
 export {
@@ -1301,63 +1306,43 @@ function dispatchAsyncOrchestrate(params: {
   readonly logger: ILogger;
   readonly trustTier?: string;
 }): ToolResult {
-  // #3042 Stage 1c: resolve idempotency BEFORE acquiring a slot — a replay
-  // or collision must not burn capacity the live caller could use.
-  const idempotency = shortCircuitOrFreshJobId<ToolResult>({
-    tool: 'orchestrate',
+  // #3729: the shared `runAsJob` dispatcher performs the EXACT sequence this
+  // hand-rolled function used to (idempotency → busy-on-cap → pending +
+  // register → detached run with complete/failed + release-in-finally →
+  // pending envelope). Orchestrate's only diffs are the freshJobId (jobId ===
+  // taskId so get_job_result resolves from the task-state log) and the `run`
+  // fn, which additionally mirrors the result/failure into the Stage-2
+  // task-state log (#3091).
+  return runAsJob<OrchestrateInput, ToolResult>({
+    toolName: 'orchestrate',
+    input: params.input,
     idempotencyKey: params.input.idempotencyKey,
-    inputs: params.input,
     // #3091: jobId === taskId. The async job's id IS the orchestration's
     // taskId, so get_job_result(jobId) resolves directly from the task-state
-    // log (orch-<ts>-<rand>) under the Stage-2 reader. Replaces the former
-    // opaque `job-orch-<uuid>` id.
+    // log (orch-<ts>-<rand>) under the Stage-2 reader.
     freshJobId: () => generateTaskId(),
-    replayEnvelope: buildReplayEnvelope,
-    collisionEnvelope: buildCollisionEnvelope,
+    run: (jobId) => runOrchestratePipelineAsJob(jobId, params),
+    toEnvelope: {
+      pending: defaultPendingEnvelope,
+      busy: defaultBusyEnvelope,
+      replay: buildReplayEnvelope,
+      collision: buildCollisionEnvelope,
+    },
+    logger: params.logger,
   });
-  if (idempotency.kind === 'shortCircuit') return idempotency.value;
-  // #3044: per-tool concurrency cap. Over-cap returns `busy` synchronously
-  // so the caller backs off; configurable via NEXUS_JOB_MAX_CONCURRENT_ORCHESTRATE.
-  if (!tryAcquire('orchestrate')) {
-    return toolSuccess(
-      JSON.stringify({
-        status: 'busy',
-        retryAfterMs: suggestRetryAfterMs('orchestrate'),
-        note: 'Async-mode concurrency cap reached for orchestrate. Retry later or use mode: "sync".',
-      })
-    );
-  }
-  const jobId = idempotency.jobId;
-  recordPendingAndRegister(jobId, params.input.idempotencyKey, params.input);
-  void runOrchestrateInBackground(jobId, params);
-  return toolSuccess(
-    JSON.stringify({
-      status: 'pending',
-      jobId,
-      pollTool: 'get_job_result',
-      note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
-    })
-  );
-}
-
-/** Write pending record + register idempotency entry (#3042 Stage 1c). */
-function recordPendingAndRegister(jobId: string, key: string | undefined, inputs: unknown): void {
-  writeJobPending(jobId, 'orchestrate');
-  if (key !== undefined && key !== '') {
-    registerIdempotentJob({ tool: 'orchestrate', idempotencyKey: key, inputs, jobId });
-  }
 }
 
 /**
- * Fire-and-forget background run. Wraps the depth-guarded pipeline with
- * complete/failed recording + slot release. Extracted from
- * `dispatchAsyncOrchestrate` so the dispatcher stays under the 50-line cap.
+ * The orchestrate-specific background work passed to {@link runAsJob}. Runs
+ * the depth-guarded pipeline keyed on `jobId === taskId`, mirrors the result
+ * into the Stage-2 task-state log on success, records a terminal failure
+ * stage on throw, then rethrows so `runAsJob` writes the `failed` job record.
  *
- * Exported for integration tests (#3091) — drives the async background run
- * deterministically (awaitable) instead of fire-and-forget.
+ * Exported (awaitable) for integration tests (#3091) — drives the async
+ * background run deterministically instead of fire-and-forget.
  * @internal
  */
-export async function runOrchestrateInBackground(
+export async function runOrchestratePipelineAsJob(
   jobId: string,
   params: {
     readonly input: OrchestrateInput;
@@ -1366,7 +1351,7 @@ export async function runOrchestrateInBackground(
     readonly logger: ILogger;
     readonly trustTier?: string;
   }
-): Promise<void> {
+): Promise<ToolResult> {
   // #3091: jobId === taskId — thread it into the pipeline so the task-state
   // log is keyed identically and get_job_result can resolve from it.
   const taskId = jobId;
@@ -1381,23 +1366,46 @@ export async function runOrchestrateInBackground(
         ...(params.trustTier !== undefined ? { trustTier: params.trustTier } : {}),
       })
     );
-    writeJobComplete(jobId, 'orchestrate', result);
-    // #3091: mirror the result payload into the Stage-2 task-state log. The
-    // terminal stage (complete | failed) was set inside the pipeline; this
-    // records the same payload the sidecar stored so the dual-read reader
-    // returns an identical record. Best-effort, gated, never throws.
+    // #3091: mirror the result payload into the Stage-2 task-state log so the
+    // dual-read reader returns an identical record. Best-effort, never throws.
     recordTaskStateResult(taskId, result, params.logger);
+    return result;
   } catch (err: unknown) {
     const errObj = err instanceof Error ? err : new Error(String(err));
-    params.logger.error('Async orchestrate dispatch failed', errObj, { jobId });
-    writeJobFailed(jobId, 'orchestrate', errObj.message);
     // #3091: a throw escaping the pipeline (e.g. depth-guard) may leave the
     // task-state log without a terminal stage — record one so the reader
-    // doesn't report a stuck 'pending'.
+    // doesn't report a stuck 'pending'. runAsJob writes the `failed` job
+    // record from the rethrown error.
     recordTaskStateFailure(taskId, errObj.message, params.logger);
-  } finally {
-    release('orchestrate');
+    throw errObj;
   }
+}
+
+/**
+ * Awaitable background-run wrapper that drives the shared {@link runJobInBackground}
+ * with orchestrate's `run` — i.e. it runs the pipeline (mirroring task-state),
+ * writes the terminal sidecar job record (complete/failed), and releases the
+ * slot, exactly as the live async dispatch does. Exported for the #3091
+ * integration tests so the fire-and-forget run is deterministic.
+ * @internal
+ */
+export async function runOrchestrateInBackground(
+  jobId: string,
+  params: {
+    readonly input: OrchestrateInput;
+    readonly deps: OrchestrateDeps;
+    readonly notifier: ReturnType<typeof createMcpNotifier>;
+    readonly logger: ILogger;
+    readonly trustTier?: string;
+  }
+): Promise<void> {
+  await runJobInBackground(jobId, {
+    toolName: 'orchestrate',
+    input: params.input,
+    freshJobId: () => jobId,
+    run: (id) => runOrchestratePipelineAsJob(id, params),
+    logger: params.logger,
+  });
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -46,10 +46,9 @@ import {
 } from './run-workflow-helpers.js';
 import { getToolMemory } from './tool-memory.js';
 import { getToolAnnotations } from '../tool-annotations.js';
-// #3044 / epic #2631 Stage 3 — async-mode dispatch + concurrency cap.
-import { writeJobPending, writeJobComplete, writeJobFailed } from '../jobs/job-result-store.js';
-import { shortCircuitOrFreshJobId, registerIdempotentJob } from '../jobs/job-idempotency.js';
-import { tryAcquire, release, suggestRetryAfterMs } from '../jobs/job-concurrency.js';
+// #3044 / epic #2631 Stage 3 — async-mode dispatch via the shared `runAsJob`
+// helper (#3729).
+import { runAsJob } from '../jobs/run-as-job.js';
 import { randomUUID } from 'node:crypto';
 
 // Re-export types for backward compatibility
@@ -313,60 +312,39 @@ function buildRunWorkflowCollisionEnvelope(existingJobId: string): ToolResponse 
 }
 
 function dispatchAsyncRunWorkflow(deps: RunWorkflowDeps, args: RunWorkflowInput): ToolResponse {
-  // #3042 Stage 1c: resolve idempotency BEFORE acquiring a slot — see
-  // orchestrate.ts for the full contract.
-  const idempotency = shortCircuitOrFreshJobId<ToolResponse>({
-    tool: 'run_workflow',
+  // #3729: dispatch via the shared `runAsJob` helper — the exact sequence this
+  // function used to inline (idempotency → busy-on-cap → pending + register →
+  // detached run with complete/failed + release-in-finally → pending
+  // envelope). run_workflow's only diffs are the freshJobId and the
+  // `ToolResponse`-shaped envelopes (structurally identical to ToolResult but
+  // built via successResponse/errorResponse for the workflow path).
+  return runAsJob<RunWorkflowInput, ToolResponse, ToolResponse>({
+    toolName: 'run_workflow',
+    input: args,
     idempotencyKey: args.idempotencyKey,
-    inputs: args,
     freshJobId: () => `job-rw-${randomUUID()}`,
-    replayEnvelope: buildRunWorkflowReplayEnvelope,
-    collisionEnvelope: buildRunWorkflowCollisionEnvelope,
-  });
-  if (idempotency.kind === 'shortCircuit') return idempotency.value;
-  // Concurrency cap. Configurable via NEXUS_JOB_MAX_CONCURRENT_RUN_WORKFLOW.
-  if (!tryAcquire('run_workflow')) {
-    return successResponse({
-      status: 'busy',
-      retryAfterMs: suggestRetryAfterMs('run_workflow'),
-      note: 'Async-mode concurrency cap reached for run_workflow. Retry later or use mode: "sync".',
-    });
-  }
-  const jobId = idempotency.jobId;
-  writeJobPending(jobId, 'run_workflow');
-  if (args.idempotencyKey !== undefined && args.idempotencyKey !== '') {
-    registerIdempotentJob({
-      tool: 'run_workflow',
-      idempotencyKey: args.idempotencyKey,
-      inputs: args,
-      jobId,
-    });
-  }
-  // Fire-and-forget — `handleRunWorkflow` already encapsulates the full
-  // sync execution path including dry-run + validation + recording, so
-  // re-using it here keeps the wrapping minimal. The dispatched
-  // response object is wrapped consistently with the sync mode's
-  // success/error envelope so polling clients consume the same shape.
-  void (async (): Promise<void> => {
-    try {
-      const result = await handleRunWorkflow(deps, args);
-      // handleRunWorkflow returns a tool-response envelope; recording
-      // the whole envelope as the job result preserves the success/error
-      // discriminator + the workflow's stepResults for polling clients.
-      writeJobComplete(jobId, 'run_workflow', result);
-    } catch (err: unknown) {
-      const errObj = err instanceof Error ? err : new Error(String(err));
-      deps.logger?.error('Async run_workflow dispatch failed', errObj, { jobId });
-      writeJobFailed(jobId, 'run_workflow', errObj.message);
-    } finally {
-      release('run_workflow');
-    }
-  })();
-  return successResponse({
-    status: 'pending',
-    jobId,
-    pollTool: 'get_job_result',
-    note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+    // `handleRunWorkflow` already encapsulates the full sync path (dry-run +
+    // validation + recording); recording its whole envelope as the job result
+    // preserves the success/error discriminator + stepResults for polling.
+    run: (_jobId, input) => handleRunWorkflow(deps, input),
+    toEnvelope: {
+      pending: (jobId) =>
+        successResponse({
+          status: 'pending',
+          jobId,
+          pollTool: 'get_job_result',
+          note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+        }),
+      busy: (retryAfterMs) =>
+        successResponse({
+          status: 'busy',
+          retryAfterMs,
+          note: 'Async-mode concurrency cap reached for run_workflow. Retry later or use mode: "sync".',
+        }),
+      replay: buildRunWorkflowReplayEnvelope,
+      collision: buildRunWorkflowCollisionEnvelope,
+    },
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });
 }
 


### PR DESCRIPTION
## What

Implements #3726 and the shared async-job helper from epic #3729.

A complete async-job protocol already existed (epic #2631), but three tools — `orchestrate`, `run_workflow`, `consensus_vote` — implemented the dispatcher **verbatim**. This PR extracts that sequence once and migrates the three onto it, then adds `run_dev_pipeline` async mode as the reference implementation.

## Step 1 — shared `runAsJob` helper

New `src/mcp/jobs/run-as-job.ts` exports `runAsJob<I, R, E>({ toolName, input, idempotencyKey?, freshJobId, run, toEnvelope?, logger? })` performing the exact dispatcher sequence: idempotency resolve → `tryAcquire` (busy envelope on cap) → `writeJobPending` → `registerIdempotentJob` → detached `run(jobId, input)` with `writeJobComplete`/`writeJobFailed` + `release` in `finally` → pending envelope. Default `ToolResult` envelope builders reproduce the orchestrate/consensus_vote shapes byte-for-byte; `toEnvelope` supports run_workflow's structurally-identical `ToolResponse`.

`orchestrate`, `run_workflow`, `consensus_vote` refactored onto it — **faithful, no behavior change**. Their existing suites stay green (orchestrate 42 + orchestrate-job-result 2, run-workflow 28, consensus-vote 84).

## Step 2 — #3726 run_dev_pipeline async (reference impl)

- New `dispatch: z.enum(['sync','async']).default('sync')` input (named `dispatch` because `mode` is already taken by autonomous/harness).
- `dispatch:'async' && !dryRun` → returns `{ status: 'pending', jobId }` immediately, backgrounds the pipeline body. The sync validation/compile prelude (input resolution + stage wiring) stays fast; only the pipeline body backgrounds.
- `dryRun` ALWAYS stays sync.
- **jobId === sessionId only when explicitly provided** (task-state resume); else `dp-<uuid>`. A reused sessionId with different inputs surfaces the **existing idempotency collision envelope** — never a silent result swap.
- Added `run_dev_pipeline` to `DEFAULT_JOB_CAPS` (cap 2) and `TOOL_NAME_BY_PREFIX` (`dp`).

## Step 3 — interim 900s cap mitigation

`pr_review`, `supply_chain_tradeoff_panel`, `execute_spec`, `run` were on the 60s MCP default and failed at 60s. Bumped to the 900s `perTool` ceiling until durable async migration lands (#3730-3732). stdio transport (no proxy/LB) makes the interim safe.

## Step 4 — discoverability

A sync long-running tool that times out now appends a per-tool hint (new `MCP_TIMEOUTS.perToolTimeoutHint`) telling the caller to retry with `dispatch:'async'` + poll `get_job_result`. The run_dev_pipeline sync error path also prepends the hint.

## Tests

- `run-as-job.test.ts` (7): pending shape, busy-on-cap, complete, failed, release-in-finally, replay, collision.
- `dev-pipeline-tool.test.ts` (+8): schema default, async pending+`dp-` id, sessionId-as-jobId, dryRun-stays-sync, sidecar-complete, sessionId-collision-surfaces, sync-error hint.
- `timeouts.test.ts` / `job-concurrency.test.ts` / `task-state-source.test.ts`: the 4 perTool caps, the hint, the cap-2, the `dp` prefix.

Full `src/mcp` suite: **179 files / 3478 tests green**. tsc clean, eslint clean (zero `any`), governance:check / check-registry-coverage / generate-repo-index --check all pass.

Closes #3726. Part of epic #3729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)