### PR TITLE
docs(audit): disclose deleted-fork-partner omission-detection gap (#4011)

### DIFF
--- a/.changeset/vote-record-omission-disclosure.md
+++ b/.changeset/vote-record-omission-disclosure.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+Doc-accuracy: disclose the known omission-detection gap in the tamper-evident
+vote-record / pr-review-record SETs (#4011). The module docstrings claimed
+"omission is detected via sequence gaps" as a flat integrity property, but
+sequence-gap detection only catches a hole in the `0..maxSeq` run — it does NOT
+catch deletion of a fork PARTNER (a record sharing a sequence with a survivor),
+because duplicate sequences are a benign concurrent-fork signal. `verifyVoteRecordSet`
+/ `verifyPrReviewRecordSet` therefore return `ok` after such a deletion.
+
+This is within the disclosed residual-trust boundary (records are author-typed
+and unsigned; closing the gap requires per-record signing, #3927 item 4) and
+grants a commit-access actor no new capability, so it is a doc-vs-reality
+correction, not a fix to detection. The docstrings, the audit-hash-chain threat
+model (recommendation 4), and a new characterization test now state the limit
+explicitly. No runtime behavior changed.

--- a/docs/security/audit-hash-chain-threat-model.md
+++ b/docs/security/audit-hash-chain-threat-model.md
@@ -127,11 +127,11 @@ and [T5](#t5-missing--selective-omission). The tool is read-only (`:9-14`).
 
 ## 2. Adversary model
 
-| Adversary | Capability | Primary relevance |
-| --------- | ---------- | ----------------- |
-| **Storage compromise** | Read/write to `logDir` files only; cannot run the logger process or modify code. | T1–T6 |
-| **Process compromise** | Runs as the logger; can call `computeEventHash`, knows the algorithm, holds no secret key (there is none). | T3, T4, T8 |
-| **Code/tool compromise** | Can modify `audit-logger.ts` or the verify tool / its inputs. | T9 |
+| Adversary                | Capability                                                                                                 | Primary relevance |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- | ----------------- |
+| **Storage compromise**   | Read/write to `logDir` files only; cannot run the logger process or modify code.                           | T1–T6             |
+| **Process compromise**   | Runs as the logger; can call `computeEventHash`, knows the algorithm, holds no secret key (there is none). | T3, T4, T8        |
+| **Code/tool compromise** | Can modify `audit-logger.ts` or the verify tool / its inputs.                                              | T9                |
 
 The critical observation: **the hashing algorithm uses no secret.**
 `computeEventHash` is a keyless `SHA-256` (`audit-logger.ts:45-56`). Any
@@ -264,7 +264,7 @@ hash). Each log directory's chain floats free.
 `policyDecision`, `violationType`, `severity`, `timestampMs`, `traceId`, etc.
 (see [§1.2](#12-how-entries-link-prevhash--hash)).
 
-**Detected?** **Partially — qualified since #3921.** For a *normal* event,
+**Detected?** **Partially — qualified since #3921.** For a _normal_ event,
 `computeEventHash` hashes only
 `{id, timestamp, category, action, outcome, actor, previousHash}`
 (`audit-logger.ts:~64`). Mutating an unhashed field leaves the stored `hash`
@@ -293,7 +293,7 @@ first line's `hash`).
 short-circuit `events[0]?.hash === undefined ⇒ { ok: true }`
 (`audit-logger.ts:131`) and reports success on a completely unprotected log. A
 green `verify_audit_chain` result does **not** prove the log was hash-chained —
-only that *if* it claims to be chained, it is internally consistent.
+only that _if_ it claims to be chained, it is internally consistent.
 
 **Residual risk: HIGH.** "OK" is ambiguous between "verified chained log" and
 "un-chained log, nothing to verify". Mitigation would require the tool to report
@@ -321,17 +321,17 @@ of the log. The single-key/no-key in-repo design cannot self-defend here.
 
 ## 4. Threat summary
 
-| # | Threat | Detected by `verify_audit_chain` today? | Residual risk |
-| - | ------ | --------------------------------------- | ------------- |
-| T1 | Truncation (drop tail) | No | HIGH |
-| T2 | Fork (divergent chains) | No (single view) | HIGH |
-| T3 | Rewrite-and-rehash | **No** (fundamental) | HIGH |
-| T4 | Reordering | Yes if not rehashed; No if rehashed | MEDIUM |
-| T5 | Missing / selective omission | Yes if not re-stitched; No if re-stitched | MEDIUM–HIGH |
-| T6 | First-record integrity (no anchor) | No | HIGH |
-| T7 | Content tampering in unhashed fields | **No** | HIGH |
-| T8 | Chain-disable / downgrade | No (reports OK) | HIGH |
-| T9 | Verifier tampering | No (by definition) | HIGH |
+| #   | Threat                               | Detected by `verify_audit_chain` today?   | Residual risk |
+| --- | ------------------------------------ | ----------------------------------------- | ------------- |
+| T1  | Truncation (drop tail)               | No                                        | HIGH          |
+| T2  | Fork (divergent chains)              | No (single view)                          | HIGH          |
+| T3  | Rewrite-and-rehash                   | **No** (fundamental)                      | HIGH          |
+| T4  | Reordering                           | Yes if not rehashed; No if rehashed       | MEDIUM        |
+| T5  | Missing / selective omission         | Yes if not re-stitched; No if re-stitched | MEDIUM–HIGH   |
+| T6  | First-record integrity (no anchor)   | No                                        | HIGH          |
+| T7  | Content tampering in unhashed fields | **No**                                    | HIGH          |
+| T8  | Chain-disable / downgrade            | No (reports OK)                           | HIGH          |
+| T9  | Verifier tampering                   | No (by definition)                        | HIGH          |
 
 **The chain reliably detects exactly one class of attack:** in-place edits or
 naive deletions/reorderings by an adversary who does **not** recompute the chain
@@ -348,7 +348,7 @@ keyless hash (T3 and its specializations) is **undetectable**.
 - **In-place tamper-evidence** via SHA-256 chaining of a subset of fields
   (`audit-logger.ts:45-56`, `:129`).
 - **Path-traversal protection** on `logDir` (`audit-storage.ts:56`, `:80`),
-  including a system-directory denylist (`:100`) — protects *where* logs are
+  including a system-directory denylist (`:100`) — protects _where_ logs are
   written, not their integrity once written.
 - **Read-only verifier** that never mutates the log (`verify-audit-chain-tool.ts:9-14`).
 - **Append-mode writes** (`audit-storage.ts:236`) — a convention, not enforcement.
@@ -399,6 +399,17 @@ Ranked by risk-reduction-per-effort. All are **out of scope for this doc**
    monotonic, non-decreasing `timestampMs` in `verifyChain`.** Strengthens
    **T4** and makes gaps in **T5** visible even when re-stitched (a gap in the
    sequence is detectable). Low–medium effort.
+
+   > Partially adopted in the SET-based record stores (`vote-record.ts`,
+   > `pr-review-record.ts`, #3927): records carry a monotonic `sequence`, and
+   > `verify*RecordSet` flags any hole in the `0..maxSeq` run as `sequence_gap`.
+   > **Known residual gap (#4011):** because duplicate sequences are a benign
+   > concurrent-fork signal, deleting ONE partner of a fork leaves the survivor on
+   > that sequence — no gap, so verification still returns `ok`. Sequence-gap
+   > omission detection therefore does NOT cover a deleted fork partner. This sits
+   > within the residual-trust boundary (records are author-typed and unsigned);
+   > closing it requires per-record signing (rec #3 / #3927 item 4), not the
+   > sequence mechanism alone.
 
 5. **Make `verify_audit_chain` fail-closed (or warn loudly) on an un-chained
    log when chaining is expected**, and report `chained: true/false` in its

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -22,6 +22,15 @@
  * participate in verification. Omission is detected via SEQUENCE GAPS; concurrent
  * forks (two records sharing a sequence) are a BENIGN signal, not a failure.
  *
+ * KNOWN GAP IN OMISSION DETECTION (#4011, mirrors vote-record.ts): sequence-gap
+ * detection only catches an omission that leaves a HOLE in the `0..maxSeq` run. It
+ * does NOT catch deletion of a FORK PARTNER — when ≥2 records share a sequence and
+ * one is removed, the survivor still occupies that sequence, so no gap appears and
+ * verification stays `ok`. Within the disclosed residual-trust boundary
+ * (author-typed records; cryptographic signing is #3927 item 4): a commit-access
+ * actor could equally never have written the partner, so it grants no new
+ * capability. Closing it folds into #3927 item 4.
+ *
  * DIFF-BINDING (Option-C, #3831 ratification). The self-`hash` covers
  * `prNumber` + **`baseSha`** + **`reviewedDiffHash`** + `verdict` + the review
  * summary content. Binding the record to the exact reviewed DIFF is what makes the
@@ -187,6 +196,10 @@ export function computePrReviewRecordHash(payload: PrReviewRecordPayload): strin
  * tamper/omission signal: `hash_mismatch` (a record's content was edited),
  * `missing_hash` (a record carries no hash), or `sequence_gap` (a record is
  * missing from the 0..maxSeq run — an omission).
+ *
+ * NOT detected (#4011): deletion of a fork PARTNER (a record sharing a sequence
+ * with a survivor) leaves no gap, so `ok` stays true. Bounded by the residual-trust
+ * boundary (author-typed records; signing deferred to #3927 item 4) — module header.
  */
 export type PrReviewRecordVerification =
   | { ok: true; recordCount: number; forks?: number[] }
@@ -275,6 +288,11 @@ function forkSequences({ counts }: SequenceCensus): number[] {
  * - DUPLICATE sequence numbers are a BENIGN concurrent-fork signal (two branches
  *   appended from the same tip, then merged): NOT a failure. They are surfaced on
  *   the success result as `forks` (the duplicated sequence numbers, ascending).
+ *
+ * LIMIT (#4011): a duplicate sequence being benign means deleting ONE partner of a
+ * fork leaves the survivor on that sequence — no gap, so this returns `ok`.
+ * Sequence-gap omission detection does NOT cover a deleted fork partner; that
+ * guarantee waits on cryptographic signing (#3927 item 4), not `verification.ok`.
  *
  * An empty set verifies trivially.
  */

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -187,6 +187,23 @@ describe('verifyVoteRecordSet', () => {
       expect(result.forks).toEqual([1]);
     }
   });
+
+  it('does NOT detect a deleted fork PARTNER — documented residual gap (#4011)', () => {
+    // A fork resolved {approve @1, reject @1}. The `reject` partner is deleted,
+    // leaving its `approve` survivor occupying sequence 1. No 0..maxSeq hole
+    // appears, so verification still returns ok — sequence-gap omission detection
+    // canNOT catch a deleted fork partner. This pins the disclosed limitation;
+    // if a future change makes this detectable, update the vote-record.ts docs.
+    const survivorOnly = [makeRecord('vote-1', 0), makeRecord('vote-2a', 1)];
+    const result = verifyVoteRecordSet(survivorOnly);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // No `forks` surfaced (only one record now carries sequence 1) and no gap —
+      // the deletion is invisible to verification, exactly as documented.
+      expect(result.forks).toBeUndefined();
+      expect(result.recordCount).toBe(2);
+    }
+  });
 });
 
 describe('ratifies subject-binding field (#3927 item 1, schema 1.2)', () => {

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -20,6 +20,20 @@
  * verification. Omission is detected via SEQUENCE GAPS; concurrent forks (two
  * records sharing a sequence) are a BENIGN signal, not a failure.
  *
+ * KNOWN GAP IN OMISSION DETECTION (#4011): sequence-gap detection only catches an
+ * omission that leaves a HOLE in the `0..maxSeq` run. It does NOT catch the
+ * deletion of a FORK PARTNER — when a sequence is shared by ≥2 records and one is
+ * removed, the surviving partner still occupies that sequence, so no gap appears
+ * and verification still returns `ok`. So a concurrent fork that resolved
+ * `approved` + `rejected` can have its `rejected` partner silently dropped. This
+ * is consistent with the residual-trust boundary (records are author-typed and
+ * NOT yet cryptographically signed — signing is #3927 item 4): a commit-access
+ * actor could equally have just never written the rejecting record, so this grants
+ * no new capability. Closing it (cross-checking `forks`/`recordCount`, or
+ * requiring fork partners to be co-present) is only meaningful once signing raises
+ * the overall bar, and folds into #3927 item 4. See the audit-hash-chain threat
+ * model for the disclosed boundary.
+ *
  * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
  * The audit-event chain (`computeEventHash` in audit-logger.ts) hashes only the
  * stable HEAD fields (id/timestamp/category/action/outcome/actor/previousHash)
@@ -215,6 +229,11 @@ export function hashProposal(proposal: string): string {
  * tamper/omission signal: `hash_mismatch` (a record's content was edited),
  * `missing_hash` (a record carries no hash), or `sequence_gap` (a record is
  * missing from the 0..maxSeq run — an omission).
+ *
+ * NOT detected (#4011): the deletion of a fork PARTNER (a record sharing a
+ * sequence with a survivor) leaves no gap, so `ok` stays true. Bounded by the
+ * residual-trust boundary (author-typed records; signing deferred to #3927 item
+ * 4) — see the module header.
  */
 export type VoteRecordVerification =
   | { ok: true; recordCount: number; forks?: number[] }
@@ -299,6 +318,13 @@ function forkSequences({ counts }: SequenceCensus): number[] {
  * - DUPLICATE sequence numbers are a BENIGN concurrent-fork signal (two branches
  *   appended from the same tip, then merged): NOT a failure. They are surfaced
  *   on the success result as `forks` (the duplicated sequence numbers, ascending).
+ *
+ * LIMIT (#4011): because a duplicate sequence is benign, deleting ONE partner of a
+ * fork leaves the survivor occupying that sequence — no gap, so this returns `ok`.
+ * Sequence-gap omission detection therefore does NOT cover a deleted fork partner.
+ * This is within the disclosed residual-trust boundary (author-typed records;
+ * cryptographic signing is #3927 item 4); callers needing that guarantee must wait
+ * for signing, not rely on `verification.ok` alone.
  *
  * An empty set verifies trivially.
  */


### PR DESCRIPTION
## What

#4011 (2026-06-21 security sweep) found a **doc-vs-reality gap**: the vote-record / pr-review-record SET verifiers' docstrings claimed "omission is detected via sequence gaps" as a flat integrity property, but that property has an undisclosed hole.

Sequence-gap detection only catches a hole in the `0..maxSeq` run. Because duplicate sequences are a *benign* concurrent-fork signal, deleting **one partner of a fork** (records sharing a sequence) leaves the survivor on that sequence — no gap — so `verifyVoteRecordSet` / `verifyPrReviewRecordSet` still return `ok`. A fork that resolved `approved` + `rejected` can have its `rejected` partner silently dropped.

## Scope — Option 1 (doc-accuracy), per the issue

The issue recommends Option 1 now and folds Option-2 hardening into #3927 item 4 (per-record signing), noting it's redundant with the residual-trust caveat until signing raises the bar. This is **doc-only — no runtime behavior changed**:

- `audit/vote-record.ts` + `audit/pr-review-record.ts` — module header, `*Verification` result type, and `verify*RecordSet` docstrings now disclose the limit. (#4011 named only vote-record.ts; its sibling carries the identical claim, so both are fixed — the template-sibling pattern.)
- `docs/security/audit-hash-chain-threat-model.md` — recommendation 4 now notes the partial adoption (sequence numbers landed via #3927) and the residual fork-partner-deletion gap.
- New **characterization test** pins the behavior (deleted fork partner → still `ok`, no `forks` surfaced), so the disclosure can't silently drift; if a future change makes it detectable, the test flags the docs for update.

## Why not Option 2 now

It grants a commit-access actor nothing new (they could equally never have written the rejecting record — the acknowledged author-typed residual-trust boundary), and is only meaningful once signing (#3927 item 4) raises the overall bar. Building it now would be redundant hardening — deferred and tracked.

## Gates

tsc + lint clean, markdownlint clean, vote-record tests green (19), gitleaks clean.

Closes #4011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)