### PR TITLE
refactor(tool-fitness): declarative break-glass + orthogonality metadata, replacing name-string heuristics (#3930)

### DIFF
--- a/.changeset/declarative-tool-fitness-metadata-3930.md
+++ b/.changeset/declarative-tool-fitness-metadata-3930.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+refactor(tool-fitness): declarative break-glass + orthogonality metadata, replacing name-string heuristics (#3930)
+
+Replace the two NAME-STRING heuristics in the tool-fitness consumer with
+DECLARATIVE TOOL METADATA, ratified per #3929.
+
+- **Break-glass exemption** no longer relies on substring-matching
+  `DEFAULT_NEVER_DEPRECATE_PATTERNS` (rollback/recover/emergency/…) against a
+  tool NAME. Tools now DECLARE `neverDeprecate: true` in `TOOL_MANIFEST` based on
+  PURPOSE; the consumer consults the declaration first and keeps the name
+  patterns only as a documented fallback for undeclared tools.
+- **Consolidation orthogonality** no longer infers substitutability from a
+  tool-name verb-suffix proxy. Tools now DECLARE an `orthogonalityGroup`; two
+  prefix-siblings with different declared groups are authoritatively orthogonal.
+  The verb-group proxy remains as the fallback for undeclared tools (the old
+  `TODO(#3902)` is superseded). Conservative fail-safe preserved: undeclared
+  still surfaces-as-LOW, never a false-high.
+
+Metadata lives on the canonical `TOOL_MANIFEST` entries (new optional
+`ToolFitnessMetadata` fields) with derived accessors; all fields are
+optional/additive so the MCP tool-count + parity guards are unaffected
+(46 tools, unchanged).

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness-heuristics.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness-heuristics.ts
@@ -9,12 +9,16 @@
  *    proof of substitutability (`git_commit` vs `git_init`, `db_read` vs
  *    `db_drop_table` share a prefix but are orthogonal). {@link consolidationConfidence}
  *    downgrades prefix-only matches to a WEAK/low-confidence hint and withholds
- *    the candidate entirely when the action-verb suffixes are clearly orthogonal,
- *    so a rare sibling is not flagged for folding into a busy one on prefix alone.
- *    (Full capability-overlap modelling is a later seam — see TODO below.)
+ *    the candidate entirely when the tools are orthogonal. As of #3930, a tool's
+ *    DECLARED {@link ToolManifestEntry.orthogonalityGroup} is authoritative (two
+ *    different declared groups → orthogonal); the action-verb suffix proxy is the
+ *    fallback for tools that have not declared a group.
  * 2. **Break-glass exemption** — {@link isNeverDeprecate} exempts low-usage-BY-DESIGN
- *    tools (rollback / recovery / emergency admin) from the `<= 2 invocations`
+ *    tools (break-glass / safety / integrity) from the `<= 2 invocations`
  *    deprecation flag so a rare-but-critical tool isn't surfaced as dead weight.
+ *    As of #3930, a tool's DECLARED {@link ToolManifestEntry.neverDeprecate} flag
+ *    is authoritative; the name-substring patterns are the fallback for undeclared
+ *    tools.
  * 3. **Workspace-scoped localized signal** — instead of FULLY suppressing a
  *    cross-workspace-healthy tool's failure, {@link buildLocalizedSignals} emits a
  *    workspace-scoped "failing here" signal (global deprecation suppressed; the
@@ -30,6 +34,10 @@
 
 import type { ImprovementSignal } from './improvement-review.js';
 import type { ToolFitnessStat } from '../../governance/tool-fitness-ledger.js';
+import {
+  declaredOrthogonalityGroup,
+  isDeclaredNeverDeprecate,
+} from './tool-manifest.js';
 
 // ============================================================================
 // Honest thresholds (documented per acceptance criteria)
@@ -105,12 +113,19 @@ export function assertNeverAutonomousRemoval(signal: ImprovementSignal): Improve
 // ============================================================================
 
 /**
- * Default action-verb fragments that mark a tool as low-usage-BY-DESIGN
- * (break-glass / recovery / emergency admin). A tool whose name contains one of
- * these is rare ON PURPOSE — flagging it for deprecation on a `<= 2 invocations`
- * count is a false positive. Matched case-insensitively as a substring of the
- * tool name. Override via {@link NeverDeprecateConfig.extraPatterns} /
+ * FALLBACK action-verb fragments for tools that have NOT declared
+ * `neverDeprecate` in the manifest (#3930). The authoritative signal is the
+ * declarative {@link ToolManifestEntry.neverDeprecate} flag, consulted first by
+ * {@link isNeverDeprecate}; these substrings remain ONLY as a conservative
+ * fail-safe so an UNDECLARED tool whose name screams break-glass
+ * (rollback / recovery / emergency admin) is still protected from a
+ * `<= 2 invocations` false positive. Matched case-insensitively as a substring
+ * of the tool name. Override via {@link NeverDeprecateConfig.extraPatterns} /
  * {@link NeverDeprecateConfig.exemptTools} for repo-specific break-glass tools.
+ *
+ * Precedence (#3930): declared manifest flag > injected config > these name
+ * patterns. Prefer DECLARING `neverDeprecate: true` on the manifest entry over
+ * relying on a name match.
  */
 export const DEFAULT_NEVER_DEPRECATE_PATTERNS: readonly string[] = [
   'rollback',
@@ -137,9 +152,22 @@ export interface NeverDeprecateConfig {
 /**
  * True when `tool` is tagged never-deprecate / break-glass and must therefore be
  * EXEMPT from the low-usage deprecation flag (item 2). Pure.
+ *
+ * Precedence (#3930, declarative-first):
+ *  1. **Declared manifest flag** — a tool that DECLARES `neverDeprecate: true`
+ *     in `TOOL_MANIFEST` is authoritatively protected, regardless of its name.
+ *  2. **Injected config** — an explicit `exemptTools` entry protects the tool.
+ *  3. **Name-substring fallback** — for UNDECLARED tools only, the documented
+ *     {@link DEFAULT_NEVER_DEPRECATE_PATTERNS} (+ any `extraPatterns`) still
+ *     guard a name that screams break-glass. This is the conservative fail-safe:
+ *     when uncertain, protect (never auto-deprecate).
  */
 export function isNeverDeprecate(tool: string, config?: NeverDeprecateConfig): boolean {
+  // 1. Declarative metadata is authoritative (#3930).
+  if (isDeclaredNeverDeprecate(tool)) return true;
+  // 2. Caller-injected exemptions.
   if (config?.exemptTools?.includes(tool) === true) return true;
+  // 3. Name-substring fallback for tools that have NOT declared.
   const lower = tool.toLowerCase();
   const patterns = [...DEFAULT_NEVER_DEPRECATE_PATTERNS, ...(config?.extraPatterns ?? [])];
   return patterns.some((p) => lower.includes(p));
@@ -152,13 +180,16 @@ export function isNeverDeprecate(tool: string, config?: NeverDeprecateConfig): b
 /**
  * Action verbs that mutate/destroy vs. read/create — when two prefix-siblings
  * carry verbs from clearly opposed groups they are ORTHOGONAL (not
- * substitutable), so the prefix match is suppressed entirely. This is the
- * honest, ledger-name-only overlap proxy; a real capability/schema-overlap model
- * is the later seam.
+ * substitutable), so the prefix match is suppressed entirely.
  *
- * TODO(#3902): replace this name-suffix heuristic with a true capability-overlap
- * signal (tool input/output schema similarity) once the tool-distinctness data
- * seam lands. Until then prefix-family is a WEAK hint only.
+ * FALLBACK ONLY (#3930): this name-suffix proxy now applies only when at least
+ * one of the two tools has NOT declared an
+ * {@link ToolManifestEntry.orthogonalityGroup}. A tool's declared group is the
+ * authoritative orthogonality signal (consulted first by
+ * {@link consolidationConfidence}); this verb-group table is the documented
+ * fallback for undeclared tools. Supersedes the former `TODO(#3902)` (declarative
+ * capability tags now stand in for the "true capability-overlap" seam, while
+ * staying conservative — undeclared still surfaces-as-LOW, never high).
  */
 const ORTHOGONAL_VERB_GROUPS: readonly (readonly string[])[] = [
   ['init', 'create', 'add', 'new', 'open', 'start', 'enable', 'register'],
@@ -185,20 +216,35 @@ function verbGroup(verb: string | undefined): number {
 
 /**
  * Confidence that a prefix-sharing pair (`candidate`, `busiest`) is genuinely a
- * consolidation candidate, using a name-suffix overlap proxy (item 1):
+ * consolidation candidate.
  *
- * - `'none'` — the two verbs sit in clearly OPPOSED action groups
- *   (e.g. `init` vs `drop`, `commit` vs `init`) → orthogonal, do NOT surface.
- * - `'low'` — prefix matches but overlap is unproven → surface as a
- *   LOW-CONFIDENCE hint (the prefix family alone is weak evidence).
+ * Precedence (#3930, declarative-first):
+ *  1. **Declared orthogonality groups** — when BOTH tools declare an
+ *     {@link ToolManifestEntry.orthogonalityGroup} and the groups DIFFER, they
+ *     are authoritatively orthogonal (distinct capability domains, e.g. memory
+ *     read vs write) → `'none'`, do NOT surface. Same declared group → they are
+ *     genuinely in the same domain, so fall through to the usage-ratio caller as
+ *     a `'low'` hint.
+ *  2. **Action-verb fallback** — when at least one tool has NOT declared a group,
+ *     use the {@link ORTHOGONAL_VERB_GROUPS} name-suffix proxy: clearly OPPOSED
+ *     verbs (e.g. `init` vs `drop`) → `'none'`; otherwise `'low'`.
  *
- * Pure. There is no `'high'` tier yet: until a real capability-overlap model
- * exists, prefix-family is never strong evidence. (See module TODO.)
+ * Conservative by construction: there is NO `'high'` tier from this signal — an
+ * undeclared / unproven pair surfaces as a LOW-CONFIDENCE hint, never hidden via
+ * a false-high. Pure.
  */
 export function consolidationConfidence(
   candidate: ToolFitnessStat,
   busiest: ToolFitnessStat
 ): ConsolidationConfidence {
+  // 1. Declarative metadata is authoritative (#3930): two DIFFERENT declared
+  //    groups → orthogonal. (Same group → not orthogonal; fall through to 'low'.)
+  const declaredA = declaredOrthogonalityGroup(candidate.tool);
+  const declaredB = declaredOrthogonalityGroup(busiest.tool);
+  if (declaredA !== undefined && declaredB !== undefined) {
+    return declaredA !== declaredB ? 'none' : 'low';
+  }
+  // 2. Fallback for UNDECLARED tools: action-verb proxy.
   const a = verbGroup(actionVerb(candidate.tool));
   const b = verbGroup(actionVerb(busiest.tool));
   // Both verbs classified and in different opposed groups → orthogonal siblings.

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-tool-fitness.test.ts
@@ -27,6 +27,12 @@ import {
   isNeverDeprecate,
   DEFAULT_NEVER_DEPRECATE_PATTERNS,
 } from './improvement-review-tool-fitness-heuristics.js';
+import {
+  NEVER_DEPRECATE_TOOLS,
+  TOOL_ORTHOGONALITY_GROUPS,
+  isDeclaredNeverDeprecate,
+  declaredOrthogonalityGroup,
+} from './tool-manifest.js';
 import { ToolFitnessLedger, type ToolFitnessStat } from '../../governance/tool-fitness-ledger.js';
 import type { ImprovementSignal } from './improvement-review.js';
 import { ImprovementReviewInputSchema } from './improvement-review.js';
@@ -467,5 +473,115 @@ describe("SignalCategory wiring — 'tool-fitness' is part of the union", () => 
       evidence: {},
     };
     expect(s.category).toBe('tool-fitness');
+  });
+});
+
+// ============================================================================
+// #3930 — declarative break-glass + orthogonality metadata supersedes the
+// two name-string heuristics (declarative-first, name-fallback-for-undeclared).
+// ============================================================================
+
+describe('declarative neverDeprecate metadata (#3930)', () => {
+  it('the manifest declares the audited break-glass/safety tools', () => {
+    // Purpose-based selection (NOT name-based): incident/integrity tools that are
+    // rare BY DESIGN. None of these names match DEFAULT_NEVER_DEPRECATE_PATTERNS.
+    expect(NEVER_DEPRECATE_TOOLS.has('verify_audit_chain')).toBe(true);
+    expect(NEVER_DEPRECATE_TOOLS.has('cancel_job')).toBe(true);
+    expect(NEVER_DEPRECATE_TOOLS.has('ci_health_check')).toBe(true);
+  });
+
+  it('a declared tool is protected REGARDLESS of name (no name pattern matches it)', () => {
+    // 'verify_audit_chain' matches none of DEFAULT_NEVER_DEPRECATE_PATTERNS, yet it
+    // is protected purely via the declaration — proving the heuristic is no longer
+    // name-driven for declared tools.
+    expect(DEFAULT_NEVER_DEPRECATE_PATTERNS.some((p) => 'verify_audit_chain'.includes(p))).toBe(
+      false
+    );
+    expect(isDeclaredNeverDeprecate('verify_audit_chain')).toBe(true);
+    expect(isNeverDeprecate('verify_audit_chain')).toBe(true);
+  });
+
+  it('declaration-protected tool is NOT flagged at <=2 invocations', () => {
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'cancel_job', invocationCount: 1, successCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW
+    );
+    expect(signals).toEqual([]);
+  });
+
+  it('a tool whose NAME matches a pattern but is UNDECLARED is still protected via the fallback', () => {
+    // 'db_rollback' is not in the manifest (undeclared) — the documented name
+    // fallback still protects it. Declarative-first, fallback-for-undeclared.
+    expect(isDeclaredNeverDeprecate('db_rollback')).toBe(false);
+    expect(isNeverDeprecate('db_rollback')).toBe(true);
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'db_rollback', invocationCount: 1, successCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW
+    );
+    expect(signals).toEqual([]);
+  });
+
+  it('an undeclared, ordinary-named low-usage tool is still flagged (exemption is targeted)', () => {
+    expect(isDeclaredNeverDeprecate('ordinary_thing')).toBe(false);
+    const signals = detectDeprecationCandidates(
+      [stat({ tool: 'ordinary_thing', invocationCount: 1, successCount: 1 })],
+      NO_WORKSPACE_SCOPE,
+      WINDOW
+    );
+    expect(signals).toHaveLength(1);
+  });
+});
+
+describe('declarative orthogonalityGroup metadata (#3930)', () => {
+  it('the manifest declares orthogonality groups for the deliberately-distinct pairs', () => {
+    expect(declaredOrthogonalityGroup('memory_query')).toBe('memory-read');
+    expect(declaredOrthogonalityGroup('memory_write')).toBe('memory-write');
+    expect(TOOL_ORTHOGONALITY_GROUPS.get('query_trace')).toBe('query-trace');
+    expect(TOOL_ORTHOGONALITY_GROUPS.get('query_task_state')).toBe('query-task-state');
+  });
+
+  it('two DIFFERENT declared groups are orthogonal → "none" (read vs write)', () => {
+    const read = stat({ tool: 'memory_query', invocationCount: 1 });
+    const write = stat({ tool: 'memory_write', invocationCount: 100 });
+    expect(consolidationConfidence(read, write)).toBe('none');
+  });
+
+  it('orthogonal declared siblings are NOT surfaced as consolidation candidates', () => {
+    const report = [
+      stat({ tool: 'memory_write', invocationCount: 100, successCount: 100 }),
+      stat({ tool: 'memory_query', invocationCount: 1, successCount: 1 }),
+    ];
+    expect(detectConsolidationCandidates(report, WINDOW)).toEqual([]);
+  });
+
+  it('SAME declared group falls through to "low" (not orthogonal)', () => {
+    const a = stat({ tool: 'memory_query', invocationCount: 1 });
+    const b = stat({ tool: 'memory_stats', invocationCount: 100 });
+    // Both declare 'memory-read' → same domain → not orthogonal → low hint.
+    expect(consolidationConfidence(a, b)).toBe('low');
+  });
+
+  it('UNDECLARED siblings fall back to the verb proxy and still surface-as-LOW (conservative)', () => {
+    // research_* tools declare no orthogonalityGroup → verb-suffix fallback path.
+    const a = stat({ tool: 'research_discover', invocationCount: 2 });
+    const b = stat({ tool: 'research_synthesize', invocationCount: 100 });
+    expect(declaredOrthogonalityGroup('research_discover')).toBeUndefined();
+    expect(consolidationConfidence(a, b)).toBe('low');
+  });
+
+  it('never emits a "high" tier from this signal (no false-high hiding)', () => {
+    // Spot-check several pairings: the only outcomes are 'none' | 'low'.
+    const pairs: Array<[string, string]> = [
+      ['memory_query', 'memory_write'],
+      ['memory_query', 'memory_stats'],
+      ['research_discover', 'research_synthesize'],
+      ['git_init', 'git_commit'],
+    ];
+    for (const [x, y] of pairs) {
+      const c = consolidationConfidence(stat({ tool: x }), stat({ tool: y }));
+      expect(['none', 'low']).toContain(c);
+    }
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
@@ -64,9 +64,45 @@ export interface ToolSideEffectsEntry {
 }
 
 /**
- * A single manifest entry: the tool name plus its annotation/side-effect data.
+ * Declarative tool-fitness metadata (#3930). OPTIONAL/additive fields that let a
+ * tool DECLARE fitness-relevant properties instead of having them inferred from
+ * its NAME. They replace two name-string heuristics in the tool-fitness consumer
+ * ({@link module:mcp/tools/improvement-review-tool-fitness-heuristics}):
+ *
+ * - `neverDeprecate` supersedes the `DEFAULT_NEVER_DEPRECATE_PATTERNS` substring
+ *   match (rollback/recover/emergency/…) against the tool name.
+ * - `orthogonalityGroup` supersedes the action-verb-suffix proxy that inferred
+ *   whether two prefix-siblings are substitutable.
+ *
+ * Both are OPTIONAL so the manifest count + parity guards are unaffected; a tool
+ * that declares neither falls back to the documented name heuristics. Set the
+ * flag based on a tool's PURPOSE, never its name.
  */
-export interface ToolManifestEntry extends ToolSideEffectsEntry {
+export interface ToolFitnessMetadata {
+  /**
+   * `true` declares this tool a break-glass / safety / integrity tool that is
+   * low-usage BY DESIGN and must NEVER be surfaced as an auto-deprecation
+   * candidate, regardless of its name. Authoritative over the name-substring
+   * fallback. (#3930, replacing the `DEFAULT_NEVER_DEPRECATE_PATTERNS` heuristic.)
+   */
+  readonly neverDeprecate?: boolean;
+  /**
+   * Capability/domain tag declaring this tool's consolidation-orthogonality.
+   * Two prefix-siblings with DIFFERENT declared groups are deliberately
+   * orthogonal (distinct capability domains, e.g. read vs mutate) and must NOT
+   * be flagged as consolidation candidates for folding into one another. Two
+   * tools in the SAME group, or any tool that has NOT declared a group, fall
+   * back to the action-verb proxy. (#3930, superseding the verb-suffix proxy of
+   * #3902 / the old `TODO(#3902)`.)
+   */
+  readonly orthogonalityGroup?: string;
+}
+
+/**
+ * A single manifest entry: the tool name plus its annotation/side-effect data
+ * and OPTIONAL declarative tool-fitness metadata (#3930).
+ */
+export interface ToolManifestEntry extends ToolSideEffectsEntry, ToolFitnessMetadata {
   readonly name: string;
 }
 
@@ -319,6 +355,9 @@ export const TOOL_MANIFEST = [
       { category: 'implicit', description: 'Consumes rate limit quota' },
       { category: 'implicit', description: 'May trigger reflective retrieval (MemR3)' },
     ],
+    // #3930: memory READ surface. Deliberately orthogonal to memory_write (mutate);
+    // a rarely-used read must never be flagged for folding into the writer.
+    orthogonalityGroup: 'memory-read',
   },
   {
     name: 'memory_stats',
@@ -330,6 +369,9 @@ export const TOOL_MANIFEST = [
       openWorldHint: false,
     },
     sideEffects: [{ category: 'implicit', description: 'Consumes rate limit quota' }],
+    // #3930: memory READ/introspection surface — same orthogonality domain as
+    // memory_query, distinct from the memory_write mutate surface.
+    orthogonalityGroup: 'memory-read',
   },
   {
     name: 'memory_write',
@@ -344,6 +386,9 @@ export const TOOL_MANIFEST = [
       { category: 'explicit', description: 'Writes data to memory backend' },
       { category: 'implicit', description: 'Consumes rate limit quota' },
     ],
+    // #3930: memory MUTATE surface. Orthogonal to the memory-read tools — a
+    // distinct capability domain, never a consolidation target for the readers.
+    orthogonalityGroup: 'memory-write',
   },
   {
     name: 'weather_report',
@@ -423,6 +468,10 @@ export const TOOL_MANIFEST = [
     sideEffects: [
       { category: 'implicit', description: 'Reads execution trace JSONL files from disk' },
     ],
+    // #3930: reads execution-trace JSONL. Deliberately distinct data domain from
+    // query_task_state (structured task-state log) despite the shared `query_`
+    // prefix — not interchangeable, so not a consolidation pair.
+    orthogonalityGroup: 'query-trace',
   },
   {
     name: 'query_task_state',
@@ -436,6 +485,9 @@ export const TOOL_MANIFEST = [
     sideEffects: [
       { category: 'implicit', description: 'Reads the structured task-state log (#2278)' },
     ],
+    // #3930: reads the structured task-state log — a distinct data domain from
+    // query_trace's execution traces. Shared prefix, orthogonal capability.
+    orthogonalityGroup: 'query-task-state',
   },
   {
     name: 'get_job_result',
@@ -490,6 +542,9 @@ export const TOOL_MANIFEST = [
           'Triggers AbortSignal unwind in same-process dispatcher (cross-process workers must poll)',
       },
     ],
+    // #3930: break-glass kill-switch — you only call it to abort a runaway async
+    // job, so it is low-usage BY DESIGN, not dead weight. Never auto-deprecate.
+    neverDeprecate: true,
   },
   {
     name: 'ci_health_check',
@@ -511,6 +566,10 @@ export const TOOL_MANIFEST = [
         description: 'Appends a local CI-health telemetry event per call for observability (#3530)',
       },
     ],
+    // #3930: incident diagnostic — used BEFORE long auto-merge waits to detect an
+    // org-wide CI wedge. Rare by design (only when CI is suspected broken), so a
+    // low invocation count is expected, not a deprecation signal.
+    neverDeprecate: true,
   },
   {
     name: 'verify_audit_chain',
@@ -527,6 +586,10 @@ export const TOOL_MANIFEST = [
         description: 'Reads the immutable audit log and verifies the hash chain',
       },
     ],
+    // #3930: tamper-evidence integrity tool — invoked rarely (on-demand chain
+    // verification), but it is the substrate's audit-integrity guarantee. Low
+    // usage is by design; deprecating it would silently drop tamper detection.
+    neverDeprecate: true,
   },
   {
     name: 'repo_analyze',
@@ -544,6 +607,10 @@ export const TOOL_MANIFEST = [
       },
       { category: 'implicit', description: 'Consumes rate limit quota' },
     ],
+    // #3930: general repo-structure analysis. Distinct capability domain from
+    // repo_security_plan (security-scanning recommendation) — shared `repo_`
+    // prefix but not substitutable.
+    orthogonalityGroup: 'repo-analyze',
   },
   {
     name: 'repo_security_plan',
@@ -561,6 +628,10 @@ export const TOOL_MANIFEST = [
       },
       { category: 'implicit', description: 'Consumes rate limit quota' },
     ],
+    // #3930: security-scanning pipeline recommendation. Orthogonal domain to
+    // repo_analyze (general structure) — a security-specific capability that
+    // must not be folded into the general analyzer.
+    orthogonalityGroup: 'repo-security',
   },
   {
     name: 'extract_symbols',
@@ -753,3 +824,52 @@ export const TOOL_MANIFEST = [
 
 /** A registered MCP tool name, derived from {@link TOOL_MANIFEST}. */
 export type RegisteredToolName = (typeof TOOL_MANIFEST)[number]['name'];
+
+// ============================================================================
+// Declarative tool-fitness metadata accessors (#3930)
+// ============================================================================
+
+/**
+ * Set of tool names that DECLARE `neverDeprecate: true` — break-glass / safety /
+ * integrity tools that are low-usage BY DESIGN. Derived from {@link TOOL_MANIFEST}
+ * so the manifest stays the single source of truth (#3930). Consumed by the
+ * tool-fitness heuristics, which treat a declared name as authoritative over the
+ * name-substring fallback.
+ */
+export const NEVER_DEPRECATE_TOOLS: ReadonlySet<string> = new Set(
+  (TOOL_MANIFEST as readonly ToolManifestEntry[])
+    .filter((t) => t.neverDeprecate === true)
+    .map((t) => t.name)
+);
+
+/**
+ * Map of tool name → declared `orthogonalityGroup` for tools that DECLARE one.
+ * Derived from {@link TOOL_MANIFEST} (#3930). Consumed by the consolidation
+ * heuristic: two prefix-siblings with DIFFERENT declared groups are orthogonal
+ * (not a consolidation pair); a tool absent from this map falls back to the
+ * action-verb proxy.
+ */
+export const TOOL_ORTHOGONALITY_GROUPS: ReadonlyMap<string, string> = new Map(
+  (TOOL_MANIFEST as readonly ToolManifestEntry[])
+    .filter(
+      (t): t is ToolManifestEntry & { orthogonalityGroup: string } =>
+        t.orthogonalityGroup !== undefined
+    )
+    .map((t) => [t.name, t.orthogonalityGroup])
+);
+
+/**
+ * True when `tool` DECLARES `neverDeprecate: true` in {@link TOOL_MANIFEST}.
+ * Authoritative break-glass signal (#3930); name-independent.
+ */
+export function isDeclaredNeverDeprecate(tool: string): boolean {
+  return NEVER_DEPRECATE_TOOLS.has(tool);
+}
+
+/**
+ * The declared {@link ToolFitnessMetadata.orthogonalityGroup} for `tool`, or
+ * `undefined` when the tool has not declared one (#3930).
+ */
+export function declaredOrthogonalityGroup(tool: string): string | undefined {
+  return TOOL_ORTHOGONALITY_GROUPS.get(tool);
+}


### PR DESCRIPTION
## What

Replace the two NAME-STRING heuristics in the tool-fitness consumer with **declarative tool metadata** on the canonical `TOOL_MANIFEST`. Direction approved by the #3929 ratification.

### Heuristics replaced
1. **Break-glass exemption** — `isNeverDeprecate(tool)` previously substring-matched `DEFAULT_NEVER_DEPRECATE_PATTERNS` (rollback/recover/emergency/…) against the tool NAME.
2. **Consolidation orthogonality** — `consolidationConfidence` previously inferred orthogonality from a tool-name verb-suffix proxy (the explicit `TODO(#3902)`).

## Where the declarative metadata lives

On the canonical `packages/nexus-agents/src/mcp/tools/tool-manifest.ts` — the single source of truth. New optional `ToolFitnessMetadata` interface (`neverDeprecate?: boolean`, `orthogonalityGroup?: string`) mixed into `ToolManifestEntry`, plus derived accessors `NEVER_DEPRECATE_TOOLS` / `TOOL_ORTHOGONALITY_GROUPS` / `isDeclaredNeverDeprecate()` / `declaredOrthogonalityGroup()`. The heuristics module (`improvement-review-tool-fitness-heuristics.ts`) imports these (one-way edge — the manifest is a pure-data leaf, no cycle).

Fields are placed **after** each entry's `sideEffects` block so the `inject-governance` `name → annotations` regex and the AST parser are both unaffected.

## Tools flagged + WHY (purpose-based, not name-based)

Audit finding: **none** of the 46 tool names match the old break-glass substring patterns — the patterns protected zero real tools. The declarations are chosen by PURPOSE:

**`neverDeprecate: true`** (low-usage BY DESIGN — rare-but-critical):
- `cancel_job` — break-glass kill-switch to abort a runaway async job.
- `ci_health_check` — incident diagnostic ("use BEFORE long auto-merge waits to skip the wedge cycle when CI is broken org-wide"); rare by design.
- `verify_audit_chain` — tamper-evidence integrity verification; deprecating it would silently drop tamper detection.

**`orthogonalityGroup`** (deliberately distinct capability domains within a shared prefix family — must NOT be consolidation-merged):
- `memory_query` / `memory_stats` → `memory-read` vs `memory_write` → `memory-write` (read vs mutate).
- `query_trace` → `query-trace` vs `query_task_state` → `query-task-state` (distinct data sources: execution traces vs structured task-state log).
- `repo_analyze` → `repo-analyze` vs `repo_security_plan` → `repo-security` (general analysis vs security planning).

## Precedence (declarative-first, fallback-for-undeclared)

- **neverDeprecate:** declared manifest flag → injected `exemptTools` config → name-substring fallback (undeclared tools only).
- **orthogonality:** both tools declare a group → different groups ⇒ orthogonal (`none`), same group ⇒ `low`; otherwise (≥1 undeclared) → action-verb proxy fallback.

## Conservative fail-safe preserved

When uncertain, protect: an undeclared name that screams break-glass is still exempt via the fallback. Consolidation never emits a `high` tier from this signal — undeclared/unproven pairs surface-as-LOW, never hidden. No other fitness logic (sample sizes, success-rate thresholds, low-usage/poor-reliability/localized signals) touched.

## Guards / tests

- `pnpm governance:check` → **MCP Tools: 46** (count guard intact, parity green).
- `tsc --noEmit` clean; eslint clean on all 3 changed files (zero `any`).
- `improvement-review-tool-fitness.test.ts` (43) + `tool-manifest.test.ts` (5) + `index.test.ts` (68) + annotations/registry-consistency + script-side parse-tool-manifest/tool-distinctness/tool-reference/description-drift — all green.
- `docs:tools:check` ✓ (47 files) and `generate-repo-index.ts --check` ✓ — declarative fitness metadata is internal, not surfaced in the tool reference or repo-index, so no generated artifact needed regen.

New tests assert: a declared tool is protected regardless of name; an undeclared name-matching tool is still protected via the fallback; declared orthogonal groups suppress consolidation; same-group / undeclared still surface-as-low.

## Judgment calls

- `repo_security_plan`/`get_job_result`/`list_jobs` were considered for `neverDeprecate` and deliberately NOT flagged — they are normal-cadence advisory/read tools, not break-glass.
- Used changeset type `minor` (added new exported manifest type surface + accessors), not `patch`.

Closes #3930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)