### PR TITLE
feat(governance): add reuse-first ladder to scope_steward voter (#4007)

### DIFF
--- a/.changeset/scope-steward-reuse-ladder.md
+++ b/.changeset/scope-steward-reuse-ladder.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+Add an explicit reuse-first ladder to the scope_steward voter (#4007, ponytail-inspired)
+
+The `scope_steward` voter now gates the _implementation altitude_ of a justified build with an ordered ladder — YAGNI → stdlib → native/substrate primitive → installed dependency → one line → minimum that works — and flags reaching for a higher rung when an earlier one holds as `OVER_ENGINEERING`. The ladder hard-fences the safety concerns that are never cut (trust-boundary validation, error handling, security, accessibility). Mirrored as an author pre-write self-check in `.rules/development-disciplines.md`. Prompt-only change; no new tool/command surface.

--- a/.rules/development-disciplines.md
+++ b/.rules/development-disciplines.md
@@ -27,6 +27,8 @@ Do not build for hypothetical future requirements. Implement only what is needed
 
 **How to apply:** if a parameter, method, or class has zero current callers, don't add it. If a feature flag has only one branch ever exercised, collapse it. If "we might want this" surfaces during review, file an issue rather than adding the code.
 
+**Reuse ladder (apply BEFORE writing, not just at review):** stop at the first rung that holds — (1) does this need to exist at all? → skip it; (2) standard library / language built-in? → use it; (3) native platform feature or an existing nexus-agents substrate primitive (canonical-path module, existing voter/pipeline/store)? → use it; (4) already-installed dependency? → use it; (5) one line? → one line; (6) only then, the minimum that works. Lazy, not negligent: trust-boundary validation, error handling, security, and accessibility are **never** the thing cut. This is the same ladder the `scope_steward` voter enforces at vote time (`cli/voter-prompts.ts`).
+
 ## DRY — Don't Repeat Yourself
 
 Every piece of knowledge must have a single, unambiguous, authoritative representation. When you see the same logic in two places, extract it. **But do not DRY prematurely — two instances is a coincidence, three is a pattern worth extracting.**

--- a/packages/nexus-agents/src/cli/voter-prompts.test.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.test.ts
@@ -171,12 +171,19 @@ describe('voter-prompts', () => {
         expect(prompt).toContain('USB flasher');
       });
 
-      it('includes all 5 mandatory checks', () => {
+      it('includes all 6 mandatory checks', () => {
         expect(prompt).toContain('Existing-tool check');
         expect(prompt).toContain('Build-vs-buy math');
         expect(prompt).toContain('Mission alignment');
         expect(prompt).toContain('Kill-the-feature option');
         expect(prompt).toContain('Sprawl audit');
+        expect(prompt).toContain('Reuse ladder');
+      });
+
+      it('gates implementation altitude without cutting safety (the reuse ladder)', () => {
+        expect(prompt).toContain('first rung that holds');
+        // The hard caveat: laziness never cuts validation/security/etc.
+        expect(prompt).toContain('NEVER the thing cut');
       });
 
       it('biases default toward not shipping', () => {

--- a/packages/nexus-agents/src/cli/voter-prompts.ts
+++ b/packages/nexus-agents/src/cli/voter-prompts.ts
@@ -181,6 +181,28 @@ ${prReviewModeAddendum()}`;
  * `catfish` (which doubts the framing). The steward asks: should we build
  * this AT ALL? Existing tools usually win; default bias is "don't ship."
  */
+/**
+ * Reuse-ladder check for the scope_steward (#4007, ponytail-inspired). Gates the
+ * SIZE of a justified build by altitude — stop at the first rung that holds —
+ * while hard-fencing the safety concerns that are never the thing cut. Hoisted to
+ * module scope to keep {@link scopeStewardPrompt} within its line budget.
+ */
+const REUSE_LADDER_CHECK = `6. **Reuse ladder (implementation altitude).** When building IS justified,
+   gate the SIZE of the build: stop at the first rung that holds, and say
+   which one.
+     1. Does this need to exist at all? → no: skip it (YAGNI).
+     2. Standard library / language built-in? → use it.
+     3. Native platform feature or an existing nexus-agents substrate
+        primitive (a canonical-path module, an existing voter/pipeline/
+        store)? → use it.
+     4. An already-installed dependency? → use it.
+     5. One line? → one line.
+     6. Only then: the minimum that works.
+   Lazy, NOT negligent — trust-boundary validation, error handling, security,
+   and accessibility are NEVER the thing cut. The code is small because it is
+   necessary, not golfed. Flag a proposal that reaches for rung 6 when an
+   earlier rung holds as OVER_ENGINEERING.`;
+
 function scopeStewardPrompt(project: string): string {
   return `You are a Scope Steward voting on proposals for the ${project} project.
 
@@ -214,6 +236,8 @@ Your evaluation criteria — work through these mandatory checks in your reasoni
    in the codebase. If it does, recommend extending — not forking. The
    anti-sprawl policy in CLAUDE.md is specifically the rule this role
    enforces.
+
+${REUSE_LADDER_CHECK}
 
 Default bias: REJECT proposals where an existing tool fits, even if our
 own implementation would be marginally nicer. Only approve when the


### PR DESCRIPTION
Closes #4007.

## What

Ponytail-inspired ([DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail), 45k★ cross-agent YAGNI skill): the `scope_steward` voter now gates the **implementation altitude** of a justified build with an explicit ordered ladder, stopping at the first rung that holds:

> 1. need-to-exist? (YAGNI) → 2. stdlib → 3. native platform / existing nexus substrate primitive → 4. installed dependency → 5. one line → 6. minimum that works

Reaching for a higher rung when an earlier one holds is flagged `OVER_ENGINEERING`. The ladder **hard-fences** the concerns that are never cut: trust-boundary validation, error handling, security, accessibility ("lazy, not negligent"). Mirrored as an author **pre-write** self-check in `.rules/development-disciplines.md` (the steward enforces it at vote time; the rule reminds authors before writing).

## Why this and nothing more

A 4-subagent survey confirmed nexus-agents already **matches or exceeds** ponytail's other ideas, so they're deliberately **not** copied:

| Ponytail idea | Nexus equivalent (kept) |
|---|---|
| Debt ledger (inline markers → file) | GitHub-issue mandate (`track-deferred-work.md`) — queryable, assignable, unblock-linkable |
| Whole-repo over-engineering audit | `nexus-agents fitness-audit` + `system-review` skill |
| Gain scoreboard | outcome-telemetry → strategy-distillation loop + fitness scoring |
| Never-cut-safety | prime directive + `.rules/security.md` |

The single genuine gap was the absence of an *ordered altitude ladder* in the steward — closed here. ~20 lines, prompt-only, no new CLI/MCP/workflow surface (no repo-index regen).

## Tests

`voter-prompts.test.ts`: now asserts all **6** mandatory checks + the ladder's "first rung that holds" + the "NEVER the thing cut" caveat. 61 pass; lint + `tsc --noEmit` + `governance:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)