### PR TITLE
refactor(routing): consolidate cost tables onto registry pricing (#4168)

### DIFF
--- a/.changeset/consolidate-cost-tables-registry-4168.md
+++ b/.changeset/consolidate-cost-tables-registry-4168.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+refactor(routing): consolidate cost tables onto registry pricing (#4168)
+
+The hardcoded per-CLI/per-model USD cost tables that were duplicated across the
+routing chain and cost gates now read `ModelEntry.pricing` from the model
+registry through a single authoritative helper, `resolveCliCostPer1M` /
+`resolveModelCostPer1M` (in `config/model-config-helpers.ts`, backed by the
+`STATIC_CLI_COST_PER_1M` fallback in `config/in-tree-data.ts`).
+
+Consolidated sources: `budget-utils.TOKEN_COSTS`, `budget-stage`'s
+`COST_PER_1K_TOKENS`, `test-metrics`'s inline table, and `buildTopsisProfiles`'
+pricing path. Priced models upgrade to real registry data; an UNPRICED model
+falls back to the conservative static per-CLI estimate — never $0, so an unknown
+candidate cannot fail OPEN through a budget filter or look cheapest to TOPSIS and
+get over-selected. Registry pricing is per-1M tokens; the per-1K `budget-stage`
+table was converted accordingly. The `#4196` cost-ceiling path
+(`estimateRegistryCostUsd`) is unchanged: it deliberately keeps its
+`undefined`-on-unpriced fail-CLOSED semantics rather than the filter's
+conservative fallback.
+
+Frontier CLI defaults (claude-fable-5, gpt-5.5, gemini-3-pro) now carry real
+registry pricing, so cost fixtures asserting the old static numbers were updated
+deliberately. Unblocks #4195.

--- a/packages/nexus-agents/src/cli-adapters/budget-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.ts
@@ -62,10 +62,12 @@ const DEFAULT_OPTIONS: Required<BudgetRouterOptions> = {
 
 /**
  * Estimate the USD cost of a task on a CLI slot using CANONICAL registry
- * pricing (#4165 path: `ModelEntry.pricing` of the slot's default model) —
- * NOT the legacy `TOKEN_COSTS` table (consolidation tracked in #4168).
+ * pricing (#4165 path: `ModelEntry.pricing` of the slot's default model).
  * Returns `undefined` when the registry has no pricing for the model, so the
  * caller can fail CLOSED on a configured ceiling (#4196 BINDING condition).
+ * This deliberately differs from `resolveCliCostPer1M` (#4168), which returns
+ * a conservative non-$0 fallback for budget FILTERING — here an unknown price
+ * must stay `undefined` to preserve the ceiling's fail-CLOSED guarantee.
  */
 export function estimateRegistryCostUsd(
   slot: CliName,

--- a/packages/nexus-agents/src/cli-adapters/budget-utils.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-utils.test.ts
@@ -5,33 +5,43 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { TOKEN_COSTS, estimateTokens, estimateCost, formatTokens } from './budget-utils.js';
+import { estimateTokens, estimateCost, formatTokens } from './budget-utils.js';
+import { resolveCliCostPer1M } from '../config/model-config-helpers.js';
 
 describe('budget-utils', () => {
-  describe('TOKEN_COSTS', () => {
+  // #4168: the former hardcoded `TOKEN_COSTS` table now resolves through the
+  // registry via `resolveCliCostPer1M` (single authoritative source). These
+  // assertions preserve the original intent (each CLI is priced, output > input).
+  describe('per-CLI token costs (registry-backed)', () => {
     it('has cost data for claude', () => {
-      expect(TOKEN_COSTS.claude).toBeDefined();
-      expect(TOKEN_COSTS.claude.input).toBeGreaterThan(0);
-      expect(TOKEN_COSTS.claude.output).toBeGreaterThan(0);
+      const c = resolveCliCostPer1M('claude');
+      expect(c.input).toBeGreaterThan(0);
+      expect(c.output).toBeGreaterThan(0);
     });
 
     it('has cost data for gemini', () => {
-      expect(TOKEN_COSTS.gemini).toBeDefined();
-      expect(TOKEN_COSTS.gemini.input).toBeGreaterThan(0);
-      expect(TOKEN_COSTS.gemini.output).toBeGreaterThan(0);
+      const c = resolveCliCostPer1M('gemini');
+      expect(c.input).toBeGreaterThan(0);
+      expect(c.output).toBeGreaterThan(0);
     });
 
     it('has cost data for codex', () => {
-      expect(TOKEN_COSTS.codex).toBeDefined();
-      expect(TOKEN_COSTS.codex.input).toBeGreaterThan(0);
-      expect(TOKEN_COSTS.codex.output).toBeGreaterThan(0);
+      const c = resolveCliCostPer1M('codex');
+      expect(c.input).toBeGreaterThan(0);
+      expect(c.output).toBeGreaterThan(0);
     });
 
     it('output costs are higher than input costs', () => {
       // This is a common pricing pattern - outputs cost more than inputs
-      expect(TOKEN_COSTS.claude.output).toBeGreaterThan(TOKEN_COSTS.claude.input);
-      expect(TOKEN_COSTS.gemini.output).toBeGreaterThan(TOKEN_COSTS.gemini.input);
-      expect(TOKEN_COSTS.codex.output).toBeGreaterThan(TOKEN_COSTS.codex.input);
+      expect(resolveCliCostPer1M('claude').output).toBeGreaterThan(
+        resolveCliCostPer1M('claude').input
+      );
+      expect(resolveCliCostPer1M('gemini').output).toBeGreaterThan(
+        resolveCliCostPer1M('gemini').input
+      );
+      expect(resolveCliCostPer1M('codex').output).toBeGreaterThan(
+        resolveCliCostPer1M('codex').input
+      );
     });
   });
 
@@ -59,23 +69,26 @@ describe('budget-utils', () => {
     });
   });
 
+  // #4168: costs now come from registry pricing for each CLI's default model
+  // (claude→claude-fable-5 $10/$50, gemini→gemini-3-pro $2/$12, codex→gpt-5.5
+  // $5/$30 per 1M), not the old static table — numbers updated deliberately.
   describe('estimateCost', () => {
     it('calculates cost for claude', () => {
-      // 1M input tokens at $3.00 + 1M output tokens at $15.00 = $18.00
+      // 1M input at $10.00 + 1M output at $50.00 = $60.00 (claude-fable-5)
       const cost = estimateCost('claude', 1_000_000, 1_000_000);
-      expect(cost).toBe(18.0);
+      expect(cost).toBe(60.0);
     });
 
     it('calculates cost for gemini', () => {
-      // 1M input tokens at $0.075 + 1M output tokens at $0.30 = $0.375
+      // 1M input at $2.00 + 1M output at $12.00 = $14.00 (gemini-3-pro)
       const cost = estimateCost('gemini', 1_000_000, 1_000_000);
-      expect(cost).toBeCloseTo(0.375, 4);
+      expect(cost).toBeCloseTo(14.0, 4);
     });
 
     it('calculates cost for codex', () => {
-      // 1M input tokens at $2.50 + 1M output tokens at $10.00 = $12.50
+      // 1M input at $5.00 + 1M output at $30.00 = $35.00 (gpt-5.5)
       const cost = estimateCost('codex', 1_000_000, 1_000_000);
-      expect(cost).toBe(12.5);
+      expect(cost).toBe(35.0);
     });
 
     it('scales linearly with tokens', () => {
@@ -90,19 +103,19 @@ describe('budget-utils', () => {
 
     it('handles input-only cost', () => {
       const cost = estimateCost('claude', 1_000_000, 0);
-      expect(cost).toBe(3.0); // Only input cost
+      expect(cost).toBe(10.0); // Only input cost (claude-fable-5 $10/1M)
     });
 
     it('handles output-only cost', () => {
       const cost = estimateCost('claude', 0, 1_000_000);
-      expect(cost).toBe(15.0); // Only output cost
+      expect(cost).toBe(50.0); // Only output cost (claude-fable-5 $50/1M)
     });
 
     it('handles small token counts', () => {
-      // 1000 input + 1000 output for claude
+      // 1000 input + 1000 output for claude (claude-fable-5)
       const cost = estimateCost('claude', 1000, 1000);
-      // (1000/1M) * 3 + (1000/1M) * 15 = 0.003 + 0.015 = 0.018
-      expect(cost).toBeCloseTo(0.018, 6);
+      // (1000/1M) * 10 + (1000/1M) * 50 = 0.01 + 0.05 = 0.06
+      expect(cost).toBeCloseTo(0.06, 6);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/budget-utils.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-utils.ts
@@ -1,25 +1,17 @@
 /**
  * Budget utilities for cost estimation and token counting.
  *
- * CANONICAL SOURCE for token costs across the codebase.
- * Other modules should import from here or align their constants.
+ * Token costs are NO LONGER hardcoded here: `estimateCost` resolves per-CLI
+ * pricing from the model registry via `resolveCliCostPer1M` (#4168), so the
+ * `ModelEntry.pricing` chain is the single authoritative source. Unpriced
+ * models fall back to the conservative `STATIC_CLI_COST_PER_1M` map (never $0).
  *
  * @module cli-adapters/budget-utils
  * (Source: Issue #102, arXiv:2508.21141 - EMNLP 2025)
  */
 
 import type { CliName } from './types.js';
-
-/**
- * Token cost estimates per 1M tokens (USD).
- * Based on public pricing as of 2025-01.
- */
-export const TOKEN_COSTS: Record<CliName, { input: number; output: number }> = {
-  claude: { input: 3.0, output: 15.0 },
-  gemini: { input: 0.075, output: 0.3 },
-  codex: { input: 2.5, output: 10.0 },
-  opencode: { input: 2.0, output: 8.0 },
-};
+import { resolveCliCostPer1M } from '../config/model-config-helpers.js';
 
 /**
  * Estimate tokens from task content.
@@ -30,10 +22,12 @@ export function estimateTokens(content: string): number {
 }
 
 /**
- * Estimate cost for a task based on estimated tokens.
+ * Estimate cost (USD) for a task based on estimated tokens, using registry
+ * pricing for the CLI's default model (conservative static fallback when
+ * unpriced — never $0). Rates are per-1M tokens.
  */
 export function estimateCost(model: CliName, inputTokens: number, outputTokens: number): number {
-  const costs = TOKEN_COSTS[model];
+  const costs = resolveCliCostPer1M(model);
   const inputCost = (inputTokens / 1_000_000) * costs.input;
   const outputCost = (outputTokens / 1_000_000) * costs.output;
   return inputCost + outputCost;

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/budget-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/budget-stage.ts
@@ -20,20 +20,11 @@ import type {
   CliName,
 } from '../router-stage.js';
 import { addTrace, filterCandidate, getRemainingCandidates } from '../router-stage.js';
+import { resolveCliCostPer1M } from '../../../config/model-config-helpers.js';
 
 // ============================================================================
 // Configuration
 // ============================================================================
-
-/**
- * Cost per 1K tokens for each CLI (approximate).
- */
-const COST_PER_1K_TOKENS: Record<CliName, { input: number; output: number }> = {
-  claude: { input: 0.015, output: 0.075 },
-  gemini: { input: 0.00125, output: 0.005 },
-  codex: { input: 0.003, output: 0.015 },
-  opencode: { input: 0.003, output: 0.012 },
-};
 
 /**
  * Configuration for the budget filter stage.
@@ -163,11 +154,17 @@ export class BudgetFilterStage implements IRouterStage {
 
   /**
    * Estimate cost for a CLI based on expected tokens.
+   *
+   * Rates come from registry pricing for the CLI's default model via
+   * `resolveCliCostPer1M` (#4168), which is per-1M tokens (the old
+   * `COST_PER_1K_TOKENS` table was per-1K — hence the 1_000_000 divisor).
+   * An unpriced model falls back to a conservative non-$0 estimate, so a
+   * candidate never resolves to $0 and passes the budget filter for free.
    */
   private estimateCost(cli: CliName): number {
-    const rates = COST_PER_1K_TOKENS[cli];
-    const inputCost = (this.config.expectedInputTokens / 1000) * rates.input;
-    const outputCost = (this.config.expectedOutputTokens / 1000) * rates.output;
+    const rates = resolveCliCostPer1M(cli);
+    const inputCost = (this.config.expectedInputTokens / 1_000_000) * rates.input;
+    const outputCost = (this.config.expectedOutputTokens / 1_000_000) * rates.output;
     return inputCost + outputCost;
   }
 

--- a/packages/nexus-agents/src/config/in-tree-data.ts
+++ b/packages/nexus-agents/src/config/in-tree-data.ts
@@ -451,3 +451,33 @@ export const DEFAULT_MODEL_PER_CLI: Record<CliNameLiteral, ModelId> = {
   codex: 'gpt-5.5',
   opencode: 'opencode-default',
 };
+
+/** A per-1M-token USD pricing pair (input/output). */
+export interface CostPer1M {
+  readonly input: number;
+  readonly output: number;
+}
+
+/**
+ * Static per-CLI USD/1M-token fallback, used ONLY when the registry has no
+ * pricing for a CLI's resolved default model (#4168). Single authoritative
+ * representation of the former hardcoded per-CLI cost tables (previously
+ * duplicated in `budget-utils.TOKEN_COSTS`, `budget-stage`'s
+ * `COST_PER_1K_TOKENS`, and `test-metrics`).
+ *
+ * It is a FALLBACK, not the primary source: a priced model always upgrades to
+ * real registry data via `resolveModelCostPer1M`. Because every current
+ * `DEFAULT_MODEL_PER_CLI` entry is priced, this map is dormant today; it exists
+ * so an UNPRICED candidate stays CONSERVATIVE (never $0) in budget/TOPSIS gates
+ * — a $0 fails OPEN and gets the unknown model over-selected (#4168 cond. 2).
+ *
+ * Lives in this leaf data module (not `model-config-helpers`) so the
+ * module-load-time `buildTopsisProfiles` call reads it after initialization,
+ * dodging the TDZ hazard documented for the registry builders.
+ */
+export const STATIC_CLI_COST_PER_1M: Record<CliNameLiteral, CostPer1M> = {
+  claude: { input: 3.0, output: 15.0 },
+  gemini: { input: 0.075, output: 0.3 },
+  codex: { input: 2.5, output: 10.0 },
+  opencode: { input: 2.0, output: 8.0 },
+};

--- a/packages/nexus-agents/src/config/model-config-helpers.test.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.test.ts
@@ -22,7 +22,10 @@ import {
   buildCliCapabilityProfiles,
   buildTopsisProfiles,
   buildMockModelInfo,
+  resolveModelCostPer1M,
+  resolveCliCostPer1M,
 } from './model-config-helpers.js';
+import type { ModelId } from './model-capabilities-types.js';
 
 // ============================================================================
 // Single-Model Lookups
@@ -324,6 +327,56 @@ describe('buildMockModelInfo', () => {
       expect(model.id).toBeTruthy();
       expect(model.name).toBeTruthy();
       expect(model.contextWindow).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ============================================================================
+// Cost resolution (#4168) — the single authoritative per-CLI/per-model $ source
+// ============================================================================
+
+describe('resolveModelCostPer1M', () => {
+  it('upgrades a priced model to real registry pricing', () => {
+    // claude-sonnet is priced $3/$15 per 1M in-tree; must NOT use the fallback.
+    const fallback = { input: 999, output: 999 };
+    expect(resolveModelCostPer1M('claude-sonnet', fallback)).toEqual({ input: 3.0, output: 15.0 });
+  });
+
+  it('FAIL DIRECTION: unpriced model falls back conservatively, never $0', () => {
+    // A model the registry cannot price MUST NOT resolve to $0 — a $0 candidate
+    // fails OPEN (always passes a budget filter, looks cheapest to TOPSIS) and
+    // gets over-selected, spending real money (#4168 binding condition 2).
+    const fallback = { input: 3.0, output: 15.0 };
+    const resolved = resolveModelCostPer1M('nonexistent-unpriced-model-xyz' as ModelId, fallback);
+    expect(resolved).toEqual(fallback);
+    expect(resolved.input).toBeGreaterThan(0);
+    expect(resolved.output).toBeGreaterThan(0);
+  });
+
+  it('preserves an EXPLICIT $0 registry price (only a missing price falls back)', () => {
+    // openrouter-nemotron-super is deliberately priced $0 in-tree — that is a
+    // real (priced) $0, not an unknown, so it is returned as-is, not the fallback.
+    const fallback = { input: 3.0, output: 15.0 };
+    expect(resolveModelCostPer1M('openrouter-nemotron-super', fallback)).toEqual({
+      input: 0,
+      output: 0,
+    });
+  });
+});
+
+describe('resolveCliCostPer1M', () => {
+  it('maps each CLI to its default model registry pricing (per-1M)', () => {
+    // claude→claude-fable-5 $10/$50, gemini→gemini-3-pro $2/$12, codex→gpt-5.5 $5/$30.
+    expect(resolveCliCostPer1M('claude')).toEqual({ input: 10.0, output: 50.0 });
+    expect(resolveCliCostPer1M('gemini')).toEqual({ input: 2.0, output: 12.0 });
+    expect(resolveCliCostPer1M('codex')).toEqual({ input: 5.0, output: 30.0 });
+  });
+
+  it('every CLI resolves to a non-$0 cost (no fail-open in budget gates)', () => {
+    for (const cli of CLI_NAMES) {
+      const c = resolveCliCostPer1M(cli);
+      expect(c.input).toBeGreaterThan(0);
+      expect(c.output).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/nexus-agents/src/config/model-config-helpers.ts
+++ b/packages/nexus-agents/src/config/model-config-helpers.ts
@@ -15,7 +15,12 @@
  */
 
 import { buildInTreeEntries } from './in-tree-entries.js';
-import { DEFAULT_MODEL_CAPABILITIES, DEFAULT_MODEL_PER_CLI } from './in-tree-data.js';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  DEFAULT_MODEL_PER_CLI,
+  STATIC_CLI_COST_PER_1M,
+  type CostPer1M,
+} from './in-tree-data.js';
 import type {
   ModelId,
   ModelCapability,
@@ -150,6 +155,33 @@ export function getDefaultModelForCli(cli: CliNameLiteral): ModelId {
   return registry.getEntry(staticDefault).id as ModelId;
 }
 
+/**
+ * Resolve per-1M-token USD pricing for a model id from the registry, falling
+ * back to a conservative static estimate when the registry has NO pricing
+ * (#4168). The fallback is NEVER $0: an unpriced candidate must stay
+ * conservative in cost gates, because a $0 always passes a budget filter (and
+ * looks cheapest to TOPSIS) and gets over-selected, spending real money.
+ *
+ * A model with EXPLICIT $0 registry pricing (a deliberately-free entry) is
+ * returned as-is — only a missing (`undefined`) price triggers the fallback,
+ * matching `computeCostDetail`'s `priced` semantics (#4165).
+ */
+export function resolveModelCostPer1M(modelId: ModelId, fallback: CostPer1M): CostPer1M {
+  const pricing = getModelPricing(modelId);
+  if (pricing === undefined) return fallback;
+  return { input: pricing.inputPer1M, output: pricing.outputPer1M };
+}
+
+/**
+ * Resolve per-1M-token USD pricing for a CLI's default model (#4168):
+ * `CliName → getDefaultModelForCli → registry pricing`, with the CLI's
+ * {@link STATIC_CLI_COST_PER_1M} entry as the conservative fallback when the
+ * resolved model is unpriced. Single source for the former per-CLI $ tables.
+ */
+export function resolveCliCostPer1M(cli: CliNameLiteral): CostPer1M {
+  return resolveModelCostPer1M(getDefaultModelForCli(cli), STATIC_CLI_COST_PER_1M[cli]);
+}
+
 /** Get the model name the CLI binary expects (e.g., 'gemini-2.5-pro'). */
 export function getCliModelName(modelId: ModelId): string {
   const entry = lookupInTree(modelId);
@@ -260,9 +292,18 @@ export function buildTopsisProfiles(): readonly TopsisProfileShape[] {
   >) {
     const entry = byId.get(modelId);
     const q = entry?.qualityScores;
-    const p = entry?.pricing;
-    if (entry === undefined || q === undefined || p === undefined) continue;
+    if (entry === undefined || q === undefined) continue;
     if (entry.contextWindow === undefined) continue;
+    // Pricing is registry-first with a conservative static fallback (#4168):
+    // an unpriced default model stays a candidate at a non-$0 cost rather than
+    // being dropped or scored as free (which TOPSIS would rank cheapest). Read
+    // the already-built in-tree `entry` directly (not `resolveModelCostPer1M`)
+    // to avoid re-entering `lookupInTree` at module-load time (TDZ hazard).
+    const p = entry.pricing;
+    const price: CostPer1M =
+      p !== undefined
+        ? { input: p.inputPer1M, output: p.outputPer1M }
+        : STATIC_CLI_COST_PER_1M[cli];
     profiles.push({
       cliName: cli,
       capabilities: {
@@ -272,8 +313,8 @@ export function buildTopsisProfiles(): readonly TopsisProfileShape[] {
         speed: q.speed,
         cost: q.cost,
       },
-      costPerMillionInput: p.inputPer1M,
-      costPerMillionOutput: p.outputPer1M,
+      costPerMillionInput: price.input,
+      costPerMillionOutput: price.output,
       averageLatencyMs: cliAvgLatency()[cli],
       qualityScore: (q.reasoning + q.codeGeneration) / 2,
     });

--- a/packages/nexus-agents/src/testing/framework/test-metrics.test.ts
+++ b/packages/nexus-agents/src/testing/framework/test-metrics.test.ts
@@ -135,23 +135,26 @@ describe('createEmptyMetrics', () => {
 // estimateCost
 // ============================================================================
 
+// #4168: costs resolve from registry pricing for each CLI's default model
+// (claude→claude-fable-5 $10/$50, gemini→gemini-3-pro $2/$12, codex→gpt-5.5
+// $5/$30 per 1M), not the old static table — numbers updated deliberately.
 describe('estimateCost', () => {
   it('calculates cost for Claude', () => {
     const cost = estimateCost('claude', { inputTokens: 1_000_000, outputTokens: 100_000 });
-    // 3.0 + 1.5 = 4.5
-    expect(cost).toBeCloseTo(4.5);
+    // 10.0 + 5.0 = 15.0 (claude-fable-5)
+    expect(cost).toBeCloseTo(15.0);
   });
 
   it('calculates cost for Gemini', () => {
     const cost = estimateCost('gemini', { inputTokens: 1_000_000, outputTokens: 1_000_000 });
-    // 0.075 + 0.3 = 0.375
-    expect(cost).toBeCloseTo(0.375);
+    // 2.0 + 12.0 = 14.0 (gemini-3-pro)
+    expect(cost).toBeCloseTo(14.0);
   });
 
   it('calculates cost for Codex', () => {
     const cost = estimateCost('codex', { inputTokens: 1_000_000, outputTokens: 1_000_000 });
-    // 2.0 + 8.0 = 10.0
-    expect(cost).toBeCloseTo(10.0);
+    // 5.0 + 30.0 = 35.0 (gpt-5.5)
+    expect(cost).toBeCloseTo(35.0);
   });
 
   it('returns 0 for zero tokens', () => {

--- a/packages/nexus-agents/src/testing/framework/test-metrics.ts
+++ b/packages/nexus-agents/src/testing/framework/test-metrics.ts
@@ -8,6 +8,7 @@
 
 import type { CliName } from '../../cli-adapters/types.js';
 import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
+import { resolveCliCostPer1M } from '../../config/model-config-helpers.js';
 import type {
   TaskTestResult,
   AggregatedMetrics,
@@ -221,21 +222,15 @@ export function computeRoutingMetrics(results: readonly TaskTestResult[]): {
 }
 
 /**
- * Estimates cost for token usage.
+ * Estimates cost (USD) for token usage using registry pricing for the CLI's
+ * default model via `resolveCliCostPer1M` (#4168, per-1M tokens). Unpriced
+ * models fall back to a conservative non-$0 estimate.
  */
 export function estimateCost(
   cli: CliName,
   usage: { inputTokens: number; outputTokens: number }
 ): number {
-  // Cost per 1M tokens (approximate)
-  const costs: Record<CliName, { input: number; output: number }> = {
-    claude: { input: 3.0, output: 15.0 },
-    gemini: { input: 0.075, output: 0.3 },
-    codex: { input: 2.0, output: 8.0 },
-    opencode: { input: 2.0, output: 8.0 },
-  };
-
-  const rate = costs[cli];
+  const rate = resolveCliCostPer1M(cli);
   const inputCost = (usage.inputTokens / 1_000_000) * rate.input;
   const outputCost = (usage.outputTokens / 1_000_000) * rate.output;
 


### PR DESCRIPTION
## Summary

Consolidates the hardcoded per-CLI/per-model USD cost tables that were duplicated across the CANONICAL routing chain and cost gates so they all read `ModelEntry.pricing` from the model registry through **one authoritative helper**, with a conservative static fallback. Closes #4168 (deferred child of epic #4163; all-or-nothing scope vote).

## Shared helper (single authoritative source)

- `resolveCliCostPer1M(cli)` and `resolveModelCostPer1M(modelId, fallback)` in `config/model-config-helpers.ts` — registry-first, per-1M tokens.
- Fallback map `STATIC_CLI_COST_PER_1M` (+ `CostPer1M` type) lives in the leaf `config/in-tree-data.ts` next to `DEFAULT_MODEL_PER_CLI` (placed there so the module-load-time `buildTopsisProfiles` call reads it after init — TDZ-safe).

CLI-keyed tables map `CliName → getDefaultModelForCli(cli) → getModelPricing(modelId)`; model-keyed uses go direct.

## Consolidated sources (4 genuine per-token $ tables)

| Site | Before | After |
|---|---|---|
| `cli-adapters/budget-utils.ts` `TOKEN_COSTS` | static per-1M table | `resolveCliCostPer1M`; table removed |
| `routing/stages/budget-stage.ts` `COST_PER_1K_TOKENS` | static per-1K table | `resolveCliCostPer1M` (per-1K→per-1M converted); table removed |
| `testing/framework/test-metrics.ts` inline table | static per-1M table | `resolveCliCostPer1M` |
| `config/model-config-helpers.ts` `buildTopsisProfiles` | dropped unpriced models | registry-first with conservative fallback (unpriced no longer dropped/zeroed) |

## Binding vote conditions

1. **Static fallback preserved as FALLBACK, not primary** — priced models upgrade to real registry data; only a `undefined` registry price triggers the static map. An explicit `$0` registry price is preserved as-is (matches `computeCostDetail`'s `priced` semantics, #4165).
2. **UNMEASURED stays conservative — never $0** — an unpriced candidate falls back to a non-$0 estimate in both budget gates and TOPSIS, so it cannot fail OPEN (a $0 always passes a budget filter / looks cheapest and gets over-selected).
3. **Unit conversion pinned** — registry pricing is per-1M; the per-1K `budget-stage` table was converted (`/1000` → `/1_000_000`) and the math is pinned in tests.
4. **#4196 ceiling logic untouched** — `estimateRegistryCostUsd` deliberately keeps its `undefined`-on-unpriced **fail-CLOSED** semantics (different from the filter's conservative fallback); only its stale `TOKEN_COSTS` comment was updated.

## Fail-direction test

`config/model-config-helpers.test.ts` → `resolveModelCostPer1M > FAIL DIRECTION: unpriced model falls back conservatively, never $0`: an unpriced model id resolves to the fallback (`> 0`), never `{0,0}`. Plus: explicit-$0 preserved, `resolveCliCostPer1M` per-CLI registry numbers, and "every CLI resolves non-$0".

## Scope note — 5th enumerated target

`workflows/aflow/evaluation-efficiency.ts:142` (`COST_MODEL`: `baseCostPerStep`/`costPerRetry`/`costPerTimeoutMs`) is an **abstract workflow-structural** cost model (arbitrary units, per-step/per-ms; `estimateCost(workflow)` has no model id and no token counts). It is **not** a per-token duplicate of `ModelEntry.pricing`, so forcing it onto registry pricing would be a category error that breaks AFlow efficiency scoring. Per binding condition 4 ("read the new helper only if it currently duplicates" — it does not), it is deliberately left unchanged. Reconciled in this pass by determination, not omission.

## Fixture cascade

Frontier CLI defaults now carry real registry pricing (claude→claude-fable-5 $10/$50, gemini→gemini-3-pro $2/$12, codex→gpt-5.5 $5/$30 per 1M), so cost fixtures asserting the old static numbers were updated deliberately in `budget-utils.test.ts` and `test-metrics.test.ts`. `topsis-helpers.test.ts` and `budget-stage.test.ts` unchanged (defaults already priced identically). Full suite green.

## Gates
- `pnpm typecheck` — pass
- full `vitest run` — 27436 passed, 16 skipped, 0 failed (1143 files)
- `eslint` on changed files — pass (complexity/line rules)
- `check-new-unused-exports.ts origin/main` — pass
- changeset: MINOR

Unblocks #4195.

Closes #4168

🤖 Generated with [Claude Code](https://claude.com/claude-code)