### PR TITLE
refactor(timeouts): sweep scattered literal timeouts into central authority (#3736)

### DIFF
--- a/.changeset/timeout-literal-sweep-3736.md
+++ b/.changeset/timeout-literal-sweep-3736.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+refactor(timeouts): sweep scattered literal timeouts into the central operation-class authority (#3736)
+
+Follow-on to #3734. Moves the remaining local literal timeouts off hardcoded
+values and onto central named constants derived from the operation-class
+taxonomy in `config/timeouts.ts`. Punitive LLM-guarding shorts (30s/60s on AFlow
+node evaluation, self-eval, and workflow mutation) are raised to the non-punitive
+`single-llm` class guard (300s); scattered network/CLI literals are centralized
+to `network-fetch` (120s), the existing v2-delegate/gh-command constants, and a
+new `SEARCH_TREE_MAX_TIME_MS`. No new punitive values introduced.

--- a/packages/nexus-agents/src/cli/registry-command.ts
+++ b/packages/nexus-agents/src/cli/registry-command.ts
@@ -24,6 +24,7 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { nexusDataPath } from '../config/nexus-data-dir.js';
+import { NETWORK_FETCH_TIMEOUT_MS } from '../config/timeouts.js';
 
 import {
   getDefaultRegistry,
@@ -327,7 +328,9 @@ const overCapError = (bytes: number | null): FetchResult => ({
 
 async function fetchWithCap(url: string, fetchImpl: typeof fetch): Promise<FetchResult> {
   try {
-    const response = await fetchImpl(url, { signal: AbortSignal.timeout(30_000) });
+    const response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(NETWORK_FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       return { ok: false, error: `HTTP ${String(response.status)}` };
     }

--- a/packages/nexus-agents/src/cli/self-eval-types.ts
+++ b/packages/nexus-agents/src/cli/self-eval-types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AggregatedResult } from '../self-eval/aggregation-logic.js';
+import { INTERNAL_TIMEOUTS } from '../config/timeouts.js';
 
 // ============================================================================
 // CLI Options
@@ -70,8 +71,9 @@ export interface EvaluationSummary {
 // Constants
 // ============================================================================
 
-/** Default timeout in milliseconds (2 minutes) */
-export const DEFAULT_TIMEOUT_MS = 120_000;
+/** Default overall self-eval wall budget. Centralized to the canonical
+ * self-eval timeout in the central authority (#3736); same 120s value. */
+export const DEFAULT_TIMEOUT_MS = INTERNAL_TIMEOUTS.selfEvalMs;
 
 /** Default target directory */
 export const DEFAULT_TARGET = 'src/adapters/';

--- a/packages/nexus-agents/src/cli/self-eval.ts
+++ b/packages/nexus-agents/src/cli/self-eval.ts
@@ -22,6 +22,7 @@ import type {
   EvaluationSummary,
 } from './self-eval-types.js';
 import { DEFAULT_TIMEOUT_MS, DEFAULT_TARGET, colors } from './self-eval-types.js';
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../config/timeouts.js';
 import { printSummaryMode, printVerboseMode, printJsonMode } from './self-eval-format.js';
 
 // Re-export types for backward compatibility
@@ -135,7 +136,10 @@ async function evaluateComponentWithTimeout(
   component: ComponentInfo,
   remainingMs: number
 ): Promise<readonly EvaluationResult[]> {
-  const componentTimeout = Math.min(remainingMs, 30_000); // Max 30s per component
+  // Per-component runaway-guard (#3736): was a punitive 30s cap on a single
+  // component's LLM evaluation; raised to the central single-llm class guard
+  // (300s). The overall remainingMs wall budget still bounds the run.
+  const componentTimeout = Math.min(remainingMs, SINGLE_LLM_EVAL_TIMEOUT_MS);
 
   try {
     const result = await Promise.race([
@@ -194,7 +198,7 @@ export function parseOptions(args: readonly string[]): EvaluateOptions {
   let target = DEFAULT_TARGET;
   let verbose = false;
   let json = false;
-  let timeout = DEFAULT_TIMEOUT_MS;
+  let timeout: number = DEFAULT_TIMEOUT_MS;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -39,6 +39,9 @@ import {
   resolveToolClassGuardMs,
   resolveTimeoutMultiplier,
   classOverrideEnvVar,
+  SINGLE_LLM_EVAL_TIMEOUT_MS,
+  NETWORK_FETCH_TIMEOUT_MS,
+  SEARCH_TREE_MAX_TIME_MS,
   type OperationClassName,
 } from './timeouts.js';
 import { TOOL_MANIFEST } from '../mcp/tools/tool-manifest.js';
@@ -512,6 +515,23 @@ describe('Centralized Timeout Configuration', () => {
     it('defaults unclassified tools to single-llm (300s), not the punitive 60s', () => {
       expect(DEFAULT_OPERATION_CLASS).toBe('single-llm');
       expect(OPERATION_CLASSES[DEFAULT_OPERATION_CLASS].guardMs).toBe(300_000);
+    });
+  });
+
+  describe('named central constants for non-MCP callers (#3736)', () => {
+    it('derives each constant from the operation-class taxonomy (no local literals)', () => {
+      expect(SINGLE_LLM_EVAL_TIMEOUT_MS).toBe(OPERATION_CLASSES['single-llm'].guardMs);
+      expect(NETWORK_FETCH_TIMEOUT_MS).toBe(OPERATION_CLASSES['network-fetch'].guardMs);
+      expect(SEARCH_TREE_MAX_TIME_MS).toBe(OPERATION_CLASSES['single-llm'].guardMs);
+    });
+
+    it('keeps every constant generous (>= its class minimum, non-punitive)', () => {
+      // single-llm guards LLM round-trips: must comfortably exceed the old
+      // punitive 30s/60s literals the sweep replaced.
+      expect(SINGLE_LLM_EVAL_TIMEOUT_MS).toBeGreaterThanOrEqual(300_000);
+      // network-fetch must exceed the old tight 10s/30s HTTP literals.
+      expect(NETWORK_FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
+      expect(SEARCH_TREE_MAX_TIME_MS).toBeGreaterThanOrEqual(300_000);
     });
   });
 

--- a/packages/nexus-agents/src/config/timeouts.ts
+++ b/packages/nexus-agents/src/config/timeouts.ts
@@ -214,6 +214,41 @@ export const TOOL_CLASS = {
   memory_write: 'interactive',
 } as const satisfies Record<string, OperationClassName>;
 
+/**
+ * Named central constants for non-MCP-tool callers that need a class guard but
+ * do not flow through {@link TOOL_CLASS} (workflows, self-eval, network fetches).
+ * Each derives from {@link OPERATION_CLASSES} so the operation-class taxonomy
+ * (#3734) stays the single source of truth — no local literals.
+ *
+ * PRINCIPLE (#3734): these are non-punitive RUNAWAY-GUARDS. The old AFlow /
+ * self-eval / mutation literals (30s/60s guarding an LLM evaluation) were
+ * punitive and have been raised to the `single-llm` class guard (300s). Network
+ * fetch literals (30s/10s) ride the `network-fetch` guard (120s).
+ * (Source: Issue #3736 — sweep scattered literal timeouts into the authority)
+ */
+
+/**
+ * Runaway-guard for a single LLM evaluation / mutation / self-eval round-trip.
+ * Resolves to the `single-llm` class guard (300s). Replaces the punitive
+ * 30s/60s literals in aflow / self-eval / mutation-operators.
+ */
+export const SINGLE_LLM_EVAL_TIMEOUT_MS = OPERATION_CLASSES['single-llm'].guardMs;
+
+/**
+ * Runaway-guard for an outbound HTTP fetch (registry/plan-compiler/github/osv/
+ * v2-delegate). Resolves to the `network-fetch` class guard (120s) — generous
+ * for any real fetch, replacing the scattered 30s/10s `AbortSignal.timeout`
+ * literals.
+ */
+export const NETWORK_FETCH_TIMEOUT_MS = OPERATION_CLASSES['network-fetch'].guardMs;
+
+/**
+ * Generous upper bound for a multi-step search tree (LATTS) run. Resolves to the
+ * `single-llm` class guard (300s) — the prior 5-minute literal happened to match
+ * the class guard exactly, so this is pure centralization.
+ */
+export const SEARCH_TREE_MAX_TIME_MS = OPERATION_CLASSES['single-llm'].guardMs;
+
 /** Env-var name for the global timeout multiplier. */
 export const TIMEOUT_MULTIPLIER_ENV_VAR = 'NEXUS_TIMEOUT_MULTIPLIER';
 

--- a/packages/nexus-agents/src/pipeline/plan-compiler.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.ts
@@ -16,6 +16,7 @@ import type { PlanContract, StageSpec, PolicyGateSpec } from './task-contract.js
 import type { IPluginRegistry } from './plugin-types.js';
 import { enforceGatePolicy } from './policy-evaluator.js';
 import type { GatePolicyEnforcement } from './policy-evaluator.js';
+import { NETWORK_FETCH_TIMEOUT_MS } from '../config/timeouts.js';
 
 /** Result of plan compilation. */
 type CompileResult =
@@ -104,7 +105,11 @@ function createStageHandler(
   const plugin = registry?.resolve(stage.pluginId);
   if (plugin !== undefined) {
     return async (_state: Readonly<GraphState>) => {
-      const ctx = { signal: AbortSignal.timeout(30_000), task: {} as never, config: stage.config };
+      const ctx = {
+        signal: AbortSignal.timeout(NETWORK_FETCH_TIMEOUT_MS),
+        task: {} as never,
+        config: stage.config,
+      };
       const result = await plugin.execute(stage, ctx);
       return {
         currentStage: stage.id,

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -14,6 +14,7 @@
  * @module pipeline/v2-delegate
  */
 import { createLogger } from '../core/index.js';
+import { API_TIMEOUTS } from '../config/timeouts.js';
 
 import { PipelineRunner } from './pipeline-runner.js';
 import { getPipelineEventBus } from './event-bus.js';
@@ -299,6 +300,7 @@ export function buildDelegatePlan(task: TaskContract): PlanContract {
     },
     approvalRequired: false,
     maxIterations: 1,
-    timeoutMs: 30_000,
+    // Centralized to the existing named v2-delegate guard (#3736); same 30s value.
+    timeoutMs: API_TIMEOUTS.v2DelegateMs,
   };
 }

--- a/packages/nexus-agents/src/scm/github-provider-traits.ts
+++ b/packages/nexus-agents/src/scm/github-provider-traits.ts
@@ -22,6 +22,7 @@ import type {
 } from './types.js';
 import { ScmError } from './types.js';
 import { GitHubProvider } from './github-provider.js';
+import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
 
 const logger = createLogger({ component: 'GitHubProviderTraits' });
 
@@ -144,7 +145,7 @@ async function execGhApi(endpoint: string, method?: string): Promise<Result<stri
   try {
     const { stdout } = await exec('gh', args, {
       maxBuffer: 10 * 1024 * 1024,
-      timeout: 30_000,
+      timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
       ...(env !== undefined ? { env } : {}),
     });
     return ok(stdout.trim());
@@ -265,7 +266,7 @@ export class GitHubReviewer implements IScmReviewer {
           '-f',
           `event=${eventMap[decision]}`,
         ],
-        { maxBuffer: 10 * 1024 * 1024, timeout: 30_000 }
+        { maxBuffer: 10 * 1024 * 1024, timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs }
       );
       return ok(undefined);
     } catch (error) {

--- a/packages/nexus-agents/src/scm/github-provider.ts
+++ b/packages/nexus-agents/src/scm/github-provider.ts
@@ -26,6 +26,7 @@ import type {
   IssueFilters,
 } from './types.js';
 import { ScmError } from './types.js';
+import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger({ component: 'GitHubProvider' });
@@ -33,8 +34,9 @@ const logger = createLogger({ component: 'GitHubProvider' });
 /** Max buffer for gh CLI output (10MB). */
 const MAX_BUFFER = 10 * 1024 * 1024;
 
-/** gh CLI timeout in ms. */
-const GH_TIMEOUT_MS = 30_000;
+/** gh CLI subprocess runaway-guard. Centralized to the canonical gh-command
+ * timeout in the central authority (#3736); same 30s value. */
+const GH_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUTS.ghCommandMs;
 
 // ============================================================================
 // gh CLI JSON schemas (internal — #2962 site 4)

--- a/packages/nexus-agents/src/security/osv-lookup.ts
+++ b/packages/nexus-agents/src/security/osv-lookup.ts
@@ -9,11 +9,14 @@
 
 import { z } from 'zod';
 import { createLogger } from '../core/index.js';
+import { NETWORK_FETCH_TIMEOUT_MS } from '../config/timeouts.js';
 
 const logger = createLogger({ component: 'osv-lookup' });
 
 const OSV_API_URL = 'https://api.osv.dev/v1/query';
-const DEFAULT_TIMEOUT_MS = 10_000;
+// Runaway-guard for the OSV.dev HTTP query (#3736): was a 10s literal — too
+// tight for a real fetch; centralized to the network-fetch class guard (120s).
+const DEFAULT_TIMEOUT_MS = NETWORK_FETCH_TIMEOUT_MS;
 
 // ============================================================================
 // Types

--- a/packages/nexus-agents/src/self-eval/evaluation-agents-types.ts
+++ b/packages/nexus-agents/src/self-eval/evaluation-agents-types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ILogger } from '../core/index.js';
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../config/timeouts.js';
 
 // ============================================================================
 // Result Types
@@ -111,6 +112,8 @@ export const DEFAULT_THRESHOLDS: Required<EvaluationThresholds> = {
 } as const;
 
 /**
- * Default timeout in milliseconds.
+ * Default timeout in milliseconds. Runaway-guard for a single component's
+ * LLM-backed evaluation (#3736): was a punitive 30s literal; raised to the
+ * central single-llm class guard (300s).
  */
-export const DEFAULT_TIMEOUT_MS = 30_000;
+export const DEFAULT_TIMEOUT_MS = SINGLE_LLM_EVAL_TIMEOUT_MS;

--- a/packages/nexus-agents/src/workflows/aflow/aflow-generator.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/aflow-generator.test.ts
@@ -20,6 +20,7 @@ import { ActionSpace, createActionSpace } from './action-space.js';
 import { WorkflowEvaluator, createWorkflowEvaluator } from './evaluation.js';
 import type { TaskSpecification, WorkflowAction } from './aflow-types.js';
 import { DEFAULT_AFLOW_CONFIG, AFlowConfigSchema } from './aflow-types.js';
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../../config/timeouts.js';
 
 // ============================================================================
 // Test Helpers
@@ -78,6 +79,15 @@ describe('AFlow Types', () => {
 
       expect(config.maxIterations).toBe(DEFAULT_AFLOW_CONFIG.maxIterations);
       expect(config.explorationConstant).toBeCloseTo(Math.SQRT2);
+    });
+
+    it('uses the central single-llm class guard for evaluation timeout (#3736, non-punitive)', () => {
+      // Was a punitive 30s literal guarding an LLM node evaluation; now derives
+      // from the central single-llm class guard (300s).
+      expect(DEFAULT_AFLOW_CONFIG.evaluationTimeoutMs).toBe(SINGLE_LLM_EVAL_TIMEOUT_MS);
+      expect(DEFAULT_AFLOW_CONFIG.evaluationTimeoutMs).toBe(300_000);
+      const parsed = AFlowConfigSchema.parse({});
+      expect(parsed.evaluationTimeoutMs).toBe(SINGLE_LLM_EVAL_TIMEOUT_MS);
     });
 
     it('should reject invalid values', () => {

--- a/packages/nexus-agents/src/workflows/aflow/aflow-types.ts
+++ b/packages/nexus-agents/src/workflows/aflow/aflow-types.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import type { WorkflowDefinition, WorkflowStep, AgentRole } from '../../core/index.js';
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../../config/timeouts.js';
 
 /**
  * Action types that can be taken during workflow construction.
@@ -153,7 +154,9 @@ export const DEFAULT_AFLOW_CONFIG: AFlowConfig = {
   acceptanceThreshold: 0.7,
   maxSteps: 20,
   minSteps: 2,
-  evaluationTimeoutMs: 30000,
+  // Runaway-guard for a single LLM node evaluation (#3736): was a punitive 30s
+  // literal; raised to the central single-llm class guard (300s).
+  evaluationTimeoutMs: SINGLE_LLM_EVAL_TIMEOUT_MS,
   enableEarlyTermination: true,
   earlyTerminationThreshold: 0.9,
   temperature: 1.0,
@@ -171,7 +174,7 @@ export const AFlowConfigSchema = z.object({
   acceptanceThreshold: z.number().min(0).max(1).default(0.7),
   maxSteps: z.number().int().positive().default(20),
   minSteps: z.number().int().positive().default(2),
-  evaluationTimeoutMs: z.number().int().positive().default(30000),
+  evaluationTimeoutMs: z.number().int().positive().default(SINGLE_LLM_EVAL_TIMEOUT_MS),
   enableEarlyTermination: z.boolean().default(true),
   earlyTerminationThreshold: z.number().min(0).max(1).default(0.9),
   temperature: z.number().positive().default(1.0),
@@ -300,7 +303,9 @@ export const DEFAULT_ACTION_SPACE_CONFIG: ActionSpaceConfig = {
     'testing_expert',
   ],
   availableActions: ['analyze', 'implement', 'review', 'test', 'document'],
-  defaultTimeout: 60000,
+  // Default per-step runaway-guard for newly generated steps (#3736): was a
+  // punitive 60s literal; raised to the central single-llm class guard (300s).
+  defaultTimeout: SINGLE_LLM_EVAL_TIMEOUT_MS,
   defaultRetries: 2,
   maxDependenciesPerStep: 5,
 };

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
@@ -353,7 +353,16 @@ describe('evaluateCompleteness', () => {
 
 describe('calculateTimeoutScore', () => {
   it('returns 1 for reasonable timeout', () => {
-    const score = calculateTimeoutScore(makeWorkflow(), makeTask());
+    // Steps carry explicit modest per-step timeouts; the COST_MODEL fallback
+    // default was centralized up to the single-llm class guard (300s, #3736),
+    // so a timeout-less 2-step workflow now exceeds the 300s default budget.
+    const wf = makeWorkflow({
+      steps: [
+        { id: 'step1', agent: 'code_expert', action: 'Implement', inputs: {}, timeout: 60000 },
+        { id: 'step2', agent: 'testing_expert', action: 'Test', inputs: {}, timeout: 60000 },
+      ],
+    });
+    const score = calculateTimeoutScore(wf, makeTask());
     expect(score).toBeGreaterThan(0);
   });
 

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-types.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-types.ts
@@ -7,6 +7,8 @@
  * (Source: Issue #329, arXiv:2410.10762)
  */
 
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../../config/timeouts.js';
+
 /**
  * Weights for evaluation components.
  */
@@ -61,5 +63,8 @@ export const COST_MODEL = {
   baseCostPerStep: 100,
   costPerRetry: 50,
   costPerTimeoutMs: 0.001,
-  defaultTimeoutMs: 60000,
+  // Assumed default LLM-step runaway-guard used for cost/score estimation when a
+  // step declares no explicit timeout (#3736): was a punitive 60s literal;
+  // centralized to the single-llm class guard (300s).
+  defaultTimeoutMs: SINGLE_LLM_EVAL_TIMEOUT_MS,
 } as const;

--- a/packages/nexus-agents/src/workflows/latts-types.ts
+++ b/packages/nexus-agents/src/workflows/latts-types.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import type { StepResult } from '../core/index.js';
+import { SEARCH_TREE_MAX_TIME_MS } from '../config/timeouts.js';
 
 /**
  * Verification result from the acceptance criterion.
@@ -141,7 +142,7 @@ export interface LattsConfig {
 export const DEFAULT_LATTS_CONFIG: LattsConfig = {
   maxAttemptsPerStep: 5,
   maxTotalAttempts: 20,
-  maxTimeMs: 300000, // 5 minutes
+  maxTimeMs: SEARCH_TREE_MAX_TIME_MS, // central single-llm guard (300s, #3736)
   acceptanceThreshold: 0.7,
   qualityThreshold: 0.6,
   allowBacktrack: true,
@@ -155,7 +156,7 @@ export const DEFAULT_LATTS_CONFIG: LattsConfig = {
 export const LattsConfigSchema = z.object({
   maxAttemptsPerStep: z.number().int().positive().default(5),
   maxTotalAttempts: z.number().int().positive().default(20),
-  maxTimeMs: z.number().int().positive().default(300000),
+  maxTimeMs: z.number().int().positive().default(SEARCH_TREE_MAX_TIME_MS),
   acceptanceThreshold: z.number().min(0).max(1).default(0.7),
   qualityThreshold: z.number().min(0).max(1).default(0.6),
   allowBacktrack: z.boolean().default(true),

--- a/packages/nexus-agents/src/workflows/self-evolving/mutation-operators.test.ts
+++ b/packages/nexus-agents/src/workflows/self-evolving/mutation-operators.test.ts
@@ -95,8 +95,9 @@ describe('Mutation Operators', () => {
       const result = adjustTimeout(workflow, 'step1', 2.0);
 
       expect(result).not.toBeNull();
-      expect(result!.mutation.originalValue).toBe(30000); // DEFAULT_TIMEOUT_MS
-      expect(result!.mutation.newValue).toBe(60000);
+      // DEFAULT_TIMEOUT_MS centralized to the single-llm class guard (300s, #3736).
+      expect(result!.mutation.originalValue).toBe(300000);
+      expect(result!.mutation.newValue).toBe(600000); // clamped to MAX_TIMEOUT_MS
     });
 
     it('should clamp timeout to minimum 1000ms', () => {

--- a/packages/nexus-agents/src/workflows/self-evolving/mutation-operators.ts
+++ b/packages/nexus-agents/src/workflows/self-evolving/mutation-operators.ts
@@ -11,6 +11,7 @@
 import type { WorkflowDefinition, WorkflowStep } from '../../core/index.js';
 import { getRandomProvider } from '../../core/index.js';
 import { clamp } from '../../utils/math-utils.js';
+import { SINGLE_LLM_EVAL_TIMEOUT_MS } from '../../config/timeouts.js';
 import type {
   WorkflowMutation,
   TimeoutAdjustment,
@@ -22,9 +23,11 @@ import type {
 import { findReorderableSteps, findParallelizableSteps } from './sew-types.js';
 
 /**
- * Default timeout value when step has none defined.
+ * Default timeout value when step has none defined. Runaway-guard for an LLM
+ * mutation evaluation (#3736): was a punitive 30s literal; raised to the central
+ * single-llm class guard (300s).
  */
-const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_TIMEOUT_MS = SINGLE_LLM_EVAL_TIMEOUT_MS;
 
 /**
  * Default retry count when step has none defined.


### PR DESCRIPTION
Follow-on to #3734 (central operation-class timeout authority in `config/timeouts.ts`). Sweeps the remaining scattered literal timeouts that bypassed the authority onto central named constants, per the #3734 principle that timeouts are **non-punitive runaway-guards**.

## New central constants (derive from `OPERATION_CLASSES`)
- `SINGLE_LLM_EVAL_TIMEOUT_MS` → `single-llm` guard (300s)
- `NETWORK_FETCH_TIMEOUT_MS` → `network-fetch` guard (120s)
- `SEARCH_TREE_MAX_TIME_MS` → `single-llm` guard (300s)

## Priority 1 — punitive LLM-guarding shorts (raised + centralized)
| File | Old | New |
| --- | --- | --- |
| `workflows/aflow/aflow-types.ts` | `evaluationTimeoutMs: 30s`, `defaultTimeout: 60s` | `SINGLE_LLM_EVAL_TIMEOUT_MS` (300s) |
| `workflows/aflow/evaluation-types.ts` | `COST_MODEL.defaultTimeoutMs: 60s` | `SINGLE_LLM_EVAL_TIMEOUT_MS` (300s) |
| `self-eval/evaluation-agents-types.ts` | `DEFAULT_TIMEOUT_MS: 30s` | `SINGLE_LLM_EVAL_TIMEOUT_MS` (300s) |
| `cli/self-eval.ts:138` | per-component clamp `30s` | `SINGLE_LLM_EVAL_TIMEOUT_MS` (300s) |
| `workflows/self-evolving/mutation-operators.ts` | `DEFAULT_TIMEOUT_MS: 30s` | `SINGLE_LLM_EVAL_TIMEOUT_MS` (300s) |

## Priority 2 — network/CLI literals centralized
| File | Old | New |
| --- | --- | --- |
| `cli/registry-command.ts` | `AbortSignal.timeout(30s)` | `NETWORK_FETCH_TIMEOUT_MS` (120s) |
| `pipeline/plan-compiler.ts` | `AbortSignal.timeout(30s)` | `NETWORK_FETCH_TIMEOUT_MS` (120s) |
| `security/osv-lookup.ts` | `10s` (too tight) | `NETWORK_FETCH_TIMEOUT_MS` (120s) |
| `pipeline/v2-delegate.ts` | `timeoutMs: 30s` | `API_TIMEOUTS.v2DelegateMs` (30s, existing) |
| `scm/github-provider.ts` + `-traits.ts` (×3) | gh-CLI `30s` | `CLI_SUBPROCESS_TIMEOUTS.ghCommandMs` (30s, existing) |
| `cli/self-eval-types.ts` | `DEFAULT_TIMEOUT_MS: 120s` | `INTERNAL_TIMEOUTS.selfEvalMs` (120s, existing) |
| `workflows/latts-types.ts` | `maxTimeMs: 300s` | `SEARCH_TREE_MAX_TIME_MS` (300s) |

## Skipped (out of scope / fine as-is)
- `mutation-operators.ts` `MAX_TIMEOUT_MS` (600s) — reasonable runaway ceiling, no exact central match; left as a named local constant.
- `cli-server.ts` SERVER_STARTUP / setup-codex/gemini — explicitly out of scope.

## Tests
- `config/timeouts.test.ts`: new constants exist, derive from the class taxonomy, and stay generous (≥ class minimums).
- `aflow-generator.test.ts` + `mutation-operators.test.ts`: assert the raised central values (300s / 600s).
- Downstream `evaluation-structure.test.ts` timeout-score test updated for the higher assumed default.

All 10633 touched-area tests pass; tsc clean; eslint clean; governance:check / registry-coverage / repo-index --check all green; changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)