### PR TITLE
feat(pr-review): persist authentic Option-C audit records (#4031)

### DIFF
--- a/.changeset/pr-review-audit-producer.md
+++ b/.changeset/pr-review-audit-producer.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': minor
+---
+
+pr_review now persists authentic, diff-bound governance records (#4031). When a
+review is given both `prNumber` and `baseSha` and runs live (not simulated), it
+writes a self-hashed Option-C record binding `{prNumber, baseSha,
+reviewedDiffHash, verdict}` to the governance ledger — the record the warn-first
+governor-review gate (#3831) queries. This completes the #3831 Stage-1 store,
+which built the reader/gate/schema but deferred the producer, so the gate could
+only ever warn against an empty ledger.
+
+The new `persistPrReviewRecord` mirrors `persistVoteRecord` (ledger-tip read →
+monotonic sequence → previousHash chaining → append; merge-safe SET semantics).
+The response carries a structured `recordOutcome` so callers see whether a record
+was written and, when not, why (`binding-inputs-absent` / `simulated` /
+`no-live-votes` / `write-failed`). An all-errored panel (no live opinion) is
+skipped with `no-live-votes` — a failed review must not seed a gate-satisfying
+record (the governor-review analogue of the consensus_vote `no_quorum` void).
+Persistence is best-effort and never fails the review. The reviewed-diff hash is
+computed over the exact diff the voters saw using the same canonical hash the gate
+recomputes with; for the gate to match a record, callers must pass the canonical
+`git diff <baseSha>..<headSha>` as `prDiff` (its first 50_000 bytes must match —
+the hash truncates there, and the producer warns when the diff exceeds it).
+`baseSha` is
+caller-asserted and not yet cross-validated against the diff — acceptable for the
+warn-first gate; a future warn→enforce flip must add that provenance check.

--- a/docs/reference/tools/pr_review.md
+++ b/docs/reference/tools/pr_review.md
@@ -22,5 +22,7 @@ Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, secu
 | `repoContext` | string | no | maxLength 2000 | Optional one-paragraph repo context (architecture, conventions) |
 | `baseRef` | string | no | maxLength 200 | Base branch ref (e.g. main) |
 | `headRef` | string | no | maxLength 200 | Head branch ref |
+| `prNumber` | integer | no | max 9007199254740991; > 0 | PR number — with baseSha, enables Option-C audit-record persistence (#4031) |
+| `baseSha` | string | no | pattern `^[0-9a-f]{40}$` | 40-hex base commit sha the reviewed diff was computed from (Option-C binding, #4031) |
 | `simulate` | boolean | no | default false | Use simulated voters (testing only; never ship live with this true) |
 | `dispatch` | enum | no | one of: sync \| async; default sync | Dispatch mode (#3731). 'sync' (default): run inline. 'async': return a jobId immediately + run the panel in background (poll get_job_result). |

--- a/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the pr-review-record PRODUCER ({@link persistPrReviewRecord}, #4031).
+ *
+ * Covers the Stage-2 producer the #3831 Stage-1 store deferred: ledger-tip read →
+ * monotonic sequence assignment → previousHash chaining → self-hashed append, plus
+ * the merge-safe SET semantics and the never-throw best-effort contract. The pure
+ * builder/reader/path resolution are exercised by `pr-review-record.test.ts`.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { verifyPrReviewRecordSet } from './pr-review-record.js';
+import type { PrReviewVoteCounts } from './pr-review-record.js';
+import {
+  persistPrReviewRecord,
+  readPrReviewRecords,
+  type PersistPrReviewRecordOptions,
+} from './pr-review-record-store.js';
+
+const BASE_SHA = 'a'.repeat(40);
+const DIFF_HASH = 'b'.repeat(64);
+
+const VOTE_COUNTS: PrReviewVoteCounts = {
+  approve: 3,
+  request_changes: 1,
+  abstain: 1,
+  error: 0,
+  total: 5,
+};
+
+function baseOpts(
+  overrides: Partial<PersistPrReviewRecordOptions> = {}
+): PersistPrReviewRecordOptions {
+  return {
+    prNumber: 42,
+    baseSha: BASE_SHA,
+    reviewedDiffHash: DIFF_HASH,
+    verdict: 'approve',
+    verified: true,
+    voteCounts: VOTE_COUNTS,
+    summary: 'approve (3/1/1) — Test PR',
+    ...overrides,
+  };
+}
+
+describe('persistPrReviewRecord (#4031)', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pr-review-records-'));
+    filePath = join(dir, 'pr-review-records.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes the first record at sequence 0 with no previousHash and a valid self-hash', () => {
+    const record = persistPrReviewRecord(baseOpts({ filePath }));
+    expect(record).toBeDefined();
+    expect(record?.sequence).toBe(0);
+    expect(record?.previousHash).toBeUndefined();
+    expect(record?.prNumber).toBe(42);
+    expect(record?.reviewedDiffHash).toBe(DIFF_HASH);
+
+    const { records, invalidLines } = readPrReviewRecords(filePath);
+    expect(invalidLines).toEqual([]);
+    expect(records).toHaveLength(1);
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
+  });
+
+  it('assigns monotonic sequences and chains previousHash to the prior tip', () => {
+    const first = persistPrReviewRecord(baseOpts({ filePath, prNumber: 1 }));
+    const second = persistPrReviewRecord(baseOpts({ filePath, prNumber: 2 }));
+
+    expect(first?.sequence).toBe(0);
+    expect(second?.sequence).toBe(1);
+    // previousHash is advisory and links to the prior tip's self-hash.
+    expect(second?.previousHash).toBe(first?.hash);
+
+    const { records } = readPrReviewRecords(filePath);
+    expect(records).toHaveLength(2);
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
+  });
+
+  it('does not include previousHash in the self-hash (position-independent / merge-safe)', () => {
+    // Two records appended from the same tip would carry the SAME sequence on a
+    // concurrent merge; the self-hash must not depend on previousHash, so a
+    // record's hash is stable regardless of which tip it observed.
+    const a = persistPrReviewRecord(baseOpts({ filePath, prNumber: 7 }));
+    const b = persistPrReviewRecord(baseOpts({ filePath, prNumber: 8 }));
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    // Re-verifying after reordering the file lines still passes (set semantics).
+    const { records } = readPrReviewRecords(filePath);
+    const reordered = [...records].reverse();
+    expect(verifyPrReviewRecordSet(reordered).ok).toBe(true);
+  });
+
+  it('returns the binding verdict + counts faithfully (no lossy projection)', () => {
+    const record = persistPrReviewRecord(
+      baseOpts({ filePath, verdict: 'request_changes', verified: false })
+    );
+    expect(record?.verdict).toBe('request_changes');
+    expect(record?.verified).toBe(false);
+    expect(record?.voteCounts).toEqual(VOTE_COUNTS);
+  });
+
+  it('returns undefined (best-effort, never throws) when the path cannot be written', () => {
+    // Point at a path whose parent is a FILE, so mkdirSync/append fails.
+    const blocker = join(dir, 'blocker');
+    writeFileSync(blocker, 'x', 'utf-8');
+    const record = persistPrReviewRecord(baseOpts({ filePath: join(blocker, 'nested.jsonl') }));
+    expect(record).toBeUndefined();
+  });
+
+  it('appends one JSON line per record (newline-delimited)', () => {
+    persistPrReviewRecord(baseOpts({ filePath, prNumber: 10 }));
+    persistPrReviewRecord(baseOpts({ filePath, prNumber: 11 }));
+    const lines = readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(() => {
+        JSON.parse(line);
+      }).not.toThrow();
+    }
+  });
+});

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -6,12 +6,13 @@
  * review gate (`scripts/check-governor-review.ts`, #3831) can QUERY it from CI:
  * does a sha-bound, verified review exist for THIS PR's number AND head sha?
  *
- * SCOPE (#3831 Stage 1). This module deliberately exposes only the PURE builder
- * ({@link buildPrReviewRecord}) and the READER ({@link readPrReviewRecords}) plus
- * the path resolution — the seam the gate and tests need. The PRODUCER (pr_review
- * writing records as a side effect, the caller-commits flow shared with #3927) is
- * a tracked FOLLOW-ON and intentionally NOT wired here, so this stage adds the
- * gate + schema + verification without changing the pr_review write path.
+ * SCOPE. Stage 1 (#3831) added the PURE builder ({@link buildPrReviewRecord}) and
+ * the READER ({@link readPrReviewRecords}) plus path resolution — the seam the gate
+ * and tests need. Stage 2 (#4031) adds the PRODUCER ({@link persistPrReviewRecord},
+ * mirroring `persistVoteRecord`): pr_review writes a record as a best-effort side
+ * effect so the warn-first gate can finally find authentic, diff-bound records (the
+ * prerequisite to ever flipping it from warn to enforce). Persistence never throws
+ * into the review path.
  *
  * MERGE SAFETY (mirrors #3927). The ledger is a SET, not a chain: `sequence` is
  * assigned as (max existing sequence)+1, and the self-hash excludes
@@ -22,10 +23,12 @@
  * @module audit/pr-review-record-store
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { isAbsolute, join, resolve } from 'node:path';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 import { findRepoRoot } from '../config/repo-root-detection.js';
+import type { ILogger } from '../core/index.js';
+import { createLogger, getErrorMessage } from '../core/index.js';
 
 import type { PrReviewRecord, PrReviewVerdict, PrReviewVoteCounts } from './pr-review-record.js';
 import { PrReviewRecordSchema, computePrReviewRecordHash } from './pr-review-record.js';
@@ -151,4 +154,105 @@ export function readPrReviewRecords(filePath: string): {
     }
   }
   return { records, invalidLines };
+}
+
+/**
+ * Read the ledger tip: the maximum existing `sequence` and the advisory last-line
+ * hash. Mirrors the vote-record store's `readLedgerTip` (#3927). The producer
+ * assigns the next record `sequence = maxSequence + 1` and records `previousHash`
+ * as the last line's hash (advisory audit texture; NOT covered by the self-hash,
+ * so concurrent appends from the same tip stay merge-safe under `merge=union`).
+ * Returns `{ maxSequence: -1, lastHash: undefined }` for a missing/empty/unreadable
+ * ledger — a tip read must never fail the producer that follows.
+ */
+function readPrReviewLedgerTip(
+  filePath: string,
+  logger: ILogger
+): { maxSequence: number; lastHash: string | undefined } {
+  if (!existsSync(filePath)) return { maxSequence: -1, lastHash: undefined };
+  try {
+    const { records } = readPrReviewRecords(filePath);
+    if (records.length === 0) return { maxSequence: -1, lastHash: undefined };
+    let maxSequence = -1;
+    for (const record of records) {
+      if (record.sequence > maxSequence) maxSequence = record.sequence;
+    }
+    const last = records[records.length - 1];
+    return { maxSequence, lastHash: last?.hash };
+  } catch (error: unknown) {
+    logger.warn('Failed to read pr-review-record ledger tip', { error: getErrorMessage(error) });
+    return { maxSequence: -1, lastHash: undefined };
+  }
+}
+
+/** Options for {@link persistPrReviewRecord}. `sequence`/`previousHash` are assigned by the store. */
+export interface PersistPrReviewRecordOptions extends Omit<
+  BuildPrReviewRecordInput,
+  'previousHash' | 'sequence'
+> {
+  /**
+   * Override the artifact path; takes precedence over {@link PR_REVIEW_RECORDS_PATH_ENV}
+   * and the {@link resolvePrReviewRecordsPath} resolution.
+   */
+  readonly filePath?: string | undefined;
+  readonly logger?: ILogger | undefined;
+}
+
+/**
+ * Persist an authentic pr-review record (#4031, the #3831 Stage-2 producer that
+ * Stage 1 deferred). Best-effort and append-only: reads the ledger tip (max
+ * sequence + advisory last hash), assigns the next monotonic `sequence`, builds a
+ * self-hashed {@link PrReviewRecord} binding {prNumber, baseSha, reviewedDiffHash,
+ * verdict}, and appends one JSON line. Returns the written record — or `undefined`
+ * when the path could not be resolved or the write failed. Persistence NEVER
+ * throws into the review path (an audit sink must not break the operation it
+ * observes), mirroring {@link persistVoteRecord} and the warn-first posture of the
+ * gate this feeds.
+ *
+ * AUTHENTICITY (the load-bearing invariant the design vote flagged): the caller
+ * MUST pass `reviewedDiffHash` computed over the EXACT diff the voters reviewed
+ * (`computeReviewedDiffHash(prDiff)`), never a re-fetched/drifted diff — an
+ * authentic-looking record bound to the wrong artifact is worse than no record.
+ * `baseSha` is CALLER-ASSERTED and NOT cross-validated against the diff here; for
+ * the current warn-first phase this is acceptable, but a future warn→enforce flip
+ * (#3831) MUST NOT treat `baseSha` as verified provenance without adding that check.
+ *
+ * Path precedence: `opts.filePath` > {@link PR_REVIEW_RECORDS_PATH_ENV} >
+ * {@link resolvePrReviewRecordsPath}.
+ */
+export function persistPrReviewRecord(
+  opts: PersistPrReviewRecordOptions
+): PrReviewRecord | undefined {
+  const logger = opts.logger ?? createLogger({ component: 'pr-review-record-store' });
+  const filePath = opts.filePath ?? resolvePrReviewRecordsPath();
+  if (filePath === undefined) {
+    logger.warn('Cannot persist pr-review record: no records path resolved', {
+      prNumber: opts.prNumber,
+    });
+    return undefined;
+  }
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const { maxSequence, lastHash } = readPrReviewLedgerTip(filePath, logger);
+    const record = buildPrReviewRecord({
+      ...opts,
+      sequence: maxSequence + 1,
+      previousHash: lastHash,
+    });
+    appendFileSync(filePath, JSON.stringify(record) + '\n', 'utf-8');
+    logger.info('Persisted authentic pr-review record', {
+      prNumber: record.prNumber,
+      verdict: record.verdict,
+      sequence: record.sequence,
+      path: filePath,
+    });
+    return record;
+  } catch (error: unknown) {
+    logger.warn('Failed to persist authentic pr-review record', {
+      error: getErrorMessage(error),
+      prNumber: opts.prNumber,
+      path: filePath,
+    });
+    return undefined;
+  }
 }

--- a/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
@@ -1,0 +1,188 @@
+/**
+ * nexus-agents/mcp — PR-Review Audit-Record Producer (#4031).
+ *
+ * The pr_review side of the #3831 Option-C arc: turn a completed review into an
+ * authentic, self-hashed governance record bound to {prNumber, baseSha,
+ * reviewedDiffHash, verdict}, so the warn-first governor-review gate can find a
+ * diff-bound record for the PR it is checking. Split out of pr-review-tool.ts to
+ * keep that file's single-purpose review flow lean.
+ *
+ * Best-effort and never-throws: a missing binding or a write failure is surfaced
+ * as a structured {@link PrReviewRecordOutcome}, never an exception into the
+ * review path (an audit sink must not break the operation it observes).
+ *
+ * @module mcp/tools/pr-review-record-producer
+ */
+
+import type { ILogger } from '../../core/index.js';
+import {
+  computeReviewedDiffHash,
+  reviewedDiffWasTruncated,
+} from '../../audit/reviewed-diff-hash.js';
+import { persistPrReviewRecord } from '../../audit/pr-review-record-store.js';
+import type { PrReviewAggregate, PrReviewInput } from './pr-review-tool.js';
+
+/**
+ * Structured outcome of the best-effort Option-C audit-record persistence
+ * (#4031). Surfaced on the pr_review response so an MCP caller can SEE whether a
+ * record was written and, when not, WHY — mirroring the consensus_vote
+ * `voteRecordPersisted` observability. Reasons:
+ *  - `binding-inputs-absent` — `prNumber` and/or `baseSha` were not supplied, so
+ *    there is nothing to bind the record to (the warn-first skip; not an error).
+ *  - `simulated` — the review used simulated voters; a committed record would
+ *    seed governance from non-live output (mirrors #2319 for votes).
+ *  - `no-live-votes` — every voter errored, so the aggregate verdict was produced
+ *    by NO live opinion. Persisting would write a gate-satisfying record for a
+ *    review that never actually happened (the governor-review analogue of the
+ *    consensus_vote `no_quorum` void, #4053). Skipped so a failed review cannot
+ *    silently flip the #3831 gate from warn to a false pass.
+ *  - `write-failed` — the binding was present but the ledger path was unresolved
+ *    or the append failed (the producer already logged the underlying cause).
+ */
+export type PrReviewRecordOutcome =
+  | {
+      readonly persisted: true;
+      readonly prNumber: number;
+      readonly baseSha: string;
+      readonly reviewedDiffHash: string;
+      readonly sequence: number;
+    }
+  | {
+      readonly persisted: false;
+      readonly reason: 'binding-inputs-absent' | 'simulated' | 'no-live-votes' | 'write-failed';
+      readonly detail: string;
+    };
+
+/** Per-decision voter tally subset {@link persistReviewRecord} consumes. */
+export interface PrReviewCounts {
+  readonly approveCount: number;
+  readonly requestChangesCount: number;
+  readonly abstainCount: number;
+  readonly errorCount: number;
+}
+
+/** Inputs for {@link persistReviewRecord} — bundled to stay within max-params. */
+export interface PersistReviewRecordArgs {
+  readonly input: PrReviewInput;
+  readonly aggregate: PrReviewAggregate;
+  readonly counts: PrReviewCounts;
+  readonly reviewCount: number;
+  readonly logger: ILogger;
+}
+
+/**
+ * Build + append the Option-C record for a review whose binding is present and
+ * live (the guards in {@link persistReviewRecord} already passed). Hashes the
+ * EXACT reviewed diff via the same canonical {@link computeReviewedDiffHash} the
+ * gate recomputes with, then maps the producer result to a structured outcome.
+ */
+function buildAndPersist(
+  prNumber: number,
+  baseSha: string,
+  args: PersistReviewRecordArgs
+): PrReviewRecordOutcome {
+  const { input, aggregate, counts, reviewCount, logger } = args;
+  // Diff-hash parity contract (#4031): the gate recomputes this hash over the
+  // first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed
+  // diff exceeds that byte cap, content past it is UNBOUND, so a record can match
+  // a different tail than the voters saw. Warn so the silent truncation is
+  // observable (the diff-hash module documents this producer obligation).
+  if (reviewedDiffWasTruncated(input.prDiff)) {
+    logger.warn(
+      'Reviewed diff exceeds the hash byte cap; content past it is unbound in reviewedDiffHash',
+      { prNumber }
+    );
+  }
+  const record = persistPrReviewRecord({
+    prNumber,
+    baseSha,
+    reviewedDiffHash: computeReviewedDiffHash(input.prDiff),
+    verdict: aggregate.decision,
+    verified: aggregate.verified,
+    voteCounts: {
+      approve: counts.approveCount,
+      request_changes: counts.requestChangesCount,
+      abstain: counts.abstainCount,
+      error: counts.errorCount,
+      total: reviewCount,
+    },
+    summary: `${aggregate.decision} (${String(counts.approveCount)} approve / ${String(counts.requestChangesCount)} request_changes / ${String(counts.abstainCount)} abstain) — ${input.prTitle}`,
+    logger,
+  });
+  if (record === undefined) {
+    return {
+      persisted: false,
+      reason: 'write-failed',
+      detail:
+        'Audit record could not be written: the records path was unresolved or the ' +
+        'append failed (see server logs for the underlying cause).',
+    };
+  }
+  return {
+    persisted: true,
+    prNumber: record.prNumber,
+    baseSha: record.baseSha,
+    reviewedDiffHash: record.reviewedDiffHash,
+    sequence: record.sequence,
+  };
+}
+
+/**
+ * Best-effort Option-C audit-record persistence (#4031). Persists ONLY when both
+ * `prNumber` and `baseSha` are present AND the review was live; otherwise returns
+ * a structured skip. `baseSha` is CALLER-ASSERTED here and NOT cross-checked
+ * against the diff; acceptable for the warn-first gate, but a future enforce flip
+ * (#3831) must add that provenance check (design-vote condition).
+ */
+export function persistReviewRecord(args: PersistReviewRecordArgs): PrReviewRecordOutcome {
+  const { input } = args;
+  if (input.prNumber === undefined || input.baseSha === undefined) {
+    return {
+      persisted: false,
+      reason: 'binding-inputs-absent',
+      detail:
+        'No audit record written: supply both prNumber and baseSha to persist an ' +
+        'Option-C governor-review record bound to {prNumber, baseSha, reviewedDiffHash}.',
+    };
+  }
+  if (input.simulate) {
+    return {
+      persisted: false,
+      reason: 'simulated',
+      detail:
+        'No audit record written: the review used simulated voters, and a committed ' +
+        'governance record must not be seeded from non-live output (mirrors #2319).',
+    };
+  }
+  // Quorum floor (#4031, found in #4031 adversarial review): an all-errored panel
+  // still aggregates to a verdict (abstain/verified — see aggregatePrDecisions),
+  // but NO voter actually reviewed. Persisting would write a gate-satisfying
+  // record for a review that never happened — the governor-review analogue of the
+  // consensus_vote `no_quorum` void (#4053). Valid (non-error) voters are exactly
+  // the approve/request_changes/abstain tallies; if all three are zero, skip.
+  const { counts } = args;
+  if (counts.approveCount + counts.requestChangesCount + counts.abstainCount === 0) {
+    return {
+      persisted: false,
+      reason: 'no-live-votes',
+      detail:
+        'No audit record written: every voter errored, so the aggregate verdict ' +
+        'reflects no live review. A committed governor-review record must not be ' +
+        'seeded from a failed panel (the pr_review analogue of no_quorum, #4053).',
+    };
+  }
+  // Defense-in-depth: buildAndPersist's only non-store-guarded step is the diff
+  // hash, which does not currently throw — but an audit sink must NEVER throw into
+  // the review path, so a future throwable change degrades to write-failed here.
+  try {
+    return buildAndPersist(input.prNumber, input.baseSha, args);
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    args.logger.warn('Audit-record persistence threw (non-fatal)', { detail });
+    return {
+      persisted: false,
+      reason: 'write-failed',
+      detail: `Audit record persistence raised: ${detail}`,
+    };
+  }
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -32,12 +32,20 @@ import {
   buildPrReviewProposal,
   mapVoteDecisionToPrDecision,
   registerPrReviewTool,
+  type PrReviewAggregate,
   type PrReviewVote,
 } from './pr-review-tool.js';
+import { persistReviewRecord } from './pr-review-record-producer.js';
 import { readJobResult } from '../jobs/job-result-store.js';
 import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
 import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
 import { createLogger } from '../../core/index.js';
+import {
+  PR_REVIEW_RECORDS_PATH_ENV,
+  readPrReviewRecords,
+} from '../../audit/pr-review-record-store.js';
+import { computeReviewedDiffHash } from '../../audit/reviewed-diff-hash.js';
+import { verifyPrReviewRecordSet } from '../../audit/pr-review-record.js';
 
 describe('pr_review tool', () => {
   describe('PR_REVIEW_ROLES', () => {
@@ -456,5 +464,126 @@ describe('pr_review async dispatch (#3731)', () => {
     await new Promise((r) => setImmediate(r));
     const record = readJobResult(jobId);
     expect(record?.status).toBe('complete');
+  });
+});
+
+describe('pr_review Option-C audit-record persistence (#4031)', () => {
+  const BASE_SHA = 'c'.repeat(40);
+  const APPROVE_AGG: PrReviewAggregate = { decision: 'approve', verified: true };
+  const COUNTS = { approveCount: 5, requestChangesCount: 0, abstainCount: 0, errorCount: 0 };
+  const logger = createLogger({ tool: 'pr-review-test' });
+
+  let dir: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pr-review-tool-records-'));
+    prevEnv = process.env[PR_REVIEW_RECORDS_PATH_ENV];
+    process.env[PR_REVIEW_RECORDS_PATH_ENV] = join(dir, 'pr-review-records.jsonl');
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
+    else process.env[PR_REVIEW_RECORDS_PATH_ENV] = prevEnv;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function input(
+    overrides: Record<string, unknown> = {}
+  ): ReturnType<typeof PrReviewInputSchema.parse> {
+    return PrReviewInputSchema.parse({
+      prTitle: 'Add audit producer',
+      prDiff: 'diff --git a/x b/x\n+line\n',
+      simulate: false,
+      ...overrides,
+    });
+  }
+
+  it('persists a record bound to {prNumber, baseSha, reviewedDiffHash} when both inputs + live review', () => {
+    const parsed = input({ prNumber: 99, baseSha: BASE_SHA });
+    const outcome = persistReviewRecord({
+      input: parsed,
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+
+    expect(outcome.persisted).toBe(true);
+    if (!outcome.persisted) throw new Error('expected persisted');
+    expect(outcome.prNumber).toBe(99);
+    expect(outcome.baseSha).toBe(BASE_SHA);
+    // Parity with the gate: producer hashes the EXACT prDiff via the same
+    // canonical computeReviewedDiffHash the gate recomputes with (#4031 condition).
+    expect(outcome.reviewedDiffHash).toBe(computeReviewedDiffHash(parsed.prDiff));
+    expect(outcome.sequence).toBe(0);
+
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records, invalidLines } = readPrReviewRecords(path);
+    expect(invalidLines).toEqual([]);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.verdict).toBe('approve');
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
+  });
+
+  it('skips with binding-inputs-absent when prNumber or baseSha is missing', () => {
+    const onlyPr = persistReviewRecord({
+      input: input({ prNumber: 99 }),
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(onlyPr).toEqual(
+      expect.objectContaining({ persisted: false, reason: 'binding-inputs-absent' })
+    );
+    const onlySha = persistReviewRecord({
+      input: input({ baseSha: BASE_SHA }),
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(onlySha).toEqual(
+      expect.objectContaining({ persisted: false, reason: 'binding-inputs-absent' })
+    );
+    // Nothing written.
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    expect(readPrReviewRecords(path).records).toHaveLength(0);
+  });
+
+  it('skips with reason=simulated even when the binding is present (no governance from non-live output)', () => {
+    const outcome = persistReviewRecord({
+      input: input({ prNumber: 99, baseSha: BASE_SHA, simulate: true }),
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome).toEqual(expect.objectContaining({ persisted: false, reason: 'simulated' }));
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    expect(readPrReviewRecords(path).records).toHaveLength(0);
+  });
+
+  it('skips with reason=no-live-votes when every voter errored (no false gate pass)', () => {
+    // An all-errored panel still aggregates to {abstain, verified:true}, but no
+    // voter actually reviewed — persisting would write a gate-satisfying record
+    // for a review that never happened (#4031 adversarial-review BLOCKER).
+    const allErrored = {
+      approveCount: 0,
+      requestChangesCount: 0,
+      abstainCount: 0,
+      errorCount: 5,
+    };
+    const outcome = persistReviewRecord({
+      input: input({ prNumber: 99, baseSha: BASE_SHA }),
+      aggregate: APPROVE_AGG,
+      counts: allErrored,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome).toEqual(expect.objectContaining({ persisted: false, reason: 'no-live-votes' }));
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    expect(readPrReviewRecords(path).records).toHaveLength(0);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -46,6 +46,7 @@ import {
   parseFindings,
   type Finding,
 } from './pr-review-findings.js';
+import { persistReviewRecord, type PrReviewRecordOutcome } from './pr-review-record-producer.js';
 
 export type { Finding, VerificationGate, FindingSeverity } from './pr-review-findings.js';
 
@@ -105,6 +106,30 @@ export const PrReviewInputSchema = z.object({
     .describe('Optional one-paragraph repo context (architecture, conventions)'),
   baseRef: z.string().max(200).optional().describe('Base branch ref (e.g. main)'),
   headRef: z.string().max(200).optional().describe('Head branch ref'),
+  /**
+   * Option-C audit binding (#4031). When BOTH `prNumber` and `baseSha` are
+   * supplied AND the review is live (not simulated), pr_review persists an
+   * authentic, self-hashed pr-review record binding {prNumber, baseSha,
+   * reviewedDiffHash(prDiff), verdict} to the governance ledger — the record the
+   * warn-first governor-review gate (#3831) queries. Omit either to skip
+   * persistence (a structured `recordOutcome` note explains why). IMPORTANT: for
+   * the gate to FIND the record, `prDiff`'s first 50_000 bytes must match the
+   * canonical `git diff <baseSha>..<headSha>` the gate recomputes (the hash
+   * truncates at that byte cap) — pass the canonical diff, not a reordered one.
+   */
+  prNumber: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('PR number — with baseSha, enables Option-C audit-record persistence (#4031)'),
+  baseSha: z
+    .string()
+    .regex(/^[0-9a-f]{40}$/, 'baseSha must be a 40-char lowercase hex commit sha')
+    .optional()
+    .describe(
+      '40-hex base commit sha the reviewed diff was computed from (Option-C binding, #4031)'
+    ),
   simulate: z
     .boolean()
     .default(false)
@@ -176,6 +201,12 @@ export interface PrReviewResponse {
    * adapter reported no usage are counted as unmeasured, not a measured $0).
    */
   readonly costSummary?: DecisionCostSummary;
+  /**
+   * Option-C audit-record persistence outcome (#4031). Present on every
+   * response: `persisted: true` with the record's binding + sequence when an
+   * authentic record was written, otherwise `persisted: false` with the reason.
+   */
+  readonly recordOutcome?: PrReviewRecordOutcome;
 }
 
 export interface PrReviewDeps extends BaseMcpToolDeps {
@@ -392,6 +423,18 @@ async function executePrReviewBody(
     });
   }
 
+  // #4031: best-effort Option-C audit-record persistence. The producer surfaces
+  // every non-persist (binding absent / simulated / no quorum / write-failed) as
+  // a structured outcome and never throws — an audit sink must not break the
+  // review it observes.
+  const recordOutcome = persistReviewRecord({
+    input,
+    aggregate,
+    counts,
+    reviewCount: reviews.length,
+    logger,
+  });
+
   const response: PrReviewResponse = {
     summary: aggregate.decision,
     verified: aggregate.verified,
@@ -399,6 +442,7 @@ async function executePrReviewBody(
     reviews,
     totalDurationMs: Date.now() - start,
     ...(costSummary !== undefined ? { costSummary } : {}),
+    recordOutcome,
   };
   return toolSuccess(JSON.stringify(response, null, 2));
 }


### PR DESCRIPTION
## What

Adds the **producer** the #3831 Stage-1 store deferred. Stage 1 shipped the pr-review record reader, schema, and warn-first governor-review gate — but nothing ever wrote records, so the gate could only warn against an empty ledger. This makes pr_review write authentic, diff-bound records the gate can find (the prerequisite to ever flipping it from warn to enforce).

## Changes

- **`audit/pr-review-record-store.ts`** — `persistPrReviewRecord`, mirroring `persistVoteRecord` (#3927): ledger-tip read → monotonic `sequence` → `previousHash` chaining → self-hashed append. Best-effort; never throws.
- **`mcp/tools/pr-review-record-producer.ts`** (new) — `persistReviewRecord` writes a record binding `{prNumber, baseSha, reviewedDiffHash, verdict}` **only** for a live review with both binding inputs. Otherwise returns a structured skip: `binding-inputs-absent` / `simulated` / `no-live-votes` / `write-failed`.
- **`mcp/tools/pr-review-tool.ts`** — optional `prNumber` + `baseSha` inputs; `recordOutcome` on the response; producer wired into `executePrReviewBody`.

## Correctness (design-vote + adversarial-review conditions)

- `reviewedDiffHash` is computed over the **exact** in-memory `prDiff` the voters saw, using the **same** canonical `computeReviewedDiffHash` the gate recomputes with. Producer warns when the diff exceeds the 50k-byte hash cap.
- **Quorum floor** (adversarial-review BLOCKER): an all-errored panel aggregates to `{abstain, verified}` but no voter reviewed — persisting would seed a gate-satisfying record for a review that never happened (the governor-review analogue of consensus_vote's `no_quorum` void, #4053). Skipped as `no-live-votes`.
- `baseSha` is **caller-asserted**, not yet validated against the diff — fine for warn-first; a future enforce flip must add that check (documented).
- Persistence is best-effort and **never fails the review**.

## Process

- Design approved by `higher_order` consensus_vote (**7-0**).
- Adversarial review subagent: 1 blocker (all-errored false pass) found → fixed + tested → re-verified **merge-ready**.
- `tsc` clean, lint clean, 335 pr-review+audit tests + 100 MCP-registration tests green, repo-index up to date.

Closes #4031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)