### PR TITLE
feat(cli-adapters): operator-configurable subprocess env + sensitive-ref scrubbing (#4037)

### DIFF
--- a/.changeset/4037-opsec-configurable-subprocess-env.md
+++ b/.changeset/4037-opsec-configurable-subprocess-env.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+Operator-configurable opsec: stop hardcoding organization-specific references in source
+
+Two changes that move org-specific values out of the (public) source tree and into operator
+config, so a deployment's sensitive references never ship in the repo:
+
+- **`NEXUS_SUBPROCESS_EXTRA_ENV` ([#4037](https://github.com/nexus-substrate/nexus-agents/issues/4037)):**
+  a comma/space-separated list of additional env-var _names_ to forward to spawned voter CLIs.
+  Custom-gateway users whose auth key is neither `NEXUS_`-prefixed nor a known vendor key can
+  now forward just that key (e.g. `NEXUS_SUBPROCESS_EXTRA_ENV=MY_GATEWAY_KEY`) and keep full
+  cross-vendor key isolation — instead of reaching for `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0`,
+  which disables the #2865 allowlist entirely and re-leaks every key to every CLI.
+
+- **`NEXUS_SENSITIVE_REFS`:** the auto-file issue scrubber (#3382) no longer hardcodes a
+  specific org/gov reference term. The terms are now read from this operator-configured env
+  var (comma/space-separated); unset ⇒ no scrubbing. **Action for operators who auto-file
+  from a sensitive context:** set `NEXUS_SENSITIVE_REFS` to your org's terms, since the
+  previous built-in default has been removed (a hardcoded denylist literal is itself a
+  disclosure in a public repo).

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -205,14 +205,17 @@ All configuration can be overridden with environment variables:
 
 ### Security Variables
 
-| Variable               | Description                                                                                                                       | Default          |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `NEXUS_SANDBOX`        | Sandbox flavor; passed through to subprocess adapters (epic #2500)                                                                | unset            |
-| `NEXUS_SANDBOX_ROOT`   | Sandbox root directory for the sandbox executor                                                                                   | unset            |
-| `NEXUS_RATE_LIMIT`     | Requests per minute                                                                                                               | `60`             |
-| `NEXUS_AUTH_ENABLED`   | Enable MCP auth (applies only to network transports; no effect on the default stdio MCP)                                          | `true`           |
-| `NEXUS_AUTH_METHOD`    | Auth method                                                                                                                       | `token`          |
-| `NEXUS_DRIFT_ADVISORY` | Model-string drift CI gate: any value except `0` (incl. unset) = advisory (warn); `0` = blocking (#2199). CI sets `0` to enforce. | unset (advisory) |
+| Variable                         | Description                                                                                                                                                                               | Default              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `NEXUS_SANDBOX`                  | Sandbox flavor; passed through to subprocess adapters (epic #2500)                                                                                                                        | unset                |
+| `NEXUS_SANDBOX_ROOT`             | Sandbox root directory for the sandbox executor                                                                                                                                           | unset                |
+| `NEXUS_SUBPROCESS_ENV_ALLOWLIST` | `0` disables the spawned-CLI env allowlist (#2865) entirely — full passthrough (minus `CLAUDECODE`). Blunt escape hatch; re-leaks cross-vendor keys. Prefer `NEXUS_SUBPROCESS_EXTRA_ENV`. | unset (allowlist on) |
+| `NEXUS_SUBPROCESS_EXTRA_ENV`     | Comma/space-separated list of additional env-var **names** to forward to spawned CLIs, e.g. a custom gateway key (#4037). Keeps cross-vendor isolation; forwards only the named vars.     | unset                |
+| `NEXUS_SENSITIVE_REFS`           | Comma/space-separated org/gov reference **terms** scrubbed from auto-filed issue text (#3382 opsec). Intentionally not hardcoded — set your org's terms here. Unset ⇒ no scrubbing.       | unset                |
+| `NEXUS_RATE_LIMIT`               | Requests per minute                                                                                                                                                                       | `60`                 |
+| `NEXUS_AUTH_ENABLED`             | Enable MCP auth (applies only to network transports; no effect on the default stdio MCP)                                                                                                  | `true`               |
+| `NEXUS_AUTH_METHOD`              | Auth method                                                                                                                                                                               | `token`              |
+| `NEXUS_DRIFT_ADVISORY`           | Model-string drift CI gate: any value except `0` (incl. unset) = advisory (warn); `0` = blocking (#2199). CI sets `0` to enforce.                                                         | unset (advisory)     |
 
 ### Orchestration Variables
 

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
@@ -160,6 +160,14 @@ describe('buildChildEnv (#2865)', () => {
       vi.stubEnv(NEXUS_SUBPROCESS_EXTRA_ENV, 'FOO, MY_GATEWAY_KEY  BAR');
       expect(buildChildEnv('codex')['MY_GATEWAY_KEY']).toBe('gw');
     });
+
+    it('empty entries (",," / ", ") never forward unrelated secrets (no match-all)', () => {
+      // Guards the load-bearing length>0 filter: an empty name must not become a
+      // wildcard that forwards every var (which would re-create the =0 leak).
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws');
+      vi.stubEnv(NEXUS_SUBPROCESS_EXTRA_ENV, 'FOO,, ,BAR');
+      expect(buildChildEnv('codex')['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+    });
   });
 
   // #4033 — nested-server deadlock guard.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.test.ts
@@ -8,6 +8,7 @@ import {
   getCliVendorKeys,
   readSubprocessDepth,
   NEXUS_SUBPROCESS_DEPTH_ENV,
+  NEXUS_SUBPROCESS_EXTRA_ENV,
 } from './subprocess-env.js';
 
 describe('buildChildEnv (#2865)', () => {
@@ -25,6 +26,8 @@ describe('buildChildEnv (#2865)', () => {
     'NEXUS_CUSTOMTEST',
     'NEXUS_SUBPROCESS_ENV_ALLOWLIST',
     'NEXUS_SUBPROCESS_DEPTH',
+    'NEXUS_SUBPROCESS_EXTRA_ENV',
+    'MY_GATEWAY_KEY',
     'npm_config_registry',
     'SOME_RANDOM_UNLISTED_VAR',
   ];
@@ -131,6 +134,32 @@ describe('buildChildEnv (#2865)', () => {
     for (const cli of ['claude', 'gemini', 'codex', 'opencode'] as const) {
       expect(map[cli].length).toBeGreaterThan(0);
     }
+  });
+
+  // #4037 — granular extra-env allowlist (avoids the =0 hammer for custom gateways).
+  describe('NEXUS_SUBPROCESS_EXTRA_ENV (#4037)', () => {
+    it('forwards an operator-named extra var that is neither vendor nor NEXUS_-prefixed', () => {
+      vi.stubEnv('MY_GATEWAY_KEY', 'gw-secret');
+      // Without the extension, MY_GATEWAY_KEY is stripped (not a vendor/base/NEXUS_ key).
+      expect(buildChildEnv('opencode')['MY_GATEWAY_KEY']).toBeUndefined();
+      vi.stubEnv(NEXUS_SUBPROCESS_EXTRA_ENV, 'MY_GATEWAY_KEY');
+      expect(buildChildEnv('opencode')['MY_GATEWAY_KEY']).toBe('gw-secret');
+    });
+
+    it('still strips OTHER non-allowlisted secrets (isolation preserved, not the =0 hammer)', () => {
+      vi.stubEnv('MY_GATEWAY_KEY', 'gw-secret');
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'aws');
+      vi.stubEnv(NEXUS_SUBPROCESS_EXTRA_ENV, 'MY_GATEWAY_KEY');
+      const env = buildChildEnv('opencode');
+      expect(env['MY_GATEWAY_KEY']).toBe('gw-secret');
+      expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+    });
+
+    it('parses a comma/space-separated list', () => {
+      vi.stubEnv('MY_GATEWAY_KEY', 'gw');
+      vi.stubEnv(NEXUS_SUBPROCESS_EXTRA_ENV, 'FOO, MY_GATEWAY_KEY  BAR');
+      expect(buildChildEnv('codex')['MY_GATEWAY_KEY']).toBe('gw');
+    });
   });
 
   // #4033 — nested-server deadlock guard.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-env.ts
@@ -91,10 +91,38 @@ const CLI_VENDOR_KEYS: Record<CliName, readonly string[]> = {
   ],
 };
 
-/** True if `key` is permitted for a CLI whose vendor keys are `vendorKeys`. */
-function isAllowed(key: string, vendorKeys: readonly string[]): boolean {
+/**
+ * Env var naming ADDITIONAL var names to forward to spawned CLIs
+ * (comma/whitespace-separated). The granular alternative to the
+ * `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` hammer: for a custom gateway whose auth key
+ * is neither `NEXUS_`-prefixed nor a known vendor key (#4037), name it here to
+ * forward ONLY that var while keeping full cross-vendor isolation for everything
+ * else. `NEXUS_`-prefixed itself, so it also reaches nested runs.
+ */
+export const NEXUS_SUBPROCESS_EXTRA_ENV = 'NEXUS_SUBPROCESS_EXTRA_ENV';
+
+/** Parse the operator-configured extra-forward var names (empty when unset). */
+function readExtraEnvNames(env: NodeJS.ProcessEnv): readonly string[] {
+  const raw = env[NEXUS_SUBPROCESS_EXTRA_ENV];
+  if (raw === undefined || raw.trim() === '') return [];
+  return raw
+    .split(/[,\s]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * True if `key` is permitted for a CLI whose vendor keys are `vendorKeys`, plus
+ * any operator-allowlisted `extraEnv` names (#4037).
+ */
+function isAllowed(
+  key: string,
+  vendorKeys: readonly string[],
+  extraEnv: readonly string[]
+): boolean {
   if (BASE_ENV_EXACT.includes(key)) return true;
   if (vendorKeys.includes(key)) return true;
+  if (extraEnv.includes(key)) return true;
   return BASE_ENV_PREFIXES.some((prefix) => key.startsWith(prefix));
 }
 
@@ -106,6 +134,10 @@ function isAllowed(key: string, vendorKeys: readonly string[]): boolean {
  * `CLAUDECODE` is never forwarded — a nested CLI seeing it would
  * believe it's already inside Claude Code, breaking nested sessions
  * (the pre-#2865 behavior also stripped it explicitly).
+ *
+ * Granular extension: {@link NEXUS_SUBPROCESS_EXTRA_ENV} forwards named extra
+ * vars (e.g. a custom gateway key) while keeping cross-vendor isolation — prefer
+ * it over the blunt `=0` hatch (#4037).
  *
  * Escape hatch: `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` restores the
  * pre-#2865 full-passthrough behavior (minus `CLAUDECODE`) — a
@@ -127,10 +159,11 @@ export function buildChildEnv(cliName: CliName): NodeJS.ProcessEnv {
   }
 
   const vendorKeys = CLI_VENDOR_KEYS[cliName];
+  const extraEnv = readExtraEnvNames(source);
   for (const [key, value] of Object.entries(source)) {
     if (value === undefined) continue;
     if (key === 'CLAUDECODE') continue;
-    if (isAllowed(key, vendorKeys)) childEnv[key] = value;
+    if (isAllowed(key, vendorKeys, extraEnv)) childEnv[key] = value;
   }
   childEnv[NEXUS_SUBPROCESS_DEPTH_ENV] = nextDepth;
   return childEnv;

--- a/packages/nexus-agents/src/cli/auto-file-suggestions.test.ts
+++ b/packages/nexus-agents/src/cli/auto-file-suggestions.test.ts
@@ -49,6 +49,14 @@ describe('scrubSensitiveRefs', () => {
       'the configured provider and the configured provider and the configured provider'
     );
   });
+  it('empty entries (",," / ", ") never scrub everything (no match-all regex)', () => {
+    // Guards the load-bearing length>0 filter: an empty term would compile to
+    // /\b\b/gi and replace at every word boundary — catastrophic over-scrub.
+    const env: NodeJS.ProcessEnv = { [SENSITIVE_REFS_ENV]: 'FOO,, ,BAR' };
+    expect(scrubSensitiveRefs('keep all these words intact', env)).toBe(
+      'keep all these words intact'
+    );
+  });
 });
 
 describe('autoFileSuggestions', () => {

--- a/packages/nexus-agents/src/cli/auto-file-suggestions.test.ts
+++ b/packages/nexus-agents/src/cli/auto-file-suggestions.test.ts
@@ -8,9 +8,16 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   autoFileSuggestions,
   scrubSensitiveRefs,
+  SENSITIVE_REFS_ENV,
   MACHINE_SUGGESTED_LABEL,
 } from './auto-file-suggestions.js';
 import type { PipelineTask } from '../pipeline/dev-pipeline.js';
+
+// A synthetic, neutral fictional-company term used only to exercise the scrubber
+// (no real org/gov connotation) — actual sensitive references live in operator
+// config (NEXUS_SENSITIVE_REFS), never in source.
+const FAKE_REF = 'ACMECORP';
+const refEnv: NodeJS.ProcessEnv = { [SENSITIVE_REFS_ENV]: FAKE_REF };
 
 function task(id: string, title = `Title ${id}`, description = `Body ${id}`): PipelineTask {
   return { id, title, description, assignedTo: 'researcher', status: 'pending' };
@@ -20,13 +27,27 @@ const noExisting = (): Promise<boolean> => Promise.resolve(false);
 const okFiler = vi.fn(() => Promise.resolve({ ok: true as const, url: 'https://gh/issue/1' }));
 
 describe('scrubSensitiveRefs', () => {
-  it('replaces sensitive org/gov references', () => {
-    expect(scrubSensitiveRefs('Deploy for USAi today')).toBe(
+  it('replaces operator-configured sensitive references (case-insensitive)', () => {
+    expect(scrubSensitiveRefs(`Deploy for ${FAKE_REF} today`, refEnv)).toBe(
       'Deploy for the configured provider today'
+    );
+    expect(scrubSensitiveRefs('deploy for acmecorp today', refEnv)).toBe(
+      'deploy for the configured provider today'
     );
   });
   it('leaves clean text unchanged', () => {
-    expect(scrubSensitiveRefs('Add a deploy tool')).toBe('Add a deploy tool');
+    expect(scrubSensitiveRefs('Add a deploy tool', refEnv)).toBe('Add a deploy tool');
+  });
+  it('is a no-op when no sensitive refs are configured', () => {
+    expect(scrubSensitiveRefs(`Deploy for ${FAKE_REF} today`, {})).toBe(
+      `Deploy for ${FAKE_REF} today`
+    );
+  });
+  it('handles a multi-term, comma/space-separated list', () => {
+    const env: NodeJS.ProcessEnv = { [SENSITIVE_REFS_ENV]: 'ACMECORP, Initech Globex' };
+    expect(scrubSensitiveRefs('ACMECORP and Initech and Globex', env)).toBe(
+      'the configured provider and the configured provider and the configured provider'
+    );
   });
 });
 
@@ -72,17 +93,23 @@ describe('autoFileSuggestions', () => {
     expect(res.skipped).toEqual([{ id: 'c', reason: 'rate-limit' }]);
   });
 
-  it('scrubs sensitive refs from the filed title and body', async () => {
-    const fileIssue = vi.fn((_opts: { title: string; body: string; labels: readonly string[] }) =>
-      Promise.resolve({ ok: true as const, url: 'u' })
-    );
-    await autoFileSuggestions([task('a', 'Tool for USAi', 'Used by USAi pipelines')], {
-      searchExisting: noExisting,
-      fileIssue,
-    });
-    const arg = fileIssue.mock.calls[0]?.[0];
-    expect(arg?.title).not.toMatch(/USAi/);
-    expect(arg?.body).not.toMatch(/USAi/);
+  it('scrubs operator-configured sensitive refs from the filed title and body', async () => {
+    vi.stubEnv(SENSITIVE_REFS_ENV, FAKE_REF);
+    try {
+      const fileIssue = vi.fn((_opts: { title: string; body: string; labels: readonly string[] }) =>
+        Promise.resolve({ ok: true as const, url: 'u' })
+      );
+      await autoFileSuggestions(
+        [task('a', `Tool for ${FAKE_REF}`, `Used by ${FAKE_REF} pipelines`)],
+        { searchExisting: noExisting, fileIssue }
+      );
+      const arg = fileIssue.mock.calls[0]?.[0];
+      expect(arg?.title).not.toMatch(new RegExp(FAKE_REF, 'i'));
+      expect(arg?.body).not.toMatch(new RegExp(FAKE_REF, 'i'));
+      expect(arg?.title).toContain('the configured provider');
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it('fails closed when the GitHub filer is unavailable (stops, does not crash)', async () => {

--- a/packages/nexus-agents/src/cli/auto-file-suggestions.ts
+++ b/packages/nexus-agents/src/cli/auto-file-suggestions.ts
@@ -37,14 +37,38 @@ export const MACHINE_SUGGESTED_LABEL = 'machine-suggested';
 const DEFAULT_MAX_PER_RUN = 3;
 
 /**
- * Sensitive org/gov reference patterns scrubbed from filed issue text (opsec).
- * Kept minimal + case-insensitive; extend as needed.
+ * Env var holding operator-configured sensitive org/gov reference terms to scrub
+ * from auto-filed issue text (comma/whitespace-separated). The terms are
+ * deliberately NOT hardcoded here: this is a public repo, so an organization's
+ * specific reference must live in that operator's own config, never in source
+ * (opsec — a hardcoded denylist literal is itself a disclosure). Unset/empty ⇒
+ * no scrubbing. Operators who auto-file from a sensitive context MUST set this.
  */
-const SENSITIVE_REF_PATTERNS: readonly RegExp[] = [/\bUSAi\b/gi];
+export const SENSITIVE_REFS_ENV = 'NEXUS_SENSITIVE_REFS';
 
-/** Replaces sensitive org/gov references with a neutral placeholder. */
-export function scrubSensitiveRefs(text: string): string {
-  return SENSITIVE_REF_PATTERNS.reduce(
+/** Escape regex metacharacters in an operator-supplied term. */
+function escapeRegExp(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Word-boundary, case-insensitive patterns from the configured terms (memoized off env). */
+function loadSensitiveRefPatterns(env: NodeJS.ProcessEnv): readonly RegExp[] {
+  const raw = env[SENSITIVE_REFS_ENV];
+  if (raw === undefined || raw.trim() === '') return [];
+  return raw
+    .split(/[,\s]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .map((t) => new RegExp(`\\b${escapeRegExp(t)}\\b`, 'gi'));
+}
+
+/**
+ * Replaces operator-configured sensitive references (see {@link SENSITIVE_REFS_ENV})
+ * with a neutral placeholder. No-op when none are configured. The `env` param is
+ * injectable for tests; production callers use `process.env`.
+ */
+export function scrubSensitiveRefs(text: string, env: NodeJS.ProcessEnv = process.env): string {
+  return loadSensitiveRefPatterns(env).reduce(
     (acc, pattern) => acc.replace(pattern, 'the configured provider'),
     text
   );

--- a/packages/nexus-agents/src/cli/auto-file-suggestions.ts
+++ b/packages/nexus-agents/src/cli/auto-file-suggestions.ts
@@ -162,6 +162,22 @@ async function fileOneTask(task: PipelineTask, deps: ResolvedDeps): Promise<Task
   }
 }
 
+/**
+ * Opsec: warn once per run when filing real issue text with scrubbing
+ * unconfigured. With no {@link SENSITIVE_REFS_ENV} terms the scrubber is a no-op
+ * (by design), so surface the silent-leak window before any issue is filed.
+ */
+function warnIfUnscrubbed(taskCount: number, dryRun: boolean): void {
+  if (taskCount === 0 || dryRun) return;
+  const refs = process.env[SENSITIVE_REFS_ENV];
+  if (refs !== undefined && refs.trim() !== '') return;
+  logger.warn(
+    `Auto-filing issue text with no ${SENSITIVE_REFS_ENV} configured — issue titles/bodies ` +
+      'are NOT scrubbed for org/gov references. Set it to your org terms if filing from a ' +
+      'sensitive context.'
+  );
+}
+
 /** Resolves options to concrete deps (defaults: conservative + real `gh`). */
 function resolveDeps(options: AutoFileOptions): ResolvedDeps {
   return {
@@ -184,6 +200,8 @@ export async function autoFileSuggestions(
   const deps = resolveDeps(options);
   const filed: Array<{ id: string; url: string }> = [];
   const skipped: Array<{ id: string; reason: SkipReason }> = [];
+
+  warnIfUnscrubbed(tasks.length, deps.dryRun);
 
   for (const task of tasks) {
     if (filed.length >= maxPerRun) {

--- a/skills/e2e-validation/SKILL.md
+++ b/skills/e2e-validation/SKILL.md
@@ -84,9 +84,11 @@ When observed behavior contradicts a claim (a "fixed" bug that reproduces, a doc
 lies, a dead voter, a missing stage), file a GitHub issue per the Discovered-Issues
 4-point gate — this is canonical tracking, not a memory note.
 
-- **OPSEC:** scrub `USAi` / government / org references from titles, bodies, and
-  pasted output; generalize to "the configured provider" / "an upstream provider".
-  Keep the technical content.
+- **OPSEC:** scrub government / organization / provider references from titles,
+  bodies, and pasted output; generalize to "the configured provider" / "an upstream
+  provider". Keep the technical content. The auto-file path applies the
+  operator-configured `NEXUS_SENSITIVE_REFS` denylist automatically — set it locally
+  to your org's terms (they are intentionally not hardcoded in this repo).
 - Cite the run (version + SHA), paste the real evidence, and link the claim it
   contradicts (changelog line, doc, or issue that declared it fixed).
 


### PR DESCRIPTION
## What

Two opsec changes that move **organization-specific values out of (public) source into operator config** — the principle that a deployment's sensitive references should never ship in the repo.

### 1. `NEXUS_SUBPROCESS_EXTRA_ENV` (#4037)
A comma/space-separated list of additional env-var **names** to forward to spawned voter CLIs. A custom-gateway operator whose auth key is neither `NEXUS_`-prefixed nor a known vendor key sets `NEXUS_SUBPROCESS_EXTRA_ENV=MY_GATEWAY_KEY` and keeps full cross-vendor key isolation — instead of `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0`, which disables the #2865 allowlist entirely and re-leaks every key to every CLI.

### 2. `NEXUS_SENSITIVE_REFS` (opsec scrubber)
The auto-file issue scrubber (#3382) previously **hardcoded a specific org/gov reference term** in source — a hardcoded denylist literal is itself a disclosure in a public repo. The scrub terms now come from this operator-configured env var; unset ⇒ no scrubbing. Tests use a neutral fictional-company placeholder (`ACMECORP`), so no real reference appears in the tree.

**Action for operators who auto-file from a sensitive context:** set `NEXUS_SENSITIVE_REFS` to your org's terms — the previous built-in default has been removed.

## Verification
- `auto-file-suggestions.test.ts` + `subprocess-env.test.ts`: 29 passed (new cases for both vars + the no-config no-op).
- typecheck / eslint / Producer-Consumer / markdownlint clean.
- Confirmed no residual hardcoded org reference remains in the tree.

## Why now
Closes #4037, and removes the only reason a custom-gateway deployment needed the insecure `=0` hammer (the root of the auth issue behind the voter-tool investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)