### PR TITLE
feat(capability-loop): autonomous code-PR write-time guard library (Stage 1, OFF — no runtime activation) (#3670)

### DIFF
--- a/.changeset/codepr-guards-stage1-3670.md
+++ b/.changeset/codepr-guards-stage1-3670.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): autonomous code-PR write-time guard library (Stage 1, OFF — no runtime activation) (#3670)
+
+Adds `src/mcp/tools/codepr-guards.ts`, a pure, deterministic guard library for
+the future autonomous code-PR adapter. Stage 1 is library + tests ONLY — it
+performs NO code-generation, NO git push, NO PR-open, and wires NO flag to live
+behavior. It registers no MCP tool, CLI command, or workflow.
+
+Guards (each returns a discriminated fail-closed result, never throws for an
+expected denial): `confinePath` (path-escape confinement via realpath, with a
+test seam), `classifyPath` (sensitive-path classifier with an exported,
+staleness-tested self-guard denylist), `checkBlastRadius`, `scanDiffOrDeny`
+(wraps the #3669 secret scan), `auditAutonomousEvent` (hash-chained audit append
+for both a would-be PR and a fail-closed abort), `checkResourceBudget`, and the
+composite `evaluateWriteGuards` entry point. Satisfies binding preconditions
+A (deterministic-only decisions), B (self-modification lockout), C (audit), and
+E (dependency-manifest authorship restriction).

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Red-team / negative-path tests for the deterministic code-PR write-time guards
+ * (#3670, Stage 1). The NEGATIVE fixtures are the point: each guard must PROVE it
+ * DENIES the unsafe case, and the composite must short-circuit fail-closed. The
+ * guards take no model output, so every case is a realized filesystem/diff fact.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  confinePath,
+  classifyPath,
+  checkBlastRadius,
+  scanDiffOrDeny,
+  auditAutonomousEvent,
+  checkResourceBudget,
+  evaluateWriteGuards,
+  SELF_GUARD_MODULE_BASENAMES,
+  SENSITIVE_PATH_RULES,
+  DEFAULT_BLAST_RADIUS_LIMITS,
+  DEFAULT_RESOURCE_BUDGET_LIMITS,
+  type ChangedFile,
+  type WriteGuardsInput,
+  type AutonomousEventRecord,
+} from './codepr-guards.js';
+import type { IAuditLogger, AuditEventInput } from '../../audit/audit-types.js';
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+/** Make a tmp dir, register cleanup, return its REALPATH (macOS /var → /private/var). */
+function makeTmpRoot(): { root: string; cleanup: () => void } {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'codepr-guards-')));
+  return {
+    root: dir,
+    cleanup: () => {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** A minimal in-memory IAuditLogger capturing `log()` inputs. */
+function makeCapturingLogger(): { logger: IAuditLogger; events: AuditEventInput[] } {
+  const events: AuditEventInput[] = [];
+  const logger: IAuditLogger = {
+    log: (input) => {
+      events.push(input);
+    },
+    logToolInvocation: () => {},
+    logPolicyDecision: () => {},
+    logSecurityEvent: () => {},
+    logRateLimitViolation: () => {},
+    logTierTransition: () => {},
+    flush: async () => {},
+    close: async () => {},
+  };
+  return { logger, events };
+}
+
+const cf = (path: string, addedLines = 1, removedLines = 0): ChangedFile => ({
+  path,
+  addedLines,
+  removedLines,
+});
+
+// ----------------------------------------------------------------------------
+// Guard 1 — Path confinement
+// ----------------------------------------------------------------------------
+
+describe('confinePath', () => {
+  it('allows a legit in-root path', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      writeFileSync(join(root, 'foo.ts'), 'export const a = 1;\n');
+      const r = confinePath(root, 'foo.ts');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.resolvedPath).toBe(join(root, 'foo.ts'));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('DENIES a `..` traversal escape', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      // ../etc/passwd-style escape; the parent dir exists so realpath resolves
+      // but lands OUTSIDE the root → path_escape (not a resolve failure).
+      const r = confinePath(root, '../');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('DENIES an absolute path outside the root', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      const r = confinePath(root, realpathSync(tmpdir()));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('DENIES a symlink whose target escapes the root', () => {
+    const { root, cleanup } = makeTmpRoot();
+    const { root: outside, cleanup: cleanupOutside } = makeTmpRoot();
+    try {
+      const secretTarget = join(outside, 'escaped.txt');
+      writeFileSync(secretTarget, 'outside the worktree\n');
+      const link = join(root, 'link-to-outside');
+      symlinkSync(secretTarget, link);
+      // candidate is in-root by name, but realpath follows the symlink OUT.
+      const r = confinePath(root, 'link-to-outside');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+      cleanupOutside();
+    }
+  });
+
+  it('fail-closed: DENIES when the candidate cannot be realpath-resolved', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      const r = confinePath(root, 'does-not-exist.ts');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('fail-closed: DENIES a non-absolute worktreeRoot', () => {
+    const r = confinePath('relative/root', 'foo.ts');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('path_escape');
+  });
+
+  it('allows a nested in-root path resolved via the realpath seam', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      mkdirSync(join(root, 'src'));
+      writeFileSync(join(root, 'src', 'a.ts'), '\n');
+      const r = confinePath(root, 'src/a.ts');
+      expect(r.ok).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Guard 2 — Sensitive-path classifier
+// ----------------------------------------------------------------------------
+
+describe('classifyPath', () => {
+  it('allows a normal source file', () => {
+    expect(classifyPath('src/foo.ts')).toEqual({ sensitive: false });
+    expect(classifyPath('packages/nexus-agents/src/mcp/tools/some-tool.ts')).toEqual({
+      sensitive: false,
+    });
+  });
+
+  const sensitiveCases: Array<[string, string]> = [
+    ['governance/x', 'governance'],
+    ['governance/ratification-votes.yaml', 'governance'],
+    ['.github/workflows/ci.yml', 'workflow'],
+    ['CODEOWNERS', 'codeowners'],
+    ['.github/CODEOWNERS', 'codeowners'],
+    ['packages/nexus-agents/src/audit/audit-logger.ts', 'self_guard'], // self-guard wins over audit
+    ['src/audit/audit-storage.ts', 'audit'],
+    ['packages/nexus-agents/src/auth/token.ts', 'authority'],
+    ['src/security/authority-tier.ts', 'authority'],
+    ['package.json', 'dependency_manifest'],
+    ['packages/nexus-agents/package.json', 'dependency_manifest'],
+    ['pnpm-lock.yaml', 'dependency_manifest'],
+    ['tsconfig.json', 'dependency_manifest'],
+    ['packages/nexus-agents/tsconfig.build.json', 'dependency_manifest'],
+  ];
+  it.each(sensitiveCases)('DENIES sensitive path %s as %s', (path, category) => {
+    const c = classifyPath(path);
+    expect(c.sensitive).toBe(true);
+    if (c.sensitive) expect(c.category).toBe(category);
+  });
+
+  it('DENIES self-modification of the guard module itself', () => {
+    for (const p of [
+      'packages/nexus-agents/src/mcp/tools/codepr-guards.ts',
+      'src/mcp/tools/codepr-guards.test.ts',
+      'codepr-guards.ts',
+      'foo/codepr-guards/index.ts',
+    ]) {
+      const c = classifyPath(p);
+      expect(c.sensitive, `should lock out: ${p}`).toBe(true);
+      if (c.sensitive) expect(c.category).toBe('self_guard');
+    }
+  });
+
+  it('DENIES self-modification of every reused safety primitive', () => {
+    const reused = [
+      'packages/nexus-agents/src/mcp/tools/diff-secret-scan.ts',
+      'packages/nexus-agents/src/config/repo-root-detection.ts',
+      'packages/nexus-agents/src/audit/audit-logger.ts',
+      'packages/nexus-agents/src/audit/audit-types.ts',
+      'packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts',
+      'packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.ts',
+    ];
+    for (const p of reused) {
+      const c = classifyPath(p);
+      expect(c.sensitive, `should lock out reused primitive: ${p}`).toBe(true);
+      if (c.sensitive) expect(c.category).toBe('self_guard');
+    }
+  });
+
+  it('normalizes Windows separators and a leading ./', () => {
+    expect(classifyPath('.\\package.json').sensitive).toBe(true);
+    expect(classifyPath('./governance/x').sensitive).toBe(true);
+    expect(classifyPath('packages\\nexus-agents\\src\\audit\\x.ts').sensitive).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Guard 3 — Blast radius
+// ----------------------------------------------------------------------------
+
+describe('checkBlastRadius', () => {
+  it('allows a change within both caps', () => {
+    const r = checkBlastRadius([cf('src/a.ts', 10, 5), cf('src/b.ts', 3, 2)]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.filesTouched).toBe(2);
+      expect(r.linesTouched).toBe(20);
+    }
+  });
+
+  it('DENIES over maxFiles', () => {
+    const files = Array.from({ length: 21 }, (_, i) => cf(`src/f${String(i)}.ts`, 1, 0));
+    const r = checkBlastRadius(files, { maxFiles: 20, maxLines: 10_000 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('blast_radius_exceeded');
+  });
+
+  it('DENIES over maxLines', () => {
+    const r = checkBlastRadius([cf('src/a.ts', 300, 200)], { maxFiles: 50, maxLines: 400 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('blast_radius_exceeded');
+  });
+
+  it('DENIES a sensitive file even when within size caps', () => {
+    const r = checkBlastRadius([cf('src/a.ts', 1, 0), cf('package.json', 1, 0)]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('sensitive_path');
+  });
+
+  it('uses documented defaults when no limits passed', () => {
+    expect(DEFAULT_BLAST_RADIUS_LIMITS.maxFiles).toBe(20);
+    expect(DEFAULT_BLAST_RADIUS_LIMITS.maxLines).toBe(400);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Guard 4 — Pre-push secret scan
+// ----------------------------------------------------------------------------
+
+describe('scanDiffOrDeny', () => {
+  it('allows a clean diff', () => {
+    const r = scanDiffOrDeny('+ adjust routing weight for docs\n- old weight\n');
+    expect(r.ok).toBe(true);
+  });
+
+  it('DENIES a diff containing a planted fake secret', () => {
+    const diff = ['+ const apiKey = "ABCDEFGHIJKLMNOP1234"', '+ // shipped by mistake'].join('\n');
+    const r = scanDiffOrDeny(diff);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('secret_detected');
+      // value-free: detail names the pattern + line, never the secret value.
+      expect(r.detail).not.toContain('ABCDEFGHIJKLMNOP1234');
+    }
+  });
+
+  it('DENIES an AWS-key-shaped secret', () => {
+    const r = scanDiffOrDeny('+ AKIAIOSFODNN7EXAMPLE\n');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('secret_detected');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Guard 5 — Audit-append (both PR and abort paths)
+// ----------------------------------------------------------------------------
+
+describe('auditAutonomousEvent', () => {
+  const baseRecord: AutonomousEventRecord = {
+    runId: 'run-123',
+    sourceSignalHash: 'sig-abc',
+    diffHash: 'diff-def',
+    scanVerdict: 'clean',
+    filesTouched: 2,
+    linesTouched: 20,
+    tokenIdentity: 'none',
+    decision: 'would_open_pr',
+  };
+
+  it('appends a record for a would-be PR (precondition C, pass path)', () => {
+    const { logger, events } = makeCapturingLogger();
+    const r = auditAutonomousEvent(logger, baseRecord);
+    expect(r.ok).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('autonomous_code_pr.would_open_pr');
+    expect(events[0]?.outcome).toBe('success');
+    expect(events[0]?.metadata?.['runId']).toBe('run-123');
+  });
+
+  it('appends a record for a fail-closed abort (precondition C, abort path)', () => {
+    const { logger, events } = makeCapturingLogger();
+    const r = auditAutonomousEvent(logger, {
+      ...baseRecord,
+      decision: 'abort',
+      abortReason: 'secret_detected',
+    });
+    expect(r.ok).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('autonomous_code_pr.abort');
+    expect(events[0]?.outcome).toBe('denied');
+    expect(events[0]?.metadata?.['abortReason']).toBe('secret_detected');
+  });
+
+  it('fail-closed: DENIES with audit_append_failed when the logger throws', () => {
+    const throwing: IAuditLogger = {
+      log: () => {
+        throw new Error('disk full');
+      },
+      logToolInvocation: () => {},
+      logPolicyDecision: () => {},
+      logSecurityEvent: () => {},
+      logRateLimitViolation: () => {},
+      logTierTransition: () => {},
+      flush: async () => {},
+      close: async () => {},
+    };
+    const r = auditAutonomousEvent(throwing, baseRecord);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('audit_append_failed');
+  });
+
+  it('never leaks a secret value into the audit record (hashes only)', () => {
+    const { logger, events } = makeCapturingLogger();
+    auditAutonomousEvent(logger, baseRecord);
+    const serialized = JSON.stringify(events[0]);
+    expect(serialized).toContain('diff-def');
+    expect(serialized).not.toMatch(/AKIA|sk-ant-|ghp_/);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Guard 6 — Resource budget
+// ----------------------------------------------------------------------------
+
+describe('checkResourceBudget', () => {
+  const within = { wallClockMs: 1_000, tokens: 1_000, toolCalls: 5 };
+
+  it('allows usage within all ceilings', () => {
+    expect(checkResourceBudget(within).ok).toBe(true);
+  });
+
+  it('allows usage exactly at the ceiling (ceiling is the last permitted value)', () => {
+    const r = checkResourceBudget({
+      wallClockMs: DEFAULT_RESOURCE_BUDGET_LIMITS.maxWallClockMs,
+      tokens: DEFAULT_RESOURCE_BUDGET_LIMITS.maxTokens,
+      toolCalls: DEFAULT_RESOURCE_BUDGET_LIMITS.maxToolCalls,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('DENIES on wall-clock breach', () => {
+    const r = checkResourceBudget({ ...within, wallClockMs: 999_999_999 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('budget_exceeded');
+  });
+
+  it('DENIES on token breach', () => {
+    const r = checkResourceBudget({ ...within, tokens: 999_999_999 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('budget_exceeded');
+  });
+
+  it('DENIES on tool-call breach', () => {
+    const r = checkResourceBudget({ ...within, toolCalls: 999_999 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('budget_exceeded');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Composite — evaluateWriteGuards
+// ----------------------------------------------------------------------------
+
+describe('evaluateWriteGuards', () => {
+  const okRealpath = (p: string): string => p; // identity seam: every path resolves in-root
+
+  function input(overrides: Partial<WriteGuardsInput> = {}): WriteGuardsInput {
+    return {
+      worktreeRoot: '/work/root',
+      changedFiles: [cf('/work/root/src/a.ts', 5, 2)],
+      diff: '+ const a = 1;\n',
+      usage: { wallClockMs: 10, tokens: 10, toolCalls: 1 },
+      realpath: okRealpath,
+      ...overrides,
+    };
+  }
+
+  it('returns ok for a fully clean change set', () => {
+    const r = evaluateWriteGuards(input());
+    expect(r.ok).toBe(true);
+  });
+
+  it('short-circuits on a path escape (guard 1) before later guards', () => {
+    // realpath that escapes the root → confinePath denies first.
+    const escaping = (p: string): string => (p === '/work/root' ? p : '/elsewhere/evil.ts');
+    const r = evaluateWriteGuards(input({ realpath: escaping }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('path_escape');
+  });
+
+  it('returns the sensitive_path denial (guard 2) for a sensitive file', () => {
+    const r = evaluateWriteGuards(
+      input({ changedFiles: [cf('/work/root/package.json', 1, 0)] })
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('sensitive_path');
+  });
+
+  it('returns the blast_radius_exceeded denial (guard 2 size)', () => {
+    const many = Array.from({ length: 30 }, (_, i) => cf(`/work/root/src/f${String(i)}.ts`, 1, 0));
+    const r = evaluateWriteGuards(input({ changedFiles: many }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('blast_radius_exceeded');
+  });
+
+  it('returns the secret_detected denial (guard 3)', () => {
+    const r = evaluateWriteGuards(input({ diff: '+ AKIAIOSFODNN7EXAMPLE\n' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('secret_detected');
+  });
+
+  it('returns the budget_exceeded denial (guard 6)', () => {
+    const r = evaluateWriteGuards(input({ usage: { wallClockMs: 9e9, tokens: 1, toolCalls: 1 } }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('budget_exceeded');
+  });
+
+  it('short-circuit order: a secret AND a budget breach reports the earlier (secret) guard', () => {
+    const r = evaluateWriteGuards(
+      input({
+        diff: '+ AKIAIOSFODNN7EXAMPLE\n',
+        usage: { wallClockMs: 9e9, tokens: 9e9, toolCalls: 9e9 },
+      })
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('secret_detected');
+  });
+
+  it('a violating set never returns ok (fail-closed)', () => {
+    // Spy proves we do not fall through to ok after a denial.
+    const spy = vi.fn(() => '/work/root');
+    const r = evaluateWriteGuards(
+      input({ changedFiles: [cf('/work/root/CODEOWNERS', 1, 0)], realpath: spy })
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Staleness — the self-guard lockout must not silently rot
+// ----------------------------------------------------------------------------
+
+describe('self-guard denylist staleness', () => {
+  it('the lockout still names this guard module itself', () => {
+    expect(SELF_GUARD_MODULE_BASENAMES).toContain('codepr-guards');
+  });
+
+  it('the lockout names every reused safety primitive', () => {
+    for (const name of [
+      'diff-secret-scan',
+      'repo-root-detection',
+      'audit-logger',
+      'audit-types',
+      'improvement-enforce-readiness',
+    ]) {
+      expect(SELF_GUARD_MODULE_BASENAMES).toContain(name);
+    }
+  });
+
+  it('the self_guard rule is the FIRST rule (wins category over audit/authority)', () => {
+    expect(SENSITIVE_PATH_RULES[0]?.category).toBe('self_guard');
+  });
+
+  it('classifyPath still treats this very test file as self-guard (lockout alive)', () => {
+    // If someone renamed the module without updating the denylist, this fails.
+    const c = classifyPath('packages/nexus-agents/src/mcp/tools/codepr-guards.test.ts');
+    expect(c.sensitive).toBe(true);
+    if (c.sensitive) expect(c.category).toBe('self_guard');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
@@ -36,6 +36,8 @@
  * @module mcp/tools/codepr-guards
  */
 
+// @export-no-consumer-yet — see #3670 (Stage 1 guard library; consumer lands in Stage 2/3)
+
 import { realpathSync } from 'node:fs';
 import { isAbsolute, resolve, relative, sep } from 'node:path';
 import { z } from 'zod';

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
@@ -1,0 +1,620 @@
+/**
+ * Deterministic write-time guard library for the (future) autonomous code-PR
+ * adapter (#3670, Stage 1 — OFF). The full safety architecture for closing the
+ * capability loop (research → auto-implementation → evaluation) was approved 7-0
+ * with binding preconditions. This module is Stage 1: the PURE, DETERMINISTIC
+ * guard primitives, behind NO runtime activation.
+ *
+ * SCOPE LOCK — this module performs NO code-generation, NO `git push`, NO
+ * PR-open, NO flag wired to live behavior, and registers NO MCP tool / CLI
+ * command / workflow. It is an internal library + tests ONLY. It is structurally
+ * incapable of taking any autonomous action: it imports no git/network/exec
+ * surface and only PROVIDES guard functions over realized facts the caller
+ * passes in.
+ *
+ * Binding preconditions this module satisfies:
+ *  - **A (deterministic-only decisions / self-guard segregation):** NO guard
+ *    derives its decision from model output or untrusted text. Every guard
+ *    operates ONLY on realized filesystem/diff facts supplied by the caller
+ *    (resolved paths, changed-file line counts, the realized diff text, usage
+ *    counters). There is no LLM call, no parsing of model rationale.
+ *  - **B (self-modification lockout):** {@link classifyPath} denies the
+ *    adapter's OWN guard code and the modules it depends on, so the autonomous
+ *    path can never author a change to its own guards. The denylist is an
+ *    explicit, exported, staleness-tested constant.
+ *  - **C (audit for both PR and abort):** {@link auditAutonomousEvent} appends a
+ *    structured record to the hash-chained audit log for BOTH a would-be PR and
+ *    a fail-closed abort (no push — just the record).
+ *  - **E (dependency-manifest authorship restriction):** {@link classifyPath}
+ *    classifies `package.json`, `pnpm-lock.yaml`, and `tsconfig*.json` as
+ *    `human-authorship-required`.
+ *
+ * Every guard returns a discriminated {@link GuardResult} — it NEVER throws for
+ * an expected denial. Fail-closed = return a denial result (and, where a fact
+ * cannot be resolved, DENY rather than allow).
+ *
+ * @module mcp/tools/codepr-guards
+ */
+
+import { realpathSync } from 'node:fs';
+import { isAbsolute, resolve, relative, sep } from 'node:path';
+import { z } from 'zod';
+import { scanForSecrets, type SecretScanResult } from './diff-secret-scan.js';
+import type { IAuditLogger, AuditActor } from '../../audit/audit-types.js';
+
+// ============================================================================
+// Result envelope
+// ============================================================================
+
+/**
+ * The set of denial reasons a guard can return. Each guard returns at most the
+ * subset relevant to it; {@link evaluateWriteGuards} can surface any of them.
+ */
+export type GuardDenialReason =
+  | 'path_escape'
+  | 'sensitive_path'
+  | 'blast_radius_exceeded'
+  | 'secret_detected'
+  | 'budget_exceeded'
+  | 'audit_append_failed';
+
+/** A fail-closed denial result: an enumerated reason + a value-free detail. */
+export interface GuardDenial {
+  readonly ok: false;
+  readonly reason: GuardDenialReason;
+  readonly detail: string;
+}
+
+/**
+ * Discriminated guard result. `ok: true` carries a guard-specific payload;
+ * `ok: false` carries an enumerated {@link GuardDenialReason} plus a value-free
+ * human detail. Guards NEVER throw for an expected denial — a denial is a value.
+ */
+export type GuardResult<TOk = Record<never, never>> = ({ readonly ok: true } & TOk) | GuardDenial;
+
+/** Construct a denial result (the single fail-closed exit shape). */
+function deny(reason: GuardDenialReason, detail: string): GuardDenial {
+  return { ok: false, reason, detail };
+}
+
+// ============================================================================
+// Guard 1 — Path confinement
+// ============================================================================
+
+/**
+ * A seam for `realpathSync` so tests can drive symlink-escape paths through a
+ * tmp dir without mocking `node:fs` globally. Defaults to the real
+ * {@link realpathSync}. The seam takes and returns absolute paths.
+ */
+export type RealpathFn = (p: string) => string;
+
+/**
+ * Confine `candidatePath` to within `worktreeRoot`. Resolves both paths through
+ * realpath semantics (so `..` traversal, an absolute path outside the root, and
+ * a symlink whose TARGET escapes the root are all caught), then checks that the
+ * resolved candidate is `worktreeRoot` itself or a descendant of it.
+ *
+ * Fail-closed: if either path cannot be realpath-resolved (e.g. the path does
+ * not exist, or realpath throws), the guard DENIES with `path_escape` rather
+ * than guessing. The caller is expected to pass paths for realized files.
+ *
+ * @param worktreeRoot - Absolute path to the worktree root the change is confined to.
+ * @param candidatePath - The path (absolute or relative-to-root) being written.
+ * @param realpath - Test seam; defaults to {@link realpathSync}.
+ */
+export function confinePath(
+  worktreeRoot: string,
+  candidatePath: string,
+  realpath: RealpathFn = realpathSync
+): GuardResult<{ readonly resolvedPath: string }> {
+  if (!isAbsolute(worktreeRoot)) {
+    return deny('path_escape', 'worktreeRoot must be an absolute path');
+  }
+
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = realpath(worktreeRoot);
+  } catch {
+    return deny('path_escape', 'worktreeRoot could not be resolved (fail-closed)');
+  }
+
+  // Resolve the candidate against the root first (handles relative inputs and
+  // `..`), then realpath the result so a symlink target that escapes is caught.
+  const joined = isAbsolute(candidatePath) ? candidatePath : resolve(resolvedRoot, candidatePath);
+  let resolvedCandidate: string;
+  try {
+    resolvedCandidate = realpath(joined);
+  } catch {
+    return deny('path_escape', 'candidate path could not be resolved (fail-closed)');
+  }
+
+  if (!isWithin(resolvedRoot, resolvedCandidate)) {
+    return deny('path_escape', 'resolved path is outside the worktree root');
+  }
+  return { ok: true, resolvedPath: resolvedCandidate };
+}
+
+/**
+ * True iff `child` is `parent` itself or a descendant of it, computed from the
+ * realpath-resolved absolute paths (no further fs access). Uses `path.relative`
+ * and rejects any result that starts with `..` or is itself absolute (a
+ * different mount/drive), which is the standard escape-proof containment check.
+ */
+function isWithin(parent: string, child: string): boolean {
+  if (child === parent) return true;
+  const rel = relative(parent, child);
+  if (rel === '') return true;
+  if (rel === '..' || rel.startsWith('..' + sep)) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
+
+// ============================================================================
+// Guard 2 — Sensitive-path classifier
+// ============================================================================
+
+/** Why a path is sensitive (and therefore human-authorship-required). */
+export type SensitiveCategory =
+  | 'governance'
+  | 'workflow'
+  | 'codeowners'
+  | 'authority'
+  | 'audit'
+  | 'self_guard'
+  | 'dependency_manifest';
+
+/** Classification of a single relative path. */
+export type PathClassification =
+  | { readonly sensitive: false }
+  | { readonly sensitive: true; readonly category: SensitiveCategory };
+
+/**
+ * One sensitive-path rule: a predicate over a NORMALIZED, POSIX-separator,
+ * leading-`./`-stripped relative path, plus the category it maps to. Kept as an
+ * explicit, exported, reviewable array (precondition B requires the self-guard
+ * denylist be reviewable + staleness-testable).
+ */
+export interface SensitivePathRule {
+  readonly category: SensitiveCategory;
+  readonly description: string;
+  readonly match: (relPathPosix: string) => boolean;
+}
+
+/** Final path segment (basename) of a POSIX-normalized relative path. */
+function basenamePosix(relPathPosix: string): string {
+  const idx = relPathPosix.lastIndexOf('/');
+  return idx === -1 ? relPathPosix : relPathPosix.slice(idx + 1);
+}
+
+/**
+ * The self-modification lockout list (precondition B). These module basenames —
+ * the guard code itself plus every reused/depended-on safety primitive — may
+ * never be authored by the autonomous path. Exported so the lockout is
+ * reviewable and the staleness test can assert it still names this very module.
+ *
+ * NOTE: each name is matched as a basename PREFIX (so `codepr-guards.ts`,
+ * `codepr-guards.test.ts`, and any future `codepr-guards/*` all lock out), and
+ * as a path segment (so a future directory of the same name locks out too).
+ */
+export const SELF_GUARD_MODULE_BASENAMES: readonly string[] = [
+  'codepr-guards', // this guard module (+ its tests / future dir) — prefix match
+  'diff-secret-scan', // reused: pre-push secret scan
+  'repo-root-detection', // reused: repo-root / path confinement source
+  'audit-logger', // reused: hash-chained audit log
+  'audit-types', // reused: audit schemas/interfaces the guard imports
+  'improvement-enforce-readiness', // the enable-readiness module (shadow→enforce gate)
+  'remediation-readiness-collector', // companion readiness collector
+] as const;
+
+/** True iff the path's basename (or a segment) matches a self-guard module. */
+function isSelfGuardPath(relPathPosix: string): boolean {
+  const base = basenamePosix(relPathPosix);
+  for (const name of SELF_GUARD_MODULE_BASENAMES) {
+    if (base === name) return true;
+    if (base.startsWith(name + '.')) return true; // foo.ts, foo.test.ts
+    // future `codepr-guards/` dir: any path segment equal to the name
+    if (relPathPosix === name || relPathPosix.startsWith(name + '/')) return true;
+    if (relPathPosix.includes('/' + name + '/')) return true;
+  }
+  return false;
+}
+
+/**
+ * The explicit, exported, reviewable sensitive-path ruleset. Order is not
+ * load-bearing for the verdict (any match → sensitive) but earlier matches win
+ * the reported `category`. Self-guard and dependency-manifest rules implement
+ * preconditions B and E respectively.
+ */
+export const SENSITIVE_PATH_RULES: readonly SensitivePathRule[] = [
+  {
+    category: 'self_guard',
+    description: 'the adapter’s own guard code + reused safety primitives (precondition B)',
+    match: isSelfGuardPath,
+  },
+  {
+    category: 'governance',
+    description: 'governance/** — voting, ratification, tier ledgers',
+    match: (p) => p === 'governance' || p.startsWith('governance/') || p.includes('/governance/'),
+  },
+  {
+    category: 'workflow',
+    description: '.github/workflows/** — CI/CD definitions',
+    match: (p) => p.startsWith('.github/workflows/') || p.includes('/.github/workflows/'),
+  },
+  {
+    category: 'codeowners',
+    description: 'any CODEOWNERS file',
+    match: (p) => basenamePosix(p) === 'CODEOWNERS',
+  },
+  {
+    category: 'audit',
+    description: 'audit subsystem: src/audit/** (tamper-evidence — human-authored only)',
+    match: (p) => p === 'src/audit' || p.startsWith('src/audit/') || p.includes('/src/audit/'),
+  },
+  {
+    category: 'authority',
+    description: 'auth/authority code: **/authority-*, **/auth/**',
+    match: (p) =>
+      basenamePosix(p).startsWith('authority-') || p.includes('/auth/') || p.startsWith('auth/'),
+  },
+  {
+    category: 'dependency_manifest',
+    description:
+      'dependency manifests: package.json, pnpm-lock.yaml, tsconfig*.json (precondition E)',
+    match: (p) => {
+      const base = basenamePosix(p);
+      if (base === 'package.json') return true;
+      if (base === 'pnpm-lock.yaml') return true;
+      if (base.startsWith('tsconfig') && base.endsWith('.json')) return true;
+      return false;
+    },
+  },
+];
+
+/**
+ * Normalize a relative path to POSIX separators and strip a leading `./` so the
+ * rules can be written against a single canonical form. Does NOT resolve the
+ * filesystem (this is a pure classifier over the supplied string).
+ */
+function normalizeRelPath(relPath: string): string {
+  let p = relPath.replace(/\\/g, '/');
+  while (p.startsWith('./')) p = p.slice(2);
+  return p;
+}
+
+/**
+ * Classify a relative path as sensitive (human-authorship-required) or not.
+ * Pure over the supplied string — no filesystem access, no model input. Returns
+ * the FIRST matching rule's category (rule order in {@link SENSITIVE_PATH_RULES}).
+ */
+export function classifyPath(relPath: string): PathClassification {
+  const p = normalizeRelPath(relPath);
+  for (const rule of SENSITIVE_PATH_RULES) {
+    if (rule.match(p)) return { sensitive: true, category: rule.category };
+  }
+  return { sensitive: false };
+}
+
+// ============================================================================
+// Guard 3 — Blast-radius cap
+// ============================================================================
+
+/** A single realized changed file (counts, not content). */
+export interface ChangedFile {
+  readonly path: string;
+  readonly addedLines: number;
+  readonly removedLines: number;
+}
+
+/** Zod schema for {@link BlastRadiusLimits} — validated, with documented defaults. */
+export const BlastRadiusLimitsSchema = z
+  .object({
+    /** Max number of files the change may touch. Default 20. */
+    maxFiles: z.number().int().positive().default(20),
+    /** Max total changed lines (added + removed across all files). Default 400. */
+    maxLines: z.number().int().positive().default(400),
+  })
+  .strict();
+export type BlastRadiusLimits = z.infer<typeof BlastRadiusLimitsSchema>;
+
+/** Documented default blast-radius limits (small, conservative for a first stage). */
+export const DEFAULT_BLAST_RADIUS_LIMITS: Readonly<BlastRadiusLimits> = Object.freeze(
+  BlastRadiusLimitsSchema.parse({})
+);
+
+/**
+ * Deny when the change set is too large OR touches a sensitive path. Pure over
+ * the supplied counts + paths (precondition A — no content, no model input).
+ *
+ *  - `sensitive_path` when ANY changed file is sensitive per {@link classifyPath}
+ *    (checked first — a sensitive touch is denied regardless of size).
+ *  - `blast_radius_exceeded` when files touched > maxFiles or total changed
+ *    lines (added + removed) > maxLines.
+ *
+ * @param changedFiles - The realized change set (paths + per-file line counts).
+ * @param limits - Validated limits; defaults to {@link DEFAULT_BLAST_RADIUS_LIMITS}.
+ */
+export function checkBlastRadius(
+  changedFiles: readonly ChangedFile[],
+  limits: BlastRadiusLimits = DEFAULT_BLAST_RADIUS_LIMITS
+): GuardResult<{ readonly filesTouched: number; readonly linesTouched: number }> {
+  const parsed = BlastRadiusLimitsSchema.safeParse(limits);
+  if (!parsed.success) {
+    return deny('blast_radius_exceeded', 'invalid blast-radius limits (fail-closed)');
+  }
+  const { maxFiles, maxLines } = parsed.data;
+
+  // Sensitive-path check first: a sensitive file is denied even within size caps.
+  for (const f of changedFiles) {
+    const cls = classifyPath(f.path);
+    if (cls.sensitive) {
+      return deny('sensitive_path', `changed file is sensitive (${cls.category}): ${f.path}`);
+    }
+  }
+
+  const filesTouched = changedFiles.length;
+  if (filesTouched > maxFiles) {
+    return deny(
+      'blast_radius_exceeded',
+      `files touched ${String(filesTouched)} exceeds maxFiles ${String(maxFiles)}`
+    );
+  }
+
+  let linesTouched = 0;
+  for (const f of changedFiles) linesTouched += f.addedLines + f.removedLines;
+  if (linesTouched > maxLines) {
+    return deny(
+      'blast_radius_exceeded',
+      `changed lines ${String(linesTouched)} exceeds maxLines ${String(maxLines)}`
+    );
+  }
+
+  return { ok: true, filesTouched, linesTouched };
+}
+
+// ============================================================================
+// Guard 4 — Pre-push secret-scan
+// ============================================================================
+
+/**
+ * Scan a realized diff for secrets and DENY on any finding. Wraps the in-tree
+ * {@link scanForSecrets} (#3669). This is the deterministic, scan-THEN-push
+ * gate: the caller, in a later stage, must NEVER push before this returns `ok`.
+ * Findings are value-free (pattern name + line only) — never the secret value.
+ *
+ * Fail-closed: any single finding flips the result to a `secret_detected` denial.
+ *
+ * @param diff - The realized unified diff text (a fact, not model output).
+ */
+export function scanDiffOrDeny(diff: string): GuardResult<{ readonly scan: SecretScanResult }> {
+  const scan = scanForSecrets(diff);
+  if (!scan.clean) {
+    const summary = scan.findings.map((f) => `${f.pattern}@L${String(f.line)}`).join(', ');
+    return deny(
+      'secret_detected',
+      `secret scan found ${String(scan.findings.length)} finding(s): ${summary}`
+    );
+  }
+  return { ok: true, scan };
+}
+
+// ============================================================================
+// Guard 5 — Audit-append (for both a would-be PR and a fail-closed abort)
+// ============================================================================
+
+/** The decision an autonomous run reached at the audit point. */
+export type AutonomousDecision = 'would_open_pr' | 'abort';
+
+/** Structured record for {@link auditAutonomousEvent}. All fields are facts/hashes. */
+export interface AutonomousEventRecord {
+  /** Correlates all events for one autonomous run. */
+  readonly runId: string;
+  /** Hash of the source signal (e.g. improvement/fitness signal) that triggered the run. */
+  readonly sourceSignalHash: string;
+  /** Hash of the realized diff (so the audited content is pinned without storing it). */
+  readonly diffHash: string;
+  /** The deterministic secret-scan verdict at the gate. */
+  readonly scanVerdict: 'clean' | 'secret_detected';
+  /** Number of files the change touched. */
+  readonly filesTouched: number;
+  /** Total changed lines (added + removed). */
+  readonly linesTouched: number;
+  /**
+   * Placeholder for the identity of the token/credential the (future) push would
+   * use. Stage 1 has no token; carried so the audit shape is stable for later
+   * stages. Use a non-secret label (e.g. a key id or `'none'`), NEVER a secret.
+   */
+  readonly tokenIdentity: string;
+  /** `would_open_pr` for a passing run, `abort` for a fail-closed stop. */
+  readonly decision: AutonomousDecision;
+  /** For an abort, the enumerated guard reason; omitted/undefined for a pass. */
+  readonly abortReason?: GuardDenialReason | undefined;
+  /** Optional actor; defaults to a system autonomous-code-PR actor. */
+  readonly actor?: AuditActor | undefined;
+}
+
+/** Default actor for an autonomous code-PR audit event. */
+const AUTONOMOUS_ACTOR: AuditActor = {
+  type: 'system',
+  id: 'autonomous-code-pr',
+  name: 'Autonomous Code-PR Adapter (Stage 1, OFF)',
+};
+
+/**
+ * Append a structured autonomous-event record to the hash-chained audit log
+ * (precondition C). Callable for BOTH a would-be PR (`decision:'would_open_pr'`)
+ * and a fail-closed abort (`decision:'abort'`, with the `abortReason`). This
+ * performs NO push — it only writes the audit record via the injected
+ * {@link IAuditLogger}.
+ *
+ * The {@link IAuditLogger.log} call is synchronous (it enqueues); a thrown error
+ * from the logger is caught and converted to an `audit_append_failed` denial so
+ * an audit failure is itself fail-closed (the caller must treat a failed audit
+ * as a reason NOT to proceed).
+ *
+ * @param logger - The hash-chained audit logger (dependency-injected).
+ * @param record - The structured, fact-only event record.
+ */
+export function auditAutonomousEvent(
+  logger: IAuditLogger,
+  record: AutonomousEventRecord
+): GuardResult {
+  try {
+    logger.log({
+      category: 'security',
+      severity: record.decision === 'abort' ? 'warning' : 'info',
+      outcome: record.decision === 'abort' ? 'denied' : 'success',
+      action: `autonomous_code_pr.${record.decision}`,
+      description:
+        record.decision === 'abort'
+          ? `autonomous code-PR aborted (${record.abortReason ?? 'unspecified'})`
+          : 'autonomous code-PR write-guards passed (would open PR)',
+      actor: record.actor ?? AUTONOMOUS_ACTOR,
+      resource: { type: 'autonomous-run', id: record.runId, name: record.runId },
+      metadata: {
+        runId: record.runId,
+        sourceSignalHash: record.sourceSignalHash,
+        diffHash: record.diffHash,
+        scanVerdict: record.scanVerdict,
+        filesTouched: record.filesTouched,
+        linesTouched: record.linesTouched,
+        tokenIdentity: record.tokenIdentity,
+        decision: record.decision,
+        abortReason: record.abortReason ?? null,
+      },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return deny('audit_append_failed', `audit append threw (fail-closed): ${detail}`);
+  }
+  return { ok: true };
+}
+
+// ============================================================================
+// Guard 6 — Resource-limit (budget) guard
+// ============================================================================
+
+/** A realized usage snapshot for one autonomous run. */
+export interface ResourceUsage {
+  /** Wall-clock elapsed for the run so far, in milliseconds. */
+  readonly wallClockMs: number;
+  /** Tokens consumed so far. */
+  readonly tokens: number;
+  /** Tool calls made so far. */
+  readonly toolCalls: number;
+}
+
+/** Zod schema for {@link ResourceBudgetLimits} — validated, with documented defaults. */
+export const ResourceBudgetLimitsSchema = z
+  .object({
+    /** Wall-clock ceiling in ms. Default 600000 (10 min). */
+    maxWallClockMs: z.number().int().positive().default(600_000),
+    /** Token ceiling. Default 200000. */
+    maxTokens: z.number().int().positive().default(200_000),
+    /** Tool-call ceiling. Default 200. */
+    maxToolCalls: z.number().int().positive().default(200),
+  })
+  .strict();
+export type ResourceBudgetLimits = z.infer<typeof ResourceBudgetLimitsSchema>;
+
+/** Documented default resource budget. */
+export const DEFAULT_RESOURCE_BUDGET_LIMITS: Readonly<ResourceBudgetLimits> = Object.freeze(
+  ResourceBudgetLimitsSchema.parse({})
+);
+
+/**
+ * Deny when any resource ceiling is breached (`budget_exceeded`). Pure function
+ * over a usage snapshot (precondition A). Denial is strictly `usage > limit`, so
+ * hitting the ceiling exactly is still permitted (the ceiling is the last
+ * allowed value).
+ *
+ * @param usage - The realized usage snapshot.
+ * @param limits - Validated ceilings; defaults to {@link DEFAULT_RESOURCE_BUDGET_LIMITS}.
+ */
+export function checkResourceBudget(
+  usage: ResourceUsage,
+  limits: ResourceBudgetLimits = DEFAULT_RESOURCE_BUDGET_LIMITS
+): GuardResult {
+  const parsed = ResourceBudgetLimitsSchema.safeParse(limits);
+  if (!parsed.success) {
+    return deny('budget_exceeded', 'invalid resource limits (fail-closed)');
+  }
+  const { maxWallClockMs, maxTokens, maxToolCalls } = parsed.data;
+
+  if (usage.wallClockMs > maxWallClockMs) {
+    return deny(
+      'budget_exceeded',
+      `wall-clock ${String(usage.wallClockMs)}ms exceeds ${String(maxWallClockMs)}ms`
+    );
+  }
+  if (usage.tokens > maxTokens) {
+    return deny('budget_exceeded', `tokens ${String(usage.tokens)} exceeds ${String(maxTokens)}`);
+  }
+  if (usage.toolCalls > maxToolCalls) {
+    return deny(
+      'budget_exceeded',
+      `tool calls ${String(usage.toolCalls)} exceeds ${String(maxToolCalls)}`
+    );
+  }
+  return { ok: true };
+}
+
+// ============================================================================
+// Composite — evaluateWriteGuards (single deterministic entry point)
+// ============================================================================
+
+/** Input to {@link evaluateWriteGuards}: a fully-realized change set. */
+export interface WriteGuardsInput {
+  /** Absolute worktree root the change must be confined to. */
+  readonly worktreeRoot: string;
+  /** The realized change set (paths + per-file line counts). */
+  readonly changedFiles: readonly ChangedFile[];
+  /** The realized unified diff text (for the secret scan). */
+  readonly diff: string;
+  /** The realized resource-usage snapshot. */
+  readonly usage: ResourceUsage;
+  /** Optional blast-radius limits override. */
+  readonly blastRadiusLimits?: BlastRadiusLimits | undefined;
+  /** Optional resource-budget limits override. */
+  readonly resourceLimits?: ResourceBudgetLimits | undefined;
+  /** Test seam for path realpath resolution. */
+  readonly realpath?: RealpathFn | undefined;
+}
+
+/**
+ * Compose guards 1–4 + 6 over a realized change set and return the FIRST denial
+ * (or `ok`). Single deterministic entry point for the future adapter; it
+ * SHORT-CIRCUITS fail-closed — the first guard to deny stops evaluation and its
+ * denial is returned unchanged.
+ *
+ * Order (hardest-stop first):
+ *  1. path confinement on every changed file (an escape is the hardest stop),
+ *  2. blast-radius (size + sensitive-path),
+ *  3. secret scan over the diff,
+ *  4. resource budget.
+ *
+ * The audit-append guard (5) is intentionally NOT composed here — auditing is
+ * the caller's responsibility on BOTH the pass and abort paths (precondition C),
+ * using the verdict this function returns.
+ */
+export function evaluateWriteGuards(input: WriteGuardsInput): GuardResult {
+  // 1. Path confinement — every changed file must resolve within the root.
+  for (const f of input.changedFiles) {
+    const confined = confinePath(input.worktreeRoot, f.path, input.realpath);
+    if (!confined.ok) return confined;
+  }
+
+  // 2. Blast radius (also denies any sensitive path).
+  const blast = checkBlastRadius(input.changedFiles, input.blastRadiusLimits);
+  if (!blast.ok) return blast;
+
+  // 3. Secret scan.
+  const secrets = scanDiffOrDeny(input.diff);
+  if (!secrets.ok) return secrets;
+
+  // 4. Resource budget.
+  const budget = checkResourceBudget(input.usage, input.resourceLimits);
+  if (!budget.ok) return budget;
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Stage 1 of #3670 — deterministic write-time guard LIBRARY (OFF)

Stage 1 of the 7-0-approved autonomous code-PR safety architecture. This adds the **pure, deterministic guard primitives** behind **NO runtime activation**.

### EXPLICIT scope statement
This stage performs **NO code-generation, NO `git push`, NO PR-open, and wires NO flag to live behavior**. It is a **library + tests only**. It registers no MCP tool, no CLI command, and no workflow (`TOOL_MANIFEST` and the CLI catalog are untouched, so the repo-index gate is unaffected). The module imports no git/network/exec surface — it is structurally incapable of taking any autonomous action and only *provides* guard functions over realized facts the caller passes in.

### Guards (all in `packages/nexus-agents/src/mcp/tools/codepr-guards.ts`)
Every guard returns a discriminated `GuardResult` (`{ ok: true, ... } | { ok: false, reason, detail }`) and **never throws for an expected denial** — fail-closed = return a denial.

1. **`confinePath(worktreeRoot, candidatePath)`** — realpath-based confinement. Denies `path_escape` for `..` traversal, an absolute path outside the root, and a symlink whose target escapes. Fail-closed: a path that can't be realpath-resolved is DENIED. Exposes a `realpath` test seam.
2. **`classifyPath(relPath)`** — sensitive-path classifier returning `{ sensitive, category }`. Sensitive categories: `governance/**`, `.github/workflows/**`, `CODEOWNERS`, `authority`/`auth`, `src/audit/**`, the **self-guard denylist**, and **dependency manifests**. Backed by the exported, reviewable `SENSITIVE_PATH_RULES` + `SELF_GUARD_MODULE_BASENAMES` constants.
3. **`checkBlastRadius(changedFiles, limits)`** — Zod-validated file/line caps (defaults: 20 files / 400 lines). Denies `blast_radius_exceeded` over a cap and `sensitive_path` if any changed file is sensitive.
4. **`scanDiffOrDeny(diff)`** — wraps the #3669 `scanForSecrets`; any finding → `secret_detected`. Scan-THEN-push gate; value-free findings.
5. **`auditAutonomousEvent(logger, record)`** — appends a structured record (runId, sourceSignalHash, diffHash, scanVerdict, files/lines touched, tokenIdentity placeholder, decision/abortReason) to the hash-chained audit log. No push.
6. **`checkResourceBudget(usage, limits)`** — Zod-validated wall-clock/token/tool-call ceilings → `budget_exceeded`.

Plus **`evaluateWriteGuards(input)`** — composes guards 1–4 + 6 over a realized change set, returns the **first** denial, short-circuit fail-closed. (Guard 5 / audit is intentionally the caller's responsibility on both pass and abort paths.)

### Binding preconditions satisfied
- **A — deterministic-only decisions / self-guard segregation.** No guard reads model output or untrusted text; every decision derives only from realized filesystem/diff facts (resolved paths, line counts, diff text, usage counters). No LLM call.
- **B — self-modification lockout.** `classifyPath` denies the adapter's own guard module (`codepr-guards*`, prefix-matched) AND every reused/depended-on primitive (`diff-secret-scan`, `repo-root-detection`, `audit-logger`, `audit-types`, `improvement-enforce-readiness`, `remediation-readiness-collector`). The denylist is an exported constant with a **staleness test** asserting it still names this very module.
- **C — audit for both PR and abort.** `auditAutonomousEvent` is tested for both `would_open_pr` and a fail-closed `abort`.
- **E — dependency-manifest authorship restriction.** `package.json`, `pnpm-lock.yaml`, `tsconfig*.json` classify as `dependency_manifest` (human-authorship-required).

### Red-team / negative tests (`codepr-guards.test.ts`, 54 tests)
- **path confinement:** `..` escape, absolute-outside, symlink-target-escape (real tmp-dir symlink), unresolvable path, non-absolute root → all DENIED; legit in-root → ok.
- **sensitive-path:** `governance/x`, `.github/workflows/ci.yml`, `CODEOWNERS`, `src/audit/audit-logger.ts`, **`codepr-guards.ts` itself (self-modification)**, every reused primitive, `package.json`, `pnpm-lock.yaml`, `tsconfig*.json` → DENIED; `src/foo.ts` → allowed.
- **blast-radius:** over maxFiles, over maxLines, a sensitive file in the set → DENIED; within → ok.
- **secret-scan:** planted fake secret (assert detail is value-free) + AWS-shape → DENIED; clean → ok.
- **resource-budget:** each ceiling breached → DENIED; exactly-at-ceiling → ok.
- **`evaluateWriteGuards`:** each guard's violation surfaces its denial; short-circuit order proven (secret beats budget); a violating set never returns ok.
- **staleness:** the self-guard denylist still names this module + every reused primitive, and `self_guard` is the first rule.

### Gates
- `pnpm tsc --noEmit` clean; eslint clean on changed files; zero `any`.
- 54 new tests pass; reused-module tests (diff-secret-scan, repo-root-detection) still pass.
- Changeset: `.changeset/codepr-guards-stage1-3670.md` (`nexus-agents`: minor, feat).

### Judgment calls
- Split `src/audit/**` into its own `audit` category (distinct from `authority`), since the brief lists both — `authority` now covers `authority-*` / `auth/**`. Self-guard rule is ordered first so `audit-logger.ts` reports `self_guard` (the stronger lockout) over `audit`.
- Conservative defaults (20 files / 400 lines / 10 min / 200k tokens / 200 tool calls) — explicit, Zod-validated, overridable.
- `tokenIdentity` is a documented non-secret placeholder (Stage 1 has no token); audit metadata carries hashes, never content.

Do NOT merge — Stage 1 review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)