### PR TITLE
feat(cli): suggest closest command on unknown subcommand (#3211)

### DIFF
--- a/.changeset/did-you-mean-3211.md
+++ b/.changeset/did-you-mean-3211.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+feat(cli): suggest closest command on unknown subcommand (#3211)
+
+An unrecognized top-level subcommand (e.g. `nexus-agents reviw`) previously
+fell through silently to the MCP stdio server. It now prints
+`Unknown command 'reviw'. Did you mean: review?` plus the usage hint and exits
+INVALID_ARGS. Suggestions are typo-tolerant via Levenshtein distance (capped at
+distance 2 and ~40% of the input length), ranked nearest-first, up to 3. When
+nothing is close, only the usage hint is shown — behavior is otherwise
+unchanged. The shared Levenshtein helper is extracted to `string-distance.ts`
+and reused by the env-var typo detector.

--- a/packages/nexus-agents/src/cli-command-suggester.test.ts
+++ b/packages/nexus-agents/src/cli-command-suggester.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { COMMAND_CATALOG } from './cli-command-catalog.js';
+import {
+  catalogCommandNames,
+  formatUnknownCommandMessage,
+  suggestCommand,
+} from './cli-command-suggester.js';
+
+const NAMES = ['review', 'vote', 'doctor', 'verify', 'research', 'workflow', 'expert', 'config'];
+
+describe('suggestCommand', () => {
+  it('suggests the closest command for a near-miss (deletion)', () => {
+    expect(suggestCommand('reviw', NAMES)).toEqual(['review']);
+  });
+
+  it('suggests the closest command for a near-miss (insertion)', () => {
+    expect(suggestCommand('vot', NAMES)).toEqual(['vote']);
+  });
+
+  it('suggests the closest command for a near-miss (substitution)', () => {
+    expect(suggestCommand('doctr', NAMES)).toEqual(['doctor']);
+  });
+
+  it('returns nothing for an exact match (no point suggesting what was typed)', () => {
+    expect(suggestCommand('review', NAMES)).toEqual([]);
+  });
+
+  it('returns nothing for a far string', () => {
+    expect(suggestCommand('zzzzzzzz', NAMES)).toEqual([]);
+  });
+
+  it('returns nothing for empty input', () => {
+    expect(suggestCommand('', NAMES)).toEqual([]);
+  });
+
+  it('ranks closer matches first', () => {
+    // 'verfy' is distance 1 from 'verify', distance 2 from 'vote' is larger.
+    const result = suggestCommand('verfy', ['verify', 'vote', 'review']);
+    expect(result[0]).toBe('verify');
+  });
+
+  it('caps suggestions at 3', () => {
+    // All within distance 2 of 'aaa'-ish; ensure no more than 3 returned.
+    const many = ['aaa', 'aab', 'aac', 'aad', 'aae', 'aaf'];
+    expect(suggestCommand('aax', many).length).toBeLessThanOrEqual(3);
+  });
+
+  it('does not suggest for a 1-char typo against a long input when relative threshold is exceeded', () => {
+    // distance from 'x' to 'review' is 6 — far beyond both caps.
+    expect(suggestCommand('x', NAMES)).toEqual([]);
+  });
+
+  it('de-duplicates and ignores case', () => {
+    expect(suggestCommand('REVIW', NAMES)).toEqual(['review']);
+  });
+});
+
+describe('catalogCommandNames', () => {
+  it('excludes the (default) placeholder', () => {
+    expect(catalogCommandNames()).not.toContain('(default)');
+  });
+
+  it('includes real commands from the catalog', () => {
+    const names = catalogCommandNames();
+    expect(names).toContain('review');
+    expect(names).toContain('vote');
+    expect(names).toContain('doctor');
+  });
+
+  it('matches the catalog minus the placeholder', () => {
+    const expected = COMMAND_CATALOG.map((e) => e.command).filter((c) => c !== '(default)');
+    expect(catalogCommandNames()).toEqual(expected);
+  });
+});
+
+describe('against the real catalog (dispatch-path integration)', () => {
+  it.each([
+    ['reviw', 'review'],
+    ['vot', 'vote'],
+    ['doctr', 'doctor'],
+    ['verifi', 'verify'],
+    ['reserch', 'research'],
+  ])('suggests %s -> %s using the live catalog names', (typo, expected) => {
+    expect(suggestCommand(typo, catalogCommandNames())).toContain(expected);
+  });
+
+  it('formats the full unknown-command message off the live catalog', () => {
+    const msg = formatUnknownCommandMessage('reviw', catalogCommandNames());
+    expect(msg).toBe(
+      [
+        "Unknown command 'reviw'.",
+        'Did you mean: review?',
+        'Run "nexus-agents --help" for usage information.',
+      ].join('\n')
+    );
+  });
+});
+
+describe('formatUnknownCommandMessage', () => {
+  it('includes a did-you-mean line when there is a close match', () => {
+    const msg = formatUnknownCommandMessage('reviw', NAMES);
+    expect(msg).toContain("Unknown command 'reviw'.");
+    expect(msg).toContain('Did you mean: review?');
+  });
+
+  it('lists multiple suggestions separated by commas', () => {
+    const msg = formatUnknownCommandMessage('aax', ['aaa', 'aab', 'aac']);
+    expect(msg).toContain('Did you mean:');
+    expect(msg).toMatch(/aa[abc], aa[abc]/);
+  });
+
+  it('omits the did-you-mean line when nothing is close', () => {
+    const msg = formatUnknownCommandMessage('zzzzzzzz', NAMES);
+    expect(msg).toContain("Unknown command 'zzzzzzzz'.");
+    expect(msg).not.toContain('Did you mean');
+  });
+});

--- a/packages/nexus-agents/src/cli-command-suggester.ts
+++ b/packages/nexus-agents/src/cli-command-suggester.ts
@@ -1,0 +1,108 @@
+/**
+ * Typo-tolerant "did you mean?" suggestions for unknown top-level CLI
+ * subcommands (#3211).
+ *
+ * When a user mistypes a command (`nexus-agents reviw`), the dispatcher in
+ * `cli.ts` calls `formatUnknownCommandMessage` to surface the closest known
+ * command(s) alongside the usual usage hint, then exits INVALID_ARGS. If
+ * nothing is close, the suggestion line is omitted and behavior is unchanged.
+ *
+ * The matcher is a small pure helper (`suggestCommand`) over Levenshtein edit
+ * distance — no new dependency.
+ *
+ * @module cli-command-suggester
+ */
+
+import { COMMAND_CATALOG } from './cli-command-catalog.js';
+import { levenshtein } from './string-distance.js';
+
+/** Maximum number of suggestions surfaced for one unknown command. */
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Absolute edit-distance ceiling. A correction more than this many edits away
+ * is almost certainly not what the user meant, so we stay silent rather than
+ * guess. Two edits covers the common typo classes (a transposition, a double
+ * fat-finger) without dredging up unrelated commands.
+ */
+const MAX_ABSOLUTE_DISTANCE = 2;
+
+/**
+ * Relative ceiling: the edit distance must also be within ~40% of the input
+ * length. This keeps short inputs honest — `x` is distance 1 from no real
+ * command but should never map to a 6-letter command, and a 2-letter typo
+ * shouldn't reach across half the alphabet. For longer inputs the absolute cap
+ * dominates.
+ */
+const RELATIVE_DISTANCE_RATIO = 0.4;
+
+/** A candidate command with its distance from the input, for ranking. */
+interface ScoredCandidate {
+  readonly name: string;
+  readonly distance: number;
+}
+
+/**
+ * Returns up to {@link MAX_SUGGESTIONS} command names closest to `input`,
+ * ranked nearest-first, within both the absolute and relative distance
+ * thresholds. An exact match returns `[]` (nothing useful to suggest). Input
+ * is lower-cased for matching; `names` are returned as given.
+ *
+ * Pure and dependency-free — unit-tested in `cli-command-suggester.test.ts`.
+ */
+export function suggestCommand(input: string, names: readonly string[]): string[] {
+  const needle = input.trim().toLowerCase();
+  if (needle.length === 0) return [];
+
+  const ceiling = Math.min(
+    MAX_ABSOLUTE_DISTANCE,
+    Math.floor(needle.length * RELATIVE_DISTANCE_RATIO)
+  );
+  if (ceiling < 1) return [];
+
+  const scored: ScoredCandidate[] = [];
+  for (const name of names) {
+    const distance = levenshtein(needle, name.toLowerCase());
+    if (distance === 0) continue; // exact match — don't suggest what was typed
+    if (distance <= ceiling) {
+      scored.push({ name, distance });
+    }
+  }
+
+  scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name));
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of scored) {
+    if (seen.has(candidate.name)) continue;
+    seen.add(candidate.name);
+    result.push(candidate.name);
+    if (result.length >= MAX_SUGGESTIONS) break;
+  }
+  return result;
+}
+
+/**
+ * Real top-level command names from the catalog, excluding the `(default)`
+ * placeholder (which has no handler and isn't something a user types).
+ * Internal/maintainer commands stay in — they're still valid invocations, so a
+ * typo toward them should resolve.
+ */
+export function catalogCommandNames(): string[] {
+  return COMMAND_CATALOG.map((e) => e.command).filter((c) => c !== '(default)');
+}
+
+/**
+ * Builds the message printed for an unknown top-level command. Always includes
+ * the `Unknown command '<input>'.` line and the usage hint; inserts a
+ * `Did you mean: ...?` line only when there is at least one close match.
+ */
+export function formatUnknownCommandMessage(input: string, names: readonly string[]): string {
+  const suggestions = suggestCommand(input, names);
+  const lines = [`Unknown command '${input}'.`];
+  if (suggestions.length > 0) {
+    lines.push(`Did you mean: ${suggestions.join(', ')}?`);
+  }
+  lines.push('Run "nexus-agents --help" for usage information.');
+  return lines.join('\n');
+}

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -25,6 +25,7 @@ import {
 } from './cli-types.js';
 import { dispatchCommand } from './cli-commands.js';
 import { formatCommandHelp } from './cli-command-help.js';
+import { catalogCommandNames, formatUnknownCommandMessage } from './cli-command-suggester.js';
 import { CLI_NAMES, type CliNameLiteral } from './config/model-capabilities-types.js';
 import {
   VoteThresholdSchema,
@@ -431,6 +432,28 @@ export function parseCliArgs(args: string[] = process.argv.slice(2)): ParsedCliA
 }
 
 /**
+ * If the user typed a first positional that isn't a recognized command, prints
+ * an `Unknown command '<x>'.` message (with a typo-tolerant "Did you mean: …?"
+ * line when a close match exists) and exits INVALID_ARGS — instead of silently
+ * falling through to the MCP server (#3211).
+ *
+ * Only fires when the resolved command is the `server` fall-through AND the
+ * first positional is present but not a valid command. A bare `nexus-agents`
+ * (no positionals) and an explicit `nexus-agents server` are untouched. No
+ * sub-handler consumes `positionals[0]` as a server goal, so an unrecognized
+ * one is unambiguously a typo.
+ */
+function maybeReportUnknownCommand(parsedArgs: ParsedCliArgs): void {
+  if (parsedArgs.command !== 'server') return;
+  if (parsedArgs.options.help || parsedArgs.options.version) return;
+  const firstArg = parsedArgs.positionals[0];
+  if (firstArg === undefined || isValidCommand(firstArg)) return;
+
+  console.error(formatUnknownCommandMessage(firstArg, catalogCommandNames()));
+  process.exit(EXIT_CODES.INVALID_ARGS);
+}
+
+/**
  * Main entry point for the Nexus Agents CLI.
  * Parses arguments and dispatches to appropriate command handler.
  */
@@ -445,6 +468,10 @@ async function main(): Promise<void> {
     console.error('Run "nexus-agents --help" for usage information.');
     process.exit(EXIT_CODES.INVALID_ARGS);
   }
+
+  // #3211: an unrecognized top-level subcommand otherwise silently starts the
+  // MCP server. Catch it here, suggest the closest command, and exit.
+  maybeReportUnknownCommand(parsedArgs);
 
   // Per-command help: show targeted help when --help is used with a command
   if (parsedArgs.options.help && parsedArgs.command !== 'help') {

--- a/packages/nexus-agents/src/config/env-schema.ts
+++ b/packages/nexus-agents/src/config/env-schema.ts
@@ -12,6 +12,7 @@
 
 import { z } from 'zod';
 import type { ILogger } from '../core/index.js';
+import { levenshtein } from '../string-distance.js';
 
 // ============================================================================
 // Helper Zod types for string-encoded values
@@ -147,31 +148,6 @@ const KNOWN_NAMES: readonly string[] = Object.keys(NexusEnvSchema.shape);
 // ============================================================================
 // Levenshtein distance
 // ============================================================================
-
-/** Safe array accessor — indices are always in-bounds by construction. */
-function at(arr: number[], i: number): number {
-  return arr[i] ?? 0;
-}
-
-/** Standard Levenshtein edit distance between two strings. */
-function levenshtein(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-
-  let prev = Array.from({ length: n + 1 }, (_, j) => j);
-  let curr = new Array<number>(n + 1).fill(0);
-
-  for (let i = 1; i <= m; i++) {
-    curr[0] = i;
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(at(prev, j) + 1, at(curr, j - 1) + 1, at(prev, j - 1) + cost);
-    }
-    [prev, curr] = [curr, prev];
-  }
-
-  return at(prev, n);
-}
 
 /** Returns the closest known var name if edit distance <= 3, or null. */
 function suggestSimilar(name: string, known: readonly string[]): string | null {

--- a/packages/nexus-agents/src/string-distance.test.ts
+++ b/packages/nexus-agents/src/string-distance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { levenshtein } from './string-distance.js';
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('review', 'review')).toBe(0);
+  });
+
+  it('returns the length when one string is empty', () => {
+    expect(levenshtein('', 'vote')).toBe(4);
+    expect(levenshtein('vote', '')).toBe(4);
+  });
+
+  it('counts a single substitution as distance 1', () => {
+    expect(levenshtein('vote', 'vate')).toBe(1);
+  });
+
+  it('counts a single deletion as distance 1', () => {
+    expect(levenshtein('reviw', 'review')).toBe(1);
+  });
+
+  it('counts a single insertion as distance 1', () => {
+    expect(levenshtein('vot', 'vote')).toBe(1);
+  });
+
+  it('is symmetric', () => {
+    expect(levenshtein('doctr', 'doctor')).toBe(levenshtein('doctor', 'doctr'));
+  });
+
+  it('computes multi-edit distance', () => {
+    expect(levenshtein('kitten', 'sitting')).toBe(3);
+  });
+});

--- a/packages/nexus-agents/src/string-distance.ts
+++ b/packages/nexus-agents/src/string-distance.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure string-distance helpers shared across the CLI surface.
+ *
+ * Currently exposes standard Levenshtein edit distance, used for typo-tolerant
+ * suggestions: unknown NEXUS_* env vars (`config/env-schema.ts`) and unknown
+ * top-level CLI subcommands (`cli-command-suggester.ts`, #3211).
+ *
+ * @module string-distance
+ */
+
+/** Safe array accessor — indices are always in-bounds by construction. */
+function at(arr: number[], i: number): number {
+  return arr[i] ?? 0;
+}
+
+/**
+ * Standard Levenshtein edit distance between two strings.
+ *
+ * Counts the minimum number of single-character insertions, deletions, and
+ * substitutions needed to turn `a` into `b`. Symmetric. O(len(a) * len(b))
+ * time, O(len(b)) space via the rolling two-row table.
+ */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  let curr = new Array<number>(n + 1).fill(0);
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(at(prev, j) + 1, at(curr, j - 1) + 1, at(prev, j - 1) + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return at(prev, n);
+}


### PR DESCRIPTION
Closes #3211.

## Problem

An unrecognized top-level subcommand (e.g. `nexus-agents reviw`) fell through `determineCommand` to the `server` default and **silently started the MCP stdio server** — no usage, no error. A typo gave the user a hung process instead of a hint.

## Change

### Helper — `suggestCommand(input, names): string[]`
A small pure matcher (`packages/nexus-agents/src/cli-command-suggester.ts`) over Levenshtein edit distance:
- Ranks catalog command names by distance, **nearest-first**, returning **up to 3**.
- **Threshold**: distance `<= min(2, floor(len(input) * 0.4))` — an absolute cap of 2 edits AND a relative ~40%-of-input ceiling. The relative bound keeps short inputs honest (`x` never maps to a 6-letter command); the absolute bound dominates for longer inputs.
- **Exact matches return none** (nothing useful to suggest), case-insensitive, de-duplicated.

`catalogCommandNames()` sources names from `COMMAND_CATALOG`, excluding only the `(default)` placeholder. `formatUnknownCommandMessage()` assembles the `Unknown command '<x>'.` line + a `Did you mean: ...?` line (only when there is a match) + the usage hint.

### Shared Levenshtein (DRY)
The repo already had a private `levenshtein` in `config/env-schema.ts` (env-var typo detection). Extracted it to a shared `string-distance.ts` module; both call sites now reuse it instead of keeping two copies.

### Wiring
`maybeReportUnknownCommand` in `cli.ts` runs in `main()` right after arg parsing. It fires **only** on the `server` fall-through with an unrecognized first positional and no `--help`/`--version` — so bare `nexus-agents`, explicit `nexus-agents server`, and the help/version paths are untouched. No sub-handler consumes `positionals[0]` as a server goal, so an unrecognized one is unambiguously a typo. Exit code stays `INVALID_ARGS` (3).

## Before -> After

```
$ nexus-agents reviw
# before: (silently launches MCP stdio server, hangs)
# after:
Unknown command 'reviw'.
Did you mean: review?
Run "nexus-agents --help" for usage information.
# exit 3
```

Far string keeps the old behavior (no suggestion line), still exit 3:
```
$ nexus-agents zzzzzzzz
Unknown command 'zzzzzzzz'.
Run "nexus-agents --help" for usage information.
```

## Tests

- `string-distance.test.ts` — identical/empty/insert/delete/substitute/symmetry/multi-edit.
- `cli-command-suggester.test.ts` — near-miss (insert/delete/substitute), exact-match suppression, far-string, empty, ranking, 3-cap, relative-threshold rejection, case-insensitive + dedup, `catalogCommandNames` excludes `(default)`, message formatting, and **live-catalog integration** (`reviw`->`review`, `vot`->`vote`, `doctr`->`doctor`, `verifi`->`verify`, `reserch`->`research`).
- Existing `cli.test.ts` (38) and `env-schema.test.ts` (22) green — no regression.

Verified end-to-end against the built `dist/cli.js`: typos suggest + exit 3, far strings omit the suggestion + exit 3, `--version`/`--help`/valid commands unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)