### PR TITLE
feat(observability): loud param-drop telemetry + MODEL_PARAMETER_UNSUPPORTED (#4069, epic #4066)

### DIFF
--- a/.changeset/loud-param-telemetry.md
+++ b/.changeset/loud-param-telemetry.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': minor
+---
+
+Make dropped model parameters LOUD (#4069, epic #4066 layer 3): planOptionalParams now classifies severity (behavioral params like temperature/seed/top_p warn loudly; cosmetic quiet), surfaces `warnings` on the CompletionResponse, and records a would-have-self-healed counter. Adds the MODEL_PARAMETER_UNSUPPORTED error code (non-retryable) for 400s that name an unsupported parameter, carrying the param name in error context.

--- a/packages/nexus-agents/src/adapters/base-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/base-adapter.test.ts
@@ -12,6 +12,8 @@ import type {
 } from '../core/index.js';
 import { ok, err, ModelError, ErrorCode, ModelCapability, NexusError } from '../core/index.js';
 import { BaseAdapter, type BaseAdapterConfig } from './base-adapter.js';
+import { isRetryableError } from './retry.js';
+import { getWouldHaveSelfHealedCounts, _resetWouldHaveSelfHealed } from './optional-params.js';
 
 /** Concrete test implementation of BaseAdapter for testing. */
 class TestAdapter extends BaseAdapter {
@@ -435,6 +437,59 @@ describe('BaseAdapter', () => {
     it('should include provider context in error', () => {
       const result = adapter.testTransformError(new Error('Test error'));
       expect(result.context).toEqual({ providerId: 'test-provider', modelId: 'test-model' });
+    });
+
+    describe('param-naming 400 → MODEL_PARAMETER_UNSUPPORTED (#4069)', () => {
+      beforeEach(() => {
+        _resetWouldHaveSelfHealed();
+      });
+
+      it('classifies a 400 that names a param as MODEL_PARAMETER_UNSUPPORTED', () => {
+        const error = Object.assign(new Error('Unsupported value: temperature'), {
+          status: 400,
+          param: 'temperature',
+        });
+        expect(adapter.testTransformError(error).code).toBe(ErrorCode.MODEL_PARAMETER_UNSUPPORTED);
+      });
+
+      it('threads the offending param name into the error context', () => {
+        const error = Object.assign(new Error('bad param'), { status: 400, param: 'temperature' });
+        const result = adapter.testTransformError(error);
+        expect(result.context).toMatchObject({ param: 'temperature' });
+      });
+
+      it('records a would-have-self-healed event for the param-naming 400', () => {
+        const error = Object.assign(new Error('bad param'), { status: 400, param: 'temperature' });
+        adapter.testTransformError(error);
+        // TestAdapter modelId is 'test-model'.
+        expect(getWouldHaveSelfHealedCounts().get('test-model:temperature')).toBe(1);
+      });
+
+      it('leaves a 400 with NO param as MODEL_ERROR (unchanged) and records nothing', () => {
+        const error = Object.assign(new Error('generic bad request'), { status: 400 });
+        const result = adapter.testTransformError(error);
+        expect(result.code).toBe(ErrorCode.MODEL_ERROR);
+        expect(result.context).toEqual({ providerId: 'test-provider', modelId: 'test-model' });
+        expect(getWouldHaveSelfHealedCounts().size).toBe(0);
+      });
+
+      it('leaves a non-400 that carries a param as its normal code (unchanged)', () => {
+        // A 429 with a param must still classify as rate-limited, not param-unsupported.
+        const error = Object.assign(new Error('too many requests'), {
+          status: 429,
+          param: 'temperature',
+        });
+        expect(adapter.testTransformError(error).code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+      });
+
+      it('MODEL_PARAMETER_UNSUPPORTED is NON-RETRYABLE per the retry mechanism', () => {
+        const error = Object.assign(new Error('Unsupported value: temperature'), {
+          status: 400,
+          param: 'temperature',
+        });
+        const modelError = adapter.testTransformError(error);
+        expect(isRetryableError(modelError)).toBe(false);
+      });
     });
   });
 

--- a/packages/nexus-agents/src/adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/adapters/base-adapter.ts
@@ -17,6 +17,7 @@ import type {
 } from '../core/index.js';
 import { getErrorMessage } from '../core/index.js';
 import { isRateLimitLikeError } from './rate-limit-detector.js';
+import { recordWouldHaveSelfHealed } from './optional-params.js';
 
 import {
   ok,
@@ -316,7 +317,19 @@ export abstract class BaseAdapter implements IModelAdapter {
     const errorMessage = getErrorMessage(error);
     const errorCode = this.determineErrorCode(error);
 
-    const modelError = this.createModelError(errorMessage, errorCode, error);
+    // #4069: a param-naming 400 carries the offending param name in context, and
+    // counts as a would-have-self-healed event (the reactive #4071 path would catch
+    // exactly this 400). Only set for MODEL_PARAMETER_UNSUPPORTED — all other codes
+    // are unchanged.
+    const param =
+      errorCode === ErrorCode.MODEL_PARAMETER_UNSUPPORTED
+        ? this.extractErrorParam(error)
+        : undefined;
+    if (param !== undefined) {
+      recordWouldHaveSelfHealed(this.modelId, param);
+    }
+
+    const modelError = this.createModelError(errorMessage, errorCode, error, param);
 
     this.logger.error('Model adapter error', modelError, {
       errorCode,
@@ -333,17 +346,24 @@ export abstract class BaseAdapter implements IModelAdapter {
   private createModelError(
     message: string,
     errorCode: (typeof ErrorCode)[keyof typeof ErrorCode],
-    originalError: unknown
+    originalError: unknown,
+    param?: string
   ): ModelError {
     const fullMessage = `${this.providerId}/${this.modelId}: ${message}`;
 
     // Build options object conditionally to satisfy exactOptionalPropertyTypes
+    const context: Record<string, unknown> = {
+      providerId: this.providerId,
+      modelId: this.modelId,
+    };
+    // #4069: surface the offending param name for a param-naming 400 so callers
+    // and the reactive self-heal path (#4071) can read which param to retry without.
+    if (param !== undefined) {
+      context.param = param;
+    }
     const options: NexusErrorOptions = {
       code: errorCode,
-      context: {
-        providerId: this.providerId,
-        modelId: this.modelId,
-      },
+      context,
     };
 
     // Only set cause if originalError is an Error
@@ -389,7 +409,34 @@ export abstract class BaseAdapter implements IModelAdapter {
       return ErrorCode.MODEL_UNAVAILABLE;
     }
 
+    // Check for a param-naming 400 (#4069): a 400 that identifies an unsupported
+    // parameter by name. Distinct from generic MODEL_ERROR — non-retryable, and the
+    // param name is threaded into context. Only changes 400s that NAME a param; a
+    // 400 with no param, and every non-400, stay MODEL_ERROR.
+    if (this.extractErrorParam(error) !== undefined) {
+      return ErrorCode.MODEL_PARAMETER_UNSUPPORTED;
+    }
+
     return ErrorCode.MODEL_ERROR;
+  }
+
+  /**
+   * Extract the offending parameter name from a param-naming 400 (#4069).
+   *
+   * Returns the param only when the error is a 400 AND carries a non-empty `param`
+   * field (the OpenAI SDK / OpenAI-compatible gateways set this on a rejected
+   * parameter; the OpenAI adapter threads it onto the classification probe).
+   * Returns undefined otherwise, so non-400s and param-less 400s are untouched.
+   */
+  private extractErrorParam(error: unknown): string | undefined {
+    if (!(error instanceof Error)) {
+      return undefined;
+    }
+    const errorObj = error as { status?: number; param?: unknown };
+    if (errorObj.status !== 400) {
+      return undefined;
+    }
+    return typeof errorObj.param === 'string' && errorObj.param !== '' ? errorObj.param : undefined;
   }
 
   /**

--- a/packages/nexus-agents/src/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.test.ts
@@ -270,6 +270,53 @@ describe('ClaudeAdapter', () => {
       expect(callArg).not.toHaveProperty('temperature');
     });
 
+    it('surfaces a dropped temperature as a response warning (#4069)', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Response' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+        stop_reason: 'end_turn',
+        model: 'claude-opus-4-8',
+      });
+
+      const adapter = new ClaudeAdapter({ ...validConfig, modelId: 'claude-opus-4-8' });
+      const result = await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        temperature: 0.3,
+        maxTokens: 1024,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.warnings).toBeDefined();
+        expect(result.value.warnings).toHaveLength(1);
+        expect(result.value.warnings?.[0]).toMatchObject({
+          param: 'temperature',
+          severity: 'behavioral',
+        });
+      }
+    });
+
+    it('omits warnings when no param was dropped (supported model)', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Response' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+        stop_reason: 'end_turn',
+        model: CLAUDE_MODELS.SONNET_4,
+      });
+
+      const adapter = new ClaudeAdapter(validConfig);
+      const result = await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        temperature: 0.5,
+        maxTokens: 1024,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.warnings).toBeUndefined();
+      }
+    });
+
     it('should include stop sequences when provided', async () => {
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: 'Response' }],

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -43,7 +43,7 @@ import {
   RESPOND_TOOL_NAME,
 } from './claude-adapter-helpers.js';
 import { extractRequestSystemPrompt } from './prompt-utils.js';
-import { planOptionalParams } from './optional-params.js';
+import { planOptionalParams, type DroppedParam } from './optional-params.js';
 
 // Re-export types and constants for backward compatibility
 export type { ClaudeAdapterConfig } from './claude-adapter-types.js';
@@ -193,7 +193,7 @@ export class ClaudeAdapter extends BaseAdapter {
    * Executes the completion request against the Anthropic API.
    */
   private async executeCompletion(request: CompletionRequest): Promise<CompletionResponse> {
-    const params = this.buildRequestParams(request);
+    const { params, dropped } = this.buildRequestParams(request);
     // #3036: forward AbortSignal into the SDK so withWatchdog timeouts
     // actually cancel the in-flight HTTP request instead of leaking it
     // past the Promise.race boundary. Branch on signal presence — vitest
@@ -208,7 +208,8 @@ export class ClaudeAdapter extends BaseAdapter {
     // #3433: when we forced a `respond` tool to satisfy a non-text
     // responseFormat, surface its structured input as a text block so the
     // caller's JSON parser keeps working unchanged.
-    return this.mapResponse(response, forcesResponseTool(request));
+    // #4069: surface params dropped by the seam (e.g. temperature) as warnings.
+    return this.mapResponse(response, forcesResponseTool(request), dropped);
   }
 
   /**
@@ -223,7 +224,7 @@ export class ClaudeAdapter extends BaseAdapter {
     }
   ): Promise<void> {
     try {
-      const params = this.buildRequestParams(request);
+      const { params } = this.buildRequestParams(request);
       const stream = this.client.messages.stream(params);
 
       for await (const event of stream) {
@@ -243,9 +244,10 @@ export class ClaudeAdapter extends BaseAdapter {
   /**
    * Builds Anthropic API request parameters from our CompletionRequest.
    */
-  private buildRequestParams(
-    request: CompletionRequest
-  ): Anthropic.MessageCreateParamsNonStreaming {
+  private buildRequestParams(request: CompletionRequest): {
+    params: Anthropic.MessageCreateParamsNonStreaming;
+    dropped: readonly DroppedParam[];
+  } {
     // Filter out system messages and map the rest
     const messages = request.messages.filter((m) => m.role !== 'system').map(mapMessage);
 
@@ -261,19 +263,21 @@ export class ClaudeAdapter extends BaseAdapter {
       params.system = systemPrompt;
     }
 
-    // Apply optional parameters
-    this.applyOptionalParams(params, request);
+    // Apply optional parameters; the seam reports any params it dropped (#4069).
+    const dropped = this.applyOptionalParams(params, request);
 
-    return params;
+    return { params, dropped };
   }
 
   /**
    * Applies optional parameters to the request params.
+   *
+   * @returns the params the seam dropped (#4069) — surfaced as response warnings.
    */
   private applyOptionalParams(
     params: Anthropic.MessageCreateParamsNonStreaming,
     request: CompletionRequest
-  ): void {
+  ): readonly DroppedParam[] {
     // #4068: the temperature drop-decision (#4061: Claude after Opus 4.6 rejects
     // any non-1.0 temperature with a 400; omit it — 1.0 is the API default, so
     // omitting is equivalent) is centralized in the shared planOptionalParams seam.
@@ -302,12 +306,18 @@ export class ClaudeAdapter extends BaseAdapter {
       params.tools = [...(params.tools ?? []), respondTool];
       params.tool_choice = { type: 'tool', name: RESPOND_TOOL_NAME };
     }
+
+    return plan.dropped;
   }
 
   /**
    * Maps Anthropic API response to our CompletionResponse format.
    */
-  private mapResponse(response: Anthropic.Message, surfaceRespondTool = false): CompletionResponse {
+  private mapResponse(
+    response: Anthropic.Message,
+    surfaceRespondTool = false,
+    dropped: readonly DroppedParam[] = []
+  ): CompletionResponse {
     const content: ContentBlock[] = surfaceRespondTool
       ? mapResponseWithRespondTool(response.content)
       : response.content.map(mapContentBlock);
@@ -323,6 +333,10 @@ export class ClaudeAdapter extends BaseAdapter {
       usage,
       stopReason: mapStopReason(response.stop_reason),
       model: response.model,
+      // #4069: surface dropped params (e.g. an omitted temperature) so the caller
+      // can see a behavioral param had no effect. Omitted entirely when nothing
+      // was dropped (exactOptionalPropertyTypes).
+      ...(dropped.length > 0 ? { warnings: dropped } : {}),
     };
   }
 

--- a/packages/nexus-agents/src/adapters/openai-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-adapter.ts
@@ -33,7 +33,7 @@ import {
   getModelCapabilities,
   type OpenAIAdapterConfig,
 } from './openai-types.js';
-import { planOptionalParams } from './optional-params.js';
+import { planOptionalParams, type DroppedParam } from './optional-params.js';
 import {
   mapMessage,
   mapTool,
@@ -231,11 +231,17 @@ export class OpenAIAdapter extends BaseAdapter {
   protected override transformError(error: unknown): ModelError {
     if (error instanceof APIError) {
       const v = error as ApiErrorView;
-      // Classify on the original SDK message + status/code only.
-      const probe: Error & { status?: number | undefined; code?: string | null | undefined } =
-        new Error(typeof v.message === 'string' ? v.message : '');
+      // Classify on the original SDK message + status/code/param only. #4069: thread
+      // `param` so a param-naming 400 classifies as MODEL_PARAMETER_UNSUPPORTED and
+      // the param name reaches the error context.
+      const probe: Error & {
+        status?: number | undefined;
+        code?: string | null | undefined;
+        param?: string | undefined;
+      } = new Error(typeof v.message === 'string' ? v.message : '');
       probe.status = typeof v.status === 'number' ? v.status : undefined;
       probe.code = v.code ?? undefined;
+      probe.param = typeof v.param === 'string' && v.param !== '' ? v.param : undefined;
       probe.cause = error;
       const classified = super.transformError(probe);
       // Surface the full diagnostic detail in the final message (code/cause kept).
@@ -280,7 +286,7 @@ export class OpenAIAdapter extends BaseAdapter {
    * Executes the completion request against the OpenAI API.
    */
   private async executeCompletion(request: CompletionRequest): Promise<CompletionResponse> {
-    const params = this.buildRequestParams(request);
+    const { params, dropped } = this.buildRequestParams(request);
     // #3036: forward AbortSignal into the OpenAI SDK so withWatchdog
     // timeouts cancel the HTTP request instead of leaking it past the
     // Promise.race boundary. Branch on signal presence — vitest 4
@@ -290,7 +296,8 @@ export class OpenAIAdapter extends BaseAdapter {
       request.signal !== undefined
         ? await this.client.chat.completions.create(params, { signal: request.signal })
         : await this.client.chat.completions.create(params);
-    return this.mapResponse(response);
+    // #4069: surface params dropped by the seam (e.g. temperature) as warnings.
+    return this.mapResponse(response, dropped);
   }
 
   /**
@@ -305,7 +312,7 @@ export class OpenAIAdapter extends BaseAdapter {
     }
   ): Promise<void> {
     try {
-      const params = this.buildRequestParams(request);
+      const { params } = this.buildRequestParams(request);
       const stream = await this.client.chat.completions.create({ ...params, stream: true });
 
       let contentIndex = 0;
@@ -335,9 +342,10 @@ export class OpenAIAdapter extends BaseAdapter {
   /**
    * Builds OpenAI API request parameters from our CompletionRequest.
    */
-  private buildRequestParams(
-    request: CompletionRequest
-  ): OpenAI.Chat.ChatCompletionCreateParamsNonStreaming {
+  private buildRequestParams(request: CompletionRequest): {
+    params: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming;
+    dropped: readonly DroppedParam[];
+  } {
     const messages = this.buildMessages(request);
 
     const params: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming = {
@@ -346,8 +354,8 @@ export class OpenAIAdapter extends BaseAdapter {
       max_completion_tokens: request.maxTokens ?? DEFAULT_MAX_TOKENS,
     };
 
-    this.addOptionalParams(params, request);
-    return params;
+    const dropped = this.addOptionalParams(params, request);
+    return { params, dropped };
   }
 
   /**
@@ -378,7 +386,7 @@ export class OpenAIAdapter extends BaseAdapter {
   private addOptionalParams(
     params: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
     request: CompletionRequest
-  ): void {
+  ): readonly DroppedParam[] {
     // #4068: the temperature drop-decision (#4061: a gateway routing to a Claude
     // model after Opus 4.6, or an OpenAI reasoning model, rejects a non-1.0
     // temperature with a 400; omit it so a gateway-routed voter panel at the
@@ -399,6 +407,9 @@ export class OpenAIAdapter extends BaseAdapter {
     }
 
     this.addResponseFormat(params, request);
+
+    // #4069: report dropped params so mapResponse can surface them as warnings.
+    return plan.dropped;
   }
 
   /**
@@ -428,12 +439,15 @@ export class OpenAIAdapter extends BaseAdapter {
   /**
    * Maps OpenAI API response to our CompletionResponse format.
    */
-  private mapResponse(response: ChatCompletion): CompletionResponse {
+  private mapResponse(
+    response: ChatCompletion,
+    dropped: readonly DroppedParam[] = []
+  ): CompletionResponse {
     const firstChoice = response.choices[0];
 
     // Handle case where no choices are returned
     if (firstChoice === undefined) {
-      return this.createEmptyResponse(response);
+      return this.createEmptyResponse(response, dropped);
     }
 
     const content = mapChoiceToContentBlocks(firstChoice);
@@ -444,18 +458,25 @@ export class OpenAIAdapter extends BaseAdapter {
       usage,
       stopReason: mapStopReason(firstChoice.finish_reason),
       model: response.model,
+      // #4069: surface dropped params (e.g. an omitted temperature). Omitted
+      // entirely when nothing was dropped (exactOptionalPropertyTypes).
+      ...(dropped.length > 0 ? { warnings: dropped } : {}),
     };
   }
 
   /**
    * Creates an empty response when no choices are returned.
    */
-  private createEmptyResponse(response: ChatCompletion): CompletionResponse {
+  private createEmptyResponse(
+    response: ChatCompletion,
+    dropped: readonly DroppedParam[] = []
+  ): CompletionResponse {
     return {
       content: [{ type: 'text', text: '' }],
       usage: mapResponseUsage(response),
       stopReason: 'end_turn',
       model: response.model,
+      ...(dropped.length > 0 ? { warnings: dropped } : {}),
     };
   }
 

--- a/packages/nexus-agents/src/adapters/optional-params.test.ts
+++ b/packages/nexus-agents/src/adapters/optional-params.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { planOptionalParams } from './optional-params.js';
+import {
+  planOptionalParams,
+  parameterSeverity,
+  recordWouldHaveSelfHealed,
+  getWouldHaveSelfHealedCounts,
+  _resetWouldHaveSelfHealed,
+} from './optional-params.js';
 import { _resetTemperatureWarnings } from '../config/temperature-support.js';
 import { modelSupportsParameter } from '../config/model-parameter-support.js';
 import type { CompletionRequest } from '../core/index.js';
@@ -93,5 +99,65 @@ describe('planOptionalParams', () => {
       planOptionalParams(makeRequest({ temperature: 0.3 }), 'claude-opus-4-8').transformed
     ).toEqual([]);
     expect(planOptionalParams(makeRequest(), 'gpt-4o').transformed).toEqual([]);
+  });
+
+  describe('dropped param severity (#4069)', () => {
+    it('tags a dropped temperature entry as behavioral', () => {
+      const plan = planOptionalParams(makeRequest({ temperature: 0.3 }), 'claude-opus-4-8');
+      expect(plan.dropped[0]).toMatchObject({ param: 'temperature', severity: 'behavioral' });
+    });
+  });
+});
+
+describe('parameterSeverity (#4069)', () => {
+  it.each(['temperature', 'seed', 'top_p'])('classifies %s as behavioral', (param) => {
+    expect(parameterSeverity(param)).toBe('behavioral');
+  });
+
+  it.each(['max_tokens', 'stop', 'foo'])('classifies %s as cosmetic', (param) => {
+    expect(parameterSeverity(param)).toBe('cosmetic');
+  });
+});
+
+describe('would-have-self-healed counter (#4069)', () => {
+  beforeEach(() => {
+    _resetTemperatureWarnings();
+    _resetWouldHaveSelfHealed();
+  });
+
+  it('increments on a proactive temperature drop, keyed by model:param', () => {
+    expect(getWouldHaveSelfHealedCounts().size).toBe(0);
+    planOptionalParams(makeRequest({ temperature: 0.3 }), 'claude-opus-4-8');
+    expect(getWouldHaveSelfHealedCounts().get('claude-opus-4-8:temperature')).toBe(1);
+  });
+
+  it('counts every drop (not deduped) — reflects how often #4071 would have fired', () => {
+    planOptionalParams(makeRequest({ temperature: 0.3 }), 'o3-mini');
+    planOptionalParams(makeRequest({ temperature: 0.3 }), 'o3-mini');
+    expect(getWouldHaveSelfHealedCounts().get('o3-mini:temperature')).toBe(2);
+  });
+
+  it('does not increment for supported models (no drop)', () => {
+    planOptionalParams(makeRequest({ temperature: 0.5 }), 'gpt-4o');
+    expect(getWouldHaveSelfHealedCounts().size).toBe(0);
+  });
+
+  it('recordWouldHaveSelfHealed increments directly (reactive-path entry)', () => {
+    recordWouldHaveSelfHealed('gpt-5.4', 'temperature');
+    recordWouldHaveSelfHealed('gpt-5.4', 'temperature');
+    expect(getWouldHaveSelfHealedCounts().get('gpt-5.4:temperature')).toBe(2);
+  });
+
+  it('getWouldHaveSelfHealedCounts returns a defensive copy', () => {
+    recordWouldHaveSelfHealed('gpt-5.4', 'temperature');
+    const snapshot = getWouldHaveSelfHealedCounts() as Map<string, number>;
+    snapshot.set('gpt-5.4:temperature', 999);
+    expect(getWouldHaveSelfHealedCounts().get('gpt-5.4:temperature')).toBe(1);
+  });
+
+  it('reset clears the counter', () => {
+    recordWouldHaveSelfHealed('gpt-5.4', 'temperature');
+    _resetWouldHaveSelfHealed();
+    expect(getWouldHaveSelfHealedCounts().size).toBe(0);
   });
 });

--- a/packages/nexus-agents/src/adapters/optional-params.ts
+++ b/packages/nexus-agents/src/adapters/optional-params.ts
@@ -20,10 +20,53 @@ import { modelSupportsParameter } from '../config/model-parameter-support.js';
 import { warnTemperatureDropped } from '../config/temperature-support.js';
 import type { CompletionRequest } from '../core/index.js';
 
+/**
+ * Severity of a dropped param (#4069, epic #4066 layer 3). Behavioral params
+ * (temperature/seed/top_p) affect determinism/output — dropping one silently is
+ * the canonical footgun, so it is surfaced LOUDLY (WARN). Everything else is
+ * cosmetic — dropping it is quiet (DEBUG).
+ */
+export type ParamSeverity = 'behavioral' | 'cosmetic';
+
+/** Params whose silent drop changes model output/determinism — loud when dropped. */
+const BEHAVIORAL_PARAMS = new Set<string>(['temperature', 'seed', 'top_p']);
+
+/** Classify a request param as behavioral (loud-on-drop) or cosmetic (quiet). */
+export function parameterSeverity(param: string): ParamSeverity {
+  return BEHAVIORAL_PARAMS.has(param) ? 'behavioral' : 'cosmetic';
+}
+
 /** A request param the seam dropped, with why (feeds the layer-3 telemetry child #4069). */
 export interface DroppedParam {
   readonly param: string;
   readonly reason: string;
+  /** Behavioral (loud) vs cosmetic (quiet) — see {@link parameterSeverity}. */
+  readonly severity: ParamSeverity;
+}
+
+/**
+ * Would-have-self-healed counter (#4069, epic #4066 layer 3). Keyed
+ * `${modelId}:${param}`. Counts every PROACTIVE drop (this module) AND every
+ * REACTIVE param-naming 400 the adapter classifies as MODEL_PARAMETER_UNSUPPORTED
+ * (base-adapter). Both are exactly the events the reactive self-heal path (#4071)
+ * would catch, so this single counter measures how often #4071 would have fired.
+ */
+const wouldHaveSelfHealed = new Map<string, number>();
+
+/** Record one would-have-self-healed event for `modelId`'s `param` (#4069). */
+export function recordWouldHaveSelfHealed(modelId: string, param: string): void {
+  const key = `${modelId}:${param}`;
+  wouldHaveSelfHealed.set(key, (wouldHaveSelfHealed.get(key) ?? 0) + 1);
+}
+
+/** Snapshot of the would-have-self-healed counts (defensive copy). */
+export function getWouldHaveSelfHealedCounts(): ReadonlyMap<string, number> {
+  return new Map(wouldHaveSelfHealed);
+}
+
+/** Test seam: clear the would-have-self-healed counter. */
+export function _resetWouldHaveSelfHealed(): void {
+  wouldHaveSelfHealed.clear();
 }
 
 /** A request param the seam transformed (name/value). Reserved for #4069 / a later max-tokens increment; empty today. */
@@ -56,8 +99,19 @@ export function planOptionalParams(request: CompletionRequest, modelId: string):
     if (modelSupportsParameter(modelId, 'temperature')) {
       temperature = request.temperature;
     } else {
+      // ONE loud line per drop, deduped: warnTemperatureDropped is the consolidated
+      // behavioral WARN (severity:'behavioral'), once per model then debug (#4066
+      // layer 3). temperature is the only param dropped today and it is behavioral,
+      // so there is no second emit — adding one would double-warn.
       warnTemperatureDropped(modelId);
-      dropped.push({ param: 'temperature', reason: `model_rejects:${modelId}` });
+      // Record the proactive drop: every time the reactive self-heal path (#4071)
+      // would have fired on a temperature-rejecting 400.
+      recordWouldHaveSelfHealed(modelId, 'temperature');
+      dropped.push({
+        param: 'temperature',
+        reason: `model_rejects:${modelId}`,
+        severity: parameterSeverity('temperature'),
+      });
     }
   }
   return { ...(temperature !== undefined ? { temperature } : {}), dropped, transformed: [] };

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -30,7 +30,7 @@ import { isRateLimitLikeError } from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
-import { planOptionalParams } from '../optional-params.js';
+import { planOptionalParams, type DroppedParam } from '../optional-params.js';
 import {
   validateCustomApiBaseUrl,
   assertCustomApiHostResolvesPublic,
@@ -380,7 +380,10 @@ export class SdkAdapter extends BaseAdapter {
   /**
    * Maps our CompletionRequest to AI SDK generateText options.
    */
-  private buildSdkOptions(request: CompletionRequest): Record<string, unknown> {
+  private buildSdkOptions(request: CompletionRequest): {
+    options: Record<string, unknown>;
+    dropped: readonly DroppedParam[];
+  } {
     const options: Record<string, unknown> = {
       model: this.model,
       messages: request.messages.map((m) => ({
@@ -413,7 +416,8 @@ export class SdkAdapter extends BaseAdapter {
       options['stopSequences'] = request.stop;
     }
 
-    return options;
+    // #4069: report dropped params so complete() can surface them as warnings.
+    return { options, dropped: plan.dropped };
   }
 
   /**
@@ -483,16 +487,21 @@ export class SdkAdapter extends BaseAdapter {
             'Ensure ensureInitialized() completes before calling complete().'
         );
       }
-      const options = this.buildSdkOptions(request);
+      const { options, dropped } = this.buildSdkOptions(request);
 
       // #3433: native structured output. json_object/json_schema route
       // through generateObject; everything else keeps the generateText path
       // unchanged.
       const responseFormat = request.responseFormat;
-      const response =
+      const base =
         responseFormat !== undefined && responseFormat.type !== 'text'
           ? await this.completeStructured(sdk, options, responseFormat)
           : await this.completeText(sdk, options);
+
+      // #4069: surface params dropped by the seam (e.g. temperature) as warnings.
+      // Omitted entirely when nothing was dropped (exactOptionalPropertyTypes).
+      const response: CompletionResponse =
+        dropped.length > 0 ? { ...base, warnings: dropped } : base;
 
       this.logResponse(response);
       return ok(response);
@@ -516,7 +525,7 @@ export class SdkAdapter extends BaseAdapter {
       });
     }
 
-    const options = this.buildSdkOptions(request);
+    const { options } = this.buildSdkOptions(request);
 
     // First yield establishes the generator — errors after this point are
     // properly caught by callers using for-await-of with try/catch.

--- a/packages/nexus-agents/src/core/errors.test.ts
+++ b/packages/nexus-agents/src/core/errors.test.ts
@@ -44,6 +44,7 @@ describe('ErrorCode', () => {
     expect(ErrorCode.MODEL_UNAVAILABLE).toBe('MODEL_UNAVAILABLE');
     expect(ErrorCode.MODEL_RATE_LIMITED).toBe('MODEL_RATE_LIMITED');
     expect(ErrorCode.MODEL_TIMEOUT).toBe('MODEL_TIMEOUT');
+    expect(ErrorCode.MODEL_PARAMETER_UNSUPPORTED).toBe('MODEL_PARAMETER_UNSUPPORTED');
   });
 
   it('contains all agent error codes', () => {

--- a/packages/nexus-agents/src/core/errors.ts
+++ b/packages/nexus-agents/src/core/errors.ts
@@ -33,6 +33,15 @@ export const ErrorCode = {
   MODEL_NOT_FOUND: 'MODEL_NOT_FOUND',
   MODEL_RATE_LIMITED: 'MODEL_RATE_LIMITED',
   MODEL_TIMEOUT: 'MODEL_TIMEOUT',
+  /**
+   * The model rejected a request parameter by name — a 400 that identifies an
+   * unsupported `param` (e.g. a post-Opus-4.6 Claude or an OpenAI reasoning model
+   * 400-ing on `temperature`). NON-RETRYABLE: retrying an identical request with
+   * the same bad param will 400 again. The offending param name is carried in the
+   * error `context.param`. Distinct from generic MODEL_ERROR so callers/telemetry
+   * (#4069) and the reactive self-heal path (#4071) can act on the named param.
+   */
+  MODEL_PARAMETER_UNSUPPORTED: 'MODEL_PARAMETER_UNSUPPORTED',
 
   // Agent errors
   AGENT_ERROR: 'AGENT_ERROR',

--- a/packages/nexus-agents/src/core/types/model.ts
+++ b/packages/nexus-agents/src/core/types/model.ts
@@ -144,6 +144,20 @@ export interface CompletionResponse {
   stopReason: StopReason;
   /** Model that generated the response */
   model: string;
+  /**
+   * Request params the adapter dropped before sending (#4069, epic #4066 layer 3).
+   * Present (and non-empty) only when a param was silently unsupported — e.g. a
+   * post-Opus-4.6 Claude or OpenAI reasoning model that rejects `temperature`. The
+   * request still ran (at the provider default); this surfaces what was omitted so
+   * the caller can SEE a behavioral param had no effect. Absent when nothing was
+   * dropped. Typed via the adapter-layer {@link DroppedParam} shape, re-declared
+   * structurally here to avoid a core→adapters import cycle.
+   */
+  warnings?: readonly {
+    readonly param: string;
+    readonly reason: string;
+    readonly severity: 'behavioral' | 'cosmetic';
+  }[];
 }
 
 /**


### PR DESCRIPTION
## What
Layer 3 of epic #4066 — the core "fail loudly, never drop silently" deliverable. A silently-ignored `temperature` makes `temp=0` and `temp=0.7` produce identical output — determinism lost with no signal. This makes every drop visible.

Four parts:
1. **Severity policy** — `planOptionalParams` classifies dropped params: **behavioral** (`temperature`/`seed`/`top_p` — affect determinism) vs **cosmetic**. Temperature stays loud (one deduped WARN per model); severity flows into the `DroppedParam` record.
2. **Response surface** — `CompletionResponse` gains an optional `warnings` field; the claude/openai/sdk adapters thread `plan.dropped` to `mapResponse` so a caller can **see** a behavioral param had no effect (Vercel AI SDK `warnings` pattern). Absent when nothing dropped. Gemini/Ollama never drop → untouched.
3. **`MODEL_PARAMETER_UNSUPPORTED` error code** — `determineErrorCode` classifies a 400 that **names** a param (only those — param-less 400s and non-400s are unchanged; a 429-with-param stays `MODEL_RATE_LIMITED`), carrying the param in `context.param`. **Non-retryable**: `retry.ts isRetryableError` is a default-deny allowlist the code isn't in (a test pins `isRetryableError === false`).
4. **Would-have-self-healed counter** — records every proactive drop **and** every param-400, measuring how often reactive self-heal (#4071) would fire — settling the layer-5 fork empirically, with a getter for inspection.

## Verification
`tsc --noEmit` clean · **2144 adapter+core tests pass** (new: severity, counter, param-400 classification + non-retryable + context, response warnings present/absent, ErrorCode enumeration) · eslint clean · producer/consumer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)