### PR TITLE
feat(voting): route consensus voters through the in-process gateway adapter (#4040)

### DIFF
--- a/.changeset/4040-voter-gateway-routing.md
+++ b/.changeset/4040-voter-gateway-routing.md
@@ -13,8 +13,10 @@ nested-spawn class, #4033).
 
 When an OpenAI-compatible gateway is configured (`NEXUS_OPENAI_COMPAT_*`), the voter panel now
 runs **in-process** over the gateway's models — no CLI subprocess, no cross-process key
-forwarding. Per-role model diversity is preserved: the gateway already discovers one adapter
-per served model, and voter roles are round-robined across them (wrapping when the gateway
-serves fewer models than roles). The bootstrap previously discarded all but the first
+forwarding. Per-role model diversity is preserved **when the gateway serves multiple models**:
+the gateway already discovers one adapter per served model, and voter roles are round-robined
+across them (wrapping when it serves fewer models than roles). A gateway that serves only one
+model collapses the panel to that single model — voters then share a model and the run logs a
+correlated-votes warning. The bootstrap previously discarded all but the first
 discovered gateway model; it now keeps the full set and threads it to the voter tools. With no
 gateway configured, behavior is unchanged (the CLI round-robin path).

--- a/.changeset/4040-voter-gateway-routing.md
+++ b/.changeset/4040-voter-gateway-routing.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+Route consensus voters through the in-process gateway adapter ([#4040](https://github.com/nexus-substrate/nexus-agents/issues/4040))
+
+`consensus_vote` and `pr_review` were the only model-using tools not wired to the in-process
+OpenAI-compatible gateway adapter that every other tool already receives. They fell back to
+the CLI adapter path, shelling out to a coding CLI (e.g. `opencode run`) — which is the sole
+reason voting alone required a separate CLI auth and the model key forwarded across the
+subprocess boundary (the root of the `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` workaround and the
+nested-spawn class, #4033).
+
+When an OpenAI-compatible gateway is configured (`NEXUS_OPENAI_COMPAT_*`), the voter panel now
+runs **in-process** over the gateway's models — no CLI subprocess, no cross-process key
+forwarding. Per-role model diversity is preserved: the gateway already discovers one adapter
+per served model, and voter roles are round-robined across them (wrapping when the gateway
+serves fewer models than roles). The bootstrap previously discarded all but the first
+discovered gateway model; it now keeps the full set and threads it to the voter tools. With no
+gateway configured, behavior is unchanged (the CLI round-robin path).

--- a/packages/nexus-agents/src/cli-server-gateway.test.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.test.ts
@@ -14,7 +14,11 @@ vi.mock('./adapters/openai-compat-adapter.js', () => ({
   readOpenAICompatEnv: (...args: unknown[]) => readOpenAICompatEnvMock(...args) as unknown,
 }));
 
-import { tryWireGatewayAdapter } from './cli-server-gateway.js';
+import {
+  tryWireGatewayAdapter,
+  tryWireGatewayAdapters,
+  resolveDefaultModelAdapter,
+} from './cli-server-gateway.js';
 
 function makeMockAdapter(modelId: string): IModelAdapter {
   return {
@@ -203,5 +207,50 @@ describe('tryWireGatewayAdapter', () => {
       const flat = JSON.stringify(allLogCalls);
       expect(flat).not.toContain('sk-secret-key-should-not-leak');
     });
+  });
+});
+
+describe('tryWireGatewayAdapters (#4040 — full list for voter diversity)', () => {
+  beforeEach(() => {
+    delete process.env['NEXUS_SANDBOX'];
+    buildOpenAICompatAdaptersMock.mockReset();
+    readOpenAICompatEnvMock.mockReset();
+  });
+
+  it('returns ALL discovered adapters (not just the first)', async () => {
+    readOpenAICompatEnvMock.mockReturnValue({
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    const adapters = [
+      makeMockAdapter('model-a'),
+      makeMockAdapter('model-b'),
+      makeMockAdapter('model-c'),
+    ];
+    buildOpenAICompatAdaptersMock.mockResolvedValue(ok(adapters));
+    const result = await tryWireGatewayAdapters(makeMockLogger());
+    expect(result).toEqual(adapters);
+    // The singular wrapper still yields only the first (existing single-adapter consumers).
+    expect(await tryWireGatewayAdapter(makeMockLogger())).toBe(adapters[0]);
+  });
+
+  it('returns undefined when no gateway is configured', async () => {
+    readOpenAICompatEnvMock.mockReturnValue(null);
+    expect(await tryWireGatewayAdapters(makeMockLogger())).toBeUndefined();
+  });
+});
+
+describe('resolveDefaultModelAdapter (#4040)', () => {
+  const registryDefault = makeMockAdapter('cli-default');
+  const registry = { getDefault: () => registryDefault };
+
+  it('prefers the primary gateway adapter when present', () => {
+    const gw = [makeMockAdapter('gw-a'), makeMockAdapter('gw-b')];
+    expect(resolveDefaultModelAdapter(gw, registry)).toBe(gw[0]);
+  });
+
+  it('falls back to the registry default when no gateway adapters', () => {
+    expect(resolveDefaultModelAdapter(undefined, registry)).toBe(registryDefault);
+    expect(resolveDefaultModelAdapter([], registry)).toBe(registryDefault);
   });
 });

--- a/packages/nexus-agents/src/cli-server-gateway.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.ts
@@ -39,7 +39,16 @@ import { EXIT_CODES } from './cli-types.js';
  * whichever the gateway lists. Per-model adapter selection lives in the
  * tool handlers, not in the bootstrap.
  */
-export async function tryWireGatewayAdapter(logger: ILogger): Promise<IModelAdapter | undefined> {
+/**
+ * Wire ALL discovered gateway adapters — one per model the gateway serves
+ * (#4040). Same probe/fail-closed contract as {@link tryWireGatewayAdapter};
+ * returns the full list so the voter path can round-robin roles across distinct
+ * models (per-role diversity, all in-process). Returns undefined when no gateway
+ * is configured or the probe fails.
+ */
+export async function tryWireGatewayAdapters(
+  logger: ILogger
+): Promise<readonly IModelAdapter[] | undefined> {
   const sandboxActive = detectSandbox().active;
   const env = readOpenAICompatEnv();
   if (env === null) {
@@ -66,7 +75,24 @@ export async function tryWireGatewayAdapter(logger: ILogger): Promise<IModelAdap
     modelCount: result.value.length,
     models: result.value.map((a) => a.modelId),
   });
-  return result.value[0];
+  return result.value;
+}
+
+export async function tryWireGatewayAdapter(logger: ILogger): Promise<IModelAdapter | undefined> {
+  const all = await tryWireGatewayAdapters(logger);
+  return all?.[0];
+}
+
+/**
+ * The default model adapter: the primary in-process gateway model when a gateway
+ * is configured (#2502/#4040), else the CLI-registry default. The registry is
+ * typed structurally so this stays free of the adapter-registry import.
+ */
+export function resolveDefaultModelAdapter(
+  gatewayAdapters: readonly IModelAdapter[] | undefined,
+  adapterRegistry: { getDefault(): IModelAdapter }
+): IModelAdapter {
+  return gatewayAdapters?.[0] ?? adapterRegistry.getDefault();
 }
 
 function handleMissingEnv(logger: ILogger, sandboxActive: boolean): void {

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -128,6 +128,12 @@ export interface RegisterMcpToolsOptions {
   /** Optional model adapter for real workflow execution with expert agents */
   modelAdapter?: IModelAdapter;
   /**
+   * In-process gateway model adapters (one per discovered gateway model, #4040).
+   * Threaded to consensus_vote/pr_review so voters route through the gateway
+   * instead of a CLI subprocess. Omitted ⇒ voters use the CLI path.
+   */
+  gatewayAdapters?: readonly IModelAdapter[];
+  /**
    * Explicitly allow mock TechLead when no model adapter is available.
    * If false or undefined, an error is thrown when no adapter is detected.
    * (Source: Issue #554 - Fix silent mock TechLead fallback)
@@ -230,6 +236,8 @@ interface ToolRegistrationContext {
   logger: ILogger;
   rateLimiterFactory: ReturnType<typeof createToolRateLimiterFactory>;
   modelAdapter?: IModelAdapter;
+  /** In-process gateway model adapters threaded to voters (#4040). */
+  gatewayAdapters?: readonly IModelAdapter[];
   builtInTemplates: Map<string, WorkflowDefinition>;
   /** Allow mock TechLead when no adapter (Issue #554) */
   useMockTechLead?: boolean;
@@ -363,6 +371,33 @@ function registerListWorkflows(ctx: ToolRegistrationContext, shared: SharedResou
   });
 }
 
+/**
+ * consensus_vote — threads the in-process gateway adapters (#4040) so voters
+ * route through the gateway instead of a CLI subprocess when one is configured.
+ * Mirrors the standard deps (logger/rateLimiter/security/auditLogger) + adds
+ * gatewayAdapters.
+ */
+function registerConsensusVote(ctx: ToolRegistrationContext): void {
+  registerConsensusVoteTool(ctx.server, {
+    logger: ctx.logger,
+    rateLimiter: ctx.rateLimiterFactory.getForTool('consensus_vote'),
+    ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
+    ...(ctx.auditLogger !== undefined && { auditLogger: ctx.auditLogger }),
+    ...(ctx.gatewayAdapters !== undefined && { gatewayAdapters: ctx.gatewayAdapters }),
+  });
+}
+
+/** pr_review — threads gateway adapters (#4040) like consensus_vote. */
+function registerPrReview(ctx: ToolRegistrationContext): void {
+  registerPrReviewTool(ctx.server, {
+    logger: ctx.logger,
+    rateLimiter: ctx.rateLimiterFactory.getForTool('pr_review'),
+    ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
+    ...(ctx.auditLogger !== undefined && { auditLogger: ctx.auditLogger }),
+    ...(ctx.gatewayAdapters !== undefined && { gatewayAdapters: ctx.gatewayAdapters }),
+  });
+}
+
 /** delegate_to_model — independent; does not require a model adapter. */
 function registerDelegate(ctx: ToolRegistrationContext): void {
   registerDelegateToModelTool(ctx.server, {
@@ -450,18 +485,27 @@ function maybeRunStpaAnalysis(options: RegisterMcpToolsOptions, logger: ILogger)
   runStpaSafetyAnalysis(logger, options.failOnHighSeverityHazards ?? false);
 }
 
+/** Optional registration-option keys copied verbatim into the tool context. */
+const OPTIONAL_CONTEXT_KEYS = [
+  'modelAdapter',
+  'gatewayAdapters',
+  'useMockTechLead',
+  'policyFirewall',
+  'executionMode',
+  'allowedPaths',
+  'securityConfig',
+  'workflowConfig',
+  'feedbackIntegration',
+  'auditLogger',
+] as const satisfies readonly (keyof RegisterMcpToolsOptions & keyof ToolRegistrationContext)[];
+
 /** Copies optional properties from registration options, excluding undefined values. */
 function copyOptionalProps(opts: RegisterMcpToolsOptions): Partial<ToolRegistrationContext> {
-  const result: Partial<ToolRegistrationContext> = {};
-  if (opts.modelAdapter !== undefined) result.modelAdapter = opts.modelAdapter;
-  if (opts.useMockTechLead !== undefined) result.useMockTechLead = opts.useMockTechLead;
-  if (opts.policyFirewall !== undefined) result.policyFirewall = opts.policyFirewall;
-  if (opts.executionMode !== undefined) result.executionMode = opts.executionMode;
-  if (opts.allowedPaths !== undefined) result.allowedPaths = opts.allowedPaths;
-  if (opts.securityConfig !== undefined) result.securityConfig = opts.securityConfig;
-  if (opts.workflowConfig !== undefined) result.workflowConfig = opts.workflowConfig;
-  if (opts.feedbackIntegration !== undefined) result.feedbackIntegration = opts.feedbackIntegration;
-  if (opts.auditLogger !== undefined) result.auditLogger = opts.auditLogger;
+  const result: Record<string, unknown> = {};
+  for (const key of OPTIONAL_CONTEXT_KEYS) {
+    const value = opts[key];
+    if (value !== undefined) result[key] = value;
+  }
   return result;
 }
 
@@ -622,7 +666,9 @@ const HANDLER_TABLE: Record<RegisteredToolName, ToolHandler> = {
   memory_stats: standardHandler('memory_stats', registerMemoryStatsTool),
   memory_write: standardHandler('memory_write', registerMemoryWriteTool),
   // Standalone tools
-  consensus_vote: standardHandler('consensus_vote', registerConsensusVoteTool),
+  consensus_vote: (ctx) => {
+    registerConsensusVote(ctx);
+  },
   weather_report: standardHandler('weather_report', registerWeatherReportTool),
   improvement_review: standardHandler('improvement_review', registerImprovementReviewTool),
   registry_import: standardHandler('registry_import', registerRegistryImportTool),
@@ -649,7 +695,9 @@ const HANDLER_TABLE: Record<RegisteredToolName, ToolHandler> = {
   search_codebase: standardHandler('search_codebase', registerSearchCodebaseTool),
   run_dev_pipeline: standardHandler('run_dev_pipeline', registerDevPipelineTool),
   run_pipeline: standardHandler('run_pipeline', registerPipelineTool),
-  pr_review: standardHandler('pr_review', registerPrReviewTool),
+  pr_review: (ctx) => {
+    registerPrReview(ctx);
+  },
   supply_chain_tradeoff_panel: standardHandler(
     'supply_chain_tradeoff_panel',
     registerSupplyChainTradeoffPanelTool

--- a/packages/nexus-agents/src/cli-server.test.ts
+++ b/packages/nexus-agents/src/cli-server.test.ts
@@ -46,6 +46,9 @@ vi.mock('./core/index.js', () => ({
 // stays focused on cli-server's own surface.
 vi.mock('./cli-server-gateway.js', () => ({
   tryWireGatewayAdapter: vi.fn(() => Promise.resolve(undefined)),
+  // #4040: cli-server now also imports these from the gateway module.
+  tryWireGatewayAdapters: vi.fn(() => Promise.resolve(undefined)),
+  resolveDefaultModelAdapter: vi.fn(() => undefined),
 }));
 
 vi.mock('./version.js', () => ({

--- a/packages/nexus-agents/src/cli-server.ts
+++ b/packages/nexus-agents/src/cli-server.ts
@@ -50,7 +50,7 @@ import {
   type AppConfig,
 } from './config/index.js';
 import { initializeExperts } from './cli-server-experts.js';
-import { tryWireGatewayAdapter } from './cli-server-gateway.js';
+import { tryWireGatewayAdapters, resolveDefaultModelAdapter } from './cli-server-gateway.js';
 import { initializeSkillLibrary } from './cli-server-skills.js';
 import { initializeSica } from './cli-server-sica.js';
 import { initializeFeedbackIntegration } from './cli-server-feedback.js';
@@ -404,8 +404,8 @@ async function initializeAndRegisterTools(
   // only available channel to LLMs, so a missing or unreachable gateway is a
   // hard startup failure (see tryWireGatewayAdapter for the matrix). Outside
   // sandbox mode it's optional — falls through to the CLI-based default.
-  const gatewayAdapter = await tryWireGatewayAdapter(logger);
-  const modelAdapter = gatewayAdapter ?? adapterRegistry.getDefault();
+  const gatewayAdapters = await tryWireGatewayAdapters(logger);
+  const modelAdapter = resolveDefaultModelAdapter(gatewayAdapters, adapterRegistry);
   const policyVals = getPolicyValues(config);
   const allowedPaths = config.security?.allowedPaths;
   const securityConfig = config.security;
@@ -417,6 +417,8 @@ async function initializeAndRegisterTools(
     policyFirewall,
     executionMode: policyVals.defaultExec,
     modelAdapter,
+    // Per-model gateway adapters routed to voters (#4040) — in-process, no subprocess.
+    ...(gatewayAdapters !== undefined && { gatewayAdapters }),
     // Gateway middleware for tier-aware dispatch logging (Issue #896, #897)
     gatewayConfig: buildGatewayConfig(config, logger),
     ...(allowedPaths !== undefined && { allowedPaths }),

--- a/packages/nexus-agents/src/cli/voter-agents.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.test.ts
@@ -661,3 +661,97 @@ That's my vote.`;
     });
   });
 });
+
+describe('collectRealVotes — gateway routing (#4040)', () => {
+  const logger = createLogger({ component: 'test', level: 'silent' });
+
+  /** A gateway-style in-process adapter (distinct modelId) returning an approve vote. */
+  function gatewayAdapter(modelId: string): IModelAdapter {
+    return {
+      providerId: 'openai-compat',
+      modelId,
+      capabilities: [],
+      complete: vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          content: JSON.stringify({
+            decision: 'approve',
+            reasoning: `ok from ${modelId}`,
+            confidence: 0.9,
+          }) as unknown as CompletionResponse['content'],
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          stopReason: 'end_turn' as const,
+          model: modelId,
+        },
+      }),
+      stream: vi.fn(),
+      countTokens: vi.fn().mockResolvedValue(10),
+      validateConfig: vi.fn().mockReturnValue({ ok: true }),
+    };
+  }
+
+  const calls = (a: IModelAdapter): number =>
+    (a.complete as ReturnType<typeof vi.fn>).mock.calls.length;
+
+  it('round-robins roles across the per-model gateway adapters (in-process, no CLI)', async () => {
+    const a = gatewayAdapter('gw-a');
+    const b = gatewayAdapter('gw-b');
+    const c = gatewayAdapter('gw-c');
+    const roles: VoterRole[] = ['architect', 'security', 'scope_steward'];
+
+    const results = await collectRealVotes({
+      roles,
+      proposal: 'ship it',
+      gatewayAdapters: [a, b, c],
+      logger,
+      timeoutMs: 5000,
+      maxRetries: 1,
+      interAgentDelayMs: 0,
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.source === 'llm')).toBe(true);
+    // 3 roles across 3 gateway adapters → each invoked exactly once. That the
+    // gateway adapters were called at all proves voters did NOT shell to a CLI.
+    expect(calls(a)).toBe(1);
+    expect(calls(b)).toBe(1);
+    expect(calls(c)).toBe(1);
+  });
+
+  it('wraps round-robin when the gateway serves fewer models than roles', async () => {
+    const a = gatewayAdapter('gw-a');
+    const b = gatewayAdapter('gw-b');
+    const roles: VoterRole[] = ['architect', 'security', 'scope_steward'];
+
+    await collectRealVotes({
+      roles,
+      proposal: 'ship it',
+      gatewayAdapters: [a, b],
+      logger,
+      timeoutMs: 5000,
+      maxRetries: 1,
+      interAgentDelayMs: 0,
+    });
+
+    // indices 0,2 → a; index 1 → b.
+    expect(calls(a)).toBe(2);
+    expect(calls(b)).toBe(1);
+  });
+
+  it('uses a single gateway model for all roles when only one is served', async () => {
+    const only = gatewayAdapter('gw-only');
+    const roles: VoterRole[] = ['architect', 'security', 'scope_steward'];
+
+    await collectRealVotes({
+      roles,
+      proposal: 'ship it',
+      gatewayAdapters: [only],
+      logger,
+      timeoutMs: 5000,
+      maxRetries: 1,
+      interAgentDelayMs: 0,
+    });
+
+    expect(calls(only)).toBe(3);
+  });
+});

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -221,6 +221,15 @@ export interface CollectRealVotesOptions extends VoterAgentOptions {
   readonly proposal: string;
   /** Use simulation mode (explicit opt-in only) */
   readonly simulate?: boolean;
+  /**
+   * In-process gateway model adapters (#4040) — one per discovered gateway model.
+   * When provided (and no explicit `adapter` override), voters route through these
+   * HTTP adapters instead of shelling out to CLIs: roles are round-robined across
+   * them for per-role model diversity, the API key stays in-process (no subprocess
+   * env-forwarding), and the nested-spawn class (#4033) cannot occur. Empty/omitted
+   * ⇒ the CLI round-robin path is used (unchanged).
+   */
+  readonly gatewayAdapters?: readonly IModelAdapter[] | undefined;
 }
 
 /**
@@ -242,6 +251,13 @@ function resolveAdapter(
 ): { adapter: IModelAdapter } | { error: string } {
   try {
     if (options.adapter !== undefined) return { adapter: options.adapter };
+    // #4040: prefer an in-process gateway adapter as the fallback so a
+    // gateway-only environment (no CLIs installed) never hits the CLI registry,
+    // which would throw "No model adapter configured".
+    const gateway = options.gatewayAdapters;
+    if (gateway !== undefined && gateway.length > 0 && gateway[0] !== undefined) {
+      return { adapter: gateway[0] };
+    }
     const registry = getGlobalRegistry({ logger });
     return { adapter: registry.getDefault() };
   } catch (error) {
@@ -294,11 +310,56 @@ function createCliAdapterMap(
  * Distributes roles across CLIs in round-robin fashion for model diversity.
  * Falls back to single adapter if only one CLI is available.
  */
+/**
+ * Round-robin assign roles across a labeled adapter list (the shared diversity
+ * primitive for both the CLI path and the gateway path #4040). `label` is the
+ * model/CLI id surfaced in the assignment log so operators can confirm which
+ * model each role used.
+ */
+function assignRoundRobinAdapters(
+  roles: readonly VoterRole[],
+  entries: readonly { readonly label: string; readonly adapter: IModelAdapter }[],
+  logger: ILogger,
+  source: string
+): Map<VoterRole, IModelAdapter> {
+  const adapters = new Map<VoterRole, IModelAdapter>();
+  const assignments: Record<string, string> = {};
+  for (let i = 0; i < roles.length; i++) {
+    const role = roles[i];
+    const entry = entries[i % entries.length];
+    if (role === undefined || entry === undefined) continue;
+    adapters.set(role, entry.adapter);
+    assignments[role] = entry.label;
+  }
+  logger.info('Diverse adapters assigned', {
+    source,
+    count: entries.length,
+    roleAssignments: assignments,
+  });
+  return adapters;
+}
+
 async function resolveDiverseAdapters(
   roles: readonly VoterRole[],
   logger: ILogger,
-  fallbackAdapter: IModelAdapter
+  fallbackAdapter: IModelAdapter,
+  gatewayAdapters?: readonly IModelAdapter[]
 ): Promise<Map<VoterRole, IModelAdapter>> {
+  // #4040: gateway path — round-robin roles across the in-process per-model
+  // gateway adapters (HTTP, no subprocess). Preferred when configured.
+  if (gatewayAdapters !== undefined && gatewayAdapters.length > 0) {
+    if (gatewayAdapters.length === 1) {
+      logger.info('Single gateway model for all roles', { model: gatewayAdapters[0]?.modelId });
+      return assignUniformAdapter(roles, gatewayAdapters[0] ?? fallbackAdapter);
+    }
+    return assignRoundRobinAdapters(
+      roles,
+      gatewayAdapters.map((a) => ({ label: a.modelId, adapter: a })),
+      logger,
+      'gateway'
+    );
+  }
+
   let availableClis: CliName[];
   try {
     availableClis = await getAvailableClis();
@@ -317,24 +378,12 @@ async function resolveDiverseAdapters(
   const cliAdapters = createCliAdapterMap(availableClis, logger);
   if (cliAdapters.size <= 1) return assignUniformAdapter(roles, fallbackAdapter);
 
-  // Round-robin assign roles to diverse CLIs
-  const cliList = [...cliAdapters.entries()];
-  const adapters = new Map<VoterRole, IModelAdapter>();
-  const assignments: Record<string, string> = {};
-  for (let i = 0; i < roles.length; i++) {
-    const role = roles[i];
-    const entry = cliList[i % cliList.length];
-    if (role === undefined || entry === undefined) continue;
-    adapters.set(role, entry[1]);
-    assignments[role] = entry[0];
-  }
-
-  logger.info('Diverse adapters assigned', {
-    cliCount: cliAdapters.size,
-    clis: [...cliAdapters.keys()],
-    roleAssignments: assignments,
-  });
-  return adapters;
+  return assignRoundRobinAdapters(
+    roles,
+    [...cliAdapters.entries()].map(([cli, adapter]) => ({ label: cli, adapter })),
+    logger,
+    'cli'
+  );
 }
 
 /** Options for staggered vote launching. */
@@ -429,7 +478,7 @@ export async function collectRealVotes(
   const roleAdapters =
     options.adapter !== undefined
       ? assignUniformAdapter(roles, adapterResult.adapter)
-      : await resolveDiverseAdapters(roles, logger, adapterResult.adapter);
+      : await resolveDiverseAdapters(roles, logger, adapterResult.adapter, options.gatewayAdapters);
 
   warnIfCodexConcurrencyExceeded(roleAdapters, logger);
 

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -349,7 +349,16 @@ async function resolveDiverseAdapters(
   // gateway adapters (HTTP, no subprocess). Preferred when configured.
   if (gatewayAdapters !== undefined && gatewayAdapters.length > 0) {
     if (gatewayAdapters.length === 1) {
-      logger.info('Single gateway model for all roles', { model: gatewayAdapters[0]?.modelId });
+      // Consensus integrity: a multi-role panel on ONE model yields correlated
+      // votes (the higher_order strategy can't down-weight what it can't tell
+      // apart). Warn so operators notice — configure the gateway with more models
+      // for a genuinely diverse panel.
+      if (roles.length > 1) {
+        logger.warn('Consensus panel collapsed to a single gateway model — votes may correlate', {
+          model: gatewayAdapters[0]?.modelId,
+          roleCount: roles.length,
+        });
+      }
       return assignUniformAdapter(roles, gatewayAdapters[0] ?? fallbackAdapter);
     }
     return assignRoundRobinAdapters(

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -63,6 +63,7 @@ import {
 import type { VoteRecordPersistOutcome } from './consensus-vote-recording.js';
 import { recordDecisionCost } from './decision-cost-recording.js';
 import { DecisionCostSummarySchema } from '../../observability/decision-cost.js';
+import type { IModelAdapter } from '../../core/index.js';
 import { emitVoteRejectedSignal } from './consensus-vote-signals.js';
 import { getPipelineEventBus } from '../../pipeline/event-bus.js';
 import { warnIfSimulatedOutsideTests } from './simulation-guard.js';
@@ -133,6 +134,13 @@ export function resetCorrelationTracker(): void {
 export interface ConsensusVoteDeps extends BaseMcpToolDeps {
   /** MCP notifier for client-visible logging (Issue #974) */
   notifier?: IMcpNotifier | undefined;
+  /**
+   * In-process gateway model adapters (#4040). When the server has a configured
+   * OpenAI-compatible gateway, voters route through these HTTP adapters instead
+   * of shelling out to a CLI subprocess — no per-subprocess key forwarding, and
+   * the nested-spawn deadlock (#4033) cannot occur. Omitted ⇒ CLI voter path.
+   */
+  gatewayAdapters?: readonly IModelAdapter[] | undefined;
 }
 
 // --- Strategy Resolution ---
@@ -561,7 +569,7 @@ async function maybeEscalateContrarian(
 export async function executeVoting(
   input: ConsensusVoteInput,
   logger: ILogger,
-  opts?: { voteTimeoutMs?: number }
+  opts?: { voteTimeoutMs?: number; gatewayAdapters?: readonly IModelAdapter[] | undefined }
 ): Promise<ExtendedVotingResult> {
   const strategy = resolveStrategy(input);
   const algorithm = strategyToAlgorithm(strategy);
@@ -580,6 +588,7 @@ export async function executeVoting(
     proposal: input.proposal,
     simulate: input.simulateVotes,
     ...(opts?.voteTimeoutMs !== undefined && { timeoutMs: opts.voteTimeoutMs }),
+    ...(opts?.gatewayAdapters !== undefined && { gatewayAdapters: opts.gatewayAdapters }),
   });
 
   // Error-policy gate (#2630): hard floor + fail_closed + reduce_denominator /
@@ -736,7 +745,9 @@ async function handleConsensusVote(
   const logger = deps.logger ?? createLogger({ tool: 'consensus_vote' });
   if (args.simulateVotes) warnIfSimulatedOutsideTests('consensus_vote', logger);
   try {
-    const result = await executeVoting(args, logger);
+    const result = await executeVoting(args, logger, {
+      ...(deps.gatewayAdapters !== undefined && { gatewayAdapters: deps.gatewayAdapters }),
+    });
     const strategy = args.strategy ?? 'simple_majority';
 
     // Detect all-error votes: return structured error instead of fake "rejected" (#1552)

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -537,7 +537,10 @@ async function maybeEscalateContrarian(
   outcome: 'approved' | 'rejected',
   ctx: { strategy: VotingStrategy; posteriorApproval: number | undefined },
   logger: ILogger,
-  opts?: { voteTimeoutMs?: number }
+  // Mirror executeVoting's opts so gateway routing (#4040) survives the escalation
+  // re-vote — the object is forwarded by reference today, but the wider type makes
+  // that contract explicit and refactor-safe.
+  opts?: { voteTimeoutMs?: number; gatewayAdapters?: readonly IModelAdapter[] | undefined }
 ): Promise<ExtendedVotingResult | undefined> {
   if (!input.quickMode || outcome !== 'approved' || input.simulateVotes) return undefined;
 

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -18,7 +18,13 @@
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
+import {
+  createLogger,
+  formatZodError,
+  getErrorMessage,
+  type ILogger,
+  type IModelAdapter,
+} from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -172,7 +178,14 @@ export interface PrReviewResponse {
   readonly costSummary?: DecisionCostSummary;
 }
 
-export type PrReviewDeps = BaseMcpToolDeps;
+export interface PrReviewDeps extends BaseMcpToolDeps {
+  /**
+   * In-process gateway model adapters (#4040) — routes the review panel through
+   * the gateway (HTTP, in-process) instead of a CLI subprocess when configured.
+   * Omitted ⇒ CLI voter path.
+   */
+  gatewayAdapters?: readonly IModelAdapter[] | undefined;
+}
 
 // ============================================================================
 // Decision Mapping
@@ -344,7 +357,11 @@ function summarizeReviews(reviews: readonly PrReviewVote[]): {
  * `collectRealVotes` is the long pole (live LLM fan-out), so the whole body
  * is what backgrounds.
  */
-async function executePrReviewBody(input: PrReviewInput, logger: ILogger): Promise<ToolResult> {
+async function executePrReviewBody(
+  input: PrReviewInput,
+  logger: ILogger,
+  gatewayAdapters?: readonly IModelAdapter[]
+): Promise<ToolResult> {
   const start = Date.now();
   const proposal = buildPrReviewProposal(input);
   const voteResults = await collectRealVotes({
@@ -352,6 +369,7 @@ async function executePrReviewBody(input: PrReviewInput, logger: ILogger): Promi
     proposal,
     simulate: input.simulate,
     logger,
+    ...(gatewayAdapters !== undefined && { gatewayAdapters }),
   });
 
   const reviews = voteResults.map(toPrReviewVote);
@@ -385,39 +403,46 @@ async function executePrReviewBody(input: PrReviewInput, logger: ILogger): Promi
   return toolSuccess(JSON.stringify(response, null, 2));
 }
 
-async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
-  const parsed = PrReviewInputSchema.safeParse(args);
-  if (!parsed.success) {
-    return toolStructuredError({
-      errorCategory: 'validation',
-      message: `Validation error: ${formatZodError(parsed.error)}`,
-    });
-  }
-  const input = parsed.data;
-
-  try {
-    // #3731: async dispatch — the 5-voter live fan-out can exceed the MCP
-    // request timeout. pr_review has no sessionId, so a fresh `pr-<uuid>` jobId
-    // is always minted (no idempotency surface). Returns a pending envelope.
-    if (input.dispatch === 'async') {
-      return runAsJob<PrReviewInput, ToolResult>({
-        toolName: 'pr_review',
-        input,
-        freshJobId: () => `pr-${randomUUID()}`,
-        run: () => executePrReviewBody(input, ctx.logger),
-        logger: ctx.logger,
+/**
+ * Build the pr_review handler, capturing the in-process gateway adapters (#4040)
+ * so the review panel routes through the gateway instead of a CLI subprocess
+ * when one is configured.
+ */
+function makePrReviewHandler(gatewayAdapters?: readonly IModelAdapter[]) {
+  return async function prReviewHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
+    const parsed = PrReviewInputSchema.safeParse(args);
+    if (!parsed.success) {
+      return toolStructuredError({
+        errorCategory: 'validation',
+        message: `Validation error: ${formatZodError(parsed.error)}`,
       });
     }
-    return await executePrReviewBody(input, ctx.logger);
-  } catch (error) {
-    // #3731 discoverability: a sync run that times out (or otherwise fails)
-    // should point the caller at async mode — the durable fix for runs that
-    // exceed the request timeout.
-    return toolStructuredError({
-      errorCategory: 'internal',
-      message: `${PR_REVIEW_ASYNC_HINT} PR review failed: ${getErrorMessage(error)}`,
-    });
-  }
+    const input = parsed.data;
+
+    try {
+      // #3731: async dispatch — the 5-voter live fan-out can exceed the MCP
+      // request timeout. pr_review has no sessionId, so a fresh `pr-<uuid>` jobId
+      // is always minted (no idempotency surface). Returns a pending envelope.
+      if (input.dispatch === 'async') {
+        return runAsJob<PrReviewInput, ToolResult>({
+          toolName: 'pr_review',
+          input,
+          freshJobId: () => `pr-${randomUUID()}`,
+          run: () => executePrReviewBody(input, ctx.logger, gatewayAdapters),
+          logger: ctx.logger,
+        });
+      }
+      return await executePrReviewBody(input, ctx.logger, gatewayAdapters);
+    } catch (error) {
+      // #3731 discoverability: a sync run that times out (or otherwise fails)
+      // should point the caller at async mode — the durable fix for runs that
+      // exceed the request timeout.
+      return toolStructuredError({
+        errorCategory: 'internal',
+        message: `${PR_REVIEW_ASYNC_HINT} PR review failed: ${getErrorMessage(error)}`,
+      });
+    }
+  };
 }
 
 // ============================================================================
@@ -432,7 +457,7 @@ export function registerPrReviewTool(server: McpServer, deps: PrReviewDeps): voi
     'devex, catfish, scope_steward) each emit approve/request_changes/abstain with reasoning ' +
     'and citations. Reuses consensus_vote infra; experimental.';
 
-  const secureHandler = createSecureHandler(prReviewHandler, {
+  const secureHandler = createSecureHandler(makePrReviewHandler(deps.gatewayAdapters), {
     toolName: 'pr_review',
     rateLimiter: deps.rateLimiter,
     logger,


### PR DESCRIPTION
## What

`consensus_vote` and `pr_review` were the **only** model-using tools not wired to the in-process OpenAI-compatible gateway adapter that every other tool already receives. They fell back to the CLI adapter path — shelling out to a coding CLI (e.g. `opencode run`) — which is the *sole* reason voting alone required a separate CLI auth and the model key forwarded across the subprocess boundary (the root of the `NEXUS_SUBPROCESS_ENV_ALLOWLIST=0` workaround and the #4033 nested-spawn class).

## Fix

When `NEXUS_OPENAI_COMPAT_*` is configured, the voter panel now runs **in-process** over the gateway's models — no CLI subprocess, no cross-process key forwarding, and the nested-spawn deadlock cannot occur.

- **Per-role model diversity preserved:** `buildOpenAICompatAdapters` already mints one adapter per discovered gateway model; the bootstrap previously kept only the first (`tryWireGatewayAdapter` → `[0]`). It now keeps the full set (`tryWireGatewayAdapters`) and threads it to the voter tools. Voter roles are round-robined across the per-model adapters (wraps when the gateway serves fewer models than roles) — the same diversity primitive the CLI path used, now over models.
- **Threading:** `gatewayAdapters` flows cli-server → `RegisterMcpToolsOptions` → `ToolRegistrationContext` → custom `consensus_vote`/`pr_review` handlers → deps → `collectRealVotes` → `resolveDiverseAdapters` gateway branch.
- **Fallback unchanged:** no gateway configured ⇒ the existing CLI round-robin path.

## Verification

- New tests: voter-agents gateway round-robin (3 roles/3 models → 1 each; wrap; single-model); `tryWireGatewayAdapters` returns the full list; `resolveDefaultModelAdapter` primary-vs-fallback.
- Affected suites (voter-agents, consensus-vote, pr-review-tool, cli-server-tools, cli-server-gateway): all green (230 tests). typecheck / eslint / Producer-Consumer clean.

## Why this is the real fix

This removes the architectural reason voting alone needed the subprocess key — pairing with #4037 (`NEXUS_SUBPROCESS_EXTRA_ENV`) so a gateway deployment can drop `=0` entirely, and rendering the #4033 nested-spawn path unreachable for gateway voters.

Closes #4040

🤖 Generated with [Claude Code](https://claude.com/claude-code)