### PR TITLE
feat(governance): warn-first governor-path pr_review audit gate — sha-bound, chain-fail-closed (#3831, Epic B)

### DIFF
--- a/.changeset/governor-review-gate-3831.md
+++ b/.changeset/governor-review-gate-3831.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): warn-first governor-path pr_review audit gate — sha-bound, chain-fail-closed (#3831, Epic B)
+
+Stage 1 of governance-of-the-governor (#3829): a WARN-FIRST CI gate asserting
+that a PR touching the GOVERNOR PATHS (the governance-of-the-governor entries in
+`/CODEOWNERS`) carries a recorded, SHA-BOUND, tamper-evident `pr_review` audit
+record before merge.
+
+- New `PrReviewRecord` Zod schema + tamper-evident record SET model
+  (`src/audit/pr-review-record.ts`), mirroring the #3927 vote-record model: each
+  record is self-hashed and position-independent (merge-safe), and the self-hash
+  covers `prNumber` + `headSha` + `verdict` (the sha-binding) plus the monotonic
+  `sequence`. `verifyPrReviewRecordSet` detects edits (`hash_mismatch`), missing
+  hashes, and omissions (`sequence_gap`); duplicate sequences are benign forks.
+- New gate `scripts/check-governor-review.ts`. The governor path set is DERIVED
+  from `/CODEOWNERS` (single source, no divergent copy). SPLIT fail-mode: chain/
+  set INTEGRITY is fail-CLOSED (a tampered ledger exits 1 — tamper evidence),
+  record ABSENCE is WARN-FIRST (exits 0 with an actionable annotation). A record
+  satisfies the gate only when it matches the PR's number AND head sha — a stale
+  sha does not count. Genesis exemption via `governance/governor-review-genesis.txt`.
+- New `.github/workflows/governor-review.yml` (paths-filtered on the governor set;
+  non-required, warn-first; integrity break still fails the job).
+- Committed empty ledger `governance/pr-review-records.jsonl` (+ `merge=union`).
+
+The PRODUCER (pr_review committing records, the caller-commits flow shared with
+#3927) and the fail-closed FLIP (absence → block) are tracked follow-ons.

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,10 @@
 # independent lines, so a union merge concatenates them conflict-free —
 # duplicate sequences are a benign fork signal, not corruption.
 governance/vote-records.jsonl merge=union
+
+# PR-review audit ledger (#3831, Epic B). Same tamper-evident record SET +
+# monotonic sequence model as the vote-record ledger above (mirrors #3927):
+# each line is a self-hashed, SHA-BOUND, position-independent record. Concurrent
+# branches that each append a review produce independent lines, so a union merge
+# concatenates them conflict-free — duplicate sequences are a benign fork signal.
+governance/pr-review-records.jsonl merge=union

--- a/.github/workflows/governor-review.yml
+++ b/.github/workflows/governor-review.yml
@@ -1,0 +1,79 @@
+# Governor-path pr_review audit gate (#3831, Epic B — governance of the governor)
+#
+# WARN-FIRST. Asserts that a PR touching the GOVERNOR PATHS (the
+# governance-of-the-governor entries in /CODEOWNERS) carries a recorded,
+# SHA-BOUND, tamper-evident pr_review audit record (governance/pr-review-records.jsonl).
+#
+# SPLIT FAIL-MODE — encoded in the script's exit code, NOT continue-on-error, so
+# the two paths stay distinct:
+#   - chain/set INTEGRITY broken (tampered ledger) => script exits 1 => job FAILS
+#     (fail-closed, condition 2). This is the path that must be able to block.
+#   - matching sha-bound record ABSENT => script prints a ::warning:: and exits 0
+#     => job SUCCEEDS but surfaces the annotation (warn-first, condition 2).
+#
+# This job is intentionally NOT added to branch protection as a required check in
+# this stage, so even the (rare) integrity failure does not hard-block a human
+# merge until the fail-closed FLIP follow-on. Flipping absence to a block and
+# making this required are tracked follow-ons.
+#
+# The `paths:` filter restricts the trigger to the governor path set. It is kept
+# in lockstep with the governance-of-the-governor section of /CODEOWNERS (the
+# single source the gate script itself parses); if those CODEOWNERS entries
+# change, update this filter to match.
+
+name: Governor Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'packages/nexus-agents/src/audit/**'
+      - 'packages/nexus-agents/src/governance/**'
+      - 'scripts/inject-governance.ts'
+      - 'governance/**'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'CODEOWNERS'
+
+permissions:
+  contents: read
+
+jobs:
+  governor-review:
+    name: Governor-path pr_review audit gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Compute changed files (base..head)
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          FILES=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          {
+            echo 'files<<FILES_EOF'
+            echo "${FILES}"
+            echo 'FILES_EOF'
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Run governor-review gate (warn-first; integrity fail-closed)
+        env:
+          # The gate gets the PR number + head sha from CI here — sha-binding
+          # (condition 1) rests on github.event.pull_request.head.sha.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        # No continue-on-error: the script encodes warn (exit 0) vs fail-closed
+        # integrity break (exit 1) in its exit code. A non-zero exit here is a
+        # tampered ledger and SHOULD surface as a job failure.
+        run: npx tsx scripts/check-governor-review.ts

--- a/governance/governor-review-genesis.txt
+++ b/governance/governor-review-genesis.txt
@@ -1,0 +1,14 @@
+# Governor-review genesis allowlist (#3831, Epic B) — condition 5.
+#
+# PR numbers here are EXEMPT from the warn-first governor-review gate
+# (scripts/check-governor-review.ts): they pre-date the pr_review record
+# convention and so legitimately carry no sha-bound record.
+#
+# ONE-TIME BOOTSTRAP, NOT A PERMANENT ESCAPE HATCH. The introducing PR
+# (#3831 itself) is listed so it does not false-warn against its own gate.
+# Once the PRODUCER lands (pr_review committing records — the tracked
+# follow-on), no further entries should be added; a new exemption after that
+# point is a governance smell, not a bootstrap.
+#
+# Format: one PR number per line; `#` starts a comment.
+3831

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -86,6 +86,31 @@ export {
 } from './vote-record-store.js';
 export type { BuildVoteRecordInput, PersistVoteRecordOptions } from './vote-record-store.js';
 
+// PR-review audit record (#3831, Epic B) — committable, tamper-evident,
+// SHA-BOUND record SET + monotonic sequence (mirrors the #3927 vote-record
+// model). Read by the warn-first governor-review gate.
+export {
+  PrReviewRecordSchema,
+  PrReviewVerdictSchema,
+  PrReviewVoteCountsSchema,
+  computePrReviewRecordHash,
+  verifyPrReviewRecordSet,
+} from './pr-review-record.js';
+export type {
+  PrReviewRecord,
+  PrReviewVerdict,
+  PrReviewVoteCounts,
+  PrReviewRecordVerification,
+} from './pr-review-record.js';
+export {
+  PR_REVIEW_RECORDS_REL_PATH,
+  PR_REVIEW_RECORDS_PATH_ENV,
+  buildPrReviewRecord,
+  resolvePrReviewRecordsPath,
+  readPrReviewRecords,
+} from './pr-review-record-store.js';
+export type { BuildPrReviewRecordInput } from './pr-review-record-store.js';
+
 // SecureHandler Integration
 export {
   actorFromContext,

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -1,0 +1,151 @@
+/**
+ * nexus-agents/audit - PR-Review Audit Record Store (#3831, Epic B).
+ *
+ * Reads/builds the COMMITTABLE, append-only, tamper-evident pr-review ledger at
+ * `<repo-root>/governance/pr-review-records.jsonl` so the WARN-FIRST governor-
+ * review gate (`scripts/check-governor-review.ts`, #3831) can QUERY it from CI:
+ * does a sha-bound, verified review exist for THIS PR's number AND head sha?
+ *
+ * SCOPE (#3831 Stage 1). This module deliberately exposes only the PURE builder
+ * ({@link buildPrReviewRecord}) and the READER ({@link readPrReviewRecords}) plus
+ * the path resolution — the seam the gate and tests need. The PRODUCER (pr_review
+ * writing records as a side effect, the caller-commits flow shared with #3927) is
+ * a tracked FOLLOW-ON and intentionally NOT wired here, so this stage adds the
+ * gate + schema + verification without changing the pr_review write path.
+ *
+ * MERGE SAFETY (mirrors #3927). The ledger is a SET, not a chain: `sequence` is
+ * assigned as (max existing sequence)+1, and the self-hash excludes
+ * `previousHash`, so two branches that each append from the same tip merge
+ * conflict-free under the `governance/pr-review-records.jsonl merge=union`
+ * attribute. Duplicate sequences from such a merge are a benign fork signal.
+ *
+ * @module audit/pr-review-record-store
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+
+import { findRepoRoot } from '../config/repo-root-detection.js';
+
+import type { PrReviewRecord, PrReviewVerdict, PrReviewVoteCounts } from './pr-review-record.js';
+import { PrReviewRecordSchema, computePrReviewRecordHash } from './pr-review-record.js';
+
+/** Repo-relative committable artifact path (read by the gate/CI). */
+export const PR_REVIEW_RECORDS_REL_PATH = 'governance/pr-review-records.jsonl';
+
+/**
+ * Env var to force the artifact path (mirrors #3927's `NEXUS_VOTE_RECORDS_PATH`).
+ * When set non-empty it is used directly (resolved to an absolute path) and the
+ * cwd/{@link findRepoRoot} detection is skipped — the escape hatch for the
+ * future producer running outside the repo (e.g. co-located/CI contexts).
+ */
+export const PR_REVIEW_RECORDS_PATH_ENV = 'NEXUS_PR_REVIEW_RECORDS_PATH';
+
+/** Max summary chars retained in the human record. */
+const MAX_SUMMARY_RECORD_CHARS = 500;
+
+/** Inputs for {@link buildPrReviewRecord} — the finalized review data. */
+export interface BuildPrReviewRecordInput {
+  readonly prNumber: number;
+  /** The 40-hex head commit SHA the review was run against (sha-binding). */
+  readonly headSha: string;
+  readonly verdict: PrReviewVerdict;
+  readonly verified: boolean;
+  readonly voteCounts: PrReviewVoteCounts;
+  readonly summary: string;
+  readonly correlationId?: string | undefined;
+  readonly recordedAt?: string | undefined;
+  /**
+   * Monotonic sequence number for this record. Defaults to 0 (first record)
+   * when omitted; the future producer supplies (max existing sequence)+1.
+   */
+  readonly sequence?: number | undefined;
+  /**
+   * Advisory tip hash (audit texture only). NOT covered by the self-hash and
+   * NOT verified — retained so a reviewer can see the write-time tip.
+   */
+  readonly previousHash?: string | undefined;
+}
+
+/**
+ * Construct a fully self-hashed {@link PrReviewRecord} from a completed review.
+ * Pure (no I/O) so it is unit-testable and reusable by the gate seam and the
+ * future producer. The self-hash covers `prNumber`/`headSha`/`verdict`/`sequence`
+ * (the sha-binding, condition 1) but EXCLUDES `previousHash`. The summary is
+ * stored truncated.
+ */
+export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRecord {
+  const summaryTruncated =
+    input.summary.length > MAX_SUMMARY_RECORD_CHARS
+      ? input.summary.slice(0, MAX_SUMMARY_RECORD_CHARS) + '...'
+      : input.summary;
+  const payload: Omit<PrReviewRecord, 'hash'> = {
+    version: '1.0',
+    sequence: input.sequence ?? 0,
+    prNumber: input.prNumber,
+    headSha: input.headSha,
+    recordedAt: input.recordedAt ?? new Date().toISOString(),
+    verdict: input.verdict,
+    verified: input.verified,
+    voteCounts: {
+      approve: input.voteCounts.approve,
+      request_changes: input.voteCounts.request_changes,
+      abstain: input.voteCounts.abstain,
+      error: input.voteCounts.error,
+      total: input.voteCounts.total,
+    },
+    summary: summaryTruncated,
+    ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+    ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
+  };
+  return { ...payload, hash: computePrReviewRecordHash(payload) };
+}
+
+/**
+ * Resolve the committable artifact path (mirrors #3927). Precedence:
+ *  1. {@link PR_REVIEW_RECORDS_PATH_ENV} when set non-empty — a RELATIVE value is
+ *     resolved against `process.cwd()` to an absolute path; an already-absolute
+ *     value is returned unchanged.
+ *  2. otherwise `<repo-root>/governance/pr-review-records.jsonl` resolved from
+ *     {@link findRepoRoot}(`process.cwd()`).
+ * Returns `undefined` when neither yields a path. A whitespace-only override is
+ * treated as unset (falls through to root detection).
+ */
+export function resolvePrReviewRecordsPath(): string | undefined {
+  const envPath = process.env[PR_REVIEW_RECORDS_PATH_ENV];
+  if (envPath !== undefined && envPath.trim() !== '') {
+    return isAbsolute(envPath) ? envPath : resolve(envPath);
+  }
+  const root = findRepoRoot(process.cwd());
+  if (root === null) return undefined;
+  return join(root, PR_REVIEW_RECORDS_REL_PATH);
+}
+
+/**
+ * Read the persisted pr-review record set from disk. The GATE SEAM (#3831):
+ * `check-governor-review.ts` reads these records, verifies the set
+ * ({@link verifyPrReviewRecordSet}), and queries for a record matching the PR's
+ * number AND head sha. File-line order is NOT significant (the records are a
+ * set). Returns the parsed records and any line that failed to parse.
+ */
+export function readPrReviewRecords(filePath: string): {
+  readonly records: PrReviewRecord[];
+  readonly invalidLines: number[];
+} {
+  const records: PrReviewRecord[] = [];
+  const invalidLines: number[] = [];
+  if (!existsSync(filePath)) return { records, invalidLines };
+  const lines = readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim() !== '');
+  for (const [i, line] of lines.entries()) {
+    try {
+      const parsed = PrReviewRecordSchema.safeParse(JSON.parse(line));
+      if (parsed.success) records.push(parsed.data);
+      else invalidLines.push(i + 1);
+    } catch {
+      invalidLines.push(i + 1);
+    }
+  }
+  return { records, invalidLines };
+}

--- a/packages/nexus-agents/src/audit/pr-review-record.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the pr-review TAMPER-EVIDENT, SHA-BOUND RECORD SET (#3831, Epic B).
+ * Mirrors the vote-record tests (#3927). Core properties:
+ *  - the self-hash covers the full payload INCLUDING prNumber + headSha + verdict
+ *    (the sha-binding, condition 1), so editing any of them is a `hash_mismatch`;
+ *  - the ledger is a SET, not a chain: order does not matter, concurrent forks
+ *    (duplicate sequences) are benign, omission shows up as a `sequence_gap`;
+ *  - `buildPrReviewRecord` produces a record that verifies.
+ *
+ * @module audit/pr-review-record.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { PrReviewRecord } from './pr-review-record.js';
+import { computePrReviewRecordHash, verifyPrReviewRecordSet } from './pr-review-record.js';
+import { buildPrReviewRecord } from './pr-review-record-store.js';
+
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+
+/**
+ * Build a self-hashed record at `sequence`. `previousHash` is advisory (NOT
+ * covered by the hash) — set it to prove verification ignores it.
+ */
+function makeRecord(
+  prNumber: number,
+  sequence: number,
+  overrides: Partial<Omit<PrReviewRecord, 'hash'>> = {}
+): PrReviewRecord {
+  const payload: Omit<PrReviewRecord, 'hash'> = {
+    version: '1.0',
+    sequence,
+    prNumber,
+    headSha: SHA_A,
+    recordedAt: '2026-06-15T00:00:00.000Z',
+    verdict: 'approve',
+    verified: false,
+    voteCounts: { approve: 3, request_changes: 0, abstain: 0, error: 0, total: 3 },
+    summary: 'looks good',
+    ...overrides,
+  };
+  return { ...payload, hash: computePrReviewRecordHash(payload) };
+}
+
+describe('verifyPrReviewRecordSet (#3831)', () => {
+  it('verifies a clean set and is order-independent', () => {
+    const a = makeRecord(100, 0);
+    const b = makeRecord(101, 1);
+    expect(verifyPrReviewRecordSet([a, b]).ok).toBe(true);
+    // Reversed order still verifies (set, not chain).
+    expect(verifyPrReviewRecordSet([b, a]).ok).toBe(true);
+  });
+
+  it('verifies an empty set trivially', () => {
+    expect(verifyPrReviewRecordSet([])).toEqual({ ok: true, recordCount: 0 });
+  });
+
+  it('ignores the advisory previousHash in the hash', () => {
+    const withPrev = makeRecord(100, 0, { previousHash: 'f'.repeat(64) });
+    expect(verifyPrReviewRecordSet([withPrev]).ok).toBe(true);
+  });
+
+  it('DETECTS a flipped verdict as hash_mismatch (tamper evidence)', () => {
+    const rec = makeRecord(100, 0);
+    const tampered: PrReviewRecord = { ...rec, verdict: 'request_changes' };
+    const result = verifyPrReviewRecordSet([tampered]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS an edited headSha as hash_mismatch (sha-binding)', () => {
+    const rec = makeRecord(100, 0);
+    // Swap the reviewed sha without recomputing the hash → tamper evidence.
+    const tampered: PrReviewRecord = { ...rec, headSha: SHA_B };
+    const result = verifyPrReviewRecordSet([tampered]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS a missing hash', () => {
+    const rec = makeRecord(100, 0);
+    const result = verifyPrReviewRecordSet([{ ...rec, hash: '' }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_hash');
+  });
+
+  it('DETECTS a sequence gap (omission)', () => {
+    const a = makeRecord(100, 0);
+    const c = makeRecord(102, 2); // 1 is missing
+    const result = verifyPrReviewRecordSet([a, c]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('sequence_gap');
+  });
+
+  it('treats duplicate sequences (concurrent forks) as benign', () => {
+    const a = makeRecord(100, 0);
+    const b = makeRecord(101, 1);
+    const bFork = makeRecord(202, 1); // same sequence, different PR
+    const result = verifyPrReviewRecordSet([a, b, bFork]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.forks).toEqual([1]);
+  });
+});
+
+describe('buildPrReviewRecord (#3831)', () => {
+  it('produces a record that verifies and binds the head sha', () => {
+    const rec = buildPrReviewRecord({
+      prNumber: 4242,
+      headSha: SHA_B,
+      verdict: 'request_changes',
+      verified: true,
+      voteCounts: { approve: 1, request_changes: 3, abstain: 1, error: 0, total: 5 },
+      summary: 'needs work',
+      sequence: 0,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+    });
+    expect(rec.headSha).toBe(SHA_B);
+    expect(rec.verdict).toBe('request_changes');
+    expect(verifyPrReviewRecordSet([rec]).ok).toBe(true);
+  });
+
+  it('truncates an over-long summary', () => {
+    const long = 'x'.repeat(2000);
+    const rec = buildPrReviewRecord({
+      prNumber: 1,
+      headSha: SHA_A,
+      verdict: 'approve',
+      verified: false,
+      voteCounts: { approve: 1, request_changes: 0, abstain: 0, error: 0, total: 1 },
+      summary: long,
+    });
+    expect(rec.summary.length).toBeLessThan(long.length);
+    expect(rec.summary.endsWith('...')).toBe(true);
+    expect(verifyPrReviewRecordSet([rec]).ok).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -1,0 +1,289 @@
+/**
+ * nexus-agents/audit - PR-Review Audit Record (#3831, Epic B — governance of
+ * the governor).
+ *
+ * A committed, append-only, tamper-EVIDENT record of a completed `pr_review`
+ * over a GOVERNOR-PATH PR, persisted so a WARN-FIRST CI gate
+ * (`scripts/check-governor-review.ts`, #3831) can assert that a PR touching the
+ * governor's own paths (the /CODEOWNERS governance-of-the-governor list) carries
+ * a recorded, SHA-BOUND review before merge — without the gate re-executing the
+ * review (it QUERIES the ledger; pr_review is never re-run in the gate).
+ *
+ * MODEL: TAMPER-EVIDENT RECORD SET + MONOTONIC SEQUENCE. This MIRRORS the
+ * authentic-vote-record model (#3927, `vote-record.ts`) exactly, for the same
+ * reason: the ledger is a multi-branch committable artifact, so a linear hash
+ * chain (whose `hash` folds in the prior record's hash) cannot survive a
+ * concurrent-branch git merge. Two branches each appending from the same tip
+ * produce records claiming the same `previousHash`, and any merge-concatenation
+ * breaks the back-link check. So this ledger is an UNORDERED SET of self-hashed
+ * records plus a monotonic `sequence`: each record's hash is POSITION-INDEPENDENT
+ * (covers `sequence` but NOT `previousHash`), stable across merges and reorders.
+ * `previousHash` is retained ADVISORILY for audit texture but does NOT
+ * participate in verification. Omission is detected via SEQUENCE GAPS; concurrent
+ * forks (two records sharing a sequence) are a BENIGN signal, not a failure.
+ *
+ * SHA-BINDING (condition 1 of the #3831 ratification). The self-`hash` covers
+ * `prNumber` + **`headSha`** + `verdict` + the review summary content. Binding
+ * the record to the exact `headSha` it reviewed is what makes the gate NOT
+ * theater: a record produced against a STALE head sha does NOT satisfy a later
+ * push (the gate matches `prNumber` AND `headSha`), and the record's content
+ * cannot be edited to claim a different sha/verdict without breaking the hash.
+ *
+ * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
+ * As in #3897/#3927: the audit-event chain (`computeEventHash` in
+ * audit-logger.ts) hashes only the stable HEAD fields and intentionally NOT
+ * `metadata`, so riding a metadata payload would leave the verdict OUTSIDE the
+ * hash — an attacker could flip `request_changes`→`approve` without breaking any
+ * hash. This record instead folds EVERY authenticity-bearing field (the PR
+ * number, the head sha, the verdict, the verified flag, the vote counts, and the
+ * `sequence`) into the self-hash, so editing any of them is a `hash_mismatch`.
+ * Cryptographic signing/provenance is DEFERRED (mirrors the #3897 follow-up).
+ *
+ * @module audit/pr-review-record
+ */
+
+import * as crypto from 'node:crypto';
+
+import { z } from 'zod';
+
+/**
+ * The aggregate verdict a `pr_review` resolves to, mirroring the pr-review
+ * decision vocabulary (`approve` / `request_changes` / `abstain`).
+ */
+export const PrReviewVerdictSchema = z.enum(['approve', 'request_changes', 'abstain']);
+export type PrReviewVerdict = z.infer<typeof PrReviewVerdictSchema>;
+
+/** The per-review voter-tally summary mirrored from the pr_review aggregate. */
+export const PrReviewVoteCountsSchema = z
+  .object({
+    approve: z.number().int().nonnegative(),
+    request_changes: z.number().int().nonnegative(),
+    abstain: z.number().int().nonnegative(),
+    error: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  })
+  .strict();
+export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
+
+/**
+ * One authentic, self-hashed pr-review record. The `hash` covers every
+ * authenticity field INCLUDING `prNumber`, `headSha`, `verdict`, and `sequence`
+ * but EXCLUDING `previousHash`, so the record is tamper-EVIDENT and
+ * POSITION-INDEPENDENT: any edit to a persisted line is detected by
+ * {@link verifyPrReviewRecordSet} as a `hash_mismatch`, while reordering file
+ * lines or merging concurrent branches does NOT break the hash.
+ */
+export const PrReviewRecordSchema = z
+  .object({
+    /** Schema version. '1.0' is the initial record-set+sequence model (#3831). */
+    version: z.literal('1.0'),
+    /**
+     * Monotonic sequence number (integer ≥ 0). Assigned as (max existing
+     * sequence)+1 at write time. Sorted, the set of sequences must cover
+     * 0..maxSeq with no gap (omission detection); DUPLICATE sequences are a
+     * benign concurrent-fork signal, not tampering.
+     */
+    sequence: z.number().int().nonnegative(),
+    /** The PR number the review covers. */
+    prNumber: z.number().int().positive(),
+    /**
+     * The 40-hex head commit SHA the review was run against. SHA-BINDING
+     * (condition 1): the gate matches THIS sha — a record for a stale head does
+     * NOT satisfy a later push, and the hash below covers it so it cannot be
+     * edited to claim a different reviewed sha.
+     */
+    headSha: z.string().regex(/^[0-9a-f]{40}$/, 'headSha must be a 40-char lowercase hex commit sha'),
+    /** ISO-8601 timestamp the review was recorded. */
+    recordedAt: z.string().min(1),
+    /** The resolved aggregate verdict. */
+    verdict: PrReviewVerdictSchema,
+    /**
+     * Whether the aggregate carried a VERIFIED finding (the 4-point gate). A
+     * `request_changes` with `verified: true` is a strict blocker; covered by the
+     * hash so it cannot be flipped without detection.
+     */
+    verified: z.boolean(),
+    /** Per-decision voter tally from the pr_review aggregate. */
+    voteCounts: PrReviewVoteCountsSchema,
+    /** Truncated human-readable review summary for the reviewer record. */
+    summary: z.string(),
+    /** Optional correlation/decision id linking to the cost rollup / trace. */
+    correlationId: z.string().min(1).optional(),
+    /**
+     * ADVISORY hash of the tip record at write time (absent for the first).
+     * Retained for audit texture but NOT covered by `hash` and NOT verified —
+     * the record-set model is position-independent (mirrors #3927).
+     */
+    previousHash: z.string().length(64).optional(),
+    /** SHA-256 over every field above EXCEPT `previousHash` (and except `hash`). */
+    hash: z.string().length(64),
+  })
+  .strict();
+export type PrReviewRecord = z.infer<typeof PrReviewRecordSchema>;
+
+/** The payload fields (everything except `hash`) — the self-hash projection. */
+type PrReviewRecordPayload = Omit<PrReviewRecord, 'hash'>;
+
+/**
+ * Compute the SHA-256 over the canonical payload projection. Folds in EVERY
+ * authenticity-bearing field — crucially `prNumber`, `headSha`, and `verdict`
+ * (the sha-binding, condition 1) plus the monotonic `sequence` — but EXCLUDES
+ * `previousHash`, so the hash is position-independent and stable across
+ * concurrent-branch merges and file reorders. Built field-by-field (not
+ * `JSON.stringify(record)`) so key-order is deterministic regardless of how the
+ * object was constructed; the nested `voteCounts` is likewise rebuilt in schema
+ * order so a formatter / `jq -S` / merge tool that reorders keys must NOT flip a
+ * legitimate record to `hash_mismatch` (mirrors #3962).
+ */
+export function computePrReviewRecordHash(payload: PrReviewRecordPayload): string {
+  const canonical = JSON.stringify({
+    version: payload.version,
+    sequence: payload.sequence,
+    prNumber: payload.prNumber,
+    headSha: payload.headSha,
+    recordedAt: payload.recordedAt,
+    verdict: payload.verdict,
+    verified: payload.verified,
+    // Rebuild voteCounts in schema order so the hash does not depend on how the
+    // nested object's keys were ordered (mirrors #3962).
+    voteCounts: {
+      approve: payload.voteCounts.approve,
+      request_changes: payload.voteCounts.request_changes,
+      abstain: payload.voteCounts.abstain,
+      error: payload.voteCounts.error,
+      total: payload.voteCounts.total,
+    },
+    summary: payload.summary,
+    correlationId: payload.correlationId ?? null,
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/**
+ * Discriminated result from {@link verifyPrReviewRecordSet}. On success it may
+ * surface `forks` — the sequence numbers that appear on more than one record (a
+ * benign concurrent-branch signal, NOT tampering). On failure it names the
+ * tamper/omission signal: `hash_mismatch` (a record's content was edited),
+ * `missing_hash` (a record carries no hash), or `sequence_gap` (a record is
+ * missing from the 0..maxSeq run — an omission).
+ */
+export type PrReviewRecordVerification =
+  | { ok: true; recordCount: number; forks?: number[] }
+  | {
+      ok: false;
+      reason: 'hash_mismatch' | 'missing_hash' | 'sequence_gap';
+      recordIndex: number;
+      prNumber: number;
+      detail: string;
+    };
+
+/** Per-record self-hash check; null when the record passes. */
+function verifyPrReviewRecord(
+  record: PrReviewRecord,
+  index: number
+): PrReviewRecordVerification | null {
+  if (record.hash.length === 0) {
+    return {
+      ok: false,
+      reason: 'missing_hash',
+      recordIndex: index,
+      prNumber: record.prNumber,
+      detail: `record at index ${String(index)} has no hash`,
+    };
+  }
+  const recomputed = computePrReviewRecordHash(record);
+  if (recomputed !== record.hash) {
+    return {
+      ok: false,
+      reason: 'hash_mismatch',
+      recordIndex: index,
+      prNumber: record.prNumber,
+      detail: `record at index ${String(index)} stored hash=${record.hash} does not match recomputed=${recomputed}`,
+    };
+  }
+  return null;
+}
+
+/** Tally of sequence number → how many records carry it, plus the max seen. */
+interface SequenceCensus {
+  readonly counts: ReadonlyMap<number, number>;
+  readonly maxSeq: number;
+}
+
+/** Count how many records carry each sequence number and find the max. */
+function censusSequences(records: readonly PrReviewRecord[]): SequenceCensus {
+  const counts = new Map<number, number>();
+  let maxSeq = 0;
+  for (const record of records) {
+    counts.set(record.sequence, (counts.get(record.sequence) ?? 0) + 1);
+    if (record.sequence > maxSeq) maxSeq = record.sequence;
+  }
+  return { counts, maxSeq };
+}
+
+/** First missing sequence in `0..maxSeq`, or null when the run is complete. */
+function firstSequenceGap({ counts, maxSeq }: SequenceCensus): number | null {
+  for (let seq = 0; seq <= maxSeq; seq++) {
+    if (!counts.has(seq)) return seq;
+  }
+  return null;
+}
+
+/** Sequence numbers carried by more than one record (concurrent forks), ascending. */
+function forkSequences({ counts }: SequenceCensus): number[] {
+  const forks: number[] = [];
+  for (const [seq, count] of counts) {
+    if (count > 1) forks.push(seq);
+  }
+  forks.sort((a, b) => a - b);
+  return forks;
+}
+
+/**
+ * Verify a tamper-evident SET of pr-review records (mirrors
+ * {@link verifyVoteRecordSet}, #3927). For each record, the self-hash must
+ * recompute from its payload (covers `prNumber`/`headSha`/`verdict`/`sequence`,
+ * excludes `previousHash`). Order of the array does NOT matter — it is a set, not
+ * a chain. Semantics:
+ *
+ * - Any record whose content was edited → `hash_mismatch`. Empty hash →
+ *   `missing_hash`. Returns the first such record (array-order scan).
+ * - The set of sequence numbers, sorted, must cover `0..maxSeq` with no missing
+ *   value. A GAP (an omitted/deleted record) → `sequence_gap` naming the first
+ *   missing sequence.
+ * - DUPLICATE sequence numbers are a BENIGN concurrent-fork signal (two branches
+ *   appended from the same tip, then merged): NOT a failure. They are surfaced on
+ *   the success result as `forks` (the duplicated sequence numbers, ascending).
+ *
+ * An empty set verifies trivially.
+ */
+export function verifyPrReviewRecordSet(
+  records: readonly PrReviewRecord[]
+): PrReviewRecordVerification {
+  // 1) Self-hash every record (order-independent).
+  for (let i = 0; i < records.length; i++) {
+    const failure = verifyPrReviewRecord(records[i] as PrReviewRecord, i);
+    if (failure !== null) return failure;
+  }
+
+  if (records.length === 0) return { ok: true, recordCount: 0 };
+
+  // 2) Sequence coverage: 0..maxSeq with no gap (omission); forks are benign.
+  const census = censusSequences(records);
+  const gap = firstSequenceGap(census);
+  if (gap !== null) {
+    const anchor = records[0] as PrReviewRecord;
+    return {
+      ok: false,
+      reason: 'sequence_gap',
+      recordIndex: 0,
+      prNumber: anchor.prNumber,
+      detail: `sequence gap: missing sequence ${String(gap)} in run 0..${String(census.maxSeq)}`,
+    };
+  }
+
+  const forks = forkSequences(census);
+  return forks.length > 0
+    ? { ok: true, recordCount: records.length, forks }
+    : { ok: true, recordCount: records.length };
+}

--- a/scripts/check-governor-review.test.ts
+++ b/scripts/check-governor-review.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the warn-first governor-path pr_review audit gate (#3831, Epic B).
+ *
+ * Proves the binding-condition behaviors:
+ *  (a) a valid sha-bound record for the PR → PASS;
+ *  (b) NO record → WARN (not fail) — warn-first;
+ *  (c) NEGATIVE: a record with the WRONG/stale headSha → NOT accepted (still
+ *      WARN), proving the gate is not theater (condition 1, mandatory);
+ *  (d) a tampered record set (bad self-hash / sequence gap) → FAIL CLOSED;
+ *  (e) genesis-exempt PR → PASS;
+ *  (f) non-governor-path PR → PASS without needing a record.
+ * Plus the CODEOWNERS single-source path derivation and the genesis parser.
+ *
+ * @module scripts/check-governor-review.test
+ * (Source: Issue #3831)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  analyzeGovernorReview,
+  governorPathsFromCodeowners,
+  matchesCodeownersPattern,
+  isGovernorPath,
+  parseGenesisExemptions,
+  resolvePrContext,
+  resolveChangedFiles,
+  type GovernorReviewInputs,
+} from './check-governor-review.js';
+import type { PrReviewRecord } from '../packages/nexus-agents/src/audit/index.js';
+import {
+  buildPrReviewRecord,
+  type BuildPrReviewRecordInput,
+} from '../packages/nexus-agents/src/audit/index.js';
+
+const SHA_HEAD = 'a'.repeat(40);
+const SHA_STALE = 'b'.repeat(40);
+
+/** A small CODEOWNERS sample carrying both pre-section and governor entries. */
+const CODEOWNERS_SAMPLE = [
+  '# Security modules',
+  '/packages/nexus-agents/src/security/ @owner',
+  '/packages/nexus-agents/src/mcp/ @owner',
+  '',
+  "# Governor's own core — the governance-of-the-governor paths.",
+  '# Audit hash chain',
+  '/packages/nexus-agents/src/audit/ @owner',
+  '# Governance source',
+  '/packages/nexus-agents/src/governance/ @owner',
+  '/scripts/inject-governance.ts @owner',
+  '/governance/ @owner',
+  '/CLAUDE.md @owner',
+  '/CODEOWNERS @owner',
+].join('\n');
+
+const GOVERNOR_PATTERNS = governorPathsFromCodeowners(CODEOWNERS_SAMPLE);
+
+function record(overrides: Partial<BuildPrReviewRecordInput> = {}): PrReviewRecord {
+  return buildPrReviewRecord({
+    prNumber: 5000,
+    headSha: SHA_HEAD,
+    verdict: 'approve',
+    verified: false,
+    voteCounts: { approve: 3, request_changes: 0, abstain: 0, error: 0, total: 3 },
+    summary: 'ok',
+    sequence: 0,
+    recordedAt: '2026-06-15T00:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function inputs(overrides: Partial<GovernorReviewInputs> = {}): GovernorReviewInputs {
+  return {
+    prNumber: 5000,
+    headSha: SHA_HEAD,
+    changedFiles: ['packages/nexus-agents/src/audit/audit-logger.ts'],
+    governorPatterns: GOVERNOR_PATTERNS,
+    records: [],
+    genesisExemptPrs: new Set<number>(),
+    ...overrides,
+  };
+}
+
+describe('governorPathsFromCodeowners — single-source path derivation', () => {
+  it('extracts ONLY the governance-of-the-governor section patterns', () => {
+    expect(GOVERNOR_PATTERNS).toEqual([
+      '/packages/nexus-agents/src/audit/',
+      '/packages/nexus-agents/src/governance/',
+      '/scripts/inject-governance.ts',
+      '/governance/',
+      '/CLAUDE.md',
+      '/CODEOWNERS',
+    ]);
+    // Pre-section entries are NOT governor paths.
+    expect(GOVERNOR_PATTERNS).not.toContain('/packages/nexus-agents/src/security/');
+    expect(GOVERNOR_PATTERNS).not.toContain('/packages/nexus-agents/src/mcp/');
+  });
+});
+
+describe('matchesCodeownersPattern', () => {
+  it('matches a directory pattern recursively', () => {
+    expect(
+      matchesCodeownersPattern(
+        'packages/nexus-agents/src/audit/pr-review-record.ts',
+        '/packages/nexus-agents/src/audit/'
+      )
+    ).toBe(true);
+  });
+  it('does not match a sibling directory', () => {
+    expect(
+      matchesCodeownersPattern(
+        'packages/nexus-agents/src/security/sanitizer.ts',
+        '/packages/nexus-agents/src/audit/'
+      )
+    ).toBe(false);
+  });
+  it('matches an exact file pattern', () => {
+    expect(matchesCodeownersPattern('scripts/inject-governance.ts', '/scripts/inject-governance.ts')).toBe(
+      true
+    );
+    expect(matchesCodeownersPattern('scripts/inject-other.ts', '/scripts/inject-governance.ts')).toBe(
+      false
+    );
+  });
+  it('matches a glob pattern within a segment', () => {
+    expect(matchesCodeownersPattern('governance/claims-registry.yaml', '/governance/claims-registry.*')).toBe(
+      true
+    );
+  });
+  it('isGovernorPath aggregates the pattern set', () => {
+    expect(isGovernorPath('CLAUDE.md', GOVERNOR_PATTERNS)).toBe(true);
+    expect(isGovernorPath('README.md', GOVERNOR_PATTERNS)).toBe(false);
+  });
+});
+
+describe('analyzeGovernorReview — binding conditions', () => {
+  it('(a) PASSES with a valid sha-bound record for the PR', () => {
+    const outcome = analyzeGovernorReview(inputs({ records: [record()] }));
+    expect(outcome.kind).toBe('pass');
+  });
+
+  it('(b) WARNS (not fails) when NO record exists — warn-first', () => {
+    const outcome = analyzeGovernorReview(inputs({ records: [] }));
+    expect(outcome.kind).toBe('warn');
+    if (outcome.kind === 'warn') {
+      expect(outcome.message).toContain('NO sha-bound pr_review record');
+      expect(outcome.message).toContain('Warn-first');
+    }
+  });
+
+  it('(c) NEGATIVE: a record with the WRONG/stale headSha is NOT accepted (still warns)', () => {
+    // Record exists for THIS PR but against a stale head sha → must NOT satisfy.
+    const stale = record({ headSha: SHA_STALE });
+    const outcome = analyzeGovernorReview(inputs({ records: [stale] }));
+    expect(outcome.kind).toBe('warn');
+    if (outcome.kind === 'warn') {
+      // The warn should call out the stale-sha record explicitly.
+      expect(outcome.message).toContain('STALE head sha');
+      expect(outcome.message).toContain(SHA_STALE);
+    }
+  });
+
+  it('(d) FAILS CLOSED on a tampered record (bad self-hash)', () => {
+    const good = record();
+    const tampered: PrReviewRecord = { ...good, verdict: 'request_changes' }; // hash no longer matches
+    const outcome = analyzeGovernorReview(inputs({ records: [tampered] }));
+    expect(outcome.kind).toBe('fail');
+    if (outcome.kind === 'fail') {
+      expect(outcome.message).toContain('TAMPER EVIDENCE');
+      expect(outcome.message).toContain('hash_mismatch');
+    }
+  });
+
+  it('(d2) FAILS CLOSED on a sequence gap — even on a non-governor PR (integrity first)', () => {
+    const a = record({ prNumber: 1, sequence: 0 });
+    const c = record({ prNumber: 2, sequence: 2 }); // gap at 1
+    const outcome = analyzeGovernorReview(
+      inputs({
+        changedFiles: ['README.md'], // non-governor
+        records: [a, c],
+      })
+    );
+    expect(outcome.kind).toBe('fail');
+    if (outcome.kind === 'fail') expect(outcome.message).toContain('sequence_gap');
+  });
+
+  it('(e) PASSES a genesis-exempt PR even with no record', () => {
+    const outcome = analyzeGovernorReview(
+      inputs({ records: [], genesisExemptPrs: new Set([5000]) })
+    );
+    expect(outcome.kind).toBe('pass');
+    if (outcome.kind === 'pass') expect(outcome.reason).toContain('genesis-exempt');
+  });
+
+  it('(f) PASSES a non-governor-path PR with no record', () => {
+    const outcome = analyzeGovernorReview(
+      inputs({ changedFiles: ['README.md', 'docs/guide.md'], records: [] })
+    );
+    expect(outcome.kind).toBe('pass');
+    if (outcome.kind === 'pass') expect(outcome.reason).toContain('no governor paths');
+  });
+});
+
+describe('genesis parser', () => {
+  it('parses PR numbers, ignoring comments and blanks', () => {
+    const set = parseGenesisExemptions('# header\n3831\n\n  4242  # inline\nnotanumber\n');
+    expect(set.has(3831)).toBe(true);
+    expect(set.has(4242)).toBe(true);
+    expect(set.size).toBe(2);
+  });
+});
+
+describe('PR context + changed-files resolution', () => {
+  it('reads --pr and --sha from argv', () => {
+    const ctx = resolvePrContext(['--pr', '777', '--sha', SHA_HEAD]);
+    expect(ctx.prNumber).toBe(777);
+    expect(ctx.headSha).toBe(SHA_HEAD);
+  });
+  it('falls back to env vars', () => {
+    const prev = { PR_NUMBER: process.env['PR_NUMBER'], PR_HEAD_SHA: process.env['PR_HEAD_SHA'] };
+    process.env['PR_NUMBER'] = '888';
+    process.env['PR_HEAD_SHA'] = SHA_STALE;
+    try {
+      const ctx = resolvePrContext([]);
+      expect(ctx.prNumber).toBe(888);
+      expect(ctx.headSha).toBe(SHA_STALE);
+    } finally {
+      if (prev.PR_NUMBER === undefined) delete process.env['PR_NUMBER'];
+      else process.env['PR_NUMBER'] = prev.PR_NUMBER;
+      if (prev.PR_HEAD_SHA === undefined) delete process.env['PR_HEAD_SHA'];
+      else process.env['PR_HEAD_SHA'] = prev.PR_HEAD_SHA;
+    }
+  });
+  it('parses changed files from a newline/comma list', () => {
+    expect(resolveChangedFiles(['--changed-files', 'a.ts\nb.ts, c.ts'])).toEqual([
+      'a.ts',
+      'b.ts',
+      'c.ts',
+    ]);
+  });
+});

--- a/scripts/check-governor-review.ts
+++ b/scripts/check-governor-review.ts
@@ -1,0 +1,349 @@
+#!/usr/bin/env npx tsx
+/**
+ * Governor-path pr_review audit gate (#3831, Epic B — governance of the governor).
+ *
+ * Stage 1: a WARN-FIRST CI gate asserting that a PR touching the GOVERNOR PATHS
+ * (the governance-of-the-governor entries in /CODEOWNERS) carries a recorded,
+ * SHA-BOUND, tamper-evident `pr_review` audit record before merge. The gate
+ * QUERIES the committed ledger (`governance/pr-review-records.jsonl`); it NEVER
+ * re-executes pr_review.
+ *
+ * SPLIT FAIL-MODE (the #3831 ratification's binding conditions):
+ *   - CHAIN/SET INTEGRITY is fail-CLOSED (exit 1, condition 2). A broken record
+ *     set — a `hash_mismatch` (an edited record) or a `sequence_gap` (a deleted
+ *     record) — is TAMPER EVIDENCE; the gate refuses regardless of warn-first.
+ *   - RECORD ABSENCE is WARN-FIRST (exit 0 + an actionable message, condition 2).
+ *     A governor PR with no matching sha-bound record is WARNED, not blocked, in
+ *     this stage. Flipping absence to fail-closed is a tracked FOLLOW-ON.
+ *
+ * SHA-BINDING (condition 1). A record satisfies the gate only when it matches
+ * THIS PR's number AND head sha. A record produced against a STALE head sha does
+ * NOT count — that is the negative case the test suite proves, and it is what
+ * makes the gate not theater.
+ *
+ * GENESIS EXEMPTION (condition 5). The introducing PR and pre-convention PRs
+ * cannot carry a record (the producer does not exist yet), so an explicit,
+ * documented allowlist ({@link GENESIS_EXEMPT_PRS} + the committed
+ * `governance/governor-review-genesis.txt`) exempts them from the warn. This is a
+ * ONE-TIME bootstrap, not a permanent escape hatch.
+ *
+ * SINGLE-SOURCE PATH FILTER. The governor path set is DERIVED from /CODEOWNERS
+ * (the governance-of-the-governor section) — there is no second hardcoded copy to
+ * drift. See {@link governorPathsFromCodeowners}.
+ *
+ * @module scripts/check-governor-review
+ * (Source: Issue #3831, Epic B / #3829)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ROOT } from './script-paths.js';
+import {
+  readPrReviewRecords,
+  verifyPrReviewRecordSet,
+  type PrReviewRecord,
+} from '../packages/nexus-agents/src/audit/index.js';
+
+const CODEOWNERS_FILE = join(ROOT, 'CODEOWNERS');
+const PR_REVIEW_RECORDS_FILE = join(ROOT, 'governance/pr-review-records.jsonl');
+const GENESIS_FILE = join(ROOT, 'governance/governor-review-genesis.txt');
+
+/**
+ * The GOVERNANCE-OF-THE-GOVERNOR section of /CODEOWNERS. Only the path patterns
+ * BELOW this marker comment are treated as governor paths; the rest of CODEOWNERS
+ * (security, pipeline, mcp, …) carries its own review requirements but is out of
+ * scope for THIS gate. The marker is the section heading committed in CODEOWNERS.
+ */
+const GOVERNOR_SECTION_MARKER = "Governor's own core";
+
+/**
+ * Genesis allowlist (condition 5): PR numbers that pre-date the pr_review record
+ * convention and so legitimately carry no record. Seeded with the introducing PR
+ * via the committed {@link GENESIS_FILE}; the embedded fallback is empty. ONE-TIME
+ * bootstrap, not a permanent escape hatch — entries should not be added after the
+ * producer lands.
+ */
+export const GENESIS_EXEMPT_PRS: ReadonlySet<number> = readGenesisExemptions(GENESIS_FILE);
+
+/** Parse the genesis allowlist file: one PR number per line, `#` comments allowed. */
+export function parseGenesisExemptions(text: string): Set<number> {
+  const out = new Set<number>();
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/#.*$/, '').trim();
+    if (line === '') continue;
+    const n = Number(line);
+    if (Number.isInteger(n) && n > 0) out.add(n);
+  }
+  return out;
+}
+
+/** Read the committed genesis allowlist file (empty set when absent). */
+function readGenesisExemptions(filePath: string): Set<number> {
+  if (!existsSync(filePath)) return new Set();
+  return parseGenesisExemptions(readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Extract the governor path PATTERNS from CODEOWNERS text — the patterns in the
+ * governance-of-the-governor section only (everything from the
+ * {@link GOVERNOR_SECTION_MARKER} heading to end of file). Each owner-rule line's
+ * FIRST token is the path pattern; comment/blank lines are skipped. This is the
+ * SINGLE SOURCE — the gate never hardcodes a divergent copy.
+ */
+export function governorPathsFromCodeowners(codeownersText: string): string[] {
+  const lines = codeownersText.split('\n');
+  const patterns: string[] = [];
+  let inSection = false;
+  for (const raw of lines) {
+    if (raw.includes(GOVERNOR_SECTION_MARKER)) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const pattern = line.split(/\s+/)[0];
+    if (pattern !== undefined && pattern !== '') patterns.push(pattern);
+  }
+  return patterns;
+}
+
+/**
+ * Match a repo-relative changed file against a single CODEOWNERS path pattern.
+ * Supports the subset CODEOWNERS uses in this repo:
+ *  - a leading `/` anchors the pattern at the repo root (all our patterns do);
+ *  - a trailing `/` matches that directory and everything under it (recursive);
+ *  - `*` matches any run of characters within a path segment;
+ *  - an exact file path matches that file.
+ * The file path is normalized to forward slashes with no leading `./`.
+ */
+export function matchesCodeownersPattern(file: string, pattern: string): boolean {
+  const f = file.replace(/\\/g, '/').replace(/^\.\//, '');
+  // Anchor: CODEOWNERS patterns here are all root-anchored ('/...'). Strip the
+  // leading slash for comparison against the (root-relative) changed file.
+  const pat = pattern.startsWith('/') ? pattern.slice(1) : pattern;
+
+  // Directory pattern: 'foo/bar/' matches 'foo/bar/anything/under/here'.
+  if (pat.endsWith('/')) {
+    return f === pat.slice(0, -1) || f.startsWith(pat);
+  }
+
+  // Glob with '*': translate to a regex anchored over the whole path.
+  if (pat.includes('*')) {
+    const re = new RegExp(
+      '^' +
+        pat
+          .split('*')
+          .map((seg) => seg.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+          .join('[^/]*') +
+        '$'
+    );
+    return re.test(f);
+  }
+
+  // Exact file match.
+  return f === pat;
+}
+
+/** True when `file` is under any governor path pattern. */
+export function isGovernorPath(file: string, patterns: readonly string[]): boolean {
+  return patterns.some((p) => matchesCodeownersPattern(file, p));
+}
+
+/** The subset of changed files that touch a governor path. */
+export function governorFilesTouched(
+  changedFiles: readonly string[],
+  patterns: readonly string[]
+): string[] {
+  return changedFiles.filter((f) => isGovernorPath(f, patterns));
+}
+
+/** The outcome the pure gate analysis resolves to. */
+export type GovernorReviewOutcome =
+  | { kind: 'pass'; reason: string }
+  | { kind: 'warn'; message: string }
+  | { kind: 'fail'; message: string };
+
+/** Inputs for the pure gate analysis (no disk/process I/O). */
+export interface GovernorReviewInputs {
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly changedFiles: readonly string[];
+  readonly governorPatterns: readonly string[];
+  readonly records: readonly PrReviewRecord[];
+  readonly genesisExemptPrs: ReadonlySet<number>;
+}
+
+/**
+ * The pure gate decision (no I/O) so it is unit-testable with injected inputs.
+ * Order of checks is load-bearing:
+ *  1. Chain/set integrity → FAIL-CLOSED (tamper evidence, condition 2). Checked
+ *     FIRST and unconditionally: a tampered ledger is refused even on a
+ *     non-governor PR, because the artifact's integrity is itself governance.
+ *  2. No governor path touched → PASS (nothing to assert).
+ *  3. Genesis-exempt PR → PASS (condition 5; pre-convention PRs carry no record).
+ *  4. A record matching THIS prNumber AND headSha exists → PASS (sha-binding,
+ *     condition 1). A stale-sha record does NOT match.
+ *  5. Otherwise → WARN (warn-first, condition 2): actionable, non-blocking.
+ */
+export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorReviewOutcome {
+  // (1) Integrity FIRST — fail-closed on tamper evidence (condition 2).
+  const verification = verifyPrReviewRecordSet(inputs.records);
+  if (!verification.ok) {
+    return {
+      kind: 'fail',
+      message:
+        `governance/pr-review-records.jsonl FAILS tamper-evident verification ` +
+        `(${verification.reason}) at record index ${String(verification.recordIndex)} ` +
+        `(prNumber=${String(verification.prNumber)}): ${verification.detail}. ` +
+        `A broken record set is TAMPER EVIDENCE — the ledger has been edited, ` +
+        `reordered into a gap, or forged. This is fail-closed regardless of warn-first.`,
+    };
+  }
+
+  // (2) Does the PR touch any governor path?
+  const touched = governorFilesTouched(inputs.changedFiles, inputs.governorPatterns);
+  if (touched.length === 0) {
+    return { kind: 'pass', reason: 'no governor paths touched — nothing to assert' };
+  }
+
+  // (3) Genesis exemption (condition 5).
+  if (inputs.genesisExemptPrs.has(inputs.prNumber)) {
+    return {
+      kind: 'pass',
+      reason: `PR #${String(inputs.prNumber)} is genesis-exempt (governance/governor-review-genesis.txt) — one-time bootstrap`,
+    };
+  }
+
+  // (4) Sha-bound record present? (condition 1 — number AND head sha must match.)
+  const match = inputs.records.find(
+    (r) => r.prNumber === inputs.prNumber && r.headSha === inputs.headSha
+  );
+  if (match !== undefined) {
+    return {
+      kind: 'pass',
+      reason: `sha-bound pr_review record found for PR #${String(inputs.prNumber)} @ ${inputs.headSha} (verdict=${match.verdict})`,
+    };
+  }
+
+  // (5) Absence → WARN-FIRST (condition 2): actionable, non-blocking this stage.
+  const staleForPr = inputs.records.filter((r) => r.prNumber === inputs.prNumber);
+  const staleNote =
+    staleForPr.length > 0
+      ? ` A record EXISTS for this PR but against a STALE head sha ` +
+        `(${staleForPr.map((r) => r.headSha).join(', ')}) — re-run pr_review at the current head.`
+      : '';
+  return {
+    kind: 'warn',
+    message:
+      `PR #${String(inputs.prNumber)} touches governor paths ` +
+      `(${touched.join(', ')}) but has NO sha-bound pr_review record for head ${inputs.headSha}.` +
+      staleNote +
+      ` Run pr_review on this PR and commit the resulting record into ` +
+      `governance/pr-review-records.jsonl. (Warn-first: not blocking merge in this stage, #3831.)`,
+  };
+}
+
+/** Parse a raw PR-number string to a positive integer, or undefined. */
+function parsePrNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+/** Trim a raw sha string, or undefined when empty/absent. */
+function parseSha(raw: string | undefined): string | undefined {
+  return raw !== undefined && raw.trim() !== '' ? raw.trim() : undefined;
+}
+
+/** Resolve PR number + head sha from CLI args (`--pr`, `--sha`) or CI env. */
+export function resolvePrContext(argv: readonly string[]): {
+  prNumber: number | undefined;
+  headSha: string | undefined;
+} {
+  const prRaw = readFlag(argv, '--pr') ?? process.env['PR_NUMBER'] ?? process.env['GITHUB_PR_NUMBER'];
+  const shaRaw =
+    readFlag(argv, '--sha') ?? process.env['PR_HEAD_SHA'] ?? process.env['GITHUB_HEAD_SHA'];
+  return { prNumber: parsePrNumber(prRaw), headSha: parseSha(shaRaw) };
+}
+
+/** Read a `--flag value` pair from argv. */
+function readFlag(argv: readonly string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  if (i >= 0 && i + 1 < argv.length) return argv[i + 1];
+  return undefined;
+}
+
+/** Resolve the changed-file list from `--changed-files` (newline/comma) or env. */
+export function resolveChangedFiles(argv: readonly string[]): string[] {
+  const arg = readFlag(argv, '--changed-files');
+  const raw = arg ?? process.env['CHANGED_FILES'] ?? '';
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+}
+
+/**
+ * The CI gate entry point. Reads CODEOWNERS, the pr-review ledger, and the
+ * genesis allowlist from disk; resolves the PR context from args/env; runs the
+ * pure analysis; prints a structured result. Exit code: 0 for pass/WARN
+ * (warn-first), 1 for a fail-closed integrity break.
+ */
+export function runGovernorReviewGate(argv: readonly string[]): number {
+  const codeownersText = existsSync(CODEOWNERS_FILE)
+    ? readFileSync(CODEOWNERS_FILE, 'utf-8')
+    : '';
+  const governorPatterns = governorPathsFromCodeowners(codeownersText);
+  const { records } = readPrReviewRecords(PR_REVIEW_RECORDS_FILE);
+  const { prNumber, headSha } = resolvePrContext(argv);
+  const changedFiles = resolveChangedFiles(argv);
+
+  // Even without a PR context we still run the integrity check (it never
+  // depends on PR number/sha) so a tampered ledger fails CI on any run.
+  if (prNumber === undefined || headSha === undefined) {
+    const verification = verifyPrReviewRecordSet(records);
+    if (!verification.ok) {
+      console.error(
+        `[governor-review] FAIL (integrity): governance/pr-review-records.jsonl is tampered ` +
+          `(${verification.reason}): ${verification.detail}`
+      );
+      return 1;
+    }
+    console.error(
+      '[governor-review] PASS: no PR context (PR_NUMBER/PR_HEAD_SHA) provided and the ' +
+        'pr-review ledger verifies. Nothing to assert for a non-PR run.'
+    );
+    return 0;
+  }
+
+  const outcome = analyzeGovernorReview({
+    prNumber,
+    headSha,
+    changedFiles,
+    governorPatterns,
+    records,
+    genesisExemptPrs: GENESIS_EXEMPT_PRS,
+  });
+
+  switch (outcome.kind) {
+    case 'fail':
+      console.error(`[governor-review] FAIL (integrity, fail-closed): ${outcome.message}`);
+      return 1;
+    case 'warn':
+      // Warn-first: surface as a GitHub Actions annotation but exit 0. The
+      // annotation directive is recognized on stderr too.
+      console.error(`::warning title=Governor review missing::${outcome.message}`);
+      console.error(`[governor-review] WARN: ${outcome.message}`);
+      return 0;
+    case 'pass':
+      console.error(`[governor-review] PASS: ${outcome.reason}`);
+      return 0;
+  }
+}
+
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  process.exit(runGovernorReviewGate(process.argv.slice(2)));
+}


### PR DESCRIPTION
Stage 1 of governance-of-the-governor (Epic B, #3829): a **WARN-FIRST** CI gate asserting that a PR touching the **GOVERNOR PATHS** carries a recorded, **SHA-BOUND**, tamper-evident `pr_review` audit record before merge. 7-0 ratified with binding conditions. Closes part of #3831.

## What this builds (scope: gate + schema + verification + tests, warn-first)

### SHA-binding — the record covers `headSha` (condition 1)
`PrReviewRecord` (`packages/nexus-agents/src/audit/pr-review-record.ts`) is a self-hashed, position-independent record whose `hash` folds in `prNumber` + **`headSha`** + `verdict` + `verified` + vote counts + the monotonic `sequence` (everything except the advisory `previousHash`). The gate accepts a record **only** when it matches the PR's number **AND** head sha — a record produced against a stale head sha does **not** satisfy a later push. This is what makes the gate not theater; the negative wrong-sha test proves it.

### Split fail-mode — integrity fail-closed / absence warn-first (condition 2)
`scripts/check-governor-review.ts`:
- **Chain/set INTEGRITY → fail-CLOSED (exit 1).** A `hash_mismatch` (edited record) or `sequence_gap` (deleted record) is tamper evidence; `verifyPrReviewRecordSet` runs first, unconditionally (even on a non-governor PR).
- **Record ABSENCE → WARN-FIRST (exit 0 + actionable `::warning::`).** A governor PR with no matching sha-bound record is warned, not blocked, in this stage.

The warn-vs-fail distinction lives in the script's **exit code** (not `continue-on-error`), so the workflow does not flatten the two paths: a warn exits 0 (job green), an integrity break exits 1 (job red).

### CODEOWNERS-derived path filter (single source)
The governor path set is parsed from the governance-of-the-governor section of `/CODEOWNERS` (`governorPathsFromCodeowners`) — no second hardcoded copy to drift. The workflow's `paths:` filter mirrors those entries.

### Genesis exemption (condition 5)
`governance/governor-review-genesis.txt` is an explicit, documented allowlist (seeded with #3831 itself) so the introducing PR + pre-convention PRs don't false-warn. Documented as a one-time bootstrap, not a permanent escape hatch.

### How CI gets PR# / headSha
`.github/workflows/governor-review.yml` passes `PR_NUMBER` = `github.event.pull_request.number` and `PR_HEAD_SHA` = `github.event.pull_request.head.sha`; changed files come from `git diff --name-only base..head`. The job is **non-required** and warn-first this stage; the integrity-break path can still fail the job.

## Files
- `packages/nexus-agents/src/audit/pr-review-record.ts` — schema + `verifyPrReviewRecordSet` (mirrors #3927 `vote-record.ts`)
- `packages/nexus-agents/src/audit/pr-review-record-store.ts` — `buildPrReviewRecord` (pure) + `readPrReviewRecords` + path resolution
- `packages/nexus-agents/src/audit/index.ts` — exports
- `scripts/check-governor-review.ts` — the gate (pure `analyzeGovernorReview` + CLI/env seam)
- `.github/workflows/governor-review.yml` — paths-filtered warn-first workflow
- `governance/pr-review-records.jsonl` — empty committed ledger (+ `.gitattributes merge=union`)
- `governance/governor-review-genesis.txt` — genesis allowlist
- `packages/nexus-agents/src/audit/pr-review-record.test.ts` (10) + `scripts/check-governor-review.test.ts` (17)
- `.changeset/governor-review-gate-3831.md` (`nexus-agents`: minor)

## Tests (27 green)
- (a) valid sha-bound record → **pass**
- (b) no record → **warn** (not fail)
- **(c) NEGATIVE: record with the WRONG/stale headSha → not accepted (still warn)** — proves it's not theater
- (d) tampered record set (bad self-hash) → **fail closed**; (d2) sequence gap → fail closed even on a non-governor PR
- (e) genesis-exempt PR → **pass**; (f) non-governor-path PR → **pass** without a record

## Follow-ons (tracked, out of scope here)
- The **PRODUCER**: `pr_review` writing records (the caller-commits flow shared with #3927).
- The **fail-closed FLIP**: absence → block (and making this a required check).

## Gates
tsc clean, eslint clean, 27 new tests green, repo-index `--check` up to date, `governance:check` passes (**MCP Tools: 46** unchanged — no MCP tool added), changeset present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)