### PR TITLE
feat(eval): surface remediation enforce-readiness verdict + harmful-rate (#4098, epic #4094)

### DIFF
--- a/.changeset/remediation-enforce-readiness-report.md
+++ b/.changeset/remediation-enforce-readiness-report.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': minor
+---
+
+Add `remediation-review readiness` — surfaces the remediation enforce-readiness verdict + per-criterion rates + harmful-rate (#4098, epic #4094), reusing the exact evidence path the #3769 enforce gate consumes (no new corpus). Read-only; never flips enforcement.

--- a/packages/nexus-agents/src/cli-command-catalog.ts
+++ b/packages/nexus-agents/src/cli-command-catalog.ts
@@ -219,7 +219,7 @@ export const COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
   {
     command: 'remediation-review',
     description:
-      'Soundness-review audit-mode selections (#3765): list pending · mark --evaluator --sound|--unsound · sign-off --owner.',
+      'Soundness-review audit-mode selections (#3765): list pending · mark --evaluator --sound|--unsound · sign-off --owner · readiness (enforce-readiness verdict + harmful-rate).',
     audience: 'maintainer',
   },
 

--- a/packages/nexus-agents/src/cli/remediation-review-command.test.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.test.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 
-import { handleRemediationReviewCommand } from './remediation-review-command.js';
+import { handleRemediationReviewCommand, harmfulRate } from './remediation-review-command.js';
 import type { ParsedCliArgs } from '../cli-types.js';
 import {
   createRemediationSoakSink,
@@ -23,6 +23,7 @@ import {
   getRemediationReviewFile,
   _resetRemediationReviewStoreForTests,
   soakRefOf,
+  type ReviewRecord,
 } from '../mcp/tools/remediation-review.js';
 
 function args(
@@ -153,5 +154,81 @@ describe('handleRemediationReviewCommand', () => {
     out.mockClear();
     await handleRemediationReviewCommand(args('list'));
     expect(output()).toContain('0 pending');
+  });
+
+  it('readiness: NOT READY (text) with no review data — fail-closed, harmful-rate line present', async () => {
+    seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(args('readiness'));
+    const text = output();
+    expect(text).toContain('Enforcement readiness: NOT READY');
+    expect(text).toContain('harmful-rate');
+    expect(text).toMatch(/Blockers:/);
+  });
+
+  it('readiness --format json: ready=false + numeric harmfulRate with no review data', async () => {
+    seedSoak();
+    _resetRemediationSoakSinkForTests();
+    await handleRemediationReviewCommand(args('readiness', { format: 'json' }));
+    const parsed = JSON.parse(output()) as {
+      ready: boolean;
+      harmfulRate: number;
+      evidence: { judgedSelections: number; judgedSound: number };
+      blockers: string[];
+    };
+    expect(parsed.ready).toBe(false);
+    expect(typeof parsed.harmfulRate).toBe('number');
+    expect(parsed.harmfulRate).toBe(0); // judgedSelections=0 → 0
+    expect(parsed.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('readiness: READY when volume + judged + sound + evaluator + owner all met', async () => {
+    const sink = createRemediationSoakSink(getRemediationSoakFile());
+    const reviewStore = createRemediationReviewStore(getRemediationReviewFile());
+    const refs: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      const rec: RemediationSoakRecord = {
+        timestamp: `2026-06-08T00:00:${String(i).padStart(2, '0')}.000Z`,
+        signalKey: 'routing:floor:codex',
+        category: 'routing',
+        priority: 'p2',
+        severity: 'warning',
+        planStepCount: 3,
+        reason: 'plan produced',
+      };
+      sink.record(rec);
+      refs.push(soakRefOf(rec));
+    }
+    // Review 18/20 (≥80% judged), all sound (100% ≥ 90%), named evaluator + owner.
+    for (const ref of refs.slice(0, 18)) {
+      const review: ReviewRecord = {
+        soakRef: ref,
+        reviewedAt: '2026-06-09T00:00:00.000Z',
+        reviewed: true,
+        sound: true,
+        evaluator: 'alice',
+        owner: 'carol',
+      };
+      reviewStore.record(review);
+    }
+    _resetRemediationSoakSinkForTests();
+    _resetRemediationReviewStoreForTests();
+    await handleRemediationReviewCommand(args('readiness', { format: 'json' }));
+    const parsed = JSON.parse(output()) as { ready: boolean; harmfulRate: number };
+    expect(parsed.ready).toBe(true);
+    expect(parsed.harmfulRate).toBeLessThanOrEqual(0.1);
+    expect(parsed.harmfulRate).toBe(0);
+  });
+});
+
+describe('harmfulRate', () => {
+  it('returns 0 when nothing judged', () => {
+    expect(harmfulRate({ shadowSelections: 5, judgedSelections: 0, judgedSound: 0 })).toBe(0);
+  });
+
+  it('is 1 − soundnessRate over judged selections (10 judged, 8 sound → 0.2)', () => {
+    expect(harmfulRate({ shadowSelections: 10, judgedSelections: 10, judgedSound: 8 })).toBeCloseTo(
+      0.2
+    );
   });
 });

--- a/packages/nexus-agents/src/cli/remediation-review-command.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.ts
@@ -13,6 +13,7 @@
  *   mark <soakRef> --evaluator <name> (--sound | --unsound) [--note <text>]
  *                                     Record one reviewed verdict by a named evaluator.
  *   sign-off --owner <name>           Record an owner sign-off across reviewed selections.
+ *   readiness                         Show the enforce-readiness verdict + per-criterion rates + harmful-rate (read-only).
  *
  * `--format json` emits structured output. Never flips enforcement on itself.
  * An optional LLM-judge pre-pass is deferred to #3773 (advisory only — the
@@ -26,15 +27,23 @@ import { cliExit, EXIT_CODES } from '../cli-types.js';
 import { getTimeProvider } from '../core/index.js';
 import {
   getRemediationSoakSink,
+  readRemediationSoakSummary,
   type RemediationSoakRecord,
 } from '../mcp/tools/improvement-remediation-shadow.js';
 import {
   getRemediationReviewStore,
   pendingSoakSelections,
+  readRemediationReviewSummary,
   soakRefOf,
   summarizeRemediationReviews,
   type ReviewRecord,
 } from '../mcp/tools/remediation-review.js';
+import { buildEnforceReadinessEvidence } from '../mcp/tools/remediation-readiness-collector.js';
+import {
+  DEFAULT_ENFORCE_READINESS_CONFIG,
+  evaluateEnforceReadiness,
+  type EnforceReadinessEvidence,
+} from '../mcp/tools/improvement-enforce-readiness.js';
 
 /** Soak records, projected to the minimal ref-able shape. */
 function soakSelections(): readonly Pick<RemediationSoakRecord, 'signalKey' | 'timestamp'>[] {
@@ -52,6 +61,49 @@ function runList(format: string): void {
   const lines = [`${String(pending.length)} pending soak selection(s) to review:`];
   for (const p of pending) lines.push(`  ${p.soakRef}  (${p.signalKey})`);
   process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+/** Fraction of JUDGED selections assessed unsound (= 1 − soundnessRate); 0 when nothing judged. */
+export function harmfulRate(ev: EnforceReadinessEvidence): number {
+  return ev.judgedSelections === 0
+    ? 0
+    : (ev.judgedSelections - ev.judgedSound) / ev.judgedSelections;
+}
+
+/** Render the text-mode readiness report (kept separate to hold `runReadiness` under the line cap). */
+function formatReadiness(
+  verdict: ReturnType<typeof evaluateEnforceReadiness>,
+  evidence: EnforceReadinessEvidence,
+  harmful: number
+): string {
+  const maxPct = Math.round((1 - DEFAULT_ENFORCE_READINESS_CONFIG.minSoundnessRate) * 100);
+  const lines = [
+    `Enforcement readiness: ${verdict.ready ? 'READY' : 'NOT READY'}`,
+    `harmful-rate: ${String(Math.round(harmful * 100))}% of ${String(evidence.judgedSelections)} judged sound-reviews (threshold ≤ ${String(maxPct)}%)`,
+    'Criteria:',
+  ];
+  for (const c of verdict.criteria) {
+    lines.push(`  [${c.met ? 'PASS' : 'FAIL'}] ${c.name}  —  ${c.detail}`);
+  }
+  if (verdict.blockers.length > 0) lines.push(`Blockers: ${verdict.blockers.join(', ')}`);
+  return lines.join('\n');
+}
+
+/** `remediation-review readiness` — read-only enforce-readiness verdict + harmful-rate (#4098). */
+function runReadiness(format: string): void {
+  const evidence = buildEnforceReadinessEvidence(
+    readRemediationSoakSummary(),
+    readRemediationReviewSummary()
+  );
+  const verdict = evaluateEnforceReadiness(evidence);
+  const harmful = harmfulRate(evidence);
+  if (format === 'json') {
+    process.stdout.write(
+      `${JSON.stringify({ ready: verdict.ready, harmfulRate: harmful, evidence, criteria: verdict.criteria, blockers: verdict.blockers }, null, 2)}\n`
+    );
+    return;
+  }
+  process.stdout.write(`${formatReadiness(verdict, evidence, harmful)}\n`);
 }
 
 /** Resolve the sound verdict from the mutually-exclusive flags. Throws on bad input. */
@@ -166,9 +218,12 @@ export async function handleRemediationReviewCommand(args: ParsedCliArgs): Promi
     case 'sign-off':
       runSignOff(args);
       break;
+    case 'readiness':
+      runReadiness(args.options.format);
+      break;
     default:
       throw new Error(
-        `remediation-review: unknown subcommand '${sub}' (expected list | mark | sign-off)`
+        `remediation-review: unknown subcommand '${sub}' (expected list | mark | sign-off | readiness)`
       );
   }
   await Promise.resolve();


### PR DESCRIPTION
## What
Child 4 of epic #4094. Adds a read-only **`remediation-review readiness`** CLI subcommand that prints the enforce-readiness verdict for the **#3769** audit→enforce decision: per-criterion PASS/FAIL (volume / judged-coverage / soundness / named-evaluator / named-owner), the explicit **harmful-rate** (1 − soundnessRate), and the blockers.

## Reshaped from the original ask (vote-gated)
The issue originally proposed a `signal→expected-soundness` corpus + scorer. A 3-voter fan-out gate + a code-grounded end-to-end trace **rejected** that:
- **Invalid labeling** — the soak record carries no remediation content; soundness is a property of the *remediation produced*, not the signal (unlike #4095, where the label is determined by the goal text).
- **Redundant** — unlike #3552, the #3769 gate already gets deterministic soundness straight from the live review store (`remediation-review mark`/`sign-off` → `evaluateEnforceReadiness`, already wired).
- The **real gap is visibility**: the gate's verdict was consumed silently — only `blockers` surfaced as a cryptic enforce-abort. Nothing let an operator *query* readiness without flipping enforce on.

## How
`runReadiness` composes the **exact** evidence path the gate uses (`readRemediationSoakSummary` + `readRemediationReviewSummary` → `buildEnforceReadinessEvidence` → `evaluateEnforceReadiness`), so the operator view cannot drift from the decision. `--format json` supported. Never writes / never flips enforcement. No new corpus, no parallel scorer, no new MCP tool or env var.

## Verification
`tsc --noEmit` clean · 12 tests pass (7 existing + 5 new: NOT-READY text/json, full READY path seeding 20 soak + 18 sound + evaluator + owner, harmfulRate units) · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)