### PR TITLE
docs: correct Configuration Precedence to match the loader (#3945)

### DIFF
--- a/.changeset/precedence-accuracy-3945.md
+++ b/.changeset/precedence-accuracy-3945.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+docs: correct the Configuration Precedence section to match the loader (#3945)
+
+The section claimed a 4-level merge (env → project → user → default) with a user
+config at `~/.config/nexus-agents/config.yaml`. The loader (`config-loader.ts`)
+actually selects ONE file (first match wins: `NEXUS_CONFIG_PATH` → project
+`./.nexus-agents/nexus-agents.yaml`/`./nexus-agents.yaml` → user
+`~/.nexus-agents/nexus-agents.yaml`), layered over defaults, with env vars
+overlaying per-setting at consumption time — not a multi-file merge, and not the
+`~/.config/...` path. Corrected to the real behavior; consistent with the
+"Configuration for Reusable Pipelines" section (#3253).

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -11,12 +11,13 @@ Configure nexus-agents with YAML files, environment variables, and programmatic 
 
 ## Configuration Precedence
 
-Configuration is loaded in order of precedence (highest to lowest):
+The loader selects **one** config file — the **first match wins**, it does NOT merge multiple files:
 
-1. **Environment variables** (`NEXUS_*` prefix)
-2. **Project config** (`./nexus-agents.yaml` in current directory)
-3. **User config** (`~/.config/nexus-agents/config.yaml`)
-4. **Default values**
+1. `NEXUS_CONFIG_PATH` (explicit path), else
+2. **Project config** — `./.nexus-agents/nexus-agents.yaml` or `./nexus-agents.yaml` (current directory), else
+3. **User config** — `~/.nexus-agents/nexus-agents.yaml`
+
+Whatever single file is selected is layered over the built-in **defaults**. Then **environment variables** (`NEXUS_*`) overlay the result **per-setting at consumption time** — so an env var overrides just that one key, and env vars (not a second config file) are the right tool for machine-local overrides. See [Configuration for Reusable Pipelines](#configuration-for-reusable-pipelines) for the project-vs-local split.
 
 ## Quick Setup
 


### PR DESCRIPTION
Fixes #3945. The 'Configuration Precedence' section claimed a 4-level **merge** (env → project → user → default) with user config at `~/.config/nexus-agents/config.yaml`. Verified against `src/config/config-loader.ts`: the loader selects **one** file (first match wins: `NEXUS_CONFIG_PATH` → `./.nexus-agents/nexus-agents.yaml`/`./nexus-agents.yaml` → `~/.nexus-agents/nexus-agents.yaml`) over defaults, with env vars overlaying **per-setting** at consumption time. Corrected to the real behavior and cross-linked to the #3253 reusable-pipelines section. Prose-only; changeset added.