### PR TITLE
fix(capability-loop): readiness evaluator/owner attribution + boundary tests (#3770)

### DIFF
--- a/.changeset/readiness-evaluator-attribution.md
+++ b/.changeset/readiness-evaluator-attribution.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+fix(capability-loop): derive readiness evaluator/owner deterministically by reviewedAt
+
+The auto-remediation soundness-review summary (#3765) selected the named
+evaluator/owner from the last-appended record rather than the most recent by
+`reviewedAt`, so hydrate/append order could shift the named-evaluator the
+enforce readiness gate reads. Now selected by max `reviewedAt`. Adds a
+regression test for the attribution + exact-boundary (0.8/0.9, `>=`) readiness
+tests. Surfaced by the #3770 adversarial security/QA review.

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
@@ -51,6 +51,23 @@ describe('evaluateEnforceReadiness', () => {
     expect(r.blockers).toContain('soundness');
   });
 
+  it('is ready at EXACTLY the threshold rates (>= boundary — catches an off-by-one flip)', () => {
+    // judged 20/25 = exactly 0.80; sound 18/20 = exactly 0.90; volume 25 ≥ 20.
+    // A `>=`→`>` regression on the gate that authorizes autonomous writes would
+    // flip this to not-ready.
+    const r = evaluateEnforceReadiness(
+      readyEvidence({ shadowSelections: 25, judgedSelections: 20, judgedSound: 18 })
+    );
+    expect(r.ready).toBe(true);
+  });
+
+  it('is ready at EXACTLY the minimum volume (>= boundary)', () => {
+    const r = evaluateEnforceReadiness(
+      readyEvidence({ shadowSelections: 20, judgedSelections: 20, judgedSound: 20 })
+    );
+    expect(r.ready).toBe(true);
+  });
+
   it('soundness fails closed when there are zero reviews (no divide-by-zero pass)', () => {
     const r = evaluateEnforceReadiness(
       readyEvidence({ shadowSelections: 25, judgedSelections: 0, judgedSound: 0 })

--- a/packages/nexus-agents/src/mcp/tools/remediation-review.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-review.test.ts
@@ -109,6 +109,29 @@ describe('summarizeRemediationReviews', () => {
     expect(summary.owner).toBeUndefined();
   });
 
+  it('attributes evaluator/owner by latest reviewedAt, not append order', () => {
+    // Out-of-order array: the newest review by reviewedAt is alice's. A later-
+    // APPENDED but chronologically OLDER bob record must NOT become the gate's
+    // named evaluator/owner (regression guard for the enforce readiness input).
+    const records: ReviewRecord[] = [
+      mkRecord({
+        soakRef: 'a',
+        evaluator: 'alice',
+        owner: 'owner-new',
+        reviewedAt: '2026-06-08T05:00:00.000Z',
+      }),
+      mkRecord({
+        soakRef: 'b',
+        evaluator: 'bob',
+        owner: 'owner-old',
+        reviewedAt: '2026-06-08T02:00:00.000Z',
+      }),
+    ];
+    const summary = summarizeRemediationReviews(records);
+    expect(summary.evaluator).toBe('alice');
+    expect(summary.owner).toBe('owner-new');
+  });
+
   it('dedupes by soakRef keeping the latest review per selection', () => {
     const records: ReviewRecord[] = [
       mkRecord({ soakRef: 'a', sound: false, reviewedAt: '2026-06-08T01:00:00.000Z' }),

--- a/packages/nexus-agents/src/mcp/tools/remediation-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-review.ts
@@ -153,15 +153,25 @@ export function summarizeRemediationReviews(
   for (const r of records) latest.set(r.soakRef, r);
 
   let judgedSound = 0;
-  let evaluator: string | undefined;
-  let owner: string | undefined;
-  for (const r of records) {
-    // evaluator/owner track append order so the most recent sign-off wins.
-    evaluator = r.evaluator;
-    if (r.owner !== undefined) owner = r.owner;
-  }
   for (const r of latest.values()) {
     if (r.sound) judgedSound++;
+  }
+  // evaluator/owner = the attestation from the most RECENT review by reviewedAt,
+  // selected deterministically (not by append/hydrate position) so the
+  // named-evaluator/owner the enforce gate reads can't shift with file order.
+  let evaluator: string | undefined;
+  let owner: string | undefined;
+  let evaluatorAt = '';
+  let ownerAt = '';
+  for (const r of records) {
+    if (r.reviewedAt >= evaluatorAt) {
+      evaluator = r.evaluator;
+      evaluatorAt = r.reviewedAt;
+    }
+    if (r.owner !== undefined && r.reviewedAt >= ownerAt) {
+      owner = r.owner;
+      ownerAt = r.reviewedAt;
+    }
   }
   return {
     judgedSelections: latest.size,


### PR DESCRIPTION
Surfaced by the #3770 adversarial security/QA review of the enforce path.

## The latent bug (both reviewers flagged)
`summarizeRemediationReviews` (#3765) selected the named `evaluator`/`owner` — which feed the enforce **readiness gate** — from the last-*appended* record, not the most recent by `reviewedAt`. Hydrate/append order could shift the named-evaluator the gate reads. Now selected deterministically by max `reviewedAt`, consistent with the per-ref dedup used for judged counts.

## Tests added
- Attribution regression: out-of-order records → evaluator/owner from the latest `reviewedAt` (not append position).
- Exact-boundary readiness: judged 20/25 = 0.80 and sound 18/20 = 0.90 → `ready === true`; volume exactly at min → ready. Catches a `>=`→`>` off-by-one on the gate that authorizes autonomous writes.

tsc clean, 22/22 tests green, lint clean. Part of #3770, #3540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)