### PR TITLE
fix(context): cap token sinks — extract_symbols full-mode + per-call context budget (#4253)

### DIFF
--- a/.changeset/cap-token-sinks-4253.md
+++ b/.changeset/cap-token-sinks-4253.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+fix(context): cap two unbounded token sinks — extract_symbols full-mode + per-call context budget (#4253, epic #4251)
+
+Phase-1 "stop the bleed" token-sink caps from the token-cost epic.
+
+**A — `extract_symbols` full-mode output cap.** Full mode previously dumped
+every matched symbol's entire source text with no cap, so a large file or
+large match set could blow a token budget with no backpressure. It now caps
+total emitted source at 20,000 chars / 200 symbols by default, overridable via
+optional `maxChars` / `maxSymbols` input fields. The boundary symbol is
+truncated with an ellipsis marker rather than silently dropped, and when
+truncation happens the JSON output reports `truncated`, `omittedSymbols`, and
+`omittedChars` so the cut is visible. Output is unchanged when results are
+under both caps.
+
+**B — per-call context budget guard in `summarizeContextForPrompt`.** The
+assembled context block is now clamped to a token budget (default 2,500 tokens,
+the CLAUDE.md "Standard" tier; overridable per call) on BOTH the ranked
+(`NEXUS_CONTEXT_RANKED`) and legacy paths — the legacy path previously had no
+budget at all, only per-section `.slice(0, 3-5)` count limits. When clamping
+truncates, a trailing notice reports how many chars were omitted. The
+memory-backend fan-out and ranking semantics are unchanged; this is a final
+clamp applied after rendering.
+
+Research-synthesis token-aware clipping remains tracked separately at #3233 and
+is out of scope here.

--- a/docs/reference/tools/extract_symbols.md
+++ b/docs/reference/tools/extract_symbols.md
@@ -18,3 +18,5 @@ Parse a SINGLE source file with the TypeScript compiler API and return its struc
 | --------- | ---- | -------- | ----------- | ----------- |
 | `filePath` | string | yes | minLength 1; maxLength 500 | Path to TypeScript/JavaScript file to extract symbols from |
 | `mode` | enum | no | one of: index \| full | index: names+lines only (minimal tokens). full: includes source text. |
+| `maxChars` | integer | no | max 1000000; > 0 | full mode only: cap on total emitted symbol source chars (default 20000). Excess is truncated and reported, never silently dropped. |
+| `maxSymbols` | integer | no | max 10000; > 0 | full mode only: cap on number of symbols emitted (default 200). |

--- a/packages/nexus-agents/src/context/context-retriever-helpers.ts
+++ b/packages/nexus-agents/src/context/context-retriever-helpers.ts
@@ -31,12 +31,7 @@ import type { TechniqueStatusSummary } from '../cli/research-types.js';
 
 /** The discriminated set of cross-rankable backends (the aggregate `outcomes` is excluded). */
 export type RankedMemorySource =
-  | 'belief'
-  | 'agentic'
-  | 'adaptive'
-  | 'experience'
-  | 'strategy'
-  | 'research';
+  'belief' | 'agentic' | 'adaptive' | 'experience' | 'strategy' | 'research';
 
 /** A backend item lifted onto a single comparable scale. */
 export interface RankedMemoryItem {
@@ -215,6 +210,33 @@ function extractKeywords(task: string): readonly string[] {
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/** Result of {@link clampToTokenBudget}. */
+export interface TokenBudgetClampResult {
+  /** The (possibly truncated) text, always a prefix of the input. */
+  readonly text: string;
+  /** Whether truncation occurred. */
+  readonly clipped: boolean;
+  /** Chars removed from the input (0 when not clipped). */
+  readonly omittedChars: number;
+}
+
+/**
+ * Clamp `text` to an estimated `maxTokens` budget using the same char/4
+ * heuristic as {@link topRankedWithinBudget} (#4253 — per-call context budget
+ * guard). Order-preserving prefix cut; never throws, never grows the input.
+ */
+export function clampToTokenBudget(text: string, maxTokens: number): TokenBudgetClampResult {
+  if (maxTokens <= 0) {
+    return { text: '', clipped: text.length > 0, omittedChars: text.length };
+  }
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+  if (text.length <= maxChars) {
+    return { text, clipped: false, omittedChars: 0 };
+  }
+  const kept = text.slice(0, maxChars);
+  return { text: kept, clipped: true, omittedChars: text.length - kept.length };
 }
 
 /** Age in ms from a possibly-invalid Date; non-finite timestamps → neutral 0. */

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -19,6 +19,7 @@ import {
   selectRelevantResearch,
   summarizeContextForPrompt,
   getContextPromptPrefix,
+  DEFAULT_CONTEXT_BUDGET_TOKENS,
   type UnifiedContext,
 } from './context-retriever.js';
 import { resetOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
@@ -479,6 +480,80 @@ describe('summarizeContextForPrompt — ranked mode (#3236)', () => {
   it('flag-on with empty backends renders nothing (fail-soft)', () => {
     process.env[RANKED] = '1';
     expect(summarizeContextForPrompt(emptyContext())).toBe('');
+  });
+});
+
+// ============================================================================
+// summarizeContextForPrompt — per-call context budget guard (#4253)
+// ============================================================================
+
+describe('summarizeContextForPrompt — per-call budget guard (#4253)', () => {
+  const prev = process.env['NEXUS_CONTEXT_RANKED'];
+  afterEach(() => {
+    if (prev === undefined) delete process.env['NEXUS_CONTEXT_RANKED'];
+    else process.env['NEXUS_CONTEXT_RANKED'] = prev;
+  });
+
+  function bigContext(): UnifiedContext {
+    const beliefs = Array.from({ length: 5 }, (_, i) => ({
+      beliefId: `b${String(i)}`,
+      subject: `subject about task ${String(i)} `.repeat(10),
+      predicate: 'requires',
+      object: `object detail ${String(i)} `.repeat(10),
+      confidence: BeliefConfidence.HIGH,
+      sourceType: BeliefSourceType.OBSERVATION,
+      version: 1,
+      createdAt: new Date('2026-06-01'),
+      updatedAt: new Date('2026-06-01'),
+      superseded: false,
+    }));
+    const base = emptyContext({ beliefs });
+    return { ...base, rankedMemories: rankMemories(base, 'task') };
+  }
+
+  it('exports a default budget matching the CLAUDE.md Standard tier (~2,500 tokens)', () => {
+    expect(DEFAULT_CONTEXT_BUDGET_TOKENS).toBe(2500);
+  });
+
+  it('clamps the legacy (flag-off) path to an explicit small budget and reports the clip', () => {
+    delete process.env['NEXUS_CONTEXT_RANKED'];
+    const ctx = bigContext();
+    const full = summarizeContextForPrompt(ctx, 5000);
+    const clamped = summarizeContextForPrompt(ctx, 5);
+    expect(clamped.length).toBeLessThan(full.length);
+    expect(clamped).toMatch(/clipped/i);
+    expect(clamped).toMatch(/chars omitted/i);
+  });
+
+  it('clamps the ranked (flag-on) path to an explicit small budget and reports the clip', () => {
+    process.env['NEXUS_CONTEXT_RANKED'] = '1';
+    const ctx = bigContext();
+    const full = summarizeContextForPrompt(ctx, 5000);
+    const clamped = summarizeContextForPrompt(ctx, 5);
+    expect(clamped.length).toBeLessThan(full.length);
+    expect(clamped).toMatch(/clipped/i);
+  });
+
+  it('does not clip a small context under the default budget (unchanged behavior)', () => {
+    delete process.env['NEXUS_CONTEXT_RANKED'];
+    const ctx = emptyContext({
+      beliefs: [
+        {
+          beliefId: 'b1',
+          subject: 'small',
+          predicate: 'is',
+          object: 'small',
+          confidence: BeliefConfidence.HIGH,
+          sourceType: BeliefSourceType.OBSERVATION,
+          version: 1,
+          createdAt: new Date('2026-06-01'),
+          updatedAt: new Date('2026-06-01'),
+          superseded: false,
+        },
+      ],
+    });
+    const out = summarizeContextForPrompt(ctx);
+    expect(out).not.toMatch(/clipped/i);
   });
 });
 

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -41,6 +41,7 @@ import type { TechniqueStatusSummary } from '../cli/research-types.js';
 import {
   rankMemories,
   topRankedWithinBudget,
+  clampToTokenBudget,
   type RankedMemoryItem,
 } from './context-retriever-helpers.js';
 
@@ -400,13 +401,53 @@ function oneLine(value: string): string {
  * When `NEXUS_CONTEXT_RANKED=1` (#3236), the per-backend sections are replaced
  * by a single globally-cross-ranked "Most relevant prior context" block drawn
  * from {@link UnifiedContext.rankedMemories} within a token budget. Flag-off
- * output is byte-identical to the legacy per-section rendering.
+ * output is byte-identical to the legacy per-section rendering (as long as
+ * the result stays under `budgetTokens` — see the budget guard below).
+ *
+ * **Per-call context budget guard (#4253):** the assembled block — on BOTH
+ * the ranked and legacy rendering paths — is clamped to `budgetTokens`
+ * (default {@link DEFAULT_CONTEXT_BUDGET_TOKENS}, the CLAUDE.md "Standard"
+ * context-budget tier) via {@link clampToTokenBudget}'s char/4 estimate.
+ * Before this guard, the legacy path had no cap at all — only per-section
+ * `.slice(0, 3-5)` limits, which bound item *count* but not total size. When
+ * clamping actually truncates, a trailing notice reports it so callers see
+ * backpressure instead of a silent cut. This does not change the
+ * memory-backend fan-out or ranking semantics (including the ranked path's
+ * own internal {@link RANKED_PREFIX_TOKEN_BUDGET}) — it is a final clamp
+ * applied after rendering.
  */
-export function summarizeContextForPrompt(ctx: UnifiedContext): string {
-  if (process.env[CONTEXT_RANKED_FLAG] === '1') {
-    return summarizeRankedContext(ctx);
-  }
+export function summarizeContextForPrompt(
+  ctx: UnifiedContext,
+  budgetTokens: number = DEFAULT_CONTEXT_BUDGET_TOKENS
+): string {
+  const rendered =
+    process.env[CONTEXT_RANKED_FLAG] === '1'
+      ? summarizeRankedContext(ctx)
+      : summarizeLegacyContext(ctx);
+  return clampRenderedContext(rendered, budgetTokens);
+}
 
+/** Default per-call context budget (tokens), applied by {@link summarizeContextForPrompt} (#4253). Matches the CLAUDE.md "Standard" context-budget tier (~2,500); pass a different value for a caller in the Minimal (~800) / Research (~1,500) / Full (~6,000) tier. */
+export const DEFAULT_CONTEXT_BUDGET_TOKENS = 2500;
+
+/** Tokens reserved for the trailing clip notice so the final block stays close to `budgetTokens` once the notice is appended. */
+const CLIP_NOTICE_RESERVE_TOKENS = 30;
+
+/**
+ * Apply the final per-call budget clamp (#4253) to an already-rendered
+ * context block, appending a visible notice when clamping actually
+ * truncated something. No-op on an empty or already-in-budget block.
+ */
+function clampRenderedContext(rendered: string, budgetTokens: number): string {
+  if (rendered === '') return rendered;
+  const contentBudget = Math.max(0, budgetTokens - CLIP_NOTICE_RESERVE_TOKENS);
+  const { text: kept, clipped, omittedChars } = clampToTokenBudget(rendered, contentBudget);
+  if (!clipped) return rendered;
+  return `${kept}\n\n_(context clipped to fit the ~${String(budgetTokens)}-token budget; ~${String(omittedChars)} chars omitted — #4253)_`;
+}
+
+/** The legacy (flag-off) per-backend-section rendering (#3148 / #3471). Extracted from {@link summarizeContextForPrompt} so the budget guard wraps both rendering paths identically (#4253). */
+function summarizeLegacyContext(ctx: UnifiedContext): string {
   const sections: string[] = [];
 
   if (ctx.beliefs.length > 0) {

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
@@ -19,9 +19,14 @@ vi.mock('../../indexer/symbol-extractor.js', () => ({
   extractSymbolIndex: vi.fn(),
 }));
 
-import { _testing } from './extract-symbols-tool.js';
+import {
+  _testing,
+  DEFAULT_EXTRACT_MAX_CHARS,
+  DEFAULT_EXTRACT_MAX_SYMBOLS,
+} from './extract-symbols-tool.js';
 import { createLogger } from '../../core/index.js';
 import * as symbolExtractor from '../../indexer/symbol-extractor.js';
+import type { CodeSymbol } from '../../indexer/symbol-extractor.js';
 
 const { extractSymbolsHandler } = _testing;
 
@@ -141,6 +146,125 @@ describe('extract-symbols-tool (#2159)', () => {
       expect(result.isError).toBeFalsy();
       const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
       expect(text).toMatch(/No symbols found/);
+    });
+  });
+
+  describe('full-mode output cap (#4253)', () => {
+    /** Build a symbol whose `text` is exactly `chars` long. */
+    function makeSymbol(name: string, chars: number): CodeSymbol {
+      return {
+        name,
+        kind: 'function',
+        startLine: 1,
+        endLine: 2,
+        exported: true,
+        text: 'x'.repeat(chars),
+      };
+    }
+
+    it('caps total emitted chars to the default budget and reports the omission', async () => {
+      // 5 symbols well past DEFAULT_EXTRACT_MAX_CHARS in aggregate.
+      const perSymbolChars = Math.ceil(DEFAULT_EXTRACT_MAX_CHARS / 2);
+      const symbols = Array.from({ length: 5 }, (_, i) =>
+        makeSymbol(`s${String(i)}`, perSymbolChars)
+      );
+      mockedExtractSymbols.mockResolvedValueOnce({
+        filePath: '/big.ts',
+        totalLines: 1000,
+        totalChars: perSymbolChars * 5,
+        symbolChars: perSymbolChars * 5,
+        savingsPercent: 0,
+        symbols,
+      });
+
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./big.ts'), mode: 'full' },
+        makeCtx()
+      );
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      const parsed = JSON.parse(text) as {
+        truncated?: boolean;
+        omittedSymbols?: number;
+        omittedChars?: number;
+        symbols: { text: string }[];
+      };
+
+      expect(parsed.truncated).toBe(true);
+      expect(parsed.omittedSymbols).toBeGreaterThan(0);
+      expect(parsed.omittedChars).toBeGreaterThan(0);
+      const emittedChars = parsed.symbols.reduce((sum, s) => sum + s.text.length, 0);
+      // Emitted text should be bounded near the cap, not the full ~2.5x-cap input.
+      expect(emittedChars).toBeLessThan(perSymbolChars * 5);
+    });
+
+    it('caps symbol count to the default budget and reports the omission', async () => {
+      const count = DEFAULT_EXTRACT_MAX_SYMBOLS + 50;
+      const symbols = Array.from({ length: count }, (_, i) => makeSymbol(`s${String(i)}`, 5));
+      mockedExtractSymbols.mockResolvedValueOnce({
+        filePath: '/many.ts',
+        totalLines: count,
+        totalChars: count * 5,
+        symbolChars: count * 5,
+        savingsPercent: 0,
+        symbols,
+      });
+
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./many.ts'), mode: 'full' },
+        makeCtx()
+      );
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      const parsed = JSON.parse(text) as {
+        truncated?: boolean;
+        omittedSymbols?: number;
+        symbols: unknown[];
+      };
+
+      expect(parsed.truncated).toBe(true);
+      expect(parsed.symbols.length).toBe(DEFAULT_EXTRACT_MAX_SYMBOLS);
+      expect(parsed.omittedSymbols).toBe(50);
+    });
+
+    it('respects an explicit maxChars/maxSymbols override', async () => {
+      const symbols = [makeSymbol('a', 100), makeSymbol('b', 100), makeSymbol('c', 100)];
+      mockedExtractSymbols.mockResolvedValueOnce({
+        filePath: '/small.ts',
+        totalLines: 10,
+        totalChars: 300,
+        symbolChars: 300,
+        savingsPercent: 0,
+        symbols,
+      });
+
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./small.ts'), mode: 'full', maxSymbols: 1 },
+        makeCtx()
+      );
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      const parsed = JSON.parse(text) as { truncated?: boolean; symbols: unknown[] };
+
+      expect(parsed.truncated).toBe(true);
+      expect(parsed.symbols.length).toBe(1);
+    });
+
+    it('preserves existing output (no truncation fields) when results are under both caps', async () => {
+      mockedExtractSymbols.mockResolvedValueOnce({
+        filePath: '/x.ts',
+        totalLines: 10,
+        totalChars: 100,
+        symbolChars: 50,
+        savingsPercent: 50,
+        symbols: [makeSymbol('foo', 20)],
+      });
+
+      const result = await extractSymbolsHandler(
+        { filePath: resolve('./x.ts'), mode: 'full' },
+        makeCtx()
+      );
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      const parsed = JSON.parse(text) as { truncated?: boolean };
+
+      expect(parsed.truncated).toBeUndefined();
     });
   });
 

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
@@ -12,7 +12,11 @@ import { resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
-import { extractSymbols, extractSymbolIndex } from '../../indexer/symbol-extractor.js';
+import {
+  extractSymbols,
+  extractSymbolIndex,
+  type CodeSymbol,
+} from '../../indexer/symbol-extractor.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -22,6 +26,21 @@ import {
   type ToolResult,
 } from './tool-result.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+
+// ============================================================================
+// Full-mode output cap (#4253)
+// ============================================================================
+
+/**
+ * Default total-chars budget for full-mode symbol source text. Before this,
+ * full mode dumped every matched symbol's entire source text with no cap —
+ * a large file or large match set could blow a token budget with no
+ * backpressure. Overridable per call via the `maxChars` input field.
+ */
+export const DEFAULT_EXTRACT_MAX_CHARS = 20_000;
+
+/** Default cap on the number of symbols emitted in full mode (#4253). Overridable via `maxSymbols`. */
+export const DEFAULT_EXTRACT_MAX_SYMBOLS = 200;
 
 // ============================================================================
 // Input Schema
@@ -37,6 +56,24 @@ export const ExtractSymbolsInputSchema = z.object({
     .enum(['index', 'full'])
     .optional()
     .describe('index: names+lines only (minimal tokens). full: includes source text.'),
+  maxChars: z
+    .number()
+    .int()
+    .positive()
+    .max(1_000_000)
+    .optional()
+    .describe(
+      `full mode only: cap on total emitted symbol source chars (default ${String(DEFAULT_EXTRACT_MAX_CHARS)}). Excess is truncated and reported, never silently dropped.`
+    ),
+  maxSymbols: z
+    .number()
+    .int()
+    .positive()
+    .max(10_000)
+    .optional()
+    .describe(
+      `full mode only: cap on number of symbols emitted (default ${String(DEFAULT_EXTRACT_MAX_SYMBOLS)}).`
+    ),
 });
 
 export type ExtractSymbolsInput = z.infer<typeof ExtractSymbolsInputSchema>;
@@ -51,27 +88,132 @@ export type ExtractSymbolsDeps = BaseMcpToolDeps;
 // Handler
 // ============================================================================
 
-/** Serialize a full symbol-extraction result to the tool's JSON shape. */
-function buildFullSymbolOutput(result: Awaited<ReturnType<typeof extractSymbols>>): string {
-  return JSON.stringify(
-    {
-      filePath: result.filePath,
-      totalLines: result.totalLines,
-      totalChars: result.totalChars,
-      symbolChars: result.symbolChars,
-      savingsPercent: result.savingsPercent,
-      symbols: result.symbols.map((s) => ({
-        name: s.name,
-        kind: s.kind,
-        startLine: s.startLine,
-        endLine: s.endLine,
-        exported: s.exported,
-        text: s.text,
-      })),
-    },
-    null,
-    2
-  );
+/** A symbol as rendered in the full-mode JSON payload. */
+interface OutputSymbol {
+  name: string;
+  kind: CodeSymbol['kind'];
+  startLine: number;
+  endLine: number;
+  exported: boolean;
+  text: string;
+}
+
+/** Outcome of applying the full-mode output cap (#4253). */
+interface CappedSymbols {
+  symbols: OutputSymbol[];
+  omittedSymbols: number;
+  omittedChars: number;
+  truncated: boolean;
+}
+
+function toOutputSymbol(s: CodeSymbol, text?: string): OutputSymbol {
+  return {
+    name: s.name,
+    kind: s.kind,
+    startLine: s.startLine,
+    endLine: s.endLine,
+    exported: s.exported,
+    text: text ?? s.text,
+  };
+}
+
+function sumChars(symbols: readonly CodeSymbol[]): number {
+  return symbols.reduce((sum, s) => sum + s.text.length, 0);
+}
+
+/** Truncate a symbol's text to `remaining` chars, appending a reported ellipsis marker. */
+function truncateSymbolText(s: CodeSymbol, remaining: number): OutputSymbol {
+  const kept = s.text.slice(0, Math.max(0, remaining));
+  const omittedChars = s.text.length - kept.length;
+  return toOutputSymbol(s, `${kept}\n… [truncated: ${String(omittedChars)} more chars omitted]`);
+}
+
+/**
+ * Running-budget pass over an already symbol-count-capped list — helper for
+ * {@link capSymbols}. Emits symbols until `maxChars` is exhausted; the symbol
+ * that would overflow the budget is truncated (not dropped) with an ellipsis
+ * marker, and every symbol after it is counted as omitted.
+ */
+function applyCharBudget(
+  symbols: readonly CodeSymbol[],
+  maxChars: number
+): { symbols: OutputSymbol[]; omittedCount: number; omittedChars: number } {
+  const out: OutputSymbol[] = [];
+  let used = 0;
+  for (let i = 0; i < symbols.length; i++) {
+    const s = symbols[i];
+    if (s === undefined) break;
+    const remaining = maxChars - used;
+    if (remaining <= 0) {
+      const rest = symbols.slice(i);
+      return { symbols: out, omittedCount: rest.length, omittedChars: sumChars(rest) };
+    }
+    if (s.text.length > remaining) {
+      out.push(truncateSymbolText(s, remaining));
+      const rest = symbols.slice(i + 1);
+      return {
+        symbols: out,
+        omittedCount: rest.length,
+        omittedChars: s.text.length - remaining + sumChars(rest),
+      };
+    }
+    out.push(toOutputSymbol(s));
+    used += s.text.length;
+  }
+  return { symbols: out, omittedCount: 0, omittedChars: 0 };
+}
+
+/**
+ * Cap full-mode symbol output to a total char budget and symbol count
+ * (#4253). Previously full mode emitted every matched symbol's entire source
+ * text with no limit — a large file/large match set could blow a token
+ * budget with no backpressure. Symbols beyond `maxSymbols`, or beyond the
+ * running `maxChars` budget, are omitted (the boundary symbol is truncated
+ * with a reported ellipsis marker instead of silently dropped); the omitted
+ * count/chars are always returned so callers see backpressure, not a silent cut.
+ */
+function capSymbols(
+  all: readonly CodeSymbol[],
+  maxChars: number,
+  maxSymbols: number
+): CappedSymbols {
+  const kept = all.slice(0, Math.max(0, maxSymbols));
+  const countOmitted = all.slice(kept.length);
+  const budgeted = applyCharBudget(kept, maxChars);
+
+  const omittedSymbols = countOmitted.length + budgeted.omittedCount;
+  const omittedChars = sumChars(countOmitted) + budgeted.omittedChars;
+  return {
+    symbols: budgeted.symbols,
+    omittedSymbols,
+    omittedChars,
+    truncated: omittedSymbols > 0,
+  };
+}
+
+/** Serialize a full symbol-extraction result to the tool's JSON shape, applying the output cap (#4253). */
+function buildFullSymbolOutput(
+  result: Awaited<ReturnType<typeof extractSymbols>>,
+  maxChars: number,
+  maxSymbols: number
+): string {
+  const capped = capSymbols(result.symbols, maxChars, maxSymbols);
+  const payload: Record<string, unknown> = {
+    filePath: result.filePath,
+    totalLines: result.totalLines,
+    totalChars: result.totalChars,
+    symbolChars: result.symbolChars,
+    savingsPercent: result.savingsPercent,
+    symbols: capped.symbols,
+  };
+  if (capped.truncated) {
+    payload['truncated'] = true;
+    payload['omittedSymbols'] = capped.omittedSymbols;
+    payload['omittedChars'] = capped.omittedChars;
+    payload['maxChars'] = maxChars;
+    payload['maxSymbols'] = maxSymbols;
+  }
+  return JSON.stringify(payload, null, 2);
 }
 
 async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
@@ -83,7 +225,7 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
     });
   }
 
-  const { filePath, mode } = parsed.data;
+  const { filePath, mode, maxChars, maxSymbols } = parsed.data;
   const resolvedPath = resolve(filePath);
 
   // Path traversal guard — restrict to cwd subtree. The `+ sep` is
@@ -100,7 +242,12 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
 
   try {
     if (mode === 'full') {
-      return toolSuccess(buildFullSymbolOutput(await extractSymbols(resolvedPath)));
+      const output = buildFullSymbolOutput(
+        await extractSymbols(resolvedPath),
+        maxChars ?? DEFAULT_EXTRACT_MAX_CHARS,
+        maxSymbols ?? DEFAULT_EXTRACT_MAX_SYMBOLS
+      );
+      return toolSuccess(output);
     }
 
     // Default: index mode (minimal tokens)
@@ -143,13 +290,32 @@ export function registerExtractSymbolsTool(server: McpServer, deps: ExtractSymbo
       .enum(['index', 'full'])
       .optional()
       .describe('index (default): names+lines. full: includes source text'),
+    maxChars: z
+      .number()
+      .int()
+      .positive()
+      .max(1_000_000)
+      .optional()
+      .describe(
+        `full mode only: cap on total emitted symbol source chars (default ${String(DEFAULT_EXTRACT_MAX_CHARS)})`
+      ),
+    maxSymbols: z
+      .number()
+      .int()
+      .positive()
+      .max(10_000)
+      .optional()
+      .describe(
+        `full mode only: cap on number of symbols emitted (default ${String(DEFAULT_EXTRACT_MAX_SYMBOLS)})`
+      ),
   };
 
   const description =
     'Parse a SINGLE TypeScript/JavaScript file with the TypeScript compiler API and return its structural AST symbols. ' +
     'Use when you need the structure of one file — function/class/method/interface/type definitions. ' +
     'Not a cross-file search; for that use `search_codebase`. ' +
-    'Output is 80%+ smaller than reading the full file.';
+    'Output is 80%+ smaller than reading the full file. ' +
+    `Full mode caps total emitted source at ${String(DEFAULT_EXTRACT_MAX_CHARS)} chars / ${String(DEFAULT_EXTRACT_MAX_SYMBOLS)} symbols by default (override via maxChars/maxSymbols); truncation is reported, never silent.`;
 
   const secureHandler = createSecureHandler(extractSymbolsHandler, {
     toolName: 'extract_symbols',


### PR DESCRIPTION
Closes #4253. Child of epic #4251 (Phase 1 — the "stop the bleed" token-sink caps).

Caps two known unbounded token sinks on existing paths. Tight scope — no redesign, no new dependency, no indexer/repo-map changes.

## Fix A — `extract_symbols` full-mode output cap
`packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts`

Full mode (`mode:'full'`) previously dumped every matched symbol's entire source text with no cap, so a large file / large match set could blow a token budget with no backpressure. It now caps total emitted source at **20,000 chars / 200 symbols** by default, overridable via new **optional `maxChars` / `maxSymbols`** input fields. The boundary symbol is **truncated with an ellipsis marker** rather than silently dropped, and when truncation happens the JSON output **reports it** (`truncated`, `omittedSymbols`, `omittedChars`, plus the applied `maxChars`/`maxSymbols`). Output is byte-for-byte unchanged when results are already under both caps.

## Fix B — per-call context budget guard in `summarizeContextForPrompt`
`packages/nexus-agents/src/context/context-retriever.ts` (+ `context-retriever-helpers.ts`)

The legacy (flag-off) summarize path had **no token budget** — only per-section `.slice(0, 3-5)` count limits, which bound item count but not total size. `summarizeContextForPrompt` now clamps the assembled block to a **per-call token budget (default 2,500 tokens — the CLAUDE.md "Standard" tier; overridable via a new optional arg)** on **both** the ranked (`NEXUS_CONTEXT_RANKED`) and legacy paths, using the existing char/4 estimate. When clamping truncates, a **trailing notice reports** how many chars were omitted. The memory-backend fan-out and ranking semantics are unchanged — this is a final clamp applied after rendering (the ranked path keeps its own internal 400-token prefix budget).

## Out of scope
Research-synthesis token-aware clipping stays tracked separately at **#3233** — referenced, not built here. No indexer/repo-map (#4254) changes; no new dependency.

## Discipline / gates
- **Red/Green TDD:** failing tests written first for both fixes, then implemented.
- **Tool Reference Drift:** `pnpm docs:tools` regenerated `docs/reference/tools/extract_symbols.md` for the new `maxChars`/`maxSymbols` Zod inputs. Repo-index `--check` is clean (no new tool/command/workflow).
- **Changeset:** patch added.
- Build, typecheck, lint (complexity ≤10, ≤50 lines/fn, zero `any`), and the full test suite all green: **27,502 passed / 16 skipped, 0 failures**. No pre-existing tests needed behavior updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)