### PR TITLE
feat(mcp): migrate remaining heavy pipelines to async job-mode (#3732)

### DIFF
--- a/.changeset/remaining-pipelines-async-3732.md
+++ b/.changeset/remaining-pipelines-async-3732.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+Migrate the remaining heavy pipeline tools to async job-mode (#3732, final child
+of epic #3729). `execute_spec`, `run_graph_workflow`, and `run` (the
+`execute: true` path) now accept `dispatch: 'async'`, which returns a
+`{ status: 'pending', jobId }` envelope immediately and runs the (long) body in
+the background via the shared `runAsJob` helper — poll `get_job_result({ jobId })`
+for the result. Sync (default) behavior is byte-identical. Fresh job ids are
+minted per tool (`es-`/`gw-`/`rn-`); each is registered in `DEFAULT_JOB_CAPS`
+(cap 2) and `TOOL_NAME_BY_PREFIX`. For `execute_spec` and `run_graph_workflow`
+`dryRun`/`list` short-circuits stay sync; `run` async applies only to
+`execute: true` (read-only routing is unaffected).

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.test.ts
@@ -56,6 +56,21 @@ describe('getJobCap', () => {
     expect(getJobCap('supply_chain_tradeoff_panel')).toBe(2);
   });
 
+  it('caps execute_spec at 2 concurrent runs (#3732)', () => {
+    expect(DEFAULT_JOB_CAPS['execute_spec']).toBe(2);
+    expect(getJobCap('execute_spec')).toBe(2);
+  });
+
+  it('caps run_graph_workflow at 2 concurrent runs (#3732)', () => {
+    expect(DEFAULT_JOB_CAPS['run_graph_workflow']).toBe(2);
+    expect(getJobCap('run_graph_workflow')).toBe(2);
+  });
+
+  it('caps run at 2 concurrent runs (#3732)', () => {
+    expect(DEFAULT_JOB_CAPS['run']).toBe(2);
+    expect(getJobCap('run')).toBe(2);
+  });
+
   it('honors NEXUS_JOB_MAX_CONCURRENT_<TOOL> env override', () => {
     process.env['NEXUS_JOB_MAX_CONCURRENT_ORCHESTRATE'] = '7';
     expect(getJobCap('orchestrate')).toBe(7);

--- a/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-concurrency.ts
@@ -53,6 +53,15 @@ export const DEFAULT_JOB_CAPS: Readonly<Record<string, number>> = {
   // #3731: supply_chain_tradeoff_panel fans out to up to 7 live LLM voters in
   // parallel. Same heavy multi-llm-panel shape as consensus_vote — cap low at 2.
   supply_chain_tradeoff_panel: 2,
+  // #3732: execute_spec runs a full spec DAG pipeline (parse→decompose→compile
+  // →execute→validate→analyze, live multi-agent execution). Heavy — cap low at 2.
+  execute_spec: 2,
+  // #3732: run_graph_workflow runs up to ~100 expert nodes with checkpoints.
+  // Heavy multi-node pipeline — cap low at 2.
+  run_graph_workflow: 2,
+  // #3732: run (execute:true) dispatches the heaviest engines (dev-pipeline/
+  // pipeline) via the MetaDispatcher. Same heavy-pipeline shape — cap low at 2.
+  run: 2,
 };
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
@@ -49,6 +49,9 @@ describe('toolNameFromJobId', () => {
     expect(toolNameFromJobId('rp-abc123')).toBe('run_pipeline');
     expect(toolNameFromJobId('pr-abc123')).toBe('pr_review');
     expect(toolNameFromJobId('sc-abc123')).toBe('supply_chain_tradeoff_panel');
+    expect(toolNameFromJobId('es-abc123')).toBe('execute_spec');
+    expect(toolNameFromJobId('gw-abc123')).toBe('run_graph_workflow');
+    expect(toolNameFromJobId('rn-abc123')).toBe('run');
   });
   it('returns "unknown" for unrecognized or prefix-less ids', () => {
     expect(toolNameFromJobId('weird-1-a')).toBe('unknown');

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
@@ -48,6 +48,12 @@ const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
   pr: 'pr_review',
   // #3731: supply_chain_tradeoff_panel async jobs mint `sc-<uuid>` ids.
   sc: 'supply_chain_tradeoff_panel',
+  // #3732: execute_spec async jobs mint `es-<uuid>` ids (no sessionId surface).
+  es: 'execute_spec',
+  // #3732: run_graph_workflow async jobs mint `gw-<uuid>` ids.
+  gw: 'run_graph_workflow',
+  // #3732: run (execute:true) async jobs mint `rn-<uuid>` ids.
+  rn: 'run',
 };
 
 /** Derive the toolName from a jobId/taskId prefix. */

--- a/packages/nexus-agents/src/mcp/tools/execute-spec-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-spec-tool.test.ts
@@ -4,8 +4,42 @@
  * (Source: Issue #853 — Phase 5 of AI Software Factory Epic #843)
  */
 
-import { describe, it, expect } from 'vitest';
-import { ExecuteSpecInputSchema } from './execute-spec-tool.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Pass-through the secure-handler / timeout chain so the registered callback is
+// the bare handler — lets the tests invoke it directly (mirrors run_pipeline).
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler: (fn: unknown) => fn,
+}));
+
+// #3732: stub the spec executor so the async background run resolves fast and
+// deterministically (no live adapters in unit tests).
+const EXECUTE_SPEC_RESULT = {
+  ok: true as const,
+  value: {
+    validation: { satisfaction: 1 },
+  },
+};
+const executeSpecMock = vi.fn(() => Promise.resolve(EXECUTE_SPEC_RESULT));
+vi.mock('../../orchestration/spec-executor.js', () => ({
+  executeSpec: () => executeSpecMock(),
+}));
+vi.mock('../../orchestration/failure-analyzer.js', () => ({
+  analyzeFailures: () => ({ ok: true, value: { passed: true } }),
+}));
+
+import { ExecuteSpecInputSchema, registerExecuteSpecTool } from './execute-spec-tool.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 
 // ============================================================================
 // Schema Validation
@@ -53,5 +87,95 @@ describe('ExecuteSpecInputSchema', () => {
       spec: 'x'.repeat(50_001),
     });
     expect(result.success).toBe(false);
+  });
+
+  it('defaults dispatch to sync and accepts async (#3732)', () => {
+    expect(ExecuteSpecInputSchema.parse({ spec: '# Feature' }).dispatch).toBe('sync');
+    expect(ExecuteSpecInputSchema.parse({ spec: '# Feature', dispatch: 'async' }).dispatch).toBe(
+      'async'
+    );
+    expect(() => ExecuteSpecInputSchema.parse({ spec: '# Feature', dispatch: 'bogus' })).toThrow();
+  });
+});
+
+// ============================================================================
+// Async dispatch (#3732)
+// ============================================================================
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
+  let captured: ((args: unknown) => Promise<CapturedToolResult>) | undefined;
+  let registeredName: string | undefined;
+  const mockServer = {
+    registerTool: (name: string, _schema: unknown, handler: unknown) => {
+      registeredName = name;
+      captured = handler as (args: unknown) => Promise<CapturedToolResult>;
+    },
+  };
+  registerExecuteSpecTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  expect(registeredName).toBe('execute_spec');
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
+
+// #3732: `dispatch: 'async'` returns a jobId immediately and runs the full spec
+// DAG pipeline in the background (poll get_job_result). execute_spec has no
+// sessionId, so a fresh `es-<uuid>` jobId is always minted.
+describe('execute_spec async dispatch (#3732)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-es-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    executeSpecMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints an es-<uuid> id", async () => {
+    const handler = captureHandler();
+    const result = await handler({ spec: '# Feature\n\n## Requirements\n- x', dispatch: 'async' });
+    const env = envelope(result);
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^es-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs the pipeline inline (sync) by default — no pending envelope', async () => {
+    const handler = captureHandler();
+    const result = await handler({ spec: '# Feature\n\n## Requirements\n- x' });
+    expect(envelope(result)['status']).toBeUndefined();
+    expect(executeSpecMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the result to the sidecar when the background run completes', async () => {
+    const handler = captureHandler();
+    const result = await handler({ spec: '# Feature\n\n## Requirements\n- x', dispatch: 'async' });
+    const jobId = envelope(result)['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/execute-spec-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-spec-tool.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
 import {
@@ -36,6 +37,8 @@ import {
   type ToolResult,
 } from './tool-result.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+// #3732 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
 
 // ============================================================================
 // Types & Schema
@@ -44,6 +47,20 @@ import { getToolAnnotations } from '../tool-annotations.js';
 export const ExecuteSpecInputSchema = z.object({
   spec: z.string().min(1).max(50_000).describe('Markdown specification to execute'),
   dryRun: z.boolean().optional().default(false).describe('Parse and decompose only'),
+  /**
+   * Dispatch mode (#3732). `sync` (default) runs the full DAG pipeline inline
+   * and returns the result — but a real parse→decompose→compile→execute→
+   * validate→analyze run can exceed the MCP request timeout. `async` returns a
+   * `{ status: 'pending', jobId }` envelope immediately and runs in the
+   * background; poll `get_job_result({ jobId })` for the result. Ignored when
+   * `dryRun` is true (parse+decompose completes fast, so dry runs stay sync).
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3732). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result). Ignored for dryRun."
+    ),
 });
 
 export type ExecuteSpecInput = z.infer<typeof ExecuteSpecInputSchema>;
@@ -114,11 +131,11 @@ async function createFullResponse(input: ExecuteSpecInput, logger: ILogger): Pro
 // Registration
 // ============================================================================
 
-/** Registers the execute_spec tool with an MCP server. @category MCP */
-export function registerExecuteSpecTool(server: McpServer, deps: ExecuteSpecDeps): void {
-  const logger = deps.logger ?? createLogger({ tool: 'execute_spec' });
-
-  const handler = async (args: unknown, _ctx: HandlerContext): Promise<ToolResult> => {
+/** Creates the execute_spec handler — parse, dryRun short-circuit, async dispatch. */
+function createExecuteSpecHandler(
+  logger: ILogger
+): (args: unknown, ctx: HandlerContext) => Promise<ToolResult> {
+  return async (args: unknown, _ctx: HandlerContext): Promise<ToolResult> => {
     const parsed = ExecuteSpecInputSchema.safeParse(args);
     if (!parsed.success) {
       return toolStructuredError({
@@ -127,12 +144,34 @@ export function registerExecuteSpecTool(server: McpServer, deps: ExecuteSpecDeps
       });
     }
 
-    if (parsed.data.dryRun) {
-      return createDryRunResponse(parsed.data, logger);
+    const input = parsed.data;
+    if (input.dryRun) {
+      return createDryRunResponse(input, logger);
     }
 
-    return createFullResponse(parsed.data, logger);
+    // #3732: async dispatch for real (non-dryRun) runs — a full spec DAG
+    // pipeline can exceed the MCP request timeout. execute_spec has no
+    // sessionId, so a fresh `es-<uuid>` jobId is always minted (no idempotency
+    // surface). Returns `{ status: 'pending', jobId }` immediately.
+    if (input.dispatch === 'async') {
+      return runAsJob<ExecuteSpecInput, ToolResult>({
+        toolName: 'execute_spec',
+        input,
+        freshJobId: () => `es-${randomUUID()}`,
+        run: () => createFullResponse(input, logger),
+        logger,
+      });
+    }
+
+    return createFullResponse(input, logger);
   };
+}
+
+/** Registers the execute_spec tool with an MCP server. @category MCP */
+export function registerExecuteSpecTool(server: McpServer, deps: ExecuteSpecDeps): void {
+  const logger = deps.logger ?? createLogger({ tool: 'execute_spec' });
+
+  const handler = createExecuteSpecHandler(logger);
 
   const secureHandler = createSecureHandler(handler, {
     toolName: 'execute_spec',
@@ -153,6 +192,12 @@ export function registerExecuteSpecTool(server: McpServer, deps: ExecuteSpecDeps
           'Must contain "## Requirements" and "## Acceptance Criteria" sections.'
       ),
     dryRun: z.boolean().optional().describe('Parse and decompose only (no execution)'),
+    dispatch: z
+      .enum(['sync', 'async'])
+      .optional()
+      .describe(
+        "Dispatch mode (#3732). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result). Ignored for dryRun."
+      ),
   };
 
   const description =

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.test.ts
@@ -4,13 +4,19 @@
  * (Source: Issue #840 — Expose graph workflows via MCP tool)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   RunGraphWorkflowInputSchema,
   registerRunGraphWorkflowTool,
   type RunGraphWorkflowResponse,
 } from './run-graph-workflow.js';
 import { RateLimiter } from '../middleware/index.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 
 // ============================================================================
 // Test Helpers
@@ -268,6 +274,81 @@ describe('pipeline workflow', () => {
     const result = parseResponse(response);
     const stepEvents = result.events.filter((e) => e.type === 'step_completed');
     expect(stepEvents.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ============================================================================
+// Async dispatch (#3732)
+// ============================================================================
+
+describe('RunGraphWorkflowInputSchema dispatch (#3732)', () => {
+  it('defaults dispatch to sync and accepts async', () => {
+    expect(RunGraphWorkflowInputSchema.parse({ workflow: 'echo' }).dispatch).toBe('sync');
+    expect(
+      RunGraphWorkflowInputSchema.parse({ workflow: 'echo', dispatch: 'async' }).dispatch
+    ).toBe('async');
+    expect(() => RunGraphWorkflowInputSchema.parse({ workflow: 'echo', dispatch: 'x' })).toThrow();
+  });
+});
+
+// #3732: `dispatch: 'async'` returns a jobId immediately and runs the graph
+// workflow (up to ~100 expert nodes) in the background (poll get_job_result).
+// run_graph_workflow has no sessionId, so a fresh `gw-<uuid>` jobId is minted.
+describe('run_graph_workflow async dispatch (#3732)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  function envelope(response: ToolResponse): Record<string, unknown> {
+    return JSON.parse(response.content[0]?.text ?? '{}') as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-gw-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints a gw-<uuid> id", async () => {
+    const handler = registerAndGetHandler();
+    const response = await handler({
+      workflow: 'echo',
+      inputs: { input: 'hi' },
+      dispatch: 'async',
+    });
+    const env = envelope(response);
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^gw-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs inline (sync) by default — no pending envelope', async () => {
+    const handler = registerAndGetHandler();
+    const response = await handler({ workflow: 'echo', inputs: { input: 'hi' } });
+    expect(envelope(response)['status']).toBe('completed');
+  });
+
+  it('records the result to the sidecar when the background run completes', async () => {
+    const handler = registerAndGetHandler();
+    const response = await handler({
+      workflow: 'echo',
+      inputs: { input: 'hi' },
+      dispatch: 'async',
+    });
+    const jobId = envelope(response)['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger } from '../../core/index.js';
 import {
@@ -40,6 +41,8 @@ import {
 } from '../../orchestration/outcomes/index.js';
 import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+// #3732 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
 
 // ============================================================================
 // Types & Schema
@@ -62,6 +65,20 @@ export const RunGraphWorkflowInputSchema = z.object({
     .optional()
     .default(false)
     .describe('Enable audit trail event logging'),
+  /**
+   * Dispatch mode (#3732). `sync` (default) runs the graph workflow inline and
+   * returns the result — but a workflow of up to ~100 expert nodes can exceed
+   * the MCP request timeout. `async` returns a `{ status: 'pending', jobId }`
+   * envelope immediately and runs in the background; poll
+   * `get_job_result({ jobId })` for the result. Ignored for the `list` sentinel.
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .optional()
+    .default('sync')
+    .describe(
+      "Dispatch mode (#3732). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result)."
+    ),
 });
 
 export type RunGraphWorkflowInput = z.infer<typeof RunGraphWorkflowInputSchema>;
@@ -211,7 +228,42 @@ const GRAPH_WORKFLOW_SCHEMA = {
   inputs: z.record(z.string(), z.unknown()).optional().describe('Input values for the workflow'),
   enableCheckpointing: z.boolean().optional().describe('Enable checkpoint saving'),
   enableAuditTrail: z.boolean().optional().describe('Enable audit trail logging'),
+  dispatch: z
+    .enum(['sync', 'async'])
+    .optional()
+    .describe(
+      "Dispatch mode (#3732). 'sync' (default): run inline. 'async': return a jobId immediately + run in background (poll get_job_result)."
+    ),
 };
+
+/**
+ * Run the graph workflow body + shape the structured envelope. The sync handler
+ * awaits this inline; the async dispatcher backgrounds it via {@link runAsJob}
+ * (#3732). Records the outcome + fires the completion notification as a side
+ * effect so both dispatch paths report identically.
+ */
+async function executeGraphWorkflowBody(
+  input: RunGraphWorkflowInput,
+  logger: ILogger,
+  notifier: IMcpNotifier
+): Promise<ToolResult> {
+  const result = await handleRunGraphWorkflow(input, logger);
+  const succeeded = result.status === 'completed';
+  notifier.info('run_graph_workflow', {
+    event: succeeded ? 'graph_workflow_complete' : 'graph_workflow_failed',
+    workflow: result.workflow,
+    nodeCount: result.nodesExecuted,
+    durationMs: result.durationMs,
+  });
+
+  // Record to memory and outcome store (Issue #1174)
+  recordGraphWorkflowResult(result);
+
+  const text = JSON.stringify(result, null, 2);
+  return succeeded
+    ? toolSuccess(text)
+    : toolStructuredError({ errorCategory: 'internal', message: text });
+}
 
 /** Creates the handler for run_graph_workflow tool. */
 function createGraphWorkflowHandler(
@@ -226,29 +278,30 @@ function createGraphWorkflowHandler(
         message: `Validation error: ${formatZodError(parsed.error)}`,
       });
     }
-    if (parsed.data.workflow === 'list') {
+    const input = parsed.data;
+    if (input.workflow === 'list') {
       return toolSuccess(JSON.stringify(getGraphWorkflowList(), null, 2));
     }
     notifier.info('run_graph_workflow', {
       event: 'graph_workflow_start',
-      workflow: parsed.data.workflow,
-    });
-    const result = await handleRunGraphWorkflow(parsed.data, logger);
-    const succeeded = result.status === 'completed';
-    notifier.info('run_graph_workflow', {
-      event: succeeded ? 'graph_workflow_complete' : 'graph_workflow_failed',
-      workflow: result.workflow,
-      nodeCount: result.nodesExecuted,
-      durationMs: result.durationMs,
+      workflow: input.workflow,
     });
 
-    // Record to memory and outcome store (Issue #1174)
-    recordGraphWorkflowResult(result);
+    // #3732: async dispatch — a workflow of up to ~100 expert nodes can exceed
+    // the MCP request timeout. run_graph_workflow has no sessionId, so a fresh
+    // `gw-<uuid>` jobId is always minted (no idempotency surface). Returns
+    // `{ status: 'pending', jobId }` immediately.
+    if (input.dispatch === 'async') {
+      return runAsJob<RunGraphWorkflowInput, ToolResult>({
+        toolName: 'run_graph_workflow',
+        input,
+        freshJobId: () => `gw-${randomUUID()}`,
+        run: () => executeGraphWorkflowBody(input, logger, notifier),
+        logger,
+      });
+    }
 
-    const text = JSON.stringify(result, null, 2);
-    return succeeded
-      ? toolSuccess(text)
-      : toolStructuredError({ errorCategory: 'internal', message: text });
+    return executeGraphWorkflowBody(input, logger, notifier);
   };
 }
 

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -24,15 +24,36 @@ vi.mock('./dev-pipeline-tool.js', () => ({
     runDevPipelineForGoalMock(goal, trustTier),
 }));
 
+// #3732: pass-through the secure-handler / timeout chain so the registered
+// callback is the bare handler — lets the async-dispatch tests invoke it
+// directly. createSecureHandler injects a minimal ctx (the run handler reads
+// ctx.requestContext.trustTier). Only the new handler-capture tests use this;
+// the existing routeGoal/executeGoal tests call those functions directly.
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler:
+    (fn: (args: unknown, ctx: { requestContext: { trustTier?: string } }) => unknown) =>
+    (args: unknown) =>
+      fn(args, { requestContext: {} }),
+}));
+
 import {
   routeGoal,
   executeGoal,
   buildDefaultExecutors,
   isShadowTrainEnabled,
+  registerRunTool,
   RunInputSchema,
   STRATEGY_ENTRYPOINT_TOOL,
   type RunResponse,
 } from './run-tool.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 import type { ExecutionStrategy } from '../../orchestration/meta-orchestrator.js';
 import {
   createRecordingOutcomeSink,
@@ -100,6 +121,12 @@ describe('RunInputSchema', () => {
 
   it('accepts the execute flag', () => {
     expect(RunInputSchema.safeParse({ goal: 'g', execute: true }).success).toBe(true);
+  });
+
+  it('accepts dispatch: async and rejects unknown values (#3732)', () => {
+    expect(RunInputSchema.safeParse({ goal: 'g', dispatch: 'async' }).success).toBe(true);
+    expect(RunInputSchema.safeParse({ goal: 'g', dispatch: 'sync' }).success).toBe(true);
+    expect(RunInputSchema.safeParse({ goal: 'g', dispatch: 'bogus' }).success).toBe(false);
   });
 });
 
@@ -254,5 +281,108 @@ describe('shadow-train gating (NEXUS_META_SHADOW_TRAIN, #3593)', () => {
       { executors }
     );
     expect(existsSync(getMetaOutcomesFile())).toBe(false);
+  });
+});
+
+// #3732: `run` with execute:true dispatches the heaviest engines (dev-pipeline/
+// pipeline), which can exceed the MCP request timeout even with the 1800s class
+// guard (#3734). `dispatch: 'async'` returns a jobId immediately and runs the
+// dispatch in the background (poll get_job_result). `run` has no sessionId, so a
+// fresh `rn-<uuid>` jobId is always minted.
+describe('run async dispatch (execute:true, #3732)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  interface CapturedToolResult {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  }
+
+  /** Registers the tool against a mock server and returns the captured callback. */
+  function captureHandler(): (args: unknown) => Promise<CapturedToolResult> {
+    let captured: ((args: unknown) => Promise<CapturedToolResult>) | undefined;
+    let registeredName: string | undefined;
+    const mockServer = {
+      registerTool: (name: string, _schema: unknown, handler: unknown) => {
+        registeredName = name;
+        captured = handler as (args: unknown) => Promise<CapturedToolResult>;
+      },
+    };
+    registerRunTool(mockServer as never, {
+      rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+    });
+    expect(registeredName).toBe('run');
+    if (captured === undefined) throw new Error('handler not registered');
+    return captured;
+  }
+
+  function envelope(result: CapturedToolResult): Record<string, unknown> {
+    return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-rn-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    runDevPipelineForGoalMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns { status: 'pending', jobId } and mints an rn-<uuid> id", async () => {
+    const handler = captureHandler();
+    const result = await handler({
+      goal: 'implement the feature',
+      forceStrategy: 'dev-pipeline',
+      execute: true,
+      dispatch: 'async',
+    });
+    const env = envelope(result);
+    expect(env['status']).toBe('pending');
+    expect(typeof env['jobId']).toBe('string');
+    expect(env['jobId'] as string).toMatch(/^rn-/);
+    expect(env['pollTool']).toBe('get_job_result');
+  });
+
+  it('runs inline (sync) by default — returns the executed result, no pending envelope', async () => {
+    const handler = captureHandler();
+    const result = await handler({
+      goal: 'implement the feature',
+      forceStrategy: 'dev-pipeline',
+      execute: true,
+    });
+    const env = envelope(result);
+    expect(env['status']).toBeUndefined();
+    expect(env['executed']).toBe(true);
+  });
+
+  it('read-only routing (execute:false) ignores dispatch and stays sync', async () => {
+    const handler = captureHandler();
+    const result = await handler({ goal: 'implement the feature', dispatch: 'async' });
+    const env = envelope(result);
+    expect(env['status']).toBeUndefined();
+    expect(env['recommendedTool']).toBeTruthy();
+  });
+
+  it('records the result to the sidecar when the background dispatch completes', async () => {
+    const handler = captureHandler();
+    const result = await handler({
+      goal: 'implement the feature',
+      forceStrategy: 'dev-pipeline',
+      execute: true,
+      dispatch: 'async',
+    });
+    const jobId = envelope(result)['jobId'] as string;
+    // The background run is fire-and-forget; let the microtask queue drain.
+    await new Promise((r) => setImmediate(r));
+    const record = readJobResult(jobId);
+    expect(record?.status).toBe('complete');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -21,6 +21,7 @@
  */
 
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { createLogger, formatZodError, type ILogger } from '../../core/index.js';
@@ -55,6 +56,8 @@ import {
 import { runDevPipelineForGoal } from './dev-pipeline-tool.js';
 import { runPipelineForGoal } from './pipeline-tool.js';
 import { runConsensusForGoal } from './consensus-vote.js';
+// #3732 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
+import { runAsJob } from '../jobs/run-as-job.js';
 
 /**
  * The concrete MCP tool / engine each strategy routes to. Used to tell the
@@ -108,6 +111,20 @@ export const RunInputSchema = z.object({
     .describe(
       'When true, actually run the selected strategy (if an executor is wired) and return ' +
         'its result; otherwise return the routing decision only (default false, read-only).'
+    ),
+  /**
+   * Dispatch mode (#3732). Only meaningful with `execute: true` — `run`
+   * dispatches the heaviest engines (dev-pipeline/pipeline), which can exceed
+   * the MCP request timeout even with the 1800s class guard (#3734). `sync`
+   * (default) runs inline; `async` returns a `{ status: 'pending', jobId }`
+   * envelope immediately and runs in the background; poll
+   * `get_job_result({ jobId })`. Ignored for read-only routing (execute:false).
+   */
+  dispatch: z
+    .enum(['sync', 'async'])
+    .optional()
+    .describe(
+      "Dispatch mode (#3732). 'sync' (default): run inline. 'async' (only with execute:true): return a jobId immediately + run in background (poll get_job_result)."
     ),
 });
 
@@ -293,6 +310,41 @@ export async function executeGoal(
   };
 }
 
+/**
+ * Run the `execute: true` body — dispatch the selected strategy via the
+ * MetaDispatcher and shape the `ToolResult`. The sync path awaits this inline;
+ * the async dispatcher backgrounds it via {@link runAsJob} (#3732). Catches the
+ * dispatch error here so a backgrounded failure records the same structured
+ * envelope a sync caller would have seen.
+ */
+async function executeRunBody(
+  input: RunInput,
+  logger: ILogger,
+  trustTier?: string
+): Promise<ToolResult> {
+  try {
+    // #3712: thread the caller's real RequestContext.trustTier into the
+    // dev-pipeline executor's consensus→execute seam. undefined ⇒ seam
+    // fail-closes to untrusted (4); never infer trust from absence.
+    const exec = await executeGoal(input, {
+      logger,
+      ...(trustTier !== undefined ? { trustTier } : {}),
+    });
+    logger.info('run: executed goal', {
+      decisionId: exec.decisionId,
+      strategy: exec.strategy,
+      durationMs: exec.durationMs,
+    });
+    return toolSuccess(JSON.stringify(exec, null, 2));
+  } catch (err) {
+    const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
+    return toolStructuredError({
+      errorCategory: noExecutor ? 'business' : 'internal',
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 async function runHandler(args: unknown, logger: ILogger, trustTier?: string): Promise<ToolResult> {
   const parsed = RunInputSchema.safeParse(args);
   if (!parsed.success) {
@@ -303,27 +355,22 @@ async function runHandler(args: unknown, logger: ILogger, trustTier?: string): P
   }
 
   if (parsed.data.execute === true) {
-    try {
-      // #3712: thread the caller's real RequestContext.trustTier into the
-      // dev-pipeline executor's consensus→execute seam. undefined ⇒ seam
-      // fail-closes to untrusted (4); never infer trust from absence.
-      const exec = await executeGoal(parsed.data, {
+    const input = parsed.data;
+    // #3732: async dispatch — `run` with execute:true routes to the heaviest
+    // engines (dev-pipeline/pipeline), which can exceed the MCP request timeout
+    // even with the 1800s class guard (#3734). `run` has no sessionId, so a
+    // fresh `rn-<uuid>` jobId is always minted (no idempotency surface).
+    // Returns `{ status: 'pending', jobId }` immediately.
+    if (input.dispatch === 'async') {
+      return runAsJob<RunInput, ToolResult>({
+        toolName: 'run',
+        input,
+        freshJobId: () => `rn-${randomUUID()}`,
+        run: () => executeRunBody(input, logger, trustTier),
         logger,
-        ...(trustTier !== undefined ? { trustTier } : {}),
-      });
-      logger.info('run: executed goal', {
-        decisionId: exec.decisionId,
-        strategy: exec.strategy,
-        durationMs: exec.durationMs,
-      });
-      return toolSuccess(JSON.stringify(exec, null, 2));
-    } catch (err) {
-      const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
-      return toolStructuredError({
-        errorCategory: noExecutor ? 'business' : 'internal',
-        message: err instanceof Error ? err.message : String(err),
       });
     }
+    return executeRunBody(input, logger, trustTier);
   }
 
   const response = routeGoal(parsed.data, logger);


### PR DESCRIPTION
Closes #3732 (final child of epic #3729).

Wires `dispatch: 'async'` onto the last three high-risk pipeline tools via the shared `runAsJob` helper (#3726/#3730 reference pattern). When `dispatch: 'async'`, the tool returns a `{ status: 'pending', jobId }` envelope immediately and runs the long body in the background; poll `get_job_result({ jobId })`. Sync (default) behavior is byte-identical.

## Tools migrated

| Tool | Prefix | Cap | Notes |
| --- | --- | --- | --- |
| `execute_spec` | `es-` | 2 | Full spec DAG (parse→decompose→compile→execute→validate→analyze). `dryRun` stays sync. |
| `run_graph_workflow` | `gw-` | 2 | Up to ~100 expert nodes (has node checkpoints). `list` sentinel stays sync. |
| `run` (execute:true) | `rn-` | 2 | Dispatches the heaviest engines (dev-pipeline/pipeline) via MetaDispatcher. |

### `run` decision — MIGRATED (not deferred)

`run`'s `execute: true` body is a single `await executeGoal(...)` that produces a `RunExecuteResponse`. Its executors call the `*ForGoal` functions directly (`runDevPipelineForGoal`/`runPipelineForGoal`/`runConsensusForGoal`), **not** the async-dispatch tool handlers — so wrapping it in `runAsJob` is a clean mirror with **no double-wrap risk**. Read-only routing (`execute: false`) ignores `dispatch` and stays sync. The 1800s pipeline class guard (#3734) remains as the sync-path backstop. No follow-up issue needed.

## Registry wiring

- `DEFAULT_JOB_CAPS` (job-concurrency.ts): `execute_spec`/`run_graph_workflow`/`run` → cap 2.
- `TOOL_NAME_BY_PREFIX` (task-state-source.ts): `es`/`gw`/`rn`.
- Verified no collision with existing prefixes: `orch`/`rwf`/`cv`/`dp`/`rp`/`pr`/`sc`.

## Tests (105 across 5 files, all green)

- `execute-spec-tool.test.ts` (+) — schema dispatch default/async/reject; async returns pending `es-` jobId; sync default; sidecar records complete via get_job_result.
- `run-graph-workflow.test.ts` (+) — same shape, `gw-` prefix (real `echo` workflow).
- `run-tool.test.ts` (+) — `rn-` prefix; sync default returns executed result; **execute:false ignores dispatch**; sidecar records complete.
- `job-concurrency.test.ts` / `task-state-source.test.ts` (+) — new cap + prefix assertions.

`vitest run src/mcp`: **179 files / 3515 tests passed**.

## Gates

`tsc --noEmit` ✓ · `eslint` ✓ · `governance:check` ✓ · `check-registry-coverage` ✓ · `generate-repo-index --check` ✓ · changeset (patch) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)