### PR TITLE
feat(security): persist ClawGuard audit-mode violations to the durable sink (#4097, epic #4094)

### DIFF
--- a/.changeset/clawguard-audit-durable-sink.md
+++ b/.changeset/clawguard-audit-durable-sink.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+Persist ClawGuard AUDIT-mode violations to the durable audit sink (#4097, epic #4094,
+unblocks #2077). Previously, audit-mode access-policy violations were only logged
+ephemerally (`logger.warn`), so no false-positive rate was computable for the
+audit→enforce graduation decision. They are now ALSO mirrored to the shared,
+hash-chained durable store as a new canonical `clawguard_violation` audit event
+(queryable by `action: 'security.clawguard_violation'`).
+
+Safe by construction: the persist is best-effort and synchronous off the log-and-allow
+path — it never awaits, never throws (a sink failure is swallowed), and never alters the
+allow/deny decision (enforce-mode violations are blocked before this point, so wiring
+here cannot change enforcement). Only sanitized fields are stored (toolName, warning
+[capped], policySource, mode, requestId) — raw tool args are dropped. The durable trail
+is established via AsyncLocalStorage at the `withAccessPolicy` boundary in the orchestrate
+and execute_expert tools, ONLY when the server threaded an audit logger; the no-logger /
+pure-CLI path establishes no trail and stays byte-identical.
+
+Follow-up #4104 builds the false-positive-rate scorer + labeled corpus over the persisted
+violations.

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -330,6 +330,9 @@ function registerExecuteExpert(ctx: ToolRegistrationContext, shared: SharedResou
     rateLimiter: ctx.rateLimiterFactory.getForTool('execute_expert'),
     cliCache: getSharedCliCache(),
     ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
+    // #4097: thread the durable logger so ClawGuard AUDIT-mode violations during
+    // the expert's nested tool calls are persisted to the shared hash chain.
+    ...(ctx.auditLogger !== undefined && { auditLogger: ctx.auditLogger }),
   });
 }
 
@@ -436,6 +439,9 @@ function registerOrchestrateToolSafe(ctx: ToolRegistrationContext): void {
       security: ctx.securityConfig,
       // Wire model adapter for fallback orchestration path (Issue #827)
       modelAdapter: ctx.modelAdapter,
+      // #4097: thread the durable logger so ClawGuard AUDIT-mode violations
+      // during nested tool calls are persisted to the shared hash chain.
+      ...(ctx.auditLogger !== undefined && { auditLogger: ctx.auditLogger }),
     });
   } catch (error) {
     const message = getErrorMessage(error);

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -48,8 +48,14 @@ import { getOutcomeStore } from '../../orchestration/outcomes/outcome-store.js';
 import {
   deriveAccessPolicy,
   withAccessPolicy,
+  withAuditTrail,
   resolveAccessPolicyMode,
 } from '../../security/access-constraint-deriver/index.js';
+// Durable AUDIT-mode violation persistence (#4097). Establishes the audit
+// trail in ALS so the access-policy middleware can mirror log-and-allow
+// violations to the shared hash chain — ONLY when the server threaded a logger.
+import { createDurableAuditTrail } from '../../security/audit-bridge.js';
+import type { IAuditLogger } from '../../audit/audit-types.js';
 // Per-expert context-budget observer (#2031). Telemetry-only; never
 // influences the call. Emits `context_warning` when utilization crosses
 // threshold (default 85%, overridable via NEXUS_CONTEXT_WARN_THRESHOLD).
@@ -118,6 +124,12 @@ export type ExecuteExpertInput = z.infer<typeof ExecuteExpertInputSchema>;
 export interface ExecuteExpertDeps extends BaseMcpToolDeps {
   /** Registry of created experts (shared with create_expert) */
   expertRegistry: Map<string, Expert>;
+  /**
+   * Durable, hash-chained audit logger (#4097). When present, ClawGuard
+   * AUDIT-mode violations during the expert's nested tool calls are persisted
+   * to the shared store. Absent on the pure-CLI path → no trail established.
+   */
+  auditLogger?: IAuditLogger;
   /** Optional CLI detection cache for checking available CLIs (Issue #747) */
   cliCache?: ICliDetectionCache;
   /** MCP notifier for client-visible logging (Issue #974) */
@@ -569,6 +581,32 @@ async function classifyExpertResult(opts: ClassifyExpertResultOpts): Promise<Exp
   };
 }
 
+/**
+ * Derive the access policy (#1977) and run `expert.execute(task)` under it,
+ * establishing a durable audit trail in ALS when a logger was threaded so
+ * ClawGuard AUDIT-mode violations from the expert's nested tool calls are
+ * persisted to the shared hash chain (#4097). No trail → byte-identical path.
+ *
+ * execute-expert runs through MCP's native task handler (not the
+ * ContextAwareHandler chain), so HandlerContext / RequestContext isn't
+ * available here. The deriver gets `undefined` and defaults to trust tier '4'
+ * (untrusted). End-to-end trust-tier wiring is a follow-up (see #2993).
+ */
+async function executeExpertUnderPolicy(
+  deps: ExecuteExpertDeps,
+  expert: Expert,
+  task: Parameters<Expert['execute']>[0],
+  policyObjective: string
+): Promise<Awaited<ReturnType<Expert['execute']>>> {
+  const policy = await deriveExpertAccessPolicy(policyObjective, deps.logger, undefined);
+  const auditTrail = createDurableAuditTrail(deps.auditLogger);
+  const runExpert = (): ReturnType<Expert['execute']> => expert.execute(task);
+  return withAccessPolicy(
+    policy,
+    auditTrail !== undefined ? () => withAuditTrail(auditTrail, runExpert) : runExpert
+  );
+}
+
 /** Runs the expert task and records outcomes. Assumes permit is held. */
 async function runExpertTask(
   deps: ExecuteExpertDeps,
@@ -606,14 +644,7 @@ async function runExpertTask(
 
       let result;
       try {
-        // execute-expert runs through MCP's native task handler (not the
-        // ContextAwareHandler chain), so HandlerContext / RequestContext
-        // isn't directly available here. Pass undefined so the deriver
-        // defaults to '4' (untrusted). Proper end-to-end trust-tier
-        // wiring for execute-expert is filed as a follow-up — see #2993
-        // (multi-file half) and the new follow-up issue.
-        const policy = await deriveExpertAccessPolicy(policyObjective, deps.logger, undefined);
-        result = await withAccessPolicy(policy, () => expert.execute(task));
+        result = await executeExpertUnderPolicy(deps, expert, task, policyObjective);
       } finally {
         clearInterval(heartbeatTimer);
         monitor.endSession(sessionId);

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -174,6 +174,12 @@ export interface OrchestrateDeps extends BaseMcpToolDeps {
   modelAdapter?: import('../../core/index.js').IModelAdapter | undefined;
   /** MCP notifier for client-visible logging (Issue #974) */
   notifier?: IMcpNotifier | undefined;
+  /**
+   * Durable, hash-chained audit logger (#4097). When present, ClawGuard
+   * AUDIT-mode violations during the orchestrator's nested tool calls are
+   * persisted to the shared store. Absent on the pure-CLI path → no trail.
+   */
+  auditLogger?: import('../../audit/audit-types.js').IAuditLogger;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -88,8 +88,14 @@ import {
 import {
   deriveAccessPolicy,
   withAccessPolicy,
+  withAuditTrail,
   resolveAccessPolicyMode,
 } from '../../security/access-constraint-deriver/index.js';
+// Durable AUDIT-mode violation persistence (#4097). Establishes the audit
+// trail in ALS so the access-policy middleware can mirror log-and-allow
+// violations from the orchestrator's nested tool calls to the hash chain.
+import { createDurableAuditTrail } from '../../security/audit-bridge.js';
+import type { AuditTrail } from '../../security/audit-trail.js';
 // Structured task state (#2033, integration from #2043). Enabled by
 // default from v2.50+; set NEXUS_TASK_STATE_ENABLED=0 to opt out.
 // When disabled, helpers no-op silently.
@@ -665,6 +671,9 @@ async function executeOrchestration(
   const definition: OrchestratorDefinition = { type: 'task', task };
   const hb = startHeartbeatTracking(`orchestrate-${taskId}`, logger);
   const policy = await deriveOrchestratePolicy(input.task, deps, logger, trustTier);
+  // #4097: build the durable trail here (deps in scope); undefined on the
+  // no-logger path so that path establishes no trail and stays byte-identical.
+  const auditTrail = createDurableAuditTrail(deps.auditLogger);
   try {
     return await runOrchestratorWithStateTracking({
       taskId,
@@ -676,6 +685,7 @@ async function executeOrchestration(
       workflowRouter,
       startTime,
       logger,
+      ...(auditTrail !== undefined ? { auditTrail } : {}),
     });
   } catch (error) {
     recordTaskStateBlocker(taskId, error instanceof Error ? error.message : String(error), logger);
@@ -700,10 +710,17 @@ async function runOrchestratorWithStateTracking(params: {
   readonly workflowRouter: IWorkflowRouter;
   readonly startTime: number;
   readonly logger: ILogger;
+  /** Durable audit trail for ClawGuard AUDIT-mode violations (#4097). */
+  readonly auditTrail?: AuditTrail;
 }): Promise<Result<OrchestrateOutput, OrchestrationError>> {
-  const { taskId, taskInput, definition, orchestrator, policy, logger } = params;
+  const { taskId, taskInput, definition, orchestrator, policy, logger, auditTrail } = params;
   recordTaskStateStage(taskId, 'executing', logger);
-  const result = await withAccessPolicy(policy, () => orchestrator.execute(definition, {}));
+  const runOrchestrator = (): ReturnType<typeof orchestrator.execute> =>
+    orchestrator.execute(definition, {});
+  const result = await withAccessPolicy(
+    policy,
+    auditTrail !== undefined ? () => withAuditTrail(auditTrail, runOrchestrator) : runOrchestrator
+  );
   if (!result.ok) {
     recordTaskStateBlocker(taskId, result.error.message, logger);
     // #3091: see executeOrchestration — terminal failure stage is 'failed'.

--- a/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
@@ -14,7 +14,7 @@
  */
 
 import { checkAccess } from './enforcer.js';
-import { denyToToolResult, getActivePolicy } from './mcp-guard.js';
+import { denyToToolResult, getActivePolicy, recordAuditModeViolation } from './mcp-guard.js';
 import type { GuardArgs } from './mcp-guard.js';
 // Type-only import: no runtime cycle with mcp/middleware/middleware-chain.ts.
 import type { Middleware } from '../../mcp/middleware/middleware-chain.js';
@@ -48,6 +48,13 @@ export function createAccessPolicyChainMiddleware(toolName: string): Middleware 
         tool: toolName,
         warning: decision.warning,
         policySource: policy.source,
+        requestId: ctx.requestContext.requestId,
+      });
+      recordAuditModeViolation({
+        toolName,
+        warning: decision.warning,
+        policySource: policy.source,
+        mode: policy.mode,
         requestId: ctx.requestContext.requestId,
       });
       return next(args, ctx);

--- a/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
@@ -24,6 +24,9 @@ export {
   guardMcpToolCall,
   denyToToolResult,
   createAccessPolicyMiddleware,
+  withAuditTrail,
+  getActiveAuditTrail,
+  recordAuditModeViolation,
 } from './mcp-guard.js';
 export type { GuardArgs } from './mcp-guard.js';
 export { createAccessPolicyChainMiddleware } from './chain-adapter.js';

--- a/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.test.ts
@@ -16,11 +16,16 @@ import {
   denyToToolResult,
   deriveAccessPolicy,
   getActivePolicy,
+  getActiveAuditTrail,
   guardMcpToolCall,
+  recordAuditModeViolation,
   resetPolicyCache,
   withAccessPolicy,
+  withAuditTrail,
 } from './index.js';
 import type { TaskAccessPolicy } from './types.js';
+import { AuditTrail, createAuditTrail } from '../audit-trail.js';
+import type { AuditEvent } from '../audit-trail.js';
 
 function policyFactory(overrides: Partial<TaskAccessPolicy> = {}): TaskAccessPolicy {
   return {
@@ -241,6 +246,97 @@ describe('createAccessPolicyMiddleware', () => {
     )) as { isError?: boolean };
     expect(next).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
+  });
+});
+
+describe('recordAuditModeViolation (#4097)', () => {
+  const sample = {
+    toolName: 'write_file',
+    warning: 'tool not in allowlist',
+    policySource: 'llm',
+    mode: 'audit',
+    requestId: 'req-1',
+  };
+
+  it('no-ops when no trail is established in ALS', () => {
+    expect(getActiveAuditTrail()).toBeUndefined();
+    // No throw and nothing to mirror — the no-logger path stays inert.
+    expect(() => {
+      recordAuditModeViolation(sample);
+    }).not.toThrow();
+  });
+
+  it('emits exactly one clawguard_violation within withAuditTrail', async () => {
+    const mirrored: AuditEvent[] = [];
+    const trail = createAuditTrail((e) => mirrored.push(e));
+    await withAuditTrail(trail, () => {
+      recordAuditModeViolation(sample);
+      return Promise.resolve();
+    });
+    expect(trail.query({ type: 'clawguard_violation' })).toHaveLength(1);
+    expect(mirrored).toHaveLength(1);
+    expect(mirrored[0]?.type).toBe('clawguard_violation');
+  });
+
+  it('caps the persisted warning at 500 chars', async () => {
+    const trail = createAuditTrail();
+    await withAuditTrail(trail, () => {
+      recordAuditModeViolation({ ...sample, warning: 'x'.repeat(1000) });
+      return Promise.resolve();
+    });
+    const ev = trail.query({ type: 'clawguard_violation' })[0];
+    if (ev?.type === 'clawguard_violation') {
+      expect(ev.warning).toHaveLength(500);
+    }
+  });
+
+  it('never throws even when the trail append throws', async () => {
+    const throwingTrail = {
+      append: () => {
+        throw new Error('sink exploded');
+      },
+    } as unknown as AuditTrail;
+    await withAuditTrail(throwingTrail, () => {
+      expect(() => {
+        recordAuditModeViolation(sample);
+      }).not.toThrow();
+      return Promise.resolve();
+    });
+  });
+});
+
+describe('log-and-allow regression: audit mode always ALLOWS (#4097)', () => {
+  function makeCtx(): { readonly requestContext: { readonly requestId: string } } {
+    return { requestContext: { requestId: 'req_reg' } };
+  }
+  const logger = { warn: vi.fn(), info: vi.fn() };
+  const auditPolicy = policyFactory({
+    allowedTools: ['gh_issue_view'],
+    mode: 'audit',
+    source: 'llm',
+  });
+
+  it('returns next() result with no trail present', async () => {
+    const mw = createAccessPolicyMiddleware({ toolName: 'gh_issue_close', logger });
+    const next = vi.fn(() => Promise.resolve({ ok: true }));
+    const result = await withAccessPolicy(auditPolicy, () => mw({}, makeCtx(), next as never));
+    expect(next).toHaveBeenCalledOnce();
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns next() result and does not throw when emit fails', async () => {
+    const throwingTrail = {
+      append: () => {
+        throw new Error('sink exploded');
+      },
+    } as unknown as AuditTrail;
+    const mw = createAccessPolicyMiddleware({ toolName: 'gh_issue_close', logger });
+    const next = vi.fn(() => Promise.resolve({ ok: true }));
+    const result = await withAccessPolicy(auditPolicy, () =>
+      withAuditTrail(throwingTrail, () => mw({}, makeCtx(), next as never))
+    );
+    expect(next).toHaveBeenCalledOnce();
+    expect(result).toEqual({ ok: true });
   });
 });
 

--- a/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.ts
@@ -22,9 +22,67 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { checkAccess } from './enforcer.js';
 import type { AccessDecision, TaskAccessPolicy } from './types.js';
+import { emitClawGuardViolation, type AuditTrail } from '../audit-trail.js';
 
 /** AsyncLocalStorage holding the active task's access policy. */
 const accessPolicyStorage = new AsyncLocalStorage<TaskAccessPolicy>();
+
+/**
+ * AsyncLocalStorage holding the active durable {@link AuditTrail} (#4097).
+ * Established by orchestrators (orchestrate / execute_expert) alongside
+ * `withAccessPolicy` ONLY when the server threaded an `auditLogger`. When
+ * absent, {@link recordAuditModeViolation} is a no-op, so the no-logger path
+ * stays byte-identical.
+ */
+const auditTrailStorage = new AsyncLocalStorage<AuditTrail>();
+
+/** Max persisted warning length (#4097) — caps unbounded decision text. */
+const MAX_WARNING_LEN = 500;
+
+/**
+ * Run `fn` with `trail` available to any nested MCP tool dispatch, so the
+ * access-policy middleware can persist AUDIT-mode violations to the durable
+ * sink. Mirrors {@link withAccessPolicy}.
+ */
+export function withAuditTrail<T>(trail: AuditTrail, fn: () => Promise<T>): Promise<T> {
+  return auditTrailStorage.run(trail, fn);
+}
+
+/**
+ * Returns the active durable audit trail, or undefined when no wrapping
+ * `withAuditTrail` is in scope (the pure-CLI / no-logger path). Mirrors
+ * {@link getActivePolicy}.
+ */
+export function getActiveAuditTrail(): AuditTrail | undefined {
+  return auditTrailStorage.getStore();
+}
+
+/**
+ * Best-effort persist of a ClawGuard AUDIT-mode violation (#4097). Reads the
+ * active trail from ALS; no-ops when none is established. NEVER throws — a sink
+ * failure must never break the log-and-allow path that ALLOWS the call.
+ */
+export function recordAuditModeViolation(input: {
+  readonly toolName: string;
+  readonly warning: string;
+  readonly policySource: string;
+  readonly mode: string;
+  readonly requestId: string;
+}): void {
+  const trail = getActiveAuditTrail();
+  if (trail === undefined) return;
+  try {
+    emitClawGuardViolation(trail, {
+      toolName: input.toolName,
+      warning: input.warning.slice(0, MAX_WARNING_LEN),
+      policySource: input.policySource,
+      mode: input.mode,
+      requestId: input.requestId,
+    });
+  } catch {
+    /* never break log-and-allow (#4097) */
+  }
+}
 
 /**
  * Run `fn` with `policy` available to any nested MCP tool dispatch.
@@ -132,6 +190,13 @@ export function createAccessPolicyMiddleware(config: {
         tool: config.toolName,
         warning: decision.warning,
         policySource: policy.source,
+        requestId: ctx.requestContext.requestId,
+      });
+      recordAuditModeViolation({
+        toolName: config.toolName,
+        warning: decision.warning,
+        policySource: policy.source,
+        mode: policy.mode,
         requestId: ctx.requestContext.requestId,
       });
       return next(args, ctx);

--- a/packages/nexus-agents/src/security/audit-bridge.test.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.test.ts
@@ -65,6 +65,16 @@ const samples: Record<SecurityAuditEvent['type'], SecurityAuditEvent> = {
     stepNumber: 3,
     detail: 'executing node n1',
   },
+  clawguard_violation: {
+    ...base,
+    component: 'clawguard-audit',
+    type: 'clawguard_violation',
+    toolName: 'write_file',
+    warning: 'tool write_file not in derived allowlist',
+    policySource: 'llm',
+    mode: 'audit',
+    requestId: 'req-42',
+  },
 };
 
 describe('securityAuditEventToInput (#3291)', () => {
@@ -115,6 +125,24 @@ describe('securityAuditEventToInput (#3291)', () => {
     expect(input.metadata?.['actionType']).toBe('GeneratePatchPlan');
     expect(input.metadata && 'mode' in input.metadata).toBe(false);
     expect(input.metadata && 'stageType' in input.metadata).toBe(false);
+  });
+
+  it('maps a clawguard_violation to a success-outcome warning with the metadata (#4097)', () => {
+    const input = securityAuditEventToInput(samples.clawguard_violation);
+    expect(input.action).toBe('security.clawguard_violation');
+    // Audit mode ALLOWED the call → success, not denied; flagged as a warning.
+    expect(input.outcome).toBe('success');
+    expect(input.severity).toBe('warning');
+    expect(input.category).toBe('authorization');
+    expect(input.actor).toMatchObject({ type: 'system', id: 'clawguard-audit' });
+    expect(input.metadata).toMatchObject({
+      toolName: 'write_file',
+      warning: 'tool write_file not in derived allowlist',
+      policySource: 'llm',
+      mode: 'audit',
+      requestId: 'req-42',
+    });
+    expect(AuditEventInputSchema.safeParse(input).success).toBe(true);
   });
 
   it('flags a downgraded trust classification as a warning', () => {

--- a/packages/nexus-agents/src/security/audit-bridge.ts
+++ b/packages/nexus-agents/src/security/audit-bridge.ts
@@ -18,7 +18,12 @@
  */
 
 import { createLogger, getErrorMessage } from '../core/index.js';
-import type { AuditEvent as SecurityAuditEvent, DurableAuditSink } from './audit-trail.js';
+import { createAuditTrail } from './audit-trail.js';
+import type {
+  AuditEvent as SecurityAuditEvent,
+  AuditTrail,
+  DurableAuditSink,
+} from './audit-trail.js';
 import type {
   AuditEventInput,
   AuditActor,
@@ -43,6 +48,7 @@ type CorroborationEvt = Extract<SecurityAuditEvent, { type: 'corroboration' }>;
 type ReputationEvt = Extract<SecurityAuditEvent, { type: 'reputation' }>;
 type SanitizationEvt = Extract<SecurityAuditEvent, { type: 'sanitization' }>;
 type GraphEvt = Extract<SecurityAuditEvent, { type: 'graph_execution' }>;
+type ClawGuardEvt = Extract<SecurityAuditEvent, { type: 'clawguard_violation' }>;
 
 function mapTrust(e: TrustEvent): AuditEventInput {
   const severity: AuditSeverity = e.wasDowngraded ? 'warning' : 'info';
@@ -171,6 +177,29 @@ function mapGraphExecution(e: GraphEvt): AuditEventInput {
 }
 
 /**
+ * Map a ClawGuard AUDIT-mode violation (#4097) to a durable event. `outcome` is
+ * `success` because audit mode ALLOWED the call (it is log-and-allow, not a
+ * denial); `severity` is `warning` to flag the policy violation. Queryable by
+ * `action: 'security.clawguard_violation'`.
+ */
+function mapClawGuard(e: ClawGuardEvt): AuditEventInput {
+  return {
+    category: 'authorization',
+    severity: 'warning',
+    outcome: 'success',
+    action: 'security.clawguard_violation',
+    actor: systemActor(e.component),
+    metadata: {
+      toolName: e.toolName,
+      warning: e.warning,
+      policySource: e.policySource,
+      mode: e.mode,
+      requestId: e.requestId,
+    },
+  };
+}
+
+/**
  * Map a security `AuditEvent` (discriminated union) to a durable
  * `AuditEventInput`. Pure — no side effects. The durable logger assigns
  * id/timestamp/hash, so those are omitted here.
@@ -189,6 +218,8 @@ export function securityAuditEventToInput(event: SecurityAuditEvent): AuditEvent
       return mapSanitization(event);
     case 'graph_execution':
       return mapGraphExecution(event);
+    case 'clawguard_violation':
+      return mapClawGuard(event);
   }
 }
 
@@ -208,4 +239,17 @@ export function createDurableAuditSink(auditLogger: IAuditLogger): DurableAuditS
       });
     }
   };
+}
+
+/**
+ * Wrap an optional `auditLogger` into a durable {@link AuditTrail} (#4097) — the
+ * single representation of "mirror security events to the shared hash chain when
+ * a logger is threaded." Returns undefined when none is present, so the no-logger
+ * path establishes NO trail and stays byte-identical (mirrors the dev-pipeline
+ * `buildPolicyAuditTrail` guard). Consumers wrap execution in `withAuditTrail`
+ * ONLY when this returns a trail.
+ */
+export function createDurableAuditTrail(auditLogger?: IAuditLogger): AuditTrail | undefined {
+  if (auditLogger === undefined) return undefined;
+  return createAuditTrail(createDurableAuditSink(auditLogger));
 }

--- a/packages/nexus-agents/src/security/audit-trail.test.ts
+++ b/packages/nexus-agents/src/security/audit-trail.test.ts
@@ -14,8 +14,10 @@ import {
   emitReputationEvent,
   emitSanitizationEvent,
   emitGraphExecutionEvent,
+  emitClawGuardViolation,
   createGraphAuditBridge,
 } from './audit-trail.js';
+import type { AuditEvent } from './audit-trail.js';
 
 describe('AuditTrail', () => {
   let trail: AuditTrail;
@@ -399,6 +401,41 @@ describe('AuditTrail', () => {
 
       const events = trail.query({ type: 'graph_execution' });
       expect(events.length).toBeGreaterThanOrEqual(3); // started, completed, step_completed, execution_complete
+    });
+  });
+
+  describe('emitClawGuardViolation (#4097)', () => {
+    it('appends a clawguard_violation event with the canonical component', () => {
+      emitClawGuardViolation(trail, {
+        toolName: 'write_file',
+        warning: 'tool not in allowlist',
+        policySource: 'llm',
+        mode: 'audit',
+        requestId: 'req-1',
+      });
+      const events = trail.query({ type: 'clawguard_violation' });
+      expect(events).toHaveLength(1);
+      const ev = events[0];
+      if (ev?.type === 'clawguard_violation') {
+        expect(ev.component).toBe('clawguard-audit');
+        expect(ev.toolName).toBe('write_file');
+        expect(ev.mode).toBe('audit');
+        expect(ev.requestId).toBe('req-1');
+      }
+    });
+
+    it('mirrors the violation through a durable sink', () => {
+      const mirrored: AuditEvent[] = [];
+      const sinkTrail = createAuditTrail((e) => mirrored.push(e));
+      emitClawGuardViolation(sinkTrail, {
+        toolName: 'run_shell',
+        warning: 'execute not permitted',
+        policySource: 'fallback-keyword',
+        mode: 'audit',
+        requestId: 'req-2',
+      });
+      expect(mirrored).toHaveLength(1);
+      expect(mirrored[0]?.type).toBe('clawguard_violation');
     });
   });
 });

--- a/packages/nexus-agents/src/security/audit-trail.ts
+++ b/packages/nexus-agents/src/security/audit-trail.ts
@@ -33,7 +33,8 @@ export type AuditEvent =
   | CorroborationEvent
   | ReputationEvent
   | SanitizationEvent
-  | GraphExecutionAuditEvent;
+  | GraphExecutionAuditEvent
+  | ClawGuardViolationEvent;
 
 /** Base fields shared by all audit events. */
 interface AuditEventBase {
@@ -137,6 +138,27 @@ export interface SanitizationEvent extends AuditEventBase {
    * Untrusted Input Policy: "Log stripped elements for audit trail."
    */
   readonly strippedElements: readonly StrippedElementSummary[];
+}
+
+/**
+ * ClawGuard AUDIT-mode violation (#4097). Records a tool call that VIOLATED the
+ * derived access policy but was ALLOWED to proceed because the policy is in
+ * `audit` mode (log-and-allow). Persisting these is what lets the audit→enforce
+ * graduation loop size the real violation rate from durable telemetry rather
+ * than ephemeral logs.
+ */
+export interface ClawGuardViolationEvent extends AuditEventBase {
+  readonly type: 'clawguard_violation';
+  /** The tool whose call violated the policy. */
+  readonly toolName: string;
+  /** Human-readable warning from the access decision (may be truncated). */
+  readonly warning: string;
+  /** Source of the derived policy (`llm` / `fallback-keyword` / `bypass`). */
+  readonly policySource: string;
+  /** Policy mode under which the violation was allowed (e.g. `audit`). */
+  readonly mode: string;
+  /** Request ID of the offending tool call, for correlation. */
+  readonly requestId: string;
 }
 
 /** Graph execution lifecycle event (Issue #839). */
@@ -462,6 +484,22 @@ export function emitGraphExecutionEvent(
   return trail.append({
     type: 'graph_execution',
     component: 'graph-executor',
+    ...data,
+  });
+}
+
+/**
+ * Records a ClawGuard AUDIT-mode violation (#4097) — a policy-violating tool
+ * call that was log-and-allowed because the policy is in `audit` mode. ONE
+ * append per call; mirrors to the durable sink when the trail is wired.
+ */
+export function emitClawGuardViolation(
+  trail: AuditTrail,
+  data: Omit<ClawGuardViolationEvent, 'id' | 'timestamp' | 'type' | 'component'>
+): string {
+  return trail.append({
+    type: 'clawguard_violation',
+    component: 'clawguard-audit',
     ...data,
   });
 }


### PR DESCRIPTION
## What
Child 3 of epic #4094 (PART 1). ClawGuard **audit-mode** access-policy violations were logged only ephemerally (`logger.warn`), so no false-positive rate was computable for the **#2077 audit→enforce** decision. They are now ALSO mirrored to the shared, hash-chained durable store as a new canonical `clawguard_violation` audit event (queryable by `action: 'security.clawguard_violation'`).

## Safe by construction (the gate's must-not-break conditions)
- **Never blocks the hot path** — the persist is best-effort + synchronous off the log-and-allow path: never `await`s, never throws (the sink swallows its own failures, and the emit is `try/catch`-wrapped), and never changes the allow/deny decision. Enforce-mode violations are blocked *before* this site, so wiring here cannot alter enforcement.
- **Untrusted input** — only sanitized fields are persisted (`toolName`, `warning` [capped 500], `policySource`, `mode`, `requestId`); **raw tool args are dropped**.
- **AsyncLocalStorage** wiring (mirrors the existing `accessPolicyStorage`), established at the `withAccessPolicy` boundary in `orchestrate` + `execute_expert` — **only** when the server threaded an `auditLogger`. No logger → no trail → byte-identical pure-CLI path.
- **Canonical** — extends the existing `AuditEvent` union + `securityAuditEventToInput` switch (no parallel type).

## Process
Scope re-cleared by a 3-voter fan-out gate (security / architecture / split-YAGNI lenses, each verifying against real code), per the issue's "re-clear scope + kill option." Implementation diff-reviewed against every gate condition. **PART 2** (FP-rate scorer + labeled corpus over the persisted violations) split to #4104.

## Verification
`tsc --noEmit` clean · **150 tests pass** across the 6 touched suites (audit-trail, audit-bridge, mcp-guard, chain-adapter, orchestrate, execute-expert) · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)