### PR TITLE
feat(config): data-driven model-parameter capability resolver (#4067, epic #4066)

### DIFF
--- a/.changeset/model-parameter-capability-resolver.md
+++ b/.changeset/model-parameter-capability-resolver.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+Add a data-driven model-parameter capability resolver (#4067, epic #4066 layer 1).
+Generalizes the ad-hoc `temperatureUnsupportedForModel` into a registry-first resolver
+(`model-parameter-support.ts`): `unsupportedParametersForModel` / `modelSupportsParameter`
+answer "does this model reject this request param?" and `getMaxTokensParamForModel`
+answers `max_tokens` vs `max_completion_tokens` (OpenAI reasoning, #4049). `ModelCapability`
+gains `unsupportedParameters` + `maxTokensParam`, encoded for the registered OpenAI codex
+models; the existing regex predicate remains the fallback for unregistered ids (Claude
+4.7/4.8, bare o-series). `temperatureUnsupportedForModel` is now a thin, behavior-preserving
+shim over the resolver — the adapter call sites are unchanged (a parity test pins the
+pre-refactor behavior). Data + resolver only; the adapter param-builders are wired in
+layer 2 (#4068).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,7 +491,7 @@ _Auto-generated from source. 46 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-17_
+_Governance Version: 2026-06-28_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/config/in-tree-data.ts
+++ b/packages/nexus-agents/src/config/in-tree-data.ts
@@ -222,6 +222,8 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       maxOutputTokens: 128_000,
       cliName: 'codex',
       cliModelName: 'gpt-5.4',
+      unsupportedParameters: ['temperature'],
+      maxTokensParam: 'max_completion_tokens',
     },
     {
       id: 'codex-5.2',
@@ -250,6 +252,8 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       maxOutputTokens: 100_000,
       cliName: 'codex',
       cliModelName: 'gpt-5.2-codex',
+      unsupportedParameters: ['temperature'],
+      maxTokensParam: 'max_completion_tokens',
     },
     {
       id: 'codex-5.1-mini',
@@ -273,6 +277,8 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       maxOutputTokens: 100_000,
       cliName: 'codex',
       cliModelName: 'o3-mini',
+      unsupportedParameters: ['temperature'],
+      maxTokensParam: 'max_completion_tokens',
     },
     // ----- OpenCode (multi-provider proxy) -----
     {

--- a/packages/nexus-agents/src/config/in-tree-entries.ts
+++ b/packages/nexus-agents/src/config/in-tree-entries.ts
@@ -53,6 +53,10 @@ function optionalFields(model: ModelCapability): Partial<ModelEntry> {
   if (model.cliName !== undefined) out.cliName = model.cliName;
   if (model.cliAlias !== undefined) out.cliAlias = model.cliAlias;
   if (model.cliModelName !== undefined) out.cliModelName = model.cliModelName;
+  if (model.unsupportedParameters !== undefined) {
+    out.unsupportedParameters = model.unsupportedParameters;
+  }
+  if (model.maxTokensParam !== undefined) out.maxTokensParam = model.maxTokensParam;
   return out;
 }
 

--- a/packages/nexus-agents/src/config/model-capabilities-types.ts
+++ b/packages/nexus-agents/src/config/model-capabilities-types.ts
@@ -167,6 +167,18 @@ export const ModelCapabilitySchema = z.object({
   specialFeatures: z.array(z.enum(SPECIAL_FEATURES)),
   /** Known constraints or limitations */
   constraints: z.array(z.string()).optional(),
+  /**
+   * Request parameters this model REJECTS (e.g. `['temperature']`); the adapter
+   * must omit them. Data-driven generalization of `temperatureUnsupportedForModel`
+   * (#4067). When absent, the regex fallback in `model-parameter-support.ts`
+   * applies (Claude>4.6, OpenAI o-series/codex/gpt-5 reject `temperature`).
+   */
+  unsupportedParameters: z.array(z.string()).optional(),
+  /**
+   * Which max-tokens param name this model expects; OpenAI reasoning models use
+   * `'max_completion_tokens'` (#4049). Defaults to `'max_tokens'` when absent.
+   */
+  maxTokensParam: z.enum(['max_tokens', 'max_completion_tokens']).optional(),
   /** Notes about the model (e.g., beta features, pricing tier) */
   notes: z.string().optional(),
   /** Pricing per 1M tokens (USD) */

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -345,6 +345,19 @@ function applyOptionalCapabilityFields(entry: ModelEntry, target: Writable<Model
   if (entry.cliAlias !== undefined) target.cliAlias = entry.cliAlias;
   if (entry.cliModelName !== undefined) target.cliModelName = entry.cliModelName;
   if (entry.aliases !== undefined) target.aliases = [...entry.aliases];
+  applyParameterSupportFields(entry, target);
+}
+
+/**
+ * Project the #4067 request-parameter capability fields back onto the legacy
+ * `ModelCapability` shape. Split from `applyOptionalCapabilityFields` to keep that
+ * function under the cyclomatic-complexity cap.
+ */
+function applyParameterSupportFields(entry: ModelEntry, target: Writable<ModelCapability>): void {
+  if (entry.unsupportedParameters !== undefined) {
+    target.unsupportedParameters = [...entry.unsupportedParameters];
+  }
+  if (entry.maxTokensParam !== undefined) target.maxTokensParam = entry.maxTokensParam;
 }
 
 function entryToCapability(entry: ModelEntry): ModelCapability {

--- a/packages/nexus-agents/src/config/model-parameter-support.test.ts
+++ b/packages/nexus-agents/src/config/model-parameter-support.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the data-driven model request-parameter resolver (#4067, epic #4066
+ * layer 1) and the now-shimmed {@link temperatureUnsupportedForModel}.
+ *
+ * The load-bearing test is PARITY: the shim must return the SAME boolean as the
+ * pre-#4067 regex predicate for a representative id table. The expected column was
+ * authored from the CURRENT (pre-refactor) regex behavior — Claude after Opus 4.6,
+ * OpenAI o-series / GPT-5 family / codex reject `temperature`; everything else does
+ * not. Registered codex models additionally exercise the DATA path.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  unsupportedParametersForModel,
+  modelSupportsParameter,
+  getMaxTokensParamForModel,
+} from './model-parameter-support.js';
+import { temperatureUnsupportedForModel } from './temperature-support.js';
+
+describe('PARITY — temperatureUnsupportedForModel shim preserves pre-#4067 regex behavior', () => {
+  // [modelId, expected] — verified against the CURRENT regex logic before refactor.
+  const parity: ReadonlyArray<readonly [string, boolean]> = [
+    // Claude: after Opus 4.6 → true; 4.6 and legacy (1/2/3) → false
+    ['claude-opus-4-8', true],
+    ['claude-opus-4-6', false],
+    ['claude-3-5-sonnet', false],
+    // OpenAI reasoning families → true
+    ['o1', true],
+    ['o3-mini', true],
+    ['codex-5.3', true], // registered → DATA path; regex would also catch it
+    ['gpt-5', true],
+    ['gpt-5-chat', false], // non-reasoning GPT-5 variant
+    // Non-reasoning / other vendors → false
+    ['gemini-3-pro', false],
+    ['gpt-4o', false],
+    ['some-unknown-model', false],
+  ];
+
+  it.each(parity)('%s → %s', (id, expected) => {
+    expect(temperatureUnsupportedForModel(id)).toBe(expected);
+  });
+
+  it('shim agrees with modelSupportsParameter inverse', () => {
+    for (const [id] of parity) {
+      expect(temperatureUnsupportedForModel(id)).toBe(!modelSupportsParameter(id, 'temperature'));
+    }
+  });
+});
+
+describe('DATA path — registered codex models read capability data, not just regex', () => {
+  const codexIds = ['codex-5.3', 'codex-5.2', 'codex-5.1-mini'] as const;
+
+  it.each(codexIds)('%s rejects temperature via unsupportedParameters', (id) => {
+    expect(unsupportedParametersForModel(id)).toContain('temperature');
+    expect(modelSupportsParameter(id, 'temperature')).toBe(false);
+  });
+
+  it.each(codexIds)('%s expects max_completion_tokens via maxTokensParam', (id) => {
+    // maxTokensParam has NO temperature-style regex of its own for short ids like
+    // `codex-5.3` (regexIsOpenAiReasoning matches on `codex`, so data + fallback
+    // agree here); this asserts the registry data is wired and surfaced.
+    expect(getMaxTokensParamForModel(id)).toBe('max_completion_tokens');
+  });
+});
+
+describe('FALLBACK path — UNREGISTERED ids resolve via regex', () => {
+  it('Claude after Opus 4.6 (unregistered exact id) → temperature unsupported', () => {
+    expect(unsupportedParametersForModel('claude-opus-4-8')).toContain('temperature');
+  });
+
+  it('bare o-series (unregistered) → temperature unsupported', () => {
+    expect(unsupportedParametersForModel('o3-mini')).toContain('temperature');
+  });
+
+  it('o-series → max_completion_tokens via regex fallback', () => {
+    expect(getMaxTokensParamForModel('o3-mini')).toBe('max_completion_tokens');
+  });
+
+  it('non-reasoning model → max_tokens via regex fallback', () => {
+    expect(getMaxTokensParamForModel('gpt-4o')).toBe('max_tokens');
+    expect(getMaxTokensParamForModel('claude-opus-4-8')).toBe('max_tokens');
+    expect(getMaxTokensParamForModel('gemini-3-pro')).toBe('max_tokens');
+  });
+
+  it('models that reject nothing return an empty list', () => {
+    expect(unsupportedParametersForModel('gpt-4o')).toEqual([]);
+    expect(unsupportedParametersForModel('gemini-3-pro')).toEqual([]);
+  });
+});
+
+describe('modelSupportsParameter', () => {
+  it('a param nothing rejects (top_p) is supported everywhere', () => {
+    for (const id of ['claude-opus-4-8', 'o3-mini', 'codex-5.3', 'gpt-4o', 'gemini-3-pro']) {
+      expect(modelSupportsParameter(id, 'top_p')).toBe(true);
+    }
+  });
+
+  it('inverse of unsupportedParametersForModel', () => {
+    expect(modelSupportsParameter('codex-5.3', 'temperature')).toBe(false);
+    expect(modelSupportsParameter('gpt-4o', 'temperature')).toBe(true);
+  });
+});
+
+describe('determinism — same id yields the same result twice', () => {
+  it.each(['codex-5.3', 'claude-opus-4-8', 'o3-mini', 'gpt-4o'])('%s', (id) => {
+    expect(unsupportedParametersForModel(id)).toEqual(unsupportedParametersForModel(id));
+    expect(getMaxTokensParamForModel(id)).toBe(getMaxTokensParamForModel(id));
+  });
+});

--- a/packages/nexus-agents/src/config/model-parameter-support.ts
+++ b/packages/nexus-agents/src/config/model-parameter-support.ts
@@ -1,0 +1,156 @@
+/**
+ * nexus-agents/config — data-driven model request-parameter capability resolver
+ * (#4067, epic #4066 layer 1).
+ *
+ * Generalizes the ad-hoc `temperatureUnsupportedForModel` (#4061/#4062) into a
+ * registry-first resolver. Two questions every adapter param-builder asks before
+ * forwarding a request parameter:
+ *
+ * 1. Does this model REJECT a given parameter (so the adapter must omit it)?
+ *    {@link unsupportedParametersForModel} / {@link modelSupportsParameter}.
+ * 2. Which max-tokens param name does it expect — `max_tokens` (chat-completions
+ *    default) or `max_completion_tokens` (OpenAI reasoning models, #4049)?
+ *    {@link getMaxTokensParamForModel}.
+ *
+ * RESOLUTION ORDER (each function): (a) registry capability data — the in-tree
+ * `ModelCapability.unsupportedParameters` / `.maxTokensParam` looked up via
+ * `lookupInTreeCapability`; if present, it WINS; (b) otherwise the regex fallback
+ * below, preserving the EXACT logic that lived in `temperature-support.ts` so
+ * unregistered ids (Claude 4.7/4.8, bare o-series) keep resolving correctly.
+ *
+ * Deterministic: a given id (with a stable registry) yields the same result every
+ * call. Biased AGAINST false-positive stripping — a missed rejection is a 400
+ * outage, a wrongly-stripped param only loses a tuning knob (the same bias the
+ * temperature predicate documented). `temperature-support.ts` is now a thin shim
+ * over {@link modelSupportsParameter}.
+ *
+ * @module config/model-parameter-support
+ */
+
+import { lookupInTreeCapability } from './model-config-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Regex fallback internals (moved verbatim from temperature-support.ts, #4061)
+// ---------------------------------------------------------------------------
+
+interface ClaudeMajorMinor {
+  readonly major: number;
+  readonly minor: number;
+}
+
+/**
+ * Parse the FIRST numeric version from a (provider-prefix-stripped) Claude model
+ * id — a major with an OPTIONAL minor, tolerating `-`, `_`, and `.` separators.
+ *
+ * A trailing snapshot date (`-20250514`, 6+ digits) is stripped FIRST so it cannot
+ * be mistaken for a minor: `claude-opus-4-20250514` is Opus **4.0**, not 4.20250514.
+ * A bare major with no minor is treated as `.0` (`claude-opus-4` → 4.0,
+ * `claude-fable-5` → 5.0). major/minor are kept as separate integers so `4.10`
+ * compares ABOVE `4.6` (a `parseFloat` would collapse to 4.1). Returns `null` only
+ * when the id carries no version digits at all (e.g. `claude-instant`,
+ * `claude-newfamily`).
+ */
+function parseClaudeMajorMinor(bareId: string): ClaudeMajorMinor | null {
+  const undated = bareId.replace(/[-_]\d{6,}$/, '');
+  const match = /(\d+)(?:[-_.](\d+))?/.exec(undated);
+  if (match === null) return null;
+  const major = Number.parseInt(match[1] as string, 10);
+  const minor = match[2] !== undefined ? Number.parseInt(match[2], 10) : 0;
+  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
+  return { major, minor };
+}
+
+/** Recognized LEGACY Claude families that still support `temperature` (pre-4.x). */
+const LEGACY_TEMPERATURE_SUPPORTING = /claude[-_](?:instant|1|2|3)(?:[-_.]|$)/;
+
+/**
+ * Claude branch of the temperature regex fallback (#4061). `bare` is the id
+ * sliced from the first `claude` (provider prefix stripped). Unsupported when the
+ * version is after Opus 4.6, or the family is unrecognized/non-numbered
+ * (`claude-fable-5`, future) — a deliberate SAFE-DROP, since a benign fall-back to
+ * the API default beats a 400.
+ */
+function claudeTemperatureUnsupported(bare: string): boolean {
+  const version = parseClaudeMajorMinor(bare);
+  if (version !== null) {
+    // "after Opus 4.6": major > 4, or 4.7+ within the 4.x line.
+    return version.major > 4 || (version.major === 4 && version.minor >= 7);
+  }
+  if (LEGACY_TEMPERATURE_SUPPORTING.test(bare)) return false;
+  return true;
+}
+
+/**
+ * OpenAI REASONING-model detection (#4062). True ONLY for the reasoning models
+ * documented to reject `temperature` and to use `max_completion_tokens`;
+ * everything else (gpt-4o, gpt-4, gpt-3.5, gemini, openrouter-*, …) returns false.
+ * `id` is the full lower-cased model id.
+ *
+ * - o-series: `o1`/`o3`/`o3-mini`/`o4-mini` — `o` + digit at the START of the last
+ *   path segment (so `claude-opus`/`openrouter-*` cannot match).
+ * - codex: all current `codex…` routes are GPT-5-reasoning-based.
+ * - GPT-5 family: `gpt-5` / `gpt5` (anchored after the `5` so `gpt-50`/`gpt-512`
+ *   do NOT match) — EXCEPT the non-reasoning `gpt-5-chat` variant.
+ */
+function openAiReasoning(id: string): boolean {
+  const segment = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
+  if (/^o[0-9]/.test(segment)) return true;
+  if (segment.includes('codex')) return true;
+  if (/gpt-?5(?![0-9])/.test(segment) && !segment.includes('gpt-5-chat')) return true;
+  return false;
+}
+
+/**
+ * Regex fallback for whether `modelId` rejects a non-default `temperature`. The
+ * EXACT predicate that was `temperatureUnsupportedForModel` before #4067 — Claude
+ * after Opus 4.6, OpenAI o-series / GPT-5 family / codex; everything else false.
+ * Robust to gateway id variants (provider prefixes, `-`/`_` separators, dated
+ * suffixes).
+ */
+function regexRejectsTemperature(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  const claudeAt = id.indexOf('claude');
+  if (claudeAt !== -1) {
+    return claudeTemperatureUnsupported(id.slice(claudeAt)); // strip provider prefix
+  }
+  return openAiReasoning(id);
+}
+
+/** Regex fallback for OpenAI-reasoning detection (Claude ids are never reasoning here). */
+function regexIsOpenAiReasoning(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  if (id.includes('claude')) return false;
+  return openAiReasoning(id);
+}
+
+// ---------------------------------------------------------------------------
+// Public resolver API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters `modelId` REJECTS. Registry capability data first
+ * (`ModelCapability.unsupportedParameters`), else the regex fallback for
+ * unregistered models (Claude>4.6, OpenAI o-series/codex/gpt-5 reject
+ * `'temperature'`; nothing else, for now). Deterministic.
+ */
+export function unsupportedParametersForModel(modelId: string): readonly string[] {
+  const cap = lookupInTreeCapability(modelId);
+  if (cap?.unsupportedParameters !== undefined) return cap.unsupportedParameters;
+  return regexRejectsTemperature(modelId) ? ['temperature'] : [];
+}
+
+/** True iff `modelId` accepts `param`. */
+export function modelSupportsParameter(modelId: string, param: string): boolean {
+  return !unsupportedParametersForModel(modelId).includes(param);
+}
+
+/**
+ * The max-tokens param name `modelId` expects: registry `maxTokensParam` first,
+ * else regex fallback (OpenAI reasoning → `'max_completion_tokens'`, else
+ * `'max_tokens'`).
+ */
+export function getMaxTokensParamForModel(modelId: string): 'max_tokens' | 'max_completion_tokens' {
+  const cap = lookupInTreeCapability(modelId);
+  if (cap?.maxTokensParam !== undefined) return cap.maxTokensParam;
+  return regexIsOpenAiReasoning(modelId) ? 'max_completion_tokens' : 'max_tokens';
+}

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -124,6 +124,18 @@ export interface ModelEntry {
   readonly pricing?: Pricing;
   readonly qualityScores?: QualityScores;
   readonly notes?: string;
+  /**
+   * Request parameters this model rejects (carried from
+   * `ModelCapability.unsupportedParameters`, #4067). Consumed by
+   * `model-parameter-support.ts`; absence means the regex fallback applies.
+   */
+  readonly unsupportedParameters?: readonly string[];
+  /**
+   * Max-tokens param name this model expects (carried from
+   * `ModelCapability.maxTokensParam`, #4049/#4067). Absence defaults to
+   * `'max_tokens'` (with the OpenAI-reasoning regex fallback).
+   */
+  readonly maxTokensParam?: 'max_tokens' | 'max_completion_tokens';
 
   // ---- CLI routing metadata (in-tree entries only) ----
   /** Which CLI tool this model belongs to (e.g. 'claude', 'gemini'). */

--- a/packages/nexus-agents/src/config/temperature-support.ts
+++ b/packages/nexus-agents/src/config/temperature-support.ts
@@ -23,10 +23,16 @@
  * AGAINST false-positive stripping — a false negative is a 400, a false positive
  * only loses the consistency setting.
  *
+ * As of #4067 the predicate is a THIN SHIM over the data-driven resolver in
+ * `model-parameter-support.ts` (registry `unsupportedParameters` first, then the
+ * same regex fallback that used to live here). The three adapter call sites and
+ * the `warnTemperatureDropped` / `_resetTemperatureWarnings` surface are unchanged.
+ *
  * @module config/temperature-support
  */
 
 import { createLogger } from '../core/index.js';
+import { modelSupportsParameter } from './model-parameter-support.js';
 
 const logger = createLogger({ component: 'temperature-support' });
 
@@ -68,92 +74,18 @@ export function _resetTemperatureWarnings(): void {
   warnedDroppedModels.clear();
 }
 
-interface ClaudeMajorMinor {
-  readonly major: number;
-  readonly minor: number;
-}
-
-/**
- * Parse the FIRST numeric version from a (provider-prefix-stripped) Claude model
- * id — a major with an OPTIONAL minor, tolerating `-`, `_`, and `.` separators.
- *
- * A trailing snapshot date (`-20250514`, 6+ digits) is stripped FIRST so it cannot
- * be mistaken for a minor: `claude-opus-4-20250514` is Opus **4.0**, not 4.20250514.
- * A bare major with no minor is treated as `.0` (`claude-opus-4` → 4.0,
- * `claude-fable-5` → 5.0). major/minor are kept as separate integers so `4.10`
- * compares ABOVE `4.6` (a `parseFloat` would collapse to 4.1). Returns `null` only
- * when the id carries no version digits at all (e.g. `claude-instant`,
- * `claude-newfamily`).
- */
-function parseClaudeMajorMinor(bareId: string): ClaudeMajorMinor | null {
-  const undated = bareId.replace(/[-_]\d{6,}$/, '');
-  const match = /(\d+)(?:[-_.](\d+))?/.exec(undated);
-  if (match === null) return null;
-  const major = Number.parseInt(match[1] as string, 10);
-  const minor = match[2] !== undefined ? Number.parseInt(match[2], 10) : 0;
-  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
-  return { major, minor };
-}
-
-/** Recognized LEGACY Claude families that still support `temperature` (pre-4.x). */
-const LEGACY_TEMPERATURE_SUPPORTING = /claude[-_](?:instant|1|2|3)(?:[-_.]|$)/;
-
-/**
- * Claude branch of {@link temperatureUnsupportedForModel} (#4061). `bare` is the
- * id sliced from the first `claude` (provider prefix stripped). Unsupported when
- * the version is after Opus 4.6, or the family is unrecognized/non-numbered
- * (`claude-fable-5`, future) — a deliberate SAFE-DROP, since a benign fall-back to
- * the API default beats a 400.
- */
-function claudeTemperatureUnsupported(bare: string): boolean {
-  const version = parseClaudeMajorMinor(bare);
-  if (version !== null) {
-    // "after Opus 4.6": major > 4, or 4.7+ within the 4.x line.
-    return version.major > 4 || (version.major === 4 && version.minor >= 7);
-  }
-  if (LEGACY_TEMPERATURE_SUPPORTING.test(bare)) return false;
-  return true;
-}
-
-/**
- * OpenAI branch of {@link temperatureUnsupportedForModel} (#4062). True ONLY for
- * the reasoning models documented to reject `temperature`; everything else
- * (gpt-4o, gpt-4, gpt-3.5, gemini, openrouter-*, …) returns false so its
- * temperature is preserved. `id` is the full lower-cased model id.
- *
- * - o-series: `o1`/`o3`/`o3-mini`/`o4-mini` — `o` + digit at the START of the last
- *   path segment (so `claude-opus`/`openrouter-*` cannot match — and the Claude
- *   branch already ran first regardless).
- * - codex: all current `codex…` routes are GPT-5-reasoning-based.
- * - GPT-5 family: `gpt-5` / `gpt5` (anchored after the `5` so `gpt-50`/`gpt-512`
- *   do NOT match) — EXCEPT the non-reasoning `gpt-5-chat` variant.
- */
-function openAiReasoningTemperatureUnsupported(id: string): boolean {
-  const segment = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
-  if (/^o[0-9]/.test(segment)) return true;
-  if (segment.includes('codex')) return true;
-  if (/gpt-?5(?![0-9])/.test(segment) && !segment.includes('gpt-5-chat')) return true;
-  return false;
-}
-
 /**
  * Whether `modelId` REJECTS a non-default `temperature` and the param must be
  * dropped before the request is sent. Single source of truth for both adapters.
  *
- * - Claude models → see {@link claudeTemperatureUnsupported} (after Opus 4.6, #4061).
- * - OpenAI reasoning models → see {@link openAiReasoningTemperatureUnsupported}
- *   (o-series / GPT-5 family / codex, #4062).
- * - Everything else (gpt-4o, gpt-4, gemini-*, openrouter-*, …) → `false`.
- *
- * Biased AGAINST false positives: a missed model is a 400 outage, a wrongly
- * matched one only loses the consistency setting. Robust to gateway id variants —
- * provider prefixes (`anthropic/…`, `openai/…`), `-`/`_` separators, dated suffixes.
+ * Thin shim over {@link modelSupportsParameter} (#4067): registry
+ * `unsupportedParameters` data wins, else the regex fallback (Claude after Opus
+ * 4.6 #4061; OpenAI o-series / GPT-5 family / codex #4062; everything else
+ * `false`). Biased AGAINST false positives: a missed model is a 400 outage, a
+ * wrongly matched one only loses the consistency setting. Robust to gateway id
+ * variants — provider prefixes (`anthropic/…`, `openai/…`), `-`/`_` separators,
+ * dated suffixes.
  */
 export function temperatureUnsupportedForModel(modelId: string): boolean {
-  const id = modelId.toLowerCase();
-  const claudeAt = id.indexOf('claude');
-  if (claudeAt !== -1) {
-    return claudeTemperatureUnsupported(id.slice(claudeAt)); // strip provider prefix
-  }
-  return openAiReasoningTemperatureUnsupported(id);
+  return !modelSupportsParameter(modelId, 'temperature');
 }


### PR DESCRIPTION
## What
Layer 1 of epic #4066 (model-parameter compatibility — the defect class behind #4061/#4062/#4049). Generalizes the ad-hoc `temperatureUnsupportedForModel` into a **data-driven, registry-first resolver** (`src/config/model-parameter-support.ts`):
- `unsupportedParametersForModel(modelId)` / `modelSupportsParameter(modelId, param)` — does this model reject a request param?
- `getMaxTokensParamForModel(modelId)` — `max_tokens` vs `max_completion_tokens` (OpenAI reasoning, #4049).

`ModelCapability` gains `unsupportedParameters` + `maxTokensParam` (round-tripped through `ModelEntry`), encoded for the registered OpenAI codex models so the **data path is real and tested**. The existing regex remains the **fallback** for unregistered ids (Claude 4.7/4.8, bare o-series — load-bearing, those aren't in the registry).

## Behavior-preserving
`temperatureUnsupportedForModel` is now a thin shim: `return !modelSupportsParameter(modelId, 'temperature')`. The regex internals moved **verbatim**; the three adapter call sites + `warnTemperatureDropped`/`_resetTemperatureWarnings` are **unchanged**. A **PARITY test** pins the pre-refactor boolean across a representative id table (`claude-opus-4-8`→true, `claude-opus-4-6`→false, `o3-mini`→true, `codex-5.3`→true via DATA path, `gpt-5-chat`→false, `gemini-3-pro`→false, unknown→false) plus a shim↔resolver cross-check.

## Scope
Data + resolver **only** — the adapter param-builders are wired in layer 2 (#4068). Resolution order in each fn: registry capability data first, regex fallback second.

## Verification
`tsc --noEmit` clean · resolver 29 + shim 56 tests pass (1775 config/adapter total) · eslint clean · producer/consumer pass (resolver consumed by the shim) · `docs:tools:check` confirms **no Tool Reference Drift** (ModelCapability is an output type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)