### PR TITLE
docs(run_graph_workflow): correct checkpoint/resume description (#3767)

### DIFF
--- a/.changeset/run-graph-workflow-checkpoint-accuracy.md
+++ b/.changeset/run-graph-workflow-checkpoint-accuracy.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+docs(run_graph_workflow): correct the checkpoint/resume description (#3767). The tool description claimed checkpoints persist "for inspection/restart", implying a caller-driven MCP resume that does not exist. Per a 7/7 higher_order consensus vote, the accurate framing: restore/resume lives in the graph EXECUTOR (`resumeFromCheckpoint` for HITL interrupts, `tryResumeFromCheckpoint` for crash recovery, `priorResults` selective-retry), but the `run_graph_workflow` MCP call is fire-and-forget with NO resume input and an in-memory (non-durable) checkpoint store. Exposing caller-driven resume + a durable backend is deferred to #3803 (no named cross-process consumer yet — capability-bias). Description-only; runtime/doc-table/tool-reference kept in lockstep.

--- a/docs/reference/tools/run_graph_workflow.md
+++ b/docs/reference/tools/run_graph_workflow.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, run_graph_workflow]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Use for multi-step pipelines where intermediate state must survive failures (checkpoints persist per node for inspection/restart). For straight linear templates, use `run_workflow` instead.
+Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.
 
 ## Parameters
 

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -215,7 +215,7 @@ async function handleRunGraphWorkflow(
 // ============================================================================
 
 const GRAPH_WORKFLOW_DESCRIPTION =
-  'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Use for multi-step pipelines where intermediate state must survive failures (checkpoints persist per node for inspection/restart). For straight linear templates, use `run_workflow` instead.';
+  'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.';
 
 const GRAPH_WORKFLOW_SCHEMA = {
   workflow: z

--- a/scripts/tool-descriptions-data.ts
+++ b/scripts/tool-descriptions-data.ts
@@ -57,7 +57,7 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
     'Get multi-CLI performance weather report with per-CLI success rates and adaptive routing bonuses.',
   issue_triage: 'Triage GitHub issues with trust classification and typed action recommendations.',
   run_graph_workflow:
-    'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Use for multi-step pipelines where intermediate state must survive failures (checkpoints persist per node for inspection/restart). For straight linear templates, use `run_workflow` instead.',
+    'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.',
   execute_spec:
     'Execute an AI software factory spec through the full pipeline (parse, decompose, compile, execute, validate).',
   registry_import:


### PR DESCRIPTION
Closes #3767. Deferred build tracked as #3803.

## Decision (7/7 higher_order consensus vote → Option B)
The #3767 issue claimed run_graph_workflow has "no rollback/restore". **That premise is wrong** (verified via an Explore subagent against the code): restore/resume already exists in the graph executor —
- `resumeFromCheckpoint()` — HITL interrupt pause/resume,
- `tryResumeFromCheckpoint()` — automatic crash recovery at graph start,
- `priorResults` selective-retry (#3534).

The real gap is narrower: the `run_graph_workflow` **MCP tool** exposes `enableCheckpointing` but **no resume input**, and the only `ICheckpointStore` is in-memory. Exposing caller-driven cross-process resume + a durable backend has **no named consumer today**, so all 7 voters (incl. security flagging checkpoint-IDs-as-capabilities + persisted-state secret/PII retention) chose to **correct the docs and defer the build** under capability-bias.

## Change (Option B deliverable)
Corrects the misleading `run_graph_workflow` description in **both** the runtime tool (`GRAPH_WORKFLOW_DESCRIPTION`) and the matching `TOOL_DESCRIPTIONS` doc-table entry (kept in lockstep for the #3528 drift gate), and regenerates the `docs/reference/tools/run_graph_workflow.md` page. New text states accurately: checkpoints drive the **executor's** in-process recovery (crash-resume + selective retry) + inspection; the **MCP call is fire-and-forget with NO caller resume input**, and the store is in-memory (not durable across restarts).

The deferred Option-A build (MCP resume input + durable store) is tracked as **#3803**, unblock trigger: a named cross-process resume consumer.

## Verification
Description-drift ✓ (46 tools), docs:tools:check ✓ (47 files — the #3689 gate), governance ✓, lint ✓, 149 run-graph-workflow tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)