### PR TITLE
docs(capability-loop): reconcile stale enforce-wiring comments (#3768)

### DIFF
--- a/.changeset/reconcile-enforce-wiring-docs.md
+++ b/.changeset/reconcile-enforce-wiring-docs.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+docs(capability-loop): reconcile stale '#3669 not landed / fail-closed stub' comments in the auto-remediation deps/cycle/CLI headers (#3768). The Option B proposal-PR implement adapter landed (#3669) and is wired in `buildAutoRemediationDeps`; the comments now state the real enforce-gating: the cycle entry point deliberately withholds `repoRoot`, so `implement` stays a fail-closed rejecting stub and enforce is structurally unreachable until #3769 Step 2 threads operator-supplied repoRoot (gated on a passing readiness verdict + the #3770 provenance re-audit). Comment-only; no behavior change.

--- a/packages/nexus-agents/src/cli/auto-remediate-command.ts
+++ b/packages/nexus-agents/src/cli/auto-remediate-command.ts
@@ -5,8 +5,9 @@
  * `NEXUS_AUTO_REMEDIATE` (off | audit | enforce), default `audit` since #3769 —
  * so a bare run collects improvement_review signals and runs research → consensus
  * vote with ZERO writes (the soak), accumulating readiness evidence. `off`
- * disables; `enforce` is opt-in + gated by the readiness verdict (and structurally
- * unavailable until repo/repoRoot are wired, #3669/#3769 Step 2).
+ * disables; `enforce` is opt-in + gated by the readiness verdict (the Option B
+ * implement adapter #3669 has landed, but the cycle withholds repoRoot so enforce
+ * stays structurally unreachable until it is threaded — #3769 Step 2).
  *
  * Flags:
  *   --format <text|json>   Output mode (default text)

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
@@ -7,8 +7,11 @@
  * `NEXUS_AUTO_REMEDIATE` unset it runs `audit` — producing the vote/plan SOAK
  * data with zero writes — so periodic local runs accumulate readiness evidence.
  * Explicit `off` short-circuits before collecting signals. `enforce` is opt-in
- * and structurally unavailable until repo/repoRoot + a passing readiness verdict
- * are wired (#3769 Step 2).
+ * and structurally unavailable: this entry point deliberately withholds `repoRoot`
+ * from {@link buildAutoRemediationDeps} (see {@link resolveCycleDeps}), so the
+ * Option B `implement` adapter — wired and landed (#3669) — stays a fail-closed
+ * rejecting stub here. Threading repoRoot (gated on a passing readiness verdict +
+ * the #3770 operator-provenance re-audit) is #3769 Step 2.
  *
  * @module mcp/tools/auto-remediation-cycle
  */
@@ -140,7 +143,16 @@ async function collectCycleSignals(
   return (await runImprovementReview(input, { logger })).signals;
 }
 
-/** Resolve deps via the injected set, or assemble the real ones. */
+/**
+ * Resolve deps via the injected set, or assemble the real ones.
+ *
+ * Deliberate fail-closed sequencing: we pass `repo`/`sha` (for the lease) but NOT
+ * `repoRoot`/`baseBranch`, so {@link buildAutoRemediationDeps} leaves `implement`
+ * as the rejecting stub and enforce cannot engage from the cycle — even though the
+ * Option B adapter (#3669) is wired. Threading repoRoot is #3769 Step 2, gated on a
+ * passing readiness verdict and the #3770 requirement that repoRoot reach the
+ * worktree/lease ONLY from operator-supplied config (never signal/telemetry-derived).
+ */
 function resolveCycleDeps(
   inject: AutoRemediationCycleInject,
   config: AutoRemediationCycleConfig,

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-deps.ts
@@ -5,9 +5,13 @@
  * {@link runAutoRemediation}. AUDIT-READY NOW: in `audit` mode the orchestrator
  * runs research → consensus vote and stops before IMPLEMENT, so this assembly
  * produces the vote/plan SOAK data the readiness gate needs using only merged
- * pieces. ENFORCE is intentionally NOT yet runnable — `implement` is a
- * fail-closed stub until the Option B proposal-PR adapter lands (#3669).
- * Readiness now reads REAL evidence from the durable soak (#3762) + soundness-
+ * pieces. The Option B proposal-PR `implement` adapter HAS landed (#3669) and is
+ * wired below — but ONLY when both `repoRoot` (a live checkout) and `repo` are
+ * passed; absent those it stays a fail-closed rejecting stub. The cycle entry
+ * point (`runAutoRemediationCycle`) deliberately withholds `repoRoot`, so enforce
+ * is unreachable from there pending #3769 Step 2 (the readiness-gated wiring that
+ * the #3770 security review requires re-audit operator-supplied repoRoot provenance for).
+ * Readiness reads REAL evidence from the durable soak (#3762) + soundness-
  * review (#3765) stores (#3764), fail-closing to not-ready when no data exists.
  *
  * @module mcp/tools/auto-remediation-deps
@@ -75,9 +79,10 @@ function collectReadinessEvidence(logger: ILogger): Promise<EnforceReadinessEvid
 
 /**
  * Assemble {@link AutoRemediationDeps} from the merged adapters. Audit-ready;
- * enforce stays fail-closed (stub `implement`, not-ready readiness, null lease
- * when `repo`/`sha` are absent) until the Option B adapter (#3669) + real
- * readiness evidence are wired.
+ * the Option B `implement` adapter (#3669) is wired when `repoRoot` + `repo` are
+ * supplied, else it stays a fail-closed rejecting stub. Enforce additionally
+ * requires a passing readiness verdict (not-ready by default) and a non-null lease
+ * (null when `repo`/`sha` are absent), so it stays fail-closed until #3769 Step 2.
  */
 export function buildAutoRemediationDeps(
   opts: AutoRemediationDepsOptions = {}


### PR DESCRIPTION
Closes #3768.

## What
The Option B proposal-PR `implement` adapter landed (#3669) and is wired in `buildAutoRemediationDeps`, but several module headers still described `implement` as a *"fail-closed stub until #3669 lands"* — stale, and misleading for an operator reasoning about enforce-availability.

Reconciles the comments in three files to state the **real** status:
- `auto-remediation-deps.ts` — module header + `buildAutoRemediationDeps` JSDoc: the adapter is wired when `repoRoot`+`repo` are supplied, else a fail-closed rejecting stub.
- `auto-remediation-cycle.ts` — module header + `resolveCycleDeps`: documents that the cycle **deliberately withholds** `repoRoot`, so enforce is structurally unreachable from the cycle.
- `auto-remediate-command.ts` — tightened the `#3669` reference (adapter landed; enforce gated on repoRoot threading at #3769 Step 2).

## The wiring decision (the #3768 open question)
#3768 asked: thread `repoRoot` through the cycle, or document why not? **Decision: keep withholding it.** Threading `repoRoot` is #3769 Step 2 — gated on a passing `evaluateEnforceReadiness` verdict AND the #3770 security-review requirement that `repoRoot` reach the worktree/lease ONLY from operator-supplied config (never signal/telemetry-derived). Documenting the deliberate withholding keeps enforce fail-closed until that gate is satisfied.

## Tests
Comment-only; no behavior change. Existing cycle tests (15 passing) already assert the fail-closed enforce behavior these comments now describe. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)