### PR TITLE
feat(governance): re-anchor promotion gate to authentic vote-record ledger (#3927 item 1)

### DIFF
--- a/.changeset/authentic-vote-record-gate.md
+++ b/.changeset/authentic-vote-record-gate.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+Re-anchor the authority-tier promotion gate to the authentic vote-record ledger (#3927 item 1)
+
+The CI promotion gate (`scripts/check-authority-tier-drift.ts`) now resolves a tier-transition's `ratificationVoteRef` against the tamper-evident `governance/vote-records.jsonl` — verified as a set with `verifyVoteRecordSet` — instead of the hand-committable `governance/ratification-votes.yaml`. It fails **closed** on a tampered/malformed ledger (`vote-records-ledger-invalid`), on conflicting-decision subjects (`promotion-ratification-ambiguous`), and on the existing unresolved/not-approved reasons. The subject is bound via a new optional, self-hash-covered `ratifies` field on the vote record (schema 1.1 → 1.2); records without it re-verify unchanged (back-compat). The YAML resolution path is removed; the file is deprecated in place (its removal is tracked separately). The change is a no-op for current behaviour (both ledgers are empty / no promotions yet). Authored from a 7/7 `higher_order` design vote. Remains tamper-**evident**, not tamper-**proof** — cryptographic signing is tracked as #3927 item 4.

--- a/docs/governance/loop-promotion-criteria.md
+++ b/docs/governance/loop-promotion-criteria.md
@@ -56,12 +56,30 @@ and any **stricter** bound.
 
 The evidence record each promotion is earned against is the
 `PromotionEvidence` tuple (`strategy-manifest.ts`), recorded in
-[`governance/authority-tier-evidence.yaml`](../../governance/authority-tier-evidence.yaml),
-and the ratification vote is recorded in
-[`governance/ratification-votes.yaml`](../../governance/ratification-votes.yaml).
-The CI gate (`scripts/check-authority-tier-drift.ts`, under `governance:check`)
-fails any promotion that lacks a floor-meeting record + an approved,
-`higher_order`, subject-matching ratification vote.
+[`governance/authority-tier-evidence.yaml`](../../governance/authority-tier-evidence.yaml).
+The ratification vote is resolved against the **authentic, tamper-evident**
+[`governance/vote-records.jsonl`](../../governance/vote-records.jsonl) ledger
+(#3927 item 1) — the hand-committable `ratification-votes.yaml` is **deprecated**
+and no longer read by the gate. The CI gate
+(`scripts/check-authority-tier-drift.ts`, under `governance:check`) fails any
+promotion that lacks a floor-meeting record + a vote record whose `decision` is
+`approved`, `strategy` is `higher_order`, and `ratifies` matches the transition
+subject. It fails **closed** on a tampered/malformed ledger, on a sequence gap
+(an omitted record), and on an ambiguous subject (records that disagree on the
+decision — no ref may cherry-pick the approving fork).
+
+**Authoring a ratification record.** The record is produced at vote time by the
+`consensus_vote` store (`audit/vote-record-store.ts`) carrying `ratifies = <subject>`,
+and committed to `governance/vote-records.jsonl` alongside the tier-transition
+audit event in the promoting PR. (Wiring the `ratifies` argument through the
+`consensus_vote` MCP tool — the last-mile authoring ergonomics — is tracked in the
+#3927 follow-up.)
+
+**Residual trust (tamper-evident, not tamper-proof).** The self-hash detects
+post-hoc edits, but a record is authored in the same PR that performs the
+promotion, so authenticity still rests on CODEOWNERS review + branch protection
+on `governance/`. Cryptographic signing (CI/OIDC, cosign/gitsign, in-toto/SLSA)
+is tracked as #3927 item 4.
 
 ---
 

--- a/docs/governance/loop-promotion-criteria.md
+++ b/docs/governance/loop-promotion-criteria.md
@@ -72,8 +72,8 @@ decision — no ref may cherry-pick the approving fork).
 `consensus_vote` store (`audit/vote-record-store.ts`) carrying `ratifies = <subject>`,
 and committed to `governance/vote-records.jsonl` alongside the tier-transition
 audit event in the promoting PR. (Wiring the `ratifies` argument through the
-`consensus_vote` MCP tool — the last-mile authoring ergonomics — is tracked in the
-#3927 follow-up.)
+`consensus_vote` MCP tool — the last-mile authoring ergonomics — is tracked in
+the #3927 follow-up, #4004.)
 
 **Residual trust (tamper-evident, not tamper-proof).** The self-hash detects
 post-hoc edits, but a record is authored in the same PR that performs the

--- a/governance/ratification-votes.yaml
+++ b/governance/ratification-votes.yaml
@@ -1,13 +1,21 @@
 # Ratification-vote ledger (Epic D, #3894 — ADR-0017).
 #
-# The COMMITTED resolution source the promotion gate
-# (scripts/check-authority-tier-drift.ts, under governance:check) resolves a
-# tier-transition's `ratificationVoteRef` against. #3842 only checked the ref was
-# non-empty — a bogus `ratificationVoteRef:'x'` passed, so "ratification-LINKED"
-# was only as strong as a non-empty string. #3894 makes the link genuine: a
-# `promotion` transition's ref must RESOLVE to a record HERE whose `decision` is
-# `approved` and whose `strategy` is `higher_order` (a promotion is
-# governance-of-the-governor), with a `subject` matching the transition.
+# DEPRECATED as the promotion-gate resolution source (#3927 item 1). The gate
+# (scripts/check-authority-tier-drift.ts, under governance:check) NO LONGER reads
+# this hand-committable YAML. It now resolves a tier-transition's
+# `ratificationVoteRef` against the AUTHENTIC, tamper-evident
+# `governance/vote-records.jsonl` — each record self-hashed at vote time and the
+# whole set verified before any ref resolves, so a forged/edited/omitted record
+# fails the gate closed. The subject is bound via the record's `ratifies` field.
+# This file is retained only to avoid churn while its full removal is tracked
+# separately; do NOT add new entries here — they have no effect on the gate.
+#
+# HISTORICAL (why the YAML existed): #3842 only checked the ref was non-empty — a
+# bogus `ratificationVoteRef:'x'` passed; #3894 resolved the ref against a record
+# HERE whose `decision` is `approved`, `strategy` is `higher_order`, with a
+# `subject` matching the transition. #3927 re-anchored that resolution to the
+# authentic ledger because this YAML is hand-committable (forgeable by anyone who
+# can land a commit), which the #3897 ratification panel flagged.
 #
 # Each record is a RatificationVote (schema: check-authority-tier-drift.ts
 # RatificationVoteSchema):

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -83,6 +83,7 @@ export {
   persistVoteRecord,
   resolveVoteRecordsPath,
   readVoteRecords,
+  parseVoteRecordsText,
 } from './vote-record-store.js';
 export type { BuildVoteRecordInput, PersistVoteRecordOptions } from './vote-record-store.js';
 

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -83,7 +83,7 @@ describe('buildVoteRecord', () => {
       result: consensusResult(),
       votes,
     });
-    expect(record.version).toBe('1.1');
+    expect(record.version).toBe('1.2');
     expect(record.sequence).toBe(0); // default first sequence
     expect(record.decision).toBe('approved');
     expect(record.proposalHash).toHaveLength(64);
@@ -292,9 +292,9 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     expect(records).toHaveLength(1);
     expect(records[0]).toEqual(written);
     // The default nexusDataPath location was NOT used.
-    expect(readVoteRecords(join(dataRoot, 'governance', 'vote-records.jsonl')).records).toHaveLength(
-      0
-    );
+    expect(
+      readVoteRecords(join(dataRoot, 'governance', 'vote-records.jsonl')).records
+    ).toHaveLength(0);
   });
 
   it('returns an absolute override unchanged (#3963)', () => {

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -127,6 +127,12 @@ export interface BuildVoteRecordInput {
   readonly correlationId?: string | undefined;
   readonly recordedAt?: string | undefined;
   /**
+   * The loop/strategy subject this vote RATIFIES (#3927 item 1). Set ONLY for a
+   * ratification vote that backs an authority-tier promotion; bound into the
+   * self-hash so the gate can trust it. Omitted on an ordinary vote.
+   */
+  readonly ratifies?: string | undefined;
+  /**
    * Monotonic sequence number for this record (#3927). Defaults to 0 (first
    * record) when omitted; the producer ({@link persistVoteRecord}) supplies
    * (max existing sequence)+1.
@@ -152,7 +158,7 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
       ? input.proposal.slice(0, MAX_PROPOSAL_RECORD_CHARS) + '...'
       : input.proposal;
   const payload: Omit<VoteRecord, 'hash'> = {
-    version: '1.1',
+    version: '1.2',
     id: input.id,
     sequence: input.sequence ?? 0,
     recordedAt: input.recordedAt ?? new Date().toISOString(),
@@ -169,6 +175,7 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
     },
     voters: toVoterSummaries(input.votes),
     ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+    ...(input.ratifies !== undefined ? { ratifies: input.ratifies } : {}),
     ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
   };
   return { ...payload, hash: computeVoteRecordHash(payload) };
@@ -267,7 +274,9 @@ export function resolveVoteRecordsPath(): string | undefined {
   // location (the base differs by layout, so we accept either).
   const expectedSuffix = `${VOTE_RECORDS_DATA_CATEGORY}${sep}${VOTE_RECORDS_FILENAME}`;
   const underHomedirRoot = isWithin(getNexusDataDir(), resolved);
-  const underRepoDataDir = resolved.includes(`.nexus-agents${sep}${VOTE_RECORDS_DATA_CATEGORY}${sep}`);
+  const underRepoDataDir = resolved.includes(
+    `.nexus-agents${sep}${VOTE_RECORDS_DATA_CATEGORY}${sep}`
+  );
   if (
     !isAbsolute(resolved) ||
     !resolved.endsWith(expectedSuffix) ||
@@ -279,8 +288,10 @@ export function resolveVoteRecordsPath(): string | undefined {
 }
 
 /** Options for {@link persistVoteRecord}. `sequence`/`previousHash` are assigned by the store. */
-export interface PersistVoteRecordOptions
-  extends Omit<BuildVoteRecordInput, 'previousHash' | 'sequence'> {
+export interface PersistVoteRecordOptions extends Omit<
+  BuildVoteRecordInput,
+  'previousHash' | 'sequence'
+> {
   /**
    * Override the artifact path; takes precedence over {@link VOTE_RECORDS_PATH_ENV}
    * and the {@link nexusDataPath} resolution (see {@link resolveVoteRecordsPath}).
@@ -354,12 +365,25 @@ export function readVoteRecords(filePath: string): {
   readonly records: VoteRecord[];
   readonly invalidLines: number[];
 } {
+  if (!existsSync(filePath)) return { records: [], invalidLines: [] };
+  return parseVoteRecordsText(readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Parse JSONL vote-record text into records + the 1-based line numbers that
+ * failed to parse/validate. The disk-free core of {@link readVoteRecords}, split
+ * out (#3927) so the authority-tier gate (`scripts/check-authority-tier-drift.ts`)
+ * can resolve `ratificationVoteRef` against the committed ledger TEXT in a pure,
+ * unit-testable path without touching the filesystem. Blank lines are skipped.
+ * Order is NOT significant — the set is verified by {@link verifyVoteRecordSet}.
+ */
+export function parseVoteRecordsText(text: string): {
+  readonly records: VoteRecord[];
+  readonly invalidLines: number[];
+} {
   const records: VoteRecord[] = [];
   const invalidLines: number[] = [];
-  if (!existsSync(filePath)) return { records, invalidLines };
-  const lines = readFileSync(filePath, 'utf-8')
-    .split('\n')
-    .filter((l) => l.trim() !== '');
+  const lines = text.split('\n').filter((l) => l.trim() !== '');
   for (const [i, line] of lines.entries()) {
     try {
       const parsed = VoteRecordSchema.safeParse(JSON.parse(line));

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
 
 import type { VoteRecord } from './vote-record.js';
 import { computeVoteRecordHash, verifyVoteRecordSet } from './vote-record.js';
@@ -185,5 +186,79 @@ describe('verifyVoteRecordSet', () => {
       expect(result.recordCount).toBe(3);
       expect(result.forks).toEqual([1]);
     }
+  });
+});
+
+describe('ratifies subject-binding field (#3927 item 1, schema 1.2)', () => {
+  it('verifies a 1.2 record that carries ratifies', () => {
+    const record = makeRecord('vote-1', 0, { version: '1.2', ratifies: 'loop:dev-pipeline' });
+    expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('folds ratifies into the self-hash — editing it is a hash_mismatch', () => {
+    const record = makeRecord('vote-1', 0, { version: '1.2', ratifies: 'loop:dev-pipeline' });
+    // An attacker repoints the ratified subject without recomputing the hash.
+    const tampered: VoteRecord = { ...record, ratifies: 'loop:some-other-loop' };
+    const result = verifyVoteRecordSet([tampered]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('detects ADDING a ratifies field to a record that had none (forgery)', () => {
+    const record = makeRecord('vote-1', 0); // no ratifies — hash computed without it
+    const forged: VoteRecord = { ...record, ratifies: 'loop:promote-me' };
+    const result = verifyVoteRecordSet([forged]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('detects REMOVING a ratifies field from a record that had one (forgery)', () => {
+    const record = makeRecord('vote-1', 0, { version: '1.2', ratifies: 'loop:promote-me' });
+    const forged: VoteRecord = { ...record };
+    delete forged.ratifies; // strip the field the hash was computed over
+    const result = verifyVoteRecordSet([forged]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('back-compat: a record WITHOUT ratifies hashes byte-identically to the pre-1.2 projection', () => {
+    // The hash of a no-ratifies payload must not change when the `ratifies`
+    // capability is added — historical 1.1 records must re-verify unchanged. We
+    // prove the canonical projection omits the key entirely (not `ratifies:null`).
+    const payload: Omit<VoteRecord, 'hash'> = {
+      version: '1.1',
+      id: 'vote-legacy',
+      sequence: 0,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      proposalHash: 'b'.repeat(64),
+      proposal: 'legacy proposal',
+      strategy: 'higher_order',
+      decision: 'approved',
+      approvalPercentage: 85.7,
+      voteCounts: { approve: 6, reject: 1, abstain: 0, total: 7 },
+      voters: [{ role: 'architect', decision: 'approve', confidence: 0.9 }],
+    };
+    // Recompute the expected hash from the exact pre-1.2 canonical projection
+    // (correlationId folded as null, NO ratifies key).
+    const expectedCanonical = JSON.stringify({
+      version: '1.1',
+      id: 'vote-legacy',
+      sequence: 0,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      proposalHash: 'b'.repeat(64),
+      proposal: 'legacy proposal',
+      strategy: 'higher_order',
+      decision: 'approved',
+      approvalPercentage: 85.7,
+      voteCounts: { approve: 6, reject: 1, abstain: 0, total: 7 },
+      voters: [{ role: 'architect', decision: 'approve', confidence: 0.9 }],
+      correlationId: null,
+    });
+    const expected = createHash('sha256').update(expectedCanonical).digest('hex');
+    expect(computeVoteRecordHash(payload)).toBe(expected);
+    expect(verifyVoteRecordSet([{ ...payload, hash: expected }])).toEqual({
+      ok: true,
+      recordCount: 1,
+    });
   });
 });

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -79,8 +79,14 @@ export type VoteRecordCounts = z.infer<typeof VoteRecordCountsSchema>;
  */
 export const VoteRecordSchema = z
   .object({
-    /** Schema version. '1.1' marks the chain→record-set+sequence model (#3927). */
-    version: z.literal('1.1'),
+    /**
+     * Schema version. '1.1' marked the chain→record-set+sequence model (#3927);
+     * '1.2' adds the optional `ratifies` subject-binding field (#3927 item 1).
+     * Both are accepted — a 1.1 record (no `ratifies`) verifies unchanged because
+     * `ratifies` is folded into the self-hash ONLY when present (see
+     * {@link computeVoteRecordHash}).
+     */
+    version: z.enum(['1.1', '1.2']),
     /** Unique record id (also usable as a `ratificationVoteRef`). */
     id: z.string().min(1),
     /**
@@ -121,6 +127,16 @@ export const VoteRecordSchema = z
     /** Optional correlation/decision id linking to the cost rollup / trace. */
     correlationId: z.string().min(1).optional(),
     /**
+     * The loop/strategy subject this vote RATIFIES (#3927 item 1). Present only on
+     * a ratification vote; set at vote time and bound into the self-hash (so it is
+     * tamper-evident). The authority-tier promotion gate
+     * (`scripts/check-authority-tier-drift.ts`) resolves a transition's
+     * `ratificationVoteRef` to a record and requires `ratifies === transition.subject`
+     * (with `decision === 'approved'` and `strategy === 'higher_order'`). Absent on
+     * an ordinary (non-ratification) vote; a 1.1 record never carries it.
+     */
+    ratifies: z.string().min(1).optional(),
+    /**
      * ADVISORY hash of the tip record at write time (absent for the first).
      * Retained for audit texture but NOT covered by `hash` and NOT verified —
      * the record-set model is position-independent (#3927).
@@ -150,7 +166,7 @@ type VoteRecordPayload = Omit<VoteRecord, 'hash'>;
  * `hash_mismatch`: the hash is independent of key insertion order at every level.
  */
 export function computeVoteRecordHash(payload: VoteRecordPayload): string {
-  const canonical = JSON.stringify({
+  const base = {
     version: payload.version,
     id: payload.id,
     sequence: payload.sequence,
@@ -174,7 +190,16 @@ export function computeVoteRecordHash(payload: VoteRecordPayload): string {
       confidence: v.confidence,
     })),
     correlationId: payload.correlationId ?? null,
-  });
+  };
+  // `ratifies` (#3927) is folded in ONLY when present, appended after the stable
+  // base fields. This keeps the projection BYTE-IDENTICAL to the pre-1.2 form for
+  // any record without it — so every historical 1.1 record (which never carried
+  // `ratifies`) re-hashes unchanged (back-compat). It stays fully tamper-evident:
+  // adding, removing, or editing `ratifies` on a persisted record flips the hash
+  // (an absent field re-hashes one way, a present field the other).
+  const canonical = JSON.stringify(
+    payload.ratifies !== undefined ? { ...base, ratifies: payload.ratifies } : base
+  );
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }
 

--- a/scripts/check-authority-tier-drift.test.ts
+++ b/scripts/check-authority-tier-drift.test.ts
@@ -16,19 +16,22 @@ import {
   analyzeTierDeclarations,
   analyzeLoopTierDeclarations,
   analyzeTierTransitionEvents,
-  buildRatificationResolver,
+  buildVoteRecordRatificationResolver,
   buildEnforceEvidenceMap,
   recoverTransitions,
   checkAuthorityTierDeclarations,
   soakDays,
   ENFORCE_FLOOR,
   type RatificationResolver,
-  type RatificationVote,
 } from './check-authority-tier-drift.js';
 import type { AuthorityTier } from '../packages/nexus-agents/src/orchestration/strategy-manifest.js';
 import type { LoopTierManifest } from '../packages/nexus-agents/src/orchestration/loop-tier-manifest.js';
 import { LOOP_TIER_REGISTRY } from '../packages/nexus-agents/src/orchestration/loop-tier-registry.js';
 import type { TierTransitionPayload } from '../packages/nexus-agents/src/audit/audit-types.js';
+import {
+  computeVoteRecordHash,
+  type VoteRecord,
+} from '../packages/nexus-agents/src/audit/vote-record.js';
 import { AuditLogger } from '../packages/nexus-agents/src/audit/audit-logger.js';
 import { InMemoryAuditStorage } from '../packages/nexus-agents/src/audit/audit-storage.js';
 
@@ -271,20 +274,51 @@ function transition(
   };
 }
 
-/** An approved higher_order ratification vote for `auto-remediation`. */
-function approvedVote(id: string): RatificationVote {
-  return {
+/**
+ * Build a properly self-hashed authentic {@link VoteRecord} (#3927). `ratifies`
+ * defaults to `auto-remediation` (the subject `transition()` promotes). Pass
+ * `ratifies: null` to omit the field (an ordinary, non-ratifying vote).
+ */
+function voteRecord(
+  id: string,
+  opts: {
+    ratifies?: string | null;
+    decision?: VoteRecord['decision'];
+    strategy?: VoteRecord['strategy'];
+    sequence?: number;
+  } = {}
+): VoteRecord {
+  const ratifies = opts.ratifies === null ? undefined : (opts.ratifies ?? 'auto-remediation');
+  const payload: Omit<VoteRecord, 'hash'> = {
+    version: '1.2',
     id,
-    subject: 'auto-remediation',
-    decision: 'approved',
-    strategy: 'higher_order',
-    votedAt: '2026-06-15T00:00:00.000Z',
+    sequence: opts.sequence ?? 0,
+    recordedAt: '2026-06-15T00:00:00.000Z',
+    proposalHash: 'a'.repeat(64),
+    proposal: 'Promote auto-remediation from advisory to enforce',
+    strategy: opts.strategy ?? 'higher_order',
+    decision: opts.decision ?? 'approved',
+    approvalPercentage: 85.7,
+    voteCounts: { approve: 6, reject: 1, abstain: 0, total: 7 },
+    voters: [{ role: 'architect', decision: 'approve', confidence: 0.9 }],
+    ...(ratifies !== undefined ? { ratifies } : {}),
   };
+  return { ...payload, hash: computeVoteRecordHash(payload) };
 }
 
-/** A resolver backed by the given recorded votes (keyed by id). */
-function resolverOf(...votes: RatificationVote[]): RatificationResolver {
-  const byId = new Map(votes.map((v) => [v.id, v]));
+/** An approved higher_order record ratifying `auto-remediation`. */
+function approvedVote(id: string): VoteRecord {
+  return voteRecord(id);
+}
+
+/** Serialize records to committed-ledger JSONL text (one record per line). */
+function jsonl(...records: VoteRecord[]): string {
+  return records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+}
+
+/** A resolver backed by the given authentic records (keyed by id). */
+function resolverOf(...records: VoteRecord[]): RatificationResolver {
+  const byId = new Map(records.map((r) => [r.id, r]));
   return (ref) => byId.get(ref);
 }
 
@@ -313,43 +347,57 @@ describe('analyzeTierTransitionEvents — ratification gate (#3842, hardened #38
     expect(findings[0]?.message).toContain("ratificationVoteRef='x'");
   });
 
-  it('FAILS a promotion whose ref resolves to a REJECTED vote (#3894)', () => {
-    const rejected: RatificationVote = { ...approvedVote('cv_no'), decision: 'rejected' };
+  it('FAILS a promotion whose ref resolves to a REJECTED record (#3894)', () => {
     const findings = analyzeTierTransitionEvents(
       [transition('promotion', 'cv_no')],
-      resolverOf(rejected)
+      resolverOf(voteRecord('cv_no', { decision: 'rejected' }))
     );
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
     expect(findings[0]?.message).toContain("'rejected'");
   });
 
-  it('FAILS a promotion whose ref resolves to a NON-higher_order vote (#3894)', () => {
-    const wrongStrategy: RatificationVote = {
-      ...approvedVote('cv_maj'),
-      strategy: 'simple_majority',
-    };
+  it('FAILS a promotion whose ref resolves to a NON-higher_order record (#3894)', () => {
     const findings = analyzeTierTransitionEvents(
       [transition('promotion', 'cv_maj')],
-      resolverOf(wrongStrategy)
+      resolverOf(voteRecord('cv_maj', { strategy: 'simple_majority' }))
     );
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
     expect(findings[0]?.message).toContain('higher_order');
   });
 
-  it('FAILS a promotion whose ref resolves to a vote for a DIFFERENT subject (#3894)', () => {
-    const otherSubject: RatificationVote = {
-      ...approvedVote('cv_other'),
-      subject: 'some-other-loop',
-    };
+  it('FAILS a promotion whose ref resolves to a record ratifying a DIFFERENT subject (#3894)', () => {
     const findings = analyzeTierTransitionEvents(
       [transition('promotion', 'cv_other')],
-      resolverOf(otherSubject)
+      resolverOf(voteRecord('cv_other', { ratifies: 'some-other-loop' }))
     );
     expect(findings).toHaveLength(1);
     expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
-    expect(findings[0]?.message).toContain('does not match');
+    expect(findings[0]?.message).toContain('not the transition subject');
+  });
+
+  it('FAILS a promotion whose ref resolves to a record with NO ratifies field (#3927)', () => {
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_plain')],
+      resolverOf(voteRecord('cv_plain', { ratifies: null }))
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-not-approved');
+    expect(findings[0]?.message).toContain('(no ratifies field)');
+  });
+
+  it('FAILS a promotion of an AMBIGUOUS subject (conflicting decisions) closed (#3927)', () => {
+    // The subject has both an approved and a rejected record; even with a ref to
+    // the approving one, the conflict must block the promotion.
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_ok')],
+      resolverOf(voteRecord('cv_ok')),
+      new Set(['auto-remediation'])
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-ambiguous');
+    expect(findings[0]?.message).toContain('CONFLICTING');
   });
 
   it('PASSES a promotion whose ref RESOLVES to an approved higher_order vote (#3894)', () => {
@@ -387,30 +435,123 @@ describe('analyzeTierTransitionEvents — ratification gate (#3842, hardened #38
   });
 });
 
-describe('buildRatificationResolver — the committed ledger (#3894)', () => {
-  it('resolves an id present in a valid ledger', () => {
-    const yaml = toYaml({
-      version: 1,
-      votes: [approvedVote('cv_resolved')],
-    });
-    const { resolver, findings } = buildRatificationResolver(yaml);
+describe('buildVoteRecordRatificationResolver — the authentic ledger (#3927 item 1)', () => {
+  it('resolves an id present in a valid, verified ledger', () => {
+    const { resolver, conflictSubjects, findings } = buildVoteRecordRatificationResolver(
+      jsonl(voteRecord('cv_resolved'))
+    );
     expect(findings).toEqual([]);
+    expect(conflictSubjects.size).toBe(0);
     expect(resolver('cv_resolved')?.decision).toBe('approved');
+    expect(resolver('cv_resolved')?.ratifies).toBe('auto-remediation');
     expect(resolver('missing')).toBeUndefined();
   });
 
-  it('resolves NOTHING (fail-closed) for an absent ledger', () => {
-    const { resolver, findings } = buildRatificationResolver(undefined);
+  it('resolves NOTHING (fail-closed) for an absent ledger, no findings', () => {
+    const { resolver, conflictSubjects, findings } = buildVoteRecordRatificationResolver(undefined);
+    expect(findings).toEqual([]);
+    expect(conflictSubjects.size).toBe(0);
+    expect(resolver('anything')).toBeUndefined();
+  });
+
+  it('resolves NOTHING for an empty ledger (no records), no findings', () => {
+    const { resolver, findings } = buildVoteRecordRatificationResolver('');
     expect(findings).toEqual([]);
     expect(resolver('anything')).toBeUndefined();
   });
 
-  it('FAILS ratification-ledger-invalid and resolves nothing on a schema-invalid ledger', () => {
-    const yaml = toYaml({ version: 1, votes: [{ id: 'x' /* missing fields */ }] });
-    const { resolver, findings } = buildRatificationResolver(yaml);
+  it('FAILS vote-records-ledger-invalid and resolves nothing on an UNPARSEABLE line', () => {
+    const { resolver, findings } = buildVoteRecordRatificationResolver(
+      `${JSON.stringify(voteRecord('cv_ok'))}\n{ not json\n`
+    );
     expect(findings).toHaveLength(1);
-    expect(findings[0]?.code).toBe('ratification-ledger-invalid');
-    expect(resolver('x')).toBeUndefined();
+    expect(findings[0]?.code).toBe('vote-records-ledger-invalid');
+    expect(findings[0]?.message).toContain('line(s)');
+    expect(resolver('cv_ok')).toBeUndefined(); // whole ledger fails closed
+  });
+
+  it('FAILS vote-records-ledger-invalid on a TAMPERED record (hash_mismatch)', () => {
+    const good = voteRecord('cv_tampered');
+    // Flip the decision on the persisted line WITHOUT recomputing the hash.
+    const tampered = JSON.stringify({ ...good, decision: 'rejected' });
+    const { resolver, findings } = buildVoteRecordRatificationResolver(`${tampered}\n`);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('vote-records-ledger-invalid');
+    expect(findings[0]?.message).toContain('hash_mismatch');
+    expect(resolver('cv_tampered')).toBeUndefined();
+  });
+
+  it('FAILS vote-records-ledger-invalid on a SEQUENCE GAP (omitted record)', () => {
+    // sequences {0, 2} — record at sequence 1 was deleted.
+    const { findings } = buildVoteRecordRatificationResolver(
+      jsonl(voteRecord('cv_a', { sequence: 0 }), voteRecord('cv_c', { sequence: 2 }))
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('vote-records-ledger-invalid');
+    expect(findings[0]?.message).toContain('sequence_gap');
+  });
+
+  it('FAILS vote-records-ledger-invalid on DUPLICATE record ids (ambiguous ref)', () => {
+    const { resolver, findings } = buildVoteRecordRatificationResolver(
+      jsonl(
+        voteRecord('dup', { sequence: 0 }),
+        voteRecord('dup', { sequence: 1, decision: 'rejected' })
+      )
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('vote-records-ledger-invalid');
+    expect(findings[0]?.message).toContain("'dup'");
+    expect(resolver('dup')).toBeUndefined();
+  });
+
+  it('surfaces a CONFLICTING-decision subject in conflictSubjects (benign fork, ambiguous basis)', () => {
+    // Two records ratify the same subject but disagree on decision — a union-merge
+    // fork. Sequences differ so the SET verifies; the conflict is reported.
+    const { conflictSubjects, findings } = buildVoteRecordRatificationResolver(
+      jsonl(
+        voteRecord('cv_yes', { sequence: 0, decision: 'approved' }),
+        voteRecord('cv_no', { sequence: 1, decision: 'rejected' })
+      )
+    );
+    expect(findings).toEqual([]); // the set is valid; conflict is not a ledger error
+    expect([...conflictSubjects]).toEqual(['auto-remediation']);
+  });
+
+  it('does NOT flag a subject with multiple AGREEING records as conflicting', () => {
+    const { conflictSubjects, findings } = buildVoteRecordRatificationResolver(
+      jsonl(
+        voteRecord('cv_1', { sequence: 0, decision: 'approved' }),
+        voteRecord('cv_2', { sequence: 1, decision: 'approved' })
+      )
+    );
+    expect(findings).toEqual([]);
+    expect(conflictSubjects.size).toBe(0);
+  });
+
+  it('END-TO-END: a conflicting ledger fails the matching promotion closed', () => {
+    const ledger = buildVoteRecordRatificationResolver(
+      jsonl(
+        voteRecord('cv_yes', { sequence: 0, decision: 'approved' }),
+        voteRecord('cv_no', { sequence: 1, decision: 'rejected' })
+      )
+    );
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_yes')],
+      ledger.resolver,
+      ledger.conflictSubjects
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.code).toBe('promotion-ratification-ambiguous');
+  });
+
+  it('END-TO-END: a clean ledger PASSES the matching promotion', () => {
+    const ledger = buildVoteRecordRatificationResolver(jsonl(voteRecord('cv_clean')));
+    const findings = analyzeTierTransitionEvents(
+      [transition('promotion', 'cv_clean')],
+      ledger.resolver,
+      ledger.conflictSubjects
+    );
+    expect(findings).toEqual([]);
   });
 });
 
@@ -475,13 +616,7 @@ describe('recoverTransitions — reads the chained transition log (#3842)', () =
     const { transitions, findings } = recoverTransitions(jsonl);
     expect(findings).toEqual([]);
     expect(transitions).toHaveLength(2);
-    const resolver = resolverOf({
-      id: 'cv_2077',
-      subject: 'clawguard',
-      decision: 'approved',
-      strategy: 'higher_order',
-      votedAt: '2026-06-15T00:00:00.000Z',
-    });
+    const resolver = resolverOf(voteRecord('cv_2077', { ratifies: 'clawguard' }));
     expect(analyzeTierTransitionEvents(transitions, resolver)).toEqual([]);
   });
 

--- a/scripts/check-authority-tier-drift.ts
+++ b/scripts/check-authority-tier-drift.ts
@@ -35,23 +35,29 @@
  * envelope nor a floor-meeting evidence record
  * (`loop-enforce-without-envelope-or-evidence`).
  *
- * Tier-transition ratification gate (#3842, hardened by #3894): in addition to the
- * declaration + evidence-floor checks, this gate also reads the hash-chained
- * tier-transition AUDIT EVENTS (Epic D / ADR-0017 §"Transition Rules") and FAILS a
- * PROMOTION transition event whose `ratificationVoteRef` does not RESOLVE to a
- * recorded, approved `higher_order` ratification vote. #3842 only checked the ref
- * was non-empty (cosmetic — a bogus `ratificationVoteRef:'x'` passed); #3894 makes
- * the link genuine by resolving the ref against a committed ratification ledger
- * (`governance/ratification-votes.yaml`, see {@link RatificationVoteSchema}) and
- * failing `promotion-ratification-unresolved` / `promotion-ratification-not-approved`.
- * Promotions must be ratification-linked (ADR-0017); demotions are automatic and
- * need no vote. The transition log lives at
- * `governance/authority-tier-transitions.jsonl` (optional — empty when no
- * transition has occurred); each line is a persisted `AuditEvent`. The pure
- * analysis ({@link analyzeTierTransitionEvents}) is unit-tested in isolation.
+ * Tier-transition ratification gate (#3842, hardened #3894, re-anchored #3927):
+ * in addition to the declaration + evidence-floor checks, this gate also reads the
+ * hash-chained tier-transition AUDIT EVENTS (Epic D / ADR-0017 §"Transition Rules")
+ * and FAILS a PROMOTION transition event whose `ratificationVoteRef` does not
+ * RESOLVE to a recorded, approved `higher_order` vote. #3842 only checked the ref
+ * was non-empty (cosmetic); #3894 resolved it against a committed ledger; #3927
+ * item 1 re-anchors that resolution to the AUTHENTIC, tamper-evident
+ * `governance/vote-records.jsonl` (self-hashed at vote time, verified as a set by
+ * {@link verifyVoteRecordSet}) — REPLACING the former hand-committable
+ * `governance/ratification-votes.yaml`. The gate now fails closed on a tampered or
+ * malformed ledger (`vote-records-ledger-invalid`), on an ambiguous
+ * conflicting-decision subject (`promotion-ratification-ambiguous`), and on the
+ * pre-existing `promotion-ratification-unresolved` / `-not-approved` reasons (the
+ * subject is matched via the record's `ratifies` field). It remains tamper-EVIDENT,
+ * not tamper-PROOF — cryptographic signing is tracked as #3927 item 4. Promotions
+ * must be ratification-linked (ADR-0017); demotions are automatic and need no vote.
+ * The transition log lives at `governance/authority-tier-transitions.jsonl`
+ * (optional — empty when no transition has occurred); each line is a persisted
+ * `AuditEvent`. The pure analysis ({@link analyzeTierTransitionEvents}) is
+ * unit-tested in isolation.
  *
  * @module scripts/check-authority-tier-drift
- * (Source: ADR-0017, Issue #3839, #3841, #3842, #3894)
+ * (Source: ADR-0017, Issue #3839, #3841, #3842, #3894, #3927)
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -75,15 +81,28 @@ import {
 } from '../packages/nexus-agents/src/audit/audit-logger.js';
 import {
   AuditEventSchema,
-  RatificationVoteLedgerSchema,
   type AuditEvent,
-  type RatificationVote,
   type TierTransitionPayload,
 } from '../packages/nexus-agents/src/audit/audit-types.js';
+import {
+  buildVoteRecordRatificationResolver,
+  ratificationFindingFor,
+  type RatificationResolver,
+} from './vote-record-ratification.js';
 
 const EVIDENCE_LEDGER = join(ROOT, 'governance/authority-tier-evidence.yaml');
 const TRANSITION_LOG = join(ROOT, 'governance/authority-tier-transitions.jsonl');
-const RATIFICATION_LEDGER = join(ROOT, 'governance/ratification-votes.yaml');
+/**
+ * The AUTHENTIC resolution source (#3927 item 1). The promotion gate resolves a
+ * transition's `ratificationVoteRef` against this committed, tamper-evident
+ * vote-record set — NOT the former hand-committable `governance/ratification-votes.yaml`,
+ * whose YAML resolution path was removed here (that file is deprecated; its
+ * removal is tracked separately). A record is produced at vote time
+ * (`audit/vote-record-store.ts`) and committed alongside the transition; the
+ * gate fails closed on any tamper/omission/ambiguity (see
+ * {@link buildVoteRecordRatificationResolver}).
+ */
+const VOTE_RECORDS_LEDGER = join(ROOT, 'governance/vote-records.jsonl');
 const LOOP_TIER_REGISTRY_FILE = join(ROOT, 'governance/loop-tiers.yaml');
 
 /**
@@ -112,75 +131,18 @@ export interface TierDriftFinding {
     | 'promotion-without-ratification'
     | 'promotion-ratification-unresolved'
     | 'promotion-ratification-not-approved'
-    | 'ratification-ledger-invalid'
+    | 'promotion-ratification-ambiguous'
+    | 'vote-records-ledger-invalid'
     | 'transition-log-invalid'
     | 'transition-log-chain-broken';
   readonly message: string;
 }
 
-// ============================================================================
-// Ratification-vote ledger (#3894) — the resolution source of truth
-// ============================================================================
-
-/**
- * A resolver: ref → recorded ratification vote (or undefined when unresolved).
- *
- * The committed ratification-vote ledger (`governance/ratification-votes.yaml`,
- * schema {@link RatificationVoteLedgerSchema} in `src/audit/audit-types.ts`) is the
- * resolution source. #3894 item 1: the promotion gate previously failed a
- * `promotion` only when its `ratificationVoteRef` was *empty* — a bogus
- * `ratificationVoteRef:'x'` passed, so the "ratification-LINKED" guarantee was
- * only as strong as a non-empty string. Resolving the ref against this ledger
- * makes the link genuine.
- *
- * RESOLUTION SOURCE & RESIDUAL GAP. Live `consensus_vote` results are persisted
- * only to per-developer home-dir stores (`~/.nexus-agents/voting/correlations.jsonl`,
- * `~/.nexus-agents/learning/outcomes.jsonl`) that a CI gate — running with no live
- * server and no developer home dir — cannot read. There is no other committed,
- * queryable source of truth for "did ratification vote X happen and pass". So the
- * honest mechanism is this committed ledger: a ratification vote must be recorded
- * HERE (a higher_order consensus_vote whose decision is `approved`) for a
- * promotion's ref to resolve. The gate verifies STRUCTURAL PRESENCE of an
- * approved, higher_order vote in a committed record — it does not (and cannot
- * from CI) re-execute the vote. Tampering with the ledger is itself a reviewable
- * governance change.
- */
-export type RatificationResolver = (ref: string) => RatificationVote | undefined;
-
-/** Re-exported for tests/callers that build resolvers. */
-export type { RatificationVote };
-
-/**
- * Build a {@link RatificationResolver} from the ledger YAML text (or undefined
- * when the file is absent). Returns the resolver plus a single
- * `ratification-ledger-invalid` finding when the ledger fails schema validation —
- * in which case the resolver resolves NOTHING (fail-closed: every promotion ref
- * is then unresolved and FAILS, rather than silently passing).
- */
-export function buildRatificationResolver(ledgerYaml: string | undefined): {
-  readonly resolver: RatificationResolver;
-  readonly findings: TierDriftFinding[];
-} {
-  if (ledgerYaml === undefined) {
-    return { resolver: () => undefined, findings: [] };
-  }
-  const parsed = RatificationVoteLedgerSchema.safeParse(parseYaml(ledgerYaml));
-  if (!parsed.success) {
-    return {
-      resolver: () => undefined,
-      findings: [
-        {
-          code: 'ratification-ledger-invalid',
-          message: `governance/ratification-votes.yaml failed schema validation: ${parsed.error.issues
-            .map((i) => i.message)
-            .join('; ')}`,
-        },
-      ],
-    };
-  }
-  const byId = new Map(parsed.data.votes.map((v) => [v.id, v]));
-  return { resolver: (ref) => byId.get(ref), findings: [] };
-}
+// The authentic vote-record resolver + per-transition verdict live in
+// ./vote-record-ratification.ts (imported above); re-exported here so existing
+// callers/tests keep importing them from the gate module.
+export { buildVoteRecordRatificationResolver };
+export type { RatificationResolver };
 
 /**
  * Parse the day-count of a simple ISO-8601 duration for the soak floor compare.
@@ -355,75 +317,45 @@ export function analyzeLoopTierDeclarations(inputs: LoopDriftInputs): TierDriftF
 }
 
 /**
- * The ratification gate (#3842, hardened by #3894). Pure analysis (no disk/process
- * I/O) over the recovered tier-transition payloads so it is unit-testable with
- * fixtures both ways. ADR-0017 §"Promotions are ratification-linked": a `promotion`
- * transition is valid only if it carries a linked ratification vote that genuinely
- * happened and PASSED; a `demotion` is automatic and needs none.
+ * The ratification gate (#3842, hardened #3894, re-anchored to authentic vote
+ * records #3927 item 1). Pure analysis (no disk/process I/O) over the recovered
+ * tier-transition payloads so it is unit-testable with fixtures. ADR-0017
+ * §"Promotions are ratification-linked": a `promotion` transition is valid only if
+ * it carries a linked ratification vote that genuinely happened and PASSED; a
+ * `demotion` is automatic and needs none.
  *
- * #3894 hardens the link from non-emptiness to RESOLVABILITY. A promotion FAILS when:
- *   - `promotion-without-ratification` — `ratificationVoteRef` is absent/empty
- *     (the #3842 cosmetic check; kept as the first gate).
- *   - `promotion-ratification-unresolved` — the ref does NOT resolve to any
- *     recorded vote in the committed ratification ledger (a bogus
- *     `ratificationVoteRef:'x'` no longer passes).
- *   - `promotion-ratification-not-approved` — the ref resolves, but the recorded
- *     vote's decision is not `approved`, it was not a `higher_order` vote (a
- *     promotion is governance-of-the-governor), or its `subject` does not match
- *     the transition subject.
+ * A promotion FAILS when (each fail-closed):
+ *   - `promotion-ratification-ambiguous` — the subject has CONFLICTING records in
+ *     the ledger (e.g. an `approved` and a `rejected` record both ratify it). No
+ *     ref may cherry-pick the approving fork; the conflict must be resolved in the
+ *     ledger first. Checked FIRST, before ref resolution (#3927, Contrarian).
+ *   - `promotion-without-ratification` — `ratificationVoteRef` is absent/empty.
+ *   - `promotion-ratification-unresolved` — the ref does NOT resolve to any record
+ *     in the committed `governance/vote-records.jsonl` (a bogus
+ *     `ratificationVoteRef:'x'` does not pass).
+ *   - `promotion-ratification-not-approved` — the ref resolves, but the record's
+ *     `decision` is not `approved`, its `strategy` is not `higher_order` (a
+ *     promotion is governance-of-the-governor), or its `ratifies` subject-binding
+ *     does not match the transition subject.
  *
  * @param transitions - tier-transition payloads recovered from the chained audit log
- * @param resolve - resolves a `ratificationVoteRef` to its recorded vote (see
- *   {@link buildRatificationResolver}); a resolver that resolves nothing makes
- *   every non-empty ref `promotion-ratification-unresolved` (fail-closed).
+ * @param resolve - resolves a `ratificationVoteRef` to its authentic record (see
+ *   {@link buildVoteRecordRatificationResolver}); a resolver that resolves nothing
+ *   makes every non-empty ref `promotion-ratification-unresolved` (fail-closed).
+ * @param conflictSubjects - subjects with conflicting-decision records; a promotion
+ *   of any such subject fails `promotion-ratification-ambiguous`.
  * @returns one finding per offending promotion
  */
 export function analyzeTierTransitionEvents(
   transitions: readonly TierTransitionPayload[],
-  resolve: RatificationResolver
+  resolve: RatificationResolver,
+  conflictSubjects: ReadonlySet<string> = new Set<string>()
 ): TierDriftFinding[] {
   const findings: TierDriftFinding[] = [];
   for (const t of transitions) {
     if (t.kind !== 'promotion') continue; // demotions are automatic — no vote required
-    const ref = t.ratificationVoteRef;
-    const where = `'${t.subject}' (${t.fromTier} → ${t.toTier}, evidenceRef='${t.evidenceRef}')`;
-
-    if (ref === undefined || ref.trim() === '') {
-      findings.push({
-        code: 'promotion-without-ratification',
-        message: `tier-transition promotion of ${where} has NO linked ratificationVoteRef. Promotions MUST be ratification-linked (ADR-0017 §"Promotions are ratification-linked") — record the consensus_vote ref on the transition audit event.`,
-      });
-      continue;
-    }
-
-    const vote = resolve(ref.trim());
-    if (vote === undefined) {
-      findings.push({
-        code: 'promotion-ratification-unresolved',
-        message: `tier-transition promotion of ${where} carries ratificationVoteRef='${ref}' that does NOT resolve to any recorded vote in governance/ratification-votes.yaml. A non-empty ref is not enough (#3894) — the vote must be a recorded, approved higher_order consensus_vote.`,
-      });
-      continue;
-    }
-
-    const reasons: string[] = [];
-    if (vote.decision !== 'approved')
-      reasons.push(`decision is '${vote.decision}', not 'approved'`);
-    if (vote.strategy !== 'higher_order') {
-      reasons.push(
-        `strategy is '${vote.strategy}', not 'higher_order' (a promotion is governance-of-the-governor)`
-      );
-    }
-    if (vote.subject !== t.subject) {
-      reasons.push(
-        `vote subject '${vote.subject}' does not match the transition subject '${t.subject}'`
-      );
-    }
-    if (reasons.length > 0) {
-      findings.push({
-        code: 'promotion-ratification-not-approved',
-        message: `tier-transition promotion of ${where} resolves ratificationVoteRef='${ref}' but that vote does not ratify the promotion: ${reasons.join('; ')}.`,
-      });
-    }
+    const finding = ratificationFindingFor(t, resolve, conflictSubjects);
+    if (finding !== null) findings.push(finding);
   }
   return findings;
 }
@@ -537,6 +469,32 @@ function enforceFloorShortfalls(e: PromotionEvidence): string[] {
  * the optional evidence ledger from disk, runs the analysis, and prints
  * structured errors. Returns true when every declaration is honest. Fails closed.
  */
+/**
+ * #3842/#3894/#3927 ratification gate: read the hash-chained tier-transition log
+ * (if any) and fail any PROMOTION event whose ratificationVoteRef does not RESOLVE
+ * to an approved higher_order record in the AUTHENTIC, tamper-evident committed
+ * ledger `governance/vote-records.jsonl` (#3927 item 1 — replaces the former
+ * hand-committable `ratification-votes.yaml`). Fails closed on a tampered/malformed
+ * ledger and on ambiguous (conflicting-decision) subjects. Returns no findings when
+ * the transition log is absent (the no-promotions-yet happy path).
+ */
+function ratificationGateFindings(): TierDriftFinding[] {
+  if (!existsSync(TRANSITION_LOG)) return [];
+  const voteRecordsJsonl = existsSync(VOTE_RECORDS_LEDGER)
+    ? readFileSync(VOTE_RECORDS_LEDGER, 'utf-8')
+    : undefined;
+  const { resolver, conflictSubjects, findings } =
+    buildVoteRecordRatificationResolver(voteRecordsJsonl);
+  const { transitions, findings: logFindings } = recoverTransitions(
+    readFileSync(TRANSITION_LOG, 'utf-8')
+  );
+  return [
+    ...findings,
+    ...logFindings,
+    ...analyzeTierTransitionEvents(transitions, resolver, conflictSubjects),
+  ];
+}
+
 export function checkAuthorityTierDeclarations(): boolean {
   const declaredTiers = new Map<string, AuthorityTier | undefined>(
     STRATEGY_MANIFEST_REGISTRY.manifests.map((m) => [m.id, m.authorityTier])
@@ -561,23 +519,7 @@ export function checkAuthorityTierDeclarations(): boolean {
     })
   );
 
-  // #3842/#3894 ratification gate: read the hash-chained tier-transition log (if
-  // any) and fail any PROMOTION event whose ratificationVoteRef does not RESOLVE
-  // to an approved higher_order vote in the committed ratification ledger.
-  if (existsSync(TRANSITION_LOG)) {
-    const ratificationYaml = existsSync(RATIFICATION_LEDGER)
-      ? readFileSync(RATIFICATION_LEDGER, 'utf-8')
-      : undefined;
-    const { resolver, findings: ledgerFindings } = buildRatificationResolver(ratificationYaml);
-    const { transitions, findings: logFindings } = recoverTransitions(
-      readFileSync(TRANSITION_LOG, 'utf-8')
-    );
-    findings.push(
-      ...ledgerFindings,
-      ...logFindings,
-      ...analyzeTierTransitionEvents(transitions, resolver)
-    );
-  }
+  findings.push(...ratificationGateFindings());
 
   if (findings.length === 0) return true;
 
@@ -589,8 +531,9 @@ export function checkAuthorityTierDeclarations(): boolean {
   console.error('  back any `enforce` with a floor-meeting record in');
   console.error('  governance/authority-tier-evidence.yaml, and link every promotion transition');
   console.error(
-    '  to an approved higher_order vote recorded in governance/ratification-votes.yaml.'
+    '  to an approved higher_order record (matching ratifies==subject) in the authentic'
   );
+  console.error('  governance/vote-records.jsonl ledger.');
   console.error('  Re-run: pnpm authority-tier:check');
   return false;
 }

--- a/scripts/vote-record-ratification.ts
+++ b/scripts/vote-record-ratification.ts
@@ -1,0 +1,198 @@
+/**
+ * Authentic vote-record ratification resolution (#3927 item 1).
+ *
+ * Extracted from `check-authority-tier-drift.ts` so the gate file stays within
+ * its size/complexity budget and the "resolve a ratificationVoteRef against the
+ * authentic ledger" concern is testable in isolation.
+ *
+ * RESOLUTION SOURCE. The committed, tamper-evident vote-record set
+ * (`governance/vote-records.jsonl`) is the resolution source — REPLACING the
+ * former hand-committable `governance/ratification-votes.yaml`. Each record is
+ * self-hashed at vote time (`audit/vote-record-store.ts`); the whole set is
+ * verified with {@link verifyVoteRecordSet} before any ref resolves, so a
+ * tampered, forged, or omitted record fails the gate rather than passing.
+ *
+ * RESIDUAL TRUST (tamper-EVIDENT, not tamper-PROOF — #3927 item 4 deferred). The
+ * self-hash detects POST-HOC edits, but a record is authored in the SAME PR that
+ * performs the promotion, so nothing here cryptographically proves the recorded
+ * decision reflects a real agent panel rather than one the author typed. The
+ * remaining trust anchor is CODEOWNERS review + branch protection on
+ * `governance/`. Binding each record to a signing key (CI/OIDC, cosign/gitsign,
+ * in-toto/SLSA) is tracked as #3927 item 4.
+ *
+ * @module scripts/vote-record-ratification
+ * (Source: ADR-0017, Issue #3897, #3926, #3927)
+ */
+
+import { parseVoteRecordsText } from '../packages/nexus-agents/src/audit/vote-record-store.js';
+import {
+  verifyVoteRecordSet,
+  type VoteRecord,
+} from '../packages/nexus-agents/src/audit/vote-record.js';
+import type { TierTransitionPayload } from '../packages/nexus-agents/src/audit/audit-types.js';
+
+import type { TierDriftFinding } from './check-authority-tier-drift.js';
+
+/**
+ * A resolver: ref → the authentic {@link VoteRecord} it names (or undefined when
+ * the ref resolves to nothing). The gate reads `decision`, `strategy`, and the
+ * subject-binding `ratifies` field off the resolved record.
+ */
+export type RatificationResolver = (ref: string) => VoteRecord | undefined;
+
+/** The product of {@link buildVoteRecordRatificationResolver}. */
+export interface VoteRecordResolution {
+  readonly resolver: RatificationResolver;
+  /** Subjects with conflicting-decision records (an ambiguous promotion basis). */
+  readonly conflictSubjects: ReadonlySet<string>;
+  /** Fail-closed findings (a malformed/tampered/duplicate ledger). */
+  readonly findings: TierDriftFinding[];
+}
+
+/** A fail-closed resolution: resolve nothing, with one ledger-invalid finding. */
+function ledgerInvalid(message: string): VoteRecordResolution {
+  return {
+    resolver: () => undefined,
+    conflictSubjects: new Set<string>(),
+    findings: [{ code: 'vote-records-ledger-invalid', message }],
+  };
+}
+
+/**
+ * Build a {@link RatificationResolver} from the committed vote-record JSONL text
+ * (or undefined when the file is absent). Fail-closed at every step: a parse
+ * error, a failed {@link verifyVoteRecordSet} (hash_mismatch / missing_hash /
+ * sequence_gap), or a duplicate record id all yield a `vote-records-ledger-invalid`
+ * finding AND a resolver that resolves NOTHING — so every promotion ref then fails
+ * unresolved rather than silently passing.
+ *
+ * AMBIGUITY (#3927, Contrarian condition). A union-merge of concurrent branches
+ * can legitimately leave MORE THAN ONE record ratifying the same subject. If two
+ * such records disagree on `decision`, a promoter must not be able to cherry-pick
+ * the approving one by ref. Such subjects are returned in `conflictSubjects`; the
+ * gate fails any promotion of a conflicted subject closed.
+ */
+export function buildVoteRecordRatificationResolver(
+  jsonlText: string | undefined
+): VoteRecordResolution {
+  if (jsonlText === undefined) {
+    return { resolver: () => undefined, conflictSubjects: new Set<string>(), findings: [] };
+  }
+
+  const { records, invalidLines } = parseVoteRecordsText(jsonlText);
+  if (invalidLines.length > 0) {
+    return ledgerInvalid(
+      `governance/vote-records.jsonl has ${String(invalidLines.length)} unparseable/invalid line(s) at ${invalidLines.join(', ')}. A malformed ledger fails closed — every promotion is rejected until it is repaired.`
+    );
+  }
+
+  const verification = verifyVoteRecordSet(records);
+  if (!verification.ok) {
+    return ledgerInvalid(
+      `governance/vote-records.jsonl failed tamper-evidence verification (${verification.reason}) at record '${verification.recordId}': ${verification.detail}. The ledger fails closed until repaired.`
+    );
+  }
+
+  // Duplicate ids make ref-resolution ambiguous — fail closed (a forged record
+  // could shadow a legitimate one under the same ref).
+  const byId = new Map<string, VoteRecord>();
+  const duplicateIds = new Set<string>();
+  for (const record of records) {
+    if (byId.has(record.id)) duplicateIds.add(record.id);
+    byId.set(record.id, record);
+  }
+  if (duplicateIds.size > 0) {
+    return ledgerInvalid(
+      `governance/vote-records.jsonl has duplicate record id(s) ${[...duplicateIds].map((id) => `'${id}'`).join(', ')}, which makes ratificationVoteRef resolution ambiguous. The ledger fails closed until ids are unique.`
+    );
+  }
+
+  return {
+    resolver: (ref) => byId.get(ref),
+    conflictSubjects: conflictingRatifiedSubjects(records),
+    findings: [],
+  };
+}
+
+/**
+ * The set of `ratifies` subjects carried by records that DISAGREE on `decision`
+ * (e.g. an `approved` and a `rejected` record both ratifying the same subject — a
+ * benign union-merge fork at the set level, but an ambiguous promotion basis). A
+ * subject with multiple records that AGREE on decision is not a conflict (the ref
+ * disambiguates which record backs the transition). Records without `ratifies`
+ * are ordinary votes and ignored here.
+ */
+function conflictingRatifiedSubjects(records: readonly VoteRecord[]): Set<string> {
+  const decisionsBySubject = new Map<string, Set<string>>();
+  for (const record of records) {
+    if (record.ratifies === undefined) continue;
+    const decisions = decisionsBySubject.get(record.ratifies) ?? new Set<string>();
+    decisions.add(record.decision);
+    decisionsBySubject.set(record.ratifies, decisions);
+  }
+  const conflicts = new Set<string>();
+  for (const [subject, decisions] of decisionsBySubject) {
+    if (decisions.size > 1) conflicts.add(subject);
+  }
+  return conflicts;
+}
+
+/**
+ * The ratification verdict for a SINGLE promotion transition (or null when it
+ * ratifies cleanly). Fail-closed precedence: ambiguous subject → missing ref →
+ * unresolved ref → not-approved (wrong decision/strategy/subject). Demotions are
+ * the caller's concern (they need no vote); this is only called for promotions.
+ */
+export function ratificationFindingFor(
+  t: TierTransitionPayload,
+  resolve: RatificationResolver,
+  conflictSubjects: ReadonlySet<string>
+): TierDriftFinding | null {
+  const where = `'${t.subject}' (${t.fromTier} → ${t.toTier}, evidenceRef='${t.evidenceRef}')`;
+
+  // Fail closed on an ambiguous ledger state BEFORE looking at the ref: if the
+  // subject carries conflicting decisions, no ref may select the approving fork.
+  if (conflictSubjects.has(t.subject)) {
+    return {
+      code: 'promotion-ratification-ambiguous',
+      message: `tier-transition promotion of ${where} cannot be ratified: governance/vote-records.jsonl has records with CONFLICTING decisions for subject '${t.subject}'. A promoter must not cherry-pick the approving fork — resolve the conflicting ratification records before promoting.`,
+    };
+  }
+
+  const ref = t.ratificationVoteRef;
+  if (ref === undefined || ref.trim() === '') {
+    return {
+      code: 'promotion-without-ratification',
+      message: `tier-transition promotion of ${where} has NO linked ratificationVoteRef. Promotions MUST be ratification-linked (ADR-0017 §"Promotions are ratification-linked") — record the consensus_vote ref on the transition audit event.`,
+    };
+  }
+
+  const record = resolve(ref.trim());
+  if (record === undefined) {
+    return {
+      code: 'promotion-ratification-unresolved',
+      message: `tier-transition promotion of ${where} carries ratificationVoteRef='${ref}' that does NOT resolve to any authentic record in governance/vote-records.jsonl. A non-empty ref is not enough — the vote must be a recorded, approved higher_order consensus_vote whose 'ratifies' matches this subject.`,
+    };
+  }
+
+  const reasons: string[] = [];
+  if (record.decision !== 'approved')
+    reasons.push(`decision is '${record.decision}', not 'approved'`);
+  if (record.strategy !== 'higher_order') {
+    reasons.push(
+      `strategy is '${record.strategy}', not 'higher_order' (a promotion is governance-of-the-governor)`
+    );
+  }
+  if (record.ratifies !== t.subject) {
+    reasons.push(
+      `record ratifies '${record.ratifies ?? '(no ratifies field)'}', not the transition subject '${t.subject}'`
+    );
+  }
+  if (reasons.length > 0) {
+    return {
+      code: 'promotion-ratification-not-approved',
+      message: `tier-transition promotion of ${where} resolves ratificationVoteRef='${ref}' but that record does not ratify the promotion: ${reasons.join('; ')}.`,
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## What

The authority-tier **promotion gate** (`scripts/check-authority-tier-drift.ts`) now resolves a tier-transition's `ratificationVoteRef` against the **authentic, tamper-evident** `governance/vote-records.jsonl` (verified as a set by `verifyVoteRecordSet`) instead of the hand-committable `governance/ratification-votes.yaml` — the forgeable trust anchor #3897's panel flagged. Closes **#3927 item 1**.

The precondition (#3927 item 2 — concurrent-branch chain forks) was already met by the set-model revision (#3926): `verifyVoteRecordSet` is order/position-independent, tolerates duplicate sequences as benign forks, and `.gitattributes` has `vote-records.jsonl merge=union`.

## How

- **Schema 1.1 → 1.2**: new optional `ratifies?` field on `VoteRecord`, folded into the self-hash **only when present** — so historical 1.1 records re-verify **byte-identically** (back-compat proven by test). Threaded through `buildVoteRecord`/`persistVoteRecord`.
- **Gate**: resolves the ref to a record requiring `decision==='approved'` AND `strategy==='higher_order'` AND `ratifies===transition.subject`. **Fails closed** on:
  - tampered/malformed ledger (`vote-records-ledger-invalid`)
  - sequence gap / omission
  - duplicate record ids
  - **ambiguous subjects** — records disagreeing on decision for one subject; no ref may cherry-pick the approving fork (`promotion-ratification-ambiguous`)
- Resolver + per-transition verdict extracted to `scripts/vote-record-ratification.ts` (keeps the gate within size/complexity budget; isolates the concern).
- YAML resolution **removed**; the file is **deprecated in place** (full removal tracked separately).
- Docs: `loop-promotion-criteria.md` updated with the new resolution source, authoring path, and residual-trust note.

## Safety / scope

- **No-op for current behaviour**: both committed ledgers are empty (no promotions yet), so the live gate stays green (verified: `authority-tier:check` exits 0, `governance:check` passes).
- Remains **tamper-EVIDENT, not tamper-PROOF** — records are authored in the promoting PR, so trust still rests on CODEOWNERS + branch protection. Cryptographic signing is **#3927 item 4**.
- The `consensus_vote` `ratifies` authoring param (the last-mile so a live vote can set `ratifies`) is **#4004**.
- Persist-failure alarm is **#3927 item 3**. Both explicitly out of scope.

## Process

- Design **ratified 7/7 `higher_order`** consensus vote (security → supermajority); the Contrarian's two binding conditions (fail-closed-on-ambiguity, concrete failure messages + test matrix) are implemented.
- **Adversarially verified fail-closed**: every probed fail-open vector (ambiguity cherry-pick, subject-binding, tamper add/remove/edit, empty/absent ledger, verify/dup/sequence-gap, findings→exit-1) confirmed to fail closed.

## Tests

- `vote-record.test.ts`: +5 `ratifies` cases incl. byte-identical back-compat (18 total).
- `check-authority-tier-drift.test.ts`: full fail-closed matrix + ambiguity + end-to-end (48 total).
- Full suites green: 397 scripts, 246 audit; `governance:check` passes; lint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)