### PR TITLE
feat(capability-loop): durably persist audit-mode remediation soak data (#3762)

### DIFF
--- a/.changeset/durable-soak-sink-3762.md
+++ b/.changeset/durable-soak-sink-3762.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): durably persist auto-remediation AUDIT-mode soak data (#3762)
+
+Audit-mode auto-remediation now writes durable, queryable evidence instead of
+only `logger.info`. Adds a shared append-only JSONL store primitive
+(`config/jsonl-store.ts`, factored from `PersistentOutcomeStore`'s
+hydrate/append/Zod-validate mechanism) and a durable remediation soak sink under
+`NEXUS_DATA_DIR/learning/remediation-soak.jsonl` that records each audit-mode
+per-signal verdict (signalKey, category, priority/severity, vote outcome + tally,
+plan step count, p0 dry-run result, reason).
+
+- Secret-scrubbed before persistence (reuses `scanForSecrets` /
+  `describeSecretFindings`) — evidence never carries a secret.
+- Bounded retention: last 10,000 records, oldest-evicted (no disk-fill growth).
+- New `summarizeRemediationSoak` / `readRemediationSoakSummary` read surface for
+  the #3764 readiness collector (counts by verdict, approval rate, breakdowns).
+- Wired into the audit branch of the auto-remediation cycle.
+
+Decision-gate evidence for the enforce-by-default arc (#3653 / #3540).

--- a/packages/nexus-agents/src/config/jsonl-store.test.ts
+++ b/packages/nexus-agents/src/config/jsonl-store.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the shared append-only JSONL store primitive (#3762).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { JsonlStore } from './jsonl-store.js';
+
+const RecordSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+type Rec = z.infer<typeof RecordSchema>;
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'jsonl-store-'));
+  filePath = join(dir, 'nested', 'records.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function makeStore(maxRecords = 100): JsonlStore<Rec> {
+  return new JsonlStore<Rec>({ filePath, schema: RecordSchema, maxRecords });
+}
+
+describe('JsonlStore', () => {
+  it('round-trips: append N then reconstruct preserving order + fidelity', () => {
+    const store = makeStore();
+    for (let i = 0; i < 5; i++) store.append({ id: i, name: `n${String(i)}` });
+    expect(store.count()).toBe(5);
+
+    // Reconstruct from disk in a fresh instance.
+    const reopened = makeStore();
+    expect(reopened.count()).toBe(5);
+    expect(reopened.all().map((r) => r.id)).toEqual([0, 1, 2, 3, 4]);
+    expect(reopened.all()[2]).toEqual({ id: 2, name: 'n2' });
+  });
+
+  it('creates the parent directory on construction', () => {
+    const store = makeStore();
+    store.append({ id: 1, name: 'a' });
+    // File lives under a nested dir that did not exist beforehand.
+    expect(readFileSync(filePath, 'utf-8')).toContain('"id":1');
+  });
+
+  it('tolerates malformed + schema-invalid lines on hydrate', () => {
+    const store = makeStore();
+    store.append({ id: 1, name: 'ok' });
+    // Inject a corrupt line and a schema-invalid line.
+    writeFileSync(
+      filePath,
+      [
+        JSON.stringify({ id: 1, name: 'ok' }),
+        '{ not json',
+        JSON.stringify({ id: 'wrong-type', name: 5 }),
+        JSON.stringify({ id: 2, name: 'ok2' }),
+      ].join('\n') + '\n',
+      'utf-8'
+    );
+    const reopened = makeStore();
+    expect(reopened.count()).toBe(2);
+    expect(reopened.all().map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('refuses to persist a record that fails schema validation', () => {
+    const store = makeStore();
+    // Bypass the compile-time type to feed an invalid record at the boundary.
+    store.append({ id: 'bad', name: 1 } as unknown as Rec);
+    expect(store.count()).toBe(0);
+    const reopened = makeStore();
+    expect(reopened.count()).toBe(0);
+  });
+
+  it('bounds retention to the last N records (oldest evicted)', () => {
+    const max = 10;
+    const store = makeStore(max);
+    for (let i = 0; i < max + 5; i++) store.append({ id: i, name: `n${String(i)}` });
+    expect(store.count()).toBe(max);
+    // Oldest 5 evicted; newest retained.
+    expect(store.all().map((r) => r.id)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+
+    // The on-disk file is also bounded after rewrite.
+    const reopened = makeStore(max);
+    expect(reopened.count()).toBe(max);
+    expect(reopened.all()[0]?.id).toBe(5);
+  });
+
+  it('trims an over-cap file down on hydrate', () => {
+    // Write 20 lines directly (flat path, no nested dir), then open with a cap of 8.
+    const flat = join(dir, 'flat.jsonl');
+    const lines = Array.from({ length: 20 }, (_, i) =>
+      JSON.stringify({ id: i, name: `n${String(i)}` })
+    );
+    writeFileSync(flat, lines.join('\n') + '\n', 'utf-8');
+    const store = new JsonlStore<Rec>({ filePath: flat, schema: RecordSchema, maxRecords: 8 });
+    expect(store.count()).toBe(8);
+    expect(store.all()[0]?.id).toBe(12);
+  });
+});

--- a/packages/nexus-agents/src/config/jsonl-store.ts
+++ b/packages/nexus-agents/src/config/jsonl-store.ts
@@ -1,0 +1,184 @@
+/**
+ * Shared append-only JSONL store primitive (#3762).
+ *
+ * Factors the hydrate-on-construct / append-on-write / Zod-validate-each-line
+ * mechanism out of {@link PersistentOutcomeStore} so durable JSONL sinks don't
+ * each fork the same fs plumbing. This is the MECHANISM only — callers supply
+ * the record TYPE (a Zod schema) and a path. Corrupt lines are skipped on
+ * hydrate (graceful degradation), and the file is bounded by oldest-eviction
+ * rotation so it can never grow without limit (disk-fill DoS).
+ *
+ * NOT a parallel persistence framework: it's a thin, generic wrapper over the
+ * exact append/read/rewrite calls {@link PersistentOutcomeStore} already makes.
+ *
+ * @module config/jsonl-store
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { z } from 'zod';
+
+import type { ILogger } from '../core/index.js';
+import { createLogger, getErrorMessage } from '../core/index.js';
+
+/** Directory mode for created parent dirs: owner-only (rwx------). */
+const DIR_MODE = 0o700;
+
+/** Configuration for a {@link JsonlStore}. */
+export interface JsonlStoreConfig<T> {
+  /** Absolute path to the JSONL file. Parent dirs are created on construct. */
+  readonly filePath: string;
+  /** Zod schema validating each line on hydrate AND each record on append. */
+  readonly schema: z.ZodType<T>;
+  /**
+   * Maximum records retained. Once exceeded, the oldest are evicted and the
+   * file is rewritten in place. Bounds disk usage (Contrarian condition, #3762).
+   */
+  readonly maxRecords: number;
+  /** Component name for log context. */
+  readonly component?: string;
+  readonly logger?: ILogger;
+}
+
+/**
+ * Append-only JSONL store with hydrate-on-construct and bounded retention.
+ *
+ * - Construction: creates the parent dir, then hydrates from the file if it
+ *   exists, Zod-validating each line and skipping corrupt/invalid ones.
+ * - {@link append}: validates the record, pushes it in-memory, and either
+ *   appends one line (fast path) or — if the cap is exceeded — evicts the
+ *   oldest in memory and rewrites the file so it stays bounded.
+ * - All fs failures are caught and logged; persistence never throws into the
+ *   caller (an observability sink must not break the operation it observes).
+ */
+export class JsonlStore<T> {
+  private readonly filePath: string;
+  private readonly schema: z.ZodType<T>;
+  private readonly maxRecords: number;
+  private readonly logger: ILogger;
+  private readonly records: T[] = [];
+
+  constructor(config: JsonlStoreConfig<T>) {
+    this.filePath = config.filePath;
+    this.schema = config.schema;
+    this.maxRecords = Math.max(1, config.maxRecords);
+    this.logger = config.logger ?? createLogger({ component: config.component ?? 'JsonlStore' });
+    this.ensureDir();
+    this.hydrate();
+  }
+
+  /** Append one record durably. Validates at the boundary; never throws. */
+  append(record: T): void {
+    const result = this.schema.safeParse(record);
+    if (!result.success) {
+      this.logger.warn('Refusing to persist invalid JSONL record', {
+        path: this.filePath,
+        issues: result.error.issues.map((i) => i.message).join('; '),
+      });
+      return;
+    }
+    this.records.push(result.data);
+    if (this.records.length > this.maxRecords) {
+      // Over the cap: evict oldest in memory and rewrite the whole file so the
+      // on-disk line count matches the bounded in-memory set.
+      this.records.splice(0, this.records.length - this.maxRecords);
+      this.rewriteFile();
+      return;
+    }
+    this.persistLine(result.data);
+  }
+
+  /** All retained records, oldest first. */
+  all(): readonly T[] {
+    return this.records;
+  }
+
+  /** Number of retained records. */
+  count(): number {
+    return this.records.length;
+  }
+
+  // ==========================================================================
+  // Private
+  // ==========================================================================
+
+  private ensureDir(): void {
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true, mode: DIR_MODE });
+    } catch (error: unknown) {
+      this.logger.warn('Failed to create JSONL store directory', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+    }
+  }
+
+  private hydrate(): void {
+    if (!existsSync(this.filePath)) {
+      this.logger.debug('No JSONL file found, starting fresh', { path: this.filePath });
+      return;
+    }
+    let loaded = 0;
+    let skipped = 0;
+    try {
+      const content = readFileSync(this.filePath, 'utf-8');
+      const lines = content.split('\n').filter((line) => line.trim().length > 0);
+      for (const line of lines) {
+        try {
+          const parsed: unknown = JSON.parse(line);
+          const result = this.schema.safeParse(parsed);
+          if (result.success) {
+            this.records.push(result.data);
+            loaded++;
+          } else {
+            skipped++;
+          }
+        } catch {
+          skipped++;
+        }
+      }
+    } catch (error: unknown) {
+      this.logger.warn('Failed to hydrate JSONL store from disk', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+      return;
+    }
+    // Enforce the bound on hydrate too — a file grown past the cap out-of-band
+    // (e.g. an older build with a larger cap) is trimmed back on first load.
+    if (this.records.length > this.maxRecords) {
+      this.records.splice(0, this.records.length - this.maxRecords);
+      this.rewriteFile();
+    }
+    this.logger.debug('Hydrated JSONL store from disk', {
+      loaded,
+      skipped,
+      retained: this.records.length,
+      path: this.filePath,
+    });
+  }
+
+  private persistLine(record: T): void {
+    try {
+      appendFileSync(this.filePath, JSON.stringify(record) + '\n', 'utf-8');
+    } catch (error: unknown) {
+      this.logger.warn('Failed to append JSONL record to disk', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+    }
+  }
+
+  private rewriteFile(): void {
+    try {
+      const content = this.records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+      writeFileSync(this.filePath, content, 'utf-8');
+    } catch (error: unknown) {
+      this.logger.warn('Failed to rewrite JSONL store file', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+    }
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
@@ -3,9 +3,14 @@
  * Off-by-default short-circuit; audit drives the full path on injected signals/deps.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { runAutoRemediationCycle } from './auto-remediation-cycle.js';
 import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
+import { createRemediationSoakSink } from './improvement-remediation-shadow.js';
 import type { ImprovementSignal } from './improvement-review.js';
 
 function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
@@ -50,5 +55,57 @@ describe('runAutoRemediationCycle', () => {
       { collectSignals: async () => Promise.resolve(signals), deps }
     );
     expect(r.considered).toBe(2);
+  });
+
+  describe('durable soak evidence (#3762)', () => {
+    let dir: string;
+    afterEach(() => {
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('audit cycle writes one durable soak record per signal', async () => {
+      dir = mkdtempSync(join(tmpdir(), 'cycle-soak-'));
+      const soakSink = createRemediationSoakSink(join(dir, 'soak.jsonl'));
+      const signals = [signal({ signalKey: 'a' }), signal({ signalKey: 'b' })];
+      const deps = buildAutoRemediationDeps({
+        voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+      });
+
+      await runAutoRemediationCycle(
+        { mode: 'audit' },
+        { collectSignals: async () => Promise.resolve(signals), deps, soakSink }
+      );
+
+      const persisted = soakSink.getRecords();
+      expect(persisted).toHaveLength(2);
+      expect(persisted.map((r) => r.signalKey).sort()).toEqual(['a', 'b']);
+      // Each record carries the vote verdict + plan step count from the run.
+      for (const r of persisted) {
+        expect(r.voteOutcome).toEqual({ approved: true, approvalPercentage: 100 });
+        expect(r.planStepCount).toBeGreaterThan(0);
+        expect(r.category).toBe('routing');
+      }
+    });
+
+    it('captures a rejected vote verdict durably', async () => {
+      dir = mkdtempSync(join(tmpdir(), 'cycle-soak-rej-'));
+      const soakSink = createRemediationSoakSink(join(dir, 'soak.jsonl'));
+      const deps = buildAutoRemediationDeps({
+        voteRunner: async () => Promise.resolve({ approved: false, approvalPercentage: 33 }),
+      });
+
+      await runAutoRemediationCycle(
+        { mode: 'audit' },
+        {
+          collectSignals: async () => Promise.resolve([signal({ signalKey: 'x' })]),
+          deps,
+          soakSink,
+        }
+      );
+
+      const rec = soakSink.getRecords()[0];
+      expect(rec?.voteOutcome?.approved).toBe(false);
+      expect(rec?.voteOutcome?.approvalPercentage).toBe(33);
+    });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
@@ -16,6 +16,13 @@ import { createLogger, type ILogger } from '../../core/index.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';
 import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
+import { classifySignalPriority } from './remediation-priority.js';
+import {
+  createRemediationSoakCollector,
+  type RemediationSoakCollector,
+  type SoakSignalMeta,
+  type IRecordingRemediationSoakSink,
+} from './improvement-remediation-shadow.js';
 import {
   runAutoRemediation,
   resolveAutoRemediateMode,
@@ -42,6 +49,8 @@ export interface AutoRemediationCycleConfig {
 export interface AutoRemediationCycleInject {
   readonly collectSignals?: () => Promise<readonly ImprovementSignal[]>;
   readonly deps?: AutoRemediationDeps;
+  /** Inject an isolated durable soak sink (tests honor a temp NEXUS_DATA_DIR). */
+  readonly soakSink?: IRecordingRemediationSoakSink;
 }
 
 function offResult(): AutoRemediationResult {
@@ -67,7 +76,54 @@ export async function runAutoRemediationCycle(
   const signals = await collectCycleSignals(inject, config, logger);
   const deps = resolveCycleDeps(inject, config, logger);
   logger.info(`auto-remediation cycle: ${mode} over ${String(signals.length)} signals`);
+
+  // AUDIT mode: capture durable soak evidence (#3762). Wrap the deps' audit
+  // callback so every per-step event ALSO feeds the soak collector, then flush
+  // the per-signal verdicts to the durable JSONL sink at the end of the run.
+  if (mode === 'audit') {
+    const collector = buildSoakCollector(signals, inject);
+    const soakDeps = withSoakAudit(deps, collector);
+    try {
+      return await runAutoRemediation(signals, soakDeps, { mode });
+    } finally {
+      collector.flush();
+    }
+  }
+
   return runAutoRemediation(signals, deps, { mode });
+}
+
+/** Build a soak collector with per-signal metadata derived from the cycle's signals. */
+function buildSoakCollector(
+  signals: readonly ImprovementSignal[],
+  inject: AutoRemediationCycleInject
+): RemediationSoakCollector {
+  const meta = new Map<string, SoakSignalMeta>();
+  for (const s of signals) {
+    meta.set(s.signalKey, {
+      category: s.category,
+      priority: classifySignalPriority(s),
+      severity: s.severity,
+    });
+  }
+  const metaFor = (key: string): SoakSignalMeta | undefined => meta.get(key);
+  return inject.soakSink !== undefined
+    ? createRemediationSoakCollector(metaFor, inject.soakSink)
+    : createRemediationSoakCollector(metaFor);
+}
+
+/** Return a deps clone whose `audit` ALSO feeds the soak collector. */
+function withSoakAudit(
+  deps: AutoRemediationDeps,
+  collector: RemediationSoakCollector
+): AutoRemediationDeps {
+  return {
+    ...deps,
+    audit: (event): void => {
+      deps.audit(event);
+      collector.observe(event);
+    },
+  };
 }
 
 /** Collect signals via the injected source, or the real improvement_review aggregator. */

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
@@ -19,10 +19,15 @@
  * @module mcp/tools/improvement-remediation-shadow
  */
 
+import { z } from 'zod';
+
 import { getTimeProvider } from '../../core/index.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { remediationTaskId } from './improvement-remediation.js';
 import { SECURITY_KEYWORDS } from '../gateway/gateway-keywords.js';
+import { JsonlStore } from '../../config/jsonl-store.js';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
+import { scanForSecrets, describeSecretFindings } from './diff-secret-scan.js';
 
 /**
  * Fail-closed security classification (#3540 inc.2e / #3615). The hard
@@ -164,4 +169,354 @@ export function recordRemediationShadow(
   const records = signals.map(evaluateRemediationShadow);
   for (const record of records) sink.record(record);
   return records;
+}
+
+// ============================================================================
+// Durable audit-mode SOAK sink (#3762) — the enforce-decision-gate evidence.
+// ============================================================================
+
+/**
+ * Verdict tally from a consensus vote (approved/rejected + the approval %).
+ * Mirrors {@link AutoRemediationDeps.vote}'s return shape (#3653).
+ */
+export const SoakVoteOutcomeSchema = z.object({
+  approved: z.boolean(),
+  /** Approval percentage at vote time, 0–100 (the consensus tally). */
+  approvalPercentage: z.number(),
+});
+export type SoakVoteOutcome = z.infer<typeof SoakVoteOutcomeSchema>;
+
+/**
+ * One durable record of what AUDIT mode decided for a single signal — the
+ * cross-run soak evidence the enforce-by-default decision gate consumes (#3540
+ * / #3762). Captures the vote/plan outcome with ZERO writes to the repo.
+ *
+ * Free-text fields (`reason`, `dryRunResult`) are secret-scrubbed before
+ * persistence (see {@link scrubSoakRecord}) — persisted evidence must never
+ * carry a secret (#3669 / Security condition).
+ */
+export const RemediationSoakRecordSchema = z.object({
+  /** ISO-8601 capture time. */
+  timestamp: z.string(),
+  /** The improvement signal's stable key. */
+  signalKey: z.string(),
+  /** The signal's category. */
+  category: z.string(),
+  /** The classified remediation priority (p0–p4). */
+  priority: z.string(),
+  /** The signal's declared severity. */
+  severity: z.string(),
+  /** Vote outcome (approved/rejected + tally), undefined if the signal never reached a vote. */
+  voteOutcome: SoakVoteOutcomeSchema.optional(),
+  /** Number of plan steps research produced (0 if research/plan failed). */
+  planStepCount: z.number(),
+  /** p0 dry-run result detail (scrubbed); undefined for non-p0 or when no dry-run ran. */
+  dryRunResult: z.string().optional(),
+  /** Human-readable verdict reason (scrubbed). */
+  reason: z.string(),
+});
+export type RemediationSoakRecord = z.infer<typeof RemediationSoakRecordSchema>;
+
+/**
+ * Retention cap for the durable soak sink. Generous enough to accumulate a real
+ * multi-week soak while bounding disk usage (oldest-evicted, #3762 Contrarian
+ * condition). Override is intentionally NOT an env var — a fixed bound keeps the
+ * evidence file size predictable for the readiness collector (#3764).
+ */
+export const SOAK_MAX_RECORDS = 10_000;
+
+/** JSONL file under NEXUS_DATA_DIR holding the durable audit-mode soak evidence. */
+export function getRemediationSoakFile(): string {
+  return nexusDataPath('learning', 'remediation-soak.jsonl');
+}
+
+/**
+ * Redact any secret in a soak record's free-text fields before it is persisted.
+ * On a hit the value is replaced with a value-free marker naming the matched
+ * pattern(s) — the record stays useful as evidence without leaking the secret.
+ */
+export function scrubSoakRecord(record: RemediationSoakRecord): RemediationSoakRecord {
+  const scrub = (text: string): string => {
+    const result = scanForSecrets(text);
+    if (result.clean) return text;
+    return `[redacted: ${describeSecretFindings(result)}]`;
+  };
+  const scrubbed: RemediationSoakRecord = {
+    ...record,
+    reason: scrub(record.reason),
+    ...(record.dryRunResult !== undefined ? { dryRunResult: scrub(record.dryRunResult) } : {}),
+  };
+  return scrubbed;
+}
+
+/** Durable sink for audit-mode soak records. Scrubs + persists; never throws. */
+export interface RemediationSoakSink {
+  record(record: RemediationSoakRecord): void;
+}
+
+/** A {@link RemediationSoakSink} that also exposes its persisted records. */
+export interface IRecordingRemediationSoakSink extends RemediationSoakSink {
+  getRecords(): readonly RemediationSoakRecord[];
+}
+
+/**
+ * Create a durable soak sink backed by an append-only JSONL file (reuses the
+ * shared {@link JsonlStore} primitive — hydrate-on-construct, append-on-write,
+ * Zod-validate each line, oldest-eviction at {@link SOAK_MAX_RECORDS}).
+ * Records are secret-scrubbed before they hit disk.
+ */
+export function createRemediationSoakSink(
+  filePath: string = getRemediationSoakFile(),
+  maxRecords: number = SOAK_MAX_RECORDS
+): IRecordingRemediationSoakSink {
+  const store = new JsonlStore<RemediationSoakRecord>({
+    filePath,
+    schema: RemediationSoakRecordSchema,
+    maxRecords,
+    component: 'RemediationSoakSink',
+  });
+  return {
+    record(record: RemediationSoakRecord): void {
+      store.append(scrubSoakRecord(record));
+    },
+    getRecords(): readonly RemediationSoakRecord[] {
+      return store.all();
+    },
+  };
+}
+
+let soakSingleton: IRecordingRemediationSoakSink | undefined;
+
+/** Process-wide durable soak sink (lazily constructed, hydrates from disk). */
+export function getRemediationSoakSink(): IRecordingRemediationSoakSink {
+  soakSingleton ??= createRemediationSoakSink();
+  return soakSingleton;
+}
+
+/** Test helper — drops the cached singleton so a fresh NEXUS_DATA_DIR is picked up. */
+export function _resetRemediationSoakSinkForTests(): void {
+  soakSingleton = undefined;
+}
+
+/**
+ * Aggregate summary over persisted soak records — the read surface the #3764
+ * readiness collector (and a human) consume. Reports counts by verdict, the
+ * approval rate over signals that reached a vote, and per-category/per-priority
+ * breakdowns. Pure over its input; does no I/O.
+ */
+export interface RemediationSoakSummary {
+  /** Total soak records. */
+  readonly total: number;
+  /** How many reached a consensus vote. */
+  readonly voted: number;
+  /** Approved votes. */
+  readonly approved: number;
+  /** Rejected votes (voted − approved). */
+  readonly rejected: number;
+  /** approved / voted, or 0 when nothing was voted. */
+  readonly approvalRate: number;
+  /** How many p0 dry-runs were captured. */
+  readonly dryRunsCaptured: number;
+  readonly byCategory: Readonly<Record<string, number>>;
+  readonly byPriority: Readonly<Record<string, number>>;
+  /** ISO timestamp of the first / last record, if any. */
+  readonly firstTimestamp?: string;
+  readonly lastTimestamp?: string;
+}
+
+/** Mutable accumulator for the soak summary tallies. */
+interface SoakTally {
+  byCategory: Record<string, number>;
+  byPriority: Record<string, number>;
+  voted: number;
+  approved: number;
+  dryRunsCaptured: number;
+}
+
+/** Fold one record into the running tally. */
+function tallySoakRecord(t: SoakTally, r: RemediationSoakRecord): void {
+  t.byCategory[r.category] = (t.byCategory[r.category] ?? 0) + 1;
+  t.byPriority[r.priority] = (t.byPriority[r.priority] ?? 0) + 1;
+  if (r.voteOutcome !== undefined) {
+    t.voted++;
+    if (r.voteOutcome.approved) t.approved++;
+  }
+  if (r.dryRunResult !== undefined) t.dryRunsCaptured++;
+}
+
+/** Summarize soak records for the readiness gate (#3764). */
+export function summarizeRemediationSoak(
+  records: readonly RemediationSoakRecord[]
+): RemediationSoakSummary {
+  const t: SoakTally = {
+    byCategory: {},
+    byPriority: {},
+    voted: 0,
+    approved: 0,
+    dryRunsCaptured: 0,
+  };
+  for (const r of records) tallySoakRecord(t, r);
+  const first = records[0]?.timestamp;
+  const last = records[records.length - 1]?.timestamp;
+  return {
+    total: records.length,
+    voted: t.voted,
+    approved: t.approved,
+    rejected: t.voted - t.approved,
+    approvalRate: t.voted === 0 ? 0 : t.approved / t.voted,
+    dryRunsCaptured: t.dryRunsCaptured,
+    byCategory: t.byCategory,
+    byPriority: t.byPriority,
+    ...(first !== undefined ? { firstTimestamp: first } : {}),
+    ...(last !== undefined ? { lastTimestamp: last } : {}),
+  };
+}
+
+/** Read + summarize the durable soak evidence from disk (convenience for #3764). */
+export function readRemediationSoakSummary(
+  sink: IRecordingRemediationSoakSink = getRemediationSoakSink()
+): RemediationSoakSummary {
+  return summarizeRemediationSoak(sink.getRecords());
+}
+
+// ============================================================================
+// Audit-branch wiring (#3762) — turn per-step audit events into soak records.
+// ============================================================================
+
+/** The per-step audit event shape emitted by runAutoRemediation. */
+export interface SoakAuditEvent {
+  readonly step: string;
+  readonly signalKey?: string;
+  readonly detail: string;
+}
+
+/** Look up a signal's category/priority/severity for the soak record. */
+export interface SoakSignalMeta {
+  readonly category: string;
+  readonly priority: string;
+  readonly severity: string;
+}
+
+/**
+ * An audit collector that turns the discrete per-step audit events
+ * (`plan` / `vote` / `dry-run` / `skip` / …) emitted by `runAutoRemediation`
+ * into one durable {@link RemediationSoakRecord} per signal, then persists them
+ * via the durable sink on {@link flush}. This is the bridge that makes AUDIT
+ * mode produce queryable, cross-run evidence instead of only `logger.info`.
+ *
+ * It accumulates by `signalKey` so a signal's plan-step count, vote tally, and
+ * dry-run result land in the SAME record. Records are flushed (persisted) at the
+ * end of the run. Never throws — observability must not break remediation.
+ */
+export interface RemediationSoakCollector {
+  /** Feed one audit event (call from the wrapped `audit` callback). */
+  observe(event: SoakAuditEvent): void;
+  /** Persist all accumulated per-signal records to the durable sink. */
+  flush(): readonly RemediationSoakRecord[];
+}
+
+/** Mutable per-signal accumulator. */
+interface SoakDraft {
+  signalKey: string;
+  planStepCount: number;
+  voteOutcome?: SoakVoteOutcome;
+  dryRunResult?: string;
+  reason: string;
+}
+
+/** Parse `"unanimous: approved (100%)"` → vote outcome. Returns undefined if unparseable. */
+function parseVoteDetail(detail: string): SoakVoteOutcome | undefined {
+  const approved = /\bapproved\b/.test(detail);
+  const rejected = /\brejected\b/.test(detail);
+  if (!approved && !rejected) return undefined;
+  const pct = /(\d+(?:\.\d+)?)%/.exec(detail);
+  return {
+    approved,
+    approvalPercentage: pct?.[1] !== undefined ? Number(pct[1]) : approved ? 100 : 0,
+  };
+}
+
+/** Steps whose detail is a terminal verdict reason for the signal. */
+const SOAK_TERMINAL_REASON_STEPS: ReadonlySet<string> = new Set([
+  'skip',
+  'research-failed',
+  'protected-path',
+]);
+
+/** Fold one audit event into the per-signal draft (mutates `d`). */
+function applySoakEvent(d: SoakDraft, event: SoakAuditEvent): void {
+  if (event.step === 'plan') {
+    const n = /(\d+)\s*steps?/.exec(event.detail);
+    d.planStepCount = n?.[1] !== undefined ? Number(n[1]) : 0;
+    if (d.reason === '') d.reason = 'plan produced';
+    return;
+  }
+  if (event.step === 'vote') {
+    const outcome = parseVoteDetail(event.detail);
+    if (outcome !== undefined) d.voteOutcome = outcome;
+    d.reason = event.detail;
+    return;
+  }
+  if (event.step === 'dry-run') {
+    d.dryRunResult = event.detail;
+    return;
+  }
+  // start / abort / pr-opened are not soak verdict inputs and are ignored.
+  if (SOAK_TERMINAL_REASON_STEPS.has(event.step)) d.reason = event.detail;
+}
+
+/** Project a finished draft + its signal meta into a durable soak record. */
+function draftToSoakRecord(
+  d: SoakDraft,
+  meta: SoakSignalMeta | undefined,
+  timestamp: string
+): RemediationSoakRecord {
+  return {
+    timestamp,
+    signalKey: d.signalKey,
+    category: meta?.category ?? 'unknown',
+    priority: meta?.priority ?? 'unknown',
+    severity: meta?.severity ?? 'unknown',
+    ...(d.voteOutcome !== undefined ? { voteOutcome: d.voteOutcome } : {}),
+    planStepCount: d.planStepCount,
+    ...(d.dryRunResult !== undefined ? { dryRunResult: d.dryRunResult } : {}),
+    reason: d.reason === '' ? 'no verdict recorded' : d.reason,
+  };
+}
+
+/**
+ * Build a soak collector. `metaFor` resolves a signal's category/priority/severity
+ * (the audit events only carry the signalKey + detail). `sink` defaults to the
+ * durable singleton; tests inject an isolated one.
+ */
+export function createRemediationSoakCollector(
+  metaFor: (signalKey: string) => SoakSignalMeta | undefined,
+  sink: IRecordingRemediationSoakSink = getRemediationSoakSink()
+): RemediationSoakCollector {
+  const drafts = new Map<string, SoakDraft>();
+  const draftFor = (signalKey: string): SoakDraft => {
+    let d = drafts.get(signalKey);
+    if (d === undefined) {
+      d = { signalKey, planStepCount: 0, reason: '' };
+      drafts.set(signalKey, d);
+    }
+    return d;
+  };
+  return {
+    observe(event: SoakAuditEvent): void {
+      if (event.signalKey === undefined) return; // run-level (start/abort) — not per-signal.
+      applySoakEvent(draftFor(event.signalKey), event);
+    },
+    flush(): readonly RemediationSoakRecord[] {
+      const ts = new Date(getTimeProvider().now()).toISOString();
+      const out: RemediationSoakRecord[] = [];
+      for (const d of drafts.values()) {
+        const record = draftToSoakRecord(d, metaFor(d.signalKey), ts);
+        sink.record(record);
+        out.push(record);
+      }
+      drafts.clear();
+      return out;
+    },
+  };
 }

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-soak.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-soak.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the durable audit-mode soak sink + summarize surface (#3762).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createRemediationSoakSink,
+  scrubSoakRecord,
+  summarizeRemediationSoak,
+  readRemediationSoakSummary,
+  SOAK_MAX_RECORDS,
+  type RemediationSoakRecord,
+} from './improvement-remediation-shadow.js';
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'soak-sink-'));
+  filePath = join(dir, 'learning', 'remediation-soak.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function rec(over: Partial<RemediationSoakRecord> = {}): RemediationSoakRecord {
+  return {
+    timestamp: '2026-06-08T00:00:00.000Z',
+    signalKey: 'routing:cli-floor:codex:docs',
+    category: 'routing',
+    priority: 'p2',
+    severity: 'warning',
+    voteOutcome: { approved: true, approvalPercentage: 100 },
+    planStepCount: 3,
+    reason: 'approved in shadow',
+    ...over,
+  };
+}
+
+describe('durable soak sink', () => {
+  it('round-trips records: write N, reconstruct from disk preserving order', () => {
+    const sink = createRemediationSoakSink(filePath);
+    for (let i = 0; i < 4; i++) {
+      sink.record(
+        rec({ signalKey: `s${String(i)}`, timestamp: `2026-06-08T00:0${String(i)}:00.000Z` })
+      );
+    }
+    expect(sink.getRecords()).toHaveLength(4);
+
+    const reopened = createRemediationSoakSink(filePath);
+    expect(reopened.getRecords().map((r) => r.signalKey)).toEqual(['s0', 's1', 's2', 's3']);
+    expect(reopened.getRecords()[1]?.voteOutcome).toEqual({
+      approved: true,
+      approvalPercentage: 100,
+    });
+  });
+
+  it('bounds retention to the last N records', () => {
+    const sink = createRemediationSoakSink(filePath, 5);
+    for (let i = 0; i < 5 + 3; i++) sink.record(rec({ signalKey: `s${String(i)}` }));
+    expect(sink.getRecords()).toHaveLength(5);
+    expect(sink.getRecords().map((r) => r.signalKey)).toEqual(['s3', 's4', 's5', 's6', 's7']);
+
+    const reopened = createRemediationSoakSink(filePath, 5);
+    expect(reopened.getRecords()).toHaveLength(5);
+    expect(reopened.getRecords()[0]?.signalKey).toBe('s3');
+  });
+
+  it('SOAK_MAX_RECORDS is a generous, finite bound', () => {
+    expect(SOAK_MAX_RECORDS).toBeGreaterThanOrEqual(1000);
+    expect(Number.isFinite(SOAK_MAX_RECORDS)).toBe(true);
+  });
+});
+
+describe('secret-scrub before persistence', () => {
+  it('redacts a secret in the reason field before write', () => {
+    const leaky = rec({
+      reason: 'token=ghp_0123456789012345678901234567890123456789 leaked',
+    });
+    const scrubbed = scrubSoakRecord(leaky);
+    expect(scrubbed.reason).not.toContain('ghp_');
+    expect(scrubbed.reason).toContain('[redacted:');
+  });
+
+  it('redacts a secret in dryRunResult before write', () => {
+    const leaky = rec({
+      dryRunResult: 'AKIAIOSFODNN7EXAMPLE found in fixture',
+    });
+    const scrubbed = scrubSoakRecord(leaky);
+    expect(scrubbed.dryRunResult).not.toContain('AKIA');
+    expect(scrubbed.dryRunResult).toContain('[redacted:');
+  });
+
+  it('a record with a secret never reaches disk un-redacted', () => {
+    const sink = createRemediationSoakSink(filePath);
+    sink.record(rec({ reason: 'leak AKIAIOSFODNN7EXAMPLE here' }));
+    const reopened = createRemediationSoakSink(filePath);
+    const persisted = reopened.getRecords()[0];
+    expect(persisted?.reason).not.toContain('AKIA');
+    expect(persisted?.reason).toContain('[redacted:');
+  });
+
+  it('leaves clean fields untouched', () => {
+    const clean = rec({ reason: 'approved supermajority (86%)' });
+    expect(scrubSoakRecord(clean).reason).toBe('approved supermajority (86%)');
+  });
+});
+
+describe('summarizeRemediationSoak', () => {
+  it('computes counts, approval rate, and breakdowns over fixtures', () => {
+    const records: RemediationSoakRecord[] = [
+      rec({
+        category: 'routing',
+        priority: 'p2',
+        voteOutcome: { approved: true, approvalPercentage: 100 },
+      }),
+      rec({
+        category: 'bug',
+        priority: 'p1',
+        voteOutcome: { approved: false, approvalPercentage: 40 },
+      }),
+      rec({
+        category: 'bug',
+        priority: 'p0',
+        voteOutcome: { approved: true, approvalPercentage: 100 },
+        dryRunResult: 'ok',
+      }),
+      rec({
+        category: 'tech-debt',
+        priority: 'p3',
+        voteOutcome: undefined,
+        planStepCount: 0,
+        reason: 'research failed',
+      }),
+    ];
+    const s = summarizeRemediationSoak(records);
+    expect(s.total).toBe(4);
+    expect(s.voted).toBe(3);
+    expect(s.approved).toBe(2);
+    expect(s.rejected).toBe(1);
+    expect(s.approvalRate).toBeCloseTo(2 / 3, 5);
+    expect(s.dryRunsCaptured).toBe(1);
+    expect(s.byCategory).toEqual({ routing: 1, bug: 2, 'tech-debt': 1 });
+    expect(s.byPriority).toEqual({ p2: 1, p1: 1, p0: 1, p3: 1 });
+  });
+
+  it('handles the empty case without NaN', () => {
+    const s = summarizeRemediationSoak([]);
+    expect(s.total).toBe(0);
+    expect(s.approvalRate).toBe(0);
+    expect(s.firstTimestamp).toBeUndefined();
+  });
+
+  it('readRemediationSoakSummary reads from the sink', () => {
+    const sink = createRemediationSoakSink(filePath);
+    sink.record(rec({ voteOutcome: { approved: true, approvalPercentage: 90 } }));
+    sink.record(rec({ voteOutcome: { approved: false, approvalPercentage: 20 } }));
+    const s = readRemediationSoakSummary(sink);
+    expect(s.total).toBe(2);
+    expect(s.approvalRate).toBeCloseTo(0.5, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Audit-mode auto-remediation now produces **durable, queryable evidence** for the enforce-by-default decision gate instead of only `logger.info`. This is the foundational soak-data surface the #3764 readiness collector consumes.

Closes #3762. Part of #3653 (autonomous remediation arc) and the decision-gate evidence for #3540.

## What changed (Option A, ratified 6-1 — all conditions applied)

1. **Shared JSONL primitive** — `config/jsonl-store.ts` factors the hydrate-on-construct / append-on-write / Zod-validate-each-line **mechanism** out of `PersistentOutcomeStore` so durable sinks don't each fork the same fs plumbing. Not a parallel persistence framework — a thin generic wrapper over the exact calls the outcome store already makes (Scope Steward condition).
2. **Durable soak sink** — extends the remediation-observability concern in `improvement-remediation-shadow.ts` with `RemediationSoakRecord` (`{timestamp, signalKey, category, priority, severity, voteOutcome (approved + tally), planStepCount, dryRunResult, reason}`) persisted to `NEXUS_DATA_DIR/learning/remediation-soak.jsonl`.
3. **Secret-scrub** — `reason` + `dryRunResult` are scrubbed via `scanForSecrets` / `describeSecretFindings` before persistence; a hit redacts the field to a value-free marker. Persisted evidence never carries a secret (Security condition).
4. **Bounded retention** — last **10,000** records, oldest-evicted with file rewrite; also trims an over-cap file on hydrate. No unbounded disk growth (Contrarian condition). Fixed cap (no new env var) keeps file size predictable for the readiness collector.
5. **Read/summarize surface** — `summarizeRemediationSoak` / `readRemediationSoakSummary` return counts by verdict, approval rate, and category/priority breakdowns for #3764 (built the surface, not #3764 itself).
6. **Audit-branch wiring** — `auto-remediation-cycle.ts` wraps the audit-mode `deps.audit` callback so per-step events also build per-signal soak records, flushed to the durable sink at run end.

## Tests (red→green, TDD)

- `config/jsonl-store.test.ts` — append+hydrate round-trip, parent-dir creation, malformed/schema-invalid line tolerance, boundary-invalid-record rejection, retention bound, over-cap hydrate trim.
- `improvement-remediation-soak.test.ts` — durable round-trip, retention bound, secret-scrub (reason + dryRunResult + never-reaches-disk-un-redacted), summarize over fixtures + empty case.
- `auto-remediation-cycle.test.ts` — audit cycle writes one durable record per signal; rejected-vote verdict captured durably. Honors a temp `NEXUS_DATA_DIR` via injected sink.

39 tests pass across the new + touched suites (109 across the broader remediation area). `tsc --noEmit`, `eslint`, `governance:check`, `check-registry-coverage`, `generate-repo-index --check` all green. Zero `any` (Zod at the boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)