### PR TITLE
fix(mcp): break the ci-health-check-tool ↔ ci-health-log circular import (#3756)

### DIFF
--- a/.changeset/ci-health-circular-import.md
+++ b/.changeset/ci-health-circular-import.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): break the `ci-health-check-tool` ↔ `ci-health-log` circular import (#3756). Importing the MCP tools barrel (or either ci-health module) under tsx ESM evaluation threw `ReferenceError: Cannot access 'CiHealthStatusSchema' before initialization` — the tool defined the shared schema/types AND imported the log's appenders, while the log used the schema at module-eval time, so the cyclic init order left it in the TDZ. Extracted `CiHealthStatusSchema`/`CiHealthStatus`/`CiHealthSignal` into a leaf `ci-health-types.ts` (imports only zod) that both modules depend on; the tool re-exports them for API compatibility. A structural guard test keeps the cycle edge from returning.

--- a/packages/nexus-agents/src/mcp/tools/ci-health-check-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-check-tool.ts
@@ -43,10 +43,15 @@ import {
 } from './tool-result.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import { appendCiHealthEvent, eventFromCheck } from './ci-health-log.js';
-
-/** Combined health verdict. `degraded` means partial — operator can still ship with caution. */
-export const CiHealthStatusSchema = z.enum(['healthy', 'degraded', 'outage', 'unknown']);
-export type CiHealthStatus = z.infer<typeof CiHealthStatusSchema>;
+// #3756: shared schema/types live in the leaf ci-health-types.js to break the
+// ci-health-check-tool ↔ ci-health-log cycle. Re-exported here for API compat.
+import {
+  CiHealthStatusSchema,
+  type CiHealthStatus,
+  type CiHealthSignal,
+} from './ci-health-types.js';
+export { CiHealthStatusSchema };
+export type { CiHealthStatus, CiHealthSignal };
 
 export const CiHealthCheckInputSchema = z.object({
   /**
@@ -71,13 +76,6 @@ export const CiHealthCheckInputSchema = z.object({
     .describe('Recent-runs lookback window in minutes (5-180; default 30).'),
 });
 export type CiHealthCheckInput = z.infer<typeof CiHealthCheckInputSchema>;
-
-/** Per-signal evidence the tool returns alongside the combined verdict. */
-export interface CiHealthSignal {
-  readonly source: 'github-status' | 'repo-activity-window';
-  readonly status: CiHealthStatus;
-  readonly evidence: string;
-}
 
 export interface CiHealthCheckResponse {
   readonly status: CiHealthStatus;

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.test.ts
@@ -15,6 +15,23 @@ import {
 } from './ci-health-log.js';
 import { resetNexusDataDirCache, nexusDataPath } from '../../config/nexus-data-dir.js';
 
+describe('ci-health-log circular-import guard (#3756)', () => {
+  it('does NOT import the shared schema from ci-health-check-tool (cycle stays broken)', () => {
+    const src = readFileSync(join(import.meta.dirname, 'ci-health-log.ts'), 'utf-8');
+    // The cycle was ci-health-log ← CiHealthStatusSchema ← ci-health-check-tool,
+    // closed by the tool's import of this module's appenders. The shared schema now
+    // lives in the leaf ci-health-types.js; importing it from the tool would
+    // re-introduce the TDZ ReferenceError under tsx ESM evaluation.
+    expect(src).not.toMatch(/from '\.\/ci-health-check-tool\.js'/);
+    expect(src).toMatch(/from '\.\/ci-health-types\.js'/);
+  });
+
+  it('loads ci-health-check-tool + the tools barrel without a circular-init error', async () => {
+    await expect(import('./ci-health-check-tool.js')).resolves.toBeDefined();
+    await expect(import('./index.js')).resolves.toBeDefined();
+  });
+});
+
 describe('ci-health-log', () => {
   let tmpDir: string;
   const originalDataDir = process.env['NEXUS_DATA_DIR'];

--- a/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-log.ts
@@ -27,7 +27,10 @@ import { z } from 'zod';
 
 import { createLogger } from '../../core/index.js';
 import { nexusDataPathEnsure } from '../../config/nexus-data-dir.js';
-import { CiHealthStatusSchema, type CiHealthSignal } from './ci-health-check-tool.js';
+// #3756: import the shared schema/types from the leaf, NOT ci-health-check-tool —
+// that import edge (combined with the tool importing this module's appenders) was
+// the cycle that left CiHealthStatusSchema in the TDZ under tsx ESM evaluation.
+import { CiHealthStatusSchema, type CiHealthSignal } from './ci-health-types.js';
 
 const logger = createLogger({ component: 'ci-health-log' });
 

--- a/packages/nexus-agents/src/mcp/tools/ci-health-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/ci-health-types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared CI-health value/types — the leaf that breaks the
+ * `ci-health-check-tool` ↔ `ci-health-log` import cycle (#3756).
+ *
+ * `ci-health-log` needs `CiHealthStatusSchema` at module-eval time (its
+ * `CiHealthEventSchema` references it), and `ci-health-check-tool` imports
+ * `ci-health-log`'s appenders — so defining the schema on the tool made the two
+ * modules mutually dependent, and under tsx ESM evaluation the tool's import of
+ * the log ran first, leaving `CiHealthStatusSchema` in the TDZ
+ * (`ReferenceError: Cannot access 'CiHealthStatusSchema' before initialization`).
+ * Hosting the shared schema/types here (imports only zod) makes both modules
+ * depend on a leaf instead of each other.
+ *
+ * @module mcp/tools/ci-health-types
+ */
+
+import { z } from 'zod';
+
+/** Combined health verdict. `degraded` means partial — operator can still ship with caution. */
+export const CiHealthStatusSchema = z.enum(['healthy', 'degraded', 'outage', 'unknown']);
+export type CiHealthStatus = z.infer<typeof CiHealthStatusSchema>;
+
+/** Per-signal evidence the tool returns alongside the combined verdict. */
+export interface CiHealthSignal {
+  readonly source: 'github-status' | 'repo-activity-window';
+  readonly status: CiHealthStatus;
+  readonly evidence: string;
+}


### PR DESCRIPTION
Closes #3756.

## Observable bug
Importing the MCP tools barrel (or either ci-health module) under tsx ESM evaluation threw:
```
ReferenceError: Cannot access 'CiHealthStatusSchema' before initialization
```
Repro (now fixed): `npx tsx -e "import('./packages/nexus-agents/src/mcp/tools/index.js')"`. This forced a static-parse workaround in the #3687 tool-reference generator.

## Cause
A circular dependency with a TDZ trap:
- `ci-health-check-tool.ts` **defined** `CiHealthStatusSchema`/`CiHealthSignal` **and** imported `ci-health-log`'s appenders.
- `ci-health-log.ts` imported `CiHealthStatusSchema` from the tool and **used it at module-eval time** (inside `CiHealthEventSchema`).
- Under tsx ESM, the tool's import of the log ran before the tool defined the schema → the log read it from the TDZ.

## Fix (standard leaf-extraction)
New **`ci-health-types.ts`** (imports only `zod`) hosts `CiHealthStatusSchema` / `CiHealthStatus` / `CiHealthSignal`. Both modules import the leaf → `check-tool → log → types`, `check-tool → types` (a DAG, no cycle). The tool **re-exports** the symbols for API compatibility. Verified all three imports load OK under tsx.

## Guard + verification
A **structural test** asserts `ci-health-log` no longer imports from `ci-health-check-tool` (cycle stays broken) + a smoke test loads the tool/barrel. 37 ci-health tests pass; typecheck, lint, governance (46 tools), description-drift, docs:tools (47), producer-consumer all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)