### PR TITLE
feat(routing): derive tier tables from registry quality+pricing (#4195)

### DIFF
--- a/.changeset/derive-tier-tables-registry-4195.md
+++ b/.changeset/derive-tier-tables-registry-4195.md
@@ -1,0 +1,44 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): derive tier tables from registry quality+pricing (#4195)
+
+The hardcoded tier / strength / rank tables that were duplicated across the
+routing chain now derive from each CLI's default-model `qualityScores` + real
+registry `pricing` through a single authoritative helper,
+`cli-adapters/derive-tier-tables.ts`. Consolidated consumers:
+
+- `zero-router-types.DEFAULT_TIER_TO_CLIS` — `deriveTierToClis()`
+- `confidence-cascade-stage.CLI_CONFIDENCE_PROFILES` — `deriveCliConfidenceProfiles()`
+- `composite-router-helpers.filterByPreferenceTier` strong/weak sets —
+  `deriveStrongClis()` / `deriveWeakClis()`, and its `filterByDifficultyTier`
+  parallel tier literal — `deriveTierToClis()`
+- `resource-strategy-stage.CLI_QUALITY_RANK` / `CLI_COST_RANK` —
+  `deriveCliQualityRank()` / `deriveCliCostRank()`
+
+Binding vote conditions (#4195), each unit-pinned in
+`derive-tier-tables.test.ts`:
+
+1. A CLI whose default model lacks `qualityScores` classifies conservative and
+   is excluded from the powerful tier and the premium ("strong") set — an
+   unvetted model never fronts the frontier tier.
+2. Composes safely with `resolve-model-for-tier`: because (1) keeps unscored
+   CLIs out of the powerful tier, and a degenerate all-unscored cohort yields an
+   _empty_ powerful tier (never a synthesised frontier default), an empty
+   powerful tier no longer silently up-costs.
+3. A $0/$0 default (genuine `:free` or a catalog artifact, #4209) is normalised
+   to most-expensive, so it can never win the cost rank or the premium set and
+   pull real traffic to it as "cheapest".
+4. Every ordering is deterministic — value-keyed with explicit, stable
+   tie-breaks (quality ties break by premium price; never `qualityScores`-NaN or
+   insertion-order dependent).
+
+The router-scoring `CAPABILITY_MATRIX` was assessed and intentionally retained:
+it is a per-task-type _affinity_ matrix (orthogonal to the quality/cost tier
+axis and not recoverable from `qualityScores`), and its per-CLI capability
+inputs are already registry-derived via `buildCliCapabilityProfiles`.
+
+Full suite green with no fixture changes — the registry-derived orderings
+reproduce every previously-pinned tier / rank / strength selection. Closes the
+last buildable child of epic #4175.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -27,6 +27,7 @@ import type { CompositeRouterConfig } from './composite-router-types.js';
 import type { IZeroRouter } from './zero-router.js';
 import type { DifficultyEstimate, DifficultyOutcome, ModelTier } from './zero-router-types.js';
 import { hashTaskContent } from './zero-router-calibration.js';
+import { deriveStrongClis, deriveWeakClis, deriveTierToClis } from './derive-tier-tables.js';
 
 /**
  * Adjusts model profile based on task characteristics.
@@ -123,12 +124,13 @@ export function filterByPreferenceTier(
   candidates: RoutingArmId[],
   tier: 'strong' | 'weak'
 ): RoutingArmId[] {
-  // Strong models: claude (opus, sonnet)
-  // Weak models: gemini (flash), codex
-  // Tier membership is slot-level; collapse an api:* arm to its display slot
-  // (#3422) so a wrapped API arm inherits its vendor slot's tier.
-  const strongModels: CliName[] = ['claude'];
-  const weakModels: CliName[] = ['gemini', 'codex'];
+  // Strong = the premium tier (most-expensive frontier default); weak = the
+  // budget CLIs. DERIVED from real registry pricing + qualityScores (#4195) —
+  // a $0/unscored default can never be "strong". Tier membership is slot-level;
+  // collapse an api:* arm to its display slot (#3422) so a wrapped API arm
+  // inherits its vendor slot's tier.
+  const strongModels: CliName[] = deriveStrongClis();
+  const weakModels: CliName[] = deriveWeakClis();
 
   const preferred = tier === 'strong' ? strongModels : weakModels;
   const filtered = candidates.filter((c) => preferred.includes(routingArmDisplaySlot(c)));
@@ -445,14 +447,9 @@ export function filterByDifficultyTier(
   candidates: RoutingArmId[],
   tier: ModelTier
 ): RoutingArmId[] {
-  // Tier mappings aligned with ZeroRouter DEFAULT_TIER_TO_CLIS
-  const tierPreferences: Record<ModelTier, CliName[]> = {
-    fast: ['gemini', 'codex', 'claude'],
-    balanced: ['codex', 'gemini', 'claude'],
-    powerful: ['claude', 'codex', 'gemini'],
-  };
-
-  const preferred = tierPreferences[tier];
+  // Single source with ZeroRouter's DEFAULT_TIER_TO_CLIS: the same
+  // registry-derived tier→CLI ordering (#4195), no longer a parallel literal.
+  const preferred = deriveTierToClis()[tier];
   // Sort candidates by tier preference order. Tier preference is slot-level;
   // an api:* arm sorts by its display slot's position (#3422).
   const sortedCandidates = [...candidates].sort((a, b) => {

--- a/packages/nexus-agents/src/cli-adapters/derive-tier-tables.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/derive-tier-tables.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for registry-derived tier / rank / strength tables (#4195).
+ *
+ * Pins the four BINDING vote conditions and the deterministic derived
+ * orderings that the five routing consumers depend on.
+ */
+import { describe, it, expect } from 'vitest';
+
+import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+import {
+  readCliModelData,
+  buildQualityRank,
+  buildCostRank,
+  buildTierToClis,
+  buildPremiumClis,
+  deriveCliQualityRank,
+  deriveCliCostRank,
+  deriveTierToClis,
+  deriveStrongClis,
+  deriveWeakClis,
+  deriveCliConfidenceProfiles,
+  normalizeBlendedPrice,
+  EXPENSIVE_SENTINEL,
+  type CliModelData,
+} from './derive-tier-tables.js';
+
+type Data = Record<CliNameLiteral, CliModelData>;
+
+/** Synthetic cohort with knobs for the fail-safe conditions. */
+function makeData(over: Partial<Record<CliNameLiteral, Partial<CliModelData>>> = {}): Data {
+  const base: Data = {
+    claude: { quality: 10, price: 60, speed: 5 },
+    gemini: { quality: 9.5, price: 14, speed: 8 },
+    codex: { quality: 10, price: 35, speed: 7 },
+    opencode: { quality: 9, price: 18, speed: 7 },
+  };
+  for (const cli of Object.keys(over) as CliNameLiteral[]) {
+    base[cli] = { ...base[cli], ...over[cli] };
+  }
+  return base;
+}
+
+describe('derive-tier-tables (#4195)', () => {
+  describe('readCliModelData — from the live registry', () => {
+    it('reads composite quality + blended real price for each CLI default', () => {
+      const data = readCliModelData();
+      // claude default (fable-5) r10/cg10 → composite 10; priced 10+50=60.
+      expect(data.claude.quality).toBe(10);
+      expect(data.claude.price).toBe(60);
+      // gemini default (gemini-3-pro) r10/cg9 → 9.5; 2+12=14.
+      expect(data.gemini.quality).toBe(9.5);
+      expect(data.gemini.price).toBe(14);
+    });
+  });
+
+  // --- Condition 1: no qualityScores → conservative, NEVER powerful ---------
+  describe('condition 1 — missing qualityScores fails SAFE', () => {
+    it('excludes an unscored CLI from the powerful tier entirely', () => {
+      const data = makeData({ codex: { quality: undefined } });
+      expect(buildTierToClis(data).powerful).not.toContain('codex');
+    });
+
+    it('never lets an unscored CLI head the powerful tier', () => {
+      // Even if the unscored CLI is the most expensive, it must not be powerful.
+      const data = makeData({ claude: { quality: undefined, price: 999 } });
+      expect(buildTierToClis(data).powerful).not.toContain('claude');
+    });
+
+    it('gives an unscored CLI the lowest (zero) quality rank', () => {
+      const data = makeData({ opencode: { quality: undefined } });
+      expect(buildQualityRank(data).opencode).toBe(0);
+    });
+
+    it('excludes an unscored CLI from the premium (strong) set', () => {
+      const data = makeData({ claude: { quality: undefined } });
+      expect(buildPremiumClis(data)).not.toContain('claude');
+    });
+  });
+
+  // --- Condition 2: empty powerful tier must not up-cost --------------------
+  describe('condition 2 — degenerate cohort does not synthesise a powerful pick', () => {
+    it('yields an EMPTY powerful tier when no CLI is scored (never a frontier default)', () => {
+      const data = makeData({
+        claude: { quality: undefined },
+        gemini: { quality: undefined },
+        codex: { quality: undefined },
+        opencode: { quality: undefined },
+      });
+      expect(buildTierToClis(data).powerful).toEqual([]);
+      // Fast/balanced still cover every CLI so routing degrades conservative.
+      expect(buildTierToClis(data).fast).toHaveLength(4);
+    });
+  });
+
+  // --- Condition 3: $0 default cannot win the cost rank ---------------------
+  describe('condition 3 — $0/$0 pricing cannot look "cheapest"', () => {
+    it('normalises a $0 (or negative) blended price to the most-expensive sentinel', () => {
+      expect(normalizeBlendedPrice(0)).toBe(EXPENSIVE_SENTINEL);
+      expect(normalizeBlendedPrice(-5)).toBe(EXPENSIVE_SENTINEL);
+      expect(normalizeBlendedPrice(14)).toBe(14);
+    });
+
+    it('ranks a $0-priced default LOWEST on cost, never highest', () => {
+      const data = makeData({ opencode: { price: EXPENSIVE_SENTINEL } });
+      const rank = buildCostRank(data);
+      const cheapest = (Object.keys(rank) as CliNameLiteral[]).sort((a, b) => rank[b] - rank[a])[0];
+      expect(cheapest).not.toBe('opencode');
+      expect(rank.opencode).toBeLessThanOrEqual(rank.claude);
+    });
+
+    it('keeps a $0 default out of the premium set', () => {
+      const data = makeData({ claude: { price: EXPENSIVE_SENTINEL } });
+      expect(buildPremiumClis(data)).not.toContain('claude');
+    });
+  });
+
+  // --- Condition 4: deterministic, stably tie-broken ordering ---------------
+  describe('condition 4 — deterministic ordering', () => {
+    it('is byte-stable across repeated derivations', () => {
+      expect(deriveTierToClis()).toEqual(deriveTierToClis());
+      expect(deriveCliQualityRank()).toEqual(deriveCliQualityRank());
+      expect(deriveCliCostRank()).toEqual(deriveCliCostRank());
+    });
+
+    it('breaks quality ties by premium price (claude before codex)', () => {
+      // claude & codex both composite 10; claude is pricier → heads powerful.
+      const powerful = buildTierToClis(makeData()).powerful;
+      expect(powerful.indexOf('claude')).toBeLessThan(powerful.indexOf('codex'));
+    });
+  });
+
+  // --- Derived orderings the consumers pin ----------------------------------
+  describe('derived tier orderings (live registry)', () => {
+    it('fast tier leads with gemini (fastest/cheapest default)', () => {
+      expect(deriveTierToClis().fast[0]).toBe('gemini');
+    });
+    it('balanced tier leads with codex (best quality/cost blend)', () => {
+      expect(deriveTierToClis().balanced[0]).toBe('codex');
+    });
+    it('powerful tier leads with claude (strongest premium default)', () => {
+      expect(deriveTierToClis().powerful[0]).toBe('claude');
+    });
+    it('powerful pick is one of the frontier CLIs', () => {
+      expect(['claude', 'codex']).toContain(deriveTierToClis().powerful[0]);
+    });
+  });
+
+  describe('quality / cost ranks (resource-strategy)', () => {
+    it('ranks claude above gemini on quality', () => {
+      const q = deriveCliQualityRank();
+      expect(q.claude).toBeGreaterThan(q.gemini);
+    });
+    it('ranks gemini above claude on cost efficiency', () => {
+      const c = deriveCliCostRank();
+      expect(c.gemini).toBeGreaterThan(c.claude);
+    });
+    it('keeps the cheapest cost rank high enough for a critical boost (>1.875)', () => {
+      // critical boost = costRank * (8/3); the resource stage asserts >5.
+      expect(deriveCliCostRank().gemini).toBeGreaterThan(1.875);
+    });
+  });
+
+  describe('confidence profiles', () => {
+    it('gemini has the highest simpleScore (fastest)', () => {
+      const p = deriveCliConfidenceProfiles();
+      const best = (Object.keys(p) as CliNameLiteral[]).sort(
+        (a, b) => p[b].simpleScore - p[a].simpleScore
+      )[0];
+      expect(best).toBe('gemini');
+    });
+    it('claude has a top complexScore (strongest quality)', () => {
+      const p = deriveCliConfidenceProfiles();
+      const max = Math.max(...(Object.keys(p) as CliNameLiteral[]).map((c) => p[c].complexScore));
+      expect(p.claude.complexScore).toBeCloseTo(max);
+    });
+  });
+
+  describe('premium (strong) / budget (weak) partition', () => {
+    it('marks the most-expensive frontier default as the sole strong CLI', () => {
+      expect(deriveStrongClis()).toEqual(['claude']);
+    });
+    it('places the cheaper CLIs in the weak set', () => {
+      const weak = deriveWeakClis();
+      expect(weak).toContain('gemini');
+      expect(weak).toContain('codex');
+      expect(weak).not.toContain('claude');
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/derive-tier-tables.ts
+++ b/packages/nexus-agents/src/cli-adapters/derive-tier-tables.ts
@@ -1,0 +1,260 @@
+/**
+ * nexus-agents/cli-adapters - Registry-derived tier / strength / rank tables.
+ *
+ * SINGLE authoritative source for the per-CLI tier, quality-rank, cost-rank,
+ * confidence-profile and premium-partition tables that the routing chain used
+ * to hardcode in five separate places (#4195, epic #4175). Every table is
+ * DERIVED from each CLI's default model (`DEFAULT_MODEL_PER_CLI`) via its
+ * registry `qualityScores` + real registry `pricing` — no hand-maintained
+ * tier literals remain alongside these.
+ *
+ * BINDING fail-safe rules (vote-conditioned, #4195):
+ *  1. A CLI whose default model lacks `qualityScores` classifies CONSERVATIVE
+ *     (fast) and is EXCLUDED from the powerful tier / premium set — never
+ *     powerful. Missing data must not send hard traffic to an unvetted model.
+ *  2. Composes safely with `resolve-model-for-tier`: because rule 1 keeps
+ *     unscored CLIs out of the powerful tier, the powerful tier only ever names
+ *     CLIs whose default is scored, so the tier resolver never has to fall back
+ *     to a frontier default for an empty powerful pick.
+ *  3. A $0-priced default (a genuine `:free` model or a $0/$0 catalog artifact,
+ *     #4209) is treated as the MOST expensive in the cost rank — it can NEVER
+ *     win the cost rank and pull real traffic to it as "cheapest".
+ *  4. Every ordering is deterministic: value-keyed with stable, explicit
+ *     tie-breaks (never `qualityScores`-NaN-sorted, never Map/insertion order).
+ *
+ * Leaf-only imports (in-tree data + static fallback) mirror `buildTopsisProfiles`
+ * so this evaluates safely at module-load time without touching the
+ * filesystem-backed registry singleton (TDZ / circular-load safe).
+ *
+ * @module cli-adapters/derive-tier-tables
+ */
+import { buildInTreeEntries } from '../config/in-tree-entries.js';
+import { DEFAULT_MODEL_PER_CLI, STATIC_CLI_COST_PER_1M } from '../config/in-tree-data.js';
+import { CLI_NAMES, type CliNameLiteral } from '../config/model-capabilities-types.js';
+import type { ModelTier } from './zero-router-types.js';
+
+/** Canonical, deterministic CLI iteration order for stable tie-breaks. */
+const CLI_ORDER: readonly CliNameLiteral[] = CLI_NAMES;
+
+/** Per-CLI signal read from that CLI's default model. */
+export interface CliModelData {
+  /** Composite quality (reasoning+codeGeneration)/2, or undefined when the
+   * default model has no qualityScores (fail-safe: rule 1). */
+  readonly quality: number | undefined;
+  /** Blended real price (input+output per 1M). A $0 blend is normalized to
+   * {@link EXPENSIVE_SENTINEL} so it can never win the cost rank (rule 3). */
+  readonly price: number;
+  /** speed dimension (0-10), or undefined when unscored. */
+  readonly speed: number | undefined;
+}
+
+/** Sentinel blended price for a $0 default: ranks as the MOST expensive. */
+export const EXPENSIVE_SENTINEL = Number.MAX_SAFE_INTEGER;
+
+/** Quality-rank / cost-rank output scale: best → 3, worst → 1 (matches the
+ * legacy hand-tuned magnitude so downstream score boosts stay in range). */
+const RANK_MAX = 3;
+const RANK_MIN = 1;
+
+function compositeQuality(reasoning: number, codeGeneration: number): number {
+  return (reasoning + codeGeneration) / 2;
+}
+
+/**
+ * Rule 3 guard: a $0 (or negative) blended price is normalized to
+ * {@link EXPENSIVE_SENTINEL} so a genuine `:free` model or a $0/$0 catalog
+ * artifact (#4209) is treated as the MOST expensive and can never win the cost
+ * rank or the premium set.
+ */
+export function normalizeBlendedPrice(blended: number): number {
+  return blended > 0 ? blended : EXPENSIVE_SENTINEL;
+}
+
+/** Read the per-CLI signal for each CLI's default model from leaf in-tree data. */
+export function readCliModelData(): Record<CliNameLiteral, CliModelData> {
+  const byId = new Map(buildInTreeEntries().map((e) => [e.id, e] as const));
+  const out = {} as Record<CliNameLiteral, CliModelData>;
+  for (const cli of CLI_ORDER) {
+    const entry = byId.get(DEFAULT_MODEL_PER_CLI[cli]);
+    const q = entry?.qualityScores;
+    // Registry `Pricing` is {inputPer1M,outputPer1M}; the static fallback is
+    // CostPer1M {input,output}. Blend each in its own shape (mirrors
+    // buildTopsisProfiles) — an UNPRICED default stays conservative (#4168).
+    const pricing = entry?.pricing;
+    const blended =
+      pricing !== undefined
+        ? pricing.inputPer1M + pricing.outputPer1M
+        : STATIC_CLI_COST_PER_1M[cli].input + STATIC_CLI_COST_PER_1M[cli].output;
+    out[cli] = {
+      quality: q !== undefined ? compositeQuality(q.reasoning, q.codeGeneration) : undefined,
+      price: normalizeBlendedPrice(blended),
+      speed: q?.speed,
+    };
+  }
+  return out;
+}
+
+/** Linear-map a value in [min,max] onto [RANK_MIN,RANK_MAX]. Flat cohort → MAX. */
+function scaleRank(value: number, min: number, max: number, invert: boolean): number {
+  if (max === min) return RANK_MAX;
+  const t = (value - min) / (max - min);
+  const norm = invert ? 1 - t : t;
+  return RANK_MIN + norm * (RANK_MAX - RANK_MIN);
+}
+
+/**
+ * Quality rank per CLI (higher = stronger). Unscored CLIs (rule 1) get 0 —
+ * strictly below every scored CLI — so they are never quality-boosted.
+ */
+export function buildQualityRank(
+  data: Record<CliNameLiteral, CliModelData>
+): Record<CliNameLiteral, number> {
+  const scored = CLI_ORDER.map((c) => data[c].quality).filter((q): q is number => q !== undefined);
+  const min = scored.length > 0 ? Math.min(...scored) : 0;
+  const max = scored.length > 0 ? Math.max(...scored) : 0;
+  const out = {} as Record<CliNameLiteral, number>;
+  for (const cli of CLI_ORDER) {
+    const q = data[cli].quality;
+    out[cli] = q === undefined ? 0 : scaleRank(q, min, max, false);
+  }
+  return out;
+}
+
+/**
+ * Cost-efficiency rank per CLI (higher = cheaper). Uses real registry pricing;
+ * a $0 default is normalized to most-expensive upstream, so it ranks LOWEST
+ * (rule 3) and can never look "cheapest-and-best".
+ */
+export function buildCostRank(
+  data: Record<CliNameLiteral, CliModelData>
+): Record<CliNameLiteral, number> {
+  const prices = CLI_ORDER.map((c) => data[c].price);
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const out = {} as Record<CliNameLiteral, number>;
+  for (const cli of CLI_ORDER) {
+    // invert: cheaper (lower price) → higher rank.
+    out[cli] = scaleRank(data[cli].price, min, max, true);
+  }
+  return out;
+}
+
+/** Best-first comparator factory with an explicit, deterministic tie-break. */
+function byDescThen(
+  primary: (c: CliNameLiteral) => number,
+  secondary: (c: CliNameLiteral) => number
+): (a: CliNameLiteral, b: CliNameLiteral) => number {
+  return (a, b) => {
+    const p = primary(b) - primary(a);
+    if (p !== 0) return p;
+    const s = secondary(b) - secondary(a);
+    if (s !== 0) return s;
+    return CLI_ORDER.indexOf(a) - CLI_ORDER.indexOf(b);
+  };
+}
+
+/**
+ * Ordered CLI preference list per tier (deterministic).
+ *  - powerful: strongest quality first (tie-break: pricier/premium first);
+ *    EXCLUDES unscored CLIs entirely (rule 1 + rule 2 composition).
+ *  - fast: fastest first (tie-break: cheaper first).
+ *  - balanced: best quality/cost blend first.
+ */
+export function buildTierToClis(
+  data: Record<CliNameLiteral, CliModelData>
+): Record<ModelTier, CliNameLiteral[]> {
+  const quality = buildQualityRank(data);
+  const cost = buildCostRank(data);
+  const speed = (c: CliNameLiteral): number => data[c].speed ?? 0;
+  const powerful = CLI_ORDER.filter((c) => data[c].quality !== undefined).sort(
+    byDescThen(
+      (c) => quality[c],
+      (c) => data[c].price
+    )
+  );
+  const fast = [...CLI_ORDER].sort(byDescThen(speed, (c) => cost[c]));
+  const balanced = [...CLI_ORDER].sort(
+    byDescThen(
+      (c) => (quality[c] + cost[c]) / 2,
+      (c) => cost[c]
+    )
+  );
+  return { powerful, balanced, fast };
+}
+
+/**
+ * Confidence profile per CLI. `complexScore` tracks quality (hard tasks want the
+ * strongest model); `simpleScore` tracks speed (easy tasks want the fastest).
+ * Both are 0-1. An unscored default gets the conservative floor 0 on quality.
+ */
+export function buildConfidenceProfiles(
+  data: Record<CliNameLiteral, CliModelData>
+): Record<CliNameLiteral, { simpleScore: number; complexScore: number }> {
+  const out = {} as Record<CliNameLiteral, { simpleScore: number; complexScore: number }>;
+  for (const cli of CLI_ORDER) {
+    const datum = data[cli];
+    out[cli] = {
+      simpleScore: (datum.speed ?? 0) / 10,
+      complexScore: (datum.quality ?? 0) / 10,
+    };
+  }
+  return out;
+}
+
+/**
+ * Premium ("strong") CLI set for preference routing: the most expensive
+ * default(s) — the deliberate premium tier — among CLIs that HAVE qualityScores
+ * (rule 1: an unscored / $0 default can never be premium). Deterministic: the
+ * exact max real price. Everything else is "weak" (budget).
+ */
+export function buildPremiumClis(data: Record<CliNameLiteral, CliModelData>): CliNameLiteral[] {
+  const eligible = CLI_ORDER.filter(
+    (c) => data[c].quality !== undefined && data[c].price !== EXPENSIVE_SENTINEL
+  );
+  if (eligible.length === 0) return [];
+  const maxPrice = Math.max(...eligible.map((c) => data[c].price));
+  return eligible.filter((c) => data[c].price === maxPrice);
+}
+
+// ---------------------------------------------------------------------------
+// Memoized public derivers (no-arg) — what the five routing consumers import.
+// ---------------------------------------------------------------------------
+
+let cachedData: Record<CliNameLiteral, CliModelData> | undefined;
+function data(): Record<CliNameLiteral, CliModelData> {
+  return (cachedData ??= readCliModelData());
+}
+
+/** @see buildQualityRank */
+export function deriveCliQualityRank(): Record<CliNameLiteral, number> {
+  return buildQualityRank(data());
+}
+
+/** @see buildCostRank */
+export function deriveCliCostRank(): Record<CliNameLiteral, number> {
+  return buildCostRank(data());
+}
+
+/** @see buildTierToClis */
+export function deriveTierToClis(): Record<ModelTier, CliNameLiteral[]> {
+  return buildTierToClis(data());
+}
+
+/** @see buildConfidenceProfiles */
+export function deriveCliConfidenceProfiles(): Record<
+  CliNameLiteral,
+  { simpleScore: number; complexScore: number }
+> {
+  return buildConfidenceProfiles(data());
+}
+
+/** Premium ("strong") CLIs for preference routing. @see buildPremiumClis */
+export function deriveStrongClis(): CliNameLiteral[] {
+  return buildPremiumClis(data());
+}
+
+/** Budget ("weak") CLIs = everything not premium. */
+export function deriveWeakClis(): CliNameLiteral[] {
+  const strong = new Set(deriveStrongClis());
+  return CLI_ORDER.filter((c) => !strong.has(c));
+}

--- a/packages/nexus-agents/src/cli-adapters/router-scoring.ts
+++ b/packages/nexus-agents/src/cli-adapters/router-scoring.ts
@@ -16,6 +16,17 @@ type TaskType = TaskTypeCategory;
 /**
  * Capability matching matrix from Issue #78.
  * Maps task types to CLI preferences (0-1 scale).
+ *
+ * NOTE (#4195 assessment): this is a per-TASK-TYPE AFFINITY matrix (e.g. gemini
+ * leads `architecture`/`large_codebase` for its context window; codex leads
+ * `code_implementation`), which is an ORTHOGONAL axis to the quality/cost TIER
+ * consolidation and is NOT recoverable from `qualityScores` — the frontier
+ * defaults share near-identical reasoning/codeGen scores, so quality-deriving
+ * this table would collapse the domain distinctions and regress routing. The
+ * per-CLI capability INPUTS the `score*` functions consume (reasoning,
+ * codeGeneration, speed, cost) are ALREADY registry-derived via
+ * `buildCliCapabilityProfiles` (config/model-config-helpers.ts). This matrix is
+ * therefore intentionally retained as authored task-affinity data.
  */
 export const CAPABILITY_MATRIX: Record<TaskType, Record<CliName, number>> = {
   architecture: { claude: 0.7, gemini: 1.0, codex: 0.5, opencode: 0.6 },

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.ts
@@ -25,20 +25,20 @@ import {
   COMPLEX_TASK_INDICATORS,
   SIMPLE_TASK_INDICATORS,
 } from '../../confidence-router-types.js';
+import { deriveCliConfidenceProfiles } from '../../derive-tier-tables.js';
 
 // ============================================================================
 // Configuration
 // ============================================================================
 
 /**
- * Confidence profile for each CLI based on typical performance.
+ * Confidence profile for each CLI, DERIVED from its default-model
+ * `qualityScores` (#4195): `complexScore` tracks composite quality (hard tasks
+ * escalate to the strongest model), `simpleScore` tracks speed (easy tasks take
+ * the fastest). No longer a hand-tuned literal.
  */
-const CLI_CONFIDENCE_PROFILES: Record<CliName, { simpleScore: number; complexScore: number }> = {
-  claude: { simpleScore: 0.7, complexScore: 1.0 }, // Best for complex reasoning
-  gemini: { simpleScore: 1.0, complexScore: 0.6 }, // Fast for simple tasks
-  codex: { simpleScore: 0.8, complexScore: 0.9 }, // Good for code tasks
-  opencode: { simpleScore: 0.8, complexScore: 0.7 }, // Multi-provider proxy
-};
+const CLI_CONFIDENCE_PROFILES: Record<CliName, { simpleScore: number; complexScore: number }> =
+  deriveCliConfidenceProfiles();
 
 /**
  * Configuration for the confidence cascade stage.

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/resource-strategy-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/resource-strategy-stage.ts
@@ -22,6 +22,7 @@ import type {
   CliName,
 } from '../router-stage.js';
 import { addTrace, updateScore, getRemainingCandidates } from '../router-stage.js';
+import { deriveCliQualityRank, deriveCliCostRank } from '../../derive-tier-tables.js';
 
 /**
  * Resource strategy tier determining routing behavior.
@@ -56,24 +57,18 @@ const DEFAULT_CONFIG: ResourceStrategyConfig = {
 };
 
 /**
- * Quality ranking per CLI (higher = better quality, higher cost).
+ * Quality ranking per CLI (higher = better quality). DERIVED from each CLI's
+ * default-model composite `qualityScores` (#4195); an unscored default ranks 0
+ * (never quality-boosted). No longer a hand-tuned literal.
  */
-const CLI_QUALITY_RANK: Record<CliName, number> = {
-  claude: 3,
-  codex: 2,
-  opencode: 1.5,
-  gemini: 1,
-};
+const CLI_QUALITY_RANK: Record<CliName, number> = deriveCliQualityRank();
 
 /**
- * Cost efficiency ranking per CLI (higher = cheaper).
+ * Cost-efficiency ranking per CLI (higher = cheaper). DERIVED from each CLI's
+ * default-model real registry pricing (#4195); a $0/$0 default is treated as
+ * most-expensive so it can never rank "cheapest" and pull budget traffic.
  */
-const CLI_COST_RANK: Record<CliName, number> = {
-  gemini: 3,
-  codex: 2,
-  opencode: 2,
-  claude: 1,
-};
+const CLI_COST_RANK: Record<CliName, number> = deriveCliCostRank();
 
 /**
  * Computes the current resource tier from a utilization level.

--- a/packages/nexus-agents/src/cli-adapters/zero-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/zero-router-types.ts
@@ -11,6 +11,7 @@
 
 import { z } from 'zod';
 import type { CliName } from './types-core.js';
+import { deriveTierToClis } from './derive-tier-tables.js';
 
 /**
  * Difficulty dimensions for task analysis.
@@ -95,12 +96,15 @@ export const DEFAULT_DIFFICULTY_TO_TIER: Record<DifficultyLevel, ModelTier> = {
 
 /**
  * Mapping from model tier to CLI preference order.
+ *
+ * DERIVED from each CLI's default-model `qualityScores` + real registry pricing
+ * (#4195) — no longer a hand-maintained literal. `powerful` leads with the
+ * strongest premium default and EXCLUDES any CLI whose default lacks
+ * qualityScores (fail-safe: an unvetted model never fronts the powerful tier);
+ * `fast` leads with the fastest/cheapest; `balanced` with the best quality/cost
+ * blend. Ordering is deterministic (stable, explicit tie-breaks).
  */
-export const DEFAULT_TIER_TO_CLIS: Record<ModelTier, CliName[]> = {
-  fast: ['gemini', 'codex', 'opencode', 'claude'],
-  balanced: ['codex', 'opencode', 'gemini', 'claude'],
-  powerful: ['claude', 'codex', 'opencode', 'gemini'],
-};
+export const DEFAULT_TIER_TO_CLIS: Record<ModelTier, CliName[]> = deriveTierToClis();
 
 /**
  * Weight configuration for difficulty aggregation.


### PR DESCRIPTION
Closes #4195. Closes the **last buildable child of epic #4175** (tier-routing).

## What
Replaces the hardcoded tier / strength / rank tables that were duplicated across the canonical routing chain with a single authoritative, registry-derived helper: **`packages/nexus-agents/src/cli-adapters/derive-tier-tables.ts`**. Every table is derived from each CLI's default model (`DEFAULT_MODEL_PER_CLI`) → registry `qualityScores` + real registry `pricing` (post-#4168 / #4176). No hardcoded tier literal remains alongside a derived one.

### Consumers wired to the shared helper
| Target | Was | Now |
|---|---|---|
| `zero-router-types.DEFAULT_TIER_TO_CLIS` | literal | `deriveTierToClis()` |
| `confidence-cascade-stage.CLI_CONFIDENCE_PROFILES` | literal | `deriveCliConfidenceProfiles()` |
| `composite-router-helpers.filterByPreferenceTier` strong/weak | `['claude']` / `['gemini','codex']` | `deriveStrongClis()` / `deriveWeakClis()` |
| `composite-router-helpers.filterByDifficultyTier` (parallel tier literal) | literal | `deriveTierToClis()` |
| `resource-strategy-stage.CLI_QUALITY_RANK` / `CLI_COST_RANK` | literals | `deriveCliQualityRank()` / `deriveCliCostRank()` |

Ranks/orderings reproduce every previously-pinned selection, so the derivation dropped in with **no fixture changes**.

## Binding vote conditions (each unit-pinned in `derive-tier-tables.test.ts`)
1. **No `qualityScores` → conservative, never powerful.** `buildTierToClis` excludes unscored CLIs from `powerful`; `buildPremiumClis` excludes them from the strong set. Tests: *"excludes an unscored CLI from the powerful tier"*, *"never lets an unscored CLI head the powerful tier"*, *"excludes an unscored CLI from the premium set"*.
2. **Empty powerful tier never up-costs.** Because (1) keeps unscored CLIs out of `powerful`, the powerful tier only names scored CLIs, so `resolve-model-for-tier` never falls back to a frontier default for an empty pick; a degenerate all-unscored cohort yields an *empty* powerful tier (never a synthesised frontier model). Test: *"yields an EMPTY powerful tier when no CLI is scored"*.
3. **$0/$0 artifact can't win the cost rank** (#4209). `normalizeBlendedPrice` maps a $0/negative blend to a most-expensive sentinel. Tests: *"normalises a $0 … to the most-expensive sentinel"*, *"ranks a $0-priced default LOWEST on cost"*, *"keeps a $0 default out of the premium set"*.
4. **Deterministic ordering.** Value-keyed comparators with explicit stable tie-breaks (quality ties break by premium price, final tie-break on canonical CLI order). Tests: *"is byte-stable across repeated derivations"*, *"breaks quality ties by premium price"*.

## router-scoring `CAPABILITY_MATRIX` — assessed, intentionally retained
It is a per-task-type **affinity** matrix (e.g. gemini leads `architecture`/`large_codebase` for context window; codex leads `code_implementation`), an axis orthogonal to the quality/cost tier consolidation and **not recoverable from `qualityScores`** (the frontier defaults share near-identical scores — deriving it would collapse the domain distinctions and regress routing). Its per-CLI capability *inputs* consumed by the `score*` functions are already registry-derived via `buildCliCapabilityProfiles`. A code comment documents this.

## Safety / composition notes
- Helper uses **leaf-only imports** (in-tree data + static fallback), mirroring `buildTopsisProfiles`, so it evaluates at module-load time without touching the filesystem-backed registry singleton (TDZ / circular-load safe). `ModelTier` is a type-only import to avoid a runtime cycle with `zero-router-types`.
- Regression pin holds: fast→`gemini`, balanced→`codex`, powerful→`claude`; strong=`['claude']`. `gemini-flash` never becomes the powerful pick.

## Gates
- `pnpm test` (full): **1144 files passed, 1 skipped, 0 failed** (27458 tests) — no fixture cascade.
- `turbo typecheck`: pass.
- `eslint` on the 7 changed files: clean (complexity ≤10, ≤50 lines/fn).
- `check-new-unused-exports.ts origin/main`: pass (new helper has real src consumers).
- Changeset: **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)