### PR TITLE
feat(registry): add frontier model entries — claude-fable-5, gpt-5.5, gemini-3.5-flash (#4176)

### DIFF
--- a/.changeset/frontier-model-entries.md
+++ b/.changeset/frontier-model-entries.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+feat(registry): add frontier model entries — claude-fable-5, gpt-5.5, gemini-3.5-flash (#4176)
+
+Adds in-tree registry entries (and MODEL_IDS tuple members) for the current
+frontier models from the models.dev snapshot (2026-06-29): claude-fable-5
+(1M context, $10/$50 per 1M, extended-thinking class, cliAlias `fable`),
+gpt-5.5 (1.05M context, $5/$30, reasoning-class: rejects `temperature`,
+expects `max_completion_tokens`, mirrors codex-5.3), and gemini-3.5-flash
+(1M context, $1.5/$9, flash tier). Quality-first defaults bump: `claude` →
+claude-fable-5 and `codex` → gpt-5.5; `gemini` stays on gemini-3-pro because
+gemini-3.5-flash is flash-tier, not a pro successor. claude-fable-5 carries
+explicit `unsupportedParameters: ['temperature']` (belt-and-braces over the
+fable→5.0 regex fallback) and both new reasoning-class incompatibilities are
+locked into KNOWN_PARAMETER_INCOMPATIBILITIES. The generated-catalog loader
+now drops $0/$0 pricing rows (litellm placeholder artifacts, e.g. the
+mythos-class bedrock entry) so `computeCostDetail` reports them as UNPRICED
+(unmeasured) instead of a fake measured $0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,7 +492,7 @@ _Auto-generated from source. 46 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-06-28_
+_Governance Version: 2026-07-03_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ The harness-neutral canonical-paths table (the routing chain, the core registrie
 
 **Adapter access:** go through `UnifiedAdapterRegistry` (singleton via `getGlobalRegistry()`); do NOT call `createAutoAdapter()`/`createResilientAdapter()` in new code. **Model registry** (`config/model-registry.ts` + `config/in-tree-data.ts`) is the single source of truth for pricing, quality, context windows, CLI aliases, defaults — read via `getDefaultRegistry()`, never hardcode.
 
-<!-- GOVERNANCE:MODEL_LIST:START -->Supported models: claude-opus, claude-sonnet, claude-haiku, gemini-3-pro, gemini-pro, gemini-3-flash, gemini-flash, codex-5.3, codex-5.2, codex-5.1-mini, opencode-default, opencode-custom-opus, opencode-custom-sonnet, openrouter-nemotron-super, openrouter-qwen-coder.<!-- GOVERNANCE:MODEL_LIST:END -->
+<!-- GOVERNANCE:MODEL_LIST:START -->Supported models: claude-fable-5, claude-opus, claude-sonnet, claude-haiku, gemini-3-pro, gemini-pro, gemini-3.5-flash, gemini-3-flash, gemini-flash, gpt-5.5, codex-5.3, codex-5.2, codex-5.1-mini, opencode-default, opencode-custom-opus, opencode-custom-sonnet, openrouter-nemotron-super, openrouter-qwen-coder.<!-- GOVERNANCE:MODEL_LIST:END -->
 
 **Voter panel:** 7 roles default (`architect, security, devex, ai_ml, pm, catfish, scope_steward`); `--quick` runs 3 (`architect, security, scope_steward`). Supermajority is 5/7. Full voting thresholds in `.rules/governance.md`.
 

--- a/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/claude-adapter.test.ts
@@ -176,11 +176,12 @@ describe('ClaudeCliAdapter', () => {
     it('should return correct capability profile', () => {
       const caps = adapter.capabilities;
 
+      // Default claude model is claude-fable-5 (frontier tier, #4176).
       expect(caps.reasoning).toBe(10);
       expect(caps.contextWindow).toBe(1_000_000);
-      expect(caps.codeGeneration).toBe(9);
+      expect(caps.codeGeneration).toBe(10);
       expect(caps.speed).toBe(5);
-      expect(caps.cost).toBe(6);
+      expect(caps.cost).toBe(4);
     });
   });
 
@@ -189,17 +190,17 @@ describe('ClaudeCliAdapter', () => {
       const info = adapter.getModelInfo();
 
       // Default model resolves to cliModelName from registry (Issue #1095)
-      expect(info.id).toBe('claude-opus-4-6');
-      expect(info.name).toBe('Claude Opus 4.6');
+      expect(info.id).toBe('claude-fable-5');
+      expect(info.name).toBe('Claude Fable 5');
       expect(info.contextWindow).toBe(1_000_000);
       expect(info.maxOutput).toBe(128_000);
     });
 
-    it('should return correct cost info for opus', () => {
+    it('should return correct cost info for the default (fable) model', () => {
       const info = adapter.getModelInfo();
 
-      expect(info.costPerMillionInput).toBe(5.0);
-      expect(info.costPerMillionOutput).toBe(25.0);
+      expect(info.costPerMillionInput).toBe(10.0);
+      expect(info.costPerMillionOutput).toBe(50.0);
     });
 
     it('resolves legacy claude-opus-4 alias to current Opus via registry (#2200 Child 1)', () => {
@@ -256,8 +257,8 @@ describe('ClaudeCliAdapter', () => {
       expect(capturedArgs).toContain('--output-format');
       expect(capturedArgs).toContain('json');
       expect(capturedArgs).toContain('--model');
-      // Default model 'opus' is passed directly (CLI alias, quality-first)
-      expect(capturedArgs).toContain('opus');
+      // Default model 'fable' is passed directly (CLI alias, quality-first)
+      expect(capturedArgs).toContain('fable');
     });
 
     it('should include system prompt when provided', async () => {

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-adapter.test.ts
@@ -127,7 +127,8 @@ describe('CodexCliAdapter (Subprocess)', () => {
       expect(caps.contextWindow).toBe(1_050_000);
       expect(caps.codeGeneration).toBe(10);
       expect(caps.speed).toBe(7);
-      expect(caps.cost).toBe(5);
+      // gpt-5.5 (frontier codex default, #4176) is pricier than codex-5.3: cost 4.
+      expect(caps.cost).toBe(4);
     });
   });
 
@@ -135,7 +136,7 @@ describe('CodexCliAdapter (Subprocess)', () => {
     it('should return correct model info for default model (from registry)', () => {
       const info = adapter.getModelInfo();
 
-      // Default model is derived from canonical registry (codex-5.3 → 'gpt-5.4')
+      // Default model is derived from canonical registry (gpt-5.5 → 'gpt-5.5', #4176)
       expect(info.id).toBe(EXPECTED_DEFAULT_ID);
       expect(info.contextWindow).toBe(1_050_000);
       expect(info.maxOutput).toBe(128_000);
@@ -144,9 +145,9 @@ describe('CodexCliAdapter (Subprocess)', () => {
     it('should return registry-derived cost info for default model', () => {
       const info = adapter.getModelInfo();
 
-      // gpt-5.4 maps to codex-5.3 in registry: pricing {2.5, 15.0}
-      expect(info.costPerMillionInput).toBe(2.5);
-      expect(info.costPerMillionOutput).toBe(15.0);
+      // Default gpt-5.5 in registry (#4176): pricing {5.0, 30.0}
+      expect(info.costPerMillionInput).toBe(5.0);
+      expect(info.costPerMillionOutput).toBe(30.0);
     });
 
     it('should return correct info for o3-mini model (from registry)', () => {

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
@@ -96,7 +96,8 @@ describe('CodexMcpAdapter', () => {
       expect(caps.contextWindow).toBe(1_050_000);
       expect(caps.codeGeneration).toBe(10);
       expect(caps.speed).toBe(7);
-      expect(caps.cost).toBe(5);
+      // gpt-5.5 (frontier codex default, #4176) is pricier than codex-5.3: cost 4.
+      expect(caps.cost).toBe(4);
     });
   });
 
@@ -112,9 +113,9 @@ describe('CodexMcpAdapter', () => {
     it('should return registry-derived cost info for default model', () => {
       const info = adapter.getModelInfo();
 
-      // o3 maps to codex-5.3 in registry: pricing {2.5, 15.0}
-      expect(info.costPerMillionInput).toBe(2.5);
-      expect(info.costPerMillionOutput).toBe(15.0);
+      // Default gpt-5.5 in registry (#4176): pricing {5.0, 30.0}
+      expect(info.costPerMillionInput).toBe(5.0);
+      expect(info.costPerMillionOutput).toBe(30.0);
     });
 
     it('should return correct info for o3-mini model (from registry)', () => {

--- a/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
@@ -29,6 +29,15 @@ describe('resolveModelForTier (#3394)', () => {
     expect(resolveModelForTier('claude', 'powerful')).toBe('claude-opus');
   });
 
+  it('picks codex-5.3 for the codex powerful tier despite gpt-5.5 being the CLI default (#4176)', () => {
+    // Deliberate tension, mirroring the claude pin above: gpt-5.5 and
+    // codex-5.3 tie at reasoning 10, so the tier resolver's tie-break
+    // (cheaper — higher cost score — first) picks codex-5.3 (cost 5 vs 4),
+    // while DEFAULT_MODEL_PER_CLI.codex is the frontier gpt-5.5.
+    expect(resolveModelForTier('codex', 'powerful')).toBe('codex-5.3');
+    expect(getDefaultModelForCli('codex')).toBe('gpt-5.5');
+  });
+
   it('picks the highest-speed model for the fast tier', () => {
     const models = findInTreeByCli('claude');
     const best = models

--- a/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/resolve-model-for-tier.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 
 import { resolveModelForTier, TIER_QUALITY_DIMENSION } from './resolve-model-for-tier.js';
 import { findInTreeByCli, getDefaultModelForCli } from '../config/model-config-helpers.js';
+import type { ModelCapability } from '../config/model-capabilities-types.js';
 
 describe('resolveModelForTier (#3394)', () => {
   it('maps each tier to its quality dimension (table-driven)', () => {
@@ -16,11 +17,16 @@ describe('resolveModelForTier (#3394)', () => {
   });
 
   it('picks the highest-reasoning claude model for the powerful tier', () => {
-    const claudeModels = findInTreeByCli('claude');
-    const best = claudeModels
+    // Mirror the documented tie-break: reasoning desc, then cheaper (higher
+    // cost score) first, then lexicographic. Since #4176 claude-fable-5 and
+    // claude-opus tie at reasoning 10; opus (cost 6 vs 4) wins as the cheaper.
+    const rank = (m: ModelCapability): number =>
+      (m.qualityScores?.reasoning ?? 0) * 100 + (m.qualityScores?.cost ?? 0);
+    const best = findInTreeByCli('claude')
       .filter((m) => typeof m.qualityScores?.reasoning === 'number')
-      .sort((a, b) => (b.qualityScores?.reasoning ?? 0) - (a.qualityScores?.reasoning ?? 0))[0];
+      .sort((a, b) => rank(b) - rank(a) || a.id.localeCompare(b.id))[0];
     expect(resolveModelForTier('claude', 'powerful')).toBe(best?.id);
+    expect(resolveModelForTier('claude', 'powerful')).toBe('claude-opus');
   });
 
   it('picks the highest-speed model for the fast tier', () => {

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/quality-constraint-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/quality-constraint-stage.test.ts
@@ -58,27 +58,28 @@ describe('QualityConstraintStage', () => {
     });
 
     it('filters low quality candidates', async () => {
-      // Derived from registry: claude=0.95, gemini=0.95, codex=1.0
-      // At minQuality=0.96, only codex (1.0) passes
+      // Derived from registry (#4176): claude=1.0 (claude-fable-5),
+      // gemini=0.95 (gemini-3-pro), codex=1.0 (gpt-5.5)
+      // At minQuality=0.96, claude and codex pass
       const strictStage = new QualityConstraintStage({ minQuality: 0.96 });
       const ctx = createContext('test task');
       const result = await strictStage.route(ctx);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Claude (0.95) and Gemini (0.95) should be filtered
+        // Gemini (0.95) should be filtered
         const filtered = result.value.context.filtered;
-        expect(filtered.has('claude')).toBe(true);
         expect(filtered.has('gemini')).toBe(true);
-        // Codex (1.0) should pass
+        // Claude (1.0) and Codex (1.0) should pass
+        expect(filtered.has('claude')).toBe(false);
         expect(filtered.has('codex')).toBe(false);
       }
     });
 
     it('filters high cost candidates', async () => {
-      // Derived from registry pricing (inputPer1M):
-      // claude-opus=$15/M → $0.015/1k, gemini-3-pro=$1.25/M → $0.00125/1k, codex-5.3=$2/M → $0.002/1k
-      // At 1500 tokens: claude=$0.0225, gemini=$0.001875, codex=$0.003
+      // Derived from registry pricing (inputPer1M, #4176 defaults):
+      // claude-fable-5=$10/M → $0.01/1k, gemini-3-pro=$2/M → $0.002/1k, gpt-5.5=$5/M → $0.005/1k
+      // At 1500 tokens: claude=$0.015, gemini=$0.003, codex=$0.0075
       const lowBudgetStage = new QualityConstraintStage({
         maxCostUsd: 0.004,
         expectedTokens: 1500,
@@ -88,11 +89,11 @@ describe('QualityConstraintStage', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Only gemini ($0.001875) and codex ($0.003) pass
+        // Only gemini ($0.003) passes
         const filtered = result.value.context.filtered;
         expect(filtered.has('claude')).toBe(true);
+        expect(filtered.has('codex')).toBe(true);
         expect(filtered.has('gemini')).toBe(false);
-        expect(filtered.has('codex')).toBe(false);
       }
     });
 
@@ -114,7 +115,7 @@ describe('QualityConstraintStage', () => {
 
     it('uses fallback when all filtered', async () => {
       // Make constraints impossible to meet
-      // Derived: claude=0.95, gemini=0.95, codex=1.0 — need >1.0 to filter all
+      // Derived: claude=1.0, gemini=0.95, codex=1.0 (#4176) — need >1.0 to filter all
       const impossibleStage = new QualityConstraintStage({
         minQuality: 1.01,
         allowFallback: true,
@@ -124,9 +125,9 @@ describe('QualityConstraintStage', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Codex should be fallback (highest quality at 1.0)
+        // Claude should be fallback (ties codex at quality 1.0; first profile wins)
         expect(result.value.context.signals).toContain('quality:used-fallback');
-        expect(result.value.context.filtered.has('codex')).toBe(false);
+        expect(result.value.context.filtered.has('claude')).toBe(false);
         expect(result.value.continuesPipeline).toBe(true);
       }
     });
@@ -146,7 +147,7 @@ describe('QualityConstraintStage', () => {
     });
 
     it('adds constraint violation signals', async () => {
-      // Derived: claude=0.95, gemini=0.95 → filtered at 0.96
+      // Derived: gemini=0.95 → filtered at 0.96 (#4176)
       const strictStage = new QualityConstraintStage({ minQuality: 0.96 });
       const ctx = createContext('test task');
       const result = await strictStage.route(ctx);
@@ -209,13 +210,13 @@ describe('QualityConstraintStage', () => {
     });
 
     it('tracks filtered count', async () => {
-      // Derived: claude=0.95, gemini=0.95 filtered at 0.96; codex=1.0 passes
+      // Derived (#4176): gemini=0.95 filtered at 0.96; claude=1.0, codex=1.0 pass
       const strictStage = new QualityConstraintStage({ minQuality: 0.96 });
       await strictStage.route(createContext('test'));
 
       const stats = strictStage.getStats();
-      // 2 candidates should be filtered (claude, gemini)
-      expect(stats['filteredCount']).toBe(2);
+      // 1 candidate should be filtered (gemini)
+      expect(stats['filteredCount']).toBe(1);
     });
 
     it('tracks fallback count', async () => {
@@ -230,23 +231,23 @@ describe('QualityConstraintStage', () => {
     });
 
     it('tracks constraint violations by type', async () => {
-      // Derived: claude=0.95, gemini=0.95 filtered at 0.96
+      // Derived (#4176): gemini=0.95 filtered at 0.96
       const qualityStage = new QualityConstraintStage({ minQuality: 0.96 });
       await qualityStage.route(createContext('test'));
 
       const stats = qualityStage.getStats();
       const violations = stats['constraintViolations'] as Record<string, number>;
-      expect(violations['quality']).toBe(2); // claude and gemini
+      expect(violations['quality']).toBe(1); // gemini
     });
 
     it('calculates filter rate', async () => {
-      // Derived: claude=0.95, gemini=0.95 filtered at 0.96
+      // Derived (#4176): gemini=0.95 filtered at 0.96
       const strictStage = new QualityConstraintStage({ minQuality: 0.96 });
       await strictStage.route(createContext('test'));
 
       const stats = strictStage.getStats();
-      // 2 filtered out of 1 routing = rate of 2
-      expect(stats['filterRate']).toBe(2);
+      // 1 filtered out of 1 routing = rate of 1
+      expect(stats['filterRate']).toBe(1);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/topsis-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/topsis-router.test.ts
@@ -231,8 +231,9 @@ describe('TopsisRouter', () => {
 
       const result = qualityOnly.selectModel();
 
-      // Codex has highest quality score (10) — quality-first defaults (Issue #807)
-      expect(result.selectedModel).toBe('codex');
+      // claude (claude-fable-5) and codex (gpt-5.5) tie at quality 10 (#4176)
+      // — with cost/latency weights at 0 either is the highest-quality pick.
+      expect(['claude', 'codex']).toContain(result.selectedModel);
       expect(result.estimatedSavingsPercent).toBeGreaterThanOrEqual(0);
     });
   });

--- a/packages/nexus-agents/src/config/in-tree-data.ts
+++ b/packages/nexus-agents/src/config/in-tree-data.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- data-only registry; grows with every supported model (#4176) */
 /**
  * nexus-agents/config - In-tree model data
  *
@@ -39,9 +40,28 @@ import type {
  */
 export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
   version: 3,
-  updatedAt: '2026-03-14',
+  updatedAt: '2026-07-03',
   models: [
     // ----- Anthropic Claude -----
+    {
+      id: 'claude-fable-5',
+      displayName: 'Claude Fable 5',
+      provider: 'anthropic',
+      contextWindow: 1_000_000,
+      outputModalities: ['text', 'structured_json', 'code'],
+      inputModalities: ['text', 'image', 'pdf', 'code'],
+      toolCapabilities: ['mcp', 'function_calling', 'computer_use', 'structured_output'],
+      specialFeatures: ['extended_thinking', 'streaming', 'citations', 'context_caching'],
+      notes: 'Frontier Claude (models.dev 2026-06-29); above Opus 4.6; 1M context',
+      pricing: { inputPer1M: 10.0, outputPer1M: 50.0 },
+      qualityScores: { reasoning: 10, codeGeneration: 10, speed: 5, cost: 4 },
+      maxOutputTokens: 128_000,
+      cliName: 'claude',
+      cliAlias: 'fable',
+      cliModelName: 'claude-fable-5',
+      // #4176 belt-and-braces: fable→5.0 regex fallback already rejects temperature.
+      unsupportedParameters: ['temperature'],
+    },
     {
       id: 'claude-opus',
       displayName: 'Claude Opus 4.6',
@@ -157,6 +177,28 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliModelName: 'gemini-2.5-pro',
     },
     {
+      id: 'gemini-3.5-flash',
+      displayName: 'Gemini 3.5 Flash',
+      provider: 'google',
+      contextWindow: 1_048_576,
+      outputModalities: ['text', 'structured_json', 'code'],
+      inputModalities: ['text', 'image', 'audio', 'video', 'pdf', 'code'],
+      toolCapabilities: [
+        'function_calling',
+        'code_execution_sandbox',
+        'web_search',
+        'structured_output',
+      ],
+      specialFeatures: ['streaming', 'grounding'],
+      notes: 'Latest fast Gemini (models.dev 2026-06-29); flash tier, NOT the gemini default',
+      pricing: { inputPer1M: 1.5, outputPer1M: 9.0 },
+      // Flash tier: reasoning stays BELOW gemini-3-pro (10) so pro keeps winning.
+      qualityScores: { reasoning: 8, codeGeneration: 9, speed: 10, cost: 8 },
+      maxOutputTokens: 65_536,
+      cliName: 'gemini',
+      cliModelName: 'gemini-3.5-flash',
+    },
+    {
       id: 'gemini-3-flash',
       displayName: 'Gemini 3 Flash (Preview)',
       provider: 'google',
@@ -199,6 +241,32 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       cliModelName: 'gemini-2.5-flash',
     },
     // ----- OpenAI Codex -----
+    {
+      id: 'gpt-5.5',
+      displayName: 'GPT-5.5',
+      provider: 'openai',
+      contextWindow: 1_050_000,
+      outputModalities: ['text', 'structured_json', 'code'],
+      inputModalities: ['text', 'image', 'pdf', 'code'],
+      toolCapabilities: [
+        'function_calling',
+        'code_execution_sandbox',
+        'web_search',
+        'file_operations',
+        'structured_output',
+        'apply_patch',
+        'computer_use',
+      ],
+      specialFeatures: ['streaming'],
+      notes: 'Frontier GPT (models.dev 2026-06-29); succeeds GPT-5.4 in Codex CLI; 1M context',
+      pricing: { inputPer1M: 5.0, outputPer1M: 30.0 },
+      qualityScores: { reasoning: 10, codeGeneration: 10, speed: 7, cost: 4 },
+      maxOutputTokens: 128_000,
+      cliName: 'codex',
+      cliModelName: 'gpt-5.5',
+      unsupportedParameters: ['temperature'],
+      maxTokensParam: 'max_completion_tokens',
+    },
     {
       id: 'codex-5.3',
       displayName: 'GPT-5.4',
@@ -377,8 +445,9 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
  * Quality-first: each CLI routes to its strongest model by default.
  */
 export const DEFAULT_MODEL_PER_CLI: Record<CliNameLiteral, ModelId> = {
-  claude: 'claude-opus',
+  // #4176: fable/gpt-5.5 are strongest per CLI; gemini-3.5-flash is flash-tier, not default.
+  claude: 'claude-fable-5',
   gemini: 'gemini-3-pro',
-  codex: 'codex-5.3',
+  codex: 'gpt-5.5',
   opencode: 'opencode-default',
 };

--- a/packages/nexus-agents/src/config/model-capabilities-types.ts
+++ b/packages/nexus-agents/src/config/model-capabilities-types.ts
@@ -107,13 +107,16 @@ export const DEFAULT_ROUTING_CONFIDENCE = 0.85;
  * until then.
  */
 export const MODEL_IDS = [
+  'claude-fable-5',
   'claude-opus',
   'claude-sonnet',
   'claude-haiku',
   'gemini-3-pro',
   'gemini-pro',
+  'gemini-3.5-flash',
   'gemini-3-flash',
   'gemini-flash',
+  'gpt-5.5',
   'codex-5.3',
   'codex-5.2',
   'codex-5.1-mini',

--- a/packages/nexus-agents/src/config/model-parameter-support.ts
+++ b/packages/nexus-agents/src/config/model-parameter-support.ts
@@ -188,10 +188,15 @@ export interface KnownParameterIncompatibility {
 export const KNOWN_PARAMETER_INCOMPATIBILITIES: readonly KnownParameterIncompatibility[] = [
   // #4061 — Claude after Opus 4.6 rejects a non-1.0 temperature with a 400 (regex fallback; unregistered concrete id).
   { modelId: 'claude-opus-4-8', param: 'temperature', issue: 4061 },
+  // #4176 — Claude Fable 5 (frontier) rejects temperature; registry-encoded via `unsupportedParameters` on the in-tree entry (regex fallback also covers it: fable→5.0 > 4.6).
+  { modelId: 'claude-fable-5', param: 'temperature', issue: 4176 },
   // #4062 — OpenAI reasoning families reject temperature (o-series/gpt-5 via regex fallback; codex via registry data).
   { modelId: 'o3-mini', param: 'temperature', issue: 4062 },
   { modelId: 'gpt-5', param: 'temperature', issue: 4062 },
   { modelId: 'codex-5.3', param: 'temperature', issue: 4062 },
+  // #4176 — GPT-5.5 (frontier reasoning) rejects temperature and expects `max_completion_tokens`; registry-encoded, mirroring codex-5.3.
+  { modelId: 'gpt-5.5', param: 'temperature', issue: 4176 },
+  { modelId: 'gpt-5.5', maxTokensParam: 'max_completion_tokens', issue: 4176 },
   // #4049 — OpenAI reasoning models expect `max_completion_tokens`, not `max_tokens` (codex via registry; o-series via fallback).
   { modelId: 'codex-5.3', maxTokensParam: 'max_completion_tokens', issue: 4049 },
   { modelId: 'o3-mini', maxTokensParam: 'max_completion_tokens', issue: 4049 },

--- a/packages/nexus-agents/src/config/model-registry.test.ts
+++ b/packages/nexus-agents/src/config/model-registry.test.ts
@@ -308,7 +308,7 @@ describe('getDefaultModelForCli — early-bootstrap fallback (#3185 condition 1)
   it('returns the static default id with NO registry constructed (no recursion)', () => {
     setDefaultRegistry(undefined);
     // peekDefaultRegistry() is undefined here, so the static fallback fires.
-    expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+    expect(getDefaultModelForCli('claude')).toBe('claude-fable-5');
     // And it must NOT have constructed the registry as a side effect.
     expect(peekDefaultRegistry()).toBeUndefined();
   });
@@ -349,7 +349,7 @@ models:
       expect(after?.contextWindow).toBe(123456);
       // getDefaultModelForCli still resolves to the canonical id, now via the
       // overlay-bearing registry (it exists post-reload).
-      expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+      expect(getDefaultModelForCli('claude')).toBe('claude-fable-5');
       expect(peekDefaultRegistry()).toBeDefined();
     } finally {
       if (previous === undefined) delete process.env['NEXUS_MODELS_OVERLAY_PATH'];
@@ -374,7 +374,7 @@ models:
       // Must degrade to the in-tree floor, not throw.
       await expect(reloadDefaultRegistry()).resolves.toBeDefined();
       // In-tree entries still resolve.
-      expect(getDefaultModelForCli('claude')).toBe('claude-opus');
+      expect(getDefaultModelForCli('claude')).toBe('claude-fable-5');
     } finally {
       if (previous === undefined) delete process.env['NEXUS_MODELS_OVERLAY_PATH'];
       else process.env['NEXUS_MODELS_OVERLAY_PATH'] = previous;

--- a/packages/nexus-agents/src/config/models-generated-loader.test.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.test.ts
@@ -65,3 +65,60 @@ describe('models-generated-loader data-dir precedence (#3707)', () => {
     expect(result.status).toBe('loaded');
   });
 });
+
+describe('models-generated-loader $0/$0 pricing guard (#4176)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-genreg-zero-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function loadFixture(entries: unknown[]): ReturnType<typeof loadGeneratedRegistryEntries> {
+    const path = join(tmpDir, 'zero-price-fixture.json');
+    writeFileSync(path, JSON.stringify({ version: 1, entries }));
+    return loadGeneratedRegistryEntries({ path });
+  }
+
+  it('drops $0/$0 catalog pricing so the entry stays UNPRICED (not a fake free model)', () => {
+    // Real incident shape: litellm carries placeholder $0/$0 rows for models it
+    // has no pricing for (e.g. amazon-bedrock/anthropic.claude-mythos-preview).
+    // If that pricing flowed through, computeCostDetail would report
+    // priced:true costUsd:0 — a measured $0 for what is actually UNMEASURED.
+    const result = loadFixture([
+      {
+        id: 'amazon-bedrock/anthropic.claude-mythos-preview',
+        contextWindow: 1_000_000,
+        pricing: { inputPer1M: 0, outputPer1M: 0 },
+      },
+    ]);
+    const entry = result.entries.find(
+      (e) => e.id === 'amazon-bedrock/anthropic.claude-mythos-preview'
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.pricing).toBeUndefined();
+  });
+
+  it('keeps real non-zero pricing untouched', () => {
+    const result = loadFixture([
+      { id: 'litellm/priced-model', pricing: { inputPer1M: 2.5, outputPer1M: 10 } },
+    ]);
+    expect(result.entries[0]?.pricing).toEqual({ inputPer1M: 2.5, outputPer1M: 10 });
+  });
+
+  it('keeps pricing where only ONE side is zero (free input tiers are real)', () => {
+    const result = loadFixture([
+      { id: 'litellm/free-input-model', pricing: { inputPer1M: 0, outputPer1M: 4 } },
+    ]);
+    expect(result.entries[0]?.pricing).toEqual({ inputPer1M: 0, outputPer1M: 4 });
+  });
+});

--- a/packages/nexus-agents/src/config/models-generated-loader.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.ts
@@ -66,17 +66,33 @@ function defaultGeneratedPath(): string {
   return join(here, 'model-registry.generated.json');
 }
 
+/**
+ * Extract usable pricing from a raw catalog record.
+ *
+ * #4176: litellm carries placeholder $0/$0 rows for models it has no pricing
+ * for (e.g. `amazon-bedrock/anthropic.claude-mythos-preview`). Treating that
+ * as real pricing makes `computeCostDetail` report priced:true costUsd:0 — a
+ * measured $0 for what is actually UNMEASURED (#4165). Drop BOTH-zero pricing
+ * so the entry stays unpriced; one-sided zeros (free input tiers) are real
+ * and kept. Genuinely free models are represented in-tree (higher tier), so
+ * nothing legitimate is lost at this lowest-priority breadth tier.
+ */
+function extractPricing(
+  rec: GeneratedRecord
+): { inputPer1M: number; outputPer1M: number } | undefined {
+  const inputPer1M = rec.pricing?.inputPer1M;
+  const outputPer1M = rec.pricing?.outputPer1M;
+  if (typeof inputPer1M !== 'number' || typeof outputPer1M !== 'number') return undefined;
+  if (inputPer1M === 0 && outputPer1M === 0) return undefined;
+  return { inputPer1M, outputPer1M };
+}
+
 /** Convert one raw catalog record into a `ModelEntry` (derived base + overlay). */
 function toModelEntry(rec: GeneratedRecord): ModelEntry | undefined {
   if (typeof rec.id !== 'string' || rec.id === '') return undefined;
   const id = rec.id;
   const base = deriveEntry(id, resolveModelIdentitySync(id));
-  const pricing =
-    rec.pricing !== undefined &&
-    typeof rec.pricing.inputPer1M === 'number' &&
-    typeof rec.pricing.outputPer1M === 'number'
-      ? { inputPer1M: rec.pricing.inputPer1M, outputPer1M: rec.pricing.outputPer1M }
-      : undefined;
+  const pricing = extractPricing(rec);
   return {
     ...base,
     source: 'generated',

--- a/packages/nexus-agents/src/config/task-specialization-integration.test.ts
+++ b/packages/nexus-agents/src/config/task-specialization-integration.test.ts
@@ -212,11 +212,12 @@ describe('selectModel with specialization integration', () => {
     expect(result.reasoning).toContain('architecture');
   });
 
-  it('prefers codex for implementation tasks', () => {
+  it('prefers a codex-CLI model for implementation tasks', () => {
     const input = { task: 'Implement the API endpoint', estimate_tokens: false };
     const req = makeReq({ needsCodeGen: true });
     const result = selectModel(input, req, 'plan');
-    // codex-5.3 should be selected (code generation + specialization)
-    expect(result.model).toContain('codex');
+    // A codex-CLI model should be selected (code generation + specialization);
+    // since #4176 the frontier gpt-5.5 tops codex-5.3.
+    expect(['gpt-5.5', 'codex-5.3', 'codex-5.2']).toContain(result.model);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model-router.test.ts
@@ -52,7 +52,7 @@ function makeDecision(overrides: Record<string, unknown> = {}) {
 
 describe('cliNameToModel', () => {
   it('maps claude to default model from registry', () => {
-    expect(cliNameToModel('claude')).toBe('claude-opus');
+    expect(cliNameToModel('claude')).toBe('claude-fable-5');
   });
 
   it('maps gemini to default model from registry', () => {
@@ -60,7 +60,7 @@ describe('cliNameToModel', () => {
   });
 
   it('maps codex to default model from registry', () => {
-    expect(cliNameToModel('codex')).toBe('codex-5.3');
+    expect(cliNameToModel('codex')).toBe('gpt-5.5');
   });
 });
 
@@ -73,7 +73,7 @@ describe('mapCompositeDecisionToOutput', () => {
     const decision = makeDecision();
     const output = mapCompositeDecisionToOutput(decision, 500);
 
-    expect(output.recommended_model).toBe('claude-opus');
+    expect(output.recommended_model).toBe('claude-fable-5');
     expect(output.reasoning).toBe('Best model for reasoning tasks');
     expect(output.estimated_tokens).toBe(500);
   });
@@ -89,13 +89,13 @@ describe('mapCompositeDecisionToOutput', () => {
     const decision = makeDecision();
     const output = mapCompositeDecisionToOutput(decision, 500);
 
-    expect(output.recommended_model).toBe('claude-opus');
+    expect(output.recommended_model).toBe('claude-fable-5');
   });
 
   it('includes capabilities from MODEL_CAPABILITIES', () => {
     const decision = makeDecision();
     const output = mapCompositeDecisionToOutput(decision, 100);
-    const expected = MODEL_CAPABILITIES['claude-opus'];
+    const expected = MODEL_CAPABILITIES['claude-fable-5'];
 
     expect(output.capabilities).toEqual(expected);
   });
@@ -127,7 +127,7 @@ describe('mapCompositeDecisionToOutput', () => {
     const output = mapCompositeDecisionToOutput(decision, 100);
 
     expect(output.alternatives[0]!.model).toBe('gemini-3-pro');
-    expect(output.alternatives[1]!.model).toBe('codex-5.3');
+    expect(output.alternatives[1]!.model).toBe('gpt-5.5');
   });
 
   it('uses topsisScore for alternative scores', () => {
@@ -176,7 +176,7 @@ describe('mapCompositeDecisionToOutput', () => {
     const decision = makeDecision({ cliName: 'codex' });
     const output = mapCompositeDecisionToOutput(decision, 100);
 
-    expect(output.capabilities).toEqual(MODEL_CAPABILITIES['codex-5.3']);
+    expect(output.capabilities).toEqual(MODEL_CAPABILITIES['gpt-5.5']);
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/delegate-to-model.test.ts
@@ -240,7 +240,9 @@ describe('delegate_to_model Tool', () => {
 
       // Top-tier models should be selected for reasoning tasks
       expect([
+        'claude-fable-5',
         'claude-opus',
+        'gpt-5.5',
         'codex-5.3',
         'codex-5.2',
         'claude-sonnet',
@@ -387,9 +389,13 @@ describe('delegate_to_model Tool', () => {
       const content = result.content as Array<{ type: string; text: string }>;
       const output = JSON.parse(content[0]!.text) as DelegateOutput;
       // Should select a fast model (gemini-flash or claude-haiku)
-      expect(['gemini-flash', 'gemini-3-flash', 'claude-haiku', 'codex-5.1-mini']).toContain(
-        output.recommended_model
-      );
+      expect([
+        'gemini-flash',
+        'gemini-3.5-flash',
+        'gemini-3-flash',
+        'claude-haiku',
+        'codex-5.1-mini',
+      ]).toContain(output.recommended_model);
     });
   });
 

--- a/packages/nexus-agents/src/testing/adapters/mock-adapter-helpers.test.ts
+++ b/packages/nexus-agents/src/testing/adapters/mock-adapter-helpers.test.ts
@@ -42,7 +42,7 @@ describe('DEFAULT_CONFIG', () => {
 
 describe('MODEL_INFO_BY_NAME', () => {
   it('contains info for claude', () => {
-    expect(MODEL_INFO_BY_NAME.claude.id).toBe('claude-opus');
+    expect(MODEL_INFO_BY_NAME.claude.id).toBe('claude-fable-5');
     expect(MODEL_INFO_BY_NAME.claude.contextWindow).toBe(1_000_000);
   });
 
@@ -51,7 +51,7 @@ describe('MODEL_INFO_BY_NAME', () => {
   });
 
   it('contains info for codex', () => {
-    expect(MODEL_INFO_BY_NAME.codex.id).toBe('codex-5.3');
+    expect(MODEL_INFO_BY_NAME.codex.id).toBe('gpt-5.5');
   });
 });
 

--- a/packages/nexus-agents/src/testing/adapters/mock-adapter.test.ts
+++ b/packages/nexus-agents/src/testing/adapters/mock-adapter.test.ts
@@ -146,7 +146,7 @@ describe('MockCliAdapter', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.model).toBe('claude-opus');
+        expect(result.value.model).toBe('claude-fable-5');
       }
     });
 
@@ -397,8 +397,8 @@ describe('MockCliAdapter', () => {
     it('should return claude model info by default', () => {
       const info = adapter.getModelInfo();
 
-      expect(info.id).toBe('claude-opus');
-      expect(info.name).toBe('Claude Opus 4.6');
+      expect(info.id).toBe('claude-fable-5');
+      expect(info.name).toBe('Claude Fable 5');
       expect(info.contextWindow).toBe(1_000_000);
     });
 
@@ -417,8 +417,8 @@ describe('MockCliAdapter', () => {
 
       const info = codexAdapter.getModelInfo();
 
-      expect(info.id).toBe('codex-5.3');
-      expect(info.name).toBe('GPT-5.4');
+      expect(info.id).toBe('gpt-5.5');
+      expect(info.name).toBe('GPT-5.5');
       expect(info.contextWindow).toBe(1_050_000);
     });
   });


### PR DESCRIPTION
Closes #4176 (child 1 of epic #4175).

## What

Adds in-tree registry entries + `MODEL_IDS` tuple members for the current frontier models, sourced from the models.dev snapshot (2026-06-29) — snapshot values used verbatim, nothing guessed:

| id | provider | context | maxOutput | pricing (in/out per 1M) | notes |
|---|---|---|---|---|---|
| `claude-fable-5` | anthropic | 1,000,000 | 128,000 | $10 / $50 | extended_thinking/streaming/citations/context_caching (claude-opus class); qualityScores 10/10/5/4; cliName `claude`, cliAlias `fable`, cliModelName `claude-fable-5` |
| `gpt-5.5` | openai | 1,050,000 | 128,000 | $5 / $30 | wired like codex-5.3: cliName `codex`, `unsupportedParameters: ['temperature']`, `maxTokensParam: 'max_completion_tokens'` |
| `gemini-3.5-flash` | google | 1,048,576 | 65,536 | $1.5 / $9 | cliName `gemini` (flash-entry convention); reasoning kept at 8 so pro-tier keeps winning reasoning-weighted routing |

No aliases were invented: the snapshot does NOT list `claude-mythos-5` (or any alias) for `claude-fable-5`, so the entry ships without aliases.

## DEFAULT_MODEL_PER_CLI decisions (quality-first convention)

- `claude` → **claude-fable-5** (frontier; above claude-opus on reasoning+code)
- `codex` → **gpt-5.5** (unambiguously stronger than codex-5.3/gpt-5.4)
- `gemini` → **unchanged (gemini-3-pro)**: gemini-3.5-flash is flash-tier, not a pro successor
- `opencode` → unchanged

## Parameter incompatibilities

- `claude-fable-5` carries explicit `unsupportedParameters: ['temperature']` — belt-and-braces over the existing fable→5.0 regex fallback in `model-parameter-support.ts`.
- `gpt-5.5` mirrors codex-5.3 (temperature rejected + `max_completion_tokens`).
- Three new `KNOWN_PARAMETER_INCOMPATIBILITIES` rows (claude-fable-5 temperature; gpt-5.5 temperature + max_completion_tokens) so the #4070 drift guard locks them in.

## $0/$0 generated-catalog pricing guard (no `registry refresh` in this PR)

The LiteLLM catalog was deliberately NOT regenerated (network-dependent, separate concern). Verified the existing catalog's `amazon-bedrock/anthropic.claude-mythos-preview` $0/$0 row **did** poison cost math: the generated loader passed `{0,0}` pricing through, so `computeCostDetail` returned `priced:true, costUsd:0` — a *measured* $0 for what is actually unmeasured (#4165 semantics). Fix: `models-generated-loader` now drops pricing where `inputPer1M===0 && outputPer1M===0` (catalog placeholder artifact; one-sided zeros like free input tiers are kept; genuinely free models live in-tree at a higher tier). Runtime probe after the fix: mythos ids resolve `priced:false`; `claude-fable-5` resolves from the in-tree tier with real pricing (`priced:true`, `resolvedId: claude-fable-5`), so fable ids never fall through to the $0 artifact. Covered by three new loader tests (TDD: written first, red, then the guard).

## Pricing-drift gate (advisory, #4173)

`pnpm check:pricing-drift` run against the live litellm catalog: **no drift reported for any entry, including the three new ones** (all three ids present in litellm and matching). Only the 5 expected not-in-catalog models (opencode/custom/openrouter gateways) were listed.

## Fixture cascade (full suite, never-weakened asserts)

`MODEL_IDS` grew 15 → 18; deliberate fixture updates:
- `model-registry.test.ts` — claude default assertions → claude-fable-5
- `delegate-to-model.test.ts` / `delegate-to-model-router.test.ts` — top-tier + fast-tier candidate sets, CLI-default mappings
- `mock-adapter.test.ts` / `mock-adapter-helpers.test.ts` — default model info per CLI
- `claude-adapter.test.ts`, `codex-adapter.test.ts`, `codex-mcp-adapter.test.ts` — capability profiles, registry pricing, `--model fable` alias
- `topsis-router.test.ts` — claude/codex now tie at quality 10 (tie documented, both accepted)
- `quality-constraint-stage.test.ts` — derived quality/cost tables recomputed for the new defaults (claude 1.0, codex 1.0, gemini 0.95; counts updated accordingly)
- `resolve-model-for-tier.test.ts` — derivation now mirrors the documented tie-break (score desc, then cheaper); pins `claude-opus` for the powerful tier (cheaper of the reasoning-10 tie)
- `task-specialization-integration.test.ts` — implementation-task pick widened to the codex-CLI model set (gpt-5.5 now tops it)
- CLAUDE.md `GOVERNANCE:MODEL_LIST` regenerated via `pnpm governance:inject` (18 models)

## Gates

- `pnpm test` (turbo, full): 27,323 passed / 16 skipped, 0 failed (1142 files)
- `pnpm test:scripts`: 428 passed (includes governance drift gate)
- `pnpm typecheck`: clean
- `pnpm lint`: clean (in-tree-data.ts gained a `max-lines` disable — data-only file that grows with every supported model; 10 prior files share the pattern)
- `pnpm check:pricing-drift`: no drift (advisory)
- changeset: minor (`.changeset/frontier-model-entries.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)