### PR TITLE
feat(remediation): auto-remediation gate honors no_quorum via absolute_quorum (#4138, epic #4130)

### DIFF
--- a/.changeset/auto-remediation-absolute-quorum.md
+++ b/.changeset/auto-remediation-absolute-quorum.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': minor
+---
+
+Opt the auto-remediation consensus→execute gate into `absolute_quorum` (#4138, epic #4130). The
+remediation vote adapter now sets `errorPolicy: 'absolute_quorum'` and surfaces the #4135-stamped
+response-layer `decision` (incl. `no_quorum`) on its verdict. A degraded panel (e.g. an errored
+contrarian) now degrades to `no_quorum` and triggers ONE bounded re-run
+(`AUTO_REMEDIATION_NO_QUORUM_RETRIES = 1`) to absorb a transient blip; a verdict that stays
+`no_quorum` becomes an EXPLICIT auditable terminal "left as an issue" (zero writes) rather than an
+incidental `!approved` collapse. A voter you can knock offline can only ever force a re-run of the
+autonomous-execution gate, never flip it. The default (approved→proceed / rejected→skip) path is
+byte-identical.

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
@@ -174,6 +174,47 @@ describe('runAutoRemediation — enforce', () => {
     expect(deps.implement).not.toHaveBeenCalled();
   });
 
+  it('an errored contrarian (absolute_quorum no_quorum) leaves the signal as an issue — NO write (#4138)', async () => {
+    // The load-bearing security test (vote condition (ii)): a degraded panel under
+    // absolute_quorum degrades to no_quorum; it must NEVER be executed. Persistent
+    // no_quorum (both attempts) → EXPLICIT terminal skip, zero writes.
+    const vote = vi.fn(async () =>
+      Promise.resolve({ approved: false, approvalPercentage: 0, decision: 'no_quorum' as const })
+    );
+    const { deps } = makeDeps({ vote });
+    const r = await runAutoRemediation([signal()], deps, enf());
+    expect(r.remediated).toEqual([]);
+    expect(r.skipped[0]?.reason).toMatch(/no_quorum/);
+    expect(r.skipped[0]?.reason).toMatch(/left as an issue/);
+    expect(deps.implement).not.toHaveBeenCalled(); // the security guarantee: no write
+    expect(vote).toHaveBeenCalledTimes(2); // initial + exactly 1 bounded re-run
+  });
+
+  it('a no_quorum that RECOVERS to approved on the bounded re-run proceeds to remediate (#4138)', async () => {
+    const vote = vi
+      .fn()
+      .mockResolvedValueOnce({ approved: false, approvalPercentage: 0, decision: 'no_quorum' })
+      .mockResolvedValueOnce({ approved: true, approvalPercentage: 100, decision: 'approved' });
+    const { deps } = makeDeps({ vote });
+    const r = await runAutoRemediation([signal()], deps, enf());
+    expect(r.remediated).toHaveLength(1); // transient blip absorbed
+    expect(deps.implement).toHaveBeenCalledTimes(1);
+    expect(vote).toHaveBeenCalledTimes(2); // initial no_quorum + one recovering re-run
+  });
+
+  it('a no_quorum that RECOVERS to rejected on the re-run leaves the signal as an issue (#4138)', async () => {
+    const vote = vi
+      .fn()
+      .mockResolvedValueOnce({ approved: false, approvalPercentage: 0, decision: 'no_quorum' })
+      .mockResolvedValueOnce({ approved: false, approvalPercentage: 30, decision: 'rejected' });
+    const { deps } = makeDeps({ vote });
+    const r = await runAutoRemediation([signal()], deps, enf());
+    expect(r.remediated).toEqual([]);
+    expect(r.skipped[0]?.reason).toMatch(/not reached/); // genuine reject, not no_quorum
+    expect(deps.implement).not.toHaveBeenCalled();
+    expect(vote).toHaveBeenCalledTimes(2);
+  });
+
   it('p0 fail-closes when no dry-run capability is available', async () => {
     const { deps } = makeDeps();
     delete (deps as { dryRun?: unknown }).dryRun; // no dry-run capability

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.ts
@@ -52,7 +52,19 @@ import {
   getRemediationCircuitBreaker,
 } from './remediation-circuit-breaker.js';
 import { planTouchesProtectedPath } from './remediation-protected-paths.js';
+import { retryOnNoQuorum, type VoteVerdict } from './remediation-vote-adapter.js';
 import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
+
+/**
+ * #4138: bounded re-runs of an `absolute_quorum` `no_quorum` void in the
+ * auto-remediation consensus gate. Auto-remediation is an unattended loop and each
+ * re-run is a full live voter panel, so the budget is deliberately tiny: 1 re-run
+ * absorbs a transient blip (a voter's adapter momentarily offline) without turning
+ * a knocked-offline voice into an autonomous-execution DoS. A verdict that stays
+ * `no_quorum` after the single re-run is an EXPLICIT terminal "left as an issue"
+ * (zero writes) — the autonomy voter's ratified condition, not a silent proceed.
+ */
+const AUTO_REMEDIATION_NO_QUORUM_RETRIES = 1;
 
 /** The three enforcement modes. */
 export type AutoRemediateMode = 'off' | 'audit' | 'enforce';
@@ -126,10 +138,7 @@ export interface AutoRemediationDeps {
    * `consensus_vote` with live voters; voter input must be sanitized (the plan is
    * a strict typed artifact, #3613).
    */
-  vote(input: { proposal: string; algorithm: ConsensusAlgorithm }): Promise<{
-    approved: boolean;
-    approvalPercentage: number;
-  }>;
+  vote(input: { proposal: string; algorithm: ConsensusAlgorithm }): Promise<VoteVerdict>;
   /**
    * Optional audit-mode dry-run, required for p0 before a real PR (#3653). Runs
    * the pipeline plan-only with no writes; must return ok before IMPLEMENT.
@@ -342,9 +351,21 @@ function admitSignal(signal: ImprovementSignal, guard: RemediationGuard, now: nu
 }
 
 /**
+ * Audit label for a vote verdict. Default path (no `decision`, or a resolved
+ * approved/rejected) is byte-identical to the pre-#4138 `approved ? … : …`; a
+ * `no_quorum` degradation surfaces as `no_quorum` so the audit trail shows the
+ * degraded panel rather than a misleading `rejected`.
+ */
+function voteVerdictLabel(v: VoteVerdict): string {
+  if (v.decision === 'no_quorum') return 'no_quorum';
+  return v.approved ? 'approved' : 'rejected';
+}
+
+/**
  * Consensus gate (#3653): run the priority-required vote on the plan; for p0 also
  * require a green dry-run. Returns a skip reason, or null to proceed. Fail-closed:
  * a rejected vote, a p0 with no dry-run capability, or a failed dry-run all skip.
+ * #4138: an absolute_quorum `no_quorum` void → bounded re-run → explicit terminal skip.
  */
 async function consensusGate(
   signal: ImprovementSignal,
@@ -356,12 +377,27 @@ async function consensusGate(
   const algorithm = requirement.algorithm;
   if (algorithm === undefined) return 'no consensus algorithm for tier'; // p4 — shouldn't reach here
   const proposal = `Auto-remediation for '${signal.signalKey}'.\n\n${renderPlanAsResearch(plan)}`;
-  const vote = await deps.vote({ proposal, algorithm });
-  deps.audit({
-    step: 'vote',
-    signalKey: signal.signalKey,
-    detail: `${algorithm}: ${vote.approved ? 'approved' : 'rejected'} (${String(Math.round(vote.approvalPercentage))}%)`,
-  });
+  // One vote attempt, audited. Under absolute_quorum (#4138) an errored voice
+  // degrades the verdict to no_quorum; retryOnNoQuorum re-runs it up to the tiny
+  // AUTO_REMEDIATION_NO_QUORUM_RETRIES budget to absorb a transient blip.
+  const runVote = async (): Promise<VoteVerdict> => {
+    const v = await deps.vote({ proposal, algorithm });
+    deps.audit({
+      step: 'vote',
+      signalKey: signal.signalKey,
+      detail: `${algorithm}: ${voteVerdictLabel(v)} (${String(Math.round(v.approvalPercentage))}%)`,
+    });
+    return v;
+  };
+  const vote = await retryOnNoQuorum(runVote, AUTO_REMEDIATION_NO_QUORUM_RETRIES);
+
+  // #4138 security condition (i): an absolute_quorum no_quorum that survives the
+  // bounded re-run is a missing/errored voice — NOT a verdict. Return an EXPLICIT
+  // terminal skip (zero writes); never let the `!vote.approved` check below collapse
+  // it incidentally, and never proceed to IMPLEMENT.
+  if (vote.decision === 'no_quorum') {
+    return `consensus no_quorum — quorum not reached after ${String(AUTO_REMEDIATION_NO_QUORUM_RETRIES)} re-run(s); left as an issue`;
+  }
   if (!vote.approved) {
     return `consensus ${algorithm} not reached (${String(Math.round(vote.approvalPercentage))}%) — left as an issue`;
   }

--- a/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { makeVoteAdapter, buildVoteInput, type VoteRunner } from './remediation-vote-adapter.js';
+import {
+  makeVoteAdapter,
+  buildVoteInput,
+  retryOnNoQuorum,
+  type VoteRunner,
+  type VoteVerdict,
+} from './remediation-vote-adapter.js';
 
 describe('buildVoteInput', () => {
   it('forces real voters (simulateVotes false) and the requested strategy', () => {
@@ -12,6 +18,13 @@ describe('buildVoteInput', () => {
     expect(input.simulateVotes).toBe(false);
     expect(input.strategy).toBe('unanimous');
     expect(input.proposal).toBe('remediate X');
+  });
+
+  it('opts into absolute_quorum so an errored voice degrades to no_quorum (#4138)', () => {
+    // Anti-DoS: a voter you can knock offline can only force a re-run, never flip
+    // an autonomous-execution gate.
+    expect(buildVoteInput('remediate X', 'higher_order').errorPolicy).toBe('absolute_quorum');
+    expect(buildVoteInput('p', 'unanimous').errorPolicy).toBe('absolute_quorum');
   });
 
   it('passes through each priority algorithm as the strategy', () => {
@@ -40,5 +53,46 @@ describe('makeVoteAdapter', () => {
       approved: false,
       approvalPercentage: 42,
     });
+  });
+
+  it('carries the runner decision (incl. no_quorum) through to the gate (#4138)', async () => {
+    const vote = makeVoteAdapter(async () =>
+      Promise.resolve({ approved: false, approvalPercentage: 0, decision: 'no_quorum' })
+    );
+    expect(await vote({ proposal: 'p', algorithm: 'higher_order' })).toEqual({
+      approved: false,
+      approvalPercentage: 0,
+      decision: 'no_quorum',
+    });
+  });
+});
+
+describe('retryOnNoQuorum (#4138)', () => {
+  it('does NOT re-run when the first verdict is decisive (approved)', async () => {
+    const runVote = vi.fn<() => Promise<VoteVerdict>>(async () =>
+      Promise.resolve({ approved: true, approvalPercentage: 100, decision: 'approved' })
+    );
+    const v = await retryOnNoQuorum(runVote, 1);
+    expect(v.approved).toBe(true);
+    expect(runVote).toHaveBeenCalledTimes(1); // no wasted re-run on a clean verdict
+  });
+
+  it('re-runs a no_quorum void and returns a recovered verdict (transient blip)', async () => {
+    const runVote = vi
+      .fn<() => Promise<VoteVerdict>>()
+      .mockResolvedValueOnce({ approved: false, approvalPercentage: 0, decision: 'no_quorum' })
+      .mockResolvedValueOnce({ approved: true, approvalPercentage: 100, decision: 'approved' });
+    const v = await retryOnNoQuorum(runVote, 1);
+    expect(v).toEqual({ approved: true, approvalPercentage: 100, decision: 'approved' });
+    expect(runVote).toHaveBeenCalledTimes(2); // initial + one re-run, then stops
+  });
+
+  it('returns the terminal no_quorum after exactly maxRetries re-runs (persistent)', async () => {
+    const runVote = vi.fn<() => Promise<VoteVerdict>>(async () =>
+      Promise.resolve({ approved: false, approvalPercentage: 0, decision: 'no_quorum' })
+    );
+    const v = await retryOnNoQuorum(runVote, 1);
+    expect(v.decision).toBe('no_quorum'); // still degraded → caller makes it a terminal skip
+    expect(runVote).toHaveBeenCalledTimes(2); // initial + exactly 1 re-run, bounded
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-vote-adapter.ts
@@ -16,17 +16,34 @@
 import { createLogger, type ILogger } from '../../core/index.js';
 import type { ConsensusAlgorithm } from '../../consensus/types-core.js';
 import { executeVoting, ConsensusVoteInputSchema } from './consensus-vote.js';
+import type { VoteDecisionStatus } from './consensus-vote-types.js';
 import type { AutoRemediationDeps } from './improvement-remediation-enforce.js';
 
+/**
+ * A vote verdict as the auto-remediation gate consumes it. `decision` (#4138) is
+ * the response-layer {@link VoteDecisionStatus} (the #4135-stamped view, incl.
+ * `'no_quorum'`) surfaced alongside the legacy 2-valued `approved` flag so the
+ * gate can honor an `absolute_quorum` `no_quorum` void (bounded re-run → explicit
+ * terminal skip) instead of misreading it as a rejection. Absent on paths that
+ * never ran `executeVoting`; callers then fall back to the legacy `approved` map.
+ */
+export interface VoteVerdict {
+  readonly approved: boolean;
+  readonly approvalPercentage: number;
+  readonly decision?: VoteDecisionStatus;
+}
+
 /** A runnable vote — abstracted so the adapter is unit-testable without live voters. */
-export type VoteRunner = (
-  proposal: string,
-  algorithm: ConsensusAlgorithm
-) => Promise<{ approved: boolean; approvalPercentage: number }>;
+export type VoteRunner = (proposal: string, algorithm: ConsensusAlgorithm) => Promise<VoteVerdict>;
 
 /**
  * Build the consensus-vote input for a remediation proposal. Forces real voters
- * (`simulateVotes: false`) and the priority-required strategy. Exported for tests.
+ * (`simulateVotes: false`) and the priority-required strategy. Opts into the
+ * anti-DoS `absolute_quorum` error policy (#4132/#4138): an errored voter —
+ * especially the contrarian (catfish) — DEGRADES the verdict to a recoverable
+ * `no_quorum` instead of being dropped from the denominator, so a voter you can
+ * knock offline can only ever force a re-run, never flip an autonomous-execution
+ * gate. Exported for tests.
  */
 export function buildVoteInput(
   proposal: string,
@@ -36,18 +53,43 @@ export function buildVoteInput(
     proposal,
     strategy: algorithm,
     simulateVotes: false, // never gate auto-remediation on simulated votes
+    errorPolicy: 'absolute_quorum', // #4138: an errored voice → no_quorum, never a flipped verdict
   });
 }
 
 /** Default runner — the real, live-voter consensus path. */
 function makeDefaultRunner(logger: ILogger): VoteRunner {
   return async (proposal, algorithm) => {
-    const { result } = await executeVoting(buildVoteInput(proposal, algorithm), logger);
+    const voting = await executeVoting(buildVoteInput(proposal, algorithm), logger);
     return {
-      approved: result.outcome === 'approved',
-      approvalPercentage: result.approvalPercentage,
+      approved: voting.result.outcome === 'approved',
+      approvalPercentage: voting.result.approvalPercentage,
+      // #4138: carry the #4135-stamped response-layer decision (incl. no_quorum) so
+      // the gate honors an absolute_quorum void instead of collapsing it to reject.
+      // Conditional spread keeps `decision` absent (not `undefined`) under
+      // exactOptionalPropertyTypes when executeVoting left it unstamped.
+      ...(voting.decision !== undefined ? { decision: voting.decision } : {}),
     };
   };
+}
+
+/**
+ * #4138: bounded re-run for an `absolute_quorum` `no_quorum` void. Re-invokes
+ * `runVote` while the verdict is `no_quorum` and retries remain, returning the
+ * last verdict (recovered → its real approved/rejected decision; still degraded →
+ * the terminal `no_quorum`). Tiny + pure so both the adapter default path and the
+ * auto-remediation gate share ONE re-run loop (not `iterative-consensus`'s private,
+ * plan-coupled `voteWithQuorumRecovery`).
+ */
+export async function retryOnNoQuorum(
+  runVote: () => Promise<VoteVerdict>,
+  maxRetries: number
+): Promise<VoteVerdict> {
+  let verdict = await runVote();
+  for (let attempt = 0; attempt < maxRetries && verdict.decision === 'no_quorum'; attempt++) {
+    verdict = await runVote();
+  }
+  return verdict;
 }
 
 /**


### PR DESCRIPTION
## What
PR-C of the #4138 capstone — the high-stakes half. The **auto-remediation consensus→execute gate** (which authorizes REAL code changes) now opts into `errorPolicy: 'absolute_quorum'` and honors the resulting `no_quorum`. Previously it dropped an errored voter and read only the 2-valued engine `outcome`; now the vote runner carries the #4135-stamped response-layer `decision` (new `VoteVerdict` type), and `consensusGate` has an **explicit `no_quorum` branch**: a bounded re-run (`retryOnNoQuorum`, budget **1**) → terminal "left as an issue" skip (**zero writes**), placed *before* the `!approved` check so intent is auditable (security condition (i)).

## Why budget 1
Auto-remediation is an unattended loop; each re-run is a full live voter panel. 1 re-run absorbs a transient blip without letting a knocked-offline voice DoS the execution gate (autonomy voter's condition). Persistent `no_quorum` → exactly 2 votes → terminal skip.

## Safety
Monotonically safer — a degraded panel can only ever **block** (file an issue), never approve a bad change. Default path **byte-identical** (when `decision` absent/not no_quorum, `retryOnNoQuorum` runs the vote once → unchanged approved/rejected branches). Opt-in only; `getDefaultErrorPolicy` untouched.

## Verification
`tsc --noEmit` clean · **30 enforce/adapter tests pass** incl. the load-bearing security test (errored contrarian → skip + `implement` NOT called → zero writes) + recover-on-re-run + persistent→terminal-after-1-retry · eslint clean · `docs:tools:check` up to date · minor changeset.

Completes #4138 with PR-A (#4148). Vote-cleared by the 3-voter higher_order gate. Refs #4130 #4132 #4135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)