### PR TITLE
feat(mcp): async job-mode for pr_review + supply_chain_tradeoff_panel (#3731)

### DIFF
--- a/.changeset/voter-panels-async-3731.md
+++ b/.changeset/voter-panels-async-3731.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+feat(mcp): add async job-mode dispatch to pr_review + supply_chain_tradeoff_panel (#3731)
+
+Both tools run 5-7 live LLM voters via `collectRealVotes` (same shape as the
+already-async `consensus_vote`), and previously could exceed even the interim
+900s per-tool cap. They now accept `dispatch: 'async'`, mirroring `consensus_vote`:
+the sync (default) path is byte-identical, while `dispatch: 'async'` routes the
+panel body through the shared `runAsJob` helper and returns
+`{ status: 'pending', jobId }` immediately (mint `pr-<uuid>` / `sc-<uuid>`,
+no sessionId/idempotency surface). Poll `get_job_result({ jobId })` for the
+result. Sync error/timeout envelopes now carry an async-retry hint. Adds both
+tools to `DEFAULT_JOB_CAPS` (cap 2 each) and the jobId-prefix → toolName map.

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
@@ -46,6 +46,16 @@ describe('getJobCap', () => {
     expect(getJobCap('run_pipeline')).toBe(2);
   });
 
+  it('caps pr_review at 2 concurrent runs (#3731)', () => {
+    expect(DEFAULT_JOB_CAPS['pr_review']).toBe(2);
+    expect(getJobCap('pr_review')).toBe(2);
+  });
+
+  it('caps supply_chain_tradeoff_panel at 2 concurrent runs (#3731)', () => {
+    expect(DEFAULT_JOB_CAPS['supply_chain_tradeoff_panel']).toBe(2);
+    expect(getJobCap('supply_chain_tradeoff_panel')).toBe(2);
+  });
+
   it('honors NEXUS_JOB_MAX_CONCURRENT_<TOOL> env override', () => {
     process.env['NEXUS_JOB_MAX_CONCURRENT_ORCHESTRATE'] = '7';
     expect(getJobCap('orchestrate')).toBe(7);

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
@@ -47,6 +47,12 @@ export const DEFAULT_JOB_CAPS: Readonly<Record<string, number>> = {
   // #3730: run_pipeline is a multi-stage adaptive orchestrator with per-stage
   // experts (live LLM calls). Same shape as run_dev_pipeline — cap low at 2.
   run_pipeline: 2,
+  // #3731: pr_review fans out to 5 live LLM voters in parallel. Same heavy
+  // multi-llm-panel shape as consensus_vote — cap low at 2.
+  pr_review: 2,
+  // #3731: supply_chain_tradeoff_panel fans out to up to 7 live LLM voters in
+  // parallel. Same heavy multi-llm-panel shape as consensus_vote — cap low at 2.
+  supply_chain_tradeoff_panel: 2,
 };
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
@@ -47,6 +47,8 @@ describe('toolNameFromJobId', () => {
     expect(toolNameFromJobId('cv-1-a')).toBe('consensus_vote');
     expect(toolNameFromJobId('dp-abc123')).toBe('run_dev_pipeline');
     expect(toolNameFromJobId('rp-abc123')).toBe('run_pipeline');
+    expect(toolNameFromJobId('pr-abc123')).toBe('pr_review');
+    expect(toolNameFromJobId('sc-abc123')).toBe('supply_chain_tradeoff_panel');
   });
   it('returns "unknown" for unrecognized or prefix-less ids', () => {
     expect(toolNameFromJobId('weird-1-a')).toBe('unknown');

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
@@ -44,6 +44,10 @@ const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
   dp: 'run_dev_pipeline',
   // #3730: run_pipeline async jobs mint `rp-<uuid>` ids (no sessionId surface).
   rp: 'run_pipeline',
+  // #3731: pr_review async jobs mint `pr-<uuid>` ids (no sessionId surface).
+  pr: 'pr_review',
+  // #3731: supply_chain_tradeoff_panel async jobs mint `sc-<uuid>` ids.
+  sc: 'supply_chain_tradeoff_panel',
 };
 
 /** Derive the toolName from a jobId/taskId prefix. */

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -8,15 +8,36 @@
  * @module mcp/tools/pr-review-tool.test
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// #3731: pass-through the secure-handler / timeout chain so the registered
+// callback is the bare `(args, ctx)` handler — lets the async-dispatch tests
+// invoke it directly.
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler: (fn: unknown) => fn,
+}));
+
 import {
   PR_REVIEW_ROLES,
   PrReviewInputSchema,
   aggregatePrDecisions,
   buildPrReviewProposal,
   mapVoteDecisionToPrDecision,
+  registerPrReviewTool,
   type PrReviewVote,
 } from './pr-review-tool.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
+import { createLogger } from '../../core/index.js';
 
 describe('pr_review tool', () => {
   describe('PR_REVIEW_ROLES', () => {
@@ -339,5 +360,101 @@ describe('pr_review tool', () => {
       const r = PrReviewInputSchema.safeParse({ prTitle: 'x', prDiff: 'y' });
       expect(r.success).toBe(true);
     });
+
+    it('defaults dispatch to sync and accepts async (#3731)', () => {
+      expect(PrReviewInputSchema.parse({ prTitle: 'x', prDiff: 'y' }).dispatch).toBe('sync');
+      expect(
+        PrReviewInputSchema.parse({ prTitle: 'x', prDiff: 'y', dispatch: 'async' }).dispatch
+      ).toBe('async');
+      expect(() =>
+        PrReviewInputSchema.parse({ prTitle: 'x', prDiff: 'y', dispatch: 'bogus' })
+      ).toThrow();
+    });
+  });
+});
+
+// #3731: async dispatch mode. The 5-voter live fan-out can exceed the MCP
+// request timeout, so `dispatch: 'async'` returns a jobId immediately and runs
+// the panel in the background (poll get_job_result). pr_review has no sessionId,
+// so a fresh `pr-<uuid>` jobId is always minted (no idempotency surface).
+interface HandlerCtx {
+  logger: ReturnType<typeof createLogger>;
+}
+type CtxHandler = (args: unknown, ctx: HandlerCtx) => Promise<CapturedToolResult>;
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+const TEST_CTX: HandlerCtx = { logger: createLogger({ tool: 'pr_review.test' }) };
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): CtxHandler {
+  let captured: CtxHandler | undefined;
+  let registeredName: string | undefined;
+  const mockServer = {
+    registerTool: (name: string, _schema: unknown, handler: unknown) => {
+      registeredName = name;
+      captured = handler as CtxHandler;
+    },
+  };
+  registerPrReviewTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  expect(registeredName).toBe('pr_review');
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
+
+describe('pr_review async dispatch (#3731)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  // simulate:true keeps the panel body fast + deterministic (no live adapters).
+  const ASYNC_ARGS = { prTitle: 'x', prDiff: 'y', simulate: true, dispatch: 'async' } as const;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-pr-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints a pr-<uuid> id", async () => {
+    const handler = captureHandler();
+    const env = envelope(await handler(ASYNC_ARGS, TEST_CTX));
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^pr-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs the panel inline (sync) by default — no pending envelope', async () => {
+    const handler = captureHandler();
+    const env = envelope(await handler({ prTitle: 'x', prDiff: 'y', simulate: true }, TEST_CTX));
+    expect(env['status']).toBeUndefined();
+    expect(env['summary']).toBeDefined();
+  });
+
+  it('records the panel result so get_job_result resolves when the background run completes', async () => {
+    const handler = captureHandler();
+    const jobId = envelope(await handler(ASYNC_ARGS, TEST_CTX))['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -16,8 +16,9 @@
  */
 
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError, getErrorMessage } from '../../core/index.js';
+import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -29,6 +30,8 @@ import {
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+// #3731 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
 import {
   FINDINGS_FORMAT_INSTRUCTIONS,
   isFindingVerified,
@@ -61,6 +64,16 @@ export const MAX_DIFF_LENGTH = 50_000;
 /** Hard cap on PR description. */
 export const MAX_DESCRIPTION_LENGTH = 10_000;
 
+/**
+ * Discoverability hint (#3731) appended to sync pr_review error/timeout
+ * envelopes. The 5-voter panel runs live LLM calls in parallel and can exceed
+ * even the interim 900s per-tool cap; async mode is the durable escape hatch.
+ */
+const PR_REVIEW_ASYNC_HINT =
+  'A pr_review run fans out to 5 live LLM voters and can exceed the synchronous ' +
+  "MCP request timeout. Retry with `dispatch: 'async'` to get a jobId immediately, " +
+  'then poll get_job_result({ jobId }) for the result.';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -88,6 +101,19 @@ export const PrReviewInputSchema = z.object({
     .boolean()
     .default(false)
     .describe('Use simulated voters (testing only; never ship live with this true)'),
+  /**
+   * Dispatch mode (#3731). `sync` (default) runs the 5-voter panel inline and
+   * returns the result — but a live fan-out can exceed the MCP request timeout.
+   * `async` returns a `{ status: 'pending', jobId }` envelope immediately and
+   * runs the panel in the background; poll `get_job_result({ jobId })` for the
+   * result.
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3731). 'sync' (default): run inline. 'async': return a jobId immediately + run the panel in background (poll get_job_result)."
+    ),
 });
 
 export type PrReviewInput = z.infer<typeof PrReviewInputSchema>;
@@ -212,7 +238,12 @@ export function aggregatePrDecisions(reviews: readonly PrReviewVote[]): PrReview
  * yes/no proposals — by framing the diff as "should this PR be merged?" we
  * get usable output without needing new system prompts (Child 3 will add
  * those). */
-export function buildPrReviewProposal(input: PrReviewInput): string {
+export function buildPrReviewProposal(
+  input: Pick<
+    PrReviewInput,
+    'prTitle' | 'prDescription' | 'prDiff' | 'repoContext' | 'baseRef' | 'headRef'
+  >
+): string {
   const parts: string[] = [];
   parts.push(`# Pull Request Review\n`);
   parts.push(`**Title:** ${input.prTitle}\n`);
@@ -298,6 +329,36 @@ function summarizeReviews(reviews: readonly PrReviewVote[]): {
 // Handler
 // ============================================================================
 
+/**
+ * Run the 5-voter panel + shape the response. The sync handler awaits this
+ * inline; the async dispatcher backgrounds it via {@link runAsJob} (#3731).
+ * `collectRealVotes` is the long pole (live LLM fan-out), so the whole body
+ * is what backgrounds.
+ */
+async function executePrReviewBody(input: PrReviewInput, logger: ILogger): Promise<ToolResult> {
+  const start = Date.now();
+  const proposal = buildPrReviewProposal(input);
+  const voteResults = await collectRealVotes({
+    roles: PR_REVIEW_ROLES,
+    proposal,
+    simulate: input.simulate,
+    logger,
+  });
+
+  const reviews = voteResults.map(toPrReviewVote);
+  const counts = summarizeReviews(reviews);
+  const aggregate = aggregatePrDecisions(reviews);
+
+  const response: PrReviewResponse = {
+    summary: aggregate.decision,
+    verified: aggregate.verified,
+    ...counts,
+    reviews,
+    totalDurationMs: Date.now() - start,
+  };
+  return toolSuccess(JSON.stringify(response, null, 2));
+}
+
 async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
   const parsed = PrReviewInputSchema.safeParse(args);
   if (!parsed.success) {
@@ -307,33 +368,28 @@ async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<Tool
     });
   }
   const input = parsed.data;
-  const start = Date.now();
 
   try {
-    const proposal = buildPrReviewProposal(input);
-    const voteResults = await collectRealVotes({
-      roles: PR_REVIEW_ROLES,
-      proposal,
-      simulate: input.simulate,
-      logger: ctx.logger,
-    });
-
-    const reviews = voteResults.map(toPrReviewVote);
-    const counts = summarizeReviews(reviews);
-    const aggregate = aggregatePrDecisions(reviews);
-
-    const response: PrReviewResponse = {
-      summary: aggregate.decision,
-      verified: aggregate.verified,
-      ...counts,
-      reviews,
-      totalDurationMs: Date.now() - start,
-    };
-    return toolSuccess(JSON.stringify(response, null, 2));
+    // #3731: async dispatch — the 5-voter live fan-out can exceed the MCP
+    // request timeout. pr_review has no sessionId, so a fresh `pr-<uuid>` jobId
+    // is always minted (no idempotency surface). Returns a pending envelope.
+    if (input.dispatch === 'async') {
+      return runAsJob<PrReviewInput, ToolResult>({
+        toolName: 'pr_review',
+        input,
+        freshJobId: () => `pr-${randomUUID()}`,
+        run: () => executePrReviewBody(input, ctx.logger),
+        logger: ctx.logger,
+      });
+    }
+    return await executePrReviewBody(input, ctx.logger);
   } catch (error) {
+    // #3731 discoverability: a sync run that times out (or otherwise fails)
+    // should point the caller at async mode — the durable fix for runs that
+    // exceed the request timeout.
     return toolStructuredError({
       errorCategory: 'internal',
-      message: `PR review failed: ${getErrorMessage(error)}`,
+      message: `${PR_REVIEW_ASYNC_HINT} PR review failed: ${getErrorMessage(error)}`,
     });
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.test.ts
@@ -6,7 +6,23 @@
  * via the existing consensus-vote integration suite.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// #3731: pass-through the secure-handler / timeout chain so the registered
+// callback is the bare `(args, ctx)` handler — lets the async-dispatch tests
+// invoke it directly.
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler: (fn: unknown) => fn,
+}));
+
 import {
   DEFAULT_AXES,
   FULL_PANEL,
@@ -17,10 +33,15 @@ import {
   aggregateAxis,
   aggregatePanel,
   buildRecommendation,
+  registerSupplyChainTradeoffPanelTool,
   type AxisVerdict,
   type PanelVote,
 } from './supply-chain-tradeoff-panel.js';
 import { VOTER_ROLES, type VoterRole } from '../../cli/vote-types.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
+import { createLogger } from '../../core/index.js';
 
 describe('supply_chain_tradeoff_panel', () => {
   describe('DEFAULT_AXES', () => {
@@ -70,15 +91,21 @@ describe('supply_chain_tradeoff_panel', () => {
         SupplyChainTradeoffPanelInputSchema.parse({ proposal: 'p', axes: [''] })
       ).toThrow();
     });
+
+    it('defaults dispatch to sync and accepts async (#3731)', () => {
+      expect(SupplyChainTradeoffPanelInputSchema.parse({ proposal: 'p' }).dispatch).toBe('sync');
+      expect(
+        SupplyChainTradeoffPanelInputSchema.parse({ proposal: 'p', dispatch: 'async' }).dispatch
+      ).toBe('async');
+      expect(() =>
+        SupplyChainTradeoffPanelInputSchema.parse({ proposal: 'p', dispatch: 'bogus' })
+      ).toThrow();
+    });
   });
 
   describe('buildTradeoffProposal', () => {
     it('includes the proposal text and default axes', () => {
-      const out = buildTradeoffProposal({
-        proposal: 'Adopt cargo-nextest?',
-        quickMode: false,
-        simulate: false,
-      });
+      const out = buildTradeoffProposal({ proposal: 'Adopt cargo-nextest?' });
       expect(out).toContain('Adopt cargo-nextest?');
       for (const axis of DEFAULT_AXES) expect(out).toContain(axis);
     });
@@ -87,8 +114,6 @@ describe('supply_chain_tradeoff_panel', () => {
       const out = buildTradeoffProposal({
         proposal: 'p',
         context: 'Repo currently uses cargo test; CI runs are 8 minutes.',
-        quickMode: false,
-        simulate: false,
       });
       expect(out).toContain('Repo currently uses cargo test');
     });
@@ -97,8 +122,6 @@ describe('supply_chain_tradeoff_panel', () => {
       const out = buildTradeoffProposal({
         proposal: 'p',
         axes: ['license_compatibility', 'maintainer_burden'],
-        quickMode: false,
-        simulate: false,
       });
       expect(out).toContain('license_compatibility');
       expect(out).toContain('maintainer_burden');
@@ -106,7 +129,7 @@ describe('supply_chain_tradeoff_panel', () => {
     });
 
     it('includes JSON output instructions', () => {
-      const out = buildTradeoffProposal({ proposal: 'p', quickMode: false, simulate: false });
+      const out = buildTradeoffProposal({ proposal: 'p' });
       expect(out).toContain('```json');
       expect(out).toContain('"axes"');
     });
@@ -333,5 +356,101 @@ describe('supply_chain_tradeoff_panel', () => {
       expect(out).toContain('b');
       expect(out.toLowerCase()).toContain('mixed');
     });
+  });
+});
+
+// #3731: async dispatch mode. The up-to-7-voter live fan-out can exceed the MCP
+// request timeout, so `dispatch: 'async'` returns a jobId immediately and runs
+// the panel in the background (poll get_job_result). This tool has no sessionId,
+// so a fresh `sc-<uuid>` jobId is always minted (no idempotency surface).
+interface HandlerCtx {
+  logger: ReturnType<typeof createLogger>;
+}
+type CtxHandler = (args: unknown, ctx: HandlerCtx) => Promise<CapturedToolResult>;
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+const TEST_CTX: HandlerCtx = { logger: createLogger({ tool: 'supply_chain_tradeoff_panel.test' }) };
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): CtxHandler {
+  let captured: CtxHandler | undefined;
+  let registeredName: string | undefined;
+  const mockServer = {
+    registerTool: (name: string, _schema: unknown, handler: unknown) => {
+      registeredName = name;
+      captured = handler as CtxHandler;
+    },
+  };
+  registerSupplyChainTradeoffPanelTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  expect(registeredName).toBe('supply_chain_tradeoff_panel');
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
+
+describe('supply_chain_tradeoff_panel async dispatch (#3731)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  // simulate:true + quickMode keeps the panel body fast + deterministic.
+  const ASYNC_ARGS = {
+    proposal: 'Should we adopt dep X?',
+    simulate: true,
+    quickMode: true,
+    dispatch: 'async',
+  } as const;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-sc-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints an sc-<uuid> id", async () => {
+    const handler = captureHandler();
+    const env = envelope(await handler(ASYNC_ARGS, TEST_CTX));
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^sc-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs the panel inline (sync) by default — no pending envelope', async () => {
+    const handler = captureHandler();
+    const env = envelope(
+      await handler(
+        { proposal: 'Should we adopt dep X?', simulate: true, quickMode: true },
+        TEST_CTX
+      )
+    );
+    expect(env['status']).toBeUndefined();
+    expect(env['decision']).toBeDefined();
+  });
+
+  it('records the panel result so get_job_result resolves when the background run completes', async () => {
+    const handler = captureHandler();
+    const jobId = envelope(await handler(ASYNC_ARGS, TEST_CTX))['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.ts
+++ b/packages/nexus-agents/src/mcp/tools/supply-chain-tradeoff-panel.ts
@@ -17,8 +17,9 @@
  */
 
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError, getErrorMessage } from '../../core/index.js';
+import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -30,6 +31,8 @@ import {
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+// #3731 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
 
 // ============================================================================
 // Constants
@@ -50,6 +53,17 @@ export const MAX_AXIS_NAME_LENGTH = 64;
 export const MAX_PROPOSAL_LENGTH = 4000;
 /** Hard cap on optional context text. */
 export const MAX_CONTEXT_LENGTH = 4000;
+
+/**
+ * Discoverability hint (#3731) appended to sync supply_chain_tradeoff_panel
+ * error/timeout envelopes. The 7-voter panel runs live LLM calls in parallel
+ * and can exceed even the interim 900s per-tool cap; async mode is the durable
+ * escape hatch.
+ */
+const TRADEOFF_PANEL_ASYNC_HINT =
+  'A supply_chain_tradeoff_panel run fans out to up to 7 live LLM voters and can ' +
+  "exceed the synchronous MCP request timeout. Retry with `dispatch: 'async'` to " +
+  'get a jobId immediately, then poll get_job_result({ jobId }) for the result.';
 
 /** 7-role default panel (matches consensus_vote's default). */
 export const FULL_PANEL: readonly VoterRole[] = [
@@ -96,6 +110,19 @@ export const SupplyChainTradeoffPanelInputSchema = z.object({
     .default(false)
     .describe('Use 3 voters (architect, security, scope_steward) instead of 7'),
   simulate: z.boolean().optional().default(false).describe('Use simulated voters (testing only)'),
+  /**
+   * Dispatch mode (#3731). `sync` (default) runs the panel inline and returns
+   * the result — but a live fan-out (up to 7 voters) can exceed the MCP request
+   * timeout. `async` returns a `{ status: 'pending', jobId }` envelope
+   * immediately and runs the panel in the background; poll
+   * `get_job_result({ jobId })` for the result.
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3731). 'sync' (default): run inline. 'async': return a jobId immediately + run the panel in background (poll get_job_result)."
+    ),
 });
 
 export type SupplyChainTradeoffPanelInput = z.infer<typeof SupplyChainTradeoffPanelInputSchema>;
@@ -149,7 +176,9 @@ export type SupplyChainTradeoffPanelDeps = BaseMcpToolDeps;
  * emit a JSON block with per-axis verdicts so the aggregator can reason
  * per-axis instead of mashing everything into a single approve/reject.
  */
-export function buildTradeoffProposal(input: SupplyChainTradeoffPanelInput): string {
+export function buildTradeoffProposal(
+  input: Pick<SupplyChainTradeoffPanelInput, 'proposal' | 'axes' | 'context'>
+): string {
   const axes = input.axes ?? DEFAULT_AXES;
   const parts: string[] = [];
   parts.push(`# Supply-Chain Tradeoff Review\n\n`);
@@ -358,6 +387,47 @@ function toPanelVote(result: AgentVoteResult, axes: readonly string[]): PanelVot
 // Handler
 // ============================================================================
 
+/**
+ * Run the voter panel + shape the response. The sync handler awaits this
+ * inline; the async dispatcher backgrounds it via {@link runAsJob} (#3731).
+ * `collectRealVotes` is the long pole (live LLM fan-out), so the whole body
+ * is what backgrounds.
+ */
+async function executeTradeoffPanelBody(
+  input: SupplyChainTradeoffPanelInput,
+  logger: ILogger
+): Promise<ToolResult> {
+  const axes = input.axes ?? DEFAULT_AXES;
+  const roles = input.quickMode ? QUICK_PANEL : FULL_PANEL;
+  const start = Date.now();
+
+  const proposal = buildTradeoffProposal(input);
+  const voteResults = await collectRealVotes({
+    roles,
+    proposal,
+    simulate: input.simulate,
+    logger,
+  });
+
+  const votes = voteResults.map((r) => toPanelVote(r, axes));
+  const axisVerdicts = axes.map((a) => aggregateAxis(a, votes));
+  const decision = aggregatePanel(axisVerdicts);
+  const recommendation = buildRecommendation(decision, axisVerdicts);
+  const voterErrors = votes.filter((v) => v.source === 'error').length;
+
+  const response: SupplyChainTradeoffPanelResponse = {
+    proposal: input.proposal,
+    axes,
+    decision,
+    axisVerdicts,
+    recommendation,
+    votes,
+    voterErrors,
+    durationMs: Date.now() - start,
+  };
+  return toolSuccess(JSON.stringify(response, null, 2));
+}
+
 async function tradeoffPanelHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
   const parsed = SupplyChainTradeoffPanelInputSchema.safeParse(args);
   if (!parsed.success) {
@@ -367,40 +437,28 @@ async function tradeoffPanelHandler(args: unknown, ctx: HandlerContext): Promise
     });
   }
   const input = parsed.data;
-  const axes = input.axes ?? DEFAULT_AXES;
-  const roles = input.quickMode ? QUICK_PANEL : FULL_PANEL;
-  const start = Date.now();
 
   try {
-    const proposal = buildTradeoffProposal(input);
-    const voteResults = await collectRealVotes({
-      roles,
-      proposal,
-      simulate: input.simulate,
-      logger: ctx.logger,
-    });
-
-    const votes = voteResults.map((r) => toPanelVote(r, axes));
-    const axisVerdicts = axes.map((a) => aggregateAxis(a, votes));
-    const decision = aggregatePanel(axisVerdicts);
-    const recommendation = buildRecommendation(decision, axisVerdicts);
-    const voterErrors = votes.filter((v) => v.source === 'error').length;
-
-    const response: SupplyChainTradeoffPanelResponse = {
-      proposal: input.proposal,
-      axes,
-      decision,
-      axisVerdicts,
-      recommendation,
-      votes,
-      voterErrors,
-      durationMs: Date.now() - start,
-    };
-    return toolSuccess(JSON.stringify(response, null, 2));
+    // #3731: async dispatch — the up-to-7-voter live fan-out can exceed the MCP
+    // request timeout. This tool has no sessionId, so a fresh `sc-<uuid>` jobId
+    // is always minted (no idempotency surface). Returns a pending envelope.
+    if (input.dispatch === 'async') {
+      return runAsJob<SupplyChainTradeoffPanelInput, ToolResult>({
+        toolName: 'supply_chain_tradeoff_panel',
+        input,
+        freshJobId: () => `sc-${randomUUID()}`,
+        run: () => executeTradeoffPanelBody(input, ctx.logger),
+        logger: ctx.logger,
+      });
+    }
+    return await executeTradeoffPanelBody(input, ctx.logger);
   } catch (error) {
+    // #3731 discoverability: a sync run that times out (or otherwise fails)
+    // should point the caller at async mode — the durable fix for runs that
+    // exceed the request timeout.
     return toolStructuredError({
       errorCategory: 'internal',
-      message: `Tradeoff panel failed: ${getErrorMessage(error)}`,
+      message: `${TRADEOFF_PANEL_ASYNC_HINT} Tradeoff panel failed: ${getErrorMessage(error)}`,
     });
   }
 }


### PR DESCRIPTION
Closes #3731 (child of epic #3729 / async-job-mode rollout #2631).

## What

`pr_review` and `supply_chain_tradeoff_panel` both fan out to 5-7 live LLM
voters via `collectRealVotes` — the same voter-panel shape as the
already-async `consensus_vote`. They previously had no async escape hatch and
could exceed even the interim 900s per-tool cap (#3733/#3734).

Both now accept `dispatch: 'async'`, mirroring `consensus_vote`:

- **Sync (default) path is byte-identical** — no behavior change for existing callers.
- `dispatch: 'async'` extracts the panel body into a dedicated function and routes
  it through the shared `runAsJob` helper, returning `{ status: 'pending', jobId }`
  immediately and running the panel in the background. Poll
  `get_job_result({ jobId })` for the result.
- jobId minted fresh per call (`pr-<uuid>` / `sc-<uuid>`) — neither tool has a
  sessionId, so there is no idempotency/collision surface (same as `run_pipeline`'s branch).
- Sync error/timeout envelopes now carry an async-retry hint pointing at `dispatch: 'async'`.

Wiring:
- `DEFAULT_JOB_CAPS` (`job-concurrency.ts`): `pr_review` and
  `supply_chain_tradeoff_panel` capped at 2 each (heavy multi-llm-panel shape).
- `TOOL_NAME_BY_PREFIX` (`task-state-source.ts`): `pr` → `pr_review`,
  `sc` → `supply_chain_tradeoff_panel` (non-colliding with `orch`/`rwf`/`cv`/`dp`/`rp`).

## Tests (TDD, red→green)

- `pr-review-tool.test.ts` / `supply-chain-tradeoff-panel.test.ts`: schema defaults
  `dispatch` to `sync` + accepts `async` + rejects bogus; async returns
  `{ status: 'pending', jobId }` with the right prefix; sync default unchanged;
  background run records a `complete` result resolvable via `get_job_result`.
- `job-concurrency.test.ts`: both new caps == 2.
- `task-state-source.test.ts`: both new prefix → toolName mappings.

Targeted suites: 114 passed. Full `src/mcp` suite: **179 files / 3499 tests passed**.

## Gates

`tsc --noEmit` clean, `eslint --no-cache` clean on all touched files, zero `any`.
`governance:check` ✓, `check-registry-coverage` ✓, `generate-repo-index --check` ✓.
Changeset added (`.changeset/voter-panels-async-3731.md`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)