### PR TITLE
chore(ci): disable broken SICA weekly schedule pending #4240

### DIFF
--- a/.github/workflows/sica-test-generation.yml
+++ b/.github/workflows/sica-test-generation.yml
@@ -4,10 +4,14 @@ name: SICA Weekly Test Generation
 # (Source: Issue #256 - Self-Generated Test Automation, Phase 3.2)
 
 on:
-  schedule:
-    # Run every Monday at 9:00 AM UTC (5:00 AM ET)
-    - cron: '0 9 * * 1'
-  # Manual trigger for testing
+  # Weekly schedule DISABLED pending #4240. This job failed on every run for 6+
+  # weeks: the generator's coverage-gap discovery is a stub with a hardcoded,
+  # repo-root-relative target path, so writeFile ENOENTs, no *.sica.test.ts files
+  # land, and Create-PR dies on an empty pathspec. Re-enable the cron once the
+  # generator is fixed or the workflow is intentionally retired (see #4240).
+  # Manual dispatch is kept so the fix can be exercised on demand.
+  # schedule:
+  #   - cron: '0 9 * * 1'  # every Monday 09:00 UTC (05:00 ET)
   workflow_dispatch:
     inputs:
       target_coverage:


### PR DESCRIPTION
## What

Comments out the weekly `schedule:` cron in `sica-test-generation.yml`, leaving `workflow_dispatch` as the only trigger.

## Why

**SICA Weekly Test Generation** has failed on **every scheduled run for 6+ weeks** (3rd recurrence after #2263 / #2591). Root cause is documented in **#4240**: the generator's coverage-gap discovery is a stub with a hardcoded, repo-root-relative target path → `writeFile` ENOENTs → no `*.sica.test.ts` files land → `Create Pull Request` dies on an empty pathspec (`fatal: pathspec '**/*.sica.test.ts' did not match any files`).

A scheduled workflow that goes red every week trains maintainers to ignore the Actions tab and can mask *other* scheduled failures. This stops the noise while the real fix (or intentional retirement) is decided in #4240.

## Scope / reversibility

- **Reversible in one line** — re-add the cron once #4240 lands.
- `workflow_dispatch` retained, inputs intact (verified: YAML parses, sole trigger `workflow_dispatch`, inputs `target_coverage,dry_run`).
- No behavior change to any other workflow; no source touched.

Refs #4240

🤖 Generated with [Claude Code](https://claude.com/claude-code)