### PR TITLE
docs(npm): fix package README accuracy + claims-registry drift guard

### DIFF
--- a/.changeset/npm-readme-accuracy.md
+++ b/.changeset/npm-readme-accuracy.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+Fix npm package README accuracy + guard it against drift
+
+The npm-rendered package README (`packages/nexus-agents/README.md`) had drifted: "42 MCP tools" (now 46), an "80% test coverage" claim (actual thresholds 60%/50%), an expert table listing 10 of the 12 types, a dated `gemini-1.5-pro` example, and several `../../` cross-links that 404 on the npm package page (npm renders the README standalone). All corrected; cross-links are now absolute GitHub URLs. A new `npm-readme-tool-count` claim in the claims registry now guards the npm README's tool count via `claims:check`, so this drift can't recur silently (chosen over symlinking to the root README, whose repo-relative links would break on npm). Docs/metadata only — no code or API change. A patch release is cut so the corrected README reaches the npm package page.

--- a/governance/claims-registry.yaml
+++ b/governance/claims-registry.yaml
@@ -35,6 +35,22 @@ claims:
       subjectContains: '46 MCP tools'
     lastVerified: '2026-06-16'
 
+  - id: npm-readme-tool-count
+    claim: 'The published npm README states the system exposes 46 MCP tools.'
+    # The npm-rendered package README is a SEPARATE file from the root README; it
+    # drifted to a stale "42 MCP tools" (caught 2026-06-21). Guarding it here so
+    # claims:check enforces the count on the npm-facing doc too, instead of a
+    # fragile symlink to the root README (whose repo-relative links break on npm).
+    subject: packages/nexus-agents/README.md
+    status: verified
+    evidenceType: source
+    verification:
+      method: manifest-tool-count
+      path: packages/nexus-agents/src/mcp/tools/tool-manifest.ts
+      expected: 46
+      subjectContains: '46 MCP tools'
+    lastVerified: '2026-06-21'
+
   - id: consensus-strategy-count
     claim: 'README advertises six consensus strategy names backed by the algorithm enum.'
     subject: README.md

--- a/packages/nexus-agents/README.md
+++ b/packages/nexus-agents/README.md
@@ -99,20 +99,22 @@ Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/
 
 The Orchestrator agent analyzes incoming tasks and delegates to specialized experts:
 
-| Expert                    | Specialization                                         |
-| ------------------------- | ------------------------------------------------------ |
-| **Code Expert**           | Implementation, debugging, optimization, refactoring   |
-| **Architecture Expert**   | System design, patterns, trade-offs, scalability       |
-| **Security Expert**       | Vulnerability analysis, secure coding, threat modeling |
-| **Documentation Expert**  | Technical writing, API docs, code comments             |
-| **Testing Expert**        | Test strategies, coverage analysis, test generation    |
-| **DevOps Expert**         | CI/CD, deployment, containerization                    |
-| **Research Expert**       | Literature review, state-of-the-art analysis           |
-| **PM Expert**             | Product management, requirements, priorities           |
-| **UX Expert**             | User experience, usability, accessibility              |
-| **Infrastructure Expert** | Server management, bare metal, networking              |
+| Expert                        | Specialization                                         |
+| ----------------------------- | ------------------------------------------------------ |
+| **Code Expert**               | Implementation, debugging, optimization, refactoring   |
+| **Architecture Expert**       | System design, patterns, trade-offs, scalability       |
+| **Security Expert**           | Vulnerability analysis, secure coding, threat modeling |
+| **Documentation Expert**      | Technical writing, API docs, code comments             |
+| **Testing Expert**            | Test strategies, coverage analysis, test generation    |
+| **DevOps Expert**             | CI/CD, deployment, containerization                    |
+| **Research Expert**           | Literature review, state-of-the-art analysis           |
+| **PM Expert**                 | Product management, requirements, priorities           |
+| **UX Expert**                 | User experience, usability, accessibility              |
+| **Infrastructure Expert**     | Server management, bare metal, networking              |
+| **QA Expert**                 | Quality gates, test-plan review, defect triage         |
+| **Data-Visualization Expert** | Charts, diagrams, dashboards, data presentation        |
 
-Experts can collaborate on complex tasks. The Orchestrator combines their outputs into a single response.
+All twelve expert types can collaborate on complex tasks. The Orchestrator combines their outputs into a single response.
 
 ### Model Adapters
 
@@ -155,7 +157,7 @@ steps:
 
 ### MCP Tools
 
-The server exposes 42 MCP tools for integration. Key tools include:
+The server exposes 46 MCP tools for integration. Key tools include:
 
 | Tool                 | Description                                    |
 | -------------------- | ---------------------------------------------- |
@@ -171,7 +173,7 @@ The server exposes 42 MCP tools for integration. Key tools include:
 | `repo_analyze`       | Analyze GitHub repository structure            |
 | `repo_security_plan` | Generate security scanning pipeline for a repo |
 
-See the root [README](../../README.md) for the complete tool list.
+See the [root README](https://github.com/nexus-substrate/nexus-agents/blob/main/README.md) for the complete tool list.
 
 ---
 
@@ -204,7 +206,7 @@ nexus-agents/
 └── pnpm-workspace.yaml
 ```
 
-See [docs/architecture/README.md](../../docs/architecture/README.md) for detailed module descriptions.
+See [docs/architecture/README.md](https://github.com/nexus-substrate/nexus-agents/blob/main/docs/architecture/README.md) for detailed module descriptions.
 
 ### Dependency Flow
 
@@ -280,7 +282,7 @@ import {
 // Create individual adapters
 const claude = createClaudeAdapter({ model: 'claude-sonnet-4-6' });
 const openai = createOpenAIAdapter({ model: 'gpt-4o' });
-const gemini = createGeminiAdapter({ model: 'gemini-1.5-pro' });
+const gemini = createGeminiAdapter({ model: 'gemini-3-pro' });
 const ollama = createOllamaAdapter({ model: 'llama3:8b' });
 
 // Or use the factory
@@ -379,11 +381,11 @@ We welcome contributions! Please see our guidelines:
 
 - Files must be under 400 lines
 - Functions must be under 50 lines
-- Test coverage must be at least 80%
+- Coverage thresholds: 60% statements/functions/lines, 50% branches (`vitest.config.ts`)
 - All code must pass linting and type checking
 
-See [CODING_STANDARDS.md](../../CODING_STANDARDS.md) for detailed guidelines.
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution workflow.
+See [CODING_STANDARDS.md](https://github.com/nexus-substrate/nexus-agents/blob/main/CODING_STANDARDS.md) for detailed guidelines.
+See [CONTRIBUTING.md](https://github.com/nexus-substrate/nexus-agents/blob/main/CONTRIBUTING.md) for contribution workflow.
 
 ### Commit Convention
 
@@ -402,7 +404,7 @@ chore(scope): maintenance tasks
 
 ## License
 
-MIT - See [LICENSE](../../LICENSE) for details.
+MIT - See [LICENSE](https://github.com/nexus-substrate/nexus-agents/blob/main/LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
Reviews and corrects the **npm-facing documentation** (the `packages/nexus-agents/README.md` that npmjs.com renders + package.json metadata).

## package.json metadata — verified accurate (no change)
description, `repository`/`homepage`/`bugs` (all `nexus-substrate`), `license` (MIT), `engines` (node ≥22), `bin`/`main`/`types`, keywords — all correct.

## Package README fixes (`packages/nexus-agents/README.md`)
- **"42 MCP tools" → 46** (the headline drift; root README already said 46).
- **"80% test coverage" → 60% statements/functions/lines, 50% branches** (`vitest.config.ts`).
- **Expert table listed 10 of 12 types** → added **QA** and **Data-Visualization**.
- **Dated `gemini-1.5-pro` example** → `gemini-3-pro`.
- **`../../` cross-links 404 on the npm page** (npm renders the README standalone; `repository.directory` isn't set) → all converted to **absolute GitHub URLs**.

## Drift guard (the "keep them in sync" answer)
Rather than symlink the npm README to the root README — which **breaks on npm** (the root README's repo-relative links 404 there) and conflates two docs that serve different surfaces — this adds a **`npm-readme-tool-count` claim** to `governance/claims-registry.yaml`. `claims:check` now enforces the npm README's tool count the same way it already guards the root README's, so a "42 vs 46"-style drift fails CI instead of shipping silently.

## Release
Patch changeset included — the npm package page only updates on publish, so a release is needed to push the corrected README to npmjs.com.

`claims:check` (14 claims) + `markdownlint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)