### PR TITLE
chore(release): widen the changeset-version retry to a multi-minute window (#4072)

### DIFF
--- a/scripts/changeset-version-with-retry.test.ts
+++ b/scripts/changeset-version-with-retry.test.ts
@@ -6,7 +6,11 @@
 
 import { afterEach, describe, it, expect } from 'vitest';
 
-import { isRetryableChangesetVersionError, intEnv } from './changeset-version-with-retry.js';
+import {
+  isRetryableChangesetVersionError,
+  intEnv,
+  backoffDelayMs,
+} from './changeset-version-with-retry.js';
 
 describe('isRetryableChangesetVersionError (#4072)', () => {
   it('retries the observed get-github-info GraphQL premature-close flake', () => {
@@ -74,5 +78,24 @@ describe('intEnv — fail-safe attempt/delay parsing (#4072 review)', () => {
     expect(intEnv(KEY, 3, 1)).toBe(3);
     process.env[KEY] = '-4';
     expect(intEnv(KEY, 3, 1)).toBe(3);
+  });
+});
+
+describe('backoffDelayMs — exponential, capped (#4072 hardening)', () => {
+  it('doubles per attempt from the base', () => {
+    expect(backoffDelayMs(1, 10_000, 60_000)).toBe(10_000);
+    expect(backoffDelayMs(2, 10_000, 60_000)).toBe(20_000);
+    expect(backoffDelayMs(3, 10_000, 60_000)).toBe(40_000);
+  });
+
+  it('caps the delay so the total wait stays bounded', () => {
+    expect(backoffDelayMs(4, 10_000, 60_000)).toBe(60_000); // 80_000 capped to 60_000
+    expect(backoffDelayMs(6, 10_000, 60_000)).toBe(60_000);
+  });
+
+  it('spans a multi-minute window across the default 6 attempts', () => {
+    // The flat 15s window exhausted on 2026-06-28; sum the first 5 waits.
+    const total = [1, 2, 3, 4, 5].reduce((s, a) => s + backoffDelayMs(a, 10_000, 60_000), 0);
+    expect(total).toBe(190_000); // 10+20+40+60+60 s ≈ 3.2 min
   });
 });

--- a/scripts/changeset-version-with-retry.ts
+++ b/scripts/changeset-version-with-retry.ts
@@ -41,8 +41,23 @@ export function intEnv(name: string, fallback: number, min: number): number {
   return Number.isInteger(n) && n >= min ? n : fallback;
 }
 
-const MAX_ATTEMPTS = intEnv('CHANGESET_VERSION_MAX_ATTEMPTS', 3, 1);
-const RETRY_DELAY_MS = intEnv('CHANGESET_VERSION_RETRY_DELAY_MS', 5000, 0);
+// Defaults span a MULTI-MINUTE outage window. The GitHub GraphQL flake can last
+// minutes (observed 2026-06-28: a flat 3×5s = 15s window exhausted while the API
+// was down ~longer), so the retry uses EXPONENTIAL backoff: with base 10s and cap
+// 60s, 6 attempts wait 10+20+40+60+60s ≈ 190s before giving up (#4072 hardening).
+const MAX_ATTEMPTS = intEnv('CHANGESET_VERSION_MAX_ATTEMPTS', 6, 1);
+const RETRY_DELAY_MS = intEnv('CHANGESET_VERSION_RETRY_DELAY_MS', 10_000, 0);
+const RETRY_MAX_DELAY_MS = intEnv('CHANGESET_VERSION_MAX_DELAY_MS', 60_000, 0);
+
+/**
+ * Exponential backoff (capped) for the delay BEFORE retry `attempt` (1-based):
+ * `min(base * 2^(attempt-1), cap)`. Spans a longer outage than a flat delay while
+ * bounding the total wait. `attempt` 1 → `base`, 2 → `2*base`, … capped at `cap`.
+ */
+export function backoffDelayMs(attempt: number, baseMs: number, capMs: number): number {
+  const exponential = baseMs * 2 ** Math.max(0, attempt - 1);
+  return Math.min(exponential, capMs);
+}
 
 /**
  * Whether `changeset version`'s combined stdout+stderr indicates a TRANSIENT
@@ -97,11 +112,12 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
+    const delayMs = backoffDelayMs(attempt, RETRY_DELAY_MS, RETRY_MAX_DELAY_MS);
     console.error(
       `[changeset-version-retry] transient GitHub GraphQL flake on attempt ` +
-        `${String(attempt)}/${String(MAX_ATTEMPTS)} (#4072) — retrying in ${String(RETRY_DELAY_MS)}ms...`
+        `${String(attempt)}/${String(MAX_ATTEMPTS)} (#4072) — retrying in ${String(delayMs)}ms...`
     );
-    await sleep(RETRY_DELAY_MS);
+    await sleep(delayMs);
   }
 }
 


### PR DESCRIPTION
## Why

The #4072 retry wrapper **worked correctly** but its window was too short. On 2026-06-28 (PR #4081's release) the GitHub GraphQL flake outlasted the flat 3×5s = 15s of retries — all 3 attempts failed within 17s while the API was down longer — and the release failed, needing a manual re-run. The flake can last minutes (this session needed re-runs minutes apart).

## Fix

Exponential, capped backoff instead of flat. New defaults: **6 attempts, 10s base, 60s cap** → waits of 10+20+40+60+60s ≈ **190s (~3.2 min)** before giving up, spanning a realistic outage.

- `backoffDelayMs(attempt, base, cap)` = `min(base · 2^(attempt-1), cap)` — a pure, unit-tested function.
- Env overrides (`CHANGESET_VERSION_MAX_ATTEMPTS` / `_RETRY_DELAY_MS` / `_MAX_DELAY_MS`) + the fail-safe `intEnv` parsing are unchanged.
- Still retries **only** the transient-classified GraphQL/network flake; a genuine error (invalid changeset, write failure) exits immediately — never masked.

## Gates

18 unit tests (classifier + intEnv + backoff) green; lint clean. **No changeset** (CI tooling, not `packages/nexus-agents/src/**`).

Refs #4072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)