### PR TITLE
chore(security): extend CODEOWNERS to the governor paths (#3830)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,23 @@
 # Governance rules — Rule-of-Two, untrusted-input, etc. (#3653 self-mod guard)
 /.rules/ @williamzujkowski
 
+# Governor's own core — the governance-of-the-governor paths (#3830, Epic #3829).
+# These are NEVER auto-merged: human ratification is required. Admin-merge
+# discipline applies to them too — an agent-authored PR must not modify the
+# audit hash chain, governance source, or drift machinery without owner review.
+#
+# Audit hash chain
+/packages/nexus-agents/src/audit/ @williamzujkowski
+# Governance source
+/packages/nexus-agents/src/governance/ @williamzujkowski
+# Governance-drift injection machinery
+/scripts/inject-governance.ts @williamzujkowski
+# Claims registry — the durable claim inventory (#3825 lands it at
+# /governance/claims-registry.yaml). The directory pattern below covers the
+# registry once it exists; it is a no-op (no dangling match required) until then.
+/governance/ @williamzujkowski
+/governance/claims-registry.* @williamzujkowski
+
 # Project governance
 /CLAUDE.md @williamzujkowski
 /AGENTS.md @williamzujkowski


### PR DESCRIPTION
Fixes #3830 (Epic #3829, governance-of-the-governor).

## What

CODEOWNERS protected 7 paths but missed the governor's own core. An agent-authored PR could modify the audit hash chain or governance source with only the default review. This extends CODEOWNERS to require owner review on those paths.

### CODEOWNERS lines added
```
# Governor's own core — the governance-of-the-governor paths (#3830, Epic #3829).
# These are NEVER auto-merged: human ratification is required. Admin-merge
# discipline applies to them too — an agent-authored PR must not modify the
# audit hash chain, governance source, or drift machinery without owner review.
#
# Audit hash chain
/packages/nexus-agents/src/audit/ @williamzujkowski
# Governance source
/packages/nexus-agents/src/governance/ @williamzujkowski
# Governance-drift injection machinery
/scripts/inject-governance.ts @williamzujkowski
# Claims registry — the durable claim inventory (#3825 lands it at
# /governance/claims-registry.yaml). The directory pattern below covers the
# registry once it exists; it is a no-op (no dangling match required) until then.
/governance/ @williamzujkowski
/governance/claims-registry.* @williamzujkowski
```

All mirror the `@williamzujkowski` owner already assigned to the existing governance paths (`src/security`, `src/consensus`, `.rules`).

### Path verification (no dangling patterns)
- `packages/nexus-agents/src/audit/` — exists
- `packages/nexus-agents/src/governance/` — exists
- `scripts/inject-governance.ts` — exists
- `/governance/claims-registry.*` — does not exist yet; lands under #3825 at `/governance/claims-registry.yaml`. A non-matching CODEOWNERS pattern is harmless (no dangling-pattern error), and the entry is in place the moment #3825 merges.

### Changeset
Not required. `scripts/check-changeset.ts` (the "Changeset Presence" gate) only requires a changeset for `packages/nexus-agents/src/**/*.ts(x)` shippable source. CODEOWNERS is a root config file, not shippable source.

## Maintainer action item — branch protection (repo SETTING, cannot be changed via PR)

Branch protection is a repository setting, not a file, so it cannot be modified in this PR. To make these CODEOWNERS entries enforced rather than advisory, a maintainer must, on the `main` branch protection rule:

- Enable **"Require review from Code Owners"** (Settings → Branches → branch protection rule for `main`).
- Confirm **"Require a pull request before merging"** with at least 1 approval is on, so the Code Owners requirement has effect.
- Keep these governor paths out of any auto-merge / admin-bypass path — they require human ratification.

Verification (per the issue's "Evidence required"): after enabling the setting, a test PR touching `packages/nexus-agents/src/audit/` should show `@williamzujkowski` auto-requested as a required reviewer and the merge button blocked until that review lands. Attach the run link / screenshot here.

## Do not merge
Leaving open for human review per repo governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)