### PR TITLE
test(security): fix CodeQL #222 — read module source via fs, not cat subprocess

### DIFF
--- a/.changeset/codeql-222-cat-subprocess.md
+++ b/.changeset/codeql-222-cat-subprocess.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix CodeQL alert #222 (`js/unnecessary-use-of-cat`): the codepr-push never-merge invariant test read the module source via `execFileSync('cat', …)`; swap to `fs.readFileSync` — strictly better (no subprocess). Test-only, no runtime change.

--- a/packages/nexus-agents/src/mcp/tools/codepr-push.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-push.test.ts
@@ -18,7 +18,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdtempSync, rmSync, writeFileSync, realpathSync, readdirSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  realpathSync,
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -300,8 +308,7 @@ describe('executeCodePrPush — happy path (ready + token + clean plan)', () => 
     // from the dry-run orchestrator's own would_open_pr audit).
     const pushAudits = m.events.filter(
       (e) =>
-        e.action === 'autonomous_code_pr.would_open_pr' &&
-        e.actor?.id === 'autonomous-code-pr-push'
+        e.action === 'autonomous_code_pr.would_open_pr' && e.actor?.id === 'autonomous-code-pr-push'
     );
     expect(pushAudits.length).toBe(2);
     // Both push audits pin a non-secret token identity (NOT the raw token).
@@ -420,9 +427,7 @@ describe('executeCodePrPush — push seam throws (atomic cleanup)', () => {
 
 describe('executeCodePrPush — never-merge / branch-name invariants', () => {
   it('the module source CODE has NO merge / auto-merge / force-push / protection surface', () => {
-    const raw = execFileSync('cat', [new URL('./codepr-push.ts', import.meta.url).pathname], {
-      encoding: 'utf8',
-    });
+    const raw = readFileSync(new URL('./codepr-push.ts', import.meta.url).pathname, 'utf8');
     // Strip block + line comments so the assertion tests EXECUTABLE code only
     // (the doc comments legitimately use the words "merge"/"auto-merge"/"protections"
     // to DOCUMENT their absence; the invariant is about the code, not the prose).


### PR DESCRIPTION
## What
Clears the **only open CodeQL alert** (#222, `js/unnecessary-use-of-cat`, medium). The `codepr-push` never-merge invariant test read its own module source via `execFileSync('cat', [path])` to assert the executable code has no merge/auto-merge/force-push/protection surface. Swapped to `fs.readFileSync(path, 'utf8')` — strictly better (no subprocess spawn), identical assertion.

## Why
Autonomous priority order puts security ahead of feature work; this takes the open-security-alert count to **zero** in a one-line, test-only change.

## Verification
14 codepr-push tests pass (the invariant assertion is unchanged) · eslint clean · empty changeset (test-only, no runtime/release impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)