### PR TITLE
feat(observability): propagate adapter per-voter tokens + non-silent cost drops (#3910)

### DIFF
--- a/.changeset/adapter-token-propagation-3910.md
+++ b/.changeset/adapter-token-propagation-3910.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': patch
+---
+
+feat(observability): propagate adapter per-voter tokens + make decision-cost drops non-silent (#3910)
+
+#3855 follow-up. Two items from the #3908 ratification.
+
+**Adapter token propagation.** The adapter layer already exposes per-call usage
+(`CompletionResponse.usage` — `inputTokens` / `outputTokens`), but the voter
+execution path discarded it, so every voter folded into the decision-cost rollup
+as `unmeasured`. `runVoteCompletion` now captures the reported usage and threads
+it up through `executeSingleVoteAttempt` → `executeWithRetries` →
+`executeAgentVote` into the new optional `AgentVoteResult.inputTokens` /
+`outputTokens` fields. The recording bridge reads them natively, so a voter whose
+adapter reports tokens now resolves to a MEASURED rollup. Reads are defensive: an
+adapter that does not report usage (CLI subscription, partial response) leaves the
+counts `undefined` and stays honestly `unmeasured` — never a fabricated 0.
+
+**Non-silent cost drops.** `JsonlStore.append` now returns whether the record was
+durably persisted (was `void`; backward-compatible for callers that ignore it).
+`DecisionCostStore.record` surfaces that flag, and the recording bridge logs a
+`warn` AND increments a process-lifetime counter (`getDroppedCostRecordCount`)
+when a rollup fails to persist — so dropped billing telemetry is visible rather
+than silently swallowed. The decision still never fails: the summary is always
+returned.
+
+Tests: a voter with adapter-provided tokens yields a MEASURED decision-cost
+rollup; a persistence failure is logged + counted (not silent) while still
+returning the summary; `JsonlStore.append` reports success/failure.

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -87,6 +87,19 @@ export interface AgentVoteResult {
    * for error/simulation votes that never reached a model.
    */
   readonly model?: string | undefined;
+  /**
+   * Input tokens the adapter reported for this voter's LLM call, when known
+   * (#3910). Propagated from `CompletionResponse.usage` so per-decision cost
+   * aggregation resolves from `unmeasured` to MEASURED. Absent for
+   * error/simulation votes that never reached a model, or for adapters that do
+   * not report usage (CLI subscriptions) — those stay honestly `unmeasured`.
+   */
+  readonly inputTokens?: number | undefined;
+  /**
+   * Output tokens the adapter reported for this voter's LLM call, when known
+   * (#3910). See {@link AgentVoteResult.inputTokens}.
+   */
+  readonly outputTokens?: number | undefined;
   /** Error message if vote fell back to simulation or encountered an error */
   readonly error?: string;
 }

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -18,6 +18,8 @@
 
 import type { VoterRole, AgentVoteResult } from './vote-types.js';
 import { VOTER_ROLES } from './vote-types.js';
+import type { Vote } from '../consensus/types.js';
+import type { VoteUsage } from './voter-execution.js';
 import type { IModelAdapter, ILogger } from '../core/index.js';
 import { createLogger, getTimeProvider, getErrorMessage } from '../core/index.js';
 import { getGlobalRegistry } from '../adapters/unified-registry.js';
@@ -125,6 +127,31 @@ export type { AgentVoteResult };
 const defaultLogger = createLogger({ component: 'voter-agents' });
 
 /**
+ * Builds the successful LLM `AgentVoteResult`, propagating the adapter-reported
+ * per-call tokens so the decision-cost rollup attributes this voter as MEASURED,
+ * not unmeasured (#3910). Only attaches a token field when the adapter actually
+ * reported it — an absent count stays absent (⇒ unmeasured), never a fabricated 0.
+ */
+function buildLlmVoteResult(
+  role: VoterRole,
+  vote: Vote,
+  usage: VoteUsage,
+  adapter: IModelAdapter,
+  processingTimeMs: number
+): AgentVoteResult {
+  return {
+    role,
+    vote,
+    processingTimeMs,
+    source: 'llm',
+    cli: adapter.providerId,
+    model: adapter.modelId,
+    ...(usage.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
+    ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
+  };
+}
+
+/**
  * Executes a real LLM vote for a single role with timeout and retry support.
  *
  * Per Issue #280: No simulation fallback by default. Returns error result
@@ -156,14 +183,7 @@ export async function executeAgentVote(
 
   if (result.ok) {
     logger.info('Vote completed', { role, model: adapter.modelId, decision: result.vote.decision });
-    return {
-      role,
-      vote: result.vote,
-      processingTimeMs,
-      source: 'llm',
-      cli: adapter.providerId,
-      model: adapter.modelId,
-    };
+    return buildLlmVoteResult(role, result.vote, result.usage, adapter, processingTimeMs);
   }
 
   // All retries exhausted

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -282,14 +282,32 @@ function isStructuredOutputUnsupported(errorMessage: string): boolean {
   return /support tool use/i.test(errorMessage);
 }
 
-/** One completion attempt: build → complete (timeout-bounded) → extract text. */
+/**
+ * Per-call token usage reported by the adapter for one voter completion (#3910).
+ * Propagated up so per-decision cost aggregation can attribute spend per voter.
+ *
+ * Token fields are OPTIONAL: an adapter that does not report usage (CLI
+ * subscription, or a `usage` object missing the counts) leaves them `undefined`
+ * so the voter stays honestly UNMEASURED downstream — never a fabricated 0.
+ */
+export interface VoteUsage {
+  readonly inputTokens?: number | undefined;
+  readonly outputTokens?: number | undefined;
+}
+
+/** Read a usage token count when the adapter actually reported a number (#3910). */
+function readTokenCount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** One completion attempt: build → complete (timeout-bounded) → extract text + usage. */
 async function runVoteCompletion(
   role: VoterRole,
   proposal: string,
   adapter: IModelAdapter,
   timeoutMs: number,
   withResponseFormat: boolean
-): Promise<{ ok: true; output: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; output: string; usage: VoteUsage } | { ok: false; error: string }> {
   const request = buildVoteRequest(role, proposal, timeoutMs, withResponseFormat);
   const timeoutResult = await withTimeout(
     adapter.complete(request),
@@ -299,7 +317,22 @@ async function runVoteCompletion(
   if (!timeoutResult.ok) return { ok: false, error: timeoutResult.error };
   const response = timeoutResult.value;
   if (!response.ok) return { ok: false, error: response.error.message };
-  return { ok: true, output: extractTextFromResponse(response.value.content) };
+  // #3910: capture the adapter-reported per-call usage so it can ride up into
+  // the AgentVoteResult and feed the decision-cost rollup as MEASURED. Cast
+  // through a loose shape: the type guarantees `usage`, but a real adapter (or a
+  // partial response) may omit the counts — read each defensively so a
+  // non-reporting call stays unmeasured rather than throwing or fabricating 0.
+  const reported = response.value.usage as unknown as
+    | {
+        inputTokens?: unknown;
+        outputTokens?: unknown;
+      }
+    | undefined;
+  const usage: VoteUsage = {
+    inputTokens: readTokenCount(reported?.inputTokens),
+    outputTokens: readTokenCount(reported?.outputTokens),
+  };
+  return { ok: true, output: extractTextFromResponse(response.value.content), usage };
 }
 
 export async function executeSingleVoteAttempt(
@@ -307,7 +340,9 @@ export async function executeSingleVoteAttempt(
   proposal: string,
   adapter: IModelAdapter,
   timeoutMs: number
-): Promise<{ ok: true; vote: Vote; output: string } | { ok: false; error: string }> {
+): Promise<
+  { ok: true; vote: Vote; output: string; usage: VoteUsage } | { ok: false; error: string }
+> {
   let completion = await runVoteCompletion(role, proposal, adapter, timeoutMs, true);
   // #3497: retry once WITHOUT responseFormat when the backend rejects the
   // tool-use-backed structured-output ask, so the panel keeps full strength.
@@ -320,7 +355,7 @@ export async function executeSingleVoteAttempt(
     // parseVoteResponse throws SyntheticVoteError if parsing fails — we only
     // accept real LLM votes, not synthetic fallbacks.
     const vote = parseVoteResponse(completion.output, role);
-    return { ok: true, vote, output: completion.output };
+    return { ok: true, vote, output: completion.output, usage: completion.usage };
   } catch (error) {
     if (error instanceof SyntheticVoteError) {
       return { ok: false, error: `Vote parsing failed: ${error.message}` };
@@ -345,7 +380,7 @@ export interface RetryOptions {
  */
 export async function executeWithRetries(
   opts: RetryOptions
-): Promise<{ vote: Vote; ok: true } | { error: string; ok: false }> {
+): Promise<{ vote: Vote; usage: VoteUsage; ok: true } | { error: string; ok: false }> {
   const { role, proposal, adapter, logger, timeoutMs, maxRetries } = opts;
   let lastError = '';
 
@@ -371,7 +406,7 @@ export async function executeWithRetries(
         attemptMs,
         succeeded: true,
       });
-      return { vote: result.vote, ok: true };
+      return { vote: result.vote, usage: result.usage, ok: true };
     }
 
     lastError = result.error;

--- a/packages/nexus-agents/src/config/jsonl-store.test.ts
+++ b/packages/nexus-agents/src/config/jsonl-store.test.ts
@@ -81,6 +81,14 @@ describe('JsonlStore', () => {
     expect(reopened.count()).toBe(0);
   });
 
+  it('reports persistence success/failure via the append return (#3910)', () => {
+    const store = makeStore();
+    // Durable write ⇒ true.
+    expect(store.append({ id: 1, name: 'ok' })).toBe(true);
+    // Schema-invalid record is dropped ⇒ false (so callers can log/count it).
+    expect(store.append({ id: 'bad', name: 1 } as unknown as Rec)).toBe(false);
+  });
+
   it('bounds retention to the last N records (oldest evicted)', () => {
     const max = 10;
     const store = makeStore(max);

--- a/packages/nexus-agents/src/config/jsonl-store.ts
+++ b/packages/nexus-agents/src/config/jsonl-store.ts
@@ -48,7 +48,9 @@ export interface JsonlStoreConfig<T> {
  *   exists, Zod-validating each line and skipping corrupt/invalid ones.
  * - {@link append}: validates the record, pushes it in-memory, and either
  *   appends one line (fast path) or — if the cap is exceeded — evicts the
- *   oldest in memory and rewrites the file so it stays bounded.
+ *   oldest in memory and rewrites the file so it stays bounded. Returns whether
+ *   the record was durably persisted so callers that must NOT silently drop
+ *   data (e.g. billing telemetry, #3910) can log/count a dropped record.
  * - All fs failures are caught and logged; persistence never throws into the
  *   caller (an observability sink must not break the operation it observes).
  */
@@ -68,25 +70,31 @@ export class JsonlStore<T> {
     this.hydrate();
   }
 
-  /** Append one record durably. Validates at the boundary; never throws. */
-  append(record: T): void {
+  /**
+   * Append one record durably. Validates at the boundary; never throws.
+   *
+   * Returns `true` when the record was durably written to disk, `false` when it
+   * was dropped (schema-invalid) or the fs write failed. Callers that ignore the
+   * return are unaffected (the prior `void` contract); callers that must surface
+   * dropped data (billing telemetry, #3910) can act on `false`.
+   */
+  append(record: T): boolean {
     const result = this.schema.safeParse(record);
     if (!result.success) {
       this.logger.warn('Refusing to persist invalid JSONL record', {
         path: this.filePath,
         issues: result.error.issues.map((i) => i.message).join('; '),
       });
-      return;
+      return false;
     }
     this.records.push(result.data);
     if (this.records.length > this.maxRecords) {
       // Over the cap: evict oldest in memory and rewrite the whole file so the
       // on-disk line count matches the bounded in-memory set.
       this.records.splice(0, this.records.length - this.maxRecords);
-      this.rewriteFile();
-      return;
+      return this.rewriteFile();
     }
-    this.persistLine(result.data);
+    return this.persistLine(result.data);
   }
 
   /** All retained records, oldest first. */
@@ -159,26 +167,30 @@ export class JsonlStore<T> {
     });
   }
 
-  private persistLine(record: T): void {
+  private persistLine(record: T): boolean {
     try {
       appendFileSync(this.filePath, JSON.stringify(record) + '\n', 'utf-8');
+      return true;
     } catch (error: unknown) {
       this.logger.warn('Failed to append JSONL record to disk', {
         error: getErrorMessage(error),
         path: this.filePath,
       });
+      return false;
     }
   }
 
-  private rewriteFile(): void {
+  private rewriteFile(): boolean {
     try {
       const content = this.records.map((r) => JSON.stringify(r)).join('\n') + '\n';
       writeFileSync(this.filePath, content, 'utf-8');
+      return true;
     } catch (error: unknown) {
       this.logger.warn('Failed to rewrite JSONL store file', {
         error: getErrorMessage(error),
         path: this.filePath,
       });
+      return false;
     }
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
@@ -13,12 +13,15 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import type { ILogger } from '../../core/index.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import { DecisionCostStore } from '../../observability/decision-cost-store.js';
 import {
   votesToCostInputs,
   recordDecisionCost,
   resolveBillingMode,
+  getDroppedCostRecordCount,
+  resetDroppedCostRecordCount,
 } from './decision-cost-recording.js';
 
 function vote(over: Partial<AgentVoteResult>): AgentVoteResult {
@@ -43,13 +46,14 @@ describe('votesToCostInputs', () => {
     expect(inputs[0]?.costUsd).toBeUndefined();
   });
 
-  it('derives api-mode cost from reported tokens via the shared pricing table', () => {
-    // A vote result carrying token counts (forward-compat shape).
-    const withTokens = {
-      ...vote({ role: 'security', model: 'claude-sonnet' }),
+  it('derives api-mode cost from adapter-reported tokens via the shared pricing table', () => {
+    // #3910: AgentVoteResult now carries the adapter's per-call token counts.
+    const withTokens = vote({
+      role: 'security',
+      model: 'claude-sonnet',
       inputTokens: 1000,
       outputTokens: 200,
-    };
+    });
     const inputs = votesToCostInputs([withTokens]);
     expect(inputs[0]?.inputTokens).toBe(1000);
     expect(inputs[0]?.outputTokens).toBe(200);
@@ -101,5 +105,92 @@ describe('recordDecisionCost', () => {
     expect(summary.unmeasuredVoters).toBe(2);
     expect(summary.totalCostUsd).toBe(0);
     expect(store.size).toBe(1);
+  });
+
+  it('a voter with adapter-provided tokens yields a MEASURED rollup (#3910)', () => {
+    const store = new DecisionCostStore({ filePath: join(dir, 'dc.jsonl'), dataDir: dir });
+    const summary = recordDecisionCost({
+      decisionId: 'd-measured',
+      gate: 'consensus_vote',
+      // Tokens now ride on AgentVoteResult straight from the adapter usage layer.
+      votes: [
+        vote({ role: 'architect', model: 'claude-sonnet', inputTokens: 1200, outputTokens: 300 }),
+        vote({ role: 'security', model: 'claude-sonnet', inputTokens: 800, outputTokens: 150 }),
+      ],
+      store,
+      billingMode: 'api',
+    });
+
+    // Resolves from unmeasured → MEASURED: both voters reported usage.
+    expect(summary.measuredVoters).toBe(2);
+    expect(summary.unmeasuredVoters).toBe(0);
+    expect(summary.totalInputTokens).toBe(2000);
+    expect(summary.totalOutputTokens).toBe(450);
+    expect(summary.totalTokens).toBe(2450);
+  });
+});
+
+describe('non-silent cost drops (#3910)', () => {
+  beforeEach(() => {
+    resetDroppedCostRecordCount();
+  });
+
+  /** A store whose persistence always reports a drop (fs/schema failure). */
+  function failingStore(): DecisionCostStore {
+    const store = new DecisionCostStore({ filePath: join(tmpdir(), 'unused.jsonl') });
+    // Simulate the JsonlStore reporting a failed persist without throwing.
+    (store as unknown as { record: (i: unknown) => unknown }).record = (input) => ({
+      record: {
+        decisionId: (input as { decisionId: string }).decisionId,
+        gate: (input as { gate: string }).gate,
+        timestamp: '2026-06-17T00:00:00.000Z',
+        summary: {
+          billingMode: 'api',
+          voterCount: 1,
+          measuredVoters: 1,
+          unmeasuredVoters: 0,
+          totalInputTokens: 100,
+          totalOutputTokens: 50,
+          totalTokens: 150,
+          totalCostUsd: 0.001,
+          perVoter: [],
+          perModel: [],
+        },
+      },
+      persisted: false,
+    });
+    return store;
+  }
+
+  it('logs AND counts a dropped rollup instead of silently swallowing it', () => {
+    const warnings: { message: string; context?: unknown }[] = [];
+    const logger: ILogger = {
+      debug: () => {},
+      info: () => {},
+      warn: (message, context) => {
+        warnings.push({ message, context });
+      },
+      error: () => {},
+      child: () => logger,
+      setLevel: () => {},
+    };
+
+    expect(getDroppedCostRecordCount()).toBe(0);
+
+    // Never throws into the caller — the decision still gets its summary.
+    const summary = recordDecisionCost({
+      decisionId: 'd-dropped',
+      gate: 'consensus_vote',
+      votes: [vote({ role: 'architect', model: 'claude-sonnet' })],
+      store: failingStore(),
+      billingMode: 'api',
+      logger,
+    });
+
+    expect(summary.totalCostUsd).toBe(0.001);
+    // Visible, not silent: counter incremented + warning logged.
+    expect(getDroppedCostRecordCount()).toBe(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain('dropped');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -20,13 +20,9 @@
  */
 
 import type { AgentVoteResult } from '../../cli/vote-types.js';
-import { getTimeProvider } from '../../core/index.js';
+import { createLogger, getTimeProvider, type ILogger } from '../../core/index.js';
 import { computeCostUSD } from '../../learning/usage-log.js';
-import {
-  DecisionCostStore,
-  type DecisionCostRecord,
-  type DecisionGate,
-} from '../../observability/decision-cost-store.js';
+import { DecisionCostStore, type DecisionGate } from '../../observability/decision-cost-store.js';
 import type {
   DecisionBillingMode,
   DecisionCostSummary,
@@ -47,12 +43,7 @@ export function resolveBillingMode(): DecisionBillingMode {
  * per-decision rollup and the per-call usage log price identically. When no
  * usage was reported the voter is left with no tokens/cost ⇒ unmeasured.
  */
-export function votesToCostInputs(
-  votes: readonly (AgentVoteResult & {
-    readonly inputTokens?: number | undefined;
-    readonly outputTokens?: number | undefined;
-  })[]
-): VoterCostInput[] {
+export function votesToCostInputs(votes: readonly AgentVoteResult[]): VoterCostInput[] {
   return votes.map((v) => {
     const hasTokens = v.inputTokens !== undefined || v.outputTokens !== undefined;
     const input: VoterCostInput = {
@@ -79,6 +70,30 @@ export interface RecordDecisionCostOptions {
   readonly store?: DecisionCostStore;
   /** Override the billing mode (testing); defaults to the env-resolved mode. */
   readonly billingMode?: DecisionBillingMode;
+  /** Override the logger (testing); defaults to a module logger. */
+  readonly logger?: ILogger;
+}
+
+const defaultLogger = createLogger({ component: 'decision-cost-recording' });
+
+/**
+ * Process-lifetime count of decision-cost rollups that FAILED to persist (#3910).
+ *
+ * The store is best-effort and never throws, so a dropped rollup is otherwise
+ * invisible. Incrementing a counter (and logging — see {@link recordDecisionCost})
+ * makes missing cost telemetry observable rather than silently swallowed. Reset
+ * is test-only.
+ */
+let droppedCostRecordCount = 0;
+
+/** Read the count of decision-cost rollups dropped at persist time (#3910). */
+export function getDroppedCostRecordCount(): number {
+  return droppedCostRecordCount;
+}
+
+/** Reset the dropped-cost-record counter (testing only, #3910). */
+export function resetDroppedCostRecordCount(): void {
+  droppedCostRecordCount = 0;
 }
 
 /**
@@ -88,18 +103,34 @@ export interface RecordDecisionCostOptions {
  * observability sink must not break the decision it observes), so on any
  * failure the rollup is still returned for the response. Riding the existing
  * surface — the caller attaches the returned `summary` to its result object.
+ *
+ * Non-silent drops (#3910): when the rollup fails to persist (fs error / schema
+ * reject) the store reports `persisted: false`; we log a warning AND increment a
+ * counter so dropped billing telemetry is visible, instead of vanishing. The
+ * decision still proceeds — the summary is always returned.
  */
 export function recordDecisionCost(options: RecordDecisionCostOptions): DecisionCostSummary {
   const billingMode = options.billingMode ?? resolveBillingMode();
   const voters = votesToCostInputs(options.votes);
   const store = options.store ?? new DecisionCostStore();
+  const logger = options.logger ?? defaultLogger;
   const timestamp = new Date(getTimeProvider().now()).toISOString();
-  const record: DecisionCostRecord = store.record({
+  const { record, persisted } = store.record({
     decisionId: options.decisionId,
     gate: options.gate,
     voters,
     billingMode,
     timestamp,
   });
+  if (!persisted) {
+    droppedCostRecordCount += 1;
+    logger.warn('Decision-cost rollup dropped (failed to persist) — billing telemetry lost', {
+      decisionId: options.decisionId,
+      gate: options.gate,
+      totalCostUsd: record.summary.totalCostUsd,
+      totalTokens: record.summary.totalTokens,
+      droppedCostRecordCount,
+    });
+  }
   return record.summary;
 }

--- a/packages/nexus-agents/src/observability/decision-cost-store.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-store.test.ts
@@ -44,7 +44,7 @@ describe('DecisionCostStore', () => {
 
   it('records a rollup and returns the persisted summary', () => {
     const store = new DecisionCostStore({ filePath: file, dataDir: dir });
-    const record = store.record({
+    const { record, persisted } = store.record({
       decisionId: 'd1',
       gate: 'consensus_vote',
       voters: VOTERS,
@@ -52,6 +52,7 @@ describe('DecisionCostStore', () => {
       timestamp: TS,
     });
 
+    expect(persisted).toBe(true);
     expect(record.decisionId).toBe('d1');
     expect(record.gate).toBe('consensus_vote');
     expect(record.summary.voterCount).toBe(2);

--- a/packages/nexus-agents/src/observability/decision-cost-store.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-store.ts
@@ -124,8 +124,14 @@ export class DecisionCostStore {
    * Roll up one decision's per-voter costs and persist the summary. Returns the
    * persisted record so the caller can attach `record.summary` to the existing
    * decision response (riding the existing surface — no new MCP tool, #3855).
+   *
+   * The boolean `persisted` flag (#3910) tells the caller whether the rollup was
+   * durably written: the underlying {@link JsonlStore} never throws on an fs/
+   * validation failure (an observability sink must not break the decision), so
+   * `false` is the ONLY signal that billing data was dropped — the recording
+   * bridge logs + counts it rather than letting it vanish silently.
    */
-  record(input: RecordDecisionCostInput): DecisionCostRecord {
+  record(input: RecordDecisionCostInput): { record: DecisionCostRecord; persisted: boolean } {
     const summary = rollupDecisionCost(input.voters, input.billingMode);
     const record: DecisionCostRecord = {
       decisionId: input.decisionId,
@@ -133,8 +139,8 @@ export class DecisionCostStore {
       timestamp: input.timestamp,
       summary,
     };
-    this.store.append(record);
-    return record;
+    const persisted = this.store.append(record);
+    return { record, persisted };
   }
 
   /** All retained records, oldest first. */


### PR DESCRIPTION
## #3910 — adapter per-voter token propagation + non-silent decision-cost drops

#3855 follow-up (the two items tracked from the #3908 ratification). Confined to the cost-telemetry path: `AgentVoteResult` + the voter execution/adapter usage path, the decision-cost recording bridge + store, and the `JsonlStore` persist signal. No docs/manifests touched.

### 1. How per-voter tokens now propagate (`unmeasured` → MEASURED)

The adapter layer already exposed per-call usage — `CompletionResponse.usage` carries `inputTokens` / `outputTokens` — but the voter execution path discarded it (it only extracted text), so every voter folded into the decision-cost rollup as `unmeasured` even on a real LLM call.

The plumbing now threads usage all the way through:

- **`voter-execution.ts`** — `runVoteCompletion` captures `response.value.usage` and returns it; it rides through `executeSingleVoteAttempt` → `executeWithRetries`. Reads are **defensive**: a call that reports no counts (CLI subscription, partial response) leaves them `undefined`, so the voter stays honestly `unmeasured` — never a fabricated 0.
- **`vote-types.ts`** — `AgentVoteResult` gains optional `inputTokens` / `outputTokens`.
- **`voter-agents.ts`** — the success-path result (extracted into `buildLlmVoteResult` to stay under the 50-line/complexity-10 lint caps) attaches each token field **only when the adapter actually reported it**.
- **`decision-cost-recording.ts`** — the bridge reads the native `AgentVoteResult` fields (drops the prior inline-cast shim). The existing `computeCostUSD` derivation is unchanged.

**Result:** a voter whose adapter reports tokens now yields a **MEASURED** decision-cost rollup (`measuredVoters` increments, totals are no longer a floor). No blocker — the adapter genuinely exposes per-call usage via the typed `CompletionResponse.usage`.

### 2. Non-silent cost drops

The recording bridge correctly never fails the decision, but a dropped rollup was previously invisible: `JsonlStore.append` swallowed fs/validation failures internally with no signal to the caller.

- **`JsonlStore.append`** now returns `boolean` (durably persisted vs dropped). Backward-compatible — `void` callers are unaffected.
- **`DecisionCostStore.record`** surfaces `{ record, persisted }`.
- **`recordDecisionCost`** logs a `warn` (with `decisionId`, `gate`, `totalCostUsd`, `totalTokens`) **and** increments a process-lifetime counter (`getDroppedCostRecordCount`) when `persisted === false`. Missing billing telemetry is now visible instead of silently swallowed. The decision still never fails — the summary is always returned.

### 3. Tests

- `decision-cost-recording.test.ts` — a voter with adapter-provided tokens yields a **MEASURED** rollup (`measuredVoters: 2`, `unmeasuredVoters: 0`, totals summed); a persistence failure is **logged + counted** (not silent) while still returning the summary.
- `jsonl-store.test.ts` — `append` reports persistence success (`true`) / drop (`false`).

### CI (local, all green)

`pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm test` (1106 files / 26477 tests passed), `pnpm build`, `pnpm lint`, `pnpm claims:check` (13/13), `pnpm governance:check`, producer/consumer unused-exports check — all pass. Changeset added (`patch`).

Fixes #3910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
