### PR TITLE
test(adapters): drift guard for temperature-drop across all 3 adapters (#4070)

### DIFF
--- a/packages/nexus-agents/src/adapters/openai-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.test.ts
@@ -292,6 +292,27 @@ describe('OpenAIAdapter', () => {
       );
     });
 
+    it('should DROP temperature for an OpenAI reasoning model (#4062 drift guard)', async () => {
+      // o-series / GPT-5 reasoning models reject a custom temperature with a 400;
+      // the adapter must omit it. Guards against a future refactor un-wiring the
+      // temperatureUnsupportedForModel check on this path.
+      mockCreate.mockResolvedValueOnce({
+        choices: [{ message: { content: 'Response', role: 'assistant' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        model: 'o3-mini',
+      });
+
+      const adapter = new OpenAIAdapter({ ...validConfig, modelId: 'o3-mini' });
+      await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        temperature: 0.3,
+        maxTokens: 1024,
+      });
+
+      const callArg = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg).not.toHaveProperty('temperature');
+    });
+
     it('should include stop sequences when provided', async () => {
       mockCreate.mockResolvedValueOnce({
         choices: [

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -115,6 +115,43 @@ describe('SdkAdapter', () => {
       }
     });
 
+    it('DROPS temperature for a reasoning model routed via the AI-SDK (#4062 drift guard)', async () => {
+      // auto-adapter wires the openai/codex provider through SdkAdapter to models
+      // like o3-mini / gpt-5.4 that reject a custom temperature. Guard against a
+      // future refactor un-wiring the temperatureUnsupportedForModel check here.
+      const { generateText } = await import('ai');
+      const mockGenerate = vi.mocked(generateText);
+      mockGenerate.mockResolvedValueOnce({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 2 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'o3-mini' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({ providerId: 'openai', modelId: 'o3-mini', apiKey: 'k' });
+      await adapter.complete(TEST_REQUEST); // TEST_REQUEST carries temperature: 0.7
+
+      const options = mockGenerate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(options).not.toHaveProperty('temperature');
+    });
+
+    it('passes temperature through for a supported model routed via the AI-SDK', async () => {
+      const { generateText } = await import('ai');
+      const mockGenerate = vi.mocked(generateText);
+      mockGenerate.mockResolvedValueOnce({
+        text: 'ok',
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 2 },
+        response: { id: 'r', timestamp: new Date(), modelId: 'gpt-4o' },
+      } as unknown as Awaited<ReturnType<typeof generateText>>);
+
+      const adapter = new SdkAdapter({ providerId: 'openai', modelId: 'gpt-4o', apiKey: 'k' });
+      await adapter.complete(TEST_REQUEST);
+
+      const options = mockGenerate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(options['temperature']).toBe(0.7);
+    });
+
     it('returns error result on API failure', async () => {
       const { generateText } = await import('ai');
       const mockGenerate = vi.mocked(generateText);


### PR DESCRIPTION
## What

A regression guard (epic #4066, layer 5 slice). The temperature-omission fix (#4061/#4062) spans **three** adapters that send `temperature` — native Claude, OpenAI-compatible gateway, and the AI-SDK adapter (which was *nearly missed* during the fix). This locks in the drop behavior so a future refactor that un-wires the `temperatureUnsupportedForModel` check on any path **fails CI** instead of silently re-introducing the 400.

- `openai-adapter`: new test — drops temperature for `o3-mini` (reasoning).
- `sdk-adapter`: new tests — drops temperature for `o3-mini`, **preserves** it for `gpt-4o` (guards against over-suppression too).
- `claude-adapter`: already had the after-Opus-4.6 drop test (#4061).

## Gates

Test-only — **no changeset / no release**. 873 adapter tests green, tsc + lint clean.

Refs #4066, #4070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)