### PR TITLE
docs: retarget FIRST_TASK dev-pipeline link off deprecated stub (#3690)

### DIFF
--- a/docs/getting-started/FIRST_TASK.md
+++ b/docs/getting-started/FIRST_TASK.md
@@ -130,14 +130,14 @@ The 12-stage CompositeRouter picks the right CLI, the right expert persona, and 
 
 ## Where to go next
 
-| Want to …                                                           | Read                                                                                   |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| **Chain tools into a goal** (research → vote → build)               | [COMPOSE_YOUR_FIRST_PIPELINE.md](./COMPOSE_YOUR_FIRST_PIPELINE.md)                     |
-| Understand the consensus voting strategies                          | [CONSENSUS_PROTOCOLS.md](../architecture/CONSENSUS_PROTOCOLS.md)                       |
-| Understand the routing pipeline                                     | [ROUTING_SYSTEM.md](../architecture/ROUTING_SYSTEM.md)                                 |
-| Configure model preferences, custom experts, sandbox modes          | [CONFIGURATION.md](./CONFIGURATION.md)                                                 |
-| Wire an editor we don't auto-detect                                 | [../guides/HARNESS_COMPATIBILITY.md](../guides/HARNESS_COMPATIBILITY.md)               |
-| Run the full dev pipeline (research → plan → vote → implement → QA) | [../workflows/SELF_DEVELOPMENT_WORKFLOW.md](../workflows/SELF_DEVELOPMENT_WORKFLOW.md) |
-| Inspect the audit chain                                             | `verify_audit_chain` MCP tool, or the JSONL under `<repo>/.nexus-agents/audit/`        |
-| Browse the research registry                                        | [../research/RESEARCH_INDEX.md](../research/RESEARCH_INDEX.md)                         |
-| See every CLI command + MCP tool                                    | [../ENTRYPOINTS.md](../ENTRYPOINTS.md)                                                 |
+| Want to …                                                           | Read                                                                            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Chain tools into a goal** (research → vote → build)               | [COMPOSE_YOUR_FIRST_PIPELINE.md](./COMPOSE_YOUR_FIRST_PIPELINE.md)              |
+| Understand the consensus voting strategies                          | [CONSENSUS_PROTOCOLS.md](../architecture/CONSENSUS_PROTOCOLS.md)                |
+| Understand the routing pipeline                                     | [ROUTING_SYSTEM.md](../architecture/ROUTING_SYSTEM.md)                          |
+| Configure model preferences, custom experts, sandbox modes          | [CONFIGURATION.md](./CONFIGURATION.md)                                          |
+| Wire an editor we don't auto-detect                                 | [../guides/HARNESS_COMPATIBILITY.md](../guides/HARNESS_COMPATIBILITY.md)        |
+| Run the full dev pipeline (research → plan → vote → implement → QA) | `run_dev_pipeline` MCP tool — see [../ENTRYPOINTS.md](../ENTRYPOINTS.md)        |
+| Inspect the audit chain                                             | `verify_audit_chain` MCP tool, or the JSONL under `<repo>/.nexus-agents/audit/` |
+| Browse the research registry                                        | [../research/RESEARCH_INDEX.md](../research/RESEARCH_INDEX.md)                  |
+| See every CLI command + MCP tool                                    | [../ENTRYPOINTS.md](../ENTRYPOINTS.md)                                          |


### PR DESCRIPTION
Closes #3690.

FIRST_TASK.md:140 ("Run the full dev pipeline") pointed newcomers at `docs/workflows/SELF_DEVELOPMENT_WORKFLOW.md`, which is a historical/deprecated pointer doc (the engine was deleted 2026-05-05 in #2402, replaced by the `improvement_review` / `run_dev_pipeline` surfaces). The file still exists, so this was a *misleading* link, not a 404 — the issue's "deleted file / broken link" framing was slightly off, but the UX problem is real: a new user is sent to a deprecated stub.

Retargets the link to the `run_dev_pipeline` MCP tool + ENTRYPOINTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)