### PR TITLE
fix(cost): compute cost from full model registry; unpriced is unmeasured, never $0 (#4165)

### DIFF
--- a/.changeset/full-registry-cost-unmeasured.md
+++ b/.changeset/full-registry-cost-unmeasured.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': minor
+---
+
+compute cost from the full model registry; unpriced is unmeasured, never $0
+
+`computeCostUSD` now reads pricing via `getDefaultRegistry().getEntry()` —
+the full chain (manifest > in-tree > models.dev > generated LiteLLM catalog),
+including the #4164 normalized/identity resolution tier — instead of the
+in-tree tier only, so long-tail catalog models and decorated model names from
+OpenAI-compatible gateways price correctly. New `computeCostDetail` returns
+`{costUsd, priced, resolvedId, matchedVia?}`; `computeCostUSD` is a thin
+wrapper (public API unchanged). `votesToCostInputs` omits `costUsd` for
+unpriced models (tokens kept) and `rollupDecisionCost` now counts a voter
+without a computable cost as UNMEASURED (#3855 semantics) — a missing price
+is never recorded as a measured $0. `UsageEvent` gains optional
+`priced`/`priceSource` provenance fields so audit can distinguish a real $0
+from an unpriced model.

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -30,7 +30,7 @@ import type {
 } from '../core/index.js';
 import { ok, err, ConfigError, getErrorMessage, getTimeProvider } from '../core/index.js';
 import { OpenAIAdapter } from './openai-adapter.js';
-import { recordUsageEvent, computeCostUSD } from '../learning/usage-log.js';
+import { recordUsageEvent, computeCostDetail } from '../learning/usage-log.js';
 import { readOpencodeGateway } from '../config/opencode-bridge.js';
 
 export interface OpenAICompatConfig {
@@ -155,15 +155,20 @@ function withUsageRecording(inner: IModelAdapter): IModelAdapter {
       try {
         if (result.ok) {
           const u = result.value.usage;
+          // Full-registry pricing with provenance (#4165): `priced: false`
+          // marks the $0 as UNPRICED (unmeasured), not a real $0.
+          const cost = computeCostDetail(inner.modelId, u.inputTokens, u.outputTokens);
           recordUsageEvent({
             timestamp: new Date().toISOString(),
             modelId: inner.modelId,
             providerId: inner.providerId,
             inputTokens: u.inputTokens,
             outputTokens: u.outputTokens,
-            usdCost: computeCostUSD(inner.modelId, u.inputTokens, u.outputTokens),
+            usdCost: cost.costUsd,
             latencyMs,
             success: true,
+            priced: cost.priced,
+            ...(cost.priced ? { priceSource: cost.resolvedId } : {}),
           });
         } else {
           recordUsageEvent({

--- a/packages/nexus-agents/src/learning/usage-log.test.ts
+++ b/packages/nexus-agents/src/learning/usage-log.test.ts
@@ -9,6 +9,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  ModelRegistry,
+  peekDefaultRegistry,
+  setDefaultRegistry,
+  type ModelEntry,
+} from '../config/model-registry.js';
+import {
+  computeCostDetail,
   computeCostUSD,
   loadUsageEvents,
   recordUsageEvent,
@@ -52,6 +59,89 @@ describe('computeCostUSD (#2469)', () => {
     const cost2 = computeCostUSD('claude-sonnet', 2000, 1000);
     // 2x tokens → 2x cost (within rounding)
     expect(cost2).toBeCloseTo(cost1 * 2, 6);
+  });
+});
+
+describe('computeCostDetail (#4165)', () => {
+  /** Canonical priced entry so the fuzzy tier (#4164) has something to match. */
+  const opus48Canonical: ModelEntry = {
+    id: 'claude-opus-4-8',
+    vendor: 'anthropic',
+    family: 'claude-opus',
+    version: '4-8',
+    displayName: 'Claude Opus 4.8',
+    pricing: { inputPer1M: 5, outputPer1M: 25 },
+    parallelToolCalls: true,
+    promptCaching: 'ephemeral',
+    toolDefinitionFormat: 'anthropic',
+    maxRecommendedTurnBudget: 20,
+    strictJson: true,
+    quirks: [],
+    profileId: 'claude-opus',
+    source: 'in-tree',
+  };
+
+  describe('with an injected registry (deterministic pricing)', () => {
+    let prevRegistry: ModelRegistry | undefined;
+
+    beforeEach(() => {
+      prevRegistry = peekDefaultRegistry();
+      setDefaultRegistry(new ModelRegistry({ inTreeEntries: [opus48Canonical] }));
+    });
+
+    afterEach(() => {
+      setDefaultRegistry(prevRegistry);
+    });
+
+    it('prices a decorated gateway id via the fuzzy tier with provenance', () => {
+      // OpenAI-compatible gateways expose decorated model names; the #4164
+      // resolution tier maps them to the canonical entry's pricing.
+      const detail = computeCostDetail('Claude_Opus_4.8_hardened', 1000, 500);
+      // 1000 * 5 + 500 * 25 = 17_500 micro-USD = 0.0175.
+      expect(detail.costUsd).toBeCloseTo(0.0175, 9);
+      expect(detail.priced).toBe(true);
+      expect(detail.matchedVia).toBe('identity');
+      expect(detail.resolvedId).toBe('claude-opus-4-8');
+    });
+
+    it('keeps the caller id as resolvedId for an exact (non-fuzzy) match', () => {
+      const detail = computeCostDetail('claude-opus-4-8', 1000, 500);
+      expect(detail.priced).toBe(true);
+      expect(detail.resolvedId).toBe('claude-opus-4-8');
+      expect(detail.matchedVia).toBeUndefined();
+    });
+
+    it('reports priced: false with costUsd 0 for an unknown model', () => {
+      const detail = computeCostDetail('mystery-model-xyz', 1000, 500);
+      expect(detail.costUsd).toBe(0);
+      expect(detail.priced).toBe(false);
+      expect(detail.resolvedId).toBe('mystery-model-xyz');
+      expect(detail.matchedVia).toBeUndefined();
+    });
+
+    it('computeCostUSD is a thin wrapper returning .costUsd (priced and unpriced)', () => {
+      expect(computeCostUSD('Claude_Opus_4.8_hardened', 1000, 500)).toBe(
+        computeCostDetail('Claude_Opus_4.8_hardened', 1000, 500).costUsd
+      );
+      expect(computeCostUSD('mystery-model-xyz', 1000, 500)).toBe(
+        computeCostDetail('mystery-model-xyz', 1000, 500).costUsd
+      );
+      expect(computeCostUSD('mystery-model-xyz', 1000, 500)).toBe(0);
+    });
+  });
+
+  describe('against the real default registry (full chain)', () => {
+    it('prices a long-tail catalog id from the generated tier', () => {
+      // 'amazon-bedrock/amazon.nova-micro-v1:0' has NO in-tree entry — its
+      // pricing only exists in the generated (LiteLLM) catalog tier, which
+      // the old lookupInTreeCapability path priced at $0.
+      const detail = computeCostDetail('amazon-bedrock/amazon.nova-micro-v1:0', 1_000_000, 0);
+      expect(detail.priced).toBe(true);
+      expect(detail.costUsd).toBeGreaterThan(0);
+      expect(computeCostUSD('amazon-bedrock/amazon.nova-micro-v1:0', 1_000_000, 0)).toBe(
+        detail.costUsd
+      );
+    });
   });
 });
 

--- a/packages/nexus-agents/src/learning/usage-log.ts
+++ b/packages/nexus-agents/src/learning/usage-log.ts
@@ -11,8 +11,13 @@
  *      log under <NEXUS_DATA_DIR>/usage/usage-YYYY-MM.jsonl.
  *   2. `loadUsageEvents({...})` — read events for a window, filtered
  *      by model / category.
- *   3. `computeCostUSD(modelId, inputTokens, outputTokens)` — compute
- *      cost from `config/in-tree-data.ts` pricing via `lookupInTreeCapability`.
+ *   3. `computeCostDetail(modelId, inputTokens, outputTokens)` (and its
+ *      thin wrapper `computeCostUSD`) — compute cost from the FULL model
+ *      registry pricing chain (manifest > in-tree > models.dev > generated
+ *      LiteLLM catalog), including the #4164 normalized/identity resolution
+ *      tier for decorated gateway model ids. A model with no pricing
+ *      anywhere in the chain is reported as `priced: false` so consumers
+ *      can treat the missing cost as UNMEASURED (#3855), never a real $0.
  *
  * The `usage` CLI command (cli/usage-command.ts) consumes this for the
  * operator dashboard. Existing OutcomeStore is intentionally untouched
@@ -23,7 +28,11 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from
 import { dirname, join } from 'node:path';
 
 import { getNexusDataDir } from '../config/nexus-data-dir.js';
-import { lookupInTreeCapability } from '../config/model-config-helpers.js';
+// NOTE: only the FUNCTION is imported here — `getDefaultRegistry()` must never
+// be CALLED at module scope (#3185 bootstrap hazard: first construction reads
+// the manifest overlay/snapshot from disk). All calls happen at invocation
+// time inside computeCostDetail.
+import { getDefaultRegistry, type MatchedVia } from '../config/model-registry.js';
 
 export interface UsageEvent {
   /** ISO 8601 timestamp of the call. */
@@ -35,7 +44,12 @@ export interface UsageEvent {
   /** Token counts. */
   readonly inputTokens: number;
   readonly outputTokens: number;
-  /** Cost in USD. Computed at write time from pricing in `config/in-tree-data.ts`. */
+  /**
+   * Cost in USD. Computed at write time from the full model-registry pricing
+   * chain (see `computeCostDetail`). 0 with `priced: false` means the model
+   * was UNPRICED (cost unknown), not a real $0 — check `priced` before
+   * treating this as a measured figure.
+   */
   readonly usdCost: number;
   /** Wall-clock latency in milliseconds. */
   readonly latencyMs: number;
@@ -48,26 +62,78 @@ export interface UsageEvent {
   readonly category?: string;
   /** Optional failure code when success === false. */
   readonly errorCode?: string;
+  /**
+   * Whether pricing data existed for the model at write time (#4165), so
+   * audit can distinguish a real $0 from an unpriced model. Absent on lines
+   * written before this field existed.
+   */
+  readonly priced?: boolean;
+  /**
+   * Pricing provenance: the canonical registry id whose pricing was applied
+   * (the entry's `resolvedFrom` when the #4164 fuzzy tier matched a decorated
+   * id, else the caller's model id). Present only when `priced` is true.
+   */
+  readonly priceSource?: string;
+}
+
+/** Result of a pricing-aware cost computation (#4165). */
+export interface CostDetail {
+  /** Cost in USD. Always 0 when `priced` is false — an unknown, not a $0. */
+  readonly costUsd: number;
+  /** Whether the resolved registry entry carried pricing data. */
+  readonly priced: boolean;
+  /**
+   * Canonical id the pricing/metadata came from: the entry's `resolvedFrom`
+   * when the #4164 fuzzy tier matched a decorated id, else the caller's id.
+   */
+  readonly resolvedId: string;
+  /** Fuzzy-resolution provenance (#4164), passed through from the entry. */
+  readonly matchedVia?: MatchedVia;
 }
 
 /**
- * Compute cost in USD given a model and token counts. Returns 0 when the
- * model has no pricing data (e.g., free local model, gateway-routed model
- * we don't have rates for). Operators with custom gateways can extend
- * `config/in-tree-data.ts` to add their pricing.
+ * Compute cost in USD given a model and token counts, with pricing
+ * provenance. Reads the FULL registry chain via
+ * `getDefaultRegistry().getEntry()` — manifest > in-tree > models.dev >
+ * generated LiteLLM catalog, plus the #4164 normalized/identity tier that
+ * resolves decorated model names from OpenAI-compatible gateways to their
+ * canonical entry's pricing.
+ *
+ * `priced: false` (with `costUsd: 0`) means NO pricing existed anywhere in
+ * the chain — consumers must treat the cost as UNMEASURED (#3855), never a
+ * real $0. Operators can add pricing for gateway-only models via the
+ * models-manifest overlay.
  */
-export function computeCostUSD(modelId: string, inputTokens: number, outputTokens: number): number {
-  const cap = lookupInTreeCapability(modelId);
-  if (cap === undefined) return 0;
-  const inputPer1M = cap.pricing?.inputPer1M ?? 0;
-  const outputPer1M = cap.pricing?.outputPer1M ?? 0;
+export function computeCostDetail(
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number
+): CostDetail {
+  // Registry read happens at INVOCATION time, never module load — first
+  // construction touches the filesystem (#3185 bootstrap hazard).
+  const entry = getDefaultRegistry().getEntry(modelId);
+  const resolvedId = entry.resolvedFrom ?? modelId;
+  const provenance = entry.matchedVia !== undefined ? { matchedVia: entry.matchedVia } : {};
+  if (entry.pricing === undefined) {
+    return { costUsd: 0, priced: false, resolvedId, ...provenance };
+  }
   // Multiply token counts by per-million rate then divide. Use Math.round
   // at micro-USD precision so JSONL files don't drift to floating-point
   // noise on small calls.
   const microUsd = Math.round(
-    inputTokens * inputPer1M + outputTokens * outputPer1M // micro-USD per million scaled
+    inputTokens * entry.pricing.inputPer1M + outputTokens * entry.pricing.outputPer1M
   );
-  return microUsd / 1_000_000;
+  return { costUsd: microUsd / 1_000_000, priced: true, resolvedId, ...provenance };
+}
+
+/**
+ * Thin wrapper over {@link computeCostDetail} returning only the USD figure.
+ * Returns 0 both for a genuinely free model and for a model with no pricing
+ * data — callers that must tell those apart (unpriced ⇒ UNMEASURED, #3855)
+ * should use `computeCostDetail` and check `priced`.
+ */
+export function computeCostUSD(modelId: string, inputTokens: number, outputTokens: number): number {
+  return computeCostDetail(modelId, inputTokens, outputTokens).costUsd;
 }
 
 /** Resolve the active usage log path for the current month. */

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.test.ts
@@ -59,8 +59,22 @@ describe('votesToCostInputs', () => {
     const inputs = votesToCostInputs([withTokens]);
     expect(inputs[0]?.inputTokens).toBe(1000);
     expect(inputs[0]?.outputTokens).toBe(200);
-    // computeCostUSD returns a number (0 for unknown-model pricing, >=0 otherwise).
-    expect(typeof inputs[0]?.costUsd).toBe('number');
+    // claude-sonnet is priced in the registry, so a real cost is attached
+    // (#4165: costUsd is only ever present when pricing actually resolved).
+    expect(inputs[0]?.costUsd).toBeGreaterThan(0);
+  });
+
+  it('OMITS costUsd for an unpriced model but keeps the tokens (#4165 — unmeasured, not $0)', () => {
+    // A model with no pricing anywhere in the registry chain must not record
+    // a measured $0 — the cost field is left off so the rollup counts the
+    // voter as UNMEASURED (#3855 semantics).
+    const inputs = votesToCostInputs([
+      vote({ role: 'devex', model: 'mystery-model-xyz', inputTokens: 500, outputTokens: 100 }),
+    ]);
+    expect(inputs[0]?.inputTokens).toBe(500);
+    expect(inputs[0]?.outputTokens).toBe(100);
+    expect(inputs[0]?.costUsd).toBeUndefined();
+    expect(Object.keys(inputs[0] ?? {})).not.toContain('costUsd');
   });
 });
 
@@ -129,6 +143,34 @@ describe('recordDecisionCost', () => {
     expect(summary.totalInputTokens).toBe(2000);
     expect(summary.totalOutputTokens).toBe(450);
     expect(summary.totalTokens).toBe(2450);
+  });
+
+  it('rolls up a token-reporting voter on an UNPRICED model as unmeasured end-to-end (#4165)', () => {
+    const store = new DecisionCostStore({ filePath: join(dir, 'dc.jsonl'), dataDir: dir });
+    const summary = recordDecisionCost({
+      decisionId: 'd-unpriced',
+      gate: 'consensus_vote',
+      votes: [
+        vote({ role: 'devex', model: 'mystery-model-xyz', inputTokens: 500, outputTokens: 100 }),
+        vote({ role: 'architect', model: 'claude-sonnet', inputTokens: 1000, outputTokens: 200 }),
+      ],
+      store,
+      billingMode: 'api',
+    });
+
+    // The unpriced voter's tokens are kept, but its unknown cost surfaces as
+    // UNMEASURED (total is a floor) — never a measured $0 (#3855).
+    expect(summary.measuredVoters).toBe(1);
+    expect(summary.unmeasuredVoters).toBe(1);
+    expect(summary.totalTokens).toBe(1800);
+    const unpriced = summary.perVoter.find((v) => v.role === 'devex');
+    expect(unpriced?.unmeasured).toBe(true);
+    expect(unpriced?.totalTokens).toBe(600);
+    expect(unpriced?.costUsd).toBe(0);
+    // Total cost reflects ONLY the priced voter.
+    const priced = summary.perVoter.find((v) => v.role === 'architect');
+    expect(summary.totalCostUsd).toBe(priced?.costUsd);
+    expect(summary.totalCostUsd).toBeGreaterThan(0);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -12,7 +12,8 @@
  * and returns the summary so the tool can attach it to its response.
  *
  * Per-voter token/cost is propagated where the adapter layer reported it; voters
- * with no usage are folded in as UNMEASURED (not a measured $0) — see
+ * with no usage — or whose model has no pricing anywhere in the registry chain
+ * (#4165) — are folded in as UNMEASURED (not a measured $0) — see
  * {@link module:observability/decision-cost}. Record + measure ONLY — no routing
  * or weighting change.
  *
@@ -21,7 +22,7 @@
 
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import { createLogger, getTimeProvider, type ILogger } from '../../core/index.js';
-import { computeCostUSD } from '../../learning/usage-log.js';
+import { computeCostDetail } from '../../learning/usage-log.js';
 import { DecisionCostStore, type DecisionGate } from '../../observability/decision-cost-store.js';
 import type {
   DecisionBillingMode,
@@ -39,21 +40,27 @@ export function resolveBillingMode(): DecisionBillingMode {
  *
  * The vote result carries the model id (#3855) and, where the adapter reported
  * it, token counts. When tokens are present we derive the api-mode cost via the
- * same registry-backed {@link computeCostUSD} the per-call usage log uses, so a
- * per-decision rollup and the per-call usage log price identically. When no
+ * same registry-backed {@link computeCostDetail} the per-call usage log uses, so
+ * a per-decision rollup and the per-call usage log price identically. When no
  * usage was reported the voter is left with no tokens/cost ⇒ unmeasured.
+ *
+ * When the model resolves WITHOUT pricing anywhere in the registry chain
+ * (#4165), `costUsd` is OMITTED — tokens are kept — so the rollup counts the
+ * voter as UNMEASURED (#3855: missing cost is unmeasured, never a measured $0).
  */
 export function votesToCostInputs(votes: readonly AgentVoteResult[]): VoterCostInput[] {
   return votes.map((v) => {
     const hasTokens = v.inputTokens !== undefined || v.outputTokens !== undefined;
+    const detail =
+      hasTokens && v.model !== undefined
+        ? computeCostDetail(v.model, v.inputTokens ?? 0, v.outputTokens ?? 0)
+        : undefined;
     const input: VoterCostInput = {
       role: v.role,
       model: v.model,
       ...(v.inputTokens !== undefined ? { inputTokens: v.inputTokens } : {}),
       ...(v.outputTokens !== undefined ? { outputTokens: v.outputTokens } : {}),
-      ...(hasTokens && v.model !== undefined
-        ? { costUsd: computeCostUSD(v.model, v.inputTokens ?? 0, v.outputTokens ?? 0) }
-        : {}),
+      ...(detail?.priced === true ? { costUsd: detail.costUsd } : {}),
     };
     return input;
   });

--- a/packages/nexus-agents/src/observability/decision-cost.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.test.ts
@@ -189,6 +189,24 @@ describe('rollupDecisionCost', () => {
       expect(summary.perModel[0]?.model).toBe(UNKNOWN_MODEL);
     });
 
+    it('a token-reporting voter WITHOUT a computable cost is unmeasured (#4165)', () => {
+      // Unpriced model: the bridge omits costUsd but keeps the tokens. The
+      // tokens still count toward consumption totals, but the voter's unknown
+      // cost must surface as UNMEASURED — a measured $0 would silently
+      // understate spend.
+      const voters: VoterCostInput[] = [
+        { role: 'devex', model: 'unpriced-model', inputTokens: 500, outputTokens: 100 },
+      ];
+
+      const summary = rollupDecisionCost(voters, 'api');
+
+      expect(summary.measuredVoters).toBe(0);
+      expect(summary.unmeasuredVoters).toBe(1);
+      expect(summary.perVoter[0]?.unmeasured).toBe(true);
+      expect(summary.totalTokens).toBe(600);
+      expect(summary.totalCostUsd).toBe(0);
+    });
+
     it('a measured voter with zero cost (free model) is NOT unmeasured', () => {
       // Reported tokens but a free model ⇒ measured, cost genuinely 0.
       const voters: VoterCostInput[] = [

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -20,12 +20,14 @@
  *
  * Design decisions that the fixture tests pin (#3855 acceptance criteria):
  *
- *  - **Missing cost is UNMEASURED, not zero.** A voter with no token counts
- *    (e.g. a CLI-subscription adapter that doesn't report usage, or an error
- *    vote that never reached the model) is counted in `unmeasuredVoters` and
- *    contributes 0 to the totals — but the summary records that the total is a
- *    floor, not an exact figure (`measured` < `voterCount`). Treating unmeasured
- *    as a true $0 would silently understate spend; this keeps the honesty.
+ *  - **Missing cost is UNMEASURED, not zero.** A voter with no computable cost
+ *    — no usage report at all (a CLI-subscription adapter, an error vote that
+ *    never reached the model) or a model with no pricing anywhere in the
+ *    registry chain (#4165) — is counted in `unmeasuredVoters` and contributes
+ *    0 to the COST totals (reported tokens still count toward consumption) —
+ *    but the summary records that the total is a floor, not an exact figure
+ *    (`measured` < `voterCount`). Treating unmeasured as a true $0 would
+ *    silently understate spend; this keeps the honesty.
  *  - **Plan mode records 0-cost but keeps tokens.** Under `NEXUS_BILLING_MODE=plan`
  *    the spend is pre-covered by a subscription, so cost is recorded as $0 while
  *    token counts are preserved (so the operator can still see consumption and
@@ -46,8 +48,10 @@ export type DecisionBillingMode = 'plan' | 'api';
  * Token counts and cost are OPTIONAL: a voter whose adapter reported no usage
  * (CLI subscription, error vote, simulation) leaves them `undefined` and is
  * folded in as `unmeasured` — never silently zeroed. `costUsd`, when present,
- * is the API-mode cost (e.g. from `computeCostUSD`); plan mode zeroes it at
- * rollup time but keeps the tokens.
+ * is the API-mode cost (e.g. from `computeCostDetail`); plan mode zeroes it at
+ * rollup time but keeps the tokens. A voter with tokens but NO `costUsd`
+ * (unpriced model, #4165) is likewise unmeasured — its tokens count toward
+ * consumption while its unknown cost is honestly excluded from the total.
  */
 export interface VoterCostInput {
   /** Voter role (e.g. 'architect', 'security'). */
@@ -76,8 +80,9 @@ export interface VoterCostBreakdown {
   /** Effective cost after billing-mode application (0 in plan mode). */
   readonly costUsd: number;
   /**
-   * True when this voter reported NO usage at all (no tokens, no cost). Its
-   * zeros are placeholders, not a measured $0 / 0-token call.
+   * True when no cost was computable for this voter — no usage report at all,
+   * or a token-reporting call on an unpriced model (#4165). Its cost zero is a
+   * placeholder, not a measured $0.
    */
   readonly unmeasured: boolean;
 }
@@ -104,9 +109,12 @@ export interface DecisionCostSummary {
   readonly billingMode: DecisionBillingMode;
   /** Total voters folded into this decision. */
   readonly voterCount: number;
-  /** Voters that reported usage (tokens and/or cost). */
+  /** Voters with a computable cost (`costUsd` present on the input). */
   readonly measuredVoters: number;
-  /** Voters that reported no usage at all (counted, not zeroed-as-fact). */
+  /**
+   * Voters whose cost could not be computed — no usage report, or an unpriced
+   * model (#4165). Counted, not zeroed-as-fact.
+   */
   readonly unmeasuredVoters: number;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -165,13 +173,15 @@ export const DecisionCostSummarySchema = z.object({
   ),
 });
 
-/** A voter contributes usage iff it reported any token count or a cost. */
+/**
+ * A voter's cost is measured iff a cost was computable for it (`costUsd`
+ * present — a genuinely free model arrives as `costUsd: 0`, still measured).
+ * Token counts alone do NOT make a voter cost-measured (#4165): an unpriced
+ * model's tokens are kept in the consumption totals, but its unknown cost must
+ * surface as UNMEASURED — a measured $0 would silently understate spend.
+ */
 function isMeasured(v: VoterCostInput): boolean {
-  return (
-    (v.inputTokens !== undefined && v.inputTokens > 0) ||
-    (v.outputTokens !== undefined && v.outputTokens > 0) ||
-    v.costUsd !== undefined
-  );
+  return v.costUsd !== undefined;
 }
 
 /** Round to micro-USD so summaries don't drift to floating-point noise. */
@@ -197,7 +207,8 @@ function toVoterBreakdown(v: VoterCostInput, isPlan: boolean): VoterCostBreakdow
   const inputTokens = v.inputTokens ?? 0;
   const outputTokens = v.outputTokens ?? 0;
   // Plan mode: cost is pre-covered, record 0 but keep tokens. Api mode: use the
-  // supplied cost (a measured voter with no costUsd ⇒ 0, e.g. a free model).
+  // supplied cost (absence ⇒ unmeasured, recorded as a placeholder 0 — a free
+  // model arrives as an explicit costUsd: 0 and stays measured, #4165).
   const costUsd = isPlan ? 0 : roundUsd(v.costUsd ?? 0);
   return {
     role: v.role,
@@ -214,9 +225,10 @@ function toVoterBreakdown(v: VoterCostInput, isPlan: boolean): VoterCostBreakdow
  * Roll N per-voter cost inputs up into one {@link DecisionCostSummary}.
  *
  * Pure and deterministic: no I/O, no clock, no env reads. `plan` mode zeroes
- * every cost (tokens kept); `api` mode uses the supplied `costUsd`. Voters that
- * reported no usage are counted in `unmeasuredVoters` and contribute zeros that
- * are explicitly NOT a measured $0 (see module doc / `unmeasured` flag).
+ * every cost (tokens kept); `api` mode uses the supplied `costUsd`. Voters with
+ * no computable cost (no usage report, or an unpriced model, #4165) are counted
+ * in `unmeasuredVoters` and contribute cost zeros that are explicitly NOT a
+ * measured $0 (see module doc / `unmeasured` flag).
  */
 export function rollupDecisionCost(
   voters: readonly VoterCostInput[],


### PR DESCRIPTION
Closes #4165 (epic #4163 child 2).

## What

`computeCostUSD` (src/learning/usage-log.ts) read `lookupInTreeCapability` — the in-tree tier ONLY — so any model whose pricing the registry already holds in another tier (manifest / models.dev / generated LiteLLM catalog) recorded $0, and unpriced models recorded a silent measured $0.

- **Full-registry pricing read-through.** New `computeCostDetail(modelId, inputTokens, outputTokens): {costUsd, priced, resolvedId, matchedVia?}` reads pricing via `getDefaultRegistry().getEntry()` — the full chain (manifest > in-tree > models.dev > generated LiteLLM), including the #4164 normalized/identity resolution tier, so decorated model names from OpenAI-compatible gateways (e.g. `Claude_Opus_4.8_hardened`) price at their canonical entry's rates with `matchedVia`/`resolvedFrom` provenance. Sync; the registry call happens at invocation time only — never module load (#3185 bootstrap hazard).
- **`computeCostUSD` is now a thin wrapper** returning `.costUsd` (public API unchanged).
- **Unpriced is UNMEASURED, never $0 (#3855).** `votesToCostInputs` OMITS `costUsd` when `priced: false` (token counts kept), and `rollupDecisionCost`'s measured predicate now keys on cost computability (`costUsd` present) — an unpriced voter's tokens still count toward consumption, but its unknown cost surfaces in `unmeasuredVoters` / the cost-floor honesty flags instead of being recorded as a measured $0. A genuinely free model arrives as an explicit `costUsd: 0` and stays measured.
- **UsageEvent pricing provenance.** Optional `priced: boolean` + `priceSource?: string` (canonical id the pricing came from) so audit can distinguish a real $0 from an unpriced model. Additive JSONL fields; the writer (`openai-compat-adapter`) populates them, readers (`rollupByModel`, usage CLI) are shape-tolerant.
- **Stale docstrings updated** (module doc, `usdCost`, cost-function docs) — they still described the in-tree-only read and the "gateway-routed model returns 0" behavior.

## Tests (TDD)

- Decorated gateway id → real canonical pricing with `matchedVia: 'identity'` + `resolvedId`
- Long-tail catalog id (`amazon-bedrock/amazon.nova-micro-v1:0`) → priced from the generated tier (was $0)
- Unknown id → `priced: false`, `costUsd: 0`
- `computeCostUSD` wrapper equivalence (priced + unpriced)
- `votesToCostInputs` omits `costUsd` for unpriced but keeps tokens (key-absence asserted)
- UNMEASURED rollup end-to-end: `recordDecisionCost` with an unpriced token-reporting voter → `unmeasuredVoters: 1`, tokens kept, total cost reflects only the priced voter
- Pure-rollup fixture: token-reporting voter without computable cost is unmeasured

## Fixture-cascade audit (full-suite rule)

Full package suite run in foreground: **1141 test files / 27289 tests passed** (nexus-memory: 63 passed). No existing fixture flipped $0→priced — deliberately checked: measured-voter fixtures in the #3855 decision-cost tests all carry explicit `costUsd`; unpriced-model tests use obviously-fake ids (`mystery-model`, `mystery-model-xyz`) that resolve nowhere in the chain; the one weak assert (`typeof costUsd === 'number'`) was deliberately strengthened to `> 0` for the priced case.

## Gates

- `pnpm test` (full, foreground): pass — 27289/27289
- `pnpm typecheck`: pass
- `pnpm lint`: pass
- changeset: minor (`full-registry-cost-unmeasured.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)