### PR TITLE
feat(eval): per-voter pr_review precision/recall metrics + persisted report (#3848)

### DIFF
--- a/.changeset/per-voter-precision-recall-3848.md
+++ b/.changeset/per-voter-precision-recall-3848.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+feat(eval): per-voter pr_review precision/recall metrics + persisted report (#3848)
+
+`pr_review` reported panel-level metrics only (v5), so a chronically-noisy voter
+could not be identified or demoted on the Epic D / ADR-0017 authority ladder.
+This adds the data plumbing to record, per labeled eval case, EACH voter role's
+verdict against the rubric ground truth (#3846) and compute per-voter
+precision/recall over time.
+
+- `src/mcp/tools/pr-review-eval-types.ts` — the persisted unit
+  `VoterEvalVerdict` (per-voter per-case true-positive / false-positive /
+  false-negative tallies + rubric class) and the report types.
+- `src/mcp/tools/pr-review-eval-scoring.ts` — two pure, deterministic functions
+  (the `computeResearchMaturityReport` / #3727 pattern): `scoreVoterCase`
+  applies the rubric class rules (buggy → matched bugs are TP, missed bugs are
+  FN; clean → verified findings are strict FP; borderline → excluded from both
+  numerators), and `computePerVoterPrecisionRecall` folds a window of verdicts
+  into per-role + aggregate precision/recall (zero-positive and no-bugs cases
+  report 0, never NaN).
+- `src/mcp/tools/pr-review-eval-store.ts` — JSONL-backed store mirroring the
+  `PersistentOutcomeStore` idiom (hydrate-on-construct, append-per-write, corrupt
+  lines skipped) under the shared learning dir. `reportPrecisionRecall(filter)`
+  is the report surface. Stores only scored tallies — never raw diffs, prompts,
+  or model outputs.
+
+Record + measure ONLY: no live routing/weighting change. Populating the store
+from an actual eval run, and acting on the metrics (voter demotion), are
+separate gated activities (#3849 / Epic D). Fixture tests cover the
+precision/recall math, the rubric application, and the persistence round-trip.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,7 +491,7 @@ _Auto-generated from source. 46 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-16_
+_Governance Version: 2026-06-17_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/config/learning-persistence.ts
+++ b/packages/nexus-agents/src/config/learning-persistence.ts
@@ -38,6 +38,18 @@ export function getRulesFile(): string {
 }
 
 /**
+ * JSONL file for per-voter pr_review eval verdicts (#3848).
+ *
+ * Stores ONLY rubric-scored per-voter TP/FP/FN tallies vs ground truth — never
+ * raw diffs, prompts, or model outputs. Lets per-voter precision/recall accrue
+ * across runs so a chronically-noisy-voter demotion (Epic D / ADR-0017) has
+ * citable evidence.
+ */
+export function getPrReviewEvalFile(): string {
+  return join(getLearningDir(), 'pr-review-eval.jsonl');
+}
+
+/**
  * JSONL file for the MetaOrchestrator shadow selector's training outcomes
  * (#3593). Stores ONLY numeric/categorical bandit-feature values + a boolean
  * success flag — never raw task text. Lets the shadow selector learn across

--- a/packages/nexus-agents/src/mcp/tools/index.ts
+++ b/packages/nexus-agents/src/mcp/tools/index.ts
@@ -476,6 +476,27 @@ export {
   type PrReviewDeps,
 } from './pr-review-tool.js';
 
+// Per-voter pr_review eval precision/recall (#3848 — Epic E, parent #3845)
+export {
+  PR_REVIEW_EVAL_ROLES,
+  PrReviewEvalRoleSchema,
+  PrReviewCaseClassSchema,
+  VoterEvalVerdictSchema,
+  VoterEvalVerdictQuerySchema,
+} from './pr-review-eval-types.js';
+export type {
+  PrReviewEvalRole,
+  PrReviewCaseClass,
+  VoterEvalVerdict,
+  VoterEvalVerdictQuery,
+  VoterPrecisionRecall,
+  PerVoterPrecisionRecallReport,
+} from './pr-review-eval-types.js';
+export { scoreVoterCase, computePerVoterPrecisionRecall } from './pr-review-eval-scoring.js';
+export type { ScoreVoterCaseInput } from './pr-review-eval-scoring.js';
+export { PrReviewEvalStore } from './pr-review-eval-store.js';
+export type { PrReviewEvalStoreConfig } from './pr-review-eval-store.js';
+
 // Supply-chain tradeoff panel (#2294 — child of #2293, structured per-axis voting)
 export {
   registerSupplyChainTradeoffPanelTool,

--- a/packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Fixture tests for the per-voter pr_review eval scoring + report (#3848).
+ *
+ * Covers the precision/recall math and the verdict-scoring rubric application:
+ * - perfect voter, zero-positive voter, missed-bug (FN) voter
+ * - clean-case false positives, borderline exclusion
+ * - aggregate folding, empty-window safety
+ *
+ * @module mcp/tools/pr-review-eval-scoring.test
+ * (Source: #3848)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { scoreVoterCase, computePerVoterPrecisionRecall } from './pr-review-eval-scoring.js';
+import type { VoterEvalVerdict } from './pr-review-eval-types.js';
+
+const TS = '2026-06-17T00:00:00Z';
+
+function verdict(over: Partial<VoterEvalVerdict>): VoterEvalVerdict {
+  return {
+    id: 'r1:c1:architect',
+    runId: 'r1',
+    caseNumber: 'c1',
+    caseClass: 'buggy',
+    role: 'architect',
+    truePositives: 0,
+    falsePositives: 0,
+    falseNegatives: 0,
+    rubricVersion: '1.0.0',
+    timestamp: TS,
+    ...over,
+  };
+}
+
+describe('scoreVoterCase (#3848 rubric application)', () => {
+  it('counts a verified finding matching a known bug as a true positive (buggy case)', () => {
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'synthetic-redos',
+      caseClass: 'buggy',
+      role: 'security',
+      knownBugCount: 1,
+      matchedBugCount: 1,
+      verifiedFindingCount: 1,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.truePositives).toBe(1);
+    expect(v.falseNegatives).toBe(0);
+    expect(v.falsePositives).toBe(0);
+    expect(v.id).toBe('r1:synthetic-redos:security');
+  });
+
+  it('counts unmatched known bugs as false negatives (voter missed a bug)', () => {
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'synthetic-redos',
+      caseClass: 'buggy',
+      role: 'devex',
+      knownBugCount: 2,
+      matchedBugCount: 0,
+      verifiedFindingCount: 0,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.truePositives).toBe(0);
+    expect(v.falseNegatives).toBe(2);
+    expect(v.falsePositives).toBe(0);
+  });
+
+  it('counts verified findings on a clean case as false positives', () => {
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'synthetic-clean-docs',
+      caseClass: 'clean',
+      role: 'catfish',
+      knownBugCount: 0,
+      matchedBugCount: 0,
+      verifiedFindingCount: 3,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.falsePositives).toBe(3);
+    expect(v.truePositives).toBe(0);
+    expect(v.falseNegatives).toBe(0);
+  });
+
+  it('excludes borderline cases from all numerators (neither catch nor FP)', () => {
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'synthetic-clean-refactor',
+      caseClass: 'borderline',
+      role: 'devex',
+      knownBugCount: 0,
+      matchedBugCount: 0,
+      verifiedFindingCount: 2,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.truePositives).toBe(0);
+    expect(v.falsePositives).toBe(0);
+    expect(v.falseNegatives).toBe(0);
+    expect(v.caseClass).toBe('borderline');
+  });
+
+  it('on a buggy case, extra verified findings beyond matched bugs are not false positives', () => {
+    // Rubric: a finding either matches a known bug (catch) or is noise on a
+    // buggy case; only clean-case findings are strict false positives. So on a
+    // buggy case we count matched bugs as TP and unmatched bugs as FN — extra
+    // unmatched findings do not inflate FP.
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'synthetic-null-deref',
+      caseClass: 'buggy',
+      role: 'architect',
+      knownBugCount: 1,
+      matchedBugCount: 1,
+      verifiedFindingCount: 4,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.truePositives).toBe(1);
+    expect(v.falseNegatives).toBe(0);
+    expect(v.falsePositives).toBe(0);
+  });
+
+  it('clamps matchedBugCount to knownBugCount (defensive)', () => {
+    const v = scoreVoterCase({
+      runId: 'r1',
+      caseNumber: 'c',
+      caseClass: 'buggy',
+      role: 'security',
+      knownBugCount: 1,
+      matchedBugCount: 5,
+      verifiedFindingCount: 5,
+      rubricVersion: '1.0.0',
+      timestamp: TS,
+    });
+    expect(v.truePositives).toBe(1);
+    expect(v.falseNegatives).toBe(0);
+  });
+});
+
+describe('computePerVoterPrecisionRecall (#3848 report)', () => {
+  it('computes precision and recall per role and aggregate', () => {
+    const verdicts: VoterEvalVerdict[] = [
+      // security: 3 TP, 1 FP, 1 FN -> precision 3/4=0.75, recall 3/4=0.75
+      verdict({
+        role: 'security',
+        caseNumber: 'a',
+        truePositives: 2,
+        falsePositives: 0,
+        falseNegatives: 0,
+      }),
+      verdict({
+        role: 'security',
+        caseNumber: 'b',
+        caseClass: 'buggy',
+        truePositives: 1,
+        falseNegatives: 1,
+      }),
+      verdict({ role: 'security', caseNumber: 'c', caseClass: 'clean', falsePositives: 1 }),
+      // architect: 1 TP, 0 FP, 0 FN -> perfect
+      verdict({ role: 'architect', caseNumber: 'a', truePositives: 1 }),
+    ];
+    const report = computePerVoterPrecisionRecall(verdicts);
+
+    expect(report.byRole.security.truePositives).toBe(3);
+    expect(report.byRole.security.falsePositives).toBe(1);
+    expect(report.byRole.security.falseNegatives).toBe(1);
+    expect(report.byRole.security.precision).toBeCloseTo(0.75);
+    expect(report.byRole.security.recall).toBeCloseTo(0.75);
+    expect(report.byRole.security.caseCount).toBe(3);
+
+    expect(report.byRole.architect.precision).toBe(1);
+    expect(report.byRole.architect.recall).toBe(1);
+
+    // aggregate: tp=4, fp=1, fn=1 -> precision 4/5=0.8, recall 4/5=0.8
+    expect(report.aggregate.truePositives).toBe(4);
+    expect(report.aggregate.falsePositives).toBe(1);
+    expect(report.aggregate.falseNegatives).toBe(1);
+    expect(report.aggregate.precision).toBeCloseTo(0.8);
+    expect(report.aggregate.recall).toBeCloseTo(0.8);
+    expect(report.totalVerdicts).toBe(4);
+  });
+
+  it('a perfect voter (no FP, no FN) scores precision=1 recall=1', () => {
+    const report = computePerVoterPrecisionRecall([
+      verdict({ role: 'catfish', truePositives: 5, falsePositives: 0, falseNegatives: 0 }),
+    ]);
+    expect(report.byRole.catfish.precision).toBe(1);
+    expect(report.byRole.catfish.recall).toBe(1);
+  });
+
+  it('a voter with zero positives reports precision=0 (not NaN)', () => {
+    const report = computePerVoterPrecisionRecall([
+      // only misses: 0 TP, 0 FP, 3 FN
+      verdict({ role: 'scope_steward', caseClass: 'buggy', falseNegatives: 3 }),
+    ]);
+    expect(report.byRole.scope_steward.precision).toBe(0);
+    expect(report.byRole.scope_steward.recall).toBe(0); // 0/(0+3)
+    expect(Number.isNaN(report.byRole.scope_steward.precision)).toBe(false);
+  });
+
+  it('a voter with no known bugs to find reports recall=0 (not NaN)', () => {
+    const report = computePerVoterPrecisionRecall([
+      // only clean-case false positives: 0 TP, 2 FP, 0 FN
+      verdict({ role: 'devex', caseClass: 'clean', falsePositives: 2 }),
+    ]);
+    expect(report.byRole.devex.recall).toBe(0); // 0/(0+0)
+    expect(report.byRole.devex.precision).toBe(0); // 0/(0+2)
+    expect(Number.isNaN(report.byRole.devex.recall)).toBe(false);
+  });
+
+  it('roles with no verdicts report all-zero entries (every role present)', () => {
+    const report = computePerVoterPrecisionRecall([
+      verdict({ role: 'security', truePositives: 1 }),
+    ]);
+    for (const role of ['architect', 'devex', 'catfish', 'scope_steward'] as const) {
+      expect(report.byRole[role]).toEqual({
+        truePositives: 0,
+        falsePositives: 0,
+        falseNegatives: 0,
+        precision: 0,
+        recall: 0,
+        caseCount: 0,
+      });
+    }
+  });
+
+  it('empty window is safe: all zeros, no NaN', () => {
+    const report = computePerVoterPrecisionRecall([]);
+    expect(report.totalVerdicts).toBe(0);
+    expect(report.aggregate.precision).toBe(0);
+    expect(report.aggregate.recall).toBe(0);
+    expect(report.byRole.architect.caseCount).toBe(0);
+  });
+
+  it('counts distinct case numbers per role for caseCount (dedupes within a role)', () => {
+    const report = computePerVoterPrecisionRecall([
+      verdict({ role: 'security', caseNumber: 'a', truePositives: 1 }),
+      verdict({ role: 'security', caseNumber: 'a', falsePositives: 1, caseClass: 'clean' }),
+      verdict({ role: 'security', caseNumber: 'b', truePositives: 1 }),
+    ]);
+    expect(report.byRole.security.caseCount).toBe(2);
+  });
+
+  it('is deterministic (same input -> identical output)', () => {
+    const input = [verdict({ role: 'security', truePositives: 2, falseNegatives: 1 })];
+    expect(computePerVoterPrecisionRecall(input)).toEqual(computePerVoterPrecisionRecall(input));
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.ts
@@ -1,0 +1,181 @@
+/**
+ * Per-voter pr_review eval scoring + precision/recall report (#3848).
+ *
+ * Two pure, deterministic functions (the computeResearchMaturityReport / #3727
+ * pattern):
+ * - {@link scoreVoterCase}: apply the rubric (#3846) to one voter's outcome on
+ *   one case, yielding a persistable {@link VoterEvalVerdict} with TP/FP/FN
+ *   tallies. Location-tolerance matching (±5 lines / structural) is the
+ *   caller's job upstream — this function takes the already-resolved
+ *   matched-bug / verified-finding counts and applies the class rules.
+ * - {@link computePerVoterPrecisionRecall}: fold a window of verdicts into
+ *   per-role + aggregate precision/recall.
+ *
+ * No I/O, no live routing change — record + measure only.
+ *
+ * @module mcp/tools/pr-review-eval-scoring
+ * (Source: #3848 — per-voter precision/recall in the outcome store)
+ */
+
+import { PR_REVIEW_EVAL_ROLES } from './pr-review-eval-types.js';
+import type {
+  PrReviewCaseClass,
+  PrReviewEvalRole,
+  VoterEvalVerdict,
+  VoterPrecisionRecall,
+  PerVoterPrecisionRecallReport,
+} from './pr-review-eval-types.js';
+
+// ============================================================================
+// Scoring one voter on one case
+// ============================================================================
+
+/**
+ * Inputs to {@link scoreVoterCase}: a single voter's adjudicated outcome on a
+ * single labeled eval case. The match counts are produced upstream by applying
+ * the rubric's location tolerance to the voter's verified findings vs the
+ * case's `knownBugs`.
+ */
+export interface ScoreVoterCaseInput {
+  readonly runId: string;
+  readonly caseNumber: string;
+  readonly caseClass: PrReviewCaseClass;
+  readonly role: PrReviewEvalRole;
+  /** Number of known bugs on the case (ground truth; 0 for clean/borderline). */
+  readonly knownBugCount: number;
+  /** Known bugs THIS voter flagged with a verified, location-matching finding. */
+  readonly matchedBugCount: number;
+  /** Count of this voter's verified findings (gate-passed). */
+  readonly verifiedFindingCount: number;
+  readonly rubricVersion: string;
+  readonly timestamp: string;
+}
+
+/**
+ * Apply the rubric to one voter/case pair and produce a scored verdict.
+ *
+ * Class rules (#3846):
+ * - `buggy`: matched bugs are true positives; unmatched known bugs are false
+ *   negatives. Extra non-matching findings are NOT counted as false positives
+ *   (strict-FP is a clean-case-only measure).
+ * - `clean`: every verified finding is a strict false positive.
+ * - `borderline`: excluded from all numerators (neither catch nor FP).
+ */
+export function scoreVoterCase(input: ScoreVoterCaseInput): VoterEvalVerdict {
+  const knownBugs = Math.max(0, Math.trunc(input.knownBugCount));
+  // Defensive clamp: a voter cannot match more bugs than exist.
+  const matched = Math.min(knownBugs, Math.max(0, Math.trunc(input.matchedBugCount)));
+  const verified = Math.max(0, Math.trunc(input.verifiedFindingCount));
+
+  let truePositives = 0;
+  let falsePositives = 0;
+  let falseNegatives = 0;
+
+  switch (input.caseClass) {
+    case 'buggy':
+      truePositives = matched;
+      falseNegatives = knownBugs - matched;
+      break;
+    case 'clean':
+      falsePositives = verified;
+      break;
+    case 'borderline':
+      // Excluded from both numerators by rubric Rule 4.
+      break;
+  }
+
+  return {
+    id: `${input.runId}:${input.caseNumber}:${input.role}`,
+    runId: input.runId,
+    caseNumber: input.caseNumber,
+    caseClass: input.caseClass,
+    role: input.role,
+    truePositives,
+    falsePositives,
+    falseNegatives,
+    rubricVersion: input.rubricVersion,
+    timestamp: input.timestamp,
+  };
+}
+
+// ============================================================================
+// Precision / recall over a window of verdicts
+// ============================================================================
+
+interface RoleAccumulator {
+  tp: number;
+  fp: number;
+  fn: number;
+  cases: Set<string>;
+}
+
+function emptyAccumulator(): RoleAccumulator {
+  return { tp: 0, fp: 0, fn: 0, cases: new Set<string>() };
+}
+
+/** precision = tp/(tp+fp), 0 when no positives raised (avoids NaN). */
+function precision(tp: number, fp: number): number {
+  const denom = tp + fp;
+  return denom > 0 ? tp / denom : 0;
+}
+
+/** recall = tp/(tp+fn), 0 when no bugs to find (avoids NaN). */
+function recall(tp: number, fn: number): number {
+  const denom = tp + fn;
+  return denom > 0 ? tp / denom : 0;
+}
+
+function finalize(acc: RoleAccumulator): VoterPrecisionRecall {
+  return {
+    truePositives: acc.tp,
+    falsePositives: acc.fp,
+    falseNegatives: acc.fn,
+    precision: precision(acc.tp, acc.fp),
+    recall: recall(acc.tp, acc.fn),
+    caseCount: acc.cases.size,
+  };
+}
+
+/**
+ * Fold a window of per-voter verdicts into a precision/recall report.
+ *
+ * Pure + deterministic. Every pr_review role appears in `byRole` (roles with no
+ * verdicts report all-zero entries) so consumers can render a stable table. The
+ * aggregate sums tallies across all roles; `caseCount` is distinct case numbers
+ * per role (so re-scoring the same case across runs does not inflate it within
+ * a role, though it does across roles).
+ */
+export function computePerVoterPrecisionRecall(
+  verdicts: readonly VoterEvalVerdict[]
+): PerVoterPrecisionRecallReport {
+  const byRoleAcc = new Map<PrReviewEvalRole, RoleAccumulator>();
+  for (const role of PR_REVIEW_EVAL_ROLES) {
+    byRoleAcc.set(role, emptyAccumulator());
+  }
+  const aggregate = emptyAccumulator();
+
+  for (const v of verdicts) {
+    const acc = byRoleAcc.get(v.role);
+    if (acc === undefined) continue; // unknown role — defensive, schema-guarded
+    acc.tp += v.truePositives;
+    acc.fp += v.falsePositives;
+    acc.fn += v.falseNegatives;
+    acc.cases.add(v.caseNumber);
+
+    aggregate.tp += v.truePositives;
+    aggregate.fp += v.falsePositives;
+    aggregate.fn += v.falseNegatives;
+    aggregate.cases.add(`${v.role}:${v.caseNumber}`);
+  }
+
+  const byRole = {} as Record<PrReviewEvalRole, VoterPrecisionRecall>;
+  for (const role of PR_REVIEW_EVAL_ROLES) {
+    byRole[role] = finalize(byRoleAcc.get(role) ?? emptyAccumulator());
+  }
+
+  return {
+    byRole,
+    aggregate: finalize(aggregate),
+    totalVerdicts: verdicts.length,
+  };
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-eval-store.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-eval-store.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Round-trip persistence tests for the per-voter pr_review eval store (#3848).
+ *
+ * Mirrors the PersistentOutcomeStore JSONL idiom: append -> JSONL line ->
+ * hydrate on construction -> query. Asserts the report computed from a hydrated
+ * store equals the report from the in-memory verdicts (persistence is lossless
+ * for the metric).
+ *
+ * @module mcp/tools/pr-review-eval-store.test
+ * (Source: #3848)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { PrReviewEvalStore } from './pr-review-eval-store.js';
+import { computePerVoterPrecisionRecall } from './pr-review-eval-scoring.js';
+import type { VoterEvalVerdict } from './pr-review-eval-types.js';
+
+let dir: string;
+let file: string;
+
+const TS = '2026-06-17T00:00:00Z';
+
+function verdict(over: Partial<VoterEvalVerdict>): VoterEvalVerdict {
+  return {
+    id: 'r1:c1:architect',
+    runId: 'r1',
+    caseNumber: 'c1',
+    caseClass: 'buggy',
+    role: 'architect',
+    truePositives: 1,
+    falsePositives: 0,
+    falseNegatives: 0,
+    rubricVersion: '1.0.0',
+    timestamp: TS,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'pr-eval-store-'));
+  file = join(dir, 'pr-review-eval.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('PrReviewEvalStore (#3848 persistence)', () => {
+  it('appends verdicts to a JSONL file and queries them back in-memory', () => {
+    const store = new PrReviewEvalStore({ filePath: file });
+    store.append(verdict({ id: 'r1:a:security', role: 'security', caseNumber: 'a' }));
+    store.append(verdict({ id: 'r1:b:devex', role: 'devex', caseNumber: 'b' }));
+
+    expect(store.size).toBe(2);
+    expect(existsSync(file)).toBe(true);
+    expect(store.query({ role: 'security' })).toHaveLength(1);
+    expect(store.query({ role: 'security' })[0]?.caseNumber).toBe('a');
+  });
+
+  it('round-trips through disk: a fresh store hydrates the same verdicts', () => {
+    const writer = new PrReviewEvalStore({ filePath: file });
+    const verdicts = [
+      verdict({ id: 'r1:a:security', role: 'security', caseNumber: 'a', truePositives: 2 }),
+      verdict({
+        id: 'r1:b:security',
+        role: 'security',
+        caseNumber: 'b',
+        caseClass: 'clean',
+        truePositives: 0,
+        falsePositives: 1,
+      }),
+      verdict({
+        id: 'r1:c:architect',
+        role: 'architect',
+        caseNumber: 'c',
+        falseNegatives: 1,
+        truePositives: 0,
+      }),
+    ];
+    for (const v of verdicts) writer.append(v);
+
+    const reader = new PrReviewEvalStore({ filePath: file });
+    expect(reader.size).toBe(3);
+
+    // Report from hydrated store === report from raw verdicts (lossless metric).
+    const fromDisk = computePerVoterPrecisionRecall(reader.query());
+    const fromMemory = computePerVoterPrecisionRecall(verdicts);
+    expect(fromDisk).toEqual(fromMemory);
+    expect(fromDisk.byRole.security.precision).toBeCloseTo(2 / 3);
+  });
+
+  it('skips malformed JSONL lines on hydration (graceful degradation)', () => {
+    writeFileSync(
+      file,
+      [
+        JSON.stringify(verdict({ id: 'ok:1', role: 'security' })),
+        'this is not json',
+        JSON.stringify({ id: 'bad', role: 'not-a-role' }), // schema-invalid
+        JSON.stringify(verdict({ id: 'ok:2', role: 'devex' })),
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+    const store = new PrReviewEvalStore({ filePath: file });
+    expect(store.size).toBe(2);
+  });
+
+  it('starts empty when no file exists', () => {
+    const store = new PrReviewEvalStore({ filePath: join(dir, 'absent.jsonl') });
+    expect(store.size).toBe(0);
+    expect(store.query()).toEqual([]);
+  });
+
+  it('filters by runId, caseClass, since, and limit', () => {
+    const store = new PrReviewEvalStore({ filePath: file });
+    store.append(
+      verdict({ id: '1', runId: 'r1', caseClass: 'buggy', timestamp: '2026-06-01T00:00:00Z' })
+    );
+    store.append(
+      verdict({ id: '2', runId: 'r2', caseClass: 'clean', timestamp: '2026-06-10T00:00:00Z' })
+    );
+    store.append(
+      verdict({ id: '3', runId: 'r2', caseClass: 'buggy', timestamp: '2026-06-20T00:00:00Z' })
+    );
+
+    expect(store.query({ runId: 'r2' })).toHaveLength(2);
+    expect(store.query({ caseClass: 'clean' })).toHaveLength(1);
+    expect(store.query({ since: '2026-06-10T00:00:00Z' })).toHaveLength(2);
+    expect(store.query({ limit: 1 })).toHaveLength(1);
+  });
+
+  it('reportPrecisionRecall() returns the per-voter report over the queried window', () => {
+    const store = new PrReviewEvalStore({ filePath: file });
+    store.append(verdict({ id: '1', role: 'security', truePositives: 3, falseNegatives: 1 }));
+    store.append(
+      verdict({
+        id: '2',
+        role: 'security',
+        caseNumber: 'x',
+        caseClass: 'clean',
+        truePositives: 0,
+        falsePositives: 1,
+      })
+    );
+
+    const report = store.reportPrecisionRecall({ role: 'security' });
+    expect(report.byRole.security.truePositives).toBe(3);
+    expect(report.byRole.security.precision).toBeCloseTo(0.75);
+    expect(report.byRole.security.recall).toBeCloseTo(0.75);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/pr-review-eval-store.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-eval-store.ts
@@ -1,0 +1,156 @@
+/**
+ * JSONL-backed store for per-voter pr_review eval verdicts (#3848).
+ *
+ * Mirrors the {@link PersistentOutcomeStore} idiom (Issue #1009): an in-memory
+ * append-only list backed by an append-only JSONL file under the shared
+ * learning dir. Hydrates (Zod-validating each line, skipping corruption) on
+ * construction; appends one line per write. The persisted unit is the
+ * rubric-scored {@link VoterEvalVerdict} — TP/FP/FN tallies only, never raw
+ * diffs or model outputs.
+ *
+ * This is the persistence target for #3848: per-voter precision/recall queryable
+ * over time, the evidence an Epic D / ADR-0017 voter demotion would cite. Record
+ * + measure ONLY — no live routing or weighting change.
+ *
+ * @module mcp/tools/pr-review-eval-store
+ * (Source: #3848 — per-voter precision/recall in the outcome store)
+ */
+
+// @export-no-consumer-yet — see #3848. This is the persistence + report surface
+// (the data plumbing). The live recording hookup — populating it from an actual
+// pr_review eval run — is a separate, gated activity (#3849 / Epic D ADR-0017);
+// acting on the metrics (voter demotion) is explicitly out of scope here.
+
+import { appendFileSync, readFileSync, existsSync } from 'node:fs';
+
+import type { ILogger } from '../../core/index.js';
+import { createLogger, getErrorMessage } from '../../core/index.js';
+import { ensureLearningDir, getPrReviewEvalFile } from '../../config/learning-persistence.js';
+import { VoterEvalVerdictSchema, VoterEvalVerdictQuerySchema } from './pr-review-eval-types.js';
+import type { VoterEvalVerdict, VoterEvalVerdictQuery } from './pr-review-eval-types.js';
+import { computePerVoterPrecisionRecall } from './pr-review-eval-scoring.js';
+import type { PerVoterPrecisionRecallReport } from './pr-review-eval-types.js';
+
+export interface PrReviewEvalStoreConfig {
+  /** Override the JSONL file path (defaults to the shared learning dir). */
+  readonly filePath?: string;
+  /** Override the data directory used for `ensureLearningDir` (testing). */
+  readonly dataDir?: string;
+}
+
+/**
+ * Append-only, JSONL-backed store of per-voter eval verdicts.
+ *
+ * Construction hydrates from disk (corrupt/invalid lines skipped with a debug
+ * log). `append` writes through to disk. `query` filters the in-memory list;
+ * `reportPrecisionRecall` is the report surface — it folds the queried window
+ * through the pure {@link computePerVoterPrecisionRecall}.
+ */
+export class PrReviewEvalStore {
+  private readonly verdicts: VoterEvalVerdict[] = [];
+  private readonly filePath: string;
+  private readonly logger: ILogger;
+
+  constructor(config?: PrReviewEvalStoreConfig, logger?: ILogger) {
+    this.filePath = config?.filePath ?? getPrReviewEvalFile();
+    this.logger = logger ?? createLogger({ component: 'PrReviewEvalStore' });
+    ensureLearningDir(config?.dataDir);
+    this.hydrate();
+  }
+
+  get size(): number {
+    return this.verdicts.length;
+  }
+
+  /** Record one scored verdict and persist it as a JSONL line. */
+  append(verdict: VoterEvalVerdict): void {
+    const parsed = VoterEvalVerdictSchema.parse(verdict);
+    this.verdicts.push(parsed);
+    this.persistLine(parsed);
+  }
+
+  /** Filter the in-memory verdicts. Returns most-recent-first when `limit` set. */
+  query(filter?: VoterEvalVerdictQuery): readonly VoterEvalVerdict[] {
+    const f = filter === undefined ? {} : VoterEvalVerdictQuerySchema.parse(filter);
+    const preds: Array<(v: VoterEvalVerdict) => boolean> = [];
+    if (f.role !== undefined) preds.push((v) => v.role === f.role);
+    if (f.runId !== undefined) preds.push((v) => v.runId === f.runId);
+    if (f.caseClass !== undefined) preds.push((v) => v.caseClass === f.caseClass);
+    if (f.rubricVersion !== undefined) preds.push((v) => v.rubricVersion === f.rubricVersion);
+    if (f.since !== undefined) {
+      const since = f.since;
+      preds.push((v) => v.timestamp >= since);
+    }
+
+    const matched = this.verdicts.filter((v) => preds.every((p) => p(v)));
+    if (f.limit !== undefined && matched.length > f.limit) {
+      return matched.slice(matched.length - f.limit);
+    }
+    return matched;
+  }
+
+  /**
+   * The report surface (#3848): per-voter + aggregate precision/recall over the
+   * window selected by `filter` (defaults to all recorded verdicts).
+   */
+  reportPrecisionRecall(filter?: VoterEvalVerdictQuery): PerVoterPrecisionRecallReport {
+    return computePerVoterPrecisionRecall(this.query(filter));
+  }
+
+  // ==========================================================================
+  // Private
+  // ==========================================================================
+
+  private hydrate(): void {
+    if (!existsSync(this.filePath)) {
+      this.logger.debug('No pr_review eval file found, starting fresh', { path: this.filePath });
+      return;
+    }
+    try {
+      const content = readFileSync(this.filePath, 'utf-8');
+      const lines = content.split('\n').filter((line) => line.trim().length > 0);
+      let loaded = 0;
+      let skipped = 0;
+      for (const line of lines) {
+        try {
+          const parsed: unknown = JSON.parse(line);
+          const result = VoterEvalVerdictSchema.safeParse(parsed);
+          if (result.success) {
+            this.verdicts.push(result.data);
+            loaded++;
+          } else {
+            skipped++;
+          }
+        } catch (parseErr: unknown) {
+          this.logger.debug('Skipping malformed pr_review eval line during hydration', {
+            error: getErrorMessage(parseErr),
+            linePreview: line.slice(0, 80),
+          });
+          skipped++;
+        }
+      }
+      this.logger.info('Hydrated pr_review eval verdicts from disk', {
+        loaded,
+        skipped,
+        total: lines.length,
+        path: this.filePath,
+      });
+    } catch (error: unknown) {
+      this.logger.warn('Failed to hydrate pr_review eval verdicts from disk', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+    }
+  }
+
+  private persistLine(verdict: VoterEvalVerdict): void {
+    try {
+      appendFileSync(this.filePath, JSON.stringify(verdict) + '\n', 'utf-8');
+    } catch (error: unknown) {
+      this.logger.warn('Failed to persist pr_review eval verdict to disk', {
+        error: getErrorMessage(error),
+        path: this.filePath,
+      });
+    }
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-eval-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-eval-types.ts
@@ -1,0 +1,142 @@
+/**
+ * Per-voter pr_review eval types — verdict records + precision/recall report.
+ *
+ * The data plumbing for #3848 (Epic E, parent #3845): for each labeled eval
+ * case, record EACH voter role's verdict against the rubric ground truth
+ * (#3846) so per-voter true-positive / false-positive / false-negative tallies
+ * accrue and precision/recall per role becomes queryable over time. This is the
+ * evidence a chronically-noisy-voter demotion (Epic D / ADR-0017 authority
+ * ladder) would cite.
+ *
+ * Records ONLY — no live routing/weighting change. Acting on the metrics
+ * (voter demotion) is a separate, ratified Epic D transition.
+ *
+ * @module mcp/tools/pr-review-eval-types
+ * (Source: #3848 — per-voter precision/recall in the outcome store)
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Voter roles (mirrors the pr_review panel — #3845)
+// ============================================================================
+
+/**
+ * The five pr_review voter roles scored by this module. Kept as a local Zod
+ * enum (not imported from the broader {@link VoterRole} union) because the eval
+ * scores ONLY the pr_review panel; the wider union carries roles
+ * (`ai_ml`, `pm`) that the pr_review tool does not run.
+ */
+export const PR_REVIEW_EVAL_ROLES = [
+  'architect',
+  'security',
+  'devex',
+  'catfish',
+  'scope_steward',
+] as const;
+
+export const PrReviewEvalRoleSchema = z.enum(PR_REVIEW_EVAL_ROLES);
+export type PrReviewEvalRole = z.infer<typeof PrReviewEvalRoleSchema>;
+
+// ============================================================================
+// Ground truth (rubric-adjudicated — #3846)
+// ============================================================================
+
+/**
+ * The rubric class of an eval case (rubric Rule 3–4).
+ * - `buggy`: contains >=1 known bug at severity medium+; a verified finding is a catch.
+ * - `clean`: zero known bugs; a verified finding is a strict false positive.
+ * - `borderline`: defensible-but-unconfirmed; excluded from BOTH numerators
+ *   (neither a catch nor a false positive).
+ */
+export const PrReviewCaseClassSchema = z.enum(['buggy', 'clean', 'borderline']);
+export type PrReviewCaseClass = z.infer<typeof PrReviewCaseClassSchema>;
+
+// ============================================================================
+// Per-voter per-case verdict record (the persisted unit)
+// ============================================================================
+
+/**
+ * One voter's scored verdict on one eval case, adjudicated against ground truth.
+ *
+ * The four tally fields are the rubric-scored outcome of comparing the voter's
+ * verified findings to the case's known bugs (with location tolerance applied
+ * upstream by {@link scoreVoterCase}):
+ * - `truePositives`: verified findings that matched a known bug (buggy cases).
+ * - `falsePositives`: verified findings on a clean case that matched no bug.
+ * - `falseNegatives`: known bugs on a buggy case that this voter did NOT flag.
+ *
+ * Borderline cases contribute zero to all three (excluded numerators) but are
+ * still recorded for provenance via `caseClass: 'borderline'`.
+ */
+export const VoterEvalVerdictSchema = z.object({
+  /** Stable record id (e.g. `${runId}:${caseNumber}:${role}`). */
+  id: z.string().min(1).max(160),
+  /** The pr_review run / batch this verdict belongs to. */
+  runId: z.string().min(1).max(64),
+  /** Dataset case identifier (the dataset's `number` field). */
+  caseNumber: z.string().min(1).max(80),
+  /** Rubric class of the case (ground-truth label). */
+  caseClass: PrReviewCaseClassSchema,
+  /** The voter role being scored. */
+  role: PrReviewEvalRoleSchema,
+  /** Verified findings that matched a known bug. */
+  truePositives: z.number().int().nonnegative(),
+  /** Verified findings on clean code that matched no known bug. */
+  falsePositives: z.number().int().nonnegative(),
+  /** Known bugs this voter failed to flag. */
+  falseNegatives: z.number().int().nonnegative(),
+  /** Rubric version the ground truth was adjudicated under. */
+  rubricVersion: z.string().min(1).max(32),
+  /** ISO-8601 timestamp the verdict was recorded. */
+  timestamp: z.string().min(1).max(40),
+});
+
+export type VoterEvalVerdict = z.infer<typeof VoterEvalVerdictSchema>;
+
+/** Query filter for {@link PrReviewEvalStore.query}. */
+export const VoterEvalVerdictQuerySchema = z.object({
+  role: PrReviewEvalRoleSchema.optional(),
+  runId: z.string().min(1).max(64).optional(),
+  caseClass: PrReviewCaseClassSchema.optional(),
+  rubricVersion: z.string().min(1).max(32).optional(),
+  /** ISO-8601 lower bound (inclusive) on `timestamp`. */
+  since: z.string().optional(),
+  /** Most-recent-N cap. */
+  limit: z.number().int().positive().optional(),
+});
+
+export type VoterEvalVerdictQuery = z.infer<typeof VoterEvalVerdictQuerySchema>;
+
+// ============================================================================
+// Report types (per-voter precision/recall — pure, fixture-tested)
+// ============================================================================
+
+/** Precision/recall tallies + derived rates for one voter role (or aggregate). */
+export interface VoterPrecisionRecall {
+  readonly truePositives: number;
+  readonly falsePositives: number;
+  readonly falseNegatives: number;
+  /**
+   * tp / (tp + fp). 0 when the voter raised zero positives (tp+fp === 0) — a
+   * voter that never speaks has no measurable precision; we report 0 rather
+   * than NaN so the value is sortable and persistable.
+   */
+  readonly precision: number;
+  /**
+   * tp / (tp + fn). 0 when there were zero known bugs to find (tp+fn === 0).
+   */
+  readonly recall: number;
+  /** Distinct eval cases that contributed to this voter's tallies. */
+  readonly caseCount: number;
+}
+
+/** Per-voter precision/recall report over a window of verdicts. */
+export interface PerVoterPrecisionRecallReport {
+  /** One entry per pr_review role (roles with no verdicts report zeros). */
+  readonly byRole: Readonly<Record<PrReviewEvalRole, VoterPrecisionRecall>>;
+  /** Panel-wide tallies summed across all roles. */
+  readonly aggregate: VoterPrecisionRecall;
+  /** Total verdict records folded into this report. */
+  readonly totalVerdicts: number;
+}


### PR DESCRIPTION
Fixes #3848 (Epic E, parent #3845). Depends on #3846 (rubric ground truth).

Records, per labeled eval case, EACH pr_review voter role's verdict against the rubric-adjudicated ground truth so per-voter precision/recall accrues over time — the evidence a chronically-noisy-voter demotion on the Epic D / ADR-0017 authority ladder would cite. **Record + measure ONLY**: no live routing/weighting change, and no live LLM eval run (that and acting on the metrics are separate gated activities). Cost is out of scope (Epic G).

## Recording mechanism
`PrReviewEvalStore` (`packages/nexus-agents/src/mcp/tools/pr-review-eval-store.ts`) is a JSONL-backed store that mirrors the established `PersistentOutcomeStore` idiom (Issue #1009): hydrate-on-construct (Zod-validating each line, skipping corruption), append-one-line-per-write, under the shared learning dir (`getPrReviewEvalFile()` → `~/.nexus/learning/pr-review-eval.jsonl`, added to `config/learning-persistence.ts`). The persisted unit is the rubric-scored `VoterEvalVerdict` — per-voter per-case true-positive / false-positive / false-negative tallies plus the rubric `class` — **never raw diffs, prompts, or model outputs**.

`scoreVoterCase()` adjudicates one voter on one case against ground truth and produces a persistable verdict, applying the #3846 rubric class rules:
- **buggy** → location-matched known bugs are true positives; unmatched known bugs are false negatives (extra non-matching findings are NOT counted as FP — strict-FP is a clean-case-only measure).
- **clean** → every verified finding is a strict false positive.
- **borderline** → excluded from both numerators (neither a catch nor a false positive), per rubric Rule 4.

## Precision/recall math
`computePerVoterPrecisionRecall()` folds a window of verdicts into per-role + aggregate stats — a pure, deterministic function in the `computeResearchMaturityReport` / #3727 pattern:
- `precision = tp / (tp + fp)`, reported as `0` (not NaN) when the voter raised zero positives.
- `recall = tp / (tp + fn)`, reported as `0` (not NaN) when there were no known bugs to find.
- Every pr_review role appears in `byRole` (roles with no verdicts report all-zero entries) so consumers render a stable table; `aggregate` sums tallies panel-wide.

## Report surface
- `computePerVoterPrecisionRecall(verdicts)` — pure report over any window of verdicts.
- `PrReviewEvalStore.reportPrecisionRecall(filter?)` — the persisted surface; folds the queried window (by role / runId / caseClass / rubricVersion / since / limit) through the pure function.

## Fixture tests (TDD)
- `pr-review-eval-scoring.test.ts` — precision/recall math + rubric application: perfect voter, zero-positive voter (precision 0 not NaN), no-bugs voter (recall 0 not NaN), clean-case FP, borderline exclusion, FN on missed bugs, aggregate folding, empty-window safety, determinism, distinct-case counting, defensive clamp.
- `pr-review-eval-store.test.ts` — persistence round-trip: append→JSONL→hydrate→query equals the in-memory report (lossless metric), malformed-line skipping, absent-file start, filters, and the report surface.

## Verification (all green)
`pnpm install --frozen-lockfile` · `pnpm typecheck` · `pnpm test` (1102 files, 26445 tests passed) · `pnpm build` · `pnpm lint` · `pnpm claims:check` (13/13) · `pnpm governance:check` · producer/consumer check (types + scoring have in-src consumers; store opted out via `@export-no-consumer-yet — see #3848` since the live recording hookup is gated). Changeset added (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)