### PR TITLE
docs(eval): pr_review labeling rubric + v5 re-adjudication + curation pipeline (#3846, #3847)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,6 +142,8 @@ Detailed technical documentation:
 | [cli-first-adapter-strategy.md](./research/cli-first-adapter-strategy.md)           | CLI-first adapter research                                                 | Canonical |
 | [pr-review-experiment-results.md](./research/pr-review-experiment-results.md)       | pr_review #2233 baseline experiment results                                | Canonical |
 | [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug    | Canonical |
+| [pr-review-eval-labeling-rubric.md](./research/pr-review-eval-labeling-rubric.md)   | pr_review eval labeling rubric v1 + v5 re-adjudication (#3846)             | Canonical |
+| [pr-review-dataset-curation.md](./research/pr-review-dataset-curation.md)           | pr_review eval dataset curation pipeline + n≥50 assessment (#3847)         | Canonical |
 | [mcp-tool-distinctness-v1.md](./research/mcp-tool-distinctness-v1.md)               | MCP tool-description pairwise similarity report (#2650)                    | Canonical |
 | [fitness-stratified-v1.md](./research/fitness-stratified-v1.md)                     | Stratified runtime-outcome report — per adapter / task-type / role (#2662) | Canonical |
 | [defending-code-harness-eval.md](./research/defending-code-harness-eval.md)         | Eval of Anthropic defending-code-reference-harness (#3574)                 | Canonical |

--- a/docs/research/pr-review-dataset-curation.md
+++ b/docs/research/pr-review-dataset-curation.md
@@ -1,0 +1,124 @@
+---
+title: pr_review eval dataset curation pipeline
+description: How the pr_review eval dataset grows — the curate-pr-review-dataset.ts pipeline, the sourcing procedure for real labeled cases, provenance and rubric-version stamping, and an honest assessment of what reaching n≥50 requires.
+tier: 2
+keywords: [pr-review, eval, dataset, curation, provenance, autonomous-sdlc]
+---
+
+# pr_review eval dataset curation pipeline
+
+**Issue:** #3847 (part of epic #3845). Depends on #3846 (the
+[labeling rubric](./pr-review-eval-labeling-rubric.md)).
+**Pipeline:** `scripts/curate-pr-review-dataset.ts`
+**Dataset:** `testing/datasets/pr-review-sample.json`
+
+## Goal
+
+Grow the eval set from n=10 toward n≥50 (target 100) **without fabricating
+cases**. A fabricated PR/bug corrupts the eval — it teaches us nothing about
+whether the panel catches _real_ bugs. So the pipeline is built to make adding a
+_genuinely-sourced_ case a one-step, provenance-stamped operation, and the doc is
+explicit about what cannot be automated.
+
+## The pipeline (`curate-pr-review-dataset.ts`)
+
+One reproducible entry point. Subcommands:
+
+- `validate` — load the dataset, validate every entry against the rubric schema,
+  and check the dataset `rubricVersion` matches the rubric doc header. This is
+  what the Vitest test and any CI gate call. Exit non-zero on any violation.
+- `stats` — print n and the class balance (buggy / clean / borderline) plus the
+  provenance-source breakdown (historical / synthetic / historical-clean). Use
+  this to track progress toward n≥50 and to document class balance per #3847's
+  acceptance criteria.
+- `add <kind>` — emit a correctly-stamped skeleton entry (`rubricVersion`,
+  pre-filled `adjudication`/`provenance` shape) to stdout for a new case, so
+  "adding case N+1" is a documented one-step that cannot forget the stamp.
+  `<kind>` is `buggy | clean | borderline | synthetic-buggy | synthetic-clean`.
+  The author fills the diff/bug fields and the rationale (`TODO` placeholders);
+  the skeleton guarantees the shape is rubric-valid.
+
+The schema module (`scripts/curate-pr-review-dataset-schema.ts`, exporting
+`parseDataset`) is the single source of truth for the dataset shape — used by
+`validate`, `add`, and the test — so the dataset cannot drift from what the
+rubric documents. It is a hand-rolled validator (not Zod) because `zod` resolves
+from the package, not the repo root where the script runs.
+
+## Sourcing procedure (how a real case is born)
+
+Cases come from three honest sources, in priority order:
+
+1. **Historical PRs with a real post-merge bug fix (gold).** Find a merged PR
+   whose diff contained a defect that was fixed by a _later_ PR/commit. The later
+   fix is the ground-truth label — the bug is real and was confirmed by a human
+   shipping a fix. Procedure:
+   - `gh pr list --state merged --search "fix"` / mine the issue tracker for
+     "fixes #N" where #N's regression was introduced by an earlier merged PR.
+   - Record `number` (the buggy PR), the `location` (file:line in that PR's
+     diff), `severity` (rubric Rule 1), and `provenance.fixReference` (the fixing
+     PR/commit). Adjudicate per rubric Rule 5.
+   - #2235 is the worked example: shipped a wrong env-var name, fixed in #2255.
+2. **Synthetic diff-readable bugs (generalize v5's 5).** Hand-crafted diffs with a
+   single planted, statable defect at a known `file:line` (ReDoS, off-by-one,
+   missing await, null deref, resource leak …). These are honestly labeled
+   `provenance.source: "synthetic"` and never presented as real. They test
+   diff-reading capability, not real-world prevalence. Use `customDiff`.
+3. **Verified-clean PRs (honest proportion).** Merged PRs that shipped with no
+   post-merge fix and no defensible medium+ objection from the diff (rubric Rule
+   3). These are the strict-FP denominator — without enough of them an FP rate is
+   not measurable.
+
+**Class balance is documented, not assumed.** `curate-pr-review-dataset.ts stats`
+prints the buggy/clean/borderline split. The target proportion is roughly
+50% buggy / 35% clean / 15% borderline so both recall (needs buggy) and strict
+precision (needs clean) are measurable.
+
+## Mining #3675 (alibaba/open-code-review)
+
+Issue #3847 calls for mining #3675's open-code-review evaluation for transferable
+cases/method. That eval set is an external corpus: its cases must be
+re-adjudicated under _this_ rubric before import (their severity/location
+conventions differ), and license/provenance must be recorded
+(`provenance.source: "external:open-code-review"`, original-ref retained). This
+is a sourcing input, not an automated import — see the blocker below.
+
+## Honest assessment: reaching n≥50 autonomously
+
+**Current n = 10** (7 buggy, 2 clean, 1 borderline after the #3846
+re-adjudication). The pipeline, schema, and stamping are in place. The remaining
+40 cases to n≥50 **cannot be generated autonomously without corrupting the
+eval**, for concrete reasons:
+
+- **Real historical/clean cases require live GitHub history mining + human
+  judgment.** Identifying a merged PR + its later regression fix, then confirming
+  the defect was in-diff, needs `gh` access to the full repo history and a
+  reviewer to adjudicate severity/reachability (rubric Rule 5). It is exactly the
+  kind of label that, if guessed, poisons the metric.
+- **Synthetic cases could be mass-produced, but they must not dominate.** If we
+  padded to 50 with synthetics we would measure diff-reading on toy code, not the
+  real-world bug-catch claim the epic is about. Honest proportion (source 3 above)
+  caps how many synthetics belong in the set.
+- **The #3675 corpus needs license/provenance review + per-case
+  re-adjudication** before any entry is admissible.
+
+Therefore this iteration delivers the **framework** and adds **no fabricated
+entries**. The genuinely-verifiable case already present (#2235, sourced from a
+real post-merge fix) is retained and re-stamped; the four other synthetics and
+two historical/clean entries are retained as-is.
+
+### What n≥50 needs (the explicit blocker)
+
+A real PR-sourcing effort, which is human/live-data-bound:
+
+1. A pass over `nexus-substrate/nexus-agents` merged-PR history to find ~25
+   buggy PRs with post-merge fixes (gold cases), each adjudicated per rubric.
+2. ~15 verified-clean merged PRs (no post-merge fix, no medium+ objection).
+3. License + provenance review of the #3675 corpus, then per-case
+   re-adjudication of any transferable cases.
+4. Optionally a bounded number of additional synthetics (≤ the honest-proportion
+   cap) for defect types not represented in the historical set.
+
+Each of (1)–(4) is a `curate-pr-review-dataset.ts add` invocation followed by
+filling real, verifiable fields and re-running `validate` + `stats`. None of it
+should be auto-generated. This effort is tracked under #3847; this PR scaffolds
+it and does not close it.

--- a/docs/research/pr-review-eval-labeling-rubric.md
+++ b/docs/research/pr-review-eval-labeling-rubric.md
@@ -1,0 +1,232 @@
+---
+title: pr_review eval labeling rubric (v1)
+description: Objective labeling rules for the pr_review evaluation dataset — severity floor, location tolerance, clean-PR and borderline criteria, adjudication procedure, and rubric versioning. Makes "did pr_review catch the bug" measurable instead of a judgment call.
+tier: 2
+keywords: [pr-review, eval, rubric, labeling, methodology, autonomous-sdlc]
+---
+
+# pr_review eval labeling rubric (v1)
+
+**Rubric version:** `1.0.0`
+**Effective:** 2026-06-16 (ET)
+**Applies to:** `testing/datasets/pr-review-sample.json` and any dataset curated by
+`scripts/curate-pr-review-dataset.ts`.
+**Issue:** #3846 (part of epic #3845). Supersedes the ad-hoc labeling described in
+[pr-review-experiment-results-v5.md](./pr-review-experiment-results-v5.md).
+
+## Why this exists
+
+v5's headline 50% false-positive rate dissolved under triage: it was mostly the
+dataset being wrong (#2235 was labeled `clean` but shipped a real bug the panel
+caught) plus borderline judgment calls scored as failures. The labeling
+methodology — not the panel — was the bottleneck. This rubric makes each label
+objective so that v6 precision/recall is measurable, not arguable.
+
+## Definitions
+
+A **case** is one dataset entry (`prs[]`): a PR diff (real `number` fetched from
+GitHub, or `customDiff` for synthetic cases) plus its `knownBugs` array and a
+`class`. The class is derived from the rubric, not asserted by the author.
+
+**Severity** of a known bug is one of (highest to lowest):
+
+| Severity   | Meaning                                                                          |
+| ---------- | -------------------------------------------------------------------------------- |
+| `critical` | Security vuln, data loss, or guaranteed crash/incorrect result on the happy path |
+| `high`     | Crash/incorrect result on a reachable non-happy path; CI-detectable type error   |
+| `medium`   | Wrong behavior on an edge case; resource leak; correctness foot-gun              |
+| `low`      | Style, naming, micro-perf, or a concern that needs author judgment to confirm    |
+
+## Rule 1 — severity floor (what counts as a bug)
+
+A case is **buggy** if and only if it contains at least one known bug at severity
+`medium` or higher. The severity floor is **`medium`**.
+
+- `low`-only findings do NOT make a case buggy. They are recorded (so we can still
+  score whether the panel raised them) but the case's `class` stays `clean` or
+  `borderline` per Rules 3–4.
+- This floor is what "did pr_review catch THE bug" is measured against: a catch
+  counts only when the panel's verified finding maps to a `>= medium` known bug
+  within location tolerance (Rule 2).
+
+## Rule 2 — location tolerance
+
+A panel finding **matches** a known bug when both:
+
+1. it cites the same file as the known bug's `location`, AND
+2. the cited line is within **±5 lines** of the known bug's line (the v5 window).
+
+Notes:
+
+- For bugs that are not line-local (e.g. #2228 — a missing entry in a `Record`
+  union relationship), set `locationTolerance: "structural"` on the bug. A
+  structural bug matches when the finding names the same symbol/relationship
+  (the missing key, the union member), regardless of line. This prevents a real
+  catch from being scored as a miss just because the defect has no single line.
+- The `location` string must be `path:line` (line required) for line-local bugs,
+  or `path` (no line) for `structural` bugs.
+
+## Rule 3 — clean-PR criteria
+
+A case is **clean** if ALL of:
+
+- it has zero known bugs at or above the severity floor, AND
+- a careful reviewer reading only the diff would have **no defensible
+  `medium`+ correctness/security objection** (low-severity nits may exist but do
+  not disqualify clean), AND
+- (for real PRs) it shipped without a post-merge fix that targets the diff.
+
+A clean case's expected panel outcome is `approve`. A verified `medium`+ finding
+on a clean case is a **strict false positive**.
+
+## Rule 4 — the borderline class (explicit)
+
+A case is **borderline** when a careful reviewer could _defensibly_ raise a
+`medium`+ concern from the diff, but it depends on context not present in the
+diff (no callers visible, locale/runtime assumptions, intentional-but-unusual
+code). v5's `synthetic-clean-refactor` is the archetype: catfish flagged "unused
+helper — no callers in diff" and devex flagged "`toLocaleDateString` is
+locale-dependent in principle." Neither is a hallucination; neither is a
+confirmed bug.
+
+Borderline cases:
+
+- carry `class: "borderline"` and `knownBugs: []` (the concern is recorded in
+  `borderlineConcerns[]`, not as a confirmed bug),
+- are **excluded from both the bug-catch numerator and the strict-FP
+  numerator**. A finding on a borderline case is scored as `borderline`, neither
+  a catch nor a false positive.
+
+This is the key v5 correction: borderline findings were counted as false
+positives, inflating the FP rate. They now have their own bucket so v6 FP is
+"strict FP on clean cases only."
+
+## Rule 5 — adjudication procedure for ambiguous cases
+
+When a case's class is contested (e.g. is this `medium` or `low`? clean or
+borderline?):
+
+1. **Default to the lower-severity / more-conservative class.** A bug is only
+   `medium`+ if its failing condition is concretely reachable and statable as a
+   failing test or exploit. If you cannot write the failing assertion, it is
+   `low` (Rule 1) or `borderline` (Rule 4).
+2. **Require a written rationale** in the entry's `adjudication.rationale`. State
+   the reachable failure (or why none exists).
+3. **Real bugs caught post-hoc are gold.** If a finding led to a real follow-up
+   fix (PR/commit), the case is buggy and the `fixReference` is the evidence —
+   this is what reclassified #2235.
+4. **Reclassify, don't excuse.** If the panel was right and the dataset was
+   wrong, fix the label (do not log it as a false positive). If the panel was
+   wrong, the label stays and it is a real FP.
+5. Stamp the entry: `rubricVersion`, `class`, `adjudication.adjudicatedAt`,
+   `adjudication.adjudicatedUnder` (this rubric version), and `provenance`.
+
+## Per-entry stamp (schema)
+
+Every entry carries:
+
+```jsonc
+{
+  "number": 2235,
+  "rubricVersion": "1.0.0",
+  "class": "buggy", // derived: buggy | clean | borderline
+  "provenance": {
+    "source": "historical", // historical | synthetic | historical-clean
+    "fixReference": "PR #2255", // evidence for buggy cases; null for clean
+    "discoveredBy": "pr_review v5 devex voter",
+  },
+  "knownBugs": [
+    {
+      "summary": "…",
+      "severity": "medium", // critical | high | medium | low
+      "location": "path/to/file.ts:108",
+      "locationTolerance": "line", // line | structural
+      "fixReference": "PR #2255",
+    },
+  ],
+  "borderlineConcerns": [], // only for class: borderline
+  "adjudication": {
+    "adjudicatedAt": "2026-06-16",
+    "adjudicatedUnder": "1.0.0",
+    "rationale": "…reachable failure or why none…",
+  },
+}
+```
+
+Synthetic entries additionally keep `customDiff` / `customDescription`.
+
+## Rubric versioning
+
+- Semver. **Major** = a scoring rule changes (severity floor, tolerance window,
+  class definitions) such that existing labels could flip. **Minor** = additive
+  (new optional field, new severity note) that cannot flip a label. **Patch** =
+  wording/typo.
+- A major bump **requires re-adjudicating the whole dataset** and logging the
+  diff in the results doc, the same way v1 re-adjudicated the v5 cases below.
+- The version lives in two places that must agree (enforced by the dataset
+  validator test): this doc's `Rubric version` header and the dataset's
+  top-level `rubricVersion`. Each entry's `rubricVersion` records the version it
+  was last adjudicated under.
+
+## v5 → v1-rubric re-adjudication (the 10 cases)
+
+Applying Rules 1–5 to the 10 v5 cases. "Changed?" = did the stamp/label move.
+
+| Case                       | v5 class | v1 class   | Severity (floor=medium)       | Changed?                            |
+| -------------------------- | -------- | ---------- | ----------------------------- | ----------------------------------- |
+| `synthetic-redos`          | buggy    | buggy      | critical (ReDoS, CWE-1333)    | severity stamped                    |
+| `synthetic-off-by-one`     | buggy    | buggy      | medium (off-by-one)           | severity stamped; line `:18` exact  |
+| `synthetic-missing-await`  | buggy    | buggy      | high (stale-token auth)       | severity stamped                    |
+| `synthetic-null-deref`     | buggy    | buggy      | high (TypeError on undefined) | severity stamped                    |
+| `synthetic-listener-leak`  | buggy    | buggy      | medium (listener/mem leak)    | severity stamped                    |
+| #2228                      | buggy    | buggy      | high (CI type error)          | `locationTolerance: structural`     |
+| #2235                      | buggy\*  | buggy      | medium (wrong env var in 429) | provenance: caught by v5; confirmed |
+| #2238                      | clean    | clean      | — (49/49 pass)                | provenance stamped                  |
+| `synthetic-clean-refactor` | "clean"  | borderline | — (no confirmed bug)          | **reclassified clean → borderline** |
+| `synthetic-clean-docs`     | clean    | clean      | — (docs-only)                 | provenance stamped                  |
+
+\* #2235 was reclassified clean → buggy during v5 (already done per #3846 history,
+and recorded in the dataset before this rubric). v1 confirms it buggy under
+Rule 5.3 (real follow-up fix #2255 = evidence) and stamps severity `medium`.
+
+### What changed, per case
+
+- **All five synthetic buggy cases + #2228, #2235**: gained an explicit
+  `severity` and the per-entry stamp (`rubricVersion`, `class`, `provenance`,
+  `adjudication`). No label flipped — these were already correctly buggy. #2228
+  gained `locationTolerance: "structural"` so the v5 "miss" (panel found a real
+  issue at a different line) is scored correctly: the defect is a missing
+  `Record` entry with no single line, so it should never have been a location
+  miss in the first place.
+- **#2235**: no class change (already buggy in the committed dataset). The rubric
+  records the provenance — caught by the v5 devex voter, fixed in #2255 — as the
+  Rule 5.3 evidence and stamps it `medium`.
+- **`synthetic-clean-refactor`: reclassified `clean` → `borderline`.** This is the
+  substantive correction. v5 counted its findings as false positives, which is
+  the single biggest driver of the inflated 50% FP headline. Under Rule 4 the
+  findings (unused helper, locale-dependent formatter) are defensible
+  context-dependent concerns, not confirmed bugs and not hallucinations. As
+  `borderline` it is excluded from the strict-FP numerator.
+- **#2238, `synthetic-clean-docs`**: stay `clean`; only gained provenance +
+  adjudication stamps.
+
+### Effect on the scored metrics
+
+Under v1 the v5 run re-scores as:
+
+- **Buggy cases:** 7 (5 synthetic + #2228 + #2235).
+- **Clean cases:** 2 (#2238, `synthetic-clean-docs`).
+- **Borderline cases:** 1 (`synthetic-clean-refactor`).
+- **Strict false-positive denominator:** the 2 clean cases. v5 emitted 0 verified
+  findings on both → **strict-FP rate 0/2 = 0%** (was reported as 50% raw).
+- Bug-catch and location-match are re-derived by v6 against these labels; this
+  rubric only fixes the labels, not the panel run (running v6 is #3849, out of
+  scope here).
+
+## Out of scope (tracked elsewhere)
+
+- Growing the set to n≥50 with provenance: #3847 (curation pipeline —
+  `scripts/curate-pr-review-dataset.ts`, see
+  [pr-review-dataset-curation.md](./pr-review-dataset-curation.md)).
+- Per-voter precision/recall in the outcome store: #3848.
+- v6 run + promotion-criterion ADR: #3849.

--- a/scripts/curate-pr-review-dataset-schema.ts
+++ b/scripts/curate-pr-review-dataset-schema.ts
@@ -1,0 +1,287 @@
+/**
+ * curate-pr-review-dataset-schema.ts — rubric schema + a self-contained
+ * validator for the pr_review eval dataset (#3846 rubric, #3847 pipeline).
+ *
+ * `zod` lives in the nexus-agents package, not at the repo root, so a root-run
+ * tsx/vitest cannot resolve it from scripts/ (the same reason build-model-
+ * registry can't run standalone here). The rubric shape is small and stable, so
+ * a hand-rolled validator keeps the curation pipeline dependency-free.
+ *
+ * @module scripts/curate-pr-review-dataset-schema
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+export const SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+export const CLASSES = ['buggy', 'clean', 'borderline'] as const;
+export const PROVENANCE_SOURCES = ['historical', 'historical-clean', 'synthetic'] as const;
+
+export type Severity = (typeof SEVERITIES)[number];
+export type CaseClass = (typeof CLASSES)[number];
+export type ProvenanceSource = (typeof PROVENANCE_SOURCES)[number];
+
+/** Severities at or above the rubric's `medium` floor (Rule 1). */
+export const SEVERITY_FLOOR: Severity = 'medium';
+const FLOOR_AND_ABOVE: ReadonlySet<Severity> = new Set<Severity>(['critical', 'high', 'medium']);
+
+export interface KnownBug {
+  readonly summary: string;
+  readonly severity: Severity;
+  readonly location: string;
+  readonly locationTolerance: 'line' | 'structural';
+  readonly fixReference: string;
+}
+
+export interface BorderlineConcern {
+  readonly summary: string;
+  readonly raisedBy: string;
+}
+
+export interface Provenance {
+  readonly source: ProvenanceSource;
+  readonly fixReference: string | null;
+  readonly discoveredBy: string | null;
+}
+
+export interface Adjudication {
+  readonly adjudicatedAt: string;
+  readonly adjudicatedUnder: string;
+  readonly rationale: string;
+}
+
+export interface PrReviewCase {
+  readonly number: string | number;
+  readonly rubricVersion: string;
+  readonly class: CaseClass;
+  readonly title: string;
+  readonly customDescription?: string;
+  readonly customDiff?: string;
+  readonly provenance: Provenance;
+  readonly knownBugs: readonly KnownBug[];
+  readonly borderlineConcerns: readonly BorderlineConcern[];
+  readonly adjudication: Adjudication;
+  readonly notes?: string;
+}
+
+export interface PrReviewDataset {
+  readonly rubricVersion: string;
+  readonly curatedAt: string;
+  readonly reAdjudicatedAt?: string;
+  readonly methodology: string;
+  readonly rubricRef?: string;
+  readonly prs: readonly PrReviewCase[];
+}
+
+export type ParseResult<T> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly errors: readonly string[] };
+
+// --- low-level guards -------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+function oneOf<T extends string>(v: unknown, allowed: readonly T[]): v is T {
+  return typeof v === 'string' && (allowed as readonly string[]).includes(v);
+}
+
+const CASE_KEYS = new Set<string>([
+  'number',
+  'rubricVersion',
+  'class',
+  'title',
+  'customDescription',
+  'customDiff',
+  'provenance',
+  'knownBugs',
+  'borderlineConcerns',
+  'adjudication',
+  'notes',
+]);
+
+function requireStr(v: unknown, minLen: number, label: string, errs: string[]): void {
+  if (typeof v !== 'string' || v.length < minLen) {
+    errs.push(`${label} must be a string >=${String(minLen)} chars`);
+  }
+}
+
+function validateLocationTolerance(
+  v: Record<string, unknown>,
+  where: string,
+  errs: string[]
+): void {
+  if (!isNonEmptyString(v.location) || typeof v.locationTolerance !== 'string') return;
+  const hasLine = /:\d+$/.test(v.location);
+  if (v.locationTolerance === 'line' && !hasLine) {
+    errs.push(`Rule 2: ${where} locationTolerance "line" needs a path:line location`);
+  }
+  if (v.locationTolerance === 'structural' && hasLine) {
+    errs.push(`Rule 2: ${where} locationTolerance "structural" needs a path with no line`);
+  }
+}
+
+function validateKnownBug(v: unknown, where: string, errs: string[]): void {
+  if (!isRecord(v)) {
+    errs.push(`${where}: not an object`);
+    return;
+  }
+  requireStr(v.summary, 10, `${where}.summary`, errs);
+  if (!oneOf(v.severity, SEVERITIES)) errs.push(`${where}.severity invalid`);
+  if (!isNonEmptyString(v.location)) errs.push(`${where}.location required`);
+  if (!oneOf(v.locationTolerance, ['line', 'structural'] as const)) {
+    errs.push(`${where}.locationTolerance must be line|structural`);
+  }
+  if (!isNonEmptyString(v.fixReference)) errs.push(`${where}.fixReference required`);
+  validateLocationTolerance(v, where, errs);
+}
+
+function validateConcern(v: unknown, where: string, errs: string[]): void {
+  if (!isRecord(v)) {
+    errs.push(`${where}: not an object`);
+    return;
+  }
+  requireStr(v.summary, 10, `${where}.summary`, errs);
+  if (!isNonEmptyString(v.raisedBy)) errs.push(`${where}.raisedBy required`);
+}
+
+function validateProvenance(v: unknown, at: string, errs: string[]): void {
+  if (!isRecord(v)) {
+    errs.push(`${at}.provenance must be an object`);
+    return;
+  }
+  if (!oneOf(v.source, PROVENANCE_SOURCES)) errs.push(`${at}.provenance.source invalid`);
+  if (!(v.fixReference === null || isNonEmptyString(v.fixReference))) {
+    errs.push(`${at}.provenance.fixReference must be string|null`);
+  }
+  if (!(v.discoveredBy === null || isNonEmptyString(v.discoveredBy))) {
+    errs.push(`${at}.provenance.discoveredBy must be string|null`);
+  }
+}
+
+function validateAdjudication(v: unknown, at: string, errs: string[]): void {
+  if (!isRecord(v)) {
+    errs.push(`${at}.adjudication must be an object`);
+    return;
+  }
+  if (typeof v.adjudicatedAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(v.adjudicatedAt)) {
+    errs.push(`${at}.adjudication.adjudicatedAt must be YYYY-MM-DD`);
+  }
+  if (!isNonEmptyString(v.adjudicatedUnder)) {
+    errs.push(`${at}.adjudication.adjudicatedUnder required`);
+  }
+  requireStr(v.rationale, 20, `${at}.adjudication.rationale`, errs);
+}
+
+function hasFloorBug(bugs: readonly unknown[]): boolean {
+  return bugs.some(
+    (b) => isRecord(b) && oneOf(b.severity, SEVERITIES) && FLOOR_AND_ABOVE.has(b.severity)
+  );
+}
+
+/** Rule 1 — a buggy case needs a medium+ bug; non-buggy cases must not have one. */
+function checkSeverityFloor(
+  cls: CaseClass,
+  bugs: readonly unknown[],
+  at: string,
+  errs: string[]
+): void {
+  const floor = hasFloorBug(bugs);
+  if (cls === 'buggy' && !floor) {
+    errs.push(`Rule 1: ${at} class "buggy" needs >=1 known bug at severity medium+`);
+  }
+  if (cls !== 'buggy' && floor) {
+    errs.push(`Rule 1: ${at} class "${cls}" must have no medium+ known bug`);
+  }
+}
+
+/** Rule 4 — borderline exclusivity. */
+function checkBorderline(
+  cls: CaseClass,
+  bugCount: number,
+  concernCount: number,
+  at: string,
+  errs: string[]
+): void {
+  if (cls === 'borderline' && bugCount > 0) {
+    errs.push(`Rule 4: ${at} a borderline case must have knownBugs: []`);
+  }
+  if (concernCount > 0 && cls !== 'borderline') {
+    errs.push(`Rule 4: ${at} borderlineConcerns are only valid on class "borderline"`);
+  }
+}
+
+function validateRubricRules(v: Record<string, unknown>, at: string, errs: string[]): void {
+  if (!oneOf(v.class, CLASSES)) return;
+  const bugs = Array.isArray(v.knownBugs) ? v.knownBugs : [];
+  const concerns = Array.isArray(v.borderlineConcerns) ? v.borderlineConcerns : [];
+  checkSeverityFloor(v.class, bugs, at, errs);
+  checkBorderline(v.class, bugs.length, concerns.length, at, errs);
+}
+
+function validateScalars(v: Record<string, unknown>, at: string, errs: string[]): void {
+  for (const k of Object.keys(v)) {
+    if (!CASE_KEYS.has(k)) errs.push(`${at}: unknown key "${k}"`);
+  }
+  if (!(isNonEmptyString(v.number) || (typeof v.number === 'number' && v.number > 0))) {
+    errs.push(`${at}.number must be a non-empty string or positive number`);
+  }
+  if (!isNonEmptyString(v.rubricVersion)) errs.push(`${at}.rubricVersion required`);
+  if (!oneOf(v.class, CLASSES)) errs.push(`${at}.class invalid`);
+  if (!isNonEmptyString(v.title)) errs.push(`${at}.title required`);
+}
+
+function validateCase(v: unknown, idx: number, errs: string[]): void {
+  const at = `prs[${String(idx)}]`;
+  if (!isRecord(v)) {
+    errs.push(`${at}: not an object`);
+    return;
+  }
+  validateScalars(v, at, errs);
+  validateProvenance(v.provenance, at, errs);
+  validateAdjudication(v.adjudication, at, errs);
+  if (!Array.isArray(v.knownBugs)) {
+    errs.push(`${at}.knownBugs must be an array`);
+  } else {
+    v.knownBugs.forEach((b, i) => {
+      validateKnownBug(b, `${at}.knownBugs[${String(i)}]`, errs);
+    });
+  }
+  if (!Array.isArray(v.borderlineConcerns)) {
+    errs.push(`${at}.borderlineConcerns must be an array`);
+  } else {
+    v.borderlineConcerns.forEach((c, i) => {
+      validateConcern(c, `${at}.borderlineConcerns[${String(i)}]`, errs);
+    });
+  }
+  validateRubricRules(v, at, errs);
+}
+
+/** Validate a parsed value as a dataset. Returns a typed result, never throws. */
+export function parseDataset(raw: unknown): ParseResult<PrReviewDataset> {
+  const errs: string[] = [];
+  if (!isRecord(raw)) {
+    return { success: false, errors: ['dataset: not an object'] };
+  }
+  if (!isNonEmptyString(raw.rubricVersion)) errs.push('dataset.rubricVersion required');
+  if (!isNonEmptyString(raw.curatedAt)) errs.push('dataset.curatedAt required');
+  if (!isNonEmptyString(raw.methodology)) errs.push('dataset.methodology required');
+  const prs = Array.isArray(raw.prs) ? raw.prs : null;
+  if (prs === null || prs.length === 0) {
+    errs.push('dataset.prs must be a non-empty array');
+  } else {
+    prs.forEach((c, i) => {
+      validateCase(c, i, errs);
+    });
+    if (isNonEmptyString(raw.rubricVersion)) {
+      prs.forEach((c, i) => {
+        if (isRecord(c) && c.rubricVersion !== raw.rubricVersion) {
+          errs.push(`prs[${String(i)}].rubricVersion != dataset.rubricVersion`);
+        }
+      });
+    }
+  }
+  if (errs.length > 0) return { success: false, errors: errs };
+  return { success: true, data: raw as unknown as PrReviewDataset };
+}

--- a/scripts/curate-pr-review-dataset.test.ts
+++ b/scripts/curate-pr-review-dataset.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the pr_review eval-set curation pipeline (#3847) and its rubric
+ * schema (#3846).
+ *
+ * Proves: (a) the committed dataset is rubric-valid and its rubricVersion
+ * matches the rubric doc header; (b) the validator enforces the rubric rules
+ * (severity floor, borderline exclusivity, location tolerance, version
+ * lockstep) by rejecting deliberately-broken fixtures; (c) stats report the
+ * documented class balance; (d) the `add` skeleton is itself rubric-valid.
+ *
+ * @module scripts/curate-pr-review-dataset.test
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseDataset } from './curate-pr-review-dataset-schema.js';
+import {
+  validateDataset,
+  loadDataset,
+  computeStats,
+  rubricDocVersion,
+  skeletonEntry,
+} from './curate-pr-review-dataset.js';
+
+/** Wrap a single case in a minimal valid dataset envelope and parse it. */
+function parseSingle(c: Record<string, unknown>): boolean {
+  return parseDataset({
+    rubricVersion: '1.0.0',
+    curatedAt: 'x',
+    methodology: 'fixture dataset',
+    prs: [c],
+  }).success;
+}
+
+// A minimal valid buggy case used as the mutation base for negative tests.
+function validBuggyCase(): Record<string, unknown> {
+  return {
+    number: 'synthetic-fixture',
+    rubricVersion: '1.0.0',
+    class: 'buggy',
+    title: 'fixture',
+    provenance: { source: 'synthetic', fixReference: 'synthetic', discoveredBy: null },
+    knownBugs: [
+      {
+        summary: 'a statable bug summary',
+        severity: 'medium',
+        location: 'path/to/file.ts:10',
+        locationTolerance: 'line',
+        fixReference: 'synthetic',
+      },
+    ],
+    borderlineConcerns: [],
+    adjudication: {
+      adjudicatedAt: '2026-06-16',
+      adjudicatedUnder: '1.0.0',
+      rationale: 'reachable failure statable as a failing test assertion',
+    },
+  };
+}
+
+describe('committed dataset', () => {
+  it('is rubric-valid and version-locked to the rubric doc', () => {
+    const { versionMatches, dataset, docVersion } = validateDataset();
+    expect(versionMatches).toBe(true);
+    expect(dataset.rubricVersion).toBe(docVersion);
+  });
+
+  it('reflects the documented post-#3846 class balance (7 buggy / 2 clean / 1 borderline, n=10)', () => {
+    const stats = computeStats(loadDataset());
+    expect(stats.n).toBe(10);
+    expect(stats.byClass).toEqual({ buggy: 7, clean: 2, borderline: 1 });
+  });
+
+  it('keeps the rubric doc version at the major it was re-adjudicated under', () => {
+    expect(rubricDocVersion().startsWith('1.')).toBe(true);
+  });
+});
+
+describe('schema — rubric rule enforcement', () => {
+  it('accepts a well-formed buggy case', () => {
+    expect(parseSingle(validBuggyCase())).toBe(true);
+  });
+
+  it('Rule 1: rejects class "clean" carrying a medium+ bug', () => {
+    expect(parseSingle({ ...validBuggyCase(), class: 'clean' })).toBe(false);
+  });
+
+  it('Rule 1: rejects class "buggy" with no medium+ bug', () => {
+    expect(parseSingle({ ...validBuggyCase(), knownBugs: [] })).toBe(false);
+  });
+
+  it('Rule 4: rejects a borderline case carrying confirmed bugs', () => {
+    expect(parseSingle({ ...validBuggyCase(), class: 'borderline' })).toBe(false);
+  });
+
+  it('Rule 4: rejects borderlineConcerns on a non-borderline case', () => {
+    expect(
+      parseSingle({
+        ...validBuggyCase(),
+        borderlineConcerns: [{ summary: 'a concern here', raisedBy: 'x' }],
+      })
+    ).toBe(false);
+  });
+
+  it('Rule 2: rejects a line-tolerance bug without a :line location', () => {
+    const base = validBuggyCase();
+    const bug = {
+      ...(base.knownBugs as Array<Record<string, unknown>>)[0],
+      location: 'path/to/file.ts',
+    };
+    expect(parseSingle({ ...base, knownBugs: [bug] })).toBe(false);
+  });
+
+  it('Rule 2: accepts a structural bug with a path-only location', () => {
+    const base = validBuggyCase();
+    const bug = {
+      ...(base.knownBugs as Array<Record<string, unknown>>)[0],
+      location: 'path/to/file.ts',
+      locationTolerance: 'structural',
+    };
+    expect(parseSingle({ ...base, knownBugs: [bug] })).toBe(true);
+  });
+
+  it('rejects unknown keys (strict shape)', () => {
+    expect(parseSingle({ ...validBuggyCase(), surprise: true })).toBe(false);
+  });
+
+  it('dataset: rejects an entry whose rubricVersion differs from the dataset version', () => {
+    const result = parseDataset({
+      rubricVersion: '1.0.0',
+      curatedAt: 'x',
+      methodology: 'fixture dataset',
+      prs: [{ ...validBuggyCase(), rubricVersion: '2.0.0' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('add skeleton', () => {
+  it.each(['buggy', 'clean', 'borderline', 'synthetic-buggy', 'synthetic-clean'] as const)(
+    'emits a rubric-valid %s skeleton (modulo TODO placeholders)',
+    (kind) => {
+      const skel = skeletonEntry(kind, '1.0.0') as Record<string, unknown>;
+      // The skeleton is structurally valid; only string CONTENT is TODO.
+      expect(parseSingle(skel)).toBe(true);
+    }
+  );
+});

--- a/scripts/curate-pr-review-dataset.ts
+++ b/scripts/curate-pr-review-dataset.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env npx tsx
+/**
+ * curate-pr-review-dataset.ts — the pr_review eval-set curation pipeline (#3847).
+ *
+ * Single, reproducible entry point for growing and validating the pr_review
+ * evaluation dataset (testing/datasets/pr-review-sample.json) under the labeling
+ * rubric (docs/research/pr-review-eval-labeling-rubric.md, #3846).
+ *
+ * Subcommands:
+ *   validate    Validate every entry against the rubric schema + check the
+ *               dataset rubricVersion matches the rubric doc. (Used by the test.)
+ *   stats       Print n + class balance (buggy/clean/borderline) + source split.
+ *   add <kind>  Print a rubric-stamped skeleton entry for a new case so adding
+ *               case N+1 cannot forget the stamp. <kind> = buggy | clean |
+ *               borderline | synthetic-buggy | synthetic-clean.
+ *
+ * The validator (parseDataset) is the single source of truth for the dataset
+ * shape — imported by the test so the dataset cannot drift from the rubric.
+ * Sourcing procedure + the honest n>=50 assessment live in
+ * docs/research/pr-review-dataset-curation.md. This script does NOT fabricate
+ * cases: `add` only emits a skeleton for a human/real-data-sourced case.
+ *
+ * @module scripts/curate-pr-review-dataset
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+/* eslint-disable no-console -- this is a CLI script that prints progress */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  CLASSES,
+  PROVENANCE_SOURCES,
+  parseDataset,
+  type CaseClass,
+  type ProvenanceSource,
+  type PrReviewDataset,
+} from './curate-pr-review-dataset-schema.js';
+
+// ============================================================================
+// Paths
+// ============================================================================
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DATASET_PATH = path.join(REPO_ROOT, 'testing/datasets/pr-review-sample.json');
+const RUBRIC_PATH = path.join(REPO_ROOT, 'docs/research/pr-review-eval-labeling-rubric.md');
+
+// ============================================================================
+// Load + rubric-version cross-check
+// ============================================================================
+
+export function loadDataset(datasetPath: string = DATASET_PATH): PrReviewDataset {
+  const raw = JSON.parse(fs.readFileSync(datasetPath, 'utf-8')) as unknown;
+  const result = parseDataset(raw);
+  if (!result.success) {
+    throw new Error(`Invalid dataset ${datasetPath}:\n  ${result.errors.join('\n  ')}`);
+  }
+  return result.data;
+}
+
+/** Extract the `**Rubric version:** \`x.y.z\`` from the rubric doc header. */
+export function rubricDocVersion(rubricPath: string = RUBRIC_PATH): string {
+  const body = fs.readFileSync(rubricPath, 'utf-8');
+  const m = /\*\*Rubric version:\*\*\s*`([^`]+)`/.exec(body);
+  if (m === null) {
+    throw new Error(`Could not find "**Rubric version:**" in ${rubricPath}`);
+  }
+  return m[1];
+}
+
+export interface ValidationResult {
+  readonly dataset: PrReviewDataset;
+  readonly docVersion: string;
+  readonly versionMatches: boolean;
+}
+
+/** Validate the dataset and cross-check its rubricVersion against the doc. */
+export function validateDataset(
+  datasetPath: string = DATASET_PATH,
+  rubricPath: string = RUBRIC_PATH
+): ValidationResult {
+  const dataset = loadDataset(datasetPath);
+  const docVersion = rubricDocVersion(rubricPath);
+  return {
+    dataset,
+    docVersion,
+    versionMatches: dataset.rubricVersion === docVersion,
+  };
+}
+
+// ============================================================================
+// Stats
+// ============================================================================
+
+export interface DatasetStats {
+  readonly n: number;
+  readonly byClass: Record<(typeof CLASSES)[number], number>;
+  readonly bySource: Record<(typeof PROVENANCE_SOURCES)[number], number>;
+}
+
+export function computeStats(dataset: PrReviewDataset): DatasetStats {
+  const byClass: Record<CaseClass, number> = { buggy: 0, clean: 0, borderline: 0 };
+  const bySource: Record<ProvenanceSource, number> = {
+    historical: 0,
+    'historical-clean': 0,
+    synthetic: 0,
+  };
+  for (const c of dataset.prs) {
+    byClass[c.class] += 1;
+    bySource[c.provenance.source] += 1;
+  }
+  return { n: dataset.prs.length, byClass, bySource };
+}
+
+// ============================================================================
+// add — emit a rubric-stamped skeleton (never a fabricated case)
+// ============================================================================
+
+type AddKind = 'buggy' | 'clean' | 'borderline' | 'synthetic-buggy' | 'synthetic-clean';
+
+function skeletonClass(kind: AddKind): CaseClass {
+  if (kind === 'buggy' || kind === 'synthetic-buggy') return 'buggy';
+  if (kind === 'borderline') return 'borderline';
+  return 'clean';
+}
+
+function skeletonSource(cls: CaseClass, synthetic: boolean): ProvenanceSource {
+  if (synthetic) return 'synthetic';
+  if (cls === 'clean') return 'historical-clean';
+  return 'historical';
+}
+
+export function skeletonEntry(kind: AddKind, rubricVersion: string): unknown {
+  const today = new Date().toISOString().slice(0, 10);
+  const synthetic = kind.startsWith('synthetic');
+  const cls = skeletonClass(kind);
+  const base: Record<string, unknown> = {
+    number: synthetic ? 'synthetic-TODO' : 'TODO-pr-number',
+    rubricVersion,
+    class: cls,
+    title: 'TODO: PR title',
+    provenance: {
+      source: skeletonSource(cls, synthetic),
+      fixReference: cls === 'buggy' ? 'TODO: fixing PR/commit' : null,
+      discoveredBy: cls === 'buggy' ? 'TODO: who/what caught it' : null,
+    },
+    knownBugs:
+      cls === 'buggy'
+        ? [
+            {
+              summary: 'TODO: >=10 chars; statable failing condition',
+              severity: 'medium',
+              location: 'path/to/file.ts:1',
+              locationTolerance: 'line',
+              fixReference: 'TODO: fixing PR/commit',
+            },
+          ]
+        : [],
+    borderlineConcerns:
+      cls === 'borderline'
+        ? [{ summary: 'TODO: defensible context-dependent concern', raisedBy: 'TODO' }]
+        : [],
+    adjudication: {
+      adjudicatedAt: today,
+      adjudicatedUnder: rubricVersion,
+      rationale: 'TODO: reachable failure (buggy) or why none exists (clean/borderline)',
+    },
+  };
+  if (synthetic) {
+    base['customDescription'] = 'TODO';
+    base['customDiff'] = 'TODO: unified diff with the planted defect at a known file:line';
+  }
+  return base;
+}
+
+// ============================================================================
+// CLI
+// ============================================================================
+
+function printStats(): void {
+  const dataset = loadDataset();
+  const s = computeStats(dataset);
+  console.log(`pr_review eval dataset — rubric ${dataset.rubricVersion}`);
+  console.log(`n = ${String(s.n)}`);
+  console.log(
+    `class: buggy=${String(s.byClass.buggy)} clean=${String(s.byClass.clean)} ` +
+      `borderline=${String(s.byClass.borderline)}`
+  );
+  console.log(
+    `source: historical=${String(s.bySource.historical)} ` +
+      `historical-clean=${String(s.bySource['historical-clean'])} ` +
+      `synthetic=${String(s.bySource.synthetic)}`
+  );
+  const target = 50;
+  console.log(
+    s.n >= target
+      ? `✓ n>=${String(target)} target met`
+      : `… ${String(target - s.n)} more cases needed to reach n>=${String(target)} ` +
+          `(see docs/research/pr-review-dataset-curation.md)`
+  );
+}
+
+function runValidate(): void {
+  const { dataset, docVersion, versionMatches } = validateDataset();
+  if (!versionMatches) {
+    console.error(
+      `::error::dataset rubricVersion "${dataset.rubricVersion}" != rubric doc "${docVersion}"`
+    );
+    process.exit(1);
+  }
+  console.log(`✓ dataset valid: n=${String(dataset.prs.length)}, rubric ${dataset.rubricVersion}`);
+}
+
+function runAdd(kind: string | undefined): void {
+  const allowed: readonly AddKind[] = [
+    'buggy',
+    'clean',
+    'borderline',
+    'synthetic-buggy',
+    'synthetic-clean',
+  ];
+  if (kind === undefined || !(allowed as readonly string[]).includes(kind)) {
+    console.error(`usage: add <${allowed.join('|')}>`);
+    process.exit(1);
+  }
+  const dataset = loadDataset();
+  console.log(JSON.stringify(skeletonEntry(kind as AddKind, dataset.rubricVersion), null, 2));
+}
+
+function main(): void {
+  const [cmd, arg] = process.argv.slice(2);
+  switch (cmd) {
+    case 'validate':
+      runValidate();
+      break;
+    case 'stats':
+      printStats();
+      break;
+    case 'add':
+      runAdd(arg);
+      break;
+    default:
+      console.error('usage: curate-pr-review-dataset.ts <validate|stats|add>');
+      process.exit(1);
+  }
+}
+
+// Only run as a CLI when invoked directly (not when imported by the test).
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  main();
+}

--- a/testing/datasets/pr-review-sample.json
+++ b/testing/datasets/pr-review-sample.json
@@ -1,121 +1,277 @@
 {
+  "rubricVersion": "1.0.0",
   "curatedAt": "2026-04-27T00:50:00Z",
-  "methodology": "Hybrid v3 dataset. 10 entries: 5 synthetic test cases with hand-crafted diff-readable bugs (ReDoS, off-by-one, missing await, null deref, resource leak — each at a known file:line) + 3 historical PRs (one with a real bug discovered by the v5 pr_review run itself — see #2235 entry) + 2 synthetic clean counterparts. Synthetic entries use customDiff to skip the GitHub fetch.\n\nThe #2235 entry was originally labeled clean but reclassified after the v5 retest's devex voter caught a real bug (wrong env var name in rate-limit message). Reclassified rather than left as 'false positive' because the finding was correct — the dataset was wrong. Entry now serves as a real-world buggy case alongside the synthetic ones.",
+  "reAdjudicatedAt": "2026-06-16",
+  "methodology": "Hybrid v3 dataset, re-adjudicated under the pr_review eval labeling rubric v1.0.0 (#3846 — docs/research/pr-review-eval-labeling-rubric.md). 10 entries: 5 synthetic test cases with hand-crafted diff-readable bugs (ReDoS, off-by-one, missing await, null deref, resource leak — each at a known file:line) + 3 historical PRs (one with a real bug discovered by the v5 pr_review run itself — see #2235 entry) + 2 synthetic clean counterparts. Synthetic entries use customDiff to skip the GitHub fetch. Every entry now carries the rubric stamp: class (buggy|clean|borderline), severity per bug, provenance, and an adjudication rationale. Re-adjudication changes vs v5: synthetic-clean-refactor reclassified clean -> borderline (its v5 'false-positive' findings are defensible context-dependent concerns, not confirmed bugs — Rule 4); #2228 bug marked locationTolerance:structural (missing Record entry has no single line); all buggy cases gained an explicit severity. No buggy/clean label flipped except the clean -> borderline reclassification. #2235 was already reclassified clean -> buggy before this rubric (during v5, per #3846 history); v1 confirms it buggy under Rule 5.3.",
+  "rubricRef": "docs/research/pr-review-eval-labeling-rubric.md",
   "prs": [
     {
       "number": "synthetic-redos",
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(security): add base64 detection for input sanitizer (synthetic test case)",
       "customDescription": "Adds a regex pattern that flags base64-encoded payloads in untrusted input.",
       "customDiff": "diff --git a/packages/nexus-agents/src/security/input-sanitizer.ts b/packages/nexus-agents/src/security/input-sanitizer.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/security/input-sanitizer.ts\n+++ b/packages/nexus-agents/src/security/input-sanitizer.ts\n@@ -94,6 +94,11 @@ const INJECTION_PATTERNS: readonly PatternMatch[] = [\n     flag: 'fake_conversation',\n     pattern: /<(?:assistant|human|user|system)>/i,\n   },\n+  {\n+    flag: 'base64_encoded',\n+    // Lookahead requires at least one base64-discriminating char to skip pure-hex.\n+    pattern: /(?=[A-Za-z0-9+/]*[g-zG-Z+/=])[A-Za-z0-9+/]{40,}={0,2}/,\n+  },\n ];",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": "synthetic (real fix: #2216 / commit f1742153b)",
+        "discoveredBy": null
+      },
       "knownBugs": [
         {
           "summary": "ReDoS via catastrophic backtracking — overlapping character classes in lookahead + quantifier (CWE-1333)",
+          "severity": "critical",
           "fixReference": "synthetic (real fix: #2216 / commit f1742153b)",
-          "location": "packages/nexus-agents/src/security/input-sanitizer.ts:99"
+          "location": "packages/nexus-agents/src/security/input-sanitizer.ts:99",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Critical: a (?=X*Y)X{n,} structure on overlapping classes is polynomial-backtracking on adversarial input, a DoS on a security-input path. Reachable from untrusted input. Pattern lifted from real #2191/#2216 history."
+      },
       "notes": "Real-world ReDoS pattern lifted from #2191/#2216 history. Security voter with OWASP context should flag the (?=X*Y)X{n,} structure as a polynomial-backtracking risk."
     },
     {
       "number": "synthetic-off-by-one",
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(pagination): clamp page size to maxItems (synthetic test case)",
       "customDescription": "Limits result page size so callers can't request unbounded sets.",
       "customDiff": "diff --git a/packages/nexus-agents/src/api/pagination.ts b/packages/nexus-agents/src/api/pagination.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/api/pagination.ts\n+++ b/packages/nexus-agents/src/api/pagination.ts\n@@ -10,6 +10,12 @@ export interface PaginatedResult<T> {\n   readonly items: readonly T[];\n   readonly nextCursor: string | undefined;\n }\n+\n+/** Clamp requested page size to [1, maxItems]. */\n+export function clampPageSize(requested: number, maxItems: number): number {\n+  if (requested < 1) return 1;\n+  if (requested > maxItems) return maxItems;\n+  return requested - 1;\n+}",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": "synthetic",
+        "discoveredBy": null
+      },
       "knownBugs": [
         {
           "summary": "Off-by-one in clampPageSize — returns requested-1 in the in-range path; should return requested unchanged",
+          "severity": "medium",
           "fixReference": "synthetic",
-          "location": "packages/nexus-agents/src/api/pagination.ts:18"
+          "location": "packages/nexus-agents/src/api/pagination.ts:18",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Medium: wrong result on the in-range path is statable as a failing test — clampPageSize(50, 100) should be 50, returns 49. Off-by-one in a widely-called helper, but not a crash or security issue."
+      },
       "notes": "Architect or devex voter should flag: function name says 'clamp to range' but returns one-less than the input when in range. Test would assert clampPageSize(50, 100) === 50, this returns 49."
     },
     {
       "number": "synthetic-missing-await",
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(session): refresh token on each request (synthetic test case)",
       "customDescription": "Auto-refreshes session token before downstream calls.",
       "customDiff": "diff --git a/packages/nexus-agents/src/auth/session.ts b/packages/nexus-agents/src/auth/session.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/auth/session.ts\n+++ b/packages/nexus-agents/src/auth/session.ts\n@@ -42,5 +42,11 @@ export class Session {\n     this.token = token;\n   }\n \n+  async refreshAndCall<T>(call: () => Promise<T>): Promise<T> {\n+    this.refreshToken();\n+    return call();\n+  }\n+\n+  private async refreshToken(): Promise<void> {\n+    this.token = await fetchFreshToken(this.userId);\n+  }\n }",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": "synthetic",
+        "discoveredBy": null
+      },
       "knownBugs": [
         {
           "summary": "Missing await on refreshToken — async fire-and-forget, the call() runs with stale token",
+          "severity": "high",
           "fixReference": "synthetic",
-          "location": "packages/nexus-agents/src/auth/session.ts:46"
+          "location": "packages/nexus-agents/src/auth/session.ts:46",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "High: an auth-token race that runs downstream calls with a stale token on the happy path. Reachable every call; statable as a failing test asserting the token was refreshed before call() ran."
+      },
       "notes": "Architect or security voter should flag: refreshToken returns Promise<void> but is invoked without await. The call() proceeds before the new token is set; downstream uses the stale token. Failing test: assert that the token was updated when call() runs."
     },
     {
       "number": "synthetic-null-deref",
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(metrics): track average latency from optional response field (synthetic test case)",
       "customDescription": "Updates a rolling average from response.timing.latencyMs.",
       "customDiff": "diff --git a/packages/nexus-agents/src/metrics/latency.ts b/packages/nexus-agents/src/metrics/latency.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/metrics/latency.ts\n+++ b/packages/nexus-agents/src/metrics/latency.ts\n@@ -8,6 +8,11 @@ export interface ApiResponse {\n   readonly status: number;\n   readonly timing?: { readonly latencyMs: number };\n }\n+\n+export function recordLatency(rolling: number[], response: ApiResponse): void {\n+  rolling.push(response.timing.latencyMs);\n+  if (rolling.length > 100) rolling.shift();\n+}",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": "synthetic",
+        "discoveredBy": null
+      },
       "knownBugs": [
         {
           "summary": "Null deref on optional `response.timing` — schema marks timing as optional but code accesses .latencyMs unconditionally",
+          "severity": "high",
           "fixReference": "synthetic",
-          "location": "packages/nexus-agents/src/metrics/latency.ts:13"
+          "location": "packages/nexus-agents/src/metrics/latency.ts:13",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "High: TypeError on a reachable path — the type says timing is optional, so any response without timing throws. Statable as a failing test: recordLatency([], { status: 200 }) throws."
+      },
       "notes": "Architect or devex voter should flag: ApiResponse.timing is optional (`?:`), but recordLatency dereferences without a guard. TypeError when response.timing is undefined. Failing test: recordLatency([], { status: 200 }) throws."
     },
     {
       "number": "synthetic-listener-leak",
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(workers): attach progress listener for streaming jobs (synthetic test case)",
       "customDescription": "Workers emit 'progress' events; subscribe so callers can show a progress bar.",
       "customDiff": "diff --git a/packages/nexus-agents/src/workers/progress.ts b/packages/nexus-agents/src/workers/progress.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/workers/progress.ts\n+++ b/packages/nexus-agents/src/workers/progress.ts\n@@ -3,6 +3,15 @@ import { EventEmitter } from 'node:events';\n export async function runWithProgress<T>(\n   worker: EventEmitter,\n   task: () => Promise<T>,\n   onProgress: (pct: number) => void\n ): Promise<T> {\n+  worker.on('progress', onProgress);\n+  try {\n+    return await task();\n+  } catch (err) {\n+    throw err;\n+  }\n+}",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": "synthetic",
+        "discoveredBy": null
+      },
       "knownBugs": [
         {
           "summary": "Listener leak — worker.on('progress', ...) added but never removed; finally/cleanup missing",
+          "severity": "medium",
           "fixReference": "synthetic",
-          "location": "packages/nexus-agents/src/workers/progress.ts:8"
+          "location": "packages/nexus-agents/src/workers/progress.ts:8",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Medium: resource leak on a long-lived worker — listeners accumulate across calls (no worker.off in finally), eventually MaxListenersExceededWarning then memory pressure. Not an immediate crash; statable as a failing test (11 sequential calls warn)."
+      },
       "notes": "Architect or security voter should flag: long-lived workers (e.g. shared singleton) accumulate listeners across calls; eventually MaxListenersExceededWarning, then memory pressure. Need worker.off('progress', onProgress) in finally. Failing test: 11 sequential runWithProgress calls trigger MaxListeners warning."
     },
     {
       "number": 2228,
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "feat(consensus): add scope_steward role for build-vs-buy gating (#2185)",
+      "provenance": {
+        "source": "historical",
+        "fixReference": "4278f2739",
+        "discoveredBy": "CI Type Check"
+      },
       "knownBugs": [
         {
-          "summary": "Missing scope_steward entry in ROLE_VOTE_DISTRIBUTIONS — Type Check failed on first CI push",
+          "summary": "Missing scope_steward entry in ROLE_VOTE_DISTRIBUTIONS — Type Check failed on first CI push (near voter-execution.ts:134)",
+          "severity": "high",
           "fixReference": "4278f2739",
-          "location": "packages/nexus-agents/src/cli/voter-execution.ts:134"
+          "location": "packages/nexus-agents/src/cli/voter-execution.ts",
+          "locationTolerance": "structural"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "High: a CI-detectable type error (broken build). locationTolerance:structural because the defect is a missing key in a Record-over-union relationship, not a single line — a finding matches when it names the missing scope_steward entry / the union-Record mismatch, regardless of line. This corrects the v5 'location miss', which was an artifact of scoring a structural defect against a single line."
+      },
       "notes": "Historical PR with CI-detectable bug — kept for cross-comparison with synthetic cases. A diff-only reviewer would need to spot the missing entry by reading the union+record relationship; harder than the synthetic cases."
     },
     {
       "number": 2235,
+      "rubricVersion": "1.0.0",
+      "class": "buggy",
       "title": "fix(research): repair github + semantic_scholar discovery (#2234)",
+      "provenance": {
+        "source": "historical",
+        "fixReference": "PR #2255",
+        "discoveredBy": "pr_review v5 devex voter"
+      },
       "knownBugs": [
         {
           "summary": "Wrong env var name in 429 message — uses GITHUB_API_KEY but GitHub uses GITHUB_TOKEN",
+          "severity": "medium",
           "fixReference": "PR #2255 (caught by pr_review v5 — devex voter)",
-          "location": "packages/nexus-agents/src/cli/research-helpers-sources.ts:108"
+          "location": "packages/nexus-agents/src/cli/research-helpers-sources.ts:108",
+          "locationTolerance": "line"
         }
       ],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Medium and confirmed buggy under Rule 5.3: the v5 devex voter flagged a real bug (the 429 hint told GitHub users to set a non-existent GITHUB_API_KEY; the standard var is GITHUB_TOKEN), fixed in #2255 with a regression test — the follow-up fix is the ground-truth evidence. Was reclassified clean -> buggy during v5 (already done per #3846 history); v1 confirms and stamps it. Wrong-guidance bug, not a crash, hence medium."
+      },
       "notes": "Originally labeled clean — re-classified after the v5 retest of pr_review (#2241) flagged a real bug in this PR's diff. The rate-limit message used `${source.toUpperCase()}_API_KEY` for all sources, but GitHub uses GITHUB_TOKEN, not GITHUB_API_KEY. Caught by devex voter, fixed in #2255 with a regression test. This entry now serves as a real-world (not synthetic) buggy case — the kind the tool is designed to catch."
     },
     {
       "number": 2238,
+      "rubricVersion": "1.0.0",
+      "class": "clean",
       "title": "feat(2233 child 3): enforce verification gate in pr_review findings",
+      "provenance": {
+        "source": "historical-clean",
+        "fixReference": null,
+        "discoveredBy": null
+      },
       "knownBugs": [],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Clean per Rule 3: 49/49 tests passed on first push, no post-merge fix targets this diff, no defensible medium+ objection from the diff. Strict-FP denominator member."
+      },
       "notes": "Clean: 49/49 tests pass on first push."
     },
     {
       "number": "synthetic-clean-refactor",
+      "rubricVersion": "1.0.0",
+      "class": "borderline",
       "title": "refactor(util): extract date-formatter helper (synthetic clean case)",
       "customDescription": "Pulls inline date formatting into a named helper. No behavior change.",
       "customDiff": "diff --git a/packages/nexus-agents/src/util/date-format.ts b/packages/nexus-agents/src/util/date-format.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/util/date-format.ts\n+++ b/packages/nexus-agents/src/util/date-format.ts\n@@ -0,0 +1,8 @@\n+/** Formats a Date as ISO date (YYYY-MM-DD) in ET timezone. */\n+export function formatIsoDate(d: Date): string {\n+  return d.toLocaleDateString('en-CA', {\n+    timeZone: 'America/New_York',\n+    year: 'numeric',\n+    month: '2-digit',\n+    day: '2-digit',\n+  });\n+}",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": null,
+        "discoveredBy": null
+      },
       "knownBugs": [],
-      "notes": "Clean refactor: single-purpose helper, named correctly, ET timezone preserved per CLAUDE.md. No bug to find. Tests false-positive risk — voter should NOT flag this."
+      "borderlineConcerns": [
+        {
+          "summary": "Unused helper — no callers visible in the diff (catfish, v5). YAGNI flag; depends on context not in the diff.",
+          "raisedBy": "pr_review v5 catfish voter"
+        },
+        {
+          "summary": "toLocaleDateString('en-CA', ...) is locale-dependent in principle even though it yields YYYY-MM-DD in practice (devex, v5). Defensible concern, not a confirmed bug.",
+          "raisedBy": "pr_review v5 devex voter"
+        }
+      ],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "RECLASSIFIED clean -> borderline under Rule 4. v5 counted the catfish/devex findings as false positives, which drove the inflated 50% FP headline. Neither finding is a hallucination and neither is a confirmed bug: both depend on context not present in the diff (no callers shown; locale behavior works in practice). As borderline it is excluded from both the bug-catch numerator and the strict-FP numerator."
+      },
+      "notes": "Clean refactor: single-purpose helper, named correctly, ET timezone preserved per CLAUDE.md. Reclassified to borderline because the v5 panel raised defensible context-dependent concerns (no callers in diff; locale-dependent formatter) — recorded in borderlineConcerns, not as bugs."
     },
     {
       "number": "synthetic-clean-docs",
+      "rubricVersion": "1.0.0",
+      "class": "clean",
       "title": "docs(api): clarify error codes returned by retry helper (synthetic clean case)",
       "customDescription": "Adds JSDoc enumerating the error codes the retry helper can return.",
       "customDiff": "diff --git a/packages/nexus-agents/src/adapters/retry.ts b/packages/nexus-agents/src/adapters/retry.ts\nindex 0000001..0000002 100644\n--- a/packages/nexus-agents/src/adapters/retry.ts\n+++ b/packages/nexus-agents/src/adapters/retry.ts\n@@ -25,6 +25,11 @@ export interface RetryConfig {\n   readonly maxDelayMs: number;\n   readonly jitterFactor: number;\n }\n+\n+/**\n+ * Error codes that withRetry may surface in the Result<T, E> error path:\n+ * - RETRY_EXHAUSTED — all attempts failed; original error wrapped\n+ * - INVALID_CONFIG — config validation failed before any attempt\n+ */",
+      "provenance": {
+        "source": "synthetic",
+        "fixReference": null,
+        "discoveredBy": null
+      },
       "knownBugs": [],
+      "borderlineConcerns": [],
+      "adjudication": {
+        "adjudicatedAt": "2026-06-16",
+        "adjudicatedUnder": "1.0.0",
+        "rationale": "Clean per Rule 3: docs-only JSDoc above an existing interface, zero code change, no behavioral risk, no defensible medium+ objection. Strict-FP denominator member."
+      },
       "notes": "Clean docs-only change: adds JSDoc above an existing interface. No code change, no behavioral risk. Tests false-positive risk."
     }
   ]


### PR DESCRIPTION
Fixes #3846. References #3847 (epic #3845).

## #3846 — labeling rubric (the methodology fix)

New rubric: `docs/research/pr-review-eval-labeling-rubric.md` (**v1.0.0**). It makes "did pr_review catch the bug" objective instead of vibes:

- **Rule 1 — severity floor:** a case is *buggy* iff it has ≥1 known bug at severity **`medium`+** (`critical/high/medium/low` defined). `low`-only does not make a case buggy.
- **Rule 2 — location tolerance:** a finding matches when it cites the same file and is within **±5 lines** (the v5 window). Non-line-local defects use `locationTolerance: "structural"` (match by symbol/relationship), so a real catch isn't scored as a location miss just because the bug has no single line.
- **Rule 3 — clean-PR criteria:** zero `medium`+ bugs, no defensible `medium`+ objection from the diff, (real PRs) no post-merge fix. A `medium`+ finding on a clean case is a **strict FP**.
- **Rule 4 — explicit borderline class:** defensible-but-context-dependent concerns (no callers in diff, locale assumptions). Borderline cases carry `borderlineConcerns[]`, `knownBugs: []`, and are **excluded from both** the bug-catch and strict-FP numerators. This is the v5 fix — borderline findings were being counted as FPs.
- **Rule 5 — adjudication procedure** (default conservative; written rationale; real post-hoc fixes are gold; reclassify don't excuse) + **semver rubric versioning** (major bump ⇒ re-adjudicate the whole set).

## #3846 — v5 re-adjudication (per-case)

All 10 v5 cases re-adjudicated under v1.0.0 in `testing/datasets/pr-review-sample.json`; each entry stamped with `rubricVersion` / `class` / `provenance` / `adjudication.rationale` + per-bug `severity`.

| Case | v5 → v1 class | severity | change |
| --- | --- | --- | --- |
| synthetic-redos | buggy → buggy | critical | stamped |
| synthetic-off-by-one | buggy → buggy | medium | stamped |
| synthetic-missing-await | buggy → buggy | high | stamped |
| synthetic-null-deref | buggy → buggy | high | stamped |
| synthetic-listener-leak | buggy → buggy | medium | stamped |
| #2228 | buggy → buggy | high | **locationTolerance: structural** (fixes the v5 "location miss" artifact) |
| #2235 | buggy → buggy | medium | provenance: caught by v5 devex, fixed in #2255 (relabel itself was already done in v5) |
| #2238 | clean → clean | — | stamped |
| **synthetic-clean-refactor** | **clean → borderline** | — | **reclassified** — its v5 "false positives" are defensible concerns, not bugs; this was the biggest driver of the inflated 50% FP headline |
| synthetic-clean-docs | clean → clean | — | stamped |

**Effect:** buggy 7 / clean 2 / borderline 1. Strict-FP denominator = the 2 clean cases; v5 emitted 0 verified findings on both → strict-FP 0/2 = 0% (vs the 50% raw headline). Re-running the panel for v6 metrics is #3849 (out of scope).

## #3847 — curation pipeline (assess + scaffold; NO fabricated cases)

- `scripts/curate-pr-review-dataset.ts` + `-schema.ts` (validator): `validate` / `stats` / `add <kind>` subcommands; provenance + rubric-version stamping; adding case N+1 is one documented step. Hand-rolled validator (zod resolves from the package, not the repo root where the script runs).
- `scripts/curate-pr-review-dataset.test.ts`: keeps the dataset green (17/17) — committed dataset valid + version-locked, schema enforces Rules 1/2/4 + version lockstep, skeletons valid.
- `docs/research/pr-review-dataset-curation.md`: sourcing procedure (historical post-merge-fix PRs = gold; synthetics in honest proportion; verified-clean; #3675 corpus needs license review) + the honest n≥50 assessment.

### Honest n≥50 assessment (the blocker)

**Current n = 10** (7 buggy / 2 clean / 1 borderline). The remaining ~40 cases **cannot be generated autonomously without corrupting the eval** — fabricated PRs/bugs are the opposite of the point. Reaching n≥50 needs a real, human/live-data-bound PR-sourcing effort: ~25 historical buggy PRs with post-merge fixes (live `gh` history mining + adjudication), ~15 verified-clean PRs, and license/provenance review + re-adjudication of the #3675 open-code-review corpus. This PR delivers the framework and adds **no fabricated entries**; the only genuinely-verifiable real case (#2235) is retained + re-stamped. Tracked under #3847 — this PR scaffolds it, does not close it.

## CI / verification

`pnpm install --frozen-lockfile` ✓ · `typecheck` ✓ · `test` ✓ (1099 files / 26399 tests; curation test 17/17 via root vitest) · `build` ✓ · `lint` ✓ · `lint:md` ✓ · `format:check` ✓ · `claims:check` ✓ (13/13) · `governance:check` ✓ + inject idempotent · `docs:check-indexed` ✓.

**Changeset:** none — no shippable src (`packages/nexus-agents/src/**`) changed; only scripts/, docs/, testing/datasets/ (verified by `check-changeset`).

**Governance hygiene:** no change to `docs-check.yml` / `inject-governance.ts` → no SKILL.md note needed. New `scripts/*.ts` are exempt from the producer-without-consumer gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)