### PR TITLE
fix(orchestration): harden manifest-driven router (#3888)

### DIFF
--- a/.changeset/router-hardening-3888.md
+++ b/.changeset/router-hardening-3888.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': patch
+---
+
+fix(orchestration): harden manifest-driven router (#3888 — #3886 follow-ups)
+
+Closes the three confirmed follow-ups from the #3886 ratification vote, all
+confined to the manifest router. No live routing decision changes for the 8
+registered manifests.
+
+- **Alternatives split-brain (DRY):** `buildAlternatives` no longer seeds the
+  transparency "alternatives" list from the hardcoded `strategyFromPattern` /
+  `strategyFromPipelineType` decision table (which encoded the pre-#3836 rules and
+  could drift from the manifests). It now derives alternatives from the SAME
+  manifest `selectionRules` source of truth via the new
+  `rankStrategiesByManifest`, ranking every OTHER matching strategy best-first by
+  matching-rule priority. The two now-dead `strategyFrom*` helpers — and their
+  re-exports from `meta-orchestrator.ts` and `orchestration/index.ts` — are
+  removed. Observable change: the alternatives list now contains only genuinely
+  manifest-routable runner-ups (best-first), instead of the former
+  pattern+pipeline+`orchestrate` heuristic triple.
+- **Optional `selectionRules` → silent un-routability:** a new Vitest asserts every
+  manifest in `STRATEGY_MANIFEST_REGISTRY` declares at least one `selectionRule`,
+  so a future manifest added without rules (silently un-routable) fails the test
+  suite. (`selectionRules` stays `.optional()` on the schema to keep force-only
+  manifests legal; the test guards the live registry — lower-risk than a schema
+  change.)
+- **Name-based tie-break:** `selectStrategyByManifest` no longer breaks an
+  equal-priority collision silently by `strategy < best.strategy` (alphabetical
+  name). A genuine equal-priority tie between two strategies now throws
+  `AmbiguousManifestSelectionError`, surfacing a future overlapping same-priority
+  rule loudly instead of letting a rename quietly change routing. No reachable tie
+  exists on today's 8 manifests, so this is dead-but-defensive now.

--- a/packages/nexus-agents/src/orchestration/index.ts
+++ b/packages/nexus-agents/src/orchestration/index.ts
@@ -109,8 +109,6 @@ export {
   createMetaOrchestrator,
   createAuditLogSink,
   createRecordingSink,
-  strategyFromPattern,
-  strategyFromPipelineType,
 } from './meta-orchestrator.js';
 export type {
   IMetaOrchestrator,

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts
@@ -3,25 +3,29 @@
  *
  * The selection logic the MetaOrchestrator routes over. Extracted from
  * `meta-orchestrator.ts` so the orchestrator file stays a thin wiring layer
- * (CODING_STANDARDS ≤400 lines) and so the router is a single cohesive unit.
+ * (CODING_STANDARDS <=400 lines) and so the router is a single cohesive unit.
  *
  * The router routes PURELY over strategy-manifest data: {@link decideStrategy}
  * matches the registry's {@link selectStrategyByManifest} rules and names ZERO
  * strategies itself. Adding a routable strategy is "register a manifest with
- * selection rules", not "edit this router" — the #3836 invariant, proven by the
- * synthetic-9th-manifest test. The two `strategyFrom*` helpers remain for the
- * best-first ALTERNATIVES list (a transparency aid, not the selection path) and
- * for the existing parity tests.
+ * selection rules", not "edit this router" -- the #3836 invariant, proven by the
+ * synthetic-9th-manifest test. The best-first ALTERNATIVES list is ALSO derived
+ * from the manifest `selectionRules` (via {@link rankStrategiesByManifest}), so
+ * the transparency path can no longer drift from the selection path (#3888 -- the
+ * former hardcoded `strategyFromPattern`/`strategyFromPipelineType` table is gone).
  *
  * @module orchestration/meta-orchestrator-routing
- * (Source: Issue #3836 — router refactor over the manifest registry)
+ * (Source: Issue #3836 -- router refactor over the manifest registry; #3888 hardening)
  */
 
 import type { ExecutionStrategy } from './meta-orchestrator.js';
-import { selectStrategyByManifest, type ManifestSelection } from './strategy-manifest-registry.js';
-import type { TaskClassification, PipelineType } from '../pipeline/adaptive-orchestrator.js';
-import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
-import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
+import {
+  selectStrategyByManifest,
+  rankStrategiesByManifest,
+  type ManifestSelection,
+} from './strategy-manifest-registry.js';
+import type { TaskClassification } from '../pipeline/adaptive-orchestrator.js';
+import type { RoutingDecision } from './workflow-router-types.js';
 
 /** The chosen strategy plus the transparency fields a decision carries. */
 export interface SelectionCore {
@@ -32,55 +36,6 @@ export interface SelectionCore {
   readonly manifestId: string;
   /** The schema version of the winning manifest (audit trail, AC #3836). */
   readonly manifestSchemaVersion: number;
-}
-
-/**
- * Maps a workflow pattern (+ complexity) to the execution strategy that engine
- * fronts. `sequential` collapses to the lightest engine that fits the
- * complexity. Retained for the alternatives list + parity tests; the SELECTION
- * path is manifest-driven via {@link decideStrategy}.
- */
-export function strategyFromPattern(
-  pattern: WorkflowPattern,
-  complexity: TaskAnalysisResult['complexity']
-): ExecutionStrategy {
-  switch (pattern) {
-    case 'consensus':
-      return 'consensus';
-    case 'graph':
-      return 'graph-workflow';
-    case 'wave':
-    case 'aflow':
-    case 'puppeteer':
-      return 'orchestrate';
-    case 'sequential':
-      return complexity === 'simple' ? 'single-shot' : 'dev-pipeline';
-    default: {
-      // Exhaustiveness guard — a new pattern must be mapped explicitly.
-      const _exhaustive: never = pattern;
-      return _exhaustive;
-    }
-  }
-}
-
-/** Maps a pipeline template to the execution strategy that fronts it. */
-export function strategyFromPipelineType(pipelineType: PipelineType): ExecutionStrategy {
-  switch (pipelineType) {
-    case 'greenfield':
-      return 'spec';
-    case 'research':
-      return 'research';
-    case 'audit':
-      return 'pipeline';
-    case 'dev':
-      return 'dev-pipeline';
-    case 'general':
-      return 'pipeline';
-    default: {
-      const _exhaustive: never = pipelineType;
-      return _exhaustive;
-    }
-  }
 }
 
 /** Human-readable reasoning for a manifest-driven selection. */
@@ -96,12 +51,13 @@ function reasoningFor(selection: ManifestSelection, routing: RoutingDecision): s
 }
 
 /**
- * The core selection rule — now fully data-driven (#3836). It matches the
+ * The core selection rule -- now fully data-driven (#3836). It matches the
  * routing signals (pattern, pipeline template, complexity) against the strategy
  * manifests' declarative {@link SelectionRule}s and picks the highest-priority
- * match. No strategy names appear here. The fallback (no rule matched — not
+ * match. No strategy names appear here. The fallback (no rule matched -- not
  * reachable today since every workflow pattern is claimed by a manifest) routes
- * to the structural-pattern strategy so selection never throws.
+ * to the multi-agent `orchestrate` catch-all so selection never throws and the
+ * router still names zero strategies in a structural table.
  */
 export function decideStrategy(
   routing: RoutingDecision,
@@ -118,8 +74,11 @@ export function decideStrategy(
 
   if (selection === undefined) {
     // Defensive: every pattern is claimed by a manifest today, so this is
-    // unreachable, but selection must never throw on a novel signal combo.
-    const fallback = strategyFromPattern(pattern, analysis.complexity);
+    // unreachable, but selection must never throw on a novel signal combo. The
+    // `orchestrate` strategy is the multi-agent catch-all; we keep this a single
+    // literal (not a structural table) so the #3836 "zero strategies named" intent
+    // holds for the selection path.
+    const fallback: ExecutionStrategy = 'orchestrate';
     return {
       strategy: fallback,
       reasoning: `No manifest rule matched pattern "${pattern}" — structural fallback to ${fallback}`,
@@ -142,24 +101,22 @@ export function decideStrategy(
   };
 }
 
-/** Builds the best-first alternatives list, excluding the chosen strategy. */
+/**
+ * Builds the best-first alternatives list, excluding the chosen strategy. Derived
+ * from the SAME manifest `selectionRules` the selection path uses (#3888): it ranks
+ * every OTHER strategy whose rules match the current signals best-first by their
+ * matching-rule priority. This closes the former split-brain where the alternatives
+ * came from a hardcoded `strategyFrom*` table that could drift from the manifest.
+ */
 export function buildAlternatives(
   chosen: ExecutionStrategy,
   routing: RoutingDecision,
   classification: TaskClassification
 ): ExecutionStrategy[] {
-  const candidates: ExecutionStrategy[] = [
-    strategyFromPattern(routing.pattern, routing.analysis.complexity),
-    strategyFromPipelineType(classification.pipelineType),
-    'orchestrate',
-  ];
-  const seen = new Set<ExecutionStrategy>([chosen]);
-  const alternatives: ExecutionStrategy[] = [];
-  for (const c of candidates) {
-    if (!seen.has(c)) {
-      seen.add(c);
-      alternatives.push(c);
-    }
-  }
-  return alternatives;
+  const ranked = rankStrategiesByManifest({
+    pattern: routing.pattern,
+    pipelineType: classification.pipelineType,
+    complexity: routing.analysis.complexity,
+  });
+  return ranked.filter((s) => s !== chosen);
 }

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -9,12 +9,11 @@ import { describe, it, expect } from 'vitest';
 import {
   createMetaOrchestrator,
   createRecordingSink,
-  strategyFromPattern,
-  strategyFromPipelineType,
   type ExecutionStrategy,
   type IMetaOrchestrator,
   type MetaSelectionRecord,
 } from './meta-orchestrator.js';
+import { rankStrategiesByManifest } from './strategy-manifest-registry.js';
 import type { IWorkflowRouter } from './workflow-router.js';
 import type { RoutingDecision, WorkflowPattern } from './workflow-router-types.js';
 import { createSharedTaskAnalyzer } from '../core/task-analysis/shared-task-analyzer.js';
@@ -27,7 +26,12 @@ import {
 } from './meta-shadow-selector.js';
 import { AuthorityRefusalError } from './authority-tier-guard.js';
 
-describe('strategyFromPattern', () => {
+// The pre-#3888 `strategyFromPattern`/`strategyFromPipelineType` helpers (a
+// hardcoded decision table that seeded the alternatives list) were removed: the
+// alternatives list now derives from the SAME manifest `selectionRules` as the
+// selection path via `rankStrategiesByManifest`, closing the split-brain (#3888).
+// These parity tests are migrated to assert the manifest-derived expectation.
+describe('manifest-derived strategy selection (was strategyFromPattern, #3888)', () => {
   const cases: ReadonlyArray<
     [WorkflowPattern, 'simple' | 'moderate' | 'complex' | 'expert', ExecutionStrategy]
   > = [
@@ -40,18 +44,11 @@ describe('strategyFromPattern', () => {
     ['sequential', 'moderate', 'dev-pipeline'],
     ['sequential', 'expert', 'dev-pipeline'],
   ];
+  // `general` keeps every structural pattern on its own engine; the head of the
+  // manifest ranking equals the strategy the selection path would pick.
   it.each(cases)('pattern %s @ %s → %s', (pattern, complexity, expected) => {
-    expect(strategyFromPattern(pattern, complexity)).toBe(expected);
-  });
-});
-
-describe('strategyFromPipelineType', () => {
-  it('maps each pipeline template to its strategy', () => {
-    expect(strategyFromPipelineType('greenfield')).toBe('spec');
-    expect(strategyFromPipelineType('research')).toBe('research');
-    expect(strategyFromPipelineType('audit')).toBe('pipeline');
-    expect(strategyFromPipelineType('dev')).toBe('dev-pipeline');
-    expect(strategyFromPipelineType('general')).toBe('pipeline');
+    const ranked = rankStrategiesByManifest({ pattern, pipelineType: 'general', complexity });
+    expect(ranked[0]).toBe(expected);
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -37,10 +37,6 @@ import {
 } from './meta-orchestrator-decision.js';
 import { guardAuthority, type ActionClass } from './authority-tier-guard.js';
 
-// Re-exported so existing importers keep their public surface (#3836 split): the
-// selection helpers + parity tests live in the routing module now.
-export { strategyFromPattern, strategyFromPipelineType } from './meta-orchestrator-routing.js';
-
 /**
  * Execution strategies the MetaOrchestrator can select. Each maps to an
  * existing entry point / engine — the MetaOrchestrator does not introduce a

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
@@ -23,6 +23,7 @@ import {
   executorAvailableFor,
   getStrategyManifest,
   selectStrategyByManifest,
+  rankStrategiesByManifest,
 } from './strategy-manifest-registry.js';
 import { parseStrategyManifestRegistry, type StrategyManifest } from './strategy-manifest.js';
 import { buildDefaultExecutors } from '../mcp/tools/run-tool.js';
@@ -235,6 +236,115 @@ describe('manifest-driven router (#3836)', () => {
         ruleless
       )
     ).toBeUndefined();
+  });
+});
+
+describe('every registered manifest is routable (#3888 — optional selectionRules guard)', () => {
+  // GUARD: `selectionRules` is `.optional()` on the schema so a force-only manifest
+  // is legal, but a manifest registered in the LIVE registry with no rules is
+  // silently un-routable (selectStrategyByManifest skips it). This test fails the
+  // suite the moment a future manifest is added to STRATEGY_MANIFEST_REGISTRY
+  // without at least one selection rule — surfacing the un-routability loudly.
+  it('every manifest in STRATEGY_MANIFEST_REGISTRY declares >=1 selectionRule', () => {
+    for (const m of STRATEGY_MANIFEST_REGISTRY.manifests) {
+      expect(
+        m.selectionRules,
+        `manifest '${m.id}' has no selectionRules — it would be silently un-routable`
+      ).toBeDefined();
+      expect(
+        m.selectionRules?.length ?? 0,
+        `manifest '${m.id}' has an empty selectionRules array — un-routable`
+      ).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('fail-fast tie-break on equal-priority collision (#3888)', () => {
+  it('throws on a genuine equal-priority match between two strategies', () => {
+    // Inject a 9th manifest whose rule collides at the SAME priority on the SAME
+    // signal as an existing manifest. The old behaviour silently routed by
+    // alphabetical strategy name; the hardened matcher must surface the ambiguity.
+    const collider: StrategyManifest = {
+      id: 'collider',
+      schemaVersion: 1,
+      strategy: 'spec', // alphabetically 'spec' > 'graph-workflow'
+      entrypointTool: 'execute_spec',
+      executorAvailable: false,
+      description: 'Synthetic manifest colliding with graph-workflow at equal priority.',
+      maturityTier: 'experimental',
+      latencyClass: 'async-job-body',
+      // graph-workflow uses { priority: 50, patterns: ['graph'] } — collide exactly.
+      selectionRules: [{ priority: 50, patterns: ['graph'] }],
+    };
+    const augmented = [...STRATEGY_MANIFEST_REGISTRY.manifests, collider];
+    expect(() =>
+      selectStrategyByManifest(
+        { pattern: 'graph', pipelineType: 'dev', complexity: 'moderate' },
+        augmented
+      )
+    ).toThrow(/equal-priority|ambiguous/i);
+  });
+
+  it('does NOT throw for the live 8 manifests (no reachable collision today)', () => {
+    // Sanity: every live signal combination resolves without ambiguity.
+    const combos = [
+      { pattern: 'consensus', pipelineType: 'general', complexity: 'moderate' },
+      { pattern: 'graph', pipelineType: 'audit', complexity: 'moderate' },
+      { pattern: 'wave', pipelineType: 'dev', complexity: 'complex' },
+      { pattern: 'sequential', pipelineType: 'greenfield', complexity: 'moderate' },
+      { pattern: 'sequential', pipelineType: 'research', complexity: 'moderate' },
+      { pattern: 'sequential', pipelineType: 'audit', complexity: 'simple' },
+      { pattern: 'sequential', pipelineType: 'dev', complexity: 'simple' },
+      { pattern: 'sequential', pipelineType: 'general', complexity: 'expert' },
+    ] as const;
+    for (const c of combos) {
+      expect(() => selectStrategyByManifest(c)).not.toThrow();
+    }
+  });
+});
+
+describe('manifest-derived alternatives ranking (#3888 — split-brain fix)', () => {
+  it('ranks every OTHER matching strategy best-first by matching-rule priority', () => {
+    // Signals where multiple manifests have a matching rule at different priorities.
+    // sequential + audit: pipeline(80, audit+sequential) AND dev-pipeline(30, sequential)
+    // both match. Best-first ranking must put the higher-priority pipeline ahead.
+    const ranked = rankStrategiesByManifest({
+      pattern: 'sequential',
+      pipelineType: 'audit',
+      complexity: 'moderate',
+    });
+    expect(ranked).toEqual(['pipeline', 'dev-pipeline']);
+  });
+
+  it('returns only genuinely-matching strategies (no hardcoded table)', () => {
+    // graph pattern: only graph-workflow has a matching rule. Nothing else routes.
+    const ranked = rankStrategiesByManifest({
+      pattern: 'graph',
+      pipelineType: 'dev',
+      complexity: 'moderate',
+    });
+    expect(ranked).toEqual(['graph-workflow']);
+  });
+
+  it('throws on an equal-priority collision (same fail-fast contract as selection)', () => {
+    const collider: StrategyManifest = {
+      id: 'collider',
+      schemaVersion: 1,
+      strategy: 'spec',
+      entrypointTool: 'execute_spec',
+      executorAvailable: false,
+      description: 'Synthetic colliding manifest.',
+      maturityTier: 'experimental',
+      latencyClass: 'async-job-body',
+      selectionRules: [{ priority: 50, patterns: ['graph'] }],
+    };
+    const augmented = [...STRATEGY_MANIFEST_REGISTRY.manifests, collider];
+    expect(() =>
+      rankStrategiesByManifest(
+        { pattern: 'graph', pipelineType: 'dev', complexity: 'moderate' },
+        augmented
+      )
+    ).toThrow(/equal-priority|ambiguous/i);
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
@@ -242,13 +242,82 @@ function ruleMatches(rule: SelectionRule, signals: RoutingSignals): boolean {
   return true;
 }
 
+/** Raised when two DIFFERENT strategies match the same signals at equal priority. */
+export class AmbiguousManifestSelectionError extends Error {
+  constructor(
+    readonly priority: number,
+    readonly strategies: readonly ExecutionStrategy[],
+    readonly signals: RoutingSignals
+  ) {
+    super(
+      `Ambiguous manifest selection: strategies [${strategies.join(', ')}] match ` +
+        `signals ${JSON.stringify(signals)} at equal priority ${String(priority)}. ` +
+        `Resolve by giving exactly one rule a higher priority or a disjoint predicate ` +
+        `(routing must never be decided by strategy name — #3888).`
+    );
+    this.name = 'AmbiguousManifestSelectionError';
+  }
+}
+
+/**
+ * Computes the best matching rule per strategy for the given signals. Returns the
+ * winners ordered best-first by matching-rule priority. The single source of truth
+ * shared by {@link selectStrategyByManifest} (takes the head) and
+ * {@link rankStrategiesByManifest} (takes the full ordered list), so the SELECTION
+ * path and the transparency ALTERNATIVES path can never drift (#3888).
+ *
+ * FAIL-FAST on ambiguity: if two DIFFERENT strategies tie at the top priority for
+ * these signals, this throws {@link AmbiguousManifestSelectionError} rather than
+ * silently breaking the tie by strategy name (the #3888 fix). No reachable tie
+ * exists on the live 8 manifests today, so this is dead-but-defensive now and
+ * surfaces a future overlapping same-priority rule loudly.
+ *
+ * Names ZERO strategies (the #3836 invariant): adding a strategy is registering a
+ * manifest with rules, never editing this matcher.
+ */
+function matchingSelections(
+  signals: RoutingSignals,
+  manifests: readonly StrategyManifest[]
+): ManifestSelection[] {
+  // Best (highest-priority) matching rule per strategy.
+  const bestPerStrategy = new Map<ExecutionStrategy, ManifestSelection>();
+  for (const manifest of manifests) {
+    if (manifest.selectionRules === undefined) continue;
+    for (const rule of manifest.selectionRules) {
+      if (!ruleMatches(rule, signals)) continue;
+      const prev = bestPerStrategy.get(manifest.strategy);
+      if (prev === undefined || rule.priority > prev.rule.priority) {
+        bestPerStrategy.set(manifest.strategy, { strategy: manifest.strategy, manifest, rule });
+      }
+    }
+  }
+
+  const selections = [...bestPerStrategy.values()].sort(
+    (a, b) => b.rule.priority - a.rule.priority
+  );
+
+  // Guard the TOP priority: two distinct strategies tied for first place means the
+  // winner would otherwise be decided by name. Surface it instead of hiding it.
+  const [first, second] = selections;
+  if (first !== undefined && first.rule.priority === second?.rule.priority) {
+    const topPriority = first.rule.priority;
+    const tied = selections.filter((s) => s.rule.priority === topPriority).map((s) => s.strategy);
+    throw new AmbiguousManifestSelectionError(topPriority, tied, signals);
+  }
+
+  return selections;
+}
+
 /**
  * The manifest-driven router core (#3836). Evaluates every registered manifest's
  * {@link SelectionRule}s against the routing signals and returns the strategy
- * whose matching rule has the HIGHEST priority. Ties (equal priority) break
- * deterministically by strategy name so selection is reproducible. Returns
- * `undefined` only if NO rule across the whole registry matches — the caller
- * decides the fallback.
+ * whose matching rule has the HIGHEST priority. Returns `undefined` only if NO
+ * rule across the whole registry matches — the caller decides the fallback.
+ *
+ * Equal-priority collisions between two strategies FAIL FAST
+ * ({@link AmbiguousManifestSelectionError}, #3888) instead of the former silent
+ * alphabetical-name tie-break, so a future overlapping same-priority rule surfaces
+ * loudly rather than letting a rename quietly change routing.
  *
  * Crucially this function names ZERO strategies: adding a strategy is registering
  * a manifest with rules, never editing this matcher (the #3836 invariant, proven
@@ -258,19 +327,21 @@ export function selectStrategyByManifest(
   signals: RoutingSignals,
   manifests: readonly StrategyManifest[] = STRATEGY_MANIFEST_REGISTRY.manifests
 ): ManifestSelection | undefined {
-  let best: ManifestSelection | undefined;
-  for (const manifest of manifests) {
-    if (manifest.selectionRules === undefined) continue;
-    for (const rule of manifest.selectionRules) {
-      if (!ruleMatches(rule, signals)) continue;
-      const better =
-        best === undefined ||
-        rule.priority > best.rule.priority ||
-        (rule.priority === best.rule.priority && manifest.strategy < best.strategy);
-      if (better) {
-        best = { strategy: manifest.strategy, manifest, rule };
-      }
-    }
-  }
-  return best;
+  return matchingSelections(signals, manifests)[0];
+}
+
+/**
+ * Ranks every strategy whose selection rules MATCH the signals, best-first by
+ * matching-rule priority (#3888). This is the manifest-derived source of truth for
+ * the transparency "alternatives" list: it replaces the former hardcoded
+ * `strategyFrom*` table so the alternatives can never drift from the selection
+ * path. Shares ambiguity-detection with {@link selectStrategyByManifest}, so an
+ * equal-priority collision throws here too. The head of this list is exactly what
+ * {@link selectStrategyByManifest} returns.
+ */
+export function rankStrategiesByManifest(
+  signals: RoutingSignals,
+  manifests: readonly StrategyManifest[] = STRATEGY_MANIFEST_REGISTRY.manifests
+): ExecutionStrategy[] {
+  return matchingSelections(signals, manifests).map((s) => s.strategy);
 }


### PR DESCRIPTION
Implements **#3888** — the three confirmed follow-ups from the #3886 ratification vote (an adversarial review confirmed all three against the merged #3836/#3837 code). All changes are confined to `src/orchestration/**` + its tests + the `index.ts` re-exports + a changeset. **No live routing decision changes** for the 8 registered manifests.

## The three fixes

### 1. Alternatives split-brain (DRY) — `strategyFrom*` removed
`buildAlternatives` previously seeded the transparency "alternatives" list from the hardcoded `strategyFromPattern` / `strategyFromPipelineType` helpers, which encoded the pre-#3836 decision table verbatim and could drift from the manifest `selectionRules`.

It now derives alternatives from the **same** manifest `selectionRules` source of truth via a new `rankStrategiesByManifest(signals)`, which ranks every *other* matching strategy best-first by its matching-rule priority. The `selectStrategyByManifest` head and the alternatives tail now share one matcher (`matchingSelections`), so the selection path and the transparency path can no longer diverge.

- The two now-dead `strategyFromPattern` / `strategyFromPipelineType` helpers are **removed**, along with their re-exports from `meta-orchestrator.ts` and `orchestration/index.ts`.
- The `decideStrategy` unreachable fallback no longer resurrects the table — it returns the `orchestrate` multi-agent catch-all as a single literal.
- **Observable behaviour change:** the alternatives list now contains only genuinely manifest-routable runner-ups (best-first by priority), instead of the former heuristic `pattern + pipeline + orchestrate` triple. E.g. for `sequential + audit + moderate` the alternatives become `[dev-pipeline]` (pipeline@80 is chosen, dev-pipeline@30 is the only other match); for a pure `graph` pattern there are no alternatives because only `graph-workflow` has a matching rule.

### 2. Optional `selectionRules` → silent un-routability — new Vitest guard
Added a test asserting **every** manifest in `STRATEGY_MANIFEST_REGISTRY` declares ≥1 `selectionRule`, so a future manifest added without rules (silently un-routable) fails the suite. `selectionRules` stays `.optional()` on the schema to keep force-only manifests legal — guarding the *live registry* in a test is lower-risk than a schema change (per the issue's guidance). (No governance gate / inject-governance touched.)

### 3. Name-based tie-break → fail-fast
`selectStrategyByManifest` no longer breaks an equal-priority collision silently via `manifest.strategy < best.strategy` (alphabetical name). A genuine equal-priority tie between two strategies now throws `AmbiguousManifestSelectionError`, surfacing a future overlapping same-priority rule loudly instead of letting a rename quietly change routing. No reachable tie exists on today's 8 manifests, so this is dead-but-defensive now (an added test confirms the live 8 never throw).

## RED / GREEN evidence
- **RED:** with the new tests added but before the implementation, the registry test file failed `4 failed | 15 passed`: `rankStrategiesByManifest is not a function` (×3) and the equal-priority-collision test got no throw. The rule-coverage test passed immediately (the live 8 all carry rules — confirming it guards *future* additions).
- **GREEN after implementation:** orchestration suite `54 files / 1110 tests passed`; the two directly-touched files `meta-orchestrator.test.ts` + `strategy-manifest-registry.test.ts` → `56 passed`.
- **Full repo test suite:** `1096 files passed | 1 skipped`, `26363 tests passed | 16 skipped`, 0 failed.

## Full CI results (all green)
- `pnpm install --frozen-lockfile` ✅
- `pnpm typecheck` ✅ (exit 0)
- `pnpm test` ✅ (26363 passed)
- `pnpm build` ✅
- `pnpm lint` ✅ (exit 0)
- `pnpm claims:check` ✅ **8/8** claims verified
- `pnpm governance:check` ✅ (inject stamps; no drift)
- `pnpm strategy-manifest:check` ✅ (drift gate)
- `pnpm authority-tier:check` ✅ (authority-tier drift gate)

Changeset: **yes** (`.changeset/router-hardening-3888.md`, `patch`).

Fixes #3888

🤖 Generated with [Claude Code](https://claude.com/claude-code)