### PR TITLE
fix(pipeline): make the missing-plugin stage placeholder loud, not a silent success (#3178)

### DIFF
--- a/.changeset/loud-missing-plugin-placeholder.md
+++ b/.changeset/loud-missing-plugin-placeholder.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+Stop silently succeeding a pipeline stage whose plugin is missing (#3178). When a
+`StageSpec` references a plugin that isn't in the registry, the compiler falls back
+to a no-op placeholder (resilience, #1179) — but it used to report `status:
+'completed'` indistinguishably from a real execution, so a typo'd or unregistered
+`pluginId` ran as a no-op and reported success with no signal (a silent failure).
+
+The placeholder fallback is now LOUD: the compiler logs a warning naming the stage
+and the unregistered `pluginId` at compile time, and the stage result carries a
+`placeholder: true` marker so an inspector can tell a skipped no-op from a real
+execution. Compilation still succeeds (the #1179 resilience contract is preserved).
+The deeper composability refactor in #3178 (a typed `StageContext` / `NodeHandler`
+factory / stage→node mapping) remains tracked separately.

--- a/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.test.ts
@@ -180,6 +180,29 @@ describe('compilePlan', () => {
     const result = compilePlan(plan, { pluginRegistry: registry });
     expect(result.ok).toBe(true);
   });
+
+  it('marks a missing-plugin stage as a placeholder so its no-op is not a silent success (#3178)', async () => {
+    // A stage referencing an unregistered plugin still compiles (#1179) but runs as
+    // a NO-OP. It used to report status 'completed' indistinguishably from a real
+    // execution — a silent failure. The result now carries `placeholder: true` so an
+    // inspector can tell the difference (and the compiler logs a warning).
+    const registry = createCorePluginRegistry();
+    const plan = makePlan({
+      stages: [makeStage({ id: 'custom', pluginId: 'unknown:plugin' })],
+    });
+    const compiled = compilePlan(plan, { pluginRegistry: registry });
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const stageResults = result.value.finalState['stageResults'] as
+      | ReadonlyArray<Record<string, unknown>>
+      | undefined;
+    const placeholderResult = stageResults?.find((s) => s['stageId'] === 'custom');
+    expect(placeholderResult).toBeDefined();
+    expect(placeholderResult?.['placeholder']).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/pipeline/plan-compiler.ts
+++ b/packages/nexus-agents/src/pipeline/plan-compiler.ts
@@ -17,6 +17,9 @@ import type { IPluginRegistry } from './plugin-types.js';
 import { enforceGatePolicy } from './policy-evaluator.js';
 import type { GatePolicyEnforcement } from './policy-evaluator.js';
 import { NETWORK_FETCH_TIMEOUT_MS } from '../config/timeouts.js';
+import { createLogger } from '../core/index.js';
+
+const logger = createLogger({ component: 'plan-compiler' });
 
 /** Result of plan compilation. */
 type CompileResult =
@@ -120,11 +123,22 @@ function createStageHandler(
       };
     };
   }
-  // Placeholder when no plugin registered for this stage's pluginId
+  // No plugin registered for this stage's pluginId. The stage still compiles
+  // (resilience, #1179) but runs as a NO-OP placeholder. Surface the
+  // misconfiguration LOUDLY at compile time (#3178: this path used to be silent —
+  // a typo'd or unregistered pluginId would run as a no-op and report success with
+  // no signal). The placeholder result is marked so an inspector can tell a real
+  // execution from a skipped one without re-parsing the node id.
+  logger.warn(
+    `Pipeline stage "${stage.id}" references unregistered plugin "${stage.pluginId}" — ` +
+      `it will run as a NO-OP placeholder (no work performed). Register the plugin or ` +
+      `remove the stage; a missing plugin is almost always a misconfiguration.`,
+    { stageId: stage.id, pluginId: stage.pluginId }
+  );
   return (_state: Readonly<GraphState>) =>
     Promise.resolve({
       currentStage: stage.id,
-      stageResults: [{ stageId: stage.id, status: 'completed' }],
+      stageResults: [{ stageId: stage.id, status: 'completed', placeholder: true }],
     });
 }
 


### PR DESCRIPTION
## What

Resolves the **silent-error-handling** half of #3178 (a 2026-05-31 system-review finding).

When a `StageSpec` references a plugin that isn't in the registry, `plan-compiler` falls back to a no-op placeholder (intentional resilience, #1179) — but the placeholder used to report `status: 'completed'` **indistinguishably from a real execution**. So a typo'd or unregistered `pluginId` ran as a no-op and the pipeline reported success with **no signal** — a silent failure (prime-directive violation: "no silent failures").

## Fix

- **Loud at compile time:** the compiler now logs a `warn` naming the stage and the unregistered `pluginId` ("…will run as a NO-OP placeholder…a missing plugin is almost always a misconfiguration").
- **Honest result:** the placeholder stage result carries a `placeholder: true` marker so an inspector can distinguish a skipped no-op from a real execution.
- **Non-breaking:** the marker is additive and the status string / node control-flow are unchanged, so the #1179 compile-resilience contract (compilation still succeeds on an unknown plugin) holds — verified by the existing #1179 test.
- A behavioral test asserts the marker is observable in the executed graph's `finalState`.

## Scope

This is the correctness/observability half of #3178. The deeper **composability refactor** (typed `StageContext` with `stageId`/`pluginId`/`pipelineId`, a typed `NodeHandler` factory, stage→node mapping) remains tracked in #3178.

## Gates

641 pipeline tests green; tsc + lint clean. Patch changeset (src bugfix).

Refs #3178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)