### PR TITLE
fix(capability-loop): harden code-PR write-time guards — new-file confinement, path-normalization bypasses, throw-free composition (#3670)

### DIFF
--- a/.changeset/codepr-guard-hardening-3670.md
+++ b/.changeset/codepr-guard-hardening-3670.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+fix(capability-loop): harden code-PR write-time guards (#3670)
+
+Adversarial review of the Stage-1 guard library (`codepr-guards.ts`, OFF, no
+runtime consumer) flagged three gaps; all are now closed, additively, with no
+currently-sensitive classification loosened:
+
+- **New-file confinement.** `confinePath` realpathed the full candidate, so a
+  not-yet-existing file (the adapter's whole purpose) hit `ENOENT` and was
+  denied as a `path_escape`. It now canonicalizes the nearest EXISTING ancestor
+  (symlink-safe for the real part) and re-appends the new tail lexically,
+  resolving `..`/`.` without touching the filesystem, then asserts containment.
+  A symlinked ancestor that escapes, a `..` that climbs out, and any non-ENOENT
+  realpath error all still fail closed. The returned `resolvedPath` is the
+  canonical path the caller MUST write to (closes the symlink TOCTOU).
+- **Path-normalization bypasses.** `classifyPath` now strips NTFS ADS suffixes
+  (`::$DATA`), trailing dots/spaces per segment, and collapses repeated slashes,
+  and matches the sensitive rules + self-guard basenames case-insensitively.
+  Forms like `Package.json`, `.GitHub/workflows/x`, `CODEOWNERS ` (trailing
+  space), `package.json.` (trailing dot), and `package.json::$DATA` now classify
+  sensitive. Over-matches toward sensitive; plain source stays non-sensitive.
+- **Throw-free composition.** `evaluateWriteGuards` wraps each guard so a thrown
+  exception (e.g. the secret scanner) becomes a fail-closed `guard_error` denial
+  (new reason; names the guard + message, never secret content) instead of
+  propagating.

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.test.ts
@@ -24,8 +24,17 @@ import {
   type ChangedFile,
   type WriteGuardsInput,
   type AutonomousEventRecord,
+  type SensitiveCategory,
 } from './codepr-guards.js';
 import type { IAuditLogger, AuditEventInput } from '../../audit/audit-types.js';
+import * as secretScan from './diff-secret-scan.js';
+
+// Mock the secret-scan module so a single test can force `scanForSecrets` to
+// THROW (Fix 3), while every other test delegates to the REAL implementation.
+vi.mock('./diff-secret-scan.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./diff-secret-scan.js')>();
+  return { ...actual, scanForSecrets: vi.fn(actual.scanForSecrets) };
+});
 
 // ----------------------------------------------------------------------------
 // Helpers
@@ -125,10 +134,71 @@ describe('confinePath', () => {
     }
   });
 
-  it('fail-closed: DENIES when the candidate cannot be realpath-resolved', () => {
+  it('Fix1: ALLOWS a NEW (not-yet-existing) in-root file', () => {
     const { root, cleanup } = makeTmpRoot();
     try {
+      // The adapter writes NEW files: a path that does not exist yet but is
+      // contained must be allowed, resolving to the canonical absolute path.
       const r = confinePath(root, 'does-not-exist.ts');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.resolvedPath).toBe(join(root, 'does-not-exist.ts'));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('Fix1: ALLOWS a NEW file under a NEW nested directory (no existing leaf)', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      const r = confinePath(root, 'new-dir/sub/file.ts');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.resolvedPath).toBe(join(root, 'new-dir', 'sub', 'file.ts'));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('Fix1: DENIES a NEW file whose path escapes via `..`', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      // Non-existent tail with a `..` that climbs out of the root.
+      const r = confinePath(root, 'sub/../../escaped-new.ts');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('Fix1: DENIES a NEW file under a symlinked EXISTING ancestor that escapes', () => {
+    const { root, cleanup } = makeTmpRoot();
+    const { root: outside, cleanup: cleanupOutside } = makeTmpRoot();
+    try {
+      // `linkdir` exists (a symlink) and points OUTSIDE the root; the leaf under
+      // it does NOT exist yet. The nearest existing ancestor is the symlink, so
+      // realpathing it lands outside → the new file under it is denied.
+      symlinkSync(outside, join(root, 'linkdir'));
+      const r = confinePath(root, 'linkdir/new-file.ts');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('path_escape');
+    } finally {
+      cleanup();
+      cleanupOutside();
+    }
+  });
+
+  it('Fix1: fail-closed when realpath errors for a reason OTHER than ENOENT', () => {
+    const { root, cleanup } = makeTmpRoot();
+    try {
+      // Seam that resolves the root but throws a non-ENOENT error for the
+      // candidate's existing ancestor → must NOT be treated as "new file".
+      const seam = (p: string): string => {
+        if (p === root) return root;
+        const err = new Error('permission denied') as Error & { code?: string };
+        err.code = 'EACCES';
+        throw err;
+      };
+      const r = confinePath(root, 'src/a.ts', seam);
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.reason).toBe('path_escape');
     } finally {
@@ -222,6 +292,33 @@ describe('classifyPath', () => {
     expect(classifyPath('.\\package.json').sensitive).toBe(true);
     expect(classifyPath('./governance/x').sensitive).toBe(true);
     expect(classifyPath('packages\\nexus-agents\\src\\audit\\x.ts').sensitive).toBe(true);
+  });
+
+  // Fix2 — normalization bypasses: each canonically-sensitive form below
+  // classified NON-sensitive before hardening. Each must now classify sensitive.
+  const bypassCases: Array<[string, string, SensitiveCategory]> = [
+    ['case-fold governance', 'Governance/x', 'governance'],
+    ['case-fold package.json', 'Package.json', 'dependency_manifest'],
+    ['case-fold .GitHub workflow', '.GitHub/workflows/ci.yml', 'workflow'],
+    ['case-fold CODEOWNERS', 'codeowners', 'codeowners'],
+    ['trailing space on CODEOWNERS', 'CODEOWNERS ', 'codeowners'],
+    ['trailing dot on package.json', 'package.json.', 'dependency_manifest'],
+    ['NTFS ADS on package.json', 'package.json::$DATA', 'dependency_manifest'],
+    ['NTFS ADS short form', 'package.json::x', 'dependency_manifest'],
+    ['repeated slashes into governance', 'governance//ratify.yaml', 'governance'],
+    ['mixed case + backslash audit', 'SRC\\Audit\\x.ts', 'audit'],
+    ['trailing dot on CODEOWNERS dir entry', '.github/CODEOWNERS.', 'codeowners'],
+  ];
+  it.each(bypassCases)('Fix2: now classifies %s as sensitive', (_label, path, category) => {
+    const c = classifyPath(path);
+    expect(c.sensitive, `should be sensitive: ${path}`).toBe(true);
+    if (c.sensitive) expect(c.category).toBe(category);
+  });
+
+  it('Fix2: a plain source file stays NON-sensitive after hardening', () => {
+    expect(classifyPath('src/foo.ts')).toEqual({ sensitive: false });
+    expect(classifyPath('src/Foo.ts')).toEqual({ sensitive: false });
+    expect(classifyPath('packages/app/src/components/Button.tsx')).toEqual({ sensitive: false });
   });
 });
 
@@ -465,6 +562,30 @@ describe('evaluateWriteGuards', () => {
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe('secret_detected');
+  });
+
+  it('Fix3: a guard that THROWS yields a guard_error denial, not an exception', () => {
+    // Force the secret scan (inside scanDiffOrDeny) to throw for this call only.
+    const spy = vi.mocked(secretScan.scanForSecrets);
+    spy.mockImplementationOnce(() => {
+      throw new Error('scanner blew up');
+    });
+    let result: ReturnType<typeof evaluateWriteGuards> | undefined;
+    expect(() => {
+      result = evaluateWriteGuards(input());
+    }).not.toThrow();
+    expect(result?.ok).toBe(false);
+    if (result && !result.ok) {
+      expect(result.reason).toBe('guard_error');
+      expect(result.detail).toContain('scanDiffOrDeny');
+      // Value-free: the error message is named, but no secret content leaks.
+      expect(result.detail).not.toMatch(/AKIA|sk-ant-|ghp_/);
+    }
+  });
+
+  it('Fix3: the normal (non-throwing) path is unchanged', () => {
+    // No mockImplementationOnce → delegates to the real scanner → ok.
+    expect(evaluateWriteGuards(input()).ok).toBe(true);
   });
 
   it('a violating set never returns ok (fail-closed)', () => {

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
@@ -39,7 +39,7 @@
 // @export-no-consumer-yet — see #3670 (Stage 1 guard library; consumer lands in Stage 2/3)
 
 import { realpathSync } from 'node:fs';
-import { isAbsolute, resolve, relative, sep } from 'node:path';
+import { isAbsolute, resolve, relative, sep, dirname, basename } from 'node:path';
 import { z } from 'zod';
 import { scanForSecrets, type SecretScanResult } from './diff-secret-scan.js';
 import type { IAuditLogger, AuditActor } from '../../audit/audit-types.js';
@@ -58,7 +58,8 @@ export type GuardDenialReason =
   | 'blast_radius_exceeded'
   | 'secret_detected'
   | 'budget_exceeded'
-  | 'audit_append_failed';
+  | 'audit_append_failed'
+  | 'guard_error';
 
 /** A fail-closed denial result: an enumerated reason + a value-free detail. */
 export interface GuardDenial {
@@ -91,14 +92,42 @@ function deny(reason: GuardDenialReason, detail: string): GuardDenial {
 export type RealpathFn = (p: string) => string;
 
 /**
- * Confine `candidatePath` to within `worktreeRoot`. Resolves both paths through
- * realpath semantics (so `..` traversal, an absolute path outside the root, and
- * a symlink whose TARGET escapes the root are all caught), then checks that the
- * resolved candidate is `worktreeRoot` itself or a descendant of it.
+ * The Node error shape we narrow to when distinguishing a benign "does not
+ * exist yet" (`ENOENT`) from any OTHER realpath failure (which is fail-closed).
+ */
+function errnoCode(err: unknown): string | undefined {
+  if (err !== null && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Confine `candidatePath` to within `worktreeRoot`, supporting NEW (not-yet-
+ * existing) files — the adapter's whole purpose is writing files that do not
+ * exist yet, so a path that does not yet exist must NOT be denied for that
+ * reason alone.
  *
- * Fail-closed: if either path cannot be realpath-resolved (e.g. the path does
- * not exist, or realpath throws), the guard DENIES with `path_escape` rather
- * than guessing. The caller is expected to pass paths for realized files.
+ * Algorithm (symlink-safe for the real part, FS-free for the new tail):
+ *  1. Realpath the worktree root (canonicalizes symlinks in the root itself).
+ *  2. Resolve the candidate against that root (handles relative inputs + `..`).
+ *  3. Walk UP from the candidate to the first EXISTING ancestor and realpath
+ *     THAT — this defeats symlink games on every component that actually exists
+ *     (a symlinked ancestor whose target escapes is caught here).
+ *  4. Re-append the remaining (non-existent) trailing segments to the realpathed
+ *     ancestor and normalize, resolving any `..`/`.` in the tail WITHOUT touching
+ *     the filesystem.
+ *  5. Assert the combined path is the canonicalized root itself or a descendant.
+ *
+ * Fail-closed (`path_escape`) if: the worktree root cannot be resolved, the
+ * combined path is outside the root, OR a realpath on an EXISTING component
+ * errors for any reason OTHER than `ENOENT`. A path that simply does not exist
+ * yet (`ENOENT` all the way up to an existing ancestor) is allowed if contained.
+ *
+ * The returned `resolvedPath` is the CANONICAL absolute path the caller MUST
+ * write to — writing to the original `candidatePath` instead would reintroduce
+ * the symlink TOCTOU this guard closes.
  *
  * @param worktreeRoot - Absolute path to the worktree root the change is confined to.
  * @param candidatePath - The path (absolute or relative-to-root) being written.
@@ -121,19 +150,46 @@ export function confinePath(
   }
 
   // Resolve the candidate against the root first (handles relative inputs and
-  // `..`), then realpath the result so a symlink target that escapes is caught.
+  // `..`), collapsing the path to an absolute lexical form.
   const joined = isAbsolute(candidatePath) ? candidatePath : resolve(resolvedRoot, candidatePath);
-  let resolvedCandidate: string;
-  try {
-    resolvedCandidate = realpath(joined);
-  } catch {
+
+  // Canonicalize the EXISTING part (symlink-safe) and re-append the new tail.
+  const reassembled = resolveNewFilePath(joined, realpath);
+  if (reassembled === undefined) {
     return deny('path_escape', 'candidate path could not be resolved (fail-closed)');
   }
 
-  if (!isWithin(resolvedRoot, resolvedCandidate)) {
+  if (!isWithin(resolvedRoot, reassembled)) {
     return deny('path_escape', 'resolved path is outside the worktree root');
   }
-  return { ok: true, resolvedPath: resolvedCandidate };
+  return { ok: true, resolvedPath: reassembled };
+}
+
+/**
+ * Canonicalize a candidate path that may name a NEW (not-yet-existing) file:
+ * walk UP to the nearest EXISTING ancestor, realpath THAT (so symlinks on the
+ * real part are resolved), then re-append the non-existent trailing segments and
+ * collapse any `..`/`.` in them lexically (no FS access). Returns the combined
+ * absolute path, or `undefined` to signal a fail-closed condition: a realpath
+ * error OTHER than `ENOENT` on an existing component, or reaching the filesystem
+ * root without any existing ancestor.
+ */
+function resolveNewFilePath(joined: string, realpath: RealpathFn): string | undefined {
+  let existing = joined;
+  const trailing: string[] = [];
+  for (;;) {
+    try {
+      existing = realpath(existing);
+      break; // `existing` now canonical; `trailing` holds the new tail (leaf-first).
+    } catch (err) {
+      if (errnoCode(err) !== 'ENOENT') return undefined; // not "absent" → fail-closed
+      const parent = dirname(existing);
+      if (parent === existing) return undefined; // hit FS root, no existing ancestor
+      trailing.push(basename(existing));
+      existing = parent;
+    }
+  }
+  return trailing.length === 0 ? existing : resolve(existing, ...trailing.reverse());
 }
 
 /**
@@ -172,9 +228,12 @@ export type PathClassification =
 
 /**
  * One sensitive-path rule: a predicate over a NORMALIZED, POSIX-separator,
- * leading-`./`-stripped relative path, plus the category it maps to. Kept as an
- * explicit, exported, reviewable array (precondition B requires the self-guard
- * denylist be reviewable + staleness-testable).
+ * leading-`./`-stripped, ADS-/trailing-dot-/trailing-space-stripped,
+ * LOWER-CASED relative path (see {@link normalizeRelPath} + {@link classifyPath}),
+ * plus the category it maps to. Because the input is already lower-cased, rule
+ * literals MUST be written lower-case. Kept as an explicit, exported, reviewable
+ * array (precondition B requires the self-guard denylist be reviewable +
+ * staleness-testable).
  */
 export interface SensitivePathRule {
   readonly category: SensitiveCategory;
@@ -245,8 +304,9 @@ export const SENSITIVE_PATH_RULES: readonly SensitivePathRule[] = [
   },
   {
     category: 'codeowners',
+    // `p` is already lower-cased by classifyPath (case-insensitive matching).
     description: 'any CODEOWNERS file',
-    match: (p) => basenamePosix(p) === 'CODEOWNERS',
+    match: (p) => basenamePosix(p) === 'codeowners',
   },
   {
     category: 'audit',
@@ -274,13 +334,40 @@ export const SENSITIVE_PATH_RULES: readonly SensitivePathRule[] = [
 ];
 
 /**
- * Normalize a relative path to POSIX separators and strip a leading `./` so the
- * rules can be written against a single canonical form. Does NOT resolve the
- * filesystem (this is a pure classifier over the supplied string).
+ * Normalize a relative path for SENSITIVE-RULE MATCHING into a single canonical
+ * form, defeating the host-filesystem normalization tricks that would otherwise
+ * let a canonically-sensitive path slip past a naive string compare. Does NOT
+ * resolve the filesystem (this is a pure classifier over the supplied string).
+ *
+ * Canonicalization steps (applied in order), all hardening toward the SENSITIVE
+ * side — none loosens a currently-sensitive classification:
+ *  - strip a Windows NTFS Alternate-Data-Stream suffix (`name::$DATA`, `name::x`)
+ *    — Windows resolves `package.json::$DATA` to `package.json`;
+ *  - convert backslashes to POSIX `/`;
+ *  - collapse runs of repeated slashes (`a//b` → `a/b`);
+ *  - strip leading `./` segments;
+ *  - per segment, strip trailing dots and spaces — Windows drops these when
+ *    opening a file, so `CODEOWNERS ` / `package.json.` map to the bare name.
+ *
+ * The result is matched CASE-INSENSITIVELY by {@link classifyPath} (both sides
+ * are lower-cased), so `Package.json` / `.GitHub/workflows/x` / `Governance/x`
+ * classify the same as their canonical forms.
  */
 function normalizeRelPath(relPath: string): string {
-  let p = relPath.replace(/\\/g, '/');
+  // 1. Strip an NTFS ADS suffix: everything from the first `::` onward.
+  const adsIdx = relPath.indexOf('::');
+  let p = adsIdx === -1 ? relPath : relPath.slice(0, adsIdx);
+  // 2. Backslashes → POSIX separators.
+  p = p.replace(/\\/g, '/');
+  // 3. Collapse repeated slashes.
+  p = p.replace(/\/{2,}/g, '/');
+  // 4. Strip leading `./` segments.
   while (p.startsWith('./')) p = p.slice(2);
+  // 5. Per-segment: strip trailing dots and spaces (Windows file-open semantics).
+  p = p
+    .split('/')
+    .map((seg) => seg.replace(/[. ]+$/, ''))
+    .join('/');
   return p;
 }
 
@@ -288,9 +375,14 @@ function normalizeRelPath(relPath: string): string {
  * Classify a relative path as sensitive (human-authorship-required) or not.
  * Pure over the supplied string — no filesystem access, no model input. Returns
  * the FIRST matching rule's category (rule order in {@link SENSITIVE_PATH_RULES}).
+ *
+ * Matching is CASE-INSENSITIVE: the normalized path is lower-cased before it is
+ * handed to the rules, which themselves test lower-cased literals. This is the
+ * safe (over-matching) direction — it can only classify MORE paths as sensitive,
+ * never fewer — closing case-fold bypasses like `Package.json` / `.GitHub/...`.
  */
 export function classifyPath(relPath: string): PathClassification {
-  const p = normalizeRelPath(relPath);
+  const p = normalizeRelPath(relPath).toLowerCase();
   for (const rule of SENSITIVE_PATH_RULES) {
     if (rule.match(p)) return { sensitive: true, category: rule.category };
   }
@@ -598,25 +690,52 @@ export interface WriteGuardsInput {
  * The audit-append guard (5) is intentionally NOT composed here — auditing is
  * the caller's responsibility on BOTH the pass and abort paths (precondition C),
  * using the verdict this function returns.
+ *
+ * THROW-FREE (fail-closed on throw): every guard call is wrapped so a thrown
+ * exception (e.g. {@link scanForSecrets} blowing up inside {@link scanDiffOrDeny})
+ * is caught and converted to a `guard_error` denial naming the guard + message —
+ * never a leaked secret value — rather than propagating. This upholds the
+ * module contract that a guard never throws for a control decision: a failure to
+ * evaluate is itself a denial.
  */
 export function evaluateWriteGuards(input: WriteGuardsInput): GuardResult {
   // 1. Path confinement — every changed file must resolve within the root.
   for (const f of input.changedFiles) {
-    const confined = confinePath(input.worktreeRoot, f.path, input.realpath);
+    const confined = runGuard('confinePath', () =>
+      confinePath(input.worktreeRoot, f.path, input.realpath)
+    );
     if (!confined.ok) return confined;
   }
 
   // 2. Blast radius (also denies any sensitive path).
-  const blast = checkBlastRadius(input.changedFiles, input.blastRadiusLimits);
+  const blast = runGuard('checkBlastRadius', () =>
+    checkBlastRadius(input.changedFiles, input.blastRadiusLimits)
+  );
   if (!blast.ok) return blast;
 
   // 3. Secret scan.
-  const secrets = scanDiffOrDeny(input.diff);
+  const secrets = runGuard('scanDiffOrDeny', () => scanDiffOrDeny(input.diff));
   if (!secrets.ok) return secrets;
 
   // 4. Resource budget.
-  const budget = checkResourceBudget(input.usage, input.resourceLimits);
+  const budget = runGuard('checkResourceBudget', () =>
+    checkResourceBudget(input.usage, input.resourceLimits)
+  );
   if (!budget.ok) return budget;
 
   return { ok: true };
+}
+
+/**
+ * Run a single composed guard, converting any THROWN exception into a
+ * fail-closed `guard_error` denial (naming the guard + the error message, never
+ * a secret value). The guard's own returned denial passes through unchanged.
+ */
+function runGuard<T>(name: string, fn: () => GuardResult<T>): GuardResult<T> {
+  try {
+    return fn();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return deny('guard_error', `guard ${name} threw (fail-closed): ${message}`);
+  }
 }


### PR DESCRIPTION
## Summary

Hardening of the Stage-1 code-PR write-time guard library (`packages/nexus-agents/src/mcp/tools/codepr-guards.ts`) per the adversarial security review on #3670. The module remains **OFF** — it registers no MCP tool / CLI command / workflow and still carries the `@export-no-consumer-yet — see #3670` marker (no runtime consumer). All existing behavior and tests preserved; changes are additive and **no currently-sensitive classification was loosened**.

## The three review-flagged gaps and their fixes

### 1. `confinePath` denied every NEW (not-yet-existing) file
`realpath` threw `ENOENT` on a path that does not exist yet, returning a `path_escape` denial — but writing NEW files is the adapter's whole purpose, so this denied every legitimate new-file write.

**Fix:** walk UP to the nearest EXISTING ancestor and `realpath` THAT (symlink-safe for the real part), then re-append the remaining non-existent trailing segments and resolve any `..`/`.` in the tail **lexically, without touching the FS**, then assert containment under `realpath(worktreeRoot)`. Fail-closed (`path_escape`) if: the combined path is outside root, a realpath on an existing component errors for any reason **other than** `ENOENT` (e.g. `EACCES`), or a `..` tail escapes. The returned `resolvedPath` is documented as the canonical path the caller **MUST** write to — closing the symlink TOCTOU. Existing-file confinement is unchanged (regression-tested).

### 2. `classifyPath` normalization bypasses (case / trailing / ADS / backslash)
`Governance/x`, `Package.json`, `.GitHub/workflows/x`, `CODEOWNERS ` (trailing space), `package.json.` (trailing dot), and `package.json::$DATA` (NTFS ADS) all classified NON-sensitive while their canonical forms are sensitive.

**Fix:** `normalizeRelPath` now strips an NTFS ADS suffix (from the first `::`), converts backslashes, collapses repeated slashes, strips leading `./`, and strips trailing dots/spaces per segment. `classifyPath` lower-cases the normalized path and the rules + self-guard basenames match case-insensitively. Over-matches toward **sensitive** (safe side). Plain `src/foo.ts` stays non-sensitive.

### 3. `evaluateWriteGuards` could throw (contract violation)
A composed guard (e.g. `scanDiffOrDeny` → `scanForSecrets`) could throw; the composite had no try/catch, contradicting the module's "guards never throw / fail-closed = return a denial" contract.

**Fix:** each guard call is wrapped; any thrown exception becomes a fail-closed denial with a new reason **`guard_error`** (detail names the guard + error message, never secret content). First-denial short-circuit preserved. `guard_error` added to the `GuardDenialReason` union.

## New tests (`codepr-guards.test.ts`, 72 passing)

- **Fix 1:** NEW in-root file → ok; NEW file under a NEW nested dir → ok; NEW file escaping via `..` → denied; NEW file under a symlinked existing ancestor that escapes → denied; non-ENOENT (`EACCES`) realpath error → fail-closed. The previous "does-not-exist → denied" test was flipped to assert the new allow behavior. Existing in-root / symlink-escape / absolute-outside / `..` cases unchanged.
- **Fix 2:** parametrized bypass table (case-fold, trailing space, trailing dot, NTFS ADS `::$DATA` and short form, repeated slashes, mixed-case backslash) → all now sensitive with correct category; plain source files (incl. mixed-case `Foo.ts`) stay non-sensitive.
- **Fix 3:** secret scanner forced to throw for one call (module-mocked, delegating to the real impl otherwise) → `evaluateWriteGuards` returns `{ok:false, reason:'guard_error'}` without throwing, detail names `scanDiffOrDeny` and leaks no secret; normal path still returns ok.

## No currently-sensitive classification loosened
Normalization and case-folding only ever map MORE inputs to a canonical sensitive form (over-match toward sensitive); rule literals were lower-cased to match the now-lower-cased input (`CODEOWNERS` → `codeowners`). Every pre-existing sensitive/non-sensitive case and the self-guard staleness suite still pass.

## Gates
- Zero `any`. `tsc --noEmit` clean; eslint clean on both changed files; `codepr-guards.test.ts` green (72 tests). No MCP tool / CLI command / workflow added (repo-index gate not triggered).
- Changeset: `.changeset/codepr-guard-hardening-3670.md` (`'nexus-agents': patch`, type `fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)