### PR TITLE
feat(cli): did-you-mean suggestions + tracking hint for unknown commands (#3207)

### DIFF
--- a/.changeset/cli-did-you-mean-3207.md
+++ b/.changeset/cli-did-you-mean-3207.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+feat(cli): did-you-mean suggestions + tracking hint for unknown commands (#3207)
+
+`handleUnimplementedCommand` now, for a recognized-but-unbuilt subcommand,
+surfaces the closest _implemented_ sibling by edit distance (reusing the
+Levenshtein-backed `suggestCommand` matcher from #3211 — e.g. `workflow lst`
+→ `Did you mean: workflow list?`) and points the user at the repo issue
+tracker to file or upvote the missing command. Near-miss-only: an unbuilt
+command with no close sibling (e.g. `expert create`) stays silent rather than
+guessing.

--- a/packages/nexus-agents/src/cli-commands-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.test.ts
@@ -5,7 +5,7 @@
  * (Source: Issue #378)
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import type { ParsedCliArgs } from './cli-types.js';
 import type { ServerMode } from './cli/index.js';
 
@@ -37,6 +37,7 @@ import {
   handleConfigCommand,
   handleExpertCommand,
   handleHelloCommand,
+  handleUnimplementedCommand,
 } from './cli-commands-handlers.js';
 import { configCommand, configInitCommand, expertListCommand, helloCommand } from './cli/index.js';
 
@@ -418,5 +419,60 @@ describe('CliExitResult return contract (#3210)', () => {
         exitCode: 1,
       });
     });
+  });
+});
+
+// #3207: did-you-mean suggestions + tracking-issue link for unimplemented
+// (recognized-but-not-built) CLI subcommands. Writes to stderr; we spy on it
+// directly since the module-level process stub only mocks stdout.
+describe('handleUnimplementedCommand (#3207)', () => {
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  function stderrOutput(): string {
+    return stderrSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('');
+  }
+
+  it('always reports the command is not implemented and points at the tracker', () => {
+    handleUnimplementedCommand('workflow bogus');
+    const out = stderrOutput();
+    expect(out).toContain("The 'workflow bogus' CLI subcommand is not yet implemented.");
+    expect(out).toContain('https://github.com/nexus-substrate/nexus-agents/issues');
+  });
+
+  it('suggests the closest implemented subcommand for a near-miss typo', () => {
+    // `lst` is one edit from `list` (an implemented workflow subcommand).
+    handleUnimplementedCommand('workflow lst');
+    expect(stderrOutput()).toContain('Did you mean: workflow list?');
+  });
+
+  it('suggests a workflow run typo', () => {
+    // `runn` is one edit from `run`; short 2-char inputs are intentionally
+    // below the suggester's relative-distance floor, so use a 4-char near-miss.
+    handleUnimplementedCommand('workflow runn');
+    expect(stderrOutput()).toContain('Did you mean: workflow run?');
+  });
+
+  it('does not emit a bogus suggestion when no implemented subcommand is close', () => {
+    // `create` is far from the only implemented expert subcommand (`list`).
+    handleUnimplementedCommand('expert create');
+    expect(stderrOutput()).not.toContain('Did you mean');
+  });
+
+  it('still names the equivalent MCP tool when one exists', () => {
+    handleUnimplementedCommand('expert create');
+    expect(stderrOutput()).toContain('create_expert');
+  });
+
+  it('does not suggest when the subcommand is empty', () => {
+    handleUnimplementedCommand('expert ');
+    expect(stderrOutput()).not.toContain('Did you mean');
   });
 });

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -75,6 +75,7 @@ import {
   printResearchUsage,
 } from './cli-commands-usage.js';
 import { getErrorMessage } from './core/index.js';
+import { suggestCommand } from './cli-command-suggester.js';
 
 // Re-export complex handlers for backward compatibility
 export {
@@ -102,6 +103,46 @@ const MCP_EQUIVALENTS: Record<string, string> = {
   'expert execute': 'execute_expert',
 };
 
+/**
+ * Implemented subcommands per top-level command, keyed by top-level name. Used
+ * only to power the "Did you mean?" hint: a mistyped subcommand
+ * (`workflow lst`) resolves to the closest *built* one (`workflow list`), while
+ * a recognized-but-unbuilt subcommand (`expert create`) has no close match and
+ * stays silent rather than guessing. Keep in sync with the dispatch switches in
+ * `handleExpertCommand` / `handleWorkflowCommand` below.
+ */
+const IMPLEMENTED_SUBCOMMANDS: Record<string, readonly string[]> = {
+  expert: ['list'],
+  workflow: ['list', 'run'],
+};
+
+/**
+ * The repo's own issue tracker — where a user can file or upvote a
+ * recognized-but-unbuilt command. Deliberately generic (no per-command issue
+ * mapping to drift): the tracker is the single durable pointer.
+ */
+const TRACKING_ISSUES_URL = 'https://github.com/nexus-substrate/nexus-agents/issues';
+
+/**
+ * Emits a `Did you mean: <top> <sub>?` line to stderr when the unimplemented
+ * `command` (`"<top> <sub>"`) has a mistyped subcommand within edit-distance of
+ * an implemented sibling. Reuses the Levenshtein-backed `suggestCommand` matcher
+ * (#3211) so the threshold/ranking matches the top-level unknown-command path.
+ * No-op when the top-level command has no implemented-subcommand table, the
+ * subcommand is empty, or nothing is close (avoids bogus suggestions).
+ */
+function writeSubcommandSuggestion(command: string): void {
+  const [topLevel, ...subParts] = command.split(' ');
+  const subcommand = subParts.join(' ');
+  if (topLevel === undefined || subcommand.length === 0) return;
+  const validSubcommands = IMPLEMENTED_SUBCOMMANDS[topLevel];
+  if (validSubcommands === undefined) return;
+  const suggestions = suggestCommand(subcommand, validSubcommands);
+  if (suggestions.length === 0) return;
+  const rendered = suggestions.map((sub) => `${topLevel} ${sub}`).join(', ');
+  process.stderr.write(`Did you mean: ${rendered}?\n`);
+}
+
 export function handleUnimplementedCommand(command: string): void {
   const equiv = MCP_EQUIVALENTS[command];
   process.stderr.write(`The '${command}' CLI subcommand is not yet implemented.\n`);
@@ -110,6 +151,10 @@ export function handleUnimplementedCommand(command: string): void {
       `Equivalent today: run \`nexus-agents --mode=server\` and call the \`${equiv}\` MCP tool.\n`
     );
   }
+  writeSubcommandSuggestion(command);
+  // #3207: point users at the tracker so a wanted-but-unbuilt command gets
+  // filed/upvoted instead of silently dropped.
+  process.stderr.write(`Track or request this command: ${TRACKING_ISSUES_URL}\n`);
   process.stderr.write('Run "nexus-agents --help" for available options.\n');
 }
 


### PR DESCRIPTION
## Summary

Completes issue #3207 by extending `handleUnimplementedCommand` (the handler that fires for a recognized-but-not-yet-built CLI subcommand, e.g. `expert create`, `workflow <x>`). The MCP-equivalent hint (item 1) already shipped in #2727; this PR adds the two residual items:

1. **Did-you-mean suggestion.** When the mistyped subcommand is within edit distance of an *implemented* sibling, we surface it — e.g. `nexus-agents workflow lst` prints `Did you mean: workflow list?`. This reuses the existing Levenshtein-backed `suggestCommand` matcher from `cli-command-suggester.ts` (#3211), so the absolute/relative distance thresholds and ranking match the top-level unknown-command path — no second distance function. Near-miss-only: an unbuilt subcommand with no close sibling (`expert create` vs the only implemented `list`) stays silent rather than guessing.
2. **Tracking-issue link.** Every unimplemented-command notice now points at the repo's own issue tracker (`.../issues`) so a wanted-but-unbuilt command gets filed/upvoted instead of silently dropped. Deliberately generic — no per-command URL mapping to drift.

## Valid-command set sourcing

The implemented-subcommand set is a small local table (`IMPLEMENTED_SUBCOMMANDS`: `expert → [list]`, `workflow → [list, run]`) co-located with, and documented to stay in sync with, the dispatch switches in `handleExpertCommand` / `handleWorkflowCommand` that decide which subcommands actually route vs. fall through to `handleUnimplementedCommand`. It mirrors the existing local-const style of the adjacent `MCP_EQUIVALENTS`. (The top-level command *names* already come from `COMMAND_CATALOG` via `catalogCommandNames()`; that path is unchanged.)

## Tests (TDD)

Added a `handleUnimplementedCommand (#3207)` block to `cli-commands-handlers.test.ts`:
- unrecognized subcommand near a valid one → suggests it (`workflow lst` → `workflow list`, `workflow runn` → `workflow run`)
- unrecognized subcommand with no close match (`expert create`) → no bogus suggestion
- unimplemented command → tracking-issue link present; MCP-equivalent still named
- empty subcommand → no suggestion

## Gates

- `pnpm test` (full): 27,464 passed / 16 skipped, 1144 files
- `pnpm typecheck`: clean
- `npx eslint` on the two changed files: clean
- Patch changeset added
- No repo-index drift (still 52 CLI commands / 46 MCP tools — no command added); `docs:tools:check` clean

Closes #3207

🤖 Generated with [Claude Code](https://claude.com/claude-code)