### PR TITLE
feat(governance): route vote-records through nexusDataPath — sandbox/global-install support, stores in .nexus-agents (#3991)

### DIFF
--- a/.changeset/vote-records-nexusdatapath-3991.md
+++ b/.changeset/vote-records-nexusdatapath-3991.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): route runtime vote-records store through `nexusDataPath` (#3991)
+
+The runtime authentic-vote-record store now resolves its ledger path through the
+canonical `nexusDataPath` resolver under a per-repo `governance/` category,
+consistent with the other 10+ runtime stores. Precedence is now:
+`NEXUS_VOTE_RECORDS_PATH` override (absolute as-is; relative resolved against cwd,
+with fail-closed path-traversal validation) → `nexusDataPath('governance',
+'vote-records.jsonl')`, which yields `<sandbox-root>/.nexus-agents/governance/`
+(sandbox), `<repo>/.nexus-agents/governance/` (repo-preferred, gitignored), or
+`~/.nexus-agents/governance/vote-records.jsonl` (default / global install).
+
+This removes the old `findRepoRoot(cwd)/governance/...` default that caused a
+silent persist-skip on global installs (cwd not a repo) and tracked-file churn.
+The runtime store now essentially always persists into `.nexus-agents`. The
+committed `<repo>/governance/vote-records.jsonl` ledger the promotion gate reads
+remains a separate caller-commits artifact, reachable only via the explicit
+override. The persistence outcome `'no-repo-root'` reason is removed (obsolete);
+a non-persist is now `'all-simulated'` or `'write-failed'` (unwritable data dir).

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -15,13 +15,19 @@ import { isAbsolute, join, resolve } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { findRepoRoot } from '../config/repo-root-detection.js';
+import { getNexusDataDir, nexusDataPath } from '../config/nexus-data-dir.js';
 
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult, VoterRole } from '../cli/vote-types.js';
 
-vi.mock('../config/repo-root-detection.js', () => ({
-  findRepoRoot: vi.fn(() => null),
+// #3991: the store now resolves the runtime ledger via nexusDataPath (governance
+// category) instead of findRepoRoot. Mock the resolver so each test pins the
+// data root without touching the real homedir/sandbox/repo layout.
+vi.mock('../config/nexus-data-dir.js', () => ({
+  getNexusDataDir: vi.fn(() => '/data-root/.nexus-agents'),
+  nexusDataPath: vi.fn((...segments: string[]) =>
+    ['/data-root/.nexus-agents', ...segments].join('/')
+  ),
 }));
 
 import { verifyVoteRecordSet } from './vote-record.js';
@@ -244,17 +250,24 @@ describe('persistVoteRecord', () => {
   });
 });
 
-describe('vote-record path resolution / persistence escape hatch (#3927)', () => {
+describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)', () => {
   let dir: string;
+  let dataRoot: string;
   let envFilePath: string;
   let optsFilePath: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'vote-records-env-'));
+    dataRoot = join(dir, 'data-root', '.nexus-agents');
     envFilePath = join(dir, 'env', 'vote-records.jsonl');
     optsFilePath = join(dir, 'opts', 'vote-records.jsonl');
-    // findRepoRoot is mocked to null by default → no cwd-based resolution.
-    vi.mocked(findRepoRoot).mockReturnValue(null);
+    // Default mock: nexusDataPath roots under a real temp data dir so persists
+    // actually write. getNexusDataDir returns the same root for the in-data-dir
+    // traversal validation in resolveVoteRecordsPath().
+    vi.mocked(getNexusDataDir).mockReturnValue(dataRoot);
+    vi.mocked(nexusDataPath).mockImplementation((...segments: string[]) =>
+      join(dataRoot, ...segments)
+    );
   });
   afterEach(() => {
     vi.unstubAllEnvs(); // restore any process.env mutations made via vi.stubEnv
@@ -278,11 +291,10 @@ describe('vote-record path resolution / persistence escape hatch (#3927)', () =>
     expect(invalidLines).toEqual([]);
     expect(records).toHaveLength(1);
     expect(records[0]).toEqual(written);
-  });
-
-  it('treats an empty/whitespace env var as unset (falls back to root detection)', () => {
-    vi.stubEnv(VOTE_RECORDS_PATH_ENV, '   ');
-    expect(resolveVoteRecordsPath()).toBeUndefined();
+    // The default nexusDataPath location was NOT used.
+    expect(readVoteRecords(join(dataRoot, 'governance', 'vote-records.jsonl')).records).toHaveLength(
+      0
+    );
   });
 
   it('returns an absolute override unchanged (#3963)', () => {
@@ -294,16 +306,35 @@ describe('vote-record path resolution / persistence escape hatch (#3927)', () =>
   });
 
   it('resolves a RELATIVE override to an absolute path against cwd (#3963)', () => {
-    // The JSDoc contract says the override is treated as an absolute path; a
-    // relative value used verbatim would silently write under process.cwd().
-    // Honor the contract: resolve it to an absolute path against cwd.
-    const relative = 'governance/custom-vote-records.jsonl';
-    vi.stubEnv(VOTE_RECORDS_PATH_ENV, relative);
+    // A relative override is resolved against cwd to an absolute path rather than
+    // written verbatim. Use a value that stays under cwd so it is NOT rejected by
+    // the path-traversal guard.
+    const rel = 'governance/custom-vote-records.jsonl';
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, rel);
     const resolved = resolveVoteRecordsPath();
-    expect(resolved).toBe(resolve(relative));
+    expect(resolved).toBe(resolve(rel));
     expect(isAbsolute(resolved as string)).toBe(true);
-    // It must NOT be returned verbatim (the pre-fix bug).
-    expect(resolved).not.toBe(relative);
+    expect(resolved).not.toBe(rel);
+  });
+
+  it('rejects (fail-closed) a relative override that escapes cwd via `..` (security #3991)', () => {
+    // A relative override resolving outside cwd is a path-traversal attempt → the
+    // resolver returns undefined rather than writing astray.
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, '../../../../../../tmp/evil-vote-records.jsonl');
+    expect(resolveVoteRecordsPath()).toBeUndefined();
+  });
+
+  it('treats an empty/whitespace env var as unset (falls through to nexusDataPath)', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, '   ');
+    // Post-#3991 the fall-through is the canonical data-dir path, NOT undefined.
+    expect(resolveVoteRecordsPath()).toBe(join(dataRoot, 'governance', 'vote-records.jsonl'));
+  });
+
+  it('falls through to nexusDataPath(governance, ...) when no override is set', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
+    const resolved = resolveVoteRecordsPath();
+    expect(resolved).toBe(join(dataRoot, 'governance', 'vote-records.jsonl'));
+    expect(vi.mocked(nexusDataPath)).toHaveBeenCalledWith('governance', 'vote-records.jsonl');
   });
 
   it('lets opts.filePath take precedence over the env var', () => {
@@ -324,8 +355,60 @@ describe('vote-record path resolution / persistence escape hatch (#3927)', () =>
     expect(readVoteRecords(envFilePath).records).toHaveLength(0);
   });
 
-  it('returns undefined and does not throw when no root resolves and no override is set', () => {
-    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined); // ensure no override
+  it('#3991 regression: global install (no override, cwd not a repo) resolves a valid .nexus-agents path and persists there', () => {
+    // The pre-#3991 bug: resolveVoteRecordsPath() returned undefined when cwd was
+    // not a repo and no override was set → the producer silently skipped. Now the
+    // canonical resolver always yields a writable data-dir path, so a persist
+    // writes a record there.
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
+    const resolved = resolveVoteRecordsPath();
+    expect(resolved).toBeDefined();
+    expect(resolved).toBe(join(dataRoot, 'governance', 'vote-records.jsonl'));
+
+    const written = persistVoteRecord({
+      id: 'vote-global',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+    });
+    expect(written).toBeDefined();
+    const { records } = readVoteRecords(resolved as string);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual(written);
+  });
+
+  it('routes under a per-repo .nexus-agents/governance/ location when nexusDataPath does (NEXUS_REPO_PREFERRED)', () => {
+    // Simulate nexusDataPath choosing the per-repo tier: the resolved path sits
+    // under <repo>/.nexus-agents/governance/, which differs from getNexusDataDir
+    // (the homedir root). The store's defense-in-depth validation must still
+    // accept it via the `.nexus-agents/governance/` segment check.
+    const repoGovDir = join(dir, 'repo', '.nexus-agents', 'governance');
+    vi.mocked(nexusDataPath).mockImplementation((...segments: string[]) =>
+      join(dir, 'repo', '.nexus-agents', ...segments)
+    );
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
+    const resolved = resolveVoteRecordsPath();
+    expect(resolved).toBe(join(repoGovDir, 'vote-records.jsonl'));
+
+    const written = persistVoteRecord({
+      id: 'vote-repo',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+    });
+    expect(written).toBeDefined();
+    expect(readVoteRecords(resolved as string).records).toHaveLength(1);
+  });
+
+  it('does not throw on a fail-closed resolution; persist returns undefined', () => {
+    // Force resolveVoteRecordsPath() to fail closed: nexusDataPath returns a path
+    // that neither sits under getNexusDataDir nor contains the canonical
+    // .nexus-agents/governance/ segment → defense-in-depth rejects it.
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
+    vi.mocked(nexusDataPath).mockReturnValue('/somewhere/else/governance/vote-records.jsonl');
+    vi.mocked(getNexusDataDir).mockReturnValue('/data-root/.nexus-agents');
     expect(resolveVoteRecordsPath()).toBeUndefined();
 
     let written: ReturnType<typeof persistVoteRecord>;

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -1,13 +1,28 @@
 /**
  * nexus-agents/audit - Authentic Vote Record Store (#3897, model revised #3927)
  *
- * Persists a completed `consensus_vote` to a COMMITTABLE, append-only,
- * tamper-evident artifact at vote time, distinct from the per-developer home-dir
- * stores (`~/.nexus-agents/voting`, `~/.nexus-agents/learning`) a CI gate cannot
- * read. The artifact lives at `<repo-root>/governance/vote-records.jsonl` so the
- * promotion gate (#3895) can read it from CI; authenticity rests on a
- * payload-covering tamper-evident record set + monotonic sequence
- * ({@link verifyVoteRecordSet}), not on manual YAML transcription.
+ * Persists a completed `consensus_vote` to an append-only, tamper-evident
+ * artifact at vote time. Authenticity rests on a payload-covering tamper-evident
+ * record set + monotonic sequence ({@link verifyVoteRecordSet}), not on manual
+ * YAML transcription.
+ *
+ * PATH RESOLUTION (#3991, design vote 7-0 Option B). The RUNTIME ledger now
+ * routes through the canonical {@link nexusDataPath} resolver under the
+ * `governance/` category, consistent with the 10+ other runtime stores — so it
+ * works for sandbox and global-install layouts and always has a writable home:
+ *   - `NEXUS_VOTE_RECORDS_PATH` explicit override (absolute used as-is; relative
+ *     resolved against cwd per #3963) — the escape hatch, and the ONLY way to
+ *     reach the committed `<repo>/governance/vote-records.jsonl` ledger the
+ *     promotion gate (#3895) reads (a separate caller-commits/governor-gate
+ *     artifact, deferred — never auto-written);
+ *   - otherwise `nexusDataPath('governance', 'vote-records.jsonl')` →
+ *     `<sandbox-root>/.nexus-agents/governance/...` (sandbox),
+ *     `<repo>/.nexus-agents/governance/...` (repo-preferred, gitignored), or
+ *     `~/.nexus-agents/governance/vote-records.jsonl` (default / global install).
+ * The pre-#3991 `findRepoRoot(cwd)/governance/...` default is GONE — it caused
+ * the #3991 silent-skip on global installs (cwd not a repo → undefined → no
+ * persist) AND tracked-file churn. The resolver now essentially always returns a
+ * path, so the producer essentially always persists into `.nexus-agents`.
  *
  * DRY/drift hazard (DevEx, #3897). This is the AUTOMATED authoring path: the
  * record is written as a side effect of the live vote, so the committed artifact
@@ -25,26 +40,42 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 
 import type { ILogger } from '../core/index.js';
 import { createLogger, getErrorMessage } from '../core/index.js';
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult } from '../cli/vote-types.js';
-import { findRepoRoot } from '../config/repo-root-detection.js';
+import { getNexusDataDir, nexusDataPath } from '../config/nexus-data-dir.js';
 
 import type { VoteRecord, VoterSummary } from './vote-record.js';
 import { VoteRecordSchema, computeVoteRecordHash, hashProposal } from './vote-record.js';
 
-/** Repo-relative committable artifact path (read by the gate/CI). */
+/**
+ * Repo-relative path of the COMMITTED governance ledger the promotion gate
+ * (#3895) reads. As of #3991 the runtime store no longer auto-writes here — this
+ * committed artifact is reached only via the {@link VOTE_RECORDS_PATH_ENV}
+ * override (the separate caller-commits/governor-gate path, deferred). Kept
+ * exported as the canonical relative location for the gate + override guidance.
+ */
 export const VOTE_RECORDS_REL_PATH = 'governance/vote-records.jsonl';
 
 /**
- * Env var to force the artifact path (#3927). When set non-empty it is used
- * directly (resolved to an absolute path — see {@link resolveVoteRecordsPath})
- * and the cwd/{@link findRepoRoot} detection is skipped — the escape hatch for
- * running the MCP server outside the repo (e.g. co-located/CI contexts) so
- * server-side persistence is reliable.
+ * {@link nexusDataPath} category + filename for the RUNTIME ledger (#3991).
+ * `governance` is a per-repo category in `nexus-data-dir.ts`, so with
+ * `NEXUS_REPO_PREFERRED=1` (default) the runtime ledger lands in
+ * `<repo>/.nexus-agents/governance/` (gitignored), under a sandbox root when
+ * `NEXUS_SANDBOX` is set, and `~/.nexus-agents/governance/` otherwise.
+ */
+const VOTE_RECORDS_DATA_CATEGORY = 'governance';
+const VOTE_RECORDS_FILENAME = 'vote-records.jsonl';
+
+/**
+ * Env var to force the artifact path. When set non-empty it is used directly
+ * (resolved to an absolute path — see {@link resolveVoteRecordsPath}) and the
+ * canonical {@link nexusDataPath} resolution is skipped — the escape hatch for
+ * targeting a specific location (e.g. the committed `<repo>/governance/...`
+ * ledger the promotion gate reads, or a co-located/CI path).
  */
 export const VOTE_RECORDS_PATH_ENV = 'NEXUS_VOTE_RECORDS_PATH';
 
@@ -52,19 +83,19 @@ export const VOTE_RECORDS_PATH_ENV = 'NEXUS_VOTE_RECORDS_PATH';
 const MAX_PROPOSAL_RECORD_CHARS = 500;
 
 /**
- * Actionable message for the no-committable-location skip (#3927, surfaced to
- * MCP callers in #3991). Exported so the `consensus_vote` result note can reuse
- * the EXACT text the server WARN logs — one source of truth for the
- * "how to fix" guidance (set {@link VOTE_RECORDS_PATH_ENV} or commit the
- * returned bytes). Previously this guidance only reached server stderr.
+ * Actionable message for a write FAILURE (#3991). Since the runtime path now
+ * routes through {@link nexusDataPath} it essentially always resolves; the
+ * remaining failure mode is an unwritable data dir. Exported so the
+ * `consensus_vote` result note can reuse the EXACT guidance the server WARN logs
+ * — one source of truth. (Pre-#3991 this covered a no-repo-root skip; that case
+ * no longer exists because the resolver always returns a path.)
  */
-export function voteRecordNoRootMessage(): string {
+export function voteRecordWriteFailedMessage(path: string): string {
   return (
-    'Authentic vote record NOT persisted: no repo root found from process.cwd() ' +
-    'and no override set. Per #3927 the authoritative population path is ' +
-    'caller-commits — commit the returned record bytes into ' +
-    `${VOTE_RECORDS_REL_PATH} in the promotion PR. To force a server-side ` +
-    `write, set ${VOTE_RECORDS_PATH_ENV} to an absolute file path.`
+    'Authentic vote record NOT persisted: the resolved data directory is not ' +
+    `writable (${path}). Check filesystem permissions on the .nexus-agents data ` +
+    `dir, or set ${VOTE_RECORDS_PATH_ENV} to a writable absolute file path. See ` +
+    'server logs for the underlying filesystem error.'
   );
 }
 
@@ -170,17 +201,41 @@ function readLedgerTip(
 }
 
 /**
- * Resolve the committable artifact path (#3927). Precedence:
+ * Fail-closed path-traversal guard (#3991 security condition, 7-0 vote). Returns
+ * `true` iff `target` resolves to an absolute path under `root` (or equal to it)
+ * with no `..` segment escaping it. Both inputs are `resolve`d first so a
+ * `..` embedded in the override (e.g. `<root>/../../etc/x`) is normalized and
+ * caught: if the relative path from `root` to `target` starts with `..` (or is
+ * itself absolute on a different volume), the target escaped and we reject.
+ */
+function isWithin(root: string, target: string): boolean {
+  const resolvedRoot = resolve(root);
+  const resolvedTarget = resolve(target);
+  if (resolvedTarget === resolvedRoot) return true;
+  const rel = relative(resolvedRoot, resolvedTarget);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * Resolve the RUNTIME vote-records ledger path (#3991, design vote 7-0). Routes
+ * through the canonical {@link nexusDataPath} resolver so it supports sandbox and
+ * global-install layouts and always has a writable home. Precedence:
+ *
  *  1. {@link VOTE_RECORDS_PATH_ENV} (`NEXUS_VOTE_RECORDS_PATH`) when set
- *     non-empty — `resolve`d to an absolute path, skipping cwd detection. A
- *     RELATIVE value is resolved against `process.cwd()` to an absolute path
- *     (#3963) so the write target is unambiguous and not silently
- *     cwd-dependent; an already-absolute value is returned unchanged.
- *  2. otherwise `<repo-root>/governance/vote-records.jsonl` resolved from
- *     {@link findRepoRoot}(`process.cwd()`).
- * Returns `undefined` when neither yields a path (server running outside the
- * repo with no override) — the caller surfaces this as an observable WARN. A
- * whitespace-only override is treated as unset (falls through to root detection).
+ *     non-empty — resolved to an absolute path (an already-absolute value is
+ *     returned unchanged; a RELATIVE value is resolved against `process.cwd()`,
+ *     #3963). This is the explicit escape hatch and the ONLY way to target the
+ *     committed `<repo>/governance/vote-records.jsonl` ledger. The resolved
+ *     override is path-traversal validated against its own join base
+ *     (fail-closed): a relative override that escapes cwd via `..` is rejected.
+ *  2. otherwise `nexusDataPath('governance', 'vote-records.jsonl')` →
+ *     a sandbox / repo-preferred / homedir `.nexus-agents/governance/` location.
+ *     Validated to stay within the resolved data root (fail-closed).
+ *
+ * Returns `undefined` only on a genuine resolver failure or a fail-closed
+ * traversal rejection — NOT for the former "no repo root" case, which no longer
+ * exists (#3991). The caller treats `undefined` as a write-failed/skip and
+ * surfaces an actionable note. A whitespace-only override is treated as unset.
  */
 export function resolveVoteRecordsPath(): string | undefined {
   const envPath = process.env[VOTE_RECORDS_PATH_ENV];
@@ -188,11 +243,39 @@ export function resolveVoteRecordsPath(): string | undefined {
     // Honor the absolute-path contract: a relative override is resolved against
     // process.cwd() rather than written verbatim (#3963). isAbsolute short-
     // circuits the common already-absolute case to a no-op for clarity.
-    return isAbsolute(envPath) ? envPath : resolve(envPath);
+    const resolved = isAbsolute(envPath) ? envPath : resolve(envPath);
+    // Path-traversal validation (#3991): a relative override must not escape the
+    // cwd it is joined against via `..`. An absolute override is the operator's
+    // explicit choice (e.g. the committed governance ledger) and is honored as-is
+    // — there is no enclosing data root to validate it against.
+    if (!isAbsolute(envPath) && !isWithin(process.cwd(), resolved)) {
+      return undefined;
+    }
+    return resolved;
   }
-  const root = findRepoRoot(process.cwd());
-  if (root === null) return undefined;
-  return join(root, VOTE_RECORDS_REL_PATH);
+  // Canonical resolver: handles sandbox, repo-preferred, and homedir layouts.
+  // nexusDataPath may root the result under the homedir/sandbox data dir OR,
+  // when `governance` routes per-repo (NEXUS_REPO_PREFERRED), under
+  // `<repo>/.nexus-agents` — so the base differs by layout.
+  const resolved = nexusDataPath(VOTE_RECORDS_DATA_CATEGORY, VOTE_RECORDS_FILENAME);
+  // Defense-in-depth (#3991): nexusDataPath joins a FIXED category + filename
+  // (no caller/user input) so traversal is structurally impossible. But fail
+  // closed against a future resolver regression: the result must be absolute,
+  // end with the expected `governance/<file>` suffix, and live under a
+  // recognized `.nexus-agents` data root — either the homedir/sandbox data dir
+  // or, when `governance` routes per-repo, a `<repo>/.nexus-agents/governance/`
+  // location (the base differs by layout, so we accept either).
+  const expectedSuffix = `${VOTE_RECORDS_DATA_CATEGORY}${sep}${VOTE_RECORDS_FILENAME}`;
+  const underHomedirRoot = isWithin(getNexusDataDir(), resolved);
+  const underRepoDataDir = resolved.includes(`.nexus-agents${sep}${VOTE_RECORDS_DATA_CATEGORY}${sep}`);
+  if (
+    !isAbsolute(resolved) ||
+    !resolved.endsWith(expectedSuffix) ||
+    !(underHomedirRoot || underRepoDataDir)
+  ) {
+    return undefined;
+  }
+  return resolved;
 }
 
 /** Options for {@link persistVoteRecord}. `sequence`/`previousHash` are assigned by the store. */
@@ -200,36 +283,40 @@ export interface PersistVoteRecordOptions
   extends Omit<BuildVoteRecordInput, 'previousHash' | 'sequence'> {
   /**
    * Override the artifact path; takes precedence over {@link VOTE_RECORDS_PATH_ENV}
-   * and the repo-root resolution (see {@link resolveVoteRecordsPath}).
+   * and the {@link nexusDataPath} resolution (see {@link resolveVoteRecordsPath}).
    */
   readonly filePath?: string | undefined;
   readonly logger?: ILogger | undefined;
 }
 
 /**
- * Persist an authentic vote record to the committable artifact at vote time.
- * Best-effort and append-only: reads the ledger tip (max sequence + advisory
- * last hash), assigns the next monotonic `sequence`, builds a self-hashed
- * record, and appends one JSON line. Returns the written record (or undefined
- * when no committable location exists / the write failed) — persistence never
- * throws into the vote path (an audit sink must not break the operation it
- * observes).
+ * Persist an authentic vote record at vote time. Best-effort and append-only:
+ * reads the ledger tip (max sequence + advisory last hash), assigns the next
+ * monotonic `sequence`, builds a self-hashed record, and appends one JSON line.
+ * Returns the written record (or undefined when the path could not be resolved /
+ * the write failed) — persistence never throws into the vote path (an audit sink
+ * must not break the operation it observes).
  *
- * AUTHORITATIVE POPULATION PATH (#3927, design vote 7-0): caller-commits. The
- * proposer commits the RETURNED record bytes into
- * `governance/vote-records.jsonl` in the promotion PR; that is what the gate
- * reads. This server-side auto-write is only a best-effort convenience and
- * no-ops when the server runs outside the repo and no override is set — hence
- * the WARN below and the {@link VOTE_RECORDS_PATH_ENV} escape hatch.
+ * RUNTIME LEDGER (#3991, design vote 7-0): the default path now routes through
+ * {@link nexusDataPath} under `governance/`, so it essentially always resolves to
+ * a writable `.nexus-agents/governance/` location (sandbox / repo-preferred /
+ * homedir) and the server-side write essentially always succeeds. The committed
+ * `<repo>/governance/vote-records.jsonl` ledger the promotion gate (#3895) reads
+ * is a SEPARATE caller-commits artifact (deferred), reached only via the
+ * {@link VOTE_RECORDS_PATH_ENV} override.
  *
  * Path precedence: `opts.filePath` > {@link VOTE_RECORDS_PATH_ENV} >
- * {@link findRepoRoot}(`process.cwd()`).
+ * `nexusDataPath('governance', 'vote-records.jsonl')`.
  */
 export function persistVoteRecord(opts: PersistVoteRecordOptions): VoteRecord | undefined {
   const logger = opts.logger ?? createLogger({ component: 'vote-record-store' });
   const filePath = opts.filePath ?? resolveVoteRecordsPath();
   if (filePath === undefined) {
-    logger.warn(voteRecordNoRootMessage(), { id: opts.id });
+    // Post-#3991 this is rare: the canonical resolver almost always returns a
+    // path. It happens only on a fail-closed traversal rejection or resolver
+    // failure — surface the write-failed guidance rather than the obsolete
+    // "no repo root" message.
+    logger.warn(voteRecordWriteFailedMessage('<unresolved>'), { id: opts.id });
     return undefined;
   }
   try {

--- a/packages/nexus-agents/src/config/nexus-data-dir.test.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.test.ts
@@ -152,6 +152,7 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, default-ON via vote #2876)',
   let originalNexusDataDir: string | undefined;
   let originalRepoPreferred: string | undefined;
   let originalSandbox: string | undefined;
+  let originalSandboxRoot: string | undefined;
   let originalGitignoreAuto: string | undefined;
   let tempRepo: string;
 
@@ -160,10 +161,12 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, default-ON via vote #2876)',
     originalNexusDataDir = process.env['NEXUS_DATA_DIR'];
     originalRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
     originalSandbox = process.env['NEXUS_SANDBOX'];
+    originalSandboxRoot = process.env['NEXUS_SANDBOX_ROOT'];
     originalGitignoreAuto = process.env['NEXUS_GITIGNORE_AUTO'];
     delete process.env['NEXUS_DATA_DIR'];
     delete process.env['NEXUS_REPO_PREFERRED'];
     delete process.env['NEXUS_SANDBOX'];
+    delete process.env['NEXUS_SANDBOX_ROOT'];
     // Silence the auto-gitignore side-effect by default — tests that want
     // to exercise it re-enable per-test.
     process.env['NEXUS_GITIGNORE_AUTO'] = '0';
@@ -185,6 +188,8 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, default-ON via vote #2876)',
     else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPreferred;
     if (originalSandbox === undefined) delete process.env['NEXUS_SANDBOX'];
     else process.env['NEXUS_SANDBOX'] = originalSandbox;
+    if (originalSandboxRoot === undefined) delete process.env['NEXUS_SANDBOX_ROOT'];
+    else process.env['NEXUS_SANDBOX_ROOT'] = originalSandboxRoot;
     if (originalGitignoreAuto === undefined) delete process.env['NEXUS_GITIGNORE_AUTO'];
     else process.env['NEXUS_GITIGNORE_AUTO'] = originalGitignoreAuto;
     const { rmSync } = await import('node:fs');
@@ -266,9 +271,41 @@ describe('NEXUS_REPO_PREFERRED routing (epic #2872, default-ON via vote #2876)',
       'audit',
       'pipeline',
       'tasks',
+      // #3991: the runtime vote-records ledger is per-repo governance state.
+      'governance',
     ]) {
       expect(nexusDataPath(subdir, 'x.jsonl')).toBe(join(repoBase, subdir, 'x.jsonl'));
     }
+  });
+
+  it('#3991: routes governance (vote-records) to <repo>/.nexus-agents/governance by default inside a repo', async () => {
+    const { nexusDataPath } = await import('./nexus-data-dir.js');
+    process.chdir(tempRepo);
+    const { realpathSync } = await import('node:fs');
+    expect(nexusDataPath('governance', 'vote-records.jsonl')).toBe(
+      join(realpathSync(tempRepo), '.nexus-agents', 'governance', 'vote-records.jsonl')
+    );
+  });
+
+  it('#3991: routes governance to homedir when NEXUS_REPO_PREFERRED=0 (global install)', async () => {
+    const { nexusDataPath } = await import('./nexus-data-dir.js');
+    process.env['NEXUS_REPO_PREFERRED'] = '0';
+    process.chdir(tempRepo);
+    expect(nexusDataPath('governance', 'vote-records.jsonl')).toBe(
+      join(homedir(), '.nexus-agents', 'governance', 'vote-records.jsonl')
+    );
+  });
+
+  it('#3991: routes governance under the sandbox root when NEXUS_SANDBOX is set', async () => {
+    const { nexusDataPath } = await import('./nexus-data-dir.js');
+    process.env['NEXUS_SANDBOX'] = '1';
+    process.env['NEXUS_SANDBOX_ROOT'] = '/sandbox';
+    process.chdir(tempRepo);
+    // Sandbox short-circuits getNexusRepoDir (detectSandbox().active) so the
+    // governance ledger lands under <sandbox-root>/.nexus-agents/governance/.
+    expect(nexusDataPath('governance', 'vote-records.jsonl')).toBe(
+      join('/sandbox', '.nexus-agents', 'governance', 'vote-records.jsonl')
+    );
   });
 
   it('routes per-repo subdir to HOMEDIR when NEXUS_REPO_PREFERRED=0 (opt-out)', async () => {

--- a/packages/nexus-agents/src/config/nexus-data-dir.ts
+++ b/packages/nexus-agents/src/config/nexus-data-dir.ts
@@ -88,6 +88,16 @@ const PER_REPO_SUBDIRS: ReadonlySet<string> = new Set([
   // reported via `ci_health_check({ repo })` are repo-correlated; a wedge
   // on repo A's queue does not predict repo B's health.
   'ci-health',
+  // Governance artifacts — the runtime authentic-vote-record ledger
+  // (`governance/vote-records.jsonl`, #3897/#3927/#3991). Per-repo because a
+  // promotion proposal is scoped to the codebase being changed; with
+  // `NEXUS_REPO_PREFERRED=1` (default) these route to
+  // `<repo>/.nexus-agents/governance/` (gitignored), and to
+  // `~/.nexus-agents/governance/` otherwise (global / non-repo install). This
+  // is DISTINCT from the committed `<repo>/governance/vote-records.jsonl`
+  // ledger the promotion gate reads — that artifact is reached only via the
+  // explicit `NEXUS_VOTE_RECORDS_PATH` override (#3991).
+  'governance',
 ]);
 
 /** Returns the absolute path to the nexus-agents data directory. */

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
@@ -11,21 +11,26 @@
  * @module mcp/tools/consensus-vote-recording.test
  */
 
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { findRepoRoot } from '../../config/repo-root-detection.js';
-import { VOTE_RECORDS_PATH_ENV, VOTE_RECORDS_REL_PATH } from '../../audit/vote-record-store.js';
+import { getNexusDataDir, nexusDataPath } from '../../config/nexus-data-dir.js';
+import { VOTE_RECORDS_PATH_ENV } from '../../audit/vote-record-store.js';
 import type { ConsensusResult, Vote } from '../../consensus/types.js';
 import type { AgentVoteResult, VoterRole } from '../../cli/vote-types.js';
 
 import { recordAuthenticVote } from './consensus-vote-recording.js';
 
-vi.mock('../../config/repo-root-detection.js', () => ({
-  findRepoRoot: vi.fn(() => null),
+// #3991: the runtime ledger resolves via nexusDataPath (governance category)
+// instead of findRepoRoot. Mock the resolver so each test pins the data root.
+vi.mock('../../config/nexus-data-dir.js', () => ({
+  getNexusDataDir: vi.fn(() => '/data-root/.nexus-agents'),
+  nexusDataPath: vi.fn((...segments: string[]) =>
+    ['/data-root/.nexus-agents', ...segments].join('/')
+  ),
 }));
 
 function vote(decision: Vote['decision'], confidence: number): Vote {
@@ -65,10 +70,16 @@ const realVotes: readonly AgentVoteResult[] = [
 
 describe('recordAuthenticVote persistence outcome (#3991)', () => {
   let dir: string;
+  let dataRoot: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'vote-outcome-'));
-    vi.mocked(findRepoRoot).mockReturnValue(null);
+    dataRoot = join(dir, 'data-root', '.nexus-agents');
+    // Default: nexusDataPath roots under a real temp data dir so persists write.
+    vi.mocked(getNexusDataDir).mockReturnValue(dataRoot);
+    vi.mocked(nexusDataPath).mockImplementation((...segments: string[]) =>
+      join(dataRoot, ...segments)
+    );
   });
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -92,9 +103,18 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     }
   });
 
-  it('reports no-repo-root with an actionable NEXUS_VOTE_RECORDS_PATH detail when no location resolves', () => {
-    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined); // no override
-    // findRepoRoot mocked to null → no committable location.
+  it('reports write-failed with an actionable note when the data dir is unwritable', () => {
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined); // no override → nexusDataPath
+    // Make the resolved path unwritable: put a regular FILE where a directory
+    // component must be, so persistVoteRecord's mkdirSync throws ENOTDIR and the
+    // outcome is classified write-failed. The path still passes the resolver's
+    // defense-in-depth check because it sits under getNexusDataDir.
+    const fileAsDir = join(dir, 'not-a-dir');
+    writeFileSync(fileAsDir, 'x', 'utf-8');
+    const unwritable = join(fileAsDir, 'governance', 'vote-records.jsonl');
+    vi.mocked(getNexusDataDir).mockReturnValue(fileAsDir);
+    vi.mocked(nexusDataPath).mockReturnValue(unwritable);
+
     const outcome = recordAuthenticVote({
       proposal: 'Promote loop X to enforce',
       strategy: 'higher_order',
@@ -103,9 +123,8 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     });
     expect(outcome.persisted).toBe(false);
     if (!outcome.persisted) {
-      expect(outcome.reason).toBe('no-repo-root');
+      expect(outcome.reason).toBe('write-failed');
       expect(outcome.detail).toContain(VOTE_RECORDS_PATH_ENV);
-      expect(outcome.detail).toContain(VOTE_RECORDS_REL_PATH);
     }
   });
 
@@ -130,9 +149,8 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     expect(written.length).toBeGreaterThan(0);
   });
 
-  it('persists to <repo-root>/governance/... when a repo root resolves (no override)', () => {
+  it('#3991: persists to the .nexus-agents/governance/ data-dir path when no override is set', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
-    vi.mocked(findRepoRoot).mockReturnValue(dir); // simulate a committable repo root
 
     const outcome = recordAuthenticVote({
       proposal: 'p',
@@ -141,7 +159,12 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
       votes: realVotes,
     });
     expect(outcome.persisted).toBe(true);
-    const written = readFileSync(join(dir, VOTE_RECORDS_REL_PATH), 'utf-8').trim();
+    // Landed under the canonical nexusDataPath governance location — the global-
+    // install / sandbox-robust path, NOT a repo-root committed ledger.
+    const written = readFileSync(
+      join(dataRoot, 'governance', 'vote-records.jsonl'),
+      'utf-8'
+    ).trim();
     expect(written.length).toBeGreaterThan(0);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -20,7 +20,7 @@ import type { VoteRecord } from '../../audit/vote-record.js';
 import {
   persistVoteRecord,
   resolveVoteRecordsPath,
-  voteRecordNoRootMessage,
+  voteRecordWriteFailedMessage,
 } from '../../audit/vote-record-store.js';
 import { getToolMemory } from './tool-memory.js';
 import {
@@ -104,34 +104,41 @@ function toRecordStrategy(strategy: string): VoteRecord['strategy'] {
 /**
  * Structured outcome of the best-effort authentic-vote-record persistence
  * (#3991). Surfaced in the `consensus_vote` result so an MCP caller can SEE
- * whether the committable record was written and, when not, WHY + how to fix —
- * previously a skipped/failed persist was only a server-side WARN invisible to
- * MCP clients (a live 2.135.0 vote produced no persisted record with no visible
- * signal). Observability only: the persistence/cwd-resolution logic is unchanged.
+ * whether the record was written and, when not, WHY + how to fix — previously a
+ * skipped/failed persist was only a server-side WARN invisible to MCP clients.
+ *
+ * Reason vocabulary (#3991, Option B). Since the runtime ledger now routes
+ * through `nexusDataPath` under `governance/`, the path essentially always
+ * resolves to a writable `.nexus-agents/governance/` location — so the normal
+ * case is `persisted: true`. The former `'no-repo-root'` reason is OBSOLETE
+ * (there is always a homedir/sandbox/repo fallback): a non-persist is now either
+ * `'all-simulated'` (skipped by design) or `'write-failed'` (the data dir was
+ * unwritable, or a fail-closed traversal rejection). Observability only.
  */
 export type VoteRecordPersistOutcome =
   | { readonly persisted: true; readonly record: VoteRecord }
   | {
       readonly persisted: false;
-      readonly reason: 'all-simulated' | 'no-repo-root' | 'write-failed';
+      readonly reason: 'all-simulated' | 'write-failed';
       readonly detail: string;
     };
 
 /**
  * Persist an authentic, self-hashed vote record (tamper-evident record set +
- * monotonic sequence, #3927) to the committable governance
- * artifact at vote time (#3897). Best-effort: a persist failure must never fail
- * the vote, so the store swallows + logs. Skips all-simulated runs (random
- * output must not seed a committed record).
+ * monotonic sequence, #3927) at vote time (#3897). Best-effort: a persist
+ * failure must never fail the vote, so the store swallows + logs. Skips
+ * all-simulated runs (random output must not seed a committed record).
  *
- * Returns a structured {@link VoteRecordPersistOutcome} (#3991) so the caller
- * can surface the result to MCP clients instead of leaving a skip invisible:
+ * RUNTIME LEDGER (#3991, design vote 7-0 Option B): the path routes through
+ * `nexusDataPath('governance', ...)`, landing in a writable
+ * `.nexus-agents/governance/` location (sandbox / repo-preferred / homedir), so
+ * `persisted: true` is the normal case. Returns a structured
+ * {@link VoteRecordPersistOutcome} so the caller can surface a non-persist to MCP
+ * clients:
  *  - `all-simulated` — every vote was simulated; a committed record would seed
  *    governance from random output (#2319);
- *  - `no-repo-root` — no committable location (server outside the repo, no
- *    override); `detail` reuses the server WARN's actionable guidance;
- *  - `write-failed` — a location resolved but the append threw.
- * Persistence remains best-effort; this only reports what happened.
+ *  - `write-failed` — the data dir was unwritable (or a fail-closed traversal
+ *    rejection); `detail` carries the actionable unwritable-data-dir guidance.
  */
 export function recordAuthenticVote(args: {
   proposal: string;
@@ -151,16 +158,17 @@ export function recordAuthenticVote(args: {
         'from random output (#2319), so persistence is skipped by design.',
     };
   }
-  // Resolve the committable location up front (mirrors the store's own
-  // precedence: env override > repo-root detection) so a no-root skip surfaces
-  // a DISTINCT, actionable reason vs a genuine write failure. The persist path
-  // and cwd-resolution logic are unchanged — this only classifies the outcome.
-  if (resolveVoteRecordsPath() === undefined) {
-    const detail = voteRecordNoRootMessage();
-    // Defense-in-depth: keep the server-side WARN (#3991). persistVoteRecord
-    // won't be reached below to log its own, so emit it here.
+  // Resolve the data-dir path up front (mirrors the store's own precedence: env
+  // override > nexusDataPath) so a fail-closed/unwritable case surfaces an
+  // actionable note carrying the resolved path. Post-#3991 this almost always
+  // returns a path; `undefined` is the rare traversal-rejection/resolver-failure
+  // case and is classified as write-failed.
+  const resolvedPath = resolveVoteRecordsPath();
+  if (resolvedPath === undefined) {
+    const detail = voteRecordWriteFailedMessage('<unresolved>');
+    // persistVoteRecord won't be reached below to log its own WARN, so emit here.
     logger.warn(detail);
-    return { persisted: false, reason: 'no-repo-root', detail };
+    return { persisted: false, reason: 'write-failed', detail };
   }
   const id = `vote-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 9)}`;
   const record = persistVoteRecord({
@@ -173,12 +181,13 @@ export function recordAuthenticVote(args: {
     logger,
   });
   if (record === undefined) {
-    // Location resolved but the append threw — persistVoteRecord already WARNed
-    // with the underlying error + path.
+    // The path resolved but the append threw (data dir unwritable) —
+    // persistVoteRecord already WARNed with the underlying error + path. Surface
+    // the actionable unwritable-data-dir guidance with the concrete path.
     return {
       persisted: false,
       reason: 'write-failed',
-      detail: 'Vote record write failed; see server logs for the underlying filesystem error.',
+      detail: voteRecordWriteFailedMessage(resolvedPath),
     };
   }
   return { persisted: true, record };

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -287,17 +287,19 @@ export interface ConsensusVoteResponse {
    */
   costSummary?: DecisionCostSummary;
   /**
-   * #3991: whether the authentic, committable vote record (#3897) was persisted
-   * at vote time. `false` when the persist was skipped (all votes simulated, or
-   * no committable repo root) or the write failed — see {@link voteRecordNote}.
-   * Surfaces to the MCP caller what was previously only a server-side WARN.
-   * Observability only: the persistence/cwd-resolution logic is unchanged.
+   * #3991: whether the authentic vote record (#3897) was persisted at vote time.
+   * Post-#3991 the runtime ledger routes through `nexusDataPath` under
+   * `governance/`, so a writable `.nexus-agents/governance/` location almost
+   * always exists and `true` is the normal case. `false` means the persist was
+   * skipped (all votes simulated) or the write failed (data dir unwritable) —
+   * see {@link voteRecordNote}. Surfaces to the MCP caller what was previously
+   * only a server-side WARN.
    */
   voteRecordPersisted: boolean;
   /**
    * #3991: present only when {@link voteRecordPersisted} is `false` — the
-   * actionable reason the record was not written (e.g. no committable repo root
-   * → set `NEXUS_VOTE_RECORDS_PATH` or commit the returned bytes).
+   * actionable reason the record was not written (e.g. the data dir is unwritable
+   * → fix permissions or set `NEXUS_VOTE_RECORDS_PATH` to a writable path).
    */
   voteRecordNote?: string;
 }

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -865,11 +865,11 @@ describe('buildResponse surfaces vote-record persistence outcome (#3991)', () =>
     expect(response.voteRecordNote).toBeUndefined();
   });
 
-  it('reports voteRecordPersisted=false + an actionable note on a no-repo-root skip', () => {
+  it('reports voteRecordPersisted=false + an actionable note on a write-failed skip', () => {
     const response = buildResponse(input, makeResult(), undefined, {
       persisted: false,
-      reason: 'no-repo-root',
-      detail: 'set NEXUS_VOTE_RECORDS_PATH to an absolute file path.',
+      reason: 'write-failed',
+      detail: 'data dir not writable; set NEXUS_VOTE_RECORDS_PATH to a writable path.',
     });
     expect(response.voteRecordPersisted).toBe(false);
     expect(response.voteRecordNote).toContain('NEXUS_VOTE_RECORDS_PATH');

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -935,10 +935,11 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   // #3124: explains a `rejected` decision that coexists with a high
   // approvalPercentage (an error-policy short-circuit, e.g. fail_closed).
   policyReason: z.string().max(200).optional(),
-  // #3991: whether the authentic, committable vote record was persisted at vote
-  // time. False when skipped (all-simulated / no committable repo root) or the
-  // write failed — voteRecordNote carries the actionable reason. Makes a
-  // previously WARN-only skip visible to MCP callers.
+  // #3991: whether the authentic vote record was persisted at vote time. Post-
+  // #3991 it routes through nexusDataPath under governance/, so true is the
+  // normal case; false means all-simulated (skipped by design) or write-failed
+  // (data dir unwritable) — voteRecordNote carries the actionable reason. Makes
+  // a previously WARN-only skip visible to MCP callers.
   voteRecordPersisted: z.boolean(),
   voteRecordNote: z.string().max(500).optional(),
 };


### PR DESCRIPTION
## Summary

Build #3991 (7-0 ratified, Option B). Routes the **runtime** authentic-vote-record store through the canonical `nexusDataPath` resolver under a per-repo `governance/` category, so it supports sandbox and global-install layouts and always has a writable home — consistent with the 10+ other runtime stores.

### Precedence change (`resolveVoteRecordsPath()`)
1. `NEXUS_VOTE_RECORDS_PATH` override — absolute used as-is; relative resolved against cwd (#3963). This is the explicit escape hatch and the **only** way to target the committed `<repo>/governance/vote-records.jsonl` ledger the promotion gate (#3895) reads (a separate caller-commits/governor-gate artifact, deferred — never auto-written).
2. otherwise `nexusDataPath('governance', 'vote-records.jsonl')` → `<sandbox-root>/.nexus-agents/governance/` (sandbox), `<repo>/.nexus-agents/governance/` (repo-preferred, gitignored), or `~/.nexus-agents/governance/vote-records.jsonl` (default / global install).
3. **Dropped** the old `findRepoRoot(cwd)/governance/...` default — it caused the #3991 silent persist-skip on global installs (cwd not a repo → `undefined` → no persist) AND tracked-file churn.

Result: the runtime store now essentially **always** persists into `.nexus-agents` (sandbox-robust), while the committed `<repo>/governance` ledger stays a separate override-reachable artifact for the deferred gate.

`nexusDataPath` call used: **`nexusDataPath('governance', 'vote-records.jsonl')`** (added `'governance'` to `PER_REPO_SUBDIRS` so it routes per-repo under `NEXUS_REPO_PREFERRED`, and to homedir/sandbox otherwise).

### Path-traversal validation (binding security condition)
- The env override is fail-closed validated: a **relative** override that escapes cwd via `..` is rejected (resolver returns `undefined` → skip persist). An absolute override is the operator's explicit choice and honored as-is.
- The `nexusDataPath`-resolved path is defense-in-depth validated to be absolute, end with the `governance/vote-records.jsonl` suffix, and live under a recognized `.nexus-agents` data root (homedir/sandbox or per-repo).
- Self-hash tamper-evidence chain unchanged (only the location moves). No VCS added to `~/.nexus-agents`.

### Persistence outcomes (#3992 reasons)
Since the path now ~always resolves, the `'no-repo-root'` reason is **removed**. A non-persist is now `'all-simulated'` or `'write-failed'` (unwritable data dir). `voteRecordNoRootMessage` → `voteRecordWriteFailedMessage(path)`; the `voteRecordNote` now explains the unwritable data dir + the override escape hatch.

### Tests
- Precedence: env override (absolute + relative→resolved); `..`-traversal escaping → rejected.
- Governance routing in `nexus-data-dir.test.ts`: `NEXUS_SANDBOX` → under sandbox root; `NEXUS_REPO_PREFERRED` (default) in a repo → `<repo>/.nexus-agents/governance/`; `NEXUS_REPO_PREFERRED=0` → homedir.
- **#3991 regression:** global install (no override, cwd not a repo) → `resolveVoteRecordsPath` returns a valid `.nexus-agents` path (not `undefined`) and a persist writes a record there.
- `recordAuthenticVote` outcome: real → `persisted:true`; all-simulated → `persisted:false`/`'all-simulated'`; unwritable path → `persisted:false`/`'write-failed'`.

### Gates
- `tsc --noEmit` clean; eslint clean on changed files; zero `any`.
- `vote-record-store` + `nexus-data-dir` + `consensus-vote-recording` + `consensus-vote` suites green (154 tests).
- `check-mcp-description-drift` green (46 tools, unchanged). Repo-index regen produces no content delta (no MCP tool/CLI added).
- Changeset added (`'nexus-agents': minor`, `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)