### PR TITLE
docs(install): document the two benign npm deprecation warnings (#4043, #4044)

### DIFF
--- a/docs/getting-started/INSTALLATION.md
+++ b/docs/getting-started/INSTALLATION.md
@@ -480,6 +480,22 @@ rm -rf ~/.config/nexus-agents
 
 ## Troubleshooting
 
+### `npm warn deprecated` on install (benign — no action needed)
+
+Installing `nexus-agents` prints two deprecation warnings. **Both are benign,
+expected, and safe to ignore** — they come from transitive dependencies of
+upstream packages, not from anything in the nexus-agents runtime:
+
+| Warning                                                                | Where it comes from                                               | Why it's harmless                                                                                                                                                                          |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `prebuild-install@…: No longer maintained`                             | `better-sqlite3` (latest still depends on it)                     | Runs only at **install time** to download the prebuilt SQLite binary. Not part of the runtime, not a security risk. ([#4043](https://github.com/nexus-substrate/nexus-agents/issues/4043)) |
+| `node-domexception@…: Use your platform's native DOMException instead` | `@google/genai` → `google-auth-library` → `gaxios` → `node-fetch` | A `DOMException` polyfill that is a no-op on Node ≥ 22 (which ships a native `DOMException`). Inert at runtime. ([#4044](https://github.com/nexus-substrate/nexus-agents/issues/4044))     |
+
+Neither can currently be removed by upgrading: both persist in the **latest**
+versions of those upstream packages, and a library's `overrides` do not
+propagate to consumers. They will clear once the upstream maintainers drop the
+deprecated transitive deps; the linked issues track that.
+
 ### "Cannot find module" errors
 
 Clear the npm cache and reinstall:


### PR DESCRIPTION
## What

Adds a Troubleshooting subsection to INSTALLATION.md documenting the two `npm warn deprecated` warnings on `npm install nexus-agents`, so consumers don't re-file them:

- **`prebuild-install`** ← `better-sqlite3` (install-time only; latest still deps it) — #4043
- **`node-domexception`** ← `@google/genai` → google-auth → gaxios → node-fetch (inert DOMException ponyfill on Node ≥22) — #4044

## Why

Investigation (this is the deliverable for the deprecation question) found **both warnings are benign and not removable by upgrading** — they persist in the latest upstream versions, and a library's `overrides` don't propagate to consumers. The `consensus_vote` (7/7, higher_order) decided to **defer** the only elimination path (migrating off better-sqlite3 to the experimental `node:sqlite`) as a bad trade. Voters' condition: document the warnings as benign. This does that.

Tracked: #4043, #4044 (upstream-blocked, with watch triggers); #4045 (separate @google/genai major-bump hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)