### PR TITLE
feat(routing): difficulty-conditional cost weighting + per-class cost ceiling (#4196)

### DIFF
--- a/.changeset/difficulty-cost-weighting.md
+++ b/.changeset/difficulty-cost-weighting.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): difficulty-conditional cost weighting + per-class cost ceiling (#4196)
+
+Under `NEXUS_BILLING_MODE=api`, the TOPSIS stage now conditions its
+quality/cost weight split on the canonical SharedTaskAnalyzer complexity
+(TaskProfile `reasoningComplexity`, 0-10 — no new difficulty estimator):
+hard tasks (>7, the existing ×1.2 boost threshold) shift 0.15 weight from
+cost to quality (0.5/0.3/0.2 → 0.65/0.15/0.2, tolerating frontier $/1M for
+hard work); easy tasks (<4) shift the other way (→ 0.35/0.45/0.2); the
+mid-band keeps the exact current criteria (same reference — byte-identical
+default path). The shift is clamped so no weight goes negative and composes
+with the per-category criteria (#1491).
+
+BudgetRouter gains per-task-class cost ceilings
+(`taskClassCostCeilings` / composite `budgetConstraints.taskClassMaxCostUsd`,
+keyed by `detectTaskCategory` class, default OFF/unlimited). Candidate cost
+is estimated from canonical registry pricing (ModelEntry.pricing, the #4165
+path — not the legacy TOKEN_COSTS table). BINDING fail direction: a
+candidate with missing registry pricing FAILS a configured ceiling
+(fail-closed), never the return-all-candidates fallback pattern. Ceilings
+are enforced only under api billing.
+
+Plan mode (the default) leaves both features as no-ops but now emits an
+explicit routing-decision annotation — 'cost weighting disabled: plan mode'
+— in the decision reason/trace (BINDING: never silent), and
+`adaptRoutingConfig` resolves the composite router's billing mode from
+`NEXUS_BILLING_MODE` so api mode is reachable outside tests.

--- a/packages/nexus-agents/src/cli-adapters/budget-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.test.ts
@@ -342,3 +342,93 @@ describe('BudgetRouter', () => {
     });
   });
 });
+
+// ============================================================================
+// Per-task-class cost ceiling (#4196)
+// ============================================================================
+
+// Partial-mock the registry pricing lookup so the fail-closed (missing
+// pricing) branch is testable; all other exports stay real.
+vi.mock('../config/model-config-helpers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config/model-config-helpers.js')>();
+  return { ...actual, getModelPricing: vi.fn(actual.getModelPricing) };
+});
+
+describe('BudgetRouter task-class cost ceiling (#4196)', () => {
+  // 'implement a function' → detectTaskCategory → code_generation.
+  // Registry pricing of per-CLI default models (in-tree-data):
+  //   claude → claude-fable-5 ($10/$50 per 1M)
+  //   gemini → gemini-3-pro   ($2/$12 per 1M)
+  //   codex  → gpt-5.5        ($5/$30 per 1M)
+  // With maxTokens 10_000 output: claude ≈ $0.50, codex ≈ $0.30, gemini ≈ $0.12.
+  const ceilingTask: CliTask = { content: 'implement a function', maxTokens: 10_000 };
+  const candidates: CliName[] = ['claude', 'gemini', 'codex'];
+
+  function makeAdapters(): Map<CliName, ICliAdapter> {
+    return new Map<CliName, ICliAdapter>([
+      ['claude', createMockAdapter('claude')],
+      ['gemini', createMockAdapter('gemini')],
+      ['codex', createMockAdapter('codex')],
+    ]);
+  }
+
+  afterEach(async () => {
+    // Re-point the partial mock at the real implementation after each test.
+    const helpers = await import('../config/model-config-helpers.js');
+    const actual = await vi.importActual<typeof import('../config/model-config-helpers.js')>(
+      '../config/model-config-helpers.js'
+    );
+    vi.mocked(helpers.getModelPricing).mockImplementation(actual.getModelPricing);
+  });
+
+  it('returns candidates unchanged when no ceilings are configured (default OFF)', () => {
+    const r = new BudgetRouter(makeAdapters());
+    expect(r.filterByTaskClassCeiling(ceilingTask, candidates)).toEqual(candidates);
+    r.dispose();
+  });
+
+  it('returns candidates unchanged when the task class has no ceiling', () => {
+    const r = new BudgetRouter(makeAdapters(), {
+      taskClassCostCeilings: { architecture: 0.001 },
+    });
+    expect(r.filterByTaskClassCeiling(ceilingTask, candidates)).toEqual(candidates);
+    r.dispose();
+  });
+
+  it('returns candidates unchanged when the task matches no category', () => {
+    const r = new BudgetRouter(makeAdapters(), {
+      taskClassCostCeilings: { code_generation: 0.001 },
+    });
+    const vague: CliTask = { content: 'hello there', maxTokens: 10_000 };
+    expect(r.filterByTaskClassCeiling(vague, candidates)).toEqual(candidates);
+    r.dispose();
+  });
+
+  it('excludes candidates whose registry-priced estimate exceeds the class ceiling', () => {
+    const r = new BudgetRouter(makeAdapters(), {
+      taskClassCostCeilings: { code_generation: 0.2 },
+    });
+    expect(r.filterByTaskClassCeiling(ceilingTask, candidates)).toEqual(['gemini']);
+    r.dispose();
+  });
+
+  it('keeps every candidate under a generous ceiling', () => {
+    const r = new BudgetRouter(makeAdapters(), {
+      taskClassCostCeilings: { code_generation: 5.0 },
+    });
+    expect(r.filterByTaskClassCeiling(ceilingTask, candidates)).toEqual(candidates);
+    r.dispose();
+  });
+
+  it('fails CLOSED when pricing is missing — candidate excluded, no return-all fallback', async () => {
+    const helpers = await import('../config/model-config-helpers.js');
+    vi.mocked(helpers.getModelPricing).mockReturnValue(undefined);
+    const r = new BudgetRouter(makeAdapters(), {
+      taskClassCostCeilings: { code_generation: 5.0 },
+    });
+    // Every candidate has unknown cost → ALL fail the ceiling (fail-closed),
+    // NOT the filterByPreferenceTier-style return-all-candidates pattern.
+    expect(r.filterByTaskClassCeiling(ceilingTask, candidates)).toEqual([]);
+    r.dispose();
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/budget-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.ts
@@ -27,9 +27,12 @@ import type {
   ICliAdapter,
 } from './types.js';
 import { DEFAULT_CAPABILITIES, routingArmDisplaySlot } from './types.js';
+import type { CliName } from './types.js';
 import { estimateTokens, estimateCost } from './budget-utils.js';
 import { generateBudgetWarnings } from './budget-warnings.js';
 import { createBudgetExceededError } from './budget-errors.js';
+import { detectTaskCategory } from '../config/task-specialization.js';
+import { getDefaultModelForCli, getModelPricing } from '../config/model-config-helpers.js';
 
 const logger = createLogger({ component: 'budget-router' });
 
@@ -53,7 +56,29 @@ const DEFAULT_OPTIONS: Required<BudgetRouterOptions> = {
     critical: 90,
   },
   enforceHardLimits: true,
+  // #4196: per-task-class cost ceilings default OFF (no ceiling configured).
+  taskClassCostCeilings: {},
 };
+
+/**
+ * Estimate the USD cost of a task on a CLI slot using CANONICAL registry
+ * pricing (#4165 path: `ModelEntry.pricing` of the slot's default model) —
+ * NOT the legacy `TOKEN_COSTS` table (consolidation tracked in #4168).
+ * Returns `undefined` when the registry has no pricing for the model, so the
+ * caller can fail CLOSED on a configured ceiling (#4196 BINDING condition).
+ */
+export function estimateRegistryCostUsd(
+  slot: CliName,
+  inputTokens: number,
+  outputTokens: number
+): number | undefined {
+  const pricing = getModelPricing(getDefaultModelForCli(slot));
+  if (pricing === undefined) return undefined;
+  return (
+    (inputTokens / 1_000_000) * pricing.inputPer1M +
+    (outputTokens / 1_000_000) * pricing.outputPer1M
+  );
+}
 
 /**
  * Budget-constrained task router.
@@ -188,6 +213,51 @@ export class BudgetRouter implements IBudgetRouter {
       warnings,
       projectedBudget,
     };
+  }
+
+  /**
+   * Per-task-class cost ceiling filter (#4196, epic #4175).
+   *
+   * Resolves the task's class via `detectTaskCategory`; when a ceiling is
+   * configured for that class, each candidate's cost is estimated with
+   * canonical registry pricing and candidates above the ceiling are dropped.
+   *
+   * BINDING fail direction: a candidate with MISSING registry pricing FAILS
+   * the check (fail-closed) — unknown cost must not slip under a configured
+   * ceiling. This is deliberately NOT the return-all-candidates fallback of
+   * `filterByPreferenceTier` (composite-router-helpers.ts).
+   *
+   * Billing-mode gating (api only) is the caller's responsibility
+   * (`applyBudgetFilter`); plan mode never invokes this.
+   */
+  filterByTaskClassCeiling(task: CliTask, candidates: RoutingArmId[]): RoutingArmId[] {
+    const ceiling = this.resolveTaskClassCeiling(task);
+    if (ceiling === undefined) return candidates;
+    const inputTokens = estimateTokens(task.content);
+    const outputTokens = task.maxTokens ?? inputTokens * 2;
+    return candidates.filter((arm) => {
+      // Pricing is slot-level; an api:* arm is priced by its display slot's
+      // default model (#3422).
+      const cost = estimateRegistryCostUsd(routingArmDisplaySlot(arm), inputTokens, outputTokens);
+      if (cost === undefined) {
+        logger.debug('Cost ceiling: missing registry pricing — failing closed', { arm, ceiling });
+        return false;
+      }
+      const within = cost <= ceiling;
+      if (!within) {
+        logger.debug('Cost ceiling: candidate excluded', { arm, cost, ceiling });
+      }
+      return within;
+    });
+  }
+
+  /** Resolve the configured ceiling for the task's detected class, if any (#4196). */
+  private resolveTaskClassCeiling(task: CliTask): number | undefined {
+    const ceilings = this.options.taskClassCostCeilings;
+    if (Object.keys(ceilings).length === 0) return undefined;
+    const match = detectTaskCategory(task.content);
+    if (match === null) return undefined;
+    return ceilings[match.category];
   }
 
   /**

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
@@ -32,7 +32,14 @@ import {
   buildDecisionFields,
   buildPreferenceStats,
   applyPerformanceFloorPenalty,
+  PLAN_MODE_COST_ANNOTATION,
 } from './composite-router-helpers.js';
+import {
+  applyDifficultyCostWeighting,
+  DEFAULT_TOPSIS_CRITERIA,
+  PLAN_BILLING_TOPSIS_CRITERIA,
+  TASK_CATEGORY_TOPSIS_CRITERIA,
+} from './topsis-types.js';
 
 // ============================================================================
 // Helpers
@@ -790,5 +797,212 @@ describe('adjustProfileWithStageScores', () => {
     ]);
     const result = adjustProfileWithStageScores([highQuality, gemini], scores);
     expect(result[0]?.qualityScore).toBeLessThanOrEqual(10);
+  });
+});
+
+// ============================================================================
+// applyDifficultyCostWeighting (#4196)
+// ============================================================================
+
+describe('applyDifficultyCostWeighting', () => {
+  const weightOf = (
+    criteria: ReturnType<typeof applyDifficultyCostWeighting>,
+    name: string
+  ): number | undefined => criteria.find((c) => c.name === name)?.weight;
+
+  it('shifts weight from cost to quality for high complexity (>7)', () => {
+    const result = applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, 8);
+    expect(weightOf(result, 'quality')).toBeCloseTo(0.65);
+    expect(weightOf(result, 'cost')).toBeCloseTo(0.15);
+    expect(weightOf(result, 'latency')).toBeCloseTo(0.2);
+  });
+
+  it('shifts weight from quality to cost for low complexity (<4)', () => {
+    const result = applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, 3);
+    expect(weightOf(result, 'quality')).toBeCloseTo(0.35);
+    expect(weightOf(result, 'cost')).toBeCloseTo(0.45);
+    expect(weightOf(result, 'latency')).toBeCloseTo(0.2);
+  });
+
+  it('returns the SAME criteria reference for mid complexity (byte-identical default path)', () => {
+    expect(applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, 5)).toBe(DEFAULT_TOPSIS_CRITERIA);
+    expect(applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, 7)).toBe(DEFAULT_TOPSIS_CRITERIA);
+    expect(applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, 4)).toBe(DEFAULT_TOPSIS_CRITERIA);
+  });
+
+  it('preserves weight sum of 1.0 after shifting', () => {
+    for (const complexity of [2, 9]) {
+      const result = applyDifficultyCostWeighting(DEFAULT_TOPSIS_CRITERIA, complexity);
+      const sum = result.reduce((a, c) => a + c.weight, 0);
+      expect(sum).toBeCloseTo(1.0, 10);
+    }
+  });
+
+  it('clamps the shift so no weight goes negative (architecture cost=0.1)', () => {
+    const architecture = TASK_CATEGORY_TOPSIS_CRITERIA['architecture'];
+    expect(architecture).toBeDefined();
+    const result = applyDifficultyCostWeighting(architecture as never, 9);
+    expect(weightOf(result, 'quality')).toBeCloseTo(0.8);
+    expect(weightOf(result, 'cost')).toBeCloseTo(0.0);
+    expect(weightOf(result, 'latency')).toBeCloseTo(0.2);
+  });
+
+  it('is a no-op when cost weight is already 0 and complexity is high (plan-shaped criteria)', () => {
+    expect(applyDifficultyCostWeighting(PLAN_BILLING_TOPSIS_CRITERIA, 9)).toBe(
+      PLAN_BILLING_TOPSIS_CRITERIA
+    );
+  });
+});
+
+// ============================================================================
+// applyTopsisRanking — difficulty conditioning gates (#4196)
+// ============================================================================
+
+describe('applyTopsisRanking difficulty conditioning', () => {
+  const candidates: CliName[] = ['claude', 'gemini', 'codex'];
+  // Complexity 3 vs 5 isolates the NEW weight conditioning: neither value
+  // triggers the pre-existing ×1.2 profile quality boost (>7), so any output
+  // difference can only come from the criteria-weight shift (#4196).
+
+  it('plan mode: weights are NOT difficulty-conditioned (regression pin)', async () => {
+    const { TopsisRouter } = await import('./topsis-router.js');
+    const router = new TopsisRouter();
+    const low = applyTopsisRanking(
+      makeTaskProfile({ taskType: 'general', reasoningComplexity: 3 }),
+      candidates,
+      router,
+      { billingMode: 'plan' }
+    );
+    const mid = applyTopsisRanking(
+      makeTaskProfile({ taskType: 'general', reasoningComplexity: 5 }),
+      candidates,
+      router,
+      { billingMode: 'plan' }
+    );
+    expect(low.ranking).toEqual(mid.ranking);
+    expect(low.topScore).toBe(mid.topScore);
+  });
+
+  it('api mode: low complexity (cost-heavy weights) changes the scoring landscape', async () => {
+    const { TopsisRouter } = await import('./topsis-router.js');
+    const router = new TopsisRouter();
+    const low = applyTopsisRanking(
+      makeTaskProfile({ taskType: 'general', reasoningComplexity: 3 }),
+      candidates,
+      router,
+      { billingMode: 'api' }
+    );
+    const mid = applyTopsisRanking(
+      makeTaskProfile({ taskType: 'general', reasoningComplexity: 5 }),
+      candidates,
+      router,
+      { billingMode: 'api' }
+    );
+    // Cost-heavy weights (0.35/0.45/0.2) must change the closeness landscape
+    // relative to defaults (0.5/0.3/0.2).
+    expect(low.topScore).not.toBe(mid.topScore);
+  });
+});
+
+// ============================================================================
+// buildReason / buildDecisionFields — plan-mode annotation (#4196)
+// ============================================================================
+
+describe('plan-mode cost annotation', () => {
+  it('buildReason appends the annotation in plan mode', () => {
+    const reason = buildReason({ selectedCli: 'claude', stages: [], billingMode: 'plan' });
+    expect(reason).toContain(PLAN_MODE_COST_ANNOTATION);
+    expect(reason).toContain('cost weighting disabled: plan mode');
+  });
+
+  it('buildReason omits the annotation in api mode', () => {
+    const reason = buildReason({ selectedCli: 'claude', stages: [], billingMode: 'api' });
+    expect(reason).not.toContain(PLAN_MODE_COST_ANNOTATION);
+  });
+
+  it('buildReason omits the annotation when billingMode is not provided (back-compat)', () => {
+    const reason = buildReason({ selectedCli: 'claude', stages: [] });
+    expect(reason).toBe('Selected claude');
+  });
+
+  it('buildDecisionFields threads billingMode into the reason', () => {
+    const base = {
+      selectedCli: 'claude' as CliName,
+      candidates: ['claude', 'gemini'] as CliName[],
+      topsisRanking: ['claude', 'gemini'] as CliName[],
+      stagesExecuted: ['task-analysis'],
+      decisionTimeMs: 5,
+      withinBudget: true,
+      difficultyEstimate: undefined,
+      difficultyTier: undefined,
+      preferenceScore: undefined,
+      preferenceTier: undefined,
+      topsisScore: 0.8,
+      ucbScore: undefined,
+      taskProfile: makeTaskProfile(),
+    };
+    const plan = buildDecisionFields({ ...base, billingMode: 'plan' });
+    expect(plan.reason).toContain(PLAN_MODE_COST_ANNOTATION);
+    const api = buildDecisionFields({ ...base, billingMode: 'api' });
+    expect(api.reason).not.toContain(PLAN_MODE_COST_ANNOTATION);
+  });
+});
+
+// ============================================================================
+// applyBudgetFilter — per-task-class cost ceiling gating (#4196)
+// ============================================================================
+
+describe('applyBudgetFilter task-class ceiling gating', () => {
+  const candidates: CliName[] = ['claude', 'gemini', 'codex'];
+
+  it('api mode: applies the ceiling filter via the budget router', () => {
+    const mockRouter = {
+      checkBudget: vi.fn(() => ({ withinBudget: true })),
+      filterByTaskClassCeiling: vi.fn(() => ['gemini']),
+    };
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      {
+        billingMode: 'api',
+      } as never
+    );
+    expect(mockRouter.filterByTaskClassCeiling).toHaveBeenCalledTimes(1);
+    expect(result.eligible).toEqual(['gemini']);
+  });
+
+  it('api mode: an empty ceiling result stays empty (fail-closed, no return-all fallback)', () => {
+    const mockRouter = {
+      checkBudget: vi.fn(() => ({ withinBudget: true })),
+      filterByTaskClassCeiling: vi.fn(() => []),
+    };
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      {
+        billingMode: 'api',
+      } as never
+    );
+    expect(result.eligible).toEqual([]);
+  });
+
+  it('plan mode: never invokes the ceiling filter (no-op)', () => {
+    const mockRouter = {
+      checkBudget: vi.fn(() => ({ withinBudget: true })),
+      filterByTaskClassCeiling: vi.fn(() => []),
+    };
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      {
+        billingMode: 'plan',
+        budgetConstraints: { taskClassMaxCostUsd: { code_generation: 0.01 } },
+      } as never
+    );
+    expect(mockRouter.filterByTaskClassCeiling).not.toHaveBeenCalled();
+    expect(result.eligible).toEqual(candidates);
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_MODEL_PROFILES,
   DEFAULT_TOPSIS_CRITERIA,
   PLAN_BILLING_TOPSIS_CRITERIA,
+  applyDifficultyCostWeighting,
   getCriteriaForTaskCategory,
 } from './topsis-types.js';
 import type { BillingMode } from '../mcp/tools/delegate-to-model-types.js';
@@ -75,6 +76,14 @@ export function calculateConfidence(
 }
 
 /**
+ * BINDING plan-mode annotation (#4196): when billing mode is 'plan' the
+ * difficulty-conditional cost weighting and the per-task-class cost ceiling
+ * are no-ops — the routing decision must SAY so explicitly (never silent),
+ * so downstream evals don't misread plan-mode routing as cost-aware.
+ */
+export const PLAN_MODE_COST_ANNOTATION = 'cost weighting disabled: plan mode';
+
+/**
  * Options for building routing reason.
  */
 export interface BuildReasonOptions {
@@ -85,6 +94,8 @@ export interface BuildReasonOptions {
   preferenceScore?: number;
   difficultyTier?: ModelTier;
   difficultyScore?: number;
+  /** Billing mode in effect; 'plan' appends {@link PLAN_MODE_COST_ANNOTATION} (#4196). */
+  billingMode?: BillingMode;
 }
 
 /**
@@ -101,6 +112,7 @@ export function buildReason(options: BuildReasonOptions): string {
   if (preferenceScore !== undefined) parts.push('preference ' + preferenceScore.toFixed(2));
   if (topsisScore !== undefined) parts.push('TOPSIS score ' + topsisScore.toFixed(2));
   if (ucbScore !== undefined) parts.push('UCB score ' + ucbScore.toFixed(2));
+  if (options.billingMode === 'plan') parts.push(PLAN_MODE_COST_ANNOTATION);
   return parts.join(', ');
 }
 
@@ -153,9 +165,7 @@ export function applyBudgetFilter(
   budgetRouter: BudgetRouter | undefined,
   config: CompositeRouterConfig
 ): BudgetFilterResult {
-  if (budgetRouter === undefined) {
-    return { eligible: candidates, withinBudget: true };
-  }
+  if (budgetRouter === undefined) return { eligible: candidates, withinBudget: true };
 
   const rawConstraints = config.budgetConstraints;
   const constraint: BudgetConstraint = {};
@@ -170,7 +180,13 @@ export function applyBudgetFilter(
   }
 
   const result = budgetRouter.checkBudget(task, constraint);
-  return { eligible: result.withinBudget ? candidates : [], withinBudget: result.withinBudget };
+  if (!result.withinBudget) return { eligible: [], withinBudget: false };
+  // #4196: per-task-class cost ceiling — enforced ONLY under api billing.
+  // Plan mode is a no-op here; the decision carries PLAN_MODE_COST_ANNOTATION
+  // instead of silently skipping. A candidate with missing registry pricing
+  // FAILS the ceiling (fail-closed) — see BudgetRouter.filterByTaskClassCeiling.
+  if (config.billingMode !== 'api') return { eligible: candidates, withinBudget: true };
+  return { eligible: budgetRouter.filterByTaskClassCeiling(task, candidates), withinBudget: true };
 }
 
 /**
@@ -192,26 +208,32 @@ export interface TopsisRankingResult {
  */
 export const TOPSIS_TOLERANCE_BAND_PERCENT = 0.05;
 
-/** Returns a TopsisRouter with task-category-aware criteria (#1491).
+/** Returns a TopsisRouter with task-category-aware criteria (#1491) and
+ * difficulty-conditional quality/cost weighting (#4196).
+ * Difficulty conditioning is api-mode ONLY: plan mode zeroes the cost weight
+ * already, so conditioning there would be a silent no-op — plan mode instead
+ * emits an explicit routing-decision annotation (see buildReason).
  * Only creates a new router when the criteria differ from the billing-mode default. */
 function selectTopsisRouter(
   router: TopsisRouter,
   billingMode: BillingMode,
-  taskType?: string
+  taskType?: string,
+  reasoningComplexity?: number
 ): TopsisRouter {
-  if (taskType !== undefined) {
-    const mode = billingMode === 'plan' ? 'plan' : 'api';
-    const criteria = getCriteriaForTaskCategory(taskType, mode);
-    const defaultCriteria =
-      mode === 'plan' ? PLAN_BILLING_TOPSIS_CRITERIA : DEFAULT_TOPSIS_CRITERIA;
-    // Only create a new router when category criteria differ from default
-    if (criteria !== defaultCriteria) {
-      return new TopsisRouter({ criteria });
-    }
-  }
-  if (billingMode === 'plan') {
-    return new TopsisRouter({ criteria: PLAN_BILLING_TOPSIS_CRITERIA });
-  }
+  const mode = billingMode === 'plan' ? 'plan' : 'api';
+  const defaultCriteria = mode === 'plan' ? PLAN_BILLING_TOPSIS_CRITERIA : DEFAULT_TOPSIS_CRITERIA;
+  const base =
+    taskType !== undefined ? getCriteriaForTaskCategory(taskType, mode) : defaultCriteria;
+  // #4196: condition the quality/cost split on the canonical SharedTaskAnalyzer
+  // complexity (TaskProfile.reasoningComplexity). Mid-band complexity returns
+  // the same reference, keeping the default path byte-identical.
+  const criteria =
+    mode === 'api' && reasoningComplexity !== undefined
+      ? applyDifficultyCostWeighting(base, reasoningComplexity)
+      : base;
+  // Only create a new router when the effective criteria differ from default
+  if (criteria !== defaultCriteria) return new TopsisRouter({ criteria });
+  if (mode === 'plan') return new TopsisRouter({ criteria: PLAN_BILLING_TOPSIS_CRITERIA });
   return router;
 }
 
@@ -351,7 +373,12 @@ export function applyTopsisRanking(
   }
 
   const billingMode = options?.billingMode ?? 'api';
-  const router = selectTopsisRouter(topsisRouter, billingMode, taskProfile.taskType);
+  const router = selectTopsisRouter(
+    topsisRouter,
+    billingMode,
+    taskProfile.taskType,
+    taskProfile.reasoningComplexity
+  );
   const adjustedProfiles = buildAdjustedProfiles(taskProfile, candidates, options);
   const result: TopsisResult = router.selectModel({ profiles: adjustedProfiles });
 
@@ -505,6 +532,8 @@ export interface BuildDecisionContext {
   topsisScore: number | undefined;
   ucbScore: number | undefined;
   taskProfile: TaskProfile;
+  /** Billing mode in effect; 'plan' surfaces the explicit annotation (#4196). */
+  billingMode?: BillingMode | undefined;
 }
 
 /**
@@ -519,6 +548,7 @@ export function buildDecisionFields(ctx: BuildDecisionContext): {
   const reason = buildReason({
     selectedCli: ctx.selectedCli,
     stages: ctx.stagesExecuted,
+    ...(ctx.billingMode !== undefined ? { billingMode: ctx.billingMode } : {}),
     ...(ctx.topsisScore !== undefined ? { topsisScore: ctx.topsisScore } : {}),
     ...(ctx.ucbScore !== undefined ? { ucbScore: ctx.ucbScore } : {}),
     ...(ctx.preferenceScore !== undefined ? { preferenceScore: ctx.preferenceScore } : {}),

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -142,6 +142,8 @@ describe('runBudgetStage', () => {
     const stages: string[] = [];
     const mockBudgetRouter = {
       checkBudget: vi.fn().mockReturnValue({ withinBudget: true }),
+      // #4196: api billing mode also runs the per-task-class ceiling filter.
+      filterByTaskClassCeiling: vi.fn((_task: unknown, cands: CliName[]) => cands),
     };
     const deps = makeDeps({
       config: { ...makeDeps().config, enableBudgetFilter: true },

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -78,6 +78,10 @@ export const CompositeRouterConfigSchema = z.object({
       maxTokens: z.number().positive(),
       maxCostUsd: z.number().positive(),
       maxLatencyMs: z.number().positive(),
+      /** Per-task-class cost ceilings in USD, keyed by TaskCategory (#4196).
+       * Default: absent → no ceiling (OFF/unlimited). Enforced only under
+       * billingMode 'api'; missing candidate pricing fails CLOSED. */
+      taskClassMaxCostUsd: z.record(z.string(), z.number().positive()),
     })
     .partial()
     .optional(),

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -1101,3 +1101,60 @@ function makeMockCache(
     getAll: vi.fn().mockResolvedValue(all),
   } as unknown as import('../config/available-models-cache.js').AvailableModelsCache;
 }
+
+// ============================================================================
+// #4196 — plan-mode cost annotation + per-task-class ceiling config surface
+// ============================================================================
+
+describe('CompositeRouter #4196 cost weighting/ceiling', () => {
+  it('default config (plan mode): decision reason carries the explicit annotation', async () => {
+    const router = new CompositeRouter(createTestAdapters());
+    const result = await router.route({ content: 'Help me write a function' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.reason).toContain('cost weighting disabled: plan mode');
+    }
+  });
+
+  it('api mode: annotation is absent from the decision reason', async () => {
+    const router = new CompositeRouter(createTestAdapters(), { billingMode: 'api' });
+    const result = await router.route({ content: 'Help me write a function' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.reason).not.toContain('cost weighting disabled: plan mode');
+    }
+  });
+
+  it('schema accepts per-task-class cost ceilings inside budgetConstraints', () => {
+    const parsed = CompositeRouterConfigSchema.parse({
+      budgetConstraints: { taskClassMaxCostUsd: { code_generation: 0.25 } },
+    });
+    expect(parsed.budgetConstraints?.taskClassMaxCostUsd).toEqual({ code_generation: 0.25 });
+  });
+
+  it('schema leaves ceilings undefined by default (OFF/unlimited)', () => {
+    const parsed = CompositeRouterConfigSchema.parse({});
+    expect(parsed.budgetConstraints?.taskClassMaxCostUsd).toBeUndefined();
+  });
+
+  it('default config (plan + ceilings configured): ceiling never filters candidates', async () => {
+    // Ceiling low enough to exclude everything IF it were enforced — plan mode must ignore it.
+    const router = new CompositeRouter(createTestAdapters(), {
+      budgetConstraints: { taskClassMaxCostUsd: { code_generation: 0.000001 } },
+    });
+    const result = await router.route({ content: 'implement a function', maxTokens: 10_000 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('api mode + ceilings: unaffordable classes reject with budget-filter error', async () => {
+    const router = new CompositeRouter(createTestAdapters(), {
+      billingMode: 'api',
+      budgetConstraints: { taskClassMaxCostUsd: { code_generation: 0.000001 } },
+    });
+    const result = await router.route({ content: 'implement a function', maxTokens: 10_000 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe('budget-filter');
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -296,7 +296,7 @@ export class CompositeRouter implements ICompositeRouter {
     latencyConfig?: Partial<LatencyTrackerConfig>
   ): void {
     if (this.config.enableBudgetFilter && adapters.size > 0) {
-      this.budgetRouter = new BudgetRouter(adapters);
+      this.budgetRouter = this.buildBudgetRouter(adapters);
     }
     if (this.config.enableZeroRouter) this.zeroRouter = new ZeroRouter(zeroConfig, this.logger);
     if (this.config.enablePreferenceRouting)
@@ -311,6 +311,15 @@ export class CompositeRouter implements ICompositeRouter {
       this.warmStartBandit();
     }
     if (this.config.enableLatencyTracking) this.latencyTracker = new LatencyTracker(latencyConfig);
+  }
+
+  /** #4196: plumb per-task-class cost ceilings into the BudgetRouter.
+   * Absent → defaults (no ceiling configured). */
+  private buildBudgetRouter(adapters: Map<RoutingArmId, ICliAdapter>): BudgetRouter {
+    const ceilings = this.config.budgetConstraints?.taskClassMaxCostUsd;
+    return ceilings !== undefined
+      ? new BudgetRouter(adapters, { taskClassCostCeilings: ceilings })
+      : new BudgetRouter(adapters);
   }
 
   private initializeMemoryAndStages(
@@ -709,8 +718,7 @@ export class CompositeRouter implements ICompositeRouter {
 
   /** (#2540 PR 7) Public accessor for the wired cache (or undefined). */
   getAvailableModelsCache():
-    | import('../config/available-models-cache.js').AvailableModelsCache
-    | undefined {
+    import('../config/available-models-cache.js').AvailableModelsCache | undefined {
     return this.availableModelsCache;
   }
 
@@ -761,7 +769,13 @@ export class CompositeRouter implements ICompositeRouter {
 
     const decisionTimeMs = getTimeProvider().now() - params.startTime;
     this.updateStats(params.selectedCli, decisionTimeMs);
-    const { confidence, reason, alternatives } = buildDecisionFields({ ...params, decisionTimeMs });
+    // #4196 BINDING: plan mode must annotate the decision explicitly
+    // ('cost weighting disabled: plan mode') — never a silent no-op.
+    const { confidence, reason, alternatives } = buildDecisionFields({
+      ...params,
+      decisionTimeMs,
+      billingMode: this.config.billingMode,
+    });
 
     // #3394: pick a concrete model from the difficulty tier (opt-in, default
     // OFF). Registry-only + synchronous — no probe on the hot path. Consumers

--- a/packages/nexus-agents/src/cli-adapters/topsis-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/topsis-types.ts
@@ -156,6 +156,65 @@ export const TASK_CATEGORY_PLAN_CRITERIA: Readonly<Record<string, readonly Topsi
 } as const;
 
 /**
+ * Difficulty-conditional weighting thresholds (#4196, epic #4175).
+ * Operate on the TaskProfile 0-10 `reasoningComplexity` scale, which is the
+ * canonical SharedTaskAnalyzer complexity estimate (`complexityScore * 10`,
+ * task-profile-adapter.ts) — no fourth difficulty estimator is introduced.
+ * The high threshold matches the existing ×1.2 quality-boost threshold in
+ * composite-router-helpers.ts `adjustProfileForTask`.
+ */
+export const DIFFICULTY_QUALITY_HEAVY_THRESHOLD = 7;
+
+/** Below this complexity the task is considered easy → cost-heavy weights (#4196). */
+export const DIFFICULTY_COST_HEAVY_THRESHOLD = 4;
+
+/**
+ * Weight mass shifted between quality and cost by difficulty conditioning
+ * (#4196). On the 0.5/0.3/0.2 defaults this yields 0.65/0.15/0.2 for hard
+ * tasks and 0.35/0.45/0.2 for easy tasks; latency is never touched and the
+ * weight sum stays 1.0.
+ */
+export const DIFFICULTY_WEIGHT_SHIFT = 0.15;
+
+/**
+ * Applies difficulty-conditional quality/cost weighting (#4196).
+ *
+ * Hard tasks (complexity > {@link DIFFICULTY_QUALITY_HEAVY_THRESHOLD}) move
+ * weight from cost to quality (tolerate frontier $/1M for hard work); easy
+ * tasks (complexity < {@link DIFFICULTY_COST_HEAVY_THRESHOLD}) move weight
+ * from quality to cost. Mid-band complexity returns the SAME criteria
+ * reference so the unchanged default path stays byte-identical.
+ *
+ * Callers MUST gate this on api billing mode: plan mode zeroes the cost
+ * weight already, and conditioning there would silently reshape quality vs
+ * latency. The shift is clamped so no weight goes negative.
+ */
+export function applyDifficultyCostWeighting(
+  criteria: readonly TopsisCredential[],
+  reasoningComplexity: number
+): readonly TopsisCredential[] {
+  const direction =
+    reasoningComplexity > DIFFICULTY_QUALITY_HEAVY_THRESHOLD
+      ? 1
+      : reasoningComplexity < DIFFICULTY_COST_HEAVY_THRESHOLD
+        ? -1
+        : 0;
+  if (direction === 0) return criteria;
+  const quality = criteria.find((c) => c.name === 'quality');
+  const cost = criteria.find((c) => c.name === 'cost');
+  if (quality === undefined || cost === undefined) return criteria;
+  // Clamp so the donating criterion never goes negative (sum stays 1.0).
+  const donorWeight = direction === 1 ? cost.weight : quality.weight;
+  const shift = Math.min(DIFFICULTY_WEIGHT_SHIFT, donorWeight);
+  if (shift <= 0) return criteria;
+  return criteria.map((c) => {
+    if (c.name === 'quality') return { ...c, weight: c.weight + direction * shift };
+    if (c.name === 'cost') return { ...c, weight: c.weight - direction * shift };
+    return c;
+  });
+}
+
+/**
  * Gets TOPSIS criteria for a task category and billing mode.
  * Falls back to default criteria if category not found.
  */

--- a/packages/nexus-agents/src/cli-adapters/types-routing.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-routing.ts
@@ -178,6 +178,14 @@ export interface BudgetRouterOptions {
   };
   /** Whether to block tasks that exceed budget (vs. warn only) */
   readonly enforceHardLimits?: boolean;
+  /**
+   * Per-task-class cost ceilings in USD per task (#4196), keyed by
+   * `TaskCategory` from `detectTaskCategory` (e.g. `code_generation`).
+   * Absent/empty → no ceiling (default OFF/unlimited). Enforced only under
+   * api billing mode by the composite pipeline; a candidate whose registry
+   * pricing is missing FAILS a configured ceiling (fail-closed).
+   */
+  readonly taskClassCostCeilings?: Readonly<Record<string, number>>;
 }
 
 /**

--- a/packages/nexus-agents/src/config/routing-config-adapter.test.ts
+++ b/packages/nexus-agents/src/config/routing-config-adapter.test.ts
@@ -6,7 +6,7 @@
  * (Source: Issue #475 - Add routing configuration section to nexus-agents.yaml)
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { adaptRoutingConfig, getTopsisConfigFromYaml } from './routing-config-adapter.js';
 import { DEFAULT_COMPOSITE_CONFIG } from '../cli-adapters/composite-router-types.js';
 import { DEFAULT_TOPSIS_CONFIG } from '../cli-adapters/topsis-types.js';
@@ -327,5 +327,30 @@ describe('routing-config-adapter', () => {
       expect(Object.prototype.hasOwnProperty.call(result, 'maxLatencyMs')).toBe(false);
       expect(Object.prototype.hasOwnProperty.call(result, 'maxCostPerRequest')).toBe(false);
     });
+  });
+});
+
+// ============================================================================
+// #4196 — NEXUS_BILLING_MODE wiring into composite config
+// ============================================================================
+
+describe('adaptRoutingConfig billing mode (#4196)', () => {
+  afterEach(() => {
+    delete process.env['NEXUS_BILLING_MODE'];
+  });
+
+  it('defaults to plan when NEXUS_BILLING_MODE is unset', () => {
+    delete process.env['NEXUS_BILLING_MODE'];
+    expect(adaptRoutingConfig(undefined).billingMode).toBe('plan');
+  });
+
+  it('resolves api when NEXUS_BILLING_MODE=api', () => {
+    process.env['NEXUS_BILLING_MODE'] = 'api';
+    expect(adaptRoutingConfig(undefined).billingMode).toBe('api');
+  });
+
+  it('treats unknown values as plan (fail-safe default)', () => {
+    process.env['NEXUS_BILLING_MODE'] = 'weird';
+    expect(adaptRoutingConfig(undefined).billingMode).toBe('plan');
   });
 });

--- a/packages/nexus-agents/src/config/routing-config-adapter.ts
+++ b/packages/nexus-agents/src/config/routing-config-adapter.ts
@@ -194,6 +194,17 @@ function resolveStageFlags(stagesConfig: Partial<CompositeRouterConfig>): StageF
 }
 
 /**
+ * Resolves the composite router's billing mode from `NEXUS_BILLING_MODE`
+ * (#4196). Only the explicit value 'api' enables cost-aware routing
+ * (difficulty-conditional TOPSIS weights + per-task-class cost ceilings);
+ * anything else falls back to the 'plan' default, where those features are
+ * annotated no-ops.
+ */
+function resolveBillingModeFromEnv(): CompositeRouterConfig['billingMode'] {
+  return process.env['NEXUS_BILLING_MODE'] === 'api' ? 'api' : DEFAULT_COMPOSITE_CONFIG.billingMode;
+}
+
+/**
  * Builds the base CompositeRouterConfig from YAML config and defaults.
  */
 function buildBaseConfig(
@@ -204,7 +215,7 @@ function buildBaseConfig(
 
   return {
     ...stageFlags,
-    billingMode: DEFAULT_COMPOSITE_CONFIG.billingMode,
+    billingMode: resolveBillingModeFromEnv(),
     latencyScoreWeight: config.latencyScoreWeight,
     budgetConstraints: config.budget,
     linucbAlpha: config.linucb?.alpha ?? DEFAULT_COMPOSITE_CONFIG.linucbAlpha,


### PR DESCRIPTION
Closes #4196 (child 4 of epic #4175, vote-conditioned — both BINDING conditions implemented and test-pinned). Sequenced after #4194 (merged in #4201).

## What

### 1. Difficulty-conditional TOPSIS quality/cost weights (api mode only)
- `applyDifficultyCostWeighting` (topsis-types.ts) conditions the weight split on the **canonical SharedTaskAnalyzer complexity** — `TaskProfile.reasoningComplexity` (0-10, = `complexityScore × 10` via task-profile-adapter). No fourth difficulty estimator is introduced.
- **Hard** (`>7`, matching the existing ×1.2 quality-boost threshold in `adjustProfileForTask`): shift 0.15 weight cost→quality → **0.65 / 0.15 / 0.2** (quality/cost/latency) from the 0.5/0.3/0.2 defaults.
- **Easy** (`<4`): shift quality→cost → **0.35 / 0.45 / 0.2**.
- **Mid-band (4–7)**: returns the *same criteria reference* — the default path is byte-identical.
- Composes with per-category criteria (#1491); the shift is clamped so no weight goes negative and the sum stays 1.0 (architecture api 0.7/0.1/0.2 → 0.8/0.0/0.2 for hard tasks).
- Active ONLY under billing mode `api` — plan mode keeps its zeroed cost weight untouched.

### 2. Per-task-class cost ceiling in BudgetRouter (api mode only)
- `BudgetRouterOptions.taskClassCostCeilings` / composite `budgetConstraints.taskClassMaxCostUsd` — USD ceiling keyed by `detectTaskCategory` class. Default **OFF/unlimited** (absent = no ceiling).
- Candidate cost is estimated from **canonical registry pricing** (`ModelEntry.pricing` via `getModelPricing(getDefaultModelForCli(slot))`, the #4165 path) — NOT the legacy `TOKEN_COSTS` table (#4168 untouched).
- **BINDING (a)**: a candidate with MISSING registry pricing **FAILS a configured ceiling (fail-closed)** — pinned that an all-unpriced candidate set yields `[]`, never the `filterByPreferenceTier` return-all-candidates fallback (composite-router-helpers.ts:125 anti-pattern).

### 3. Plan-mode annotation (BINDING (b))
- Plan mode (the default) makes both features no-ops but **never silently**: the routing decision reason (which flows into the `routing.decision` trace event) carries `'cost weighting disabled: plan mode'` (`PLAN_MODE_COST_ANNOTATION`).
- Test-pinned: annotation **present** under default/plan config, **absent** under api.
- `adaptRoutingConfig` now resolves the composite router's billing mode from `NEXUS_BILLING_MODE` (only the explicit value `api` enables cost-aware routing), so the api path is reachable outside tests; unset/unknown values stay `plan`.

## Regression pins (default config byte-identical except the annotation)
- Plan mode, complexity 3 vs 5 → identical ranking + topScore (weights not conditioned in plan).
- Plan mode + ceilings configured → ceiling never invoked; route succeeds.
- Mid-band complexity returns the same criteria reference (no new router construction on the default path).
- Full suite: 27,380 tests pass unchanged apart from one stage-test mock gaining the new api-mode method.

## Weight-profile rationale
±0.15 is implemented as a bounded *shift* between quality and cost rather than fixed profiles, so category-aware criteria (#1491) keep their relative intent: on the 0.5/0.3/0.2 defaults it lands exactly on the issue's suggested 0.65/0.15/0.2 (hard) and 0.35/0.45/0.2 (easy), halves/×1.5s the cost weight (a strong but not absolute signal), leaves latency untouched, and clamps at zero for already-quality-heavy categories.

## Gates
- `pnpm test` — full suite foreground: 1141 files / 27,380 tests passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean (complexity ≤10, ≤50 lines/fn, max-lines respected)
- changeset: minor (`.changeset/difficulty-cost-weighting.md`)
- no MCP tool input shapes changed (no tool-reference drift); no new CLI cmd/tool/workflow (no repo-index entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
