### PR TITLE
chore(release): retry changeset version on the transient GitHub GraphQL flake (#4072)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "git:cleanup:branches": "./scripts/git-housekeeping.sh --include-squash-merged",
     "git:cleanup:branches:dry": "./scripts/git-housekeeping.sh --include-squash-merged --dry-run",
     "changeset": "changeset",
-    "changeset:version": "changeset version && npx tsx scripts/sync-plugin-version.ts && pnpm governance:inject && npx tsx scripts/generate-repo-index.ts && npx tsx scripts/generate-docs-content.ts && pnpm --filter nexus-agents docs",
+    "changeset:version": "npx tsx scripts/changeset-version-with-retry.ts && npx tsx scripts/sync-plugin-version.ts && pnpm governance:inject && npx tsx scripts/generate-repo-index.ts && npx tsx scripts/generate-docs-content.ts && pnpm --filter nexus-agents docs",
     "changeset:publish": "changeset publish",
     "release": "pnpm build && changeset publish"
   },

--- a/scripts/changeset-version-with-retry.test.ts
+++ b/scripts/changeset-version-with-retry.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the transient-error classifier in changeset-version-with-retry (#4072).
+ * The classifier decides whether a `changeset version` failure is the retryable
+ * GitHub-GraphQL flake or a genuine error that must surface.
+ */
+
+import { afterEach, describe, it, expect } from 'vitest';
+
+import { isRetryableChangesetVersionError, intEnv } from './changeset-version-with-retry.js';
+
+describe('isRetryableChangesetVersionError (#4072)', () => {
+  it('retries the observed get-github-info GraphQL premature-close flake', () => {
+    const real = [
+      'The following error was encountered while generating changelog entries',
+      'We have escaped applying the changesets, and no files should have been affected',
+      '🦋  error Error: Failed to parse data from GitHub',
+      '🦋  error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close',
+      '    at node_modules/.pnpm/@changesets+get-github-info@0.8.0/...changesets-get-github-info.cjs.js:185:11',
+    ].join('\n');
+    expect(isRetryableChangesetVersionError(real)).toBe(true);
+  });
+
+  it.each([
+    'Invalid response body while trying to fetch https://api.github.com/graphql: Premature close',
+    'Error: connect ECONNRESET 140.82.112.5:443',
+    'request to https://api.github.com/graphql failed, reason: socket hang up',
+    'getaddrinfo EAI_AGAIN api.github.com',
+    'fetch failed: ETIMEDOUT',
+  ])('treats network/GraphQL transient %# as retryable', (msg) => {
+    expect(isRetryableChangesetVersionError(msg)).toBe(true);
+  });
+
+  it.each([
+    'Some of your changesets contain invalid frontmatter',
+    'error No unreleased changesets found, exiting.',
+    'EACCES: permission denied, open CHANGELOG.md',
+    'error A changeset references a package that does not exist',
+    '',
+  ])('does NOT retry a genuine (non-transient) failure: %s', (msg) => {
+    expect(isRetryableChangesetVersionError(msg)).toBe(false);
+  });
+});
+
+describe('intEnv — fail-safe attempt/delay parsing (#4072 review)', () => {
+  const KEY = 'CHANGESET_VERSION_TEST_KNOB';
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, KEY);
+  });
+
+  it('returns the fallback when unset or blank', () => {
+    Reflect.deleteProperty(process.env, KEY);
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+    process.env[KEY] = '   ';
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+  });
+
+  it('parses a valid integer at/above the floor', () => {
+    process.env[KEY] = '5';
+    expect(intEnv(KEY, 3, 1)).toBe(5);
+    process.env[KEY] = '0';
+    expect(intEnv(KEY, 5000, 0)).toBe(0);
+  });
+
+  it('falls back (NEVER NaN) on a non-numeric value — the desync footgun', () => {
+    // A NaN MAX_ATTEMPTS would skip the loop and exit 0 without versioning.
+    process.env[KEY] = 'abc';
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+    process.env[KEY] = '2.5';
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+  });
+
+  it('falls back when below the floor (MAX_ATTEMPTS must be >= 1)', () => {
+    process.env[KEY] = '0';
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+    process.env[KEY] = '-4';
+    expect(intEnv(KEY, 3, 1)).toBe(3);
+  });
+});

--- a/scripts/changeset-version-with-retry.ts
+++ b/scripts/changeset-version-with-retry.ts
@@ -1,0 +1,111 @@
+/**
+ * Run `changeset version` with bounded retries on the transient
+ * `@changesets/get-github-info` GraphQL flake (#4072).
+ *
+ * The Release workflow's `version: pnpm changeset:version` step intermittently
+ * fails while changesets enriches the changelog from the GitHub GraphQL API:
+ *
+ *   🦋  error Failed to parse data from GitHub
+ *   🦋  error Invalid response body while trying to fetch
+ *           https://api.github.com/graphql: Premature close
+ *
+ * This is a NETWORK flake, not a data error — changesets explicitly "escapes
+ * applying the changesets, and no files should have been affected", so re-running
+ * `changeset version` is SAFE and succeeds (observed: failed twice, passed on the
+ * 3rd run on 2026-06-26). Each occurrence otherwise stalls the autonomous release
+ * cycle until a human re-runs the job. This wrapper retries ONLY that transient
+ * class — a non-transient failure (e.g. a malformed changeset) exits immediately
+ * so real errors are never masked.
+ *
+ * Drop-in for the bare `changeset version` at the head of the `changeset:version`
+ * npm script; the rest of that chain (sync-plugin-version, governance:inject, …)
+ * is unchanged and runs after this succeeds.
+ *
+ * @module scripts/changeset-version-with-retry
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Parse an integer env override, falling back to `fallback` when unset OR invalid.
+ * The fail-safe fallback matters: a bad `CHANGESET_VERSION_MAX_ATTEMPTS` must NOT
+ * yield `NaN` (which would make the attempt loop never run, returning success
+ * WITHOUT versioning — the exact desync this script exists to prevent, #4072
+ * review). `min` guards the floor (MAX_ATTEMPTS must be ≥ 1 so the loop always
+ * runs once).
+ */
+export function intEnv(name: string, fallback: number, min: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= min ? n : fallback;
+}
+
+const MAX_ATTEMPTS = intEnv('CHANGESET_VERSION_MAX_ATTEMPTS', 3, 1);
+const RETRY_DELAY_MS = intEnv('CHANGESET_VERSION_RETRY_DELAY_MS', 5000, 0);
+
+/**
+ * Whether `changeset version`'s combined stdout+stderr indicates a TRANSIENT
+ * changelog-enrichment failure (GitHub GraphQL premature-close / connection
+ * reset) that is safe to retry. Returns false for any other failure so genuine
+ * errors (invalid changeset, write failure) are surfaced, not retried away.
+ */
+export function isRetryableChangesetVersionError(output: string): boolean {
+  return /Failed to parse data from GitHub|get-github-info|api\.github\.com\/graphql|Premature close|ECONNRESET|ETIMEDOUT|socket hang up|EAI_AGAIN/i.test(
+    output
+  );
+}
+
+/** Run `changeset version` once, forwarding its output, and report success + captured text. */
+function runChangesetVersion(): { ok: boolean; output: string } {
+  const res = spawnSync('pnpm', ['exec', 'changeset', 'version'], {
+    encoding: 'utf-8',
+    // Generous buffer: a large changelog must not ENOBUFS the captured output.
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  // spawn itself failed (e.g. binary not found) — not a retryable GraphQL flake.
+  if (res.error !== undefined) {
+    const message = res.error.message;
+    process.stderr.write(`${message}\n`);
+    return { ok: false, output: message };
+  }
+  // With a spawn success + `encoding`, stdout/stderr are strings.
+  const { stdout, stderr } = res;
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  return { ok: res.status === 0, output: `${stdout}${stderr}` };
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main(): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const { ok, output } = runChangesetVersion();
+    if (ok) {
+      if (attempt > 1) {
+        process.stdout.write(
+          `[changeset-version-retry] succeeded on attempt ${String(attempt)}.\n`
+        );
+      }
+      return;
+    }
+    const retryable = isRetryableChangesetVersionError(output);
+    if (!retryable || attempt === MAX_ATTEMPTS) {
+      console.error(
+        `[changeset-version-retry] \`changeset version\` failed on attempt ` +
+          `${String(attempt)}/${String(MAX_ATTEMPTS)} (retryable=${String(retryable)}); not retrying.`
+      );
+      process.exit(1);
+    }
+    console.error(
+      `[changeset-version-retry] transient GitHub GraphQL flake on attempt ` +
+        `${String(attempt)}/${String(MAX_ATTEMPTS)} (#4072) — retrying in ${String(RETRY_DELAY_MS)}ms...`
+    );
+    await sleep(RETRY_DELAY_MS);
+  }
+}
+
+// Only run when invoked directly (not when imported by the test).
+if (process.argv[1]?.endsWith('changeset-version-with-retry.ts') === true) {
+  void main();
+}


### PR DESCRIPTION
## Problem

The Release workflow's `version: pnpm changeset:version` step intermittently fails inside `@changesets/get-github-info` while enriching the changelog from GitHub's GraphQL API:

```
🦋  error Failed to parse data from GitHub
🦋  error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
```

It's a **transient network flake** — changesets escapes cleanly ("no files should have been affected") and a re-run succeeds. **Observed twice this week**; each occurrence stalls the autonomous release cycle until a human notices and re-runs the job.

## Fix

`scripts/changeset-version-with-retry.ts` runs `pnpm exec changeset version` and retries up to 3× (5s backoff) **only** on a transient-classified failure (GraphQL premature-close / connection reset). A genuine failure (invalid/absent changeset, write error) exits immediately so **real errors are never masked**. The `changeset:version` npm script calls the wrapper instead of bare `changeset version`; the rest of the chain is unchanged.

## Safety (adversarial review, source-verified)

- **Idempotent retry confirmed** against the pinned `@changesets/apply-release-plan@7.1.1`: `getNewChangelogEntry` (the get-github-info GraphQL call) runs **before** any `fs.writeFile` of package.json/CHANGELOG, so a flake throws with zero files written — retrying cannot double-bump.
- **Behavior-preserving**: the changesets-action reads filesystem/git state, not the version step's stdout, so the wrapper's output prefix is harmless.
- **Fail-closed**: a transient that doesn't match → no retry (same as today); a real error → exit 1 → the action sees the failure.
- Review found + I fixed a latent **desync footgun**: a non-numeric `CHANGESET_VERSION_MAX_ATTEMPTS` would yield `NaN` → skip the loop → exit 0 **without versioning**. `intEnv()` now falls back safely (never NaN, floor-guarded) and is unit-tested.

## Gates

Classifier + `intEnv` unit tests (15) green; lint clean. No changeset (CI tooling, not `packages/nexus-agents/src/**`).

Closes #4072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)