### PR TITLE
refactor(eval): extract the shared readiness-verdict envelope (#4096, epic #4094)

### DIFF
--- a/.changeset/readiness-verdict-envelope.md
+++ b/.changeset/readiness-verdict-envelope.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+Extract the shared readiness-verdict envelope (#4096, epic #4094). The two
+independent readiness evaluators — `codepr-enable-readiness` (the OFF→on enable gate)
+and `improvement-enforce-readiness` (the shadow→enforce promotion gate) — carried
+byte-identical copies of the `ReadinessCriterion` / verdict-envelope types. They now
+share one authoritative `readiness-verdict.ts` (`ReadinessCriterion`, `ReadinessVerdict`).
+
+Behavior-preserving and API-stable: each module re-exports the shared types under its
+historical names (`CodePrReadinessCriterion`/`CodePrEnableReadiness`,
+`EnforceReadinessReport`), and both keep their own `presenceCriterion` helper — the two
+copies emit deliberately different `detail` wording ("no {label}" vs "no named {label}"),
+a real domain difference that must NOT be unified. Only the envelope is shared.
+
+Scope is the envelope ONLY, by design: a survey of all four corpus→score→verdict sites
+(this pair plus pr-review-eval and the #4095 meta-strategy eval) confirmed their corpus
+types, score functions, evidence shapes, and gate configs diverge and stay per-consumer.
+The full labeled-corpus→score→verdict pipeline extraction is deferred until a third
+corpus-based gate demonstrates a unified shape.

--- a/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.ts
@@ -27,6 +27,8 @@
 
 import { z } from 'zod';
 
+import type { ReadinessCriterion, ReadinessVerdict } from './readiness-verdict.js';
+
 /**
  * Tuning for {@link evaluateCodePrEnableReadiness}. Conservative, fail-closed
  * defaults: enabling an autonomous push path is high-stakes, so the soak bar is
@@ -85,20 +87,18 @@ export const CodePrEnableReadinessEvidenceSchema = z
   .strict();
 export type CodePrEnableReadinessEvidence = z.infer<typeof CodePrEnableReadinessEvidenceSchema>;
 
-/** One checked condition of the enable gate. */
-export interface CodePrReadinessCriterion {
-  readonly name: string;
-  readonly met: boolean;
-  readonly detail: string;
-}
+/**
+ * One checked condition of the enable gate. Alias of the shared
+ * {@link ReadinessCriterion} envelope (#4096) — kept as a named re-export so existing
+ * consumers of this name are unaffected.
+ */
+export type CodePrReadinessCriterion = ReadinessCriterion;
 
-/** Full enable-readiness verdict. `ready` is true IFF every criterion is met. */
-export interface CodePrEnableReadiness {
-  readonly ready: boolean;
-  readonly criteria: readonly CodePrReadinessCriterion[];
-  /** Names of the unmet criteria (empty when ready). */
-  readonly blockers: readonly string[];
-}
+/**
+ * Full enable-readiness verdict. `ready` is true IFF every criterion is met. Alias of
+ * the shared {@link ReadinessVerdict} envelope (#4096).
+ */
+export type CodePrEnableReadiness = ReadinessVerdict;
 
 /** Build a "named X present" criterion, keeping the main fn flat. */
 function presenceCriterion(

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
@@ -27,6 +27,12 @@
  * @module mcp/tools/improvement-enforce-readiness
  */
 
+import type { ReadinessCriterion, ReadinessVerdict } from './readiness-verdict.js';
+
+// Re-export the shared envelope under this module's historical name so existing
+// consumers of `ReadinessCriterion` from here are unaffected (#4096).
+export type { ReadinessCriterion } from './readiness-verdict.js';
+
 /** Tuning for {@link evaluateEnforceReadiness}. */
 export interface EnforceReadinessConfig {
   /** Minimum shadow would-remediate decisions before enforce can be considered. */
@@ -64,20 +70,11 @@ export interface EnforceReadinessEvidence {
   readonly owner?: string;
 }
 
-/** One checked condition of the exit criterion. */
-export interface ReadinessCriterion {
-  readonly name: string;
-  readonly met: boolean;
-  readonly detail: string;
-}
-
-/** Full readiness verdict. `ready` is true iff every criterion is met. */
-export interface EnforceReadinessReport {
-  readonly ready: boolean;
-  readonly criteria: readonly ReadinessCriterion[];
-  /** Names of the unmet criteria (empty when ready). */
-  readonly blockers: readonly string[];
-}
+/**
+ * Full readiness verdict. `ready` is true iff every criterion is met. Alias of the
+ * shared {@link ReadinessVerdict} envelope (#4096).
+ */
+export type EnforceReadinessReport = ReadinessVerdict;
 
 function pct(n: number, d: number): number {
   return d === 0 ? 0 : n / d;

--- a/packages/nexus-agents/src/mcp/tools/readiness-verdict.ts
+++ b/packages/nexus-agents/src/mcp/tools/readiness-verdict.ts
@@ -1,0 +1,41 @@
+/**
+ * nexus-agents/mcp/tools — shared readiness-verdict envelope (#4096, epic #4094).
+ *
+ * The single authoritative shape for a multi-criterion "are we ready?" gate verdict.
+ * Two independent readiness evaluators were carrying byte-identical copies of these
+ * types — codepr-enable-readiness.ts (the OFF→on enable gate) and
+ * improvement-enforce-readiness.ts (the shadow→enforce promotion gate). This DRYs the
+ * envelope (the genuine shared shape) without forcing the evaluators to share anything
+ * that actually differs between them.
+ *
+ * SCOPE — DELIBERATELY THE ENVELOPE ONLY. A code survey of all four corpus→score→verdict
+ * sites (this pair plus pr-review-eval and the #4095 meta-strategy eval) confirmed the
+ * corpus types, score functions, evidence shapes, and gate configs DIVERGE and must stay
+ * per-consumer. Even the `presenceCriterion` helper is NOT shared: the two copies emit
+ * different `detail` wording ("no {label}" vs "no named {label}") — a real domain
+ * difference, so each evaluator keeps its own. Only the verdict envelope below is shared.
+ * The full "labeled-corpus → score → verdict pipeline" extraction is deferred until a
+ * third corpus-based gate demonstrates a unified shape (tracked separately under #4094).
+ *
+ * WARNING: do NOT route unrelated gates (code-quality, deploy-safety, …) through this
+ * type just because they also yield a boolean. It models a readiness gate whose verdict
+ * is "ready IFF every criterion is met". If your gate's verdict shape differs, define it
+ * independently rather than over-coupling here.
+ *
+ * @module mcp/tools/readiness-verdict
+ */
+
+/** One checked condition of a readiness gate. */
+export interface ReadinessCriterion {
+  readonly name: string;
+  readonly met: boolean;
+  readonly detail: string;
+}
+
+/** A multi-criterion readiness verdict. `ready` is true IFF every criterion is met. */
+export interface ReadinessVerdict {
+  readonly ready: boolean;
+  readonly criteria: readonly ReadinessCriterion[];
+  /** Names of the unmet criteria (empty when ready). */
+  readonly blockers: readonly string[];
+}


### PR DESCRIPTION
## What
Child 2 of epic #4094. DRY the byte-identical `ReadinessCriterion` / verdict-envelope types carried by **two** independent readiness evaluators — `codepr-enable-readiness` (OFF→on enable gate) and `improvement-enforce-readiness` (shadow→enforce promotion gate) — into one authoritative `mcp/tools/readiness-verdict.ts` (`ReadinessCriterion`, `ReadinessVerdict`).

## Scope re-cleared (the issue's gate)
#4096 explicitly said *"do NOT pre-design the abstraction — re-clear scope when child 1 (#4095) lands and the shape is confirmed."* #4095 landed (v2.145.0). A survey of all **four** corpus→score→verdict sites (this pair + pr-review-eval + the #4095 meta-strategy eval) found their corpus types, score fns, evidence shapes, and gate configs **diverge** — only the verdict **envelope** is genuinely shared. A 3-voter fan-out scope-clearance gate ratified the narrowed scope and **caught a trap**: the two `presenceCriterion` copies emit different `detail` wording (`no {label}` vs `no named {label}`), which the tests don't assert on — naive extraction would have **silently changed operator-visible output**. So `presenceCriterion` stays per-module; only the envelope is shared.

## Behavior-preserving + API-stable
- Each module re-exports the shared types under its historical names (`CodePrReadinessCriterion`/`CodePrEnableReadiness`, `EnforceReadinessReport`).
- Both keep their own `presenceCriterion` (the wording divergence is real domain semantics).
- **37 consumer tests pass unchanged**; `tsc --noEmit` clean; producer/consumer gate green.

## Deferred (tracked, not in this PR)
The full labeled-corpus→score→verdict **pipeline** extraction waits for a third corpus-based gate to demonstrate a unified shape — follow-up issue filed under epic #4094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)