### PR TITLE
fix(audit/observability): fail-loud audit persist failures + rate-limit dropped-cost warn (#3916)

### DIFF
--- a/.changeset/audit-nonsilent-and-warn-ratelimit-3916.md
+++ b/.changeset/audit-nonsilent-and-warn-ratelimit-3916.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': patch
+---
+
+fix(audit/observability): fail-loud audit persist failures + rate-limit the dropped-cost warn (#3916)
+
+#3915 follow-up. Items 1 and 2 from the #3915 ratification (item 3 — counter
+export to the observability surface — is deferred).
+
+**Audit-log non-silent drop (fail-loud).** A silently-dropped audit/tier-transition
+event undermines the tamper-evident hash chain (ADR-0017 /
+`docs/security/audit-hash-chain-threat-model.md`). The audit log uses
+`FileAuditStorage`'s own buffered append (not `JsonlStore`), and a failed flush was
+previously swallowed by the flush-timer's `.catch` (a single error log, no counter,
+no escalation). `AuditLogger` now treats a persist failure as governance-critical
+and FAIL-LOUD: `flush()` records-then-rethrows so an awaiting governance caller
+still gets the error, while a shared handler logs prominently at `error` level
+(`AUDIT PERSIST FAILURE — audit event NOT durably written`), increments a
+process-lifetime counter (`getPersistFailureCount()`), and invokes an optional
+`onPersistFailure(error)` escalation hook (new optional ctor / `createAuditLogger`
+param). The periodic flush timer routes through the same handler so a failure that
+arrives via the timer is counted and surfaced rather than silent. This is stronger
+than the best-effort warn used for cost, because audit is governance-of-the-governor.
+
+**Rate-limit the dropped-cost warn.** `recordDecisionCost` previously warned on
+every `persisted === false`; an unwritable store (disk full / perms / I/O) would
+flood logs per-decision and could degrade the main path — ironically risking the
+never-fail invariant. The warn is now rate-limited (first-5 burst, then at most once
+per 1000 further drops) while the drop COUNTER still increments on EVERY drop (stays
+exact) and the decision still never fails. The emitted warn carries
+`suppressedSinceLastWarn` so one line accounts for the suppressed drops;
+`getDroppedCostWarnCount()` exposes the emitted-warn count for tests.
+
+Tests: a failed audit persist is surfaced (error-logged + counted + thrown, and the
+`onPersistFailure` hook fires) — NOT silent; a successful flush neither counts nor
+escalates; 200 consecutive cost drops produce a bounded number of warns (≤ 6, not
+one-per-drop) while the drop counter reflects all 200 and the decision still returns.

--- a/packages/nexus-agents/src/audit/audit-logger.test.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IAuditStorage, AuditEvent, AuditLogConfig } from './audit-types.js';
+import type { ILogger } from '../core/logger.js';
 
 vi.mock('../core/logger.js', () => ({
   createLogger: vi.fn(() => ({
@@ -388,6 +389,60 @@ describe('AuditLogger', () => {
       const l = new AuditLogger(makeConfig({ flushIntervalMs: 100 }), s);
       l.log(ev('test'));
       expect(() => vi.advanceTimersByTime(200)).not.toThrow();
+    });
+  });
+
+  describe('fail-loud on persist failure (#3916 / ADR-0017)', () => {
+    it('surfaces a failed flush — NOT silent: error-logged + counted + thrown', async () => {
+      // A failed audit persist undermines the tamper-evident hash chain, so it
+      // must fail loud rather than be swallowed like the best-effort cost path.
+      const errLog = vi.fn();
+      const failLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: errLog,
+        debug: vi.fn(),
+        child: vi.fn(),
+        setLevel: vi.fn(),
+      } as unknown as ILogger;
+      s.flush.mockRejectedValueOnce(new Error('disk full'));
+      const l = new AuditLogger(makeConfig(), s, failLogger);
+      l.log(ev('governance-critical'));
+
+      // (a) the awaited manual flush() rethrows (fail-loud to the caller)
+      await expect(l.flush()).rejects.toThrow('disk full');
+      // (b) prominent error log fired (not a quiet debug/warn)
+      expect(errLog).toHaveBeenCalledTimes(1);
+      expect(errLog.mock.calls[0]![0]).toContain('AUDIT PERSIST FAILURE');
+      // (c) the failure is counted/observable
+      expect(l.getPersistFailureCount()).toBe(1);
+    });
+
+    it('invokes the onPersistFailure escalation hook with the error', async () => {
+      const onFail = vi.fn();
+      s.flush.mockRejectedValueOnce(new Error('eio'));
+      const l = new AuditLogger(makeConfig(), s, undefined, onFail);
+      l.log(ev('tier-transition'));
+      await expect(l.flush()).rejects.toThrow('eio');
+      expect(onFail).toHaveBeenCalledTimes(1);
+      expect((onFail.mock.calls[0]![0] as Error).message).toBe('eio');
+    });
+
+    it('counts a flush failure that arrives via the periodic timer (not silent)', async () => {
+      s.write.mockRejectedValueOnce(new Error('disk full'));
+      const l = new AuditLogger(makeConfig({ flushIntervalMs: 100 }), s);
+      l.log(ev('via-timer'));
+      await vi.advanceTimersByTimeAsync(150);
+      expect(l.getPersistFailureCount()).toBe(1);
+    });
+
+    it('does not count or escalate a successful flush', async () => {
+      const onFail = vi.fn();
+      const l = new AuditLogger(makeConfig(), s, undefined, onFail);
+      l.log(ev('ok'));
+      await l.flush();
+      expect(l.getPersistFailureCount()).toBe(0);
+      expect(onFail).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/nexus-agents/src/audit/audit-logger.test.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.test.ts
@@ -428,6 +428,35 @@ describe('AuditLogger', () => {
       expect((onFail.mock.calls[0]![0] as Error).message).toBe('eio');
     });
 
+    it('isolates a throwing onPersistFailure hook — original audit error still rethrown + counted', async () => {
+      // A throwing escalation hook must NOT mask the real I/O error or break the
+      // record-then-rethrow path (and on a timer tick could risk an unhandled
+      // rejection). The hook's own failure is logged, not propagated.
+      const errLog = vi.fn();
+      const failLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: errLog,
+        debug: vi.fn(),
+        child: vi.fn(),
+        setLevel: vi.fn(),
+      } as unknown as ILogger;
+      const onFail = vi.fn(() => {
+        throw new Error('hook boom');
+      });
+      s.flush.mockRejectedValueOnce(new Error('eio'));
+      const l = new AuditLogger(makeConfig(), s, failLogger, onFail);
+      l.log(ev('tier-transition'));
+      // The ORIGINAL audit error rethrows (not the hook's 'hook boom').
+      await expect(l.flush()).rejects.toThrow('eio');
+      expect(onFail).toHaveBeenCalledTimes(1);
+      // Counter intact; both the audit failure and the hook failure are logged.
+      expect(l.getPersistFailureCount()).toBe(1);
+      const msgs = errLog.mock.calls.map((c) => String(c[0]));
+      expect(msgs.some((m) => m.includes('AUDIT PERSIST FAILURE — audit event'))).toBe(true);
+      expect(msgs.some((m) => m.includes('onPersistFailure hook threw'))).toBe(true);
+    });
+
     it('counts a flush failure that arrives via the periodic timer (not silent)', async () => {
       s.write.mockRejectedValueOnce(new Error('disk full'));
       const l = new AuditLogger(makeConfig({ flushIntervalMs: 100 }), s);

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -264,7 +264,18 @@ export class AuditLogger implements IAuditLogger {
       hashChainEnabled: this.enableHashChain,
     });
     if (this.onPersistFailure !== undefined) {
-      this.onPersistFailure(error);
+      // An escalation hook must never break the failure-recording path or mask
+      // the original audit error (it would otherwise throw past the counter +
+      // the flush() record-then-rethrow, replacing the real I/O error and — on
+      // a timer tick — risking an unhandled rejection). Isolate it.
+      try {
+        this.onPersistFailure(error);
+      } catch (hookErr) {
+        this.logger.error(
+          'AUDIT PERSIST FAILURE — onPersistFailure hook threw (original audit error preserved)',
+          hookErr instanceof Error ? hookErr : new AuditError(String(hookErr))
+        );
+      }
     }
   }
 

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -201,8 +201,15 @@ export class AuditLogger implements IAuditLogger {
   private closed = false;
   private inFlightFlush: Promise<void> | null = null;
   private droppedEventCount = 0;
+  private persistFailureCount = 0;
+  private readonly onPersistFailure: ((error: Error) => void) | undefined;
 
-  constructor(config: AuditLogConfig, storage?: IAuditStorage, logger?: ILogger) {
+  constructor(
+    config: AuditLogConfig,
+    storage?: IAuditStorage,
+    logger?: ILogger,
+    onPersistFailure?: (error: Error) => void
+  ) {
     const validated = AuditLogConfigSchema.safeParse(config);
     if (!validated.success) {
       const issues = validated.error.issues
@@ -218,6 +225,7 @@ export class AuditLogger implements IAuditLogger {
     this.flushIntervalMs = validated.data.flushIntervalMs;
     this.maxQueueDepth = validated.data.maxQueueDepth;
     this.storage = storage ?? new FileAuditStorage(validated.data, this.logger);
+    this.onPersistFailure = onPersistFailure;
 
     this.startFlushTimer();
     this.logger.info('AuditLogger initialized', { logDir: config.logDir });
@@ -228,10 +236,46 @@ export class AuditLogger implements IAuditLogger {
     // storage AND storage's own buffer must drain to disk on each tick.
     // See #2979.
     this.flushTimer = setInterval(() => {
-      this.flush().catch((err: unknown) => {
-        this.logger.error('Audit flush failed', err instanceof Error ? err : undefined);
+      // The timer fires into nobody, so it cannot rethrow to a caller. flush()
+      // itself runs the fail-loud handler (error-log + counter + callback) on
+      // failure — #3916 / ADR-0017 — so the timer just absorbs the rethrow here
+      // to avoid an unhandled rejection. The failure is already observable.
+      this.flush().catch(() => {
+        /* fail-loud handling already ran inside flush(); swallow the rethrow */
       });
     }, this.flushIntervalMs);
+  }
+
+  /**
+   * Fail-loud handler for an audit-persist failure (#3916). A dropped/failed
+   * audit write undermines the tamper-evident hash chain (ADR-0017 /
+   * docs/security/audit-hash-chain-threat-model.md), so unlike the best-effort
+   * cost path this is NOT swallowed: it logs prominently at error level,
+   * increments a process-lifetime counter (exposed via
+   * {@link getPersistFailureCount}), and invokes the optional `onPersistFailure`
+   * hook so a governance consumer can escalate (e.g. raise/alert). Callers on the
+   * awaited flush()/close() path additionally receive the thrown error directly.
+   */
+  private recordPersistFailure(err: unknown): void {
+    this.persistFailureCount += 1;
+    const error = err instanceof Error ? err : new AuditError(String(err));
+    this.logger.error('AUDIT PERSIST FAILURE — audit event NOT durably written', error, {
+      totalPersistFailures: this.persistFailureCount,
+      hashChainEnabled: this.enableHashChain,
+    });
+    if (this.onPersistFailure !== undefined) {
+      this.onPersistFailure(error);
+    }
+  }
+
+  /**
+   * Process-lifetime count of audit flushes that FAILED to persist (#3916). A
+   * non-zero value means at least one audit event was not durably written — the
+   * hash chain may have a gap. Surfaced so the failure is observable rather than
+   * silent.
+   */
+  getPersistFailureCount(): number {
+    return this.persistFailureCount;
   }
 
   private shouldLog(input: AuditEventInput): boolean {
@@ -463,9 +507,19 @@ export class AuditLogger implements IAuditLogger {
    */
   async flush(): Promise<void> {
     if (this.inFlightFlush !== null) return this.inFlightFlush;
-    const drain = this.drainAndFlushOnce().finally(() => {
-      this.inFlightFlush = null;
-    });
+    // Record-then-rethrow: a failed flush is fail-loud both ways — the counter +
+    // error-log + callback fire (observable even when the caller ignores the
+    // promise), AND the error still propagates to an awaiting governance caller
+    // (#3916). The single in-flight drain is shared, so the timer's catch and a
+    // concurrent awaited flush() both observe the same failure exactly once.
+    const drain = this.drainAndFlushOnce()
+      .catch((err: unknown) => {
+        this.recordPersistFailure(err);
+        throw err;
+      })
+      .finally(() => {
+        this.inFlightFlush = null;
+      });
     this.inFlightFlush = drain;
     return drain;
   }
@@ -492,7 +546,8 @@ export class AuditLogger implements IAuditLogger {
 export function createAuditLogger(
   config: AuditLogConfig,
   storage?: IAuditStorage,
-  logger?: ILogger
+  logger?: ILogger,
+  onPersistFailure?: (error: Error) => void
 ): AuditLogger {
-  return new AuditLogger(config, storage, logger);
+  return new AuditLogger(config, storage, logger, onPersistFailure);
 }

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
@@ -23,6 +23,7 @@ import {
   getDroppedCostRecordCount,
   getDroppedCostWarnCount,
   resetDroppedCostRecordCount,
+  _setWarnClockForTests,
 } from './decision-cost-recording.js';
 
 function vote(over: Partial<AgentVoteResult>): AgentVoteResult {
@@ -234,5 +235,44 @@ describe('non-silent cost drops (#3910)', () => {
     expect(warnCount).toBeGreaterThanOrEqual(1);
     expect(warnCount).toBeLessThanOrEqual(6);
     expect(warnCount).toBeLessThan(drops);
+  });
+
+  it('still warns on a SLOW leak after the silence window despite count suppression (#3916)', () => {
+    // Pure count-based suppression would hide a 1/hr leak for ~999 drops. The
+    // time escape surfaces it once the silence window elapses.
+    let warnCount = 0;
+    const logger: ILogger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {
+        warnCount += 1;
+      },
+      error: () => {},
+      child: () => logger,
+      setLevel: () => {},
+    };
+    const store = failingStore();
+    const drop = (id: string): void => {
+      recordDecisionCost({
+        decisionId: id,
+        gate: 'consensus_vote',
+        votes: [vote({ role: 'architect', model: 'claude-sonnet' })],
+        store,
+        billingMode: 'api',
+        logger,
+      });
+    };
+
+    _setWarnClockForTests(1_000_000);
+    for (let i = 0; i < 5; i++) drop(`burst-${String(i)}`); // first-5 burst → 5 warns
+    expect(warnCount).toBe(5);
+    drop('same-time-1'); // post-burst, no time elapsed, not 1000th → suppressed
+    drop('same-time-2');
+    expect(warnCount).toBe(5);
+    _setWarnClockForTests(1_000_000 + 60_000); // advance past the silence window
+    drop('after-window'); // time escape → warns even though count would suppress
+    expect(warnCount).toBe(6);
+    expect(getDroppedCostRecordCount()).toBe(8); // every drop still counted
+    _setWarnClockForTests(null);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
@@ -21,6 +21,7 @@ import {
   recordDecisionCost,
   resolveBillingMode,
   getDroppedCostRecordCount,
+  getDroppedCostWarnCount,
   resetDroppedCostRecordCount,
 } from './decision-cost-recording.js';
 
@@ -192,5 +193,46 @@ describe('non-silent cost drops (#3910)', () => {
     expect(getDroppedCostRecordCount()).toBe(1);
     expect(warnings).toHaveLength(1);
     expect(warnings[0]?.message).toContain('dropped');
+  });
+
+  it('rate-limits the warn under sustained drops while counting every drop (#3916)', () => {
+    // An unwritable store must not flood the log per-decision. Drive many
+    // consecutive drops and assert the warn count is BOUNDED (first-N burst,
+    // then suppressed) while the drop counter still reflects EVERY drop and the
+    // decision never fails.
+    let warnCount = 0;
+    const logger: ILogger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {
+        warnCount += 1;
+      },
+      error: () => {},
+      child: () => logger,
+      setLevel: () => {},
+    };
+    const store = failingStore();
+
+    const drops = 200;
+    for (let i = 0; i < drops; i++) {
+      const summary = recordDecisionCost({
+        decisionId: `d-${String(i)}`,
+        gate: 'consensus_vote',
+        votes: [vote({ role: 'architect', model: 'claude-sonnet' })],
+        store,
+        billingMode: 'api',
+        logger,
+      });
+      // Never-fail invariant holds on every iteration.
+      expect(summary.totalCostUsd).toBe(0.001);
+    }
+
+    // Counter is exact: every drop counted.
+    expect(getDroppedCostRecordCount()).toBe(drops);
+    // Warns are bounded, NOT one-per-drop (first-5 burst, then periodic).
+    expect(warnCount).toBe(getDroppedCostWarnCount());
+    expect(warnCount).toBeGreaterThanOrEqual(1);
+    expect(warnCount).toBeLessThanOrEqual(6);
+    expect(warnCount).toBeLessThan(drops);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -105,18 +105,46 @@ export function getDroppedCostRecordCount(): number {
  */
 const WARN_BURST = 5;
 const WARN_PERIOD = 1000;
+// Never stay silent longer than this on a SLOW leak (#3916): pure count-based
+// suppression (every 1000th) would hide ~999 drops for ~41 days at 1/hr. A
+// time escape surfaces a persistent low-rate failure within the window.
+const WARN_MAX_SILENCE_MS = 60_000;
 let warnCountSinceReset = 0;
+let lastWarnAtMs = 0;
+let warnClockOverrideMs: number | null = null;
 
-/** Whether this drop should emit a warn under the first-N-then-periodic limiter. */
+/** Testing seam: pin the warn-limiter clock (#3916). Pass null to use real time. */
+export function _setWarnClockForTests(ms: number | null): void {
+  warnClockOverrideMs = ms;
+}
+
+function warnNowMs(): number {
+  return warnClockOverrideMs ?? Date.now();
+}
+
+/**
+ * Whether this drop should emit a warn: the first {@link WARN_BURST} consecutive
+ * drops, then every {@link WARN_PERIOD}-th, OR after {@link WARN_MAX_SILENCE_MS}
+ * of silence (so a slow leak still surfaces rather than being suppressed for
+ * thousands of drops). Side effect: anchors the silence timer on each emitted warn.
+ */
 function shouldWarnForDrop(dropIndex: number): boolean {
-  if (dropIndex <= WARN_BURST) return true;
-  return (dropIndex - WARN_BURST) % WARN_PERIOD === 0;
+  const now = warnNowMs();
+  const countTrigger = dropIndex <= WARN_BURST || (dropIndex - WARN_BURST) % WARN_PERIOD === 0;
+  const timeTrigger = dropIndex > WARN_BURST && now - lastWarnAtMs >= WARN_MAX_SILENCE_MS;
+  if (countTrigger || timeTrigger) {
+    lastWarnAtMs = now;
+    return true;
+  }
+  return false;
 }
 
 /** Reset the dropped-cost-record counter and warn limiter (testing only, #3910/#3916). */
 export function resetDroppedCostRecordCount(): void {
   droppedCostRecordCount = 0;
   warnCountSinceReset = 0;
+  lastWarnAtMs = 0;
+  warnClockOverrideMs = null;
 }
 
 /** Read how many dropped-cost warns have actually been emitted (testing, #3916). */

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -91,9 +91,37 @@ export function getDroppedCostRecordCount(): number {
   return droppedCostRecordCount;
 }
 
-/** Reset the dropped-cost-record counter (testing only, #3910). */
+/**
+ * Warn rate-limiter for dropped cost rollups (#3916).
+ *
+ * If the store goes unwritable (disk full / perms / I/O), a per-decision warn
+ * would flood the logs and could degrade the main decision path — ironically
+ * risking the never-fail invariant the warn exists to protect. So the warn is
+ * rate-limited: emit it for the first {@link WARN_BURST} consecutive drops, then
+ * at most once per {@link WARN_PERIOD} further drops. The COUNTER still
+ * increments on EVERY drop (it stays exact regardless of suppression), and the
+ * decision still never fails. The emitted warn carries `suppressedSinceLastWarn`
+ * so a reader can see how many drops a single line stands in for.
+ */
+const WARN_BURST = 5;
+const WARN_PERIOD = 1000;
+let warnCountSinceReset = 0;
+
+/** Whether this drop should emit a warn under the first-N-then-periodic limiter. */
+function shouldWarnForDrop(dropIndex: number): boolean {
+  if (dropIndex <= WARN_BURST) return true;
+  return (dropIndex - WARN_BURST) % WARN_PERIOD === 0;
+}
+
+/** Reset the dropped-cost-record counter and warn limiter (testing only, #3910/#3916). */
 export function resetDroppedCostRecordCount(): void {
   droppedCostRecordCount = 0;
+  warnCountSinceReset = 0;
+}
+
+/** Read how many dropped-cost warns have actually been emitted (testing, #3916). */
+export function getDroppedCostWarnCount(): number {
+  return warnCountSinceReset;
 }
 
 /**
@@ -123,14 +151,21 @@ export function recordDecisionCost(options: RecordDecisionCostOptions): Decision
     timestamp,
   });
   if (!persisted) {
+    // Count EVERY drop (stays exact); rate-limit only the warn so an unwritable
+    // store can't flood the log per-decision and degrade the main path (#3916).
     droppedCostRecordCount += 1;
-    logger.warn('Decision-cost rollup dropped (failed to persist) — billing telemetry lost', {
-      decisionId: options.decisionId,
-      gate: options.gate,
-      totalCostUsd: record.summary.totalCostUsd,
-      totalTokens: record.summary.totalTokens,
-      droppedCostRecordCount,
-    });
+    if (shouldWarnForDrop(droppedCostRecordCount)) {
+      const suppressedSinceLastWarn = droppedCostRecordCount - warnCountSinceReset - 1;
+      warnCountSinceReset += 1;
+      logger.warn('Decision-cost rollup dropped (failed to persist) — billing telemetry lost', {
+        decisionId: options.decisionId,
+        gate: options.gate,
+        totalCostUsd: record.summary.totalCostUsd,
+        totalTokens: record.summary.totalTokens,
+        droppedCostRecordCount,
+        suppressedSinceLastWarn,
+      });
+    }
   }
   return record.summary;
 }


### PR DESCRIPTION
#3915 follow-up. Implements **items 1 and 2** from the #3915 ratification. **Item 3** (export the dropped-cost counter to the observability surface, e.g. `weather_report`/metrics hook) is **DEFERRED** to a later PR.

Leave OPEN — audit is governance-of-the-governor; ratify via `higher_order` vote before merge.

## Item 1 — Audit-log non-silent drop (FAIL-LOUD)

A silently-dropped audit / tier-transition event undermines the tamper-evident hash chain (ADR-0017 / `docs/security/audit-hash-chain-threat-model.md`).

**Where it was silent:** the audit log uses `FileAuditStorage`'s own buffered append (not `JsonlStore`), and the real disk write happens in `FileAuditStorage.flush()`, which rejects on I/O error. That rejection was swallowed by the flush-timer's `.catch` — a single `error` log, no counter, no escalation, and the timer is the only caller on the steady-state path.

**Fix — fail-loud rationale.** Unlike the best-effort `warn` used for cost (cost is telemetry; a gap is acceptable), an audit gap breaks a security invariant, so this prefers FAIL-LOUD:

- `AuditLogger.flush()` now **records-then-rethrows**: an awaiting governance caller (e.g. a tier-transition emitter that `await`s the flush) still receives the thrown error.
- A shared handler logs **prominently at `error` level** (`AUDIT PERSIST FAILURE — audit event NOT durably written`), increments a process-lifetime counter exposed via **`getPersistFailureCount()`** (a non-zero value means the chain may have a gap), and invokes an optional **`onPersistFailure(error)`** escalation hook (new optional ctor / `createAuditLogger` parameter) so a governance consumer can alert/raise.
- The periodic flush timer routes through the **same** handler, so a failure that arrives via the timer (the steady-state path) is counted and surfaced rather than swallowed. The single in-flight drain is shared, so a concurrent timer tick and awaited `flush()` observe the failure exactly once (no double-count).

## Item 2 — Rate-limit the dropped-cost warn

`recordDecisionCost` previously `warn`ed on **every** `persisted === false`. If the store goes unwritable (disk full / perms / I/O), that floods logs per-decision and could degrade the main decision path — ironically risking the never-fail invariant the warn exists to protect.

- The warn is now **rate-limited**: first-5 burst, then at most once per 1000 further drops (first-N-then-periodic).
- The drop **counter increments on EVERY drop** (`getDroppedCostRecordCount` stays exact regardless of suppression).
- The decision **still never fails** — the summary is always returned.
- The emitted warn carries `suppressedSinceLastWarn` so one line accounts for the suppressed drops; `getDroppedCostWarnCount()` exposes the emitted-warn count.

## Tests (TDD)

- **Item 1** (`audit-logger.test.ts`, `fail-loud on persist failure`): a failed flush is surfaced — `error`-logged + counted (`getPersistFailureCount() === 1`) + **thrown** to the awaiting caller, NOT silent; the `onPersistFailure` hook fires with the error; a timer-path failure is counted; a successful flush neither counts nor escalates.
- **Item 2** (`decision-cost-recording.test.ts`, `rate-limits the warn under sustained drops`): 200 consecutive drops produce a **bounded** number of warns (≤ 6, not one-per-drop) while the drop counter reflects **all 200** and every decision still returns its summary.

## CI (local, all green)

`pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm test` (audit dir 186 + targeted suites — audit-chain, tier-transition, decision-cost — all pass), `pnpm build`, `pnpm lint` (max-lines-per-function=50 OK), `pnpm claims:check` (13/13), `pnpm governance:check`, producer/consumer unused-exports gate (exit 0) — all pass. Changeset added (`patch`).

## Scope

Confined to `src/audit/**`, `mcp/tools/decision-cost-recording.ts`, + tests + changeset. `config/jsonl-store.ts` was NOT touched (audit uses its own append, not `JsonlStore`). No docs/README/website/manifests touched.

Fixes #3916

🤖 Generated with [Claude Code](https://claude.com/claude-code)