### PR TITLE
docs: configuration for reusable pipelines (#3253)

### DIFF
--- a/.changeset/config-reuse-docs-3253.md
+++ b/.changeset/config-reuse-docs-3253.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+docs: add "Configuration for Reusable Pipelines" section to CONFIGURATION.md (#3253)
+
+Documents configuration composition and the project-level vs user-level split:
+how billing mode, data dir / repo-preferred, and model tiers / sandbox affect a
+composed pipeline; which settings belong in a committed project config vs
+per-user environment overrides; and how the loader resolves them (single-file
+selection, first match wins, with env vars overlaying per-setting). Claims
+verified against `config-loader.ts`, `nexus-data-dir.ts`, and
+`decision-cost-recording.ts`.

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -767,6 +767,37 @@ logging:
   format: json
 ```
 
+## Configuration for Reusable Pipelines
+
+A composed pipeline (research → vote → plan → run → review) inherits the same resolved config at every stage, so a single knob changes behavior fleet-wide. Three high-impact knobs and what they do across stages:
+
+- **`NEXUS_BILLING_MODE`** — `plan` (default) zeroes model cost in scoring, so routing's `ZeroRouter`/TOPSIS stages pick the strongest model regardless of price; every voter, planner, and worker in the pipeline trends toward `claude-opus`-tier. `api` keeps cost-aware routing, so the same pipeline shifts toward cheaper tiers under the session budget. Verified in `decision-cost-recording.ts` (default `'plan'`) and `defaults.ts:298`.
+- **`NEXUS_DATA_DIR` / `NEXUS_REPO_PREFERRED`** — per-repo state (`sessions`, `checkpoints`, `traces`, `runs`, `audit`, `pipeline`, `tasks`, `jobs`, `ci-health`) lands in `<repo>/.nexus-agents/` when `NEXUS_REPO_PREFERRED=1` (default), so two checkouts keep independent run/audit history. `NEXUS_DATA_DIR` overrides the split entirely. Cross-repo state — `learning/`, `memory`, `voting`, `research`, `auth` — always resolves to `~/.nexus-agents/`, so the routing-feedback loop is shared across projects regardless (`nexus-data-dir.ts`).
+- **Model tiers + sandbox** — `models.tiers` (`fast`/`balanced`/`powerful`) and `models.default` feed the router at every stage; `security.sandbox.mode` (`none`/`policy`/`container`) bounds every `execute_command` the pipeline issues.
+
+### Project-level vs user-level
+
+The loader selects **one** config file (first match wins): `NEXUS_CONFIG_PATH`, then `./.nexus-agents/nexus-agents.yaml` or `./nexus-agents.yaml`, then `~/.nexus-agents/nexus-agents.yaml`. It does not merge a project file with a user file. Per-setting **environment variables** overlay the loaded file at consumption time, so use them — not a second file — for local overrides.
+
+Commit the **project file** for shared, reproducible choices: `models.tiers`/`default`, `routing` weights, gate modes (`NEXUS_ACCESS_POLICY_MODE`, `NEXUS_POLICY_GATE_MODE`), and `security.sandbox.mode`. Keep **machine-specific** settings out of the repo and set them per-user via env: API keys (`ANTHROPIC_API_KEY`, …), `NEXUS_DATA_DIR`, `NEXUS_SANDBOX_ROOT`, and `NEXUS_BILLING_MODE`. Committed config defines the team's pipeline; each env var wins over it locally.
+
+```yaml
+# nexus-agents.yaml (committed)
+models:
+  default: claude-sonnet
+  tiers:
+    powerful: [claude-opus, codex-5.3]
+security:
+  sandbox: { mode: policy }
+```
+
+```bash
+# each teammate, locally (not committed)
+export ANTHROPIC_API_KEY=...
+export NEXUS_BILLING_MODE=api   # cost-aware on a personal key
+export NEXUS_DATA_DIR=/scratch/nexus
+```
+
 ## Related Documentation
 
 - [CLI Usage](../ENTRYPOINTS.md) - Use configuration in CLI commands


### PR DESCRIPTION
Closes #3253.

Adds a **"Configuration for Reusable Pipelines"** section to `docs/getting-started/CONFIGURATION.md` (~300 words), covering what the existing reference omits: configuration *composition* and the *project-level vs user-level* split for sharing a pipeline across a team.

## What the section covers

**Composition effects** (pick 3 high-impact knobs, pipeline-level not one-liner):
- `NEXUS_BILLING_MODE` — `plan` (default) zeroes model cost in scoring so routing trends to the strongest tier at every stage; `api` keeps cost-aware routing.
- `NEXUS_DATA_DIR` / `NEXUS_REPO_PREFERRED` — per-repo run/audit/trace state vs always-cross-repo `learning/`/`memory`/`voting`; `NEXUS_DATA_DIR` overrides the split.
- Model tiers + `security.sandbox.mode` — feed the router / bound `execute_command` at every stage.

**Project-level vs user-level** — commit shared/reproducible choices (model tiers, routing weights, gate modes, sandbox mode); keep machine-specific values (API keys, data dir, sandbox root, billing mode) as per-user env vars. Includes a minimal committed YAML + local-env example, and how precedence resolves conflicts (env wins per-setting).

## Verified against code (not invented)

| Claim | Source |
| --- | --- |
| `plan` default + cost-zeroing in scoring; `api` cost-aware | `packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts`, `src/config/defaults.ts:298` |
| `NEXUS_DATA_DIR` overrides split; `NEXUS_REPO_PREFERRED` default ON; per-repo subdir list; `learning/`+memory+voting always cross-repo | `packages/nexus-agents/src/config/nexus-data-dir.ts` |
| Loader selects a **single** file (first match wins): `NEXUS_CONFIG_PATH` → `./.nexus-agents/nexus-agents.yaml` / `./nexus-agents.yaml` → `~/.nexus-agents/nexus-agents.yaml`; does **not** merge project+user files | `packages/nexus-agents/src/config/config-loader.ts:108-138` (`findConfigPath`, `CONFIG_LOOKUP_PATHS`) |
| Env vars overlay per-setting at consumption time | `packages/nexus-agents/src/config/defaults-env.ts` |
| `models.tiers` (fast/balanced/powerful) + `models.default` consumed by router | `src/config/schemas.ts`, `schemas-routing.ts` |

**Note on an existing-doc discrepancy (not touched here):** the file's current "Configuration Precedence" section describes a 4-level *merge* (env → project → user → default) with user config at `~/.config/nexus-agents/config.yaml`. The code instead selects **one** file (no project+user merge) and the global path is `~/.nexus-agents/nexus-agents.yaml`; env vars overlay per-setting separately. The new section documents the real behavior accurately. The pre-existing section was left unchanged to keep this PR scoped to the new content; the precedence-section accuracy fix can be a follow-up.

## Gates
- Changeset `.changeset/config-reuse-docs-3253.md` (`'nexus-agents': patch`, type docs).
- Prose only — no code / governance / workflow files touched.
- `markdownlint --config .markdownlint.json` passes clean.
- `git diff --stat`: only CONFIGURATION.md + changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)