### PR TITLE
feat(adapters): warn loudly when temperature is dropped (#4066 layer 3 / #4069)

### DIFF
--- a/.changeset/temperature-drop-loud-warning.md
+++ b/.changeset/temperature-drop-loud-warning.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+Fail loudly when `temperature` is dropped for a model that rejects it (#4066 layer
+3). Since #4061/#4062, the adapters silently omit `temperature` for Claude models
+after Opus 4.6 and OpenAI reasoning models — but silently dropping a BEHAVIORAL
+parameter is the canonical footgun: a determinism/consistency setting is ignored
+with no signal (0.0 and 0.7 yield identical output).
+
+The three temperature-sending adapters (native Claude, OpenAI-compatible gateway,
+AI-SDK) now emit a structured WARNING the first time they drop `temperature` for a
+given model — naming the model, stating the param was omitted and the request runs
+at the provider default, and that temperature has no effect on that model.
+Deduped once-per-model-per-process (repeats log at debug) so a multi-call voter
+panel does not spam. This is the first slice of the epic #4066 "never drop a param
+silently" invariant; the response-surfaced `warnings`, the
+`MODEL_PARAMETER_UNSUPPORTED` error code, and the would-have-self-healed counter
+remain tracked in #4069.

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -43,7 +43,10 @@ import {
   RESPOND_TOOL_NAME,
 } from './claude-adapter-helpers.js';
 import { extractRequestSystemPrompt } from './prompt-utils.js';
-import { temperatureUnsupportedForModel } from '../config/temperature-support.js';
+import {
+  temperatureUnsupportedForModel,
+  warnTemperatureDropped,
+} from '../config/temperature-support.js';
 
 // Re-export types and constants for backward compatibility
 export type { ClaudeAdapterConfig } from './claude-adapter-types.js';
@@ -278,12 +281,13 @@ export class ClaudeAdapter extends BaseAdapter {
     // with a 400 (per the @anthropic-ai/sdk deprecation note). Omit the param for
     // those models — 1.0 is the API default, so omitting is equivalent and avoids
     // the 400 the voter/base-agent default (0.3) would otherwise trigger.
-    if (
-      request.temperature !== undefined &&
-      !temperatureUnsupportedForModel(this.resolvedModelId)
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- still valid for older Anthropic models (≤ Opus 4.6) and value 1.0; gated by temperatureUnsupportedForModel
-      params.temperature = request.temperature;
+    if (request.temperature !== undefined) {
+      if (temperatureUnsupportedForModel(this.resolvedModelId)) {
+        warnTemperatureDropped(this.resolvedModelId);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- still valid for older Anthropic models (≤ Opus 4.6) and value 1.0; gated by temperatureUnsupportedForModel
+        params.temperature = request.temperature;
+      }
     }
 
     if (request.stop !== undefined && request.stop.length > 0) {

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -33,7 +33,10 @@ import {
   getModelCapabilities,
   type OpenAIAdapterConfig,
 } from './openai-types.js';
-import { temperatureUnsupportedForModel } from '../config/temperature-support.js';
+import {
+  temperatureUnsupportedForModel,
+  warnTemperatureDropped,
+} from '../config/temperature-support.js';
 import {
   mapMessage,
   mapTool,
@@ -385,11 +388,12 @@ export class OpenAIAdapter extends BaseAdapter {
     // models (gpt-*, etc.) are unaffected. NOTE: a gateway that injects its OWN
     // default temperature when the field is absent is outside our control — our
     // contract is only to not SEND a value the target model rejects.
-    if (
-      request.temperature !== undefined &&
-      !temperatureUnsupportedForModel(this.resolvedModelId)
-    ) {
-      params.temperature = request.temperature;
+    if (request.temperature !== undefined) {
+      if (temperatureUnsupportedForModel(this.resolvedModelId)) {
+        warnTemperatureDropped(this.resolvedModelId);
+      } else {
+        params.temperature = request.temperature;
+      }
     }
 
     if (request.stop !== undefined && request.stop.length > 0) {

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -30,7 +30,10 @@ import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
-import { temperatureUnsupportedForModel } from '../../config/temperature-support.js';
+import {
+  temperatureUnsupportedForModel,
+  warnTemperatureDropped,
+} from '../../config/temperature-support.js';
 import {
   validateCustomApiBaseUrl,
   assertCustomApiHostResolvesPublic,
@@ -402,8 +405,12 @@ export class SdkAdapter extends BaseAdapter {
     // (o-series, GPT-5 family) reject a non-1.0 temperature with a 400. The AI-SDK
     // path routes to both (auto-adapter wires openai/codex + anthropic), so omit
     // the param for those models — 1.0 is the API default, so omitting is equivalent.
-    if (request.temperature !== undefined && !temperatureUnsupportedForModel(this.modelId)) {
-      options['temperature'] = request.temperature;
+    if (request.temperature !== undefined) {
+      if (temperatureUnsupportedForModel(this.modelId)) {
+        warnTemperatureDropped(this.modelId);
+      } else {
+        options['temperature'] = request.temperature;
+      }
     }
     if (request.maxTokens !== undefined) {
       options['maxTokens'] = request.maxTokens;

--- a/packages/nexus-agents/src/config/temperature-support.test.ts
+++ b/packages/nexus-agents/src/config/temperature-support.test.ts
@@ -6,9 +6,19 @@
  * whether an adapter must drop the param before sending.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { temperatureUnsupportedForModel } from './temperature-support.js';
+// Spy on the module logger so the loud-drop warning (#4066 layer 3) is assertable.
+const { warnSpy, debugSpy } = vi.hoisted(() => ({ warnSpy: vi.fn(), debugSpy: vi.fn() }));
+vi.mock('../core/index.js', () => ({
+  createLogger: () => ({ warn: warnSpy, debug: debugSpy, info: vi.fn(), error: vi.fn() }),
+}));
+
+import {
+  temperatureUnsupportedForModel,
+  warnTemperatureDropped,
+  _resetTemperatureWarnings,
+} from './temperature-support.js';
 
 describe('temperatureUnsupportedForModel (#4061)', () => {
   describe('Claude models AFTER Opus 4.6 → unsupported (drop temperature)', () => {
@@ -116,5 +126,40 @@ describe('temperatureUnsupportedForModel (#4061)', () => {
   it('is case-insensitive', () => {
     expect(temperatureUnsupportedForModel('Claude-Opus-4-8')).toBe(true);
     expect(temperatureUnsupportedForModel('CLAUDE-OPUS-4-6')).toBe(false);
+  });
+});
+
+describe('warnTemperatureDropped — fail loudly on a dropped behavioral param (#4066 layer 3)', () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+    debugSpy.mockClear();
+    _resetTemperatureWarnings();
+  });
+
+  it('warns LOUDLY (once) the first time temperature is dropped for a model', () => {
+    warnTemperatureDropped('claude-opus-4-8');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message, context] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toContain('claude-opus-4-8');
+    expect(message).toMatch(/temperature/i);
+    expect(context).toMatchObject({
+      modelId: 'claude-opus-4-8',
+      parameter: 'temperature',
+      severity: 'behavioral',
+    });
+  });
+
+  it('dedupes per model: repeat drops for the same model log at debug, not warn', () => {
+    warnTemperatureDropped('o3-mini');
+    warnTemperatureDropped('o3-mini');
+    warnTemperatureDropped('o3-mini');
+    expect(warnSpy).toHaveBeenCalledTimes(1); // loud once
+    expect(debugSpy).toHaveBeenCalledTimes(2); // quiet thereafter
+  });
+
+  it('warns separately for distinct models', () => {
+    warnTemperatureDropped('claude-opus-4-8');
+    warnTemperatureDropped('gpt-5.4');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/nexus-agents/src/config/temperature-support.ts
+++ b/packages/nexus-agents/src/config/temperature-support.ts
@@ -26,6 +26,48 @@
  * @module config/temperature-support
  */
 
+import { createLogger } from '../core/index.js';
+
+const logger = createLogger({ component: 'temperature-support' });
+
+/**
+ * Models we have ALREADY warned about dropping `temperature` for, so the loud
+ * warning fires once per model per process rather than on every request (a voter
+ * panel makes many calls). Repeats log at debug.
+ */
+const warnedDroppedModels = new Set<string>();
+
+/**
+ * FAIL LOUDLY when `temperature` is omitted because the target model rejects it
+ * (#4066 layer 3). `temperature` is a BEHAVIORAL parameter — silently dropping it
+ * means a determinism/consistency setting is ignored with no signal (e.g. 0.0 and
+ * 0.7 yield identical output), the canonical footgun. So the first drop per model
+ * is a WARN that says the param was omitted and the request runs at the provider
+ * default; subsequent drops for that model log at debug to avoid per-call spam.
+ */
+export function warnTemperatureDropped(modelId: string): void {
+  if (warnedDroppedModels.has(modelId)) {
+    logger.debug('Omitted unsupported temperature (already warned for this model)', {
+      modelId,
+      parameter: 'temperature',
+    });
+    return;
+  }
+  warnedDroppedModels.add(modelId);
+  logger.warn(
+    `Model "${modelId}" does not support a custom \`temperature\` (the provider rejects ` +
+      `non-default values with a 400). nexus-agents omitted it; the request runs at the ` +
+      `provider default. Any determinism/consistency you expected from temperature has NO ` +
+      `effect on this model.`,
+    { modelId, parameter: 'temperature', severity: 'behavioral' }
+  );
+}
+
+/** Test seam: clear the once-per-model warning dedupe set. */
+export function _resetTemperatureWarnings(): void {
+  warnedDroppedModels.clear();
+}
+
 interface ClaudeMajorMinor {
   readonly major: number;
   readonly minor: number;


### PR DESCRIPTION
## What

The first slice of epic **#4066**'s "never drop a param silently" invariant — directly addresses the *fail-loudly* ask.

Since #4061/#4062, the adapters correctly omit `temperature` for models that reject it (Claude after Opus 4.6, OpenAI reasoning models) — but they do it **silently**. Silently dropping a **behavioral** parameter is the canonical footgun the research flagged: a determinism/consistency setting is ignored with no signal (temp 0.0 and 0.7 produce identical output).

## Change

- `warnTemperatureDropped(modelId)` in `config/temperature-support.ts` (module logger): the **first** drop per model emits a structured `WARN` — names the model, states `temperature` was omitted and the request runs at the provider default, and that temperature has no effect on that model. Context: `{ modelId, parameter: 'temperature', severity: 'behavioral' }`.
- **Deduped once-per-model-per-process** (repeats log at `debug`) so a multi-call voter panel doesn't spam.
- Wired into all three temperature-sending adapters: native Claude, OpenAI-compatible gateway, AI-SDK.

## Scope / tracking

This is the highest-value, grounded slice (temperature is the one real param-compat case today; `max_completion_tokens` is already handled in `openai-adapter`). The remaining **#4069** pieces stay tracked: response-object `warnings` surfacing, the `MODEL_PARAMETER_UNSUPPORTED` error code, cosmetic-param severity, and the would-have-self-healed counter. The full data-driven resolver/builder (#4067/#4068) remains deferred until more params accrue (YAGNI — one param today).

## Gates

tsc + lint clean, 56 config tests (incl. loud-once / dedupe / per-model) + 870 adapter tests green, gitleaks clean.

Refs #4066, #4069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)