### PR TITLE
fix(indexer): correct broken exclude globs and single-line JSDoc parsing

### DIFF
--- a/.changeset/fix-indexer-exclude-and-jsdoc.md
+++ b/.changeset/fix-indexer-exclude-and-jsdoc.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': patch
+---
+
+Fix two indexer bugs: default exclude globs (`**/*.test.ts`, `**/*.d.ts`) were never actually applied because `shouldExcludeFile` stripped `*`/`**` from patterns before matching, leaving a broken substring check that couldn't match real file paths — test files and `.d.ts` files were being indexed. Excludes are now passed as negated globs directly to ts-morph's `addSourceFilesAtPaths`, which resolves them correctly.
+
+Also fixed `extractDescription` mishandling single-line JSDoc headers (e.g. `/** Utils. */`): `classifyJsDocLine` checked `startsWith('/**')` before `endsWith('*/')`, so a self-closing single-line comment never closed the comment state, causing the next code line to be misread as the description. A leading non-JSDoc block comment (e.g. `/* eslint-disable */`) also incorrectly aborted extraction before reaching the real module JSDoc; it is now skipped instead.

--- a/packages/nexus-agents/src/indexer/description-extraction.ts
+++ b/packages/nexus-agents/src/indexer/description-extraction.ts
@@ -10,21 +10,45 @@ import type { SourceFile } from 'ts-morph';
 import { truncateSentence } from '../utils/text-utils.js';
 
 /** Result of processing a single line in JSDoc extraction. */
-type LineResult = 'start' | 'end' | 'stop' | 'skip' | 'content';
+type LineResult = 'start' | 'startEnd' | 'end' | 'stop' | 'skip' | 'content';
+
+/** True for a self-contained block comment that is not a JSDoc header (e.g. `/* eslint-disable *\/`). */
+function isPlainBlockComment(trimmed: string): boolean {
+  return trimmed.startsWith('/*') && trimmed.endsWith('*/');
+}
+
+/** Classifies a line encountered before any JSDoc block has been entered. */
+function classifyOutsideComment(trimmed: string): LineResult {
+  if (isPlainBlockComment(trimmed)) return 'skip';
+  if (trimmed.length > 0 && !trimmed.startsWith('//')) return 'stop';
+  return 'skip';
+}
+
+/** Classifies a line encountered inside an open JSDoc block. */
+function classifyInsideComment(trimmed: string): LineResult {
+  if (trimmed.endsWith('*/')) return 'end';
+  if (trimmed.startsWith('* @') || trimmed.startsWith('@')) return 'skip';
+  return 'content';
+}
 
 /** Determines how to handle a line during JSDoc extraction. */
 function classifyJsDocLine(trimmed: string, inComment: boolean): LineResult {
-  if (trimmed.startsWith('/**')) return 'start';
-  if (trimmed.endsWith('*/')) return 'end';
-  if (!inComment && trimmed.length > 0 && !trimmed.startsWith('//')) return 'stop';
-  if (!inComment) return 'skip';
-  if (trimmed.startsWith('* @') || trimmed.startsWith('@')) return 'skip';
-  return 'content';
+  if (trimmed.startsWith('/**')) {
+    // Single-line JSDoc header, e.g. `/** Utils. */` — opens and closes on
+    // the same line, so it must not leave `inComment` dangling true.
+    return trimmed.endsWith('*/') ? 'startEnd' : 'start';
+  }
+  return inComment ? classifyInsideComment(trimmed) : classifyOutsideComment(trimmed);
 }
 
 /** Extracts content from a JSDoc comment line (strips leading * and whitespace). */
 function extractJsDocLineContent(trimmed: string): string {
   return trimmed.startsWith('*') ? trimmed.slice(1).trim() : trimmed;
+}
+
+/** Extracts the inner text of a single-line JSDoc header like `/** text *\/`. */
+function extractInlineJsDocContent(trimmed: string): string {
+  return trimmed.slice(3, -2).trim();
 }
 
 /**
@@ -50,6 +74,11 @@ export function extractDescription(sourceFile: SourceFile): string | undefined {
     if (result === 'start') {
       inComment = true;
       continue;
+    }
+    if (result === 'startEnd') {
+      const inline = extractInlineJsDocContent(trimmed);
+      if (inline.length > 0) description.push(inline);
+      break;
     }
     if (result === 'end' || result === 'stop') break;
     if (result === 'skip') continue;

--- a/packages/nexus-agents/src/indexer/extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/extractor.test.ts
@@ -361,6 +361,26 @@ export const x = 1;
     const desc = extractDescription(sourceFile);
     expect(desc?.length).toBeLessThanOrEqual(153); // 150 + '...'
   });
+
+  it('should extract description from a single-line JSDoc header', () => {
+    const sourceFile = createSourceFile(`/** Utils. */
+import { z } from 'zod';
+
+export const x = z.number();
+    `);
+    const desc = extractDescription(sourceFile);
+    expect(desc).toBe('Utils.');
+  });
+
+  it('should skip a leading non-JSDoc block comment to find the real JSDoc', () => {
+    const sourceFile = createSourceFile(`/* eslint-disable */
+
+/** Real. */
+export const x = 1;
+    `);
+    const desc = extractDescription(sourceFile);
+    expect(desc).toBe('Real.');
+  });
 });
 
 describe('extractFileEntry', () => {

--- a/packages/nexus-agents/src/indexer/project-extraction.test.ts
+++ b/packages/nexus-agents/src/indexer/project-extraction.test.ts
@@ -1,0 +1,56 @@
+/**
+ * nexus-agents/indexer - Project Extraction Tests (#4243)
+ *
+ * Regression coverage for default exclude globs: `**\/*.test.ts` and
+ * `**\/*.d.ts` must actually be excluded from `extractProject` output.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { extractProject } from './project-extraction.js';
+
+describe('extractProject default excludes', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir !== undefined) {
+      fs.rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  it('excludes co-located .test.ts and .d.ts files by default', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-extraction-test-'));
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'export const foo = 1;\n');
+    fs.writeFileSync(path.join(srcDir, 'foo.test.ts'), 'export const t = 1;\n');
+    fs.writeFileSync(path.join(srcDir, 'foo.d.ts'), 'export declare const foo: number;\n');
+
+    const result = extractProject({ rootDir: srcDir });
+
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('foo.ts');
+    expect(paths.some((p) => p.endsWith('.test.ts'))).toBe(false);
+    expect(paths.some((p) => p.endsWith('.d.ts'))).toBe(false);
+  });
+
+  it('still excludes files under node_modules', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-extraction-nm-'));
+    const srcDir = path.join(dir, 'src');
+    const nmDir = path.join(srcDir, 'node_modules', 'somepkg');
+    fs.mkdirSync(nmDir, { recursive: true });
+
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'export const foo = 1;\n');
+    fs.writeFileSync(path.join(nmDir, 'index.ts'), 'export const bundled = 1;\n');
+
+    const result = extractProject({ rootDir: srcDir });
+
+    const paths = result.files.map((f) => f.path);
+    expect(paths).toContain('foo.ts');
+    expect(paths.some((p) => p.includes('node_modules'))).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/indexer/project-extraction.ts
+++ b/packages/nexus-agents/src/indexer/project-extraction.ts
@@ -59,22 +59,15 @@ export function extractFileEntry(
 }
 
 /**
- * Checks if a file path matches any exclusion pattern.
- */
-function shouldExcludeFile(filePath: string, excludePatterns: string[], rootDir: string): boolean {
-  return excludePatterns.some((pattern) => {
-    const patternBase = pattern.replace(/\*\*/g, '').replace(/\*/g, '');
-    return filePath.includes(patternBase.replace(rootDir, '').replace(/^\//, ''));
-  });
-}
-
-/**
  * Processes source files and extracts metadata.
+ *
+ * Exclusion is enforced by ts-morph itself via negated glob patterns passed
+ * to `addSourceFilesAtPaths` (see `extractProject`), so every source file
+ * already in the project is eligible for extraction here.
  */
 function processSourceFiles(
   project: Project,
   rootDir: string,
-  excludePatterns: string[],
   extractDescriptions: boolean
 ): { files: FileEntry[]; errors: string[] } {
   const files: FileEntry[] = [];
@@ -82,10 +75,6 @@ function processSourceFiles(
 
   for (const sourceFile of project.getSourceFiles()) {
     const filePath = sourceFile.getFilePath();
-
-    if (shouldExcludeFile(filePath, excludePatterns, rootDir)) {
-      continue;
-    }
 
     try {
       files.push(extractFileEntry(sourceFile, rootDir, extractDescriptions));
@@ -112,16 +101,14 @@ export function extractProject(options: Partial<ExtractorOptions> = {}): Extract
 
   const rootDir = path.resolve(process.cwd(), opts.rootDir);
   const includePatterns = opts.include.map((p) => path.join(rootDir, p));
-  const excludePatterns = opts.exclude.map((p) => path.join(rootDir, p));
+  // Negated glob patterns: ts-morph forwards these straight through to
+  // tinyglobby, which honors `!`-prefixed entries as exclusions within the
+  // same pattern list passed to `addSourceFilesAtPaths`.
+  const excludePatterns = opts.exclude.map((p) => `!${path.join(rootDir, p)}`);
 
   try {
-    project.addSourceFilesAtPaths(includePatterns);
-    const { files, errors } = processSourceFiles(
-      project,
-      rootDir,
-      excludePatterns,
-      opts.extractDescriptions
-    );
+    project.addSourceFilesAtPaths([...includePatterns, ...excludePatterns]);
+    const { files, errors } = processSourceFiles(project, rootDir, opts.extractDescriptions);
     return { files, errors, durationMs: getTimeProvider().now() - startTime };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Two independent, confirmed bugs in the codebase indexer, each with regression tests added first (red → green):

- **Bug A — broken exclude globs** (`packages/nexus-agents/src/indexer/project-extraction.ts`): `shouldExcludeFile` "matched" glob patterns by stripping all `*`/`**` characters and then doing a plain substring check. Because exclude patterns are pre-joined with `rootDir` (`path.join(rootDir, p)`), stripping the stars from `**/*.test.ts` produced a mangled fragment (`/.test.ts`) that could never appear in a real file path. The default excludes for `**/*.test.ts` and `**/*.d.ts` were silent no-ops — test files and `.d.ts` files were being indexed. `**/node_modules/**` happened to still work by accident (the literal substring `node_modules` survives the stripping).

  **Fix:** removed `shouldExcludeFile` entirely and pass excludes as negated globs (`!<pattern>`) directly into ts-morph's `addSourceFilesAtPaths`, alongside the include globs. ts-morph forwards these straight to `tinyglobby` (already a transitive dependency via `@ts-morph/common`), which natively honors `!`-prefixed entries — no new dependency added. Verified empirically with a standalone script before touching the real code.

- **Bug B — single-line JSDoc mishandled** (`packages/nexus-agents/src/indexer/description-extraction.ts`): `classifyJsDocLine` checked `startsWith('/**')` (→ `'start'`) before `endsWith('*/')` (→ `'end'`), so a single-line header like `/** Utils. */` opened the comment state and never closed it — the following code line was then misread as the description. Separately, a leading non-JSDoc block comment like `/* eslint-disable */` matched the generic `endsWith('*/')` check and returned `'end'`, aborting extraction before it ever reached the real module JSDoc below it.

  **Fix:** `classifyJsDocLine` now detects a same-line `/** ... */` and returns a new `'startEnd'` result (extracts the inner text and closes immediately), and treats a self-contained block comment that starts with `/*` but *not* `/**` as `'skip'` rather than `'end'`. Split into small helpers (`isPlainBlockComment`, `classifyOutsideComment`, `classifyInsideComment`) to keep cyclomatic complexity under the repo's limit of 10. Multi-line JSDoc behavior is unchanged.

## Test plan

- [x] Added failing tests first, confirmed red, then green after each fix:
  - `packages/nexus-agents/src/indexer/project-extraction.test.ts` (new file): co-located `.test.ts`/`.d.ts` excluded by default; `node_modules` still excluded.
  - `packages/nexus-agents/src/indexer/extractor.test.ts`: single-line `/** Utils. */` header yields description `"Utils."` (not the following import line); a leading `/* eslint-disable */` no longer aborts extraction before a real `/** Real. */` JSDoc.
- [x] `pnpm build` — passes.
- [x] `pnpm --filter nexus-agents typecheck` — passes.
- [x] `pnpm --filter nexus-agents lint` — passes (0 errors after splitting `classifyJsDocLine` to satisfy `complexity: 10`).
- [x] `pnpm --filter nexus-agents test` — full suite passes: 1145 files / 27475 tests passed (16 pre-existing skips), 0 failures.
- [x] No pre-existing tests encoded the buggy behavior — none needed updating; this repo had no direct unit test file for `project-extraction.ts`'s exclude behavior and no existing `description-extraction.ts` test file (`extractDescription` was only covered in `extractor.test.ts` via multi-line JSDoc fixtures, which continue to pass unchanged).
- [x] Changeset added (`.changeset/fix-indexer-exclude-and-jsdoc.md`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)