### PR TITLE
fix(ci): pass PR_BASE_SHA to governor-review gate so diff-binding runs

### DIFF
--- a/.changeset/governor-review-base-sha.md
+++ b/.changeset/governor-review-base-sha.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the governor-review CI gate: pass `PR_BASE_SHA` to the gate step so the Option-C diff-binding (`git diff base..head`) actually runs (#4227). Without it the gate's core diff-match was inert — it could never match a pr_review record regardless of ledger contents. No package code change (workflow only).

--- a/.github/workflows/governor-review.yml
+++ b/.github/workflows/governor-review.yml
@@ -68,9 +68,12 @@ jobs:
 
       - name: Run governor-review gate (warn-first; integrity fail-closed)
         env:
-          # The gate gets the PR number + head sha from CI here — sha-binding
-          # (condition 1) rests on github.event.pull_request.head.sha.
+          # The gate needs BOTH base and head sha: sha-binding (condition 1) AND
+          # the Option-C diff-binding recompute `git diff base..head` (#3831).
+          # Without PR_BASE_SHA, resolvePrContext.baseSha is undefined and the
+          # diff-binding never runs, so the gate cannot match any record (#4227).
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         # No continue-on-error: the script encodes warn (exit 0) vs fail-closed


### PR DESCRIPTION
Child A / prerequisite of #4226 (feed the pr-review ledger). Discovered during that investigation.

`governor-review.yml`'s gate step passed only `PR_NUMBER` + `PR_HEAD_SHA`; the `BASE_SHA` env (line 59) was scoped to the earlier 'Compute changed files' step, not the gate step. So `resolvePrContext.baseSha` (check-governor-review.ts:329) resolved to `undefined`, `recomputeReviewedDiffHash(baseSha, headSha)` couldn't compute the base..head diff, and the Option-C diff-binding — the core of the #3831 governor-review gate — **never ran**. The gate fell to WARN/'cannot verify' regardless of what's in the ledger, so even a fully-populated ledger could never satisfy it.

One-line fix: add `PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}` to the gate step env. The gate correctly stays WARN while the ledger is empty; this makes the diff-binding path live so it can match records once #4226 children B/C feed it.

Closes #4227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)