### PR TITLE
feat(governance): tool-fitness ledger data layer (#3851)

### DIFF
--- a/.changeset/tool-fitness-ledger-3851.md
+++ b/.changeset/tool-fitness-ledger-3851.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): tool-fitness ledger data layer (#3851)
+
+Adds the per-tool fitness ledger data layer that epic #3850 (suggest-tier
+pruning pipeline — never autonomous removal) builds on. New module
+`src/governance/tool-fitness-ledger.ts` records and aggregates per-tool fitness
+signals: `invocationCount`, `lastUsedAt`, success/failure correlation
+(`successCount`/`failureCount`/`successRate`), and a `cost` placeholder (full
+cost accounting lands with Epic G; `undefined` distinguishes unmeasured from
+zero).
+
+Persistence MIRRORS the established durable-telemetry idiom rather than forking
+a parallel one: storage is the shared `JsonlStore` primitive
+(`config/jsonl-store`, #3762) — the same hydrate-on-construct /
+append-on-write / Zod-validate-each-line mechanism behind `PersistentOutcomeStore`
+and the `ci-health` event log — bounded by oldest-eviction rotation (#3089
+size-cap concern). The path resolves via `nexusDataPath('tool-fitness',
+'ledger.jsonl')`; `tool-fitness` is cross-repo (homedir-scoped) because tool
+fitness accumulates across the operator's whole workflow.
+
+API: `ToolFitnessLedger.record()` / `statFor()` / `report()` / `size()`, the
+`ToolFitnessEventSchema` Zod schema + inferred type, and a lazy
+`getToolFitnessLedger()` singleton.
+
+DATA LAYER ONLY. The `tool-fitness` SignalCategory wiring into
+`improvement_review` is deferred to #3852 (its first consumer), so this producer
+carries the sanctioned `@export-no-consumer-yet — see #3852` marker for the
+producer/consumer gate (#3024). No pruning/removal pipeline is included —
+removal is never autonomous and requires the Epic D human-ratification path.

--- a/packages/nexus-agents/src/governance/tool-fitness-ledger.test.ts
+++ b/packages/nexus-agents/src/governance/tool-fitness-ledger.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the tool-fitness ledger data layer (#3851).
+ *
+ * Covers record → aggregate → query, round-trip persistence, bounded
+ * retention, and the edge cases called out in the issue (unknown tool,
+ * empty ledger).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  ToolFitnessLedger,
+  ToolFitnessEventSchema,
+  getToolFitnessLedger,
+  _resetToolFitnessLedgerForTests,
+  type ToolFitnessEvent,
+} from './tool-fitness-ledger.js';
+
+let tmpDir: string;
+let filePath: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `nexus-tool-fitness-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  filePath = join(tmpDir, 'ledger.jsonl');
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  _resetToolFitnessLedgerForTests();
+});
+
+describe('ToolFitnessEventSchema', () => {
+  it('accepts a well-formed event', () => {
+    const ev: ToolFitnessEvent = {
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'memory_query',
+      success: true,
+      cost: 42,
+    };
+    expect(ToolFitnessEventSchema.safeParse(ev).success).toBe(true);
+  });
+
+  it('rejects an empty tool name', () => {
+    const parsed = ToolFitnessEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: '',
+      success: true,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a negative cost', () => {
+    const parsed = ToolFitnessEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'x',
+      success: true,
+      cost: -1,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('ToolFitnessLedger — record → aggregate → query', () => {
+  it('records invocations and counts them per tool', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'memory_query', success: true });
+    ledger.record({ tool: 'memory_query', success: false });
+    ledger.record({ tool: 'orchestrate', success: true });
+
+    expect(ledger.size()).toBe(3);
+
+    const mq = ledger.statFor('memory_query');
+    expect(mq).toBeDefined();
+    expect(mq?.invocationCount).toBe(2);
+    expect(mq?.successCount).toBe(1);
+    expect(mq?.failureCount).toBe(1);
+    expect(mq?.successRate).toBe(0.5);
+  });
+
+  it('tracks lastUsedAt as the most recent timestamp regardless of insert order', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'run', success: true, ts: '2026-06-10T00:00:00.000Z' });
+    ledger.record({ tool: 'run', success: true, ts: '2026-06-15T00:00:00.000Z' });
+    ledger.record({ tool: 'run', success: true, ts: '2026-06-12T00:00:00.000Z' });
+
+    expect(ledger.statFor('run')?.lastUsedAt).toBe('2026-06-15T00:00:00.000Z');
+  });
+
+  it('sums cost only over events that reported one (undefined = unmeasured)', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    // No cost reported anywhere → totalCost stays undefined (unmeasured).
+    ledger.record({ tool: 'no_cost', success: true });
+    expect(ledger.statFor('no_cost')?.totalCost).toBeUndefined();
+
+    // Mixed: only measured events contribute.
+    ledger.record({ tool: 'has_cost', success: true, cost: 10 });
+    ledger.record({ tool: 'has_cost', success: false });
+    ledger.record({ tool: 'has_cost', success: true, cost: 5 });
+    expect(ledger.statFor('has_cost')?.totalCost).toBe(15);
+  });
+
+  it('report() returns every tool sorted by descending invocation count', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'rare', success: true });
+    ledger.record({ tool: 'busy', success: true });
+    ledger.record({ tool: 'busy', success: true });
+    ledger.record({ tool: 'busy', success: false });
+    ledger.record({ tool: 'mid', success: true });
+    ledger.record({ tool: 'mid', success: true });
+
+    const report = ledger.report();
+    expect(report.map((s) => s.tool)).toEqual(['busy', 'mid', 'rare']);
+    expect(report.map((s) => s.invocationCount)).toEqual([3, 2, 1]);
+  });
+
+  it('report() breaks invocation-count ties by tool name', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'zebra', success: true });
+    ledger.record({ tool: 'alpha', success: true });
+    expect(ledger.report().map((s) => s.tool)).toEqual(['alpha', 'zebra']);
+  });
+});
+
+describe('ToolFitnessLedger — edge cases', () => {
+  it('statFor() returns undefined for an unknown tool', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'known', success: true });
+    expect(ledger.statFor('never_seen')).toBeUndefined();
+  });
+
+  it('statFor() returns undefined on an empty ledger', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    expect(ledger.statFor('anything')).toBeUndefined();
+  });
+
+  it('report() returns an empty array on an empty ledger', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    expect(ledger.report()).toEqual([]);
+    expect(ledger.size()).toBe(0);
+  });
+});
+
+describe('ToolFitnessLedger — persistence', () => {
+  it('round-trips through save → reload', () => {
+    const first = new ToolFitnessLedger({ filePath });
+    first.record({ tool: 'pipeline', success: true, cost: 3 });
+    first.record({ tool: 'pipeline', success: false });
+
+    const reloaded = new ToolFitnessLedger({ filePath });
+    expect(reloaded.size()).toBe(2);
+    const stat = reloaded.statFor('pipeline');
+    expect(stat?.invocationCount).toBe(2);
+    expect(stat?.successCount).toBe(1);
+    expect(stat?.totalCost).toBe(3);
+  });
+
+  it('writes one JSONL line per recorded event', () => {
+    const ledger = new ToolFitnessLedger({ filePath });
+    ledger.record({ tool: 'a', success: true });
+    ledger.record({ tool: 'b', success: false });
+
+    const lines = readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2);
+    const parsed = JSON.parse(lines[0]!) as ToolFitnessEvent;
+    expect(parsed.v).toBe(1);
+    expect(parsed.tool).toBe('a');
+  });
+
+  it('skips corrupt lines on hydrate without throwing', () => {
+    const good: ToolFitnessEvent = {
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'survivor',
+      success: true,
+    };
+    writeFileSync(filePath, `${JSON.stringify(good)}\nnot-json\n{"v":1}\n`);
+
+    const ledger = new ToolFitnessLedger({ filePath });
+    expect(ledger.size()).toBe(1);
+    expect(ledger.statFor('survivor')?.invocationCount).toBe(1);
+  });
+
+  it('bounds retention to maxEvents (oldest evicted)', () => {
+    const ledger = new ToolFitnessLedger({ filePath, maxEvents: 3 });
+    for (let i = 0; i < 5; i++) ledger.record({ tool: `t${String(i)}`, success: true });
+
+    expect(ledger.size()).toBe(3);
+    // Oldest two (t0, t1) evicted; newest three retained.
+    expect(ledger.statFor('t0')).toBeUndefined();
+    expect(ledger.statFor('t1')).toBeUndefined();
+    expect(ledger.statFor('t4')).toBeDefined();
+
+    const onDisk = readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(onDisk).toHaveLength(3);
+  });
+});
+
+describe('getToolFitnessLedger — singleton', () => {
+  beforeEach(() => {
+    // Route the default-path ledger into the isolated temp dir so the
+    // singleton never touches the operator's real ~/.nexus-agents.
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env['NEXUS_DATA_DIR'];
+  });
+
+  it('returns the same instance until reset', () => {
+    const a = getToolFitnessLedger();
+    const b = getToolFitnessLedger();
+    expect(a).toBe(b);
+    _resetToolFitnessLedgerForTests();
+    const c = getToolFitnessLedger();
+    expect(c).not.toBe(a);
+  });
+});

--- a/packages/nexus-agents/src/governance/tool-fitness-ledger.ts
+++ b/packages/nexus-agents/src/governance/tool-fitness-ledger.ts
@@ -1,0 +1,253 @@
+/**
+ * Tool-fitness ledger — data layer (#3851, child of epic #3850).
+ *
+ * Records per-tool fitness signals so a later consumer can reason about which
+ * of the ~47 MCP tools are pulling their weight. Each MCP invocation (seen by
+ * the tool-wrapper / secure-handler middleware) can be appended as one fitness
+ * event; the ledger aggregates events into a per-tool stat — invocation count,
+ * last-used timestamp, success/failure correlation, and a cost placeholder
+ * (full cost lands with Epic G).
+ *
+ * ## Persistence idiom
+ *
+ * This MIRRORS the established durable-telemetry idiom rather than inventing a
+ * parallel one:
+ *
+ * - Storage is the shared {@link JsonlStore} primitive (`config/jsonl-store`,
+ *   #3762) — the same hydrate-on-construct / append-on-write / Zod-validate-
+ *   each-line mechanism that backs {@link PersistentOutcomeStore} and the
+ *   `ci-health` event log. Bounded by oldest-eviction rotation so the file can
+ *   never grow without limit (the #3089 size-cap concern).
+ * - The path resolves via {@link nexusDataPath} at `tool-fitness/ledger.jsonl`.
+ *   `tool-fitness` is NOT in `PER_REPO_SUBDIRS`, so it routes cross-repo
+ *   (homedir-scoped) — tool fitness accumulates across the operator's whole
+ *   workflow, like the learning/usage state, not per-codebase like `runs`.
+ * - Append is best-effort: a telemetry sink must never throw into the operation
+ *   it observes (inherited from the JsonlStore contract).
+ *
+ * ## Scope
+ *
+ * DATA LAYER ONLY. This module does NOT wire into `improvement_review` and does
+ * NOT add a `tool-fitness` SignalCategory — that consumer is #3852. It does NOT
+ * implement any pruning/removal pipeline — that is later in epic #3850 and is
+ * NEVER autonomous (human ratification via the Epic D path). Because the
+ * consumer (#3852) is not built yet this producer has no in-src consumer; the
+ * sanctioned marker below opts it out of the producer/consumer gate (#3024).
+ *
+ * @module governance/tool-fitness-ledger
+ */
+
+// @export-no-consumer-yet — see #3852
+
+import { z } from 'zod';
+
+import { JsonlStore } from '../config/jsonl-store.js';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+/**
+ * One recorded fitness event for a single tool invocation. Versioned (`v`) for
+ * forward-compatible on-disk evolution, matching the `ci-health` event idiom.
+ */
+export const ToolFitnessEventSchema = z.object({
+  /** Schema version. Forward-compat for on-disk evolution. */
+  v: z.literal(1),
+  /** ISO-8601 timestamp of the invocation. */
+  ts: z.iso.datetime(),
+  /** Tool identifier (e.g. the MCP tool name). */
+  tool: z.string().min(1).max(100),
+  /** Whether the invocation succeeded. Drives the success/failure correlation. */
+  success: z.boolean(),
+  /**
+   * Cost of the invocation in arbitrary units (e.g. tokens), when the calling
+   * surface exposes it. Placeholder until full cost accounting lands with
+   * Epic G — absent (not zero) when unknown so aggregates don't conflate
+   * "free" with "unmeasured".
+   */
+  cost: z.number().nonnegative().optional(),
+});
+export type ToolFitnessEvent = z.infer<typeof ToolFitnessEventSchema>;
+
+/** Aggregated fitness stats for a single tool. */
+export interface ToolFitnessStat {
+  /** Tool identifier. */
+  readonly tool: string;
+  /** Total recorded invocations. */
+  readonly invocationCount: number;
+  /** Count where `success === true`. */
+  readonly successCount: number;
+  /** Count where `success === false`. */
+  readonly failureCount: number;
+  /**
+   * `successCount / invocationCount`. `0` when `invocationCount === 0`
+   * (which cannot occur for a returned stat, but keeps the type total).
+   */
+  readonly successRate: number;
+  /** ISO-8601 timestamp of the most recent invocation. */
+  readonly lastUsedAt: string;
+  /**
+   * Sum of `cost` across events that carried one. `undefined` when NO event
+   * for this tool reported a cost — distinguishes "unmeasured" from "zero".
+   */
+  readonly totalCost: number | undefined;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Default retained-event cap. Bounds disk + hydrate cost of an unbounded
+ * append loop (the #3089 concern). Tunable per-instance via
+ * {@link ToolFitnessLedgerConfig.maxEvents} for tests.
+ */
+const DEFAULT_MAX_EVENTS = 50_000;
+
+/** Subdir + file name under the nexus data dir (cross-repo / homedir-scoped). */
+const LEDGER_SUBDIR = 'tool-fitness';
+const LEDGER_FILE = 'ledger.jsonl';
+
+export interface ToolFitnessLedgerConfig {
+  /**
+   * Absolute path to the JSONL file. Defaults to
+   * `<nexusDataDir>/tool-fitness/ledger.jsonl`. Pass an explicit path in tests
+   * to isolate from the real data dir.
+   */
+  readonly filePath?: string;
+  /** Max retained events before oldest-eviction. Defaults to {@link DEFAULT_MAX_EVENTS}. */
+  readonly maxEvents?: number;
+}
+
+// ============================================================================
+// Ledger
+// ============================================================================
+
+/**
+ * Per-tool fitness ledger. A thin record/aggregate/query API over the shared
+ * {@link JsonlStore} primitive — it owns the tool-fitness SCHEMA and the
+ * aggregation, and delegates all persistence plumbing to JsonlStore.
+ */
+export class ToolFitnessLedger {
+  private readonly store: JsonlStore<ToolFitnessEvent>;
+
+  constructor(config?: ToolFitnessLedgerConfig) {
+    this.store = new JsonlStore<ToolFitnessEvent>({
+      filePath: config?.filePath ?? nexusDataPath(LEDGER_SUBDIR, LEDGER_FILE),
+      schema: ToolFitnessEventSchema,
+      maxRecords: config?.maxEvents ?? DEFAULT_MAX_EVENTS,
+      component: 'ToolFitnessLedger',
+    });
+  }
+
+  /**
+   * Record one tool invocation. `v`/`ts` are stamped here so callers pass only
+   * the observed signal. Best-effort durability (inherited from JsonlStore):
+   * never throws into the observed operation.
+   */
+  record(event: {
+    tool: string;
+    success: boolean;
+    cost?: number;
+    /** Override the timestamp (defaults to now). Mainly for tests/backfill. */
+    ts?: string;
+  }): void {
+    const record: ToolFitnessEvent = {
+      v: 1,
+      ts: event.ts ?? new Date().toISOString(),
+      tool: event.tool,
+      success: event.success,
+      ...(event.cost !== undefined ? { cost: event.cost } : {}),
+    };
+    this.store.append(record);
+  }
+
+  /** Total retained events across all tools. */
+  size(): number {
+    return this.store.count();
+  }
+
+  /**
+   * Aggregate stats for a single tool, or `undefined` when the tool has no
+   * recorded events (unknown tool / empty ledger). Pure over the current
+   * event set — no I/O.
+   */
+  statFor(tool: string): ToolFitnessStat | undefined {
+    const events = this.store.all().filter((e) => e.tool === tool);
+    if (events.length === 0) return undefined;
+    return aggregate(tool, events);
+  }
+
+  /**
+   * Aggregate stats for every tool with at least one event, sorted by
+   * descending invocation count (most-used first) then tool name for a stable
+   * order. Returns `[]` for an empty ledger.
+   */
+  report(): readonly ToolFitnessStat[] {
+    const byTool = new Map<string, ToolFitnessEvent[]>();
+    for (const event of this.store.all()) {
+      const bucket = byTool.get(event.tool);
+      if (bucket === undefined) byTool.set(event.tool, [event]);
+      else bucket.push(event);
+    }
+    const stats: ToolFitnessStat[] = [];
+    for (const [tool, events] of byTool) {
+      stats.push(aggregate(tool, events));
+    }
+    stats.sort((a, b) => b.invocationCount - a.invocationCount || a.tool.localeCompare(b.tool));
+    return stats;
+  }
+}
+
+// ============================================================================
+// Pure aggregation
+// ============================================================================
+
+/**
+ * Fold a non-empty event list for one tool into a {@link ToolFitnessStat}.
+ * Pure (fixture-testable): same input always yields the same output.
+ */
+function aggregate(tool: string, events: readonly ToolFitnessEvent[]): ToolFitnessStat {
+  let successCount = 0;
+  let lastUsedAt = '';
+  let totalCost: number | undefined;
+  for (const event of events) {
+    if (event.success) successCount++;
+    if (lastUsedAt === '' || Date.parse(event.ts) >= Date.parse(lastUsedAt)) lastUsedAt = event.ts;
+    if (event.cost !== undefined) totalCost = (totalCost ?? 0) + event.cost;
+  }
+  const invocationCount = events.length;
+  return {
+    tool,
+    invocationCount,
+    successCount,
+    failureCount: invocationCount - successCount,
+    successRate: successCount / invocationCount,
+    lastUsedAt,
+    totalCost,
+  };
+}
+
+// ============================================================================
+// Singleton
+// ============================================================================
+
+let singleton: ToolFitnessLedger | undefined;
+
+/**
+ * Process-wide ledger backed by the default on-disk path. Lazily constructed
+ * so tests that never touch it don't create a data dir. Tests that DO exercise
+ * persistence should construct their own {@link ToolFitnessLedger} with an
+ * explicit `filePath` to stay isolated.
+ */
+export function getToolFitnessLedger(): ToolFitnessLedger {
+  singleton ??= new ToolFitnessLedger();
+  return singleton;
+}
+
+/** Test helper — drops the process singleton so the next get reconstructs it. */
+export function _resetToolFitnessLedgerForTests(): void {
+  singleton = undefined;
+}


### PR DESCRIPTION
## What

Implements the **tool-fitness ledger data layer** per #3851 — the first child of epic #3850 (tool fitness ledger + suggest-tier pruning pipeline, **never autonomous removal**). DATA LAYER ONLY.

New module `packages/nexus-agents/src/governance/tool-fitness-ledger.ts` records and aggregates per-tool fitness signals.

## Ledger API

- `class ToolFitnessLedger`
  - `record({ tool, success, cost?, ts? })` — append one invocation event (`v`/`ts` stamped; best-effort, never throws into the observed op)
  - `statFor(tool): ToolFitnessStat | undefined` — per-tool aggregate; `undefined` for unknown tool / empty ledger
  - `report(): readonly ToolFitnessStat[]` — all tools, sorted by descending invocation count then name; `[]` when empty
  - `size(): number` — total retained events
- `ToolFitnessEventSchema` (Zod) + inferred `ToolFitnessEvent` type
- `getToolFitnessLedger()` lazy process singleton (+ `_resetToolFitnessLedgerForTests`)

`ToolFitnessStat` exposes: `invocationCount`, `successCount`, `failureCount`, `successRate`, `lastUsedAt`, and `totalCost` (`number | undefined` — `undefined` = unmeasured, distinct from zero; full cost lands with Epic G).

## Persistence idiom mirrored

Storage is the shared **`JsonlStore<T>`** primitive (`config/jsonl-store`, #3762) — the same hydrate-on-construct / append-on-write / Zod-validate-each-line mechanism behind `PersistentOutcomeStore` and the `ci-health` event log — bounded by **oldest-eviction rotation** (the #3089 size-cap concern). The path resolves via `nexusDataPath('tool-fitness', 'ledger.jsonl')`; `tool-fitness` is **cross-repo (homedir-scoped)** because tool fitness accumulates across the operator's whole workflow (not per-codebase). No parallel persistence framework invented.

## Tests (`tool-fitness-ledger.test.ts`, 16 passing)

Schema validation; record → aggregate → query; `lastUsedAt` regardless of insert order; cost summed only over measured events; `report()` ordering + tie-break; edge cases (unknown tool, empty ledger); round-trip persistence; one JSONL line per event; corrupt-line skip on hydrate; bounded retention (oldest evicted, on-disk too); singleton identity/reset.

## Deferred (NOT in this PR)

- **#3852** — the `tool-fitness` SignalCategory wiring into `improvement_review` (this ledger's first consumer). Because that consumer isn't built yet, this producer carries the sanctioned `// @export-no-consumer-yet — see #3852` marker to satisfy the producer/consumer gate (#3024).
- Epic #3850 later — pruning/consolidation pipeline. Removal is **never autonomous**; it requires the Epic D human-ratification path.

## Verification

`pnpm install --frozen-lockfile`, `typecheck`, new tests (16/16) + governance suite (73/73), `build`, `lint`, `claims:check` (8/8), `governance:check`, and the producer/consumer gate (`check-new-unused-exports.ts origin/main`, passes via marker) — all green. Changeset added.

Fixes #3851

🤖 Generated with [Claude Code](https://claude.com/claude-code)