### PR TITLE
fix(jobs): guard async job terminal writers against complete-after-cancel (#4017)

### DIFF
--- a/.changeset/fix-4017-complete-after-cancel.md
+++ b/.changeset/fix-4017-complete-after-cancel.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+Fix async job complete-after-cancel rewriting the cancellation (#4017)
+
+`writeJobComplete` / `writeJobFailed` now no-op when the job record is already `cancelled`, so a `runAsJob`-dispatched job whose work finishes _after_ `cancel_job` landed no longer silently overwrites the `cancelled` status back to `complete`/`failed`. This makes the guard symmetric with the existing caller-side cancel-after-complete protection. (Aborting the still-running in-flight work — `runAsJob` threads no AbortSignal — remains a separate follow-up under #4017.)

--- a/packages/nexus-agents/src/mcp/jobs/job-result-store.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-result-store.test.ts
@@ -110,6 +110,28 @@ describe('job-result-store', () => {
     expect(readJobResult('does-not-exist')).toBeNull();
   });
 
+  // #4017: complete/fail-after-cancel must NOT rewrite a cancellation. A
+  // runAsJob-dispatched job's work keeps running after cancel_job (no abort
+  // wiring), so the terminal writers must preserve the `cancelled` record.
+  it('writeJobComplete is a NO-OP once the job is cancelled (#4017)', () => {
+    writeJobPending('job-cancel-complete', 'run');
+    writeJobCancelled('job-cancel-complete', 'run', 'user cancelled');
+    writeJobComplete('job-cancel-complete', 'run', { ok: true });
+    const record = readJobResult('job-cancel-complete');
+    expect(record?.status).toBe('cancelled');
+    expect(record?.result).toBeUndefined();
+    expect(record?.error).toBe('user cancelled');
+  });
+
+  it('writeJobFailed is a NO-OP once the job is cancelled (#4017)', () => {
+    writeJobPending('job-cancel-fail', 'run');
+    writeJobCancelled('job-cancel-fail', 'run', 'user cancelled');
+    writeJobFailed('job-cancel-fail', 'run', 'late failure');
+    const record = readJobResult('job-cancel-fail');
+    expect(record?.status).toBe('cancelled');
+    expect(record?.error).toBe('user cancelled');
+  });
+
   it('writeJobPending is idempotent — re-call does not overwrite a completed record', () => {
     writeJobPending('job-test-5', 'orchestrate');
     writeJobComplete('job-test-5', 'orchestrate', { done: true });

--- a/packages/nexus-agents/src/mcp/jobs/job-result-store.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-result-store.ts
@@ -116,14 +116,28 @@ export function writeJobPending(jobId: string, toolName: string): void {
  * Replace the record with a terminal `complete` status carrying the
  * structured payload. Caller writes the SAME shape the sync mode would
  * have returned, so a polling client can use the result interchangeably.
+ *
+ * COMPLETE-AFTER-CANCEL guard (#4017): if the job was already `cancelled`
+ * (e.g. `cancel_job` landed while the work was in-flight — `runAsJob` does not
+ * yet abort the underlying work), this is a NO-OP so the cancellation is not
+ * silently rewritten back to `complete`. Symmetric with the caller-side
+ * cancel-after-complete guard documented on {@link writeJobCancelled}.
  */
 export function writeJobComplete(jobId: string, toolName: string, result: unknown): void {
+  const existing = readJobResult(jobId);
+  if (existing?.status === 'cancelled') {
+    logger.debug('Skipping complete write — job already cancelled (preserving cancellation)', {
+      jobId,
+      toolName,
+    });
+    return;
+  }
   const record: JobResult = {
     v: 1,
     jobId,
     toolName,
     status: 'complete',
-    createdAt: readJobResult(jobId)?.createdAt ?? new Date().toISOString(),
+    createdAt: existing?.createdAt ?? new Date().toISOString(),
     completedAt: new Date().toISOString(),
     result,
   };
@@ -131,14 +145,26 @@ export function writeJobComplete(jobId: string, toolName: string, result: unknow
   logger.debug('Wrote complete job record', { jobId, toolName });
 }
 
-/** Terminal `failed` status. `error` is the human-readable failure message. */
+/**
+ * Terminal `failed` status. `error` is the human-readable failure message.
+ * Like {@link writeJobComplete}, a NO-OP when the job is already `cancelled`
+ * (#4017) so a post-cancel failure cannot rewrite the cancellation.
+ */
 export function writeJobFailed(jobId: string, toolName: string, error: string): void {
+  const existing = readJobResult(jobId);
+  if (existing?.status === 'cancelled') {
+    logger.debug('Skipping failed write — job already cancelled (preserving cancellation)', {
+      jobId,
+      toolName,
+    });
+    return;
+  }
   const record: JobResult = {
     v: 1,
     jobId,
     toolName,
     status: 'failed',
-    createdAt: readJobResult(jobId)?.createdAt ?? new Date().toISOString(),
+    createdAt: existing?.createdAt ?? new Date().toISOString(),
     completedAt: new Date().toISOString(),
     error,
   };


### PR DESCRIPTION
Fixes the HIGH-severity integrity bug from the 2026-06-21 QA sweep (#4017).

## Bug
A caller cancels an in-flight async job, polls `get_job_result` and sees `cancelled`, then **later sees `complete`/`failed`** — cancellation silently reverted. Root cause: `runAsJob` threads no AbortSignal (`run-as-job.ts:271` calls `params.run` with no signal), so the background work keeps running after `cancel_job`; when it settles, `writeJobComplete`/`writeJobFailed` unconditionally overwrote the `cancelled` record. The mirror case (cancel-after-complete) was already guarded caller-side; this adds the missing symmetric guard.

## Fix
`writeJobComplete` / `writeJobFailed` now **no-op when the record is already `cancelled`**, preserving the cancellation. Both already read the existing record (for `createdAt`), so the status check is free.

## Tests
Two new cases: pending → cancelled → complete (and → failed) both keep `status: cancelled`. 13 job-result-store tests pass; lint + `tsc --noEmit` clean.

## Scope note
This resolves the **integrity** half of #4017 (cancellation no longer rewritten). The remaining half — actually **aborting** the still-running work for `runAsJob`-dispatched tools (and the cancel-tool docstring's abort claim) — needs the #3035/#3038 AbortSignal plumbing threaded through `runAsJob` and is left as a tracked follow-up on #4017. I'll reframe #4017 to that remaining work after merge rather than auto-closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)