### PR TITLE
fix(memory): clamp typed-memory ttl + harden outcome-store secret redaction (#4018)

### DIFF
--- a/.changeset/fix-4018-memory-ttl-redaction.md
+++ b/.changeset/fix-4018-memory-ttl-redaction.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': patch
+---
+
+Fix typed-memory invalidation silently failing + harden outcome-store secret redaction
+
+- **#4018:** `TypedMemory.invalidateFact` (and `storeFact`/`KnowledgeVault.store` with a past `validUntil`/`expiresAt`) computed a non-positive `ttl`, which `MemoryMetadataSchema` (`ttl: positive()`) rejected — so the store silently failed with `Invalid metadata` and the fact was never invalidated. The ttl is now clamped to ≥1ms at both computation sites, so a past/now expiry stores-then-expires-on-next-retrieve (the closest to immediate invalidation without a backend delete method).
+- **Security hardening (CWE-532):** the outcome-store error-message redaction (`sanitizeErrorMessage`) now also redacts GitHub PATs (`ghp_/gho_/ghu_/ghs_/github_pat_`), AWS access keys (`AKIA…`), and space-separated `Bearer <token>` — formats the previous `sk-…`/`keyword=value` regex missed before persisting `error_message` to SQLite. Patterns are linear (ReDoS-safe).
+
+Both found in the 2026-06-21 QA/security sweep.

--- a/packages/nexus-agents/src/context/typed-memory-impl.test.ts
+++ b/packages/nexus-agents/src/context/typed-memory-impl.test.ts
@@ -274,6 +274,29 @@ describe('SemanticMemoryImpl', () => {
     expect(result.ok).toBe(true);
   });
 
+  // #4018: invalidateFact set validUntil=now → storeFact computed ttl≤0 →
+  // MemoryMetadataSchema.positive() rejected it → silent 'Invalid metadata'.
+  // The mock backend ignores ttl, so assert the CLAMPED ttl (≥1) is what reaches
+  // the backend — the property the real backend's positive() schema requires.
+  it('invalidateFact passes a POSITIVE ttl to the backend (clamped) (#4018)', async () => {
+    await semantic.storeFact(makeFact());
+    (backend.store as ReturnType<typeof vi.fn>).mockClear();
+    await semantic.invalidateFact('fact-1');
+    const meta = (backend.store as ReturnType<typeof vi.fn>).mock.calls[0]?.[2] as {
+      ttl?: number;
+    };
+    expect(meta.ttl).toBeGreaterThanOrEqual(1);
+  });
+
+  it('storeFact with a PAST validUntil still passes a positive ttl (#4018)', async () => {
+    const past = new Date(Date.now() - 60_000);
+    await semantic.storeFact(makeFact({ validUntil: past }));
+    const meta = (backend.store as ReturnType<typeof vi.fn>).mock.calls[0]?.[2] as {
+      ttl?: number;
+    };
+    expect(meta.ttl).toBeGreaterThanOrEqual(1);
+  });
+
   it('invalidateFact succeeds for unknown fact', async () => {
     const result = await semantic.invalidateFact('unknown');
     expect(result.ok).toBe(true);

--- a/packages/nexus-agents/src/context/typed-memory-impl.ts
+++ b/packages/nexus-agents/src/context/typed-memory-impl.ts
@@ -131,7 +131,12 @@ export class SemanticMemoryImpl implements ISemanticMemory {
       tags: ['semantic', fact.domain, fact.subject],
     };
     if (fact.validUntil !== undefined) {
-      meta.ttl = fact.validUntil.getTime() - getTimeProvider().now();
+      // #4018: clamp to ≥1ms. A past/now `validUntil` (e.g. invalidateFact sets
+      // it to now) yields a non-positive ttl that MemoryMetadataSchema.positive()
+      // REJECTS — silently failing the whole store with 'Invalid metadata'. ttl=1
+      // expires the entry on the next retrieve, the closest we get to immediate
+      // invalidation without a backend delete method.
+      meta.ttl = Math.max(1, fact.validUntil.getTime() - getTimeProvider().now());
     }
     return this.backend.store(`semantic:${fact.factId}`, fact, meta);
   }
@@ -309,7 +314,9 @@ export class KnowledgeVaultImpl implements IKnowledgeVault {
     const tags = ['vault', entry.category, entry.importance, ...(entry.tags ?? [])];
     const meta: MemoryMetadata = { importance, tags };
     if (entry.expiresAt !== undefined) {
-      meta.ttl = entry.expiresAt.getTime() - getTimeProvider().now();
+      // #4018: clamp to ≥1ms — a past/now expiry would make a non-positive ttl
+      // that MemoryMetadataSchema.positive() rejects, silently failing the store.
+      meta.ttl = Math.max(1, entry.expiresAt.getTime() - getTimeProvider().now());
     }
     return this.backend.store(`vault:${entry.vaultId}`, entry, meta);
   }

--- a/packages/nexus-agents/src/learning/outcome-storage.test.ts
+++ b/packages/nexus-agents/src/learning/outcome-storage.test.ts
@@ -14,7 +14,38 @@ import type {
   ModelStatsRow,
 } from './outcome-storage-types.js';
 import { OutcomeStorageError } from './outcome-storage-types.js';
-import { SQLiteOutcomeStorage, createOutcomeStorage } from './outcome-storage.js';
+import {
+  SQLiteOutcomeStorage,
+  createOutcomeStorage,
+  sanitizeErrorMessage,
+} from './outcome-storage.js';
+
+describe('sanitizeErrorMessage — secret redaction (security hardening)', () => {
+  it('redacts the original sk- and keyword=value forms', () => {
+    expect(sanitizeErrorMessage('failed with sk-abcdefghijklmnopqrstuvwxyz123')).toContain(
+      '[REDACTED]'
+    );
+    expect(sanitizeErrorMessage('api_key=supersecretvalue123')).toContain('[REDACTED]');
+  });
+
+  it('redacts GitHub PATs, AWS keys, and space-separated Bearer tokens (newly covered)', () => {
+    expect(sanitizeErrorMessage('token ghp_0123456789abcdefghijklmnopqrstuvwx')).toContain(
+      '[REDACTED]'
+    );
+    expect(sanitizeErrorMessage('github_pat_11ABCDEFG0abcdefghij_KLMNOP')).toContain('[REDACTED]');
+    expect(sanitizeErrorMessage('AWS key AKIAIOSFODNN7EXAMPLE denied')).toContain('[REDACTED]');
+    expect(sanitizeErrorMessage('Authorization: Bearer eyJhbGciOi.JIUzI1.NiIs')).toContain(
+      '[REDACTED]'
+    );
+  });
+
+  it('leaves benign messages untouched', () => {
+    expect(sanitizeErrorMessage('connection timed out after 30s')).toBe(
+      'connection timed out after 30s'
+    );
+    expect(sanitizeErrorMessage(undefined)).toBeUndefined();
+  });
+});
 
 // ============================================================================
 // Mocks

--- a/packages/nexus-agents/src/learning/outcome-storage.ts
+++ b/packages/nexus-agents/src/learning/outcome-storage.ts
@@ -47,15 +47,23 @@ import {
 /** Maximum length for persisted error messages. Truncates to prevent data leakage. */
 const MAX_ERROR_MESSAGE_LENGTH = 200;
 
-/** Sensitive patterns to redact from error messages before persisting. */
+/**
+ * Sensitive patterns to redact from error messages before persisting. Covers
+ * OpenAI/Anthropic-style `sk-…`, GitHub PATs (`ghp_/gho_/ghu_/ghs_/github_pat_`),
+ * AWS access keys (`AKIA…`), space-separated `Bearer <token>`, and the generic
+ * `keyword[=:]value` form. Each alternative is linear (no nested quantifiers) so
+ * the global match stays ReDoS-safe over untrusted-ish error strings.
+ */
 const SENSITIVE_PATTERNS =
-  /(?:sk-[a-zA-Z0-9]{20,}|(?:api[_-]?key|token|secret|password|auth)[=:]\s*\S+)/gi;
+  /(?:sk-[a-zA-Z0-9]{20,}|gh[posu]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|bearer\s+\S+|(?:api[_-]?key|token|secret|password|auth)[=:]\s*\S+)/gi;
 
 /**
  * Sanitizes error messages before persisting to SQLite.
  * Truncates to MAX_ERROR_MESSAGE_LENGTH and redacts potential secrets.
+ * Exported for unit-testing the redaction coverage (the patterns are
+ * security-relevant — a missed credential format would persist a secret).
  */
-function sanitizeErrorMessage(msg: string | undefined): string | undefined {
+export function sanitizeErrorMessage(msg: string | undefined): string | undefined {
   if (msg === undefined) return undefined;
   const redacted = msg.replace(SENSITIVE_PATTERNS, '[REDACTED]');
   return redacted.length > MAX_ERROR_MESSAGE_LENGTH


### PR DESCRIPTION
Two fixes from the 2026-06-21 QA/security sweep, both in `nexus-agents`.

## #4018 — typed-memory invalidation silently fails (HIGH)
**Closes #4018.** `TypedMemory.invalidateFact` set `validUntil = now()`, then `storeFact` computed `ttl = validUntil − now() ≤ 0`. `MemoryMetadataSchema` requires `ttl: positive()`, so `store()` returned `err('Invalid metadata')` — the fact was **never invalidated** and the caller got a spurious error. Same root hit `storeFact`/`KnowledgeVault.store` for any past `validUntil`/`expiresAt`.

**Fix:** clamp `ttl` to `Math.max(1, delta)` at both computation sites. Since `IMemoryBackend` has no `delete` and `ttl` → `expiresAt = now + ttl` (auto-expired on retrieve), a 1ms ttl expires the entry on the next retrieve — the closest to immediate invalidation available. Tests assert the clamped ttl reaching the backend is ≥1 (the property the real schema requires; the mock backend ignored ttl, which is why the existing test never caught it).

## Secret-redaction hardening (CWE-532)
The outcome-store's `sanitizeErrorMessage` redacted `sk-…` and `keyword=value` but **missed** GitHub PATs (`ghp_/gho_/ghu_/ghs_/github_pat_`), AWS keys (`AKIA…`), and space-separated `Bearer <token>` before persisting `error_message` to SQLite. Extended the pattern set (all alternatives linear → ReDoS-safe) and exported the helper for a focused redaction test. (Reported privately during the sweep; the fix is benign hardening, not a disclosed exploit.)

## Tests
88 tests pass across typed-memory + outcome-storage (incl. new ttl-clamp and redaction cases); lint + `tsc --noEmit` clean.

## Scope note
#4021 (nexus-memory backend `write(key, undefined)` parity) is a separate package and ships in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)