### PR TITLE
fix(pipeline): vote stage fails closed on error, not auto-approve (#4143, epic #4130)

### DIFF
--- a/.changeset/agent-executor-fail-closed.md
+++ b/.changeset/agent-executor-fail-closed.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Fix a fail-open in the dev-pipeline vote stage (#4143, epic #4130). When the consensus vote
+stage threw (all voters errored, adapter down, timeout), `agent-executor` caught it and
+returned `{ kind: 'approved' }` ("Error (auto-approved)") — executing an unvoted plan as if
+the panel had approved it. It now FAILS CLOSED to `no_quorum` (a recoverable "vote couldn't
+complete — re-run/escalate" state, handled by #4135), never auto-approving. Consistent with
+the fail-loud principle behind the voter-drop epic: an errored gate must block, not grant,
+execution.

--- a/packages/nexus-agents/src/pipeline/agent-executor.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.test.ts
@@ -606,6 +606,19 @@ describe('vote stage — no_quorum handling (#4135)', () => {
     }
   });
 
+  it('#4143: a vote-stage infra error FAILS CLOSED to no_quorum, never auto-approved', async () => {
+    // Previously the catch block returned { kind:'approved' } ("Error (auto-approved)"),
+    // a fail-OPEN that would execute an unvoted plan. It now fails closed to no_quorum.
+    mockExecuteVoting.mockRejectedValue(new Error('all voters errored / adapter down'));
+    const stages = createAgentStages({ simulateVotes: false });
+    const vote = await stages.vote('the plan', '');
+    expect(vote.kind).toBe('no_quorum');
+    expect(vote.kind).not.toBe('approved');
+    if (vote.kind === 'no_quorum') {
+      expect(vote.reason).toMatch(/errored|failing closed/i);
+    }
+  });
+
   it('approve/reject paths are unchanged when decision is absent (default-policy fallback)', async () => {
     mockExecuteVoting.mockResolvedValueOnce(
       votingResult({ outcome: 'approved', approve: 6, reject: 0 })

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -630,8 +630,22 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
           success: false,
           durationMs: getTimeProvider().now() - start,
         });
-        await postProgress(config, 'Vote', `Error (auto-approved): ${msg.slice(0, 200)}`);
-        return { kind: 'approved' as const, approvalPercentage: 0 };
+        // #4143: a vote-stage infra error (all voters errored / adapter down /
+        // timeout) FAILS CLOSED to `no_quorum` — a recoverable "the vote couldn't
+        // complete, re-run/escalate" state (#4135) — NOT auto-approved. Granting
+        // approval on an errored gate is a fail-OPEN: it would execute an unvoted
+        // plan. no_quorum blocks execution and routes to the bounded re-run/escalate
+        // recovery, consistent with the fail-loud principle behind #4130/#4132.
+        await postProgress(
+          config,
+          'Vote',
+          `Error (failing closed — no quorum): ${msg.slice(0, 200)}`
+        );
+        return {
+          kind: 'no_quorum' as const,
+          reason: `vote stage errored — failing closed: ${msg.slice(0, 160)}`,
+          approvalPercentage: 0,
+        };
       }
     },
 


### PR DESCRIPTION
## What
A **fail-open security fix**. The dev-pipeline vote stage (`agent-executor`) caught a thrown consensus vote (all voters errored / adapter down / timeout) and returned `{ kind: 'approved' }` — literally logging `Error (auto-approved)` — **executing an unvoted plan as if the panel had approved it**. An errored governance gate *granted* execution.

It now **fails closed to `no_quorum`** — a recoverable "the vote couldn't complete; re-run then escalate" state (handled by #4135's consumer recovery) — never auto-approving. Same fail-loud principle as the rest of the voter-drop epic (#4130): an errored gate must **block** execution, not grant it. A vote infra error is a missing/invalid vote, not an approval.

## Why now
Surfaced during the #4135 survey and deliberately left untouched there (single-purpose PRs). Verified real against the code (the catch at `agent-executor.ts` returned `{ kind:'approved' }` on any throw). Now that #4135 landed the `no_quorum` recovery path, fail-closed-to-no_quorum is the natural, non-executing failure mode.

## Verification
`tsc --noEmit` clean · 23 agent-executor tests pass (new: a thrown vote → `no_quorum`, never `approved`) · eslint clean · patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)