### PR TITLE
fix(governance): surface + override vote-record persistence skip so authentic votes aren't silently lost (#3927)

### DIFF
--- a/.changeset/vote-record-persist-observability-3927.md
+++ b/.changeset/vote-record-persist-observability-3927.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): surface + override vote-record persistence skip so authentic votes aren't silently lost (#3927)
+
+When the MCP server runs with a `process.cwd()` outside the repo, `resolveVoteRecordsPath()` returned `undefined` and `persistVoteRecord()` skipped the write at DEBUG level — real consensus votes were lost with no visible signal. The skip is now an actionable WARN, and a `NEXUS_VOTE_RECORDS_PATH` env var lets you force the write to an explicit absolute path. Precedence: `opts.filePath` > `NEXUS_VOTE_RECORDS_PATH` > `findRepoRoot(process.cwd())`. Caller-commits (the proposer commits the returned record bytes into `governance/vote-records.jsonl` in the promotion PR) remains the authoritative population path per the 7-0 design vote; this is observability + an escape hatch, not enforcement.

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -13,13 +13,25 @@ import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { findRepoRoot } from '../config/repo-root-detection.js';
 
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult, VoterRole } from '../cli/vote-types.js';
 
+vi.mock('../config/repo-root-detection.js', () => ({
+  findRepoRoot: vi.fn(() => null),
+}));
+
 import { verifyVoteRecordSet } from './vote-record.js';
-import { buildVoteRecord, persistVoteRecord, readVoteRecords } from './vote-record-store.js';
+import {
+  VOTE_RECORDS_PATH_ENV,
+  buildVoteRecord,
+  persistVoteRecord,
+  readVoteRecords,
+  resolveVoteRecordsPath,
+} from './vote-record-store.js';
 
 function vote(decision: Vote['decision'], confidence: number): Vote {
   return { decision, confidence, reasoning: 'because' };
@@ -229,5 +241,82 @@ describe('persistVoteRecord', () => {
       filePath,
     });
     expect(written).toBeDefined();
+  });
+});
+
+describe('vote-record path resolution / persistence escape hatch (#3927)', () => {
+  let dir: string;
+  let envFilePath: string;
+  let optsFilePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vote-records-env-'));
+    envFilePath = join(dir, 'env', 'vote-records.jsonl');
+    optsFilePath = join(dir, 'opts', 'vote-records.jsonl');
+    // findRepoRoot is mocked to null by default → no cwd-based resolution.
+    vi.mocked(findRepoRoot).mockReturnValue(null);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs(); // restore any process.env mutations made via vi.stubEnv
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('honors the env-var override path when no opts.filePath is given', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, envFilePath);
+    expect(resolveVoteRecordsPath()).toBe(envFilePath);
+
+    const written = persistVoteRecord({
+      id: 'vote-env',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+    });
+    expect(written).toBeDefined();
+
+    const { records, invalidLines } = readVoteRecords(envFilePath);
+    expect(invalidLines).toEqual([]);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual(written);
+  });
+
+  it('treats an empty/whitespace env var as unset (falls back to root detection)', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, '   ');
+    expect(resolveVoteRecordsPath()).toBeUndefined();
+  });
+
+  it('lets opts.filePath take precedence over the env var', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, envFilePath);
+
+    const written = persistVoteRecord({
+      id: 'vote-opts',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+      filePath: optsFilePath,
+    });
+    expect(written).toBeDefined();
+
+    // Written to opts path, not the env path.
+    expect(readVoteRecords(optsFilePath).records).toHaveLength(1);
+    expect(readVoteRecords(envFilePath).records).toHaveLength(0);
+  });
+
+  it('returns undefined and does not throw when no root resolves and no override is set', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined); // ensure no override
+    expect(resolveVoteRecordsPath()).toBeUndefined();
+
+    let written: ReturnType<typeof persistVoteRecord>;
+    expect(() => {
+      written = persistVoteRecord({
+        id: 'vote-none',
+        proposal: 'p',
+        strategy: 'higher_order',
+        result: consensusResult(),
+        votes,
+      });
+    }).not.toThrow();
+    expect(written!).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -39,6 +39,14 @@ import { VoteRecordSchema, computeVoteRecordHash, hashProposal } from './vote-re
 /** Repo-relative committable artifact path (read by the gate/CI). */
 export const VOTE_RECORDS_REL_PATH = 'governance/vote-records.jsonl';
 
+/**
+ * Env var to force the artifact path (#3927). When set non-empty it is used
+ * directly (treated as an absolute path) and the cwd/{@link findRepoRoot}
+ * detection is skipped — the escape hatch for running the MCP server outside the
+ * repo (e.g. co-located/CI contexts) so server-side persistence is reliable.
+ */
+export const VOTE_RECORDS_PATH_ENV = 'NEXUS_VOTE_RECORDS_PATH';
+
 /** Max proposal chars retained in the human record (full text is hashed). */
 const MAX_PROPOSAL_RECORD_CHARS = 500;
 
@@ -143,8 +151,18 @@ function readLedgerTip(
   }
 }
 
-/** Resolve the committable artifact path under the current repo root, if any. */
+/**
+ * Resolve the committable artifact path (#3927). Precedence:
+ *  1. {@link VOTE_RECORDS_PATH_ENV} (`NEXUS_VOTE_RECORDS_PATH`) when set
+ *     non-empty — used directly as an absolute path, skipping cwd detection.
+ *  2. otherwise `<repo-root>/governance/vote-records.jsonl` resolved from
+ *     {@link findRepoRoot}(`process.cwd()`).
+ * Returns `undefined` when neither yields a path (server running outside the
+ * repo with no override) — the caller surfaces this as an observable WARN.
+ */
 export function resolveVoteRecordsPath(): string | undefined {
+  const envPath = process.env[VOTE_RECORDS_PATH_ENV];
+  if (envPath !== undefined && envPath.trim() !== '') return envPath;
   const root = findRepoRoot(process.cwd());
   if (root === null) return undefined;
   return join(root, VOTE_RECORDS_REL_PATH);
@@ -153,7 +171,10 @@ export function resolveVoteRecordsPath(): string | undefined {
 /** Options for {@link persistVoteRecord}. `sequence`/`previousHash` are assigned by the store. */
 export interface PersistVoteRecordOptions
   extends Omit<BuildVoteRecordInput, 'previousHash' | 'sequence'> {
-  /** Override the artifact path (tests); defaults to the repo-root resolution. */
+  /**
+   * Override the artifact path; takes precedence over {@link VOTE_RECORDS_PATH_ENV}
+   * and the repo-root resolution (see {@link resolveVoteRecordsPath}).
+   */
   readonly filePath?: string | undefined;
   readonly logger?: ILogger | undefined;
 }
@@ -166,12 +187,29 @@ export interface PersistVoteRecordOptions
  * when no committable location exists / the write failed) — persistence never
  * throws into the vote path (an audit sink must not break the operation it
  * observes).
+ *
+ * AUTHORITATIVE POPULATION PATH (#3927, design vote 7-0): caller-commits. The
+ * proposer commits the RETURNED record bytes into
+ * `governance/vote-records.jsonl` in the promotion PR; that is what the gate
+ * reads. This server-side auto-write is only a best-effort convenience and
+ * no-ops when the server runs outside the repo and no override is set — hence
+ * the WARN below and the {@link VOTE_RECORDS_PATH_ENV} escape hatch.
+ *
+ * Path precedence: `opts.filePath` > {@link VOTE_RECORDS_PATH_ENV} >
+ * {@link findRepoRoot}(`process.cwd()`).
  */
 export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | undefined {
   const logger = opts.logger ?? createLogger({ component: 'vote-record-store' });
   const filePath = opts.filePath ?? resolveVoteRecordsPath();
   if (filePath === undefined) {
-    logger.debug('No committable repo root; skipping authentic vote record persist');
+    logger.warn(
+      'Authentic vote record NOT persisted: no repo root found from process.cwd() ' +
+        'and no override set. Per #3927 the authoritative population path is ' +
+        'caller-commits — commit the returned record bytes into ' +
+        `${VOTE_RECORDS_REL_PATH} in the promotion PR. To force a server-side ` +
+        `write, set ${VOTE_RECORDS_PATH_ENV} to an absolute file path.`,
+      { id: opts.id }
+    );
     return undefined;
   }
   try {


### PR DESCRIPTION
## The bug (silent loss)

When the MCP server runs with a `process.cwd()` outside the repo,
`resolveVoteRecordsPath()` returns `undefined`, and `persistVoteRecord()` then
logged at **DEBUG** (`'No committable repo root; skipping authentic vote record
persist'`) and silently returned. Real consensus votes were lost with no
visible signal.

**Evidence:** ~5 real votes this session left `governance/vote-records.jsonl`
at **0 bytes** because the running MCP server's cwd was outside the repo. The
only trace was a DEBUG line nobody sees.

## The fix (observability + escape hatch — NOT enforcement)

1. **Skip is now observable.** When persistence is skipped for lack of a
   committable root, we log a single actionable **WARN**: that the authentic
   record was NOT persisted, that per #3927 the authoritative population path is
   caller-commits (commit the returned record bytes into
   `governance/vote-records.jsonl` in the promotion PR), and that
   `NEXUS_VOTE_RECORDS_PATH` can force a server-side write. One WARN, not noisy.
2. **Explicit override.** New `NEXUS_VOTE_RECORDS_PATH` env var: when set
   non-empty it is used directly as an absolute path, skipping the
   cwd/`findRepoRoot` detection. Documented in `resolveVoteRecordsPath`'s
   doc-comment.
3. **Precedence (explicit and tested):**
   `opts.filePath` > `NEXUS_VOTE_RECORDS_PATH` > `findRepoRoot(process.cwd())`.
4. **Doc-comment** on `persistVoteRecord` records that caller-commits is the
   authoritative path per the 7-0 vote and that the server-side auto-write is
   best-effort.

## Authoritative path unchanged

Per the **7-0 design vote**, **caller-commits** remains the authoritative
population path (the proposer commits the returned record bytes into the ledger
in the promotion PR). This PR adds **only observability + an escape hatch** — it
does **not** add a validator, touch the CI gate, add fail-closed enforcement, or
add signing.

## Tests

`vote-record-store.test.ts` adds: env-var override honored; `opts.filePath`
takes precedence over the env var; empty/whitespace env var falls back; no-root
+ no-override returns `undefined` and does not throw. `findRepoRoot` is mocked to
null and `vi.stubEnv`/`vi.unstubAllEnvs` keep env changes deterministic.

- `tsc --noEmit`: clean
- `eslint` on changed files: clean (zero `any`)
- `vitest run vote-record-store.test.ts vote-record.test.ts`: **22 passed**

No CLI command / MCP tool added — TOOL_MANIFEST and CLI catalog untouched
(repo-index unaffected).

Changeset: `.changeset/vote-record-persist-observability-3927.md` (`'nexus-agents': patch`, type `fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)