### PR TITLE
feat(orchestration): migrate all 8 run-tool strategies to manifests (#3835)

### DIFF
--- a/.changeset/migrate-strategies-to-manifests-3835.md
+++ b/.changeset/migrate-strategies-to-manifests-3835.md
@@ -1,0 +1,34 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): migrate all 8 run-tool strategies to the manifest registry (#3835)
+
+Replace the hardcoded `STRATEGY_ENTRYPOINT_TOOL` map (run-tool.ts) and the
+implicit "which strategies have a wired executor" knowledge with eight registered
+strategy manifests, validated against the #3834 Zod schema. Adding a capability
+becomes "register a manifest", not "edit a map in the tool layer" (Epic C #3833).
+
+- `governance/strategy-manifests.yaml` — the human-facing source of truth: one
+  manifest per strategy (single-shot, dev-pipeline, pipeline, graph-workflow,
+  orchestrate, consensus, spec, research) with entrypointTool, executorAvailable
+  (4/8 true: dev-pipeline, pipeline, research, consensus), description,
+  whenToForce, maturityTier, latencyClass. Forward-compat authorityTier (Epic D)
+  / costProfile (Epic G) intentionally omitted until those epics populate them.
+- `src/orchestration/strategy-manifest-registry.ts` — the same 8 manifests
+  embedded as a typed constant (no disk I/O on the MCP hot path), validated
+  through the Zod schema at module load (fail-closed on a malformed embedded
+  manifest). Exposes `entrypointToolFor` / `executorAvailableFor` /
+  `getStrategyManifest`.
+- run-tool.ts now resolves `recommendedTool` via `entrypointToolFor(strategy)`;
+  the `STRATEGY_ENTRYPOINT_TOOL` constant + its barrel export are DELETED (zero
+  remaining references to the symbol).
+- Behaviour-parity golden test: the pre-migration entrypoint map and the
+  wired-executor set are snapshotted verbatim and asserted to match the
+  manifest-sourced lookups exactly for all 8 strategies — proving the migration
+  is a no-op on behaviour. Plus full-coverage, fail-closed, and a YAML↔TS
+  no-drift assertion.
+
+Deferred: the `decideStrategy` selection-logic refactor that routes PURELY over
+manifest capability predicates is #3836; drift-gating the YAML under
+`governance:check` is #3837.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,7 +491,7 @@ _Auto-generated from source. 46 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-09_
+_Governance Version: 2026-06-16_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/governance/strategy-manifests.yaml
+++ b/governance/strategy-manifests.yaml
@@ -1,0 +1,115 @@
+# Strategy Manifest Registry
+#
+# Single source of truth for the 8 routable execution strategies the
+# MetaOrchestrator can select. Validated by the Zod schema in
+# packages/nexus-agents/src/orchestration/strategy-manifest.ts and embedded as a
+# typed constant in strategy-manifest-registry.ts (the two are asserted equal by
+# strategy-manifest-registry.test.ts so they cannot drift; #3837 gates this under
+# governance:check).
+#
+# Each manifest:
+#   id                stable kebab-case id (never reused; == strategy for the initial 8)
+#   schemaVersion     per-entry SHAPE version; must equal STRATEGY_MANIFEST_SCHEMA_VERSION
+#   strategy          the router ExecutionStrategy this manifest describes
+#   entrypointTool    the concrete MCP tool / engine that fronts this strategy
+#                     (generalizes the former STRATEGY_ENTRYPOINT_TOOL map)
+#   executorAvailable whether a wired inline executor exists (run-tool buildDefaultExecutors).
+#                     FAIL-CLOSED routing key: only 4/8 are true today
+#                     (dev-pipeline, pipeline, research, consensus). The rest declare
+#                     false so execute:true returns the structured no_executor error.
+#   description       one-line human description of what the strategy is for
+#   whenToForce       operator guidance for run({ forceStrategy }) (#3838)
+#   maturityTier      experimental | beta | stable
+#   latencyClass      expected latency class (#3734 operation-class taxonomy)
+#
+# Forward-compat governance/cost fields (authorityTier — Epic D #3552;
+# costProfile — Epic G) are intentionally OMITTED for the initial 8: they are
+# optional on the schema and are populated when those epics land, not here.
+#
+# Adding a strategy = register a manifest here (and mirror it in the TS module),
+# NOT editing the router (Epic C, #3833). The selection-logic refactor that
+# routes purely over this data is #3836.
+# Source: Issue #3833, #3835 (M2). Schema landed via #3834.
+
+version: 1
+
+manifests:
+  - id: single-shot
+    schemaVersion: 1
+    strategy: single-shot
+    entrypointTool: delegate_to_model
+    executorAvailable: false
+    description: Trivial single-step task delegated to one model.
+    whenToForce: Force when the goal is a one-shot ask that needs no pipeline, gate, or multi-step plan.
+    maturityTier: stable
+    latencyClass: single-llm
+
+  - id: dev-pipeline
+    schemaVersion: 1
+    strategy: dev-pipeline
+    entrypointTool: run_dev_pipeline
+    executorAvailable: true
+    description: Code change run through the dev gate (test / lint / typecheck).
+    whenToForce: Force when the goal is a code change that must pass the dev quality gate before it counts as done.
+    maturityTier: stable
+    latencyClass: pipeline
+
+  - id: pipeline
+    schemaVersion: 1
+    strategy: pipeline
+    entrypointTool: run_pipeline
+    executorAvailable: true
+    description: Multi-stage templated work (audit / general) via the pipeline engine.
+    whenToForce: Force when the work fits a templated multi-stage pipeline rather than a single model call.
+    maturityTier: stable
+    latencyClass: pipeline
+
+  - id: graph-workflow
+    schemaVersion: 1
+    strategy: graph-workflow
+    entrypointTool: run_graph_workflow
+    executorAvailable: false
+    description: DAG / conditional-edge workflow execution.
+    whenToForce: Force when the work is an explicit dependency graph with conditional edges (a predefined workflow template).
+    maturityTier: beta
+    latencyClass: pipeline
+
+  - id: orchestrate
+    schemaVersion: 1
+    strategy: orchestrate
+    entrypointTool: orchestrate
+    executorAvailable: false
+    description: Pattern-based multi-agent orchestration (wave / aflow / puppeteer).
+    whenToForce: Force when the work needs multi-agent orchestration patterns rather than a single linear pipeline.
+    maturityTier: beta
+    latencyClass: async-job-body
+
+  - id: consensus
+    schemaVersion: 1
+    strategy: consensus
+    entrypointTool: consensus_vote
+    executorAvailable: true
+    description: Multi-perspective decision routed to a consensus vote.
+    whenToForce: Force when a decision needs N independent voters rather than one model.
+    maturityTier: stable
+    latencyClass: multi-llm-panel
+
+  - id: spec
+    schemaVersion: 1
+    strategy: spec
+    entrypointTool: execute_spec
+    executorAvailable: false
+    description: Greenfield project built from a markdown spec document.
+    whenToForce: Force when building a greenfield project from a written spec, not a plain goal string.
+    maturityTier: beta
+    latencyClass: async-job-body
+
+  - id: research
+    schemaVersion: 1
+    strategy: research
+    entrypointTool: run_pipeline
+    executorAvailable: true
+    description: Research-heavy work routed through the research pipeline.
+    whenToForce: Force when the goal is research-led (gather, synthesize, compare) rather than a code change or decision.
+    maturityTier: stable
+    latencyClass: pipeline

--- a/packages/nexus-agents/src/mcp/tools/index.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.ts
@@ -442,7 +442,6 @@ export {
   registerRunTool,
   routeGoal,
   RunInputSchema,
-  STRATEGY_ENTRYPOINT_TOOL,
   type RunInput,
   type RunResponse,
 } from './run-tool.js';

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -48,9 +48,9 @@ import {
   isShadowTrainEnabled,
   registerRunTool,
   RunInputSchema,
-  STRATEGY_ENTRYPOINT_TOOL,
   type RunResponse,
 } from './run-tool.js';
+import { entrypointToolFor } from '../../orchestration/strategy-manifest-registry.js';
 import { readJobResult } from '../jobs/job-result-store.js';
 import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
 import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
@@ -73,10 +73,14 @@ const ALL_STRATEGIES: ExecutionStrategy[] = [
   'research',
 ];
 
-describe('STRATEGY_ENTRYPOINT_TOOL', () => {
-  it('maps every execution strategy to a recommended tool', () => {
+// The entrypoint-tool map moved to the strategy-manifest registry (#3835); the
+// exhaustive coverage + behaviour-parity assertions now live in
+// strategy-manifest-registry.test.ts. routeGoal still resolves its
+// recommendedTool through the manifest-sourced entrypointToolFor() below.
+describe('strategy entrypoint resolution (manifest-sourced, #3835)', () => {
+  it('resolves a recommended tool for every execution strategy', () => {
     for (const s of ALL_STRATEGIES) {
-      expect(STRATEGY_ENTRYPOINT_TOOL[s]).toBeTruthy();
+      expect(entrypointToolFor(s)).toBeTruthy();
     }
   });
 });
@@ -104,7 +108,7 @@ describe('routeGoal', () => {
 
   it('always includes a recommendedTool consistent with the strategy', () => {
     const r = routeGoal({ goal: 'research and compare alternatives and evaluate the landscape' });
-    expect(r.recommendedTool).toBe(STRATEGY_ENTRYPOINT_TOOL[r.strategy]);
+    expect(r.recommendedTool).toBe(entrypointToolFor(r.strategy));
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -53,27 +53,12 @@ import {
   type MetaOutcomeSink,
   type MetaOutcomeObserver,
 } from '../../orchestration/meta-dispatcher.js';
+import { entrypointToolFor } from '../../orchestration/strategy-manifest-registry.js';
 import { runDevPipelineForGoal } from './dev-pipeline-tool.js';
 import { runPipelineForGoal } from './pipeline-tool.js';
 import { runConsensusForGoal } from './consensus-vote.js';
 // #3732 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
 import { runAsJob } from '../jobs/run-as-job.js';
-
-/**
- * The concrete MCP tool / engine each strategy routes to. Used to tell the
- * caller which "force-strategy" path executes a given selection until inline
- * execution lands (increment B).
- */
-export const STRATEGY_ENTRYPOINT_TOOL: Readonly<Record<ExecutionStrategy, string>> = {
-  'single-shot': 'delegate_to_model',
-  'dev-pipeline': 'run_dev_pipeline',
-  pipeline: 'run_pipeline',
-  'graph-workflow': 'run_graph_workflow',
-  orchestrate: 'orchestrate',
-  consensus: 'consensus_vote',
-  spec: 'execute_spec',
-  research: 'run_pipeline',
-};
 
 /** Input schema for the `run` tool. */
 export const RunInputSchema = z.object({
@@ -194,7 +179,7 @@ export function routeGoal(input: RunInput, logger?: ILogger): RunResponse {
     ...(decision.shapingQuestions !== undefined
       ? { shapingQuestions: decision.shapingQuestions }
       : {}),
-    recommendedTool: STRATEGY_ENTRYPOINT_TOOL[decision.strategy],
+    recommendedTool: entrypointToolFor(decision.strategy),
     decisionId: decision.decisionId,
     note: NOTE,
   };

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
@@ -1,0 +1,121 @@
+/**
+ * nexus-agents/orchestration - Strategy manifest registry tests (#3835).
+ *
+ * Behaviour-parity golden test for the migration of the 8 run-tool strategies
+ * onto the manifest registry. The pre-migration source of truth — the hardcoded
+ * `STRATEGY_ENTRYPOINT_TOOL` map and the implicit "which strategies have a wired
+ * executor" set (the keys of run-tool's `buildDefaultExecutors`) — is SNAPSHOTTED
+ * here verbatim, and the manifest-sourced lookups are asserted to match it
+ * EXACTLY for all 8 strategies. This proves the migration is a no-op on
+ * behaviour. Plus: full strategy coverage, fail-closed on an unregistered
+ * strategy, and that the embedded TS registry mirrors governance/*.yaml.
+ *
+ * @module orchestration/strategy-manifest-registry.test
+ * (Source: Issue #3833, #3835)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  STRATEGY_MANIFEST_REGISTRY,
+  entrypointToolFor,
+  executorAvailableFor,
+  getStrategyManifest,
+} from './strategy-manifest-registry.js';
+import { parseStrategyManifestRegistry } from './strategy-manifest.js';
+import type { ExecutionStrategy } from './meta-orchestrator.js';
+
+/**
+ * GOLDEN SNAPSHOT — the pre-#3835 hardcoded entrypoint map, copied verbatim from
+ * run-tool.ts before it was deleted. The migration must reproduce these values
+ * byte-for-byte.
+ */
+const LEGACY_STRATEGY_ENTRYPOINT_TOOL: Readonly<Record<ExecutionStrategy, string>> = {
+  'single-shot': 'delegate_to_model',
+  'dev-pipeline': 'run_dev_pipeline',
+  pipeline: 'run_pipeline',
+  'graph-workflow': 'run_graph_workflow',
+  orchestrate: 'orchestrate',
+  consensus: 'consensus_vote',
+  spec: 'execute_spec',
+  research: 'run_pipeline',
+};
+
+/**
+ * GOLDEN SNAPSHOT — the pre-#3835 executor-availability truth. Inline execution
+ * was wired for exactly these 4 strategies (the keys of run-tool's
+ * `buildDefaultExecutors`); the other 4 failed closed with `no_executor`. The
+ * manifest `executorAvailable` flags must reproduce this set exactly.
+ */
+const LEGACY_EXECUTOR_AVAILABLE: Readonly<Record<ExecutionStrategy, boolean>> = {
+  'single-shot': false,
+  'dev-pipeline': true,
+  pipeline: true,
+  'graph-workflow': false,
+  orchestrate: false,
+  consensus: true,
+  spec: false,
+  research: true,
+};
+
+const ALL_STRATEGIES = Object.keys(LEGACY_STRATEGY_ENTRYPOINT_TOOL) as ExecutionStrategy[];
+
+describe('strategy manifest registry (#3835)', () => {
+  it('registers exactly one manifest per execution strategy (all 8)', () => {
+    expect(STRATEGY_MANIFEST_REGISTRY.manifests).toHaveLength(ALL_STRATEGIES.length);
+    for (const s of ALL_STRATEGIES) {
+      expect(getStrategyManifest(s), `manifest missing for strategy '${s}'`).toBeDefined();
+    }
+  });
+
+  it("each manifest's id equals its strategy for the initial 8", () => {
+    for (const m of STRATEGY_MANIFEST_REGISTRY.manifests) {
+      expect(m.id).toBe(m.strategy);
+    }
+  });
+});
+
+describe('behaviour parity: manifest-sourced lookups === legacy STRATEGY_ENTRYPOINT_TOOL', () => {
+  it('entrypoint tool matches the legacy map EXACTLY for all 8 strategies', () => {
+    for (const s of ALL_STRATEGIES) {
+      expect(entrypointToolFor(s), `entrypoint mismatch for '${s}'`).toBe(
+        LEGACY_STRATEGY_ENTRYPOINT_TOOL[s]
+      );
+    }
+  });
+
+  it('executorAvailable matches the legacy wired-executor set EXACTLY (4/8 true)', () => {
+    for (const s of ALL_STRATEGIES) {
+      expect(executorAvailableFor(s), `executorAvailable mismatch for '${s}'`).toBe(
+        LEGACY_EXECUTOR_AVAILABLE[s]
+      );
+    }
+    const wired = ALL_STRATEGIES.filter((s) => executorAvailableFor(s));
+    expect(wired.sort()).toEqual(['consensus', 'dev-pipeline', 'pipeline', 'research'].sort());
+  });
+});
+
+describe('fail-closed behaviour', () => {
+  it('throws on an unregistered strategy (entrypoint)', () => {
+    expect(() => entrypointToolFor('does-not-exist' as ExecutionStrategy)).toThrow(
+      /No strategy manifest registered/
+    );
+  });
+
+  it('throws on an unregistered strategy (executorAvailable)', () => {
+    expect(() => executorAvailableFor('does-not-exist' as ExecutionStrategy)).toThrow(
+      /No strategy manifest registered/
+    );
+  });
+});
+
+describe('governance YAML mirror', () => {
+  it('the embedded TS registry equals governance/strategy-manifests.yaml (no drift)', () => {
+    // src/orchestration -> repo root is four levels up.
+    const repoRoot = join(import.meta.dirname, '..', '..', '..', '..');
+    const yamlPath = join(repoRoot, 'governance', 'strategy-manifests.yaml');
+    const fromYaml = parseStrategyManifestRegistry(readFileSync(yamlPath, 'utf-8'));
+    expect(fromYaml).toEqual(STRATEGY_MANIFEST_REGISTRY);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
@@ -1,0 +1,186 @@
+/**
+ * nexus-agents/orchestration - Strategy manifest registry (the live 8 manifests).
+ *
+ * The runtime source of truth for the eight routable execution strategies. This
+ * REPLACES the former hardcoded `STRATEGY_ENTRYPOINT_TOOL` map in run-tool.ts
+ * (#3835): the entrypoint-tool and executor-availability lookups the run path
+ * needs are now DATA, read from a validated manifest registry rather than a
+ * literal map embedded in the tool layer.
+ *
+ * The manifests are embedded here as a typed constant (no disk I/O on the MCP
+ * hot path) and validated through {@link parseStrategyManifestRegistry} AT MODULE
+ * LOAD — a malformed registry fails closed at import time, exactly as the
+ * disk-loaded path would. The companion `governance/strategy-manifests.yaml` is
+ * the human-facing / docs source of truth (#3838) and the drift-gate target
+ * (#3837); `strategy-manifest-registry.test.ts` asserts the two are equal so
+ * they cannot diverge.
+ *
+ * Out of scope (deferred): the selection-logic refactor that routes PURELY over
+ * this data — `decideStrategy` in meta-orchestrator.ts — is #3836. This module
+ * only relocates the entrypoint/executor lookups off the hardcoded map.
+ *
+ * @module orchestration/strategy-manifest-registry
+ * (Source: Issue #3833, #3835 — schema landed via #3834)
+ */
+
+import {
+  StrategyManifestRegistrySchema,
+  STRATEGY_MANIFEST_SCHEMA_VERSION,
+  type StrategyManifest,
+  type StrategyManifestRegistry,
+} from './strategy-manifest.js';
+import type { ExecutionStrategy } from './meta-orchestrator.js';
+
+/**
+ * The eight live strategy manifests. MIRRORS `governance/strategy-manifests.yaml`
+ * byte-for-byte (enforced by the registry test). Forward-compat `authorityTier`
+ * (Epic D) / `costProfile` (Epic G) are intentionally omitted until those epics
+ * populate them.
+ */
+const RAW_REGISTRY: StrategyManifestRegistry = {
+  version: 1,
+  manifests: [
+    {
+      id: 'single-shot',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'single-shot',
+      entrypointTool: 'delegate_to_model',
+      executorAvailable: false,
+      description: 'Trivial single-step task delegated to one model.',
+      whenToForce:
+        'Force when the goal is a one-shot ask that needs no pipeline, gate, or multi-step plan.',
+      maturityTier: 'stable',
+      latencyClass: 'single-llm',
+    },
+    {
+      id: 'dev-pipeline',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'dev-pipeline',
+      entrypointTool: 'run_dev_pipeline',
+      executorAvailable: true,
+      description: 'Code change run through the dev gate (test / lint / typecheck).',
+      whenToForce:
+        'Force when the goal is a code change that must pass the dev quality gate before it counts as done.',
+      maturityTier: 'stable',
+      latencyClass: 'pipeline',
+    },
+    {
+      id: 'pipeline',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'pipeline',
+      entrypointTool: 'run_pipeline',
+      executorAvailable: true,
+      description: 'Multi-stage templated work (audit / general) via the pipeline engine.',
+      whenToForce:
+        'Force when the work fits a templated multi-stage pipeline rather than a single model call.',
+      maturityTier: 'stable',
+      latencyClass: 'pipeline',
+    },
+    {
+      id: 'graph-workflow',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'graph-workflow',
+      entrypointTool: 'run_graph_workflow',
+      executorAvailable: false,
+      description: 'DAG / conditional-edge workflow execution.',
+      whenToForce:
+        'Force when the work is an explicit dependency graph with conditional edges (a predefined workflow template).',
+      maturityTier: 'beta',
+      latencyClass: 'pipeline',
+    },
+    {
+      id: 'orchestrate',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'orchestrate',
+      entrypointTool: 'orchestrate',
+      executorAvailable: false,
+      description: 'Pattern-based multi-agent orchestration (wave / aflow / puppeteer).',
+      whenToForce:
+        'Force when the work needs multi-agent orchestration patterns rather than a single linear pipeline.',
+      maturityTier: 'beta',
+      latencyClass: 'async-job-body',
+    },
+    {
+      id: 'consensus',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'consensus',
+      entrypointTool: 'consensus_vote',
+      executorAvailable: true,
+      description: 'Multi-perspective decision routed to a consensus vote.',
+      whenToForce: 'Force when a decision needs N independent voters rather than one model.',
+      maturityTier: 'stable',
+      latencyClass: 'multi-llm-panel',
+    },
+    {
+      id: 'spec',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'spec',
+      entrypointTool: 'execute_spec',
+      executorAvailable: false,
+      description: 'Greenfield project built from a markdown spec document.',
+      whenToForce:
+        'Force when building a greenfield project from a written spec, not a plain goal string.',
+      maturityTier: 'beta',
+      latencyClass: 'async-job-body',
+    },
+    {
+      id: 'research',
+      schemaVersion: STRATEGY_MANIFEST_SCHEMA_VERSION,
+      strategy: 'research',
+      entrypointTool: 'run_pipeline',
+      executorAvailable: true,
+      description: 'Research-heavy work routed through the research pipeline.',
+      whenToForce:
+        'Force when the goal is research-led (gather, synthesize, compare) rather than a code change or decision.',
+      maturityTier: 'stable',
+      latencyClass: 'pipeline',
+    },
+  ],
+};
+
+/**
+ * The validated live registry. Parsed through the Zod schema at module load so a
+ * malformed embedded manifest fails closed at import time (same discipline as the
+ * disk loader). The `.strict()` schema also rejects a typo'd field.
+ */
+export const STRATEGY_MANIFEST_REGISTRY: StrategyManifestRegistry =
+  StrategyManifestRegistrySchema.parse(RAW_REGISTRY);
+
+/** Index manifests by strategy for O(1) lookups; built once at module load. */
+const BY_STRATEGY: ReadonlyMap<ExecutionStrategy, StrategyManifest> = new Map(
+  STRATEGY_MANIFEST_REGISTRY.manifests.map((m) => [m.strategy, m])
+);
+
+/** Returns the manifest fronting a strategy, or undefined if none is registered. */
+export function getStrategyManifest(strategy: ExecutionStrategy): StrategyManifest | undefined {
+  return BY_STRATEGY.get(strategy);
+}
+
+/**
+ * The concrete MCP tool / engine that fronts a strategy — the manifest-sourced
+ * replacement for the former `STRATEGY_ENTRYPOINT_TOOL[strategy]` lookup. Throws
+ * if the strategy has no manifest: every {@link ExecutionStrategy} MUST be
+ * registered, and a missing one is a programming error caught fail-closed (the
+ * registry test asserts full coverage).
+ */
+export function entrypointToolFor(strategy: ExecutionStrategy): string {
+  const manifest = BY_STRATEGY.get(strategy);
+  if (manifest === undefined) {
+    throw new Error(`No strategy manifest registered for strategy '${strategy}'`);
+  }
+  return manifest.entrypointTool;
+}
+
+/**
+ * Whether a wired inline executor exists for a strategy (the fail-closed routing
+ * key) — the manifest-sourced replacement for the implicit "is this strategy a
+ * key of buildDefaultExecutors" check. Throws on an unregistered strategy for the
+ * same reason as {@link entrypointToolFor}.
+ */
+export function executorAvailableFor(strategy: ExecutionStrategy): boolean {
+  const manifest = BY_STRATEGY.get(strategy);
+  if (manifest === undefined) {
+    throw new Error(`No strategy manifest registered for strategy '${strategy}'`);
+  }
+  return manifest.executorAvailable;
+}


### PR DESCRIPTION
Fixes #3835. Part of Epic C #3833 (M2). Builds on the #3834 strategy-manifest schema.

## What this does
Replaces the hardcoded `STRATEGY_ENTRYPOINT_TOOL` map (run-tool.ts) and the implicit "which strategies have a wired executor" knowledge with **8 registered strategy manifests**, validated against the #3834 Zod schema. The entrypoint-tool / executor-availability lookups the run path needs are now **data read from a validated registry**, not literals in the tool layer. Selection logic is untouched (deferred to #3836).

## The 8 manifests (`executorAvailable`)
| strategy | entrypointTool | executorAvailable |
|---|---|---|
| single-shot | `delegate_to_model` | **false** |
| dev-pipeline | `run_dev_pipeline` | **true** |
| pipeline | `run_pipeline` | **true** |
| graph-workflow | `run_graph_workflow` | **false** |
| orchestrate | `orchestrate` | **false** |
| consensus | `consensus_vote` | **true** |
| spec | `execute_spec` | **false** |
| research | `run_pipeline` | **true** |

4/8 wired (dev-pipeline, pipeline, research, consensus) — matches the pre-migration `buildDefaultExecutors` keys exactly.

## Manifest registry location
- `governance/strategy-manifests.yaml` — human-facing source of truth (mirrors the claims-registry pattern; the #3837 drift-gate target).
- `packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts` — the same 8 manifests embedded as a typed constant (no disk I/O on the MCP hot path), validated through the Zod schema **at module load** (fail-closed on a malformed embedded manifest). Exposes `entrypointToolFor` / `executorAvailableFor` / `getStrategyManifest`.

## What was retargeted
- `run-tool.ts`: `routeGoal` now resolves `recommendedTool` via `entrypointToolFor(decision.strategy)` instead of indexing the deleted map.
- `mcp/tools/index.ts`: dropped the `STRATEGY_ENTRYPOINT_TOOL` barrel re-export.
- `run-tool.test.ts`: the old `STRATEGY_ENTRYPOINT_TOOL` describe block + references now use the manifest-sourced `entrypointToolFor`.

## Parity golden test (TDD)
`strategy-manifest-registry.test.ts` snapshots the **legacy** `STRATEGY_ENTRYPOINT_TOOL` map AND the legacy wired-executor set verbatim, then asserts the manifest-sourced `entrypointToolFor` / `executorAvailableFor` match them **exactly** for all 8 strategies — proving the migration is a no-op on behaviour. Also asserts full strategy coverage, fail-closed on an unregistered strategy, and that the embedded TS registry equals the governance YAML (no drift).

## `STRATEGY_ENTRYPOINT_TOOL` deleted — zero refs
The exported symbol is removed. `grep -rn STRATEGY_ENTRYPOINT_TOOL packages/nexus-agents/src` now matches only: the test's `LEGACY_STRATEGY_ENTRYPOINT_TOOL` golden snapshot, a describe-string, and JSDoc references — no live code reads the old map.

## Deferred
- `decideStrategy` selection-logic refactor that routes purely over manifest capability predicates → **#3836**.
- Drift-gating `governance/strategy-manifests.yaml` under `governance:check` → **#3837**.

## CI (local, all green)
- `pnpm install --frozen-lockfile` ✅
- `pnpm typecheck` ✅
- `pnpm test` (orchestration + mcp/tools: 177 files / 3191 tests passed; parity test green) ✅
- `pnpm build` ✅
- `pnpm lint` ✅
- `pnpm claims:check` ✅ (8 claims verified — blocking gate kept green)
- Changeset added: `.changeset/migrate-strategies-to-manifests-3835.md` (minor) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)