### PR TITLE
fix(ci): ecosystem-smoke targets output must be single-line JSON

### DIFF
--- a/.github/workflows/ecosystem-smoke.yml
+++ b/.github/workflows/ecosystem-smoke.yml
@@ -89,7 +89,13 @@ jobs:
             exit 1
           fi
 
-          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          # Compact to a SINGLE line before writing: $targets is pretty-printed
+          # multi-line jq output, and the `key=value` GITHUB_OUTPUT format only
+          # accepts single-line values — a multi-line value makes Actions reject
+          # the second line ("Invalid format '  {'") and fail the step (it did so
+          # on every scheduled run since #2838's discovery rewrite). Compact JSON
+          # also parses cleanly via fromJSON() in the matrix consumer below.
+          echo "targets=$(jq -c . <<< "$targets")" >> "$GITHUB_OUTPUT"
 
   smoke:
     name: Smoke — ${{ matrix.target.owner }}/${{ matrix.target.name }}

--- a/.github/workflows/ecosystem-smoke.yml
+++ b/.github/workflows/ecosystem-smoke.yml
@@ -95,7 +95,13 @@ jobs:
           # the second line ("Invalid format '  {'") and fail the step (it did so
           # on every scheduled run since #2838's discovery rewrite). Compact JSON
           # also parses cleanly via fromJSON() in the matrix consumer below.
-          echo "targets=$(jq -c . <<< "$targets")" >> "$GITHUB_OUTPUT"
+          # (Kept as a bare assignment for consistency with the jq accumulation
+          # above; $targets is already validated JSON here — it passed through the
+          # same jq twice and the MIN_REPOS floor — so this compaction cannot fail
+          # in practice. Note bash `set -e` does NOT abort on a command-sub failure
+          # inside an assignment, so a hard guarantee would need an explicit check.)
+          targets=$(jq -c . <<< "$targets")
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
 
   smoke:
     name: Smoke — ${{ matrix.target.owner }}/${{ matrix.target.name }}


### PR DESCRIPTION
## Problem

The scheduled **Ecosystem Smoke** workflow has failed on **every run since at least June 1** (6+ consecutive weekly failures). The `Discover test repos` job resolves the repos correctly — 9 targets, above the `MIN_REPOS=5` floor — then dies at the very last line:

```
Resolved 9 target(s): …
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '  {'
```

`$targets` holds **pretty-printed multi-line** jq output. `echo "targets=$targets" >> "$GITHUB_OUTPUT"` therefore writes a multi-line `KEY=value`, and Actions' output-file parser rejects the second line (`  {`). The step fails and the whole smoke matrix is skipped — so the ecosystem smoke has effectively been dark for over a month.

## Fix

Compact the value to a single line with `jq -c` before writing. Single-line JSON satisfies the `KEY=value` output format **and** still parses via `fromJSON()` in the matrix consumer.

## Verification

Reproduced locally with the workflow's exact shell logic:

```
OLD:  targets=[
        {            ← Actions chokes here: 'Invalid format '  {''
NEW:  targets=[{"owner":"…","name":"…"},…]   (1 line, fromJSON-valid, length N)
```

Same GITHUB_OUTPUT multi-line class as the registry-refresh fix (#4237); this is the sibling occurrence in a different workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)