### PR TITLE
docs: tighten closed-loop tagline to human-gated/demotion-only reality (#3909)

### DIFF
--- a/.changeset/tagline-honesty-3909.md
+++ b/.changeset/tagline-honesty-3909.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+docs(readme): tighten the closed-loop tagline to human-gated/demotion-only reality (#3909)
+
+From the #3907 ratification honesty-of-framing note. The README headline read as fully autonomous ("closed-loop self-tuning"), but the loop does not close autonomously: tier promotion is earned via the ADR-0017 authority ladder (human-gated ratification), and the `TuneAdjustmentStore` is bounded and demotion-only — autonomous changes only ever reduce authority/aggressiveness. Reworded the root and package taglines to "human-gated closed-loop tuning (autonomous demotion, earned promotion)" so a reader seeing only the one-liner does not infer full autonomy. Prose only; no code changes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12365/badge)](https://www.bestpractices.dev/projects/12365) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nexus-substrate/nexus-agents/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nexus-substrate/nexus-agents)
 
-> Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, closed-loop self-tuning
+> Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, human-gated closed-loop tuning (autonomous demotion, earned promotion)
 
 [![npm version](https://img.shields.io/npm/v/nexus-agents)](https://www.npmjs.com/package/nexus-agents)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packages/nexus-agents/README.md
+++ b/packages/nexus-agents/README.md
@@ -1,6 +1,6 @@
 # Nexus Agents
 
-> Governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry
+> Governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, human-gated closed-loop tuning (autonomous demotion, earned promotion)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org)


### PR DESCRIPTION
Implements #3909. From the #3907 ratification (recurring honesty-of-framing note): the README headline read as fully autonomous, but the loop does **not** close autonomously — tier promotion is EARNED via the ADR-0017 authority ladder (human-gated ratification), and the `TuneAdjustmentStore` is bounded and **demotion-only** (autonomous changes only ever reduce authority/aggressiveness; raising it requires earned, ratified promotion).

Headline-level prose only. No code, no `scripts/inject-governance.ts`, no `docs-check.yml`, no `SKILL.md`. Stamped governance regions left untouched.

## Before → After

**Root `README.md`:**

- Before: `> Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, closed-loop self-tuning`
- After: `> Autonomic control plane for AI coding agents — one entry point, adversarial review, tamper-evident hash-chained audit, human-gated closed-loop tuning (autonomous demotion, earned promotion)`

**`packages/nexus-agents/README.md`:**

- Before: `> Governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, closed-loop telemetry`
- After: `> Governance substrate for your AI coding agents — adversarial review, drift-detected rules, immutable audit, human-gated closed-loop tuning (autonomous demotion, earned promotion)`

Existing body caveats (the ADR-0017 honesty note, "Not fully autonomous", the demotion-only / capped / auto-decaying detail) already agree with the new headline and were left intact.

## Changeset
`.changeset/tagline-honesty-3909.md` — `'nexus-agents': patch`, `docs(readme):` summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
