### PR TITLE
fix(mcp): surface voter transport (in-process gateway vs CLI subprocess) for consensus_vote

### DIFF
--- a/.changeset/voter-transport-notice-4255.md
+++ b/.changeset/voter-transport-notice-4255.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): surface voter transport (in-process gateway vs CLI subprocess) for consensus_vote (#4255)
+
+`consensus_vote` and other voter-agent tools already support routing votes
+in-process through an OpenAI-compatible gateway when `NEXUS_OPENAI_COMPAT_URL`
+/ `NEXUS_OPENAI_COMPAT_KEY` are set (#4040), but nothing told operators that —
+so many harnesses silently ran the slower CLI-subprocess fallback path
+(~90s wall time, per-CLI auth/quota dependent) without knowing a faster
+option existed.
+
+- **One-time startup notice** (`cli-server-gateway.ts`): when no in-process
+  gateway ends up wired — env unset, probe failed, or the gateway returned 0
+  models — nexus-agents now logs a single info-level line pointing the
+  operator at `NEXUS_OPENAI_COMPAT_URL`/`NEXUS_OPENAI_COMPAT_KEY`. Emitted at
+  most once per process (module-level guard), so repeated calls can't spam it.
+- **`nexus-agents doctor`**: reports a new "Voter transport" line — "In-process
+  gateway" or "CLI subprocess" — based on the same presence check (no network
+  probe), so operators can see which transport is active without waiting for
+  a real vote.
+- **Docs**: `docs/guides/HARNESS_COMPATIBILITY.md` gets a short "voter
+  transport / performance" note explaining the two paths generically (no
+  vendor/gateway names).
+
+No behavior change to voting itself — this is observability/DX only.

--- a/docs/guides/HARNESS_COMPATIBILITY.md
+++ b/docs/guides/HARNESS_COMPATIBILITY.md
@@ -29,6 +29,28 @@ export NEXUS_CUSTOM_API_KEY=...
 
 See [CUSTOM_ENDPOINT_SETUP.md](./CUSTOM_ENDPOINT_SETUP.md) for the custom-gateway path in depth.
 
+### Voter transport / performance (consensus_vote and similar tools)
+
+Tools that collect multiple LLM "votes" (e.g. `consensus_vote`) need one model
+call per voter role. There are two ways nexus-agents can make those calls:
+
+- **In-process, via an OpenAI-compatible gateway** — set both
+  `NEXUS_OPENAI_COMPAT_URL` and `NEXUS_OPENAI_COMPAT_KEY` (see
+  [CONFIGURATION.md](../getting-started/CONFIGURATION.md)) and nexus-agents
+  routes every voter through that gateway's HTTP API directly, in-process. No
+  subprocess is spawned per vote, so it's lower-latency and doesn't depend on
+  any individual CLI's own auth/quota.
+- **CLI subprocess round-robin (default when no gateway is set)** — with
+  neither env var set, voters shell out to whichever CLIs (claude/gemini/codex)
+  are installed, round-robining roles across them. This works with no extra
+  configuration, but each vote spawns a subprocess and inherits that CLI's own
+  auth/quota, so a full panel is noticeably slower.
+
+If you don't need per-CLI diversity and just want the fastest, most
+predictable voting path, configure an OpenAI-compatible gateway. nexus-agents
+logs a one-time notice at startup when it falls back to the CLI-subprocess
+path so you can tell which transport is active.
+
 ---
 
 ## OpenCode

--- a/packages/nexus-agents/src/cli-server-gateway.test.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.test.ts
@@ -18,6 +18,7 @@ import {
   tryWireGatewayAdapter,
   tryWireGatewayAdapters,
   resolveDefaultModelAdapter,
+  _resetCliSubprocessFallbackNotice,
 } from './cli-server-gateway.js';
 
 function makeMockAdapter(modelId: string): IModelAdapter {
@@ -237,6 +238,60 @@ describe('tryWireGatewayAdapters (#4040 — full list for voter diversity)', () 
   it('returns undefined when no gateway is configured', async () => {
     readOpenAICompatEnvMock.mockReturnValue(null);
     expect(await tryWireGatewayAdapters(makeMockLogger())).toBeUndefined();
+  });
+});
+
+describe('CLI subprocess fallback notice (#4255)', () => {
+  beforeEach(() => {
+    delete process.env['NEXUS_SANDBOX'];
+    buildOpenAICompatAdaptersMock.mockReset();
+    readOpenAICompatEnvMock.mockReset();
+    _resetCliSubprocessFallbackNotice();
+  });
+
+  it('logs once when no gateway env is configured', async () => {
+    readOpenAICompatEnvMock.mockReturnValue(null);
+    const logger = makeMockLogger();
+    await tryWireGatewayAdapters(logger);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('NEXUS_OPENAI_COMPAT_URL') as unknown
+    );
+  });
+
+  it('does not log when a gateway is configured and wiring succeeds', async () => {
+    readOpenAICompatEnvMock.mockReturnValue({
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    buildOpenAICompatAdaptersMock.mockResolvedValue(ok([makeMockAdapter('model-a')]));
+    const logger = makeMockLogger();
+    await tryWireGatewayAdapters(logger);
+    const calls = [...logger.info.mock.calls, ...logger.warn.mock.calls] as unknown[][];
+    const flat = JSON.stringify(calls);
+    expect(flat).not.toContain('NEXUS_OPENAI_COMPAT_URL');
+  });
+
+  it('logs once even when the probe fails or returns 0 models (still no usable gateway)', async () => {
+    readOpenAICompatEnvMock.mockReturnValue({
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'sk-test',
+    });
+    buildOpenAICompatAdaptersMock.mockResolvedValue(ok([]));
+    const logger = makeMockLogger();
+    await tryWireGatewayAdapters(logger);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('NEXUS_OPENAI_COMPAT_URL') as unknown
+    );
+  });
+
+  it('is emitted only once per process even across repeated calls (once-guard)', async () => {
+    readOpenAICompatEnvMock.mockReturnValue(null);
+    const loggerA = makeMockLogger();
+    const loggerB = makeMockLogger();
+    await tryWireGatewayAdapters(loggerA);
+    await tryWireGatewayAdapters(loggerB);
+    expect(loggerA.info).toHaveBeenCalledTimes(1);
+    expect(loggerB.info).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nexus-agents/src/cli-server-gateway.ts
+++ b/packages/nexus-agents/src/cli-server-gateway.ts
@@ -53,17 +53,24 @@ export async function tryWireGatewayAdapters(
   const env = readOpenAICompatEnv();
   if (env === null) {
     handleMissingEnv(logger, sandboxActive);
+    noticeCliSubprocessFallback(logger);
     return undefined;
   }
 
   const result = await buildOpenAICompatAdapters();
-  if (result === null) return undefined; // env-was-set guard; build contract allows it
+  if (result === null) {
+    // env-was-set guard; build contract allows it
+    noticeCliSubprocessFallback(logger);
+    return undefined;
+  }
   if (!result.ok) {
     handleProbeFailure(logger, sandboxActive, result.error.message);
+    noticeCliSubprocessFallback(logger);
     return undefined;
   }
   if (result.value.length === 0) {
     handleZeroModels(logger, sandboxActive);
+    noticeCliSubprocessFallback(logger);
     return undefined;
   }
 
@@ -81,6 +88,34 @@ export async function tryWireGatewayAdapters(
 export async function tryWireGatewayAdapter(logger: ILogger): Promise<IModelAdapter | undefined> {
   const all = await tryWireGatewayAdapters(logger);
   return all?.[0];
+}
+
+/**
+ * One-time operator notice (#4255): whenever no in-process gateway ends up
+ * wired — env unset, probe failed, or the gateway listed 0 models — voter
+ * and consensus calls fall through to the CLI-subprocess round-robin path
+ * (`voter-agents.ts` `getAvailableClis`). That path is slower (~90s wall
+ * time observed) and depends on each CLI's own auth/quota, but nothing told
+ * the operator a faster in-process option exists (#4040). Logged once per
+ * process via {@link cliSubprocessFallbackNoticeLogged} so a busy startup
+ * (or repeated calls in tests) can't spam it.
+ */
+let cliSubprocessFallbackNoticeLogged = false;
+
+function noticeCliSubprocessFallback(logger: ILogger): void {
+  if (cliSubprocessFallbackNoticeLogged) return;
+  cliSubprocessFallbackNoticeLogged = true;
+  logger.info(
+    'No in-process gateway is configured, so voter/consensus calls will spawn CLI ' +
+      "subprocesses (slower per-vote startup, subject to each CLI's own auth/quota). " +
+      'Set NEXUS_OPENAI_COMPAT_URL and NEXUS_OPENAI_COMPAT_KEY to route voters through ' +
+      'an OpenAI-compatible gateway in-process instead (lower latency, no subprocess spawn).'
+  );
+}
+
+/** Test-only: reset the one-time notice guard so repeated tests can re-trigger it. */
+export function _resetCliSubprocessFallbackNotice(): void {
+  cliSubprocessFallbackNoticeLogged = false;
 }
 
 /**

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -128,6 +128,7 @@ describe('doctor-formatting', () => {
       clis?: CliCheckResult[];
       mcpServerReady?: boolean;
       mcpClientReady?: boolean;
+      voterTransport?: { configured: boolean };
     } = {}
   ): DoctorResult => ({
     allHealthy: options.allHealthy ?? true,
@@ -179,6 +180,7 @@ describe('doctor-formatting', () => {
       driftCount: 0,
       missingCount: 0,
     },
+    voterTransport: options.voterTransport ?? { configured: false },
     timestamp: new Date('2024-01-01T00:00:00Z'),
   });
 
@@ -422,6 +424,24 @@ describe('doctor-formatting', () => {
         const calls = getCalls();
         expect(calls.some((call) => call.includes(tc.serverExpect))).toBe(true);
         expect(calls.some((call) => call.includes(tc.clientExpect))).toBe(true);
+      }
+    });
+
+    it('should print voter transport status (#4255)', () => {
+      const testCases = [
+        { configured: true, expected: 'Voter transport: In-process gateway' },
+        { configured: false, expected: 'Voter transport:' },
+      ];
+
+      for (const tc of testCases) {
+        writeLineMock.mockClear();
+        const result = createDoctorResult({ voterTransport: { configured: tc.configured } });
+        printDoctorResults(result);
+        const calls = getCalls();
+        expect(calls.some((call) => call.includes(tc.expected))).toBe(true);
+        if (!tc.configured) {
+          expect(calls.some((call) => call.includes('NEXUS_OPENAI_COMPAT_URL'))).toBe(true);
+        }
       }
     });
 

--- a/packages/nexus-agents/src/cli/doctor-formatting.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.ts
@@ -377,6 +377,22 @@ function printDoctorSummary(result: DoctorResult): void {
 }
 
 /**
+ * Prints which transport voter/consensus calls will use (#4255): an
+ * in-process OpenAI-compatible gateway when configured, else the CLI
+ * subprocess round-robin fallback.
+ */
+function printVoterTransportCheck(check: DoctorResult['voterTransport']): void {
+  if (check.configured) {
+    writeLine(`${formatStatus(true)} Voter transport: In-process gateway`);
+    return;
+  }
+  writeLine(`${formatStatus(true)} Voter transport: ${colors.dim}CLI subprocess${colors.reset}`);
+  writeLine(
+    `  ${colors.dim}Set NEXUS_OPENAI_COMPAT_URL and NEXUS_OPENAI_COMPAT_KEY for faster in-process voting${colors.reset}`
+  );
+}
+
+/**
  * Prints the doctor results to stdout.
  */
 export function printDoctorResults(result: DoctorResult): void {
@@ -406,6 +422,7 @@ export function printDoctorResults(result: DoctorResult): void {
   writeLine(
     `${formatStatus(result.mcpClientReady)} MCP Client mode: ${result.mcpClientReady ? 'Ready (Codex mcp-server)' : 'Not ready (Codex not installed)'}`
   );
+  printVoterTransportCheck(result.voterTransport);
   writeLine('');
 
   writeLine(`${colors.cyan}Checking capabilities...${colors.reset}`);

--- a/packages/nexus-agents/src/cli/doctor.test.ts
+++ b/packages/nexus-agents/src/cli/doctor.test.ts
@@ -128,6 +128,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
       driftCount: 0,
       missingCount: 0,
     },
+    voterTransport: { configured: false },
     allHealthy: true,
     timestamp: new Date(),
     ...overrides,
@@ -794,6 +795,35 @@ describe('Doctor Command', () => {
       writeSpy.mockRestore();
     });
 
+    it('should show voter transport as CLI subprocess when no gateway is configured', () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const result = createMockDoctorResult({ voterTransport: { configured: false } });
+
+      printDoctorResults(result);
+
+      const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+      expect(output).toContain('Voter transport');
+      expect(output).toContain('CLI subprocess');
+      expect(output).toContain('NEXUS_OPENAI_COMPAT_URL');
+
+      writeSpy.mockRestore();
+    });
+
+    it('should show voter transport as in-process gateway when configured', () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const result = createMockDoctorResult({ voterTransport: { configured: true } });
+
+      printDoctorResults(result);
+
+      const output = writeSpy.mock.calls.map((c) => c[0]).join('');
+      expect(output).toContain('Voter transport');
+      expect(output).toContain('In-process gateway');
+
+      writeSpy.mockRestore();
+    });
+
     it('should show configuration file status', () => {
       const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
@@ -1136,6 +1166,48 @@ describe('Doctor Command', () => {
       const { checkSandbox } = await import('./doctor.js');
       const result = checkSandbox();
       expect(result.dataDirInsideRepo).toBe(false);
+    });
+  });
+
+  describe('checkVoterTransport() (#4255)', () => {
+    let originalUrl: string | undefined;
+    let originalKey: string | undefined;
+    let originalOpencodeConfig: string | undefined;
+
+    beforeEach(() => {
+      originalUrl = process.env['NEXUS_OPENAI_COMPAT_URL'];
+      originalKey = process.env['NEXUS_OPENAI_COMPAT_KEY'];
+      originalOpencodeConfig = process.env['NEXUS_OPENCODE_CONFIG'];
+      delete process.env['NEXUS_OPENAI_COMPAT_URL'];
+      delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+      delete process.env['NEXUS_OPENCODE_CONFIG'];
+    });
+
+    afterEach(() => {
+      if (originalUrl === undefined) delete process.env['NEXUS_OPENAI_COMPAT_URL'];
+      else process.env['NEXUS_OPENAI_COMPAT_URL'] = originalUrl;
+      if (originalKey === undefined) delete process.env['NEXUS_OPENAI_COMPAT_KEY'];
+      else process.env['NEXUS_OPENAI_COMPAT_KEY'] = originalKey;
+      if (originalOpencodeConfig === undefined) delete process.env['NEXUS_OPENCODE_CONFIG'];
+      else process.env['NEXUS_OPENCODE_CONFIG'] = originalOpencodeConfig;
+    });
+
+    it('reports not configured when neither env var is set', async () => {
+      const { checkVoterTransport } = await import('./doctor.js');
+      expect(checkVoterTransport()).toEqual({ configured: false });
+    });
+
+    it('reports configured when both gateway env vars are set', async () => {
+      process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+      process.env['NEXUS_OPENAI_COMPAT_KEY'] = 'sk-test';
+      const { checkVoterTransport } = await import('./doctor.js');
+      expect(checkVoterTransport()).toEqual({ configured: true });
+    });
+
+    it('reports not configured when only one of the two env vars is set', async () => {
+      process.env['NEXUS_OPENAI_COMPAT_URL'] = 'https://gateway.example/v1';
+      const { checkVoterTransport } = await import('./doctor.js');
+      expect(checkVoterTransport()).toEqual({ configured: false });
     });
   });
 });

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -35,6 +35,7 @@ import { createAllAdapters } from '../cli-adapters/factory.js';
 import type { CliName, HealthStatus, CapacityStatus } from '../cli-adapters/types.js';
 import { getInTreeCapabilitiesMatrix } from '../config/model-config-helpers.js';
 import { createServer } from '../mcp/server.js';
+import { readOpenAICompatEnv } from '../adapters/openai-compat-adapter.js';
 import { printDoctorResults } from './doctor-formatting.js';
 import { probeCli } from './cli-auth-probe.js';
 import type { AuthProbeResult } from './cli-auth-probe.js';
@@ -209,6 +210,18 @@ export interface SandboxCheck {
 }
 
 /**
+ * Voter transport check (#4255): whether an OpenAI-compatible gateway is
+ * configured (env vars or the opencode.json bridge). Presence-only, same
+ * spirit as {@link checkApiKeys} — no network probe, and the key itself is
+ * never surfaced. When configured, consensus/voter calls route in-process
+ * through the gateway; otherwise they fall back to CLI subprocesses (see
+ * `cli-server-gateway.ts` `tryWireGatewayAdapters`).
+ */
+export interface VoterTransportCheck {
+  readonly configured: boolean;
+}
+
+/**
  * Complete doctor check results.
  */
 export interface DoctorResult {
@@ -230,6 +243,8 @@ export interface DoctorResult {
   readonly sandbox: SandboxCheck;
   /** Per-harness config alignment with AGENTS.md federation (#2805). */
   readonly harnessAlignment: HarnessAlignmentCheck;
+  /** Voter transport: in-process gateway vs CLI subprocess fallback (#4255). */
+  readonly voterTransport: VoterTransportCheck;
   readonly allHealthy: boolean;
   readonly timestamp: Date;
 }
@@ -679,6 +694,15 @@ export function checkSandbox(): SandboxCheck {
 }
 
 /**
+ * Checks whether an OpenAI-compatible gateway is configured (#4255).
+ * Presence-only — mirrors {@link checkApiKeys}, no network probe and the
+ * key value never leaves `process.env`.
+ */
+export function checkVoterTransport(): VoterTransportCheck {
+  return { configured: readOpenAICompatEnv() !== null };
+}
+
+/**
  * Runs the complete doctor check.
  */
 export async function runDoctor(): Promise<DoctorResult> {
@@ -700,6 +724,7 @@ export async function runDoctor(): Promise<DoctorResult> {
   const dataDirectory = checkDataDirectory();
   const sandbox = checkSandbox();
   const harnessAlignment = checkHarnessAlignment();
+  const voterTransport = checkVoterTransport();
 
   // At least one API key configured or one CLI authenticated
   const hasAuthMethod =
@@ -724,6 +749,7 @@ export async function runDoctor(): Promise<DoctorResult> {
     dataDirectory,
     sandbox,
     harnessAlignment,
+    voterTransport,
     allHealthy,
     timestamp: new Date(getTimeProvider().now()),
   };

--- a/packages/nexus-agents/src/cli/validate-command.test.ts
+++ b/packages/nexus-agents/src/cli/validate-command.test.ts
@@ -99,6 +99,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
       driftCount: 0,
       missingCount: 0,
     },
+    voterTransport: { configured: false },
     allHealthy: true,
     timestamp: new Date(),
     ...overrides,


### PR DESCRIPTION
## Summary

`consensus_vote` and other voter-agent tools already support routing votes in-process through an OpenAI-compatible gateway when `NEXUS_OPENAI_COMPAT_URL` / `NEXUS_OPENAI_COMPAT_KEY` are set (#4040) — but nothing told operators that, so many harnesses silently ran the slower CLI-subprocess fallback path (~90s wall time, per-CLI auth/quota dependent) without knowing a faster option existed. This is a pure DX/observability change — no change to voting correctness.

- **One-time startup notice** (`cli-server-gateway.ts`): whenever `tryWireGatewayAdapters` falls through to "no gateway wired" (env unset, probe failed, or the gateway returned 0 models), it now logs a single info-level line pointing the operator at `NEXUS_OPENAI_COMPAT_URL`/`NEXUS_OPENAI_COMPAT_KEY`. Guarded by a module-level once-flag (`noticeCliSubprocessFallback`) with a test-only reset hook (`_resetCliSubprocessFallbackNotice`), following the existing `simulation-guard.ts` `warnOnce` convention.
- **`nexus-agents doctor`**: new "Voter transport" line reporting `In-process gateway` or `CLI subprocess`, via a presence-only check of the gateway env vars (`checkVoterTransport`) — no network probe, so it's cheap and always safe to run.
- **Docs**: `docs/guides/HARNESS_COMPATIBILITY.md` gets a short "Voter transport / performance" section explaining the two paths generically (no vendor/gateway names, per OPSEC).
- Both env vars were already documented in `docs/getting-started/CONFIGURATION.md` and `docs/guides/SANDBOXED-USAGE.md` — no new env var, no new CLI/MCP tool, so no repo-index or Tool-Reference-Drift regen is needed.

Fixes #4255.

## Test plan

- [x] Red/green TDD: added failing tests first for the once-guarded notice (`cli-server-gateway.test.ts`) and the doctor check (`doctor.test.ts`, `doctor-formatting.test.ts`), then implemented.
- [x] `pnpm build` — green
- [x] `pnpm --filter nexus-agents typecheck` — green
- [x] `pnpm --filter nexus-agents lint` — green (0 errors)
- [x] `pnpm --filter nexus-agents test` — full suite green: 1146 test files passed (1 pre-existing skip), 27532 tests passed, 16 skipped, 0 failed
- [x] `npx markdownlint docs/guides/HARNESS_COMPATIBILITY.md` — clean
- [x] Added changeset (patch): `.changeset/voter-transport-notice-4255.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)