### PR TITLE
feat(orchestration): meta-strategy learned-selector readiness signal (#4094)

### DIFF
--- a/.changeset/meta-strategy-readiness-signal.md
+++ b/.changeset/meta-strategy-readiness-signal.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': minor
+---
+
+Add the learned-selector promotion readiness signal (#4094, EVIDENCE half). New pure `evaluateMetaStrategyReadiness(evaluateMetaStrategy(META_STRATEGY_CORPUS))` (`orchestration/meta-strategy-readiness.ts`) turns the offline learned-vs-rules eval into a falsifiable, fail-closed `ReadinessVerdict` (reusing the shared #4096 envelope) over three criteria: `volume` (≥20 held-out cases), `learned-beats-rules` (delta ≥0.05 margin, a tie is not enough), and `learned-accuracy-floor` (learned accuracy ≥0.70, so "beats rules" can't pass on two weak arms). The labeled `META_STRATEGY_CORPUS` grew 40→80 (10 per ExecutionStrategy, balanced) so a 25% split yields ≥20 held-out cases. The `run` tool now computes and LOGS the verdict once per process at shadow-enable time (`meta-strategy learned-selector readiness`) as an AUDIT-MODE operator signal — it never alters the routed decision. This is the readiness signal only; the promotion path that lets the learned selector actually route (#3552) is a separate vote-gated increment and is deliberately NOT built here.

--- a/packages/nexus-agents/src/mcp/tools/run-tool-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-readiness.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the non-routing meta-strategy readiness consumer wired into `run`
+ * (#4094). The verdict is SURFACED (logged) for operators; it must NEVER alter the
+ * routed decision — that promotion path is #3552, deliberately not built here.
+ *
+ * The readiness log is emitted once per process (a deterministic function of the
+ * static corpus). Each test resets modules so it observes a fresh first emission
+ * against a clean `readinessLogged` guard.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { ILogger } from '../../core/index.js';
+import type { LogContext } from '../../core/logger.js';
+
+interface LogLine {
+  readonly message: string;
+  readonly context: LogContext | undefined;
+}
+
+/** A logger that records every info/warn line for assertion. */
+function capturingLogger(): { logger: ILogger; lines: LogLine[] } {
+  const lines: LogLine[] = [];
+  const record = (message: string, context?: LogContext): void => {
+    lines.push({ message, context });
+  };
+  const logger: ILogger = {
+    debug: () => undefined,
+    info: (message, context) => {
+      record(message, context);
+    },
+    warn: (message, context) => {
+      record(message, context);
+    },
+    error: () => undefined,
+    child: () => logger,
+    setLevel: () => undefined,
+  };
+  return { logger, lines };
+}
+
+const READINESS_MSG = 'meta-strategy learned-selector readiness';
+
+/** Fresh module each test → clean once-per-process `readinessLogged` guard. */
+async function freshRouteGoal(): Promise<typeof import('./run-tool.js').routeGoal> {
+  vi.resetModules();
+  const mod = await import('./run-tool.js');
+  return mod.routeGoal;
+}
+
+describe('run readiness consumer — non-routing audit signal (#4094)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('surfaces the readiness verdict with delta/testCount when routing a goal', async () => {
+    const routeGoal = await freshRouteGoal();
+    const { logger, lines } = capturingLogger();
+    routeGoal(
+      { goal: 'fix the off-by-one bug in pagination.ts and make sure the tests pass' },
+      logger
+    );
+
+    const readiness = lines.find((l) => l.message === READINESS_MSG);
+    expect(readiness).toBeDefined();
+    expect(readiness?.context).toMatchObject({
+      ready: expect.any(Boolean),
+      delta: expect.any(Number),
+      testCount: expect.any(Number),
+    });
+  });
+
+  it('logs the readiness verdict exactly once per process (not per decision)', async () => {
+    const routeGoal = await freshRouteGoal();
+    const { logger, lines } = capturingLogger();
+    routeGoal({ goal: 'run a security audit of the payments module' }, logger);
+    routeGoal({ goal: 'research the best vector database for our use case' }, logger);
+    routeGoal({ goal: 'hold a consensus vote on whether to adopt GraphQL' }, logger);
+
+    const emissions = lines.filter((l) => l.message === READINESS_MSG);
+    expect(emissions).toHaveLength(1);
+  });
+
+  it('does NOT alter the routed decision (readiness is observed, never acted on)', async () => {
+    const routeGoal = await freshRouteGoal();
+    const goal = 'build a greenfield todo app from this written spec';
+    // With the readiness consumer active (logger present) vs the routing-only path:
+    // the selected strategy must be identical, proving the signal never feeds routing.
+    const withLogger = routeGoal({ goal }, capturingLogger().logger);
+    const withoutLogger = routeGoal({ goal });
+
+    expect(withLogger.strategy).toBe(withoutLogger.strategy);
+    expect(typeof withLogger.strategy).toBe('string');
+    expect(withLogger.decisionId).not.toBe(withoutLogger.decisionId); // fresh id per call
+  });
+
+  it('is best-effort: a readiness-log failure never breaks routing', async () => {
+    const routeGoal = await freshRouteGoal();
+    // Throw ONLY on the readiness line so the orchestrator's own info logging (audit
+    // sink, selection line) still works — isolating the readiness seam.
+    let warned = false;
+    const partialLogger: ILogger = {
+      debug: () => undefined,
+      info: (message: string) => {
+        if (message === READINESS_MSG) throw new Error('readiness log boom');
+      },
+      warn: () => {
+        warned = true;
+      },
+      error: () => undefined,
+      child: () => partialLogger,
+      setLevel: () => undefined,
+    };
+    const res = routeGoal({ goal: 'format this JSON snippet' }, partialLogger);
+    expect(res.strategy).toBeDefined();
+    expect(warned).toBe(true); // the swallow path logged a warn
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -25,7 +25,7 @@ import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { IModelAdapter } from '../../core/index.js';
 
-import { createLogger, formatZodError, type ILogger } from '../../core/index.js';
+import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -46,6 +46,9 @@ import {
   getShadowSink,
   persistMetaOutcome,
 } from '../../orchestration/meta-shadow-selector.js';
+import { evaluateMetaStrategy } from '../../orchestration/meta-strategy-eval.js';
+import { META_STRATEGY_CORPUS } from '../../orchestration/meta-strategy-corpus.js';
+import { evaluateMetaStrategyReadiness } from '../../orchestration/meta-strategy-readiness.js';
 import { isPersistenceEnabled } from '../../config/learning-persistence.js';
 import {
   createMetaDispatcher,
@@ -170,6 +173,42 @@ function toMetaInput(
 }
 
 /**
+ * Whether the learned-selector readiness signal has already been logged this
+ * process. The verdict is a deterministic function of the STATIC labeled corpus, so
+ * it never changes within a run — compute + log it exactly once at first shadow-enable
+ * (not per decision), matching the shadow selector's own one-time hydrate log.
+ */
+let readinessLogged = false;
+
+/**
+ * Compute the learned-selector promotion readiness verdict once and SURFACE it for
+ * operators (#4094). AUDIT-MODE ONLY — this is a non-routing observer of the offline
+ * eval: it logs whether the learned arm has crossed the promotion bar so the #3552
+ * shadow→route flip has a falsifiable signal to gate on. It NEVER touches the routed
+ * decision. Best-effort: an eval failure is swallowed so selection never breaks.
+ */
+function logMetaStrategyReadinessOnce(logger: ILogger): void {
+  if (readinessLogged) return;
+  readinessLogged = true;
+  try {
+    const evalResult = evaluateMetaStrategy(META_STRATEGY_CORPUS);
+    const verdict = evaluateMetaStrategyReadiness(evalResult);
+    logger.info('meta-strategy learned-selector readiness', {
+      ready: verdict.ready,
+      delta: evalResult.delta,
+      learnedAccuracy: evalResult.learnedAccuracy,
+      rulesAccuracy: evalResult.rulesAccuracy,
+      testCount: evalResult.testCount,
+      blockers: verdict.blockers,
+    });
+  } catch (err) {
+    logger.warn('meta-strategy readiness signal failed (non-fatal)', {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+/**
  * Selects a strategy for a goal via the MetaOrchestrator. `mode` is the dispatch
  * mode the selection feeds (#3920): it sets the `requiredAuthority` the
  * authority-ladder router enforces, so `select` can refuse an above-tier action
@@ -184,6 +223,10 @@ function selectDecision(input: RunInput, mode: DispatchMode, logger?: ILogger): 
     shadowSelector: getShadowSelector(),
     shadowSink: getShadowSink(),
   });
+  // Non-routing audit signal (#4094): surface the learned-selector readiness verdict
+  // alongside shadow enablement. Observed, never acted on — the routed decision below
+  // is untouched by it.
+  logMetaStrategyReadinessOnce(logger ?? createLogger({ component: 'RunTool' }));
   return meta.select(toMetaInput(input, mode));
 }
 

--- a/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-corpus.ts
@@ -18,17 +18,14 @@
  *  - `spec`            a greenfield build FROM A WRITTEN SPEC ("from scratch", "new … from this spec").
  *  - `research`        research-heavy investigation / comparison / survey.
  *
- * Balanced 5 per strategy (40 total). GROWTH TARGET: expand toward ≥80 (≥10/strategy)
- * so a 25% test split yields ≥20 held-out cases — the volume the #3552 readiness gate
- * expects (improvement-enforce-readiness: volume≥20). This starter establishes the
- * eval mechanism + the routing-accuracy regression guard.
+ * Balanced 10 per strategy (80 total) so a 25% test split yields ≥20 held-out cases —
+ * the volume the #3552 readiness gate expects ({@link evaluateMetaStrategyReadiness}:
+ * volume≥20). This grew from the starter 40 (5/strategy) as the eval matured from a
+ * mechanism-demonstrator into the corpus that backs the audit-mode readiness signal.
+ * The corpus doubles as the routing-accuracy regression guard.
  *
  * @module orchestration/meta-strategy-corpus
  */
-
-// @export-no-consumer-yet — see #4095. The labeled corpus is consumed by the eval's
-// test now; its production consumer is epic #4094's child 2 (the readiness collector
-// over the shared corpus→score→verdict primitive).
 
 import type { MetaStrategyCorpusEntry } from './meta-strategy-eval.js';
 
@@ -39,6 +36,17 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
   { goal: 'format this JSON snippet', expectedStrategy: 'single-shot' },
   { goal: 'add a one-line comment explaining this regex', expectedStrategy: 'single-shot' },
   { goal: 'convert this value from Celsius to Fahrenheit', expectedStrategy: 'single-shot' },
+  {
+    goal: 'explain what the useEffect hook does in one paragraph',
+    expectedStrategy: 'single-shot',
+  },
+  { goal: 'convert this markdown table to CSV', expectedStrategy: 'single-shot' },
+  {
+    goal: 'rename the function calcTotal to computeTotal in cart.ts',
+    expectedStrategy: 'single-shot',
+  },
+  { goal: 'what is the time complexity of binary search?', expectedStrategy: 'single-shot' },
+  { goal: 'format this SQL query for readability', expectedStrategy: 'single-shot' },
 
   // dev-pipeline — code change needing the test/lint/typecheck gate
   {
@@ -55,6 +63,26 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
     goal: 'patch the null-pointer in parser.ts and verify the build',
     expectedStrategy: 'dev-pipeline',
   },
+  {
+    goal: 'fix the memory leak in the websocket handler and make the tests green',
+    expectedStrategy: 'dev-pipeline',
+  },
+  {
+    goal: 'add a rate limiter to the API middleware with unit tests',
+    expectedStrategy: 'dev-pipeline',
+  },
+  {
+    goal: 'correct the timezone bug in the scheduler and run the test suite',
+    expectedStrategy: 'dev-pipeline',
+  },
+  {
+    goal: 'implement pagination on the users endpoint with tests and typecheck',
+    expectedStrategy: 'dev-pipeline',
+  },
+  {
+    goal: 'fix the flaky retry test in queue.ts and keep lint clean',
+    expectedStrategy: 'dev-pipeline',
+  },
 
   // pipeline — multi-stage templated audit/general
   { goal: 'run a security audit of the payments module', expectedStrategy: 'pipeline' },
@@ -62,6 +90,11 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
   { goal: 'produce an architecture review of the data pipeline', expectedStrategy: 'pipeline' },
   { goal: 'run the documentation-quality audit over the docs tree', expectedStrategy: 'pipeline' },
   { goal: 'perform a compliance audit of the logging subsystem', expectedStrategy: 'pipeline' },
+  { goal: 'run a performance audit of the checkout flow', expectedStrategy: 'pipeline' },
+  { goal: 'do a dependency-vulnerability audit of the whole repo', expectedStrategy: 'pipeline' },
+  { goal: 'produce an accessibility audit of the web frontend', expectedStrategy: 'pipeline' },
+  { goal: 'run a code-quality audit across the billing service', expectedStrategy: 'pipeline' },
+  { goal: 'perform a test-coverage audit of the core package', expectedStrategy: 'pipeline' },
 
   // graph-workflow — DAG / conditional-edge
   {
@@ -84,6 +117,26 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
     goal: 'design a graph workflow with a fan-in join after three sequential gated branches',
     expectedStrategy: 'graph-workflow',
   },
+  {
+    goal: 'build a workflow that runs A then branches to B or C based on the security-scan verdict',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'create a DAG where build and lint run in parallel then merge into a gated deploy step',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'design a workflow with a retry-loop edge back to the fetch step on transient failure',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'wire a pipeline that skips the migration step when the schema-check passes',
+    expectedStrategy: 'graph-workflow',
+  },
+  {
+    goal: 'orchestrate a conditional graph: on approval go to publish, otherwise route to a rework node',
+    expectedStrategy: 'graph-workflow',
+  },
 
   // orchestrate — pattern-based multi-agent
   {
@@ -103,6 +156,26 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
     expectedStrategy: 'orchestrate',
   },
   { goal: 'dispatch a wave of agents to audit each microservice', expectedStrategy: 'orchestrate' },
+  {
+    goal: 'spawn a swarm of agents to add type annotations across every module in parallel',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'fan out a wave of agents to update the copyright header in each file',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'use a multi-agent pattern to generate unit tests for each untested component concurrently',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'dispatch parallel agents to translate the docs into each supported language',
+    expectedStrategy: 'orchestrate',
+  },
+  {
+    goal: 'run a fan-out of agents to bump the dependency version in every package independently',
+    expectedStrategy: 'orchestrate',
+  },
 
   // consensus — multi-perspective decision/vote
   { goal: 'hold a consensus vote on whether to adopt GraphQL', expectedStrategy: 'consensus' },
@@ -119,6 +192,20 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
     goal: 'do a multi-perspective review and vote on the migration plan',
     expectedStrategy: 'consensus',
   },
+  { goal: 'hold a vote on which cloud provider to standardize on', expectedStrategy: 'consensus' },
+  {
+    goal: 'get a consensus decision on whether to drop support for Node 18',
+    expectedStrategy: 'consensus',
+  },
+  {
+    goal: 'run a multi-perspective panel to decide the caching strategy',
+    expectedStrategy: 'consensus',
+  },
+  { goal: 'we need a consensus vote on the proposed pricing model', expectedStrategy: 'consensus' },
+  {
+    goal: 'gather multiple expert opinions and vote on the rollout timeline',
+    expectedStrategy: 'consensus',
+  },
 
   // spec — greenfield from a written spec
   { goal: 'build a greenfield todo app from this written spec', expectedStrategy: 'spec' },
@@ -132,6 +219,26 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
     goal: 'build the new notification service from scratch following the spec',
     expectedStrategy: 'spec',
   },
+  {
+    goal: 'build a new authentication service from scratch following this specification',
+    expectedStrategy: 'spec',
+  },
+  {
+    goal: 'scaffold a greenfield mobile backend from the attached spec document',
+    expectedStrategy: 'spec',
+  },
+  {
+    goal: 'implement a brand-new billing engine from this written spec',
+    expectedStrategy: 'spec',
+  },
+  {
+    goal: 'create a new GraphQL gateway from scratch per the provided spec',
+    expectedStrategy: 'spec',
+  },
+  {
+    goal: 'build the greenfield analytics dashboard from this specification',
+    expectedStrategy: 'spec',
+  },
 
   // research — research-heavy investigation
   { goal: 'research the best vector database for our use case', expectedStrategy: 'research' },
@@ -143,6 +250,26 @@ export const META_STRATEGY_CORPUS: readonly MetaStrategyCorpusEntry[] = [
   { goal: 'survey the landscape of LLM evaluation frameworks', expectedStrategy: 'research' },
   {
     goal: 'research which benchmarks are worth adopting for our agents',
+    expectedStrategy: 'research',
+  },
+  {
+    goal: 'research the current best practices for prompt caching across LLM providers',
+    expectedStrategy: 'research',
+  },
+  {
+    goal: 'compare and evaluate message-queue technologies for our throughput needs',
+    expectedStrategy: 'research',
+  },
+  {
+    goal: 'survey the state of the art in retrieval-augmented generation',
+    expectedStrategy: 'research',
+  },
+  {
+    goal: 'investigate which observability stack fits our microservices best',
+    expectedStrategy: 'research',
+  },
+  {
+    goal: 'research the tradeoffs between monorepo and polyrepo for our team',
     expectedStrategy: 'research',
   },
 ];

--- a/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-eval.ts
@@ -37,10 +37,6 @@
  * @module orchestration/meta-strategy-eval
  */
 
-// @export-no-consumer-yet — see #4095. Consumed by its test (evals run in CI via
-// tests); the production consumer is epic #4094's child 2 — the extracted shared
-// labeled-corpus→score→readiness-verdict primitive that feeds the #3552 gate.
-
 import { createMetaOrchestrator, type ExecutionStrategy } from './meta-orchestrator.js';
 import { createLearnedStrategySelector } from './meta-shadow-selector.js';
 

--- a/packages/nexus-agents/src/orchestration/meta-strategy-readiness.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-readiness.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the learned-selector promotion readiness gate (#4094).
+ * Falsifiable, fail-closed: ready only when EVERY criterion passes.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  evaluateMetaStrategyReadiness,
+  DEFAULT_META_STRATEGY_READINESS_CONFIG,
+} from './meta-strategy-readiness.js';
+import type { MetaStrategyEvalResult } from './meta-strategy-eval.js';
+import { evaluateMetaStrategy } from './meta-strategy-eval.js';
+import { META_STRATEGY_CORPUS } from './meta-strategy-corpus.js';
+import { SHADOW_STRATEGY_ARMS } from './meta-shadow-selector.js';
+
+/** A result that satisfies every default criterion. */
+function readyResult(over: Partial<MetaStrategyEvalResult> = {}): MetaStrategyEvalResult {
+  const rulesAccuracy = 0.7;
+  const learnedAccuracy = 0.8; // delta 0.10 ≥ 0.05, and ≥ 0.7 floor
+  return {
+    total: 80,
+    trainCount: 60,
+    testCount: 20, // ≥ 20
+    rulesAccuracy,
+    learnedAccuracy,
+    delta: learnedAccuracy - rulesAccuracy,
+    ...over,
+  };
+}
+
+describe('evaluateMetaStrategyReadiness — promotion gate (#4094)', () => {
+  it('is ready when every criterion is met', () => {
+    const v = evaluateMetaStrategyReadiness(readyResult());
+    expect(v.ready).toBe(true);
+    expect(v.blockers).toEqual([]);
+    expect(v.criteria).toHaveLength(3);
+  });
+
+  it('blocks on insufficient volume (testCount < 20)', () => {
+    const v = evaluateMetaStrategyReadiness(readyResult({ testCount: 19 }));
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toContain('volume');
+  });
+
+  it('blocks when the learned arm only ties rules (delta below margin)', () => {
+    // learned == rules → delta 0, below the 0.05 margin. A tie is not enough.
+    const v = evaluateMetaStrategyReadiness(
+      readyResult({ rulesAccuracy: 0.8, learnedAccuracy: 0.8, delta: 0 })
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toContain('learned-beats-rules');
+  });
+
+  it('blocks when learned beats rules but is below the absolute accuracy floor', () => {
+    // learned 0.6 beats rules 0.5 by 0.10, but 0.6 < 0.7 floor: both arms are weak.
+    const v = evaluateMetaStrategyReadiness(
+      readyResult({ rulesAccuracy: 0.5, learnedAccuracy: 0.6, delta: 0.1 })
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toContain('learned-accuracy-floor');
+    expect(v.blockers).not.toContain('learned-beats-rules');
+  });
+
+  it('fail-closed: an empty/thin corpus eval is never ready', () => {
+    const empty: MetaStrategyEvalResult = {
+      total: 0,
+      trainCount: 0,
+      testCount: 0,
+      rulesAccuracy: 0,
+      learnedAccuracy: 0,
+      delta: 0,
+    };
+    const v = evaluateMetaStrategyReadiness(empty);
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toEqual(['volume', 'learned-beats-rules', 'learned-accuracy-floor']);
+  });
+
+  describe('boundary conditions — exactly at the thresholds', () => {
+    it('passes volume at exactly minTestCases', () => {
+      const v = evaluateMetaStrategyReadiness(readyResult({ testCount: 20 }));
+      expect(v.blockers).not.toContain('volume');
+    });
+
+    it('passes learned-beats-rules at exactly minDelta', () => {
+      const v = evaluateMetaStrategyReadiness(
+        readyResult({ rulesAccuracy: 0.7, learnedAccuracy: 0.75, delta: 0.05 })
+      );
+      expect(v.blockers).not.toContain('learned-beats-rules');
+    });
+
+    it('passes learned-accuracy-floor at exactly minLearnedAccuracy', () => {
+      const v = evaluateMetaStrategyReadiness(
+        readyResult({ rulesAccuracy: 0.6, learnedAccuracy: 0.7, delta: 0.1 })
+      );
+      expect(v.blockers).not.toContain('learned-accuracy-floor');
+    });
+
+    it('is ready at all three thresholds simultaneously', () => {
+      const v = evaluateMetaStrategyReadiness(
+        readyResult({ testCount: 20, rulesAccuracy: 0.65, learnedAccuracy: 0.7, delta: 0.05 })
+      );
+      expect(v.ready).toBe(true);
+    });
+  });
+
+  it('honors a stricter caller-supplied config', () => {
+    const base = readyResult();
+    // Default config says ready; a raised floor blocks it (monotonically safer).
+    expect(evaluateMetaStrategyReadiness(base).ready).toBe(true);
+    const strict = evaluateMetaStrategyReadiness(base, {
+      ...DEFAULT_META_STRATEGY_READINESS_CONFIG,
+      minLearnedAccuracy: 0.95,
+    });
+    expect(strict.ready).toBe(false);
+    expect(strict.blockers).toContain('learned-accuracy-floor');
+  });
+
+  it('conservative defaults are the documented values', () => {
+    expect(DEFAULT_META_STRATEGY_READINESS_CONFIG).toEqual({
+      minTestCases: 20,
+      minDelta: 0.05,
+      minLearnedAccuracy: 0.7,
+    });
+  });
+
+  it('applies over the real corpus without throwing (audit-mode signal)', () => {
+    const v = evaluateMetaStrategyReadiness(evaluateMetaStrategy(META_STRATEGY_CORPUS));
+    expect(typeof v.ready).toBe('boolean');
+    expect(v.criteria).toHaveLength(3);
+  });
+});
+
+describe('META_STRATEGY_CORPUS — balance guard (#4094)', () => {
+  it('has at least 80 entries', () => {
+    expect(META_STRATEGY_CORPUS.length).toBeGreaterThanOrEqual(80);
+  });
+
+  it('has at least 10 entries for every ExecutionStrategy label (even balance)', () => {
+    const counts = new Map<string, number>();
+    for (const entry of META_STRATEGY_CORPUS) {
+      counts.set(entry.expectedStrategy, (counts.get(entry.expectedStrategy) ?? 0) + 1);
+    }
+    for (const strategy of SHADOW_STRATEGY_ARMS) {
+      expect(counts.get(strategy) ?? 0).toBeGreaterThanOrEqual(10);
+    }
+    // Every label present in the corpus is one of the 8 known strategies.
+    expect([...counts.keys()].sort()).toEqual([...SHADOW_STRATEGY_ARMS].sort());
+  });
+
+  it('has no duplicate goals (no near-duplicate padding by exact match)', () => {
+    const goals = META_STRATEGY_CORPUS.map((e) => e.goal);
+    expect(new Set(goals).size).toBe(goals.length);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/meta-strategy-readiness.ts
+++ b/packages/nexus-agents/src/orchestration/meta-strategy-readiness.ts
@@ -1,0 +1,109 @@
+/**
+ * nexus-agents/orchestration — learned-selector promotion readiness gate (#4094).
+ *
+ * Turns the offline {@link MetaStrategyEvalResult} (learned-vs-rules accuracy over
+ * the labeled corpus, {@link evaluateMetaStrategy}) into a FALSIFIABLE, fail-closed
+ * "is the learned strategy selector ready to promote?" verdict — the AUDIT-MODE
+ * readiness SIGNAL for the #3552 shadow→route flip, NOT the flip itself. This module
+ * only EVALUATES; it flips no flag, alters no routing, and runs no selector. The
+ * promotion path (#3552, letting the learned arm actually route) is a separate
+ * vote-gated increment that consumes this signal — it is deliberately NOT built here.
+ *
+ * Mirrors {@link evaluateEnforceReadiness} (the shadow→enforce sibling gate): a fixed
+ * set of independently-checkable numeric conditions, ALL required (fail-closed — any
+ * unmet condition blocks promotion). Reuses the shared {@link ReadinessVerdict}
+ * envelope (#4096) rather than minting a new verdict type.
+ *
+ * THE CRITERIA (per the epic #4094 design):
+ *  1. **volume** — the held-out test split is large enough to judge (`testCount >=
+ *     minTestCases`). A thin corpus can't certify a selector; fail-closed here keeps
+ *     an under-grown corpus in audit longer.
+ *  2. **learned-beats-rules** — the learned arm beats rules by a real MARGIN
+ *     (`delta >= minDelta`), not merely a tie. Promoting a selector that only ties
+ *     the rule router adds bandit complexity for no measured gain.
+ *  3. **learned-accuracy-floor** — the learned arm clears an ABSOLUTE accuracy floor
+ *     (`learnedAccuracy >= minLearnedAccuracy`). Guards the pathological case where
+ *     learned "beats" rules only because rules are worse — both weak. We refuse to
+ *     promote a learned selector that is merely less-bad but still poor.
+ *
+ * INTELLECTUAL HONESTY (carried from the eval): the eval's training reward is
+ * SYNTHESIZED from the oracle label, so `learnedAccuracy` is a DIRECTIONAL signal,
+ * not a production number. This gate is therefore an AUDIT readiness indicator for
+ * operators, not an auto-promote trigger. Crossing it is necessary-not-sufficient for
+ * the #3552 flip, which additionally requires the vote gate + real shadow-outcome
+ * training.
+ *
+ * @module orchestration/meta-strategy-readiness
+ */
+
+import type { ReadinessCriterion, ReadinessVerdict } from '../mcp/tools/readiness-verdict.js';
+import type { MetaStrategyEvalResult } from './meta-strategy-eval.js';
+
+// Re-export the shared envelope so consumers of this gate get the verdict shape
+// without a second import site (#4096).
+export type { ReadinessCriterion, ReadinessVerdict } from '../mcp/tools/readiness-verdict.js';
+
+/** Tuning for {@link evaluateMetaStrategyReadiness}. */
+export interface MetaStrategyReadinessConfig {
+  /** Minimum held-out test cases before promotion can be considered. */
+  readonly minTestCases: number;
+  /** Minimum learned−rules accuracy margin (a tie is not enough). */
+  readonly minDelta: number;
+  /** Minimum ABSOLUTE learned accuracy (don't promote a merely-less-bad selector). */
+  readonly minLearnedAccuracy: number;
+}
+
+/**
+ * Conservative defaults — high bar, fail-closed.
+ *
+ * - `minTestCases` is 20: the held-out count a 25%-split ≥80-entry corpus yields — the
+ *   volume the #3552 readiness gate expects (matching improvement-enforce-readiness's
+ *   own volume floor of 20 at its introduction). A thinner split stays in audit longer.
+ * - `minDelta` is 0.05: learned must beat rules by a real margin; a tie stays blocked.
+ * - `minLearnedAccuracy` is 0.7: an absolute floor so "learned beats rules" can't pass
+ *   on two weak arms.
+ *
+ * Overridable per-caller; raising any value is monotonically safer.
+ */
+export const DEFAULT_META_STRATEGY_READINESS_CONFIG: MetaStrategyReadinessConfig = {
+  minTestCases: 20,
+  minDelta: 0.05,
+  minLearnedAccuracy: 0.7,
+};
+
+function pctStr(n: number): string {
+  return String(Math.round(n * 100));
+}
+
+/**
+ * Evaluate whether the learned strategy selector's offline eval clears the promotion
+ * bar. Pure: supply an {@link evaluateMetaStrategy} result. Never returns
+ * `ready: true` unless ALL criteria pass. Fail-closed — an empty/thin corpus yields
+ * `testCount: 0`, `delta: 0`, `learnedAccuracy: 0`, so every criterion fails and the
+ * verdict is not-ready.
+ */
+export function evaluateMetaStrategyReadiness(
+  result: MetaStrategyEvalResult,
+  config: MetaStrategyReadinessConfig = DEFAULT_META_STRATEGY_READINESS_CONFIG
+): ReadinessVerdict {
+  const criteria: ReadinessCriterion[] = [
+    {
+      name: 'volume',
+      met: result.testCount >= config.minTestCases,
+      detail: `${String(result.testCount)} held-out test cases (need ≥ ${String(config.minTestCases)})`,
+    },
+    {
+      name: 'learned-beats-rules',
+      met: result.delta >= config.minDelta,
+      detail: `learned−rules delta ${result.delta.toFixed(2)} (need ≥ ${config.minDelta.toFixed(2)})`,
+    },
+    {
+      name: 'learned-accuracy-floor',
+      met: result.learnedAccuracy >= config.minLearnedAccuracy,
+      detail: `learned accuracy ${pctStr(result.learnedAccuracy)}% (need ≥ ${pctStr(config.minLearnedAccuracy)}%)`,
+    },
+  ];
+
+  const blockers = criteria.filter((c) => !c.met).map((c) => c.name);
+  return { ready: blockers.length === 0, criteria, blockers };
+}


### PR DESCRIPTION
## What
The first shipped increment of epic #4094 (audit→enforce evidence). Activates the orphaned meta-strategy eval (#4095) as the **audit-mode readiness signal** for the #3552 learned-vs-rules routing flip — **without touching routing** (the promotion path is #3552, a separate vote-gated increment).

## How
- **New `orchestration/meta-strategy-readiness.ts`:** pure `evaluateMetaStrategyReadiness(result, config?) → ReadinessVerdict` (reuses the shared #4096 `readiness-verdict` envelope — no new verdict type; mirrors `improvement-enforce-readiness`). Fail-closed, 3 criteria: **volume** (`testCount ≥ 20`), **learned-beats-rules** (`delta ≥ 0.05` margin — a tie stays blocked), **learned-accuracy-floor** (`learnedAccuracy ≥ 0.70`).
- **Corpus 40→80** — exactly 10 per each of the 8 `ExecutionStrategy` labels, 80/80 unique goals (a balance test guards future drift).
- **Non-routing consumer** in `run-tool.ts` `selectDecision`: `logMetaStrategyReadinessOnce` computes + logs the verdict **once per process**, as a separate statement *before* `meta.select` — it **never alters the routed decision** (a test asserts identical routing with/without it). Both `@export-no-consumer-yet` markers removed.

## Honest signal
The real-corpus verdict is currently **NOT ready** (`rules=0.38, learned=0.08, delta=−0.29`): the learned selector loses to rules today, so the gate correctly refuses to signal promotion-readiness. That's exactly the audit-mode evidence #4094 wants — a real gate, not a rubber stamp.

## Verification
`tsc --noEmit` clean · **full package suite 27252 pass (0 failed)** · 24 new/adjacent tests (gate criteria + boundaries + fail-closed + corpus balance + non-routing) · eslint clean · producer/consumer gate clean (run-tool.ts is the real src consumer) · minor changeset. **#3552 promotion path NOT built** (deferred, separate vote).

Refs #4094 #4095 #4096 #3552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)