### PR TITLE
fix(audit): close tier-transition hash-coverage escape — unify transition predicate (#3961)

### DIFF
--- a/.changeset/tier-transition-hash-predicate-3961.md
+++ b/.changeset/tier-transition-hash-predicate-3961.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(audit): close tier-transition hash-coverage escape — unify transition predicate (#3961)
+
+The tier-transition hash projection folded the integrity-critical
+`metadata.tierTransition` payload into the chain hash only when
+`isTierTransitionEvent` returned true, which required `action.startsWith('tier.')`.
+But `extractTierTransition` (consumed by the ratification/drift gate) recovers a
+transition from ANY `governance` event carrying a valid payload, regardless of
+action. A `governance.audit` (non-`tier.`) event with a valid `tierTransition`
+payload was therefore hashed WITHOUT covering the payload, yet consumed by the
+gate as a promotion — a single-event undetectable forge.
+
+Both decisions now derive from one shared predicate, `hasTierTransitionPayload`
+(governance category + payload parses against `TierTransitionPayloadSchema`), so
+hash-coverage ⊇ gate-consumption by construction and the two can never diverge
+again. The chain remains tamper-EVIDENT (unkeyed SHA-256), not tamper-proof.

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -35,7 +35,7 @@ import {
   AUDIT_HASH_VERSION_TIER_TRANSITION,
 } from './audit-types.js';
 import { FileAuditStorage } from './audit-storage.js';
-import { canonicalTierTransition, isTierTransitionEvent } from './tier-transition-hash.js';
+import { canonicalTierTransition, hasTierTransitionPayload } from './tier-transition-hash.js';
 
 // ============================================================================
 // ID Generation
@@ -58,7 +58,7 @@ function generateEventId(): string {
  * a tier-transition event additionally folds in `hashVersion: 2` and the
  * canonicalized `metadata.tierTransition` payload, so its integrity-critical
  * fields are chain-covered. The version is DERIVED from the covered head fields
- * (see {@link isTierTransitionEvent}), never read from the mutable stored
+ * (see {@link hasTierTransitionPayload}), never read from the mutable stored
  * `hashVersion`, so a tampered/stripped version field cannot downgrade the hash.
  */
 function computeEventHash(event: AuditEvent): string {
@@ -71,7 +71,7 @@ function computeEventHash(event: AuditEvent): string {
     actor: event.actor,
     previousHash: event.previousHash,
   };
-  if (isTierTransitionEvent(event)) {
+  if (hasTierTransitionPayload(event)) {
     projection['hashVersion'] = AUDIT_HASH_VERSION_TIER_TRANSITION;
     const raw = event.metadata?.[TIER_TRANSITION_METADATA_KEY];
     projection['tierTransition'] = canonicalTierTransition(raw);
@@ -174,12 +174,13 @@ export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
  * `null` if the event is not a (valid) tier-transition event. A tier-transition
  * event is a `governance`-category event whose `metadata.tierTransition` parses
  * against {@link TierTransitionPayloadSchema}. Used by the ratification gate to
- * read transition events back out of the chained log.
+ * read transition events back out of the chained log. Gated on the SAME
+ * predicate the hash projection uses ({@link hasTierTransitionPayload}), so
+ * gate-consumption and hash-coverage cannot diverge (#3961).
  */
 export function extractTierTransition(event: AuditEvent): TierTransitionPayload | null {
-  if (event.category !== 'governance') return null;
+  if (!hasTierTransitionPayload(event)) return null;
   const raw = event.metadata?.[TIER_TRANSITION_METADATA_KEY];
-  if (raw === undefined) return null;
   const parsed = TierTransitionPayloadSchema.safeParse(raw);
   return parsed.success ? parsed.data : null;
 }
@@ -347,9 +348,9 @@ export class AuditLogger implements IAuditLogger {
 
     // #3921: stamp the v2 hash version on a tier-transition event for
     // observability/schema. NOTE: computeEventHash DERIVES the version from the
-    // covered head fields (see isTierTransitionEvent), so this stamp is not
+    // covered head fields (see hasTierTransitionPayload), so this stamp is not
     // load-bearing for integrity — it cannot be trusted to downgrade the hash.
-    if (isTierTransitionEvent(event)) event.hashVersion = AUDIT_HASH_VERSION_TIER_TRANSITION;
+    if (hasTierTransitionPayload(event)) event.hashVersion = AUDIT_HASH_VERSION_TIER_TRANSITION;
 
     if (this.enableHashChain) {
       event.hash = computeEventHash(event);

--- a/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
+++ b/packages/nexus-agents/src/audit/tier-transition-audit.test.ts
@@ -234,7 +234,8 @@ describe('logTierTransition — payload is hash-covered (#3921)', () => {
   // head-only projection (which excludes the payload). If the verifier trusted
   // the stored hashVersion it would drop to v1, recompute the same head-only
   // hash, and accept the forgery. The verifier instead DERIVES v2 from the
-  // covered `action` (tier.*), so the strip cannot downgrade it.
+  // covered `category` plus the (still-present, still-valid) payload — see
+  // hasTierTransitionPayload (#3961) — so the strip cannot downgrade it.
   function v1HeadHash(event: AuditEvent): string {
     // Mirror computeEventHash's v1 projection EXACTLY (field order included).
     const projection = {
@@ -378,6 +379,79 @@ describe('extractTierTransition', () => {
     await logger.close();
     expect(extractTierTransition(storage.getAll()[0]!)).toBeNull();
   });
+});
+
+// #3961 (HIGH): the hash-coverage predicate was `action.startsWith('tier.')`,
+// NARROWER than what the ratification gate consumes (extractTierTransition
+// recovers a transition from ANY governance event with a valid tierTransition
+// payload, any action). So a `governance.audit` (non-`tier.`) event carrying a
+// valid payload was hashed WITHOUT covering the payload, yet the drift gate
+// treated it as a promotion — a single-event undetectable forge. Both sides now
+// share hasTierTransitionPayload, so hash-coverage ⊇ gate-consumption.
+describe('non-`tier.` governance event payload is hash-covered (#3961)', () => {
+  const validPayload = {
+    kind: 'promotion' as const,
+    subject: 'sneaky-loop',
+    fromTier: 'advisory' as const,
+    toTier: 'enforce' as const,
+    evidenceRef: 'evidence#3961',
+    ratificationVoteRef: 'cv_3961',
+  };
+
+  // Emit a governance event with a NON-`tier.` action carrying a valid payload
+  // via the public log() path (logTierTransition always uses `tier.*`, so we go
+  // through the generic logger to reproduce the escapable shape).
+  function sealNonTierGovernance(): { logger: AuditLogger; storage: InMemoryAuditStorage } {
+    const { logger, storage } = makeLogger();
+    logger.log({
+      category: 'governance',
+      severity: 'info',
+      outcome: 'success',
+      action: 'governance.audit', // NOT tier.* — the escapable action
+      description: 'governance audit carrying a tier-transition payload',
+      actor: { type: 'system', id: 'nexus-agents', name: 'Nexus Agents System' },
+      metadata: { [TIER_TRANSITION_METADATA_KEY]: validPayload },
+    });
+    return { logger, storage };
+  }
+
+  it('the drift gate consumes it as a transition (extractTierTransition is non-null)', async () => {
+    const { logger, storage } = sealNonTierGovernance();
+    await logger.close();
+    const event = storage.getAll()[0]!;
+    expect(event.action).toBe('governance.audit');
+    expect(extractTierTransition(event)).toEqual(validPayload);
+    // ...and it is now stamped v2 (hash-covered), matching gate-consumption.
+    expect(event.hashVersion).toBe(2);
+  });
+
+  it('an unmutated such event still verifies ok', async () => {
+    const { logger, storage } = sealNonTierGovernance();
+    await logger.close();
+    expect(verifyChain(storage.getAll()).ok).toBe(true);
+  });
+
+  it.each(['toTier', 'subject'] as const)(
+    'verifyChain detects a flipped %s in the payload (was undetectable pre-#3961)',
+    async (field) => {
+      const { logger, storage } = sealNonTierGovernance();
+      await logger.close();
+      const event = storage.getAll()[0]!;
+      const tampered: AuditEvent = {
+        ...event,
+        metadata: {
+          ...event.metadata,
+          [TIER_TRANSITION_METADATA_KEY]: {
+            ...(event.metadata?.[TIER_TRANSITION_METADATA_KEY] as Record<string, unknown>),
+            [field]: `forged-${field}`,
+          },
+        },
+      };
+      const result = verifyChain([tampered]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+    }
+  );
 });
 
 describe('RatificationVoteSchema — the #3894 resolution-source schema', () => {

--- a/packages/nexus-agents/src/audit/tier-transition-hash.ts
+++ b/packages/nexus-agents/src/audit/tier-transition-hash.ts
@@ -7,23 +7,48 @@
  * `computeEventHash` can fold it into the chain under `hashVersion: 2`. Kept in a
  * sibling module so the logger stays under the file-length cap.
  *
+ * INVARIANT (#3961): hash-coverage ⊇ gate-consumption. The SAME predicate
+ * ({@link hasTierTransitionPayload}) decides both whether the payload is folded
+ * into the hash and whether the ratification gate treats the event as a
+ * transition, so any governance event the gate consumes as a transition has its
+ * payload hash-covered. Mutating a covered payload therefore always breaks the
+ * chain. (Tamper-EVIDENT under unkeyed SHA-256, not tamper-proof — see the
+ * audit-hash-chain threat model.)
+ *
  * @module audit/tier-transition-hash
  */
 
-import { TierTransitionPayloadSchema, type AuditEvent } from './audit-types.js';
+import {
+  TierTransitionPayloadSchema,
+  TIER_TRANSITION_METADATA_KEY,
+  type AuditEvent,
+} from './audit-types.js';
 
 /**
- * Identify a tier-transition event by its COVERED head fields — a `governance`
- * event whose `action` is `tier.*` (the only emitter is `logTierTransition`) —
- * NOT by the mutable `hashVersion` metadata field. This is the integrity hinge
- * (#3921 downgrade fix): keying the v2 projection off the stored `hashVersion`
- * let an attacker editing the plaintext log strip/alter that field to force the
- * v1 head-only projection and silently flip `toTier`. Because `category` and
- * `action` are themselves folded into the hash, an attacker cannot escape the
- * payload-covering v2 projection without breaking the chain.
+ * THE single predicate for "this event carries a tier-transition payload": a
+ * `governance`-category event whose `metadata.tierTransition` parses against
+ * {@link TierTransitionPayloadSchema}. This is the ONE definition both the
+ * hash-coverage decision (`computeEventHash`) and the gate-consumption recovery
+ * (`extractTierTransition` in audit-logger.ts) derive from, so the two can NEVER
+ * diverge (#3961) and hash-coverage ⊇ gate-consumption holds by construction.
+ *
+ * Previously the hash side keyed off `action.startsWith('tier.')`, NARROWER than
+ * what the gate recovers: a `governance` event with a non-`tier.` action carrying
+ * a valid payload was hashed WITHOUT covering the payload, yet consumed by the
+ * gate as a transition — a single-event undetectable forge (#3961, now closed).
+ *
+ * Detection is keyed off COVERED head fields (`category`) plus the payload's own
+ * validity — NOT the mutable `hashVersion` metadata field (#3921 downgrade fix):
+ * keying off stored `hashVersion` let an attacker strip/alter that field to force
+ * the v1 head-only projection and silently flip `toTier`. Because `category` and
+ * the canonicalized payload are folded into the hash, an attacker cannot escape
+ * the payload-covering v2 projection without breaking the chain.
  */
-export function isTierTransitionEvent(event: AuditEvent): boolean {
-  return event.category === 'governance' && event.action.startsWith('tier.');
+export function hasTierTransitionPayload(event: AuditEvent): boolean {
+  if (event.category !== 'governance') return false;
+  const raw = event.metadata?.[TIER_TRANSITION_METADATA_KEY];
+  if (raw === undefined) return false;
+  return TierTransitionPayloadSchema.safeParse(raw).success;
 }
 
 /**


### PR DESCRIPTION
## The bug (HIGH security, #3961)

The tier-transition hash projection and the ratification/drift gate disagreed on what counts as a transition — a **predicate mismatch**:

- `computeEventHash` folded the integrity-critical `metadata.tierTransition` payload into the chain hash **only** when `isTierTransitionEvent` returned true, which required `event.action.startsWith('tier.')`.
- `extractTierTransition` (consumed by the drift gate, `scripts/check-authority-tier-drift.ts`) recovers a transition from **ANY** `governance` event carrying a payload that parses against `TierTransitionPayloadSchema`, regardless of action.

So a `governance` event with a **non-`tier.`** action (e.g. `governance.audit`) carrying a valid `tierTransition` payload was hashed **WITHOUT covering the payload**, yet the gate consumed it as a promotion. An attacker editing the plaintext log could flip `toTier`/`subject` on such an event and recompute the head-only hash — the chain still verifies, but the gate sees a forged promotion. A single-event undetectable forge. The old docstring asserted an invariant that was false.

## The fix (fail-closed — widen hash coverage)

Extracted a single shared predicate `hasTierTransitionPayload(event)` in `tier-transition-hash.ts`:

```ts
export function hasTierTransitionPayload(event: AuditEvent): boolean {
  if (event.category !== 'governance') return false;
  const raw = event.metadata?.[TIER_TRANSITION_METADATA_KEY];
  if (raw === undefined) return false;
  return TierTransitionPayloadSchema.safeParse(raw).success;
}
```

Both sides now derive from this ONE definition:
- `computeEventHash` (and the `hashVersion` stamp in `createEvent`) gate on `hasTierTransitionPayload`.
- `extractTierTransition` gates on the same `hasTierTransitionPayload`.

Import direction matches the existing #3921 direction (`tier-transition-hash.ts` exports, `audit-logger.ts` imports) — no cycle. The now-redundant `isTierTransitionEvent` alias was **removed** (it had no remaining callers once both internal uses moved to the shared predicate). The canonical v2 projection (`canonicalTierTransition`) still folds the payload into the hash for all such events.

## Corrected invariant

Updated the module docstring at `tier-transition-hash.ts` to state the now-TRUE invariant: **hash-coverage ⊇ gate-consumption** — the same predicate decides both, so any governance event the gate treats as a transition has its payload hash-covered, by construction. Mutating a covered payload always breaks the chain. The chain remains **tamper-EVIDENT** (unkeyed SHA-256), not tamper-proof.

## Regression test

In `tier-transition-audit.test.ts`, a new describe block seals a `governance.audit` (non-`tier.`) event carrying a valid `metadata.tierTransition` via the public `log()` path, then:
- asserts the drift gate consumes it (`extractTierTransition` non-null) **and** it is now stamped `hashVersion: 2` (hash-covered);
- asserts an unmutated such event still `verifyChain`-passes;
- mutates `toTier`/`subject` in place → asserts `verifyChain` now returns `hash_mismatch` (previously undetectable).

All existing `tier.*` tests and the downgrade-forgery tests keep passing.

## Other `isTierTransitionEvent` call sites

Grep across `packages/` + `scripts/`: the only callers were the two internal uses in `audit-logger.ts` (`computeEventHash` and the `createEvent` `hashVersion` stamp). Both moved to `hasTierTransitionPayload`. It was **not** exported from the audit `index.ts` (only `extractTierTransition` is), so removing the alias has no external impact. Widening is fail-closed (more events get payload-covered), so no caller breaks.

## Confirmation

- `tsc --noEmit` clean; `eslint` clean on the 3 changed files (zero `any`).
- `src/audit/` — 223/223 tests pass (incl. 4 new #3961 tests).
- `scripts/check-authority-tier-drift.test.ts` — 38/38 pass.
- hash-coverage ⊇ gate-consumption now holds by construction (one shared predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)