### PR TITLE
feat(security): polyglot Python/Go ast-grep QA/security rules — read-only runAstQaRules (#4249 child C)

### DIFF
--- a/.changeset/ast-qa-polyglot-rules.md
+++ b/.changeset/ast-qa-polyglot-rules.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+feat(security): polyglot (Python/Go) ast-grep QA/security rules via read-only runAstQaRules (#4249 child C)
+
+Adds a new read-only `runAstQaRules` runner (`security/ast-rule-runner.ts`,
+exported from `exports/security.ts`) that runs YAML-defined `@ast-grep/napi`
+rules against Python/Go source, detecting dynamic `eval`/`exec`, shell
+injection (`os.system`/`subprocess(..., shell=True)`), and unchecked external
+command execution (`exec.Command`). Ships three built-in rules under
+`security/ast-rules/*.yml` plus fixtures with both positive hits and
+near-miss negatives (`evaluate`/`executor`/no-`shell=True`/local `Command`
+helper/aliased `myexec.Command`), mirroring the #4243 lesson that a rule
+which "sort of" matches over-fires on lookalikes.
+
+`@ast-grep/napi@0.44.1`'s `Lang` enum has no Python/Go, so this adds the
+dynamic-language grammar packages `@ast-grep/lang-python@0.0.6` and
+`@ast-grep/lang-go@0.0.6` (both EXACT-pinned — early/experimental packages
+where a caret range could silently swap in an incompatible native `.so`
+grammar build) and registers them once per process via a lazy
+`ensurePolyglotLangs()` singleton, since napi's `@experimental
+registerDynamicLanguage` throws if called more than once. Both grammar
+packages are added to tsup's `external` list — like the other native-addon
+deps — since they resolve their prebuilt `.so` via a `__dirname`-relative
+lookup that bundling would break.
+
+Detection-only by construction: ast-grep's YAML `fix:` key is never read by
+`SgNode.findAll` (only ast-grep's separate CLI/rewrite machinery applies it),
+so this runner cannot become a writer even if a rule author adds one.
+
+MCP exposure is deferred to a follow-up issue to keep this surface a plain
+function until a named consumer needs it wired through a tool.

--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -20,6 +20,7 @@
     "dist",
     "scripts/postinstall.js",
     "src/workflows/templates",
+    "src/security/ast-rules",
     "README.md"
   ],
   "repository": {
@@ -78,6 +79,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
+    "@ast-grep/lang-go": "0.0.6",
+    "@ast-grep/lang-python": "0.0.6",
     "@ast-grep/napi": "0.44.1",
     "@google/genai": "^1.52.0",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/nexus-agents/src/exports/security.ts
+++ b/packages/nexus-agents/src/exports/security.ts
@@ -180,6 +180,7 @@ export {
   AST_RULE_SEVERITIES,
   DEFAULT_AST_QA_LIMIT,
   MAX_AST_QA_LIMIT,
+  MAX_FILES_SCANNED,
 } from '../security/ast-rule-runner.js';
 export type {
   AstRuleLanguage,

--- a/packages/nexus-agents/src/exports/security.ts
+++ b/packages/nexus-agents/src/exports/security.ts
@@ -168,3 +168,24 @@ export type { FirewallResult } from '../security/firewall/firewall-pipeline.js';
 export { generateATL, parseATL } from '../security/firewall/agent-trust-labels.js';
 export { createGitHubAdapter } from '../security/firewall/github-adapter.js';
 export type { GitHubInput } from '../security/firewall/github-adapter.js';
+
+// Polyglot (Python/Go) ast-grep QA/security rules — read-only (#4249 child C)
+export {
+  ensurePolyglotLangs,
+  loadRules,
+  getBuiltInAstRulesPath,
+  collectAstQaFindings,
+  runAstQaRules,
+  AST_RULE_LANGUAGES,
+  AST_RULE_SEVERITIES,
+  DEFAULT_AST_QA_LIMIT,
+  MAX_AST_QA_LIMIT,
+} from '../security/ast-rule-runner.js';
+export type {
+  AstRuleLanguage,
+  AstRuleSeverity,
+  AstQaRuleFile,
+  AstRuleFinding,
+  RunAstQaRulesOptions,
+  AstQaCollectResult,
+} from '../security/ast-rule-runner.js';

--- a/packages/nexus-agents/src/security/ast-rule-runner.test.ts
+++ b/packages/nexus-agents/src/security/ast-rule-runner.test.ts
@@ -7,12 +7,15 @@
  * line number, and every documented NEGATIVE (near-miss) produces none —
  * mirroring the #4243 lesson that a rule which "sort of" matches over-fires
  * on lookalikes. Also covers: fail-closed rule loading, the once-only
- * dynamic-language registration guard, the path-traversal guard, and the
- * cap/overflow discipline (excess findings counted, never silently dropped).
+ * dynamic-language registration guard, the path-traversal guard, the
+ * cap/overflow discipline (excess findings counted, never silently dropped),
+ * and — the #4277 fail-open coverage gaps — that a truncated FILE scan is
+ * surfaced (not silently partial) and that an unreadable / non-directory
+ * scan root fails LOUD rather than returning an empty "clean" result.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -23,6 +26,8 @@ import {
   runAstQaRules,
   getBuiltInAstRulesPath,
   DEFAULT_AST_QA_LIMIT,
+  MAX_AST_QA_LIMIT,
+  MAX_FILES_SCANNED,
   type AstRuleFinding,
 } from './ast-rule-runner.js';
 
@@ -32,6 +37,23 @@ const FIXTURES_DIR = join(HERE, 'ast-rules', 'fixtures');
 
 function findingsFor(ruleId: string, findings: AstRuleFinding[]): AstRuleFinding[] {
   return findings.filter((f) => f.ruleId === ruleId);
+}
+
+/** Capture everything written to stderr (where the runner's warn logger goes by
+ * default) so a warn can be asserted deterministically. Always `restore()`. */
+function captureStderr(): { calls: string[]; restore: () => void } {
+  const original = process.stderr.write.bind(process.stderr);
+  const calls: string[] = [];
+  process.stderr.write = (chunk: string | Uint8Array): boolean => {
+    calls.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  };
+  return {
+    calls,
+    restore: () => {
+      process.stderr.write = original;
+    },
+  };
 }
 
 describe('ast-rule-runner (#4249 child C)', () => {
@@ -174,6 +196,10 @@ describe('ast-rule-runner (#4249 child C)', () => {
       expect(result.total).toBe(12);
       expect(result.findings.length).toBe(5);
       expect(result.limit).toBe(5);
+      // Findings cap was hit but the FILE cap was not — scan is still complete.
+      expect(result.filesTruncated).toBe(false);
+      expect(result.filesSkipped).toBe(0);
+      expect(result.filesScanned).toBe(1);
 
       // The convenience wrapper returns only the capped array — same cap.
       const capped = await runAstQaRules({
@@ -187,6 +213,126 @@ describe('ast-rule-runner (#4249 child C)', () => {
     it('defaults to DEFAULT_AST_QA_LIMIT when no limit is given', async () => {
       const findings = await runAstQaRules({ rulesDir: RULES_DIR, targetDir: FIXTURES_DIR });
       expect(findings.length).toBeLessThanOrEqual(DEFAULT_AST_QA_LIMIT);
+    });
+
+    it('clamps a non-positive limit up to 1 (never reports total>0 with zero findings)', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-overflow-test-'));
+      const rulesSubdir = join(scratchDir, 'rules');
+      mkdirSync(rulesSubdir);
+      writeFileSync(
+        join(rulesSubdir, 'eval.yml'),
+        'id: dangerous-eval-python\nlanguage: python\nseverity: error\nmessage: msg\nrule:\n  pattern: eval($CODE)\n'
+      );
+      writeFileSync(join(scratchDir, 'x.py'), 'eval(a)\neval(b)\n');
+
+      const result = await collectAstQaFindings({
+        rulesDir: rulesSubdir,
+        targetDir: scratchDir,
+        limit: 0,
+      });
+      // With a floor of 1, a positive total is always accompanied by >=1 finding.
+      expect(result.total).toBe(2);
+      expect(result.limit).toBe(1);
+      expect(result.findings.length).toBe(1);
+    });
+
+    it('clamps a limit above MAX_AST_QA_LIMIT down to the ceiling', async () => {
+      const result = await collectAstQaFindings({
+        rulesDir: RULES_DIR,
+        targetDir: FIXTURES_DIR,
+        limit: MAX_AST_QA_LIMIT + 1000,
+      });
+      expect(result.limit).toBe(MAX_AST_QA_LIMIT);
+    });
+  });
+
+  // ==========================================================================
+  // #4277 fail-open coverage gaps
+  // ==========================================================================
+
+  describe('file-cap truncation is SURFACED (not silently partial) — #4277 gap 1', () => {
+    let scratchDir: string;
+
+    afterEach(() => {
+      if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('reports filesTruncated/filesSkipped AND warns when discovered files exceed MAX_FILES_SCANNED', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-filecap-test-'));
+      const rulesSubdir = join(scratchDir, 'rules');
+      const srcSubdir = join(scratchDir, 'src');
+      mkdirSync(rulesSubdir);
+      mkdirSync(srcSubdir);
+      writeFileSync(
+        join(rulesSubdir, 'eval.yml'),
+        'id: dangerous-eval-python\nlanguage: python\nseverity: error\nmessage: msg\nrule:\n  pattern: eval($CODE)\n'
+      );
+      // One more polyglot file than the cap allows → exactly one must be dropped.
+      const fileCount = MAX_FILES_SCANNED + 1;
+      for (let i = 0; i < fileCount; i += 1) {
+        writeFileSync(join(srcSubdir, `f${String(i)}.py`), '');
+      }
+
+      const spy = captureStderr();
+      let result;
+      try {
+        result = await collectAstQaFindings({ rulesDir: rulesSubdir, targetDir: scratchDir });
+      } finally {
+        spy.restore();
+      }
+
+      // The gap: this used to be `.slice(0, MAX)` with NO signal. Now surfaced:
+      expect(result.filesTruncated).toBe(true);
+      expect(result.filesSkipped).toBe(1);
+      expect(result.filesScanned).toBe(MAX_FILES_SCANNED);
+      // ...and a warn is emitted so a log-only consumer also sees the partiality.
+      const warned = spy.calls.join('');
+      expect(warned).toContain('file cap');
+      expect(warned).toMatch(/PARTIAL/);
+    });
+  });
+
+  describe('unreadable / non-directory scan root fails LOUD — #4277 gap 2', () => {
+    it('throws when targetDir is a FILE, not a directory (no empty "clean" result)', async () => {
+      // A lone .py file within cwd: passes the traversal guard, then must be
+      // rejected by the is-directory check rather than yielding {findings:[]}.
+      const filePath = join('src', 'security', 'ast-rules', 'fixtures', 'sample.py');
+      await expect(runAstQaRules({ rulesDir: RULES_DIR, targetDir: filePath })).rejects.toThrow(
+        /must be a directory/
+      );
+    });
+
+    it('throws when targetDir does not exist (no empty "clean" result)', async () => {
+      await expect(
+        runAstQaRules({ rulesDir: RULES_DIR, targetDir: 'no-such-dir-xyz-4277' })
+      ).rejects.toThrow(/cannot read targetDir/);
+    });
+
+    it('WARNS (does not silently swallow) when a SUBDIRECTORY is unreadable mid-walk', async () => {
+      // chmod is a no-op for root; skip there rather than assert a false negative.
+      if (typeof process.getuid === 'function' && process.getuid() === 0) return;
+
+      const scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-subdir-test-'));
+      const badSub = join(scratchDir, 'locked');
+      mkdirSync(badSub);
+      writeFileSync(join(badSub, 'hidden.py'), 'eval(secret)\n');
+      chmodSync(badSub, 0o000);
+
+      const spy = captureStderr();
+      let result;
+      try {
+        // Root itself is readable (stat + readdir succeed); the LOCKED subdir's
+        // readdir fails and must produce a per-dir warn, not a silent skip.
+        result = await collectAstQaFindings({ rulesDir: RULES_DIR, targetDir: scratchDir });
+      } finally {
+        spy.restore();
+        chmodSync(badSub, 0o755); // re-open so rm can clean up
+      }
+
+      expect(spy.calls.join('')).toContain('skipped unreadable directory');
+      // The hidden eval was NOT scanned, but the partiality was surfaced above.
+      expect(result.findings).toEqual([]);
+      rmSync(scratchDir, { recursive: true, force: true });
     });
   });
 });

--- a/packages/nexus-agents/src/security/ast-rule-runner.test.ts
+++ b/packages/nexus-agents/src/security/ast-rule-runner.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for ast-rule-runner (#4249 child C — polyglot Python/Go QA/security
+ * ast-grep rules).
+ *
+ * Red/Green per rule against `ast-rules/fixtures/{sample.py,sample.go}`:
+ * every documented POSITIVE line produces a finding with the right ruleId +
+ * line number, and every documented NEGATIVE (near-miss) produces none —
+ * mirroring the #4243 lesson that a rule which "sort of" matches over-fires
+ * on lookalikes. Also covers: fail-closed rule loading, the once-only
+ * dynamic-language registration guard, the path-traversal guard, and the
+ * cap/overflow discipline (excess findings counted, never silently dropped).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  ensurePolyglotLangs,
+  loadRules,
+  collectAstQaFindings,
+  runAstQaRules,
+  getBuiltInAstRulesPath,
+  DEFAULT_AST_QA_LIMIT,
+  type AstRuleFinding,
+} from './ast-rule-runner.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_DIR = join(HERE, 'ast-rules');
+const FIXTURES_DIR = join(HERE, 'ast-rules', 'fixtures');
+
+function findingsFor(ruleId: string, findings: AstRuleFinding[]): AstRuleFinding[] {
+  return findings.filter((f) => f.ruleId === ruleId);
+}
+
+describe('ast-rule-runner (#4249 child C)', () => {
+  describe('built-in rules dir resolution', () => {
+    it('resolves to the checked-in ast-rules directory in dev', () => {
+      expect(getBuiltInAstRulesPath()).toBe(RULES_DIR);
+    });
+  });
+
+  describe('per-rule red/green against fixtures', () => {
+    it('dangerous-eval-python: matches eval()/exec() positives, not evaluate()/executor() negatives', async () => {
+      const findings = await runAstQaRules({ rulesDir: RULES_DIR, targetDir: FIXTURES_DIR });
+      const hits = findingsFor('dangerous-eval-python', findings);
+      const lines = hits.filter((h) => h.file.endsWith('sample.py')).map((h) => h.line);
+
+      expect(lines).toContain(11); // eval(user_input)
+      expect(lines).toContain(15); // exec(payload)
+      expect(hits.every((h) => h.severity === 'error')).toBe(true);
+
+      // Negatives: evaluate(x) at L31 and executor(y) at L35 must NOT match.
+      expect(lines).not.toContain(31);
+      expect(lines).not.toContain(35);
+    });
+
+    it('shell-injection-python: matches os.system()/shell=True positives, not the no-shell negative', async () => {
+      const findings = await runAstQaRules({ rulesDir: RULES_DIR, targetDir: FIXTURES_DIR });
+      const hits = findingsFor('shell-injection-python', findings);
+      const lines = hits.filter((h) => h.file.endsWith('sample.py')).map((h) => h.line);
+
+      expect(lines).toContain(21); // os.system(cmd)
+      expect(lines).toContain(27); // subprocess.run(cmd, shell=True)
+
+      // Negative: subprocess.run(cmd) (no shell=True) at L41 must NOT match.
+      expect(lines).not.toContain(41);
+    });
+
+    it('command-exec-go: matches exec.Command() positive, not the local-helper/aliased negatives', async () => {
+      const findings = await runAstQaRules({ rulesDir: RULES_DIR, targetDir: FIXTURES_DIR });
+      const hits = findingsFor('command-exec-go', findings);
+      const lines = hits.map((h) => h.line);
+
+      expect(lines).toContain(13); // exec.Command("sh", "-c", input)
+      expect(hits.every((h) => h.severity === 'warning')).toBe(true);
+
+      // Negatives: local `Command(x)` helper (L18-19), bare call (L24), and
+      // the `myexec.Command(...)` near-miss (L32) must NOT match.
+      expect(lines).not.toContain(19);
+      expect(lines).not.toContain(24);
+      expect(lines).not.toContain(32);
+    });
+  });
+
+  describe('loader fail-closed', () => {
+    let scratchDir: string;
+
+    afterEach(() => {
+      if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('throws on malformed YAML — no partial run', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-loader-test-'));
+      writeFileSync(
+        join(scratchDir, 'good.yml'),
+        'id: ok\nlanguage: python\nseverity: error\nmessage: fine\nrule:\n  pattern: x\n'
+      );
+      writeFileSync(
+        join(scratchDir, 'bad.yml'),
+        'id: [unterminated\n  - this is not valid yaml: [[['
+      );
+
+      await expect(loadRules(scratchDir)).rejects.toThrow();
+    });
+
+    it('throws on an unknown `language` value — no partial run', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-loader-test-'));
+      writeFileSync(
+        join(scratchDir, 'unknown-lang.yml'),
+        'id: bad-lang\nlanguage: rust\nseverity: error\nmessage: nope\nrule:\n  pattern: x\n'
+      );
+
+      await expect(loadRules(scratchDir)).rejects.toThrow();
+    });
+
+    it('a single bad file fails the whole load even alongside valid ones', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-loader-test-'));
+      writeFileSync(
+        join(scratchDir, 'a-good.yml'),
+        'id: ok\nlanguage: python\nseverity: error\nmessage: fine\nrule:\n  pattern: x\n'
+      );
+      writeFileSync(
+        join(scratchDir, 'z-bad.yml'),
+        'severity: error\nmessage: missing id and language\n'
+      );
+
+      await expect(loadRules(scratchDir)).rejects.toThrow();
+    });
+  });
+
+  describe('idempotent dynamic-language registration', () => {
+    it('calling ensurePolyglotLangs twice in one process does not throw', () => {
+      expect(() => {
+        ensurePolyglotLangs();
+        ensurePolyglotLangs();
+      }).not.toThrow();
+    });
+  });
+
+  describe('path-traversal guard', () => {
+    it('rejects a targetDir outside the cwd subtree', async () => {
+      await expect(runAstQaRules({ rulesDir: RULES_DIR, targetDir: '../..' })).rejects.toThrow(
+        /Path traversal denied/
+      );
+    });
+  });
+
+  describe('cap/overflow discipline', () => {
+    let scratchDir: string;
+
+    afterEach(() => {
+      if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('caps findings at `limit` and reports the true total — never silently drops', async () => {
+      scratchDir = mkdtempSync(join(process.cwd(), '.ast-qa-overflow-test-'));
+      const rulesSubdir = join(scratchDir, 'rules');
+      mkdirSync(rulesSubdir);
+      writeFileSync(
+        join(rulesSubdir, 'eval.yml'),
+        'id: dangerous-eval-python\nlanguage: python\nseverity: error\nmessage: msg\nrule:\n  pattern: eval($CODE)\n'
+      );
+      const many = Array.from({ length: 12 }, (_, i) => `eval(x${String(i)})`).join('\n');
+      writeFileSync(join(scratchDir, 'many.py'), many);
+
+      const result = await collectAstQaFindings({
+        rulesDir: rulesSubdir,
+        targetDir: scratchDir,
+        limit: 5,
+      });
+
+      expect(result.total).toBe(12);
+      expect(result.findings.length).toBe(5);
+      expect(result.limit).toBe(5);
+
+      // The convenience wrapper returns only the capped array — same cap.
+      const capped = await runAstQaRules({
+        rulesDir: rulesSubdir,
+        targetDir: scratchDir,
+        limit: 5,
+      });
+      expect(capped.length).toBe(5);
+    });
+
+    it('defaults to DEFAULT_AST_QA_LIMIT when no limit is given', async () => {
+      const findings = await runAstQaRules({ rulesDir: RULES_DIR, targetDir: FIXTURES_DIR });
+      expect(findings.length).toBeLessThanOrEqual(DEFAULT_AST_QA_LIMIT);
+    });
+  });
+});

--- a/packages/nexus-agents/src/security/ast-rule-runner.ts
+++ b/packages/nexus-agents/src/security/ast-rule-runner.ts
@@ -34,10 +34,10 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Lang, parse, registerDynamicLanguage } from '@ast-grep/napi';
+import { parse, registerDynamicLanguage } from '@ast-grep/napi';
 import type { NapiConfig } from '@ast-grep/napi';
 // Both packages are CJS `export = <LanguageRegistration>` modules — the
 // default import is the whole registration object (`libraryPath` getter,
@@ -71,10 +71,15 @@ export function ensurePolyglotLangs(): void {
 // Rule schema (fail-closed)
 // ============================================================================
 
-/** Languages a rule file may declare. Only python/go are scanned for today (see
- * {@link inferRuleLang}); typescript/javascript are accepted by the schema so a
- * future rule file is not rejected by the loader before a walker exists for it. */
-export const AST_RULE_LANGUAGES = ['python', 'go', 'typescript', 'javascript'] as const;
+/** Languages a rule file may declare. Deliberately narrowed to the two this
+ * runner actually SCANS (python/go): admitting `typescript`/`javascript` here
+ * would let a TS/JS rule file validate at load time and then silently never
+ * fire (there is no TS/JS extension in {@link POLYGLOT_EXT_TO_LANG}), which is
+ * a fail-OPEN gap for a security scanner where "no findings" reads as "clean".
+ * TS/JS structural analysis is already covered by `search_usages` (#4265) and
+ * the ast-fixer rewrites (#4243); a TS/JS rule here would fail LOUD at load
+ * (unknown-language Zod error) instead of loading dead. */
+export const AST_RULE_LANGUAGES = ['python', 'go'] as const;
 export type AstRuleLanguage = (typeof AST_RULE_LANGUAGES)[number];
 
 export const AST_RULE_SEVERITIES = ['error', 'warning', 'info'] as const;
@@ -104,8 +109,10 @@ export const MAX_AST_QA_LIMIT = 2000;
 /** Directory walk depth for the target-dir scan (not caller-configurable — no
  * named consumer needs a deeper/shallower walk yet; YAGNI). */
 const AST_QA_MAX_DEPTH = 24;
-/** Upper bound on files parsed in a single run, to bound worst-case cost. */
-const MAX_FILES_SCANNED = 5000;
+/** Upper bound on files parsed in a single run, to bound worst-case cost.
+ * Exceeding it makes the scan PARTIAL — surfaced via {@link AstQaCollectResult}'s
+ * `filesTruncated`/`filesSkipped` + a warn, never silently dropped. */
+export const MAX_FILES_SCANNED = 5000;
 
 const logger = createLogger({ component: 'ast-rule-runner' });
 
@@ -122,7 +129,7 @@ const logger = createLogger({ component: 'ast-rule-runner' });
 export async function loadRules(dir: string): Promise<AstQaRuleFile[]> {
   let entries: string[];
   try {
-    entries = (await readdir(dir)).filter((f) => f.endsWith('.yml')).sort();
+    entries = (await readdir(dir)).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml')).sort();
   } catch (caught: unknown) {
     const e = caught instanceof Error ? caught : new Error(String(caught));
     throw new ValidationError(`ast-rule-runner: cannot read rules dir ${dir}: ${e.message}`, {
@@ -227,11 +234,25 @@ function inferRuleLang(file: string): AstRuleLanguage | null {
   return POLYGLOT_EXT_TO_LANG[extname(file).toLowerCase()] ?? null;
 }
 
-/** Recursively collect `.py`/`.go` files under `dir`, bounded by `maxDepth`. */
+/**
+ * Recursively collect `.py`/`.go` files under `dir`, bounded by `maxDepth`.
+ * A subdirectory whose `readdir` fails mid-walk (e.g. a `chmod 000` dir) is
+ * WARNED about per-dir and skipped rather than silently swallowed — the scan
+ * continues, but the partiality is surfaced in the log. The SCAN ROOT's own
+ * readability is validated up front by {@link collectAstQaFindings} (fail
+ * loud), so this soft-skip only ever applies to descendant dirs.
+ */
 async function findPolyglotFiles(dir: string, maxDepth: number): Promise<string[]> {
   if (maxDepth <= 0) return [];
   const out: string[] = [];
-  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (caught: unknown) {
+    const e = caught instanceof Error ? caught : new Error(String(caught));
+    logger.warn(`ast-rule-runner: skipped unreadable directory ${dir}: ${e.message}`);
+    return out;
+  }
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
@@ -244,13 +265,12 @@ async function findPolyglotFiles(dir: string, maxDepth: number): Promise<string[
 }
 
 /** Map a rule's declared language to the `parse()` first argument, registering
- * the dynamic grammars on first use of python/go. */
-function langToParseArg(lang: AstRuleLanguage): Lang | string {
-  if (lang === 'python' || lang === 'go') {
-    ensurePolyglotLangs();
-    return lang; // the CustomLang string keys used in registerDynamicLanguage()
-  }
-  return lang === 'javascript' ? Lang.JavaScript : Lang.TypeScript;
+ * the dynamic grammars on first use. Both supported languages (python/go) are
+ * dynamically-registered CustomLangs, so the language name string IS the
+ * `parse()` key set up in {@link ensurePolyglotLangs}. */
+function langToParseArg(lang: AstRuleLanguage): AstRuleLanguage {
+  ensurePolyglotLangs();
+  return lang; // the CustomLang string keys used in registerDynamicLanguage()
 }
 
 // ============================================================================
@@ -288,6 +308,14 @@ export interface AstQaCollectResult {
   /** True count of matches found, before the `limit` cap was applied. */
   total: number;
   limit: number;
+  /** Number of `.py`/`.go` files actually scanned (after the file cap). */
+  filesScanned: number;
+  /** Number of discovered files DROPPED because the file cap ({@link MAX_FILES_SCANNED})
+   * was exceeded. Non-zero means the scan was PARTIAL — a downstream consumer
+   * must not treat empty/low findings as a clean bill of health. */
+  filesSkipped: number;
+  /** True iff `filesSkipped > 0` — the scan did not cover every candidate file. */
+  filesTruncated: boolean;
 }
 
 /** Findings + true-match-count from scanning ONE already-read source file. */
@@ -348,6 +376,53 @@ function scanFile(
 }
 
 /**
+ * Fail LOUD on an unreadable / non-directory scan root. `loadRules` already
+ * throws on an unreadable RULES dir; the TARGET traversal must not fail OPEN —
+ * a lone file path, a bad path, or a `000` root would otherwise return an empty
+ * finding set that reads as "clean" for a security scanner.
+ */
+async function assertScanRootIsDirectory(resolved: string): Promise<void> {
+  let rootStat;
+  try {
+    rootStat = await stat(resolved);
+  } catch (caught: unknown) {
+    const e = caught instanceof Error ? caught : new Error(String(caught));
+    throw new ValidationError(`ast-rule-runner: cannot read targetDir ${resolved}: ${e.message}`, {
+      cause: e,
+    });
+  }
+  if (!rootStat.isDirectory()) {
+    throw new ValidationError(
+      `ast-rule-runner: targetDir must be a directory, got a non-directory path: ${resolved}`
+    );
+  }
+}
+
+/** Result of resolving the candidate file set under a scan root, with the
+ * file-cap truncation signal surfaced (never a silent `.slice`). */
+interface ScanFileSet {
+  files: string[];
+  filesSkipped: number;
+  filesTruncated: boolean;
+}
+
+/** Discover candidate `.py`/`.go` files, applying + SURFACING the file cap. */
+async function resolveScanFiles(root: string): Promise<ScanFileSet> {
+  const discovered = await findPolyglotFiles(root, AST_QA_MAX_DEPTH);
+  const files = discovered.slice(0, MAX_FILES_SCANNED);
+  const filesSkipped = discovered.length - files.length;
+  const filesTruncated = filesSkipped > 0;
+  if (filesTruncated) {
+    logger.warn(
+      `ast-rule-runner: ${String(filesSkipped)} file(s) NOT scanned — file cap ` +
+        `${String(MAX_FILES_SCANNED)} exceeded (discovered=${String(discovered.length)}). ` +
+        `Scan is PARTIAL; do not treat findings as exhaustive.`
+    );
+  }
+  return { files, filesSkipped, filesTruncated };
+}
+
+/**
  * Run every applicable rule in `rulesDir` against every `.py`/`.go` file under
  * `targetDir`, returning capped findings plus the true total (so callers that
  * need the overflow count — e.g. a future MCP tool wrapper — can report it).
@@ -360,15 +435,15 @@ export async function collectAstQaFindings(
   if ('error' in guard) {
     throw new SecurityError(guard.error);
   }
+  await assertScanRootIsDirectory(guard.resolved);
 
   const rulesDir = opts.rulesDir ?? getBuiltInAstRulesPath();
   const rules = await loadRules(rulesDir);
-  const limit = Math.min(opts.limit ?? DEFAULT_AST_QA_LIMIT, MAX_AST_QA_LIMIT);
+  // Clamp into [1, MAX]: a limit <= 0 would report total > 0 with zero findings
+  // (fail-open "clean" signal), so the floor is load-bearing, not cosmetic.
+  const limit = Math.min(Math.max(opts.limit ?? DEFAULT_AST_QA_LIMIT, 1), MAX_AST_QA_LIMIT);
 
-  const files = (await findPolyglotFiles(guard.resolved, AST_QA_MAX_DEPTH)).slice(
-    0,
-    MAX_FILES_SCANNED
-  );
+  const { files, filesSkipped, filesTruncated } = await resolveScanFiles(guard.resolved);
 
   const findings: AstRuleFinding[] = [];
   let total = 0;
@@ -400,7 +475,7 @@ export async function collectAstQaFindings(
     );
   }
 
-  return { findings, total, limit };
+  return { findings, total, limit, filesScanned: files.length, filesSkipped, filesTruncated };
 }
 
 /**

--- a/packages/nexus-agents/src/security/ast-rule-runner.ts
+++ b/packages/nexus-agents/src/security/ast-rule-runner.ts
@@ -1,0 +1,415 @@
+/**
+ * nexus-agents/security - Polyglot (Python/Go) AST QA/Security Rule Runner (#4249 child C)
+ *
+ * Runs YAML-defined `@ast-grep/napi` rules against Python/Go source, detecting
+ * common QA/security anti-patterns (dynamic `eval`/`exec`, shell injection,
+ * unchecked external command execution). Same engine already used by
+ * `search_usages` (indexer/usage-ast.ts, #4265) and the ast-fixer rewrites
+ * (agents/collaboration/ast-rewrites.ts, #4243/#4249 child B) — no new AST
+ * dependency, just new language grammars for it.
+ *
+ * **Language support gap.** `Lang` in `@ast-grep/napi@0.44.1` ships only
+ * Html/JavaScript/Tsx/Css/TypeScript — no Python, no Go. This module closes
+ * that gap via napi's `@experimental registerDynamicLanguage` API, backed by
+ * the `@ast-grep/lang-python`/`@ast-grep/lang-go` prebuilt tree-sitter
+ * grammars. Both are EXACT-pinned in package.json (no caret): these are
+ * early/experimental packages and a caret range could silently swap in an
+ * incompatible native `.so` grammar build underneath a "safe" semver-minor
+ * bump. `registerDynamicLanguage` throws if called more than once per
+ * process (napi-rs's own documented constraint) — {@link ensurePolyglotLangs}
+ * is a lazy, module-level, once-only guard so repeated calls (tests, repeat
+ * runner invocations within one process) never trip it twice.
+ *
+ * **Read-only.** Reads rule YAML and target source files, walks their ASTs,
+ * performs NO writes. ast-grep YAML rule files support a `fix:` key for
+ * autofixing, but napi's `SgNode.findAll` (used here) never applies it —
+ * only ast-grep's separate rewrite/CLI machinery does — so even a rule
+ * author who adds `fix:` cannot turn this runner into a writer by accident.
+ * MCP exposure is deliberately deferred (see the follow-up issue referenced
+ * in the #4249 child C PR) to keep this surface a plain function until a
+ * named consumer needs it wired through a tool.
+ *
+ * @module security/ast-rule-runner
+ * @see Issue #4249 - epic: ast-grep adoption (Child C: polyglot QA/security rules)
+ */
+
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Lang, parse, registerDynamicLanguage } from '@ast-grep/napi';
+import type { NapiConfig } from '@ast-grep/napi';
+// Both packages are CJS `export = <LanguageRegistration>` modules — the
+// default import is the whole registration object (`libraryPath` getter,
+// `extensions`, `languageSymbol`, `expandoChar`). See their `index.d.ts`.
+import goLangRegistration from '@ast-grep/lang-go';
+import pythonLangRegistration from '@ast-grep/lang-python';
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+import { createLogger, SecurityError, ValidationError, formatZodError } from '../core/index.js';
+
+// ============================================================================
+// Dynamic language registration (@experimental, call-once)
+// ============================================================================
+
+let polyglotLangsRegistered = false;
+
+/**
+ * Lazily register the Python/Go tree-sitter grammars with ast-grep's
+ * `registerDynamicLanguage`. That API throws if called more than once in a
+ * process; this guard makes every call after the first a no-op so repeated
+ * runner invocations (or a test suite that constructs the runner many times)
+ * never trip the constraint.
+ */
+export function ensurePolyglotLangs(): void {
+  if (polyglotLangsRegistered) return;
+  registerDynamicLanguage({ python: pythonLangRegistration, go: goLangRegistration });
+  polyglotLangsRegistered = true;
+}
+
+// ============================================================================
+// Rule schema (fail-closed)
+// ============================================================================
+
+/** Languages a rule file may declare. Only python/go are scanned for today (see
+ * {@link inferRuleLang}); typescript/javascript are accepted by the schema so a
+ * future rule file is not rejected by the loader before a walker exists for it. */
+export const AST_RULE_LANGUAGES = ['python', 'go', 'typescript', 'javascript'] as const;
+export type AstRuleLanguage = (typeof AST_RULE_LANGUAGES)[number];
+
+export const AST_RULE_SEVERITIES = ['error', 'warning', 'info'] as const;
+export type AstRuleSeverity = (typeof AST_RULE_SEVERITIES)[number];
+
+/** Schema for one `*.yml` rule file. `rule` is passed through as ast-grep's
+ * own `Rule` object (napi already validates it structurally at match time);
+ * Zod only pins down the envelope so an unknown `language` or a missing
+ * field FAILS CLOSED instead of silently loading a partial/broken rule. */
+const RuleFileSchema = z.object({
+  id: z.string().min(1),
+  language: z.enum(AST_RULE_LANGUAGES),
+  severity: z.enum(AST_RULE_SEVERITIES),
+  message: z.string().min(1),
+  rule: z.record(z.string(), z.unknown()),
+});
+
+export type AstQaRuleFile = z.infer<typeof RuleFileSchema>;
+
+/** Per-match snippet char cap (matches indexer/usage-ast.ts's discipline). */
+const MAX_SNIPPET_CHARS = 200;
+
+/** Default cap on emitted findings. Excess is counted + reported, never silently dropped. */
+export const DEFAULT_AST_QA_LIMIT = 200;
+/** Hard upper bound a caller may request for the finding cap. */
+export const MAX_AST_QA_LIMIT = 2000;
+/** Directory walk depth for the target-dir scan (not caller-configurable — no
+ * named consumer needs a deeper/shallower walk yet; YAGNI). */
+const AST_QA_MAX_DEPTH = 24;
+/** Upper bound on files parsed in a single run, to bound worst-case cost. */
+const MAX_FILES_SCANNED = 5000;
+
+const logger = createLogger({ component: 'ast-rule-runner' });
+
+// ============================================================================
+// Rule loading
+// ============================================================================
+
+/**
+ * Load and Zod-validate every `*.yml` rule file in `dir`. FAILS CLOSED: a
+ * single malformed YAML file, or a file with an unrecognized `language` or
+ * missing field, throws a {@link ValidationError} — there is no
+ * "load what parsed, skip the rest" partial mode.
+ */
+export async function loadRules(dir: string): Promise<AstQaRuleFile[]> {
+  let entries: string[];
+  try {
+    entries = (await readdir(dir)).filter((f) => f.endsWith('.yml')).sort();
+  } catch (caught: unknown) {
+    const e = caught instanceof Error ? caught : new Error(String(caught));
+    throw new ValidationError(`ast-rule-runner: cannot read rules dir ${dir}: ${e.message}`, {
+      cause: e,
+    });
+  }
+
+  const rules: AstQaRuleFile[] = [];
+  for (const file of entries) {
+    const path = join(dir, file);
+    const raw = await readFile(path, 'utf8');
+
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(raw);
+    } catch (caught: unknown) {
+      const e = caught instanceof Error ? caught : new Error(String(caught));
+      throw new ValidationError(`ast-rule-runner: malformed YAML in ${path}: ${e.message}`, {
+        cause: e,
+      });
+    }
+
+    const result = RuleFileSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new ValidationError(
+        `ast-rule-runner: invalid rule file ${path}: ${formatZodError(result.error)}`
+      );
+    }
+    rules.push(result.data);
+  }
+  return rules;
+}
+
+// ============================================================================
+// Built-in rules dir resolution (mirrors workflows/template-loader.ts)
+// ============================================================================
+
+/**
+ * Resolve the built-in `ast-rules/` directory, handling both dev (unbundled,
+ * `src/security/ast-rule-runner.ts`) and published (bundled,
+ * `dist/index.js` + `dist/security/ast-rules/*.yml` copied by tsup's
+ * `onSuccess` step) layouts — the same two-layout problem
+ * `getBuiltInTemplatesPath` solves for workflow templates.
+ */
+export function getBuiltInAstRulesPath(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = dirname(currentFile);
+
+  if (currentFile.includes(`${sep}dist${sep}`) || currentFile.endsWith(`${sep}dist`)) {
+    const distIndex = currentFile.lastIndexOf(`${sep}dist${sep}`);
+    if (distIndex !== -1) {
+      const distDir = currentFile.substring(0, distIndex + 5); // +5 for "/dist"
+      const bundledPath = join(distDir, 'security', 'ast-rules');
+      if (existsSync(bundledPath)) return bundledPath;
+    }
+  }
+
+  const possiblePaths = [
+    join(currentDir, 'ast-rules'), // Unbundled: sibling of this file in src/security/
+    join(currentDir, 'security', 'ast-rules'), // Bundled chunk: dist/security sibling
+    join(dirname(currentDir), 'security', 'ast-rules'),
+  ];
+  for (const path of possiblePaths) {
+    if (existsSync(path)) return path;
+  }
+  return join(currentDir, 'ast-rules'); // Fallback (for error reporting)
+}
+
+// ============================================================================
+// Path-traversal guard (copied from mcp/tools/search-usages-tool.ts —
+// keep in sync if that guard changes)
+// ============================================================================
+
+/** Resolve a caller path against a path-traversal guard (must stay within cwd). */
+function resolveWithinCwd(target: string): { resolved: string } | { error: string } {
+  const resolved = resolve(target);
+  const cwdRoot = resolve('.');
+  // The `+ sep` is load-bearing: a sibling dir whose name starts with the cwd
+  // basename bypasses a bare startsWith. Matches security/safe-path.ts.
+  if (resolved !== cwdRoot && !resolved.startsWith(cwdRoot + sep)) {
+    return { error: `Path traversal denied: scope must be within ${cwdRoot}` };
+  }
+  return { resolved };
+}
+
+// ============================================================================
+// File walk (LOCAL extension map — python/go only; does NOT reuse
+// indexer/usage-ast.ts's TS/JS inferLang or indexer/codebase-search.ts's
+// TS/JS-only findSourceFiles)
+// ============================================================================
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git']);
+
+/** file-extension -> ast-rule language, for the two languages this runner scans. */
+const POLYGLOT_EXT_TO_LANG: Readonly<Record<string, AstRuleLanguage>> = {
+  '.py': 'python',
+  '.go': 'go',
+};
+
+/** Infer the ast-rule language for a file from its extension, or `null` if unsupported. */
+function inferRuleLang(file: string): AstRuleLanguage | null {
+  return POLYGLOT_EXT_TO_LANG[extname(file).toLowerCase()] ?? null;
+}
+
+/** Recursively collect `.py`/`.go` files under `dir`, bounded by `maxDepth`. */
+async function findPolyglotFiles(dir: string, maxDepth: number): Promise<string[]> {
+  if (maxDepth <= 0) return [];
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+      out.push(...(await findPolyglotFiles(fullPath, maxDepth - 1)));
+    } else if (entry.isFile() && inferRuleLang(entry.name) !== null) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+/** Map a rule's declared language to the `parse()` first argument, registering
+ * the dynamic grammars on first use of python/go. */
+function langToParseArg(lang: AstRuleLanguage): Lang | string {
+  if (lang === 'python' || lang === 'go') {
+    ensurePolyglotLangs();
+    return lang; // the CustomLang string keys used in registerDynamicLanguage()
+  }
+  return lang === 'javascript' ? Lang.JavaScript : Lang.TypeScript;
+}
+
+// ============================================================================
+// Findings
+// ============================================================================
+
+/** One ast-grep rule match against a source file. */
+export interface AstRuleFinding {
+  ruleId: string;
+  severity: AstRuleSeverity;
+  message: string;
+  /** Path relative to the resolved `targetDir`. */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  /** 1-based column number. */
+  column: number;
+  /** Trimmed, length-capped source line for the match. */
+  snippet: string;
+}
+
+export interface RunAstQaRulesOptions {
+  /** Directory containing `*.yml` rule files (default: the built-in bundled rules). */
+  rulesDir?: string;
+  /** Directory to scan for `.py`/`.go` source files (must stay within cwd). */
+  targetDir: string;
+  /** Max findings emitted (default {@link DEFAULT_AST_QA_LIMIT}). Excess is counted + reported. */
+  limit?: number;
+}
+
+/** {@link collectAstQaFindings}'s full result — findings plus the true total,
+ * so overflow beyond `limit` is counted and reported, never silently dropped. */
+export interface AstQaCollectResult {
+  findings: AstRuleFinding[];
+  /** True count of matches found, before the `limit` cap was applied. */
+  total: number;
+  limit: number;
+}
+
+/** Findings + true-match-count from scanning ONE already-read source file. */
+interface FileScanResult {
+  findings: AstRuleFinding[];
+  total: number;
+}
+
+/** Bundles {@link scanFile}'s cap-tracking inputs (max-params discipline). */
+interface FileScanBudget {
+  /** Path emitted on each finding (relative to the resolved `targetDir`). */
+  rel: string;
+  /** Max TOTAL findings across the whole run. */
+  limit: number;
+  /** Findings already accepted by earlier files in this run. */
+  alreadyFound: number;
+}
+
+/**
+ * Scan one already-read source file against the rules applicable to its
+ * language, pushing findings only while the running total (`budget.alreadyFound`
+ * + findings pushed so far) stays under `budget.limit` — while still counting
+ * every true match, so the caller can report overflow instead of silently
+ * dropping it.
+ */
+function scanFile(
+  src: string,
+  lang: AstRuleLanguage,
+  applicable: readonly AstQaRuleFile[],
+  budget: FileScanBudget
+): FileScanResult {
+  const { rel, limit, alreadyFound } = budget;
+  const root = parse(langToParseArg(lang), src).root();
+  const lines = src.split('\n');
+  const findings: AstRuleFinding[] = [];
+  let total = 0;
+
+  for (const rule of applicable) {
+    const config: NapiConfig = { rule: rule.rule };
+    for (const node of root.findAll(config)) {
+      total += 1;
+      if (alreadyFound + findings.length < limit) {
+        const { start } = node.range();
+        const rawLine = lines[start.line] ?? node.text();
+        findings.push({
+          ruleId: rule.id,
+          severity: rule.severity,
+          message: rule.message,
+          file: rel,
+          line: start.line + 1,
+          column: start.column + 1,
+          snippet: rawLine.trim().slice(0, MAX_SNIPPET_CHARS),
+        });
+      }
+    }
+  }
+  return { findings, total };
+}
+
+/**
+ * Run every applicable rule in `rulesDir` against every `.py`/`.go` file under
+ * `targetDir`, returning capped findings plus the true total (so callers that
+ * need the overflow count — e.g. a future MCP tool wrapper — can report it).
+ * {@link runAstQaRules} is the capped-array convenience wrapper over this.
+ */
+export async function collectAstQaFindings(
+  opts: RunAstQaRulesOptions
+): Promise<AstQaCollectResult> {
+  const guard = resolveWithinCwd(opts.targetDir);
+  if ('error' in guard) {
+    throw new SecurityError(guard.error);
+  }
+
+  const rulesDir = opts.rulesDir ?? getBuiltInAstRulesPath();
+  const rules = await loadRules(rulesDir);
+  const limit = Math.min(opts.limit ?? DEFAULT_AST_QA_LIMIT, MAX_AST_QA_LIMIT);
+
+  const files = (await findPolyglotFiles(guard.resolved, AST_QA_MAX_DEPTH)).slice(
+    0,
+    MAX_FILES_SCANNED
+  );
+
+  const findings: AstRuleFinding[] = [];
+  let total = 0;
+
+  for (const file of files) {
+    const lang = inferRuleLang(file);
+    if (lang === null) continue;
+    const applicable = rules.filter((r) => r.language === lang);
+    if (applicable.length === 0) continue;
+
+    let src: string;
+    try {
+      src = await readFile(file, 'utf8');
+    } catch {
+      logger.warn(`ast-rule-runner: skipped unreadable file ${file}`);
+      continue;
+    }
+
+    const rel = relative(guard.resolved, file) || file;
+    const scanned = scanFile(src, lang, applicable, { rel, limit, alreadyFound: findings.length });
+    findings.push(...scanned.findings);
+    total += scanned.total;
+  }
+
+  if (total > findings.length) {
+    logger.warn(
+      `ast-rule-runner: ${String(total - findings.length)} finding(s) omitted beyond ` +
+        `limit=${String(limit)} (total=${String(total)})`
+    );
+  }
+
+  return { findings, total, limit };
+}
+
+/**
+ * Run the polyglot QA/security ast-grep rules and return the capped findings
+ * array. Overflow beyond `limit` is counted and logged (never silently
+ * dropped) — use {@link collectAstQaFindings} directly when the caller needs
+ * the true total/overflow count programmatically.
+ */
+export async function runAstQaRules(opts: RunAstQaRulesOptions): Promise<AstRuleFinding[]> {
+  const { findings } = await collectAstQaFindings(opts);
+  return findings;
+}

--- a/packages/nexus-agents/src/security/ast-rules/command-exec-go.yml
+++ b/packages/nexus-agents/src/security/ast-rules/command-exec-go.yml
@@ -1,0 +1,15 @@
+id: command-exec-go
+language: go
+severity: warning
+message: External command execution — verify args are not attacker-controlled
+rule:
+  # A bare selector-expression pattern (`exec.Command($$$ARGS)`) does not
+  # reliably match against the dynamically-registered Go grammar (verified
+  # against @ast-grep/napi@0.44.1 + @ast-grep/lang-go@0.0.6): the pattern
+  # parser needs a valid enclosing Go context to resolve the `call_expression`
+  # selector for a dotted callee. The explicit context+selector form matches
+  # correctly and still excludes local/aliased near-misses (a bare `Command(x)`
+  # call, or a `myexec.Command(...)` call through a differently-named object).
+  pattern:
+    context: 'func f() { exec.Command($$$ARGS) }'
+    selector: call_expression

--- a/packages/nexus-agents/src/security/ast-rules/dangerous-eval-python.yml
+++ b/packages/nexus-agents/src/security/ast-rules/dangerous-eval-python.yml
@@ -1,0 +1,8 @@
+id: dangerous-eval-python
+language: python
+severity: error
+message: Dynamic code execution via eval/exec
+rule:
+  any:
+    - pattern: eval($CODE)
+    - pattern: exec($CODE)

--- a/packages/nexus-agents/src/security/ast-rules/fixtures/sample.go
+++ b/packages/nexus-agents/src/security/ast-rules/fixtures/sample.go
@@ -1,0 +1,33 @@
+// Fixture for the command-exec-go ast-grep rule.
+//
+// One rule-hit per statement keeps the red/green test assertions (ruleId +
+// line number) stable across edits. Generic sample data only (input, x) —
+// no project- or vendor-specific names.
+package fixtures
+
+import "os/exec"
+
+// PositiveDirectCall shells out via the standard library exec.Command —
+// POSITIVE: command-exec-go.
+func PositiveDirectCall(input string) {
+	exec.Command("sh", "-c", input) // POSITIVE: command-exec-go (exec.Command)
+}
+
+// Command is a local helper of the SAME NAME as the stdlib call, but it is
+// not `exec.Command` (no selector on the `exec` package) — must NOT match.
+func Command(x string) string {
+	return x // NEGATIVE: local `Command(...)` helper, not `exec.Command`
+}
+
+// NegativeLocalHelper calls the local helper above directly — NEGATIVE.
+func NegativeLocalHelper(x string) string {
+	return Command(x) // NEGATIVE: bare `Command(...)` call, no `exec.` selector
+}
+
+// NegativeAliasedNearMiss calls a `.Command(...)` method through a package
+// alias that is NOT literally named `exec` — the ast-grep pattern matches on
+// the literal identifier `exec`, so an aliased or differently-named package
+// must not match.
+func NegativeAliasedNearMiss(input string) {
+	myexec.Command("sh", "-c", input) // NEGATIVE: object is `myexec`, not `exec`
+}

--- a/packages/nexus-agents/src/security/ast-rules/fixtures/sample.py
+++ b/packages/nexus-agents/src/security/ast-rules/fixtures/sample.py
@@ -1,0 +1,41 @@
+"""Fixture for dangerous-eval-python / shell-injection-python ast-grep rules.
+
+Each function below is intentionally tiny and self-contained: one rule-hit
+per line keeps the red/green test assertions (ruleId + line number) stable
+across edits. Generic sample data only (payload/user_input/cmd) — no
+project- or vendor-specific names.
+"""
+
+
+def positive_eval(user_input):
+    return eval(user_input)  # POSITIVE: dangerous-eval-python (eval)
+
+
+def positive_exec(payload):
+    exec(payload)  # POSITIVE: dangerous-eval-python (exec)
+
+
+def positive_os_system(cmd):
+    import os
+
+    os.system(cmd)  # POSITIVE: shell-injection-python (os.system)
+
+
+def positive_subprocess_shell_true(cmd):
+    import subprocess
+
+    subprocess.run(cmd, shell=True)  # POSITIVE: shell-injection-python (shell=True)
+
+
+def negative_evaluate(x):
+    return evaluate(x)  # NEGATIVE: not `eval` — must not match dangerous-eval-python
+
+
+def negative_executor(y):
+    return executor(y)  # NEGATIVE: not `exec` — must not match dangerous-eval-python
+
+
+def negative_subprocess_no_shell(cmd):
+    import subprocess
+
+    return subprocess.run(cmd)  # NEGATIVE: no shell=True — must not match shell-injection-python

--- a/packages/nexus-agents/src/security/ast-rules/shell-injection-python.yml
+++ b/packages/nexus-agents/src/security/ast-rules/shell-injection-python.yml
@@ -1,0 +1,13 @@
+id: shell-injection-python
+language: python
+severity: error
+message: Possible shell injection — shell=True / os.system with dynamic input
+rule:
+  any:
+    - pattern: os.system($CMD)
+    # ast-grep's multi-meta-var cannot match a trailing empty `$$$B` right
+    # after another matched arg (a napi/dynamic-lang quirk, verified against
+    # @ast-grep/napi@0.44.1 + @ast-grep/lang-python@0.0.6) — `shell=True` as
+    # the LAST arg needs its own arm alongside the "more args follow" arm.
+    - pattern: subprocess.$FN($$$A, shell=True, $$$B)
+    - pattern: subprocess.$FN($$$A, shell=True)

--- a/packages/nexus-agents/tsup.config.ts
+++ b/packages/nexus-agents/tsup.config.ts
@@ -20,7 +20,19 @@ export default defineConfig({
   // better-sqlite3 is a native C++ addon and cannot be bundled.
   // ts-morph/typescript use CommonJS internally (require("fs")) and must be external.
   // better-sqlite3 is a native C++ addon and cannot be bundled.
-  external: ['ts-morph', '@ts-morph/common', 'better-sqlite3', 'typescript'],
+  // @ast-grep/lang-{python,go} (#4249 child C) resolve their `.so` grammar via a
+  // `__dirname`-relative lookup (see @ast-grep/setup-lang's `resolvePrebuild`).
+  // Bundling would rewrite `__dirname` to point at our `dist/` output instead of
+  // the installed package directory where the prebuilt `.so`/`prebuilds/` live,
+  // so these MUST stay external like the other native-addon deps above.
+  external: [
+    'ts-morph',
+    '@ts-morph/common',
+    'better-sqlite3',
+    'typescript',
+    '@ast-grep/lang-python',
+    '@ast-grep/lang-go',
+  ],
   define: {
     __NEXUS_VERSION__: JSON.stringify(pkg.version),
   },
@@ -28,5 +40,8 @@ export default defineConfig({
     'cp -r src/workflows/templates dist/workflows/ 2>/dev/null || true',
     // T2 bundled model registry (#2174 / #2175) — runtime reads from dist
     'cp src/config/model-registry.generated.json dist/model-registry.generated.json 2>/dev/null || true',
+    // Polyglot QA/security ast-grep rules (#4249 child C) — YAML, tsup won't bundle
+    // it. Only the *.yml rules ship to dist; fixtures/ are test-only.
+    'mkdir -p dist/security/ast-rules && cp src/security/ast-rules/*.yml dist/security/ast-rules/ 2>/dev/null || true',
   ].join(' && '),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.110.0
         version: 0.110.0(zod@4.4.3)
+      '@ast-grep/lang-go':
+        specifier: 0.0.6
+        version: 0.0.6
+      '@ast-grep/lang-python':
+        specifier: 0.0.6
+        version: 0.0.6
       '@ast-grep/napi':
         specifier: 0.44.1
         version: 0.44.1
@@ -298,6 +304,22 @@ packages:
       zod:
         optional: true
 
+  '@ast-grep/lang-go@0.0.6':
+    resolution: {integrity: sha512-PZap9Rp6t+YKbLjRnFRF5aGBX3/HV9s5Rp7ZPsCM+o3tlTZDo1IqDYnFu+Oeh5Razs2U8K8ccPSJ+GBxalVhWg==}
+    peerDependencies:
+      tree-sitter-cli: 0.25.8
+    peerDependenciesMeta:
+      tree-sitter-cli:
+        optional: true
+
+  '@ast-grep/lang-python@0.0.6':
+    resolution: {integrity: sha512-eF/bEBspmrxdVuPNihvZDyyJx5qtIpGEMz9l1nNQmrji7NZcUiRNC8WwzYyQCBdy1mj8HZ0Tn4I2q3gp/6Bkiw==}
+    peerDependencies:
+      tree-sitter-cli: 0.25.8
+    peerDependenciesMeta:
+      tree-sitter-cli:
+        optional: true
+
   '@ast-grep/napi-darwin-arm64@0.44.1':
     resolution: {integrity: sha512-JPcb1PvOkwKgccGbBgtoc4e6qfx/luvAtlc6SEtNPhvSwV8qagLb9MCSDcCiuqrqICx3qHj2CXouGbs66lCFvA==}
     engines: {node: '>= 10'}
@@ -355,6 +377,9 @@ packages:
   '@ast-grep/napi@0.44.1':
     resolution: {integrity: sha512-dJAJVYRKmUjXn+4mXUgfRvMrWujB9mLzPSq/2e8J7n6Hn3dY4jpZNpChj6hMi7PlZ2J2c7coAVoDBaax06uvXw==}
     engines: {node: '>= 10'}
+
+  '@ast-grep/setup-lang@0.0.6':
+    resolution: {integrity: sha512-aSYZNF5nGQMxnwiA3Lcc8zi0AtpGlug47ADgqCgP/2n7p922FbnW7vo1rbW4kKjW72B/3mDdN7uvYidv8JnPnw==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -5785,6 +5810,14 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  '@ast-grep/lang-go@0.0.6':
+    dependencies:
+      '@ast-grep/setup-lang': 0.0.6
+
+  '@ast-grep/lang-python@0.0.6':
+    dependencies:
+      '@ast-grep/setup-lang': 0.0.6
+
   '@ast-grep/napi-darwin-arm64@0.44.1':
     optional: true
 
@@ -5823,6 +5856,8 @@ snapshots:
       '@ast-grep/napi-win32-arm64-msvc': 0.44.1
       '@ast-grep/napi-win32-ia32-msvc': 0.44.1
       '@ast-grep/napi-win32-x64-msvc': 0.44.1
+
+  '@ast-grep/setup-lang@0.0.6': {}
 
   '@astrojs/check@0.9.9(prettier@3.9.4)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a new read-only runner, `runAstQaRules` (`packages/nexus-agents/src/security/ast-rule-runner.ts`, exported from `exports/security.ts`), that runs YAML-defined `@ast-grep/napi` rules against Python/Go source. Same ast-grep engine already used by `search_usages` (#4265) and the ast-fixer rewrites (#4243/#4249 child B) — no new AST dependency, just new language grammars for it.
- Ships three built-in rules under `packages/nexus-agents/src/security/ast-rules/*.yml`:
  - `dangerous-eval-python` (error) — `eval($CODE)` / `exec($CODE)`.
  - `shell-injection-python` (error) — `os.system($CMD)` / `subprocess.$FN(..., shell=True[, ...])`.
  - `command-exec-go` (warning) — `exec.Command($$$ARGS)`.
- Ships fixtures (`ast-rules/fixtures/sample.{py,go}`) with both POSITIVE hits and NEGATIVE near-misses (`evaluate`/`executor`, `subprocess.run(cmd)` with no `shell=True`, a local `Command(x)` helper, and a `myexec.Command(...)` alias) — mirroring the #4243 lesson that a rule which "sort of" matches over-fires on lookalikes.

## The dynamic-language dependency + exact-pin + lazy-registration rationale

`@ast-grep/napi@0.44.1`'s `Lang` enum ships only Html/JavaScript/Tsx/Css/TypeScript — no Python, no Go. This adds `@ast-grep/lang-python@0.0.6` and `@ast-grep/lang-go@0.0.6`, both **exact-pinned (no caret)**: these are early/experimental grammar packages where a caret range could silently swap in an incompatible native `.so` grammar build under a "safe" semver-minor bump.

Both grammars are registered via napi's `@experimental registerDynamicLanguage`, which **throws if called more than once per process** — `ensurePolyglotLangs()` is a lazy, module-level, once-only guard so repeated calls (tests, repeat invocations) never trip it.

Both grammar packages are also added to `tsup`'s `external` list (alongside `ts-morph`/`better-sqlite3`/`typescript`): they resolve their prebuilt `.so` via a `__dirname`-relative lookup that bundling would rewrite to point at `dist/` instead of the installed package directory.

Two ast-grep pattern quirks discovered and worked around (documented inline in the YAML):
- A multi-meta-var (`$$$B`) cannot match a trailing *empty* tail right after another matched arg — `subprocess.$FN($$$A, shell=True, $$$B)` needed a second arm, `subprocess.$FN($$$A, shell=True)`, for the "last arg" case.
- A bare selector-expression pattern (`exec.Command($$$ARGS)`) does not reliably match against the dynamically-registered Go grammar; the explicit `{ context, selector: call_expression }` pattern form does.

## Tarball-contents proof (build/release path, not just tests)

Ran the full verify chain against the actual published artifact, not just source:

```
$ pnpm install   # resolves @ast-grep/lang-python@0.0.6 / @ast-grep/lang-go@0.0.6, finds Linux X64 prebuilds
$ pnpm build     # tsup ESM+DTS build succeeds; onSuccess copies *.yml into dist/security/ast-rules/
$ pnpm -C packages/nexus-agents pack
$ tar tzf nexus-agents-2.170.0.tgz | grep -i ast-rules
package/src/security/ast-rules/fixtures/sample.go
package/src/security/ast-rules/fixtures/sample.py
package/dist/security/ast-rules/command-exec-go.yml
package/src/security/ast-rules/command-exec-go.yml
package/dist/security/ast-rules/dangerous-eval-python.yml
package/src/security/ast-rules/dangerous-eval-python.yml
package/dist/security/ast-rules/shell-injection-python.yml
package/src/security/ast-rules/shell-injection-python.yml
```

Then installed that tarball into a scratch project (`npm install <tarball>`) and exercised it directly:

```js
import { runAstQaRules } from 'nexus-agents';
await runAstQaRules({ targetDir: 'sample-target' }); // .py and .go fixtures
```

`registerDynamicLanguage` did **not** throw, both native grammars resolved from the installed `node_modules`, `getBuiltInAstRulesPath()` correctly resolved to the bundled `dist/security/ast-rules`, and findings came back correct for both languages (right `ruleId`/`line`/`column`/`snippet`).

## Test evidence

```
pnpm -C packages/nexus-agents test -- ast-rule-runner
✓ src/security/ast-rule-runner.test.ts (11 tests) — all green
```

Covers: per-rule red/green against fixtures (positives hit, negatives don't); loader fail-closed on malformed YAML and unknown `language` (no partial run — a single bad file fails the whole load even alongside valid ones); idempotent `ensurePolyglotLangs()` (calling it twice does not throw); the copied `resolveWithinCwd` path-traversal guard (`targetDir: '../..'` rejected); and cap/overflow (findings beyond `limit` are counted via `collectAstQaFindings`'s `total` and logged, never silently dropped).

`pnpm typecheck` and `eslint` on the changed/new files are both clean. `npx tsx scripts/generate-repo-index.ts --check` and `pnpm docs:tools:check` show no drift (no new MCP tool/CLI command registered). No new env var was added (rules dir is a function option), so the Registry-Coverage gate is not implicated.

## Deferred

MCP exposure (wiring `runAstQaRules` into `run_quality_gate` or a new tool) is deferred to #4276, to keep this surface a plain function until a named consumer needs it — avoids the Repo Index + Tool Reference + MCP Description + ENTRYPOINTS peer-file cost speculatively.

Refs #4249 (epic).

## Test plan

- [x] `pnpm install` — resolves new deps, native prebuilds found for Linux X64
- [x] `pnpm build` — ESM + DTS build succeeds
- [x] `pnpm -C packages/nexus-agents pack` — `src/security/ast-rules/*.yml` and `dist/security/ast-rules/*.yml` both present in tarball
- [x] Installed tarball in a scratch project and exercised `runAstQaRules` directly — works for both Python and Go
- [x] `pnpm -C packages/nexus-agents test -- ast-rule-runner` — 11/11 green
- [x] `pnpm -C packages/nexus-agents typecheck` — clean
- [x] `eslint` on changed/new files — clean
- [x] `generate-repo-index.ts --check` / `docs:tools:check` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)