### PR TITLE
fix(voting): route the run/MetaOrchestrator consensus path through the gateway (#4042)

### DIFF
--- a/.changeset/4042-run-consensus-gateway-routing.md
+++ b/.changeset/4042-run-consensus-gateway-routing.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+Route the `run`/MetaOrchestrator consensus-strategy path through the in-process gateway ([#4042](https://github.com/nexus-substrate/nexus-agents/issues/4042))
+
+#4040 routed `consensus_vote` and `pr_review` voters through the in-process gateway adapter
+when configured, but consensus reached via the `run` tool's consensus strategy
+(`runConsensusForGoal`) still called `executeVoting` with no gateway adapters — so it fell
+back to the CLI subprocess voter path. This threads `gatewayAdapters` from the `run` tool's
+deps through `buildDefaultExecutors` → `runConsensusForGoal` → `executeVoting`, so the `run`
+consensus path matches the two MCP tools: in-process voters (no subprocess, no cross-process
+key) when a gateway is configured, CLI fallback otherwise. Closes a gap surfaced by the #4040
+review; routing in-process also removes the subprocess that was the re-entrancy concern.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -398,6 +398,18 @@ function registerPrReview(ctx: ToolRegistrationContext): void {
   });
 }
 
+/** run — threads gateway adapters (#4042) so the consensus strategy routes
+ * voters through the gateway, matching consensus_vote/pr_review (#4040). */
+function registerRun(ctx: ToolRegistrationContext): void {
+  registerRunTool(ctx.server, {
+    logger: ctx.logger,
+    rateLimiter: ctx.rateLimiterFactory.getForTool('run'),
+    ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
+    ...(ctx.auditLogger !== undefined && { auditLogger: ctx.auditLogger }),
+    ...(ctx.gatewayAdapters !== undefined && { gatewayAdapters: ctx.gatewayAdapters }),
+  });
+}
+
 /** delegate_to_model — independent; does not require a model adapter. */
 function registerDelegate(ctx: ToolRegistrationContext): void {
   registerDelegateToModelTool(ctx.server, {
@@ -689,7 +701,9 @@ const HANDLER_TABLE: Record<RegisteredToolName, ToolHandler> = {
     registerSuggestResearchTasksTool
   ),
   list_available_models: standardHandler('list_available_models', registerListAvailableModelsTool),
-  run: standardHandler('run', registerRunTool),
+  run: (ctx) => {
+    registerRun(ctx);
+  },
   verify_audit_chain: standardHandler('verify_audit_chain', registerVerifyAuditChainTool),
   extract_symbols: standardHandler('extract_symbols', registerExtractSymbolsTool),
   search_codebase: standardHandler('search_codebase', registerSearchCodebaseTool),

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -654,10 +654,16 @@ export async function executeVoting(
  */
 export async function runConsensusForGoal(
   goal: string,
-  logger: ILogger = createLogger({ tool: 'consensus_vote' })
+  logger: ILogger = createLogger({ tool: 'consensus_vote' }),
+  gatewayAdapters?: readonly IModelAdapter[]
 ): Promise<ExtendedVotingResult> {
   // Parse through the schema so defaults (quickMode, simulateVotes:false) apply.
-  return executeVoting(ConsensusVoteInputSchema.parse({ proposal: goal }), logger);
+  // #4042: thread the in-process gateway adapters so the run/MetaOrchestrator
+  // consensus path routes voters through the gateway like consensus_vote (#4040),
+  // not the CLI subprocess.
+  return executeVoting(ConsensusVoteInputSchema.parse({ proposal: goal }), logger, {
+    ...(gatewayAdapters !== undefined && { gatewayAdapters }),
+  });
 }
 
 /** Build the final `ExtendedVotingResult` once the engine + cascade settle. */

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -243,13 +243,15 @@ describe('run-path trustTier threading (#3712) — the run→dev-pipeline hole',
     expect(Number(threaded)).toBeGreaterThanOrEqual(3);
   });
 
-  it('threads gatewayAdapters into the consensus executor (#4042)', () => {
+  it('threads gatewayAdapters through executeGoal into the consensus executor (#4042)', async () => {
     runConsensusForGoalMock.mockClear();
     const gw = [{ modelId: 'gw-x' }] as unknown as Parameters<typeof buildDefaultExecutors>[1];
-    const executors = buildDefaultExecutors('3', gw);
-    void executors.consensus({} as never, { goal: 'ship it' });
-    // executor: runConsensusForGoal(goal, undefined, gatewayAdapters)
-    expect(runConsensusForGoalMock).toHaveBeenCalledWith('ship it', undefined, gw);
+    await executeGoal(
+      { goal: 'decide A or B', forceStrategy: 'consensus', execute: true },
+      { gatewayAdapters: gw }
+    );
+    // executeGoal -> buildDefaultExecutors -> consensus executor -> runConsensusForGoal(goal, undefined, gw)
+    expect(runConsensusForGoalMock).toHaveBeenCalledWith('decide A or B', undefined, gw);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -24,6 +24,20 @@ vi.mock('./dev-pipeline-tool.js', () => ({
     runDevPipelineForGoalMock(goal, trustTier),
 }));
 
+// #4042: capture the gatewayAdapters threaded into the consensus executor. Keep
+// every other consensus-vote export real (run-tool only imports runConsensusForGoal).
+const runConsensusForGoalMock = vi.fn((_goal: string, _logger?: unknown, _gw?: unknown) =>
+  Promise.resolve({ result: { outcome: 'approved' } })
+);
+vi.mock('./consensus-vote.js', async () => {
+  const actual = await vi.importActual<typeof import('./consensus-vote.js')>('./consensus-vote.js');
+  return {
+    ...actual,
+    runConsensusForGoal: (goal: string, logger?: unknown, gw?: unknown) =>
+      runConsensusForGoalMock(goal, logger, gw),
+  };
+});
+
 // #3732: pass-through the secure-handler / timeout chain so the registered
 // callback is the bare handler — lets the async-dispatch tests invoke it
 // directly. createSecureHandler injects a minimal ctx (the run handler reads
@@ -227,6 +241,15 @@ describe('run-path trustTier threading (#3712) — the run→dev-pipeline hole',
     const threaded = runDevPipelineForGoalMock.mock.calls[0]?.[1];
     expect(threaded).toBeDefined();
     expect(Number(threaded)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('threads gatewayAdapters into the consensus executor (#4042)', () => {
+    runConsensusForGoalMock.mockClear();
+    const gw = [{ modelId: 'gw-x' }] as unknown as Parameters<typeof buildDefaultExecutors>[1];
+    const executors = buildDefaultExecutors('3', gw);
+    void executors.consensus({} as never, { goal: 'ship it' });
+    // executor: runConsensusForGoal(goal, undefined, gatewayAdapters)
+    expect(runConsensusForGoalMock).toHaveBeenCalledWith('ship it', undefined, gw);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -23,6 +23,7 @@
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { IModelAdapter } from '../../core/index.js';
 
 import { createLogger, formatZodError, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
@@ -226,7 +227,10 @@ export function routeGoal(input: RunInput, logger?: ILogger): RunResponse {
  * tier threaded) leaves the seam to fail-close to untrusted (tier 4). Only the
  * dev-pipeline executor consumes the tier; the others don't reach that seam.
  */
-export function buildDefaultExecutors(trustTier?: string): StrategyExecutorMap {
+export function buildDefaultExecutors(
+  trustTier?: string,
+  gatewayAdapters?: readonly IModelAdapter[]
+): StrategyExecutorMap {
   return {
     'dev-pipeline': (_decision, metaInput: MetaOrchestratorInput) =>
       runDevPipelineForGoal(metaInput.goal, trustTier),
@@ -239,7 +243,8 @@ export function buildDefaultExecutors(trustTier?: string): StrategyExecutorMap {
     // registry is a feature with no current consumer (YAGNI) — add it only when a
     // named loop needs research-specific stages; until then research==pipeline.
     research: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
-    consensus: (_decision, metaInput: MetaOrchestratorInput) => runConsensusForGoal(metaInput.goal),
+    consensus: (_decision, metaInput: MetaOrchestratorInput) =>
+      runConsensusForGoal(metaInput.goal, undefined, gatewayAdapters),
   };
 }
 
@@ -303,6 +308,8 @@ export async function executeGoal(
      * instead of fail-closing. Ignored when `executors` is supplied explicitly.
      */
     readonly trustTier?: string | undefined;
+    /** In-process gateway model adapters routed to consensus voters (#4042). */
+    readonly gatewayAdapters?: readonly IModelAdapter[] | undefined;
   } = {}
 ): Promise<RunExecuteResponse> {
   // The authority-ladder guard fires inside `select` (#3920): an above-tier
@@ -311,7 +318,7 @@ export async function executeGoal(
   const decision = selectDecision(input, 'execute', opts.logger);
   const onOutcome = opts.onOutcome ?? buildShadowTrainObserver(opts.logger);
   const dispatcher = createMetaDispatcher({
-    executors: opts.executors ?? buildDefaultExecutors(opts.trustTier),
+    executors: opts.executors ?? buildDefaultExecutors(opts.trustTier, opts.gatewayAdapters),
     ...(opts.logger !== undefined ? { logger: opts.logger } : {}),
     ...(opts.outcomeSink !== undefined ? { outcomeSink: opts.outcomeSink } : {}),
     ...(onOutcome !== undefined ? { onOutcome } : {}),
@@ -337,7 +344,8 @@ export async function executeGoal(
 async function executeRunBody(
   input: RunInput,
   logger: ILogger,
-  trustTier?: string
+  trustTier?: string,
+  gatewayAdapters?: readonly IModelAdapter[]
 ): Promise<ToolResult> {
   try {
     // #3712: thread the caller's real RequestContext.trustTier into the
@@ -346,6 +354,7 @@ async function executeRunBody(
     const exec = await executeGoal(input, {
       logger,
       ...(trustTier !== undefined ? { trustTier } : {}),
+      ...(gatewayAdapters !== undefined ? { gatewayAdapters } : {}),
     });
     logger.info('run: executed goal', {
       decisionId: exec.decisionId,
@@ -366,7 +375,12 @@ async function executeRunBody(
   }
 }
 
-async function runHandler(args: unknown, logger: ILogger, trustTier?: string): Promise<ToolResult> {
+async function runHandler(
+  args: unknown,
+  logger: ILogger,
+  trustTier?: string,
+  gatewayAdapters?: readonly IModelAdapter[]
+): Promise<ToolResult> {
   const parsed = RunInputSchema.safeParse(args);
   if (!parsed.success) {
     return toolStructuredError({
@@ -387,11 +401,11 @@ async function runHandler(args: unknown, logger: ILogger, trustTier?: string): P
         toolName: 'run',
         input,
         freshJobId: () => `rn-${randomUUID()}`,
-        run: () => executeRunBody(input, logger, trustTier),
+        run: () => executeRunBody(input, logger, trustTier, gatewayAdapters),
         logger,
       });
     }
-    return executeRunBody(input, logger, trustTier);
+    return executeRunBody(input, logger, trustTier, gatewayAdapters);
   }
 
   const response = routeGoal(parsed.data, logger);
@@ -413,8 +427,13 @@ const DESCRIPTION =
   'Prefer this over choosing a pipeline tool by hand — the specialized tools remain ' +
   'available as advanced force-strategy paths.';
 
+/** Deps for the `run` tool — adds the in-process gateway adapters (#4042). */
+export interface RunToolDeps extends BaseMcpToolDeps {
+  gatewayAdapters?: readonly IModelAdapter[] | undefined;
+}
+
 /** @category MCP */
-export function registerRunTool(server: McpServer, deps: BaseMcpToolDeps): void {
+export function registerRunTool(server: McpServer, deps: RunToolDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run' });
 
   // 2-arg context-aware form (mirrors delegate-to-model.ts / run_dev_pipeline):
@@ -422,7 +441,8 @@ export function registerRunTool(server: McpServer, deps: BaseMcpToolDeps): void 
   // consensus→execute seam sees the real tier (#3712) — this closes the hole
   // where a possibly-untrusted goal ran a real research stage with no tier.
   const secureHandler = createSecureHandler(
-    (args: unknown, ctx: HandlerContext) => runHandler(args, logger, ctx.requestContext.trustTier),
+    (args: unknown, ctx: HandlerContext) =>
+      runHandler(args, logger, ctx.requestContext.trustTier, deps.gatewayAdapters),
     {
       toolName: 'run',
       rateLimiter: deps.rateLimiter,


### PR DESCRIPTION
## What

#4040 routed `consensus_vote`/`pr_review` voters through the in-process gateway adapter when configured, but consensus reached via the **`run` tool's consensus strategy** (`runConsensusForGoal`) still called `executeVoting` with no gateway adapters — so it fell back to the **CLI subprocess** voter path. This threads `gatewayAdapters` end-to-end:

`registerRun` (ctx.gatewayAdapters) → `registerRunTool` (RunToolDeps) → `runHandler` → `executeRunBody` → `executeGoal` opts → `buildDefaultExecutors` → consensus executor → `runConsensusForGoal` → `executeVoting`.

Result: the `run` consensus path matches the two MCP tools — in-process voters when a gateway is configured, CLI fallback otherwise.

## Re-entrancy note

The #4040 review's Contrarian flagged a nested-spawn risk for the run/orchestrator path. Routing voters **in-process** is precisely what *removes* the subprocess that could nest — so this fix reduces, not adds, that risk.

## Verification

- New test: `buildDefaultExecutors('3', gatewayAdapters).consensus(...)` forwards the adapters to `runConsensusForGoal('goal', undefined, gatewayAdapters)` (mocked to avoid running real votes). Downstream routing (collectRealVotes round-robin, executeVoting threading) already covered by #4040 tests.
- `run-tool.test.ts` 25 passed; adjacent suites (authority-guard, consensus-vote, cli-server-tools) 133 passed; typecheck/eslint/Producer-Consumer clean.

Closes #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)