### PR TITLE
fix(registry): generated-registry loader reads the refreshed data-dir file (#3707)

### DIFF
--- a/.changeset/registry-refresh-loader-path.md
+++ b/.changeset/registry-refresh-loader-path.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(registry): generated-registry loader now reads the refreshed data-dir file (#3707)
+
+`registry refresh` writes the regenerated model catalog to the data dir, but `loadGeneratedRegistryEntries` read only the bundled package copy — so a refresh's generated file was silently never picked up, even after #3185's in-process `reloadDefaultRegistry()`. The loader now prefers a refreshed `model-registry.generated.json` in the data dir when present (the same data-dir > package precedence the overlay path uses; the package dir is also typically read-only under a global npm install), falling back to the bundled copy. Fail-soft preserved.

--- a/packages/nexus-agents/src/config/models-generated-loader.test.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the generated-registry loader's data-dir precedence (#3707).
+ *
+ * `registry refresh` writes the regenerated catalog to the DATA dir, but the
+ * loader historically read only the bundled PACKAGE copy — so a refresh was
+ * never picked up. These tests pin the fixed precedence: a refreshed file in
+ * the data dir wins; otherwise fall back to the bundled package copy.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadGeneratedRegistryEntries } from './models-generated-loader.js';
+import { resetNexusDataDirCache, nexusDataPath } from './nexus-data-dir.js';
+
+describe('models-generated-loader data-dir precedence (#3707)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-genreg-test-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads a refreshed generated file from the data dir (precedence over package)', () => {
+    const dataPath = nexusDataPath('model-registry.generated.json');
+    writeFileSync(
+      dataPath,
+      JSON.stringify({
+        version: 1,
+        entries: [{ id: 'litellm/refresh-probe-model', contextWindow: 123456 }],
+      })
+    );
+
+    const result = loadGeneratedRegistryEntries();
+    expect(result.status).toBe('loaded');
+    expect(result.path).toBe(dataPath);
+    const probe = result.entries.find((e) => e.id === 'litellm/refresh-probe-model');
+    expect(probe).toBeDefined();
+    expect(probe?.contextWindow).toBe(123456);
+  });
+
+  it('falls back to the bundled package path when no data-dir file exists', () => {
+    const result = loadGeneratedRegistryEntries();
+    // Resolves to the bundled package copy, NOT the (absent) data-dir file.
+    expect(result.path).not.toBe(nexusDataPath('model-registry.generated.json'));
+    expect(result.path).toMatch(/model-registry\.generated\.json$/);
+  });
+
+  it('still honors an explicit path override (unchanged by the data-dir preference)', () => {
+    const explicit = join(tmpDir, 'explicit.json');
+    writeFileSync(explicit, JSON.stringify({ version: 1, entries: [] }));
+    const result = loadGeneratedRegistryEntries({ path: explicit });
+    expect(result.path).toBe(explicit);
+    expect(result.status).toBe('loaded');
+  });
+});

--- a/packages/nexus-agents/src/config/models-generated-loader.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createLogger } from '../core/index.js';
+import { nexusDataPath } from './nexus-data-dir.js';
 import { resolveModelIdentitySync } from './model-identity.js';
 import { deriveEntry } from './model-derivation.js';
 import type { ModelEntry } from './model-registry.js';
@@ -47,6 +48,20 @@ export interface GeneratedLoadResult {
 }
 
 function defaultGeneratedPath(): string {
+  // #3707: `registry refresh` writes the regenerated catalog to the DATA dir
+  // (nexusDataPath), but this loader historically read only the bundled PACKAGE
+  // copy — so a refresh was silently never picked up (even after #3185's
+  // reloadDefaultRegistry, which re-reads via this path). Prefer a refreshed file
+  // in the data dir when present, falling back to the bundled copy — the same
+  // data-dir > package precedence the overlay path already uses. The package dir
+  // is also often read-only under a global npm install, so the data dir is the
+  // only writable target a refresh has.
+  try {
+    const dataPath = nexusDataPath('model-registry.generated.json');
+    if (existsSync(dataPath)) return dataPath;
+  } catch {
+    // Fall through to the bundled package copy on any data-dir resolution error.
+  }
   const here = dirname(fileURLToPath(import.meta.url));
   return join(here, 'model-registry.generated.json');
 }


### PR DESCRIPTION
Closes #3707.

## Bug
`registry refresh` writes the regenerated catalog to the **data dir** (`registry-command.ts:293` → `nexusDataPath('model-registry.generated.json')`), but `loadGeneratedRegistryEntries` read only the bundled **package** copy (`models-generated-loader.ts:50` → `dirname(import.meta.url)/…`). So a refresh's generated file was **silently never picked up** — even after #3185's in-process `reloadDefaultRegistry()`, which re-reads via the same package path. The hot-reload reported success but had no effect on the generated long-tail tier.

## Fix
`defaultGeneratedPath()` now prefers a refreshed file in the data dir when present, falling back to the bundled package copy — the same **data-dir > package** precedence the overlay path already uses. (The package dir is also typically read-only under a global npm install, so the data dir is the only writable target a refresh has.) Fail-soft behavior preserved; an explicit `path` override is unchanged.

## Verification (TDD)
New `models-generated-loader.test.ts`:
- data-dir precedence (was **RED** before the fix)
- package fallback when no data-dir file
- explicit `path` override still honored

804 config tests pass; typecheck, lint, governance, producer-consumer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)