### PR TITLE
refactor(cli): unify exit handling under CommandResult (#3210)

### DIFF
--- a/.changeset/command-result-migration-3210.md
+++ b/.changeset/command-result-migration-3210.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+refactor(cli): unify exit handling under CommandResult (#3210)
+
+CLI command handlers in `cli-commands-handlers.ts` and
+`cli-commands-handlers-complex.ts` now RETURN a `CliExitResult` (a
+`CommandResult` carrying an `exitCode`) instead of calling `process.exit`
+inline. The single `process.exit` boundary lives in the dispatcher
+(`dispatchCommand` → `exitWith`). Exit codes are identical to before for
+every path — this is a behavior-preserving structural refactor, not a
+behavior change. Handlers that own the process lifecycle (the MCP stdio
+server, the `session` valid-subcommand path) intentionally return
+`undefined` so the dispatcher does not force an exit, preserving prior
+event-loop-drain behavior.

--- a/packages/nexus-agents/src/cli-commands-handlers-complex.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers-complex.test.ts
@@ -157,7 +157,7 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['config', 'bogus'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
       expect(writeSpy).toHaveBeenCalledWith(
         expect.stringContaining("Unknown config subcommand: 'bogus'")
@@ -165,7 +165,8 @@ describe('cli-commands-handlers-complex', () => {
       expect(writeSpy).toHaveBeenCalledWith(
         expect.stringContaining('Valid subcommands: init, get, set, list, reset, export, import')
       );
-      expect(mockExit).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS
+      // #3210: handler RETURNS the exit code; the dispatcher owns process.exit.
+      expect(result).toEqual({ success: false, exitCode: 3 }); // EXIT_CODES.INVALID_ARGS
       expect(configCommand).not.toHaveBeenCalled();
     });
 
@@ -174,15 +175,15 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['config'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
       expect(writeSpy).toHaveBeenCalledWith(
         expect.stringContaining("Unknown config subcommand: ''")
       );
-      expect(mockExit).toHaveBeenCalledWith(3);
+      expect(result).toEqual({ success: false, exitCode: 3 });
     });
 
-    it('exits SUCCESS on exit code 0', async () => {
+    it('returns SUCCESS on exit code 0', async () => {
       vi.mocked(configCommand).mockResolvedValueOnce(0);
 
       const args = createArgs({
@@ -190,12 +191,12 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['config', 'list'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
-      expect(mockExit).toHaveBeenCalledWith(0); // EXIT_CODES.SUCCESS
+      expect(result).toEqual({ success: true, exitCode: 0 }); // EXIT_CODES.SUCCESS
     });
 
-    it('exits SERVER_START_FAILED on non-zero exit code', async () => {
+    it('returns SERVER_START_FAILED on non-zero exit code', async () => {
       vi.mocked(configCommand).mockResolvedValueOnce(1);
 
       const args = createArgs({
@@ -203,9 +204,9 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['config', 'list'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
-      expect(mockExit).toHaveBeenCalledWith(1); // EXIT_CODES.SERVER_START_FAILED
+      expect(result).toEqual({ success: false, exitCode: 1 }); // EXIT_CODES.SERVER_START_FAILED
     });
 
     it('passes format as yaml when specified', async () => {
@@ -269,10 +270,10 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['orchestrate'],
       });
 
-      await handleOrchestrateCommand(args);
+      const result = await handleOrchestrateCommand(args);
 
       expect(printOrchestrateUsage).toHaveBeenCalled();
-      expect(mockExit).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS
+      expect(result).toEqual({ success: false, exitCode: 3 }); // EXIT_CODES.INVALID_ARGS
     });
 
     it('passes valid model through', async () => {
@@ -429,7 +430,7 @@ describe('cli-commands-handlers-complex', () => {
       );
     });
 
-    it('exits with correct code on success', async () => {
+    it('returns the correct code on success', async () => {
       vi.mocked(orchestrateCommand).mockResolvedValueOnce(0);
 
       const args = createArgs({
@@ -437,21 +438,21 @@ describe('cli-commands-handlers-complex', () => {
         positionals: ['orchestrate', 'some task'],
       });
 
-      await handleOrchestrateCommand(args);
+      const result = await handleOrchestrateCommand(args);
 
-      expect(mockExit).toHaveBeenCalledWith(0); // EXIT_CODES.SUCCESS
+      expect(result).toEqual({ success: true, exitCode: 0 }); // EXIT_CODES.SUCCESS
     });
   });
 
   describe('handleSweBenchCommand (deprecation shim, #2515)', () => {
-    it('exits with INVALID_ARGS and prints migration message', async () => {
+    it('returns INVALID_ARGS and prints migration message', async () => {
       const args = createArgs({
         command: 'swe-bench',
         positionals: ['swe-bench'],
       });
       const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-      await handleSweBenchCommand(args);
-      expect(mockExit).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS
+      const result = await handleSweBenchCommand(args);
+      expect(result).toEqual({ success: false, exitCode: 3 }); // EXIT_CODES.INVALID_ARGS
       const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(written).toContain('nexus-eval-swebench');
       stderrSpy.mockRestore();

--- a/packages/nexus-agents/src/cli-commands-handlers-complex.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers-complex.ts
@@ -14,20 +14,26 @@ import {
   isValidConfigAction,
   orchestrateCommand,
 } from './cli/index.js';
-import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
+import {
+  EXIT_CODES,
+  cliExit,
+  cliExitFromStatus,
+  type CliExitResult,
+  type ParsedCliArgs,
+} from './cli-types.js';
 import { isValidOrchestrateModel } from './cli-commands-validators.js';
 import { printOrchestrateUsage } from './cli-commands-usage.js';
 
 /**
  * Handles the config init subcommand.
  */
-async function handleConfigInit(args: ParsedCliArgs): Promise<void> {
+async function handleConfigInit(args: ParsedCliArgs): Promise<CliExitResult> {
   const configOpts = {
     force: args.options.force,
     ...(args.options.output !== undefined && { output: args.options.output }),
   };
   const exitCode = await configInitCommand(configOpts);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
@@ -75,7 +81,7 @@ function buildConfigOptions(
  * Supports: init, get, set, list, reset, export, import
  * (Source: Issue #360, Issue #378)
  */
-export async function handleConfigCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleConfigCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const subcommand = args.subcommand ?? '';
 
   // Handle init separately (uses different implementation)
@@ -86,13 +92,12 @@ export async function handleConfigCommand(args: ParsedCliArgs): Promise<void> {
   // Validate subcommand is a valid config action
   if (!isValidConfigAction(subcommand)) {
     printUnknownConfigSubcommand(subcommand);
-    process.exit(EXIT_CODES.INVALID_ARGS);
-    return;
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const configOpts = buildConfigOptions(args, subcommand);
   const exitCode = await configCommand(configOpts);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
@@ -108,12 +113,12 @@ function isValidOrchestrateEngine(value: string): value is 'router' | 'puppeteer
  * (Source: Issue #183, 5-0 consensus vote)
  * (Source: Issue #386 - PuppeteerOrchestrator integration)
  */
-export async function handleOrchestrateCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleOrchestrateCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // Get task from positionals (orchestrate <task>)
   const task = args.positionals[1];
   if (task === undefined) {
     printOrchestrateUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Parse optional model
@@ -147,7 +152,7 @@ export async function handleOrchestrateCommand(args: ParsedCliArgs): Promise<voi
     policyPath,
     maxSteps,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
@@ -159,7 +164,7 @@ export async function handleOrchestrateCommand(args: ParsedCliArgs): Promise<voi
  * doesn't silently break — prints the migration command to stderr and
  * exits non-zero. Slated for removal after the next minor.
  */
-export async function handleSweBenchCommand(_args: ParsedCliArgs): Promise<void> {
+export async function handleSweBenchCommand(_args: ParsedCliArgs): Promise<CliExitResult> {
   process.stderr.write(
     "The 'nexus-agents swe-bench' subcommand was removed in this release.\n" +
       'The SWE-bench harness now lives in its own repo per the harness-extraction\n' +
@@ -173,7 +178,7 @@ export async function handleSweBenchCommand(_args: ParsedCliArgs): Promise<void>
       'for library-mode usage and the v0.2 clean-room implementation.\n'
   );
   await Promise.resolve();
-  process.exit(EXIT_CODES.INVALID_ARGS);
+  return cliExit(EXIT_CODES.INVALID_ARGS);
 }
 
 /**
@@ -185,7 +190,7 @@ export async function handleSweBenchCommand(_args: ParsedCliArgs): Promise<void>
  * doesn't silently break — prints the migration command to stderr and
  * exits non-zero. Slated for removal after the next minor.
  */
-export async function handleAtbenchCommand(_args: ParsedCliArgs): Promise<void> {
+export async function handleAtbenchCommand(_args: ParsedCliArgs): Promise<CliExitResult> {
   process.stderr.write(
     "The 'nexus-agents atbench' subcommand was removed in this release.\n" +
       'The Atbench harness now lives in its own repo per the harness-extraction\n' +
@@ -197,5 +202,5 @@ export async function handleAtbenchCommand(_args: ParsedCliArgs): Promise<void> 
       "Run 'npx nexus-eval-atbench --help' for the full flag set.\n"
   );
   await Promise.resolve();
-  process.exit(EXIT_CODES.INVALID_ARGS);
+  return cliExit(EXIT_CODES.INVALID_ARGS);
 }

--- a/packages/nexus-agents/src/cli-commands-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.test.ts
@@ -26,11 +26,19 @@ vi.mock('./cli/index.js', async (importOriginal) => {
     ...original,
     configCommand: vi.fn().mockResolvedValue(0),
     configInitCommand: vi.fn().mockResolvedValue(0),
+    // #3210: stub status-returning commands so we can assert the handler's
+    // CliExitResult maps the underlying 0|non-0 status to SUCCESS|SERVER_START_FAILED.
+    expertListCommand: vi.fn().mockReturnValue(0),
+    helloCommand: vi.fn().mockReturnValue(0),
   };
 });
 
-import { handleConfigCommand } from './cli-commands-handlers.js';
-import { configCommand, configInitCommand } from './cli/index.js';
+import {
+  handleConfigCommand,
+  handleExpertCommand,
+  handleHelloCommand,
+} from './cli-commands-handlers.js';
+import { configCommand, configInitCommand, expertListCommand, helloCommand } from './cli/index.js';
 
 /**
  * Creates a ParsedCliArgs object with default values.
@@ -325,12 +333,13 @@ describe('handleConfigCommand routing', () => {
         positionals: ['config', 'unknown'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
       expect(process.stdout.write).toHaveBeenCalledWith(
         expect.stringContaining("Unknown config subcommand: 'unknown'")
       );
-      expect(mockExit).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS
+      // #3210: handler RETURNS the exit code; the dispatcher owns process.exit.
+      expect(result).toEqual({ success: false, exitCode: 3 }); // EXIT_CODES.INVALID_ARGS
       expect(configCommand).not.toHaveBeenCalled();
     });
 
@@ -355,12 +364,59 @@ describe('handleConfigCommand routing', () => {
         positionals: ['config'],
       });
 
-      await handleConfigCommand(args);
+      const result = await handleConfigCommand(args);
 
       expect(process.stdout.write).toHaveBeenCalledWith(
         expect.stringContaining("Unknown config subcommand: ''")
       );
-      expect(mockExit).toHaveBeenCalledWith(3);
+      expect(result).toEqual({ success: false, exitCode: 3 });
+    });
+  });
+});
+
+// #3210: migrated handlers RETURN a CliExitResult instead of calling
+// process.exit. These tests prove the returned exitCode is identical to the
+// pre-refactor exit code on both a success and a failure path, without
+// asserting on real process.exit.
+describe('CliExitResult return contract (#3210)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleExpertCommand', () => {
+    it('returns SUCCESS (0) when expertListCommand reports 0', () => {
+      vi.mocked(expertListCommand).mockReturnValueOnce(0);
+      const args = createMockArgs({ command: 'expert', subcommand: 'list' });
+      expect(handleExpertCommand(args)).toEqual({ success: true, exitCode: 0 });
+    });
+
+    it('returns SERVER_START_FAILED (1) when expertListCommand reports non-zero', () => {
+      vi.mocked(expertListCommand).mockReturnValueOnce(1);
+      const args = createMockArgs({ command: 'expert', subcommand: 'list' });
+      expect(handleExpertCommand(args)).toEqual({ success: false, exitCode: 1 });
+    });
+
+    it('returns NOT_IMPLEMENTED (4) for an unimplemented subcommand', () => {
+      const args = createMockArgs({ command: 'expert', subcommand: 'create' });
+      expect(handleExpertCommand(args)).toEqual({ success: false, exitCode: 4 });
+    });
+  });
+
+  describe('handleHelloCommand', () => {
+    it('returns SUCCESS (0) when helloCommand reports 0', () => {
+      vi.mocked(helloCommand).mockReturnValueOnce(0);
+      expect(handleHelloCommand(createMockArgs({ command: 'hello' }))).toEqual({
+        success: true,
+        exitCode: 0,
+      });
+    });
+
+    it('returns SERVER_START_FAILED (1) when helloCommand reports non-zero', () => {
+      vi.mocked(helloCommand).mockReturnValueOnce(2);
+      expect(handleHelloCommand(createMockArgs({ command: 'hello' }))).toEqual({
+        success: false,
+        exitCode: 1,
+      });
     });
   });
 });

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -49,7 +49,13 @@ import { runMemoryEval, formatMemoryEvalReport } from './cli/memory-eval.js';
 import { existsSync } from 'node:fs';
 import { getNexusDataDir } from './config/nexus-data-dir.js';
 import { initPortable, formatInitPortableMessage } from './cli/init-portable.js';
-import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
+import {
+  EXIT_CODES,
+  cliExit,
+  cliExitFromStatus,
+  type CliExitResult,
+  type ParsedCliArgs,
+} from './cli-types.js';
 import { startServer, type OrchestratorModeOptions } from './cli-server.js';
 import {
   isValidExpertListFormat,
@@ -81,7 +87,8 @@ export {
 /**
  * Handles unimplemented CLI subcommands. Writes to stderr (not stdout) so
  * a shell script piping stdout doesn't silently consume the notice, and
- * the caller is expected to follow up with `process.exit(EXIT_CODES.NOT_IMPLEMENTED)`.
+ * the caller is expected to follow up by returning
+ * `cliExit(EXIT_CODES.NOT_IMPLEMENTED)` (the dispatcher then exits with it).
  *
  * Pre-#2727 this wrote to stdout and callers exited with EXIT_CODES.SUCCESS —
  * automation scripts couldn't tell that nothing happened.
@@ -109,34 +116,32 @@ export function handleUnimplementedCommand(command: string): void {
 /**
  * Handles the expert command and its subcommands.
  */
-export function handleExpertCommand(args: ParsedCliArgs): void {
+export function handleExpertCommand(args: ParsedCliArgs): CliExitResult {
   if (args.subcommand === 'list') {
     const format = isValidExpertListFormat(args.options.format) ? args.options.format : 'table';
-    const exitCode = expertListCommand({ format });
-    process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
-  } else {
-    handleUnimplementedCommand(`expert ${args.subcommand ?? ''}`);
-    process.exit(EXIT_CODES.NOT_IMPLEMENTED);
+    return cliExitFromStatus(expertListCommand({ format }));
   }
+  handleUnimplementedCommand(`expert ${args.subcommand ?? ''}`);
+  return cliExit(EXIT_CODES.NOT_IMPLEMENTED);
 }
 
 /**
  * Handles the workflow command and its subcommands.
  */
-export async function handleWorkflowCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleWorkflowCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   if (args.subcommand === 'list') {
     // #2726 A: respect --format=json. Pre-fix the flag parsed but the
     // dispatcher never forwarded it to printWorkflowTemplates, so the
     // table form rendered regardless.
     const format = args.options.format === 'json' ? 'json' : 'table';
     await printWorkflowTemplates({ format });
-    process.exit(EXIT_CODES.SUCCESS);
+    return cliExit(EXIT_CODES.SUCCESS);
   } else if (args.subcommand === 'run') {
     // Get workflow name from positionals (workflow run <name>)
     const workflowName = args.positionals[2];
     if (workflowName === undefined) {
       printWorkflowRunUsage();
-      process.exit(EXIT_CODES.INVALID_ARGS);
+      return cliExit(EXIT_CODES.INVALID_ARGS);
     }
 
     const exitCode = await workflowRunCommand({
@@ -145,11 +150,10 @@ export async function handleWorkflowCommand(args: ParsedCliArgs): Promise<void> 
       dryRun: args.options.dryRun,
       verbose: args.options.verbose,
     });
-    process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
-  } else {
-    handleUnimplementedCommand(`workflow ${args.subcommand ?? ''}`);
-    process.exit(EXIT_CODES.NOT_IMPLEMENTED);
+    return cliExitFromStatus(exitCode);
   }
+  handleUnimplementedCommand(`workflow ${args.subcommand ?? ''}`);
+  return cliExit(EXIT_CODES.NOT_IMPLEMENTED);
 }
 
 /**
@@ -189,25 +193,30 @@ function printFirstRunHint(): void {
  * In orchestrator mode, executes tasks directly without MCP server.
  * (Source: Issue #446 - Implement orchestrator mode)
  */
-export async function handleServerCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleServerCommand(args: ParsedCliArgs): Promise<CliExitResult | undefined> {
   printFirstRunHint();
   if (args.options.interactive) {
     const exitCode = await replCommand({ verbose: args.options.verbose });
-    process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+    return cliExitFromStatus(exitCode);
   } else if (args.options.mode === 'orchestrator') {
     // Orchestrator mode: execute tasks directly (Issue #446)
     const orchestratorOptions = buildOrchestratorOptions(args);
     await startServer(args.options.verbose, args.options.mode, true, orchestratorOptions);
   } else {
+    // MCP stdio server: startServer owns the process lifecycle (it runs
+    // until the transport closes, then exits itself). No CliExitResult is
+    // returned so the dispatcher does not call process.exit — preserving
+    // pre-#3210 behavior where this path never hit the exit ternary.
     await startServer(args.options.verbose, args.options.mode);
   }
+  return undefined;
 }
 
 /**
  * Handles the review command for PR review (dogfooding).
  * Enhanced with setup wizard and pre-flight checks (Issue #258).
  */
-export async function handleReviewCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleReviewCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // Get PR URL from positionals (review <url>) - optional with --setup
   const prUrl = args.positionals[1] ?? '';
 
@@ -218,18 +227,18 @@ export async function handleReviewCommand(args: ParsedCliArgs): Promise<void> {
     verbose: args.options.verbose,
     skipChecks: args.options.skipChecks,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the routing-audit command for debugging model selection.
  */
-export function handleRoutingAuditCommand(args: ParsedCliArgs): void {
+export function handleRoutingAuditCommand(args: ParsedCliArgs): CliExitResult {
   // Get task from positionals (routing-audit <task>)
   const task = args.positionals[1];
   if (task === undefined) {
     printRoutingAuditUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const exitCode = routingAuditCommand({
@@ -240,31 +249,31 @@ export function handleRoutingAuditCommand(args: ParsedCliArgs): void {
     verbose: args.options.verbose,
     banditStats: args.options.banditStats,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the system-review command for automated system review.
  * (Source: Issue #211, Process Automation Epic #209)
  */
-export function handleSystemReviewCommand(args: ParsedCliArgs): void {
+export function handleSystemReviewCommand(args: ParsedCliArgs): CliExitResult {
   const exitCode = systemReviewCommand({
     createIssue: args.options.createIssue,
     fix: args.options.fix,
     verbose: args.options.verbose,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the vote command for consensus voting.
  * (Source: Issue #212, Process Automation Epic #209)
  */
-export async function handleVoteCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleVoteCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const proposal = args.options.proposal;
   if (proposal === undefined) {
     printVoteUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const threshold = args.options.threshold;
@@ -282,18 +291,18 @@ export async function handleVoteCommand(args: ParsedCliArgs): Promise<void> {
     quick: args.options.quick,
     verbose: args.options.verbose,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the index command for codebase indexing.
  * (Source: Issue #240)
  */
-export async function handleIndexCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleIndexCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const subcommand = args.subcommand;
   if (!isValidIndexSubcommand(subcommand)) {
     printIndexUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const format = isValidIndexFormat(args.options.format) ? args.options.format : undefined;
@@ -306,18 +315,18 @@ export async function handleIndexCommand(args: ParsedCliArgs): Promise<void> {
   });
 
   process.stdout.write(formatIndexResult(result) + '\n');
-  process.exit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }
 
 /**
  * Handles the research command for research registry management.
  * (Source: Issue #237, Epic #225, Epic #261)
  */
-export async function handleResearchCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleResearchCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const subcommand = args.subcommand;
   if (!isValidResearchSubcommand(subcommand)) {
     printResearchUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Get positional args after subcommand (research <subcommand> [args...])
@@ -341,11 +350,11 @@ export async function handleResearchCommand(args: ParsedCliArgs): Promise<void> 
     // reporting "Research index is out of date" therefore exited 0 in
     // CI, silently passing. The contract is now: handler returns
     // exitCode → process exits with that code.
-    process.exit(result.exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+    return cliExitFromStatus(result.exitCode);
   } catch (error) {
     const message = getErrorMessage(error);
     process.stdout.write(`Error: ${message}\n`);
-    process.exit(EXIT_CODES.SERVER_START_FAILED);
+    return cliExit(EXIT_CODES.SERVER_START_FAILED, message);
   }
 }
 
@@ -353,13 +362,13 @@ export async function handleResearchCommand(args: ParsedCliArgs): Promise<void> 
  * Handles the `registry` command: doctor or refresh subcommand (#2179).
  * Dispatches to registryCommand and forwards the text + exit code.
  */
-export async function handleRegistryCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleRegistryCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const { registryCommand, isValidRegistrySubcommand, formatRegistryUsage } =
     await import('./cli/registry-command.js');
   const subcommand = args.subcommand;
   if (!isValidRegistrySubcommand(subcommand)) {
     process.stdout.write(`${formatRegistryUsage()}\n`);
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const source = typeof args.options.source === 'string' ? args.options.source : undefined;
@@ -372,11 +381,11 @@ export async function handleRegistryCommand(args: ParsedCliArgs): Promise<void> 
   try {
     const result = await registryCommand(subcommand, options);
     process.stdout.write(`${result.text}\n`);
-    process.exit(result.exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+    return cliExitFromStatus(result.exitCode);
   } catch (error) {
     const message = getErrorMessage(error);
     process.stdout.write(`Error: ${message}\n`);
-    process.exit(EXIT_CODES.SERVER_START_FAILED);
+    return cliExit(EXIT_CODES.SERVER_START_FAILED, message);
   }
 }
 
@@ -384,17 +393,17 @@ export async function handleRegistryCommand(args: ParsedCliArgs): Promise<void> 
  * Handles the validation command for learning validation dashboard.
  * (Source: Issue #273)
  */
-export function handleValidationCommand(args: ParsedCliArgs): void {
+export function handleValidationCommand(args: ParsedCliArgs): CliExitResult {
   const options = parseValidationArgs(args.positionals, args.options.format, args.options.verbose);
   const exitCode = validationDashboardCommand(options);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the learning-metrics command for aggregated learning dashboard.
  * (Source: Issue #284)
  */
-export function handleLearningMetricsCommand(args: ParsedCliArgs): void {
+export function handleLearningMetricsCommand(args: ParsedCliArgs): CliExitResult {
   const format: 'ascii' | 'json' = args.options.format === 'json' ? 'json' : 'ascii';
   const exitCode = learningMetricsCommand({
     period: args.options.period ?? 24,
@@ -403,33 +412,37 @@ export function handleLearningMetricsCommand(args: ParsedCliArgs): void {
     showTrends: args.options.noTrends !== true,
     ...(args.options.export !== undefined && { exportPath: args.options.export }),
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles the verify command for quick installation verification.
  * (Source: Issue #253)
  */
-export async function handleVerifyCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleVerifyCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const exitCode = await verifyCommand({ verbose: args.options.verbose });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles doctor command (extracted for dispatch table).
  */
-export async function handleDoctorCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleDoctorCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const exitCode = await doctorCommand({ fix: args.options.fix });
   if (args.options.deep) {
     const { runDeepDiagnostics, formatDeepDiagnostics } = await import('./cli/doctor-deep.js');
     const diag = runDeepDiagnostics();
     process.stdout.write(formatDeepDiagnostics(diag) + '\n');
   }
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
-/** Validates init flag combinations; exits if a problem is found. */
-function validateInitFlags(args: ParsedCliArgs): void {
+/**
+ * Validates init flag combinations. Returns a failing {@link CliExitResult}
+ * when a problem is found (caller propagates it to the dispatcher), or
+ * `undefined` when the flags are valid.
+ */
+function validateInitFlags(args: ParsedCliArgs): CliExitResult | undefined {
   const hasPortable = args.options.portable === true;
   const hasOpencode = args.options.opencode !== undefined && args.options.opencode !== '';
   if (!hasPortable && !hasOpencode) {
@@ -442,16 +455,17 @@ function validateInitFlags(args: ParsedCliArgs): void {
         'Bootstraps a workspace-local nexus-agents data directory or merges\n' +
         'the nexus-agents MCP block into an existing opencode.json.\n'
     );
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   if (hasPortable && hasOpencode) {
     process.stderr.write('Error: --portable and --opencode are mutually exclusive entry modes.\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   if (args.options.install === true && args.options.uninstall === true) {
     process.stderr.write('Error: --install and --uninstall are mutually exclusive.\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
+  return undefined;
 }
 
 /**
@@ -461,12 +475,19 @@ function validateInitFlags(args: ParsedCliArgs): void {
  * Async because `--install` may spawn `npm install`. When neither
  * `--install` nor `--uninstall` is set, no subprocess is spawned.
  */
-export async function handleInitCommand(args: ParsedCliArgs): Promise<void> {
-  validateInitFlags(args);
-  if (args.options.opencode !== undefined && args.options.opencode !== '') {
-    await runInitOpencodeFlow(args);
-    return;
+export async function handleInitCommand(args: ParsedCliArgs): Promise<CliExitResult> {
+  const flagError = validateInitFlags(args);
+  if (flagError !== undefined) {
+    return flagError;
   }
+  if (args.options.opencode !== undefined && args.options.opencode !== '') {
+    return runInitOpencodeFlow(args);
+  }
+  return runInitPortableFlow(args);
+}
+
+/** Runs the `init --portable` path and renders its outcome (#2305/#2308/#2311). */
+async function runInitPortableFlow(args: ParsedCliArgs): Promise<CliExitResult> {
   const targetPath = args.positionals[1]; // [0] is "init"
   const result = await initPortable({
     ...(targetPath !== undefined && targetPath !== '' ? { path: targetPath } : {}),
@@ -478,15 +499,15 @@ export async function handleInitCommand(args: ParsedCliArgs): Promise<void> {
     uninstall: args.options.uninstall ?? false,
   });
   process.stdout.write(formatInitPortableMessage(result, args.options.dryRun));
-  process.exit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }
 
-async function runInitOpencodeFlow(args: ParsedCliArgs): Promise<void> {
+async function runInitOpencodeFlow(args: ParsedCliArgs): Promise<CliExitResult> {
   const { runInitOpencode } = await import('./cli/init-opencode.js');
   const opencodePath = args.options.opencode;
   if (opencodePath === undefined || opencodePath === '') {
     process.stderr.write('Error: --opencode requires a path argument.\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   // The CLI binary path the MCP block will spawn — defaults to the running
   // binary so the resulting opencode.json points at this install. Operators
@@ -505,10 +526,9 @@ async function runInitOpencodeFlow(args: ParsedCliArgs): Promise<void> {
   }
 
   if (args.options.validate === true) {
-    const exitCode = await renderOpencodeValidate(opencodePath);
-    process.exit(exitCode);
+    return cliExit(await renderOpencodeValidate(opencodePath));
   }
-  process.exit(EXIT_CODES.SUCCESS);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 /**
@@ -536,7 +556,7 @@ async function renderOpencodeValidate(opencodePath: string): Promise<number> {
  * (Source: Issue #363 - Auto-configure Claude CLI integration)
  * (Source: Issue #416 - Setup command hook configuration)
  */
-export function handleSetupCommand(args: ParsedCliArgs): void {
+export function handleSetupCommand(args: ParsedCliArgs): CliExitResult {
   const exitCode = setupCommand({
     nonInteractive: args.options.nonInteractive,
     force: args.options.force,
@@ -551,7 +571,7 @@ export function handleSetupCommand(args: ParsedCliArgs): void {
     verbose: args.options.verbose,
     scope: args.options.scope === 'project' ? 'project' : 'user',
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
@@ -564,10 +584,9 @@ export function handleSetupCommand(args: ParsedCliArgs): void {
  * MCP hookup; custom-api is orthogonal — the user has a gateway they
  * want to plug in, not a harness they want to wire up.
  */
-export async function handleSetupCommandAsync(args: ParsedCliArgs): Promise<void> {
+export async function handleSetupCommandAsync(args: ParsedCliArgs): Promise<CliExitResult> {
   if (args.options.customApi !== undefined && args.options.customApi !== '') {
-    const exitCode = await runCustomApiSetup(args);
-    process.exit(exitCode);
+    return cliExit(await runCustomApiSetup(args));
   }
   const exitCode = await setupCommandAsync({
     interactive: args.options.interactive,
@@ -584,7 +603,7 @@ export async function handleSetupCommandAsync(args: ParsedCliArgs): Promise<void
     verbose: args.options.verbose,
     scope: args.options.scope === 'project' ? 'project' : 'user',
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /** Wrapper for `setup --custom-api` (#2124). */
@@ -616,16 +635,15 @@ async function runCustomApiSetup(args: ParsedCliArgs): Promise<number> {
  * Handles hello command for quick introduction.
  * (Source: Issue #423 - Hello World Command)
  */
-export function handleHelloCommand(_args: ParsedCliArgs): void {
-  const exitCode = helloCommand();
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+export function handleHelloCommand(_args: ParsedCliArgs): CliExitResult {
+  return cliExitFromStatus(helloCommand());
 }
 
 /**
  * Handles demo command for API-free exploration.
  * (Source: Issue #424 - Demo mode for API-free exploration)
  */
-export async function handleDemoCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleDemoCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // Get subcommand from positionals (demo <subcommand> [args...])
   const subcommand = args.subcommand;
   const additionalArgs = args.positionals.slice(2);
@@ -633,7 +651,7 @@ export async function handleDemoCommand(args: ParsedCliArgs): Promise<void> {
     mock: args.options.mock,
   };
   const exitCode = await demoCommand(subcommand, additionalArgs, options);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
@@ -641,27 +659,27 @@ export async function handleDemoCommand(args: ParsedCliArgs): Promise<void> {
  * four headline tools. Reuses the existing `--non-interactive` option for
  * the scripted mode. (Source: Issue #2851)
  */
-export async function handleTourCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleTourCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const io = args.options.nonInteractive ? scriptedIO() : interactiveIO();
   const exitCode = await runTour({ nonInteractive: args.options.nonInteractive }, io);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles hooks command for Claude CLI hook integration.
  * (Source: Issue #411 - Claude CLI Hook Integration Commands)
  */
-export async function handleHooksCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleHooksCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // If --help flag or no subcommand, print help
   if (args.options.help || args.positionals.length < 2) {
     printHookHelp();
-    process.exit(EXIT_CODES.SUCCESS);
+    return cliExit(EXIT_CODES.SUCCESS);
   }
 
   // Pass remaining args to hook command (hooks <subcommand> [options...])
   const hookArgs = args.positionals.slice(1);
   const exitCode = await hookCommand(hookArgs);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 // ============================================================================
@@ -672,7 +690,7 @@ export async function handleHooksCommand(args: ParsedCliArgs): Promise<void> {
  * Handles sprint command for automated sprint planning.
  * (Source: Issue #230, Epic #225)
  */
-export async function handleSprintCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleSprintCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const subcommand = args.subcommand;
   if (subcommand !== 'plan' && subcommand !== 'list') {
     process.stdout.write('Usage: nexus-agents sprint <plan|list> [options]\n');
@@ -684,7 +702,7 @@ export async function handleSprintCommand(args: ParsedCliArgs): Promise<void> {
     process.stdout.write('  --create-issue  Create GitHub issue if approved\n');
     process.stdout.write('  --dry-run       Preview without side effects\n');
     process.stdout.write('  --format        Output format (text|json)\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Build options based on flags
@@ -706,14 +724,16 @@ export async function handleSprintCommand(args: ParsedCliArgs): Promise<void> {
     sprintOpts.dryRun = true;
   }
   const exitCode = await sprintCommand(sprintOpts);
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles session command for session management.
  * (Source: Issue #190 - CLI session persistence with SQLite)
  */
-export async function handleSessionCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleSessionCommand(
+  args: ParsedCliArgs
+): Promise<CliExitResult | undefined> {
   const subcommand = args.subcommand;
   if (
     subcommand !== 'list' &&
@@ -733,20 +753,25 @@ export async function handleSessionCommand(args: ParsedCliArgs): Promise<void> {
     process.stdout.write('  --limit <n>     Limit results (default: 20)\n');
     process.stdout.write('  --format        Output format (table|json)\n');
     process.stdout.write('  --output <path> Output file path\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Pass remaining args after subcommand to sessionCommand.
   // Errors thrown by sessionCommand propagate to the top-level CLI error handler.
+  // The valid-subcommand path intentionally returns `undefined` (no forced
+  // process.exit) — pre-#3210 this path never called process.exit, letting
+  // the event loop drain naturally (e.g. pending SQLite writes) before the
+  // process ends with code 0. Forcing an exit here could truncate that I/O.
   const remainingArgs = args.positionals.slice(2);
   await sessionCommand(subcommand, remainingArgs);
+  return undefined;
 }
 
 /**
  * Handles evaluate command for self-evaluation.
  * (Source: Issue #140, Self-Evaluation MVP)
  */
-export async function handleEvaluateCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleEvaluateCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // Build args array for evaluateCommand
   const evalArgs: string[] = [];
 
@@ -760,8 +785,11 @@ export async function handleEvaluateCommand(args: ParsedCliArgs): Promise<void> 
     evalArgs.push('--target', target);
   }
 
+  // NOTE: evaluate uses a 3-way exit mapping (0→SUCCESS, 1→SERVER_START_FAILED,
+  // other→SHUTDOWN_ERROR), distinct from the binary `cliExitFromStatus` map —
+  // preserved verbatim (#3210 is behavior-preserving).
   const exitCode = await evaluateCommand(evalArgs);
-  process.exit(
+  return cliExit(
     exitCode === 0
       ? EXIT_CODES.SUCCESS
       : exitCode === 1
@@ -774,7 +802,7 @@ export async function handleEvaluateCommand(args: ParsedCliArgs): Promise<void> 
  * Handles issue command for issue template management.
  * (Source: Issue #229, Epic #225)
  */
-export function handleIssueCommand(args: ParsedCliArgs): void {
+export function handleIssueCommand(args: ParsedCliArgs): CliExitResult {
   const subcommand = args.subcommand;
   if (subcommand !== 'validate' && subcommand !== 'create') {
     process.stdout.write('Usage: nexus-agents issue <subcommand> [options]\n');
@@ -782,14 +810,14 @@ export function handleIssueCommand(args: ParsedCliArgs): void {
     process.stdout.write('  validate <number>  Validate issue against template\n');
     process.stdout.write('  create <type>      Show issue template for creating\n');
     process.stdout.write('\nTypes: feat, bug, task, refactor, docs\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Get issue number or template type from positionals
   const arg = args.positionals[2];
   if (arg === undefined) {
     process.stdout.write('Error: Missing argument\n');
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   // Build options based on subcommand
@@ -799,27 +827,28 @@ export function handleIssueCommand(args: ParsedCliArgs): void {
     const issueNumber = parseInt(arg, 10);
     if (isNaN(issueNumber)) {
       process.stdout.write('Error: Invalid issue number\n');
-      process.exit(EXIT_CODES.INVALID_ARGS);
+      return cliExit(EXIT_CODES.INVALID_ARGS);
     }
-    const exitCode = issueCommand({
-      subcommand: 'validate',
-      issueNumber,
-      format,
-    });
-    process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
-  } else {
-    // create subcommand
-    const validTypes = ['feat', 'bug', 'task', 'refactor', 'docs'];
-    const type = validTypes.includes(arg)
-      ? (arg as 'feat' | 'bug' | 'task' | 'refactor' | 'docs')
-      : 'feat';
-    const exitCode = issueCommand({
+    return cliExitFromStatus(
+      issueCommand({
+        subcommand: 'validate',
+        issueNumber,
+        format,
+      })
+    );
+  }
+  // create subcommand
+  const validTypes = ['feat', 'bug', 'task', 'refactor', 'docs'];
+  const type = validTypes.includes(arg)
+    ? (arg as 'feat' | 'bug' | 'task' | 'refactor' | 'docs')
+    : 'feat';
+  return cliExitFromStatus(
+    issueCommand({
       subcommand: 'create',
       type,
       format,
-    });
-    process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
-  }
+    })
+  );
 }
 
 // ============================================================================
@@ -830,11 +859,11 @@ export function handleIssueCommand(args: ParsedCliArgs): void {
  * Handles fitness-audit command for CLI orchestration fitness scoring.
  * (Source: System Mandate LOOP I)
  */
-export function handleFitnessAuditCommand(args: ParsedCliArgs): void {
+export function handleFitnessAuditCommand(args: ParsedCliArgs): CliExitResult {
   const exitCode = fitnessAuditCommand({
     json: args.options.format === 'json',
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }
 
 // ============================================================================
@@ -845,44 +874,44 @@ export function handleFitnessAuditCommand(args: ParsedCliArgs): void {
  * Handles warm-up command for LinUCB bandit cold-start seeding.
  * (Source: Issue #1023 — Bootstrap LinUCB with synthetic outcomes)
  */
-export function handleWarmUpCommand(_args: ParsedCliArgs): void {
+export function handleWarmUpCommand(_args: ParsedCliArgs): CliExitResult {
   const result = runWarmUp();
   const msg = result.skipped
     ? `Warm-up skipped: ${result.reason ?? 'already seeded'}`
     : `Seeded with ${String(result.seeded)} synthetic observations`;
   process.stdout.write(msg + '\n');
-  process.exit(EXIT_CODES.SUCCESS);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 /**
  * Handles e2e-eval command for learning loop validation.
  * (Source: Issue #1030 — E2E scenario runner)
  */
-export function handleE2EEvalCommand(args: ParsedCliArgs): void {
+export function handleE2EEvalCommand(args: ParsedCliArgs): CliExitResult {
   const count = parsePositiveInt(args.positionals[1], 50);
   const result = runE2EEval({ taskCount: count });
   process.stdout.write(formatE2EEvalResult(result) + '\n');
-  process.exit(result.passed ? EXIT_CODES.SUCCESS : 1);
+  return cliExit(result.passed ? EXIT_CODES.SUCCESS : 1);
 }
 
 /**
  * Handles routing-ab command for A/B comparison of routing strategies.
  * (Source: Issue #1033 — Routing strategy A/B framework)
  */
-export function handleRoutingABCommand(args: ParsedCliArgs): void {
+export function handleRoutingABCommand(args: ParsedCliArgs): CliExitResult {
   const count = parsePositiveInt(args.positionals[1], 30);
   const result = runRoutingAB({ taskCount: count });
   process.stdout.write(formatABReport(result) + '\n');
-  process.exit(EXIT_CODES.SUCCESS);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 /**
  * Handles memory-eval command for comparative memory evaluation.
  * (Source: Issue #1034 — Comparative memory evaluation benchmark)
  */
-export function handleMemoryEvalCommand(args: ParsedCliArgs): void {
+export function handleMemoryEvalCommand(args: ParsedCliArgs): CliExitResult {
   const count = parsePositiveInt(args.positionals[1], 50);
   const result = runMemoryEval(count);
   process.stdout.write(formatMemoryEvalReport(result) + '\n');
-  process.exit(EXIT_CODES.SUCCESS);
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli-commands.test.ts
+++ b/packages/nexus-agents/src/cli-commands.test.ts
@@ -193,6 +193,31 @@ describe('cli-commands', () => {
       await expect(dispatchCommand(createArgs('nonexistent'))).resolves.toBeUndefined();
     });
 
+    // #3210: the dispatcher is the single process.exit boundary. A handler
+    // that RETURNS a CliExitResult must map to process.exit(result.exitCode);
+    // a handler that returns undefined/void must NOT force an exit.
+    it('maps a returned CliExitResult to process.exit (sync handler)', async () => {
+      const { handleExpertCommand } = await import('./cli-commands-handlers.js');
+      vi.mocked(handleExpertCommand).mockReturnValueOnce({ success: false, exitCode: 4 });
+      // Vitest turns process.exit into a throw; assert the code via the message.
+      await expect(dispatchCommand(createArgs('expert'))).rejects.toThrow(/process\.exit.*4|4/);
+    });
+
+    it('maps a returned CliExitResult to process.exit (async handler)', async () => {
+      const { handleVoteCommand } = await import('./cli-commands-handlers.js');
+      vi.mocked(handleVoteCommand).mockResolvedValueOnce({ success: true, exitCode: 0 });
+      await expect(dispatchCommand(createArgs('vote'))).rejects.toThrow(/process\.exit/);
+    });
+
+    it('does NOT call process.exit when a handler returns undefined', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+      const { handleServerCommand } = await import('./cli-commands-handlers.js');
+      vi.mocked(handleServerCommand).mockResolvedValueOnce(undefined);
+      await dispatchCommand(createArgs('server'));
+      expect(exitSpy).not.toHaveBeenCalled();
+      exitSpy.mockRestore();
+    });
+
     it('should pass args to handler', async () => {
       const { handleDoctorCommand } = await import('./cli-commands-handlers.js');
       const args = createArgs('doctor', { options: { verbose: true } });

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -12,7 +12,7 @@
  */
 
 import { VERSION } from './version.js';
-import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
+import { EXIT_CODES, type CliExitResult, type ParsedCliArgs } from './cli-types.js';
 import { renderHelp } from './cli-help-text.js';
 
 // Re-export handlers for backward compatibility
@@ -183,8 +183,45 @@ export function printVersion(): void {
   process.stdout.write(`nexus-agents v${VERSION}\n`);
 }
 
+/**
+ * A CLI command handler. Migrated handlers (#3210) RETURN a
+ * {@link CliExitResult} (or `undefined` to signal "do not force an exit",
+ * e.g. the MCP stdio server) so the single `process.exit` lives here at the
+ * dispatcher boundary. Not-yet-migrated handlers (auth, login, usage,
+ * release, scaffold, …) still call `process.exit` internally and return
+ * `void`; `exitWith` no-ops on their `void`/`undefined` return, so both
+ * styles coexist during the incremental migration.
+ */
+// `void` is required in these unions to bridge migrated handlers (which
+// return CliExitResult) and not-yet-migrated handlers (which return void
+// after exiting internally). `undefined` alone is not assignable from a
+// `void`-returning function, so the union must include `void` until the
+// migration is complete. Safe here: exitWith() treats both void and
+// undefined as "no forced exit".
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+type SyncHandlerResult = CliExitResult | void;
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+type AsyncHandlerResult = Promise<CliExitResult | undefined | void>;
+
+/**
+ * The single `process.exit` boundary for migrated handlers (#3210). When a
+ * handler returns a {@link CliExitResult}, terminate with its `exitCode`.
+ * A `void`/`undefined` return means the handler either already exited
+ * internally (legacy, not-yet-migrated) or deliberately owns the process
+ * lifecycle (MCP stdio server) — so do nothing.
+ */
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- bridges migrated/legacy handler returns; see SyncHandlerResult
+function exitWith(result: CliExitResult | undefined | void): void {
+  if (result !== undefined) {
+    process.exit(result.exitCode);
+  }
+}
+
 /** Sync command dispatch table for reduced complexity. */
-const SYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => void) | undefined> = {
+const SYNC_COMMAND_HANDLERS: Record<
+  string,
+  ((args: ParsedCliArgs) => SyncHandlerResult) | undefined
+> = {
   hello: handleHelloCommand,
   expert: handleExpertCommand,
   'routing-audit': handleRoutingAuditCommand,
@@ -232,65 +269,68 @@ function handleSyncCommand(args: ParsedCliArgs): boolean {
   // Dispatch to sync handler table
   const handler = SYNC_COMMAND_HANDLERS[args.command];
   if (handler !== undefined) {
-    handler(args);
+    // #3210: handlers RETURN their exit code; the single process.exit lives here.
+    exitWith(handler(args));
     return true;
   }
   return false;
 }
 
 /** Async command dispatch table for reduced complexity. */
-const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<void>) | undefined> =
-  {
-    server: handleServerCommand,
-    doctor: handleDoctorCommand,
-    verify: handleVerifyCommand,
-    config: handleConfigCommand,
-    workflow: handleWorkflowCommand,
-    review: handleReviewCommand,
-    orchestrate: handleOrchestrateCommand,
-    vote: handleVoteCommand,
-    index: handleIndexCommand,
-    research: handleResearchCommand,
-    registry: handleRegistryCommand,
-    'swe-bench': handleSweBenchCommand,
-    atbench: handleAtbenchCommand,
-    hooks: handleHooksCommand,
-    setup: handleSetupCommandAsync, // Uses async for interactive wizard support (Issue #425)
-    // Issue #2447: nexus-agents login — async because it spawns codex/opencode for status probes.
-    // Issue #2449 made `auth status` the canonical name; this remains as a soft alias.
-    login: handleLoginCommand,
-    // Issue #739/#2449: auth command (now async — `auth status` routes to login probe)
-    auth: handleAuthCommand,
-    // Issue #2469: usage command (cost / usage / quality dashboard)
-    usage: handleUsageCommand,
-    // Issue #2444: improvement-review command (observability-driven improvement loop)
-    'improvement-review': handleImprovementReviewCommand,
-    // #3540 phase 3 / #3671: run one auto-remediation cycle (mode from NEXUS_AUTO_REMEDIATE).
-    'auto-remediate': handleAutoRemediateCommand,
-    // #3765: human soundness-review surface — produces the enforce-gate readiness evidence.
-    'remediation-review': handleRemediationReviewCommand,
-    // Issue #2879 / epic #2872: migrate command (relocate homedir state per-repo)
-    migrate: handleMigrateCommand,
-    // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)
-    init: handleInitCommand,
-    demo: handleDemoCommand, // Made async for live CLI execution
-    // Issue #2851: nexus-agents tour — interactive zero-API walkthrough
-    tour: handleTourCommand,
-    // Issue #526: Newly wired async commands
-    sprint: handleSprintCommand,
-    session: handleSessionCommand,
-    evaluate: handleEvaluateCommand,
-    // Issue #637: Release Automation Suite
-    'release-notes': handleReleaseNotesCommand,
-    'release-validate': handleReleaseValidateCommand,
-    'release-announce': handleReleaseAnnounceCommand,
-    // Issue #748: Memory Benchmark Command
-    'memory-benchmark': handleMemoryBenchmarkCommand,
-    // Epic #952: Scenario Command
-    scenario: handleScenarioCommand,
-    // Issue #1598: Validate Command
-    validate: handleValidateCommand,
-  };
+const ASYNC_COMMAND_HANDLERS: Record<
+  string,
+  ((args: ParsedCliArgs) => AsyncHandlerResult) | undefined
+> = {
+  server: handleServerCommand,
+  doctor: handleDoctorCommand,
+  verify: handleVerifyCommand,
+  config: handleConfigCommand,
+  workflow: handleWorkflowCommand,
+  review: handleReviewCommand,
+  orchestrate: handleOrchestrateCommand,
+  vote: handleVoteCommand,
+  index: handleIndexCommand,
+  research: handleResearchCommand,
+  registry: handleRegistryCommand,
+  'swe-bench': handleSweBenchCommand,
+  atbench: handleAtbenchCommand,
+  hooks: handleHooksCommand,
+  setup: handleSetupCommandAsync, // Uses async for interactive wizard support (Issue #425)
+  // Issue #2447: nexus-agents login — async because it spawns codex/opencode for status probes.
+  // Issue #2449 made `auth status` the canonical name; this remains as a soft alias.
+  login: handleLoginCommand,
+  // Issue #739/#2449: auth command (now async — `auth status` routes to login probe)
+  auth: handleAuthCommand,
+  // Issue #2469: usage command (cost / usage / quality dashboard)
+  usage: handleUsageCommand,
+  // Issue #2444: improvement-review command (observability-driven improvement loop)
+  'improvement-review': handleImprovementReviewCommand,
+  // #3540 phase 3 / #3671: run one auto-remediation cycle (mode from NEXUS_AUTO_REMEDIATE).
+  'auto-remediate': handleAutoRemediateCommand,
+  // #3765: human soundness-review surface — produces the enforce-gate readiness evidence.
+  'remediation-review': handleRemediationReviewCommand,
+  // Issue #2879 / epic #2872: migrate command (relocate homedir state per-repo)
+  migrate: handleMigrateCommand,
+  // #2305 / #2308 / #2311: Init Portable Command (async because --install spawns npm)
+  init: handleInitCommand,
+  demo: handleDemoCommand, // Made async for live CLI execution
+  // Issue #2851: nexus-agents tour — interactive zero-API walkthrough
+  tour: handleTourCommand,
+  // Issue #526: Newly wired async commands
+  sprint: handleSprintCommand,
+  session: handleSessionCommand,
+  evaluate: handleEvaluateCommand,
+  // Issue #637: Release Automation Suite
+  'release-notes': handleReleaseNotesCommand,
+  'release-validate': handleReleaseValidateCommand,
+  'release-announce': handleReleaseAnnounceCommand,
+  // Issue #748: Memory Benchmark Command
+  'memory-benchmark': handleMemoryBenchmarkCommand,
+  // Epic #952: Scenario Command
+  scenario: handleScenarioCommand,
+  // Issue #1598: Validate Command
+  validate: handleValidateCommand,
+};
 
 /**
  * Handles async commands that require await.
@@ -298,7 +338,8 @@ const ASYNC_COMMAND_HANDLERS: Record<string, ((args: ParsedCliArgs) => Promise<v
 async function handleAsyncCommand(args: ParsedCliArgs): Promise<void> {
   const handler = ASYNC_COMMAND_HANDLERS[args.command];
   if (handler !== undefined) {
-    await handler(args);
+    // #3210: handlers RETURN their exit code; the single process.exit lives here.
+    exitWith(await handler(args));
   }
 }
 

--- a/packages/nexus-agents/src/cli-exit-result.test.ts
+++ b/packages/nexus-agents/src/cli-exit-result.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the CLI exit-result helpers (#3210).
+ *
+ * `cliExit` / `cliExitFromStatus` centralize the exit-code → CliExitResult
+ * mapping that was previously inlined as `exitCode === 0 ? SUCCESS : ...`
+ * ternaries across every CLI handler. These tests pin the mapping so the
+ * behavior-preserving guarantee of the migration holds.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EXIT_CODES, cliExit, cliExitFromStatus } from './cli-types.js';
+
+describe('cliExit (#3210)', () => {
+  it('derives success=true for exit code 0', () => {
+    expect(cliExit(EXIT_CODES.SUCCESS)).toEqual({ success: true, exitCode: 0 });
+  });
+
+  it('derives success=false for any non-zero exit code', () => {
+    expect(cliExit(EXIT_CODES.INVALID_ARGS)).toEqual({ success: false, exitCode: 3 });
+    expect(cliExit(EXIT_CODES.NOT_IMPLEMENTED)).toEqual({ success: false, exitCode: 4 });
+  });
+
+  it('preserves a provided message', () => {
+    expect(cliExit(EXIT_CODES.SERVER_START_FAILED, 'boom')).toEqual({
+      success: false,
+      exitCode: 1,
+      message: 'boom',
+    });
+  });
+
+  it('omits the message field entirely when none is given', () => {
+    expect(cliExit(EXIT_CODES.SUCCESS)).not.toHaveProperty('message');
+  });
+});
+
+describe('cliExitFromStatus (#3210)', () => {
+  it('maps status 0 to SUCCESS', () => {
+    expect(cliExitFromStatus(0)).toEqual({ success: true, exitCode: EXIT_CODES.SUCCESS });
+  });
+
+  it('maps any non-zero status to SERVER_START_FAILED', () => {
+    // This is the exact binary mapping the bulk of handlers used pre-#3210:
+    // `exitCode === 0 ? SUCCESS : SERVER_START_FAILED`.
+    expect(cliExitFromStatus(1)).toEqual({
+      success: false,
+      exitCode: EXIT_CODES.SERVER_START_FAILED,
+    });
+    expect(cliExitFromStatus(2)).toEqual({
+      success: false,
+      exitCode: EXIT_CODES.SERVER_START_FAILED,
+    });
+    expect(cliExitFromStatus(99)).toEqual({
+      success: false,
+      exitCode: EXIT_CODES.SERVER_START_FAILED,
+    });
+  });
+
+  it('preserves a provided message', () => {
+    expect(cliExitFromStatus(0, 'done')).toEqual({
+      success: true,
+      exitCode: 0,
+      message: 'done',
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -10,6 +10,7 @@
 import type { ServerMode } from './cli/index.js';
 import type { CliNameLiteral } from './config/model-capabilities-types.js';
 import type { ErrorPolicy, VoteThreshold } from './mcp/tools/consensus-vote-types.js';
+import type { CommandResult } from './core/command-result.js';
 
 // Re-export help text from extracted module for backward compatibility
 export { HELP_TEXT } from './cli-help-text.js';
@@ -25,6 +26,46 @@ export const EXIT_CODES = {
   /** Subcommand is stubbed / advertised but not implemented (#2727). */
   NOT_IMPLEMENTED: 4,
 } as const;
+
+/**
+ * A {@link CommandResult} that also carries the process exit code the
+ * dispatcher should terminate with (#3210).
+ *
+ * Handlers RETURN this instead of calling `process.exit` inline, and the
+ * single `process.exit` lives at the dispatcher boundary (see `exitWith`).
+ * This makes exit behavior unit-testable (assert the returned `exitCode`)
+ * without mocking `process.exit`, and centralizes the one process-killing
+ * call so its policy is consistent across commands.
+ */
+export interface CliExitResult extends CommandResult {
+  /** The exit code the CLI process should terminate with. */
+  readonly exitCode: number;
+}
+
+/**
+ * Builds a {@link CliExitResult} from a raw exit code, deriving `success`
+ * from the conventional `0 == success` mapping. Optional human-readable
+ * `message` is preserved for callers/tests.
+ */
+export function cliExit(exitCode: number, message?: string): CliExitResult {
+  return message === undefined
+    ? { success: exitCode === EXIT_CODES.SUCCESS, exitCode }
+    : { success: exitCode === EXIT_CODES.SUCCESS, exitCode, message };
+}
+
+/**
+ * Maps a handler's `0|non-0` status to the canonical success/failure exit
+ * codes (`SUCCESS` / `SERVER_START_FAILED`) used by the bulk of CLI
+ * commands, then wraps it in a {@link CliExitResult}. Centralizes the
+ * `exitCode === 0 ? SUCCESS : SERVER_START_FAILED` ternary that was
+ * duplicated across every handler.
+ */
+export function cliExitFromStatus(status: number, message?: string): CliExitResult {
+  return cliExit(
+    status === EXIT_CODES.SUCCESS ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED,
+    message
+  );
+}
 
 /**
  * CLI command types that can be executed.


### PR DESCRIPTION
## Summary

Closes #3210. CLI command handlers now **RETURN a `CliExitResult`** (a `CommandResult` carrying an `exitCode`) instead of calling `process.exit(...)` inline. The single `process.exit` boundary moves to the dispatcher (`dispatchCommand` → `exitWith`) in `cli-commands.ts`.

This is a **strictly behavior-preserving structural refactor** — every path's exit code is identical to before. No CLI command added, no MCP tool added, `COMMAND_CATALOG` untouched.

### New contract (`cli-types.ts`)
- `interface CliExitResult extends CommandResult { exitCode: number }`
- `cliExit(exitCode, message?)` — derives `success` from `0 == success`
- `cliExitFromStatus(status, message?)` — centralizes the `status === 0 ? SUCCESS : SERVER_START_FAILED` ternary duplicated across handlers

### Dispatcher boundary
`exitWith(result)` calls `process.exit(result.exitCode)` when a handler returns a `CliExitResult`, and **no-ops on `void`/`undefined`** — so migrated handlers and not-yet-migrated handlers (which still exit internally) coexist during the incremental migration.

## Before → After exit-code map (preservation proof)

All migrated handlers in `cli-commands-handlers.ts` / `cli-commands-handlers-complex.ts`. "Before" = pre-refactor `process.exit(...)`; "After" = returned `CliExitResult.exitCode`. Codes: SUCCESS=0, SERVER_START_FAILED=1, SHUTDOWN_ERROR=2, INVALID_ARGS=3, NOT_IMPLEMENTED=4.

| Handler | Path | Before | After |
| --- | --- | --- | --- |
| `handleExpertCommand` | list ok / fail | 0 / 1 | 0 / 1 |
| | unimplemented sub | 4 | 4 |
| `handleWorkflowCommand` | list | 0 | 0 |
| | run no-name / run ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| | unimplemented sub | 4 | 4 |
| `handleReviewCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleRoutingAuditCommand` | no-task / ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| `handleSystemReviewCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleVoteCommand` | no-proposal / ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| `handleIndexCommand` | bad-sub / ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| `handleResearchCommand` | bad-sub / ok\|fail / throw | 3 / 0\|1 / 1 | 3 / 0\|1 / 1 |
| `handleRegistryCommand` | bad-sub / ok\|fail / throw | 3 / 0\|1 / 1 | 3 / 0\|1 / 1 |
| `handleValidationCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleLearningMetricsCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleVerifyCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleDoctorCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleInitCommand` | flag errors | 3 | 3 |
| | portable ok / fail | 0 / 1 | 0 / 1 |
| | opencode flow / `--validate` | 0 / raw (0\|1) | 0 / raw (0\|1) |
| `handleSetupCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleSetupCommandAsync` | custom-api / normal ok\|fail | raw / 0\|1 | raw / 0\|1 |
| `handleHelloCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleDemoCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleTourCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleHooksCommand` | help / ok\|fail | 0 / 0\|1 | 0 / 0\|1 |
| `handleSprintCommand` | bad-sub / ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| `handleEvaluateCommand` | **3-way** 0\|1\|other | 0\|1\|2 | 0\|1\|2 (preserved verbatim) |
| `handleIssueCommand` | bad-sub / missing-arg / bad-num / ok\|fail | 3 / 3 / 3 / 0\|1 | same |
| `handleFitnessAuditCommand` | ok / fail | 0 / 1 | 0 / 1 |
| `handleWarmUpCommand` | always | 0 | 0 |
| `handleE2EEvalCommand` | passed / failed | 0 / 1 | 0 / 1 |
| `handleRoutingABCommand` | always | 0 | 0 |
| `handleMemoryEvalCommand` | always | 0 | 0 |
| `handleConfigCommand` (complex) | init / bad-sub / ok\|fail | 0\|1 / 3 / 0\|1 | same |
| `handleOrchestrateCommand` (complex) | no-task / ok\|fail | 3 / 0\|1 | 3 / 0\|1 |
| `handleSweBenchCommand` (complex) | shim | 3 | 3 |
| `handleAtbenchCommand` (complex) | shim | 3 | 3 |

## Handlers intentionally NOT forced to exit (return `undefined`)

- **`handleServerCommand`** default + orchestrator server modes — `startServer` owns the process lifecycle (runs until the MCP stdio transport closes). Pre-#3210 this path never hit an exit ternary; returning `undefined` keeps it that way.
- **`handleSessionCommand`** valid-subcommand path — pre-#3210 never called `process.exit`, letting the event loop drain naturally (e.g. pending SQLite writes) before exiting 0. Forcing an exit could truncate that I/O, so it returns `undefined`. The invalid-args path returns `cliExit(3)`.

## Handlers left as-is (not migrated — out of scope, still exit internally)

Handlers in **other files** (`cli-auth-handler.ts`, `cli/login-command.ts`, `cli/usage-command.ts`, `cli/improvement-review-command.ts`, `cli/auto-remediate-command.ts`, `cli/remediation-review-command.ts`, `cli/migrate-command.ts`, `cli/memory-benchmark-command.ts`, `cli/scenario-command.ts`, `cli/validate-command.ts`, `cli-release-handlers.ts`, `cli-scaffold-handler.ts`, `cli/visualize-command.ts`, `cli/capabilities-command.ts`, `cli/status-command.ts`, `cli/health-command.ts`, `cli/mode-command.ts`) still call `process.exit` internally and return `void`. `exitWith` no-ops on their return, so they are fully backward-compatible. Migrating them is a clean follow-up (they each live in their own file).

## Tests added

- `cli-exit-result.test.ts` — `cliExit` / `cliExitFromStatus` mapping (success/failure/message).
- `cli-commands-handlers.test.ts` — per-handler return-contract tests (`handleExpertCommand` success/fail/unimplemented; `handleHelloCommand` success/fail); updated config-routing tests to assert the returned `CliExitResult` instead of `process.exit`.
- `cli-commands-handlers-complex.test.ts` — updated config/orchestrate/swe-bench assertions to the returned contract.
- `cli-commands.test.ts` — dispatcher tests proving a returned `CliExitResult` maps to `process.exit(exitCode)` (sync + async) and that an `undefined` return does NOT force an exit.

## Gates
- `tsc --noEmit` clean; eslint clean on all changed files; `pnpm build` succeeds.
- Full CLI vitest suite green: **259 files / 6305 tests pass** (8 skipped e2e).
- Zero `any`; no function >50 lines; no complexity violations. `COMMAND_CATALOG` / help-text / count assertions untouched.
- Changeset: `.changeset/command-result-migration-3210.md` (`'nexus-agents': patch`, refactor).

## Follow-up (not in this PR)
Migrate the remaining `void`-returning handlers (listed above) to return `CliExitResult` so the `void` in the dispatcher union can be dropped. Worth a tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)