### PR TITLE
feat(observability): weather_report cost section + populate manifest costProfile (#3856)

### DIFF
--- a/.changeset/weather-report-cost-3856.md
+++ b/.changeset/weather-report-cost-3856.md
@@ -1,0 +1,41 @@
+---
+'nexus-agents': patch
+---
+
+feat(observability): surface decision costs in weather_report + populate manifest cost profiles (#3856)
+
+Epic G child of #3854 (M4). Builds on the #3855 per-decision cost aggregation to
+answer "what does a governed decision cost?" from recorded data, riding existing
+surfaces — NO new MCP tool.
+
+**weather_report cost section.** `weather_report` gains a `costSection` with two
+parts:
+
+- `decisionCosts` — windowed per-gate-type aggregates over the lookback window,
+  rolled up from the `DecisionCostStore` records (#3855) via a new PURE,
+  fixture-tested `aggregateDecisionCosts` (`observability/decision-cost-aggregate.ts`):
+  per `consensus_vote` / `pr_review` gate it reports decision count, average +
+  total cost (USD), average + total tokens, average voters, and the
+  measured/unmeasured voter split with a `costIsFloor` flag (averages understate
+  spend when some voter calls reported no usage — the same honesty the
+  per-decision rollup keeps). The store is only constructed when persistence is
+  enabled, so a persistence-off context surfaces an empty `decisionCosts` rather
+  than throwing; tests inject deterministic records.
+- `strategyCostProfiles` — each strategy's declared coarse `costProfile`, read
+  straight off the manifest registry (single source of truth) so the surfaced
+  hint can never drift from the authored manifest.
+
+**Manifest costProfile populated.** The Epic C `costProfile` field (#3834,
+optional until now) is DECLARED for all 8 live strategies, scaled by fan-out:
+`low` (single-shot), `medium` (dev-pipeline, pipeline), `high` (consensus,
+orchestrate, spec), `variable` (graph-workflow, research). Populated in
+`governance/strategy-manifests.yaml` AND mirrored in lockstep into
+`STRATEGY_MANIFEST_REGISTRY` (the #3837 drift gate + the YAML↔TS mirror test both
+stay green). A refresh path — re-grade against measured per-decision aggregates,
+reconcile both sources in lockstep — is documented in the YAML.
+
+BudgetRouter is unchanged: it routes over per-model token budgets, not the
+strategy `costProfile`, so there is no static-estimate site to replace (#3856
+acceptance criterion verified; changing routing policy/weights is out of scope).
+
+Record + surface only — no routing or weighting change.

--- a/governance/strategy-manifests.yaml
+++ b/governance/strategy-manifests.yaml
@@ -37,8 +37,22 @@
 # `enforce` — reaching `enforce` requires an earned evidence record + ratification
 # (the absorbed promotion cases #3552/#3769/#2077), never a default flip.
 #
-# costProfile (Epic G) stays OMITTED for the initial 8 (optional; populated when
-# Epic G lands).
+# costProfile (Epic G, #3856) is now DECLARED for every strategy as a COARSE cost
+# hint, scaled by the strategy's fan-out:
+#   low       a single model call (single-shot)
+#   medium    a templated multi-stage gate with bounded fan-out (dev-pipeline, pipeline)
+#   high      an N-voter panel / multi-agent orchestration / greenfield build
+#             (consensus, orchestrate, spec)
+#   variable  spend scales with input size — graph topology or research breadth
+#             (graph-workflow, research)
+# These are authored hints, surfaced in the weather_report cost section alongside
+# the MEASURED per-decision cost aggregates the DecisionCostStore records (#3855).
+#
+# Refresh path: as real decision-cost data accumulates (DecisionCostStore →
+# weather_report `decisionCosts` section), re-grade a strategy's costProfile against
+# its measured per-decision average and reconcile the hint here + the embedded TS
+# registry IN LOCKSTEP (the #3837 drift gate fails otherwise), then re-run
+# `pnpm strategy-manifest:check`.
 #
 # Adding a strategy = register a manifest here (and mirror it in the TS module),
 # NOT editing the router (Epic C, #3833). The router routes PURELY over the
@@ -58,6 +72,7 @@ manifests:
     maturityTier: stable
     latencyClass: single-llm
     authorityTier: suggest
+    costProfile: low
     selectionRules:
       - priority: 40
         patterns: [sequential]
@@ -73,6 +88,7 @@ manifests:
     maturityTier: stable
     latencyClass: pipeline
     authorityTier: suggest
+    costProfile: medium
     selectionRules:
       - priority: 30
         patterns: [sequential]
@@ -87,6 +103,7 @@ manifests:
     maturityTier: stable
     latencyClass: pipeline
     authorityTier: suggest
+    costProfile: medium
     selectionRules:
       - priority: 80
         pipelineTypes: [audit]
@@ -102,6 +119,7 @@ manifests:
     maturityTier: beta
     latencyClass: pipeline
     authorityTier: suggest
+    costProfile: variable
     selectionRules:
       - priority: 50
         patterns: [graph]
@@ -116,6 +134,7 @@ manifests:
     maturityTier: beta
     latencyClass: async-job-body
     authorityTier: suggest
+    costProfile: high
     selectionRules:
       - priority: 50
         patterns: [wave, aflow, puppeteer]
@@ -130,6 +149,7 @@ manifests:
     maturityTier: stable
     latencyClass: multi-llm-panel
     authorityTier: advisory
+    costProfile: high
     selectionRules:
       - priority: 100
         patterns: [consensus]
@@ -144,6 +164,7 @@ manifests:
     maturityTier: beta
     latencyClass: async-job-body
     authorityTier: suggest
+    costProfile: high
     selectionRules:
       - priority: 90
         pipelineTypes: [greenfield]
@@ -158,6 +179,7 @@ manifests:
     maturityTier: stable
     latencyClass: pipeline
     authorityTier: suggest
+    costProfile: variable
     selectionRules:
       - priority: 90
         pipelineTypes: [research]

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -12,6 +12,8 @@ import { z } from 'zod';
 import type { TaskCategory } from '../../config/task-specialization-types.js';
 import type { GroupStats } from '../../orchestration/outcomes/outcome-types.js';
 import { CLI_NAMES, type CliNameLiteral } from '../../config/model-capabilities-types.js';
+import type { DecisionCostReport } from '../../observability/decision-cost-aggregate.js';
+import type { StrategyCostProfileEntry } from '../../orchestration/strategy-manifest-registry.js';
 
 // ============================================================================
 // Input Schema
@@ -207,6 +209,20 @@ export interface TriageStats {
   readonly actionBreakdown: readonly { readonly action: string; readonly count: number }[];
 }
 
+/**
+ * Cost section of the weather report (Epic G, #3856). Answers "what do governed
+ * decisions cost?" by surfacing the MEASURED per-decision cost aggregates
+ * (DecisionCostStore, #3855) windowed by gate type, alongside each strategy's
+ * coarse declared `costProfile` from the manifest registry. Both ride existing
+ * surfaces — no new MCP tool.
+ */
+export interface CostSection {
+  /** Measured per-gate-type cost aggregates over the lookback window (#3855/#3856). */
+  readonly decisionCosts: DecisionCostReport;
+  /** Each strategy's declared coarse cost profile from the manifest registry. */
+  readonly strategyCostProfiles: readonly StrategyCostProfileEntry[];
+}
+
 /** Full weather report response. */
 export interface WeatherReportResponse {
   readonly overall: AdapterAttemptStats & {
@@ -236,6 +252,8 @@ export interface WeatherReportResponse {
   readonly swarmHealth?: SwarmHealthMetrics;
   /** Worker failure triage statistics (#1506). */
   readonly triageStats?: TriageStats;
+  /** Cost section: per-gate decision-cost aggregates + strategy cost profiles (Epic G, #3856). */
+  readonly costSection?: CostSection;
   /** Recent performance within the lookback window (#1401). */
   readonly recentWindow?: {
     readonly windowMs: number;

--- a/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
@@ -696,3 +696,85 @@ describe('swarmHealth in weather report', () => {
     expect(report.swarmHealth?.observedRoles).toBe(2);
   });
 });
+
+// ============================================================================
+// Cost section (Epic G, #3856)
+// ============================================================================
+
+function makeDecisionCostRecord(
+  gate: 'consensus_vote' | 'pr_review',
+  over: {
+    voterCount?: number;
+    measuredVoters?: number;
+    unmeasuredVoters?: number;
+    totalTokens?: number;
+    totalCostUsd?: number;
+  } = {}
+): import('../../observability/decision-cost-store.js').DecisionCostRecord {
+  const voterCount = over.voterCount ?? 0;
+  const measuredVoters = over.measuredVoters ?? voterCount;
+  return {
+    decisionId: `dc-${Math.random().toString(36).slice(2)}`,
+    gate,
+    timestamp: '2026-06-17T00:00:00.000Z',
+    summary: {
+      billingMode: 'api',
+      voterCount,
+      measuredVoters,
+      unmeasuredVoters: over.unmeasuredVoters ?? voterCount - measuredVoters,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalTokens: over.totalTokens ?? 0,
+      totalCostUsd: over.totalCostUsd ?? 0,
+      perVoter: [],
+      perModel: [],
+    },
+  };
+}
+
+describe('weather report cost section (#3856)', () => {
+  it('always surfaces strategy cost profiles from the manifest registry', () => {
+    const report = generateWeatherReport({});
+    expect(report.costSection).toBeDefined();
+    const profiles = report.costSection?.strategyCostProfiles ?? [];
+    expect(profiles.length).toBe(8);
+    const consensus = profiles.find((p) => p.strategy === 'consensus');
+    expect(consensus?.costProfile).toBe('high');
+    const singleShot = profiles.find((p) => p.strategy === 'single-shot');
+    expect(singleShot?.costProfile).toBe('low');
+  });
+
+  it('has empty decisionCosts when no decision-cost records are available', () => {
+    const report = generateWeatherReport({});
+    expect(report.costSection?.decisionCosts.byGate).toEqual([]);
+    expect(report.costSection?.decisionCosts.totalDecisions).toBe(0);
+  });
+
+  it('aggregates injected decision-cost records per gate type', () => {
+    const records = [
+      makeDecisionCostRecord('consensus_vote', {
+        voterCount: 7,
+        totalTokens: 1000,
+        totalCostUsd: 0.06,
+      }),
+      makeDecisionCostRecord('consensus_vote', {
+        voterCount: 5,
+        totalTokens: 2000,
+        totalCostUsd: 0.12,
+      }),
+      makeDecisionCostRecord('pr_review', {
+        voterCount: 5,
+        totalTokens: 800,
+        totalCostUsd: 0.02,
+      }),
+    ];
+    const report = generateWeatherReport({}, undefined, { decisionCostRecords: records });
+    const byGate = report.costSection?.decisionCosts.byGate ?? [];
+    expect(byGate.map((g) => g.gate)).toEqual(['consensus_vote', 'pr_review']);
+    const consensus = byGate.find((g) => g.gate === 'consensus_vote');
+    expect(consensus?.decisionCount).toBe(2);
+    expect(consensus?.avgCostUsd).toBeCloseTo(0.09, 6);
+    expect(consensus?.avgVoters).toBe(6);
+    expect(report.costSection?.decisionCosts.totalDecisions).toBe(3);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/weather-report.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.ts
@@ -44,13 +44,35 @@ import { computeAdaptiveThresholds } from '../../orchestration/outcomes/adaptive
 import { getRateLimitStats } from '../../adapters/rate-limit-detector.js';
 import { getToolStats } from '../middleware/tool-metrics.js';
 import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
-import type { AgentHealthSummary } from './weather-report-types.js';
+import type { AgentHealthSummary, CostSection } from './weather-report-types.js';
+import { isPersistenceEnabled } from '../../config/learning-persistence.js';
+import { aggregateDecisionCosts } from '../../observability/decision-cost-aggregate.js';
+import {
+  DecisionCostStore,
+  type DecisionCostRecord,
+} from '../../observability/decision-cost-store.js';
+import { strategyCostProfiles } from '../../orchestration/strategy-manifest-registry.js';
 
 // ============================================================================
 // Public API
 // ============================================================================
 
 const CLI_NAMES = ['claude', 'gemini', 'codex', 'opencode'] as const;
+
+/**
+ * Optional injectable dependencies for {@link generateWeatherReport} (#3856).
+ * The cost section reads persisted per-decision cost records; tests inject a
+ * deterministic set via {@link WeatherReportDeps.decisionCostRecords} rather than
+ * touching the durable {@link DecisionCostStore}.
+ */
+export interface WeatherReportDeps {
+  /**
+   * Pre-resolved decision-cost records to aggregate for the cost section. When
+   * omitted, the records are read from the durable {@link DecisionCostStore} iff
+   * persistence is enabled (no store is constructed when it is off).
+   */
+  readonly decisionCostRecords?: readonly DecisionCostRecord[];
+}
 
 /** Collect non-empty optional sections into a spread-friendly object. */
 function collectOptionalSections(sections: Record<string, unknown>): Record<string, unknown> {
@@ -89,7 +111,8 @@ function buildOptionalSections(
  */
 export function generateWeatherReport(
   input: WeatherReportOptions,
-  config?: Partial<WeatherReportConfig>
+  config?: Partial<WeatherReportConfig>,
+  deps?: WeatherReportDeps
 ): WeatherReportResponse {
   const cfg = { ...createDefaultWeatherConfig(), ...config };
   const store = getOutcomeStore();
@@ -108,6 +131,7 @@ export function generateWeatherReport(
     adaptiveBonuses: includeAdaptive ? computeAdaptiveBonuses(cfg) : [],
     tierRecommendations: buildTierRecommendations(summary),
     ...buildOptionalSections(input, cfg),
+    costSection: buildCostSection(cfg, deps),
     explorationRate: cfg.explorationRate,
     coldStartThreshold: cfg.coldStartThreshold,
     collectedAt: new Date().toISOString(),
@@ -159,6 +183,45 @@ function buildRecentWindow(cfg: WeatherReportConfig): WeatherReportResponse['rec
     successRate: round3(successes / recent.length),
     avgDurationMs: Math.round(totalDuration / recent.length),
   };
+}
+
+/**
+ * Builds the cost section (Epic G, #3856): MEASURED per-gate decision-cost
+ * aggregates over the lookback window + each strategy's declared cost profile.
+ *
+ * The strategy cost profiles always come from the manifest registry (pure). The
+ * decision-cost records come from `deps.decisionCostRecords` when injected
+ * (tests), else from the durable {@link DecisionCostStore} — but ONLY when
+ * persistence is enabled, so a persistence-off context (or a test that mocks it
+ * off) never constructs the store and the section degrades to an empty
+ * `decisionCosts` rather than throwing.
+ */
+function buildCostSection(cfg: WeatherReportConfig, deps?: WeatherReportDeps): CostSection {
+  const windowMs = cfg.outcomeLookbackMs;
+  const records = resolveDecisionCostRecords(windowMs, deps);
+  return {
+    decisionCosts: aggregateDecisionCosts(records, windowMs),
+    strategyCostProfiles: strategyCostProfiles(),
+  };
+}
+
+/**
+ * Resolves the decision-cost records to aggregate: the injected set when
+ * present, else the durable store windowed to the lookback (all history when
+ * `windowMs <= 0`). Returns `[]` when persistence is off so no store is built.
+ */
+function resolveDecisionCostRecords(
+  windowMs: number,
+  deps?: WeatherReportDeps
+): readonly DecisionCostRecord[] {
+  if (deps?.decisionCostRecords !== undefined) return deps.decisionCostRecords;
+  // Only construct the store when persistence is on — its constructor touches the
+  // learning dir, which a persistence-off (or test-mocked) context lacks.
+  if (!isPersistenceEnabled()) return [];
+  const store = new DecisionCostStore();
+  if (windowMs <= 0) return store.all();
+  const since = new Date(Date.now() - windowMs).toISOString();
+  return store.query({ since });
 }
 
 /** Builds rate limit report from tracked events (Issue #996). */

--- a/packages/nexus-agents/src/observability/decision-cost-aggregate.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-aggregate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Fixture tests for the pure cross-decision cost aggregation (#3856).
+ *
+ * Pins the per-gate windowed rollup the weather_report cost section surfaces:
+ *  - grouping records by gate type
+ *  - per-gate averages (cost / tokens / voters) over the decision count
+ *  - the measured/unmeasured voter split + the `costIsFloor` honesty flag
+ *  - deterministic sort (total cost desc, then gate name)
+ *
+ * @module observability/decision-cost-aggregate.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { aggregateDecisionCosts } from './decision-cost-aggregate.js';
+import type { DecisionCostRecord, DecisionGate } from './decision-cost-store.js';
+import type { DecisionCostSummary } from './decision-cost.js';
+
+/** Build a minimal decision-cost summary for a record fixture. */
+function summary(over: Partial<DecisionCostSummary> = {}): DecisionCostSummary {
+  return {
+    billingMode: 'api',
+    voterCount: 0,
+    measuredVoters: 0,
+    unmeasuredVoters: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalTokens: 0,
+    totalCostUsd: 0,
+    perVoter: [],
+    perModel: [],
+    ...over,
+  };
+}
+
+function record(
+  gate: DecisionGate,
+  over: Partial<DecisionCostSummary> = {},
+  id = `d-${Math.random().toString(36).slice(2)}`
+): DecisionCostRecord {
+  return { decisionId: id, gate, timestamp: '2026-06-17T00:00:00.000Z', summary: summary(over) };
+}
+
+describe('aggregateDecisionCosts', () => {
+  it('returns empty byGate for no records', () => {
+    const report = aggregateDecisionCosts([], 1000);
+    expect(report.byGate).toEqual([]);
+    expect(report.totalDecisions).toBe(0);
+    expect(report.totalCostUsd).toBe(0);
+    expect(report.windowMs).toBe(1000);
+  });
+
+  it('averages cost, tokens, and voters per gate over the decision count', () => {
+    const records: DecisionCostRecord[] = [
+      record('consensus_vote', {
+        voterCount: 7,
+        measuredVoters: 7,
+        totalTokens: 1000,
+        totalCostUsd: 0.06,
+      }),
+      record('consensus_vote', {
+        voterCount: 5,
+        measuredVoters: 5,
+        totalTokens: 2000,
+        totalCostUsd: 0.12,
+      }),
+    ];
+    const report = aggregateDecisionCosts(records, 0);
+    expect(report.byGate).toHaveLength(1);
+    const gate = report.byGate[0];
+    expect(gate?.gate).toBe('consensus_vote');
+    expect(gate?.decisionCount).toBe(2);
+    expect(gate?.avgCostUsd).toBeCloseTo(0.09, 6);
+    expect(gate?.avgTokens).toBe(1500);
+    expect(gate?.avgVoters).toBe(6); // (7 + 5) / 2
+    expect(gate?.totalCostUsd).toBeCloseTo(0.18, 6);
+    expect(gate?.totalTokens).toBe(3000);
+    expect(gate?.measuredVoters).toBe(12);
+    expect(gate?.costIsFloor).toBe(false);
+  });
+
+  it('groups by gate type and sorts by total cost desc', () => {
+    const records: DecisionCostRecord[] = [
+      record('pr_review', { voterCount: 5, measuredVoters: 5, totalCostUsd: 0.02 }),
+      record('consensus_vote', { voterCount: 7, measuredVoters: 7, totalCostUsd: 0.5 }),
+    ];
+    const report = aggregateDecisionCosts(records, 0);
+    expect(report.byGate.map((g) => g.gate)).toEqual(['consensus_vote', 'pr_review']);
+    expect(report.totalDecisions).toBe(2);
+    expect(report.totalCostUsd).toBeCloseTo(0.52, 6);
+  });
+
+  it('flags costIsFloor when any voter in the gate window was unmeasured', () => {
+    const records: DecisionCostRecord[] = [
+      record('pr_review', {
+        voterCount: 5,
+        measuredVoters: 4,
+        unmeasuredVoters: 1,
+        totalCostUsd: 0.03,
+      }),
+    ];
+    const report = aggregateDecisionCosts(records, 0);
+    const gate = report.byGate[0];
+    expect(gate?.unmeasuredVoters).toBe(1);
+    expect(gate?.measuredVoters).toBe(4);
+    expect(gate?.costIsFloor).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/observability/decision-cost-aggregate.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-aggregate.ts
@@ -1,0 +1,145 @@
+/**
+ * decision-cost-aggregate — windowed CROSS-decision cost rollups by gate type.
+ *
+ * Source: Issue #3856 (epic #3854 child, M4).
+ *
+ * Where {@link module:observability/decision-cost} rolls N voters UP into one
+ * per-decision summary, this module rolls N *decisions* up into one per-GATE
+ * answer: "across the recent window, what does a `consensus_vote` / `pr_review`
+ * decision cost on average?". It is the aggregation `weather_report` surfaces
+ * (#3856) so an operator sees what governed decisions are costing without a new
+ * MCP tool — the report reads the {@link DecisionCostStore}'s persisted records
+ * and folds them through this PURE function.
+ *
+ * Pure and deterministic: no I/O, no clock, no env reads. The caller supplies
+ * the records (already windowed/queried) and this returns the per-gate averages.
+ * Averages are reported alongside the decision count and the measured/unmeasured
+ * voter split so a reader knows the confidence — a per-gate average is a FLOOR
+ * when unmeasured voters contributed (their unknown real cost counts as 0), the
+ * same honesty {@link module:observability/decision-cost} keeps per-decision.
+ *
+ * @module observability/decision-cost-aggregate
+ */
+
+import type { DecisionGate, DecisionCostRecord } from './decision-cost-store.js';
+
+/** Per-gate windowed cost aggregate surfaced in the weather report (#3856). */
+export interface GateCostAggregate {
+  /** Which gate type these decisions came from. */
+  readonly gate: DecisionGate;
+  /** Number of decisions folded in. */
+  readonly decisionCount: number;
+  /** Mean total cost (USD) per decision over the window. */
+  readonly avgCostUsd: number;
+  /** Mean total tokens per decision over the window. */
+  readonly avgTokens: number;
+  /** Mean number of voters per decision. */
+  readonly avgVoters: number;
+  /** Sum of cost (USD) across all decisions in the window. */
+  readonly totalCostUsd: number;
+  /** Sum of tokens across all decisions in the window. */
+  readonly totalTokens: number;
+  /**
+   * Total voters that reported usage across the window. With `unmeasuredVoters`
+   * this is the confidence signal: the averages are a FLOOR when
+   * `unmeasuredVoters > 0` (unmeasured voters contribute 0, not their real cost).
+   */
+  readonly measuredVoters: number;
+  /** Total voters that reported no usage across the window. */
+  readonly unmeasuredVoters: number;
+  /**
+   * True when `unmeasuredVoters > 0` — the averages understate true spend
+   * because some voter calls reported no usage and were folded in as 0.
+   */
+  readonly costIsFloor: boolean;
+}
+
+/** The decision-cost section of the weather report (#3856). */
+export interface DecisionCostReport {
+  /** Lookback window the records were drawn from, in ms (0 ⇒ all history). */
+  readonly windowMs: number;
+  /** Per-gate-type aggregates, sorted by total cost desc then gate name. */
+  readonly byGate: readonly GateCostAggregate[];
+  /** Total decisions across all gates in the window. */
+  readonly totalDecisions: number;
+  /** Total cost (USD) across all gates in the window. */
+  readonly totalCostUsd: number;
+}
+
+/** Round to micro-USD so aggregates don't drift to floating-point noise. */
+function roundUsd(usd: number): number {
+  return Math.round(usd * 1_000_000) / 1_000_000;
+}
+
+/** Mutable per-gate accumulator used while folding records. */
+interface GateAcc {
+  decisions: number;
+  cost: number;
+  tokens: number;
+  voters: number;
+  measured: number;
+  unmeasured: number;
+}
+
+function emptyAcc(): GateAcc {
+  return { decisions: 0, cost: 0, tokens: 0, voters: 0, measured: 0, unmeasured: 0 };
+}
+
+/** Fold one record's summary into its gate accumulator. */
+function foldRecord(acc: GateAcc, record: DecisionCostRecord): void {
+  const s = record.summary;
+  acc.decisions += 1;
+  acc.cost += s.totalCostUsd;
+  acc.tokens += s.totalTokens;
+  acc.voters += s.voterCount;
+  acc.measured += s.measuredVoters;
+  acc.unmeasured += s.unmeasuredVoters;
+}
+
+/** Turn a gate accumulator into its reported aggregate (means + floor flag). */
+function toAggregate(gate: DecisionGate, acc: GateAcc): GateCostAggregate {
+  const n = acc.decisions;
+  return {
+    gate,
+    decisionCount: n,
+    avgCostUsd: n > 0 ? roundUsd(acc.cost / n) : 0,
+    avgTokens: n > 0 ? Math.round(acc.tokens / n) : 0,
+    avgVoters: n > 0 ? Math.round((acc.voters / n) * 10) / 10 : 0,
+    totalCostUsd: roundUsd(acc.cost),
+    totalTokens: acc.tokens,
+    measuredVoters: acc.measured,
+    unmeasuredVoters: acc.unmeasured,
+    costIsFloor: acc.unmeasured > 0,
+  };
+}
+
+/**
+ * Aggregate persisted per-decision cost records into a per-gate report (#3856).
+ *
+ * Pure: the caller supplies the already-windowed records and the `windowMs`
+ * they were drawn from (for the report header). Records are grouped by their
+ * gate type; each group's totals are averaged over its decision count. Returns
+ * an empty `byGate` when no records are supplied.
+ */
+export function aggregateDecisionCosts(
+  records: readonly DecisionCostRecord[],
+  windowMs: number
+): DecisionCostReport {
+  const byGate = new Map<DecisionGate, GateAcc>();
+  for (const record of records) {
+    const acc = byGate.get(record.gate) ?? emptyAcc();
+    foldRecord(acc, record);
+    byGate.set(record.gate, acc);
+  }
+
+  const aggregates = [...byGate.entries()]
+    .map(([gate, acc]) => toAggregate(gate, acc))
+    .sort((a, b) => b.totalCostUsd - a.totalCostUsd || a.gate.localeCompare(b.gate));
+
+  return {
+    windowMs,
+    byGate: aggregates,
+    totalDecisions: aggregates.reduce((sum, g) => sum + g.decisionCount, 0),
+    totalCostUsd: roundUsd(aggregates.reduce((sum, g) => sum + g.totalCostUsd, 0)),
+  };
+}

--- a/packages/nexus-agents/src/observability/index.ts
+++ b/packages/nexus-agents/src/observability/index.ts
@@ -82,6 +82,10 @@ export type {
   RecordDecisionCostInput,
 } from './decision-cost-store.js';
 
+// Cross-decision cost aggregation by gate type (#3856, epic #3854)
+export { aggregateDecisionCosts } from './decision-cost-aggregate.js';
+export type { GateCostAggregate, DecisionCostReport } from './decision-cost-aggregate.js';
+
 // Adapter-failover → pipeline-bus signal producer (#3321)
 export {
   startFailoverSignals,

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.test.ts
@@ -24,8 +24,13 @@ import {
   getStrategyManifest,
   selectStrategyByManifest,
   rankStrategiesByManifest,
+  strategyCostProfiles,
 } from './strategy-manifest-registry.js';
-import { parseStrategyManifestRegistry, type StrategyManifest } from './strategy-manifest.js';
+import {
+  parseStrategyManifestRegistry,
+  type StrategyManifest,
+  type CostProfile,
+} from './strategy-manifest.js';
 import { buildDefaultExecutors } from '../mcp/tools/run-tool.js';
 import type { ExecutionStrategy } from './meta-orchestrator.js';
 
@@ -345,6 +350,45 @@ describe('manifest-derived alternatives ranking (#3888 — split-brain fix)', ()
         augmented
       )
     ).toThrow(/equal-priority|ambiguous/i);
+  });
+});
+
+describe('cost profiles (Epic G, #3856)', () => {
+  /** The graded cost profile per strategy — the fan-out scaling #3856 authored. */
+  const EXPECTED_COST_PROFILES: Readonly<Record<ExecutionStrategy, CostProfile>> = {
+    'single-shot': 'low',
+    'dev-pipeline': 'medium',
+    pipeline: 'medium',
+    'graph-workflow': 'variable',
+    orchestrate: 'high',
+    consensus: 'high',
+    spec: 'high',
+    research: 'variable',
+  };
+
+  it('every live strategy declares a costProfile', () => {
+    for (const m of STRATEGY_MANIFEST_REGISTRY.manifests) {
+      expect(m.costProfile, `costProfile missing for '${m.strategy}'`).toBeDefined();
+    }
+  });
+
+  it('costProfile matches the graded fan-out scaling for all 8', () => {
+    for (const s of ALL_STRATEGIES) {
+      expect(getStrategyManifest(s)?.costProfile, `costProfile mismatch for '${s}'`).toBe(
+        EXPECTED_COST_PROFILES[s]
+      );
+    }
+  });
+
+  it('strategyCostProfiles() surfaces every strategy, sorted by name', () => {
+    const profiles = strategyCostProfiles();
+    expect(profiles).toHaveLength(ALL_STRATEGIES.length);
+    const names = profiles.map((p) => p.strategy);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    for (const p of profiles) {
+      expect(p.costProfile).toBe(EXPECTED_COST_PROFILES[p.strategy]);
+      expect(p.entrypointTool).toBe(entrypointToolFor(p.strategy));
+    }
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts
@@ -31,6 +31,7 @@ import {
   type SelectionRule,
 } from './strategy-manifest.js';
 import type { ExecutionStrategy } from './meta-orchestrator.js';
+import type { CostProfile } from './strategy-manifest.js';
 import type { WorkflowPattern } from './workflow-router-types.js';
 import type { PipelineType } from '../pipeline/adaptive-orchestrator.js';
 import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
@@ -41,8 +42,15 @@ import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analy
  * and machine-enforced (Epic D, #3841 — semantics in ADR-0017): work-producing
  * strategies are `suggest` (output inert until a human/governor acts), `consensus`
  * is `advisory` (non-blocking votes). None are `enforce` — that requires an earned
- * evidence record + ratification, never a default flip. `costProfile` (Epic G)
- * stays omitted until that epic populates it.
+ * evidence record + ratification, never a default flip. `costProfile` (Epic G,
+ * #3856) is now DECLARED for every strategy as a coarse cost hint, scaled by the
+ * strategy's fan-out: a single model call is `low`; a templated multi-stage gate is
+ * `medium`; an N-voter panel / multi-agent orchestration / greenfield build is
+ * `high`; a strategy whose spend scales with input size (graph topology, research
+ * breadth) is `variable`. These are authored hints surfaced in `weather_report`
+ * (the cost section) and refreshed against the measured per-decision aggregates the
+ * DecisionCostStore now records (#3855); the refresh path is documented in
+ * governance/strategy-manifests.yaml.
  */
 const RAW_REGISTRY: StrategyManifestRegistry = {
   version: 1,
@@ -59,6 +67,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'stable',
       latencyClass: 'single-llm',
       authorityTier: 'suggest',
+      // One model call — the cheapest engine.
+      costProfile: 'low',
       // Sequential + trivial complexity collapses to the lightest engine.
       selectionRules: [{ priority: 40, patterns: ['sequential'], complexities: ['simple'] }],
     },
@@ -74,6 +84,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'stable',
       latencyClass: 'pipeline',
       authorityTier: 'suggest',
+      // Multi-stage dev gate (test / lint / typecheck) — bounded fan-out.
+      costProfile: 'medium',
       // The default for any non-trivial sequential task (single-shot outranks it
       // only at `simple` complexity; the audit/template overrides outrank both).
       selectionRules: [{ priority: 30, patterns: ['sequential'] }],
@@ -90,6 +102,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'stable',
       latencyClass: 'pipeline',
       authorityTier: 'suggest',
+      // Templated multi-stage pipeline — bounded fan-out.
+      costProfile: 'medium',
       // The audit template is more specific than the plain sequential default:
       // it upgrades a sequential single-shot/dev-pipeline choice to the pipeline.
       selectionRules: [{ priority: 80, pipelineTypes: ['audit'], patterns: ['sequential'] }],
@@ -106,6 +120,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'beta',
       latencyClass: 'pipeline',
       authorityTier: 'suggest',
+      // Spend scales with the graph topology (node/edge count) — input-dependent.
+      costProfile: 'variable',
       selectionRules: [{ priority: 50, patterns: ['graph'] }],
     },
     {
@@ -120,6 +136,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'beta',
       latencyClass: 'async-job-body',
       authorityTier: 'suggest',
+      // Multi-agent fan-out (wave / aflow / puppeteer) — many model calls per run.
+      costProfile: 'high',
       selectionRules: [{ priority: 50, patterns: ['wave', 'aflow', 'puppeteer'] }],
     },
     {
@@ -133,6 +151,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'stable',
       latencyClass: 'multi-llm-panel',
       authorityTier: 'advisory',
+      // N independent voter calls per decision (up to the 7-voter panel) — high.
+      costProfile: 'high',
       // An explicit consensus requirement outranks every template/pattern choice.
       selectionRules: [{ priority: 100, patterns: ['consensus'] }],
     },
@@ -148,6 +168,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'beta',
       latencyClass: 'async-job-body',
       authorityTier: 'suggest',
+      // Greenfield multi-stage build from a spec — many model calls per run.
+      costProfile: 'high',
       // A greenfield template outranks the structural pattern fallback.
       selectionRules: [{ priority: 90, pipelineTypes: ['greenfield'] }],
     },
@@ -163,6 +185,8 @@ const RAW_REGISTRY: StrategyManifestRegistry = {
       maturityTier: 'stable',
       latencyClass: 'pipeline',
       authorityTier: 'suggest',
+      // Spend scales with research breadth (sources gathered, depth) — input-dependent.
+      costProfile: 'variable',
       // A research template outranks the structural pattern fallback.
       selectionRules: [{ priority: 90, pipelineTypes: ['research'] }],
     },
@@ -185,6 +209,31 @@ const BY_STRATEGY: ReadonlyMap<ExecutionStrategy, StrategyManifest> = new Map(
 /** Returns the manifest fronting a strategy, or undefined if none is registered. */
 export function getStrategyManifest(strategy: ExecutionStrategy): StrategyManifest | undefined {
   return BY_STRATEGY.get(strategy);
+}
+
+/** One strategy's declared cost profile, for the weather_report cost section (#3856). */
+export interface StrategyCostProfileEntry {
+  readonly strategy: ExecutionStrategy;
+  readonly entrypointTool: string;
+  /** The declared coarse cost hint; undefined for any manifest not yet populated. */
+  readonly costProfile: CostProfile | undefined;
+}
+
+/**
+ * The declared cost profile for every registered strategy (#3856). Surfaced in
+ * the weather report so a reader sees each strategy's coarse cost hint alongside
+ * the measured per-decision cost aggregates. Sorted by strategy name for a stable
+ * report. Reads straight off the manifest registry — the single source of truth —
+ * so the surfaced hint can never drift from the authored manifest.
+ */
+export function strategyCostProfiles(): readonly StrategyCostProfileEntry[] {
+  return STRATEGY_MANIFEST_REGISTRY.manifests
+    .map((m) => ({
+      strategy: m.strategy,
+      entrypointTool: m.entrypointTool,
+      costProfile: m.costProfile,
+    }))
+    .sort((a, b) => a.strategy.localeCompare(b.strategy));
 }
 
 /**

--- a/packages/nexus-agents/src/orchestration/strategy-manifest.ts
+++ b/packages/nexus-agents/src/orchestration/strategy-manifest.ts
@@ -187,9 +187,13 @@ export const MaturityTierSchema = z.enum(['experimental', 'beta', 'stable']);
 export type MaturityTier = z.infer<typeof MaturityTierSchema>;
 
 /**
- * Cost profile (Epic G). Placeholder vocabulary so manifests can be authored
- * with a coarse hint now; Epic G POPULATES real cost data and may extend this.
- * Optional on the manifest until Epic G lands.
+ * Cost profile (Epic G, #3856). A coarse cost hint scaled by a strategy's
+ * fan-out: `low` (one model call), `medium` (templated multi-stage gate), `high`
+ * (N-voter panel / multi-agent orchestration / greenfield build), `variable`
+ * (spend scales with input size — graph topology, research breadth). Populated
+ * for the live 8 manifests by #3856 and surfaced in the weather_report cost
+ * section alongside the measured per-decision aggregates (#3855). Stays optional
+ * on the schema so a future manifest can register before grading its profile.
  */
 export const CostProfileSchema = z.enum(['low', 'medium', 'high', 'variable']);
 export type CostProfile = z.infer<typeof CostProfileSchema>;
@@ -314,8 +318,10 @@ export const StrategyManifestSchema = z
      */
     authorityTier: AuthorityTierSchema.optional(),
     /**
-     * Cost profile — FORWARD-COMPAT for Epic G. Optional until Epic G populates
-     * real cost data; when present it must be a valid {@link CostProfile}.
+     * Cost profile (Epic G, #3856) — a coarse cost hint surfaced in the
+     * weather_report cost section. Populated for the live 8 manifests; stays
+     * optional so a future manifest can register before grading its profile.
+     * When present it must be a valid {@link CostProfile}.
      */
     costProfile: CostProfileSchema.optional(),
     /**


### PR DESCRIPTION
Epic G child of #3854 (M4). Fixes #3856. Surfaces what governed decisions cost, riding the #3855 per-decision cost surface — **no new MCP tool**.

> Note: stacked on **#3855** (per-decision cost aggregation). The #3855 branch is not currently on the remote, so this PR's diff includes its 2 commits (`decision-cost.ts`, `decision-cost-store.ts`, `decision-cost-recording.ts`). Review/merge #3855 first if it lands separately; the #3856-specific changes are the cost-section + costProfile work below.

## 1. weather_report cost section

`weather_report` gains a `costSection` with two parts:

- **`decisionCosts`** — windowed per-gate-type aggregates over the lookback window, rolled up from the `DecisionCostStore` records (#3855) via a new PURE, fixture-tested `aggregateDecisionCosts` (`observability/decision-cost-aggregate.ts`). Per `consensus_vote` / `pr_review` gate: `decisionCount`, `avgCostUsd` + `totalCostUsd`, `avgTokens` + `totalTokens`, `avgVoters`, the `measuredVoters` / `unmeasuredVoters` split, and a `costIsFloor` flag (averages understate spend when some voter calls reported no usage — the same honesty the per-decision rollup keeps). The store is only constructed when persistence is enabled, so a persistence-off context surfaces an empty `decisionCosts` rather than throwing; tests inject deterministic records via an optional `WeatherReportDeps`.
- **`strategyCostProfiles`** — each strategy's declared coarse `costProfile`, read straight off the manifest registry (single source of truth) via `strategyCostProfiles()`, so the surfaced hint can never drift from the authored manifest.

## 2. costProfile surfaced + populated

The Epic C `costProfile` field (#3834 schema; optional until now) is **DECLARED for all 8 live strategies**, graded by fan-out:

| profile | strategies |
| --- | --- |
| `low` | single-shot |
| `medium` | dev-pipeline, pipeline |
| `high` | consensus, orchestrate, spec |
| `variable` | graph-workflow, research |

Surfaced in `weather_report.costSection.strategyCostProfiles`.

**BudgetRouter**: verified — it routes over per-model token budgets, not the strategy `costProfile`, so there is no static-estimate site to replace (acceptance criterion #3 confirmed). Changing routing policy/weights is explicitly out of scope per #3856.

## Lockstep confirmation

`costProfile` populated in `governance/strategy-manifests.yaml` **and mirrored in lockstep** into `STRATEGY_MANIFEST_REGISTRY` (`strategy-manifest-registry.ts`). Verified green:
- `pnpm strategy-manifest:check` (exit 0) — YAML↔TS no-drift (#3837)
- `pnpm authority-tier:check` (exit 0) — tier declarations (#3841)
- the `strategy-manifest-registry.test.ts` YAML↔TS mirror test
- a refresh path (re-grade against measured aggregates, reconcile both sources in lockstep) is documented in the YAML.

## TDD / CI

- New tests: `decision-cost-aggregate.test.ts` (pure rollup fixtures), `strategy-manifest-registry.test.ts` cost-profile block, `weather-report.test.ts` cost-section block.
- `pnpm install --frozen-lockfile` ✓ · `typecheck` ✓ · `test` (1106 files, 26474 tests, 0 fail) ✓ · `build` ✓ · `lint` ✓ · `claims:check` 13/13 ✓ · `governance:check` (incl. manifest + authority-tier drift gates) ✓
- Changeset added (`.changeset/weather-report-cost-3856.md`).

No hardcoded MCP tool count introduced. `pnpm governance:inject` produced no version-stamp diff (tool/expert counts unchanged). No `inject-governance.ts` / `docs-check.yml` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)