### PR TITLE
docs(governance): contributor guide for the claims registry + README badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,6 +412,15 @@ pnpm test --watch
 - Include examples in documentation
 - Update the CHANGELOG.md for user-facing changes
 
+### Claims in README / ARCHITECTURE
+
+When a PR adds or changes a substantive claim in `README.md` or
+`ARCHITECTURE.md` (a count, a capability, a roadmap status), add or update a
+matching entry in `governance/claims-registry.yaml` so the **Claims Registry
+Drift** gate can verify it against live source. Run `pnpm claims:check` locally
+before pushing. See [docs/development/CLAIMS_REGISTRY.md](docs/development/CLAIMS_REGISTRY.md)
+for the entry shape, verification methods, and a worked example.
+
 ### JSDoc Example
 
 ````typescript

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/nexus-agents)](https://www.npmjs.com/package/nexus-agents)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org)
+[![Claims Registry Drift](https://img.shields.io/github/actions/workflow/status/nexus-substrate/nexus-agents/docs-check.yml?branch=main&label=claims%20registry)](https://github.com/nexus-substrate/nexus-agents/actions/workflows/docs-check.yml)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,6 +129,7 @@ Detailed technical documentation:
 | [CONTRIBUTION_GUIDE.md](./development/CONTRIBUTION_GUIDE.md)                   | PR workflow, git conventions    | Canonical |
 | [SHELL_TESTING_ANTI_PATTERNS.md](./development/SHELL_TESTING_ANTI_PATTERNS.md) | Shell testing pitfalls to avoid | Canonical |
 | [CLI_UX_QUALITY_GATE.md](./development/CLI_UX_QUALITY_GATE.md)                 | CLI UX pre-release checklist    | Canonical |
+| [CLAIMS_REGISTRY.md](./development/CLAIMS_REGISTRY.md)                         | Add/verify claims, drift gate   | Canonical |
 
 #### Research
 

--- a/docs/development/CLAIMS_REGISTRY.md
+++ b/docs/development/CLAIMS_REGISTRY.md
@@ -1,0 +1,159 @@
+---
+title: Claims Registry Guide
+description: How to add and verify claims so README/ARCHITECTURE assertions can't silently drift from the code
+tier: 2
+keywords: [claims, registry, governance, drift, verification, contributing]
+related_files:
+  - governance/claims-registry.yaml
+  - scripts/claims-check.ts
+  - packages/nexus-agents/src/governance/claims-registry.ts
+  - packages/nexus-agents/src/governance/claims-verify.ts
+---
+
+# Claims Registry Guide
+
+**Tier 2** | Read before adding a substantive claim to `README.md` or `ARCHITECTURE.md`
+
+The claims registry is a **claims-to-reality registry**: a machine-verifiable
+inventory of the substantive assertions our top-level docs make about the
+system. Each entry pairs a human-readable claim with a `verification` recipe a
+script runs against live source. When a doc claim and the code drift apart, the
+`claims:check` gate fails CI instead of shipping a stale promise.
+
+This is the same single-source-of-truth pattern as `governance:check`
+(`scripts/inject-governance.ts`): the doc is downstream, the code is the source
+of truth, and a blocking gate keeps them honest.
+
+- Registry: [`governance/claims-registry.yaml`](../../governance/claims-registry.yaml)
+- Schema + loader: [`packages/nexus-agents/src/governance/claims-registry.ts`](../../packages/nexus-agents/src/governance/claims-registry.ts)
+- Verification runner: [`packages/nexus-agents/src/governance/claims-verify.ts`](../../packages/nexus-agents/src/governance/claims-verify.ts)
+- Gate script: [`scripts/claims-check.ts`](../../scripts/claims-check.ts)
+- CI job: **Claims Registry Drift** in `.github/workflows/docs-check.yml` (blocking)
+
+---
+
+## When you must add an entry
+
+Add (or update) a registry entry whenever a PR introduces or changes a
+**substantive, falsifiable claim** in `README.md` or `ARCHITECTURE.md` — a
+count ("46 MCP tools", "12 expert types"), a capability ("audit trail is
+hash-chained"), or a roadmap status ("standalone CLI is Phase 2, not shipped").
+
+If you can't point the claim at a live source of truth, soften the prose
+instead of adding an unverifiable entry. The gate exists to stop claims the
+script cannot prove.
+
+---
+
+## Entry shape
+
+Each item under `claims:` in `governance/claims-registry.yaml` has these fields
+(validated by the Zod schema in `claims-registry.ts`):
+
+| Field          | Required | Meaning                                                                     |
+| -------------- | -------- | --------------------------------------------------------------------------- |
+| `id`           | yes      | Stable kebab-case identifier, never reused                                  |
+| `claim`        | yes      | Human-readable claim text, capped at 25 words                               |
+| `subject`      | yes      | Repo-root-relative doc that makes the claim (e.g. `README.md`)              |
+| `status`       | yes      | `verified` \| `partial` \| `aspirational` \| `stale`                        |
+| `evidenceType` | yes      | `test` \| `gate` \| `eval-artifact` \| `adr` \| `source`                    |
+| `verification` | yes      | Recipe the runner executes: `method`, `path`, optional `expected`, `symbol` |
+| `lastVerified` | yes      | `YYYY-MM-DD` the entry was last manually confirmed                          |
+| `caveat`       | no       | Note surfaced in reports; use it to explain a `partial` claim               |
+
+`status` values mean:
+
+- `verified` — backed by live evidence the runner checks every CI run.
+- `partial` — backed, but with a documented `caveat` (e.g. a small-n eval).
+- `aspirational` — roadmap only; allowed when the subject doc marks it roadmap.
+- `stale` — known-broken backing, tracked so it can't regress to silent.
+
+`evidenceType` categorizes what backs the claim: a `test`, a CI `gate`, an
+`eval-artifact`, an `adr`, or the `source` itself.
+
+---
+
+## Verification methods
+
+The `verification.method` picks how the runner
+([`claims-verify.ts`](../../packages/nexus-agents/src/governance/claims-verify.ts))
+proves the claim. Pick the narrowest method that actually proves it.
+
+| Method                | `expected` | `symbol` | What a green check guarantees                                            |
+| --------------------- | ---------- | -------- | ------------------------------------------------------------------------ |
+| `file-exists`         | unused     | unused   | The evidence `path` resolves to an existing file                         |
+| `file-contains`       | string     | unused   | The evidence file exists and contains the `expected` substring           |
+| `enum-member-count`   | number     | required | The named `z.enum([...])` / string-union `symbol` has `expected` members |
+| `manifest-tool-count` | number     | unused   | The tool-manifest file registers exactly `expected` MCP tools            |
+| `roadmap-status`      | string     | unused   | The subject doc still marks the feature roadmap (contains the token)     |
+
+Notes:
+
+- `expected` is **numeric** for the counting methods (`enum-member-count`,
+  `manifest-tool-count`) and a **string** for `file-contains` / `roadmap-status`.
+  `file-exists` ignores it.
+- `symbol` is **required** for `enum-member-count` and names the exported
+  `z.enum` const (or a `type X = 'a' | 'b'` string union) to count.
+- Use `roadmap-status` for `aspirational` claims: point `path` at the doc whose
+  roadmap row marks the feature unshipped, and set `expected` to that row token.
+
+---
+
+## How to add or update a claim
+
+1. Find the live source of truth for the claim (the file/symbol the code owns).
+2. Add an entry to `governance/claims-registry.yaml` under `claims:`, choosing
+   the narrowest verification method that proves it. Give it a fresh,
+   never-reused `id` and set `lastVerified` to today.
+3. Run `pnpm claims:check` locally and confirm the entry reports `ok`.
+4. Keep the doc prose and the entry in lockstep — if you change the claim text
+   in `README.md`/`ARCHITECTURE.md`, update the entry (and `lastVerified`).
+
+### Worked example
+
+`README.md` states the system exposes **46 MCP tools**. The source of truth is
+the MCP tool manifest, so the entry uses `manifest-tool-count`:
+
+```yaml
+- id: mcp-tool-count
+  claim: 'README states the system exposes 46 MCP tools.'
+  subject: README.md
+  status: verified
+  evidenceType: source
+  verification:
+    method: manifest-tool-count
+    path: packages/nexus-agents/src/mcp/tools/tool-manifest.ts
+    expected: 46
+  lastVerified: '2026-06-16'
+```
+
+If someone adds a 47th tool to the manifest without updating the README and the
+registry, `claims:check` fails: `manifest has 47 tools, expected 46`. The
+contributor reconciles the README prose, bumps `expected` to `47`, refreshes
+`lastVerified`, and the gate goes green again.
+
+For an `aspirational` claim, use `roadmap-status` and point `expected` at the
+roadmap-row token in the subject doc (see the `standalone-cli-roadmap` entry).
+
+---
+
+## Running the gate locally
+
+```bash
+pnpm claims:check
+```
+
+The gate loads `governance/claims-registry.yaml`, validates it against the Zod
+schema, then verifies every claim against live source. It prints `ok <id>` per
+claim and exits non-zero on any drift — a missing evidence path, a vanished doc
+substring, a count mismatch, or an aspirational claim whose roadmap marker
+disappeared. The CI job **Claims Registry Drift** runs the same command and
+blocks merge on failure.
+
+---
+
+## Related Documents
+
+- **Contributor hub:** [development/README.md](./README.md)
+- **PR workflow:** [CONTRIBUTION_GUIDE.md](./CONTRIBUTION_GUIDE.md)
+- **Governance contributing notes:** [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -27,6 +27,7 @@ related_files:
 | Tool Development   | This file | [TOOL_DEVELOPMENT.md](./TOOL_DEVELOPMENT.md)                       |
 | Memory Development | This file | [MEMORY_DEVELOPMENT.md](./MEMORY_DEVELOPMENT.md)                   |
 | CLI Delegation     | This file | [CLI_DELEGATION_GUIDE.md](./CLI_DELEGATION_GUIDE.md)               |
+| Claims Registry    | This file | [CLAIMS_REGISTRY.md](./CLAIMS_REGISTRY.md)                         |
 | Coding Standards   | This file | [CODING_STANDARDS.md](../../CODING_STANDARDS.md)                   |
 | Debugging          | This file | [DEBUGGING_OBSERVABILITY.md](../guides/DEBUGGING_OBSERVABILITY.md) |
 


### PR DESCRIPTION
Fixes #3827 (Epic A #3824).

## What

- **Contributor doc** — `docs/development/CLAIMS_REGISTRY.md` documents the landed claims registry: what it is (a claims-to-reality registry catching README/ARCHITECTURE drift), the YAML entry shape (`id`, `claim`, `subject`, `status`, `evidenceType`, `verification {method, path, expected, symbol}`, `lastVerified`, `caveat`), the five verification methods (`file-exists`, `file-contains`, `enum-member-count`, `manifest-tool-count`, `roadmap-status`), how to add/update a claim, a worked example (the `mcp-tool-count` / 46-tools entry), and how to run `pnpm claims:check` locally.
- **Indexed** in the canonical index `docs/README.md` (Development section) and the development hub `docs/development/README.md` Quick Navigation. Linked from `CONTRIBUTING.md` Documentation Requirements.
- **README badge** — a shields.io GitHub-Actions **CI-status** badge for the Documentation Gate workflow (`docs-check.yml`), which hosts the blocking "Claims Registry Drift" job, added to the hand-maintained header badge group (not the auto-generated `GOVERNANCE:README_TOOLS` section).

## Why a CI-status badge, not a count

A hardcoded "8 claims" number in the README would itself become stale — the exact doc/code drift the registry exists to prevent — and would need a generator + inject markers to stay honest (out of scope, and new drift surface). A workflow-status badge reflects live gate health and can never go stale.

## Gates run locally

- `pnpm claims:check` — green, 8/8 claims verified (unchanged; no new claim introduced).
- markdownlint (`.markdownlint.json`) on all touched markdown — clean (fixed one MD060 table-alignment issue).
- Canonical Index Check (`scripts/check-docs-indexed.ts`) — green, 0 unindexed.

Docs + README only — no shippable `src` change, so no changeset (per `scripts/check-changeset.ts` scope). No docs-pipeline change, so no DocOps Skill Sync note required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)