### PR TITLE
feat(capability-loop): wire enforce-gate readiness evidence chain (#3765, #3764)

### DIFF
--- a/.changeset/readiness-evidence-collector.md
+++ b/.changeset/readiness-evidence-collector.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+Wire the enforce-decision-gate readiness evidence chain (#3765, #3764 — part of #3653/#3540).
+
+- #3765: durable soundness-review surface — a `JsonlStore`-backed review-record store
+  (secret-scrubbed `note`), a `summarizeRemediationReviews` aggregate, and a new
+  `nexus-agents remediation-review` CLI command (`list` pending soak selections,
+  `mark <soakRef> --evaluator <name> --sound|--unsound`, `sign-off --owner <name>`).
+- #3764: `buildEnforceReadinessEvidence` collector that builds `EnforceReadinessEvidence`
+  from the durable soak (#3762) + review summaries, now wired as the `readiness` provider
+  in `buildAutoRemediationDeps` — replacing the hardcoded `NOT_READY`. Fail-closed:
+  missing/zero data keeps enforce blocked; audit mode never consults readiness.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-06-09T01:13:38.576Z",
+  "generated": "2026-06-09T01:25:23.810Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.126.0",
   "cli": {
@@ -172,6 +172,12 @@
         "name": "release-validate",
         "type": "async",
         "handler": "handleReleaseValidateCommand",
+        "file": "src/cli-commands-handlers.ts"
+      },
+      {
+        "name": "remediation-review",
+        "type": "async",
+        "handler": "handleRemediationReviewCommand",
         "file": "src/cli-commands-handlers.ts"
       },
       {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-06-09T01:13:38.576Z
+**Generated:** 2026-06-09T01:25:23.810Z
 **Package Version:** 2.126.0
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CLI Commands (50)
+## CLI Commands (51)
 
 Binary: `nexus-agents`
 
@@ -43,6 +43,7 @@ Binary: `nexus-agents`
 | `release-announce` | async | `handleReleaseAnnounceCommand` | `src/cli-commands-handlers.ts` |
 | `release-notes` | async | `handleReleaseNotesCommand` | `src/cli-commands-handlers.ts` |
 | `release-validate` | async | `handleReleaseValidateCommand` | `src/cli-commands-handlers.ts` |
+| `remediation-review` | async | `handleRemediationReviewCommand` | `src/cli-commands-handlers.ts` |
 | `research` | async | `handleResearchCommand` | `src/cli-commands-handlers.ts` |
 | `review` | async | `handleReviewCommand` | `src/cli-commands-handlers.ts` |
 | `routing-ab` | sync | `handleRoutingABCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -208,6 +208,12 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
       'Run one auto-remediation cycle (#3540). OFF unless NEXUS_AUTO_REMEDIATE=audit|enforce; never auto-merges.',
     audience: 'maintainer',
   },
+  {
+    command: 'remediation-review',
+    description:
+      'Soundness-review audit-mode selections (#3765): list pending · mark --evaluator --sound|--unsound · sign-off --owner.',
+    audience: 'maintainer',
+  },
 
   // ── Maintainer (hidden by default) ───────────────────────────────────────
   {

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -129,6 +129,8 @@ import { handleUsageCommand } from './cli/usage-command.js';
 // Issue #2444: nexus-agents improvement-review — observability-driven improvement loop CLI surface
 import { handleImprovementReviewCommand } from './cli/improvement-review-command.js';
 import { handleAutoRemediateCommand } from './cli/auto-remediate-command.js';
+// #3765: nexus-agents remediation-review — human soundness-review surface (enforce gate evidence)
+import { handleRemediationReviewCommand } from './cli/remediation-review-command.js';
 // Issue #2879 / epic #2872: nexus-agents migrate — relocate homedir state per-repo
 import { handleMigrateCommand } from './cli/migrate-command.js';
 // Issue #637: Release Automation Suite
@@ -259,6 +261,8 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
     'improvement-review': handleImprovementReviewCommand,
     // #3540 phase 3 / #3671: run one auto-remediation cycle (mode from NEXUS_AUTO_REMEDIATE).
     'auto-remediate': handleAutoRemediateCommand,
+    // #3765: human soundness-review surface — produces the enforce-gate readiness evidence.
+    'remediation-review': handleRemediationReviewCommand,
     // Issue #2879 / epic #2872: migrate command (relocate homedir state per-repo)
     migrate: handleMigrateCommand,
     // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -81,7 +81,8 @@ export type CliCommand =
   | 'migrate'
   | 'tour'
   | 'improvement-review'
-  | 'auto-remediate';
+  | 'auto-remediate'
+  | 'remediation-review';
 
 /**
  * Parsed CLI arguments and command.
@@ -177,6 +178,12 @@ export interface ParsedCliArgs {
     // init --opencode <path> flag (#2504)
     opencode?: string;
     validate?: boolean;
+    // remediation-review command options (#3765)
+    evaluator?: string;
+    owner?: string;
+    note?: string;
+    sound?: boolean;
+    unsound?: boolean;
   };
   positionals: string[];
 }
@@ -486,6 +493,24 @@ export const PARSE_ARGS_CONFIG = {
       type: 'boolean' as const,
       default: false,
     },
+    // remediation-review command options (#3765)
+    evaluator: {
+      type: 'string' as const,
+    },
+    owner: {
+      type: 'string' as const,
+    },
+    note: {
+      type: 'string' as const,
+    },
+    sound: {
+      type: 'boolean' as const,
+      default: false,
+    },
+    unsound: {
+      type: 'boolean' as const,
+      default: false,
+    },
   },
   allowPositionals: true,
   strict: true,
@@ -544,6 +569,7 @@ const VALID_COMMANDS: readonly CliCommand[] = [
   'migrate',
   'tour',
   'auto-remediate',
+  'remediation-review',
 ];
 
 /**

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -167,6 +167,12 @@ interface ParsedValues {
   // init --opencode <path> options (#2504)
   opencode?: string;
   validate: boolean;
+  // remediation-review command options (#3765)
+  evaluator?: string;
+  owner?: string;
+  note?: string;
+  sound: boolean;
+  unsound: boolean;
 }
 
 /** Builds orchestrate-specific options. */
@@ -353,6 +359,12 @@ function buildOptions(values: ParsedValues): ParsedCliArgs['options'] {
     mock: values.mock,
     deep: values.deep,
     json: values.json,
+    // remediation-review command options (#3765)
+    sound: values.sound,
+    unsound: values.unsound,
+    ...(values.evaluator !== undefined && { evaluator: values.evaluator }),
+    ...(values.owner !== undefined && { owner: values.owner }),
+    ...(values.note !== undefined && { note: values.note }),
     ...(values.source !== undefined && { source: values.source }),
     ...(values.output !== undefined && { output: values.output }),
     ...(values.input !== undefined && { input: values.input }),

--- a/packages/nexus-agents/src/cli/remediation-review-command.test.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the `remediation-review` CLI handler (#3765) — the human
+ * soundness-review surface: list pending soak selections, mark one
+ * reviewed+sound|unsound by a named evaluator, and record an owner sign-off.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+
+import { handleRemediationReviewCommand } from './remediation-review-command.js';
+import type { ParsedCliArgs } from '../cli-types.js';
+import {
+  createRemediationSoakSink,
+  getRemediationSoakFile,
+  _resetRemediationSoakSinkForTests,
+  type RemediationSoakRecord,
+} from '../mcp/tools/improvement-remediation-shadow.js';
+import {
+  createRemediationReviewStore,
+  getRemediationReviewFile,
+  _resetRemediationReviewStoreForTests,
+  soakRefOf,
+} from '../mcp/tools/remediation-review.js';
+
+function args(
+  subcommand: string | undefined,
+  over: Partial<ParsedCliArgs['options']> = {},
+  positionals: string[] = []
+): ParsedCliArgs {
+  return {
+    command: 'remediation-review',
+    ...(subcommand !== undefined ? { subcommand } : {}),
+    options: { format: 'text', ...over },
+    positionals: [
+      'remediation-review',
+      ...(subcommand !== undefined ? [subcommand] : []),
+      ...positionals,
+    ],
+  } as unknown as ParsedCliArgs;
+}
+
+function seedSoak(): RemediationSoakRecord {
+  const rec: RemediationSoakRecord = {
+    timestamp: '2026-06-08T00:00:00.000Z',
+    signalKey: 'routing:floor:codex',
+    category: 'routing',
+    priority: 'p2',
+    severity: 'warning',
+    planStepCount: 3,
+    reason: 'plan produced',
+  };
+  createRemediationSoakSink(getRemediationSoakFile()).record(rec);
+  return rec;
+}
+
+let dir: string;
+let prevDataDir: string | undefined;
+let out: MockInstance<(buffer: Uint8Array | string) => boolean>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'review-cli-'));
+  prevDataDir = process.env['NEXUS_DATA_DIR'];
+  process.env['NEXUS_DATA_DIR'] = dir;
+  _resetRemediationSoakSinkForTests();
+  _resetRemediationReviewStoreForTests();
+  out = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (prevDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+  else process.env['NEXUS_DATA_DIR'] = prevDataDir;
+  _resetRemediationSoakSinkForTests();
+  _resetRemediationReviewStoreForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function output(): string {
+  return out.mock.calls.map((c) => String(c[0])).join('');
+}
+
+describe('handleRemediationReviewCommand', () => {
+  it('list: shows pending (un-reviewed) soak selections', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(args('list'));
+    expect(output()).toContain(soakRefOf(rec));
+    expect(output()).toContain('1 pending');
+  });
+
+  it('mark: records a reviewed+sound verdict by a named evaluator', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(
+      args('mark', { evaluator: 'alice', sound: true }, [soakRefOf(rec)])
+    );
+    const reviews = createRemediationReviewStore(getRemediationReviewFile()).getRecords();
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.sound).toBe(true);
+    expect(reviews[0]?.evaluator).toBe('alice');
+  });
+
+  it('mark --unsound: records sound=false', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(
+      args('mark', { evaluator: 'alice', unsound: true }, [soakRefOf(rec)])
+    );
+    const reviews = createRemediationReviewStore(getRemediationReviewFile()).getRecords();
+    expect(reviews[0]?.sound).toBe(false);
+  });
+
+  it('mark: requires a named --evaluator (fail-closed)', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await expect(
+      handleRemediationReviewCommand(args('mark', { sound: true }, [soakRefOf(rec)]))
+    ).rejects.toThrow(/evaluator/i);
+  });
+
+  it('mark: rejects when both --sound and --unsound are given', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await expect(
+      handleRemediationReviewCommand(
+        args('mark', { evaluator: 'alice', sound: true, unsound: true }, [soakRefOf(rec)])
+      )
+    ).rejects.toThrow(/sound|unsound/i);
+  });
+
+  it('sign-off: records an owner sign-off carried into the review summary', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(
+      args('mark', { evaluator: 'alice', sound: true }, [soakRefOf(rec)])
+    );
+    _resetRemediationReviewStoreForTests();
+    await handleRemediationReviewCommand(args('sign-off', { owner: 'carol' }));
+    const reviews = createRemediationReviewStore(getRemediationReviewFile()).getRecords();
+    expect(reviews.some((r) => r.owner === 'carol')).toBe(true);
+  });
+
+  it('list reflects that a marked selection is no longer pending', async () => {
+    const rec = seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(
+      args('mark', { evaluator: 'alice', sound: true }, [soakRefOf(rec)])
+    );
+    _resetRemediationReviewStoreForTests();
+    out.mockClear();
+    await handleRemediationReviewCommand(args('list'));
+    expect(output()).toContain('0 pending');
+  });
+});

--- a/packages/nexus-agents/src/cli/remediation-review-command.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.ts
@@ -1,0 +1,166 @@
+/**
+ * `nexus-agents remediation-review` — the human soundness-review surface (#3765).
+ *
+ * The 2nd link in the autonomy enforce-decision-gate evidence chain (#3540 /
+ * #3653). The durable soak (#3762) is the set of audit-mode selections to
+ * review; a NAMED evaluator marks each reviewed + sound|unsound, and a named
+ * owner signs off — producing the `judgedSelections`/`judgedSound`/`evaluator`/
+ * `owner` the readiness collector (#3764) feeds to the enforce gate. Named
+ * evaluator + owner are inherently human acts, so this is a CLI surface.
+ *
+ * Subcommands:
+ *   list                              List pending (un-reviewed) soak selections.
+ *   mark <soakRef> --evaluator <name> (--sound | --unsound) [--note <text>]
+ *                                     Record one reviewed verdict by a named evaluator.
+ *   sign-off --owner <name>           Record an owner sign-off across reviewed selections.
+ *
+ * `--format json` emits structured output. Never flips enforcement on itself.
+ * An optional LLM-judge pre-pass is deferred to #3773 (advisory only — the
+ * named-evaluator criterion needs human confirmation regardless).
+ *
+ * @module cli/remediation-review-command
+ */
+
+import type { ParsedCliArgs } from '../cli-types.js';
+import { getTimeProvider } from '../core/index.js';
+import {
+  getRemediationSoakSink,
+  type RemediationSoakRecord,
+} from '../mcp/tools/improvement-remediation-shadow.js';
+import {
+  getRemediationReviewStore,
+  pendingSoakSelections,
+  soakRefOf,
+  summarizeRemediationReviews,
+  type ReviewRecord,
+} from '../mcp/tools/remediation-review.js';
+
+/** Soak records, projected to the minimal ref-able shape. */
+function soakSelections(): readonly Pick<RemediationSoakRecord, 'signalKey' | 'timestamp'>[] {
+  return getRemediationSoakSink().getRecords();
+}
+
+/** `remediation-review list` — print the pending (un-reviewed) selections. */
+function runList(format: string): void {
+  const reviews = getRemediationReviewStore().getRecords();
+  const pending = pendingSoakSelections(soakSelections(), reviews);
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify({ pending }, null, 2)}\n`);
+    return;
+  }
+  const lines = [`${String(pending.length)} pending soak selection(s) to review:`];
+  for (const p of pending) lines.push(`  ${p.soakRef}  (${p.signalKey})`);
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+/** Resolve the sound verdict from the mutually-exclusive flags. Throws on bad input. */
+function resolveSound(options: ParsedCliArgs['options']): boolean {
+  const sound = options.sound === true;
+  const unsound = options.unsound === true;
+  if (sound && unsound) {
+    throw new Error('remediation-review mark: pass exactly one of --sound or --unsound, not both');
+  }
+  if (!sound && !unsound) {
+    throw new Error('remediation-review mark: pass one of --sound or --unsound');
+  }
+  return sound;
+}
+
+/** Validate the mark inputs, returning the resolved {soakRef, evaluator, sound}. Throws on bad input. */
+function validateMark(args: ParsedCliArgs): {
+  soakRef: string;
+  evaluator: string;
+  sound: boolean;
+} {
+  const soakRef = args.positionals[2];
+  if (soakRef === undefined || soakRef === '') {
+    throw new Error('remediation-review mark: a <soakRef> argument is required (see `list`)');
+  }
+  const evaluator = args.options.evaluator?.trim();
+  if (evaluator === undefined || evaluator === '') {
+    throw new Error('remediation-review mark: a named --evaluator is required');
+  }
+  const sound = resolveSound(args.options);
+  if (!new Set(soakSelections().map(soakRefOf)).has(soakRef)) {
+    throw new Error(`remediation-review mark: unknown soakRef '${soakRef}' (not in the soak)`);
+  }
+  return { soakRef, evaluator, sound };
+}
+
+/** `remediation-review mark <soakRef> --evaluator <name> (--sound|--unsound)`. */
+function runMark(args: ParsedCliArgs): void {
+  const { soakRef, evaluator, sound } = validateMark(args);
+  const owner = args.options.owner?.trim();
+  const record: ReviewRecord = {
+    soakRef,
+    reviewedAt: new Date(getTimeProvider().now()).toISOString(),
+    reviewed: true,
+    sound,
+    evaluator,
+    ...(owner !== undefined && owner !== '' ? { owner } : {}),
+    ...(args.options.note !== undefined && args.options.note !== ''
+      ? { note: args.options.note }
+      : {}),
+  };
+  getRemediationReviewStore().record(record);
+  if (args.options.format === 'json') {
+    process.stdout.write(`${JSON.stringify({ marked: record }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`marked ${soakRef} as ${sound ? 'SOUND' : 'UNSOUND'} by ${evaluator}\n`);
+}
+
+/**
+ * `remediation-review sign-off --owner <name>` — record an owner sign-off. Re-affirms
+ * each already-reviewed selection's latest verdict with the owner attached, so the
+ * review summary's `owner` reflects the named sign-off (summary is last-wins per ref).
+ */
+function runSignOff(args: ParsedCliArgs): void {
+  const owner = args.options.owner?.trim();
+  if (owner === undefined || owner === '') {
+    throw new Error('remediation-review sign-off: a named --owner is required');
+  }
+  const store = getRemediationReviewStore();
+  const existing = store.getRecords();
+  if (existing.length === 0) {
+    throw new Error('remediation-review sign-off: no reviews to sign off (mark selections first)');
+  }
+  // Latest verdict per selection — re-affirm with the owner attached.
+  const latest = new Map<string, ReviewRecord>();
+  for (const r of existing) latest.set(r.soakRef, r);
+  const reviewedAt = new Date(getTimeProvider().now()).toISOString();
+  let count = 0;
+  for (const r of latest.values()) {
+    store.record({ ...r, reviewedAt, owner });
+    count++;
+  }
+  const summary = summarizeRemediationReviews(store.getRecords());
+  if (args.options.format === 'json') {
+    process.stdout.write(`${JSON.stringify({ owner, signedOff: count, summary }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `owner sign-off recorded by ${owner} across ${String(count)} selection(s)\n`
+  );
+}
+
+/** Handle `nexus-agents remediation-review <subcommand>`. */
+export async function handleRemediationReviewCommand(args: ParsedCliArgs): Promise<void> {
+  const sub = args.subcommand ?? 'list';
+  switch (sub) {
+    case 'list':
+      runList(args.options.format);
+      break;
+    case 'mark':
+      runMark(args);
+      break;
+    case 'sign-off':
+      runSignOff(args);
+      break;
+    default:
+      throw new Error(
+        `remediation-review: unknown subcommand '${sub}' (expected list | mark | sign-off)`
+      );
+  }
+  return Promise.resolve();
+}

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.test.ts
@@ -4,12 +4,28 @@
  * not-ready readiness, null lease when unconfigured).
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, it, expect, vi } from 'vitest';
 import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
 import { runAutoRemediation } from './improvement-remediation-enforce.js';
 import { RemediationGuard } from './improvement-remediation-guard.js';
 import { parseRemediationPlan, CapabilityLedger } from './improvement-remediation-capability.js';
 import type { ImprovementSignal } from './improvement-review.js';
+import {
+  createRemediationSoakSink,
+  getRemediationSoakFile,
+  _resetRemediationSoakSinkForTests,
+  type RemediationSoakRecord,
+} from './improvement-remediation-shadow.js';
+import {
+  createRemediationReviewStore,
+  getRemediationReviewFile,
+  _resetRemediationReviewStoreForTests,
+  soakRefOf,
+} from './remediation-review.js';
 
 function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
   return {
@@ -56,10 +72,85 @@ describe('buildAutoRemediationDeps', () => {
     expect(await deps.acquireLease('auto-remediation')).toBeNull();
   });
 
-  it('readiness defaults to not-ready (enforce blocked until evidence is wired)', async () => {
-    const deps = buildAutoRemediationDeps();
-    const ev = await deps.readinessEvidence();
-    expect(ev.shadowSelections).toBe(0);
+  it('readiness is fail-closed (not-ready) when no soak/review data exists', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'deps-empty-'));
+    const prev = process.env['NEXUS_DATA_DIR'];
+    process.env['NEXUS_DATA_DIR'] = dir;
+    _resetRemediationSoakSinkForTests();
+    _resetRemediationReviewStoreForTests();
+    try {
+      const deps = buildAutoRemediationDeps();
+      const ev = await deps.readinessEvidence();
+      expect(ev.shadowSelections).toBe(0);
+      expect(ev.judgedSelections).toBe(0);
+      expect(ev.evaluator).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prev;
+      _resetRemediationSoakSinkForTests();
+      _resetRemediationReviewStoreForTests();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('readiness provider returns REAL evidence built from the durable soak + review stores (#3764)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'deps-real-'));
+    const prev = process.env['NEXUS_DATA_DIR'];
+    process.env['NEXUS_DATA_DIR'] = dir;
+    _resetRemediationSoakSinkForTests();
+    _resetRemediationReviewStoreForTests();
+    try {
+      const soakSink = createRemediationSoakSink(getRemediationSoakFile());
+      const soakRecord: RemediationSoakRecord = {
+        timestamp: '2026-06-08T00:00:00.000Z',
+        signalKey: 'routing:floor:codex',
+        category: 'routing',
+        priority: 'p2',
+        severity: 'warning',
+        planStepCount: 3,
+        reason: 'plan produced',
+      };
+      soakSink.record(soakRecord);
+      const reviewStore = createRemediationReviewStore(getRemediationReviewFile());
+      reviewStore.record({
+        soakRef: soakRefOf(soakRecord),
+        reviewedAt: '2026-06-08T01:00:00.000Z',
+        reviewed: true,
+        sound: true,
+        evaluator: 'alice',
+        owner: 'carol',
+      });
+      // Fresh singletons hydrate from the files the provider reads.
+      _resetRemediationSoakSinkForTests();
+      _resetRemediationReviewStoreForTests();
+
+      const deps = buildAutoRemediationDeps();
+      const ev = await deps.readinessEvidence();
+      expect(ev.shadowSelections).toBe(1);
+      expect(ev.judgedSelections).toBe(1);
+      expect(ev.judgedSound).toBe(1);
+      expect(ev.evaluator).toBe('alice');
+      expect(ev.owner).toBe('carol');
+    } finally {
+      if (prev === undefined) delete process.env['NEXUS_DATA_DIR'];
+      else process.env['NEXUS_DATA_DIR'] = prev;
+      _resetRemediationSoakSinkForTests();
+      _resetRemediationReviewStoreForTests();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('audit run does not consult readiness (audit path untouched by the readiness wiring)', async () => {
+    const deps = buildAutoRemediationDeps({
+      voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+    });
+    const readinessSpy = vi.spyOn(deps, 'readinessEvidence');
+    await runAutoRemediation([signal()], deps, {
+      mode: 'audit',
+      now: 0,
+      guard: new RemediationGuard(),
+    });
+    expect(readinessSpy).not.toHaveBeenCalled();
   });
 
   it('drives a full AUDIT run end-to-end on built pieces (soak data, zero writes)', async () => {

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
@@ -6,8 +6,9 @@
  * runs research → consensus vote and stops before IMPLEMENT, so this assembly
  * produces the vote/plan SOAK data the readiness gate needs using only merged
  * pieces. ENFORCE is intentionally NOT yet runnable — `implement` is a
- * fail-closed stub until the Option B proposal-PR adapter lands (#3669), and
- * readiness defaults to not-ready until real evidence is supplied.
+ * fail-closed stub until the Option B proposal-PR adapter lands (#3669).
+ * Readiness now reads REAL evidence from the durable soak (#3762) + soundness-
+ * review (#3765) stores (#3764), fail-closing to not-ready when no data exists.
  *
  * @module mcp/tools/auto-remediation-deps
  */
@@ -23,6 +24,9 @@ import {
   makeGhPrCreator,
 } from './remediation-proposal-pr.js';
 import type { EnforceReadinessEvidence } from './improvement-enforce-readiness.js';
+import { readRemediationSoakSummary } from './improvement-remediation-shadow.js';
+import { readRemediationReviewSummary } from './remediation-review.js';
+import { buildEnforceReadinessEvidence } from './remediation-readiness-collector.js';
 
 /** Options for assembling the deps. */
 export interface AutoRemediationDepsOptions {
@@ -41,12 +45,33 @@ export interface AutoRemediationDepsOptions {
   readonly logger?: ILogger;
 }
 
-/** Evidence that fails the readiness gate — the safe default until real data is wired. */
+/** Evidence that fails the readiness gate — the fail-closed fallback when no data exists. */
 const NOT_READY: EnforceReadinessEvidence = {
   shadowSelections: 0,
   judgedSelections: 0,
   judgedSound: 0,
 };
+
+/**
+ * The real readiness provider (#3764): builds {@link EnforceReadinessEvidence}
+ * from the durable soak (#3762) + soundness-review (#3765) stores on disk.
+ * FAIL-CLOSED: if either read fails, or no data exists, it returns
+ * {@link NOT_READY} so enforce stays blocked. Audit mode never calls this
+ * (readiness is only consulted on the enforce path), so reading the stores here
+ * cannot change audit behavior.
+ */
+function collectReadinessEvidence(logger: ILogger): Promise<EnforceReadinessEvidence> {
+  try {
+    const soak = readRemediationSoakSummary();
+    const reviews = readRemediationReviewSummary();
+    return Promise.resolve(buildEnforceReadinessEvidence(soak, reviews));
+  } catch (error: unknown) {
+    logger.warn('readiness evidence collection failed — fail-closed to NOT_READY', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return Promise.resolve(NOT_READY);
+  }
+}
 
 /**
  * Assemble {@link AutoRemediationDeps} from the merged adapters. Audit-ready;
@@ -87,7 +112,7 @@ export function buildAutoRemediationDeps(
     vote: makeVoteAdapter(opts.voteRunner, logger),
     acquireLease,
     readinessEvidence:
-      opts.readiness ?? ((): Promise<EnforceReadinessEvidence> => Promise.resolve(NOT_READY)),
+      opts.readiness ?? ((): Promise<EnforceReadinessEvidence> => collectReadinessEvidence(logger)),
     implement,
     audit: (event): void => {
       logger.info(`[auto-remediation] ${event.step}`, {

--- a/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the readiness-evidence collector (#3764) — builds
+ * EnforceReadinessEvidence from the durable soak (#3762) + review (#3765)
+ * summaries, and proves the fail-closed default.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildEnforceReadinessEvidence } from './remediation-readiness-collector.js';
+import { evaluateEnforceReadiness } from './improvement-enforce-readiness.js';
+import type { RemediationSoakSummary } from './improvement-remediation-shadow.js';
+import type { RemediationReviewSummary } from './remediation-review.js';
+
+function soak(total: number): RemediationSoakSummary {
+  return {
+    total,
+    voted: total,
+    approved: total,
+    rejected: 0,
+    approvalRate: total === 0 ? 0 : 1,
+    dryRunsCaptured: 0,
+    byCategory: {},
+    byPriority: {},
+  };
+}
+
+describe('buildEnforceReadinessEvidence', () => {
+  it('maps soak total → shadowSelections and review counts/evaluator/owner', () => {
+    const reviews: RemediationReviewSummary = {
+      judgedSelections: 18,
+      judgedSound: 17,
+      evaluator: 'alice',
+      owner: 'carol',
+    };
+    const evidence = buildEnforceReadinessEvidence(soak(20), reviews);
+    expect(evidence.shadowSelections).toBe(20);
+    expect(evidence.judgedSelections).toBe(18);
+    expect(evidence.judgedSound).toBe(17);
+    expect(evidence.evaluator).toBe('alice');
+    expect(evidence.owner).toBe('carol');
+  });
+
+  it('produces evidence that PASSES the readiness gate when criteria are met', () => {
+    const reviews: RemediationReviewSummary = {
+      judgedSelections: 18,
+      judgedSound: 17,
+      evaluator: 'alice',
+      owner: 'carol',
+    };
+    const evidence = buildEnforceReadinessEvidence(soak(20), reviews);
+    expect(evaluateEnforceReadiness(evidence).ready).toBe(true);
+  });
+
+  it('FAIL-CLOSED: no reviews → judged 0 → readiness not ready', () => {
+    const reviews: RemediationReviewSummary = { judgedSelections: 0, judgedSound: 0 };
+    const evidence = buildEnforceReadinessEvidence(soak(20), reviews);
+    expect(evidence.judgedSelections).toBe(0);
+    const report = evaluateEnforceReadiness(evidence);
+    expect(report.ready).toBe(false);
+    expect(report.blockers).toContain('judged-coverage');
+  });
+
+  it('FAIL-CLOSED: empty soak + empty reviews → not ready', () => {
+    const evidence = buildEnforceReadinessEvidence(soak(0), {
+      judgedSelections: 0,
+      judgedSound: 0,
+    });
+    expect(evidence.shadowSelections).toBe(0);
+    expect(evaluateEnforceReadiness(evidence).ready).toBe(false);
+  });
+
+  it('omits evaluator/owner when reviews carry none', () => {
+    const evidence = buildEnforceReadinessEvidence(soak(5), {
+      judgedSelections: 0,
+      judgedSound: 0,
+    });
+    expect(evidence.evaluator).toBeUndefined();
+    expect(evidence.owner).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.ts
@@ -1,0 +1,42 @@
+/**
+ * Readiness-evidence collector (#3764) — the 3rd link in the autonomy
+ * enforce-decision-gate evidence chain (#3540 / #3653).
+ *
+ * Builds the {@link EnforceReadinessEvidence} that {@link evaluateEnforceReadiness}
+ * consumes, from two durable, secret-scrubbed surfaces that just landed:
+ *  - the soak summary (#3762) → `shadowSelections` (audit-mode would-remediate count);
+ *  - the soundness-review summary (#3765) → `judgedSelections` / `judgedSound` /
+ *    `evaluator` / `owner`.
+ *
+ * This replaces the hardcoded `NOT_READY` producer in `auto-remediation-deps.ts`.
+ * FAIL-CLOSED by construction: with no review data, `judgedSelections` is 0 →
+ * the judged-coverage criterion fails → enforce stays blocked. It is a pure
+ * projection (the two summaries are the only inputs); the async `readiness()`
+ * provider that reads them off disk lives in `auto-remediation-deps.ts`.
+ *
+ * @module mcp/tools/remediation-readiness-collector
+ */
+
+import type { EnforceReadinessEvidence } from './improvement-enforce-readiness.js';
+import type { RemediationSoakSummary } from './improvement-remediation-shadow.js';
+import type { RemediationReviewSummary } from './remediation-review.js';
+
+/**
+ * Project the durable soak + review summaries into the evidence the readiness
+ * gate evaluates. Pure; no I/O. `shadowSelections` is the soak total (every
+ * audit-mode selection is a would-remediate observation). Evaluator/owner are
+ * carried through only when present, so the gate's named-evaluator/owner
+ * criteria fail-closed when the human surface has not signed off.
+ */
+export function buildEnforceReadinessEvidence(
+  soak: RemediationSoakSummary,
+  reviews: RemediationReviewSummary
+): EnforceReadinessEvidence {
+  return {
+    shadowSelections: soak.total,
+    judgedSelections: reviews.judgedSelections,
+    judgedSound: reviews.judgedSound,
+    ...(reviews.evaluator !== undefined ? { evaluator: reviews.evaluator } : {}),
+    ...(reviews.owner !== undefined ? { owner: reviews.owner } : {}),
+  };
+}

--- a/packages/nexus-agents/src/mcp/tools/remediation-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-review.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the soundness-review surface (#3765) — durable review-record store,
+ * secret-scrub, and the summarize surface the readiness collector (#3764) reads.
+ */
+
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  ReviewRecordSchema,
+  createRemediationReviewStore,
+  scrubReviewRecord,
+  summarizeRemediationReviews,
+  type ReviewRecord,
+} from './remediation-review.js';
+
+function mkRecord(over: Partial<ReviewRecord> = {}): ReviewRecord {
+  return {
+    soakRef: 'signal-A::2026-06-08T00:00:00.000Z',
+    reviewedAt: '2026-06-08T01:00:00.000Z',
+    reviewed: true,
+    sound: true,
+    evaluator: 'alice',
+    ...over,
+  };
+}
+
+describe('ReviewRecordSchema', () => {
+  it('accepts a valid record', () => {
+    expect(ReviewRecordSchema.safeParse(mkRecord()).success).toBe(true);
+  });
+
+  it('rejects a record missing the evaluator', () => {
+    const bad = { ...mkRecord() } as Record<string, unknown>;
+    delete bad['evaluator'];
+    expect(ReviewRecordSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('scrubReviewRecord', () => {
+  it('redacts a secret in the note while leaving clean fields intact', () => {
+    const withSecret = mkRecord({
+      note: 'token ghp_0123456789abcdefghijklmnopqrstuvwxyz0 leaked',
+    });
+    const scrubbed = scrubReviewRecord(withSecret);
+    expect(scrubbed.note).toContain('[redacted:');
+    expect(scrubbed.note).not.toContain('ghp_0123456789');
+    expect(scrubbed.evaluator).toBe('alice');
+  });
+
+  it('leaves a clean note untouched and is a no-op when note is absent', () => {
+    expect(scrubReviewRecord(mkRecord({ note: 'looks fine' })).note).toBe('looks fine');
+    expect(scrubReviewRecord(mkRecord()).note).toBeUndefined();
+  });
+});
+
+describe('createRemediationReviewStore round-trip', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'review-store-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('persists a review and re-hydrates it on reconstruct', () => {
+    const path = join(dir, 'reviews.jsonl');
+    const store = createRemediationReviewStore(path);
+    store.record(mkRecord({ soakRef: 'sig-1::t1' }));
+    expect(existsSync(path)).toBe(true);
+
+    const reloaded = createRemediationReviewStore(path);
+    expect(reloaded.getRecords()).toHaveLength(1);
+    expect(reloaded.getRecords()[0]?.soakRef).toBe('sig-1::t1');
+  });
+
+  it('scrubs a secret in the note before it hits disk', () => {
+    const path = join(dir, 'reviews.jsonl');
+    const store = createRemediationReviewStore(path);
+    store.record(mkRecord({ note: 'aws AKIAIOSFODNN7EXAMPLE here' }));
+    const raw = readFileSync(path, 'utf-8');
+    expect(raw).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(raw).toContain('[redacted:');
+  });
+});
+
+describe('summarizeRemediationReviews', () => {
+  it('counts judged + sound and surfaces the latest evaluator/owner', () => {
+    const records: ReviewRecord[] = [
+      mkRecord({ soakRef: 'a', sound: true, evaluator: 'alice' }),
+      mkRecord({ soakRef: 'b', sound: false, evaluator: 'alice' }),
+      mkRecord({ soakRef: 'c', sound: true, evaluator: 'bob', owner: 'carol' }),
+    ];
+    const summary = summarizeRemediationReviews(records);
+    expect(summary.judgedSelections).toBe(3);
+    expect(summary.judgedSound).toBe(2);
+    expect(summary.evaluator).toBe('bob');
+    expect(summary.owner).toBe('carol');
+  });
+
+  it('returns zeros and no evaluator/owner for an empty set (fail-closed)', () => {
+    const summary = summarizeRemediationReviews([]);
+    expect(summary.judgedSelections).toBe(0);
+    expect(summary.judgedSound).toBe(0);
+    expect(summary.evaluator).toBeUndefined();
+    expect(summary.owner).toBeUndefined();
+  });
+
+  it('dedupes by soakRef keeping the latest review per selection', () => {
+    const records: ReviewRecord[] = [
+      mkRecord({ soakRef: 'a', sound: false, reviewedAt: '2026-06-08T01:00:00.000Z' }),
+      mkRecord({ soakRef: 'a', sound: true, reviewedAt: '2026-06-08T02:00:00.000Z' }),
+    ];
+    const summary = summarizeRemediationReviews(records);
+    expect(summary.judgedSelections).toBe(1);
+    expect(summary.judgedSound).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/remediation-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-review.ts
@@ -1,0 +1,198 @@
+/**
+ * Soundness-review surface for audit-mode remediation selections (#3765).
+ *
+ * The 2nd link in the autonomy enforce-decision-gate evidence chain (#3540 /
+ * #3653). The durable soak (#3762) is the set of selections to review; this
+ * module records a NAMED-EVALUATOR's verdict (reviewed + sound|unsound) and an
+ * owner sign-off for each, then summarizes them into the
+ * `judgedSelections`/`judgedSound`/`evaluator`/`owner` the readiness collector
+ * (#3764) feeds to {@link evaluateEnforceReadiness}.
+ *
+ * Why a human surface: the readiness exit criterion (#3612) requires a *named*
+ * evaluator and owner — an inherently human act. An LLM-judge pre-pass is
+ * deliberately deferred to #3773 (still needs human confirmation regardless).
+ *
+ * Persistence reuses the shared {@link JsonlStore} primitive — no parallel
+ * persistence path. Free-text (`note`) is secret-scrubbed before persist.
+ *
+ * @module mcp/tools/remediation-review
+ */
+
+import { z } from 'zod';
+
+import { JsonlStore } from '../../config/jsonl-store.js';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
+import { scanForSecrets, describeSecretFindings } from './diff-secret-scan.js';
+import type { RemediationSoakRecord } from './improvement-remediation-shadow.js';
+
+/**
+ * A reference uniquely identifying the soak selection a review applies to:
+ * `signalKey::timestamp`. Stable across runs (the soak record's own coordinates).
+ */
+export function soakRefOf(record: Pick<RemediationSoakRecord, 'signalKey' | 'timestamp'>): string {
+  return `${record.signalKey}::${record.timestamp}`;
+}
+
+/**
+ * One durable soundness-review verdict for a single audit-mode soak selection.
+ * `note` is free-text and secret-scrubbed before persist (see
+ * {@link scrubReviewRecord}).
+ */
+export const ReviewRecordSchema = z.object({
+  /** Reference to the reviewed soak selection (`signalKey::timestamp`). */
+  soakRef: z.string(),
+  /** ISO-8601 time the review was recorded. */
+  reviewedAt: z.string(),
+  /** Always true — a persisted record is, by construction, a review. */
+  reviewed: z.literal(true),
+  /** Whether the evaluator assessed the selection SOUND. */
+  sound: z.boolean(),
+  /** Named evaluator who performed the review (required — the gate's named-evaluator criterion). */
+  evaluator: z.string().min(1),
+  /** Named owner accepting enforcement, recorded at sign-off time (optional per record). */
+  owner: z.string().min(1).optional(),
+  /** Free-text note (secret-scrubbed). */
+  note: z.string().optional(),
+});
+export type ReviewRecord = z.infer<typeof ReviewRecordSchema>;
+
+/**
+ * Retention cap for the durable review store. Matches the soak cap so every
+ * soak selection can have a corresponding review without eviction skew (#3762).
+ */
+export const REVIEW_MAX_RECORDS = 10_000;
+
+/** JSONL file under NEXUS_DATA_DIR holding the durable soundness-review verdicts. */
+export function getRemediationReviewFile(): string {
+  return nexusDataPath('learning', 'remediation-reviews.jsonl');
+}
+
+/**
+ * Redact any secret in a review record's `note` before persist. On a hit the
+ * value is replaced with a value-free marker naming the matched pattern(s).
+ */
+export function scrubReviewRecord(record: ReviewRecord): ReviewRecord {
+  if (record.note === undefined) return record;
+  const result = scanForSecrets(record.note);
+  if (result.clean) return record;
+  return { ...record, note: `[redacted: ${describeSecretFindings(result)}]` };
+}
+
+/** Durable store for soundness-review records. Scrubs + persists; never throws. */
+export interface RemediationReviewStore {
+  /** Record (scrub + persist) one review verdict. */
+  record(record: ReviewRecord): void;
+  /** All persisted review records, oldest first. */
+  getRecords(): readonly ReviewRecord[];
+}
+
+/**
+ * Create a durable review store backed by the shared {@link JsonlStore}
+ * (hydrate-on-construct, append-on-write, Zod-validate, oldest-eviction at
+ * {@link REVIEW_MAX_RECORDS}). Records are secret-scrubbed before they hit disk.
+ */
+export function createRemediationReviewStore(
+  filePath: string = getRemediationReviewFile(),
+  maxRecords: number = REVIEW_MAX_RECORDS
+): RemediationReviewStore {
+  const store = new JsonlStore<ReviewRecord>({
+    filePath,
+    schema: ReviewRecordSchema,
+    maxRecords,
+    component: 'RemediationReviewStore',
+  });
+  return {
+    record(record: ReviewRecord): void {
+      store.append(scrubReviewRecord(record));
+    },
+    getRecords(): readonly ReviewRecord[] {
+      return store.all();
+    },
+  };
+}
+
+let reviewSingleton: RemediationReviewStore | undefined;
+
+/** Process-wide durable review store (lazily constructed, hydrates from disk). */
+export function getRemediationReviewStore(): RemediationReviewStore {
+  reviewSingleton ??= createRemediationReviewStore();
+  return reviewSingleton;
+}
+
+/** Test helper — drops the cached singleton so a fresh NEXUS_DATA_DIR is picked up. */
+export function _resetRemediationReviewStoreForTests(): void {
+  reviewSingleton = undefined;
+}
+
+/**
+ * The aggregate the readiness collector (#3764) consumes: how many selections
+ * were judged, how many sound, and the evaluator/owner of record.
+ */
+export interface RemediationReviewSummary {
+  /** Distinct soak selections that have been reviewed. */
+  readonly judgedSelections: number;
+  /** Of those, how many were assessed SOUND. */
+  readonly judgedSound: number;
+  /** Latest named evaluator across reviews (undefined when none). */
+  readonly evaluator?: string;
+  /** Latest named owner sign-off (undefined when none). */
+  readonly owner?: string;
+}
+
+/**
+ * Summarize review records for the readiness gate. Dedupes by `soakRef` keeping
+ * the LATEST review per selection (a selection re-reviewed counts once, with the
+ * newest verdict). The evaluator/owner reported are from the most recent review
+ * that carried them. Pure over its input; does no I/O.
+ */
+export function summarizeRemediationReviews(
+  records: readonly ReviewRecord[]
+): RemediationReviewSummary {
+  // Last-wins per soakRef: later records in the append-ordered log supersede.
+  const latest = new Map<string, ReviewRecord>();
+  for (const r of records) latest.set(r.soakRef, r);
+
+  let judgedSound = 0;
+  let evaluator: string | undefined;
+  let owner: string | undefined;
+  for (const r of records) {
+    // evaluator/owner track append order so the most recent sign-off wins.
+    evaluator = r.evaluator;
+    if (r.owner !== undefined) owner = r.owner;
+  }
+  for (const r of latest.values()) {
+    if (r.sound) judgedSound++;
+  }
+  return {
+    judgedSelections: latest.size,
+    judgedSound,
+    ...(evaluator !== undefined ? { evaluator } : {}),
+    ...(owner !== undefined ? { owner } : {}),
+  };
+}
+
+/** Read + summarize the durable review evidence from disk (convenience for #3764). */
+export function readRemediationReviewSummary(
+  store: RemediationReviewStore = getRemediationReviewStore()
+): RemediationReviewSummary {
+  return summarizeRemediationReviews(store.getRecords());
+}
+
+/**
+ * The soak selections that have NOT yet been reviewed — the pending queue the
+ * CLI `list` surface shows. Pure over its inputs.
+ */
+export function pendingSoakSelections(
+  soak: readonly Pick<RemediationSoakRecord, 'signalKey' | 'timestamp'>[],
+  reviews: readonly ReviewRecord[]
+): readonly { soakRef: string; signalKey: string; timestamp: string }[] {
+  const reviewed = new Set(reviews.map((r) => r.soakRef));
+  const out: { soakRef: string; signalKey: string; timestamp: string }[] = [];
+  for (const s of soak) {
+    const soakRef = soakRefOf(s);
+    if (!reviewed.has(soakRef)) {
+      out.push({ soakRef, signalKey: s.signalKey, timestamp: s.timestamp });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #3765. Closes #3764. Part of #3653 / #3540.

The 2nd + 3rd links in the autonomy enforce-decision-gate evidence chain — building on the durable soak persistence (#3762) that just landed.

## #3765 — soundness-review surface
- `ReviewRecord` Zod schema + a `JsonlStore`-backed durable review store (reuses the shared persistence primitive — no parallel path). Free-text `note` is secret-scrubbed (`scanForSecrets`) before persist.
- New CLI command `nexus-agents remediation-review` (the primary human surface — named-evaluator + owner sign-off are inherently human acts):
  - `list` — pending (un-reviewed) soak selections
  - `mark <soakRef> --evaluator <name> --sound|--unsound [--note <text>]`
  - `sign-off --owner <name>`
  - Fully wired: `CliCommand` union, `VALID_COMMANDS`, parser options, `buildOptions`, command catalog, dispatch map.
- `summarizeRemediationReviews()` → `{ judgedSelections, judgedSound, evaluator, owner }` (last-wins dedupe per `soakRef`).
- Optional LLM-judge pre-pass deferred to #3773 (advisory only — named-evaluator criterion needs human confirmation regardless).

## #3764 — readiness collector
- `buildEnforceReadinessEvidence(soakSummary, reviewSummary)` → `EnforceReadinessEvidence` (`shadowSelections` = soak total; judged/sound/evaluator/owner from reviews).
- Wired as the `readiness` provider in `buildAutoRemediationDeps`, replacing the hardcoded `NOT_READY`. **Fail-closed**: missing/zero data (or a read failure) keeps enforce blocked; readiness is enforce-only so the audit path is untouched.

## Fail-closed proof
`buildEnforceReadinessEvidence(soak(20), { judgedSelections: 0, judgedSound: 0 })` → `evaluateEnforceReadiness(...).ready === false` with `judged-coverage` as a blocker; empty soak + empty reviews → not ready; a deps test seeds soak+review fixtures under a temp `NEXUS_DATA_DIR` and asserts the provider returns real evidence, while an audit-run test asserts `readinessEvidence` is never consulted.

## Tests (red→green) + gates
- New: `remediation-review.test.ts` (round-trip + secret-scrub + summarize), `remediation-readiness-collector.test.ts` (mapping + fail-closed), `remediation-review-command.test.ts` (list/mark/sound/unsound/sign-off + validation), extended `auto-remediation-deps.test.ts` (real-evidence provider + audit-untouched).
- tsc clean · eslint clean (changed files) · affected vitest green · governance:check ✓ · check-registry-coverage ✓ · generate-repo-index regenerated (50→51 CLI commands).
- Changeset (minor) added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)