### PR TITLE
fix(config): remove unread env-var declarations — never wired (#4180)

### DIFF
--- a/.changeset/unread-env-vars-4180.md
+++ b/.changeset/unread-env-vars-4180.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Remove three never-wired env-var declarations from the env-schema (#4180, same silent-no-op class as #2977): `NEXUS_TEST_TIMEOUT_MS` had no production reader, and `NEXUS_TIMEOUT_CLISIMPLE` / `NEXUS_TIMEOUT_CLICOMPLEX` fed only `getTimeout('cliSimpleMs'/'cliComplexMs')`, which has zero production call sites — per-complexity CLI timeouts flow through `TIMEOUT_PROFILES` / `getTimeoutForCli`. The equally unread `DEFAULTS.TIMEOUT_DEFAULTS.cliSimpleMs` / `cliComplexMs` keys are removed with them (internal surface only; not exported from the package entry point). Setting the removed vars now produces an unknown-variable warning from `validateNexusEnv` instead of silently doing nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Most-used env vars:
 
 Full list in [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md). Install: [INSTALLATION.md](./docs/getting-started/INSTALLATION.md). Sandboxed: [SANDBOXED-USAGE.md](./docs/guides/SANDBOXED-USAGE.md).
 
-Note: `NEXUS_WORKERS_*` / `NEXUS_WORKFLOW_MAX_PARALLEL` / `NEXUS_TEST_PARALLELISM` / `NEXUS_EVALUATION_MAX_WORKERS` / `NEXUS_EVENTBUS_MAX_HISTORY` / `NEXUS_SWARM_OBSERVER_MAX_EVENTS` were removed in 2.82.0 (#2977 — silent no-ops; consumer wiring never landed).
+Note: `NEXUS_WORKERS_*` / `NEXUS_WORKFLOW_MAX_PARALLEL` / `NEXUS_TEST_PARALLELISM` / `NEXUS_EVALUATION_MAX_WORKERS` / `NEXUS_EVENTBUS_MAX_HISTORY` / `NEXUS_SWARM_OBSERVER_MAX_EVENTS` were removed in 2.82.0 (#2977 — silent no-ops; consumer wiring never landed); `NEXUS_TEST_TIMEOUT_MS` / `NEXUS_TIMEOUT_CLISIMPLE` / `NEXUS_TIMEOUT_CLICOMPLEX` were removed for the same reason in #4180 (per-complexity CLI timeouts flow through `TIMEOUT_PROFILES`, not env vars).
 
 ---
 

--- a/cspell.json
+++ b/cspell.json
@@ -110,6 +110,8 @@
     "aflow",
     "alfworld",
     "aorchestra",
+    "clisimple",
+    "clicomplex",
     "appcypher",
     "atproto",
     "autoloads",

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -388,6 +388,20 @@ error from `validateNexusEnv`. If you had any of them set, just unset them:
 The matching `WORKER_DEFAULTS.*` config-set keys are also gone; `config set
 WORKER_DEFAULTS.foo X` now returns "key not found" instead of a false success.
 
+### Removed (#4180)
+
+Three more env vars from the same silent-no-op class, missed by the #2977 sweep,
+were declared in the env-schema but never read by any production code. They have
+been removed; `validateNexusEnv` now flags them as unknown. If you had any of
+them set, just unset them:
+
+`NEXUS_TEST_TIMEOUT_MS`, `NEXUS_TIMEOUT_CLISIMPLE`, `NEXUS_TIMEOUT_CLICOMPLEX`.
+
+The matching (equally unread) `TIMEOUT_DEFAULTS.cliSimpleMs` /
+`TIMEOUT_DEFAULTS.cliComplexMs` defaults keys are also gone. Per-complexity CLI
+timeouts were never driven by these knobs — they flow through the internal
+per-CLI `TIMEOUT_PROFILES` (`getTimeoutForCli`).
+
 ## Model Configuration
 
 ### Default Model

--- a/packages/nexus-agents/src/config/defaults-env.ts
+++ b/packages/nexus-agents/src/config/defaults-env.ts
@@ -64,8 +64,7 @@ export function parseBoolEnv(envKey: string, fallback: boolean): boolean {
 /** Timeout defaults type from DEFAULTS object */
 export interface TimeoutDefaultsConst {
   readonly cliMs: number;
-  readonly cliSimpleMs: number;
-  readonly cliComplexMs: number;
+  // cliSimpleMs / cliComplexMs removed in #4180 — see config/defaults.ts.
   readonly apiMs: number;
   readonly apiMaxMs: number;
   readonly workflowMs: number;

--- a/packages/nexus-agents/src/config/defaults-types.ts
+++ b/packages/nexus-agents/src/config/defaults-types.ts
@@ -46,8 +46,7 @@ export type KnownCliName = CliNameLiteral | 'default';
  */
 export interface TimeoutDefaults {
   cliMs: number;
-  cliSimpleMs: number;
-  cliComplexMs: number;
+  // cliSimpleMs / cliComplexMs removed in #4180 — see config/defaults.ts.
   apiMs: number;
   apiMaxMs: number;
   workflowMs: number;
@@ -213,8 +212,7 @@ export const ToolRateLimitConfigSchema = z.object({
  */
 export const TimeoutDefaultsSchema = z.object({
   cliMs: durationMs.describe('Default CLI timeout'),
-  cliSimpleMs: durationMs.describe('Simple CLI task timeout'),
-  cliComplexMs: durationMs.describe('Complex CLI task timeout'),
+  // cliSimpleMs / cliComplexMs removed in #4180 — see config/defaults.ts.
   apiMs: durationMs.describe('Default API timeout'),
   apiMaxMs: durationMs.describe('Maximum API timeout'),
   workflowMs: durationMs.describe('Default workflow timeout'),

--- a/packages/nexus-agents/src/config/defaults.ts
+++ b/packages/nexus-agents/src/config/defaults.ts
@@ -110,10 +110,10 @@ export const DEFAULTS = {
   TIMEOUT_DEFAULTS: {
     /** CLI tool execution timeout in milliseconds. */
     cliMs: _CLI.default.standard,
-    /** Simple CLI task timeout (single function, quick query). */
-    cliSimpleMs: _CLI.default.simple,
-    /** Complex CLI task timeout (codebase-wide, deep analysis). */
-    cliComplexMs: _CLI.default.complex,
+    // cliSimpleMs / cliComplexMs removed in #4180 — never read by any production
+    // code (the matching NEXUS_TIMEOUT_CLISIMPLE/CLICOMPLEX env vars were silent
+    // no-ops, #2977 class). Per-complexity CLI timeouts come from
+    // getTimeoutForCli/TIMEOUT_PROFILES (CLI_TIMEOUTS in config/timeouts.ts).
     /** API request timeout in milliseconds. */
     apiMs: _API.defaultMs,
     /** Maximum API timeout in milliseconds. */

--- a/packages/nexus-agents/src/config/env-schema.test.ts
+++ b/packages/nexus-agents/src/config/env-schema.test.ts
@@ -51,6 +51,12 @@ describe('env-schema', () => {
       expect(result.invalidVars).toHaveLength(0);
     });
 
+    it('flags the never-wired timeout vars removed in #4180 as unknown', () => {
+      vi.stubEnv('NEXUS_TEST_TIMEOUT_MS', '60000');
+      const result = validateNexusEnv();
+      expect(result.unknownVars.map((u) => u.name)).toContain('NEXUS_TEST_TIMEOUT_MS');
+    });
+
     it('rejects an invalid NEXUS_ALLOW_SIMULATE value (#4170)', () => {
       vi.stubEnv('NEXUS_ALLOW_SIMULATE', 'yes');
       const result = validateNexusEnv();
@@ -206,6 +212,13 @@ describe('env-schema', () => {
       expect(names).toContain('NEXUS_PERSIST_LEARNING');
       expect(names).toContain('NEXUS_AUTH_ENABLED');
       expect(names).toContain('NEXUS_BILLING_MODE');
+    });
+
+    it('does not register the never-wired timeout vars removed in #4180', () => {
+      const names = getKnownNexusVarNames();
+      expect(names).not.toContain('NEXUS_TEST_TIMEOUT_MS');
+      expect(names).not.toContain('NEXUS_TIMEOUT_CLISIMPLE');
+      expect(names).not.toContain('NEXUS_TIMEOUT_CLICOMPLEX');
     });
 
     it('all names start with NEXUS_', () => {

--- a/packages/nexus-agents/src/config/env-schema.ts
+++ b/packages/nexus-agents/src/config/env-schema.ts
@@ -39,8 +39,10 @@ const floatStr = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a non-negative numbe
 const NexusEnvSchema = z.object({
   // --- Timeouts ---
   NEXUS_TIMEOUT_CLI: positiveIntStr.optional(),
-  NEXUS_TIMEOUT_CLISIMPLE: positiveIntStr.optional(),
-  NEXUS_TIMEOUT_CLICOMPLEX: positiveIntStr.optional(),
+  // NEXUS_TIMEOUT_CLISIMPLE + NEXUS_TIMEOUT_CLICOMPLEX removed in #4180 — silent
+  // no-ops (#2977 class). Their only possible reader, getTimeout('cliSimpleMs' /
+  // 'cliComplexMs'), had zero production call sites; per-complexity CLI timeouts
+  // flow through getTimeoutForCli/TIMEOUT_PROFILES instead.
   NEXUS_TIMEOUT_API: positiveIntStr.optional(),
   NEXUS_TIMEOUT_WORKFLOW: positiveIntStr.optional(),
   NEXUS_TIMEOUT_MCP: positiveIntStr.optional(),
@@ -48,7 +50,9 @@ const NexusEnvSchema = z.object({
   NEXUS_MCP_TIMEOUT_MS: positiveIntStr.optional(),
   NEXUS_WORKFLOW_TIMEOUT_MS: positiveIntStr.optional(),
   NEXUS_GRAPH_TIMEOUT_MS: positiveIntStr.optional(),
-  NEXUS_TEST_TIMEOUT_MS: positiveIntStr.optional(),
+  // NEXUS_TEST_TIMEOUT_MS removed in #4180 — silent no-op (#2977 class). No
+  // production reader ever constructed this name; TEST_TIMEOUTS takes no env
+  // override. Re-register only alongside a real consumer.
   NEXUS_EXPERT_TIMEOUT_MS: positiveIntStr.optional(),
   NEXUS_WORKER_TIMEOUT_MS: positiveIntStr.optional(),
 

--- a/packages/nexus-agents/src/config/timeouts.test.ts
+++ b/packages/nexus-agents/src/config/timeouts.test.ts
@@ -295,14 +295,17 @@ describe('Centralized Timeout Configuration', () => {
   });
 
   describe('resolveEnvTimeout()', () => {
-    const testVar = 'NEXUS_TEST_TIMEOUT_MS';
+    // Deliberately NOT a registered env var (was NEXUS_TEST_TIMEOUT_MS before
+    // #4180 removed that never-wired schema entry); resolveEnvTimeout accepts
+    // any name, so use one that cannot be mistaken for a real knob.
+    const testVar = 'NEXUS_FIXTURE_TIMEOUT_MS';
 
     beforeEach(() => {
-      delete process.env.NEXUS_TEST_TIMEOUT_MS;
+      delete process.env.NEXUS_FIXTURE_TIMEOUT_MS;
     });
 
     afterEach(() => {
-      delete process.env.NEXUS_TEST_TIMEOUT_MS;
+      delete process.env.NEXUS_FIXTURE_TIMEOUT_MS;
     });
 
     it('returns default when env var not set', () => {


### PR DESCRIPTION
Closes #4180

## What

Removes three env-var declarations from the env-schema that were registered but never read by any production code — the #2977 silent-no-op class, missed by that sweep:

- `NEXUS_TEST_TIMEOUT_MS` (env-schema.ts:51)
- `NEXUS_TIMEOUT_CLISIMPLE` / `NEXUS_TIMEOUT_CLICOMPLEX` (env-schema.ts:42-43)

Also removes the equally unread `DEFAULTS.TIMEOUT_DEFAULTS.cliSimpleMs` / `cliComplexMs` keys (and their fields in the `TimeoutDefaults` interface, `TimeoutDefaultsSchema`, and `TimeoutDefaultsConst`).

## Decisions + evidence

**1. `NEXUS_TEST_TIMEOUT_MS` — removed (no wiring).** No dynamic reader constructs this name anywhere; the only occurrences outside the schema were `timeouts.test.ts:298-305`, where the string was an arbitrary fixture name passed to `resolveEnvTimeout()`. `TEST_TIMEOUTS` (config/timeouts.ts:690) has no env-override path and no non-config consumers of `testGlobalMs`/`testTaskMs`, so wiring an override would just create another dead knob. Follows the #2977 removal precedent (removal note left in the schema). The test fixture is renamed to `NEXUS_FIXTURE_TIMEOUT_MS` so it can't be mistaken for a real knob.

**2. `NEXUS_TIMEOUT_CLISIMPLE` / `NEXUS_TIMEOUT_CLICOMPLEX` — removed, including the DEFAULTS keys (option b).** Their only possible reader is `getTimeout('cliSimpleMs'/'cliComplexMs')` (via `createGetTimeout`'s name mangling), and `getTimeout` has zero non-test call sites. Per-complexity CLI timeouts actually flow through `getTimeoutForCli`/`TIMEOUT_PROFILES`; config-manager's `ENV_VAR_MAP` covers only `cliMs`/`apiMs`/`workflowMs`/`mcpMs`.

**Public-surface check (the breaking-change guard):** `package.json` exports only `"."` → `dist/index.js`; `src/index.ts` re-exports the `src/exports/*.ts` barrels, and `exports/config.ts` does **not** re-export `getTimeout`, `DEFAULTS`, `TimeoutDefaults`, or `TimeoutDefaultsSchema` (they live only on the internal `src/config/index.ts` barrel, which is not a published entry point; verified no other `exports/*.ts` barrel or workspace package deep-imports them). So removing the DEFAULTS keys is **not** a published-API break, and `getTimeout` itself stays (its key type just shrinks). Patch changeset accordingly — these declarations never did anything.

Behavior change for anyone who had the vars set: `validateNexusEnv` now emits an unknown-variable warning instead of silently accepting a no-op (warn-only; never blocks startup).

## Peer-file gates

- CLAUDE.md "Most-used env vars" note line extended (the removed vars were not table rows; the #2977 removal note now covers #4180 too) — `GITHUB_BASE_REF=main npx tsx scripts/check-registry-coverage.ts --verbose` passes (`NEXUS_ENV_VARS` registry: CLAUDE.md + docs/getting-started/CONFIGURATION.md both touched)
- docs/getting-started/CONFIGURATION.md: new "Removed (#4180)" subsection next to the "Removed in 2.82.0 (#2977)" precedent
- cspell.json: added the two var-name fragments so the (warn-only) spell job doesn't gain new warnings

## Gates

- `pnpm test` (full suite, foreground): 1141 files / 27319 tests passed, 16 skipped
- `pnpm typecheck`: pass
- `pnpm lint`: pass
- `pnpm docs:tools:check` / `pnpm governance:check`: pass
- registry-coverage (`GITHUB_BASE_REF=main`): no violations
- changeset: patch (`.changeset/unread-env-vars-4180.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
