### PR TITLE
feat(capability-loop): code-PR enable-readiness gate + dry-run worktree orchestrator (Stage 2, OFF — no push) (#3670)

### DIFF
--- a/.changeset/codepr-orchestrator-stage2-3670.md
+++ b/.changeset/codepr-orchestrator-stage2-3670.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): code-PR enable-readiness gate + dry-run worktree orchestrator (Stage 2, OFF — no push) (#3670)
+
+Stage 2 of closing the capability loop, OFF-by-default with no runtime consumer.
+Composes the hardened Stage-1 guards (`codepr-guards.ts`); reimplements no guard
+logic.
+
+- `codepr-enable-readiness.ts` — `evaluateCodePrEnableReadiness`, a pure,
+  deterministic DOUBLE-GATE mirroring `evaluateEnforceReadiness`. Returns
+  `ready: true` only when ALL hold: the OFF→on flag is set, a recorded
+  enable-vote ref is present, a guards-green soak threshold is met (N consecutive
+  dry-run plans with zero guard denials), and a named owner has acknowledged. The
+  raw flag ALONE can never activate the push path. Stage 3 (the push) must call
+  this and refuse unless `ready`.
+- `codepr-orchestrator.ts` — `planCodePrRun`, a dry-run orchestrator that applies
+  a proposed change set in an ISOLATED throwaway git worktree, composes
+  `confinePath`/`classifyPath`/`evaluateWriteGuards`, records the audit on both
+  the pass and abort paths, and returns a planned PR descriptor (what it WOULD
+  push). It performs NO push, NO PR-open, and NO live-tree write, and atomically
+  discards the worktree in a `finally` even on failure/throw. Fail-closed: a
+  sensitive path, path escape, secret, over-budget change set, or any throw
+  returns a denied plan (never thrown), with no partial application.
+
+No MCP tool / CLI command / workflow added (repo-index unaffected). Stage 3 (the
+scoped-token push behind the enable-vote) is still pending.

--- a/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the code-PR enable-readiness DOUBLE-GATE (#3670, Stage 2). The point
+ * of the gate is that the raw OFF→on flag ALONE can NEVER make it ready — these
+ * tests prove the flag-only case stays denied and each missing criterion is named.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateCodePrEnableReadiness,
+  DEFAULT_CODEPR_ENABLE_READINESS_CONFIG,
+  type CodePrEnableReadinessEvidence,
+} from './codepr-enable-readiness.js';
+
+const SOAK = DEFAULT_CODEPR_ENABLE_READINESS_CONFIG.minGuardsGreenSoak;
+
+/** A fully-satisfying evidence object; override fields per test. */
+function fullEvidence(over: Partial<CodePrEnableReadinessEvidence> = {}): CodePrEnableReadinessEvidence {
+  return {
+    flagEnabled: true,
+    enableVoteRef: 'vote-3670-enable',
+    consecutiveGreenDryRuns: SOAK,
+    owner: 'william',
+    ...over,
+  };
+}
+
+describe('evaluateCodePrEnableReadiness', () => {
+  it('flag-only (no vote/soak/owner) is NOT ready — the flag alone can never activate', () => {
+    const r = evaluateCodePrEnableReadiness({
+      flagEnabled: true,
+      enableVoteRef: '',
+      consecutiveGreenDryRuns: 0,
+      owner: '',
+    });
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toContain('enable-vote-ref');
+    expect(r.blockers).toContain('guards-green-soak');
+    expect(r.blockers).toContain('owner-ack');
+    // The flag itself IS met — proving "flag set but still not ready".
+    expect(r.criteria.find((c) => c.name === 'flag-enabled')?.met).toBe(true);
+  });
+
+  it('all criteria satisfied → ready:true with no blockers', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence());
+    expect(r.ready).toBe(true);
+    expect(r.blockers).toEqual([]);
+    expect(r.criteria.every((c) => c.met)).toBe(true);
+  });
+
+  it('missing flag → ready:false naming flag-enabled', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ flagEnabled: false }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['flag-enabled']);
+  });
+
+  it('missing enable-vote ref → ready:false naming enable-vote-ref', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ enableVoteRef: '' }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['enable-vote-ref']);
+  });
+
+  it('whitespace-only vote ref counts as absent', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ enableVoteRef: '   ' }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['enable-vote-ref']);
+  });
+
+  it('soak below threshold → ready:false naming guards-green-soak', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ consecutiveGreenDryRuns: SOAK - 1 }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['guards-green-soak']);
+  });
+
+  it('soak exactly at threshold is met (>=)', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ consecutiveGreenDryRuns: SOAK }));
+    expect(r.ready).toBe(true);
+  });
+
+  it('missing owner → ready:false naming owner-ack', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence({ owner: '' }));
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['owner-ack']);
+  });
+
+  it('reports every criterion regardless of verdict', () => {
+    const r = evaluateCodePrEnableReadiness(fullEvidence());
+    const names = r.criteria.map((c) => c.name);
+    expect(names).toEqual(['flag-enabled', 'enable-vote-ref', 'guards-green-soak', 'owner-ack']);
+  });
+
+  it('config can drop the vote/owner requirement (still needs flag + soak)', () => {
+    const r = evaluateCodePrEnableReadiness(
+      { flagEnabled: true, enableVoteRef: '', consecutiveGreenDryRuns: 5, owner: '' },
+      { minGuardsGreenSoak: 5, requireEnableVoteRef: false, requireOwnerAck: false }
+    );
+    expect(r.ready).toBe(true);
+  });
+
+  it('malformed evidence fails closed (ready:false, evidence-shape blocker)', () => {
+    const bad = { flagEnabled: 'yes' } as unknown as CodePrEnableReadinessEvidence;
+    const r = evaluateCodePrEnableReadiness(bad);
+    expect(r.ready).toBe(false);
+    expect(r.blockers).toEqual(['evidence-shape']);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
@@ -1,0 +1,179 @@
+/**
+ * Code-PR adapter enable-readiness DOUBLE-GATE (#3670, Stage 2 — OFF).
+ *
+ * Mirrors {@link evaluateEnforceReadiness} (the shadow→enforce exit criterion):
+ * a fixed set of FALSIFIABLE, independently-checkable conditions, ALL required
+ * (fail-closed — any unmet condition blocks enabling the autonomous push path).
+ *
+ * The point of the double-gate: the raw OFF→on flag ALONE can NEVER activate the
+ * push path. `ready: true` additionally requires a recorded enable-vote ref, a
+ * guards-green soak (N consecutive dry-run plans with zero guard denials), AND a
+ * named owner acknowledgement. A flag flip without the vote/soak/owner stays
+ * `ready: false`.
+ *
+ * This module is PURE and DETERMINISTIC: it derives nothing from model output,
+ * reads NO environment (the flag is passed in as a boolean — keeping it pure and
+ * testable), performs NO I/O, flips NO flag, and runs NO push. Stage 3 (the
+ * actual scoped-token push behind the enable-vote) MUST call this and refuse to
+ * push unless it returns `ready: true`.
+ *
+ * @module mcp/tools/codepr-enable-readiness
+ */
+
+// @export-no-consumer-yet — see #3670 (Stage 2; consumer/push lands in Stage 3 behind enable-vote)
+
+import { z } from 'zod';
+
+/**
+ * Tuning for {@link evaluateCodePrEnableReadiness}. Conservative, fail-closed
+ * defaults: enabling an autonomous push path is high-stakes, so the soak bar is
+ * non-trivial and both the vote ref and owner sign-off are required.
+ */
+export const CodePrEnableReadinessConfigSchema = z
+  .object({
+    /**
+     * Minimum number of CONSECUTIVE dry-run plans observed with ZERO guard
+     * denials before the push path may be considered. The soak proves the
+     * orchestrator + guards behave on real change sets before any push.
+     */
+    minGuardsGreenSoak: z.number().int().positive().default(50),
+    /** Whether a recorded enable-vote ref is required (analogous to ratificationVoteRef). */
+    requireEnableVoteRef: z.boolean().default(true),
+    /** Whether a named owner acknowledgement is required. */
+    requireOwnerAck: z.boolean().default(true),
+  })
+  .strict();
+export type CodePrEnableReadinessConfig = z.infer<typeof CodePrEnableReadinessConfigSchema>;
+
+/** Documented, conservative defaults (high bar, fail-closed). */
+export const DEFAULT_CODEPR_ENABLE_READINESS_CONFIG: Readonly<CodePrEnableReadinessConfig> =
+  Object.freeze(CodePrEnableReadinessConfigSchema.parse({}));
+
+/**
+ * The deterministic evidence the enable double-gate is evaluated against. NO
+ * field is model-derived; every value is a realized operational fact the caller
+ * supplies. Zod-validated so a malformed evidence object fails closed.
+ */
+export const CodePrEnableReadinessEvidenceSchema = z
+  .object({
+    /**
+     * The explicit OFF→on flag. Passed in as a boolean (NOT read from env here —
+     * this module stays pure). This is the FLAG half of the double-gate: true
+     * alone is necessary but NEVER sufficient.
+     */
+    flagEnabled: z.boolean(),
+    /**
+     * A recorded enable-vote ref (analogous to a ratification vote ref). The
+     * VOTE half of the gate: a non-empty string is required when
+     * `requireEnableVoteRef` is set. Whitespace-only counts as absent.
+     */
+    enableVoteRef: z.string().default(''),
+    /**
+     * Count of CONSECUTIVE dry-run plans observed with zero guard denials (the
+     * guards-green soak). Compared against `minGuardsGreenSoak`.
+     */
+    consecutiveGreenDryRuns: z.number().int().nonnegative().default(0),
+    /**
+     * Named owner accepting activation of the push path (the OWNER half of the
+     * gate). Required when `requireOwnerAck` is set. Whitespace-only = absent.
+     */
+    owner: z.string().default(''),
+  })
+  .strict();
+export type CodePrEnableReadinessEvidence = z.infer<typeof CodePrEnableReadinessEvidenceSchema>;
+
+/** One checked condition of the enable gate. */
+export interface CodePrReadinessCriterion {
+  readonly name: string;
+  readonly met: boolean;
+  readonly detail: string;
+}
+
+/** Full enable-readiness verdict. `ready` is true IFF every criterion is met. */
+export interface CodePrEnableReadiness {
+  readonly ready: boolean;
+  readonly criteria: readonly CodePrReadinessCriterion[];
+  /** Names of the unmet criteria (empty when ready). */
+  readonly blockers: readonly string[];
+}
+
+/** Build a "named X present" criterion, keeping the main fn flat. */
+function presenceCriterion(
+  name: string,
+  label: string,
+  value: string,
+  required: boolean
+): CodePrReadinessCriterion {
+  const present = value !== '';
+  return {
+    name,
+    met: !required || present,
+    detail: present ? `${label}: ${value}` : `no ${label}`,
+  };
+}
+
+/** Build the four ordered enable-gate criteria from validated evidence + config. */
+function buildCriteria(
+  ev: CodePrEnableReadinessEvidence,
+  cfg: CodePrEnableReadinessConfig
+): CodePrReadinessCriterion[] {
+  const voteRef = ev.enableVoteRef.trim();
+  const owner = ev.owner.trim();
+  return [
+    {
+      name: 'flag-enabled',
+      met: ev.flagEnabled,
+      detail: ev.flagEnabled ? 'OFF→on flag is set' : 'OFF→on flag is not set',
+    },
+    {
+      name: 'enable-vote-ref',
+      met: !cfg.requireEnableVoteRef || voteRef !== '',
+      detail: voteRef !== '' ? `enable-vote ref: ${voteRef}` : 'no enable-vote ref',
+    },
+    {
+      name: 'guards-green-soak',
+      met: ev.consecutiveGreenDryRuns >= cfg.minGuardsGreenSoak,
+      detail: `${String(ev.consecutiveGreenDryRuns)} consecutive green dry-runs (need ≥ ${String(cfg.minGuardsGreenSoak)})`,
+    },
+    presenceCriterion('owner-ack', 'owner', owner, cfg.requireOwnerAck),
+  ];
+}
+
+/** A single-blocker fail-closed verdict (malformed evidence/config). */
+function failClosed(name: string, detail: string): CodePrEnableReadiness {
+  return { ready: false, criteria: [{ name, met: false, detail }], blockers: [name] };
+}
+
+/**
+ * Evaluate whether the code-PR autonomous push path may be enabled. Pure and
+ * deterministic; supply the realized evidence. Returns `ready: true` ONLY when
+ * ALL criteria hold — the flag ALONE can never make it ready:
+ *
+ *  1. **flag-enabled** — the explicit OFF→on flag is set;
+ *  2. **enable-vote-ref** — a recorded enable-vote ref is present (non-empty);
+ *  3. **guards-green-soak** — `consecutiveGreenDryRuns >= minGuardsGreenSoak`;
+ *  4. **owner-ack** — a named owner accepts activation.
+ *
+ * On a malformed evidence object the function fails closed (`ready: false` with
+ * an `evidence-shape` blocker) rather than throwing — an unparseable gate input
+ * must never be read as "ready".
+ *
+ * Stage 3 (the push) MUST call this and refuse to push unless `ready === true`.
+ */
+export function evaluateCodePrEnableReadiness(
+  evidence: CodePrEnableReadinessEvidence,
+  config: CodePrEnableReadinessConfig = DEFAULT_CODEPR_ENABLE_READINESS_CONFIG
+): CodePrEnableReadiness {
+  const parsedEvidence = CodePrEnableReadinessEvidenceSchema.safeParse(evidence);
+  if (!parsedEvidence.success) {
+    return failClosed('evidence-shape', 'malformed enable-readiness evidence (fail-closed)');
+  }
+  const parsedConfig = CodePrEnableReadinessConfigSchema.safeParse(config);
+  if (!parsedConfig.success) {
+    return failClosed('config-shape', 'malformed enable-readiness config (fail-closed)');
+  }
+
+  const criteria = buildCriteria(parsedEvidence.data, parsedConfig.data);
+  const blockers = criteria.filter((c) => !c.met).map((c) => c.name);
+  return { ready: blockers.length === 0, criteria, blockers };
+}

--- a/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the dry-run code-PR worktree orchestrator (#3670, Stage 2 — OFF).
+ *
+ * The point: prove the orchestrator (a) produces a planned PR descriptor on a
+ * small in-bounds change, (b) NEVER pushes/opens a PR (it imports no such
+ * surface — asserted structurally over the source), (c) ATOMICALLY DISCARDS the
+ * throwaway worktree even on failure/throw, and (d) FAILS CLOSED on a sensitive
+ * path, a secret, an over-budget change set, and an induced throw — with NO
+ * partial application.
+ *
+ * Each test spawns its worktree from a REAL throwaway git repo (init'd in tmp),
+ * never the live checkout.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, realpathSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { planCodePrRun, type CodePrRunInput, type OrchestratorPhase } from './codepr-orchestrator.js';
+import type { IAuditLogger, AuditEventInput } from '../../audit/audit-types.js';
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function makeCapturingLogger(): { logger: IAuditLogger; events: AuditEventInput[] } {
+  const events: AuditEventInput[] = [];
+  const logger: IAuditLogger = {
+    log: (input) => {
+      events.push(input);
+    },
+    logToolInvocation: () => {},
+    logPolicyDecision: () => {},
+    logSecurityEvent: () => {},
+    logRateLimitViolation: () => {},
+    logTierTransition: () => {},
+    flush: async () => {},
+    close: async () => {},
+  };
+  return { logger, events };
+}
+
+/** Init a real, committed throwaway git repo to spawn worktrees from. */
+function makeRepo(): { repoRoot: string; cleanup: () => void } {
+  const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'codepr-orch-repo-')));
+  const run = (args: string[]): void => {
+    execFileSync('git', args, { cwd: repoRoot, stdio: 'ignore' });
+  };
+  run(['init', '-b', 'main']);
+  run(['config', 'user.email', 'test@example.com']);
+  run(['config', 'user.name', 'Test']);
+  writeFileSync(join(repoRoot, 'README.md'), '# fixture repo\n');
+  run(['add', '-A']);
+  run(['commit', '-m', 'init']);
+  return {
+    repoRoot,
+    cleanup: () => {
+      rmSync(repoRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+/** List worktrees the repo currently knows about (besides the main one). */
+function linkedWorktrees(repoRoot: string): string[] {
+  const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .filter((l) => l.startsWith('worktree '))
+    .map((l) => l.slice('worktree '.length))
+    .filter((p) => realpathSync(p) !== repoRoot);
+}
+
+/** Count temp dirs the orchestrator may have left behind. */
+function residualTempDirs(): string[] {
+  return readdirSync(tmpdir()).filter((n) => n.startsWith('codepr-orchestrator-'));
+}
+
+let repo: { repoRoot: string; cleanup: () => void };
+beforeEach(() => {
+  repo = makeRepo();
+});
+afterEach(() => {
+  repo.cleanup();
+});
+
+const baseInput = (changes: CodePrRunInput['changes']): CodePrRunInput => ({
+  runId: 'run-abc',
+  sourceSignalHash: 'sig-hash-123',
+  changes,
+});
+
+// ----------------------------------------------------------------------------
+// Happy path
+// ----------------------------------------------------------------------------
+
+describe('planCodePrRun — happy path', () => {
+  it('small in-bounds change → ok plan, audit recorded, worktree discarded', () => {
+    const { logger, events } = makeCapturingLogger();
+    const before = residualTempDirs().length;
+
+    const result = planCodePrRun(
+      baseInput([{ relPath: 'src/new-feature.ts', newContent: 'export const x = 1;\n' }]),
+      logger,
+      { repoRoot: repo.repoRoot }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.auditRecorded).toBe(true);
+    expect(result.plan.branchName).toBe('auto/codepr/run-abc');
+    expect(result.plan.files.map((f) => f.path)).toEqual(['src/new-feature.ts']);
+    expect(result.plan.filesTouched).toBe(1);
+    expect(result.plan.linesTouched).toBe(1);
+    expect(result.plan.diffHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // Audit recorded a would_open_pr event.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('autonomous_code_pr.would_open_pr');
+
+    // The live fixture repo was NOT modified.
+    expect(readFileSync(join(repo.repoRoot, 'README.md'), 'utf8')).toBe('# fixture repo\n');
+    expect(existsSync(join(repo.repoRoot, 'src/new-feature.ts'))).toBe(false);
+
+    // Worktree discarded: none linked, no residual temp dir.
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+    expect(residualTempDirs().length).toBe(before);
+  });
+
+  it('the orchestrator source imports NO push/PR-open/network surface', () => {
+    const src = readFileSync(new URL('./codepr-orchestrator.ts', import.meta.url), 'utf8');
+    // No PR-open or push verbs.
+    expect(src).not.toMatch(/git\s*\(\s*[^)]*['"`]push['"`]/);
+    expect(src).not.toMatch(/['"`]push['"`]\s*,/);
+    expect(src).not.toMatch(/gh\s+pr\s+create|pulls|createPullRequest|octokit|@octokit/i);
+    // No network clients.
+    expect(src).not.toMatch(/\bfetch\b|node:https?|axios|undici/);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Fail-closed
+// ----------------------------------------------------------------------------
+
+describe('planCodePrRun — fail-closed', () => {
+  it('sensitive path (package.json) → denied, no partial apply, worktree discarded', () => {
+    const { logger, events } = makeCapturingLogger();
+    const result = planCodePrRun(
+      baseInput([
+        { relPath: 'src/ok.ts', newContent: 'export const ok = 1;\n' },
+        { relPath: 'package.json', newContent: '{"name":"x"}\n' },
+      ]),
+      logger,
+      { repoRoot: repo.repoRoot }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('sensitive_path');
+    // Abort was audited.
+    expect(events.some((e) => e.action === 'autonomous_code_pr.abort')).toBe(true);
+    // No partial application reached the live repo, worktree gone.
+    expect(existsSync(join(repo.repoRoot, 'src/ok.ts'))).toBe(false);
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('sensitive path (governance/x) → denied', () => {
+    const { logger } = makeCapturingLogger();
+    const result = planCodePrRun(
+      baseInput([{ relPath: 'governance/policy.yaml', newContent: 'x: 1\n' }]),
+      logger,
+      { repoRoot: repo.repoRoot }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('sensitive_path');
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('path escape (../) → denied path_escape', () => {
+    const { logger } = makeCapturingLogger();
+    const result = planCodePrRun(
+      baseInput([{ relPath: '../escape.ts', newContent: 'export const e = 1;\n' }]),
+      logger,
+      { repoRoot: repo.repoRoot }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('path_escape');
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('secret in newContent → denied secret_detected via scanDiffOrDeny', () => {
+    const { logger } = makeCapturingLogger();
+    const result = planCodePrRun(
+      baseInput([
+        { relPath: 'src/leak.ts', newContent: 'const key = "AKIAIOSFODNN7EXAMPLE";\n' },
+      ]),
+      logger,
+      { repoRoot: repo.repoRoot }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('secret_detected');
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('over-budget change set (too many lines) → denied blast_radius_exceeded', () => {
+    const { logger } = makeCapturingLogger();
+    const bigContent = `${Array.from({ length: 50 }, (_, i) => `export const v${String(i)} = ${String(i)};`).join('\n')}\n`;
+    const result = planCodePrRun(
+      baseInput([{ relPath: 'src/big.ts', newContent: bigContent }]),
+      logger,
+      { repoRoot: repo.repoRoot, blastRadiusLimits: { maxFiles: 20, maxLines: 10 } }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('blast_radius_exceeded');
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it.each<OrchestratorPhase>(['after-worktree', 'after-apply', 'after-diff'])(
+    'induced throw at %s → denied (not thrown) AND worktree discarded (atomic)',
+    (phase) => {
+      const { logger } = makeCapturingLogger();
+      const before = residualTempDirs().length;
+      const result = planCodePrRun(
+        baseInput([{ relPath: 'src/ok.ts', newContent: 'export const ok = 1;\n' }]),
+        logger,
+        {
+          repoRoot: repo.repoRoot,
+          faultInjector: (p) => {
+            if (p === phase) throw new Error(`injected fault at ${p}`);
+          },
+        }
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected denial');
+      expect(result.reason).toBe('guard_error');
+      expect(result.detail).toContain('injected fault');
+      // Atomic discard held despite the throw.
+      expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+      expect(residualTempDirs().length).toBe(before);
+    }
+  );
+
+  it('invalid input (empty changes) → denied without throwing', () => {
+    const { logger } = makeCapturingLogger();
+    const result = planCodePrRun(baseInput([]), logger, { repoRoot: repo.repoRoot });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('guard_error');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.ts
@@ -1,0 +1,467 @@
+/**
+ * Dry-run code-PR worktree orchestrator (#3670, Stage 2 — OFF, NO push).
+ *
+ * COMPOSES the hardened Stage-1 guards ({@link confinePath}, {@link classifyPath},
+ * {@link evaluateWriteGuards}, {@link auditAutonomousEvent}) over a PROPOSED change
+ * set inside an ISOLATED, throwaway git worktree, then returns a "planned PR
+ * descriptor" — what it WOULD push — and ATOMICALLY DISCARDS the worktree. It
+ * does NOT reimplement any guard.
+ *
+ * ABSOLUTE SCOPE LOCK (this stage):
+ *  - NO `git push`, NO PR-open, NO write to the live working tree, NO network.
+ *    This module imports NO push/PR-open/network surface — it is STRUCTURALLY
+ *    incapable of an autonomous external action. The only git it touches is the
+ *    local `git worktree add/remove` of a private temp checkout, and a local
+ *    `git diff` to realize line counts.
+ *  - OFF-by-default with no runtime consumer (see the export marker below). The
+ *    actual scoped-token push is Stage 3, gated behind the enable-vote double-gate
+ *    in {@link evaluateCodePrEnableReadiness}.
+ *
+ * Flow (all fail-closed):
+ *  1. Create an isolated throwaway worktree under `os.tmpdir()` via
+ *     `git worktree add --detach` from the repo (never the live tree).
+ *  2. For each change, run {@link confinePath} + {@link classifyPath}. Any
+ *     escape or sensitive path → ABORT the WHOLE plan (no partial application),
+ *     audit the abort, return a denied plan.
+ *  3. Apply the confined, non-sensitive changes inside the worktree only.
+ *  4. Realize the diff (files + added/removed line counts) via `git diff`.
+ *  5. Run {@link evaluateWriteGuards} (blast-radius, secret-scan, budget). Any
+ *     denial → abort fail-closed + audit + denied plan.
+ *  6. On success, build the planned PR descriptor, audit `would_open_pr`, return
+ *     `{ ok: true, plan, auditRecorded: true }`. DO NOT push or open a PR.
+ *  7. ATOMIC DISCARD: a `finally` ALWAYS removes the throwaway worktree (even on
+ *     throw). The whole body is wrapped so a throw becomes a denied result.
+ *
+ * @module mcp/tools/codepr-orchestrator
+ */
+
+// @export-no-consumer-yet — see #3670 (Stage 2; consumer/push lands in Stage 3 behind enable-vote)
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { z } from 'zod';
+import {
+  confinePath,
+  classifyPath,
+  evaluateWriteGuards,
+  auditAutonomousEvent,
+  type GuardDenialReason,
+  type ChangedFile,
+  type BlastRadiusLimits,
+  type ResourceBudgetLimits,
+  type ResourceUsage,
+} from './codepr-guards.js';
+import type { IAuditLogger } from '../../audit/audit-types.js';
+
+// ============================================================================
+// Input / output shapes
+// ============================================================================
+
+/** Zod schema for a single proposed change (a relative path + its new content). */
+export const ProposedChangeSchema = z
+  .object({
+    /** Repo-relative path the change would write. */
+    relPath: z.string().min(1),
+    /** The full new file content. */
+    newContent: z.string(),
+  })
+  .strict();
+export type ProposedChange = z.infer<typeof ProposedChangeSchema>;
+
+/** Zod schema for {@link planCodePrRun}'s input. */
+export const CodePrRunInputSchema = z
+  .object({
+    /** Correlates all audit events for this run. */
+    runId: z.string().min(1),
+    /** Hash of the source signal (fitness/improvement) that triggered the run. */
+    sourceSignalHash: z.string().min(1),
+    /** The proposed change set. */
+    changes: z.array(ProposedChangeSchema).min(1),
+  })
+  .strict();
+export type CodePrRunInput = z.infer<typeof CodePrRunInputSchema>;
+
+/** Optional knobs for {@link planCodePrRun} (limits + dependency seams for tests). */
+export interface CodePrRunOptions {
+  /** Absolute path to the repo to spawn the throwaway worktree from. Defaults to cwd. */
+  readonly repoRoot?: string | undefined;
+  /** Optional blast-radius limits override (passed straight to the guards). */
+  readonly blastRadiusLimits?: BlastRadiusLimits | undefined;
+  /** Optional resource-budget limits override (passed straight to the guards). */
+  readonly resourceLimits?: ResourceBudgetLimits | undefined;
+  /** Realized resource usage for the run; defaults to a zero snapshot. */
+  readonly usage?: ResourceUsage | undefined;
+  /**
+   * Test seam: inject a fault at a named phase so the fail-closed + atomic-discard
+   * paths are exercisable without a real failure. Undefined in production.
+   */
+  readonly faultInjector?: ((phase: OrchestratorPhase) => void) | undefined;
+}
+
+/** Lifecycle phases a {@link CodePrRunOptions.faultInjector} can target. */
+export type OrchestratorPhase = 'after-worktree' | 'after-apply' | 'after-diff';
+
+/** A file in the planned PR descriptor. */
+export interface PlannedFile {
+  readonly path: string;
+  readonly addedLines: number;
+  readonly removedLines: number;
+}
+
+/** The "planned PR descriptor" — what the run WOULD push (it does NOT push). */
+export interface PlannedPrDescriptor {
+  /** The branch name the push WOULD use (never created on a remote). */
+  readonly branchName: string;
+  /** The PR title the open WOULD use. */
+  readonly title: string;
+  /** Files the change touched, with realized line counts. */
+  readonly files: readonly PlannedFile[];
+  /** Total files touched. */
+  readonly filesTouched: number;
+  /** Total changed lines (added + removed). */
+  readonly linesTouched: number;
+  /** SHA-256 of the realized unified diff (content pinned without storing it). */
+  readonly diffHash: string;
+}
+
+/** Discriminated plan result. NEVER thrown — a failure is a denied value. */
+export type CodePrPlan =
+  | { readonly ok: true; readonly plan: PlannedPrDescriptor; readonly auditRecorded: boolean }
+  | {
+      readonly ok: false;
+      readonly reason: GuardDenialReason;
+      readonly detail: string;
+      readonly auditRecorded: boolean;
+    };
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+const ORCHESTRATOR_USAGE_ZERO: ResourceUsage = { wallClockMs: 0, tokens: 0, toolCalls: 0 };
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+/** Run git in a given cwd, capturing stdout. Throws on non-zero (caller wraps). */
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Parse `git diff --numstat` output into per-file added/removed line counts.
+ * A binary file is reported as `-\t-\t<path>`; we count those as 0/0 (the secret
+ * scan + blast radius already operate on the realized diff text and paths).
+ */
+function parseNumstat(numstat: string): ChangedFile[] {
+  const files: ChangedFile[] = [];
+  for (const line of numstat.split('\n')) {
+    if (line.trim() === '') continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    const added = parts[0] === '-' ? 0 : Number.parseInt(parts[0] ?? '0', 10);
+    const removed = parts[1] === '-' ? 0 : Number.parseInt(parts[1] ?? '0', 10);
+    const path = parts.slice(2).join('\t');
+    files.push({
+      path,
+      addedLines: Number.isFinite(added) ? added : 0,
+      removedLines: Number.isFinite(removed) ? removed : 0,
+    });
+  }
+  return files;
+}
+
+function denied(
+  reason: GuardDenialReason,
+  detail: string,
+  auditRecorded: boolean
+): CodePrPlan {
+  return { ok: false, reason, detail, auditRecorded };
+}
+
+/** Arguments for {@link auditAbort} (bundled to keep the param count low). */
+interface AbortAudit {
+  readonly input: CodePrRunInput;
+  readonly reason: GuardDenialReason;
+  readonly diffHash: string;
+  readonly filesTouched: number;
+  readonly linesTouched: number;
+}
+
+/**
+ * Audit a fail-closed abort, returning whether the audit append itself succeeded.
+ * Never throws (delegates to {@link auditAutonomousEvent}, which converts a logger
+ * throw to a denial result).
+ */
+function auditAbort(logger: IAuditLogger, a: AbortAudit): boolean {
+  const res = auditAutonomousEvent(logger, {
+    runId: a.input.runId,
+    sourceSignalHash: a.input.sourceSignalHash,
+    diffHash: a.diffHash,
+    scanVerdict: a.reason === 'secret_detected' ? 'secret_detected' : 'clean',
+    filesTouched: a.filesTouched,
+    linesTouched: a.linesTouched,
+    tokenIdentity: 'none',
+    decision: 'abort',
+    abortReason: a.reason,
+  });
+  return res.ok;
+}
+
+/**
+ * Confine + classify EVERY change BEFORE applying any (no partial application).
+ * Returns a denied plan on the first escape/sensitive path, else `undefined`.
+ */
+function precheckChanges(
+  worktreeRoot: string,
+  run: CodePrRunInput,
+  logger: IAuditLogger
+): CodePrPlan | undefined {
+  for (const change of run.changes) {
+    const confined = confinePath(worktreeRoot, change.relPath);
+    if (!confined.ok) {
+      const recorded = auditAbort(logger, {
+        input: run,
+        reason: confined.reason,
+        diffHash: sha256(''),
+        filesTouched: 0,
+        linesTouched: 0,
+      });
+      return denied(confined.reason, confined.detail, recorded);
+    }
+    const cls = classifyPath(change.relPath);
+    if (cls.sensitive) {
+      const recorded = auditAbort(logger, {
+        input: run,
+        reason: 'sensitive_path',
+        diffHash: sha256(''),
+        filesTouched: 0,
+        linesTouched: 0,
+      });
+      return denied('sensitive_path', `sensitive path (${cls.category}): ${change.relPath}`, recorded);
+    }
+  }
+  return undefined;
+}
+
+/** Apply the (already prechecked) changes inside the worktree, writing to the canonical path. */
+function applyChanges(worktreeRoot: string, run: CodePrRunInput): void {
+  for (const change of run.changes) {
+    // Re-resolve to the canonical path confinePath returned and write THERE
+    // (closing the symlink TOCTOU). Precheck guarantees this resolves.
+    const confined = confinePath(worktreeRoot, change.relPath);
+    if (!confined.ok) throw new Error(`apply: ${confined.detail}`);
+    mkdirSync(dirname(confined.resolvedPath), { recursive: true });
+    writeFileSync(confined.resolvedPath, change.newContent);
+  }
+}
+
+/** The realized diff facts for the staged worktree change set. */
+interface RealizedDiff {
+  readonly diffText: string;
+  readonly diffHash: string;
+  readonly changedFiles: ChangedFile[];
+  readonly linesTouched: number;
+}
+
+/** Stage all changes and realize the diff (files + line counts) from the worktree. */
+function realizeDiff(worktreeRoot: string): RealizedDiff {
+  git(worktreeRoot, ['add', '-A']);
+  const diffText = git(worktreeRoot, ['diff', '--cached']);
+  const changedFiles = parseNumstat(git(worktreeRoot, ['diff', '--cached', '--numstat']));
+  let linesTouched = 0;
+  for (const f of changedFiles) linesTouched += f.addedLines + f.removedLines;
+  return { diffText, diffHash: sha256(diffText), changedFiles, linesTouched };
+}
+
+/** Bundle for {@link runGuardsAndPlan} (kept low to satisfy the param-count rule). */
+interface GuardsStageArgs {
+  readonly worktreeRoot: string;
+  readonly run: CodePrRunInput;
+  readonly realized: RealizedDiff;
+  readonly usage: ResourceUsage;
+  readonly blastRadiusLimits?: BlastRadiusLimits | undefined;
+  readonly resourceLimits?: ResourceBudgetLimits | undefined;
+}
+
+/**
+ * Steps 5–6: compose the hardened write guards over the realized change set, and
+ * on success build + audit the planned PR descriptor. Returns a denied plan on any
+ * guard denial or a failed audit, else the green plan. NO push.
+ */
+function runGuardsAndPlan(args: GuardsStageArgs, logger: IAuditLogger): CodePrPlan {
+  const { worktreeRoot, run, realized } = args;
+  const verdict = evaluateWriteGuards({
+    worktreeRoot,
+    changedFiles: realized.changedFiles,
+    diff: realized.diffText,
+    usage: args.usage,
+    blastRadiusLimits: args.blastRadiusLimits,
+    resourceLimits: args.resourceLimits,
+  });
+  if (!verdict.ok) {
+    const recorded = auditAbort(logger, {
+      input: run,
+      reason: verdict.reason,
+      diffHash: realized.diffHash,
+      filesTouched: realized.changedFiles.length,
+      linesTouched: realized.linesTouched,
+    });
+    return denied(verdict.reason, verdict.detail, recorded);
+  }
+
+  const plan: PlannedPrDescriptor = {
+    branchName: `auto/codepr/${run.runId}`,
+    title: `auto code-PR (dry-run, NO push) for run ${run.runId}`,
+    files: realized.changedFiles.map((f) => ({
+      path: f.path,
+      addedLines: f.addedLines,
+      removedLines: f.removedLines,
+    })),
+    filesTouched: realized.changedFiles.length,
+    linesTouched: realized.linesTouched,
+    diffHash: realized.diffHash,
+  };
+  const audit = auditAutonomousEvent(logger, {
+    runId: run.runId,
+    sourceSignalHash: run.sourceSignalHash,
+    diffHash: realized.diffHash,
+    scanVerdict: 'clean',
+    filesTouched: plan.filesTouched,
+    linesTouched: plan.linesTouched,
+    tokenIdentity: 'none',
+    decision: 'would_open_pr',
+  });
+  if (!audit.ok) {
+    // A failed audit is itself fail-closed: do NOT report a green plan.
+    return denied(audit.reason, audit.detail, false);
+  }
+  return { ok: true, plan, auditRecorded: true };
+}
+
+// ============================================================================
+// Orchestrator
+// ============================================================================
+
+/** Mutable holder for the throwaway worktree paths, so the finally can discard them. */
+interface WorktreeHandle {
+  worktreeRoot?: string;
+  tempParent?: string;
+}
+
+/**
+ * Steps 1–6 inside the throwaway worktree. Records its created paths into
+ * `handle` so the caller's finally can discard them even if this throws. Returns
+ * a plan (ok or denied); throws only on an unexpected fault (the caller wraps).
+ */
+function runInWorktree(
+  run: CodePrRunInput,
+  logger: IAuditLogger,
+  options: CodePrRunOptions,
+  handle: WorktreeHandle
+): CodePrPlan {
+  const fault = options.faultInjector;
+  const repoRoot = options.repoRoot ?? process.cwd();
+
+  // 1. Isolated throwaway worktree under os.tmpdir() — NEVER the live tree.
+  handle.tempParent = realpathSync(mkdtempSync(join(tmpdir(), 'codepr-orchestrator-')));
+  handle.worktreeRoot = join(handle.tempParent, 'wt');
+  git(repoRoot, ['worktree', 'add', '--detach', handle.worktreeRoot]);
+  fault?.('after-worktree');
+
+  // 2. Confine + classify EVERY change before applying any (no partial apply).
+  const precheck = precheckChanges(handle.worktreeRoot, run, logger);
+  if (precheck !== undefined) return precheck;
+
+  // 3. Apply the confined, non-sensitive changes inside the worktree only.
+  applyChanges(handle.worktreeRoot, run);
+  fault?.('after-apply');
+
+  // 4. Realize the diff (files + line counts) from the worktree itself.
+  const realized = realizeDiff(handle.worktreeRoot);
+  fault?.('after-diff');
+
+  // 5–6. Compose the hardened write guards, then build + audit the plan. NO push.
+  return runGuardsAndPlan(
+    {
+      worktreeRoot: handle.worktreeRoot,
+      run,
+      realized,
+      usage: options.usage ?? ORCHESTRATOR_USAGE_ZERO,
+      blastRadiusLimits: options.blastRadiusLimits,
+      resourceLimits: options.resourceLimits,
+    },
+    logger
+  );
+}
+
+/** ATOMIC DISCARD — best-effort remove the throwaway worktree + temp dir. Never throws. */
+function discardWorktree(repoRoot: string, handle: WorktreeHandle): void {
+  if (handle.worktreeRoot !== undefined) {
+    try {
+      git(repoRoot, ['worktree', 'remove', '--force', handle.worktreeRoot]);
+    } catch {
+      // fall through to the rm below (the rmSync still clears residual state)
+    }
+  }
+  if (handle.tempParent !== undefined) {
+    try {
+      rmSync(handle.tempParent, { recursive: true, force: true });
+    } catch {
+      // best-effort; the temp dir is under os.tmpdir() and OS-reclaimable
+    }
+  }
+}
+
+/**
+ * Plan a dry-run code-PR over `input`'s change set inside an isolated throwaway
+ * worktree, composing the Stage-1 guards. Returns a {@link CodePrPlan} — `ok` with
+ * a planned PR descriptor (NO push), or a fail-closed denial. NEVER throws and
+ * NEVER pushes/opens a PR/writes the live tree; ALWAYS removes the throwaway
+ * worktree (atomic discard) in a `finally`.
+ *
+ * @param input - The proposed change set (Zod-validated; bad shape → denied).
+ * @param logger - Hash-chained audit logger (precondition C audit on pass + abort).
+ * @param options - Limits + test seams (repo root, fault injector).
+ */
+export function planCodePrRun(
+  input: CodePrRunInput,
+  logger: IAuditLogger,
+  options: CodePrRunOptions = {}
+): CodePrPlan {
+  const parsed = CodePrRunInputSchema.safeParse(input);
+  if (!parsed.success) {
+    // Cannot even audit meaningfully without a runId; fail closed as a value.
+    return denied('guard_error', 'invalid code-PR run input (fail-closed)', false);
+  }
+  const run = parsed.data;
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const handle: WorktreeHandle = {};
+
+  try {
+    return runInWorktree(run, logger, options, handle);
+  } catch (err) {
+    // Any throw (worktree spawn, git, fs, injected fault) becomes a denial.
+    const message = err instanceof Error ? err.message : String(err);
+    let recorded = false;
+    try {
+      recorded = auditAbort(logger, {
+        input: run,
+        reason: 'guard_error',
+        diffHash: sha256(''),
+        filesTouched: 0,
+        linesTouched: 0,
+      });
+    } catch {
+      recorded = false;
+    }
+    return denied('guard_error', `orchestrator failed (fail-closed): ${message}`, recorded);
+  } finally {
+    // 7. ATOMIC DISCARD — always remove the throwaway worktree, even on throw.
+    discardWorktree(repoRoot, handle);
+  }
+}


### PR DESCRIPTION
Stage 2 of closing the capability loop (#3670). **OFF-by-default, no runtime consumer.** Composes the hardened, merged Stage-1 guards (`codepr-guards.ts`); reimplements no guard logic. Both new files carry the `@export-no-consumer-yet — see #3670` marker.

## Part A — enable-readiness DOUBLE-GATE (pure, deterministic)

`evaluateCodePrEnableReadiness(evidence)` mirrors `evaluateEnforceReadiness`'s shape. Returns `ready: true` **only** when ALL criteria hold (fail-closed otherwise, naming each blocker):

1. **flag-enabled** — the explicit OFF→on flag is set (passed in as a boolean, NOT read from env — kept pure).
2. **enable-vote-ref** — a recorded enable-vote ref is present (non-empty), analogous to `ratificationVoteRef`.
3. **guards-green-soak** — `consecutiveGreenDryRuns >= minGuardsGreenSoak` (default 50 consecutive dry-run plans with zero guard denials).
4. **owner-ack** — a named owner accepts activation.

The point of the double-gate: **the raw flag ALONE can never activate the push path** — `ready` additionally requires the vote ref + soak + owner. Evidence is Zod-validated; a malformed object fails closed (`ready:false`). Stage 3 (the push) MUST call this and refuse unless `ready === true`.

## Part B — dry-run worktree orchestrator

`planCodePrRun(input, logger, options)` given `{ runId, sourceSignalHash, changes: {relPath, newContent}[] }`:

1. Creates an **isolated throwaway worktree** under `os.tmpdir()` via `git worktree add --detach` from the repo — never the live working tree.
2. Runs `confinePath` + `classifyPath` on **every** change *before* applying any. Any escape or sensitive path → ABORT the whole plan fail-closed (no partial application), audit the abort, return a denied plan.
3. Applies the confined, non-sensitive changes inside the worktree only (writing to the canonical resolved path, closing the symlink TOCTOU).
4. Realizes the diff (files + added/removed line counts) via `git diff --cached --numstat`.
5. Runs `evaluateWriteGuards` (blast-radius, secret-scan, resource budget). Any denial → abort fail-closed + audit + denied plan.
6. On success, builds a **planned PR descriptor** (branch name, title, diff summary, files touched) — what it WOULD push — audits `would_open_pr`, and returns `{ ok:true, plan, auditRecorded:true }`.
7. **ATOMIC DISCARD**: a `finally` always removes the throwaway worktree (`git worktree remove --force` + `rm` the temp dir), even on failure/throw. The whole body is wrapped so a throw becomes a fail-closed denied result — it **never throws**.

## NO push / PR-open / live-write — structural

This stage performs **NO `git push`, NO PR-open, NO write to the live checkout, NO network**. The module imports no push/PR-open/network surface; the only git it touches is the local `git worktree add/remove` of a private temp checkout plus a local `git diff`. A dedicated test asserts the source contains no push/PR-open/network references. It is structurally incapable of an autonomous external action.

## Tests (94 pass: 22 new + 72 existing guards still green)

**enable-readiness (11):** flag-only (no vote/soak/owner) → `ready:false` naming all three; all criteria → `ready:true`; each missing criterion → `ready:false` naming it; whitespace-only refs treated as absent; soak boundary (`>=`); malformed evidence fails closed.

**orchestrator happy path:** small in-bounds change → ok plan, audit recorded, live fixture repo unmodified, worktree removed (no linked worktree, no residual temp dir); source-scan test asserts no push/PR-open/network import.

**orchestrator fail-closed:** sensitive path (`package.json`, `governance/x`) → denied, no partial apply, worktree removed; path escape (`../`) → `path_escape`; secret in `newContent` → `secret_detected` via `scanDiffOrDeny`; over-budget change set → `blast_radius_exceeded`; **induced throw at each phase (after-worktree / after-apply / after-diff) → returns denied (not thrown) AND worktree still removed (atomic discard verified)**; invalid input → denied without throwing.

## Gates

Zero `any`; `tsc --noEmit` clean; eslint clean on changed files; new + existing tests green. No MCP tool / CLI command / workflow added — **repo-index unaffected**. Changeset `.changeset/codepr-orchestrator-stage2-3670.md` (`'nexus-agents': minor`, `feat`).

## Stage 3 (still pending)

The actual scoped-token push behind the enable-vote is **Stage 3**, gated by `evaluateCodePrEnableReadiness` returning `ready:true`. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)