### PR TITLE
feat(pipeline): run_pipeline async job-mode via runAsJob (#3730)

### DIFF
--- a/.changeset/run-pipeline-async-3730.md
+++ b/.changeset/run-pipeline-async-3730.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+pipeline: `run_pipeline` gains async job-mode (#3730). A new `dispatch: 'async'`
+input returns `{ status: 'pending', jobId }` immediately and runs the multi-stage
+adaptive orchestrator in the background via the shared `runAsJob` helper; poll
+`get_job_result({ jobId })` for the result. `dispatch: 'sync'` (default) is
+byte-identical to prior behavior; `dryRun` always stays sync. async jobs mint an
+`rp-<uuid>` jobId (run_pipeline has no sessionId surface) and are capped at 2
+concurrent runs. Mirrors the `run_dev_pipeline` migration (#3726).

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
@@ -41,6 +41,11 @@ describe('getJobCap', () => {
     expect(getJobCap('run_dev_pipeline')).toBe(2);
   });
 
+  it('caps run_pipeline at 2 concurrent runs (#3730)', () => {
+    expect(DEFAULT_JOB_CAPS['run_pipeline']).toBe(2);
+    expect(getJobCap('run_pipeline')).toBe(2);
+  });
+
   it('honors NEXUS_JOB_MAX_CONCURRENT_<TOOL> env override', () => {
     process.env['NEXUS_JOB_MAX_CONCURRENT_ORCHESTRATE'] = '7';
     expect(getJobCap('orchestrate')).toBe(7);

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
@@ -44,6 +44,9 @@ export const DEFAULT_JOB_CAPS: Readonly<Record<string, number>> = {
   // decompose→implement→qa→security, each a live LLM call). Cap low — 2
   // concurrent real runs already saturate adapter slots on most hosts.
   run_dev_pipeline: 2,
+  // #3730: run_pipeline is a multi-stage adaptive orchestrator with per-stage
+  // experts (live LLM calls). Same shape as run_dev_pipeline — cap low at 2.
+  run_pipeline: 2,
 };
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
@@ -46,6 +46,7 @@ describe('toolNameFromJobId', () => {
     expect(toolNameFromJobId('rwf-1-a')).toBe('run_workflow');
     expect(toolNameFromJobId('cv-1-a')).toBe('consensus_vote');
     expect(toolNameFromJobId('dp-abc123')).toBe('run_dev_pipeline');
+    expect(toolNameFromJobId('rp-abc123')).toBe('run_pipeline');
   });
   it('returns "unknown" for unrecognized or prefix-less ids', () => {
     expect(toolNameFromJobId('weird-1-a')).toBe('unknown');

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
@@ -42,6 +42,8 @@ const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
   // caller's sessionId — which has no fixed prefix, so the dual-read reader
   // resolves those from the sidecar via toolName recorded at writeJobPending).
   dp: 'run_dev_pipeline',
+  // #3730: run_pipeline async jobs mint `rp-<uuid>` ids (no sessionId surface).
+  rp: 'run_pipeline',
 };
 
 /** Derive the toolName from a jobId/taskId prefix. */

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
@@ -2,7 +2,10 @@
  * run_pipeline MCP Tool Tests (#1736)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // Pass-through the secure-handler / timeout chain so the registered callback
 // is the bare handler — lets the tests invoke it directly (#2824).
@@ -15,7 +18,29 @@ vi.mock('../middleware/secure-handler.js', () => ({
   createSecureHandler: (fn: unknown) => fn,
 }));
 
+// #3730: stub the adaptive orchestrator so the async background run resolves
+// fast and deterministically (no live adapters in unit tests).
+const ORCHESTRATOR_RESULT = {
+  success: true,
+  templateId: 'general',
+  selectionMethod: 'auto',
+  taskClassification: { pipelineType: 'general' },
+  stepsExecuted: 1,
+  durationMs: 1,
+};
+const runAdaptiveOrchestratorMock = vi.fn(() => Promise.resolve(ORCHESTRATOR_RESULT));
+vi.mock('../../pipeline/adaptive-orchestrator.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../pipeline/adaptive-orchestrator.js')>();
+  return {
+    ...actual,
+    runAdaptiveOrchestrator: () => runAdaptiveOrchestratorMock(),
+  };
+});
+
 import { PipelineInputSchema, registerPipelineTool } from './pipeline-tool.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 
 describe('PipelineInputSchema', () => {
   it('accepts a valid task with defaults', () => {
@@ -45,6 +70,14 @@ describe('PipelineInputSchema', () => {
     expect(parsed.template).toBe('audit');
     expect(parsed.dryRun).toBe(true);
   });
+
+  it('defaults dispatch to sync and accepts async (#3730)', () => {
+    expect(PipelineInputSchema.parse({ task: 'valid task' }).dispatch).toBe('sync');
+    expect(PipelineInputSchema.parse({ task: 'valid task', dispatch: 'async' }).dispatch).toBe(
+      'async'
+    );
+    expect(() => PipelineInputSchema.parse({ task: 'valid task', dispatch: 'bogus' })).toThrow();
+  });
 });
 
 interface CapturedToolResult {
@@ -69,6 +102,64 @@ function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
   if (captured === undefined) throw new Error('handler not registered');
   return captured;
 }
+
+// #3730: async dispatch mode. A real run can exceed the 900s MCP request
+// timeout, so `dispatch: 'async'` returns a jobId immediately and runs the
+// pipeline in the background (poll get_job_result). run_pipeline has no
+// sessionId, so a fresh `rp-<uuid>` jobId is always minted (no idempotency
+// surface).
+describe('run_pipeline async dispatch (#3730)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  /** Parse the JSON envelope out of a captured tool result. */
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-rp-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    runAdaptiveOrchestratorMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints an rp-<uuid> id", async () => {
+    const handler = captureHandler();
+    const result = await handler({ task: 'Build feature X', dispatch: 'async' });
+    const env = envelope(result);
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^rp-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs the pipeline inline (sync) by default — no pending envelope', async () => {
+    const handler = captureHandler();
+    const result = await handler({ task: 'Build feature X' });
+    expect(envelope(result)['status']).toBeUndefined();
+    expect(runAdaptiveOrchestratorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the pipeline result to the sidecar when the background run completes', async () => {
+    const handler = captureHandler();
+    const result = await handler({ task: 'Build feature X', dispatch: 'async' });
+    const jobId = envelope(result)['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
+  });
+});
 
 // #2824: run_pipeline used to register a bare callback that called
 // `schema.parse(args)` outside any try/catch — a ZodError on bad input

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -11,6 +11,7 @@
 import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, getErrorMessage, formatZodError, type ILogger } from '../../core/index.js';
 import { runAdaptiveOrchestrator, classifyTask } from '../../pipeline/adaptive-orchestrator.js';
@@ -36,6 +37,18 @@ import {
   type BaseMcpToolDeps,
   type ToolResult,
 } from './tool-result.js';
+// #3730 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
+
+/**
+ * Discoverability hint (#3730) appended to sync run_pipeline error/timeout
+ * envelopes. A real multi-stage adaptive run can exceed the 900s MCP request
+ * timeout; async mode is the durable escape hatch.
+ */
+const PIPELINE_ASYNC_HINT =
+  'A full run_pipeline run can exceed the synchronous MCP request timeout. ' +
+  "Retry with `dispatch: 'async'` to get a jobId immediately, then poll " +
+  'get_job_result({ jobId }) for the result.';
 
 // ============================================================================
 // Input Schema
@@ -89,6 +102,20 @@ export const PipelineInputSchema = z.object({
     .describe('Max time per stage in ms (30000-600000). Default: varies by stage complexity'),
   /** Stop after planning/voting (no implementation). */
   dryRun: z.boolean().default(false).describe('Stop after vote stage (no implementation)'),
+  /**
+   * Dispatch mode (#3730). `sync` (default) runs the pipeline inline and
+   * returns the result — but a real multi-stage adaptive run can exceed the
+   * 900s MCP request timeout. `async` returns a `{ status: 'pending', jobId }`
+   * envelope immediately and runs the pipeline in the background; poll
+   * `get_job_result({ jobId })` for the result. Ignored when `dryRun` is true
+   * (plan+vote completes fast, so dry runs always stay sync).
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3730). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result). Ignored for dryRun."
+    ),
   /** TESTS ONLY — random output, must not be used for real decisions. (#2319) */
   simulateVotes: z
     .boolean()
@@ -237,6 +264,27 @@ export async function runPipelineForGoal(
   return runAdaptiveOrchestrator(goal, { stages });
 }
 
+/**
+ * Run the adaptive-orchestrator body + shape the structured success envelope.
+ * The sync handler awaits this inline; the async dispatcher backgrounds it via
+ * {@link runAsJob}. `task` + `stages` are resolved by the sync prelude in
+ * {@link runPipelineHandler} so only the (long) orchestrator body runs in the
+ * background (#3730).
+ */
+async function executePipelineBody(
+  task: string,
+  stages: ReturnType<typeof selectStageRegistry>,
+  templateId: string | undefined,
+  dryRun: boolean
+): Promise<ToolResult> {
+  const result = await runAdaptiveOrchestrator(task, {
+    stages,
+    templateId,
+    dryRun,
+  });
+  return toolSuccessStructured(buildOutput(result));
+}
+
 /** Validates input, runs the adaptive orchestrator, and shapes the result. */
 async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
   const parsed = PipelineInputSchema.safeParse(args);
@@ -252,6 +300,8 @@ async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolR
   }
 
   try {
+    // Sync prelude — fast: input resolution + stage wiring. Only the
+    // orchestrator BODY backgrounds in async mode (#3730).
     const task = await resolveTask(input.task, input.specFile);
     const agentStages = createAgentStages({
       simulateVotes: input.simulateVotes,
@@ -261,17 +311,29 @@ async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolR
     });
     const stages = selectStageRegistry(input.template, task, agentStages);
 
-    const result = await runAdaptiveOrchestrator(task, {
-      stages,
-      templateId: input.template,
-      dryRun: input.dryRun,
-    });
+    // #3730: async dispatch for real (non-dryRun) runs — a full adaptive
+    // pipeline can exceed the 900s MCP request timeout. dryRun ALWAYS stays
+    // sync (plan+vote completes fast). run_pipeline has no sessionId, so a
+    // fresh `rp-<uuid>` jobId is always minted (no idempotency surface).
+    // Returns `{ status: 'pending', jobId }` immediately.
+    if (input.dispatch === 'async' && !input.dryRun) {
+      return runAsJob<PipelineInput, ToolResult>({
+        toolName: 'run_pipeline',
+        input,
+        freshJobId: () => `rp-${randomUUID()}`,
+        run: () => executePipelineBody(task, stages, input.template, input.dryRun),
+        logger,
+      });
+    }
 
-    return toolSuccessStructured(buildOutput(result));
+    return await executePipelineBody(task, stages, input.template, input.dryRun);
   } catch (error: unknown) {
+    // #3730 discoverability: a sync run that times out (or otherwise fails
+    // mid-pipeline) should point the caller at async mode — the durable fix
+    // for runs that exceed the request timeout.
     return toolStructuredError({
       errorCategory: 'internal',
-      message: `Pipeline error: ${getErrorMessage(error)}`,
+      message: `${PIPELINE_ASYNC_HINT} Pipeline error: ${getErrorMessage(error)}`,
     });
   }
 }


### PR DESCRIPTION
Migrates `run_pipeline` onto async job-mode, mirroring the merged `run_dev_pipeline` migration (#3726/#3733). Child of epic #3729; closes #3730.

## What
- New `dispatch: z.enum(['sync','async']).default('sync')` field on `PipelineInputSchema`. `sync` (default) is byte-identical to prior behavior.
- `dispatch: 'async'` (non-dryRun) dispatches the multi-stage adaptive orchestrator through the shared `runAsJob` helper and returns `{ status: 'pending', jobId }` immediately; poll `get_job_result({ jobId })`.
- Sync prelude (input resolution + stage-registry wiring) stays fast; only the orchestrator body backgrounds (`executePipelineBody` extracted).
- `dryRun` always stays sync (plan+vote completes fast).
- `run_pipeline` has no sessionId, so a fresh `rp-<uuid>` jobId is always minted — no idempotency/collision surface (mirrors run_dev_pipeline's no-sessionId branch).
- Registered `run_pipeline: 2` in `DEFAULT_JOB_CAPS` and `rp → run_pipeline` in `TOOL_NAME_BY_PREFIX`.
- Sync error envelope now carries an async-mode discoverability hint.

## Tests (Red/Green TDD)
- pipeline-tool.test.ts: schema dispatch default/accept/reject; async returns pending + `rp-` jobId; sync default runs inline; background completion records to sidecar.
- job-concurrency.test.ts: `run_pipeline` cap is 2.
- task-state-source.test.ts: `rp-` prefix → `run_pipeline`.

## Gates
- `tsc --noEmit`, `eslint --no-cache` (changed files): clean.
- `vitest run src/mcp`: 3489 passed (179 files).
- governance:check, check-registry-coverage, generate-repo-index --check: pass.
- Changeset added (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)