### PR TITLE
perf(weather): gate per-model lens out of the routing-bonus path

### DIFF
--- a/.changeset/gate-model-weather-lens.md
+++ b/.changeset/gate-model-weather-lens.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Gate the per-model weather telemetry lens behind an opt-in (`includeModelWeather`), default off (#4202). The routing-bonus path no longer pays the per-model full-store scans introduced in #4194; the `weather_report` MCP tool always opts in, so its response is unchanged.

--- a/packages/nexus-agents/src/mcp/tools/weather-report-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-tool.ts
@@ -79,6 +79,9 @@ function weatherReportHandler(args: unknown, ctx: HandlerContext): Promise<ToolR
       ...(cli !== undefined && { cli }),
       ...(category !== undefined && { category }),
       includeAdaptive,
+      // The MCP tool always opts into the per-model lens (#4194/#4202);
+      // the routing-bonus path stays lens-free.
+      includeModelWeather: true,
     };
     const report = generateWeatherReport(opts);
     const serialized = serializeReport(report);

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -54,6 +54,13 @@ export interface WeatherReportOptions {
   readonly cli?: CliNameLiteral;
   readonly category?: string;
   readonly includeAdaptive?: boolean;
+  /**
+   * Opt-in for the per-model telemetry lens (#4194). Default off (#4202):
+   * the lens scans the full store per distinct model, so the hot
+   * routing-bonus path (weather-bonus-stage) must not pay for it; the
+   * weather_report MCP tool always opts in.
+   */
+  readonly includeModelWeather?: boolean;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.test.ts
@@ -405,7 +405,7 @@ describe('getModelWeatherSummary (#4194)', () => {
   it('rides the report payload without changing routing-visible bonuses', () => {
     seedOutcomes(15, { model: 'claude-opus-4', cli: 'claude', category: 'code_generation' });
 
-    const report = generateWeatherReport({});
+    const report = generateWeatherReport({ includeModelWeather: true });
 
     // Telemetry lens present…
     expect(report.modelWeather?.some((e) => e.model === 'claude-opus-4')).toBe(true);
@@ -421,6 +421,14 @@ describe('getModelWeatherSummary (#4194)', () => {
 
   it('omits the modelWeather section when no model has sufficient samples', () => {
     seedOutcomes(2, { model: 'gpt-5', cli: 'codex' });
+
+    const report = generateWeatherReport({ includeModelWeather: true });
+
+    expect(report.modelWeather).toBeUndefined();
+  });
+
+  it('omits the modelWeather lens entirely when not opted in (#4202 — routing path)', () => {
+    seedOutcomes(15, { model: 'claude-opus-4', cli: 'claude', category: 'code_generation' });
 
     const report = generateWeatherReport({});
 

--- a/packages/nexus-agents/src/mcp/tools/weather-report.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.ts
@@ -106,8 +106,12 @@ function buildOptionalSections(
     triageStats: buildTriageStats(input),
     recentWindow: buildRecentWindow(cfg),
     // Per-model telemetry lens (#4194) — additive optional section; the
-    // routing-visible adaptiveBonuses above stay CLI×category.
-    modelWeather: getModelWeatherSummary(input, cfg),
+    // routing-visible adaptiveBonuses above stay CLI×category. Gated off by
+    // default (#4202): the lens costs a full-store scan per distinct model,
+    // and the routing-bonus path (weather-bonus-stage) reads only
+    // adaptiveBonuses — only the MCP tool opts in.
+    modelWeather:
+      input.includeModelWeather === true ? getModelWeatherSummary(input, cfg) : undefined,
   });
 }
 


### PR DESCRIPTION
Adversarial-review follow-up from #4201 (#4202): the per-model telemetry lens ran unconditionally inside `generateWeatherReport`, so the hot routing-bonus path (weather-bonus-stage → adaptiveBonuses only) paid a full-store scan per distinct model. Now opt-in via `includeModelWeather` (default off); the `weather_report` MCP tool always opts in — tool response unchanged, routing path lens-free again. Tests: lens present when opted in, absent by default (new regression pin), bonuses unchanged. No Zod input change (no Tool Drift). Closes #4202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)