### PR TITLE
fix(docs): correct 11 verified JSDoc/MCP-description accuracy findings from Phase 2 audit (#3519)

### DIFF
--- a/.changeset/jsdoc-phase2-accuracy-3519.md
+++ b/.changeset/jsdoc-phase2-accuracy-3519.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+fix(docs): correct 11 verified JSDoc/MCP-description accuracy findings from the #3519 Phase-2 semantic-accuracy audit
+
+Make each doc/description/annotation match what the code actually does:
+
+- delegate_to_model: drop the false "Read-only." claim (the handler records a routing decision to tool-memory on every call) and set `readOnlyHint: false` in the manifest with an explicit side-effect entry.
+- model-registry module doc: rewrite the resolution chain to include the `manifest` and `generated` tiers in correct priority order; replace stale "lands in PR 4 / later PR" forward-refs (both shipped).
+- consensus_vote: 7 roles by default / 3 with quickMode; document async mode (returns a jobId to poll via get_job_result).
+- registry_import: document `dryRun` as a no-op echo — the tool never persists.
+- repo_analyze: document `depth` as a no-op — the handler always runs the full analysis.
+- research_add_source: remove the false GitHub `gh`-CLI auto-fetch claim; quality_score is computed from caller-provided quality_signals only.
+- composite-router: scoring stages run sequentially (dependency-ordered), not in parallel.
+- memory_write: belief predicate is fixed as `has_knowledge` (caller controls key + content only).
+- research_catalog_review: note the optional GitHub-issue side-effect on approve.
+- 4 pipeline tools (run_dev_pipeline, run_pipeline, run_workflow, run_graph_workflow): document the async dispatch capability.

--- a/docs/reference/tools/consensus_vote.md
+++ b/docs/reference/tools/consensus_vote.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, consensus_vote]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Execute multi-model consensus voting on a proposal. Uses specialized agent roles to vote with configurable strategies.
+Execute multi-model consensus voting on a proposal. Uses 7 roles by default (or 3 with quickMode), voting with configurable strategies. Supports async mode (returns a jobId to poll via get_job_result).
 
 ## Parameters
 

--- a/docs/reference/tools/delegate_to_model.md
+++ b/docs/reference/tools/delegate_to_model.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, delegate_to_model]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Pick which existing model should HANDLE a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Read-only.
+Pick which existing model should HANDLE a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Records the routing decision to tool-memory for learning feedback (not a pure read).
 
 ## Parameters
 

--- a/docs/reference/tools/registry_import.md
+++ b/docs/reference/tools/registry_import.md
@@ -18,4 +18,4 @@ Draft a registry ENTRY YAML for a NEW model so routing can consider it later. Re
 | --------- | ---- | -------- | ----------- | ----------- |
 | `provider` | enum | yes | one of: anthropic \| google \| openai | Model provider (anthropic, google, openai) |
 | `modelId` | string | yes | minLength 1 | Provider model identifier |
-| `dryRun` | boolean | no | default true | Preview without persisting |
+| `dryRun` | boolean | no | default true | No-op flag echoed back in the response; the tool never persists regardless |

--- a/docs/reference/tools/repo_analyze.md
+++ b/docs/reference/tools/repo_analyze.md
@@ -17,4 +17,4 @@ Analyze a GitHub repository structure. Returns language, framework, package mana
 | Parameter | Type | Required | Constraints | Description |
 | --------- | ---- | -------- | ----------- | ----------- |
 | `repo` | string | yes | minLength 1 | GitHub repository in "owner/name" format (e.g., "cloudfoundry/korifi") or full URL |
-| `depth` | enum | no | one of: shallow \| deep; default shallow | Analysis depth: shallow (tree + README) or deep (full analysis) |
+| `depth` | enum | no | one of: shallow \| deep; default shallow | Currently a no-op — the handler always runs the full analysis (both values identical) |

--- a/docs/reference/tools/research_add_source.md
+++ b/docs/reference/tools/research_add_source.md
@@ -22,7 +22,7 @@ NON-PAPER source: add a GitHub repo / tool / blog URL to the research registry w
 | `vendor` | string | no | maxLength 100 | Vendor or organization |
 | `topics` | array of string | no | — | Research topics (max 5) |
 | `tags` | array of string | no | — | Searchable tags (max 10) |
-| `quality_signals` | object | no | — | Quality signals (auto-fetched for GitHub repos if omitted) |
+| `quality_signals` | object | no | — | Quality signals used to compute quality_score; provide explicitly — no GitHub metadata is fetched |
 | `techniques_extracted` | array of string | no | — | Techniques identified in this source (max 5) |
 | `verdict` | enum | no | one of: adopted \| partially_adopted \| rejected \| monitoring \| planned | Adoption verdict |
 | `verdict_notes` | string | no | maxLength 500 | Notes explaining the verdict |

--- a/docs/reference/tools/run_dev_pipeline.md
+++ b/docs/reference/tools/run_dev_pipeline.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, run_dev_pipeline]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).
+Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only). Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.
 
 ## Parameters
 

--- a/docs/reference/tools/run_graph_workflow.md
+++ b/docs/reference/tools/run_graph_workflow.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, run_graph_workflow]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.
+Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead. Supports dispatch: 'async' — returns a jobId immediately; poll get_job_result.
 
 ## Parameters
 

--- a/docs/reference/tools/run_pipeline.md
+++ b/docs/reference/tools/run_pipeline.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, run_pipeline]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Single unified entry point for all pipeline templates (dev/research/audit/greenfield/general). Auto-detects template from task content or accepts an explicit override.
+Single unified entry point for all pipeline templates (dev/research/audit/greenfield/general). Auto-detects template from task content or accepts an explicit override. Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.
 
 ## Parameters
 

--- a/docs/reference/tools/run_workflow.md
+++ b/docs/reference/tools/run_workflow.md
@@ -10,7 +10,7 @@ keywords: [mcp, tool, reference, run_workflow]
 > Auto-generated from the registered MCP tool descriptions and input
 > schemas. Do not edit by hand — run `pnpm docs:tools` to regenerate.
 
-Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching or per-node checkpoints, use `run_graph_workflow` instead.
+Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching or per-node checkpoints, use `run_graph_workflow` instead. Supports mode: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.
 
 ## Parameters
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -4,7 +4,7 @@
  *
  * Stage order (executed by `composite-router-stages.ts:runPipeline`):
  *   1. Budget — eliminate CLIs that exceed session token/cost budget
- *   2. Scoring (parallel) — ConfidenceCascade / CapabilityMatch / KnnRouting /
+ *   2. Scoring (sequential, dependency-ordered) — ConfidenceCascade / CapabilityMatch / KnnRouting /
  *      DistilledRule / ResourceStrategy / ZeroRouter / Preference
  *   3. QualityConstraint — constraint-first filter; can short-circuit (#1686)
  *   4. CategoryOverride — `CATEGORY_CHAIN_OVERRIDES` per task category; can

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -14,22 +14,27 @@
  * the modelId is known, derived entry if vendor + family can be
  * inferred, universal default otherwise.
  *
- * Resolution chain (most specific first):
+ * Resolution chain (highest priority first; the constructor loads
+ * lowest-priority first so higher tiers overwrite lower ones field-by-field —
+ * see {@link EntrySource} and `ModelRegistry` constructor):
  *
- *   1. modelHints / explicit alias        ← operator override
- *   2. models.dev snapshot                ← seeded externally (PR 4)
+ *   1. modelHints / explicit alias        ← operator override (resolver hints)
+ *   2. manifest entries                   ← operator manifest overlay (#2547)
  *   3. in-tree authoritative entries      ← measured/validated by us
- *   4. derived from vendor + family       ← pattern-matched fallback
- *   5. universal default                  ← never fails
+ *   4. models.dev snapshot                ← seeded externally
+ *   5. generated catalog (LiteLLM)        ← LOWEST tier; long-tail breadth (#3293)
+ *   6. derived from vendor + family       ← pattern-matched fallback
+ *   7. universal default                  ← never fails
  *
  * This module ships the type + class + derived-fallback logic. The
- * authoritative entries (PR 1's payload) are populated alongside; the
- * models.dev snapshot loader lands in PR 4.
+ * authoritative in-tree entries are populated by `buildInTreeEntries()`; the
+ * models.dev snapshot is loaded by `loadModelsDevSnapshot()` in
+ * `buildDefaultRegistry()`.
  *
- * Availability is a SEPARATE concern — see `AvailableModelsCache` in
- * a later PR. The registry tells you "what does this model id mean";
- * `AvailableModelsCache` tells you "is the harness currently able to
- * serve it." Routing decisions consume both.
+ * Availability is a SEPARATE concern — see `AvailableModelsCache`
+ * (`config/available-models-cache.ts`). The registry tells you "what does
+ * this model id mean"; `AvailableModelsCache` tells you "is the harness
+ * currently able to serve it." Routing decisions consume both.
  *
  * @module config/model-registry
  */

--- a/packages/nexus-agents/src/mcp/middleware/tool-prerequisites.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-prerequisites.ts
@@ -130,6 +130,8 @@ export const TOOL_PREREQUISITES: Record<string, ToolPrerequisite> = {
  * added sensitive tool can't ship ungated by omission.
  */
 export const NO_PREREQUISITE: Record<string, string> = {
+  delegate_to_model:
+    'inspects a task and recommends a model + records the decision to tool-memory; no world-state precondition to gate',
   orchestrate: 'orchestration is self-contained; sub-tool calls carry their own gates',
   create_expert: 'in-memory expert creation; no external precondition',
   execute_expert:
@@ -147,7 +149,7 @@ export const NO_PREREQUISITE: Record<string, string> = {
   research_add:
     'arXiv fetch failures surface as a transient envelope from the handler; no useful pre-gate',
   research_add_source:
-    'GitHub metadata fetch is best-effort with graceful fallback; no useful pre-gate',
+    'quality_score is computed from caller-provided quality_signals only (no GitHub fetch); no useful pre-gate',
   research_catalog_review: 'operates on local catalog state already loaded by the handler',
   issue_triage:
     'untrusted-input safety (trust-tier classification, Rule of Two) is internal-handler logic per .rules/untrusted-input.md — not a call-time world-state predicate',

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -950,9 +950,10 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
 
   const description =
     'Execute multi-model consensus voting on a proposal. ' +
-    'Uses 7 specialized agent roles (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
-    'to vote on proposals with configurable strategies. ' +
-    'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514).';
+    'Uses 7 roles by default (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
+    'or 3 with quickMode (architect, security, scope_steward), voting with configurable strategies. ' +
+    'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514). ' +
+    "Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result.";
 
   const secureHandler = createSecureHandler(createConsensusVoteHandler(depsWithNotifier), {
     toolName: 'consensus_vote',

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.ts
@@ -309,7 +309,7 @@ export function registerDelegateToModelTool(server: McpServer, deps: DelegateDep
     'delegate_to_model',
     {
       description:
-        'Pick which EXISTING model should handle a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Read-only. (For drafting a registry entry for a new model, use `registry_import`.)',
+        'Pick which EXISTING model should handle a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Records the routing decision to tool-memory for learning feedback (not a pure read). (For drafting a registry entry for a new model, use `registry_import`.)',
       inputSchema: TOOL_SCHEMA,
       outputSchema: DelegateOutputSchema.shape,
 

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -282,7 +282,7 @@ function buildStructuredOutput(result: DevPipelineResult): Record<string, unknow
 }
 
 const RUN_DEV_PIPELINE_DESCRIPTION =
-  'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).';
+  "Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only). Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.";
 
 /**
  * Validates input, runs the dev pipeline, and shapes the result.

--- a/packages/nexus-agents/src/mcp/tools/memory-write.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-write.ts
@@ -302,7 +302,7 @@ export function registerMemoryWriteTool(server: McpServer, deps: MemoryWriteDeps
 
   const description =
     'Write a memory entry to a specific backend. ' +
-    'Supports session (learnings), belief (subject-predicate-object triples), ' +
+    'Supports session (learnings), belief assertions (subject + object; predicate fixed as `has_knowledge`), ' +
     'agentic (knowledge with attributes), adaptive (priority-scored), ' +
     'and typed (MIRIX-style semantic) backends.';
 

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -246,7 +246,7 @@ function selectStageRegistry(
 // Templates listed dynamically so a new entry in PIPELINE_TEMPLATES can't
 // drift this description (#2728 — previously hardcoded the pre-`general`
 // 4-template list).
-const RUN_PIPELINE_DESCRIPTION = `Single unified entry point for all pipeline templates (${listTemplateIds().join('/')}). Auto-detects template from task content or accepts an explicit override.`;
+const RUN_PIPELINE_DESCRIPTION = `Single unified entry point for all pipeline templates (${listTemplateIds().join('/')}). Auto-detects template from task content or accepts an explicit override. Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.`;
 
 /**
  * Run the adaptive pipeline for a plain goal string with default settings

--- a/packages/nexus-agents/src/mcp/tools/registry-import-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/registry-import-tool.ts
@@ -67,14 +67,17 @@ export function registerRegistryImportTool(server: McpServer, deps: RegistryImpo
       .enum(['anthropic', 'google', 'openai'])
       .describe('Model provider (anthropic, google, openai)'),
     modelId: z.string().min(1).describe('Provider model identifier'),
-    dryRun: z.boolean().optional().describe('Preview without persisting (default: true)'),
+    dryRun: z
+      .boolean()
+      .optional()
+      .describe('No-op flag echoed back in the response; the tool never persists regardless'),
   };
 
   const description =
     'Draft a registry ENTRY for a NEW model so routing can consider it later. ' +
     'Generates a ModelCapability YAML with conservative quality scores (5/10) for human review. ' +
-    'For picking among ALREADY-registered models, use `delegate_to_model`. ' +
-    'Use dryRun=true (default) to preview the entry without saving.';
+    'Always returns a draft entry for human review (never persists). ' +
+    'For picking among ALREADY-registered models, use `delegate_to_model`.';
 
   const secureHandler = createSecureHandler(registryImportHandler, {
     toolName: 'registry_import',

--- a/packages/nexus-agents/src/mcp/tools/registry-import-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/registry-import-types.ts
@@ -21,8 +21,12 @@ export const RegistryImportInputSchema = z.object({
     .describe('Model provider (anthropic, google, openai)'),
   /** Model identifier from the provider (e.g., "claude-4-opus-20260201"). */
   modelId: z.string().min(1).describe('Provider model identifier'),
-  /** Preview without persisting (default: true). */
-  dryRun: z.boolean().optional().default(true).describe('Preview without persisting'),
+  /** No-op flag echoed back in the response; the tool never persists regardless. */
+  dryRun: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('No-op flag echoed back in the response; the tool never persists regardless'),
 });
 
 export type RegistryImportInput = z.infer<typeof RegistryImportInputSchema>;

--- a/packages/nexus-agents/src/mcp/tools/repo-analyze-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/repo-analyze-tool.ts
@@ -64,7 +64,7 @@ export function registerRepoAnalyzeTool(server: McpServer, deps: RepoAnalyzeDeps
     depth: z
       .enum(['shallow', 'deep'])
       .optional()
-      .describe('Analysis depth: shallow (tree + README) or deep'),
+      .describe('Currently a no-op — the handler always runs the full analysis (both values identical)'),
   };
 
   const description =

--- a/packages/nexus-agents/src/mcp/tools/repo-analyze-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/repo-analyze-types.ts
@@ -23,12 +23,16 @@ export const RepoAnalyzeInputSchema = z.object({
       'Only HTTP/HTTPS URLs are allowed'
     )
     .describe('GitHub repository in "owner/name" format (e.g., "cloudfoundry/korifi") or full URL'),
-  /** Analysis depth: shallow (tree + README) or deep (full analysis). */
+  /**
+   * Currently a no-op: the handler ignores this flag and always runs the full
+   * analysis. Both values resolve to identical behavior; retained for input-shape
+   * stability until a distinct shallow path is implemented.
+   */
   depth: z
     .enum(['shallow', 'deep'])
     .optional()
     .default('shallow')
-    .describe('Analysis depth: shallow (tree + README) or deep (full analysis)'),
+    .describe('Currently a no-op — the handler always runs the full analysis (both values identical)'),
 });
 
 export type RepoAnalyzeInput = z.infer<typeof RepoAnalyzeInputSchema>;

--- a/packages/nexus-agents/src/mcp/tools/research-add-source.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-add-source.ts
@@ -2,8 +2,9 @@
  * nexus-agents/mcp - Research Add Source Tool
  *
  * MCP tool for adding non-paper sources (repos, tools, blogs) to the
- * research registry. Accepts pre-populated metadata or fetches from
- * GitHub via `gh` CLI (optional, graceful fallback).
+ * research registry. The quality_score is computed from the quality_signals
+ * the caller provides — no GitHub metadata is fetched (provide signals
+ * explicitly).
  *
  * @module mcp/tools/research-add-source
  * @see Issue #1580
@@ -64,7 +65,7 @@ export const ResearchAddSourceInputSchema = z.object({
       has_paper: z.boolean().optional(),
     })
     .optional()
-    .describe('Quality signals (auto-fetched for GitHub repos if omitted)'),
+    .describe('Quality signals used to compute quality_score; provide explicitly — no GitHub metadata is fetched'),
   techniques_extracted: z
     .array(z.string().max(100))
     .max(5)

--- a/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-catalog-review.ts
@@ -282,7 +282,7 @@ export function registerResearchCatalogReviewTool(
 
   const description =
     'Review auto-cataloged research references found during tool execution. ' +
-    'List pending references, approve them for registry addition, dismiss, or clear all.';
+    'List pending references, approve them for registry addition (optionally filing a GitHub issue), dismiss, or clear all.';
 
   const secureHandler = createSecureHandler(createCatalogReviewHandler(deps), {
     toolName: 'research_catalog_review',

--- a/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-graph-workflow.ts
@@ -215,7 +215,7 @@ async function handleRunGraphWorkflow(
 // ============================================================================
 
 const GRAPH_WORKFLOW_DESCRIPTION =
-  'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.';
+  "Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead. Supports dispatch: 'async' — returns a jobId immediately; poll get_job_result.";
 
 const GRAPH_WORKFLOW_SCHEMA = {
   workflow: z

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -434,7 +434,7 @@ export function registerRunWorkflowTool(server: McpServer, deps: RunWorkflowDeps
     'run_workflow',
     {
       description:
-        'Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching, checkpoints, or rollback, use `run_graph_workflow` instead.',
+        "Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching, checkpoints, or rollback, use `run_graph_workflow` instead. Supports mode: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.",
       inputSchema: toolInputSchema,
 
       annotations: getToolAnnotations('run_workflow'),

--- a/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-annotations.test.ts
@@ -81,7 +81,6 @@ describe('tool-annotations', () => {
 
   describe('read-only tools', () => {
     const readOnlyTools = [
-      'delegate_to_model',
       'list_experts',
       'list_workflows',
       'research_query',
@@ -105,6 +104,7 @@ describe('tool-annotations', () => {
 
   describe('state-mutating tools', () => {
     const mutatingTools = [
+      'delegate_to_model',
       'orchestrate',
       'create_expert',
       'execute_expert',
@@ -204,8 +204,8 @@ describe('tool-annotations', () => {
     });
 
     it('returns empty array when no effects match category', () => {
-      // delegate_to_model has no explicit side effects
-      const effects = getSideEffectsByCategory('delegate_to_model', 'explicit');
+      // list_experts has only an implicit side effect (rate-limit quota), no explicit.
+      const effects = getSideEffectsByCategory('list_experts', 'explicit');
       expect(effects).toEqual([]);
     });
   });

--- a/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-manifest.ts
@@ -176,12 +176,17 @@ export const TOOL_MANIFEST = [
     name: 'delegate_to_model',
     annotations: {
       title: 'Delegate to Model',
-      readOnlyHint: true,
+      // Not read-only: every call records the routing decision to tool-memory
+      // (recordLearning + runPromotionPipeline) for learning feedback.
+      readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: false,
     },
-    sideEffects: [{ category: 'implicit', description: 'Consumes rate limit quota' }],
+    sideEffects: [
+      { category: 'implicit', description: 'Consumes rate limit quota' },
+      { category: 'explicit', description: 'Records routing decision to tool-memory (learning feedback)' },
+    ],
   },
   {
     name: 'list_experts',

--- a/scripts/tool-descriptions-data.ts
+++ b/scripts/tool-descriptions-data.ts
@@ -25,11 +25,11 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
   execute_expert:
     'Run a task through an expert YOU PREVIOUSLY CREATED via `create_expert`. Requires the expertId returned by create_expert; not for ad-hoc execution.',
   run_workflow:
-    'Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching or per-node checkpoints, use `run_graph_workflow` instead.',
+    "Run a LINEAR (single-path) workflow template by name with typed inputs. For DAG-shaped workflows with branching or per-node checkpoints, use `run_graph_workflow` instead. Supports mode: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.",
   consensus_vote:
-    'Execute multi-model consensus voting on a proposal. Uses specialized agent roles to vote with configurable strategies.',
+    'Execute multi-model consensus voting on a proposal. Uses 7 roles by default (or 3 with quickMode), voting with configurable strategies. Supports async mode (returns a jobId to poll via get_job_result).',
   delegate_to_model:
-    'Pick which existing model should HANDLE a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Read-only.',
+    'Pick which existing model should HANDLE a task. Inspects task complexity and returns the best-fit model from the routing registry — does NOT add a new model. Records the routing decision to tool-memory for learning feedback (not a pure read).',
   list_experts:
     'Inventory of expert ROLES available to `create_expert` (architect, security, devex, etc.). Use this BEFORE create_expert to pick a role; returns role name and capability summary.',
   list_workflows:
@@ -57,7 +57,7 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
     'Get multi-CLI performance weather report with per-CLI success rates and adaptive routing bonuses.',
   issue_triage: 'Triage GitHub issues with trust classification and typed action recommendations.',
   run_graph_workflow:
-    'Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead.',
+    "Run a DAG-shaped workflow with per-node checkpoints, event streaming, and an audit trail. Checkpoints drive the executor in-process recovery (crash-resume + selective node retry) and inspection — the MCP call is fire-and-forget with NO caller resume input, and the checkpoint store is in-memory (not durable across process restarts). For straight linear templates, use `run_workflow` instead. Supports dispatch: 'async' — returns a jobId immediately; poll get_job_result.",
   execute_spec:
     'Execute an AI software factory spec through the full pipeline (parse, decompose, compile, execute, validate).',
   registry_import:
@@ -87,9 +87,9 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
   ci_health_check:
     "Diagnostic for CI infrastructure health (#3076). Composes GitHub status-page state (githubstatus.com/api/v2/components.json) + the configured repo's recent workflow-runs activity into one verdict { status: healthy|degraded|outage|unknown, signals }. Pessimistic combination — repo-level wedge downgrades a healthy status page. Use BEFORE long auto-merge waits to skip the wedge cycle when CI is broken org-wide. Reads GitHub state only; appends a local CI-health telemetry event per call (no remote state mutated, not strictly idempotent).",
   run_dev_pipeline:
-    'Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only).',
+    "Run the multi-agent development pipeline. Accepts direct task instructions, a plan file, or a spec file. Supports dry-run (plan+vote only). Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.",
   run_pipeline:
-    'Single unified entry point for all pipeline templates (dev/research/audit/greenfield/general). Auto-detects template from task content or accepts an explicit override.',
+    "Single unified entry point for all pipeline templates (dev/research/audit/greenfield/general). Auto-detects template from task content or accepts an explicit override. Supports dispatch: 'async' (non-dryRun runs) — returns a jobId immediately; poll get_job_result.",
   pr_review:
     'Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, security, devex, catfish, scope_steward) each emit approve/request_changes/abstain with reasoning and citations. Reuses consensus_vote infra; experimental.',
   supply_chain_tradeoff_panel:


### PR DESCRIPTION
## Summary

Fixes the 11 adversarially-verified findings from the #3519 JSDoc Phase-2 semantic-accuracy audit. Principle: every doc/description/annotation must match what the code actually does. Each finding was re-read against the cited code before editing.

## Findings + fixes

### HIGH
1. **delegate_to_model** — registered description said "Read-only." and the manifest set `readOnlyHint: true`, but the handler writes on every call (`recordToMemory` → `recordLearning` + `runPromotionPipeline`). Removed the "Read-only." claim (runtime description + doc-table), stated it records a routing decision to tool-memory, set `readOnlyHint: false` with an explicit side-effect entry in `TOOL_MANIFEST`. Reconciled the read-only/mutating annotation tests and added `delegate_to_model` to `NO_PREREQUISITE` (the readOnly flip triggered the #2652 prerequisite-decision gate).

### MEDIUM
2. **model-registry** module doc — resolution chain omitted the `manifest` (#2547) and `generated` (#3293) tiers. Rewrote to: modelHints/alias → manifest → in-tree → models.dev → generated → derived → universal-default (verified against the constructor's lowest-priority-first load order).
3. **consensus_vote** — hardcoded "7 specialized agent roles". Now "7 roles by default (or 3 with quickMode); supports async mode (returns a jobId to poll via get_job_result)."
4. **registry_import** — `dryRun` framed as a save-toggle, but the tool never persists (`persisted: false` always). **Kept** `dryRun` (handler echoes it into the response and 8 tests assert pass-through — removal unsafe); reworded schema describes + the registered description to "Always returns a draft entry for human review (never persists)" and the param as a no-op echo.
5. **repo_analyze** — `depth` (shallow/deep) is ignored by the handler (zero references). **Kept** `depth` (3 schema tests assert parse-shape; removal would touch the public input schema + tool-reference and delete tests); reworded both describes to "Currently a no-op — the handler always runs the full analysis."
6. **research_add_source** — module JSDoc + schema describe claimed GitHub `gh`-CLI auto-fetch the handler never performs. Deleted the claims; quality_score is computed from caller-provided quality_signals only. Also corrected the stale `NO_PREREQUISITE` reason (same false claim).

### LOW
7. **composite-router** module doc — "Scoring (parallel)" → "Scoring (sequential, dependency-ordered)" (`runScoringStages` awaits stages one-by-one, threading `filtered`).
8. **model-registry** module doc — replaced stale "models.dev snapshot loader lands in PR 4" / "AvailableModelsCache … in a later PR" forward-refs with present-tense accurate descriptions (both shipped).
9. **memory_write** — "belief (subject-predicate-object triples)" → "belief assertions (subject + object; predicate fixed as `has_knowledge`)" (`writeToBelief` hardcodes the predicate).
10. **research_catalog_review** — noted the optional GitHub-issue side-effect on approve+`createIssue:true`.
11. **4 pipeline tools** — documented the async dispatch capability. `run_workflow` uses `mode: 'async'`; `run_dev_pipeline` / `run_pipeline` / `run_graph_workflow` use `dispatch: 'async'` (dev/pipeline gate async on non-dryRun). Matched each tool's actual param name.

## Dead-param judgment calls

- **registry_import `dryRun`**: documented as no-op, NOT removed — the response echoes `dryRun` and `registry-import-tool.test.ts` / `registry-import.test.ts` assert pass-through.
- **repo_analyze `depth`**: documented as no-op, NOT removed — schema tests assert default/accept/reject and removal would mutate the public input schema + tool-reference artifacts.

No schema params removed → changeset is `patch`.

## Gates (all green)

- `check-mcp-description-drift.ts`: ✓ 46 tools (runtime descriptions + `TOOL_DESCRIPTIONS` doc-table updated in lockstep)
- `generate-tool-reference.ts --check`: ✓ (regenerated 9 `docs/reference/tools/*.md`)
- `generate-repo-index.ts --check`: ✓ up to date
- `inject-governance.ts check`: ✓ MCP Tools: 46 — manifest/handler parity + tool-count intact; delegate_to_model's `readOnlyHint` reconciled with its prerequisite decision
- `tsc --noEmit`: ✓ clean
- `eslint` (changed files): ✓ clean
- Tested: tool-annotations, tool-manifest, annotation-proxy, index, registry-import(-tool), repo-analyze-tool, consensus-vote, delegate-to-model, memory-write, research-catalog-review, dev-pipeline-tool, pipeline-tool, run-workflow, run-graph-workflow, model-registry, tool-prerequisites — all pass.

delegate_to_model's `readOnlyHint` is now `false`, consistent with the handler's intentional tool-memory write (observability, not removed). The #3209 CLI vote-agent-count fix and this MCP description stay consistent (7 default / 3 quick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)