### PR TITLE
feat(ci): verify pr_review record baseSha against the PR's actual base (#4058)

### DIFF
--- a/scripts/check-governor-review.test.ts
+++ b/scripts/check-governor-review.test.ts
@@ -86,6 +86,7 @@ function inputs(overrides: Partial<GovernorReviewInputs> = {}): GovernorReviewIn
   return {
     prNumber: 5000,
     reviewedDiffHash: DIFF_HASH,
+    baseSha: SHA_BASE,
     changedFiles: ['packages/nexus-agents/src/audit/audit-logger.ts'],
     governorPatterns: GOVERNOR_PATTERNS,
     records: [],
@@ -147,8 +148,34 @@ describe('matchesCodeownersPattern', () => {
 });
 
 describe('analyzeGovernorReview — binding conditions', () => {
-  it('(a) PASSES with a valid diff-bound record for the PR', () => {
+  it('(a) PASSES with a valid diff-bound record for the PR (baseSha consistent)', () => {
     const outcome = analyzeGovernorReview(inputs({ records: [record()] }));
+    expect(outcome.kind).toBe('pass');
+    if (outcome.kind === 'pass') expect(outcome.reason).toContain('baseSha consistent');
+  });
+
+  it("(a2) WARNS when the record's baseSha does NOT match the PR's actual base (#4058)", () => {
+    // Same diff CONTENT (reviewedDiffHash matches) but the record records a base that
+    // is not the PR's real base → provenance inconsistent → warn-first (enforce: fail).
+    const outcome = analyzeGovernorReview(inputs({ records: [record()], baseSha: SHA_STALE }));
+    expect(outcome.kind).toBe('warn');
+    if (outcome.kind === 'warn') {
+      expect(outcome.message).toContain('does NOT match');
+      expect(outcome.message).toContain('#4058');
+    }
+  });
+
+  it('(a3) is case-insensitive on baseSha — no spurious warn for an upper-cased CI base', () => {
+    const outcome = analyzeGovernorReview(
+      inputs({ records: [record()], baseSha: SHA_BASE.toUpperCase() })
+    );
+    expect(outcome.kind).toBe('pass');
+  });
+
+  it('(a4) FAILS OPEN (passes) on a non-40-hex CI base — no spurious provenance warn', () => {
+    // An abbreviated/odd base is not comparable to the record's pinned 40-hex format;
+    // we PASS on the hash match rather than risk a false warn.
+    const outcome = analyzeGovernorReview(inputs({ records: [record()], baseSha: 'abc1234' }));
     expect(outcome.kind).toBe('pass');
   });
 

--- a/scripts/check-governor-review.ts
+++ b/scripts/check-governor-review.ts
@@ -183,6 +183,13 @@ export interface GovernorReviewInputs {
    * headSha binding.
    */
   readonly reviewedDiffHash: string;
+  /**
+   * The PR's ACTUAL base commit sha (the trusted `base..head` range the CI gate
+   * recomputed {@link reviewedDiffHash} from). A matching record's caller-asserted
+   * `baseSha` is verified against THIS (#4058): a record that reviewed the right
+   * diff bytes but claims a different base has inaccurate provenance.
+   */
+  readonly baseSha: string;
   readonly changedFiles: readonly string[];
   readonly governorPatterns: readonly string[];
   readonly records: readonly PrReviewRecord[];
@@ -201,6 +208,48 @@ export interface GovernorReviewInputs {
  *     condition 1). A stale-sha record does NOT match.
  *  5. Otherwise → WARN (warn-first, condition 2): actionable, non-blocking.
  */
+/**
+ * Outcome for a record that matched on prNumber + reviewedDiffHash (#4058).
+ *
+ * PROVENANCE HYGIENE, not a new integrity gain: the matched `reviewedDiffHash` is
+ * already recomputed by CI from `git diff <trusted PR base>..<head>`, so a matching
+ * record provably reviewed byte-identical CONTENT to the real PR range — the
+ * record's stored `baseSha` is a label, and a wrong label CANNOT make a record
+ * falsely satisfy the gate (satisfaction is bound to the trusted-base hash, not the
+ * record's base). What this catches is a producer MISCONFIGURATION — a record that
+ * reviewed the right bytes but recorded a base inconsistent with the PR's actual
+ * base. Surfaced warn-first; a future enforce flip (#3831) can decide whether to
+ * harden it to a fail.
+ *
+ * Fail-OPEN on a non-comparable CI base (abbreviated / non-40-hex): the canonical
+ * CI path passes a full lowercase 40-hex `pull_request.base.sha`, but we only flag
+ * a mismatch when the base is directly comparable to the record's pinned
+ * `^[0-9a-f]{40}$` format — otherwise we PASS rather than risk a spurious warn.
+ */
+function matchedRecordOutcome(
+  match: PrReviewRecord,
+  inputs: GovernorReviewInputs
+): GovernorReviewOutcome {
+  const ciBase = inputs.baseSha.toLowerCase();
+  const comparable = /^[0-9a-f]{40}$/.test(ciBase);
+  if (comparable && match.baseSha.toLowerCase() !== ciBase) {
+    return {
+      kind: 'warn',
+      message:
+        `PR #${String(inputs.prNumber)} has a diff-bound pr_review record whose baseSha ` +
+        `(${match.baseSha.slice(0, 12)}…) does NOT match the PR's actual base ` +
+        `(${ciBase.slice(0, 12)}…). The reviewed diff content matches (hash verified), but the ` +
+        `record's recorded base is inconsistent with the PR — likely a producer ` +
+        `misconfiguration. Re-run pr_review with the PR's base and commit the record. ` +
+        `(Warn-first: not blocking this stage; provenance hygiene for a future enforce flip, #4058.)`,
+    };
+  }
+  return {
+    kind: 'pass',
+    reason: `diff-bound pr_review record found for PR #${String(inputs.prNumber)} (reviewedDiffHash=${inputs.reviewedDiffHash.slice(0, 12)}…${comparable ? ', baseSha consistent' : ''}, verdict=${match.verdict})`,
+  };
+}
+
 export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorReviewOutcome {
   // (1) Integrity FIRST — fail-closed on tamper evidence (condition 2).
   const verification = verifyPrReviewRecordSet(inputs.records);
@@ -235,10 +284,7 @@ export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorRev
     (r) => r.prNumber === inputs.prNumber && r.reviewedDiffHash === inputs.reviewedDiffHash
   );
   if (match !== undefined) {
-    return {
-      kind: 'pass',
-      reason: `diff-bound pr_review record found for PR #${String(inputs.prNumber)} (reviewedDiffHash=${inputs.reviewedDiffHash.slice(0, 12)}…, verdict=${match.verdict})`,
-    };
+    return matchedRecordOutcome(match, inputs);
   }
 
   // (5) Absence → WARN-FIRST (condition 2): actionable, non-blocking this stage.
@@ -356,7 +402,9 @@ function tamperExitCode(records: readonly PrReviewRecord[]): number | null {
 function resolveGateContext(
   argv: readonly string[],
   records: readonly PrReviewRecord[]
-): { prNumber: number; reviewedDiffHash: string; changedFiles: string[] } | { exit: number } {
+):
+  | { prNumber: number; reviewedDiffHash: string; baseSha: string; changedFiles: string[] }
+  | { exit: number } {
   const { prNumber, baseSha, headSha } = resolvePrContext(argv);
   const changedFiles = resolveChangedFiles(argv);
 
@@ -384,7 +432,7 @@ function resolveGateContext(
     return { exit: 0 };
   }
 
-  return { prNumber, reviewedDiffHash, changedFiles };
+  return { prNumber, reviewedDiffHash, baseSha, changedFiles };
 }
 
 export function runGovernorReviewGate(argv: readonly string[]): number {
@@ -398,6 +446,7 @@ export function runGovernorReviewGate(argv: readonly string[]): number {
   const outcome = analyzeGovernorReview({
     prNumber: ctx.prNumber,
     reviewedDiffHash: ctx.reviewedDiffHash,
+    baseSha: ctx.baseSha,
     changedFiles: ctx.changedFiles,
     governorPatterns,
     records,


### PR DESCRIPTION
## What

The warn-first governor-review gate (`scripts/check-governor-review.ts`) matched a pr_review record on `prNumber + reviewedDiffHash` but never checked the record's stored `baseSha`. This adds that provenance check, closing the #4058 follow-up filed during #4031.

## Honest framing (the adversarial review reframed the value — recorded here)

This is **provenance / misconfiguration hygiene, NOT a new integrity gain.** The review correctly observed that the gate already recomputes `reviewedDiffHash` from `git diff <trusted PR base>..<head>`, so a matching record *provably reviewed byte-identical content* to the real PR range — and a wrong `record.baseSha` **cannot** make a record falsely satisfy the gate, because satisfaction is bound to the trusted-base hash, not the record's base. The original #4058 exploit concern (a mismatched base falsely satisfying enforce) is therefore **already structurally mitigated by the trusted-base hash recompute.**

What this check actually catches: a producer that reviewed the right bytes but **recorded a base inconsistent with the PR** (a misconfiguration). Surfaced warn-first; the enforce flip (#3831) can decide whether to harden to a fail.

## Safety (review findings addressed)

- **No false positives:** the comparison is case-insensitive and **fails open** (passes) on a non-40-hex CI base — the canonical CI path passes a full lowercase 40-hex `pull_request.base.sha`, but an abbreviated/odd base isn't comparable to the record's pinned `^[0-9a-f]{40}$`, so we PASS rather than risk a spurious warn.
- **No weakening:** only ever downgrades PASS→WARN (never WARN→PASS); warn-first exit-0 behavior intact.
- The committed ledger is empty (0 records), so zero regression to existing PRs.

## Gates

20 gate tests green (base-consistent→pass, mismatch→warn, upper-cased→pass, non-40-hex→pass); lint clean. No changeset (CI script, not `packages/nexus-agents/src/**`).

Closes #4058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)