### PR TITLE
fix(adapters): surface real HTTP status + body for OpenAI-compatible gateway errors (#4047)

### DIFF
--- a/.changeset/4047-openai-compat-error-surfacing.md
+++ b/.changeset/4047-openai-compat-error-surfacing.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Surface the real HTTP status + body for OpenAI / OpenAI-compatible gateway errors ([#4047](https://github.com/nexus-substrate/nexus-agents/issues/4047))
+
+When a request to OpenAI or a custom OpenAI-compatible (litellm-style) gateway failed, the
+adapter discarded the OpenAI SDK `APIError`'s `status`/`type`/`code`/`param`/body and kept
+only the SDK's `.message` — which for an unparseable error body collapses to the useless
+`"400 status code (no body)"`. `OpenAIAdapter.transformError` now surfaces the real HTTP
+status and the gateway's response body (while preserving the fields the error classifier
+keys on), so a gateway rejection is diagnosable instead of opaque.
+
+This also corrects a mis-diagnosis: the `<provider>/<model>` seen in such errors is the
+error **format** (`providerId`/`modelId`), not a transport prefix injected into the request
+`model` field — the request already sends the bare model id. (A "strip the prefix" change
+would have been wrong and would break gateways that require `provider/model`, e.g. OpenRouter.)

--- a/packages/nexus-agents/src/adapters/openai-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.test.ts
@@ -19,16 +19,21 @@ const mocks = vi.hoisted(() => {
   return { mockCreate };
 });
 
-// Mock the OpenAI SDK - reference hoisted mock
-vi.mock('openai', () => ({
-  default: class MockOpenAI {
-    chat = {
-      completions: {
-        create: mocks.mockCreate,
-      },
-    };
-  },
-}));
+// Mock the OpenAI SDK - reference hoisted mock. Keep the REAL `APIError` (the
+// adapter's #4047 error-surfacing does `instanceof APIError`), only stub the client.
+vi.mock('openai', async () => {
+  const actual = await vi.importActual<typeof import('openai')>('openai');
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: mocks.mockCreate,
+        },
+      };
+    },
+    APIError: actual.APIError,
+  };
+});
 
 // Re-export for test access
 const mockCreate = mocks.mockCreate;
@@ -40,6 +45,7 @@ import {
   OPENAI_MODEL_ALIASES,
   type OpenAIAdapterConfig,
 } from './openai-adapter.js';
+import { APIError } from 'openai';
 
 describe('OpenAIAdapter', () => {
   const validConfig: OpenAIAdapterConfig = {
@@ -420,6 +426,45 @@ describe('OpenAIAdapter', () => {
       if (!result.ok) {
         expect(result.error.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
       }
+    });
+
+    it('surfaces the gateway HTTP status + body for an OpenAI APIError (#4047)', async () => {
+      // A compat gateway's rejection — previously collapsed to an opaque
+      // "<provider>/<model>: 400 status code (no body)".
+      const apiError = new APIError(
+        422,
+        {
+          error: {
+            message: 'unsupported parameter',
+            type: 'invalid_request_error',
+            param: 'max_completion_tokens',
+          },
+        },
+        'unprocessable',
+        undefined
+      );
+      mockCreate.mockRejectedValueOnce(apiError);
+
+      const adapter = new OpenAIAdapter(validConfig);
+      const result = await adapter.complete({ messages: [{ role: 'user', content: 'Hi!' }] });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // Real status is now explicit (not the SDK's opaque collapse)...
+        expect(result.error.message).toContain('HTTP 422');
+        // ...and the gateway's body (which carries the real reason) is surfaced.
+        expect(result.error.message).toContain('max_completion_tokens');
+        // The bare model id (not a transport prefix) is what the request used.
+        expect(result.error.message).toContain('openai/gpt-4o');
+      }
+    });
+
+    it('leaves non-APIError errors unchanged (classification preserved)', async () => {
+      mockCreate.mockRejectedValueOnce(Object.assign(new Error('boom'), { status: 503 }));
+      const adapter = new OpenAIAdapter(validConfig);
+      const result = await adapter.complete({ messages: [{ role: 'user', content: 'Hi!' }] });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.message).toContain('boom');
     });
 
     it('should set MODEL_TIMEOUT error code for timeout errors', async () => {

--- a/packages/nexus-agents/src/adapters/openai-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.test.ts
@@ -456,6 +456,25 @@ describe('OpenAIAdapter', () => {
         expect(result.error.message).toContain('max_completion_tokens');
         // The bare model id (not a transport prefix) is what the request used.
         expect(result.error.message).toContain('openai/gpt-4o');
+        // 422 is not a special code → MODEL_ERROR (classification through the override).
+        expect(result.error.code).toBe(ErrorCode.MODEL_ERROR);
+      }
+    });
+
+    it('preserves error-code classification through the APIError override (429 → rate-limited)', async () => {
+      const apiError = new APIError(
+        429,
+        { error: { message: 'rate limited' } },
+        'too many',
+        undefined
+      );
+      mockCreate.mockRejectedValueOnce(apiError);
+      const adapter = new OpenAIAdapter(validConfig);
+      const result = await adapter.complete({ messages: [{ role: 'user', content: 'Hi!' }] });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+        expect(result.error.message).toContain('HTTP 429');
       }
     });
 

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -9,7 +9,7 @@
  * (Source: npm registry)
  */
 
-import OpenAI from 'openai';
+import OpenAI, { APIError } from 'openai';
 import type { ChatCompletionMessageParam, ChatCompletion } from 'openai/resources/chat/completions';
 import type {
   Result,
@@ -68,6 +68,50 @@ export { OPENAI_MODELS, OPENAI_MODEL_ALIASES, type OpenAIAdapterConfig } from '.
  * }
  * ```
  */
+
+/**
+ * Compose a diagnostic string from an OpenAI SDK `APIError`'s real fields
+ * (#4047). The SDK's `.message` alone can be as useless as
+ * `"400 status code (no body)"` for an OpenAI-compatible gateway; this pulls the
+ * HTTP status, structured error fields, and the raw body so the actual rejection
+ * reason is visible.
+ */
+/** Typed structural view of the OpenAI SDK `APIError` fields we read (the SDK's
+ * generic `APIError<any,…>` otherwise leaks `any`). */
+interface ApiErrorView {
+  readonly status?: number | null;
+  readonly type?: string | null;
+  readonly code?: string | null;
+  readonly param?: string | null;
+  readonly requestID?: string | null;
+  readonly error?: unknown;
+  readonly message?: string;
+}
+
+/** `key=value` tag, or `''` when the value is absent. */
+function kvTag(key: string, val: string | number | null | undefined): string {
+  return val === null || val === undefined || val === '' ? '' : `${key}=${String(val)}`;
+}
+
+function describeOpenAIApiError(v: ApiErrorView): string {
+  const tags = [
+    `HTTP ${String(v.status ?? 'unknown')}`,
+    kvTag('type', v.type),
+    kvTag('code', v.code),
+    kvTag('param', v.param),
+    kvTag('request_id', v.requestID),
+  ].filter((t) => t !== '');
+  let body = '';
+  if (v.error !== undefined && v.error !== null) {
+    try {
+      body = ` body=${JSON.stringify(v.error)}`;
+    } catch {
+      body = ' body=<unserializable>';
+    }
+  }
+  return `${tags.join(' ')}: ${v.message ?? ''}${body}`;
+}
+
 export class OpenAIAdapter extends BaseAdapter {
   private readonly client: OpenAI;
   private readonly resolvedModelId: string;
@@ -165,6 +209,29 @@ export class OpenAIAdapter extends BaseAdapter {
     } catch (error) {
       return err(this.transformError(error));
     }
+  }
+
+  /**
+   * Surface an OpenAI / OpenAI-compatible gateway's REAL HTTP status + response
+   * body in the error (#4047). The OpenAI SDK's default message collapses a
+   * gateway rejection to e.g. `"400 status code (no body)"`, which hides WHY a
+   * litellm-style gateway rejected a request — exactly the wall hit when
+   * diagnosing degraded voter panels on a custom gateway. We re-message with the
+   * status/type/code/param/request-id/body while preserving the fields the base
+   * classifier keys on (`status`/`code`/`message`), so error-code routing is
+   * unchanged. Applies to direct OpenAI and the compat gateway alike.
+   */
+  protected override transformError(error: unknown): ModelError {
+    if (error instanceof APIError) {
+      const v = error as ApiErrorView;
+      const tagged: Error & { status?: number | undefined; code?: string | null | undefined } =
+        new Error(describeOpenAIApiError(v));
+      tagged.status = typeof v.status === 'number' ? v.status : undefined;
+      tagged.code = v.code ?? undefined;
+      tagged.cause = error;
+      return super.transformError(tagged);
+    }
+    return super.transformError(error);
   }
 
   /**

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -104,13 +104,17 @@ function describeOpenAIApiError(v: ApiErrorView): string {
   let body = '';
   if (v.error !== undefined && v.error !== null) {
     try {
-      body = ` body=${JSON.stringify(v.error)}`;
+      const raw = JSON.stringify(v.error);
+      body = ` body=${raw.length > MAX_ERROR_BODY_CHARS ? `${raw.slice(0, MAX_ERROR_BODY_CHARS)}…` : raw}`;
     } catch {
       body = ' body=<unserializable>';
     }
   }
   return `${tags.join(' ')}: ${v.message ?? ''}${body}`;
 }
+
+/** Cap the surfaced gateway error body so a huge response can't bloat logs/messages. */
+const MAX_ERROR_BODY_CHARS = 600;
 
 export class OpenAIAdapter extends BaseAdapter {
   private readonly client: OpenAI;
@@ -217,19 +221,25 @@ export class OpenAIAdapter extends BaseAdapter {
    * gateway rejection to e.g. `"400 status code (no body)"`, which hides WHY a
    * litellm-style gateway rejected a request — exactly the wall hit when
    * diagnosing degraded voter panels on a custom gateway. We re-message with the
-   * status/type/code/param/request-id/body while preserving the fields the base
-   * classifier keys on (`status`/`code`/`message`), so error-code routing is
-   * unchanged. Applies to direct OpenAI and the compat gateway alike.
+   * status/type/code/param/request-id/body. Error-code routing is unchanged: we
+   * classify on the ORIGINAL signal (`status`/`code`/`message`) via a clean probe
+   * error, so the diagnostic `request_id`/`body` can't pollute the message-
+   * substring classifier, then re-message the result with the full detail.
+   * Applies to direct OpenAI and the compat gateway alike.
    */
   protected override transformError(error: unknown): ModelError {
     if (error instanceof APIError) {
       const v = error as ApiErrorView;
-      const tagged: Error & { status?: number | undefined; code?: string | null | undefined } =
-        new Error(describeOpenAIApiError(v));
-      tagged.status = typeof v.status === 'number' ? v.status : undefined;
-      tagged.code = v.code ?? undefined;
-      tagged.cause = error;
-      return super.transformError(tagged);
+      // Classify on the original SDK message + status/code only.
+      const probe: Error & { status?: number | undefined; code?: string | null | undefined } =
+        new Error(typeof v.message === 'string' ? v.message : '');
+      probe.status = typeof v.status === 'number' ? v.status : undefined;
+      probe.code = v.code ?? undefined;
+      probe.cause = error;
+      const classified = super.transformError(probe);
+      // Surface the full diagnostic detail in the final message (code/cause kept).
+      classified.message = `${this.providerId}/${this.modelId}: ${describeOpenAIApiError(v)}`;
+      return classified;
     }
     return super.transformError(error);
   }


### PR DESCRIPTION
## What

When OpenAI / a custom OpenAI-compatible (litellm-style) gateway rejects a request, `OpenAIAdapter` discarded the SDK `APIError`'s `status`/`type`/`code`/`param`/body and kept only `.message` — which collapses to the opaque **`"400 status code (no body)"`** when the SDK can't parse the error body. That hid *why* a gateway rejected voter requests (degraded panels with no actionable reason).

`transformError` now surfaces the real HTTP status + structured fields + raw body via `describeOpenAIApiError`, while preserving the `status`/`code`/`message` the base error-classifier keys on (error-code routing unchanged). Applies to direct OpenAI and the compat gateway.

## Corrects a mis-diagnosis

A downstream report attributed degraded voter panels to a transport **prefix** (`openai/<model>`) being sent in the request `model` field. The code disproves it: `providerId: 'openai'` is hardcoded (openai-adapter:86) and errors format as `${providerId}/${modelId}` (base-adapter:338) — so `openai/<model>` is the error **format** with a **bare** modelId, not a request prefix (the request sends `this.resolvedModelId`, bare). A blanket prefix-strip would be wrong and would break gateways that *require* `provider/model` (OpenRouter). The real cause is hidden by the error collapse — this fix surfaces it.

## Verification

- New tests: APIError → message contains `HTTP 422` + the body (`max_completion_tokens`) + bare `openai/gpt-4o`; non-APIError path unchanged. Updated the `openai` module mock to keep the real `APIError` (the adapter now does `instanceof APIError`).
- `openai-adapter.test.ts`: 54 passed. Full adapters suite: **868 passed**. typecheck/eslint clean.

## Open follow-on

The actual per-model gateway rejection cause is still unknown (some voter models fail, one works, all 200 to a bare direct curl) — leading hypothesis is a request-param incompat (`max_completion_tokens` vs `max_tokens` on compat gateways). This surfacing fix is the prerequisite to pin it; tracked in #4047.

Closes #4047

🤖 Generated with [Claude Code](https://claude.com/claude-code)