### PR TITLE
refactor(cli): single-source command descriptions from COMMAND_CATALOG — fix 3-way help drift (#3209)

### DIFF
--- a/.changeset/help-description-single-source-3209.md
+++ b/.changeset/help-description-single-source-3209.md
@@ -1,0 +1,36 @@
+---
+'nexus-agents': patch
+---
+
+refactor(cli): single-source command descriptions from COMMAND_CATALOG (#3209)
+
+The one-line description of each top-level command was copied across three
+files and had DRIFTED: `vote` read "Run consensus vote on a proposal (5-6
+agents)" in `cli-command-catalog.ts`, "Run consensus vote on a proposal (6
+agents)" in the hardcoded `HELP_TEXT` command list, and "Run multi-agent
+consensus vote on a proposal (6 agents by default)." in `COMMAND_HELP` — all
+three wrong (the panel is 7 roles by default, 3 with `--quick`, per
+`getVoterRoles` in `mcp/tools/consensus-vote.ts`).
+
+`COMMAND_CATALOG` is now the single source of each command's one-line
+description:
+
+- The hardcoded COMMANDS list was removed from `HELP_TEXT`; `renderHelp` now
+  fills a single placeholder in the static frame with
+  `renderCommandsSection(showAll)` for BOTH the default (`--help`) and full
+  (`--help --all`) views — previously only the default view derived from the
+  catalog while `--all` returned the drifted hardcoded list.
+- `CommandHelpEntry.description` was dropped; `formatCommandHelp` /
+  `formatAllCommandsHelp` look the one-liner up from the catalog via the new
+  `getCommandDescription`. The richer per-command help (flags, examples,
+  API-key requirements) stays in `COMMAND_HELP`.
+- A drift gate in `cli-command-catalog.test.ts` asserts the rendered `--help`
+  command list and every `COMMAND_HELP` command agree with the catalog, and
+  that `vote` reflects the real 7-agent default.
+
+The catalog `vote` description was corrected to "Run consensus vote on a
+proposal (7 agents; --quick uses 3)". Per the 7-0 vote in #3212, no unified
+registry / dispatch refactor was done — this only consolidates the
+description into the existing catalog. `--help` output is unchanged except the
+corrected vote count and `--all` now using the same catalog-grouped layout as
+the default view.

--- a/packages/nexus-agents/src/cli-command-catalog.test.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.test.ts
@@ -14,8 +14,10 @@ import {
   groupByAudience,
   renderCommandsSection,
   catalogForExtractors,
+  getCommandDescription,
 } from './cli-command-catalog.js';
 import { renderHelp, HELP_TEXT } from './cli-help-text.js';
+import { COMMAND_HELP, formatCommandHelp, formatAllCommandsHelp } from './cli-command-help.js';
 import { isValidCommand } from './cli-types.js';
 
 describe('cli-command-catalog (#2135)', () => {
@@ -187,6 +189,80 @@ describe('cli-command-catalog (#2135)', () => {
       const tiered = renderHelp({ all: false });
       const full = renderHelp({ all: true });
       expect(tiered.length).toBeLessThan(full.length);
+    });
+  });
+
+  // ── Single-source drift gate (#3209) ──────────────────────────────────────
+  // The same one-line description used to be copied (and DRIFTED) across three
+  // files: the catalog, the HELP_TEXT command list, and COMMAND_HELP. The exact
+  // bug: `vote` read "5-6 agents" (catalog) vs "6 agents" (HELP_TEXT) vs
+  // "6 agents by default" (COMMAND_HELP) — all wrong; the panel is 7. These
+  // tests assert COMMAND_CATALOG is the ONE source and every other help surface
+  // derives from it, so the drift cannot regress.
+  describe('single-source command descriptions (#3209)', () => {
+    /**
+     * Asserts the rendered COMMANDS block contains one row per visible catalog
+     * command whose text is exactly `<command padEnd(16)> <catalog description>`
+     * — i.e. the rendered list IS the catalog, with no drifted copy. Matches the
+     * exact row shape `renderCommandsSection` produces (padEnd(16), 1 space).
+     */
+    function expectCommandsMatchCatalog(helpText: string, showAll: boolean): void {
+      const commandsMatch = /COMMANDS:\n([\s\S]*?)\n\nOPTIONS:/.exec(helpText);
+      expect(commandsMatch).not.toBeNull();
+      const block = commandsMatch?.[1] ?? '';
+      for (const entry of filterCatalog(showAll)) {
+        const expectedRow = `    ${entry.command.padEnd(16)} ${entry.description}`;
+        expect(
+          block.includes(expectedRow),
+          `COMMANDS list is missing the catalog row for "${entry.command}" ` +
+            `(expected exactly: "${expectedRow.trim()}") — descriptions have drifted ` +
+            `from COMMAND_CATALOG`
+        ).toBe(true);
+      }
+    }
+
+    it('the rendered COMMANDS list (--all) matches catalog descriptions verbatim', () => {
+      expectCommandsMatchCatalog(renderHelp({ all: true }), true);
+    });
+
+    it('the default COMMANDS list matches catalog descriptions verbatim', () => {
+      expectCommandsMatchCatalog(renderHelp({ all: false }), false);
+    });
+
+    it('every COMMAND_HELP command has a catalog description (no third copy)', () => {
+      for (const entry of COMMAND_HELP) {
+        expect(
+          getCommandDescription(entry.command),
+          `COMMAND_HELP command "${entry.command}" is not in COMMAND_CATALOG — ` +
+            `its one-line description cannot be single-sourced`
+        ).toBeDefined();
+      }
+    });
+
+    it('per-command help renders the catalog description (formatCommandHelp)', () => {
+      for (const entry of COMMAND_HELP) {
+        const help = formatCommandHelp(entry.command);
+        expect(help).toBeDefined();
+        const description = getCommandDescription(entry.command) ?? '';
+        expect(help).toContain(description);
+      }
+    });
+
+    it('the all-commands summary renders catalog descriptions (formatAllCommandsHelp)', () => {
+      const summary = formatAllCommandsHelp();
+      for (const entry of COMMAND_HELP) {
+        const description = getCommandDescription(entry.command) ?? '';
+        expect(summary).toContain(description);
+      }
+    });
+
+    it('reconciles the vote drift to the real 7-agent default panel', () => {
+      // Regression for the exact #3209 example. getVoterRoles() in
+      // mcp/tools/consensus-vote.ts returns 7 roles by default, 3 for --quick.
+      const vote = getCommandDescription('vote');
+      expect(vote).toContain('7 agents');
+      expect(vote).not.toContain('6 agents');
+      expect(vote).not.toContain('5-6');
     });
   });
 });

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -101,7 +101,10 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   },
   {
     command: 'vote',
-    description: 'Run consensus vote on a proposal (5-6 agents)',
+    // Default panel is 7 roles; `--quick` runs 3 (getVoterRoles in
+    // mcp/tools/consensus-vote.ts). Prior drift: "5-6 agents" here, "6 agents"
+    // in HELP_TEXT, "6 agents by default" in COMMAND_HELP — all wrong (#3209).
+    description: 'Run consensus vote on a proposal (7 agents; --quick uses 3)',
     audience: 'essential',
   },
   {
@@ -371,6 +374,20 @@ export function filterCatalog(showAll: boolean): readonly CommandCatalogEntry[] 
  */
 export function catalogForExtractors(): readonly CommandCatalogEntry[] {
   return COMMAND_CATALOG.filter((e) => e.command !== '(default)');
+}
+
+/**
+ * Looks up the canonical one-line description for a command from the catalog
+ * (the single source of truth — #3209). Returns `undefined` if the command is
+ * not cataloged.
+ *
+ * Used by `cli-command-help.ts` so per-command help (`formatCommandHelp`,
+ * `formatAllCommandsHelp`) does not keep a third independent copy of the
+ * one-line summary. The richer per-command help (flags, examples) still lives
+ * in `COMMAND_HELP`; only the one-liner is single-sourced here.
+ */
+export function getCommandDescription(command: string): string | undefined {
+  return COMMAND_CATALOG.find((e) => e.command === command)?.description;
 }
 
 /** Groups entries by audience, preserving catalog order within each group. */

--- a/packages/nexus-agents/src/cli-command-help.test.ts
+++ b/packages/nexus-agents/src/cli-command-help.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { COMMAND_HELP, formatCommandHelp, formatAllCommandsHelp } from './cli-command-help.js';
+import { getCommandDescription } from './cli-command-catalog.js';
 
 // ============================================================================
 // Help metadata registry
@@ -23,9 +24,14 @@ describe('COMMAND_HELP', () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
-  it('every entry has non-empty description', () => {
+  // #3209: the one-line description is no longer stored on the entry — it is
+  // single-sourced from COMMAND_CATALOG. Assert every command resolves to a
+  // non-empty catalog description (so per-command help is never blank).
+  it('every command resolves a non-empty catalog description (single-sourced #3209)', () => {
     for (const entry of COMMAND_HELP) {
-      expect(entry.description.length).toBeGreaterThan(0);
+      const description = getCommandDescription(entry.command);
+      expect(description, `no COMMAND_CATALOG description for "${entry.command}"`).toBeDefined();
+      expect((description ?? '').length).toBeGreaterThan(0);
     }
   });
 

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -4,8 +4,16 @@
  * Structured help metadata for individual CLI commands.
  * Used by `nexus-agents <command> --help` to show targeted help.
  *
+ * The one-line command description is NOT stored here (#3209). It is
+ * single-sourced from `COMMAND_CATALOG` in `cli-command-catalog.ts` and looked
+ * up via `getCommandDescription` when formatting. This module owns the RICHER
+ * per-command help — flags, examples, API-key requirements — that the catalog
+ * does not carry.
+ *
  * @module cli-command-help
  */
+
+import { getCommandDescription } from './cli-command-catalog.js';
 
 /**
  * Flag metadata for a CLI command.
@@ -18,10 +26,13 @@ export interface CommandFlagEntry {
 
 /**
  * Structured help entry for a single CLI command.
+ *
+ * No `description` field: the one-line summary comes from `COMMAND_CATALOG`
+ * (single source — #3209) via {@link getCommandDescription}. This entry holds
+ * only the richer help the catalog lacks (flags, examples, API-key needs).
  */
 export interface CommandHelpEntry {
   readonly command: string;
-  readonly description: string;
   readonly examples: readonly string[];
   readonly flags?: readonly CommandFlagEntry[];
   readonly requiresApiKey?: readonly string[];
@@ -29,7 +40,6 @@ export interface CommandHelpEntry {
 
 const ORCHESTRATE_HELP: CommandHelpEntry = {
   command: 'orchestrate',
-  description: 'Execute a task using CLI tools (standalone mode). Routes to optimal model.',
   examples: [
     'nexus-agents orchestrate "Explain this function"',
     'nexus-agents orchestrate "Generate unit tests" --model=claude',
@@ -53,7 +63,6 @@ const ORCHESTRATE_HELP: CommandHelpEntry = {
 
 const VOTE_HELP: CommandHelpEntry = {
   command: 'vote',
-  description: 'Run multi-agent consensus vote on a proposal (6 agents by default).',
   examples: [
     'nexus-agents vote --proposal "Add caching layer"',
     'nexus-agents vote -p "Migrate to PostgreSQL" -t supermajority',
@@ -63,7 +72,7 @@ const VOTE_HELP: CommandHelpEntry = {
   flags: [
     { flag: '-p, --proposal <text>', description: 'Proposal text to vote on (required)' },
     { flag: '-t, --threshold <t>', description: 'Threshold: majority, supermajority, unanimous' },
-    { flag: '--quick', description: 'Use 3 agents instead of 6 for faster votes' },
+    { flag: '--quick', description: 'Use 3 agents instead of the full 7 for faster votes' },
     { flag: '--dry-run', description: 'Simulate votes without agent execution' },
     { flag: '--timeout=<seconds>', description: 'Timeout per vote in seconds', defaultValue: '90' },
     {
@@ -78,7 +87,6 @@ const VOTE_HELP: CommandHelpEntry = {
 
 const EXPERT_HELP: CommandHelpEntry = {
   command: 'expert',
-  description: 'Manage expert agents. Subcommands: list, create, execute.',
   examples: ['nexus-agents expert list', 'nexus-agents expert list --format=json'],
   flags: [
     {
@@ -91,7 +99,6 @@ const EXPERT_HELP: CommandHelpEntry = {
 
 const WORKFLOW_HELP: CommandHelpEntry = {
   command: 'workflow',
-  description: 'Manage and run workflow templates. Subcommands: list, run.',
   examples: [
     'nexus-agents workflow list',
     'nexus-agents workflow run code-review --input=\'{"url":"https://github.com/o/r/pull/1"}\'',
@@ -105,7 +112,6 @@ const WORKFLOW_HELP: CommandHelpEntry = {
 
 const DOCTOR_HELP: CommandHelpEntry = {
   command: 'doctor',
-  description: 'Check CLI installations, adapters, and system health.',
   examples: ['nexus-agents doctor', 'nexus-agents doctor --deep', 'nexus-agents doctor --fix'],
   flags: [
     { flag: '--deep', description: 'Run deep health checks (adapter connectivity)' },
@@ -116,8 +122,6 @@ const DOCTOR_HELP: CommandHelpEntry = {
 
 const MODE_HELP: CommandHelpEntry = {
   command: 'mode',
-  description:
-    'Inspect the detected invocation mode (server vs orchestrator), the signals that fed the decision, and the one-line reasoning. Useful for debugging unexpected modes in CI/containers.',
   examples: [
     'nexus-agents mode',
     'nexus-agents mode --format=json',
@@ -134,7 +138,6 @@ const MODE_HELP: CommandHelpEntry = {
 
 const SETUP_HELP: CommandHelpEntry = {
   command: 'setup',
-  description: 'Configure MCP integration for Claude, Gemini, Codex, and OpenCode CLIs.',
   examples: [
     'nexus-agents setup',
     'nexus-agents setup --interactive',
@@ -173,8 +176,6 @@ const SETUP_HELP: CommandHelpEntry = {
 
 const CONFIG_HELP: CommandHelpEntry = {
   command: 'config',
-  description:
-    'Manage nexus-agents configuration. Subcommands: init, get, set, list, reset, export, import.',
   examples: [
     'nexus-agents config init',
     'nexus-agents config get TIMEOUT_DEFAULTS.cliMs',
@@ -195,8 +196,6 @@ const CONFIG_HELP: CommandHelpEntry = {
 
 const RESEARCH_HELP: CommandHelpEntry = {
   command: 'research',
-  description:
-    'Manage research registry and paper tracking. Subcommands: status, overlap, add, stats, refresh, check, index.',
   examples: [
     'nexus-agents research status',
     'nexus-agents research stats --format=json',
@@ -212,7 +211,6 @@ const RESEARCH_HELP: CommandHelpEntry = {
 
 const FITNESS_AUDIT_HELP: CommandHelpEntry = {
   command: 'fitness-audit',
-  description: 'Run CLI orchestration fitness score audit. Target: 90+/100.',
   examples: [
     'nexus-agents fitness-audit',
     'nexus-agents fitness-audit --format=json',
@@ -230,7 +228,6 @@ const FITNESS_AUDIT_HELP: CommandHelpEntry = {
 
 const REVIEW_HELP: CommandHelpEntry = {
   command: 'review',
-  description: 'Review a GitHub pull request (dogfooding mode).',
   examples: [
     'nexus-agents review https://github.com/owner/repo/pull/123',
     'nexus-agents review owner/repo#123 --dry-run',
@@ -267,6 +264,16 @@ function formatFlag(entry: CommandFlagEntry): string {
 }
 
 /**
+ * Resolves a command's one-line description from the catalog (single source —
+ * #3209). Every `COMMAND_HELP` command is also in `COMMAND_CATALOG` (asserted
+ * by the drift gate in `cli-command-help.test.ts`); the empty-string fallback
+ * is a defensive default that never fires in practice.
+ */
+function describe(command: string): string {
+  return getCommandDescription(command) ?? '';
+}
+
+/**
  * Formats help output for a specific command.
  *
  * @param command - The command name to look up
@@ -277,7 +284,7 @@ export function formatCommandHelp(command: string): string | undefined {
   if (entry === undefined) return undefined;
 
   const lines: string[] = [];
-  lines.push(`nexus-agents ${entry.command} -- ${entry.description}`);
+  lines.push(`nexus-agents ${entry.command} -- ${describe(entry.command)}`);
   lines.push('');
 
   if (entry.flags !== undefined && entry.flags.length > 0) {
@@ -312,7 +319,7 @@ export function formatAllCommandsHelp(): string {
   lines.push('');
 
   for (const entry of COMMAND_HELP) {
-    lines.push(`  ${entry.command.padEnd(20)} ${entry.description}`);
+    lines.push(`  ${entry.command.padEnd(20)} ${describe(entry.command)}`);
   }
 
   lines.push('');

--- a/packages/nexus-agents/src/cli-help-text.ts
+++ b/packages/nexus-agents/src/cli-help-text.ts
@@ -4,12 +4,19 @@
  * Help documentation for the CLI commands and options.
  * Extracted from cli-types.ts to maintain file size limits.
  *
- * HELP_TEXT below is the full (`--all`) view and also doubles as the raw
- * template that `entrypoint-cli-extractor.ts` parses via AST to build the
- * entrypoint index. Do not reshape its top-level sections without updating
- * that extractor. Tiered rendering (default vs `--all`) lives in
- * `renderHelp({ all })`, which swaps the COMMANDS block based on the
- * audience catalog in `cli-command-catalog.ts`.
+ * The COMMANDS list is NO LONGER hardcoded here (#3209). It is generated from
+ * `COMMAND_CATALOG` in `cli-command-catalog.ts` — the single source of truth
+ * for each command's one-line description — via `renderCommandsSection`. The
+ * non-command sections (USAGE, OPTIONS, EXAMPLES) stay static in
+ * `HELP_TEXT_FRAME`. `HELP_TEXT` is that frame with the full (`--all`)
+ * catalog-derived COMMANDS block stitched in; `renderHelp({ all: false })`
+ * stitches in the audience-filtered block instead.
+ *
+ * Do not reshape the top-level sections (USAGE / COMMANDS / OPTIONS /
+ * EXAMPLES): `indexer/entrypoint-extractor.ts` loads this module by AST and
+ * the catalog/help snapshot tests assert their presence. (Command names +
+ * descriptions for the entrypoint index come from the catalog via
+ * `catalogForExtractors()`, not from parsing this text — #2156.)
  *
  * @module cli-help-text
  */
@@ -17,9 +24,17 @@
 import { renderCommandsSection } from './cli-command-catalog.js';
 
 /**
- * Help text for the CLI.
+ * Placeholder token inside {@link HELP_TEXT_FRAME} that the renderers replace
+ * with the catalog-derived COMMANDS block. Distinct from any real help content
+ * so the single substitution is unambiguous.
  */
-export const HELP_TEXT = `
+const COMMANDS_PLACEHOLDER = '__COMMANDS__';
+
+/**
+ * Static help frame: everything except the COMMANDS list, which is a single
+ * {@link COMMANDS_PLACEHOLDER} token filled at render time from the catalog.
+ */
+const HELP_TEXT_FRAME = `
 nexus-agents - Intelligent orchestration platform for AI coding tools
 
 USAGE:
@@ -27,44 +42,7 @@ USAGE:
   nexus-agents [COMMAND] [SUBCOMMAND] [OPTIONS]
 
 COMMANDS:
-  (default)       Start MCP server with stdio transport
-  hello           Show welcome message and quick start (no API keys needed)
-  demo            API-free exploration mode (no API keys needed)
-  setup           Configure Claude CLI integration (MCP + CLAUDE.md rules)
-  login           Show per-CLI auth status + login fix instructions
-  verify          Quick installation verification (no API keys needed)
-  doctor          Check CLI installations and health status
-  config          Manage configuration (init, get, set, list, reset, export, import)
-  expert list     List available experts (built-in and custom)
-  workflow list   List available workflow templates
-  workflow run    Execute a workflow template
-  review <url>    Review a GitHub pull request (dogfooding)
-  routing-audit   Debug model routing decisions
-  orchestrate     Execute task using CLI tools (standalone mode)
-  vote            Run consensus vote on a proposal (6 agents)
-  system-review   Run automated system review (5-phase checklist)
-  sprint          Automated sprint planning from open issues
-  session         Manage session persistence (list, show, export, delete, prune)
-  evaluate        Self-evaluation of codebase components
-  issue           Issue template validation and management
-  index           Generate and manage codebase index
-  research        Manage research registry and index
-  validation      Show learning validation dashboard
-  learning-metrics Show aggregated learning metrics dashboard
-  swe-bench       Run SWE-bench evaluation benchmark
-  atbench         Run ATBench trajectory-safety evaluation (#1981)
-  hooks           Claude CLI hook integration commands
-  fitness-audit   Run CLI orchestration fitness score audit
-  release-notes   Generate release notes from git commits
-  release-validate Run expert swarm validation for releases
-  release-announce Generate release announcements (blog, Bluesky)
-  scaffold        Generate project files from templates (tool, expert, workflow, command)
-  visualize       Generate Mermaid diagrams and ASCII dashboards (architecture, swarm, flow)
-  capabilities    Show model capabilities matrix (modalities, tools, features)
-  status          At-a-glance project health dashboard (fitness, adapters, version)
-  health          Swarm health metrics dashboard (utilization, routing accuracy, failures)
-  validate        Run unified validation (doctor + fitness + config)
-  auth            Manage MCP authentication tokens (init, show, rotate)
+${COMMANDS_PLACEHOLDER}
 
 OPTIONS:
   -h, --help           Show this help message
@@ -91,26 +69,29 @@ EXAMPLES:
 For more information, visit: https://github.com/nexus-substrate/nexus-agents
 `.trim();
 
+/** Fills the COMMANDS placeholder in the frame with a catalog-derived block. */
+function composeHelp(commandsSection: string): string {
+  return HELP_TEXT_FRAME.replace(COMMANDS_PLACEHOLDER, commandsSection);
+}
+
 /**
- * Regex matching the COMMANDS: block in HELP_TEXT, from the heading line
- * through (but not including) the blank line before OPTIONS:.
- *
- * The template literal in HELP_TEXT has the COMMANDS list indented 2 spaces,
- * followed by a blank line, followed by `OPTIONS:`. We swap out everything
- * between `COMMANDS:\n` and the blank line before `OPTIONS:`.
+ * Full (`--all`) help text, with the COMMANDS list generated from
+ * `COMMAND_CATALOG` (single source of truth — #3209). Equivalent to
+ * `renderHelp({ all: true })`; exported for callers/tests that want the
+ * canonical full view as a value.
  */
-const COMMANDS_BLOCK_RE = /COMMANDS:\n([\s\S]*?)\n\nOPTIONS:/;
+export const HELP_TEXT = composeHelp(renderCommandsSection(true));
 
 /**
  * Renders the top-level help output.
  *
- * @param opts.all - If true, returns the full HELP_TEXT (includes maintainer
+ * @param opts.all - If true, returns the full view (includes maintainer
  *   commands like benchmarks and release tooling). If false, returns a tiered
  *   view that hides maintainer commands — surfaced via `--all` hint at the
- *   bottom of the COMMANDS block.
+ *   bottom of the COMMANDS block. Both views derive the command list (and its
+ *   one-line descriptions) from `COMMAND_CATALOG`.
  */
 export function renderHelp(opts: { all: boolean }): string {
   if (opts.all) return HELP_TEXT;
-  const replacement = renderCommandsSection(false);
-  return HELP_TEXT.replace(COMMANDS_BLOCK_RE, `COMMANDS:\n${replacement}\n\nOPTIONS:`);
+  return composeHelp(renderCommandsSection(false));
 }


### PR DESCRIPTION
## Problem (#3209) — verified 3-way drift

The same command's one-line description was duplicated across three files and had **drifted**. The canonical example is `vote`:

| File | Description |
| --- | --- |
| `cli-command-catalog.ts` (`COMMAND_CATALOG`) | `Run consensus vote on a proposal (5-6 agents)` |
| `cli-help-text.ts` (hardcoded `HELP_TEXT` list) | `Run consensus vote on a proposal (6 agents)` |
| `cli-command-help.ts` (`COMMAND_HELP`) | `Run multi-agent consensus vote on a proposal (6 agents by default).` |

All three were **wrong**: `getVoterRoles` in `mcp/tools/consensus-vote.ts` returns **7 roles** by default and **3** for `--quick`.

## Consolidation — `COMMAND_CATALOG` is the single source

- **HELP_TEXT command list → generated from the catalog.** The hardcoded COMMANDS block was removed. `renderHelp` now fills a single placeholder in the static help frame with `renderCommandsSection(showAll)` for **both** the default (`--help`) and full (`--help --all`) views. Previously only the default view derived from the catalog; `--all` returned the drifted hardcoded list. USAGE / OPTIONS / EXAMPLES are unchanged.
- **COMMAND_HELP one-line description → single-sourced via option (a).** `CommandHelpEntry.description` was **removed**; `formatCommandHelp` / `formatAllCommandsHelp` resolve the one-liner from the catalog via a new `getCommandDescription(command)`. The richer per-command help (flags, examples, API-key requirements) stays in `COMMAND_HELP`.
- **Drift gate (test).** New describe block in `cli-command-catalog.test.ts` asserts the rendered `--help` command list (default and `--all`) matches catalog descriptions verbatim, every `COMMAND_HELP` command resolves a catalog description (no third copy), per-command help renders it, and `vote` reflects the real 7-agent default.

## Reconciled drift

Catalog `vote` description corrected to `Run consensus vote on a proposal (7 agents; --quick uses 3)` — now the single, **correct** source. The `vote --quick` flag help was also corrected from "instead of 6" to "instead of the full 7".

## Scope discipline (per #3212, 7-0)

**No** unified `CommandRegistry` / dispatch refactor, **no** new YAML/JSON registry, **no** catalog restructure. Dispatch, command names, and the command-parity gate are untouched. This only consolidates the one-line description into the existing catalog and makes the other surfaces derive from it.

## --help output: unchanged-or-corrected

Default `--help` is identical to before (it already derived from the catalog) except the corrected `vote` count. `--help --all` now uses the same catalog-grouped layout as the default (Essential / Advanced / Maintainer) instead of the stale flat hardcoded list, with every command preserved.

## Gates

- `tsc --noEmit` clean; `eslint` clean on changed files; zero `any`.
- Full cli suite green: `cli-command-catalog` (27), `cli-command-help` (17), `command-parity` (5), `cli-command-suggester` (22), `entrypoint-cli-extractor` (11), `entrypoint-extractor` (26).
- `scripts/generate-repo-index.ts --check` ✓ (catalog descriptions do not feed the repo-index; it carries name/type/handler/file only). `scripts/check-docops-skill.ts --verbose` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)