### PR TITLE
docs: fix stale skills count + add pr_review metric-honesty guardrails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ keywords: [documentation, index, reference, navigation, docs, control-plane, map
 
 # Nexus Agents Documentation
 
-**Canonical Documentation Index** | Last Updated: 2026-06-17 (32 skills, 46 MCP tools, 12 expert types, 11 workflow templates)
+**Canonical Documentation Index** | Last Updated: 2026-06-17 (the skills under `skills/`, 46 MCP tools, 12 expert types, 11 workflow templates)
 
 This is the **single source of truth** for all nexus-agents documentation. All documentation must be indexed here to be considered valid.
 

--- a/docs/research/pr-review-eval-labeling-rubric.md
+++ b/docs/research/pr-review-eval-labeling-rubric.md
@@ -218,10 +218,36 @@ Under v1 the v5 run re-scores as:
 - **Clean cases:** 2 (#2238, `synthetic-clean-docs`).
 - **Borderline cases:** 1 (`synthetic-clean-refactor`).
 - **Strict false-positive denominator:** the 2 clean cases. v5 emitted 0 verified
-  findings on both → **strict-FP rate 0/2 = 0%** (was reported as 50% raw).
+  findings on both → **strict FP = 0/2 (n=2 clean, 1 borderline excluded)**.
+  Do NOT round this to a "0% false-positive rate." See the metric-honesty
+  guardrail below: at n=2 this number is not a rate.
 - Bug-catch and location-match are re-derived by v6 against these labels; this
   rubric only fixes the labels, not the panel run (running v6 is #3849, out of
   scope here).
+
+### Metric-honesty guardrails (#3903, required by the #3901 6-1 ratification)
+
+The 50% → 0% swing on the strict-FP figure is small-n adjudication noise, not a
+measured improvement in the tool. Treat these as binding when citing the number:
+
+- **The strict-FP "0%" is at n=2 and is statistically meaningless** — a single
+  future FP would swing it to 50%. **Never cite a bare "0% false-positive
+  rate."** Always report it WITH the n, the clean-denominator count, and the
+  borderline count: "strict FP = 0/2 (n=2 clean cases, 1 borderline excluded),
+  v5 re-adjudicated under rubric 1.0.0."
+- The honest reading is: **"the 50% headline was an artifact of n and
+  adjudication noise"** — not "pr_review has a 0% FP rate." The v5 numbers are
+  directional only.
+- **The `synthetic-clean-refactor` clean → borderline reclassification is the
+  single lever that moved 50% → 0%, and it must be re-audited on its own merits
+  before the 0% is cited anywhere external.** Its rationale (Rule 4:
+  context-dependent concerns are not hard FPs; symmetrically excluded from BOTH
+  numerators, so not gaming) must stand independently of its effect on the
+  metric. The reclassification is defensible, but "defensible" is not the same
+  as "audited."
+- **Real, statistically meaningful FP/bug-catch numbers await #3847** (curate the
+  dataset to n ≥ 50 with real PR data). Until then no FP rate from this dataset
+  should be presented as a measured rate.
 
 ## Out of scope (tracked elsewhere)
 

--- a/docs/research/pr-review-experiment-results-v5.md
+++ b/docs/research/pr-review-experiment-results-v5.md
@@ -16,13 +16,13 @@ keywords: [pr-review, experiment, results, json-findings, autonomous-sdlc]
 
 The fix landed: voters now reliably emit structured findings. **All five #2233 metrics shifted dramatically — three positively, two raising new questions.** Most importantly, the system caught a real bug in my own #2235 commit that no human reviewer flagged.
 
-| Metric                            | v3      | v4      | **v5**      | Target | Status                                          |
-| --------------------------------- | ------- | ------- | ----------- | ------ | ----------------------------------------------- |
-| Bug-catch rate                    | 50%     | 50%     | **100%**    | ≥10%   | ✓ PASS                                          |
-| **Verified findings emitted**     | 0       | 0       | **26**      | n/a    | breakthrough                                    |
-| **Known-bug location-match rate** | 0%      | 0%      | **83.3%**   | n/a    | new metric                                      |
-| False-positive rate               | 0%      | 0%      | **50%**     | <20%   | ✗ FAIL (see "Real findings vs false positives") |
-| Avg duration                      | 2.8 min | 2.1 min | **1.4 min** | <5 min | ✓ PASS                                          |
+| Metric                            | v3      | v4      | **v5**      | Target | Status                                      |
+| --------------------------------- | ------- | ------- | ----------- | ------ | ------------------------------------------- |
+| Bug-catch rate                    | 50%     | 50%     | **100%**    | ≥10%   | ✓ PASS                                      |
+| **Verified findings emitted**     | 0       | 0       | **26**      | n/a    | breakthrough                                |
+| **Known-bug location-match rate** | 0%      | 0%      | **83.3%**   | n/a    | new metric                                  |
+| False-positive rate               | 0%      | 0%      | **50% raw** | <20%   | directional — see metric-honesty note below |
+| Avg duration                      | 2.8 min | 2.1 min | **1.4 min** | <5 min | ✓ PASS                                      |
 
 ## Per-PR results (v5)
 
@@ -81,6 +81,25 @@ If we re-classify the data:
 - **Borderline** (legit concerns on debatable code): 1 / 4 (synthetic-clean-refactor)
 
 The 50% headline "FP rate" is mostly the dataset, not the tool. The tool is finding things.
+
+> **Metric-honesty guardrail (#3903, required by the #3901 6-1 ratification).**
+> These v5 FP figures are directional only — do **not** cite them as measured
+> rates. Specifically:
+>
+> - The honest reading is **"the 50% headline was an artifact of n and
+>   adjudication noise,"** NOT "pr_review has a 0% FP rate." The strict-FP figure
+>   the v1 rubric derives is **0/2 (n=2 clean cases, 1 borderline excluded)** —
+>   at n=2 a single future FP swings it to 50%, so it is not a rate. **Never cite
+>   a bare "0% false-positive rate";** always carry the n, the clean-denominator
+>   count, and the borderline count.
+> - The `synthetic-clean-refactor` clean → borderline reclassification is the
+>   single lever that moved 50% → 0%. It **must be re-audited on its own merits
+>   before the 0% is cited anywhere external** — its rationale has to stand
+>   independently of its metric effect.
+> - Statistically meaningful FP/bug-catch numbers **await #3847** (curate to
+>   n ≥ 50 with real PR data). See
+>   [pr-review-eval-labeling-rubric.md](./pr-review-eval-labeling-rubric.md) for
+>   the binding rubric and the full guardrail.
 
 ## Verified-finding distribution
 


### PR DESCRIPTION
Two small docs-only fixes in one branch.

## #3919 — stale skills count
`docs/README.md` header prose said "32 skills" while `governance:inject` reports 33. Reworded to not hardcode the number — now reads "the skills under `skills/`" — so the surface can't drift again (it isn't covered by the MCP_TOOL_COUNT guard or the claims scan). The "46 MCP tools" claims subject is preserved untouched.

Fixes #3919

## #3903 — pr_review metric honesty
Added the metric-honesty guardrails the #3901 (6-1) ratification required, to the eval rubric (`docs/research/pr-review-eval-labeling-rubric.md`) and the v5 results doc (`docs/research/pr-review-experiment-results-v5.md`):

- The strict-FP "0%" is at n=2 and statistically meaningless — **never cite a bare "0% false-positive rate"**; always report it WITH n + the clean-denominator count + the borderline count (`0/2, n=2 clean, 1 borderline excluded`).
- Explicit note that the `synthetic-clean-refactor` clean→borderline reclassification (the single lever that moved 50%→0%) **must be re-audited on its own merits before the 0% is cited anywhere external**; real numbers await #3847 (n≥50).
- The docs now state the honest reading: **"the 50% headline was an artifact of n + adjudication noise,"** not "pr_review has a 0% FP rate."

Fixes #3903

## Gates
- markdownlint: clean (MD060 table alignment fixed)
- claims:check: 13/13
- check-docs-indexed: 0 unindexed / 0 stale
- governance:check + inject: no stamp drift (Skills: 33)
- cspell: no new findings introduced
- Changeset: none (docs-only, no shippable src changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)