### PR TITLE
fix(memory): reject write(key, undefined) uniformly across backends (#4021)

### DIFF
--- a/.changeset/fix-4021-backend-undefined-parity.md
+++ b/.changeset/fix-4021-backend-undefined-parity.md
@@ -1,0 +1,7 @@
+---
+'nexus-memory': patch
+---
+
+Reject `write(key, undefined)` uniformly across backends (#4021)
+
+`InMemoryBackend` and `SqliteBackend` diverged on `write(key, undefined)`: the in-memory backend stored a phantom row (a later `read` looked like a miss but `count`/`query` included it) while the SQLite backend threw a cryptic NOT NULL bind error. Both `validate()` methods now reject `undefined` up front (before the optional schema check) with a clear `MemoryValidationError` — `undefined` is the missing-key sentinel `read` returns; callers wanting an explicit absent value use `null`. The shared backend contract test now asserts uniform rejection. Found in the 2026-06-21 QA/security sweep.

--- a/packages/nexus-memory/src/backends/contract.test.ts
+++ b/packages/nexus-memory/src/backends/contract.test.ts
@@ -71,6 +71,18 @@ for (const [name, factory] of factories) {
       expect(await backend.read('k1')).toEqual({ text: 'hello', count: 1 });
     });
 
+    // #4021: both backends must REJECT write(key, undefined) identically. Before
+    // the fix, InMemoryBackend stored a phantom row while SqliteBackend threw a
+    // cryptic NOT NULL bind error — a contract divergence. Now both throw
+    // MemoryValidationError, and the key stays absent.
+    it('rejects write(key, undefined) uniformly and stores nothing', async () => {
+      // Cast through unknown to exercise the runtime undefined-guard (the type
+      // forbids undefined, but a caller bug or untyped JS path can still reach it).
+      const undefinedValue = undefined as unknown as SamplePayload;
+      await expect(backend.write('k-undef', undefinedValue)).rejects.toThrow(MemoryValidationError);
+      expect(await backend.read('k-undef')).toBeUndefined();
+    });
+
     it('write upserts on existing key', async () => {
       await backend.write('k1', { text: 'first', count: 1 });
       await backend.write('k1', { text: 'second', count: 2 });

--- a/packages/nexus-memory/src/backends/memory.ts
+++ b/packages/nexus-memory/src/backends/memory.ts
@@ -107,6 +107,14 @@ export class InMemoryBackend<TKey, TValue> implements IMemoryBackend<TKey, TValu
   }
 
   private validate(value: TValue): void {
+    // #4021: reject `undefined` uniformly (before the optional schema check) so
+    // both backends behave identically. Previously this backend stored a phantom
+    // row for `write(key, undefined)` while SqliteBackend threw a cryptic NOT NULL
+    // bind error — a contract divergence. `undefined` is the missing-key sentinel
+    // `read` returns; an explicit `undefined` write is a caller bug — use `null`.
+    if (value === undefined) {
+      throw new MemoryValidationError(this.domain, 'value must not be undefined (use null)');
+    }
     if (this.schema === undefined) return;
     const result = this.schema.safeParse(value);
     if (!result.success) {

--- a/packages/nexus-memory/src/backends/sqlite.ts
+++ b/packages/nexus-memory/src/backends/sqlite.ts
@@ -194,6 +194,14 @@ export class SqliteBackend<TKey, TValue> implements IMemoryBackend<TKey, TValue>
   }
 
   private validate(value: TValue): void {
+    // #4021: reject `undefined` uniformly (before the optional schema check) so
+    // both backends behave identically. Previously SqliteBackend threw a cryptic
+    // NOT NULL bind error for `write(key, undefined)` while InMemoryBackend stored
+    // a phantom row. `undefined` is the missing-key sentinel; use `null` for an
+    // explicit absent value.
+    if (value === undefined) {
+      throw new MemoryValidationError(this.domain, 'value must not be undefined (use null)');
+    }
     if (this.schema === undefined) return;
     const result = this.schema.safeParse(value);
     if (!result.success) {


### PR DESCRIPTION
Closes #4021. Last item from the 2026-06-21 QA/security sweep.

## Bug
`InMemoryBackend` and `SqliteBackend` diverged on `write(key, undefined)`:
- **in-memory** stored a phantom row (a later `read` returned `undefined` looking like a miss, but `count`/`query` counted it),
- **SQLite** threw a cryptic NOT NULL bind error (`JSON.stringify(undefined)` → `undefined` → bound to a NOT NULL column).

Both `validate()` methods early-returned when no schema was supplied, so neither caught `undefined`.

## Fix
Both backends' `validate()` now reject `undefined` up front (before the optional schema check) with a clear `MemoryValidationError`. `undefined` is the missing-key sentinel `read` returns; a caller wanting an explicit absent value uses `null`. The shared backend **contract test** now asserts both backends reject `write(key, undefined)` identically and store nothing.

## Tests
nexus-memory backend + contract tests pass (38); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)