### PR TITLE
test(ci): model-parameter drift guard via a named incompatibility registry (#4070, epic #4066)

### DIFF
--- a/.changeset/param-incompatibility-drift-guard.md
+++ b/.changeset/param-incompatibility-drift-guard.md
@@ -1,0 +1,12 @@
+---
+'nexus-agents': patch
+---
+
+Add the model-parameter drift guard (#4070, epic #4066 layer 4): a single declarative,
+exported `KNOWN_PARAMETER_INCOMPATIBILITIES` registry of the documented incidents
+(#4061 Claude>4.6, #4062 OpenAI reasoning, #4049 max_completion_tokens), asserted in CI
+against the resolver. The next param drift — a bumped Claude threshold, an edited regex,
+a removed `unsupportedParameters` — now fails CI instead of 400-ing in production. The
+registry is exported so it doubles as documentation and as the anchor for the deferred
+provider-reality reconciliation. Part 2 (scheduled OpenRouter `supported_parameters`
+reconciliation) is tracked separately.

--- a/packages/nexus-agents/src/config/model-parameter-support.test.ts
+++ b/packages/nexus-agents/src/config/model-parameter-support.test.ts
@@ -15,6 +15,7 @@ import {
   unsupportedParametersForModel,
   modelSupportsParameter,
   getMaxTokensParamForModel,
+  KNOWN_PARAMETER_INCOMPATIBILITIES,
 } from './model-parameter-support.js';
 import { temperatureUnsupportedForModel } from './temperature-support.js';
 
@@ -106,5 +107,29 @@ describe('determinism — same id yields the same result twice', () => {
   it.each(['codex-5.3', 'claude-opus-4-8', 'o3-mini', 'gpt-4o'])('%s', (id) => {
     expect(unsupportedParametersForModel(id)).toEqual(unsupportedParametersForModel(id));
     expect(getMaxTokensParamForModel(id)).toBe(getMaxTokensParamForModel(id));
+  });
+});
+
+describe('DRIFT GUARD — documented incompatibilities must never regress (#4070)', () => {
+  // Each entry is a real incident (#4061/#4062/#4049). If a resolver/data edit ever
+  // stops handling one — a bumped Claude threshold, an edited regex, a removed
+  // `unsupportedParameters` — this fails CI instead of 400-ing in production.
+  it('the registry is non-empty and every entry names exactly one expectation', () => {
+    expect(KNOWN_PARAMETER_INCOMPATIBILITIES.length).toBeGreaterThan(0);
+    for (const e of KNOWN_PARAMETER_INCOMPATIBILITIES) {
+      // Exactly one of `param` / `maxTokensParam` per entry.
+      expect((e.param !== undefined) !== (e.maxTokensParam !== undefined)).toBe(true);
+      expect(e.issue).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(
+    KNOWN_PARAMETER_INCOMPATIBILITIES.map((e) => [`#${String(e.issue)} ${e.modelId}`, e] as const)
+  )('%s is still handled by the resolver', (_label, e) => {
+    if (e.param !== undefined) {
+      expect(modelSupportsParameter(e.modelId, e.param)).toBe(false);
+    } else {
+      expect(getMaxTokensParamForModel(e.modelId)).toBe(e.maxTokensParam);
+    }
   });
 });

--- a/packages/nexus-agents/src/config/model-parameter-support.ts
+++ b/packages/nexus-agents/src/config/model-parameter-support.ts
@@ -154,3 +154,45 @@ export function getMaxTokensParamForModel(modelId: string): 'max_tokens' | 'max_
   if (cap?.maxTokensParam !== undefined) return cap.maxTokensParam;
   return regexIsOpenAiReasoning(modelId) ? 'max_completion_tokens' : 'max_tokens';
 }
+
+// ---------------------------------------------------------------------------
+// Known-incompatibility registry — the drift guard's source of truth (#4070)
+// ---------------------------------------------------------------------------
+
+/**
+ * One DOCUMENTED model-parameter incompatibility — a real incident the resolver
+ * MUST keep handling. A `param` entry asserts the model rejects that request
+ * parameter ({@link modelSupportsParameter} must be false); a `maxTokensParam`
+ * entry asserts the max-tokens field name ({@link getMaxTokensParamForModel}).
+ */
+export interface KnownParameterIncompatibility {
+  /** A model id that hits the case (registry-encoded OR regex-fallback). */
+  readonly modelId: string;
+  /** The rejected request parameter (mutually exclusive with `maxTokensParam`). */
+  readonly param?: string;
+  /** The expected max-tokens field name (mutually exclusive with `param`). */
+  readonly maxTokensParam?: 'max_tokens' | 'max_completion_tokens';
+  /** The GitHub incident this case locks in, so a reviewer sees WHY it matters. */
+  readonly issue: number;
+}
+
+/**
+ * The documented model-parameter incompatibilities (#4061/#4062/#4049) as a single
+ * declarative, greppable source of truth. The layer-4 drift guard (#4070) asserts
+ * every entry against the resolver, so the next param drift — a bumped Claude
+ * threshold, an edited regex, a removed `unsupportedParameters` on a registered
+ * model — fails CI instead of silently 400-ing in production. Exported so it doubles
+ * as documentation and as the anchor the (deferred) provider-reality reconciliation
+ * checks against. Spans BOTH the registry data path and the regex fallback path.
+ */
+export const KNOWN_PARAMETER_INCOMPATIBILITIES: readonly KnownParameterIncompatibility[] = [
+  // #4061 — Claude after Opus 4.6 rejects a non-1.0 temperature with a 400 (regex fallback; unregistered concrete id).
+  { modelId: 'claude-opus-4-8', param: 'temperature', issue: 4061 },
+  // #4062 — OpenAI reasoning families reject temperature (o-series/gpt-5 via regex fallback; codex via registry data).
+  { modelId: 'o3-mini', param: 'temperature', issue: 4062 },
+  { modelId: 'gpt-5', param: 'temperature', issue: 4062 },
+  { modelId: 'codex-5.3', param: 'temperature', issue: 4062 },
+  // #4049 — OpenAI reasoning models expect `max_completion_tokens`, not `max_tokens` (codex via registry; o-series via fallback).
+  { modelId: 'codex-5.3', maxTokensParam: 'max_completion_tokens', issue: 4049 },
+  { modelId: 'o3-mini', maxTokensParam: 'max_completion_tokens', issue: 4049 },
+];


### PR DESCRIPTION
## What
Layer 4 of epic #4066. A single declarative, **exported** `KNOWN_PARAMETER_INCOMPATIBILITIES` registry of the documented incidents (#4061 Claude>4.6, #4062 OpenAI reasoning, #4049 `max_completion_tokens`), asserted in CI against the resolver. The next param drift — a bumped Claude threshold, an edited regex, a removed `unsupportedParameters` on a registered model — now **fails CI** instead of silently 400-ing in production.

## Honest scoping (survey-driven)
A survey confirmed #4067's parity test **already covers** the three incident cases on both the data and regex paths — so this adds **near-zero new coverage by design**. Its value is making the "these incidents must never regress" guarantee **explicit, greppable, keyed to the issue numbers**, and a single exported source of truth (DRY for the incident knowledge) — plus the concrete **anchor** the deferred provider-reality reconciliation checks against.

## Part 2 deferred → #4121
The larger, separable piece the issue flagged ("need not run on every CI pass; could be a scheduled job") — the OpenRouter `supported_parameters` reconciliation — is split to **#4121**, modeled on `pricing-drift.yml`. An internal-only guard can stay green while the hand-maintained map diverges from provider reality; #4121 closes that gap externally on a schedule.

## Verification
`tsc --noEmit` clean · **36 resolver tests pass** (6 new registry-driven guard cases) · the registry is exported so it doubles as documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)