### PR TITLE
fix(adapters): omit temperature for Claude models after Opus 4.6 (#4061)

### DIFF
--- a/.changeset/temperature-after-opus-46.md
+++ b/.changeset/temperature-after-opus-46.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+Fix 400 errors on Claude Opus 4.7 / 4.8 (#4061). Claude models released after
+Opus 4.6 reject any non-1.0 `temperature` with a 400 (per the installed
+`@anthropic-ai/sdk`: "all other values will be rejected with a 400 error"), but
+both the native Claude adapter and the OpenAI-compatible gateway adapter forwarded
+the voter / base-agent default (`0.3`) unconditionally — so every call to those
+models failed.
+
+A shared, tested predicate (`temperatureUnsupportedForModel`) now gates the param:
+both adapters OMIT `temperature` for Claude models after Opus 4.6 — and for
+unrecognized/non-numbered Claude families (e.g. `claude-fable-5`, future
+families) as a safe-drop — while leaving non-Claude models and recognized ≤4.6 /
+legacy Claude untouched. Omitting is equivalent to sending `1.0` (the API default)
+and avoids the deprecation. The predicate is robust to provider prefixes,
+`-`/`_` separators, and dated suffixes. Note: on after-4.6 models `temperature` is
+no longer settable, so voters run at the API default rather than the configured
+`0.3` — an unavoidable Anthropic constraint. OpenAI o-series reasoning models have
+the same restriction and are tracked separately (#4062).

--- a/packages/nexus-agents/src/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.test.ts
@@ -249,6 +249,27 @@ describe('ClaudeAdapter', () => {
       );
     });
 
+    it('should DROP temperature for a Claude model after Opus 4.6 (#4061)', async () => {
+      // Models released after Opus 4.6 reject any non-1.0 temperature with a 400;
+      // the adapter must omit the param so the request does not fail.
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Response' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+        stop_reason: 'end_turn',
+        model: 'claude-opus-4-8',
+      });
+
+      const adapter = new ClaudeAdapter({ ...validConfig, modelId: 'claude-opus-4-8' });
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        temperature: 0.3,
+        maxTokens: 1024,
+      });
+
+      const callArg = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg).not.toHaveProperty('temperature');
+    });
+
     it('should include stop sequences when provided', async () => {
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: 'Response' }],

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -43,6 +43,7 @@ import {
   RESPOND_TOOL_NAME,
 } from './claude-adapter-helpers.js';
 import { extractRequestSystemPrompt } from './prompt-utils.js';
+import { temperatureUnsupportedForModel } from '../config/temperature-support.js';
 
 // Re-export types and constants for backward compatibility
 export type { ClaudeAdapterConfig } from './claude-adapter-types.js';
@@ -273,8 +274,15 @@ export class ClaudeAdapter extends BaseAdapter {
     params: Anthropic.MessageCreateParamsNonStreaming,
     request: CompletionRequest
   ): void {
-    if (request.temperature !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- SDK 0.88 deprecated `temperature` for post-Opus-4.6 models; kept for backward compat with older Anthropic models and value 1.0
+    // #4061: Claude models released after Opus 4.6 reject any non-1.0 temperature
+    // with a 400 (per the @anthropic-ai/sdk deprecation note). Omit the param for
+    // those models — 1.0 is the API default, so omitting is equivalent and avoids
+    // the 400 the voter/base-agent default (0.3) would otherwise trigger.
+    if (
+      request.temperature !== undefined &&
+      !temperatureUnsupportedForModel(this.resolvedModelId)
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- still valid for older Anthropic models (≤ Opus 4.6) and value 1.0; gated by temperatureUnsupportedForModel
       params.temperature = request.temperature;
     }
 

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -33,6 +33,7 @@ import {
   getModelCapabilities,
   type OpenAIAdapterConfig,
 } from './openai-types.js';
+import { temperatureUnsupportedForModel } from '../config/temperature-support.js';
 import {
   mapMessage,
   mapTool,
@@ -378,7 +379,16 @@ export class OpenAIAdapter extends BaseAdapter {
     params: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
     request: CompletionRequest
   ): void {
-    if (request.temperature !== undefined) {
+    // #4061: a gateway routing to a Claude model after Opus 4.6 rejects any
+    // non-1.0 temperature with a 400. Omit the param for those models so a
+    // gateway-routed voter panel (default 0.3) does not 400. Non-Claude gateway
+    // models (gpt-*, etc.) are unaffected. NOTE: a gateway that injects its OWN
+    // default temperature when the field is absent is outside our control — our
+    // contract is only to not SEND a value the target model rejects.
+    if (
+      request.temperature !== undefined &&
+      !temperatureUnsupportedForModel(this.resolvedModelId)
+    ) {
       params.temperature = request.temperature;
     }
 

--- a/packages/nexus-agents/src/config/temperature-support.test.ts
+++ b/packages/nexus-agents/src/config/temperature-support.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for {@link temperatureUnsupportedForModel} (#4061).
+ *
+ * Ground truth (installed @anthropic-ai/sdk messages.d.ts): Claude models released
+ * after Opus 4.6 reject any non-1.0 `temperature` with a 400. The predicate decides
+ * whether an adapter must drop the param before sending.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { temperatureUnsupportedForModel } from './temperature-support.js';
+
+describe('temperatureUnsupportedForModel (#4061)', () => {
+  describe('Claude models AFTER Opus 4.6 → unsupported (drop temperature)', () => {
+    const after46 = [
+      'claude-opus-4-7',
+      'claude-opus-4-8',
+      'claude-sonnet-4-7',
+      'claude-haiku-4-7',
+      'claude-opus-4-10', // 4.10 is ABOVE 4.6 — integer-tuple compare, not parseFloat
+      'claude-opus-5-0',
+      'claude-opus-5',
+      // gateway / provider-prefixed / underscore variants
+      'claude_4_8',
+      'anthropic/claude-opus-4-8',
+      'custom/claude-opus-4-7',
+      'claude-opus-4-8-20260115', // dated suffix must not shadow the 4-8 version
+    ];
+    it.each(after46)('%s → true', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(true);
+    });
+  });
+
+  describe('Claude Fable 5 and unrecognized Claude families → unsupported (safe-drop)', () => {
+    // Contrarian-review condition (#4061): the rule is temporal ("after 4.6"), so a
+    // post-4.6 Claude family with no 4.x version (Fable 5, future families) must
+    // safe-drop rather than be wrongly treated as supported.
+    const unrecognizedClaude = ['claude-fable-5', 'claude-fable', 'claude-newfamily-x'];
+    it.each(unrecognizedClaude)('%s → true', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(true);
+    });
+  });
+
+  describe('Claude models AT/BEFORE Opus 4.6 → supported (keep temperature)', () => {
+    const upTo46 = [
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-5-20250929',
+      'claude-opus-4-5-20251101',
+      'claude-opus-4-0',
+      'custom/claude-opus-4-6',
+      'anthropic/claude-sonnet-4-6',
+      // bare major 4 (= 4.0) with an 8-digit snapshot date: the date must NOT be
+      // parsed as the minor version (#4061 adversarial-review regression guard).
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+    ];
+    it.each(upTo46)('%s → false', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(false);
+    });
+  });
+
+  describe('legacy Claude families (≤ 3.x) → supported', () => {
+    const legacy = [
+      'claude-3-5-sonnet-20241022', // parses 3.5 → supported
+      'claude-3-7-sonnet',
+      'claude-3-opus',
+      'claude-2',
+      'claude-2.1',
+      'claude-instant-1',
+    ];
+    it.each(legacy)('%s → false', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(false);
+    });
+  });
+
+  describe('non-Claude models → supported (never touched)', () => {
+    const nonClaude = [
+      'gpt-5.4',
+      'gpt-4o',
+      'o1-preview', // OpenAI reasoning models also reject temp, but are OUT OF SCOPE here
+      'gemini-3-pro',
+      'gemini-2.5-flash',
+      'openrouter/qwen-coder',
+      'nemotron-super',
+    ];
+    it.each(nonClaude)('%s → false', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(false);
+    });
+  });
+
+  it('is case-insensitive', () => {
+    expect(temperatureUnsupportedForModel('Claude-Opus-4-8')).toBe(true);
+    expect(temperatureUnsupportedForModel('CLAUDE-OPUS-4-6')).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/config/temperature-support.ts
+++ b/packages/nexus-agents/src/config/temperature-support.ts
@@ -1,0 +1,84 @@
+/**
+ * nexus-agents/config — model `temperature` support (#4061).
+ *
+ * Anthropic Claude models released AFTER Opus 4.6 do not support setting
+ * `temperature`. Per the installed `@anthropic-ai/sdk` (messages.d.ts): "Models
+ * released after Claude Opus 4.6 do not support setting temperature. A value of
+ * 1.0 will be accepted for backwards compatibility, all other values will be
+ * rejected with a 400 error." So sending the voter / base-agent default (0.3) to
+ * Opus 4.7 / 4.8 — or routing them through an OpenAI-compatible gateway that
+ * forwards the param — yields a hard 400.
+ *
+ * {@link temperatureUnsupportedForModel} is the single source of truth both the
+ * native Claude adapter and the OpenAI-compatible gateway adapter consult before
+ * forwarding `temperature`. When it returns true the adapter OMITS the param
+ * (value 1.0 is the API default, so omitting is equivalent and sidesteps the
+ * deprecation).
+ *
+ * @module config/temperature-support
+ */
+
+interface ClaudeMajorMinor {
+  readonly major: number;
+  readonly minor: number;
+}
+
+/**
+ * Parse the FIRST numeric version from a (provider-prefix-stripped) Claude model
+ * id — a major with an OPTIONAL minor, tolerating `-`, `_`, and `.` separators.
+ *
+ * A trailing snapshot date (`-20250514`, 6+ digits) is stripped FIRST so it cannot
+ * be mistaken for a minor: `claude-opus-4-20250514` is Opus **4.0**, not 4.20250514.
+ * A bare major with no minor is treated as `.0` (`claude-opus-4` → 4.0,
+ * `claude-fable-5` → 5.0). major/minor are kept as separate integers so `4.10`
+ * compares ABOVE `4.6` (a `parseFloat` would collapse to 4.1). Returns `null` only
+ * when the id carries no version digits at all (e.g. `claude-instant`,
+ * `claude-newfamily`).
+ */
+function parseClaudeMajorMinor(bareId: string): ClaudeMajorMinor | null {
+  const undated = bareId.replace(/[-_]\d{6,}$/, '');
+  const match = /(\d+)(?:[-_.](\d+))?/.exec(undated);
+  if (match === null) return null;
+  const major = Number.parseInt(match[1] as string, 10);
+  const minor = match[2] !== undefined ? Number.parseInt(match[2], 10) : 0;
+  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
+  return { major, minor };
+}
+
+/** Recognized LEGACY Claude families that still support `temperature` (pre-4.x). */
+const LEGACY_TEMPERATURE_SUPPORTING = /claude[-_](?:instant|1|2|3)(?:[-_.]|$)/;
+
+/**
+ * Whether `modelId` REJECTS a non-default `temperature` and the param must be
+ * dropped before the request is sent.
+ *
+ * - Non-Claude models (gpt-*, gemini-*, …) → `false`: never touched here.
+ * - Claude opus/sonnet/haiku with a parseable version > 4.6 → `true` (the SDK
+ *   boundary: 4.7+, 5.x).
+ * - Recognized legacy Claude (claude-2/3/instant) → `false`: still support it.
+ * - Any OTHER Claude id (no parseable version and not legacy — e.g.
+ *   `claude-fable-5`, a future Claude family, or a bare alias) → `true`. This
+ *   SAFE-DROP default is deliberate: dropping `temperature` is a benign fall-back
+ *   to the API default, whereas forwarding it to a model that rejects it is a 400
+ *   outage. Errors are worse than losing a temperature setting.
+ *
+ * Robust to gateway id variants — provider prefixes (`anthropic/…`, `custom/…`),
+ * `-`/`_` separators (`claude-opus-4-8`, `claude_4_8`), and dated suffixes.
+ */
+export function temperatureUnsupportedForModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  const claudeAt = id.indexOf('claude');
+  if (claudeAt === -1) return false; // not a Claude model — leave temperature alone
+  const bare = id.slice(claudeAt); // strip any `anthropic/` / `custom/` prefix
+
+  const version = parseClaudeMajorMinor(bare);
+  if (version !== null) {
+    // "after Opus 4.6": major > 4, or 4.7+ within the 4.x line.
+    return version.major > 4 || (version.major === 4 && version.minor >= 7);
+  }
+  // No version digits at all (e.g. `claude-instant`, a bare family alias, an
+  // unknown future family): legacy families keep temperature; everything else
+  // Claude is treated as unsupported (safe-drop — a benign default beats a 400).
+  if (LEGACY_TEMPERATURE_SUPPORTING.test(bare)) return false;
+  return true;
+}


### PR DESCRIPTION
## The bug (user-reported, confirmed against the installed SDK)

`@anthropic-ai/sdk` 0.104 `messages.d.ts` on `temperature`:
> @deprecated. **Models released after Claude Opus 4.6 do not support setting temperature. A value of 1.0 will be accepted for backwards compatibility, all other values will be rejected with a 400 error.**

Both adapters forwarded `temperature` unconditionally — `claude-adapter.ts` (native) and `openai-adapter.ts` (the OpenAI-compatible gateway voters route through). The voter/base-agent default is `0.3`, so **every** call to Opus 4.7/4.8 (native or gateway-routed) 400s. The registry only declares up to `claude-opus-4-6`, so 4.7/4.8 are unregistered — a registry-flag fix can't reach them. The reporting agent's diagnosis ("4.8/4.7 don't support temperature and we were including it") was correct.

## Fix

New shared predicate `temperatureUnsupportedForModel(modelId)` (`config/temperature-support.ts`), consulted by both adapters before forwarding the param. Omits `temperature` for:
- Claude opus/sonnet/haiku version > 4.6, **and**
- unrecognized/non-numbered Claude families (`claude-fable-5`, future) — **safe-drop** (a benign fall-back to the API default beats a 400).

Non-Claude models (gpt/gemini/…) and recognized ≤4.6 / legacy Claude are untouched. Robust to provider prefixes, `-`/`_` separators, and trailing snapshot dates. Omitting equals sending `1.0` (the API default), so no behavior change on supported models.

## Process

- Design approved by `higher_order` consensus_vote (**7-0**); the panel surfaced the Fable-5 temporal-vs-version gap → handled via safe-drop.
- Adversarial review found one low-impact hole (dated `claude-opus-4-20250514` → Opus 4.0 misparsed) → **fixed + regression-guarded** (strip trailing date, bare major = `.0`).
- 35-case predicate truth table + adapter drop/keep integration tests; tsc + lint clean, 870 adapter tests green, gitleaks clean.

## Tradeoff & follow-ups

Voters lose the `0.3` consistency setting on after-4.6 models (unavoidable Anthropic constraint). OpenAI o-series reasoning models share the restriction — tracked in **#4062**. Likely resolves part of **#4049** (gateway 400s) — cross-referenced there.

Closes #4061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)