### PR TITLE
docs: governed-decision cost doc (#3857) + org/scope naming ADR (#3862)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -13,6 +13,8 @@
   ],
   "ignoreRegExpList": ["/```[\\s\\S]*?```/g", "\\[.*?\\]\\(.*?\\)", "`[^`]+`"],
   "words": [
+    "lookback",
+    "devex",
     "autonomic",
     "MAPE",
     "dogfooded",

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,6 +175,7 @@ Detailed technical documentation:
 | [0015](./adr/0015-multi-repo-orchestration.md)           | Multi-Repo Orchestration           | Proposed   |
 | [0016](./adr/0016-multi-round-consensus-voting.md)       | Multi-Round Consensus Voting       | Accepted   |
 | [0017](./adr/0017-authority-ladder.md)                   | Authority Ladder                   | Accepted   |
+| [0018](./adr/0018-org-scope-naming.md)                   | Org/Scope Naming                   | Accepted   |
 
 #### Guides
 
@@ -210,6 +211,7 @@ Detailed technical documentation:
 | [docs-inventory.md](./ops/docs-inventory.md)                 | Documentation inventory        | Canonical |
 | [release-changeset-race.md](./ops/release-changeset-race.md) | Publish-race runbook (#2382)   | Canonical |
 | [git-housekeeping.md](./ops/git-housekeeping.md)             | Git GC cleanup runbook (#3062) | Canonical |
+| [governed-decision-cost.md](./ops/governed-decision-cost.md) | Governed-decision cost (#3857) | Canonical |
 
 #### Interfaces
 

--- a/docs/adr/0018-org-scope-naming.md
+++ b/docs/adr/0018-org-scope-naming.md
@@ -1,0 +1,168 @@
+---
+title: 'ADR 0018: Org and npm-Scope Naming under the Control-Plane Positioning'
+description: Decision framework for org + npm-scope naming under the Epic H autonomic-control-plane repositioning — keep nexus-substrate org and unscoped npm names as legacy lineage, with a documented forcing-function trigger for a future scope rename. Absorbs the deferred #2834 scope-rename decision.
+tier: 3
+keywords:
+  [
+    naming,
+    npm,
+    scope,
+    org,
+    nexus-substrate,
+    control-plane,
+    repositioning,
+    deferred,
+    trigger,
+    adr,
+    governance,
+  ]
+---
+
+# ADR 0018: Org and npm-Scope Naming under the Control-Plane Positioning
+
+**Status:** Accepted (deferred-trigger decision)
+**Date:** 2026-06-17
+**Context:** Epic H — Repositioning: autonomic control plane for AI coding agents
+(#3858); child #3862. **Absorbs** #2834 (deferred npm scope rename).
+**Ratification:** naming is architecture-adjacent → requires a **supermajority
+`consensus_vote`** per the governance thresholds; this ADR records the decision
+and its trigger conditions for that vote.
+
+## Decision
+
+**Keep the current names. Rename the category, not the project.**
+
+Under the autonomic-control-plane repositioning, nexus-agents:
+
+1. **Keeps the `nexus-substrate` GitHub org** as the project's lineage name.
+2. **Keeps unscoped npm package names** (`nexus-agents`, `nexus-memory`, and the
+   other unscoped workspace packages) — no rename to `@nexus-substrate/*`.
+3. **Repositions by description, not by identifier.** The "autonomic control
+   plane" framing is a _category_ change (how the project is described and
+   marketed); it is **not** a forcing function to rename the org, the repo, or the
+   npm packages.
+
+This is the decision framework, not a rename. A scope/org rename remains
+**deferred** until a concrete forcing function fires (see _Trigger Conditions_).
+This carries forward #2834's deferral verbatim rather than reopening it — the
+repositioning does **not** count as a trigger.
+
+## Context
+
+Issue #2834 deferred the `@nexus-substrate/*` npm scope rename. The 2026-05-17
+consensus vote treated it as YAGNI: a scope rename is a major-version event with deprecation
+shims that forces every consumer to update `package.json`, so do it **only** when a
+forcing function appears (name collision, governance/security requirement, or a
+supply-chain reason). Phase 1 of the org migration deliberately kept all npm names
+unscoped.
+
+Epic H repositions the project as an _autonomic control plane for AI coding
+agents_. The open question #3862 raises: does that repositioning **force** the
+deferred decision? Specifically — does "control plane" positioning require a name
+change, or does nexus-substrate stay as legacy lineage that we simply document?
+
+The repositioning is a _descriptor_ change. Every plank of the new descriptor maps
+to existing, verified code (one entry point = `run`/MetaOrchestrator; adversarial
+review = the panel + catfish; immutable audit = the hash chain; closed-loop
+self-tuning = the bounded tune loop). None of those planks depends on the project's
+_name_. A category rename and a project rename are independent decisions, and
+conflating them imports a costly, breaking change for a marketing benefit that does
+not require it.
+
+## Options Considered
+
+### Option A: Keep nexus-substrate org + unscoped npm names (RECOMMENDED)
+
+Treat the repositioning as category-only. Document `nexus-substrate` as the lineage
+name; ship the control-plane descriptor in README/docs/website without touching any
+identifier.
+
+- **Pros:** zero install-base breakage; no deprecation shims; no consumer
+  `package.json` churn; no redirect cost; orthogonal to the #2872 repo-move plan;
+  preserves #2834's YAGNI discipline; the repositioning ships _last_, on a verified
+  system, with no naming risk added.
+- **Cons:** the org name and the marketed category diverge (lineage name ≠
+  descriptor) — a documentation/onboarding nuance someone must explain; some may
+  read "nexus-substrate" as not signaling "control plane".
+
+### Option B: Rename npm packages to `@nexus-substrate/*` (scoped)
+
+Adopt the org scope on npm now, with deprecation shims for the unscoped names.
+
+- **Pros:** org-level package access control becomes possible; scope-level
+  discoverability; a single coherent namespace.
+- **Cons:** this is exactly the deferred #2834 event — a major-version break that
+  forces every consumer to update `package.json`; needs deprecation shims and a
+  redirect/changelog story; high effort for a benefit the repositioning does not
+  require; no forcing function has fired.
+
+### Option C: Rename the org/project itself (e.g. to a "control-plane" name)
+
+Rename the GitHub org and/or project to match the new category.
+
+- **Pros:** name and category fully aligned; strongest brand signal.
+- **Cons:** the largest breaking change of the three — repo redirects, npm renames,
+  doc/link rot, badge churn, lost lineage; collides with the #2872 repo-move plan;
+  category rename ≠ project rename (the #2834 principle); no forcing function;
+  highest risk on the epic that explicitly ships last on a verified system.
+
+## Trigger Conditions (when to re-open)
+
+This ADR stays in force until one of the following fires; the repositioning itself
+is explicitly **not** one of them. These carry #2834's re-evaluation triggers
+forward and add the positioning-era ones:
+
+- **Name collision** — an unscoped npm name we want is contested, or
+  `nexus-substrate` collides with another org/brand.
+- **Governance / security requirement** — we need org-level npm package access
+  control, scoped provenance, or a supply-chain control that requires a scope.
+- **Consumer-ecosystem discoverability** — a consumer ecosystem develops that
+  measurably benefits from scope-level discoverability.
+- **Repo-move forcing function** — the #2872 repo-move plan reaches a stage where a
+  rename is cheaper to do _with_ the move than separately.
+
+When a trigger fires, run a fresh **supermajority `consensus_vote`** with the
+forcing function as evidence (naming is architecture-adjacent). Until then, **do
+not propose a rename** — and treat a proposal lacking a documented trigger as out
+of contract.
+
+## Consequences
+
+### Positive
+
+- No install-base breakage, no deprecation shims, no consumer churn — the
+  repositioning ships with zero naming risk.
+- #2834's YAGNI discipline is preserved and given an explicit, documented home; the
+  deferred decision is now traceable to an ADR rather than a closed issue's prose.
+- The rename, if it ever happens, happens _with_ a forcing function and (ideally)
+  _with_ the #2872 repo move, amortizing the breakage once.
+
+### Negative
+
+- The lineage name (`nexus-substrate`) and the marketed category
+  (autonomic control plane) diverge; onboarding docs must explain that the org name
+  is lineage, not the product category.
+- A future rename, when triggered, will still pay the full major-version /
+  deprecation-shim cost — this ADR defers that cost, it does not remove it.
+
+## Migration Steps
+
+This is a **no-migration** decision. The only actions are documentary:
+
+1. Document `nexus-substrate` as the project's **lineage** name in the repositioned
+   README/docs (Epic H, #3859/#3860) — "the org name is the lineage; the category
+   is the autonomic control plane."
+2. Keep npm names unscoped; make **no** `package.json` name changes.
+3. **Close #2834** as absorbed by this ADR (decision: defer stands; trigger
+   conditions recorded here).
+4. If a trigger fires later, open a fresh issue with the forcing function as
+   evidence and run the supermajority ratification vote.
+
+## References
+
+- Epic: [#3858](https://github.com/nexus-substrate/nexus-agents/issues/3858) — repositioning: autonomic control plane
+- Issue: [#3862](https://github.com/nexus-substrate/nexus-agents/issues/3862) — this ADR (org/scope naming)
+- Absorbs: [#2834](https://github.com/nexus-substrate/nexus-agents/issues/2834) — deferred npm scope rename to `@nexus-substrate/*`
+- Related: [#2872](https://github.com/nexus-substrate/nexus-agents/issues/2872) — repo-move plan; [#2831](https://github.com/nexus-substrate/nexus-agents/issues/2831) — org migration (Phase 3 deferred)
+- Repositioning siblings: [#3859](https://github.com/nexus-substrate/nexus-agents/issues/3859) (README rewrite), [#3860](https://github.com/nexus-substrate/nexus-agents/issues/3860) (docs IA), [#3861](https://github.com/nexus-substrate/nexus-agents/issues/3861) (website hero)
+- Related ADRs: [ADR-0015](./0015-multi-repo-orchestration.md) (multi-repo orchestration), [ADR-0017](./0017-authority-ladder.md) (authority ladder — supermajority ratification pattern)

--- a/docs/ops/governed-decision-cost.md
+++ b/docs/ops/governed-decision-cost.md
@@ -1,0 +1,230 @@
+---
+title: 'What Does a Governed Decision Cost?'
+description: How a governed decision (consensus_vote / pr_review) accrues cost — per-voter rollup to per-decision summary, the measured-vs-unmeasured floor, plan vs api billing, reading the weather_report cost section, and what each strategy's costProfile means. Grounded in the shipped DecisionCostStore (#3855), the weather_report cost section (#3856), and the manifest cost profiles.
+tier: 2
+keywords:
+  [
+    cost,
+    governed-decision,
+    consensus,
+    pr-review,
+    weather-report,
+    billing,
+    costProfile,
+    tokens,
+    observability,
+    floor,
+    unmeasured,
+  ]
+---
+
+# What Does a Governed Decision Cost?
+
+**Status:** Active
+**Date:** 2026-06-17
+**Epic:** G — Cost telemetry per governed decision (#3854)
+**Sources:** #3855 (per-decision rollup), #3856 (weather_report + manifest cost
+profiles), #3857 (this doc)
+
+This is the honest answer to "what does a governed decision cost?" — grounded in
+the cost telemetry that actually ships, not in projected figures. It explains how
+cost accrues, what is measured today versus what is a known floor, and how to read
+the surfaces that report it.
+
+## TL;DR
+
+- A **governed decision** — a `consensus_vote` or `pr_review` run — fans out to N
+  independent voter calls. Cost is rolled up **per-voter → per-decision**: each
+  voter contributes `{role, model, inputTokens, outputTokens, costUsd}`, and the
+  decision summary totals them (`packages/nexus-agents/src/observability/decision-cost.ts`).
+- **Unmeasured is not $0.** A voter that reports no usage (a subscription-CLI
+  adapter that doesn't surface tokens, an error vote that never reached a model)
+  is counted as **unmeasured** and contributes 0 to the totals — but the summary
+  records that the total is a **floor**, not an exact figure.
+- **Billing mode** changes what the dollar figure means: `plan` records $0 cost
+  while keeping token counts (spend is pre-covered by a subscription); `api`
+  records the registry-priced dollar cost. Default is `plan`.
+- **As of this writing, per-voter token counts are largely unmeasured** pending
+  adapter propagation (#3910). Treat the dollar/token totals as a floor and the
+  per-decision counts (how many voters, which models) as the reliable signal until
+  #3910 lands.
+- The **weather_report** cost section surfaces per-gate-type aggregates over a
+  lookback window plus each strategy's declared `costProfile`.
+
+## How a governed decision accrues cost
+
+A governed decision is one panel run that fans out to multiple LLM calls:
+
+| Gate             | Panel                                                 | Roles                                                                       |
+| ---------------- | ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| `consensus_vote` | Up to a **7-voter** panel of independent perspectives | architect, security, devex, and more (strategy `consensus`, profile `high`) |
+| `pr_review`      | A **5-role** adversarial panel wrapping consensus     | architect, security, devex, catfish, scope_steward (`PR_REVIEW_EVAL_ROLES`) |
+
+Each voter is one model call. Per-call token + cost telemetry already existed (the
+usage log, `packages/nexus-agents/src/learning/usage-log.ts`). The cost-telemetry
+epic added the **aggregation** layer that rolls those per-call numbers up into one
+per-decision answer.
+
+The flow is:
+
+1. The panel runs; each voter returns a result carrying its `role`, `model`, and —
+   where the adapter reported them — `inputTokens` / `outputTokens`
+   (`votesToCostInputs` in `packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts`).
+2. Each voter's dollar cost, when tokens are present, is derived with the same
+   registry-backed `computeCostUSD` the per-call usage log uses — so a per-decision
+   rollup and the per-call log price identically.
+3. `rollupDecisionCost` (pure, in `observability/decision-cost.ts`) folds the N
+   voters into a `DecisionCostSummary`: total tokens, total USD, a per-voter
+   breakdown, a per-model breakdown, and the measured/unmeasured voter split.
+4. The summary is persisted one record per decision in the `DecisionCostStore`
+   (`observability/decision-cost-store.ts`, JSONL, bounded retention) and attached
+   to the decision response. **No new MCP tool** — it rides the existing surface.
+
+So "what did this decision cost?" is answerable from recorded data: read the
+`DecisionCostStore` record for the decision id, or the per-gate aggregate in the
+weather report.
+
+## The measured-vs-unmeasured floor (the honesty rule)
+
+The single most important thing to understand about these numbers: **a missing
+cost is treated as unmeasured, never as a true $0.**
+
+A voter contributes "measured" usage only if it reported a token count or a cost.
+A voter with none — a CLI-subscription adapter that does not surface usage, an
+error vote that never reached the model, a simulated vote — is folded in as
+**unmeasured**. It contributes 0 to the totals (there is nothing else it can
+contribute), but the summary records that fact:
+
+- `measuredVoters` / `unmeasuredVoters` / `voterCount` — the confidence split.
+- A total is a **floor** whenever `unmeasuredVoters > 0`: the real cost is _at
+  least_ this, because unmeasured voters' unknown real cost was counted as 0.
+
+Treating unmeasured as a real $0 would silently understate spend. The system
+refuses to do that. When you read any total, read it alongside the
+measured/unmeasured split. In the per-gate aggregate this is surfaced as an
+explicit `costIsFloor` boolean.
+
+> **Current state (#3910).** Per-voter token counts are largely **unmeasured**
+> today: the adapter layer does not yet propagate per-voter tokens through the
+> vote result for every adapter, and decision-cost drops are currently silent.
+> #3910 tracks both fixes. Until it lands, expect `unmeasuredVoters > 0` on most
+> decisions, the dollar/token totals to be a floor (often $0 under `plan` mode),
+> and the **reliable** signal to be the structural facts: how many voters, which
+> models, which gate. Do not quote a per-decision dollar figure as exact.
+
+## Plan vs api billing mode
+
+Cost is recorded under a billing mode (mirrors `NEXUS_BILLING_MODE`):
+
+| Mode   | Dollar cost recorded                 | Tokens recorded | When it applies                                                   |
+| ------ | ------------------------------------ | --------------- | ----------------------------------------------------------------- |
+| `plan` | **$0** (pre-covered by subscription) | kept            | Default. Subscription/CLI auth; spend is flat-rate, not per-token |
+| `api`  | registry-priced USD per voter call   | kept            | `NEXUS_BILLING_MODE=api`; metered per-token API keys              |
+
+Plan mode zeroes the dollar cost **but keeps the token counts**, so an operator can
+still see consumption and a later `api`-mode reprice is possible. This mirrors how
+plan mode zeroes cost in routing/scoring without dropping the token signal. The
+default resolves to `plan` (`resolveBillingMode` in `decision-cost-recording.ts`),
+so unless you have set `NEXUS_BILLING_MODE=api`, the dollar totals you see are $0 by
+construction — the meaningful number under plan mode is **tokens**, not dollars.
+
+## Reading the weather_report cost section
+
+`weather_report` carries a `costSection` (Epic G, #3856; see the `CostSection`
+type in `packages/nexus-agents/src/mcp/tools/weather-report-types.ts`) with two
+parts:
+
+### 1. Per-gate decision-cost aggregates (`decisionCosts`)
+
+`aggregateDecisionCosts`
+(`packages/nexus-agents/src/observability/decision-cost-aggregate.ts`) rolls the
+persisted per-decision records up into one per-gate answer over a lookback window:
+
+- `gate` — `consensus_vote` or `pr_review`.
+- `decisionCount` — how many decisions folded in.
+- `avgCostUsd`, `avgTokens`, `avgVoters` — the per-decision means.
+- `totalCostUsd`, `totalTokens` — the window sums.
+- `measuredVoters` / `unmeasuredVoters` — the confidence split.
+- `costIsFloor` — **true when any voter was unmeasured**: the averages understate
+  true spend.
+
+Read `costIsFloor` first. When it is true (the common case today, per #3910), the
+averages are a lower bound; lean on `avgVoters` and the per-gate decision count for
+the structural story rather than the dollar mean.
+
+### 2. Strategy cost profiles (`strategyCostProfiles`)
+
+Each registered strategy's declared `costProfile`, read straight off the manifest
+registry (the single source of truth — it cannot drift from the authored manifest).
+See the next section.
+
+## What each strategy's `costProfile` means
+
+`costProfile` is a **coarse, authored cost hint** scaled by a strategy's fan-out —
+not a measured dollar figure. The enum is
+`low | medium | high | variable`
+(`CostProfileSchema`, `packages/nexus-agents/src/orchestration/strategy-manifest.ts`).
+It is declared for every live strategy and refreshed against the measured
+per-decision aggregates the `DecisionCostStore` records.
+
+| Profile    | Meaning                                                         |
+| ---------- | --------------------------------------------------------------- |
+| `low`      | One model call — the cheapest engine                            |
+| `medium`   | A templated multi-stage gate — bounded fan-out                  |
+| `high`     | An N-voter panel / multi-agent orchestration / greenfield build |
+| `variable` | Spend scales with input size (graph topology, research breadth) |
+
+The eight live strategies (`packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts`):
+
+| Strategy         | Entrypoint tool      | `costProfile` | Why                                            |
+| ---------------- | -------------------- | ------------- | ---------------------------------------------- |
+| `single-shot`    | `delegate_to_model`  | `low`         | One model call                                 |
+| `dev-pipeline`   | `run_dev_pipeline`   | `medium`      | Multi-stage dev gate (test / lint / typecheck) |
+| `pipeline`       | `run_pipeline`       | `medium`      | Templated multi-stage pipeline                 |
+| `graph-workflow` | `run_graph_workflow` | `variable`    | Spend scales with graph topology               |
+| `orchestrate`    | `orchestrate`        | `high`        | Multi-agent fan-out (wave / aflow / puppeteer) |
+| `consensus`      | `consensus_vote`     | `high`        | Up to a 7-voter panel — N calls per decision   |
+| `spec`           | `execute_spec`       | `high`        | Greenfield multi-stage build from a spec       |
+| `research`       | `run_pipeline`       | `variable`    | Spend scales with research breadth             |
+
+A rough ordering of governed spend, then, runs from a `single-shot` delegate
+(`low`, one call) → a `dev-pipeline` / `pipeline` gate (`medium`, bounded stages) →
+a full `consensus_vote` or `pr_review` panel and `orchestrate` / `spec` runs
+(`high`, N calls per decision). `variable` strategies (graph, research) sit
+wherever their input size places them. These are hints for cost-aware routing, not
+billing-grade numbers — the billing-grade numbers come from the measured aggregates
+above once #3910 lands per-voter token propagation.
+
+## Methodology and variance notes
+
+- **Measured numbers come only from `api` billing mode with reporting adapters.**
+  Under `plan` mode (the default) the dollar figure is $0 by design; tokens are the
+  signal.
+- **All totals are a floor when `unmeasuredVoters > 0`.** This is the dominant
+  caveat today (#3910) — most per-decision totals are floors.
+- **Variance is real and not yet characterized.** Panel fan-out (a `consensus`
+  panel can run up to 7 voters; `pr_review` runs 5 roles), model mix, and prompt
+  size all move per-decision cost. The aggregate reports means over a window, not a
+  distribution; do not read `avgCostUsd` as a tight estimate.
+- **Any cost claim in README/positioning must trace to measured data**, not to
+  this doc's structural description. Until measured per-decision aggregates with
+  propagated per-voter tokens exist (#3910), positioning should describe the
+  _shape_ of governed-decision cost (per-voter rollup, floor honesty, profile
+  ordering) rather than quote a dollar figure. This honesty is the evidence base
+  for any future batch-mode decision (#2699).
+
+## References
+
+- Epic: [#3854](https://github.com/nexus-substrate/nexus-agents/issues/3854) — cost telemetry per governed decision
+- [#3855](https://github.com/nexus-substrate/nexus-agents/issues/3855) — per-voter per-decision cost aggregation
+- [#3856](https://github.com/nexus-substrate/nexus-agents/issues/3856) — weather_report + manifest cost profiles
+- [#3857](https://github.com/nexus-substrate/nexus-agents/issues/3857) — this doc
+- [#3910](https://github.com/nexus-substrate/nexus-agents/issues/3910) — propagate adapter per-voter tokens; make decision-cost drops non-silent
+- [#2699](https://github.com/nexus-substrate/nexus-agents/issues/2699) — batch-submission mode (cost data here is the trigger evidence)
+- Per-decision rollup: `packages/nexus-agents/src/observability/decision-cost.ts`
+- Persistence: `packages/nexus-agents/src/observability/decision-cost-store.ts`
+- Per-gate aggregate: `packages/nexus-agents/src/observability/decision-cost-aggregate.ts`
+- Recording bridge: `packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts`
+- Weather report cost section: `packages/nexus-agents/src/mcp/tools/weather-report-types.ts` (`CostSection`)
+- Strategy cost profiles: `packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts`, `strategy-manifest.ts` (`CostProfileSchema`)
+- MCP tool count: see `packages/nexus-agents/src/mcp/tools/tool-manifest.ts` (do not hardcode)


### PR DESCRIPTION
Two M4 documentation deliverables in one branch, with a **single** `docs/README.md` index update (to avoid index merge conflicts). Docs-only — no `src/`, manifests, root README, or website touched.

## Epic G — "What does a governed decision cost?" (#3857)

`docs/ops/governed-decision-cost.md` — the honest answer, grounded in the shipped cost surfaces (no projected numbers):

- **Accrual:** a governed decision (`consensus_vote` up to 7 voters, `pr_review` 5 roles) fans out to N voter calls; cost rolls up per-voter `{role, model, tokens, cost}` → per-decision summary (`rollupDecisionCost`, #3855), persisted in `DecisionCostStore`. No new MCP tool — rides the existing surface.
- **Floor semantics:** unmeasured ≠ $0. A voter with no usage is counted as `unmeasured` and contributes 0; totals are a **floor** when `unmeasuredVoters > 0` (`costIsFloor`).
- **Billing:** `plan` (default) records $0 but keeps tokens; `api` records registry-priced USD.
- **weather_report cost section** (#3856): per-gate aggregates (`aggregateDecisionCosts`) + each strategy's declared `costProfile`.
- **costProfile** meaning + the 8 live strategies (`low`/`medium`/`high`/`variable`).
- **Honesty:** notes per-voter tokens are largely **unmeasured today pending adapter propagation (#3910)** — does not overclaim; positioning should describe the cost *shape*, not quote a dollar figure. Evidence base for the future batch-mode decision (#2699). MCP tool count is referenced via `tool-manifest.ts`, never hardcoded.

## Epic H — Org/scope naming ADR (#3862, absorbs #2834)

`docs/adr/0018-org-scope-naming.md` — records the decision under the autonomic-control-plane repositioning.

- **Decision/recommendation:** **keep the current names — rename the category, not the project.** Keep the `nexus-substrate` org and unscoped npm names (`nexus-agents`, `nexus-memory`, …); the repositioning is a *descriptor* change and is explicitly **not** a forcing function to rename.
- **Options:** (A) keep org + unscoped names — **RECOMMENDED**; (B) rename packages to `@nexus-substrate/*` (the deferred #2834 break); (C) rename the org/project. Pros/cons each, weighing install-base breakage, the #2872 repo-move plan, redirect costs.
- **Deferred trigger:** stays in force until a forcing function fires (name collision; governance/security; consumer-ecosystem discoverability; repo-move). Then a fresh **supermajority `consensus_vote`** (naming = architecture-adjacent). Mirrors how #2834's deferral is handled — framework documented, no rename invented.
- **No-migration** decision; absorbs and closes #2834.

## Hygiene / gates

- Single `docs/README.md` index update: ADR-0018 row + ops `governed-decision-cost.md` row.
- `check-docs-indexed`: **0 unindexed**.
- markdownlint (`.markdownlint.json`, incl. MD060 tables): **clean**.
- cspell: added `lookback`, `devex` to `cspell.json`; new docs clean. (Pre-existing `worktree` flag on an untouched README line left as-is.)
- `pnpm claims:check`: **13/13** (unchanged).
- `pnpm governance:inject`: no version-stamp change (no canonical source touched).
- **No changeset** — docs + cspell config only, nothing shippable in `src/`.

Fixes #3857
Fixes #3862

🤖 Generated with [Claude Code](https://claude.com/claude-code)