### PR TITLE
fix(governance): canonicalize vote-record hash + resolve NEXUS_VOTE_RECORDS_PATH to absolute (#3962, #3963)

### DIFF
--- a/.changeset/vote-record-hardening-3962-3963.md
+++ b/.changeset/vote-record-hardening-3962-3963.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): canonicalize vote-record hash + resolve NEXUS_VOTE_RECORDS_PATH to absolute (#3962, #3963)
+
+- #3962 (MEDIUM): `computeVoteRecordHash` now rebuilds the nested `voteCounts`
+  object field-by-field in schema order (`approve, reject, abstain, total`)
+  before hashing, matching how `voters[]` elements are already rebuilt. Previously
+  `voteCounts` was passed straight to `JSON.stringify`, so the self-hash depended
+  on key insertion order — a formatter / `jq -S` / merge tool that reordered
+  `voteCounts` keys flipped a legitimate committed record to `hash_mismatch`,
+  defeating the merge-safety premise of the record-set model. The hash of a
+  record whose keys are already in canonical order is unchanged, so existing
+  writer-produced records still verify without a rewrite.
+- #3963 (LOW): `resolveVoteRecordsPath` now resolves a relative
+  `NEXUS_VOTE_RECORDS_PATH` override to an absolute path against `process.cwd()`
+  instead of returning it verbatim, honoring the documented absolute-path
+  contract and removing a silent cwd-dependent write. Absolute values are
+  returned unchanged; whitespace-only values still fall through to repo-root
+  detection. JSDoc updated to match.

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -11,7 +11,7 @@
 
 import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -283,6 +283,27 @@ describe('vote-record path resolution / persistence escape hatch (#3927)', () =>
   it('treats an empty/whitespace env var as unset (falls back to root detection)', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, '   ');
     expect(resolveVoteRecordsPath()).toBeUndefined();
+  });
+
+  it('returns an absolute override unchanged (#3963)', () => {
+    // envFilePath is already absolute → returned verbatim (resolve is a no-op).
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, envFilePath);
+    const resolved = resolveVoteRecordsPath();
+    expect(resolved).toBe(envFilePath);
+    expect(isAbsolute(resolved as string)).toBe(true);
+  });
+
+  it('resolves a RELATIVE override to an absolute path against cwd (#3963)', () => {
+    // The JSDoc contract says the override is treated as an absolute path; a
+    // relative value used verbatim would silently write under process.cwd().
+    // Honor the contract: resolve it to an absolute path against cwd.
+    const relative = 'governance/custom-vote-records.jsonl';
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, relative);
+    const resolved = resolveVoteRecordsPath();
+    expect(resolved).toBe(resolve(relative));
+    expect(isAbsolute(resolved as string)).toBe(true);
+    // It must NOT be returned verbatim (the pre-fix bug).
+    expect(resolved).not.toBe(relative);
   });
 
   it('lets opts.filePath take precedence over the env var', () => {

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -25,7 +25,7 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 import type { ILogger } from '../core/index.js';
 import { createLogger, getErrorMessage } from '../core/index.js';
@@ -41,9 +41,10 @@ export const VOTE_RECORDS_REL_PATH = 'governance/vote-records.jsonl';
 
 /**
  * Env var to force the artifact path (#3927). When set non-empty it is used
- * directly (treated as an absolute path) and the cwd/{@link findRepoRoot}
- * detection is skipped — the escape hatch for running the MCP server outside the
- * repo (e.g. co-located/CI contexts) so server-side persistence is reliable.
+ * directly (resolved to an absolute path — see {@link resolveVoteRecordsPath})
+ * and the cwd/{@link findRepoRoot} detection is skipped — the escape hatch for
+ * running the MCP server outside the repo (e.g. co-located/CI contexts) so
+ * server-side persistence is reliable.
  */
 export const VOTE_RECORDS_PATH_ENV = 'NEXUS_VOTE_RECORDS_PATH';
 
@@ -154,15 +155,24 @@ function readLedgerTip(
 /**
  * Resolve the committable artifact path (#3927). Precedence:
  *  1. {@link VOTE_RECORDS_PATH_ENV} (`NEXUS_VOTE_RECORDS_PATH`) when set
- *     non-empty — used directly as an absolute path, skipping cwd detection.
+ *     non-empty — `resolve`d to an absolute path, skipping cwd detection. A
+ *     RELATIVE value is resolved against `process.cwd()` to an absolute path
+ *     (#3963) so the write target is unambiguous and not silently
+ *     cwd-dependent; an already-absolute value is returned unchanged.
  *  2. otherwise `<repo-root>/governance/vote-records.jsonl` resolved from
  *     {@link findRepoRoot}(`process.cwd()`).
  * Returns `undefined` when neither yields a path (server running outside the
- * repo with no override) — the caller surfaces this as an observable WARN.
+ * repo with no override) — the caller surfaces this as an observable WARN. A
+ * whitespace-only override is treated as unset (falls through to root detection).
  */
 export function resolveVoteRecordsPath(): string | undefined {
   const envPath = process.env[VOTE_RECORDS_PATH_ENV];
-  if (envPath !== undefined && envPath.trim() !== '') return envPath;
+  if (envPath !== undefined && envPath.trim() !== '') {
+    // Honor the absolute-path contract: a relative override is resolved against
+    // process.cwd() rather than written verbatim (#3963). isAbsolute short-
+    // circuits the common already-absolute case to a no-op for clarity.
+    return isAbsolute(envPath) ? envPath : resolve(envPath);
+  }
   const root = findRepoRoot(process.cwd());
   if (root === null) return undefined;
   return join(root, VOTE_RECORDS_REL_PATH);

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -129,6 +129,49 @@ describe('verifyVoteRecordSet', () => {
     }
   });
 
+  it('verifies a record whose nested voteCounts keys were reordered (#3962, hash is order-independent)', () => {
+    // A writer-produced record (canonical voteCounts key order).
+    const canonical = makeRecord('vote-1', 0);
+    // Simulate a formatter / `jq -S` / merge tool reordering the nested
+    // voteCounts keys (total, abstain, reject, approve) WITHOUT touching `hash`.
+    // Pre-fix this flipped the record to hash_mismatch; now it must still verify.
+    const reordered: VoteRecord = {
+      ...canonical,
+      voteCounts: { total: 7, abstain: 0, reject: 1, approve: 6 },
+    };
+    // Sanity: the values are identical, only key insertion order differs.
+    expect(JSON.stringify(reordered.voteCounts)).not.toBe(JSON.stringify(canonical.voteCounts));
+    expect(verifyVoteRecordSet([reordered])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('produces the SAME hash for canonical-order voteCounts before/after reorder (#3962, no rehash needed)', () => {
+    // Lock the order-independence: a payload with canonical key order and the
+    // same payload with reordered voteCounts keys must hash identically. This
+    // guarantees existing writer-produced (canonical-order) records still verify
+    // unchanged — the fix does NOT alter the hash of a canonical record.
+    const base: Omit<VoteRecord, 'hash'> = {
+      version: '1.1',
+      id: 'vote-hash-lock',
+      sequence: 0,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      proposalHash: 'b'.repeat(64),
+      proposal: 'lock the canonical hash',
+      strategy: 'higher_order',
+      decision: 'approved',
+      approvalPercentage: 85.7,
+      voteCounts: { approve: 6, reject: 1, abstain: 0, total: 7 },
+      voters: [{ role: 'architect', decision: 'approve', confidence: 0.9 }],
+    };
+    const reordered: Omit<VoteRecord, 'hash'> = {
+      ...base,
+      voteCounts: { total: 7, abstain: 0, reject: 1, approve: 6 },
+    };
+    expect(computeVoteRecordHash(reordered)).toBe(computeVoteRecordHash(base));
+    // And a record built from the canonical payload self-verifies.
+    const record: VoteRecord = { ...base, hash: computeVoteRecordHash(base) };
+    expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
   it('treats DUPLICATE sequences (concurrent fork) as benign and surfaces them in forks', () => {
     // Two branches each appended sequence 1 from the same tip, then merged.
     const records = [

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -143,7 +143,11 @@ type VoteRecordPayload = Omit<VoteRecord, 'hash'>;
  * `previousHash`, so the hash is position-independent and stable across
  * concurrent-branch merges and file reorders. The projection is built
  * field-by-field (not `JSON.stringify(record)`) so key-order is deterministic
- * regardless of how the object was constructed.
+ * regardless of how the object was constructed — and the NESTED objects
+ * (`voteCounts` and each `voters[]` element) are likewise rebuilt field-by-field
+ * in schema order (#3962). A formatter / `jq -S` / merge tool that reorders the
+ * keys of a persisted record must NOT flip a legitimate record to
+ * `hash_mismatch`: the hash is independent of key insertion order at every level.
  */
 export function computeVoteRecordHash(payload: VoteRecordPayload): string {
   const canonical = JSON.stringify({
@@ -156,7 +160,14 @@ export function computeVoteRecordHash(payload: VoteRecordPayload): string {
     strategy: payload.strategy,
     decision: payload.decision,
     approvalPercentage: payload.approvalPercentage,
-    voteCounts: payload.voteCounts,
+    // Rebuild voteCounts in schema order (approve, reject, abstain, total) so the
+    // hash does not depend on how the nested object's keys were ordered (#3962).
+    voteCounts: {
+      approve: payload.voteCounts.approve,
+      reject: payload.voteCounts.reject,
+      abstain: payload.voteCounts.abstain,
+      total: payload.voteCounts.total,
+    },
     voters: payload.voters.map((v) => ({
       role: v.role,
       decision: v.decision,


### PR DESCRIPTION
Two verified findings from a security review of the vote-record subsystem.

## #3962 (MEDIUM) — `computeVoteRecordHash` did not canonicalize nested `voteCounts` key order

`computeVoteRecordHash` (`vote-record.ts`) rebuilt top-level fields and `voters[]` elements field-by-field in fixed order, but passed `payload.voteCounts` **straight to `JSON.stringify`**, so the self-hash depended on `voteCounts` key insertion order. A JSON formatter / `jq -S` / merge tool that reorders `voteCounts` keys flipped a legitimate committed record to `hash_mismatch` — defeating the merge-safety premise of the record-set model (#3927).

**Fix:** rebuild `voteCounts` field-by-field in schema order (`approve, reject, abstain, total`) inside the hash projection, exactly as `voters[]` elements are rebuilt. Audited the rest of the projection: every other hashed field is a scalar (`version`/`id`/`recordedAt`/`proposalHash`/`proposal`/`strategy`/`decision`/`approvalPercentage`/`sequence`/`correlationId`) or the already-canonicalized `voters[]` array — `voteCounts` was the only remaining nested object with this risk.

## #3963 (LOW) — relative `NEXUS_VOTE_RECORDS_PATH` used verbatim vs 'absolute' JSDoc

`resolveVoteRecordsPath` (`vote-record-store.ts`) returned the env value raw (`return envPath`) with no normalization, while the docstring said it is "treated as an absolute path". A relative override resolved against `process.cwd()` — a silent, cwd-dependent write target.

**Fix:** honor the contract — `resolve(envPath)` to an absolute path (judgment call: resolve-to-absolute over reject-with-WARN, as the least-surprising behavior for an operator aiming writes and matching the doc intent). `isAbsolute` short-circuits the common already-absolute case to a no-op. Kept the existing `.trim()`/whitespace-only fall-through unchanged. JSDoc updated to state that a relative value is resolved against cwd to an absolute path.

## Existing records still verify (hash unchanged for canonical-order input)

The canonical order chosen (`approve, reject, abstain, total`) is exactly the order `buildVoteRecord` and the test helpers already write `voteCounts` in, so a record produced by the writer hashes **identically** before and after this change — no rewrite/migration needed. Locked by a test asserting `computeVoteRecordHash(canonical) === computeVoteRecordHash(reordered)` and that a `buildVoteRecord`-shaped record self-verifies.

## Tests

- `vote-record.test.ts`: reorder the nested `voteCounts` keys of a writer-produced record without rehashing → `verifyVoteRecordSet` still returns `ok` (order-independent); plus the hash-lock test above.
- `vote-record-store.test.ts`: relative `NEXUS_VOTE_RECORDS_PATH` → `resolveVoteRecordsPath()` returns an absolute path resolved against cwd (and not the verbatim relative value); absolute override returned as-is; whitespace-only still falls through to repo-root detection. Env restored via `vi.unstubAllEnvs()` in `afterEach`.

## Gates

- `tsc --noEmit` clean, eslint clean on all four changed files, both vote-record test files green (26 tests). Zero `any`. No new MCP tool/CLI command (repo-index unaffected).
- Changeset `.changeset/vote-record-hardening-3962-3963.md` (`nexus-agents: patch`, type `fix`, both issues referenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)