### PR TITLE
fix(routing): auto-route named consensus/wave goals instead of single-shot (#3989)

### DIFF
--- a/.changeset/route-consensus-wave-from-text.md
+++ b/.changeset/route-consensus-wave-from-text.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+Fix auto-route under-routing of consensus/wave goals (#3989). Plain goal strings
+like "we need consensus on adopting GraphQL" or "run a multi-agent wave over these
+modules" used to fall through to the generic fallback (single-shot / graph),
+because the workflow router's consensus/wave rules key on the `requiresConsensus` /
+`dependencyStructure` structural signals that a goal string never sets.
+
+The router now gap-fills those signals from the goal text (`deriveStructuralSignals`)
+before rule matching, but ONLY for phrases that NAME the orchestration process —
+"consensus vote/decision/review/panel" or "multi-perspective review" →
+`requiresConsensus`; "multi-agent wave", "wave of agents", "fan out to
+agents/subtasks", "independent subtasks" → `dependencyStructure: 'independent'`.
+
+Because a false positive sends a cheap task to an expensive N-voter panel, the
+detection is deliberately HIGH-PRECISION: it excludes verb+"consensus" ("reach
+consensus on the leader election" — distributed-systems code), bare "vote on"
+(voting features), "should we use/adopt" (trivial local decisions), and bare
+"in parallel"/"fan out"/"parallelize" (impl/perf). A goal that only IMPLIES a group
+decision ("should we adopt GraphQL?") intentionally does NOT auto-route — the
+caller uses the `requiresConsensus` hint / `forceStrategy`; false negatives are safe
+(today's behavior), a false positive is not. Caller-provided signals stay
+authoritative (a field already set — including `false` — is never overridden). A
+labeled goal→expected-pattern routing-accuracy eval covers the positive routes AND
+the realistic false-positive guards. Greenfield stays force-only by design.

--- a/packages/nexus-agents/src/orchestration/workflow-router-signal-derivation.test.ts
+++ b/packages/nexus-agents/src/orchestration/workflow-router-signal-derivation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Routing-accuracy eval for goal-text → structural-signal derivation (#3989).
+ *
+ * A labeled goal→expected-pattern set proving that consensus/wave goals reach the
+ * richer strategy via AUTO selection (no caller hints / forceStrategy), plus the
+ * false-positive guards that keep coding tasks mentioning the words from tripping it.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { createWorkflowRouter } from './workflow-router.js';
+import { deriveStructuralSignals } from './workflow-router-signal-derivation.js';
+import type { TaskSignals } from './workflow-router-types.js';
+
+function patternFor(description: string): string {
+  return createWorkflowRouter().route({ description }).pattern;
+}
+
+describe('deriveStructuralSignals (#3989) — pure derivation', () => {
+  it('fills requiresConsensus from a named consensus process', () => {
+    const out = deriveStructuralSignals({ description: 'hold a consensus vote on the DB choice' });
+    expect(out.requiresConsensus).toBe(true);
+  });
+
+  it('fills dependencyStructure=independent from a named wave/decomposition', () => {
+    const out = deriveStructuralSignals({ description: 'run a multi-agent wave over these files' });
+    expect(out.dependencyStructure).toBe('independent');
+  });
+
+  it('NEVER overrides a caller-provided signal (authoritative escape hatch)', () => {
+    const explicitFalse: TaskSignals = {
+      description: 'hold a consensus vote on adopting GraphQL',
+      requiresConsensus: false,
+    };
+    expect(deriveStructuralSignals(explicitFalse).requiresConsensus).toBe(false);
+
+    const explicitDep: TaskSignals = {
+      description: 'split into independent subtasks',
+      dependencyStructure: 'linear',
+    };
+    expect(deriveStructuralSignals(explicitDep).dependencyStructure).toBe('linear');
+  });
+});
+
+describe('routing-accuracy eval (#3989) — named consensus process → consensus', () => {
+  it.each([
+    'hold a consensus vote on the database choice',
+    'we need a consensus decision on the API redesign',
+    'do a multi-perspective review of the auth rewrite',
+  ])('routes "%s" to consensus', (goal) => {
+    expect(patternFor(goal)).toBe('consensus');
+  });
+});
+
+describe('routing-accuracy eval (#3989) — named wave/decomposition → wave', () => {
+  it.each([
+    'run a multi-agent wave over these modules',
+    'decompose into independent subtasks',
+    'dispatch a wave of agents to audit each service',
+  ])('routes "%s" to wave', (goal) => {
+    expect(patternFor(goal)).toBe('wave');
+  });
+});
+
+describe('routing-accuracy eval (#3989) — false-positive guards (must NOT over-route)', () => {
+  // The #3989 review's realistic over-trigger cases — these are ordinary dev goals
+  // that merely mention the words and MUST NOT be sent to an expensive panel/wave.
+  it.each([
+    'fix the consensus engine bug in engine.ts',
+    'implement the consensus voting algorithm',
+    'reach consensus on the leader election in raft.ts',
+    'let users vote on posts',
+    'add an upvote/downvote button on comments',
+    'should we use a Map or an array here',
+    'should we adopt GraphQL or REST?',
+    'document the API from multiple perspectives',
+    // #3989 review residuals — code nouns with no decision-subject preposition:
+    'add a consensus vote endpoint',
+    'persist the consensus decision to the raft log',
+  ])('does NOT route "%s" to consensus', (goal) => {
+    expect(patternFor(goal)).not.toBe('consensus');
+  });
+
+  it.each([
+    'implement parallel array processing',
+    'load these rows in parallel for latency',
+    'fan out the API calls to all shards',
+    'parallelize the hot loop in image.ts',
+    // #3989 review residuals — self-referential maintenance goals in this repo:
+    'fix the wave scheduler retry bug',
+    'optimize wave execution latency',
+    'fan out to workers for the image resize',
+  ])('does NOT route "%s" to wave', (goal) => {
+    expect(patternFor(goal)).not.toBe('wave');
+  });
+});

--- a/packages/nexus-agents/src/orchestration/workflow-router-signal-derivation.ts
+++ b/packages/nexus-agents/src/orchestration/workflow-router-signal-derivation.ts
@@ -1,0 +1,81 @@
+/**
+ * nexus-agents/orchestration — derive missing structural routing signals from
+ * goal text (#3989).
+ *
+ * The workflow router's consensus/wave rules key on `requiresConsensus` and
+ * `dependencyStructure` — structural signals a plain goal STRING never sets. So
+ * goals like "we need consensus on adopting GraphQL" or "run a multi-agent wave
+ * over these modules" used to fall through to the generic fallback (single-shot /
+ * graph) instead of the richer strategy. This gap-fills those signals from the
+ * text so AUTO selection routes them correctly.
+ *
+ * Two guardrails keep this safe — and here the cost-asymmetry is the OPPOSITE of a
+ * dropped param: a false positive sends a cheap task to an expensive N-voter panel
+ * or a parallel wave, so this biases HARD toward precision (accepting false
+ * negatives, which simply degrade to today's behavior):
+ *  1. Caller-provided signals are AUTHORITATIVE — a field already set (including
+ *     explicitly `false`) is never overridden; this only fills `undefined`.
+ *  2. The patterns fire ONLY on explicit multi-agent-ORCHESTRATION language
+ *     ("need/reach consensus", "consensus vote", "multi-agent wave", "independent
+ *     subtasks") — NOT on verb phrases that pervade ordinary dev goals. Deliberately
+ *     EXCLUDED because they over-trigger (#3989 review): bare "vote on" (matches
+ *     voting features — "let users vote on posts"), "in parallel"/"fan out"/
+ *     "parallelize" (impl/perf tasks — "load these in parallel"), "should we
+ *     use/adopt" (trivial local decisions — "should we use a Map"), and bare
+ *     "multiple perspectives" (docs — "document from multiple perspectives").
+ *
+ * Consequence (documented boundary): we only auto-derive when the goal NAMES the
+ * orchestration process ("consensus vote", "multi-agent wave"). A goal that merely
+ * IMPLIES a group decision — "we need consensus on adopting GraphQL", "should we
+ * adopt GraphQL?" — does NOT auto-route, because the same verb+"consensus" shape
+ * also describes distributed-systems CODE ("reach consensus on the leader
+ * election"); free-text cannot tell them apart, so the caller uses the
+ * `requiresConsensus` hint / `forceStrategy` for those. False negatives here are
+ * safe (degrade to today); a false positive is an expensive mis-route.
+ *
+ * Greenfield is intentionally NOT auto-derived: the strategy manifest gates the
+ * greenfield template on a written spec ("not a plain goal string"), force-only.
+ *
+ * @module orchestration/workflow-router-signal-derivation
+ */
+
+import type { TaskSignals } from './workflow-router-types.js';
+
+/**
+ * Phrases that REQUEST a consensus PROCESS over a subject — "consensus
+ * vote/decision/review ON|ABOUT|REGARDING|FOR <x>", "consensus panel", or
+ * "multi-perspective review/decision/analysis". The required decision-subject
+ * preposition is what separates the request ("consensus vote ON the DB choice")
+ * from a code noun ("consensus vote endpoint", "consensus decision to the raft
+ * log") — the latter has no on/about/for and so does NOT match. Also excludes
+ * verb+"consensus" ("reach consensus on the leader") and bare "vote on".
+ */
+const CONSENSUS_INTENT =
+  /\bconsensus\s+(?:vote|decision|review)\s+(?:on|about|regarding|for)\b|\bconsensus\s+panel\b|\bmulti[-\s]?perspective\s+(?:review|decision|analysis)\b/i;
+
+/**
+ * Phrases that NAME a multi-agent WAVE / explicit task-decomposition: "multi-agent
+ * wave", "wave of agents", "fan out to agents/subtasks", "independent subtasks".
+ * Excludes bare "in parallel" / "fan out" / "parallelize" (impl/perf), and the
+ * CODE-COMPONENT names "wave scheduler" / "wave execution" / "fan out to workers"
+ * (self-referential maintenance goals in this very repo — #3989 review).
+ */
+const WAVE_INTENT =
+  /\bmulti[-\s]?agent\s+wave\b|\bwave\s+of\s+agents\b|\bfan[-\s]?out\s+(?:to\s+)?(?:agents|sub-?tasks)\b|\bindependent\s+sub-?tasks?\b/i;
+
+/**
+ * Return `signals` with `requiresConsensus` / `dependencyStructure` filled from the
+ * goal text when the caller left them unset. Pure; preserves every caller-provided
+ * field unchanged.
+ */
+export function deriveStructuralSignals(signals: TaskSignals): TaskSignals {
+  const text = signals.description;
+  let next = signals;
+  if (next.requiresConsensus === undefined && CONSENSUS_INTENT.test(text)) {
+    next = { ...next, requiresConsensus: true };
+  }
+  if (next.dependencyStructure === undefined && WAVE_INTENT.test(text)) {
+    next = { ...next, dependencyStructure: 'independent' };
+  }
+  return next;
+}

--- a/packages/nexus-agents/src/orchestration/workflow-router.ts
+++ b/packages/nexus-agents/src/orchestration/workflow-router.ts
@@ -19,6 +19,7 @@ import type {
   TaskAnalysisResult,
 } from '../core/task-analysis/shared-task-analyzer.js';
 import { detectCapabilityGaps } from '../core/task-analysis/capability-gap-detector.js';
+import { deriveStructuralSignals } from './workflow-router-signal-derivation.js';
 import type {
   TaskSignals,
   WorkflowPattern,
@@ -143,7 +144,9 @@ function routeTask(
   _opts?: WorkflowRouterOptions
 ): RoutingDecision {
   const analysis = analyzer.analyze(signals.description);
-  const enriched = enrichSignals(signals, analysis);
+  // #3989: gap-fill consensus/wave structural signals from the goal text so plain
+  // goal strings reach the richer strategy instead of the generic fallback.
+  const enriched = enrichSignals(deriveStructuralSignals(signals), analysis);
   const matchedRules: string[] = [];
   const alternatives: WorkflowPattern[] = [];
 


### PR DESCRIPTION
## What

The workflow router's consensus/wave rules key on the `requiresConsensus` / `dependencyStructure` structural signals — which a plain goal STRING never sets. So "hold a consensus vote on the DB choice" or "run a multi-agent wave over these modules" fell through to the generic fallback (single-shot / graph) instead of the richer strategy. `deriveStructuralSignals` now gap-fills those signals from goal text before rule matching.

## Precision (the load-bearing concern)

A false positive here sends a **cheap task to an expensive N-voter panel / wave**, so detection is deliberately HIGH-PRECISION — it fires only on phrases that **name the orchestration process**:
- consensus: `consensus vote/decision/review ON|ABOUT|FOR <x>`, `consensus panel`, `multi-perspective review`
- wave: `multi-agent wave`, `wave of agents`, `fan out to agents/subtasks`, `independent subtasks`

It **excludes** (all tested as guards): verb+"consensus" ("reach consensus on the leader election" — distributed code), bare "vote on" (voting features), "in parallel"/"fan out"/"parallelize" (impl/perf), "should we use/adopt" (trivial decisions), and the repo's own code-component names ("wave scheduler", "consensus vote endpoint", "consensus decision to the raft log"). The decision-subject preposition (`on/about/for`) is what separates "consensus vote **on** the DB choice" (a request) from "consensus vote endpoint" (a code noun).

Caller-provided signals stay authoritative (a field already set — including `false` — is never overridden). **Greenfield stays force-only by design** (the manifest gates it on a written spec, not a goal string), so it's intentionally not auto-derived.

## Process

- **Two-round adversarial review:** round 1 found BLOCKER-grade false positives (bare "vote on", "in parallel", "should we use") → narrowed to process-naming phrases; round 2 cleared the blocker (NON-BLOCKING) and surfaced repo-specific residuals ("wave scheduler", "consensus decision to raft log") → tightened with the preposition requirement + dropped code-component names. Every surfaced false positive is now a guard test.
- 26-case routing-accuracy eval (the labeled goal→pattern set #3989 asked for) + 1151 orchestration tests green; tsc + lint clean.

Closes #3989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)