### PR TITLE
feat(jobs): make cancel_job actually abort in-flight runAsJob work (#4086)

### DIFF
--- a/.changeset/job-abort-controller.md
+++ b/.changeset/job-abort-controller.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': minor
+---
+
+`cancel_job` can now actually STOP in-flight work for `runAsJob`-dispatched tools
+(#4086, the follow-on to #4017). Previously the shared async-job path had no abort
+wiring, so a cancel only marked the durable record while the background work ran to
+completion. A per-job `AbortController` registry now backs every dispatched job:
+its `AbortSignal` is threaded into the job body (`run(jobId, input, signal)`), and
+cancelling a `pending` job fires that signal.
+
+A tool that threads the signal into its awaited operations is genuinely interrupted
+in-process; when its `run()` rejects on abort, the terminal-writer guards (#4022)
+preserve the `cancelled` record. A tool that ignores the signal still runs to
+completion (you cannot stop an unyielding Promise), but its record stays
+`cancelled` — so adopting the signal is per-tool and incremental, and the dispatch
+infrastructure now makes it possible. Backward compatible: existing 2-arg `run`
+callbacks remain valid (the trailing `signal` is simply ignored). Same-process only
+(no IPC) — cross-process workers still observe cancellation by polling the record.

--- a/packages/nexus-agents/src/mcp/jobs/job-abort-registry.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-abort-registry.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the per-job AbortController registry (#4086).
+ */
+
+import { afterEach, describe, it, expect } from 'vitest';
+
+import {
+  registerJobAbort,
+  abortJob,
+  unregisterJobAbort,
+  jobAbortRegistrySize,
+} from './job-abort-registry.js';
+
+describe('job-abort-registry (#4086)', () => {
+  afterEach(() => {
+    // Clean any leftovers so size assertions stay isolated.
+    for (const id of ['j1', 'j2', 'unknown']) unregisterJobAbort(id);
+  });
+
+  it('registers a controller and exposes its signal', () => {
+    const controller = registerJobAbort('j1');
+    expect(controller.signal.aborted).toBe(false);
+    expect(jobAbortRegistrySize()).toBeGreaterThanOrEqual(1);
+    unregisterJobAbort('j1');
+  });
+
+  it('abortJob aborts the registered signal and returns true', () => {
+    const controller = registerJobAbort('j1');
+    let firedReason: unknown;
+    controller.signal.addEventListener('abort', () => {
+      firedReason = controller.signal.reason;
+    });
+    expect(abortJob('j1', 'user cancel')).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+    expect(String(firedReason)).toContain('user cancel');
+  });
+
+  it('removes the entry on abort so a late settle cannot double-fire', () => {
+    registerJobAbort('j1');
+    expect(abortJob('j1')).toBe(true);
+    // Already removed → a second abort is a no-op miss.
+    expect(abortJob('j1')).toBe(false);
+  });
+
+  it('abortJob returns false for an unknown / already-settled job', () => {
+    expect(abortJob('unknown')).toBe(false);
+  });
+
+  it('unregisterJobAbort removes the controller and is idempotent', () => {
+    registerJobAbort('j2');
+    unregisterJobAbort('j2');
+    unregisterJobAbort('j2'); // idempotent — no throw
+    expect(abortJob('j2')).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/mcp/jobs/job-abort-registry.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-abort-registry.ts
@@ -1,0 +1,54 @@
+/**
+ * nexus-agents/mcp/jobs — per-job AbortController registry (#4086).
+ *
+ * `runAsJob` dispatches detached background work; `cancel_job` previously only
+ * wrote a durable `cancelled` record but could not actually STOP the in-flight
+ * work (run-as-job had no abort wiring, #4017). This registry closes that gap: a
+ * dispatched job registers an `AbortController` keyed by `jobId`, the job body
+ * receives `controller.signal`, and `cancel_job` calls {@link abortJob} to abort
+ * it — so a tool that threads the signal into its awaited work is interrupted in
+ * the same process. (Tools that ignore the signal still run to completion, but the
+ * record is preserved as `cancelled` by the terminal-writer guards, #4022.)
+ *
+ * Process-local and same-process only (no IPC): a worker in another process must
+ * still poll the durable record.
+ *
+ * @module mcp/jobs/job-abort-registry
+ */
+
+const controllers = new Map<string, AbortController>();
+
+/**
+ * Register a fresh `AbortController` for `jobId` and return it. The dispatcher
+ * passes its `signal` to the job body and must call {@link unregisterJobAbort}
+ * when the job settles (whether it completed, failed, or was aborted).
+ */
+export function registerJobAbort(jobId: string): AbortController {
+  const controller = new AbortController();
+  controllers.set(jobId, controller);
+  return controller;
+}
+
+/**
+ * Abort the in-flight job's signal, if it is still registered. Returns true when a
+ * live controller was found and aborted, false when the job is unknown / already
+ * settled (in which case there is nothing in-flight to stop — the durable record
+ * is the source of truth). The entry is removed so a late settle doesn't double-fire.
+ */
+export function abortJob(jobId: string, reason?: string): boolean {
+  const controller = controllers.get(jobId);
+  if (controller === undefined) return false;
+  controllers.delete(jobId);
+  controller.abort(reason ?? 'cancelled via cancel_job');
+  return true;
+}
+
+/** Remove the controller for a settled job. Idempotent. */
+export function unregisterJobAbort(jobId: string): void {
+  controllers.delete(jobId);
+}
+
+/** Number of in-flight controllers (test/observability). @internal */
+export function jobAbortRegistrySize(): number {
+  return controllers.size;
+}

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
@@ -8,7 +8,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { runAsJob, runJobInBackground } from './run-as-job.js';
-import { readJobResult } from './job-result-store.js';
+import { readJobResult, writeJobPending, writeJobCancelled } from './job-result-store.js';
+import { abortJob } from './job-abort-registry.js';
 import { registerIdempotentJob, resolveIdempotency } from './job-idempotency.js';
 import { _resetForTests as resetConcurrency, getInFlight, getJobCap } from './job-concurrency.js';
 import { resetNexusDataDirCache, nexusDataPath } from '../../config/nexus-data-dir.js';
@@ -232,5 +233,73 @@ describe('runAsJob', () => {
       // The finally must still release the slot even on guard expiry.
       expect(getInFlight('orchestrate')).toBe(0);
     });
+  });
+});
+
+describe('runAsJob — cancellation aborts in-flight work (#4086)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-runasjob-abort-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetConcurrency();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('a signal-respecting job stops when cancelled, and the cancellation is preserved', async () => {
+    const jobId = 'job-abort-1';
+    writeJobPending(jobId, 'orchestrate');
+    let sawAbort = false;
+    const bg = runJobInBackground<DummyInput, { ok: true }, never>(jobId, {
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => jobId,
+      // Respects the signal: never resolves on its own, rejects when aborted.
+      run: (_id, _input, signal) =>
+        new Promise<{ ok: true }>((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            sawAbort = true;
+            reject(new Error('aborted by signal'));
+          });
+        }),
+    });
+
+    // Simulate cancel_job: write the durable cancelled record FIRST, then abort.
+    writeJobCancelled(jobId, 'orchestrate', 'user cancel');
+    expect(abortJob(jobId, 'user cancel')).toBe(true);
+    await bg;
+
+    expect(sawAbort).toBe(true); // the work actually observed the abort
+    // The terminal writer (writeJobFailed on the abort rejection) must NOT have
+    // overwritten the cancellation (#4022 guard).
+    expect(readJobResult(jobId)?.status).toBe('cancelled');
+    // Slot released.
+    expect(getInFlight('orchestrate')).toBe(0);
+  });
+
+  it('a job that IGNORES the signal still completes, but its cancelled record wins', async () => {
+    const jobId = 'job-abort-2';
+    writeJobPending(jobId, 'orchestrate');
+    const bg = runJobInBackground<DummyInput, { ok: true }, never>(jobId, {
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => jobId,
+      run: () => Promise.resolve({ ok: true }), // ignores the signal, resolves immediately
+    });
+
+    writeJobCancelled(jobId, 'orchestrate', 'user cancel');
+    await bg;
+
+    // writeJobComplete ran but no-ops against the cancelled record (#4022).
+    expect(readJobResult(jobId)?.status).toBe('cancelled');
   });
 });

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
@@ -22,6 +22,7 @@
 import type { ILogger } from '../../core/index.js';
 import { toolSuccess, toolStructuredError, type ToolResult } from '../tools/tool-result.js';
 import { writeJobComplete, writeJobFailed, writeJobPending } from './job-result-store.js';
+import { registerJobAbort, unregisterJobAbort } from './job-abort-registry.js';
 import { registerIdempotentJob, shortCircuitOrFreshJobId } from './job-idempotency.js';
 import { release, suggestRetryAfterMs, tryAcquire } from './job-concurrency.js';
 import { resolveClassGuardMs } from '../../config/timeouts.js';
@@ -183,11 +184,14 @@ export interface RunAsJobParams<I, R, E = ToolResult> {
   readonly freshJobId: () => string;
   /**
    * The detached background work. Receives the resolved `jobId` (so the
-   * runner can thread it into a task-state log) and the `input`. Its
-   * resolved value is recorded as the job's `complete` result; a rejection
-   * is recorded as `failed`.
+   * runner can thread it into a task-state log), the `input`, and an
+   * `AbortSignal` (#4086) that fires when `cancel_job` cancels this job —
+   * thread it into awaited operations to make cancellation actually stop the
+   * work. Existing 2-arg callbacks remain valid (the trailing param is
+   * ignored). Its resolved value is recorded as the job's `complete` result;
+   * a rejection is recorded as `failed`.
    */
-  readonly run: (jobId: string, input: I) => Promise<R>;
+  readonly run: (jobId: string, input: I, signal: AbortSignal) => Promise<R>;
   /** Per-tool envelope builders. Defaults to the {@link ToolResult} set. */
   readonly toEnvelope?: JobEnvelopeBuilders<E>;
   /** Optional logger for the background failure path. */
@@ -264,11 +268,18 @@ export async function runJobInBackground<I, R, E>(
 ): Promise<void> {
   const guardMs = resolveClassGuardMs(ASYNC_JOB_BODY_GUARD_CLASS);
   const guard = makeAsyncBodyGuard(jobId, params.toolName, guardMs, params.logger);
+  // #4086: register an AbortController so cancel_job can stop this job's work. Its
+  // signal is threaded into params.run; abort → run rejects → writeJobFailed, which
+  // no-ops against the already-written `cancelled` record (#4022), preserving it.
+  const controller = registerJobAbort(jobId);
   try {
     // Race the body against the runaway-guard. On guard expiry the guard
     // rejects with the sentinel → recorded as failed below. On body settle the
     // guard is cleared so it can never fire afterward.
-    const result = await Promise.race([params.run(jobId, params.input), guard.expired]);
+    const result = await Promise.race([
+      params.run(jobId, params.input, controller.signal),
+      guard.expired,
+    ]);
     writeJobComplete(jobId, params.toolName, result);
   } catch (err: unknown) {
     const errObj = err instanceof Error ? err : new Error(String(err));
@@ -276,6 +287,7 @@ export async function runJobInBackground<I, R, E>(
     writeJobFailed(jobId, params.toolName, errObj.message);
   } finally {
     guard.clear();
+    unregisterJobAbort(jobId);
     release(params.toolName);
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/cancel-job-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/cancel-job-tool.ts
@@ -14,19 +14,19 @@
  * - **`already_cancelled`** — second + cancellation against the same
  *   jobId is a no-op. Idempotent for safe retry.
  *
- * **IMPORTANT — cancel marks the record; it does NOT abort in-flight work
- * for jobs dispatched via the shared `runAsJob` path (#4017).** `run-as-job.ts`
- * has no AbortController/signal wiring, so for `run`, `run_pipeline`,
- * `run_dev_pipeline`, and every other `runAsJob`-dispatched tool, the
- * background `params.run(...)` keeps executing to completion after a cancel —
- * only the persisted record is marked `cancelled` (now preserved by the
- * terminal-writer guards). `consensus_vote` is the exception: it has its own
- * AbortSignal plumbing (#3038) and IS genuinely interrupted. Wiring a real
- * per-job AbortController through `runAsJob` so cancel actually stops the work
- * is tracked as a follow-up enhancement.
+ * **What cancel does to in-flight work (#4086).** Cancelling a `pending` job now
+ * fires that job's `AbortController` (registered by `runAsJob`, threaded into the
+ * job body as an `AbortSignal`). A `runAsJob`-dispatched tool that THREADS the
+ * signal into its awaited operations is genuinely interrupted in this process;
+ * when its `run()` rejects on abort, the terminal writers no-op against the
+ * already-written `cancelled` record (#4022), so the cancellation wins. A tool that
+ * IGNORES the signal still runs to completion (you cannot stop an unyielding
+ * Promise from outside) — but its record stays `cancelled`. So adopting the signal
+ * is per-tool and incremental; the dispatch infrastructure now makes it possible.
+ * (`consensus_vote` had its own AbortSignal plumbing pre-#4086, #3038.)
  *
- * It also doesn't abort work in OTHER processes (no IPC; per-process
- * AbortControllers can only abort what they own). In a multi-process
+ * Same-process only: it does not abort work in OTHER processes (no IPC; a
+ * per-process AbortController can only abort what it owns). In a multi-process
  * deployment the durable cancellation record is observable via
  * `get_job_result` / `list_jobs`, but the worker process must poll for it.
  *
@@ -46,6 +46,7 @@ import {
   type ToolResult,
 } from './tool-result.js';
 import { readJobResult, writeJobCancelled, type JobStatus } from '../jobs/job-result-store.js';
+import { abortJob } from '../jobs/job-abort-registry.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 export const CancelJobInputSchema = z.object({
@@ -118,14 +119,30 @@ function cancelJobHandler(args: unknown): Promise<ToolResult> {
   }
 
   // Status is 'pending' — perform the cancel.
-  writeJobCancelled(jobId, existing.toolName, reason);
-  const response: CancelJobResponse = {
+  return Promise.resolve(
+    toolSuccess(JSON.stringify(cancelPendingJob(jobId, existing.toolName, reason), null, 2))
+  );
+}
+
+/**
+ * Cancel a `pending` job: write the durable `cancelled` record FIRST, then abort
+ * the in-flight work (#4086). When the aborted `run()` rejects, the terminal
+ * writers no-op against the `cancelled` record (#4022), so the cancellation wins.
+ */
+function cancelPendingJob(jobId: string, toolName: string, reason?: string): CancelJobResponse {
+  writeJobCancelled(jobId, toolName, reason);
+  const aborted = abortJob(jobId, reason);
+  return {
     jobId,
     outcome: 'cancelled',
     status: 'cancelled',
-    message: `Job ${jobId} marked cancelled. In-flight work in the dispatching process aborts via AbortSignal; cross-process workers need to poll get_job_result to observe.`,
+    message:
+      `Job ${jobId} marked cancelled. ` +
+      (aborted
+        ? 'Its in-flight AbortSignal was fired — work that threads the signal stops in this process; '
+        : 'No in-flight controller was registered (the job already settled or runs in another process); ') +
+      'cross-process workers need to poll get_job_result to observe.',
   };
-  return Promise.resolve(toolSuccess(JSON.stringify(response, null, 2)));
 }
 
 /** @category MCP */


### PR DESCRIPTION
## What

The follow-on to #4017 — where I corrected the `cancel_job` docstring to admit it *didn't* stop work. This makes it actually true. The shared async-job path (`runAsJob`) had **no abort wiring**, so cancel only marked the durable record while the background work ran to completion (a cancelled, expensive job kept burning tokens). Now a per-job `AbortController` backs every dispatched job.

## Change

- **`job-abort-registry.ts`** (new): `Map<jobId, AbortController>` with `registerJobAbort` / `abortJob` / `unregisterJobAbort` / `jobAbortRegistrySize`.
- **`run-as-job.ts`**: `runJobInBackground` registers a controller, threads `controller.signal` into `params.run(jobId, input, signal)`, unregisters in `finally`. `RunAsJobParams.run` gained a 3rd `signal: AbortSignal` param — **backward compatible** (existing 2-arg callbacks ignore the trailing arg; verified across every caller).
- **`cancel-job-tool.ts`**: a `pending` cancel writes the `cancelled` record **first**, then `abortJob(jobId)`. The aborted `run()` rejects → `writeJobFailed` no-ops against the `cancelled` record (#4022 guard) → the cancellation wins. A tool that **ignores** the signal still completes, but its record stays `cancelled`.

So adopting the signal is per-tool and incremental; the dispatch infrastructure now makes cancellation *able* to stop work.

## Safety (adversarial review: **clean, no blockers**)

The reviewer verified: ordering is airtight (sync `writeJobCancelled`→`abortJob`, no await between; single-threaded), no registry leaks (`finally` always runs; double-delete idempotent), backward-compat across all `run:` callers, and no new unhandled rejection from the guard race.

## Tests

`job-abort-registry` unit tests + integration: **signal-respecting job stops + cancellation preserved**, **signal-ignoring job completes but cancelled record wins**, `abortJob` false on unknown/settled. 102 jobs/cancel tests green; tsc + lint clean. Minor changeset.

Closes #4086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)