### PR TITLE
feat(context): repo-map — rank by real call-site edges from search_usages (#4268)

### DIFF
--- a/.changeset/repo-map-callsite-ranking.md
+++ b/.changeset/repo-map-callsite-ranking.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': minor
+---
+
+repo-map: rank by real call-site edges from `search_usages` (#4268, epic #4251)
+
+The repo-map context provider (`context/repo-map.ts`, behind default-off
+`NEXUS_REPO_MAP`) now blends import-graph PageRank with a real **call-site
+frequency** signal, so ranking surfaces modules that are actually _called_, not
+just imported. The signal reuses the `search_usages` ast-grep machinery shipped
+in #4265 (extracted to the shared `indexer/usage-ast.ts` — no duplication, no
+new dependency) via a single-parse-per-file, top-N-bounded pass
+(`context/repo-map-callsites.ts`). The stale "import-graph only, no call-site
+data" caveat is replaced with an honest note about the remaining
+structural/syntactic limitation (dynamic dispatch, computed/string-keyed calls,
+same-named members). Default stays OFF; flag-off output is byte-for-byte
+unchanged. Flipping the default to ON (#4262) remains out of scope.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -815,9 +815,10 @@ describe('summarizeContextForPrompt — repo-map section + ledger (#4254)', () =
   }
 
   const REPO_MAP =
-    '## Repo Map (module import graph — PageRank-ranked)\n' +
-    '> Import-graph only: edges are module import dependencies + declaration names, ' +
-    'NOT call-site/usage data.\n- core (centrality 0.400, 3 files): foundation';
+    '## Repo Map (module import graph + call-site usage — ranked)\n' +
+    '> Ranking blends import-graph PageRank with structural call-site frequency ' +
+    '(ast-grep). Call-site matching is syntactic, not type-aware.\n' +
+    '- core (centrality 0.400, 12 call-sites, 3 files): foundation';
 
   it('flag off (no repoMap): no repo-map section and no repo-map ledger entry', () => {
     delete process.env['NEXUS_CONTEXT_RANKED'];
@@ -829,13 +830,13 @@ describe('summarizeContextForPrompt — repo-map section + ledger (#4254)', () =
     expect(summary.overall.entries).toBe(1);
   });
 
-  it('flag on (repoMap present): appends the ranked map with the import-graph-only caveat', () => {
+  it('flag on (repoMap present): appends the ranked map with the call-site-aware caveat', () => {
     delete process.env['NEXUS_CONTEXT_RANKED'];
     const ctx: UnifiedContext = { ...withBelief(), repoMap: REPO_MAP };
     const out = summarizeContextForPrompt(ctx);
     expect(out).toContain('### Beliefs');
     expect(out).toContain('Repo Map');
-    expect(out).toContain('Import-graph only');
+    expect(out).toContain('call-site frequency');
   });
 
   it('records a separate repo-map-tagged ledger entry when the map is emitted', () => {

--- a/packages/nexus-agents/src/context/repo-map-callsites.test.ts
+++ b/packages/nexus-agents/src/context/repo-map-callsites.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the repo-map call-site signal (#4268).
+ *
+ * Covers (a) the pure single-parse call-site tally, (b) the bounded per-module
+ * count over a real temp source tree (incl. the file / probe bounds), and
+ * (c) the ranking flip: a module heavily CALLED but lightly IMPORTED outranks
+ * a more-imported one that pure import PageRank ranked higher.
+ *
+ * @module context/repo-map-callsites.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  CodebaseIndex,
+  ExportEntry,
+  FileEntry,
+  ModuleEntry,
+  ModuleStats,
+} from '../indexer/types.js';
+import { SCHEMA_VERSION } from '../indexer/types.js';
+import { countCallSitesInSource } from '../indexer/usage-ast.js';
+import { MAX_PROBE_SYMBOLS, computeCallSiteCounts } from './repo-map-callsites.js';
+import {
+  getRepoMapForTask,
+  rankRepoMapEntries,
+  REPO_MAP_CAVEAT,
+  REPO_MAP_FLAG,
+} from './repo-map.js';
+
+// ---------------------------------------------------------------------------
+// countCallSitesInSource — single-parse structural call-site tally
+// ---------------------------------------------------------------------------
+
+describe('countCallSitesInSource', () => {
+  const src = [
+    "import { foo } from './x.js';",
+    'export function bar() {}',
+    'foo();',
+    'foo();',
+    'obj.baz();',
+    'const q = new Qux();',
+    'const y = foo;', // bare reference, NOT a call
+    'bar;', // reference to a declared name, NOT a call
+  ].join('\n');
+
+  it('counts calls, member-calls and new — but not declarations, imports or references', () => {
+    const counts = countCallSitesInSource(new Set(['foo', 'baz', 'Qux', 'bar']), src, 'typescript');
+    expect(counts.get('foo')).toBe(2); // two call-sites; the import + reference are excluded
+    expect(counts.get('baz')).toBe(1); // obj.baz() member-call
+    expect(counts.get('Qux')).toBe(1); // new Qux()
+    expect(counts.get('bar')).toBeUndefined(); // only declared + referenced, never called
+  });
+
+  it('returns an empty map for an empty probe set (no work)', () => {
+    expect(countCallSitesInSource(new Set(), src, 'typescript').size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCallSiteCounts — bounded per-module count over a real temp tree
+// ---------------------------------------------------------------------------
+
+function stats(fileCount: number): ModuleStats {
+  return { fileCount, totalLines: 10, exportCount: fileCount, internalDeps: 0, externalDeps: 0 };
+}
+
+function exp(name: string): ExportEntry {
+  return { name, kind: 'function', isReExport: false };
+}
+
+function file(path: string, exports: ExportEntry[]): FileEntry {
+  return { path, lines: 5, category: 'implementation', exports, dependencies: [] };
+}
+
+function mod(name: string, files: FileEntry[], dependsOn: string[]): ModuleEntry {
+  return { name, path: name, purpose: name, files, stats: stats(files.length), dependsOn };
+}
+
+function indexOf(modules: Record<string, ModuleEntry>): CodebaseIndex {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: '2026-07-06T00:00:00-04:00',
+    stats: {
+      totalFiles: 0,
+      totalLines: 0,
+      totalExports: 0,
+      moduleCount: Object.keys(modules).length,
+      externalPackages: [],
+    },
+    modules,
+  };
+}
+
+describe('computeCallSiteCounts (bounded, over a temp source tree)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'repo-map-callsites-'));
+    mkdirSync(join(root, 'core'));
+    mkdirSync(join(root, 'app'));
+    writeFileSync(join(root, 'core', 'helper.ts'), 'export function helper() {\n  return 1;\n}\n');
+    writeFileSync(
+      join(root, 'app', 'main.ts'),
+      "import { helper } from '../core/helper.js';\nhelper();\nhelper();\n"
+    );
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const index = (): CodebaseIndex =>
+    indexOf({
+      core: mod('core', [file('core/helper.ts', [exp('helper')])], []),
+      app: mod('app', [file('app/main.ts', [])], ['core']),
+    });
+
+  it('attributes call-sites of a module’s exports to that module', () => {
+    const counts = computeCallSiteCounts(index(), ['core'], { sourceRoot: root });
+    // helper() is called twice from app/main.ts; the declaration + import do not count.
+    expect(counts.get('core')).toBe(2);
+    expect(counts.get('app')).toBeUndefined();
+  });
+
+  it('respects the maxFiles bound (fewer files scanned ⇒ fewer call-sites seen)', () => {
+    // Only the first file (core/helper.ts, which merely declares helper) is scanned,
+    // so the caller in app/main.ts is never parsed and no call-sites are counted.
+    const counts = computeCallSiteCounts(index(), ['core'], { sourceRoot: root, maxFiles: 1 });
+    expect(counts.get('core') ?? 0).toBe(0);
+  });
+
+  it('probes only the given top-N modules (empty ⇒ no counting)', () => {
+    expect(computeCallSiteCounts(index(), [], { sourceRoot: root }).size).toBe(0);
+  });
+
+  it('is best-effort: a missing source root yields an empty map, never a throw', () => {
+    const counts = computeCallSiteCounts(index(), ['core'], {
+      sourceRoot: join(root, 'does-not-exist'),
+    });
+    expect(counts.size).toBe(0);
+  });
+
+  it('caps the probe set at MAX_PROBE_SYMBOLS', () => {
+    const many = Array.from({ length: MAX_PROBE_SYMBOLS + 40 }, (_, i) => exp(`sym${String(i)}`));
+    writeFileSync(
+      join(root, 'core', 'big.ts'),
+      many.map((e) => `export const ${e.name} = 1;`).join('\n')
+    );
+    const wide = indexOf({ core: mod('core', [file('core/big.ts', many)], []) });
+    // Should not throw and should complete; the cap keeps the probe set bounded.
+    expect(() => computeCallSiteCounts(wide, ['core'], { sourceRoot: root })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ranking flip — call-site signal reorders toward actually-used modules
+// ---------------------------------------------------------------------------
+
+describe('rankRepoMapEntries — call-site signal changes ordering (#4268)', () => {
+  // alpha is imported (by `user`); beta is imported by nobody, so pure import
+  // PageRank ranks alpha above beta. beta is the more heavily CALLED module.
+  function flipIndex(): CodebaseIndex {
+    return indexOf({
+      core: mod('core', [], []),
+      alpha: mod('alpha', [], ['core']),
+      beta: mod('beta', [], ['core']),
+      user: mod('user', [], ['alpha']),
+    });
+  }
+
+  it('pure import ranking puts the more-imported alpha above beta', () => {
+    const order = rankRepoMapEntries(flipIndex()).map((e) => e.module);
+    expect(order.indexOf('alpha')).toBeLessThan(order.indexOf('beta'));
+  });
+
+  it('blending heavy call-sites lifts beta above alpha', () => {
+    const counts = new Map<string, number>([['beta', 25]]);
+    const order = rankRepoMapEntries(flipIndex(), counts).map((e) => e.module);
+    expect(order.indexOf('beta')).toBeLessThan(order.indexOf('alpha'));
+  });
+
+  it('all-zero counts reduce to pure import order (byte-identical ranking)', () => {
+    const pure = rankRepoMapEntries(flipIndex()).map((e) => e.module);
+    const zeroed = rankRepoMapEntries(flipIndex(), new Map([['alpha', 0]])).map((e) => e.module);
+    expect(zeroed).toEqual(pure);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider — flag-on end-to-end with an injected call-site signal
+// ---------------------------------------------------------------------------
+
+describe('getRepoMapForTask — flag-on call-site blend (#4268)', () => {
+  let prev: string | undefined;
+  const flipIndex = (): CodebaseIndex =>
+    indexOf({
+      core: mod('core', [], []),
+      alpha: mod('alpha', [], ['core']),
+      beta: mod('beta', [], ['core']),
+      user: mod('user', [], ['alpha']),
+    });
+
+  beforeEach(() => {
+    prev = process.env[REPO_MAP_FLAG];
+    process.env[REPO_MAP_FLAG] = '1';
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env['NEXUS_REPO_MAP'];
+    else process.env[REPO_MAP_FLAG] = prev;
+  });
+
+  it('renders beta above alpha and shows the call-site count when counts are injected', () => {
+    const out =
+      getRepoMapForTask({
+        task: 'refactor the module architecture',
+        category: 'architecture',
+        indexProvider: flipIndex,
+        callSiteCounts: new Map([['beta', 25]]),
+      }) ?? '';
+    expect(out).toContain('call-sites');
+    expect(out.indexOf('beta')).toBeLessThan(out.indexOf('alpha'));
+    expect(out).toContain(REPO_MAP_CAVEAT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caveat honesty — no stale "no call-site data" claim
+// ---------------------------------------------------------------------------
+
+describe('REPO_MAP_CAVEAT (updated for #4268)', () => {
+  it('no longer claims the map lacks call-site data', () => {
+    expect(REPO_MAP_CAVEAT).not.toMatch(/no call-site|NOT call-site|import-graph only/i);
+  });
+
+  it('is honest about the remaining structural/syntactic limitation', () => {
+    expect(REPO_MAP_CAVEAT).toMatch(/call-site/i);
+    expect(REPO_MAP_CAVEAT).toMatch(/syntactic|not type-aware/i);
+  });
+});

--- a/packages/nexus-agents/src/context/repo-map-callsites.ts
+++ b/packages/nexus-agents/src/context/repo-map-callsites.ts
@@ -1,0 +1,149 @@
+/**
+ * Repo-map call-site signal (#4268, enhancement of #4254 / epic #4251).
+ *
+ * Turns the `search_usages` ast-grep machinery (#4265, shared via
+ * `indexer/usage-ast.ts`) into a per-module **call-site frequency** signal the
+ * repo-map ranker blends with import-graph PageRank, so ranking reflects which
+ * modules are actually *called*, not just imported.
+ *
+ * ## Cost bound (call-site extraction is heavier than the import graph)
+ *
+ * The signal is deliberately bounded so a flag-on structural call cannot blow
+ * the per-call budget or add unbounded latency:
+ *  1. **Probe symbols come only from the TOP-N import-ranked modules**
+ *     ({@link CALLSITE_TOP_N_MODULES}); the whole probe set is capped at
+ *     {@link MAX_PROBE_SYMBOLS}.
+ *  2. **Each source file is parsed at most ONCE** — {@link countCallSitesInSource}
+ *     tallies every probe symbol in a single parse (not one parse per symbol).
+ *  3. **Total files scanned is capped** at {@link MAX_CALLSITE_FILES}.
+ *
+ * Best-effort: any read/parse failure degrades to a partial/empty count (the
+ * ranker then falls back toward import-only ordering) — it never throws into
+ * context assembly.
+ *
+ * @module context/repo-map-callsites
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { CodebaseIndex, ModuleEntry } from '../indexer/types.js';
+import type { ILogger } from '../core/logger.js';
+import { createLogger } from '../core/logger.js';
+import { countCallSitesInSource, inferLang } from '../indexer/usage-ast.js';
+
+/** How many top import-ranked modules contribute probe symbols. */
+export const CALLSITE_TOP_N_MODULES = 25;
+/** Hard cap on the total number of probe symbols scanned per repo-map build. */
+export const MAX_PROBE_SYMBOLS = 60;
+/** Hard cap on files parsed per repo-map build, to bound worst-case latency. */
+export const MAX_CALLSITE_FILES = 4000;
+
+/** Options for {@link computeCallSiteCounts}. */
+export interface CallSiteCountOptions {
+  /**
+   * Root the index's relative file paths resolve against. Defaults to
+   * `<cwd>/src`, matching the default index provider (`extractProject` rootDir).
+   */
+  readonly sourceRoot?: string;
+  /** Cap on files parsed. Defaults to {@link MAX_CALLSITE_FILES}. */
+  readonly maxFiles?: number;
+  /** Optional logger override. */
+  readonly logger?: ILogger;
+}
+
+/** The bounded probe: the tracked symbols + which module each belongs to. */
+interface ProbeSet {
+  readonly symbols: ReadonlySet<string>;
+  readonly owner: ReadonlyMap<string, string>;
+}
+
+interface FileRef {
+  readonly abs: string;
+  readonly rel: string;
+}
+
+function defaultSourceRoot(): string {
+  return resolve(process.cwd(), 'src');
+}
+
+/** Add a module's own (non-re-exported) symbol names to the probe owner map. */
+function addModuleExports(mod: ModuleEntry, name: string, owner: Map<string, string>): void {
+  for (const file of mod.files) {
+    for (const exp of file.exports) {
+      if (exp.isReExport) continue;
+      if (!owner.has(exp.name)) owner.set(exp.name, name);
+      if (owner.size >= MAX_PROBE_SYMBOLS) return;
+    }
+  }
+}
+
+/** Build the bounded probe set from the top import-ranked modules' exports. */
+function buildProbeSet(index: CodebaseIndex, topModuleNames: readonly string[]): ProbeSet {
+  const owner = new Map<string, string>();
+  for (const name of topModuleNames) {
+    const mod = index.modules[name];
+    if (mod === undefined) continue;
+    addModuleExports(mod, name, owner);
+    if (owner.size >= MAX_PROBE_SYMBOLS) break;
+  }
+  return { symbols: new Set(owner.keys()), owner };
+}
+
+/** Deduplicated, capped list of every source file the index knows about. */
+function collectFiles(index: CodebaseIndex, sourceRoot: string, maxFiles: number): FileRef[] {
+  const refs: FileRef[] = [];
+  const seen = new Set<string>();
+  for (const mod of Object.values(index.modules)) {
+    for (const file of mod.files) {
+      if (seen.has(file.path)) continue;
+      seen.add(file.path);
+      refs.push({ abs: resolve(sourceRoot, file.path), rel: file.path });
+      if (refs.length >= maxFiles) return refs;
+    }
+  }
+  return refs;
+}
+
+/** Parse one file once and fold its probe-symbol call-sites into per-module counts. */
+function tallyFile(probe: ProbeSet, ref: FileRef, counts: Map<string, number>, log: ILogger): void {
+  let src: string;
+  try {
+    src = readFileSync(ref.abs, 'utf8');
+  } catch {
+    log.debug('repo-map call-site: unreadable file', { file: ref.rel });
+    return;
+  }
+  for (const [sym, n] of countCallSitesInSource(probe.symbols, src, inferLang(ref.rel))) {
+    const owner = probe.owner.get(sym);
+    if (owner !== undefined) counts.set(owner, (counts.get(owner) ?? 0) + n);
+  }
+}
+
+/**
+ * Count structural call-sites of the top import-ranked modules' exported
+ * symbols across the codebase, returning a `module → call-site count` map used
+ * as a secondary rank signal (#4268). Bounded per the module docstring and
+ * best-effort — a failure yields a partial/empty map, never a throw.
+ */
+export function computeCallSiteCounts(
+  index: CodebaseIndex,
+  topModuleNames: readonly string[],
+  options: CallSiteCountOptions = {}
+): Map<string, number> {
+  const log = options.logger ?? createLogger({ component: 'RepoMapCallSites' });
+  const counts = new Map<string, number>();
+  try {
+    const probe = buildProbeSet(index, topModuleNames);
+    if (probe.symbols.size === 0) return counts;
+    const sourceRoot = options.sourceRoot ?? defaultSourceRoot();
+    const maxFiles = options.maxFiles ?? MAX_CALLSITE_FILES;
+    for (const ref of collectFiles(index, sourceRoot, maxFiles)) {
+      tallyFile(probe, ref, counts, log);
+    }
+  } catch (error: unknown) {
+    log.debug('repo-map call-site counting failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return counts;
+}

--- a/packages/nexus-agents/src/context/repo-map.ts
+++ b/packages/nexus-agents/src/context/repo-map.ts
@@ -1,12 +1,15 @@
 /**
  * Repo-map context provider — pull-shaped, usage-aware, measured (#4254,
- * Phase 3 of epic #4251).
+ * Phase 3 of epic #4251; call-site signal added in #4268).
  *
  * Wires the EXISTING module-import graph (`indexer/types.ts`
  * `ModuleEntry.dependsOn`, built by `analyzer.ts buildIndex`, until now
  * emitted only as docs/mermaid) into context assembly as a **ranked,
- * token-budgeted repo-map**. Modules are ordered by PageRank centrality over
- * the import graph, then budget-clipped to a small token target.
+ * token-budgeted repo-map**. Modules are ordered by import-graph PageRank
+ * centrality **blended with real call-site frequency** (#4268 — the
+ * `search_usages` ast-grep signal, `context/repo-map-callsites.ts`), then
+ * budget-clipped to a small token target so heavily-*called* modules surface,
+ * not just heavily-imported ones.
  *
  * ## Shaped exactly as the consensus vote (#4251) constrained it
  *
@@ -17,12 +20,18 @@
  * 2. **Pull-shaped / rank-gated.** Even with the flag on, the map is produced
  *    ONLY for tasks that plausibly span multiple modules ({@link taskNeedsRepoMap}) —
  *    never pushed onto 100% of calls (the rejected eager-RAG anti-pattern).
- * 3. **PageRank ranking** over the import graph orders entries; the block is
+ * 3. **PageRank + call-site ranking.** Import-graph PageRank is the base score;
+ *    a bounded per-module call-site count ({@link computeCallSiteCounts}) is
+ *    blended in as a secondary signal ({@link blendRankScore}). The block is
  *    then clipped to a token budget (reusing the #4253 char/4 mechanism —
  *    {@link clampToTokenBudget}).
- * 4. **Usage-aware caveat.** The graph is import-edges + declaration-names only
- *    (NO call-site edges yet — that is #4249-A). Every rendered map carries an
- *    explicit {@link REPO_MAP_CAVEAT} so agents do not over-trust it as a call graph.
+ * 4. **Honest caveat.** Call-site data IS incorporated, but structural matching
+ *    is syntactic (no type checker): dynamic dispatch, computed/string-keyed
+ *    calls, and same-named members on unrelated objects are not resolved, and
+ *    the call-site signal only samples the top import-ranked modules. Every
+ *    rendered map carries an explicit {@link REPO_MAP_CAVEAT} at the top so
+ *    agents treat centrality as an approximate structural+usage signal, not an
+ *    exact call graph.
  * 5. **Measured.** The emitted token count is recorded in the token ledger
  *    tagged `contextSource: 'repo-map'` by the `context-retriever.ts` wiring.
  * 6. **Fresh, not persisted.** The default index provider builds from the
@@ -30,8 +39,8 @@
  *    stale-map path. (A scoped index cache is a tracked follow-up; the
  *    provider is opt-in + rank-gated so the build cost is only paid when asked.)
  *
- * Pure builder + fail-soft provider: a build failure yields `undefined`, never
- * a throw into the calling context assembly.
+ * Pure builder + fail-soft provider: a build (or call-site) failure degrades to
+ * import-only ranking / `undefined`, never a throw into context assembly.
  *
  * @module context/repo-map
  */
@@ -43,6 +52,7 @@ import { createLogger } from '../core/logger.js';
 import { extractProject } from '../indexer/extractor.js';
 import { buildIndex } from '../indexer/analyzer.js';
 import { clampToTokenBudget } from './context-retriever-helpers.js';
+import { CALLSITE_TOP_N_MODULES, computeCallSiteCounts } from './repo-map-callsites.js';
 
 // ============================================================================
 // Public constants
@@ -55,18 +65,22 @@ export const REPO_MAP_FLAG = 'NEXUS_REPO_MAP';
 export const DEFAULT_REPO_MAP_TOKEN_BUDGET = 400;
 
 /**
- * Mandatory usage caveat (#4254 constraint 4). The graph is import-edges +
- * declaration-names only — there are NO call-site/usage edges yet (that is
- * #4249-A). This caveat is rendered at the TOP of every map so a prefix-cut
- * budget clamp can never remove it.
+ * Mandatory honesty caveat (#4254 constraint 4, updated in #4268 once call-site
+ * data landed). Ranking now blends import PageRank with real call-site
+ * frequency, so the old "no call-site data" wording is gone. The remaining,
+ * honest limitation is that call-site matching is structural/syntactic (no type
+ * checker). Rendered at the TOP of every map so a prefix-cut budget clamp can
+ * never remove it.
  */
 export const REPO_MAP_CAVEAT =
-  'Import-graph only: edges are module import dependencies + declaration names, ' +
-  'NOT call-site/usage data. Centrality reflects import structure, not runtime ' +
-  'call frequency — do not treat this as a call graph (call-site edges tracked in #4249-A).';
+  'Ranking blends import-graph PageRank with structural call-site frequency ' +
+  '(ast-grep, sampled over the top import-ranked modules). Call-site matching is ' +
+  'syntactic, not type-aware: dynamic dispatch, computed/string-keyed calls, and ' +
+  'same-named members on unrelated objects are not resolved — treat centrality as ' +
+  'an approximate structural+usage signal, not an exact call graph.';
 
 /** Section header for the rendered repo-map block. */
-const REPO_MAP_HEADER = '## Repo Map (module import graph — PageRank-ranked)';
+const REPO_MAP_HEADER = '## Repo Map (module import graph + call-site usage — ranked)';
 
 // ============================================================================
 // PageRank over the module-import graph
@@ -163,12 +177,14 @@ function l1Delta(a: Map<string, number>, b: Map<string, number>): number {
 // Ranked entries
 // ============================================================================
 
-/** One repo-map row: a module with its centrality and import edges. */
+/** One repo-map row: a module with its centrality, call-site count, and import edges. */
 export interface RepoMapEntry {
   /** Module name. */
   readonly module: string;
   /** PageRank centrality in [0, 1]. */
   readonly centrality: number;
+  /** Structural call-sites of this module's exported symbols (#4268; 0 when no call-site data). */
+  readonly callSites: number;
   /** Module purpose (from the index). */
   readonly purpose: string;
   /** Modules this module imports (out-edges). */
@@ -178,21 +194,61 @@ export interface RepoMapEntry {
 }
 
 /**
- * Rank every module in the index by PageRank centrality (descending; ties
- * broken by name for a deterministic order). Pure.
+ * Weight of the call-site signal relative to import centrality (#4268). At
+ * `2`, a max-called module scores up to 3× its centrality, so a heavily-called
+ * but lightly-imported module can overtake a lightly-called one with up to ~3×
+ * its centrality — enough to measurably reorder toward actually-used modules
+ * while keeping import centrality as the base signal.
  */
-export function rankRepoMapEntries(index: CodebaseIndex): readonly RepoMapEntry[] {
+const CALL_SITE_WEIGHT = 2;
+
+/** Blend import centrality with a normalized call-site count into the sort score (#4268). */
+export function blendRankScore(
+  centrality: number,
+  callSites: number,
+  maxCallSites: number
+): number {
+  if (maxCallSites <= 0) return centrality;
+  return centrality * (1 + CALL_SITE_WEIGHT * (callSites / maxCallSites));
+}
+
+/** Largest call-site count across modules, used to normalize the blend. */
+function maxCount(counts: ReadonlyMap<string, number>): number {
+  let max = 0;
+  for (const v of counts.values()) if (v > max) max = v;
+  return max;
+}
+
+/**
+ * Rank every module in the index by import-graph PageRank centrality blended
+ * with call-site frequency (#4268) — descending, ties broken by name for a
+ * deterministic order. With no `callSiteCounts` (or all-zero counts) the score
+ * reduces to pure centrality, so import-only callers rank identically. Pure.
+ */
+export function rankRepoMapEntries(
+  index: CodebaseIndex,
+  callSiteCounts?: ReadonlyMap<string, number>
+): readonly RepoMapEntry[] {
   const ranks = computeModulePageRank(index.modules);
-  const entries: RepoMapEntry[] = Object.entries(index.modules).map(([name, mod]) => ({
-    module: name,
-    centrality: ranks.get(name) ?? 0,
-    purpose: mod.purpose,
-    dependsOn: mod.dependsOn,
-    fileCount: mod.stats.fileCount,
-  }));
-  return entries.sort((a, b) =>
-    b.centrality !== a.centrality ? b.centrality - a.centrality : a.module.localeCompare(b.module)
+  const counts = callSiteCounts ?? new Map<string, number>();
+  const max = maxCount(counts);
+  const scored = Object.entries(index.modules).map(([name, mod]) => {
+    const centrality = ranks.get(name) ?? 0;
+    const callSites = counts.get(name) ?? 0;
+    const entry: RepoMapEntry = {
+      module: name,
+      centrality,
+      callSites,
+      purpose: mod.purpose,
+      dependsOn: mod.dependsOn,
+      fileCount: mod.stats.fileCount,
+    };
+    return { entry, score: blendRankScore(centrality, callSites, max) };
+  });
+  scored.sort((a, b) =>
+    b.score !== a.score ? b.score - a.score : a.entry.module.localeCompare(b.entry.module)
   );
+  return scored.map((s) => s.entry);
 }
 
 // ============================================================================
@@ -203,6 +259,8 @@ export function rankRepoMapEntries(index: CodebaseIndex): readonly RepoMapEntry[
 export interface BuildRepoMapOptions {
   /** Token budget for the rendered block. Defaults to {@link DEFAULT_REPO_MAP_TOKEN_BUDGET}. */
   readonly budgetTokens?: number;
+  /** Per-module call-site counts to blend into ranking (#4268). Absent ⇒ import-only order. */
+  readonly callSiteCounts?: ReadonlyMap<string, number>;
 }
 
 /** Rough chars-per-token estimate, matching {@link clampToTokenBudget} / token-counter (~4). */
@@ -221,7 +279,7 @@ const MAX_LINE_CHARS = 200;
  * caveat (#4254 constraint 4). Empty index → empty string. Pure.
  */
 export function buildRepoMap(index: CodebaseIndex, options: BuildRepoMapOptions = {}): string {
-  const entries = rankRepoMapEntries(index);
+  const entries = rankRepoMapEntries(index, options.callSiteCounts);
   if (entries.length === 0) return '';
   const budget = options.budgetTokens ?? DEFAULT_REPO_MAP_TOKEN_BUDGET;
   return renderRepoMap(entries, budget);
@@ -243,12 +301,13 @@ function renderRepoMap(entries: readonly RepoMapEntry[], budgetTokens: number): 
   return `${preamble}${body}${notice}`;
 }
 
-/** Render one module row: `- name (centrality, files): purpose → dep, dep`. */
+/** Render one module row: `- name (centrality, N call-sites, files): purpose → dep, dep`. */
 function formatEntryLine(e: RepoMapEntry): string {
   const shownDeps = e.dependsOn.slice(0, MAX_DEPS_PER_LINE);
   const more = e.dependsOn.length > MAX_DEPS_PER_LINE ? ', …' : '';
   const deps = shownDeps.length > 0 ? ` → ${shownDeps.join(', ')}${more}` : '';
-  const line = `- ${e.module} (centrality ${e.centrality.toFixed(3)}, ${String(e.fileCount)} files): ${oneLine(e.purpose)}${deps}`;
+  const calls = e.callSites > 0 ? `, ${String(e.callSites)} call-sites` : '';
+  const line = `- ${e.module} (centrality ${e.centrality.toFixed(3)}${calls}, ${String(e.fileCount)} files): ${oneLine(e.purpose)}${deps}`;
   return line.slice(0, MAX_LINE_CHARS);
 }
 
@@ -323,6 +382,12 @@ export interface RepoMapProviderOptions {
    * stale map). Injected in tests for a deterministic fixture graph.
    */
   readonly indexProvider?: () => CodebaseIndex;
+  /**
+   * Injectable per-module call-site counts (#4268). Defaults to a live,
+   * bounded {@link computeCallSiteCounts} pass over the index. Injected in tests
+   * for a deterministic call-site signal without touching disk.
+   */
+  readonly callSiteCounts?: ReadonlyMap<string, number>;
   /** Optional logger override. */
   readonly logger?: ILogger;
 }
@@ -331,8 +396,10 @@ export interface RepoMapProviderOptions {
  * Produce a ranked, budgeted repo-map for a task — or `undefined`. Returns
  * `undefined` (doing no work) when the `NEXUS_REPO_MAP` flag is off or the
  * task doesn't plausibly need cross-file structure, so it is safe to call
- * unconditionally from context assembly. Fail-soft: any index-build or render
- * error is logged at debug and yields `undefined`, never a throw.
+ * unconditionally from context assembly. Ranking blends import PageRank with a
+ * bounded call-site signal (#4268). Fail-soft: any index-build, call-site, or
+ * render error is logged at debug and yields `undefined` / import-only order,
+ * never a throw.
  */
 export function getRepoMapForTask(options: RepoMapProviderOptions): string | undefined {
   if (process.env[REPO_MAP_FLAG] !== '1') return undefined;
@@ -340,8 +407,10 @@ export function getRepoMapForTask(options: RepoMapProviderOptions): string | und
   const log = options.logger ?? createLogger({ component: 'RepoMap' });
   try {
     const index = (options.indexProvider ?? buildLiveIndex)();
+    const callSiteCounts = options.callSiteCounts ?? liveCallSiteCounts(index, log);
     const map = buildRepoMap(index, {
       budgetTokens: options.budgetTokens ?? DEFAULT_REPO_MAP_TOKEN_BUDGET,
+      callSiteCounts,
     });
     return map === '' ? undefined : map;
   } catch (error: unknown) {
@@ -350,6 +419,20 @@ export function getRepoMapForTask(options: RepoMapProviderOptions): string | und
     });
     return undefined;
   }
+}
+
+/**
+ * Compute the bounded call-site signal for a live index: take the TOP-N
+ * import-ranked modules ({@link CALLSITE_TOP_N_MODULES}) and count structural
+ * call-sites of their exported symbols across the tree (#4268). Best-effort —
+ * {@link computeCallSiteCounts} never throws; a failure yields an empty map and
+ * ranking degrades to import-only order.
+ */
+function liveCallSiteCounts(index: CodebaseIndex, log: ILogger): ReadonlyMap<string, number> {
+  const topModules = rankRepoMapEntries(index)
+    .slice(0, CALLSITE_TOP_N_MODULES)
+    .map((e) => e.module);
+  return computeCallSiteCounts(index, topModules, { logger: log });
 }
 
 /**

--- a/packages/nexus-agents/src/indexer/usage-ast.ts
+++ b/packages/nexus-agents/src/indexer/usage-ast.ts
@@ -1,0 +1,225 @@
+/**
+ * nexus-agents/indexer - Shared structural usage / call-site AST core.
+ *
+ * The ast-grep (`@ast-grep/napi`, MIT, Rust + tree-sitter) primitives that
+ * answer "where is symbol X used / called". Extracted from the `search_usages`
+ * MCP tool (#4265 / epic #4249 Child A) so a SECOND consumer — the repo-map
+ * ranker (#4268) — can reuse the exact same call-site-finding logic instead of
+ * duplicating the ast-grep querying or going through the MCP tool layer.
+ *
+ * Two entry points share the same classification core:
+ *  - {@link findUsagesInSource} — every usage of ONE symbol (call, member call,
+ *    `new`, import, reference), the `search_usages` tool's per-symbol scan.
+ *  - {@link countCallSitesInSource} — a SINGLE-parse tally of how often each of
+ *    MANY symbols is *called* (call / member-call / `new`) in a source, the
+ *    bounded signal the repo-map needs (one parse per file, not one per symbol).
+ *
+ * Syntactic, not type-aware: matches are structural and are NOT resolved
+ * against a type checker — a member call on an unrelated object of the same
+ * property name will match. That is the documented ast-grep trade-off.
+ *
+ * @module indexer/usage-ast
+ */
+
+import { extname } from 'node:path';
+import { Lang, parse } from '@ast-grep/napi';
+import type { NapiConfig, SgNode } from '@ast-grep/napi';
+
+// ============================================================================
+// Language + identifier primitives
+// ============================================================================
+
+export const LANG_VALUES = ['typescript', 'tsx', 'javascript'] as const;
+export type SupportedLang = (typeof LANG_VALUES)[number];
+
+/** Per-match snippet char cap. */
+const MAX_SNIPPET_CHARS = 200;
+
+/** A single JS identifier — anchored so a symbol can't smuggle ast-grep pattern metachars. */
+export const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/** The kind of a usage site. Declarations are excluded (that is the name index's job). */
+export type UsageKind = 'call' | 'method-call' | 'new' | 'import' | 'reference';
+
+/** Usage kinds that represent an actual call-site (what the repo-map ranks on). */
+const CALL_USAGE_KINDS: ReadonlySet<UsageKind> = new Set<UsageKind>(['call', 'method-call', 'new']);
+
+/** A single usage match within one source string. */
+export interface UsageMatch {
+  /** 1-based line number. */
+  line: number;
+  /** 1-based column number. */
+  column: number;
+  kind: UsageKind;
+  /** Trimmed, length-capped source line for the match. */
+  snippet: string;
+}
+
+/** Identifier parents whose matched identifier IS the declared name — not a usage. */
+const DECLARATION_PARENT_KINDS = new Set<string>([
+  'function_declaration',
+  'generator_function_declaration',
+  'class_declaration',
+  'interface_declaration',
+  'type_alias_declaration',
+  'enum_declaration',
+  'function_signature',
+  'method_definition',
+  'abstract_method_signature',
+]);
+
+/** Identifier parents that denote an import binding. */
+const IMPORT_PARENT_KINDS = new Set<string>([
+  'import_specifier',
+  'namespace_import',
+  'import_clause',
+]);
+
+function langToNapi(lang: SupportedLang): Lang {
+  if (lang === 'tsx') return Lang.Tsx;
+  if (lang === 'javascript') return Lang.JavaScript;
+  return Lang.TypeScript;
+}
+
+/** Infer the ast-grep language for a file from its extension. */
+export function inferLang(file: string): SupportedLang {
+  const ext = extname(file).toLowerCase();
+  if (ext === '.tsx' || ext === '.jsx') return 'tsx';
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') return 'javascript';
+  return 'typescript';
+}
+
+/** Escape regex metacharacters so a `$`-bearing identifier anchors correctly. */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ============================================================================
+// Classification
+// ============================================================================
+
+/** True when the identifier `node` is the `name` field of its variable_declarator parent. */
+function isDeclaredName(declarator: SgNode, node: SgNode): boolean {
+  const name = declarator.field('name');
+  return name !== null && name.id() === node.id();
+}
+
+/** Classify a plain `identifier` occurrence; returns null when it is a declaration name to skip. */
+function classifyIdentifier(node: SgNode): UsageKind | null {
+  const parent = node.parent();
+  if (parent === null) return 'reference';
+  const pk = String(parent.kind());
+  if (DECLARATION_PARENT_KINDS.has(pk)) return null;
+  if (pk === 'variable_declarator') return isDeclaredName(parent, node) ? null : 'reference';
+  if (IMPORT_PARENT_KINDS.has(pk)) return 'import';
+  if (pk === 'call_expression') return 'call';
+  if (pk === 'new_expression') return 'new';
+  return 'reference';
+}
+
+/** Classify a `property_identifier` occurrence (member access): method-call vs plain reference. */
+function classifyProperty(node: SgNode): UsageKind {
+  const member = node.parent();
+  const grandparent = member === null ? null : member.parent();
+  if (grandparent !== null && String(grandparent.kind()) === 'call_expression')
+    return 'method-call';
+  return 'reference';
+}
+
+function toMatch(node: SgNode, kind: UsageKind, lines: readonly string[]): UsageMatch {
+  const { start } = node.range();
+  const rawLine = lines[start.line] ?? node.text();
+  return {
+    line: start.line + 1,
+    column: start.column + 1,
+    kind,
+    snippet: rawLine.trim().slice(0, MAX_SNIPPET_CHARS),
+  };
+}
+
+// ============================================================================
+// Single-symbol scan (search_usages)
+// ============================================================================
+
+/**
+ * Find every structural usage of `symbol` in `src`. Returns call-sites, member
+ * calls, `new` expressions, imports, and bare references — but NOT the symbol's
+ * own declaration (that is what `search_codebase`'s name index already covers).
+ * Sorted by position. This is the capability `search_codebase` cannot provide.
+ */
+export function findUsagesInSource(symbol: string, src: string, lang: SupportedLang): UsageMatch[] {
+  if (!IDENTIFIER_RE.test(symbol)) return [];
+  const root = parse(langToNapi(lang), src).root();
+  const lines = src.split('\n');
+  const out: UsageMatch[] = [];
+
+  for (const node of root.findAll(symbol)) {
+    const kind = classifyIdentifier(node);
+    if (kind !== null) out.push(toMatch(node, kind, lines));
+  }
+
+  // Member-access occurrences are `property_identifier` nodes, which the bare
+  // identifier pattern above does not match — collect them via a kind rule.
+  const propRule: NapiConfig = {
+    rule: { kind: 'property_identifier', regex: `^${escapeRegex(symbol)}$` },
+  };
+  for (const node of root.findAll(propRule)) {
+    out.push(toMatch(node, classifyProperty(node), lines));
+  }
+
+  return out.sort((a, b) => a.line - b.line || a.column - b.column);
+}
+
+// ============================================================================
+// Multi-symbol call-site tally (repo-map ranking, #4268)
+// ============================================================================
+
+/** Bump the tally for `name` when it is one of the tracked symbols. */
+function bump(counts: Map<string, number>, symbols: ReadonlySet<string>, name: string): void {
+  if (symbols.has(name)) counts.set(name, (counts.get(name) ?? 0) + 1);
+}
+
+/** Tally call-kind occurrences of tracked plain-identifier symbols in one parse. */
+function tallyIdentifierCalls(
+  root: SgNode,
+  symbols: ReadonlySet<string>,
+  counts: Map<string, number>
+): void {
+  for (const node of root.findAll({ rule: { kind: 'identifier' } })) {
+    const kind = classifyIdentifier(node);
+    if (kind !== null && CALL_USAGE_KINDS.has(kind)) bump(counts, symbols, node.text());
+  }
+}
+
+/** Tally method-call occurrences of tracked member-access symbols in one parse. */
+function tallyPropertyCalls(
+  root: SgNode,
+  symbols: ReadonlySet<string>,
+  counts: Map<string, number>
+): void {
+  for (const node of root.findAll({ rule: { kind: 'property_identifier' } })) {
+    if (CALL_USAGE_KINDS.has(classifyProperty(node))) bump(counts, symbols, node.text());
+  }
+}
+
+/**
+ * Count structural CALL-SITES (call / member-call / `new`) of any symbol in
+ * `symbols` within `src`, in a SINGLE parse — the bounded signal the repo-map
+ * ranks on (#4268). Returns per-symbol counts (symbols with zero call-sites are
+ * absent). Excludes declarations, imports, and bare references — only actual
+ * call-sites, since that is what "how used is this module" means for ranking.
+ * Syntactic like {@link findUsagesInSource}: same-named members on unrelated
+ * objects can match; that is the documented ast-grep trade-off.
+ */
+export function countCallSitesInSource(
+  symbols: ReadonlySet<string>,
+  src: string,
+  lang: SupportedLang
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  if (symbols.size === 0) return counts;
+  const root = parse(langToNapi(lang), src).root();
+  tallyIdentifierCalls(root, symbols, counts);
+  tallyPropertyCalls(root, symbols, counts);
+  return counts;
+}

--- a/packages/nexus-agents/src/mcp/tools/search-usages-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/search-usages-tool.ts
@@ -22,13 +22,18 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { extname, relative, resolve, sep } from 'node:path';
+import { relative, resolve, sep } from 'node:path';
 import { z } from 'zod';
-import { Lang, parse } from '@ast-grep/napi';
-import type { NapiConfig, SgNode } from '@ast-grep/napi';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import { findSourceFiles } from '../../indexer/codebase-search.js';
+import {
+  IDENTIFIER_RE,
+  LANG_VALUES,
+  findUsagesInSource,
+  inferLang,
+  type UsageMatch,
+} from '../../indexer/usage-ast.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -38,6 +43,13 @@ import {
   type ToolResult,
 } from './tool-result.js';
 import { getToolAnnotations } from '../tool-annotations.js';
+
+// The structural usage/call-site AST core moved to `indexer/usage-ast.ts` so a
+// second consumer (the repo-map ranker, #4268) can reuse it without going
+// through this MCP tool layer. Re-exported here so the #4265 tool module stays
+// the public import site for existing consumers (mcp/tools/index.ts, tests).
+export { findUsagesInSource };
+export type { UsageKind, UsageMatch } from '../../indexer/usage-ast.js';
 
 // ============================================================================
 // Constants + output cap (reuses the #4253 output-cap discipline)
@@ -53,18 +65,10 @@ const DEFAULT_USAGES_MAX_DEPTH = 24;
 const MAX_USAGES_MAX_DEPTH = 64;
 /** Upper bound on files parsed in a single dir-scope search, to bound worst-case cost. */
 const MAX_FILES_SCANNED = 5000;
-/** Per-match snippet char cap. */
-const MAX_SNIPPET_CHARS = 200;
-
-/** A single JS identifier — anchored so a symbol can't smuggle ast-grep pattern metachars. */
-const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 // ============================================================================
 // Input Schema
 // ============================================================================
-
-const LANG_VALUES = ['typescript', 'tsx', 'javascript'] as const;
-type SupportedLang = (typeof LANG_VALUES)[number];
 
 export const SearchUsagesInputSchema = z.object({
   symbol: z
@@ -113,133 +117,8 @@ export type SearchUsagesInput = z.infer<typeof SearchUsagesInputSchema>;
 export type SearchUsagesDeps = BaseMcpToolDeps;
 
 // ============================================================================
-// Core: structural usage matching via ast-grep
-// ============================================================================
-
-/** The kind of a usage site. Declarations are excluded (that is the name index's job). */
-export type UsageKind = 'call' | 'method-call' | 'new' | 'import' | 'reference';
-
-/** A single usage match within one source string. */
-export interface UsageMatch {
-  /** 1-based line number. */
-  line: number;
-  /** 1-based column number. */
-  column: number;
-  kind: UsageKind;
-  /** Trimmed, length-capped source line for the match. */
-  snippet: string;
-}
-
-/** Identifier parents whose matched identifier IS the declared name — not a usage. */
-const DECLARATION_PARENT_KINDS = new Set<string>([
-  'function_declaration',
-  'generator_function_declaration',
-  'class_declaration',
-  'interface_declaration',
-  'type_alias_declaration',
-  'enum_declaration',
-  'function_signature',
-  'method_definition',
-  'abstract_method_signature',
-]);
-
-/** Identifier parents that denote an import binding. */
-const IMPORT_PARENT_KINDS = new Set<string>([
-  'import_specifier',
-  'namespace_import',
-  'import_clause',
-]);
-
-function langToNapi(lang: SupportedLang): Lang {
-  if (lang === 'tsx') return Lang.Tsx;
-  if (lang === 'javascript') return Lang.JavaScript;
-  return Lang.TypeScript;
-}
-
-/** Escape regex metacharacters so a `$`-bearing identifier anchors correctly. */
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** True when the identifier `node` is the `name` field of its variable_declarator parent. */
-function isDeclaredName(declarator: SgNode, node: SgNode): boolean {
-  const name = declarator.field('name');
-  return name !== null && name.id() === node.id();
-}
-
-/** Classify a plain `identifier` occurrence; returns null when it is a declaration name to skip. */
-function classifyIdentifier(node: SgNode): UsageKind | null {
-  const parent = node.parent();
-  if (parent === null) return 'reference';
-  const pk = String(parent.kind());
-  if (DECLARATION_PARENT_KINDS.has(pk)) return null;
-  if (pk === 'variable_declarator') return isDeclaredName(parent, node) ? null : 'reference';
-  if (IMPORT_PARENT_KINDS.has(pk)) return 'import';
-  if (pk === 'call_expression') return 'call';
-  if (pk === 'new_expression') return 'new';
-  return 'reference';
-}
-
-/** Classify a `property_identifier` occurrence (member access): method-call vs plain reference. */
-function classifyProperty(node: SgNode): UsageKind {
-  const member = node.parent();
-  const grandparent = member === null ? null : member.parent();
-  if (grandparent !== null && String(grandparent.kind()) === 'call_expression')
-    return 'method-call';
-  return 'reference';
-}
-
-function toMatch(node: SgNode, kind: UsageKind, lines: readonly string[]): UsageMatch {
-  const { start } = node.range();
-  const rawLine = lines[start.line] ?? node.text();
-  return {
-    line: start.line + 1,
-    column: start.column + 1,
-    kind,
-    snippet: rawLine.trim().slice(0, MAX_SNIPPET_CHARS),
-  };
-}
-
-/**
- * Find every structural usage of `symbol` in `src`. Returns call-sites, member
- * calls, `new` expressions, imports, and bare references — but NOT the symbol's
- * own declaration (that is what `search_codebase`'s name index already covers).
- * Sorted by position. This is the capability `search_codebase` cannot provide.
- */
-export function findUsagesInSource(symbol: string, src: string, lang: SupportedLang): UsageMatch[] {
-  if (!IDENTIFIER_RE.test(symbol)) return [];
-  const root = parse(langToNapi(lang), src).root();
-  const lines = src.split('\n');
-  const out: UsageMatch[] = [];
-
-  for (const node of root.findAll(symbol)) {
-    const kind = classifyIdentifier(node);
-    if (kind !== null) out.push(toMatch(node, kind, lines));
-  }
-
-  // Member-access occurrences are `property_identifier` nodes, which the bare
-  // identifier pattern above does not match — collect them via a kind rule.
-  const propRule: NapiConfig = {
-    rule: { kind: 'property_identifier', regex: `^${escapeRegex(symbol)}$` },
-  };
-  for (const node of root.findAll(propRule)) {
-    out.push(toMatch(node, classifyProperty(node), lines));
-  }
-
-  return out.sort((a, b) => a.line - b.line || a.column - b.column);
-}
-
-// ============================================================================
 // File scope resolution + gathering
 // ============================================================================
-
-/** Infer the ast-grep language for a file from its extension. */
-function inferLang(file: string): SupportedLang {
-  const ext = extname(file).toLowerCase();
-  if (ext === '.tsx' || ext === '.jsx') return 'tsx';
-  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') return 'javascript';
-  return 'typescript';
-}
 
 /** Resolve a caller path against a path-traversal guard (must stay within cwd). */
 function resolveWithinCwd(target: string): { resolved: string } | { error: string } {


### PR DESCRIPTION
## What

The repo-map context provider (`context/repo-map.ts`, behind default-off `NEXUS_REPO_MAP`) previously ranked modules by PageRank over the **import graph only**, carrying a mandatory "import-graph only, no call-site data" caveat. #4265 shipped `search_usages` (ast-grep call-site search) in v2.169.0, so the repo-map can now rank by **real call-site frequency**. This closes #4268 (enhancement of #4254, epic #4251).

## How the call-site signal is incorporated — secondary rank key (not new graph edges)

Chosen the **simpler** of the two options in the issue: a per-module call-site count blended as a **secondary rank signal**, not new PageRank edges.

- `rankRepoMapEntries` now scores each module `centrality × (1 + 2 × normalizedCallSites)`, then sorts by that blended score (name tiebreak). Import-graph PageRank stays the base signal; the call-site count lifts actually-*called* modules.
- **Why secondary key over call-site edges:** edges require attributing each call-site to a *source* module (caller→callee resolution) and re-running PageRank over a merged graph — materially more code and cost. A per-module call-site *count* needs only the callee, reuses the existing PageRank unchanged, and measurably reorders toward used modules (proven by the ordering test). With no/zero counts the score reduces to pure centrality, so import-only behavior is preserved exactly.

Reuse, not duplication: the `search_usages` ast-grep core (#4265) was **extracted** to shared `indexer/usage-ast.ts` (re-exported from the tool for existing consumers), plus a new single-parse multi-symbol `countCallSitesInSource`. No new dependency (`@ast-grep/napi` already present); read-only.

## New caveat text

> Ranking blends import-graph PageRank with structural call-site frequency (ast-grep, sampled over the top import-ranked modules). Call-site matching is syntactic, not type-aware: dynamic dispatch, computed/string-keyed calls, and same-named members on unrelated objects are not resolved — treat centrality as an approximate structural+usage signal, not an exact call graph.

The stale "no call-site data" wording is gone; the remaining honest limitation (syntactic matching) is stated.

## Cost bound

Call-site extraction (`context/repo-map-callsites.ts`) is bounded so a flag-on structural call can't blow the budget:
- Probe symbols come only from the **top-N = 25** import-ranked modules' exports, capped at **60** total probe symbols.
- **One parse per file** (single-parse multi-symbol tally), not one per symbol.
- Files scanned capped at **4000**.
- Best-effort: any read/parse failure degrades to import-only ranking; never throws into context assembly.

## Invariants held

- **Default OFF** via `NEXUS_REPO_MAP`; **flag-off ⇒ `getContextForTask` byte-for-byte unchanged** — the existing `context-retriever.test.ts` flag-off test is unmodified and still passes (flag check returns `undefined` before any call-site work).
- Pull-gated, budget-clipped, ledger entry stays tagged `contextSource: 'repo-map'`, fresh-not-persisted, read-only.
- #4262 (flip default-ON) stays **out of scope** — this improves the numbers that gate feeds.

## Tests (red/green TDD)

- **Ordering flip:** a module heavily *called* but lightly *imported* ranks above a more-imported one that pure import-PageRank ranked higher (`rankRepoMapEntries` + end-to-end `getRepoMapForTask`).
- **Caveat:** asserts the caveat no longer claims "no call-site data" and states the syntactic limitation.
- **Bound:** `computeCallSiteCounts` respects the top-N/probe-cap/maxFiles bounds (over a real temp tree) and is best-effort on missing sources.
- **Pure tally:** `countCallSitesInSource` counts calls/member-calls/`new`, excludes declarations/imports/references.
- Full suite green: **27,578 passed / 16 skipped**; build, typecheck, lint all clean. Changeset (minor) included.

Refs #4268, #4251, #4254, #4265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)