### PR TITLE
feat(cli): expose mode detection for inspection (#3214)

### DIFF
--- a/.changeset/mode-inspection-3214.md
+++ b/.changeset/mode-inspection-3214.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(cli): expose mode detection for inspection (#3214)
+
+Add a `nexus-agents mode` subcommand that prints the detected invocation mode
+(server vs orchestrator), the signals that fed the decision (MCP client, stdin/
+stdout TTY, CI platform, container) with their observed values, and the one-line
+reasoning. Previously the detection in `mode-detector.ts` was only reachable
+internally, so users had no way to see _why_ a given mode was chosen when
+debugging CI/container issues. Supports `--format=json` for scripting and
+`--mode=<m>` to report what an explicit override would resolve to.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-06-17T14:47:20.553Z",
+  "generated": "2026-06-18T02:24:45.881Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.132.1",
   "cli": {
@@ -142,6 +142,12 @@
         "name": "migrate",
         "type": "async",
         "handler": "handleMigrateCommand",
+        "file": "src/cli-commands-handlers.ts"
+      },
+      {
+        "name": "mode",
+        "type": "sync",
+        "handler": "handleModeCommand",
         "file": "src/cli-commands-handlers.ts"
       },
       {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-06-17T14:47:20.553Z
+**Generated:** 2026-06-18T02:24:45.881Z
 **Package Version:** 2.132.1
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CLI Commands (51)
+## CLI Commands (52)
 
 Binary: `nexus-agents`
 
@@ -38,6 +38,7 @@ Binary: `nexus-agents`
 | `memory-benchmark` | async | `handleMemoryBenchmarkCommand` | `src/cli-commands-handlers.ts` |
 | `memory-eval` | sync | `handleMemoryEvalCommand` | `src/cli-commands-handlers.ts` |
 | `migrate` | async | `handleMigrateCommand` | `src/cli-commands-handlers.ts` |
+| `mode` | sync | `handleModeCommand` | `src/cli-commands-handlers.ts` |
 | `orchestrate` | async | `handleOrchestrateCommand` | `src/cli-commands-handlers.ts` |
 | `registry` | async | `handleRegistryCommand` | `src/cli-commands-handlers.ts` |
 | `release-announce` | async | `handleReleaseAnnounceCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -160,6 +160,11 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
     audience: 'advanced',
   },
   {
+    command: 'mode',
+    description: 'Inspect detected mode (server/orchestrator) + signals + reasoning (#3214)',
+    audience: 'advanced',
+  },
+  {
     command: 'registry',
     description: 'Inspect + refresh the dynamic model registry (doctor / refresh)',
     audience: 'advanced',

--- a/packages/nexus-agents/src/cli-command-help.test.ts
+++ b/packages/nexus-agents/src/cli-command-help.test.ts
@@ -14,8 +14,8 @@ import { COMMAND_HELP, formatCommandHelp, formatAllCommandsHelp } from './cli-co
 // ============================================================================
 
 describe('COMMAND_HELP', () => {
-  it('contains 10 command entries', () => {
-    expect(COMMAND_HELP).toHaveLength(10);
+  it('contains 11 command entries', () => {
+    expect(COMMAND_HELP).toHaveLength(11);
   });
 
   it('has unique command names', () => {

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -114,6 +114,24 @@ const DOCTOR_HELP: CommandHelpEntry = {
   ],
 };
 
+const MODE_HELP: CommandHelpEntry = {
+  command: 'mode',
+  description:
+    'Inspect the detected invocation mode (server vs orchestrator), the signals that fed the decision, and the one-line reasoning. Useful for debugging unexpected modes in CI/containers.',
+  examples: [
+    'nexus-agents mode',
+    'nexus-agents mode --format=json',
+    'nexus-agents mode --mode=mesh',
+  ],
+  flags: [
+    { flag: '--format=<fmt>', description: 'Output format: text, json', defaultValue: 'text' },
+    {
+      flag: '--mode=<m>',
+      description: 'Report what an explicit override would resolve to: server, orchestrator, mesh',
+    },
+  ],
+};
+
 const SETUP_HELP: CommandHelpEntry = {
   command: 'setup',
   description: 'Configure MCP integration for Claude, Gemini, Codex, and OpenCode CLIs.',
@@ -234,6 +252,7 @@ export const COMMAND_HELP: readonly CommandHelpEntry[] = [
   EXPERT_HELP,
   WORKFLOW_HELP,
   DOCTOR_HELP,
+  MODE_HELP,
   SETUP_HELP,
   CONFIG_HELP,
   RESEARCH_HELP,

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -80,6 +80,8 @@ export { handleScenarioCommand } from './cli/scenario-command.js';
 export { handleHealthCommand } from './cli/health-command.js';
 // Issue #1598: Validate Command
 export { handleValidateCommand } from './cli/validate-command.js';
+// Issue #3214: Mode Command — expose mode detection for inspection/debugging
+export { handleModeCommand } from './cli/mode-command.js';
 
 // Import handlers for dispatch
 import {
@@ -155,6 +157,8 @@ import { handleScenarioCommand } from './cli/scenario-command.js';
 import { handleHealthCommand } from './cli/health-command.js';
 // Issue #1598: Validate Command
 import { handleValidateCommand } from './cli/validate-command.js';
+// Issue #3214: Mode Command — expose mode detection for inspection/debugging
+import { handleModeCommand } from './cli/mode-command.js';
 // Issue #1398: Lazy data directory initialization
 import { initDataDirectories } from './cli/setup-data-dir.js';
 // #1930: Step notifications (human-readable progress trail)
@@ -206,6 +210,8 @@ const SYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => void) | un
   'memory-eval': handleMemoryEvalCommand,
   // Issue #1403: Health Command
   health: handleHealthCommand,
+  // Issue #3214: Mode Command — print detected mode + signals + reasoning
+  mode: handleModeCommand,
 };
 
 /**

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -82,7 +82,8 @@ export type CliCommand =
   | 'tour'
   | 'improvement-review'
   | 'auto-remediate'
-  | 'remediation-review';
+  | 'remediation-review'
+  | 'mode';
 
 /**
  * Parsed CLI arguments and command.
@@ -570,6 +571,7 @@ const VALID_COMMANDS: readonly CliCommand[] = [
   'tour',
   'auto-remediate',
   'remediation-review',
+  'mode',
 ];
 
 /**

--- a/packages/nexus-agents/src/cli/index.ts
+++ b/packages/nexus-agents/src/cli/index.ts
@@ -62,13 +62,21 @@ export { evaluateCommand, parseOptions } from './self-eval.js';
 export type { EvaluateOptions, EvaluateCommandResult, EvaluationSummary } from './self-eval.js';
 
 // Mode detection
-export { detectMode, formatModeDetection, isValidServerMode } from './mode-detector.js';
+export {
+  detectMode,
+  formatModeDetection,
+  formatModeInspection,
+  describeSignals,
+  isValidServerMode,
+} from './mode-detector.js';
 export type {
   ServerMode,
   ModeDetectionResult,
   DetectionSignals,
   DetectModeOptions,
+  SignalRow,
 } from './mode-detector.js';
+export { handleModeCommand } from './mode-command.js';
 
 // PR Review (dogfooding)
 export { reviewCommand } from './review-command.js';

--- a/packages/nexus-agents/src/cli/mode-command.ts
+++ b/packages/nexus-agents/src/cli/mode-command.ts
@@ -1,0 +1,79 @@
+/**
+ * nexus-agents/cli - Mode Command
+ *
+ * Exposes the otherwise-internal mode detection (server vs orchestrator) for
+ * inspection and debugging. Prints the detected mode, the signals that fed the
+ * decision (each signal + observed value), and a one-line reasoning — useful
+ * when a CI/container run lands in an unexpected mode.
+ *
+ * @module cli/mode-command
+ * (Source: Issue #3214 — expose mode detection for inspection/debugging)
+ */
+
+import type { ParsedCliArgs } from '../cli-types.js';
+import { EXIT_CODES } from '../cli-types.js';
+import {
+  detectMode,
+  describeSignals,
+  formatModeInspection,
+  isValidServerMode,
+  type ServerMode,
+} from './mode-detector.js';
+
+/** Writes a line to stdout (single sink keeps output testable/consistent). */
+function write(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+/**
+ * Resolves the explicit-mode override from `--mode`.
+ *
+ * The `--mode` flag defaults to `'server'` in PARSE_ARGS_CONFIG and doubles as
+ * the server-launch flag, so a bare `nexus-agents mode` must NOT be treated as
+ * an explicit override — that would always report `server`. Only treat it as
+ * explicit when the user passed a non-default, valid value.
+ *
+ * @param raw - The raw `--mode` flag value
+ * @returns The explicit mode, or undefined to let auto-detection run
+ */
+function resolveExplicitMode(raw: ServerMode | undefined): ServerMode | undefined {
+  // `--mode` defaults to 'server'; a bare invocation must not be read as an
+  // explicit override. parseArgs hands back a string at runtime, so re-validate
+  // defensively rather than trusting the declared type.
+  if (raw === undefined || raw === 'server') return undefined;
+  return isValidServerMode(raw) ? raw : undefined;
+}
+
+/**
+ * Handles `nexus-agents mode` — print the detected invocation mode and why.
+ *
+ * Flags:
+ * - `--mode=<m>` reports what an explicit `--mode` override would resolve to.
+ * - `--format=json` emits a machine-readable object instead of the report.
+ *
+ * @param args - Parsed CLI arguments
+ */
+export function handleModeCommand(args: ParsedCliArgs): void {
+  const explicitMode = resolveExplicitMode(args.options.mode);
+  const result = detectMode(explicitMode !== undefined ? { explicitMode } : {});
+
+  if (args.options.format === 'json') {
+    write(
+      JSON.stringify(
+        {
+          mode: result.mode,
+          source: result.source,
+          reason: result.reason,
+          detectionTimeMs: result.detectionTimeMs,
+          signals: describeSignals(result.signals),
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    write(formatModeInspection(result));
+  }
+
+  process.exit(EXIT_CODES.SUCCESS);
+}

--- a/packages/nexus-agents/src/cli/mode-detector.test.ts
+++ b/packages/nexus-agents/src/cli/mode-detector.test.ts
@@ -8,9 +8,12 @@ import { describe, it, expect } from 'vitest';
 import {
   detectMode,
   formatModeDetection,
+  formatModeInspection,
+  describeSignals,
   isValidServerMode,
   type ServerMode,
   type DetectModeOptions,
+  type DetectionSignals,
 } from './mode-detector.js';
 
 describe('Mode Detector', () => {
@@ -339,6 +342,142 @@ describe('Mode Detector', () => {
       expect(formatted).toContain('mode=orchestrator');
       expect(formatted).toContain('source=auto');
       expect(formatted).toContain('CI environment');
+    });
+  });
+
+  describe('describeSignals()', () => {
+    function signals(overrides: Partial<DetectionSignals> = {}): DetectionSignals {
+      return {
+        stdinIsTty: true,
+        stdoutIsTty: true,
+        mcpClientName: undefined,
+        isCI: false,
+        ciPlatform: undefined,
+        isContainer: false,
+        ...overrides,
+      };
+    }
+
+    it('renders an MCP client name when present', () => {
+      const rows = describeSignals(signals({ mcpClientName: 'claude-code' }));
+      const mcpRow = rows.find((r) => r.label === 'MCP client');
+      expect(mcpRow?.value).toBe('claude-code');
+    });
+
+    it('renders "(none)" for an absent or empty MCP client', () => {
+      expect(describeSignals(signals()).find((r) => r.label === 'MCP client')?.value).toBe(
+        '(none)'
+      );
+      expect(
+        describeSignals(signals({ mcpClientName: '' })).find((r) => r.label === 'MCP client')?.value
+      ).toBe('(none)');
+    });
+
+    it('renders TTY booleans as yes/no', () => {
+      const rows = describeSignals(signals({ stdinIsTty: false, stdoutIsTty: true }));
+      expect(rows.find((r) => r.label === 'stdin is TTY')?.value).toBe('no');
+      expect(rows.find((r) => r.label === 'stdout is TTY')?.value).toBe('yes');
+    });
+
+    it('renders the CI platform when CI is detected', () => {
+      const rows = describeSignals(signals({ isCI: true, ciPlatform: 'GitHub Actions' }));
+      expect(rows.find((r) => r.label === 'CI environment')?.value).toBe('yes (GitHub Actions)');
+    });
+
+    it('renders CI as "no" when not in CI', () => {
+      expect(describeSignals(signals()).find((r) => r.label === 'CI environment')?.value).toBe(
+        'no'
+      );
+    });
+  });
+
+  describe('formatModeInspection()', () => {
+    // Build a result from fabricated signals — never touches process.env so the
+    // formatter's behavior is asserted in isolation from the host environment.
+    function fakeSignals(overrides: Partial<DetectionSignals> = {}): DetectionSignals {
+      return {
+        stdinIsTty: true,
+        stdoutIsTty: true,
+        mcpClientName: undefined,
+        isCI: false,
+        ciPlatform: undefined,
+        isContainer: false,
+        ...overrides,
+      };
+    }
+
+    it('reports server mode + reasoning when an MCP client is detected', () => {
+      const result = detectMode({
+        stdinIsTty: true,
+        stdoutIsTty: true,
+        env: { MCP_CLIENT_NAME: 'claude-code' },
+      });
+      const out = formatModeInspection(result);
+
+      expect(out).toContain('Detected mode: server (auto)');
+      expect(out).toContain('Reasoning:');
+      expect(out).toContain('MCP client detected: claude-code');
+      expect(out).toContain('Signals:');
+      expect(out).toContain('MCP client');
+    });
+
+    it('reports server mode for piped (non-TTY) stdin', () => {
+      const result = detectMode({ stdinIsTty: false, stdoutIsTty: true, env: {} });
+      const out = formatModeInspection(result);
+
+      expect(out).toContain('Detected mode: server (auto)');
+      expect(out).toContain('stdin is not a TTY');
+      expect(out).toContain('stdin is TTY    no');
+    });
+
+    it('reports orchestrator mode for an interactive terminal', () => {
+      const result = detectMode({ stdinIsTty: true, stdoutIsTty: true, env: {} });
+      const out = formatModeInspection(result);
+
+      expect(out).toContain('Detected mode: orchestrator (auto)');
+      expect(out).toContain('Interactive terminal');
+    });
+
+    it('reports orchestrator mode + CI platform in a CI environment', () => {
+      const result = detectMode({
+        stdinIsTty: true,
+        stdoutIsTty: true,
+        env: { GITHUB_ACTIONS: 'true' },
+      });
+      const out = formatModeInspection(result);
+
+      expect(out).toContain('Detected mode: orchestrator (auto)');
+      expect(out).toContain('CI environment detected (GitHub Actions)');
+      expect(out).toContain('yes (GitHub Actions)');
+    });
+
+    it('marks the source as explicit when --mode is overridden', () => {
+      const result = detectMode({
+        explicitMode: 'mesh',
+        stdinIsTty: true,
+        stdoutIsTty: true,
+        env: {},
+      });
+      const out = formatModeInspection(result);
+
+      expect(out).toContain('Detected mode: mesh (explicit)');
+      expect(out).toContain('--mode=mesh');
+    });
+
+    it('renders one signal line per signal and no secrets', () => {
+      const result = detectMode({
+        stdinIsTty: false,
+        stdoutIsTty: false,
+        env: { KUBERNETES_SERVICE_HOST: '10.0.0.1' },
+      });
+      const out = formatModeInspection(result);
+
+      // Each describeSignals row appears as a labeled line.
+      for (const row of describeSignals(fakeSignals())) {
+        expect(out).toContain(row.label);
+      }
+      // The container IP (a host detail) is a value we never surface.
+      expect(out).not.toContain('10.0.0.1');
     });
   });
 

--- a/packages/nexus-agents/src/cli/mode-detector.ts
+++ b/packages/nexus-agents/src/cli/mode-detector.ts
@@ -298,3 +298,81 @@ export function formatModeDetection(result: ModeDetectionResult): string {
 
   return parts.join(' ');
 }
+
+/** A single human-readable signal row: name + observed value. */
+export interface SignalRow {
+  readonly label: string;
+  readonly value: string;
+}
+
+/**
+ * Projects the raw detection signals into ordered, human-readable rows.
+ *
+ * Pure: depends only on its `signals` argument, never on `process.env` or the
+ * real TTY state. The ordering mirrors the detection priority in
+ * `determineMode` so a reader can follow why the mode was chosen.
+ *
+ * @param signals - Detection signals to project
+ * @returns Ordered rows, one per signal, with the observed value rendered
+ */
+export function describeSignals(signals: DetectionSignals): readonly SignalRow[] {
+  return [
+    {
+      label: 'MCP client',
+      value:
+        signals.mcpClientName !== undefined && signals.mcpClientName !== ''
+          ? signals.mcpClientName
+          : '(none)',
+    },
+    { label: 'stdin is TTY', value: signals.stdinIsTty ? 'yes' : 'no' },
+    { label: 'stdout is TTY', value: signals.stdoutIsTty ? 'yes' : 'no' },
+    {
+      label: 'CI environment',
+      value: signals.isCI ? `yes (${signals.ciPlatform ?? 'unknown'})` : 'no',
+    },
+    { label: 'container', value: signals.isContainer ? 'yes' : 'no' },
+  ];
+}
+
+/**
+ * Formats a mode detection result as a readable inspection report for humans.
+ *
+ * Shows the detected mode, the source (explicit `--mode` vs auto-detected), the
+ * one-line reasoning, and a table of every signal that fed the decision with
+ * its observed value. No secrets are emitted — the signals are TTY/CI/container
+ * booleans and the MCP client name (a non-secret identifier).
+ *
+ * Pure: the report is derived entirely from `result`, so it can be unit-tested
+ * with fabricated signal inputs.
+ *
+ * @param result - Detection result to render
+ * @returns Multi-line report suitable for `stdout`
+ *
+ * @example
+ * ```typescript
+ * const result = detectMode({ stdinIsTty: false, env: {} });
+ * console.log(formatModeInspection(result));
+ * // Detected mode: server (auto)
+ * // Reasoning:     stdin is not a TTY (piped input detected)
+ * // Signals:
+ * //   MCP client      (none)
+ * //   stdin is TTY    no
+ * //   ...
+ * ```
+ */
+export function formatModeInspection(result: ModeDetectionResult): string {
+  const rows = describeSignals(result.signals);
+  const labelWidth = Math.max(...rows.map((r) => r.label.length));
+
+  const lines: string[] = [
+    `Detected mode: ${result.mode} (${result.source})`,
+    `Reasoning:     ${result.reason}`,
+    `Detected in:   ${result.detectionTimeMs.toFixed(2)}ms`,
+    'Signals:',
+  ];
+  for (const row of rows) {
+    lines.push(`  ${row.label.padEnd(labelWidth)}  ${row.value}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Closes #3214.

## Integration chosen + why
A **dedicated `nexus-agents mode` subcommand**, not a section bolted onto `doctor`/`status`/`validate`.

Those three are health/fitness dashboards (adapters, sqlite, config, fitness score). Mode detection is a distinct, single-purpose diagnostic — "which mode did I resolve to and why" — that users reach for when a CI/container run lands somewhere unexpected. A dedicated verb keeps it discoverable (`nexus-agents mode`), scriptable (`--format=json`), and doesn't dilute the existing diagnostics. It also mirrors the existing capability-inspection commands (`capabilities`, `registry`) that already live in the `advanced` audience band.

## Sample output
```
$ nexus-agents mode
Detected mode: server (auto)
Reasoning:     stdin is not a TTY (piped input detected)
Detected in:   0.13ms
Signals:
  MCP client      (none)
  stdin is TTY    no
  stdout is TTY   no
  CI environment  no
  container       no
```
```
$ GITHUB_ACTIONS=true nexus-agents mode      # interactive TTY
Detected mode: orchestrator (auto)
Reasoning:     CI environment detected (GitHub Actions)
...
  CI environment  yes (GitHub Actions)
```
```
$ nexus-agents mode --format=json
{ "mode": "server", "source": "auto", "reason": "...", "detectionTimeMs": 0.12,
  "signals": [ { "label": "MCP client", "value": "(none)" }, ... ] }
```
`--mode=<m>` reports what an explicit override would resolve to (`Detected mode: mesh (explicit)`). No secrets emitted — signals are TTY/CI/container booleans + the (non-secret) MCP client identifier; the container host IP is deliberately not surfaced.

## Wiring points touched
- `src/cli/mode-detector.ts` — new **pure** `describeSignals()` (ordered signal→value rows) + `formatModeInspection()` (human report). File stays at 378 lines (<400).
- `src/cli/mode-command.ts` — new `handleModeCommand` (sync); `--format=json`, `--mode` override (ignores the default `'server'` so a bare invocation auto-detects).
- `src/cli-types.ts` — `'mode'` in `CliCommand` union + `VALID_COMMANDS`.
- `src/cli-commands.ts` — import, re-export, `SYNC_COMMAND_HANDLERS['mode']`.
- `src/cli-command-catalog.ts` — `COMMAND_CATALOG` entry, `advanced` audience.
- `src/cli-command-help.ts` — `MODE_HELP` registered in `COMMAND_HELP`.
- `src/cli/index.ts` — barrel exports for the new pure fns/types + handler.
- `.changeset/mode-inspection-3214.md` — `'nexus-agents': patch`, feat.

The #3211 unknown-command suggester reads `COMMAND_CATALOG`, so `mode` is automatically treated as a known command.

## Tests
TDD on the **pure** surface (no real `process.env` in assertions — signals fabricated/parametrized):
- `describeSignals()`: MCP-present vs `(none)`, TTY yes/no, CI platform rendering.
- `formatModeInspection()`: MCP→server, piped-stdin→server, interactive→orchestrator, CI→orchestrator + platform, explicit→`mesh (explicit)`, one line per signal, container IP not leaked.

47 tests pass in `mode-detector.test.ts`; catalog/suggester/extractor suites green; `tsc --noEmit` clean; eslint clean on changed files; built CLI verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)