### PR TITLE
test(qa): pin rubric and readiness wording; verify config check fails on error (#4181)

### DIFF
--- a/.changeset/verify-config-check-fails-on-error.md
+++ b/.changeset/verify-config-check-fails-on-error.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+`nexus-agents verify`: the Configuration check now reports a failure (warn severity, with a fix hint) when the config loader throws, instead of passing silently — config breakage surfaces in the diagnostic. Warn severity keeps the exit code at 0 (diagnostic-only, not a gate). Also pins previously shape-only test assertions: DEFAULT_RUBRICS criterion configs/weights and the readiness-criterion detail wording (#4181).

--- a/packages/nexus-agents/src/cli/verify-command.test.ts
+++ b/packages/nexus-agents/src/cli/verify-command.test.ts
@@ -244,6 +244,33 @@ describe('verify-command', () => {
       expect(failing.noHardFailures).toBe(false);
     });
 
+    it('reports Configuration as failed (warn) with a fix hint when config access throws (#4181)', async () => {
+      vi.resetModules();
+      vi.doMock('../config/index.js', async (importOriginal) => {
+        const actual = await importOriginal<typeof import('../config/index.js')>();
+        return {
+          ...actual,
+          get defaultConfig(): never {
+            throw new Error('simulated config loader failure');
+          },
+        };
+      });
+      try {
+        const mod = await import('./verify-command.js');
+        const result = await mod.runVerify();
+        const configCheck = result.checks.find((c) => c.name === 'Configuration');
+        expect(configCheck).toBeDefined();
+        expect(configCheck?.passed).toBe(false);
+        // Diagnostic-only: degraded, not a hard gate.
+        expect(configCheck?.severity).toBe('warn');
+        expect(configCheck?.message).toBe('Failed to load default configuration');
+        expect(configCheck?.fix).toContain('Reinstall nexus-agents');
+      } finally {
+        vi.doUnmock('../config/index.js');
+        vi.resetModules();
+      }
+    });
+
     it('printVerifyResult renders warn-only failures as degraded, not failed', () => {
       const result: VerifyResult = {
         version: '1.0.0',

--- a/packages/nexus-agents/src/cli/verify-command.ts
+++ b/packages/nexus-agents/src/cli/verify-command.ts
@@ -155,10 +155,14 @@ function checkConfigLoading(): VerifyCheck {
       message: 'Using default configuration',
     };
   } catch {
+    // #4181: config breakage must SURFACE in the diagnostic instead of being
+    // reported as a pass. Warn severity — degraded, not a hard gate (exit 0).
     return {
       name: 'Configuration',
-      passed: true, // Still works with defaults
-      message: 'Using default configuration',
+      passed: false,
+      severity: 'warn',
+      message: 'Failed to load default configuration',
+      fix: 'Reinstall nexus-agents (npm install -g nexus-agents); if a local config override exists, check it for syntax errors',
     };
   }
 }

--- a/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/codepr-enable-readiness.test.ts
@@ -14,7 +14,9 @@ import {
 const SOAK = DEFAULT_CODEPR_ENABLE_READINESS_CONFIG.minGuardsGreenSoak;
 
 /** A fully-satisfying evidence object; override fields per test. */
-function fullEvidence(over: Partial<CodePrEnableReadinessEvidence> = {}): CodePrEnableReadinessEvidence {
+function fullEvidence(
+  over: Partial<CodePrEnableReadinessEvidence> = {}
+): CodePrEnableReadinessEvidence {
   return {
     flagEnabled: true,
     enableVoteRef: 'vote-3670-enable',
@@ -57,6 +59,7 @@ describe('evaluateCodePrEnableReadiness', () => {
     const r = evaluateCodePrEnableReadiness(fullEvidence({ enableVoteRef: '' }));
     expect(r.ready).toBe(false);
     expect(r.blockers).toEqual(['enable-vote-ref']);
+    expect(r.criteria.find((c) => c.name === 'enable-vote-ref')?.detail).toBe('no enable-vote ref');
   });
 
   it('whitespace-only vote ref counts as absent', () => {
@@ -80,12 +83,43 @@ describe('evaluateCodePrEnableReadiness', () => {
     const r = evaluateCodePrEnableReadiness(fullEvidence({ owner: '' }));
     expect(r.ready).toBe(false);
     expect(r.blockers).toEqual(['owner-ack']);
+    // #4181: pin THIS copy's wording. readiness-verdict.ts documents that the two
+    // presenceCriterion copies deliberately diverge ("no {label}" here vs
+    // "no named {label}" in improvement-enforce-readiness) — do not unify.
+    expect(r.criteria.find((c) => c.name === 'owner-ack')?.detail).toBe('no owner');
   });
 
-  it('reports every criterion regardless of verdict', () => {
+  it('reports every criterion with the exact detail wording (#4181)', () => {
     const r = evaluateCodePrEnableReadiness(fullEvidence());
-    const names = r.criteria.map((c) => c.name);
-    expect(names).toEqual(['flag-enabled', 'enable-vote-ref', 'guards-green-soak', 'owner-ack']);
+    expect(r.criteria).toEqual([
+      { name: 'flag-enabled', met: true, detail: 'OFF→on flag is set' },
+      { name: 'enable-vote-ref', met: true, detail: 'enable-vote ref: vote-3670-enable' },
+      {
+        name: 'guards-green-soak',
+        met: true,
+        detail: `${String(SOAK)} consecutive green dry-runs (need ≥ ${String(SOAK)})`,
+      },
+      { name: 'owner-ack', met: true, detail: 'owner: william' },
+    ]);
+  });
+
+  it('pins the unmet-side detail wording (#4181)', () => {
+    const r = evaluateCodePrEnableReadiness({
+      flagEnabled: false,
+      enableVoteRef: '',
+      consecutiveGreenDryRuns: 0,
+      owner: '',
+    });
+    expect(r.criteria).toEqual([
+      { name: 'flag-enabled', met: false, detail: 'OFF→on flag is not set' },
+      { name: 'enable-vote-ref', met: false, detail: 'no enable-vote ref' },
+      {
+        name: 'guards-green-soak',
+        met: false,
+        detail: `0 consecutive green dry-runs (need ≥ ${String(SOAK)})`,
+      },
+      { name: 'owner-ack', met: false, detail: 'no owner' },
+    ]);
   });
 
   it('config can drop the vote/owner requirement (still needs flag + soak)', () => {

--- a/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-enforce-readiness.test.ts
@@ -86,6 +86,10 @@ describe('evaluateEnforceReadiness', () => {
     });
     expect(r.ready).toBe(false);
     expect(r.blockers).toContain('named-evaluator');
+    // #4181: pin THIS copy's wording. readiness-verdict.ts documents that the two
+    // presenceCriterion copies deliberately diverge ("no named {label}" here vs
+    // "no {label}" in codepr-enable-readiness) — do not unify.
+    expect(r.criteria.find((c) => c.name === 'named-evaluator')?.detail).toBe('no named evaluator');
   });
 
   it('blocks on missing / blank named owner', () => {
@@ -96,9 +100,11 @@ describe('evaluateEnforceReadiness', () => {
       evaluator: 'rev@example',
     });
     expect(missing.blockers).toContain('named-owner');
-    expect(evaluateEnforceReadiness(readyEvidence({ owner: '   ' })).blockers).toContain(
-      'named-owner'
-    );
+    // #4181: pin this copy's deliberate "no named {label}" wording (see readiness-verdict.ts).
+    expect(missing.criteria.find((c) => c.name === 'named-owner')?.detail).toBe('no named owner');
+    const blank = evaluateEnforceReadiness(readyEvidence({ owner: '   ' }));
+    expect(blank.blockers).toContain('named-owner');
+    expect(blank.criteria.find((c) => c.name === 'named-owner')?.detail).toBe('no named owner');
   });
 
   it('honors relaxed config (evaluator/owner not required)', () => {
@@ -122,15 +128,19 @@ describe('evaluateEnforceReadiness', () => {
     expect(DEFAULT_ENFORCE_READINESS_CONFIG.requireNamedOwner).toBe(true);
   });
 
-  it('reports every criterion with a human-readable detail', () => {
+  it('reports every criterion with the exact human-readable detail (#4181)', () => {
+    // 110/120 judged = 91.7% → rounds to 92; 105/110 sound = 95.5% → rounds to 95.
     const r = evaluateEnforceReadiness(readyEvidence());
-    expect(r.criteria.map((c) => c.name)).toEqual([
-      'volume',
-      'judged-coverage',
-      'soundness',
-      'named-evaluator',
-      'named-owner',
+    expect(r.criteria).toEqual([
+      { name: 'volume', met: true, detail: '120 shadow selections (need ≥ 100)' },
+      { name: 'judged-coverage', met: true, detail: '92% reviewed (need ≥ 80%)' },
+      {
+        name: 'soundness',
+        met: true,
+        detail: '95% of reviewed judged sound (need ≥ 90%, with reviews present)',
+      },
+      { name: 'named-evaluator', met: true, detail: 'evaluator: security-reviewer@example' },
+      { name: 'named-owner', met: true, detail: 'owner: williamzujkowski' },
     ]);
-    expect(r.criteria.every((c) => c.detail.length > 0)).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/testing/framework/default-rubrics.test.ts
+++ b/packages/nexus-agents/src/testing/framework/default-rubrics.test.ts
@@ -59,10 +59,10 @@ describe('DEFAULT_RUBRICS - criteria', () => {
     }
   });
 
-  it('criterion weights sum to approximately 1.0 per rubric', () => {
+  it('criterion weights sum to 1.0 per rubric', () => {
     for (const rubric of DEFAULT_RUBRICS) {
       const sum = rubric.criteria.reduce((acc, c) => acc + c.weight, 0);
-      expect(sum).toBeCloseTo(1.0, 1);
+      expect(sum).toBeCloseTo(1.0, 5);
     }
   });
 
@@ -115,31 +115,198 @@ describe('DEFAULT_RUBRICS - categories', () => {
 });
 
 // ============================================================================
-// Specific rubric checks
+// Content pins (#4181)
+//
+// These rubrics score agent outputs via rubric-scorer, so the keyword lists,
+// minCount/length bounds, and weight splits are load-bearing. Pin them exactly
+// — a silent edit to any of them changes every score downstream.
 // ============================================================================
 
-describe('DEFAULT_RUBRICS - specific rubrics', () => {
-  it('code-generation rubric exists with 3 criteria', () => {
+describe('DEFAULT_RUBRICS - content pins', () => {
+  it('pins the rubric IDs in order', () => {
+    expect(DEFAULT_RUBRICS.map((r) => r.id)).toEqual([
+      'code-generation',
+      'code-review',
+      'architecture',
+      'testing',
+      'documentation',
+      'large-context',
+    ]);
+  });
+
+  it('pins the code-generation rubric (0.3/0.4/0.3 split)', () => {
     const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'code-generation');
-    expect(rubric).toBeDefined();
-    expect(rubric?.criteria).toHaveLength(3);
+    expect(rubric?.categories).toEqual(['code_generation', 'refactoring']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'syntax-correctness',
+        description: 'Code has correct syntax',
+        weight: 0.3,
+        scoringFunction: 'keyword_presence',
+        config: {
+          keywords: ['function', 'const', 'let', 'class', 'return', 'async', '=>'],
+          minCount: 2,
+        },
+      },
+      {
+        id: 'pattern-coverage',
+        description: 'Response includes expected patterns',
+        weight: 0.4,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'response-length',
+        description: 'Response has appropriate length',
+        weight: 0.3,
+        scoringFunction: 'length_check',
+        config: { minLength: 50, maxLength: 10000 },
+      },
+    ]);
   });
 
-  it('code-review rubric exists with 3 criteria', () => {
+  it('pins the code-review rubric (0.4/0.3/0.3 split, fix-suggestion keywords + minCount 2)', () => {
     const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'code-review');
-    expect(rubric).toBeDefined();
-    expect(rubric?.criteria).toHaveLength(3);
+    expect(rubric?.categories).toEqual(['code_review', 'debugging']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'issue-identification',
+        description: 'Identifies issues in the code',
+        weight: 0.4,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'explanation-quality',
+        description: 'Provides clear explanations',
+        weight: 0.3,
+        scoringFunction: 'length_check',
+        config: { minLength: 100, maxLength: 5000 },
+      },
+      {
+        id: 'fix-suggestion',
+        description: 'Suggests fixes or improvements',
+        weight: 0.3,
+        scoringFunction: 'keyword_presence',
+        config: {
+          keywords: ['fix', 'change', 'instead', 'should', 'recommend', 'suggest', 'better'],
+          minCount: 2,
+        },
+      },
+    ]);
   });
 
-  it('testing rubric exists with 3 criteria', () => {
+  it('pins the architecture rubric (0.3/0.4/0.3 split)', () => {
+    const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'architecture');
+    expect(rubric?.categories).toEqual(['architecture']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'component-description',
+        description: 'Describes system components',
+        weight: 0.3,
+        scoringFunction: 'keyword_presence',
+        config: {
+          keywords: ['service', 'component', 'module', 'layer', 'api', 'database', 'interface'],
+          minCount: 3,
+        },
+      },
+      {
+        id: 'pattern-coverage',
+        description: 'Response includes expected patterns',
+        weight: 0.4,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'thoroughness',
+        description: 'Provides thorough analysis',
+        weight: 0.3,
+        scoringFunction: 'length_check',
+        config: { minLength: 200, maxLength: 15000 },
+      },
+    ]);
+  });
+
+  it('pins the testing rubric (0.4/0.4/0.2 split)', () => {
     const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'testing');
-    expect(rubric).toBeDefined();
-    expect(rubric?.criteria).toHaveLength(3);
+    expect(rubric?.categories).toEqual(['testing']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'test-structure',
+        description: 'Has proper test structure',
+        weight: 0.4,
+        scoringFunction: 'keyword_presence',
+        config: {
+          keywords: ['describe', 'it', 'test', 'expect', 'assert', 'mock', 'beforeEach'],
+          minCount: 3,
+        },
+      },
+      {
+        id: 'pattern-coverage',
+        description: 'Response includes expected patterns',
+        weight: 0.4,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'test-count',
+        description: 'Contains multiple test cases',
+        weight: 0.2,
+        scoringFunction: 'length_check',
+        config: { minLength: 100, maxLength: 10000 },
+      },
+    ]);
   });
 
-  it('large-context rubric exists with 2 criteria', () => {
+  it('pins the documentation rubric (0.4/0.4/0.2 split)', () => {
+    const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'documentation');
+    expect(rubric?.categories).toEqual(['documentation']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'documentation-format',
+        description: 'Uses proper documentation format',
+        weight: 0.4,
+        scoringFunction: 'keyword_presence',
+        config: {
+          keywords: ['@param', '@returns', '@example', '@description', '/**', '*/'],
+          minCount: 2,
+        },
+      },
+      {
+        id: 'pattern-coverage',
+        description: 'Response includes expected patterns',
+        weight: 0.4,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'content-length',
+        description: 'Appropriate documentation length',
+        weight: 0.2,
+        scoringFunction: 'length_check',
+        config: { minLength: 50, maxLength: 5000 },
+      },
+    ]);
+  });
+
+  it('pins the large-context rubric (0.5/0.5 split)', () => {
     const rubric = DEFAULT_RUBRICS.find((r) => r.id === 'large-context');
-    expect(rubric).toBeDefined();
-    expect(rubric?.criteria).toHaveLength(2);
+    expect(rubric?.categories).toEqual(['large_context']);
+    expect(rubric?.criteria).toEqual([
+      {
+        id: 'comprehensiveness',
+        description: 'Addresses the full context',
+        weight: 0.5,
+        scoringFunction: 'pattern_match',
+        config: { matchAll: false },
+      },
+      {
+        id: 'thoroughness',
+        description: 'Provides thorough analysis',
+        weight: 0.5,
+        scoringFunction: 'length_check',
+        config: { minLength: 200, maxLength: 20000 },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Closes #4181.

Three verified QA findings from the 2026-07-02 review sweep (the #4096 length-only-assert class):

## 1. `default-rubrics.test.ts` — content pins instead of shape-only asserts
- Each of the six `DEFAULT_RUBRICS` entries now has a `toEqual` pin of its full criterion configs: criterion ids, keyword lists (incl. the fix-suggestion keywords + `minCount: 2` at `default-rubrics.ts:69-70`), `minLength`/`maxLength` bounds, and the exact weight splits (0.3/0.4/0.3, 0.4/0.3/0.3, 0.4/0.4/0.2, 0.5/0.5).
- Rubric ID order pinned; weight-sum assert tightened from `toBeCloseTo(1.0, 1)` to `toBeCloseTo(1.0, 5)`.
- Verified before pinning: every weight set sums to exactly 1.0 — no production values changed.

## 2. Readiness-criterion detail wording pinned exactly
- `improvement-enforce-readiness.test.ts`: missing-evaluator/missing-owner tests now assert the exact `'no named evaluator'` / `'no named owner'` details; the criteria-report test pins all five exact detail strings (replacing `detail.length > 0`).
- `codepr-enable-readiness.test.ts`: pins the exact met- and unmet-side detail strings for all four criteria, incl. `'no enable-vote ref'` and `'no owner'`.
- Per `readiness-verdict.ts:14-16`, the two `presenceCriterion` copies deliberately diverge (`'no named {label}'` vs `'no {label}'`) — each copy's own wording is pinned faithfully, with comments warning against unification.

## 3. `verify-command.ts` — config check is now falsifiable
- `checkConfigLoading`'s catch previously returned `passed: true`, so config breakage could never surface in the `nexus-agents verify` diagnostic. It now returns `passed: false` with `severity: 'warn'` and a fix hint — mirroring the file's existing warn convention (SQLite, data dirs, adapters). Diagnostic-only: warn severity keeps exit code 0, per the issue.
- New test: mocks the config module so `defaultConfig` access throws → asserts `passed: false`, `severity: 'warn'`, exact message, and fix hint.

## Gates
- Touched suites: 4 files, 70 tests passed
- Full `pnpm test`: 1141 files / 27304 tests passed, 16 skipped
- `pnpm typecheck`: pass
- `pnpm lint`: pass
- Changeset: patch (item 3 changes shipped `nexus-agents verify` behavior; items 1–2 are test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)