### PR TITLE
feat(governance): pr_review records bind to reviewed diff, not headSha (#3831 Option-C)

### DIFF
--- a/.changeset/3831-pr-review-option-c-binding.md
+++ b/.changeset/3831-pr-review-option-c-binding.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+pr_review records bind to the reviewed DIFF, not headSha (#3831 Option-C)
+
+Migrates the authority `PrReviewRecord` schema (1.0 → 1.1) and the governor-path gate (`scripts/check-governor-review.ts`) from the rejected `headSha` binding to the ratified Option-C `{prNumber, baseSha, reviewedDiffHash}`. `reviewedDiffHash` is the sha256 of the canonical reviewed diff — a single shared `audit/reviewed-diff-hash.ts` pins the exact `git diff` invocation (algorithm/context/prefixes/autocrlf, two-dot range) + a 50k byte-boundary truncation so the producer and the gate cannot drift (proven by a cross-environment, hostile-gitconfig test). The gate now recomputes `reviewedDiffHash` from the committed PR's `base..head` and matches it; a record bound to a different diff does not satisfy the gate. The gate STAYS warn-first (no fail-closed flip). The committed `governance/pr-review-records.jsonl` ledger is empty on every install, so the schema bump needs no data migration. Ratified 7/0 (higher_order). The producer that writes these records is a tracked follow-up.

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -47,8 +47,10 @@ const MAX_SUMMARY_RECORD_CHARS = 500;
 /** Inputs for {@link buildPrReviewRecord} — the finalized review data. */
 export interface BuildPrReviewRecordInput {
   readonly prNumber: number;
-  /** The 40-hex head commit SHA the review was run against (sha-binding). */
-  readonly headSha: string;
+  /** The 40-hex BASE commit SHA the reviewed diff range was computed from (Option-C). */
+  readonly baseSha: string;
+  /** sha256 of the canonical reviewed diff (`audit/reviewed-diff-hash.ts`) — diff-binding. */
+  readonly reviewedDiffHash: string;
   readonly verdict: PrReviewVerdict;
   readonly verified: boolean;
   readonly voteCounts: PrReviewVoteCounts;
@@ -70,9 +72,9 @@ export interface BuildPrReviewRecordInput {
 /**
  * Construct a fully self-hashed {@link PrReviewRecord} from a completed review.
  * Pure (no I/O) so it is unit-testable and reusable by the gate seam and the
- * future producer. The self-hash covers `prNumber`/`headSha`/`verdict`/`sequence`
- * (the sha-binding, condition 1) but EXCLUDES `previousHash`. The summary is
- * stored truncated.
+ * future producer. The self-hash covers `prNumber`/`baseSha`/`reviewedDiffHash`/
+ * `verdict`/`sequence` (the diff-binding, Option-C) but EXCLUDES `previousHash`.
+ * The summary is stored truncated.
  */
 export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRecord {
   const summaryTruncated =
@@ -80,10 +82,11 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
       ? input.summary.slice(0, MAX_SUMMARY_RECORD_CHARS) + '...'
       : input.summary;
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.0',
+    version: '1.1',
     sequence: input.sequence ?? 0,
     prNumber: input.prNumber,
-    headSha: input.headSha,
+    baseSha: input.baseSha,
+    reviewedDiffHash: input.reviewedDiffHash,
     recordedAt: input.recordedAt ?? new Date().toISOString(),
     verdict: input.verdict,
     verified: input.verified,

--- a/packages/nexus-agents/src/audit/pr-review-record.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for the pr-review TAMPER-EVIDENT, SHA-BOUND RECORD SET (#3831, Epic B).
- * Mirrors the vote-record tests (#3927). Core properties:
- *  - the self-hash covers the full payload INCLUDING prNumber + headSha + verdict
- *    (the sha-binding, condition 1), so editing any of them is a `hash_mismatch`;
+ * Tests for the pr-review TAMPER-EVIDENT, DIFF-BOUND RECORD SET (#3831, Epic B,
+ * Option-C binding). Mirrors the vote-record tests (#3927). Core properties:
+ *  - the self-hash covers the full payload INCLUDING prNumber + baseSha +
+ *    reviewedDiffHash + verdict (the diff-binding), so editing any is a `hash_mismatch`;
  *  - the ledger is a SET, not a chain: order does not matter, concurrent forks
  *    (duplicate sequences) are benign, omission shows up as a `sequence_gap`;
  *  - `buildPrReviewRecord` produces a record that verifies.
@@ -18,6 +18,8 @@ import { buildPrReviewRecord } from './pr-review-record-store.js';
 
 const SHA_A = 'a'.repeat(40);
 const SHA_B = 'b'.repeat(40);
+const DIFF_HASH_A = 'c'.repeat(64);
+const DIFF_HASH_B = 'd'.repeat(64);
 
 /**
  * Build a self-hashed record at `sequence`. `previousHash` is advisory (NOT
@@ -29,10 +31,11 @@ function makeRecord(
   overrides: Partial<Omit<PrReviewRecord, 'hash'>> = {}
 ): PrReviewRecord {
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.0',
+    version: '1.1',
     sequence,
     prNumber,
-    headSha: SHA_A,
+    baseSha: SHA_A,
+    reviewedDiffHash: DIFF_HASH_A,
     recordedAt: '2026-06-15T00:00:00.000Z',
     verdict: 'approve',
     verified: false,
@@ -69,10 +72,18 @@ describe('verifyPrReviewRecordSet (#3831)', () => {
     if (!result.ok) expect(result.reason).toBe('hash_mismatch');
   });
 
-  it('DETECTS an edited headSha as hash_mismatch (sha-binding)', () => {
+  it('DETECTS an edited reviewedDiffHash as hash_mismatch (diff-binding)', () => {
     const rec = makeRecord(100, 0);
-    // Swap the reviewed sha without recomputing the hash → tamper evidence.
-    const tampered: PrReviewRecord = { ...rec, headSha: SHA_B };
+    // Swap the reviewed-diff hash without recomputing the self-hash → tamper.
+    const tampered: PrReviewRecord = { ...rec, reviewedDiffHash: DIFF_HASH_B };
+    const result = verifyPrReviewRecordSet([tampered]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('hash_mismatch');
+  });
+
+  it('DETECTS an edited baseSha as hash_mismatch (diff-binding)', () => {
+    const rec = makeRecord(100, 0);
+    const tampered: PrReviewRecord = { ...rec, baseSha: SHA_B };
     const result = verifyPrReviewRecordSet([tampered]);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('hash_mismatch');
@@ -104,10 +115,11 @@ describe('verifyPrReviewRecordSet (#3831)', () => {
 });
 
 describe('buildPrReviewRecord (#3831)', () => {
-  it('produces a record that verifies and binds the head sha', () => {
+  it('produces a record that verifies and binds the reviewed diff', () => {
     const rec = buildPrReviewRecord({
       prNumber: 4242,
-      headSha: SHA_B,
+      baseSha: SHA_B,
+      reviewedDiffHash: DIFF_HASH_B,
       verdict: 'request_changes',
       verified: true,
       voteCounts: { approve: 1, request_changes: 3, abstain: 1, error: 0, total: 5 },
@@ -115,7 +127,8 @@ describe('buildPrReviewRecord (#3831)', () => {
       sequence: 0,
       recordedAt: '2026-06-15T00:00:00.000Z',
     });
-    expect(rec.headSha).toBe(SHA_B);
+    expect(rec.baseSha).toBe(SHA_B);
+    expect(rec.reviewedDiffHash).toBe(DIFF_HASH_B);
     expect(rec.verdict).toBe('request_changes');
     expect(verifyPrReviewRecordSet([rec]).ok).toBe(true);
   });
@@ -124,7 +137,8 @@ describe('buildPrReviewRecord (#3831)', () => {
     const long = 'x'.repeat(2000);
     const rec = buildPrReviewRecord({
       prNumber: 1,
-      headSha: SHA_A,
+      baseSha: SHA_A,
+      reviewedDiffHash: DIFF_HASH_A,
       verdict: 'approve',
       verified: false,
       voteCounts: { approve: 1, request_changes: 0, abstain: 0, error: 0, total: 1 },

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -6,7 +6,7 @@
  * over a GOVERNOR-PATH PR, persisted so a WARN-FIRST CI gate
  * (`scripts/check-governor-review.ts`, #3831) can assert that a PR touching the
  * governor's own paths (the /CODEOWNERS governance-of-the-governor list) carries
- * a recorded, SHA-BOUND review before merge — without the gate re-executing the
+ * a recorded, DIFF-BOUND review before merge — without the gate re-executing the
  * review (it QUERIES the ledger; pr_review is never re-run in the gate).
  *
  * MODEL: TAMPER-EVIDENT RECORD SET + MONOTONIC SEQUENCE. This MIRRORS the
@@ -38,8 +38,9 @@
  * `metadata`, so riding a metadata payload would leave the verdict OUTSIDE the
  * hash — an attacker could flip `request_changes`→`approve` without breaking any
  * hash. This record instead folds EVERY authenticity-bearing field (the PR
- * number, the head sha, the verdict, the verified flag, the vote counts, and the
- * `sequence`) into the self-hash, so editing any of them is a `hash_mismatch`.
+ * number, the base sha, the reviewed-diff hash, the verdict, the verified flag,
+ * the vote counts, and the `sequence`) into the self-hash, so editing any of them
+ * is a `hash_mismatch`.
  * Cryptographic signing/provenance is DEFERRED (mirrors the #3897 follow-up).
  *
  * @module audit/pr-review-record
@@ -146,7 +147,7 @@ type PrReviewRecordPayload = Omit<PrReviewRecord, 'hash'>;
 /**
  * Compute the SHA-256 over the canonical payload projection. Folds in EVERY
  * authenticity-bearing field — crucially `prNumber`, `baseSha`, `reviewedDiffHash`, and `verdict`
- * (the sha-binding, condition 1) plus the monotonic `sequence` — but EXCLUDES
+ * (the diff-binding, Option-C) plus the monotonic `sequence` — but EXCLUDES
  * `previousHash`, so the hash is position-independent and stable across
  * concurrent-branch merges and file reorders. Built field-by-field (not
  * `JSON.stringify(record)`) so key-order is deterministic regardless of how the

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -22,12 +22,15 @@
  * participate in verification. Omission is detected via SEQUENCE GAPS; concurrent
  * forks (two records sharing a sequence) are a BENIGN signal, not a failure.
  *
- * SHA-BINDING (condition 1 of the #3831 ratification). The self-`hash` covers
- * `prNumber` + **`headSha`** + `verdict` + the review summary content. Binding
- * the record to the exact `headSha` it reviewed is what makes the gate NOT
- * theater: a record produced against a STALE head sha does NOT satisfy a later
- * push (the gate matches `prNumber` AND `headSha`), and the record's content
- * cannot be edited to claim a different sha/verdict without breaking the hash.
+ * DIFF-BINDING (Option-C, #3831 ratification). The self-`hash` covers
+ * `prNumber` + **`baseSha`** + **`reviewedDiffHash`** + `verdict` + the review
+ * summary content. Binding the record to the exact reviewed DIFF is what makes the
+ * gate NOT theater: a record produced against a different diff does NOT satisfy a
+ * later push (the gate matches `prNumber` AND recomputes `reviewedDiffHash` from
+ * the committed PR's canonical diff), and the record's content cannot be edited to
+ * claim a different diff/verdict without breaking the hash. This replaces the
+ * rejected `headSha` binding (a head pointer is mutable; the reviewed bytes are
+ * what the voters actually saw).
  *
  * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
  * As in #3897/#3927: the audit-event chain (`computeEventHash` in
@@ -67,7 +70,7 @@ export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
 
 /**
  * One authentic, self-hashed pr-review record. The `hash` covers every
- * authenticity field INCLUDING `prNumber`, `headSha`, `verdict`, and `sequence`
+ * authenticity field INCLUDING `prNumber`, `baseSha`, `reviewedDiffHash`, `verdict`, and `sequence`
  * but EXCLUDING `previousHash`, so the record is tamper-EVIDENT and
  * POSITION-INDEPENDENT: any edit to a persisted line is detected by
  * {@link verifyPrReviewRecordSet} as a `hash_mismatch`, while reordering file
@@ -75,8 +78,14 @@ export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
  */
 export const PrReviewRecordSchema = z
   .object({
-    /** Schema version. '1.0' is the initial record-set+sequence model (#3831). */
-    version: z.literal('1.0'),
+    /**
+     * Schema version. '1.1' is the Option-C binding (#3831): the record binds to
+     * `{prNumber, baseSha, reviewedDiffHash}` instead of the rejected `headSha`.
+     * Clean break — the committed `governance/pr-review-records.jsonl` ledger is
+     * empty on every install (no producer ever wrote a '1.0' record), so there is
+     * no '1.0' data to migrate.
+     */
+    version: z.literal('1.1'),
     /**
      * Monotonic sequence number (integer ≥ 0). Assigned as (max existing
      * sequence)+1 at write time. Sorted, the set of sequences must cover
@@ -87,12 +96,22 @@ export const PrReviewRecordSchema = z
     /** The PR number the review covers. */
     prNumber: z.number().int().positive(),
     /**
-     * The 40-hex head commit SHA the review was run against. SHA-BINDING
-     * (condition 1): the gate matches THIS sha — a record for a stale head does
-     * NOT satisfy a later push, and the hash below covers it so it cannot be
-     * edited to claim a different reviewed sha.
+     * The 40-hex BASE commit SHA the reviewed diff was computed against (the
+     * `<base>..<head>` range base). Part of the Option-C binding so the gate knows
+     * which range to recompute {@link reviewedDiffHash} over.
      */
-    headSha: z.string().regex(/^[0-9a-f]{40}$/, 'headSha must be a 40-char lowercase hex commit sha'),
+    baseSha: z
+      .string()
+      .regex(/^[0-9a-f]{40}$/, 'baseSha must be a 40-char lowercase hex commit sha'),
+    /**
+     * DIFF-BINDING (Option-C, #3831): sha256 of the canonical reviewed diff bytes
+     * (see `audit/reviewed-diff-hash.ts` — pinned `git diff` invocation + 50k
+     * byte-truncation). The gate recomputes this from the committed PR's diff and
+     * matches it, so a record only satisfies a PR whose reviewed diff is
+     * byte-identical to what the voters saw. Covered by the self-hash below, so it
+     * cannot be edited to claim a different reviewed diff.
+     */
+    reviewedDiffHash: z.string().length(64),
     /** ISO-8601 timestamp the review was recorded. */
     recordedAt: z.string().min(1),
     /** The resolved aggregate verdict. */
@@ -126,7 +145,7 @@ type PrReviewRecordPayload = Omit<PrReviewRecord, 'hash'>;
 
 /**
  * Compute the SHA-256 over the canonical payload projection. Folds in EVERY
- * authenticity-bearing field — crucially `prNumber`, `headSha`, and `verdict`
+ * authenticity-bearing field — crucially `prNumber`, `baseSha`, `reviewedDiffHash`, and `verdict`
  * (the sha-binding, condition 1) plus the monotonic `sequence` — but EXCLUDES
  * `previousHash`, so the hash is position-independent and stable across
  * concurrent-branch merges and file reorders. Built field-by-field (not
@@ -140,7 +159,8 @@ export function computePrReviewRecordHash(payload: PrReviewRecordPayload): strin
     version: payload.version,
     sequence: payload.sequence,
     prNumber: payload.prNumber,
-    headSha: payload.headSha,
+    baseSha: payload.baseSha,
+    reviewedDiffHash: payload.reviewedDiffHash,
     recordedAt: payload.recordedAt,
     verdict: payload.verdict,
     verified: payload.verified,
@@ -242,7 +262,7 @@ function forkSequences({ counts }: SequenceCensus): number[] {
 /**
  * Verify a tamper-evident SET of pr-review records (mirrors
  * {@link verifyVoteRecordSet}, #3927). For each record, the self-hash must
- * recompute from its payload (covers `prNumber`/`headSha`/`verdict`/`sequence`,
+ * recompute from its payload (covers `prNumber`/`baseSha`/`reviewedDiffHash`/`verdict`/`sequence`,
  * excludes `previousHash`). Order of the array does NOT matter — it is a set, not
  * a chain. Semantics:
  *

--- a/packages/nexus-agents/src/audit/reviewed-diff-hash.test.ts
+++ b/packages/nexus-agents/src/audit/reviewed-diff-hash.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the canonical reviewed-diff hash (#3831 Option-C binding).
+ *
+ * The load-bearing test (panel condition A): the canonical `git diff` invocation
+ * must produce BYTE-IDENTICAL output regardless of the host's local gitconfig, so
+ * the producer's `reviewedDiffHash` and the gate's recomputation cannot drift.
+ * This exercises a REAL git repo with HOSTILE config (not a shared in-process
+ * helper) — per the Contrarian's "a same-helper test is theater".
+ *
+ * @module audit/reviewed-diff-hash.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  computeReviewedDiffHash,
+  reviewedDiffWasTruncated,
+  canonicalGitDiffArgs,
+  MAX_REVIEWED_DIFF_BYTES,
+} from './reviewed-diff-hash.js';
+
+describe('computeReviewedDiffHash', () => {
+  it('is deterministic for the same bytes', () => {
+    const diff = 'diff --git a/x b/x\n+hello\n';
+    expect(computeReviewedDiffHash(diff)).toBe(computeReviewedDiffHash(diff));
+    expect(computeReviewedDiffHash(diff)).toHaveLength(64);
+  });
+
+  it('binds only the first MAX_REVIEWED_DIFF_BYTES (content past the cap is unbound)', () => {
+    const head = 'A'.repeat(MAX_REVIEWED_DIFF_BYTES);
+    // Two diffs that share the first 50k bytes but differ after → same hash.
+    expect(computeReviewedDiffHash(head + 'tailX')).toBe(computeReviewedDiffHash(head + 'tailY'));
+    // A change WITHIN the cap flips the hash.
+    expect(computeReviewedDiffHash(head)).not.toBe(computeReviewedDiffHash('B' + head.slice(1)));
+  });
+
+  it('truncates on a byte boundary (multibyte-safe, no throw)', () => {
+    const multibyte = '€'.repeat(MAX_REVIEWED_DIFF_BYTES); // 3 bytes each → well over cap
+    expect(() => computeReviewedDiffHash(multibyte)).not.toThrow();
+    expect(computeReviewedDiffHash(multibyte)).toHaveLength(64);
+  });
+
+  it('reviewedDiffWasTruncated flags over-cap diffs by byte length', () => {
+    expect(reviewedDiffWasTruncated('a'.repeat(MAX_REVIEWED_DIFF_BYTES))).toBe(false);
+    expect(reviewedDiffWasTruncated('a'.repeat(MAX_REVIEWED_DIFF_BYTES + 1))).toBe(true);
+    // 2-byte chars: 25_001 of them = 50_002 bytes > cap.
+    expect(reviewedDiffWasTruncated('é'.repeat(MAX_REVIEWED_DIFF_BYTES / 2 + 1))).toBe(true);
+  });
+});
+
+describe('canonical git diff is config-invariant (panel condition A — cross-env)', () => {
+  let repo: string;
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, {
+      cwd: repo,
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'reviewed-diff-git-'));
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    writeFileSync(join(repo, 'f.txt'), 'line1\nline2\nline3\nline4\nline5\n');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'base']);
+    writeFileSync(join(repo, 'f.txt'), 'line1\nline2\nCHANGED\nline4\nline5\nline6\n');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'head']);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('produces an identical hash under hostile, differing local gitconfig', () => {
+    const base = git(['rev-parse', 'HEAD~1']).trim();
+    const head = git(['rev-parse', 'HEAD']).trim();
+
+    // Config set A — non-default context, patience algorithm, mnemonic prefixes.
+    git(['config', 'diff.context', '9']);
+    git(['config', 'diff.algorithm', 'patience']);
+    git(['config', 'diff.mnemonicPrefix', 'true']);
+    git(['config', 'core.autocrlf', 'true']);
+    const diffA = git(canonicalGitDiffArgs(base, head));
+    const hashA = computeReviewedDiffHash(diffA);
+
+    // Config set B — different hostile values. The pinned `-c` overrides + flags
+    // in canonicalGitDiffArgs must neutralize BOTH.
+    git(['config', 'diff.context', '1']);
+    git(['config', 'diff.algorithm', 'histogram']);
+    git(['config', 'diff.noprefix', 'true']);
+    const diffB = git(canonicalGitDiffArgs(base, head));
+    const hashB = computeReviewedDiffHash(diffB);
+
+    expect(diffA).toBe(diffB); // byte-identical output
+    expect(hashA).toBe(hashB); // therefore identical hash
+    expect(hashA).toHaveLength(64);
+  });
+
+  it('producer-side and gate-side compute the SAME hash for the reviewed diff', () => {
+    const base = git(['rev-parse', 'HEAD~1']).trim();
+    const head = git(['rev-parse', 'HEAD']).trim();
+    // "Producer side": the diff text handed to the pr_review tool (produced via the
+    // canonical invocation, per the binding contract).
+    const reviewedDiff = git(canonicalGitDiffArgs(base, head));
+    const producerHash = computeReviewedDiffHash(reviewedDiff);
+    // "Gate side": recompute from raw SHAs in CI via the same canonical invocation.
+    const gateHash = computeReviewedDiffHash(git(canonicalGitDiffArgs(base, head)));
+    expect(producerHash).toBe(gateHash);
+  });
+});

--- a/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
+++ b/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical reviewed-diff hashing for the Option-C pr_review binding (#3831).
+ *
+ * The authority `pr_review` record binds to `{prNumber, baseSha, reviewedDiffHash}`
+ * (replacing the rejected `headSha` binding). `reviewedDiffHash` must be computed
+ * BYTE-IDENTICALLY by the producer (over the diff the voters reviewed) and the
+ * governor gate (`scripts/check-governor-review.ts`, which recomputes it from the
+ * committed PR's diff). This module is the single shared definition so the two
+ * sides cannot drift.
+ *
+ * CANONICAL FORM (the binding contract — pinned per the #3831 ratification panel):
+ *  1. The diff bytes are produced by the EXACT git invocation
+ *     {@link CANONICAL_GIT_DIFF_ARGS} (pinned config so the bytes are stable across
+ *     git versions / local gitconfig). The gate runs this; the producer is handed
+ *     the same bytes (the pr_review tool reviews exactly this diff).
+ *  2. The UTF-8 bytes are truncated to {@link MAX_REVIEWED_DIFF_BYTES} at a BYTE
+ *     boundary (NOT a codepoint boundary — both sides truncate identically).
+ *  3. `sha256(truncatedBytes)` hex.
+ *
+ * KNOWN LIMITATION (#3831 condition B): because the truncation is part of the
+ * canonical form, content past {@link MAX_REVIEWED_DIFF_BYTES} is UNBOUND — two
+ * diffs sharing the first 50k bytes hash identically. The voters only saw the
+ * first 50k, so binding to that is the honest contract, but a record cannot attest
+ * anything beyond the cap. Producers MUST surface {@link reviewedDiffWasTruncated}
+ * so an over-cap review is visible.
+ *
+ * @module audit/reviewed-diff-hash
+ */
+
+import * as crypto from 'node:crypto';
+
+/**
+ * Max reviewed-diff size folded into the canonical hash, in BYTES (UTF-8). Mirrors
+ * the pr_review tool's `MAX_DIFF_LENGTH` review cap — the voters never see past it,
+ * so the binding cannot honestly attest past it either (#3831 condition B).
+ */
+export const MAX_REVIEWED_DIFF_BYTES = 50_000;
+
+/**
+ * The pinned `git diff` argument vector that defines the canonical reviewed-diff
+ * bytes. Both the gate (which runs git) and any producer that recomputes locally
+ * MUST use these exact args so the output is byte-stable regardless of the host's
+ * git version or `~/.gitconfig`:
+ *  - `-c core.autocrlf=false` — never rewrite line endings.
+ *  - `-c diff.algorithm=myers` — pin the diff algorithm (patience/histogram/minimal
+ *    via local config would change the bytes).
+ *  - `-c diff.mnemonicprefix=false` / `-c diff.noprefix=false` — keep the default
+ *    `a/`,`b/` prefixes regardless of local config.
+ *  - `--no-color` / `--no-ext-diff` — no ANSI, no external differ.
+ *  - `--no-renames` — rename detection output is config/version-sensitive; off.
+ *  - `-U3` — pin the context-line count (git default is 3, but it is configurable).
+ *  - `<base>..<head>` — TWO-DOT range (base→head), NOT three-dot/merge-base.
+ * Caller appends the `<base>..<head>` range as the final element.
+ */
+export const CANONICAL_GIT_DIFF_ARGS: readonly string[] = Object.freeze([
+  '-c',
+  'core.autocrlf=false',
+  '-c',
+  'diff.algorithm=myers',
+  '-c',
+  'diff.mnemonicprefix=false',
+  '-c',
+  'diff.noprefix=false',
+  'diff',
+  '--no-color',
+  '--no-ext-diff',
+  '--no-renames',
+  '-U3',
+]);
+
+/** Build the full canonical `git` argv for a base..head range (two-dot). */
+export function canonicalGitDiffArgs(baseSha: string, headSha: string): string[] {
+  return [...CANONICAL_GIT_DIFF_ARGS, `${baseSha}..${headSha}`];
+}
+
+/**
+ * Compute the canonical `reviewedDiffHash` over a reviewed-diff string. Truncates
+ * the UTF-8 bytes to {@link MAX_REVIEWED_DIFF_BYTES} at a BYTE boundary, then
+ * sha256. The SAME function is called by the producer (over the diff the tool
+ * reviewed) and the gate (over {@link canonicalGitDiffArgs} output) so the hash
+ * reproduces iff the committed PR's canonical diff is byte-identical to what was
+ * reviewed.
+ */
+export function computeReviewedDiffHash(diff: string): string {
+  const bytes = Buffer.from(diff, 'utf-8');
+  const truncated =
+    bytes.byteLength > MAX_REVIEWED_DIFF_BYTES ? bytes.subarray(0, MAX_REVIEWED_DIFF_BYTES) : bytes;
+  return crypto.createHash('sha256').update(truncated).digest('hex');
+}
+
+/**
+ * Whether the reviewed diff exceeds the canonical cap (so the hash binds only the
+ * first {@link MAX_REVIEWED_DIFF_BYTES} bytes). Producers SHOULD log/warn when true
+ * (#3831 condition B) so an over-cap review is observable.
+ */
+export function reviewedDiffWasTruncated(diff: string): boolean {
+  return Buffer.byteLength(diff, 'utf-8') > MAX_REVIEWED_DIFF_BYTES;
+}

--- a/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
+++ b/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
@@ -1,3 +1,6 @@
+// @export-no-consumer-yet — see #3831. Consumed today by the governor gate
+// (scripts/check-governor-review.ts, outside src/); the in-src/ consumer is the
+// recordAuthenticPrReview producer, the tracked #3831 follow-up.
 /**
  * Canonical reviewed-diff hashing for the Option-C pr_review binding (#3831).
  *

--- a/scripts/check-governor-review.test.ts
+++ b/scripts/check-governor-review.test.ts
@@ -2,10 +2,10 @@
  * Tests for the warn-first governor-path pr_review audit gate (#3831, Epic B).
  *
  * Proves the binding-condition behaviors:
- *  (a) a valid sha-bound record for the PR → PASS;
+ *  (a) a valid diff-bound record for the PR → PASS;
  *  (b) NO record → WARN (not fail) — warn-first;
- *  (c) NEGATIVE: a record with the WRONG/stale headSha → NOT accepted (still
- *      WARN), proving the gate is not theater (condition 1, mandatory);
+ *  (c) NEGATIVE: a record bound to a DIFFERENT reviewed diff → NOT accepted (still
+ *      WARN), proving the gate is not theater (Option-C diff-binding, mandatory);
  *  (d) a tampered record set (bad self-hash / sequence gap) → FAIL CLOSED;
  *  (e) genesis-exempt PR → PASS;
  *  (f) non-governor-path PR → PASS without needing a record.
@@ -35,6 +35,18 @@ import {
 
 const SHA_HEAD = 'a'.repeat(40);
 const SHA_STALE = 'b'.repeat(40);
+const SHA_BASE = 'e'.repeat(40);
+// reviewedDiffHash values (64-hex): DIFF_HASH is the gate-recomputed hash a record
+// must match; DIFF_HASH_STALE is a record bound to a DIFFERENT (changed) diff.
+const DIFF_HASH = 'c'.repeat(64);
+const DIFF_HASH_STALE = 'd'.repeat(64);
+
+/** Restore (or clear) an env var after a test override. `Reflect.deleteProperty`
+ * avoids the `delete obj[key]` dynamic-delete lint rule. */
+function restoreEnv(key: string, prev: string | undefined): void {
+  if (prev === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = prev;
+}
 
 /** A small CODEOWNERS sample carrying both pre-section and governor entries. */
 const CODEOWNERS_SAMPLE = [
@@ -58,7 +70,8 @@ const GOVERNOR_PATTERNS = governorPathsFromCodeowners(CODEOWNERS_SAMPLE);
 function record(overrides: Partial<BuildPrReviewRecordInput> = {}): PrReviewRecord {
   return buildPrReviewRecord({
     prNumber: 5000,
-    headSha: SHA_HEAD,
+    baseSha: SHA_BASE,
+    reviewedDiffHash: DIFF_HASH,
     verdict: 'approve',
     verified: false,
     voteCounts: { approve: 3, request_changes: 0, abstain: 0, error: 0, total: 3 },
@@ -72,7 +85,7 @@ function record(overrides: Partial<BuildPrReviewRecordInput> = {}): PrReviewReco
 function inputs(overrides: Partial<GovernorReviewInputs> = {}): GovernorReviewInputs {
   return {
     prNumber: 5000,
-    headSha: SHA_HEAD,
+    reviewedDiffHash: DIFF_HASH,
     changedFiles: ['packages/nexus-agents/src/audit/audit-logger.ts'],
     governorPatterns: GOVERNOR_PATTERNS,
     records: [],
@@ -115,17 +128,17 @@ describe('matchesCodeownersPattern', () => {
     ).toBe(false);
   });
   it('matches an exact file pattern', () => {
-    expect(matchesCodeownersPattern('scripts/inject-governance.ts', '/scripts/inject-governance.ts')).toBe(
-      true
-    );
-    expect(matchesCodeownersPattern('scripts/inject-other.ts', '/scripts/inject-governance.ts')).toBe(
-      false
-    );
+    expect(
+      matchesCodeownersPattern('scripts/inject-governance.ts', '/scripts/inject-governance.ts')
+    ).toBe(true);
+    expect(
+      matchesCodeownersPattern('scripts/inject-other.ts', '/scripts/inject-governance.ts')
+    ).toBe(false);
   });
   it('matches a glob pattern within a segment', () => {
-    expect(matchesCodeownersPattern('governance/claims-registry.yaml', '/governance/claims-registry.*')).toBe(
-      true
-    );
+    expect(
+      matchesCodeownersPattern('governance/claims-registry.yaml', '/governance/claims-registry.*')
+    ).toBe(true);
   });
   it('isGovernorPath aggregates the pattern set', () => {
     expect(isGovernorPath('CLAUDE.md', GOVERNOR_PATTERNS)).toBe(true);
@@ -143,20 +156,20 @@ describe('analyzeGovernorReview — binding conditions', () => {
     const outcome = analyzeGovernorReview(inputs({ records: [] }));
     expect(outcome.kind).toBe('warn');
     if (outcome.kind === 'warn') {
-      expect(outcome.message).toContain('NO sha-bound pr_review record');
+      expect(outcome.message).toContain('NO diff-bound pr_review record');
       expect(outcome.message).toContain('Warn-first');
     }
   });
 
-  it('(c) NEGATIVE: a record with the WRONG/stale headSha is NOT accepted (still warns)', () => {
-    // Record exists for THIS PR but against a stale head sha → must NOT satisfy.
-    const stale = record({ headSha: SHA_STALE });
+  it('(c) NEGATIVE: a record bound to a DIFFERENT reviewed diff is NOT accepted (still warns)', () => {
+    // Record exists for THIS PR but against a different (changed) diff → must NOT satisfy.
+    const stale = record({ reviewedDiffHash: DIFF_HASH_STALE });
     const outcome = analyzeGovernorReview(inputs({ records: [stale] }));
     expect(outcome.kind).toBe('warn');
     if (outcome.kind === 'warn') {
-      // The warn should call out the stale-sha record explicitly.
-      expect(outcome.message).toContain('STALE head sha');
-      expect(outcome.message).toContain(SHA_STALE);
+      // The warn should call out the different-diff record explicitly.
+      expect(outcome.message).toContain('DIFFERENT reviewed diff');
+      expect(outcome.message).toContain(DIFF_HASH_STALE.slice(0, 12));
     }
   });
 
@@ -211,24 +224,30 @@ describe('genesis parser', () => {
 });
 
 describe('PR context + changed-files resolution', () => {
-  it('reads --pr and --sha from argv', () => {
-    const ctx = resolvePrContext(['--pr', '777', '--sha', SHA_HEAD]);
+  it('reads --pr, --base, and --sha from argv', () => {
+    const ctx = resolvePrContext(['--pr', '777', '--base', SHA_BASE, '--sha', SHA_HEAD]);
     expect(ctx.prNumber).toBe(777);
+    expect(ctx.baseSha).toBe(SHA_BASE);
     expect(ctx.headSha).toBe(SHA_HEAD);
   });
   it('falls back to env vars', () => {
-    const prev = { PR_NUMBER: process.env['PR_NUMBER'], PR_HEAD_SHA: process.env['PR_HEAD_SHA'] };
+    const prev = {
+      PR_NUMBER: process.env['PR_NUMBER'],
+      PR_BASE_SHA: process.env['PR_BASE_SHA'],
+      PR_HEAD_SHA: process.env['PR_HEAD_SHA'],
+    };
     process.env['PR_NUMBER'] = '888';
+    process.env['PR_BASE_SHA'] = SHA_BASE;
     process.env['PR_HEAD_SHA'] = SHA_STALE;
     try {
       const ctx = resolvePrContext([]);
       expect(ctx.prNumber).toBe(888);
+      expect(ctx.baseSha).toBe(SHA_BASE);
       expect(ctx.headSha).toBe(SHA_STALE);
     } finally {
-      if (prev.PR_NUMBER === undefined) delete process.env['PR_NUMBER'];
-      else process.env['PR_NUMBER'] = prev.PR_NUMBER;
-      if (prev.PR_HEAD_SHA === undefined) delete process.env['PR_HEAD_SHA'];
-      else process.env['PR_HEAD_SHA'] = prev.PR_HEAD_SHA;
+      restoreEnv('PR_NUMBER', prev.PR_NUMBER);
+      restoreEnv('PR_BASE_SHA', prev.PR_BASE_SHA);
+      restoreEnv('PR_HEAD_SHA', prev.PR_HEAD_SHA);
     }
   });
   it('parses changed files from a newline/comma list', () => {

--- a/scripts/check-governor-review.test.ts
+++ b/scripts/check-governor-review.test.ts
@@ -147,7 +147,7 @@ describe('matchesCodeownersPattern', () => {
 });
 
 describe('analyzeGovernorReview — binding conditions', () => {
-  it('(a) PASSES with a valid sha-bound record for the PR', () => {
+  it('(a) PASSES with a valid diff-bound record for the PR', () => {
     const outcome = analyzeGovernorReview(inputs({ records: [record()] }));
     expect(outcome.kind).toBe('pass');
   });

--- a/scripts/check-governor-review.ts
+++ b/scripts/check-governor-review.ts
@@ -4,7 +4,7 @@
  *
  * Stage 1: a WARN-FIRST CI gate asserting that a PR touching the GOVERNOR PATHS
  * (the governance-of-the-governor entries in /CODEOWNERS) carries a recorded,
- * SHA-BOUND, tamper-evident `pr_review` audit record before merge. The gate
+ * DIFF-BOUND, tamper-evident `pr_review` audit record before merge. The gate
  * QUERIES the committed ledger (`governance/pr-review-records.jsonl`); it NEVER
  * re-executes pr_review.
  *
@@ -13,13 +13,15 @@
  *     set — a `hash_mismatch` (an edited record) or a `sequence_gap` (a deleted
  *     record) — is TAMPER EVIDENCE; the gate refuses regardless of warn-first.
  *   - RECORD ABSENCE is WARN-FIRST (exit 0 + an actionable message, condition 2).
- *     A governor PR with no matching sha-bound record is WARNED, not blocked, in
+ *     A governor PR with no matching diff-bound record is WARNED, not blocked, in
  *     this stage. Flipping absence to fail-closed is a tracked FOLLOW-ON.
  *
- * SHA-BINDING (condition 1). A record satisfies the gate only when it matches
- * THIS PR's number AND head sha. A record produced against a STALE head sha does
- * NOT count — that is the negative case the test suite proves, and it is what
- * makes the gate not theater.
+ * DIFF-BINDING (Option-C, #3831). A record satisfies the gate only when it matches
+ * THIS PR's number AND `reviewedDiffHash` — the gate recomputes the canonical diff
+ * hash from `base..head` (see `audit/reviewed-diff-hash.ts`) and a record produced
+ * against a DIFFERENT diff does NOT count. That is the negative case the test suite
+ * proves, and it is what makes the gate not theater (a head pointer is mutable; the
+ * reviewed bytes are what the voters actually saw).
  *
  * GENESIS EXEMPTION (condition 5). The introducing PR and pre-convention PRs
  * cannot carry a record (the producer does not exist yet), so an explicit,
@@ -36,6 +38,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
 import { ROOT } from './script-paths.js';
@@ -44,6 +47,10 @@ import {
   verifyPrReviewRecordSet,
   type PrReviewRecord,
 } from '../packages/nexus-agents/src/audit/index.js';
+import {
+  canonicalGitDiffArgs,
+  computeReviewedDiffHash,
+} from '../packages/nexus-agents/src/audit/reviewed-diff-hash.js';
 
 const CODEOWNERS_FILE = join(ROOT, 'CODEOWNERS');
 const PR_REVIEW_RECORDS_FILE = join(ROOT, 'governance/pr-review-records.jsonl');
@@ -168,7 +175,14 @@ export type GovernorReviewOutcome =
 /** Inputs for the pure gate analysis (no disk/process I/O). */
 export interface GovernorReviewInputs {
   readonly prNumber: number;
-  readonly headSha: string;
+  /**
+   * sha256 of the PR's CANONICAL reviewed diff (Option-C, #3831), recomputed by
+   * the impure caller from `git <canonicalGitDiffArgs(baseSha, headSha)>` via
+   * {@link computeReviewedDiffHash}. A record matches only if its `reviewedDiffHash`
+   * equals this — i.e. it reviewed the byte-identical diff. Replaces the rejected
+   * headSha binding.
+   */
+  readonly reviewedDiffHash: string;
   readonly changedFiles: readonly string[];
   readonly governorPatterns: readonly string[];
   readonly records: readonly PrReviewRecord[];
@@ -183,7 +197,7 @@ export interface GovernorReviewInputs {
  *     non-governor PR, because the artifact's integrity is itself governance.
  *  2. No governor path touched → PASS (nothing to assert).
  *  3. Genesis-exempt PR → PASS (condition 5; pre-convention PRs carry no record).
- *  4. A record matching THIS prNumber AND headSha exists → PASS (sha-binding,
+ *  4. A record matching THIS prNumber AND reviewedDiffHash exists → PASS (diff-binding,
  *     condition 1). A stale-sha record does NOT match.
  *  5. Otherwise → WARN (warn-first, condition 2): actionable, non-blocking.
  */
@@ -216,14 +230,14 @@ export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorRev
     };
   }
 
-  // (4) Sha-bound record present? (condition 1 — number AND head sha must match.)
+  // (4) Diff-bound record present? (Option-C — number AND reviewedDiffHash match.)
   const match = inputs.records.find(
-    (r) => r.prNumber === inputs.prNumber && r.headSha === inputs.headSha
+    (r) => r.prNumber === inputs.prNumber && r.reviewedDiffHash === inputs.reviewedDiffHash
   );
   if (match !== undefined) {
     return {
       kind: 'pass',
-      reason: `sha-bound pr_review record found for PR #${String(inputs.prNumber)} @ ${inputs.headSha} (verdict=${match.verdict})`,
+      reason: `diff-bound pr_review record found for PR #${String(inputs.prNumber)} (reviewedDiffHash=${inputs.reviewedDiffHash.slice(0, 12)}…, verdict=${match.verdict})`,
     };
   }
 
@@ -231,14 +245,14 @@ export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorRev
   const staleForPr = inputs.records.filter((r) => r.prNumber === inputs.prNumber);
   const staleNote =
     staleForPr.length > 0
-      ? ` A record EXISTS for this PR but against a STALE head sha ` +
-        `(${staleForPr.map((r) => r.headSha).join(', ')}) — re-run pr_review at the current head.`
+      ? ` A record EXISTS for this PR but against a DIFFERENT reviewed diff ` +
+        `(${staleForPr.map((r) => `${r.reviewedDiffHash.slice(0, 12)}…`).join(', ')}) — the diff changed since review; re-run pr_review at the current head.`
       : '';
   return {
     kind: 'warn',
     message:
       `PR #${String(inputs.prNumber)} touches governor paths ` +
-      `(${touched.join(', ')}) but has NO sha-bound pr_review record for head ${inputs.headSha}.` +
+      `(${touched.join(', ')}) but has NO diff-bound pr_review record for its current diff.` +
       staleNote +
       ` Run pr_review on this PR and commit the resulting record into ` +
       `governance/pr-review-records.jsonl. (Warn-first: not blocking merge in this stage, #3831.)`,
@@ -257,15 +271,40 @@ function parseSha(raw: string | undefined): string | undefined {
   return raw !== undefined && raw.trim() !== '' ? raw.trim() : undefined;
 }
 
-/** Resolve PR number + head sha from CLI args (`--pr`, `--sha`) or CI env. */
+/** Resolve PR number + base/head sha from CLI args (`--pr`, `--base`, `--sha`) or CI env. */
 export function resolvePrContext(argv: readonly string[]): {
   prNumber: number | undefined;
+  baseSha: string | undefined;
   headSha: string | undefined;
 } {
-  const prRaw = readFlag(argv, '--pr') ?? process.env['PR_NUMBER'] ?? process.env['GITHUB_PR_NUMBER'];
+  const prRaw =
+    readFlag(argv, '--pr') ?? process.env['PR_NUMBER'] ?? process.env['GITHUB_PR_NUMBER'];
+  const baseRaw =
+    readFlag(argv, '--base') ?? process.env['PR_BASE_SHA'] ?? process.env['GITHUB_BASE_SHA'];
   const shaRaw =
     readFlag(argv, '--sha') ?? process.env['PR_HEAD_SHA'] ?? process.env['GITHUB_HEAD_SHA'];
-  return { prNumber: parsePrNumber(prRaw), headSha: parseSha(shaRaw) };
+  return { prNumber: parsePrNumber(prRaw), baseSha: parseSha(baseRaw), headSha: parseSha(shaRaw) };
+}
+
+/**
+ * Recompute the canonical {@link computeReviewedDiffHash} of the PR's diff from
+ * raw SHAs (Option-C, #3831) — the gate side of the diff-binding. Runs the pinned
+ * {@link canonicalGitDiffArgs} so the bytes match what the producer hashed.
+ * Returns undefined when git cannot produce the diff (e.g. the base/head commits
+ * are not present in a shallow CI checkout) — the caller treats that as
+ * "cannot verify" → WARN, never a false PASS.
+ */
+function recomputeReviewedDiffHash(baseSha: string, headSha: string): string | undefined {
+  try {
+    const diff = execFileSync('git', canonicalGitDiffArgs(baseSha, headSha), {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return computeReviewedDiffHash(diff);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Read a `--flag value` pair from argv. */
@@ -291,37 +330,75 @@ export function resolveChangedFiles(argv: readonly string[]): string[] {
  * pure analysis; prints a structured result. Exit code: 0 for pass/WARN
  * (warn-first), 1 for a fail-closed integrity break.
  */
-export function runGovernorReviewGate(argv: readonly string[]): number {
-  const codeownersText = existsSync(CODEOWNERS_FILE)
-    ? readFileSync(CODEOWNERS_FILE, 'utf-8')
-    : '';
-  const governorPatterns = governorPathsFromCodeowners(codeownersText);
-  const { records } = readPrReviewRecords(PR_REVIEW_RECORDS_FILE);
-  const { prNumber, headSha } = resolvePrContext(argv);
+/**
+ * Run the fail-closed integrity check. Returns 1 (after logging) when the ledger
+ * is tampered, else null — so callers fail-close on tamper even when no PR context
+ * or no recomputable diff is available.
+ */
+function tamperExitCode(records: readonly PrReviewRecord[]): number | null {
+  const verification = verifyPrReviewRecordSet(records);
+  if (!verification.ok) {
+    console.error(
+      `[governor-review] FAIL (integrity): governance/pr-review-records.jsonl is tampered ` +
+        `(${verification.reason}): ${verification.detail}`
+    );
+    return 1;
+  }
+  return null;
+}
+
+/**
+ * Resolve the PR context + recompute the canonical reviewed-diff hash, handling
+ * the two early-exit cases (no PR context; git cannot produce the diff) — both of
+ * which still fail-close on a tampered ledger. Returns the resolved gate inputs,
+ * or `{ exit }` when the gate should terminate early.
+ */
+function resolveGateContext(
+  argv: readonly string[],
+  records: readonly PrReviewRecord[]
+): { prNumber: number; reviewedDiffHash: string; changedFiles: string[] } | { exit: number } {
+  const { prNumber, baseSha, headSha } = resolvePrContext(argv);
   const changedFiles = resolveChangedFiles(argv);
 
-  // Even without a PR context we still run the integrity check (it never
-  // depends on PR number/sha) so a tampered ledger fails CI on any run.
-  if (prNumber === undefined || headSha === undefined) {
-    const verification = verifyPrReviewRecordSet(records);
-    if (!verification.ok) {
-      console.error(
-        `[governor-review] FAIL (integrity): governance/pr-review-records.jsonl is tampered ` +
-          `(${verification.reason}): ${verification.detail}`
-      );
-      return 1;
-    }
+  if (prNumber === undefined || baseSha === undefined || headSha === undefined) {
+    const code = tamperExitCode(records);
+    if (code !== null) return { exit: code };
     console.error(
-      '[governor-review] PASS: no PR context (PR_NUMBER/PR_HEAD_SHA) provided and the ' +
+      '[governor-review] PASS: no PR context (PR_NUMBER/PR_BASE_SHA/PR_HEAD_SHA) provided and the ' +
         'pr-review ledger verifies. Nothing to assert for a non-PR run.'
     );
-    return 0;
+    return { exit: 0 };
   }
 
+  // Option-C (#3831): recompute the canonical reviewed-diff hash from base..head.
+  const reviewedDiffHash = recomputeReviewedDiffHash(baseSha, headSha);
+  if (reviewedDiffHash === undefined) {
+    const code = tamperExitCode(records); // fail-closed even when git can't diff
+    if (code !== null) return { exit: code };
+    const msg =
+      `could not recompute the canonical reviewed diff for ${baseSha.slice(0, 12)}..${headSha.slice(0, 12)} ` +
+      `(are both commits fetched? a shallow CI checkout may lack the base). Cannot verify a diff-bound ` +
+      `pr_review record. (Warn-first, #3831.)`;
+    console.error(`::warning title=Governor review unverifiable::${msg}`);
+    console.error(`[governor-review] WARN: ${msg}`);
+    return { exit: 0 };
+  }
+
+  return { prNumber, reviewedDiffHash, changedFiles };
+}
+
+export function runGovernorReviewGate(argv: readonly string[]): number {
+  const codeownersText = existsSync(CODEOWNERS_FILE) ? readFileSync(CODEOWNERS_FILE, 'utf-8') : '';
+  const governorPatterns = governorPathsFromCodeowners(codeownersText);
+  const { records } = readPrReviewRecords(PR_REVIEW_RECORDS_FILE);
+
+  const ctx = resolveGateContext(argv, records);
+  if ('exit' in ctx) return ctx.exit;
+
   const outcome = analyzeGovernorReview({
-    prNumber,
-    headSha,
-    changedFiles,
+    prNumber: ctx.prNumber,
+    reviewedDiffHash: ctx.reviewedDiffHash,
+    changedFiles: ctx.changedFiles,
     governorPatterns,
     records,
     genesisExemptPrs: GENESIS_EXEMPT_PRS,


### PR DESCRIPTION
Part of #3831 (governance-of-the-governor). **Ratified 7/0 (higher_order).** This is the **atomic schema+gate migration** to the Option-C binding; the producer that writes records is a tracked follow-up. The gate **stays warn-first** (no fail-closed flip — owner deferred that).

## What
Migrates the authority `PrReviewRecord` (schema 1.0 → 1.1) and the governor-path gate from the rejected `headSha` binding to the ratified **`{prNumber, baseSha, reviewedDiffHash}`**. A record now binds to the exact reviewed **diff**, not a mutable head pointer — the bytes the voters actually saw.

## The crux — canonicalization determinism (panel condition A)
A shared `audit/reviewed-diff-hash.ts` is the single definition of `reviewedDiffHash` so the producer and gate cannot drift. It pins the exact `git diff` invocation (`core.autocrlf=false`, `diff.algorithm=myers`, `mnemonicprefix/noprefix=false`, `--no-color/--no-ext-diff/--no-renames/-U3`, **two-dot** range) + a **50k byte-boundary** truncation + sha256.

**Proven across a real-git boundary** (not a same-helper test, per the Contrarian): the cross-env test builds a git repo, sets **hostile, differing local gitconfig** (patience/histogram algorithm, context 9 vs 1, mnemonic prefixes, autocrlf), and asserts the canonical invocation is **byte-identical** → same hash.

## The gate
`check-governor-review.ts` now resolves `--base`/`--sha` (PR_BASE_SHA/PR_HEAD_SHA), recomputes `reviewedDiffHash` from the committed PR's `base..head`, and matches a record on it. A record bound to a **different** diff does **not** satisfy the gate (the negative case the suite proves). Git-can't-diff (shallow checkout) → still fail-closed on tamper, else warn (never a false pass).

## Conditions met
- **(A) canonicalization** pinned + cross-env tested. **(B) truncation limitation** documented (content past 50k is unbound) + `reviewedDiffWasTruncated` surfaces it. **(C) env-override** — the gate reads the fixed committed path, never `NEXUS_PR_REVIEW_RECORDS_PATH`. **No data migration** — the `pr-review-records.jsonl` ledger is empty on every install.

## Tests
247 audit tests + 17 gate tests pass; typecheck + lint + `governance:check` green; live gate exits 0 on the empty ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)