### PR TITLE
feat(registry): normalized/identity resolution tier for decorated model ids (#4164)

### DIFF
--- a/.changeset/fuzzy-model-id-resolution.md
+++ b/.changeset/fuzzy-model-id-resolution.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': minor
+---
+
+normalized/identity resolution tier for decorated gateway model ids
+
+`ModelRegistry.getEntry` now retries an exact miss with the normalized id
+(reusing `normaliseModelId`) and then identity-matches
+{vendor, family, version} against loaded entries, so OpenAI-compatible
+gateways exposing vendor models under decorated names
+(`Claude_Opus_4.8_hardened`, `2025-claude-opus-4_0_high`) resolve to the
+canonical entry's pricing/metadata instead of bare derivation. Matches grant
+pricing/metadata ONLY — behaviour and request-shaping fields still derive
+from the original id — and carry `matchedVia`/`resolvedFrom` provenance.
+Tier-ordered uniqueness (manifest/in-tree before models-dev/generated) with
+provider-prefix duplicate dedupe; ambiguity fails closed. `hasAuthoritative`
+and `lookupInTreeCapability` stay exact-match.

--- a/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
+++ b/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
@@ -37,6 +37,24 @@ export const MAX_FUZZY_ID_LENGTH = 256;
 const BREADTH_SOURCES: ReadonlySet<ModelEntry['source']> = new Set(['models-dev', 'generated']);
 
 /**
+ * Explicit tier priority (lower = higher). The registry's entry maps
+ * iterate in LOAD order, which is lowest-priority-FIRST (generated →
+ * models-dev → in-tree → manifest), so candidate selection must rank by
+ * source explicitly — never rely on map insertion order.
+ */
+const SOURCE_RANK: Record<ModelEntry['source'], number> = {
+  manifest: 0,
+  'in-tree': 1,
+  'models-dev': 2,
+  generated: 3,
+  derived: 4,
+};
+
+function byTierPriority(a: ModelEntry, b: ModelEntry): number {
+  return SOURCE_RANK[a.source] - SOURCE_RANK[b.source];
+}
+
+/**
  * Canonical comparison key for version strings. Reuses `normaliseModelId`,
  * additionally unifying `.` with `-` so a decorated `4.8` compares equal to
  * the canonical Anthropic-style `4-8`. This is a version-KEY canonicalizer
@@ -89,15 +107,27 @@ function samePricing(a: Pricing, b: Pricing): boolean {
 
 /**
  * Two candidates are "effectively the same model" when their ids normalize
- * to the same canonical id, or when both carry identical pricing — LiteLLM
- * catalogs list the same model under many provider prefixes.
+ * to the same canonical id, or when their pricing AND capability envelope
+ * (contextWindow, maxOutputTokens) are all identical — LiteLLM catalogs
+ * list the same model under many provider prefixes. Identical pricing
+ * ALONE is not sufficient: a GA/preview pair can share a price while
+ * differing on routing-relevant data like the context window.
  */
 function isEffectivelySameModel(a: ModelEntry, b: ModelEntry): boolean {
   if (normaliseModelId(a.id) === normaliseModelId(b.id)) return true;
-  return a.pricing !== undefined && b.pricing !== undefined && samePricing(a.pricing, b.pricing);
+  if (a.pricing === undefined || b.pricing === undefined) return false;
+  return (
+    samePricing(a.pricing, b.pricing) &&
+    a.contextWindow === b.contextWindow &&
+    a.maxOutputTokens === b.maxOutputTokens
+  );
 }
 
-/** Keep the first of each effective-duplicate group (load order = tier order). */
+/**
+ * Keep the first of each effective-duplicate group. Callers pass candidates
+ * already ranked by tier priority, so "first" is the highest-priority
+ * representative of the group.
+ */
 function dedupeEffectiveDuplicates(candidates: readonly ModelEntry[]): readonly ModelEntry[] {
   const kept: ModelEntry[] = [];
   for (const candidate of candidates) {
@@ -123,7 +153,10 @@ export function selectIdentityCandidate(
   candidates: readonly ModelEntry[] | undefined
 ): ModelEntry | undefined {
   if (candidates === undefined) return undefined;
-  const authoritative = candidates.filter((e) => !BREADTH_SOURCES.has(e.source));
+  // Rank by tier priority first (stable sort keeps within-tier load order)
+  // so dedupe keeps the highest-priority representative of each group.
+  const ranked = [...candidates].sort(byTierPriority);
+  const authoritative = ranked.filter((e) => !BREADTH_SOURCES.has(e.source));
   if (authoritative.length > 0) return uniqueCandidate(authoritative);
-  return uniqueCandidate(candidates.filter((e) => BREADTH_SOURCES.has(e.source)));
+  return uniqueCandidate(ranked.filter((e) => BREADTH_SOURCES.has(e.source)));
 }

--- a/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
+++ b/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
@@ -1,0 +1,129 @@
+/**
+ * Identity-index helpers for the ModelRegistry's normalized/identity
+ * resolution tier (#4164).
+ *
+ * OpenAI-compatible gateways frequently expose vendor models under
+ * decorated names (`Claude_Opus_4.8_hardened`, `2025-claude-opus-4_0_high`).
+ * An exact registry lookup misses those, which used to drop the request to
+ * bare derivation — losing pricing/metadata the registry actually has for
+ * the underlying model. This module supplies the second-chance machinery:
+ *
+ *   - a load-time `vendor|family|version` index over loaded entries (built
+ *     once, never per-request O(N) scans),
+ *   - tier-ordered candidate selection (manifest/in-tree before
+ *     models-dev/generated) with effective-duplicate dedupe, failing CLOSED
+ *     when more than one distinct candidate survives.
+ *
+ * The registry itself (model-registry.ts) owns the merge semantics —
+ * matched entries grant PRICING/METADATA ONLY; behaviour fields still come
+ * from derivation for the original decorated id.
+ *
+ * @module config/model-fuzzy-resolution
+ */
+
+import { normaliseModelId, resolveModelIdentitySync } from './model-identity.js';
+import type { ResolvedModelIdentity } from './model-identity.js';
+import type { ModelEntry } from './model-registry.js';
+import type { Pricing } from './model-capabilities-types.js';
+
+/**
+ * Ids longer than this skip the fuzzy tier entirely (straight to
+ * derivation). Guards the normalizer/regex parses against pathological
+ * inputs; checked BEFORE normalization.
+ */
+export const MAX_FUZZY_ID_LENGTH = 256;
+
+/** Breadth catalog tiers — searched only when no authoritative tier matches. */
+const BREADTH_SOURCES: ReadonlySet<ModelEntry['source']> = new Set(['models-dev', 'generated']);
+
+/**
+ * Canonical comparison key for version strings. Reuses `normaliseModelId`,
+ * additionally unifying `.` with `-` so a decorated `4.8` compares equal to
+ * the canonical Anthropic-style `4-8`. This is a version-KEY canonicalizer
+ * only — id normalization stays `normaliseModelId` verbatim.
+ */
+function versionKey(version: string): string {
+  return normaliseModelId(version).replace(/\./g, '-');
+}
+
+/** Entry-side version: the stored field, else best-effort parse of the id. */
+function entryVersion(entry: ModelEntry): string | undefined {
+  return entry.version ?? resolveModelIdentitySync(entry.id).version;
+}
+
+/**
+ * `vendor|family|version` index key, or undefined when the identity cannot
+ * participate in identity matching: version is REQUIRED on both sides, and
+ * the `unknown` vendor/family sentinels never match anything.
+ */
+export function identityKeyFor(
+  identity: Pick<ResolvedModelIdentity, 'vendor' | 'family' | 'version'>
+): string | undefined {
+  if (identity.vendor === 'unknown' || identity.family === 'unknown') return undefined;
+  if (identity.version === undefined) return undefined;
+  return `${identity.vendor}|${identity.family}|${versionKey(identity.version)}`;
+}
+
+/**
+ * Build the identity index over loaded entries. Called ONCE (lazily, on the
+ * first fuzzy lookup) — the registry's entry maps are immutable after
+ * construction, so the index never goes stale.
+ */
+export function buildIdentityIndex(entries: Iterable<ModelEntry>): Map<string, ModelEntry[]> {
+  const index = new Map<string, ModelEntry[]>();
+  for (const entry of entries) {
+    const version = entryVersion(entry);
+    if (version === undefined) continue;
+    const key = identityKeyFor({ vendor: entry.vendor, family: entry.family, version });
+    if (key === undefined) continue;
+    const bucket = index.get(key);
+    if (bucket === undefined) index.set(key, [entry]);
+    else bucket.push(entry);
+  }
+  return index;
+}
+
+function samePricing(a: Pricing, b: Pricing): boolean {
+  return a.inputPer1M === b.inputPer1M && a.outputPer1M === b.outputPer1M;
+}
+
+/**
+ * Two candidates are "effectively the same model" when their ids normalize
+ * to the same canonical id, or when both carry identical pricing — LiteLLM
+ * catalogs list the same model under many provider prefixes.
+ */
+function isEffectivelySameModel(a: ModelEntry, b: ModelEntry): boolean {
+  if (normaliseModelId(a.id) === normaliseModelId(b.id)) return true;
+  return a.pricing !== undefined && b.pricing !== undefined && samePricing(a.pricing, b.pricing);
+}
+
+/** Keep the first of each effective-duplicate group (load order = tier order). */
+function dedupeEffectiveDuplicates(candidates: readonly ModelEntry[]): readonly ModelEntry[] {
+  const kept: ModelEntry[] = [];
+  for (const candidate of candidates) {
+    if (!kept.some((k) => isEffectivelySameModel(k, candidate))) kept.push(candidate);
+  }
+  return kept;
+}
+
+/** Unique candidate from one tier bucket, or undefined (fail closed on >1). */
+function uniqueCandidate(candidates: readonly ModelEntry[]): ModelEntry | undefined {
+  const distinct = dedupeEffectiveDuplicates(candidates);
+  return distinct.length === 1 ? distinct[0] : undefined;
+}
+
+/**
+ * Tier-ordered uniqueness: manifest/in-tree candidates are considered
+ * first; only when that bucket is EMPTY do the breadth tiers
+ * (models-dev/generated) get a look. Within a bucket, effective duplicates
+ * are collapsed before ambiguity is declared; if more than one distinct
+ * candidate survives, fail closed (no match) rather than guess.
+ */
+export function selectIdentityCandidate(
+  candidates: readonly ModelEntry[] | undefined
+): ModelEntry | undefined {
+  if (candidates === undefined) return undefined;
+  const authoritative = candidates.filter((e) => !BREADTH_SOURCES.has(e.source));
+  if (authoritative.length > 0) return uniqueCandidate(authoritative);
+  return uniqueCandidate(candidates.filter((e) => BREADTH_SOURCES.has(e.source)));
+}

--- a/packages/nexus-agents/src/config/model-identity.ts
+++ b/packages/nexus-agents/src/config/model-identity.ts
@@ -253,8 +253,11 @@ export function parseModelId(modelId: string): ParseResult {
  * Lowercase + replace `_` and `/` with `-` so word boundaries land on
  * the real model-name tokens. Collapses runs of `-` so we don't get
  * empty tokens from `--`.
+ *
+ * Exported (#4164) so the ModelRegistry's normalized-retry tier reuses
+ * THIS normalizer for decorated gateway ids — do not add another one.
  */
-function normaliseModelId(modelId: string): string {
+export function normaliseModelId(modelId: string): string {
   return modelId.toLowerCase().replace(/[_/]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 

--- a/packages/nexus-agents/src/config/model-registry.test.ts
+++ b/packages/nexus-agents/src/config/model-registry.test.ts
@@ -420,6 +420,7 @@ const opus48Canonical: ModelEntry = {
   unsupportedParameters: ['temperature'],
   maxTokensParam: 'max_completion_tokens',
   source: 'in-tree',
+  verifiedAt: '2026-01-01',
 };
 
 const opus40Snapshot: ModelEntry = {
@@ -551,6 +552,8 @@ describe('ModelRegistry — identity resolution tier (#4164)', () => {
     expect(entry.cliAlias).toBeUndefined();
     expect(entry.cliModelName).toBeUndefined();
     expect(entry.aliases).toBeUndefined();
+    // verifiedAt attests the CANONICAL entry, not this decorated derivation.
+    expect(entry.verifiedAt).toBeUndefined();
   });
 
   it('does not mutate the stored canonical entry (returns a copy)', () => {
@@ -632,6 +635,70 @@ describe('ModelRegistry — identity resolution tier (#4164)', () => {
     const entry = reg.getEntry('Claude_Opus_4.8_hardened');
     expect(entry.resolvedFrom).toBe('claude-opus-4-8');
     expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+
+  it('tier order: a MANIFEST effective-duplicate beats its in-tree twin', () => {
+    // Effective duplicates (identical pricing + contextWindow +
+    // maxOutputTokens) across the authoritative bucket: the manifest
+    // (operator) entry must win — the registry's maps iterate
+    // lowest-priority-first, so selection must NOT rely on insertion order.
+    const manifestTwin: ModelEntry = {
+      ...opus48Canonical,
+      id: 'operator/claude-opus-4-8',
+      aliases: [],
+      displayName: 'Operator Opus 4.8',
+      source: 'manifest',
+    };
+    const reg = new ModelRegistry({
+      inTreeEntries: [opus48Canonical],
+      manifestEntries: [manifestTwin],
+    });
+    const entry = reg.getEntry('Claude_Opus_4.8_hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('operator/claude-opus-4-8');
+    expect(entry.displayName).toBe('Operator Opus 4.8');
+  });
+
+  it('tier order: a models-dev effective-duplicate beats its generated twin', () => {
+    const generatedTwin: ModelEntry = {
+      ...opus40Snapshot,
+      id: 'litellm/claude-opus-4-0',
+      displayName: 'LiteLLM Opus 4.0',
+      source: 'generated',
+    };
+    const reg = new ModelRegistry({
+      modelsDevEntries: [opus40Snapshot],
+      generatedEntries: [generatedTwin],
+    });
+    const entry = reg.getEntry('claude-opus-4.0-hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('claude-opus-4-0');
+    expect(entry.displayName).toBe('Claude Opus 4 (latest)');
+  });
+
+  it('fails closed for same-price DISTINCT models (different context windows)', () => {
+    // Identical pricing alone must not collapse a GA/preview pair whose
+    // routing-relevant capability data (contextWindow) differs.
+    const ga: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9',
+      version: '4-9',
+      aliases: [],
+      contextWindow: 200_000,
+    };
+    const preview: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9-preview',
+      version: '4-9',
+      aliases: [],
+      contextWindow: 1_000_000,
+    };
+    const reg = new ModelRegistry({ inTreeEntries: [ga, preview] });
+    const entry = reg.getEntry('claude-opus-4.9-hardened');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.resolvedFrom).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+    expect(entry.source).toBe('derived');
   });
 
   it('falls back to the generated tier only when no authoritative candidate exists', () => {

--- a/packages/nexus-agents/src/config/model-registry.test.ts
+++ b/packages/nexus-agents/src/config/model-registry.test.ts
@@ -13,7 +13,11 @@ import {
   type ModelEntry,
 } from './model-registry.js';
 import { resolveModelIdentitySync } from './model-identity.js';
-import { getDefaultModelForCli, getInTreeCapabilitiesMatrix } from './model-config-helpers.js';
+import {
+  getDefaultModelForCli,
+  getInTreeCapabilitiesMatrix,
+  lookupInTreeCapability,
+} from './model-config-helpers.js';
 
 const sampleAuthoritative: ModelEntry = {
   id: 'claude-opus-4-1',
@@ -377,6 +381,316 @@ models:
       setDefaultRegistry(undefined);
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ============================================================================
+// #4164 — normalized/identity resolution tier for decorated gateway model ids.
+// OpenAI-compatible gateways expose vendor models under decorated names
+// (`Claude_Opus_4.8_hardened`, `2025-claude-opus-4_0_high`); on exact miss the
+// registry retries with the normalized id, then identity-matches
+// {vendor, family, version} against loaded entries. Matches grant
+// PRICING/METADATA ONLY — behaviour fields still come from derivation.
+// ============================================================================
+
+/**
+ * Canonical entry with deliberately UNUSUAL behaviour values so tests can
+ * prove the fuzzy tier does NOT inherit them (derived values must win).
+ */
+const opus48Canonical: ModelEntry = {
+  id: 'claude-opus-4-8',
+  aliases: ['claude-opus-48-latest'],
+  vendor: 'anthropic',
+  family: 'claude-opus',
+  version: '4-8',
+  displayName: 'Claude Opus 4.8',
+  contextWindow: 1_000_000,
+  maxOutputTokens: 128_000,
+  pricing: { inputPer1M: 5, outputPer1M: 25 },
+  parallelToolCalls: false, // derived for anthropic: true
+  promptCaching: 'none', // derived for anthropic: 'ephemeral'
+  toolDefinitionFormat: 'openai', // derived for anthropic: 'anthropic'
+  maxRecommendedTurnBudget: 99, // derived for claude-opus: 20
+  strictJson: false, // derived: true
+  quirks: ['matched-entry-quirk'],
+  profileId: 'matched-entry-profile', // derived: 'claude-opus'
+  cliName: 'claude',
+  cliAlias: 'opus-48',
+  cliModelName: 'claude-opus-4-8',
+  unsupportedParameters: ['temperature'],
+  maxTokensParam: 'max_completion_tokens',
+  source: 'in-tree',
+};
+
+const opus40Snapshot: ModelEntry = {
+  id: 'claude-opus-4-0',
+  vendor: 'anthropic',
+  family: 'claude-opus',
+  version: '4-0',
+  displayName: 'Claude Opus 4 (latest)',
+  contextWindow: 200_000,
+  maxOutputTokens: 32_000,
+  pricing: { inputPer1M: 15, outputPer1M: 75 },
+  parallelToolCalls: false,
+  promptCaching: 'none',
+  toolDefinitionFormat: 'openai',
+  maxRecommendedTurnBudget: 10,
+  strictJson: true,
+  quirks: [],
+  profileId: 'models-dev-anthropic',
+  source: 'models-dev',
+};
+
+const haikuVersionless: ModelEntry = {
+  id: 'claude-haiku',
+  vendor: 'anthropic',
+  family: 'claude-haiku',
+  pricing: { inputPer1M: 1, outputPer1M: 5 },
+  parallelToolCalls: true,
+  promptCaching: 'ephemeral',
+  toolDefinitionFormat: 'anthropic',
+  maxRecommendedTurnBudget: 8,
+  strictJson: true,
+  quirks: [],
+  profileId: 'claude-haiku',
+  source: 'in-tree',
+};
+
+function generatedOpus48(
+  id: string,
+  pricing: { inputPer1M: number; outputPer1M: number }
+): ModelEntry {
+  return {
+    id,
+    vendor: 'anthropic',
+    family: 'claude-opus',
+    version: '4-8',
+    pricing,
+    contextWindow: 500_000,
+    parallelToolCalls: false,
+    promptCaching: 'none',
+    toolDefinitionFormat: 'openai',
+    maxRecommendedTurnBudget: 10,
+    strictJson: true,
+    quirks: [],
+    profileId: 'litellm-derived',
+    source: 'generated',
+  };
+}
+
+describe('ModelRegistry — normalized resolution tier (#4164)', () => {
+  it('resolves a case/underscore-decorated exact id via the normalized id', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const entry = reg.getEntry('Claude_Opus_4-8');
+    expect(entry.id).toBe('Claude_Opus_4-8'); // caller's id preserved
+    expect(entry.matchedVia).toBe('normalized');
+    expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+    expect(entry.contextWindow).toBe(1_000_000);
+    expect(entry.source).toBe('derived');
+  });
+
+  it('resolves a decorated ALIAS via the normalized id (alias + alias-shadow keep working)', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const entry = reg.getEntry('Claude_Opus_48-Latest');
+    expect(entry.matchedVia).toBe('normalized');
+    expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+});
+
+describe('ModelRegistry — identity resolution tier (#4164)', () => {
+  it.each(['Claude_Opus_4.8_hardened', 'claude-opus-4.8-hardened'])(
+    'resolves decorated id %s to the canonical entry pricing/metadata',
+    (decorated) => {
+      const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+      const entry = reg.getEntry(decorated);
+      expect(entry.id).toBe(decorated); // caller's id preserved
+      expect(entry.matchedVia).toBe('identity');
+      expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+      expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+      expect(entry.contextWindow).toBe(1_000_000);
+      expect(entry.maxOutputTokens).toBe(128_000);
+      expect(entry.displayName).toBe('Claude Opus 4.8');
+      expect(entry.source).toBe('derived');
+    }
+  );
+
+  it('resolves 2025-claude-opus-4_0_high against a breadth-tier entry (merged, never raw)', () => {
+    const reg = new ModelRegistry({ modelsDevEntries: [opus40Snapshot] });
+    const entry = reg.getEntry('2025-claude-opus-4_0_high');
+    expect(entry.id).toBe('2025-claude-opus-4_0_high');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('claude-opus-4-0');
+    expect(entry.pricing).toEqual({ inputPer1M: 15, outputPer1M: 75 });
+    // #3293 semantics: breadth-tier data merges with derivation — behaviour
+    // fields must be the derived anthropic/claude-opus values, not the
+    // snapshot's, and the source is non-authoritative.
+    expect(entry.source).toBe('derived');
+    expect(entry.toolDefinitionFormat).toBe('anthropic');
+    expect(entry.profileId).toBe('claude-opus');
+    expect(entry.quirks).toContain('high-variant');
+  });
+
+  it('grants pricing/metadata ONLY — behaviour fields come from derivation for the original id', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const entry = reg.getEntry('Claude_Opus_4.8_hardened');
+    // Derived anthropic/claude-opus behaviour wins over the matched entry's
+    // unusual values.
+    expect(entry.parallelToolCalls).toBe(true);
+    expect(entry.promptCaching).toBe('ephemeral');
+    expect(entry.toolDefinitionFormat).toBe('anthropic');
+    expect(entry.maxRecommendedTurnBudget).toBe(20);
+    expect(entry.strictJson).toBe(true);
+    expect(entry.profileId).toBe('claude-opus');
+    expect(entry.quirks).not.toContain('matched-entry-quirk');
+    // Request-shaping + routing fields are NOT inherited either.
+    expect(entry.unsupportedParameters).toBeUndefined();
+    expect(entry.maxTokensParam).toBeUndefined();
+    expect(entry.cliName).toBeUndefined();
+    expect(entry.cliAlias).toBeUndefined();
+    expect(entry.cliModelName).toBeUndefined();
+    expect(entry.aliases).toBeUndefined();
+  });
+
+  it('does not mutate the stored canonical entry (returns a copy)', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    reg.getEntry('Claude_Opus_4.8_hardened');
+    const canonical = reg.getEntry('claude-opus-4-8');
+    expect(canonical.id).toBe('claude-opus-4-8');
+    expect(canonical.matchedVia).toBeUndefined();
+    expect(canonical.resolvedFrom).toBeUndefined();
+    expect(canonical.maxRecommendedTurnBudget).toBe(99);
+  });
+
+  it('version-less decorated id falls to derivation with no pricing', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [haikuVersionless] });
+    const entry = reg.getEntry('claude-haiku-hardened');
+    expect(entry.source).toBe('derived');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.resolvedFrom).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+  });
+
+  it('fails closed when two distinct canonical models share vendor+family+version', () => {
+    const a: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9',
+      version: '4-9',
+      aliases: [],
+    };
+    const b: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9-preview',
+      version: '4-9',
+      aliases: [],
+      pricing: { inputPer1M: 7, outputPer1M: 35 },
+    };
+    const reg = new ModelRegistry({ inTreeEntries: [a, b] });
+    const entry = reg.getEntry('claude_opus_4.9_hardened');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.resolvedFrom).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+    expect(entry.source).toBe('derived');
+  });
+
+  it('dedupes provider-prefixed duplicates with identical pricing before declaring ambiguity', () => {
+    const reg = new ModelRegistry({
+      generatedEntries: [
+        generatedOpus48('anthropic/claude-opus-4-8', { inputPer1M: 5, outputPer1M: 25 }),
+        generatedOpus48('gateway-x/anthropic.claude-opus-4-8-v1', {
+          inputPer1M: 5,
+          outputPer1M: 25,
+        }),
+      ],
+    });
+    const entry = reg.getEntry('claude-opus-4.8-hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+
+  it('dedupes candidates whose ids normalize to the same canonical id', () => {
+    const reg = new ModelRegistry({
+      generatedEntries: [
+        generatedOpus48('anthropic/claude-opus-4-8', { inputPer1M: 5, outputPer1M: 25 }),
+        generatedOpus48('anthropic_claude-opus-4-8', { inputPer1M: 9, outputPer1M: 99 }),
+      ],
+    });
+    const entry = reg.getEntry('claude-opus-4.8-hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('anthropic/claude-opus-4-8');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+
+  it('tier order: manifest/in-tree candidate beats a generated-tier candidate', () => {
+    const reg = new ModelRegistry({
+      inTreeEntries: [opus48Canonical],
+      generatedEntries: [
+        generatedOpus48('gateway/claude-opus-4-8', { inputPer1M: 1, outputPer1M: 2 }),
+      ],
+    });
+    const entry = reg.getEntry('Claude_Opus_4.8_hardened');
+    expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+
+  it('falls back to the generated tier only when no authoritative candidate exists', () => {
+    const reg = new ModelRegistry({
+      generatedEntries: [
+        generatedOpus48('gateway/claude-opus-4-8', { inputPer1M: 1, outputPer1M: 2 }),
+      ],
+    });
+    const entry = reg.getEntry('Claude_Opus_4.8_hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('gateway/claude-opus-4-8');
+    expect(entry.pricing).toEqual({ inputPer1M: 1, outputPer1M: 2 });
+    // Breadth-tier match still merges with derivation (never returned raw).
+    expect(entry.source).toBe('derived');
+    expect(entry.toolDefinitionFormat).toBe('anthropic');
+  });
+
+  it('ids longer than 256 chars skip the fuzzy tier entirely (no crash)', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const longId = `claude-opus-4-8-${'h'.repeat(300)}`;
+    const entry = reg.getEntry(longId);
+    expect(entry.id).toBe(longId);
+    expect(entry.source).toBe('derived');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+  });
+});
+
+describe('ModelRegistry — exact-match surfaces stay exact (#4164)', () => {
+  it('hasAuthoritative stays false for decorated ids that only fuzzy-match', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    expect(reg.hasAuthoritative('claude-opus-4-8')).toBe(true);
+    expect(reg.hasAuthoritative('Claude_Opus_4-8')).toBe(false);
+    expect(reg.hasAuthoritative('Claude_Opus_4.8_hardened')).toBe(false);
+  });
+
+  it('lookupInTreeCapability stays undefined for decorated ids', () => {
+    setDefaultRegistry(undefined);
+    try {
+      expect(lookupInTreeCapability('claude-opus')).toBeDefined(); // regression
+      expect(lookupInTreeCapability('CLAUDE-OPUS')).toBeUndefined();
+      expect(lookupInTreeCapability('Claude_Opus_4.8_hardened')).toBeUndefined();
+    } finally {
+      setDefaultRegistry(undefined);
+    }
+  });
+
+  it('exact and alias matches are completely unaffected (regression)', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const exact = reg.getEntry('claude-opus-4-8');
+    expect(exact.source).toBe('in-tree');
+    expect(exact.matchedVia).toBeUndefined();
+    expect(exact.resolvedFrom).toBeUndefined();
+    expect(exact.maxRecommendedTurnBudget).toBe(99); // authoritative values untouched
+    expect(exact.unsupportedParameters).toEqual(['temperature']);
+    const viaAlias = reg.getEntry('claude-opus-48-latest');
+    expect(viaAlias.id).toBe('claude-opus-4-8');
+    expect(viaAlias.source).toBe('in-tree');
+    expect(viaAlias.matchedVia).toBeUndefined();
   });
 });
 

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -39,7 +39,18 @@
  * @module config/model-registry
  */
 
-import { resolveModelIdentitySync, type ModelHints, type ModelVendor } from './model-identity.js';
+import {
+  normaliseModelId,
+  resolveModelIdentitySync,
+  type ModelHints,
+  type ModelVendor,
+} from './model-identity.js';
+import {
+  MAX_FUZZY_ID_LENGTH,
+  buildIdentityIndex,
+  identityKeyFor,
+  selectIdentityCandidate,
+} from './model-fuzzy-resolution.js';
 import { buildInTreeEntries } from './in-tree-entries.js';
 import { loadManifestOverlay } from './manifest-overlay.js';
 import { DEFAULT_ENTRY, deriveEntry } from './model-derivation.js';
@@ -82,6 +93,14 @@ export type PromptCachingMode = 'none' | 'ephemeral' | 'aggressive';
  * ones field-by-field; `derived` is always the fallback floor.
  */
 export type EntrySource = 'in-tree' | 'models-dev' | 'manifest' | 'derived' | 'generated';
+
+/**
+ * How the normalized/identity resolution tier (#4164) found a canonical
+ * entry for a decorated gateway model id: `'normalized'` — the id matched
+ * an entry/alias after `normaliseModelId`; `'identity'` — the parsed
+ * {vendor, family, version} matched exactly one loaded entry.
+ */
+export type MatchedVia = 'normalized' | 'identity';
 
 /**
  * One model's full metadata. Combines what was previously split
@@ -158,6 +177,14 @@ export interface ModelEntry {
   readonly source: EntrySource;
   /** ISO date when this entry was last validated against the upstream. */
   readonly verifiedAt?: string;
+  /**
+   * Set when the normalized/identity resolution tier (#4164) matched this
+   * (decorated) id to a canonical entry. Absent for exact/alias hits and
+   * pure derivation.
+   */
+  readonly matchedVia?: MatchedVia;
+  /** Canonical id of the matched entry the pricing/metadata came from. */
+  readonly resolvedFrom?: string;
 }
 
 // Derivation (DEFAULT_ENTRY, VENDOR_DEFAULTS, FAMILY_DEFAULTS, deriveEntry)
@@ -192,6 +219,13 @@ export interface ModelRegistryOptions {
 export class ModelRegistry {
   private readonly byId = new Map<string, ModelEntry>();
   private readonly byAlias = new Map<string, string>(); // alias → canonical id
+  /**
+   * `vendor|family|version` → candidate entries, for the identity tier
+   * (#4164). Built ONCE, lazily on the first fuzzy lookup — the entry maps
+   * are immutable after construction, so it never goes stale. No caching of
+   * UNMATCHED ids happens anywhere (the index only holds loaded entries).
+   */
+  private identityIndex: Map<string, ModelEntry[]> | undefined;
 
   constructor(options: ModelRegistryOptions = {}) {
     // Load order: lowest priority first; later sources overwrite.
@@ -212,6 +246,10 @@ export class ModelRegistry {
   /**
    * Resolve a model id to its full metadata entry. Always returns —
    * unknown models get a derived entry with sensible defaults.
+   *
+   * On exact miss, the normalized/identity resolution tier (#4164) runs
+   * BEFORE derivation so decorated gateway ids (`Claude_Opus_4.8_hardened`)
+   * still pick up the canonical entry's pricing/metadata.
    */
   getEntry(modelId: string, hints?: ModelHints): ModelEntry {
     const direct = this.lookupExact(modelId);
@@ -220,6 +258,10 @@ export class ModelRegistry {
     // authoritative and return directly). (#3293)
     if (direct !== undefined && direct.source !== 'models-dev' && direct.source !== 'generated') {
       return direct;
+    }
+    if (direct === undefined) {
+      const fuzzy = this.lookupFuzzy(modelId, hints);
+      if (fuzzy !== undefined) return fuzzy;
     }
 
     const identity = resolveModelIdentitySync(modelId, augmentHints(hints, direct));
@@ -259,6 +301,46 @@ export class ModelRegistry {
     const canonical = this.byAlias.get(modelId);
     if (canonical !== undefined) return this.byId.get(canonical);
     return undefined;
+  }
+
+  /**
+   * Normalized/identity resolution tier (#4164). Runs on exact miss only:
+   * (a) retry `lookupExact` with the `normaliseModelId`-normalized id so
+   *     aliases + alias-shadow (#3293) keep working;
+   * (b) identity-match {vendor, family, version} against the load-time
+   *     index — version required on both sides, tier-ordered uniqueness,
+   *     fail closed on ambiguity (see model-fuzzy-resolution.ts).
+   * Over-long ids skip the tier entirely (straight to derivation).
+   */
+  private lookupFuzzy(modelId: string, hints?: ModelHints): ModelEntry | undefined {
+    if (modelId.length > MAX_FUZZY_ID_LENGTH) return undefined;
+    const normalized = normaliseModelId(modelId);
+    const byNormalized = normalized === modelId ? undefined : this.lookupExact(normalized);
+    if (byNormalized !== undefined) {
+      return this.resolveMatched(byNormalized, modelId, hints, 'normalized');
+    }
+    const key = identityKeyFor(resolveModelIdentitySync(modelId, hints));
+    if (key === undefined) return undefined;
+    this.identityIndex ??= buildIdentityIndex(this.byId.values());
+    const matched = selectIdentityCandidate(this.identityIndex.get(key));
+    if (matched === undefined) return undefined;
+    return this.resolveMatched(matched, modelId, hints, 'identity');
+  }
+
+  /**
+   * Build the entry returned for a fuzzy match: a fresh COPY that keeps the
+   * CALLER'S id and takes behaviour from derivation for that original id —
+   * the matched entry grants pricing/metadata only.
+   */
+  private resolveMatched(
+    matched: ModelEntry,
+    modelId: string,
+    hints: ModelHints | undefined,
+    matchedVia: MatchedVia
+  ): ModelEntry {
+    const identity = resolveModelIdentitySync(modelId, augmentHints(hints, matched));
+    const derived = deriveEntry(modelId, identity);
+    return mergeMatchedWithDerived(matched, derived, matchedVia);
   }
 
   private loadEntries(entries: readonly ModelEntry[]): void {
@@ -310,6 +392,40 @@ function mergeSnapshotWithDerived(snapshot: ModelEntry, derived: ModelEntry): Mo
     profileId: derived.profileId,
     source: 'derived',
   };
+}
+
+/**
+ * Merge for the normalized/identity resolution tier (#4164) — extends the
+ * #3293 `mergeSnapshotWithDerived` semantics: capability/metadata (pricing,
+ * contextWindow, maxOutputTokens, displayName, modalities, quality) come
+ * from the matched canonical entry, behaviour fields from the derived entry
+ * for the ORIGINAL decorated id. On top of that base merge it:
+ *   - keeps the CALLER'S id (and its parsed version) — not the canonical's,
+ *   - withholds fields outside the pricing/metadata grant: alias/CLI routing
+ *     belongs to the canonical entry, and request-shaping fields
+ *     (unsupportedParameters, maxTokensParam) must follow the original id,
+ *   - stamps `matchedVia` + `resolvedFrom` provenance.
+ * Always returns a fresh object — stored entries are never mutated.
+ */
+function mergeMatchedWithDerived(
+  matched: ModelEntry,
+  derived: ModelEntry,
+  matchedVia: MatchedVia
+): ModelEntry {
+  const merged: { -readonly [K in keyof ModelEntry]?: ModelEntry[K] } = {
+    ...mergeSnapshotWithDerived(matched, derived),
+  };
+  delete merged.aliases;
+  delete merged.cliName;
+  delete merged.cliAlias;
+  delete merged.cliModelName;
+  delete merged.unsupportedParameters;
+  delete merged.maxTokensParam;
+  merged.id = derived.id;
+  if (derived.version !== undefined) merged.version = derived.version;
+  merged.matchedVia = matchedVia;
+  merged.resolvedFrom = matched.id;
+  return merged as ModelEntry;
 }
 
 // Re-export the derivation surface so existing consumers keep working

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -402,8 +402,9 @@ function mergeSnapshotWithDerived(snapshot: ModelEntry, derived: ModelEntry): Mo
  * for the ORIGINAL decorated id. On top of that base merge it:
  *   - keeps the CALLER'S id (and its parsed version) — not the canonical's,
  *   - withholds fields outside the pricing/metadata grant: alias/CLI routing
- *     belongs to the canonical entry, and request-shaping fields
+ *     belongs to the canonical entry, request-shaping fields
  *     (unsupportedParameters, maxTokensParam) must follow the original id,
+ *     and `verifiedAt` attests the canonical entry — not this derivation,
  *   - stamps `matchedVia` + `resolvedFrom` provenance.
  * Always returns a fresh object — stored entries are never mutated.
  */
@@ -421,6 +422,7 @@ function mergeMatchedWithDerived(
   delete merged.cliModelName;
   delete merged.unsupportedParameters;
   delete merged.maxTokensParam;
+  delete merged.verifiedAt;
   merged.id = derived.id;
   if (derived.version !== undefined) merged.version = derived.version;
   merged.matchedVia = matchedVia;


### PR DESCRIPTION
## What

Adds a normalized/identity resolution tier to `ModelRegistry.getEntry` (#4164, child 1 of epic #4163). On exact miss, BEFORE derivation:

1. **Normalized retry** — the id is re-looked-up through `lookupExact` after `normaliseModelId` (now exported from `model-identity.ts`; reused verbatim, no second normalizer), so decorated ids that normalize to a known id/alias resolve — alias + alias-shadow (#3293) semantics keep working.
2. **Identity match** — `resolveModelIdentitySync(modelId)`'s `{vendor, family, version}` is matched against a load-time `vendor|family|version` index over loaded entries. Version is REQUIRED on both sides and compared under the same normalization (with `.`/`-` separator unification so a decorated `4.8` matches the canonical `4-8`). Tier-ordered uniqueness: manifest/in-tree candidates are considered before models-dev/generated; effective duplicates (same normalized canonical id, or identical pricing — LiteLLM provider-prefixed clones) are collapsed before ambiguity is declared; >1 distinct survivor fails CLOSED to derivation.

## Why

OpenAI-compatible gateways expose vendor models under decorated names (`Claude_Opus_4.8_hardened`, `claude-opus-4.8-hardened`, `2025-claude-opus-4_0_high`). Previously these fell straight to pattern derivation and lost the pricing/context-window/display metadata the registry already has for the canonical model.

## Semantics (vote-gated conditions)

- Matches grant **PRICING/METADATA ONLY**: pricing, contextWindow, maxOutputTokens, displayName (+ modalities/quality) come from the matched entry; behaviour fields (parallelToolCalls, promptCaching, toolDefinitionFormat, maxRecommendedTurnBudget, strictJson, quirks, profileId) and `unsupportedParameters`/`maxTokensParam` come from `deriveEntry` for the ORIGINAL decorated id, via an extension of the existing `mergeSnapshotWithDerived` (#3293) path — breadth-tier matches are never returned raw.
- Returned entry keeps the CALLER'S id, is stamped `source: 'derived'`, carries new provenance fields `matchedVia: 'normalized' | 'identity'` and `resolvedFrom` (canonical id), and is always a fresh copy — stored entries are never mutated.
- `hasAuthoritative` and `lookupInTreeCapability` stay EXACT-match (covered by tests).
- Hardening: ids >256 chars skip the fuzzy tier entirely; the identity index is built ONCE (lazily on first fuzzy lookup — entry maps are immutable post-construction); no levenshtein; no memoization of unmatched ids.

## Tests

New coverage in `src/config/model-registry.test.ts` (16 new cases):

- decorated fixtures (`Claude_Opus_4.8_hardened`, `claude-opus-4.8-hardened`, `2025-claude-opus-4_0_high`) resolve with pricing + `matchedVia` + `resolvedFrom`, caller's id preserved
- normalized-tier hits on exact ids AND aliases
- version-less id (`claude-haiku-hardened`) → no fuzzy match, falls to derivation
- ambiguity (two distinct models sharing vendor+family+version) → fail closed
- tier order: in-tree beats generated; breadth fallback merges with derivation (never raw)
- behaviour fields / unsupportedParameters / CLI routing NOT inherited from the matched entry (matched entry constructed with unusual behaviour values; derived values win)
- >256-char id → derivation, no crash; stored entries not mutated
- `hasAuthoritative` / `lookupInTreeCapability` unchanged for decorated ids; exact + alias regression

## Gates

- `pnpm -w turbo run typecheck --filter=nexus-agents` — pass
- `pnpm lint` — pass (helpers kept small; complexity ≤10, ≤50 lines/function)
- `pnpm test` (full package suite) — pass
- `npx tsx scripts/check-new-unused-exports.ts origin/main` — pass (new `model-fuzzy-resolution.ts` is consumed by `model-registry.ts`)
- changeset added (minor, nexus-agents)

Closes #4164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
