### PR TITLE
docs(jobs): correct cancel_job's false in-flight-abort claim (#4017)

### DIFF
--- a/.changeset/cancel-job-doc-accuracy.md
+++ b/.changeset/cancel-job-doc-accuracy.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Correct the `cancel_job` doc to stop overstating what cancellation does (#4017).
+The tool's docstring claimed an "in-process AbortController is the source of truth
+for ACTUALLY stopping in-flight work" — but the shared `runAsJob` dispatch path
+(`run`, `run_pipeline`, `run_dev_pipeline`, …) has no AbortController/signal wiring,
+so a cancel marks the durable record but the background work keeps running to
+completion. (`consensus_vote` is the exception — it has its own AbortSignal
+plumbing and is genuinely interrupted.)
+
+The docstring now states this accurately: cancel writes the `cancelled` record,
+the terminal-writer guards (#4022) preserve it (no silent revert), and in-flight
+`runAsJob` work continues. Wiring a real per-job AbortController so cancel actually
+stops the work is tracked as #4086. No behavior change — this is a doc-vs-reality
+correction.

--- a/packages/nexus-agents/src/mcp/tools/cancel-job-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/cancel-job-tool.ts
@@ -3,27 +3,32 @@
  *
  * Marks an async-mode job as cancelled. Three semantic outcomes:
  *
- * - **`cancelled`** — the job was `pending` and is now `cancelled`. The
- *   dispatcher's in-process AbortController (from #3035/#3038 plumbing)
- *   is the source of truth for ACTUALLY stopping in-flight work in the
- *   same process; this tool's job is to write the durable cancellation
- *   record so cross-session pollers can observe it.
+ * - **`cancelled`** — the job was `pending` and is now `cancelled`. This
+ *   writes the durable `cancelled` record, and the terminal writers
+ *   (`writeJobComplete`/`writeJobFailed`) no-op against it (#4017/#4022),
+ *   so a later-settling background job can no longer silently revert the
+ *   cancellation. See the IMPORTANT caveat below on what this does NOT stop.
  * - **`already_complete`** — the job is already `complete` / `failed`.
  *   The terminal record is preserved (Security flag from #3041 vote:
  *   cancel-after-complete must not rewrite history).
  * - **`already_cancelled`** — second + cancellation against the same
  *   jobId is a no-op. Idempotent for safe retry.
  *
- * **What this tool does NOT do:** it doesn't abort in-flight work in
- * OTHER processes (no IPC; per-process AbortControllers can only abort
- * what they own). For the same-process case, every async-mode dispatcher
- * shipped in Stages 1+3+4 already pairs `tryAcquire` with `release` in
- * `finally`, so the abort signal lands on the right Promise.
+ * **IMPORTANT — cancel marks the record; it does NOT abort in-flight work
+ * for jobs dispatched via the shared `runAsJob` path (#4017).** `run-as-job.ts`
+ * has no AbortController/signal wiring, so for `run`, `run_pipeline`,
+ * `run_dev_pipeline`, and every other `runAsJob`-dispatched tool, the
+ * background `params.run(...)` keeps executing to completion after a cancel —
+ * only the persisted record is marked `cancelled` (now preserved by the
+ * terminal-writer guards). `consensus_vote` is the exception: it has its own
+ * AbortSignal plumbing (#3038) and IS genuinely interrupted. Wiring a real
+ * per-job AbortController through `runAsJob` so cancel actually stops the work
+ * is tracked as a follow-up enhancement.
  *
- * In a multi-process deployment, the durable cancellation record this
- * tool writes is observable via `get_job_result` and `list_jobs`, but
- * the worker process needs to poll for it (future work; not part of
- * this PR).
+ * It also doesn't abort work in OTHER processes (no IPC; per-process
+ * AbortControllers can only abort what they own). In a multi-process
+ * deployment the durable cancellation record is observable via
+ * `get_job_result` / `list_jobs`, but the worker process must poll for it.
  *
  * @module mcp/tools/cancel-job-tool
  */


### PR DESCRIPTION
## What

Resolves the remaining half of #4017 (a 2026-06-21 QA/security finding).

**The observable failure** — a settled background job silently reverting a `cancelled` record — was already fixed by the terminal-writer guards in **#4022** (`writeJobComplete`/`writeJobFailed` no-op against a `cancelled` record; tested at `job-result-store.test.ts:116`).

**The remaining gap** was a false capability claim in the `cancel_job` docstring: it said an "in-process AbortController is the source of truth for ACTUALLY stopping in-flight work in the same process." That is **false** for the shared `runAsJob` dispatch path — `run-as-job.ts` has zero AbortController/signal wiring (verified), so for `run`, `run_pipeline`, `run_dev_pipeline`, and every other `runAsJob`-dispatched tool, the background work **runs to completion** after a cancel; only the durable record is marked `cancelled` (and now preserved by the #4022 guards). `consensus_vote` is the exception — it has its own AbortSignal plumbing (#3038) and is genuinely interrupted.

## Change

Docstring-only: it now states the cancellation semantics accurately (marks + preserves the record; does NOT abort in-flight `runAsJob` work). **No behavior change.**

Wiring a real per-job AbortController through `runAsJob` so cancel actually halts the work is tracked as the enhancement **#4086**.

## Gates

tsc + lint clean. Patch changeset (doc-accuracy correction of a documented capability). Closes #4017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)