### PR TITLE
feat(capability-loop): dry-run code-PR soak consumer in audit mode — accumulates enable-readiness evidence, no push (#3670)

### DIFF
--- a/.changeset/codepr-soak-consumer-3670.md
+++ b/.changeset/codepr-soak-consumer-3670.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): dry-run code-PR soak consumer in audit mode (#3670 Stage 2.5)
+
+Wire the dry-run code-PR orchestrator (`planCodePrRun`) as a SOAK consumer of the
+Stage-1 guards, driven from auto-remediation's AUDIT mode. When a code-touching
+remediation plan is produced in audit mode, the cycle now runs `planCodePrRun` in
+dry-run over a derived change set and records one durable guards-green-soak data
+point (green on a clean plan, denied on a guard denial/error). The recorded count
+is read back as the `consecutiveGreenDryRuns` evidence
+`evaluateCodePrEnableReadiness` consumes — so audit mode accumulates the
+guards-green-soak the enable double-gate requires.
+
+Dry-run only: NO push, NO PR-open, NO live write (the orchestrator already
+discards its throwaway worktree atomically). Best-effort: a soak-step failure is
+swallowed (WARN) and never breaks the remediation cycle. Runs ONLY in audit mode;
+off/enforce behavior is unchanged.

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.test.ts
@@ -16,6 +16,9 @@ import {
   _resetRemediationSoakSinkForTests,
 } from './improvement-remediation-shadow.js';
 import type { ImprovementSignal } from './improvement-review.js';
+import { createCodePrSoakSink, readCodePrGuardsGreenSoak } from './codepr-soak-store.js';
+import type { CodePrPlan, PlannedPrDescriptor } from './codepr-orchestrator.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
 
 // The cycle's DEFAULT durable soak sink resolves under NEXUS_DATA_DIR (#3932).
 // Pin it to a throwaway temp dir for the whole suite so audit-mode cycles that
@@ -162,6 +165,132 @@ describe('runAutoRemediationCycle', () => {
       const rec = soakSink.getRecords()[0];
       expect(rec?.voteOutcome?.approved).toBe(false);
       expect(rec?.voteOutcome?.approvalPercentage).toBe(33);
+    });
+  });
+
+  // #3670 Stage 2.5 — the dry-run code-PR guards-green soak consumer.
+  describe('code-PR dry-run soak (#3670 Stage 2.5)', () => {
+    const okPlan: PlannedPrDescriptor = {
+      branchName: 'auto/codepr/x',
+      title: 't',
+      files: [{ path: 'src/x.ts', addedLines: 1, removedLines: 0 }],
+      filesTouched: 1,
+      linesTouched: 1,
+      diffHash: 'h',
+    };
+
+    function codeSignal(over: Partial<ImprovementSignal> = {}): ImprovementSignal {
+      // category 'bug' → the plan builder emits a code-touching 'fix-bug' + 'add-test' step.
+      // Use a NON-security key/title (no security keyword) so it admits as a normal
+      // (non-p0) remediation that reaches a plan in audit mode.
+      return signal({
+        category: 'bug',
+        signalKey: 'bug:render-glitch:ui',
+        title: 'render glitch in the dashboard',
+        body: 'pixels misaligned',
+        ...over,
+      });
+    }
+
+    it('audit-mode code-touching remediation runs planCodePrRun dry-run and increments green soak', async () => {
+      const soakDir = mkdtempSync(join(tmpdir(), 'codepr-soak-'));
+      try {
+        const sink = createCodePrSoakSink(join(soakDir, 'codepr.jsonl'));
+        const planRun = vi.fn((): CodePrPlan => ({ ok: true, plan: okPlan, auditRecorded: true }));
+        const deps = buildAutoRemediationDeps({
+          voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+        });
+
+        await runAutoRemediationCycle(
+          { mode: 'audit' },
+          {
+            collectSignals: async () => Promise.resolve([codeSignal()]),
+            deps,
+            codePrSoak: { sink, planRun },
+          }
+        );
+
+        expect(planRun).toHaveBeenCalledTimes(1);
+        expect(sink.getRecords()).toHaveLength(1);
+        expect(sink.getRecords()[0]?.green).toBe(true);
+        // The recorded count is the consecutiveGreenDryRuns evidence.
+        expect(readCodePrGuardsGreenSoak(sink)).toBe(1);
+      } finally {
+        rmSync(soakDir, { recursive: true, force: true });
+      }
+    });
+
+    it('a guard-denied dry-run records a denial (does NOT increment the green streak)', async () => {
+      const soakDir = mkdtempSync(join(tmpdir(), 'codepr-soak-denied-'));
+      try {
+        const sink = createCodePrSoakSink(join(soakDir, 'codepr.jsonl'));
+        const planRun = vi.fn(
+          (): CodePrPlan => ({ ok: false, reason: 'sensitive_path', detail: 'x', auditRecorded: true })
+        );
+        const deps = buildAutoRemediationDeps({
+          voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+        });
+
+        await runAutoRemediationCycle(
+          { mode: 'audit' },
+          {
+            collectSignals: async () => Promise.resolve([codeSignal()]),
+            deps,
+            codePrSoak: { sink, planRun },
+          }
+        );
+
+        expect(sink.getRecords()[0]?.green).toBe(false);
+        expect(readCodePrGuardsGreenSoak(sink)).toBe(0); // denial → consecutive-green is 0
+      } finally {
+        rmSync(soakDir, { recursive: true, force: true });
+      }
+    });
+
+    it('BEST-EFFORT: a soak that throws does NOT break the cycle', async () => {
+      const runCodePrSoakThrows = (_plan: RemediationPlan): void => {
+        throw new Error('soak blew up');
+      };
+      const deps = buildAutoRemediationDeps({
+        voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+      });
+
+      const r = await runAutoRemediationCycle(
+        { mode: 'audit' },
+        {
+          collectSignals: async () => Promise.resolve([codeSignal()]),
+          deps,
+          runCodePrSoak: runCodePrSoakThrows,
+        }
+      );
+
+      // The cycle still completed normally — the soak failure was swallowed.
+      expect(r.mode).toBe('audit');
+      expect(r.plans).toHaveLength(1);
+      expect(r.remediated).toEqual([]);
+    });
+
+    it('off mode does NOT run the soak', async () => {
+      const runSoak = vi.fn();
+      await runAutoRemediationCycle(
+        { mode: 'off' },
+        { collectSignals: async () => Promise.resolve([codeSignal()]), runCodePrSoak: runSoak }
+      );
+      expect(runSoak).not.toHaveBeenCalled();
+    });
+
+    it('enforce mode does NOT run the soak (soak is audit-only)', async () => {
+      const runSoak = vi.fn();
+      // Enforce aborts fail-closed (not ready / no lease) before any plan, but even
+      // if it produced a plan, the cycle only wires onPlanProduced on the audit branch.
+      const deps = buildAutoRemediationDeps({
+        voteRunner: async () => Promise.resolve({ approved: true, approvalPercentage: 100 }),
+      });
+      await runAutoRemediationCycle(
+        { mode: 'enforce' },
+        { collectSignals: async () => Promise.resolve([codeSignal()]), deps, runCodePrSoak: runSoak }
+      );
+      expect(runSoak).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-cycle.ts
@@ -27,6 +27,8 @@ import {
   type SoakSignalMeta,
   type IRecordingRemediationSoakSink,
 } from './improvement-remediation-shadow.js';
+import { runCodePrSoak, type CodePrSoakInject } from './codepr-soak-consumer.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
 import {
   runAutoRemediation,
   resolveAutoRemediateMode,
@@ -55,6 +57,14 @@ export interface AutoRemediationCycleInject {
   readonly deps?: AutoRemediationDeps;
   /** Inject an isolated durable soak sink (tests honor a temp NEXUS_DATA_DIR). */
   readonly soakSink?: IRecordingRemediationSoakSink;
+  /**
+   * AUDIT-mode dry-run code-PR soak seams (#3670 Stage 2.5). When provided,
+   * forwarded to {@link runCodePrSoak}; tests inject an isolated sink / a fake
+   * planRun. Ignored outside audit mode (the soak only runs in audit).
+   */
+  readonly codePrSoak?: CodePrSoakInject;
+  /** Test seam: override the per-plan soak runner. Defaults to {@link runCodePrSoak}. */
+  readonly runCodePrSoak?: (plan: RemediationPlan, inject?: CodePrSoakInject) => void;
 }
 
 function offResult(): AutoRemediationResult {
@@ -86,7 +96,7 @@ export async function runAutoRemediationCycle(
   // the per-signal verdicts to the durable JSONL sink at the end of the run.
   if (mode === 'audit') {
     const collector = buildSoakCollector(signals, inject);
-    const soakDeps = withSoakAudit(deps, collector);
+    const soakDeps = withCodePrSoak(withSoakAudit(deps, collector), inject);
     try {
       return await runAutoRemediation(signals, soakDeps, { mode });
     } finally {
@@ -95,6 +105,27 @@ export async function runAutoRemediationCycle(
   }
 
   return runAutoRemediation(signals, deps, { mode });
+}
+
+/**
+ * Return a deps clone whose `onPlanProduced` runs the AUDIT-mode dry-run code-PR
+ * guards-green soak (#3670 Stage 2.5) over each produced plan. The soak runner is
+ * THROW-FREE (best-effort), and `onPlanProduced` is itself wrapped by the
+ * orchestrator — a soak failure can never break the remediation cycle. Only wired
+ * on the AUDIT branch (this function is not called for off/enforce), and DRY-RUN
+ * only: no push, no PR-open, no live write.
+ */
+function withCodePrSoak(
+  deps: AutoRemediationDeps,
+  inject: AutoRemediationCycleInject
+): AutoRemediationDeps {
+  const runSoak = inject.runCodePrSoak ?? runCodePrSoak;
+  return {
+    ...deps,
+    onPlanProduced: (_signal, plan): void => {
+      runSoak(plan, inject.codePrSoak);
+    },
+  };
 }
 
 /** Build a soak collector with per-signal metadata derived from the cycle's signals. */

--- a/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
@@ -20,7 +20,10 @@
  * @module mcp/tools/codepr-enable-readiness
  */
 
-// @export-no-consumer-yet — see #3670 (Stage 2; consumer/push lands in Stage 3 behind enable-vote)
+// @export-no-consumer-yet — see #3670 (the enable double-gate is consumed by the
+// Stage-3 push, which is NOT wired yet. Stage 2.5 (#3670) now PRODUCES this gate's
+// `guards-green-soak` evidence via codepr-soak-store; `evaluateCodePrEnableReadiness`
+// itself stays without a runtime caller until Stage 3 wires the push behind it.)
 
 import { z } from 'zod';
 

--- a/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-guards.ts
@@ -36,8 +36,6 @@
  * @module mcp/tools/codepr-guards
  */
 
-// @export-no-consumer-yet — see #3670 (Stage 1 guard library; consumer lands in Stage 2/3)
-
 import { realpathSync } from 'node:fs';
 import { isAbsolute, resolve, relative, sep, dirname, basename } from 'node:path';
 import { z } from 'zod';

--- a/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-orchestrator.ts
@@ -35,8 +35,6 @@
  * @module mcp/tools/codepr-orchestrator
  */
 
-// @export-no-consumer-yet — see #3670 (Stage 2; consumer/push lands in Stage 3 behind enable-vote)
-
 import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/nexus-agents/src/mcp/tools/codepr-soak-consumer.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-soak-consumer.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the AUDIT-mode dry-run code-PR soak consumer (#3670 Stage 2.5).
+ *
+ * The point: a code-touching plan drives planCodePrRun in DRY-RUN over a derived
+ * change set and records a green/denied soak data point; a non-code plan is a
+ * no-op; the step is BEST-EFFORT (a thrown planRun is swallowed, no exception
+ * propagates); and NO push / PR-open surface is imported.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  runCodePrSoak,
+  planTouchesCode,
+  deriveProposedChanges,
+} from './codepr-soak-consumer.js';
+import type { IRecordingCodePrSoakSink } from './codepr-soak-store.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+import type { CodePrPlan, PlannedPrDescriptor } from './codepr-orchestrator.js';
+
+function plan(over: Partial<RemediationPlan> = {}): RemediationPlan {
+  return {
+    signalKey: 'bug:crash:auth',
+    category: 'bug',
+    summary: 'fix the crash',
+    steps: [
+      { kind: 'investigate', description: 'diagnose' },
+      { kind: 'fix-bug', description: 'apply the fix' },
+      { kind: 'add-test', description: 'add a regression test' },
+    ],
+    ...over,
+  };
+}
+
+const okPlan: PlannedPrDescriptor = {
+  branchName: 'auto/codepr/x',
+  title: 't',
+  files: [{ path: 'src/x.ts', addedLines: 1, removedLines: 0 }],
+  filesTouched: 2,
+  linesTouched: 2,
+  diffHash: 'h',
+};
+
+/** An in-memory soak sink (no disk). */
+function memSink(): IRecordingCodePrSoakSink {
+  const records: Parameters<IRecordingCodePrSoakSink['record']>[0][] = [];
+  return {
+    record: (r) => {
+      records.push(r);
+    },
+    getRecords: () => records,
+  };
+}
+
+describe('planTouchesCode / deriveProposedChanges', () => {
+  it('investigate-only plan does not touch code', () => {
+    expect(planTouchesCode(plan({ steps: [{ kind: 'investigate', description: 'd' }] }))).toBe(false);
+  });
+
+  it('a plan with a code-touching step touches code', () => {
+    expect(planTouchesCode(plan())).toBe(true);
+  });
+
+  it('derives one change per code-touching step, using targetPath when present', () => {
+    const p = plan({
+      steps: [
+        { kind: 'investigate', description: 'd' },
+        { kind: 'fix-bug', description: 'd', targetPath: 'src/auth/login.ts' },
+        { kind: 'add-test', description: 'd' }, // no targetPath → synthesized
+      ],
+    });
+    const changes = deriveProposedChanges(p);
+    expect(changes).toHaveLength(2);
+    expect(changes.map((c) => c.relPath)).toContain('src/auth/login.ts');
+    // The synthesized path is under src/ (a non-sensitive location).
+    expect(changes.every((c) => c.relPath.startsWith('src/'))).toBe(true);
+  });
+
+  it('investigate-only plan derives no changes', () => {
+    expect(deriveProposedChanges(plan({ steps: [{ kind: 'investigate', description: 'd' }] }))).toEqual(
+      []
+    );
+  });
+});
+
+describe('runCodePrSoak', () => {
+  it('green dry-run plan → records a green data point', () => {
+    const sink = memSink();
+    const planRun = vi.fn(
+      (): CodePrPlan => ({ ok: true, plan: okPlan, auditRecorded: true })
+    );
+    runCodePrSoak(plan(), { sink, planRun });
+
+    expect(planRun).toHaveBeenCalledTimes(1);
+    expect(sink.getRecords()).toHaveLength(1);
+    expect(sink.getRecords()[0]?.green).toBe(true);
+    expect(sink.getRecords()[0]?.filesTouched).toBe(2);
+  });
+
+  it('guard-denied dry-run plan → records a denied data point (streak reset)', () => {
+    const sink = memSink();
+    const planRun = vi.fn(
+      (): CodePrPlan => ({ ok: false, reason: 'sensitive_path', detail: 'x', auditRecorded: true })
+    );
+    runCodePrSoak(plan(), { sink, planRun });
+
+    expect(sink.getRecords()).toHaveLength(1);
+    expect(sink.getRecords()[0]?.green).toBe(false);
+    expect(sink.getRecords()[0]?.denialReason).toBe('sensitive_path');
+  });
+
+  it('non-code plan is a no-op — planRun is never called, nothing recorded', () => {
+    const sink = memSink();
+    const planRun = vi.fn((): CodePrPlan => ({ ok: true, plan: okPlan, auditRecorded: true }));
+    runCodePrSoak(plan({ steps: [{ kind: 'investigate', description: 'd' }] }), { sink, planRun });
+
+    expect(planRun).not.toHaveBeenCalled();
+    expect(sink.getRecords()).toHaveLength(0);
+  });
+
+  it('BEST-EFFORT: a thrown planRun is swallowed — no exception propagates, nothing recorded', () => {
+    const sink = memSink();
+    const planRun = vi.fn((): CodePrPlan => {
+      throw new Error('boom');
+    });
+    expect(() => {
+      runCodePrSoak(plan(), { sink, planRun });
+    }).not.toThrow();
+    expect(sink.getRecords()).toHaveLength(0);
+  });
+
+  it('BEST-EFFORT: a throwing sink does not propagate', () => {
+    const throwingSink: IRecordingCodePrSoakSink = {
+      record: () => {
+        throw new Error('disk full');
+      },
+      getRecords: () => [],
+    };
+    const planRun = vi.fn((): CodePrPlan => ({ ok: true, plan: okPlan, auditRecorded: true }));
+    expect(() => {
+      runCodePrSoak(plan(), { sink: throwingSink, planRun });
+    }).not.toThrow();
+  });
+});
+
+describe('no push / PR-open surface', () => {
+  it('the consumer source imports NO push/PR-open/network surface', () => {
+    const src = readFileSync(new URL('./codepr-soak-consumer.ts', import.meta.url), 'utf8');
+    expect(src).not.toMatch(/gh\s+pr\s+create|pulls|createPullRequest|octokit|@octokit/i);
+    expect(src).not.toMatch(/\bfetch\b|node:https?|axios|undici/);
+    expect(src).not.toMatch(/['"`]push['"`]/);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-soak-consumer.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-soak-consumer.ts
@@ -1,0 +1,215 @@
+/**
+ * AUDIT-mode dry-run code-PR SOAK consumer (#3670, Stage 2.5).
+ *
+ * Wires {@link planCodePrRun} (the Stage-2 dry-run orchestrator) as a real
+ * consumer of the Stage-1 guards, driven from auto-remediation's AUDIT mode. For
+ * a remediation plan that WOULD touch code files, it:
+ *
+ *  1. derives a PROPOSED change set from the plan's step `targetPath` hints (the
+ *     only path facts the typed plan carries) — inert marker content, never
+ *     model output, never the real edit;
+ *  2. runs {@link planCodePrRun} in DRY-RUN (it already performs NO push / NO
+ *     PR-open / NO live write — it composes the guards inside a throwaway
+ *     worktree and atomically discards it);
+ *  3. records ONE durable soak data point: green on a clean plan, denied on a
+ *     guard denial or error.
+ *
+ * The recorded streak is read back by {@link readCodePrGuardsGreenSoak} as the
+ * `consecutiveGreenDryRuns` evidence {@link evaluateCodePrEnableReadiness}
+ * consumes — so AUDIT mode now ACCUMULATES the guards-green-soak the enable
+ * double-gate requires, with zero blast radius.
+ *
+ * BEST-EFFORT: {@link runCodePrSoak} NEVER throws — any failure is logged WARN and
+ * swallowed so the auto-remediation cycle proceeds unaffected. It runs ONLY when
+ * the cycle is in AUDIT mode (the caller gates that); it does NOT run in off/enforce.
+ *
+ * @module mcp/tools/codepr-soak-consumer
+ */
+
+import { createHash } from 'node:crypto';
+
+import { createLogger, getErrorMessage, type ILogger } from '../../core/index.js';
+import type { IAuditLogger, AuditEventInput } from '../../audit/audit-types.js';
+import type { RemediationPlan } from './improvement-remediation-capability.js';
+import {
+  planCodePrRun,
+  type CodePrRunOptions,
+  type ProposedChange,
+} from './codepr-orchestrator.js';
+import {
+  getCodePrSoakSink,
+  greenCodePrSoakRecord,
+  deniedCodePrSoakRecord,
+  type CodePrSoakSink,
+} from './codepr-soak-store.js';
+
+/**
+ * Action kinds that imply a FILE change (and therefore a code-PR the push path
+ * would eventually open). `investigate` and `adjust-routing` are config/analysis
+ * actions that do not author a tracked file, so a plan made only of those is NOT
+ * a code-touching remediation and is skipped (no soak data point).
+ */
+const CODE_TOUCHING_KINDS: ReadonlySet<RemediationPlan['steps'][number]['kind']> = new Set([
+  'add-test',
+  'refactor',
+  'update-docs',
+  'fix-bug',
+]);
+
+/**
+ * Whether a plan WOULD touch code files: at least one step whose action kind
+ * authors a file ({@link CODE_TOUCHING_KINDS}). A plan made only of `investigate`
+ * / `adjust-routing` steps does NOT author a tracked file, so it is not a
+ * code-touching remediation and is skipped (no soak data point).
+ */
+export function planTouchesCode(plan: RemediationPlan): boolean {
+  return plan.steps.some((s) => CODE_TOUCHING_KINDS.has(s.kind));
+}
+
+/**
+ * A SAFE, deterministic placeholder path for a code-touching step that carries no
+ * `targetPath` hint (the deterministic plan builder produces such steps). Keyed by
+ * the signal hash so it is stable across runs and lands under `src/` (a
+ * non-sensitive location the guards permit) — enough for the orchestrator to
+ * realize a diff and run the guards over it. NEVER an operator-supplied or
+ * model-derived path.
+ */
+function placeholderPathFor(plan: RemediationPlan, kind: string): string {
+  const h = createHash('sha256').update(`${plan.signalKey}:${kind}`).digest('hex').slice(0, 12);
+  return `src/__codepr_soak__/${kind}-${h}.ts`;
+}
+
+/**
+ * Derive the PROPOSED dry-run change set from a plan's code-touching steps. Each
+ * code-touching step contributes one proposed change with inert, value-free marker
+ * content (NEVER model output / the real edit). A step's `targetPath` hint is used
+ * when present (so the guards run over the realistic path the change would touch);
+ * otherwise a safe deterministic placeholder path is synthesized. Distinct paths
+ * only. Returns an empty array when the plan touches no code.
+ */
+export function deriveProposedChanges(plan: RemediationPlan): ProposedChange[] {
+  const seen = new Set<string>();
+  const changes: ProposedChange[] = [];
+  for (const step of plan.steps) {
+    if (!CODE_TOUCHING_KINDS.has(step.kind)) continue;
+    const path =
+      step.targetPath !== undefined && step.targetPath !== ''
+        ? step.targetPath
+        : placeholderPathFor(plan, step.kind);
+    if (seen.has(path)) continue;
+    seen.add(path);
+    // Inert marker content — the dry-run only needs a realized diff to guard over.
+    changes.push({
+      relPath: path,
+      newContent: `// codepr soak dry-run placeholder for ${plan.signalKey} (${step.kind})\n`,
+    });
+  }
+  return changes;
+}
+
+/**
+ * A minimal {@link IAuditLogger} that forwards the orchestrator's autonomous-event
+ * records to the structured {@link ILogger} (debug). The dry-run orchestrator only
+ * ever calls `log()`; the rest are no-ops. This keeps the soak step zero-config
+ * (no hash-chain storage wiring) while still observing the would_open_pr/abort
+ * events — and a real {@link IAuditLogger} can be injected when one is available.
+ */
+function loggerBackedAuditLogger(logger: ILogger): IAuditLogger {
+  return {
+    log: (input: AuditEventInput): void => {
+      logger.debug('codepr soak dry-run audit event', {
+        action: input.action,
+        outcome: input.outcome,
+      });
+    },
+    logToolInvocation: (): void => {},
+    logPolicyDecision: (): void => {},
+    logSecurityEvent: (): void => {},
+    logRateLimitViolation: (): void => {},
+    logTierTransition: (): void => {},
+    flush: (): Promise<void> => Promise.resolve(),
+    close: (): Promise<void> => Promise.resolve(),
+  };
+}
+
+/** Stable, non-secret runId for a soak dry-run, correlating the audit + soak record. */
+function soakRunId(plan: RemediationPlan): string {
+  return `codepr-soak-${createHash('sha256').update(plan.signalKey).digest('hex').slice(0, 16)}`;
+}
+
+/** Hash of the source signal — pins what triggered the dry-run without storing it. */
+function sourceSignalHash(plan: RemediationPlan): string {
+  return createHash('sha256').update(plan.signalKey).digest('hex');
+}
+
+/** Injectable seams for {@link runCodePrSoak} (real defaults; fakes in tests). */
+export interface CodePrSoakInject {
+  readonly sink?: CodePrSoakSink;
+  readonly auditLogger?: IAuditLogger;
+  readonly logger?: ILogger;
+  /** Orchestrator options forwarded to {@link planCodePrRun} (repoRoot, fault injector). */
+  readonly orchestratorOptions?: CodePrRunOptions;
+  /** Test seam: override the dry-run plan invocation. Defaults to {@link planCodePrRun}. */
+  readonly planRun?: typeof planCodePrRun;
+}
+
+/**
+ * Run ONE dry-run code-PR soak for a code-touching remediation plan and record
+ * the data point. BEST-EFFORT and THROW-FREE: any failure (orchestrator,
+ * persistence, audit) is logged WARN and swallowed — the auto-remediation cycle
+ * must never break because the soak step failed.
+ *
+ * - Plan touches no code → no-op (returns without recording).
+ * - Dry-run plan is green (no guard denial) → records a green data point
+ *   (extends the consecutive guards-green streak).
+ * - Dry-run plan is denied/errors → records a denied data point (resets the
+ *   consecutive streak to 0, per the readiness gate's CONSECUTIVE semantics).
+ *
+ * NO push, NO PR-open, NO live write — {@link planCodePrRun} is dry-run only.
+ */
+export function runCodePrSoak(plan: RemediationPlan, inject: CodePrSoakInject = {}): void {
+  const logger = inject.logger ?? createLogger({ tool: 'codepr-soak' });
+  try {
+    soakOnce(plan, inject, logger);
+  } catch (err: unknown) {
+    // Best-effort: a soak failure must NEVER break the auto-remediation cycle.
+    logger.warn('codepr soak step failed (swallowed; cycle proceeds)', {
+      signalKey: plan.signalKey,
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+/** The soak core: derive changes, dry-run the plan, record the verdict. May throw (caller wraps). */
+function soakOnce(plan: RemediationPlan, inject: CodePrSoakInject, logger: ILogger): void {
+  if (!planTouchesCode(plan)) return;
+  const changes = deriveProposedChanges(plan);
+  if (changes.length === 0) return; // defensive: planTouchesCode true ⇒ non-empty.
+
+  const runId = soakRunId(plan);
+  const planRun = inject.planRun ?? planCodePrRun;
+  const result = planRun(
+    { runId, sourceSignalHash: sourceSignalHash(plan), changes },
+    inject.auditLogger ?? loggerBackedAuditLogger(logger),
+    inject.orchestratorOptions ?? {}
+  );
+
+  const sink = inject.sink ?? getCodePrSoakSink();
+  if (result.ok) {
+    sink.record(
+      greenCodePrSoakRecord({ runId, signalKey: plan.signalKey, filesTouched: result.plan.filesTouched })
+    );
+    logger.debug('codepr soak: green dry-run recorded', {
+      signalKey: plan.signalKey,
+      filesTouched: result.plan.filesTouched,
+    });
+  } else {
+    sink.record(
+      deniedCodePrSoakRecord({ runId, signalKey: plan.signalKey, denialReason: result.reason })
+    );
+    logger.debug('codepr soak: denied dry-run recorded (streak reset)', {
+      signalKey: plan.signalKey,
+      reason: result.reason,
+    });
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/codepr-soak-store.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-soak-store.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the durable code-PR guards-green-soak store (#3670 Stage 2.5).
+ *
+ * The point: the store persists green/denied dry-run data points via the shared
+ * JsonlStore (round-trips from disk), and the read surface reports the CONSECUTIVE
+ * trailing-green count — the `consecutiveGreenDryRuns` evidence the enable
+ * double-gate consumes — so a denial RESETS the streak, matching readiness semantics.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createCodePrSoakSink,
+  countTrailingGreen,
+  readCodePrGuardsGreenSoak,
+  greenCodePrSoakRecord,
+  deniedCodePrSoakRecord,
+  type CodePrSoakRecord,
+} from './codepr-soak-store.js';
+import {
+  evaluateCodePrEnableReadiness,
+  type CodePrEnableReadinessEvidence,
+} from './codepr-enable-readiness.js';
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'codepr-soak-store-'));
+  filePath = join(dir, 'learning', 'codepr-guards-soak.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function green(over: Partial<CodePrSoakRecord> = {}): CodePrSoakRecord {
+  return {
+    timestamp: '2026-06-08T00:00:00.000Z',
+    runId: 'codepr-soak-abc',
+    signalKey: 'routing:cli-floor:codex:docs',
+    green: true,
+    filesTouched: 1,
+    ...over,
+  };
+}
+
+function denied(over: Partial<CodePrSoakRecord> = {}): CodePrSoakRecord {
+  return {
+    timestamp: '2026-06-08T00:00:00.000Z',
+    runId: 'codepr-soak-abc',
+    signalKey: 'bug:crash:auth',
+    green: false,
+    denialReason: 'sensitive_path',
+    filesTouched: 0,
+    ...over,
+  };
+}
+
+describe('durable code-PR soak sink', () => {
+  it('round-trips records from disk preserving order', () => {
+    const sink = createCodePrSoakSink(filePath);
+    sink.record(green({ signalKey: 's0' }));
+    sink.record(denied({ signalKey: 's1' }));
+    sink.record(green({ signalKey: 's2' }));
+    expect(sink.getRecords()).toHaveLength(3);
+
+    const reopened = createCodePrSoakSink(filePath);
+    expect(reopened.getRecords().map((r) => r.signalKey)).toEqual(['s0', 's1', 's2']);
+    expect(reopened.getRecords()[1]?.green).toBe(false);
+    expect(reopened.getRecords()[1]?.denialReason).toBe('sensitive_path');
+  });
+
+  it('bounds retention to the last N records', () => {
+    const sink = createCodePrSoakSink(filePath, 4);
+    for (let i = 0; i < 7; i++) sink.record(green({ signalKey: `s${String(i)}` }));
+    expect(sink.getRecords()).toHaveLength(4);
+    expect(sink.getRecords().map((r) => r.signalKey)).toEqual(['s3', 's4', 's5', 's6']);
+  });
+});
+
+describe('countTrailingGreen — consecutive-green semantics', () => {
+  it('counts the trailing run of green records', () => {
+    expect(countTrailingGreen([green(), green(), green()])).toBe(3);
+  });
+
+  it('returns 0 when the most-recent record is a denial', () => {
+    expect(countTrailingGreen([green(), green(), denied()])).toBe(0);
+  });
+
+  it('resets the streak at the last denial (only the trailing greens count)', () => {
+    // green, green, DENIED, green, green → trailing run is 2 (the denial forfeits the prior 2)
+    expect(countTrailingGreen([green(), green(), denied(), green(), green()])).toBe(2);
+  });
+
+  it('is 0 for an empty soak', () => {
+    expect(countTrailingGreen([])).toBe(0);
+  });
+});
+
+describe('builders', () => {
+  it('greenCodePrSoakRecord marks green with the file count and no denial reason', () => {
+    const r = greenCodePrSoakRecord({ runId: 'r1', signalKey: 'k', filesTouched: 3 });
+    expect(r.green).toBe(true);
+    expect(r.filesTouched).toBe(3);
+    expect(r.denialReason).toBeUndefined();
+  });
+
+  it('deniedCodePrSoakRecord marks not-green with the reason and zero files', () => {
+    const r = deniedCodePrSoakRecord({ runId: 'r1', signalKey: 'k', denialReason: 'secret_detected' });
+    expect(r.green).toBe(false);
+    expect(r.denialReason).toBe('secret_detected');
+    expect(r.filesTouched).toBe(0);
+  });
+});
+
+describe('the recorded count flows into evaluateCodePrEnableReadiness', () => {
+  it('readCodePrGuardsGreenSoak feeds consecutiveGreenDryRuns evidence', () => {
+    const sink = createCodePrSoakSink(filePath);
+    for (let i = 0; i < 50; i++) sink.record(green({ signalKey: `s${String(i)}` }));
+
+    const consecutiveGreenDryRuns = readCodePrGuardsGreenSoak(sink);
+    expect(consecutiveGreenDryRuns).toBe(50);
+
+    // Feed it as the gate's evidence — the guards-green-soak criterion is now met
+    // (the gate still fails-closed on the other halves: vote ref + owner).
+    const evidence: CodePrEnableReadinessEvidence = {
+      flagEnabled: true,
+      enableVoteRef: 'vote-123',
+      consecutiveGreenDryRuns,
+      owner: 'williamzujkowski',
+    };
+    const verdict = evaluateCodePrEnableReadiness(evidence);
+    expect(verdict.criteria.find((c) => c.name === 'guards-green-soak')?.met).toBe(true);
+    expect(verdict.ready).toBe(true);
+  });
+
+  it('a denial mid-soak drops the count below the bar, blocking the gate', () => {
+    const sink = createCodePrSoakSink(filePath);
+    for (let i = 0; i < 49; i++) sink.record(green({ signalKey: `s${String(i)}` }));
+    sink.record(denied({ signalKey: 'oops' })); // resets the streak to 0
+    sink.record(green({ signalKey: 'after' }));
+
+    expect(readCodePrGuardsGreenSoak(sink)).toBe(1); // only the trailing green
+    const verdict = evaluateCodePrEnableReadiness({
+      flagEnabled: true,
+      enableVoteRef: 'vote-123',
+      consecutiveGreenDryRuns: readCodePrGuardsGreenSoak(sink),
+      owner: 'williamzujkowski',
+    });
+    expect(verdict.criteria.find((c) => c.name === 'guards-green-soak')?.met).toBe(false);
+    expect(verdict.blockers).toContain('guards-green-soak');
+    expect(verdict.ready).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-soak-store.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-soak-store.ts
@@ -1,0 +1,174 @@
+/**
+ * Durable code-PR guards-green-soak store (#3670, Stage 2.5).
+ *
+ * The SOAK-evidence persistence the {@link evaluateCodePrEnableReadiness}
+ * double-gate consumes for its `guards-green-soak` criterion. Each AUDIT-mode
+ * cycle that runs {@link planCodePrRun} in dry-run over a code-touching
+ * remediation appends ONE data point here: green (no guard denial) or denied.
+ *
+ * The readiness gate wants CONSECUTIVE green dry-runs (`consecutiveGreenDryRuns`
+ * compared against `minGuardsGreenSoak`) — a denial RESETS the streak to 0. So
+ * the read surface ({@link readCodePrGuardsGreenSoak}) counts the TRAILING run of
+ * green records: the number of green data points since the last denial. This
+ * matches the readiness semantics exactly (a single denial mid-soak forfeits the
+ * accumulated streak, which is the conservative, fail-closed reading).
+ *
+ * Persistence mirrors the audit-mode soak store (#3762): the shared
+ * {@link JsonlStore} primitive under `NEXUS_DATA_DIR` (hydrate-on-construct,
+ * append-on-write, Zod-validate-each-line, oldest-eviction). NO push, NO PR-open,
+ * NO live writes — this only records what the dry-run orchestrator already did
+ * with zero blast radius.
+ *
+ * @module mcp/tools/codepr-soak-store
+ */
+
+import { z } from 'zod';
+
+import { getTimeProvider } from '../../core/index.js';
+import { JsonlStore } from '../../config/jsonl-store.js';
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
+import type { GuardDenialReason } from './codepr-guards.js';
+
+/**
+ * One durable code-PR soak data point — the outcome of a single dry-run
+ * {@link planCodePrRun} over a proposed code-touching remediation change set.
+ * Records ONLY realized facts (a green/denied verdict + non-secret counts); the
+ * orchestrator already discarded its throwaway worktree before this is written.
+ */
+export const CodePrSoakRecordSchema = z
+  .object({
+    /** ISO-8601 capture time. */
+    timestamp: z.string(),
+    /** Correlates the data point to the dry-run's orchestrator runId. */
+    runId: z.string(),
+    /** The improvement signal's stable key that triggered the dry-run. */
+    signalKey: z.string(),
+    /** True when the dry-run plan succeeded with ZERO guard denial. */
+    green: z.boolean(),
+    /** The guard denial reason when `green` is false; omitted for a green plan. */
+    denialReason: z.string().optional(),
+    /** Files the dry-run plan touched (0 on denial before the diff was realized). */
+    filesTouched: z.number().int().nonnegative(),
+  })
+  .strict();
+export type CodePrSoakRecord = z.infer<typeof CodePrSoakRecordSchema>;
+
+/**
+ * Retention cap for the durable code-PR soak file. Generous enough to hold a
+ * full guards-green soak (the readiness default `minGuardsGreenSoak` is 50, but a
+ * real soak interleaves denials) while bounding disk usage via oldest-eviction.
+ */
+export const CODEPR_SOAK_MAX_RECORDS = 10_000;
+
+/** JSONL file under NEXUS_DATA_DIR holding the durable code-PR soak evidence. */
+export function getCodePrSoakFile(): string {
+  return nexusDataPath('learning', 'codepr-guards-soak.jsonl');
+}
+
+/** Durable sink for code-PR soak records. Persists; never throws. */
+export interface CodePrSoakSink {
+  record(record: CodePrSoakRecord): void;
+}
+
+/** A {@link CodePrSoakSink} that also exposes its persisted records. */
+export interface IRecordingCodePrSoakSink extends CodePrSoakSink {
+  getRecords(): readonly CodePrSoakRecord[];
+}
+
+/**
+ * Create a durable code-PR soak sink backed by an append-only JSONL file
+ * (reuses the shared {@link JsonlStore} — the same storage seam the #3762
+ * audit-mode soak store uses).
+ */
+export function createCodePrSoakSink(
+  filePath: string = getCodePrSoakFile(),
+  maxRecords: number = CODEPR_SOAK_MAX_RECORDS
+): IRecordingCodePrSoakSink {
+  const store = new JsonlStore<CodePrSoakRecord>({
+    filePath,
+    schema: CodePrSoakRecordSchema,
+    maxRecords,
+    component: 'CodePrSoakSink',
+  });
+  return {
+    record(record: CodePrSoakRecord): void {
+      store.append(record);
+    },
+    getRecords(): readonly CodePrSoakRecord[] {
+      return store.all();
+    },
+  };
+}
+
+let soakSingleton: IRecordingCodePrSoakSink | undefined;
+
+/** Process-wide durable code-PR soak sink (lazily constructed, hydrates from disk). */
+export function getCodePrSoakSink(): IRecordingCodePrSoakSink {
+  soakSingleton ??= createCodePrSoakSink();
+  return soakSingleton;
+}
+
+/** Test helper — drops the cached singleton so a fresh NEXUS_DATA_DIR is picked up. */
+export function _resetCodePrSoakSinkForTests(): void {
+  soakSingleton = undefined;
+}
+
+/** Build a green code-PR soak record from a clean dry-run plan. */
+export function greenCodePrSoakRecord(args: {
+  runId: string;
+  signalKey: string;
+  filesTouched: number;
+}): CodePrSoakRecord {
+  return {
+    timestamp: new Date(getTimeProvider().now()).toISOString(),
+    runId: args.runId,
+    signalKey: args.signalKey,
+    green: true,
+    filesTouched: args.filesTouched,
+  };
+}
+
+/** Build a denied code-PR soak record from a guard-denied (or errored) dry-run plan. */
+export function deniedCodePrSoakRecord(args: {
+  runId: string;
+  signalKey: string;
+  denialReason: GuardDenialReason;
+}): CodePrSoakRecord {
+  return {
+    timestamp: new Date(getTimeProvider().now()).toISOString(),
+    runId: args.runId,
+    signalKey: args.signalKey,
+    green: false,
+    denialReason: args.denialReason,
+    filesTouched: 0,
+  };
+}
+
+/**
+ * Count the CONSECUTIVE green dry-runs ending at the most-recent record — the
+ * trailing run of `green === true` since the last denial. This is the value fed
+ * to {@link evaluateCodePrEnableReadiness} as `consecutiveGreenDryRuns`: a denial
+ * anywhere forfeits the streak before it, matching the gate's "N CONSECUTIVE
+ * dry-run plans with zero guard denials" requirement.
+ *
+ * Pure over its input; does no I/O.
+ */
+export function countTrailingGreen(records: readonly CodePrSoakRecord[]): number {
+  let count = 0;
+  for (let i = records.length - 1; i >= 0; i--) {
+    if (records[i]?.green === true) count++;
+    else break;
+  }
+  return count;
+}
+
+/**
+ * Read the durable soak evidence and return the consecutive guards-green count —
+ * the `consecutiveGreenDryRuns` evidence the code-PR enable-readiness gate
+ * consumes. Convenience over {@link countTrailingGreen}.
+ */
+export function readCodePrGuardsGreenSoak(
+  sink: IRecordingCodePrSoakSink = getCodePrSoakSink()
+): number {
+  return countTrailingGreen(sink.getRecords());
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
@@ -142,6 +142,15 @@ export interface AutoRemediationDeps {
   recordOutcome?(plan: RemediationPlan, pr: RemediationPrResult): void;
   /** Per-step audit emission. */
   audit(event: AutoRemediationAuditEvent): void;
+  /**
+   * Optional observer fired in EVERY mode right after a signal's typed
+   * {@link RemediationPlan} is produced (post-RESEARCH, pre-consensus). Best-effort
+   * and side-effect-only — the orchestrator ignores its return and never lets it
+   * throw into the control flow. The AUDIT-mode cycle uses this to drive the
+   * dry-run code-PR guards-green soak (#3670 Stage 2.5) over the proposed change
+   * set; it MUST NOT push, open a PR, or write the live tree.
+   */
+  onPlanProduced?(signal: ImprovementSignal, plan: RemediationPlan): void;
   readonly logger?: ILogger;
 }
 
@@ -370,6 +379,27 @@ async function consensusGate(
 }
 
 /**
+ * Fire the optional best-effort {@link AutoRemediationDeps.onPlanProduced} observer
+ * (#3670 Stage 2.5). Side-effect-only and fully isolated — a throw is swallowed
+ * (logged WARN) so the observer can never break the remediation control flow.
+ */
+function firePlanObserver(
+  deps: AutoRemediationDeps,
+  signal: ImprovementSignal,
+  plan: RemediationPlan
+): void {
+  if (deps.onPlanProduced === undefined) return;
+  try {
+    deps.onPlanProduced(signal, plan);
+  } catch (err: unknown) {
+    deps.logger?.warn('onPlanProduced observer threw (swallowed)', {
+      signalKey: signal.signalKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * Execute the phase machine for one admitted signal. RESEARCH always runs, then
  * the consensus gate (#3653). In audit the vote is observed but IMPLEMENT is
  * skipped (zero writes); enforce proceeds to the write phase only on approval.
@@ -396,6 +426,11 @@ async function executeOne(
     signalKey: signal.signalKey,
     detail: `${String(plan.steps.length)} steps`,
   });
+
+  // Best-effort plan observer (#3670 Stage 2.5): drives the AUDIT-mode dry-run
+  // code-PR soak. Side-effect-only and isolated — a throw here must NEVER break
+  // the remediation control flow.
+  firePlanObserver(deps, signal, plan);
 
   // Self-modification guard (#3653): never autonomously touch the loop's own
   // rails / auth / secrets / CI — leave for a human (neutral for the breaker).


### PR DESCRIPTION
## #3670 Stage 2.5 — wire the dry-run code-PR orchestrator as a SOAK consumer

Closes the producer-without-consumer gap for the Stage-1/2 code-PR guards by giving them a real consumer: auto-remediation's **AUDIT mode** now exercises `planCodePrRun` in dry-run and accumulates the `guards-green-soak` evidence that `evaluateCodePrEnableReadiness` requires before any Stage-3 push could ever be enabled.

### How it wires into audit mode
- `AutoRemediationDeps` gains an optional, side-effect-only `onPlanProduced(signal, plan)` hook, fired in `executeOne` right after a typed `RemediationPlan` is produced (post-RESEARCH, pre-consensus). The orchestrator wraps the call so it can never throw into the control flow.
- `runAutoRemediationCycle` wires this hook **only on the AUDIT branch** (`withCodePrSoak`). For a code-touching plan it calls `runCodePrSoak`, which derives a proposed change set from the plan's code-touching steps (`add-test`/`refactor`/`update-docs`/`fix-bug`), using each step's `targetPath` when present or a safe deterministic `src/__codepr_soak__/…` placeholder otherwise, with inert marker content (never model output / the real edit).
- `planCodePrRun` runs in **dry-run** over that change set inside its own throwaway worktree and atomically discards it.

### The persisted soak counter feeding evaluateCodePrEnableReadiness
- New `codepr-soak-store.ts`: a durable JSONL store (`learning/codepr-guards-soak.jsonl` under `NEXUS_DATA_DIR`, via the shared `JsonlStore` — the same storage seam the #3762 audit-mode soak store uses). Each dry-run records one data point: `green` on a clean plan, `denied` (with the guard reason) otherwise.
- The readiness gate wants **CONSECUTIVE** green dry-runs (`consecutiveGreenDryRuns` vs `minGuardsGreenSoak`). `readCodePrGuardsGreenSoak` counts the **trailing run of green records** — so a denial anywhere RESETS the streak to 0, matching the gate's "N consecutive dry-run plans with zero guard denials" semantics exactly. A test feeds the count into `evaluateCodePrEnableReadiness` and shows the `guards-green-soak` criterion flipping met/unmet.

### Dry-run / no-push
`planCodePrRun` imports no push/PR-open/network surface (asserted structurally in both the orchestrator's and the new consumer's tests). This PR adds **no** live external action and does **not** wire Stage 3 (the real push) — that's the next stage.

### Best-effort guarantee
`runCodePrSoak` is throw-free (try/catch → WARN), and `onPlanProduced` is independently wrapped in the orchestrator. A test injects a throwing soak runner and asserts the auto-remediation cycle still completes normally.

### off/enforce unaffected
The soak hook is wired only on the audit branch. Tests assert the soak runner is never called in `off` or `enforce` mode. No off/enforce control flow changed.

### Export markers
Removed the `@export-no-consumer-yet — see #3670` markers from `codepr-guards.ts` and `codepr-orchestrator.ts` (now consumed by `codepr-soak-store.ts` / `codepr-soak-consumer.ts` respectively). Kept it on `codepr-enable-readiness.ts` with a precise note: this PR *produces* its soak evidence, but `evaluateCodePrEnableReadiness` itself still awaits its Stage-3 push consumer. `npx tsx scripts/check-new-unused-exports.ts origin/main` passes (2 new files have production consumers).

### Tests / gates
- New `codepr-soak-store.test.ts` + `codepr-soak-consumer.test.ts`; extended `auto-remediation-cycle.test.ts` (audit increments green soak; guard-denied does not; best-effort throw swallowed; off/enforce do not run the soak).
- `tsc --noEmit` clean, eslint clean on changed files, full codepr + auto-remediation suite green (146 tests). Zero `any`.
- No MCP tool / CLI command / workflow added → no repo-index regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)