### PR TITLE
feat(observability): deterministic perf-regression improvement signal — benchmark regression vs static baseline, surfaced-not-auto-acted (#3692, #3246)

### DIFF
--- a/.changeset/perf-regression-signal-3692.md
+++ b/.changeset/perf-regression-signal-3692.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(observability): deterministic perf-regression improvement signal (#3692, #3246)
+
+Extend the existing `improvement_review` `SignalCategory` enum with a new
+`perf-regression` value (no new parallel feedback pathway). A new deterministic
+detector maps a benchmark measurement (p95 latency / throughput) against a
+STATIC, pinned baseline + a fixed tolerance (default 0.2 = 20% worse than
+baseline) to an optional `perf-regression` `ImprovementSignal`. The baseline is
+configured/injected, never auto-derived from a rolling window — keeping this out
+of the deferred #3230 adaptive-control scope. A missing baseline emits nothing
+(conservative). The signal is SURFACED-ONLY: it is appended to the review's
+signal list exactly like the existing tech-debt / tool-fitness signals and never
+auto-applies a fitness/governance penalty or mutates any score/state.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.test.ts
@@ -17,6 +17,7 @@ import {
   renderPlanAsResearch,
   type RemediationPlan,
 } from './improvement-remediation-capability.js';
+import type { SignalCategory } from './improvement-review.js';
 
 describe('PHASE_CAPABILITIES invariant', () => {
   it('no phase declares all three Rule-of-Two legs', () => {
@@ -114,6 +115,23 @@ describe('RemediationPlanSchema (strict boundary artifact)', () => {
   it('rejects unknown keys inside a step', () => {
     const bad = { ...valid, steps: [{ kind: 'fix-bug', description: 'x', patch: 'diff…' }] };
     expect(() => parseRemediationPlan(bad)).toThrow(RuleOfTwoViolation);
+  });
+
+  it('accepts every SignalCategory value, including perf-regression (#3692)', () => {
+    // The schema enum mirrors the SignalCategory union; a new category must be
+    // accepted here or a perf-regression remediation plan could never cross.
+    const categories: SignalCategory[] = [
+      'routing',
+      'tech-debt',
+      'bug',
+      'security',
+      'consensus',
+      'tool-fitness',
+      'perf-regression',
+    ];
+    for (const category of categories) {
+      expect(RemediationPlanSchema.safeParse({ ...valid, category }).success).toBe(true);
+    }
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-capability.ts
@@ -146,8 +146,16 @@ export const RemediationPlanSchema = z
   .object({
     /** Source signal key (mirrors ImprovementSignal.signalKey). */
     signalKey: z.string().min(1).max(200),
-    /** Signal category (mirrors SignalCategory; 'tool-fitness' added #3852). */
-    category: z.enum(['routing', 'tech-debt', 'bug', 'security', 'consensus', 'tool-fitness']),
+    /** Signal category (mirrors SignalCategory; 'tool-fitness' #3852, 'perf-regression' #3692). */
+    category: z.enum([
+      'routing',
+      'tech-debt',
+      'bug',
+      'security',
+      'consensus',
+      'tool-fitness',
+      'perf-regression',
+    ]),
     summary: z.string().min(1).max(1000),
     steps: z.array(RemediationStepSchema).min(1).max(20),
   })

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation.test.ts
@@ -39,6 +39,8 @@ describe('improvementSignalToTask', () => {
       ['tech-debt', 'coder'],
       ['routing', 'researcher'],
       ['consensus', 'researcher'],
+      ['tool-fitness', 'researcher'],
+      ['perf-regression', 'coder'],
     ];
     for (const [category, role] of cases) {
       expect(improvementSignalToTask(signal({ category })).assignedTo).toBe(role);

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation.ts
@@ -33,6 +33,10 @@ const ROLE_BY_CATEGORY: Readonly<Record<SignalCategory, PipelineRole>> = {
   // a researcher owns the investigation seed (suggest-tier; the dev-pipeline
   // re-plans anyway). NEVER an autonomous removal.
   'tool-fitness': 'researcher',
+  // #3692/#3246: a perf regression vs a static baseline is a performance
+  // investigation seed — a coder owns the diagnosis. Surfaced-only; the
+  // dev-pipeline re-plans, nothing is auto-applied.
+  'perf-regression': 'coder',
 };
 
 /** Stable, dedup-friendly task id for a signal (mirrors the signalKey). */

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-perf-regression.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-perf-regression.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for the deterministic perf-regression detector (#3692 + #3246).
+ *
+ * Pure-function tests: a benchmark measurement vs a STATIC baseline + fixed
+ * tolerance. Plus a wiring test that the signal is SURFACED-ONLY through
+ * `runImprovementReview` and mutates no fitness/governance score.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectPerfRegressionSignals,
+  baselineKey,
+  DEFAULT_REGRESSION_TOLERANCE_FRACTION,
+  type PerfBaseline,
+  type PerfBaselineMap,
+} from './improvement-review-perf-regression.js';
+import { runImprovementReview, ImprovementReviewInputSchema } from './improvement-review.js';
+import type {
+  BenchmarkSuiteResult,
+  OperationBenchmark,
+  LatencyMetrics,
+  ThroughputMetrics,
+} from '../../benchmarks/benchmark-types.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function latency(p95: number): LatencyMetrics {
+  return {
+    min: 0,
+    max: p95,
+    mean: p95,
+    p50: p95,
+    p75: p95,
+    p90: p95,
+    p95,
+    p99: p95,
+    stdDev: 0,
+    sampleCount: 100,
+  };
+}
+
+function throughput(opsPerSecond: number): ThroughputMetrics {
+  return { opsPerSecond, totalOps: 1000, durationMs: 1000 };
+}
+
+function operation(name: string, p95Ms: number, opsPerSecond: number): OperationBenchmark {
+  return {
+    operation: name,
+    datasetSize: 1000,
+    latency: latency(p95Ms),
+    throughput: throughput(opsPerSecond),
+    resources: { peakMemoryBytes: 0, avgMemoryBytes: 0, cpuTimeMs: 0 },
+    timestamp: '2026-06-19T00:00:00.000Z',
+  };
+}
+
+function suite(component: string, ops: readonly OperationBenchmark[]): BenchmarkSuiteResult {
+  return {
+    name: `${component}-suite`,
+    component,
+    version: '1.0.0',
+    operations: ops,
+    environment: {
+      nodeVersion: 'v22.0.0',
+      platform: 'linux',
+      arch: 'x64',
+      cpuModel: 'test',
+      cpuCores: 8,
+      totalMemory: 0,
+    },
+    summary: {
+      totalDurationMs: 0,
+      totalOperations: ops.length,
+      overallThroughput: 0,
+      avgP95Latency: 0,
+      passed: true,
+      failures: [],
+    },
+  };
+}
+
+function baselines(entries: Record<string, PerfBaseline>): PerfBaselineMap {
+  return new Map(Object.entries(entries));
+}
+
+// ============================================================================
+// (a) measurement above baseline*tolerance → exactly one signal, correct payload
+// ============================================================================
+
+describe('detectPerfRegressionSignals — latency regression', () => {
+  it('emits exactly one perf-regression signal when p95 exceeds baseline*(1+tolerance)', () => {
+    // baseline 100ms, tolerance 20% → threshold 120ms; measured 150ms regresses.
+    const result = suite('memory-store', [operation('search', 150, 500)]);
+    const signals = detectPerfRegressionSignals(result, baselines({ 'memory-store::search': { baselineP95Ms: 100 } }));
+
+    expect(signals).toHaveLength(1);
+    const sig = signals[0];
+    expect(sig).toBeDefined();
+    if (sig === undefined) return;
+    expect(sig.category).toBe('perf-regression');
+    expect(sig.signalKey).toBe('perf-regression:latency:memory-store:search');
+    expect(sig.severity).toBe('warning');
+    expect(sig.title).toContain('150ms');
+    expect(sig.title).toContain('100ms');
+    expect(sig.evidence.observedValue).toBe(150);
+    expect(sig.evidence.threshold).toBe(120);
+    expect(sig.body).toContain('static/configured');
+    expect(sig.body).toContain('No fitness/governance score is mutated');
+  });
+
+  it('emits a throughput-regression signal when throughput drops below baseline*(1-tolerance)', () => {
+    // baseline 1000 ops/s, tolerance 20% → threshold 800 ops/s; measured 700 regresses.
+    const result = suite('router', [operation('route', 10, 700)]);
+    const signals = detectPerfRegressionSignals(result, baselines({ 'router::route': { baselineThroughput: 1000 } }));
+
+    expect(signals).toHaveLength(1);
+    const sig = signals[0];
+    if (sig === undefined) throw new Error('expected a signal');
+    expect(sig.signalKey).toBe('perf-regression:throughput:router:route');
+    expect(sig.evidence.observedValue).toBe(700);
+    expect(sig.evidence.threshold).toBe(800);
+  });
+
+  it('can emit BOTH a latency and a throughput signal for one operation', () => {
+    const result = suite('store', [operation('write', 200, 600)]);
+    const signals = detectPerfRegressionSignals(
+      result,
+      baselines({ 'store::write': { baselineP95Ms: 100, baselineThroughput: 1000 } })
+    );
+    expect(signals).toHaveLength(2);
+    expect(signals.map((s) => s.signalKey).sort()).toEqual([
+      'perf-regression:latency:store:write',
+      'perf-regression:throughput:store:write',
+    ]);
+  });
+
+  it('is deterministic — same inputs produce identical output', () => {
+    const result = suite('store', [operation('write', 200, 600)]);
+    const map = baselines({ 'store::write': { baselineP95Ms: 100, baselineThroughput: 1000 } });
+    expect(detectPerfRegressionSignals(result, map)).toEqual(detectPerfRegressionSignals(result, map));
+  });
+});
+
+// ============================================================================
+// (b) within tolerance → no signal
+// ============================================================================
+
+describe('detectPerfRegressionSignals — within tolerance', () => {
+  it('emits nothing when latency is within tolerance', () => {
+    // baseline 100, threshold 120; measured 115 is within tolerance.
+    const result = suite('store', [operation('search', 115, 1000)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineP95Ms: 100 } }))
+    ).toHaveLength(0);
+  });
+
+  it('emits nothing when throughput is within tolerance', () => {
+    // baseline 1000, threshold 800; measured 850 is within tolerance.
+    const result = suite('store', [operation('search', 10, 850)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineThroughput: 1000 } }))
+    ).toHaveLength(0);
+  });
+
+  it('emits nothing when the measurement is BETTER than baseline', () => {
+    const result = suite('store', [operation('search', 50, 2000)]);
+    expect(
+      detectPerfRegressionSignals(
+        result,
+        baselines({ 'store::search': { baselineP95Ms: 100, baselineThroughput: 1000 } })
+      )
+    ).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// (c) boundary — EXCLUSIVE: exactly at the threshold is NOT a regression
+// ============================================================================
+
+describe('detectPerfRegressionSignals — threshold boundary (exclusive)', () => {
+  it('does NOT emit when latency is EXACTLY at baseline*(1+tolerance)', () => {
+    // baseline 100, tolerance 20% → threshold exactly 120; measured 120 → no signal.
+    const result = suite('store', [operation('search', 120, 1000)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineP95Ms: 100 } }))
+    ).toHaveLength(0);
+  });
+
+  it('DOES emit one tick above the latency threshold', () => {
+    const result = suite('store', [operation('search', 120.01, 1000)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineP95Ms: 100 } }))
+    ).toHaveLength(1);
+  });
+
+  it('does NOT emit when throughput is EXACTLY at baseline*(1-tolerance)', () => {
+    // baseline 1000, tolerance 20% → threshold exactly 800; measured 800 → no signal.
+    const result = suite('store', [operation('route', 10, 800)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::route': { baselineThroughput: 1000 } }))
+    ).toHaveLength(0);
+  });
+
+  it('DOES emit one tick below the throughput threshold', () => {
+    const result = suite('store', [operation('route', 10, 799.99)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::route': { baselineThroughput: 1000 } }))
+    ).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// (d) no configured baseline → no signal (conservative; never invents a baseline)
+// ============================================================================
+
+describe('detectPerfRegressionSignals — no configured baseline', () => {
+  it('emits nothing when the component+operation has no baseline entry', () => {
+    const result = suite('store', [operation('search', 9999, 1)]);
+    expect(detectPerfRegressionSignals(result, baselines({}))).toHaveLength(0);
+  });
+
+  it('only flags operations that have a baseline; others are silent', () => {
+    const result = suite('store', [
+      operation('search', 999, 1), // no baseline → silent
+      operation('write', 200, 1000), // baseline present → flagged
+    ]);
+    const signals = detectPerfRegressionSignals(
+      result,
+      baselines({ 'store::write': { baselineP95Ms: 100 } })
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.signalKey).toBe('perf-regression:latency:store:write');
+  });
+
+  it('skips a baseline whose component matches but operation does not', () => {
+    const result = suite('store', [operation('search', 9999, 1)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::other': { baselineP95Ms: 1 } }))
+    ).toHaveLength(0);
+  });
+
+  it('exposes the default tolerance as 0.2 (20%) and uses it when omitted', () => {
+    expect(DEFAULT_REGRESSION_TOLERANCE_FRACTION).toBe(0.2);
+    // measured 121 with baseline 100 → > 120 default threshold → regression.
+    const result = suite('store', [operation('search', 121, 1000)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineP95Ms: 100 } }))
+    ).toHaveLength(1);
+  });
+
+  it('honors a custom tolerance override', () => {
+    // tolerance 50% → threshold 150; measured 140 within → no signal.
+    const result = suite('store', [operation('search', 140, 1000)]);
+    expect(
+      detectPerfRegressionSignals(result, baselines({ 'store::search': { baselineP95Ms: 100 } }), 0.5)
+    ).toHaveLength(0);
+  });
+
+  it('baselineKey builds the documented "component::operation" key', () => {
+    expect(baselineKey('store', 'search')).toBe('store::search');
+  });
+});
+
+// ============================================================================
+// (e) SURFACED-ONLY — wiring through runImprovementReview mutates no score
+// ============================================================================
+
+describe('runImprovementReview — perf-regression is surfaced, not auto-acted', () => {
+  it('surfaces a perf-regression signal without mutating fitness/governance scores', async () => {
+    const result = suite('memory-store', [operation('search', 300, 1000)]);
+    const perfBaselines = baselines({ 'memory-store::search': { baselineP95Ms: 100 } });
+    const input = ImprovementReviewInputSchema.parse({ lookbackDays: 7, fileIssues: false });
+
+    // Run WITHOUT the perf input — establishes the surfaced-signal baseline and the
+    // fitness-derived state of the review with no perf detector active.
+    const without = await runImprovementReview(input);
+
+    // Run WITH the perf input. fileIssues:false → nothing is filed/executed.
+    const withPerf = await runImprovementReview(input, {
+      perfRegression: { result, baselines: perfBaselines },
+    });
+
+    const perfSignals = withPerf.signals.filter((s) => s.category === 'perf-regression');
+    expect(perfSignals).toHaveLength(1);
+
+    // SURFACED-ONLY guarantee: the perf signal is purely additive. Every NON-perf
+    // signal is byte-identical to the run without the perf input — emitting the
+    // signal mutated no fitness/governance/other detector state.
+    const nonPerfWith = withPerf.signals.filter((s) => s.category !== 'perf-regression');
+    expect(nonPerfWith).toEqual(without.signals);
+
+    // It surfaces in the response signals + suggest-only remediation tasks, and
+    // nothing is filed (no autonomous action).
+    expect(withPerf.issuesFiled).toEqual([]);
+    const perfTasks = withPerf.remediationTasks.filter((t) =>
+      t.id.startsWith('improvement-perf-regression:')
+    );
+    expect(perfTasks).toHaveLength(1);
+  });
+
+  it('runs the perf detector only when a benchmark+baseline is injected', async () => {
+    const input = ImprovementReviewInputSchema.parse({ lookbackDays: 7, fileIssues: false });
+    const response = await runImprovementReview(input);
+    expect(response.signals.filter((s) => s.category === 'perf-regression')).toHaveLength(0);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-perf-regression.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-perf-regression.ts
@@ -1,0 +1,197 @@
+/**
+ * Deterministic performance-regression detector for `improvement_review`
+ * (#3692 + #3246, design-vote Option A).
+ *
+ * Maps a benchmark measurement against a STATIC, PINNED baseline + a fixed
+ * tolerance to an optional `perf-regression` {@link ImprovementSignal}. This is
+ * the deterministic core of the observability-feedback cluster: same inputs →
+ * same output, NO model judgment.
+ *
+ * LOAD-BEARING CONSTRAINT (why this is deterministic and NOT #3230 auto-tuning):
+ * the baseline is STATIC — supplied by a configured/committed baseline map, never
+ * derived from a rolling window over the OutcomeStore or recent runs. A rolling
+ * baseline would reintroduce the deferred #3230 adaptive control. If no baseline
+ * is configured for a component+operation, this emits NOTHING (conservative — a
+ * missing baseline is "unknown", never "regressed"), so it cannot invent a
+ * regression from recent data.
+ *
+ * SURFACED-NOT-AUTO-ACTED: this module only BUILDS signals. The returned
+ * signals are spread into `improvement_review`'s surfaced-signals list exactly
+ * like the tech-debt / tool-fitness / below-floor signals. Nothing here mutates a
+ * fitness or governance score, applies a penalty, or takes any autonomous action.
+ *
+ * @module mcp/tools/improvement-review-perf-regression
+ * (Source: Issue #3692, #3246)
+ */
+
+import type { ImprovementSignal } from './improvement-review.js';
+import type { BenchmarkSuiteResult } from '../../benchmarks/benchmark-types.js';
+
+/**
+ * A static, pinned baseline for one benchmarked component+operation. These values
+ * are CONFIGURED/COMMITTED (e.g. a baseline field in benchmark config or a
+ * versioned baseline file) — they are never auto-derived from recent runs.
+ */
+export interface PerfBaseline {
+  /**
+   * Baseline p95 latency in milliseconds. A measured p95 above
+   * `baselineP95Ms * (1 + tolerance)` is a latency regression. Omit to skip the
+   * latency check for this operation.
+   */
+  readonly baselineP95Ms?: number;
+  /**
+   * Baseline throughput in ops/second. A measured throughput below
+   * `baselineThroughput * (1 - tolerance)` is a throughput regression. Omit to
+   * skip the throughput check for this operation.
+   */
+  readonly baselineThroughput?: number;
+}
+
+/**
+ * Static baseline map keyed by `"<component>::<operation>"`. A component+operation
+ * with NO entry here produces no signal (conservative — no false regressions).
+ * Construct the key with {@link baselineKey}.
+ */
+export type PerfBaselineMap = ReadonlyMap<string, PerfBaseline>;
+
+/**
+ * Documented default regression tolerance: a measurement may be up to 20% worse
+ * than baseline before it is flagged. 0.2 = 20% worse than baseline.
+ */
+export const DEFAULT_REGRESSION_TOLERANCE_FRACTION = 0.2;
+
+/** Stable key for the {@link PerfBaselineMap}: `"<component>::<operation>"`. */
+export function baselineKey(component: string, operation: string): string {
+  return `${component}::${operation}`;
+}
+
+/** Round to 2 decimals for stable, readable signal payloads. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Percentage delta worse-than-baseline, rounded, for the signal body. */
+function pctWorse(measured: number, baseline: number): number {
+  if (baseline === 0) return 0;
+  return round2((Math.abs(measured - baseline) / baseline) * 100);
+}
+
+/**
+ * Build a latency-regression signal. Boundary is EXCLUSIVE: fires only when
+ * `measuredP95Ms > baselineP95Ms * (1 + tolerance)` — exactly at the threshold is
+ * NOT a regression (conservative).
+ */
+function latencyRegressionSignal(
+  component: string,
+  operation: string,
+  measuredP95Ms: number,
+  baselineP95Ms: number,
+  tolerance: number
+): ImprovementSignal | undefined {
+  const threshold = baselineP95Ms * (1 + tolerance);
+  if (measuredP95Ms <= threshold) return undefined;
+  const deltaPct = pctWorse(measuredP95Ms, baselineP95Ms);
+  return {
+    category: 'perf-regression',
+    signalKey: `perf-regression:latency:${component}:${operation}`,
+    severity: 'warning',
+    title: `perf-regression: ${component}/${operation} p95 latency ${String(round2(measuredP95Ms))}ms vs baseline ${String(round2(baselineP95Ms))}ms (+${String(deltaPct)}%)`,
+    body: [
+      `Measured p95 latency regressed beyond the configured tolerance against a STATIC baseline.`,
+      '',
+      `- Component: \`${component}\``,
+      `- Operation: \`${operation}\``,
+      `- Measured p95: ${String(round2(measuredP95Ms))} ms`,
+      `- Baseline p95: ${String(round2(baselineP95Ms))} ms (static/configured — not a rolling window)`,
+      `- Tolerance: ${String(round2(tolerance * 100))}% (regression threshold ${String(round2(threshold))} ms)`,
+      `- Delta: +${String(deltaPct)}% worse than baseline`,
+      '',
+      'Surfaced as a candidate finding for human review. No fitness/governance score is mutated and no remediation is auto-applied.',
+    ].join('\n'),
+    evidence: { observedValue: round2(measuredP95Ms), threshold: round2(threshold) },
+  };
+}
+
+/**
+ * Build a throughput-regression signal. Boundary is EXCLUSIVE: fires only when
+ * `measuredThroughput < baselineThroughput * (1 - tolerance)` — exactly at the
+ * threshold is NOT a regression (conservative).
+ */
+function throughputRegressionSignal(
+  component: string,
+  operation: string,
+  measuredThroughput: number,
+  baselineThroughput: number,
+  tolerance: number
+): ImprovementSignal | undefined {
+  const threshold = baselineThroughput * (1 - tolerance);
+  if (measuredThroughput >= threshold) return undefined;
+  const deltaPct = pctWorse(measuredThroughput, baselineThroughput);
+  return {
+    category: 'perf-regression',
+    signalKey: `perf-regression:throughput:${component}:${operation}`,
+    severity: 'warning',
+    title: `perf-regression: ${component}/${operation} throughput ${String(round2(measuredThroughput))} ops/s vs baseline ${String(round2(baselineThroughput))} ops/s (-${String(deltaPct)}%)`,
+    body: [
+      `Measured throughput regressed beyond the configured tolerance against a STATIC baseline.`,
+      '',
+      `- Component: \`${component}\``,
+      `- Operation: \`${operation}\``,
+      `- Measured throughput: ${String(round2(measuredThroughput))} ops/s`,
+      `- Baseline throughput: ${String(round2(baselineThroughput))} ops/s (static/configured — not a rolling window)`,
+      `- Tolerance: ${String(round2(tolerance * 100))}% (regression threshold ${String(round2(threshold))} ops/s)`,
+      `- Delta: -${String(deltaPct)}% below baseline`,
+      '',
+      'Surfaced as a candidate finding for human review. No fitness/governance score is mutated and no remediation is auto-applied.',
+    ].join('\n'),
+    evidence: { observedValue: round2(measuredThroughput), threshold: round2(threshold) },
+  };
+}
+
+/**
+ * Map a benchmark suite result + a STATIC baseline map to `perf-regression`
+ * signals. Pure and deterministic: same inputs → same output.
+ *
+ * For each operation, looks up `"<component>::<operation>"` in `baselines`:
+ * - No entry → emit nothing (conservative; never invents a baseline).
+ * - Latency: emit when measured p95 > baseline p95 * (1 + tolerance).
+ * - Throughput: emit when measured throughput < baseline throughput * (1 - tolerance).
+ * Latency and throughput are independent — an operation can emit both.
+ *
+ * @param result    the measured benchmark suite (component + operations).
+ * @param baselines the static, configured baseline map (never auto-derived).
+ * @param tolerance fractional tolerance; defaults to
+ *                  {@link DEFAULT_REGRESSION_TOLERANCE_FRACTION} (0.2 = 20%).
+ */
+export function detectPerfRegressionSignals(
+  result: BenchmarkSuiteResult,
+  baselines: PerfBaselineMap,
+  tolerance: number = DEFAULT_REGRESSION_TOLERANCE_FRACTION
+): readonly ImprovementSignal[] {
+  const signals: ImprovementSignal[] = [];
+  for (const op of result.operations) {
+    const baseline = baselines.get(baselineKey(result.component, op.operation));
+    if (baseline === undefined) continue; // no configured baseline → no signal.
+    if (baseline.baselineP95Ms !== undefined) {
+      const sig = latencyRegressionSignal(
+        result.component,
+        op.operation,
+        op.latency.p95,
+        baseline.baselineP95Ms,
+        tolerance
+      );
+      if (sig !== undefined) signals.push(sig);
+    }
+    if (baseline.baselineThroughput !== undefined) {
+      const sig = throughputRegressionSignal(
+        result.component,
+        op.operation,
+        op.throughput.opsPerSecond,
+        baseline.baselineThroughput,
+        tolerance
+      );
+      if (sig !== undefined) signals.push(sig);
+    }
+  }
+  return signals;
+}

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -39,6 +39,11 @@ import type { VoteRejectedSignalEvent } from '../../pipeline/event-types.js';
 import { REJECTION_CATEGORIES } from '../../consensus/types-core.js';
 import { emitFitnessDeclinedSignal } from './improvement-review-signals.js';
 import { loadToolFitnessSignals } from './improvement-review-tool-fitness.js';
+import {
+  detectPerfRegressionSignals,
+  type PerfBaselineMap,
+} from './improvement-review-perf-regression.js';
+import type { BenchmarkSuiteResult } from '../../benchmarks/benchmark-types.js';
 import { improvementSignalsToTasks } from './improvement-remediation.js';
 import { recordRemediationShadow } from './improvement-remediation-shadow.js';
 import { classifySignalPriority, priorityLabel } from './remediation-priority.js';
@@ -105,7 +110,12 @@ export type SignalCategory =
   // #3852 (closes the #3692 sequencing): tool-fitness deprecation/consolidation
   // candidates from the #3851 ledger. SUGGEST-TIER ONLY — never autonomous
   // removal (Epic F invariant). See improvement-review-tool-fitness.ts.
-  | 'tool-fitness';
+  | 'tool-fitness'
+  // #3692 + #3246 (Option A): deterministic benchmark perf regression vs a
+  // STATIC, pinned baseline + fixed tolerance. SURFACED-ONLY — never auto-applies
+  // a fitness/governance penalty. The static baseline keeps this out of the
+  // deferred #3230 adaptive-control scope. See improvement-review-perf-regression.ts.
+  | 'perf-regression';
 
 export interface ImprovementSignal {
   readonly category: SignalCategory;
@@ -716,9 +726,43 @@ function readBufferedVoteRejections(
  * — pass a logger and an OutcomeStore-query result if you want to inject test
  * data; defaults read the global store and a no-op logger.
  */
+/**
+ * A measured benchmark suite paired with its STATIC, configured baseline map
+ * (#3692/#3246). Injected — there is no global benchmark store and the baseline
+ * is never auto-derived from recent runs (that would be the deferred #3230
+ * adaptive control). When absent, the perf-regression detector does not run.
+ */
+export interface PerfRegressionInput {
+  readonly result: BenchmarkSuiteResult;
+  /** Static, configured baselines keyed by `"<component>::<operation>"`. */
+  readonly baselines: PerfBaselineMap;
+  /** Optional override of the default 20% tolerance. */
+  readonly toleranceFraction?: number;
+}
+
+/**
+ * Gather deterministic perf-regression signals when a benchmark+baseline is
+ * injected; otherwise none. Thin wrapper around {@link detectPerfRegressionSignals}
+ * so the review runner stays under the per-function line cap.
+ */
+function gatherPerfRegressionSignals(
+  perf: PerfRegressionInput | undefined
+): readonly ImprovementSignal[] {
+  if (perf === undefined) return [];
+  return detectPerfRegressionSignals(perf.result, perf.baselines, perf.toleranceFraction);
+}
+
 export async function runImprovementReview(
   input: ImprovementReviewInput,
-  deps: { readonly logger?: ReturnType<typeof createLogger> } = {}
+  deps: {
+    readonly logger?: ReturnType<typeof createLogger>;
+    /**
+     * Optional benchmark measurement + STATIC baseline for the deterministic
+     * perf-regression detector (#3692/#3246). Surfaced-only — emitting a signal
+     * never mutates a fitness/governance score. Absent → detector is a no-op.
+     */
+    readonly perfRegression?: PerfRegressionInput;
+  } = {}
 ): Promise<ImprovementReviewResponse> {
   const logger = deps.logger ?? createLogger({ component: 'improvement_review' });
   const { lookbackDays, fileIssues, minSampleSize, fitnessFloor, selfEvalReportPath } = input;
@@ -748,6 +792,14 @@ export async function runImprovementReview(
   // the review). Workspace-scoped to defeat context-poisoning (#3852 concern 1).
   const toolFitnessSignals = loadToolFitnessSignals(windowLabel);
 
+  // Deterministic perf-regression candidates (#3692/#3246): a measured benchmark
+  // vs a STATIC, configured baseline + fixed tolerance. SURFACED-ONLY — appended
+  // to the signals list exactly like every other detector; nothing mutates a
+  // fitness/governance score or auto-applies a remediation. Runs only when a
+  // benchmark+baseline is injected (no global store; no rolling baseline → out of
+  // the deferred #3230 adaptive-control scope).
+  const perfRegressionSignals = gatherPerfRegressionSignals(deps.perfRegression);
+
   const signals: ImprovementSignal[] = [
     ...detectCliPerformanceFloor(windowed, minSampleSize, windowLabel),
     ...detectFailureCategoryConcentration(windowed, windowLabel),
@@ -755,6 +807,7 @@ export async function runImprovementReview(
     ...detectConsensusRejectionSignals(rejectionEvents, windowLabel),
     ...selfEvalSignals,
     ...toolFitnessSignals,
+    ...perfRegressionSignals,
   ];
   signals.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
 

--- a/packages/nexus-agents/src/mcp/tools/remediation-research.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-research.ts
@@ -33,6 +33,9 @@ const ACTION_BY_CATEGORY: Readonly<Record<SignalCategory, RemediationActionKind>
   // #3852: a deprecation/consolidation candidate is a human decision, never an
   // autonomous code change — investigate only (Epic D ratification path).
   'tool-fitness': 'investigate',
+  // #3692/#3246: a perf regression needs root-cause diagnosis before any change —
+  // investigate only; the surfaced signal never auto-applies a fix.
+  'perf-regression': 'investigate',
 };
 
 /** Bound a string to a schema-safe length. */


### PR DESCRIPTION
## Summary

Deterministic core of the observability-feedback cluster (#3692 + #3246), per the 7-0 design vote (Option A). Surfaces a benchmark performance regression as a candidate finding in `improvement_review` — deterministic, surfaced-not-auto-acted.

## New SignalCategory value (extends the existing enum — NOT a new pathway)

Added `'perf-regression'` to the existing `improvement_review` `SignalCategory` union (`packages/nexus-agents/src/mcp/tools/improvement-review.ts`). Chose the precise `perf-regression` over a broad `tuning` bucket: the existing pattern uses precise hyphenated categories (`tech-debt`, `tool-fitness`) and there is no broad-bucket precedent. No new feedback module/pathway — signals are gathered and surfaced by the same `runImprovementReview` path as every other detector.

Exhaustiveness fixed for the new value (tsc would flag these):
- `ROLE_BY_CATEGORY` (`improvement-remediation.ts`) → `coder` seed role
- `ACTION_BY_CATEGORY` (`remediation-research.ts`) → `investigate`
- `RemediationPlanSchema` Zod `z.enum` (`improvement-remediation-capability.ts`)

## Deterministic detector (static baseline + fixed tolerance — no rolling window)

New module `improvement-review-perf-regression.ts`, `detectPerfRegressionSignals(result, baselines, tolerance)`:
- Input: a `BenchmarkSuiteResult` (p95 latency + ops/sec per operation) + a STATIC `PerfBaselineMap` keyed by `"<component>::<operation>"` + a fixed `tolerance` (default `DEFAULT_REGRESSION_TOLERANCE_FRACTION = 0.2` = 20% worse than baseline).
- Logic: latency regression when `measuredP95 > baseline*(1+tolerance)`; throughput regression when `measuredThroughput < baseline*(1-tolerance)`. Pure/deterministic — same inputs → same output, no model judgment.
- Boundary is **exclusive**: exactly at the threshold is NOT a regression (conservative).

### Baseline-source design

The baseline is **static/configured/injected**, supplied via `runImprovementReview(input, { perfRegression: { result, baselines, toleranceFraction } })`. It is **never** auto-derived from a rolling window over the OutcomeStore or recent runs — a rolling baseline would reintroduce the deferred #3230 adaptive control (the load-bearing constraint). There is no global benchmark store, so the detector runs only when a benchmark + baseline is explicitly injected; absent that, it is a no-op. **If no baseline is configured for a component+operation, it emits nothing** (conservative — a missing baseline is "unknown", never "regressed"; no invented baselines).

## Surfaced-not-auto-acted guarantee (how enforced)

The detector only *builds* `ImprovementSignal`s. They are spread into the `signals` array in `runImprovementReview` exactly like the existing tech-debt / tool-fitness / below-floor signals. Nothing in the module or wiring mutates a fitness/governance score, applies a penalty, or takes autonomous action. Enforced by test: running the review with vs without the perf input yields byte-identical non-perf signals (the perf signal is purely additive), `issuesFiled` is empty, and only a suggest-only remediation task is produced.

## Tests (19 new + extended)

`improvement-review-perf-regression.test.ts`:
- (a) above baseline*tolerance → exactly one signal with correct payload (latency + throughput; both can fire for one op); determinism asserted
- (b) within tolerance / better-than-baseline → no signal
- (c) boundary exclusive — exactly at threshold → no signal; one tick past → signal (both latency and throughput)
- (d) no configured baseline → no signal; partial baselines flag only configured ops; default tolerance is 0.2 and is used; custom tolerance honored
- (e) surfaced-only — wired through `runImprovementReview`, no fitness/governance mutation, nothing filed
- (f) SignalCategory schema exhaustiveness: `RemediationPlanSchema` accepts every category incl. `perf-regression`; `ROLE_BY_CATEGORY` mapping covers it

## Gates

- Zero `any`; `tsc --noEmit` clean (all exhaustiveness gaps fixed); eslint clean on changed files.
- Tests: 113 passed (perf-regression 19, improvement-review 32, remediation 6, capability 16, benchmark-runner 40).
- Repository Index Verification (`generate-repo-index.ts --check`) and `docs:tools:check` both pass — `perf-regression` is a signal-payload value, not a tool/command/category enumerated in any generated artifact, so no regen needed (MCP tool count unchanged at 46; tool description unchanged).
- Changeset `.changeset/perf-regression-signal-3692.md`, `'nexus-agents': minor`, type `feat`.

## Scope

- #3230 auto-tuning: **deferred / NOT built** (the static-baseline constraint keeps this strictly observational).
- #3227 / #3228: **untouched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)