### PR TITLE
feat(execute_expert): surface expert confidence in the response (#3766)

### DIFF
--- a/.changeset/execute-expert-confidence.md
+++ b/.changeset/execute-expert-confidence.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+feat(execute_expert): surface the expert's self-reported confidence in `ExecuteExpertResponse` (#3766). Experts emit an `ExpertOutput`-shaped analysis carrying a numeric `confidence` (0-1), but it was dropped when the MCP boundary stringified the output. Added an optional `confidence?: number` field (plus a fail-safe `extractExpertConfidence` helper, validated to `[0,1]`) and re-stated it in the tool description. Additive and backward-compatible; consumers can now route/weight on the real per-expert confidence instead of the success=1/fail=0 placeholder.

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.test.ts
@@ -12,6 +12,8 @@ import {
   type ExecuteExpertDeps,
   buildTask,
   maybeFetchContextPrefix,
+  buildSuccessResponse,
+  extractExpertConfidence,
 } from './execute-expert.js';
 
 /**
@@ -220,6 +222,51 @@ describe('ExecuteExpertInputSchema', () => {
       expect(result.success).toBe(true);
       if (result.success) expect(result.data.timeoutMs).toBeUndefined();
     });
+  });
+});
+
+describe('extractExpertConfidence (#3766)', () => {
+  it('returns the confidence from an ExpertOutput-shaped object in [0,1]', () => {
+    expect(extractExpertConfidence({ content: 'x', confidence: 0.7 })).toBe(0.7);
+    expect(extractExpertConfidence({ content: 'x', confidence: 0 })).toBe(0);
+    expect(extractExpertConfidence({ content: 'x', confidence: 1 })).toBe(1);
+  });
+
+  it('returns undefined when confidence is absent, non-numeric, or out of range', () => {
+    expect(extractExpertConfidence({ content: 'no confidence' })).toBeUndefined();
+    expect(extractExpertConfidence({ confidence: 'high' })).toBeUndefined();
+    expect(extractExpertConfidence({ confidence: 1.5 })).toBeUndefined();
+    expect(extractExpertConfidence({ confidence: -0.1 })).toBeUndefined();
+    expect(extractExpertConfidence({ confidence: Number.NaN })).toBeUndefined();
+    expect(extractExpertConfidence('a plain string output')).toBeUndefined();
+    expect(extractExpertConfidence(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildSuccessResponse confidence surfacing (#3766)', () => {
+  it('surfaces the expert confidence from the analysis output', () => {
+    const res = buildSuccessResponse({
+      expertId: 'e1',
+      role: 'architecture',
+      output: { content: 'analysis text', confidence: 0.42 },
+      durationMs: 10,
+      tokensUsed: 5,
+    });
+    expect(res.confidence).toBe(0.42);
+    // Output is still stringified for the human-readable field.
+    expect(res.output).toContain('analysis text');
+  });
+
+  it('omits confidence when the output carries none (plain string)', () => {
+    const res = buildSuccessResponse({
+      expertId: 'e1',
+      role: 'code',
+      output: 'just a string',
+      durationMs: 10,
+      tokensUsed: 5,
+    });
+    expect(res.confidence).toBeUndefined();
+    expect(res.output).toBe('just a string');
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -144,6 +144,12 @@ export interface ExecuteExpertResponse {
   error?: string;
   /** Model used for execution (Issue #817) */
   modelUsed?: string;
+  /**
+   * The expert's self-reported confidence in `[0, 1]` (#3766). Present only when
+   * the expert emitted an {@link ExpertOutput}-shaped analysis carrying a numeric
+   * confidence; absent for plain-string outputs. Consumers can route/weight on it.
+   */
+  confidence?: number;
 }
 
 /**
@@ -272,7 +278,22 @@ interface SuccessResponseParams {
   modelUsed?: string | undefined;
 }
 
-function buildSuccessResponse(params: SuccessResponseParams): ExecuteExpertResponse {
+/**
+ * Extract an expert's self-reported confidence from its task output (#3766).
+ *
+ * Experts emit an {@link ExpertOutput}-shaped analysis object whose `confidence`
+ * is a number in `[0, 1]`; the MCP boundary stringifies the output, dropping that
+ * structured field. This recovers it (fail-safe: returns `undefined` for plain
+ * strings, missing/non-numeric/out-of-range values) so the response can surface it.
+ */
+export function extractExpertConfidence(output: unknown): number | undefined {
+  if (typeof output !== 'object' || output === null) return undefined;
+  const c = (output as { confidence?: unknown }).confidence;
+  if (typeof c !== 'number' || !Number.isFinite(c) || c < 0 || c > 1) return undefined;
+  return c;
+}
+
+export function buildSuccessResponse(params: SuccessResponseParams): ExecuteExpertResponse {
   const outputStr =
     typeof params.output === 'string' ? params.output : JSON.stringify(params.output, null, 2);
   const response: ExecuteExpertResponse = {
@@ -285,6 +306,11 @@ function buildSuccessResponse(params: SuccessResponseParams): ExecuteExpertRespo
   };
   if (params.modelUsed !== undefined) {
     response.modelUsed = params.modelUsed;
+  }
+  // #3766: surface the expert's real confidence before the output is flattened.
+  const confidence = extractExpertConfidence(params.output);
+  if (confidence !== undefined) {
+    response.confidence = confidence;
   }
   return response;
 }
@@ -827,7 +853,8 @@ export function registerExecuteExpertTool(server: McpServer, deps: ExecuteExpert
   const description =
     'Run a task through an expert YOU PREVIOUSLY CREATED via `create_expert`. ' +
     'Requires the expertId returned by create_expert; not for ad-hoc execution. ' +
-    'Returns the expert analysis including output, status, model used, and token usage.';
+    'Returns the expert analysis including output, status, model used, token usage, ' +
+    "and the expert's confidence (0-1) when it reports one.";
 
   server.experimental.tasks.registerToolTask(
     'execute_expert',


### PR DESCRIPTION
Closes #3766. Part of #3516 (carved out of the #3531 build-vs-drop umbrella — the "build now" candidate).

## What
`execute_expert` once advertised returning "output, **confidence**, and token usage", but the confidence was dropped at the MCP boundary (the doc was honestly trimmed instead). The data already exists: every expert emits an `ExpertOutput`-shaped analysis with a numeric `confidence` (0-1) — it was just lost when `result.value.output` got JSON-stringified into the response's `output` string.

## Change (additive, no design vote needed)
- `ExecuteExpertResponse` gains an optional **`confidence?: number`**.
- New `extractExpertConfidence(output)` helper — **fail-safe**: returns the value only for an object with a finite numeric `confidence` in `[0, 1]`; plain strings / missing / non-numeric / out-of-range all yield `undefined`.
- `buildSuccessResponse` surfaces it before the output is flattened.
- Tool description re-states confidence (the #3528 description-drift gate stays green — within the 0.5 similarity threshold).

This replaces the success=1/fail=0 placeholder (`execute-expert.ts:779`, a separate orchestrate-style path) with the expert's real score, so consumers can route/weight on it.

## Tests
TDD (red→green): 4 new tests covering the helper's range/guards and confidence surfacing through `buildSuccessResponse`. 40 execute-expert + 6 degradation tests pass; typecheck, lint, governance (46 tools) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)