### PR TITLE
feat(pipeline): opt dev-pipeline plan gate into absolute_quorum (#4138, epic #4130)

### DIFF
--- a/.changeset/dev-pipeline-absolute-quorum.md
+++ b/.changeset/dev-pipeline-absolute-quorum.md
@@ -1,0 +1,10 @@
+---
+'nexus-agents': minor
+---
+
+Opt the dev-pipeline plan gate into `absolute_quorum` (#4138, epic #4130). `iterative-consensus`
+now defaults its vote `errorPolicy` to `absolute_quorum` (overridable per-caller), so an errored
+voter — especially the contrarian — degrades the plan verdict to a recoverable `no_quorum` (which
+the existing bounded `maxNoQuorumRetries` re-run-then-terminal path already honors) instead of
+being silently dropped from the denominator. Day-one opt-in wiring; the global default policy is
+unchanged.

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.test.ts
@@ -110,6 +110,24 @@ describe('runIterativeConsensus', () => {
     );
   });
 
+  it('#4138: opts the plan gate into absolute_quorum by default', async () => {
+    mockExecuteVoting.mockResolvedValueOnce(makeVotingResult('approved', 6, 0));
+    await runIterativeConsensus('Plan', vi.fn(), {});
+    expect(mockExecuteVoting).toHaveBeenCalledWith(
+      expect.objectContaining({ errorPolicy: 'absolute_quorum' }),
+      expect.anything()
+    );
+  });
+
+  it('#4138: errorPolicy is overridable per-caller', async () => {
+    mockExecuteVoting.mockResolvedValueOnce(makeVotingResult('approved', 6, 0));
+    await runIterativeConsensus('Plan', vi.fn(), { errorPolicy: 'reduce_denominator' });
+    expect(mockExecuteVoting).toHaveBeenCalledWith(
+      expect.objectContaining({ errorPolicy: 'reduce_denominator' }),
+      expect.anything()
+    );
+  });
+
   it('truncates proposal to maxProposalLength', async () => {
     mockExecuteVoting.mockResolvedValueOnce(makeVotingResult('approved', 4, 2));
     const longPlan = 'x'.repeat(10000);

--- a/packages/nexus-agents/src/pipeline/iterative-consensus.ts
+++ b/packages/nexus-agents/src/pipeline/iterative-consensus.ts
@@ -10,7 +10,7 @@
 import { createLogger, getTimeProvider } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
 import type { VoteResult } from './dev-pipeline.js';
-import type { VotingStrategy } from '../mcp/tools/consensus-vote-types.js';
+import type { VotingStrategy, ErrorPolicy } from '../mcp/tools/consensus-vote-types.js';
 import { emitPipelineStageEvent } from './pipeline-observability.js';
 
 const defaultLogger = createLogger({ component: 'iterative-consensus' });
@@ -29,6 +29,14 @@ export interface IterativeConsensusConfig {
   readonly quickMode?: boolean | undefined;
   /** Voting strategy (default: 'higher_order'). */
   readonly strategy?: VotingStrategy | undefined;
+  /**
+   * #4138: error policy for the vote (default: 'absolute_quorum'). The dev-pipeline
+   * plan gate opts in to `absolute_quorum` so an errored voter — especially the
+   * contrarian — degrades to a recoverable `no_quorum` (which the bounded
+   * `maxNoQuorumRetries` re-run then terminal path already honors) instead of being
+   * silently dropped from the denominator. Overridable per-caller.
+   */
+  readonly errorPolicy?: ErrorPolicy | undefined;
   /**
    * #4135: how many times to re-run the SAME plan when a vote returns
    * `no_quorum` — a missing/errored voice, not a rejection — before giving up
@@ -228,13 +236,22 @@ function buildExhaustedResult(
 function buildVotingInput(
   plan: string,
   config: IterativeConsensusConfig | undefined
-): { proposal: string; strategy: VotingStrategy; simulateVotes: boolean; quickMode: boolean } {
-  const maxLen = config?.maxProposalLength ?? DEFAULT_MAX_PROPOSAL_LENGTH;
+): {
+  proposal: string;
+  strategy: VotingStrategy;
+  simulateVotes: boolean;
+  quickMode: boolean;
+  errorPolicy: ErrorPolicy;
+} {
+  const c = config ?? {};
+  const maxLen = c.maxProposalLength ?? DEFAULT_MAX_PROPOSAL_LENGTH;
   return {
     proposal: plan.slice(0, maxLen),
-    strategy: config?.strategy ?? DEFAULT_STRATEGY,
-    simulateVotes: config?.simulateVotes ?? false,
-    quickMode: config?.quickMode ?? false,
+    strategy: c.strategy ?? DEFAULT_STRATEGY,
+    simulateVotes: c.simulateVotes ?? false,
+    quickMode: c.quickMode ?? false,
+    // #4138: the dev-pipeline plan gate opts in to absolute_quorum (overridable).
+    errorPolicy: c.errorPolicy ?? 'absolute_quorum',
   };
 }
 


### PR DESCRIPTION
## What
PR-A of the #4138 capstone (opt-in wiring). The dev-pipeline consensus **plan gate** (`iterative-consensus`) now defaults its vote `errorPolicy` to `absolute_quorum` (overridable per-caller via `IterativeConsensusConfig.errorPolicy`). An errored voter — especially the contrarian — now degrades the plan verdict to a recoverable `no_quorum`, which the existing #4135 bounded re-run (`maxNoQuorumRetries`, default 2) → terminal path already honors, instead of being silently dropped from the denominator and proceeding on survivors.

## Why this is the trivial half
Per the 3-voter higher_order gate (all APPROVE-WITH-CONDITIONS), the plan gate's recovery machinery already exists (#4135); the only missing piece was `buildVotingInput` not passing `errorPolicy`. This is the one-line flip. The meatier auto-remediation gate (needs a `no_quorum` channel through the adapter/enforce) is PR-C, split per the autonomy voter.

## Safety
Day-one opt-in wiring — the global default policy (`getDefaultErrorPolicy`) is **unchanged**; only this internal call site opts in. Monotonically safer: a degraded plan panel now blocks+re-runs rather than proceeding on survivors. Bounded by `maxNoQuorumRetries` then `maxIterations` — no wedge.

## Verification
`tsc --noEmit` clean · iterative-consensus tests pass incl. new (`errorPolicy` defaults to `absolute_quorum`; overridable) · eslint clean · minor changeset.

Refs #4130 #4132 #4135. PR-C (auto-remediation gate) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)