### PR TITLE
fix(governance): persist authentic vote records at vote time (#3897)

### DIFF
--- a/.changeset/authentic-vote-record-3897.md
+++ b/.changeset/authentic-vote-record-3897.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): persist authentic vote records at vote time (#3897)
+
+The authority-ladder promotion gate (#3895) resolves a `ratificationVoteRef`
+against the committed `governance/ratification-votes.yaml` ledger, but that
+ledger is hand-committable — the gate verifies STRUCTURAL PRESENCE, not
+AUTHENTICITY, so anyone who can land a commit can forge a conforming entry. Live
+`consensus_vote` results previously persisted only to per-developer home-dir
+stores (`~/.nexus-agents/voting`, `~/.nexus-agents/learning`) that CI cannot
+read.
+
+This change persists each completed `consensus_vote` to a committed,
+append-only, tamper-EVIDENT artifact at vote time
+(`governance/vote-records.jsonl`), so authenticity rests on a hash chain rather
+than on manual YAML transcription.
+
+**Design.** A dedicated payload-covering hash chain (`src/audit/vote-record.ts`)
+rather than riding the existing audit-event head hash. The audit-event chain
+(`computeEventHash`) folds only the stable HEAD fields and intentionally NOT
+`metadata`, so a tier-transition-style metadata payload would leave the vote
+`decision`/`approvalPercentage` OUTSIDE the chain — an attacker could flip
+`rejected`→`approved` without breaking any hash. The vote record instead folds
+EVERY authenticity-bearing field (proposal content hash, decision, approval
+percentage, vote counts, per-voter summary) into the chained hash, so editing
+any of them is detected as a `hash_mismatch`. The record is written as a
+best-effort side effect of the existing vote path (`recordAuthenticVote` in
+`consensus-vote-recording.ts`) — no new MCP tool, the tool ceiling is respected.
+
+**Gate seam (next step).** `readVoteRecords` + `verifyVoteRecordChain` are the
+tested seam a future `check-authority-tier-drift.ts` revision uses to resolve a
+`ratificationVoteRef` against the committed records and reject a chain that
+fails verification. This PR does not rewire the gate.
+
+**Deferred.** Cryptographic signing / provenance-stamping (binding the record to
+a key — the AI/ML voter's stretch goal) is deferred to a follow-up. Tamper-
+EVIDENCE via the hash chain is the MVP; tamper-PROOF signing is later.

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -59,6 +59,32 @@ export type { ChainVerification } from './audit-logger.js';
 // Storage
 export { FileAuditStorage, InMemoryAuditStorage } from './audit-storage.js';
 
+// Authentic vote record (#3897) — committable, hash-chained, tamper-evident.
+export {
+  VoteRecordSchema,
+  VoterSummarySchema,
+  VoteRecordCountsSchema,
+  VoteRecordDecisionSchema,
+  computeVoteRecordHash,
+  hashProposal,
+  verifyVoteRecordChain,
+} from './vote-record.js';
+export type {
+  VoteRecord,
+  VoterSummary,
+  VoteRecordCounts,
+  VoteRecordDecision,
+  VoteRecordVerification,
+} from './vote-record.js';
+export {
+  VOTE_RECORDS_REL_PATH,
+  buildVoteRecord,
+  persistVoteRecord,
+  resolveVoteRecordsPath,
+  readVoteRecords,
+} from './vote-record-store.js';
+export type { BuildVoteRecordInput, PersistVoteRecordOptions } from './vote-record-store.js';
+
 // SecureHandler Integration
 export {
   actorFromContext,

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the authentic vote-record store (#3897): a completed vote persists
+ * an authentic record carrying the proposal hash + decision + per-voter summary,
+ * the record is append-only and round-trips, and tampering with a persisted
+ * line is detected by chain verification.
+ *
+ * @module audit/vote-record-store.test
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ConsensusResult, Vote } from '../consensus/types.js';
+import type { AgentVoteResult, VoterRole } from '../cli/vote-types.js';
+
+import { verifyVoteRecordChain } from './vote-record.js';
+import { buildVoteRecord, persistVoteRecord, readVoteRecords } from './vote-record-store.js';
+
+function vote(decision: Vote['decision'], confidence: number): Vote {
+  return { decision, confidence, reasoning: 'because' };
+}
+
+function agentVote(
+  role: VoterRole,
+  decision: Vote['decision'],
+  source: AgentVoteResult['source'] = 'llm'
+): AgentVoteResult {
+  return { role, vote: vote(decision, 0.8), processingTimeMs: 10, source };
+}
+
+function consensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
+  const now = '2026-06-15T00:00:00.000Z';
+  return {
+    proposalId: 'p-1',
+    proposal: { title: 'T', description: 'D', algorithm: 'higher_order' },
+    outcome: 'approved',
+    votes: new Map(),
+    voteCounts: { approve: 2, reject: 1, abstain: 0, total: 3 },
+    approvalPercentage: 66.7,
+    quorumReached: true,
+    startedAt: now,
+    closedAt: now,
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+const votes: readonly AgentVoteResult[] = [
+  agentVote('architect', 'approve'),
+  agentVote('security', 'approve'),
+  agentVote('catfish', 'reject'),
+];
+
+describe('buildVoteRecord', () => {
+  it('carries the proposal hash, decision, counts, and per-voter summary', () => {
+    const record = buildVoteRecord({
+      id: 'vote-1',
+      proposal: 'Promote loop X to enforce',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+    });
+    expect(record.decision).toBe('approved');
+    expect(record.proposalHash).toHaveLength(64);
+    expect(record.approvalPercentage).toBeCloseTo(66.7);
+    expect(record.voteCounts).toEqual({ approve: 2, reject: 1, abstain: 0, total: 3 });
+    expect(record.voters).toEqual([
+      { role: 'architect', decision: 'approve', confidence: 0.8 },
+      { role: 'security', decision: 'approve', confidence: 0.8 },
+      { role: 'catfish', decision: 'reject', confidence: 0.8 },
+    ]);
+    expect(verifyVoteRecordChain([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('excludes error-source voters from the per-voter summary', () => {
+    const record = buildVoteRecord({
+      id: 'vote-1',
+      proposal: 'p',
+      strategy: 'simple_majority',
+      result: consensusResult(),
+      votes: [...votes, agentVote('pm', 'abstain', 'error')],
+    });
+    expect(record.voters.map((v) => v.role)).not.toContain('pm');
+  });
+});
+
+describe('persistVoteRecord', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vote-records-'));
+    filePath = join(dir, 'governance', 'vote-records.jsonl');
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('persists an authentic record that round-trips through read', () => {
+    const written = persistVoteRecord({
+      id: 'vote-1',
+      proposal: 'Promote loop X to enforce',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+      filePath,
+    });
+    expect(written).toBeDefined();
+
+    const { records, invalidLines } = readVoteRecords(filePath);
+    expect(invalidLines).toEqual([]);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual(written);
+  });
+
+  it('is append-only and chains each record onto the prior one', () => {
+    persistVoteRecord({
+      id: 'vote-1',
+      proposal: 'first',
+      strategy: 'higher_order',
+      result: consensusResult({ outcome: 'rejected', approvalPercentage: 20 }),
+      votes,
+      filePath,
+    });
+    persistVoteRecord({
+      id: 'vote-2',
+      proposal: 'second',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+      filePath,
+    });
+
+    const { records } = readVoteRecords(filePath);
+    expect(records).toHaveLength(2);
+    expect(records[0]!.previousHash).toBeUndefined();
+    expect(records[1]!.previousHash).toBe(records[0]!.hash);
+    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 2 });
+  });
+
+  it('detects tampering with a persisted line (decision flip) via chain verification', () => {
+    persistVoteRecord({
+      id: 'vote-1',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult({ outcome: 'rejected', approvalPercentage: 20 }),
+      votes,
+      filePath,
+    });
+
+    // Forge the committed artifact: flip rejected → approved on the raw line.
+    const raw = readFileSync(filePath, 'utf-8');
+    writeFileSync(filePath, raw.replace('"decision":"rejected"', '"decision":"approved"'), 'utf-8');
+
+    const { records } = readVoteRecords(filePath);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.decision).toBe('approved'); // the forged value is present...
+    const result = verifyVoteRecordChain(records);
+    expect(result.ok).toBe(false); // ...but the chain rejects it
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it("skips persistence when every vote is simulated is the caller's job; store itself writes given real votes", () => {
+    const written = persistVoteRecord({
+      id: 'vote-1',
+      proposal: 'p',
+      strategy: 'simple_majority',
+      result: consensusResult(),
+      votes,
+      filePath,
+    });
+    expect(written).toBeDefined();
+  });
+});

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -1,0 +1,191 @@
+/**
+ * nexus-agents/audit - Authentic Vote Record Store (#3897)
+ *
+ * Persists a completed `consensus_vote` to a COMMITTABLE, append-only,
+ * hash-chained artifact at vote time, distinct from the per-developer home-dir
+ * stores (`~/.nexus-agents/voting`, `~/.nexus-agents/learning`) a CI gate cannot
+ * read. The artifact lives at `<repo-root>/governance/vote-records.jsonl` so the
+ * promotion gate (#3895) can read it from CI; authenticity rests on the
+ * payload-covering hash chain ({@link verifyVoteRecordChain}), not on manual
+ * YAML transcription.
+ *
+ * DRY/drift hazard (DevEx, #3897). This is the AUTOMATED authoring path: the
+ * record is written as a side effect of the live vote, so the committed artifact
+ * cannot drift from what actually happened the way a hand-edited
+ * `ratification-votes.yaml` entry can. The chain links each new record to the
+ * last persisted one, so a forged/edited line breaks verification.
+ *
+ * @module audit/vote-record-store
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { ILogger } from '../core/index.js';
+import { createLogger, getErrorMessage } from '../core/index.js';
+import type { ConsensusResult, Vote } from '../consensus/types.js';
+import type { AgentVoteResult } from '../cli/vote-types.js';
+import { findRepoRoot } from '../config/repo-root-detection.js';
+
+import type { VoteRecord, VoterSummary } from './vote-record.js';
+import { VoteRecordSchema, computeVoteRecordHash, hashProposal } from './vote-record.js';
+
+/** Repo-relative committable artifact path (read by the gate/CI). */
+export const VOTE_RECORDS_REL_PATH = 'governance/vote-records.jsonl';
+
+/** Max proposal chars retained in the human record (full text is hashed). */
+const MAX_PROPOSAL_RECORD_CHARS = 500;
+
+/** Map a consensus outcome to the recorded decision vocabulary. */
+function outcomeToDecision(result: ConsensusResult): VoteRecord['decision'] {
+  if (result.outcome === 'approved') return 'approved';
+  if (!result.quorumReached && result.outcome !== 'rejected') return 'no_quorum';
+  return 'rejected';
+}
+
+/** Build the per-voter summary from the (real) agent votes, skipping errors. */
+function toVoterSummaries(votes: readonly AgentVoteResult[]): VoterSummary[] {
+  const summaries: VoterSummary[] = [];
+  for (const v of votes) {
+    if (v.source === 'error') continue;
+    const vote: Vote = v.vote;
+    summaries.push({ role: v.role, decision: vote.decision, confidence: vote.confidence });
+  }
+  return summaries;
+}
+
+/** Inputs for {@link buildVoteRecord} — the finalized vote data. */
+export interface BuildVoteRecordInput {
+  readonly id: string;
+  readonly proposal: string;
+  readonly strategy: VoteRecord['strategy'];
+  readonly result: ConsensusResult;
+  readonly votes: readonly AgentVoteResult[];
+  readonly correlationId?: string | undefined;
+  readonly recordedAt?: string | undefined;
+  readonly previousHash?: string | undefined;
+}
+
+/**
+ * Construct a fully-hashed {@link VoteRecord} from a completed vote, chained to
+ * `previousHash`. Pure (no I/O) so it is unit-testable and reusable by the gate
+ * seam. The proposal is hashed in full but stored truncated.
+ */
+export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
+  const proposalTruncated =
+    input.proposal.length > MAX_PROPOSAL_RECORD_CHARS
+      ? input.proposal.slice(0, MAX_PROPOSAL_RECORD_CHARS) + '...'
+      : input.proposal;
+  const payload: Omit<VoteRecord, 'hash'> = {
+    version: '1.0',
+    id: input.id,
+    recordedAt: input.recordedAt ?? new Date().toISOString(),
+    proposalHash: hashProposal(input.proposal),
+    proposal: proposalTruncated,
+    strategy: input.strategy,
+    decision: outcomeToDecision(input.result),
+    approvalPercentage: input.result.approvalPercentage,
+    voteCounts: {
+      approve: input.result.voteCounts.approve,
+      reject: input.result.voteCounts.reject,
+      abstain: input.result.voteCounts.abstain,
+      total: input.result.voteCounts.total,
+    },
+    voters: toVoterSummaries(input.votes),
+    ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+    ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
+  };
+  return { ...payload, hash: computeVoteRecordHash(payload) };
+}
+
+/** Read the last persisted record's hash so the next record chains onto it. */
+function readLastHash(filePath: string, logger: ILogger): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const lines = content.split('\n').filter((l) => l.trim() !== '');
+    const last = lines[lines.length - 1];
+    if (last === undefined) return undefined;
+    const parsed = VoteRecordSchema.safeParse(JSON.parse(last));
+    return parsed.success ? parsed.data.hash : undefined;
+  } catch (error: unknown) {
+    logger.warn('Failed to read prior vote record hash', { error: getErrorMessage(error) });
+    return undefined;
+  }
+}
+
+/** Resolve the committable artifact path under the current repo root, if any. */
+export function resolveVoteRecordsPath(): string | undefined {
+  const root = findRepoRoot(process.cwd());
+  if (root === null) return undefined;
+  return join(root, VOTE_RECORDS_REL_PATH);
+}
+
+/** Options for {@link persistVoteRecord}. */
+export interface PersistVoteRecordOptions extends Omit<BuildVoteRecordInput, 'previousHash'> {
+  /** Override the artifact path (tests); defaults to the repo-root resolution. */
+  readonly filePath?: string | undefined;
+  readonly logger?: ILogger | undefined;
+}
+
+/**
+ * Persist an authentic vote record to the committable artifact at vote time.
+ * Best-effort and append-only: reads the prior hash, builds a chained record,
+ * and appends one JSON line. Returns the written record (or undefined when no
+ * committable location exists / the write failed) — persistence never throws
+ * into the vote path (an audit sink must not break the operation it observes).
+ */
+export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | undefined {
+  const logger = opts.logger ?? createLogger({ component: 'vote-record-store' });
+  const filePath = opts.filePath ?? resolveVoteRecordsPath();
+  if (filePath === undefined) {
+    logger.debug('No committable repo root; skipping authentic vote record persist');
+    return undefined;
+  }
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const previousHash = readLastHash(filePath, logger);
+    const record = buildVoteRecord({ ...opts, previousHash });
+    appendFileSync(filePath, JSON.stringify(record) + '\n', 'utf-8');
+    logger.info('Persisted authentic vote record', {
+      id: record.id,
+      decision: record.decision,
+      path: filePath,
+    });
+    return record;
+  } catch (error: unknown) {
+    logger.warn('Failed to persist authentic vote record', {
+      error: getErrorMessage(error),
+      path: filePath,
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Read + verify the persisted vote-record chain from disk. The GATE SEAM
+ * (#3897): a future `check-authority-tier-drift.ts` revision resolves a
+ * `ratificationVoteRef` against these records and rejects a chain that fails
+ * verification. Returns the parsed records and any line that failed to parse.
+ */
+export function readVoteRecords(filePath: string): {
+  readonly records: VoteRecord[];
+  readonly invalidLines: number[];
+} {
+  const records: VoteRecord[] = [];
+  const invalidLines: number[] = [];
+  if (!existsSync(filePath)) return { records, invalidLines };
+  const lines = readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim() !== '');
+  for (const [i, line] of lines.entries()) {
+    try {
+      const parsed = VoteRecordSchema.safeParse(JSON.parse(line));
+      if (parsed.success) records.push(parsed.data);
+      else invalidLines.push(i + 1);
+    } catch {
+      invalidLines.push(i + 1);
+    }
+  }
+  return { records, invalidLines };
+}

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the authentic vote-record hash chain (#3897). The core property:
+ * tampering with a persisted record (flipping `decision`, altering
+ * `approvalPercentage`, editing a voter) is DETECTED as a `hash_mismatch`,
+ * because the chain hash covers the full payload — not just head fields.
+ *
+ * @module audit/vote-record.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { VoteRecord } from './vote-record.js';
+import { computeVoteRecordHash, verifyVoteRecordChain } from './vote-record.js';
+
+function makeRecord(
+  id: string,
+  previousHash: string | undefined,
+  overrides: Partial<Omit<VoteRecord, 'hash'>> = {}
+): VoteRecord {
+  const payload: Omit<VoteRecord, 'hash'> = {
+    version: '1.0',
+    id,
+    recordedAt: '2026-06-15T00:00:00.000Z',
+    proposalHash: 'a'.repeat(64),
+    proposal: 'Promote loop X from advisory to enforce',
+    strategy: 'higher_order',
+    decision: 'approved',
+    approvalPercentage: 85.7,
+    voteCounts: { approve: 6, reject: 1, abstain: 0, total: 7 },
+    voters: [
+      { role: 'architect', decision: 'approve', confidence: 0.9 },
+      { role: 'security', decision: 'reject', confidence: 0.6 },
+    ],
+    ...(previousHash !== undefined ? { previousHash } : {}),
+    ...overrides,
+  };
+  return { ...payload, hash: computeVoteRecordHash(payload) };
+}
+
+function chain(...records: VoteRecord[]): VoteRecord[] {
+  // Re-link each record onto the prior one's hash, then rehash.
+  const out: VoteRecord[] = [];
+  let prev: string | undefined;
+  for (const r of records) {
+    const payload: Omit<VoteRecord, 'hash'> = {
+      version: r.version,
+      id: r.id,
+      recordedAt: r.recordedAt,
+      proposalHash: r.proposalHash,
+      proposal: r.proposal,
+      strategy: r.strategy,
+      decision: r.decision,
+      approvalPercentage: r.approvalPercentage,
+      voteCounts: r.voteCounts,
+      voters: r.voters,
+      ...(r.correlationId !== undefined ? { correlationId: r.correlationId } : {}),
+      ...(prev !== undefined ? { previousHash: prev } : {}),
+    };
+    const linked: VoteRecord = { ...payload, hash: computeVoteRecordHash(payload) };
+    out.push(linked);
+    prev = linked.hash;
+  }
+  return out;
+}
+
+describe('verifyVoteRecordChain', () => {
+  it('verifies an empty chain trivially', () => {
+    expect(verifyVoteRecordChain([])).toEqual({ ok: true, recordCount: 0 });
+  });
+
+  it('verifies a well-formed single-record chain', () => {
+    const records = chain(makeRecord('vote-1', undefined));
+    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('verifies a multi-record chain that round-trips', () => {
+    const records = chain(
+      makeRecord('vote-1', undefined),
+      makeRecord('vote-2', undefined, { decision: 'rejected', approvalPercentage: 28.5 }),
+      makeRecord('vote-3', undefined)
+    );
+    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 3 });
+  });
+
+  it('DETECTS a flipped decision (rejected → approved) as hash_mismatch', () => {
+    const records = chain(makeRecord('vote-1', undefined, { decision: 'rejected' }));
+    // Forge: flip the decision on the persisted record WITHOUT rehashing.
+    const tampered: VoteRecord[] = [{ ...records[0]!, decision: 'approved' }];
+    const result = verifyVoteRecordChain(tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('hash_mismatch');
+      expect(result.recordId).toBe('vote-1');
+    }
+  });
+
+  it('DETECTS an altered approvalPercentage as hash_mismatch', () => {
+    const records = chain(makeRecord('vote-1', undefined, { approvalPercentage: 51 }));
+    const tampered: VoteRecord[] = [{ ...records[0]!, approvalPercentage: 99 }];
+    const result = verifyVoteRecordChain(tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS an edited voter summary as hash_mismatch', () => {
+    const records = chain(makeRecord('vote-1', undefined));
+    const tampered: VoteRecord[] = [
+      {
+        ...records[0]!,
+        voters: [{ role: 'security', decision: 'approve', confidence: 0.99 }],
+      },
+    ];
+    const result = verifyVoteRecordChain(tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS a broken back-link (re-ordered / spliced record) as previous_hash_mismatch', () => {
+    const records = chain(
+      makeRecord('vote-1', undefined),
+      makeRecord('vote-2', undefined),
+      makeRecord('vote-3', undefined)
+    );
+    // Drop the middle record: vote-3's previousHash no longer matches vote-1's hash.
+    const spliced = [records[0]!, records[2]!];
+    const result = verifyVoteRecordChain(spliced);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('previous_hash_mismatch');
+      expect(result.recordIndex).toBe(1);
+    }
+  });
+});

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -1,0 +1,209 @@
+/**
+ * nexus-agents/audit - Authentic Vote Record (#3897)
+ *
+ * A committed, append-only, tamper-EVIDENT record of a completed
+ * `consensus_vote`, persisted at vote time so the authority-ladder promotion
+ * gate (`scripts/check-authority-tier-drift.ts`, #3895) can rest authenticity
+ * on a hash chain instead of on hand-transcribed YAML.
+ *
+ * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
+ * The audit-event chain (`computeEventHash` in audit-logger.ts) hashes only the
+ * stable HEAD fields (id/timestamp/category/action/outcome/actor/previousHash)
+ * and intentionally NOT `metadata` — so riding a tier-transition-style metadata
+ * payload would leave the vote `decision`/`approvalPercentage` OUTSIDE the
+ * chain: an attacker could flip `rejected`→`approved` in the metadata without
+ * breaking any hash. That defeats the whole point of #3897. This record instead
+ * folds EVERY authenticity-bearing field — the proposal content hash, the
+ * decision, the approval percentage, the vote counts, and the per-voter
+ * summary — into the chained hash, so editing any of them is detected as a
+ * `hash_mismatch`. This is the tamper-evidence MVP; cryptographic
+ * signing/provenance (binding the record to a key) is DEFERRED (#3897 follow-up).
+ *
+ * @module audit/vote-record
+ */
+
+import * as crypto from 'node:crypto';
+
+import { z } from 'zod';
+
+/** Decision an `approved`/`rejected`/`no_quorum` consensus vote resolves to. */
+export const VoteRecordDecisionSchema = z.enum(['approved', 'rejected', 'no_quorum']);
+export type VoteRecordDecision = z.infer<typeof VoteRecordDecisionSchema>;
+
+/** Per-voter summary carried in an authentic vote record. */
+export const VoterSummarySchema = z
+  .object({
+    role: z.string().min(1).max(100),
+    decision: z.enum(['approve', 'reject', 'abstain']),
+    confidence: z.number().min(0).max(1),
+  })
+  .strict();
+export type VoterSummary = z.infer<typeof VoterSummarySchema>;
+
+/** The vote-count breakdown mirrored from the consensus engine result. */
+export const VoteRecordCountsSchema = z
+  .object({
+    approve: z.number().int().nonnegative(),
+    reject: z.number().int().nonnegative(),
+    abstain: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  })
+  .strict();
+export type VoteRecordCounts = z.infer<typeof VoteRecordCountsSchema>;
+
+/**
+ * One authentic, hash-chained vote record. The `hash` covers every field above
+ * it (including `previousHash`), so the record is tamper-EVIDENT: any edit to a
+ * persisted line is detected by {@link verifyVoteRecordChain}.
+ */
+export const VoteRecordSchema = z
+  .object({
+    /** Schema version for forward migrations. */
+    version: z.literal('1.0'),
+    /** Unique record id (also usable as a `ratificationVoteRef`). */
+    id: z.string().min(1),
+    /** ISO-8601 timestamp the vote was recorded. */
+    recordedAt: z.string().min(1),
+    /**
+     * SHA-256 of the FULL proposal text. The proposal itself is truncated for
+     * the human record (`proposal`), but the hash binds the record to the exact
+     * proposal voted on — a later edit of `proposal` that changes meaning is
+     * detectable by recomputing this hash from the original.
+     */
+    proposalHash: z.string().length(64),
+    /** Truncated proposal text for the human/reviewer record. */
+    proposal: z.string(),
+    /** The voting strategy used. */
+    strategy: z.enum([
+      'simple_majority',
+      'supermajority',
+      'unanimous',
+      'higher_order',
+      'opinion_wise',
+      'proof_of_learning',
+    ]),
+    /** The resolved decision. */
+    decision: VoteRecordDecisionSchema,
+    /** Approval fraction as a percentage (0-100). */
+    approvalPercentage: z.number().min(0).max(100),
+    /** Vote-count breakdown. */
+    voteCounts: VoteRecordCountsSchema,
+    /** Per-voter {role, decision, confidence} summary. */
+    voters: z.array(VoterSummarySchema),
+    /** Optional correlation/decision id linking to the cost rollup / trace. */
+    correlationId: z.string().min(1).optional(),
+    /** Hash of the previous record in the chain (absent for the first). */
+    previousHash: z.string().length(64).optional(),
+    /** SHA-256 over every field above + previousHash. */
+    hash: z.string().length(64),
+  })
+  .strict();
+export type VoteRecord = z.infer<typeof VoteRecordSchema>;
+
+/** The payload fields (everything except `hash`) the chain hash covers. */
+type VoteRecordPayload = Omit<VoteRecord, 'hash'>;
+
+/**
+ * Compute the SHA-256 over the canonical payload projection. Unlike the
+ * audit-event head hash, this folds in EVERY authenticity-bearing field, so a
+ * flipped `decision` or altered `approvalPercentage` changes the hash (the
+ * core #3897 property). The projection is built field-by-field (not
+ * `JSON.stringify(record)`) so key-order is deterministic regardless of how the
+ * object was constructed.
+ */
+export function computeVoteRecordHash(payload: VoteRecordPayload): string {
+  const canonical = JSON.stringify({
+    version: payload.version,
+    id: payload.id,
+    recordedAt: payload.recordedAt,
+    proposalHash: payload.proposalHash,
+    proposal: payload.proposal,
+    strategy: payload.strategy,
+    decision: payload.decision,
+    approvalPercentage: payload.approvalPercentage,
+    voteCounts: payload.voteCounts,
+    voters: payload.voters.map((v) => ({
+      role: v.role,
+      decision: v.decision,
+      confidence: v.confidence,
+    })),
+    correlationId: payload.correlationId ?? null,
+    previousHash: payload.previousHash ?? null,
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/** SHA-256 of arbitrary text — used for the proposal content hash. */
+export function hashProposal(proposal: string): string {
+  return crypto.createHash('sha256').update(proposal).digest('hex');
+}
+
+/**
+ * Discriminated result from {@link verifyVoteRecordChain}. Mirrors the audit
+ * `ChainVerification` shape so a future gate consumer handles both uniformly.
+ */
+export type VoteRecordVerification =
+  | { ok: true; recordCount: number }
+  | {
+      ok: false;
+      reason: 'hash_mismatch' | 'previous_hash_mismatch' | 'missing_hash';
+      recordIndex: number;
+      recordId: string;
+      detail: string;
+    };
+
+/** Per-record check; null when the record passes. */
+function verifyVoteRecord(
+  record: VoteRecord,
+  index: number,
+  priorHash: string | undefined
+): VoteRecordVerification | null {
+  if (record.hash.length === 0) {
+    return {
+      ok: false,
+      reason: 'missing_hash',
+      recordIndex: index,
+      recordId: record.id,
+      detail: `record at index ${String(index)} has no hash`,
+    };
+  }
+  if (index > 0 && record.previousHash !== priorHash) {
+    return {
+      ok: false,
+      reason: 'previous_hash_mismatch',
+      recordIndex: index,
+      recordId: record.id,
+      detail: `record at index ${String(index)} previousHash=${record.previousHash ?? '(missing)'} does not match prior record hash=${priorHash ?? '(missing)'}`,
+    };
+  }
+  const recomputed = computeVoteRecordHash(record);
+  if (recomputed !== record.hash) {
+    return {
+      ok: false,
+      reason: 'hash_mismatch',
+      recordIndex: index,
+      recordId: record.id,
+      detail: `record at index ${String(index)} stored hash=${record.hash} does not match recomputed=${recomputed}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Verify a hash-chained sequence of vote records. Walks the array in order and
+ * checks (a) each record's `hash` recomputes from its payload, and (b) each
+ * record's `previousHash` matches the prior record's `hash`. Returns the first
+ * detected tampering signal — a single tamper invalidates everything
+ * downstream. An empty sequence verifies trivially.
+ */
+export function verifyVoteRecordChain(records: readonly VoteRecord[]): VoteRecordVerification {
+  let priorHash: string | undefined;
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    if (record === undefined) continue;
+    const failure = verifyVoteRecord(record, i, priorHash);
+    if (failure !== null) return failure;
+    priorHash = record.hash;
+  }
+  return { ok: true, recordCount: records.length };
+}

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -15,6 +15,9 @@ import {
   getRandomProvider,
 } from '../../core/index.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
+import type { ConsensusResult } from '../../consensus/types.js';
+import type { VoteRecord } from '../../audit/vote-record.js';
+import { persistVoteRecord } from '../../audit/vote-record-store.js';
 import { getToolMemory } from './tool-memory.js';
 import {
   getOutcomeStore,
@@ -75,6 +78,54 @@ export function recordVoteSuccess(
   if (votes !== undefined) {
     recordVoteOutcomes(votes);
   }
+}
+
+/** Strategy values that map cleanly onto a {@link VoteRecord} strategy. */
+const VOTE_RECORD_STRATEGIES: ReadonlySet<VoteRecord['strategy']> = new Set([
+  'simple_majority',
+  'supermajority',
+  'unanimous',
+  'higher_order',
+  'opinion_wise',
+  'proof_of_learning',
+]);
+
+/** Narrow an arbitrary strategy string to the record enum, defaulting safely. */
+function toRecordStrategy(strategy: string): VoteRecord['strategy'] {
+  return VOTE_RECORD_STRATEGIES.has(strategy as VoteRecord['strategy'])
+    ? (strategy as VoteRecord['strategy'])
+    : 'simple_majority';
+}
+
+/**
+ * Persist an authentic, hash-chained vote record to the committable governance
+ * artifact at vote time (#3897). Best-effort: a persist failure must never fail
+ * the vote, so the store swallows + logs. Skips all-simulated runs (random
+ * output must not seed a committed record). Returns the written record (or
+ * undefined when skipped / no committable location).
+ */
+export function recordAuthenticVote(args: {
+  proposal: string;
+  strategy: string;
+  result: ConsensusResult;
+  votes: readonly AgentVoteResult[];
+  correlationId?: string | undefined;
+}): VoteRecord | undefined {
+  const allSimulated = args.votes.length > 0 && args.votes.every((v) => v.source === 'simulation');
+  if (allSimulated) {
+    logger.debug('Skipping authentic vote record — all votes simulated');
+    return undefined;
+  }
+  const id = `vote-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 9)}`;
+  return persistVoteRecord({
+    id,
+    proposal: args.proposal,
+    strategy: toRecordStrategy(args.strategy),
+    result: args.result,
+    votes: args.votes,
+    ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
+    logger,
+  });
 }
 
 /** Records a failed consensus vote to session memory. Best-effort. */

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -54,7 +54,11 @@ import {
   shouldEscalateLowPosterior,
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
-import { recordVoteSuccess, recordVoteError } from './consensus-vote-recording.js';
+import {
+  recordVoteSuccess,
+  recordVoteError,
+  recordAuthenticVote,
+} from './consensus-vote-recording.js';
 import { recordDecisionCost } from './decision-cost-recording.js';
 import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
@@ -675,6 +679,41 @@ function finalizeVotingResult(args: {
 }
 
 // --- Handler & Registration ---
+/**
+ * Best-effort post-vote side effects, extracted to keep `handleConsensusVote`
+ * under the per-function line cap. Persists the authentic hash-chained vote
+ * record (#3897) and rolls up per-decision cost (#3855), sharing one decision
+ * id as the correlation key. Neither must fail the vote — both are guarded.
+ */
+function recordVoteSideEffects(
+  proposal: string,
+  strategy: string,
+  result: ExtendedVotingResult,
+  logger: ILogger
+): ReturnType<typeof recordDecisionCost> | undefined {
+  const decisionId = `consensus-${String(getTimeProvider().now())}-${randomUUID().slice(0, 8)}`;
+  // #3897: persist an authentic, hash-chained vote record to the committable
+  // governance artifact at vote time so the promotion gate/CI can rest
+  // authenticity on the chain, not on hand-transcribed YAML.
+  recordAuthenticVote({
+    proposal,
+    strategy,
+    result: result.result,
+    votes: result.votes,
+    correlationId: decisionId,
+  });
+  // #3855: roll up + persist this decision's per-voter cost and ride it on the
+  // existing response (no new MCP tool). A rollup failure must not fail the vote.
+  try {
+    return recordDecisionCost({ decisionId, gate: 'consensus_vote', votes: result.votes });
+  } catch (costError) {
+    logger.warn('Per-decision cost rollup failed (non-fatal)', {
+      error: getErrorMessage(costError),
+    });
+    return undefined;
+  }
+}
+
 async function handleConsensusVote(
   deps: ConsensusVoteDeps,
   args: ConsensusVoteInput
@@ -704,22 +743,7 @@ async function handleConsensusVote(
       result.totalTimeMs,
       result.votes
     );
-    // #3855: roll up + persist this decision's per-voter cost and ride it on the
-    // existing response (no new MCP tool). Best-effort — the store never throws,
-    // and a rollup failure must not fail the vote, so guard the whole step.
-    let costSummary;
-    try {
-      const decisionId = `consensus-${String(getTimeProvider().now())}-${randomUUID().slice(0, 8)}`;
-      costSummary = recordDecisionCost({
-        decisionId,
-        gate: 'consensus_vote',
-        votes: result.votes,
-      });
-    } catch (costError) {
-      logger.warn('Per-decision cost rollup failed (non-fatal)', {
-        error: getErrorMessage(costError),
-      });
-    }
+    const costSummary = recordVoteSideEffects(args.proposal, strategy, result, logger);
     // Close the self-tuning loop: a rejected vote emits signal.vote_rejected
     // onto the typed pipeline bus for the shadow TuneStage (#3147; #3289 Option 2).
     emitVoteRejectedSignal(result.result, getPipelineEventBus(), logger);


### PR DESCRIPTION
## Summary

Issue #3897 (security): the authority-ladder promotion gate (#3895) resolves a `ratificationVoteRef` against the committed `governance/ratification-votes.yaml` ledger, but that ledger is **hand-committable** — the gate verifies STRUCTURAL PRESENCE, not AUTHENTICITY, so anyone who can land a commit can forge a conforming entry. Live `consensus_vote` results previously persisted only to per-developer home-dir stores (`~/.nexus-agents/voting`, `~/.nexus-agents/learning`) that CI cannot read.

This PR persists each completed `consensus_vote` to a **committed, append-only, tamper-EVIDENT artifact at vote time** (`governance/vote-records.jsonl`), so authenticity rests on a hash chain rather than on manual YAML transcription.

## Design

**Dedicated payload-covering hash chain, NOT the audit-event head hash.** I evaluated riding the existing hash-chained audit log via a `logTierTransition`-style metadata payload, but rejected it: `computeEventHash` (audit-logger.ts) folds only the stable HEAD fields (id/timestamp/category/action/outcome/actor/previousHash) and **intentionally NOT `metadata`**. A metadata-carried vote payload would therefore leave the vote `decision`/`approvalPercentage` OUTSIDE the chain — an attacker could flip `rejected`→`approved` in the metadata without breaking any hash, defeating the whole point of #3897. (The `#3921` "payload-covering projection / tier-transition-hash.ts" referenced in the issue does not exist in the tree today, so there was nothing to reuse.)

Instead, `src/audit/vote-record.ts` defines a self-contained chain whose `hash` folds in **every authenticity-bearing field** — proposal content hash, decision, approval percentage, vote counts, and per-voter `{role, decision, confidence}` — plus `previousHash`. Editing any of them is detected as a `hash_mismatch`; splicing/reordering is detected as `previous_hash_mismatch`. This mirrors the tier-transition tamper-evidence approach while closing its payload-coverage gap.

**Rides the existing vote path; no new MCP tool.** `recordAuthenticVote` (in `consensus-vote-recording.ts`) is called as a best-effort side effect from `handleConsensusVote`'s success branch, sharing the same decision id used by the #3855 cost rollup as the correlation key. The store (`vote-record-store.ts`) writes to `<repo-root>/governance/vote-records.jsonl` (committable, CI-readable) and never throws into the vote path. MCP_TOOL_COUNT is unchanged (#3855 precedent respected).

**DRY/drift hazard removed (DevEx, #3897).** This is the *automated* authoring path: the committed record is written from the live vote, so it cannot drift from what actually happened the way a hand-edited `ratification-votes.yaml` entry can.

## Gate seam (next step, deferred)

`readVoteRecords` + `verifyVoteRecordChain` are the tested seam a future `scripts/check-authority-tier-drift.ts` revision uses to resolve a `ratificationVoteRef` against the committed records and reject a chain that fails verification. This PR does **not** rewire the gate.

## Deferred

- **Cryptographic signing / provenance-stamping** (binding the record to a key — the AI/ML voter's stretch goal) is deferred to a follow-up. Tamper-EVIDENCE via the hash chain is the MVP; tamper-PROOF signing is later.
- **Full gate rewiring** to consume the new artifact (see the seam above).

## Tests (TDD)

`src/audit/vote-record.test.ts` + `src/audit/vote-record-store.test.ts`:
- A completed vote persists an authentic record carrying the proposal hash + decision + per-voter summary.
- Flipping `decision` (rejected→approved) on a persisted line is DETECTED as `hash_mismatch` — the core authenticity property; also covers altered `approvalPercentage` and edited voter.
- The record is append-only, chains onto the prior record, and round-trips through read.

## Gate-tripwire checks run green

- `tsc --noEmit` — clean (pre-existing `nexus-memory` dist errors resolved by building the workspace dep).
- `eslint` on all changed files — clean (file ≤400 lines, functions ≤50 lines; `handleConsensusVote` kept under cap by extracting `recordVoteSideEffects`).
- `vitest run` — 200/200 audit tests + 84/84 consensus-vote tests pass.
- `scripts/check-new-unused-exports.ts` — pass (real in-`src` consumers; no `@export-no-consumer-yet` needed).
- `scripts/check-authority-tier-drift.ts` — pass (new artifact does not perturb the existing gate).
- Changeset `.changeset/authentic-vote-record-3897.md` (`'nexus-agents': patch`, `fix(...)` type).

## Judgment calls to review

1. **Standalone chain vs. audit log.** I did NOT ride the audit logger, for the payload-coverage reason above. If you'd prefer extending `computeEventHash` to optionally cover a metadata projection (and thus unify with the tier-transition log), that's a larger change worth its own issue.
2. **Artifact location** `governance/vote-records.jsonl` (committed), distinct from the `.nexus-agents/` home-dir stores. Committed an empty placeholder so the path is stable for the gate seam.
3. **all-simulated skip** is enforced in `recordAuthenticVote` (not the store), so the store stays a pure mechanism — matching `recordVoteSuccess`'s posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
