### PR TITLE
docs: accuracy pass — fix stale counts/version, de-exaggerate claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Nexus Agents Architecture
 
-**Version:** 2.72.0
-**Last Updated:** 2026-05-12 (ET)
+**Version:** 2.137.0
+**Last Updated:** 2026-06-21 (ET)
 **Status:** Current
 
 ---
@@ -30,9 +30,9 @@ Nexus Agents is an intelligent orchestration platform for AI coding tools. It co
 - **Expert System**: Specialized agents (Code, Architecture, Security, etc.)
 - **Workflow Engine**: YAML-defined automated workflows
 - **MCP Protocol**: Claude Desktop integration via Model Context Protocol
-- **11 Consensus Protocols**: Byzantine fault tolerant multi-agent decisions
-- **8-Type Memory**: MIRIX-inspired memory architecture
-- **Intelligent Routing**: Budget→TOPSIS→LinUCB pipeline
+- **5 Consensus Strategies** (6 names — `higher_order` aliases the Bayesian path): multi-agent decisions with Byzantine-pattern detection in weighted voting (see [CONSENSUS_PROTOCOLS.md](./docs/architecture/CONSENSUS_PROTOCOLS.md))
+- **7-Type Memory**: MIRIX-inspired memory architecture (see [MEMORY_SYSTEM.md](./docs/architecture/MEMORY_SYSTEM.md))
+- **Intelligent Routing**: Budget → parallel scoring → TOPSIS → LinUCB pipeline (full chain in [ROUTING_SYSTEM.md](./docs/architecture/ROUTING_SYSTEM.md))
 
 ---
 
@@ -324,7 +324,7 @@ security:
 
 ### Pre-Merge
 
-- 80% test coverage
+- Coverage thresholds met (60% statements/functions/lines, 50% branches — `vitest.config.ts`)
 - Security audit clean
 - No deprecated dependencies
 
@@ -339,5 +339,5 @@ security:
 
 ---
 
-_Last updated: 2026-01-15 (ET)_
+_Last updated: 2026-06-21 (ET)_
 _MCP Protocol: 2025-11-25_

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,7 +20,7 @@ gh search repos --owner williamzujkowski --topic nexus-agents-companion
 
 ## Test Projects (`nexus-agents-test`)
 
-Each exercises a specific subset of the 38 MCP tools end-to-end. Intended as regression harness — if a tool's contract changes, the corresponding test repo should fail.
+Each exercises a specific subset of the 46 MCP tools end-to-end. Intended as regression harness — if a tool's contract changes, the corresponding test repo should fail.
 
 | Repo                                                                         | Tools Under Test                                                                          | Description                                              |
 | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------- |

--- a/docs/adr/0019-governance-record-signing.md
+++ b/docs/adr/0019-governance-record-signing.md
@@ -27,7 +27,7 @@ keywords:
 **Date:** 2026-06-20
 **Context:** #3897 — "Ratification ledger verifies presence, not authenticity." Residual
 flagged by every voter on the #3895 (7/7) ratification: governance records are
-tamper-evident but hand-committable, so a gate verifies *presence*, not *authenticity*.
+tamper-evident but hand-committable, so a gate verifies _presence_, not _authenticity_.
 **Ratification:** `consensus_vote`, **APPROVED 7/0**, recording the keyless
 OIDC/Sigstore direction (Architecture A) and the deferred build trigger below.
 
@@ -52,15 +52,15 @@ governance record it relies on:
    any other workflow, or any other repository fails.
 2. **Payload binding** — the signed payload bytes are **byte-identical** to the
    committed record bytes (this preserves the Option-C content-diff binding ratified
-   for the producer; the signature attests *this exact record*, not a paraphrase).
+   for the producer; the signature attests _this exact record_, not a paraphrase).
 3. **Rekor inclusion** — the record's entry is present and verifiable in the Rekor
-   transparency log (external witness; see *Honest value assessment*).
+   transparency log (external witness; see _Honest value assessment_).
 
 A record that lacks a valid bundle satisfying all three is not authentic to the gate.
 
 ### Rejected alternatives
 
-- **B — Interactive per-produce keyless login.** Sign at *local production* time via an
+- **B — Interactive per-produce keyless login.** Sign at _local production_ time via an
   interactive OIDC login (`cosign sign` against the developer's identity). Rejected:
   the records are produced locally where there is **no CI OIDC identity**, an
   interactive browser login per produce is high-friction, and — decisively — it is
@@ -69,7 +69,7 @@ A record that lacks a valid bundle satisfying all three is not authentic to the 
   ledger through sanctioned CI."
 - **C — Hybrid (local content-hash + CI signature + a second human-attestation layer).**
   Rejected as **premature**: there is no multi-reviewer / external-contributor consumer
-  today to attest *to*, so the second layer would be machinery with no reader. Revisit
+  today to attest _to_, so the second layer would be machinery with no reader. Revisit
   only if the build trigger's threat model materializes.
 
 ## Context
@@ -79,9 +79,9 @@ over the record bytes, so any post-hoc edit to a committed record is detectable 
 its hash (the same tamper-evident-not-tamper-proof posture as the
 [audit hash-chain](../security/audit-hash-chain-threat-model.md)). What they are **not**
 is **forgery-proof**: as #3897 found, the ledger is **hand-committable**, so any actor
-who can land a commit can author a *conforming* entry. A content hash proves the bytes
-have not changed since *someone* wrote them; it does not prove *who* wrote them or
-*how* they entered the ledger. The gate therefore verifies **structural presence** of
+who can land a commit can author a _conforming_ entry. A content hash proves the bytes
+have not changed since _someone_ wrote them; it does not prove _who_ wrote them or
+_how_ they entered the ledger. The gate therefore verifies **structural presence** of
 an approved record, not its **authenticity**. The trust anchor today is PR review of
 the record (CODEOWNERS on `governance/` + branch protection) — a human, not a machine.
 
@@ -94,27 +94,27 @@ Two facts shape the design:
 - **Records are produced locally but committed via caller-commits.** Production happens
   on a developer machine that has **no CI OIDC identity** to sign under; the record then
   reaches the repository through the **caller-commits** path (the producer writes the
-  record set locally; a PR commits it). The only place a *sanctioned, attestable*
+  record set locally; a PR commits it). The only place a _sanctioned, attestable_
   identity exists in this flow is **CI at commit time** — which is exactly where
   Architecture A signs.
 - **The producer is deferred.** The record producer itself — the component that would
   emit `vote-records.jsonl` / `pr-review-records.jsonl` at vote/review time as a
-  tamper-evident keyless-hash record *set* (Option C content-diff binding ratified) — is
+  tamper-evident keyless-hash record _set_ (Option C content-diff binding ratified) — is
   **deferred** (#3831 / #3927). There is, today, **no populated record stream** to sign.
 
 ## What it attests (explicit and honest)
 
 A CI-commit-time signature attests exactly one thing: **provenance-through-CI** —
 
-> *this exact record entered the ledger through this repository's sanctioned CI,
-> under identity X.*
+> _this exact record entered the ledger through this repository's sanctioned CI,
+> under identity X._
 
 It does **NOT** attest **who reviewed** anything, and — stated plainly — **it does not
 prove that a human reviewed the record at all.** A signature proves the record's bytes
 passed through the repo's CI identity; it says nothing about whether a person read,
 judged, or approved the underlying vote or PR review. Conflating "signed by CI" with
 "reviewed by a human" is the failure mode this ADR refuses to commit: the attestation
-is about *the path into the ledger*, not *the judgment behind the content*. The
+is about _the path into the ledger_, not _the judgment behind the content_. The
 ADR/docs MUST state this (binding condition 4).
 
 ## Honest value assessment
@@ -134,18 +134,18 @@ The genuine delta requires **both** of:
   a forged or rewritten ledger entry is detectable after the fact because the authentic
   entries are publicly logged and the forged one is not. This is why Rekor verification
   is **mandatory**, not optional — it is the part that carries the real security value.
-- **(ii) Multi-party / external-contributor review.** Provenance-through-CI is *real*
+- **(ii) Multi-party / external-contributor review.** Provenance-through-CI is _real_
   value precisely when the producer/committer is **not** the sole trust anchor — when an
   external contributor or a second reviewer is in the loop and "did this record actually
   enter through our sanctioned CI, or was it hand-forged into the PR?" is a question with
   a non-trivial answer.
 
 Absent (i), there is no external witness; absent (ii), there is no adversary the
-provenance defends against. The build is gated on **both** appearing (see *Sequencing*).
+provenance defends against. The build is gated on **both** appearing (see _Sequencing_).
 
 ## Sequencing / build trigger
 
-**DESIGN NOW (this ADR) / BUILD WITH THE PRODUCER.** This ADR is the *design-of-record*;
+**DESIGN NOW (this ADR) / BUILD WITH THE PRODUCER.** This ADR is the _design-of-record_;
 it ships no code.
 
 The **build trigger** is the conjunction of:
@@ -172,11 +172,11 @@ When the trigger fires, the implementation MUST satisfy all of:
    fails verification. Identity match is not advisory — it is the gate.
 2. **Payload-bytes binding.** The gate verifies the **signed-payload bytes ==
    committed-record bytes**, preserving the Option-C content-diff binding (the signature
-   attests *this exact record*, not a re-serialization or a paraphrase).
+   attests _this exact record_, not a re-serialization or a paraphrase).
 3. **Mandatory Rekor inclusion verification.** Rekor transparency-log inclusion
    verification is **required**; a bundle without verifiable Rekor inclusion is rejected.
-   Without it the design is an ephemeral cert with no external witness (see *Honest value
-   assessment*).
+   Without it the design is an ephemeral cert with no external witness (see _Honest value
+   assessment_).
 4. **Honest attestation wording.** The ADR/docs state that the signature attests
    **provenance-through-CI, not human review** — the build does not market it as proof a
    human reviewed.
@@ -198,8 +198,12 @@ When the trigger fires, the implementation MUST satisfy all of:
 ### Negative
 
 - The authenticity gap **remains open until the build trigger fires** — until then the
-  trust anchor is still PR review of the record (CODEOWNERS + branch protection), and
-  `governance/ratification-votes.yaml` MUST stay under CODEOWNERS review (per #3897).
+  trust anchor is still PR review of the record (CODEOWNERS + branch protection).
+  <br>**Update (#4005/#4010):** the resolution source moved from the hand-committable
+  `governance/ratification-votes.yaml` (now **removed**) to the authentic, tamper-evident
+  `governance/vote-records.jsonl` (verified by `verifyVoteRecordSet`); CODEOWNERS review on
+  `governance/` is the trust anchor that must stay in place. The original #3897 reasoning below
+  is preserved as the historical record.
 - A future build carries real cost: a signing workflow, bundle verification in the gate,
   Rekor availability as a CI dependency, and the operational story for Rekor/Fulcio
   outages — costs this ADR defers but does not remove.

--- a/docs/architecture/EVENT_BUS_BOUNDARIES.md
+++ b/docs/architecture/EVENT_BUS_BOUNDARIES.md
@@ -94,10 +94,10 @@ The dev-pipeline consensus→execute policy gate
 (`pipeline/policy-evaluator.ts → evaluatePipelinePolicy`) **dual-emits** each
 `policy.evaluated` decision:
 
-| Sink                           | Path                                                                      | Lifetime                                            | Role                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **Bus A (observability)**      | `IEventBus.emit` → `TraceWriter` → per-run `trace.jsonl`                  | Per-run, bounded ring buffer, dropped on no session | **Observability only.** Replay/debug a single run.                                      |
-| **Durable hash-chained audit** | `AuditTrail` → `createDurableAuditSink(auditLogger)` → `FileAuditStorage` | Immutable, process-spanning, `verify_audit_chain`   | **Canonical source** for tune/readiness aggregation (soak-vs-enforce evidence — #3653). |
+| Sink                           | Path                                                                      | Lifetime                                                                                     | Role                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Bus A (observability)**      | `IEventBus.emit` → `TraceWriter` → per-run `trace.jsonl`                  | Per-run, bounded ring buffer, dropped on no session                                          | **Observability only.** Replay/debug a single run.                                      |
+| **Durable hash-chained audit** | `AuditTrail` → `createDurableAuditSink(auditLogger)` → `FileAuditStorage` | Tamper-evident (not tamper-proof — see threat model), process-spanning, `verify_audit_chain` | **Canonical source** for tune/readiness aggregation (soak-vs-enforce evidence — #3653). |
 
 The durable `policy_gate` record carries `mode` (`warn`=soak vs `block`=enforce),
 `ruleIds`, and `stageType` in its metadata — exactly what the tune/readiness

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -205,14 +205,14 @@ All configuration can be overridden with environment variables:
 
 ### Security Variables
 
-| Variable               | Description                                                                              | Default |
-| ---------------------- | ---------------------------------------------------------------------------------------- | ------- |
-| `NEXUS_SANDBOX`        | Sandbox flavor; passed through to subprocess adapters (epic #2500)                       | unset   |
-| `NEXUS_SANDBOX_ROOT`   | Sandbox root directory for the sandbox executor                                          | unset   |
-| `NEXUS_RATE_LIMIT`     | Requests per minute                                                                      | `60`    |
-| `NEXUS_AUTH_ENABLED`   | Enable MCP auth (applies only to network transports; no effect on the default stdio MCP) | `true`  |
-| `NEXUS_AUTH_METHOD`    | Auth method                                                                              | `token` |
-| `NEXUS_DRIFT_ADVISORY` | Model-string drift CI gate: `1`=advisory (warn), `0`=blocking (#2199)                    | `0`     |
+| Variable               | Description                                                                                                                       | Default          |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `NEXUS_SANDBOX`        | Sandbox flavor; passed through to subprocess adapters (epic #2500)                                                                | unset            |
+| `NEXUS_SANDBOX_ROOT`   | Sandbox root directory for the sandbox executor                                                                                   | unset            |
+| `NEXUS_RATE_LIMIT`     | Requests per minute                                                                                                               | `60`             |
+| `NEXUS_AUTH_ENABLED`   | Enable MCP auth (applies only to network transports; no effect on the default stdio MCP)                                          | `true`           |
+| `NEXUS_AUTH_METHOD`    | Auth method                                                                                                                       | `token`          |
+| `NEXUS_DRIFT_ADVISORY` | Model-string drift CI gate: any value except `0` (incl. unset) = advisory (warn); `0` = blocking (#2199). CI sets `0` to enforce. | unset (advisory) |
 
 ### Orchestration Variables
 

--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -1,6 +1,6 @@
 ---
 title: 'Claude Code Plugin Install'
-description: Install nexus-agents as a Claude Code plugin — exposes 46 MCP tools, 32 skills, 12 agent mirrors, and governance hooks
+description: Install nexus-agents as a Claude Code plugin — exposes 46 MCP tools, 33 skills, 12 agent mirrors, and governance hooks
 tier: 2
 keywords: [plugin, claude-code, installation, marketplace, mcp, getting-started]
 ---


### PR DESCRIPTION
2026-06-21 documentation accuracy audit (4-subagent fan-out over the doc tree). Verifies the user's ask: docs are accurate, up to date, and don't exaggerate. **Finding: the deep architecture/guide docs are already accurate** (CONSENSUS_PROTOCOLS, MEMORY_SYSTEM, ROUTING_SYSTEM, governance docs all match code) — the issues concentrated in the root `ARCHITECTURE.md` hub plus a few one-liners.

## Fixes (all verified against code)

**ARCHITECTURE.md** (the main offender):
- Version `2.72.0`→`2.137.0`; dates→`2026-06-21` (header + footer were conflicting/stale).
- **De-exaggerated:** "11 Consensus Protocols"→**5 strategies (6 names)** (`consensus/strategies.ts`); "Byzantine fault tolerant"→**Byzantine-pattern detection in weighted voting** (matches CONSENSUS_PROTOCOLS.md, which frames Aegean as inspiration); "8-Type Memory"→**7-Type** (`context/memory-types.ts`); "80% test coverage"→**actual 60% thresholds (50% branches)** (`vitest.config.ts`).
- Routing line points at ROUTING_SYSTEM.md for the real chain.

**One-liners:**
- `ECOSYSTEM.md`: "38 MCP tools"→**46**.
- `PLUGIN_INSTALL.md`: front-matter "32 skills"→**33**.
- `CONFIGURATION.md`: `NEXUS_DRIFT_ADVISORY` default corrected — unset = advisory; only `0` = blocking (the documented default `0` implied blocking-by-default, contradicting `check-model-string-drift.ts`).
- `ADR-0019`: superseded-note that `ratification-votes.yaml` was removed (#4005/#4010) and resolution moved to the authentic `vote-records.jsonl`; original #3897 reasoning preserved as history.
- `EVENT_BUS_BOUNDARIES.md`: audit-sink row "Immutable"→**"Tamper-evident (not tamper-proof)"** (consistent with the rest of the doc + threat model).

## What the audit deliberately did NOT change
Roadmap statuses for Standalone-CLI / REST-Gateway stayed **roadmap** — the `claims-registry` intentionally tracks them as not-yet-shipped, and `claims:check` flagged my initial attempt to mark them done as drift. Marking them complete would have been the exaggeration this pass is meant to remove. Verifying beat blindly applying the subagent's "stale roadmap" finding.

Docs-only (no `src/`, no changeset). `claims:check` + `markdownlint` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)