### PR TITLE
fix(mcp): declare panelWarning + costSummary in consensus_vote output schema (#4032)

### DIFF
--- a/.changeset/4032-consensus-vote-output-schema.md
+++ b/.changeset/4032-consensus-vote-output-schema.md
@@ -9,7 +9,12 @@ Fix `consensus_vote` rejecting on strict MCP clients (`-32602 additional propert
 `CONSENSUS_VOTE_OUTPUT_SCHEMA` never declared them. A spec-strict MCP client — one that
 validates the result against the advertised `outputSchema` with
 `additionalProperties: false` — rejected the response on most real votes. Both fields are
-now declared. The cost-summary shape is captured once in a shared
-`DecisionCostSummarySchema` (co-located with the `DecisionCostSummary` type), and a
-regression guard test asserts the strict output schema accepts a fully-populated response
-so the schema can't silently drift from the response type again.
+now declared. The same review found a second instance of the bug class: the schema's
+`decision` enum listed only `approved`/`rejected`/`no_quorum`, but the response can also
+carry the reachable `timeout`/`pending` outcomes — so a timed-out vote hit the same
+`-32602` rejection. `decision` now reuses a canonical `VoteDecisionStatusSchema` (the
+single source the `VoteDecisionStatus` type is also derived from), making that drift
+structurally impossible. The cost-summary shape is likewise captured once in a shared
+`DecisionCostSummarySchema` co-located with its type. Regression guards assert the strict
+output schema accepts a fully-populated response (key parity) and every reachable
+`decision` value, and pin the cost schema to the `rollupDecisionCost` producer.

--- a/.changeset/4032-consensus-vote-output-schema.md
+++ b/.changeset/4032-consensus-vote-output-schema.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+Fix `consensus_vote` rejecting on strict MCP clients (`-32602 additional properties`, [#4032](https://github.com/nexus-substrate/nexus-agents/issues/4032))
+
+`consensus_vote` returns `panelWarning` (#3587, on a degraded panel) and `costSummary`
+(#3855, whenever per-decision cost recording succeeds) in its `structuredContent`, but
+`CONSENSUS_VOTE_OUTPUT_SCHEMA` never declared them. A spec-strict MCP client — one that
+validates the result against the advertised `outputSchema` with
+`additionalProperties: false` — rejected the response on most real votes. Both fields are
+now declared. The cost-summary shape is captured once in a shared
+`DecisionCostSummarySchema` (co-located with the `DecisionCostSummary` type), and a
+regression guard test asserts the strict output schema accepts a fully-populated response
+so the schema can't silently drift from the response type again.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -258,7 +258,24 @@ export interface AgentVoteSummary {
   rejectionCategories?: readonly string[];
 }
 
-export type VoteDecisionStatus = 'approved' | 'rejected' | 'pending' | 'timeout' | 'no_quorum';
+/**
+ * Canonical set of decision statuses a vote response can carry. Single source
+ * of truth: the `consensus_vote` MCP `outputSchema` reuses
+ * {@link VoteDecisionStatusSchema} so the advertised enum can never be narrower
+ * than what {@link buildResponse} emits (all five are reachable —
+ * `no_quorum` on an all-error/no-quorum panel, the rest via
+ * {@link mapOutcomeToDecision}). A narrower schema made strict MCP clients
+ * reject `timeout`/`pending` votes with a `-32602`-class error (#4032).
+ */
+export const VoteDecisionStatusSchema = z.enum([
+  'approved',
+  'rejected',
+  'pending',
+  'timeout',
+  'no_quorum',
+]);
+
+export type VoteDecisionStatus = z.infer<typeof VoteDecisionStatusSchema>;
 
 /** Higher-Order Voting metadata (Issue #514). */
 export interface HigherOrderMetadata {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -28,6 +28,7 @@ import type { VotingStrategy } from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ExtendedVotingResult } from './consensus-vote-types.js';
 import type { VoteRecord } from '../../audit/vote-record.js';
+import { rollupDecisionCost } from '../../observability/decision-cost.js';
 
 /**
  * Creates a permissive rate limiter for tests.
@@ -1303,5 +1304,71 @@ describe('getDefaultErrorPolicy (#3167)', () => {
   it('non-strict strategies default to reduce_denominator', () => {
     expect(getDefaultErrorPolicy('simple_majority')).toBe('reduce_denominator');
     expect(getDefaultErrorPolicy('supermajority')).toBe('reduce_denominator');
+  });
+});
+
+describe('CONSENSUS_VOTE_OUTPUT_SCHEMA covers the full response (#4032)', () => {
+  // A fully-populated response with EVERY optional field set, incl. the two
+  // (`panelWarning` #3587, `costSummary` #3855) whose omission from the output
+  // schema made a strict MCP client reject the result with `-32602 additional
+  // properties`. The fixture is typed `ConsensusVoteResponse`, so a newly-added
+  // required response field forces this fixture to set it, surfacing schema drift.
+  const fullResponse: ConsensusVoteResponse = {
+    proposal: 'ship it',
+    threshold: 'majority',
+    strategy: 'higher_order',
+    decision: 'approved',
+    approvalPercentage: 66.7,
+    voteCounts: { approve: 2, reject: 0, abstain: 0, error: 1 },
+    votes: [
+      {
+        role: 'architect',
+        decision: 'approve',
+        confidence: 0.9,
+        reasoning: 'sound',
+        simulated: false,
+        error: false,
+        modelUsed: 'claude-sonnet',
+        rejectionCategories: [],
+      },
+    ],
+    durationMs: 4321,
+    simulateVotes: false,
+    higherOrderMetadata: {
+      posteriorApproval: 0.8,
+      posteriorRejection: 0.2,
+      effectiveVoteCount: 2.4,
+      method: 'ow',
+      usedCorrelationData: true,
+      improvementOverBaseline: 0.05,
+      downweightedAgents: ['devex'],
+      reasoning: 'correlation-aware',
+    },
+    policyReason: 'fail_closed: 1 voter(s) errored',
+    panelWarning: 'Panel degraded: 1 of 3 voters errored; decision rests on 2 voter(s).',
+    costSummary: rollupDecisionCost(
+      [
+        {
+          role: 'architect',
+          model: 'claude-sonnet',
+          inputTokens: 1000,
+          outputTokens: 200,
+          costUsd: 0.006,
+        },
+      ],
+      'api'
+    ),
+    voteRecordPersisted: true,
+    voteRecordNote: 'persisted',
+  };
+
+  it('strictly accepts a response carrying panelWarning + costSummary', () => {
+    expect(() => z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict().parse(fullResponse)).not.toThrow();
+  });
+
+  it('declares exactly the response keys (no schema/response drift)', () => {
+    expect(Object.keys(CONSENSUS_VOTE_OUTPUT_SCHEMA).sort()).toEqual(
+      Object.keys(fullResponse).sort()
+    );
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -1366,9 +1366,23 @@ describe('CONSENSUS_VOTE_OUTPUT_SCHEMA covers the full response (#4032)', () => 
     expect(() => z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict().parse(fullResponse)).not.toThrow();
   });
 
-  it('declares exactly the response keys (no schema/response drift)', () => {
+  it('declares exactly the response keys (no schema/response key drift)', () => {
+    // Key-level guard: catches a response field absent from the schema (the
+    // panelWarning/costSummary failure mode). It does NOT police value
+    // constraints — the `decision` enum is kept aligned structurally instead,
+    // by reusing VoteDecisionStatusSchema (see the enum test below).
     expect(Object.keys(CONSENSUS_VOTE_OUTPUT_SCHEMA).sort()).toEqual(
       Object.keys(fullResponse).sort()
     );
   });
+
+  it.each(['approved', 'rejected', 'pending', 'timeout', 'no_quorum'] as const)(
+    'accepts every reachable decision value (%s) — not just the old 3-value subset (#4032)',
+    (decision) => {
+      // 'timeout'/'pending' are reachable via mapOutcomeToDecision and were
+      // rejected by the previous narrower enum on a strict MCP client.
+      const response: ConsensusVoteResponse = { ...fullResponse, decision };
+      expect(() => z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict().parse(response)).not.toThrow();
+    }
+  );
 });

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -46,6 +46,7 @@ import {
 import {
   MAX_PROPOSAL_LENGTH,
   VotingStrategySchema,
+  VoteDecisionStatusSchema,
   VoteThresholdSchema,
   ConsensusVoteInputSchema,
   buildResponse,
@@ -890,7 +891,10 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
 export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   proposal: z.string(),
   strategy: VotingStrategySchema,
-  decision: z.enum(['approved', 'rejected', 'no_quorum']),
+  // Reuses the canonical VoteDecisionStatusSchema (single source) — a hand-listed
+  // subset here (was ['approved','rejected','no_quorum']) omitted the reachable
+  // 'timeout'/'pending' outcomes and made strict clients reject those votes (#4032).
+  decision: VoteDecisionStatusSchema,
   approvalPercentage: z.number(),
   voteCounts: z.object({
     approve: z.number(),

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -61,6 +61,7 @@ import {
 } from './consensus-vote-recording.js';
 import type { VoteRecordPersistOutcome } from './consensus-vote-recording.js';
 import { recordDecisionCost } from './decision-cost-recording.js';
+import { DecisionCostSummarySchema } from '../../observability/decision-cost.js';
 import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
@@ -946,6 +947,15 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   // a previously WARN-only skip visible to MCP callers.
   voteRecordPersisted: z.boolean(),
   voteRecordNote: z.string().max(500).optional(),
+  // #3587: set when the panel DEGRADED (some voters errored), so the decision
+  // rests on fewer voters than requested. Part of the response since #3587 but
+  // omitted from this schema until #4032 — its absence made a strict MCP client
+  // reject any degraded-panel vote (`-32602 additional properties`).
+  panelWarning: z.string().optional(),
+  // #3855: per-decision cost rollup. Same omission as panelWarning (#4032) — it
+  // is present on the response whenever cost recording succeeds (common in `api`
+  // billing mode). Shared schema lives with the type (single source of truth).
+  costSummary: DecisionCostSummarySchema.optional(),
 };
 
 /** Advertised MCP input schema for consensus_vote (hoisted to keep the register fn within its line budget). */

--- a/packages/nexus-agents/src/observability/decision-cost.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.test.ts
@@ -12,7 +12,12 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { rollupDecisionCost, UNKNOWN_MODEL, type VoterCostInput } from './decision-cost.js';
+import {
+  rollupDecisionCost,
+  DecisionCostSummarySchema,
+  UNKNOWN_MODEL,
+  type VoterCostInput,
+} from './decision-cost.js';
 
 describe('rollupDecisionCost', () => {
   describe('per-voter → per-decision totals (api mode)', () => {
@@ -258,5 +263,44 @@ describe('rollupDecisionCost', () => {
       // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754; rounded to micro-USD = 0.3.
       expect(summary.totalCostUsd).toBe(0.3);
     });
+  });
+});
+
+describe('DecisionCostSummarySchema (#4032 — pins the MCP cost-summary shape)', () => {
+  // This schema rides consensus_vote/pr_review `outputSchema`. A strict MCP client
+  // validates the cost summary recursively, so any field the producer emits that
+  // the schema does not declare → `-32602 additional properties`. Validate a REAL
+  // rollup output strictly so producer↔schema drift fails the test, not a client.
+  it('strictly accepts a real rollup output, top-level and per-row', () => {
+    const voters: VoterCostInput[] = [
+      {
+        role: 'architect',
+        model: 'claude-sonnet',
+        inputTokens: 1000,
+        outputTokens: 200,
+        costUsd: 0.006,
+      },
+      { role: 'security', model: 'gemini-flash' }, // unmeasured (no token/cost report)
+    ];
+    const summary = rollupDecisionCost(voters, 'api');
+
+    expect(() => DecisionCostSummarySchema.strict().parse(summary)).not.toThrow();
+    expect(Object.keys(summary.perVoter[0]!).sort()).toEqual([
+      'costUsd',
+      'inputTokens',
+      'model',
+      'outputTokens',
+      'role',
+      'totalTokens',
+      'unmeasured',
+    ]);
+    expect(Object.keys(summary.perModel[0]!).sort()).toEqual([
+      'costUsd',
+      'inputTokens',
+      'model',
+      'outputTokens',
+      'totalTokens',
+      'voterCount',
+    ]);
   });
 });

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -35,6 +35,8 @@
  * @module observability/decision-cost
  */
 
+import { z } from 'zod';
+
 /** Billing mode in effect for a decision. Mirrors `NEXUS_BILLING_MODE`. */
 export type DecisionBillingMode = 'plan' | 'api';
 
@@ -120,6 +122,47 @@ export interface DecisionCostSummary {
   /** Per-model breakdown, sorted by total cost desc then total tokens desc. */
   readonly perModel: readonly ModelCostBreakdown[];
 }
+
+/**
+ * Zod schema for {@link DecisionCostSummary} — the single source of truth for
+ * the cost-rollup shape when it rides an MCP tool's `outputSchema`. Both
+ * `consensus_vote` and `pr_review` return this object on their response, so a
+ * spec-strict MCP client validates it against the advertised schema; declaring
+ * it once here keeps the two tool schemas from drifting (the omission that
+ * caused #4032's `-32602 additional properties` rejection). A runtime guard test
+ * pins it to the producer output (`rollupDecisionCost`) so the shape can't drift.
+ */
+export const DecisionCostSummarySchema = z.object({
+  billingMode: z.enum(['plan', 'api']),
+  voterCount: z.number(),
+  measuredVoters: z.number(),
+  unmeasuredVoters: z.number(),
+  totalInputTokens: z.number(),
+  totalOutputTokens: z.number(),
+  totalTokens: z.number(),
+  totalCostUsd: z.number(),
+  perVoter: z.array(
+    z.object({
+      role: z.string(),
+      model: z.string(),
+      inputTokens: z.number(),
+      outputTokens: z.number(),
+      totalTokens: z.number(),
+      costUsd: z.number(),
+      unmeasured: z.boolean(),
+    })
+  ),
+  perModel: z.array(
+    z.object({
+      model: z.string(),
+      voterCount: z.number(),
+      inputTokens: z.number(),
+      outputTokens: z.number(),
+      totalTokens: z.number(),
+      costUsd: z.number(),
+    })
+  ),
+});
 
 /** A voter contributes usage iff it reported any token count or a cost. */
 function isMeasured(v: VoterCostInput): boolean {

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -125,12 +125,13 @@ export interface DecisionCostSummary {
 
 /**
  * Zod schema for {@link DecisionCostSummary} — the single source of truth for
- * the cost-rollup shape when it rides an MCP tool's `outputSchema`. Both
- * `consensus_vote` and `pr_review` return this object on their response, so a
- * spec-strict MCP client validates it against the advertised schema; declaring
- * it once here keeps the two tool schemas from drifting (the omission that
- * caused #4032's `-32602 additional properties` rejection). A runtime guard test
- * pins it to the producer output (`rollupDecisionCost`) so the shape can't drift.
+ * the cost-rollup shape when it rides an MCP tool's `outputSchema`. `consensus_vote`
+ * declares this in its `outputSchema`, so a spec-strict MCP client validates the
+ * cost summary against it; declaring the shape once here is what fixed #4032's
+ * `-32602 additional properties` rejection. `pr_review` returns the same object
+ * but does not yet advertise an `outputSchema`, so it will reuse this when it does.
+ * A runtime guard test pins the schema to the producer output (`rollupDecisionCost`)
+ * so the shape can't drift.
  */
 export const DecisionCostSummarySchema = z.object({
   billingMode: z.enum(['plan', 'api']),


### PR DESCRIPTION
## What

`consensus_vote` returns `panelWarning` (#3587, degraded panel) and `costSummary` (#3855, whenever per-decision cost recording succeeds) in its `structuredContent`, but `CONSENSUS_VOTE_OUTPUT_SCHEMA` never declared them. A spec-strict MCP client — one validating the result against the advertised `outputSchema` with `additionalProperties: false` — rejected the response on most real votes:

```
MCP error -32602: Structured content does not match the tool's output schema: data must NOT have additional properties
```

## Fix

- Declare `panelWarning` + `costSummary` in `CONSENSUS_VOTE_OUTPUT_SCHEMA`.
- Capture the cost-summary shape **once** in a shared `DecisionCostSummarySchema`, co-located with the `DecisionCostSummary` interface in `observability/decision-cost.ts` (single source; reusable by `pr_review`, which returns the same type).
- **Regression guards:** a test asserts `z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict()` accepts a fully-populated `ConsensusVoteResponse` and that the schema's key set equals the response's; a second pins `DecisionCostSummarySchema` to the real `rollupDecisionCost` output. This is the guard that was missing when #3587/#3855 drifted.

## Verification

- `decision-cost.test.ts` + `consensus-vote.test.ts`: 100 passed (incl. new guards)
- typecheck clean, eslint clean, Producer/Consumer gate exit 0

## Scope

`pr_review` returns the same `costSummary` but advertises **no** `outputSchema`, so it does not hit this error today — tracked separately as a latent gap.

Closes #4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)