### PR TITLE
fix(orchestration): make strategy-manifest lockstep test real, cross-check executorAvailable (#3881)

### DIFF
--- a/.changeset/manifest-lockstep-cross-check-3881.md
+++ b/.changeset/manifest-lockstep-cross-check-3881.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+fix(orchestration): make the strategy-manifest lockstep test real and cross-check executorAvailable (#3881)
+
+The strategy-manifest schema billed two safety properties that were not actually
+anchored to reality:
+
+1. The "lockstep" test used a hand-copied literal list of the 8 router strategies
+   instead of deriving from the `ExecutionStrategy` union, so ADDING a strategy to
+   the router without registering a manifest stayed green. The expected strategy
+   set is now derived from a single runtime tuple (`EXECUTION_STRATEGY_NAMES`) that
+   the Zod enum is built from, tied to the router `ExecutionStrategy` union by a
+   compile-time mutual-assignability assertion — adding a member on either side is
+   now a typecheck failure.
+
+2. `executorAvailable` was a self-declared boolean never cross-checked against the
+   real executor registry, so it could silently go fail-OPEN. A new test in
+   `strategy-manifest-registry.test.ts` derives the wired-executor set from the
+   LIVE `buildDefaultExecutors` factory keys and asserts each manifest's
+   `executorAvailable` matches, plus a guard that the frozen legacy snapshot has
+   not rotted versus the live factory.
+
+Scope confined to `strategy-manifest.ts`, `strategy-manifest-registry.ts`, and
+their test files; `meta-orchestrator.ts` was not modified.

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
@@ -25,6 +25,7 @@ import {
   selectStrategyByManifest,
 } from './strategy-manifest-registry.js';
 import { parseStrategyManifestRegistry, type StrategyManifest } from './strategy-manifest.js';
+import { buildDefaultExecutors } from '../mcp/tools/run-tool.js';
 import type { ExecutionStrategy } from './meta-orchestrator.js';
 
 /**
@@ -94,6 +95,53 @@ describe('behaviour parity: manifest-sourced lookups === legacy STRATEGY_ENTRYPO
     }
     const wired = ALL_STRATEGIES.filter((s) => executorAvailableFor(s));
     expect(wired.sort()).toEqual(['consensus', 'dev-pipeline', 'pipeline', 'research'].sort());
+  });
+});
+
+describe('executorAvailable cross-check against the LIVE executor registry (#3881)', () => {
+  // The #3881 fix: executorAvailable was a self-declared boolean never checked
+  // against the real wired executors. The LEGACY_EXECUTOR_AVAILABLE snapshot above
+  // is a FROZEN copy and can rot; here we derive the wired set from the LIVE
+  // buildDefaultExecutors factory so a manifest claiming executorAvailable:true for
+  // a strategy with NO wired executor (fail-OPEN) — or :false for one that IS wired
+  // — fails the build. trustTier is irrelevant to which KEYS exist, so a fixed
+  // value is fine.
+  const LIVE_WIRED_EXECUTORS = new Set(
+    Object.keys(buildDefaultExecutors('3')) as ExecutionStrategy[]
+  );
+
+  it('every wired executor in buildDefaultExecutors maps to a registered strategy', () => {
+    for (const s of LIVE_WIRED_EXECUTORS) {
+      expect(
+        getStrategyManifest(s),
+        `executor wired for unregistered strategy '${s}'`
+      ).toBeDefined();
+    }
+  });
+
+  it("each manifest's executorAvailable matches whether the LIVE factory provides an executor", () => {
+    for (const s of ALL_STRATEGIES) {
+      const liveAvailable = LIVE_WIRED_EXECUTORS.has(s);
+      const declared = String(executorAvailableFor(s));
+      expect(
+        executorAvailableFor(s),
+        `executorAvailable for '${s}' is self-declared ${declared} but the live ` +
+          `buildDefaultExecutors ${liveAvailable ? 'DOES' : 'does NOT'} provide an executor — ` +
+          `fail-${liveAvailable ? 'closed-on-a-wired-strategy' : 'open'} drift (#3881)`
+      ).toBe(liveAvailable);
+    }
+  });
+
+  it('the legacy snapshot itself still matches the live factory (snapshot has not rotted)', () => {
+    // Keeps LEGACY_EXECUTOR_AVAILABLE honest: if someone wires/unwires an executor
+    // in run-tool.ts and updates the manifests but forgets this frozen snapshot,
+    // this catches the snapshot rot rather than letting the parity test pass on
+    // stale data.
+    for (const s of ALL_STRATEGIES) {
+      expect(LIVE_WIRED_EXECUTORS.has(s), `legacy snapshot stale for '${s}'`).toBe(
+        LEGACY_EXECUTOR_AVAILABLE[s]
+      );
+    }
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.test.ts
@@ -12,6 +12,7 @@ import {
   StrategyManifestSchema,
   StrategyManifestRegistrySchema,
   StrategyNameSchema,
+  EXECUTION_STRATEGY_NAMES,
   parseStrategyManifest,
   parseStrategyManifestRegistry,
   loadStrategyManifestRegistry,
@@ -19,6 +20,21 @@ import {
   type StrategyManifest,
 } from './strategy-manifest.js';
 import { type ExecutionStrategy } from './meta-orchestrator.js';
+
+/**
+ * Type-level assertion mirror of the compile-time lockstep guard in
+ * strategy-manifest.ts. If a strategy is ADDED to the router `ExecutionStrategy`
+ * union without being added to `EXECUTION_STRATEGY_NAMES`, BOTH this and the
+ * source-file guard fail to typecheck (#3881). `assignableToUnion` requires every
+ * tuple member to be a router strategy; `assignableFromUnion` (the typed
+ * `ExecutionStrategy[]` cast of the array) requires every router strategy to be
+ * in the tuple — that direction is what the old hand-copied literal could not
+ * detect.
+ */
+const _assignableToUnion: readonly ExecutionStrategy[] = EXECUTION_STRATEGY_NAMES;
+const _assignableFromUnion = EXECUTION_STRATEGY_NAMES as readonly ExecutionStrategy[];
+void _assignableToUnion;
+void _assignableFromUnion;
 
 const FIXTURE_PATH = join(import.meta.dirname, '__fixtures__/strategy-manifests.example.yaml');
 
@@ -112,23 +128,21 @@ describe('strategy manifest schema', () => {
     expect(StrategyManifestSchema.safeParse(m).success).toBe(false);
   });
 
-  it('keeps the strategy enum in lockstep with the router ExecutionStrategy', () => {
-    // Compile-time + runtime guard: every router strategy must be a valid
-    // manifest strategy name (a divergence would break #3835's migration).
-    const routerStrategies: ExecutionStrategy[] = [
-      'single-shot',
-      'dev-pipeline',
-      'pipeline',
-      'graph-workflow',
-      'orchestrate',
-      'consensus',
-      'spec',
-      'research',
-    ];
-    for (const s of routerStrategies) {
+  it('keeps the manifest enum in lockstep with the router ExecutionStrategy (#3881)', () => {
+    // The expected strategy set is DERIVED from EXECUTION_STRATEGY_NAMES — the
+    // runtime tuple that strategy-manifest.ts ties to the router ExecutionStrategy
+    // union by a compile-time mutual-assignability assertion. Adding a member to
+    // the router union without adding it to that tuple is a TYPE error (caught by
+    // typecheck before this test even runs); the old hand-copied literal here
+    // could not detect an *added* router strategy, which #3881 fixes.
+    //
+    // The runtime assertions below prove the Zod enum is built FROM that same
+    // tuple, so the schema, the type guard, and this test cannot drift apart.
+    for (const s of EXECUTION_STRATEGY_NAMES) {
       expect(StrategyNameSchema.safeParse(s).success).toBe(true);
     }
-    expect(StrategyNameSchema.options.length).toBe(routerStrategies.length);
+    expect([...StrategyNameSchema.options].sort()).toEqual([...EXECUTION_STRATEGY_NAMES].sort());
+    expect(StrategyNameSchema.options.length).toBe(EXECUTION_STRATEGY_NAMES.length);
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.ts
@@ -26,6 +26,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
+import type { ExecutionStrategy } from './meta-orchestrator.js';
 
 /**
  * Bump when a backward-incompatible change to the manifest shape lands. The
@@ -35,13 +36,18 @@ import { z } from 'zod';
 export const STRATEGY_MANIFEST_SCHEMA_VERSION = 1 as const;
 
 /**
- * The eight execution strategies the MetaOrchestrator can select today. Mirrors
- * (and must stay in lockstep with) `ExecutionStrategy` in `meta-orchestrator.ts`;
- * kept as an independent `z.enum` here so the manifest schema is self-contained
- * and validatable without importing the router. #3835 registers one manifest per
- * member; a divergence between the two is caught by the manifest registry test.
+ * The execution strategies the MetaOrchestrator can select today, as a runtime
+ * `as const` tuple. This is the SINGLE enumerable source the manifest schema and
+ * the lockstep test both derive from — it gives `ExecutionStrategy` (a pure TS
+ * union with no runtime value to enumerate) a runtime mirror.
+ *
+ * LOCKSTEP IS COMPILE-TIME ENFORCED: {@link assertExecutionStrategyLockstep}
+ * below asserts this tuple's element type is mutually assignable with the router
+ * `ExecutionStrategy` union. If someone ADDS a member to `ExecutionStrategy`
+ * without adding it here (or vice-versa), that assertion fails to typecheck —
+ * closing the #3881 hole where an added strategy could drift in undetected.
  */
-export const StrategyNameSchema = z.enum([
+export const EXECUTION_STRATEGY_NAMES = [
   'single-shot',
   'dev-pipeline',
   'pipeline',
@@ -50,7 +56,34 @@ export const StrategyNameSchema = z.enum([
   'consensus',
   'spec',
   'research',
-]);
+] as const;
+
+/**
+ * Compile-time exhaustiveness guard for the #3881 lockstep promise. `expect`
+ * yields `never` only when its two type args are MUTUALLY assignable, so:
+ * - adding a member to `ExecutionStrategy` (router) without adding it to
+ *   {@link EXECUTION_STRATEGY_NAMES} ⇒ `ExecutionStrategy` no longer extends the
+ *   tuple union ⇒ `never` resolves to `false` ⇒ TYPE ERROR.
+ * - adding a member here without it existing on the router ⇒ symmetric TYPE
+ *   ERROR.
+ * Purely a type-level assertion — erased at runtime, zero cost.
+ */
+type Expect<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type _AssertExecutionStrategyLockstep = Expect<
+  (typeof EXECUTION_STRATEGY_NAMES)[number],
+  ExecutionStrategy
+>;
+// If this line errors, EXECUTION_STRATEGY_NAMES has drifted from the router
+// ExecutionStrategy union — reconcile the two (that is the #3881 guarantee).
+const _executionStrategyLockstepHolds: _AssertExecutionStrategyLockstep = true;
+void _executionStrategyLockstepHolds;
+
+/**
+ * The execution strategies as a Zod enum, derived from
+ * {@link EXECUTION_STRATEGY_NAMES} so the schema and the lockstep guard share one
+ * source. #3835 registers one manifest per member.
+ */
+export const StrategyNameSchema = z.enum(EXECUTION_STRATEGY_NAMES);
 export type StrategyName = z.infer<typeof StrategyNameSchema>;
 
 /**
@@ -195,6 +228,11 @@ export const StrategyManifestSchema = z
      * `false` so the router never selects an unexecutable strategy silently and
      * `execute:true` returns the structured `no_executor` envelope from manifest
      * data (#3835) instead of a hardcoded map.
+     *
+     * NOT trusted blindly: this self-declared boolean is CROSS-CHECKED against the
+     * live `buildDefaultExecutors` key set in `strategy-manifest-registry.test.ts`
+     * (#3881), so declaring `true` for a strategy with no wired executor (silent
+     * fail-OPEN) fails the build rather than mis-advertising routability.
      */
     executorAvailable: z.boolean(),
     /** One-line human description of what this strategy is for (#3838 docs). */


### PR DESCRIPTION
## Summary

Closes the two #3881 holes where the strategy-manifest schema's "reality-anchoring" claims were not actually anchored.

### Fix 1 — lockstep test now derives from the `ExecutionStrategy` union (not a hand-copied literal)

`strategy-manifest.test.ts` previously hand-copied a literal `routerStrategies` array of the 8 names, so ADDING a 9th member to the router `ExecutionStrategy` union without registering a manifest stayed green — the exact drift the doc promised to catch.

Now `strategy-manifest.ts` exports a single runtime tuple `EXECUTION_STRATEGY_NAMES`, builds `StrategyNameSchema` from it (`z.enum(EXECUTION_STRATEGY_NAMES)`), and ties it to the router union with a **compile-time mutual-assignability assertion**:

```ts
type Expect<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
type _AssertExecutionStrategyLockstep = Expect<(typeof EXECUTION_STRATEGY_NAMES)[number], ExecutionStrategy>;
const _executionStrategyLockstepHolds: _AssertExecutionStrategyLockstep = true; // errors if drifted
```

Adding a member on EITHER side (router union or tuple) without the other is now a **typecheck failure**. The test derives its expected set from `EXECUTION_STRATEGY_NAMES` and asserts the Zod enum's options equal it. `meta-orchestrator.ts` was deliberately NOT modified (parallel #3836 refactor) — the runtime tuple lives in the manifest module and is bound to the union by type only.

### Fix 2 — `executorAvailable` cross-checked against the LIVE executor registry

`executorAvailable` was a self-declared `z.boolean()` never validated against the real wired executors, so it could silently go fail-OPEN. A new describe block in `strategy-manifest-registry.test.ts` derives the wired set from the **live `buildDefaultExecutors` factory keys** (not the frozen snapshot) and asserts each manifest's `executorAvailable` matches reality, plus a guard that the legacy snapshot itself has not rotted versus the live factory.

## RED / GREEN evidence

**Fix 1 (RED):**
- Added a fake member to `EXECUTION_STRATEGY_NAMES` (tuple) → `tsc` fails: `strategy-manifest.ts: Type 'true' is not assignable to type 'false'` (plus registry-map + test-cast errors).
- Temporarily added a 9th member to the router `ExecutionStrategy` union, tuple unchanged → `tsc` fails: `strategy-manifest.ts(78,7): Type 'true' is not assignable to type 'false'`. This is the "added strategy" drift the old literal could NOT detect. (meta-orchestrator.ts restored — final diff is empty.)

**Fix 2 (RED):**
- Flipped `graph-workflow`'s `executorAvailable` from `false` → `true` (no wired executor) → cross-check fails: `executorAvailable for 'graph-workflow' is self-declared true but the live buildDefaultExecutors does NOT provide an executor — fail-open drift (#3881)`.

**GREEN:** with honest data, target tests 28/28 pass (was 25; +3 cross-check tests), typecheck clean.

## CI

- `pnpm install --frozen-lockfile` — OK
- `pnpm typecheck` — OK
- `pnpm test` — OK (5/5 turbo tasks)
- `pnpm build` — OK (3/3)
- `pnpm lint` — OK
- `pnpm claims:check` — 8/8 verified
- `pnpm governance:check` — OK (no stamp regeneration needed)
- changeset added

## Scope discipline

Confined to `strategy-manifest.ts`, `strategy-manifest-registry.ts`, their `.test.ts` files, and a new changeset. **`meta-orchestrator.ts` was NOT modified** (verified empty diff) to avoid colliding with the parallel #3836 router refactor.

Fixes #3881

🤖 Generated with [Claude Code](https://claude.com/claude-code)