### PR TITLE
feat(audit): tier-transition audit events + ratification-linked promotion gate (#3842)

### DIFF
--- a/.changeset/tier-transition-audit-3842.md
+++ b/.changeset/tier-transition-audit-3842.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+feat(audit): tier-transition audit events + ratification-linked promotion gate (#3842)
+
+Completes the authority-ladder enforcement (Epic D / ADR-0017) by giving
+promotions and demotions an auditable, ratification-linked trail. The #3841 vote
+flagged that refusals/promotions currently leave no audit record; this closes
+that gap.
+
+A new typed, hash-chained audit event records every authority-tier transition:
+`{ kind: 'promotion' | 'demotion', subject, fromTier, toTier, evidenceRef,
+ratificationVoteRef? }`. It is emitted via `AuditLogger.logTierTransition(...)`
+as a `governance`-category event whose `metadata.tierTransition` carries the
+structured payload, so the existing hash chain (and `verifyChain`) is unchanged
+and the transition is recovered by `extractTierTransition`.
+
+The authority-tier CI gate (`scripts/check-authority-tier-drift.ts`, already
+joined into `governance:check`) is extended with the ratification invariant
+ADR-0017 requires: it reads the hash-chained tier-transition log
+(`governance/authority-tier-transitions.jsonl`, optional) and FAILS any
+`promotion` event lacking a linked `ratificationVoteRef`. Demotions are automatic
+and need no vote. No parallel governance mechanism was introduced.
+
+Tests prove (a) a tier-transition event hash-chains correctly and `verifyChain`
+still validates over the new event type, (b) the gate FAILS on a promotion event
+without a `ratificationVoteRef`, and (c) PASSES on a promotion WITH a vote ref and
+on a demotion without one — both with hand-built payloads and with events emitted
+through the real hash-chained logger.

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -24,8 +24,15 @@ import type {
   PolicyDecisionAuditOpts,
   SecurityEventAuditOpts,
   RateLimitAuditOpts,
+  TierTransitionAuditOpts,
+  TierTransitionPayload,
 } from './audit-types.js';
-import { AuditLogConfigSchema, AuditError } from './audit-types.js';
+import {
+  AuditLogConfigSchema,
+  AuditError,
+  TierTransitionPayloadSchema,
+  TIER_TRANSITION_METADATA_KEY,
+} from './audit-types.js';
 import { FileAuditStorage } from './audit-storage.js';
 
 // ============================================================================
@@ -139,6 +146,25 @@ export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
     priorHash = event.hash;
   }
   return { ok: true, eventCount: events.length };
+}
+
+// ============================================================================
+// Tier-Transition Extraction (Epic D / ADR-0017, #3842)
+// ============================================================================
+
+/**
+ * Recover the structured {@link TierTransitionPayload} from an audit event, or
+ * `null` if the event is not a (valid) tier-transition event. A tier-transition
+ * event is a `governance`-category event whose `metadata.tierTransition` parses
+ * against {@link TierTransitionPayloadSchema}. Used by the ratification gate to
+ * read transition events back out of the chained log.
+ */
+export function extractTierTransition(event: AuditEvent): TierTransitionPayload | null {
+  if (event.category !== 'governance') return null;
+  const raw = event.metadata?.[TIER_TRANSITION_METADATA_KEY];
+  if (raw === undefined) return null;
+  const parsed = TierTransitionPayloadSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }
 
 // ============================================================================
@@ -349,6 +375,45 @@ export class AuditLogger implements IAuditLogger {
       requestId: opts.requestId,
       toolName: opts.toolName,
       metadata: { currentRate: opts.currentRate, limitRate: opts.limitRate },
+    });
+  }
+
+  /**
+   * Log an authority-tier transition (Epic D / ADR-0017, #3842). A promotion or
+   * demotion of a loop's authority tier is recorded as a hash-chained
+   * `governance`-category event whose `metadata.tierTransition` carries the
+   * structured {@link TierTransitionPayload} ({subject, fromTier, toTier,
+   * evidenceRef, ratificationVoteRef?}).
+   *
+   * The emitter does NOT itself enforce the ratification invariant (a promotion
+   * with no `ratificationVoteRef` is still chained — tampering with the log to
+   * remove the field must not erase the event). The invariant is enforced by the
+   * ratification gate (`scripts/check-authority-tier-drift.ts`), which reads the
+   * chained events back and FAILS a `promotion` lacking a vote ref. A promotion
+   * is emitted at `warning` severity (it grants authority) so it surfaces above
+   * the default info floor; a demotion is `info` (it is the safe direction).
+   */
+  logTierTransition(opts: TierTransitionAuditOpts): void {
+    const payload: TierTransitionPayload = TierTransitionPayloadSchema.parse({
+      kind: opts.kind,
+      subject: opts.subject,
+      fromTier: opts.fromTier,
+      toTier: opts.toTier,
+      evidenceRef: opts.evidenceRef,
+      ...(opts.ratificationVoteRef !== undefined
+        ? { ratificationVoteRef: opts.ratificationVoteRef }
+        : {}),
+    });
+    this.log({
+      category: 'governance',
+      severity: opts.kind === 'promotion' ? 'warning' : 'info',
+      outcome: 'success',
+      action: `tier.${opts.kind}`,
+      description: `Authority-tier ${opts.kind}: '${opts.subject}' ${opts.fromTier} → ${opts.toTier}`,
+      actor: opts.actor ?? SYSTEM_ACTOR,
+      resource: { type: 'loop', id: opts.subject, name: opts.subject },
+      requestId: opts.requestId,
+      metadata: { ...opts.metadata, [TIER_TRANSITION_METADATA_KEY]: payload },
     });
   }
 

--- a/packages/nexus-agents/src/audit/audit-types.ts
+++ b/packages/nexus-agents/src/audit/audit-types.ts
@@ -41,8 +41,86 @@ export const AuditCategorySchema = z.enum([
   'configuration', // Settings changes
   'security', // Security events, violations
   'system', // System events, startup, shutdown
+  'governance', // Authority-tier transitions, ratification (Epic D, #3842)
 ]);
 export type AuditCategory = z.infer<typeof AuditCategorySchema>;
+
+// ============================================================================
+// Tier-Transition Audit Events (Epic D / ADR-0017, #3842)
+// ============================================================================
+
+/**
+ * The two directions a loop can move on the authority ladder (ADR-0017
+ * §"Transition Rules"). A `promotion` moves UP a tier and is invalid without a
+ * linked ratification vote; a `demotion` moves DOWN and is automatic (needs no
+ * vote). The ratification gate (`scripts/check-authority-tier-drift.ts`) keys
+ * off this kind: a `promotion` event lacking `ratificationVoteRef` FAILS the
+ * gate, a `demotion` does not.
+ */
+export const TierTransitionKindSchema = z.enum(['promotion', 'demotion']);
+export type TierTransitionKind = z.infer<typeof TierTransitionKindSchema>;
+
+/**
+ * The authority tier vocabulary, mirrored from
+ * `orchestration/strategy-manifest.ts` `AuthorityTierSchema`. Declared here so
+ * the audit module has no dependency on the orchestration layer (the audit log
+ * is the lower layer). A drift between the two enums is caught by the audit
+ * tier-transition tests, which round-trip every tier through the emitter.
+ */
+export const TierTransitionTierSchema = z.enum(['observe', 'suggest', 'advisory', 'enforce']);
+export type TierTransitionTier = z.infer<typeof TierTransitionTierSchema>;
+
+/**
+ * The structured payload of a tier-transition audit event (ADR-0017,
+ * §"All transitions are audit events"). Carried in the event's `metadata` under
+ * the `tierTransition` key so the existing hash-chain (which hashes the stable
+ * head fields) is unchanged, and recovered by the ratification gate.
+ *
+ * `ratificationVoteRef` is OPTIONAL on the schema (a demotion legitimately has
+ * none), but REQUIRED for a `promotion` by the gate, not the schema — this keeps
+ * the event-shape uniform and locates the invariant in one place (the gate).
+ */
+export const TierTransitionPayloadSchema = z
+  .object({
+    /** Whether the loop moved up (`promotion`) or down (`demotion`) the ladder. */
+    kind: TierTransitionKindSchema,
+    /** The loop/strategy whose tier changed (manifest `id` or loop identifier). */
+    subject: z.string().min(1),
+    /** Tier before the transition. */
+    fromTier: TierTransitionTierSchema,
+    /** Tier after the transition. */
+    toTier: TierTransitionTierSchema,
+    /** Ref to the promotion-evidence record this transition was earned against. */
+    evidenceRef: z.string().min(1),
+    /**
+     * Ref to the recorded `consensus_vote` that ratified a PROMOTION. Required
+     * by the ratification gate for `kind: 'promotion'`; legitimately absent for
+     * `kind: 'demotion'` (automatic, ADR-0017 §"Demotion is automatic").
+     */
+    ratificationVoteRef: z.string().min(1).optional(),
+  })
+  .strict();
+export type TierTransitionPayload = z.infer<typeof TierTransitionPayloadSchema>;
+
+/** The `metadata` key under which a tier-transition event carries its payload. */
+export const TIER_TRANSITION_METADATA_KEY = 'tierTransition' as const;
+
+/**
+ * Options for {@link IAuditLogger.logTierTransition}. The `actor` defaults to the
+ * system actor at the emission site when omitted (a tier change recorded by the
+ * evidence ledger is a system event).
+ */
+export interface TierTransitionAuditOpts {
+  kind: TierTransitionKind;
+  subject: string;
+  fromTier: TierTransitionTier;
+  toTier: TierTransitionTier;
+  evidenceRef: string;
+  ratificationVoteRef?: string | undefined;
+  actor?: AuditActor | undefined;
+  requestId?: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
+}
 
 // ============================================================================
 // Audit Severity Levels
@@ -252,6 +330,9 @@ export interface IAuditLogger {
 
   /** Log a rate limit violation */
   logRateLimitViolation(opts: RateLimitAuditOpts): void;
+
+  /** Log an authority-tier transition (promotion/demotion) — Epic D, #3842. */
+  logTierTransition(opts: TierTransitionAuditOpts): void;
 
   /** Flush pending events */
   flush(): Promise<void>;

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -20,6 +20,10 @@ export {
   AuditEventInputSchema,
   AuditLogConfigSchema,
   AuditQueryCriteriaSchema,
+  TierTransitionKindSchema,
+  TierTransitionTierSchema,
+  TierTransitionPayloadSchema,
+  TIER_TRANSITION_METADATA_KEY,
 } from './audit-types.js';
 export type {
   AuditCategory,
@@ -37,10 +41,20 @@ export type {
   PolicyDecisionAuditOpts,
   SecurityEventAuditOpts,
   RateLimitAuditOpts,
+  TierTransitionKind,
+  TierTransitionTier,
+  TierTransitionPayload,
+  TierTransitionAuditOpts,
 } from './audit-types.js';
 
 // Logger
-export { AuditLogger, createAuditLogger } from './audit-logger.js';
+export {
+  AuditLogger,
+  createAuditLogger,
+  verifyChain,
+  extractTierTransition,
+} from './audit-logger.js';
+export type { ChainVerification } from './audit-logger.js';
 
 // Storage
 export { FileAuditStorage, InMemoryAuditStorage } from './audit-storage.js';

--- a/packages/nexus-agents/src/audit/secure-handler-audit.test.ts
+++ b/packages/nexus-agents/src/audit/secure-handler-audit.test.ts
@@ -40,6 +40,7 @@ function makeMockAuditLogger() {
     logPolicyDecision: vi.fn(),
     logSecurityEvent: vi.fn(),
     logRateLimitViolation: vi.fn(),
+    logTierTransition: vi.fn(),
     flush: vi.fn(() => Promise.resolve()),
     close: vi.fn(() => Promise.resolve()),
   } satisfies IAuditLogger;

--- a/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
+++ b/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for tier-transition audit events (Epic D / ADR-0017, #3842).
+ *
+ * Uses REAL SHA-256 (no `node:crypto` stub, unlike audit-logger.test.ts) so the
+ * hash-chain round-trip is genuine: events emitted by `logTierTransition` must
+ * chain into the log and `verifyChain` must still validate over the new event
+ * type. Also covers the `extractTierTransition` recovery helper and the
+ * structured payload shape {subject, fromTier, toTier, evidenceRef,
+ * ratificationVoteRef?}.
+ *
+ * @module audit/tier-transition-audit.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AuditLogger, verifyChain, extractTierTransition } from './audit-logger.js';
+import { InMemoryAuditStorage } from './audit-storage.js';
+import type { AuditLogConfig } from './audit-types.js';
+import { TIER_TRANSITION_METADATA_KEY } from './audit-types.js';
+
+function makeLogger(): { logger: AuditLogger; storage: InMemoryAuditStorage } {
+  const storage = new InMemoryAuditStorage();
+  const config: AuditLogConfig = {
+    logDir: '/tmp/tier-transition-test',
+    filePrefix: 'audit',
+    maxFileSizeBytes: 10 * 1024 * 1024,
+    maxFiles: 10,
+    enableHashChain: true,
+    enableCompression: false,
+    flushIntervalMs: 60_000,
+    maxQueueDepth: 10_000,
+    minSeverity: 'info',
+  };
+  const logger = new AuditLogger(config, storage);
+  return { logger, storage };
+}
+
+describe('logTierTransition — event shape', () => {
+  it('emits a governance event carrying the structured tier-transition payload', async () => {
+    const { logger, storage } = makeLogger();
+    logger.logTierTransition({
+      kind: 'promotion',
+      subject: 'auto-remediation',
+      fromTier: 'advisory',
+      toTier: 'enforce',
+      evidenceRef: 'governance/authority-tier-evidence.yaml#auto-remediation',
+      ratificationVoteRef: 'consensus_vote/cv_3769_enforce',
+    });
+    await logger.close();
+
+    const events = storage.getAll();
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.category).toBe('governance');
+    expect(event.action).toBe('tier.promotion');
+    expect(event.severity).toBe('warning'); // promotions grant authority
+    expect(event.resource).toEqual({
+      type: 'loop',
+      id: 'auto-remediation',
+      name: 'auto-remediation',
+    });
+
+    const payload = extractTierTransition(event);
+    expect(payload).toEqual({
+      kind: 'promotion',
+      subject: 'auto-remediation',
+      fromTier: 'advisory',
+      toTier: 'enforce',
+      evidenceRef: 'governance/authority-tier-evidence.yaml#auto-remediation',
+      ratificationVoteRef: 'consensus_vote/cv_3769_enforce',
+    });
+    expect(event.metadata?.[TIER_TRANSITION_METADATA_KEY]).toEqual(payload);
+  });
+
+  it('emits a demotion at info severity with no ratificationVoteRef', async () => {
+    const { logger, storage } = makeLogger();
+    logger.logTierTransition({
+      kind: 'demotion',
+      subject: 'tune-loop',
+      fromTier: 'enforce',
+      toTier: 'advisory',
+      evidenceRef: 'regression/tune-precision-drop',
+    });
+    await logger.close();
+
+    const event = storage.getAll()[0]!;
+    expect(event.action).toBe('tier.demotion');
+    expect(event.severity).toBe('info');
+    const payload = extractTierTransition(event);
+    expect(payload?.kind).toBe('demotion');
+    expect(payload?.ratificationVoteRef).toBeUndefined();
+  });
+});
+
+describe('logTierTransition — hash chain', () => {
+  it('hash-chains a tier-transition event into the log and verifyChain validates', async () => {
+    const { logger, storage } = makeLogger();
+    // Interleave a system event, a promotion, and a demotion.
+    logger.logSystemStartup({ note: 'boot' });
+    logger.logTierTransition({
+      kind: 'promotion',
+      subject: 'learned-selection-rules',
+      fromTier: 'advisory',
+      toTier: 'enforce',
+      evidenceRef: 'evidence#3552',
+      ratificationVoteRef: 'cv_3552',
+    });
+    logger.logTierTransition({
+      kind: 'demotion',
+      subject: 'learned-selection-rules',
+      fromTier: 'enforce',
+      toTier: 'advisory',
+      evidenceRef: 'regression#3552',
+    });
+    await logger.close();
+
+    const events = storage.getAll();
+    expect(events).toHaveLength(3);
+    // Each event after the first links to its predecessor's hash.
+    expect(events[1]!.previousHash).toBe(events[0]!.hash);
+    expect(events[2]!.previousHash).toBe(events[1]!.hash);
+
+    const result = verifyChain(events);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.eventCount).toBe(3);
+  });
+
+  it('verifyChain detects tampering with a tier-transition event body', async () => {
+    const { logger, storage } = makeLogger();
+    logger.logTierTransition({
+      kind: 'promotion',
+      subject: 'clawguard',
+      fromTier: 'advisory',
+      toTier: 'enforce',
+      evidenceRef: 'evidence#2077',
+      ratificationVoteRef: 'cv_2077',
+    });
+    await logger.close();
+
+    const events = storage.getAll();
+    // Tamper the action without recomputing the hash.
+    const tampered = { ...events[0]!, action: 'tier.demotion' as const };
+    const result = verifyChain([tampered]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+});
+
+describe('extractTierTransition', () => {
+  it('returns null for a non-governance event', async () => {
+    const { logger, storage } = makeLogger();
+    logger.logSystemStartup();
+    await logger.close();
+    expect(extractTierTransition(storage.getAll()[0]!)).toBeNull();
+  });
+});

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
@@ -1270,6 +1270,7 @@ describe('SecureHandler', () => {
       logPolicyDecision: Mock;
       logRateLimitViolation: Mock;
       logSecurityEvent: Mock;
+      logTierTransition: Mock;
       log: Mock;
       flush: Mock;
       close: Mock;
@@ -1282,6 +1283,7 @@ describe('SecureHandler', () => {
         logPolicyDecision: vi.fn(),
         logRateLimitViolation: vi.fn(),
         logSecurityEvent: vi.fn(),
+        logTierTransition: vi.fn(),
         log: vi.fn(),
         flush: vi.fn().mockResolvedValue(undefined),
         close: vi.fn().mockResolvedValue(undefined),

--- a/packages/nexus-agents/src/security/audit-bridge.test.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.test.ts
@@ -152,6 +152,7 @@ function captureLogger(logImpl?: (i: AuditEventInput) => void): {
     logPolicyDecision: vi.fn(),
     logSecurityEvent: vi.fn(),
     logRateLimitViolation: vi.fn(),
+    logTierTransition: vi.fn(),
     flush: vi.fn(() => Promise.resolve()),
     close: vi.fn(() => Promise.resolve()),
   };

--- a/scripts/check-authority-tier-drift.test.ts
+++ b/scripts/check-authority-tier-drift.test.ts
@@ -14,11 +14,16 @@ import { describe, it, expect } from 'vitest';
 import { stringify as toYaml } from 'yaml';
 import {
   analyzeTierDeclarations,
+  analyzeTierTransitionEvents,
+  recoverTransitions,
   checkAuthorityTierDeclarations,
   soakDays,
   ENFORCE_FLOOR,
 } from './check-authority-tier-drift.js';
 import type { AuthorityTier } from '../packages/nexus-agents/src/orchestration/strategy-manifest.js';
+import type { TierTransitionPayload } from '../packages/nexus-agents/src/audit/audit-types.js';
+import { AuditLogger } from '../packages/nexus-agents/src/audit/audit-logger.js';
+import { InMemoryAuditStorage } from '../packages/nexus-agents/src/audit/audit-storage.js';
 
 /** A floor-meeting promotion-evidence record for `loopId`, advisory→enforce. */
 function meetingEvidence(loopId: string): Record<string, unknown> {
@@ -119,8 +124,138 @@ describe('analyzeTierDeclarations (#3841)', () => {
   });
 });
 
-describe('checkAuthorityTierDeclarations — live registry (#3841)', () => {
-  it('the committed registry + evidence ledger pass the gate', () => {
+/** A tier-transition payload with the given kind and optional vote ref. */
+function transition(
+  kind: 'promotion' | 'demotion',
+  ratificationVoteRef?: string
+): TierTransitionPayload {
+  return {
+    kind,
+    subject: 'auto-remediation',
+    fromTier: kind === 'promotion' ? 'advisory' : 'enforce',
+    toTier: kind === 'promotion' ? 'enforce' : 'advisory',
+    evidenceRef: 'evidence#3769',
+    ...(ratificationVoteRef !== undefined ? { ratificationVoteRef } : {}),
+  };
+}
+
+describe('analyzeTierTransitionEvents — ratification gate (#3842)', () => {
+  it('FAILS a promotion event with NO ratificationVoteRef (breakage fixture)', () => {
+    const findings = analyzeTierTransitionEvents([transition('promotion')]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-without-ratification');
+    expect(findings[0]?.message).toContain('auto-remediation');
+  });
+
+  it('FAILS a promotion event whose ratificationVoteRef is empty/whitespace', () => {
+    const findings = analyzeTierTransitionEvents([transition('promotion', '   ')]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-without-ratification');
+  });
+
+  it('PASSES a promotion event WITH a ratificationVoteRef', () => {
+    const findings = analyzeTierTransitionEvents([transition('promotion', 'cv_3769')]);
+    expect(findings).toEqual([]);
+  });
+
+  it('PASSES a demotion event with NO ratificationVoteRef (automatic, ADR-0017)', () => {
+    const findings = analyzeTierTransitionEvents([transition('demotion')]);
+    expect(findings).toEqual([]);
+  });
+
+  it('flags only the offending promotion in a mixed batch', () => {
+    const findings = analyzeTierTransitionEvents([
+      transition('promotion', 'cv_ok'),
+      transition('demotion'),
+      transition('promotion'), // offender
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-without-ratification');
+  });
+});
+
+describe('recoverTransitions — reads the chained transition log (#3842)', () => {
+  /** Emit transitions through the real hash-chained logger and serialize to JSONL. */
+  async function jsonlOf(
+    emit: (logger: AuditLogger) => void
+  ): Promise<{ jsonl: string; eventCount: number }> {
+    const storage = new InMemoryAuditStorage();
+    const logger = new AuditLogger(
+      {
+        logDir: '/tmp/recover-transitions-test',
+        enableHashChain: true,
+        flushIntervalMs: 60_000,
+        minSeverity: 'info',
+      },
+      storage
+    );
+    emit(logger);
+    await logger.close();
+    const events = storage.getAll();
+    return { jsonl: events.map((e) => JSON.stringify(e)).join('\n'), eventCount: events.length };
+  }
+
+  it('recovers a promotion-without-vote from real emitted events and the gate FAILS', async () => {
+    const { jsonl } = await jsonlOf((l) => {
+      l.logTierTransition({
+        kind: 'promotion',
+        subject: 'clawguard',
+        fromTier: 'advisory',
+        toTier: 'enforce',
+        evidenceRef: 'evidence#2077',
+        // no ratificationVoteRef — the breakage
+      });
+    });
+    const { transitions, findings } = recoverTransitions(jsonl);
+    expect(findings).toEqual([]); // the log itself is valid
+    expect(transitions).toHaveLength(1);
+    const gate = analyzeTierTransitionEvents(transitions);
+    expect(gate).toHaveLength(1);
+    expect(gate[0]?.code).toBe('promotion-without-ratification');
+  });
+
+  it('recovers a ratified promotion + a demotion and the gate PASSES', async () => {
+    const { jsonl } = await jsonlOf((l) => {
+      l.logTierTransition({
+        kind: 'promotion',
+        subject: 'clawguard',
+        fromTier: 'advisory',
+        toTier: 'enforce',
+        evidenceRef: 'evidence#2077',
+        ratificationVoteRef: 'cv_2077',
+      });
+      l.logTierTransition({
+        kind: 'demotion',
+        subject: 'clawguard',
+        fromTier: 'enforce',
+        toTier: 'advisory',
+        evidenceRef: 'regression#2077',
+      });
+    });
+    const { transitions, findings } = recoverTransitions(jsonl);
+    expect(findings).toEqual([]);
+    expect(transitions).toHaveLength(2);
+    expect(analyzeTierTransitionEvents(transitions)).toEqual([]);
+  });
+
+  it('FAILS transition-log-invalid on a malformed JSONL line', () => {
+    const { findings } = recoverTransitions('{ not json');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('transition-log-invalid');
+  });
+
+  it('skips non-tier-transition audit events without error', async () => {
+    const { jsonl } = await jsonlOf((l) => {
+      l.logSystemStartup({ note: 'boot' });
+    });
+    const { transitions, findings } = recoverTransitions(jsonl);
+    expect(findings).toEqual([]);
+    expect(transitions).toEqual([]);
+  });
+});
+
+describe('checkAuthorityTierDeclarations — live registry (#3841/#3842)', () => {
+  it('the committed registry + evidence ledger + transition log pass the gate', () => {
     expect(checkAuthorityTierDeclarations()).toBe(true);
   });
 });

--- a/scripts/check-authority-tier-drift.ts
+++ b/scripts/check-authority-tier-drift.ts
@@ -25,13 +25,18 @@
  * sibling to the #3837 manifest drift-gate, and exposed standalone as
  * `pnpm authority-tier:check`.
  *
- * Deferred to #3842: the tier-transition AUDIT EVENTS + the gate that fails a
- * promotion audit event lacking a linked ratification vote. This gate validates
- * the manifest DECLARATION + the evidence floor; the hash-chained transition log
- * is #3842's surface.
+ * Tier-transition ratification gate (#3842): in addition to the declaration +
+ * evidence-floor checks, this gate now also reads the hash-chained
+ * tier-transition AUDIT EVENTS (Epic D / ADR-0017 §"Transition Rules") and FAILS
+ * a PROMOTION transition event that lacks a linked `ratificationVoteRef`.
+ * Promotions must be ratification-linked (ADR-0017); demotions are automatic and
+ * need no vote. The transition log lives at
+ * `governance/authority-tier-transitions.jsonl` (optional — empty when no
+ * transition has occurred); each line is a persisted `AuditEvent`. The pure
+ * analysis ({@link analyzeTierTransitionEvents}) is unit-tested in isolation.
  *
  * @module scripts/check-authority-tier-drift
- * (Source: ADR-0017, Issue #3839, #3841)
+ * (Source: ADR-0017, Issue #3839, #3841, #3842)
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -44,8 +49,14 @@ import {
   type PromotionEvidence,
 } from '../packages/nexus-agents/src/orchestration/strategy-manifest.js';
 import { STRATEGY_MANIFEST_REGISTRY } from '../packages/nexus-agents/src/orchestration/strategy-manifest-registry.js';
+import { extractTierTransition } from '../packages/nexus-agents/src/audit/audit-logger.js';
+import {
+  AuditEventSchema,
+  type TierTransitionPayload,
+} from '../packages/nexus-agents/src/audit/audit-types.js';
 
 const EVIDENCE_LEDGER = join(ROOT, 'governance/authority-tier-evidence.yaml');
+const TRANSITION_LOG = join(ROOT, 'governance/authority-tier-transitions.jsonl');
 
 /**
  * The ADR-0017 advisory→enforce promotion floor. The minimum a gate enforces; a
@@ -66,7 +77,9 @@ export interface TierDriftFinding {
     | 'tier-undeclared'
     | 'enforce-without-evidence'
     | 'enforce-evidence-below-floor'
-    | 'evidence-ledger-invalid';
+    | 'evidence-ledger-invalid'
+    | 'promotion-without-ratification'
+    | 'transition-log-invalid';
   readonly message: string;
 }
 
@@ -151,6 +164,75 @@ export function analyzeTierDeclarations(inputs: DriftInputs): TierDriftFinding[]
   return findings;
 }
 
+/**
+ * The ratification gate (#3842). Pure analysis (no disk/process I/O) over the
+ * recovered tier-transition payloads so it is unit-testable with fixtures both
+ * ways. ADR-0017 §"Promotions are ratification-linked": a `promotion` transition
+ * is valid only if it carries a linked `ratificationVoteRef`; a `demotion` is
+ * automatic and needs none. This is the machine-enforced invariant the
+ * ratification panel's Contrarian required: a tier-transition audit event of kind
+ * `promotion` lacking a linked ratification vote FAILS the gate.
+ *
+ * @param transitions - tier-transition payloads recovered from the chained audit log
+ * @returns one `promotion-without-ratification` finding per offending promotion
+ */
+export function analyzeTierTransitionEvents(
+  transitions: readonly TierTransitionPayload[]
+): TierDriftFinding[] {
+  const findings: TierDriftFinding[] = [];
+  for (const t of transitions) {
+    if (t.kind !== 'promotion') continue; // demotions are automatic — no vote required
+    const ref = t.ratificationVoteRef;
+    if (ref === undefined || ref.trim() === '') {
+      findings.push({
+        code: 'promotion-without-ratification',
+        message: `tier-transition promotion of '${t.subject}' (${t.fromTier} → ${t.toTier}, evidenceRef='${t.evidenceRef}') has NO linked ratificationVoteRef. Promotions MUST be ratification-linked (ADR-0017 §"Promotions are ratification-linked") — record the consensus_vote ref on the transition audit event.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Read the optional tier-transition log (JSONL of persisted AuditEvents) and
+ * recover the tier-transition payloads. Returns the findings: a single
+ * `transition-log-invalid` if a line is not a valid AuditEvent (fail-closed — we
+ * cannot trust the log), plus the recovered payloads for the ratification check.
+ * A non-tier-transition event (any other audit event sharing the file) is simply
+ * skipped, not an error.
+ */
+export function recoverTransitions(jsonl: string): {
+  readonly transitions: TierTransitionPayload[];
+  readonly findings: TierDriftFinding[];
+} {
+  const transitions: TierTransitionPayload[] = [];
+  const findings: TierDriftFinding[] = [];
+  const lines = jsonl.split('\n').filter((l) => l.trim() !== '');
+  for (const [i, line] of lines.entries()) {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      findings.push({
+        code: 'transition-log-invalid',
+        message: `governance/authority-tier-transitions.jsonl line ${String(i + 1)} is not valid JSON.`,
+      });
+      continue;
+    }
+    const parsed = AuditEventSchema.safeParse(raw);
+    if (!parsed.success) {
+      findings.push({
+        code: 'transition-log-invalid',
+        message: `governance/authority-tier-transitions.jsonl line ${String(i + 1)} is not a valid AuditEvent: ${parsed.error.issues.map((x) => x.message).join('; ')}.`,
+      });
+      continue;
+    }
+    const payload = extractTierTransition(parsed.data);
+    if (payload !== null) transitions.push(payload);
+  }
+  return { transitions, findings };
+}
+
 /** The ways an evidence record falls short of the advisory→enforce floor. */
 function enforceFloorShortfalls(e: PromotionEvidence): string[] {
   const out: string[] = [];
@@ -187,13 +269,24 @@ export function checkAuthorityTierDeclarations(): boolean {
     : undefined;
 
   const findings = analyzeTierDeclarations({ declaredTiers, evidenceYaml });
+
+  // #3842 ratification gate: read the hash-chained tier-transition log (if any)
+  // and fail any PROMOTION event lacking a linked ratificationVoteRef.
+  if (existsSync(TRANSITION_LOG)) {
+    const { transitions, findings: logFindings } = recoverTransitions(
+      readFileSync(TRANSITION_LOG, 'utf-8')
+    );
+    findings.push(...logFindings, ...analyzeTierTransitionEvents(transitions));
+  }
+
   if (findings.length === 0) return true;
 
-  console.error('Authority-tier declaration drift (#3841, ADR-0017):');
+  console.error('Authority-tier drift (#3841/#3842, ADR-0017):');
   for (const f of findings) console.error(`  - [${f.code}] ${f.message}`);
-  console.error('  Declare a tier on every manifest in governance/strategy-manifests.yaml, and');
+  console.error('  Declare a tier on every manifest in governance/strategy-manifests.yaml,');
   console.error('  back any `enforce` with a floor-meeting record in');
-  console.error('  governance/authority-tier-evidence.yaml. Re-run: pnpm authority-tier:check');
+  console.error('  governance/authority-tier-evidence.yaml, and link a ratification vote on');
+  console.error('  every promotion transition. Re-run: pnpm authority-tier:check');
   return false;
 }
 


### PR DESCRIPTION
Completes the authority-ladder enforcement (Epic D / ADR-0017, M3) by giving promotions and demotions an auditable, ratification-linked trail. The #3841 vote flagged that refusals/promotions currently leave no audit record; this closes that gap. Fixes #3842.

## Event shape

A new typed, hash-chained audit event records every authority-tier transition (`audit/audit-types.ts` → `TierTransitionPayloadSchema`):

```
{ kind: 'promotion' | 'demotion', subject, fromTier, toTier, evidenceRef, ratificationVoteRef? }
```

`ratificationVoteRef` is optional on the schema (a demotion legitimately has none) — the promotion invariant lives in the gate, not the schema, so the event shape stays uniform.

## Where emitted

`AuditLogger.logTierTransition(opts)` (`audit/audit-logger.ts`) emits it as a `governance`-category event whose `metadata.tierTransition` carries the structured payload. This keeps the existing hash chain (which hashes the stable head fields) and `verifyChain` unchanged. A promotion is emitted at `warning` severity (it grants authority); a demotion at `info` (the safe direction). The payload is recovered with the new `extractTierTransition(event)` helper. This is the emission point ADR-0017 §"All transitions are audit events" calls for — the spot where a tier change is recorded (e.g. when the evidence ledger records a promotion/demotion).

## Ratification gate (promotion-gate logic)

Implemented by EXTENDING the existing authority-tier check (`scripts/check-authority-tier-drift.ts`, already joined into `governance:check`) — no parallel governance mechanism. New pure analyzer:

- `analyzeTierTransitionEvents(transitions)` — FAILS (`promotion-without-ratification`) any `kind: 'promotion'` payload whose `ratificationVoteRef` is missing/empty; `kind: 'demotion'` is skipped (automatic, ADR-0017 §"Demotion is automatic").
- `recoverTransitions(jsonl)` — reads the optional hash-chained transition log `governance/authority-tier-transitions.jsonl` (each line a persisted `AuditEvent`), validates each against `AuditEventSchema` (fail-closed `transition-log-invalid` on a bad line), and recovers tier-transition payloads via `extractTierTransition`.

The CI entrypoint `checkAuthorityTierDeclarations()` now appends these findings, so `governance:check` (and `pnpm authority-tier:check`) fail a promotion event lacking a linked ratification vote.

## Tests (hash-chain + RED/GREEN)

- **Hash chain** (`audit/tier-transition-audit.test.ts`, real SHA-256): a tier-transition event hash-chains into the log (`previousHash` links verified) and `verifyChain` validates over the new event type; tampering a transition event's body is detected as `hash_mismatch`.
- **RED/GREEN gate** (`scripts/check-authority-tier-drift.test.ts`): the gate FAILS on a promotion with no `ratificationVoteRef` (and on empty/whitespace), and PASSES on a promotion WITH a vote ref and on a demotion without one — both with hand-built payloads and with events emitted through the real hash-chained logger. RED was confirmed by disabling the promotion branch (5 gate tests flip to failing); GREEN with it in place (19/19).

## CI

`pnpm install --frozen-lockfile`, `typecheck`, `build`, `lint` all green. Full `pnpm test`: 26363 passed / 16 skipped, 0 failures (incl. the new audit + gate tests and the existing audit-chain tests). `claims:check` 8/8, `governance:check` (incl. the authority-tier gate) green. `governance:inject` produced no stamp drift.

Did NOT touch `meta-orchestrator*.ts`, `strategy-manifest*.ts`, `inject-governance.ts`, or `docs-check.yml`. Changeset added (`minor`). Three audit/test mocks gained a `logTierTransition` stub because the new method was added to the `IAuditLogger` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)