### PR TITLE
feat(consensus): make the higher-order correlation tracker injectable (#3173)

### DIFF
--- a/.changeset/owvoting-injectable-tracker.md
+++ b/.changeset/owvoting-injectable-tracker.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+Make the higher-order voting strategy's correlation tracker injectable (#3173).
+`OWVoting.aggregate()` previously required an `ICorrelationTracker` argument, and
+the MCP consensus path always threaded its process-wide singleton through — so
+higher-order voting could not be reused as a building block (autonomous agents,
+test harnesses, custom pipelines) without coupling to that singleton or modifying
+the call signature.
+
+`OWVotingOptions` now accepts an optional `tracker`, and `aggregate(votes, tracker?)`
+resolves the tracker as: per-call argument → constructor-injected → else throws a
+clear error. Fully backward compatible — existing callers that pass the tracker
+positionally are unchanged, and the MCP path keeps owning its persistent singleton.
+The `IHigherOrderVoting.aggregate` signature's `tracker` is now optional to match.

--- a/packages/nexus-agents/src/consensus/higher-order-types.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-types.ts
@@ -343,10 +343,15 @@ export interface IHigherOrderVoting {
 
   /**
    * Full pipeline: estimate correlation, compute result.
+   *
+   * `tracker` is OPTIONAL (#3173): when omitted, the instance uses the tracker
+   * injected at construction (`OWVotingOptions.tracker`), letting higher-order
+   * voting be reused as a building block without threading the tracker through
+   * every call. A per-call `tracker` still wins. Throws if neither is available.
    */
   aggregate(
     votes: ReadonlyMap<string, Vote>,
-    tracker: ICorrelationTracker
+    tracker?: ICorrelationTracker
   ): HigherOrderVotingResult;
 
   /**

--- a/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
@@ -8,8 +8,9 @@
  * (Source: Issue #333)
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Vote } from './types-core.js';
+import type { ICorrelationTracker } from './higher-order-types.js';
 import {
   createAgentPairKey,
   parseAgentPairKey,
@@ -965,5 +966,51 @@ describe('OWVoting.algorithm label (#3168)', () => {
   it('HigherOrderVotingStrategy reports opinion_wise however it is created', () => {
     expect(new HigherOrderVotingStrategy().algorithm).toBe('opinion_wise');
     expect(createHigherOrderVotingStrategy().algorithm).toBe('opinion_wise');
+  });
+});
+
+// ============================================================================
+// Injectable correlation tracker (#3173)
+// ============================================================================
+
+/** Minimal spy tracker — `hasSufficientData=false` makes aggregate fall back to
+ *  simple voting (only that method is touched), so a spy proves WHICH tracker ran. */
+function spyTracker(): ICorrelationTracker {
+  return {
+    hasSufficientData: vi.fn(() => false),
+    computeCorrelationMatrix: vi.fn(() => new Map()),
+    identifyIndependentSubsets: vi.fn(() => []),
+  } as unknown as ICorrelationTracker;
+}
+
+describe('OWVoting — injectable correlation tracker (#3173)', () => {
+  const votes = createVoteMap([
+    ['alice', 'approve'],
+    ['bob', 'reject'],
+  ]);
+
+  it('uses the constructor-injected tracker when aggregate() is called WITHOUT one', () => {
+    const injected = spyTracker();
+    const owv = createOWVoting({ tracker: injected });
+    const result = owv.aggregate(votes); // no per-call tracker
+    expect(result).toBeDefined();
+    expect(injected.hasSufficientData).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a per-call tracker WIN over the injected one', () => {
+    const injected = spyTracker();
+    const perCall = spyTracker();
+    createOWVoting({ tracker: injected }).aggregate(votes, perCall);
+    expect(perCall.hasSufficientData).toHaveBeenCalledTimes(1);
+    expect(injected.hasSufficientData).not.toHaveBeenCalled();
+  });
+
+  it('THROWS a clear error when neither a per-call nor an injected tracker is available', () => {
+    expect(() => createOWVoting().aggregate(votes)).toThrow(/requires an ICorrelationTracker/);
+  });
+
+  it('still works with a real injected tracker (composability smoke test)', () => {
+    const owv = createOWVoting({ tracker: createCorrelationTracker() });
+    expect(owv.aggregate(votes)).toBeDefined();
   });
 });

--- a/packages/nexus-agents/src/consensus/higher-order-voting.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.ts
@@ -48,6 +48,15 @@ export interface OWVotingOptions {
    * Keeps the label consistent whether constructed directly or via a factory.
    */
   readonly algorithm?: ConsensusAlgorithm;
+  /**
+   * Correlation tracker this instance uses when {@link OWVoting.aggregate} is
+   * called WITHOUT a per-call tracker (#3173). Injecting here lets higher-order
+   * voting be reused as a building block (autonomous agents, test harnesses,
+   * custom pipelines) without coupling to the MCP tool's process-wide singleton
+   * or threading the tracker through every call. Omit it to keep the singleton
+   * model — the MCP consensus path injects/passes its persistent tracker.
+   */
+  readonly tracker?: ICorrelationTracker;
 }
 
 /**
@@ -57,12 +66,15 @@ export interface OWVotingOptions {
 export class OWVoting implements IHigherOrderVoting, IVotingStrategy {
   readonly algorithm: ConsensusAlgorithm;
   private readonly config: HigherOrderVotingConfig;
+  /** #3173: tracker used when `aggregate` is called without a per-call one. */
+  private readonly injectedTracker: ICorrelationTracker | undefined;
 
   constructor(options: OWVotingOptions = {}) {
     this.config = { ...DEFAULT_HIGHER_ORDER_CONFIG, ...options.config };
     // #3168: configurable so the label is correct whether built directly or via
     // a factory; defaults to simple_majority for backward compatibility.
     this.algorithm = options.algorithm ?? 'simple_majority';
+    this.injectedTracker = options.tracker;
     logger.info('OWVoting initialized', { config: this.config, algorithm: this.algorithm });
   }
 
@@ -180,6 +192,23 @@ export class OWVoting implements IHigherOrderVoting, IVotingStrategy {
   }
 
   aggregate(
+    votes: ReadonlyMap<string, Vote>,
+    tracker?: ICorrelationTracker
+  ): HigherOrderVotingResult {
+    // #3173: per-call tracker wins; otherwise use the one injected at construction.
+    // Neither present is a programming error (no correlation data source available).
+    const effectiveTracker = tracker ?? this.injectedTracker;
+    if (effectiveTracker === undefined) {
+      throw new Error(
+        'OWVoting.aggregate requires an ICorrelationTracker — pass it as an argument ' +
+          'or inject one via OWVotingOptions.tracker (#3173).'
+      );
+    }
+    return this.aggregateWith(votes, effectiveTracker);
+  }
+
+  /** Core aggregation against a resolved tracker (#3173 — extracted from aggregate). */
+  private aggregateWith(
     votes: ReadonlyMap<string, Vote>,
     tracker: ICorrelationTracker
   ): HigherOrderVotingResult {


### PR DESCRIPTION
## What

Resolves the #3173 composability-friction finding (2026-05-31 system review). `OWVoting.aggregate()` required an `ICorrelationTracker` argument, and the MCP consensus path always threaded its process-wide singleton through — so higher-order voting couldn't be reused as a building block (autonomous agents, test harnesses, custom pipelines) without coupling to that singleton or modifying the call signature.

## Change

- `OWVotingOptions` accepts an optional `tracker` (constructor injection).
- `aggregate(votes, tracker?)` resolves the tracker: **per-call argument → constructor-injected → else throws a clear error**. (Core extracted into a private `aggregateWith` so each method stays small.)
- `IHigherOrderVoting.aggregate`'s `tracker` is now optional to match.
- The singleton stays owned by its MCP-layer home (no layering violation — the consensus layer doesn't reach into the MCP tool).

## Backward compatibility

Fully compatible — existing callers that pass the tracker positionally (including the MCP consensus path) are unchanged. **Proven by the unchanged 56 existing higher-order-voting tests still passing** plus 117 MCP-consensus tests green; the refactor is pure DI with no behavior change to the aggregation logic.

## Tests

4 new: injected-tracker-used (no per-call), per-call-wins-over-injected, throws-when-neither, real-tracker composability smoke. 535 consensus + 117 MCP-consensus tests green; tsc + lint clean. Minor changeset (additive injectable option).

Closes #3173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)