### PR TITLE
refactor(cli): finish CommandResult migration + explicit lifecycle sentinel (#3942, completes #3210)

### DIFF
--- a/.changeset/finish-command-result-3942.md
+++ b/.changeset/finish-command-result-3942.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+refactor(cli): finish CommandResult migration + explicit lifecycle sentinel (#3942, completes #3210)
+
+Completes the #3210 migration started in #3941. Every CLI command handler
+dispatched from `cli-commands.ts` now RETURNS its exit code instead of calling
+`process.exit` inline; the single `process.exit` lives at the dispatcher
+boundary in `exitWith()`. Migrated behavior-preservingly (exit codes
+byte-identical): auth, login, usage, release-notes/validate/announce, scaffold,
+visualize, capabilities, mode, scenario, validate, migrate, memory-benchmark,
+status, health, improvement-review, auto-remediate, remediation-review.
+
+Adds an explicit `LIFECYCLE_DELEGATED` sentinel (+ `LifecycleDelegated` type and
+`isLifecycleDelegated` guard) to `cli-types.ts`. Lifecycle-owning handlers (the
+MCP stdio server, the session valid-subcommand path) now RETURN the sentinel
+instead of a bare `undefined`/`void`. Every handler is typed
+`CliExitResult | LifecycleDelegated` (`CliHandlerResult`) with no `undefined`/
+`void` member, so a dropped return is a compile error (TS2366) rather than a
+silently-swallowed exit code. `exitWith` handles the union exhaustively. The two
+`eslint-disable @typescript-eslint/no-invalid-void-type` suppressions are
+removed.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-06-18T02:24:45.881Z",
+  "generated": "2026-06-18T03:54:30.717Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.132.1",
   "cli": {
@@ -296,7 +296,7 @@
       },
       {
         "name": "visualize",
-        "type": "sync",
+        "type": "async",
         "handler": "handleVisualizeCommand",
         "file": "src/cli-commands-handlers.ts"
       },

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-06-18T02:24:45.881Z
+**Generated:** 2026-06-18T03:54:30.717Z
 **Package Version:** 2.132.1
 **Generator:** `scripts/generate-repo-index.ts`
 
@@ -63,7 +63,7 @@ Binary: `nexus-agents`
 | `validate` | async | `handleValidateCommand` | `src/cli-commands-handlers.ts` |
 | `validation` | sync | `handleValidationCommand` | `src/cli-commands-handlers.ts` |
 | `verify` | async | `handleVerifyCommand` | `src/cli-commands-handlers.ts` |
-| `visualize` | sync | `handleVisualizeCommand` | `src/cli-commands-handlers.ts` |
+| `visualize` | async | `handleVisualizeCommand` | `src/cli-commands-handlers.ts` |
 | `vote` | async | `handleVoteCommand` | `src/cli-commands-handlers.ts` |
 | `warm-up` | sync | `handleWarmUpCommand` | `src/cli-commands-handlers.ts` |
 | `workflow` | async | `handleWorkflowCommand` | `src/cli-commands-handlers.ts` |

--- a/packages/nexus-agents/src/cli-auth-handler.test.ts
+++ b/packages/nexus-agents/src/cli-auth-handler.test.ts
@@ -3,11 +3,13 @@ import { handleAuthCommand } from './cli-auth-handler.js';
 import type { ParsedCliArgs } from './cli-types.js';
 
 vi.mock('./cli/index.js', () => ({
-  authCommand: vi.fn(),
+  // #3942: authCommand now returns success boolean; default to success.
+  authCommand: vi.fn(() => true),
 }));
 
 vi.mock('./cli/login-command.js', () => ({
-  handleLoginCommand: vi.fn(() => Promise.resolve()),
+  // #3942: handleLoginCommand now resolves a CliExitResult.
+  handleLoginCommand: vi.fn(() => Promise.resolve({ success: true, exitCode: 0 })),
 }));
 
 function createArgs(

--- a/packages/nexus-agents/src/cli-auth-handler.ts
+++ b/packages/nexus-agents/src/cli-auth-handler.ts
@@ -10,7 +10,12 @@
 
 import { authCommand } from './cli/index.js';
 import { handleLoginCommand } from './cli/login-command.js';
-import type { ParsedCliArgs } from './cli-types.js';
+import {
+  cliExitFromStatus,
+  EXIT_CODES,
+  type CliExitResult,
+  type ParsedCliArgs,
+} from './cli-types.js';
 
 /**
  * Handles auth command for token management.
@@ -22,11 +27,15 @@ import type { ParsedCliArgs } from './cli-types.js';
  *
  * (Source: Issue #739 - enable MCP authentication by default)
  */
-export async function handleAuthCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleAuthCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   if (args.subcommand === 'status') {
-    await handleLoginCommand(args);
-    return;
+    // #3942: forward the login probe's exit result unchanged.
+    return handleLoginCommand(args);
   }
   const format: 'text' | 'json' = args.options.format === 'json' ? 'json' : 'text';
-  authCommand(args.subcommand, { force: args.options.force, format });
+  const success = authCommand(args.subcommand, { force: args.options.force, format });
+  // #3942: byte-identical to the prior behavior, which set `process.exitCode = 1`
+  // on failure and otherwise exited 0 naturally. `cliExitFromStatus(0|1)` maps
+  // to SUCCESS (0) / SERVER_START_FAILED (1).
+  return cliExitFromStatus(success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -53,7 +53,9 @@ import {
   EXIT_CODES,
   cliExit,
   cliExitFromStatus,
+  LIFECYCLE_DELEGATED,
   type CliExitResult,
+  type LifecycleDelegated,
   type ParsedCliArgs,
 } from './cli-types.js';
 import { startServer, type OrchestratorModeOptions } from './cli-server.js';
@@ -193,23 +195,28 @@ function printFirstRunHint(): void {
  * In orchestrator mode, executes tasks directly without MCP server.
  * (Source: Issue #446 - Implement orchestrator mode)
  */
-export async function handleServerCommand(args: ParsedCliArgs): Promise<CliExitResult | undefined> {
+export async function handleServerCommand(
+  args: ParsedCliArgs
+): Promise<CliExitResult | LifecycleDelegated> {
   printFirstRunHint();
   if (args.options.interactive) {
     const exitCode = await replCommand({ verbose: args.options.verbose });
     return cliExitFromStatus(exitCode);
   } else if (args.options.mode === 'orchestrator') {
-    // Orchestrator mode: execute tasks directly (Issue #446)
+    // Orchestrator mode: execute tasks directly (Issue #446). startServer
+    // delegates to startOrchestratorMode, which owns the process lifecycle
+    // (it calls process.exit itself once the task/REPL completes).
     const orchestratorOptions = buildOrchestratorOptions(args);
     await startServer(args.options.verbose, args.options.mode, true, orchestratorOptions);
   } else {
     // MCP stdio server: startServer owns the process lifecycle (it runs
-    // until the transport closes, then exits itself). No CliExitResult is
-    // returned so the dispatcher does not call process.exit — preserving
-    // pre-#3210 behavior where this path never hit the exit ternary.
+    // until the transport closes, then exits itself).
     await startServer(args.options.verbose, args.options.mode);
   }
-  return undefined;
+  // #3942: explicit lifecycle-delegation sentinel — the dispatcher must NOT
+  // force an exit here (the server/orchestrator path owns the process). This
+  // is a deliberate, type-checked choice, not an accidentally-dropped return.
+  return LIFECYCLE_DELEGATED;
 }
 
 /**
@@ -733,7 +740,7 @@ export async function handleSprintCommand(args: ParsedCliArgs): Promise<CliExitR
  */
 export async function handleSessionCommand(
   args: ParsedCliArgs
-): Promise<CliExitResult | undefined> {
+): Promise<CliExitResult | LifecycleDelegated> {
   const subcommand = args.subcommand;
   if (
     subcommand !== 'list' &&
@@ -758,13 +765,15 @@ export async function handleSessionCommand(
 
   // Pass remaining args after subcommand to sessionCommand.
   // Errors thrown by sessionCommand propagate to the top-level CLI error handler.
-  // The valid-subcommand path intentionally returns `undefined` (no forced
+  // The valid-subcommand path intentionally delegates the lifecycle (no forced
   // process.exit) — pre-#3210 this path never called process.exit, letting
   // the event loop drain naturally (e.g. pending SQLite writes) before the
   // process ends with code 0. Forcing an exit here could truncate that I/O.
+  // #3942: signal that delegation explicitly with the sentinel rather than a
+  // bare `undefined`, so a dropped return on the error path above is caught.
   const remainingArgs = args.positionals.slice(2);
   await sessionCommand(subcommand, remainingArgs);
-  return undefined;
+  return LIFECYCLE_DELEGATED;
 }
 
 /**

--- a/packages/nexus-agents/src/cli-commands.test.ts
+++ b/packages/nexus-agents/src/cli-commands.test.ts
@@ -1,74 +1,90 @@
 import { describe, it, expect, vi, afterEach, beforeEach, type MockInstance } from 'vitest';
 import { dispatchCommand, printHelp, printVersion } from './cli-commands.js';
-import type { ParsedCliArgs } from './cli-types.js';
+import { LIFECYCLE_DELEGATED, type ParsedCliArgs } from './cli-types.js';
+
+// #3942: every handler now returns a CliHandlerResult (CliExitResult |
+// LifecycleDelegated) — never void/undefined. The dispatcher's `exitWith`
+// calls `process.exit` for a CliExitResult and no-ops for LIFECYCLE_DELEGATED.
+// These dispatch-routing tests only assert the handler was invoked, so the
+// mocks return the LIFECYCLE_DELEGATED sentinel to keep `dispatchCommand`
+// resolving (no forced exit) — the old no-op-on-undefined behavior, now typed.
+// `vi.hoisted` is required because `vi.mock` factories are hoisted above the
+// module body, so the helpers must be hoisted alongside them.
+const { DELEGATED, DELEGATED_ASYNC } = vi.hoisted(() => {
+  const sentinel = { __lifecycleDelegated: true } as const;
+  return {
+    DELEGATED: (): typeof sentinel => sentinel,
+    DELEGATED_ASYNC: (): Promise<typeof sentinel> => Promise.resolve(sentinel),
+  };
+});
 
 // Mock all handler modules
 vi.mock('./cli-commands-handlers.js', () => ({
-  handleUnimplementedCommand: vi.fn(),
-  handleConfigCommand: vi.fn(() => Promise.resolve()),
-  handleExpertCommand: vi.fn(),
-  handleWorkflowCommand: vi.fn(() => Promise.resolve()),
-  handleServerCommand: vi.fn(() => Promise.resolve()),
-  handleReviewCommand: vi.fn(() => Promise.resolve()),
-  handleRoutingAuditCommand: vi.fn(),
-  handleOrchestrateCommand: vi.fn(() => Promise.resolve()),
-  handleSystemReviewCommand: vi.fn(),
-  handleVoteCommand: vi.fn(() => Promise.resolve()),
-  handleIndexCommand: vi.fn(() => Promise.resolve()),
-  handleResearchCommand: vi.fn(() => Promise.resolve()),
-  handleRegistryCommand: vi.fn(() => Promise.resolve()),
-  handleValidationCommand: vi.fn(),
-  handleLearningMetricsCommand: vi.fn(),
-  handleSweBenchCommand: vi.fn(() => Promise.resolve()),
-  handleAtbenchCommand: vi.fn(() => Promise.resolve()),
-  handleVerifyCommand: vi.fn(() => Promise.resolve()),
-  handleDoctorCommand: vi.fn(() => Promise.resolve()),
-  handleSetupCommand: vi.fn(),
-  handleSetupCommandAsync: vi.fn(() => Promise.resolve()),
-  handleHelloCommand: vi.fn(),
-  handleHooksCommand: vi.fn(() => Promise.resolve()),
-  handleDemoCommand: vi.fn(() => Promise.resolve()),
-  handleTourCommand: vi.fn(() => Promise.resolve()),
-  handleSprintCommand: vi.fn(() => Promise.resolve()),
-  handleSessionCommand: vi.fn(() => Promise.resolve()),
-  handleEvaluateCommand: vi.fn(() => Promise.resolve()),
-  handleIssueCommand: vi.fn(),
-  handleFitnessAuditCommand: vi.fn(),
-  handleWarmUpCommand: vi.fn(),
-  handleE2EEvalCommand: vi.fn(),
-  handleRoutingABCommand: vi.fn(),
-  handleMemoryEvalCommand: vi.fn(),
-  handleInitCommand: vi.fn(() => Promise.resolve()),
+  handleUnimplementedCommand: vi.fn(DELEGATED),
+  handleConfigCommand: vi.fn(DELEGATED_ASYNC),
+  handleExpertCommand: vi.fn(DELEGATED),
+  handleWorkflowCommand: vi.fn(DELEGATED_ASYNC),
+  handleServerCommand: vi.fn(DELEGATED_ASYNC),
+  handleReviewCommand: vi.fn(DELEGATED_ASYNC),
+  handleRoutingAuditCommand: vi.fn(DELEGATED),
+  handleOrchestrateCommand: vi.fn(DELEGATED_ASYNC),
+  handleSystemReviewCommand: vi.fn(DELEGATED),
+  handleVoteCommand: vi.fn(DELEGATED_ASYNC),
+  handleIndexCommand: vi.fn(DELEGATED_ASYNC),
+  handleResearchCommand: vi.fn(DELEGATED_ASYNC),
+  handleRegistryCommand: vi.fn(DELEGATED_ASYNC),
+  handleValidationCommand: vi.fn(DELEGATED),
+  handleLearningMetricsCommand: vi.fn(DELEGATED),
+  handleSweBenchCommand: vi.fn(DELEGATED_ASYNC),
+  handleAtbenchCommand: vi.fn(DELEGATED_ASYNC),
+  handleVerifyCommand: vi.fn(DELEGATED_ASYNC),
+  handleDoctorCommand: vi.fn(DELEGATED_ASYNC),
+  handleSetupCommand: vi.fn(DELEGATED),
+  handleSetupCommandAsync: vi.fn(DELEGATED_ASYNC),
+  handleHelloCommand: vi.fn(DELEGATED),
+  handleHooksCommand: vi.fn(DELEGATED_ASYNC),
+  handleDemoCommand: vi.fn(DELEGATED_ASYNC),
+  handleTourCommand: vi.fn(DELEGATED_ASYNC),
+  handleSprintCommand: vi.fn(DELEGATED_ASYNC),
+  handleSessionCommand: vi.fn(DELEGATED_ASYNC),
+  handleEvaluateCommand: vi.fn(DELEGATED_ASYNC),
+  handleIssueCommand: vi.fn(DELEGATED),
+  handleFitnessAuditCommand: vi.fn(DELEGATED),
+  handleWarmUpCommand: vi.fn(DELEGATED),
+  handleE2EEvalCommand: vi.fn(DELEGATED),
+  handleRoutingABCommand: vi.fn(DELEGATED),
+  handleMemoryEvalCommand: vi.fn(DELEGATED),
+  handleInitCommand: vi.fn(DELEGATED_ASYNC),
 }));
 
 vi.mock('./cli-auth-handler.js', () => ({
-  handleAuthCommand: vi.fn(),
+  handleAuthCommand: vi.fn(DELEGATED_ASYNC),
 }));
 
 vi.mock('./cli-release-handlers.js', () => ({
-  handleReleaseNotesCommand: vi.fn(() => Promise.resolve()),
-  handleReleaseValidateCommand: vi.fn(() => Promise.resolve()),
-  handleReleaseAnnounceCommand: vi.fn(() => Promise.resolve()),
+  handleReleaseNotesCommand: vi.fn(DELEGATED_ASYNC),
+  handleReleaseValidateCommand: vi.fn(DELEGATED_ASYNC),
+  handleReleaseAnnounceCommand: vi.fn(DELEGATED_ASYNC),
 }));
 
 vi.mock('./cli-scaffold-handler.js', () => ({
-  handleScaffoldCommand: vi.fn(),
+  handleScaffoldCommand: vi.fn(DELEGATED),
 }));
 
 vi.mock('./cli/visualize-command.js', () => ({
-  handleVisualizeCommand: vi.fn(),
+  handleVisualizeCommand: vi.fn(DELEGATED_ASYNC),
 }));
 
 vi.mock('./cli/capabilities-command.js', () => ({
-  handleCapabilitiesCommand: vi.fn(),
+  handleCapabilitiesCommand: vi.fn(DELEGATED),
 }));
 
 vi.mock('./cli/status-command.js', () => ({
-  handleStatusCommand: vi.fn(),
+  handleStatusCommand: vi.fn(DELEGATED),
 }));
 
 vi.mock('./cli/memory-benchmark-command.js', () => ({
-  handleMemoryBenchmarkCommand: vi.fn(() => Promise.resolve()),
+  handleMemoryBenchmarkCommand: vi.fn(DELEGATED_ASYNC),
 }));
 
 function createArgs(command: string, overrides: Record<string, unknown> = {}): ParsedCliArgs {
@@ -195,7 +211,8 @@ describe('cli-commands', () => {
 
     // #3210: the dispatcher is the single process.exit boundary. A handler
     // that RETURNS a CliExitResult must map to process.exit(result.exitCode);
-    // a handler that returns undefined/void must NOT force an exit.
+    // a handler that returns the LIFECYCLE_DELEGATED sentinel must NOT force
+    // an exit (#3942 — the sentinel replaces the old bare-undefined signal).
     it('maps a returned CliExitResult to process.exit (sync handler)', async () => {
       const { handleExpertCommand } = await import('./cli-commands-handlers.js');
       vi.mocked(handleExpertCommand).mockReturnValueOnce({ success: false, exitCode: 4 });
@@ -209,10 +226,13 @@ describe('cli-commands', () => {
       await expect(dispatchCommand(createArgs('vote'))).rejects.toThrow(/process\.exit/);
     });
 
-    it('does NOT call process.exit when a handler returns undefined', async () => {
+    // #3942: lifecycle-owning handlers RETURN the explicit LIFECYCLE_DELEGATED
+    // sentinel instead of a bare undefined. exitWith must no-op on it so the
+    // handler keeps ownership of the process (e.g. the MCP stdio server).
+    it('does NOT call process.exit when a handler returns LIFECYCLE_DELEGATED', async () => {
       const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
       const { handleServerCommand } = await import('./cli-commands-handlers.js');
-      vi.mocked(handleServerCommand).mockResolvedValueOnce(undefined);
+      vi.mocked(handleServerCommand).mockResolvedValueOnce(LIFECYCLE_DELEGATED);
       await dispatchCommand(createArgs('server'));
       expect(exitSpy).not.toHaveBeenCalled();
       exitSpy.mockRestore();

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -12,7 +12,12 @@
  */
 
 import { VERSION } from './version.js';
-import { EXIT_CODES, type CliExitResult, type ParsedCliArgs } from './cli-types.js';
+import {
+  EXIT_CODES,
+  isLifecycleDelegated,
+  type CliHandlerResult,
+  type ParsedCliArgs,
+} from './cli-types.js';
 import { renderHelp } from './cli-help-text.js';
 
 // Re-export handlers for backward compatibility
@@ -184,37 +189,31 @@ export function printVersion(): void {
 }
 
 /**
- * A CLI command handler. Migrated handlers (#3210) RETURN a
- * {@link CliExitResult} (or `undefined` to signal "do not force an exit",
- * e.g. the MCP stdio server) so the single `process.exit` lives here at the
- * dispatcher boundary. Not-yet-migrated handlers (auth, login, usage,
- * release, scaffold, …) still call `process.exit` internally and return
- * `void`; `exitWith` no-ops on their `void`/`undefined` return, so both
- * styles coexist during the incremental migration.
+ * A CLI command handler (#3210, completed in #3942). Every handler RETURNS
+ * a {@link CliHandlerResult}: either a `CliExitResult` (the dispatcher exits
+ * with its `exitCode`) or the `LIFECYCLE_DELEGATED` sentinel (the handler
+ * owns its own process lifecycle — e.g. the MCP stdio server — so the
+ * dispatcher does nothing). The union has NO `undefined`/`void` member, so
+ * a handler that drops a return on some path is a compile error rather than
+ * a silently-swallowed exit code. The single `process.exit` lives here at
+ * the dispatcher boundary (see `exitWith`).
  */
-// `void` is required in these unions to bridge migrated handlers (which
-// return CliExitResult) and not-yet-migrated handlers (which return void
-// after exiting internally). `undefined` alone is not assignable from a
-// `void`-returning function, so the union must include `void` until the
-// migration is complete. Safe here: exitWith() treats both void and
-// undefined as "no forced exit".
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-type SyncHandlerResult = CliExitResult | void;
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-type AsyncHandlerResult = Promise<CliExitResult | undefined | void>;
+type SyncHandlerResult = CliHandlerResult;
+type AsyncHandlerResult = Promise<CliHandlerResult>;
 
 /**
- * The single `process.exit` boundary for migrated handlers (#3210). When a
- * handler returns a {@link CliExitResult}, terminate with its `exitCode`.
- * A `void`/`undefined` return means the handler either already exited
- * internally (legacy, not-yet-migrated) or deliberately owns the process
- * lifecycle (MCP stdio server) — so do nothing.
+ * The single `process.exit` boundary for command handlers (#3210/#3942).
+ * Handles the {@link CliHandlerResult} union exhaustively: a
+ * {@link CliExitResult} terminates the process with its `exitCode`; the
+ * {@link LIFECYCLE_DELEGATED} sentinel is an explicit no-op (the handler
+ * owns the process lifecycle). There is no `void`/`undefined` fallthrough —
+ * an unhandled return shape would not type-check.
  */
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- bridges migrated/legacy handler returns; see SyncHandlerResult
-function exitWith(result: CliExitResult | undefined | void): void {
-  if (result !== undefined) {
-    process.exit(result.exitCode);
+function exitWith(result: CliHandlerResult): void {
+  if (isLifecycleDelegated(result)) {
+    return;
   }
+  process.exit(result.exitCode);
 }
 
 /** Sync command dispatch table for reduced complexity. */
@@ -234,8 +233,6 @@ const SYNC_COMMAND_HANDLERS: Record<
   'fitness-audit': handleFitnessAuditCommand,
   // Issue #653: Scaffold Command
   scaffold: handleScaffoldCommand,
-  // Creative: Visualize Command
-  visualize: handleVisualizeCommand,
   // Issue #684: Capabilities Command
   capabilities: handleCapabilitiesCommand,
   // Issue #688: Status Command
@@ -330,6 +327,9 @@ const ASYNC_COMMAND_HANDLERS: Record<
   scenario: handleScenarioCommand,
   // Issue #1598: Validate Command
   validate: handleValidateCommand,
+  // Creative: Visualize Command — async since #3942 (awaits the file write
+  // instead of exiting from a floating promise).
+  visualize: handleVisualizeCommand,
 };
 
 /**

--- a/packages/nexus-agents/src/cli-lifecycle-sentinel.test.ts
+++ b/packages/nexus-agents/src/cli-lifecycle-sentinel.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the explicit lifecycle-delegation sentinel (#3942).
+ *
+ * Before #3942, a lifecycle-owning handler (the MCP stdio server, the
+ * session valid-subcommand path) signaled "I own my own exit" by returning
+ * `undefined`/`void`, and the dispatcher's union included `void`. That
+ * conflated *intentional* delegation with an *accidentally dropped* return:
+ * a missing return on an error path was not a compile error, `exitWith`
+ * no-op'd, and a non-zero exit code was silently swallowed.
+ *
+ * These tests pin the replacement contract:
+ *  - `LIFECYCLE_DELEGATED` is a recognizable sentinel (type guard matches it,
+ *    and never matches a `CliExitResult`).
+ *  - `CliHandlerResult` is an EXHAUSTIVE union with NO `undefined`/`void`
+ *    member — proven at compile time below, so the "void hole" cannot
+ *    silently reopen.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LIFECYCLE_DELEGATED,
+  isLifecycleDelegated,
+  cliExit,
+  EXIT_CODES,
+  type CliHandlerResult,
+  type CliExitResult,
+  type LifecycleDelegated,
+} from './cli-types.js';
+
+describe('LIFECYCLE_DELEGATED sentinel (#3942)', () => {
+  it('the type guard matches the sentinel', () => {
+    expect(isLifecycleDelegated(LIFECYCLE_DELEGATED)).toBe(true);
+  });
+
+  it('the type guard does NOT match a CliExitResult (any exit code)', () => {
+    expect(isLifecycleDelegated(cliExit(EXIT_CODES.SUCCESS))).toBe(false);
+    expect(isLifecycleDelegated(cliExit(EXIT_CODES.SERVER_START_FAILED))).toBe(false);
+    expect(isLifecycleDelegated(cliExit(EXIT_CODES.INVALID_ARGS))).toBe(false);
+  });
+
+  it('carries the brand property so it is distinguishable structurally', () => {
+    expect(LIFECYCLE_DELEGATED).toEqual({ __lifecycleDelegated: true });
+  });
+});
+
+describe('CliHandlerResult is an exhaustive non-void union (#3942)', () => {
+  // ---- Compile-time exhaustiveness assertions -------------------------------
+  // These never run; they fail `tsc` if the union ever (re)admits a
+  // void/undefined member, which is exactly the hole #3942 closed. If someone
+  // re-adds `| void` / `| undefined` to CliHandlerResult, the `IsNever` checks
+  // below stop resolving to `true` and the file no longer type-checks.
+
+  type Extends<A, B> = A extends B ? true : false;
+  type IsNever<T> = [T] extends [never] ? true : false;
+
+  // The union is exactly CliExitResult | LifecycleDelegated — no third member.
+  type _UnionIsExactlyTwoMembers = Extends<CliHandlerResult, CliExitResult | LifecycleDelegated>;
+  const unionIsExactlyTwoMembers: _UnionIsExactlyTwoMembers = true;
+
+  // `undefined` is NOT assignable to the handler-result contract.
+  type _NoUndefinedMember = IsNever<Extract<CliHandlerResult, undefined>>;
+  const noUndefinedMember: _NoUndefinedMember = true;
+
+  // `void` is NOT assignable either (void widens to undefined at call sites).
+  type _NoVoidMember = Extends<undefined, CliHandlerResult> extends true ? false : true;
+  const noVoidMember: _NoVoidMember = true;
+
+  it('admits exactly CliExitResult and LifecycleDelegated (compile-time)', () => {
+    expect(unionIsExactlyTwoMembers).toBe(true);
+    expect(noUndefinedMember).toBe(true);
+    expect(noVoidMember).toBe(true);
+  });
+
+  it('a CliExitResult satisfies the contract', () => {
+    const ok: CliHandlerResult = cliExit(EXIT_CODES.SUCCESS);
+    expect(isLifecycleDelegated(ok)).toBe(false);
+  });
+
+  it('the sentinel satisfies the contract', () => {
+    const delegated: CliHandlerResult = LIFECYCLE_DELEGATED;
+    expect(isLifecycleDelegated(delegated)).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/cli-release-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-release-handlers.test.ts
@@ -5,7 +5,7 @@
  * (Source: Issue #637 - Release automation suite)
  */
 
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { ParsedCliArgs } from './cli-types.js';
 import { EXIT_CODES } from './cli-types.js';
 import type { ServerMode } from './cli/index.js';
@@ -27,18 +27,6 @@ import {
   releaseValidateCommand,
   releaseAnnounceCommand,
 } from './cli/index.js';
-
-// Mock process.exit — re-applied fresh before each test
-let mockExit: { mockRestore: () => void };
-
-beforeEach(() => {
-  mockExit = vi.spyOn(process, 'exit').mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- process.exit accepts string|number|null|undefined; simpler (code?: number) signature needs explicit widening to match
-    ((code?: number) => {
-      throw new Error(`process.exit(${String(code)})`);
-    }) as unknown as typeof process.exit
-  );
-});
 
 /**
  * Creates a ParsedCliArgs object with sensible defaults for release handler tests.
@@ -77,10 +65,6 @@ function createArgs(overrides?: Partial<ParsedCliArgs>): ParsedCliArgs {
   return result;
 }
 
-afterAll(() => {
-  mockExit.mockRestore();
-});
-
 describe('handleReleaseNotesCommand', () => {
   it('passes correct options to releaseNotesCommand', async () => {
     const args = createArgs({
@@ -93,7 +77,7 @@ describe('handleReleaseNotesCommand', () => {
       },
     });
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseNotesCommand(args);
 
     expect(releaseNotesCommand).toHaveBeenCalledWith({
       positionals: ['release-notes'],
@@ -103,23 +87,24 @@ describe('handleReleaseNotesCommand', () => {
         verbose: true,
       },
     });
+    expect(result).toEqual({ success: true, exitCode: EXIT_CODES.SUCCESS });
   });
 
-  it('calls process.exit(0) on success', async () => {
+  it('returns SUCCESS exit code', async () => {
     const args = createArgs();
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseNotesCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SUCCESS);
+    expect(result).toEqual({ success: true, exitCode: EXIT_CODES.SUCCESS });
   });
 
-  it('calls process.exit with SERVER_START_FAILED on failure', async () => {
+  it('returns SERVER_START_FAILED exit code', async () => {
     vi.mocked(releaseNotesCommand).mockResolvedValueOnce(1);
     const args = createArgs();
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseNotesCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SERVER_START_FAILED);
+    expect(result).toEqual({ success: false, exitCode: EXIT_CODES.SERVER_START_FAILED });
   });
 
   it('defaults format to changelog for unrecognized formats', async () => {
@@ -131,7 +116,7 @@ describe('handleReleaseNotesCommand', () => {
       },
     });
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseNotesCommand(args);
 
     expect(releaseNotesCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -151,7 +136,7 @@ describe('handleReleaseNotesCommand', () => {
       },
     });
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseNotesCommand(args);
 
     expect(releaseNotesCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -167,7 +152,7 @@ describe('handleReleaseNotesCommand', () => {
       positionals: ['release-notes', 'v1.0.0', 'v2.0.0'],
     });
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseNotesCommand(args);
 
     expect(releaseNotesCommand).toHaveBeenCalledWith({
       positionals: ['release-notes', 'v1.0.0', 'v2.0.0'],
@@ -186,7 +171,7 @@ describe('handleReleaseNotesCommand', () => {
       positionals: ['release-notes'],
     });
 
-    await expect(handleReleaseNotesCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseNotesCommand(args);
 
     expect(releaseNotesCommand).toHaveBeenCalledWith({
       positionals: ['release-notes'],
@@ -211,7 +196,7 @@ describe('handleReleaseValidateCommand', () => {
       },
     });
 
-    await expect(handleReleaseValidateCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseValidateCommand(args);
 
     expect(releaseValidateCommand).toHaveBeenCalledWith({
       positionals: ['release-validate', '2.0.0'],
@@ -223,27 +208,27 @@ describe('handleReleaseValidateCommand', () => {
     });
   });
 
-  it('calls process.exit(0) on success', async () => {
+  it('returns SUCCESS exit code', async () => {
     const args = createArgs({
       command: 'release-validate',
       positionals: ['release-validate'],
     });
 
-    await expect(handleReleaseValidateCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseValidateCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SUCCESS);
+    expect(result).toEqual({ success: true, exitCode: EXIT_CODES.SUCCESS });
   });
 
-  it('calls process.exit with SERVER_START_FAILED on failure', async () => {
+  it('returns SERVER_START_FAILED exit code', async () => {
     vi.mocked(releaseValidateCommand).mockResolvedValueOnce(1);
     const args = createArgs({
       command: 'release-validate',
       positionals: ['release-validate'],
     });
 
-    await expect(handleReleaseValidateCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseValidateCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SERVER_START_FAILED);
+    expect(result).toEqual({ success: false, exitCode: EXIT_CODES.SERVER_START_FAILED });
   });
 
   it('reuses force flag as strict', async () => {
@@ -256,7 +241,7 @@ describe('handleReleaseValidateCommand', () => {
       },
     });
 
-    await expect(handleReleaseValidateCommand(argsWithForce)).rejects.toThrow(/process\.exit/);
+    await handleReleaseValidateCommand(argsWithForce);
 
     expect(releaseValidateCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -277,7 +262,7 @@ describe('handleReleaseValidateCommand', () => {
       },
     });
 
-    await expect(handleReleaseValidateCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseValidateCommand(args);
 
     expect(releaseValidateCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -294,7 +279,7 @@ describe('handleReleaseValidateCommand', () => {
       positionals: ['release-validate'],
     });
 
-    await expect(handleReleaseValidateCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseValidateCommand(args);
 
     expect(releaseValidateCommand).toHaveBeenCalledWith({
       positionals: ['release-validate'],
@@ -318,7 +303,7 @@ describe('handleReleaseAnnounceCommand', () => {
       },
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseAnnounceCommand(args);
 
     expect(releaseAnnounceCommand).toHaveBeenCalledWith({
       positionals: ['release-announce', '2.0.0', 'slack,discord'],
@@ -331,27 +316,27 @@ describe('handleReleaseAnnounceCommand', () => {
     });
   });
 
-  it('calls process.exit(0) on success', async () => {
+  it('returns SUCCESS exit code', async () => {
     const args = createArgs({
       command: 'release-announce',
       positionals: ['release-announce', '1.0.0'],
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseAnnounceCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SUCCESS);
+    expect(result).toEqual({ success: true, exitCode: EXIT_CODES.SUCCESS });
   });
 
-  it('calls process.exit with SERVER_START_FAILED on failure', async () => {
+  it('returns SERVER_START_FAILED exit code', async () => {
     vi.mocked(releaseAnnounceCommand).mockResolvedValueOnce(1);
     const args = createArgs({
       command: 'release-announce',
       positionals: ['release-announce', '1.0.0'],
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    const result = await handleReleaseAnnounceCommand(args);
 
-    expect(process.exit).toHaveBeenCalledWith(EXIT_CODES.SERVER_START_FAILED);
+    expect(result).toEqual({ success: false, exitCode: EXIT_CODES.SERVER_START_FAILED });
   });
 
   it('passes channels from positionals[2]', async () => {
@@ -360,7 +345,7 @@ describe('handleReleaseAnnounceCommand', () => {
       positionals: ['release-announce', '1.0.0', 'email'],
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseAnnounceCommand(args);
 
     expect(releaseAnnounceCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -377,7 +362,7 @@ describe('handleReleaseAnnounceCommand', () => {
       positionals: ['release-announce'],
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseAnnounceCommand(args);
 
     expect(releaseAnnounceCommand).toHaveBeenCalledWith({
       positionals: ['release-announce'],
@@ -394,7 +379,7 @@ describe('handleReleaseAnnounceCommand', () => {
       positionals: ['release-announce', '3.0.0'],
     });
 
-    await expect(handleReleaseAnnounceCommand(args)).rejects.toThrow(/process\.exit/);
+    await handleReleaseAnnounceCommand(args);
 
     expect(releaseAnnounceCommand).toHaveBeenCalledWith({
       positionals: ['release-announce', '3.0.0'],

--- a/packages/nexus-agents/src/cli-release-handlers.ts
+++ b/packages/nexus-agents/src/cli-release-handlers.ts
@@ -7,7 +7,7 @@
  * (Source: Issue #637 - Release automation suite)
  */
 
-import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
+import { cliExitFromStatus, type CliExitResult, type ParsedCliArgs } from './cli-types.js';
 import {
   releaseNotesCommand,
   releaseValidateCommand,
@@ -22,7 +22,7 @@ import {
  * Handles release-notes command for generating release notes.
  * (Source: Issue #639 - Automated release notes generator)
  */
-export async function handleReleaseNotesCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleReleaseNotesCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const format = ['changelog', 'json', 'markdown'].includes(args.options.format)
     ? (args.options.format as 'changelog' | 'json' | 'markdown')
     : 'changelog';
@@ -40,14 +40,16 @@ export async function handleReleaseNotesCommand(args: ParsedCliArgs): Promise<vo
       verbose: args.options.verbose,
     },
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Mapping is
+  // byte-identical to the prior inline ternary (0 → SUCCESS, non-0 → 1).
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles release-validate command for expert swarm validation.
  * (Source: Issue #640 - Multi-model release validation swarm)
  */
-export async function handleReleaseValidateCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleReleaseValidateCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const version = args.positionals[1];
 
   const exitCode = await releaseValidateCommand({
@@ -58,14 +60,15 @@ export async function handleReleaseValidateCommand(args: ParsedCliArgs): Promise
       strict: args.options.force, // Reuse force flag for strict mode
     },
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  // #3942: RETURN the exit code; dispatcher owns process.exit (0 → SUCCESS, non-0 → 1).
+  return cliExitFromStatus(exitCode);
 }
 
 /**
  * Handles release-announce command for generating announcements.
  * (Source: Issue #641 - Release announcement bot)
  */
-export async function handleReleaseAnnounceCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleReleaseAnnounceCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const version = args.positionals[1];
   const channels = args.positionals[2];
 
@@ -78,5 +81,6 @@ export async function handleReleaseAnnounceCommand(args: ParsedCliArgs): Promise
       verbose: args.options.verbose,
     },
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  // #3942: RETURN the exit code; dispatcher owns process.exit (0 → SUCCESS, non-0 → 1).
+  return cliExitFromStatus(exitCode);
 }

--- a/packages/nexus-agents/src/cli-scaffold-handler.test.ts
+++ b/packages/nexus-agents/src/cli-scaffold-handler.test.ts
@@ -17,20 +17,16 @@ function createArgs(positionals: string[], options: Record<string, unknown> = {}
 }
 
 describe('handleScaffoldCommand', () => {
-  // Vitest 3.x intercepts process.exit before spies fire, so we verify
-  // exit codes via the thrown error message format:
-  // "process.exit unexpectedly called with \"N\""
-  vi.spyOn(process, 'exit');
-
+  // #3942: the handler now RETURNS a CliExitResult instead of calling
+  // process.exit; the dispatcher owns the exit. Assert the returned exitCode.
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   it('should call scaffoldCommand with valid type and name', async () => {
     const { scaffoldCommand } = await import('./cli/index.js');
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'expert', 'my-expert']));
-    }).toThrow('process.exit');
+    const result = handleScaffoldCommand(createArgs(['scaffold', 'expert', 'my-expert']));
+    expect(result).toEqual({ success: true, exitCode: 0 });
     expect(scaffoldCommand).toHaveBeenCalledWith({
       type: 'expert',
       name: 'my-expert',
@@ -38,49 +34,58 @@ describe('handleScaffoldCommand', () => {
     });
   });
 
-  it('should exit SUCCESS when scaffoldCommand returns 0', () => {
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'expert', 'test']));
-    }).toThrow(/process\.exit.*"0"/);
+  it('should return SUCCESS when scaffoldCommand returns 0', () => {
+    expect(handleScaffoldCommand(createArgs(['scaffold', 'expert', 'test']))).toEqual({
+      success: true,
+      exitCode: 0,
+    });
   });
 
-  it('should exit SERVER_START_FAILED when scaffoldCommand returns non-zero', async () => {
+  it('should return SERVER_START_FAILED when scaffoldCommand returns non-zero', async () => {
     const { scaffoldCommand } = await import('./cli/index.js');
     vi.mocked(scaffoldCommand).mockReturnValue(1);
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'expert', 'test']));
-    }).toThrow(/process\.exit.*"1"/);
+    expect(handleScaffoldCommand(createArgs(['scaffold', 'expert', 'test']))).toEqual({
+      success: false,
+      exitCode: 1,
+    });
   });
 
-  it('should print usage and exit when type is missing', async () => {
+  it('should print usage and return INVALID_ARGS when type is missing', async () => {
     const { printScaffoldUsage } = await import('./cli/index.js');
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold']));
-    }).toThrow(/process\.exit.*"3"/);
+    expect(handleScaffoldCommand(createArgs(['scaffold']))).toEqual({
+      success: false,
+      exitCode: 3,
+    });
     expect(printScaffoldUsage).toHaveBeenCalled();
   });
 
-  it('should print usage and exit when name is missing', async () => {
+  it('should print usage and return INVALID_ARGS when name is missing', async () => {
     const { printScaffoldUsage } = await import('./cli/index.js');
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'expert']));
-    }).toThrow(/process\.exit.*"3"/);
+    expect(handleScaffoldCommand(createArgs(['scaffold', 'expert']))).toEqual({
+      success: false,
+      exitCode: 3,
+    });
     expect(printScaffoldUsage).toHaveBeenCalled();
   });
 
-  it('should print usage and exit for invalid scaffold type', async () => {
+  it('should print usage and return INVALID_ARGS for invalid scaffold type', async () => {
     const { printScaffoldUsage } = await import('./cli/index.js');
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'invalid-type', 'name']));
-    }).toThrow(/process\.exit.*"3"/);
+    expect(handleScaffoldCommand(createArgs(['scaffold', 'invalid-type', 'name']))).toEqual({
+      success: false,
+      exitCode: 3,
+    });
     expect(printScaffoldUsage).toHaveBeenCalled();
   });
 
   it('should pass dryRun option', async () => {
     const { scaffoldCommand } = await import('./cli/index.js');
-    expect(() => {
-      handleScaffoldCommand(createArgs(['scaffold', 'workflow', 'my-wf'], { dryRun: true }));
-    }).toThrow('process.exit');
+    // clearAllMocks resets call history but not the implementation, so a prior
+    // test's mockReturnValue(1) would leak; pin success for this assertion.
+    vi.mocked(scaffoldCommand).mockReturnValue(0);
+    const result = handleScaffoldCommand(
+      createArgs(['scaffold', 'workflow', 'my-wf'], { dryRun: true })
+    );
+    expect(result).toEqual({ success: true, exitCode: 0 });
     expect(scaffoldCommand).toHaveBeenCalledWith({
       type: 'workflow',
       name: 'my-wf',

--- a/packages/nexus-agents/src/cli-scaffold-handler.ts
+++ b/packages/nexus-agents/src/cli-scaffold-handler.ts
@@ -7,21 +7,32 @@
  * (Source: Issue #653 - Scaffold command)
  */
 
-import { EXIT_CODES, type ParsedCliArgs } from './cli-types.js';
+import {
+  EXIT_CODES,
+  cliExit,
+  cliExitFromStatus,
+  type CliExitResult,
+  type ParsedCliArgs,
+} from './cli-types.js';
 import { scaffoldCommand, isValidScaffoldType, printScaffoldUsage } from './cli/index.js';
 
 /**
  * Handles scaffold command for generating project files.
  * (Source: Issue #653 - Scaffold command)
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * Exit-code mapping is byte-identical to the pre-migration inline exits:
+ * INVALID_ARGS (3) on bad/missing type or name; SUCCESS (0) / SERVER_START_FAILED (1)
+ * from `scaffoldCommand`'s 0|non-0 status.
  */
-export function handleScaffoldCommand(args: ParsedCliArgs): void {
+export function handleScaffoldCommand(args: ParsedCliArgs): CliExitResult {
   // scaffold <type> <name>
   const type = args.positionals[1];
   const name = args.positionals[2];
 
   if (type === undefined || name === undefined || !isValidScaffoldType(type)) {
     printScaffoldUsage();
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
 
   const exitCode = scaffoldCommand({
@@ -29,5 +40,5 @@ export function handleScaffoldCommand(args: ParsedCliArgs): void {
     name,
     dryRun: args.options.dryRun,
   });
-  process.exit(exitCode === 0 ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
+  return cliExitFromStatus(exitCode);
 }

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -68,6 +68,61 @@ export function cliExitFromStatus(status: number, message?: string): CliExitResu
 }
 
 /**
+ * Explicit sentinel a handler RETURNS to signal "I own my own process
+ * lifecycle — do NOT force an exit at the dispatcher" (#3942).
+ *
+ * Before #3942 this was conveyed by returning `undefined`/`void`, which
+ * conflated *intentional* delegation (the MCP stdio server runs until its
+ * transport closes, then exits itself) with an *accidentally dropped*
+ * return on an error path. A missing return was not a compile error, so
+ * `exitWith` would silently no-op and a non-zero exit code would be lost.
+ *
+ * By typing every handler as {@link CliHandlerResult} (a union that
+ * excludes `undefined`/`void`), a handler that falls off the end without
+ * returning is a TS2366 compile error ("Function lacks ending return
+ * statement…"). Lifecycle-owning handlers RETURN this sentinel explicitly,
+ * making delegation a deliberate, checked choice.
+ *
+ * Implemented as a branded const so it is a single unique value (not just
+ * any object), and `exitWith` can match it by identity.
+ */
+export const LIFECYCLE_DELEGATED = {
+  __lifecycleDelegated: true,
+} as const;
+
+/**
+ * The type of {@link LIFECYCLE_DELEGATED}. A handler whose return type
+ * includes this signals lifecycle delegation; see the sentinel docs.
+ */
+export type LifecycleDelegated = typeof LIFECYCLE_DELEGATED;
+
+/**
+ * The exhaustive return contract for every CLI command handler dispatched
+ * from `cli-commands.ts` (#3942). A handler EITHER returns a
+ * {@link CliExitResult} (the dispatcher exits with its `exitCode`) OR the
+ * {@link LIFECYCLE_DELEGATED} sentinel (the dispatcher does nothing because
+ * the handler owns the process lifecycle). There is deliberately NO
+ * `undefined`/`void` member: that is what makes a dropped return a compile
+ * error rather than a silently-swallowed exit code.
+ */
+export type CliHandlerResult = CliExitResult | LifecycleDelegated;
+
+/**
+ * Type guard distinguishing the {@link LIFECYCLE_DELEGATED} sentinel from a
+ * {@link CliExitResult}. Used by `exitWith` to handle the handler-result
+ * union exhaustively without a `void` fallthrough.
+ *
+ * Discriminates on the brand property rather than reference identity so the
+ * guard is robust across module-boundary/test-mock copies of the sentinel
+ * while remaining unambiguous (a `CliExitResult` never carries this brand).
+ */
+export function isLifecycleDelegated(result: CliHandlerResult): result is LifecycleDelegated {
+  return (
+    (result as Partial<LifecycleDelegated>).__lifecycleDelegated === true && !('exitCode' in result)
+  );
+}
+
+/**
  * CLI command types that can be executed.
  */
 export type CliCommand =

--- a/packages/nexus-agents/src/cli/auth-command.ts
+++ b/packages/nexus-agents/src/cli/auth-command.ts
@@ -338,8 +338,14 @@ export function printAuthResult(result: AuthCommandResult, format: 'text' | 'jso
 /**
  * Main auth command entry point.
  * Called by CLI dispatcher.
+ *
+ * #3942: returns the command's `success` boolean so the caller
+ * (`handleAuthCommand`) can map it to a `CliExitResult` and let the dispatcher
+ * own `process.exit`. Previously this set `process.exitCode = 1` on failure and
+ * relied on a natural exit; the returned boolean preserves that exact mapping
+ * (success → exit 0, failure → exit 1).
  */
-export function authCommand(subcommand?: string, options?: Partial<AuthCommandOptions>): void {
+export function authCommand(subcommand?: string, options?: Partial<AuthCommandOptions>): boolean {
   const parsedSubcommand = isValidAuthSubcommand(subcommand) ? subcommand : 'help';
   const result = runAuthCommand({
     ...options,
@@ -348,7 +354,5 @@ export function authCommand(subcommand?: string, options?: Partial<AuthCommandOp
   const format = options?.format ?? 'text';
   printAuthResult(result, format);
 
-  if (!result.success) {
-    process.exitCode = 1;
-  }
+  return result.success;
 }

--- a/packages/nexus-agents/src/cli/auto-remediate-command.ts
+++ b/packages/nexus-agents/src/cli/auto-remediate-command.ts
@@ -18,7 +18,8 @@
  * @module cli/auto-remediate-command
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { runAutoRemediationCycle } from '../mcp/tools/auto-remediation-cycle.js';
 import type { AutoRemediationResult } from '../mcp/tools/improvement-remediation-enforce.js';
 
@@ -32,12 +33,19 @@ function summarize(r: AutoRemediationResult): string {
   );
 }
 
-/** Handle `nexus-agents auto-remediate`. */
-export async function handleAutoRemediateCommand(args: ParsedCliArgs): Promise<void> {
+/**
+ * Handle `nexus-agents auto-remediate`.
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * This command never forced an exit (natural exit 0) — SUCCESS (0) is
+ * byte-identical.
+ */
+export async function handleAutoRemediateCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const result = await runAutoRemediationCycle();
   if (args.options.format === 'json') {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-    return;
+    return cliExit(EXIT_CODES.SUCCESS);
   }
   process.stdout.write(summarize(result));
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/capabilities-command.test.ts
+++ b/packages/nexus-agents/src/cli/capabilities-command.test.ts
@@ -8,7 +8,6 @@ import type { ParsedCliArgs } from '../cli-types.js';
 
 describe('handleCapabilitiesCommand', () => {
   let stdoutSpy: MockInstance;
-  let exitSpy: MockInstance;
 
   function makeArgs(positionals: string[], options: Record<string, string> = {}): ParsedCliArgs {
     return {
@@ -19,35 +18,29 @@ describe('handleCapabilitiesCommand', () => {
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
-    });
   });
 
   afterEach(() => {
     stdoutSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
-  it('should show usage when no subcommand is provided', async () => {
+  // #3942: the handler RETURNS a CliExitResult instead of calling process.exit;
+  // the dispatcher owns the exit. Assert the returned exitCode.
+  it('should show usage and return SUCCESS when no subcommand is provided', async () => {
     const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
 
-    expect(() => {
-      handleCapabilitiesCommand(makeArgs(['capabilities']));
-    }).toThrow('process.exit called');
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    const result = handleCapabilitiesCommand(makeArgs(['capabilities']));
+    expect(result).toEqual({ success: true, exitCode: 0 });
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('capabilities');
     expect(output).toContain('SUBCOMMANDS');
   });
 
-  it('should show usage and exit with error for invalid subcommand', async () => {
+  it('should show usage and return INVALID_ARGS for invalid subcommand', async () => {
     const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
 
-    expect(() => {
-      handleCapabilitiesCommand(makeArgs(['capabilities', 'invalid']));
-    }).toThrow('process.exit called');
-    expect(exitSpy).toHaveBeenCalledWith(3); // EXIT_CODES.INVALID_ARGS = 3
+    const result = handleCapabilitiesCommand(makeArgs(['capabilities', 'invalid']));
+    expect(result).toEqual({ success: false, exitCode: 3 }); // EXIT_CODES.INVALID_ARGS = 3
   });
 
   it('should list models with table format (default)', async () => {
@@ -84,19 +77,15 @@ describe('handleCapabilitiesCommand', () => {
   it('should require two models for compare subcommand', async () => {
     const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
 
-    expect(() => {
-      handleCapabilitiesCommand(makeArgs(['capabilities', 'compare']));
-    }).toThrow('process.exit called');
-    expect(exitSpy).toHaveBeenCalled();
+    const result = handleCapabilitiesCommand(makeArgs(['capabilities', 'compare']));
+    expect(result).toEqual({ success: false, exitCode: 3 });
   });
 
   it('should require a capability for find subcommand', async () => {
     const { handleCapabilitiesCommand } = await import('./capabilities-command.js');
 
-    expect(() => {
-      handleCapabilitiesCommand(makeArgs(['capabilities', 'find']));
-    }).toThrow('process.exit called');
-    expect(exitSpy).toHaveBeenCalled();
+    const result = handleCapabilitiesCommand(makeArgs(['capabilities', 'find']));
+    expect(result).toEqual({ success: false, exitCode: 3 });
   });
 
   it('should find models by capability', async () => {

--- a/packages/nexus-agents/src/cli/capabilities-command.ts
+++ b/packages/nexus-agents/src/cli/capabilities-command.ts
@@ -9,8 +9,8 @@
  * (Source: Issue #684, Epic #682)
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
-import { EXIT_CODES } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { EXIT_CODES, cliExit } from '../cli-types.js';
 import {
   OUTPUT_MODALITIES,
   INPUT_MODALITIES,
@@ -250,12 +250,12 @@ function renderFind(query: string): void {
 // Subcommand dispatchers
 // ============================================================================
 
-function handleCompare(args: ParsedCliArgs): void {
+function handleCompare(args: ParsedCliArgs): CliExitResult {
   const id1 = args.positionals[2];
   const id2 = args.positionals[3];
   if (id1 === undefined || id2 === undefined) {
     write(`${C.red}Usage: nexus-agents capabilities compare <model1> <model2>${C.reset}`);
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   const m1 = lookupInTreeCapability(id1);
   const m2 = lookupInTreeCapability(id2);
@@ -266,18 +266,20 @@ function handleCompare(args: ParsedCliArgs): void {
       .join(', ');
     write(`${C.red}Unknown model: ${missing}${C.reset}`);
     write(`Valid models: ${ids}`);
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   renderCompare(m1, m2);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
-function handleFindSubcmd(args: ParsedCliArgs): void {
+function handleFindSubcmd(args: ParsedCliArgs): CliExitResult {
   const query = args.positionals[2];
   if (query === undefined) {
     write(`${C.red}Usage: nexus-agents capabilities find <capability>${C.reset}`);
-    process.exit(EXIT_CODES.INVALID_ARGS);
+    return cliExit(EXIT_CODES.INVALID_ARGS);
   }
   renderFind(query);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 // ============================================================================
@@ -285,9 +287,10 @@ function handleFindSubcmd(args: ParsedCliArgs): void {
 // ============================================================================
 
 /** Dispatch table for subcommands. */
-const SUBCOMMAND_HANDLERS: Record<string, (args: ParsedCliArgs) => void> = {
+const SUBCOMMAND_HANDLERS: Record<string, (args: ParsedCliArgs) => CliExitResult> = {
   list: (args) => {
     handleList((args.options.format as OutputFormat | undefined) ?? 'table');
+    return cliExit(EXIT_CODES.SUCCESS);
   },
   compare: handleCompare,
   find: handleFindSubcmd,
@@ -295,8 +298,14 @@ const SUBCOMMAND_HANDLERS: Record<string, (args: ParsedCliArgs) => void> = {
 
 /**
  * Handles the `nexus-agents capabilities` command.
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * Exit codes are byte-identical to the pre-migration inline exits: a bare/
+ * unknown subcommand prints usage and returns SUCCESS (0) when no subcommand
+ * was given, INVALID_ARGS (3) when an unrecognized one was; the `compare`/
+ * `find` argument-validation errors return INVALID_ARGS (3); success returns 0.
  */
-export function handleCapabilitiesCommand(args: ParsedCliArgs): void {
+export function handleCapabilitiesCommand(args: ParsedCliArgs): CliExitResult {
   const subcommand = args.positionals[1];
 
   if (
@@ -304,9 +313,12 @@ export function handleCapabilitiesCommand(args: ParsedCliArgs): void {
     !VALID_SUBCOMMANDS.includes(subcommand as CapabilitiesSubcommand)
   ) {
     process.stdout.write(USAGE + '\n');
-    process.exit(subcommand === undefined ? EXIT_CODES.SUCCESS : EXIT_CODES.INVALID_ARGS);
+    return cliExit(subcommand === undefined ? EXIT_CODES.SUCCESS : EXIT_CODES.INVALID_ARGS);
   }
 
   const handler = SUBCOMMAND_HANDLERS[subcommand];
-  if (handler !== undefined) handler(args);
+  // The guard above guarantees `subcommand` is one of VALID_SUBCOMMANDS, so the
+  // table lookup is defined; the fallback preserves the pre-#3942 behavior
+  // (silently do nothing → natural exit 0) for the unreachable miss.
+  return handler !== undefined ? handler(args) : cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/health-command.ts
+++ b/packages/nexus-agents/src/cli/health-command.ts
@@ -8,7 +8,8 @@
  * (Source: Issue #1403)
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { getTuneAdjustmentStore, type TuneDemotionStat } from '../core/index.js';
 import { colors, symbols } from './ansi-output.js';
 import { generateWeatherReport } from '../mcp/tools/weather-report.js';
@@ -222,7 +223,7 @@ function renderJson(health: HealthResult): void {
 /**
  * Handle the `nexus-agents health` CLI command.
  */
-export function handleHealthCommand(args: ParsedCliArgs): void {
+export function handleHealthCommand(args: ParsedCliArgs): CliExitResult {
   const health = collectHealth();
 
   if (args.options.format === 'json') {
@@ -230,4 +231,9 @@ export function handleHealthCommand(args: ParsedCliArgs): void {
   } else {
     renderTable(health);
   }
+
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Pre-migration
+  // this returned void and the dispatcher no-op'd (natural exit 0) — SUCCESS (0)
+  // is byte-identical.
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/improvement-review-command.ts
+++ b/packages/nexus-agents/src/cli/improvement-review-command.ts
@@ -21,7 +21,8 @@
 
 /* eslint-disable no-console */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import {
   runImprovementReview,
   ImprovementReviewInputSchema,
@@ -78,7 +79,7 @@ function parseOptions(args: ParsedCliArgs): CliOptions {
   };
 }
 
-export async function handleImprovementReviewCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleImprovementReviewCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const cli = parseOptions(args);
   const response = await runImprovementReview({
     lookbackDays: cli.lookbackDays,
@@ -89,10 +90,13 @@ export async function handleImprovementReviewCommand(args: ParsedCliArgs): Promi
 
   if (cli.format === 'json') {
     process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
-    return;
+    return cliExit(EXIT_CODES.SUCCESS);
   }
 
   printTextReport(response, cli);
+  // #3942: RETURN the exit code; dispatcher owns process.exit. This command
+  // never forced an exit (natural exit 0) — SUCCESS (0) is byte-identical.
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 function printTextReport(response: ImprovementReviewResponse, opts: CliOptions): void {

--- a/packages/nexus-agents/src/cli/login-command.test.ts
+++ b/packages/nexus-agents/src/cli/login-command.test.ts
@@ -126,38 +126,23 @@ describe('summarize', () => {
 // ============================================================================
 
 describe('handleLoginCommand exit codes (#2953 truth table)', () => {
-  let exitSpy: MockInstance;
   let consoleLogSpy: MockInstance;
   let consoleErrorSpy: MockInstance;
 
   beforeEach(() => {
     probeAllClis.mockReset();
-    // process.exit throws to abort the function under test without
-    // actually exiting the test runner. The test asserts via the mock
-    // call record.
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
-      throw new Error(`__test_exit:${String(code ?? 'undefined')}`);
-    });
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    exitSpy.mockRestore();
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
   });
 
   async function runAndCaptureExit(): Promise<number> {
-    try {
-      await handleLoginCommand(makeArgs('auth'));
-      // process.exit was supposed to fire — if we get here, it didn't.
-      throw new Error('handleLoginCommand returned without exiting');
-    } catch (err) {
-      const m = /^__test_exit:(\d+)$/.exec((err as Error).message);
-      if (m === null) throw err;
-      return Number(m[1]);
-    }
+    const result = await handleLoginCommand(makeArgs('auth'));
+    return result.exitCode;
   }
 
   // Cell 1: anyAuthenticated=true, actionable.length=0 → EXIT_OK
@@ -187,22 +172,14 @@ describe('handleLoginCommand exit codes (#2953 truth table)', () => {
 
   it('prints deprecation hint when invoked as the `login` alias (#2449)', async () => {
     probeAllClis.mockResolvedValue([authed('claude')]);
-    try {
-      await handleLoginCommand(makeArgs('login'));
-    } catch {
-      // expected — exit fires
-    }
+    await handleLoginCommand(makeArgs('login'));
     const printed = consoleErrorSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(printed).toContain("'nexus-agents login' is now 'nexus-agents auth status'");
   });
 
   it('does NOT print the deprecation hint for the canonical `auth` command', async () => {
     probeAllClis.mockResolvedValue([authed('claude')]);
-    try {
-      await handleLoginCommand(makeArgs('auth'));
-    } catch {
-      // expected
-    }
+    await handleLoginCommand(makeArgs('auth'));
     const printed = consoleErrorSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(printed).not.toContain('login is now');
   });

--- a/packages/nexus-agents/src/cli/login-command.ts
+++ b/packages/nexus-agents/src/cli/login-command.ts
@@ -12,12 +12,13 @@
 
 /* eslint-disable no-console */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { probeAllClis } from './cli-auth-probe.js';
 import type { AuthProbeResult } from './cli-auth-probe.js';
 
-const EXIT_OK = 0;
-const EXIT_ERR = 1;
+const EXIT_OK = EXIT_CODES.SUCCESS;
+const EXIT_ERR = EXIT_CODES.SERVER_START_FAILED;
 
 const STATE_GLYPH: Record<AuthProbeResult['state'], string> = {
   authenticated: '✓', // ✓
@@ -63,7 +64,7 @@ function printNextStepFor(r: AuthProbeResult & { state: 'needs-login' }): void {
   }
 }
 
-export async function handleLoginCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleLoginCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   // Deprecation hint when invoked via the standalone `login` command.
   // Routing through `auth status` is silent. Issue #2449.
   if (args.command === 'login') {
@@ -83,11 +84,13 @@ export async function handleLoginCommand(args: ParsedCliArgs): Promise<void> {
   console.log(summary.line);
   printNextSteps(ordered, summary.actionable);
 
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Mapping is
+  // byte-identical: EXIT_OK (0) when authenticated or no action needed,
+  // EXIT_ERR (1) when no CLI is authenticated AND there's a clear next action.
   if (summary.anyAuthenticated || summary.actionable.length === 0) {
-    process.exit(EXIT_OK);
+    return cliExit(EXIT_OK);
   }
-  // Exit 1 when no CLI is authenticated AND there's a clear next action.
-  process.exit(EXIT_ERR);
+  return cliExit(EXIT_ERR);
 }
 
 /**

--- a/packages/nexus-agents/src/cli/memory-benchmark-command.test.ts
+++ b/packages/nexus-agents/src/cli/memory-benchmark-command.test.ts
@@ -205,16 +205,17 @@ describe('memory-benchmark-command', () => {
       expect(vi.mocked(validateBenchmarkResults)).toHaveBeenCalled();
     });
 
-    it('should set exitCode 1 when validation fails', async () => {
+    it('should return exit code 1 when validation fails', async () => {
       const args = createMockArgs({ subcommand: 'validate' });
       vi.mocked(validateBenchmarkResults).mockReturnValue({
         pass: false,
         failures: ['recall too low'],
       });
 
-      await handleMemoryBenchmarkCommand(args);
+      // #3942: handler RETURNS the exit code; dispatcher owns process.exit.
+      const result = await handleMemoryBenchmarkCommand(args);
 
-      expect(process.exitCode).toBe(1);
+      expect(result).toEqual({ success: false, exitCode: 1 });
       expect(stdoutSpy).toHaveBeenCalledWith(
         expect.stringContaining('Threshold validation failed')
       );
@@ -282,12 +283,13 @@ describe('memory-benchmark-command', () => {
         Promise.reject(new Error('Benchmark failed'))
       );
 
-      await handleMemoryBenchmarkCommand(args);
+      // #3942: handler RETURNS the exit code; dispatcher owns process.exit.
+      const result = await handleMemoryBenchmarkCommand(args);
 
       expect(stderrSpy).toHaveBeenCalledWith(
         expect.stringContaining('Benchmark failed: Benchmark failed')
       );
-      expect(process.exitCode).toBe(1);
+      expect(result).toEqual({ success: false, exitCode: 1 });
     });
 
     it('should handle non-Error exceptions', async () => {

--- a/packages/nexus-agents/src/cli/memory-benchmark-command.ts
+++ b/packages/nexus-agents/src/cli/memory-benchmark-command.ts
@@ -8,7 +8,8 @@
  * (Source: Issue #748 - Memory evaluation framework)
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { colors, symbols } from './ansi-output.js';
 import {
   runMemoryBenchmark,
@@ -190,7 +191,7 @@ function parseOptions(args: ParsedCliArgs): MemoryBenchmarkOptions {
  *   nexus-agents memory-benchmark validate  # Validate against thresholds
  *   nexus-agents memory-benchmark --format json # Output as JSON
  */
-export async function handleMemoryBenchmarkCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleMemoryBenchmarkCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const options = parseOptions(args);
   const startTime = getTimeProvider().now();
 
@@ -199,12 +200,16 @@ export async function handleMemoryBenchmarkCommand(args: ParsedCliArgs): Promise
     printRunning();
   }
 
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Byte-identical
+  // to the prior `process.exitCode = 1` behavior: a failed validation or a
+  // thrown benchmark error yields SERVER_START_FAILED (1); otherwise SUCCESS (0).
+  let exitCode: number = EXIT_CODES.SUCCESS;
   try {
     const result = await runBenchmark(options);
     printResults(result, options.format);
 
     if (options.validate && !validateAndPrint(result)) {
-      process.exitCode = 1;
+      exitCode = EXIT_CODES.SERVER_START_FAILED;
     }
 
     if (options.format === 'text') {
@@ -215,6 +220,7 @@ export async function handleMemoryBenchmarkCommand(args: ParsedCliArgs): Promise
     process.stderr.write(
       `${colors.red}${symbols.cross} Benchmark failed: ${message}${colors.reset}\n`
     );
-    process.exitCode = 1;
+    exitCode = EXIT_CODES.SERVER_START_FAILED;
   }
+  return cliExit(exitCode);
 }

--- a/packages/nexus-agents/src/cli/migrate-command.ts
+++ b/packages/nexus-agents/src/cli/migrate-command.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import { createLogger } from '../core/index.js';
 import { getPerRepoSubdirs } from '../config/nexus-data-dir.js';
 import { findRepoRoot } from '../config/repo-root-detection.js';
+import { cliExit, EXIT_CODES, type CliExitResult } from '../cli-types.js';
 
 const logger = createLogger({ component: 'migrate-command' });
 
@@ -242,7 +243,7 @@ export async function handleMigrateCommand(args: {
     readonly input?: string;
     readonly output?: string;
   };
-}): Promise<void> {
+}): Promise<CliExitResult> {
   const opts: MigrateOptions = {
     ...(args.options.input !== undefined ? { from: args.options.input } : {}),
     ...(args.options.output !== undefined ? { to: args.options.output } : {}),
@@ -251,9 +252,10 @@ export async function handleMigrateCommand(args: {
   const result = runMigrate(opts);
   process.stderr.write(formatMigrationResult(result));
   await Promise.resolve();
-  if (!result.success) {
-    process.exit(1);
-  }
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Byte-identical:
+  // failure → SERVER_START_FAILED (1), success → SUCCESS (0) (was a natural
+  // exit-0 after the function returned).
+  return cliExit(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }
 
 /** Re-export for the migrate command's CLI surface area. */

--- a/packages/nexus-agents/src/cli/mode-command.ts
+++ b/packages/nexus-agents/src/cli/mode-command.ts
@@ -10,8 +10,8 @@
  * (Source: Issue #3214 — expose mode detection for inspection/debugging)
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
-import { EXIT_CODES } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { EXIT_CODES, cliExit } from '../cli-types.js';
 import {
   detectMode,
   describeSignals,
@@ -53,7 +53,7 @@ function resolveExplicitMode(raw: ServerMode | undefined): ServerMode | undefine
  *
  * @param args - Parsed CLI arguments
  */
-export function handleModeCommand(args: ParsedCliArgs): void {
+export function handleModeCommand(args: ParsedCliArgs): CliExitResult {
   const explicitMode = resolveExplicitMode(args.options.mode);
   const result = detectMode(explicitMode !== undefined ? { explicitMode } : {});
 
@@ -75,5 +75,6 @@ export function handleModeCommand(args: ParsedCliArgs): void {
     write(formatModeInspection(result));
   }
 
-  process.exit(EXIT_CODES.SUCCESS);
+  // #3942: RETURN the exit code (always SUCCESS, as before); dispatcher exits.
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/remediation-review-command.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.ts
@@ -21,7 +21,8 @@
  * @module cli/remediation-review-command
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { getTimeProvider } from '../core/index.js';
 import {
   getRemediationSoakSink,
@@ -144,8 +145,16 @@ function runSignOff(args: ParsedCliArgs): void {
   );
 }
 
-/** Handle `nexus-agents remediation-review <subcommand>`. */
-export async function handleRemediationReviewCommand(args: ParsedCliArgs): Promise<void> {
+/**
+ * Handle `nexus-agents remediation-review <subcommand>`.
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * On the happy path this command never forced an exit (natural exit 0) —
+ * SUCCESS (0) is byte-identical. Bad input still throws (an unknown subcommand,
+ * or the argument validation in `runMark`/`runSignOff`), propagating to the
+ * top-level CLI error handler exactly as before.
+ */
+export async function handleRemediationReviewCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const sub = args.subcommand ?? 'list';
   switch (sub) {
     case 'list':
@@ -162,5 +171,6 @@ export async function handleRemediationReviewCommand(args: ParsedCliArgs): Promi
         `remediation-review: unknown subcommand '${sub}' (expected list | mark | sign-off)`
       );
   }
-  return Promise.resolve();
+  await Promise.resolve();
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/scenario-command.ts
+++ b/packages/nexus-agents/src/cli/scenario-command.ts
@@ -14,8 +14,8 @@ import { readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { createScenarioRunner } from '../testing/e2e/scenario-runner.js';
 import type { ScenarioResult } from '../testing/e2e/types.js';
-import type { ParsedCliArgs } from '../cli-types.js';
-import { EXIT_CODES } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { EXIT_CODES, cliExit } from '../cli-types.js';
 
 const FIXTURES_DIR = resolve(import.meta.dirname, '../testing/e2e/fixtures');
 
@@ -33,8 +33,8 @@ async function listScenarios(): Promise<string[]> {
   }
 }
 
-/** Print scenario list and exit. */
-async function handleList(): Promise<void> {
+/** Print scenario list. Returns SUCCESS (0), matching the prior inline exit. */
+async function handleList(): Promise<CliExitResult> {
   const names = await listScenarios();
   if (names.length === 0) {
     process.stdout.write('No scenario fixtures found.\n');
@@ -44,7 +44,7 @@ async function handleList(): Promise<void> {
       process.stdout.write(`  - ${n}\n`);
     }
   }
-  process.exit(EXIT_CODES.SUCCESS);
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 /** Print scenario result to stdout. */
@@ -66,12 +66,16 @@ function printResult(result: ScenarioResult): void {
   }
 }
 
-/** Run a single scenario by name and exit. */
-async function handleRun(args: ParsedCliArgs): Promise<void> {
+/**
+ * Run a single scenario by name. Exit codes match the prior inline exits:
+ * missing name → SERVER_START_FAILED (1); run → SUCCESS (0) if passed else 1;
+ * load/run throw → 1.
+ */
+async function handleRun(args: ParsedCliArgs): Promise<CliExitResult> {
   const name = args.positionals[1] ?? args.positionals[0];
   if (name === undefined || name === 'run') {
     process.stdout.write('Usage: nexus-agents scenario run <name>\n');
-    process.exit(EXIT_CODES.SERVER_START_FAILED);
+    return cliExit(EXIT_CODES.SERVER_START_FAILED);
   }
 
   const runner = createScenarioRunner();
@@ -82,31 +86,33 @@ async function handleRun(args: ParsedCliArgs): Promise<void> {
     const result = await runner.run(fixture);
     printResult(result);
     const code = result.passed ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED;
-    process.exit(code);
+    return cliExit(code);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stdout.write(`Failed to run scenario: ${msg}\n`);
-    process.exit(EXIT_CODES.SERVER_START_FAILED);
+    return cliExit(EXIT_CODES.SERVER_START_FAILED);
   }
 }
 
 /**
  * Handle the `scenario` CLI command.
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * Exit codes are byte-identical to the prior inline exits (see helpers above);
+ * an unknown subcommand returns SERVER_START_FAILED (1).
  */
-export async function handleScenarioCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleScenarioCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const sub = args.subcommand ?? args.positionals[0] ?? 'list';
 
   if (sub === 'list') {
-    await handleList();
-    return;
+    return handleList();
   }
 
   if (sub === 'run') {
-    await handleRun(args);
-    return;
+    return handleRun(args);
   }
 
   process.stdout.write(`Unknown subcommand: ${sub}\n`);
   process.stdout.write('Usage: nexus-agents scenario [list|run <name>]\n');
-  process.exit(EXIT_CODES.SERVER_START_FAILED);
+  return cliExit(EXIT_CODES.SERVER_START_FAILED);
 }

--- a/packages/nexus-agents/src/cli/status-command.ts
+++ b/packages/nexus-agents/src/cli/status-command.ts
@@ -13,7 +13,8 @@ import { VERSION } from '../version.js';
 import { colors, symbols } from './ansi-output.js';
 import { createFitnessScoreCalculator } from '../governance/fitness-score.js';
 import { createLogger } from '../core/index.js';
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { execFileSync } from 'node:child_process';
 import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
 
@@ -185,7 +186,7 @@ function renderJson(status: StatusResult): void {
 /**
  * Handle the `nexus-agents status` CLI command.
  */
-export function handleStatusCommand(args: ParsedCliArgs): void {
+export function handleStatusCommand(args: ParsedCliArgs): CliExitResult {
   const status = collectStatus();
 
   if (args.options.format === 'json') {
@@ -193,4 +194,9 @@ export function handleStatusCommand(args: ParsedCliArgs): void {
   } else {
     renderTable(status);
   }
+
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Pre-migration
+  // this returned void and the dispatcher no-op'd, so the process exited 0
+  // naturally — SUCCESS (0) is byte-identical.
+  return cliExit(EXIT_CODES.SUCCESS);
 }

--- a/packages/nexus-agents/src/cli/usage-command.ts
+++ b/packages/nexus-agents/src/cli/usage-command.ts
@@ -18,7 +18,8 @@
 
 /* eslint-disable no-console */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { loadUsageEvents, rollupByModel, type ModelRollup } from '../learning/usage-log.js';
 
 interface UsageOptions {
@@ -46,7 +47,7 @@ function parseOptions(args: ParsedCliArgs): UsageOptions {
   return { format, sinceIso, untilIso: until, modelId: model };
 }
 
-export async function handleUsageCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleUsageCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const opts = parseOptions(args);
 
   const loadOpts: Parameters<typeof loadUsageEvents>[0] = { sinceIso: opts.sinceIso };
@@ -62,11 +63,14 @@ export async function handleUsageCommand(args: ParsedCliArgs): Promise<void> {
   if (opts.format === 'json') {
     process.stdout.write(`${JSON.stringify({ since: opts.sinceIso, rollups }, null, 2)}\n`);
     await Promise.resolve();
-    return;
+    return cliExit(EXIT_CODES.SUCCESS);
   }
 
   printTextReport(opts, rollups, events.length);
   await Promise.resolve();
+  // #3942: RETURN the exit code; dispatcher owns process.exit. This command
+  // never forced an exit (natural exit 0) — SUCCESS (0) is byte-identical.
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 function printTextReport(

--- a/packages/nexus-agents/src/cli/validate-command.ts
+++ b/packages/nexus-agents/src/cli/validate-command.ts
@@ -8,7 +8,8 @@
  * (Source: Issue #1598)
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { runDoctor } from './doctor.js';
 import type { DoctorResult } from './doctor.js';
 import { calculateFitnessScore } from '../governance/index.js';
@@ -114,7 +115,7 @@ export async function runValidate(): Promise<ValidateResult> {
 /**
  * CLI handler for the validate command.
  */
-export async function handleValidateCommand(args: ParsedCliArgs): Promise<void> {
+export async function handleValidateCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const result = await runValidate();
   const isJson = args.options.format === 'json';
 
@@ -124,5 +125,7 @@ export async function handleValidateCommand(args: ParsedCliArgs): Promise<void> 
     printReport(result);
   }
 
-  process.exit(result.allPassed ? 0 : 1);
+  // #3942: RETURN the exit code; dispatcher owns process.exit. Byte-identical
+  // to the prior `process.exit(result.allPassed ? 0 : 1)` mapping.
+  return cliExit(result.allPassed ? EXIT_CODES.SUCCESS : EXIT_CODES.SERVER_START_FAILED);
 }

--- a/packages/nexus-agents/src/cli/visualize-command.test.ts
+++ b/packages/nexus-agents/src/cli/visualize-command.test.ts
@@ -82,21 +82,16 @@ function makeArgs(positionals: string[], options: Record<string, string | undefi
 describe('handleVisualizeCommand', () => {
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
-  let exitSpy: MockInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
-    });
   });
 
   afterEach(() => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
   // ==========================================================================
@@ -104,35 +99,30 @@ describe('handleVisualizeCommand', () => {
   // ==========================================================================
 
   describe('subcommand validation', () => {
-    it('should show usage and exit 0 when no subcommand is provided', async () => {
+    it('should show usage and return exit 0 when no subcommand is provided', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs(['visualize']));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs(['visualize']));
 
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(result).toEqual({ success: true, exitCode: 0 });
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('SUBCOMMANDS');
     });
 
-    it('should show usage and exit 3 for invalid subcommand', async () => {
+    it('should show usage and return exit 3 for invalid subcommand', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs(['visualize', 'invalid']));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'invalid']));
 
-      expect(exitSpy).toHaveBeenCalledWith(3);
+      expect(result).toEqual({ success: false, exitCode: 3 });
     });
 
     it('should show usage text containing all valid subcommands', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs(['visualize']));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs(['visualize']));
 
+      expect(result).toEqual({ success: true, exitCode: 0 });
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('architecture');
       expect(output).toContain('swarm');
@@ -144,10 +134,9 @@ describe('handleVisualizeCommand', () => {
     it('should show usage containing format and output options', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs(['visualize']));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs(['visualize']));
 
+      expect(result).toEqual({ success: true, exitCode: 0 });
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('--format');
       expect(output).toContain('--output');
@@ -163,8 +152,9 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateArchitectureDiagram } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'architecture']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'architecture']));
 
+      expect(result.exitCode).toBe(0);
       expect(generateArchitectureDiagram).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('graph TB');
@@ -174,8 +164,11 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { wrapInMarkdownFence } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'architecture'], { format: 'markdown' }));
+      const result = await handleVisualizeCommand(
+        makeArgs(['visualize', 'architecture'], { format: 'markdown' })
+      );
 
+      expect(result.exitCode).toBe(0);
       expect(wrapInMarkdownFence).toHaveBeenCalledWith(
         'graph TB\n  A-->B',
         'Nexus Agents Architecture'
@@ -192,8 +185,9 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateSwarmVisualization } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'swarm']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'swarm']));
 
+      expect(result.exitCode).toBe(0);
       expect(generateSwarmVisualization).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('graph LR');
@@ -203,7 +197,7 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateSwarmVisualization } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'swarm']));
+      await handleVisualizeCommand(makeArgs(['visualize', 'swarm']));
 
       const call = vi.mocked(generateSwarmVisualization).mock.calls[0]!;
       expect(call).toBeDefined();
@@ -220,8 +214,9 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateOrchestrationSequence } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'orchestration']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'orchestration']));
 
+      expect(result.exitCode).toBe(0);
       expect(generateOrchestrationSequence).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('sequenceDiagram');
@@ -231,8 +226,11 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateAsciiDashboard } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'orchestration'], { format: 'ascii' }));
+      const result = await handleVisualizeCommand(
+        makeArgs(['visualize', 'orchestration'], { format: 'ascii' })
+      );
 
+      expect(result.exitCode).toBe(0);
       expect(generateAsciiDashboard).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('DASH');
@@ -242,8 +240,11 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { wrapInMarkdownFence } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'orchestration'], { format: 'markdown' }));
+      const result = await handleVisualizeCommand(
+        makeArgs(['visualize', 'orchestration'], { format: 'markdown' })
+      );
 
+      expect(result.exitCode).toBe(0);
       expect(wrapInMarkdownFence).toHaveBeenCalledWith(
         'sequenceDiagram\n  O->>A: Do',
         'Orchestration Execution'
@@ -260,8 +261,9 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateFlowDiagram } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'flow']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'flow']));
 
+      expect(result.exitCode).toBe(0);
       expect(generateFlowDiagram).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('graph TD');
@@ -271,7 +273,7 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { generateFlowDiagram } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'flow']));
+      await handleVisualizeCommand(makeArgs(['visualize', 'flow']));
 
       const call = vi.mocked(generateFlowDiagram).mock.calls[0]!;
       expect(call).toBeDefined();
@@ -289,8 +291,9 @@ describe('handleVisualizeCommand', () => {
       const { generateSystemSummary } = await import('../utils/visual-output.js');
       const { gatherSystemSummary } = await import('./visualize-summary.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'summary']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'summary']));
 
+      expect(result.exitCode).toBe(0);
       expect(gatherSystemSummary).toHaveBeenCalled();
       expect(generateSystemSummary).toHaveBeenCalled();
     });
@@ -298,8 +301,9 @@ describe('handleVisualizeCommand', () => {
     it('should output summary content to stdout', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'summary']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'summary']));
 
+      expect(result.exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('SUMMARY');
     });
@@ -318,16 +322,34 @@ describe('handleVisualizeCommand', () => {
 
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      handleVisualizeCommand(
+      const result = await handleVisualizeCommand(
         makeArgs(['visualize', 'architecture'], { output: '/tmp/test-out.md' })
       );
 
-      // writeOutput uses dynamic import('node:fs'), which is async.
-      // Wait for the microtask to resolve.
-      await vi.waitFor(() => {
-        const calls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
-        expect(calls).toContain('/tmp/test-out.md');
-      });
+      expect(result).toEqual({ success: true, exitCode: 0 });
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      const calls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+      expect(calls).toContain('/tmp/test-out.md');
+
+      vi.doUnmock('node:fs');
+    });
+
+    it('should return exit 1 when the file write throws', async () => {
+      vi.doMock('node:fs', () => ({
+        writeFileSync: vi.fn(() => {
+          throw new Error('EACCES: permission denied');
+        }),
+      }));
+
+      const { handleVisualizeCommand } = await import('./visualize-command.js');
+
+      const result = await handleVisualizeCommand(
+        makeArgs(['visualize', 'architecture'], { output: '/tmp/test-out.md' })
+      );
+
+      expect(result).toEqual({ success: false, exitCode: 1 });
+      const errOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+      expect(errOutput).toContain('Failed to write file');
 
       vi.doUnmock('node:fs');
     });
@@ -335,8 +357,9 @@ describe('handleVisualizeCommand', () => {
     it('should write to stdout when no --output is specified', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'flow']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'flow']));
 
+      expect(result.exitCode).toBe(0);
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
       expect(output).toContain('graph TD');
@@ -352,8 +375,9 @@ describe('handleVisualizeCommand', () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
       const { wrapInMarkdownFence } = await import('../utils/visual-output.js');
 
-      handleVisualizeCommand(makeArgs(['visualize', 'architecture']));
+      const result = await handleVisualizeCommand(makeArgs(['visualize', 'architecture']));
 
+      expect(result.exitCode).toBe(0);
       // Should NOT wrap in markdown when format defaults to mermaid
       expect(wrapInMarkdownFence).not.toHaveBeenCalled();
     });
@@ -367,21 +391,17 @@ describe('handleVisualizeCommand', () => {
     it('should handle empty positionals array gracefully', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs([]));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs([]));
 
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(result).toEqual({ success: true, exitCode: 0 });
     });
 
-    it('should exit with INVALID_ARGS for unknown subcommand string', async () => {
+    it('should return INVALID_ARGS for unknown subcommand string', async () => {
       const { handleVisualizeCommand } = await import('./visualize-command.js');
 
-      expect(() => {
-        handleVisualizeCommand(makeArgs(['visualize', '']));
-      }).toThrow('process.exit called');
+      const result = await handleVisualizeCommand(makeArgs(['visualize', '']));
 
-      expect(exitSpy).toHaveBeenCalledWith(3);
+      expect(result).toEqual({ success: false, exitCode: 3 });
     });
   });
 });

--- a/packages/nexus-agents/src/cli/visualize-command.ts
+++ b/packages/nexus-agents/src/cli/visualize-command.ts
@@ -8,8 +8,8 @@
  * @module cli/visualize-command
  */
 
-import type { ParsedCliArgs } from '../cli-types.js';
-import { EXIT_CODES } from '../cli-types.js';
+import type { CliExitResult, ParsedCliArgs } from '../cli-types.js';
+import { EXIT_CODES, cliExit } from '../cli-types.js';
 import {
   generateArchitectureDiagram,
   generateSwarmVisualization,
@@ -295,36 +295,49 @@ function generateDiagramOutput(subcommand: VisualizeSubcommand, format: OutputFo
   }
 }
 
-/** Write output to file or stdout. */
-function writeOutput(output: string, outputPath: string | undefined): void {
+/**
+ * Write output to file or stdout. The file path is async; #3942 makes this
+ * return a promise so the (now-async) handler awaits it and RETURNS the exit
+ * code instead of `writeOutput` calling `process.exit` from a floating
+ * `.catch`. Exit mapping is preserved: a write failure yields
+ * SERVER_START_FAILED (1), success yields SUCCESS (0).
+ */
+async function writeOutput(output: string, outputPath: string | undefined): Promise<CliExitResult> {
   if (outputPath !== undefined) {
-    import('node:fs')
-      .then((fs) => {
-        fs.writeFileSync(outputPath, output + '\n', 'utf-8');
-        process.stdout.write(`Diagram written to ${outputPath}\n`);
-      })
-      .catch((e: unknown) => {
-        const msg = e instanceof Error ? e.message : String(e);
-        process.stderr.write(`Failed to write file: ${msg}\n`);
-        process.exit(EXIT_CODES.SERVER_START_FAILED);
-      });
+    try {
+      const fs = await import('node:fs');
+      fs.writeFileSync(outputPath, output + '\n', 'utf-8');
+      process.stdout.write(`Diagram written to ${outputPath}\n`);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`Failed to write file: ${msg}\n`);
+      return cliExit(EXIT_CODES.SERVER_START_FAILED);
+    }
   } else {
     process.stdout.write(output + '\n');
   }
+  return cliExit(EXIT_CODES.SUCCESS);
 }
 
 /**
  * Handles the `nexus-agents visualize` command.
+ *
+ * #3942: RETURNS a {@link CliExitResult}; the dispatcher owns `process.exit`.
+ * Exit codes match the pre-migration behavior: bare invocation prints usage
+ * and returns SUCCESS (0); an unknown subcommand returns INVALID_ARGS (3); a
+ * file-write failure returns SERVER_START_FAILED (1); success returns 0. The
+ * handler is now async so it can await the file write rather than exiting from
+ * a floating promise.
  */
-export function handleVisualizeCommand(args: ParsedCliArgs): void {
+export async function handleVisualizeCommand(args: ParsedCliArgs): Promise<CliExitResult> {
   const subcommand = args.positionals[1];
 
   if (subcommand === undefined || !VALID_SUBCOMMANDS.includes(subcommand as VisualizeSubcommand)) {
     process.stdout.write(USAGE + '\n');
-    process.exit(subcommand === undefined ? EXIT_CODES.SUCCESS : EXIT_CODES.INVALID_ARGS);
+    return cliExit(subcommand === undefined ? EXIT_CODES.SUCCESS : EXIT_CODES.INVALID_ARGS);
   }
 
   const format = (args.options.format as OutputFormat | undefined) ?? 'mermaid';
   const output = generateDiagramOutput(subcommand as VisualizeSubcommand, format);
-  writeOutput(output, args.options.output);
+  return writeOutput(output, args.options.output);
 }


### PR DESCRIPTION
Completes the #3210 CommandResult migration begun in #3941. Closes the two gaps #3941 left open.

## Gap 1 — remaining void-returning handlers migrated

Every CLI command handler dispatched from `cli-commands.ts` now RETURNS its exit code (a `CliExitResult`) instead of calling `process.exit` inline. The single `process.exit` lives at the dispatcher boundary in `exitWith()`. All migrations are behavior-preserving — exit codes are byte-identical (each mapped before changing; oddities preserved, nothing silently "fixed").

| Handler | File | Before (exit) | After (returned exitCode) |
| --- | --- | --- | --- |
| `handleScaffoldCommand` | cli-scaffold-handler.ts | `exit(3)` bad args; `exit(0\|1)` from status | `cliExit(3)`; `cliExitFromStatus` |
| `handleReleaseNotesCommand` | cli-release-handlers.ts | `exit(0\|1)` | `cliExitFromStatus` |
| `handleReleaseValidateCommand` | cli-release-handlers.ts | `exit(0\|1)` | `cliExitFromStatus` |
| `handleReleaseAnnounceCommand` | cli-release-handlers.ts | `exit(0\|1)` | `cliExitFromStatus` |
| `handleVisualizeCommand` | cli/visualize-command.ts | `exit(0)` usage / `exit(3)` bad sub / `exit(1)` write-fail (floating `.catch`) | now async, awaits write; `cliExit(0\|3\|1)` |
| `handleCapabilitiesCommand` | cli/capabilities-command.ts | `exit(0)` usage / `exit(3)` bad sub & arg errors | `cliExit(0\|3)` |
| `handleModeCommand` | cli/mode-command.ts | `exit(0)` | `cliExit(0)` |
| `handleScenarioCommand` | cli/scenario-command.ts | `exit(0)` list / `exit(1)` errors & fail | `cliExit(0\|1)` |
| `handleValidateCommand` | cli/validate-command.ts | `exit(allPassed?0:1)` | `cliExit(0\|1)` |
| `handleLoginCommand` | cli/login-command.ts | `exit(0\|1)` truth table | `cliExit(0\|1)` |
| `handleAuthCommand` | cli-auth-handler.ts | `status`→login exit; else `process.exitCode=1` on fail (natural exit) | forwards login result; `cliExitFromStatus(0\|1)` (authCommand now returns success bool) |
| `handleMigrateCommand` | cli/migrate-command.ts | `exit(1)` on fail (natural 0) | `cliExit(0\|1)` |
| `handleMemoryBenchmarkCommand` | cli/memory-benchmark-command.ts | `process.exitCode=1` on fail (natural exit) | `cliExit(0\|1)` |
| `handleStatusCommand` | cli/status-command.ts | void (natural 0) | `cliExit(0)` |
| `handleHealthCommand` | cli/health-command.ts | void (natural 0) | `cliExit(0)` |
| `handleUsageCommand` | cli/usage-command.ts | void (natural 0) | `cliExit(0)` |
| `handleImprovementReviewCommand` | cli/improvement-review-command.ts | void (natural 0) | `cliExit(0)` |
| `handleAutoRemediateCommand` | cli/auto-remediate-command.ts | void (natural 0) | `cliExit(0)` |
| `handleRemediationReviewCommand` | cli/remediation-review-command.ts | void (natural 0); throws on bad input (unchanged) | `cliExit(0)` |

Note: the `server` / `orchestrator` subtree (`cli-server.ts`, `cli-orchestrator.ts`) deliberately owns its own process lifecycle — its deep `process.exit` calls are left as-is and `handleServerCommand` now returns the lifecycle sentinel (see Gap 2). Same for the session valid-subcommand path.

## Gap 2 — explicit lifecycle sentinel (the #3941 Contrarian's type-safety fix)

Added to `cli-types.ts`:
- `LIFECYCLE_DELEGATED` — a branded const a lifecycle-owning handler RETURNS to mean "I own my own exit; do nothing at the dispatcher".
- `LifecycleDelegated` type + `isLifecycleDelegated()` guard (brand-property check, robust across module/test-mock copies).
- `CliHandlerResult = CliExitResult | LifecycleDelegated` — the exhaustive handler contract with **no** `undefined`/`void` member.

`handleServerCommand` and `handleSessionCommand` (the two lifecycle-owning handlers) now RETURN `LIFECYCLE_DELEGATED` instead of a bare `undefined`. `exitWith()` handles the union exhaustively: a `CliExitResult` → `process.exit(exitCode)`; the sentinel → no-op. No `void` fallthrough.

The two `// eslint-disable @typescript-eslint/no-invalid-void-type` suppressions in `cli-commands.ts` are **removed** — the sentinel makes the union exhaustive without them.

### The union is now exhaustive — a dropped return is a compile error

`noImplicitReturns` was **not** previously on and I did **not** enable it. The lever is the explicit return type: a handler declared `CliExitResult | LifecycleDelegated` (excluding `undefined`) that drops a return path is **TS2366** ("Function lacks ending return statement and return type does not include 'undefined'") — verified independent of `noImplicitReturns`. So the void hole cannot silently reopen.

## Tests

- Per-handler return-contract assertions updated to assert the exact prior exit code for success + failure (scaffold, release ×3, visualize, capabilities, login, auth, memory-benchmark).
- `cli-commands.test.ts`: handler mocks return the sentinel; the old "returns undefined ⇒ no exit" test rewritten to "returns LIFECYCLE_DELEGATED ⇒ no exit".
- New `cli-lifecycle-sentinel.test.ts`: proves the guard matches the sentinel and never a `CliExitResult`, plus **compile-time** assertions that `CliHandlerResult` admits exactly two members with no `undefined`/`void` — so the hole can't reopen.

## Gates

- Changeset `.changeset/finish-command-result-3942.md` (`'nexus-agents': patch`, refactor).
- `tsc --noEmit` clean; eslint clean on all changed files; the two void-type disables confirmed gone (`grep` finds none).
- Full CLI vitest suite green (6356 passed / 8 skipped e2e). `COMMAND_CATALOG` / `cli-command-help` counts untouched (no commands added) and pass.
- Zero `any`; no new MCP tool; no new CLI command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)