### PR TITLE
feat(eval): pr_review case-curation pipeline + pilot batch (#3847)

### DIFF
--- a/.changeset/eval-curation-pilot-3847.md
+++ b/.changeset/eval-curation-pilot-3847.md
@@ -1,0 +1,36 @@
+---
+'nexus-agents': patch
+---
+
+feat(eval): pr_review case-curation pipeline + pilot batch (#3847)
+
+First increment of #3847: a curation pipeline that grows the `pr_review` eval set
+from the org's OWN merged PRs + their real review outcomes as ground truth (not
+public datasets, not synthetic injection), plus a validated pilot batch.
+
+**Pipeline (two modules, the labeling logic unit-tested).**
+`scripts/curate-pr-review-harvest.ts` is the thin gh-fetch I/O layer: it harvests
+merged PRs via `gh`, and for each extracts OBJECTIVE signals — the changed source
+files, the GitHub review decision, and (critically) whether a LATER `fix`/`revert`
+PR referenced it AND touched the same source files (a confirmed post-merge
+correction, the rubric Rule 5.3 "gold" signal). `scripts/curate-pr-review-labeling.ts`
+is the PURE signal→label core (zero I/O, fully tested in
+`scripts/curate-pr-review-labeling.test.ts`): it applies the labeling rubric
+(`docs/research/pr-review-eval-labeling-rubric.md`, #3846) to PROPOSE a class +
+severity per case.
+
+**No invented labels.** A PR with no post-merge-fix signal is proposed `clean`
+(Rule 3). A confirmed `fix`/`revert` in a correctness/integrity domain is proposed
+`buggy` at the `medium` floor (never auto-escalated; Rule 5.1). An ambiguous
+follow-up (heuristic refinement, no-behaviour-change hardening, or outside a
+correctness domain) is proposed `borderline` with `needsAdjudication: true` —
+flagged for a human, NEVER guessed into buggy/clean (Rule 4). Every proposal is
+emitted with full provenance: the real source PR URL, the objective signals used,
+and a confidence + justification.
+
+**Pilot output (separate file, the validated v5 set untouched).** Running the
+pipeline against `nexus-substrate/nexus-agents` produced a 10-case pilot in
+`testing/datasets/pr-review-candidates-pilot.json` — 1 buggy / 5 clean / 4
+borderline, 5 flagged for adjudication, every case citing a real merged PR. This
+needs label-quality review before the eval set trusts it; scaling to n>=50 is a
+follow-up under #3847.

--- a/scripts/curate-pr-review-harvest.ts
+++ b/scripts/curate-pr-review-harvest.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env npx tsx
+/**
+ * curate-pr-review-harvest.ts — the gh-fetch I/O layer of the pr_review
+ * eval-set curation pipeline (#3847).
+ *
+ * Harvests merged PRs from the org (default nexus-substrate/nexus-agents) via
+ * `gh`, extracts the OBJECTIVE signals (changed source files, review decision,
+ * and whether a LATER fix/revert PR touched the same source files), then hands
+ * each PR's signals to the PURE labeling logic (curate-pr-review-labeling.ts)
+ * for a rubric-derived proposal. The proposals are written to a candidates file
+ * WITH FULL PROVENANCE (source PR URL, the signals used, the proposed label, a
+ * confidence + justification) for human adjudication.
+ *
+ * This file is deliberately thin and untested-by-unit (it is pure I/O over the
+ * `gh` CLI, like build-model-registry.ts); all rubric decisions live in the
+ * tested labeling module. It does NOT overwrite the validated dataset
+ * (testing/datasets/pr-review-sample.json) — it writes a SEPARATE candidates
+ * file. It never fabricates: a PR with no objective fix signal is proposed
+ * `clean`, an ambiguous fix signal is proposed `borderline` + needsAdjudication.
+ *
+ * Usage:
+ *   npx tsx scripts/curate-pr-review-harvest.ts harvest [--limit N] [--out PATH]
+ *
+ * @module scripts/curate-pr-review-harvest
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+/* eslint-disable no-console -- CLI script that prints progress */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  proposeLabel,
+  provenanceSourceFor,
+  type FollowUpFix,
+  type PrSignals,
+  type ProposedLabel,
+} from './curate-pr-review-labeling.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DEFAULT_OUT = path.join(REPO_ROOT, 'testing/datasets/pr-review-candidates-pilot.json');
+const REPO = 'nexus-substrate/nexus-agents';
+
+// ============================================================================
+// gh fetch (the only I/O)
+// ============================================================================
+
+interface RawPr {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly files: ReadonlyArray<{ readonly path: string }>;
+  readonly reviewDecision?: string;
+}
+
+/** A merged-PR page from `gh pr list --json …`. Throws on gh failure. */
+function fetchMergedPrs(limit: number): readonly RawPr[] {
+  const out = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      REPO,
+      '--state',
+      'merged',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,body,url,files,reviewDecision',
+    ],
+    { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  return JSON.parse(out) as readonly RawPr[];
+}
+
+// ============================================================================
+// Signal extraction (objective — no labels)
+// ============================================================================
+
+const isSourceFile = (p: string): boolean =>
+  p.startsWith('packages/nexus-agents/src/') && !p.endsWith('.test.ts');
+
+function sourceFilesOf(pr: RawPr): readonly string[] {
+  return pr.files.map((f) => f.path).filter(isSourceFile);
+}
+
+/** Conventional-commit type prefix, lower-cased (`fix`, `revert`, `feat`, …). */
+function commitType(title: string): string {
+  const m = /^([a-z]+)[(:]/.exec(title.toLowerCase());
+  return m?.[1] ?? '';
+}
+
+function referencedPrNumbers(body: string): readonly number[] {
+  const hits = body.match(/#\d{3,4}/g) ?? [];
+  return [...new Set(hits.map((s) => Number(s.slice(1))))];
+}
+
+/**
+ * Find, for `prior`, every LATER `fix`/`revert` PR that references it and shares
+ * at least one source file — the objective "shipped a defect, later corrected"
+ * signal. Pure given the page; extracted here so the harvester stays declarative.
+ */
+function followUpFixesFor(prior: RawPr, all: readonly RawPr[]): readonly FollowUpFix[] {
+  const priorSrc = new Set(sourceFilesOf(prior));
+  if (priorSrc.size === 0) return [];
+  const fixes: FollowUpFix[] = [];
+  for (const cand of all) {
+    if (cand.number <= prior.number) continue;
+    const type = commitType(cand.title);
+    if (type !== 'fix' && type !== 'revert') continue;
+    if (!referencedPrNumbers(cand.body).includes(prior.number)) continue;
+    const overlap = sourceFilesOf(cand).filter((f) => priorSrc.has(f));
+    if (overlap.length > 0) {
+      fixes.push({ fixPrNumber: cand.number, fixType: type, overlappingSourceFiles: overlap });
+    }
+  }
+  return fixes;
+}
+
+function signalsFor(pr: RawPr, all: readonly RawPr[]): PrSignals {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    changedSourceFiles: sourceFilesOf(pr),
+    followUpFixes: followUpFixesFor(pr, all),
+    reviewDecision: pr.reviewDecision ?? null,
+  };
+}
+
+// ============================================================================
+// Candidate emission (full provenance)
+// ============================================================================
+
+function prUrl(pr: RawPr): string {
+  return pr.url.length > 0 ? pr.url : `https://github.com/${REPO}/pull/${String(pr.number)}`;
+}
+
+interface PilotCandidate {
+  readonly number: number;
+  readonly title: string;
+  readonly proposedClass: ProposedLabel['class'];
+  readonly proposedSeverity: ProposedLabel['severity'];
+  readonly needsAdjudication: boolean;
+  readonly confidence: number;
+  readonly provenance: {
+    readonly source: ReturnType<typeof provenanceSourceFor>;
+    readonly sourcePrUrl: string;
+    readonly objectiveSignals: PrSignals;
+    readonly justification: string;
+  };
+}
+
+function toCandidate(pr: RawPr, all: readonly RawPr[]): PilotCandidate {
+  const titles = new Map(all.map((p) => [p.number, p.title]));
+  const signals = signalsFor(pr, all);
+  const label = proposeLabel(signals, titles);
+  return {
+    number: pr.number,
+    title: pr.title,
+    proposedClass: label.class,
+    proposedSeverity: label.severity,
+    needsAdjudication: label.needsAdjudication,
+    confidence: label.confidence,
+    provenance: {
+      source: provenanceSourceFor(label),
+      sourcePrUrl: prUrl(pr),
+      objectiveSignals: signals,
+      justification: label.justification,
+    },
+  };
+}
+
+// ============================================================================
+// CLI
+// ============================================================================
+
+interface Args {
+  readonly limit: number;
+  readonly out: string;
+  /** Cap on `clean` proposals kept (keeps the pilot batch class-balanced). 0 = no cap. */
+  readonly maxClean: number;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  let limit = 60;
+  let out = DEFAULT_OUT;
+  let maxClean = 0;
+  for (let i = 0; i < argv.length; i += 1) {
+    const next = argv[i + 1];
+    if (next === undefined) continue;
+    if (argv[i] === '--limit') limit = Number(next);
+    if (argv[i] === '--out') out = next;
+    if (argv[i] === '--max-clean') maxClean = Number(next);
+  }
+  return { limit, out, maxClean };
+}
+
+/**
+ * Apply the clean-cap so the pilot batch is class-balanced. Keeps ALL buggy +
+ * borderline proposals (they are the scarce, signal-bearing cases) and only
+ * trims the clean tail — most-recent first — to `maxClean`. This is a
+ * presentation cap, not a label change: dropped cleans had no objective fix
+ * signal and remain clean if re-harvested without the cap.
+ */
+function applyCleanCap(candidates: readonly PilotCandidate[], maxClean: number): PilotCandidate[] {
+  if (maxClean <= 0) return [...candidates];
+  let kept = 0;
+  return candidates.filter((c) => {
+    if (c.proposedClass !== 'clean') return true;
+    kept += 1;
+    return kept <= maxClean;
+  });
+}
+
+function harvest(args: Args): void {
+  console.log(`Harvesting up to ${String(args.limit)} merged PRs from ${REPO} …`);
+  const prs = fetchMergedPrs(args.limit);
+  const all = prs
+    .filter((pr) => sourceFilesOf(pr).length > 0)
+    .filter((pr) => commitType(pr.title) !== 'fix' && commitType(pr.title) !== 'revert')
+    .map((pr) => toCandidate(pr, prs));
+  const candidates = applyCleanCap(all, args.maxClean);
+  const balance = { buggy: 0, clean: 0, borderline: 0 };
+  for (const c of candidates) balance[c.proposedClass] += 1;
+  console.log(
+    `Proposed ${String(candidates.length)} candidates: ` +
+      `buggy=${String(balance.buggy)} clean=${String(balance.clean)} borderline=${String(balance.borderline)}; ` +
+      `needsAdjudication=${String(candidates.filter((c) => c.needsAdjudication).length)}`
+  );
+  fs.writeFileSync(args.out, `${JSON.stringify(candidates, null, 2)}\n`, 'utf-8');
+  console.log(`Wrote ${args.out}`);
+}
+
+function main(): void {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd !== 'harvest') {
+    console.error('usage: curate-pr-review-harvest.ts harvest [--limit N] [--out PATH]');
+    process.exit(1);
+  }
+  harvest(parseArgs(rest));
+}
+
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  main();
+}
+
+export {
+  followUpFixesFor,
+  signalsFor,
+  commitType,
+  sourceFilesOf,
+  toCandidate,
+  type PilotCandidate,
+};

--- a/scripts/curate-pr-review-labeling.test.ts
+++ b/scripts/curate-pr-review-labeling.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the pr_review curation pipeline's PURE signal→label logic (#3847).
+ *
+ * Proves the rubric decision table holds against fixtures (no live gh): a PR
+ * with no follow-up fix is proposed `clean`; a confirmed fix/revert in a
+ * correctness domain is proposed `buggy` at the `medium` floor with
+ * `needsAdjudication`; an ambiguous follow-up (heuristic refine / no-behavior
+ * hardening / outside a correctness domain) is proposed `borderline` +
+ * `needsAdjudication`, NEVER guessed into buggy/clean. Also covers the
+ * harvester's pure signal-extraction helpers (commit-type, source-file filter,
+ * follow-up matching).
+ *
+ * @module scripts/curate-pr-review-labeling.test
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  proposeLabel,
+  provenanceSourceFor,
+  type FollowUpFix,
+  type PrSignals,
+} from './curate-pr-review-labeling.js';
+import { commitType, sourceFilesOf, followUpFixesFor } from './curate-pr-review-harvest.js';
+
+function signals(over: Partial<PrSignals> = {}): PrSignals {
+  return {
+    number: 100,
+    title: 'feat(x): a feature',
+    url: 'https://github.com/o/r/pull/100',
+    changedSourceFiles: ['packages/nexus-agents/src/x/a.ts'],
+    followUpFixes: [],
+    reviewDecision: null,
+    ...over,
+  };
+}
+
+function fix(over: Partial<FollowUpFix> = {}): FollowUpFix {
+  return {
+    fixPrNumber: 200,
+    fixType: 'fix',
+    overlappingSourceFiles: ['packages/nexus-agents/src/audit/a.ts'],
+    ...over,
+  };
+}
+
+describe('proposeLabel — rubric decision table', () => {
+  it('proposes clean when no follow-up fix exists (Rule 3)', () => {
+    const l = proposeLabel(signals(), new Map());
+    expect(l.class).toBe('clean');
+    expect(l.severity).toBeNull();
+    expect(l.needsAdjudication).toBe(false);
+  });
+
+  it('proposes buggy at the medium floor for a fix in a correctness domain (Rule 5.3)', () => {
+    const l = proposeLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(audit): correct silent drop']])
+    );
+    expect(l.class).toBe('buggy');
+    expect(l.severity).toBe('medium');
+    expect(l.needsAdjudication).toBe(true);
+    expect(l.justification).toContain('#200');
+  });
+
+  it('never auto-escalates severity above medium', () => {
+    const l = proposeLabel(
+      signals({
+        followUpFixes: [
+          fix({ overlappingSourceFiles: ['packages/nexus-agents/src/security/s.ts'] }),
+        ],
+      }),
+      new Map([[200, 'fix(security): patch']])
+    );
+    expect(l.severity).toBe('medium');
+  });
+
+  it('proposes borderline + needsAdjudication for a heuristic refinement (Rule 4)', () => {
+    const l = proposeLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(governance): refine suggest-signal heuristics']])
+    );
+    expect(l.class).toBe('borderline');
+    expect(l.needsAdjudication).toBe(true);
+    expect(l.severity).toBeNull();
+  });
+
+  it('proposes borderline for a no-behavior-change hardening', () => {
+    const l = proposeLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(orchestration): harden router — no live routing change']])
+    );
+    expect(l.class).toBe('borderline');
+  });
+
+  it('proposes borderline when the fix is outside a correctness domain', () => {
+    const l = proposeLabel(
+      signals({
+        followUpFixes: [fix({ overlappingSourceFiles: ['packages/nexus-agents/src/util/u.ts'] })],
+      }),
+      new Map([[200, 'fix(util): tweak']])
+    );
+    expect(l.class).toBe('borderline');
+    expect(l.needsAdjudication).toBe(true);
+  });
+
+  it('treats a revert as a confirmed bug even with a refine-like title', () => {
+    const l = proposeLabel(
+      signals({ followUpFixes: [fix({ fixType: 'revert' })] }),
+      new Map([[200, 'revert: refine xyz']])
+    );
+    expect(l.class).toBe('buggy');
+  });
+
+  it('maps provenance source: clean→historical-clean, else historical', () => {
+    expect(
+      provenanceSourceFor({
+        class: 'clean',
+        severity: null,
+        needsAdjudication: false,
+        confidence: 1,
+        justification: '',
+      })
+    ).toBe('historical-clean');
+    expect(
+      provenanceSourceFor({
+        class: 'buggy',
+        severity: 'medium',
+        needsAdjudication: true,
+        confidence: 1,
+        justification: '',
+      })
+    ).toBe('historical');
+    expect(
+      provenanceSourceFor({
+        class: 'borderline',
+        severity: null,
+        needsAdjudication: true,
+        confidence: 1,
+        justification: '',
+      })
+    ).toBe('historical');
+  });
+});
+
+describe('harvest signal extraction (pure helpers)', () => {
+  it('parses the conventional-commit type', () => {
+    expect(commitType('fix(governance): x')).toBe('fix');
+    expect(commitType('feat: y')).toBe('feat');
+    expect(commitType('revert(core): z')).toBe('revert');
+    expect(commitType('no prefix here')).toBe('');
+  });
+
+  it('keeps only non-test source files', () => {
+    const pr = {
+      number: 1,
+      title: 't',
+      body: '',
+      url: '',
+      files: [
+        { path: 'packages/nexus-agents/src/a.ts' },
+        { path: 'packages/nexus-agents/src/a.test.ts' },
+        { path: '.changeset/x.md' },
+        { path: 'docs/y.md' },
+      ],
+    };
+    expect(sourceFilesOf(pr)).toEqual(['packages/nexus-agents/src/a.ts']);
+  });
+
+  it('matches only LATER fix/revert PRs that reference the prior and share a source file', () => {
+    const prior = {
+      number: 3010,
+      title: 'feat: x',
+      body: '',
+      url: '',
+      files: [{ path: 'packages/nexus-agents/src/a.ts' }],
+    };
+    const all = [
+      prior,
+      // later fix, references #3010, shares the file → matches
+      {
+        number: 3020,
+        title: 'fix: correct a',
+        body: 'follow-up to #3010',
+        url: '',
+        files: [{ path: 'packages/nexus-agents/src/a.ts' }],
+      },
+      // later fix, references #3010, but different file → no match
+      {
+        number: 3021,
+        title: 'fix: b',
+        body: '#3010',
+        url: '',
+        files: [{ path: 'packages/nexus-agents/src/b.ts' }],
+      },
+      // earlier number → not a follow-up
+      {
+        number: 3005,
+        title: 'fix: x',
+        body: '#3010',
+        url: '',
+        files: [{ path: 'packages/nexus-agents/src/a.ts' }],
+      },
+      // a feat referencing #3010, shares file, but not fix/revert → no match
+      {
+        number: 3022,
+        title: 'feat: more',
+        body: '#3010',
+        url: '',
+        files: [{ path: 'packages/nexus-agents/src/a.ts' }],
+      },
+    ];
+    const fixes = followUpFixesFor(prior, all);
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0]?.fixPrNumber).toBe(3020);
+    expect(fixes[0]?.overlappingSourceFiles).toEqual(['packages/nexus-agents/src/a.ts']);
+  });
+
+  it('returns no follow-ups for a PR with no source files', () => {
+    const prior = {
+      number: 3010,
+      title: 'docs: x',
+      body: '',
+      url: '',
+      files: [{ path: 'docs/a.md' }],
+    };
+    expect(followUpFixesFor(prior, [prior])).toEqual([]);
+  });
+});

--- a/scripts/curate-pr-review-labeling.ts
+++ b/scripts/curate-pr-review-labeling.ts
@@ -1,0 +1,224 @@
+/**
+ * curate-pr-review-labeling.ts — PURE signal→label logic for the pr_review
+ * eval-set curation pipeline (#3847).
+ *
+ * This is the testable core of the curation pipeline. It contains ZERO I/O: it
+ * takes already-fetched OBJECTIVE signals about a merged PR (the merge outcome,
+ * the review verdict, and — critically — whether a LATER PR fixed/reverted code
+ * it touched) and applies the labeling rubric (docs/research/
+ * pr-review-eval-labeling-rubric.md, #3846) to PROPOSE a class + severity.
+ *
+ * The gh-fetch I/O lives in curate-pr-review-harvest.ts. Keeping the logic pure
+ * here means every rubric decision below is unit-tested against fixtures rather
+ * than against a live GitHub round-trip.
+ *
+ * Hard rule (owner-mandated, non-negotiable): NO INVENTED LABELS. Every `buggy`
+ * label must trace to an objective post-merge-fix signal. When the signal is
+ * present but its severity/reachability cannot be established from the signal
+ * alone (e.g. the follow-up was a heuristic refinement or a no-behavior-change
+ * DRY hardening), the case is emitted as `borderline` with `needsAdjudication`,
+ * NEVER forced to `buggy` or `clean`. Fabricated eval data is forbidden.
+ *
+ * @module scripts/curate-pr-review-labeling
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import type {
+  CaseClass,
+  PrReviewCase,
+  ProvenanceSource,
+  Severity,
+} from './curate-pr-review-dataset-schema.js';
+
+// ============================================================================
+// Objective signals (what the harvester extracts per merged PR)
+// ============================================================================
+
+/**
+ * A later PR that fixed/reverted code the candidate PR touched. This is the
+ * ground-truth "the diff shipped a defect" signal (rubric Rule 5.3).
+ */
+export interface FollowUpFix {
+  /** The fixing/reverting PR number. */
+  readonly fixPrNumber: number;
+  /** Its conventional-commit type, lower-cased: `fix` | `revert` | other. */
+  readonly fixType: string;
+  /** Source (non-test, non-changeset) files BOTH PRs touched — the overlap. */
+  readonly overlappingSourceFiles: readonly string[];
+}
+
+/** Objective signals for one merged PR, all extracted via `gh` (no judgment). */
+export interface PrSignals {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  /** Source (non-test, non-changeset) files this PR changed. */
+  readonly changedSourceFiles: readonly string[];
+  /** Later PRs that fixed/reverted files this PR touched (may be empty). */
+  readonly followUpFixes: readonly FollowUpFix[];
+  /** GitHub review decision when known: 'APPROVED' | 'CHANGES_REQUESTED' | … */
+  readonly reviewDecision: string | null;
+}
+
+// ============================================================================
+// Proposed label (what the pipeline emits before human adjudication)
+// ============================================================================
+
+export interface ProposedLabel {
+  readonly class: CaseClass;
+  /** Severity for buggy proposals; null for clean/borderline. */
+  readonly severity: Severity | null;
+  /** True when a human must confirm before this case is trusted. */
+  readonly needsAdjudication: boolean;
+  /** 0..1 — heuristic confidence in the proposal, for triage ordering. */
+  readonly confidence: number;
+  /** Objective justification: which signal drove the proposal. */
+  readonly justification: string;
+}
+
+// ============================================================================
+// Severity heuristics (conservative; default to lower per rubric Rule 5.1)
+// ============================================================================
+
+/**
+ * Defect-domain hints that, when a follow-up FIX touches them, indicate a
+ * confirmed correctness/integrity defect (medium+ under Rule 1) rather than a
+ * pure refactor/heuristic tweak. Matched against overlapping file paths.
+ */
+const CORRECTNESS_DOMAINS: readonly string[] = [
+  '/audit/',
+  '/security/',
+  '/auth/',
+  '/governance/',
+  '/pipeline/',
+];
+
+/**
+ * Title markers on the FOLLOW-UP fix that signal it was NOT a confirmed runtime
+ * bug — a heuristic refinement or a no-behavior-change hardening. These force
+ * `borderline` + `needsAdjudication` instead of `buggy` (Rule 4 / Rule 5.1).
+ */
+const NON_BUG_FIX_MARKERS: readonly string[] = [
+  'refine',
+  'harden',
+  'tighten',
+  'heuristic',
+  'dry',
+  'split-brain',
+  'no behavior change',
+  'no behaviour change',
+  'no live',
+];
+
+function looksLikeNonBugFix(fix: FollowUpFix, fixTitle: string): boolean {
+  // A `revert` is always a confirmed correction — never treat it as a non-bug.
+  if (fix.fixType === 'revert') return false;
+  const t = fixTitle.toLowerCase();
+  return NON_BUG_FIX_MARKERS.some((m) => t.includes(m));
+}
+
+function touchesCorrectnessDomain(files: readonly string[]): boolean {
+  return files.some((f) => CORRECTNESS_DOMAINS.some((d) => f.includes(d)));
+}
+
+/**
+ * Propose a severity for a confirmed buggy case. The post-merge-fix SIGNAL only
+ * establishes that a real defect existed and was corrected — it cannot, on its
+ * own, distinguish `medium` from `high`/`critical`. So we always propose the
+ * rubric floor (`medium`, Rule 5.1: default to the lower severity) and let
+ * adjudication escalate with an explicit reachability/exploit rationale. Never
+ * auto-`critical`.
+ */
+function proposeSeverity(): Severity {
+  return 'medium';
+}
+
+// ============================================================================
+// The core decision (pure, fully tested)
+// ============================================================================
+
+/**
+ * Apply the rubric to a PR's objective signals and PROPOSE a label.
+ *
+ * Decision table:
+ *  - No follow-up fix at all → propose `clean` (Rule 3). Absence of a post-merge
+ *    correction is a strong clean signal; the justification records that a
+ *    reviewer should still confirm no defensible medium+ objection from the diff.
+ *  - A follow-up `fix`/`revert` touching the same source files, in a
+ *    correctness/integrity domain, NOT marked as a refine/harden tweak →
+ *    propose `buggy` at the medium floor (Rule 5.3 gold).
+ *  - A follow-up fix that is a heuristic refinement / no-behavior-change
+ *    hardening, OR sits outside a correctness domain → propose `borderline`
+ *    with `needsAdjudication` (Rule 4): the signal is real but not a confirmed
+ *    runtime bug. NEVER guessed into buggy/clean.
+ */
+export function proposeLabel(
+  signals: PrSignals,
+  fixTitles: ReadonlyMap<number, string>
+): ProposedLabel {
+  const fix = signals.followUpFixes[0];
+  if (fix === undefined) {
+    return {
+      class: 'clean',
+      severity: null,
+      needsAdjudication: false,
+      confidence: 0.7,
+      justification:
+        `No later PR fixed or reverted any source file #${String(signals.number)} touched ` +
+        `(within the harvested window). Rule 3 clean candidate; a reviewer confirms ` +
+        `no defensible medium+ objection from the diff before trusting.`,
+    };
+  }
+
+  const fixTitle = fixTitles.get(fix.fixPrNumber) ?? '';
+  const nonBug = looksLikeNonBugFix(fix, fixTitle);
+  const correctness = touchesCorrectnessDomain(fix.overlappingSourceFiles);
+
+  if (nonBug || !correctness) {
+    return {
+      class: 'borderline',
+      severity: null,
+      needsAdjudication: true,
+      confidence: 0.4,
+      justification:
+        `Later PR #${String(fix.fixPrNumber)} (${fixTitle || fix.fixType}) touched the same ` +
+        `source file(s) [${fix.overlappingSourceFiles.join(', ')}], but the follow-up reads as a ` +
+        `${nonBug ? 'heuristic refinement / no-behavior-change hardening' : 'change outside a correctness/integrity domain'}. ` +
+        `Real signal, NOT a confirmed runtime bug — flagged for human adjudication (Rule 4 / 5.1). Not guessed.`,
+    };
+  }
+
+  return {
+    class: 'buggy',
+    severity: proposeSeverity(),
+    needsAdjudication: true,
+    confidence: 0.75,
+    justification:
+      `Later PR #${String(fix.fixPrNumber)} (${fixTitle || fix.fixType}) fixed/reverted the same ` +
+      `correctness/integrity source file(s) [${fix.overlappingSourceFiles.join(', ')}] #${String(signals.number)} ` +
+      `introduced — a confirmed post-merge correction (Rule 5.3 gold). Severity proposed conservatively; ` +
+      `the exact line + final severity are set during adjudication.`,
+  };
+}
+
+// ============================================================================
+// Provenance assembly (maps a proposal onto the dataset schema's source enum)
+// ============================================================================
+
+export function provenanceSourceFor(label: ProposedLabel): ProvenanceSource {
+  return label.class === 'clean' ? 'historical-clean' : 'historical';
+}
+
+/**
+ * Build the schema-shaped case skeleton from a proposal + signals. The author
+ * still fills the exact knownBug location/line during adjudication (the harvest
+ * cannot know the line a reviewer would cite); here we emit a structural
+ * location so the entry is shape-valid and honestly provisional. Returns a
+ * partial — the harvester serializes it into the candidates file with the
+ * full-provenance fields.
+ */
+export interface CandidateCase extends PrReviewCase {
+  readonly sourcePrUrl: string;
+  readonly objectiveSignals: PrSignals;
+  readonly proposal: ProposedLabel;
+}

--- a/testing/datasets/pr-review-candidates-pilot.json
+++ b/testing/datasets/pr-review-candidates-pilot.json
@@ -1,0 +1,308 @@
+[
+  {
+    "number": 3915,
+    "title": "feat(observability): propagate adapter per-voter tokens + non-silent cost drops (#3910)",
+    "proposedClass": "borderline",
+    "proposedSeverity": null,
+    "needsAdjudication": true,
+    "confidence": 0.4,
+    "provenance": {
+      "source": "historical",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3915",
+      "objectiveSignals": {
+        "number": 3915,
+        "title": "feat(observability): propagate adapter per-voter tokens + non-silent cost drops (#3910)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3915",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/cli/vote-types.ts",
+          "packages/nexus-agents/src/cli/voter-agents.ts",
+          "packages/nexus-agents/src/cli/voter-execution.ts",
+          "packages/nexus-agents/src/config/jsonl-store.ts",
+          "packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts",
+          "packages/nexus-agents/src/observability/decision-cost-store.ts"
+        ],
+        "followUpFixes": [
+          {
+            "fixPrNumber": 3918,
+            "fixType": "fix",
+            "overlappingSourceFiles": [
+              "packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts"
+            ]
+          }
+        ],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "Later PR #3918 (fix(audit/observability): fail-loud audit persist failures + rate-limit dropped-cost warn (#3916)) touched the same source file(s) [packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts], but the follow-up reads as a change outside a correctness/integrity domain. Real signal, NOT a confirmed runtime bug — flagged for human adjudication (Rule 4 / 5.1). Not guessed."
+    }
+  },
+  {
+    "number": 3913,
+    "title": "feat(observability): weather_report cost section + populate manifest costProfile (#3856)",
+    "proposedClass": "clean",
+    "proposedSeverity": null,
+    "needsAdjudication": false,
+    "confidence": 0.7,
+    "provenance": {
+      "source": "historical-clean",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3913",
+      "objectiveSignals": {
+        "number": 3913,
+        "title": "feat(observability): weather_report cost section + populate manifest costProfile (#3856)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3913",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/mcp/tools/weather-report-types.ts",
+          "packages/nexus-agents/src/mcp/tools/weather-report.ts",
+          "packages/nexus-agents/src/observability/decision-cost-aggregate.ts",
+          "packages/nexus-agents/src/observability/index.ts",
+          "packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts",
+          "packages/nexus-agents/src/orchestration/strategy-manifest.ts"
+        ],
+        "followUpFixes": [],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "No later PR fixed or reverted any source file #3913 touched (within the harvested window). Rule 3 clean candidate; a reviewer confirms no defensible medium+ objection from the diff before trusting."
+    }
+  },
+  {
+    "number": 3912,
+    "title": "refactor(eval): delegate PrReviewEvalStore persistence to shared JsonlStore<T> (#3906)",
+    "proposedClass": "clean",
+    "proposedSeverity": null,
+    "needsAdjudication": false,
+    "confidence": 0.7,
+    "provenance": {
+      "source": "historical-clean",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3912",
+      "objectiveSignals": {
+        "number": 3912,
+        "title": "refactor(eval): delegate PrReviewEvalStore persistence to shared JsonlStore<T> (#3906)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3912",
+        "changedSourceFiles": ["packages/nexus-agents/src/mcp/tools/pr-review-eval-store.ts"],
+        "followUpFixes": [],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "No later PR fixed or reverted any source file #3912 touched (within the harvested window). Rule 3 clean candidate; a reviewer confirms no defensible medium+ objection from the diff before trusting."
+    }
+  },
+  {
+    "number": 3908,
+    "title": "feat(observability): per-voter, per-decision cost aggregation on consensus + pr_review (#3855)",
+    "proposedClass": "clean",
+    "proposedSeverity": null,
+    "needsAdjudication": false,
+    "confidence": 0.7,
+    "provenance": {
+      "source": "historical-clean",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3908",
+      "objectiveSignals": {
+        "number": 3908,
+        "title": "feat(observability): per-voter, per-decision cost aggregation on consensus + pr_review (#3855)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3908",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/cli/vote-types.ts",
+          "packages/nexus-agents/src/cli/voter-agents.ts",
+          "packages/nexus-agents/src/config/learning-persistence.ts",
+          "packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts",
+          "packages/nexus-agents/src/mcp/tools/consensus-vote.ts",
+          "packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts",
+          "packages/nexus-agents/src/mcp/tools/pr-review-tool.ts",
+          "packages/nexus-agents/src/observability/decision-cost-store.ts",
+          "packages/nexus-agents/src/observability/decision-cost.ts",
+          "packages/nexus-agents/src/observability/index.ts"
+        ],
+        "followUpFixes": [],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "No later PR fixed or reverted any source file #3908 touched (within the harvested window). Rule 3 clean candidate; a reviewer confirms no defensible medium+ objection from the diff before trusting."
+    }
+  },
+  {
+    "number": 3905,
+    "title": "feat(eval): per-voter pr_review precision/recall metrics + persisted report (#3848)",
+    "proposedClass": "clean",
+    "proposedSeverity": null,
+    "needsAdjudication": false,
+    "confidence": 0.7,
+    "provenance": {
+      "source": "historical-clean",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3905",
+      "objectiveSignals": {
+        "number": 3905,
+        "title": "feat(eval): per-voter pr_review precision/recall metrics + persisted report (#3848)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3905",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/config/learning-persistence.ts",
+          "packages/nexus-agents/src/mcp/tools/index.ts",
+          "packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.ts",
+          "packages/nexus-agents/src/mcp/tools/pr-review-eval-store.ts",
+          "packages/nexus-agents/src/mcp/tools/pr-review-eval-types.ts"
+        ],
+        "followUpFixes": [],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "No later PR fixed or reverted any source file #3905 touched (within the harvested window). Rule 3 clean candidate; a reviewer confirms no defensible medium+ objection from the diff before trusting."
+    }
+  },
+  {
+    "number": 3900,
+    "title": "feat(observability): tool-fitness SignalCategory consumer in improvement_review (#3852)",
+    "proposedClass": "borderline",
+    "proposedSeverity": null,
+    "needsAdjudication": true,
+    "confidence": 0.4,
+    "provenance": {
+      "source": "historical",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3900",
+      "objectiveSignals": {
+        "number": 3900,
+        "title": "feat(observability): tool-fitness SignalCategory consumer in improvement_review (#3852)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3900",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/governance/tool-fitness-ledger.ts",
+          "packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts",
+          "packages/nexus-agents/src/mcp/tools/improvement-remediation.ts",
+          "packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.ts",
+          "packages/nexus-agents/src/mcp/tools/improvement-review.ts",
+          "packages/nexus-agents/src/mcp/tools/remediation-research.ts"
+        ],
+        "followUpFixes": [
+          {
+            "fixPrNumber": 3929,
+            "fixType": "fix",
+            "overlappingSourceFiles": [
+              "packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.ts"
+            ]
+          }
+        ],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "Later PR #3929 (fix(governance): refine tool-fitness suggest-signal heuristics (#3902)) touched the same source file(s) [packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.ts], but the follow-up reads as a heuristic refinement / no-behavior-change hardening. Real signal, NOT a confirmed runtime bug — flagged for human adjudication (Rule 4 / 5.1). Not guessed."
+    }
+  },
+  {
+    "number": 3899,
+    "title": "chore(governance): declare four un-issued loops' authority tiers + per-loop promotion-criteria docs (#3843, #3844)",
+    "proposedClass": "clean",
+    "proposedSeverity": null,
+    "needsAdjudication": false,
+    "confidence": 0.7,
+    "provenance": {
+      "source": "historical-clean",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3899",
+      "objectiveSignals": {
+        "number": 3899,
+        "title": "chore(governance): declare four un-issued loops' authority tiers + per-loop promotion-criteria docs (#3843, #3844)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3899",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/orchestration/loop-tier-manifest.ts",
+          "packages/nexus-agents/src/orchestration/loop-tier-registry.ts"
+        ],
+        "followUpFixes": [],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "No later PR fixed or reverted any source file #3899 touched (within the harvested window). Rule 3 clean candidate; a reviewer confirms no defensible medium+ objection from the diff before trusting."
+    }
+  },
+  {
+    "number": 3893,
+    "title": "feat(audit): tier-transition audit events + ratification-linked promotion gate (#3842)",
+    "proposedClass": "buggy",
+    "proposedSeverity": "medium",
+    "needsAdjudication": true,
+    "confidence": 0.75,
+    "provenance": {
+      "source": "historical",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3893",
+      "objectiveSignals": {
+        "number": 3893,
+        "title": "feat(audit): tier-transition audit events + ratification-linked promotion gate (#3842)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3893",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/audit/audit-logger.ts",
+          "packages/nexus-agents/src/audit/audit-types.ts",
+          "packages/nexus-agents/src/audit/index.ts"
+        ],
+        "followUpFixes": [
+          {
+            "fixPrNumber": 3895,
+            "fixType": "fix",
+            "overlappingSourceFiles": ["packages/nexus-agents/src/audit/audit-types.ts"]
+          }
+        ],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "Later PR #3895 (fix(governance): verify ratification-vote resolvability in promotion gate (#3894)) fixed/reverted the same correctness/integrity source file(s) [packages/nexus-agents/src/audit/audit-types.ts] #3893 introduced — a confirmed post-merge correction (Rule 5.3 gold). Severity proposed conservatively; the exact line + final severity are set during adjudication."
+    }
+  },
+  {
+    "number": 3886,
+    "title": "feat(orchestration): manifest-driven MetaOrchestrator router (#3836)",
+    "proposedClass": "borderline",
+    "proposedSeverity": null,
+    "needsAdjudication": true,
+    "confidence": 0.4,
+    "provenance": {
+      "source": "historical",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3886",
+      "objectiveSignals": {
+        "number": 3886,
+        "title": "feat(orchestration): manifest-driven MetaOrchestrator router (#3836)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3886",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/orchestration/meta-orchestrator-decision.ts",
+          "packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts",
+          "packages/nexus-agents/src/orchestration/meta-orchestrator.ts",
+          "packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts",
+          "packages/nexus-agents/src/orchestration/strategy-manifest.ts"
+        ],
+        "followUpFixes": [
+          {
+            "fixPrNumber": 3892,
+            "fixType": "fix",
+            "overlappingSourceFiles": [
+              "packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts",
+              "packages/nexus-agents/src/orchestration/meta-orchestrator.ts",
+              "packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts"
+            ]
+          }
+        ],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "Later PR #3892 (fix(orchestration): harden manifest-driven router (#3888)) touched the same source file(s) [packages/nexus-agents/src/orchestration/meta-orchestrator-routing.ts, packages/nexus-agents/src/orchestration/meta-orchestrator.ts, packages/nexus-agents/src/orchestration/strategy-manifest-registry.ts], but the follow-up reads as a heuristic refinement / no-behavior-change hardening. Real signal, NOT a confirmed runtime bug — flagged for human adjudication (Rule 4 / 5.1). Not guessed."
+    }
+  },
+  {
+    "number": 3873,
+    "title": "feat(governance): claims registry + blocking claims:check gate (#3825, #3826)",
+    "proposedClass": "borderline",
+    "proposedSeverity": null,
+    "needsAdjudication": true,
+    "confidence": 0.4,
+    "provenance": {
+      "source": "historical",
+      "sourcePrUrl": "https://github.com/nexus-substrate/nexus-agents/pull/3873",
+      "objectiveSignals": {
+        "number": 3873,
+        "title": "feat(governance): claims registry + blocking claims:check gate (#3825, #3826)",
+        "url": "https://github.com/nexus-substrate/nexus-agents/pull/3873",
+        "changedSourceFiles": [
+          "packages/nexus-agents/src/governance/claims-registry.ts",
+          "packages/nexus-agents/src/governance/claims-verify.ts",
+          "packages/nexus-agents/src/governance/index.ts"
+        ],
+        "followUpFixes": [
+          {
+            "fixPrNumber": 3884,
+            "fixType": "fix",
+            "overlappingSourceFiles": [
+              "packages/nexus-agents/src/governance/claims-registry.ts",
+              "packages/nexus-agents/src/governance/claims-verify.ts"
+            ]
+          }
+        ],
+        "reviewDecision": "REVIEW_REQUIRED"
+      },
+      "justification": "Later PR #3884 (fix(governance): claims:check verifies subject docs + hardens weak methods (#3877, #3878, #3879, #3882)) touched the same source file(s) [packages/nexus-agents/src/governance/claims-registry.ts, packages/nexus-agents/src/governance/claims-verify.ts], but the follow-up reads as a heuristic refinement / no-behavior-change hardening. Real signal, NOT a confirmed runtime bug — flagged for human adjudication (Rule 4 / 5.1). Not guessed."
+    }
+  }
+]


### PR DESCRIPTION
## What

First increment of #3847: a **curation pipeline** that grows the `pr_review` eval set from the org's **OWN merged PRs + their real review outcomes** as ground truth (not public datasets, not synthetic injection — authenticity is the priority), plus a **validated pilot batch** proving it. Full scaling to n>=50 is a deliberate follow-up, gated on the label-quality review this PR exists to enable.

## The pipeline

Two modules, split so the decision logic is unit-tested in isolation from live GitHub:

- **`scripts/curate-pr-review-harvest.ts`** — the thin gh-fetch I/O layer. Harvests merged PRs via `gh pr list … --json number,title,body,url,files,reviewDecision`, and for each PR extracts **objective signals**: the changed source files, the GitHub review decision, and — critically — whether a **later `fix`/`revert` PR referenced it AND touched the same source files**. That overlap is the ground-truth "this diff shipped a defect, later corrected" signal (rubric Rule 5.3). Emits each case with **full provenance**: real source PR URL, the signals used, the proposed label, a confidence + justification. (Untested-by-unit by design — it is pure `gh` I/O, like `build-model-registry.ts`.)
- **`scripts/curate-pr-review-labeling.ts`** — the **PURE** signal→label core (zero I/O), applying the #3846 labeling rubric. Fully unit-tested.
- **`scripts/curate-pr-review-labeling.test.ts`** — 12 tests covering the decision table + the pure signal-extraction helpers.

## Objective-signal → label logic (no invented labels)

| Objective signal | Proposed label |
|---|---|
| No later PR fixed/reverted any file this PR touched | `clean` (Rule 3) |
| A later `fix`/`revert` touched the **same source file** in a correctness/integrity domain (`/audit/`, `/security/`, `/auth/`, `/governance/`, `/pipeline/`), not marked as a refine/harden tweak | `buggy` at the **`medium` floor** (Rule 5.3 gold); severity never auto-escalated (Rule 5.1) |
| A later fix that reads as a **heuristic refinement / no-behaviour-change hardening**, OR sits **outside** a correctness domain | `borderline` + **`needsAdjudication: true`** (Rule 4) — a real signal but NOT a confirmed runtime bug, flagged for a human, **never guessed** into buggy/clean |

A `revert` is always treated as a confirmed correction (never downgraded by title markers). Severity is never proposed above `medium` — the fix signal proves a defect existed but cannot, alone, establish high/critical reachability; that is the adjudicator's job.

## Pilot output

Running `npx tsx scripts/curate-pr-review-harvest.ts harvest --limit 60 --max-clean 5` against `nexus-substrate/nexus-agents` produced **`testing/datasets/pr-review-candidates-pilot.json`** — a **new** file. The validated v5 set (`pr-review-sample.json`) is **untouched**.

- **10 pilot cases.** Class balance: **1 buggy / 5 clean / 4 borderline**.
- **5 flagged `needsAdjudication`** (the 1 buggy + 4 borderline) — these must be reviewed before the eval set trusts them.
- **Every case cites a real merged PR** (URL + the objective signals in the provenance block). No fabricated cases.

The skew toward clean/borderline is the pipeline being conservative on purpose: of five PRs with a real post-merge fix, only #3893 (fix #3895 hardened a governance promotion gate that accepted a bogus `ratificationVoteRef`) cleared the bar for an automatic `buggy` proposal; the other four were flagged for a human rather than guessed.

## Cases I was unsure about (deliberately flagged, not guessed)

- **#3915** (fix #3918 — "fail-loud audit persist failures"): a real defect by my reading (silently-dropped audit events), but `decision-cost-recording.ts` is under `/mcp/tools/`, not a correctness-domain path → the pipeline proposed `borderline + needsAdjudication`. A reviewer may well promote it to `buggy`.
- **#3873** (fix #3884 — "claims:check verifies subject docs + hardens weak methods"): the fix PR says the gate "does not do its job" (four correctness bugs), which sounds `buggy`, but its title carries a `harden` marker → flagged `borderline`. Likely a `buggy` after adjudication.
- **#3900** (fix #3929, heuristic refinement) and **#3886** (fix #3892, DRY/"no live routing change" hardening): genuinely ambiguous — correctly `borderline`.

## Gates

- Changeset `.changeset/eval-curation-pilot-3847.md` (`'nexus-agents': patch`, `feat`).
- New exports consumed in-tree (labeling ← harvest + test; harvest ← test). `scripts/` is outside the `src/**` unused-exports + changeset scan scopes.
- Lines <=400/file, functions <=50; zero `any`; no MCP tool added (count unchanged); no touch to `inject-governance.ts` / `docs-check.yml` / `SKILL.md`. New files pass `tsc --noEmit`, eslint, and the new vitest file (29 tests green incl. the existing curate suite).

## Do not merge

This needs **label-quality review** before the eval set trusts the pilot. Scaling to n>=50 follows once the labeling logic is signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
