### PR TITLE
fix(adapters): omit temperature for OpenAI reasoning models (#4062)

### DIFF
--- a/.changeset/temperature-openai-reasoning.md
+++ b/.changeset/temperature-openai-reasoning.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+Extend the temperature-omission fix to OpenAI reasoning models (#4062, follow-on
+to #4061). The o-series (o1/o3/o3-mini/o4-mini) reject `temperature` outright, and
+the GPT-5 family accepts only the default (`1`) — per OpenAI's documented behavior.
+This repo routes codex-5.3→gpt-5.4, codex-5.2→gpt-5.2-codex, codex-5.1-mini→o3-mini,
+so gateway-routed voters at the default `0.3` were 400-ing on every one of them,
+exactly like the Claude 4.7/4.8 case.
+
+`temperatureUnsupportedForModel` now also returns true for OpenAI reasoning models
+(o-series, GPT-5 family except the non-reasoning `gpt-5-chat` variant, and codex
+ids), while preserving temperature for non-reasoning models (gpt-4o, gpt-4,
+gpt-3.5, gemini, openrouter-\*). The GPT-5 match is anchored so `gpt-50`/`gpt-512`
+do not falsely match. The predicate is biased against false positives — a missed
+model is a 400 outage, a wrongly matched one only loses the consistency setting.
+
+Also closes a third unguarded path found during the fix: the AI-SDK adapter
+(`sdk-adapter.ts`, used by `auto-adapter` for the openai/codex provider — which
+routes to reasoning models like gpt-5.4 / o3-mini) forwarded `temperature`
+unconditionally and now consults the same predicate. All three adapters that send
+`temperature` (native Claude, OpenAI-compatible gateway, AI-SDK) are now covered.

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -30,6 +30,7 @@ import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
+import { temperatureUnsupportedForModel } from '../../config/temperature-support.js';
 import {
   validateCustomApiBaseUrl,
   assertCustomApiHostResolvesPublic,
@@ -397,7 +398,11 @@ export class SdkAdapter extends BaseAdapter {
     if (request.systemPrompt !== undefined) {
       options['system'] = request.systemPrompt;
     }
-    if (request.temperature !== undefined) {
+    // #4061/#4062: Claude models after Opus 4.6 and OpenAI reasoning models
+    // (o-series, GPT-5 family) reject a non-1.0 temperature with a 400. The AI-SDK
+    // path routes to both (auto-adapter wires openai/codex + anthropic), so omit
+    // the param for those models — 1.0 is the API default, so omitting is equivalent.
+    if (request.temperature !== undefined && !temperatureUnsupportedForModel(this.modelId)) {
       options['temperature'] = request.temperature;
     }
     if (request.maxTokens !== undefined) {

--- a/packages/nexus-agents/src/config/temperature-support.test.ts
+++ b/packages/nexus-agents/src/config/temperature-support.test.ts
@@ -74,17 +74,41 @@ describe('temperatureUnsupportedForModel (#4061)', () => {
     });
   });
 
-  describe('non-Claude models → supported (never touched)', () => {
-    const nonClaude = [
+  describe('OpenAI reasoning models → unsupported (#4062)', () => {
+    const reasoning = [
+      'o1',
+      'o1-preview',
+      'o1-mini',
+      'o3',
+      'o3-mini',
+      'o4-mini',
+      'gpt-5',
       'gpt-5.4',
+      'gpt-5.2-codex',
+      'codex-5.3', // internal id; resolves to gpt-5.4 but match either way
+      'openai/o3-mini', // provider-prefixed → last segment matched
+    ];
+    it.each(reasoning)('%s → true', (id) => {
+      expect(temperatureUnsupportedForModel(id)).toBe(true);
+    });
+  });
+
+  describe('non-reasoning models → supported (never touched)', () => {
+    const supported = [
       'gpt-4o',
-      'o1-preview', // OpenAI reasoning models also reject temp, but are OUT OF SCOPE here
+      'gpt-4',
+      'gpt-4-turbo',
+      'gpt-3.5-turbo',
+      'gpt-5-chat-latest', // the documented non-reasoning GPT-5 carve-out
+      'gpt-50', // over-match guard: NOT gpt-5 (anchored after the 5)
+      'gpt-512', // over-match guard
       'gemini-3-pro',
       'gemini-2.5-flash',
       'openrouter/qwen-coder',
+      'openrouter-nemotron-super',
       'nemotron-super',
     ];
-    it.each(nonClaude)('%s → false', (id) => {
+    it.each(supported)('%s → false', (id) => {
       expect(temperatureUnsupportedForModel(id)).toBe(false);
     });
   });

--- a/packages/nexus-agents/src/config/temperature-support.ts
+++ b/packages/nexus-agents/src/config/temperature-support.ts
@@ -1,19 +1,27 @@
 /**
- * nexus-agents/config — model `temperature` support (#4061).
+ * nexus-agents/config — model `temperature` support (#4061, #4062).
  *
- * Anthropic Claude models released AFTER Opus 4.6 do not support setting
- * `temperature`. Per the installed `@anthropic-ai/sdk` (messages.d.ts): "Models
- * released after Claude Opus 4.6 do not support setting temperature. A value of
- * 1.0 will be accepted for backwards compatibility, all other values will be
- * rejected with a 400 error." So sending the voter / base-agent default (0.3) to
- * Opus 4.7 / 4.8 — or routing them through an OpenAI-compatible gateway that
- * forwards the param — yields a hard 400.
+ * Some models reject a custom `temperature` with a hard 400, so both adapters
+ * must OMIT the param for them. Two families:
+ *
+ * 1. Anthropic Claude AFTER Opus 4.6 (#4061). Per the installed `@anthropic-ai/sdk`
+ *    (messages.d.ts): "Models released after Claude Opus 4.6 do not support setting
+ *    temperature. A value of 1.0 will be accepted for backwards compatibility, all
+ *    other values will be rejected with a 400 error."
+ * 2. OpenAI REASONING models (#4062): the o-series (o1/o3/o3-mini/o4-mini) reject
+ *    `temperature` outright ("Unsupported parameter"), and the GPT-5 family accepts
+ *    only the default ("Only the default (1) value is supported") — except the
+ *    non-reasoning `gpt-5-chat` variant. This repo routes codex-5.3→gpt-5.4,
+ *    codex-5.2→gpt-5.2-codex, codex-5.1-mini→o3-mini, so gateway voters at the
+ *    default 0.3 400 on all of them.
  *
  * {@link temperatureUnsupportedForModel} is the single source of truth both the
  * native Claude adapter and the OpenAI-compatible gateway adapter consult before
  * forwarding `temperature`. When it returns true the adapter OMITS the param
- * (value 1.0 is the API default, so omitting is equivalent and sidesteps the
- * deprecation).
+ * (value 1.0 is the API default, so omitting is equivalent). It returns FALSE for
+ * every model NOT known to reject temperature (gpt-4o, gpt-4, gemini, …), biasing
+ * AGAINST false-positive stripping — a false negative is a 400, a false positive
+ * only loses the consistency setting.
  *
  * @module config/temperature-support
  */
@@ -49,36 +57,61 @@ function parseClaudeMajorMinor(bareId: string): ClaudeMajorMinor | null {
 const LEGACY_TEMPERATURE_SUPPORTING = /claude[-_](?:instant|1|2|3)(?:[-_.]|$)/;
 
 /**
- * Whether `modelId` REJECTS a non-default `temperature` and the param must be
- * dropped before the request is sent.
- *
- * - Non-Claude models (gpt-*, gemini-*, …) → `false`: never touched here.
- * - Claude opus/sonnet/haiku with a parseable version > 4.6 → `true` (the SDK
- *   boundary: 4.7+, 5.x).
- * - Recognized legacy Claude (claude-2/3/instant) → `false`: still support it.
- * - Any OTHER Claude id (no parseable version and not legacy — e.g.
- *   `claude-fable-5`, a future Claude family, or a bare alias) → `true`. This
- *   SAFE-DROP default is deliberate: dropping `temperature` is a benign fall-back
- *   to the API default, whereas forwarding it to a model that rejects it is a 400
- *   outage. Errors are worse than losing a temperature setting.
- *
- * Robust to gateway id variants — provider prefixes (`anthropic/…`, `custom/…`),
- * `-`/`_` separators (`claude-opus-4-8`, `claude_4_8`), and dated suffixes.
+ * Claude branch of {@link temperatureUnsupportedForModel} (#4061). `bare` is the
+ * id sliced from the first `claude` (provider prefix stripped). Unsupported when
+ * the version is after Opus 4.6, or the family is unrecognized/non-numbered
+ * (`claude-fable-5`, future) — a deliberate SAFE-DROP, since a benign fall-back to
+ * the API default beats a 400.
  */
-export function temperatureUnsupportedForModel(modelId: string): boolean {
-  const id = modelId.toLowerCase();
-  const claudeAt = id.indexOf('claude');
-  if (claudeAt === -1) return false; // not a Claude model — leave temperature alone
-  const bare = id.slice(claudeAt); // strip any `anthropic/` / `custom/` prefix
-
+function claudeTemperatureUnsupported(bare: string): boolean {
   const version = parseClaudeMajorMinor(bare);
   if (version !== null) {
     // "after Opus 4.6": major > 4, or 4.7+ within the 4.x line.
     return version.major > 4 || (version.major === 4 && version.minor >= 7);
   }
-  // No version digits at all (e.g. `claude-instant`, a bare family alias, an
-  // unknown future family): legacy families keep temperature; everything else
-  // Claude is treated as unsupported (safe-drop — a benign default beats a 400).
   if (LEGACY_TEMPERATURE_SUPPORTING.test(bare)) return false;
   return true;
+}
+
+/**
+ * OpenAI branch of {@link temperatureUnsupportedForModel} (#4062). True ONLY for
+ * the reasoning models documented to reject `temperature`; everything else
+ * (gpt-4o, gpt-4, gpt-3.5, gemini, openrouter-*, …) returns false so its
+ * temperature is preserved. `id` is the full lower-cased model id.
+ *
+ * - o-series: `o1`/`o3`/`o3-mini`/`o4-mini` — `o` + digit at the START of the last
+ *   path segment (so `claude-opus`/`openrouter-*` cannot match — and the Claude
+ *   branch already ran first regardless).
+ * - codex: all current `codex…` routes are GPT-5-reasoning-based.
+ * - GPT-5 family: `gpt-5` / `gpt5` (anchored after the `5` so `gpt-50`/`gpt-512`
+ *   do NOT match) — EXCEPT the non-reasoning `gpt-5-chat` variant.
+ */
+function openAiReasoningTemperatureUnsupported(id: string): boolean {
+  const segment = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
+  if (/^o[0-9]/.test(segment)) return true;
+  if (segment.includes('codex')) return true;
+  if (/gpt-?5(?![0-9])/.test(segment) && !segment.includes('gpt-5-chat')) return true;
+  return false;
+}
+
+/**
+ * Whether `modelId` REJECTS a non-default `temperature` and the param must be
+ * dropped before the request is sent. Single source of truth for both adapters.
+ *
+ * - Claude models → see {@link claudeTemperatureUnsupported} (after Opus 4.6, #4061).
+ * - OpenAI reasoning models → see {@link openAiReasoningTemperatureUnsupported}
+ *   (o-series / GPT-5 family / codex, #4062).
+ * - Everything else (gpt-4o, gpt-4, gemini-*, openrouter-*, …) → `false`.
+ *
+ * Biased AGAINST false positives: a missed model is a 400 outage, a wrongly
+ * matched one only loses the consistency setting. Robust to gateway id variants —
+ * provider prefixes (`anthropic/…`, `openai/…`), `-`/`_` separators, dated suffixes.
+ */
+export function temperatureUnsupportedForModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  const claudeAt = id.indexOf('claude');
+  if (claudeAt !== -1) {
+    return claudeTemperatureUnsupported(id.slice(claudeAt)); // strip provider prefix
+  }
+  return openAiReasoningTemperatureUnsupported(id);
 }


### PR DESCRIPTION
## What — follow-on to #4061

OpenAI **reasoning models reject a custom `temperature`** with a 400 ([researched, authoritative](https://community.openai.com/t/o3-mini-unsupported-parameter-temperature/1140846)):
- **o-series** (o1/o3/o3-mini/o4-mini) → 400 *"Unsupported parameter: 'temperature' is not supported with this model"*.
- **GPT-5 family** → 400 *"Only the default (1) value is supported"* (except the non-reasoning `gpt-5-chat` variant).

This repo routes `codex-5.3→gpt-5.4`, `codex-5.2→gpt-5.2-codex`, `codex-5.1-mini→o3-mini` — all reasoning models — so gateway-routed voters at the default `0.3` were **400-ing on all of them**, exactly like the Claude 4.7/4.8 case.

## Fix

`temperatureUnsupportedForModel` (the shared predicate both adapters already consult) now also returns true for OpenAI reasoning models:
- o-series via `/^o[0-9]/` (excludes `claude-opus`/`openrouter-*`; Claude branch runs first anyway),
- GPT-5 family via `/gpt-?5(?![0-9])/` **anchored** so `gpt-50`/`gpt-512` do NOT match, minus the `gpt-5-chat` carve-out,
- `codex` ids.

Non-reasoning models (gpt-4o, gpt-4, gpt-3.5, gemini, openrouter-*) keep their temperature. **Biased against false positives** — a missed model is a 400 outage, a wrongly matched one only loses the consistency setting.

**Third adapter guarded:** found during the fix — the AI-SDK adapter (`sdk-adapter.ts`, used by `auto-adapter` for the openai/codex provider → gpt-5.4/o3-mini) forwarded `temperature` unconditionally and now consults the same predicate. All three temperature-sending adapters (native Claude, OpenAI-compatible gateway, AI-SDK) are covered.

## Process

- Design approved by `higher_order` consensus_vote (**7-0**); grounded in OpenAI's documented behavior. Panel endorsed family-match over allowlist (asymmetric failure: false-negative = 400, false-positive = lost consistency).
- Adversarial review: **clean, no blockers** (verified no false positives against the actual registry; `gpt-5.4`'s `.` passes the lookahead; `qwen3-coder`≠`codex`; `this.modelId` is the real AI-SDK target).
- 53-case predicate truth table (incl. over-match guards + carve-out) + 870 adapter tests green; tsc/lint clean; gitleaks clean.

Closes #4062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)