### PR TITLE
fix(registry): keep genuine :free catalog pricing through the zero-rate guard (#4209)

### DIFF
--- a/.changeset/free-catalog-pricing-exemption.md
+++ b/.changeset/free-catalog-pricing-exemption.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+fix(registry): keep genuine :free catalog pricing through the zero-rate guard (#4209)
+
+The #4176 $0/$0 pricing guard dropped pricing for ALL zero-rate generated-catalog
+rows, but the openrouter `:free`-suffixed entries (e.g.
+`openrouter/meta-llama/llama-3.3-70b-instruct:free`) are genuinely free — their
+$0/$0 is real pricing, not a litellm placeholder, and they exist only in the
+generated catalog. Ids ending in `:free` are now exempt from the guard, so
+`computeCostDetail` reports a measured $0 (priced: true) for them instead of
+UNPRICED/unmeasured, while non-`:free` $0/$0 placeholder rows still drop their
+pricing. Also corrects the guard's doc-comment, which falsely claimed genuinely
+free models live in-tree.

--- a/packages/nexus-agents/src/config/models-generated-loader.test.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.test.ts
@@ -121,4 +121,28 @@ describe('models-generated-loader $0/$0 pricing guard (#4176)', () => {
     ]);
     expect(result.entries[0]?.pricing).toEqual({ inputPer1M: 0, outputPer1M: 4 });
   });
+
+  it('keeps $0/$0 pricing for `:free`-suffixed ids — genuinely free tiers (#4209)', () => {
+    // openrouter ':free' entries are GENUINELY free; their $0/$0 is real
+    // pricing, not a catalog placeholder. They must stay PRICED (measured $0)
+    // rather than falling to UNPRICED/unmeasured.
+    const result = loadFixture([
+      {
+        id: 'openrouter/meta-llama/llama-3.3-70b-instruct:free',
+        pricing: { inputPer1M: 0, outputPer1M: 0 },
+      },
+    ]);
+    const entry = result.entries.find(
+      (e) => e.id === 'openrouter/meta-llama/llama-3.3-70b-instruct:free'
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.pricing).toEqual({ inputPer1M: 0, outputPer1M: 0 });
+  });
+
+  it('still drops $0/$0 when `:free` appears mid-id, not as the suffix', () => {
+    const result = loadFixture([
+      { id: 'litellm/foo:free-preview', pricing: { inputPer1M: 0, outputPer1M: 0 } },
+    ]);
+    expect(result.entries[0]?.pricing).toBeUndefined();
+  });
 });

--- a/packages/nexus-agents/src/config/models-generated-loader.ts
+++ b/packages/nexus-agents/src/config/models-generated-loader.ts
@@ -74,16 +74,22 @@ function defaultGeneratedPath(): string {
  * as real pricing makes `computeCostDetail` report priced:true costUsd:0 — a
  * measured $0 for what is actually UNMEASURED (#4165). Drop BOTH-zero pricing
  * so the entry stays unpriced; one-sided zeros (free input tiers) are real
- * and kept. Genuinely free models are represented in-tree (higher tier), so
- * nothing legitimate is lost at this lowest-priority breadth tier.
+ * and kept.
+ *
+ * #4209 exception: ids ending in `:free` (openrouter free tiers, e.g.
+ * `openrouter/meta-llama/llama-3.3-70b-instruct:free`) are GENUINELY free —
+ * their $0/$0 is real pricing, not a placeholder, and they exist ONLY in this
+ * generated catalog (not in-tree). They keep their pricing so the cost chain
+ * reports a measured $0 (priced: true) instead of falling to UNPRICED.
  */
 function extractPricing(
-  rec: GeneratedRecord
+  rec: GeneratedRecord,
+  id: string
 ): { inputPer1M: number; outputPer1M: number } | undefined {
   const inputPer1M = rec.pricing?.inputPer1M;
   const outputPer1M = rec.pricing?.outputPer1M;
   if (typeof inputPer1M !== 'number' || typeof outputPer1M !== 'number') return undefined;
-  if (inputPer1M === 0 && outputPer1M === 0) return undefined;
+  if (inputPer1M === 0 && outputPer1M === 0 && !id.endsWith(':free')) return undefined;
   return { inputPer1M, outputPer1M };
 }
 
@@ -92,7 +98,7 @@ function toModelEntry(rec: GeneratedRecord): ModelEntry | undefined {
   if (typeof rec.id !== 'string' || rec.id === '') return undefined;
   const id = rec.id;
   const base = deriveEntry(id, resolveModelIdentitySync(id));
-  const pricing = extractPricing(rec);
+  const pricing = extractPricing(rec, id);
   return {
     ...base,
     source: 'generated',

--- a/packages/nexus-agents/src/learning/usage-log.test.ts
+++ b/packages/nexus-agents/src/learning/usage-log.test.ts
@@ -142,6 +142,20 @@ describe('computeCostDetail (#4165)', () => {
         detail.costUsd
       );
     });
+
+    it('reports a MEASURED $0 (priced: true) for a `:free` catalog id (#4209)', () => {
+      // ':free'-suffixed openrouter entries are genuinely free: the generated
+      // loader keeps their $0/$0 pricing (exempt from the #4176 placeholder
+      // guard), so the full chain prices them at a real, measured $0 — not
+      // priced:false/UNMEASURED (#3855/#4165 semantics).
+      const detail = computeCostDetail(
+        'openrouter/meta-llama/llama-3.3-70b-instruct:free',
+        1_000_000,
+        500_000
+      );
+      expect(detail.priced).toBe(true);
+      expect(detail.costUsd).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #4205's $0/$0 generated-catalog pricing guard (#4176). The guard dropped pricing for ALL 54 zero-rate rows, but 22 of them are openrouter `:free`-suffixed entries (e.g. `openrouter/meta-llama/llama-3.3-70b-instruct:free`) whose $0/$0 is genuine — they were incorrectly demoted to UNPRICED (unmeasured).

- Exempt generated-catalog ids ending in `:free` from the $0/$0 pricing-drop guard: they keep `pricing {inputPer1M: 0, outputPer1M: 0}` and stay PRICED (measured $0) through `computeCostDetail` (#3855/#4165 semantics).
- Rewrite the guard's doc-comment: it claimed 'genuinely free models live in-tree', which is false — the `:free` entries exist only in the generated catalog. It now states the guard drops $0/$0 as catalog placeholders EXCEPT explicit `:free`-suffixed ids.
- Non-`:free` $0/$0 placeholder rows still drop pricing (existing test kept), including ids with `:free` mid-string (new negative test).

## Tests

- loader: `:free`-suffixed $0/$0 entry keeps pricing; mid-id `:free-preview` still drops
- usage-log (full chain): `computeCostDetail` for a bundled `:free` id → `priced: true`, `costUsd: 0`
- Full suite: 27353 passed / 16 skipped; typecheck and lint clean

Closes #4209

🤖 Generated with [Claude Code](https://claude.com/claude-code)