### PR TITLE
refactor(adapters): single temperature drop-decision seam (#4068, epic #4066)

### DIFF
--- a/.changeset/optional-params-seam.md
+++ b/.changeset/optional-params-seam.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Extract the shared temperature drop-decision from the claude/openai/sdk adapters into one `planOptionalParams` seam (#4068, epic #4066 layer 2), consulting the layer-1 capability resolver and returning {dropped, transformed} for the layer-3 telemetry child (#4069). Behavior-preserving; gemini/ollama and all max-tokens handling are unchanged.

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -43,10 +43,7 @@ import {
   RESPOND_TOOL_NAME,
 } from './claude-adapter-helpers.js';
 import { extractRequestSystemPrompt } from './prompt-utils.js';
-import {
-  temperatureUnsupportedForModel,
-  warnTemperatureDropped,
-} from '../config/temperature-support.js';
+import { planOptionalParams } from './optional-params.js';
 
 // Re-export types and constants for backward compatibility
 export type { ClaudeAdapterConfig } from './claude-adapter-types.js';
@@ -277,17 +274,13 @@ export class ClaudeAdapter extends BaseAdapter {
     params: Anthropic.MessageCreateParamsNonStreaming,
     request: CompletionRequest
   ): void {
-    // #4061: Claude models released after Opus 4.6 reject any non-1.0 temperature
-    // with a 400 (per the @anthropic-ai/sdk deprecation note). Omit the param for
-    // those models — 1.0 is the API default, so omitting is equivalent and avoids
-    // the 400 the voter/base-agent default (0.3) would otherwise trigger.
-    if (request.temperature !== undefined) {
-      if (temperatureUnsupportedForModel(this.resolvedModelId)) {
-        warnTemperatureDropped(this.resolvedModelId);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- still valid for older Anthropic models (≤ Opus 4.6) and value 1.0; gated by temperatureUnsupportedForModel
-        params.temperature = request.temperature;
-      }
+    // #4068: the temperature drop-decision (#4061: Claude after Opus 4.6 rejects
+    // any non-1.0 temperature with a 400; omit it — 1.0 is the API default, so
+    // omitting is equivalent) is centralized in the shared planOptionalParams seam.
+    const plan = planOptionalParams(request, this.resolvedModelId);
+    if (plan.temperature !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- still valid for older Anthropic models (≤ Opus 4.6) and value 1.0; the seam gates on temperatureUnsupportedForModel
+      params.temperature = plan.temperature;
     }
 
     if (request.stop !== undefined && request.stop.length > 0) {

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -33,10 +33,7 @@ import {
   getModelCapabilities,
   type OpenAIAdapterConfig,
 } from './openai-types.js';
-import {
-  temperatureUnsupportedForModel,
-  warnTemperatureDropped,
-} from '../config/temperature-support.js';
+import { planOptionalParams } from './optional-params.js';
 import {
   mapMessage,
   mapTool,
@@ -382,18 +379,15 @@ export class OpenAIAdapter extends BaseAdapter {
     params: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
     request: CompletionRequest
   ): void {
-    // #4061: a gateway routing to a Claude model after Opus 4.6 rejects any
-    // non-1.0 temperature with a 400. Omit the param for those models so a
-    // gateway-routed voter panel (default 0.3) does not 400. Non-Claude gateway
-    // models (gpt-*, etc.) are unaffected. NOTE: a gateway that injects its OWN
-    // default temperature when the field is absent is outside our control — our
-    // contract is only to not SEND a value the target model rejects.
-    if (request.temperature !== undefined) {
-      if (temperatureUnsupportedForModel(this.resolvedModelId)) {
-        warnTemperatureDropped(this.resolvedModelId);
-      } else {
-        params.temperature = request.temperature;
-      }
+    // #4068: the temperature drop-decision (#4061: a gateway routing to a Claude
+    // model after Opus 4.6, or an OpenAI reasoning model, rejects a non-1.0
+    // temperature with a 400; omit it so a gateway-routed voter panel at the
+    // default 0.3 does not 400) is centralized in the shared planOptionalParams
+    // seam. NOTE: a gateway that injects its OWN default when the field is absent
+    // is outside our control — our contract is only to not SEND a rejected value.
+    const plan = planOptionalParams(request, this.resolvedModelId);
+    if (plan.temperature !== undefined) {
+      params.temperature = plan.temperature;
     }
 
     if (request.stop !== undefined && request.stop.length > 0) {

--- a/packages/nexus-agents/src/adapters/optional-params.test.ts
+++ b/packages/nexus-agents/src/adapters/optional-params.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Characterization tests for the shared optional-parameter decision seam
+ * (#4068, epic #4066 layer 2). Pins the temperature drop-decision that the
+ * claude/openai/sdk adapters previously inlined identically. The provider-specific
+ * adapter tests (claude/openai/sdk-adapter.test.ts) remain the behavior-preservation
+ * safety net; these assert the seam in isolation.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { planOptionalParams } from './optional-params.js';
+import { _resetTemperatureWarnings } from '../config/temperature-support.js';
+import { modelSupportsParameter } from '../config/model-parameter-support.js';
+import type { CompletionRequest } from '../core/index.js';
+
+function makeRequest(overrides: Partial<CompletionRequest> = {}): CompletionRequest {
+  return {
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  };
+}
+
+// Models the layer-1 resolver knows reject `temperature` (Claude after Opus 4.6;
+// OpenAI o-series; codex routes are GPT-5-reasoning-based).
+const UNSUPPORTED_IDS = ['claude-opus-4-8', 'o3-mini', 'codex-5.3'];
+// Models that accept a custom `temperature`.
+const SUPPORTED_IDS = ['claude-opus-4-6', 'gpt-4o', 'gemini-3-pro'];
+
+describe('planOptionalParams', () => {
+  beforeEach(() => {
+    // Reset the once-per-model warning dedupe so each drop-case warns deterministically.
+    _resetTemperatureWarnings();
+  });
+
+  describe('temperature drop for unsupported models', () => {
+    for (const modelId of UNSUPPORTED_IDS) {
+      it(`drops temperature for ${modelId} and records it in dropped[]`, () => {
+        const plan = planOptionalParams(makeRequest({ temperature: 0.3 }), modelId);
+        expect(plan.temperature).toBeUndefined();
+        expect('temperature' in plan).toBe(false);
+        expect(plan.dropped).toHaveLength(1);
+        expect(plan.dropped[0]).toMatchObject({ param: 'temperature' });
+        expect(plan.dropped[0]?.reason).toContain(modelId);
+      });
+    }
+  });
+
+  describe('temperature pass-through for supported models', () => {
+    for (const modelId of SUPPORTED_IDS) {
+      it(`keeps temperature for ${modelId} and leaves dropped[] empty`, () => {
+        const plan = planOptionalParams(makeRequest({ temperature: 0.5 }), modelId);
+        expect(plan.temperature).toBe(0.5);
+        expect(plan.dropped).toHaveLength(0);
+      });
+    }
+  });
+
+  it('omits temperature entirely when the request has no temperature', () => {
+    const plan = planOptionalParams(makeRequest(), 'claude-opus-4-8');
+    expect(plan.temperature).toBeUndefined();
+    expect('temperature' in plan).toBe(false);
+    expect(plan.dropped).toHaveLength(0);
+  });
+
+  it('passes through temperature 0 (falsy but defined)', () => {
+    const plan = planOptionalParams(makeRequest({ temperature: 0 }), 'gpt-4o');
+    expect(plan.temperature).toBe(0);
+    expect(plan.dropped).toHaveLength(0);
+  });
+
+  describe('regex-false-match guard (documents why gemini/ollama are out of scope)', () => {
+    it('gemini-3-pro supports temperature — would never be dropped', () => {
+      expect(modelSupportsParameter('gemini-3-pro', 'temperature')).toBe(true);
+      const plan = planOptionalParams(makeRequest({ temperature: 0.7 }), 'gemini-3-pro');
+      expect(plan.temperature).toBe(0.7);
+    });
+
+    it('an ollama-style id supports temperature — would never be dropped', () => {
+      expect(modelSupportsParameter('llama3.1:8b', 'temperature')).toBe(true);
+      const plan = planOptionalParams(makeRequest({ temperature: 0.7 }), 'llama3.1:8b');
+      expect(plan.temperature).toBe(0.7);
+    });
+  });
+
+  it('is deterministic — same inputs yield an equal plan', () => {
+    const a = planOptionalParams(makeRequest({ temperature: 0.5 }), 'gpt-4o');
+    const b = planOptionalParams(makeRequest({ temperature: 0.5 }), 'gpt-4o');
+    expect(a).toEqual(b);
+  });
+
+  it('always returns transformed as an empty array (reserved for #4069)', () => {
+    expect(planOptionalParams(makeRequest({ temperature: 0.5 }), 'gpt-4o').transformed).toEqual([]);
+    expect(
+      planOptionalParams(makeRequest({ temperature: 0.3 }), 'claude-opus-4-8').transformed
+    ).toEqual([]);
+    expect(planOptionalParams(makeRequest(), 'gpt-4o').transformed).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/adapters/optional-params.ts
+++ b/packages/nexus-agents/src/adapters/optional-params.ts
@@ -1,0 +1,64 @@
+/**
+ * nexus-agents/adapters — shared optional-parameter decision seam (#4068, epic #4066 layer 2).
+ *
+ * The claude / openai / sdk adapters each inlined an IDENTICAL temperature
+ * drop-decision before forwarding a request: consult the layer-1 capability
+ * resolver, drop `temperature` (and warn once) when the model rejects it, else
+ * pass it through. This module is the single seam for that decision so the three
+ * call sites stop duplicating it.
+ *
+ * It returns DECISION METADATA, not a provider-neutral params dict: each adapter
+ * still owns its own wire shape (field names + nesting for stop/tools/
+ * response_format/max-tokens), so the seam only decides the shared bit
+ * (temperature) and records what it dropped/transformed for the layer-3 telemetry
+ * child (#4069). Behavior-preserving by construction.
+ *
+ * @module adapters/optional-params
+ */
+
+import { modelSupportsParameter } from '../config/model-parameter-support.js';
+import { warnTemperatureDropped } from '../config/temperature-support.js';
+import type { CompletionRequest } from '../core/index.js';
+
+/** A request param the seam dropped, with why (feeds the layer-3 telemetry child #4069). */
+export interface DroppedParam {
+  readonly param: string;
+  readonly reason: string;
+}
+
+/** A request param the seam transformed (name/value). Reserved for #4069 / a later max-tokens increment; empty today. */
+export interface TransformedParam {
+  readonly param: string;
+  readonly from: unknown;
+  readonly to: unknown;
+}
+
+/** The provider-NEUTRAL decision the adapters apply to their own wire shape. */
+export interface OptionalParamPlan {
+  /** Present iff temperature should be sent (the adapter sets it under its own field name — all 3 use `temperature`). Absent = drop it. */
+  readonly temperature?: number;
+  readonly dropped: readonly DroppedParam[];
+  readonly transformed: readonly TransformedParam[];
+}
+
+/**
+ * Centralizes the temperature drop-decision shared by the claude/openai/sdk adapters
+ * (#4068, epic #4066 layer 2). Consults the layer-1 resolver; when the model rejects
+ * temperature it is dropped (and `warnTemperatureDropped` fires, exactly as before) and
+ * recorded in `dropped` for the layer-3 telemetry child (#4069). Behavior-preserving:
+ * the adapters previously inlined this identically. Returns DECISION METADATA, not a
+ * neutral params dict (each adapter still owns its wire names/nesting for stop/tools/etc).
+ */
+export function planOptionalParams(request: CompletionRequest, modelId: string): OptionalParamPlan {
+  const dropped: DroppedParam[] = [];
+  let temperature: number | undefined;
+  if (request.temperature !== undefined) {
+    if (modelSupportsParameter(modelId, 'temperature')) {
+      temperature = request.temperature;
+    } else {
+      warnTemperatureDropped(modelId);
+      dropped.push({ param: 'temperature', reason: `model_rejects:${modelId}` });
+    }
+  }
+  return { ...(temperature !== undefined ? { temperature } : {}), dropped, transformed: [] };
+}

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -30,10 +30,7 @@ import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
-import {
-  temperatureUnsupportedForModel,
-  warnTemperatureDropped,
-} from '../../config/temperature-support.js';
+import { planOptionalParams } from '../optional-params.js';
 import {
   validateCustomApiBaseUrl,
   assertCustomApiHostResolvesPublic,
@@ -401,16 +398,13 @@ export class SdkAdapter extends BaseAdapter {
     if (request.systemPrompt !== undefined) {
       options['system'] = request.systemPrompt;
     }
-    // #4061/#4062: Claude models after Opus 4.6 and OpenAI reasoning models
-    // (o-series, GPT-5 family) reject a non-1.0 temperature with a 400. The AI-SDK
-    // path routes to both (auto-adapter wires openai/codex + anthropic), so omit
-    // the param for those models — 1.0 is the API default, so omitting is equivalent.
-    if (request.temperature !== undefined) {
-      if (temperatureUnsupportedForModel(this.modelId)) {
-        warnTemperatureDropped(this.modelId);
-      } else {
-        options['temperature'] = request.temperature;
-      }
+    // #4068: the temperature drop-decision (#4061/#4062: Claude after Opus 4.6 and
+    // OpenAI reasoning models reject a non-1.0 temperature with a 400; the AI-SDK
+    // path routes to both, so omit the param for those models — 1.0 is the API
+    // default, equivalent) is centralized in the shared planOptionalParams seam.
+    const plan = planOptionalParams(request, this.modelId);
+    if (plan.temperature !== undefined) {
+      options['temperature'] = plan.temperature;
     }
     if (request.maxTokens !== undefined) {
       options['maxTokens'] = request.maxTokens;


### PR DESCRIPTION
## What
Layer 2 of epic #4066. The claude/openai/sdk adapters each inlined an **identical** temperature drop-decision (consult the layer-1 capability resolver, drop+warn when the model rejects temperature, else pass through). This centralizes it in a new `planOptionalParams` seam (`src/adapters/optional-params.ts`) returning **decision metadata** `{ temperature?, dropped, transformed }`.

## Narrowed from "all 5 builders" (3-voter scope-clearance gate)
The survey showed the "5 parallel builders" framing overstates the shared surface:
- **Genuine shared logic = the temperature drop-decision, in only 3 of 5 adapters** (claude/openai/sdk — even the wire name `temperature` is shared there).
- **Gemini + Ollama set temperature unconditionally and never consult the resolver** — routing them through it would risk a regex false-positive drop. They stay per-adapter, **untouched**.
- **Decision metadata, not a neutral params dict** (voter 1): a neutral dict doesn't DRY, since each adapter still remaps its own stop/tools/response_format/max-tokens names.
- **max-tokens param-name transform OUT of scope** (voter 2): wiring `getMaxTokensParamForModel` would break Gemini/Ollama (names the resolver doesn't know); left exactly as-is.

`{dropped, transformed}` is the contract the layer-3 telemetry child (#4069) consumes; `dropped` is real (temperature), `transformed` empty until a transform is wired.

## Behavior-preserving
Same resolver, same `warnTemperatureDropped`, same per-adapter field. **Characterization tests** (12 new: drop for unsupported ids, keep for supported, a regex-false-match guard proving gemini/ollama wouldn't drop) + **all 5 existing adapter suites (275 tests) pass unchanged** — the safety net.

## Verification
`tsc --noEmit` clean · new suite + 5 adapter suites green · eslint clean · producer/consumer pass (seam consumed by the 3 adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)