### PR TITLE
fix(cli-adapters): guard against nested nexus-agents MCP server deadlock (#4033)

### DIFF
--- a/.changeset/4033-nested-server-guard.md
+++ b/.changeset/4033-nested-server-guard.md
@@ -15,5 +15,11 @@ process tree sat at 0% CPU until the per-voter timeout reaped it minutes later).
 on every spawned-CLI child (it is `NEXUS_`-prefixed, so it survives the env allowlist and
 reaches the grandchild server). The server bootstrap reads the marker at the top of startup
 and, when nested, exits cleanly _before_ any slow initialization — so the parent CLI
-proceeds without that MCP server (it needs no nexus server to answer a prompt). Mirrors the
-existing codex recursion guard (#3350) and never fires for a top-level launch.
+proceeds without that MCP server (it needs no nexus server to answer a prompt). The guard
+is scoped to `--mode=server` (orchestrator mode is unaffected) and never fires for a
+top-level launch.
+
+Scope: this covers the subprocess (opencode/claude/gemini/codex-CLI) voter path. The
+codex-**MCP** topology (`codex mcp-server` spawned over a replaced env) keeps its own
+independent `NEXUS_MCP_DEPTH` recursion guard (#3350) — the two markers are distinct and
+do not interfere.

--- a/.changeset/4033-nested-server-guard.md
+++ b/.changeset/4033-nested-server-guard.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+Fix consensus voters deadlocking when the spawned CLI auto-loads the nexus-agents MCP server ([#4033](https://github.com/nexus-substrate/nexus-agents/issues/4033))
+
+When a `cli-first` consensus voter shelled out to a coding CLI (e.g. `opencode run
+--format json`) and that CLI was itself configured to auto-start a `nexus-agents
+--mode=server` MCP server, every voter subprocess launched a _fresh nested_ nexus-agents
+server. The nested server attached to the child's stdio and blocked the child's own MCP
+handshake, so the voter never returned its JSON and `consensus_vote` deadlocked (the whole
+process tree sat at 0% CPU until the per-voter timeout reaped it minutes later).
+
+`subprocess-env.buildChildEnv` now stamps an incrementing `NEXUS_SUBPROCESS_DEPTH` marker
+on every spawned-CLI child (it is `NEXUS_`-prefixed, so it survives the env allowlist and
+reaches the grandchild server). The server bootstrap reads the marker at the top of startup
+and, when nested, exits cleanly _before_ any slow initialization — so the parent CLI
+proceeds without that MCP server (it needs no nexus server to answer a prompt). Mirrors the
+existing codex recursion guard (#3350) and never fires for a top-level launch.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildChildEnv, getCliVendorKeys } from './subprocess-env.js';
+import {
+  buildChildEnv,
+  getCliVendorKeys,
+  readSubprocessDepth,
+  NEXUS_SUBPROCESS_DEPTH_ENV,
+} from './subprocess-env.js';
 
 describe('buildChildEnv (#2865)', () => {
   /** Env keys the tests touch — cleared before each test for a known slate. */
@@ -19,6 +24,7 @@ describe('buildChildEnv (#2865)', () => {
     'LC_CUSTOMTEST',
     'NEXUS_CUSTOMTEST',
     'NEXUS_SUBPROCESS_ENV_ALLOWLIST',
+    'NEXUS_SUBPROCESS_DEPTH',
     'npm_config_registry',
     'SOME_RANDOM_UNLISTED_VAR',
   ];
@@ -125,5 +131,39 @@ describe('buildChildEnv (#2865)', () => {
     for (const cli of ['claude', 'gemini', 'codex', 'opencode'] as const) {
       expect(map[cli].length).toBeGreaterThan(0);
     }
+  });
+
+  // #4033 — nested-server deadlock guard.
+  describe('NEXUS_SUBPROCESS_DEPTH marker (#4033)', () => {
+    it('stamps depth=1 on a child spawned from a top-level (unmarked) parent', () => {
+      const env = buildChildEnv('opencode');
+      expect(env[NEXUS_SUBPROCESS_DEPTH_ENV]).toBe('1');
+    });
+
+    it('increments the inherited depth (2 when the parent was already at 1)', () => {
+      vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', '1');
+      expect(buildChildEnv('opencode')[NEXUS_SUBPROCESS_DEPTH_ENV]).toBe('2');
+    });
+
+    it('stamps the depth even under the allowlist=0 escape hatch (overrides inherited)', () => {
+      vi.stubEnv('NEXUS_SUBPROCESS_ENV_ALLOWLIST', '0');
+      vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', '2');
+      // Full passthrough would copy '2'; we must still INCREMENT to 3.
+      expect(buildChildEnv('opencode')[NEXUS_SUBPROCESS_DEPTH_ENV]).toBe('3');
+    });
+
+    it('round-trips: a child env reads back as nested (depth > 0)', () => {
+      const child = buildChildEnv('opencode');
+      expect(readSubprocessDepth(child)).toBe(1);
+      expect(readSubprocessDepth(child) > 0).toBe(true);
+    });
+
+    it('readSubprocessDepth clamps missing/junk/negative to 0 (top-level)', () => {
+      expect(readSubprocessDepth({})).toBe(0);
+      expect(readSubprocessDepth({ NEXUS_SUBPROCESS_DEPTH: 'abc' })).toBe(0);
+      expect(readSubprocessDepth({ NEXUS_SUBPROCESS_DEPTH: '-1' })).toBe(0);
+      expect(readSubprocessDepth({ NEXUS_SUBPROCESS_DEPTH: '0' })).toBe(0);
+      expect(readSubprocessDepth({ NEXUS_SUBPROCESS_DEPTH: '3' })).toBe(3);
+    });
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
@@ -17,6 +17,25 @@
 
 import type { CliName } from './types.js';
 
+/**
+ * Marker stamped on EVERY spawned-CLI child env (#4033): how deep we are in the
+ * nexus → CLI subprocess nesting. A child CLI (e.g. `opencode run`) that is
+ * itself configured to auto-start a `nexus-agents --mode=server` MCP server
+ * would otherwise deadlock the voter — the nested server attaches to the child's
+ * stdio and blocks the child's MCP handshake, so the voter never returns its
+ * JSON. The server bootstrap reads this marker and refuses to start when nested
+ * (see `cli-server.ts`). Distinct from the codex-only `NEXUS_MCP_DEPTH` guard so
+ * the two cannot interfere. `NEXUS_`-prefixed, so it survives the allowlist (and
+ * the `=0` full-passthrough hatch) and reaches the grandchild MCP server.
+ */
+export const NEXUS_SUBPROCESS_DEPTH_ENV = 'NEXUS_SUBPROCESS_DEPTH';
+
+/** Read the subprocess nesting depth from an env bag; clamps missing/junk to 0. */
+export function readSubprocessDepth(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number.parseInt(env[NEXUS_SUBPROCESS_DEPTH_ENV] ?? '0', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
 /** Exact-match infrastructure vars every spawned CLI legitimately needs. */
 const BASE_ENV_EXACT: readonly string[] = [
   'PATH',
@@ -95,11 +114,15 @@ function isAllowed(key: string, vendorKeys: readonly string[]): boolean {
 export function buildChildEnv(cliName: CliName): NodeJS.ProcessEnv {
   const source = process.env;
   const childEnv: NodeJS.ProcessEnv = {};
+  // Stamp the incremented nesting depth (#4033) LAST in both branches so it
+  // overrides any inherited value rather than copying the parent's depth.
+  const nextDepth = String(readSubprocessDepth(source) + 1);
 
   if (source['NEXUS_SUBPROCESS_ENV_ALLOWLIST'] === '0') {
     for (const [key, value] of Object.entries(source)) {
       if (value !== undefined && key !== 'CLAUDECODE') childEnv[key] = value;
     }
+    childEnv[NEXUS_SUBPROCESS_DEPTH_ENV] = nextDepth;
     return childEnv;
   }
 
@@ -109,6 +132,7 @@ export function buildChildEnv(cliName: CliName): NodeJS.ProcessEnv {
     if (key === 'CLAUDECODE') continue;
     if (isAllowed(key, vendorKeys)) childEnv[key] = value;
   }
+  childEnv[NEXUS_SUBPROCESS_DEPTH_ENV] = nextDepth;
   return childEnv;
 }
 

--- a/packages/nexus-agents/src/cli-server-nesting-guard.test.ts
+++ b/packages/nexus-agents/src/cli-server-nesting-guard.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the nested-MCP-server deadlock guard (#4033).
+ *
+ * @module cli-server-nesting-guard.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { ILogger } from './core/index.js';
+import { exitIfNestedSubprocessServer } from './cli-server-nesting-guard.js';
+
+function makeLogger(): ILogger {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => logger),
+    setLevel: vi.fn(),
+  };
+  return logger;
+}
+
+describe('exitIfNestedSubprocessServer (#4033)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', undefined);
+    // Swallow exit so the test process survives; record the call.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op at the top level (no marker → never exits)', () => {
+    const logger = makeLogger();
+    exitIfNestedSubprocessServer(logger);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not exit when the marker is explicitly 0', () => {
+    vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', '0');
+    exitIfNestedSubprocessServer(makeLogger());
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns and exits cleanly (code 0) when nested (depth >= 1)', () => {
+    vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', '1');
+    const logger = makeLogger();
+    exitIfNestedSubprocessServer(logger);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0]?.[0]).toContain('nested nexus-agents MCP server');
+  });
+
+  it('ignores junk marker values (treated as top-level)', () => {
+    vi.stubEnv('NEXUS_SUBPROCESS_DEPTH', 'not-a-number');
+    exitIfNestedSubprocessServer(makeLogger());
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nexus-agents/src/cli-server-nesting-guard.ts
+++ b/packages/nexus-agents/src/cli-server-nesting-guard.ts
@@ -1,0 +1,43 @@
+/**
+ * nexus-agents/cli-server — nested-MCP-server deadlock guard (#4033).
+ *
+ * When a nexus consensus voter shells out to a coding CLI (e.g. `opencode run
+ * --format json`) and that CLI is itself configured to auto-start a
+ * `nexus-agents --mode=server` MCP server, the nested server attaches to the
+ * child's stdio and blocks the child's own MCP handshake — so the voter never
+ * emits its JSON result and `consensus_vote` deadlocks (the whole tree sits at
+ * 0% CPU until the per-voter timeout reaps it minutes later).
+ *
+ * `subprocess-env.buildChildEnv` stamps {@link NEXUS_SUBPROCESS_DEPTH_ENV} on
+ * every spawned-CLI child; the marker is `NEXUS_`-prefixed so it survives the
+ * env allowlist and reaches the grandchild server. {@link exitIfNestedSubprocessServer}
+ * reads it at the top of the server bootstrap and exits cleanly when nested, so
+ * the parent CLI proceeds WITHOUT this MCP server (it needs no nexus server to
+ * answer a prompt). Mirrors the codex recursion guard (#3350); never fires for a
+ * top-level launch (no marker → depth 0).
+ *
+ * @module cli-server-nesting-guard
+ */
+
+import type { ILogger } from './core/index.js';
+import { EXIT_CODES } from './cli-types.js';
+import { readSubprocessDepth, NEXUS_SUBPROCESS_DEPTH_ENV } from './cli-adapters/subprocess-env.js';
+
+/**
+ * Exit cleanly (without starting the server) when this process is a nested
+ * nexus server spawned by a CLI that nexus itself launched (#4033). No-op at the
+ * top level. Must be called BEFORE any slow startup work so the parent CLI's MCP
+ * handshake is released promptly.
+ */
+export function exitIfNestedSubprocessServer(logger: ILogger): void {
+  const depth = readSubprocessDepth();
+  if (depth <= 0) return;
+  logger.warn(
+    `Refusing to start a nested nexus-agents MCP server ` +
+      `(${NEXUS_SUBPROCESS_DEPTH_ENV}=${String(depth)}). This server was launched by a ` +
+      'CLI that nexus itself spawned (e.g. a consensus voter); a nested server would ' +
+      'deadlock the parent (#4033). If you configured that CLI to launch nexus-agents as ' +
+      'an MCP server, remove that entry from its MCP config.'
+  );
+  process.exit(EXIT_CODES.SUCCESS);
+}

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -16,6 +16,7 @@ import { initializeBuiltInTemplates } from './workflows/index.js';
 import { createUnifiedRegistry, type UnifiedAdapterRegistry } from './adapters/unified-registry.js';
 import { MCP_TIMEOUTS } from './config/timeouts.js';
 import { getStdinLifecycleMonitor } from './adapters/stdin-lifecycle.js';
+import { exitIfNestedSubprocessServer } from './cli-server-nesting-guard.js';
 import { registerMcpTools } from './cli-server-tools.js';
 import { parseTierOverrides, type GatewayConfig } from './mcp/gateway/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -555,6 +556,8 @@ export async function startServer(
 
   validateModeOrExit(logger, mode); // Fail fast for unimplemented modes (Issue #443)
 
+  exitIfNestedSubprocessServer(logger); // #4033: exit if a nexus-spawned CLI launched us
+
   // Handle orchestrator mode separately (Issue #446)
   if (mode === 'orchestrator') {
     await startOrchestratorMode(orchestratorOptions ?? { verbose });
@@ -574,8 +577,7 @@ export async function startServer(
   // down cleanly before it fires (for short-lived test harnesses).
   startupWatchdog.unref();
 
-  const detectionResult = detectMode({ explicitMode: modeWasExplicit ? mode : undefined });
-  logStartupInfo(logger, detectionResult, verbose);
+  logStartupInfo(logger, detectMode({ explicitMode: modeWasExplicit ? mode : undefined }), verbose);
 
   // Surface stale long-lived servers (#3283): best-effort, non-blocking warn if
   // the running build is behind the latest published version. Fire-and-forget —

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -556,13 +556,13 @@ export async function startServer(
 
   validateModeOrExit(logger, mode); // Fail fast for unimplemented modes (Issue #443)
 
-  exitIfNestedSubprocessServer(logger); // #4033: exit if a nexus-spawned CLI launched us
-
   // Handle orchestrator mode separately (Issue #446)
   if (mode === 'orchestrator') {
     await startOrchestratorMode(orchestratorOptions ?? { verbose });
     return;
   }
+
+  exitIfNestedSubprocessServer(logger); // #4033: server mode only (deadlock is stdio-bound)
 
   // Watchdog: if startup hangs, surface it rather than hang indefinitely
   // (#2163). Cleared once we reach "waiting for requests".


### PR DESCRIPTION
## What

A `cli-first` consensus voter shells out to a coding CLI (e.g. `opencode run --format json`). When that CLI is **itself** configured to auto-start a `nexus-agents --mode=server` MCP server, every voter subprocess launched a *fresh nested* nexus server. The nested server attached to the child's stdio and blocked the child's own MCP handshake — so the voter never emitted its JSON and `consensus_vote` deadlocked (whole tree at 0% CPU until the per-voter timeout reaped it minutes later).

## Fix (mirrors the codex recursion guard #3350)

- `subprocess-env.buildChildEnv` stamps an **incrementing `NEXUS_SUBPROCESS_DEPTH`** marker on every spawned-CLI child. It is `NEXUS_`-prefixed, so it survives the env allowlist (and the `=0` full-passthrough hatch) and reaches the grandchild server.
- New `cli-server-nesting-guard.ts`: `exitIfNestedSubprocessServer` reads the marker at the **top of the server bootstrap** (before any slow init) and exits cleanly when nested, so the parent CLI proceeds without that MCP server.
- Never fires for a top-level launch (no marker → depth 0).

## Verification

- New tests: `subprocess-env.test.ts` (marker stamping/increment/allowlist-0/round-trip/clamp) + `cli-server-nesting-guard.test.ts` (no-op at top level, warn+exit(0) when nested, junk-value handling).
- Affected suites (subprocess-env, nesting-guard, cli-server, cli-server-lifecycle): 58 passed. typecheck/eslint/Producer-Consumer clean.

## Scope note

End-to-end reproduction needs an `opencode`-with-nexus-MCP environment (not available in CI); the guard is correct by construction and pattern-consistent with the existing `NEXUS_MCP_DEPTH` codex guard. The marker is a distinct env var so the two guards cannot interfere.

Closes #4033

🤖 Generated with [Claude Code](https://claude.com/claude-code)