### PR TITLE
feat(ci): scheduled parameter-capability drift guard (#4121, epic #4066)

### DIFF
--- a/.changeset/parameter-drift-guard-4121.md
+++ b/.changeset/parameter-drift-guard-4121.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Add the parameter-capability drift guard (#4121, epic #4066). Widen the OpenRouter catalog parse (`parseCatalog`) to additively surface each model's `supported_parameters` as `supportedParameters` (backward-compatible — existence-only `.id` consumers are unaffected; the field is `undefined` when the provider omits it), and add a pure `reconcileParameterDrift` that compares the hand-curated param-capability map against the provider's advertised capabilities. A weekly `parameter-drift.yml` workflow runs the reconciliation and opens ONE issue on drift — it NEVER auto-edits the curated map, and a provider fetch failure is a loud skip rather than a false "no drift".

--- a/.github/workflows/parameter-drift.yml
+++ b/.github/workflows/parameter-drift.yml
@@ -1,0 +1,87 @@
+name: Parameter Capability Drift Check
+
+# Reconciles the hand-curated model-parameter capability map
+# (KNOWN_PARAMETER_INCOMPATIBILITIES + ModelCapability.unsupportedParameters) against
+# the provider's machine-readable `supported_parameters` (#4121, epic #4066). On
+# drift it opens ONE issue for a human to vet — it NEVER auto-edits the curated map.
+# Modeled on pricing-drift.yml. A provider fetch failure is a LOUD skip, not a
+# false "no drift".
+
+on:
+  schedule:
+    - cron: '37 8 * * 1' # Weekly Monday ~8:37am UTC (off-minute; distinct from pricing-drift 8:23)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check model parameter-capability drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Reconcile curated param map against provider supported_parameters
+        id: drift
+        run: |
+          OUTPUT=$(pnpm check:parameter-drift 2>&1)
+          echo "$OUTPUT"
+          STATUS=$(echo "$OUTPUT" | grep -oP 'PARAM_DRIFT_STATUS=\K\S+' | tail -1 || echo "skipped")
+          COUNT=$(echo "$OUTPUT" | grep -oP 'PARAM_DRIFT_COUNT=\K\d+' | tail -1 || echo "0")
+          echo "drift_status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "drift_count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" > parameter-drift-report.txt
+
+      - name: Note a loud skip (provider fetch failure — NOT "no drift")
+        if: steps.drift.outputs.drift_status == 'skipped'
+        run: |
+          echo "::warning::Parameter-drift check SKIPPED — OpenRouter catalog fetch failed or empty. Not treated as 'no drift'; re-run when the provider is reachable."
+
+      - name: Create issue if parameter drift found
+        if: steps.drift.outputs.drift_status == 'drift'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('parameter-drift-report.txt', 'utf-8');
+            const count = '${{ steps.drift.outputs.drift_count }}';
+
+            // Dedup by a stable title fragment across open discovered-drift issues.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'tech-debt,discovered',
+              per_page: 100,
+            });
+            const hasIssue = existing.data.some(i =>
+              i.title.includes('parameter-capability drift')
+            );
+            if (hasIssue) {
+              console.log('Parameter-capability drift issue already open, skipping');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore(model-registry): review parameter-capability drift (${count} pairs)`,
+              labels: ['tech-debt', 'discovered'],
+              body: [
+                '**Found during:** weekly parameter-capability drift check (#4121, epic #4066)',
+                '**Severity:** medium — a stale param map risks a silent 400 (wrongly-forwarded param) or a lost tuning knob (wrongly-stripped param).',
+                '',
+                'The curated map is **hand-vetted** — this check does NOT auto-edit it. A human must confirm each pair below and reconcile `KNOWN_PARAMETER_INCOMPATIBILITIES` / the model’s `unsupportedParameters`.',
+                '',
+                '```',
+                report.slice(0, 3000),
+                '```',
+                '',
+                'Reconcile in `packages/nexus-agents/src/config/model-parameter-support.ts` and `src/config/in-tree-data.ts`.',
+              ].join('\n'),
+            });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "research:check": "npx tsx scripts/update-research-index.ts --check",
     "research:validate": "npx tsx scripts/update-research-index.ts --validate",
     "check:pricing-drift": "npx tsx scripts/check-pricing-drift.ts",
+    "check:parameter-drift": "npx tsx scripts/check-parameter-drift.ts",
     "check:model-drift": "npx tsx scripts/check-model-string-drift.ts",
     "build:registry": "npx tsx scripts/build-model-registry.ts",
     "build:registry:dry": "npx tsx scripts/build-model-registry.ts --dry",

--- a/packages/nexus-agents/src/config/openrouter-models-source.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-import { createOpenRouterModelsSource } from './openrouter-models-source.js';
+import { createOpenRouterModelsSource, parseCatalog } from './openrouter-models-source.js';
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
@@ -89,5 +89,37 @@ describe('createOpenRouterModelsSource (#3404)', () => {
     const src = createOpenRouterModelsSource({ fetchImpl });
     const ids = await src.listModels();
     expect(ids.length).toBe(5000);
+  });
+});
+
+describe('parseCatalog supported_parameters widening (#4121)', () => {
+  it('captures supported_parameters as supportedParameters when present', () => {
+    const models = parseCatalog(
+      JSON.stringify({
+        data: [{ id: 'vendor/model-a', supported_parameters: ['temperature', 'top_p'] }],
+      })
+    );
+    expect(models).toEqual([
+      { id: 'vendor/model-a', supportedParameters: ['temperature', 'top_p'] },
+    ]);
+  });
+
+  it('leaves supportedParameters undefined when the provider omits it (backward-compat)', () => {
+    const models = parseCatalog(JSON.stringify({ data: [{ id: 'vendor/model-b' }] }));
+    expect(models).toEqual([{ id: 'vendor/model-b' }]);
+    expect(models[0]?.supportedParameters).toBeUndefined();
+  });
+
+  it('still fails open ([]) on a malformed payload (unchanged guardrail)', () => {
+    expect(parseCatalog(JSON.stringify({ data: [{ notId: 1 }] }))).toEqual([]);
+  });
+
+  it('drops a malformed supported_parameters (non-string entries) via schema, failing open', () => {
+    // supported_parameters must be string[]; a number entry fails validation → [].
+    expect(
+      parseCatalog(
+        JSON.stringify({ data: [{ id: 'vendor/model-c', supported_parameters: [1, 2] }] })
+      )
+    ).toEqual([]);
   });
 });

--- a/packages/nexus-agents/src/config/openrouter-models-source.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.ts
@@ -31,8 +31,27 @@ const MAX_MODELS = 5_000;
 /** Byte cap on the raw response body (~8 MB) — the real catalog is well under. */
 const MAX_BYTES = 8_000_000;
 
-const OpenRouterModelSchema = z.object({ id: z.string().min(1).max(256) });
+/** Cap on a model's `supported_parameters` list — bounds an untrusted payload. */
+const MAX_SUPPORTED_PARAMETERS = 256;
+
+const OpenRouterModelSchema = z.object({
+  id: z.string().min(1).max(256),
+  // #4121: the provider's machine-readable capability list. Optional & additive —
+  // older catalogs (and our older fixtures) omit it; consumers reading only `.id`
+  // are unaffected. Bounded so a hostile payload can't blow memory.
+  supported_parameters: z.array(z.string().max(256)).max(MAX_SUPPORTED_PARAMETERS).optional(),
+});
 const OpenRouterModelsResponseSchema = z.object({ data: z.array(OpenRouterModelSchema) });
+
+/**
+ * A validated catalog model. `supportedParameters` is the provider's
+ * machine-readable capability list (#4121) — `undefined` when the catalog omits
+ * it (backward-compat). Existing existence-only consumers read `.id` and ignore it.
+ */
+export interface OpenRouterCatalogModel {
+  readonly id: string;
+  readonly supportedParameters?: readonly string[];
+}
 
 export interface OpenRouterModelsSourceOptions {
   /** Override the catalog URL (tests / self-hosted gateways). */
@@ -50,8 +69,13 @@ export interface OpenRouterModelsSourceOptions {
  */
 const logger = createLogger({ component: 'openrouter-models-source' });
 
-/** Validate + cap a catalog body. Returns `[]` on oversize or schema failure. */
-function parseCatalog(text: string): readonly { id: string }[] {
+/**
+ * Validate + cap a catalog body. Returns `[]` on oversize or schema failure.
+ * Widened in #4121 to also surface each model's `supported_parameters` (as
+ * `supportedParameters`); the field is omitted when the provider doesn't send it,
+ * so existing `.id`-only readers are unaffected.
+ */
+export function parseCatalog(text: string): readonly OpenRouterCatalogModel[] {
   if (text.length > MAX_BYTES) {
     logger.warn('OpenRouter catalog exceeds byte cap; ignoring', { bytes: text.length });
     return [];
@@ -63,7 +87,13 @@ function parseCatalog(text: string): readonly { id: string }[] {
     });
     return [];
   }
-  return parsed.data.data.slice(0, MAX_MODELS).map((m) => ({ id: m.id }));
+  return parsed.data.data
+    .slice(0, MAX_MODELS)
+    .map((m) =>
+      m.supported_parameters === undefined
+        ? { id: m.id }
+        : { id: m.id, supportedParameters: m.supported_parameters }
+    );
 }
 
 /** Fetch + validate the catalog. Fail-OPEN: any failure returns `[]`. */
@@ -71,7 +101,7 @@ async function fetchCatalog(
   url: string,
   timeoutMs: number,
   doFetch: typeof fetch
-): Promise<readonly { id: string }[]> {
+): Promise<readonly OpenRouterCatalogModel[]> {
   const controller = new AbortController();
   const timer = setTimeout(() => {
     controller.abort();
@@ -123,4 +153,21 @@ export function createOpenRouterModelsSource(
     providerHint: 'openrouter',
     listModels: () => fetchCatalog(url, timeoutMs, doFetch),
   };
+}
+
+/**
+ * Fetch the OpenRouter catalog WITH `supportedParameters` retained in the return
+ * type (the {@link AvailableModelsSource} interface narrows to `.id`-only). Used by
+ * the #4121 parameter-drift reconciliation job, which needs the provider's
+ * capability list. Preserves the same fail-OPEN semantics — any fetch/schema
+ * failure yields `[]`. The reconciliation job treats an empty result as a LOUD
+ * skip (the real catalog is never empty), NOT as "no drift".
+ */
+export function fetchOpenRouterCatalog(
+  opts: OpenRouterModelsSourceOptions = {}
+): Promise<readonly OpenRouterCatalogModel[]> {
+  const url = opts.url ?? OPENROUTER_MODELS_URL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const doFetch = opts.fetchImpl ?? fetch;
+  return fetchCatalog(url, timeoutMs, doFetch);
 }

--- a/scripts/check-parameter-drift.ts
+++ b/scripts/check-parameter-drift.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+/**
+ * Reconcile the hand-curated model-parameter capability map against the
+ * provider's machine-readable `supported_parameters` (#4121, epic #4066 layer 4).
+ *
+ * The curated map — `KNOWN_PARAMETER_INCOMPATIBILITIES` +
+ * `ModelCapability.unsupportedParameters` / `.maxTokensParam`, resolved through
+ * `unsupportedParametersForModel` — is the SOURCE OF TRUTH a human vets. This job
+ * NEVER edits it. It only checks whether the provider's advertised capabilities
+ * still agree with what the curated map asserts, and prints a machine-readable
+ * status the `parameter-drift.yml` workflow uses to open ONE issue on drift.
+ *
+ * Output contract (parsed by the workflow):
+ *   PARAM_DRIFT_STATUS=clean|drift|skipped
+ *   PARAM_DRIFT_COUNT=<n>
+ *
+ * FAIL-LOUD on a provider fetch failure: the OpenRouter catalog is never legitimately
+ * empty, so an empty result is a fetch problem — we emit `skipped` (NOT a false
+ * `clean`/"no drift") so a provider outage can never mask real drift. Advisory:
+ * always exits 0 (drift is reported via an issue, never a red build).
+ *
+ * Usage: `npx tsx scripts/check-parameter-drift.ts`
+ *
+ * @module scripts/check-parameter-drift
+ * (Source: Issue #4121 — provider-reality reconciliation for the param-capability map)
+ */
+/* eslint-disable no-console */
+
+import { fetchOpenRouterCatalog } from '../packages/nexus-agents/src/config/openrouter-models-source.js';
+import { getInTreeCapabilitiesMatrix } from '../packages/nexus-agents/src/config/model-config-helpers.js';
+import { unsupportedParametersForModel } from '../packages/nexus-agents/src/config/model-parameter-support.js';
+import { reconcileParameterDrift, type RegistryParamView } from './parameter-drift-reconcile.js';
+
+/** Build the curated-map view: one entry per registered model with the ids it may
+ * appear under in the provider catalog and its resolver-computed unsupported set. */
+function buildRegistryViews(): RegistryParamView[] {
+  const { models } = getInTreeCapabilitiesMatrix();
+  return models.map((m) => {
+    const providerIds = [m.id, m.cliModelName].filter(
+      (v): v is string => typeof v === 'string' && v.length > 0
+    );
+    return {
+      modelId: m.id,
+      providerIds: [...new Set(providerIds)],
+      unsupportedParameters: [...unsupportedParametersForModel(m.id)],
+    };
+  });
+}
+
+async function main(): Promise<void> {
+  console.log('Fetching OpenRouter catalog (supported_parameters)…');
+  const catalog = await fetchOpenRouterCatalog();
+
+  // Fail-LOUD: the real catalog is never empty; an empty result means the fetch
+  // failed (network/timeout/schema/size). Do NOT report "no drift" — skip loudly.
+  if (catalog.length === 0) {
+    console.error(
+      '⚠️  SKIP: OpenRouter catalog came back empty — treating as a FETCH FAILURE, not "no drift".'
+    );
+    console.error(
+      '   A provider outage must not mask real parameter drift. Re-run when reachable.'
+    );
+    console.log('PARAM_DRIFT_STATUS=skipped');
+    console.log('PARAM_DRIFT_COUNT=0');
+    return;
+  }
+  console.log(`Catalog has ${String(catalog.length)} models.`);
+
+  const withCaps = catalog.filter((m) => m.supportedParameters !== undefined).length;
+  console.log(`${String(withCaps)} advertise a supported_parameters list.\n`);
+
+  const registryViews = buildRegistryViews();
+  const findings = reconcileParameterDrift(catalog, registryViews);
+
+  if (findings.length === 0) {
+    console.log(
+      '✅ No parameter drift — the curated map agrees with the provider for all matched models.'
+    );
+    console.log('PARAM_DRIFT_STATUS=clean');
+    console.log('PARAM_DRIFT_COUNT=0');
+    return;
+  }
+
+  console.log(`📊 Parameter drift found for ${String(findings.length)} (model, param) pair(s):\n`);
+  for (const f of findings) {
+    const registry = f.registrySupported ? 'supported' : 'unsupported';
+    const provider = f.providerSupported ? 'supported' : 'unsupported';
+    console.log(
+      `  ${f.modelId.padEnd(24)} ${f.param.padEnd(14)} registry=${registry.padEnd(11)} provider=${provider}  (catalog id: ${f.providerId})`
+    );
+  }
+  console.log('');
+  console.log('The curated map is hand-vetted — this job does NOT auto-edit it.');
+  console.log(
+    'Review packages/nexus-agents/src/config/model-parameter-support.ts (KNOWN_PARAMETER_INCOMPATIBILITIES)'
+  );
+  console.log(
+    'and the affected models’ unsupportedParameters in in-tree-data.ts, then reconcile by hand.'
+  );
+  console.log(`PARAM_DRIFT_STATUS=drift`);
+  console.log(`PARAM_DRIFT_COUNT=${String(findings.length)}`);
+}
+
+main().catch((e: unknown) => {
+  const msg = e instanceof Error ? e.message : String(e);
+  // Even an unexpected error is a LOUD skip, never a silent "clean".
+  console.error(`⚠️  SKIP: parameter-drift check errored (non-blocking): ${msg}`);
+  console.log('PARAM_DRIFT_STATUS=skipped');
+  console.log('PARAM_DRIFT_COUNT=0');
+  process.exit(0);
+});

--- a/scripts/parameter-drift-reconcile.test.ts
+++ b/scripts/parameter-drift-reconcile.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the pure parameter-drift reconciliation (#4121, epic #4066).
+ *
+ * Covers the diff logic only — the IO (catalog fetch, `gh issue create`) lives in
+ * scripts/check-parameter-drift.ts and is deliberately NOT exercised here.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  reconcileParameterDrift,
+  DEFAULT_RECONCILABLE_PARAMS,
+  type ProviderParamView,
+  type RegistryParamView,
+} from './parameter-drift-reconcile.js';
+
+describe('reconcileParameterDrift (#4121)', () => {
+  it('flags drift: provider omits temperature but the registry declares it supported', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/model-x', supportedParameters: ['top_p', 'max_tokens'] }, // no temperature
+    ];
+    const registry: RegistryParamView[] = [
+      { modelId: 'model-x', providerIds: ['vendor/model-x'], unsupportedParameters: [] }, // registry: supported
+    ];
+    const findings = reconcileParameterDrift(provider, registry);
+    expect(findings).toEqual([
+      {
+        modelId: 'model-x',
+        providerId: 'vendor/model-x',
+        param: 'temperature',
+        registrySupported: true,
+        providerSupported: false,
+      },
+    ]);
+  });
+
+  it('flags drift: registry declares temperature unsupported but the provider now lists it', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/model-y', supportedParameters: ['temperature', 'top_p'] },
+    ];
+    const registry: RegistryParamView[] = [
+      {
+        modelId: 'model-y',
+        providerIds: ['vendor/model-y'],
+        unsupportedParameters: ['temperature'],
+      },
+    ];
+    const findings = reconcileParameterDrift(provider, registry);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      modelId: 'model-y',
+      param: 'temperature',
+      registrySupported: false,
+      providerSupported: true,
+    });
+  });
+
+  it('no finding when the two sources agree (both support temperature)', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/model-z', supportedParameters: ['temperature', 'top_p'] },
+    ];
+    const registry: RegistryParamView[] = [
+      { modelId: 'model-z', providerIds: ['vendor/model-z'], unsupportedParameters: [] },
+    ];
+    expect(reconcileParameterDrift(provider, registry)).toEqual([]);
+  });
+
+  it('no finding when the two sources agree (both reject temperature)', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/reasoner', supportedParameters: ['top_p', 'max_tokens'] }, // no temperature
+    ];
+    const registry: RegistryParamView[] = [
+      {
+        modelId: 'reasoner',
+        providerIds: ['vendor/reasoner'],
+        unsupportedParameters: ['temperature'],
+      },
+    ];
+    expect(reconcileParameterDrift(provider, registry)).toEqual([]);
+  });
+
+  it('no false finding for a model present only in the registry', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/other', supportedParameters: ['temperature'] },
+    ];
+    const registry: RegistryParamView[] = [
+      {
+        modelId: 'registry-only',
+        providerIds: ['vendor/registry-only'],
+        unsupportedParameters: ['temperature'],
+      },
+    ];
+    expect(reconcileParameterDrift(provider, registry)).toEqual([]);
+  });
+
+  it('no false finding for a model present only in the provider catalog', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/provider-only', supportedParameters: ['temperature'] },
+    ];
+    const registry: RegistryParamView[] = [];
+    expect(reconcileParameterDrift(provider, registry)).toEqual([]);
+  });
+
+  it('skips a provider model that reports no capability list (cannot reconcile)', () => {
+    const provider: ProviderParamView[] = [
+      { id: 'vendor/no-caps' }, // supportedParameters undefined
+    ];
+    const registry: RegistryParamView[] = [
+      {
+        modelId: 'no-caps',
+        providerIds: ['vendor/no-caps'],
+        unsupportedParameters: ['temperature'],
+      },
+    ];
+    expect(reconcileParameterDrift(provider, registry)).toEqual([]);
+  });
+
+  it('matches on the first providerId candidate present in the catalog', () => {
+    const provider: ProviderParamView[] = [{ id: 'gpt-5.4', supportedParameters: ['temperature'] }];
+    const registry: RegistryParamView[] = [
+      // canonical id absent from catalog; cliModelName present → still joins.
+      {
+        modelId: 'codex-5.4',
+        providerIds: ['codex-5.4', 'gpt-5.4'],
+        unsupportedParameters: ['temperature'],
+      },
+    ];
+    const findings = reconcileParameterDrift(provider, registry);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      modelId: 'codex-5.4',
+      providerId: 'gpt-5.4',
+      param: 'temperature',
+    });
+  });
+
+  it('does not mutate its inputs', () => {
+    const provider: ProviderParamView[] = [{ id: 'm', supportedParameters: ['top_p'] }];
+    const registry: RegistryParamView[] = [
+      { modelId: 'm', providerIds: ['m'], unsupportedParameters: [] },
+    ];
+    reconcileParameterDrift(provider, registry);
+    expect(provider[0]?.supportedParameters).toEqual(['top_p']);
+    expect(registry[0]?.unsupportedParameters).toEqual([]);
+  });
+
+  it('DEFAULT_RECONCILABLE_PARAMS covers the temperature incidents', () => {
+    expect(DEFAULT_RECONCILABLE_PARAMS).toContain('temperature');
+  });
+});

--- a/scripts/parameter-drift-reconcile.ts
+++ b/scripts/parameter-drift-reconcile.ts
@@ -1,0 +1,141 @@
+/**
+ * nexus-agents/config — pure reconciliation between the hand-curated
+ * model-parameter capability map and the provider's machine-readable
+ * `supported_parameters` (#4121, epic #4066 layer 4).
+ *
+ * The curated map (`KNOWN_PARAMETER_INCOMPATIBILITIES` +
+ * `ModelCapability.unsupportedParameters` / `.maxTokensParam`, resolved via
+ * {@link unsupportedParametersForModel}) is the SOURCE OF TRUTH — a human vets
+ * every change to it. This module never edits it. It only ANSWERS: "for the models
+ * the provider and the registry both know about, does the registry's opinion about
+ * a request parameter still match what the provider now advertises?" A mismatch is
+ * DRIFT — surfaced as a finding so the drift-guard workflow can open an issue for a
+ * human to reconcile.
+ *
+ * Design: this is a PURE function over already-fetched views (no network, no clock,
+ * no `gh`) so the diff logic is unit-testable in isolation. The IO — fetching the
+ * catalog, enumerating the registry, opening the issue — lives in the thin script
+ * `scripts/check-parameter-drift.ts`.
+ *
+ * @module config/parameter-drift-reconcile
+ */
+
+/** The provider's view of one model (subset of {@link OpenRouterCatalogModel}). */
+export interface ProviderParamView {
+  /** The id as it appears in the provider catalog. */
+  readonly id: string;
+  /**
+   * The provider's machine-readable capability list. A param present here is
+   * supported; a param absent is unsupported. `undefined` means the provider
+   * reported NO capability list for this model — we cannot reconcile it (skip).
+   */
+  readonly supportedParameters?: readonly string[];
+}
+
+/** The registry's (curated) view of one model. */
+export interface RegistryParamView {
+  /** The canonical registry id — used only for reporting. */
+  readonly modelId: string;
+  /**
+   * Ids under which this model may appear in the provider catalog (e.g. the
+   * registry id and its `cliModelName`). The join matches on the FIRST of these
+   * present in the provider catalog.
+   */
+  readonly providerIds: readonly string[];
+  /**
+   * The params the curated map declares this model REJECTS
+   * ({@link unsupportedParametersForModel}). A param NOT in this list is, per the
+   * registry, supported.
+   */
+  readonly unsupportedParameters: readonly string[];
+}
+
+/** One reconciliation disagreement between the curated map and the provider. */
+export interface ParameterDriftFinding {
+  /** Canonical registry id. */
+  readonly modelId: string;
+  /** The provider-catalog id we matched it against. */
+  readonly providerId: string;
+  /** The request parameter the two sources disagree about. */
+  readonly param: string;
+  /** The registry's (curated) opinion: does it accept `param`? */
+  readonly registrySupported: boolean;
+  /** The provider's advertised opinion: does it accept `param`? */
+  readonly providerSupported: boolean;
+}
+
+/**
+ * Params the curated map reasons about and that a provider catalog also reports —
+ * so a disagreement is meaningful. Currently `temperature` (the #4061/#4062
+ * incidents). Kept explicit rather than "every param the provider lists" so we
+ * don't raise noise for params the registry has no opinion about.
+ */
+export const DEFAULT_RECONCILABLE_PARAMS: readonly string[] = ['temperature'];
+
+/**
+ * Reconcile the curated capability map against the provider's advertised
+ * `supported_parameters`. Returns one finding per (model, param) the two sources
+ * disagree about.
+ *
+ * Rules:
+ *  - Only models present in BOTH sources are compared (a model in one source only
+ *    yields NO finding — we can't reconcile what one side doesn't know).
+ *  - A provider model whose `supportedParameters` is `undefined` is skipped (the
+ *    provider gave us no capability list to compare against).
+ *  - For each candidate param (the union of `reconcilableParams` and the model's
+ *    own declared-unsupported params), DRIFT = registry-supported !=
+ *    provider-supported.
+ *
+ * Pure & deterministic: same inputs → same findings. It NEVER mutates its inputs
+ * and NEVER touches the curated map.
+ */
+/** First provider-catalog id (of a model's candidates) that carries a capability
+ * list, plus that list. `undefined` when none match (only-in-one-source). */
+function joinToCatalog(
+  providerIds: readonly string[],
+  byId: ReadonlyMap<string, readonly string[]>
+): { providerId: string; providerParams: readonly string[] } | undefined {
+  for (const candidate of providerIds) {
+    const providerParams = byId.get(candidate);
+    if (providerParams !== undefined) return { providerId: candidate, providerParams };
+  }
+  return undefined;
+}
+
+export function reconcileParameterDrift(
+  providerModels: readonly ProviderParamView[],
+  registryModels: readonly RegistryParamView[],
+  reconcilableParams: readonly string[] = DEFAULT_RECONCILABLE_PARAMS
+): ParameterDriftFinding[] {
+  // Index the provider catalog by id, keeping only models that carry a capability
+  // list (the ones we can actually reconcile).
+  const byId = new Map<string, readonly string[]>();
+  for (const m of providerModels) {
+    if (m.supportedParameters !== undefined) byId.set(m.id, m.supportedParameters);
+  }
+
+  const findings: ParameterDriftFinding[] = [];
+  for (const reg of registryModels) {
+    // Join: first provider id we know about wins.
+    const match = joinToCatalog(reg.providerIds, byId);
+    if (match === undefined) continue; // only-in-one-source → no finding
+    const { providerId, providerParams } = match;
+
+    const unsupported = new Set(reg.unsupportedParameters);
+    const candidates = new Set<string>([...reconcilableParams, ...reg.unsupportedParameters]);
+    for (const param of candidates) {
+      const registrySupported = !unsupported.has(param);
+      const providerSupported = providerParams.includes(param);
+      if (registrySupported !== providerSupported) {
+        findings.push({
+          modelId: reg.modelId,
+          providerId,
+          param,
+          registrySupported,
+          providerSupported,
+        });
+      }
+    }
+  }
+  return findings;
+}


### PR DESCRIPTION
## What
The drift-guard half of epic #4066's layer 4. Keeps the **hand-curated** model-parameter capability map (`KNOWN_PARAMETER_INCOMPATIBILITIES` + the registry's `unsupportedParameters`/`maxTokensParam`) honest against provider reality. A weekly workflow fetches the provider catalog's machine-readable `supported_parameters` and reconciles it against the registry; on drift it opens **one deduped issue** — it **never auto-edits** the curated map (a human vets changes).

## How (mirrors the existing `pricing-drift.yml` pattern)
- `openrouter-models-source.ts`: `parseCatalog` additively captures `supported_parameters` (`{id, supportedParameters?}`) + exported `fetchOpenRouterCatalog()`. **Backward-compatible** — `.id`-only consumers unaffected; field omitted when absent; malformed payloads still fail open to `[]`.
- `parameter-drift-reconcile.ts` (new): **pure** `reconcileParameterDrift()` — joins provider↔registry by id, flags `registrySupported !== providerSupported`; only models in BOTH sources; never mutates.
- `scripts/check-parameter-drift.ts` (new): emits `PARAM_DRIFT_STATUS=clean|drift|skipped`. An empty/failed fetch → **`skipped`** (+`::warning::`), NOT a false `clean` — a provider outage can't mask real drift (fail-loud, per #4066).
- `.github/workflows/parameter-drift.yml` (new): weekly cron + `workflow_dispatch`, `contents:read`/`issues:write`.

## Verification
`tsc --noEmit` clean · **21 tests** (10 pure reconcile + 11 widened `parseCatalog`) · eslint clean · YAML valid · **live run: 338 models fetched, reported clean/0** (real E2E) · patch changeset.

Closes #4066's active drift-guard work (the deferred reactive self-heal #4071 remains, data-gated). Refs #4066 #4070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)