### PR TITLE
test(capability-loop): worktree failure-cleanup + breaker trip→reset→resume coverage (#3779)

### DIFF
--- a/.changeset/enforce-qa-hardening-3779.md
+++ b/.changeset/enforce-qa-hardening-3779.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+test(capability-loop): worktree add/commit failure-cleanup + breaker trip→reset→resume coverage (#3779)
+
+Closes the last non-blocking QA-hardening gap from the #3770 enforce-path review.
+Two coverage holes the existing tests left open: (1) `remediation-proposal-pr.ts` — the
+`finally` cleanup lives inside the `try` that opens AFTER `addWorktree` resolves, so an
+`addWorktree` rejection must NOT call `removeWorktree` (no worktree was created) while a
+`commitAll` rejection MUST clean up exactly once with the created worktree path; both are
+now asserted with the injected `WorktreeOps` fakes. (2) `improvement-remediation-enforce.ts`
+— the breaker round-trip (trip → abort → consensus re-vote `reset()` → resume) is now driven
+through the REAL `RemediationCircuitBreaker`, proving a tripped breaker un-trips via `reset()`
+and the enforce run resumes; a broken reset would have stranded enforce permanently-off.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
@@ -220,6 +220,56 @@ describe('runAutoRemediation — enforce', () => {
     expect(breaker.state().consecutiveFailures).toBe(1);
   });
 
+  it('trip → abort → re-vote reset() → resume: a reset breaker re-enables the run (#3779)', async () => {
+    // A broken reset would strand enforce permanently-off after one bad streak.
+    // The recovery path is reset() (wired to the consensus re-vote), NOT a bare
+    // success — recordSuccess clears the streak but never un-trips (see the breaker
+    // unit test). This drives the full round-trip through the real enforce path.
+    const breaker = new RemediationCircuitBreaker({ threshold: 1 });
+
+    // 1. A rejected vote trips the breaker (threshold 1).
+    const { deps: rejecting } = makeDeps({
+      vote: vi.fn(async () => Promise.resolve({ approved: false, approvalPercentage: 10 })),
+    });
+    await runAutoRemediation([signal()], rejecting, {
+      mode: 'enforce',
+      now: 0,
+      guard: new RemediationGuard(),
+      breaker,
+    });
+    expect(breaker.isTripped()).toBe(true);
+
+    // 2. While tripped, the next run auto-reverts to off — aborts before research.
+    const { deps: blocked } = makeDeps();
+    const abortedRun = await runAutoRemediation([signal()], blocked, {
+      mode: 'enforce',
+      now: 0,
+      guard: new RemediationGuard(),
+      breaker,
+    });
+    expect(abortedRun.aborted).toMatch(/circuit breaker tripped/);
+    expect(blocked.research).not.toHaveBeenCalled();
+
+    // 3. The consensus re-vote re-enables the path: reset() un-trips the breaker.
+    breaker.reset();
+    expect(breaker.isTripped()).toBe(false);
+
+    // 4. A subsequent SUCCESS path RESUMES — it remediates and stays healthy
+    //    (recordSuccess keeps the streak clear; no re-trip).
+    const { deps: approving } = makeDeps();
+    const resumed = await runAutoRemediation([signal()], approving, {
+      mode: 'enforce',
+      now: 0,
+      guard: new RemediationGuard(),
+      breaker,
+    });
+    expect(resumed.aborted).toBeUndefined();
+    expect(resumed.remediated).toHaveLength(1);
+    expect(approving.implement).toHaveBeenCalledTimes(1);
+    expect(breaker.isTripped()).toBe(false);
+    expect(breaker.state().consecutiveFailures).toBe(0);
+  });
+
   it('refuses to auto-remediate a plan that targets a protected path (self-mod guard)', async () => {
     const { deps } = makeDeps({
       research: vi.fn(async (s: ImprovementSignal) =>

--- a/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-proposal-pr.test.ts
@@ -102,6 +102,38 @@ describe('makeProposalPrImplementAdapter', () => {
     expect(calls).toContain('remove'); // finally cleanup ran
   });
 
+  it('does NOT clean up a worktree that was never created when addWorktree fails', async () => {
+    const { ops, calls } = fakeOps();
+    (ops.addWorktree as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('add boom'));
+    const implement = makeProposalPrImplementAdapter({ ops, pr: okPr });
+    await expect(implement(plan(), implementLedger())).rejects.toThrow('add boom');
+    // The `finally` lives inside the `try` that opens AFTER addWorktree resolves,
+    // so removeWorktree must never run on a worktree that was never created.
+    expect(ops.removeWorktree).not.toHaveBeenCalled();
+    // Nothing downstream ran either — no write/commit/push, no cleanup.
+    expect(calls).toEqual([]);
+    expect(ops.writeFileIn).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the worktree (once, by path) when commitAll fails after add succeeds', async () => {
+    const { ops, calls } = fakeOps();
+    (ops.commitAll as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('commit boom'));
+    const implement = makeProposalPrImplementAdapter({ ops, pr: okPr });
+    await expect(implement(plan(), implementLedger())).rejects.toThrow('commit boom');
+    // addWorktree resolved, so the `finally` MUST remove the worktree it created —
+    // exactly once, with the path addWorktree returned.
+    expect(ops.removeWorktree).toHaveBeenCalledTimes(1);
+    expect(ops.removeWorktree).toHaveBeenCalledWith(
+      '/wt/auto-remediation_routing-cli-floor-codex-docs'
+    );
+    expect(calls).toEqual([
+      'add:auto-remediation/routing-cli-floor-codex-docs',
+      'write:remediation-plans/routing-cli-floor-codex-docs.md',
+      'remove',
+    ]);
+    expect(ops.pushBranch).not.toHaveBeenCalled(); // never reached push
+  });
+
   it('fail-closes if invoked outside the IMPLEMENT phase (no repo-write capability)', async () => {
     const { ops } = fakeOps();
     const researchLedger = new CapabilityLedger();


### PR DESCRIPTION
Closes #3779 — the last non-blocking QA-hardening child of the #3770 enforce-path review.

Two coverage gaps the existing tests left open (happy path + push-failure cleanup + breaker-abort were already covered; not duplicated):

## `remediation-proposal-pr.test.ts` — worktree failure modes
- **addWorktree rejects** → adapter rejects AND `removeWorktree` is NOT called. The `finally` lives inside the `try` that opens *after* `addWorktree` resolves, so cleanup must not run on a worktree that was never created. Also asserts no downstream write ran.
- **commitAll rejects** (after addWorktree succeeded) → adapter rejects AND `removeWorktree` IS called exactly once with the created worktree path; push is never reached.

## `improvement-remediation-enforce.test.ts` — breaker trip→reset→resume
- Drives the full round-trip through the **real** `RemediationCircuitBreaker`: a rejected vote trips the breaker (threshold 1), the next run aborts before research, `reset()` un-trips, and a subsequent success path **resumes** (remediates, stays healthy). A broken reset would strand enforce permanently-off.

### Breaker reset finding (verified against `remediation-circuit-breaker.ts`)
`reset()` exists and is the **sole** recovery path — it un-trips and clears the streak. `recordSuccess()` clears the failure streak but does **not** un-trip; the recovery is the consensus re-vote calling `reset()`, exactly as the issue title's "trip→re-vote→reset→resume" describes. No bug: the breaker resets correctly. (The pure-breaker semantics are already covered in `remediation-circuit-breaker.test.ts`; this PR adds the integration-level round-trip through the enforce path.)

## Gates
- 3 target files + remediation cluster: **134 tests pass**
- `tsc --noEmit`: clean · `eslint --no-cache` (changed files): clean · `governance:check`: pass
- Changeset added (patch). No `any`.

Part of #3770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)