### PR TITLE
fix(governance): refine tool-fitness suggest-signal heuristics (#3902)

### DIFF
--- a/.changeset/tool-fitness-heuristics-3902.md
+++ b/.changeset/tool-fitness-heuristics-3902.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): refine tool-fitness suggest-signal heuristics (#3902)
+
+Refines three signal-quality heuristics in the `tool-fitness` improvement_review
+consumer flagged in the #3900 ratification (Contrarian's signal-quality
+concerns). The Epic F invariant is preserved throughout: every signal is
+suggest-tier only (severity `info`/`warning`, never `critical`, routed through
+`assertNeverAutonomousRemoval`) — a human always reviews; nothing here removes a
+tool.
+
+1. **Consolidation: shared name-prefix is now only a WEAK hint.** A shared
+   prefix is no longer treated as proof of substitutability. An orthogonal
+   action-verb check suppresses prefix-siblings whose verbs sit in clearly
+   opposed groups (`git_init` vs `git_commit`, `db_read` vs `db_drop_table`), so
+   a rare sibling is never flagged for folding into a busy one on prefix alone.
+   Surviving prefix-only matches are surfaced as LOW-CONFIDENCE candidates.
+   Scoped step: a true capability/schema-overlap model is deferred behind a
+   `TODO(#3902)` — until that data seam lands, prefix-family is never strong
+   evidence.
+
+2. **Break-glass exemption for low-usage-BY-DESIGN tools.** Rare-but-critical
+   tools (rollback / recovery / emergency admin) are exempt from the
+   `<= 2 invocations` deprecation flag via a never-deprecate predicate (default
+   break-glass name patterns + an injectable `NeverDeprecateConfig`
+   exempt-tools/extra-patterns override), removing false-positive deprecation
+   noise.
+
+3. **Workspace-scoped localized signal instead of full suppression.** When a
+   tool's poor global rate is suppressed as context-poisoning (healthy in
+   another workspace), the genuine localized failure is no longer fully
+   silenced: a workspace-scoped "failing here" signal surfaces the local
+   misconfig (global deprecation still suppressed).
+
+New pure heuristics live in a sibling module
+(`improvement-review-tool-fitness-heuristics.ts`) so the consumer stays under
+the 400-line cap. RED-then-GREEN tests added for all three items.

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness-heuristics.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness-heuristics.ts
@@ -1,0 +1,357 @@
+/**
+ * Refined heuristics for the tool-fitness consumer (#3902, refining #3852).
+ *
+ * Sibling helper module extracted to keep the consumer under the 400-line cap.
+ * Owns three signal-quality refinements raised in the #3900 ratification
+ * (Contrarian's signal-quality concerns):
+ *
+ * 1. **Consolidation overlap, not bare prefix** — a shared name-prefix is NOT
+ *    proof of substitutability (`git_commit` vs `git_init`, `db_read` vs
+ *    `db_drop_table` share a prefix but are orthogonal). {@link consolidationConfidence}
+ *    downgrades prefix-only matches to a WEAK/low-confidence hint and withholds
+ *    the candidate entirely when the action-verb suffixes are clearly orthogonal,
+ *    so a rare sibling is not flagged for folding into a busy one on prefix alone.
+ *    (Full capability-overlap modelling is a later seam — see TODO below.)
+ * 2. **Break-glass exemption** — {@link isNeverDeprecate} exempts low-usage-BY-DESIGN
+ *    tools (rollback / recovery / emergency admin) from the `<= 2 invocations`
+ *    deprecation flag so a rare-but-critical tool isn't surfaced as dead weight.
+ * 3. **Workspace-scoped localized signal** — instead of FULLY suppressing a
+ *    cross-workspace-healthy tool's failure, {@link buildLocalizedSignals} emits a
+ *    workspace-scoped "failing here" signal (global deprecation suppressed; the
+ *    genuine localized misconfig warning still surfaces).
+ *
+ * EPIC F INVARIANT preserved: every builder here returns a suggest-tier signal
+ * (severity `info`/`warning`, never `critical`) routed through the consumer's
+ * `assertNeverAutonomousRemoval` guard. Nothing here removes anything.
+ *
+ * @module mcp/tools/improvement-review-tool-fitness-heuristics
+ * (Source: Issue #3902)
+ */
+
+import type { ImprovementSignal } from './improvement-review.js';
+import type { ToolFitnessStat } from '../../governance/tool-fitness-ledger.js';
+
+// ============================================================================
+// Honest thresholds (documented per acceptance criteria)
+// ============================================================================
+
+/**
+ * Minimum invocations before the success-rate dimension is trustworthy. Below
+ * this, a tool is judged on USAGE only (a 1/2-failure tool is noise, not a
+ * fitness signal). Mirrors the improvement_review `minSampleSize` philosophy.
+ */
+export const FITNESS_MIN_SAMPLE = 10;
+
+/**
+ * At/under this invocation count a tool is a LOW-USAGE deprecation candidate —
+ * it is barely being selected, so it may be dead weight against the ~47-tool
+ * selection ceiling (epic #3850 narrative). Usage is global by nature, so this
+ * is NOT workspace-scoped.
+ */
+export const LOW_USAGE_MAX_INVOCATIONS = 2;
+
+/**
+ * Success rate at/under this (with >= {@link FITNESS_MIN_SAMPLE} samples) makes a
+ * tool a POOR-RELIABILITY deprecation candidate — it is selected but frequently
+ * fails. Workspace-scoped.
+ */
+export const POOR_SUCCESS_RATE_MAX = 0.5;
+
+/**
+ * A tool counts as "healthy in another workspace" when, scoped to that
+ * workspace, its success rate clears this floor over a meaningful sample. Used
+ * to suppress a global poor-reliability flag that is really workspace-local.
+ */
+export const HEALTHY_WORKSPACE_SUCCESS_FLOOR = 0.8;
+
+/**
+ * Consolidation: within a shared tool-name prefix family (e.g. `research_*`), a
+ * member used at/under this FRACTION of the busiest sibling's invocations is a
+ * consolidation candidate (could fold into a sibling). Family must have >= 2
+ * members and the busiest sibling must clear {@link FITNESS_MIN_SAMPLE} so the
+ * comparison isn't noise.
+ */
+export const CONSOLIDATION_USAGE_FRACTION = 0.1;
+
+// ============================================================================
+// SUGGEST-TIER invariant guard (Epic F)
+// ============================================================================
+
+/**
+ * Runtime assertion of the Epic-F invariant: a tool-fitness signal is ALWAYS a
+ * suggest-tier candidate, never an autonomous removal. Caps severity at
+ * `warning` (never `critical`) so the priority classifier can't escalate a
+ * fitness signal toward an auto-remediation tier, and pins the category. Throws
+ * (loudly, in tests + dev) if a future edit tries to emit a removal-grade
+ * signal. Returns the signal unchanged on success for fluent use.
+ */
+export function assertNeverAutonomousRemoval(signal: ImprovementSignal): ImprovementSignal {
+  if (signal.category !== 'tool-fitness') {
+    throw new Error(
+      `tool-fitness invariant: expected category 'tool-fitness', got '${signal.category}'`
+    );
+  }
+  if (signal.severity === 'critical') {
+    throw new Error(
+      `tool-fitness invariant (Epic F): a tool-fitness signal must be suggest-tier ` +
+        `(severity 'info'|'warning'), never 'critical' — removal is NEVER autonomous`
+    );
+  }
+  return signal;
+}
+
+// ============================================================================
+// Item 2 — break-glass / never-deprecate exemption
+// ============================================================================
+
+/**
+ * Default action-verb fragments that mark a tool as low-usage-BY-DESIGN
+ * (break-glass / recovery / emergency admin). A tool whose name contains one of
+ * these is rare ON PURPOSE — flagging it for deprecation on a `<= 2 invocations`
+ * count is a false positive. Matched case-insensitively as a substring of the
+ * tool name. Override via {@link NeverDeprecateConfig.extraPatterns} /
+ * {@link NeverDeprecateConfig.exemptTools} for repo-specific break-glass tools.
+ */
+export const DEFAULT_NEVER_DEPRECATE_PATTERNS: readonly string[] = [
+  'rollback',
+  'recover',
+  'restore',
+  'emergency',
+  'break_glass',
+  'breakglass',
+  'panic',
+  'failover',
+  'disaster',
+  'evacuate',
+  'quarantine',
+];
+
+/** Injectable break-glass exemption config (defaults preserve current behavior + the safe-list). */
+export interface NeverDeprecateConfig {
+  /** Exact tool names that are never deprecation candidates regardless of usage. */
+  readonly exemptTools?: readonly string[];
+  /** Extra substring patterns appended to {@link DEFAULT_NEVER_DEPRECATE_PATTERNS}. */
+  readonly extraPatterns?: readonly string[];
+}
+
+/**
+ * True when `tool` is tagged never-deprecate / break-glass and must therefore be
+ * EXEMPT from the low-usage deprecation flag (item 2). Pure.
+ */
+export function isNeverDeprecate(tool: string, config?: NeverDeprecateConfig): boolean {
+  if (config?.exemptTools?.includes(tool) === true) return true;
+  const lower = tool.toLowerCase();
+  const patterns = [...DEFAULT_NEVER_DEPRECATE_PATTERNS, ...(config?.extraPatterns ?? [])];
+  return patterns.some((p) => lower.includes(p));
+}
+
+// ============================================================================
+// Item 1 — consolidation overlap confidence (prefix is only a WEAK hint)
+// ============================================================================
+
+/**
+ * Action verbs that mutate/destroy vs. read/create — when two prefix-siblings
+ * carry verbs from clearly opposed groups they are ORTHOGONAL (not
+ * substitutable), so the prefix match is suppressed entirely. This is the
+ * honest, ledger-name-only overlap proxy; a real capability/schema-overlap model
+ * is the later seam.
+ *
+ * TODO(#3902): replace this name-suffix heuristic with a true capability-overlap
+ * signal (tool input/output schema similarity) once the tool-distinctness data
+ * seam lands. Until then prefix-family is a WEAK hint only.
+ */
+const ORTHOGONAL_VERB_GROUPS: readonly (readonly string[])[] = [
+  ['init', 'create', 'add', 'new', 'open', 'start', 'enable', 'register'],
+  ['drop', 'delete', 'remove', 'destroy', 'close', 'stop', 'disable', 'purge'],
+  ['read', 'get', 'list', 'query', 'show', 'status', 'inspect'],
+  ['commit', 'write', 'update', 'set', 'put', 'apply'],
+];
+
+/** Confidence of a prefix-only consolidation hint. */
+export type ConsolidationConfidence = 'low' | 'none';
+
+/** The action-verb suffix of a tool name (segment after the family prefix). */
+function actionVerb(tool: string): string | undefined {
+  const sep = /[_-]/;
+  const parts = tool.toLowerCase().split(sep).filter(Boolean);
+  return parts.length >= 2 ? parts[1] : undefined;
+}
+
+/** Index of the orthogonal-verb group a verb belongs to, or -1. */
+function verbGroup(verb: string | undefined): number {
+  if (verb === undefined) return -1;
+  return ORTHOGONAL_VERB_GROUPS.findIndex((g) => g.includes(verb));
+}
+
+/**
+ * Confidence that a prefix-sharing pair (`candidate`, `busiest`) is genuinely a
+ * consolidation candidate, using a name-suffix overlap proxy (item 1):
+ *
+ * - `'none'` — the two verbs sit in clearly OPPOSED action groups
+ *   (e.g. `init` vs `drop`, `commit` vs `init`) → orthogonal, do NOT surface.
+ * - `'low'` — prefix matches but overlap is unproven → surface as a
+ *   LOW-CONFIDENCE hint (the prefix family alone is weak evidence).
+ *
+ * Pure. There is no `'high'` tier yet: until a real capability-overlap model
+ * exists, prefix-family is never strong evidence. (See module TODO.)
+ */
+export function consolidationConfidence(
+  candidate: ToolFitnessStat,
+  busiest: ToolFitnessStat
+): ConsolidationConfidence {
+  const a = verbGroup(actionVerb(candidate.tool));
+  const b = verbGroup(actionVerb(busiest.tool));
+  // Both verbs classified and in different opposed groups → orthogonal siblings.
+  if (a !== -1 && b !== -1 && a !== b) return 'none';
+  return 'low';
+}
+
+// ============================================================================
+// Suggest-tier signal builders (all routed through the Epic-F guard)
+// ============================================================================
+
+/** Build a low-usage deprecation candidate signal (suggest-tier). */
+export function lowUsageSignal(stat: ToolFitnessStat, windowLabel: string): ImprovementSignal {
+  return assertNeverAutonomousRemoval({
+    category: 'tool-fitness',
+    signalKey: `tool-fitness:deprecation-candidate:low-usage:${stat.tool}`,
+    severity: 'info',
+    title: `tool-fitness: \`${stat.tool}\` is a low-usage deprecation CANDIDATE (${String(stat.invocationCount)} invocations)`,
+    body: [
+      `\`${stat.tool}\` is barely selected and is a CANDIDATE for human review — NOT an automatic removal.`,
+      '',
+      `- Invocations: ${String(stat.invocationCount)} (threshold: ≤ ${String(LOW_USAGE_MAX_INVOCATIONS)})`,
+      `- Last used: ${stat.lastUsedAt}`,
+      `- Success rate: ${String(Math.round(stat.successRate * 100))}%`,
+      `- Window: ${windowLabel}`,
+      '',
+      'SUGGEST-TIER ONLY (Epic F): low usage against the ~47-tool selection ceiling ' +
+        'may mean dead weight. Removal is NEVER autonomous — it requires the Epic D ' +
+        'human-ratification path (see the #3853 removal/consolidation runbook). ' +
+        'Mind the LinUCB exploration floor: a low-usage tool must not death-spiral.',
+    ].join('\n'),
+    evidence: {
+      samples: stat.invocationCount,
+      window: windowLabel,
+      observedValue: stat.invocationCount,
+      threshold: LOW_USAGE_MAX_INVOCATIONS,
+    },
+  });
+}
+
+/** Build a poor-reliability deprecation candidate signal (suggest-tier). */
+export function poorReliabilitySignal(
+  stat: ToolFitnessStat,
+  windowLabel: string
+): ImprovementSignal {
+  return assertNeverAutonomousRemoval({
+    category: 'tool-fitness',
+    signalKey: `tool-fitness:deprecation-candidate:poor-success:${stat.tool}`,
+    severity: 'warning',
+    title: `tool-fitness: \`${stat.tool}\` has a low success rate ${String(Math.round(stat.successRate * 100))}% — deprecation CANDIDATE`,
+    body: [
+      `\`${stat.tool}\` fails often across its uses and is a CANDIDATE for human review — NOT an automatic removal.`,
+      '',
+      `- Success rate: ${String(Math.round(stat.successRate * 100))}% (${String(stat.successCount)}/${String(stat.invocationCount)}, threshold ≤ ${String(Math.round(POOR_SUCCESS_RATE_MAX * 100))}%)`,
+      `- Samples: ${String(stat.invocationCount)} (≥ ${String(FITNESS_MIN_SAMPLE)} required)`,
+      `- Workspaces observed: ${stat.workspaces.join(', ')}`,
+      `- Window: ${windowLabel}`,
+      '',
+      'Workspace-scoped (#3852): this fires only because the tool is unhealthy across ' +
+        'workspaces, not just one — a single-workspace failure (local perms / missing ' +
+        'deps) is suppressed so it cannot globally mis-flag a healthy tool.',
+      '',
+      'SUGGEST-TIER ONLY (Epic F): consider consolidating or deprecating after human ' +
+        'review. Removal is NEVER autonomous — Epic D ratification (#3853 runbook).',
+    ].join('\n'),
+    evidence: {
+      samples: stat.invocationCount,
+      window: windowLabel,
+      observedValue: stat.successRate,
+      threshold: POOR_SUCCESS_RATE_MAX,
+    },
+  });
+}
+
+/**
+ * Build a WORKSPACE-SCOPED localized reliability signal (#3902 item 3). Emitted
+ * when a tool's poor GLOBAL rate was suppressed as context-poisoning (healthy
+ * elsewhere) BUT it is genuinely failing in `workspace` — the global deprecation
+ * stays suppressed, yet the localized "failing here" misconfig warning still
+ * surfaces instead of being fully silenced. Suggest-tier; explicitly NOT a
+ * deprecation candidate.
+ */
+export function localizedReliabilitySignal(
+  scoped: ToolFitnessStat,
+  workspace: string,
+  windowLabel: string
+): ImprovementSignal {
+  return assertNeverAutonomousRemoval({
+    category: 'tool-fitness',
+    signalKey: `tool-fitness:localized-failure:${scoped.tool}:${workspace}`,
+    severity: 'warning',
+    title: `tool-fitness: \`${scoped.tool}\` is failing in workspace \`${workspace}\` (healthy elsewhere)`,
+    body: [
+      `\`${scoped.tool}\` is healthy in other workspaces, so this is NOT a global deprecation ` +
+        `candidate. But it fails locally in \`${workspace}\` — a likely LOCALIZED misconfig ` +
+        `(local perms / missing deps / repo-specific config) worth investigating HERE.`,
+      '',
+      `- Workspace: ${workspace}`,
+      `- Local success rate: ${String(Math.round(scoped.successRate * 100))}% (${String(scoped.successCount)}/${String(scoped.invocationCount)}, threshold ≤ ${String(Math.round(POOR_SUCCESS_RATE_MAX * 100))}%)`,
+      `- Local samples: ${String(scoped.invocationCount)} (≥ ${String(FITNESS_MIN_SAMPLE)} required)`,
+      `- Window: ${windowLabel}`,
+      '',
+      'WORKSPACE-SCOPED (#3902): cross-workspace suppression fixes context-poisoning but ' +
+        'should not discard a genuine localized warning. This surfaces the local failure ' +
+        'WITHOUT globally mis-flagging a tool that is healthy elsewhere.',
+      '',
+      'SUGGEST-TIER ONLY (Epic F): a localized diagnostic for human review — never an ' +
+        'autonomous removal. Removal is Epic D ratification (#3853 runbook).',
+    ].join('\n'),
+    evidence: {
+      samples: scoped.invocationCount,
+      window: windowLabel,
+      observedValue: scoped.successRate,
+      threshold: POOR_SUCCESS_RATE_MAX,
+    },
+  });
+}
+
+/** Build a consolidation candidate signal (suggest-tier, LOW-CONFIDENCE per #3902). */
+export function consolidationSignal(
+  stat: ToolFitnessStat,
+  family: string,
+  busiestTool: string,
+  busiestCount: number,
+  windowLabel: string
+): ImprovementSignal {
+  return assertNeverAutonomousRemoval({
+    category: 'tool-fitness',
+    signalKey: `tool-fitness:consolidation-candidate:${stat.tool}`,
+    severity: 'info',
+    title: `tool-fitness: \`${stat.tool}\` is a LOW-CONFIDENCE consolidation CANDIDATE within the \`${family}_*\` family`,
+    body: [
+      `\`${stat.tool}\` is far less used than its \`${family}_*\` siblings and is a CANDIDATE ` +
+        `for folding into a sibling — for human review, NOT an automatic removal.`,
+      '',
+      `- This tool: ${String(stat.invocationCount)} invocations`,
+      `- Busiest sibling \`${busiestTool}\`: ${String(busiestCount)} invocations`,
+      `- Ratio: ${String(Math.round((stat.invocationCount / busiestCount) * 100))}% (threshold ≤ ${String(Math.round(CONSOLIDATION_USAGE_FRACTION * 100))}%)`,
+      `- Window: ${windowLabel}`,
+      `- Confidence: LOW (#3902) — a shared name-prefix is a WEAK hint, NOT proof of`,
+      '  substitutability. The orthogonal-action-verb check passed (siblings are not',
+      '  obviously opposed like `init` vs `drop`), but no capability/schema-overlap',
+      '  signal exists yet to confirm these tools are actually interchangeable.',
+      '',
+      'SUGGEST-TIER ONLY (Epic F): overlapping tools inflate the selection surface. ' +
+        'Consolidation is a human decision via the Epic D path (#3853 runbook); nothing ' +
+        'here removes or merges anything automatically.',
+    ].join('\n'),
+    evidence: {
+      samples: stat.invocationCount,
+      window: windowLabel,
+      observedValue: stat.invocationCount / busiestCount,
+      threshold: CONSOLIDATION_USAGE_FRACTION,
+    },
+  });
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.test.ts
@@ -15,12 +15,18 @@ import {
   detectDeprecationCandidates,
   detectConsolidationCandidates,
   isHealthyInAnyOtherWorkspace,
+  locallyFailingWorkspaces,
   assertNeverAutonomousRemoval,
   loadToolFitnessSignals,
   FITNESS_MIN_SAMPLE,
   LOW_USAGE_MAX_INVOCATIONS,
   POOR_SUCCESS_RATE_MAX,
 } from './improvement-review-tool-fitness.js';
+import {
+  consolidationConfidence,
+  isNeverDeprecate,
+  DEFAULT_NEVER_DEPRECATE_PATTERNS,
+} from './improvement-review-tool-fitness-heuristics.js';
 import { ToolFitnessLedger, type ToolFitnessStat } from '../../governance/tool-fitness-ledger.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { ImprovementReviewInputSchema } from './improvement-review.js';
@@ -156,7 +162,7 @@ describe('detectDeprecationCandidates — poor reliability + workspace scoping (
     expect(signals[0]!.body).toMatch(/NEVER autonomous/);
   });
 
-  it('does NOT flag a tool that fails in one workspace but is healthy in another', () => {
+  it('does NOT raise a GLOBAL deprecation when a tool fails in one workspace but is healthy in another', () => {
     const poisoned = stat({
       tool: 'workspace_local_fail',
       invocationCount: 2 * FITNESS_MIN_SAMPLE,
@@ -170,6 +176,7 @@ describe('detectDeprecationCandidates — poor reliability + workspace scoping (
           tool: 'workspace_local_fail',
           invocationCount: FITNESS_MIN_SAMPLE,
           successCount: FITNESS_MIN_SAMPLE,
+          workspaces: ['healthy-repo'],
         });
       }
       // broken-repo: all failures (local perms / missing deps).
@@ -177,10 +184,14 @@ describe('detectDeprecationCandidates — poor reliability + workspace scoping (
         tool: 'workspace_local_fail',
         invocationCount: FITNESS_MIN_SAMPLE,
         successCount: 0,
+        workspaces: ['broken-repo'],
       });
     };
     const signals = detectDeprecationCandidates([poisoned], statInWorkspace, WINDOW);
-    expect(signals).toEqual([]); // suppressed — the failure is workspace-local
+    // #3902 item 3: global deprecation is suppressed, but the localized failure is
+    // NOT fully silenced — a workspace-scoped signal still surfaces the misconfig.
+    expect(signals.every((s) => !s.signalKey.includes('deprecation-candidate'))).toBe(true);
+    expect(signals.some((s) => s.signalKey.includes('localized-failure'))).toBe(true);
   });
 
   it('isHealthyInAnyOtherWorkspace requires >=2 real workspaces', () => {
@@ -250,6 +261,152 @@ describe('detectConsolidationCandidates', () => {
       stat({ tool: 'run', invocationCount: 1 }),
     ];
     expect(detectConsolidationCandidates(report, WINDOW)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// #3902 item 1 — prefix is only a WEAK hint; orthogonal siblings not flagged
+// ============================================================================
+
+describe('consolidationConfidence (#3902 item 1) — shared prefix ≠ substitutable', () => {
+  it('returns "none" for orthogonal action verbs (git_init vs git_commit)', () => {
+    const init = stat({ tool: 'git_init', invocationCount: 2 });
+    const commit = stat({ tool: 'git_commit', invocationCount: 100 });
+    expect(consolidationConfidence(init, commit)).toBe('none');
+  });
+
+  it('returns "none" for db_read vs db_drop_table (read vs destroy)', () => {
+    const read = stat({ tool: 'db_read', invocationCount: 2 });
+    const drop = stat({ tool: 'db_drop_table', invocationCount: 100 });
+    expect(consolidationConfidence(read, drop)).toBe('none');
+  });
+
+  it('returns "low" (never high) when verbs are not clearly opposed', () => {
+    const a = stat({ tool: 'research_discover', invocationCount: 2 });
+    const b = stat({ tool: 'research_synthesize', invocationCount: 100 });
+    expect(consolidationConfidence(a, b)).toBe('low');
+  });
+});
+
+describe('detectConsolidationCandidates (#3902 item 1)', () => {
+  it('does NOT flag a rare orthogonal sibling for folding into a busy one on prefix alone', () => {
+    const report = [
+      stat({ tool: 'git_commit', invocationCount: 100, successCount: 100 }),
+      stat({ tool: 'git_init', invocationCount: 1, successCount: 1 }),
+    ];
+    // git_init must NOT be surfaced — it shares a prefix but is orthogonal to git_commit.
+    expect(detectConsolidationCandidates(report, WINDOW)).toEqual([]);
+  });
+
+  it('surviving prefix-only matches are surfaced as LOW-CONFIDENCE candidates', () => {
+    const report = [
+      stat({ tool: 'research_discover', invocationCount: 100, successCount: 100 }),
+      stat({ tool: 'research_obscure', invocationCount: 2, successCount: 2 }),
+    ];
+    const signals = detectConsolidationCandidates(report, WINDOW);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.title.toLowerCase()).toContain('low-confidence');
+    expect(signals[0]!.body).toMatch(/WEAK hint/);
+    expect(signals[0]!.severity).not.toBe('critical');
+  });
+});
+
+// ============================================================================
+// #3902 item 2 — break-glass / never-deprecate exemption for low-usage tools
+// ============================================================================
+
+describe('isNeverDeprecate (#3902 item 2)', () => {
+  it('matches default break-glass patterns (rollback, recovery, emergency)', () => {
+    expect(isNeverDeprecate('db_rollback')).toBe(true);
+    expect(isNeverDeprecate('disaster_recovery')).toBe(true);
+    expect(isNeverDeprecate('emergency_admin')).toBe(true);
+    expect(DEFAULT_NEVER_DEPRECATE_PATTERNS.length).toBeGreaterThan(0);
+  });
+
+  it('does not match an ordinary tool', () => {
+    expect(isNeverDeprecate('research_discover')).toBe(false);
+  });
+
+  it('honors an explicit exempt-tools override', () => {
+    expect(isNeverDeprecate('weird_tool', { exemptTools: ['weird_tool'] })).toBe(true);
+  });
+});
+
+describe('detectDeprecationCandidates — break-glass exemption (#3902 item 2)', () => {
+  it('does NOT flag a break-glass tool with <=2 invocations as a deprecation candidate', () => {
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'db_rollback', invocationCount: 1, successCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW
+    );
+    expect(signals).toEqual([]);
+  });
+
+  it('still flags an ordinary low-usage tool (exemption is targeted, not blanket)', () => {
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'ordinary_thing', invocationCount: 1, successCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW
+    );
+    expect(signals).toHaveLength(1);
+  });
+
+  it('exempts a tool named via the injected never-deprecate config', () => {
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'custom_breakglass_op', invocationCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW,
+      { exemptTools: ['custom_breakglass_op'] }
+    );
+    expect(signals).toEqual([]);
+  });
+});
+
+// ============================================================================
+// #3902 item 3 — workspace-scoped localized signal (not full suppression)
+// ============================================================================
+
+describe('detectDeprecationCandidates — localized signal not full suppression (#3902 item 3)', () => {
+  const poisoned = stat({
+    tool: 'workspace_local_fail',
+    invocationCount: 2 * FITNESS_MIN_SAMPLE,
+    successCount: FITNESS_MIN_SAMPLE, // 50% globally
+    workspaces: ['healthy-repo', 'broken-repo'],
+  });
+  const statInWorkspace = (_tool: string, ws: string): ToolFitnessStat | undefined => {
+    if (ws === 'healthy-repo') {
+      return stat({
+        tool: 'workspace_local_fail',
+        invocationCount: FITNESS_MIN_SAMPLE,
+        successCount: FITNESS_MIN_SAMPLE,
+        workspaces: ['healthy-repo'],
+      });
+    }
+    return stat({
+      tool: 'workspace_local_fail',
+      invocationCount: FITNESS_MIN_SAMPLE,
+      successCount: 0,
+      workspaces: ['broken-repo'],
+    });
+  };
+
+  it('emits a workspace-scoped localized signal instead of a global deprecation', () => {
+    const signals = detectDeprecationCandidates([poisoned], statInWorkspace, WINDOW);
+    expect(signals).toHaveLength(1);
+    const sig = signals[0]!;
+    // NOT a global deprecation candidate…
+    expect(sig.signalKey).not.toContain('deprecation-candidate');
+    // …but a localized "failing here" signal that names the broken workspace.
+    expect(sig.signalKey).toContain('localized-failure:workspace_local_fail:broken-repo');
+    expect(sig.title).toContain('broken-repo');
+    expect(sig.body).toMatch(/healthy in other workspaces/i);
+    expect(sig.severity).not.toBe('critical');
+  });
+
+  it('locallyFailingWorkspaces returns only the genuinely-failing workspace', () => {
+    const failing = locallyFailingWorkspaces(poisoned, statInWorkspace);
+    expect(failing).toHaveLength(1);
+    expect(failing[0]!.workspaces).toContain('broken-repo');
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.ts
@@ -42,80 +42,39 @@
 
 import type { ImprovementSignal } from './improvement-review.js';
 import {
+  assertNeverAutonomousRemoval,
+  consolidationConfidence,
+  consolidationSignal,
+  CONSOLIDATION_USAGE_FRACTION,
+  FITNESS_MIN_SAMPLE,
+  HEALTHY_WORKSPACE_SUCCESS_FLOOR,
+  isNeverDeprecate,
+  localizedReliabilitySignal,
+  lowUsageSignal,
+  LOW_USAGE_MAX_INVOCATIONS,
+  poorReliabilitySignal,
+  POOR_SUCCESS_RATE_MAX,
+  type NeverDeprecateConfig,
+} from './improvement-review-tool-fitness-heuristics.js';
+import {
   getToolFitnessLedger,
   ToolFitnessLedger,
   UNATTRIBUTED_WORKSPACE,
   type ToolFitnessStat,
 } from '../../governance/tool-fitness-ledger.js';
 
-// ============================================================================
-// Honest thresholds (documented per acceptance criteria)
-// ============================================================================
-
-/**
- * Minimum invocations before the success-rate dimension is trustworthy. Below
- * this, a tool is judged on USAGE only (a 1/2-failure tool is noise, not a
- * fitness signal). Mirrors the improvement_review `minSampleSize` philosophy.
- */
-export const FITNESS_MIN_SAMPLE = 10;
-
-/**
- * At/under this invocation count a tool is a LOW-USAGE deprecation candidate —
- * it is barely being selected, so it may be dead weight against the ~47-tool
- * selection ceiling (epic #3850 narrative). Usage is global by nature, so this
- * is NOT workspace-scoped.
- */
-export const LOW_USAGE_MAX_INVOCATIONS = 2;
-
-/**
- * Success rate at/under this (with >= {@link FITNESS_MIN_SAMPLE} samples) makes a
- * tool a POOR-RELIABILITY deprecation candidate — it is selected but frequently
- * fails. Workspace-scoped (see {@link isHealthyInAnyOtherWorkspace}).
- */
-export const POOR_SUCCESS_RATE_MAX = 0.5;
-
-/**
- * A tool counts as "healthy in another workspace" when, scoped to that
- * workspace, its success rate clears this floor over a meaningful sample. Used
- * to suppress a global poor-reliability flag that is really workspace-local.
- */
-export const HEALTHY_WORKSPACE_SUCCESS_FLOOR = 0.8;
-
-/**
- * Consolidation: within a shared tool-name prefix family (e.g. `research_*`), a
- * member used at/under this FRACTION of the busiest sibling's invocations is a
- * consolidation candidate (could fold into a sibling). Family must have >= 2
- * members and the busiest sibling must clear {@link FITNESS_MIN_SAMPLE} so the
- * comparison isn't noise.
- */
-export const CONSOLIDATION_USAGE_FRACTION = 0.1;
-
-// ============================================================================
-// SUGGEST-TIER invariant guard (Epic F)
-// ============================================================================
-
-/**
- * Runtime assertion of the Epic-F invariant: a tool-fitness signal is ALWAYS a
- * suggest-tier candidate, never an autonomous removal. Caps severity at
- * `warning` (never `critical`) so the priority classifier can't escalate a
- * fitness signal toward an auto-remediation tier, and pins the category. Throws
- * (loudly, in tests + dev) if a future edit tries to emit a removal-grade
- * signal. Returns the signal unchanged on success for fluent use.
- */
-export function assertNeverAutonomousRemoval(signal: ImprovementSignal): ImprovementSignal {
-  if (signal.category !== 'tool-fitness') {
-    throw new Error(
-      `tool-fitness invariant: expected category 'tool-fitness', got '${signal.category}'`
-    );
-  }
-  if (signal.severity === 'critical') {
-    throw new Error(
-      `tool-fitness invariant (Epic F): a tool-fitness signal must be suggest-tier ` +
-        `(severity 'info'|'warning'), never 'critical' — removal is NEVER autonomous`
-    );
-  }
-  return signal;
-}
+// Re-export the thresholds + Epic-F guard so existing consumers/tests keep their
+// import surface (the constants & guard now live in the heuristics sibling so
+// this consumer stays under the 400-line cap, #3902).
+export {
+  assertNeverAutonomousRemoval,
+  CONSOLIDATION_USAGE_FRACTION,
+  FITNESS_MIN_SAMPLE,
+  HEALTHY_WORKSPACE_SUCCESS_FLOOR,
+  LOW_USAGE_MAX_INVOCATIONS,
+  POOR_SUCCESS_RATE_MAX,
+};
+export type { NeverDeprecateConfig };
 
 // ============================================================================
 // Pure detection logic (fixture-testable — no fs, no ledger I/O)
@@ -145,99 +104,29 @@ export function isHealthyInAnyOtherWorkspace(
   });
 }
 
-/** Build a low-usage deprecation candidate signal (suggest-tier). */
-function lowUsageSignal(stat: ToolFitnessStat, windowLabel: string): ImprovementSignal {
-  return assertNeverAutonomousRemoval({
-    category: 'tool-fitness',
-    signalKey: `tool-fitness:deprecation-candidate:low-usage:${stat.tool}`,
-    severity: 'info',
-    title: `tool-fitness: \`${stat.tool}\` is a low-usage deprecation CANDIDATE (${String(stat.invocationCount)} invocations)`,
-    body: [
-      `\`${stat.tool}\` is barely selected and is a CANDIDATE for human review — NOT an automatic removal.`,
-      '',
-      `- Invocations: ${String(stat.invocationCount)} (threshold: ≤ ${String(LOW_USAGE_MAX_INVOCATIONS)})`,
-      `- Last used: ${stat.lastUsedAt}`,
-      `- Success rate: ${String(Math.round(stat.successRate * 100))}%`,
-      `- Window: ${windowLabel}`,
-      '',
-      'SUGGEST-TIER ONLY (Epic F): low usage against the ~47-tool selection ceiling ' +
-        'may mean dead weight. Removal is NEVER autonomous — it requires the Epic D ' +
-        'human-ratification path (see the #3853 removal/consolidation runbook). ' +
-        'Mind the LinUCB exploration floor: a low-usage tool must not death-spiral.',
-    ].join('\n'),
-    evidence: {
-      samples: stat.invocationCount,
-      window: windowLabel,
-      observedValue: stat.invocationCount,
-      threshold: LOW_USAGE_MAX_INVOCATIONS,
-    },
-  });
-}
-
-/** Build a poor-reliability deprecation candidate signal (suggest-tier). */
-function poorReliabilitySignal(stat: ToolFitnessStat, windowLabel: string): ImprovementSignal {
-  return assertNeverAutonomousRemoval({
-    category: 'tool-fitness',
-    signalKey: `tool-fitness:deprecation-candidate:poor-success:${stat.tool}`,
-    severity: 'warning',
-    title: `tool-fitness: \`${stat.tool}\` has a low success rate ${String(Math.round(stat.successRate * 100))}% — deprecation CANDIDATE`,
-    body: [
-      `\`${stat.tool}\` fails often across its uses and is a CANDIDATE for human review — NOT an automatic removal.`,
-      '',
-      `- Success rate: ${String(Math.round(stat.successRate * 100))}% (${String(stat.successCount)}/${String(stat.invocationCount)}, threshold ≤ ${String(Math.round(POOR_SUCCESS_RATE_MAX * 100))}%)`,
-      `- Samples: ${String(stat.invocationCount)} (≥ ${String(FITNESS_MIN_SAMPLE)} required)`,
-      `- Workspaces observed: ${stat.workspaces.join(', ')}`,
-      `- Window: ${windowLabel}`,
-      '',
-      'Workspace-scoped (#3852): this fires only because the tool is unhealthy across ' +
-        'workspaces, not just one — a single-workspace failure (local perms / missing ' +
-        'deps) is suppressed so it cannot globally mis-flag a healthy tool.',
-      '',
-      'SUGGEST-TIER ONLY (Epic F): consider consolidating or deprecating after human ' +
-        'review. Removal is NEVER autonomous — Epic D ratification (#3853 runbook).',
-    ].join('\n'),
-    evidence: {
-      samples: stat.invocationCount,
-      window: windowLabel,
-      observedValue: stat.successRate,
-      threshold: POOR_SUCCESS_RATE_MAX,
-    },
-  });
-}
-
-/** Build a consolidation candidate signal (suggest-tier). */
-function consolidationSignal(
+/**
+ * Workspaces where `stat` is genuinely failing LOCALLY (#3902 item 3): scoped
+ * success rate at/under {@link POOR_SUCCESS_RATE_MAX} over a meaningful sample.
+ * Used to surface a localized warning when the global flag is suppressed as
+ * context-poisoning. Pure (resolver injected). Returns the failing scoped stats.
+ */
+export function locallyFailingWorkspaces(
   stat: ToolFitnessStat,
-  family: string,
-  busiestTool: string,
-  busiestCount: number,
-  windowLabel: string
-): ImprovementSignal {
-  return assertNeverAutonomousRemoval({
-    category: 'tool-fitness',
-    signalKey: `tool-fitness:consolidation-candidate:${stat.tool}`,
-    severity: 'info',
-    title: `tool-fitness: \`${stat.tool}\` is a consolidation CANDIDATE within the \`${family}_*\` family`,
-    body: [
-      `\`${stat.tool}\` is far less used than its \`${family}_*\` siblings and is a CANDIDATE ` +
-        `for folding into a sibling — for human review, NOT an automatic removal.`,
-      '',
-      `- This tool: ${String(stat.invocationCount)} invocations`,
-      `- Busiest sibling \`${busiestTool}\`: ${String(busiestCount)} invocations`,
-      `- Ratio: ${String(Math.round((stat.invocationCount / busiestCount) * 100))}% (threshold ≤ ${String(Math.round(CONSOLIDATION_USAGE_FRACTION * 100))}%)`,
-      `- Window: ${windowLabel}`,
-      '',
-      'SUGGEST-TIER ONLY (Epic F): overlapping tools inflate the selection surface. ' +
-        'Consolidation is a human decision via the Epic D path (#3853 runbook); nothing ' +
-        'here removes or merges anything automatically.',
-    ].join('\n'),
-    evidence: {
-      samples: stat.invocationCount,
-      window: windowLabel,
-      observedValue: stat.invocationCount / busiestCount,
-      threshold: CONSOLIDATION_USAGE_FRACTION,
-    },
-  });
+  statInWorkspace: (tool: string, workspace: string) => ToolFitnessStat | undefined
+): readonly ToolFitnessStat[] {
+  const realWorkspaces = stat.workspaces.filter((w) => w !== UNATTRIBUTED_WORKSPACE);
+  const failing: ToolFitnessStat[] = [];
+  for (const ws of realWorkspaces) {
+    const scoped = statInWorkspace(stat.tool, ws);
+    if (
+      scoped !== undefined &&
+      scoped.invocationCount >= FITNESS_MIN_SAMPLE &&
+      scoped.successRate <= POOR_SUCCESS_RATE_MAX
+    ) {
+      failing.push(scoped);
+    }
+  }
+  return failing;
 }
 
 /** Tool-name family = prefix before the first underscore (e.g. `research`). */
@@ -264,7 +153,14 @@ function busiestMember(members: readonly ToolFitnessStat[]): ToolFitnessStat {
   return members.reduce((best, m) => (m.invocationCount > best.invocationCount ? m : best));
 }
 
-/** Consolidation candidates within ONE family (busiest already cleared the floor). */
+/**
+ * Consolidation candidates within ONE family (busiest already cleared the floor).
+ * #3902: a shared prefix is only a WEAK hint — a member is dropped when its
+ * action verb is clearly ORTHOGONAL to the busiest sibling's (e.g. `git_init`
+ * vs `git_commit`, `db_read` vs `db_drop_table`), so a rare sibling is never
+ * flagged for folding into a busy one on prefix alone. Survivors are emitted as
+ * LOW-CONFIDENCE candidates (see {@link consolidationSignal}).
+ */
 function familyConsolidationSignals(
   members: readonly ToolFitnessStat[],
   family: string,
@@ -274,6 +170,7 @@ function familyConsolidationSignals(
   const cutoff = busiest.invocationCount * CONSOLIDATION_USAGE_FRACTION;
   return members
     .filter((m) => m.tool !== busiest.tool && m.invocationCount <= cutoff)
+    .filter((m) => consolidationConfidence(m, busiest) !== 'none')
     .map((m) => consolidationSignal(m, family, busiest.tool, busiest.invocationCount, windowLabel));
 }
 
@@ -296,29 +193,51 @@ export function detectConsolidationCandidates(
   return signals;
 }
 
+/** Reliability signals for one stat: global poor-reliability OR localized failures. */
+function reliabilitySignalsFor(
+  stat: ToolFitnessStat,
+  statInWorkspace: (tool: string, workspace: string) => ToolFitnessStat | undefined,
+  windowLabel: string
+): readonly ImprovementSignal[] {
+  if (stat.invocationCount < FITNESS_MIN_SAMPLE || stat.successRate > POOR_SUCCESS_RATE_MAX) {
+    return [];
+  }
+  // #3902 item 3: when healthy elsewhere, the global flag is suppressed BUT the
+  // localized "failing here" warning still surfaces (don't fully silence it).
+  if (isHealthyInAnyOtherWorkspace(stat, statInWorkspace)) {
+    return locallyFailingWorkspaces(stat, statInWorkspace).map((scoped) =>
+      localizedReliabilitySignal(
+        scoped,
+        scoped.workspaces[0] ?? UNATTRIBUTED_WORKSPACE,
+        windowLabel
+      )
+    );
+  }
+  return [poorReliabilitySignal(stat, windowLabel)];
+}
+
 /**
  * Detect deprecation candidates (low usage OR poor reliability) from a fitness
  * report, scoping the reliability dimension by workspace to defeat
- * context-poisoning. Pure: the `statInWorkspace` resolver is injected.
+ * context-poisoning. #3902: low-usage break-glass tools are EXEMPT (item 2), and
+ * a cross-workspace-suppressed failure still emits a workspace-scoped localized
+ * signal (item 3). Pure: the `statInWorkspace` resolver is injected.
  */
 export function detectDeprecationCandidates(
   report: readonly ToolFitnessStat[],
   statInWorkspace: (tool: string, workspace: string) => ToolFitnessStat | undefined,
-  windowLabel: string
+  windowLabel: string,
+  neverDeprecate?: NeverDeprecateConfig
 ): readonly ImprovementSignal[] {
   const signals: ImprovementSignal[] = [];
   for (const stat of report) {
     if (stat.invocationCount <= LOW_USAGE_MAX_INVOCATIONS) {
+      // #3902 item 2: break-glass / never-deprecate tools are low-usage BY DESIGN.
+      if (isNeverDeprecate(stat.tool, neverDeprecate)) continue;
       signals.push(lowUsageSignal(stat, windowLabel));
       continue; // low-usage already covers it; don't double-flag.
     }
-    if (
-      stat.invocationCount >= FITNESS_MIN_SAMPLE &&
-      stat.successRate <= POOR_SUCCESS_RATE_MAX &&
-      !isHealthyInAnyOtherWorkspace(stat, statInWorkspace)
-    ) {
-      signals.push(poorReliabilitySignal(stat, windowLabel));
-    }
+    signals.push(...reliabilitySignalsFor(stat, statInWorkspace, windowLabel));
   }
   return signals;
 }
@@ -331,10 +250,11 @@ export function detectDeprecationCandidates(
 export function detectToolFitnessSignals(
   report: readonly ToolFitnessStat[],
   statInWorkspace: (tool: string, workspace: string) => ToolFitnessStat | undefined,
-  windowLabel: string
+  windowLabel: string,
+  neverDeprecate?: NeverDeprecateConfig
 ): readonly ImprovementSignal[] {
   return [
-    ...detectDeprecationCandidates(report, statInWorkspace, windowLabel),
+    ...detectDeprecationCandidates(report, statInWorkspace, windowLabel, neverDeprecate),
     ...detectConsolidationCandidates(report, windowLabel),
   ];
 }


### PR DESCRIPTION
Closes #3902. Refines three signal-quality heuristics in the `tool-fitness` `improvement_review` consumer raised in the #3900 ratification (Contrarian's signal-quality concerns).

**Epic F invariant preserved.** Every signal stays SUGGEST-TIER (severity `info`/`warning`, never `critical`, all routed through `assertNeverAutonomousRemoval`). A human always reviews; nothing here removes or merges a tool. No MCP tool added/removed (count guard untouched).

## Item 1 — Consolidation: shared name-prefix is now only a WEAK hint
A shared prefix was treated as a substitutability signal, but `git_init` vs `git_commit` and `db_read` vs `db_drop_table` share a prefix while being orthogonal.

- New `consolidationConfidence(candidate, busiest)` classifies the action-verb suffix of each prefix-sibling against opposed verb groups (create/init vs drop/destroy vs read/get vs write/commit). Clearly-opposed pairs return `'none'` and are **suppressed entirely** — a rare sibling is never flagged for folding into a busy one on prefix alone.
- Survivors return `'low'` and are surfaced as **LOW-CONFIDENCE** candidates (title + body say so).
- **Approach: scoped weak-hint downgrade, NOT full overlap modelling.** A true capability/schema-overlap signal needs a tool-distinctness data seam that doesn't exist yet, so it's deferred behind `TODO(#3902)`. There is deliberately no `'high'` confidence tier — prefix-family is never strong evidence until that seam lands. This matches the issue's "acceptable scoped step" guidance.

## Item 2 — Break-glass exemption for low-usage-BY-DESIGN tools
`<= 2 invocations` was flagging rare-but-critical break-glass tools (rollback/recovery/emergency admin) as deprecation noise.

- New `isNeverDeprecate(tool, config?)` + `DEFAULT_NEVER_DEPRECATE_PATTERNS` (rollback, recover, restore, emergency, break_glass, panic, failover, disaster, evacuate, quarantine) and an injectable `NeverDeprecateConfig` (`exemptTools` / `extraPatterns`).
- `detectDeprecationCandidates` skips the low-usage flag for exempt tools. Exemption is targeted, not blanket — ordinary low-usage tools still flag.

## Item 3 — Workspace-scoped localized signal instead of full suppression
Cross-workspace suppression (#3852) fixed context-poisoning but **fully silenced** a genuinely-useful localized warning.

- New `locallyFailingWorkspaces()` + `localizedReliabilitySignal()`. When a tool is healthy in another workspace, the **global** deprecation stays suppressed, but a **workspace-scoped** "failing here" signal now surfaces the local misconfig (names the broken workspace, `localized-failure:<tool>:<workspace>` signal key).

## Structure
New pure heuristics + signal builders extracted to a sibling module `improvement-review-tool-fitness-heuristics.ts` so the consumer stays under the 400-line cap. The consumer re-exports the thresholds + Epic-F guard to keep the existing import surface stable.

## Gate checks run green
- `pnpm typecheck` (tsc --noEmit) — clean (after building the `nexus-memory` workspace dep)
- eslint on the 3 changed `.ts` files — clean
- `vitest run` on `improvement-review-tool-fitness.test.ts` (32) + `improvement-review.test.ts` (32) + `tool-fitness-ledger.test.ts` (23) — all pass
- producer/consumer gate (`check-new-unused-exports.ts`) — exit 0 (new sibling module is imported by the consumer)
- line caps: consumer 281 / sibling 357 (both ≤ 400); functions ≤ 50; zero `any`
- changeset `.changeset/tool-fitness-heuristics-3902.md` (`'nexus-agents': patch`, `fix` type)
- no MCP tool added/removed; inject-governance.ts / docs-check.yml / SKILL.md untouched

## Judgment calls to review
1. **Weak-hint downgrade vs full overlap model (item 1).** Chose the scoped downgrade with a TODO, per the issue's explicit allowance. The orthogonal-verb groups are a name-suffix proxy — a deliberately conservative list; unknown verbs default to `'low'` (surface as low-confidence) rather than suppress, so we don't accidentally hide a real candidate.
2. **Localized signal severity (item 3) = `warning`.** It's an actionable local misconfig, but capped at warning (never critical) to honor Epic F. Its signal key is `localized-failure:*`, deliberately NOT `deprecation-candidate:*`, so downstream dedup/classification never mistakes it for a removal candidate.
3. **Break-glass detection is name-pattern based.** The ledger carries no tool metadata/tags, so I used a curated default substring list + an injectable override rather than introduce a tool-registry dependency. A future registry-backed criticality tag could replace the default list.

Do NOT merge — for human review (Epic F path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)