### PR TITLE
feat(eval): pr_review candidate-mining curation pipeline — mines merged PRs for owner adjudication toward n>=50 (#3847)

### DIFF
--- a/.changeset/eval-curation-pipeline-3847.md
+++ b/.changeset/eval-curation-pipeline-3847.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': minor
+---
+
+feat(eval): pr_review candidate-mining curation pipeline — mines merged PRs for owner adjudication toward n>=50 (#3847)
+
+A curation pipeline that mines THIS repo's merged-PR history into CANDIDATE
+pr_review eval cases for the owner to adjudicate, to grow the dataset
+(`testing/datasets/pr-review-sample.json`) from n=19 toward n>=50. The pipeline
+produces candidates + weak labels ONLY; it never fabricates an adjudicated
+verdict (the owner adjudicates each candidate per the rubric).
+
+- New miner `scripts/mine-pr-review-candidates.ts` (npm: `eval:mine-candidates`)
+  shells out to `gh` LOCALLY (owner auth; CI never runs it). It pulls a window of
+  recently-merged PRs, excludes bot PRs (changeset-release/dependabot/
+  github-actions/renovate/`[bot]`) and PRs already in the dataset/candidates file,
+  extracts each PR's real (bounded) diff + objective signals, and emits NEW
+  candidates to `testing/datasets/pr-review-candidates.json`.
+- **Weak-label heuristic (triage hint, NOT a verdict):** reuses the tested rubric
+  labeler so the mining heuristic matches adjudication. A confirmed defect-fix/
+  revert on the same source file → `likely-buggy`; a refinement-only follow-up or
+  no corrective PR within the 42-day long-tenure window → `likely-clean`; an
+  ambiguous `fix(` or a too-young no-fix PR → `unknown`. Conservative by design;
+  `weakLabelEvidence` records the objective basis.
+- **No-fabrication guarantee:** every emitted case is `adjudicated: false` with a
+  neutral placeholder `class: "borderline"`, empty `knownBugs`, an UNADJUDICATED
+  rationale, and a `customDiff` that is a real bounded slice of `gh pr diff`
+  (never synthesized). The signal lives only in `weakLabel`.
+- **Idempotent + safe:** re-running dedups against both the dataset and the
+  candidates file, and never overwrites an `adjudicated: true` candidate.
+- Pure logic factored into `mine-pr-review-candidates-core.ts` (bot exclusion,
+  tenure math, weak label, diff bounding) + `mine-pr-review-candidates-assemble.ts`
+  (candidate assembly, dedup, adjudication-preserving merge), unit-tested against
+  fixtures with NO live gh (`mine-pr-review-candidates.test.ts`, 18 tests).
+- Doc `docs/research/pr-review-eval-curation.md` explains the
+  mine -> adjudicate -> promote flow, the weak-label heuristic, and the
+  no-fabrication guarantee.

--- a/cspell.json
+++ b/cspell.json
@@ -162,6 +162,7 @@
     "seccomp",
     "semgrep",
     "sklearn",
+    "sdlc",
     "sota",
     "stopwords",
     "strmac",

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,6 +164,7 @@ Nothing ships without passing a gate. Adversarial PR review, multi-voter consens
 | [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug | Canonical |
 | [pr-review-eval-labeling-rubric.md](./research/pr-review-eval-labeling-rubric.md)   | pr_review eval labeling rubric v1 + v5 re-adjudication (#3846)          | Canonical |
 | [pr-review-dataset-curation.md](./research/pr-review-dataset-curation.md)           | pr_review eval dataset curation pipeline + n≥50 assessment (#3847)      | Canonical |
+| [pr-review-eval-curation.md](./research/pr-review-eval-curation.md)                 | pr_review eval candidate-mining curation pipeline (#3847)               | Canonical |
 
 ---
 

--- a/docs/research/pr-review-eval-curation.md
+++ b/docs/research/pr-review-eval-curation.md
@@ -1,0 +1,137 @@
+---
+title: pr_review eval candidate-mining curation pipeline
+description: How merged-PR history is mined into CANDIDATE pr_review eval cases for owner adjudication — the weak-label triage heuristic, the no-fabrication guarantee, idempotent dedup, and the mine -> adjudicate -> promote flow toward n>=50.
+tier: 2
+keywords: [pr-review, eval, dataset, curation, candidate-mining, weak-label, autonomous-sdlc]
+---
+
+# pr_review eval candidate-mining curation pipeline
+
+**Issue:** #3847 (part of epic #3845). Depends on #3846 (the
+[labeling rubric](./pr-review-eval-labeling-rubric.md)).
+**Miner:** `scripts/mine-pr-review-candidates.ts` (npm: `eval:mine-candidates`)
+**Candidates file:** `testing/datasets/pr-review-candidates.json`
+**Curated dataset:** `testing/datasets/pr-review-sample.json`
+
+This complements the dataset-validation/stamping pipeline
+([pr-review-dataset-curation.md](./pr-review-dataset-curation.md),
+`scripts/curate-pr-review-dataset.ts`). That pipeline validates + stamps cases
+the owner has already adjudicated; this one **mines candidates** to put in front
+of the owner. Both share the pure rubric labeler (`curate-pr-review-labeling.ts`)
+so the mining heuristic stays consistent with the adjudication rubric.
+
+## The mine -> adjudicate -> promote flow
+
+```text
+  merged PRs (gh)                                pr-review-candidates.json
+        │   eval:mine-candidates                          │
+        ▼   (weak label = triage hint only)               ▼   OWNER reads, adjudicates
+  ┌───────────────┐                              ┌────────────────────────┐
+  │ CANDIDATE     │  adjudicated:false           │ owner sets the REAL    │
+  │ cases         │ ───────────────────────────► │ class buggy/clean/     │
+  │ + weakLabel   │                              │ borderline per rubric  │
+  └───────────────┘                              └───────────┬────────────┘
+                                                             │ promote
+                                                             ▼
+                                              pr-review-sample.json (toward n>=50)
+```
+
+1. **Mine.** The owner runs `npm run eval:mine-candidates` **locally** (it shells
+   out to `gh` with the owner's auth — CI never runs it). It pulls a window of
+   recently-merged PRs, excludes bot PRs and PRs already in the dataset/candidates
+   file, extracts each PR's real diff (bounded) + objective signals, computes a
+   **weak label** (triage hint), and appends NEW candidates to
+   `testing/datasets/pr-review-candidates.json`.
+2. **Adjudicate.** The owner reads each candidate and assigns the REAL class
+   (`buggy` / `clean` / `borderline`) per the
+   [rubric](./pr-review-eval-labeling-rubric.md) — filling `knownBugs` (with
+   severity + location), the `adjudication.rationale`, and flipping
+   `adjudicated: true`. The `weakLabel` only orders this queue; it is never the
+   verdict.
+3. **Promote.** Adjudicated candidates are moved into
+   `testing/datasets/pr-review-sample.json` (re-using
+   `curate-pr-review-dataset.ts add` for a rubric-valid skeleton, then filling the
+   real fields), then `curate-pr-review-dataset.ts validate` + `stats` confirm the
+   set is still rubric-valid and report progress toward n>=50.
+
+## The weak-label heuristic (triage hint, NOT a verdict)
+
+The miner attaches one `weakLabel` per candidate, derived purely from objective
+signals via the same rubric labeler the adjudication uses. It is a **triage hint
+to order the owner's queue**, never a label that ships:
+
+| weakLabel      | Objective signal that produces it                                                                                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `likely-buggy` | A later `fix(`/`revert` PR that touches the same source file AND reads as a genuine defect correction (adds a guard / fail-loud / resolution, or is a revert). Evidence names the fixing PR. |
+| `likely-clean` | Either a later follow-up that only **refines** (tunes heuristics / no-behavior-change hardening), OR **no** corrective PR within the long-tenure window (>= 42 days since merge).            |
+| `unknown`      | A `fix(` whose nature can't be established from its title (neither defect nor refinement marker), OR no corrective PR but the PR is **too young** (< 42 days) to be a clean signal.          |
+
+It is deliberately **conservative**: `unknown` whenever the signal is ambiguous or
+not yet established. The 42-day long-tenure window mirrors the dataset's existing
+clean rationale (a defect would usually have surfaced a corrective PR within ~6
+weeks), and deliberately avoids the rejected short (~1-week) no-fix window whose
+false-clean risk was too high.
+
+`weakLabelEvidence` records the exact objective basis (the fixing PR number, the
+refinement marker, or the tenure) so the owner can verify the hint quickly.
+
+## The no-fabrication guarantee
+
+The pipeline produces **candidates + weak labels only**. It does NOT fabricate
+adjudicated eval data — the entire value of the eval is REAL owner-adjudicated
+cases; a guessed verdict would poison the metric. Concretely, every emitted case:
+
+- is `adjudicated: false` with a neutral placeholder `class: "borderline"`, empty
+  `knownBugs` / `borderlineConcerns`, and an `adjudication.rationale` that says
+  `UNADJUDICATED`;
+- carries the signal **only** in `weakLabel` / `weakLabelEvidence` — the miner
+  asserts no buggy/clean class;
+- has a `customDiff` that is a **bounded slice of the REAL `gh pr diff`** output
+  (truncated with an explicit marker when long), never synthesized.
+
+This invariant is stated in the script header and enforced by the test
+(`adjudicated:false`, neutral class, real diff).
+
+## Idempotent + safe
+
+Re-running `eval:mine-candidates` is safe:
+
+- **Dedup against both** the curated dataset (`pr-review-sample.json`) and the
+  already-emitted candidates file — a PR is never proposed twice.
+- **Bot PRs excluded** (changeset-release, dependabot, github-actions, renovate,
+  any `[bot]`).
+- **Never overwrites an adjudicated candidate** — a candidate the owner has marked
+  `adjudicated: true` is preserved verbatim; a freshly-mined case that collides on
+  PR number is dropped.
+- **Never invents a diff** — if `gh pr diff` fails for a PR, the excerpt is empty
+  rather than fabricated.
+
+## How the owner runs it
+
+```bash
+# Local only — uses your gh auth. Default: 50 most-recent merged PRs.
+npm run eval:mine-candidates
+# Or with options:
+npx tsx scripts/mine-pr-review-candidates.ts --limit 80 --diff-cap 6000
+```
+
+Then adjudicate the populated `testing/datasets/pr-review-candidates.json`
+in-place (set the real class, fill `knownBugs`, flip `adjudicated: true`), and
+promote the adjudicated cases into `pr-review-sample.json`. Run
+`npx tsx scripts/curate-pr-review-dataset.ts validate` and `… stats` to confirm
+rubric validity and track the n>=50 target.
+
+## Architecture (pure core, gh at the edges)
+
+Mirrors the `curate-pr-review-harvest` / `-labeling` split so the rubric logic is
+unit-tested without a live GitHub round-trip:
+
+- `scripts/mine-pr-review-candidates-core.ts` — pure: bot exclusion, tenure math,
+  the weak-label heuristic (delegating to the rubric labeler), diff bounding.
+- `scripts/mine-pr-review-candidates-assemble.ts` — pure: candidate-case assembly
+  (schema mirrors `pr-review-sample.json` + `weakLabel` / `weakLabelEvidence` /
+  `adjudicated`), bot/dedup filtering, adjudication-preserving merge.
+- `scripts/mine-pr-review-candidates.ts` — the thin `gh` I/O edge + CLI (untested
+  by unit, like `build-model-registry.ts`).
+- `scripts/mine-pr-review-candidates.test.ts` — fixtures only, **no network**;
+  collected by the CI Script Tests job.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "build:registry": "npx tsx scripts/build-model-registry.ts",
     "build:registry:dry": "npx tsx scripts/build-model-registry.ts --dry",
     "review": "npx tsx scripts/review-pr.ts",
+    "eval:mine-candidates": "npx tsx scripts/mine-pr-review-candidates.ts",
     "link-check": "npx lychee --config lychee.toml .",
     "git:cleanup": "./scripts/git-housekeeping.sh",
     "git:cleanup:dry": "./scripts/git-housekeeping.sh --dry-run",

--- a/scripts/curate-pr-review-harvest.ts
+++ b/scripts/curate-pr-review-harvest.ts
@@ -46,7 +46,13 @@ const REPO = 'nexus-substrate/nexus-agents';
 // gh fetch (the only I/O)
 // ============================================================================
 
-interface RawPr {
+/**
+ * The minimal merged-PR shape the pure signal-extraction helpers (`signalsFor`,
+ * `followUpFixesFor`, `sourceFilesOf`) consume. Exported as `RawPrLike` so the
+ * candidate-mining pipeline (mine-pr-review-candidates-*) can reuse the same
+ * signal extraction rather than duplicate it (#3847).
+ */
+export interface RawPrLike {
   readonly number: number;
   readonly title: string;
   readonly body: string;
@@ -54,6 +60,8 @@ interface RawPr {
   readonly files: ReadonlyArray<{ readonly path: string }>;
   readonly reviewDecision?: string;
 }
+
+type RawPr = RawPrLike;
 
 /** A merged-PR page from `gh pr list --json …`. Throws on gh failure. */
 function fetchMergedPrs(limit: number): readonly RawPr[] {

--- a/scripts/mine-pr-review-candidates-assemble.ts
+++ b/scripts/mine-pr-review-candidates-assemble.ts
@@ -1,0 +1,222 @@
+/**
+ * mine-pr-review-candidates-assemble.ts — PURE assembly of CANDIDATE cases for
+ * the pr_review eval curation pipeline (#3847).
+ *
+ * Turns objective merged-PR signals + a weak label into a CANDIDATE case whose
+ * shape mirrors testing/datasets/pr-review-sample.json (rubricVersion, class,
+ * title, provenance, knownBugs, borderlineConcerns, adjudication) PLUS the
+ * candidate-only fields `weakLabel`, `weakLabelEvidence`, and
+ * `adjudicated: false`. These are PROPOSALS for the owner to adjudicate per the
+ * rubric — NOT final dataset entries.
+ *
+ * Critical no-fabrication property: the assembled `class` is always the neutral
+ * placeholder `'borderline'` with empty `knownBugs`/`borderlineConcerns` and an
+ * adjudication rationale that says "UNADJUDICATED". The miner does NOT assert
+ * buggy/clean — only the `weakLabel` triage hint carries the signal, and the
+ * owner sets the real class during adjudication. This keeps the candidates file
+ * schema-recognizable without ever encoding a fabricated verdict.
+ *
+ * @module scripts/mine-pr-review-candidates-assemble
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import { signalsFor, type RawPrLike } from './curate-pr-review-harvest.js';
+import {
+  boundDiff,
+  daysSinceMerge,
+  deriveWeakLabel,
+  isBotAuthored,
+  type DedupIndex,
+  type MergedPrWithDiff,
+  type WeakLabel,
+} from './mine-pr-review-candidates-core.js';
+
+// ============================================================================
+// The candidate case schema (mirrors pr-review-sample.json + candidate fields)
+// ============================================================================
+
+/** A candidate pr_review eval case — a PROPOSAL, never an adjudicated entry. */
+export interface CandidateCase {
+  readonly number: number;
+  readonly rubricVersion: string;
+  /**
+   * Always the neutral 'borderline' placeholder until the owner adjudicates.
+   * The triage signal lives in `weakLabel`, NOT here — the miner never asserts
+   * buggy/clean.
+   */
+  readonly class: 'borderline';
+  readonly title: string;
+  readonly customDescription: string;
+  /** The bounded, REAL gh-fetched diff excerpt (never synthesized). */
+  readonly customDiff: string;
+  readonly provenance: {
+    readonly source: 'outcome-mined';
+    readonly sourcePrUrl: string;
+    readonly mergedAt: string;
+    readonly fixReference: string | null;
+    readonly discoveredBy: null;
+  };
+  readonly knownBugs: readonly never[];
+  readonly borderlineConcerns: readonly never[];
+  /** TRIAGE HINT only — 'likely-buggy' | 'likely-clean' | 'unknown'. Not a verdict. */
+  readonly weakLabel: WeakLabel;
+  readonly weakLabelEvidence: string;
+  /** Always false on emission — flips to true only by owner adjudication. */
+  readonly adjudicated: false;
+  readonly adjudication: {
+    readonly adjudicatedAt: null;
+    readonly adjudicatedUnder: null;
+    readonly rationale: string;
+  };
+}
+
+/** The candidates file: a thin wrapper around the candidate array. */
+export interface CandidatesFile {
+  readonly rubricVersion: string;
+  readonly generatedAt: string;
+  readonly generatedBy: 'scripts/mine-pr-review-candidates.ts';
+  readonly note: string;
+  readonly candidates: readonly CandidateCase[];
+}
+
+const UNADJUDICATED_RATIONALE =
+  'UNADJUDICATED candidate mined from merged-PR history. The weakLabel is a triage ' +
+  'hint, NOT a verdict. The owner adjudicates this into buggy/clean/borderline per ' +
+  'the rubric (docs/research/pr-review-eval-labeling-rubric.md) and only then is it ' +
+  'promoted into pr-review-sample.json. The miner asserts no class.';
+
+const CANDIDATES_FILE_NOTE =
+  'CANDIDATE pr_review eval cases mined from merged-PR history for OWNER ADJUDICATION ' +
+  '(#3847). These are PROPOSALS, not dataset entries: every case is adjudicated:false ' +
+  'and carries a weakLabel triage hint (likely-buggy|likely-clean|unknown), never a ' +
+  'verdict. The pipeline does NOT fabricate adjudicated eval data. Flow: mine → owner ' +
+  'adjudicates each per the rubric → promote adjudicated cases into pr-review-sample.json.';
+
+// ============================================================================
+// Per-PR assembly (pure)
+// ============================================================================
+
+/** Map a MergedPrWithDiff onto the RawPrLike shape the harvest helpers consume. */
+function toRawPrLike(pr: MergedPrWithDiff): RawPrLike {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    url: pr.url,
+    files: pr.files.map((path) => ({ path })),
+  };
+}
+
+export interface MineOptions {
+  readonly rubricVersion: string;
+  readonly now: Date;
+  readonly diffCharCap: number;
+}
+
+/**
+ * Build one candidate case from a merged PR, its real diff, the full page (for
+ * follow-up detection), and the fix-title index. Pure.
+ */
+export function assembleCandidate(
+  pr: MergedPrWithDiff,
+  page: readonly MergedPrWithDiff[],
+  fixTitles: ReadonlyMap<number, string>,
+  opts: MineOptions
+): CandidateCase {
+  const signals = signalsFor(toRawPrLike(pr), page.map(toRawPrLike));
+  const ageDays = daysSinceMerge(pr.mergedAt, opts.now);
+  const { weakLabel, weakLabelEvidence } = deriveWeakLabel(signals, fixTitles, ageDays);
+  const firstFix = signals.followUpFixes[0];
+  const fixReference =
+    weakLabel === 'likely-buggy' && firstFix !== undefined
+      ? `#${String(firstFix.fixPrNumber)}`
+      : null;
+  return {
+    number: pr.number,
+    rubricVersion: opts.rubricVersion,
+    class: 'borderline',
+    title: pr.title,
+    customDescription: pr.body.slice(0, 500),
+    customDiff: boundDiff(pr.diff, opts.diffCharCap),
+    provenance: {
+      source: 'outcome-mined',
+      sourcePrUrl: pr.url,
+      mergedAt: pr.mergedAt,
+      fixReference,
+      discoveredBy: null,
+    },
+    knownBugs: [],
+    borderlineConcerns: [],
+    weakLabel,
+    weakLabelEvidence,
+    adjudicated: false,
+    adjudication: {
+      adjudicatedAt: null,
+      adjudicatedUnder: null,
+      rationale: UNADJUDICATED_RATIONALE,
+    },
+  };
+}
+
+// ============================================================================
+// Batch mining (pure): filter bots + dedup, assemble survivors, merge
+// ============================================================================
+
+/** A PR is eligible if it is human-authored, touches source, and is not a dedup hit. */
+function isEligible(pr: MergedPrWithDiff, dedup: DedupIndex): boolean {
+  if (isBotAuthored(pr.author)) return false;
+  if (dedup.datasetNumbers.has(pr.number)) return false;
+  if (dedup.existingCandidateNumbers.has(pr.number)) return false;
+  const touchesSource = pr.files.some(
+    (f) => f.startsWith('packages/nexus-agents/src/') && !f.endsWith('.test.ts')
+  );
+  return touchesSource;
+}
+
+/**
+ * Mine a fetched page into NEW candidate cases.
+ *
+ * Idempotent + safe: excludes bot PRs, PRs already in the dataset, and PRs
+ * already emitted as candidates (dedup against BOTH). The whole `page` is used
+ * for follow-up-fix detection even though only eligible PRs become candidates,
+ * so a later fix among the existing/bot PRs still informs the weak label.
+ */
+export function mineCandidates(
+  page: readonly MergedPrWithDiff[],
+  dedup: DedupIndex,
+  opts: MineOptions
+): readonly CandidateCase[] {
+  const fixTitles = new Map(page.map((p) => [p.number, p.title]));
+  return page
+    .filter((pr) => isEligible(pr, dedup))
+    .map((pr) => assembleCandidate(pr, page, fixTitles, opts));
+}
+
+/**
+ * Merge newly-mined candidates into the prior candidates list WITHOUT ever
+ * overwriting a candidate the owner has already adjudicated. A prior candidate
+ * with `adjudicated: true` is preserved verbatim; new candidates that collide
+ * on `number` with ANY prior candidate are dropped (re-running never clobbers).
+ */
+export function mergeCandidates(
+  prior: readonly CandidateCase[],
+  mined: readonly CandidateCase[]
+): readonly CandidateCase[] {
+  const priorNumbers = new Set(prior.map((c) => c.number));
+  const fresh = mined.filter((c) => !priorNumbers.has(c.number));
+  return [...prior, ...fresh];
+}
+
+export function buildCandidatesFile(
+  candidates: readonly CandidateCase[],
+  rubricVersion: string,
+  now: Date
+): CandidatesFile {
+  return {
+    rubricVersion,
+    generatedAt: now.toISOString().slice(0, 10),
+    generatedBy: 'scripts/mine-pr-review-candidates.ts',
+    note: CANDIDATES_FILE_NOTE,
+    candidates,
+  };
+}

--- a/scripts/mine-pr-review-candidates-core.ts
+++ b/scripts/mine-pr-review-candidates-core.ts
@@ -1,0 +1,187 @@
+/**
+ * mine-pr-review-candidates-core.ts — PURE candidate-mining logic for the
+ * pr_review eval curation pipeline (#3847).
+ *
+ * Given already-fetched merged-PR metadata + a fix/revert index, this module
+ * produces CANDIDATE pr_review eval cases (proposals) for the owner to
+ * adjudicate. It contains ZERO I/O: the `gh` shelling-out lives in
+ * mine-pr-review-candidates.ts; every decision here is unit-tested against
+ * fixtures (no live network).
+ *
+ * What this module does NOT do (owner-mandated, non-negotiable):
+ *   - It NEVER sets a final buggy/clean verdict. The only label it assigns is a
+ *     `weakLabel` ('likely-buggy' | 'likely-clean' | 'unknown') — a TRIAGE HINT,
+ *     not a ground-truth class. Every emitted case carries `adjudicated: false`.
+ *   - It NEVER invents a diff. The diff excerpt is a bounded slice of the real
+ *     `gh`-fetched diff; if none was fetched the excerpt is empty.
+ *   - It is conservative: `unknown` whenever the corrective-change signal is
+ *     ambiguous or absent-but-recent (no clean tenure established).
+ *
+ * The weak label reuses the tested rubric labeler (curate-pr-review-labeling.ts)
+ * so the mining heuristic stays consistent with the adjudication rubric
+ * (docs/research/pr-review-eval-labeling-rubric.md, #3846): a confirmed
+ * defect-fix → likely-buggy, a refinement / long-tenure-no-fix → likely-clean,
+ * an ambiguous fix → unknown.
+ *
+ * @module scripts/mine-pr-review-candidates-core
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import { proposeLabel, type PrSignals } from './curate-pr-review-labeling.js';
+
+// ============================================================================
+// Inputs (what the gh I/O layer hands us — objective, no labels)
+// ============================================================================
+
+/** A merged PR as fetched from `gh pr list --json …`. */
+export interface MergedPr {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly author: string;
+  readonly mergedAt: string;
+  readonly files: readonly string[];
+  readonly reviewDecision: string | null;
+}
+
+/** A merged PR plus its real, gh-fetched unified diff (bounded later). */
+export interface MergedPrWithDiff extends MergedPr {
+  /** The real unified diff text fetched via `gh pr diff`. */
+  readonly diff: string;
+}
+
+/** The set of PR numbers already present so the miner can dedup against them. */
+export interface DedupIndex {
+  /** PR numbers already in testing/datasets/pr-review-sample.json. */
+  readonly datasetNumbers: ReadonlySet<number>;
+  /** PR numbers already emitted to the candidates file (never re-propose). */
+  readonly existingCandidateNumbers: ReadonlySet<number>;
+}
+
+// ============================================================================
+// Bot-PR exclusion
+// ============================================================================
+
+/**
+ * Login fragments that mark a PR as bot-authored. Substring match, lower-cased:
+ * changeset-release (the version-packages PR), dependabot, github-actions, and
+ * the generic `[bot]` suffix GitHub appends to App identities.
+ */
+const BOT_AUTHOR_MARKERS: readonly string[] = [
+  'changeset-release',
+  'dependabot',
+  'github-actions',
+  'renovate',
+  '[bot]',
+  'app/',
+];
+
+/** True when the PR's author login looks bot-authored. */
+export function isBotAuthored(author: string): boolean {
+  const a = author.toLowerCase();
+  return BOT_AUTHOR_MARKERS.some((m) => a.includes(m));
+}
+
+// ============================================================================
+// Weak label (TRIAGE HINT — never a verdict)
+// ============================================================================
+
+export type WeakLabel = 'likely-buggy' | 'likely-clean' | 'unknown';
+
+export interface WeakLabelResult {
+  readonly weakLabel: WeakLabel;
+  /** The objective evidence string for the weak label (for owner triage). */
+  readonly weakLabelEvidence: string;
+}
+
+/**
+ * The minimum age (days since merge) a no-corrective-PR signal needs before it
+ * is treated as a `likely-clean` hint rather than `unknown`. Mirrors the
+ * dataset's long-tenure rationale: a defect would usually have surfaced a
+ * corrective PR within ~6 weeks, so a younger no-fix PR is not yet clean
+ * evidence. Below this floor a no-fix PR is `unknown` (no signal yet).
+ */
+export const CLEAN_TENURE_DAYS = 42;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Whole days between an ISO merge timestamp and `now` (>=0; 0 if unparseable). */
+export function daysSinceMerge(mergedAt: string, now: Date): number {
+  const merged = Date.parse(mergedAt);
+  if (Number.isNaN(merged)) return 0;
+  const diff = now.getTime() - merged;
+  return diff <= 0 ? 0 : Math.floor(diff / DAY_MS);
+}
+
+/** likely-clean hint from a refinement-only follow-up (the prior PR was not corrected). */
+function refinementClean(justification: string): WeakLabelResult {
+  return { weakLabel: 'likely-clean', weakLabelEvidence: justification };
+}
+
+/** Tenure-based clean / unknown split for a PR with NO corrective follow-up. */
+function noFixTenure(signals: PrSignals, ageDays: number): WeakLabelResult {
+  if (ageDays >= CLEAN_TENURE_DAYS) {
+    return {
+      weakLabel: 'likely-clean',
+      weakLabelEvidence:
+        `No corrective/revert PR has touched any source file #${String(signals.number)} ` +
+        `changed in the ${String(ageDays)} days since merge (>= ${String(CLEAN_TENURE_DAYS)}-day ` +
+        `long-tenure window). Long-tenure clean hint — owner confirms no defensible ` +
+        `medium+ objection from the diff before promoting.`,
+    };
+  }
+  return {
+    weakLabel: 'unknown',
+    weakLabelEvidence:
+      `No corrective/revert PR found, but #${String(signals.number)} merged only ` +
+      `${String(ageDays)} days ago (< ${String(CLEAN_TENURE_DAYS)}-day long-tenure window) — ` +
+      `too young for a clean signal. Conservative 'unknown' until the window clears.`,
+  };
+}
+
+/**
+ * Derive a conservative weak label from the rubric labeler's proposal + tenure.
+ *
+ *  - proposal `buggy`  → `likely-buggy` (a confirmed defect-fix touched the same
+ *    source file later; evidence names the fixing PR).
+ *  - proposal `clean` from a refinement-only follow-up → `likely-clean`.
+ *  - proposal `clean` from NO follow-up at all → `likely-clean` ONLY if the PR
+ *    has cleared the long-tenure window; otherwise `unknown` (too young to be a
+ *    clean signal — conservative).
+ *  - proposal `borderline` (ambiguous fix) → `unknown` (never guessed).
+ */
+export function deriveWeakLabel(
+  signals: PrSignals,
+  fixTitles: ReadonlyMap<number, string>,
+  ageDays: number
+): WeakLabelResult {
+  const proposal = proposeLabel(signals, fixTitles);
+  if (proposal.class === 'buggy') {
+    return { weakLabel: 'likely-buggy', weakLabelEvidence: proposal.justification };
+  }
+  if (proposal.class === 'borderline') {
+    return { weakLabel: 'unknown', weakLabelEvidence: proposal.justification };
+  }
+  // proposal.class === 'clean'
+  if (signals.followUpFixes.length > 0) return refinementClean(proposal.justification);
+  return noFixTenure(signals, ageDays);
+}
+
+// ============================================================================
+// Diff bounding (never invent — only bound the real diff)
+// ============================================================================
+
+/** Default cap on the candidate diff excerpt (chars). Keeps the file bounded. */
+export const DEFAULT_DIFF_CHAR_CAP = 6000;
+
+/**
+ * Bound a real diff to `cap` chars. Returns the diff verbatim when it fits;
+ * otherwise a head slice with an explicit truncation marker (so a reader never
+ * mistakes a truncated excerpt for the full diff). NEVER synthesizes content.
+ */
+export function boundDiff(diff: string, cap: number = DEFAULT_DIFF_CHAR_CAP): string {
+  if (diff.length <= cap) return diff;
+  const head = diff.slice(0, cap);
+  return `${head}\n… [diff truncated at ${String(cap)} chars — see the source PR for the full diff]`;
+}

--- a/scripts/mine-pr-review-candidates.test.ts
+++ b/scripts/mine-pr-review-candidates.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the pr_review candidate-MINING pipeline's PURE logic (#3847).
+ *
+ * Proves, against fixtures (NO live gh, NO network): bot-PR exclusion; the
+ * conservative weak-label heuristic (confirmed defect-fix → likely-buggy;
+ * refinement / long-tenure-no-fix → likely-clean; ambiguous fix or too-young
+ * no-fix → unknown); diff bounding never invents content; dedup against both the
+ * dataset and prior candidates; and that re-running never overwrites an
+ * owner-adjudicated candidate. Every emitted case is adjudicated:false with a
+ * neutral placeholder class — the miner asserts no verdict.
+ *
+ * @module scripts/mine-pr-review-candidates.test
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  boundDiff,
+  daysSinceMerge,
+  deriveWeakLabel,
+  isBotAuthored,
+  CLEAN_TENURE_DAYS,
+  DEFAULT_DIFF_CHAR_CAP,
+  type MergedPrWithDiff,
+} from './mine-pr-review-candidates-core.js';
+import {
+  assembleCandidate,
+  mineCandidates,
+  mergeCandidates,
+  buildCandidatesFile,
+  type CandidateCase,
+} from './mine-pr-review-candidates-assemble.js';
+import { parseArgs, summarize } from './mine-pr-review-candidates.js';
+import type { PrSignals, FollowUpFix } from './curate-pr-review-labeling.js';
+
+const NOW = new Date('2026-06-20T00:00:00Z');
+
+function signals(over: Partial<PrSignals> = {}): PrSignals {
+  return {
+    number: 100,
+    title: 'feat(x): a feature',
+    url: 'https://github.com/nexus-substrate/nexus-agents/pull/100',
+    changedSourceFiles: ['packages/nexus-agents/src/x/a.ts'],
+    followUpFixes: [],
+    reviewDecision: null,
+    ...over,
+  };
+}
+
+function fix(over: Partial<FollowUpFix> = {}): FollowUpFix {
+  return {
+    fixPrNumber: 200,
+    fixType: 'fix',
+    overlappingSourceFiles: ['packages/nexus-agents/src/x/a.ts'],
+    ...over,
+  };
+}
+
+function mergedPr(over: Partial<MergedPrWithDiff> = {}): MergedPrWithDiff {
+  return {
+    number: 100,
+    title: 'feat(x): a feature',
+    body: 'does a thing',
+    url: 'https://github.com/nexus-substrate/nexus-agents/pull/100',
+    author: 'williamzujkowski',
+    mergedAt: '2026-01-01T00:00:00Z',
+    files: ['packages/nexus-agents/src/x/a.ts'],
+    reviewDecision: null,
+    diff: 'diff --git a/x b/x\n+const x = 1;\n',
+    ...over,
+  };
+}
+
+// ============================================================================
+// Bot-PR exclusion
+// ============================================================================
+
+describe('isBotAuthored', () => {
+  it('flags changeset-release, dependabot, github-actions, and [bot]', () => {
+    expect(isBotAuthored('changeset-release[bot]')).toBe(true);
+    expect(isBotAuthored('dependabot[bot]')).toBe(true);
+    expect(isBotAuthored('github-actions[bot]')).toBe(true);
+    expect(isBotAuthored('renovate[bot]')).toBe(true);
+  });
+  it('does not flag human logins', () => {
+    expect(isBotAuthored('williamzujkowski')).toBe(false);
+    expect(isBotAuthored('grenlan')).toBe(false);
+  });
+});
+
+// ============================================================================
+// daysSinceMerge
+// ============================================================================
+
+describe('daysSinceMerge', () => {
+  it('computes whole days, floors negatives/unparseable to 0', () => {
+    expect(daysSinceMerge('2026-06-10T00:00:00Z', NOW)).toBe(10);
+    expect(daysSinceMerge('2026-06-25T00:00:00Z', NOW)).toBe(0); // future → 0
+    expect(daysSinceMerge('not-a-date', NOW)).toBe(0);
+  });
+});
+
+// ============================================================================
+// Weak-label heuristic (TRIAGE HINT — never a verdict)
+// ============================================================================
+
+describe('deriveWeakLabel — conservative triage heuristic', () => {
+  it('likely-buggy on a confirmed defect-fix follow-up', () => {
+    const r = deriveWeakLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(x): guard against a silently dropped result']]),
+      100
+    );
+    expect(r.weakLabel).toBe('likely-buggy');
+    expect(r.weakLabelEvidence).toContain('#200');
+  });
+
+  it('likely-clean on a refinement-only follow-up', () => {
+    const r = deriveWeakLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(x): refine heuristics, no behavior change']]),
+      100
+    );
+    expect(r.weakLabel).toBe('likely-clean');
+  });
+
+  it('likely-clean on NO follow-up once the long-tenure window clears', () => {
+    const r = deriveWeakLabel(signals(), new Map(), CLEAN_TENURE_DAYS + 1);
+    expect(r.weakLabel).toBe('likely-clean');
+    expect(r.weakLabelEvidence).toContain('long-tenure');
+  });
+
+  it('unknown on NO follow-up when the PR is too young (conservative)', () => {
+    const r = deriveWeakLabel(signals(), new Map(), CLEAN_TENURE_DAYS - 1);
+    expect(r.weakLabel).toBe('unknown');
+    expect(r.weakLabelEvidence).toContain('too young');
+  });
+
+  it('unknown on an ambiguous bare fix (never guessed)', () => {
+    const r = deriveWeakLabel(
+      signals({ followUpFixes: [fix()] }),
+      new Map([[200, 'fix(x): tweak']]),
+      100
+    );
+    expect(r.weakLabel).toBe('unknown');
+  });
+});
+
+// ============================================================================
+// Diff bounding (never invent)
+// ============================================================================
+
+describe('boundDiff', () => {
+  it('returns the diff verbatim when within the cap', () => {
+    expect(boundDiff('short diff', 100)).toBe('short diff');
+  });
+  it('truncates with an explicit marker, never synthesizes', () => {
+    const big = 'x'.repeat(DEFAULT_DIFF_CHAR_CAP + 100);
+    const bounded = boundDiff(big);
+    expect(bounded.length).toBeLessThan(big.length + 100);
+    expect(bounded).toContain('diff truncated');
+    expect(bounded.startsWith('x'.repeat(DEFAULT_DIFF_CHAR_CAP))).toBe(true);
+  });
+});
+
+// ============================================================================
+// assembleCandidate — schema mirrors pr-review-sample + candidate fields
+// ============================================================================
+
+describe('assembleCandidate', () => {
+  const page = [
+    mergedPr({ number: 100, mergedAt: '2026-01-01T00:00:00Z' }),
+    mergedPr({
+      number: 200,
+      title: 'fix(x): guard against a silently dropped result',
+      body: 'follow-up to #100',
+      files: ['packages/nexus-agents/src/x/a.ts'],
+    }),
+  ];
+  const titles = new Map(page.map((p) => [p.number, p.title]));
+
+  it('emits a neutral, adjudicated:false candidate carrying only a weakLabel', () => {
+    const c = assembleCandidate(page[0]!, page, titles, {
+      rubricVersion: '1.0.0',
+      now: NOW,
+      diffCharCap: DEFAULT_DIFF_CHAR_CAP,
+    });
+    expect(c.class).toBe('borderline'); // neutral placeholder, NOT a verdict
+    expect(c.adjudicated).toBe(false);
+    expect(c.knownBugs).toEqual([]);
+    expect(c.adjudication.adjudicatedAt).toBeNull();
+    expect(c.adjudication.rationale).toContain('UNADJUDICATED');
+    expect(c.provenance.source).toBe('outcome-mined');
+    // #100 has a defect-fix follow-up (#200) → likely-buggy + fixReference set.
+    expect(c.weakLabel).toBe('likely-buggy');
+    expect(c.provenance.fixReference).toBe('#200');
+  });
+
+  it('uses the REAL diff (bounded), never invents one', () => {
+    const c = assembleCandidate(page[0]!, page, titles, {
+      rubricVersion: '1.0.0',
+      now: NOW,
+      diffCharCap: DEFAULT_DIFF_CHAR_CAP,
+    });
+    expect(c.customDiff).toBe(page[0]!.diff);
+  });
+});
+
+// ============================================================================
+// mineCandidates — bot/dedup filtering
+// ============================================================================
+
+describe('mineCandidates — eligibility + dedup', () => {
+  const opts = { rubricVersion: '1.0.0', now: NOW, diffCharCap: DEFAULT_DIFF_CHAR_CAP };
+
+  it('excludes bot PRs, dataset PRs, prior candidates, and non-source PRs', () => {
+    const page: MergedPrWithDiff[] = [
+      mergedPr({ number: 1, author: 'williamzujkowski', mergedAt: '2026-01-01T00:00:00Z' }),
+      mergedPr({ number: 2, author: 'changeset-release[bot]' }), // bot
+      mergedPr({ number: 3 }), // dataset dup
+      mergedPr({ number: 4 }), // prior-candidate dup
+      mergedPr({ number: 5, files: ['docs/x.md'] }), // no source
+    ];
+    const dedup = {
+      datasetNumbers: new Set([3]),
+      existingCandidateNumbers: new Set([4]),
+    };
+    const mined = mineCandidates(page, dedup, opts);
+    expect(mined.map((c) => c.number)).toEqual([1]);
+  });
+
+  it('is idempotent: re-mining the same page against its own output adds nothing', () => {
+    const page = [
+      mergedPr({ number: 1, mergedAt: '2026-01-01T00:00:00Z' }),
+      mergedPr({ number: 2, mergedAt: '2026-01-01T00:00:00Z' }),
+    ];
+    const dedup = {
+      datasetNumbers: new Set<number>(),
+      existingCandidateNumbers: new Set<number>(),
+    };
+    const first = mineCandidates(page, dedup, opts);
+    const second = mineCandidates(
+      page,
+      {
+        datasetNumbers: new Set<number>(),
+        existingCandidateNumbers: new Set(first.map((c) => c.number)),
+      },
+      opts
+    );
+    expect(second).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// mergeCandidates — never overwrite an adjudicated candidate
+// ============================================================================
+
+describe('mergeCandidates', () => {
+  function candidate(over: Partial<CandidateCase>): CandidateCase {
+    return {
+      number: 1,
+      rubricVersion: '1.0.0',
+      class: 'borderline',
+      title: 't',
+      customDescription: '',
+      customDiff: '',
+      provenance: {
+        source: 'outcome-mined',
+        sourcePrUrl: '',
+        mergedAt: '',
+        fixReference: null,
+        discoveredBy: null,
+      },
+      knownBugs: [],
+      borderlineConcerns: [],
+      weakLabel: 'unknown',
+      weakLabelEvidence: '',
+      adjudicated: false,
+      adjudication: { adjudicatedAt: null, adjudicatedUnder: null, rationale: '' },
+      ...over,
+    };
+  }
+
+  it('preserves a prior adjudicated candidate verbatim and drops a colliding new one', () => {
+    const prior = [
+      {
+        ...candidate({ number: 7 }),
+        adjudicated: true as unknown as false,
+        weakLabel: 'likely-buggy' as const,
+      },
+    ];
+    const mined = [candidate({ number: 7, weakLabel: 'unknown' }), candidate({ number: 8 })];
+    const merged = mergeCandidates(prior, mined);
+    const seven = merged.find((c) => c.number === 7);
+    expect(seven?.adjudicated).toBe(true); // not clobbered
+    expect(seven?.weakLabel).toBe('likely-buggy');
+    expect(merged.map((c) => c.number).sort((a, b) => a - b)).toEqual([7, 8]);
+  });
+});
+
+// ============================================================================
+// buildCandidatesFile + CLI helpers
+// ============================================================================
+
+describe('buildCandidatesFile', () => {
+  it('wraps candidates with the no-fabrication note and generator stamp', () => {
+    const file = buildCandidatesFile([], '1.0.0', NOW);
+    expect(file.generatedBy).toBe('scripts/mine-pr-review-candidates.ts');
+    expect(file.note).toContain('not dataset entries');
+    expect(file.note).toContain('triage hint');
+    expect(file.generatedAt).toBe('2026-06-20');
+  });
+});
+
+describe('parseArgs / summarize', () => {
+  it('parses limit/diff-cap/out with sane defaults', () => {
+    expect(parseArgs([])).toEqual({
+      limit: 50,
+      diffCap: DEFAULT_DIFF_CHAR_CAP,
+      out: expect.any(String),
+    });
+    const a = parseArgs(['--limit', '10', '--diff-cap', '500', '--out', '/tmp/x.json']);
+    expect(a).toEqual({ limit: 10, diffCap: 500, out: '/tmp/x.json' });
+  });
+
+  it('tallies weak labels for the run summary', () => {
+    const cs = [
+      { weakLabel: 'likely-buggy' },
+      { weakLabel: 'likely-clean' },
+      { weakLabel: 'likely-clean' },
+      { weakLabel: 'unknown' },
+    ] as CandidateCase[];
+    expect(summarize(cs)).toBe('likely-buggy=1 likely-clean=2 unknown=1');
+  });
+});

--- a/scripts/mine-pr-review-candidates.ts
+++ b/scripts/mine-pr-review-candidates.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env npx tsx
+/**
+ * mine-pr-review-candidates.ts — the gh-fetch I/O layer of the pr_review
+ * candidate-MINING curation pipeline (#3847).
+ *
+ * Mines recently-merged PRs from nexus-substrate/nexus-agents via `gh` and emits
+ * CANDIDATE pr_review eval cases to testing/datasets/pr-review-candidates.json
+ * for the OWNER to adjudicate per the rubric. It runs LOCALLY with the owner's
+ * `gh` auth (the owner runs it; CI does not — see the test, which uses fixtures).
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * NO-FABRICATION GUARANTEE (owner-mandated, non-negotiable)
+ * ───────────────────────────────────────────────────────────────────────────
+ * This pipeline produces CANDIDATES + weak labels ONLY. It does NOT fabricate
+ * adjudicated eval data — the whole point of the eval is REAL owner-adjudicated
+ * cases. Concretely:
+ *   - Every emitted case is `adjudicated: false` with a neutral placeholder
+ *     `class: "borderline"`, empty knownBugs, and an UNADJUDICATED rationale.
+ *   - The only signal the miner assigns is `weakLabel`
+ *     (likely-buggy | likely-clean | unknown) — a TRIAGE HINT to order the
+ *     owner's adjudication queue, NOT a verdict.
+ *   - The diff is a bounded slice of the REAL `gh pr diff` output; never invented.
+ *
+ * Idempotent + safe: re-running dedups against BOTH the curated dataset
+ * (testing/datasets/pr-review-sample.json) and the already-emitted candidates
+ * file, and NEVER overwrites a candidate the owner has marked `adjudicated:true`.
+ *
+ * All rubric / labeling / assembly logic is pure + unit-tested in
+ * mine-pr-review-candidates-core.ts and mine-pr-review-candidates-assemble.ts
+ * (mirrors the curate-pr-review-harvest / -labeling split). This file is the
+ * thin, untested-by-unit `gh` edge (like build-model-registry.ts).
+ *
+ * Usage (owner runs locally with gh auth):
+ *   npm run eval:mine-candidates -- [--limit N] [--diff-cap CHARS] [--out PATH]
+ *   npx tsx scripts/mine-pr-review-candidates.ts [--limit N] …
+ *
+ * @module scripts/mine-pr-review-candidates
+ * (Source: Issue #3847, epic #3845; rubric #3846)
+ */
+
+/* eslint-disable no-console -- CLI script that prints progress */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  DEFAULT_DIFF_CHAR_CAP,
+  type DedupIndex,
+  type MergedPr,
+  type MergedPrWithDiff,
+} from './mine-pr-review-candidates-core.js';
+import {
+  buildCandidatesFile,
+  mergeCandidates,
+  mineCandidates,
+  type CandidateCase,
+  type CandidatesFile,
+} from './mine-pr-review-candidates-assemble.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const REPO = 'nexus-substrate/nexus-agents';
+const DATASET_PATH = path.join(REPO_ROOT, 'testing/datasets/pr-review-sample.json');
+const RUBRIC_PATH = path.join(REPO_ROOT, 'docs/research/pr-review-eval-labeling-rubric.md');
+const DEFAULT_OUT = path.join(REPO_ROOT, 'testing/datasets/pr-review-candidates.json');
+
+// ============================================================================
+// gh fetch (the only I/O)
+// ============================================================================
+
+interface RawListPr {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly mergedAt: string;
+  readonly author: { readonly login: string } | null;
+  readonly files: ReadonlyArray<{ readonly path: string }>;
+  readonly reviewDecision?: string;
+}
+
+/** A page of merged PRs from `gh pr list --json …`. Throws on gh failure. */
+function fetchMergedPrs(limit: number): readonly RawListPr[] {
+  const out = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      REPO,
+      '--state',
+      'merged',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,body,url,mergedAt,author,files,reviewDecision',
+    ],
+    { encoding: 'utf-8', maxBuffer: 128 * 1024 * 1024 }
+  );
+  return JSON.parse(out) as readonly RawListPr[];
+}
+
+/** Fetch the real unified diff for one PR. Empty string on any gh failure. */
+function fetchPrDiff(number: number): string {
+  try {
+    return execFileSync('gh', ['pr', 'diff', String(number), '--repo', REPO], {
+      encoding: 'utf-8',
+      maxBuffer: 128 * 1024 * 1024,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function toMergedPr(raw: RawListPr): MergedPr {
+  return {
+    number: raw.number,
+    title: raw.title,
+    body: raw.body,
+    url: raw.url,
+    author: raw.author?.login ?? '',
+    mergedAt: raw.mergedAt,
+    files: raw.files.map((f) => f.path),
+    reviewDecision: raw.reviewDecision ?? null,
+  };
+}
+
+// ============================================================================
+// Dedup index + prior candidates (read-only file I/O)
+// ============================================================================
+
+interface DatasetShape {
+  readonly rubricVersion: string;
+  readonly prs: ReadonlyArray<{ readonly number: string | number }>;
+}
+
+function loadDatasetNumbers(): { readonly numbers: Set<number>; readonly rubricVersion: string } {
+  const raw = JSON.parse(fs.readFileSync(DATASET_PATH, 'utf-8')) as DatasetShape;
+  const numbers = new Set<number>();
+  for (const pr of raw.prs) {
+    if (typeof pr.number === 'number') numbers.add(pr.number);
+  }
+  return { numbers, rubricVersion: raw.rubricVersion };
+}
+
+function loadPriorCandidates(outPath: string): readonly CandidateCase[] {
+  if (!fs.existsSync(outPath)) return [];
+  const raw = JSON.parse(fs.readFileSync(outPath, 'utf-8')) as Partial<CandidatesFile>;
+  return raw.candidates ?? [];
+}
+
+// ============================================================================
+// CLI
+// ============================================================================
+
+interface Args {
+  readonly limit: number;
+  readonly diffCap: number;
+  readonly out: string;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  let limit = 50;
+  let diffCap = DEFAULT_DIFF_CHAR_CAP;
+  let out = DEFAULT_OUT;
+  for (let i = 0; i < argv.length; i += 1) {
+    const next = argv[i + 1];
+    if (next === undefined) continue;
+    if (argv[i] === '--limit') limit = Number(next);
+    if (argv[i] === '--diff-cap') diffCap = Number(next);
+    if (argv[i] === '--out') out = next;
+  }
+  return { limit, diffCap, out };
+}
+
+function summarize(candidates: readonly CandidateCase[]): string {
+  const tally = { 'likely-buggy': 0, 'likely-clean': 0, unknown: 0 };
+  for (const c of candidates) tally[c.weakLabel] += 1;
+  return (
+    `likely-buggy=${String(tally['likely-buggy'])} ` +
+    `likely-clean=${String(tally['likely-clean'])} ` +
+    `unknown=${String(tally.unknown)}`
+  );
+}
+
+function run(args: Args): void {
+  console.log(`Mining up to ${String(args.limit)} merged PRs from ${REPO} …`);
+  const { numbers: datasetNumbers, rubricVersion } = loadDatasetNumbers();
+  const prior = loadPriorCandidates(args.out);
+  const dedup: DedupIndex = {
+    datasetNumbers,
+    existingCandidateNumbers: new Set(prior.map((c) => c.number)),
+  };
+
+  const list = fetchMergedPrs(args.limit);
+  // Attach the real diff only to PRs that will actually be assembled — but pass
+  // the whole page (with diffs lazily empty for ineligible PRs) for follow-up
+  // detection. We fetch diffs only for not-yet-known, non-bot, source-touching
+  // PRs to keep the gh round-trips bounded.
+  const page: readonly MergedPrWithDiff[] = list.map((raw) => {
+    const base = toMergedPr(raw);
+    const known =
+      dedup.datasetNumbers.has(base.number) || dedup.existingCandidateNumbers.has(base.number);
+    const diff = known ? '' : fetchPrDiff(base.number);
+    return { ...base, diff };
+  });
+
+  const now = new Date();
+  const mined = mineCandidates(page, dedup, {
+    rubricVersion,
+    now,
+    diffCharCap: args.diffCap,
+  });
+  const all = mergeCandidates(prior, mined);
+
+  console.log(
+    `Mined ${String(mined.length)} NEW candidates ` +
+      `(${String(prior.length)} prior preserved, total ${String(all.length)}); ${summarize(mined)}`
+  );
+  const file = buildCandidatesFile(all, rubricVersion, now);
+  fs.writeFileSync(args.out, `${JSON.stringify(file, null, 2)}\n`, 'utf-8');
+  console.log(`Wrote ${args.out}`);
+  console.log(
+    `Next: the OWNER adjudicates each candidate into buggy/clean/borderline per ` +
+      `${path.relative(REPO_ROOT, RUBRIC_PATH)}, then promotes adjudicated cases into ` +
+      `testing/datasets/pr-review-sample.json. The weakLabel is a triage hint, not a verdict.`
+  );
+}
+
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  run(parseArgs(process.argv.slice(2)));
+}
+
+export { parseArgs, toMergedPr, summarize };

--- a/testing/datasets/pr-review-candidates.json
+++ b/testing/datasets/pr-review-candidates.json
@@ -1,0 +1,7 @@
+{
+  "rubricVersion": "1.0.0",
+  "generatedAt": "2026-06-20",
+  "generatedBy": "scripts/mine-pr-review-candidates.ts",
+  "note": "CANDIDATE pr_review eval cases mined from merged-PR history for OWNER ADJUDICATION (#3847). These are PROPOSALS, not dataset entries: every case is adjudicated:false and carries a weakLabel triage hint (likely-buggy|likely-clean|unknown), never a verdict. The pipeline does NOT fabricate adjudicated eval data. Flow: mine -> owner adjudicates each per the rubric -> promote adjudicated cases into pr-review-sample.json. This seed file is intentionally empty; the owner runs `npm run eval:mine-candidates` locally (with gh auth) to populate it. Re-running dedups against pr-review-sample.json and this file, and never overwrites an adjudicated:true candidate.",
+  "candidates": []
+}


### PR DESCRIPTION
## What

A curation pipeline that **mines this repo's merged-PR history into CANDIDATE pr_review eval cases** for the owner to adjudicate, to grow `testing/datasets/pr-review-sample.json` from n=19 toward n>=50. The pipeline produces **candidates + weak labels ONLY** — it never fabricates an adjudicated verdict. Closes part of #3847 (epic #3845; rubric #3846). Does not close #3847 (the owner still runs the miner + adjudicates).

## The mine → adjudicate → promote flow

1. **Mine** — owner runs `npm run eval:mine-candidates` **locally** (shells out to `gh` with the owner's auth; CI never runs it). Pulls a window of recently-merged PRs, excludes bot PRs + dataset/candidate dups, fetches each PR's real bounded diff + objective signals, and appends NEW candidates to `testing/datasets/pr-review-candidates.json`.
2. **Adjudicate** — owner reads each candidate, sets the REAL `class` (buggy/clean/borderline) per the [rubric](docs/research/pr-review-eval-labeling-rubric.md), fills `knownBugs`/rationale, and flips `adjudicated: true`. The `weakLabel` only orders this queue.
3. **Promote** — adjudicated cases move into `pr-review-sample.json` (via `curate-pr-review-dataset.ts add` for a rubric-valid skeleton), then `validate` + `stats` confirm rubric validity and track n>=50.

Full doc: `docs/research/pr-review-eval-curation.md`.

## The weak-label heuristic (a TRIAGE HINT, not a verdict)

Derived purely from objective signals via the same tested rubric labeler the adjudication uses, so mining stays consistent with adjudication:

| weakLabel | Objective signal |
| --- | --- |
| `likely-buggy` | A later `fix(`/`revert` on the same source file that reads as a genuine defect correction (adds guard/fail-loud/resolution, or a revert). Evidence names the fixing PR. |
| `likely-clean` | A refinement-only follow-up (tunes heuristics / no-behavior-change), OR no corrective PR within the **42-day long-tenure window**. |
| `unknown` | A `fix(` whose nature can't be established from its title, OR no corrective PR but the PR is **too young** (< 42 days) — conservative. |

`weakLabel` is a hint to order the owner's adjudication queue; it is **never** the shipped label. `weakLabelEvidence` records the exact objective basis (fixing PR / refinement marker / tenure). The 42-day window mirrors the dataset's existing long-tenure clean rationale and avoids the rejected ~1-week no-fix window (too high a false-clean risk).

## No-fabrication guarantee

The pipeline produces candidates + weak labels ONLY — the eval's value is REAL owner-adjudicated cases; a guessed verdict would poison the metric. Every emitted case:

- is `adjudicated: false` with a neutral placeholder `class: "borderline"`, empty `knownBugs`/`borderlineConcerns`, and an `UNADJUDICATED` rationale;
- carries the signal **only** in `weakLabel`/`weakLabelEvidence` — the miner asserts no buggy/clean class;
- has a `customDiff` that is a **bounded slice of the REAL `gh pr diff`** (truncated with an explicit marker; empty if the fetch fails), never synthesized.

Stated in the script header + doc and enforced by the test.

## Idempotent + safe

Re-running dedups against **both** the dataset and the candidates file, excludes bot PRs (changeset-release/dependabot/github-actions/renovate/`[bot]`), **never overwrites an `adjudicated: true` candidate**, and never invents a diff.

## How the owner runs it

```bash
npm run eval:mine-candidates                 # 50 most-recent merged PRs (local; gh auth)
npx tsx scripts/mine-pr-review-candidates.ts --limit 80 --diff-cap 6000
```
Then adjudicate `pr-review-candidates.json` in place and promote into `pr-review-sample.json`.

## Architecture (pure core, gh at the edges)

- `scripts/mine-pr-review-candidates-core.ts` — pure: bot exclusion, tenure math, weak-label heuristic, diff bounding.
- `scripts/mine-pr-review-candidates-assemble.ts` — pure: candidate assembly (schema mirrors the sample + `weakLabel`/`weakLabelEvidence`/`adjudicated`), dedup, adjudication-preserving merge.
- `scripts/mine-pr-review-candidates.ts` — thin `gh` I/O edge + CLI.
- `scripts/mine-pr-review-candidates.test.ts` — **18 tests, fixtures only, NO network** (Script Tests job).
- Reuses `curate-pr-review-labeling.ts` (exported `RawPrLike` from `curate-pr-review-harvest.ts` to share signal extraction).

## Verification

- `vitest`: 18 new tests green; existing curate-pr-review tests still green (56 pr_review-related tests total; full root Script Tests suite 387 green).
- `eslint` clean on all changed files; `tsc --noEmit` introduces no new errors in changed files; `prettier --check` clean.
- Repo-index `--check` green (npm script + scripts/ files don't trip the gate). cspell clean (`sdlc` added to dictionary).
- Smoke-tested the gh I/O path with a stubbed `gh` (no network): bot PR excluded, follow-up-fix PR → likely-buggy with fixReference, all `adjudicated: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)