### PR TITLE
feat(eval): offline meta-strategy accuracy eval — learned vs rules (#4095, epic #4094)

### DIFF
--- a/.changeset/meta-strategy-eval.md
+++ b/.changeset/meta-strategy-eval.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+Add an offline meta-strategy accuracy eval (#4095, epic #4094) — the first,
+deterministic increment of the audit→enforce evidence work. It produces the
+"learned vs rules" routing-accuracy number that the #3552 learned-selection
+enforce flip is blocked on, fully offline (no soak server, no cost-gated live
+run), and doubles as a routing-accuracy regression guard with standalone value.
+
+`evaluateMetaStrategy(corpus)` runs the rule MetaOrchestrator and a FRESH (never the
+process singleton) LinUCB learned selector over a labeled `goal→ExecutionStrategy`
+corpus using a stratified, deterministic train/test split: it trains the learned arm
+on synthesized oracle rewards over the train split, then scores both arms on the
+held-out test split. Ships with a 40-entry starter corpus (5/strategy, labeled by
+each strategy's documented purpose, blind to either arm) and a growth target toward
+≥80 for the readiness-gate volume.
+
+Honest first finding: on the starter corpus the learned arm sits near chance
+(rules ≈ 0.63, learned ≈ 0.13) — a contextual bandit over 8 strategies is badly
+under-trained at this volume, which is itself evidence pointing AWAY from the enforce
+flip. The training reward is a proxy for real run outcomes, so the learned number is
+directional; `rulesAccuracy` is the load-bearing regression-guard metric.

--- a/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
@@ -1,0 +1,144 @@
+/**
+ * nexus-agents/orchestration — labeled meta-strategy corpus (#4095, epic #4094).
+ *
+ * A `goal → expected ExecutionStrategy` oracle for the offline learned-vs-rules
+ * accuracy eval ({@link evaluateMetaStrategy}).
+ *
+ * LABELING PROTOCOL (reproducible; deliberately NOT tuned to favor either arm).
+ * Each goal is assigned the single ExecutionStrategy whose DOCUMENTED purpose (the
+ * JSDoc on `ExecutionStrategy` in meta-orchestrator.ts) best matches the goal's
+ * DOMINANT intent — judged from the goal text alone, BLIND to what the rule router
+ * or the learned selector would actually pick:
+ *  - `single-shot`     trivial single-step request (rename, explain, format, convert).
+ *  - `dev-pipeline`    a code change that should pass the test/lint/typecheck gate.
+ *  - `pipeline`        multi-stage templated work — an audit or general pipeline.
+ *  - `graph-workflow`  a DAG / conditional-edge workflow (branch, fan-in, gated steps).
+ *  - `orchestrate`     pattern-based MULTI-AGENT work (wave / fan-out / swarm).
+ *  - `consensus`       a multi-perspective DECISION reached by a vote/panel.
+ *  - `spec`            a greenfield build FROM A WRITTEN SPEC ("from scratch", "new … from this spec").
+ *  - `research`        research-heavy investigation / comparison / survey.
+ *
+ * Balanced 5 per strategy (40 total). GROWTH TARGET: expand toward ≥80 (≥10/strategy)
+ * so a 25% test split yields ≥20 held-out cases — the volume the #3552 readiness gate
+ * expects (improvement-enforce-readiness: volume≥20). This starter establishes the
+ * eval mechanism + the routing-accuracy regression guard.
+ *
+ * @module orchestration/meta-strategy-corpus
+ */
+
+import type { MetaStrategyCorpusEntry } from './meta-strategy-eval.js';
+
+export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
+  // single-shot — trivial single-step
+  { goal: 'rename the variable foo to bar in utils.ts', expectedStrategy: 'single-shot' },
+  { goal: 'what does the git rebase --onto flag do?', expectedStrategy: 'single-shot' },
+  { goal: 'format this JSON snippet', expectedStrategy: 'single-shot' },
+  { goal: 'add a one-line comment explaining this regex', expectedStrategy: 'single-shot' },
+  { goal: 'convert this value from Celsius to Fahrenheit', expectedStrategy: 'single-shot' },
+
+  // dev-pipeline — code change needing the test/lint/typecheck gate
+  {
+    goal: 'fix the off-by-one bug in pagination.ts and make sure the tests pass',
+    expectedStrategy: 'dev-pipeline',
+  },
+  {
+    goal: 'add input validation to the login handler with unit tests',
+    expectedStrategy: 'dev-pipeline',
+  },
+  { goal: 'refactor the auth module and run lint and typecheck', expectedStrategy: 'dev-pipeline' },
+  { goal: 'implement retry logic in the http client with tests', expectedStrategy: 'dev-pipeline' },
+  {
+    goal: 'patch the null-pointer in parser.ts and verify the build',
+    expectedStrategy: 'dev-pipeline',
+  },
+
+  // pipeline — multi-stage templated audit/general
+  { goal: 'run a security audit of the payments module', expectedStrategy: 'pipeline' },
+  { goal: 'do a full quality audit of the API layer', expectedStrategy: 'pipeline' },
+  { goal: 'produce an architecture review of the data pipeline', expectedStrategy: 'pipeline' },
+  { goal: 'run the documentation-quality audit over the docs tree', expectedStrategy: 'pipeline' },
+  { goal: 'perform a compliance audit of the logging subsystem', expectedStrategy: 'pipeline' },
+
+  // graph-workflow — DAG / conditional-edge
+  {
+    goal: 'build a conditional workflow that branches on the test result then deploys or rolls back',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'orchestrate a DAG fetch then transform then validate then load, halting at the validate gate on failure',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'create a multi-stage workflow with conditional edges depending on the lint outcome',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'wire a workflow where step C runs only if both A and B succeed',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'design a graph workflow with a fan-in join after three sequential gated branches',
+    expectedStrategy: 'graph-workflow',
+  },
+
+  // orchestrate — pattern-based multi-agent
+  {
+    goal: 'run a multi-agent wave over these modules to refactor them in parallel',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'fan out independent subtasks across the codebase to add logging',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'orchestrate a swarm of agents to triage the open issues',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'use a multi-agent pattern to migrate each service independently',
+    expectedStrategy: 'orchestrate',
+  },
+  { goal: 'dispatch a wave of agents to audit each microservice', expectedStrategy: 'orchestrate' },
+
+  // consensus — multi-perspective decision/vote
+  { goal: 'hold a consensus vote on whether to adopt GraphQL', expectedStrategy: 'consensus' },
+  { goal: 'we need a consensus decision on the database choice', expectedStrategy: 'consensus' },
+  {
+    goal: 'get multiple perspectives via a vote on the API redesign',
+    expectedStrategy: 'consensus',
+  },
+  {
+    goal: 'run a consensus panel on the proposed authentication change',
+    expectedStrategy: 'consensus',
+  },
+  {
+    goal: 'do a multi-perspective review and vote on the migration plan',
+    expectedStrategy: 'consensus',
+  },
+
+  // spec — greenfield from a written spec
+  { goal: 'build a greenfield todo app from this written spec', expectedStrategy: 'spec' },
+  {
+    goal: 'implement a new microservice from scratch per the attached spec document',
+    expectedStrategy: 'spec',
+  },
+  { goal: 'create a brand-new CLI tool from this specification', expectedStrategy: 'spec' },
+  { goal: 'scaffold a greenfield REST API from the provided spec', expectedStrategy: 'spec' },
+  {
+    goal: 'build the new notification service from scratch following the spec',
+    expectedStrategy: 'spec',
+  },
+
+  // research — research-heavy investigation
+  { goal: 'research the best vector database for our use case', expectedStrategy: 'research' },
+  { goal: 'investigate and compare OAuth libraries for Node', expectedStrategy: 'research' },
+  {
+    goal: 'do a deep research report on consensus algorithms for distributed systems',
+    expectedStrategy: 'research',
+  },
+  { goal: 'survey the landscape of LLM evaluation frameworks', expectedStrategy: 'research' },
+  {
+    goal: 'research which benchmarks are worth adopting for our agents',
+    expectedStrategy: 'research',
+  },
+];

--- a/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
@@ -26,6 +26,10 @@
  * @module orchestration/meta-strategy-corpus
  */
 
+// @export-no-consumer-yet — see #4095. The labeled corpus is consumed by the eval's
+// test now; its production consumer is epic #4094's child 2 (the readiness collector
+// over the shared corpus→score→verdict primitive).
+
 import type { MetaStrategyCorpusEntry } from './meta-strategy-eval.js';
 
 export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [

--- a/packages/nexus-agents/src/orchestration/meta-strategy-eval.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-eval.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the offline meta-strategy accuracy eval (#4095, epic #4094).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  evaluateMetaStrategy,
+  splitCorpus,
+  type MetaStrategyCorpusEntry,
+} from './meta-strategy-eval.js';
+import { META_STRATEGY_CORPUS } from './meta-strategy-corpus.js';
+
+describe('splitCorpus — stratified, deterministic (#4095)', () => {
+  it('covers every strategy in BOTH splits and is index-stable', () => {
+    const { train, test } = splitCorpus(META_STRATEGY_CORPUS, 0.25);
+    const trainStrats = new Set(train.map((e) => e.expectedStrategy));
+    const testStrats = new Set(test.map((e) => e.expectedStrategy));
+    const allStrats = new Set(META_STRATEGY_CORPUS.map((e) => e.expectedStrategy));
+    expect(trainStrats).toEqual(allStrats);
+    expect(testStrats).toEqual(allStrats);
+    expect(train.length + test.length).toBe(META_STRATEGY_CORPUS.length);
+    // Re-split → identical (no randomness).
+    const again = splitCorpus(META_STRATEGY_CORPUS, 0.25);
+    expect(again.train).toEqual(train);
+    expect(again.test).toEqual(test);
+  });
+});
+
+describe('evaluateMetaStrategy — offline learned-vs-rules accuracy (#4095)', () => {
+  it('is fully deterministic (same corpus → identical numbers)', () => {
+    const a = evaluateMetaStrategy(META_STRATEGY_CORPUS);
+    const b = evaluateMetaStrategy(META_STRATEGY_CORPUS);
+    expect(a).toEqual(b);
+  });
+
+  it('produces valid accuracy numbers over a held-out test split', () => {
+    const r = evaluateMetaStrategy(META_STRATEGY_CORPUS);
+    expect(r.total).toBe(META_STRATEGY_CORPUS.length);
+    expect(r.testCount).toBeGreaterThan(0);
+    expect(r.trainCount + r.testCount).toBe(r.total);
+    for (const acc of [r.rulesAccuracy, r.learnedAccuracy]) {
+      expect(acc).toBeGreaterThanOrEqual(0);
+      expect(acc).toBeLessThanOrEqual(1);
+    }
+    expect(r.delta).toBeCloseTo(r.learnedAccuracy - r.rulesAccuracy, 10);
+    // Surface the headline number (this is the #3552-blocked metric).
+    // eslint-disable-next-line no-console
+    console.log(
+      `[meta-strategy-eval #4095] rules=${r.rulesAccuracy.toFixed(2)} ` +
+        `learned=${r.learnedAccuracy.toFixed(2)} delta=${r.delta.toFixed(2)} (test n=${String(r.testCount)})`
+    );
+  });
+
+  it('REGRESSION GUARD: the rule router classifies a meaningful share of goals', () => {
+    // Routing-accuracy regression guard (the standalone value): a drop here means a
+    // routing change degraded auto-strategy selection. Floor set conservatively below
+    // the observed baseline; tighten as the corpus grows.
+    const r = evaluateMetaStrategy(META_STRATEGY_CORPUS);
+    expect(r.rulesAccuracy).toBeGreaterThanOrEqual(0.25);
+  });
+
+  it('handles an empty corpus without dividing by zero', () => {
+    const empty: MetaStrategyCorpusEntry[] = [];
+    const r = evaluateMetaStrategy(empty);
+    expect(r.rulesAccuracy).toBe(0);
+    expect(r.learnedAccuracy).toBe(0);
+    expect(r.testCount).toBe(0);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
@@ -37,6 +37,10 @@
  * @module orchestration/meta-strategy-eval
  */
 
+// @export-no-consumer-yet — see #4095. Consumed by its test (evals run in CI via
+// tests); the production consumer is epic #4094's child 2 — the extracted shared
+// labeled-corpus→score→readiness-verdict primitive that feeds the #3552 gate.
+
 import { createMetaOrchestrator, type ExecutionStrategy } from './meta-orchestrator.js';
 import { createLearnedStrategySelector } from './meta-shadow-selector.js';
 

--- a/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
@@ -1,0 +1,143 @@
+/**
+ * nexus-agents/orchestration — offline meta-strategy accuracy eval (#4095, epic #4094).
+ *
+ * Produces the "learned beats rules" number that the #3552 learned-selection
+ * audit→enforce flip is blocked on — fully OFFLINE and DETERMINISTIC, so it needs
+ * no persistent soak server and no cost-gated live run (the #3863 blocker). It also
+ * doubles as a routing-accuracy regression guard with standalone value.
+ *
+ * HOW IT STAYS DETERMINISTIC. The rule arm (`createMetaOrchestrator().select`) and
+ * the learned arm (`createLearnedStrategySelector` → a FRESH `LinUCBBandit`, whose
+ * `select`/`update` are pure UCB-argmax + matrix math, no RNG/clock) are both
+ * deterministic. We use a FRESH learned selector (never the `getShadowSelector()`
+ * process singleton, which carries accumulated state) and a stratified, index-based
+ * train/test split (no shuffling). Same corpus ⇒ identical numbers.
+ *
+ * THE LEARNED ARM NEEDS TRAINING. A cold bandit is uninformative, and its trained
+ * state is exactly the soak that can't accrue locally — so the eval trains it
+ * offline: for each TRAIN entry it records `recordOutcome(expectedStrategy, decision,
+ * success=true)` (the oracle label as a positive reward), then measures `predict`
+ * accuracy on the HELD-OUT test split vs the rule arm's accuracy on the same split.
+ *
+ * Built against the `pr-review-eval` store/scoring shape so epic #4094's child 2 can
+ * extract the shared `labeled-corpus → score → readiness-verdict` primitive.
+ *
+ * INTERPRETING THE RESULT (intellectual honesty, for the #3552 decision):
+ *  - The training reward is SYNTHESIZED from the oracle label (expected strategy =
+ *    success) — a proxy for the real shadow loop, which trains on ACTUAL run
+ *    outcomes. So `learnedAccuracy` is a DIRECTIONAL signal, not a production number.
+ *  - On the starter 32-example train set the learned arm sits near chance (~1/8 for
+ *    8 arms): a contextual bandit over 8 strategies is badly under-trained at that
+ *    volume. That is itself useful evidence — it points AWAY from the enforce flip
+ *    (do not enforce a selector that currently loses to rules), and it sharpens as
+ *    the corpus grows toward the readiness-gate volume.
+ *  - `rulesAccuracy` is the load-bearing standalone metric: a drop is a routing
+ *    regression. That is what the test's regression-guard floor protects.
+ *
+ * @module orchestration/meta-strategy-eval
+ */
+
+import { createMetaOrchestrator, type ExecutionStrategy } from './meta-orchestrator.js';
+import { createLearnedStrategySelector } from './meta-shadow-selector.js';
+
+/** One labeled corpus entry: a goal and the strategy its documented purpose best fits. */
+export interface MetaStrategyCorpusEntry {
+  readonly goal: string;
+  readonly expectedStrategy: ExecutionStrategy;
+}
+
+/** Per-arm accuracy over the held-out test split. */
+export interface MetaStrategyEvalResult {
+  readonly total: number;
+  readonly trainCount: number;
+  readonly testCount: number;
+  /** Fraction of the test split where the rule MetaOrchestrator picked the expected strategy. */
+  readonly rulesAccuracy: number;
+  /** Fraction of the test split where the trained learned selector picked it. */
+  readonly learnedAccuracy: number;
+  /** learnedAccuracy − rulesAccuracy (the "learned beats rules" delta; >0 favors learned). */
+  readonly delta: number;
+}
+
+export interface MetaStrategyEvalOptions {
+  /**
+   * Fraction (0,1) of EACH strategy's entries held out for test (stratified so both
+   * splits cover every strategy). Default 0.25. Deterministic: the first
+   * `ceil(n*(1-ratio))` entries of each strategy go to train, the rest to test.
+   */
+  readonly testRatio?: number;
+}
+
+/** Group corpus indices by expected strategy, preserving order. */
+function groupByStrategy(
+  corpus: readonly MetaStrategyCorpusEntry[]
+): Map<ExecutionStrategy, MetaStrategyCorpusEntry[]> {
+  const groups = new Map<ExecutionStrategy, MetaStrategyCorpusEntry[]>();
+  for (const entry of corpus) {
+    const list = groups.get(entry.expectedStrategy) ?? [];
+    list.push(entry);
+    groups.set(entry.expectedStrategy, list);
+  }
+  return groups;
+}
+
+/**
+ * Stratified, DETERMINISTIC train/test split: within each strategy the leading
+ * `(1-testRatio)` share is train, the trailing share is test. Both splits cover
+ * every strategy present, with no randomness.
+ */
+export function splitCorpus(
+  corpus: readonly MetaStrategyCorpusEntry[],
+  testRatio: number
+): { train: MetaStrategyCorpusEntry[]; test: MetaStrategyCorpusEntry[] } {
+  const train: MetaStrategyCorpusEntry[] = [];
+  const test: MetaStrategyCorpusEntry[] = [];
+  for (const entries of groupByStrategy(corpus).values()) {
+    const testN = Math.max(1, Math.round(entries.length * testRatio));
+    const trainN = Math.max(0, entries.length - testN);
+    train.push(...entries.slice(0, trainN));
+    test.push(...entries.slice(trainN));
+  }
+  return { train, test };
+}
+
+/**
+ * Run the offline learned-vs-rules accuracy eval over `corpus`. Deterministic.
+ */
+export function evaluateMetaStrategy(
+  corpus: readonly MetaStrategyCorpusEntry[],
+  options: MetaStrategyEvalOptions = {}
+): MetaStrategyEvalResult {
+  const testRatio = options.testRatio ?? 0.25;
+  const { train, test } = splitCorpus(corpus, testRatio);
+
+  const orchestrator = createMetaOrchestrator();
+  const learned = createLearnedStrategySelector();
+
+  // Train the learned arm: the oracle label is a positive reward for its context.
+  for (const entry of train) {
+    const decision = orchestrator.select({ goal: entry.goal });
+    learned.recordOutcome(entry.expectedStrategy, decision, true);
+  }
+
+  // Score both arms on the held-out test split.
+  let rulesCorrect = 0;
+  let learnedCorrect = 0;
+  for (const entry of test) {
+    const decision = orchestrator.select({ goal: entry.goal });
+    if (decision.strategy === entry.expectedStrategy) rulesCorrect++;
+    if (learned.predict(decision).strategy === entry.expectedStrategy) learnedCorrect++;
+  }
+
+  const testCount = test.length;
+  const rulesAccuracy = testCount === 0 ? 0 : rulesCorrect / testCount;
+  const learnedAccuracy = testCount === 0 ? 0 : learnedCorrect / testCount;
+  return {
+    total: corpus.length,
+    trainCount: train.length,
+    testCount,
+    rulesAccuracy,
+    learnedAccuracy,
+    delta: learnedAccuracy - rulesAccuracy,
+  };
+}


### PR DESCRIPTION
## What

Child 1 of the audit→enforce evidence epic (**#4094**) — the approved, **offline FIRST increment** (`higher_order` vote 7-0). It produces the "learned vs rules" routing-accuracy number that the **#3552** learned-selection enforce flip is blocked on, **fully offline** (no soak server, no cost-gated live run — the #3863 blocker), and doubles as a **routing-accuracy regression guard** (standalone value).

## How

- `evaluateMetaStrategy(corpus)` runs the **rule** MetaOrchestrator and a **fresh** LinUCB learned selector (`createLearnedStrategySelector` — *not* the process singleton, which carries state) over a labeled `goal→ExecutionStrategy` corpus.
- **Deterministic** stratified train/test split (no RNG; LinUCB `select`/`update` are pure UCB-argmax + matrix math — determinism condition discharged). Trains the learned arm on synthesized oracle rewards over the train split, scores both arms on the held-out test split.
- 40-entry starter corpus (5/strategy) with a **documented labeling protocol** (by each strategy's documented purpose, blind to either arm); growth target ≥80 for the readiness-gate volume.
- Built against the **`pr-review-eval` seams** so child 2 (#4096) can extract the shared `labeled-corpus → score → verdict` primitive.

## Honest first finding (the point of the eval)

`rules ≈ 0.63, learned ≈ 0.13` — the learned arm sits at ~chance (1/8 for 8 arms): a contextual bandit is **badly under-trained at 32 examples**. That's itself useful evidence — it points **AWAY from the enforce flip** (don't enforce a selector currently worse than rules), and sharpens as the corpus grows. The training reward is a **proxy** for real run outcomes, so the learned number is *directional*; `rulesAccuracy` is the load-bearing regression-guard metric (the test floors it at 0.25, well below the 0.63 baseline).

## Gates

57 orchestration tests green (incl. determinism, stratified-split, empty-corpus, regression-guard); tsc + lint clean. Minor changeset.

Closes #4095. Refs #4094, #3552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)