### PR TITLE
feat(pr_review): honest large-diff review — security-first pack, partial barred from verified-approve (#4140, epic #4130)

### DIFF
--- a/.changeset/pr-review-large-diff-affordance.md
+++ b/.changeset/pr-review-large-diff-affordance.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+`pr_review` large-diff affordance (#4140, epic #4130). A PR diff over the 50KB voter
+PANEL budget is no longer hard-failed at the schema or lossily hand-truncated
+mid-hunk: it is now accepted (new `MAX_DIFF_INPUT_LENGTH = 2_000_000` DoS bound) and
+reviewed on a REAL, security-prioritized subset of WHOLE files. A new pure module
+(`pr-review-diff-budget.ts`) splits the diff on `diff --git` file boundaries
+(fragment-safe: robust to rename-only / binary / no-newline entries), orders
+sensitive-path files first (`auth`, `crypto`, `secret`, `credential`, `security`,
+`exec`, `spawn`, `password`, `token`, `.env`, `permission`, `sql` — a documented
+substring list, not scored weights), and greedily packs whole files into the budget;
+a single over-budget file is included truncated-with-marker AND listed as
+partially-seen.
+
+The review is HONESTLY labeled: a partial-review NOTE is prepended to the voter
+proposal, and machine-readable `coverage` (`{ reviewedFiles, totalFiles, droppedFiles,
+partial, strategy: 'budget' }`) rides the response and is stamped into the audit
+record summary. C1 (load-bearing): a partial review is BARRED from a
+verified-approve — a would-be `{ approve, verified:true }` degrades to the #4132
+`{ abstain, verified:false, reason: 'no_quorum: partial diff …' }` shape, while a
+`request_changes` blocker from a reviewed file still wins. A partial review can
+BLOCK but never verified-APPROVE. Diffs within budget are byte-identical to before;
+`reviewedDiffHash` still binds the canonical first 50KB of `prDiff` (unchanged).
+Options C (#4151), B (#4152), and a scored ranker are deferred.

--- a/docs/reference/tools/pr_review.md
+++ b/docs/reference/tools/pr_review.md
@@ -18,7 +18,7 @@ Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, secu
 | --------- | ---- | -------- | ----------- | ----------- |
 | `prTitle` | string | yes | minLength 1; maxLength 500 | PR title |
 | `prDescription` | string | no | maxLength 10000 | PR body / description |
-| `prDiff` | string | yes | minLength 1; maxLength 50000 | Unified diff text (max 50000 chars; truncate before calling) |
+| `prDiff` | string | yes | minLength 1; maxLength 2000000 | Unified diff text (max 2000000 chars). No need to truncate before calling: diffs over 50000 chars are security-prioritized and PARTIALLY reviewed (lowest-priority whole files dropped; coverage reported on the response, and a partial review can block but never verified-approve). |
 | `repoContext` | string | no | maxLength 2000 | Optional one-paragraph repo context (architecture, conventions; max 2000 chars; trim before calling) |
 | `baseRef` | string | no | maxLength 200 | Base branch ref (e.g. main) |
 | `headRef` | string | no | maxLength 200 | Head branch ref |

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the #4140 large-diff budget packer (pure module).
+ *
+ * @module mcp/tools/pr-review-diff-budget.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SENSITIVE_PATH_PATTERNS,
+  securityFirstPack,
+  splitByFile,
+  type DiffFile,
+} from './pr-review-diff-budget.js';
+
+/** Build a normal file diff segment with `bodyLines` added lines. */
+function fileDiff(path: string, bodyLines: number): string {
+  const lines = Array.from({ length: bodyLines }, (_, i) => `+line ${String(i)}`).join('\n');
+  return (
+    `diff --git a/${path} b/${path}\n` +
+    `index 0000000..1111111 100644\n` +
+    `--- a/${path}\n` +
+    `+++ b/${path}\n` +
+    `@@ -0,0 +1,${String(bodyLines)} @@\n` +
+    `${lines}\n`
+  );
+}
+
+function totalBytes(files: readonly DiffFile[]): number {
+  return files.reduce((n, f) => n + f.bytes, 0);
+}
+
+describe('pr-review-diff-budget', () => {
+  describe('splitByFile', () => {
+    it('splits a multi-file diff into one segment per file, round-trip lossless', () => {
+      const diff = fileDiff('src/a.ts', 3) + fileDiff('src/b.ts', 2) + fileDiff('src/c.ts', 4);
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(3);
+      expect(files.map((f) => f.path)).toEqual(['src/a.ts', 'src/b.ts', 'src/c.ts']);
+      // Fragment safety: concatenating the segments in order reproduces the input
+      // byte-for-byte — no file was corrupted, split mid-hunk, or dropped.
+      expect(files.map((f) => f.text).join('')).toBe(diff);
+      for (const f of files) expect(f.text.startsWith('diff --git ')).toBe(true);
+    });
+
+    it('extracts the destination path from a rename-only entry', () => {
+      const diff =
+        'diff --git a/old-name.ts b/new-name.ts\n' +
+        'similarity index 100%\n' +
+        'rename from old-name.ts\n' +
+        'rename to new-name.ts\n';
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.path).toBe('new-name.ts');
+      expect(files[0]?.text).toBe(diff);
+    });
+
+    it('keeps a Binary files differ entry whole', () => {
+      const diff =
+        'diff --git a/logo.png b/logo.png\n' +
+        'index 1111111..2222222 100644\n' +
+        'Binary files a/logo.png and b/logo.png differ\n';
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.path).toBe('logo.png');
+      expect(files[0]?.text).toContain('Binary files');
+    });
+
+    it('preserves "\\ No newline at end of file" markers within a file segment', () => {
+      const diff =
+        'diff --git a/c.ts b/c.ts\n' +
+        '--- a/c.ts\n' +
+        '+++ b/c.ts\n' +
+        '@@ -1 +1 @@\n' +
+        '-a\n' +
+        '\\ No newline at end of file\n' +
+        '+b\n' +
+        '\\ No newline at end of file\n';
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.text).toContain('\\ No newline at end of file');
+      expect(files[0]?.text).toBe(diff);
+    });
+
+    it('mixed multi-file diff (normal + rename + binary + no-newline) round-trips whole', () => {
+      const diff =
+        fileDiff('src/normal.ts', 3) +
+        'diff --git a/old.ts b/renamed.ts\nsimilarity index 100%\nrename from old.ts\nrename to renamed.ts\n' +
+        'diff --git a/pic.png b/pic.png\nindex 111..222 100644\nBinary files a/pic.png and b/pic.png differ\n' +
+        'diff --git a/tail.ts b/tail.ts\n--- a/tail.ts\n+++ b/tail.ts\n@@ -1 +1 @@\n-x\n\\ No newline at end of file\n+y\n';
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(4);
+      expect(files.map((f) => f.path)).toEqual([
+        'src/normal.ts',
+        'renamed.ts',
+        'pic.png',
+        'tail.ts',
+      ]);
+      expect(files.map((f) => f.text).join('')).toBe(diff);
+    });
+
+    it('handles content before the first header as a (preamble) segment', () => {
+      const diff = 'commit abc\nAuthor: x\n\n' + fileDiff('a.ts', 2);
+      const files = splitByFile(diff);
+      expect(files).toHaveLength(2);
+      expect(files[0]?.path).toBe('(preamble)');
+      expect(files.map((f) => f.text).join('')).toBe(diff);
+    });
+
+    it('returns a single (unstructured) segment for a diff with no file header', () => {
+      const files = splitByFile('some non-diff text\nwith lines\n');
+      expect(files).toHaveLength(1);
+      expect(files[0]?.path).toBe('(unstructured)');
+    });
+
+    it('returns [] for empty input', () => {
+      expect(splitByFile('')).toEqual([]);
+    });
+  });
+
+  describe('securityFirstPack', () => {
+    it('reviews a sensitive-path file even when it is LAST in the diff (security-first)', () => {
+      // auth file is the LAST file in original order; it must survive a tight budget.
+      const diff =
+        fileDiff('src/util.ts', 4) + fileDiff('README.md', 4) + fileDiff('src/auth-handler.ts', 4);
+      const files = splitByFile(diff);
+      const budget = totalBytes(files) - 1; // forces at least one drop
+      const res = securityFirstPack(files, budget);
+
+      expect(res.reviewedFiles).toContain('src/auth-handler.ts');
+      expect(res.partial).toBe(true);
+      expect(res.totalFiles).toBe(3);
+      expect(res.droppedFiles.length).toBeGreaterThan(0);
+      // packed contains the sensitive file's content.
+      expect(res.packed).toContain('src/auth-handler.ts');
+    });
+
+    it('handles a real >50000-char diff with the sensitive file near the END', () => {
+      // Two large filler files then a sensitive file — total > 50000, budget 50000.
+      const filler = fileDiff('src/big-a.ts', 3000);
+      const filler2 = fileDiff('src/big-b.ts', 3000);
+      const sensitive = fileDiff('src/security-token.ts', 400);
+      const diff = filler + filler2 + sensitive;
+      expect(diff.length).toBeGreaterThan(50_000);
+
+      const res = securityFirstPack(splitByFile(diff), 50_000);
+      // Security-first ordering pulls the sensitive file ahead of the fillers, so it
+      // is reviewed while a lower-priority filler is dropped.
+      expect(res.reviewedFiles).toContain('src/security-token.ts');
+      expect(res.partial).toBe(true);
+      expect(res.reviewedFiles.length + res.droppedFiles.length).toBe(res.totalFiles);
+    });
+
+    it('non-partial when everything fits (partial:false, no drops)', () => {
+      const diff = fileDiff('a.ts', 2) + fileDiff('b.ts', 2);
+      const files = splitByFile(diff);
+      const res = securityFirstPack(files, totalBytes(files));
+      expect(res.partial).toBe(false);
+      expect(res.droppedFiles).toEqual([]);
+      expect(res.reviewedFiles).toEqual(['a.ts', 'b.ts']);
+    });
+
+    it('a single file larger than budget is included TRUNCATED and listed as partially-seen', () => {
+      const diff = fileDiff('src/huge.ts', 500);
+      const files = splitByFile(diff);
+      const budget = 200; // far below the single file's size
+      const res = securityFirstPack(files, budget);
+
+      expect(res.reviewedFiles).toEqual(['src/huge.ts']);
+      expect(res.droppedFiles).toContain('src/huge.ts'); // honest: partially seen
+      expect(res.partial).toBe(true);
+      expect(res.packed).toContain('TRUNCATED');
+      expect(Buffer.byteLength(res.packed, 'utf-8')).toBeLessThanOrEqual(budget);
+    });
+
+    it('stable ordering: two sensitive files keep original relative order', () => {
+      const diff =
+        fileDiff('src/authz.ts', 2) + fileDiff('src/plain.ts', 2) + fileDiff('src/crypto.ts', 2);
+      const files = splitByFile(diff);
+      const res = securityFirstPack(files, totalBytes(files));
+      // Both sensitive files come first, in their original relative order.
+      expect(res.reviewedFiles).toEqual(['src/authz.ts', 'src/crypto.ts', 'src/plain.ts']);
+    });
+
+    it('SENSITIVE_PATH_PATTERNS is a documented substring list (no scored weights)', () => {
+      expect(SENSITIVE_PATH_PATTERNS).toContain('auth');
+      expect(SENSITIVE_PATH_PATTERNS).toContain('.env');
+      expect(SENSITIVE_PATH_PATTERNS.every((p) => typeof p === 'string')).toBe(true);
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
@@ -1,0 +1,301 @@
+/**
+ * nexus-agents/mcp — PR-Review Large-Diff Budget Packer (#4140, epic #4130).
+ *
+ * Option A of the large-diff affordance: when a PR diff exceeds the voter PANEL
+ * budget (`MAX_DIFF_LENGTH`), pack it down to a REAL, security-prioritized subset
+ * of WHOLE files instead of hard-failing at the schema or lossily hand-truncating
+ * mid-hunk. A packed review is honestly labeled PARTIAL and (per the #4140 C1
+ * gate wired in pr-review-tool.ts) is BARRED from a verified-approve — it can
+ * BLOCK on a reviewed file but never verified-APPROVE.
+ *
+ * This module is PURE, deterministic, and I/O-free: no model call, no filesystem,
+ * no clock. It is unit-testable in isolation and reused by `executePrReviewBody`.
+ *
+ * FILE-BOUNDARY SAFETY is the load-bearing invariant. `splitByFile` splits only on
+ * `^diff --git ` file headers, so each unit is a whole file's hunk-set. The packer
+ * includes each file WHOLE or drops it — worst case a single over-budget file is
+ * included TRUNCATED with an explicit marker AND still listed as partially-seen. A
+ * voter never receives a corrupted mid-hunk fragment that reads as complete.
+ *
+ * NOT built here (deferred): the exhaustive multi-pass arm (#4151), file-fetch
+ * (#4152), and any scored/weighted ranker. Ordering is a documented two-tier
+ * partition (sensitive-path files first, stable; then the rest in diff order) —
+ * NOT a score.
+ *
+ * @module mcp/tools/pr-review-diff-budget
+ */
+
+import type { PrReviewAggregate } from './pr-review-tool.js';
+
+/** One whole file's slice of a unified diff (header + all its hunks). */
+export interface DiffFile {
+  /** Destination path from the `diff --git a/<x> b/<path>` header (best-effort). */
+  readonly path: string;
+  /** The exact bytes of this file's diff segment, verbatim from the input. */
+  readonly text: string;
+  /** UTF-8 byte length of `text` — the budgeting unit. */
+  readonly bytes: number;
+}
+
+/** Result of {@link securityFirstPack}. */
+export interface DiffPackResult {
+  /** The concatenated diff text of the reviewed (included) files, in packed order. */
+  readonly packed: string;
+  /** Paths of files included in `packed` (whole, or the one truncated head). */
+  readonly reviewedFiles: string[];
+  /** Total number of files in the original diff. */
+  readonly totalFiles: number;
+  /** Paths of files NOT fully reviewed (dropped, or the truncated head — honest). */
+  readonly droppedFiles: string[];
+  /** True when at least one file was dropped/truncated (coverage is incomplete). */
+  readonly partial: boolean;
+}
+
+/**
+ * Documented sensitive-path signals. A file whose path contains ANY of these
+ * substrings (case-insensitive) is ordered FIRST in the pack so the highest-risk
+ * changes are the ones that survive a tight budget. This is a small, auditable
+ * const list — deliberately NOT scored weights (a ranker is deferred, #4140). Add
+ * a substring here to raise a path class into the security-first tier.
+ */
+export const SENSITIVE_PATH_PATTERNS: readonly string[] = Object.freeze([
+  'auth',
+  'crypto',
+  'secret',
+  'credential',
+  'security',
+  'exec',
+  'spawn',
+  'password',
+  'token',
+  '.env',
+  'permission',
+  'sql',
+]);
+
+/** Whether a file path matches any {@link SENSITIVE_PATH_PATTERNS} substring. */
+function isSensitivePath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return SENSITIVE_PATH_PATTERNS.some((p) => lower.includes(p));
+}
+
+/** UTF-8 byte length helper (the budgeting unit). */
+function byteLen(text: string): number {
+  return Buffer.byteLength(text, 'utf-8');
+}
+
+/**
+ * Extract the reviewed (destination) path from a file segment's `diff --git` header
+ * line: `diff --git a/<old> b/<new>`. Prefers the `b/<new>` path (correct for
+ * rename-only entries). Falls back to the raw header remainder when the shape is
+ * unusual (mode-only / binary / malformed) — the segment is still kept WHOLE, so a
+ * degraded path label never corrupts content.
+ */
+function extractPath(fileText: string): string {
+  const nl = fileText.indexOf('\n');
+  const firstLine = nl === -1 ? fileText : fileText.slice(0, nl);
+  const m = /^diff --git a\/(.+?) b\/(.+)$/.exec(firstLine);
+  if (m !== null) return m[2] as string;
+  return firstLine.replace(/^diff --git\s*/, '').trim();
+}
+
+/**
+ * Split a unified diff into whole-file segments on `^diff --git ` boundaries
+ * (multiline). Each returned {@link DiffFile} is a complete file segment — header
+ * plus every hunk up to the next file header — so the packer can only ever include
+ * or drop a WHOLE file, never a mid-hunk fragment. Robust to rename-only, mode-only,
+ * `Binary files … differ`, and `\ No newline at end of file` entries (they live
+ * inside a segment and are carried verbatim).
+ *
+ * Edge cases, all fragment-safe:
+ *  - Content BEFORE the first `diff --git` (rare preamble) becomes a `(preamble)`
+ *    segment kept in original order — carried whole, never corrupted.
+ *  - A diff with NO `diff --git` header at all becomes one `(unstructured)` segment
+ *    (kept whole or dropped as a unit).
+ *  - Empty input → `[]`.
+ */
+export function splitByFile(diff: string): DiffFile[] {
+  if (diff.length === 0) return [];
+
+  const headerRe = /^diff --git .*$/gm;
+  const starts: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = headerRe.exec(diff)) !== null) {
+    starts.push(m.index);
+  }
+
+  if (starts.length === 0) {
+    return [{ path: '(unstructured)', text: diff, bytes: byteLen(diff) }];
+  }
+
+  const files: DiffFile[] = [];
+  const firstStart = starts[0] as number;
+  if (firstStart > 0) {
+    const text = diff.slice(0, firstStart);
+    files.push({ path: '(preamble)', text, bytes: byteLen(text) });
+  }
+  for (let i = 0; i < starts.length; i++) {
+    const start = starts[i] as number;
+    const end = i + 1 < starts.length ? (starts[i + 1] as number) : diff.length;
+    const text = diff.slice(start, end);
+    files.push({ path: extractPath(text), text, bytes: byteLen(text) });
+  }
+  return files;
+}
+
+/**
+ * Build the truncated-head text for a single file that alone exceeds the budget.
+ * Includes a byte-bounded prefix plus an explicit marker so a voter can SEE it is
+ * partial. Byte-truncation may clip a trailing multibyte codepoint — acceptable for
+ * this display-only marker (the canonical `reviewedDiffHash` is computed elsewhere,
+ * over `input.prDiff`, and is NOT affected).
+ */
+function truncateWithMarker(file: DiffFile, budget: number): string {
+  const marker =
+    `\n[... TRUNCATED: file ${file.path} is ${String(file.bytes)} bytes, over the ` +
+    `${String(budget)}-byte review budget; showing a partial prefix — this file is ` +
+    `listed in droppedFiles as partially-seen ...]\n`;
+  const room = Math.max(0, budget - byteLen(marker));
+  const prefix = Buffer.from(file.text, 'utf-8').subarray(0, room).toString('utf-8');
+  return prefix + marker;
+}
+
+/**
+ * Pack files into `budget` UTF-8 bytes, SECURITY FIRST. Ordering: files whose path
+ * matches {@link SENSITIVE_PATH_PATTERNS} come first (STABLE — original relative
+ * order preserved), then the rest in original diff order. The packer then greedily
+ * includes WHOLE files in that priority order until the next file would exceed
+ * `budget`; that file and every remaining file go to `droppedFiles`.
+ *
+ * Single oversize file (nothing has fit yet AND the highest-priority file alone
+ * exceeds `budget`): it is included TRUNCATED with a marker AND still listed in
+ * `droppedFiles` as partially-seen — honest coverage, never a fragment that reads
+ * as whole.
+ *
+ * `partial = droppedFiles.length > 0`. Pure, deterministic, no I/O, no model call.
+ */
+export function securityFirstPack(files: DiffFile[], budget: number): DiffPackResult {
+  const sensitive = files.filter((f) => isSensitivePath(f.path));
+  const rest = files.filter((f) => !isSensitivePath(f.path));
+  const ordered = [...sensitive, ...rest];
+
+  const segments: string[] = [];
+  const reviewedFiles: string[] = [];
+  const droppedFiles: string[] = [];
+  let used = 0;
+
+  for (let i = 0; i < ordered.length; i++) {
+    const file = ordered[i] as DiffFile;
+    if (used + file.bytes <= budget) {
+      segments.push(file.text);
+      reviewedFiles.push(file.path);
+      used += file.bytes;
+      continue;
+    }
+
+    // This file does not fit. If NOTHING has fit yet, it is the highest-priority
+    // file and it alone exceeds budget — include a truncated head (honest partial)
+    // rather than showing the voter zero content.
+    if (used === 0) {
+      segments.push(truncateWithMarker(file, budget));
+      reviewedFiles.push(file.path);
+      droppedFiles.push(file.path);
+    } else {
+      droppedFiles.push(file.path);
+    }
+    // Everything after the first non-fitting file is dropped (greedy stop).
+    for (let j = i + 1; j < ordered.length; j++) {
+      droppedFiles.push((ordered[j] as DiffFile).path);
+    }
+    break;
+  }
+
+  return {
+    packed: segments.join(''),
+    reviewedFiles,
+    totalFiles: files.length,
+    droppedFiles,
+    partial: droppedFiles.length > 0,
+  };
+}
+
+/**
+ * Machine-readable coverage of a large-diff review (#4140). Present ONLY when the
+ * input diff exceeded the panel budget and was packed; ABSENT for a whole-diff
+ * review (a within-budget diff is byte-identical to pre-#4140). `partial: true`
+ * means the verdict was BARRED from a verified-approve (the C1 gate below).
+ */
+export interface PrReviewCoverage {
+  /** Number of files whose full diff the panel actually reviewed. */
+  readonly reviewedFiles: number;
+  /** Total number of files in the original diff. */
+  readonly totalFiles: number;
+  /** Paths NOT fully reviewed (dropped, or the one truncated-head file). */
+  readonly droppedFiles: readonly string[];
+  /** True when coverage is incomplete (`droppedFiles.length > 0`). */
+  readonly partial: boolean;
+  /** Day-one strategy is always `'budget'` (exhaustive arm deferred to #4151). */
+  readonly strategy: 'budget';
+}
+
+/** The proposal-shaping inputs {@link packDiffForReview} produces from a raw diff. */
+export interface DiffReviewPacking {
+  /** Coverage to ride on the response; `undefined` for a within-budget diff. */
+  readonly coverage: PrReviewCoverage | undefined;
+  /** The diff to embed in the proposal (packed subset when over budget). */
+  readonly packedDiff: string;
+  /** Visible partial-review NOTE to PREPEND to the proposal (`''` when whole). */
+  readonly note: string;
+}
+
+/**
+ * Decide the #4140 large-diff affordance for a raw `prDiff`. Within `budget`:
+ * returns the diff unchanged, `coverage: undefined`, `note: ''` — the caller builds
+ * a BYTE-IDENTICAL proposal (no pack, no note). Over budget: security-first packs
+ * whole files, returns the packed subset, the coverage object, and a visible NOTE
+ * so voters know coverage is partial. Pure — no I/O, no model call, no logging.
+ */
+export function packDiffForReview(prDiff: string, budget: number): DiffReviewPacking {
+  if (prDiff.length <= budget) {
+    return { coverage: undefined, packedDiff: prDiff, note: '' };
+  }
+  const pack = securityFirstPack(splitByFile(prDiff), budget);
+  const coverage: PrReviewCoverage = {
+    reviewedFiles: pack.reviewedFiles.length,
+    totalFiles: pack.totalFiles,
+    droppedFiles: pack.droppedFiles,
+    partial: pack.partial,
+    strategy: 'budget',
+  };
+  const note = pack.partial
+    ? `> NOTE: partial review — ${String(pack.reviewedFiles.length)} of ${String(pack.totalFiles)} ` +
+      `files reviewed (security-prioritized; lowest-priority dropped): ${pack.droppedFiles.join(', ')}\n\n`
+    : '';
+  return { coverage, packedDiff: pack.packed, note };
+}
+
+/**
+ * #4140 C1 gate (LOAD-BEARING). A PARTIAL review (some files dropped) MUST NOT
+ * produce a `{ approve, verified: true }` verdict — the panel never saw the dropped
+ * files, so it cannot honestly verified-approve the whole PR. If the aggregate would
+ * otherwise be a verified approve, degrade to a recoverable `{ abstain, verified:false,
+ * reason }` (the #4132 no_quorum shape). A `request_changes` / genuine blocker from a
+ * REVIEWED file STILL WINS: it is produced by Tiers 1-2 inside `aggregatePrDecisions`
+ * (run first), and this gate only rewrites a would-be verified APPROVE — so a partial
+ * review can BLOCK but never verified-APPROVE. A whole-diff review (`coverage`
+ * undefined or not partial) is returned unchanged.
+ */
+export function applyPartialCoverageGate(
+  aggregate: PrReviewAggregate,
+  coverage: PrReviewCoverage | undefined
+): PrReviewAggregate {
+  if (coverage?.partial !== true) return aggregate;
+  if (aggregate.decision === 'approve' && aggregate.verified) {
+    return {
+      decision: 'abstain',
+      verified: false,
+      reason: `no_quorum: partial diff — ${String(coverage.reviewedFiles)} of ${String(coverage.totalFiles)} files reviewed`,
+    };
+  }
+  return aggregate;
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
@@ -61,6 +61,20 @@ export interface PrReviewCounts {
   readonly errorCount: number;
 }
 
+/**
+ * Large-diff review coverage stamped onto the record (#4140). Present only when the
+ * review was over-budget and partially reviewed. Folded into the (hash-covered)
+ * record `summary` for honest completeness — the `reviewedDiffHash` binding is
+ * UNCHANGED (still the canonical first-`MAX_REVIEWED_DIFF_BYTES` of `input.prDiff`);
+ * the gate matches on `{prNumber, reviewedDiffHash}`, never on the summary text.
+ */
+export interface PrReviewCoverageStamp {
+  readonly reviewedFiles: number;
+  readonly totalFiles: number;
+  readonly droppedFiles: readonly string[];
+  readonly partial: boolean;
+}
+
 /** Inputs for {@link persistReviewRecord} — bundled to stay within max-params. */
 export interface PersistReviewRecordArgs {
   readonly input: PrReviewInput;
@@ -68,6 +82,8 @@ export interface PersistReviewRecordArgs {
   readonly counts: PrReviewCounts;
   readonly reviewCount: number;
   readonly logger: ILogger;
+  /** #4140: large-diff coverage; stamped into the record summary when partial. */
+  readonly coverage?: PrReviewCoverageStamp | undefined;
 }
 
 /**
@@ -81,7 +97,14 @@ function buildAndPersist(
   baseSha: string,
   args: PersistReviewRecordArgs
 ): PrReviewRecordOutcome {
-  const { input, aggregate, counts, reviewCount, logger } = args;
+  const { input, aggregate, counts, reviewCount, logger, coverage } = args;
+  // #4140: honest completeness — stamp partial coverage into the (hash-covered)
+  // summary so an auditor reading the ledger sees the review was partial. Does NOT
+  // touch reviewedDiffHash (the gate's binding), so gate parity is preserved.
+  const coverageSuffix =
+    coverage?.partial === true
+      ? ` [partial coverage: ${String(coverage.reviewedFiles)}/${String(coverage.totalFiles)} files reviewed, dropped: ${coverage.droppedFiles.join(', ')}]`
+      : '';
   // Diff-hash parity contract (#4031): the gate recomputes this hash over the
   // first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed
   // diff exceeds that byte cap, content past it is UNBOUND, so a record can match
@@ -106,7 +129,7 @@ function buildAndPersist(
       error: counts.errorCount,
       total: reviewCount,
     },
-    summary: `${aggregate.decision} (${String(counts.approveCount)} approve / ${String(counts.requestChangesCount)} request_changes / ${String(counts.abstainCount)} abstain) — ${input.prTitle}`,
+    summary: `${aggregate.decision} (${String(counts.approveCount)} approve / ${String(counts.requestChangesCount)} request_changes / ${String(counts.abstainCount)} abstain) — ${input.prTitle}${coverageSuffix}`,
     logger,
   });
   if (record === undefined) {

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -26,6 +26,7 @@ vi.mock('../middleware/secure-handler.js', () => ({
 }));
 
 import {
+  MAX_DIFF_INPUT_LENGTH,
   PR_REVIEW_ROLES,
   PrReviewInputSchema,
   aggregatePrDecisions,
@@ -35,6 +36,7 @@ import {
   type PrReviewAggregate,
   type PrReviewVote,
 } from './pr-review-tool.js';
+import { applyPartialCoverageGate, type PrReviewCoverage } from './pr-review-diff-budget.js';
 import { persistReviewRecord } from './pr-review-record-producer.js';
 import { readJobResult } from '../jobs/job-result-store.js';
 import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
@@ -323,6 +325,47 @@ describe('pr_review tool', () => {
     });
   });
 
+  describe('applyPartialCoverageGate — C1 (#4140)', () => {
+    const partial = (over: Partial<PrReviewCoverage> = {}): PrReviewCoverage => ({
+      reviewedFiles: 2,
+      totalFiles: 5,
+      droppedFiles: ['src/x.ts', 'src/y.ts', 'src/z.ts'],
+      partial: true,
+      strategy: 'budget',
+      ...over,
+    });
+
+    it('BARS a partial would-be verified approve → abstain/verified:false (no_quorum shape)', () => {
+      const out = applyPartialCoverageGate({ decision: 'approve', verified: true }, partial());
+      expect(out.decision).toBe('abstain');
+      expect(out.verified).toBe(false);
+      expect(out.reason).toContain('partial diff');
+      expect(out.reason).toContain('no_quorum');
+      expect(out.reason).toContain('2 of 5');
+    });
+
+    it('a request_changes blocker from a REVIEWED file STILL WINS under a partial review', () => {
+      const blocker: PrReviewAggregate = { decision: 'request_changes', verified: true };
+      expect(applyPartialCoverageGate(blocker, partial())).toEqual(blocker);
+    });
+
+    it('a soft request_changes (verified:false) is untouched — a partial review can still block', () => {
+      const soft: PrReviewAggregate = { decision: 'request_changes', verified: false };
+      expect(applyPartialCoverageGate(soft, partial())).toEqual(soft);
+    });
+
+    it('whole-diff review (coverage undefined) → verified approve is unchanged', () => {
+      const approve: PrReviewAggregate = { decision: 'approve', verified: true };
+      expect(applyPartialCoverageGate(approve, undefined)).toEqual(approve);
+    });
+
+    it('non-partial coverage (nothing dropped) → verified approve is unchanged', () => {
+      const approve: PrReviewAggregate = { decision: 'approve', verified: true };
+      const cov = partial({ partial: false, droppedFiles: [] });
+      expect(applyPartialCoverageGate(approve, cov)).toEqual(approve);
+    });
+  });
+
   describe('buildPrReviewProposal', () => {
     const baseInput = {
       prTitle: 'Add foo widget',
@@ -417,10 +460,17 @@ describe('pr_review tool', () => {
       expect(r.success).toBe(false);
     });
 
-    it('should reject overlong diff (>50k chars)', () => {
+    it('accepts a diff between the panel budget and the 2MB input cap (#4140)', () => {
+      // Pre-#4140 this hard-failed at 50k; now diffs up to MAX_DIFF_INPUT_LENGTH are
+      // accepted and (over 50k) security-prioritized + partially reviewed.
+      const r = PrReviewInputSchema.safeParse({ prTitle: 'x', prDiff: 'a'.repeat(50_001) });
+      expect(r.success).toBe(true);
+    });
+
+    it('should reject a diff over the 2MB input DoS cap (#4140)', () => {
       const r = PrReviewInputSchema.safeParse({
         prTitle: 'x',
-        prDiff: 'a'.repeat(50_001),
+        prDiff: 'a'.repeat(MAX_DIFF_INPUT_LENGTH + 1),
       });
       expect(r.success).toBe(false);
     });
@@ -630,6 +680,37 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     expect(outcome).toEqual(expect.objectContaining({ persisted: false, reason: 'simulated' }));
     const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
     expect(readPrReviewRecords(path).records).toHaveLength(0);
+  });
+
+  it('stamps partial coverage into the (hash-covered) record summary without breaking verification (#4140)', () => {
+    const parsed = input({ prNumber: 77, baseSha: BASE_SHA });
+    const outcome = persistReviewRecord({
+      input: parsed,
+      // A partial review degrades to abstain/verified:false per the C1 gate.
+      aggregate: {
+        decision: 'abstain',
+        verified: false,
+        reason: 'no_quorum: partial diff — 2 of 5 files reviewed',
+      },
+      counts: { approveCount: 3, requestChangesCount: 0, abstainCount: 0, errorCount: 0 },
+      reviewCount: 3,
+      logger,
+      coverage: {
+        reviewedFiles: 2,
+        totalFiles: 5,
+        droppedFiles: ['src/z.ts', 'src/w.ts', 'src/v.ts'],
+        partial: true,
+      },
+    });
+    expect(outcome.persisted).toBe(true);
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records } = readPrReviewRecords(path);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.summary).toContain('partial coverage: 2/5 files reviewed');
+    // reviewedDiffHash basis is unchanged — still the canonical hash of prDiff.
+    expect(records[0]?.reviewedDiffHash).toBe(computeReviewedDiffHash(parsed.prDiff));
+    // The summary stamp is hash-covered, so verification still passes.
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
   });
 
   it('skips with reason=no-live-votes when every voter errored (no false gate pass)', () => {

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -47,6 +47,8 @@ import {
   type Finding,
 } from './pr-review-findings.js';
 import { persistReviewRecord, type PrReviewRecordOutcome } from './pr-review-record-producer.js';
+// prettier-ignore
+import { applyPartialCoverageGate, packDiffForReview, type PrReviewCoverage } from './pr-review-diff-budget.js';
 
 export type { Finding, VerificationGate, FindingSeverity } from './pr-review-findings.js';
 
@@ -65,10 +67,16 @@ export const PR_REVIEW_ROLES: readonly VoterRole[] = [
   'scope_steward',
 ];
 
-/** Hard cap on diff size sent to voters. Diffs above this are truncated with
- * an explicit notice — the tool stays useful for typical PRs without blowing
- * the context budget. */
+/** Voter PANEL budget: the max diff bytes packed into the proposal sent to the
+ * 5-voter panel. Diffs above this are NOT rejected — they are security-prioritized
+ * and PARTIALLY reviewed (whole-file packing via `pr-review-diff-budget.ts`, #4140).
+ * Also the byte cap the canonical `reviewedDiffHash` binds to (unchanged, #3831). */
 export const MAX_DIFF_LENGTH = 50_000;
+/** DoS bound on `prDiff` INPUT (#4140). Diffs up to this size are ACCEPTED (no
+ * hard-fail, no caller-side truncation); those over `MAX_DIFF_LENGTH` are packed
+ * to a security-prioritized, partially-reviewed subset. Two-number contract:
+ * `MAX_DIFF_INPUT_LENGTH` gates acceptance, `MAX_DIFF_LENGTH` gates the panel. */
+export const MAX_DIFF_INPUT_LENGTH = 2_000_000;
 /** Max `repoContext` length; over-limit input hard-fails Zod validation (#4133). */
 export const MAX_REPO_CONTEXT_LENGTH = 2000;
 
@@ -99,8 +107,10 @@ export const PrReviewInputSchema = z.object({
   prDiff: z
     .string()
     .min(1)
-    .max(MAX_DIFF_LENGTH)
-    .describe(`Unified diff text (max ${String(MAX_DIFF_LENGTH)} chars; truncate before calling)`),
+    .max(MAX_DIFF_INPUT_LENGTH)
+    .describe(
+      `Unified diff text (max ${String(MAX_DIFF_INPUT_LENGTH)} chars). No need to truncate before calling: diffs over ${String(MAX_DIFF_LENGTH)} chars are security-prioritized and PARTIALLY reviewed (lowest-priority whole files dropped; coverage reported on the response, and a partial review can block but never verified-approve).`
+    ),
   repoContext: z
     .string()
     .max(MAX_REPO_CONTEXT_LENGTH)
@@ -236,6 +246,12 @@ export interface PrReviewResponse {
    * authentic record was written, otherwise `persisted: false` with the reason.
    */
   readonly recordOutcome?: PrReviewRecordOutcome;
+  /**
+   * Large-diff review coverage (#4140). Present only when the input diff exceeded
+   * `MAX_DIFF_LENGTH` and was security-prioritized + partially reviewed; absent for
+   * a whole-diff (≤`MAX_DIFF_LENGTH`) review.
+   */
+  readonly coverage?: PrReviewCoverage;
 }
 
 export interface PrReviewDeps extends BaseMcpToolDeps {
@@ -455,30 +471,53 @@ function summarizeReviews(reviews: readonly PrReviewVote[]): {
 // ============================================================================
 
 /**
- * Run the 5-voter panel + shape the response. The sync handler awaits this
- * inline; the async dispatcher backgrounds it via {@link runAsJob} (#3731).
- * `collectRealVotes` is the long pole (live LLM fan-out), so the whole body
- * is what backgrounds.
+ * Aggregate the panel, emit telemetry, and apply the #4140 C1 gate. Under
+ * absolute_quorum (#4132) an errored/incomplete panel degrades a would-be approve to
+ * a recoverable abstain (logged). Then the C1 gate bars a PARTIAL review from a
+ * verified-approve (degrade to the same no_quorum shape) while a genuine blocker from
+ * a reviewed file still wins — reference inequality signals the degrade for logging.
  */
-/**
- * Aggregate the panel and, under absolute_quorum (#4132), emit the actionable
- * "re-run the missing voice" telemetry when a would-be approve degraded to a
- * recoverable abstain because a voter (esp. the contrarian) errored.
- */
-function aggregateWithTelemetry(
+function resolveAggregate(
   reviews: readonly PrReviewVote[],
-  errorPolicy: 'standard' | 'absolute_quorum',
+  input: PrReviewInput,
   errorCount: number,
+  coverage: PrReviewCoverage | undefined,
   logger: ILogger
 ): PrReviewAggregate {
-  const aggregate = aggregatePrDecisions(reviews, errorPolicy);
-  if (aggregate.reason !== undefined) {
+  const preGate = aggregatePrDecisions(reviews, input.errorPolicy);
+  if (preGate.reason !== undefined) {
     logger.warn('pr_review degraded to no_quorum under absolute_quorum (#4132)', {
-      reason: aggregate.reason,
+      reason: preGate.reason,
       errorCount,
     });
   }
+  const aggregate = applyPartialCoverageGate(preGate, coverage);
+  if (aggregate !== preGate) {
+    logger.warn(
+      'pr_review partial review barred from verified-approve — degraded to no_quorum (#4140)',
+      { reason: aggregate.reason }
+    );
+  }
   return aggregate;
+}
+
+/**
+ * #4140 large-diff affordance: within budget → byte-identical proposal (no pack, no
+ * note, `coverage: undefined`); over budget → security-first packed subset with a
+ * prepended partial-review NOTE. Logs an over-budget warning when partial.
+ */
+function preparePanelProposal(
+  input: PrReviewInput,
+  logger: ILogger
+): { proposal: string; coverage: PrReviewCoverage | undefined } {
+  const { coverage, packedDiff, note } = packDiffForReview(input.prDiff, MAX_DIFF_LENGTH);
+  const body = coverage === undefined ? input : { ...input, prDiff: packedDiff };
+  if (coverage?.partial === true) {
+    logger.warn(
+      `pr_review diff over budget — reviewed ${String(coverage.reviewedFiles)} of ${String(coverage.totalFiles)} files, dropped ${String(coverage.droppedFiles.length)}`
+    );
+  }
+  return { proposal: note + buildPrReviewProposal(body), coverage };
 }
 
 async function executePrReviewBody(
@@ -487,7 +526,7 @@ async function executePrReviewBody(
   gatewayAdapters?: readonly IModelAdapter[]
 ): Promise<ToolResult> {
   const start = Date.now();
-  const proposal = buildPrReviewProposal(input);
+  const { proposal, coverage } = preparePanelProposal(input, logger);
   const voteResults = await collectRealVotes({
     roles: PR_REVIEW_ROLES,
     proposal,
@@ -498,7 +537,7 @@ async function executePrReviewBody(
 
   const reviews = voteResults.map(toPrReviewVote);
   const counts = summarizeReviews(reviews);
-  const aggregate = aggregateWithTelemetry(reviews, input.errorPolicy, counts.errorCount, logger);
+  const aggregate = resolveAggregate(reviews, input, counts.errorCount, coverage, logger);
 
   // #3855: roll up + persist this review's per-voter cost and ride it on the
   // existing response (no new MCP tool). Best-effort — a rollup failure must
@@ -526,6 +565,7 @@ async function executePrReviewBody(
     counts,
     reviewCount: reviews.length,
     logger,
+    ...(coverage !== undefined ? { coverage } : {}),
   });
 
   const response: PrReviewResponse = {
@@ -536,6 +576,7 @@ async function executePrReviewBody(
     totalDurationMs: Date.now() - start,
     ...(costSummary !== undefined ? { costSummary } : {}),
     recordOutcome,
+    ...(coverage !== undefined ? { coverage } : {}),
   };
   return toolSuccess(JSON.stringify(response, null, 2));
 }


### PR DESCRIPTION
## What
The final child of #4130. `pr_review`'s `prDiff` hard-failed over 50000 chars, forcing lossy **hand-truncation** — a voter can't flag what it can't see. It now accepts a large diff (input cap raised to **2 MB**) and, when over the 50000 panel budget, deterministically packs the **most security-relevant files first** (sensitive-path ordering, then diff order; **no scored ranker** — simplicity over cleverness) into the budget, reviewing that instead of a blind `head`-truncation.

## Load-bearing safety property (vote condition C1)
A **partial review** (any dropped file) is **barred from a verified-approve**: `applyPartialCoverageGate` degrades a would-be `{approve, verified:true}` to `{abstain, verified:false, reason:'no_quorum: partial diff — N of M files reviewed'}` — mirroring #4132's `absolute_quorum` posture, because approving unseen hunks manufactures the same false confidence as an incomplete panel. A `request_changes` blocker in a **reviewed** file still wins — a partial review can **block** but never verified-**approve**.

## Auditability (no silent truncation)
`coverage:{reviewedFiles,totalFiles,droppedFiles,partial,strategy}` on the response (top-level `partial` flag for the autonomy loop) + stamped into the audit record + `logger.warn` + a visible `NOTE: N of M files reviewed` in the voter proposal. `reviewedDiffHash` basis **unchanged** (canonical first-50KB; #3831 gate parity holds). `splitByFile` is file-boundary-safe (robust to rename-only / binary / `\ No newline`).

## Safety / scope
**≤50000 diffs are byte-identical** (no pack, no coverage, verified-approve still possible; existing callers unaffected). Options **C** (exhaustive chunking, #4151), **B** (file-fetch, #4152), and a scored ranker are deferred to follow-ups. Vote-cleared by a 3-voter higher_order gate (review-integrity, architecture/contract, cost/pragmatism).

## Verification
`tsc --noEmit` clean · **68 pr-review tests pass** (C1 gate; security-first ordering; `splitByFile` robustness; audit stamp; ≤50000 byte-identical) · eslint clean · `docs:tools` regenerated (`pr_review.md`) · minor changeset.

Completes epic #4130. Refs #4132 #4133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)