### PR TITLE
docs(task-analysis): cross-reference the 5 intentionally-separate task classifiers (#3299)

### DIFF
--- a/.changeset/classifier-cross-references-3299.md
+++ b/.changeset/classifier-cross-references-3299.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+docs(task-analysis): cross-reference the 5 intentionally-separate task classifiers (#3299)
+
+Add standardized module doc-comment cross-references to the 5 task
+classifiers (shared-task-analyzer, task-type-classifier,
+cli-adapters/task-classifier, coordination/task-features, and
+pipeline/adaptive-orchestrator's `classifyTask`). #3299 resolved to "by
+design, not duplication": the classifiers have incompatible output enums and
+drive distinct routing decisions, so their superficial keyword overlap does
+not warrant consolidation. The cross-references durably document this so
+future consolidation audits don't re-flag it. Doc-comments only — no logic,
+type, or behavior change.

--- a/packages/nexus-agents/src/agents/coordination/task-features.ts
+++ b/packages/nexus-agents/src/agents/coordination/task-features.ts
@@ -5,15 +5,16 @@
  * (how many agents to dispatch). Uses keyword matching, pattern detection,
  * and structural analysis against the `ScalingTaskType` taxonomy.
  *
- * This module is distinct from `SharedTaskAnalyzer`:
- * - `task-features` (here): features for scaling-predictor model input
- *   (sequential_reasoning / parallelizable / tool_heavy, etc.)
- * - `SharedTaskAnalyzer` (core): features for capability-based CLI routing
- *
- * Both coexist by design.
+ * Task classifier — one of 5 INTENTIONALLY SEPARATE classifiers (see #3299, by-design).
+ * This one: `ScalingTaskType` (8-value) → scaling-predictor / coordination-topology input
+ * (arXiv:2512.08296). Distinct from: shared-task-analyzer (9-category capability routing),
+ * task-type-classifier (reasoning|knowledge protocol selection), cli-adapters/task-classifier
+ * (CLI fallback-chain ordering), pipeline/adaptive-orchestrator (pipeline-stage selection).
+ * Keyword overlap is superficial — the same token routes differently per layer and the
+ * output enums are incompatible, so these are NOT consolidated. See #3299.
  *
  * @module agents/coordination/task-features
- * (Source: Issue #337, arXiv:2512.08296; Issue #1985 audit)
+ * (Source: Issue #337, arXiv:2512.08296; Issue #1985 audit; Issue #3299)
  */
 
 import type { Task } from '../../core/index.js';

--- a/packages/nexus-agents/src/cli-adapters/task-classifier.ts
+++ b/packages/nexus-agents/src/cli-adapters/task-classifier.ts
@@ -2,18 +2,19 @@
  * nexus-agents/cli-adapters - Task Classifier for Fallback Chains
  *
  * Classifies tasks into types for selecting appropriate CLI fallback chains.
- * Uses keyword-based classification with configurable patterns. The 5-value
- * `FallbackTaskType` taxonomy (code/research/documentation/analysis/general)
- * is tuned for CLI-selection decisions and is distinct from
- * `SharedTaskAnalyzer`'s 9-value `TaskTypeCategory`, which is tuned for
- * capability-based routing.
+ * Uses keyword-based classification with configurable patterns.
  *
- * Both modules coexist by design — they solve different problems:
- * - `task-classifier` (here): which CLI to try in what order, by task shape
- * - `SharedTaskAnalyzer` (core): which model capability to route to
+ * Task classifier — one of 5 INTENTIONALLY SEPARATE classifiers (see #3299, by-design).
+ * This one: `FallbackTaskType` (5-value: code/research/documentation/analysis/general) →
+ * CLI fallback-chain ordering (deliberately coarse and independent of the heavy analyzer).
+ * Distinct from: shared-task-analyzer (9-category capability routing), task-type-classifier
+ * (reasoning|knowledge protocol selection), coordination/task-features (scaling topology),
+ * pipeline/adaptive-orchestrator (pipeline-stage selection). Keyword overlap is superficial
+ * — the same token routes differently per layer and the output enums are incompatible, so
+ * these are NOT consolidated. See #3299.
  *
  * @module cli-adapters/task-classifier
- * (Source: Issue #362 - Task-type-aware fallback chains; Issue #1985 audit)
+ * (Source: Issue #362 - Task-type-aware fallback chains; Issue #1985 audit; Issue #3299)
  */
 
 import { z } from 'zod';

--- a/packages/nexus-agents/src/core/task-analysis/shared-task-analyzer.ts
+++ b/packages/nexus-agents/src/core/task-analysis/shared-task-analyzer.ts
@@ -1,8 +1,17 @@
 /**
  * Unified task analysis — classification views for routing.
  * Consolidates 5 independent analyzers per ADR-0004.
+ *
+ * Task classifier — one of 5 INTENTIONALLY SEPARATE classifiers (see #3299, by-design).
+ * This one: `TaskTypeCategory` (9-category) → capability-based routing / expert selection.
+ * Distinct from: task-type-classifier (reasoning|knowledge protocol selection),
+ * cli-adapters/task-classifier (CLI fallback-chain ordering), coordination/task-features
+ * (scaling topology), pipeline/adaptive-orchestrator (pipeline-stage selection). Keyword
+ * overlap is superficial — the same token routes differently per layer and the output enums
+ * are incompatible, so these are NOT consolidated. See #3299.
+ *
  * @module core/task-analysis/shared-task-analyzer
- * (Source: Issue #574, ADR-0004)
+ * (Source: Issue #574, ADR-0004; Issue #3299)
  */
 
 import { createLogger, type ILogger } from '../logger.js';

--- a/packages/nexus-agents/src/core/task-analysis/task-type-classifier.ts
+++ b/packages/nexus-agents/src/core/task-analysis/task-type-classifier.ts
@@ -10,8 +10,16 @@
  *
  * Moved to core/ to allow use by adapters layer without layer violation.
  *
+ * Task classifier — one of 5 INTENTIONALLY SEPARATE classifiers (see #3299, by-design).
+ * This one: `reasoning|knowledge|unknown` (binary) → protocol selection (voting vs
+ * consensus, arXiv:2502.19130). Distinct from: shared-task-analyzer (capability routing),
+ * cli-adapters/task-classifier (CLI fallback-chain ordering), coordination/task-features
+ * (scaling topology), pipeline/adaptive-orchestrator (pipeline-stage selection). Keyword
+ * overlap is superficial — the same token routes differently per layer and the output enums
+ * are incompatible, so these are NOT consolidated. See #3299.
+ *
  * @module core/task-analysis/task-type-classifier
- * (Source: Issue #125, arXiv:2502.19130)
+ * (Source: Issue #125, arXiv:2502.19130; Issue #3299)
  */
 
 import type { Task } from '../types/agent.js';

--- a/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
+++ b/packages/nexus-agents/src/pipeline/adaptive-orchestrator.ts
@@ -8,7 +8,16 @@
  * Design pattern: deterministic state machine backbone + selective
  * LLM invocation at decision nodes only (per CrewAI Flows / Temporal).
  *
+ * `classifyTask` is a task classifier — one of 5 INTENTIONALLY SEPARATE classifiers
+ * (see #3299, by-design). This one: `PipelineType` (5-value: dev/research/audit/greenfield/
+ * general) → pipeline-stage selection. Distinct from: shared-task-analyzer (9-category
+ * capability routing), task-type-classifier (reasoning|knowledge protocol selection),
+ * cli-adapters/task-classifier (CLI fallback-chain ordering), coordination/task-features
+ * (scaling topology). Keyword overlap is superficial — the same token routes differently per
+ * layer and the output enums are incompatible, so these are NOT consolidated. See #3299.
+ *
  * @module pipeline/adaptive-orchestrator
+ * (Source: Issue #1736; Issue #3299)
  */
 
 import { createLogger } from '../core/index.js';


### PR DESCRIPTION
## Summary

#3299 investigated whether the codebase's five task classifiers were duplicative. A read-only evidence pass confirmed they are **orthogonal by design, not duplication**: each emits an incompatible output enum and drives a distinct routing decision. The superficial keyword overlap (some classifiers match the same tokens) routes differently per layer.

This PR adds standardized module doc-comment cross-references to all five so the intentional separation is **durably documented** and future consolidation audits don't re-flag the overlap. Where a file already carried an ad-hoc distinctness note, the #3299 reference and cross-links were folded into it rather than adding a second block.

The five classifiers and their distinct roles:

| File | Output enum | Routing decision |
| --- | --- | --- |
| `core/task-analysis/shared-task-analyzer.ts` | `TaskTypeCategory` (9-cat) | capability-based routing / expert selection |
| `core/task-analysis/task-type-classifier.ts` | `reasoning\|knowledge\|unknown` | protocol selection (voting vs consensus, arXiv:2502.19130) |
| `cli-adapters/task-classifier.ts` | `FallbackTaskType` (5-val) | CLI fallback-chain ordering |
| `agents/coordination/task-features.ts` | `ScalingTaskType` (8-val) | scaling-predictor / coordination-topology (arXiv:2512.08296) |
| `pipeline/adaptive-orchestrator.ts` (`classifyTask`) | `PipelineType` (5-val) | pipeline-stage selection |

## Scope

**Doc-comments only — zero logic, type, or behavior change.** `git diff` is 100% comment lines (verified: no added/removed line is non-comment). Not a DocOps pipeline file; no CLI/MCP/workflow surface change, so the repo-index is unaffected.

## Gates

- `tsc --noEmit`: clean
- `eslint` on the 5 changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)