### PR TITLE
feat(registry): dated-decoration matching and sub-sku fail-closed guard (#4183)

### DIFF
--- a/.changeset/dated-decoration-subsku-guard.md
+++ b/.changeset/dated-decoration-subsku-guard.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': minor
+---
+
+feat(registry): dated-decoration matching and sub-sku fail-closed guard (#4183)
+
+The fuzzy-resolution identity tier now tolerates ONE trailing snapshot-date
+segment on a decorated gateway id (`claude-opus-4-8-20250514` resolves to the
+canonical `claude-opus-4-8` pricing/metadata) — fail-closed: the fallback only
+applies when the canonical entry's own version is date-free, so snapshot-style
+dated canonicals (`gpt-4o-2024-08-06`) still require full version equality.
+Sub-SKU decorations now fail closed: a size/tier quirk (`-mini`/`-lite`/
+`-nano`, `-large`, `7b`-style) on the decorated id that the canonical candidate
+lacks abandons the match instead of inheriting the parent SKU's pricing;
+mode/feature quirks (`thinking`, `high`, `vision`) still match. Also threads
+the resolved model identity through `getEntry` so derivation-bound misses
+resolve it once instead of twice.

--- a/docs/guides/MODEL_REGISTRY_PRICING.md
+++ b/docs/guides/MODEL_REGISTRY_PRICING.md
@@ -13,7 +13,8 @@ OpenAI-compatible gateways often expose vendor models under decorated names — 
 
 - Decorated names resolve automatically when they normalize to a known id/alias, or when their parsed `vendor + family + version` identity matches exactly one registry entry. Version equality is required; ambiguity fails closed.
 - A fuzzy match grants **pricing and capability metadata only** — behavior and request-shaping fields never transfer.
-- Version-less, dated (`-20250514`), and ambiguous decorations do not resolve — declare those in `models-manifest.yaml` instead. Sub-SKU decorations (`-mini`) are a known hazard tracked in [#4183](https://github.com/nexus-substrate/nexus-agents/issues/4183); declare them explicitly.
+- Dated decorations (`claude-opus-4-8-20250514`) resolve too (#4183): one trailing snapshot-date segment is ignored when the canonical entry's own version carries no date. Version-less and ambiguous decorations still do not resolve — declare those in `models-manifest.yaml` instead.
+- Sub-SKU decorations (`-mini`, `-lite`) **fail closed** (#4183): a size/tier marker the canonical entry lacks means a different SKU, so no pricing is inherited. Declare gateway sub-SKUs explicitly to give them their real price.
 - A model with no pricing anywhere in the chain is **UNMEASURED, never $0** — decision-cost totals become a floor, flagged via `measuredVoters < voterCount`.
 
 ## What resolves automatically
@@ -25,6 +26,8 @@ On an exact-id and alias miss, `ModelRegistry.getEntry()` runs a two-step resolu
 **Step 2 — identity match.** The decorated id is parsed into `{vendor, family, version}` and matched against a load-time index of every loaded entry:
 
 - **Version equality is required on both sides.** Version keys treat `.` and `-` as equal, so a decorated `4.8` matches a canonical `4-8`. An id that parses without a version never identity-matches.
+- **One trailing date segment is tolerated on the decorated side (#4183).** `claude-opus-4-8-20250514` parses to version `4-8-20250514`; when no entry matches it exactly, a single trailing 6–8-digit date segment is stripped and `4-8` is retried. The fallback is fail-closed: it only applies when the canonical entry's own version is date-free, so snapshot-style ids whose date _is_ the version (`gpt-4o-2024-08-06`) still require full equality.
+- **Size/tier markers fail closed (#4183).** If the decorated id carries a size/tier quirk (`mini`/`nano`/`tiny`/`small`/`lite`, `large`/`xl`/`big`/`maxi`, or a `7b`-style parameter count) that the canonical candidate lacks, the match is abandoned — `claude-opus-4-8-mini` is a different SKU, not decorated Opus 4.8. Mode/feature markers (`thinking`, `high`, `vision`, `coder`, `instruct`) are variants of the same SKU and do not block.
 - **Candidates are consulted tier-ordered.** Authoritative tiers (manifest, in-tree) are checked first; the breadth catalogs (models.dev, generated LiteLLM) only get a look when no authoritative candidate exists.
 - **Effective duplicates are collapsed, then uniqueness is enforced.** Catalog entries that normalize to the same id, or share identical pricing _and_ context-window/max-output envelope, count as one. If more than one distinct candidate survives, the match is abandoned — no guessing.
 
@@ -32,14 +35,16 @@ So `Claude_Opus_4.8_hardened` parses to `anthropic / claude-opus / 4.8`, matches
 
 ### What deliberately does not resolve
 
-| Decoration   | Example                               | Behavior                                                                                                                                                                        |
-| ------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Version-less | `claude-opus-hardened`                | No version parses → no identity key → derivation only (no pricing)                                                                                                              |
-| Ambiguous    | identity matches two distinct entries | Fails closed → derivation only                                                                                                                                                  |
-| Dated        | `claude-opus-4-8-20250514`            | Version parses as `4-8-20250514`, which never equals canonical `4-8` → no match ([#4183](https://github.com/nexus-substrate/nexus-agents/issues/4183) considers date-stripping) |
-| Over-long    | id > 256 chars                        | Fuzzy tier skipped entirely                                                                                                                                                     |
+| Decoration      | Example                                   | Behavior                                                                                                                                                                                               |
+| --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Version-less    | `claude-opus-hardened`                    | No version parses → no identity key → derivation only (no pricing)                                                                                                                                     |
+| Ambiguous       | identity matches two distinct entries     | Fails closed → derivation only (the date-stripped retry obeys the same tier-order/dedupe/uniqueness rules)                                                                                             |
+| Wrong-base date | `claude-opus-4-9-20250514` (no 4.9 entry) | Date-stripping only tolerates the date — the remaining version must equal a canonical one → no match                                                                                                   |
+| Dated snapshot  | `gpt-4o-2024-08-06-20250101`              | The canonical's version _is_ the date → full equality required; extra date segments never strip their way onto a snapshot entry ([#4183](https://github.com/nexus-substrate/nexus-agents/issues/4183)) |
+| Sub-SKU         | `claude-opus-4-8-mini`                    | Size/tier marker absent from the canonical → different SKU → fails closed instead of inheriting Opus pricing ([#4183](https://github.com/nexus-substrate/nexus-agents/issues/4183))                    |
+| Over-long       | id > 256 chars                            | Fuzzy tier skipped entirely                                                                                                                                                                            |
 
-**Sub-SKU hazard.** Size markers parse as quirks, not version segments, so `claude-opus-4-8-mini` currently _does_ identity-match the full `claude-opus-4-8` entry and inherits its (higher) pricing. Failing closed on mismatched size markers is tracked in [#4183](https://github.com/nexus-substrate/nexus-agents/issues/4183); until it lands, declare gateway sub-SKUs explicitly in the manifest (example below) so their real price wins.
+**Sub-SKU pricing.** Size markers parse as quirks, not version segments, so before #4183 `claude-opus-4-8-mini` identity-matched the full `claude-opus-4-8` entry and inherited its (higher) pricing. It now fails closed — which also means a sub-SKU has **no pricing at all** until you declare it explicitly in the manifest (example below) with its real price. A decoration whose size marker exists on the canonical side too (`claude-haiku-4-5-lite-hardened` against a declared `claude-haiku-4-5-lite`) still matches normally.
 
 ### Provenance and merge semantics
 
@@ -54,7 +59,7 @@ Implementation: [model-registry.ts](../../packages/nexus-agents/src/config/model
 
 ## When to use a manifest-overlay alias instead
 
-Reach for the operator manifest (#2547) whenever automatic resolution can't or shouldn't apply: version-less decorations, dated decorations, ambiguous names, sub-SKUs with their own price, or gateway-only models the registry has never heard of.
+Reach for the operator manifest (#2547) whenever automatic resolution can't or shouldn't apply: version-less decorations, ambiguous names, sub-SKUs (which fail closed since #4183 and need their own price declared), or gateway-only models the registry has never heard of.
 
 The operator manifest lives at `<NEXUS_DATA_DIR>/models-manifest.yaml` (default `~/.nexus-agents/models-manifest.yaml`), or wherever `NEXUS_MODELS_OVERLAY_PATH` points. A per-user overlay (`models.yaml` / `NEXUS_MODEL_REGISTRY_OVERLAY`, #3351) uses the same schema at lower precedence — the operator entry wins on id collision. Manifest entries sit at the **top** of the pricing chain, above in-tree data.
 
@@ -78,8 +83,8 @@ models:
       inputPer1M: 5.0 # USD per million input tokens
       outputPer1M: 25.0 # USD per million output tokens
 
-  # Declare a sub-SKU as its own entry so it never inherits Opus pricing
-  # (#4183 hazard above).
+  # A sub-SKU fails closed since #4183 (it never inherits Opus pricing) —
+  # declare it as its own entry so it gets its REAL price instead of none.
   - id: claude-opus-4-8-mini
     vendor: anthropic
     family: claude-opus

--- a/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
+++ b/packages/nexus-agents/src/config/model-fuzzy-resolution.ts
@@ -12,7 +12,14 @@
  *     once, never per-request O(N) scans),
  *   - tier-ordered candidate selection (manifest/in-tree before
  *     models-dev/generated) with effective-duplicate dedupe, failing CLOSED
- *     when more than one distinct candidate survives.
+ *     when more than one distinct candidate survives,
+ *   - dated-decoration tolerance (#4183): ONE trailing snapshot-date
+ *     segment on the decorated side is stripped when the canonical's
+ *     version is date-free — snapshot-style dated canonicals still require
+ *     full equality,
+ *   - a sub-SKU guard (#4183): a size/tier quirk (`-mini`, `-lite`, `70b`)
+ *     on the decorated id that the canonical lacks fails CLOSED instead of
+ *     inheriting the parent SKU's pricing.
  *
  * The registry itself (model-registry.ts) owns the merge semantics —
  * matched entries grant PRICING/METADATA ONLY; behaviour fields still come
@@ -159,4 +166,96 @@ export function selectIdentityCandidate(
   const authoritative = ranked.filter((e) => !BREADTH_SOURCES.has(e.source));
   if (authoritative.length > 0) return uniqueCandidate(authoritative);
   return uniqueCandidate(ranked.filter((e) => BREADTH_SOURCES.has(e.source)));
+}
+
+// ============================================================================
+// #4183 — dated-decoration matching + sub-SKU fail-closed guard
+// ============================================================================
+
+/**
+ * ONE trailing snapshot-date segment on a version KEY — `4-8-20250514`
+ * ends in a strippable `-20250514`. Mirrors `parseClaudeMajorMinor`'s
+ * date-tolerant parse (model-parameter-support.ts): 6–8 digits covers
+ * `202505`/`20250514` while a short numeric segment (`-8`, `-70`) stays
+ * version-significant. Applied AFTER normalization, so `_`/`.` separators
+ * have already become `-`.
+ */
+const TRAILING_DATE_SEGMENT = /-\d{6,8}$/;
+
+/**
+ * Any date-LIKE segment inside a version key (`20250514`, `2024-08`,
+ * `2024-08-06`). Detects snapshot-style versions where the date IS (part
+ * of) the version — those require full equality and never participate in
+ * date-stripped matching, on either side.
+ */
+const DATE_SEGMENT = /(?:^|-)(?:\d{6,8}|\d{4}-\d{2}(?:-\d{2})?)(?:-|$)/;
+
+/**
+ * Size/tier quirk markers from model-identity.ts's QUIRK_PATTERNS (#4183).
+ * These denote a DIFFERENT SKU with its own pricing, not a variant of the
+ * matched model:
+ *   - 'small' (mini|nano|tiny|small|lite) and 'large' (large|xl|big|maxi)
+ *     are distinct size tiers sold at their own price points;
+ *   - 'sized-suffix' (7b/70b/405b) is a parameter-count SKU marker.
+ * Deliberately EXCLUDED: 'thinking', 'high-variant', 'vision', 'coder',
+ * 'instruct' (mode/feature variants of the same SKU, same price sheet),
+ * 'embedding' (never reaches identity matching with a matching family),
+ * and 'dated' (handled by the date-stripping rule above).
+ */
+const SIZE_TIER_QUIRKS: ReadonlySet<string> = new Set(['small', 'large', 'sized-suffix']);
+
+/**
+ * Full identity-match for a decorated id (#4164 + #4183): primary exact
+ * version-key lookup, then a date-stripped fallback for dated decorations,
+ * then the sub-SKU guard. Fails closed at every step.
+ */
+export function matchIdentityCandidate(
+  index: ReadonlyMap<string, ModelEntry[]>,
+  identity: ResolvedModelIdentity
+): ModelEntry | undefined {
+  const key = identityKeyFor(identity);
+  if (key === undefined || identity.version === undefined) return undefined;
+  const matched =
+    selectIdentityCandidate(index.get(key)) ??
+    selectDateStripped(index, identity, identity.version);
+  if (matched === undefined) return undefined;
+  return blockedBySizeQuirk(identity, matched) ? undefined : matched;
+}
+
+/** Date-stripped fallback lookup, scoped to the identity's vendor|family. */
+function selectDateStripped(
+  index: ReadonlyMap<string, ModelEntry[]>,
+  identity: Pick<ResolvedModelIdentity, 'vendor' | 'family'>,
+  version: string
+): ModelEntry | undefined {
+  const vk = versionKey(version);
+  if (!TRAILING_DATE_SEGMENT.test(vk)) return undefined;
+  const stripped = vk.replace(TRAILING_DATE_SEGMENT, '');
+  // FAIL-CLOSED guard: index buckets are keyed by the canonical side's
+  // versionKey, so requiring the stripped key to be date-FREE guarantees
+  // every candidate's own version carries no date segment. Snapshot-style
+  // canonicals (dated gpt-4o ids, version = the date) stay reachable only
+  // through full equality on the primary key.
+  if (stripped.length === 0 || DATE_SEGMENT.test(stripped)) return undefined;
+  const strippedKey = identityKeyFor({
+    vendor: identity.vendor,
+    family: identity.family,
+    version: stripped,
+  });
+  if (strippedKey === undefined) return undefined;
+  return selectIdentityCandidate(index.get(strippedKey));
+}
+
+/**
+ * Sub-SKU guard (#4183): a size/tier quirk on the DECORATED id that is
+ * absent from the canonical candidate's identity means the decoration names
+ * a different SKU (`claude-opus-4-8-mini` is not Opus 4.8) — fail closed
+ * rather than grant the parent's pricing. Quirks present on BOTH sides
+ * (`…-lite-hardened` matching a canonical `…-lite`) do not block.
+ */
+function blockedBySizeQuirk(identity: ResolvedModelIdentity, matched: ModelEntry): boolean {
+  const sizeQuirks = identity.quirks.filter((q) => SIZE_TIER_QUIRKS.has(q));
+  if (sizeQuirks.length === 0) return false;
+  const canonicalQuirks = resolveModelIdentitySync(matched.id).quirks;
+  return sizeQuirks.some((q) => !canonicalQuirks.includes(q));
 }

--- a/packages/nexus-agents/src/config/model-registry.test.ts
+++ b/packages/nexus-agents/src/config/model-registry.test.ts
@@ -727,6 +727,172 @@ describe('ModelRegistry — identity resolution tier (#4164)', () => {
   });
 });
 
+// ============================================================================
+// #4183 — fuzzy-resolution follow-ups: dated decorations match their
+// canonical (ONE trailing date segment stripped, fail-closed for
+// snapshot-style dated canonicals), and sub-SKU decorations (size/tier
+// quirk absent from the canonical) fail closed instead of inheriting the
+// full SKU's pricing.
+// ============================================================================
+
+/** Snapshot-style canonical whose version IS the date (gpt-4o-2024-08-06). */
+const gpt4oDatedSnapshot: ModelEntry = {
+  id: 'gpt-4o-2024-08-06',
+  vendor: 'openai',
+  family: 'gpt-4o',
+  version: '2024-08-06',
+  displayName: 'GPT-4o (2024-08-06)',
+  contextWindow: 128_000,
+  maxOutputTokens: 16_384,
+  pricing: { inputPer1M: 2.5, outputPer1M: 10 },
+  parallelToolCalls: true,
+  promptCaching: 'none',
+  toolDefinitionFormat: 'openai',
+  maxRecommendedTurnBudget: 10,
+  strictJson: true,
+  quirks: [],
+  profileId: 'gpt-4o',
+  source: 'in-tree',
+};
+
+/** Canonical gateway sub-SKU that carries a size quirk ('lite') itself. */
+const haikuLiteCanonical: ModelEntry = {
+  id: 'claude-haiku-4-5-lite',
+  vendor: 'anthropic',
+  family: 'claude-haiku',
+  version: '4-5',
+  displayName: 'Claude Haiku 4.5 Lite (gateway SKU)',
+  contextWindow: 200_000,
+  maxOutputTokens: 32_000,
+  pricing: { inputPer1M: 0.5, outputPer1M: 2.5 },
+  parallelToolCalls: true,
+  promptCaching: 'ephemeral',
+  toolDefinitionFormat: 'anthropic',
+  maxRecommendedTurnBudget: 8,
+  strictJson: true,
+  quirks: [],
+  profileId: 'claude-haiku',
+  source: 'manifest',
+};
+
+describe('ModelRegistry — dated decorations (#4183)', () => {
+  it.each(['claude-opus-4-8-20250514', 'anthropic/Claude_Opus_4.8_20250514'])(
+    'dated decoration %s matches its canonical (one trailing date segment stripped)',
+    (decorated) => {
+      const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+      const entry = reg.getEntry(decorated);
+      expect(entry.id).toBe(decorated); // caller's id preserved
+      expect(entry.matchedVia).toBe('identity');
+      expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+      expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+    }
+  );
+
+  it('dated decoration with the WRONG base version fails closed', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const entry = reg.getEntry('claude-opus-4-9-20250514');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.resolvedFrom).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+    expect(entry.source).toBe('derived');
+  });
+
+  it('canonical whose version IS dated still requires full version equality', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [gpt4oDatedSnapshot] });
+    // Exact hit and full-equality decorated hit keep working.
+    expect(reg.getEntry('gpt-4o-2024-08-06').pricing).toEqual({
+      inputPer1M: 2.5,
+      outputPer1M: 10,
+    });
+    const fullEquality = reg.getEntry('gpt-4o-2024-08-06-hardened');
+    expect(fullEquality.matchedVia).toBe('identity');
+    expect(fullEquality.resolvedFrom).toBe('gpt-4o-2024-08-06');
+    // But an EXTRA trailing date segment must not strip its way onto the
+    // snapshot entry — the canonical side's version carries the date.
+    const extraDate = reg.getEntry('gpt-4o-2024-08-06-20250101');
+    expect(extraDate.matchedVia).toBeUndefined();
+    expect(extraDate.pricing).toBeUndefined();
+    expect(extraDate.source).toBe('derived');
+  });
+
+  it('date-stripped fallback keeps ambiguity rules: two distinct candidates fail closed', () => {
+    const a: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9',
+      version: '4-9',
+      aliases: [],
+    };
+    const b: ModelEntry = {
+      ...opus48Canonical,
+      id: 'claude-opus-4-9-preview',
+      version: '4-9',
+      aliases: [],
+      pricing: { inputPer1M: 7, outputPer1M: 35 },
+    };
+    const reg = new ModelRegistry({ inTreeEntries: [a, b] });
+    const entry = reg.getEntry('claude-opus-4-9-20250514');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+    expect(entry.source).toBe('derived');
+  });
+
+  it('date-stripped fallback keeps dedupe rules: effective duplicates collapse first', () => {
+    const reg = new ModelRegistry({
+      generatedEntries: [
+        generatedOpus48('anthropic/claude-opus-4-8', { inputPer1M: 5, outputPer1M: 25 }),
+        generatedOpus48('gateway-x/anthropic.claude-opus-4-8-v1', {
+          inputPer1M: 5,
+          outputPer1M: 25,
+        }),
+      ],
+    });
+    const entry = reg.getEntry('claude-opus-4-8-20250514');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+});
+
+describe('ModelRegistry — sub-SKU fail-closed guard (#4183)', () => {
+  it.each(['claude-opus-4-8-mini', 'claude-opus-4-8-lite', 'claude-opus-4-8-nano'])(
+    'size-marked decoration %s no longer inherits the full SKU pricing',
+    (decorated) => {
+      const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+      const entry = reg.getEntry(decorated);
+      expect(entry.matchedVia).toBeUndefined();
+      expect(entry.resolvedFrom).toBeUndefined();
+      expect(entry.pricing).toBeUndefined();
+      expect(entry.source).toBe('derived');
+    }
+  );
+
+  it('a decoration whose size quirk exists on the canonical too still matches', () => {
+    const reg = new ModelRegistry({ manifestEntries: [haikuLiteCanonical] });
+    const entry = reg.getEntry('claude-haiku-4-5-lite-hardened');
+    expect(entry.matchedVia).toBe('identity');
+    expect(entry.resolvedFrom).toBe('claude-haiku-4-5-lite');
+    expect(entry.pricing).toEqual({ inputPer1M: 0.5, outputPer1M: 2.5 });
+  });
+
+  it.each(['claude-opus-4-8-thinking', 'claude-opus-4-8-high'])(
+    'non-size quirk decoration %s still matches (same-SKU variant)',
+    (decorated) => {
+      const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+      const entry = reg.getEntry(decorated);
+      expect(entry.matchedVia).toBe('identity');
+      expect(entry.resolvedFrom).toBe('claude-opus-4-8');
+      expect(entry.pricing).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+    }
+  );
+
+  it('the guard applies to date-stripped matches too', () => {
+    const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });
+    const entry = reg.getEntry('claude-opus-4-8-20250514-mini');
+    expect(entry.matchedVia).toBeUndefined();
+    expect(entry.pricing).toBeUndefined();
+    expect(entry.source).toBe('derived');
+  });
+});
+
 describe('ModelRegistry — exact-match surfaces stay exact (#4164)', () => {
   it('hasAuthoritative stays false for decorated ids that only fuzzy-match', () => {
     const reg = new ModelRegistry({ inTreeEntries: [opus48Canonical] });

--- a/packages/nexus-agents/src/config/model-registry.ts
+++ b/packages/nexus-agents/src/config/model-registry.ts
@@ -44,12 +44,12 @@ import {
   resolveModelIdentitySync,
   type ModelHints,
   type ModelVendor,
+  type ResolvedModelIdentity,
 } from './model-identity.js';
 import {
   MAX_FUZZY_ID_LENGTH,
   buildIdentityIndex,
-  identityKeyFor,
-  selectIdentityCandidate,
+  matchIdentityCandidate,
 } from './model-fuzzy-resolution.js';
 import { buildInTreeEntries } from './in-tree-entries.js';
 import { loadManifestOverlay } from './manifest-overlay.js';
@@ -260,16 +260,20 @@ export class ModelRegistry {
       return direct;
     }
     if (direct === undefined) {
-      const fuzzy = this.lookupFuzzy(modelId, hints);
+      // Resolve the identity ONCE (#4183 perf): the fuzzy tier's identity
+      // key and, on a miss, derivation both consume the same resolution.
+      const identity = resolveModelIdentitySync(modelId, hints);
+      const fuzzy = this.lookupFuzzy(modelId, identity, hints);
       if (fuzzy !== undefined) return fuzzy;
+      return deriveEntry(modelId, identity);
     }
 
     const identity = resolveModelIdentitySync(modelId, augmentHints(hints, direct));
     const derived = deriveEntry(modelId, identity);
-    if (direct !== undefined && identity.vendor !== 'unknown') {
+    if (identity.vendor !== 'unknown') {
       return mergeSnapshotWithDerived(direct, derived);
     }
-    return direct ?? derived;
+    return direct;
   }
 
   /**
@@ -308,21 +312,27 @@ export class ModelRegistry {
    * (a) retry `lookupExact` with the `normaliseModelId`-normalized id so
    *     aliases + alias-shadow (#3293) keep working;
    * (b) identity-match {vendor, family, version} against the load-time
-   *     index — version required on both sides, tier-ordered uniqueness,
-   *     fail closed on ambiguity (see model-fuzzy-resolution.ts).
+   *     index — version required on both sides (ONE trailing date segment
+   *     tolerated on the decorated side, #4183), tier-ordered uniqueness,
+   *     fail closed on ambiguity and on sub-SKU size markers (see
+   *     model-fuzzy-resolution.ts).
    * Over-long ids skip the tier entirely (straight to derivation).
+   * `identity` is the caller's already-resolved identity for `modelId`
+   * (#4183 perf: resolved once per getEntry call).
    */
-  private lookupFuzzy(modelId: string, hints?: ModelHints): ModelEntry | undefined {
+  private lookupFuzzy(
+    modelId: string,
+    identity: ResolvedModelIdentity,
+    hints?: ModelHints
+  ): ModelEntry | undefined {
     if (modelId.length > MAX_FUZZY_ID_LENGTH) return undefined;
     const normalized = normaliseModelId(modelId);
     const byNormalized = normalized === modelId ? undefined : this.lookupExact(normalized);
     if (byNormalized !== undefined) {
       return this.resolveMatched(byNormalized, modelId, hints, 'normalized');
     }
-    const key = identityKeyFor(resolveModelIdentitySync(modelId, hints));
-    if (key === undefined) return undefined;
     this.identityIndex ??= buildIdentityIndex(this.byId.values());
-    const matched = selectIdentityCandidate(this.identityIndex.get(key));
+    const matched = matchIdentityCandidate(this.identityIndex, identity);
     if (matched === undefined) return undefined;
     return this.resolveMatched(matched, modelId, hints, 'identity');
   }


### PR DESCRIPTION
Closes #4183 (epic #4163). Follow-ups from the adversarial review of #4179, implemented as one slice with decorated-fixture tests (TDD — the six new positive/guard tests were written first and failed before the implementation landed).

## 1. Dated decorations now match their canonical

`claude-opus-4-8-20250514` previously never matched: `extractVersion` yields `4-8-20250514`, which can never equal the canonical `4-8` — yet date-stamping is the most common real gateway decoration. The identity tier (`matchIdentityCandidate` in `model-fuzzy-resolution.ts`) now retries with ONE trailing date segment stripped from the decorated side's version key (`/-\d{6,8}$/` after normalization, mirroring `parseClaudeMajorMinor`'s date-tolerant parse in `model-parameter-support.ts` — same pattern, reimplemented rather than importing a private helper).

**Fail-closed guard:** the fallback only fires when the stripped remainder is itself date-free. Since index buckets are keyed by the canonical side's version key, a date-free stripped key guarantees every candidate's own version carries no date segment — so snapshot-style canonicals whose version IS the date (`gpt-4o-2024-08-06`) stay reachable only through full equality, exactly as before. The stripped retry goes through the same `selectIdentityCandidate`, so tier order, effective-duplicate dedupe, and fail-closed-on-ambiguity are unchanged (covered by tests).

## 2. Sub-SKU fail-closed guard

`claude-opus-4-8-mini` previously identity-matched full Opus 4.8 and inherited its (higher) pricing. Now: if the decorated id's resolved identity carries a size/tier quirk absent from the canonical candidate's identity, the match is abandoned (no pricing — declare the sub-SKU in the manifest to give it its real price).

**Quirk classification reasoning** (from `QUIRK_PATTERNS` in `model-identity.ts`):

- **Size/tier (block):** `small` (`mini|nano|tiny|small|lite`), `large` (`large|xl|big|maxi`), `sized-suffix` (`7b`/`70b`/`405b`). Each names a *different SKU with its own price sheet* — a "mini" of a model is a distinct, separately-priced model, and a parameter-count suffix picks a distinct weight class. Granting the parent's pricing would be a wrong price, which is worse than no price.
- **Mode/feature (do not block):** `thinking`/`reasoning`, `high-variant`, `vision`, `coder`, `instruct` — these are variants or serving modes of the *same* SKU (same underlying model, same price sheet), which is precisely what the fuzzy tier exists to resolve (`2025-claude-opus-4_0_high` was a launch fixture for #4164).
- **`dated`** is handled by item 1's stripping rule, and **`embedding`** cannot reach an identity match with a matching family in practice; neither blocks.

The guard is one-directional per the issue (decorated-side marker missing on the canonical). Quirks present on both sides still match (`claude-haiku-4-5-lite-hardened` against a declared `claude-haiku-4-5-lite`), and the guard also applies to matches found via the date-stripped fallback.

## 3. Perf: identity resolved once per `getEntry`

Derivation-bound misses used to run `resolveModelIdentitySync` twice (identity-key computation in the fuzzy path, then again for derivation). `getEntry` now resolves it once on the exact-miss path and threads it through `lookupFuzzy` and `deriveEntry`. No behavior change — pinned by the existing suite.

## Docs

`docs/guides/MODEL_REGISTRY_PRICING.md` (#4192) updated: dated decorations moved from the "does NOT resolve" hazards to resolved behavior (with the snapshot-canonical full-equality caveat), and the sub-SKU section now documents fail-closed + the manifest declaration being how a sub-SKU gets its real price.

## Gates

- `pnpm test` (full, foreground): 1141 files / 27312 tests passed, 16 skipped, 0 failed
- `pnpm typecheck`: pass
- `pnpm lint`: pass
- changeset: minor (`nexus-agents`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)