### PR TITLE
feat(governance): vote-record tamper-evident set + monotonic sequence — merge-safe ledger (#3927 PR-1)

### DIFF
--- a/.changeset/vote-record-set-model-3927.md
+++ b/.changeset/vote-record-set-model-3927.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): convert the authentic vote-record ledger from a linear hash
+chain to a tamper-evident record SET + monotonic sequence (#3927 PR-1).
+
+The `governance/vote-records.jsonl` ledger is a multi-branch committable
+artifact, so the chain model (each record's hash folding in the prior record's
+hash) could not survive a concurrent-branch git merge. The revised model
+(design vote 7-0, Option B) treats the ledger as an unordered SET of self-hashed
+records plus a monotonic `sequence`:
+
+- New required `sequence` field (integer ≥ 0); record `version` bumped `1.0` →
+  `1.1`. `previousHash` is now advisory/optional and NOT verified.
+- The self-hash covers `sequence` but EXCLUDES `previousHash`, so hashes are
+  position-independent and stable across merges and file reorders.
+- `verifyVoteRecordChain` → `verifyVoteRecordSet`. New verification reasons:
+  `sequence_gap` (omission) added; `previous_hash_mismatch` removed. Duplicate
+  sequences are a benign concurrent-fork signal (surfaced as `forks`), not a
+  failure.
+- `.gitattributes`: `governance/vote-records.jsonl merge=union` for conflict-free
+  append merges.
+
+The separate audit-event/tier-transition chain is unchanged (single-writer
+runtime — still a real chain). Fail-closed enforcement is deferred to PR-2; this
+seam remains warn-only/unenforced.

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,10 @@
 *.jpg binary
 *.ico binary
 *.woff2 binary
+
+# Authentic vote-record ledger (#3927). A tamper-evident record SET + monotonic
+# sequence (not a linear hash chain): each line is a self-hashed, position-
+# independent record. Concurrent branches that each append a vote produce
+# independent lines, so a union merge concatenates them conflict-free —
+# duplicate sequences are a benign fork signal, not corruption.
+governance/vote-records.jsonl merge=union

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -59,7 +59,8 @@ export type { ChainVerification } from './audit-logger.js';
 // Storage
 export { FileAuditStorage, InMemoryAuditStorage } from './audit-storage.js';
 
-// Authentic vote record (#3897) — committable, hash-chained, tamper-evident.
+// Authentic vote record (#3897, model revised #3927) — committable,
+// tamper-evident record SET + monotonic sequence (merge-safe; not a chain).
 export {
   VoteRecordSchema,
   VoterSummarySchema,
@@ -67,7 +68,7 @@ export {
   VoteRecordDecisionSchema,
   computeVoteRecordHash,
   hashProposal,
-  verifyVoteRecordChain,
+  verifyVoteRecordSet,
 } from './vote-record.js';
 export type {
   VoteRecord,

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -1,13 +1,15 @@
 /**
- * Tests for the authentic vote-record store (#3897): a completed vote persists
- * an authentic record carrying the proposal hash + decision + per-voter summary,
- * the record is append-only and round-trips, and tampering with a persisted
- * line is detected by chain verification.
+ * Tests for the authentic vote-record store (#3897, model revised #3927): a
+ * completed vote persists a self-hashed record carrying the proposal hash +
+ * decision + per-voter summary + monotonic `sequence`. The record is append-only
+ * and round-trips, persisted sequences increment, tampering is detected as a
+ * `hash_mismatch`, and the ledger survives a simulated concurrent-branch merge
+ * (duplicate sequence → benign fork, not a failure).
  *
  * @module audit/vote-record-store.test
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -16,7 +18,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult, VoterRole } from '../cli/vote-types.js';
 
-import { verifyVoteRecordChain } from './vote-record.js';
+import { verifyVoteRecordSet } from './vote-record.js';
 import { buildVoteRecord, persistVoteRecord, readVoteRecords } from './vote-record-store.js';
 
 function vote(decision: Vote['decision'], confidence: number): Vote {
@@ -55,7 +57,7 @@ const votes: readonly AgentVoteResult[] = [
 ];
 
 describe('buildVoteRecord', () => {
-  it('carries the proposal hash, decision, counts, and per-voter summary', () => {
+  it('carries the proposal hash, decision, counts, per-voter summary, and a sequence', () => {
     const record = buildVoteRecord({
       id: 'vote-1',
       proposal: 'Promote loop X to enforce',
@@ -63,6 +65,8 @@ describe('buildVoteRecord', () => {
       result: consensusResult(),
       votes,
     });
+    expect(record.version).toBe('1.1');
+    expect(record.sequence).toBe(0); // default first sequence
     expect(record.decision).toBe('approved');
     expect(record.proposalHash).toHaveLength(64);
     expect(record.approvalPercentage).toBeCloseTo(66.7);
@@ -72,7 +76,7 @@ describe('buildVoteRecord', () => {
       { role: 'security', decision: 'approve', confidence: 0.8 },
       { role: 'catfish', decision: 'reject', confidence: 0.8 },
     ]);
-    expect(verifyVoteRecordChain([record])).toEqual({ ok: true, recordCount: 1 });
+    expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
   });
 
   it('excludes error-source voters from the per-voter summary', () => {
@@ -99,7 +103,7 @@ describe('persistVoteRecord', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('persists an authentic record that round-trips through read', () => {
+  it('persists a self-hashed record that round-trips through read', () => {
     const written = persistVoteRecord({
       id: 'vote-1',
       proposal: 'Promote loop X to enforce',
@@ -116,8 +120,8 @@ describe('persistVoteRecord', () => {
     expect(records[0]).toEqual(written);
   });
 
-  it('is append-only and chains each record onto the prior one', () => {
-    persistVoteRecord({
+  it('assigns an incrementing sequence and an advisory previousHash on append', () => {
+    const first = persistVoteRecord({
       id: 'vote-1',
       proposal: 'first',
       strategy: 'higher_order',
@@ -125,7 +129,7 @@ describe('persistVoteRecord', () => {
       votes,
       filePath,
     });
-    persistVoteRecord({
+    const second = persistVoteRecord({
       id: 'vote-2',
       proposal: 'second',
       strategy: 'higher_order',
@@ -136,12 +140,16 @@ describe('persistVoteRecord', () => {
 
     const { records } = readVoteRecords(filePath);
     expect(records).toHaveLength(2);
+    expect(records[0]!.sequence).toBe(0);
+    expect(records[1]!.sequence).toBe(1);
     expect(records[0]!.previousHash).toBeUndefined();
-    expect(records[1]!.previousHash).toBe(records[0]!.hash);
-    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 2 });
+    // previousHash is advisory (set to the prior tip) but NOT verified.
+    expect(records[1]!.previousHash).toBe(first!.hash);
+    expect(second!.sequence).toBe(1);
+    expect(verifyVoteRecordSet(records)).toEqual({ ok: true, recordCount: 2 });
   });
 
-  it('detects tampering with a persisted line (decision flip) via chain verification', () => {
+  it('detects tampering with a persisted line (decision flip) via set verification', () => {
     persistVoteRecord({
       id: 'vote-1',
       proposal: 'p',
@@ -158,9 +166,57 @@ describe('persistVoteRecord', () => {
     const { records } = readVoteRecords(filePath);
     expect(records).toHaveLength(1);
     expect(records[0]!.decision).toBe('approved'); // the forged value is present...
-    const result = verifyVoteRecordChain(records);
-    expect(result.ok).toBe(false); // ...but the chain rejects it
+    const result = verifyVoteRecordSet(records);
+    expect(result.ok).toBe(false); // ...but verification rejects it
     if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('survives a simulated two-branch concurrent merge (merge=union) as a benign fork', () => {
+    // Branch base: one record at sequence 0.
+    persistVoteRecord({
+      id: 'vote-base',
+      proposal: 'base proposal',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+      filePath,
+    });
+    const baseRaw = readFileSync(filePath, 'utf-8');
+
+    // Two branches each fork from the same tip and append THEIR OWN sequence-1
+    // record (each computed the same max sequence = 0 → next = 1).
+    const branchA = buildVoteRecord({
+      id: 'vote-A',
+      proposal: 'branch A proposal',
+      strategy: 'higher_order',
+      result: consensusResult({ approvalPercentage: 71 }),
+      votes,
+      sequence: 1,
+    });
+    const branchB = buildVoteRecord({
+      id: 'vote-B',
+      proposal: 'branch B proposal',
+      strategy: 'higher_order',
+      result: consensusResult({ outcome: 'rejected', approvalPercentage: 33 }),
+      votes,
+      sequence: 1,
+    });
+
+    // Simulate what `merge=union` produces: base line + both branch lines.
+    writeFileSync(filePath, baseRaw, 'utf-8');
+    appendFileSync(filePath, JSON.stringify(branchA) + '\n', 'utf-8');
+    appendFileSync(filePath, JSON.stringify(branchB) + '\n', 'utf-8');
+
+    const { records, invalidLines } = readVoteRecords(filePath);
+    expect(invalidLines).toEqual([]);
+    expect(records).toHaveLength(3);
+
+    const result = verifyVoteRecordSet(records);
+    expect(result.ok).toBe(true); // a concurrent fork is NOT a failure
+    if (result.ok) {
+      expect(result.recordCount).toBe(3);
+      expect(result.forks).toEqual([1]); // the duplicated sequence is surfaced
+    }
   });
 
   it("skips persistence when every vote is simulated is the caller's job; store itself writes given real votes", () => {

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -1,19 +1,25 @@
 /**
- * nexus-agents/audit - Authentic Vote Record Store (#3897)
+ * nexus-agents/audit - Authentic Vote Record Store (#3897, model revised #3927)
  *
  * Persists a completed `consensus_vote` to a COMMITTABLE, append-only,
- * hash-chained artifact at vote time, distinct from the per-developer home-dir
+ * tamper-evident artifact at vote time, distinct from the per-developer home-dir
  * stores (`~/.nexus-agents/voting`, `~/.nexus-agents/learning`) a CI gate cannot
  * read. The artifact lives at `<repo-root>/governance/vote-records.jsonl` so the
- * promotion gate (#3895) can read it from CI; authenticity rests on the
- * payload-covering hash chain ({@link verifyVoteRecordChain}), not on manual
- * YAML transcription.
+ * promotion gate (#3895) can read it from CI; authenticity rests on a
+ * payload-covering tamper-evident record set + monotonic sequence
+ * ({@link verifyVoteRecordSet}), not on manual YAML transcription.
  *
  * DRY/drift hazard (DevEx, #3897). This is the AUTOMATED authoring path: the
  * record is written as a side effect of the live vote, so the committed artifact
  * cannot drift from what actually happened the way a hand-edited
- * `ratification-votes.yaml` entry can. The chain links each new record to the
- * last persisted one, so a forged/edited line breaks verification.
+ * `ratification-votes.yaml` entry can. Each record is self-hashed (covering its
+ * `sequence`), so a forged/edited line breaks verification.
+ *
+ * MERGE SAFETY (#3927). The ledger is a SET, not a chain: `sequence` is assigned
+ * as (max existing sequence)+1, and the self-hash excludes `previousHash`, so
+ * two branches that each append from the same tip merge conflict-free under the
+ * `governance/vote-records.jsonl merge=union` attribute. Duplicate sequences
+ * from such a merge are a benign fork signal, not tampering.
  *
  * @module audit/vote-record-store
  */
@@ -63,13 +69,25 @@ export interface BuildVoteRecordInput {
   readonly votes: readonly AgentVoteResult[];
   readonly correlationId?: string | undefined;
   readonly recordedAt?: string | undefined;
+  /**
+   * Monotonic sequence number for this record (#3927). Defaults to 0 (first
+   * record) when omitted; the producer ({@link persistVoteRecord}) supplies
+   * (max existing sequence)+1.
+   */
+  readonly sequence?: number | undefined;
+  /**
+   * Advisory tip hash (audit texture only). NOT covered by the self-hash and
+   * NOT verified — retained so a reviewer can see the write-time tip (#3927).
+   */
   readonly previousHash?: string | undefined;
 }
 
 /**
- * Construct a fully-hashed {@link VoteRecord} from a completed vote, chained to
- * `previousHash`. Pure (no I/O) so it is unit-testable and reusable by the gate
- * seam. The proposal is hashed in full but stored truncated.
+ * Construct a fully self-hashed {@link VoteRecord} from a completed vote. Pure
+ * (no I/O) so it is unit-testable and reusable by the gate seam. The self-hash
+ * covers `sequence` but EXCLUDES `previousHash`, so the record is
+ * position-independent (#3927). The proposal is hashed in full but stored
+ * truncated.
  */
 export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
   const proposalTruncated =
@@ -77,8 +95,9 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
       ? input.proposal.slice(0, MAX_PROPOSAL_RECORD_CHARS) + '...'
       : input.proposal;
   const payload: Omit<VoteRecord, 'hash'> = {
-    version: '1.0',
+    version: '1.1',
     id: input.id,
+    sequence: input.sequence ?? 0,
     recordedAt: input.recordedAt ?? new Date().toISOString(),
     proposalHash: hashProposal(input.proposal),
     proposal: proposalTruncated,
@@ -98,19 +117,29 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
   return { ...payload, hash: computeVoteRecordHash(payload) };
 }
 
-/** Read the last persisted record's hash so the next record chains onto it. */
-function readLastHash(filePath: string, logger: ILogger): string | undefined {
-  if (!existsSync(filePath)) return undefined;
+/**
+ * Read the current ledger tip (#3927): the max existing `sequence` (so the next
+ * record gets max+1) and the last line's hash (advisory `previousHash` for audit
+ * texture only). Returns `{ maxSequence: -1, lastHash: undefined }` for an empty
+ * or unreadable file, so the first record lands at sequence 0.
+ */
+function readLedgerTip(
+  filePath: string,
+  logger: ILogger
+): { maxSequence: number; lastHash: string | undefined } {
+  if (!existsSync(filePath)) return { maxSequence: -1, lastHash: undefined };
   try {
-    const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n').filter((l) => l.trim() !== '');
-    const last = lines[lines.length - 1];
-    if (last === undefined) return undefined;
-    const parsed = VoteRecordSchema.safeParse(JSON.parse(last));
-    return parsed.success ? parsed.data.hash : undefined;
+    const { records } = readVoteRecords(filePath);
+    if (records.length === 0) return { maxSequence: -1, lastHash: undefined };
+    let maxSequence = -1;
+    for (const record of records) {
+      if (record.sequence > maxSequence) maxSequence = record.sequence;
+    }
+    const last = records[records.length - 1];
+    return { maxSequence, lastHash: last?.hash };
   } catch (error: unknown) {
-    logger.warn('Failed to read prior vote record hash', { error: getErrorMessage(error) });
-    return undefined;
+    logger.warn('Failed to read vote-record ledger tip', { error: getErrorMessage(error) });
+    return { maxSequence: -1, lastHash: undefined };
   }
 }
 
@@ -121,8 +150,9 @@ export function resolveVoteRecordsPath(): string | undefined {
   return join(root, VOTE_RECORDS_REL_PATH);
 }
 
-/** Options for {@link persistVoteRecord}. */
-export interface PersistVoteRecordOptions extends Omit<BuildVoteRecordInput, 'previousHash'> {
+/** Options for {@link persistVoteRecord}. `sequence`/`previousHash` are assigned by the store. */
+export interface PersistVoteRecordOptions
+  extends Omit<BuildVoteRecordInput, 'previousHash' | 'sequence'> {
   /** Override the artifact path (tests); defaults to the repo-root resolution. */
   readonly filePath?: string | undefined;
   readonly logger?: ILogger | undefined;
@@ -130,10 +160,12 @@ export interface PersistVoteRecordOptions extends Omit<BuildVoteRecordInput, 'pr
 
 /**
  * Persist an authentic vote record to the committable artifact at vote time.
- * Best-effort and append-only: reads the prior hash, builds a chained record,
- * and appends one JSON line. Returns the written record (or undefined when no
- * committable location exists / the write failed) — persistence never throws
- * into the vote path (an audit sink must not break the operation it observes).
+ * Best-effort and append-only: reads the ledger tip (max sequence + advisory
+ * last hash), assigns the next monotonic `sequence`, builds a self-hashed
+ * record, and appends one JSON line. Returns the written record (or undefined
+ * when no committable location exists / the write failed) — persistence never
+ * throws into the vote path (an audit sink must not break the operation it
+ * observes).
  */
 export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | undefined {
   const logger = opts.logger ?? createLogger({ component: 'vote-record-store' });
@@ -144,8 +176,12 @@ export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | 
   }
   try {
     mkdirSync(dirname(filePath), { recursive: true });
-    const previousHash = readLastHash(filePath, logger);
-    const record = buildVoteRecord({ ...opts, previousHash });
+    const { maxSequence, lastHash } = readLedgerTip(filePath, logger);
+    const record = buildVoteRecord({
+      ...opts,
+      sequence: maxSequence + 1,
+      previousHash: lastHash,
+    });
     appendFileSync(filePath, JSON.stringify(record) + '\n', 'utf-8');
     logger.info('Persisted authentic vote record', {
       id: record.id,
@@ -163,10 +199,11 @@ export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | 
 }
 
 /**
- * Read + verify the persisted vote-record chain from disk. The GATE SEAM
- * (#3897): a future `check-authority-tier-drift.ts` revision resolves a
- * `ratificationVoteRef` against these records and rejects a chain that fails
- * verification. Returns the parsed records and any line that failed to parse.
+ * Read the persisted vote-record set from disk. The GATE SEAM (#3897): a future
+ * `check-authority-tier-drift.ts` revision resolves a `ratificationVoteRef`
+ * against these records and rejects a set that fails {@link verifyVoteRecordSet}.
+ * File-line order is NOT significant (#3927) — verification treats the records
+ * as a set. Returns the parsed records and any line that failed to parse.
  */
 export function readVoteRecords(filePath: string): {
   readonly records: VoteRecord[];

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -1,8 +1,12 @@
 /**
- * Tests for the authentic vote-record hash chain (#3897). The core property:
- * tampering with a persisted record (flipping `decision`, altering
- * `approvalPercentage`, editing a voter) is DETECTED as a `hash_mismatch`,
- * because the chain hash covers the full payload — not just head fields.
+ * Tests for the authentic vote-record TAMPER-EVIDENT RECORD SET (#3897, model
+ * revised #3927). Core properties:
+ *  - tampering with a persisted record (flipping `decision`, altering
+ *    `approvalPercentage`, editing a voter) is DETECTED as a `hash_mismatch`,
+ *    because the self-hash covers the full payload (+ `sequence`), not just head
+ *    fields;
+ *  - the ledger is a SET, not a chain: order does not matter, concurrent forks
+ *    (duplicate sequences) are benign, and omission shows up as a `sequence_gap`.
  *
  * @module audit/vote-record.test
  */
@@ -10,16 +14,21 @@
 import { describe, it, expect } from 'vitest';
 
 import type { VoteRecord } from './vote-record.js';
-import { computeVoteRecordHash, verifyVoteRecordChain } from './vote-record.js';
+import { computeVoteRecordHash, verifyVoteRecordSet } from './vote-record.js';
 
+/**
+ * Build a self-hashed record at `sequence`. `previousHash` is advisory (NOT
+ * covered by the hash) — set it to prove verification ignores it.
+ */
 function makeRecord(
   id: string,
-  previousHash: string | undefined,
+  sequence: number,
   overrides: Partial<Omit<VoteRecord, 'hash'>> = {}
 ): VoteRecord {
   const payload: Omit<VoteRecord, 'hash'> = {
-    version: '1.0',
+    version: '1.1',
     id,
+    sequence,
     recordedAt: '2026-06-15T00:00:00.000Z',
     proposalHash: 'a'.repeat(64),
     proposal: 'Promote loop X from advisory to enforce',
@@ -31,62 +40,51 @@ function makeRecord(
       { role: 'architect', decision: 'approve', confidence: 0.9 },
       { role: 'security', decision: 'reject', confidence: 0.6 },
     ],
-    ...(previousHash !== undefined ? { previousHash } : {}),
     ...overrides,
   };
   return { ...payload, hash: computeVoteRecordHash(payload) };
 }
 
-function chain(...records: VoteRecord[]): VoteRecord[] {
-  // Re-link each record onto the prior one's hash, then rehash.
-  const out: VoteRecord[] = [];
-  let prev: string | undefined;
-  for (const r of records) {
-    const payload: Omit<VoteRecord, 'hash'> = {
-      version: r.version,
-      id: r.id,
-      recordedAt: r.recordedAt,
-      proposalHash: r.proposalHash,
-      proposal: r.proposal,
-      strategy: r.strategy,
-      decision: r.decision,
-      approvalPercentage: r.approvalPercentage,
-      voteCounts: r.voteCounts,
-      voters: r.voters,
-      ...(r.correlationId !== undefined ? { correlationId: r.correlationId } : {}),
-      ...(prev !== undefined ? { previousHash: prev } : {}),
-    };
-    const linked: VoteRecord = { ...payload, hash: computeVoteRecordHash(payload) };
-    out.push(linked);
-    prev = linked.hash;
-  }
-  return out;
-}
-
-describe('verifyVoteRecordChain', () => {
-  it('verifies an empty chain trivially', () => {
-    expect(verifyVoteRecordChain([])).toEqual({ ok: true, recordCount: 0 });
+describe('verifyVoteRecordSet', () => {
+  it('verifies an empty set trivially', () => {
+    expect(verifyVoteRecordSet([])).toEqual({ ok: true, recordCount: 0 });
   });
 
-  it('verifies a well-formed single-record chain', () => {
-    const records = chain(makeRecord('vote-1', undefined));
-    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 1 });
+  it('verifies a well-formed single record', () => {
+    expect(verifyVoteRecordSet([makeRecord('vote-1', 0)])).toEqual({ ok: true, recordCount: 1 });
   });
 
-  it('verifies a multi-record chain that round-trips', () => {
-    const records = chain(
-      makeRecord('vote-1', undefined),
-      makeRecord('vote-2', undefined, { decision: 'rejected', approvalPercentage: 28.5 }),
-      makeRecord('vote-3', undefined)
-    );
-    expect(verifyVoteRecordChain(records)).toEqual({ ok: true, recordCount: 3 });
+  it('verifies a multi-record set that round-trips', () => {
+    const records = [
+      makeRecord('vote-1', 0),
+      makeRecord('vote-2', 1, { decision: 'rejected', approvalPercentage: 28.5 }),
+      makeRecord('vote-3', 2),
+    ];
+    expect(verifyVoteRecordSet(records)).toEqual({ ok: true, recordCount: 3 });
+  });
+
+  it('ignores an advisory previousHash entirely (position-independent self-hash)', () => {
+    // A bogus previousHash must NOT affect verification — it is not hashed.
+    const records = [
+      makeRecord('vote-1', 0, { previousHash: 'f'.repeat(64) }),
+      makeRecord('vote-2', 1, { previousHash: '9'.repeat(64) }),
+    ];
+    expect(verifyVoteRecordSet(records)).toEqual({ ok: true, recordCount: 2 });
+  });
+
+  it('tolerates file lines reordered relative to sequence (it is a set)', () => {
+    const r0 = makeRecord('vote-1', 0);
+    const r1 = makeRecord('vote-2', 1);
+    const r2 = makeRecord('vote-3', 2);
+    // Lines out of sequence order — still ok:true.
+    expect(verifyVoteRecordSet([r2, r0, r1])).toEqual({ ok: true, recordCount: 3 });
   });
 
   it('DETECTS a flipped decision (rejected → approved) as hash_mismatch', () => {
-    const records = chain(makeRecord('vote-1', undefined, { decision: 'rejected' }));
-    // Forge: flip the decision on the persisted record WITHOUT rehashing.
-    const tampered: VoteRecord[] = [{ ...records[0]!, decision: 'approved' }];
-    const result = verifyVoteRecordChain(tampered);
+    const record = makeRecord('vote-1', 0, { decision: 'rejected' });
+    // Forge: flip the decision WITHOUT rehashing.
+    const tampered: VoteRecord[] = [{ ...record, decision: 'approved' }];
+    const result = verifyVoteRecordSet(tampered);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe('hash_mismatch');
@@ -95,39 +93,54 @@ describe('verifyVoteRecordChain', () => {
   });
 
   it('DETECTS an altered approvalPercentage as hash_mismatch', () => {
-    const records = chain(makeRecord('vote-1', undefined, { approvalPercentage: 51 }));
-    const tampered: VoteRecord[] = [{ ...records[0]!, approvalPercentage: 99 }];
-    const result = verifyVoteRecordChain(tampered);
+    const record = makeRecord('vote-1', 0, { approvalPercentage: 51 });
+    const tampered: VoteRecord[] = [{ ...record, approvalPercentage: 99 }];
+    const result = verifyVoteRecordSet(tampered);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('hash_mismatch');
   });
 
   it('DETECTS an edited voter summary as hash_mismatch', () => {
-    const records = chain(makeRecord('vote-1', undefined));
+    const record = makeRecord('vote-1', 0);
     const tampered: VoteRecord[] = [
-      {
-        ...records[0]!,
-        voters: [{ role: 'security', decision: 'approve', confidence: 0.99 }],
-      },
+      { ...record, voters: [{ role: 'security', decision: 'approve', confidence: 0.99 }] },
     ];
-    const result = verifyVoteRecordChain(tampered);
+    const result = verifyVoteRecordSet(tampered);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('hash_mismatch');
   });
 
-  it('DETECTS a broken back-link (re-ordered / spliced record) as previous_hash_mismatch', () => {
-    const records = chain(
-      makeRecord('vote-1', undefined),
-      makeRecord('vote-2', undefined),
-      makeRecord('vote-3', undefined)
-    );
-    // Drop the middle record: vote-3's previousHash no longer matches vote-1's hash.
-    const spliced = [records[0]!, records[2]!];
-    const result = verifyVoteRecordChain(spliced);
+  it('DETECTS a tampered sequence as hash_mismatch (sequence is covered by the hash)', () => {
+    const record = makeRecord('vote-1', 1);
+    const tampered: VoteRecord[] = [{ ...record, sequence: 0 }];
+    const result = verifyVoteRecordSet(tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS an omitted middle record as sequence_gap', () => {
+    // Build 0,1,2 then drop sequence 1 — a gap in the 0..2 run.
+    const spliced = [makeRecord('vote-1', 0), makeRecord('vote-3', 2)];
+    const result = verifyVoteRecordSet(spliced);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toBe('previous_hash_mismatch');
-      expect(result.recordIndex).toBe(1);
+      expect(result.reason).toBe('sequence_gap');
+      expect(result.detail).toContain('missing sequence 1');
+    }
+  });
+
+  it('treats DUPLICATE sequences (concurrent fork) as benign and surfaces them in forks', () => {
+    // Two branches each appended sequence 1 from the same tip, then merged.
+    const records = [
+      makeRecord('vote-1', 0),
+      makeRecord('vote-2a', 1, { proposal: 'branch A proposal' }),
+      makeRecord('vote-2b', 1, { proposal: 'branch B proposal' }),
+    ];
+    const result = verifyVoteRecordSet(records);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.recordCount).toBe(3);
+      expect(result.forks).toEqual([1]);
     }
   });
 });

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -1,23 +1,42 @@
 /**
- * nexus-agents/audit - Authentic Vote Record (#3897)
+ * nexus-agents/audit - Authentic Vote Record (#3897, model revised #3927)
  *
  * A committed, append-only, tamper-EVIDENT record of a completed
  * `consensus_vote`, persisted at vote time so the authority-ladder promotion
  * gate (`scripts/check-authority-tier-drift.ts`, #3895) can rest authenticity
- * on a hash chain instead of on hand-transcribed YAML.
+ * on a tamper-evident record set instead of on hand-transcribed YAML.
+ *
+ * MODEL: TAMPER-EVIDENT RECORD SET + MONOTONIC SEQUENCE (NOT a linear hash
+ * chain). #3927 (design vote 7-0, Option B). The original #3897 design was a
+ * LINEAR HASH CHAIN: each record's `hash` folded in the prior record's hash, so
+ * the order of file lines was load-bearing. That model cannot survive a
+ * concurrent-branch git merge — two branches that each append a record from the
+ * same tip produce two records claiming the same `previousHash`, and any
+ * merge-concatenation breaks the back-link check. The revised model treats the
+ * ledger as an UNORDERED SET of self-hashed records plus a monotonic `sequence`
+ * number: each record's hash is POSITION-INDEPENDENT (covers `sequence` but NOT
+ * `previousHash`), so it is stable across merges and reorders. `previousHash`
+ * is retained ADVISORILY for audit texture but does NOT participate in
+ * verification. Omission is detected via SEQUENCE GAPS; concurrent forks (two
+ * records sharing a sequence) are a BENIGN signal, not a failure.
  *
  * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
  * The audit-event chain (`computeEventHash` in audit-logger.ts) hashes only the
  * stable HEAD fields (id/timestamp/category/action/outcome/actor/previousHash)
  * and intentionally NOT `metadata` — so riding a tier-transition-style metadata
  * payload would leave the vote `decision`/`approvalPercentage` OUTSIDE the
- * chain: an attacker could flip `rejected`→`approved` in the metadata without
+ * hash: an attacker could flip `rejected`→`approved` in the metadata without
  * breaking any hash. That defeats the whole point of #3897. This record instead
  * folds EVERY authenticity-bearing field — the proposal content hash, the
- * decision, the approval percentage, the vote counts, and the per-voter
- * summary — into the chained hash, so editing any of them is detected as a
- * `hash_mismatch`. This is the tamper-evidence MVP; cryptographic
+ * decision, the approval percentage, the vote counts, the per-voter summary,
+ * and the `sequence` — into the self-hash, so editing any of them is detected
+ * as a `hash_mismatch`. This is the tamper-evidence MVP; cryptographic
  * signing/provenance (binding the record to a key) is DEFERRED (#3897 follow-up).
+ *
+ * NOTE: the separate audit-event/tier-transition chain (`audit-logger.ts`) IS
+ * still a real linear hash chain — it has a single-writer runtime and never
+ * merges concurrent branches, so the chain model holds there. Only THIS ledger
+ * (a multi-branch committable artifact) was converted to a record set.
  *
  * @module audit/vote-record
  */
@@ -52,16 +71,25 @@ export const VoteRecordCountsSchema = z
 export type VoteRecordCounts = z.infer<typeof VoteRecordCountsSchema>;
 
 /**
- * One authentic, hash-chained vote record. The `hash` covers every field above
- * it (including `previousHash`), so the record is tamper-EVIDENT: any edit to a
- * persisted line is detected by {@link verifyVoteRecordChain}.
+ * One authentic, self-hashed vote record. The `hash` covers every authenticity
+ * field INCLUDING `sequence` but EXCLUDING `previousHash`, so the record is
+ * tamper-EVIDENT and POSITION-INDEPENDENT: any edit to a persisted line is
+ * detected by {@link verifyVoteRecordSet} as a `hash_mismatch`, while reordering
+ * file lines or merging concurrent branches does NOT break the hash.
  */
 export const VoteRecordSchema = z
   .object({
-    /** Schema version for forward migrations. */
-    version: z.literal('1.0'),
+    /** Schema version. '1.1' marks the chain→record-set+sequence model (#3927). */
+    version: z.literal('1.1'),
     /** Unique record id (also usable as a `ratificationVoteRef`). */
     id: z.string().min(1),
+    /**
+     * Monotonic sequence number (integer ≥ 0). Assigned as (max existing
+     * sequence)+1 at write time. Sorted, the set of sequences must cover
+     * 0..maxSeq with no gap (omission detection); DUPLICATE sequences are a
+     * benign concurrent-fork signal, not tampering.
+     */
+    sequence: z.number().int().nonnegative(),
     /** ISO-8601 timestamp the vote was recorded. */
     recordedAt: z.string().min(1),
     /**
@@ -92,29 +120,36 @@ export const VoteRecordSchema = z
     voters: z.array(VoterSummarySchema),
     /** Optional correlation/decision id linking to the cost rollup / trace. */
     correlationId: z.string().min(1).optional(),
-    /** Hash of the previous record in the chain (absent for the first). */
+    /**
+     * ADVISORY hash of the tip record at write time (absent for the first).
+     * Retained for audit texture but NOT covered by `hash` and NOT verified —
+     * the record-set model is position-independent (#3927).
+     */
     previousHash: z.string().length(64).optional(),
-    /** SHA-256 over every field above + previousHash. */
+    /** SHA-256 over every field above EXCEPT `previousHash` (and except `hash`). */
     hash: z.string().length(64),
   })
   .strict();
 export type VoteRecord = z.infer<typeof VoteRecordSchema>;
 
-/** The payload fields (everything except `hash`) the chain hash covers. */
+/** The payload fields (everything except `hash`) — the self-hash projection. */
 type VoteRecordPayload = Omit<VoteRecord, 'hash'>;
 
 /**
  * Compute the SHA-256 over the canonical payload projection. Unlike the
- * audit-event head hash, this folds in EVERY authenticity-bearing field, so a
- * flipped `decision` or altered `approvalPercentage` changes the hash (the
- * core #3897 property). The projection is built field-by-field (not
- * `JSON.stringify(record)`) so key-order is deterministic regardless of how the
- * object was constructed.
+ * audit-event head hash, this folds in EVERY authenticity-bearing field (so a
+ * flipped `decision` or altered `approvalPercentage` changes the hash — the
+ * core #3897 property) AND the monotonic `sequence` (#3927) — but it EXCLUDES
+ * `previousHash`, so the hash is position-independent and stable across
+ * concurrent-branch merges and file reorders. The projection is built
+ * field-by-field (not `JSON.stringify(record)`) so key-order is deterministic
+ * regardless of how the object was constructed.
  */
 export function computeVoteRecordHash(payload: VoteRecordPayload): string {
   const canonical = JSON.stringify({
     version: payload.version,
     id: payload.id,
+    sequence: payload.sequence,
     recordedAt: payload.recordedAt,
     proposalHash: payload.proposalHash,
     proposal: payload.proposal,
@@ -128,7 +163,6 @@ export function computeVoteRecordHash(payload: VoteRecordPayload): string {
       confidence: v.confidence,
     })),
     correlationId: payload.correlationId ?? null,
-    previousHash: payload.previousHash ?? null,
   });
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }
@@ -139,25 +173,25 @@ export function hashProposal(proposal: string): string {
 }
 
 /**
- * Discriminated result from {@link verifyVoteRecordChain}. Mirrors the audit
- * `ChainVerification` shape so a future gate consumer handles both uniformly.
+ * Discriminated result from {@link verifyVoteRecordSet}. On success it may
+ * surface `forks` — the sequence numbers that appear on more than one record
+ * (a benign concurrent-branch signal, NOT tampering). On failure it names the
+ * tamper/omission signal: `hash_mismatch` (a record's content was edited),
+ * `missing_hash` (a record carries no hash), or `sequence_gap` (a record is
+ * missing from the 0..maxSeq run — an omission).
  */
 export type VoteRecordVerification =
-  | { ok: true; recordCount: number }
+  | { ok: true; recordCount: number; forks?: number[] }
   | {
       ok: false;
-      reason: 'hash_mismatch' | 'previous_hash_mismatch' | 'missing_hash';
+      reason: 'hash_mismatch' | 'missing_hash' | 'sequence_gap';
       recordIndex: number;
       recordId: string;
       detail: string;
     };
 
-/** Per-record check; null when the record passes. */
-function verifyVoteRecord(
-  record: VoteRecord,
-  index: number,
-  priorHash: string | undefined
-): VoteRecordVerification | null {
+/** Per-record self-hash check; null when the record passes. */
+function verifyVoteRecord(record: VoteRecord, index: number): VoteRecordVerification | null {
   if (record.hash.length === 0) {
     return {
       ok: false,
@@ -165,15 +199,6 @@ function verifyVoteRecord(
       recordIndex: index,
       recordId: record.id,
       detail: `record at index ${String(index)} has no hash`,
-    };
-  }
-  if (index > 0 && record.previousHash !== priorHash) {
-    return {
-      ok: false,
-      reason: 'previous_hash_mismatch',
-      recordIndex: index,
-      recordId: record.id,
-      detail: `record at index ${String(index)} previousHash=${record.previousHash ?? '(missing)'} does not match prior record hash=${priorHash ?? '(missing)'}`,
     };
   }
   const recomputed = computeVoteRecordHash(record);
@@ -189,21 +214,83 @@ function verifyVoteRecord(
   return null;
 }
 
-/**
- * Verify a hash-chained sequence of vote records. Walks the array in order and
- * checks (a) each record's `hash` recomputes from its payload, and (b) each
- * record's `previousHash` matches the prior record's `hash`. Returns the first
- * detected tampering signal — a single tamper invalidates everything
- * downstream. An empty sequence verifies trivially.
- */
-export function verifyVoteRecordChain(records: readonly VoteRecord[]): VoteRecordVerification {
-  let priorHash: string | undefined;
-  for (let i = 0; i < records.length; i++) {
-    const record = records[i];
-    if (record === undefined) continue;
-    const failure = verifyVoteRecord(record, i, priorHash);
-    if (failure !== null) return failure;
-    priorHash = record.hash;
+/** Tally of sequence number → how many records carry it, plus the max seen. */
+interface SequenceCensus {
+  readonly counts: ReadonlyMap<number, number>;
+  readonly maxSeq: number;
+}
+
+/** Count how many records carry each sequence number and find the max. */
+function censusSequences(records: readonly VoteRecord[]): SequenceCensus {
+  const counts = new Map<number, number>();
+  let maxSeq = 0;
+  for (const record of records) {
+    counts.set(record.sequence, (counts.get(record.sequence) ?? 0) + 1);
+    if (record.sequence > maxSeq) maxSeq = record.sequence;
   }
-  return { ok: true, recordCount: records.length };
+  return { counts, maxSeq };
+}
+
+/** First missing sequence in `0..maxSeq`, or null when the run is complete. */
+function firstSequenceGap({ counts, maxSeq }: SequenceCensus): number | null {
+  for (let seq = 0; seq <= maxSeq; seq++) {
+    if (!counts.has(seq)) return seq;
+  }
+  return null;
+}
+
+/** Sequence numbers carried by more than one record (concurrent forks), ascending. */
+function forkSequences({ counts }: SequenceCensus): number[] {
+  const forks: number[] = [];
+  for (const [seq, count] of counts) {
+    if (count > 1) forks.push(seq);
+  }
+  forks.sort((a, b) => a - b);
+  return forks;
+}
+
+/**
+ * Verify a tamper-evident SET of vote records (#3927). For each record, the
+ * self-hash must recompute from its payload (covers `sequence`, excludes
+ * `previousHash`). Order of the array does NOT matter — it is a set, not a
+ * chain. Semantics:
+ *
+ * - Any record whose content was edited → `hash_mismatch`. Empty hash →
+ *   `missing_hash`. Returns the first such record (array-order scan).
+ * - The set of sequence numbers, sorted, must cover `0..maxSeq` with no missing
+ *   value. A GAP (an omitted/deleted record) → `sequence_gap` naming the first
+ *   missing sequence.
+ * - DUPLICATE sequence numbers are a BENIGN concurrent-fork signal (two branches
+ *   appended from the same tip, then merged): NOT a failure. They are surfaced
+ *   on the success result as `forks` (the duplicated sequence numbers, ascending).
+ *
+ * An empty set verifies trivially.
+ */
+export function verifyVoteRecordSet(records: readonly VoteRecord[]): VoteRecordVerification {
+  // 1) Self-hash every record (order-independent).
+  for (let i = 0; i < records.length; i++) {
+    const failure = verifyVoteRecord(records[i] as VoteRecord, i);
+    if (failure !== null) return failure;
+  }
+
+  if (records.length === 0) return { ok: true, recordCount: 0 };
+
+  // 2) Sequence coverage: 0..maxSeq with no gap (omission); forks are benign.
+  const census = censusSequences(records);
+  const gap = firstSequenceGap(census);
+  if (gap !== null) {
+    const anchor = records[0] as VoteRecord;
+    return {
+      ok: false,
+      reason: 'sequence_gap',
+      recordIndex: 0,
+      recordId: anchor.id,
+      detail: `sequence gap: missing sequence ${String(gap)} in run 0..${String(census.maxSeq)}`,
+    };
+  }
+
+  const forks = forkSequences(census);
+  return forks.length > 0
+    ? { ok: true, recordCount: records.length, forks }
+    : { ok: true, recordCount: records.length };
 }

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -98,7 +98,8 @@ function toRecordStrategy(strategy: string): VoteRecord['strategy'] {
 }
 
 /**
- * Persist an authentic, hash-chained vote record to the committable governance
+ * Persist an authentic, self-hashed vote record (tamper-evident record set +
+ * monotonic sequence, #3927) to the committable governance
  * artifact at vote time (#3897). Best-effort: a persist failure must never fail
  * the vote, so the store swallows + logs. Skips all-simulated runs (random
  * output must not seed a committed record). Returns the written record (or


### PR DESCRIPTION
## Model change: linear hash chain → tamper-evident record SET + monotonic sequence

Implements #3927 PR-1 (design vote 7-0 → Option B). The authentic vote-record ledger at `governance/vote-records.jsonl` is a **multi-branch committable artifact**: the original #3897 design was a *linear hash chain* (each record's `hash` folded in the prior record's `hash`), which cannot survive a concurrent-branch git merge — two branches that each append from the same tip claim the same `previousHash`, and any merge-concatenation breaks the back-link check.

This PR converts the ledger to an **unordered SET of self-hashed records + a monotonic `sequence`**. This is the **precondition** for the fail-closed promotion gate; this PR keeps the seam **unenforced / warn-only**.

### Why
- Concurrent-branch merge safety: agents on different branches each record a vote; a union merge must concatenate them conflict-free without invalidating the ledger.

### What changed
- **Schema** (`vote-record.ts`): added required `sequence: number` (int ≥ 0). `previousHash` is now **advisory/optional** and **does not participate in verification**. `version` bumped `'1.0'` → `'1.1'` to mark the model change.
- **Hash projection**: `computeVoteRecordHash` now covers `sequence` but **excludes `previousHash`**, so the self-hash is **position-independent** (stable across merges and file reorders). Deterministic field-by-field key ordering preserved.
- **Producer** (`vote-record-store.ts`): `persistVoteRecord` reads the ledger tip via `readVoteRecords`, assigns `sequence = (max existing sequence) + 1` (0 if empty), and still populates `previousHash` advisorily (last record's hash).
- **Verification**: `verifyVoteRecordChain` → **`verifyVoteRecordSet(records)`**.
  - Per record: recompute self-hash → `hash_mismatch` on mismatch; empty hash → `missing_hash`.
  - **New reason `sequence_gap`**: the sorted sequence set must cover `0..maxSeq`; a missing value (omission) fails and names the gap.
  - **Duplicate sequences are BENIGN** (concurrent fork): result stays `ok:true` and surfaces them via an optional `forks?: number[]`.
  - File-line order ≠ sequence order is **tolerated** (it is a set).
  - **Removed `previous_hash_mismatch`** entirely — concurrent forks must not fail.
- **`.gitattributes`**: `governance/vote-records.jsonl merge=union` (conflict-free append of the record set), with an explanatory comment.
- **Docs honesty**: source doc-comments updated from "hash chain" → "tamper-evident record set + monotonic sequence". The separate audit-event/tier-transition chain is **untouched** (single-writer runtime — still a real chain).

### Verification reasons
| Reason | Status |
| --- | --- |
| `hash_mismatch` | kept |
| `missing_hash` | kept |
| `sequence_gap` | **added** |
| `previous_hash_mismatch` | **removed** |

### Tests
`vote-record.test.ts` + `vote-record-store.test.ts` rewritten/adapted: incrementing-sequence round-trip, self-hash verify, **simulated two-branch concurrent merge** (duplicate sequence → `ok:true` + `forks:[1]`, not a failure), sequence gap → `sequence_gap`, content tampering → `hash_mismatch`, tampered `sequence` → `hash_mismatch`, reordered file lines → still `ok:true`. No test asserts `previous_hash_mismatch`.

**Results:** `tsc --noEmit` clean, eslint clean on changed files, **18/18 vote-record tests pass**.

### Scope / non-goals
- **No fail-closed enforcement** — deferred to **PR-2**. The seam (`verifyVoteRecordSet` + `readVoteRecords`) stays warn-only/unenforced. `scripts/check-authority-tier-drift.ts` does not import the vote-record verifier (it resolves against `governance/ratification-votes.yaml`), so no behavior change there.
- No new CLI command or MCP tool; `TOOL_MANIFEST` / repo-index / `MCP_TOOL_COUNT` unaffected.

### Judgment calls
- **No back-compat alias kept.** A `verifyVoteRecordChain = verifyVoteRecordSet` alias was added initially, but eslint's `no-deprecated` flagged its re-export and a grep confirmed **no live source/script imports the old name** (only CHANGELOG history + regenerated `dist/`). Removed the alias for a clean barrel; the only call sites were the two test files, which were updated.
- **Version bump `1.0` → `1.1` (minor changeset).** The schema gains a required field and verification semantics change; the ledger is currently empty (no migration risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)