### PR TITLE
fix(ci): collect script tests in the CI run (#3952)

### DIFF
--- a/.changeset/ci-script-tests-3952.md
+++ b/.changeset/ci-script-tests-3952.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+test(ci): collect repo-root script tests in the CI run (#3952)
+
+The package vitest config only globs `packages/nexus-agents/src/**`, so the
+`scripts/**/*.test.ts` files (the doc generators and drift gates shipped in
+#3688/#3949 and others) were never collected by CI — they passed locally but
+gave zero CI protection. This adds a root `vitest.config.ts` that collects them
+(excluding stale `.claude/` worktree copies), a `test:scripts` npm script, and a
+`Script Tests` CI job that builds `nexus-memory` first then runs the suite.
+
+Collecting these tests immediately surfaced a real bug masked by the missing
+coverage: `scripts/check-mcp-description-drift.test.ts` passed the raw
+`TOOL_MANIFEST` objects to `buildDriftReport` (which expects tool _names_, as
+the CLI gate does), so every lookup missed; fixed to `.map((t) => t.name)`.
+
+`scripts/inject-governance.test.ts` is scoped out for now: it spawns ~30 `npx
+tsx` subprocesses that mutate shared repo files in place, takes ~400s solo, and
+is flaky under the forks pool. The governance `check` it exercises is already
+gated in CI via `docs-check.yml`, so its protection is not lost. Tracked for a
+parallel-safe/fast rework in #3954.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,26 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # The repo-root scripts/ tests (generators + drift gates) are NOT collected
+  # by the package suite above (its vitest config only globs packages/.../src),
+  # so they ran only locally and gave zero CI protection (#3952). This job runs
+  # them via the root vitest.config.ts.
+  script-tests:
+    name: Script Tests
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/setup-node
+
+      # generate-tool-reference.test.ts transitively imports tool schemas that
+      # reach `nexus-memory`; build it first (mirrors docs-check.yml).
+      - name: Build nexus-memory (workspace dep)
+        run: pnpm --filter nexus-memory build
+
+      - name: Run script tests
+        run: pnpm test:scripts
+
   fitness-audit:
     name: Fitness Audit (${{ matrix.os }})
     runs-on: ${{ vars.CI_RUNNER || matrix.os }}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "turbo build",
     "test": "turbo test",
     "test:coverage": "turbo test:coverage",
+    "test:scripts": "vitest run",
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
     "lint:arch": "npx tsx scripts/arch-lint.ts",
@@ -91,7 +92,8 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vitest": "^4.1.9",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/nexus-agents:
     dependencies:

--- a/scripts/check-mcp-description-drift.test.ts
+++ b/scripts/check-mcp-description-drift.test.ts
@@ -74,7 +74,14 @@ describe('similarity (overlap coefficient)', () => {
 });
 
 describe('live gate: runtime vs doc-table descriptions agree (#3528)', () => {
-  const report = buildDriftReport([...TOOL_MANIFEST], TOOL_DESCRIPTIONS);
+  // TOOL_MANIFEST entries are `{ name, annotations, sideEffects }` objects;
+  // buildDriftReport (and the CLI gate, check-mcp-description-drift.ts main())
+  // take the tool *names*. Passing the raw objects made every lookup miss —
+  // a bug masked while these tests were uncollected by CI (#3952).
+  const report = buildDriftReport(
+    TOOL_MANIFEST.map((t) => t.name),
+    TOOL_DESCRIPTIONS
+  );
 
   it('every manifest tool has a TOOL_DESCRIPTIONS entry', () => {
     expect(report.missingDocEntry).toEqual([]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,66 @@
+/**
+ * Root Vitest Configuration for the repo-root scripts tests.
+ *
+ * The package suite (packages/nexus-agents/vitest.config.ts) only globs the
+ * package src tree, so the script tests under scripts/ (the generators and
+ * drift gates: generate-tool-reference, curate-pr-review, check-drift, etc.)
+ * were never collected by CI and gave zero protection (issue #3952). This
+ * root config collects them and is wired into the CI test path.
+ *
+ * Forks pool plus per-test isolation mirror the package config. The timeout is
+ * raised above Vitest's 5s default because several script tests dynamically
+ * import the package TypeScript schema sources (transform cost) or spawn
+ * `npx tsx` subprocesses against the real repo.
+ *
+ * @module vitest.config
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['scripts/**/*.test.ts'],
+    exclude: [
+      'node_modules',
+      '**/node_modules/**',
+      'dist',
+      // Stale per-agent git worktrees carry duplicate copies of the script
+      // tests with broken module resolution; never collect them.
+      '.claude/**',
+      '**/.claude/**',
+      'packages/**',
+      // scripts/inject-governance.test.ts spawns ~30 `npx tsx` subprocesses
+      // that mutate shared repo files (server.json, AGENTS.md) in place. It
+      // takes ~400s solo and is flaky under the forks pool (subprocess
+      // contention trips the per-call timeout), so it is scoped out here and
+      // tracked for a rework. The governance `check` it exercises is already
+      // gated in CI via .github/workflows/docs-check.yml, so collection of
+      // this test is not what provides that protection. Re-include once it is
+      // made parallel-safe and fast. Tracked in #3954.
+      'scripts/inject-governance.test.ts',
+    ],
+
+    // Forks pool for process isolation (mirrors the package config); each test
+    // file runs in its own Node.js process. Several script tests shell out to
+    // npx tsx, so keep concurrency bounded to avoid subprocess contention.
+    pool: 'forks',
+    isolate: true,
+    maxWorkers: 4,
+
+    // Script tests dynamically import TS schema sources or spawn subprocesses;
+    // the 5s default is too tight for the cold transform and subprocess paths.
+    testTimeout: 60000,
+    hookTimeout: 30000,
+
+    reporters: ['default'],
+    environment: 'node',
+    globals: true,
+
+    sequence: {
+      shuffle: false,
+    },
+
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Problem (#3952)
The package vitest config (`packages/nexus-agents/vitest.config.ts`) only globs `src/**`, and there was no root vitest config. The repo-root `scripts/**/*.test.ts` files — the doc generators and drift gates, including those just shipped in #3688/#3949 — were therefore **never collected by CI**. They passed locally and gave zero CI protection.

## Investigation: ran the script tests as CI would, before changing config
Ran vitest over `scripts/` from the repo root. Findings per file (26 test files at repo root):

- **25 files / 297 tests PASS** cleanly and quickly (~13s) once two environment issues were handled:
  - **5s default timeout too tight**: `generate-tool-reference.test.ts` dynamically imports the package's TS schema sources (transform cost) and timed out at the 5s default; passes with a raised timeout (the per-file run is ~13s).
  - **`zod` unresolvable from repo-root cwd**: `build-model-registry-helpers.test.ts` failed to load — its source `build-model-registry-types.ts` has a static `import { z } from 'zod'`, but `zod` was only a `packages/nexus-agents` dep, not resolvable from the root. Fixed by adding `zod` to root devDependencies.
  - **`.claude/worktrees/` contamination**: a root glob also swept stale per-agent worktree copies of the script tests (broken module resolution); excluded in the config.

- **1 real bug surfaced** (exactly the kind of defect #3952 is about): `check-mcp-description-drift.test.ts` passed the raw `TOOL_MANIFEST` (an array of `{name, annotations, sideEffects}` objects) to `buildDriftReport`, which expects tool **names** (as the CLI gate `main()` does via `.map(t => t.name)`). Every lookup missed → all 46 tools reported "missing doc entry". The CLI gate was correct; only the never-run test was wrong. **Fixed** to `.map((t) => t.name)`.

- **1 file scoped out**: `inject-governance.test.ts`. It spawns ~30 `npx tsx` subprocesses that mutate shared repo files (`server.json`, `AGENTS.md`, `CLAUDE.md`) in place, runs ~400s solo, and is **flaky under the forks pool** (subprocess contention trips the 30s per-call timeout; concurrent mutation breaks the broken-fixture assertions — observed as a clean pass on one run and ~19 failed subtests on the next from an identical tree). In isolation it passes but at ~400s would threaten the CI budget. Its governance `check` is **already gated in CI via `docs-check.yml`**, so excluding the test loses no protection. Filed **#3954** to make it parallel-safe + fast, then re-include.

## Change
- New root `vitest.config.ts` globbing `scripts/**/*.test.ts` (forks pool, isolate, 60s timeout), excluding `.claude/`, `packages/`, `node_modules`, and the scoped-out `inject-governance.test.ts`.
- `test:scripts` script in root `package.json`.
- New `Script Tests` CI job that builds `nexus-memory` first (mirrors `docs-check.yml`, since the tool-reference test transitively imports it) then runs `pnpm test:scripts`.
- `zod` added to root devDependencies.
- Bug fix in `check-mcp-description-drift.test.ts`.
- Changeset `ci-script-tests-3952.md` (`'nexus-agents': patch`).

## Result (exact CI command)
`pnpm test:scripts` → **Test Files 25 passed (25), Tests 297 passed (297)**, ~13s, exit 0. Stable across repeated runs.

## Scoped out / follow-up
- `scripts/inject-governance.test.ts` → **#3954** (parallel-safe + fast rework; protection already covered by `docs-check.yml`).

## Judgment calls
- Did NOT force a red gate — fixed the trivial/legitimate failures (timeout, zod resolution, the manifest-name bug) and scoped out the one test needing real rework rather than wiring a 400s flaky test into CI.
- Added a separate `Script Tests` CI job rather than folding into the package `test` job, for an independent signal and because the scripts run from repo-root cwd with their own config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)