### PR TITLE
feat(orchestration): versioned strategy-manifest schema

### DIFF
--- a/.changeset/strategy-manifest-schema-3834.md
+++ b/.changeset/strategy-manifest-schema-3834.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): versioned strategy-manifest schema + loader (#3834)
+
+Add the schema foundation for Epic C's manifest-driven MetaOrchestrator (#3833):
+a Zod-validated, versioned strategy manifest so a strategy self-describes and the
+router can route over manifest data instead of hardcoded rules.
+
+- `src/orchestration/strategy-manifest.ts` — versioned Zod schema + loader
+  (strict, zero-`any`), MIRRORING the claims-registry pattern (versioned YAML +
+  Zod + loader + Vitest). Per-entry `schemaVersion` (literal, fail-closed on a
+  future shape) plus a top-level registry `version`. Required fields model the
+  current 8 strategies: `id`, `strategy` (router enum), `entrypointTool`,
+  `executorAvailable` (the 4/8 wired-executor gap, declared so routing fails
+  closed), `description`, `maturityTier`, `latencyClass` (reuses the #3734
+  operation-class taxonomy); optional `whenToForce` (#3838 docs). Forward-compat
+  optional fields declared now: `authorityTier` (Epic D #3552) and `costProfile`
+  (Epic G). Registry enforces unique `id` AND unique `strategy`.
+- `__fixtures__/strategy-manifests.example.yaml` — 2-manifest schema fixture
+  (one wired, one fail-closed); NOT loaded by production code.
+- `src/orchestration/strategy-manifest.test.ts` — 18 tests: valid manifests,
+  bad authority/cost enum, missing required field, duplicate id/strategy,
+  schemaVersion literal enforced, router-enum lockstep, fail-closed loader.
+
+Deferred to siblings (out of scope for #3834): migrating the 8 live strategies
+and deleting `STRATEGY_ENTRYPOINT_TOOL` (#3835); the manifest-driven router
+refactor (#3836); drift-gating the registry under `governance:check` (#3837).

--- a/packages/nexus-agents/src/orchestration/__fixtures__/strategy-manifests.example.yaml
+++ b/packages/nexus-agents/src/orchestration/__fixtures__/strategy-manifests.example.yaml
@@ -1,0 +1,29 @@
+# Strategy manifest registry — SCHEMA FIXTURE ONLY (#3834).
+#
+# Two example manifests exercising the schema: one strategy with a wired
+# executor (consensus) and one without (graph-workflow, fail-closed). The full
+# set of 8 live manifests is deferred to #3835; this file exists so the schema
+# has a realistic round-trip test and is NOT loaded by production code.
+version: 1
+manifests:
+  - id: consensus
+    schemaVersion: 1
+    strategy: consensus
+    entrypointTool: consensus_vote
+    executorAvailable: true
+    description: Multi-perspective decision routed to a consensus vote.
+    whenToForce: Force when a decision needs N independent voters rather than one model.
+    maturityTier: stable
+    latencyClass: multi-llm-panel
+    authorityTier: advisory
+    costProfile: medium
+  - id: graph-workflow
+    schemaVersion: 1
+    strategy: graph-workflow
+    entrypointTool: run_graph_workflow
+    # No wired executor today — must declare false so routing fails closed.
+    executorAvailable: false
+    description: DAG / conditional-edge workflow execution.
+    whenToForce: Force when the work is an explicit dependency graph with conditional edges.
+    maturityTier: beta
+    latencyClass: pipeline

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -123,6 +123,29 @@ export type {
 } from './meta-orchestrator.js';
 
 export {
+  StrategyManifestSchema,
+  StrategyManifestRegistrySchema,
+  StrategyNameSchema,
+  AuthorityTierSchema,
+  LatencyClassSchema,
+  MaturityTierSchema,
+  CostProfileSchema,
+  STRATEGY_MANIFEST_SCHEMA_VERSION,
+  parseStrategyManifest,
+  parseStrategyManifestRegistry,
+  loadStrategyManifestRegistry,
+} from './strategy-manifest.js';
+export type {
+  StrategyManifest,
+  StrategyManifestRegistry,
+  StrategyName,
+  AuthorityTier,
+  LatencyClass,
+  MaturityTier,
+  CostProfile,
+} from './strategy-manifest.js';
+
+export {
   createMetaDispatcher,
   createAuditLogOutcomeSink,
   createRecordingOutcomeSink,

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
@@ -1,0 +1,162 @@
+/**
+ * nexus-agents/orchestration - Strategy manifest schema + loader tests.
+ *
+ * @module orchestration/strategy-manifest.test
+ * (Source: Issue #3833, #3834)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  StrategyManifestSchema,
+  StrategyManifestRegistrySchema,
+  StrategyNameSchema,
+  parseStrategyManifest,
+  parseStrategyManifestRegistry,
+  loadStrategyManifestRegistry,
+  STRATEGY_MANIFEST_SCHEMA_VERSION,
+  type StrategyManifest,
+} from './strategy-manifest.js';
+import { type ExecutionStrategy } from './meta-orchestrator.js';
+
+const FIXTURE_PATH = join(import.meta.dirname, '__fixtures__/strategy-manifests.example.yaml');
+
+function baseManifest(overrides: Partial<StrategyManifest> = {}): StrategyManifest {
+  return {
+    id: 'consensus',
+    schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+    strategy: 'consensus',
+    entrypointTool: 'consensus_vote',
+    executorAvailable: true,
+    description: 'Multi-perspective decision routed to a consensus vote.',
+    maturityTier: 'stable',
+    latencyClass: 'multi-llm-panel',
+    ...overrides,
+  };
+}
+
+describe('strategy manifest schema', () => {
+  it('accepts a valid manifest (forward-compat fields optional)', () => {
+    expect(parseStrategyManifest(baseManifest())).toMatchObject({ id: 'consensus' });
+  });
+
+  it('accepts a manifest with the forward-compat Epic D / G fields populated', () => {
+    const m = baseManifest({ authorityTier: 'advisory', costProfile: 'medium' });
+    expect(StrategyManifestSchema.safeParse(m).success).toBe(true);
+  });
+
+  it('rejects a bad authorityTier enum value (Epic D field)', () => {
+    const bad = baseManifest({ authorityTier: 'god-mode' as never });
+    expect(StrategyManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a bad costProfile enum value (Epic G field)', () => {
+    const bad = baseManifest({ costProfile: 'free' as never });
+    expect(StrategyManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a missing required field (executorAvailable)', () => {
+    const rest: Record<string, unknown> = { ...baseManifest() };
+    delete rest['executorAvailable'];
+    expect(StrategyManifestSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects a non-kebab-case id', () => {
+    expect(StrategyManifestSchema.safeParse(baseManifest({ id: 'Bad ID' })).success).toBe(false);
+  });
+
+  it('rejects an unknown strategy name', () => {
+    const bad = { ...baseManifest(), strategy: 'mega-pipeline' };
+    expect(StrategyManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects unknown extra fields (strict)', () => {
+    const bad = { ...baseManifest(), bogus: true };
+    expect(StrategyManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('enforces the schemaVersion literal (fail closed on a future shape)', () => {
+    const bad = { ...baseManifest(), schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION + 1 };
+    expect(StrategyManifestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('allows executorAvailable:false for unwired strategies (fail-closed declaration)', () => {
+    const m = baseManifest({
+      id: 'graph-workflow',
+      strategy: 'graph-workflow',
+      entrypointTool: 'run_graph_workflow',
+      executorAvailable: false,
+    });
+    expect(StrategyManifestSchema.safeParse(m).success).toBe(true);
+  });
+
+  it('keeps the strategy enum in lockstep with the router ExecutionStrategy', () => {
+    // Compile-time + runtime guard: every router strategy must be a valid
+    // manifest strategy name (a divergence would break #3835's migration).
+    const routerStrategies: ExecutionStrategy[] = [
+      'single-shot',
+      'dev-pipeline',
+      'pipeline',
+      'graph-workflow',
+      'orchestrate',
+      'consensus',
+      'spec',
+      'research',
+    ];
+    for (const s of routerStrategies) {
+      expect(StrategyNameSchema.safeParse(s).success).toBe(true);
+    }
+    expect(StrategyNameSchema.options.length).toBe(routerStrategies.length);
+  });
+});
+
+describe('strategy manifest registry schema', () => {
+  it('rejects duplicate manifest ids', () => {
+    const bad = { version: 1, manifests: [baseManifest(), baseManifest()] };
+    expect(StrategyManifestRegistrySchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects two manifests fronting the same strategy', () => {
+    const bad = {
+      version: 1,
+      manifests: [baseManifest({ id: 'consensus' }), baseManifest({ id: 'consensus-alt' })],
+    };
+    expect(StrategyManifestRegistrySchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('requires at least one manifest', () => {
+    expect(StrategyManifestRegistrySchema.safeParse({ version: 1, manifests: [] }).success).toBe(
+      false
+    );
+  });
+
+  it('requires a positive top-level version', () => {
+    const bad = { version: 0, manifests: [baseManifest()] };
+    expect(StrategyManifestRegistrySchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('strategy manifest loader', () => {
+  it('loads + validates the example fixture registry from disk', () => {
+    const registry = loadStrategyManifestRegistry(FIXTURE_PATH);
+    expect(registry.version).toBe(1);
+    expect(registry.manifests.length).toBe(2);
+    // The fixture covers both a wired and a fail-closed strategy.
+    expect(registry.manifests.some((m) => m.executorAvailable)).toBe(true);
+    expect(registry.manifests.some((m) => !m.executorAvailable)).toBe(true);
+  });
+
+  it('parses the fixture via the YAML text parser', () => {
+    const text = readFileSync(FIXTURE_PATH, 'utf-8');
+    const registry = parseStrategyManifestRegistry(text);
+    const ids = registry.manifests.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('throws fail-closed when the registry file is missing', () => {
+    expect(() => loadStrategyManifestRegistry('/no/such/strategy-manifests.yaml')).toThrow(
+      /not found/
+    );
+  });
+});

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.ts
@@ -1,0 +1,227 @@
+/**
+ * nexus-agents/orchestration - Strategy Manifest schema + loader.
+ *
+ * The strategy-manifest registry (`governance/strategy-manifests.yaml`) is the
+ * single source of truth describing each routable execution strategy: which
+ * engine fronts it, whether it has a wired executor, when to force it, and the
+ * forward-compat governance (authority tier — Epic D) and cost (Epic G) fields.
+ * The MetaOrchestrator routes purely over manifest data — adding a capability
+ * becomes "register a manifest", not "edit the router" (Epic C, #3833).
+ *
+ * This module owns ONLY the schema + loader/validator (child #3834). It MIRRORS
+ * the claims-registry pattern (versioned YAML + Zod schema + loader + Vitest) so
+ * a reviewer reasons about both with the same mental model.
+ *
+ * Explicitly deferred to siblings:
+ * - #3835: migrating the 8 live strategies (`STRATEGY_ENTRYPOINT_TOOL`,
+ *   run-tool.ts) to registered manifests + the behaviour-parity golden test.
+ * - #3836: the router refactor that consumes these manifests instead of the
+ *   hardcoded `decideStrategy` rules.
+ * - #3837: drift-gating the registry under `governance:check`.
+ *
+ * @module orchestration/strategy-manifest
+ * (Source: Issue #3833, #3834)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+
+/**
+ * Bump when a backward-incompatible change to the manifest shape lands. The
+ * loader rejects any document whose `schemaVersion` it does not understand, so a
+ * stale manifest fails closed at startup rather than routing on a misread shape.
+ */
+export const STRATEGY_MANIFEST_SCHEMA_VERSION = 1 as const;
+
+/**
+ * The eight execution strategies the MetaOrchestrator can select today. Mirrors
+ * (and must stay in lockstep with) `ExecutionStrategy` in `meta-orchestrator.ts`;
+ * kept as an independent `z.enum` here so the manifest schema is self-contained
+ * and validatable without importing the router. #3835 registers one manifest per
+ * member; a divergence between the two is caught by the manifest registry test.
+ */
+export const StrategyNameSchema = z.enum([
+  'single-shot',
+  'dev-pipeline',
+  'pipeline',
+  'graph-workflow',
+  'orchestrate',
+  'consensus',
+  'spec',
+  'research',
+]);
+export type StrategyName = z.infer<typeof StrategyNameSchema>;
+
+/**
+ * Authority tier (Epic D, #3552). Declares HOW MUCH AUTHORITY a strategy's
+ * output carries in the governed action path. The field lands now (#3834) so
+ * manifests can be authored against it; ENFORCEMENT lands in Epic D. Ordered
+ * least→most authoritative:
+ * - `observe`: produces signal only; never acts.
+ * - `suggest`: proposes; a human/governor must approve before any action.
+ * - `advisory`: acts in low-stakes paths; gated in high-stakes ones.
+ * - `enforce`: may take governed action directly (the promotion target #3552
+ *   gates into).
+ */
+export const AuthorityTierSchema = z.enum(['observe', 'suggest', 'advisory', 'enforce']);
+export type AuthorityTier = z.infer<typeof AuthorityTierSchema>;
+
+/**
+ * Expected latency class — reuses the #3734 operation-class taxonomy
+ * (`OperationClassName` in `config/timeouts.ts`) so a manifest's latency
+ * expectation is the SAME vocabulary the runaway-guard layer already speaks.
+ * Declared independently here (no cross-module import in the schema) for the
+ * same self-containment reason as {@link StrategyNameSchema}.
+ */
+export const LatencyClassSchema = z.enum([
+  'interactive',
+  'single-llm',
+  'multi-llm-panel',
+  'pipeline',
+  'network-fetch',
+  'async-job-body',
+]);
+export type LatencyClass = z.infer<typeof LatencyClassSchema>;
+
+/**
+ * Maturity tier — how battle-tested a strategy is. Routing/observability may
+ * down-weight `experimental` strategies. Distinct from {@link AuthorityTier},
+ * which is about permission, not proven-ness.
+ */
+export const MaturityTierSchema = z.enum(['experimental', 'beta', 'stable']);
+export type MaturityTier = z.infer<typeof MaturityTierSchema>;
+
+/**
+ * Cost profile (Epic G). Placeholder vocabulary so manifests can be authored
+ * with a coarse hint now; Epic G POPULATES real cost data and may extend this.
+ * Optional on the manifest until Epic G lands.
+ */
+export const CostProfileSchema = z.enum(['low', 'medium', 'high', 'variable']);
+export type CostProfile = z.infer<typeof CostProfileSchema>;
+
+/**
+ * A single strategy manifest. `.strict()` so an unknown/typo'd field fails
+ * validation rather than being silently ignored (same discipline as the claims
+ * registry). Required fields model the current reality; the two forward-compat
+ * governance/cost fields are optional so #3835 can register all 8 manifests
+ * before Epic D/G populate them.
+ */
+export const StrategyManifestSchema = z
+  .object({
+    /**
+     * Stable kebab-case identifier; never reused. For the initial 8 this equals
+     * the strategy name, but `id` is a distinct field so future strategies can
+     * carry a more specific id without colliding with the {@link StrategyName}
+     * enum.
+     */
+    id: z.string().regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'id must be kebab-case'),
+    /**
+     * The manifest-shape version this entry was authored against. Must equal
+     * {@link STRATEGY_MANIFEST_SCHEMA_VERSION}; a mismatch fails closed so a
+     * manifest written for a future shape is never misread.
+     */
+    schemaVersion: z.literal(STRATEGY_MANIFEST_SCHEMA_VERSION),
+    /** The execution strategy this manifest describes (router enum). */
+    strategy: StrategyNameSchema,
+    /**
+     * The concrete MCP tool / engine that fronts this strategy — the
+     * force-strategy entry point (generalizes `STRATEGY_ENTRYPOINT_TOOL`,
+     * run-tool.ts). Non-empty.
+     */
+    entrypointTool: z.string().min(1),
+    /**
+     * Whether a wired executor exists for this strategy (run-tool.ts
+     * `buildDefaultExecutors`). FAIL-CLOSED routing key: only 4/8 are `true`
+     * today (dev-pipeline, pipeline, research, consensus); the rest must declare
+     * `false` so the router never selects an unexecutable strategy silently and
+     * `execute:true` returns the structured `no_executor` envelope from manifest
+     * data (#3835) instead of a hardcoded map.
+     */
+    executorAvailable: z.boolean(),
+    /** One-line human description of what this strategy is for (#3838 docs). */
+    description: z.string().min(1),
+    /**
+     * Guidance on when to FORCE this strategy via `run({ forceStrategy })` —
+     * the escape-hatch docs surfaced in #3838. Optional: the router selects by
+     * capability; this is operator guidance, not a routing input.
+     */
+    whenToForce: z.string().min(1).optional(),
+    /** Maturity tier; defaults are not assumed — author states it explicitly. */
+    maturityTier: MaturityTierSchema,
+    /** Expected latency class (#3734 taxonomy). */
+    latencyClass: LatencyClassSchema,
+    /**
+     * Authority tier — FORWARD-COMPAT for Epic D (#3552). Optional until Epic D
+     * enforcement lands; when present it must be a valid {@link AuthorityTier}.
+     */
+    authorityTier: AuthorityTierSchema.optional(),
+    /**
+     * Cost profile — FORWARD-COMPAT for Epic G. Optional until Epic G populates
+     * real cost data; when present it must be a valid {@link CostProfile}.
+     */
+    costProfile: CostProfileSchema.optional(),
+  })
+  .strict();
+export type StrategyManifest = z.infer<typeof StrategyManifestSchema>;
+
+/**
+ * The full versioned manifest-registry document. Top-level `version` tracks the
+ * registry CONTENTS revision (cf. the claims registry); each manifest's
+ * `schemaVersion` tracks the per-entry SHAPE. Both `id` and `strategy` must be
+ * unique across the registry — a strategy is fronted by exactly one manifest.
+ */
+export const StrategyManifestRegistrySchema = z
+  .object({
+    version: z.number().int().positive(),
+    manifests: z
+      .array(StrategyManifestSchema)
+      .min(1)
+      .superRefine((manifests, ctx) => {
+        const seenIds = new Set<string>();
+        const seenStrategies = new Set<string>();
+        for (const [i, m] of manifests.entries()) {
+          if (seenIds.has(m.id)) {
+            ctx.addIssue({
+              code: 'custom',
+              message: `duplicate manifest id '${m.id}'`,
+              path: [i, 'id'],
+            });
+          }
+          seenIds.add(m.id);
+          if (seenStrategies.has(m.strategy)) {
+            ctx.addIssue({
+              code: 'custom',
+              message: `duplicate strategy '${m.strategy}' (a strategy is fronted by exactly one manifest)`,
+              path: [i, 'strategy'],
+            });
+          }
+          seenStrategies.add(m.strategy);
+        }
+      }),
+  })
+  .strict();
+export type StrategyManifestRegistry = z.infer<typeof StrategyManifestRegistrySchema>;
+
+/** Parse + validate a single manifest from a plain object. Throws `ZodError`. */
+export function parseStrategyManifest(raw: unknown): StrategyManifest {
+  return StrategyManifestSchema.parse(raw);
+}
+
+/** Parse + validate a registry from raw YAML text. Throws `ZodError` on drift. */
+export function parseStrategyManifestRegistry(yamlText: string): StrategyManifestRegistry {
+  const raw: unknown = parseYaml(yamlText);
+  return StrategyManifestRegistrySchema.parse(raw);
+}
+
+/**
+ * Load + validate the manifest registry from disk. Fail-closed: a missing file
+ * or a schema violation throws rather than returning a partial registry.
+ * @throws if the file is missing or fails schema validation.
+ */
+export function loadStrategyManifestRegistry(registryPath: string): StrategyManifestRegistry {
+  if (!existsSync(registryPath)) {
+    throw new Error(`Strategy manifest registry not found: ${registryPath}`);
+  }
+  return parseStrategyManifestRegistry(readFileSync(registryPath, 'utf-8'));
+}


### PR DESCRIPTION
Fixes #3834. Part of Epic C #3833 (M2).

The schema foundation the rest of Epic C (and parts of D/G) build on. Scope is **the schema + loader + tests only** — no strategy migration, no router refactor.

## What landed

- **`src/orchestration/strategy-manifest.ts`** — versioned, Zod-validated strategy manifest + registry, plus parse/load helpers. Strict (`.strict()`), zero-`any`. MIRRORS the claims-registry pattern (versioned YAML + Zod schema + loader + Vitest) for reviewer consistency.
- **`__fixtures__/strategy-manifests.example.yaml`** — a 2-manifest schema fixture (one wired, one fail-closed). NOT loaded by production code; the 8 live manifests are deferred to #3835.
- **`strategy-manifest.test.ts`** — 18 tests (TDD).
- Exports wired through `orchestration/index.ts`; changeset added (`minor`).

## Schema design + field rationale

Two version layers, on purpose: a top-level registry `version` (contents revision, like the claims registry) and a per-entry `schemaVersion` (a `z.literal(1)` — a manifest authored for a future shape **fails closed** rather than being misread).

| Field | Type | Req? | Rationale |
|---|---|---|---|
| `id` | kebab-case string | yes | Stable identifier, never reused. Distinct from `strategy` so future strategies can carry a more specific id. |
| `schemaVersion` | `literal(1)` | yes | Per-entry shape version; fail-closed on mismatch. |
| `strategy` | enum (the 8) | yes | Router strategy name; kept in lockstep with `ExecutionStrategy` (guarded by a test). |
| `entrypointTool` | non-empty string | yes | The MCP tool/engine that fronts the strategy — generalizes `STRATEGY_ENTRYPOINT_TOOL`. |
| `executorAvailable` | boolean | yes | **Fail-closed routing key.** Only 4/8 are `true` today (dev-pipeline, pipeline, research, consensus); the rest declare `false` so routing never picks an unexecutable strategy silently. |
| `description` | non-empty string | yes | One-line purpose (#3838 docs). |
| `whenToForce` | string | optional | Operator guidance for `run({ forceStrategy })` escape hatch (#3838). |
| `maturityTier` | `experimental\|beta\|stable` | yes | Proven-ness (distinct from authority). |
| `latencyClass` | enum | yes | Reuses the **#3734 operation-class taxonomy** (`OperationClassName`). |
| **`authorityTier`** | `observe\|suggest\|advisory\|enforce` | **optional (forward-compat)** | **Epic D (#3552).** Field lands now; enforcement lands in D. |
| **`costProfile`** | `low\|medium\|high\|variable` | **optional (forward-compat)** | **Epic G.** Placeholder vocabulary; G populates real cost data. |

Registry-level invariants: ≥1 manifest, unique `id` AND unique `strategy` (a strategy is fronted by exactly one manifest). Loader throws on a missing file or schema violation (fail-closed at startup).

## Tests (18, all green)

Valid manifest (forward-compat fields omitted and populated); rejects bad `authorityTier` enum, bad `costProfile` enum, missing required field, non-kebab `id`, unknown strategy, unknown extra field (strict), wrong `schemaVersion` literal; allows `executorAvailable:false`; router-enum lockstep; duplicate `id` / duplicate `strategy` rejected; ≥1-manifest + positive-version registry rules; loader round-trips the fixture from disk and throws fail-closed when missing.

## Deferred (out of scope here)

- **#3835** — migrate the 8 live strategies to manifests; delete `STRATEGY_ENTRYPOINT_TOOL`; behaviour-parity golden test.
- **#3836** — manifest-driven router refactor (≤400 lines).
- **#3837** — drift-gate the registry under `governance:check`.

## CI

`pnpm install --frozen-lockfile`, `typecheck`, `lint`, `build`, `claims:check` (stays green, 8/8), and the orchestration+governance suite (1106 tests) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)