### PR TITLE
test(cli): command-metadata parity gate to prevent dispatch/catalog drift (#3212)

### DIFF
--- a/.changeset/command-parity-gate-3212.md
+++ b/.changeset/command-parity-gate-3212.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+test(cli): command-metadata parity gate to prevent dispatch/catalog drift (#3212)
+
+Add `command-parity.test.ts` asserting the real invariant between the three
+parallel command-name structures — the dispatch tables (`cli-commands.ts`),
+`COMMAND_CATALOG` (`cli-command-catalog.ts`), and `VALID_COMMANDS`
+(`cli-types.ts`) — so drift (e.g. #3713's `auto-remediate` silent
+MCP-server fallthrough) fails CI with the offending command named.
+
+The gate asserts: dispatch ⊆ catalog, catalog ⊆ dispatch, and
+`VALID_COMMANDS` == dispatchable, with a small documented `ALLOWED_ASYMMETRY`
+allowlist (`(default)` catalog pseudo-entry; special-cased `help`/`version`).
+Adds a minimal `listDispatchableCommands()` export to `cli-commands.ts` and
+exports the existing `VALID_COMMANDS` const so the test derives sets from the
+real dispatch tables rather than re-listing names. No dispatch refactor, no
+unified registry, no new CLI command or MCP tool.

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -333,6 +333,36 @@ const ASYNC_COMMAND_HANDLERS: Record<
 };
 
 /**
+ * Commands dispatched outside the {@link SYNC_COMMAND_HANDLERS} /
+ * {@link ASYNC_COMMAND_HANDLERS} tables because they have special exit
+ * behavior: `help` and `version` are intercepted at the top of
+ * {@link handleSyncCommand} and `process.exit` immediately. They are real,
+ * routable commands (present in `VALID_COMMANDS`) and so count as
+ * "dispatchable" for the parity gate (#3212), but they intentionally carry
+ * no `COMMAND_CATALOG` metadata (they are rendered by the `--help` header,
+ * not the commands list).
+ */
+const SPECIAL_DISPATCH_COMMANDS: readonly string[] = ['help', 'version'];
+
+/**
+ * Lists every command name the dispatcher can route (#3212): the union of the
+ * sync and async dispatch-table keys plus the special-cased `help`/`version`
+ * commands. This is the authoritative "dispatchable" set — the parity gate
+ * (`command-parity.test.ts`) asserts it against `COMMAND_CATALOG` and
+ * `VALID_COMMANDS` to catch drift between the parallel command structures.
+ *
+ * Exported solely so the test can derive the set from the real dispatch tables
+ * rather than re-listing command names (which would itself drift).
+ */
+export function listDispatchableCommands(): readonly string[] {
+  return [
+    ...Object.keys(SYNC_COMMAND_HANDLERS),
+    ...Object.keys(ASYNC_COMMAND_HANDLERS),
+    ...SPECIAL_DISPATCH_COMMANDS,
+  ];
+}
+
+/**
  * Handles async commands that require await.
  */
 async function handleAsyncCommand(args: ParsedCliArgs): Promise<void> {

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -613,7 +613,13 @@ export const PARSE_ARGS_CONFIG = {
   strict: true,
 } as const;
 
-const VALID_COMMANDS: readonly CliCommand[] = [
+/**
+ * Every command name {@link isValidCommand} accepts. Exported so the parity
+ * gate (`command-parity.test.ts`, #3212) can assert it stays consistent with
+ * the real dispatch tables and `COMMAND_CATALOG`, rather than trusting the
+ * `isValidCommand` predicate alone.
+ */
+export const VALID_COMMANDS: readonly CliCommand[] = [
   'server',
   'help',
   'version',

--- a/packages/nexus-agents/src/command-parity.test.ts
+++ b/packages/nexus-agents/src/command-parity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Command-metadata PARITY GATE (Issue #3212, Option B — vote-decided 7-0).
+ *
+ * #3212's dispatch refactor already shipped: dispatch is table-driven
+ * (`SYNC_COMMAND_HANDLERS` / `ASYNC_COMMAND_HANDLERS` in `cli-commands.ts`),
+ * `COMMAND_CATALOG` (`cli-command-catalog.ts`) is the metadata source, and
+ * `VALID_COMMANDS` (`cli-types.ts`) is the routing allowlist. Those three are
+ * PARALLEL command-name structures maintained by hand, so they DRIFT — #3713
+ * is the canonical example (`auto-remediate` was dispatchable + cataloged but
+ * absent from `VALID_COMMANDS`, so the CLI silently started the MCP server).
+ *
+ * This gate asserts the REAL invariant between the three structures so that
+ * drift fails CI with the offending command named. It deliberately does NOT
+ * assert blanket set-equality — there are legitimate, documented asymmetries
+ * (see {@link ALLOWED_ASYMMETRY}). It builds NO unified registry and refactors
+ * NO dispatch (the vote rejected both).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { listDispatchableCommands } from './cli-commands.js';
+import { COMMAND_CATALOG } from './cli-command-catalog.js';
+import { VALID_COMMANDS } from './cli-types.js';
+
+/**
+ * Documented, legitimate asymmetries between the command structures. Every
+ * entry needs a one-line justification for WHY it is exempt; the gate must
+ * not force deleting intentional behavior. Keep this list as small as the
+ * truth allows — anything here is a structure the parity check would
+ * otherwise flag.
+ */
+const ALLOWED_ASYMMETRY = {
+  /**
+   * In `COMMAND_CATALOG` but intentionally NOT dispatchable. These have no
+   * entry in either dispatch table by design.
+   */
+  catalogNotDispatchable: new Set<string>([
+    // Pseudo-entry: the no-arg invocation (`nexus-agents`) runs the MCP
+    // server. There is no `(default)` handler — `server` is the dispatchable
+    // form. `catalogForExtractors()` already strips it for the same reason.
+    '(default)',
+  ]),
+  /**
+   * Dispatchable (routable) but intentionally NOT in `COMMAND_CATALOG`. These
+   * are real commands the dispatcher routes but that carry no catalog metadata
+   * by design.
+   */
+  dispatchableNotCatalog: new Set<string>([
+    // `help` / `version` are intercepted at the top of `handleSyncCommand`
+    // with special `process.exit` behavior (not via the dispatch tables) and
+    // are rendered by the `--help` HEADER, not the COMMANDS list — so they
+    // correctly carry no `COMMAND_CATALOG` entry.
+    'help',
+    'version',
+  ]),
+} as const;
+
+/** Sorted symmetric set helpers — keep failure messages deterministic. */
+function diff(a: ReadonlySet<string>, b: ReadonlySet<string>): string[] {
+  return [...a].filter((x) => !b.has(x)).sort((x, y) => x.localeCompare(y));
+}
+
+describe('command parity gate (#3212)', () => {
+  const dispatchable = new Set(listDispatchableCommands());
+  const catalog = new Set(COMMAND_CATALOG.map((e) => e.command));
+  const valid = new Set<string>(VALID_COMMANDS);
+
+  it('lists dispatchable commands with no duplicates across the sync/async/special sets', () => {
+    const raw = listDispatchableCommands();
+    expect(
+      new Set(raw).size,
+      `duplicate dispatchable command name(s): ${raw
+        .filter((c, i) => raw.indexOf(c) !== i)
+        .join(', ')}`
+    ).toBe(raw.length);
+  });
+
+  // ── dispatch ⊆ catalog ────────────────────────────────────────────────────
+  // Every command the dispatcher routes must have catalog metadata, so it
+  // shows up in `--help`, the entrypoint extractor, and the repo-index. The
+  // only exemptions are the special-cased `help`/`version` (see allowlist).
+  it('every dispatchable command has COMMAND_CATALOG metadata (minus allowed asymmetry)', () => {
+    const offenders = diff(dispatchable, catalog).filter(
+      (c) => !ALLOWED_ASYMMETRY.dispatchableNotCatalog.has(c)
+    );
+    expect(
+      offenders,
+      `dispatchable but MISSING from COMMAND_CATALOG: ${offenders.join(', ')}. ` +
+        `Add a catalog entry (correct, surfaced behavior) or, if intentionally ` +
+        `metadata-free, add to ALLOWED_ASYMMETRY.dispatchableNotCatalog with a reason.`
+    ).toEqual([]);
+  });
+
+  // ── catalog ⊆ dispatch ────────────────────────────────────────────────────
+  // Every cataloged command must be dispatchable, else `--help` advertises a
+  // command the CLI cannot route. Only `(default)` (the pseudo no-arg entry)
+  // is exempt.
+  it('every COMMAND_CATALOG command is dispatchable (minus allowed asymmetry)', () => {
+    const offenders = diff(catalog, dispatchable).filter(
+      (c) => !ALLOWED_ASYMMETRY.catalogNotDispatchable.has(c)
+    );
+    expect(
+      offenders,
+      `in COMMAND_CATALOG but NOT dispatchable: ${offenders.join(', ')}. ` +
+        `This advertises a command with no handler — investigate for a removed/renamed ` +
+        `handler (real bug), or add to ALLOWED_ASYMMETRY.catalogNotDispatchable if intentional.`
+    ).toEqual([]);
+  });
+
+  // ── VALID_COMMANDS == dispatchable ─────────────────────────────────────────
+  // `VALID_COMMANDS` carries no independent data — it is the routing allowlist
+  // and must be EXACTLY the dispatchable set. A valid-but-undispatchable
+  // command routes to nothing; a dispatchable-but-invalid command is rejected
+  // by `isValidCommand` and silently falls through to the MCP server (#3713).
+  it('VALID_COMMANDS equals the dispatchable set exactly', () => {
+    const validNotDispatchable = diff(valid, dispatchable);
+    const dispatchableNotValid = diff(dispatchable, valid);
+    expect(
+      validNotDispatchable,
+      `in VALID_COMMANDS but NOT dispatchable (routes to nothing): ${validNotDispatchable.join(
+        ', '
+      )}`
+    ).toEqual([]);
+    expect(
+      dispatchableNotValid,
+      `dispatchable but NOT in VALID_COMMANDS (isValidCommand rejects it → silent ` +
+        `MCP-server fallthrough, cf. #3713): ${dispatchableNotValid.join(', ')}`
+    ).toEqual([]);
+  });
+
+  // Guard the allowlist itself: a stale exemption (for a command that no longer
+  // exists, or that is now correctly symmetric) should be removed so the list
+  // stays honest.
+  it('ALLOWED_ASYMMETRY has no stale entries', () => {
+    const staleCatalogNotDispatchable = [...ALLOWED_ASYMMETRY.catalogNotDispatchable].filter(
+      (c) => !(catalog.has(c) && !dispatchable.has(c))
+    );
+    expect(
+      staleCatalogNotDispatchable,
+      `ALLOWED_ASYMMETRY.catalogNotDispatchable lists command(s) that are no longer ` +
+        `catalog-only: ${staleCatalogNotDispatchable.join(', ')}`
+    ).toEqual([]);
+    const staleDispatchableNotCatalog = [...ALLOWED_ASYMMETRY.dispatchableNotCatalog].filter(
+      (c) => !(dispatchable.has(c) && !catalog.has(c))
+    );
+    expect(
+      staleDispatchableNotCatalog,
+      `ALLOWED_ASYMMETRY.dispatchableNotCatalog lists command(s) that are no longer ` +
+        `dispatch-only: ${staleDispatchableNotCatalog.join(', ')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Issue #3212 — Option B (vote-decided 7-0): a command-registry PARITY GATE

Most of #3212 already shipped (table-driven dispatch, `COMMAND_CATALOG` metadata source, #3211 suggestions). The only remaining work was closing the DRIFT risk between the three parallel command-name structures. This PR does exactly that — **no dispatch refactor, no unified `CommandRegistry`, no tools-cli-mapping** (all rejected/deferred by the vote).

### The invariant asserted

`command-parity.test.ts` derives three sets and asserts the real invariant (NOT blanket set-equality):

- **dispatchable** = keys of `SYNC_COMMAND_HANDLERS` ∪ keys of `ASYNC_COMMAND_HANDLERS` ∪ the special-cased `help`/`version`, via a new minimal `listDispatchableCommands()` export in `cli-commands.ts`.
- **catalog** = `COMMAND_CATALOG` command names (`cli-command-catalog.ts`).
- **valid** = `VALID_COMMANDS` (`cli-types.ts`), now exported (it was previously module-private behind `isValidCommand`).

Assertions:
1. **dispatch ⊆ catalog** — every dispatchable command has catalog metadata (minus allowlist).
2. **catalog ⊆ dispatch** — every cataloged command is dispatchable (minus allowlist).
3. **VALID_COMMANDS == dispatchable** — `VALID_COMMANDS` carries no independent data, so it must equal the dispatchable set exactly. This is the #3713 class of bug: a dispatchable-but-invalid command is rejected by `isValidCommand` and silently falls through to starting the MCP server.
4. **No duplicate dispatchable names** and **no stale `ALLOWED_ASYMMETRY` entries** (each allowlist entry must still be a live asymmetry).

On failure, every assertion names the offending command(s) and which structure they're missing from (sorted symmetric difference per pair).

### ALLOWED_ASYMMETRY (documented, justified)

- `catalogNotDispatchable`:
  - `(default)` — pseudo catalog entry for the no-arg `nexus-agents` invocation (runs the MCP server). No `(default)` handler exists; `server` is the dispatchable form. `catalogForExtractors()` already strips it for the same reason.
- `dispatchableNotCatalog`:
  - `help`, `version` — intercepted at the top of `handleSyncCommand` with special `process.exit` behavior (not via the dispatch tables), and rendered by the `--help` HEADER rather than the COMMANDS list, so they correctly carry no catalog metadata.

### Drift found

**None.** Running the gate against `main`, the only asymmetries present are exactly the three allowlisted intentional ones (`(default)`, `help`, `version`); `VALID_COMMANDS` already equals the dispatchable set. The stale-entry guard confirms each allowlist entry is a genuine live asymmetry. No catalog entries needed adding and no real bug surfaced — the structures are currently consistent, and this gate locks that in.

### Confirmation

- No dispatch refactor; no unified CommandRegistry; no tools-cli-mapping.
- No new CLI command or MCP tool — only an exported helper function (`listDispatchableCommands`) and an existing const made `export` (`VALID_COMMANDS`). **repo-index / entrypoints.yaml unaffected** (entrypoint extraction reads `catalogForExtractors()`, which is unchanged).
- Zero `any`.
- Gates green: `tsc --noEmit`, eslint on the 3 changed files, the new test + all 25 `cli-*` suites (390 tests).

Changeset: `.changeset/command-parity-gate-3212.md` (`'nexus-agents': patch`, type `test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)