### PR TITLE
fix(governance): verify ratification-vote resolvability in promotion gate (#3894)

### DIFF
--- a/.changeset/ratification-resolvability-3894.md
+++ b/.changeset/ratification-resolvability-3894.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): make the promotion gate verify ratification-vote RESOLVABILITY, not non-emptiness (#3894)
+
+The authority-ladder promotion gate (`analyzeTierTransitionEvents` in
+`scripts/check-authority-tier-drift.ts`, under `governance:check`) failed a
+`kind:'promotion'` tier-transition only when its `ratificationVoteRef` was
+_empty_ — a bogus `ratificationVoteRef:'x'` passed. The "ratification-LINKED"
+guarantee (#3842) was therefore only as strong as a non-empty string, the
+cosmetic-linkage gap the #3893 ratification panel's Contrarian flagged.
+
+The gate now RESOLVES the ref against a committed ratification-vote ledger and
+fails three new ways:
+
+- `promotion-ratification-unresolved` — the (non-empty) ref does not resolve to
+  any recorded vote.
+- `promotion-ratification-not-approved` — it resolves but the vote was not
+  `approved`, was not a `higher_order` vote (a promotion is
+  governance-of-the-governor), or its `subject` does not match the transition.
+- `ratification-ledger-invalid` — the ledger itself fails schema validation
+  (fail-closed: the resolver then resolves nothing, so every promotion fails).
+
+**Resolution source.** Live `consensus_vote` results are persisted only to
+per-developer home-dir stores (`~/.nexus-agents/voting/`,
+`~/.nexus-agents/learning/`) that a CI gate — no live server, no developer home
+dir — cannot read. There is no other committed, queryable source of truth. So
+the honest mechanism is a new committed ledger `governance/ratification-votes.yaml`
+(schema `RatificationVoteLedgerSchema` in `src/audit/audit-types.ts`), empty
+today. **Residual gap:** the gate verifies STRUCTURAL PRESENCE of an approved,
+higher_order vote in a committed (hence reviewable) record — it does not, and
+cannot from CI, re-execute the vote.
+
+The schema-level discriminated-union tightening of `TierTransitionPayload`
+(#3894 item 2) was intentionally NOT done: the emitter deliberately still chains
+a promotion that lacks a vote ref (so tampering cannot erase the event), with the
+invariant located in the gate — a write-time required field would conflict with
+that documented design, so it is not low-risk.

--- a/governance/ratification-votes.yaml
+++ b/governance/ratification-votes.yaml
@@ -1,0 +1,40 @@
+# Ratification-vote ledger (Epic D, #3894 — ADR-0017).
+#
+# The COMMITTED resolution source the promotion gate
+# (scripts/check-authority-tier-drift.ts, under governance:check) resolves a
+# tier-transition's `ratificationVoteRef` against. #3842 only checked the ref was
+# non-empty — a bogus `ratificationVoteRef:'x'` passed, so "ratification-LINKED"
+# was only as strong as a non-empty string. #3894 makes the link genuine: a
+# `promotion` transition's ref must RESOLVE to a record HERE whose `decision` is
+# `approved` and whose `strategy` is `higher_order` (a promotion is
+# governance-of-the-governor), with a `subject` matching the transition.
+#
+# Each record is a RatificationVote (schema: check-authority-tier-drift.ts
+# RatificationVoteSchema):
+#   id                 the ref a tier-transition's ratificationVoteRef must equal
+#   subject            the loop/strategy id the vote ratified (must match the transition)
+#   decision           'approved' | 'rejected' (only 'approved' ratifies a promotion)
+#   strategy           the voting strategy ('higher_order' required for promotions)
+#   votedAt            ISO-8601 timestamp the vote was recorded
+#   approvalPercentage optional approval fraction (human record)
+#   voteUri            optional link to the vote artifact / issue thread (human record)
+#
+# RESOLUTION SOURCE & RESIDUAL GAP (#3894). Live `consensus_vote` results are
+# persisted only to per-developer home-dir stores (~/.nexus-agents/voting/,
+# ~/.nexus-agents/learning/) that a CI gate — no live server, no developer home
+# dir — cannot read. There is no other committed, queryable source of truth for
+# "did ratification vote X happen and pass". So this committed ledger IS the
+# resolution source: the gate verifies STRUCTURAL PRESENCE of an approved,
+# higher_order vote in a committed (hence reviewable) record. It does not, and
+# cannot from CI, re-execute the vote — recording a vote here is itself a
+# reviewable governance change.
+#
+# EMPTY today: the initial 8 strategies are declared at suggest/advisory baselines
+# (no promotion) and the transition log is empty. The absorbed promotion cases
+# (#3552/#3769/#2077) each land their ratification record here in their own PR,
+# alongside the matching tier-transition audit event.
+#
+# Source: ADR-0017, Issue #3894 (hardens #3842).
+
+version: 1
+votes: []

--- a/packages/nexus-agents/src/audit/audit-types.ts
+++ b/packages/nexus-agents/src/audit/audit-types.ts
@@ -105,6 +105,67 @@ export type TierTransitionPayload = z.infer<typeof TierTransitionPayloadSchema>;
 /** The `metadata` key under which a tier-transition event carries its payload. */
 export const TIER_TRANSITION_METADATA_KEY = 'tierTransition' as const;
 
+// ============================================================================
+// Ratification-vote ledger (Epic D / ADR-0017, #3894)
+// ============================================================================
+
+/**
+ * A recorded ratification vote in the committed ratification ledger
+ * (`governance/ratification-votes.yaml`). #3894: the promotion gate previously
+ * failed a `promotion` transition only when its `ratificationVoteRef` was *empty*
+ * — a bogus `ratificationVoteRef:'x'` passed, so the "ratification-LINKED"
+ * guarantee was only as strong as a non-empty string. This record is the
+ * resolution source: a promotion's `ratificationVoteRef` must RESOLVE to a record
+ * here whose `decision` is `approved` and whose `strategy` is `higher_order`.
+ *
+ * RESOLUTION SOURCE & RESIDUAL GAP. Live `consensus_vote` results are persisted
+ * only to per-developer home-dir stores (`~/.nexus-agents/voting/`,
+ * `~/.nexus-agents/learning/`) that a CI gate — no live server, no developer home
+ * dir — cannot read. There is no other committed, queryable source of truth for
+ * "did ratification vote X happen and pass". So this committed ledger IS the
+ * resolution source; the gate verifies STRUCTURAL PRESENCE of an approved,
+ * higher_order vote in a committed (hence reviewable) record. It does not — and
+ * cannot from CI — re-execute the vote.
+ *
+ * Declared here (the audit layer) so the gate's schema import keeps the same
+ * zod-via-package resolution as the other tier-transition schemas (the repo-root
+ * `scripts/` dir cannot itself resolve `zod`).
+ */
+export const RatificationVoteSchema = z
+  .object({
+    /** The ref a tier-transition's `ratificationVoteRef` must equal to resolve. */
+    id: z.string().min(1),
+    /** The loop/strategy the vote ratified (cross-checked against the transition subject). */
+    subject: z.string().min(1),
+    /**
+     * The recorded decision. Only `approved` ratifies a promotion; `rejected`
+     * fails the gate (`promotion-ratification-not-approved`).
+     */
+    decision: z.enum(['approved', 'rejected']),
+    /**
+     * The voting strategy. A promotion is governance-of-the-governor and must be
+     * ratified by a `higher_order` consensus_vote (ADR-0017).
+     */
+    strategy: z.enum(['higher_order', 'simple_majority', 'supermajority', 'unanimous']),
+    /** ISO-8601 timestamp the vote was recorded. */
+    votedAt: z.string().min(1),
+    /** Optional approval fraction / quorum detail, for the human record. */
+    approvalPercentage: z.number().min(0).max(100).optional(),
+    /** Optional link to the vote artifact / issue thread for the human record. */
+    voteUri: z.string().min(1).optional(),
+  })
+  .strict();
+export type RatificationVote = z.infer<typeof RatificationVoteSchema>;
+
+/** The versioned ratification-vote ledger document (#3894). */
+export const RatificationVoteLedgerSchema = z
+  .object({
+    version: z.number().int().positive(),
+    votes: z.array(RatificationVoteSchema),
+  })
+  .strict();
+export type RatificationVoteLedger = z.infer<typeof RatificationVoteLedgerSchema>;
+
 /**
  * Options for {@link IAuditLogger.logTierTransition}. The `actor` defaults to the
  * system actor at the emission site when omitted (a tier change recorded by the

--- a/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
+++ b/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
@@ -15,7 +15,11 @@ import { describe, it, expect } from 'vitest';
 import { AuditLogger, verifyChain, extractTierTransition } from './audit-logger.js';
 import { InMemoryAuditStorage } from './audit-storage.js';
 import type { AuditLogConfig } from './audit-types.js';
-import { TIER_TRANSITION_METADATA_KEY } from './audit-types.js';
+import {
+  TIER_TRANSITION_METADATA_KEY,
+  RatificationVoteSchema,
+  RatificationVoteLedgerSchema,
+} from './audit-types.js';
 
 function makeLogger(): { logger: AuditLogger; storage: InMemoryAuditStorage } {
   const storage = new InMemoryAuditStorage();
@@ -151,5 +155,53 @@ describe('extractTierTransition', () => {
     logger.logSystemStartup();
     await logger.close();
     expect(extractTierTransition(storage.getAll()[0]!)).toBeNull();
+  });
+});
+
+describe('RatificationVoteSchema — the #3894 resolution-source schema', () => {
+  const approved = {
+    id: 'cv_2026-06-15_abc',
+    subject: 'auto-remediation',
+    decision: 'approved' as const,
+    strategy: 'higher_order' as const,
+    votedAt: '2026-06-15T00:00:00.000Z',
+  };
+
+  it('accepts a minimal approved higher_order vote', () => {
+    expect(RatificationVoteSchema.safeParse(approved).success).toBe(true);
+  });
+
+  it('accepts optional approvalPercentage + voteUri', () => {
+    const parsed = RatificationVoteSchema.safeParse({
+      ...approved,
+      approvalPercentage: 85,
+      voteUri: 'https://example.test/vote/abc',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an unknown decision and an unknown strategy', () => {
+    expect(RatificationVoteSchema.safeParse({ ...approved, decision: 'maybe' }).success).toBe(
+      false
+    );
+    expect(RatificationVoteSchema.safeParse({ ...approved, strategy: 'coin_flip' }).success).toBe(
+      false
+    );
+  });
+
+  it('is strict — rejects an unknown extra field', () => {
+    expect(RatificationVoteSchema.safeParse({ ...approved, extra: 1 }).success).toBe(false);
+  });
+
+  it('ledger schema accepts an empty votes array (the committed default)', () => {
+    expect(RatificationVoteLedgerSchema.safeParse({ version: 1, votes: [] }).success).toBe(true);
+  });
+
+  it('ledger schema rejects a vote missing required fields', () => {
+    const parsed = RatificationVoteLedgerSchema.safeParse({
+      version: 1,
+      votes: [{ id: 'x' }],
+    });
+    expect(parsed.success).toBe(false);
   });
 });

--- a/scripts/check-authority-tier-drift.test.ts
+++ b/scripts/check-authority-tier-drift.test.ts
@@ -15,10 +15,13 @@ import { stringify as toYaml } from 'yaml';
 import {
   analyzeTierDeclarations,
   analyzeTierTransitionEvents,
+  buildRatificationResolver,
   recoverTransitions,
   checkAuthorityTierDeclarations,
   soakDays,
   ENFORCE_FLOOR,
+  type RatificationResolver,
+  type RatificationVote,
 } from './check-authority-tier-drift.js';
 import type { AuthorityTier } from '../packages/nexus-agents/src/orchestration/strategy-manifest.js';
 import type { TierTransitionPayload } from '../packages/nexus-agents/src/audit/audit-types.js';
@@ -139,38 +142,146 @@ function transition(
   };
 }
 
-describe('analyzeTierTransitionEvents — ratification gate (#3842)', () => {
+/** An approved higher_order ratification vote for `auto-remediation`. */
+function approvedVote(id: string): RatificationVote {
+  return {
+    id,
+    subject: 'auto-remediation',
+    decision: 'approved',
+    strategy: 'higher_order',
+    votedAt: '2026-06-15T00:00:00.000Z',
+  };
+}
+
+/** A resolver backed by the given recorded votes (keyed by id). */
+function resolverOf(...votes: RatificationVote[]): RatificationResolver {
+  const byId = new Map(votes.map((v) => [v.id, v]));
+  return (ref) => byId.get(ref);
+}
+
+/** A resolver that resolves nothing (empty/absent ledger). */
+const emptyResolver: RatificationResolver = () => undefined;
+
+describe('analyzeTierTransitionEvents — ratification gate (#3842, hardened #3894)', () => {
   it('FAILS a promotion event with NO ratificationVoteRef (breakage fixture)', () => {
-    const findings = analyzeTierTransitionEvents([transition('promotion')]);
+    const findings = analyzeTierTransitionEvents([transition('promotion')], emptyResolver);
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-without-ratification');
     expect(findings[0]?.message).toContain('auto-remediation');
   });
 
   it('FAILS a promotion event whose ratificationVoteRef is empty/whitespace', () => {
-    const findings = analyzeTierTransitionEvents([transition('promotion', '   ')]);
+    const findings = analyzeTierTransitionEvents([transition('promotion', '   ')], emptyResolver);
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-without-ratification');
   });
 
-  it('PASSES a promotion event WITH a ratificationVoteRef', () => {
-    const findings = analyzeTierTransitionEvents([transition('promotion', 'cv_3769')]);
+  // #3894: non-emptiness is no longer enough — the ref must RESOLVE.
+  it('FAILS a promotion whose non-empty ref does NOT resolve (bogus ref, #3894)', () => {
+    const findings = analyzeTierTransitionEvents([transition('promotion', 'x')], emptyResolver);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-unresolved');
+    expect(findings[0]?.message).toContain("ratificationVoteRef='x'");
+  });
+
+  it('FAILS a promotion whose ref resolves to a REJECTED vote (#3894)', () => {
+    const rejected: RatificationVote = { ...approvedVote('cv_no'), decision: 'rejected' };
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_no')],
+      resolverOf(rejected)
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
+    expect(findings[0]?.message).toContain("'rejected'");
+  });
+
+  it('FAILS a promotion whose ref resolves to a NON-higher_order vote (#3894)', () => {
+    const wrongStrategy: RatificationVote = {
+      ...approvedVote('cv_maj'),
+      strategy: 'simple_majority',
+    };
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_maj')],
+      resolverOf(wrongStrategy)
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
+    expect(findings[0]?.message).toContain('higher_order');
+  });
+
+  it('FAILS a promotion whose ref resolves to a vote for a DIFFERENT subject (#3894)', () => {
+    const otherSubject: RatificationVote = {
+      ...approvedVote('cv_other'),
+      subject: 'some-other-loop',
+    };
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_other')],
+      resolverOf(otherSubject)
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
+    expect(findings[0]?.message).toContain('does not match');
+  });
+
+  it('PASSES a promotion whose ref RESOLVES to an approved higher_order vote (#3894)', () => {
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_3769')],
+      resolverOf(approvedVote('cv_3769'))
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('resolves a ref with surrounding whitespace (trimmed) (#3894)', () => {
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', '  cv_3769  ')],
+      resolverOf(approvedVote('cv_3769'))
+    );
     expect(findings).toEqual([]);
   });
 
   it('PASSES a demotion event with NO ratificationVoteRef (automatic, ADR-0017)', () => {
-    const findings = analyzeTierTransitionEvents([transition('demotion')]);
+    const findings = analyzeTierTransitionEvents([transition('demotion')], emptyResolver);
     expect(findings).toEqual([]);
   });
 
   it('flags only the offending promotion in a mixed batch', () => {
-    const findings = analyzeTierTransitionEvents([
-      transition('promotion', 'cv_ok'),
-      transition('demotion'),
-      transition('promotion'), // offender
-    ]);
+    const findings = analyzeTierTransitionEvents(
+      [
+        transition('promotion', 'cv_ok'),
+        transition('demotion'),
+        transition('promotion'), // offender — no ref
+      ],
+      resolverOf(approvedVote('cv_ok'))
+    );
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-without-ratification');
+  });
+});
+
+describe('buildRatificationResolver — the committed ledger (#3894)', () => {
+  it('resolves an id present in a valid ledger', () => {
+    const yaml = toYaml({
+      version: 1,
+      votes: [approvedVote('cv_resolved')],
+    });
+    const { resolver, findings } = buildRatificationResolver(yaml);
+    expect(findings).toEqual([]);
+    expect(resolver('cv_resolved')?.decision).toBe('approved');
+    expect(resolver('missing')).toBeUndefined();
+  });
+
+  it('resolves NOTHING (fail-closed) for an absent ledger', () => {
+    const { resolver, findings } = buildRatificationResolver(undefined);
+    expect(findings).toEqual([]);
+    expect(resolver('anything')).toBeUndefined();
+  });
+
+  it('FAILS ratification-ledger-invalid and resolves nothing on a schema-invalid ledger', () => {
+    const yaml = toYaml({ version: 1, votes: [{ id: 'x' /* missing fields */ }] });
+    const { resolver, findings } = buildRatificationResolver(yaml);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('ratification-ledger-invalid');
+    expect(resolver('x')).toBeUndefined();
   });
 });
 
@@ -209,12 +320,12 @@ describe('recoverTransitions — reads the chained transition log (#3842)', () =
     const { transitions, findings } = recoverTransitions(jsonl);
     expect(findings).toEqual([]); // the log itself is valid
     expect(transitions).toHaveLength(1);
-    const gate = analyzeTierTransitionEvents(transitions);
+    const gate = analyzeTierTransitionEvents(transitions, emptyResolver);
     expect(gate).toHaveLength(1);
     expect(gate[0]?.code).toBe('promotion-without-ratification');
   });
 
-  it('recovers a ratified promotion + a demotion and the gate PASSES', async () => {
+  it('recovers a ratified promotion + a demotion and the gate PASSES (#3894 resolved)', async () => {
     const { jsonl } = await jsonlOf((l) => {
       l.logTierTransition({
         kind: 'promotion',
@@ -235,7 +346,31 @@ describe('recoverTransitions — reads the chained transition log (#3842)', () =
     const { transitions, findings } = recoverTransitions(jsonl);
     expect(findings).toEqual([]);
     expect(transitions).toHaveLength(2);
-    expect(analyzeTierTransitionEvents(transitions)).toEqual([]);
+    const resolver = resolverOf({
+      id: 'cv_2077',
+      subject: 'clawguard',
+      decision: 'approved',
+      strategy: 'higher_order',
+      votedAt: '2026-06-15T00:00:00.000Z',
+    });
+    expect(analyzeTierTransitionEvents(transitions, resolver)).toEqual([]);
+  });
+
+  it('recovers a promotion whose ref does NOT resolve and the gate FAILS (#3894)', async () => {
+    const { jsonl } = await jsonlOf((l) => {
+      l.logTierTransition({
+        kind: 'promotion',
+        subject: 'clawguard',
+        fromTier: 'advisory',
+        toTier: 'enforce',
+        evidenceRef: 'evidence#2077',
+        ratificationVoteRef: 'bogus-ref', // non-empty, but resolves to nothing
+      });
+    });
+    const { transitions } = recoverTransitions(jsonl);
+    const gate = analyzeTierTransitionEvents(transitions, emptyResolver);
+    expect(gate).toHaveLength(1);
+    expect(gate[0]?.code).toBe('promotion-ratification-unresolved');
   });
 
   it('FAILS transition-log-invalid on a malformed JSONL line', () => {

--- a/scripts/check-authority-tier-drift.ts
+++ b/scripts/check-authority-tier-drift.ts
@@ -25,10 +25,15 @@
  * sibling to the #3837 manifest drift-gate, and exposed standalone as
  * `pnpm authority-tier:check`.
  *
- * Tier-transition ratification gate (#3842): in addition to the declaration +
- * evidence-floor checks, this gate now also reads the hash-chained
- * tier-transition AUDIT EVENTS (Epic D / ADR-0017 §"Transition Rules") and FAILS
- * a PROMOTION transition event that lacks a linked `ratificationVoteRef`.
+ * Tier-transition ratification gate (#3842, hardened by #3894): in addition to the
+ * declaration + evidence-floor checks, this gate also reads the hash-chained
+ * tier-transition AUDIT EVENTS (Epic D / ADR-0017 §"Transition Rules") and FAILS a
+ * PROMOTION transition event whose `ratificationVoteRef` does not RESOLVE to a
+ * recorded, approved `higher_order` ratification vote. #3842 only checked the ref
+ * was non-empty (cosmetic — a bogus `ratificationVoteRef:'x'` passed); #3894 makes
+ * the link genuine by resolving the ref against a committed ratification ledger
+ * (`governance/ratification-votes.yaml`, see {@link RatificationVoteSchema}) and
+ * failing `promotion-ratification-unresolved` / `promotion-ratification-not-approved`.
  * Promotions must be ratification-linked (ADR-0017); demotions are automatic and
  * need no vote. The transition log lives at
  * `governance/authority-tier-transitions.jsonl` (optional — empty when no
@@ -36,7 +41,7 @@
  * analysis ({@link analyzeTierTransitionEvents}) is unit-tested in isolation.
  *
  * @module scripts/check-authority-tier-drift
- * (Source: ADR-0017, Issue #3839, #3841, #3842)
+ * (Source: ADR-0017, Issue #3839, #3841, #3842, #3894)
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -52,11 +57,14 @@ import { STRATEGY_MANIFEST_REGISTRY } from '../packages/nexus-agents/src/orchest
 import { extractTierTransition } from '../packages/nexus-agents/src/audit/audit-logger.js';
 import {
   AuditEventSchema,
+  RatificationVoteLedgerSchema,
+  type RatificationVote,
   type TierTransitionPayload,
 } from '../packages/nexus-agents/src/audit/audit-types.js';
 
 const EVIDENCE_LEDGER = join(ROOT, 'governance/authority-tier-evidence.yaml');
 const TRANSITION_LOG = join(ROOT, 'governance/authority-tier-transitions.jsonl');
+const RATIFICATION_LEDGER = join(ROOT, 'governance/ratification-votes.yaml');
 
 /**
  * The ADR-0017 advisory→enforce promotion floor. The minimum a gate enforces; a
@@ -79,8 +87,75 @@ export interface TierDriftFinding {
     | 'enforce-evidence-below-floor'
     | 'evidence-ledger-invalid'
     | 'promotion-without-ratification'
+    | 'promotion-ratification-unresolved'
+    | 'promotion-ratification-not-approved'
+    | 'ratification-ledger-invalid'
     | 'transition-log-invalid';
   readonly message: string;
+}
+
+// ============================================================================
+// Ratification-vote ledger (#3894) — the resolution source of truth
+// ============================================================================
+
+/**
+ * A resolver: ref → recorded ratification vote (or undefined when unresolved).
+ *
+ * The committed ratification-vote ledger (`governance/ratification-votes.yaml`,
+ * schema {@link RatificationVoteLedgerSchema} in `src/audit/audit-types.ts`) is the
+ * resolution source. #3894 item 1: the promotion gate previously failed a
+ * `promotion` only when its `ratificationVoteRef` was *empty* — a bogus
+ * `ratificationVoteRef:'x'` passed, so the "ratification-LINKED" guarantee was
+ * only as strong as a non-empty string. Resolving the ref against this ledger
+ * makes the link genuine.
+ *
+ * RESOLUTION SOURCE & RESIDUAL GAP. Live `consensus_vote` results are persisted
+ * only to per-developer home-dir stores (`~/.nexus-agents/voting/correlations.jsonl`,
+ * `~/.nexus-agents/learning/outcomes.jsonl`) that a CI gate — running with no live
+ * server and no developer home dir — cannot read. There is no other committed,
+ * queryable source of truth for "did ratification vote X happen and pass". So the
+ * honest mechanism is this committed ledger: a ratification vote must be recorded
+ * HERE (a higher_order consensus_vote whose decision is `approved`) for a
+ * promotion's ref to resolve. The gate verifies STRUCTURAL PRESENCE of an
+ * approved, higher_order vote in a committed record — it does not (and cannot
+ * from CI) re-execute the vote. Tampering with the ledger is itself a reviewable
+ * governance change.
+ */
+export type RatificationResolver = (ref: string) => RatificationVote | undefined;
+
+/** Re-exported for tests/callers that build resolvers. */
+export type { RatificationVote };
+
+/**
+ * Build a {@link RatificationResolver} from the ledger YAML text (or undefined
+ * when the file is absent). Returns the resolver plus a single
+ * `ratification-ledger-invalid` finding when the ledger fails schema validation —
+ * in which case the resolver resolves NOTHING (fail-closed: every promotion ref
+ * is then unresolved and FAILS, rather than silently passing).
+ */
+export function buildRatificationResolver(ledgerYaml: string | undefined): {
+  readonly resolver: RatificationResolver;
+  readonly findings: TierDriftFinding[];
+} {
+  if (ledgerYaml === undefined) {
+    return { resolver: () => undefined, findings: [] };
+  }
+  const parsed = RatificationVoteLedgerSchema.safeParse(parseYaml(ledgerYaml));
+  if (!parsed.success) {
+    return {
+      resolver: () => undefined,
+      findings: [
+        {
+          code: 'ratification-ledger-invalid',
+          message: `governance/ratification-votes.yaml failed schema validation: ${parsed.error.issues
+            .map((i) => i.message)
+            .join('; ')}`,
+        },
+      ],
+    };
+  }
+  const byId = new Map(parsed.data.votes.map((v) => [v.id, v]));
+  return { resolver: (ref) => byId.get(ref), findings: [] };
 }
 
 /**
@@ -165,28 +240,73 @@ export function analyzeTierDeclarations(inputs: DriftInputs): TierDriftFinding[]
 }
 
 /**
- * The ratification gate (#3842). Pure analysis (no disk/process I/O) over the
- * recovered tier-transition payloads so it is unit-testable with fixtures both
- * ways. ADR-0017 §"Promotions are ratification-linked": a `promotion` transition
- * is valid only if it carries a linked `ratificationVoteRef`; a `demotion` is
- * automatic and needs none. This is the machine-enforced invariant the
- * ratification panel's Contrarian required: a tier-transition audit event of kind
- * `promotion` lacking a linked ratification vote FAILS the gate.
+ * The ratification gate (#3842, hardened by #3894). Pure analysis (no disk/process
+ * I/O) over the recovered tier-transition payloads so it is unit-testable with
+ * fixtures both ways. ADR-0017 §"Promotions are ratification-linked": a `promotion`
+ * transition is valid only if it carries a linked ratification vote that genuinely
+ * happened and PASSED; a `demotion` is automatic and needs none.
+ *
+ * #3894 hardens the link from non-emptiness to RESOLVABILITY. A promotion FAILS when:
+ *   - `promotion-without-ratification` — `ratificationVoteRef` is absent/empty
+ *     (the #3842 cosmetic check; kept as the first gate).
+ *   - `promotion-ratification-unresolved` — the ref does NOT resolve to any
+ *     recorded vote in the committed ratification ledger (a bogus
+ *     `ratificationVoteRef:'x'` no longer passes).
+ *   - `promotion-ratification-not-approved` — the ref resolves, but the recorded
+ *     vote's decision is not `approved`, it was not a `higher_order` vote (a
+ *     promotion is governance-of-the-governor), or its `subject` does not match
+ *     the transition subject.
  *
  * @param transitions - tier-transition payloads recovered from the chained audit log
- * @returns one `promotion-without-ratification` finding per offending promotion
+ * @param resolve - resolves a `ratificationVoteRef` to its recorded vote (see
+ *   {@link buildRatificationResolver}); a resolver that resolves nothing makes
+ *   every non-empty ref `promotion-ratification-unresolved` (fail-closed).
+ * @returns one finding per offending promotion
  */
 export function analyzeTierTransitionEvents(
-  transitions: readonly TierTransitionPayload[]
+  transitions: readonly TierTransitionPayload[],
+  resolve: RatificationResolver
 ): TierDriftFinding[] {
   const findings: TierDriftFinding[] = [];
   for (const t of transitions) {
     if (t.kind !== 'promotion') continue; // demotions are automatic — no vote required
     const ref = t.ratificationVoteRef;
+    const where = `'${t.subject}' (${t.fromTier} → ${t.toTier}, evidenceRef='${t.evidenceRef}')`;
+
     if (ref === undefined || ref.trim() === '') {
       findings.push({
         code: 'promotion-without-ratification',
-        message: `tier-transition promotion of '${t.subject}' (${t.fromTier} → ${t.toTier}, evidenceRef='${t.evidenceRef}') has NO linked ratificationVoteRef. Promotions MUST be ratification-linked (ADR-0017 §"Promotions are ratification-linked") — record the consensus_vote ref on the transition audit event.`,
+        message: `tier-transition promotion of ${where} has NO linked ratificationVoteRef. Promotions MUST be ratification-linked (ADR-0017 §"Promotions are ratification-linked") — record the consensus_vote ref on the transition audit event.`,
+      });
+      continue;
+    }
+
+    const vote = resolve(ref.trim());
+    if (vote === undefined) {
+      findings.push({
+        code: 'promotion-ratification-unresolved',
+        message: `tier-transition promotion of ${where} carries ratificationVoteRef='${ref}' that does NOT resolve to any recorded vote in governance/ratification-votes.yaml. A non-empty ref is not enough (#3894) — the vote must be a recorded, approved higher_order consensus_vote.`,
+      });
+      continue;
+    }
+
+    const reasons: string[] = [];
+    if (vote.decision !== 'approved')
+      reasons.push(`decision is '${vote.decision}', not 'approved'`);
+    if (vote.strategy !== 'higher_order') {
+      reasons.push(
+        `strategy is '${vote.strategy}', not 'higher_order' (a promotion is governance-of-the-governor)`
+      );
+    }
+    if (vote.subject !== t.subject) {
+      reasons.push(
+        `vote subject '${vote.subject}' does not match the transition subject '${t.subject}'`
+      );
+    }
+    if (reasons.length > 0) {
+      findings.push({
+        code: 'promotion-ratification-not-approved',
+        message: `tier-transition promotion of ${where} resolves ratificationVoteRef='${ref}' but that vote does not ratify the promotion: ${reasons.join('; ')}.`,
       });
     }
   }
@@ -270,13 +390,22 @@ export function checkAuthorityTierDeclarations(): boolean {
 
   const findings = analyzeTierDeclarations({ declaredTiers, evidenceYaml });
 
-  // #3842 ratification gate: read the hash-chained tier-transition log (if any)
-  // and fail any PROMOTION event lacking a linked ratificationVoteRef.
+  // #3842/#3894 ratification gate: read the hash-chained tier-transition log (if
+  // any) and fail any PROMOTION event whose ratificationVoteRef does not RESOLVE
+  // to an approved higher_order vote in the committed ratification ledger.
   if (existsSync(TRANSITION_LOG)) {
+    const ratificationYaml = existsSync(RATIFICATION_LEDGER)
+      ? readFileSync(RATIFICATION_LEDGER, 'utf-8')
+      : undefined;
+    const { resolver, findings: ledgerFindings } = buildRatificationResolver(ratificationYaml);
     const { transitions, findings: logFindings } = recoverTransitions(
       readFileSync(TRANSITION_LOG, 'utf-8')
     );
-    findings.push(...logFindings, ...analyzeTierTransitionEvents(transitions));
+    findings.push(
+      ...ledgerFindings,
+      ...logFindings,
+      ...analyzeTierTransitionEvents(transitions, resolver)
+    );
   }
 
   if (findings.length === 0) return true;
@@ -285,8 +414,11 @@ export function checkAuthorityTierDeclarations(): boolean {
   for (const f of findings) console.error(`  - [${f.code}] ${f.message}`);
   console.error('  Declare a tier on every manifest in governance/strategy-manifests.yaml,');
   console.error('  back any `enforce` with a floor-meeting record in');
-  console.error('  governance/authority-tier-evidence.yaml, and link a ratification vote on');
-  console.error('  every promotion transition. Re-run: pnpm authority-tier:check');
+  console.error('  governance/authority-tier-evidence.yaml, and link every promotion transition');
+  console.error(
+    '  to an approved higher_order vote recorded in governance/ratification-votes.yaml.'
+  );
+  console.error('  Re-run: pnpm authority-tier:check');
   return false;
 }
 


### PR DESCRIPTION
## What & why (#3894 item 1)

The authority-ladder promotion gate (`analyzeTierTransitionEvents` in `scripts/check-authority-tier-drift.ts`, run under `governance:check`) failed a `kind:'promotion'` tier-transition **only when its `ratificationVoteRef` was empty** — a bogus `ratificationVoteRef:'x'` passed. The "ratification-LINKED" guarantee (#3842) was therefore only as strong as a non-empty string: the cosmetic-linkage gap the #3893 ratification panel's Contrarian flagged.

This hardens the gate so a promotion's `ratificationVoteRef` must **RESOLVE** to a recorded, **approved**, **higher_order** ratification vote whose `subject` matches the transition.

## Resolution source (and why)

I investigated where `consensus_vote` results are persisted. They are written only to **per-developer home-dir stores** — `~/.nexus-agents/voting/correlations.jsonl` (correlation tracker) and `~/.nexus-agents/learning/outcomes.jsonl` (outcome store). A CI gate runs with **no live server and no developer home dir**, so it cannot read those. There is **no other committed, queryable source of truth** for "did ratification vote X happen and pass".

So the honest mechanism is a **new committed ledger**: `governance/ratification-votes.yaml` (schema `RatificationVoteLedgerSchema` in `packages/nexus-agents/src/audit/audit-types.ts`). A promotion's ref must resolve to a record there. The ledger is **empty today** (no promotions have occurred; the transition log is empty), so the gate still passes.

**Residual gap (stated honestly):** the gate verifies **structural presence** of an approved, higher_order vote in a committed (hence reviewable) record. It does **not**, and **cannot from CI**, re-execute the vote. Recording a vote in the ledger is itself a reviewable governance change. A future follow-up could persist live `consensus_vote` results to a committed artifact at vote time to close the loop end-to-end.

## What FAILS now that didn't before

A `promotion` transition now fails when its (non-empty) ref:
- `promotion-ratification-unresolved` — does not resolve to any recorded vote (a bogus `ratificationVoteRef:'x'` no longer passes);
- `promotion-ratification-not-approved` — resolves but the vote's `decision` is not `approved`, its `strategy` is not `higher_order`, or its `subject` does not match the transition;
- `ratification-ledger-invalid` — the ledger itself fails schema validation (fail-closed: the resolver then resolves nothing, so every promotion fails).

The original `promotion-without-ratification` (absent/empty ref) is kept as the first check. Demotions still need no vote.

## RED / GREEN

5 new tests assert the resolvability failure modes. Reverting `analyzeTierTransitionEvents` to the old emptiness-only logic (resolver ignored):

```
× FAILS a promotion whose non-empty ref does NOT resolve (bogus ref, #3894)
× FAILS a promotion whose ref resolves to a REJECTED vote (#3894)
× FAILS a promotion whose ref resolves to a NON-higher_order vote (#3894)
× FAILS a promotion whose ref resolves to a vote for a DIFFERENT subject (#3894)
× recovers a promotion whose ref does NOT resolve and the gate FAILS (#3894)
Tests  5 failed | 23 passed (28)
```

With the hardened gate: **28/28 gate tests pass**, plus **11/11** new audit-schema tests in `tier-transition-audit.test.ts`.

## Payload discriminated union (#3894 item 2) — intentionally skipped

The emitter (`logTierTransition`) **deliberately still chains a promotion that lacks a vote ref** so tampering cannot erase the event, locating the invariant in the gate (documented in `audit-logger.ts`). A write-time required field (discriminated union) would conflict with that design and break the existing "recovers a promotion-without-vote from real emitted events" test — so it is **not** clean/low-risk. Left as documented.

## CI

- `pnpm install --frozen-lockfile` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (26374 passed, 16 skipped)
- `pnpm build` ✓
- `pnpm lint` ✓ (+ direct eslint on the changed root scripts ✓)
- `pnpm claims:check` ✓ (8/8)
- `pnpm governance:check` ✓ (incl. authority-tier gate)
- Changeset: ✓ (`patch`)

## Scope

Confined to `scripts/check-authority-tier-drift.ts` (+ test), `src/audit/audit-types.ts` (+ `tier-transition-audit.test.ts`), and a new `governance/ratification-votes.yaml`. No docs-generation scripts, `docs-check.yml`, manifest registry/schema, or `meta-orchestrator*` touched.

**Leave OPEN — do not merge** (governance-of-the-governor; requires a higher_order ratification vote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)