### PR TITLE
feat(observability): per-voter, per-decision cost aggregation on consensus + pr_review (#3855)

### DIFF
--- a/.changeset/per-decision-cost-3855.md
+++ b/.changeset/per-decision-cost-3855.md
@@ -1,0 +1,35 @@
+---
+'nexus-agents': patch
+---
+
+feat(observability): per-voter, per-decision cost aggregation on consensus + pr_review (#3855)
+
+A governed decision — a `consensus_vote` or `pr_review` run — fans out to N voter
+LLM calls. Per-CALL usage telemetry already existed (`learning/usage-log.ts`:
+token + cost per model call); what was missing was the AGGREGATION rolling those
+per-call numbers up into one per-decision answer.
+
+This adds that rollup layer, riding the EXISTING decision surfaces — NO new MCP
+tool (the 47-tool ceiling is respected; tool count stays at 46):
+
+- `observability/decision-cost.ts` — the pure, fixture-tested rollup
+  (`rollupDecisionCost`): per-voter → per-decision totals, per-model breakdown,
+  micro-USD rounding. Missing cost is counted as UNMEASURED (a floor), never a
+  measured $0; `NEXUS_BILLING_MODE=plan` records 0-cost while KEEPING token
+  counts (mirrors how plan mode zeroes cost in routing without dropping the
+  token signal).
+- `observability/decision-cost-store.ts` — durable JSONL persistence built on
+  the shared `JsonlStore<T>` primitive (no hand-rolled JSONL), written under the
+  shared learning dir like the OutcomeStore idiom. Stores only per-voter /
+  per-model token + USD totals — never proposals, diffs, prompts, or outputs.
+- `mcp/tools/decision-cost-recording.ts` — the consumer bridge: maps a panel's
+  per-voter results into cost inputs (model captured on `AgentVoteResult`,
+  api-mode cost derived via the same registry-backed `computeCostUSD` the
+  per-call usage log uses), reads the live billing mode, rolls up + persists, and
+  returns the summary. `consensus_vote` and `pr_review` attach the returned
+  `costSummary` to their existing responses (best-effort — a rollup failure never
+  fails the decision).
+
+Record + measure only — no routing or weighting change. Feeds Epic G's
+weather_report + manifest cost profiles (#3856) and the governed-decision cost
+doc (#3857).

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -81,6 +81,12 @@ export interface AgentVoteResult {
   readonly source: 'llm' | 'simulation' | 'error';
   /** CLI that executed this vote (for adaptive routing feedback). */
   readonly cli?: string | undefined;
+  /**
+   * Model id that executed this vote, when known (e.g. 'claude-sonnet'). Carried
+   * so per-decision cost aggregation can attribute spend per model (#3855). Absent
+   * for error/simulation votes that never reached a model.
+   */
+  readonly model?: string | undefined;
   /** Error message if vote fell back to simulation or encountered an error */
   readonly error?: string;
 }

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -156,7 +156,14 @@ export async function executeAgentVote(
 
   if (result.ok) {
     logger.info('Vote completed', { role, model: adapter.modelId, decision: result.vote.decision });
-    return { role, vote: result.vote, processingTimeMs, source: 'llm', cli: adapter.providerId };
+    return {
+      role,
+      vote: result.vote,
+      processingTimeMs,
+      source: 'llm',
+      cli: adapter.providerId,
+      model: adapter.modelId,
+    };
   }
 
   // All retries exhausted

--- a/packages/nexus-agents/src/config/learning-persistence.ts
+++ b/packages/nexus-agents/src/config/learning-persistence.ts
@@ -50,6 +50,19 @@ export function getPrReviewEvalFile(): string {
 }
 
 /**
+ * JSONL file for per-decision cost rollups (#3855).
+ *
+ * Stores ONLY the per-decision cost summary (per-voter / per-model token + USD
+ * totals) for a governed `consensus_vote` / `pr_review` run — never raw
+ * proposals, diffs, prompts, or model outputs. Lets "what did this governed
+ * decision cost?" be answered from recorded data (epic #3854; feeds Epic G's
+ * weather_report + manifest cost profiles in #3856).
+ */
+export function getDecisionCostFile(): string {
+  return join(getLearningDir(), 'decision-costs.jsonl');
+}
+
+/**
  * JSONL file for the MetaOrchestrator shadow selector's training outcomes
  * (#3593). Stores ONLY numeric/categorical bandit-feature values + a boolean
  * success flag — never raw task text. Lets the shadow selector learn across

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { AgentVoteResult, VotingResult } from '../../cli/vote-types.js';
 import { VOTER_ROLES } from '../../cli/vote-types.js';
 import type { HigherOrderVotingResult } from '../../consensus/higher-order-types.js';
+import type { DecisionCostSummary } from '../../observability/decision-cost.js';
 
 /** Maximum proposal length (memory bounds per Issue #435). */
 export const MAX_PROPOSAL_LENGTH = 4000;
@@ -277,6 +278,13 @@ export interface ConsensusVoteResponse {
    * Absent when every requested voter returned a real vote.
    */
   panelWarning?: string;
+  /**
+   * Per-decision cost rollup (#3855): per-voter / per-model token + USD totals
+   * for this governed decision. Rides the existing response — no new MCP tool.
+   * Totals are a floor when `costSummary.unmeasuredVoters > 0` (voters whose
+   * adapter reported no usage are counted as unmeasured, not a measured $0).
+   */
+  costSummary?: DecisionCostSummary;
 }
 
 /** Extended voting result with optional Higher-Order metadata. */
@@ -338,7 +346,8 @@ function panelDegradationWarning(errorCount: number, total: number): string | un
 /** Builds the response from voting result. */
 export function buildResponse(
   input: ConsensusVoteInput,
-  result: ExtendedVotingResult
+  result: ExtendedVotingResult,
+  costSummary?: DecisionCostSummary
 ): ConsensusVoteResponse {
   const proposalTruncated =
     input.proposal.length > 200 ? input.proposal.slice(0, 200) + '...' : input.proposal;
@@ -367,24 +376,38 @@ export function buildResponse(
     simulateVotes: result.simulateVotes,
   };
 
+  applyOptionalResponseFields(response, input, result, errorCount, costSummary);
+  return response;
+}
+
+/**
+ * Attach the optional response fields (threshold, policy reason, panel warning,
+ * higher-order metadata, cost summary). Extracted from {@link buildResponse} to
+ * keep its cyclomatic complexity within the lint budget (#3855).
+ */
+function applyOptionalResponseFields(
+  response: ConsensusVoteResponse,
+  input: ConsensusVoteInput,
+  result: ExtendedVotingResult,
+  errorCount: number,
+  costSummary?: DecisionCostSummary
+): void {
   if (input.threshold !== undefined) {
     response.threshold = input.threshold;
   }
-
   if (result.policyReason !== undefined) {
     response.policyReason = result.policyReason;
   }
-
   const panelWarning = panelDegradationWarning(errorCount, result.votes.length);
   if (panelWarning !== undefined) {
     response.panelWarning = panelWarning;
   }
-
   if (isHigherOrderStrategy(result.strategy) && result.higherOrderResult) {
     response.higherOrderMetadata = toHigherOrderMetadata(result.higherOrderResult);
   }
-
-  return response;
+  if (costSummary !== undefined) {
+    response.costSummary = costSummary;
+  }
 }
 
 /** Maps a HigherOrderVotingResult to the response's metadata shape. */

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -55,6 +55,7 @@ import {
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import { recordVoteSuccess, recordVoteError } from './consensus-vote-recording.js';
+import { recordDecisionCost } from './decision-cost-recording.js';
 import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
@@ -703,10 +704,26 @@ async function handleConsensusVote(
       result.totalTimeMs,
       result.votes
     );
+    // #3855: roll up + persist this decision's per-voter cost and ride it on the
+    // existing response (no new MCP tool). Best-effort — the store never throws,
+    // and a rollup failure must not fail the vote, so guard the whole step.
+    let costSummary;
+    try {
+      const decisionId = `consensus-${String(getTimeProvider().now())}-${randomUUID().slice(0, 8)}`;
+      costSummary = recordDecisionCost({
+        decisionId,
+        gate: 'consensus_vote',
+        votes: result.votes,
+      });
+    } catch (costError) {
+      logger.warn('Per-decision cost rollup failed (non-fatal)', {
+        error: getErrorMessage(costError),
+      });
+    }
     // Close the self-tuning loop: a rejected vote emits signal.vote_rejected
     // onto the typed pipeline bus for the shadow TuneStage (#3147; #3289 Option 2).
     emitVoteRejectedSignal(result.result, getPipelineEventBus(), logger);
-    return { ok: true, value: buildResponse(args, result) };
+    return { ok: true, value: buildResponse(args, result, costSummary) };
   } catch (error) {
     const message = getErrorMessage(error);
     const cause = error instanceof Error ? error : new Error(message);

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the decision-cost recording bridge (#3855).
+ *
+ * Covers the vote-result → VoterCostInput mapping (model captured, missing
+ * usage left unmeasured) and the end-to-end record path against an injected
+ * store.
+ *
+ * @module mcp/tools/decision-cost-recording.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { AgentVoteResult } from '../../cli/vote-types.js';
+import { DecisionCostStore } from '../../observability/decision-cost-store.js';
+import {
+  votesToCostInputs,
+  recordDecisionCost,
+  resolveBillingMode,
+} from './decision-cost-recording.js';
+
+function vote(over: Partial<AgentVoteResult>): AgentVoteResult {
+  return {
+    role: 'architect',
+    vote: { decision: 'approve', reasoning: 'ok', confidence: 0.8 },
+    processingTimeMs: 100,
+    source: 'llm',
+    cli: 'anthropic',
+    model: 'claude-sonnet',
+    ...over,
+  };
+}
+
+describe('votesToCostInputs', () => {
+  it('captures the model and leaves usage unmeasured when the adapter reported none', () => {
+    const inputs = votesToCostInputs([vote({ role: 'architect', model: 'claude-sonnet' })]);
+    expect(inputs[0]?.role).toBe('architect');
+    expect(inputs[0]?.model).toBe('claude-sonnet');
+    expect(inputs[0]?.inputTokens).toBeUndefined();
+    expect(inputs[0]?.outputTokens).toBeUndefined();
+    expect(inputs[0]?.costUsd).toBeUndefined();
+  });
+
+  it('derives api-mode cost from reported tokens via the shared pricing table', () => {
+    // A vote result carrying token counts (forward-compat shape).
+    const withTokens = {
+      ...vote({ role: 'security', model: 'claude-sonnet' }),
+      inputTokens: 1000,
+      outputTokens: 200,
+    };
+    const inputs = votesToCostInputs([withTokens]);
+    expect(inputs[0]?.inputTokens).toBe(1000);
+    expect(inputs[0]?.outputTokens).toBe(200);
+    // computeCostUSD returns a number (0 for unknown-model pricing, >=0 otherwise).
+    expect(typeof inputs[0]?.costUsd).toBe('number');
+  });
+});
+
+describe('resolveBillingMode', () => {
+  const original = process.env['NEXUS_BILLING_MODE'];
+  afterEach(() => {
+    if (original === undefined) delete process.env['NEXUS_BILLING_MODE'];
+    else process.env['NEXUS_BILLING_MODE'] = original;
+  });
+
+  it('defaults to plan', () => {
+    delete process.env['NEXUS_BILLING_MODE'];
+    expect(resolveBillingMode()).toBe('plan');
+  });
+
+  it('honors api', () => {
+    process.env['NEXUS_BILLING_MODE'] = 'api';
+    expect(resolveBillingMode()).toBe('api');
+  });
+});
+
+describe('recordDecisionCost', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'decision-cost-rec-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rolls up + persists and returns the summary for the response', () => {
+    const store = new DecisionCostStore({ filePath: join(dir, 'dc.jsonl'), dataDir: dir });
+    const summary = recordDecisionCost({
+      decisionId: 'd1',
+      gate: 'consensus_vote',
+      votes: [vote({ role: 'architect' }), vote({ role: 'security' })],
+      store,
+      billingMode: 'api',
+    });
+
+    expect(summary.voterCount).toBe(2);
+    // No tokens reported ⇒ both unmeasured (honest floor, not measured $0).
+    expect(summary.unmeasuredVoters).toBe(2);
+    expect(summary.totalCostUsd).toBe(0);
+    expect(store.size).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -1,0 +1,105 @@
+/**
+ * decision-cost-recording — attach a per-decision cost rollup to the EXISTING
+ * consensus_vote / pr_review result + persist it.
+ *
+ * Source: Issue #3855 (epic #3854 child, M4).
+ *
+ * This is the consumer that rides the existing decision surfaces (#3855
+ * explicitly forbids a new MCP tool — the 47-tool ceiling). It bridges a
+ * panel's per-voter results into {@link VoterCostInput}s, reads the live billing
+ * mode from `NEXUS_BILLING_MODE`, rolls them up via the pure
+ * {@link rollupDecisionCost}, persists the summary to the {@link DecisionCostStore},
+ * and returns the summary so the tool can attach it to its response.
+ *
+ * Per-voter token/cost is propagated where the adapter layer reported it; voters
+ * with no usage are folded in as UNMEASURED (not a measured $0) — see
+ * {@link module:observability/decision-cost}. Record + measure ONLY — no routing
+ * or weighting change.
+ *
+ * @module mcp/tools/decision-cost-recording
+ */
+
+import type { AgentVoteResult } from '../../cli/vote-types.js';
+import { getTimeProvider } from '../../core/index.js';
+import { computeCostUSD } from '../../learning/usage-log.js';
+import {
+  DecisionCostStore,
+  type DecisionCostRecord,
+  type DecisionGate,
+} from '../../observability/decision-cost-store.js';
+import type {
+  DecisionBillingMode,
+  DecisionCostSummary,
+  VoterCostInput,
+} from '../../observability/decision-cost.js';
+
+/** Resolve the active billing mode from env (default 'plan'). */
+export function resolveBillingMode(): DecisionBillingMode {
+  return process.env['NEXUS_BILLING_MODE'] === 'api' ? 'api' : 'plan';
+}
+
+/**
+ * Bridge a panel's per-voter results into per-voter cost inputs.
+ *
+ * The vote result carries the model id (#3855) and, where the adapter reported
+ * it, token counts. When tokens are present we derive the api-mode cost via the
+ * same registry-backed {@link computeCostUSD} the per-call usage log uses, so a
+ * per-decision rollup and the per-call usage log price identically. When no
+ * usage was reported the voter is left with no tokens/cost ⇒ unmeasured.
+ */
+export function votesToCostInputs(
+  votes: readonly (AgentVoteResult & {
+    readonly inputTokens?: number | undefined;
+    readonly outputTokens?: number | undefined;
+  })[]
+): VoterCostInput[] {
+  return votes.map((v) => {
+    const hasTokens = v.inputTokens !== undefined || v.outputTokens !== undefined;
+    const input: VoterCostInput = {
+      role: v.role,
+      model: v.model,
+      ...(v.inputTokens !== undefined ? { inputTokens: v.inputTokens } : {}),
+      ...(v.outputTokens !== undefined ? { outputTokens: v.outputTokens } : {}),
+      ...(hasTokens && v.model !== undefined
+        ? { costUsd: computeCostUSD(v.model, v.inputTokens ?? 0, v.outputTokens ?? 0) }
+        : {}),
+    };
+    return input;
+  });
+}
+
+export interface RecordDecisionCostOptions {
+  /** Stable id for the decision (correlation id / jobId / proposal hash). */
+  readonly decisionId: string;
+  /** Which gate type incurred the cost. */
+  readonly gate: DecisionGate;
+  /** The panel's per-voter results. */
+  readonly votes: readonly AgentVoteResult[];
+  /** Override the store (testing). */
+  readonly store?: DecisionCostStore;
+  /** Override the billing mode (testing); defaults to the env-resolved mode. */
+  readonly billingMode?: DecisionBillingMode;
+}
+
+/**
+ * Roll up + persist a decision's cost and return the summary for the response.
+ *
+ * Best-effort persistence: the store never throws into the caller (an
+ * observability sink must not break the decision it observes), so on any
+ * failure the rollup is still returned for the response. Riding the existing
+ * surface — the caller attaches the returned `summary` to its result object.
+ */
+export function recordDecisionCost(options: RecordDecisionCostOptions): DecisionCostSummary {
+  const billingMode = options.billingMode ?? resolveBillingMode();
+  const voters = votesToCostInputs(options.votes);
+  const store = options.store ?? new DecisionCostStore();
+  const timestamp = new Date(getTimeProvider().now()).toISOString();
+  const record: DecisionCostRecord = store.record({
+    decisionId: options.decisionId,
+    gate: options.gate,
+    voters,
+    billingMode,
+    timestamp,
+  });
+  return record.summary;
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -30,6 +30,8 @@ import {
 import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+import { recordDecisionCost } from './decision-cost-recording.js';
+import type { DecisionCostSummary } from '../../observability/decision-cost.js';
 // #3731 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
 import { runAsJob } from '../jobs/run-as-job.js';
 import {
@@ -161,6 +163,13 @@ export interface PrReviewResponse {
   readonly errorCount: number;
   readonly reviews: readonly PrReviewVote[];
   readonly totalDurationMs: number;
+  /**
+   * Per-decision cost rollup (#3855): per-voter / per-model token + USD totals
+   * for this governed review. Rides the existing response — no new MCP tool.
+   * Totals are a floor when `costSummary.unmeasuredVoters > 0` (voters whose
+   * adapter reported no usage are counted as unmeasured, not a measured $0).
+   */
+  readonly costSummary?: DecisionCostSummary;
 }
 
 export type PrReviewDeps = BaseMcpToolDeps;
@@ -349,12 +358,29 @@ async function executePrReviewBody(input: PrReviewInput, logger: ILogger): Promi
   const counts = summarizeReviews(reviews);
   const aggregate = aggregatePrDecisions(reviews);
 
+  // #3855: roll up + persist this review's per-voter cost and ride it on the
+  // existing response (no new MCP tool). Best-effort — a rollup failure must
+  // not fail the review.
+  let costSummary: DecisionCostSummary | undefined;
+  try {
+    costSummary = recordDecisionCost({
+      decisionId: `pr-${randomUUID().slice(0, 8)}`,
+      gate: 'pr_review',
+      votes: voteResults,
+    });
+  } catch (costError) {
+    logger.warn('Per-decision cost rollup failed (non-fatal)', {
+      error: getErrorMessage(costError),
+    });
+  }
+
   const response: PrReviewResponse = {
     summary: aggregate.decision,
     verified: aggregate.verified,
     ...counts,
     reviews,
     totalDurationMs: Date.now() - start,
+    ...(costSummary !== undefined ? { costSummary } : {}),
   };
   return toolSuccess(JSON.stringify(response, null, 2));
 }

--- a/packages/nexus-agents/src/observability/decision-cost-store.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-store.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the JSONL-backed per-decision cost store (#3855).
+ *
+ * Round-trip persistence (write → hydrate from disk → query), corruption
+ * tolerance (inherited from the shared JsonlStore primitive), and the
+ * record-via-rollup path.
+ *
+ * @module observability/decision-cost-store.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { DecisionCostStore } from './decision-cost-store.js';
+import type { VoterCostInput } from './decision-cost.js';
+
+const TS = '2026-06-17T00:00:00.000Z';
+
+const VOTERS: VoterCostInput[] = [
+  {
+    role: 'architect',
+    model: 'claude-sonnet',
+    inputTokens: 1000,
+    outputTokens: 200,
+    costUsd: 0.006,
+  },
+  { role: 'security', model: 'claude-sonnet' }, // unmeasured
+];
+
+describe('DecisionCostStore', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'decision-cost-store-'));
+    file = join(dir, 'decision-costs.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('records a rollup and returns the persisted summary', () => {
+    const store = new DecisionCostStore({ filePath: file, dataDir: dir });
+    const record = store.record({
+      decisionId: 'd1',
+      gate: 'consensus_vote',
+      voters: VOTERS,
+      billingMode: 'api',
+      timestamp: TS,
+    });
+
+    expect(record.decisionId).toBe('d1');
+    expect(record.gate).toBe('consensus_vote');
+    expect(record.summary.voterCount).toBe(2);
+    expect(record.summary.measuredVoters).toBe(1);
+    expect(record.summary.unmeasuredVoters).toBe(1);
+    expect(record.summary.totalCostUsd).toBeCloseTo(0.006, 9);
+    expect(store.size).toBe(1);
+  });
+
+  it('round-trips through disk: a fresh store hydrates the same records', () => {
+    const writer = new DecisionCostStore({ filePath: file, dataDir: dir });
+    writer.record({
+      decisionId: 'd1',
+      gate: 'consensus_vote',
+      voters: VOTERS,
+      billingMode: 'api',
+      timestamp: TS,
+    });
+    writer.record({
+      decisionId: 'd2',
+      gate: 'pr_review',
+      voters: VOTERS,
+      billingMode: 'plan',
+      timestamp: TS,
+    });
+
+    const reader = new DecisionCostStore({ filePath: file, dataDir: dir });
+    expect(reader.size).toBe(2);
+    expect(reader.all().map((r) => r.decisionId)).toEqual(['d1', 'd2']);
+    // Plan-mode record persisted 0 cost but kept tokens.
+    const planRec = reader.all().find((r) => r.decisionId === 'd2');
+    expect(planRec?.summary.totalCostUsd).toBe(0);
+    expect(planRec?.summary.totalTokens).toBe(1200);
+  });
+
+  it('skips corrupt lines on hydrate (graceful degradation)', () => {
+    const writer = new DecisionCostStore({ filePath: file, dataDir: dir });
+    writer.record({
+      decisionId: 'd1',
+      gate: 'consensus_vote',
+      voters: VOTERS,
+      billingMode: 'api',
+      timestamp: TS,
+    });
+
+    // Inject a malformed line + a schema-invalid line.
+    const good = readFileSync(file, 'utf-8').trim();
+    writeFileSync(file, `${good}\nnot-json{{\n${JSON.stringify({ decisionId: 'd2' })}\n`, 'utf-8');
+
+    const reader = new DecisionCostStore({ filePath: file, dataDir: dir });
+    expect(reader.size).toBe(1);
+    expect(reader.all()[0]?.decisionId).toBe('d1');
+  });
+
+  it('filters by gate and since-timestamp', () => {
+    const store = new DecisionCostStore({ filePath: file, dataDir: dir });
+    store.record({
+      decisionId: 'a',
+      gate: 'consensus_vote',
+      voters: VOTERS,
+      billingMode: 'api',
+      timestamp: '2026-06-15T00:00:00.000Z',
+    });
+    store.record({
+      decisionId: 'b',
+      gate: 'pr_review',
+      voters: VOTERS,
+      billingMode: 'api',
+      timestamp: '2026-06-17T00:00:00.000Z',
+    });
+
+    expect(store.query({ gate: 'pr_review' }).map((r) => r.decisionId)).toEqual(['b']);
+    expect(store.query({ since: '2026-06-16T00:00:00.000Z' }).map((r) => r.decisionId)).toEqual([
+      'b',
+    ]);
+    expect(store.query()).toHaveLength(2);
+  });
+});

--- a/packages/nexus-agents/src/observability/decision-cost-store.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-store.ts
@@ -1,0 +1,158 @@
+/**
+ * decision-cost-store — durable per-decision cost rollups.
+ *
+ * Source: Issue #3855 (epic #3854 child, M4).
+ *
+ * Persists one {@link DecisionCostRecord} per governed decision (a
+ * `consensus_vote` / `pr_review` run) so the question "what did this decision
+ * cost?" can be answered from recorded data later — feeding Epic G's
+ * weather_report / manifest cost profiles (#3856) and the governed-decision
+ * cost doc (#3857).
+ *
+ * Mirrors the established persistence idiom: it reuses the shared
+ * {@link JsonlStore} primitive ({@link module:config/jsonl-store}, #3762) rather
+ * than re-forking the hydrate/append/rotate fs plumbing, and writes under the
+ * shared learning dir like {@link module:orchestration/outcomes/outcome-store}.
+ * Record + measure ONLY — no routing or weighting change (#3855 acceptance).
+ *
+ * @module observability/decision-cost-store
+ */
+
+import { z } from 'zod';
+
+import { JsonlStore } from '../config/jsonl-store.js';
+import { ensureLearningDir, getDecisionCostFile } from '../config/learning-persistence.js';
+import { rollupDecisionCost } from './decision-cost.js';
+import type { DecisionBillingMode, DecisionCostSummary, VoterCostInput } from './decision-cost.js';
+
+/** Decision surface that incurred the cost — the gate type (#3854). */
+export const DecisionGateSchema = z.enum(['consensus_vote', 'pr_review']);
+export type DecisionGate = z.infer<typeof DecisionGateSchema>;
+
+const VoterCostBreakdownSchema = z.object({
+  role: z.string().min(1).max(64),
+  model: z.string().min(1).max(120),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  unmeasured: z.boolean(),
+});
+
+const ModelCostBreakdownSchema = z.object({
+  model: z.string().min(1).max(120),
+  voterCount: z.number().int().nonnegative(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+});
+
+const DecisionCostSummarySchema = z.object({
+  billingMode: z.enum(['plan', 'api']),
+  voterCount: z.number().int().nonnegative(),
+  measuredVoters: z.number().int().nonnegative(),
+  unmeasuredVoters: z.number().int().nonnegative(),
+  totalInputTokens: z.number().int().nonnegative(),
+  totalOutputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  totalCostUsd: z.number().nonnegative(),
+  perVoter: z.array(VoterCostBreakdownSchema).readonly(),
+  perModel: z.array(ModelCostBreakdownSchema).readonly(),
+});
+
+/** One persisted per-decision cost rollup. */
+export const DecisionCostRecordSchema = z.object({
+  /** Stable id for the decision (correlation id / jobId / minted decision id). */
+  decisionId: z.string().min(1).max(160),
+  /** Which gate type incurred the cost. */
+  gate: DecisionGateSchema,
+  /** ISO 8601 timestamp the rollup was recorded. */
+  timestamp: z.string().min(1).max(40),
+  /** The rolled-up cost summary. */
+  summary: DecisionCostSummarySchema,
+});
+export type DecisionCostRecord = z.infer<typeof DecisionCostRecordSchema>;
+
+/** Bounded retention — keep the most recent N decision rollups. */
+const MAX_DECISION_COST_RECORDS = 5000;
+
+export interface DecisionCostStoreConfig {
+  /** Override the JSONL file path (defaults to the shared learning dir). */
+  readonly filePath?: string;
+  /** Override the data directory used for `ensureLearningDir` (testing). */
+  readonly dataDir?: string;
+  /** Override retention cap. */
+  readonly maxRecords?: number;
+}
+
+export interface RecordDecisionCostInput {
+  readonly decisionId: string;
+  readonly gate: DecisionGate;
+  readonly voters: readonly VoterCostInput[];
+  readonly billingMode: DecisionBillingMode;
+  /** ISO timestamp; the caller supplies the clock (keeps the store deterministic). */
+  readonly timestamp: string;
+}
+
+/**
+ * Append-only, JSONL-backed store of per-decision cost rollups, built on the
+ * shared {@link JsonlStore} primitive.
+ *
+ * `record` rolls the per-voter inputs up (via the pure {@link rollupDecisionCost})
+ * and persists the resulting summary; `query` filters the in-memory window;
+ * `report` re-derives the cross-decision rollup the caller asks for.
+ */
+export class DecisionCostStore {
+  private readonly store: JsonlStore<DecisionCostRecord>;
+
+  constructor(config?: DecisionCostStoreConfig) {
+    ensureLearningDir(config?.dataDir);
+    this.store = new JsonlStore<DecisionCostRecord>({
+      filePath: config?.filePath ?? getDecisionCostFile(),
+      schema: DecisionCostRecordSchema,
+      maxRecords: config?.maxRecords ?? MAX_DECISION_COST_RECORDS,
+      component: 'DecisionCostStore',
+    });
+  }
+
+  get size(): number {
+    return this.store.count();
+  }
+
+  /**
+   * Roll up one decision's per-voter costs and persist the summary. Returns the
+   * persisted record so the caller can attach `record.summary` to the existing
+   * decision response (riding the existing surface — no new MCP tool, #3855).
+   */
+  record(input: RecordDecisionCostInput): DecisionCostRecord {
+    const summary = rollupDecisionCost(input.voters, input.billingMode);
+    const record: DecisionCostRecord = {
+      decisionId: input.decisionId,
+      gate: input.gate,
+      timestamp: input.timestamp,
+      summary,
+    };
+    this.store.append(record);
+    return record;
+  }
+
+  /** All retained records, oldest first. */
+  all(): readonly DecisionCostRecord[] {
+    return this.store.all();
+  }
+
+  /** Filter retained records by gate and/or a since-timestamp. */
+  query(filter?: { gate?: DecisionGate; since?: string }): readonly DecisionCostRecord[] {
+    const records = this.store.all();
+    if (filter === undefined) return records;
+    return records.filter((r) => {
+      if (filter.gate !== undefined && r.gate !== filter.gate) return false;
+      if (filter.since !== undefined && r.timestamp < filter.since) return false;
+      return true;
+    });
+  }
+}
+
+/** Re-export the summary type for ergonomic consumer imports. */
+export type { DecisionCostSummary };

--- a/packages/nexus-agents/src/observability/decision-cost.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Fixture tests for the pure per-decision cost rollup (#3855).
+ *
+ * Pins the acceptance-criteria math:
+ *  - per-voter → per-decision totals
+ *  - per-model breakdown
+ *  - missing-cost handling as UNMEASURED, not zero
+ *  - plan mode records 0-cost but keeps token counts
+ *
+ * @module observability/decision-cost.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { rollupDecisionCost, UNKNOWN_MODEL, type VoterCostInput } from './decision-cost.js';
+
+describe('rollupDecisionCost', () => {
+  describe('per-voter → per-decision totals (api mode)', () => {
+    it('sums tokens and cost across measured voters', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'architect',
+          model: 'claude-sonnet',
+          inputTokens: 1000,
+          outputTokens: 200,
+          costUsd: 0.006,
+        },
+        {
+          role: 'security',
+          model: 'claude-sonnet',
+          inputTokens: 500,
+          outputTokens: 100,
+          costUsd: 0.003,
+        },
+        {
+          role: 'devex',
+          model: 'gemini-flash',
+          inputTokens: 2000,
+          outputTokens: 400,
+          costUsd: 0.0016,
+        },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.voterCount).toBe(3);
+      expect(summary.measuredVoters).toBe(3);
+      expect(summary.unmeasuredVoters).toBe(0);
+      expect(summary.totalInputTokens).toBe(3500);
+      expect(summary.totalOutputTokens).toBe(700);
+      expect(summary.totalTokens).toBe(4200);
+      expect(summary.totalCostUsd).toBeCloseTo(0.0106, 9);
+      expect(summary.perVoter).toHaveLength(3);
+    });
+
+    it('preserves per-voter breakdown in input order', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'architect',
+          model: 'claude-opus',
+          inputTokens: 10,
+          outputTokens: 5,
+          costUsd: 0.001,
+        },
+        {
+          role: 'catfish',
+          model: 'gemini-flash',
+          inputTokens: 20,
+          outputTokens: 8,
+          costUsd: 0.0001,
+        },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.perVoter[0]?.role).toBe('architect');
+      expect(summary.perVoter[0]?.totalTokens).toBe(15);
+      expect(summary.perVoter[0]?.unmeasured).toBe(false);
+      expect(summary.perVoter[1]?.role).toBe('catfish');
+      expect(summary.perVoter[1]?.totalTokens).toBe(28);
+    });
+  });
+
+  describe('per-model breakdown', () => {
+    it('groups voters by model and sums per model', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'architect',
+          model: 'claude-sonnet',
+          inputTokens: 1000,
+          outputTokens: 200,
+          costUsd: 0.006,
+        },
+        {
+          role: 'security',
+          model: 'claude-sonnet',
+          inputTokens: 500,
+          outputTokens: 100,
+          costUsd: 0.003,
+        },
+        {
+          role: 'devex',
+          model: 'gemini-flash',
+          inputTokens: 2000,
+          outputTokens: 400,
+          costUsd: 0.0016,
+        },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.perModel).toHaveLength(2);
+      const sonnet = summary.perModel.find((m) => m.model === 'claude-sonnet');
+      const flash = summary.perModel.find((m) => m.model === 'gemini-flash');
+      expect(sonnet?.voterCount).toBe(2);
+      expect(sonnet?.inputTokens).toBe(1500);
+      expect(sonnet?.outputTokens).toBe(300);
+      expect(sonnet?.totalTokens).toBe(1800);
+      expect(sonnet?.costUsd).toBeCloseTo(0.009, 9);
+      expect(flash?.voterCount).toBe(1);
+      expect(flash?.totalTokens).toBe(2400);
+    });
+
+    it('sorts per-model breakdown by cost desc (highest spend first)', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'devex',
+          model: 'cheap-model',
+          inputTokens: 100,
+          outputTokens: 50,
+          costUsd: 0.0001,
+        },
+        {
+          role: 'architect',
+          model: 'pricey-model',
+          inputTokens: 100,
+          outputTokens: 50,
+          costUsd: 0.5,
+        },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.perModel[0]?.model).toBe('pricey-model');
+      expect(summary.perModel[1]?.model).toBe('cheap-model');
+    });
+  });
+
+  describe('missing-cost handling: UNMEASURED, not zero', () => {
+    it('counts a voter with no usage as unmeasured, not a measured $0', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'architect',
+          model: 'claude-sonnet',
+          inputTokens: 1000,
+          outputTokens: 200,
+          costUsd: 0.006,
+        },
+        // A CLI-subscription / error voter that reported NO usage:
+        { role: 'security', model: 'claude-cli' },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.voterCount).toBe(2);
+      expect(summary.measuredVoters).toBe(1);
+      expect(summary.unmeasuredVoters).toBe(1);
+      // The total is a FLOOR — the unmeasured voter contributes 0, not its
+      // unknown real cost.
+      expect(summary.totalCostUsd).toBeCloseTo(0.006, 9);
+      const unmeasured = summary.perVoter.find((v) => v.role === 'security');
+      expect(unmeasured?.unmeasured).toBe(true);
+      expect(unmeasured?.costUsd).toBe(0);
+      expect(unmeasured?.totalTokens).toBe(0);
+    });
+
+    it('treats a voter with no model as the unknown-model sentinel', () => {
+      const voters: VoterCostInput[] = [{ role: 'catfish' }];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.perVoter[0]?.model).toBe(UNKNOWN_MODEL);
+      expect(summary.perVoter[0]?.unmeasured).toBe(true);
+      expect(summary.perModel[0]?.model).toBe(UNKNOWN_MODEL);
+    });
+
+    it('a measured voter with zero cost (free model) is NOT unmeasured', () => {
+      // Reported tokens but a free model ⇒ measured, cost genuinely 0.
+      const voters: VoterCostInput[] = [
+        { role: 'devex', model: 'free-model', inputTokens: 500, outputTokens: 100, costUsd: 0 },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.measuredVoters).toBe(1);
+      expect(summary.unmeasuredVoters).toBe(0);
+      expect(summary.perVoter[0]?.unmeasured).toBe(false);
+      expect(summary.totalTokens).toBe(600);
+      expect(summary.totalCostUsd).toBe(0);
+    });
+  });
+
+  describe('plan mode: 0-cost recorded, token counts kept', () => {
+    it('zeroes every cost but preserves tokens', () => {
+      const voters: VoterCostInput[] = [
+        {
+          role: 'architect',
+          model: 'claude-sonnet',
+          inputTokens: 1000,
+          outputTokens: 200,
+          costUsd: 0.006,
+        },
+        {
+          role: 'security',
+          model: 'claude-sonnet',
+          inputTokens: 500,
+          outputTokens: 100,
+          costUsd: 0.003,
+        },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'plan');
+
+      expect(summary.billingMode).toBe('plan');
+      expect(summary.totalCostUsd).toBe(0);
+      expect(summary.perVoter.every((v) => v.costUsd === 0)).toBe(true);
+      expect(summary.perModel.every((m) => m.costUsd === 0)).toBe(true);
+      // Tokens are KEPT — plan mode still measures consumption.
+      expect(summary.totalInputTokens).toBe(1500);
+      expect(summary.totalOutputTokens).toBe(300);
+      expect(summary.totalTokens).toBe(1800);
+      // Token-reporting voters are still measured in plan mode.
+      expect(summary.measuredVoters).toBe(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles an empty panel (all zeros, no NaN)', () => {
+      const summary = rollupDecisionCost([], 'api');
+
+      expect(summary.voterCount).toBe(0);
+      expect(summary.measuredVoters).toBe(0);
+      expect(summary.unmeasuredVoters).toBe(0);
+      expect(summary.totalTokens).toBe(0);
+      expect(summary.totalCostUsd).toBe(0);
+      expect(summary.perVoter).toEqual([]);
+      expect(summary.perModel).toEqual([]);
+    });
+
+    it('rounds totals to micro-USD to avoid float drift', () => {
+      const voters: VoterCostInput[] = [
+        { role: 'a', model: 'm', inputTokens: 1, outputTokens: 1, costUsd: 0.1 },
+        { role: 'b', model: 'm', inputTokens: 1, outputTokens: 1, costUsd: 0.2 },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754; rounded to micro-USD = 0.3.
+      expect(summary.totalCostUsd).toBe(0.3);
+    });
+  });
+});

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -203,19 +203,7 @@ export function rollupDecisionCost(
     modelAcc.set(line.model, acc);
   }
 
-  const perModel: ModelCostBreakdown[] = [...modelAcc.entries()]
-    .map(([model, a]) => ({
-      model,
-      voterCount: a.count,
-      inputTokens: a.input,
-      outputTokens: a.output,
-      totalTokens: a.input + a.output,
-      costUsd: roundUsd(a.cost),
-    }))
-    .sort(
-      (x, y) =>
-        y.costUsd - x.costUsd || y.totalTokens - x.totalTokens || x.model.localeCompare(y.model)
-    );
+  const perModel = buildPerModelBreakdowns(modelAcc);
 
   return {
     billingMode,
@@ -229,4 +217,21 @@ export function rollupDecisionCost(
     perVoter,
     perModel,
   };
+}
+
+/** Aggregate the per-model accumulator into sorted {@link ModelCostBreakdown} rows. */
+function buildPerModelBreakdowns(modelAcc: Map<string, ModelAcc>): ModelCostBreakdown[] {
+  return [...modelAcc.entries()]
+    .map(([model, a]) => ({
+      model,
+      voterCount: a.count,
+      inputTokens: a.input,
+      outputTokens: a.output,
+      totalTokens: a.input + a.output,
+      costUsd: roundUsd(a.cost),
+    }))
+    .sort(
+      (x, y) =>
+        y.costUsd - x.costUsd || y.totalTokens - x.totalTokens || x.model.localeCompare(y.model)
+    );
 }

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -1,0 +1,232 @@
+/**
+ * decision-cost — per-DECISION cost aggregation over a governed panel's voters.
+ *
+ * Source: Issue #3855 (epic #3854 child, M4).
+ *
+ * A governed decision — a `consensus_vote` or `pr_review` run — fans out to N
+ * voter calls; each voter is one LLM call. Per-CALL usage telemetry already
+ * exists ({@link module:learning/usage-log} — token + cost per model call,
+ * PR #2479/#2480 era). This module is the AGGREGATION layer that rolls those
+ * per-call numbers UP into a single per-decision answer: "what did this
+ * governed decision cost?".
+ *
+ * It is a PURE rollup (no I/O, no clock, no env reads at the math layer):
+ * {@link rollupDecisionCost} takes the per-voter cost inputs + the billing mode
+ * and returns a {@link DecisionCostSummary} — total tokens, total USD, a
+ * per-voter breakdown, and a per-model breakdown. Persistence + the live
+ * `process.env` billing-mode read live in the callers (the store + the tools),
+ * mirroring the usage-log split between `computeCostUSD` (pure) and
+ * `recordUsageEvent` (I/O).
+ *
+ * Design decisions that the fixture tests pin (#3855 acceptance criteria):
+ *
+ *  - **Missing cost is UNMEASURED, not zero.** A voter with no token counts
+ *    (e.g. a CLI-subscription adapter that doesn't report usage, or an error
+ *    vote that never reached the model) is counted in `unmeasuredVoters` and
+ *    contributes 0 to the totals — but the summary records that the total is a
+ *    floor, not an exact figure (`measured` < `voterCount`). Treating unmeasured
+ *    as a true $0 would silently understate spend; this keeps the honesty.
+ *  - **Plan mode records 0-cost but keeps tokens.** Under `NEXUS_BILLING_MODE=plan`
+ *    the spend is pre-covered by a subscription, so cost is recorded as $0 while
+ *    token counts are preserved (so the operator can still see consumption and
+ *    a later `api`-mode reprice is possible). This mirrors how plan mode zeroes
+ *    cost in routing/scoring without dropping the token signal.
+ *
+ * @module observability/decision-cost
+ */
+
+/** Billing mode in effect for a decision. Mirrors `NEXUS_BILLING_MODE`. */
+export type DecisionBillingMode = 'plan' | 'api';
+
+/**
+ * One voter's measured (or unmeasured) cost contribution to a decision.
+ *
+ * Token counts and cost are OPTIONAL: a voter whose adapter reported no usage
+ * (CLI subscription, error vote, simulation) leaves them `undefined` and is
+ * folded in as `unmeasured` — never silently zeroed. `costUsd`, when present,
+ * is the API-mode cost (e.g. from `computeCostUSD`); plan mode zeroes it at
+ * rollup time but keeps the tokens.
+ */
+export interface VoterCostInput {
+  /** Voter role (e.g. 'architect', 'security'). */
+  readonly role: string;
+  /** Model id the voter call used, when known (e.g. 'claude-sonnet'). */
+  readonly model?: string | undefined;
+  /** Input tokens for the voter call, when the adapter reported them. */
+  readonly inputTokens?: number | undefined;
+  /** Output tokens for the voter call, when the adapter reported them. */
+  readonly outputTokens?: number | undefined;
+  /**
+   * API-mode cost in USD for the voter call, when computable. Absent ⇒ the
+   * voter is unmeasured (see module doc). Present ⇒ used as-is in `api` mode,
+   * zeroed in `plan` mode.
+   */
+  readonly costUsd?: number | undefined;
+}
+
+/** Per-voter line in the decision rollup. */
+export interface VoterCostBreakdown {
+  readonly role: string;
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  /** Effective cost after billing-mode application (0 in plan mode). */
+  readonly costUsd: number;
+  /**
+   * True when this voter reported NO usage at all (no tokens, no cost). Its
+   * zeros are placeholders, not a measured $0 / 0-token call.
+   */
+  readonly unmeasured: boolean;
+}
+
+/** Per-model rollup line within a single decision. */
+export interface ModelCostBreakdown {
+  readonly model: string;
+  readonly voterCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
+/** Sentinel model id for a voter call whose model is unknown. */
+export const UNKNOWN_MODEL = 'unknown';
+
+/**
+ * The per-decision cost rollup. Totals are a FLOOR when `unmeasuredVoters > 0`
+ * — read alongside `measuredVoters` / `voterCount` for the confidence.
+ */
+export interface DecisionCostSummary {
+  /** Billing mode applied to produce `totalCostUsd` (and per-line `costUsd`). */
+  readonly billingMode: DecisionBillingMode;
+  /** Total voters folded into this decision. */
+  readonly voterCount: number;
+  /** Voters that reported usage (tokens and/or cost). */
+  readonly measuredVoters: number;
+  /** Voters that reported no usage at all (counted, not zeroed-as-fact). */
+  readonly unmeasuredVoters: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly totalTokens: number;
+  /**
+   * Total cost in USD. 0 under `plan` mode by construction. A FLOOR when
+   * `unmeasuredVoters > 0` (unmeasured voters contribute 0, not their unknown
+   * real cost).
+   */
+  readonly totalCostUsd: number;
+  /** Per-voter breakdown, in input order. */
+  readonly perVoter: readonly VoterCostBreakdown[];
+  /** Per-model breakdown, sorted by total cost desc then total tokens desc. */
+  readonly perModel: readonly ModelCostBreakdown[];
+}
+
+/** A voter contributes usage iff it reported any token count or a cost. */
+function isMeasured(v: VoterCostInput): boolean {
+  return (
+    (v.inputTokens !== undefined && v.inputTokens > 0) ||
+    (v.outputTokens !== undefined && v.outputTokens > 0) ||
+    v.costUsd !== undefined
+  );
+}
+
+/** Round to micro-USD so summaries don't drift to floating-point noise. */
+function roundUsd(usd: number): number {
+  return Math.round(usd * 1_000_000) / 1_000_000;
+}
+
+/** Per-model accumulator used while folding voters. */
+interface ModelAcc {
+  input: number;
+  output: number;
+  cost: number;
+  count: number;
+}
+
+/**
+ * Resolve one voter into its per-decision breakdown line under the billing mode.
+ * Plan mode zeroes cost (tokens kept); unmeasured voters surface zeros flagged
+ * as placeholders.
+ */
+function toVoterBreakdown(v: VoterCostInput, isPlan: boolean): VoterCostBreakdown {
+  const measured = isMeasured(v);
+  const inputTokens = v.inputTokens ?? 0;
+  const outputTokens = v.outputTokens ?? 0;
+  // Plan mode: cost is pre-covered, record 0 but keep tokens. Api mode: use the
+  // supplied cost (a measured voter with no costUsd ⇒ 0, e.g. a free model).
+  const costUsd = isPlan ? 0 : roundUsd(v.costUsd ?? 0);
+  return {
+    role: v.role,
+    model: v.model ?? UNKNOWN_MODEL,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    costUsd,
+    unmeasured: !measured,
+  };
+}
+
+/**
+ * Roll N per-voter cost inputs up into one {@link DecisionCostSummary}.
+ *
+ * Pure and deterministic: no I/O, no clock, no env reads. `plan` mode zeroes
+ * every cost (tokens kept); `api` mode uses the supplied `costUsd`. Voters that
+ * reported no usage are counted in `unmeasuredVoters` and contribute zeros that
+ * are explicitly NOT a measured $0 (see module doc / `unmeasured` flag).
+ */
+export function rollupDecisionCost(
+  voters: readonly VoterCostInput[],
+  billingMode: DecisionBillingMode
+): DecisionCostSummary {
+  const isPlan = billingMode === 'plan';
+  const perVoter: VoterCostBreakdown[] = [];
+  const modelAcc = new Map<string, ModelAcc>();
+
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let totalCostUsd = 0;
+  let measuredVoters = 0;
+
+  for (const v of voters) {
+    const line = toVoterBreakdown(v, isPlan);
+    if (!line.unmeasured) measuredVoters++;
+    totalInputTokens += line.inputTokens;
+    totalOutputTokens += line.outputTokens;
+    totalCostUsd += line.costUsd;
+    perVoter.push(line);
+
+    const acc = modelAcc.get(line.model) ?? { input: 0, output: 0, cost: 0, count: 0 };
+    acc.input += line.inputTokens;
+    acc.output += line.outputTokens;
+    acc.cost += line.costUsd;
+    acc.count += 1;
+    modelAcc.set(line.model, acc);
+  }
+
+  const perModel: ModelCostBreakdown[] = [...modelAcc.entries()]
+    .map(([model, a]) => ({
+      model,
+      voterCount: a.count,
+      inputTokens: a.input,
+      outputTokens: a.output,
+      totalTokens: a.input + a.output,
+      costUsd: roundUsd(a.cost),
+    }))
+    .sort(
+      (x, y) =>
+        y.costUsd - x.costUsd || y.totalTokens - x.totalTokens || x.model.localeCompare(y.model)
+    );
+
+  return {
+    billingMode,
+    voterCount: voters.length,
+    measuredVoters,
+    unmeasuredVoters: voters.length - measuredVoters,
+    totalInputTokens,
+    totalOutputTokens,
+    totalTokens: totalInputTokens + totalOutputTokens,
+    totalCostUsd: roundUsd(totalCostUsd),
+    perVoter,
+    perModel,
+  };
+}

--- a/packages/nexus-agents/src/observability/index.ts
+++ b/packages/nexus-agents/src/observability/index.ts
@@ -61,6 +61,27 @@ export {
 } from './swarm-health-signals.js';
 export type { SwarmHealthSignalsOptions } from './swarm-health-signals.js';
 
+// Per-decision cost aggregation (#3855, epic #3854)
+export { rollupDecisionCost, UNKNOWN_MODEL } from './decision-cost.js';
+export type {
+  DecisionBillingMode,
+  VoterCostInput,
+  VoterCostBreakdown,
+  ModelCostBreakdown,
+  DecisionCostSummary,
+} from './decision-cost.js';
+export {
+  DecisionCostStore,
+  DecisionCostRecordSchema,
+  DecisionGateSchema,
+} from './decision-cost-store.js';
+export type {
+  DecisionCostRecord,
+  DecisionGate,
+  DecisionCostStoreConfig,
+  RecordDecisionCostInput,
+} from './decision-cost-store.js';
+
 // Adapter-failover → pipeline-bus signal producer (#3321)
 export {
   startFailoverSignals,


### PR DESCRIPTION
Closes #3855 (Epic G / M4, child of #3854).

## What

A governed decision — a `consensus_vote` or `pr_review` run — fans out to N voter LLM calls. Per-CALL usage telemetry already existed (`learning/usage-log.ts`: token + cost per model call, PR #2479/#2480 era). What was missing was the **aggregation** rolling those per-call numbers up into one per-decision answer: *"what did this governed decision cost?"*. This PR adds that rollup layer.

## Aggregation surface — rides existing telemetry, NO new MCP tool

The roadmap is explicit about the 47-tool ceiling, so this adds **no MCP tool** (tool count stays **46**; `governance:check` + `claims:check` confirm). The rollup is attached to the **existing decision responses**:

- `consensus_vote` → `ConsensusVoteResponse.costSummary`
- `pr_review` → `PrReviewResponse.costSummary`

…and persisted to a durable JSONL store so the question is answerable from recorded data later (feeds #3856 weather_report / manifest cost profiles and #3857 the cost doc).

Rides ON TOP OF the existing per-call layer: per-voter api-mode cost is derived via the same registry-backed `computeCostUSD` the per-call usage log uses, so a per-decision rollup and the per-call usage log price identically.

## Files

- `observability/decision-cost.ts` — the **pure** rollup `rollupDecisionCost()` (no I/O / clock / env at the math layer).
- `observability/decision-cost-store.ts` — durable persistence built on the shared `JsonlStore<T>` primitive (`config/jsonl-store.ts`, #3762) — no hand-rolled JSONL — under the shared learning dir, mirroring the OutcomeStore idiom. Stores only per-voter / per-model token + USD totals; never proposals, diffs, prompts, or outputs.
- `mcp/tools/decision-cost-recording.ts` — the consumer bridge: maps a panel's per-voter results into cost inputs (model now carried on `AgentVoteResult`), reads the live `NEXUS_BILLING_MODE`, rolls up + persists, returns the summary for the response. Best-effort — a rollup failure never fails the decision.
- `cli/vote-types.ts` + `cli/voter-agents.ts` — carry the executing `model` on `AgentVoteResult` so spend attributes per model.
- Wiring: `consensus-vote.ts`, `consensus-vote-types.ts` (`buildResponse`), `pr-review-tool.ts`.

## Rollup math + tests

`rollupDecisionCost(voters, billingMode)`:
- **per-voter → per-decision totals**: sums input/output/total tokens + cost across voters.
- **per-model breakdown**: groups by model, sorted by cost desc (then tokens desc).
- **missing-cost = UNMEASURED, not zero**: a voter whose adapter reported no usage is counted in `unmeasuredVoters` and contributes 0 — but the total is documented as a **floor** (`measuredVoters` < `voterCount`), never a measured \$0. A measured voter on a free model (tokens reported, cost 0) is *not* unmeasured.
- **plan mode**: `NEXUS_BILLING_MODE=plan` records 0-cost while **keeping token counts** (mirrors how plan mode zeroes cost in routing without dropping the token signal).
- micro-USD rounding to avoid float drift.

Fixture tests (19, all green):
- `observability/decision-cost.test.ts` (10) — the rollup math: totals, per-model breakdown + sort, unmeasured-not-zero, free-model-is-measured, plan-mode 0-cost-tokens-kept, empty panel, micro-USD rounding.
- `observability/decision-cost-store.test.ts` (4) — record-via-rollup, disk round-trip (hydrate), corrupt-line tolerance, gate/since filtering.
- `mcp/tools/decision-cost-recording.test.ts` (5) — vote→cost-input mapping, billing-mode resolution, end-to-end record path.

## Scope

Record + measure ONLY — no routing or weighting change. Per-voter token capture into `AgentVoteResult` is the next increment; today every voter is honestly reported as **unmeasured** (model captured, tokens not yet propagated from the adapter layer) — which is exactly the "unmeasured, not zero" behavior the acceptance criteria require. Live-run token sample is the BLOCKED-on-live-adapter evidence item per the issue.

## Verification

- `pnpm install --frozen-lockfile` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (26464 passed, 16 skipped, 0 failed)
- `pnpm build` ✓
- `pnpm lint` ✓ (pre-commit eslint --fix clean)
- `pnpm claims:check` ✓ (13/13)
- `pnpm governance:check` ✓ (MCP Tools: 46 — unchanged)
- producer/consumer export check ✓
- changeset added ✓

No README / docs-check.yml / inject-governance.ts / claims-registry touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)