### PR TITLE
fix(cli): proactive first-run setup hint across all commands (stderr, marker-gated, non-interactive-safe) (#3208)

### DIFF
--- a/.changeset/proactive-first-run-hint-3208.md
+++ b/.changeset/proactive-first-run-hint-3208.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli): proactive first-run setup hint across all commands (#3208)
+
+The first-run setup hint previously fired only during `server` mode, so CLI
+tooling users who run verification/inspection commands never saw it. It now
+fires from the CLI dispatch seam on the first invocation of ANY command except
+`version`/`help` (and their `-v`/`-h`/`--version`/`--help` flag forms, which
+resolve to those commands) and `setup` itself.
+
+The hint is marker-gated (`~/.nexus-agents/.first-run-done`, resolved via the
+existing `nexusSharedPath` per-user data-dir helper), best-effort on write
+(read-only FS / perms failures still show the hint once and never crash or
+block), stderr-only (never pollutes piped/scripted stdout or JSON), and
+TTY-gated so a first run in CI/pipes emits nothing and does not consume the
+marker — the operator's first interactive run still gets the hint. Exit codes,
+ordering, and stdout are unchanged; the hint is purely additive.

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -46,8 +46,6 @@ import { runWarmUp } from './cli/warm-up.js';
 import { runE2EEval, formatE2EEvalResult } from './cli/e2e-eval.js';
 import { runRoutingAB, formatABReport } from './cli/routing-ab.js';
 import { runMemoryEval, formatMemoryEvalReport } from './cli/memory-eval.js';
-import { existsSync } from 'node:fs';
-import { getNexusDataDir } from './config/nexus-data-dir.js';
 import { initPortable, formatInitPortableMessage } from './cli/init-portable.js';
 import {
   EXIT_CODES,
@@ -174,31 +172,18 @@ function buildOrchestratorOptions(args: ParsedCliArgs): OrchestratorModeOptions 
   };
 }
 
-/** Prints a first-run hint to stderr when no setup has been done (#1261). */
-function printFirstRunHint(): void {
-  const isTTY = process.stderr.isTTY;
-  if (!isTTY) return;
-  const dataDir = getNexusDataDir();
-  const hasConfig =
-    existsSync('./.nexus-agents/nexus-agents.yaml') ||
-    existsSync('./.nexus-agents/nexus-agents.yml') ||
-    existsSync('./nexus-agents.yaml') ||
-    existsSync('./nexus-agents.yml');
-  if (existsSync(dataDir) || hasConfig) return;
-  process.stderr.write(
-    '\n\x1b[36mnexus-agents\x1b[0m: First time? Run \x1b[1mnexus-agents setup\x1b[0m to configure.\n\n'
-  );
-}
-
 /**
  * Handles the server command (default mode or interactive REPL).
  * In orchestrator mode, executes tasks directly without MCP server.
  * (Source: Issue #446 - Implement orchestrator mode)
+ *
+ * The first-run setup hint moved out of here in #3208 — it now fires from the
+ * CLI dispatch seam (`dispatchCommand` → `maybeShowFirstRunHint`) for ALL
+ * commands except version/help/setup, not just `server`.
  */
 export async function handleServerCommand(
   args: ParsedCliArgs
 ): Promise<CliExitResult | LifecycleDelegated> {
-  printFirstRunHint();
   if (args.options.interactive) {
     const exitCode = await replCommand({ verbose: args.options.verbose });
     return cliExitFromStatus(exitCode);

--- a/packages/nexus-agents/src/cli-commands.ts
+++ b/packages/nexus-agents/src/cli-commands.ts
@@ -168,6 +168,8 @@ import { handleModeCommand } from './cli/mode-command.js';
 import { initDataDirectories } from './cli/setup-data-dir.js';
 // #1930: Step notifications (human-readable progress trail)
 import { bootstrapStepNotifications } from './core/step-notifications.js';
+// #3208: proactive first-run setup hint, broadened from server-only (#1261)
+import { maybeShowFirstRunHint } from './cli/first-run-hint.js';
 
 /**
  * Prints help text to stdout.
@@ -381,6 +383,11 @@ async function handleAsyncCommand(args: ParsedCliArgs): Promise<void> {
 export async function dispatchCommand(args: ParsedCliArgs): Promise<void> {
   // Ensure data directories exist before any command runs (#1398)
   initDataDirectories();
+
+  // #3208: proactive first-run hint. Fires for any command except
+  // version/help/setup, marker-gated, stderr-only, TTY-only. Purely additive —
+  // it never touches stdout, exit codes, or ordering (no-op on every guard).
+  maybeShowFirstRunHint(args.command);
 
   // #1930: Wire step notifications. `server` command is the MCP stdio server —
   // renderer must default off there to protect JSON-RPC frames. All other

--- a/packages/nexus-agents/src/cli/first-run-hint.test.ts
+++ b/packages/nexus-agents/src/cli/first-run-hint.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the proactive first-run setup hint (#3208).
+ *
+ * The marker filesystem, the data-dir resolver, and the TTY signal are all
+ * mocked — nothing here touches the real home dir or real stderr.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+
+import { maybeShowFirstRunHint, firstRunMarkerPath } from './first-run-hint.js';
+
+// Mock the data-dir resolver so the marker path is deterministic and never
+// points at the operator's real ~/.nexus-agents.
+vi.mock('../config/nexus-data-dir.js', () => ({
+  nexusSharedPath: (...segments: string[]): string => `/fake-home/.nexus-agents/${segments.join('/')}`,
+}));
+
+// Mock node:fs so existence + writes are observable and never hit disk.
+const fsState = vi.hoisted(() => ({
+  existing: new Set<string>(),
+  writes: [] as { path: string; data: string }[],
+  existsSyncThrows: false,
+  writeThrows: false,
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn((p: string): boolean => {
+    if (fsState.existsSyncThrows) throw new Error('EACCES: cannot stat');
+    return fsState.existing.has(p);
+  }),
+  mkdirSync: vi.fn((): undefined => undefined),
+  writeFileSync: vi.fn((p: string, data: string): void => {
+    if (fsState.writeThrows) throw new Error('EROFS: read-only file system');
+    fsState.writes.push({ path: p, data });
+    fsState.existing.add(p);
+  }),
+}));
+
+const MARKER = '/fake-home/.nexus-agents/.first-run-done';
+
+/** Forces `process.stderr.isTTY` for the duration of one test. */
+function withTty<T>(isTty: boolean, fn: () => T): T {
+  const original = process.stderr.isTTY;
+  Object.defineProperty(process.stderr, 'isTTY', { value: isTty, configurable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process.stderr, 'isTTY', { value: original, configurable: true });
+  }
+}
+
+describe('first-run-hint', () => {
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    fsState.existing.clear();
+    fsState.writes.length = 0;
+    fsState.existsSyncThrows = false;
+    fsState.writeThrows = false;
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('resolves the marker under the per-user shared data dir', () => {
+    expect(firstRunMarkerPath()).toBe(MARKER);
+  });
+
+  describe('first run (marker absent, interactive)', () => {
+    it('emits the hint to stderr and creates the marker for a normal command', () => {
+      withTty(true, () => {
+        maybeShowFirstRunHint('verify');
+      });
+
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const output = String(stderrSpy.mock.calls[0]?.[0]);
+      expect(output).toContain('nexus-agents setup');
+      // Marker created.
+      expect(fsState.writes).toHaveLength(1);
+      expect(fsState.writes[0]?.path).toBe(MARKER);
+    });
+  });
+
+  describe('second run (marker present)', () => {
+    it('emits nothing and does not rewrite the marker', () => {
+      fsState.existing.add(MARKER);
+      withTty(true, () => {
+        maybeShowFirstRunHint('doctor');
+      });
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(fsState.writes).toHaveLength(0);
+    });
+  });
+
+  describe('suppressed commands never emit (even on first run)', () => {
+    it.each(['version', 'help', 'setup'])('skips %s', (command) => {
+      withTty(true, () => {
+        maybeShowFirstRunHint(command);
+      });
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+      // Suppressed commands must not consume the first-run marker either.
+      expect(fsState.writes).toHaveLength(0);
+    });
+  });
+
+  describe('non-interactive (stderr not a TTY)', () => {
+    it('emits nothing AND does not create the marker, preserving the hint for the first interactive run', () => {
+      withTty(false, () => {
+        maybeShowFirstRunHint('verify');
+      });
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+      // Decision: do NOT mark in non-interactive runs, so a CI/piped first run
+      // doesn't silently consume the operator's one-and-only hint.
+      expect(fsState.writes).toHaveLength(0);
+    });
+
+    it('treats isTTY === undefined as non-interactive', () => {
+      withTty(undefined as unknown as boolean, () => {
+        maybeShowFirstRunHint('verify');
+      });
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(fsState.writes).toHaveLength(0);
+    });
+  });
+
+  describe('marker write failure (read-only FS / perms)', () => {
+    it('still shows the hint once and does not throw', () => {
+      fsState.writeThrows = true;
+      expect(() => {
+        withTty(true, () => {
+          maybeShowFirstRunHint('verify');
+        });
+      }).not.toThrow();
+
+      // Hint was still shown despite the marker write failing.
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      expect(fsState.writes).toHaveLength(0);
+    });
+  });
+
+  describe('marker existence-probe failure', () => {
+    it('falls through to showing the hint rather than crashing', () => {
+      fsState.existsSyncThrows = true;
+      fsState.writeThrows = true; // also block the write so the probe path is isolated
+      expect(() => {
+        withTty(true, () => {
+          maybeShowFirstRunHint('doctor');
+        });
+      }).not.toThrow();
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('writes only to stderr, never stdout', () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      withTty(true, () => {
+        maybeShowFirstRunHint('verify');
+      });
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli/first-run-hint.ts
+++ b/packages/nexus-agents/src/cli/first-run-hint.ts
@@ -1,0 +1,88 @@
+/**
+ * Proactive first-run setup hint (#3208, broadening #1261).
+ *
+ * Shows a minimal, non-blocking pointer to `nexus-agents setup` the FIRST
+ * time the operator runs ANY command — not just the server mode. Previously
+ * the hint only fired inside `handleServerCommand`, so the (common) CLI-tooling
+ * user who runs verification/inspection commands never saw it.
+ *
+ * Design constraints (all enforced here, see each guard):
+ * - **Scope:** fires for any command EXCEPT `version` / `help` / `setup`. The
+ *   CLI resolves `--version`/`-v` → `version` and `--help`/`-h` → `help`
+ *   (see `determineCommand` in `cli.ts`), so gating on the resolved command
+ *   name covers the flag forms too. `setup` is skipped so the hint never nags
+ *   during the very thing it points to.
+ * - **Marker-gated:** a marker file at `~/.nexus-agents/.first-run-done`
+ *   (resolved via `nexusSharedPath`, the cross-repo / per-user data root)
+ *   records that the hint has been shown. Present → silent forever after.
+ * - **Non-interactive-safe:** only emits when stderr is a TTY (the existing
+ *   convention — `process.stderr.isTTY`). A first run in CI / a piped context
+ *   shows nothing AND does not create the marker, so the operator's first
+ *   *interactive* run still gets the hint rather than having it silently
+ *   consumed by a log-only run.
+ * - **Non-polluting:** writes to stderr only, 2 lines, so piped/scripted
+ *   stdout (incl. JSON) is never touched.
+ * - **Best-effort marker write:** if the marker can't be written (read-only
+ *   FS, perms), the hint still shows that once and nothing crashes or blocks.
+ *
+ * @module cli/first-run-hint
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { nexusSharedPath } from '../config/nexus-data-dir.js';
+
+/**
+ * Commands that must never trigger the hint, even on a genuine first run:
+ * `version`/`help` (the user is just asking for info — and the resolved
+ * command name covers `--version`/`-v`/`--help`/`-h`), and `setup` itself
+ * (the hint points there; nagging during it would be absurd).
+ */
+const HINT_SUPPRESSED_COMMANDS: ReadonlySet<string> = new Set(['version', 'help', 'setup']);
+
+/** Absolute path to the first-run marker file. Per-user / cross-repo. */
+export function firstRunMarkerPath(): string {
+  return nexusSharedPath('.first-run-done');
+}
+
+/**
+ * Shows the proactive first-run hint exactly once, then records that it was
+ * shown. No-op (and no marker write) when stderr isn't a TTY, when the marker
+ * already exists, or when the command is in {@link HINT_SUPPRESSED_COMMANDS}.
+ *
+ * Purely additive: never throws, never blocks, never touches stdout, and
+ * never affects the command's exit code or ordering. Call it before dispatch.
+ *
+ * @param command - The resolved CLI command name (e.g. `'verify'`, `'doctor'`).
+ */
+export function maybeShowFirstRunHint(command: string): void {
+  if (HINT_SUPPRESSED_COMMANDS.has(command)) return;
+  // Non-interactive (CI, pipes, redirected stderr): stay silent and do NOT
+  // mark, so the first *interactive* run still gets the hint. `isTTY` is
+  // `undefined` (falsy) on non-TTY streams, so the truthiness check is enough.
+  if (!process.stderr.isTTY) return;
+
+  const marker = firstRunMarkerPath();
+  // Best-effort existence probe — a stat failure here just falls through to
+  // showing the hint, which is the safe (additive) direction.
+  try {
+    if (existsSync(marker)) return;
+  } catch {
+    // Treat an unreadable marker location as "not yet shown".
+  }
+
+  process.stderr.write(
+    '\x1b[36mnexus-agents\x1b[0m: First time? Run \x1b[1mnexus-agents setup\x1b[0m to configure.\n' +
+      '  (This one-time hint is now dismissed.)\n'
+  );
+
+  // Best-effort marker creation. A read-only FS / perms failure must not crash
+  // or block the command — the hint was already shown, which is the contract.
+  try {
+    mkdirSync(dirname(marker), { recursive: true });
+    writeFileSync(marker, `${new Date().toISOString()}\n`, { flag: 'w' });
+  } catch {
+    // Intentionally swallowed — see the best-effort contract in the docstring.
+  }
+}


### PR DESCRIPTION
Closes #3208.

## What changed

The first-run setup hint previously fired **only during `server` mode** (`printFirstRunHint` inside `handleServerCommand`), so CLI-tooling users who run verification/inspection commands never saw it. This broadens it to **all commands**.

### Broadened scope (server-only → all commands except version/help/setup)
- New module `packages/nexus-agents/src/cli/first-run-hint.ts` exposes `maybeShowFirstRunHint(command)`.
- Wired into `dispatchCommand` (the single dispatch seam reached from `cli.ts` `main`), **before** dispatch.
- Fires for any command **except** `version`/`help` and `setup`. The CLI resolves `--version`/`-v` → `version` and `--help`/`-h` → `help` (per `determineCommand`), so gating on the resolved command name covers the flag forms too. `setup` is skipped so the hint never nags during the very thing it points to.
- Removed the old server-only `printFirstRunHint` and its now-unused `existsSync` / `getNexusDataDir` imports.

### Marker file + best-effort write
- Marker `~/.nexus-agents/.first-run-done`, resolved via the **existing** `nexusSharedPath` per-user / cross-repo data-dir helper (no new path scheme hardcoded; `nexusSharedPath` is the hard-guarantee homedir resolver, correct for a per-user "have I seen this" flag).
- Marker absent → show hint + create marker. Present → silent forever after.
- Marker creation is **best-effort**: a read-only FS / perms failure still shows the hint once and never crashes or blocks the command. An unreadable existence-probe falls through to showing the hint (the safe, additive direction).

### stderr-only + TTY / non-interactive gating (no CI pollution)
- Writes to **stderr only** (2 lines), never stdout — piped/scripted output and JSON are untouched.
- Gated on `process.stderr.isTTY` (the existing convention).
- **Non-interactive decision:** when stderr is not a TTY (CI, pipes, redirected stderr) the hint emits nothing **and does not write the marker**. Rationale (least-surprising): a first run in CI shouldn't silently consume the operator's one-and-only first-run hint — their first *interactive* run still gets it.

### Exit codes / stdout unchanged
The hint is purely additive: it never throws, never blocks, never touches stdout, and never affects a command's exit code or ordering.

## Tests
New `cli/first-run-hint.test.ts` (11 tests, marker FS + TTY mocked, never touches real home dir):
- first run (marker absent, interactive) → hint to stderr + marker created
- second run (marker present) → silent, no rewrite
- `version` / `help` / `setup` → never emit (even first run), and don't consume the marker
- non-interactive (stderr not a TTY, and `isTTY === undefined`) → silent + no marker
- marker write failure (read-only FS) → hint still shown once, no crash
- existence-probe failure → falls through to showing the hint, no crash
- stderr-only (stdout never written)

## Gates
- Zero `any`; `tsc --noEmit` clean; eslint clean on changed files.
- CLI suites green: `first-run-hint` (11), `cli-commands` (20), `cli-commands-handlers` (21), `command-parity` (5), `cli-command-catalog` (27) — 84/84.
- No new CLI command or MCP tool (bootstrap behavior only) — `VALID_COMMANDS`, dispatch tables, and the MCP tool registry are unchanged, so repo-index / `MCP_TOOL_COUNT` are unaffected.
- Changeset: `'nexus-agents': patch`, type `fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)