### PR TITLE
fix(remediation): isolate soak/shadow tests from the production data dir (#3932)

### DIFF
--- a/.changeset/soak-test-isolation-3932.md
+++ b/.changeset/soak-test-isolation-3932.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+fix(remediation): isolate soak/shadow tests from the production data dir (#3932)
+
+The auto-remediation cycle's default durable soak sink resolves under
+`NEXUS_DATA_DIR` (falling back to `~/.nexus-agents/learning/remediation-soak.jsonl`).
+Audit-mode cases in `auto-remediation-cycle.test.ts` ran `runAutoRemediationCycle`
+without injecting a `soakSink`, so synthetic fixture records (signalKeys `a`/`b`)
+were written into the operator's real home-dir soak file — inflating the
+enforce-readiness `volume` criterion with non-real data.
+
+The cycle test now pins `NEXUS_DATA_DIR` to a throwaway temp dir for the whole
+suite (with singleton reset + cleanup), a regression guard asserts the soak file
+resolves under the temp data dir and never the home dir, and the readiness read
+path now drops structurally-implausible soak records (signalKeys lacking the real
+`category:detail` shape) as defense-in-depth so junk can't inflate the volume count.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
@@ -3,15 +3,41 @@
  * Off-by-default short-circuit; audit drives the full path on injected signals/deps.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { runAutoRemediationCycle } from './auto-remediation-cycle.js';
 import { buildAutoRemediationDeps } from './auto-remediation-deps.js';
-import { createRemediationSoakSink } from './improvement-remediation-shadow.js';
+import {
+  createRemediationSoakSink,
+  getRemediationSoakFile,
+  _resetRemediationSoakSinkForTests,
+} from './improvement-remediation-shadow.js';
 import type { ImprovementSignal } from './improvement-review.js';
+
+// The cycle's DEFAULT durable soak sink resolves under NEXUS_DATA_DIR (#3932).
+// Pin it to a throwaway temp dir for the whole suite so audit-mode cycles that
+// do NOT inject a soakSink (the cases below that omit it) accumulate synthetic
+// signal evidence in isolation — never in the operator's real
+// ~/.nexus-agents/learning/remediation-soak.jsonl, which the readiness gate reads.
+let dataDir: string;
+let prevDataDir: string | undefined;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'cycle-datadir-'));
+  prevDataDir = process.env['NEXUS_DATA_DIR'];
+  process.env['NEXUS_DATA_DIR'] = dataDir;
+  _resetRemediationSoakSinkForTests(); // drop any cached singleton so the temp dir wins
+});
+
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+  else process.env['NEXUS_DATA_DIR'] = prevDataDir;
+  _resetRemediationSoakSinkForTests();
+  rmSync(dataDir, { recursive: true, force: true });
+});
 
 function signal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
   return {
@@ -31,6 +57,36 @@ describe('runAutoRemediationCycle', () => {
     const r = await runAutoRemediationCycle({ mode: 'off' }, { collectSignals });
     expect(r.mode).toBe('off');
     expect(collectSignals).not.toHaveBeenCalled();
+  });
+
+  // #3932 regression guard: the durable soak file MUST honor NEXUS_DATA_DIR so a
+  // test can never silently write synthetic records into the operator's real
+  // ~/.nexus-agents/learning/remediation-soak.jsonl (the readiness gate's input).
+  describe('soak path isolation (#3932 regression guard)', () => {
+    it('getRemediationSoakFile resolves under NEXUS_DATA_DIR, not the home dir', () => {
+      const file = getRemediationSoakFile();
+      expect(file.startsWith(dataDir)).toBe(true);
+      expect(file).toContain(join('learning', 'remediation-soak.jsonl'));
+      expect(file.startsWith(join(homedir(), '.nexus-agents'))).toBe(false);
+    });
+
+    it('an audit cycle with NO injected soakSink writes only under the temp data dir', async () => {
+      const homeSoak = join(homedir(), '.nexus-agents', 'learning', 'remediation-soak.jsonl');
+      const homeExistedBefore = existsSync(homeSoak);
+      const deps = buildAutoRemediationDeps({
+        voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+      });
+
+      await runAutoRemediationCycle(
+        { mode: 'audit' },
+        { collectSignals: async () => Promise.resolve([signal({ signalKey: 'a' })]), deps }
+      );
+
+      // The default sink resolved under the temp data dir and wrote there.
+      expect(existsSync(getRemediationSoakFile())).toBe(true);
+      // The real home-dir file's existence is unchanged by this test.
+      expect(existsSync(homeSoak)).toBe(homeExistedBefore);
+    });
   });
 
   it('audit mode collects signals and runs the path (zero writes)', async () => {

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
@@ -372,11 +372,45 @@ export function summarizeRemediationSoak(
   };
 }
 
-/** Read + summarize the durable soak evidence from disk (convenience for #3764). */
+/**
+ * Conservative sanity check on a soak record's `signalKey` (#3932). Real keys
+ * are emitted by `improvement_review` and always carry the `category:detail`
+ * shape (e.g. `routing:cli-floor:codex:docs`, `bug:failure-concentration:auth`,
+ * `tech-debt:fitness-below-floor`): at least one `:` with a non-empty segment on
+ * each side. Synthetic test fixtures that leaked into the durable file used bare
+ * single tokens (`a`, `b`, `x`) with no colon. Rejecting those keeps obviously-
+ * junk records from inflating the readiness `volume` criterion.
+ *
+ * Intentionally permissive: it requires only the colon-delimited shape, NOT a
+ * known category enum — a legitimate future category must never be dropped. Any
+ * real key passes; only structureless tokens fail.
+ */
+export function isPlausibleSoakSignalKey(signalKey: string): boolean {
+  const colon = signalKey.indexOf(':');
+  if (colon <= 0) return false; // no colon, or empty category before it
+  return colon < signalKey.length - 1; // a non-empty detail follows the colon
+}
+
+/**
+ * Drop obviously-synthetic soak records before they reach the readiness gate
+ * (#3932 defense-in-depth). Conservative: only records whose `signalKey` lacks
+ * the real `category:detail` shape are discarded — see {@link isPlausibleSoakSignalKey}.
+ */
+export function filterPlausibleSoakRecords(
+  records: readonly RemediationSoakRecord[]
+): readonly RemediationSoakRecord[] {
+  return records.filter((r) => isPlausibleSoakSignalKey(r.signalKey));
+}
+
+/**
+ * Read + summarize the durable soak evidence from disk (convenience for #3764).
+ * Filters out structurally-implausible records first (#3932) so junk fixtures
+ * that may have leaked into the file can't inflate the readiness volume count.
+ */
 export function readRemediationSoakSummary(
   sink: IRecordingRemediationSoakSink = getRemediationSoakSink()
 ): RemediationSoakSummary {
-  return summarizeRemediationSoak(sink.getRecords());
+  return summarizeRemediationSoak(filterPlausibleSoakRecords(sink.getRecords()));
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-soak.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-soak.test.ts
@@ -13,6 +13,8 @@ import {
   scrubSoakRecord,
   summarizeRemediationSoak,
   readRemediationSoakSummary,
+  isPlausibleSoakSignalKey,
+  filterPlausibleSoakRecords,
   SOAK_MAX_RECORDS,
   type RemediationSoakRecord,
 } from './improvement-remediation-shadow.js';
@@ -164,5 +166,49 @@ describe('summarizeRemediationSoak', () => {
     const s = readRemediationSoakSummary(sink);
     expect(s.total).toBe(2);
     expect(s.approvalRate).toBeCloseTo(0.5, 5);
+  });
+});
+
+// #3932 defense-in-depth: the readiness gate's volume criterion reads soak.total,
+// so structureless test fixtures that leak into the durable file must not count.
+describe('synthetic-record sanity filter (#3932)', () => {
+  it('accepts real category:detail signalKeys', () => {
+    for (const key of [
+      'routing:cli-floor:codex:docs',
+      'bug:failure-concentration:auth',
+      'tech-debt:fitness-below-floor',
+      'consensus:rejection-pattern:scope',
+    ]) {
+      expect(isPlausibleSoakSignalKey(key)).toBe(true);
+    }
+  });
+
+  it('rejects structureless synthetic keys (no category:detail shape)', () => {
+    for (const key of ['a', 'b', 'x', '', ':', ':trailing', 'leading:']) {
+      expect(isPlausibleSoakSignalKey(key)).toBe(false);
+    }
+  });
+
+  it('filterPlausibleSoakRecords drops only the junk records', () => {
+    const records = [
+      rec({ signalKey: 'routing:cli-floor:codex:docs' }),
+      rec({ signalKey: 'a' }),
+      rec({ signalKey: 'b' }),
+      rec({ signalKey: 'tech-debt:fitness-below-floor' }),
+    ];
+    const kept = filterPlausibleSoakRecords(records);
+    expect(kept.map((r) => r.signalKey)).toEqual([
+      'routing:cli-floor:codex:docs',
+      'tech-debt:fitness-below-floor',
+    ]);
+  });
+
+  it('readRemediationSoakSummary excludes synthetic records from the volume count', () => {
+    const sink = createRemediationSoakSink(filePath);
+    sink.record(rec({ signalKey: 'routing:cli-floor:codex:docs' }));
+    sink.record(rec({ signalKey: 'a' })); // synthetic — must not inflate volume
+    sink.record(rec({ signalKey: 'b' })); // synthetic — must not inflate volume
+    const s = readRemediationSoakSummary(sink);
+    expect(s.total).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #3932.

## Problem
The auto-remediation enforce-readiness gate reads the durable soak sink `~/.nexus-agents/learning/remediation-soak.jsonl` (via `summarizeRemediationShadow` → `soak.total` → `shadowSelections`). The cycle's default soak sink (`getRemediationSoakSink()`) resolves under `NEXUS_DATA_DIR`, falling back to that home-dir file.

### Which tests were writing to the real soak file
Only **`auto-remediation-cycle.test.ts`**. Two audit-mode cases called `runAutoRemediationCycle({ mode: 'audit' }, ...)` **without** injecting a `soakSink`, so `buildSoakCollector` fell through to the default durable singleton and persisted synthetic records into the operator's home-dir file:
- `audit mode collects signals and runs the path` → wrote `routing:cli-floor:codex:docs`
- `forwards every collected signal to the run` → wrote **signalKeys `a` and `b`** (the synthetic records the issue calls out)

Confirmed against the live file: 105 records, **70** of them synthetic `a`/`b`.

The other six soak/shadow/readiness test files were already isolated — they either use in-memory sinks (`createRemediationShadowSink`), inject an explicit temp-file `createRemediationSoakSink(join(tmpdir(), ...))`, or set `NEXUS_DATA_DIR` to a `mkdtempSync` dir + reset the singleton (`auto-remediation-deps.test.ts`, `remediation-review-command.test.ts`). The e2e test always injects a recording sink and uses throwaway git repos.

## How they were isolated
`auto-remediation-cycle.test.ts` now pins `NEXUS_DATA_DIR` to a `mkdtempSync` temp dir for the **whole suite** (`beforeEach`/`afterEach`), with `_resetRemediationSoakSinkForTests()` on both ends and `rmSync` cleanup. This protects every case in the file — including future ones — regardless of whether they inject a sink. The writer already honors `NEXUS_DATA_DIR` via `nexusDataPath('learning', ...)` (`learning` is a cross-repo subdir; an explicit `NEXUS_DATA_DIR` overrides it), so no production-path threading was needed.

## Regression guard
Added in the cycle test:
- `getRemediationSoakFile()` resolves under the temp `NEXUS_DATA_DIR` and **not** under `~/.nexus-agents` — so a future test can't silently write to production.
- An audit cycle with **no** injected soakSink writes only under the temp dir and leaves the home-dir file's existence unchanged.

## Sanity filter (added — defense-in-depth, the issue's preferred option)
`readRemediationSoakSummary()` now drops structurally-implausible records before summarizing, via the new `isPlausibleSoakSignalKey` / `filterPlausibleSoakRecords`. Real keys always carry the `category:detail` shape (`routing:cli-floor:codex:docs`, `tech-debt:fitness-below-floor`, …); the synthetic leaks were bare tokens (`a`, `b`, `x`). The check is conservative — it requires only the colon-delimited shape, **not** a known category enum — so no legitimate record (including future categories) is dropped. This means the readiness `volume` criterion can no longer be inflated by junk even if some leaked into the file historically.

## Home-dir file
Per the issue, I did **not** clean the owner's real `~/.nexus-agents/learning/remediation-soak.jsonl` — that runtime home-dir state is out of repo scope and the one-time cleanup is the owner's local action. Verified the file (105 lines, mtime 2026-06-17) was **not** touched by the test run after this change.

## Gates
- `tsc --noEmit` clean; eslint clean on the 3 changed files; all 7 soak/shadow/readiness suites green (**61 tests**).
- Changeset `.changeset/soak-test-isolation-3932.md` (`'nexus-agents': patch`, `fix`). Zero `any`; no new MCP tool / CLI command; new exports consumed in-`src` (`readRemediationSoakSummary` → `filterPlausibleSoakRecords` → `isPlausibleSoakSignalKey`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)