### PR TITLE
docs(run): note research strategy aliases the pipeline engine (#3988)

### DIFF
--- a/.changeset/research-strategy-aliasing-note.md
+++ b/.changeset/research-strategy-aliasing-note.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(#3988): document that the `research` run-strategy intentionally aliases the `pipeline` engine
+
+Comment-only clarification in `run-tool.ts` `buildDefaultExecutors`: the `research` strategy executor runs the same generic pipeline stage registry as `pipeline` (shaped by goal text, not a distinct research stage registry), matching the registry's research `entrypointTool` already pointing at `run_pipeline`. Corrects the overstated strategy-distinctness claim flagged in #3988; a real research-shaped registry is deferred as a no-consumer feature (YAGNI). No behavior change.

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -231,6 +231,13 @@ export function buildDefaultExecutors(trustTier?: string): StrategyExecutorMap {
     'dev-pipeline': (_decision, metaInput: MetaOrchestratorInput) =>
       runDevPipelineForGoal(metaInput.goal, trustTier),
     pipeline: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
+    // #3988: `research` deliberately ALIASES the `pipeline` engine — it runs the
+    // SAME generic stage registry (selectStageRegistry only branches greenfield/
+    // audit), shaped by the goal text, NOT a distinct research stage registry.
+    // The registry's research `entrypointTool` already points at run_pipeline, so
+    // this is intended aliasing, not a distinct executor. A real research-shaped
+    // registry is a feature with no current consumer (YAGNI) — add it only when a
+    // named loop needs research-specific stages; until then research==pipeline.
     research: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
     consensus: (_decision, metaInput: MetaOrchestratorInput) => runConsensusForGoal(metaInput.goal),
   };


### PR DESCRIPTION
Closes #3988 (LOW, quality — surfaced by the #3548 MetaOrchestrator QA review).

## What

Comment-only clarification in `run-tool.ts` `buildDefaultExecutors`: the `research` strategy executor intentionally **aliases** the `pipeline` engine — it runs the same generic stage registry (`selectStageRegistry` only branches greenfield/audit), shaped by the goal text, **not** a distinct research stage registry. This matches the registry's research `entrypointTool` already pointing at `run_pipeline`.

## Why (b), not (a)

#3988 offered two options: (a) build a real research stage-registry branch, or (b) document the aliasing so the strategy-distinctness claim isn't overstated. Per the reuse-first ladder just added to the `scope_steward` voter (#4007) and bounded-YAGNI, (a) is a feature with **no current consumer** — a research-shaped registry should be built only when a named loop needs research-specific stages. So this takes (b): make the behavior honest in-code (claims-accuracy), and defer (a) until a consumer exists.

No behavior change; empty changeset (comment-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)