### PR TITLE
fix(memory): route mobimem + nexus-memory default DB through .nexus-agents resolver + auto-create (#3995)

### DIFF
--- a/.changeset/memory-nexusdatapath-3995.md
+++ b/.changeset/memory-nexusdatapath-3995.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': patch
+'nexus-memory': patch
+---
+
+fix(memory): route mobimem + nexus-memory default DB through the `.nexus-agents` resolver + auto-create the data dir (#3995)
+
+Two memory-subsystem stores bypassed the canonical `nexusDataPath` resolver by
+re-implementing `~/.nexus-agents` inline (same class of defect as #3994):
+
+- **MobiMem** (`context/mobimem.ts`): `defaultSharedDbPath()` now resolves via
+  `nexusDataPath('memory', 'mobimem.db')`, gaining sandbox detection, the
+  per-repo/cross-repo split, the homedir-unwritable fallback, and `.gitignore`
+  auto-wiring instead of a hardcoded `NEXUS_DATA_DIR ?? $HOME/.nexus-agents`.
+- **nexus-memory default DB**: nexus-agents now injects the canonical
+  `nexusDataPath('memory', 'memory.db')` into the shared `MemoryRegistry`
+  before first use (`ensureSharedMemoryRegistry()`), so the resolver — not
+  nexus-memory's inline fallback — supplies the production path. nexus-memory
+  stays dep-free: the path is resolved on the nexus-agents side and passed as a
+  plain string; `resolveDefaultDbPath()` remains the dep-free fallback for
+  `nexus-eval-*` reuse.
+
+Also fixes a fresh-install regression: opening a SQLite store whose parent
+directory does not exist threw `SQLITE_CANTOPEN`. A shared dep-free
+`openSqliteDatabase()` helper now `mkdirSync(dirname, { recursive: true })`
+before `new Database()` at every on-disk open site in nexus-memory (the
+registry connection and the `SqliteBackend`); `:memory:` is unaffected.
+
+`core/trace-exporter.ts` gains a code comment noting that if trace persistence
+is ever wired into production, the path should come from
+`nexusDataPath('traces', ...)` (currently test-only / param-driven — no
+behavior change).

--- a/packages/nexus-agents/src/context/mobimem.test.ts
+++ b/packages/nexus-agents/src/context/mobimem.test.ts
@@ -7,8 +7,20 @@
  * (Source: Issue #149)
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { MobiMem, createMobiMem, type ActionStep, type ExecutionOutcome } from './mobimem.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  MobiMem,
+  createMobiMem,
+  defaultSharedDbPath,
+  type ActionStep,
+  type ExecutionOutcome,
+} from './mobimem.js';
+
+/** Restore an env var to a saved value, or clear it if it was unset. */
+function restoreEnv(key: string, saved: string | undefined): void {
+  if (saved === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = saved;
+}
 
 describe('MobiMem', () => {
   let mobimem: MobiMem;
@@ -372,6 +384,49 @@ describe('MobiMem', () => {
       });
 
       expect(instance).toBeInstanceOf(MobiMem);
+    });
+  });
+
+  // #3995: the shared-DB default resolver must route through `nexusDataPath`
+  // instead of re-implementing `~/.nexus-agents` inline.
+  describe('defaultSharedDbPath (#3995)', () => {
+    let savedDataDir: string | undefined;
+    let savedRepoPreferred: string | undefined;
+    let savedSandbox: string | undefined;
+    let savedSandboxRoot: string | undefined;
+
+    beforeEach(() => {
+      savedDataDir = process.env['NEXUS_DATA_DIR'];
+      savedRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
+      savedSandbox = process.env['NEXUS_SANDBOX'];
+      savedSandboxRoot = process.env['NEXUS_SANDBOX_ROOT'];
+    });
+
+    afterEach(() => {
+      restoreEnv('NEXUS_DATA_DIR', savedDataDir);
+      restoreEnv('NEXUS_REPO_PREFERRED', savedRepoPreferred);
+      restoreEnv('NEXUS_SANDBOX', savedSandbox);
+      restoreEnv('NEXUS_SANDBOX_ROOT', savedSandboxRoot);
+    });
+
+    it('resolves under NEXUS_DATA_DIR/memory/mobimem.db when that env is set', () => {
+      process.env['NEXUS_DATA_DIR'] = '/var/lib/nexus-test';
+      // env override wins regardless of repo-preferred.
+      expect(defaultSharedDbPath()).toBe('/var/lib/nexus-test/memory/mobimem.db');
+    });
+
+    it('resolves under the sandbox root when NEXUS_SANDBOX is active', () => {
+      delete process.env['NEXUS_DATA_DIR'];
+      process.env['NEXUS_SANDBOX'] = 'docker-opencode';
+      process.env['NEXUS_SANDBOX_ROOT'] = '/projects';
+      expect(defaultSharedDbPath()).toBe('/projects/.nexus-agents/memory/mobimem.db');
+    });
+
+    it('always ends in the cross-repo memory subdir', () => {
+      // `memory` is intentionally NOT a per-repo subdir, so the path always
+      // carries the `memory/mobimem.db` tail regardless of resolution tier.
+      process.env['NEXUS_DATA_DIR'] = '/tmp/nexus-x';
+      expect(defaultSharedDbPath().endsWith('/memory/mobimem.db')).toBe(true);
     });
   });
 });

--- a/packages/nexus-agents/src/context/mobimem.ts
+++ b/packages/nexus-agents/src/context/mobimem.ts
@@ -18,6 +18,7 @@ import { dirname } from 'node:path';
 import { mkdirSync } from 'node:fs';
 
 type DatabaseType = InstanceType<typeof Database>;
+import { nexusDataPath } from '../config/nexus-data-dir.js';
 import { createLogger } from '../core/logger.js';
 import type { IMobiMem, MobiMemConfig, MobiMemStats } from './mobimem-types.js';
 import { DEFAULT_MOBIMEM_CONFIG, MobiMemConfigSchema } from './mobimem-types.js';
@@ -173,7 +174,17 @@ export function setSharedMobiMemDbPathResolver(resolver: () => string): void {
   resolveSharedDbPath = resolver;
 }
 
-function defaultSharedDbPath(): string {
-  const root = process.env['NEXUS_DATA_DIR'] ?? `${process.env['HOME'] ?? '/tmp'}/.nexus-agents`;
-  return `${root}/memory/mobimem.db`;
+/**
+ * Default resolver for the shared MobiMem SQLite path. Routes through the
+ * canonical {@link nexusDataPath} resolver (#3995) so it inherits sandbox
+ * detection, the per-repo/cross-repo split, the homedir-unwritable fallback,
+ * and `.gitignore` auto-wiring — instead of re-implementing `~/.nexus-agents`
+ * inline. `memory` is intentionally NOT in `PER_REPO_SUBDIRS`, so this stays
+ * cross-repo (homedir on normal machines). Exported for the resolver-routing
+ * regression test. Used only when no caller has overridden the resolver via
+ * {@link setSharedMobiMemDbPathResolver} (`tool-memory.ts` does override it
+ * with the equivalent `nexusDataPath('memory','mobimem.db')`).
+ */
+export function defaultSharedDbPath(): string {
+  return nexusDataPath('memory', 'mobimem.db');
 }

--- a/packages/nexus-agents/src/core/trace-exporter.ts
+++ b/packages/nexus-agents/src/core/trace-exporter.ts
@@ -71,6 +71,14 @@ const DEFAULT_VIS_OPTIONS: ResolvedVisualizationOptions = {
 /**
  * Exports trace data to JSON file.
  *
+ * NOTE (#3995): `filepath` is fully caller-supplied — today this is test-only /
+ * param-driven and creates the parent dir on demand, so it does not touch the
+ * canonical data-dir resolver. If this is ever wired to persist traces in
+ * production, the destination should be derived from
+ * `nexusDataPath('traces', generateTraceFilename(traceId))` (`traces` is a
+ * per-repo subdir) rather than an inline path, so it inherits the
+ * sandbox/per-repo-fallback/gitignore handling like the other stores.
+ *
  * @param tracer - Tracer instance to export from
  * @param filepath - Destination file path
  * @param format - Export format (default: 'json-pretty')
@@ -205,6 +213,11 @@ export function printTrace(tracer: Tracer, options?: VisualizationOptions): void
 
 /**
  * Generates a default filename for trace export.
+ *
+ * NOTE (#3995): returns a bare filename, not a path. Production callers that
+ * persist traces should join it under `nexusDataPath('traces', ...)` (a
+ * per-repo subdir) rather than the cwd, so traces land in the canonical
+ * data dir with the rest of the runtime state.
  *
  * @param traceId - Trace ID to include in filename
  * @returns Filename with timestamp

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
@@ -6,8 +6,20 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { closeMemoryRegistry, createInMemoryMemoryRegistry, setMemoryRegistry } from 'nexus-memory';
-import { StatsOnlyAdapter } from './tool-memory-registry-adapters.js';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  closeMemoryRegistry,
+  createInMemoryMemoryRegistry,
+  getMemoryRegistry,
+  hasMemoryRegistry,
+  setMemoryRegistry,
+} from 'nexus-memory';
+import {
+  StatsOnlyAdapter,
+  ensureSharedMemoryRegistry,
+} from './tool-memory-registry-adapters.js';
 
 describe('StatsOnlyAdapter', () => {
   beforeEach(() => {
@@ -187,5 +199,53 @@ describe('registry-level fan-out (#2792 Phase 1)', () => {
     const byDomain = new Map(results.map((r) => [r.domain, r.rows]));
     expect(byDomain.get('domain-a')).toEqual(['a:task:1', 'a:task:2']);
     expect(byDomain.get('domain-b')).toEqual([{ from: 'b', q: 'task', limit: 3 }]);
+  });
+});
+
+describe('ensureSharedMemoryRegistry (#3995)', () => {
+  let root: string;
+  let savedDataDir: string | undefined;
+  let savedRepoPreferred: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'nexus-reg-inject-'));
+    savedDataDir = process.env['NEXUS_DATA_DIR'];
+    savedRepoPreferred = process.env['NEXUS_REPO_PREFERRED'];
+    // Pin resolution to the temp dir so the injected path is deterministic.
+    process.env['NEXUS_DATA_DIR'] = root;
+    // Start with no registry so the injection path runs.
+    setMemoryRegistry(null);
+  });
+
+  afterEach(async () => {
+    await closeMemoryRegistry();
+    if (savedDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = savedDataDir;
+    if (savedRepoPreferred === undefined) delete process.env['NEXUS_REPO_PREFERRED'];
+    else process.env['NEXUS_REPO_PREFERRED'] = savedRepoPreferred;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('injects a registry resolved via nexusDataPath when none exists', async () => {
+    expect(hasMemoryRegistry()).toBe(false);
+    ensureSharedMemoryRegistry();
+    expect(hasMemoryRegistry()).toBe(true);
+
+    // Writing through the registry persists under <NEXUS_DATA_DIR>/memory/memory.db,
+    // proving the canonical resolver supplied the path (and the parent dir was
+    // auto-created on open — fresh-install case).
+    const registry = getMemoryRegistry();
+    const backend = registry.register<string, { v: number }>({ domain: 'inject_check' });
+    await backend.write('k', { v: 5 });
+    expect(await backend.read('k')).toEqual({ v: 5 });
+    expect(existsSync(join(root, 'memory', 'memory.db'))).toBe(true);
+  });
+
+  it('is a no-op when a registry is already set (respects test injection)', () => {
+    const injected = createInMemoryMemoryRegistry();
+    setMemoryRegistry(injected);
+    ensureSharedMemoryRegistry();
+    // The in-memory test registry must NOT have been clobbered.
+    expect(getMemoryRegistry()).toBe(injected);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
@@ -13,7 +13,10 @@
  * @module mcp/tools/tool-memory-registry-adapters
  */
 
+import { MemoryRegistry, hasMemoryRegistry, setMemoryRegistry } from 'nexus-memory';
 import type { BackendStats, CliName, IMemoryBackend, QueryFilter, WriteMeta } from 'nexus-memory';
+
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
 
 /** Default cap when a consumer omits `limit` in `query()`. */
 const DEFAULT_SEARCH_LIMIT = 10;
@@ -142,3 +145,38 @@ function extractCount(value: unknown): number {
 
 /** Convenience tag the adapter passes to `WriteMeta.cli` for future writes. */
 export type AdapterCli = CliName;
+
+// ============================================================================
+// Shared MemoryRegistry path injection (#3995)
+// ============================================================================
+
+/**
+ * Ensure the process-wide shared {@link MemoryRegistry} is constructed with
+ * the canonical nexus-agents data path (#3995).
+ *
+ * nexus-memory ships a dep-free `resolveDefaultDbPath()` fallback that
+ * re-implements `~/.nexus-agents/memory/memory.db` inline so the package stays
+ * free of inter-package imports (it is reused by `nexus-eval-*`). In
+ * production nexus-agents we want the canonical {@link nexusDataPath} resolver
+ * instead — it adds sandbox detection, the per-repo/cross-repo split, the
+ * homedir-unwritable fallback, and `.gitignore` auto-wiring that the dep-free
+ * fallback cannot know about. We keep nexus-memory dep-free by doing the
+ * resolution HERE (on the nexus-agents side) and injecting the resolved path
+ * as a plain string via `setMemoryRegistry`.
+ *
+ * No-op when a registry is already present (`hasMemoryRegistry()`): that means
+ * either a test injected an in-memory registry, or a prior call already wired
+ * the canonical path. Checking presence — rather than calling
+ * `getMemoryRegistry()` — is what lets us win the race against nexus-memory's
+ * lazy default-path initialization without ever triggering it. Call this
+ * before the first `getMemoryRegistry()` in any production path that attaches
+ * a backend.
+ */
+export function ensureSharedMemoryRegistry(): void {
+  if (hasMemoryRegistry()) return;
+  // `memory` is intentionally cross-repo (not in PER_REPO_SUBDIRS), so this
+  // resolves to `~/.nexus-agents/memory/memory.db` on a normal machine and to
+  // the sandbox / per-repo-fallback root under those modes.
+  const dbPath = nexusDataPath('memory', 'memory.db');
+  setMemoryRegistry(new MemoryRegistry({ dbPath }));
+}

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -48,7 +48,10 @@ import {
   getSharedMobiMem,
   setSharedMobiMemDbPathResolver,
 } from '../../context/mobimem.js';
-import { StatsOnlyAdapter } from './tool-memory-registry-adapters.js';
+import {
+  StatsOnlyAdapter,
+  ensureSharedMemoryRegistry,
+} from './tool-memory-registry-adapters.js';
 import type { MobiMemStats } from '../../context/mobimem-types.js';
 import {
   MemoryPromoter,
@@ -132,6 +135,10 @@ function attachToRegistry(
   }
 ): void {
   try {
+    // #3995: inject the canonical nexusDataPath-resolved DB path before the
+    // first registry touch, so production uses the resolver instead of
+    // nexus-memory's dep-free fallback. No-op once a registry exists.
+    ensureSharedMemoryRegistry();
     getMemoryRegistry().attach(domain, new StatsOnlyAdapter(domain, backend));
   } catch {
     // Domain already registered — re-init of tool-memory should be a no-op.

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-store.ts
@@ -293,6 +293,12 @@ async function attachOutcomeStoreToRegistry(store: OutcomeStore): Promise<void> 
   try {
     const { getMemoryRegistry } = await import('nexus-memory');
     const { OutcomeStoreAdapter } = await import('./outcome-store-adapter.js');
+    const { ensureSharedMemoryRegistry } = await import(
+      '../../mcp/tools/tool-memory-registry-adapters.js'
+    );
+    // #3995: inject the canonical nexusDataPath-resolved DB path before the
+    // first registry touch. No-op once a registry exists.
+    ensureSharedMemoryRegistry();
     getMemoryRegistry().attach('outcomes', new OutcomeStoreAdapter(store));
   } catch {
     // Already attached or nexus-memory unavailable — silent.

--- a/packages/nexus-memory/src/backends/open-database.test.ts
+++ b/packages/nexus-memory/src/backends/open-database.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Fresh-install auto-create regression tests (#3995).
+ *
+ * Before #3995, opening a SQLite-backed store at a path whose parent
+ * directory did not yet exist threw `SQLITE_CANTOPEN` — the classic
+ * fresh-install failure when the resolver hands back
+ * `~/.nexus-agents/memory/*.db` and nobody has created the dir. The shared
+ * `openSqliteDatabase` helper now creates the parent dir first. `:memory:`
+ * keeps working (no dir created).
+ *
+ * @module nexus-memory/backends/open-database.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openSqliteDatabase } from './open-database.js';
+import { SqliteBackend } from './sqlite.js';
+import { MemoryRegistry } from '../registry.js';
+
+describe('openSqliteDatabase fresh-install auto-create (#3995)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'nexus-mem-open-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('creates the missing parent directory before opening the DB', () => {
+    // `root/a/b/` does not exist yet — pre-#3995 this threw SQLITE_CANTOPEN.
+    const dbPath = join(root, 'a', 'b', 'memory.db');
+    expect(existsSync(join(root, 'a', 'b'))).toBe(false);
+
+    const db = openSqliteDatabase(dbPath);
+    try {
+      expect(existsSync(join(root, 'a', 'b'))).toBe(true);
+      expect(existsSync(dbPath)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('opens :memory: without creating any directory', () => {
+    const db = openSqliteDatabase(':memory:');
+    try {
+      // A `:memory:` file must never appear on disk.
+      expect(existsSync(join(process.cwd(), ':memory:'))).toBe(false);
+      // The handle is usable.
+      db.exec('CREATE TABLE t (k TEXT)');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('SqliteBackend opens at a path with a missing parent dir', async () => {
+    const dbPath = join(root, 'missing', 'sub', 'backend.db');
+    const backend = new SqliteBackend<string, { v: number }>({
+      domain: 'fresh_install',
+      dbPath,
+    });
+    try {
+      await backend.write('k', { v: 1 });
+      expect(await backend.read('k')).toEqual({ v: 1 });
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it('MemoryRegistry opens at a path with a missing parent dir', async () => {
+    const dbPath = join(root, 'reg', 'deep', 'registry.db');
+    const registry = new MemoryRegistry({ dbPath });
+    try {
+      expect(existsSync(join(root, 'reg', 'deep'))).toBe(true);
+      const backend = registry.register<string, { v: number }>({ domain: 'reg_fresh' });
+      await backend.write('k', { v: 7 });
+      expect(await backend.read('k')).toEqual({ v: 7 });
+    } finally {
+      await registry.close();
+    }
+  });
+});

--- a/packages/nexus-memory/src/backends/open-database.ts
+++ b/packages/nexus-memory/src/backends/open-database.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared helper for opening a `better-sqlite3` connection on disk.
+ *
+ * Centralizes the two pre-#3995 concerns that were duplicated at every
+ * `new Database(dbPath)` site in this package:
+ *
+ * 1. **Auto-create the parent directory.** `better-sqlite3` throws
+ *    `SQLITE_CANTOPEN` when the parent directory of `dbPath` does not exist
+ *    (the classic fresh-install regression — the resolver hands back a path
+ *    under `~/.nexus-agents/memory/` that nobody has created yet). We
+ *    `mkdirSync(dirname(dbPath), { recursive: true })` first so opening the
+ *    DB never throws merely because the directory is missing. `:memory:`
+ *    (and the empty string) are pure in-memory handles with no parent dir, so
+ *    they skip the mkdir.
+ * 2. **WAL journal mode.** Keeps concurrent MCP-server + CLI readers coherent.
+ *
+ * Kept dep-free on purpose: nexus-memory must stay free of inter-package
+ * imports so `nexus-eval-*` repos can reuse it. The canonical
+ * `nexusDataPath` resolver lives in nexus-agents and injects the path here as
+ * a plain string (see `getMemoryRegistry` wiring in nexus-agents). This helper
+ * only guarantees that whatever absolute path it is handed is openable.
+ *
+ * @module nexus-memory/backends/open-database
+ */
+
+import Database, { type Database as DatabaseType } from 'better-sqlite3';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Open a `better-sqlite3` database at `dbPath`, creating the parent directory
+ * first (for on-disk paths) and enabling WAL journal mode.
+ *
+ * @param dbPath Absolute SQLite file path, or `':memory:'` / `''` for an
+ *   in-memory database (no directory is created in that case).
+ */
+export function openSqliteDatabase(dbPath: string): DatabaseType {
+  if (dbPath !== ':memory:' && dbPath !== '') {
+    // Fresh-install robustness (#3995): better-sqlite3 throws SQLITE_CANTOPEN
+    // when the parent dir is missing. Create it up front, idempotently.
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
+  const db = new Database(dbPath);
+  (db as unknown as { pragma(s: string): void }).pragma('journal_mode = WAL');
+  return db;
+}

--- a/packages/nexus-memory/src/backends/sqlite.ts
+++ b/packages/nexus-memory/src/backends/sqlite.ts
@@ -13,11 +13,12 @@
  * @module nexus-memory/backends/sqlite
  */
 
-import Database, { type Database as DatabaseType, type Statement } from 'better-sqlite3';
+import { type Database as DatabaseType, type Statement } from 'better-sqlite3';
 import type { z } from 'zod';
 import { recordMemoryEvent } from '../telemetry.js';
 import type { BackendStats, IMemoryBackend, QueryFilter, WriteMeta } from '../types.js';
 import { MemoryValidationError } from './memory.js';
+import { openSqliteDatabase } from './open-database.js';
 
 export interface SqliteBackendOptions<TValue> {
   readonly domain: string;
@@ -115,9 +116,9 @@ export class SqliteBackend<TKey, TValue> implements IMemoryBackend<TKey, TValue>
       this.db = options.db;
       this.ownsDb = false;
     } else {
-      const db = new Database(options.dbPath);
-      (db as unknown as { pragma(s: string): void }).pragma('journal_mode = WAL');
-      this.db = db;
+      // #3995: open via the shared helper, which creates the parent dir
+      // first (fresh-install robustness) and enables WAL mode.
+      this.db = openSqliteDatabase(options.dbPath);
       this.ownsDb = true;
     }
     if (options.schema !== undefined) {

--- a/packages/nexus-memory/src/index.ts
+++ b/packages/nexus-memory/src/index.ts
@@ -36,6 +36,7 @@ export {
   MemoryRegistry,
   getMemoryRegistry,
   setMemoryRegistry,
+  hasMemoryRegistry,
   closeMemoryRegistry,
 } from './registry.js';
 export type { MemoryRegistryOptions, RegisterBackendOptions } from './registry.js';

--- a/packages/nexus-memory/src/registry.ts
+++ b/packages/nexus-memory/src/registry.ts
@@ -11,9 +11,10 @@
  * @module nexus-memory/registry
  */
 
-import Database, { type Database as DatabaseType } from 'better-sqlite3';
+import { type Database as DatabaseType } from 'better-sqlite3';
 import type { z } from 'zod';
 import { InMemoryBackend } from './backends/memory.js';
+import { openSqliteDatabase } from './backends/open-database.js';
 import { SqliteBackend } from './backends/sqlite.js';
 import type { IMemoryBackend } from './types.js';
 
@@ -44,9 +45,9 @@ export class MemoryRegistry {
 
   constructor(options: MemoryRegistryOptions = {}) {
     if (options.dbPath !== undefined) {
-      const db = new Database(options.dbPath);
-      (db as unknown as { pragma(s: string): void }).pragma('journal_mode = WAL');
-      this.db = db;
+      // #3995: open via the shared helper, which creates the parent dir
+      // first (fresh-install robustness) and enables WAL mode.
+      this.db = openSqliteDatabase(options.dbPath);
     }
   }
 
@@ -174,6 +175,17 @@ export function getMemoryRegistry(): MemoryRegistry {
  */
 export function setMemoryRegistry(registry: MemoryRegistry | null): void {
   sharedRegistry = registry;
+}
+
+/**
+ * True when the shared registry has already been constructed or injected.
+ * Lets nexus-agents inject the canonical {@link nexusDataPath}-resolved DB
+ * path (#3995) WITHOUT clobbering a registry a test already set, and without
+ * triggering the lazy default-path resolution that `getMemoryRegistry()`
+ * would. Read-only — keeps nexus-memory dep-free.
+ */
+export function hasMemoryRegistry(): boolean {
+  return sharedRegistry !== null;
 }
 
 /** Close + null out the shared registry. Idempotent. */


### PR DESCRIPTION
## Summary

Fixes #3995. Two memory-subsystem stores re-implemented `~/.nexus-agents` inline, bypassing the canonical `nexusDataPath` resolver (the same class of defect as #3994). This routes both through the resolver and fixes a fresh-install auto-create bug.

## The two bypassers fixed

1. **MobiMem** (`packages/nexus-agents/src/context/mobimem.ts`)
   `defaultSharedDbPath()` previously returned `(NEXUS_DATA_DIR ?? $HOME/.nexus-agents)/memory/mobimem.db`. It now resolves via `nexusDataPath('memory','mobimem.db')`, gaining sandbox detection, the per-repo/cross-repo split, the homedir-unwritable fallback, and `.gitignore` auto-wiring. (`memory` is intentionally NOT a per-repo subdir, so it stays cross-repo.) `tool-memory.ts` already overrode the resolver with the equivalent `nexusDataPath('memory','mobimem.db')` path, so this only changes the otherwise-inline default.

2. **nexus-memory default DB** (cross-package)
   nexus-agents now injects the canonical `nexusDataPath('memory','memory.db')` into the shared `MemoryRegistry` before first use, via a new `ensureSharedMemoryRegistry()` helper called at the two production attach sites (`tool-memory.ts attachToRegistry`, `outcome-store.ts attachOutcomeStoreToRegistry`).

## How the nexus-memory injection keeps the package dep-free

The path is resolved **on the nexus-agents side** and passed to `setMemoryRegistry(new MemoryRegistry({ dbPath }))` as a plain string — no nexus-agents↔nexus-memory import is added. nexus-memory's `resolveDefaultDbPath()` stays the dep-free fallback for `nexus-eval-*` reuse; production nexus-agents just wins the race and supplies the canonical path first.

To make injection safe I added a read-only `hasMemoryRegistry()` to nexus-memory. `ensureSharedMemoryRegistry()` is a no-op when a registry already exists, so it never clobbers a test-injected in-memory registry and never triggers nexus-memory's lazy default-path init.

## Fresh-install auto-create fix

Opening a SQLite store at a path whose parent dir doesn't exist threw `SQLITE_CANTOPEN`. A shared dep-free `openSqliteDatabase()` helper (`packages/nexus-memory/src/backends/open-database.ts`) `mkdirSync(dirname, { recursive: true })` before `new Database()`, used at both on-disk open sites in nexus-memory — the `MemoryRegistry` connection **and** `SqliteBackend` (the registry ctor opens the file first on a fresh install, so the mkdir had to cover it too). `:memory:` / empty paths skip the mkdir.

## trace-exporter note (minor, no behavior change)

`core/trace-exporter.ts` gains code comments on `exportTraceToFile` / `generateTraceFilename` noting that production trace persistence should derive its path from `nexusDataPath('traces', ...)`. Currently test-only / param-driven.

## Files

- `packages/nexus-agents/src/context/mobimem.ts` — route default through resolver; export `defaultSharedDbPath`
- `packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts` — new `ensureSharedMemoryRegistry()`
- `packages/nexus-agents/src/mcp/tools/tool-memory.ts` + `orchestration/outcomes/outcome-store.ts` — call the injector before first registry touch
- `packages/nexus-agents/src/core/trace-exporter.ts` — notes
- `packages/nexus-memory/src/backends/open-database.ts` (new) — mkdir+open helper
- `packages/nexus-memory/src/backends/sqlite.ts` + `registry.ts` — use the helper
- `packages/nexus-memory/src/registry.ts` + `index.ts` — `hasMemoryRegistry()`
- tests: `mobimem.test.ts`, `open-database.test.ts` (new), `tool-memory-registry-adapters.test.ts`

## Tests

- mobimem resolver routing: `NEXUS_DATA_DIR` → that root; sandbox env → sandbox root; always ends in `memory/mobimem.db`.
- nexus-memory fresh-install: opening a DB whose parent dir is missing now creates it (helper, `SqliteBackend`, and `MemoryRegistry`); `:memory:` creates no dir.
- registry injection: `ensureSharedMemoryRegistry()` persists under `<NEXUS_DATA_DIR>/memory/memory.db`; no-op when a registry is already set.
- Green: nexus-memory (`open-database`, `contract`, `registry` — 46), nexus-agents context dir + adapters (1194), `tool-memory` / `memory-stats` / `outcome-store*` (240). `tsc --noEmit` clean on both packages; eslint clean on changed files; zero `any`. No MCP tool/CLI added — repo-index / MCP_TOOL_COUNT unaffected.

## Judgment calls

- **Helper over inline mkdir**: the instructions specified the mkdir in `sqlite.ts`, but `MemoryRegistry`'s ctor also calls `new Database` directly and opens the file *first* on a fresh install. A shared `openSqliteDatabase()` keeps the mkdir+WAL DRY across both sites rather than duplicating the guard.
- **`hasMemoryRegistry()`**: adding a tiny read-only accessor is the clean way to make injection idempotent and test-safe without exposing or racing the lazy init. Kept dep-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)