### PR TITLE
feat(cli): single-source on-error usage examples from COMMAND_HELP (#3209, epic #3691)

### DIFF
--- a/.changeset/usage-examples-single-source.md
+++ b/.changeset/usage-examples-single-source.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Single-source the CLI on-error usage examples from `COMMAND_HELP` (#3209, epic #3691).
+`printVoteUsage` / `printOrchestrateUsage` previously hand-maintained example strings that
+had drifted from each command's `--help` examples; they now render their Examples block
+from the shared `getCommandHelp(command).examples`, so the on-error usage can't diverge from
+`nexus-agents <cmd> --help`. A drift-guard test pins the single-source invariant. Completes
+the residual of #3209 — the description consolidation already shipped via #3212's parity-gate
+(Option B) and the help-text derivation.

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -274,13 +274,26 @@ function describe(command: string): string {
 }
 
 /**
+ * Look up the richer help entry (examples/flags/api-key needs) for a command.
+ * The single source other surfaces derive from — e.g. the error-usage messages
+ * in `cli-commands-usage.ts` render their Examples block from `entry.examples`
+ * rather than hand-maintaining a parallel (drift-prone) copy (#3209, epic #3691).
+ *
+ * @param command - The command name to look up
+ * @returns The {@link CommandHelpEntry}, or undefined if none exists
+ */
+export function getCommandHelp(command: string): CommandHelpEntry | undefined {
+  return COMMAND_HELP.find((e) => e.command === command);
+}
+
+/**
  * Formats help output for a specific command.
  *
  * @param command - The command name to look up
  * @returns Formatted help string, or undefined if no help entry exists
  */
 export function formatCommandHelp(command: string): string | undefined {
-  const entry = COMMAND_HELP.find((e) => e.command === command);
+  const entry = getCommandHelp(command);
   if (entry === undefined) return undefined;
 
   const lines: string[] = [];

--- a/packages/nexus-agents/src/cli-commands-usage.test.ts
+++ b/packages/nexus-agents/src/cli-commands-usage.test.ts
@@ -9,6 +9,7 @@ import {
   printVoteUsage,
   printWorkflowRunUsage,
 } from './cli-commands-usage.js';
+import { getCommandHelp } from './cli-command-help.js';
 
 describe('cli-commands-usage', () => {
   let writeSpy: MockInstance;
@@ -193,6 +194,23 @@ describe('cli-commands-usage', () => {
       printValidationUsage();
       const output = writeSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Options:');
+    });
+  });
+
+  // DRIFT GUARD (#3209, epic #3691): the on-error usage examples are single-sourced
+  // from COMMAND_HELP, so they can't diverge from `nexus-agents <cmd> --help`.
+  describe('usage examples are single-sourced from COMMAND_HELP', () => {
+    it.each([
+      ['vote', printVoteUsage],
+      ['orchestrate', printOrchestrateUsage],
+    ] as const)('%s usage renders exactly the COMMAND_HELP examples', (command, printUsage) => {
+      printUsage();
+      const output = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+      const examples = getCommandHelp(command)?.examples ?? [];
+      expect(examples.length).toBeGreaterThan(0);
+      for (const example of examples) {
+        expect(output).toContain(`  ${example}\n`);
+      }
     });
   });
 });

--- a/packages/nexus-agents/src/cli-commands-usage.ts
+++ b/packages/nexus-agents/src/cli-commands-usage.ts
@@ -7,6 +7,30 @@
  * (Source: Extracted from cli-commands.ts for #272)
  */
 
+import { getCommandHelp } from './cli-command-help.js';
+
+/**
+ * Print a standard "missing required arg" usage message whose Examples block is
+ * single-sourced from {@link getCommandHelp} (#3209, epic #3691) — so the on-error
+ * examples can't drift from `nexus-agents <cmd> --help`. The Examples section is
+ * omitted when the command has no registered help examples.
+ */
+function printUsageWithExamples(opts: {
+  readonly error: string;
+  readonly usage: string;
+  readonly command: string;
+}): void {
+  process.stdout.write(`Error: ${opts.error}\n`);
+  process.stdout.write(`Usage: ${opts.usage}\n`);
+  const examples = getCommandHelp(opts.command)?.examples ?? [];
+  if (examples.length > 0) {
+    process.stdout.write('Examples:\n');
+    for (const example of examples) {
+      process.stdout.write(`  ${example}\n`);
+    }
+  }
+}
+
 /**
  * Prints workflow run usage and exits.
  */
@@ -31,24 +55,22 @@ export function printRoutingAuditUsage(): void {
  * Prints orchestrate command usage and exits.
  */
 export function printOrchestrateUsage(): void {
-  process.stdout.write('Error: Task description is required.\n');
-  process.stdout.write('Usage: nexus-agents orchestrate <task> [options]\n');
-  process.stdout.write('Examples:\n');
-  process.stdout.write('  nexus-agents orchestrate "Explain this function"\n');
-  process.stdout.write('  nexus-agents orchestrate "Generate tests" --model=claude\n');
-  process.stdout.write('  nexus-agents orchestrate "Refactor code" --dry-run\n');
+  printUsageWithExamples({
+    error: 'Task description is required.',
+    usage: 'nexus-agents orchestrate <task> [options]',
+    command: 'orchestrate',
+  });
 }
 
 /**
  * Prints vote command usage and exits.
  */
 export function printVoteUsage(): void {
-  process.stdout.write('Error: Proposal is required.\n');
-  process.stdout.write('Usage: nexus-agents vote --proposal "..." [options]\n');
-  process.stdout.write('Examples:\n');
-  process.stdout.write('  nexus-agents vote --proposal "Add feature X"\n');
-  process.stdout.write('  nexus-agents vote -p "Proposal" -t supermajority\n');
-  process.stdout.write('  nexus-agents vote -p "Quick decision" --quick\n');
+  printUsageWithExamples({
+    error: 'Proposal is required.',
+    usage: 'nexus-agents vote --proposal "..." [options]',
+    command: 'vote',
+  });
 }
 
 /**


### PR DESCRIPTION
## What
The remaining residual of #3209 (epic #3691: one command-metadata source feeding help/usage). `printVoteUsage` / `printOrchestrateUsage` hand-maintained example strings that had **drifted** from each command's `--help` examples (vote showed 3 stale examples vs `VOTE_HELP`'s 4, with different prose). They now render their Examples block from the shared `getCommandHelp(command).examples`, so the on-error usage **can't diverge** from `nexus-agents <cmd> --help`. A new drift-guard test pins the single-source invariant.

## Survey finding (why this is small)
A survey confirmed #3209's core was **already delivered**: descriptions are single-sourced via #3212's parity gate (Option B, 7-0 vote that *rejected* a unified-registry class) + the `cli-help-text.ts`/`cli-command-help.ts` derivation. The **only ungated drift source left** was `cli-commands-usage.ts`'s hardcoded examples — this closes it. Out of scope (no example duplication): subcommand-list usage (research/index) and commands with no `COMMAND_HELP` entry (routing-audit/validation).

## Verification
`tsc --noEmit` clean · 47 cli-help/usage tests pass (the existing loose assertions are unchanged; the new gate asserts the usage examples == `COMMAND_HELP` examples by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)