### PR TITLE
feat(orchestration): manifest-driven MetaOrchestrator router (#3836)

### DIFF
--- a/.changeset/manifest-driven-router-3836.md
+++ b/.changeset/manifest-driven-router-3836.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': minor
+---
+
+feat(orchestration): MetaOrchestrator routes over the strategy-manifest registry (#3836)
+
+The MetaOrchestrator's `decideStrategy` selection logic now routes PURELY over
+strategy-manifest data — no strategy names are hardcoded in the router. Adding a
+capability becomes "register a manifest with selection rules", not "edit the
+router" (Epic C #3833), and that invariant is now TESTED.
+
+- `strategy-manifest.ts` (#3834 schema) gains an optional `selectionRules` field:
+  a list of declarative `SelectionRule`s (priority + `patterns` / `pipelineTypes`
+  / `complexities` predicates). Self-contained `WorkflowPattern` / `PipelineType` /
+  complexity enums mirror the router types. Backed by `governance/strategy-manifests.yaml`
+  (mirrored byte-for-byte; the registry test asserts no drift).
+- `strategy-manifest-registry.ts` gains `selectStrategyByManifest(signals, manifests?)`
+  — a generic matcher that evaluates every manifest's rules and picks the
+  highest-priority match (ties broken deterministically by strategy name). It
+  names ZERO strategies. The optional `manifests` arg lets a test register a
+  synthetic 9th manifest and route it with no router edit.
+- All 8 live manifests carry `selectionRules` reproducing the pre-#3836 decision
+  table exactly (consensus 100 > greenfield/research 90 > audit-upgrade 80 >
+  graph/orchestrate 50 > single-shot 40 > dev-pipeline 30). The behaviour-parity
+  matrix is asserted green.
+- `MetaDecision` / `MetaSelectionRecord` now record the matched `manifestId` +
+  `manifestSchemaVersion` (decision provenance / audit trail).
+- File split for the ≤400-line CODING_STANDARDS constraint: `meta-orchestrator.ts`
+  drops from 489 → 317 lines. The routing core moved to
+  `meta-orchestrator-routing.ts` and the decision/record builders to
+  `meta-orchestrator-decision.ts`.
+
+Still literal (by design, not router branches): the structural `strategyFrom*`
+helpers remain for the best-first ALTERNATIVES list (a transparency aid, not the
+selection path) and the existing parity tests; `run-tool.ts buildDefaultExecutors`
+remains a tool-layer map (out of scope — that is run-tool's concern, not the
+router's).

--- a/governance/strategy-manifests.yaml
+++ b/governance/strategy-manifests.yaml
@@ -21,14 +21,17 @@
 #   whenToForce       operator guidance for run({ forceStrategy }) (#3838)
 #   maturityTier      experimental | beta | stable
 #   latencyClass      expected latency class (#3734 operation-class taxonomy)
+#   selectionRules    declarative routing rules the manifest-driven router matches
+#                     over (#3836): each rule has a priority + pattern/pipelineType/
+#                     complexity predicates; highest-priority matching rule wins.
 #
 # Forward-compat governance/cost fields (authorityTier — Epic D #3552;
 # costProfile — Epic G) are intentionally OMITTED for the initial 8: they are
 # optional on the schema and are populated when those epics land, not here.
 #
 # Adding a strategy = register a manifest here (and mirror it in the TS module),
-# NOT editing the router (Epic C, #3833). The selection-logic refactor that
-# routes purely over this data is #3836.
+# NOT editing the router (Epic C, #3833). The router routes PURELY over the
+# selectionRules below (#3836) — no strategy names are hardcoded in the router.
 # Source: Issue #3833, #3835 (M2). Schema landed via #3834.
 
 version: 1
@@ -43,6 +46,10 @@ manifests:
     whenToForce: Force when the goal is a one-shot ask that needs no pipeline, gate, or multi-step plan.
     maturityTier: stable
     latencyClass: single-llm
+    selectionRules:
+      - priority: 40
+        patterns: [sequential]
+        complexities: [simple]
 
   - id: dev-pipeline
     schemaVersion: 1
@@ -53,6 +60,9 @@ manifests:
     whenToForce: Force when the goal is a code change that must pass the dev quality gate before it counts as done.
     maturityTier: stable
     latencyClass: pipeline
+    selectionRules:
+      - priority: 30
+        patterns: [sequential]
 
   - id: pipeline
     schemaVersion: 1
@@ -63,6 +73,10 @@ manifests:
     whenToForce: Force when the work fits a templated multi-stage pipeline rather than a single model call.
     maturityTier: stable
     latencyClass: pipeline
+    selectionRules:
+      - priority: 80
+        pipelineTypes: [audit]
+        patterns: [sequential]
 
   - id: graph-workflow
     schemaVersion: 1
@@ -73,6 +87,9 @@ manifests:
     whenToForce: Force when the work is an explicit dependency graph with conditional edges (a predefined workflow template).
     maturityTier: beta
     latencyClass: pipeline
+    selectionRules:
+      - priority: 50
+        patterns: [graph]
 
   - id: orchestrate
     schemaVersion: 1
@@ -83,6 +100,9 @@ manifests:
     whenToForce: Force when the work needs multi-agent orchestration patterns rather than a single linear pipeline.
     maturityTier: beta
     latencyClass: async-job-body
+    selectionRules:
+      - priority: 50
+        patterns: [wave, aflow, puppeteer]
 
   - id: consensus
     schemaVersion: 1
@@ -93,6 +113,9 @@ manifests:
     whenToForce: Force when a decision needs N independent voters rather than one model.
     maturityTier: stable
     latencyClass: multi-llm-panel
+    selectionRules:
+      - priority: 100
+        patterns: [consensus]
 
   - id: spec
     schemaVersion: 1
@@ -103,6 +126,9 @@ manifests:
     whenToForce: Force when building a greenfield project from a written spec, not a plain goal string.
     maturityTier: beta
     latencyClass: async-job-body
+    selectionRules:
+      - priority: 90
+        pipelineTypes: [greenfield]
 
   - id: research
     schemaVersion: 1
@@ -113,3 +139,6 @@ manifests:
     whenToForce: Force when the goal is research-led (gather, synthesize, compare) rather than a code change or decision.
     maturityTier: stable
     latencyClass: pipeline
+    selectionRules:
+      - priority: 90
+        pipelineTypes: [research]

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator-decision.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator-decision.ts
@@ -1,0 +1,99 @@
+/**
+ * nexus-agents/orchestration - MetaOrchestrator decision + record builders (#3836).
+ *
+ * The pure functions that assemble a {@link MetaDecision} (forced or selected)
+ * and project it to its {@link MetaSelectionRecord} for the audit sink. Extracted
+ * from `meta-orchestrator.ts` so the orchestrator file stays a thin wiring layer
+ * (CODING_STANDARDS ≤400 lines). No I/O, no side effects — every function here is
+ * deterministic given its inputs.
+ *
+ * @module orchestration/meta-orchestrator-decision
+ * (Source: Issue #3836 — router refactor over the manifest registry)
+ */
+
+import type { ExecutionStrategy, MetaDecision, MetaSelectionRecord } from './meta-orchestrator.js';
+import { entrypointToolFor, getStrategyManifest } from './strategy-manifest-registry.js';
+import { decideStrategy, buildAlternatives } from './meta-orchestrator-routing.js';
+import type { TaskClassification } from '../pipeline/adaptive-orchestrator.js';
+import type { RoutingDecision } from './workflow-router-types.js';
+
+/** Common sub-signal fields shared by every decision. */
+function subSignals(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): Pick<MetaDecision, 'pattern' | 'pipelineType' | 'analysis' | 'capabilityGaps'> {
+  return {
+    pattern: routing.pattern,
+    pipelineType: classification.pipelineType,
+    analysis: routing.analysis,
+    ...(routing.capabilityGaps !== undefined ? { capabilityGaps: routing.capabilityGaps } : {}),
+  };
+}
+
+/**
+ * Builds a forced decision. The manifest still backs the audit trail: a forced
+ * strategy resolves its manifest (and entrypoint tool) through the registry, so
+ * even the escape-hatch path is manifest-sourced, not literal.
+ */
+export function buildForcedDecision(
+  forced: ExecutionStrategy,
+  routing: RoutingDecision,
+  classification: TaskClassification
+): Omit<MetaDecision, 'decisionId'> {
+  const manifest = getStrategyManifest(forced);
+  return {
+    strategy: forced,
+    reasoning: `Strategy forced by caller: ${forced} (entrypoint ${entrypointToolFor(forced)})`,
+    confidence: 1.0,
+    alternatives: buildAlternatives(forced, routing, classification),
+    needsShaping: false,
+    manifestId: manifest?.id ?? forced,
+    manifestSchemaVersion: manifest?.schemaVersion ?? 0,
+    ...subSignals(routing, classification),
+  };
+}
+
+/** Builds a selected (auto-routed) decision from the manifest-driven router. */
+export function buildSelectedDecision(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): Omit<MetaDecision, 'decisionId'> {
+  const core = decideStrategy(routing, classification);
+  const needsShaping = routing.needsClarification === true;
+  return {
+    strategy: core.strategy,
+    reasoning: core.reasoning,
+    confidence: core.confidence,
+    alternatives: buildAlternatives(core.strategy, routing, classification),
+    needsShaping,
+    manifestId: core.manifestId,
+    manifestSchemaVersion: core.manifestSchemaVersion,
+    ...(needsShaping && routing.suggestedQuestions !== undefined
+      ? { shapingQuestions: routing.suggestedQuestions }
+      : {}),
+    ...subSignals(routing, classification),
+  };
+}
+
+/** Maps a finished decision to its observability record. */
+export function toRecord(
+  decision: MetaDecision,
+  goal: string,
+  forced: boolean,
+  timestamp: string
+): MetaSelectionRecord {
+  return {
+    decisionId: decision.decisionId,
+    timestamp,
+    goal,
+    strategy: decision.strategy,
+    confidence: decision.confidence,
+    pattern: decision.pattern,
+    pipelineType: decision.pipelineType,
+    alternatives: decision.alternatives,
+    needsShaping: decision.needsShaping,
+    forced,
+    manifestId: decision.manifestId,
+    manifestSchemaVersion: decision.manifestSchemaVersion,
+  };
+}

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts
@@ -1,0 +1,165 @@
+/**
+ * nexus-agents/orchestration - MetaOrchestrator manifest-driven routing core (#3836).
+ *
+ * The selection logic the MetaOrchestrator routes over. Extracted from
+ * `meta-orchestrator.ts` so the orchestrator file stays a thin wiring layer
+ * (CODING_STANDARDS ≤400 lines) and so the router is a single cohesive unit.
+ *
+ * The router routes PURELY over strategy-manifest data: {@link decideStrategy}
+ * matches the registry's {@link selectStrategyByManifest} rules and names ZERO
+ * strategies itself. Adding a routable strategy is "register a manifest with
+ * selection rules", not "edit this router" — the #3836 invariant, proven by the
+ * synthetic-9th-manifest test. The two `strategyFrom*` helpers remain for the
+ * best-first ALTERNATIVES list (a transparency aid, not the selection path) and
+ * for the existing parity tests.
+ *
+ * @module orchestration/meta-orchestrator-routing
+ * (Source: Issue #3836 — router refactor over the manifest registry)
+ */
+
+import type { ExecutionStrategy } from './meta-orchestrator.js';
+import { selectStrategyByManifest, type ManifestSelection } from './strategy-manifest-registry.js';
+import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
+import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
+import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
+
+/** The chosen strategy plus the transparency fields a decision carries. */
+export interface SelectionCore {
+  readonly strategy: ExecutionStrategy;
+  readonly reasoning: string;
+  readonly confidence: number;
+  /** The manifest id that won the selection (audit trail, AC #3836). */
+  readonly manifestId: string;
+  /** The schema version of the winning manifest (audit trail, AC #3836). */
+  readonly manifestSchemaVersion: number;
+}
+
+/**
+ * Maps a workflow pattern (+ complexity) to the execution strategy that engine
+ * fronts. `sequential` collapses to the lightest engine that fits the
+ * complexity. Retained for the alternatives list + parity tests; the SELECTION
+ * path is manifest-driven via {@link decideStrategy}.
+ */
+export function strategyFromPattern(
+  pattern: WorkflowPattern,
+  complexity: TaskAnalysisResult['complexity']
+): ExecutionStrategy {
+  switch (pattern) {
+    case 'consensus':
+      return 'consensus';
+    case 'graph':
+      return 'graph-workflow';
+    case 'wave':
+    case 'aflow':
+    case 'puppeteer':
+      return 'orchestrate';
+    case 'sequential':
+      return complexity === 'simple' ? 'single-shot' : 'dev-pipeline';
+    default: {
+      // Exhaustiveness guard — a new pattern must be mapped explicitly.
+      const _exhaustive: never = pattern;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Maps a pipeline template to the execution strategy that fronts it. */
+export function strategyFromPipelineType(pipelineType: PipelineType): ExecutionStrategy {
+  switch (pipelineType) {
+    case 'greenfield':
+      return 'spec';
+    case 'research':
+      return 'research';
+    case 'audit':
+      return 'pipeline';
+    case 'dev':
+      return 'dev-pipeline';
+    case 'general':
+      return 'pipeline';
+    default: {
+      const _exhaustive: never = pipelineType;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Human-readable reasoning for a manifest-driven selection. */
+function reasoningFor(selection: ManifestSelection, routing: RoutingDecision): string {
+  const { manifest, rule } = selection;
+  const cause =
+    rule.pipelineTypes !== undefined && rule.patterns === undefined
+      ? `pipeline template "${rule.pipelineTypes.join('/')}"`
+      : rule.pipelineTypes !== undefined
+        ? `pipeline template "${rule.pipelineTypes.join('/')}" under pattern "${routing.pattern}"`
+        : `pattern "${routing.pattern}"`;
+  return `${cause} → ${manifest.strategy} (manifest ${manifest.id}; ${routing.reasoning})`;
+}
+
+/**
+ * The core selection rule — now fully data-driven (#3836). It matches the
+ * routing signals (pattern, pipeline template, complexity) against the strategy
+ * manifests' declarative {@link SelectionRule}s and picks the highest-priority
+ * match. No strategy names appear here. The fallback (no rule matched — not
+ * reachable today since every workflow pattern is claimed by a manifest) routes
+ * to the structural-pattern strategy so selection never throws.
+ */
+export function decideStrategy(
+  routing: RoutingDecision,
+  classification: TaskClassification
+): SelectionCore {
+  const { pattern, analysis } = routing;
+  const { pipelineType } = classification;
+
+  const selection = selectStrategyByManifest({
+    pattern,
+    pipelineType,
+    complexity: analysis.complexity,
+  });
+
+  if (selection === undefined) {
+    // Defensive: every pattern is claimed by a manifest today, so this is
+    // unreachable, but selection must never throw on a novel signal combo.
+    const fallback = strategyFromPattern(pattern, analysis.complexity);
+    return {
+      strategy: fallback,
+      reasoning: `No manifest rule matched pattern "${pattern}" — structural fallback to ${fallback}`,
+      confidence: routing.confidence,
+      manifestId: fallback,
+      manifestSchemaVersion: 0,
+    };
+  }
+
+  // A pipeline-template match (greenfield/research/audit) reflects the
+  // classifier's confidence; a pure structural-pattern match reflects the
+  // router's. This preserves the pre-#3836 confidence sourcing exactly.
+  const fromTemplate = selection.rule.pipelineTypes !== undefined;
+  return {
+    strategy: selection.strategy,
+    reasoning: reasoningFor(selection, routing),
+    confidence: fromTemplate ? classification.confidence : routing.confidence,
+    manifestId: selection.manifest.id,
+    manifestSchemaVersion: selection.manifest.schemaVersion,
+  };
+}
+
+/** Builds the best-first alternatives list, excluding the chosen strategy. */
+export function buildAlternatives(
+  chosen: ExecutionStrategy,
+  routing: RoutingDecision,
+  classification: TaskClassification
+): ExecutionStrategy[] {
+  const candidates: ExecutionStrategy[] = [
+    strategyFromPattern(routing.pattern, routing.analysis.complexity),
+    strategyFromPipelineType(classification.pipelineType),
+    'orchestrate',
+  ];
+  const seen = new Set<ExecutionStrategy>([chosen]);
+  const alternatives: ExecutionStrategy[] = [];
+  for (const c of candidates) {
+    if (!seen.has(c)) {
+      seen.add(c);
+      alternatives.push(c);
+    }
+  }
+  return alternatives;
+}

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -158,6 +158,47 @@ describe('MetaOrchestrator.select — integration via real router', () => {
   });
 });
 
+describe('MetaOrchestrator.select — manifest-driven routing audit (#3836)', () => {
+  it('records the matched manifest id + schema version on an auto-routed decision', () => {
+    const meta = createMetaOrchestrator();
+    const d = meta.select({
+      goal: 'should we adopt approach A or approach B',
+      signals: { requiresConsensus: true },
+    });
+    expect(d.strategy).toBe('consensus');
+    expect(d.manifestId).toBe('consensus');
+    expect(d.manifestSchemaVersion).toBe(1);
+  });
+
+  it('reasoning cites the backing manifest (router routes over manifest data)', () => {
+    const meta = createMetaOrchestrator();
+    const d = meta.select({ goal: 'scaffold a new cli project from scratch' });
+    expect(d.strategy).toBe('spec');
+    expect(d.reasoning).toContain('manifest spec');
+  });
+
+  it('emits the manifest id + version into the selection record', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    meta.select({
+      goal: 'research and compare alternative approaches and evaluate the landscape',
+    });
+    const rec = sink.getRecords()[0] as MetaSelectionRecord;
+    expect(rec.strategy).toBe('research');
+    expect(rec.manifestId).toBe('research');
+    expect(rec.manifestSchemaVersion).toBe(1);
+  });
+
+  it('a forced strategy still resolves its manifest for the audit trail', () => {
+    const sink = createRecordingSink();
+    const meta = createMetaOrchestrator({ sink });
+    const d = meta.select({ goal: 'anything', forceStrategy: 'dev-pipeline' });
+    expect(d.manifestId).toBe('dev-pipeline');
+    expect(d.manifestSchemaVersion).toBe(1);
+    expect(sink.getRecords()[0]?.manifestId).toBe('dev-pipeline');
+  });
+});
+
 describe('MetaOrchestrator.select — force override', () => {
   it('honors forceStrategy with full confidence and no shaping', () => {
     const meta = createMetaOrchestrator();

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -23,13 +23,22 @@ import { createLogger, getTimeProvider, getErrorMessage } from '../core/index.js
 import type { ILogger } from '../core/index.js';
 import type { ILearnedStrategySelector, MetaShadowSink } from './meta-shadow-selector.js';
 import { classifyTask } from '../pipeline/adaptive-orchestrator.js';
-import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
+import type { PipelineType } from '../pipeline/adaptive-orchestrator.js';
 import { createWorkflowRouter } from './workflow-router.js';
 import type { IWorkflowRouter } from './workflow-router.js';
-import type { TaskSignals, RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
+import type { TaskSignals, WorkflowPattern } from './workflow-router-types.js';
 import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
 import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
 import type { ICapabilityGapLedger } from '../core/task-analysis/capability-gap-ledger.js';
+import {
+  buildForcedDecision,
+  buildSelectedDecision,
+  toRecord,
+} from './meta-orchestrator-decision.js';
+
+// Re-exported so existing importers keep their public surface (#3836 split): the
+// selection helpers + parity tests live in the routing module now.
+export { strategyFromPattern, strategyFromPipelineType } from './meta-orchestrator-routing.js';
 
 /**
  * Execution strategies the MetaOrchestrator can select. Each maps to an
@@ -100,6 +109,15 @@ export interface MetaDecision {
   readonly analysis: TaskAnalysisResult;
   /** Capability gap report — what's available vs needed. */
   readonly capabilityGaps?: CapabilityGapReport;
+  /**
+   * The id of the strategy manifest that backs this decision (#3836). For an
+   * auto-routed decision it is the manifest whose selection rule won; for a
+   * forced one it is the forced strategy's manifest. The router routes purely
+   * over manifest data, so this is the provenance of the choice.
+   */
+  readonly manifestId: string;
+  /** The schema version of {@link manifestId}'s manifest (#3836 audit trail). */
+  readonly manifestSchemaVersion: number;
 }
 
 /** Public interface for the MetaOrchestrator. */
@@ -141,6 +159,10 @@ export interface MetaSelectionRecord {
   readonly needsShaping: boolean;
   /** Whether the strategy was forced by the caller (vs selected). */
   readonly forced: boolean;
+  /** The strategy manifest id that backed the decision (#3836 audit trail). */
+  readonly manifestId: string;
+  /** The schema version of the backing manifest (#3836 audit trail). */
+  readonly manifestSchemaVersion: number;
 }
 
 /** A sink that receives every selection decision for observability. */
@@ -190,217 +212,6 @@ export function createRecordingSink(maxRecords = DEFAULT_MAX_RECORDS): IRecordin
 }
 
 /**
- * Maps a workflow pattern (+ complexity) to the execution strategy that engine
- * fronts. `sequential` collapses to the lightest engine that fits the
- * complexity.
- */
-export function strategyFromPattern(
-  pattern: WorkflowPattern,
-  complexity: TaskAnalysisResult['complexity']
-): ExecutionStrategy {
-  switch (pattern) {
-    case 'consensus':
-      return 'consensus';
-    case 'graph':
-      return 'graph-workflow';
-    case 'wave':
-    case 'aflow':
-    case 'puppeteer':
-      return 'orchestrate';
-    case 'sequential':
-      return complexity === 'simple' ? 'single-shot' : 'dev-pipeline';
-    default: {
-      // Exhaustiveness guard — a new pattern must be mapped explicitly.
-      const _exhaustive: never = pattern;
-      return _exhaustive;
-    }
-  }
-}
-
-/** Maps a pipeline template to the execution strategy that fronts it. */
-export function strategyFromPipelineType(pipelineType: PipelineType): ExecutionStrategy {
-  switch (pipelineType) {
-    case 'greenfield':
-      return 'spec';
-    case 'research':
-      return 'research';
-    case 'audit':
-      return 'pipeline';
-    case 'dev':
-      return 'dev-pipeline';
-    case 'general':
-      return 'pipeline';
-    default: {
-      const _exhaustive: never = pipelineType;
-      return _exhaustive;
-    }
-  }
-}
-
-interface SelectionCore {
-  readonly strategy: ExecutionStrategy;
-  readonly reasoning: string;
-  readonly confidence: number;
-}
-
-/**
- * The core selection rule. Distinctive pipeline templates (greenfield,
- * research) and an explicit consensus requirement take precedence over the
- * structural pattern; otherwise the structural pattern drives the choice, with
- * the audit template upgrading a plain sequential default to the templated
- * pipeline.
- */
-function decideStrategy(
-  routing: RoutingDecision,
-  classification: TaskClassification
-): SelectionCore {
-  const { pattern, analysis } = routing;
-  const { pipelineType } = classification;
-
-  if (pattern === 'consensus') {
-    return {
-      strategy: 'consensus',
-      reasoning: `Consensus pattern selected (${routing.reasoning}) — routing to a multi-perspective vote`,
-      confidence: routing.confidence,
-    };
-  }
-  if (pipelineType === 'greenfield') {
-    return {
-      strategy: 'spec',
-      reasoning: 'Greenfield work detected — routing to a spec-driven build',
-      confidence: classification.confidence,
-    };
-  }
-  if (pipelineType === 'research') {
-    return {
-      strategy: 'research',
-      reasoning: 'Research-heavy work detected — routing to the research pipeline',
-      confidence: classification.confidence,
-    };
-  }
-
-  const patternStrategy = strategyFromPattern(pattern, analysis.complexity);
-  // The audit template is more specific than a plain sequential default.
-  if (
-    pipelineType === 'audit' &&
-    (patternStrategy === 'dev-pipeline' || patternStrategy === 'single-shot')
-  ) {
-    return {
-      strategy: 'pipeline',
-      reasoning: 'Audit work detected — routing to the templated audit pipeline',
-      confidence: classification.confidence,
-    };
-  }
-  return {
-    strategy: patternStrategy,
-    reasoning: `Pattern "${pattern}" → ${patternStrategy} (${routing.reasoning})`,
-    confidence: routing.confidence,
-  };
-}
-
-/** Builds the best-first alternatives list, excluding the chosen strategy. */
-function buildAlternatives(
-  chosen: ExecutionStrategy,
-  routing: RoutingDecision,
-  classification: TaskClassification
-): ExecutionStrategy[] {
-  const candidates: ExecutionStrategy[] = [
-    strategyFromPattern(routing.pattern, routing.analysis.complexity),
-    strategyFromPipelineType(classification.pipelineType),
-    'orchestrate',
-  ];
-  const seen = new Set<ExecutionStrategy>([chosen]);
-  const alternatives: ExecutionStrategy[] = [];
-  for (const c of candidates) {
-    if (!seen.has(c)) {
-      seen.add(c);
-      alternatives.push(c);
-    }
-  }
-  return alternatives;
-}
-
-/** Common sub-signal fields shared by every decision. */
-function subSignals(
-  routing: RoutingDecision,
-  classification: TaskClassification
-): Pick<MetaDecision, 'pattern' | 'pipelineType' | 'analysis' | 'capabilityGaps'> {
-  return {
-    pattern: routing.pattern,
-    pipelineType: classification.pipelineType,
-    analysis: routing.analysis,
-    ...(routing.capabilityGaps !== undefined ? { capabilityGaps: routing.capabilityGaps } : {}),
-  };
-}
-
-function buildForcedDecision(
-  forced: ExecutionStrategy,
-  routing: RoutingDecision,
-  classification: TaskClassification
-): Omit<MetaDecision, 'decisionId'> {
-  return {
-    strategy: forced,
-    reasoning: `Strategy forced by caller: ${forced}`,
-    confidence: 1.0,
-    alternatives: buildAlternatives(forced, routing, classification),
-    needsShaping: false,
-    ...subSignals(routing, classification),
-  };
-}
-
-function buildSelectedDecision(
-  routing: RoutingDecision,
-  classification: TaskClassification
-): Omit<MetaDecision, 'decisionId'> {
-  const core = decideStrategy(routing, classification);
-  const needsShaping = routing.needsClarification === true;
-  return {
-    strategy: core.strategy,
-    reasoning: core.reasoning,
-    confidence: core.confidence,
-    alternatives: buildAlternatives(core.strategy, routing, classification),
-    needsShaping,
-    ...(needsShaping && routing.suggestedQuestions !== undefined
-      ? { shapingQuestions: routing.suggestedQuestions }
-      : {}),
-    ...subSignals(routing, classification),
-  };
-}
-
-/** Maps a finished decision to its observability record. */
-function toRecord(
-  decision: MetaDecision,
-  goal: string,
-  forced: boolean,
-  timestamp: string
-): MetaSelectionRecord {
-  return {
-    decisionId: decision.decisionId,
-    timestamp,
-    goal,
-    strategy: decision.strategy,
-    confidence: decision.confidence,
-    pattern: decision.pattern,
-    pipelineType: decision.pipelineType,
-    alternatives: decision.alternatives,
-    needsShaping: decision.needsShaping,
-    forced,
-  };
-}
-
-/**
- * Creates a MetaOrchestrator. Selection is deterministic and reuses the
- * existing routing/classification logic rather than duplicating it (DRY). Each
- * selection is emitted to the decision sink for observability (step 2, #3550).
- *
- * @param options.logger - optional logger.
- * @param options.router - optional workflow router (injectable for tests).
- * @param options.sink - optional decision sink (default: audit-log sink).
- * @param options.gapLedger - optional capability-gap ledger; when provided, each
- *   decision's capability gaps are recorded for the self-directed build backlog
- *   (#3555). Default absent — no gap recording, no behavior change.
- */
-/**
  * Computes the learned would-be strategy and logs it alongside the rule-based
  * decision (#3551). Shadow only — never alters the executed decision. Best-effort:
  * a selector/sink failure is logged and swallowed so selection never breaks.
@@ -428,6 +239,33 @@ function recordShadow(
   }
 }
 
+/** Emits the structured "strategy selected" audit log line for a decision. */
+function logSelection(logger: ILogger, decision: MetaDecision, forced: boolean): void {
+  logger.info('MetaOrchestrator strategy selected', {
+    decisionId: decision.decisionId,
+    strategy: decision.strategy,
+    confidence: decision.confidence,
+    pattern: decision.pattern,
+    pipelineType: decision.pipelineType,
+    needsShaping: decision.needsShaping,
+    forced,
+    manifestId: decision.manifestId,
+    manifestSchemaVersion: decision.manifestSchemaVersion,
+  });
+}
+
+/**
+ * Creates a MetaOrchestrator. Selection is deterministic and routes purely over
+ * the strategy-manifest registry (#3836) rather than hardcoded rules. Each
+ * selection is emitted to the decision sink for observability (step 2, #3550).
+ *
+ * @param options.logger - optional logger.
+ * @param options.router - optional workflow router (injectable for tests).
+ * @param options.sink - optional decision sink (default: audit-log sink).
+ * @param options.gapLedger - optional capability-gap ledger; when provided, each
+ *   decision's capability gaps are recorded for the self-directed build backlog
+ *   (#3555). Default absent — no gap recording, no behavior change.
+ */
 export function createMetaOrchestrator(options?: {
   readonly logger?: ILogger | undefined;
   readonly router?: IWorkflowRouter | undefined;
@@ -474,15 +312,7 @@ export function createMetaOrchestrator(options?: {
         });
       }
 
-      logger.info('MetaOrchestrator strategy selected', {
-        decisionId: decision.decisionId,
-        strategy: decision.strategy,
-        confidence: decision.confidence,
-        pattern: decision.pattern,
-        pipelineType: decision.pipelineType,
-        needsShaping: decision.needsShaping,
-        forced,
-      });
+      logSelection(logger, decision, forced);
       return decision;
     },
   };

--- a/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
@@ -54,6 +54,8 @@ function decision(over: Partial<MetaDecision> = {}): MetaDecision {
     pattern: 'sequential',
     pipelineType: 'general',
     analysis: analysis(),
+    manifestId: 'pipeline',
+    manifestSchemaVersion: 1,
     ...over,
   };
 }

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
@@ -22,8 +22,9 @@ import {
   entrypointToolFor,
   executorAvailableFor,
   getStrategyManifest,
+  selectStrategyByManifest,
 } from './strategy-manifest-registry.js';
-import { parseStrategyManifestRegistry } from './strategy-manifest.js';
+import { parseStrategyManifestRegistry, type StrategyManifest } from './strategy-manifest.js';
 import type { ExecutionStrategy } from './meta-orchestrator.js';
 
 /**
@@ -107,6 +108,85 @@ describe('fail-closed behaviour', () => {
     expect(() => executorAvailableFor('does-not-exist' as ExecutionStrategy)).toThrow(
       /No strategy manifest registered/
     );
+  });
+});
+
+describe('manifest-driven router (#3836)', () => {
+  it('reproduces the 8-strategy routing decisions purely from manifest rules', () => {
+    // Parity matrix: { pattern, pipelineType, complexity } → strategy. Mirrors the
+    // pre-#3836 decideStrategy rules, now asserted to come out of the data matcher.
+    const cases: ReadonlyArray<
+      [Parameters<typeof selectStrategyByManifest>[0], ExecutionStrategy]
+    > = [
+      [{ pattern: 'consensus', pipelineType: 'general', complexity: 'moderate' }, 'consensus'],
+      // Consensus pattern outranks every pipeline template.
+      [{ pattern: 'consensus', pipelineType: 'greenfield', complexity: 'moderate' }, 'consensus'],
+      [{ pattern: 'sequential', pipelineType: 'greenfield', complexity: 'moderate' }, 'spec'],
+      [{ pattern: 'sequential', pipelineType: 'research', complexity: 'moderate' }, 'research'],
+      [{ pattern: 'sequential', pipelineType: 'audit', complexity: 'moderate' }, 'pipeline'],
+      [{ pattern: 'sequential', pipelineType: 'audit', complexity: 'simple' }, 'pipeline'],
+      // Audit only upgrades the SEQUENTIAL fallback; graph/wave keep their engine.
+      [{ pattern: 'graph', pipelineType: 'audit', complexity: 'moderate' }, 'graph-workflow'],
+      [{ pattern: 'wave', pipelineType: 'audit', complexity: 'moderate' }, 'orchestrate'],
+      [{ pattern: 'graph', pipelineType: 'dev', complexity: 'moderate' }, 'graph-workflow'],
+      [{ pattern: 'wave', pipelineType: 'dev', complexity: 'moderate' }, 'orchestrate'],
+      [{ pattern: 'aflow', pipelineType: 'dev', complexity: 'complex' }, 'orchestrate'],
+      [{ pattern: 'puppeteer', pipelineType: 'dev', complexity: 'moderate' }, 'orchestrate'],
+      [{ pattern: 'sequential', pipelineType: 'dev', complexity: 'simple' }, 'single-shot'],
+      [{ pattern: 'sequential', pipelineType: 'dev', complexity: 'moderate' }, 'dev-pipeline'],
+      [{ pattern: 'sequential', pipelineType: 'dev', complexity: 'expert' }, 'dev-pipeline'],
+      [{ pattern: 'sequential', pipelineType: 'general', complexity: 'moderate' }, 'dev-pipeline'],
+    ];
+    for (const [signals, expected] of cases) {
+      const selection = selectStrategyByManifest(signals);
+      expect(selection?.strategy, JSON.stringify(signals)).toBe(expected);
+    }
+  });
+
+  it('routes a SYNTHETIC 9th manifest with NO router edit (#3836 invariant)', () => {
+    // A novel strategy carrying its own high-priority rule for a previously
+    // unclaimed signal combination. The matcher selects it with zero code change,
+    // proving "adding a capability = registering a manifest, not editing router".
+    const ninth: StrategyManifest = {
+      id: 'simulation',
+      schemaVersion: 1,
+      strategy: 'spec', // reuse a valid enum member; the id is what's novel here
+      entrypointTool: 'run_simulation',
+      executorAvailable: false,
+      description: 'Synthetic 9th strategy for the no-router-edit invariant test.',
+      maturityTier: 'experimental',
+      latencyClass: 'async-job-body',
+      selectionRules: [{ priority: 200, patterns: ['graph'], pipelineTypes: ['research'] }],
+    };
+    const augmented = [...STRATEGY_MANIFEST_REGISTRY.manifests, ninth];
+    const selection = selectStrategyByManifest(
+      { pattern: 'graph', pipelineType: 'research', complexity: 'complex' },
+      augmented
+    );
+    expect(selection?.manifest.id).toBe('simulation');
+    expect(selection?.rule.priority).toBe(200);
+  });
+
+  it('returns undefined when no manifest rule matches the signals', () => {
+    // A manifest with no selection rules is never auto-routed.
+    const ruleless: StrategyManifest[] = [
+      {
+        id: 'orphan',
+        schemaVersion: 1,
+        strategy: 'spec',
+        entrypointTool: 'execute_spec',
+        executorAvailable: false,
+        description: 'Force-only manifest with no selection rules.',
+        maturityTier: 'beta',
+        latencyClass: 'async-job-body',
+      },
+    ];
+    expect(
+      selectStrategyByManifest(
+        { pattern: 'graph', pipelineType: 'dev', complexity: 'moderate' },
+        ruleless
+      )
+    ).toBeUndefined();
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
@@ -28,8 +28,12 @@ import {
   STRATEGY_MANIFEST_SCHEMA_VERSION,
   type StrategyManifest,
   type StrategyManifestRegistry,
+  type SelectionRule,
 } from './strategy-manifest.js';
 import type { ExecutionStrategy } from './meta-orchestrator.js';
+import type { WorkflowPattern } from './workflow-router-types.js';
+import type { PipelineType } from '../pipeline/adaptive-orchestrator.js';
+import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
 
 /**
  * The eight live strategy manifests. MIRRORS `governance/strategy-manifests.yaml`
@@ -51,6 +55,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the goal is a one-shot ask that needs no pipeline, gate, or multi-step plan.',
       maturityTier: 'stable',
       latencyClass: 'single-llm',
+      // Sequential + trivial complexity collapses to the lightest engine.
+      selectionRules: [{ priority: 40, patterns: ['sequential'], complexities: ['simple'] }],
     },
     {
       id: 'dev-pipeline',
@@ -63,6 +69,9 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the goal is a code change that must pass the dev quality gate before it counts as done.',
       maturityTier: 'stable',
       latencyClass: 'pipeline',
+      // The default for any non-trivial sequential task (single-shot outranks it
+      // only at `simple` complexity; the audit/template overrides outrank both).
+      selectionRules: [{ priority: 30, patterns: ['sequential'] }],
     },
     {
       id: 'pipeline',
@@ -75,6 +84,9 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the work fits a templated multi-stage pipeline rather than a single model call.',
       maturityTier: 'stable',
       latencyClass: 'pipeline',
+      // The audit template is more specific than the plain sequential default:
+      // it upgrades a sequential single-shot/dev-pipeline choice to the pipeline.
+      selectionRules: [{ priority: 80, pipelineTypes: ['audit'], patterns: ['sequential'] }],
     },
     {
       id: 'graph-workflow',
@@ -87,6 +99,7 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the work is an explicit dependency graph with conditional edges (a predefined workflow template).',
       maturityTier: 'beta',
       latencyClass: 'pipeline',
+      selectionRules: [{ priority: 50, patterns: ['graph'] }],
     },
     {
       id: 'orchestrate',
@@ -99,6 +112,7 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the work needs multi-agent orchestration patterns rather than a single linear pipeline.',
       maturityTier: 'beta',
       latencyClass: 'async-job-body',
+      selectionRules: [{ priority: 50, patterns: ['wave', 'aflow', 'puppeteer'] }],
     },
     {
       id: 'consensus',
@@ -110,6 +124,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       whenToForce: 'Force when a decision needs N independent voters rather than one model.',
       maturityTier: 'stable',
       latencyClass: 'multi-llm-panel',
+      // An explicit consensus requirement outranks every template/pattern choice.
+      selectionRules: [{ priority: 100, patterns: ['consensus'] }],
     },
     {
       id: 'spec',
@@ -122,6 +138,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when building a greenfield project from a written spec, not a plain goal string.',
       maturityTier: 'beta',
       latencyClass: 'async-job-body',
+      // A greenfield template outranks the structural pattern fallback.
+      selectionRules: [{ priority: 90, pipelineTypes: ['greenfield'] }],
     },
     {
       id: 'research',
@@ -134,6 +152,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
         'Force when the goal is research-led (gather, synthesize, compare) rather than a code change or decision.',
       maturityTier: 'stable',
       latencyClass: 'pipeline',
+      // A research template outranks the structural pattern fallback.
+      selectionRules: [{ priority: 90, pipelineTypes: ['research'] }],
     },
   ],
 };
@@ -183,4 +203,63 @@ export function executorAvailableFor(strategy: ExecutionStrategy): boolean {
     throw new Error(`No strategy manifest registered for strategy '${strategy}'`);
   }
   return manifest.executorAvailable;
+}
+
+/** The routing signals a manifest selection rule is matched against (#3836). */
+export interface RoutingSignals {
+  readonly pattern: WorkflowPattern;
+  readonly pipelineType: PipelineType;
+  readonly complexity: TaskAnalysisResult['complexity'];
+}
+
+/** A manifest matched by the router, plus the rule that won. */
+export interface ManifestSelection {
+  readonly strategy: ExecutionStrategy;
+  readonly manifest: StrategyManifest;
+  readonly rule: SelectionRule;
+}
+
+/** Whether one selection rule matches the routing signals (all predicates AND). */
+function ruleMatches(rule: SelectionRule, signals: RoutingSignals): boolean {
+  if (rule.patterns !== undefined && !rule.patterns.includes(signals.pattern)) return false;
+  if (rule.pipelineTypes !== undefined && !rule.pipelineTypes.includes(signals.pipelineType)) {
+    return false;
+  }
+  if (rule.complexities !== undefined && !rule.complexities.includes(signals.complexity)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The manifest-driven router core (#3836). Evaluates every registered manifest's
+ * {@link SelectionRule}s against the routing signals and returns the strategy
+ * whose matching rule has the HIGHEST priority. Ties (equal priority) break
+ * deterministically by strategy name so selection is reproducible. Returns
+ * `undefined` only if NO rule across the whole registry matches — the caller
+ * decides the fallback.
+ *
+ * Crucially this function names ZERO strategies: adding a strategy is registering
+ * a manifest with rules, never editing this matcher (the #3836 invariant, proven
+ * by the synthetic-9th-manifest test).
+ */
+export function selectStrategyByManifest(
+  signals: RoutingSignals,
+  manifests: readonly StrategyManifest[] = STRATEGY_MANIFEST_REGISTRY.manifests
+): ManifestSelection | undefined {
+  let best: ManifestSelection | undefined;
+  for (const manifest of manifests) {
+    if (manifest.selectionRules === undefined) continue;
+    for (const rule of manifest.selectionRules) {
+      if (!ruleMatches(rule, signals)) continue;
+      const better =
+        best === undefined ||
+        rule.priority > best.rule.priority ||
+        (rule.priority === best.rule.priority && manifest.strategy < best.strategy);
+      if (better) {
+        best = { strategy: manifest.strategy, manifest, rule };
+      }
+    }
+  }
+  return best;
 }

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
@@ -91,6 +91,27 @@ describe('strategy manifest schema', () => {
     expect(StrategyManifestSchema.safeParse(m).success).toBe(true);
   });
 
+  it('accepts a manifest with declarative selectionRules (#3836)', () => {
+    const m = baseManifest({
+      selectionRules: [{ priority: 100, patterns: ['consensus'] }],
+    });
+    expect(StrategyManifestSchema.safeParse(m).success).toBe(true);
+  });
+
+  it('rejects a selection rule that constrains neither patterns nor pipelineTypes', () => {
+    const m = baseManifest({
+      selectionRules: [{ priority: 10, complexities: ['simple'] }] as never,
+    });
+    expect(StrategyManifestSchema.safeParse(m).success).toBe(false);
+  });
+
+  it('rejects an unknown workflow pattern in a selection rule', () => {
+    const m = baseManifest({
+      selectionRules: [{ priority: 10, patterns: ['mega-wave'] }] as never,
+    });
+    expect(StrategyManifestSchema.safeParse(m).success).toBe(false);
+  });
+
   it('keeps the strategy enum in lockstep with the router ExecutionStrategy', () => {
     // Compile-time + runtime guard: every router strategy must be a valid
     // manifest strategy name (a divergence would break #3835's migration).

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.ts
@@ -101,6 +101,64 @@ export const CostProfileSchema = z.enum(['low', 'medium', 'high', 'variable']);
 export type CostProfile = z.infer<typeof CostProfileSchema>;
 
 /**
+ * Workflow patterns the router's structural classifier emits. Declared
+ * independently here (no import of `workflow-router-types`) for the same
+ * self-containment reason as {@link StrategyNameSchema}; a divergence is caught
+ * by the registry test, which routes every live pattern through the matcher.
+ */
+export const WorkflowPatternSchema = z.enum([
+  'sequential',
+  'wave',
+  'graph',
+  'consensus',
+  'aflow',
+  'puppeteer',
+]);
+
+/**
+ * Pipeline templates the classifier emits (mirrors `PipelineType` in
+ * `pipeline/adaptive-orchestrator.ts`). Self-contained here for the same reason
+ * as {@link WorkflowPatternSchema}.
+ */
+export const PipelineTypeSchema = z.enum(['dev', 'research', 'audit', 'greenfield', 'general']);
+
+/**
+ * Task-complexity tiers (mirrors `TaskAnalysisResult.complexity`). Used by a
+ * selection rule's complexity gate so the sequential default can split between a
+ * single-shot and a pipeline strategy purely from manifest data.
+ */
+export const ComplexityTierSchema = z.enum(['simple', 'moderate', 'complex', 'expert']);
+
+/**
+ * One declarative selection rule (#3836). A rule MATCHES when every predicate it
+ * declares holds for the current routing signals; among all matching rules
+ * across all manifests, the router picks the strategy whose matching rule has the
+ * HIGHEST {@link priority} (ties broken deterministically by strategy name). This
+ * is what lets the MetaOrchestrator route purely over manifest data: adding a
+ * strategy means registering a manifest with its rules, not editing the router.
+ *
+ * `.strict()` so a typo'd predicate fails validation rather than matching
+ * unexpectedly. At least one predicate must be present (a rule that matches every
+ * signal would shadow the whole table) — enforced by {@link SelectionRuleSchema}.
+ */
+export const SelectionRuleSchema = z
+  .object({
+    /** Higher wins. Distinctive templates outrank the structural-pattern fallback. */
+    priority: z.number().int(),
+    /** Matches only when the routed workflow pattern is one of these. */
+    patterns: z.array(WorkflowPatternSchema).min(1).optional(),
+    /** Matches only when the classified pipeline template is one of these. */
+    pipelineTypes: z.array(PipelineTypeSchema).min(1).optional(),
+    /** Matches only when the analyzed complexity is one of these. */
+    complexities: z.array(ComplexityTierSchema).min(1).optional(),
+  })
+  .strict()
+  .refine((r) => r.patterns !== undefined || r.pipelineTypes !== undefined, {
+    message: 'a selection rule must constrain at least patterns or pipelineTypes',
+  });
+export type SelectionRule = z.infer<typeof SelectionRuleSchema>;
+
+/**
  * A single strategy manifest. `.strict()` so an unknown/typo'd field fails
  * validation rather than being silently ignored (same discipline as the claims
  * registry). Required fields model the current reality; the two forward-compat
@@ -161,6 +219,14 @@ export const StrategyManifestSchema = z
      * real cost data; when present it must be a valid {@link CostProfile}.
      */
     costProfile: CostProfileSchema.optional(),
+    /**
+     * Declarative routing rules (#3836) — the data the manifest-driven router
+     * matches over to SELECT this strategy. Optional: a manifest without rules is
+     * still force-selectable via `entrypointTool` but is never auto-routed (it has
+     * no claim on any signal). Each rule is a {@link SelectionRule}; the router
+     * applies the highest-priority matching rule across the whole registry.
+     */
+    selectionRules: z.array(SelectionRuleSchema).min(1).optional(),
   })
   .strict();
 export type StrategyManifest = z.infer<typeof StrategyManifestSchema>;


### PR DESCRIPTION
## What this does

Makes the `MetaOrchestrator` route **purely over the strategy-manifest registry** (#3836, Epic C). `decideStrategy` no longer hardcodes strategy-specific branches — it matches the routed signals against declarative selection rules carried by the manifests and picks the highest-priority match. Adding a routable strategy is now "register a manifest with selection rules", not "edit the router", and that invariant is **tested** (synthetic-9th-manifest test).

Fixes #3836.

## Now manifest-driven (was literal)

- `decideStrategy` selection path → `selectStrategyByManifest(signals)`: a generic matcher in `strategy-manifest-registry.ts` that evaluates every manifest's `selectionRules` and returns the highest-priority match (ties broken deterministically by strategy name). **It names zero strategies.**
- All 8 live manifests carry `selectionRules` reproducing the pre-#3836 decision table exactly:
  - `consensus` 100 (pattern `consensus`) > `spec` 90 / `research` 90 (pipeline templates) > `pipeline` 80 (audit-upgrade: `audit` + `sequential`) > `graph-workflow` / `orchestrate` 50 > `single-shot` 40 (`sequential` + `simple`) > `dev-pipeline` 30 (`sequential` default).
- `entrypointTool` / `executorAvailable` resolution already routed through `entrypointToolFor` / `executorAvailableFor` (#3835) — confirmed; the forced-decision path now also resolves its manifest for the audit trail.

## Schema field added + rationale

Added an **optional** `selectionRules: SelectionRule[]` to the #3834 manifest schema (`strategy-manifest.ts`), plus self-contained `WorkflowPattern` / `PipelineType` / complexity enums (mirroring the router types, kept import-free for the same self-containment discipline as the existing `StrategyNameSchema`).

A `SelectionRule` is `{ priority, patterns?, pipelineTypes?, complexities? }` and must constrain at least `patterns` or `pipelineTypes` (a rule matching every signal would shadow the table). This is the minimal descriptor needed to express the existing routing predicates as data — no speculative fields. It is optional: a manifest without rules is still force-selectable via `entrypointTool` but is never auto-routed. Mirrored byte-for-byte into `governance/strategy-manifests.yaml` (the registry test asserts no YAML↔TS drift).

## Audit trail (AC)

`MetaDecision` and `MetaSelectionRecord` now record the matched `manifestId` + `manifestSchemaVersion` (decision provenance), surfaced in the "strategy selected" audit log line.

## File split + line count (hard requirement)

`meta-orchestrator.ts`: **489 → 319 lines** (≤400). Extracted two cohesive siblings:
- `meta-orchestrator-routing.ts` (the manifest-driven `decideStrategy` + the `strategyFrom*` helpers + `buildAlternatives`).
- `meta-orchestrator-decision.ts` (the forced/selected decision builders + record projection).

## Parity confirmation

All 8 strategies' routing decisions are unchanged. The existing meta-orchestrator integration suite stays green, plus a new `selectStrategyByManifest` parity matrix asserts the full `{ pattern, pipelineType, complexity } → strategy` table comes out of the data matcher. New tests: the synthetic-9th-manifest routability invariant (no router edit), the no-match → `undefined` case, the recorded manifest id/version, and the `selectionRules` schema validation.

## What remains literal & why

- The `strategyFromPattern` / `strategyFromPipelineType` helpers remain (with strategy literals) but are used **only for the best-first ALTERNATIVES list** — a transparency aid, not the selection path. The selection path itself is fully data-driven.
- `run-tool.ts buildDefaultExecutors` remains a tool-layer executor map. That is run-tool's concern (executor wiring), not the router's selection logic, and is out of scope for #3836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
