### PR TITLE
fix(orchestration): wire the authority-tier runtime guard into the live dispatch path (#3920)

### DIFF
--- a/.changeset/wire-authority-guard-3920.md
+++ b/.changeset/wire-authority-guard-3920.md
@@ -1,0 +1,47 @@
+---
+'nexus-agents': patch
+---
+
+fix(orchestration): wire the authority-tier runtime guard into the live dispatch path (#3920)
+
+ADR-0017's "router refusal" was dead code in production. `guardAuthority`'s only
+non-test caller (meta-orchestrator `select`) is gated on
+`input.requiredAuthority !== undefined`, but no production dispatch path ever set
+it — `toMetaInput` omitted it on BOTH the route-only (`execute:false`) and inline
+`execute:true` paths. So the `if` was always false and the runtime ceiling never
+ran; only the CI declaration gate (`check-authority-tier-drift.ts`) was live.
+
+**The wiring.** `requiredAuthority` is now derived from the DISPATCH MODE and
+threaded through `toMetaInput`:
+
+- A new pure, exported `dispatchActionClass(mode)` in `authority-tier-guard.ts`
+  maps the two `run` dispatch modes to the authority class each EXERCISES.
+- `run-tool.ts` passes `'route'` (from `routeGoal`) / `'execute'` (from
+  `executeGoal`) so the guard fires at the router on every real dispatch.
+
+**Refusal semantics (conservative, ADR-0017-grounded).** Both modes floor at
+`suggest`: a routing recommendation is `suggest`-class by ADR definition ("inert
+until a human acts"), and an inline `run` result is likewise inert (it does not
+merge/deploy/gate a protected resource). Flooring at `suggest` — not `observe` —
+is what gives the guard teeth without breaking parity: every live strategy is
+declared `suggest`/`advisory`, so all pass. The guard refuses fail-closed
+(`AuthorityRefusalError`, before any executor runs) only on a genuine above-tier
+action — an `observe`-tier strategy reaching dispatch (`above_declared_tier`), or
+a strategy with no declared tier (`tier_undeclared`, the runtime backstop behind
+the CI gate). The `run` execute path maps the refusal to a `business`-class
+structured error (a policy outcome, not an internal fault). A higher action floor
+(an `advisory`/`enforce` dispatch surface) is a future, owner-approved widening
+localized to `dispatchActionClass`.
+
+**No behaviour change for correctly-declared loops.** Parity suite green; normal
+suggest/advisory dispatch proceeds unchanged.
+
+**Regression test.** `run-tool-authority-guard.test.ts` drives above-tier actions
+through the REAL `routeGoal`/`executeGoal` paths (not a hand-built
+`MetaOrchestratorInput`) via a deliberate-breakage manifest fixture, and asserts
+refusal (route + execute) while normal dispatch proceeds — RED before the wiring,
+GREEN after. This is the regression that would have caught the dead-code gap.
+
+Left for the governance ratification vote (governance-of-the-governor): the
+precise "dispatch action → requiredAuthority" mapping is the design judgment to
+ratify.

--- a/packages/nexus-agents/src/mcp/tools/run-tool-authority-guard.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-authority-guard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for #3920 — the authority-tier runtime guard must fire on a
+ * REAL production dispatch path (`routeGoal` / `executeGoal`), not only when a
+ * test hand-builds a `MetaOrchestratorInput` with `requiredAuthority` set.
+ *
+ * The bug (#3920): `guardAuthority`'s only non-test caller was gated on
+ * `input.requiredAuthority !== undefined`, but NO production path set it
+ * (`toMetaInput` omitted it on both the route-only and execute:true paths). So the
+ * ADR-0017 router refusal was dead code: an above-tier action was never refused at
+ * runtime. The fix derives `requiredAuthority` from the dispatch MODE
+ * (`dispatchActionClass`, floored at `suggest`) and threads it through
+ * `toMetaInput`, so the guard now fires at the router.
+ *
+ * Deliberate-breakage fixture: every LIVE strategy is declared `suggest`/`advisory`
+ * (≥ the `suggest` dispatch floor), so none can prove an above-tier refusal on the
+ * real registry. We therefore mock the manifest registry's `getStrategyManifest`
+ * (the seam the guard reads) to DOWNGRADE one strategy below the floor:
+ *  - `single-shot` → declared `observe` (below `suggest`) ⇒ `above_declared_tier`,
+ *  - `graph-workflow` → NO declared tier (undefined) ⇒ `tier_undeclared` backstop.
+ * Every other strategy keeps its real, correctly-declared tier, proving normal
+ * dispatch is unaffected.
+ *
+ * Without the fix these tests are RED: with `requiredAuthority` never written, the
+ * guard never runs and `routeGoal`/`executeGoal` return normally instead of
+ * refusing. With the fix they are GREEN.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { StrategyManifest } from '../../orchestration/strategy-manifest.js';
+import type { ExecutionStrategy } from '../../orchestration/meta-orchestrator.js';
+
+// Mock ONLY getStrategyManifest (the guard's tier source) — keep entrypointToolFor
+// and the rest of the registry real so routing/recommended-tool resolution is
+// unaffected. The downgrade map is the deliberate-breakage fixture (#3841 evidence
+// requirement: a below-tier manifest attempting a dispatch action must be refused).
+vi.mock('../../orchestration/strategy-manifest-registry.js', async (importActual) => {
+  const actual =
+    await importActual<typeof import('../../orchestration/strategy-manifest-registry.js')>();
+  return {
+    ...actual,
+    getStrategyManifest: (strategy: ExecutionStrategy): StrategyManifest | undefined => {
+      const real = actual.getStrategyManifest(strategy);
+      if (real === undefined) return undefined;
+      if (strategy === 'single-shot') {
+        return { ...real, authorityTier: 'observe' };
+      }
+      if (strategy === 'graph-workflow') {
+        const withoutTier: StrategyManifest = { ...real };
+        delete (withoutTier as { authorityTier?: unknown }).authorityTier;
+        return withoutTier;
+      }
+      return real;
+    },
+  };
+});
+
+const { routeGoal, executeGoal } = await import('./run-tool.js');
+const { AuthorityRefusalError } = await import('../../orchestration/authority-tier-guard.js');
+const { MetaDispatchError } = await import('../../orchestration/meta-dispatcher.js');
+
+describe('run authority-ladder guard fires on a real dispatch path (#3920)', () => {
+  describe('route-only path (routeGoal, execute:false)', () => {
+    it('REFUSES an above-tier dispatch: observe-tier strategy, suggest-class route', () => {
+      let thrown: unknown;
+      try {
+        routeGoal({ goal: 'anything', forceStrategy: 'single-shot' });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AuthorityRefusalError);
+      const refusal = thrown as InstanceType<typeof AuthorityRefusalError>;
+      expect(refusal.code).toBe('above_declared_tier');
+      expect(refusal.strategy).toBe('single-shot');
+      expect(refusal.declaredTier).toBe('observe');
+      expect(refusal.attemptedAction).toBe('suggest');
+    });
+
+    it('REFUSES fail-closed when the strategy has NO declared tier (tier_undeclared backstop)', () => {
+      let thrown: unknown;
+      try {
+        routeGoal({ goal: 'implement the feature', forceStrategy: 'graph-workflow' });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AuthorityRefusalError);
+      expect((thrown as InstanceType<typeof AuthorityRefusalError>).code).toBe('tier_undeclared');
+    });
+
+    it('PROCEEDS unchanged for a correctly-declared at/below-tier strategy (consensus@advisory)', () => {
+      const r = routeGoal({ goal: 'should we adopt A or B', requiresConsensus: true });
+      expect(r.strategy).toBe('consensus');
+      expect(r.recommendedTool).toBe('consensus_vote');
+    });
+
+    it('PROCEEDS unchanged for a normal suggest-tier dispatch (dev-pipeline@suggest)', () => {
+      // dev-pipeline keeps its real `suggest` tier in the fixture; a suggest-class
+      // route is at-tier, so it is NOT refused.
+      const r = routeGoal({ goal: 'implement the feature', forceStrategy: 'dev-pipeline' });
+      expect(r.strategy).toBe('dev-pipeline');
+      expect(r.recommendedTool).toBe('run_dev_pipeline');
+    });
+  });
+
+  describe('inline-execute path (executeGoal, execute:true)', () => {
+    it('REFUSES an above-tier dispatch BEFORE any executor runs', async () => {
+      const executor = vi.fn(() => Promise.resolve({ ran: true }));
+      let thrown: unknown;
+      try {
+        await executeGoal(
+          { goal: 'anything', forceStrategy: 'single-shot', execute: true },
+          { executors: { 'single-shot': executor } }
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AuthorityRefusalError);
+      expect((thrown as InstanceType<typeof AuthorityRefusalError>).code).toBe(
+        'above_declared_tier'
+      );
+      // Fail-closed: the refusal is at the router, so the executor never runs.
+      expect(executor).not.toHaveBeenCalled();
+    });
+
+    it('PROCEEDS unchanged for a normal suggest-tier execute (dev-pipeline@suggest)', async () => {
+      const executor = vi.fn(() => Promise.resolve({ completed: true }));
+      const res = await executeGoal(
+        { goal: 'implement the feature', forceStrategy: 'dev-pipeline', execute: true },
+        { executors: { 'dev-pipeline': executor } }
+      );
+      expect(res.executed).toBe(true);
+      expect(res.strategy).toBe('dev-pipeline');
+      expect(executor).toHaveBeenCalledTimes(1);
+    });
+
+    it('still fails closed with MetaDispatchError for an at-tier strategy with no wired executor', async () => {
+      // Proves the authority guard does not swallow / pre-empt the existing
+      // no-executor fail-closed path for a correctly-declared strategy.
+      let thrown: unknown;
+      try {
+        await executeGoal(
+          { goal: 'decide A or B', forceStrategy: 'consensus', execute: true },
+          { executors: {} }
+        );
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(MetaDispatchError);
+      expect((thrown as InstanceType<typeof MetaDispatchError>).code).toBe('no_executor');
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -54,6 +54,11 @@ import {
   type MetaOutcomeObserver,
 } from '../../orchestration/meta-dispatcher.js';
 import { entrypointToolFor } from '../../orchestration/strategy-manifest-registry.js';
+import {
+  dispatchActionClass,
+  AuthorityRefusalError,
+  type DispatchMode,
+} from '../../orchestration/authority-tier-guard.js';
 import { runDevPipelineForGoal } from './dev-pipeline-tool.js';
 import { runPipelineForGoal } from './pipeline-tool.js';
 import { runConsensusForGoal } from './consensus-vote.js';
@@ -135,9 +140,20 @@ const NOTE =
   'wait for inline execution (run execute: true) in a later release. The other ' +
   'pipeline tools remain available as advanced force-strategy paths.';
 
-/** Maps validated input to the MetaOrchestrator input shape. */
+/**
+ * Maps validated input to the MetaOrchestrator input shape.
+ *
+ * Threads `requiredAuthority` derived from the DISPATCH MODE (#3920, ADR-0017) —
+ * this is the production writer that was missing, which left the authority-ladder
+ * router refusal as dead code. The router (meta-orchestrator `select`) refuses
+ * fail-closed when the selected/forced strategy would act ABOVE its declared
+ * tier; `dispatchActionClass` floors both modes at `suggest` so every live
+ * strategy passes and the guard fires only on a genuine above-tier action (an
+ * `observe`/undeclared strategy reaching dispatch). See {@link dispatchActionClass}.
+ */
 function toMetaInput(
-  input: RunInput
+  input: RunInput,
+  mode: DispatchMode
 ): Parameters<ReturnType<typeof createMetaOrchestrator>['select']>[0] {
   const signals: Record<string, unknown> = {};
   if (input.requiresConsensus !== undefined) signals.requiresConsensus = input.requiresConsensus;
@@ -146,13 +162,19 @@ function toMetaInput(
   if (input.isNovel !== undefined) signals.isNovel = input.isNovel;
   return {
     goal: input.goal,
+    requiredAuthority: dispatchActionClass(mode),
     ...(Object.keys(signals).length > 0 ? { signals } : {}),
     ...(input.forceStrategy !== undefined ? { forceStrategy: input.forceStrategy } : {}),
   };
 }
 
-/** Selects a strategy for a goal via the MetaOrchestrator. */
-function selectDecision(input: RunInput, logger?: ILogger): MetaDecision {
+/**
+ * Selects a strategy for a goal via the MetaOrchestrator. `mode` is the dispatch
+ * mode the selection feeds (#3920): it sets the `requiredAuthority` the
+ * authority-ladder router enforces, so `select` can refuse an above-tier action
+ * fail-closed at the router rather than after the fact.
+ */
+function selectDecision(input: RunInput, mode: DispatchMode, logger?: ILogger): MetaDecision {
   // Shadow-mode learned selection (#3551): the process-scoped selector + sink
   // log a would-be learned choice alongside the executed rule-based choice.
   // Never alters what runs; builds the comparison surface for offline eval.
@@ -161,7 +183,7 @@ function selectDecision(input: RunInput, logger?: ILogger): MetaDecision {
     shadowSelector: getShadowSelector(),
     shadowSink: getShadowSink(),
   });
-  return meta.select(toMetaInput(input));
+  return meta.select(toMetaInput(input, mode));
 }
 
 /**
@@ -169,7 +191,7 @@ function selectDecision(input: RunInput, logger?: ILogger): MetaDecision {
  * (read-only — no execution). Exported for testing.
  */
 export function routeGoal(input: RunInput, logger?: ILogger): RunResponse {
-  const decision = selectDecision(input, logger);
+  const decision = selectDecision(input, 'route', logger);
   return {
     strategy: decision.strategy,
     reasoning: decision.reasoning,
@@ -276,7 +298,10 @@ export async function executeGoal(
     readonly trustTier?: string | undefined;
   } = {}
 ): Promise<RunExecuteResponse> {
-  const decision = selectDecision(input, opts.logger);
+  // The authority-ladder guard fires inside `select` (#3920): an above-tier
+  // dispatch is refused fail-closed (AuthorityRefusalError) here, BEFORE any
+  // executor runs.
+  const decision = selectDecision(input, 'execute', opts.logger);
   const onOutcome = opts.onOutcome ?? buildShadowTrainObserver(opts.logger);
   const dispatcher = createMetaDispatcher({
     executors: opts.executors ?? buildDefaultExecutors(opts.trustTier),
@@ -284,7 +309,7 @@ export async function executeGoal(
     ...(opts.outcomeSink !== undefined ? { outcomeSink: opts.outcomeSink } : {}),
     ...(onOutcome !== undefined ? { onOutcome } : {}),
   });
-  const dispatch = await dispatcher.dispatch(decision, toMetaInput(input));
+  const dispatch = await dispatcher.dispatch(decision, toMetaInput(input, 'execute'));
   return {
     strategy: dispatch.strategy,
     decisionId: dispatch.decisionId,
@@ -323,8 +348,12 @@ async function executeRunBody(
     return toolSuccess(JSON.stringify(exec, null, 2));
   } catch (err) {
     const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
+    // #3920: an authority-ladder refusal is a fail-closed POLICY outcome (the
+    // caller asked an above-tier strategy to act), not an internal fault — it is
+    // a `business` error, same class as a missing executor.
+    const refused = err instanceof AuthorityRefusalError;
     return toolStructuredError({
-      errorCategory: noExecutor ? 'business' : 'internal',
+      errorCategory: noExecutor || refused ? 'business' : 'internal',
       message: err instanceof Error ? err.message : String(err),
     });
   }

--- a/packages/nexus-agents/src/orchestration/authority-tier-guard.test.ts
+++ b/packages/nexus-agents/src/orchestration/authority-tier-guard.test.ts
@@ -17,6 +17,7 @@ import {
   permitsAction,
   evaluateAuthority,
   guardAuthority,
+  dispatchActionClass,
   AuthorityRefusalError,
   type ActionClass,
 } from './authority-tier-guard.js';
@@ -123,6 +124,29 @@ describe('authority-tier guard — registry-backed enforcement (#3841)', () => {
     for (const [action, strategy] of Object.entries(byTier)) {
       const decision = evaluateAuthority(strategy as never, action as ActionClass);
       expect(decision.permitted, `${strategy}@${action} should be permitted`).toBe(true);
+    }
+  });
+});
+
+describe('dispatchActionClass — dispatch-mode → action-class map (#3920)', () => {
+  it("maps the route-only dispatch to a 'suggest'-class action (recommendation)", () => {
+    expect(dispatchActionClass('route')).toBe('suggest');
+  });
+
+  it("maps the inline-execute dispatch to a 'suggest'-class action (inert result)", () => {
+    expect(dispatchActionClass('execute')).toBe('suggest');
+  });
+
+  it('floors both modes at suggest so every live suggest+/advisory strategy passes', () => {
+    // The conservative #3920 interpretation: both dispatch modes floor at
+    // `suggest`. Every live strategy is declared `suggest`+, so a dispatch-class
+    // action is at/below tier for all of them — the guard fires only on a genuine
+    // above-tier (observe / undeclared) strategy.
+    for (const mode of ['route', 'execute'] as const) {
+      expect(permitsAction('suggest', dispatchActionClass(mode))).toBe(true);
+      expect(permitsAction('advisory', dispatchActionClass(mode))).toBe(true);
+      // An observe-tier strategy is BELOW the floor — refused.
+      expect(permitsAction('observe', dispatchActionClass(mode))).toBe(false);
     }
   });
 });

--- a/packages/nexus-agents/src/orchestration/authority-tier-guard.ts
+++ b/packages/nexus-agents/src/orchestration/authority-tier-guard.ts
@@ -82,6 +82,55 @@ export function permitsAction(
   return authorityRank(actionClass) <= ceiling;
 }
 
+/**
+ * The two ways the `run` entry point dispatches a selected strategy, and the
+ * authority class each EXERCISES (#3920, ADR-0017). This is the "dispatch action
+ * → requiredAuthority" mapping that wires the guard to a real action class — the
+ * piece that was missing (the guard had no production writer of
+ * `requiredAuthority`, so it never fired).
+ *
+ * The interpretation is grounded in ADR-0017 §"The Four Tiers" and kept
+ * deliberately CONSERVATIVE (so today's correctly-declared flows are never
+ * spuriously refused — every live strategy is `suggest` or `advisory`):
+ *
+ *  - `route`  — read-only routing (`execute:false`): emits a recommendation the
+ *    caller may invoke. Per ADR-0017 `suggest` is exactly "produce a
+ *    recommendation … inert until a human acts on it", so routing is a
+ *    `suggest`-class action.
+ *  - `execute` — inline execution (`execute:true`): runs the selected engine and
+ *    returns its result. The `run` tool's result is still inert (it does not
+ *    merge, deploy, or gate a protected resource on the caller's behalf), so it
+ *    too floors at `suggest` — the same authority a recommendation carries.
+ *
+ * Flooring BOTH modes at `suggest` (not `observe`) is what gives the guard teeth
+ * without breaking parity: every live strategy is declared `suggest`+, so all
+ * pass; the guard fires fail-closed exactly on a genuine above-tier action —
+ *  - a strategy declared `observe` (signal-only: "no proposal, no … action")
+ *    being dispatched through `run` (which produces a recommendation/result),
+ *    refused `above_declared_tier`; and
+ *  - a strategy with NO declared tier reaching dispatch, refused `tier_undeclared`
+ *    (the runtime backstop behind the CI declaration gate).
+ *
+ * Higher action floors (e.g. an `advisory`/`enforce` dispatch surface) are a
+ * future, owner-approved widening once a higher-authority `run` action exists;
+ * pinning the floor at `suggest` keeps #3920 a wiring fix, not a behaviour change.
+ */
+export type DispatchMode = 'route' | 'execute';
+
+/**
+ * The authority class a {@link DispatchMode} exercises — the pure
+ * dispatch-action → action-class map (ADR-0017). Both production dispatch modes
+ * floor at `suggest`; see {@link DispatchMode} for the ADR-grounded rationale.
+ * Pure and exported so the wiring (`run-tool.ts`) and its regression test share
+ * one source of truth, and so the mapping is unit-testable in isolation.
+ */
+export function dispatchActionClass(_mode: DispatchMode): ActionClass {
+  // Both `route` and `execute` floor at `suggest` today (see DispatchMode docs).
+  // Kept as a function (not a constant) so a future per-mode widening is a
+  // localized, reviewable change at this single seam.
+  return 'suggest';
+}
+
 /** Why an authority guard refused. */
 export type AuthorityRefusalCode = 'above_declared_tier' | 'tier_undeclared';
 


### PR DESCRIPTION
## Summary

ADR-0017's authority-ladder **router refusal** was **dead code in production** (#3920). `guardAuthority`'s only non-test caller — `meta-orchestrator.select()` (~L316) — is gated on `input.requiredAuthority !== undefined`, but **no production dispatch path set it**: `toMetaInput` in `run-tool.ts` omitted `requiredAuthority` on **both** the route-only (`execute:false`) and inline `execute:true` paths. So the `if` was always false and the runtime ceiling **never ran**; only the CI declaration gate (`check-authority-tier-drift.ts`) was live. This is exactly the failure the ADR's Contrarian condition was meant to close ("the tier field MUST have a machine consumer … not documentation dressed as architecture").

## Where `requiredAuthority` is derived + wired

- New pure, exported **`dispatchActionClass(mode: DispatchMode): ActionClass`** in `orchestration/authority-tier-guard.ts`. It maps the two `run` dispatch modes to the authority class each **exercises**. It is the "dispatch action → requiredAuthority" mapping that was missing — the production writer of `requiredAuthority`.
- `mcp/tools/run-tool.ts`: `toMetaInput(input, mode)` now sets `requiredAuthority: dispatchActionClass(mode)`. `selectDecision` threads the mode; `routeGoal` passes `'route'`, `executeGoal` passes `'execute'`. The guard now fires at the router on **every real dispatch**, before any executor runs.

## Refusal semantics (conservative, ADR-0017-grounded — for the ratification vote)

Both modes **floor at `suggest`**:

- **route** (`execute:false`) emits a recommendation — ADR-0017 defines `suggest` as exactly "produce a recommendation … inert until a human acts on it".
- **execute** (`execute:true`) runs the engine and returns a result that is **still inert** (the `run` tool does not merge, deploy, or gate a protected resource on the caller's behalf), so it floors at `suggest` too.

Flooring at `suggest` (not `observe`) is what gives the guard **teeth without breaking parity**. The guard refuses fail-closed (`AuthorityRefusalError`) **only** on a genuine above-tier action:
- an `observe`-tier strategy reaching dispatch → `above_declared_tier`;
- a strategy with **no** declared tier → `tier_undeclared` (runtime backstop behind the CI gate).

On the `execute` path, an `AuthorityRefusalError` is surfaced as a **`business`**-class structured error (a policy refusal, same class as a missing executor — not an internal fault).

A higher action floor (an `advisory`/`enforce` dispatch surface) is a future, owner-approved widening, localized to `dispatchActionClass` — **this PR is a wiring fix, not a behaviour change.**

## Why normal flows are not broken

Every live strategy is declared `suggest` (work producers) or `advisory` (consensus) — all **at or above** the `suggest` floor — so a dispatch-class action is at/below tier for all of them and **none are refused**. Full parity suite green (26,494 passed). The "PROCEEDS unchanged" cases in the regression test cover both route and execute on real suggest/advisory strategies.

## The regression test (RED → GREEN)

`mcp/tools/run-tool-authority-guard.test.ts` drives above-tier actions through the **real** `routeGoal`/`executeGoal` paths (not a hand-built `MetaOrchestratorInput`), using a **deliberate-breakage manifest fixture** (mocks only `getStrategyManifest` to downgrade `single-shot`→`observe` and drop `graph-workflow`'s tier; every other strategy keeps its real tier):

- route + execute above-tier → `AuthorityRefusalError` (`above_declared_tier`); executor **never runs** (fail-closed).
- undeclared tier → `tier_undeclared` backstop.
- normal suggest/advisory dispatch → proceeds unchanged; at-tier no-executor still fails closed with `MetaDispatchError`.

Verified **RED before the wiring** (the 3 "REFUSES" tests fail when `requiredAuthority` is not written — the exact dead-code gap) and **GREEN after**. A `dispatchActionClass` unit test is added to `authority-tier-guard.test.ts`.

## CI

`pnpm install --frozen-lockfile`, typecheck, full test (26,494 passed / 16 skipped), build, **full lint** (max-lines-per-function=50), `governance:inject` (no doc drift), `governance:check`, `claims:check` (13), authority-tier drift gate, producer/consumer gate — **all green**.

## Scope

Confined to `orchestration/authority-tier-guard.ts`, `mcp/tools/run-tool.ts`, their tests, and a changeset. No touches to `src/audit/**`, `scripts/check-authority-tier-drift.ts`, docs, or website.

**Leave OPEN — do not merge.** Governance-of-the-governor: the dispatch-action → `requiredAuthority` mapping is the design judgment for a `higher_order` ratification vote.

Fixes #3920

🤖 Generated with [Claude Code](https://claude.com/claude-code)