### PR TITLE
feat(routing): yaml surface + typed keys for per-class cost ceilings (#4214)

### DIFF
--- a/.changeset/yaml-task-class-cost-ceilings.md
+++ b/.changeset/yaml-task-class-cost-ceilings.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+feat(routing): yaml surface + typed keys for per-class cost ceilings (#4214)
+
+- `routing.budget.taskClassMaxCostUsd` is now configurable via nexus-agents.yaml (previously programmatic-only; the YAML schema stripped it)
+- Ceiling keys are validated against the `TaskCategory` enum (`z.partialRecord`) in both the YAML and composite-router schemas, so a typo'd task class fails config parsing instead of silently configuring nothing; `BudgetRouterOptions.taskClassCostCeilings` is typed accordingly
+- Documented the operator surface in CONFIGURATION.md (ceilings, `NEXUS_BILLING_MODE=api` requirement, fail-closed semantics for unpriced candidates)

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -513,6 +513,38 @@ routing:
     resetIntervalMs: 3600000 # Reset every hour
 ```
 
+### Per-Task-Class Cost Ceilings
+
+Cap the per-task USD cost by task class (#4196, #4214). Each key is a
+`TaskCategory` (`architecture`, `code_generation`, `code_review`, `research`,
+`security_review`, `planning`, `documentation`, `testing`, `devops`,
+`exploration`); a typo'd key fails config validation instead of silently
+configuring nothing:
+
+```yaml
+routing:
+  budget:
+    taskClassMaxCostUsd:
+      code_generation: 0.25 # Max $0.25 per code-generation task
+      research: 1.00 # Research tasks may spend more
+```
+
+Two things to know before relying on ceilings:
+
+- **`NEXUS_BILLING_MODE=api` is required.** Ceilings are only enforced in
+  cost-aware (`api`) billing mode. Under the default `plan` mode they are an
+  annotated no-op — the routing decision reason carries
+  `cost weighting disabled: plan mode` and no candidate is ever filtered.
+- **Unpriced candidates fail closed.** When a ceiling is configured for the
+  task's detected class, any candidate whose model has no registry pricing is
+  excluded — an unknown cost is never allowed to slip under a configured
+  ceiling. If every candidate exceeds the ceiling (or is unpriced), routing
+  fails at the budget-filter stage rather than falling back to
+  all-candidates.
+
+Omit `taskClassMaxCostUsd` (or leave it empty) to disable ceilings entirely
+(the default).
+
 ### TOPSIS Weights
 
 Adjust multi-criteria optimization:

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from 'zod';
+import { TaskCategorySchema } from '../config/task-specialization-types.js';
 import type { ICliAdapter, CliName, RoutingArmId } from './types.js';
 import type { TaskProfile } from '../core/index.js';
 import type { PreferenceRouterConfig } from './preference-router-types.js';
@@ -79,9 +80,11 @@ export const CompositeRouterConfigSchema = z.object({
       maxCostUsd: z.number().positive(),
       maxLatencyMs: z.number().positive(),
       /** Per-task-class cost ceilings in USD, keyed by TaskCategory (#4196).
+       * Keys are validated against the TaskCategory enum (#4214) so a typo'd
+       * class fails config parsing instead of silently configuring nothing.
        * Default: absent → no ceiling (OFF/unlimited). Enforced only under
        * billingMode 'api'; missing candidate pricing fails CLOSED. */
-      taskClassMaxCostUsd: z.record(z.string(), z.number().positive()),
+      taskClassMaxCostUsd: z.partialRecord(TaskCategorySchema, z.number().positive()),
     })
     .partial()
     .optional(),

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -6,12 +6,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import {
   CompositeRouter,
   createCompositeRouter,
   CompositeRouterConfigSchema,
   CompositeRoutingError,
 } from './composite-router.js';
+import { RoutingConfigSchema } from '../config/schemas-routing.js';
+import { adaptRoutingConfig } from '../config/routing-config-adapter.js';
 import type { ICliAdapter, CliTask, CliName, RoutingArmId } from './types.js';
 import {
   AvailableModelsCache,
@@ -1156,5 +1159,67 @@ describe('CompositeRouter #4196 cost weighting/ceiling', () => {
     if (!result.ok) {
       expect(result.error.stage).toBe('budget-filter');
     }
+  });
+
+  it("schema rejects typo'd task-class ceiling keys (#4214)", () => {
+    expect(() =>
+      CompositeRouterConfigSchema.parse({
+        budgetConstraints: { taskClassMaxCostUsd: { code_gen: 0.25 } },
+      })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// #4214 — end-to-end: nexus-agents.yaml text → RoutingConfigSchema →
+// adaptRoutingConfig → CompositeRouter enforces per-task-class ceilings
+// ============================================================================
+
+describe('CompositeRouter #4214 YAML-configured cost ceilings (end-to-end)', () => {
+  // Explicit stage flags keep the pipeline deterministic regardless of the
+  // learning-persistence env (which auto-enables routingMemory et al., #1353).
+  const yamlText = `
+routing:
+  stages:
+    preferenceRouting: false
+    routingMemory: false
+    strategyDistillation: false
+  budget:
+    taskClassMaxCostUsd:
+      code_generation: 0.000001
+`;
+
+  afterEach(() => {
+    delete process.env['NEXUS_BILLING_MODE'];
+  });
+
+  function buildRouterFromYaml(): CompositeRouter {
+    const doc = parseYaml(yamlText) as { routing: unknown };
+    const routingConfig = RoutingConfigSchema.parse(doc.routing);
+    return new CompositeRouter(createTestAdapters(), adaptRoutingConfig(routingConfig));
+  }
+
+  it('api billing: YAML ceiling reaches the BudgetRouter and rejects unaffordable classes', async () => {
+    process.env['NEXUS_BILLING_MODE'] = 'api';
+    const router = buildRouterFromYaml();
+    const result = await router.route({ content: 'implement a function', maxTokens: 10_000 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe('budget-filter');
+    }
+  });
+
+  it('plan billing (default): the same YAML ceiling is an annotated no-op', async () => {
+    delete process.env['NEXUS_BILLING_MODE'];
+    const router = buildRouterFromYaml();
+    const result = await router.route({ content: 'implement a function', maxTokens: 10_000 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('adapted YAML config carries the ceilings into budgetConstraints', () => {
+    const doc = parseYaml(yamlText) as { routing: unknown };
+    const routingConfig = RoutingConfigSchema.parse(doc.routing);
+    const adapted = adaptRoutingConfig(routingConfig);
+    expect(adapted.budgetConstraints?.taskClassMaxCostUsd).toEqual({ code_generation: 0.000001 });
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/types-routing.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-routing.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Result } from '../core/index.js';
+import type { TaskCategory } from '../config/task-specialization-types.js';
 import type { CliName, CliResponse, CliError } from './types-core.js';
 import type { CliTask, ICliAdapter } from './types-capability.js';
 
@@ -181,11 +182,13 @@ export interface BudgetRouterOptions {
   /**
    * Per-task-class cost ceilings in USD per task (#4196), keyed by
    * `TaskCategory` from `detectTaskCategory` (e.g. `code_generation`).
+   * Keys are the TaskCategory enum (#4214) so a typo'd class is a compile
+   * error rather than a silently ignored entry.
    * Absent/empty → no ceiling (default OFF/unlimited). Enforced only under
    * api billing mode by the composite pipeline; a candidate whose registry
    * pricing is missing FAILS a configured ceiling (fail-closed).
    */
-  readonly taskClassCostCeilings?: Readonly<Record<string, number>>;
+  readonly taskClassCostCeilings?: Readonly<Partial<Record<TaskCategory, number>>>;
 }
 
 /**

--- a/packages/nexus-agents/src/config/routing-config-adapter.test.ts
+++ b/packages/nexus-agents/src/config/routing-config-adapter.test.ts
@@ -89,6 +89,23 @@ describe('routing-config-adapter', () => {
       });
     });
 
+    it('plumbs budget.taskClassMaxCostUsd through to budgetConstraints (#4214)', () => {
+      const yamlConfig: RoutingConfig = {
+        budget: {
+          maxCostUsd: 5,
+          taskClassMaxCostUsd: { code_generation: 0.25, research: 1.0 },
+        },
+        latencyScoreWeight: 0.2,
+      };
+
+      const result = adaptRoutingConfig(yamlConfig);
+
+      expect(result.budgetConstraints?.taskClassMaxCostUsd).toEqual({
+        code_generation: 0.25,
+        research: 1.0,
+      });
+    });
+
     it('adapts linucb parameters', () => {
       const yamlConfig: RoutingConfig = {
         linucb: {

--- a/packages/nexus-agents/src/config/schemas-routing.test.ts
+++ b/packages/nexus-agents/src/config/schemas-routing.test.ts
@@ -55,6 +55,40 @@ describe('BudgetConstraintsSchema', () => {
     const tiny = { maxTokens: 0.0001, maxCostUsd: 0.0001, maxLatencyMs: 1 };
     expect(BudgetConstraintsSchema.parse(tiny)).toEqual(tiny);
   });
+
+  // #4214 — per-task-class cost ceilings on the YAML surface
+  it('retains taskClassMaxCostUsd instead of stripping it (#4214)', () => {
+    const valid = {
+      maxCostUsd: 1.0,
+      taskClassMaxCostUsd: { code_generation: 0.25, architecture: 1.5 },
+    };
+    expect(BudgetConstraintsSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('rejects typo’d task-class ceiling keys (#4214)', () => {
+    expect(() =>
+      BudgetConstraintsSchema.parse({ taskClassMaxCostUsd: { code_gen: 0.25 } })
+    ).toThrow();
+  });
+
+  it('rejects non-positive ceiling values (#4214)', () => {
+    expect(() =>
+      BudgetConstraintsSchema.parse({ taskClassMaxCostUsd: { code_generation: 0 } })
+    ).toThrow();
+  });
+
+  it('accepts an empty ceilings map (OFF/unlimited) (#4214)', () => {
+    expect(BudgetConstraintsSchema.parse({ taskClassMaxCostUsd: {} })).toEqual({
+      taskClassMaxCostUsd: {},
+    });
+  });
+
+  it('RoutingConfigSchema retains nested budget.taskClassMaxCostUsd (#4214)', () => {
+    const parsed = RoutingConfigSchema.parse({
+      budget: { taskClassMaxCostUsd: { testing: 0.05 } },
+    });
+    expect(parsed.budget?.taskClassMaxCostUsd).toEqual({ testing: 0.05 });
+  });
 });
 
 describe('TopsisCriterionSchema', () => {

--- a/packages/nexus-agents/src/config/schemas-routing.ts
+++ b/packages/nexus-agents/src/config/schemas-routing.ts
@@ -11,6 +11,7 @@
 
 import { z } from 'zod';
 import { CliNameSchema } from './model-capabilities-types.js';
+import { TaskCategorySchema } from './task-specialization-types.js';
 
 /**
  * Budget constraints schema for cost/token/latency limits.
@@ -23,6 +24,15 @@ export const BudgetConstraintsSchema = z
     maxCostUsd: z.number().positive().optional(),
     /** Maximum latency per request in milliseconds */
     maxLatencyMs: z.number().positive().optional(),
+    /**
+     * Per-task-class cost ceilings in USD, keyed by `TaskCategory`
+     * (#4196, #4214). Keys are validated against the enum so a typo'd
+     * class fails config parsing instead of silently configuring nothing.
+     * Absent → no ceiling (OFF/unlimited). Enforced only under
+     * `NEXUS_BILLING_MODE=api`; a candidate with missing registry pricing
+     * fails a configured ceiling (fail-closed).
+     */
+    taskClassMaxCostUsd: z.partialRecord(TaskCategorySchema, z.number().positive()).optional(),
   })
   .optional();
 


### PR DESCRIPTION
Closes #4214. Small follow-up to #4196/#4213.

## What

1. **YAML surface** — `BudgetConstraintsSchema` (config/schemas-routing.ts) now includes `taskClassMaxCostUsd`, so `routing.budget.taskClassMaxCostUsd` in nexus-agents.yaml reaches `BudgetRouterOptions.taskClassCostCeilings` (previously zod stripped it; ceilings were programmatic-only). The adapter path (`routing-config-adapter.ts` → `budgetConstraints` pass-through → `CompositeRouter.buildBudgetRouter`) needed no code change once both schemas carry the field — covered by an end-to-end YAML-text → `RoutingConfigSchema` → `adaptRoutingConfig` → `CompositeRouter` test.

2. **Typed ceiling keys** — chose the **enum tightening** (not validate+warn): `TaskCategorySchema` lives in `config/task-specialization-types.ts`, which depends only on zod and `model-capabilities-types.ts` (also zod-only), so importing it from `cli-adapters/composite-router-types.ts` and `config/schemas-routing.ts` introduces no cycle (verified by typecheck + full suite). Both schemas now use `z.partialRecord(TaskCategorySchema, z.number().positive())` (Zod 4: subset-of-enum keys allowed, unknown keys rejected), and `BudgetRouterOptions.taskClassCostCeilings` is `Readonly<Partial<Record<TaskCategory, number>>>`. A typo'd task class is now a parse error / compile error instead of a silently ignored entry.

3. **Docs** — CONFIGURATION.md gains a "Per-Task-Class Cost Ceilings" section: valid keys, `NEXUS_BILLING_MODE=api` requirement (plan mode = annotated no-op), and fail-closed semantics for candidates with missing registry pricing.

## Tests (TDD — written first, 7 failing, then green)

- `schemas-routing.test.ts`: retains `taskClassMaxCostUsd`, rejects typo'd keys and non-positive values, nested `RoutingConfigSchema` retention
- `routing-config-adapter.test.ts`: YAML budget → `budgetConstraints.taskClassMaxCostUsd` plumb-through
- `composite-router.test.ts`: `CompositeRouterConfigSchema` rejects typo'd keys; end-to-end YAML text → router (api billing rejects at budget-filter; plan billing no-op; adapted config carries ceilings)

## Gates

- FULL `pnpm test` foreground: 1141 files / 27,393 tests passed, 16 skipped
- `pnpm typecheck`: clean
- `pnpm lint`: clean
- changeset: patch
- No new env vars; no Zod MCP tool input changes (no repo-index / tool-reference drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)