### PR TITLE
feat(audit): feed ledger from pr-review-local; exclude ledger from reviewed-diff (#4229)

### DIFF
--- a/.changeset/feed-ledger-exclude-reviewed-diff-4229.md
+++ b/.changeset/feed-ledger-exclude-reviewed-diff-4229.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+feat(audit): feed the pr-review ledger from pr-review-local; exclude the ledger from the reviewed-diff hash (#4229)
+
+Two changes behind the #3831 Option-C governor-review gate (epic #4226, child B):
+
+- **Reviewed-diff primitive (security-sensitive).** `canonicalGitDiffArgs` now
+  appends `-- :(exclude)governance/pr-review-records.jsonl`, excluding the
+  append-only pr-review ledger from the canonical reviewed diff. This makes
+  committing a pr_review record to the PR head safe: previously, committing the
+  record advanced head, changed `git diff base..head`, and self-invalidated the
+  record's stored `reviewedDiffHash`. The same `canonicalGitDiffArgs` is used by
+  both the producer and the gate recompute, so the exclusion applies identically
+  by construction. ONLY the exact ledger path is excluded (not a glob/dir), the
+  ledger's integrity is still fully checked by `verifyPrReviewRecordSet`, and a PR
+  that edits the ledger still cannot smuggle non-ledger code changes past review.
+
+- **Feeder.** `scripts/pr-review-local.ts` now fetches the PR base+head SHAs,
+  generates the reviewed diff canonically (byte-identical to the gate recompute,
+  ledger-excluded), and after the live 5-voter panel calls `persistReviewRecord`
+  so the run's authentic verdict lands in the governance ledger the gate queries.

--- a/packages/nexus-agents/src/audit/reviewed-diff-hash.test.ts
+++ b/packages/nexus-agents/src/audit/reviewed-diff-hash.test.ts
@@ -20,8 +20,10 @@ import {
   computeReviewedDiffHash,
   reviewedDiffWasTruncated,
   canonicalGitDiffArgs,
+  LEDGER_EXCLUDE_PATHSPEC,
   MAX_REVIEWED_DIFF_BYTES,
 } from './reviewed-diff-hash.js';
+import { PR_REVIEW_RECORDS_REL_PATH } from './pr-review-record-store.js';
 
 describe('computeReviewedDiffHash', () => {
   it('is deterministic for the same bytes', () => {
@@ -115,5 +117,140 @@ describe('canonical git diff is config-invariant (panel condition A — cross-en
     // "Gate side": recompute from raw SHAs in CI via the same canonical invocation.
     const gateHash = computeReviewedDiffHash(git(canonicalGitDiffArgs(base, head)));
     expect(producerHash).toBe(gateHash);
+  });
+});
+
+describe('canonicalGitDiffArgs ledger-exclusion argv (#4229)', () => {
+  it('appends the exclude pathspec AFTER the range, separated by `--`', () => {
+    const args = canonicalGitDiffArgs('BASE', 'HEAD');
+    // The last three argv elements are the range, the `--` separator, then the
+    // single exclude pathspec — no earlier reordering of the pinned config flags.
+    expect(args.slice(-3)).toEqual(['BASE..HEAD', '--', LEDGER_EXCLUDE_PATHSPEC]);
+  });
+
+  it('excludes ONLY the exact ledger path via git pathspec magic (no glob, no dir)', () => {
+    // Pin the exact pathspec so a future edit cannot silently widen it to a glob
+    // or a directory (which could hide reviewable code from the canonical diff).
+    expect(LEDGER_EXCLUDE_PATHSPEC).toBe(':(exclude)governance/pr-review-records.jsonl');
+  });
+
+  it('targets exactly the store ledger path (drift guard against the canonical const)', () => {
+    // The excluded path MUST be the same literal the store appends records to;
+    // if the store path ever moves, this test fails so the exclusion follows it.
+    expect(LEDGER_EXCLUDE_PATHSPEC).toBe(`:(exclude)${PR_REVIEW_RECORDS_REL_PATH}`);
+  });
+});
+
+describe('ledger exclusion is authenticity-safe (#4229 — real git)', () => {
+  let repo: string;
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, {
+      cwd: repo,
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  }
+
+  function commitAll(msg: string): string {
+    git(['add', '-A']);
+    git(['commit', '-q', '-m', msg]);
+    return git(['rev-parse', 'HEAD']).trim();
+  }
+
+  const LEDGER = 'governance/pr-review-records.jsonl';
+
+  let baseSha: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'reviewed-diff-exclude-'));
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    // Base tree: a reviewable code file + an existing ledger + similarly-named
+    // decoys that MUST NOT be swept up by the exclusion.
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 1;\n');
+    execFileSync('mkdir', ['-p', join(repo, 'governance')]);
+    writeFileSync(join(repo, LEDGER), '{"seq":0}\n');
+    writeFileSync(join(repo, 'governance/other.jsonl'), 'other-a\n');
+    writeFileSync(join(repo, `${LEDGER}.bak`), 'bak-a\n');
+    baseSha = commitAll('base');
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('exclusion works: committing a record to head does NOT change the canonical hash (self-invalidation fix)', () => {
+    // Head A — only the code file changes (the diff a record's producer hashed).
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 2;\n');
+    const headCodeOnly = commitAll('code only');
+    const hashCodeOnly = computeReviewedDiffHash(git(canonicalGitDiffArgs(baseSha, headCodeOnly)));
+
+    // Head B — the SAME code change PLUS an appended ledger record (committing the
+    // pr_review record to the PR head, which is what would otherwise advance head
+    // and self-invalidate the record). Branch fresh from base so only these two
+    // files differ.
+    git(['checkout', '-q', baseSha]);
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 2;\n');
+    writeFileSync(join(repo, LEDGER), '{"seq":0}\n{"seq":1,"prNumber":4229}\n');
+    const headCodeAndLedger = commitAll('code + ledger record');
+    const hashCodeAndLedger = computeReviewedDiffHash(
+      git(canonicalGitDiffArgs(baseSha, headCodeAndLedger))
+    );
+
+    // The ledger append is invisible to the canonical reviewed diff → same hash.
+    expect(hashCodeAndLedger).toBe(hashCodeOnly);
+  });
+
+  it('a code-only diff is unaffected by the exclusion (the code change is still reviewed)', () => {
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 99;\n');
+    const head = commitAll('code only');
+    const diff = git(canonicalGitDiffArgs(baseSha, head));
+    // The code change is present in the canonical diff (exclusion drops only the ledger).
+    expect(diff).toContain('code.ts');
+    expect(diff).toContain('export const x = 99;');
+    // ...and it differs from the no-op base→base hash (the change is bound).
+    const noopHash = computeReviewedDiffHash(git(canonicalGitDiffArgs(baseSha, baseSha)));
+    expect(computeReviewedDiffHash(diff)).not.toBe(noopHash);
+  });
+
+  it('does NOT drop similarly-named files (governance/other.jsonl, ledger.bak)', () => {
+    // Change ONLY the decoys — a too-broad glob/dir exclusion would make this diff
+    // empty (and hash equal to a no-op), hiding real content from review.
+    writeFileSync(join(repo, 'governance/other.jsonl'), 'other-b\n');
+    writeFileSync(join(repo, `${LEDGER}.bak`), 'bak-b\n');
+    const head = commitAll('decoys');
+    const diff = git(canonicalGitDiffArgs(baseSha, head));
+    expect(diff).toContain('governance/other.jsonl');
+    expect(diff).toContain('governance/pr-review-records.jsonl.bak');
+    const noopHash = computeReviewedDiffHash(git(canonicalGitDiffArgs(baseSha, baseSha)));
+    expect(computeReviewedDiffHash(diff)).not.toBe(noopHash);
+  });
+
+  it('cannot smuggle non-ledger changes: a ledger+code diff still binds the code', () => {
+    // A hostile head that edits BOTH the ledger and a code file: the exclusion
+    // hides ONLY the ledger, never the code — so the hash still reflects the code
+    // change (identical to the code-only diff, and different from a pure no-op).
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 7;\n');
+    writeFileSync(join(repo, LEDGER), '{"seq":0}\n{"smuggle":true}\n');
+    const head = commitAll('ledger + code');
+    const excluded = git(canonicalGitDiffArgs(baseSha, head));
+    // Code IS in the excluded diff.
+    expect(excluded).toContain('export const x = 7;');
+    // The ledger line is NOT.
+    expect(excluded).not.toContain('smuggle');
+
+    // Same code change without the ledger edit → identical canonical hash.
+    git(['checkout', '-q', baseSha]);
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 7;\n');
+    const headCodeOnly = commitAll('code only');
+    expect(computeReviewedDiffHash(excluded)).toBe(
+      computeReviewedDiffHash(git(canonicalGitDiffArgs(baseSha, headCodeOnly)))
+    );
+    // ...and still different from a no-op (the code change is bound, not hidden).
+    expect(computeReviewedDiffHash(excluded)).not.toBe(
+      computeReviewedDiffHash(git(canonicalGitDiffArgs(baseSha, baseSha)))
+    );
   });
 });

--- a/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
+++ b/packages/nexus-agents/src/audit/reviewed-diff-hash.ts
@@ -53,7 +53,8 @@ export const MAX_REVIEWED_DIFF_BYTES = 50_000;
  *  - `--no-renames` — rename detection output is config/version-sensitive; off.
  *  - `-U3` — pin the context-line count (git default is 3, but it is configurable).
  *  - `<base>..<head>` — TWO-DOT range (base→head), NOT three-dot/merge-base.
- * Caller appends the `<base>..<head>` range as the final element.
+ * {@link canonicalGitDiffArgs} appends the range, then the `--` separator and the
+ * {@link LEDGER_EXCLUDE_PATHSPEC} exclude pathspec (see that constant for why).
  */
 export const CANONICAL_GIT_DIFF_ARGS: readonly string[] = Object.freeze([
   '-c',
@@ -71,9 +72,50 @@ export const CANONICAL_GIT_DIFF_ARGS: readonly string[] = Object.freeze([
   '-U3',
 ]);
 
-/** Build the full canonical `git` argv for a base..head range (two-dot). */
+/**
+ * Git pathspec (magic `:(exclude)` prefix) that removes the append-only pr-review
+ * ledger from the canonical reviewed diff (#4229). WHY it must be excluded from
+ * the authenticity primitive:
+ *
+ *   A pr_review record for PR N must be COMMITTED to PR N's head branch, because
+ *   the governor gate reads the ledger from the head checkout (`readFileSync`).
+ *   But committing the record advances head, so a naive `git diff base..head`
+ *   would then include the record line — changing the diff bytes and thus the
+ *   recomputed `reviewedDiffHash`, which no longer matches the hash stored IN that
+ *   record. The record would self-invalidate the moment it is committed. Excluding
+ *   the ledger from the canonical diff makes committing a record to head safe.
+ *
+ * The SAME {@link canonicalGitDiffArgs} is used by BOTH the producer (over the diff
+ * the voters reviewed) and the gate (`scripts/check-governor-review.ts` recompute),
+ * so the exclusion applies identically to both sides by construction — they cannot
+ * drift.
+ *
+ * SECURITY (pinned by tests in `reviewed-diff-hash.test.ts`):
+ *  - ONLY this EXACT path is excluded — the leading-space-free `:(exclude)` magic
+ *    matches one literal file, NOT a glob or directory, so it can never hide
+ *    reviewable code (e.g. `governance/other.jsonl` or `…records.jsonl.bak` stay
+ *    in the diff).
+ *  - The ledger's INTEGRITY is unaffected: it is still fully tamper-checked by
+ *    `verifyPrReviewRecordSet`. Excluding it from the *reviewed diff* does not
+ *    remove it from tamper-evidence.
+ *  - A PR that changes ledger content still cannot smuggle non-ledger changes: the
+ *    exclusion drops only the ledger file; every other changed path (code) remains
+ *    in the canonical diff and thus in the hash.
+ *
+ * The literal path is kept in sync with the store's `PR_REVIEW_RECORDS_REL_PATH`
+ * by a drift-guard test (this module stays dependency-minimal — only `node:crypto`
+ * — so it does not import the heavier store module here).
+ */
+export const LEDGER_EXCLUDE_PATHSPEC = ':(exclude)governance/pr-review-records.jsonl';
+
+/**
+ * Build the full canonical `git` argv for a base..head range (two-dot). The range
+ * is followed by `--` (revision/pathspec separator) and {@link LEDGER_EXCLUDE_PATHSPEC}
+ * so the append-only pr-review ledger is excluded from the reviewed diff (#4229) —
+ * committing a record to head then does not change the hash the record binds to.
+ */
 export function canonicalGitDiffArgs(baseSha: string, headSha: string): string[] {
-  return [...CANONICAL_GIT_DIFF_ARGS, `${baseSha}..${headSha}`];
+  return [...CANONICAL_GIT_DIFF_ARGS, `${baseSha}..${headSha}`, '--', LEDGER_EXCLUDE_PATHSPEC];
 }
 
 /**

--- a/scripts/pr-review-local-ledger.ts
+++ b/scripts/pr-review-local-ledger.ts
@@ -1,0 +1,314 @@
+/**
+ * pr-review-local ledger feeder (#4229, epic #4226 child B).
+ *
+ * Turns a completed local `pr_review` panel run into an authentic, diff-bound
+ * governance record so the warn-first governor-review gate (#3831) can MATCH the
+ * PR it is checking. Split out of `scripts/pr-review-local.ts` to keep the watcher
+ * lean and the feeder independently unit-testable.
+ *
+ * THE LOAD-BEARING INVARIANT: the record's `reviewedDiffHash` must equal what the
+ * gate recomputes for the same `base..head`. Guaranteed by hashing the SAME
+ * canonical, ledger-excluded diff — {@link generateCanonicalReviewDiff} runs the
+ * pinned {@link canonicalGitDiffArgs} (now `-- :(exclude)governance/pr-review-records.jsonl`)
+ * and {@link persistReviewRecord} hashes it with the shared
+ * `computeReviewedDiffHash`, byte-identical to `scripts/check-governor-review.ts`.
+ * Excluding the ledger is what makes committing the record to the PR head hash-safe.
+ *
+ * @module scripts/pr-review-local-ledger
+ */
+
+/* eslint-disable no-console -- CLI-adjacent helper that prints progress */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { canonicalGitDiffArgs } from '../packages/nexus-agents/src/audit/reviewed-diff-hash.js';
+import {
+  persistReviewRecord,
+  type PrReviewCounts,
+  type PrReviewRecordOutcome,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-record-producer.js';
+import {
+  MAX_DIFF_LENGTH,
+  type PrReviewAggregate,
+  type PrReviewInput,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-tool.js';
+import { createLogger, type ILogger } from '../packages/nexus-agents/src/core/index.js';
+import { ROOT } from './script-paths.js';
+
+const execFileP = promisify(execFile);
+
+const REPO_OWNER = 'nexus-substrate';
+const REPO_NAME = 'nexus-agents';
+
+/**
+ * Minimal injectable exec seam for the `gh`/`git` subprocess calls so the feeder is
+ * unit-testable without touching the network or a real PR. Matches the shape of
+ * `promisify(execFile)`; production passes the real one.
+ */
+export interface GhGitExec {
+  (
+    command: string,
+    args: readonly string[],
+    options?: { readonly maxBuffer?: number; readonly cwd?: string }
+  ): Promise<{ stdout: string; stderr: string }>;
+}
+
+/** PR metadata needed for both the review and the Option-C audit binding (#4229). */
+export interface PrMeta {
+  readonly title: string;
+  readonly body: string;
+  readonly baseRef: string;
+  readonly headRef: string;
+  /** 40-hex base commit SHA — the range base the gate recomputes the diff hash over. */
+  readonly baseSha: string;
+  /** 40-hex head commit SHA — the range head. */
+  readonly headSha: string;
+}
+
+/**
+ * Fetch PR metadata INCLUDING the base+head commit SHAs (#4229). The SHAs
+ * (`.base.sha`/`.head.sha`) — not just the ref names — are what the governor gate
+ * recomputes the reviewed-diff hash over, so a persisted record can only match if
+ * it is bound to these exact commits.
+ */
+export async function fetchPrMeta(prNumber: number, exec: GhGitExec = execFileP): Promise<PrMeta> {
+  const { stdout } = await exec('gh', [
+    'api',
+    `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
+    '--jq',
+    '{title, body, headRef: .head.ref, baseRef: .base.ref, baseSha: .base.sha, headSha: .head.sha}',
+  ]);
+  const m = JSON.parse(stdout) as {
+    title?: string;
+    body?: string;
+    headRef?: string;
+    baseRef?: string;
+    baseSha?: string;
+    headSha?: string;
+  };
+  return {
+    title: m.title ?? '',
+    body: m.body ?? '',
+    headRef: m.headRef ?? '',
+    baseRef: m.baseRef ?? '',
+    baseSha: m.baseSha ?? '',
+    headSha: m.headSha ?? '',
+  };
+}
+
+/**
+ * Fetch the PR diff via the GitHub API (`v3.diff`). FALLBACK path only: used to
+ * review a PR whose base/head commits are not fetchable locally (so the canonical
+ * git diff cannot be produced). A review from THIS diff is NOT hash-parity with the
+ * gate, so it does NOT feed the ledger — the record is written only from the
+ * canonical diff (see {@link generateCanonicalReviewDiff}).
+ */
+export async function fetchGhDiff(
+  prNumber: number,
+  exec: GhGitExec = execFileP
+): Promise<{ diff: string; truncated: boolean }> {
+  const { stdout: diffOut } = await exec(
+    'gh',
+    [
+      'api',
+      `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
+      '-H',
+      'Accept: application/vnd.github.v3.diff',
+    ],
+    { maxBuffer: 16 * 1024 * 1024 }
+  );
+  const truncated = diffOut.length > MAX_DIFF_LENGTH;
+  const diff = truncated ? `${diffOut.slice(0, MAX_DIFF_LENGTH)}\n[...truncated]` : diffOut;
+  return { diff, truncated };
+}
+
+/**
+ * Best-effort: make the PR's base+head commits available locally so the canonical
+ * `git diff base..head` can run. Fork PRs never push to `origin`, so we fetch the
+ * PR head ref (`pull/N/head`) and the base sha. NEVER throws — a fetch failure just
+ * means {@link generateCanonicalReviewDiff} will fail and record persistence is
+ * skipped (the review still runs off the gh-diff fallback).
+ */
+export async function ensurePrCommitsLocal(
+  prNumber: number,
+  baseSha: string,
+  exec: GhGitExec = execFileP,
+  cwd: string = ROOT
+): Promise<void> {
+  try {
+    await exec('git', ['fetch', '--quiet', 'origin', baseSha, `pull/${String(prNumber)}/head`], {
+      cwd,
+    });
+  } catch {
+    // ignore — canonical diff generation surfaces unavailability
+  }
+}
+
+/**
+ * Produce the CANONICAL reviewed diff for `base..head` (#4229) — the SAME pinned
+ * {@link canonicalGitDiffArgs} invocation the governor gate recomputes with, now
+ * with the pr-review ledger excluded. Hashing THIS output yields a value
+ * byte-identical to the gate's recompute (the load-bearing invariant), so the
+ * persisted record can match.
+ */
+export async function generateCanonicalReviewDiff(
+  baseSha: string,
+  headSha: string,
+  exec: GhGitExec = execFileP,
+  cwd: string = ROOT
+): Promise<string> {
+  const { stdout } = await exec('git', canonicalGitDiffArgs(baseSha, headSha), {
+    cwd,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+/** Inputs for {@link feedLedgerFromReview}. */
+export interface FeedLedgerParams {
+  readonly prNumber: number;
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly title: string;
+  readonly description?: string | undefined;
+  readonly aggregate: PrReviewAggregate;
+  readonly counts: PrReviewCounts;
+  readonly reviewCount: number;
+  /**
+   * The EXACT canonical diff the voters reviewed (from {@link generateCanonicalReviewDiff}).
+   * When provided it is hashed verbatim — avoiding a re-diff race where a push
+   * between the review and the record binds the record to bytes the voters never
+   * saw. Omitted ⇒ the diff is (re)generated from `base..head`.
+   */
+  readonly canonicalDiff?: string | undefined;
+  readonly exec?: GhGitExec | undefined;
+  readonly cwd?: string | undefined;
+  readonly logger?: ILogger | undefined;
+}
+
+/** Resolve the canonical diff bytes to hash: the passed-in one, or (re)generate. */
+async function resolveCanonicalDiff(
+  params: FeedLedgerParams,
+  exec: GhGitExec,
+  cwd: string
+): Promise<{ diff: string } | { skip: PrReviewRecordOutcome }> {
+  if (params.canonicalDiff !== undefined) return { diff: params.canonicalDiff };
+  await ensurePrCommitsLocal(params.prNumber, params.baseSha, exec, cwd);
+  try {
+    return { diff: await generateCanonicalReviewDiff(params.baseSha, params.headSha, exec, cwd) };
+  } catch (e) {
+    return {
+      skip: {
+        persisted: false,
+        reason: 'write-failed',
+        detail:
+          `No record written: could not produce the canonical git diff for ` +
+          `${params.baseSha.slice(0, 12)}..${params.headSha.slice(0, 12)} ` +
+          `(are both commits fetched?): ${(e as Error).message.slice(0, 160)}`,
+      },
+    };
+  }
+}
+
+/**
+ * Feed the governance ledger from a completed local review (#4229). Produces the
+ * canonical, ledger-excluded diff for `base..head` and calls the shared
+ * {@link persistReviewRecord} producer so the run's authentic verdict lands as a
+ * diff-bound record the governor gate can MATCH.
+ *
+ * The producer's simulate/no-live-votes guards are NOT bypassed (this always passes
+ * `simulate: false` and the real vote counts). Never throws — returns a structured
+ * {@link PrReviewRecordOutcome} (a `write-failed` skip when the canonical diff is
+ * unavailable, e.g. the base/head commits are not fetchable).
+ */
+export async function feedLedgerFromReview(
+  params: FeedLedgerParams
+): Promise<PrReviewRecordOutcome> {
+  const logger = params.logger ?? createLogger({ component: 'pr-review-local' });
+  const exec = params.exec ?? execFileP;
+  const cwd = params.cwd ?? ROOT;
+  if (params.baseSha === '' || params.headSha === '') {
+    return {
+      persisted: false,
+      reason: 'binding-inputs-absent',
+      detail: 'No record written: PR base/head SHA was not resolved (gh api .base.sha/.head.sha).',
+    };
+  }
+  const resolved = await resolveCanonicalDiff(params, exec, cwd);
+  if ('skip' in resolved) return resolved.skip;
+
+  const input: PrReviewInput = {
+    prTitle: params.title,
+    prDiff: resolved.diff,
+    prNumber: params.prNumber,
+    baseSha: params.baseSha,
+    simulate: false,
+    errorPolicy: 'standard',
+    dispatch: 'sync',
+    ...(params.description !== undefined && params.description !== ''
+      ? { prDescription: params.description }
+      : {}),
+  };
+  return persistReviewRecord({
+    input,
+    aggregate: params.aggregate,
+    counts: params.counts,
+    reviewCount: params.reviewCount,
+    logger,
+  });
+}
+
+/** A completed local review, reduced to the fields the ledger record needs. */
+export interface LocalReviewSummary {
+  readonly prNumber: number;
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly title: string;
+  readonly description: string;
+  readonly aggregate: PrReviewAggregate;
+  readonly counts: PrReviewCounts;
+  readonly reviewCount: number;
+  /** Canonical (ledger-excluded) diff the voters reviewed; undefined ⇒ no record. */
+  readonly canonicalDiff: string | undefined;
+}
+
+/**
+ * Feed the ledger from a completed live review and PRINT the outcome (#4229). Wraps
+ * {@link feedLedgerFromReview} for the CLI: best-effort — the caller's comment/label
+ * already landed, so a persistence skip only logs. Matches the script's
+ * non-committing side-effect model: it writes the record to the ledger and logs the
+ * actionable next step (commit it onto the PR head — hash-safe now the ledger is
+ * excluded from the reviewed diff) rather than pushing to an arbitrary head branch.
+ */
+export async function feedLedgerRecord(summary: LocalReviewSummary): Promise<void> {
+  if (summary.canonicalDiff === undefined) {
+    console.log(
+      `  ledger: canonical diff unavailable (base/head not fetched) — no governance record written.`
+    );
+    return;
+  }
+  const outcome = await feedLedgerFromReview({
+    prNumber: summary.prNumber,
+    baseSha: summary.baseSha,
+    headSha: summary.headSha,
+    title: summary.title,
+    description: summary.description,
+    aggregate: summary.aggregate,
+    canonicalDiff: summary.canonicalDiff,
+    counts: summary.counts,
+    reviewCount: summary.reviewCount,
+  });
+  if (outcome.persisted) {
+    console.log(
+      `  ledger: wrote pr-review record seq=${String(outcome.sequence)} ` +
+        `(reviewedDiffHash=${outcome.reviewedDiffHash.slice(0, 12)}…) to governance/pr-review-records.jsonl.`
+    );
+    console.log(
+      `  ledger: commit this record onto PR #${String(summary.prNumber)}'s head branch to satisfy the ` +
+        `governor-review gate — the ledger is excluded from the reviewed diff, so committing it is hash-safe (#4229).`
+    );
+  } else {
+    console.log(`  ledger: no record written (${outcome.reason}): ${outcome.detail}`);
+  }
+}

--- a/scripts/pr-review-local.test.ts
+++ b/scripts/pr-review-local.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the pr-review-local ledger feeder (#4229, epic #4226 child B).
+ *
+ * The load-bearing invariant (Part 2): a completed local review persists a
+ * governance record whose `reviewedDiffHash` is BYTE-IDENTICAL to what the
+ * governor gate recomputes from the same `base..head` — i.e. the record the gate
+ * would MATCH. The feeder guarantees this by hashing the SAME canonical,
+ * ledger-excluded diff (`canonicalGitDiffArgs` → `computeReviewedDiffHash`) that
+ * `scripts/check-governor-review.ts` recomputes. This test drives a REAL git repo
+ * (not a shared in-process helper) so the parity is proven against actual git
+ * output, and it appends a ledger line to head to prove the exclusion makes
+ * committing the record hash-safe.
+ *
+ * @module scripts/pr-review-local.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  fetchPrMeta,
+  generateCanonicalReviewDiff,
+  feedLedgerFromReview,
+  type GhGitExec,
+} from './pr-review-local-ledger.js';
+import {
+  canonicalGitDiffArgs,
+  computeReviewedDiffHash,
+} from '../packages/nexus-agents/src/audit/reviewed-diff-hash.js';
+import {
+  readPrReviewRecords,
+  PR_REVIEW_RECORDS_PATH_ENV,
+} from '../packages/nexus-agents/src/audit/index.js';
+
+describe('fetchPrMeta (base/head SHA fetch, #4229 Part 2)', () => {
+  it('requests the pulls endpoint and returns base.sha / head.sha', async () => {
+    const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+    const exec: GhGitExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return Promise.resolve({
+        stdout: JSON.stringify({
+          title: 'T',
+          body: 'B',
+          baseRef: 'main',
+          headRef: 'feat/x',
+          baseSha: 'a'.repeat(40),
+          headSha: 'b'.repeat(40),
+        }),
+        stderr: '',
+      });
+    };
+    const meta = await fetchPrMeta(4229, exec);
+    expect(meta.baseSha).toBe('a'.repeat(40));
+    expect(meta.headSha).toBe('b'.repeat(40));
+    expect(meta.title).toBe('T');
+    // The jq must pull the SHAs (.base.sha/.head.sha), not just the ref names.
+    const gh = calls.find((c) => c.cmd === 'gh');
+    expect(gh).toBeDefined();
+    const jq = gh?.args.join(' ') ?? '';
+    expect(jq).toContain('.base.sha');
+    expect(jq).toContain('.head.sha');
+  });
+});
+
+describe('pr-review-local ledger feeder (#4229 Part 2 — real git)', () => {
+  let repo: string;
+  let ledgerPath: string;
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, { cwd: repo, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+  }
+
+  const LEDGER = 'governance/pr-review-records.jsonl';
+
+  let baseSha: string;
+  let headSha: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'pr-review-local-repo-'));
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 1;\n');
+    mkdirSync(join(repo, 'governance'), { recursive: true });
+    writeFileSync(join(repo, LEDGER), '{"seq":0}\n');
+    git(['add', '-A']);
+    git(['commit', '-q', '-m', 'base']);
+    baseSha = git(['rev-parse', 'HEAD']).trim();
+    // Head advances BOTH a reviewable code file AND the ledger (as if the record
+    // were already committed to head) — the exclusion must keep the hash stable.
+    writeFileSync(join(repo, 'code.ts'), 'export const x = 2;\n');
+    writeFileSync(join(repo, LEDGER), '{"seq":0}\n{"seq":1,"prNumber":4229}\n');
+    git(['add', '-A']);
+    git(['commit', '-q', '-m', 'head']);
+    headSha = git(['rev-parse', 'HEAD']).trim();
+
+    // Redirect the ledger the producer writes to at a temp file we can inspect.
+    ledgerPath = join(
+      mkdtempSync(join(tmpdir(), 'pr-review-local-ledger-')),
+      'pr-review-records.jsonl'
+    );
+    vi.stubEnv(PR_REVIEW_RECORDS_PATH_ENV, ledgerPath);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('generateCanonicalReviewDiff excludes the ledger from the reviewed diff', async () => {
+    const diff = await generateCanonicalReviewDiff(baseSha, headSha, execAsyncGit(repo), repo);
+    expect(diff).toContain('code.ts');
+    expect(diff).not.toContain('"prNumber":4229'); // the ledger append is excluded
+  });
+
+  it('persists a record whose reviewedDiffHash EQUALS the gate recompute (the record the gate MATCHES)', async () => {
+    // What the CI governor gate would recompute for this PR's base..head.
+    const gateHash = computeReviewedDiffHash(
+      execFileSync('git', canonicalGitDiffArgs(baseSha, headSha), {
+        cwd: repo,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+      })
+    );
+
+    const outcome = await feedLedgerFromReview({
+      prNumber: 4229,
+      baseSha,
+      headSha,
+      title: 'feed the ledger',
+      aggregate: { decision: 'approve', verified: true },
+      counts: { approveCount: 5, requestChangesCount: 0, abstainCount: 0, errorCount: 0 },
+      reviewCount: 5,
+      exec: execAsyncGit(repo),
+      cwd: repo,
+    });
+
+    expect(outcome.persisted).toBe(true);
+    if (!outcome.persisted) throw new Error('expected persisted record');
+    // THE INVARIANT: the persisted hash matches what the gate recomputes.
+    expect(outcome.reviewedDiffHash).toBe(gateHash);
+    expect(outcome.baseSha).toBe(baseSha);
+
+    // And the on-disk record (what the gate reads) matches too.
+    const { records } = readPrReviewRecords(ledgerPath);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.reviewedDiffHash).toBe(gateHash);
+    expect(records[0]?.prNumber).toBe(4229);
+    expect(records[0]?.baseSha).toBe(baseSha);
+  });
+
+  it('does NOT bypass the producer live-review guard (all-errored panel → no record)', async () => {
+    const outcome = await feedLedgerFromReview({
+      prNumber: 4229,
+      baseSha,
+      headSha,
+      title: 'all voters errored',
+      aggregate: { decision: 'abstain', verified: false },
+      counts: { approveCount: 0, requestChangesCount: 0, abstainCount: 0, errorCount: 5 },
+      reviewCount: 5,
+      exec: execAsyncGit(repo),
+      cwd: repo,
+    });
+    expect(outcome.persisted).toBe(false);
+    if (outcome.persisted) throw new Error('expected skip');
+    expect(outcome.reason).toBe('no-live-votes');
+    const { records } = readPrReviewRecords(ledgerPath);
+    expect(records).toHaveLength(0);
+  });
+});
+
+/** A GhGitExec that runs `git` for real (in `cwd`) and rejects any non-git command. */
+function execAsyncGit(cwd: string): GhGitExec {
+  // eslint-disable-next-line @typescript-eslint/require-await -- async so a throw becomes a rejection
+  return async (cmd, args, options) => {
+    if (cmd !== 'git') throw new Error(`unexpected command in test: ${cmd}`);
+    const stdout = execFileSync('git', [...args], {
+      cwd: options?.cwd ?? cwd,
+      encoding: 'utf-8',
+      maxBuffer: options?.maxBuffer ?? 16 * 1024 * 1024,
+    });
+    return { stdout, stderr: '' };
+  };
+}

--- a/scripts/pr-review-local.ts
+++ b/scripts/pr-review-local.ts
@@ -10,25 +10,16 @@
  *   npx tsx scripts/pr-review-local.ts --watch --interval 600 # custom poll
  *   npx tsx scripts/pr-review-local.ts <pr-number> --no-post # dry run
  *
- * What it does (one-shot):
- *   1. Fetches PR diff via `gh api`
- *   2. Runs the same 5-voter pipeline pr_review uses (voters route
- *      through CLI subprocesses → use your local subscription auth)
- *   3. Posts a single review comment back via `gh pr comment`
- *   4. Adds the `pr-reviewed` label so --watch mode skips on next pass
+ * What it does (one-shot): fetch the PR's canonical `base..head` diff (ledger-
+ * excluded, #4229), run the same live 5-voter pr_review panel, post a single review
+ * comment (`gh pr comment`), add the `pr-reviewed` label, and feed the governance
+ * ledger with a diff-bound record the governor gate can MATCH (see
+ * `pr-review-local-ledger.ts`). Watch mode polls open, unlabelled, non-draft PRs on
+ * an interval and reviews each.
  *
- * What it does (watch mode):
- *   Polls open PRs without the `pr-reviewed` label, runs review on each,
- *   sleeps for --interval seconds (default 300), repeats.
- *
- * Safety:
- *   - Adds `pr-reviewed` label so the same PR isn't reviewed twice
- *   - Skips PRs with `skip-pr-review` label (matches the workflow's opt-out)
- *   - Skips draft PRs by default (use --include-drafts to override)
- *   - Adds [bot] suffix to comment body so it's clearly automated
- *
- * Cost: ~5 voter LLM calls per PR (5 messages of subscription quota at
- * typical PR size, ~2 minutes wall-clock per PR).
+ * Safety: `pr-reviewed` avoids double review; `skip-pr-review` opts out; drafts
+ * skipped unless `--include-drafts`; comment carries a [bot] suffix. Cost: ~5 voter
+ * LLM calls (~2 min) per PR.
  *
  * @module scripts/pr-review-local
  */
@@ -44,16 +35,23 @@ import {
   mapVoteDecisionToPrDecision,
   aggregatePrDecisions,
   MAX_DIFF_LENGTH,
+  type PrReviewAggregate,
 } from '../packages/nexus-agents/src/mcp/tools/pr-review-tool.js';
 import {
   isFindingVerified,
   type Finding,
 } from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
+import {
+  ensurePrCommitsLocal,
+  generateCanonicalReviewDiff,
+  feedLedgerRecord,
+  fetchPrMeta,
+  fetchGhDiff,
+  type PrMeta,
+} from './pr-review-local-ledger.js';
 
 const execFileP = promisify(execFile);
 
-const REPO_OWNER = 'nexus-substrate';
-const REPO_NAME = 'nexus-agents';
 const REVIEWED_LABEL = 'pr-reviewed';
 const SKIP_LABEL = 'skip-pr-review';
 
@@ -138,45 +136,6 @@ async function listOpenPrs(): Promise<readonly OpenPr[]> {
   }));
 }
 
-async function fetchPrDiff(prNumber: number): Promise<{
-  diff: string;
-  truncated: boolean;
-  baseRef: string;
-  headRef: string;
-  title: string;
-  body: string;
-}> {
-  const [{ stdout: meta }, { stdout: diffOut }] = await Promise.all([
-    execFileP('gh', [
-      'api',
-      `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
-      '--jq',
-      '{title, body, head: .head.ref, base: .base.ref}',
-    ]),
-    execFileP(
-      'gh',
-      [
-        'api',
-        `repos/${REPO_OWNER}/${REPO_NAME}/pulls/${String(prNumber)}`,
-        '-H',
-        'Accept: application/vnd.github.v3.diff',
-      ],
-      { maxBuffer: 16 * 1024 * 1024 }
-    ),
-  ]);
-  const m = JSON.parse(meta) as { title?: string; body?: string; head?: string; base?: string };
-  const truncated = diffOut.length > MAX_DIFF_LENGTH;
-  const diff = truncated ? `${diffOut.slice(0, MAX_DIFF_LENGTH)}\n[...truncated]` : diffOut;
-  return {
-    diff,
-    truncated,
-    title: m.title ?? '',
-    body: m.body ?? '',
-    headRef: m.head ?? '',
-    baseRef: m.base ?? '',
-  };
-}
-
 async function postPrComment(prNumber: number, body: string): Promise<void> {
   // Use stdin to avoid shell-escape headaches on the markdown body.
   const child = execFile('gh', ['pr', 'comment', String(prNumber), '--body-file', '-']);
@@ -214,31 +173,55 @@ interface VoterResult {
   readonly cli?: string | undefined;
 }
 
-async function runReview(
-  prNumber: number
-): Promise<{ summary: string; verified: boolean; reviews: VoterResult[] }> {
-  console.log(`\n[#${String(prNumber)}] fetching diff…`);
-  const { diff, title, body, baseRef, headRef } = await fetchPrDiff(prNumber);
-  console.log(`  ${title}`);
-  console.log(`  diff size: ${String(diff.length)} chars`);
+interface ReviewResult {
+  readonly summary: string;
+  readonly verified: boolean;
+  readonly reviews: VoterResult[];
+  readonly aggregate: PrReviewAggregate;
+  readonly title: string;
+  readonly description: string;
+  readonly baseSha: string;
+  readonly headSha: string;
+  /**
+   * The full canonical (ledger-excluded) `base..head` diff the voters reviewed and
+   * that gets hashed for the ledger record — undefined when the local clone could
+   * not produce it (fell back to the gh v3.diff for the review; no ledger record).
+   */
+  readonly canonicalDiff: string | undefined;
+}
 
-  const proposal = buildPrReviewProposal({
-    prTitle: title,
-    prDescription: body,
-    prDiff: diff,
-    ...(baseRef !== '' && { baseRef }),
-    ...(headRef !== '' && { headRef }),
-    simulate: false,
-  });
+/**
+ * Produce the diff the voters review. Prefers the CANONICAL, ledger-excluded
+ * `git diff base..head` (so its hash matches the gate recompute and the review can
+ * feed the ledger); falls back to the GitHub `v3.diff` when the base/head commits
+ * are not fetchable locally (review still runs, but no record — the fallback diff
+ * is not hash-parity with the gate).
+ */
+async function resolveReviewDiff(
+  prNumber: number,
+  meta: PrMeta
+): Promise<{ reviewDiff: string; canonicalDiff: string | undefined }> {
+  if (meta.baseSha !== '' && meta.headSha !== '') {
+    await ensurePrCommitsLocal(prNumber, meta.baseSha);
+    try {
+      const full = await generateCanonicalReviewDiff(meta.baseSha, meta.headSha);
+      const reviewDiff =
+        full.length > MAX_DIFF_LENGTH ? `${full.slice(0, MAX_DIFF_LENGTH)}\n[...truncated]` : full;
+      return { reviewDiff, canonicalDiff: full };
+    } catch (e) {
+      console.warn(
+        `  canonical git diff unavailable (${(e as Error).message.slice(0, 120)}); ` +
+          `falling back to gh diff (review only, no ledger record).`
+      );
+    }
+  }
+  const { diff } = await fetchGhDiff(prNumber);
+  return { reviewDiff: diff, canonicalDiff: undefined };
+}
 
-  console.log(`  running ${String(PR_REVIEW_ROLES.length)} voters via local CLI auth…`);
-  const voteResults = await collectRealVotes({
-    roles: PR_REVIEW_ROLES,
-    proposal,
-    simulate: false,
-  });
-
-  const reviews: VoterResult[] = voteResults.map((r) => {
+/** Normalize the raw voter results into the local {@link VoterResult} shape. */
+function mapVoterResults(voteResults: Awaited<ReturnType<typeof collectRealVotes>>): VoterResult[] {
+  return voteResults.map((r) => {
     const raw = r.vote.findings;
     const findings: Finding[] =
       raw !== undefined && raw.length > 0
@@ -261,9 +244,46 @@ async function runReview(
       cli: r.cli,
     };
   });
+}
 
+async function runReview(prNumber: number): Promise<ReviewResult> {
+  console.log(`\n[#${String(prNumber)}] fetching diff…`);
+  const meta = await fetchPrMeta(prNumber);
+  const { reviewDiff, canonicalDiff } = await resolveReviewDiff(prNumber, meta);
+  console.log(`  ${meta.title}`);
+  console.log(
+    `  diff size: ${String(reviewDiff.length)} chars${canonicalDiff !== undefined ? ' (canonical, ledger-excluded)' : ' (gh fallback)'}`
+  );
+
+  const proposal = buildPrReviewProposal({
+    prTitle: meta.title,
+    prDescription: meta.body,
+    prDiff: reviewDiff,
+    ...(meta.baseRef !== '' && { baseRef: meta.baseRef }),
+    ...(meta.headRef !== '' && { headRef: meta.headRef }),
+    simulate: false,
+  });
+
+  console.log(`  running ${String(PR_REVIEW_ROLES.length)} voters via local CLI auth…`);
+  const voteResults = await collectRealVotes({
+    roles: PR_REVIEW_ROLES,
+    proposal,
+    simulate: false,
+  });
+
+  const reviews = mapVoterResults(voteResults);
   const aggregate = aggregatePrDecisions(reviews);
-  return { summary: aggregate.decision, verified: aggregate.verified, reviews };
+  return {
+    summary: aggregate.decision,
+    verified: aggregate.verified,
+    reviews,
+    aggregate,
+    title: meta.title,
+    description: meta.body,
+    baseSha: meta.baseSha,
+    headSha: meta.headSha,
+    canonicalDiff,
+  };
 }
 
 // ============================================================================
@@ -375,6 +395,25 @@ async function runOnce(prNumber: number, post: boolean): Promise<void> {
   await postPrComment(prNumber, body);
   await applyLabel(prNumber, REVIEWED_LABEL);
   console.log(`  posted comment + applied '${REVIEWED_LABEL}' label.`);
+
+  // Feed the governance ledger (#4229): persist an authentic, diff-bound record so
+  // the governor-review gate can MATCH this PR's review.
+  await feedLedgerRecord({
+    prNumber,
+    baseSha: result.baseSha,
+    headSha: result.headSha,
+    title: result.title,
+    description: result.description,
+    aggregate: result.aggregate,
+    canonicalDiff: result.canonicalDiff,
+    counts: {
+      approveCount: counts.approve,
+      requestChangesCount: counts.rc,
+      abstainCount: counts.abstain,
+      errorCount: counts.err,
+    },
+    reviewCount: result.reviews.length,
+  });
 }
 
 async function runWatch(args: Args): Promise<void> {
@@ -422,4 +461,10 @@ async function main(): Promise<void> {
   await runOnce(args.prNumber, args.post);
 }
 
-await main();
+// Run only when invoked directly (not when imported by the test suite), mirroring
+// scripts/check-governor-review.ts — so the exported ledger-feeder seams are unit
+// testable without executing the watcher.
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  await main();
+}


### PR DESCRIPTION
Closes #4229. Child B of epic #4226 (feed the pr-review governance ledger from live diff-bound reviews). Security-sensitive: touches the shared reviewed-diff-hash primitive the governor gate trusts. Two clean separable commits.

## Part 1 — exclude the ledger from the canonical reviewed diff (the authenticity primitive)
`canonicalGitDiffArgs` now appends `-- :(exclude)governance/pr-review-records.jsonl`, dropping the append-only pr-review ledger from the canonical reviewed diff.

**Why:** a pr_review record for PR N must be committed to PR N's head branch so the gate (which reads the ledger from the head checkout via `readFileSync`) sees it — but committing the record advances head, so `git diff base..head` changes and no longer matches the record's stored `reviewedDiffHash` (self-invalidation). Excluding the append-only ledger makes committing a record to head hash-safe. The **same** `canonicalGitDiffArgs`/`computeReviewedDiffHash` is used by both the producer and the gate recompute (`scripts/check-governor-review.ts`), so the exclusion applies identically to both by construction.

**Security (pinned by tests):** (a) ONLY the exact ledger path is excluded — a `:(exclude)` pathspec matching one literal file, not a glob or directory, so it can never hide reviewable code (`governance/other.jsonl`, `…records.jsonl.bak` stay in the diff); (b) the ledger's integrity is still fully checked by `verifyPrReviewRecordSet`; (c) a PR that edits the ledger still cannot smuggle non-ledger code changes — every other changed path stays in the canonical diff and hash.

Exact argv position: `[...CANONICAL_GIT_DIFF_ARGS, "<base>..<head>", "--", ":(exclude)governance/pr-review-records.jsonl"]` (verified empirically: pathspec after the range, `--`-separated; git 2.43).

## Part 2 — wire pr-review-local.ts to feed the ledger
After the live 5-voter panel resolves, `scripts/pr-review-local.ts` now: fetches the PR **base+head SHAs** (`gh api … --jq .base.sha/.head.sha`); generates the reviewed diff **canonically** via `canonicalGitDiffArgs(baseSha, headSha)` (ledger-excluded) so the voters review — and the record hashes — the exact bytes the gate recomputes; calls `persistReviewRecord({prNumber, baseSha, prDiff, verdict, voteCounts})` (simulate/no-live-votes guards NOT bypassed); writes the record to the ledger and logs the actionable next step (commit it onto the PR head — hash-safe post-Part-1), matching the script's existing non-committing comment/label side-effect model. If base/head commits aren't fetchable locally, the review still runs off the gh v3.diff fallback but no record is written (that diff is not hash-parity with the gate). Feeder split into `scripts/pr-review-local-ledger.ts`; `main()` guarded behind `import.meta.url` for testability.

## The load-bearing invariant
The record's `reviewedDiffHash` must equal the gate's recompute for the same `base..head`, else no record ever matches. Guaranteed by both sides calling the **same** `canonicalGitDiffArgs` (config-pinned, ledger-excluded) → `computeReviewedDiffHash`. A real-git integration test asserts the persisted record's hash equals `computeReviewedDiffHash(git canonicalGitDiffArgs(base, head))` — including a head that appends a ledger line, proving the exclusion makes committing the record hash-stable.

## Gates
- `pnpm test` (full, foreground): **27465 passed**, 16 skipped, 0 failed
- `pnpm typecheck`: pass
- `npx eslint` (changed files): clean
- `pnpm test:scripts`: 432 passed (incl. `pr-review-local.test.ts`)
- changeset: minor (`nexus-agents`) — shared-primitive behavior change + new feeder capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)