### PR TITLE
fix(pr_review): document the repoContext 2000-char cap (#4133, epic #4130)

### DIFF
--- a/.changeset/pr-review-repocontext-doc.md
+++ b/.changeset/pr-review-repocontext-doc.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+Document the `pr_review` `repoContext` 2000-char cap (#4133, epic #4130). The field silently
+hard-failed Zod validation over 2000 chars with no limit stated in its description (unlike
+`prDiff`, which documents its 50000 cap). The cap is now a named `MAX_REPO_CONTEXT_LENGTH`
+constant and stated in the field description + regenerated tool reference. The larger
+diff-summarization affordance for the 50000-char `prDiff` cap is tracked separately.

--- a/docs/reference/tools/pr_review.md
+++ b/docs/reference/tools/pr_review.md
@@ -19,7 +19,7 @@ Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, secu
 | `prTitle` | string | yes | minLength 1; maxLength 500 | PR title |
 | `prDescription` | string | no | maxLength 10000 | PR body / description |
 | `prDiff` | string | yes | minLength 1; maxLength 50000 | Unified diff text (max 50000 chars; truncate before calling) |
-| `repoContext` | string | no | maxLength 2000 | Optional one-paragraph repo context (architecture, conventions) |
+| `repoContext` | string | no | maxLength 2000 | Optional one-paragraph repo context (architecture, conventions; max 2000 chars; trim before calling) |
 | `baseRef` | string | no | maxLength 200 | Base branch ref (e.g. main) |
 | `headRef` | string | no | maxLength 200 | Head branch ref |
 | `prNumber` | integer | no | max 9007199254740991; > 0 | PR number — with baseSha, enables Option-C audit-record persistence (#4031) |

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -69,6 +69,8 @@ export const PR_REVIEW_ROLES: readonly VoterRole[] = [
  * an explicit notice — the tool stays useful for typical PRs without blowing
  * the context budget. */
 export const MAX_DIFF_LENGTH = 50_000;
+/** Max `repoContext` length; over-limit input hard-fails Zod validation (#4133). */
+export const MAX_REPO_CONTEXT_LENGTH = 2000;
 
 /** Hard cap on PR description. */
 export const MAX_DESCRIPTION_LENGTH = 10_000;
@@ -101,9 +103,11 @@ export const PrReviewInputSchema = z.object({
     .describe(`Unified diff text (max ${String(MAX_DIFF_LENGTH)} chars; truncate before calling)`),
   repoContext: z
     .string()
-    .max(2000)
+    .max(MAX_REPO_CONTEXT_LENGTH)
     .optional()
-    .describe('Optional one-paragraph repo context (architecture, conventions)'),
+    .describe(
+      `Optional one-paragraph repo context (architecture, conventions; max ${String(MAX_REPO_CONTEXT_LENGTH)} chars; trim before calling)`
+    ),
   baseRef: z.string().max(200).optional().describe('Base branch ref (e.g. main)'),
   headRef: z.string().max(200).optional().describe('Head branch ref'),
   /**


### PR DESCRIPTION
## What
Child 3 of #4130 (the small ergonomics fix). `pr_review`'s `repoContext` field silently hard-failed Zod validation over 2000 chars with **no limit stated** in its `.describe()` — unlike `prDiff`, which documents its 50000 cap. Field-reported as cryptic friction. The cap is now a named `MAX_REPO_CONTEXT_LENGTH` constant, stated in the field description, and reflected in the regenerated tool reference (`docs/reference/tools/pr_review.md`).

The larger **diff-summarization affordance** for the 50000-char `prDiff` cap (so big PRs are reviewed on real content instead of a hand-curated subset) is split to **#4140** (design + vote first).

## Verification
`tsc --noEmit` clean · tool-reference regenerated via `pnpm docs:tools` (Tool Reference Drift gate satisfied) · patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)