### PR TITLE
fix(ci): parse registry-refresh verdict from file not first stdin chunk

### DIFF
--- a/.github/workflows/registry-refresh.yml
+++ b/.github/workflows/registry-refresh.yml
@@ -53,19 +53,26 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          OUTPUT=$(npx tsx scripts/check-registry-diff.ts \
+          npx tsx scripts/check-registry-diff.ts \
             /tmp/old-registry.json \
             packages/nexus-agents/src/config/model-registry.generated.json \
-            --json)
-          echo "$OUTPUT" > /tmp/diff-report.json
-          REQUIRES_REVIEW=$(echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data",d=>{const r=JSON.parse(d);console.log(r.verdict.requiresHumanReview)})' || echo "false")
-          TOTAL_ADDED=$(echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data",d=>{const r=JSON.parse(d);console.log(r.summary.added.length)})')
-          TOTAL_REMOVED=$(echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data",d=>{const r=JSON.parse(d);console.log(r.summary.removed.length)})')
-          TOTAL_CHANGED=$(echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data",d=>{const r=JSON.parse(d);console.log(r.summary.changed.length)})')
-          echo "requires_review=$REQUIRES_REVIEW" >> "$GITHUB_OUTPUT"
-          echo "total_added=$TOTAL_ADDED" >> "$GITHUB_OUTPUT"
-          echo "total_removed=$TOTAL_REMOVED" >> "$GITHUB_OUTPUT"
-          echo "total_changed=$TOTAL_CHANGED" >> "$GITHUB_OUTPUT"
+            --json > /tmp/diff-report.json
+          # Parse the verdict from the FILE, not a stdin pipe. The prior
+          # `echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data", ...)'` parsed only
+          # the FIRST stdin chunk; the report JSON for a ~1k-entry registry spans
+          # multiple chunks, so JSON.parse got a truncated prefix -> "Unexpected end
+          # of JSON input" and this step failed on every scheduled run. Reading the
+          # already-written file in one shot removes the chunk-boundary hazard and
+          # collapses four fragile re-parses into one.
+          node -e '
+            const fs = require("fs");
+            const r = JSON.parse(fs.readFileSync("/tmp/diff-report.json", "utf8"));
+            fs.appendFileSync(process.env.GITHUB_OUTPUT,
+              `requires_review=${r.verdict.requiresHumanReview}\n` +
+              `total_added=${r.summary.added.length}\n` +
+              `total_removed=${r.summary.removed.length}\n` +
+              `total_changed=${r.summary.changed.length}\n`);
+          '
           npx tsx scripts/check-registry-diff.ts \
             /tmp/old-registry.json \
             packages/nexus-agents/src/config/model-registry.generated.json \


### PR DESCRIPTION
## Problem

The scheduled **Registry Refresh** workflow fails on every run at the `Compute diff + guardrail verdict` step:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Socket.<anonymous> ([eval]:2:18)
```

The step piped the diff-report JSON through four inline node scripts of the form:

```bash
echo "$OUTPUT" | npx tsx -e 'process.stdin.on("data", d => { const r = JSON.parse(d); ... })'
```

`process.stdin.on("data")` fires **once per chunk**. The report JSON for the ~1k-entry generated registry is **167 KB** — well over the ~64 KB stdin chunk size — so `JSON.parse` received a truncated prefix and threw. The registry has therefore not auto-refreshed since this pattern landed.

## Fix

The `--json` output is already written to `/tmp/diff-report.json`. Parse **that file** in one shot instead of re-piping through stdin, collapsing four fragile re-parses into a single file read. No chunk-boundary hazard.

## Verification

Ran the real `check-registry-diff.ts --json` (produces a 167 KB report) and executed the exact new parse against it:

```
report bytes: 167484
requires_review=false
total_added=0
total_removed=0
total_changed=0
```

All four `GITHUB_OUTPUT` values populate correctly where the old first-chunk parse threw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)