### PR TITLE
fix(consensus): voter-output resilience — stop dropping voters on output shape (#4131, epic #4130)

### DIFF
--- a/.changeset/voter-output-resilience.md
+++ b/.changeset/voter-output-resilience.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Stop dropping voters on output SHAPE (#4131, epic #4130). The shared voter parser
+(`cli/voter-response.ts`) used by `consensus_vote` and `pr_review` previously discarded a
+voter — silently removing it from the panel denominator — whenever its output tripped the
+parser/schema: (1) reasoning >4000 chars hard-failed validation; (2) `extractJsonFromResponse`
+grabbed a ` ```yaml findings ` fence and fed YAML to `JSON.parse`; (3) a large findings vote
+was cut mid-JSON by the token cap. The most thorough voter (the contrarian) was the likeliest
+to be dropped — exactly the reviewer a panel exists to protect.
+
+Now: extraction prefers a ```json fence, skips non-JSON fences, extracts the first *balanced*
+JSON object (string/escape-aware) and repairs a truncated one; oversize `reasoning`/`claim`is truncated with a`…[truncated]` marker instead of hard-rejected; and the vote completion
+token cap is raised (2000→4000) so findings-bearing verdicts aren't cut off. A genuinely
+malformed vote still errors. (The governance-semantics fix — an errored voter degrading the
+verdict instead of shrinking the denominator — is tracked separately in #4132.)

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -258,8 +258,12 @@ function buildVoteRequest(
       { role: 'system', content: VOTER_SYSTEM_PROMPTS[role] },
       { role: 'user', content: buildVotePrompt(proposal) },
     ],
-    // 2000 (#2245): JSON envelope + reasoning + YAML findings exceed the old 500.
-    maxTokens: 2000,
+    // 4000 (#4131): headroom so a findings-bearing verdict (JSON envelope +
+    // reasoning + structured findings) isn't cut mid-JSON by the token cap and
+    // silently dropped. Was 2000 (#2245, up from 500); large contrarian findings
+    // still overflowed it. Non-findings votes stop at natural completion, so the
+    // higher cap adds no cost for them.
+    maxTokens: 4000,
     temperature: 0.3, // Low temperature for consistent evaluations
     // Thread the vote budget so the CLI timeout doesn't fire first (#3304); pass
     // signal too for CLI-vs-API cancellation parity (#3036/#3304).

--- a/packages/nexus-agents/src/cli/voter-response.test.ts
+++ b/packages/nexus-agents/src/cli/voter-response.test.ts
@@ -901,3 +901,79 @@ describe('buildVotePrompt workflow-test criteria', () => {
     expect(prompt).toContain('Example reject response');
   });
 });
+
+// ============================================================================
+// #4131 — voter-output resilience: stop dropping voters on output shape
+// ============================================================================
+
+describe('#4131 voter-output resilience', () => {
+  const role: VoterRole = 'catfish'; // the contrarian — most affected by shape drops
+
+  describe('extractJsonFromResponse — shape-aware', () => {
+    it('prefers a ```json fence', () => {
+      const text = 'Here is my vote:\n```json\n{"decision":"approve","confidence":0.9}\n```';
+      expect(JSON.parse(extractJsonFromResponse(text))).toMatchObject({ decision: 'approve' });
+    });
+
+    it('takes the JSON verdict and IGNORES a trailing ```yaml findings block', () => {
+      const text =
+        '{"decision":"reject","reasoning":"see findings","confidence":0.8}\n\n```yaml findings\n- severity: high\n  claim: bad\n```';
+      const parsed = JSON.parse(extractJsonFromResponse(text)) as { decision: string };
+      expect(parsed.decision).toBe('reject');
+    });
+
+    it('finds the JSON verdict even when a ```yaml findings block leads (repro: Unexpected token y)', () => {
+      const text =
+        '```yaml findings\n- severity: high\n  claim: something\n```\n{"decision":"approve","reasoning":"ok enough","confidence":0.7}';
+      // Previously extractJsonFromResponse returned the yaml block → JSON.parse threw
+      // "Unexpected token 'y', \"yaml findi\"...". Now it returns the JSON object.
+      expect(() => {
+        JSON.parse(extractJsonFromResponse(text));
+      }).not.toThrow();
+      expect(JSON.parse(extractJsonFromResponse(text))).toMatchObject({ decision: 'approve' });
+    });
+
+    it('does not miscount braces/brackets inside string values', () => {
+      const text =
+        '{"decision":"approve","reasoning":"uses { and } and ] in prose","confidence":0.5}';
+      expect(JSON.parse(extractJsonFromResponse(text))).toMatchObject({
+        reasoning: 'uses { and } and ] in prose',
+      });
+    });
+
+    it('repairs a truncated object (repro: position 7181 mid-JSON cut)', () => {
+      // decision/reasoning/confidence emitted before a findings array cut off mid-value.
+      const truncated =
+        '{"decision":"reject","reasoning":"blockers found","confidence":0.9,"findings":[{"severity":"high","claim":"this was cut of';
+      const repaired = extractJsonFromResponse(truncated);
+      const parsed = JSON.parse(repaired) as { decision: string; findings: unknown[] };
+      expect(parsed.decision).toBe('reject');
+      expect(Array.isArray(parsed.findings)).toBe(true);
+    });
+  });
+
+  describe('parseVoteResponse — no silent drop on shape', () => {
+    it('clamps oversize reasoning with a marker instead of erroring (repro: >4000 char drop)', () => {
+      const huge = 'x'.repeat(5000);
+      const output = JSON.stringify({ decision: 'reject', reasoning: huge, confidence: 0.9 });
+      const vote = parseVoteResponse(output, role);
+      expect(vote.source).toBe('parsed'); // NOT 'error' / dropped
+      expect(vote.decision).toBe('reject');
+      expect(vote.reasoning.length).toBeLessThanOrEqual(4000);
+      expect(vote.reasoning.endsWith('…[truncated]')).toBe(true);
+    });
+
+    it('parses a pr-review-style output (JSON verdict + trailing yaml findings block)', () => {
+      const output =
+        '{"decision":"approve","reasoning":"looks fine overall","confidence":0.8}\n```yaml findings\n- claim: nit\n```';
+      const vote = parseVoteResponse(output, role);
+      expect(vote.source).toBe('parsed');
+      expect(vote.decision).toBe('approve');
+    });
+
+    it('still throws on a genuinely malformed vote (missing decision) — behavior preserved', () => {
+      const output = '{"reasoning":"no decision field here","confidence":0.5}';
+      expect(() => parseVoteResponse(output, role)).toThrow(SyntheticVoteError);
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli/voter-response.ts
+++ b/packages/nexus-agents/src/cli/voter-response.ts
@@ -309,23 +309,109 @@ ${VOTE_PROMPT_EXAMPLES}`;
 // ============================================================================
 
 /**
- * Extracts JSON from LLM response text.
- * Handles responses that may include markdown code blocks.
+ * Extract the FIRST balanced top-level JSON object from `text`, respecting
+ * string literals + escapes so braces/brackets inside strings don't miscount
+ * (#4131). Returns the object substring, or undefined if no `{` is present.
+ *
+ * If the object is TRUNCATED (containers still open at end-of-input — e.g. a
+ * large findings-bearing vote cut off by the completion token cap), it returns a
+ * best-effort repair: the open string is closed and the open `{`/`[` containers
+ * are closed in order. Since a well-formed vote emits `decision`/`reasoning`/
+ * `confidence` before the optional `findings` array, a truncation inside
+ * `findings` still yields a parseable verdict. If the repair is still invalid,
+ * the caller's JSON.parse throws exactly as before (no regression).
+ */
+/** Mutable scan state for {@link extractFirstJsonObject}. */
+interface JsonScanState {
+  readonly closers: string[];
+  inString: boolean;
+  escaped: boolean;
+}
+
+type ScanResult = 'complete' | 'unbalanced' | 'continue';
+
+/** Handle one char while inside a JSON string literal. */
+function stepInString(state: JsonScanState, ch: string): void {
+  if (ch === '\\') state.escaped = true;
+  else if (ch === '"') state.inString = false;
+}
+
+/** Handle one structural (non-string) char, tracking open/close containers. */
+function stepStructural(state: JsonScanState, ch: string): ScanResult {
+  if (ch === '"') state.inString = true;
+  else if (ch === '{') state.closers.push('}');
+  else if (ch === '[') state.closers.push(']');
+  else if (ch === '}' || ch === ']') {
+    if (state.closers.pop() === undefined) return 'unbalanced';
+    if (state.closers.length === 0) return 'complete';
+  }
+  return 'continue';
+}
+
+/** Advance the balanced-object scan by one char. Returns whether the object closed / broke. */
+function stepJsonScan(state: JsonScanState, ch: string): ScanResult {
+  if (state.escaped) {
+    state.escaped = false;
+    return 'continue';
+  }
+  if (state.inString) {
+    stepInString(state, ch);
+    return 'continue';
+  }
+  return stepStructural(state, ch);
+}
+
+/** Best-effort close of an object truncated mid-scan (open string + open containers). */
+function repairTruncatedObject(fragment: string, state: JsonScanState): string {
+  let repaired = state.inString ? `${fragment}"` : fragment;
+  for (let i = state.closers.length - 1; i >= 0; i--) {
+    const closer = state.closers[i];
+    if (closer !== undefined) repaired += closer;
+  }
+  return repaired;
+}
+
+function extractFirstJsonObject(text: string): string | undefined {
+  const start = text.indexOf('{');
+  if (start === -1) return undefined;
+  const state: JsonScanState = { closers: [], inString: false, escaped: false };
+  for (let i = start; i < text.length; i++) {
+    const result = stepJsonScan(state, text[i] as string);
+    if (result === 'complete') return text.slice(start, i + 1);
+    if (result === 'unbalanced') return undefined;
+  }
+  // Loop ran off the end with containers still open ⇒ truncated; repair best-effort.
+  return state.closers.length > 0 ? repairTruncatedObject(text.slice(start), state) : undefined;
+}
+
+/**
+ * Extracts the JSON vote object from raw LLM response text (#4131).
+ *
+ * Robust to the ways a voter's output shape used to silently DROP the voter:
+ *  1. Prefer an explicit ` ```json ` fence.
+ *  2. Otherwise scan every fenced block and use the first whose content is a
+ *     JSON object — so a ` ```yaml findings ` block (pr-review mode) is SKIPPED
+ *     instead of being handed to JSON.parse (the `Unexpected token 'y'` drop).
+ *  3. Otherwise take the first balanced JSON object anywhere in the text, so a
+ *     verdict followed by a trailing prose / YAML block still parses, and a
+ *     truncated object is repaired.
+ *  4. Fallback: the trimmed text (JSON.parse will surface a real malformation).
  */
 export function extractJsonFromResponse(text: string): string {
-  // Try to find JSON in code blocks first
-  const codeBlockMatch = /```(?:json)?\s*([\s\S]*?)```/i.exec(text);
-  if (codeBlockMatch?.[1] !== undefined) {
-    return codeBlockMatch[1].trim();
+  const jsonFence = /```json\s*([\s\S]*?)```/i.exec(text);
+  if (jsonFence?.[1] !== undefined) {
+    return extractFirstJsonObject(jsonFence[1]) ?? jsonFence[1].trim();
   }
 
-  // Look for JSON object directly
-  const jsonMatch = /\{[\s\S]*\}/i.exec(text);
-  if (jsonMatch?.[0] !== undefined) {
-    return jsonMatch[0];
+  for (const match of text.matchAll(/```[a-zA-Z0-9]*\s*([\s\S]*?)```/g)) {
+    const inner = match[1];
+    if (inner?.trimStart().startsWith('{') === true) {
+      const obj = extractFirstJsonObject(inner);
+      if (obj !== undefined) return obj;
+    }
   }
 
-  return text.trim();
+  return extractFirstJsonObject(text) ?? text.trim();
 }
 
 /**
@@ -358,6 +444,48 @@ function createFallbackVote(output: string, _role: VoterRole, reason: string): P
     confidence: 0.5,
     source: 'fallback', // Mark as synthetic
   };
+}
+
+/** Caps mirroring {@link VoteResponseSchema} (reasoning) + {@link RawFindingSchema} (claim). */
+const REASONING_MAX_CHARS = 4000;
+const CLAIM_MAX_CHARS = 2000;
+const TRUNCATION_MARKER = ' …[truncated]';
+
+/** Truncate `s` to `max` chars with a marker; a no-op when already within cap. */
+function clampWithMarker(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - TRUNCATION_MARKER.length)) + TRUNCATION_MARKER;
+}
+
+/**
+ * Clamp the capped string fields of a parsed vote to their schema limits with a
+ * truncation marker BEFORE validation (#4131). A thorough voter (esp. the
+ * contrarian, which writes the most detailed findings) whose `reasoning` exceeds
+ * the 4000-char cap previously hard-failed validation and was SILENTLY DROPPED
+ * from the panel denominator. Clamping records a (clipped, clearly-marked) real
+ * vote instead. Only shape (oversize strings) is repaired — a genuinely
+ * malformed vote (missing decision, bad confidence) still fails `safeParse`.
+ */
+function clampOversizeVoteStrings(parsed: unknown): unknown {
+  if (typeof parsed !== 'object' || parsed === null) return parsed;
+  const obj = { ...(parsed as Record<string, unknown>) };
+  if (typeof obj['reasoning'] === 'string') {
+    obj['reasoning'] = clampWithMarker(obj['reasoning'], REASONING_MAX_CHARS);
+  }
+  if (Array.isArray(obj['findings'])) {
+    obj['findings'] = (obj['findings'] as unknown[]).map((finding): unknown => {
+      if (
+        typeof finding === 'object' &&
+        finding !== null &&
+        typeof (finding as Record<string, unknown>)['claim'] === 'string'
+      ) {
+        const f = finding as Record<string, unknown>;
+        return { ...f, claim: clampWithMarker(f['claim'] as string, CLAIM_MAX_CHARS) };
+      }
+      return finding;
+    });
+  }
+  return obj;
 }
 
 /** Maps a validated VoteResponse into a ParsedVote, threading optional fields. */
@@ -399,7 +527,9 @@ export function parseVoteResponse(
   try {
     const jsonStr = extractJsonFromResponse(output);
     const parsed = JSON.parse(jsonStr) as unknown;
-    const validated = VoteResponseSchema.safeParse(parsed);
+    // #4131: clip oversize reasoning/claims (with a marker) so a thorough voter
+    // records a real vote instead of being silently dropped on the char cap.
+    const validated = VoteResponseSchema.safeParse(clampOversizeVoteStrings(parsed));
 
     if (validated.success) {
       return buildParsedVote(validated.data);


### PR DESCRIPTION
## What
Child 1 of #4130 (fail-silent voter-drop robustness). The shared voter parser (`cli/voter-response.ts`, used by **both** `consensus_vote` and `pr_review`) silently dropped a voter — erasing it from the panel denominator — whenever its output *shape* tripped the parser/schema. The most thorough voter (the **contrarian/`catfish`**) was the likeliest to trip it, so a "clean approve" was really 6-of-7 (or pr_review 3-of-5) with the dissenter gone.

Three shape-drops fixed (each reproduced by a test):
1. **`extractJsonFromResponse` is shape-aware:** prefers a ` ```json ` fence; **skips** a ` ```yaml findings ` fence (pr-review mode) instead of feeding YAML to `JSON.parse` — the exact `Unexpected token 'y', "yaml findi"...` drop; extracts the first **balanced** JSON object (string/escape-aware, tolerant of a trailing prose/YAML block); and **repairs a truncated object** — the `... position 7181` mid-JSON cut.
2. **Oversize reasoning/claim** is truncated with a `…[truncated]` marker before validation instead of hard-rejected (the `>4000 chars` drop) — a thorough voter records a clipped *real* vote, not an error.
3. **Token headroom:** the vote completion cap is raised 2000→4000 so findings-bearing verdicts aren't cut mid-JSON (non-findings votes stop at natural completion → no added cost).

A genuinely malformed vote (missing `decision`, bad `confidence`) still errors — behavior preserved.

## Scope
Pure-upside parser robustness; **no governance-semantics change**. The load-bearing governance fix — making an errored voter (esp. the contrarian) *degrade/void* the verdict via an absolute-approval quorum instead of shrinking the denominator — is tracked in **#4132** (revisits #3138, needs a higher_order vote).

## Verification
`tsc --noEmit` clean · **728 tests pass** across voter-response / voter-execution / all `consensus/` / `pr-review-tool` (new #4131 repro cases for both field errors + the oversize drop; all existing behavior preserved) · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)