### PR TITLE
fix(ci): exempt Dependabot 'Bump' subjects from commitlint (#3761)

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -31,6 +31,12 @@ const config: UserConfig = {
     'body-max-line-length': [0] as const,
     'footer-max-line-length': [0] as const,
   },
+  // #3761: Dependabot keeps a capital 'Bump' in its subject even with the
+  // configured `chore(deps)`/`chore(ci)` prefix (.github/dependabot.yml), which
+  // `subject-case` (no sentence-case) rejects — blocking EVERY dep-bump PR's
+  // Commit Messages gate. Exempt those bot-authored commits rather than weaken the
+  // rule for humans. Matches `<prefix>: Bump <pkg> from <a> to <b>`.
+  ignores: [(message: string): boolean => /^chore\((?:deps|deps-dev|ci)\): Bump /.test(message)],
 };
 
 export default config;


### PR DESCRIPTION
Closes #3761.

## Problem
Dependabot keeps a capital **'Bump'** in its commit subject even with the configured `chore(deps)`/`chore(ci)` prefix (`.github/dependabot.yml`), and `subject-case` (no `sentence-case`) rejects it. So **every** Dependabot PR fails the Commit Messages gate (and CI Success cascades) despite green tests, requiring a manual squash-with-corrected-subject each time (#3757/#3758/#3759 were all blocked).

## Fix
Add a commitlint `ignores` predicate matching `<prefix>: Bump <pkg> from <a> to <b>` so those bot commits are exempt — **without weakening `subject-case` for human commits** (the alternative, lowering the rule, was rejected).

## Verified (commitlint CLI)
| message | exit |
|---|---|
| `chore(deps): Bump vitest from 4.1.7 to 4.1.8` | 0 (ignored) |
| `chore(ci): Bump actions/checkout from 4 to 5` | 0 (ignored) |
| `fix(mcp): break a cycle` | 0 (valid) |
| `badtype: whatever` | 1 (gate works) |
| `feat: Add a thing` | 1 (sentence-case still rejected) |

Config-only (root `commitlint.config.ts`) — no `src/` change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)