### PR TITLE
fix(pipeline): honor no_quorum in vote consumers — bounded re-run, then escalate (#4135, epic #4130)

### DIFF
--- a/.changeset/no-quorum-consumers.md
+++ b/.changeset/no-quorum-consumers.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': minor
+---
+
+Teach vote consumers to honor a `no_quorum` outcome instead of misreading it as a rejection (#4135, epic #4130).
+
+`executeVoting` now stamps the response-layer `decision` (incl. `no_quorum`) onto its `ExtendedVotingResult`, computed once via the exported `resolveVoteDecision` that `buildResponse` reuses (DRY — the decision can't diverge). Consumers read `decision` (falling back to the engine outcome when absent):
+
+- **iterative-consensus:** on `no_quorum`, re-runs the SAME plan (a missing voice, not a bad plan) bounded by a new `maxNoQuorumRetries` (default 2, counted separately from `maxIterations`); on exhaustion it terminates as a non-rejected failure rather than dropping into the refine loop.
+- **agent-executor vote stage:** returns a distinct `kind:'no_quorum'` terminal signal instead of `{kind:'rejected', feedback}` fed into plan-revision.
+- **vote CLI:** new `--on-no-quorum` flag (`fail` default → exit 1 for back-compat | `exit2` → distinct exit 2 | `retry` → re-run once, then fail); `formatVoteComment` labels `no_quorum` distinctly.
+- **graph consensus gate:** `ConsensusVerdict.outcome` widened to `'approved' | 'rejected' | 'no_quorum'` (the voter-throw path stays fail-closed `rejected`).
+
+Inert by default: under every default error policy `resolveVoteDecision` never yields `no_quorum` from a genuine tally, so these paths activate only when a caller opts into `absolute_quorum` (#4132) or an error-policy short-circuit voids the vote.

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -80,6 +80,11 @@ const VOTE_HELP: CommandHelpEntry = {
       description:
         'How to count errored/timed-out voters: reduce_denominator | count_as_abstain | fail_closed | absolute_quorum (#4132 — an errored voter degrades the verdict to no_quorum) (default: fail_closed for unanimous, reduce_denominator otherwise)',
     },
+    {
+      flag: '--on-no-quorum <p>',
+      description:
+        'How to map a no_quorum decision (#4135): fail (exit 1, default) | exit2 (distinct exit 2) | retry (re-run once, then fail)',
+    },
     { flag: '--verbose', description: 'Show vote verification hashes' },
   ],
   requiresApiKey: ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_AI_API_KEY'],

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -279,11 +279,15 @@ export async function handleVoteCommand(args: ParsedCliArgs): Promise<CliExitRes
     proposal,
     ...(validThreshold !== undefined && { threshold: validThreshold }),
     ...(validErrorPolicy !== undefined && { errorPolicy: validErrorPolicy }),
+    ...(args.options.onNoQuorum !== undefined && { onNoQuorum: args.options.onNoQuorum }),
     dryRun: args.options.dryRun,
     quick: args.options.quick,
     verbose: args.options.verbose,
   });
-  return cliExitFromStatus(exitCode);
+  // #4135: use `cliExit` (not `cliExitFromStatus`) so a distinct `--on-no-quorum=exit2`
+  // code (2) survives to the process instead of being collapsed to 1. Codes 0/1 map
+  // identically, so back-compat holds.
+  return cliExit(exitCode);
 }
 
 /**

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -10,6 +10,7 @@
 import type { ServerMode } from './cli/index.js';
 import type { CliNameLiteral } from './config/model-capabilities-types.js';
 import type { ErrorPolicy, VoteThreshold } from './mcp/tools/consensus-vote-types.js';
+import type { NoQuorumPolicy } from './cli/vote-types.js';
 import type { CommandResult } from './core/command-result.js';
 
 // Re-export help text from extracted module for backward compatibility
@@ -223,6 +224,8 @@ export interface ParsedCliArgs {
     timeoutMs?: number;
     /** #2630 — see `applyErrorPolicy`. */
     errorPolicy?: ErrorPolicy;
+    /** #4135 — how the vote command maps a `no_quorum` decision. Default `fail`. */
+    onNoQuorum?: NoQuorumPolicy;
     // SWE-bench command options
     variant?: 'lite' | 'verified' | 'full';
     limit?: number;
@@ -411,6 +414,10 @@ export const PARSE_ARGS_CONFIG = {
     },
     // #2630 — error policy for the vote command.
     'error-policy': {
+      type: 'string' as const,
+    },
+    // #4135 — how the vote command maps a no_quorum decision (fail|exit2|retry).
+    'on-no-quorum': {
       type: 'string' as const,
     },
     // SWE-bench command options

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -33,6 +33,7 @@ import {
   type VoteThreshold,
   type ErrorPolicy,
 } from './mcp/tools/consensus-vote-types.js';
+import type { NoQuorumPolicy } from './cli/vote-types.js';
 
 // Re-export types and constants for external use
 export { EXIT_CODES, type CliCommand, type ParsedCliArgs } from './cli-types.js';
@@ -123,6 +124,7 @@ interface ParsedValues {
   quick: boolean;
   timeout?: string;
   'error-policy'?: string;
+  'on-no-quorum'?: string;
   // SWE-bench options
   variant?: string;
   limit?: string;
@@ -214,6 +216,15 @@ function parseErrorPolicy(value: string | undefined): ErrorPolicy | undefined {
   return parsed.success ? parsed.data : undefined;
 }
 
+/**
+ * #4135: validates the `--on-no-quorum` flag (fail | exit2 | retry). Unknown
+ * values fall through to `undefined` → the command default (`fail`).
+ */
+function parseNoQuorumPolicy(value: string | undefined): NoQuorumPolicy | undefined {
+  if (value === 'fail' || value === 'exit2' || value === 'retry') return value;
+  return undefined;
+}
+
 /** Builds vote-specific options. */
 function buildVoteOptions(values: ParsedValues): Record<string, unknown> {
   const threshold = parseThreshold(values.threshold);
@@ -221,11 +232,13 @@ function buildVoteOptions(values: ParsedValues): Record<string, unknown> {
   // Convert seconds to milliseconds (CLI uses seconds for readability)
   const timeoutMs = timeoutSec !== undefined ? timeoutSec * 1000 : undefined;
   const errorPolicy = parseErrorPolicy(values['error-policy']);
+  const onNoQuorum = parseNoQuorumPolicy(values['on-no-quorum']);
   return {
     ...(values.proposal !== undefined && { proposal: values.proposal }),
     ...(threshold !== undefined && { threshold }),
     ...(timeoutMs !== undefined && { timeoutMs }),
     ...(errorPolicy !== undefined && { errorPolicy }),
+    ...(onNoQuorum !== undefined && { onNoQuorum }),
   };
 }
 

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -8,14 +8,21 @@ import type { VotingResult } from './vote-types.js';
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult } from './voter-agents.js';
 
-const { safeExecSandboxedMock } = vi.hoisted(() => ({ safeExecSandboxedMock: vi.fn() }));
+const { safeExecSandboxedMock, executeVotingMock } = vi.hoisted(() => ({
+  safeExecSandboxedMock: vi.fn(),
+  executeVotingMock: vi.fn(),
+}));
 vi.mock('./sandbox-exec.js', () => ({ safeExecSandboxed: safeExecSandboxedMock }));
+// #4135: stub executeVoting so voteCommand exit-code mapping can be driven by a
+// fixed response-layer decision (approved / rejected / no_quorum).
+vi.mock('../mcp/tools/consensus-vote.js', () => ({ executeVoting: executeVotingMock }));
 
 import {
   formatVoteComment,
   formatVoteRow,
   explainOutcome,
   recordVoteToGitHub,
+  voteCommand,
 } from './vote-command.js';
 
 function createMockConsensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
@@ -314,5 +321,74 @@ describe('recordVoteToGitHub', () => {
     const commandString = safeExecSandboxedMock.mock.calls[0]?.[0] as string;
     // The body (which contains `|`, `(`, `)`) lives in stdin, not the command.
     expect(commandString).not.toMatch(/[|()]/);
+  });
+});
+
+describe('formatVoteComment — no_quorum labeling (#4135)', () => {
+  it('labels a no_quorum decision distinctly (not APPROVED/REJECTED)', () => {
+    // Engine outcome stays 'rejected' (2-valued); the decision is the void.
+    const result = createMockVotingResult({
+      result: createMockConsensusResult({ outcome: 'rejected' }),
+    });
+    const comment = formatVoteComment(result, 'no_quorum');
+    expect(comment).toContain('NO QUORUM');
+    expect(comment).not.toContain('**REJECTED**');
+    expect(comment).not.toContain('**APPROVED**');
+  });
+
+  it('falls back to the engine outcome label when no decision is passed (back-compat)', () => {
+    const result = createMockVotingResult();
+    expect(formatVoteComment(result)).toContain('**APPROVED**');
+  });
+});
+
+describe('voteCommand — exit-code mapping for no_quorum (#4135)', () => {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function extendedResult(decision: string) {
+    return {
+      proposal: 'p',
+      threshold: 'simple_majority',
+      result: createMockConsensusResult({ outcome: 'rejected' }),
+      votes: [],
+      totalTimeMs: 5,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+      decision,
+    };
+  }
+
+  beforeEach(() => {
+    executeVotingMock.mockReset();
+    safeExecSandboxedMock.mockReset();
+  });
+
+  it('default (fail) → exit 1 on a no_quorum (back-compat)', async () => {
+    executeVotingMock.mockResolvedValue(extendedResult('no_quorum'));
+    const code = await voteCommand({ proposal: 'p' });
+    expect(code).toBe(1);
+  });
+
+  it('--on-no-quorum=exit2 → distinct exit 2 on a no_quorum', async () => {
+    executeVotingMock.mockResolvedValue(extendedResult('no_quorum'));
+    const code = await voteCommand({ proposal: 'p', onNoQuorum: 'exit2' });
+    expect(code).toBe(2);
+  });
+
+  it('--on-no-quorum=retry → re-runs the vote once, then falls to exit 1', async () => {
+    executeVotingMock.mockResolvedValue(extendedResult('no_quorum'));
+    const code = await voteCommand({ proposal: 'p', onNoQuorum: 'retry' });
+    expect(code).toBe(1);
+    // 1 initial run + 1 retry.
+    expect(executeVotingMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('an approved decision → exit 0 regardless of policy', async () => {
+    executeVotingMock.mockResolvedValue(extendedResult('approved'));
+    expect(await voteCommand({ proposal: 'p', onNoQuorum: 'exit2' })).toBe(0);
+  });
+
+  it('a rejected decision → exit 1 (unchanged)', async () => {
+    executeVotingMock.mockResolvedValue(extendedResult('rejected'));
+    expect(await voteCommand({ proposal: 'p', onNoQuorum: 'exit2' })).toBe(1);
   });
 });

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -19,13 +19,20 @@
 import * as crypto from 'node:crypto';
 import { getTimeProvider, formatPercentage, getErrorMessage, createLogger } from '../core/index.js';
 import { safeExecSandboxed } from './sandbox-exec.js';
-import type { VoteCommandOptions, VoterRole, VotingResult, VoteHash } from './vote-types.js';
+import type {
+  VoteCommandOptions,
+  VoterRole,
+  VotingResult,
+  VoteHash,
+  NoQuorumPolicy,
+} from './vote-types.js';
 import { VOTER_ROLES } from './vote-types.js';
 import type { Vote, ConsensusAlgorithm, ConsensusResult } from '../consensus/types.js';
 import { DEFAULT_VOTE_TIMEOUT_MS, type AgentVoteResult } from './voter-agents.js';
 import { validateTimeout } from '../config/timeouts.js';
 import { executeVoting } from '../mcp/tools/consensus-vote.js';
-import type { ConsensusVoteInput } from '../mcp/tools/consensus-vote-types.js';
+import type { ConsensusVoteInput, VoteDecisionStatus } from '../mcp/tools/consensus-vote-types.js';
+import { mapOutcomeToDecision } from '../mcp/tools/consensus-vote-types.js';
 import { colors, symbols, writeLine } from './ansi-output.js';
 
 function generateVoteHash(role: VoterRole, vote: Vote): VoteHash {
@@ -164,9 +171,30 @@ function validateGitHubIssue(issueNumber: number): boolean {
 }
 
 /**
- * Formats vote result as markdown comment.
+ * Maps a decision to the markdown result label. `no_quorum` (#4135) renders
+ * distinctly from a rejection — a quorum void is recoverable ("re-run the missing
+ * voice"), NOT the panel rejecting the proposal.
  */
-export function formatVoteComment(result: VotingResult): string {
+function decisionResultLabel(decision: VoteDecisionStatus): { emoji: string; text: string } {
+  switch (decision) {
+    case 'approved':
+      return { emoji: '✅', text: 'APPROVED' };
+    case 'no_quorum':
+      return { emoji: '⚠️', text: 'NO QUORUM' };
+    default:
+      // rejected / timeout / pending — the same ❌ the pre-#4135 formatter used.
+      return { emoji: '❌', text: decision.toUpperCase() };
+  }
+}
+
+/**
+ * Formats vote result as markdown comment.
+ *
+ * `decision` (#4135) is the response-layer decision (incl. `no_quorum`). When
+ * omitted, it falls back to mapping the 2-valued engine outcome — so pre-#4135
+ * callers get the identical `APPROVED`/`REJECTED` label.
+ */
+export function formatVoteComment(result: VotingResult, decision?: VoteDecisionStatus): string {
   const now = new Date(getTimeProvider().now()).toLocaleDateString('en-US', {
     timeZone: 'America/New_York',
     year: 'numeric',
@@ -174,8 +202,8 @@ export function formatVoteComment(result: VotingResult): string {
     day: '2-digit',
   });
 
-  const outcomeEmoji = result.result.outcome === 'approved' ? '✅' : '❌';
-  const outcomeText = result.result.outcome.toUpperCase();
+  const effectiveDecision = decision ?? mapOutcomeToDecision(result.result.outcome);
+  const { emoji: outcomeEmoji, text: outcomeText } = decisionResultLabel(effectiveDecision);
 
   const voteRows = result.votes
     .map(({ role, vote }) => {
@@ -218,8 +246,12 @@ ${voteRows}
  * shell-metacharacter pattern. Piping keeps the body off the shell
  * entirely — no escaping, no injection surface.
  */
-export function recordVoteToGitHub(issueNumber: number, result: VotingResult): void {
-  const comment = formatVoteComment(result);
+export function recordVoteToGitHub(
+  issueNumber: number,
+  result: VotingResult,
+  decision?: VoteDecisionStatus
+): void {
+  const comment = formatVoteComment(result, decision);
 
   const output = safeExecSandboxed(`gh issue comment ${String(issueNumber)} --body-file -`, {
     context: 'gh',
@@ -245,7 +277,9 @@ export function recordVoteToGitHub(issueNumber: number, result: VotingResult): v
  * CLI-specific concerns (timeout clamping + diagnostic line) remain here
  * because they belong to the operator UX, not the voting flow itself.
  */
-async function runVote(options: VoteCommandOptions): Promise<VotingResult> {
+async function runVote(
+  options: VoteCommandOptions
+): Promise<VotingResult & { readonly decision: VoteDecisionStatus }> {
   // Validate and constrain timeout to allowed range (Issue #607). Done at
   // the CLI boundary so the operator sees the adjustment immediately.
   const requestedTimeoutMs = options.timeoutMs ?? DEFAULT_VOTE_TIMEOUT_MS;
@@ -277,7 +311,9 @@ async function runVote(options: VoteCommandOptions): Promise<VotingResult> {
 
   // `ExtendedVotingResult` is a superset of `VotingResult` — return the
   // narrower view since the CLI pretty-printers only consume the base
-  // fields and don't render `strategy` / `higherOrderResult`.
+  // fields and don't render `strategy` / `higherOrderResult`. #4135: also carry
+  // the response-layer `decision` (incl. `no_quorum`) so the command can honor a
+  // quorum void; fall back to mapping the engine outcome when it's absent.
   return {
     proposal: result.proposal,
     threshold: result.threshold,
@@ -285,6 +321,7 @@ async function runVote(options: VoteCommandOptions): Promise<VotingResult> {
     votes: result.votes,
     totalTimeMs: result.totalTimeMs,
     simulateVotes: result.simulateVotes,
+    decision: result.decision ?? mapOutcomeToDecision(result.result.outcome),
   };
 }
 
@@ -318,7 +355,11 @@ function validateIssueIfNeeded(issueNumber: number | undefined): boolean {
 /**
  * Handles recording vote to GitHub or dry-run message.
  */
-function handleRecording(options: VoteCommandOptions, result: VotingResult): void {
+function handleRecording(
+  options: VoteCommandOptions,
+  result: VotingResult,
+  decision?: VoteDecisionStatus
+): void {
   if (options.issueNumber === undefined) return;
 
   if (options.dryRun === true) {
@@ -326,8 +367,19 @@ function handleRecording(options: VoteCommandOptions, result: VotingResult): voi
       `${colors.yellow}[DRY RUN]${colors.reset} Would record to issue #${String(options.issueNumber)}\n`
     );
   } else {
-    recordVoteToGitHub(options.issueNumber, result);
+    recordVoteToGitHub(options.issueNumber, result, decision);
   }
+}
+
+/**
+ * #4135: map a resolved decision to the CLI exit code, honoring `--on-no-quorum`.
+ * `approved` → 0; a quorum void → 2 under `exit2`, else 1 (`fail`/`retry`
+ * fall-through, back-compat); everything else (a genuine rejection) → 1.
+ */
+function exitCodeForDecision(decision: VoteDecisionStatus, policy: NoQuorumPolicy): number {
+  if (decision === 'approved') return 0;
+  if (decision === 'no_quorum') return policy === 'exit2' ? 2 : 1;
+  return 1;
 }
 
 /**
@@ -343,16 +395,25 @@ export async function voteCommand(options: VoteCommandOptions): Promise<number> 
   writeLine(
     `${colors.dim}Proposal: ${options.proposal.slice(0, 100)}${options.proposal.length > 100 ? '...' : ''}${colors.reset}\n`
   );
+  const onNoQuorum: NoQuorumPolicy = options.onNoQuorum ?? 'fail';
   try {
-    const result = await runVote(options);
+    let result = await runVote(options);
+    // #4135: a quorum void is recoverable (a voice was missing) — under `retry`,
+    // re-run the vote ONCE before falling back to `fail`. The plan is unchanged.
+    if (result.decision === 'no_quorum' && onNoQuorum === 'retry') {
+      writeLine(
+        `${colors.yellow}No quorum — re-running the vote once (--on-no-quorum=retry)...${colors.reset}\n`
+      );
+      result = await runVote(options);
+    }
     printVoteDetails(result.votes);
     printSummary({ result: result.result, votes: result.votes, threshold: result.threshold });
     if (options.verbose === true) printHashes(result.votes);
     writeLine(`${colors.dim}Completed in ${String(result.totalTimeMs)}ms${colors.reset}\n`);
 
-    handleRecording(options, result);
+    handleRecording(options, result, result.decision);
 
-    return result.result.outcome === 'approved' ? 0 : 1;
+    return exitCodeForDecision(result.decision, onNoQuorum);
   } catch (error) {
     writeLine(`${colors.red}Error: ${getErrorMessage(error)}${colors.reset}`);
     return 1;

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -10,6 +10,19 @@ import type { ConsensusAlgorithm, Vote, ConsensusResult } from '../consensus/typ
 import type { ErrorPolicy, VoteThreshold } from '../mcp/tools/consensus-vote-types.js';
 
 /**
+ * #4135: how the `vote` command maps a `no_quorum` decision — a quorum void
+ * (a missing/errored voice under the opt-in `absolute_quorum` error policy, or an
+ * error-policy short-circuit), which is DISTINCT from a genuine rejection.
+ *
+ * - `fail` (default): exit 1, exactly as a rejection would — back-compat.
+ * - `exit2`: exit with a distinct code 2 so scripts can tell a quorum void apart
+ *   from an approval (0) or a rejection (1).
+ * - `retry`: re-run the vote ONCE (the plan is fine, a voice was missing); if it
+ *   still cannot reach quorum, fall back to `fail` (exit 1).
+ */
+export type NoQuorumPolicy = 'fail' | 'exit2' | 'retry';
+
+/**
  * Options for the vote command.
  */
 export interface VoteCommandOptions {
@@ -29,6 +42,12 @@ export interface VoteCommandOptions {
    * `fail_closed` for unanimous, `reduce_denominator` otherwise.
    */
   readonly errorPolicy?: ErrorPolicy;
+  /**
+   * #4135: how to map a `no_quorum` decision (a recoverable quorum void, not a
+   * rejection). Default `fail` (exit 1) preserves back-compat. See
+   * {@link NoQuorumPolicy}.
+   */
+  readonly onNoQuorum?: NoQuorumPolicy;
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -375,6 +375,17 @@ export interface ExtendedVotingResult extends VotingResult {
    * carve-out). True on the full 7-role panel.
    */
   contrarianRequested?: boolean;
+  /**
+   * #4135: the response-layer decision (incl. `no_quorum`) for this vote, computed
+   * by {@link resolveVoteDecision}. Set by `executeVoting` right before it returns
+   * so pipeline consumers (iterative-consensus, agent-executor, the CLI) can honor
+   * a `no_quorum` void instead of misreading it as a rejection — WITHOUT recomputing
+   * the policy math. The engine `ConsensusResult.outcome` stays 2-valued
+   * (`approved`/`rejected`); this is the widened, opt-in-aware view. Absent on
+   * results built by paths that never ran `executeVoting` (direct unit calls to
+   * `buildResponse`), where consumers fall back to mapping the engine outcome.
+   */
+  decision?: VoteDecisionStatus;
 }
 
 // ============================================================================
@@ -550,8 +561,14 @@ function computeAbsoluteQuorumDecision(
  * Resolve the user-facing decision for a tallied vote. Keeps the pre-#4132 path
  * verbatim for every policy except `absolute_quorum`, which routes through
  * {@link computeAbsoluteQuorumDecision}.
+ *
+ * Exported (#4135) so `executeVoting` can stamp `ExtendedVotingResult.decision`
+ * with the SAME computation `buildResponse` uses — the response-layer decision
+ * (including `no_quorum`) is derived once, in one place, and can't diverge
+ * between the engine result and the MCP response. The engine
+ * `ConsensusResult.outcome` stays 2-valued; this is the widened view.
  */
-function resolveVoteDecision(
+export function resolveVoteDecision(
   input: ConsensusVoteInput,
   result: ExtendedVotingResult,
   errorCount: number
@@ -617,7 +634,14 @@ export function buildResponse(
   // an induced error can never manufacture approved/rejected. Every other policy
   // keeps the legacy mapping. `degradeReason` (when present) is the actionable
   // "re-run" message; it rides the response as `policyReason`.
-  const { decision, degradeReason } = resolveVoteDecision(input, result, errorCount);
+  //
+  // #4135 (DRY): `executeVoting` already stamped `result.decision` via THIS same
+  // `resolveVoteDecision`. Reuse it so the response decision can't diverge from the
+  // one pipeline consumers read; recompute only for the `degradeReason` telemetry
+  // and for direct unit calls that bypass `executeVoting` (where `decision` is absent).
+  const resolved = resolveVoteDecision(input, result, errorCount);
+  const decision = result.decision ?? resolved.decision;
+  const { degradeReason } = resolved;
 
   const response: ConsensusVoteResponse = {
     proposal: proposalTruncated,

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -892,6 +892,146 @@ describe('buildResponse surfaces policyReason (#3124)', () => {
   }
 });
 
+describe('#4135: decision plumbing (executeVoting stamps decision; buildResponse reuses it)', () => {
+  it('executeVoting stamps result.decision matching the legacy mapping under a default policy', async () => {
+    const { executeVoting } = await import('./consensus-vote.js');
+    const { mapOutcomeToDecision } = await import('./consensus-vote-types.js');
+    const result = await executeVoting(
+      { proposal: 'Ship the plumbing', simulateVotes: true, quickMode: true },
+      createMockLogger()
+    );
+    // Under a default policy the decision is the legacy 2-valued mapping — never
+    // no_quorum. This is the inert-by-default guarantee (#4135).
+    expect(result.decision).toBeDefined();
+    expect(result.decision).toBe(mapOutcomeToDecision(result.result.outcome));
+    expect(result.decision).not.toBe('no_quorum');
+  });
+
+  it('buildResponse REUSES a pre-stamped result.decision (DRY — decision cannot diverge)', () => {
+    // A deliberately "stale" stamped decision proves buildResponse reads
+    // result.decision rather than recomputing: an all-approve clean panel would
+    // normally compute 'approved', but the stamped 'no_quorum' must win.
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 10,
+        source: 'llm',
+      },
+    ];
+    const base: ExtendedVotingResult = {
+      proposal: 'Test',
+      threshold: 'simple_majority',
+      result: {
+        proposalId: 'p1',
+        proposal: { title: 't', description: 'Test', algorithm: 'simple_majority' },
+        outcome: 'approved',
+        votes: new Map(),
+        voteCounts: { approve: 1, reject: 0, abstain: 0, total: 1 },
+        approvalPercentage: 100,
+        quorumReached: true,
+        startedAt: 'now',
+        closedAt: 'now',
+        durationMs: 1,
+      },
+      votes,
+      totalTimeMs: 10,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+      decision: 'no_quorum',
+    };
+    const response = buildResponse(
+      { proposal: 'Test', simulateVotes: false, quickMode: false },
+      base
+    );
+    expect(response.decision).toBe('no_quorum');
+  });
+
+  it('buildResponse COMPUTES the decision when result.decision is absent (fallback unchanged)', () => {
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 10,
+        source: 'llm',
+      },
+    ];
+    const base: ExtendedVotingResult = {
+      proposal: 'Test',
+      threshold: 'simple_majority',
+      result: {
+        proposalId: 'p1',
+        proposal: { title: 't', description: 'Test', algorithm: 'simple_majority' },
+        outcome: 'approved',
+        votes: new Map(),
+        voteCounts: { approve: 1, reject: 0, abstain: 0, total: 1 },
+        approvalPercentage: 100,
+        quorumReached: true,
+        startedAt: 'now',
+        closedAt: 'now',
+        durationMs: 1,
+      },
+      votes,
+      totalTimeMs: 10,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+      // decision intentionally absent
+    };
+    const response = buildResponse(
+      { proposal: 'Test', simulateVotes: false, quickMode: false },
+      base
+    );
+    expect(response.decision).toBe('approved');
+  });
+
+  it('absolute_quorum with an errored voter → executeVoting stamps decision:no_quorum', () => {
+    // Reuses the buildResponse absolute_quorum path (which resolveVoteDecision drives,
+    // the same function executeVoting stamps with): an errored voter voids the quorum.
+    const votes: AgentVoteResult[] = [
+      {
+        role: 'architect',
+        vote: { decision: 'approve', reasoning: 'ok', confidence: 0.9 },
+        processingTimeMs: 10,
+        source: 'llm',
+      },
+      {
+        role: 'catfish',
+        vote: { decision: 'abstain', reasoning: 'timeout', confidence: 0 },
+        processingTimeMs: 10,
+        source: 'error',
+      },
+    ];
+    const base: ExtendedVotingResult = {
+      proposal: 'Test',
+      threshold: 'simple_majority',
+      result: {
+        proposalId: 'p1',
+        proposal: { title: 't', description: 'Test', algorithm: 'simple_majority' },
+        outcome: 'approved',
+        votes: new Map(),
+        voteCounts: { approve: 1, reject: 0, abstain: 0, total: 1 },
+        approvalPercentage: 100,
+        quorumReached: true,
+        startedAt: 'now',
+        closedAt: 'now',
+        durationMs: 1,
+      },
+      votes,
+      totalTimeMs: 10,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+      panelSize: 2,
+      contrarianRequested: true,
+    };
+    resetDegradedPanelCount();
+    const response = buildResponse(
+      { proposal: 'Test', simulateVotes: false, quickMode: false, errorPolicy: 'absolute_quorum' },
+      base
+    );
+    expect(response.decision).toBe('no_quorum');
+  });
+});
+
 describe('buildResponse surfaces vote-record persistence outcome (#3991)', () => {
   function makeResult(): ExtendedVotingResult {
     const votes: AgentVoteResult[] = [

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -54,6 +54,7 @@ import {
   getDefaultErrorPolicy,
   isHigherOrderStrategy,
   shouldEscalateLowPosterior,
+  resolveVoteDecision,
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import {
@@ -600,8 +601,24 @@ export async function maybeEscalateContrarian(
  * are applyErrorPolicy, buildPolicyShortCircuitResult,
  * maybeEscalateContrarian, finalizeVotingResult.
  */
-// eslint-disable-next-line max-lines-per-function -- see block comment above
 export async function executeVoting(
+  input: ConsensusVoteInput,
+  logger: ILogger,
+  opts?: { voteTimeoutMs?: number; gatewayAdapters?: readonly IModelAdapter[] | undefined }
+): Promise<ExtendedVotingResult> {
+  const result = await executeVotingInner(input, logger, opts);
+  // #4135: stamp the response-layer decision (incl. `no_quorum`) ONCE, using the
+  // SAME `resolveVoteDecision` `buildResponse` consumes, so pipeline consumers can
+  // honor a quorum void instead of misreading it as a rejection — without
+  // recomputing the policy math (DRY; the decision can't diverge). `errorCount`
+  // uses the identical definition `buildResponse` uses.
+  const errorCount = result.votes.filter((v) => v.source === 'error').length;
+  result.decision = resolveVoteDecision(input, result, errorCount).decision;
+  return result;
+}
+
+// eslint-disable-next-line max-lines-per-function -- see block comment above
+async function executeVotingInner(
   input: ConsensusVoteInput,
   logger: ILogger,
   opts?: { voteTimeoutMs?: number; gatewayAdapters?: readonly IModelAdapter[] | undefined }

--- a/packages/nexus-agents/src/orchestration/graph/consensus-node.test.ts
+++ b/packages/nexus-agents/src/orchestration/graph/consensus-node.test.ts
@@ -33,6 +33,22 @@ describe('runConsensusGate', () => {
     await runConsensusGate(spy, { proposal: 'p', context: 'c' });
     expect(spy).toHaveBeenCalledWith({ proposal: 'p', context: 'c' });
   });
+
+  it('propagates a no_quorum verdict from the voter (#4135 — distinct from rejected)', async () => {
+    const noQuorumVoter: ConsensusVoter = () =>
+      Promise.resolve({ outcome: 'no_quorum', feedback: 're-run — a voice was missing' });
+    const v = await runConsensusGate(noQuorumVoter, { proposal: 'plan' });
+    expect(v.outcome).toBe('no_quorum');
+    // A quorum void is NOT success and NOT a rejection — the widened union carries it.
+    expect(v.outcome).not.toBe('rejected');
+    expect(v.outcome).not.toBe('approved');
+  });
+
+  it('a voter THROW still fails closed to rejected, not no_quorum (an error is not a valid void)', async () => {
+    const throwing: ConsensusVoter = () => Promise.reject(new Error('adapter offline'));
+    const v = await runConsensusGate(throwing, { proposal: 'plan' });
+    expect(v.outcome).toBe('rejected');
+  });
 });
 
 describe('createConsensusGateNode', () => {

--- a/packages/nexus-agents/src/orchestration/graph/consensus-node.ts
+++ b/packages/nexus-agents/src/orchestration/graph/consensus-node.ts
@@ -33,8 +33,21 @@ export interface ConsensusProposalInput {
 
 /** The typed verdict a consensus round produces. */
 export interface ConsensusVerdict {
-  /** Whether the proposal cleared the consensus bar. */
-  readonly outcome: 'approved' | 'rejected';
+  /**
+   * Whether the proposal cleared the consensus bar.
+   *
+   * `no_quorum` (#4135) is DISTINCT from `rejected`: the panel could not reach a
+   * valid quorum (an errored/absent voice under the opt-in `absolute_quorum`
+   * policy, or an error-policy short-circuit) — a recoverable "re-run the missing
+   * voice" state, NOT the panel rejecting the proposal. A voter that maps a
+   * `consensus_vote` result into a verdict should surface the vote's `decision`
+   * here so `no_quorum` propagates. It is not `success` — pair the gate with a
+   * conditional edge that routes `no_quorum` to a bounded re-vote/escalate rather
+   * than the reject/revise path. The voter-throw fail-closed path stays `rejected`
+   * (an exception is an error, not a valid quorum void). Inert until a caller opts
+   * into `absolute_quorum`.
+   */
+  readonly outcome: 'approved' | 'rejected' | 'no_quorum';
   /** Reviewer feedback (empty on a clean approval). */
   readonly feedback: string;
   /** Optional structured detail (approval %, the raw vote, …) for consumers. */

--- a/packages/nexus-agents/src/pipeline/agent-executor.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.test.ts
@@ -21,10 +21,12 @@ const {
   mockEmit,
   mockExecuteDiscovery,
   mockAnalyzeGaps,
+  mockExecuteVoting,
 } = vi.hoisted(() => ({
   mockExecuteExpert: vi.fn(),
   mockExecuteDiscovery: vi.fn(),
   mockAnalyzeGaps: vi.fn(),
+  mockExecuteVoting: vi.fn(),
   mockGetOutcomeSummaryText: vi.fn(),
   mockGetOutcomeStore: vi.fn(() => ({ append: vi.fn(), query: vi.fn().mockReturnValue([]) })),
   mockGenerateWeatherReport: vi.fn(),
@@ -92,6 +94,12 @@ vi.mock('./event-bus.js', () => ({
 
 vi.mock('./security-gate.js', () => ({
   checkSecurityScan: () => () => Promise.resolve({ verdict: 'pass', details: 'ok' }),
+}));
+
+// #4135: the vote stage dynamically imports executeVoting — stub it so the vote
+// stage can be driven by a fixed decision (approved/rejected/no_quorum).
+vi.mock('../mcp/tools/consensus-vote.js', () => ({
+  executeVoting: mockExecuteVoting,
 }));
 
 import { createAgentStages, buildVoteProposal } from './agent-executor.js';
@@ -558,6 +566,59 @@ describe('createAgentStages — central workflow hub', () => {
 
       expect(findModelCalled()).toBeUndefined();
     });
+  });
+});
+
+describe('vote stage — no_quorum handling (#4135)', () => {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function votingResult(opts: {
+    decision?: string;
+    outcome: string;
+    approve: number;
+    reject: number;
+  }) {
+    return {
+      ...(opts.decision !== undefined ? { decision: opts.decision } : {}),
+      result: {
+        outcome: opts.outcome,
+        voteCounts: { approve: opts.approve, reject: opts.reject, abstain: 0, error: 0 },
+      },
+      votes: [{ vote: { decision: 'reject', reasoning: 'a concern' } }],
+    };
+  }
+
+  beforeEach(() => {
+    mockExecuteVoting.mockReset();
+  });
+
+  it('a no_quorum decision blocks + escalates — returns kind:no_quorum, NOT rejected-into-revision', async () => {
+    mockExecuteVoting.mockResolvedValue(
+      votingResult({ decision: 'no_quorum', outcome: 'rejected', approve: 5, reject: 1 })
+    );
+    const stages = createAgentStages({ simulateVotes: false });
+    const vote = await stages.vote('the plan', '');
+    expect(vote.kind).toBe('no_quorum');
+    // A no_quorum void carries no reviewer feedback (the plan is fine) — so it is
+    // NOT a { kind:'rejected', feedback } that would drive plan-revision.
+    expect(vote.kind).not.toBe('rejected');
+    if (vote.kind === 'no_quorum') {
+      expect(vote.reason).toContain('quorum');
+    }
+  });
+
+  it('approve/reject paths are unchanged when decision is absent (default-policy fallback)', async () => {
+    mockExecuteVoting.mockResolvedValueOnce(
+      votingResult({ outcome: 'approved', approve: 6, reject: 0 })
+    );
+    const stages = createAgentStages({ simulateVotes: false });
+    const approvedVote = await stages.vote('plan', '');
+    expect(approvedVote.kind).toBe('approved');
+
+    mockExecuteVoting.mockResolvedValueOnce(
+      votingResult({ outcome: 'rejected', approve: 1, reject: 5 })
+    );
+    const rejectedVote = await stages.vote('plan', '');
+    expect(rejectedVote.kind).toBe('rejected');
   });
 });
 

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -11,7 +11,12 @@
  */
 
 import { createLogger, getTimeProvider } from '../core/index.js';
-import type { DevPipelineStages, PipelineTask, QaReviewResult } from './dev-pipeline.js';
+import type {
+  DevPipelineStages,
+  PipelineTask,
+  QaReviewResult,
+  VoteResult,
+} from './dev-pipeline.js';
 import { checkSecurityScan } from './security-gate.js';
 import { runQualityGate, checkTypeCheck, checkLint, checkTests } from '../security/quality-gate.js';
 import type { ITaskTracker } from './task-tracker.js';
@@ -52,6 +57,51 @@ export function buildVoteProposal(plan: string, research: string): string {
   const planPart = plan.slice(0, planBudget);
   const researchPart = trimmed.slice(0, VOTE_RESEARCH_BUDGET);
   return `${planPart}${RESEARCH_HEADER}${researchPart}`.slice(0, VOTE_PROPOSAL_MAX);
+}
+
+/**
+ * #4135: classify a `consensus_vote` result into the pipeline {@link VoteResult},
+ * reading the response-layer `decision` (which honors a `no_quorum` void under the
+ * opt-in absolute_quorum policy / an error-policy short-circuit) rather than the
+ * 2-valued engine outcome. Falls back to the engine outcome when `decision` is
+ * absent — default-policy callers never see `no_quorum`, so this stays inert until
+ * a call site opts in. `no_quorum` is a DISTINCT terminal signal (no reviewer
+ * feedback — the plan is fine, a voice was missing), NOT a rejection fed into
+ * plan-revision. Extracted from the vote stage to keep it within its complexity budget.
+ */
+function classifyVoteStageResult(votingResult: {
+  readonly decision?: string;
+  readonly result: {
+    readonly outcome: string;
+    readonly voteCounts: { readonly approve: number; readonly reject: number };
+  };
+  readonly votes: ReadonlyArray<{
+    readonly vote: { readonly decision: string; readonly reasoning: string };
+  }>;
+}): { vote: VoteResult; label: string } {
+  const { approve, reject } = votingResult.result.voteCounts;
+  const pct = (approve / Math.max(1, approve + reject)) * 100;
+  const decision =
+    votingResult.decision ?? (votingResult.result.outcome === 'approved' ? 'approved' : 'rejected');
+
+  if (decision === 'no_quorum') {
+    return {
+      vote: {
+        kind: 'no_quorum',
+        reason: 'consensus vote could not reach quorum (a voice was missing)',
+        approvalPercentage: pct,
+      },
+      label: 'No quorum — re-run needed',
+    };
+  }
+  if (decision !== 'approved') {
+    const feedback = votingResult.votes
+      .filter((v) => v.vote.decision !== 'approve')
+      .map((v) => v.vote.reasoning)
+      .join('\n');
+    return { vote: { kind: 'rejected', feedback, approvalPercentage: pct }, label: 'Rejected' };
+  }
+  return { vote: { kind: 'approved', approvalPercentage: pct }, label: 'Approved' };
 }
 
 // DRY: delegate to shared pipeline-observability.ts (#1734 Phase 1.1)
@@ -540,18 +590,17 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
           },
           logger
         );
-        const approved = votingResult.result.outcome === 'approved';
-        const pct =
-          (votingResult.result.voteCounts.approve /
-            Math.max(
-              1,
-              votingResult.result.voteCounts.approve + votingResult.result.voteCounts.reject
-            )) *
-          100;
-        const feedback = votingResult.votes
-          .filter((v) => v.vote.decision !== 'approve')
-          .map((v) => v.vote.reasoning)
-          .join('\n');
+        // #4135: read the response-layer decision (honors a `no_quorum` void under
+        // the opt-in absolute_quorum policy / an error-policy short-circuit) instead
+        // of the 2-valued engine outcome. Falls back to the engine outcome when
+        // `decision` is absent — default-policy callers never see `no_quorum`, so
+        // this is inert until a call site opts in. (The #4143 catch-block
+        // auto-approve bug below is a SEPARATE issue and is intentionally untouched.)
+        // #4135: read the response-layer decision (honors a `no_quorum` void under
+        // the opt-in absolute_quorum policy / an error-policy short-circuit) instead
+        // of the 2-valued engine outcome. `classifyVoteStageResult` maps it to the
+        // stage VoteResult (incl. the distinct no_quorum terminal signal).
+        const { vote, label } = classifyVoteStageResult(votingResult);
         const ms = getTimeProvider().now() - start;
         emitStageEvent('vote', 'completed', { durationMs: ms });
         // Vote is itself a consensus result, not a single CLI's output;
@@ -562,18 +611,15 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
           taskId: 'vote',
           category: 'planning',
           cli: undefined,
-          success: approved,
+          success: vote.kind === 'approved',
           durationMs: ms,
         });
         await postProgress(
           config,
           'Vote',
-          `${approved ? 'Approved' : 'Rejected'} (${Math.round(pct)}%, ${ms}ms)`
+          `${label} (${Math.round(vote.approvalPercentage)}%, ${ms}ms)`
         );
-        if (!approved) {
-          return { kind: 'rejected' as const, feedback, approvalPercentage: pct };
-        }
-        return { kind: 'approved' as const, approvalPercentage: pct };
+        return vote;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         emitStageEvent('vote', 'failed', { error: msg });

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -92,7 +92,15 @@ export type VoteResult =
       readonly conditions: readonly string[];
       readonly caveats: readonly string[];
       readonly approvalPercentage: number;
-    };
+    }
+  // #4135: the vote could not reach a valid quorum — a recoverable "re-run the
+  // missing voice" state, DISTINCT from a rejection. Only produced when a caller
+  // opts into the `absolute_quorum` error policy (or an error-policy short-circuit
+  // voids the vote); inert under every default policy. Consumers must NOT feed this
+  // into plan-revision (it carries no reviewer feedback — the plan is fine, a voice
+  // was missing); it terminates/escalates instead. `isApproved` and
+  // `getVoteFeedback` already treat it as not-approved / no-feedback.
+  | { readonly kind: 'no_quorum'; readonly reason: string; readonly approvalPercentage: number };
 
 /** Construct VoteResult from legacy approval flow. */
 export function createVoteResult(

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
@@ -169,4 +169,71 @@ describe('runIterativeConsensus', () => {
       expect(result.vote.feedback).toContain('Missing tests');
     }
   });
+
+  // ==========================================================================
+  // #4135 — no_quorum recovery (bounded re-run of the SAME plan, then terminate)
+  // ==========================================================================
+
+  // A vote whose response-layer decision is `no_quorum` (a missing voice, not a
+  // rejection). `outcome` stays 'rejected' (the engine is 2-valued) — the point is
+  // parseVotingResult must read `decision`, not `outcome`.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function makeNoQuorumResult() {
+    return {
+      decision: 'no_quorum',
+      result: { outcome: 'rejected', voteCounts: { approve: 1, reject: 0, abstain: 0, error: 1 } },
+      votes: [{ vote: { decision: 'approve', reasoning: 'ok' } }],
+      durationMs: 100,
+    };
+  }
+
+  it('re-runs the SAME plan on no_quorum up to maxNoQuorumRetries, then terminates non-rejected', async () => {
+    // Every vote comes back no_quorum → the bounded re-runs exhaust and the result
+    // is a TERMINAL no_quorum failure, NOT a rejection, and revisePlan is never called.
+    mockExecuteVoting.mockResolvedValue(makeNoQuorumResult());
+    const revisePlan = vi
+      .fn<(plan: string, feedback: string) => Promise<string>>()
+      .mockResolvedValue('Revised');
+
+    const result = await runIterativeConsensus('Plan', revisePlan, {
+      maxIterations: 3,
+      maxNoQuorumRetries: 2,
+    });
+
+    expect(result.vote.kind).toBe('no_quorum');
+    if (result.vote.kind === 'no_quorum') {
+      expect(result.vote.reason).toContain('could not reach quorum');
+      expect(result.vote.reason).toContain('2 re-run');
+    }
+    // 1 initial vote + 2 bounded re-runs, all within the first iteration.
+    expect(mockExecuteVoting).toHaveBeenCalledTimes(3);
+    // The plan is fine — a voice was missing — so we NEVER revise on no_quorum.
+    expect(revisePlan).not.toHaveBeenCalled();
+    expect(result.iterations).toBe(1);
+  });
+
+  it('recovers when a bounded re-run reaches approval (does not terminate)', async () => {
+    mockExecuteVoting
+      .mockResolvedValueOnce(makeNoQuorumResult())
+      .mockResolvedValueOnce(makeVotingResult('approved', 5, 1));
+    const revisePlan = vi.fn<(plan: string, feedback: string) => Promise<string>>();
+
+    const result = await runIterativeConsensus('Plan', revisePlan, {
+      maxIterations: 3,
+      maxNoQuorumRetries: 2,
+    });
+
+    expect(result.vote.kind).toBe('approved');
+    expect(mockExecuteVoting).toHaveBeenCalledTimes(2); // initial no_quorum + 1 recovery re-run
+    expect(revisePlan).not.toHaveBeenCalled();
+    expect(result.iterations).toBe(1);
+  });
+
+  it('a normal approve/reject path is unaffected when decision is absent (fallback)', async () => {
+    // Mocks that don't set `decision` fall back to the legacy outcome mapping —
+    // the pre-#4135 behavior, proving the default path is inert.
+    mockExecuteVoting.mockResolvedValueOnce(makeVotingResult('rejected', 1, 5, 'Nope'));
+    const result = await runIterativeConsensus('Plan', vi.fn(), { maxIterations: 1 });
+    expect(result.vote.kind).toBe('rejected');
+  });
 });

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.ts
@@ -29,6 +29,14 @@ export interface IterativeConsensusConfig {
   readonly quickMode?: boolean | undefined;
   /** Voting strategy (default: 'higher_order'). */
   readonly strategy?: VotingStrategy | undefined;
+  /**
+   * #4135: how many times to re-run the SAME plan when a vote returns
+   * `no_quorum` — a missing/errored voice, not a rejection — before giving up
+   * (default: 2). Counted SEPARATELY from `maxIterations`: a quorum void is a
+   * recoverable "re-run the missing voice" state, not a plan-revision trigger, so
+   * it must not consume the refine budget.
+   */
+  readonly maxNoQuorumRetries?: number | undefined;
   /** Max proposal length sent to voters (default: 4000). */
   readonly maxProposalLength?: number | undefined;
   /** Logger instance. */
@@ -49,6 +57,8 @@ export interface IterativeConsensusResult {
 // ============================================================================
 
 const DEFAULT_MAX_ITERATIONS = 3;
+/** #4135: default bounded re-runs for a `no_quorum` void (separate from maxIterations). */
+const DEFAULT_MAX_NO_QUORUM_RETRIES = 2;
 const DEFAULT_MAX_PROPOSAL_LENGTH = 4000;
 const DEFAULT_STRATEGY: VotingStrategy = 'higher_order';
 const DEFAULT_PREFIX = 'pipeline';
@@ -71,25 +81,68 @@ interface ConsensusLoopState {
   readonly log: ILogger;
   readonly prefix: string;
   readonly globalStart: number;
+  /** #4135: bounded re-runs for a `no_quorum` void (separate from maxIterations). */
+  readonly maxNoQuorumRetries: number;
 }
 
-/** Run one iteration of the consensus loop. Returns result if accepted, undefined to continue. */
+/**
+ * Run one vote and, on a `no_quorum` void, re-run the SAME plan (a voice was
+ * missing — the plan is fine, so we do NOT revise) up to `maxNoQuorumRetries`
+ * times (#4135). Returns the recovered vote, or the last `no_quorum` when the
+ * bounded re-runs are exhausted.
+ */
+async function voteWithQuorumRecovery(state: ConsensusLoopState): Promise<VoteResult> {
+  let vote = await executeSingleVote(state.plan, state.config, state.log);
+  for (
+    let attempt = 1;
+    vote.kind === 'no_quorum' && attempt <= state.maxNoQuorumRetries;
+    attempt++
+  ) {
+    state.log.warn('Vote reached no_quorum — re-running the missing voice (bounded)', {
+      attempt,
+      maxNoQuorumRetries: state.maxNoQuorumRetries,
+      reason: vote.reason,
+    });
+    emitPipelineStageEvent(state.prefix, 'vote', 'started');
+    vote = await executeSingleVote(state.plan, state.config, state.log);
+  }
+  return vote;
+}
+
+/**
+ * Run one consensus iteration: vote (with bounded no_quorum recovery), then
+ * classify. Returns `{ result }` when accepted (stop), `{ terminal }` when the
+ * quorum could not be reached after the bounded re-runs (#4135 — a non-rejected
+ * TERMINAL failure, do NOT drop into revise), or `{}` to continue (rejected).
+ */
 async function runOneIteration(
   state: ConsensusLoopState,
   iteration: number
-): Promise<IterativeConsensusResult | undefined> {
+): Promise<{ result?: IterativeConsensusResult; terminal?: IterativeConsensusResult }> {
   state.log.info('Consensus iteration', { iteration });
   emitPipelineStageEvent(state.prefix, 'vote', 'started');
 
-  state.lastVote = await executeSingleVote(state.plan, state.config, state.log);
+  state.lastVote = await voteWithQuorumRecovery(state);
   const iterMs = getTimeProvider().now() - state.globalStart;
-  const status = isVoteAccepted(state.lastVote) ? 'completed' : 'failed';
-  emitPipelineStageEvent(state.prefix, 'vote', status, { durationMs: iterMs });
+  const accepted = isVoteAccepted(state.lastVote);
+  emitPipelineStageEvent(state.prefix, 'vote', accepted ? 'completed' : 'failed', {
+    durationMs: iterMs,
+  });
 
-  if (isVoteAccepted(state.lastVote)) {
-    return { vote: state.lastVote, iterations: iteration, durationMs: iterMs };
+  if (accepted) {
+    return { result: { vote: state.lastVote, iterations: iteration, durationMs: iterMs } };
   }
-  return undefined;
+  // #4135: a quorum void that survived the bounded re-runs is TERMINAL — surface a
+  // non-rejected failure so it never enters the refine-and-re-vote loop.
+  if (state.lastVote.kind === 'no_quorum') {
+    const terminalVote: VoteResult = {
+      kind: 'no_quorum',
+      reason: `vote could not reach quorum after ${String(state.maxNoQuorumRetries)} re-run(s): ${state.lastVote.reason}`,
+      approvalPercentage: state.lastVote.approvalPercentage,
+    };
+    return { terminal: { vote: terminalVote, iterations: iteration, durationMs: iterMs } };
+  }
+  return {};
 }
 
 export async function runIterativeConsensus(
@@ -105,11 +158,25 @@ export async function runIterativeConsensus(
     log: config?.logger ?? defaultLogger,
     prefix: config?.pipelinePrefix ?? DEFAULT_PREFIX,
     globalStart: getTimeProvider().now(),
+    maxNoQuorumRetries: config?.maxNoQuorumRetries ?? DEFAULT_MAX_NO_QUORUM_RETRIES,
   };
 
+  return runConsensusLoop(state, maxIter, revisePlan);
+}
+
+/**
+ * The plan→vote→(revise) loop. Stops on acceptance, on a terminal `no_quorum`
+ * void (#4135 — never dropping into revise), or on iteration exhaustion.
+ */
+async function runConsensusLoop(
+  state: ConsensusLoopState,
+  maxIter: number,
+  revisePlan: (plan: string, feedback: string) => Promise<string>
+): Promise<IterativeConsensusResult> {
   for (let i = 0; i < maxIter; i++) {
-    const accepted = await runOneIteration(state, i + 1);
-    if (accepted !== undefined) return accepted;
+    const outcome = await runOneIteration(state, i + 1);
+    const done = outcome.result ?? outcome.terminal;
+    if (done !== undefined) return done;
     await maybeRevise(state, i, maxIter, revisePlan);
   }
 
@@ -204,6 +271,13 @@ async function executeSingleVote(
 
 /** Parse executeVoting output into a VoteResult. */
 function parseVotingResult(result: {
+  /**
+   * #4135: the response-layer decision (incl. `no_quorum`) `executeVoting` stamps.
+   * Preferred over the 2-valued engine `outcome` so a quorum void is honored, not
+   * misread as a rejection. Absent for callers/mocks that don't set it — the
+   * engine outcome is the fallback (legacy behavior, never `no_quorum`).
+   */
+  readonly decision?: string;
   readonly result: {
     readonly outcome: string;
     readonly voteCounts: { readonly approve: number; readonly reject: number };
@@ -212,12 +286,23 @@ function parseVotingResult(result: {
     readonly vote: { readonly decision: string; readonly reasoning: string };
   }>;
 }): VoteResult {
-  const approved = result.result.outcome === 'approved';
   const total = Math.max(1, result.result.voteCounts.approve + result.result.voteCounts.reject);
   const pct = (result.result.voteCounts.approve / total) * 100;
 
-  if (approved) {
+  const decision =
+    result.decision ?? (result.result.outcome === 'approved' ? 'approved' : 'rejected');
+
+  if (decision === 'approved') {
     return { kind: 'approved', approvalPercentage: pct };
+  }
+  // #4135: a quorum void — the plan is fine, a voice was missing. Do NOT synthesize
+  // rejection feedback (that would feed a plan revision the loop must skip).
+  if (decision === 'no_quorum') {
+    return {
+      kind: 'no_quorum',
+      reason: 'vote could not reach quorum (a voice was missing)',
+      approvalPercentage: pct,
+    };
   }
 
   const feedback = result.votes


### PR DESCRIPTION
## What
The keystone of #4130's rollout. #4132's `absolute_quorum` policy degrades a panel with an errored/missing contrarian to `no_quorum` (in `buildResponse`) — but the pipeline/graph/CLI consumers read the **raw engine outcome** (`approved|rejected`) and never reach `buildResponse`, so they were structurally blind to it and would misread a degraded panel as a rejection (feeding it into plan-revision). This teaches them to honor `no_quorum`: **recover by re-running the same plan** (a voice was missing — the plan is fine) up to a **bounded** `maxNoQuorumRetries` (default 2, separate from `maxIterations`), then terminate as a **non-rejected** failure.

## Plumbing (DRY, single source)
`resolveVoteDecision` is exported; `executeVoting` stamps the response-layer `decision` (incl. `no_quorum`) **once** on `ExtendedVotingResult`; `buildResponse` **reuses** that stamped value so the MCP-response decision and the pipeline-read decision can't diverge. The engine `ConsensusResult.outcome` stays 2-valued; `ConsensusVerdict.outcome` widens to add `no_quorum` (no switch/exhaustiveness break).

## Consumers
- **iterative-consensus** — bounded re-run of the same plan → terminal non-rejected on exhaustion (never `revisePlan`).
- **agent-executor** — distinct `no_quorum` signal, blocks + escalates; does **not** feed `rejected` into revision. (The separate #4143 catch-block auto-approve bug is **untouched**.)
- **vote-command** — `--on-no-quorum=fail|exit2|retry` (default `fail`→exit 1, back-compat); labels `no_quorum`.
- **consensus-node** — verdict exposes `no_quorum` (graph re-vote edge left to the graph author, per scope).

## Safety
**Inert by default:** with every default error policy `resolveVoteDecision` never returns `no_quorum`, so all new branches are dead code until #4138 opts a call site into `absolute_quorum`. The bounded retry caps the contrarian-griefing/DoS vector the #4132 gate raised. Direction was higher_order-vote-cleared in #4132's gate; this is the implementation of that cleared condition.

## Verification
`tsc --noEmit` clean · **1509 consensus/pipeline/graph/vote tests pass** — new `no_quorum` cases (bounded re-run→terminate; blocks+escalates; exit-code contract; verdict propagation) + **all existing tests UNCHANGED** (default-policy behavior inert) · eslint clean · `docs:tools` up to date.

Unblocks #4138 (day-one opt-in wiring). Refs #4132 #4135 #4143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)