### PR TITLE
feat(governance): surface authentic-vote-record persistence outcome in consensus_vote result (#3991)

### DIFF
--- a/.changeset/surface-vote-record-persistence-3991.md
+++ b/.changeset/surface-vote-record-persistence-3991.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): surface authentic-vote-record persistence outcome in consensus_vote result (#3991)
+
+The `consensus_vote` tool persists an authentic, committable vote record
+(`governance/vote-records.jsonl`, #3897) at vote time, but a skipped or failed
+persist was only a server-side WARN — invisible to MCP clients. A live 2.135.0
+vote produced a real decision with NO persisted record and no signal the MCP
+caller could see.
+
+Observability only — the persistence path and cwd-resolution logic are
+UNCHANGED, the vote outcome is unchanged, and persistence stays best-effort
+(a persist skip never fails or blocks the vote).
+
+- `recordAuthenticVote` now returns a structured `VoteRecordPersistOutcome`
+  (`{ persisted: true, record }` or `{ persisted: false, reason, detail }`,
+  where `reason` is `'all-simulated' | 'no-repo-root' | 'write-failed'`). The
+  `no-repo-root` detail reuses the existing server WARN text, so it carries the
+  actionable fix (set `NEXUS_VOTE_RECORDS_PATH` or commit the returned bytes).
+- The `consensus_vote` result gains additive fields `voteRecordPersisted:
+  boolean` and, when not persisted, `voteRecordNote: string`. The output schema
+  is updated to match. No existing result fields are renamed or removed; the
+  tool description is unchanged.
+- The server-side WARN is retained (defense-in-depth).

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -51,6 +51,23 @@ export const VOTE_RECORDS_PATH_ENV = 'NEXUS_VOTE_RECORDS_PATH';
 /** Max proposal chars retained in the human record (full text is hashed). */
 const MAX_PROPOSAL_RECORD_CHARS = 500;
 
+/**
+ * Actionable message for the no-committable-location skip (#3927, surfaced to
+ * MCP callers in #3991). Exported so the `consensus_vote` result note can reuse
+ * the EXACT text the server WARN logs — one source of truth for the
+ * "how to fix" guidance (set {@link VOTE_RECORDS_PATH_ENV} or commit the
+ * returned bytes). Previously this guidance only reached server stderr.
+ */
+export function voteRecordNoRootMessage(): string {
+  return (
+    'Authentic vote record NOT persisted: no repo root found from process.cwd() ' +
+    'and no override set. Per #3927 the authoritative population path is ' +
+    'caller-commits — commit the returned record bytes into ' +
+    `${VOTE_RECORDS_REL_PATH} in the promotion PR. To force a server-side ` +
+    `write, set ${VOTE_RECORDS_PATH_ENV} to an absolute file path.`
+  );
+}
+
 /** Map a consensus outcome to the recorded decision vocabulary. */
 function outcomeToDecision(result: ConsensusResult): VoteRecord['decision'] {
   if (result.outcome === 'approved') return 'approved';
@@ -212,14 +229,7 @@ export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | 
   const logger = opts.logger ?? createLogger({ component: 'vote-record-store' });
   const filePath = opts.filePath ?? resolveVoteRecordsPath();
   if (filePath === undefined) {
-    logger.warn(
-      'Authentic vote record NOT persisted: no repo root found from process.cwd() ' +
-        'and no override set. Per #3927 the authoritative population path is ' +
-        'caller-commits — commit the returned record bytes into ' +
-        `${VOTE_RECORDS_REL_PATH} in the promotion PR. To force a server-side ` +
-        `write, set ${VOTE_RECORDS_PATH_ENV} to an absolute file path.`,
-      { id: opts.id }
-    );
+    logger.warn(voteRecordNoRootMessage(), { id: opts.id });
     return undefined;
   }
   try {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the authentic-vote-record persistence OUTCOME (#3991).
+ *
+ * `recordAuthenticVote` returns a structured {@link VoteRecordPersistOutcome} so
+ * a skipped/failed persist is observable to the MCP caller instead of being a
+ * server-only WARN. Covered: all-simulated skip, no-committable-root skip (with
+ * an actionable `NEXUS_VOTE_RECORDS_PATH` detail), env-override write, and
+ * repo-root write. The persistence/cwd-resolution logic itself is unchanged —
+ * these assert only the classification of the outcome.
+ *
+ * @module mcp/tools/consensus-vote-recording.test
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { findRepoRoot } from '../../config/repo-root-detection.js';
+import { VOTE_RECORDS_PATH_ENV, VOTE_RECORDS_REL_PATH } from '../../audit/vote-record-store.js';
+import type { ConsensusResult, Vote } from '../../consensus/types.js';
+import type { AgentVoteResult, VoterRole } from '../../cli/vote-types.js';
+
+import { recordAuthenticVote } from './consensus-vote-recording.js';
+
+vi.mock('../../config/repo-root-detection.js', () => ({
+  findRepoRoot: vi.fn(() => null),
+}));
+
+function vote(decision: Vote['decision'], confidence: number): Vote {
+  return { decision, confidence, reasoning: 'because' };
+}
+
+function agentVote(
+  role: VoterRole,
+  decision: Vote['decision'],
+  source: AgentVoteResult['source'] = 'llm'
+): AgentVoteResult {
+  return { role, vote: vote(decision, 0.8), processingTimeMs: 10, source };
+}
+
+function consensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
+  const now = '2026-06-15T00:00:00.000Z';
+  return {
+    proposalId: 'p-1',
+    proposal: { title: 'T', description: 'D', algorithm: 'higher_order' },
+    outcome: 'approved',
+    votes: new Map(),
+    voteCounts: { approve: 2, reject: 1, abstain: 0, total: 3 },
+    approvalPercentage: 66.7,
+    quorumReached: true,
+    startedAt: now,
+    closedAt: now,
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+const realVotes: readonly AgentVoteResult[] = [
+  agentVote('architect', 'approve'),
+  agentVote('security', 'approve'),
+  agentVote('catfish', 'reject'),
+];
+
+describe('recordAuthenticVote persistence outcome (#3991)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'vote-outcome-'));
+    vi.mocked(findRepoRoot).mockReturnValue(null);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports all-simulated when every vote is simulated', () => {
+    const outcome = recordAuthenticVote({
+      proposal: 'p',
+      strategy: 'simple_majority',
+      result: consensusResult(),
+      votes: [
+        agentVote('architect', 'approve', 'simulation'),
+        agentVote('security', 'reject', 'simulation'),
+      ],
+    });
+    expect(outcome.persisted).toBe(false);
+    if (!outcome.persisted) {
+      expect(outcome.reason).toBe('all-simulated');
+      expect(outcome.detail).toContain('simulated');
+    }
+  });
+
+  it('reports no-repo-root with an actionable NEXUS_VOTE_RECORDS_PATH detail when no location resolves', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined); // no override
+    // findRepoRoot mocked to null → no committable location.
+    const outcome = recordAuthenticVote({
+      proposal: 'Promote loop X to enforce',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes: realVotes,
+    });
+    expect(outcome.persisted).toBe(false);
+    if (!outcome.persisted) {
+      expect(outcome.reason).toBe('no-repo-root');
+      expect(outcome.detail).toContain(VOTE_RECORDS_PATH_ENV);
+      expect(outcome.detail).toContain(VOTE_RECORDS_REL_PATH);
+    }
+  });
+
+  it('persists and returns the record when the env override path is set', () => {
+    const filePath = join(dir, 'env', 'vote-records.jsonl');
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, filePath);
+
+    const outcome = recordAuthenticVote({
+      proposal: 'Promote loop X to enforce',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes: realVotes,
+      correlationId: 'corr-1',
+    });
+    expect(outcome.persisted).toBe(true);
+    if (outcome.persisted) {
+      expect(outcome.record.decision).toBe('approved');
+      expect(outcome.record.correlationId).toBe('corr-1');
+    }
+    // The record actually landed on disk at the override path.
+    const written = readFileSync(filePath, 'utf-8').trim();
+    expect(written.length).toBeGreaterThan(0);
+  });
+
+  it('persists to <repo-root>/governance/... when a repo root resolves (no override)', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
+    vi.mocked(findRepoRoot).mockReturnValue(dir); // simulate a committable repo root
+
+    const outcome = recordAuthenticVote({
+      proposal: 'p',
+      strategy: 'simple_majority',
+      result: consensusResult(),
+      votes: realVotes,
+    });
+    expect(outcome.persisted).toBe(true);
+    const written = readFileSync(join(dir, VOTE_RECORDS_REL_PATH), 'utf-8').trim();
+    expect(written.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -17,7 +17,11 @@ import {
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ConsensusResult } from '../../consensus/types.js';
 import type { VoteRecord } from '../../audit/vote-record.js';
-import { persistVoteRecord } from '../../audit/vote-record-store.js';
+import {
+  persistVoteRecord,
+  resolveVoteRecordsPath,
+  voteRecordNoRootMessage,
+} from '../../audit/vote-record-store.js';
 import { getToolMemory } from './tool-memory.js';
 import {
   getOutcomeStore,
@@ -98,12 +102,36 @@ function toRecordStrategy(strategy: string): VoteRecord['strategy'] {
 }
 
 /**
+ * Structured outcome of the best-effort authentic-vote-record persistence
+ * (#3991). Surfaced in the `consensus_vote` result so an MCP caller can SEE
+ * whether the committable record was written and, when not, WHY + how to fix —
+ * previously a skipped/failed persist was only a server-side WARN invisible to
+ * MCP clients (a live 2.135.0 vote produced no persisted record with no visible
+ * signal). Observability only: the persistence/cwd-resolution logic is unchanged.
+ */
+export type VoteRecordPersistOutcome =
+  | { readonly persisted: true; readonly record: VoteRecord }
+  | {
+      readonly persisted: false;
+      readonly reason: 'all-simulated' | 'no-repo-root' | 'write-failed';
+      readonly detail: string;
+    };
+
+/**
  * Persist an authentic, self-hashed vote record (tamper-evident record set +
  * monotonic sequence, #3927) to the committable governance
  * artifact at vote time (#3897). Best-effort: a persist failure must never fail
  * the vote, so the store swallows + logs. Skips all-simulated runs (random
- * output must not seed a committed record). Returns the written record (or
- * undefined when skipped / no committable location).
+ * output must not seed a committed record).
+ *
+ * Returns a structured {@link VoteRecordPersistOutcome} (#3991) so the caller
+ * can surface the result to MCP clients instead of leaving a skip invisible:
+ *  - `all-simulated` — every vote was simulated; a committed record would seed
+ *    governance from random output (#2319);
+ *  - `no-repo-root` — no committable location (server outside the repo, no
+ *    override); `detail` reuses the server WARN's actionable guidance;
+ *  - `write-failed` — a location resolved but the append threw.
+ * Persistence remains best-effort; this only reports what happened.
  */
 export function recordAuthenticVote(args: {
   proposal: string;
@@ -111,14 +139,31 @@ export function recordAuthenticVote(args: {
   result: ConsensusResult;
   votes: readonly AgentVoteResult[];
   correlationId?: string | undefined;
-}): VoteRecord | undefined {
+}): VoteRecordPersistOutcome {
   const allSimulated = args.votes.length > 0 && args.votes.every((v) => v.source === 'simulation');
   if (allSimulated) {
     logger.debug('Skipping authentic vote record — all votes simulated');
-    return undefined;
+    return {
+      persisted: false,
+      reason: 'all-simulated',
+      detail:
+        'All votes were simulated; a committed vote record would seed governance ' +
+        'from random output (#2319), so persistence is skipped by design.',
+    };
+  }
+  // Resolve the committable location up front (mirrors the store's own
+  // precedence: env override > repo-root detection) so a no-root skip surfaces
+  // a DISTINCT, actionable reason vs a genuine write failure. The persist path
+  // and cwd-resolution logic are unchanged — this only classifies the outcome.
+  if (resolveVoteRecordsPath() === undefined) {
+    const detail = voteRecordNoRootMessage();
+    // Defense-in-depth: keep the server-side WARN (#3991). persistVoteRecord
+    // won't be reached below to log its own, so emit it here.
+    logger.warn(detail);
+    return { persisted: false, reason: 'no-repo-root', detail };
   }
   const id = `vote-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 9)}`;
-  return persistVoteRecord({
+  const record = persistVoteRecord({
     id,
     proposal: args.proposal,
     strategy: toRecordStrategy(args.strategy),
@@ -127,6 +172,16 @@ export function recordAuthenticVote(args: {
     ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
     logger,
   });
+  if (record === undefined) {
+    // Location resolved but the append threw — persistVoteRecord already WARNed
+    // with the underlying error + path.
+    return {
+      persisted: false,
+      reason: 'write-failed',
+      detail: 'Vote record write failed; see server logs for the underlying filesystem error.',
+    };
+  }
+  return { persisted: true, record };
 }
 
 /** Records a failed consensus vote to session memory. Best-effort. */

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -10,6 +10,7 @@ import type { AgentVoteResult, VotingResult } from '../../cli/vote-types.js';
 import { VOTER_ROLES } from '../../cli/vote-types.js';
 import type { HigherOrderVotingResult } from '../../consensus/higher-order-types.js';
 import type { DecisionCostSummary } from '../../observability/decision-cost.js';
+import type { VoteRecordPersistOutcome } from './consensus-vote-recording.js';
 
 /** Maximum proposal length (memory bounds per Issue #435). */
 export const MAX_PROPOSAL_LENGTH = 4000;
@@ -285,6 +286,20 @@ export interface ConsensusVoteResponse {
    * adapter reported no usage are counted as unmeasured, not a measured $0).
    */
   costSummary?: DecisionCostSummary;
+  /**
+   * #3991: whether the authentic, committable vote record (#3897) was persisted
+   * at vote time. `false` when the persist was skipped (all votes simulated, or
+   * no committable repo root) or the write failed — see {@link voteRecordNote}.
+   * Surfaces to the MCP caller what was previously only a server-side WARN.
+   * Observability only: the persistence/cwd-resolution logic is unchanged.
+   */
+  voteRecordPersisted: boolean;
+  /**
+   * #3991: present only when {@link voteRecordPersisted} is `false` — the
+   * actionable reason the record was not written (e.g. no committable repo root
+   * → set `NEXUS_VOTE_RECORDS_PATH` or commit the returned bytes).
+   */
+  voteRecordNote?: string;
 }
 
 /** Extended voting result with optional Higher-Order metadata. */
@@ -343,11 +358,18 @@ function panelDegradationWarning(errorCount: number, total: number): string | un
   );
 }
 
-/** Builds the response from voting result. */
+/**
+ * Builds the response from voting result.
+ *
+ * `voteRecord` (#3991) is the structured authentic-vote-record persistence
+ * outcome; when omitted (direct unit calls) `voteRecordPersisted` defaults to
+ * `false` with no note. The live handler always supplies it.
+ */
 export function buildResponse(
   input: ConsensusVoteInput,
   result: ExtendedVotingResult,
-  costSummary?: DecisionCostSummary
+  costSummary?: DecisionCostSummary,
+  voteRecord?: VoteRecordPersistOutcome
 ): ConsensusVoteResponse {
   const proposalTruncated =
     input.proposal.length > 200 ? input.proposal.slice(0, 200) + '...' : input.proposal;
@@ -374,7 +396,13 @@ export function buildResponse(
     votes: result.votes.map(toAgentVoteSummary),
     durationMs: result.totalTimeMs,
     simulateVotes: result.simulateVotes,
+    // #3991: surface the authentic-vote-record persistence outcome so a skipped
+    // or failed persist is visible to the MCP caller (was WARN-only).
+    voteRecordPersisted: voteRecord?.persisted ?? false,
   };
+  if (voteRecord !== undefined && !voteRecord.persisted) {
+    response.voteRecordNote = voteRecord.detail;
+  }
 
   applyOptionalResponseFields(response, input, result, errorCount, costSummary);
   return response;

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -27,6 +27,7 @@ import {
 import type { VotingStrategy } from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ExtendedVotingResult } from './consensus-vote-types.js';
+import type { VoteRecord } from '../../audit/vote-record.js';
 
 /**
  * Creates a permissive rate limiter for tests.
@@ -442,6 +443,7 @@ describe('ConsensusVoteResponse structure', () => {
       ],
       durationMs: 5000,
       simulateVotes: false,
+      voteRecordPersisted: true,
     };
 
     expect(response.decision).toBe('approved');
@@ -469,6 +471,7 @@ describe('ConsensusVoteResponse structure', () => {
       votes: [],
       durationMs: 4500,
       simulateVotes: false,
+      voteRecordPersisted: false,
     };
 
     expect(response.decision).toBe('rejected');
@@ -829,6 +832,54 @@ describe('buildResponse surfaces policyReason (#3124)', () => {
       policyReason: 'fail_closed: 1 voter(s) errored',
     };
   }
+});
+
+describe('buildResponse surfaces vote-record persistence outcome (#3991)', () => {
+  function makeResult(): ExtendedVotingResult {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 10,
+        source: 'llm',
+      },
+    ];
+    return {
+      proposal: 'Test',
+      threshold: 'simple_majority',
+      result: createPolicyFailedResult('Test', 'simple_majority', 'x', votes),
+      votes,
+      totalTimeMs: 10,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+    };
+  }
+  const input = { proposal: 'Test', simulateVotes: false, quickMode: false };
+
+  it('reports voteRecordPersisted=true with no note when the record was written', () => {
+    const response = buildResponse(input, makeResult(), undefined, {
+      persisted: true,
+      record: { id: 'vote-1', decision: 'approved' } as unknown as VoteRecord,
+    });
+    expect(response.voteRecordPersisted).toBe(true);
+    expect(response.voteRecordNote).toBeUndefined();
+  });
+
+  it('reports voteRecordPersisted=false + an actionable note on a no-repo-root skip', () => {
+    const response = buildResponse(input, makeResult(), undefined, {
+      persisted: false,
+      reason: 'no-repo-root',
+      detail: 'set NEXUS_VOTE_RECORDS_PATH to an absolute file path.',
+    });
+    expect(response.voteRecordPersisted).toBe(false);
+    expect(response.voteRecordNote).toContain('NEXUS_VOTE_RECORDS_PATH');
+  });
+
+  it('defaults voteRecordPersisted=false (no note) when no outcome is supplied', () => {
+    const response = buildResponse(input, makeResult());
+    expect(response.voteRecordPersisted).toBe(false);
+    expect(response.voteRecordNote).toBeUndefined();
+  });
 });
 
 describe('shouldEscalateLowPosterior (#3174)', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -59,6 +59,7 @@ import {
   recordVoteError,
   recordAuthenticVote,
 } from './consensus-vote-recording.js';
+import type { VoteRecordPersistOutcome } from './consensus-vote-recording.js';
 import { recordDecisionCost } from './decision-cost-recording.js';
 import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
@@ -684,18 +685,25 @@ function finalizeVotingResult(args: {
  * under the per-function line cap. Persists the authentic hash-chained vote
  * record (#3897) and rolls up per-decision cost (#3855), sharing one decision
  * id as the correlation key. Neither must fail the vote — both are guarded.
+ *
+ * Returns both the cost rollup and the structured vote-record persistence
+ * outcome (#3991) so the handler can surface persistence visibility in the
+ * result instead of leaving a skip as a server-only WARN.
  */
 function recordVoteSideEffects(
   proposal: string,
   strategy: string,
   result: ExtendedVotingResult,
   logger: ILogger
-): ReturnType<typeof recordDecisionCost> | undefined {
+): {
+  costSummary: ReturnType<typeof recordDecisionCost> | undefined;
+  voteRecord: VoteRecordPersistOutcome;
+} {
   const decisionId = `consensus-${String(getTimeProvider().now())}-${randomUUID().slice(0, 8)}`;
   // #3897: persist an authentic, hash-chained vote record to the committable
   // governance artifact at vote time so the promotion gate/CI can rest
   // authenticity on the chain, not on hand-transcribed YAML.
-  recordAuthenticVote({
+  const voteRecord = recordAuthenticVote({
     proposal,
     strategy,
     result: result.result,
@@ -704,14 +712,16 @@ function recordVoteSideEffects(
   });
   // #3855: roll up + persist this decision's per-voter cost and ride it on the
   // existing response (no new MCP tool). A rollup failure must not fail the vote.
+  let costSummary: ReturnType<typeof recordDecisionCost> | undefined;
   try {
-    return recordDecisionCost({ decisionId, gate: 'consensus_vote', votes: result.votes });
+    costSummary = recordDecisionCost({ decisionId, gate: 'consensus_vote', votes: result.votes });
   } catch (costError) {
     logger.warn('Per-decision cost rollup failed (non-fatal)', {
       error: getErrorMessage(costError),
     });
-    return undefined;
+    costSummary = undefined;
   }
+  return { costSummary, voteRecord };
 }
 
 async function handleConsensusVote(
@@ -743,11 +753,16 @@ async function handleConsensusVote(
       result.totalTimeMs,
       result.votes
     );
-    const costSummary = recordVoteSideEffects(args.proposal, strategy, result, logger);
+    const { costSummary, voteRecord } = recordVoteSideEffects(
+      args.proposal,
+      strategy,
+      result,
+      logger
+    );
     // Close the self-tuning loop: a rejected vote emits signal.vote_rejected
     // onto the typed pipeline bus for the shadow TuneStage (#3147; #3289 Option 2).
     emitVoteRejectedSignal(result.result, getPipelineEventBus(), logger);
-    return { ok: true, value: buildResponse(args, result, costSummary) };
+    return { ok: true, value: buildResponse(args, result, costSummary, voteRecord) };
   } catch (error) {
     const message = getErrorMessage(error);
     const cause = error instanceof Error ? error : new Error(message);
@@ -920,6 +935,12 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   // #3124: explains a `rejected` decision that coexists with a high
   // approvalPercentage (an error-policy short-circuit, e.g. fail_closed).
   policyReason: z.string().max(200).optional(),
+  // #3991: whether the authentic, committable vote record was persisted at vote
+  // time. False when skipped (all-simulated / no committable repo root) or the
+  // write failed — voteRecordNote carries the actionable reason. Makes a
+  // previously WARN-only skip visible to MCP callers.
+  voteRecordPersisted: z.boolean(),
+  voteRecordNote: z.string().max(500).optional(),
 };
 
 /**


### PR DESCRIPTION
## Problem (silent skip — live-test evidence)

`consensus_vote` persists an authentic, committable vote record
(`governance/vote-records.jsonl`, #3897) as a best-effort side effect of the
live vote. When that persist is **skipped or fails**, the only signal was a
`logger.warn(...)` to server stderr — **invisible to MCP clients**. A live
2.135.0 vote produced a real decision with **no persisted record and no visible
signal** to the caller. The promotion gate then has nothing to read, and nobody
operating through MCP can tell.

## Change (observability only)

The persistence path, cwd-resolution logic, and the vote outcome are **unchanged**.
Persistence stays best-effort — a skip never blocks or fails the vote. This PR
only makes the outcome **visible**.

- **Structured outcome.** `recordAuthenticVote` now returns a
  `VoteRecordPersistOutcome` instead of `VoteRecord | undefined`:
  - `{ persisted: true, record }`
  - `{ persisted: false, reason: 'all-simulated' | 'no-repo-root' | 'write-failed', detail }`

  It pre-resolves the committable location (mirroring the store's own precedence:
  env override > repo-root detection) so a no-root skip is classified distinctly
  from a genuine write failure. `persistVoteRecord`'s own signature is unchanged
  (its tests stay as-is).

- **Actionable no-repo-root note.** The `no-repo-root` `detail` **reuses the
  exact existing server WARN text** (extracted to `voteRecordNoRootMessage()`),
  so the caller is told how to fix it: set `NEXUS_VOTE_RECORDS_PATH` (the
  override) or commit the returned bytes per the caller-commits path (#3927).

- **Result fields (additive).** The `consensus_vote` result gains
  `voteRecordPersisted: boolean` and, when not persisted, `voteRecordNote: string`.
  No existing result fields are renamed/removed; `CONSENSUS_VOTE_OUTPUT_SCHEMA`
  is updated to match. The tool **description is unchanged**.

- **WARN retained** (defense-in-depth).

## Tests

- New `consensus-vote-recording.test.ts`: all-simulated → `all-simulated`;
  `findRepoRoot→null` + no env → `no-repo-root` with a detail mentioning
  `NEXUS_VOTE_RECORDS_PATH`; env-override (tmp) → `persisted:true` + record on
  disk; repo-root (tmp) → `persisted:true`.
- `consensus-vote.test.ts`: `buildResponse` surfaces `voteRecordPersisted`
  (+note when false), with the recording outcome injected (no real vote run).
- Existing consensus-vote + vote-record-store tests stay green (104 tests pass).

## Gates

tsc `--noEmit` clean; eslint clean on changed files (zero `any`);
`check-mcp-description-drift` green (46 tools); MCP tool count unaffected.

Changeset: `nexus-agents` minor, type `feat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)