### PR TITLE
chore: remove stale export-no-consumer markers + fix dead job-prefix entries

### DIFF
--- a/.changeset/vestigial-cleanup-postsession.md
+++ b/.changeset/vestigial-cleanup-postsession.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+chore: remove stale @export-no-consumer-yet markers and fix dead job-prefix entries
+
+Post-session vestigial-code cleanup:
+
+- Removed 16 stale `@export-no-consumer-yet` markers on auto-remediation /
+  tune-loop modules that now have real (non-test) production consumers reachable
+  from the live `auto-remediate` CLI command. The producer/consumer CI gate uses
+  these markers as opt-outs, so removing them where a consumer landed keeps the
+  gate honest. The one remaining marker (`improvement-remediation-outcome`,
+  test-only) is intentionally kept with its tracking issue.
+- Fixed dead `TOOL_NAME_BY_PREFIX` entries in `task-state-source.ts`:
+  `run_workflow` and `consensus_vote` mint two-segment `job-rw-…` / `job-vote-…`
+  job ids, which the previous `rwf` / `cv` single-segment keys never matched.
+  `toolNameFromJobId` now tries a two-segment prefix first so the two stay
+  distinct instead of colliding on `job`.

--- a/packages/nexus-agents/src/core/tune-adjustment-store.ts
+++ b/packages/nexus-agents/src/core/tune-adjustment-store.ts
@@ -25,9 +25,6 @@
  * @module core/tune-adjustment-store
  */
 
-// @export-no-consumer-yet — see #3147 (keystone step 1: the bounded adjustment
-// mechanism lands first; the CompositeRouter read + TuneStage write are the
-// immediately-following PRs, careful about TOPSIS scoring blast radius).
 import { getTimeProvider } from './time-provider.js';
 
 /** Lowest multiplier tuning can drive a CLI to — never zeroes it out. */

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.test.ts
@@ -43,8 +43,10 @@ function makeState(overrides: Partial<StructuredTaskState> = {}): StructuredTask
 describe('toolNameFromJobId', () => {
   it('maps known prefixes', () => {
     expect(toolNameFromJobId('orch-1-a')).toBe('orchestrate');
-    expect(toolNameFromJobId('rwf-1-a')).toBe('run_workflow');
-    expect(toolNameFromJobId('cv-1-a')).toBe('consensus_vote');
+    // run_workflow / consensus_vote mint two-segment `job-rw-…` / `job-vote-…`
+    // ids; they must stay distinct despite sharing the `job` first segment.
+    expect(toolNameFromJobId('job-rw-abc123')).toBe('run_workflow');
+    expect(toolNameFromJobId('job-vote-abc123')).toBe('consensus_vote');
     expect(toolNameFromJobId('dp-abc123')).toBe('run_dev_pipeline');
     expect(toolNameFromJobId('rp-abc123')).toBe('run_pipeline');
     expect(toolNameFromJobId('pr-abc123')).toBe('pr_review');

--- a/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
+++ b/packages/nexus-agents/src/mcp/jobs/task-state-source.ts
@@ -30,14 +30,22 @@ import { readJobResult } from './job-result-store.js';
 const logger = createLogger({ component: 'task-state-source' });
 
 /**
- * jobId-prefix → toolName. Async-mode writers mint task ids as
- * `<prefix>-<ts>-<rand>` (e.g. orchestrate's `generateTaskId` → `orch-…`).
- * Extended as each writer migrates (#3091, #3092). Unknown → `'unknown'`.
+ * jobId-prefix → toolName. Async-mode writers mint task ids two ways:
+ * - orchestrate's `generateTaskId` → `orch-<ts>-<rand>` (single-segment prefix);
+ * - the `runAsJob` writers → `<prefix>-<uuid>`, where some prefixes are
+ *   themselves two-segment (`job-rw-…`, `job-vote-…`). Both forms are matched by
+ *   {@link toolNameFromJobId}, which tries the two-segment prefix before the
+ *   single-segment one so `job-rw-…` resolves to `run_workflow` rather than
+ *   colliding on `job`. Extended as each writer migrates (#3091, #3092).
+ * Unknown → `'unknown'`.
  */
 const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
   orch: 'orchestrate',
-  rwf: 'run_workflow',
-  cv: 'consensus_vote',
+  // run_workflow mints `job-rw-<uuid>`; consensus_vote mints `job-vote-<uuid>`.
+  // Both share the `job` first segment, so they are keyed (and matched) on the
+  // two-segment prefix to stay distinct.
+  'job-rw': 'run_workflow',
+  'job-vote': 'consensus_vote',
   // #3726: run_dev_pipeline async jobs mint `dp-<uuid>` ids (or reuse the
   // caller's sessionId — which has no fixed prefix, so the dual-read reader
   // resolves those from the sidecar via toolName recorded at writeJobPending).
@@ -58,6 +66,13 @@ const TOOL_NAME_BY_PREFIX: Readonly<Record<string, string>> = {
 
 /** Derive the toolName from a jobId/taskId prefix. */
 export function toolNameFromJobId(jobId: string): string {
+  const [first, second] = jobId.split('-');
+  // Try the two-segment prefix first (e.g. `job-rw`, `job-vote`) so distinct
+  // tools that share a leading segment don't collide, then the single segment.
+  if (first !== undefined && second !== undefined) {
+    const byTwo = TOOL_NAME_BY_PREFIX[`${first}-${second}`];
+    if (byTwo !== undefined) return byTwo;
+  }
   const dash = jobId.indexOf('-');
   const prefix = dash === -1 ? jobId : jobId.slice(0, dash);
   return TOOL_NAME_BY_PREFIX[prefix] ?? 'unknown';

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-branch.ts
@@ -16,10 +16,6 @@
  * @module mcp/tools/auto-remediation-branch
  */
 
-// @export-no-consumer-yet — see #3618
-// The enforce capstone (#3618) creates remediation branches with this convention;
-// built ahead for that named consumer. CI workflows already gate on the literal.
-
 /** Canonical prefix for branches the auto-remediation enforce path creates. */
 export const AUTO_REMEDIATION_BRANCH_PREFIX = 'auto-remediation/';
 

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
@@ -12,9 +12,6 @@
  * @module mcp/tools/auto-remediation-cycle
  */
 
-// @export-no-consumer-yet — see #3671
-// Invoked by the CLI/MCP/scheduled surface; the thin registration follows.
-
 import { createLogger, type ILogger } from '../../core/index.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
@@ -12,9 +12,6 @@
  * @module mcp/tools/auto-remediation-deps
  */
 
-// @export-no-consumer-yet — see #3671
-// The CLI/MCP entry point (#3671) calls buildAutoRemediationDeps + runAutoRemediation.
-
 import { createLogger, type ILogger } from '../../core/index.js';
 import type { AutoRemediationDeps } from './improvement-remediation-enforce.js';
 import { buildRemediationPlanFromSignal } from './remediation-research.js';

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-lease.ts
@@ -19,10 +19,6 @@
  * @module mcp/tools/auto-remediation-lease
  */
 
-// @export-no-consumer-yet — see #3648
-// Wired into AutoRemediationDeps.acquireLease by the enforce entry point (the
-// remaining #3648 increment). Built first as the most-scrutinized condition.
-
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { ILogger } from '../../core/index.js';

--- a/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
+++ b/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
@@ -14,9 +14,6 @@
  * @module mcp/tools/diff-secret-scan
  */
 
-// @export-no-consumer-yet — see #3669
-// The Option B / Option A implement adapters call scanForSecrets before push.
-
 /** A known secret shape. */
 interface SecretPattern {
   readonly name: string;

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
@@ -27,10 +27,6 @@
  * @module mcp/tools/improvement-enforce-readiness
  */
 
-// @export-no-consumer-yet — see #3618
-// The enforce capstone (#3618) is explicitly "blocked by" this exit criterion and
-// consumes it to gate enforcement. Built ahead deliberately (named consumer).
-
 /** Tuning for {@link evaluateEnforceReadiness}. */
 export interface EnforceReadinessConfig {
   /** Minimum shadow would-remediate decisions before enforce can be considered. */

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
@@ -30,10 +30,6 @@
 
 import { z } from 'zod';
 
-// @export-no-consumer-yet — see #3618
-// These boundary primitives are consumed by the enforce capstone (#3618), which
-// is explicitly "blocked by" this increment. Built ahead for that named consumer.
-
 /** The three Rule-of-Two legs. No single phase may hold all three. */
 export type Capability = 'untrusted-input' | 'repo-write' | 'secrets';
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
@@ -25,13 +25,6 @@
  * @module mcp/tools/improvement-remediation-enforce
  */
 
-// @export-no-consumer-yet — see #3648
-// This ships the ratified, fully-tested orchestrator (pure control flow). The
-// real side-effecting AutoRemediationDeps adapters (git-ref lease, the
-// #3643-guarded dev-pipeline `implement` + GitHub PR, research diagnosis,
-// audit-chain) + the entry point that calls runAutoRemediation are the wiring
-// increment #3648. Enforce stays owner-gated regardless.
-
 import type { ILogger } from '../../core/index.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { RemediationGuard, getRemediationGuard } from './improvement-remediation-guard.js';

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-guard.ts
@@ -26,11 +26,6 @@
  * @module mcp/tools/improvement-remediation-guard
  */
 
-// @export-no-consumer-yet — see #3618
-// This guard is one of the hard-blocker safety primitives the enforce capstone
-// (#3618) is explicitly "blocked by"; it is consumed there once all of
-// inc.2b–inc.2g have landed. Built ahead deliberately (named near-term consumer).
-
 /** Tuning for {@link RemediationGuard}. All durations in milliseconds. */
 export interface RemediationGuardConfig {
   /** Minimum time before the same signalKey may be attempted again (idempotency). */

--- a/packages/nexus-agents/src/mcp/tools/remediation-circuit-breaker.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-circuit-breaker.ts
@@ -17,10 +17,6 @@
  * @module mcp/tools/remediation-circuit-breaker
  */
 
-// @export-no-consumer-yet — see #3648
-// Consulted by the enforce entry point (#3648): abort if tripped, record each
-// remediation's result, and reset only after a re-vote. Built ahead for it.
-
 /** Tuning for the breaker. */
 export interface CircuitBreakerConfig {
   /** Consecutive failures before the breaker trips to off. */

--- a/packages/nexus-agents/src/mcp/tools/remediation-priority.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-priority.ts
@@ -14,10 +14,6 @@
  * @module mcp/tools/remediation-priority
  */
 
-// @export-no-consumer-yet — see #3653
-// The p0–p4 auto-filer (labels) and the enforce orchestrator (consensus gating)
-// consume this policy next; it is the shared authoritative mapping built first.
-
 import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { isSecuritySignal } from './improvement-remediation-shadow.js';

--- a/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.ts
@@ -15,10 +15,6 @@
  * @module mcp/tools/remediation-proposal-pr
  */
 
-// @export-no-consumer-yet — see #3648
-// Wired as AutoRemediationDeps.implement by the enforce entry point once Option B
-// is enabled (still owner-gated by NEXUS_AUTO_REMEDIATE=enforce + readiness).
-
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { writeFile, mkdir } from 'node:fs/promises';

--- a/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-protected-paths.ts
@@ -18,10 +18,6 @@
  * @module mcp/tools/remediation-protected-paths
  */
 
-// @export-no-consumer-yet — see #3648
-// The enforce entry point (#3648) calls planTouchesProtectedPath before IMPLEMENT
-// to refuse self-modifying/secret-touching remediations. Built ahead for it.
-
 import type { RemediationPlan } from './improvement-remediation-capability.js';
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/remediation-research.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-research.ts
@@ -17,9 +17,6 @@
  * @module mcp/tools/remediation-research
  */
 
-// @export-no-consumer-yet — see #3648
-// Wired into AutoRemediationDeps.research by the enforce entry point (#3648).
-
 import type { ImprovementSignal, SignalCategory } from './improvement-review.js';
 import type {
   RemediationPlan,

--- a/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
@@ -13,9 +13,6 @@
  * @module mcp/tools/remediation-vote-adapter
  */
 
-// @export-no-consumer-yet — see #3648
-// Wired into AutoRemediationDeps.vote by the enforce entry point (#3648).
-
 import { createLogger, type ILogger } from '../../core/index.js';
 import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
 import { executeVoting, ConsensusVoteInputSchema } from './consensus-vote.js';


### PR DESCRIPTION
Post-session vestigial-code cleanup pass. No behavior change to wired paths; removes misleading markers and a real (latent) bug in async job toolName resolution.

## 1. Stale `@export-no-consumer-yet` markers (16 removed)

Every marked auto-remediation / tune-loop module now has a real non-test production consumer. The chain is wired and reachable from the registered `auto-remediate` CLI command:

`cli-commands.ts` → `cli/auto-remediate-command.ts` → `auto-remediation-cycle` (`runAutoRemediationCycle`) → `auto-remediation-deps` (`buildAutoRemediationDeps`) → adapter modules (lease, vote, research, proposal-PR, branch, secret-scan, capability, priority, guard, circuit-breaker, protected-paths, enforce-readiness, enforce orchestrator). `tune-adjustment-store` is consumed by `pipeline/tune-stage.ts` + `cli-adapters/composite-router-stages.ts`.

The producer/consumer gate (`scripts/check-new-unused-exports.ts`) treats the marker as an opt-out, so clearing it where a consumer landed keeps the gate honest.

**Kept:** `improvement-remediation-outcome.ts` — still test-only (no production consumer); marker retained with its `#3618` tracking issue.

## 2. Dead `TOOL_NAME_BY_PREFIX` entries (`mcp/jobs/task-state-source.ts`)

`run_workflow` mints `job-rw-<uuid>` and `consensus_vote` mints `job-vote-<uuid>` (via `runAsJob`'s `freshJobId`). The previous `rwf` / `cv` single-segment keys never matched — `toolNameFromJobId` split on the first dash, so both ids resolved to prefix `job` and collided. `toolNameFromJobId` now tries a two-segment prefix (`job-rw`, `job-vote`) before the single-segment lookup, keeping the two distinct. The test asserted the dead `rwf-`/`cv-` prefixes and is updated to the real minted ones. `orchestrate` (`orch-`) and the `dp/rp/pr/sc/es/gw/rn` entries were already correct.

## 3. Dead exports — reported, none removed

Audited exported symbols across the new auto-remediation / job / timeout modules. The flagged symbols are all either consumed within their own module (config/return types, schemas, constants) or are named-consumer public surface for the auto-remediation arc (tracking issues `#3618`/`#3648`/`#3653`/`#3671`). No genuinely-dead, untracked, non-public export was found, so nothing was deleted (conservative).

## Gates
- `tsc --noEmit` clean
- `eslint --no-cache` clean on changed files
- vitest: 36 (task-state + tune) + 110 (remediation modules) pass
- `check-new-unused-exports.ts main` (producer/consumer gate) OK
- `governance:check`, `check-registry-coverage`, `generate-repo-index --check` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)