### PR TITLE
feat(context): per-call token ledger tagged by context-source (#4252)

### DIFF
--- a/.changeset/token-ledger-4252.md
+++ b/.changeset/token-ledger-4252.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+feat(context): per-call token ledger tagged by context-source (#4252, Phase 0 of epic #4251)
+
+Adds a lightweight, queryable per-call token ledger so the token-optimization
+epic's claimed savings (#4253 caps, #4254 repo-map) are falsifiable instead of
+assumed.
+
+**`TokenLedger` (`context/token-ledger.ts`)** — records, per call: input/output
+tokens, a `tool` identifier, and a `contextSource` tag (`memory-backend`,
+`research-synthesis`, `repo-map`, `raw`, `tool-output`, `system`, or any future
+tag — the schema doesn't hard-enforce the enum so a new source never needs a
+migration), plus optional `model`/`taskId`/`variant` dimensions. Persists to
+`<nexus data dir>/token-ledger/ledger.jsonl` (append-only, hydrate-on-construct,
+bounded retention) via the shared `JsonlStore` primitive (#3762) — the same
+idiom as `governance/tool-fitness-ledger.ts` (#3851). Builds on the existing
+`token-counter.ts` (estimation) and mirrors the `token-budget-tracker.ts`
+`TokenUsageRecord` field vocabulary rather than forking a parallel shape.
+
+**Query surface** — `TokenLedger.summarize({ sinceMs?, untilMs? })` aggregates
+total/input/output tokens by `contextSource` and by `tool`, optionally scoped
+to a time window; calling it twice with windows bracketing a change supports a
+manual before/after comparison today. A dedicated fixed-sample A/B diff
+harness remains a documented follow-up under epic #4251.
+
+**Wiring** — `context/context-retriever.ts`'s `summarizeContextForPrompt` now
+records one `memory-backend`-tagged ledger entry per non-empty call, tagged
+`variant: 'ranked' | 'legacy'` for which rendering path (`NEXUS_CONTEXT_RANKED`)
+produced it. Assembly/ranking semantics are unchanged — this is additive
+telemetry only.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -27,6 +27,30 @@ import type { DistilledRule } from '../learning/strategy-distiller-types.js';
 import type { TechniqueStatusSummary } from '../cli/research-types.js';
 import { rankMemories } from './context-retriever-helpers.js';
 import { BeliefConfidence, BeliefSourceType } from './belief-core-types.js';
+import { getTokenLedger, _resetTokenLedgerForTests } from './token-ledger.js';
+
+// File-level isolation (#4252): `summarizeContextForPrompt` now records a
+// token-ledger entry on every call. Route ALL tests in this file to an
+// isolated NEXUS_DATA_DIR and reset the ledger singleton so no test writes to
+// the operator's real ~/.nexus-agents, regardless of whether the individual
+// describe block already manages its own data dir (this hook composes with
+// those — it runs first on the way in, last on the way out).
+let ledgerDataDir: string;
+let prevLedgerDataDir: string | undefined;
+
+beforeEach(() => {
+  prevLedgerDataDir = process.env['NEXUS_DATA_DIR'];
+  ledgerDataDir = mkdtempSync(join(tmpdir(), 'context-retriever-ledger-'));
+  process.env['NEXUS_DATA_DIR'] = ledgerDataDir;
+  _resetTokenLedgerForTests();
+});
+
+afterEach(() => {
+  if (prevLedgerDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+  else process.env['NEXUS_DATA_DIR'] = prevLedgerDataDir;
+  rmSync(ledgerDataDir, { recursive: true, force: true });
+  _resetTokenLedgerForTests();
+});
 
 describe('getContextForTask', () => {
   let dataDir: string;
@@ -554,6 +578,90 @@ describe('summarizeContextForPrompt — per-call budget guard (#4253)', () => {
     });
     const out = summarizeContextForPrompt(ctx);
     expect(out).not.toMatch(/clipped/i);
+  });
+});
+
+// ============================================================================
+// summarizeContextForPrompt — token ledger wiring (#4252, Phase 0 of epic #4251)
+// ============================================================================
+
+describe('summarizeContextForPrompt — token ledger wiring (#4252)', () => {
+  const prev = process.env['NEXUS_CONTEXT_RANKED'];
+  afterEach(() => {
+    if (prev === undefined) delete process.env['NEXUS_CONTEXT_RANKED'];
+    else process.env['NEXUS_CONTEXT_RANKED'] = prev;
+  });
+
+  function withBelief(): UnifiedContext {
+    const belief = {
+      beliefId: 'b1',
+      subject: 'authentication token refresh',
+      predicate: 'requires',
+      object: 'oauth',
+      confidence: BeliefConfidence.HIGH,
+      sourceType: BeliefSourceType.OBSERVATION,
+      version: 1,
+      createdAt: new Date('2026-06-01'),
+      updatedAt: new Date('2026-06-01'),
+      superseded: false,
+    } as const;
+    const base = emptyContext({ beliefs: [belief] });
+    return { ...base, rankedMemories: rankMemories(base, 'authentication token refresh') };
+  }
+
+  it('records a memory-backend/legacy ledger entry when the legacy path renders content', () => {
+    delete process.env['NEXUS_CONTEXT_RANKED'];
+    const out = summarizeContextForPrompt(withBelief());
+    expect(out).not.toBe('');
+
+    const summary = getTokenLedger().summarize();
+    expect(summary.overall.entries).toBe(1);
+    expect(summary.bySource['memory-backend']?.entries).toBe(1);
+    const [entry] = getTokenLedger().all();
+    expect(entry?.contextSource).toBe('memory-backend');
+    expect(entry?.variant).toBe('legacy');
+    expect(entry?.inputTokens).toBeGreaterThan(0);
+  });
+
+  it('records a memory-backend/ranked ledger entry when the ranked path is active', () => {
+    process.env['NEXUS_CONTEXT_RANKED'] = '1';
+    summarizeContextForPrompt(withBelief());
+
+    const [entry] = getTokenLedger().all();
+    expect(entry?.contextSource).toBe('memory-backend');
+    expect(entry?.variant).toBe('ranked');
+  });
+
+  it('does not record an entry when there is no signal to render', () => {
+    summarizeContextForPrompt(emptyContext());
+    expect(getTokenLedger().size()).toBe(0);
+  });
+
+  it('the recorded token count tracks rendered size (a bigger context records more tokens)', () => {
+    delete process.env['NEXUS_CONTEXT_RANKED'];
+    summarizeContextForPrompt(withBelief());
+    const [small] = getTokenLedger().all();
+
+    const manyBeliefs = Array.from({ length: 5 }, (_, i) => ({
+      beliefId: `b${String(i)}`,
+      subject: `subject about task ${String(i)} `.repeat(10),
+      predicate: 'requires',
+      object: `object detail ${String(i)} `.repeat(10),
+      confidence: BeliefConfidence.HIGH,
+      sourceType: BeliefSourceType.OBSERVATION,
+      version: 1,
+      createdAt: new Date('2026-06-01'),
+      updatedAt: new Date('2026-06-01'),
+      superseded: false,
+    }));
+    const base = emptyContext({ beliefs: manyBeliefs });
+    summarizeContextForPrompt({ ...base, rankedMemories: rankMemories(base, 'task') }, 5000);
+    // Both calls share the same ledger in this test (no reset in between), so
+    // the second recorded entry — the "big" one — is the last, not the first.
+    const events = getTokenLedger().all();
+    const big = events[events.length - 1];
+
+    expect(big?.inputTokens).toBeGreaterThan(small?.inputTokens ?? 0);
   });
 });
 

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -44,6 +44,8 @@ import {
   clampToTokenBudget,
   type RankedMemoryItem,
 } from './context-retriever-helpers.js';
+import { createTokenCounter } from './token-counter.js';
+import { getTokenLedger } from './token-ledger.js';
 
 /**
  * What we know about a task, derived from every shared memory backend.
@@ -415,16 +417,43 @@ function oneLine(value: string): string {
  * memory-backend fan-out or ranking semantics (including the ranked path's
  * own internal {@link RANKED_PREFIX_TOKEN_BUDGET}) — it is a final clamp
  * applied after rendering.
+ *
+ * **Token ledger wiring (#4252, Phase 0 of epic #4251):** every non-empty
+ * result is also recorded in the {@link getTokenLedger} as one `memory-backend`
+ * entry, tagged with `variant: 'ranked' | 'legacy'` for which rendering path
+ * produced it. This is the single highest-value measurement point named by
+ * #4252 — without it, the C3 (#4253 caps) and C1' (#4254 repo-map) savings
+ * have no per-call baseline to diff against.
  */
 export function summarizeContextForPrompt(
   ctx: UnifiedContext,
   budgetTokens: number = DEFAULT_CONTEXT_BUDGET_TOKENS
 ): string {
-  const rendered =
-    process.env[CONTEXT_RANKED_FLAG] === '1'
-      ? summarizeRankedContext(ctx)
-      : summarizeLegacyContext(ctx);
-  return clampRenderedContext(rendered, budgetTokens);
+  const ranked = process.env[CONTEXT_RANKED_FLAG] === '1';
+  const rendered = ranked ? summarizeRankedContext(ctx) : summarizeLegacyContext(ctx);
+  const clamped = clampRenderedContext(rendered, budgetTokens);
+  recordAssembledContextTokens(clamped, ranked);
+  return clamped;
+}
+
+/** Shared estimator for the ledger wiring below — builds on `token-counter.ts` (#4252). */
+const contextTokenCounter = createTokenCounter();
+
+/**
+ * Record the assembled-context token count in the per-call token ledger
+ * (#4252). Best-effort: {@link getTokenLedger}'s persistence never throws
+ * (inherited from the `JsonlStore` contract), so this cannot break context
+ * assembly. Skipped for an empty block — there is nothing to measure, and
+ * recording it would add "0 tokens" noise to every no-signal call.
+ */
+function recordAssembledContextTokens(rendered: string, ranked: boolean): void {
+  if (rendered === '') return;
+  getTokenLedger().record({
+    tool: 'context-retriever.summarizeContextForPrompt',
+    contextSource: 'memory-backend',
+    inputTokens: contextTokenCounter.estimate(rendered),
+    variant: ranked ? 'ranked' : 'legacy',
+  });
 }
 
 /** Default per-call context budget (tokens), applied by {@link summarizeContextForPrompt} (#4253). Matches the CLAUDE.md "Standard" context-budget tier (~2,500); pass a different value for a caller in the Minimal (~800) / Research (~1,500) / Full (~6,000) tier. */

--- a/packages/nexus-agents/src/context/index.ts
+++ b/packages/nexus-agents/src/context/index.ts
@@ -284,3 +284,19 @@ export {
   type RankedMemorySource,
   type RankMemoriesOptions,
 } from './context-retriever-helpers.js';
+
+// Per-call token ledger (#4252, Phase 0 of epic #4251) — records input/output
+// tokens per call tagged by context-source, so the C3 (#4253)/C1' (#4254)
+// savings are measurable rather than assumed.
+export {
+  TokenLedger,
+  getTokenLedger,
+  CONTEXT_SOURCE_TAGS,
+  TokenLedgerEventSchema,
+  type ContextSourceTag,
+  type TokenLedgerEvent,
+  type TokenLedgerConfig,
+  type TokenLedgerAggregate,
+  type TokenLedgerSummary,
+  type TokenLedgerWindow,
+} from './token-ledger.js';

--- a/packages/nexus-agents/src/context/token-ledger.test.ts
+++ b/packages/nexus-agents/src/context/token-ledger.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for the per-call token ledger (#4252, Phase 0 of epic #4251).
+ *
+ * Mirrors the tool-fitness-ledger test shape (#3851): schema validation,
+ * record → aggregate → query, bounded retention, persistence round-trip, and
+ * the singleton contract. New here: aggregation is by contextSource TAG and by
+ * tool, plus an optional time window — the query surface #4252 asks for.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  TokenLedger,
+  TokenLedgerEventSchema,
+  getTokenLedger,
+  _resetTokenLedgerForTests,
+  CONTEXT_SOURCE_TAGS,
+  type TokenLedgerEvent,
+} from './token-ledger.js';
+
+let tmpDir: string;
+let filePath: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `nexus-token-ledger-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  filePath = join(tmpDir, 'ledger.jsonl');
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  _resetTokenLedgerForTests();
+});
+
+describe('TokenLedgerEventSchema', () => {
+  it('accepts a well-formed event', () => {
+    const ev: TokenLedgerEvent = {
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'context-retriever.summarizeContextForPrompt',
+      contextSource: 'memory-backend',
+      inputTokens: 120,
+      outputTokens: 0,
+    };
+    expect(TokenLedgerEventSchema.safeParse(ev).success).toBe(true);
+  });
+
+  it('rejects an empty tool name', () => {
+    const parsed = TokenLedgerEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: '',
+      contextSource: 'raw',
+      inputTokens: 1,
+      outputTokens: 0,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a negative token count', () => {
+    const parsed = TokenLedgerEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'x',
+      contextSource: 'raw',
+      inputTokens: -1,
+      outputTokens: 0,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts optional model/taskId/variant dimensions', () => {
+    const parsed = TokenLedgerEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'orchestrate',
+      contextSource: 'research-synthesis',
+      inputTokens: 500,
+      outputTokens: 50,
+      model: 'claude-sonnet-5',
+      taskId: 'task-1',
+      variant: 'ranked',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('does not restrict contextSource to a fixed enum (forward-compat for future tags)', () => {
+    // A future phase (e.g. #4254 repo-map) may introduce a new tag; the ledger
+    // schema must not require a migration to accept it.
+    const parsed = TokenLedgerEventSchema.safeParse({
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'x',
+      contextSource: 'a-brand-new-tag-from-a-later-phase',
+      inputTokens: 1,
+      outputTokens: 0,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('exports the documented known-tag vocabulary', () => {
+    expect(CONTEXT_SOURCE_TAGS).toContain('memory-backend');
+    expect(CONTEXT_SOURCE_TAGS).toContain('research-synthesis');
+    expect(CONTEXT_SOURCE_TAGS).toContain('repo-map');
+    expect(CONTEXT_SOURCE_TAGS).toContain('raw');
+    expect(CONTEXT_SOURCE_TAGS).toContain('tool-output');
+    expect(CONTEXT_SOURCE_TAGS).toContain('system');
+  });
+});
+
+describe('TokenLedger — record → aggregate → query', () => {
+  it('records calls and counts them', () => {
+    const ledger = new TokenLedger({ filePath });
+    ledger.record({ tool: 'a', contextSource: 'memory-backend', inputTokens: 100 });
+    ledger.record({ tool: 'a', contextSource: 'raw', inputTokens: 50, outputTokens: 10 });
+    ledger.record({ tool: 'b', contextSource: 'memory-backend', inputTokens: 30 });
+
+    expect(ledger.size()).toBe(3);
+  });
+
+  it('defaults outputTokens to 0 when omitted', () => {
+    const ledger = new TokenLedger({ filePath });
+    ledger.record({ tool: 'a', contextSource: 'raw', inputTokens: 42 });
+    expect(ledger.all()[0]?.outputTokens).toBe(0);
+  });
+
+  it('summarize() aggregates totals by contextSource tag and by tool', () => {
+    const ledger = new TokenLedger({ filePath });
+    ledger.record({ tool: 'context-retriever', contextSource: 'memory-backend', inputTokens: 100 });
+    ledger.record({
+      tool: 'context-retriever',
+      contextSource: 'memory-backend',
+      inputTokens: 200,
+      outputTokens: 5,
+    });
+    ledger.record({ tool: 'orchestrate', contextSource: 'research-synthesis', inputTokens: 40 });
+
+    const summary = ledger.summarize();
+    expect(summary.overall).toEqual({
+      entries: 3,
+      inputTokens: 340,
+      outputTokens: 5,
+      totalTokens: 345,
+    });
+    expect(summary.bySource['memory-backend']).toEqual({
+      entries: 2,
+      inputTokens: 300,
+      outputTokens: 5,
+      totalTokens: 305,
+    });
+    expect(summary.bySource['research-synthesis']).toEqual({
+      entries: 1,
+      inputTokens: 40,
+      outputTokens: 0,
+      totalTokens: 40,
+    });
+    expect(summary.byTool['context-retriever']).toEqual({
+      entries: 2,
+      inputTokens: 300,
+      outputTokens: 5,
+      totalTokens: 305,
+    });
+    expect(summary.byTool['orchestrate']).toEqual({
+      entries: 1,
+      inputTokens: 40,
+      outputTokens: 0,
+      totalTokens: 40,
+    });
+  });
+
+  it('summarize() restricts to a time window when sinceMs/untilMs are given', () => {
+    const ledger = new TokenLedger({ filePath });
+    ledger.record({
+      tool: 'a',
+      contextSource: 'raw',
+      inputTokens: 10,
+      ts: '2026-01-01T00:00:00.000Z',
+    });
+    ledger.record({
+      tool: 'a',
+      contextSource: 'raw',
+      inputTokens: 20,
+      ts: '2026-06-01T00:00:00.000Z',
+    });
+    ledger.record({
+      tool: 'a',
+      contextSource: 'raw',
+      inputTokens: 30,
+      ts: '2026-12-01T00:00:00.000Z',
+    });
+
+    const midYear = Date.parse('2026-06-01T00:00:00.000Z');
+    const before = ledger.summarize({ untilMs: midYear });
+    expect(before.overall.entries).toBe(1);
+    expect(before.overall.inputTokens).toBe(10);
+
+    const fromMidYear = ledger.summarize({ sinceMs: midYear });
+    expect(fromMidYear.overall.entries).toBe(2);
+    expect(fromMidYear.overall.inputTokens).toBe(50);
+  });
+
+  it('summarize() on an empty ledger returns zeroed aggregates', () => {
+    const ledger = new TokenLedger({ filePath });
+    const summary = ledger.summarize();
+    expect(summary.overall).toEqual({
+      entries: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+    expect(summary.bySource).toEqual({});
+    expect(summary.byTool).toEqual({});
+  });
+});
+
+describe('TokenLedger — persistence', () => {
+  it('round-trips through save → reload', () => {
+    const first = new TokenLedger({ filePath });
+    first.record({ tool: 'a', contextSource: 'memory-backend', inputTokens: 10, outputTokens: 2 });
+    first.record({ tool: 'b', contextSource: 'raw', inputTokens: 5 });
+
+    const reloaded = new TokenLedger({ filePath });
+    expect(reloaded.size()).toBe(2);
+    expect(reloaded.summarize().overall.entries).toBe(2);
+  });
+
+  it('writes one JSONL line per recorded call', () => {
+    const ledger = new TokenLedger({ filePath });
+    ledger.record({ tool: 'a', contextSource: 'raw', inputTokens: 1 });
+    ledger.record({ tool: 'b', contextSource: 'raw', inputTokens: 2 });
+
+    const lines = readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2);
+    const parsed = JSON.parse(lines[0]!) as TokenLedgerEvent;
+    expect(parsed.v).toBe(1);
+    expect(parsed.tool).toBe('a');
+  });
+
+  it('skips corrupt lines on hydrate without throwing', () => {
+    const good: TokenLedgerEvent = {
+      v: 1,
+      ts: '2026-06-15T10:00:00.000Z',
+      tool: 'survivor',
+      contextSource: 'raw',
+      inputTokens: 1,
+      outputTokens: 0,
+    };
+    writeFileSync(filePath, `${JSON.stringify(good)}\nnot-json\n{"v":1}\n`);
+
+    const ledger = new TokenLedger({ filePath });
+    expect(ledger.size()).toBe(1);
+  });
+
+  it('bounds retention to maxEvents (oldest evicted)', () => {
+    const ledger = new TokenLedger({ filePath, maxEvents: 3 });
+    for (let i = 0; i < 5; i++) {
+      ledger.record({ tool: `t${String(i)}`, contextSource: 'raw', inputTokens: i });
+    }
+
+    expect(ledger.size()).toBe(3);
+    const onDisk = readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(onDisk).toHaveLength(3);
+  });
+});
+
+describe('getTokenLedger — singleton', () => {
+  beforeEach(() => {
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env['NEXUS_DATA_DIR'];
+  });
+
+  it('returns the same instance until reset', () => {
+    const a = getTokenLedger();
+    const b = getTokenLedger();
+    expect(a).toBe(b);
+    _resetTokenLedgerForTests();
+    const c = getTokenLedger();
+    expect(c).not.toBe(a);
+  });
+});

--- a/packages/nexus-agents/src/context/token-ledger.ts
+++ b/packages/nexus-agents/src/context/token-ledger.ts
@@ -1,0 +1,315 @@
+/**
+ * Per-call token ledger tagged by context-source (#4252, Phase 0 of epic #4251).
+ *
+ * Why: the token-optimization vote (#4251) found that without a per-call,
+ * per-source token record, none of the claimed savings from later phases
+ * (#4253 per-call context caps, #4254 repo-map) are falsifiable — there is
+ * no baseline to diff against. `TokenBudgetTracker` (`token-budget-tracker.ts`)
+ * already tracks usage, but only as a running SESSION/task total — it cannot
+ * answer "how many tokens came from the memory backends vs. a raw grep vs.
+ * research synthesis, for this one call." This module adds that dimension.
+ *
+ * ## Extend, don't fork
+ *
+ * This deliberately reuses rather than reinvents:
+ * - **Fields**: `inputTokens`/`outputTokens`/`taskId` mirror
+ *   {@link TokenUsageRecord} in `token-budget-tracker.ts` — this is the same
+ *   vocabulary, widened with `tool` and `contextSource` (the two dimensions
+ *   {@link TokenBudgetTracker} does not carry per-event).
+ * - **Estimation**: callers that need to turn rendered text into a token count
+ *   (e.g. the `context-retriever.ts` wiring, #4252 acceptance) should use
+ *   {@link TokenCounter.estimate} (`token-counter.ts`) rather than a third
+ *   copy of the chars-per-token heuristic.
+ * - **Persistence**: the shared {@link JsonlStore} primitive (`config/jsonl-store`,
+ *   #3762) — the same hydrate-on-construct / append-on-write / Zod-validate-
+ *   each-line mechanism that backs {@link PersistentOutcomeStore}, the
+ *   `ci-health` event log, and `governance/tool-fitness-ledger.ts` (#3851),
+ *   which this module's shape most closely mirrors. Bounded by
+ *   oldest-eviction rotation so the file can never grow without limit.
+ * - **Path**: resolves via {@link nexusDataPath} at `token-ledger/ledger.jsonl`.
+ *   `token-ledger` is NOT in `PER_REPO_SUBDIRS`, so it routes cross-repo
+ *   (homedir-scoped) like `tool-fitness` — token usage is an operator-wide
+ *   telemetry signal, not scoped to one codebase.
+ * - Append is best-effort: a telemetry sink must never throw into the
+ *   operation it observes (inherited from the JsonlStore contract).
+ *
+ * ## Scope
+ *
+ * DATA LAYER + a minimal query surface ({@link TokenLedger.summarize}). The
+ * full A/B diff harness that fixes a task sample and diffs `getContextForTask`
+ * token counts across two configurations (the #4251 acceptance criterion) is
+ * OUT of scope for this issue — `summarize()` accepts a `{ sinceMs, untilMs }`
+ * window so a before/after comparison is already possible by calling it twice
+ * with windows that bracket a change (e.g. a deploy timestamp). The dedicated
+ * harness is a documented follow-up tracked under epic #4251.
+ *
+ * @module context/token-ledger
+ */
+
+import { z } from 'zod';
+
+import { JsonlStore } from '../config/jsonl-store.js';
+import { nexusDataPath } from '../config/nexus-data-dir.js';
+
+// ============================================================================
+// Context-source tags
+// ============================================================================
+
+/**
+ * Known context-source tags (#4252). This list documents the vocabulary call
+ * sites should draw from — it is NOT a closed enum enforced by the schema
+ * (see {@link TokenLedgerEventSchema}), so a later phase can introduce a new
+ * tag (e.g. #4254's repo-map, already listed here in anticipation) without a
+ * ledger schema migration.
+ */
+export const CONTEXT_SOURCE_TAGS = [
+  /** Assembled context from `getContextForTask` / the shared memory backends. */
+  'memory-backend',
+  /** Content synthesized from the research registry/pipeline. */
+  'research-synthesis',
+  /** Content from a repo-map / codebase-structure summary (#4254). */
+  'repo-map',
+  /** Unclassified free-text input (e.g. a raw grep/file dump). */
+  'raw',
+  /** Output returned by a tool call, fed back in as input elsewhere. */
+  'tool-output',
+  /** System-prompt / instruction scaffolding, not task-specific content. */
+  'system',
+] as const;
+
+/** A known context-source tag. See {@link CONTEXT_SOURCE_TAGS}. */
+export type ContextSourceTag = (typeof CONTEXT_SOURCE_TAGS)[number];
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+/**
+ * One recorded per-call token event. Versioned (`v`) for forward-compatible
+ * on-disk evolution, matching the `tool-fitness` / `ci-health` event idiom.
+ * `contextSource` is a bounded-length string rather than a `z.enum` of
+ * {@link CONTEXT_SOURCE_TAGS} so a future tag never fails validation and gets
+ * silently dropped by {@link JsonlStore} (see its `append` contract).
+ */
+export const TokenLedgerEventSchema = z.object({
+  /** Schema version. Forward-compat for on-disk evolution. */
+  v: z.literal(1),
+  /** ISO-8601 timestamp of the call. */
+  ts: z.iso.datetime(),
+  /** Tool/call-site identifier (e.g. an MCP tool name or module.function). */
+  tool: z.string().min(1).max(200),
+  /** Context-source classification. See {@link CONTEXT_SOURCE_TAGS}. */
+  contextSource: z.string().min(1).max(64),
+  /** Input tokens attributed to this call/source. */
+  inputTokens: z.number().nonnegative(),
+  /** Output tokens attributed to this call. `0` when the call is context-only. */
+  outputTokens: z.number().nonnegative(),
+  /** Model identifier, when the calling surface exposes one. */
+  model: z.string().min(1).max(200).optional(),
+  /** Task/operation identifier, mirroring {@link TokenUsageRecord.taskId}. */
+  taskId: z.string().min(1).max(200).optional(),
+  /**
+   * Free-form call-site variant (e.g. `'ranked' | 'legacy'` for the
+   * `context-retriever.ts` rendering path, #4252 wiring). Optional dimension
+   * so producers that have no variant to report don't need a placeholder.
+   */
+  variant: z.string().min(1).max(100).optional(),
+});
+export type TokenLedgerEvent = z.infer<typeof TokenLedgerEventSchema>;
+
+// ============================================================================
+// Aggregates
+// ============================================================================
+
+/** Summed token counts for one group (a source tag, a tool, or the whole ledger). */
+export interface TokenLedgerAggregate {
+  /** Number of recorded calls in this group. */
+  readonly entries: number;
+  /** Sum of `inputTokens`. */
+  readonly inputTokens: number;
+  /** Sum of `outputTokens`. */
+  readonly outputTokens: number;
+  /** `inputTokens + outputTokens`. */
+  readonly totalTokens: number;
+}
+
+/** Result of {@link TokenLedger.summarize} — the #4252 query surface. */
+export interface TokenLedgerSummary {
+  /** Totals across every event in the queried window. */
+  readonly overall: TokenLedgerAggregate;
+  /** Totals grouped by `contextSource` tag. */
+  readonly bySource: Readonly<Record<string, TokenLedgerAggregate>>;
+  /** Totals grouped by `tool`. */
+  readonly byTool: Readonly<Record<string, TokenLedgerAggregate>>;
+}
+
+/** Optional time window for {@link TokenLedger.summarize}. Both bounds are epoch ms. */
+export interface TokenLedgerWindow {
+  /** Inclusive lower bound. Omit for no lower bound. */
+  readonly sinceMs?: number;
+  /** Exclusive upper bound. Omit for no upper bound. */
+  readonly untilMs?: number;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Default retained-event cap. Bounds disk + hydrate cost (the #3089 concern). */
+const DEFAULT_MAX_EVENTS = 50_000;
+
+/** Subdir + file name under the nexus data dir (cross-repo / homedir-scoped). */
+const LEDGER_SUBDIR = 'token-ledger';
+const LEDGER_FILE = 'ledger.jsonl';
+
+export interface TokenLedgerConfig {
+  /**
+   * Absolute path to the JSONL file. Defaults to
+   * `<nexusDataDir>/token-ledger/ledger.jsonl`. Pass an explicit path in tests
+   * to isolate from the real data dir.
+   */
+  readonly filePath?: string;
+  /** Max retained events before oldest-eviction. Defaults to {@link DEFAULT_MAX_EVENTS}. */
+  readonly maxEvents?: number;
+}
+
+// ============================================================================
+// Ledger
+// ============================================================================
+
+/**
+ * Per-call token ledger. A thin record/aggregate/query API over the shared
+ * {@link JsonlStore} primitive — it owns the token-ledger SCHEMA and
+ * aggregation, and delegates all persistence plumbing to JsonlStore.
+ */
+export class TokenLedger {
+  private readonly store: JsonlStore<TokenLedgerEvent>;
+
+  constructor(config?: TokenLedgerConfig) {
+    this.store = new JsonlStore<TokenLedgerEvent>({
+      filePath: config?.filePath ?? nexusDataPath(LEDGER_SUBDIR, LEDGER_FILE),
+      schema: TokenLedgerEventSchema,
+      maxRecords: config?.maxEvents ?? DEFAULT_MAX_EVENTS,
+      component: 'TokenLedger',
+    });
+  }
+
+  /**
+   * Record one call's token usage. `v`/`ts` are stamped here so callers pass
+   * only the observed signal. Best-effort durability (inherited from
+   * JsonlStore): never throws into the observed operation.
+   */
+  record(event: {
+    tool: string;
+    contextSource: string;
+    inputTokens: number;
+    outputTokens?: number;
+    model?: string;
+    taskId?: string;
+    variant?: string;
+    /** Override the timestamp (defaults to now). Mainly for tests/backfill. */
+    ts?: string;
+  }): void {
+    const record: TokenLedgerEvent = {
+      v: 1,
+      ts: event.ts ?? new Date().toISOString(),
+      tool: event.tool,
+      contextSource: event.contextSource,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens ?? 0,
+      ...(event.model !== undefined ? { model: event.model } : {}),
+      ...(event.taskId !== undefined ? { taskId: event.taskId } : {}),
+      ...(event.variant !== undefined ? { variant: event.variant } : {}),
+    };
+    this.store.append(record);
+  }
+
+  /** Total retained events. */
+  size(): number {
+    return this.store.count();
+  }
+
+  /** All retained events, oldest first. Mainly for tests/inspection. */
+  all(): readonly TokenLedgerEvent[] {
+    return this.store.all();
+  }
+
+  /**
+   * Aggregate totals by `contextSource` tag and by `tool`, optionally
+   * restricted to a time window (#4252 query surface). Pure over the current
+   * retained event set — no I/O.
+   *
+   * Manual before/after comparison (the #4251 A/B measurement need) is
+   * possible today by calling this twice with windows that bracket a change,
+   * e.g. `summarize({ untilMs: deployedAt })` vs.
+   * `summarize({ sinceMs: deployedAt })`. A dedicated harness that fixes a
+   * task sample and runs it under two configurations is deliberately out of
+   * scope here — tracked as a follow-up under epic #4251.
+   */
+  summarize(window: TokenLedgerWindow = {}): TokenLedgerSummary {
+    const events = this.store.all().filter((e) => withinWindow(e.ts, window));
+    return aggregateEvents(events);
+  }
+}
+
+/** Whether an ISO timestamp falls within `window`. Missing bounds never exclude. */
+function withinWindow(ts: string, window: TokenLedgerWindow): boolean {
+  const t = Date.parse(ts);
+  if (window.sinceMs !== undefined && t < window.sinceMs) return false;
+  if (window.untilMs !== undefined && t >= window.untilMs) return false;
+  return true;
+}
+
+/** A zeroed {@link TokenLedgerAggregate}. */
+function emptyAggregate(): TokenLedgerAggregate {
+  return { entries: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+/** Fold one event into an aggregate. Pure. */
+function addEvent(agg: TokenLedgerAggregate, e: TokenLedgerEvent): TokenLedgerAggregate {
+  return {
+    entries: agg.entries + 1,
+    inputTokens: agg.inputTokens + e.inputTokens,
+    outputTokens: agg.outputTokens + e.outputTokens,
+    totalTokens: agg.totalTokens + e.inputTokens + e.outputTokens,
+  };
+}
+
+/** Fold an event list into overall + by-source + by-tool aggregates. Pure. */
+function aggregateEvents(events: readonly TokenLedgerEvent[]): TokenLedgerSummary {
+  let overall = emptyAggregate();
+  const bySource = new Map<string, TokenLedgerAggregate>();
+  const byTool = new Map<string, TokenLedgerAggregate>();
+  for (const e of events) {
+    overall = addEvent(overall, e);
+    bySource.set(e.contextSource, addEvent(bySource.get(e.contextSource) ?? emptyAggregate(), e));
+    byTool.set(e.tool, addEvent(byTool.get(e.tool) ?? emptyAggregate(), e));
+  }
+  return {
+    overall,
+    bySource: Object.fromEntries(bySource),
+    byTool: Object.fromEntries(byTool),
+  };
+}
+
+// ============================================================================
+// Singleton
+// ============================================================================
+
+let singleton: TokenLedger | undefined;
+
+/**
+ * Process-wide ledger backed by the default on-disk path. Lazily constructed
+ * so tests that never touch it don't create a data dir. Tests that DO
+ * exercise persistence should construct their own {@link TokenLedger} with an
+ * explicit `filePath` to stay isolated.
+ */
+export function getTokenLedger(): TokenLedger {
+  singleton ??= new TokenLedger();
+  return singleton;
+}
+
+/** Test helper — drops the process singleton so the next get reconstructs it. */
+export function _resetTokenLedgerForTests(): void {
+  singleton = undefined;
+}


### PR DESCRIPTION
## Summary

Phase 0 prerequisite for the token-optimization epic (#4251), closes #4252.

- Adds `TokenLedger` (`packages/nexus-agents/src/context/token-ledger.ts`) — a
  per-call token ledger built on the shared `JsonlStore` primitive (#3762),
  mirroring the existing `governance/tool-fitness-ledger.ts` (#3851) idiom
  rather than forking a new persistence mechanism. Records, per call: input
  tokens, output tokens, a `tool` identifier, and a `contextSource` tag
  (`memory-backend`, `research-synthesis`, `repo-map`, `raw`, `tool-output`,
  `system`, or any future tag — the schema doesn't hard-enforce a closed enum,
  so a later phase's new tag never needs a schema migration), plus optional
  `model`/`taskId`/`variant` dimensions. Persists as JSONL to
  `<nexus data dir>/token-ledger/ledger.jsonl` (append-only,
  hydrate-on-construct, bounded retention — cross-repo/homedir-scoped like
  `tool-fitness`, since token usage is operator-wide telemetry). Builds on the
  existing `token-counter.ts` (used for the estimation in the wiring below)
  and mirrors `token-budget-tracker.ts`'s `TokenUsageRecord` field vocabulary
  (`inputTokens`/`outputTokens`/`taskId`) instead of inventing a parallel
  shape.
- **Query surface**: `TokenLedger.summarize({ sinceMs?, untilMs? })`
  aggregates total/input/output tokens by `contextSource` tag and by `tool`,
  optionally scoped to a time window. Calling it twice with windows that
  bracket a change (e.g. a deploy timestamp) already supports a manual
  before/after comparison. The full fixed-sample A/B diff harness is
  deliberately out of scope here — documented as a follow-up tracked under
  epic #4251.
- **Wiring**: `context/context-retriever.ts`'s `summarizeContextForPrompt` (the
  single highest-value measurement point named by #4252) now records one
  `memory-backend`-tagged ledger entry per non-empty call, tagged
  `variant: 'ranked' | 'legacy'` for which rendering path
  (`NEXUS_CONTEXT_RANKED`) produced it. This is additive telemetry only —
  assembly/ranking semantics are unchanged.

## Scope / gates

- No new CLI subcommand, MCP tool, or workflow — the repo-index and Tool
  Reference Drift gates don't apply.
- No new env var — reuses the existing `NEXUS_DATA_DIR` resolution
  (`token-ledger` is a new subdir under it, not in `PER_REPO_SUBDIRS`, so it
  routes cross-repo like `tool-fitness`). No CLAUDE.md env-table change
  needed.
- No file deletions — the Canonical Paths / Governance Drift gates don't
  apply.
- Changeset added (`minor`, new public export surface via `context/index.ts`).

## Test plan

- [x] Red/Green TDD: wrote failing tests first for the ledger
      (`token-ledger.test.ts`) and the `context-retriever.ts` wiring
      (new describe block in `context-retriever.test.ts`), confirmed they
      failed before implementing, then implemented until green.
- [x] `pnpm build` — success
- [x] `pnpm --filter nexus-agents typecheck` — clean
- [x] `pnpm --filter nexus-agents lint` — clean (exit 0, no output)
- [x] `pnpm --filter nexus-agents test` — full suite:
      **1146 test files passed | 1 skipped (1147)**,
      **27522 tests passed | 16 skipped (27538)**

References #4252 / #4251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)