### PR TITLE
test(authority): pin the execute dispatch-floor inert-strategy invariant (#3925)

### DIFF
--- a/packages/nexus-agents/src/orchestration/authority-tier-guard.test.ts
+++ b/packages/nexus-agents/src/orchestration/authority-tier-guard.test.ts
@@ -21,7 +21,7 @@ import {
   AuthorityRefusalError,
   type ActionClass,
 } from './authority-tier-guard.js';
-import { getStrategyManifest } from './strategy-manifest-registry.js';
+import { getStrategyManifest, STRATEGY_MANIFEST_REGISTRY } from './strategy-manifest-registry.js';
 import type { AuthorityTier } from './strategy-manifest.js';
 
 describe('authority-tier guard — tier→action mapping (#3841)', () => {
@@ -148,5 +148,46 @@ describe('dispatchActionClass — dispatch-mode → action-class map (#3920)', (
       // An observe-tier strategy is BELOW the floor — refused.
       expect(permitsAction('observe', dispatchActionClass(mode))).toBe(false);
     }
+  });
+});
+
+describe('execute-path dispatch floor invariant (#3925)', () => {
+  // The `suggest` dispatch floor (`dispatchActionClass`) is safe ONLY while every
+  // strategy reachable on the execute path is inert/advisory — its output is a
+  // recommendation / non-blocking vote that does NOT merge, deploy, or gate until a
+  // human or governor acts. These are the tiers safe under that floor; `enforce` is
+  // deliberately EXCLUDED: it is the only side-effecting tier, and the `suggest`
+  // floor would under-classify (and thus under-require authority for) an enforce
+  // strategy. This converts the previously asserted-but-untested assumption (#3924
+  // deferral, #3925) into a machine-checked, fail-closed gate.
+  const INERT_UNDER_SUGGEST_FLOOR: ReadonlySet<AuthorityTier> = new Set([
+    'observe',
+    'suggest',
+    'advisory',
+  ]);
+
+  it('pins the dispatch floor the invariant rests on (suggest)', () => {
+    expect(dispatchActionClass('route')).toBe('suggest');
+    expect(dispatchActionClass('execute')).toBe('suggest');
+  });
+
+  it('every live registry strategy is inert under the suggest floor — no silent enforce', () => {
+    for (const manifest of STRATEGY_MANIFEST_REGISTRY.manifests) {
+      // Fail-closed: an undeclared tier acts as the lowest rung (`observe`),
+      // mirroring permitsAction.
+      const tier: AuthorityTier = manifest.authorityTier ?? 'observe';
+      expect(
+        INERT_UNDER_SUGGEST_FLOOR.has(tier),
+        `Strategy "${manifest.strategy}" declares authorityTier "${tier}", which is NOT ` +
+          `inert under the 'suggest' execute dispatch floor. A side-effecting (enforce) ` +
+          `strategy must NOT rely on the suggest floor to gate it — raise ` +
+          `dispatchActionClass for its dispatch mode (and update this invariant) before ` +
+          `adding it (#3925).`
+      ).toBe(true);
+    }
+  });
+
+  it('covers a non-empty registry (the invariant is not vacuously true)', () => {
+    expect(STRATEGY_MANIFEST_REGISTRY.manifests.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

`dispatchActionClass` floors both `route` and `execute` dispatch at `suggest`. Its safety rests on an **asserted-but-untested** claim (explicitly deferred at the #3924 vote): every live execute-path strategy is inert/advisory (it does not merge/deploy/gate), so the `suggest` floor never under-requires authority. The existing guard test only drives **synthetic** above-tier actions through a fixture — nothing proved a real `STRATEGY_MANIFEST_REGISTRY` strategy is inert. If a side-effecting strategy were added at `enforce`, the floor would silently under-require authority and the guard would pass it.

## Fix (test-only, fail-closed gate)

A registry-driven invariant that:
1. enumerates every live strategy in `STRATEGY_MANIFEST_REGISTRY`,
2. asserts each `authorityTier` is **inert under the suggest floor** (`observe`/`suggest`/`advisory`), excluding the only side-effecting tier, `enforce`,
3. fails closed with an actionable message ("raise `dispatchActionClass` for its mode") if an `enforce` strategy is ever added,
4. plus a non-empty-registry guard so the invariant can't pass vacuously.

This converts the implicit "all execute strategies are inert" assumption into machine-checked policy, so it can't silently rot — and lets the dispatch floor be tightened later with confidence.

Passes today (no `enforce` strategy exists). **Test-only — no changeset / no release.** 1154 orchestration tests green; tsc + lint clean.

Closes #3925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)