### PR TITLE
feat(capability-loop): code-PR scoped-token push + PR-open (Stage 3, OFF — gated on enable-readiness + credentials, never auto-merge) (#3670)

### DIFF
--- a/.changeset/codepr-push-stage3-3670.md
+++ b/.changeset/codepr-push-stage3-3670.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+feat(capability-loop): code-PR scoped-token push + PR-open (#3670 Stage 3, OFF)
+
+Add `codepr-push.ts` — the ONLY module in the code-PR capability loop that can
+take an external action (a `git push` to a NEW `nexus-codepr/<runId>` feature
+branch + a PR open). It ships OFF-by-default and is DOUBLE-GATED: a push is
+impossible unless BOTH (a) `evaluateCodePrEnableReadiness` returns `ready` against
+the explicit flag/enable-vote/owner evidence AND the durable guards-green soak
+read from `readCodePrGuardsGreenSoak`, AND (b) an explicit scoped token is present
+in `NEXUS_CODEPR_TOKEN`. Either block alone refuses the push.
+
+`executeCodePrPush` runs a strict fail-closed sequence: readiness gate FIRST
+(not-ready → `not_enabled`, no worktree/push), credentials required
+(`no_credentials` when the token is absent/empty), build + validate the plan via
+the dry-run `planCodePrRun`, then re-realize the diff in a fresh worktree and
+RE-RUN `evaluateWriteGuards` immediately before push (defense-in-depth), push via
+injectable seams to a `nexus-codepr/<runId>` branch (NEVER main, NEVER merge,
+NEVER alter protections), and audit (hash-chained) BOTH before (intent: branch,
+diff hash, token identity) and after (PR url/number). Any throw is wrapped into a
+fail-closed denial; the push worktree is always discarded.
+
+There is NO merge / auto-merge surface anywhere in the module (asserted
+structurally in tests). NOT wired to any live runtime trigger / auto-remediation
+enforce path — activation still requires the enable-vote + a real soak ≥ min +
+owner-ack via the readiness gate (none triggered here). No MCP tool / CLI command
+added.

--- a/packages/nexus-agents/src/mcp/tools/codepr-push.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-push.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tests for the gated code-PR scoped-token PUSH + PR-open (#3670, Stage 3 — OFF).
+ *
+ * SECURITY-CRITICAL invariants proven here (NO real push — every external seam is
+ * mocked):
+ *  - NOT ready (flag off / missing vote-ref / soak below min / no owner-ack) →
+ *    `not_enabled`, and gitPush/openPullRequest are NEVER called and NO push
+ *    worktree is created;
+ *  - ready but `NEXUS_CODEPR_TOKEN` absent → `no_credentials`, no push;
+ *  - ready + token + clean plan → gitPush to a `nexus-codepr/*` branch (NOT main)
+ *    then openPullRequest; audits BEFORE + AFTER; returns ok with the PR ref;
+ *  - ready + token but the pre-push `evaluateWriteGuards` re-check DENIES → fail
+ *    closed, gitPush NEVER called;
+ *  - an induced throw in the push seam → denied (not thrown), worktree cleaned;
+ *  - a source/structure assertion that the module has NO merge/auto-merge surface.
+ *
+ * Each test spawns its worktree from a REAL throwaway git repo (init'd in tmp).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync, realpathSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  executeCodePrPush,
+  pushBranchName,
+  CODEPR_TOKEN_ENV,
+  CODEPR_PUSH_BRANCH_PREFIX,
+  defaultGitPush,
+  type CodePrPushInput,
+  type CodePrPushDeps,
+  type OpenedPrRef,
+  type OpenPullRequestArgs,
+} from './codepr-push.js';
+import type { CodePrEnableReadinessConfig } from './codepr-enable-readiness.js';
+import type { IAuditLogger, AuditEventInput } from '../../audit/audit-types.js';
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function makeCapturingLogger(): { logger: IAuditLogger; events: AuditEventInput[] } {
+  const events: AuditEventInput[] = [];
+  const logger: IAuditLogger = {
+    log: (input) => {
+      events.push(input);
+    },
+    logToolInvocation: () => {},
+    logPolicyDecision: () => {},
+    logSecurityEvent: () => {},
+    logRateLimitViolation: () => {},
+    logTierTransition: () => {},
+    flush: async () => {},
+    close: async () => {},
+  };
+  return { logger, events };
+}
+
+/** Init a real, committed throwaway git repo to spawn worktrees from. */
+function makeRepo(): { repoRoot: string; cleanup: () => void } {
+  const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'codepr-push-repo-')));
+  const run = (args: string[]): void => {
+    execFileSync('git', args, { cwd: repoRoot, stdio: 'ignore' });
+  };
+  run(['init', '-b', 'main']);
+  run(['config', 'user.email', 'test@example.com']);
+  run(['config', 'user.name', 'Test']);
+  writeFileSync(join(repoRoot, 'README.md'), '# fixture repo\n');
+  run(['add', '-A']);
+  run(['commit', '-m', 'init']);
+  return {
+    repoRoot,
+    cleanup: () => {
+      rmSync(repoRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+/** List worktrees the repo currently knows about (besides the main one). */
+function linkedWorktrees(repoRoot: string): string[] {
+  const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .filter((l) => l.startsWith('worktree '))
+    .map((l) => l.slice('worktree '.length))
+    .filter((p) => realpathSync(p) !== repoRoot);
+}
+
+/** Count temp dirs the push module may have left behind. */
+function residualPushTempDirs(): string[] {
+  return readdirSync(tmpdir()).filter((n) => n.startsWith('codepr-push-') && !n.includes('repo'));
+}
+
+/** A mock deps bundle that records every external-seam call. */
+interface MockDeps {
+  deps: CodePrPushDeps;
+  gitPush: ReturnType<typeof vi.fn>;
+  openPullRequest: ReturnType<typeof vi.fn>;
+  events: AuditEventInput[];
+}
+
+function makeMockDeps(opts: {
+  soak: number;
+  pr?: OpenedPrRef;
+  gitPushImpl?: (branch: string, worktreeRoot: string, token: string) => void;
+}): MockDeps {
+  const { logger, events } = makeCapturingLogger();
+  const pr = opts.pr ?? { number: 42, url: 'https://example.com/org/repo/pull/42' };
+  const gitPush = vi.fn(
+    opts.gitPushImpl ??
+      ((_b: string, _w: string, _t: string) => {
+        /* mock: no real push */
+      })
+  );
+  const openPullRequest = vi.fn((_a: OpenPullRequestArgs): OpenedPrRef => pr);
+  const deps: CodePrPushDeps = {
+    gitPush,
+    openPullRequest,
+    logger,
+    readSoak: () => opts.soak,
+  };
+  return { deps, gitPush, openPullRequest, events };
+}
+
+let repo: { repoRoot: string; cleanup: () => void };
+beforeEach(() => {
+  repo = makeRepo();
+});
+afterEach(() => {
+  repo.cleanup();
+  vi.unstubAllEnvs();
+});
+
+// A low soak bar so a small soak value satisfies the gate in tests.
+const readinessConfig: CodePrEnableReadinessConfig = {
+  minGuardsGreenSoak: 3,
+  requireEnableVoteRef: true,
+  requireOwnerAck: true,
+};
+
+const baseInput = (over: Partial<CodePrPushInput> = {}): CodePrPushInput => ({
+  run: {
+    runId: 'run-xyz',
+    sourceSignalHash: 'sig-hash-1',
+    changes: [{ relPath: 'src/feature.ts', newContent: 'export const x = 1;\n' }],
+  },
+  readiness: { flagEnabled: true, enableVoteRef: 'vote-123', owner: 'alice' },
+  prTitle: 'auto code-PR',
+  prBody: 'body',
+  repoRoot: repo.repoRoot,
+  readinessConfig,
+  ...over,
+});
+
+// ----------------------------------------------------------------------------
+// Step 1 — readiness gate (not_enabled): no push, no worktree
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — readiness gate (step 1)', () => {
+  it('flag OFF → not_enabled, NO push, NO worktree created', () => {
+    const m = makeMockDeps({ soak: 100 });
+    const before = residualPushTempDirs().length;
+    const result = executeCodePrPush(
+      baseInput({ readiness: { flagEnabled: false, enableVoteRef: 'v', owner: 'alice' } }),
+      m.deps
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('not_enabled');
+    expect(result.detail).toContain('flag-enabled');
+    expect(m.gitPush).not.toHaveBeenCalled();
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+    expect(residualPushTempDirs().length).toBe(before);
+    // The refusal was audited (decision: abort).
+    expect(m.events.some((e) => e.action === 'autonomous_code_pr.abort')).toBe(true);
+  });
+
+  it('missing enable-vote-ref → not_enabled, NO push', () => {
+    const m = makeMockDeps({ soak: 100 });
+    const result = executeCodePrPush(
+      baseInput({ readiness: { flagEnabled: true, enableVoteRef: '  ', owner: 'alice' } }),
+      m.deps
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('not_enabled');
+    expect(result.detail).toContain('enable-vote-ref');
+    expect(m.gitPush).not.toHaveBeenCalled();
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('soak below min → not_enabled, NO push', () => {
+    const m = makeMockDeps({ soak: 1 }); // min is 3
+    const result = executeCodePrPush(baseInput(), m.deps);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('not_enabled');
+    expect(result.detail).toContain('guards-green-soak');
+    expect(m.gitPush).not.toHaveBeenCalled();
+  });
+
+  it('no owner-ack → not_enabled, NO push', () => {
+    const m = makeMockDeps({ soak: 100 });
+    const result = executeCodePrPush(
+      baseInput({ readiness: { flagEnabled: true, enableVoteRef: 'v', owner: '' } }),
+      m.deps
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('not_enabled');
+    expect(result.detail).toContain('owner-ack');
+    expect(m.gitPush).not.toHaveBeenCalled();
+  });
+
+  it('readiness gate runs BEFORE credentials — not_enabled even with a token set', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, 'tok-present');
+    const m = makeMockDeps({ soak: 100 });
+    const result = executeCodePrPush(
+      baseInput({ readiness: { flagEnabled: false, enableVoteRef: 'v', owner: 'a' } }),
+      m.deps
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('not_enabled');
+    expect(m.gitPush).not.toHaveBeenCalled();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Step 2 — credentials required
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — credentials gate (step 2)', () => {
+  it('ready but NEXUS_CODEPR_TOKEN absent → no_credentials, NO push', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, '');
+    const m = makeMockDeps({ soak: 100 });
+    const result = executeCodePrPush(baseInput(), m.deps);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('no_credentials');
+    expect(m.gitPush).not.toHaveBeenCalled();
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('ready but token is whitespace-only → no_credentials', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, '   ');
+    const m = makeMockDeps({ soak: 100 });
+    const result = executeCodePrPush(baseInput(), m.deps);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('no_credentials');
+    expect(m.gitPush).not.toHaveBeenCalled();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Happy path — ready + token + clean plan
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — happy path (ready + token + clean plan)', () => {
+  it('pushes a nexus-codepr/* feature branch (NOT main) then opens a PR; audits before+after', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, 'scoped-token-abc');
+    const m = makeMockDeps({ soak: 100 });
+    const before = residualPushTempDirs().length;
+
+    const result = executeCodePrPush(baseInput(), m.deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.pr).toEqual({ number: 42, url: 'https://example.com/org/repo/pull/42' });
+    expect(result.branch).toBe('nexus-codepr/run-xyz');
+    expect(result.diffHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // gitPush was called with a feature branch (NOT main) and the scoped token.
+    expect(m.gitPush).toHaveBeenCalledTimes(1);
+    const [branchArg, worktreeArg, tokenArg] = m.gitPush.mock.calls[0] as [string, string, string];
+    expect(branchArg).toBe('nexus-codepr/run-xyz');
+    expect(branchArg.startsWith(CODEPR_PUSH_BRANCH_PREFIX)).toBe(true);
+    expect(branchArg).not.toBe('main');
+    expect(branchArg).not.toBe('master');
+    expect(tokenArg).toBe('scoped-token-abc');
+    expect(typeof worktreeArg).toBe('string');
+
+    // openPullRequest was called AFTER gitPush with the same feature branch.
+    expect(m.openPullRequest).toHaveBeenCalledTimes(1);
+    const prArgs = m.openPullRequest.mock.calls[0]?.[0] as OpenPullRequestArgs;
+    expect(prArgs.branch).toBe('nexus-codepr/run-xyz');
+    expect(prArgs.token).toBe('scoped-token-abc');
+    expect(m.gitPush.mock.invocationCallOrder[0]).toBeLessThan(
+      m.openPullRequest.mock.invocationCallOrder[0] ?? Infinity
+    );
+
+    // Audited BOTH before (intent) and after (result) by the PUSH actor (distinct
+    // from the dry-run orchestrator's own would_open_pr audit).
+    const pushAudits = m.events.filter(
+      (e) =>
+        e.action === 'autonomous_code_pr.would_open_pr' &&
+        e.actor?.id === 'autonomous-code-pr-push'
+    );
+    expect(pushAudits.length).toBe(2);
+    // Both push audits pin a non-secret token identity (NOT the raw token).
+    for (const a of pushAudits) {
+      expect(a.metadata?.['tokenIdentity']).toMatch(/^codepr-token:[0-9a-f]{12}$/);
+    }
+    // The "intent" audit (branch in actor name) was recorded before the push.
+    expect(pushAudits[0]?.actor?.name).toContain('intent');
+    // The "result" audit names the opened PR number.
+    expect(pushAudits[1]?.actor?.name).toContain('#42');
+    expect(JSON.stringify(m.events)).not.toContain('scoped-token-abc');
+
+    // Worktree discarded; live repo untouched.
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+    expect(residualPushTempDirs().length).toBe(before);
+    expect(existsSync(join(repo.repoRoot, 'src/feature.ts'))).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Pre-push guard re-check DENIES → fail-closed, gitPush NEVER called
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — pre-push guard re-check (step 3, defense-in-depth)', () => {
+  it('a sensitive path that slips into the change set → pre_push_guard_denied, gitPush NEVER called', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, 'scoped-token-abc');
+    const m = makeMockDeps({ soak: 100 });
+    // A dry-run plan stub that REPORTS ok (simulating the earlier verdict being
+    // trusted) while the realized change set actually touches a sensitive path.
+    // The pre-push evaluateWriteGuards re-check must catch it regardless.
+    const result = executeCodePrPush(
+      baseInput({
+        run: {
+          runId: 'run-xyz',
+          sourceSignalHash: 'sig-hash-1',
+          changes: [{ relPath: 'package.json', newContent: '{"name":"x"}\n' }],
+        },
+      }),
+      {
+        ...m.deps,
+        // Force the dry-run plan to pass so ONLY the pre-push re-check can stop it.
+        planRun: (_input, _logger, _options) => ({
+          ok: true as const,
+          plan: {
+            branchName: 'auto/codepr/run-xyz',
+            title: 't',
+            files: [],
+            filesTouched: 0,
+            linesTouched: 0,
+            diffHash: 'x',
+          },
+          auditRecorded: true,
+        }),
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('pre_push_guard_denied');
+    expect(result.detail).toContain('sensitive_path');
+    expect(m.gitPush).not.toHaveBeenCalled();
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+  });
+
+  it('dry-run plan itself denies (real planCodePrRun on a sensitive path) → plan_denied, NO push', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, 'scoped-token-abc');
+    const m = makeMockDeps({ soak: 100 }); // uses the real planCodePrRun default
+    const result = executeCodePrPush(
+      baseInput({
+        run: {
+          runId: 'run-xyz',
+          sourceSignalHash: 'sig-hash-1',
+          changes: [{ relPath: 'governance/policy.yaml', newContent: 'x: 1\n' }],
+        },
+      }),
+      m.deps
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('plan_denied');
+    expect(m.gitPush).not.toHaveBeenCalled();
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Induced throw in the push seam → denied (not thrown), worktree cleaned
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — push seam throws (atomic cleanup)', () => {
+  it('gitPush throws → push_failed (not thrown) AND worktree discarded', () => {
+    vi.stubEnv(CODEPR_TOKEN_ENV, 'scoped-token-abc');
+    const before = residualPushTempDirs().length;
+    const m = makeMockDeps({
+      soak: 100,
+      gitPushImpl: () => {
+        throw new Error('simulated push network failure');
+      },
+    });
+    const result = executeCodePrPush(baseInput(), m.deps);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected denial');
+    expect(result.reason).toBe('push_failed');
+    expect(result.detail).toContain('simulated push network failure');
+    // openPullRequest never reached after the push seam threw.
+    expect(m.openPullRequest).not.toHaveBeenCalled();
+    // Atomic discard held despite the throw.
+    expect(linkedWorktrees(repo.repoRoot)).toEqual([]);
+    expect(residualPushTempDirs().length).toBe(before);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Structure / source — NO merge or auto-merge surface
+// ----------------------------------------------------------------------------
+
+describe('executeCodePrPush — never-merge / branch-name invariants', () => {
+  it('the module source CODE has NO merge / auto-merge / force-push / protection surface', () => {
+    const raw = execFileSync('cat', [new URL('./codepr-push.ts', import.meta.url).pathname], {
+      encoding: 'utf8',
+    });
+    // Strip block + line comments so the assertion tests EXECUTABLE code only
+    // (the doc comments legitimately use the words "merge"/"auto-merge"/"protections"
+    // to DOCUMENT their absence; the invariant is about the code, not the prose).
+    const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    // No merge verbs of any kind in code.
+    expect(code).not.toMatch(/\bmerge\b/i);
+    expect(code).not.toMatch(/--merge\b|auto-?merge|enableAutoMerge|mergePullRequest/i);
+    // No force-PUSH (a `push` arg list containing a force flag), no protection mutation.
+    // (`worktree remove --force` / `rmSync({force})` are legitimate cleanup, not a force-push.)
+    expect(code).not.toMatch(/--force-with-lease/i);
+    expect(code).not.toMatch(/['"]push['"][^\n]*--force/i);
+    expect(code).not.toMatch(/branch.?protection|protected.?branch/i);
+    // The push refspec only ever targets a nexus-codepr feature branch.
+    expect(code).toContain('nexus-codepr/');
+  });
+
+  it('pushBranchName always yields a nexus-codepr/<runId> branch (never main)', () => {
+    expect(pushBranchName('run-1')).toBe('nexus-codepr/run-1');
+    expect(pushBranchName('main')).toBe('nexus-codepr/main'); // even "main" runId is namespaced
+    expect(pushBranchName('run-1').startsWith(CODEPR_PUSH_BRANCH_PREFIX)).toBe(true);
+  });
+
+  it('defaultGitPush REFUSES to push a non-codepr branch (e.g. main) — fail-closed', () => {
+    expect(() => {
+      defaultGitPush('main', repo.repoRoot, 'tok');
+    }).toThrow(/non-codepr|default branch/i);
+    expect(() => {
+      defaultGitPush('feature/x', repo.repoRoot, 'tok');
+    }).toThrow(/non-codepr/i);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/codepr-push.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-push.ts
@@ -1,0 +1,579 @@
+/**
+ * Code-PR scoped-token PUSH + PR-open (#3670, Stage 3 — OFF, SECURITY-CRITICAL).
+ *
+ * This is the ONLY module in the code-PR capability loop that can take an
+ * EXTERNAL action (a `git push` to a NEW feature branch + a PR open). It ships
+ * OFF-by-default and DOUBLE-GATED: a push is IMPOSSIBLE unless ALL of the
+ * enable-readiness criteria pass ({@link evaluateCodePrEnableReadiness} — flag +
+ * enable-vote ref + guards-green soak ≥ min + named owner-ack) AND an explicit
+ * scoped credential is present in the environment ({@link CODEPR_TOKEN_ENV}).
+ * Either block alone refuses the push.
+ *
+ * STRICT FAIL-CLOSED SEQUENCE ({@link executeCodePrPush}) — every step returns a
+ * discriminated denial value; the module NEVER throws (a throw is wrapped into a
+ * denied result):
+ *  1. **Readiness gate FIRST.** Assemble the enable-readiness evidence (explicit
+ *     flag, enable-vote ref, `guardsGreenSoak` from {@link readCodePrGuardsGreenSoak},
+ *     owner-ack) and call {@link evaluateCodePrEnableReadiness}. NOT ready →
+ *     `not_enabled` and DO NOTHING ELSE (no worktree, no push). Audit the refusal.
+ *  2. **Credentials required.** The push seam requires a non-empty token from
+ *     {@link CODEPR_TOKEN_ENV}. Absent/empty → `no_credentials`, no push. (So even
+ *     when enabled, no token = no action.)
+ *  3. **Produce + re-validate the plan.** Call {@link planCodePrRun} (dry-run) to
+ *     build the plan in an isolated worktree it discards. Then re-realize the diff
+ *     in a FRESH push worktree and RE-RUN {@link evaluateWriteGuards} on it
+ *     immediately before push (defense-in-depth — never trust the earlier
+ *     verdict). Any denial → fail-closed, audit, NO push.
+ *  4. **Push via INJECTABLE seams** ({@link CodePrPushDeps.gitPush} +
+ *     {@link CodePrPushDeps.openPullRequest}). The production seams push ONLY to a
+ *     NEW feature branch `nexus-codepr/<runId>`, NEVER to main, NEVER merge, NEVER
+ *     alter protections, and use the scoped token. The PR is a normal
+ *     feature-branch PR subject to CI + CODEOWNERS. There is NO merge call here.
+ *  5. **Audit (hash-chained) BOTH** before the push (intent: branch, diff hash,
+ *     token identity) and after (result: PR url/number) via {@link auditAutonomousEvent}.
+ *  6. **Atomic cleanup**: the push worktree is discarded in a `finally`.
+ *
+ * NOT WIRED to any live runtime trigger / auto-remediation enforce path — it is a
+ * gated capability only. Activation still requires the enable-vote + a real soak +
+ * owner-ack via the readiness gate (none triggered here).
+ *
+ * @module mcp/tools/codepr-push
+ */
+
+// @export-no-consumer-yet — see #3670 (Stage 3; activation requires enable-vote + soak + owner-ack)
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import {
+  confinePath,
+  evaluateWriteGuards,
+  auditAutonomousEvent,
+  type ChangedFile,
+  type BlastRadiusLimits,
+  type ResourceBudgetLimits,
+  type ResourceUsage,
+} from './codepr-guards.js';
+import {
+  planCodePrRun,
+  type CodePrRunInput,
+  type CodePrRunOptions,
+} from './codepr-orchestrator.js';
+import {
+  evaluateCodePrEnableReadiness,
+  type CodePrEnableReadinessConfig,
+} from './codepr-enable-readiness.js';
+import { readCodePrGuardsGreenSoak } from './codepr-soak-store.js';
+import type { IAuditLogger } from '../../audit/audit-types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * The ONLY environment variable the push seam reads a credential from. An
+ * absent/empty value is a hard `no_credentials` refusal (step 2) — so even a
+ * fully-enabled gate cannot push without an explicit, operator-provisioned token.
+ */
+export const CODEPR_TOKEN_ENV = 'NEXUS_CODEPR_TOKEN' as const;
+
+/** The MANDATORY feature-branch prefix. A push is confined to `nexus-codepr/<runId>`. */
+export const CODEPR_PUSH_BRANCH_PREFIX = 'nexus-codepr/' as const;
+
+/** Zero usage snapshot used for the pre-push guard re-check when none supplied. */
+const PUSH_USAGE_ZERO: ResourceUsage = { wallClockMs: 0, tokens: 0, toolCalls: 0 };
+
+// ============================================================================
+// Input / output / deps shapes
+// ============================================================================
+
+/**
+ * The enable-readiness evidence the caller supplies EXPLICITLY (the flag is NOT
+ * read from env here — the gate stays a pure, testable decision). The
+ * `guardsGreenSoak` value is read from {@link readCodePrGuardsGreenSoak} inside
+ * {@link executeCodePrPush}, NOT taken from this input — the caller cannot forge
+ * the soak streak.
+ */
+export interface CodePrPushReadiness {
+  /** The explicit OFF→on flag (flag half of the double-gate; true alone is never enough). */
+  readonly flagEnabled: boolean;
+  /** A recorded enable-vote ref (vote half). Empty/whitespace = absent. */
+  readonly enableVoteRef: string;
+  /** A named owner accepting activation (owner half). Empty/whitespace = absent. */
+  readonly owner: string;
+}
+
+/** Input to {@link executeCodePrPush}. */
+export interface CodePrPushInput {
+  /** The proposed change set + run identity (forwarded to {@link planCodePrRun}). */
+  readonly run: CodePrRunInput;
+  /** The explicitly-supplied enable-readiness evidence (flag/vote/owner). */
+  readonly readiness: CodePrPushReadiness;
+  /** PR title for the opened pull request. */
+  readonly prTitle: string;
+  /** PR body for the opened pull request. */
+  readonly prBody: string;
+  /** Absolute repo root to spawn worktrees from. Defaults to cwd. */
+  readonly repoRoot?: string | undefined;
+  /** Optional enable-readiness config override (e.g. a lower soak bar in tests). */
+  readonly readinessConfig?: CodePrEnableReadinessConfig | undefined;
+  /** Optional blast-radius limits forwarded to the plan + the pre-push re-check. */
+  readonly blastRadiusLimits?: BlastRadiusLimits | undefined;
+  /** Optional resource-budget limits forwarded to the plan + the pre-push re-check. */
+  readonly resourceLimits?: ResourceBudgetLimits | undefined;
+  /** Realized usage snapshot for the pre-push budget re-check; defaults to zero. */
+  readonly usage?: ResourceUsage | undefined;
+}
+
+/** The realized PR reference returned by a successful push. */
+export interface OpenedPrRef {
+  /** The PR number assigned by the forge. */
+  readonly number: number;
+  /** The PR URL. */
+  readonly url: string;
+}
+
+/** Arguments to the {@link CodePrPushDeps.openPullRequest} seam. */
+export interface OpenPullRequestArgs {
+  /** The feature branch the PR is opened FROM (always `nexus-codepr/<runId>`). */
+  readonly branch: string;
+  readonly title: string;
+  readonly body: string;
+  /** The scoped token (never logged; only the non-secret identity is audited). */
+  readonly token: string;
+}
+
+/**
+ * The injectable external-action seams. Tests pass mocks (NO real push in CI). The
+ * production defaults ({@link defaultGitPush}, {@link defaultOpenPullRequest}) push
+ * ONLY to a new `nexus-codepr/<runId>` feature branch and NEVER merge.
+ */
+export interface CodePrPushDeps {
+  /** Push the worktree's committed branch to the remote. NEW branch only; never main. */
+  readonly gitPush: (branch: string, worktreeRoot: string, token: string) => void;
+  /** Open a normal feature-branch PR (subject to CI + CODEOWNERS). NEVER merges. */
+  readonly openPullRequest: (args: OpenPullRequestArgs) => OpenedPrRef;
+  /** Hash-chained audit logger (intent + result records). */
+  readonly logger: IAuditLogger;
+  /**
+   * Test seam: override the soak read. Defaults to {@link readCodePrGuardsGreenSoak}.
+   * Production leaves this undefined (reads the durable soak store).
+   */
+  readonly readSoak?: (() => number) | undefined;
+  /** Test seam: override the dry-run plan invocation. Defaults to {@link planCodePrRun}. */
+  readonly planRun?: typeof planCodePrRun | undefined;
+}
+
+/** Why a push was refused (fail-closed). NEVER thrown — a refusal is a value. */
+export type CodePrPushReason =
+  | 'not_enabled'
+  | 'no_credentials'
+  | 'plan_denied'
+  | 'pre_push_guard_denied'
+  | 'push_failed'
+  | 'audit_failed';
+
+/** Discriminated push result. NEVER thrown — a failure is a denied value. */
+export type CodePrPushResult =
+  | { readonly ok: true; readonly pr: OpenedPrRef; readonly branch: string; readonly diffHash: string }
+  | { readonly ok: false; readonly reason: CodePrPushReason; readonly detail: string };
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function pushDenied(reason: CodePrPushReason, detail: string): CodePrPushResult {
+  return { ok: false, reason, detail };
+}
+
+/** The feature branch a run pushes to. ALWAYS `nexus-codepr/<runId>` — never main. */
+export function pushBranchName(runId: string): string {
+  return `${CODEPR_PUSH_BRANCH_PREFIX}${runId}`;
+}
+
+/**
+ * A non-secret identity label for the scoped token, for the audit record. Derived
+ * as a short SHA-256 prefix so the audit pins WHICH credential was used without
+ * EVER recording the secret value itself.
+ */
+function tokenIdentity(token: string): string {
+  return `codepr-token:${sha256(token).slice(0, 12)}`;
+}
+
+/** Parse `git diff --numstat` into per-file counts (binary files count as 0/0). */
+function parseNumstat(numstat: string): ChangedFile[] {
+  const files: ChangedFile[] = [];
+  for (const line of numstat.split('\n')) {
+    if (line.trim() === '') continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    const added = parts[0] === '-' ? 0 : Number.parseInt(parts[0] ?? '0', 10);
+    const removed = parts[1] === '-' ? 0 : Number.parseInt(parts[1] ?? '0', 10);
+    files.push({
+      path: parts.slice(2).join('\t'),
+      addedLines: Number.isFinite(added) ? added : 0,
+      removedLines: Number.isFinite(removed) ? removed : 0,
+    });
+  }
+  return files;
+}
+
+/** Audit a fail-closed refusal/denial (decision `abort`). Best-effort; never throws. */
+function auditRefusal(
+  logger: IAuditLogger,
+  run: CodePrRunInput,
+  reason: string,
+  diffHash: string
+): void {
+  try {
+    auditAutonomousEvent(logger, {
+      runId: run.runId,
+      sourceSignalHash: run.sourceSignalHash,
+      diffHash,
+      scanVerdict: 'clean',
+      filesTouched: 0,
+      linesTouched: 0,
+      tokenIdentity: 'none',
+      decision: 'abort',
+      abortReason: 'guard_error',
+      actor: { type: 'system', id: 'autonomous-code-pr-push', name: `code-PR push refused (${reason})` },
+    });
+  } catch {
+    // Auditing the refusal is best-effort; the refusal itself already stands.
+  }
+}
+
+// ============================================================================
+// Step 1 — readiness gate
+// ============================================================================
+
+/**
+ * Step 1: evaluate the enable-readiness DOUBLE-GATE. The `guardsGreenSoak` is read
+ * from the durable soak store (NOT from caller input — the streak cannot be
+ * forged). Returns a `not_enabled` denial (audited) when NOT ready, else undefined.
+ */
+function checkReadiness(input: CodePrPushInput, deps: CodePrPushDeps): CodePrPushResult | undefined {
+  const readSoak = deps.readSoak ?? readCodePrGuardsGreenSoak;
+  const consecutiveGreenDryRuns = readSoak();
+  const verdict = evaluateCodePrEnableReadiness(
+    {
+      flagEnabled: input.readiness.flagEnabled,
+      enableVoteRef: input.readiness.enableVoteRef,
+      consecutiveGreenDryRuns,
+      owner: input.readiness.owner,
+    },
+    input.readinessConfig
+  );
+  if (verdict.ready) return undefined;
+  auditRefusal(deps.logger, input.run, 'not_enabled', sha256(''));
+  return pushDenied('not_enabled', `enable-readiness not satisfied: blockers=[${verdict.blockers.join(', ')}]`);
+}
+
+// ============================================================================
+// Steps 3–4 — realize in a fresh worktree, re-guard, push
+// ============================================================================
+
+/** Mutable holder for the push worktree paths so a `finally` can discard them. */
+interface PushWorktree {
+  worktreeRoot?: string;
+  tempParent?: string;
+}
+
+/** The realized diff for the committed push branch. */
+interface RealizedPush {
+  readonly diffText: string;
+  readonly diffHash: string;
+  readonly changedFiles: ChangedFile[];
+  readonly linesTouched: number;
+}
+
+/**
+ * Create a fresh isolated worktree on a NEW `nexus-codepr/<runId>` branch, apply
+ * the confined changes, and commit them. Records the worktree paths into `handle`
+ * for the caller's `finally`. The branch is checked out via `worktree add -b` so
+ * the push seam pushes a NEW branch — never main.
+ */
+function realizeInPushWorktree(
+  input: CodePrPushInput,
+  branch: string,
+  handle: PushWorktree
+): RealizedPush {
+  const repoRoot = input.repoRoot ?? process.cwd();
+  handle.tempParent = realpathSync(mkdtempSync(join(tmpdir(), 'codepr-push-')));
+  handle.worktreeRoot = join(handle.tempParent, 'wt');
+  // `-b <branch>` creates the NEW feature branch in the throwaway worktree.
+  git(repoRoot, ['worktree', 'add', '-b', branch, handle.worktreeRoot, 'HEAD']);
+
+  for (const change of input.run.changes) {
+    const confined = confinePath(handle.worktreeRoot, change.relPath);
+    if (!confined.ok) throw new Error(`confine failed: ${confined.detail}`);
+    mkdirSync(dirname(confined.resolvedPath), { recursive: true });
+    writeFileSync(confined.resolvedPath, change.newContent);
+  }
+  git(handle.worktreeRoot, ['add', '-A']);
+  const diffText = git(handle.worktreeRoot, ['diff', '--cached']);
+  const changedFiles = parseNumstat(git(handle.worktreeRoot, ['diff', '--cached', '--numstat']));
+  let linesTouched = 0;
+  for (const f of changedFiles) linesTouched += f.addedLines + f.removedLines;
+  // Commit so there is a branch tip to push (no merge, no push here).
+  git(handle.worktreeRoot, [
+    '-c',
+    'user.email=autonomous-code-pr@nexus.local',
+    '-c',
+    'user.name=Autonomous Code-PR',
+    'commit',
+    '-m',
+    `${input.prTitle}\n\nrunId: ${input.run.runId}`,
+  ]);
+  return { diffText, diffHash: sha256(diffText), changedFiles, linesTouched };
+}
+
+/** Discard the push worktree + temp dir. Best-effort; never throws. */
+function discardPushWorktree(repoRoot: string, handle: PushWorktree): void {
+  if (handle.worktreeRoot !== undefined) {
+    try {
+      git(repoRoot, ['worktree', 'remove', '--force', handle.worktreeRoot]);
+    } catch {
+      // fall through to rm
+    }
+  }
+  if (handle.tempParent !== undefined) {
+    try {
+      rmSync(handle.tempParent, { recursive: true, force: true });
+    } catch {
+      // best-effort; under os.tmpdir()
+    }
+  }
+}
+
+/** Bundle for {@link doPush} (keeps the param count within the lint cap). */
+interface PushStageArgs {
+  readonly input: CodePrPushInput;
+  readonly deps: CodePrPushDeps;
+  readonly branch: string;
+  readonly token: string;
+  readonly worktreeRoot: string;
+  readonly realized: RealizedPush;
+}
+
+/**
+ * Step 3 (re-guard) + step 4 (push) + step 5 (audit before/after). RE-RUNS
+ * {@link evaluateWriteGuards} on the freshly-realized diff immediately before the
+ * push (defense-in-depth). Audits intent BEFORE the push and the result AFTER.
+ * Returns a denial on a guard re-deny or a failed pre-push audit — gitPush is NOT
+ * called in either case.
+ */
+function reguardAndPush(args: PushStageArgs): CodePrPushResult {
+  const { input, deps, branch, token, worktreeRoot, realized } = args;
+
+  // Step 3: defense-in-depth — re-run the write guards on the REALIZED diff.
+  const verdict = evaluateWriteGuards({
+    worktreeRoot,
+    changedFiles: realized.changedFiles,
+    diff: realized.diffText,
+    usage: input.usage ?? PUSH_USAGE_ZERO,
+    blastRadiusLimits: input.blastRadiusLimits,
+    resourceLimits: input.resourceLimits,
+  });
+  if (!verdict.ok) {
+    auditRefusal(deps.logger, input.run, `pre_push_guard:${verdict.reason}`, realized.diffHash);
+    return pushDenied('pre_push_guard_denied', `pre-push guard re-check denied (${verdict.reason}): ${verdict.detail}`);
+  }
+
+  // Step 5a: audit the INTENT before any external action (branch, diff, token id).
+  const intent = auditAutonomousEvent(deps.logger, {
+    runId: input.run.runId,
+    sourceSignalHash: input.run.sourceSignalHash,
+    diffHash: realized.diffHash,
+    scanVerdict: 'clean',
+    filesTouched: realized.changedFiles.length,
+    linesTouched: realized.linesTouched,
+    tokenIdentity: tokenIdentity(token),
+    decision: 'would_open_pr',
+    actor: { type: 'system', id: 'autonomous-code-pr-push', name: `code-PR push intent (${branch})` },
+  });
+  if (!intent.ok) {
+    // A failed pre-push audit is itself fail-closed: do NOT push.
+    return pushDenied('audit_failed', `pre-push audit append failed (fail-closed): ${intent.detail}`);
+  }
+
+  // Step 4: external action via the injectable seams. NEW branch only; NEVER merge.
+  deps.gitPush(branch, worktreeRoot, token);
+  const pr = deps.openPullRequest({ branch, title: input.prTitle, body: input.prBody, token });
+
+  // Step 5b: audit the RESULT after the push (PR url/number).
+  auditAutonomousEvent(deps.logger, {
+    runId: input.run.runId,
+    sourceSignalHash: input.run.sourceSignalHash,
+    diffHash: realized.diffHash,
+    scanVerdict: 'clean',
+    filesTouched: realized.changedFiles.length,
+    linesTouched: realized.linesTouched,
+    tokenIdentity: tokenIdentity(token),
+    decision: 'would_open_pr',
+    actor: { type: 'system', id: 'autonomous-code-pr-push', name: `code-PR PR opened #${String(pr.number)}` },
+  });
+  return { ok: true, pr, branch, diffHash: realized.diffHash };
+}
+
+/** Forward the plan-relevant push options to {@link planCodePrRun}. */
+function planOptions(input: CodePrPushInput): CodePrRunOptions {
+  return {
+    repoRoot: input.repoRoot,
+    blastRadiusLimits: input.blastRadiusLimits,
+    resourceLimits: input.resourceLimits,
+    usage: input.usage,
+  };
+}
+
+/**
+ * Steps 3–6 once readiness + credentials passed: dry-run the plan, then realize +
+ * re-guard + push in a fresh worktree, discarding it in a `finally`. May throw
+ * (the caller wraps a throw into a denied result).
+ */
+function planRealizePush(input: CodePrPushInput, deps: CodePrPushDeps, token: string): CodePrPushResult {
+  // Step 3a: build + validate the plan via the dry-run orchestrator (it discards
+  // its OWN worktree). A denial here is a hard stop — never reach the push.
+  const planRun = deps.planRun ?? planCodePrRun;
+  const plan = planRun(input.run, deps.logger, planOptions(input));
+  if (!plan.ok) {
+    return pushDenied('plan_denied', `dry-run plan denied (${plan.reason}): ${plan.detail}`);
+  }
+
+  // Step 3b–6: realize in a FRESH push worktree, re-guard, push, audit, cleanup.
+  const branch = pushBranchName(input.run.runId);
+  const repoRoot = input.repoRoot ?? process.cwd();
+  const handle: PushWorktree = {};
+  try {
+    const realized = realizeInPushWorktree(input, branch, handle);
+    if (handle.worktreeRoot === undefined) throw new Error('push worktree not created');
+    return reguardAndPush({ input, deps, branch, token, worktreeRoot: handle.worktreeRoot, realized });
+  } finally {
+    discardPushWorktree(repoRoot, handle);
+  }
+}
+
+// ============================================================================
+// Entry point
+// ============================================================================
+
+/**
+ * Execute the gated code-PR push. The STRICT fail-closed sequence (readiness gate
+ * → credentials → dry-run plan → fresh-worktree realize → pre-push guard re-check
+ * → push → PR-open, auditing before AND after). Returns a {@link CodePrPushResult}
+ * — `ok` with the opened PR ref, or a fail-closed denial. NEVER throws (a throw is
+ * wrapped into a `push_failed` denial); ALWAYS discards the push worktree.
+ *
+ * A push is IMPOSSIBLE unless BOTH (a) {@link evaluateCodePrEnableReadiness}
+ * returns `ready` against the explicit flag/vote/owner evidence AND the durable
+ * guards-green soak read from {@link readCodePrGuardsGreenSoak}, AND (b) an
+ * explicit scoped token is present in {@link CODEPR_TOKEN_ENV}. There is NO merge
+ * path anywhere in this module: the PR is a normal feature-branch PR subject to
+ * CI + CODEOWNERS.
+ */
+export function executeCodePrPush(input: CodePrPushInput, deps: CodePrPushDeps): CodePrPushResult {
+  // Step 1: readiness gate FIRST — NOT ready ⇒ do nothing else (no worktree/push).
+  const notReady = checkReadiness(input, deps);
+  if (notReady !== undefined) return notReady;
+
+  // Step 2: credentials required — absent/empty token ⇒ no push.
+  const token = process.env[CODEPR_TOKEN_ENV] ?? '';
+  if (token.trim() === '') {
+    return pushDenied('no_credentials', `no scoped credential in ${CODEPR_TOKEN_ENV} (fail-closed)`);
+  }
+
+  // Steps 3–6 — wrapped so ANY throw becomes a fail-closed denial.
+  try {
+    return planRealizePush(input, deps, token);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    auditRefusal(deps.logger, input.run, 'push_failed', sha256(''));
+    return pushDenied('push_failed', `code-PR push failed (fail-closed): ${message}`);
+  }
+}
+
+// ============================================================================
+// Production seam implementations
+// ============================================================================
+
+/** Repo `origin` URL (used to build the per-push tokenized push URL). Throws on failure. */
+function originUrl(worktreeRoot: string): string {
+  return git(worktreeRoot, ['remote', 'get-url', 'origin']).trim();
+}
+
+/**
+ * Build the tokenized HTTPS push URL for `origin` using the scoped token as the
+ * `x-access-token` basic-auth user. Only `https://` origins are supported (an
+ * ssh/`git@` origin is rejected fail-closed — there is no safe place to inject a
+ * token). The token is embedded ONLY in the in-memory URL passed to `git push`
+ * (never written to the repo config — see {@link defaultGitPush}).
+ */
+function tokenizedPushUrl(origin: string, token: string): string {
+  if (!origin.startsWith('https://')) {
+    throw new Error('code-PR push requires an https origin (fail-closed)');
+  }
+  return `https://x-access-token:${token}@${origin.slice('https://'.length)}`;
+}
+
+/**
+ * The PRODUCTION `gitPush` seam. Pushes the worktree's CURRENT branch to the
+ * remote under the SAME (new) branch name — and ONLY a `nexus-codepr/<runId>`
+ * branch (asserted fail-closed). It NEVER pushes to main, NEVER force-pushes,
+ * NEVER merges, and NEVER alters branch protections. The scoped token is supplied
+ * as an explicit per-invocation remote URL so it is not persisted in repo config.
+ *
+ * `--no-verify` is intentionally NOT passed (hooks run); `:refs/heads/<branch>`
+ * names the destination ref EXPLICITLY so the push can only create/update that one
+ * feature branch on the remote.
+ */
+export function defaultGitPush(branch: string, worktreeRoot: string, token: string): void {
+  if (!branch.startsWith(CODEPR_PUSH_BRANCH_PREFIX)) {
+    throw new Error(`refusing to push non-codepr branch "${branch}" (fail-closed)`);
+  }
+  if (branch === 'main' || branch === 'master') {
+    throw new Error('refusing to push to a default branch (fail-closed)');
+  }
+  const url = tokenizedPushUrl(originUrl(worktreeRoot), token);
+  // Explicit src:dst refspec to the SAME feature branch — never main, no merge.
+  git(worktreeRoot, ['push', url, `refs/heads/${branch}:refs/heads/${branch}`]);
+}
+
+/**
+ * The PRODUCTION `openPullRequest` seam: open a NORMAL feature-branch PR via
+ * `gh pr create` (subject to CI + CODEOWNERS). It does NOT pass `--merge`, does NOT
+ * enable auto-merge, and does NOT merge — there is no merge surface here. Returns
+ * the parsed PR number + URL. `GH_TOKEN` is set for the `gh` invocation from the
+ * scoped token; it is never logged.
+ */
+export function defaultOpenPullRequest(args: OpenPullRequestArgs): OpenedPrRef {
+  const out = execFileSync(
+    'gh',
+    ['pr', 'create', '--head', args.branch, '--title', args.title, '--body', args.body],
+    { encoding: 'utf8', env: { ...process.env, GH_TOKEN: args.token } }
+  ).trim();
+  const url = out.split('\n').find((l) => l.startsWith('http'))?.trim() ?? out;
+  const num = url.match(/\/pull\/(\d+)/);
+  return { number: num?.[1] !== undefined ? Number.parseInt(num[1], 10) : 0, url };
+}
+
+/**
+ * Assemble the production push deps (real `gitPush`/`openPullRequest` seams over
+ * the scoped token, plus the supplied audit logger). The durable soak read + the
+ * dry-run plan default to {@link readCodePrGuardsGreenSoak} / {@link planCodePrRun}.
+ * Note: assembling these deps does NOT push — a push still requires the full
+ * readiness gate + the explicit token at {@link executeCodePrPush} time.
+ */
+export function defaultCodePrPushDeps(logger: IAuditLogger): CodePrPushDeps {
+  return { gitPush: defaultGitPush, openPullRequest: defaultOpenPullRequest, logger };
+}


### PR DESCRIPTION
## #3670 Stage 3 (FINAL, SECURITY-CRITICAL) — the scoped-token push + PR-open

Adds `codepr-push.ts` — the **ONLY** module in the code-PR capability loop that can take an external action (a `git push` to a **new** `nexus-codepr/<runId>` feature branch + a PR open). It ships **OFF-by-default** and is **NOT wired** to any live runtime trigger / auto-remediation enforce path. Activation still requires the enable-vote + a real soak ≥ min + owner-ack via the readiness gate — **none of which is triggered here**.

### Strict fail-closed sequence (`executeCodePrPush`)
Every step returns a discriminated denial value; the module **never throws** (a throw is wrapped into a `push_failed` denial).

1. **Readiness gate FIRST.** Assemble the enable-readiness evidence (explicit flag, `enableVoteRef`, the durable `guardsGreenSoak` read from `readCodePrGuardsGreenSoak`, owner-ack) and call `evaluateCodePrEnableReadiness`. NOT ready → `{ok:false, reason:'not_enabled'}` and **do nothing else** (no worktree, no push). The refusal is audited. The soak count is read from the store, **not** taken from caller input — the streak cannot be forged.
2. **Credentials required.** The push seam requires a non-empty token from `NEXUS_CODEPR_TOKEN`. Absent/empty/whitespace → `{ok:false, reason:'no_credentials'}`, no push. So even when fully enabled, **no token = no action.**
3. **Produce + re-validate the plan.** Call `planCodePrRun` (dry-run) to build + validate the plan in an isolated worktree it discards. Then re-realize the diff in a **fresh** push worktree and **RE-RUN `evaluateWriteGuards`** on it immediately before the push (defense-in-depth — never trust the earlier verdict). Any denial → fail-closed, audit, **no push**.
4. **Push via injectable seams** (`deps.gitPush` / `deps.openPullRequest`). Production seams (`defaultGitPush`/`defaultOpenPullRequest`) push **only** to a new `nexus-codepr/<runId>` branch (asserted fail-closed — a non-`nexus-codepr/` or `main`/`master` branch is refused), **never to main**, **never merge**, **never alter protections**, using the scoped token. The PR is a normal feature-branch PR subject to **CI + CODEOWNERS**.
5. **Audit (hash-chained) BOTH** before the push (intent: branch, diff hash, non-secret token identity) and after (result: PR url/number) via `auditAutonomousEvent`.
6. **Atomic cleanup:** the push worktree is discarded in a `finally`.

### The double-block
A push is **impossible** unless **BOTH** (a) `evaluateCodePrEnableReadiness` returns `ready` against the explicit flag/vote/owner evidence AND the durable guards-green soak, **AND** (b) an explicit scoped token is present in `NEXUS_CODEPR_TOKEN`. Either block alone refuses the push.

### Never-pushes-main / never-merges invariant
There is **no merge / auto-merge surface anywhere** in the module — asserted structurally over the (comment-stripped) source in the tests. The production push uses an explicit `refs/heads/<branch>:refs/heads/<branch>` refspec to the **same** `nexus-codepr/*` feature branch only. The scoped token is embedded only in the in-memory push URL / `gh` env, never persisted in repo config and never logged (the audit pins a non-secret `codepr-token:<12-hex>` identity).

### Tests (`codepr-push.test.ts`, 14 — NO real push; seams mocked)
- **not-enabled** (flag off / missing vote-ref / soak below min / no owner-ack) → `not_enabled`; `gitPush`/`openPullRequest` **never** called, **no worktree created**; readiness runs **before** credentials (still `not_enabled` even with a token set).
- **no-credentials** (token absent / whitespace) → `no_credentials`, no push.
- **happy path** → pushes a `nexus-codepr/*` feature branch (asserted **not** `main`/`master`) with the scoped token, **then** opens the PR (call order asserted); audits **before + after**; returns ok with the PR ref; worktree discarded; raw token never appears in audit metadata.
- **pre-push guard re-check denies** (a sensitive `package.json` slips into the realized change set while the dry-run plan is stubbed ok) → `pre_push_guard_denied`, `gitPush` **never** called. Plus the dry-run plan itself denying (real `planCodePrRun` on a `governance/` path) → `plan_denied`, no push.
- **induced throw** in the push seam → `push_failed` (not thrown), `openPullRequest` not reached, worktree cleaned (atomic).
- **structure assertion**: no merge/auto-merge/force-push/protection surface in the code.

### Gates
- Zero `any`; `tsc --noEmit` clean; eslint clean; full codepr suite green (**128 tests**). Unused-export gate passes via the `@export-no-consumer-yet — see #3670` marker (no runtime consumer yet — activation is a future owner step). No MCP tool / CLI command added (repo-index unaffected). Changeset `.changeset/codepr-push-stage3-3670.md` (`'nexus-agents': minor`, `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)