### PR TITLE
fix(security): diff-secret-scan catches newer key formats (#3752)

### DIFF
--- a/.changeset/diff-secret-scan-newer-key-formats.md
+++ b/.changeset/diff-secret-scan-newer-key-formats.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+security(capability-loop): the pre-push diff-secret-scan now catches newer OpenAI key prefixes (`sk-proj-`/`sk-svcacct-`/`sk-admin-`, whose hyphen broke the classic `sk-[A-Za-z0-9]{32,}` class) and base64 credential values with `=` padding (the generic-credential value class omitted `=`). This scanner is the fail-closed pre-push gate that must be solid before Option A (#3670) pushes attacker-influenceable diffs. (#3752)

--- a/packages/nexus-agents/src/mcp/tools/diff-secret-scan.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/diff-secret-scan.test.ts
@@ -28,6 +28,35 @@ describe('scanForSecrets', () => {
     }
   });
 
+  it('catches newer OpenAI key prefixes that the classic sk- pattern misses (#3752)', () => {
+    // The classic `sk-[A-Za-z0-9]{32,}` class breaks at the hyphen in these prefixes.
+    const cases: Array<[string, string]> = [
+      ['sk-proj-' + 'a'.repeat(40), 'openai-key'],
+      ['sk-svcacct-' + 'b'.repeat(40), 'openai-key'],
+      ['sk-admin-' + 'c'.repeat(40), 'openai-key'],
+      // bodies legitimately contain - and _ (base64url); must still match
+      ['sk-proj-' + 'aB1_-'.repeat(10), 'openai-key'],
+    ];
+    for (const [text, expected] of cases) {
+      const r = scanForSecrets(text);
+      expect(r.clean, `should flag: ${text}`).toBe(false);
+      expect(r.findings.map((f) => f.pattern)).toContain(expected);
+    }
+  });
+
+  it('catches base64 credential values with = padding (#3752)', () => {
+    // base64 of a 16-byte value ends in '==' — the generic class omitted '='.
+    const r = scanForSecrets('const token = "YWJjZGVmZ2hpamtsbW5vcA=="');
+    expect(r.clean).toBe(false);
+    expect(r.findings.map((f) => f.pattern)).toContain('generic-credential-assignment');
+  });
+
+  it('still ignores ordinary hyphenated prose after the prefix widening (#3752)', () => {
+    // Guard against the widened openai pattern over-matching short / non-key strings.
+    expect(scanForSecrets('use the sk- prefix for OpenAI keys in docs').clean).toBe(true);
+    expect(scanForSecrets('the well-documented multi-step build-and-test flow').clean).toBe(true);
+  });
+
   it('reports the line number, never the secret value', () => {
     const r = scanForSecrets(`line one\nAKIAIOSFODNN7EXAMPLE\nline three`);
     expect(r.findings[0]?.line).toBe(2);

--- a/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
+++ b/packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts
@@ -28,12 +28,17 @@ const SECRET_PATTERNS: readonly SecretPattern[] = [
   { name: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
   { name: 'google-api-key', re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
   { name: 'openai-key', re: /\bsk-[A-Za-z0-9]{32,}\b/ },
+  // Newer OpenAI key families: project/service-account/admin keys carry a
+  // `sk-proj-`/`sk-svcacct-`/`sk-admin-` prefix and base64url bodies (with - and
+  // _), so the classic class above breaks at the first hyphen (#3752).
+  { name: 'openai-key', re: /\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}\b/ },
   { name: 'anthropic-key', re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/ },
   { name: 'jwt', re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
-  // Generic `secret/token/password/api_key = "long-value"` assignments.
+  // Generic `secret/token/password/api_key = "long-value"` assignments. The value
+  // class includes `=` so base64 values with padding (…==) still match (#3752).
   {
     name: 'generic-credential-assignment',
-    re: /(?:api[_-]?key|secret|token|password|passwd|credential)\s*[:=]\s*["'][A-Za-z0-9/+_-]{16,}["']/i,
+    re: /(?:api[_-]?key|secret|token|password|passwd|credential)\s*[:=]\s*["'][A-Za-z0-9/+_=-]{16,}["']/i,
   },
 ];
 


### PR DESCRIPTION
Closes #3752.

## What
The pre-push `diff-secret-scan` (the fail-closed gate that scans a remediation diff **before** `gh pr create` publishes the branch) missed two secret shapes found in the post-session security audit:

1. **Newer OpenAI key prefixes** — `sk-proj-…`, `sk-svcacct-…`, `sk-admin-…`. The hyphen in the prefix breaks the classic `\bsk-[A-Za-z0-9]{32,}\b` character class, so these slipped through. Added a dedicated prefixed pattern with a base64url body class (`[A-Za-z0-9_-]{20,}`).
2. **base64 values with `=` padding** — the generic-credential value class `[A-Za-z0-9/+_-]` omitted `=`, so a quoted base64 secret ending in `==` did not match. Added `=` to the class.

## Why now
This scanner is the **fail-closed pre-push gate that must be solid before Option A (#3670)** lands real, attacker-influenceable code diffs. Low risk today (Option B proposal text is inert), but #3752 explicitly **blocks #3670**.

## Tests (TDD: red → green)
- `sk-proj-`/`sk-svcacct-`/`sk-admin-` keys, incl. a body with `-`/`_` → now flagged `openai-key`.
- base64 value with `==` padding → now flagged `generic-credential-assignment`.
- **Over-match guard**: ordinary hyphenated prose (`sk-` prefix in docs, `well-documented multi-step build-and-test`) stays clean.

8/8 scanner tests pass; the proposal-PR consumer tests (7/7) unchanged; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)