### PR TITLE
fix(governance): raise auto-remediation enforce-readiness volume bar 20→100 (#4158, epic #4066)

### DIFF
--- a/.changeset/enforce-readiness-volume-bar.md
+++ b/.changeset/enforce-readiness-volume-bar.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Raise the auto-remediation enforce-readiness volume bar (#4158): `DEFAULT_ENFORCE_READINESS_CONFIG.minShadowSelections` 20 → 100. This gate authorizes the auto-remediation enforce flip, which makes REAL code changes; its volume bar now matches the comparably-stakes access-policy flip (clawguard-eval ≥100, #2077) rather than sitting 5× lower. Monotonically safer (a thinner corpus stays in audit longer); overridable per-caller via `readinessConfig`. Surfaced by the #4094 vote-gate.

--- a/packages/nexus-agents/src/cli/remediation-review-command.test.ts
+++ b/packages/nexus-agents/src/cli/remediation-review-command.test.ts
@@ -186,9 +186,10 @@ describe('handleRemediationReviewCommand', () => {
     const sink = createRemediationSoakSink(getRemediationSoakFile());
     const reviewStore = createRemediationReviewStore(getRemediationReviewFile());
     const refs: string[] = [];
-    for (let i = 0; i < 20; i++) {
+    // #4158: volume bar is now ≥100 shadow selections.
+    for (let i = 0; i < 120; i++) {
       const rec: RemediationSoakRecord = {
-        timestamp: `2026-06-08T00:00:${String(i).padStart(2, '0')}.000Z`,
+        timestamp: `2026-06-08T00:${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}.000Z`,
         signalKey: 'routing:floor:codex',
         category: 'routing',
         priority: 'p2',
@@ -199,8 +200,8 @@ describe('handleRemediationReviewCommand', () => {
       sink.record(rec);
       refs.push(soakRefOf(rec));
     }
-    // Review 18/20 (≥80% judged), all sound (100% ≥ 90%), named evaluator + owner.
-    for (const ref of refs.slice(0, 18)) {
+    // Review 110/120 (≥80% judged), all sound (100% ≥ 90%), named evaluator + owner.
+    for (const ref of refs.slice(0, 110)) {
       const review: ReviewRecord = {
         soakRef: ref,
         reviewedAt: '2026-06-09T00:00:00.000Z',

--- a/packages/nexus-agents/src/mcp/tools/auto-remediation-enforce-e2e.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/auto-remediation-enforce-e2e.test.ts
@@ -345,9 +345,9 @@ describe('enforce path — e2e against a throwaway repo (#3777)', () => {
       const deps = enforceReadyDeps();
       deps.readinessEvidence = () =>
         Promise.resolve({
-          shadowSelections: 50,
-          judgedSelections: 50,
-          judgedSound: 50,
+          shadowSelections: 120, // ≥ 100 (#4158)
+          judgedSelections: 110,
+          judgedSound: 105,
           evaluator: 'e2e',
           owner: 'e2e',
         });

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
@@ -13,9 +13,9 @@ import {
 /** Evidence that satisfies every default criterion. */
 function readyEvidence(over: Partial<EnforceReadinessEvidence> = {}): EnforceReadinessEvidence {
   return {
-    shadowSelections: 25,
-    judgedSelections: 22, // 88% ≥ 80%
-    judgedSound: 21, // 95% ≥ 90%
+    shadowSelections: 120, // ≥ 100 (#4158)
+    judgedSelections: 110, // 91.7% ≥ 80%
+    judgedSound: 105, // 95.5% ≥ 90%
     evaluator: 'security-reviewer@example',
     owner: 'williamzujkowski',
     ...over,
@@ -39,7 +39,7 @@ describe('evaluateEnforceReadiness', () => {
 
   it('blocks on insufficient judged coverage', () => {
     const r = evaluateEnforceReadiness(
-      readyEvidence({ shadowSelections: 25, judgedSelections: 10 })
+      readyEvidence({ shadowSelections: 120, judgedSelections: 10 })
     );
     expect(r.ready).toBe(false);
     expect(r.blockers).toContain('judged-coverage');
@@ -52,25 +52,25 @@ describe('evaluateEnforceReadiness', () => {
   });
 
   it('is ready at EXACTLY the threshold rates (>= boundary — catches an off-by-one flip)', () => {
-    // judged 20/25 = exactly 0.80; sound 18/20 = exactly 0.90; volume 25 ≥ 20.
+    // judged 80/100 = exactly 0.80; sound 72/80 = exactly 0.90; volume 100 ≥ 100.
     // A `>=`→`>` regression on the gate that authorizes autonomous writes would
     // flip this to not-ready.
     const r = evaluateEnforceReadiness(
-      readyEvidence({ shadowSelections: 25, judgedSelections: 20, judgedSound: 18 })
+      readyEvidence({ shadowSelections: 100, judgedSelections: 80, judgedSound: 72 })
     );
     expect(r.ready).toBe(true);
   });
 
   it('is ready at EXACTLY the minimum volume (>= boundary)', () => {
     const r = evaluateEnforceReadiness(
-      readyEvidence({ shadowSelections: 20, judgedSelections: 20, judgedSound: 20 })
+      readyEvidence({ shadowSelections: 100, judgedSelections: 100, judgedSound: 100 })
     );
     expect(r.ready).toBe(true);
   });
 
   it('soundness fails closed when there are zero reviews (no divide-by-zero pass)', () => {
     const r = evaluateEnforceReadiness(
-      readyEvidence({ shadowSelections: 25, judgedSelections: 0, judgedSound: 0 })
+      readyEvidence({ shadowSelections: 120, judgedSelections: 0, judgedSound: 0 })
     );
     expect(r.ready).toBe(false);
     expect(r.blockers).toEqual(expect.arrayContaining(['judged-coverage', 'soundness']));
@@ -79,7 +79,7 @@ describe('evaluateEnforceReadiness', () => {
   it('blocks on missing named evaluator', () => {
     // Omit evaluator entirely (exactOptionalPropertyTypes — no explicit undefined).
     const r = evaluateEnforceReadiness({
-      shadowSelections: 25,
+      shadowSelections: 120,
       judgedSelections: 22,
       judgedSound: 21,
       owner: 'williamzujkowski',
@@ -90,7 +90,7 @@ describe('evaluateEnforceReadiness', () => {
 
   it('blocks on missing / blank named owner', () => {
     const missing = evaluateEnforceReadiness({
-      shadowSelections: 25,
+      shadowSelections: 120,
       judgedSelections: 22,
       judgedSound: 21,
       evaluator: 'rev@example',
@@ -103,7 +103,7 @@ describe('evaluateEnforceReadiness', () => {
 
   it('honors relaxed config (evaluator/owner not required)', () => {
     const r = evaluateEnforceReadiness(
-      { shadowSelections: 25, judgedSelections: 22, judgedSound: 21 },
+      { shadowSelections: 120, judgedSelections: 110, judgedSound: 105 },
       {
         ...DEFAULT_ENFORCE_READINESS_CONFIG,
         requireNamedEvaluator: false,
@@ -115,6 +115,9 @@ describe('evaluateEnforceReadiness', () => {
 
   it('default config is a high, conservative bar', () => {
     expect(DEFAULT_ENFORCE_READINESS_CONFIG.minSoundnessRate).toBeGreaterThanOrEqual(0.9);
+    // #4158: volume bar matches the comparably-stakes access-policy flip (clawguard ≥100),
+    // not the prior 20 — this gate authorizes autonomous REAL code changes.
+    expect(DEFAULT_ENFORCE_READINESS_CONFIG.minShadowSelections).toBeGreaterThanOrEqual(100);
     expect(DEFAULT_ENFORCE_READINESS_CONFIG.requireNamedEvaluator).toBe(true);
     expect(DEFAULT_ENFORCE_READINESS_CONFIG.requireNamedOwner).toBe(true);
   });

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.ts
@@ -47,9 +47,18 @@ export interface EnforceReadinessConfig {
   readonly requireNamedOwner: boolean;
 }
 
-/** Conservative defaults — high bar, fail-closed. */
+/**
+ * Conservative defaults — high bar, fail-closed.
+ *
+ * #4158: `minShadowSelections` is 100 (raised from 20). This gate authorizes the
+ * auto-remediation enforce flip, which makes REAL code changes — its volume bar
+ * should match the comparably-stakes access-policy flip (clawguard-eval requires
+ * ≥100 judged events, #2077), not sit 5× lower. Raising it is monotonically safer
+ * (a thinner corpus stays in audit longer); overridable per-caller via
+ * `config.readinessConfig`.
+ */
 export const DEFAULT_ENFORCE_READINESS_CONFIG: EnforceReadinessConfig = {
-  minShadowSelections: 20,
+  minShadowSelections: 100,
   minJudgedRate: 0.8,
   minSoundnessRate: 0.9,
   requireNamedEvaluator: true,

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-enforce.test.ts
@@ -41,9 +41,9 @@ function rawPlanFor(s: ImprovementSignal): unknown {
 
 function readyEvidence(): EnforceReadinessEvidence {
   return {
-    shadowSelections: 25,
-    judgedSelections: 22,
-    judgedSound: 21,
+    shadowSelections: 120, // ≥ 100 (#4158)
+    judgedSelections: 110, // 91.7% ≥ 80%
+    judgedSound: 105, // 95.5% ≥ 90%
     evaluator: 'rev@example',
     owner: 'williamzujkowski',
   };

--- a/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/remediation-readiness-collector.test.ts
@@ -41,13 +41,14 @@ describe('buildEnforceReadinessEvidence', () => {
   });
 
   it('produces evidence that PASSES the readiness gate when criteria are met', () => {
+    // #4158: the volume bar is now ≥100 shadow selections.
     const reviews: RemediationReviewSummary = {
-      judgedSelections: 18,
-      judgedSound: 17,
+      judgedSelections: 110, // 91.7% ≥ 80%
+      judgedSound: 105, // 95.5% ≥ 90%
       evaluator: 'alice',
       owner: 'carol',
     };
-    const evidence = buildEnforceReadinessEvidence(soak(20), reviews);
+    const evidence = buildEnforceReadinessEvidence(soak(120), reviews);
     expect(evaluateEnforceReadiness(evidence).ready).toBe(true);
   });
 


### PR DESCRIPTION
## What
`DEFAULT_ENFORCE_READINESS_CONFIG.minShadowSelections` 20 → **100**. This gate authorizes the auto-remediation enforce flip (`NEXUS_AUTO_REMEDIATE` audit→enforce, #3769) which makes **real code changes**, yet its volume bar sat 5× below the comparably-stakes access-policy flip (clawguard-eval requires ≥100 judged events, #2077).

## Why / safety
Monotonically safer — a thinner corpus stays in **audit** longer before it can flip to enforce. Overridable per-caller via `readinessConfig`. Surfaced by the #4094 vote-gate (corpus/correctness voter, who noted the redundancy of a proposed P/R scorer *and* this too-low bar).

## Verification
`tsc --noEmit` clean · **53 readiness-dependent tests pass** — scaled the "ready" fixtures across the enforce-readiness, remediation-enforce, e2e, and review-command suites to ≥100 volume with valid judged/sound rates; the negative volume tests unchanged · eslint clean · patch changeset.

Refs #4094 #4066 #3769 #2077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)