### PR TITLE
security: pin CI to ubuntu-latest, drop CI_RUNNER self-hosted escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   commitlint:
     name: Commit Messages
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
@@ -30,7 +30,7 @@ jobs:
 
   changeset-check:
     name: Changeset Presence
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   producer-consumer-check:
     name: Producer/Consumer Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -77,7 +77,7 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.os }})
-    runs-on: ${{ vars.CI_RUNNER || matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -111,7 +111,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
-    runs-on: ${{ vars.CI_RUNNER || matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
   # them via the root vitest.config.ts.
   script-tests:
     name: Script Tests
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -184,7 +184,7 @@ jobs:
 
   fitness-audit:
     name: Fitness Audit (${{ matrix.os }})
-    runs-on: ${{ vars.CI_RUNNER || matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -221,7 +221,7 @@ jobs:
   # writable homedir, one with a read-only homedir (the sandbox case).
   consolidation-test:
     name: Consolidation E2E
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -244,7 +244,7 @@ jobs:
 
   model-string-drift:
     name: Model String Drift Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -285,7 +285,7 @@ jobs:
 
   index-check:
     name: Index Freshness Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     # Warning only - does not block CI
     continue-on-error: true
@@ -307,7 +307,7 @@ jobs:
 
   security:
     name: Security Audit
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -325,7 +325,7 @@ jobs:
     name: CI Success
     needs:
       [commitlint, changeset-check, lint, typecheck, build, test, fitness-audit, consolidation-test]
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
     steps:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -44,7 +44,7 @@ jobs:
   # (#2027)
   typedoc-check:
     name: TypeDoc Verification
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -77,7 +77,7 @@ jobs:
   # Job 3: Documentation Coverage Check (non-blocking warning per DevEx amendment)
   docs-coverage:
     name: Documentation Coverage
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     continue-on-error: true
@@ -261,7 +261,7 @@ jobs:
   # Job 5: Secrets Guardrails
   secrets-scan:
     name: Documentation Secrets Scan
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -277,7 +277,7 @@ jobs:
   # Job 6: Repository Index Check
   repo-index:
     name: Repository Index Verification
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -301,7 +301,7 @@ jobs:
   # memory and fail if the committed output differs.
   tool-reference-drift:
     name: Tool Reference Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -334,7 +334,7 @@ jobs:
   # drift gate: regenerate in memory and fail if the committed output differs.
   strategy-reference-drift:
     name: Strategy Reference Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -355,7 +355,7 @@ jobs:
   # Job 8: DocOps Skill Synchronization
   docops-skill-sync:
     name: DocOps Skill Sync
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
 
@@ -381,7 +381,7 @@ jobs:
   # Job 8b: Registry-Coverage Gate (#2406)
   registry-coverage:
     name: Registry-Coverage Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
 
@@ -400,7 +400,7 @@ jobs:
   # must agree with the TOOL_DESCRIPTIONS doc-table source.
   mcp-description-drift:
     name: MCP Description Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
 
@@ -416,7 +416,7 @@ jobs:
   # Job 8d: Orphan Detection (#2410) — audit-only v1
   orphan-detection:
     name: Orphan Detection
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
 
@@ -432,7 +432,7 @@ jobs:
   # Job 9: Canonical Index Validation
   canonical-index:
     name: Canonical Index Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -457,7 +457,7 @@ jobs:
   # option-B federation invariant: redirects, never duplication.
   harness-alignment:
     name: Harness Alignment Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -470,7 +470,7 @@ jobs:
   # Job 10: Markdown Linting
   markdown-lint:
     name: Markdown Lint
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -491,7 +491,7 @@ jobs:
   # Job 10.5: Documentation Content Drift Detection
   docs-content-drift:
     name: Docs Content Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -655,7 +655,7 @@ jobs:
   # Job 10.6: Skills Index Freshness (#1828)
   skills-index-check:
     name: Skills Index Freshness
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -674,7 +674,7 @@ jobs:
   # Job 10.7: Agents Index Freshness + Gap Coverage (#1825 follow-up)
   agents-index-check:
     name: Agents Index Freshness
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -693,7 +693,7 @@ jobs:
   # Job 11: Governance Registry Drift Detection
   governance-drift:
     name: Governance Drift Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -744,7 +744,7 @@ jobs:
   # high-precision via a closed set of sentinel regexes (low false positives).
   claims-check:
     name: Claims Registry Drift
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -765,7 +765,7 @@ jobs:
   # Job 13: Spell Check (Warning Only)
   spell-check:
     name: Spell Check
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     # Non-blocking - reports warnings only
     continue-on-error: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -31,7 +31,7 @@ permissions: read-all
 jobs:
   link-check:
     name: Check Links
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     # #3778 (Rule-of-Two CI leg): skip on auto-remediation bot-branch PRs — the
     # plan doc is markdown (matches the path filter) and this job carries

--- a/.github/workflows/npm-verify.yml
+++ b/.github/workflows/npm-verify.yml
@@ -38,7 +38,7 @@ jobs:
   verify-from-source:
     name: Verify pre-publish tarball
     if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
@@ -69,7 +69,7 @@ jobs:
   verify-published-latest:
     name: Verify published @latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/opencode-e2e.yml
+++ b/.github/workflows/opencode-e2e.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   opencode-e2e:
     name: OpenCode E2E (Linux)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push'
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: write
@@ -249,7 +249,7 @@ jobs:
   manual-publish:
     name: Manual Publish
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read


### PR DESCRIPTION
Part of the cross-repo self-hosted-runner removal (williamzujkowski/homelab-iac#747).

All 39 workflow jobs across 6 files used `runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` (and `|| matrix.os` for the 3 matrix jobs). `CI_RUNNER` was a dormant repo-variable escape hatch to redirect CI onto a self-hosted runner.

This hardcodes `ubuntu-latest` (and `${{ matrix.os }}` for matrix jobs) everywhere, removing the self-hosted capability. **Zero behavior change** — `CI_RUNNER` is unset, so every job already runs on GitHub-hosted runners; this just removes the ability to flip them onto a self-hosted runner.

Files: ci.yml (14), docs-check.yml (19), release.yml (2), npm-verify.yml (2), link-check.yml (1), opencode-e2e.yml (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)