### PR TITLE
docs(website): hero + positioning to the autonomic control-plane framing (#3861)

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -16,12 +16,12 @@ interface Props {
 
 const {
   title,
-  description = 'Governance substrate for AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry.',
+  description = 'Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, bounded self-tuning.',
   noindex = false,
 } = Astro.props;
 const siteTitle =
   title === 'Home'
-    ? 'Nexus Agents — Governance substrate for AI coding agents'
+    ? 'Nexus Agents — Autonomic control plane for AI coding agents'
     : `${title} — Nexus Agents`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
@@ -59,7 +59,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Nexus Agents",
-      "description": "Governance substrate for AI coding agents — adversarial review across Claude/Codex/Gemini/OpenCode, drift-detected rules, immutable audit chain, closed-loop telemetry. The substrate AI agents need to be trusted in production.",
+      "description": "Autonomic control plane for AI coding agents — one entry point, adversarial review across Claude/Codex/Gemini/OpenCode, tamper-evident hash-chained audit, bounded self-tuning. The agents are the data plane; nexus-agents admits, reviews, audits, and routes their work.",
       "url": Astro.site?.toString(),
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Cross-platform",
@@ -118,7 +118,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       <hr class="colophon-rule" />
       <div class="colophon-inner">
         <div class="colophon-left">
-          <p class="colophon-mark">Nexus Agents — governance substrate for AI coding agents.</p>
+          <p class="colophon-mark">Nexus Agents — autonomic control plane for AI coding agents.</p>
           <p class="colophon-meta">
             MIT licensed. Source at <a href="https://github.com/nexus-substrate/nexus-agents">github.com/nexus-substrate/nexus-agents</a>.
             Maintained by <a href="https://github.com/williamzujkowski">William Zujkowski</a>.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -16,7 +16,7 @@ import {
 
 <BaseLayout
   title="Home"
-  description="Governance substrate for AI coding agents — multi-model consensus, learning-aware routing, content-addressed audit chain. Works across Claude, Codex, Gemini, and OpenCode via MCP."
+  description="Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, bounded self-tuning. Works across Claude, Codex, Gemini, and OpenCode via MCP."
 >
   <!-- ─── Hero ─── -->
   <header class="hero">
@@ -31,14 +31,15 @@ import {
     </p>
 
     <h1 class="display hero-headline">
-      Governance for <span class="register-em">AI coding agents</span>.
+      A control plane for <span class="register-em">AI coding agents</span>.
     </h1>
 
     <p class="lede hero-lede">
-      Your agents already write the code. Nexus Agents enforces the rules they
-      follow, reviews their work adversarially via multi-model consensus, and
-      writes everything they touch to a content-addressed audit chain.
-      One MCP server. Every CLI you already have.
+      Your agents already write the code — they're the data plane. Nexus Agents
+      is the control plane above them: it admits work through one entry point,
+      reviews it adversarially before it ships, records every action in a
+      tamper-evident hash-chained audit log, and routes the next task based on
+      what actually worked. One MCP server. Every CLI you already have.
     </p>
 
     <div class="hero-actions">
@@ -172,37 +173,41 @@ nexus-agents setup</code></pre>
 
       <div class="pillars">
         <article class="pillar">
-          <p class="pillar-tag">consensus</p>
-          <h3 class="pillar-title">Multi-model consensus voting.</h3>
+          <p class="pillar-tag">admission control</p>
+          <h3 class="pillar-title">Adversarial review before it ships.</h3>
           <p class="pillar-body">
-            {CONSENSUS_ALGORITHM_COUNT} aggregation strategies — simple majority,
-            supermajority, unanimous, proof-of-learning, higher-order Bayesian.
-            Seven specialised voter roles. Run <code>consensus_vote</code> as an
-            MCP tool, or <code>nexus-agents vote</code> from your shell.
-            Decisions are recorded with per-voter reasoning and confidence.
+            The gate that catches what a data-plane agent would otherwise ship.
+            <code>pr_review</code> runs voter roles against a verification gate;
+            <code>consensus_vote</code> offers {CONSENSUS_ALGORITHM_COUNT}
+            aggregation strategies — simple majority, supermajority, unanimous,
+            proof-of-learning, higher-order Bayesian — across seven specialised
+            roles. Every decision is recorded with per-voter reasoning.
           </p>
         </article>
 
         <article class="pillar">
-          <p class="pillar-tag">routing</p>
-          <h3 class="pillar-title">Learning-aware routing.</h3>
+          <p class="pillar-tag">event log</p>
+          <h3 class="pillar-title">Tamper-evident hash-chained audit.</h3>
+          <p class="pillar-body">
+            Every model call, every vote, every routing choice flows through an
+            append-only, hash-chained audit log on disk. Replay any decision;
+            integrity is verifiable via <code>verify_audit_chain</code>. It is
+            tamper-evident, not tamper-proof — alteration is detectable, not
+            impossible. Drift detection fires when conventions slip.
+          </p>
+        </article>
+
+        <article class="pillar">
+          <p class="pillar-tag">closed loop</p>
+          <h3 class="pillar-title">Route the next task on evidence.</h3>
           <p class="pillar-body">
             A {ROUTING_STAGE_COUNT}-stage pipeline (budget → capability →
             preference → TOPSIS → LinUCB → latency) picks the right CLI from the
             {CLI_ADAPTER_COUNT} adapters you have installed. Outcomes feed
-            {MEMORY_BACKEND_COUNT} memory backends so tomorrow's routing is
-            informed by today's failures — not by static rules.
-          </p>
-        </article>
-
-        <article class="pillar">
-          <p class="pillar-tag">audit</p>
-          <h3 class="pillar-title">Content-addressed audit chain.</h3>
-          <p class="pillar-body">
-            Every model call, every vote, every research citation lands in a
-            content-addressed log on disk. Replay any decision, identify which
-            agent recommended what, when, with what evidence. Drift detection
-            fires when conventions slip.
+            {MEMORY_BACKEND_COUNT} memory backends so tomorrow's routing learns
+            from today's failures. A second bounded loop demotes unhealthy CLIs
+            automatically — capped, auto-decaying, demotion-only. Higher
+            authority is earned against evidence, never flipped on by default.
           </p>
         </article>
       </div>
@@ -222,9 +227,10 @@ nexus-agents setup</code></pre>
     <div class="article-body">
       <h2 class="headline section-headline">Architecture, briefly.</h2>
       <p class="lede section-lede">
-        Tasks enter through MCP, route through the pipeline, execute on whichever
-        CLI scored best, and get validated by consensus before outcomes feed back
-        into the router.
+        Control plane and data plane. Work is admitted through MCP, scheduled to
+        whichever CLI scored best, reviewed by consensus, and recorded in the
+        audit log — then outcomes feed back so the control plane routes the next
+        task on what actually worked.
       </p>
 
       <div class="mermaid diagram" aria-label="Architecture diagram: MCP protocol feeds the Orchestrator, which routes through a multi-stage pipeline to one of several CLIs. Consensus, memory, and audit run alongside. Outcomes feed back into the router.">


### PR DESCRIPTION
Implements Epic H **#3861** — updates the website hero and positioning copy to the autonomic-control-plane framing, consistent with the just-merged README repositioning (#3859 / Epic #3858).

## Hero / positioning changes

`website/src/pages/index.astro`:
- **Descriptor (page `description`):** "Governance substrate for AI coding agents …" → "Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, bounded self-tuning."
- **Headline:** "Governance for AI coding agents." → "A control plane for AI coding agents."
- **Lede:** rewritten around the control-plane / data-plane metaphor — agents are the data plane; nexus-agents admits work through one entry point, reviews adversarially, records to a tamper-evident hash-chained audit log, and routes the next task on what worked.
- **Pillars** re-tagged to the control-plane roles: `admission control` (adversarial review), `event log` (tamper-evident hash-chained audit), `closed loop` (evidence-based routing + bounded demotion-only tuning).
- **Architecture summary** lede reframed as control plane / data plane.

`website/src/layouts/BaseLayout.astro`:
- Default meta `description`, the Home `<title>`, the JSON-LD `SoftwareApplication.description`, and the footer colophon all moved from "governance substrate … immutable audit …" to the control-plane descriptor.

## Consistency with the README

Language mirrors the merged README: "Autonomic control plane for AI coding agents", control-plane vs data-plane, admission control / event log, and the self-* / closed-loop vocabulary.

## Honesty framing

- Uses **"tamper-evident"** (and spells out "tamper-evident, not tamper-proof — alteration is detectable, not impossible"), never "immutable" — matching the README and removing the prior "immutable audit" overstatement that was still live in `BaseLayout`.
- **Tightened the tagline per #3909:** rather than copy the README's "closed-loop self-tuning" headline (which reads as fully autonomous), the website says **"bounded self-tuning"** in the descriptor, and the closed-loop pillar makes the earned-promotion / demotion-only reality explicit — "capped, auto-decaying, demotion-only … higher authority is earned against evidence, never flipped on by default." A reader who sees only the headline does not infer full autonomy.

## Hygiene

- `pnpm build` (astro) green — 108 pages built; `pnpm check` 0 errors (only a pre-existing JSON-LD `is:inline` hint).
- No stale hardcoded counts: the website's quantified claims still flow from `site-data.ts` (`MCP_TOOL_COUNT = 46`, etc.); nothing hardcoded.
- `pnpm claims:check` stays **13/13** (website is not a claims-coverage subject — coverage scans `README.md`/`ARCHITECTURE.md` only).
- `pnpm governance:inject` produced no stamp change.
- **No changeset** — `check-changeset.ts` requires one only for `packages/nexus-agents/src/**`; website docs are not shippable src.

Scope confined to `website/` only (README, src, manifests, cost telemetry untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)