### PR TITLE
feat(governance): wire consensus_vote ratifies param (#4004)

### DIFF
--- a/.changeset/consensus-vote-ratifies-param.md
+++ b/.changeset/consensus-vote-ratifies-param.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+Add `ratifies` param to the consensus_vote MCP tool — the authentic-record authoring last-mile (#4004)
+
+`consensus_vote` now accepts an optional `ratifies` argument: the loop/strategy subject an authority-ladder ratification vote authorizes. It is threaded into the persisted authentic vote record's self-hash (`ratifies` field, #3927 item 1), so a real `higher_order` ratification vote cast with `ratifies=<subject>` lands a tamper-evident record the promotion gate (`check-authority-tier-drift.ts`) can resolve a `ratificationVoteRef` against and verify (`ratifies === transition.subject`, decision=approved, strategy=higher_order). Completes the authoring path so the first real authority-tier promotion can be ratified end-to-end. Omitted on ordinary votes (no behaviour change). Tool reference + repo index regenerated.

--- a/artifacts/repo-index.json
+++ b/artifacts/repo-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-06-20T18:21:23.012Z",
+  "generated": "2026-06-21T15:57:15.802Z",
   "generator": "scripts/generate-repo-index.ts",
   "packageVersion": "2.137.0",
   "cli": {

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,6 +1,6 @@
 # Repository Capabilities Index
 
-**Generated:** 2026-06-20T18:21:23.012Z
+**Generated:** 2026-06-21T15:57:15.802Z
 **Package Version:** 2.137.0
 **Generator:** `scripts/generate-repo-index.ts`
 

--- a/docs/reference/tools/consensus_vote.md
+++ b/docs/reference/tools/consensus_vote.md
@@ -24,3 +24,4 @@ Execute multi-model consensus voting on a proposal. Uses 7 roles by default (or 
 | `simulateVotes` | boolean | no | default false | TESTS ONLY — when true, voters return random decisions. Output must not be used for real decisions. (#2319) |
 | `mode` | enum | no | one of: sync \| async | Dispatch mode (default: sync). Use "async" for higher-order strategies with 7 voters. |
 | `idempotencyKey` | string | no | minLength 1; maxLength 256 | Replay-safe key for async-mode dispatch (#3042 Stage 1c). Same (key, inputs) returns existing jobId. |
+| `ratifies` | string | no | minLength 1; maxLength 256 | Authority-tier ratification subject (#4004) — the loop/strategy id this vote ratifies for an authority-ladder promotion. Bound into the authentic vote record so the promotion gate can verify it. Omit for ordinary votes. |

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
@@ -149,6 +149,27 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     expect(written.length).toBeGreaterThan(0);
   });
 
+  it('#4004: binds the ratifies subject into the persisted record', () => {
+    const filePath = join(dir, 'ratify', 'vote-records.jsonl');
+    vi.stubEnv(VOTE_RECORDS_PATH_ENV, filePath);
+
+    const outcome = recordAuthenticVote({
+      proposal: 'Promote auto-remediation to enforce',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes: realVotes,
+      correlationId: 'corr-ratify',
+      ratifies: 'auto-remediation',
+    });
+    expect(outcome.persisted).toBe(true);
+    if (outcome.persisted) {
+      expect(outcome.record.ratifies).toBe('auto-remediation');
+      // ratifies is covered by the self-hash, so the on-disk line carries it.
+      const written = readFileSync(filePath, 'utf-8').trim();
+      expect(JSON.parse(written).ratifies).toBe('auto-remediation');
+    }
+  });
+
   it('#3991: persists to the .nexus-agents/governance/ data-dir path when no override is set', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -146,6 +146,8 @@ export function recordAuthenticVote(args: {
   result: ConsensusResult;
   votes: readonly AgentVoteResult[];
   correlationId?: string | undefined;
+  /** Authority-tier ratification subject (#4004) — bound into the record's self-hash. */
+  ratifies?: string | undefined;
 }): VoteRecordPersistOutcome {
   const allSimulated = args.votes.length > 0 && args.votes.every((v) => v.source === 'simulation');
   if (allSimulated) {
@@ -178,6 +180,7 @@ export function recordAuthenticVote(args: {
     result: args.result,
     votes: args.votes,
     ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
+    ...(args.ratifies !== undefined ? { ratifies: args.ratifies } : {}),
     logger,
   });
   if (record === undefined) {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -219,6 +219,23 @@ export const ConsensusVoteInputSchema = z.object({
     .describe(
       'Replay-safe key for async-mode dispatch (#3042 Stage 1c). Same (key, inputs) returns existing jobId.'
     ),
+  /**
+   * Authority-tier ratification subject (#4004). Set ONLY when this vote
+   * ratifies an authority-ladder promotion: the loop/strategy id (the
+   * tier-transition `subject`) this vote authorizes. It is bound into the
+   * persisted record's self-hash as `ratifies`, so the promotion gate
+   * (`check-authority-tier-drift.ts`) can resolve a `ratificationVoteRef` to this
+   * record and require `ratifies === transition.subject` (with decision=approved,
+   * strategy=higher_order). Omit on an ordinary vote.
+   */
+  ratifies: z
+    .string()
+    .min(1)
+    .max(256)
+    .optional()
+    .describe(
+      'Authority-tier ratification subject (#4004) — the loop/strategy id this vote ratifies for an authority-ladder promotion. Bound into the authentic vote record so the promotion gate can verify it. Omit for ordinary votes.'
+    ),
 });
 
 export type ConsensusVoteInput = z.infer<typeof ConsensusVoteInputSchema>;

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -694,7 +694,8 @@ function recordVoteSideEffects(
   proposal: string,
   strategy: string,
   result: ExtendedVotingResult,
-  logger: ILogger
+  logger: ILogger,
+  ratifies?: string
 ): {
   costSummary: ReturnType<typeof recordDecisionCost> | undefined;
   voteRecord: VoteRecordPersistOutcome;
@@ -702,13 +703,15 @@ function recordVoteSideEffects(
   const decisionId = `consensus-${String(getTimeProvider().now())}-${randomUUID().slice(0, 8)}`;
   // #3897: persist an authentic, hash-chained vote record to the committable
   // governance artifact at vote time so the promotion gate/CI can rest
-  // authenticity on the chain, not on hand-transcribed YAML.
+  // authenticity on the chain, not on hand-transcribed YAML. #4004: bind the
+  // authority-tier ratification subject into the record when provided.
   const voteRecord = recordAuthenticVote({
     proposal,
     strategy,
     result: result.result,
     votes: result.votes,
     correlationId: decisionId,
+    ...(ratifies !== undefined ? { ratifies } : {}),
   });
   // #3855: roll up + persist this decision's per-voter cost and ride it on the
   // existing response (no new MCP tool). A rollup failure must not fail the vote.
@@ -757,7 +760,8 @@ async function handleConsensusVote(
       args.proposal,
       strategy,
       result,
-      logger
+      logger,
+      args.ratifies
     );
     // Close the self-tuning loop: a rejected vote emits signal.vote_rejected
     // onto the typed pipeline bus for the shadow TuneStage (#3147; #3289 Option 2).
@@ -944,6 +948,41 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   voteRecordNote: z.string().max(500).optional(),
 };
 
+/** Advertised MCP input schema for consensus_vote (hoisted to keep the register fn within its line budget). */
+const CONSENSUS_VOTE_TOOL_SCHEMA = {
+  proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
+  threshold: z
+    .enum(['majority', 'supermajority', 'unanimous'])
+    .optional()
+    .describe('Voting threshold (legacy). Use strategy instead.'),
+  strategy: VotingStrategySchema.optional().describe(
+    'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order'
+  ),
+  quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 7'),
+  simulateVotes: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('TESTS ONLY — random output, must not be used for real decisions (#2319)'),
+  ratifies: z
+    .string()
+    .min(1)
+    .max(256)
+    .optional()
+    .describe(
+      'Authority-tier ratification subject (#4004) — the loop/strategy id this vote ratifies for an authority-ladder promotion. Bound into the authentic vote record so the promotion gate can verify it. Omit for ordinary votes.'
+    ),
+};
+
+/** Advertised MCP tool description for consensus_vote. */
+const CONSENSUS_VOTE_DESCRIPTION =
+  'Execute multi-model consensus voting on a proposal. ' +
+  'Uses 7 roles by default (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
+  'or 3 with quickMode (architect, security, scope_steward), voting with configurable strategies. ' +
+  'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514). ' +
+  "Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result. " +
+  'Pass ratifies=<subject> to bind an authority-ladder ratification vote into its authentic record.';
+
 /**
  * Registers the consensus_vote tool with the MCP server.
  * Uses createSecureHandler (Issue #531) with timeout protection (Issue #271).
@@ -953,29 +992,6 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
   const logger = deps.logger ?? createLogger({ tool: 'consensus_vote' });
   const notifier = deps.notifier ?? createMcpNotifier(server);
   const depsWithNotifier = { ...deps, notifier };
-  const toolSchema = {
-    proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
-    threshold: z
-      .enum(['majority', 'supermajority', 'unanimous'])
-      .optional()
-      .describe('Voting threshold (legacy). Use strategy instead.'),
-    strategy: VotingStrategySchema.optional().describe(
-      'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order'
-    ),
-    quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 7'),
-    simulateVotes: z
-      .boolean()
-      .optional()
-      .default(false)
-      .describe('TESTS ONLY — random output, must not be used for real decisions (#2319)'),
-  };
-
-  const description =
-    'Execute multi-model consensus voting on a proposal. ' +
-    'Uses 7 roles by default (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
-    'or 3 with quickMode (architect, security, scope_steward), voting with configurable strategies. ' +
-    'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514). ' +
-    "Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result.";
 
   const secureHandler = createSecureHandler(createConsensusVoteHandler(depsWithNotifier), {
     toolName: 'consensus_vote',
@@ -992,8 +1008,8 @@ export function registerConsensusVoteTool(server: McpServer, deps: ConsensusVote
   server.registerTool(
     'consensus_vote',
     {
-      description,
-      inputSchema: toolSchema,
+      description: CONSENSUS_VOTE_DESCRIPTION,
+      inputSchema: CONSENSUS_VOTE_TOOL_SCHEMA,
       outputSchema: CONSENSUS_VOTE_OUTPUT_SCHEMA,
       annotations: getToolAnnotations('consensus_vote'),
     },


### PR DESCRIPTION
Closes #4004. The authoring last-mile for #3927 item 1.

## What

Adds an optional **`ratifies`** argument to the `consensus_vote` MCP tool — the loop/strategy subject an authority-ladder ratification vote authorizes. It threads through `recordAuthenticVote` → `persistVoteRecord` into the persisted record's **self-hash** (the `ratifies` field added in #3927 item 1).

## Why

#3927 item 1 re-anchored the promotion gate to read the authentic `governance/vote-records.jsonl` and match `ratifies === transition.subject` — but nothing could *set* `ratifies` from a live vote, so the field had a reader and no writer. This closes that loop: a real `higher_order` ratification vote cast with `ratifies=<subject>` now lands a tamper-evident record the gate resolves a `ratificationVoteRef` against. The first real authority-tier promotion can now be ratified end-to-end.

## Changes

- `consensus-vote-types.ts`: `ratifies?` on `ConsensusVoteInputSchema` (validation).
- `consensus-vote.ts`: `ratifies` on the advertised MCP `toolSchema` + description; threaded `args.ratifies` → `recordVoteSideEffects` → `recordAuthenticVote`. Hoisted `toolSchema`/`description` to module constants (line budget).
- `consensus-vote-recording.ts`: `recordAuthenticVote` accepts + forwards `ratifies` to `persistVoteRecord`.
- Regenerated `docs/reference/tools/consensus_vote.md`, `docs/reference/capabilities.md`, `artifacts/repo-index.json` (tool-reference drift + repo-index verification both pass; MCP tool count unchanged at 46).

## Safety / tests

- Omitted on ordinary votes → no behaviour change.
- `consensus-vote-recording.test.ts`: new case asserts a vote with `ratifies` persists a record whose `ratifies` is set AND present on the hashed on-disk line. 109 tool tests pass; lint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)