### PR TITLE
feat(voting): per-role voter model overrides (NEXUS_VOTER_MODEL_<ROLE>) (#4055)

### DIFF
--- a/.changeset/voter-model-overrides.md
+++ b/.changeset/voter-model-overrides.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': minor
+---
+
+Add per-role voter model overrides (#4055). Voters round-robin across the gateway's
+discovered models (#4040), so a role can land on a model that fails on a particular
+gateway (e.g. a bodyless HTTP 400 for specific model ids, #4049) with no way to pin
+a known-good model. Operators can now route a role to a gateway-accepted model:
+
+```
+NEXUS_VOTER_MODEL_<ROLE>=<bare gateway model id>
+# e.g. NEXUS_VOTER_MODEL_ARCHITECT=claude_4_5_opus
+```
+
+In the gateway round-robin (`resolveDiverseAdapters`), a role with a valid override
+is pinned to that model and the remaining roles round-robin as before. The override
+is validated against the discovered gateway catalog: an id that is not a live
+gateway model warns and falls back to round-robin for that role (no hard failure).
+Roles without an override are unchanged. This is the operator escape hatch for the
+per-model gateway-rejection situation, independent of the underlying gateway fix
+(#4049).

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -17,6 +17,7 @@
  */
 
 import type { VoterRole, AgentVoteResult } from './vote-types.js';
+import { resolveVoterModelOverrides } from './voter-model-overrides.js';
 import { VOTER_ROLES } from './vote-types.js';
 import type { Vote } from '../consensus/types.js';
 import type { VoteUsage } from './voter-execution.js';
@@ -339,34 +340,64 @@ function assignRoundRobinAdapters(
   return adapters;
 }
 
+/**
+ * Gateway path (#4040): assign roles across the in-process per-model gateway
+ * adapters. A single model collapses to a uniform panel (warned). With multiple
+ * models, per-role operator overrides (#4055) pin chosen roles to a known-good
+ * model and the rest round-robin.
+ */
+export function resolveGatewayRoleAdapters(
+  roles: readonly VoterRole[],
+  gatewayAdapters: readonly IModelAdapter[],
+  fallbackAdapter: IModelAdapter,
+  logger: ILogger
+): Map<VoterRole, IModelAdapter> {
+  if (gatewayAdapters.length === 1) {
+    // Consensus integrity: a multi-role panel on ONE model yields correlated votes
+    // (the higher_order strategy can't down-weight what it can't tell apart). Warn
+    // so operators configure the gateway with more models for a diverse panel.
+    if (roles.length > 1) {
+      logger.warn('Consensus panel collapsed to a single gateway model — votes may correlate', {
+        model: gatewayAdapters[0]?.modelId,
+        roleCount: roles.length,
+      });
+    }
+    return assignUniformAdapter(roles, gatewayAdapters[0] ?? fallbackAdapter);
+  }
+  // #4055: per-role overrides (NEXUS_VOTER_MODEL_<ROLE>) pin a role to a known-good
+  // gateway model; the rest round-robin. An unknown override id warns + falls
+  // through to round-robin (handled in the resolver).
+  const overrides = resolveVoterModelOverrides(roles, gatewayAdapters, logger);
+  const roundRobinRoles = roles.filter((r) => !overrides.has(r));
+  const assigned = assignRoundRobinAdapters(
+    roundRobinRoles,
+    gatewayAdapters.map((a) => ({ label: a.modelId, adapter: a })),
+    logger,
+    'gateway'
+  );
+  for (const [role, adapter] of overrides) assigned.set(role, adapter);
+  // Consensus-integrity parity with the single-model path (#4055 review): warn if
+  // the FINAL assignment collapsed every role onto one model — e.g. an operator
+  // pinned all roles to the same override — since correlated votes defeat the panel.
+  const distinctModels = new Set([...assigned.values()].map((a) => a.modelId));
+  if (roles.length > 1 && distinctModels.size === 1) {
+    logger.warn(
+      'Consensus panel collapsed to a single gateway model via overrides — votes may correlate',
+      { model: [...distinctModels][0], roleCount: roles.length }
+    );
+  }
+  return assigned;
+}
+
 async function resolveDiverseAdapters(
   roles: readonly VoterRole[],
   logger: ILogger,
   fallbackAdapter: IModelAdapter,
   gatewayAdapters?: readonly IModelAdapter[]
 ): Promise<Map<VoterRole, IModelAdapter>> {
-  // #4040: gateway path — round-robin roles across the in-process per-model
-  // gateway adapters (HTTP, no subprocess). Preferred when configured.
+  // #4040: gateway path is preferred when configured.
   if (gatewayAdapters !== undefined && gatewayAdapters.length > 0) {
-    if (gatewayAdapters.length === 1) {
-      // Consensus integrity: a multi-role panel on ONE model yields correlated
-      // votes (the higher_order strategy can't down-weight what it can't tell
-      // apart). Warn so operators notice — configure the gateway with more models
-      // for a genuinely diverse panel.
-      if (roles.length > 1) {
-        logger.warn('Consensus panel collapsed to a single gateway model — votes may correlate', {
-          model: gatewayAdapters[0]?.modelId,
-          roleCount: roles.length,
-        });
-      }
-      return assignUniformAdapter(roles, gatewayAdapters[0] ?? fallbackAdapter);
-    }
-    return assignRoundRobinAdapters(
-      roles,
-      gatewayAdapters.map((a) => ({ label: a.modelId, adapter: a })),
-      logger,
-      'gateway'
-    );
+    return resolveGatewayRoleAdapters(roles, gatewayAdapters, fallbackAdapter, logger);
   }
 
   let availableClis: CliName[];

--- a/packages/nexus-agents/src/cli/voter-model-overrides.test.ts
+++ b/packages/nexus-agents/src/cli/voter-model-overrides.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for per-role voter model overrides (#4055).
+ */
+
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import type { ILogger, IModelAdapter } from '../core/index.js';
+import { resolveVoterModelOverrides, voterModelOverrideEnvKey } from './voter-model-overrides.js';
+import { resolveGatewayRoleAdapters } from './voter-agents.js';
+
+/** Minimal adapter stub — the resolver only reads `modelId`. */
+function adapter(modelId: string): IModelAdapter {
+  return { modelId } as unknown as IModelAdapter;
+}
+
+function fakeLogger(): ILogger & {
+  warn: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+} {
+  return {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ILogger & { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+}
+
+const GATEWAY = [adapter('gpt-4o'), adapter('claude_4_5_opus'), adapter('gemini-3-pro')];
+const ENV_KEYS = [
+  'NEXUS_VOTER_MODEL_ARCHITECT',
+  'NEXUS_VOTER_MODEL_SECURITY',
+  'NEXUS_VOTER_MODEL_AI_ML',
+];
+
+describe('voterModelOverrideEnvKey (#4055)', () => {
+  it('derives the env key from the role (underscores preserved, upper-cased)', () => {
+    expect(voterModelOverrideEnvKey('architect')).toBe('NEXUS_VOTER_MODEL_ARCHITECT');
+    expect(voterModelOverrideEnvKey('ai_ml')).toBe('NEXUS_VOTER_MODEL_AI_ML');
+    expect(voterModelOverrideEnvKey('scope_steward')).toBe('NEXUS_VOTER_MODEL_SCOPE_STEWARD');
+  });
+});
+
+describe('resolveVoterModelOverrides (#4055)', () => {
+  afterEach(() => {
+    for (const k of ENV_KEYS) Reflect.deleteProperty(process.env, k);
+  });
+
+  it('returns an empty map when no overrides are set (round-robin unchanged)', () => {
+    const logger = fakeLogger();
+    const out = resolveVoterModelOverrides(['architect', 'security'], GATEWAY, logger);
+    expect(out.size).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('pins a role to a valid gateway model id', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'claude_4_5_opus';
+    const logger = fakeLogger();
+    const out = resolveVoterModelOverrides(['architect', 'security'], GATEWAY, logger);
+    expect(out.get('architect')?.modelId).toBe('claude_4_5_opus');
+    expect(out.has('security')).toBe(false); // no override → round-robin
+  });
+
+  it('matches case-insensitively as a convenience', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'CLAUDE_4_5_OPUS';
+    const out = resolveVoterModelOverrides(['architect'], GATEWAY, fakeLogger());
+    expect(out.get('architect')?.modelId).toBe('claude_4_5_opus');
+  });
+
+  it('warns and falls back (omits the role) when the override id is not in the catalog', () => {
+    process.env['NEXUS_VOTER_MODEL_SECURITY'] = 'not-a-real-model';
+    const logger = fakeLogger();
+    const out = resolveVoterModelOverrides(['security'], GATEWAY, logger);
+    expect(out.has('security')).toBe(false);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message] = logger.warn.mock.calls[0] as [string];
+    expect(message).toContain('not-a-real-model');
+  });
+
+  it('ignores a blank override value', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = '   ';
+    const out = resolveVoterModelOverrides(['architect'], GATEWAY, fakeLogger());
+    expect(out.size).toBe(0);
+  });
+
+  it('handles multiple roles with distinct overrides', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'gpt-4o';
+    process.env['NEXUS_VOTER_MODEL_AI_ML'] = 'gemini-3-pro';
+    const out = resolveVoterModelOverrides(
+      ['architect', 'security', 'ai_ml'],
+      GATEWAY,
+      fakeLogger()
+    );
+    expect(out.get('architect')?.modelId).toBe('gpt-4o');
+    expect(out.get('ai_ml')?.modelId).toBe('gemini-3-pro');
+    expect(out.has('security')).toBe(false);
+  });
+
+  it('returns empty when there are no gateway adapters', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'gpt-4o';
+    const out = resolveVoterModelOverrides(['architect'], [], fakeLogger());
+    expect(out.size).toBe(0);
+  });
+});
+
+describe('resolveGatewayRoleAdapters — override + round-robin integration (#4055)', () => {
+  afterEach(() => {
+    for (const k of ENV_KEYS) Reflect.deleteProperty(process.env, k);
+  });
+
+  const fallback = adapter('fallback-model');
+
+  it('pins the overridden role and round-robins the rest', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'claude_4_5_opus';
+    const assigned = resolveGatewayRoleAdapters(
+      ['architect', 'security', 'ai_ml'],
+      GATEWAY,
+      fallback,
+      fakeLogger()
+    );
+    // architect is pinned; the other two are NOT (they round-robin, so they are not
+    // the override-only model unless round-robin lands there).
+    expect(assigned.get('architect')?.modelId).toBe('claude_4_5_opus');
+    expect(assigned.size).toBe(3);
+  });
+
+  it('warns when overrides collapse the whole panel to one model (governance guard)', () => {
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'gpt-4o';
+    process.env['NEXUS_VOTER_MODEL_SECURITY'] = 'gpt-4o';
+    process.env['NEXUS_VOTER_MODEL_AI_ML'] = 'gpt-4o';
+    const logger = fakeLogger();
+    const assigned = resolveGatewayRoleAdapters(
+      ['architect', 'security', 'ai_ml'],
+      GATEWAY,
+      fallback,
+      logger
+    );
+    expect([...assigned.values()].every((a) => a.modelId === 'gpt-4o')).toBe(true);
+    const collapseWarn = logger.warn.mock.calls.find((c) =>
+      String(c[0]).includes('collapsed to a single gateway model via overrides')
+    );
+    expect(collapseWarn).toBeDefined();
+  });
+
+  it('does NOT warn collapse when diversity is preserved', () => {
+    // architect pinned to gemini-3-pro; security round-robins to entries[0] (gpt-4o)
+    // → 2 distinct models, no collapse. (If the override were gpt-4o it WOULD collapse,
+    // since the lone round-robin role also lands on entries[0] — verified above.)
+    process.env['NEXUS_VOTER_MODEL_ARCHITECT'] = 'gemini-3-pro';
+    const logger = fakeLogger();
+    const assigned = resolveGatewayRoleAdapters(
+      ['architect', 'security'],
+      GATEWAY,
+      fallback,
+      logger
+    );
+    expect(new Set([...assigned.values()].map((a) => a.modelId)).size).toBe(2);
+    const collapseWarn = logger.warn.mock.calls.find((c) =>
+      String(c[0]).includes('collapsed to a single gateway model via overrides')
+    );
+    expect(collapseWarn).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/cli/voter-model-overrides.ts
+++ b/packages/nexus-agents/src/cli/voter-model-overrides.ts
@@ -1,0 +1,74 @@
+/**
+ * nexus-agents/cli — per-role voter model overrides (#4055).
+ *
+ * Voters round-robin across the gateway's discovered models (#4040), so a role can
+ * land on a model that fails on a particular gateway (e.g. a bodyless HTTP 400 for
+ * specific model ids — #4049). This lets an operator PIN a known-good gateway model
+ * for a role:
+ *
+ *   NEXUS_VOTER_MODEL_<ROLE>=<bare gateway model id>
+ *   e.g. NEXUS_VOTER_MODEL_ARCHITECT=claude_4_5_opus
+ *
+ * The override is validated against the discovered gateway catalog: an id that is
+ * NOT a live gateway model warns and falls back to round-robin for that role (no
+ * hard failure). Roles without an override round-robin unchanged.
+ *
+ * @module cli/voter-model-overrides
+ */
+
+import type { ILogger, IModelAdapter } from '../core/index.js';
+import type { VoterRole } from './vote-types.js';
+
+/** Env var name for a role's voter-model override (e.g. role `ai_ml` → `NEXUS_VOTER_MODEL_AI_ML`). */
+export function voterModelOverrideEnvKey(role: VoterRole): string {
+  return `NEXUS_VOTER_MODEL_${role.toUpperCase()}`;
+}
+
+/**
+ * Resolve per-role gateway-model overrides from the environment, validated against
+ * the discovered gateway adapters. Returns a map of ONLY the roles that have a
+ * valid override (matched to a live gateway model by `modelId`); roles with no
+ * override, or an override id not in the catalog, are omitted (and the latter is
+ * warned) so the caller round-robins them as usual.
+ *
+ * Matching is exact on `modelId` first, then case-insensitive as a convenience.
+ */
+export function resolveVoterModelOverrides(
+  roles: readonly VoterRole[],
+  gatewayAdapters: readonly IModelAdapter[],
+  logger: ILogger
+): Map<VoterRole, IModelAdapter> {
+  const overrides = new Map<VoterRole, IModelAdapter>();
+  if (gatewayAdapters.length === 0) return overrides;
+
+  const byId = new Map<string, IModelAdapter>();
+  for (const adapter of gatewayAdapters) byId.set(adapter.modelId, adapter);
+
+  for (const role of roles) {
+    const envKey = voterModelOverrideEnvKey(role);
+    const raw = process.env[envKey];
+    if (raw === undefined || raw.trim() === '') continue;
+    const requested = raw.trim();
+
+    const adapter =
+      byId.get(requested) ??
+      gatewayAdapters.find((a) => a.modelId.toLowerCase() === requested.toLowerCase());
+
+    if (adapter === undefined) {
+      logger.warn(
+        `Voter model override ${envKey}="${requested}" is not a discovered gateway model — ` +
+          `falling back to round-robin for role "${role}".`,
+        { role, requested, available: [...byId.keys()] }
+      );
+      continue;
+    }
+    overrides.set(role, adapter);
+  }
+
+  if (overrides.size > 0) {
+    logger.info('Applied per-role voter model overrides (#4055)', {
+      overrides: Object.fromEntries([...overrides].map(([r, a]) => [r, a.modelId])),
+    });
+  }
+  return overrides;
+}


### PR DESCRIPTION
## What

Voters round-robin across the gateway's discovered models (#4040), so a role can land on a model that fails on a particular gateway (e.g. a bodyless HTTP 400 for specific ids, #4049) — with no way to pin a known-good one. This adds the operator escape hatch:

```
NEXUS_VOTER_MODEL_<ROLE>=<bare gateway model id>
# e.g. NEXUS_VOTER_MODEL_ARCHITECT=claude_4_5_opus
```

A role with a valid override is pinned to that model; the remaining roles round-robin as before.

## Behavior (acceptance criteria)

- **Override applied:** a role with the env set to a live gateway model id uses it.
- **Unknown id → warn + fallback:** not in the discovered catalog → warns and round-robins that role (no hard failure).
- **Roles without an override:** round-robin unchanged. Blank value ignored. Env key derived from the role (`ai_ml` → `NEXUS_VOTER_MODEL_AI_ML`); match is exact then case-insensitive.

## Consensus-integrity guard (from adversarial review)

The reviewer flagged that an operator pinning *all* roles to one model collapses panel diversity (correlated votes) — and the override path lacked the warning the single-gateway-model path already has. Added: the override path now **warns when the final assignment collapses every role onto one model**, matching the existing guard. Covered by an integration test.

## Gates

71 voter tests green (8 resolver unit + 3 integration incl. the collapse guard); tsc + lint clean. Minor changeset.

Closes #4055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)