### PR TITLE
feat(resilience): opt-in expert execution recovery policy (#4286)

### DIFF
--- a/.changeset/opt-in-expert-recovery.md
+++ b/.changeset/opt-in-expert-recovery.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+feat(resilience): opt-in expert execution recovery policy (#4286)
+
+Wire the `FailureDetector`/`RecoveryManager` resilience module into the expert
+factory as an opt-in, transient-vs-permanent execution recovery policy.
+
+- New `ExpertRecoveryPolicy` on `CreateExpertOptions`. When present, `createExpert`
+  returns a `RecoverableExpert` whose `execute()` wraps the base run in the shared
+  `withRetry`/`isRetryableError` primitives (no new retry loop) with a
+  classification predicate: caller-abort → permanent, transport 429/408/5xx/network
+  → transient, behavioral archetype (arxiv:2512.07497) → per-strategy action,
+  otherwise fail closed. Archetype retries inject recovery guidance into the next
+  attempt's prompt.
+- Default (no policy) is bit-for-bit the previous behavior — a plain `Expert`.
+- Experts created via `create_expert` (and executed via `execute_expert`) now get a
+  conservative `{ maxRetries: 1 }` inner recovery layer; the existing rate-limit CLI
+  fallback (#1532) remains the outer layer.
+- New exports: `RecoverableExpert`, `classifyExpertFailure`, `ExpertRecoveryPolicy`,
+  `FailureClassification`.

--- a/packages/nexus-agents/src/agents/experts/expert-agent.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-agent.ts
@@ -1,0 +1,38 @@
+/**
+ * nexus-agents/agents/experts - Expert Agent
+ *
+ * The concrete {@link Expert} agent class, extracted from `expert-factory.ts`
+ * so that both the factory and the opt-in recovery wrapper
+ * ({@link ./expert-recovery.ts | RecoverableExpert}) can extend/reference it
+ * without a factory↔recovery import cycle (#4286).
+ */
+
+import { SimpleAgent } from '../simple-agent.js';
+import type { BaseAgentOptions } from '../base-agent.js';
+import type { ExpertConfig } from './expert-config.js';
+
+/**
+ * Expert agent extending SimpleAgent with configuration-based setup.
+ */
+export class Expert extends SimpleAgent {
+  readonly expertConfig: ExpertConfig;
+
+  constructor(options: BaseAgentOptions, config: ExpertConfig) {
+    super(options);
+    this.expertConfig = config;
+  }
+
+  /**
+   * Get the expert's name.
+   */
+  get name(): string {
+    return this.expertConfig.name;
+  }
+
+  /**
+   * Get the expert's metadata.
+   */
+  get metadata(): Record<string, unknown> | undefined {
+    return this.expertConfig.metadata;
+  }
+}

--- a/packages/nexus-agents/src/agents/experts/expert-factory.test.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-factory.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { ExpertFactory, Expert, FactoryError, type CreateExpertOptions } from './expert-factory.js';
+import { RecoverableExpert } from './expert-recovery.js';
 import { type ExpertConfig, BUILT_IN_EXPERTS } from './expert-config.js';
 
 describe('ExpertFactory', () => {
@@ -178,6 +179,45 @@ describe('ExpertFactory', () => {
         expect(result.value.id).toBe('pruning-expert');
         // Note: context pruning is applied internally to BaseAgent
         // We verify the expert was created successfully with the config
+      }
+    });
+
+    it('should return a RecoverableExpert when a recoveryPolicy is passed (#4286)', () => {
+      const config: ExpertConfig = {
+        id: 'recoverable-expert',
+        name: 'Recoverable Expert',
+        role: 'code_expert',
+        systemPrompt: 'Prompt.',
+        capabilities: ['task_execution'],
+      };
+
+      const options: CreateExpertOptions = { recoveryPolicy: { maxRetries: 1 } };
+
+      const result = ExpertFactory.create(config, options);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeInstanceOf(RecoverableExpert);
+        // RecoverableExpert must still be an Expert (subclass).
+        expect(result.value).toBeInstanceOf(Expert);
+      }
+    });
+
+    it('should return a plain Expert (not RecoverableExpert) without a policy (#4286)', () => {
+      const config: ExpertConfig = {
+        id: 'plain-expert',
+        name: 'Plain Expert',
+        role: 'code_expert',
+        systemPrompt: 'Prompt.',
+        capabilities: ['task_execution'],
+      };
+
+      const result = ExpertFactory.create(config);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeInstanceOf(Expert);
+        expect(result.value).not.toBeInstanceOf(RecoverableExpert);
       }
     });
 

--- a/packages/nexus-agents/src/agents/experts/expert-factory.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-factory.ts
@@ -13,9 +13,10 @@ import { extractLessons, formatLessonsForPrompt } from '../../orchestration/fail
 import type { TaskCategory } from '../../config/task-specialization-types.js';
 import type { ICTMConfig } from '../ictm/ictm-types.js';
 import { ictmToExpertConfig } from '../ictm/ictm-factory.js';
-import { SimpleAgent } from '../simple-agent.js';
 import type { BaseAgentOptions } from '../base-agent.js';
 import type { ContextPrunerAgentConfig } from '../base-agent-pruning-init.js';
+import { Expert } from './expert-agent.js';
+import { RecoverableExpert, type ExpertRecoveryPolicy } from './expert-recovery.js';
 import {
   type ExpertConfig,
   type BuiltInExpertType,
@@ -25,6 +26,10 @@ import {
   BuiltInExpertTypeSchema,
   BUILT_IN_EXPERTS,
 } from './expert-config.js';
+
+// Re-export the Expert class (moved to ./expert-agent.ts to break the
+// factory↔recovery import cycle, #4286) for backward-compatible imports.
+export { Expert } from './expert-agent.js';
 
 /**
  * Error specific to factory operations.
@@ -53,32 +58,16 @@ export interface CreateExpertOptions {
    * Since Issue #479, context pruning is enabled by default.
    */
   contextPruning?: ContextPrunerAgentConfig;
-}
-
-/**
- * Expert agent extending SimpleAgent with configuration-based setup.
- */
-export class Expert extends SimpleAgent {
-  readonly expertConfig: ExpertConfig;
-
-  constructor(options: BaseAgentOptions, config: ExpertConfig) {
-    super(options);
-    this.expertConfig = config;
-  }
-
   /**
-   * Get the expert's name.
+   * Opt-in transient-vs-permanent execution recovery policy (#4286).
+   *
+   * When present, `createExpert` returns a {@link RecoverableExpert} whose
+   * `execute()` retries transient failures (transport 429/5xx/network errors,
+   * and archetype failures classified as recoverable) with exponential backoff,
+   * and fails closed on permanent failures. When ABSENT, a plain {@link Expert}
+   * is constructed and behavior is bit-for-bit identical to the pre-#4286 path.
    */
-  get name(): string {
-    return this.expertConfig.name;
-  }
-
-  /**
-   * Get the expert's metadata.
-   */
-  get metadata(): Record<string, unknown> | undefined {
-    return this.expertConfig.metadata;
-  }
+  recoveryPolicy?: ExpertRecoveryPolicy;
 }
 
 // buildValidationError removed - use formatZodError from core/index.js instead
@@ -254,7 +243,13 @@ export function createExpert(
   const agentOptions = buildAgentOptions(validConfig, options);
 
   try {
-    const expert = new Expert(agentOptions, validConfig);
+    // Opt-in recovery (#4286): when a policy is supplied, wrap execution in the
+    // transient-vs-permanent retry policy; otherwise the plain Expert path is
+    // bit-for-bit unchanged.
+    const expert =
+      options?.recoveryPolicy !== undefined
+        ? new RecoverableExpert(agentOptions, validConfig, options.recoveryPolicy)
+        : new Expert(agentOptions, validConfig);
     return ok(expert);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/nexus-agents/src/agents/experts/expert-recovery.test.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-recovery.test.ts
@@ -1,0 +1,227 @@
+/**
+ * nexus-agents/agents/experts - Expert Recovery Tests (#4286)
+ *
+ * Covers the opt-in transient-vs-permanent execution recovery policy wired into
+ * the expert factory. Uses a mock IModelAdapter per expert-factory.test.ts /
+ * simple-agent.test.ts conventions, with baseDelayMs: 0 so retries are instant.
+ */
+
+import { describe, it, expect, vi, afterEach, type Mock } from 'vitest';
+import type { IModelAdapter, CompletionResponse, StreamChunk, Task } from '../../core/index.js';
+import { ok, ModelError, AgentError, ErrorCode } from '../../core/index.js';
+import { createExpert, Expert } from './expert-factory.js';
+import {
+  RecoverableExpert,
+  classifyExpertFailure,
+  type ExpertRecoveryPolicy,
+} from './expert-recovery.js';
+import { FailureDetector } from '../resilience/index.js';
+import type { ExpertConfig } from './expert-config.js';
+
+/** A completion response carrying non-empty text so executeTask succeeds. */
+function textResponse(text = 'Recovered output'): CompletionResponse {
+  return {
+    content: [{ type: 'text', text }],
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    stopReason: 'end_turn',
+    model: 'test-model',
+  };
+}
+
+/**
+ * Mock adapter whose `complete` is a vi.fn the test wires with
+ * mockResolvedValue/mockRejectedValue sequences.
+ */
+function createMockAdapter(complete: Mock): IModelAdapter {
+  return {
+    providerId: 'test-provider',
+    modelId: 'test-model',
+    capabilities: ['completion'],
+    complete,
+    stream: vi.fn().mockImplementation(function* (): Iterable<StreamChunk> {
+      yield { type: 'message_start', message: { model: 'test-model' } };
+      yield { type: 'message_stop' };
+    }),
+    countTokens: vi.fn().mockResolvedValue(10),
+    validateConfig: vi.fn().mockReturnValue(ok(undefined)),
+  };
+}
+
+function baseConfig(): ExpertConfig {
+  return {
+    id: 'recovery-expert',
+    name: 'Recovery Expert',
+    role: 'code_expert',
+    systemPrompt: 'You are a test expert.',
+    capabilities: ['task_execution'],
+  };
+}
+
+/** Builds a task; buildPrompt turns description into the last user message. */
+function makeTask(description = 'Do the thing'): Task {
+  return { id: 'task-1', description, context: {} };
+}
+
+/** An Error carrying an HTTP status, as thrown by HTTP-style adapters. */
+function statusError(status: number, message: string): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+function createRecoverableExpert(policy: ExpertRecoveryPolicy, complete: Mock): RecoverableExpert {
+  const result = createExpert(baseConfig(), {
+    adapter: createMockAdapter(complete),
+    recoveryPolicy: policy,
+  });
+  if (!result.ok) throw new Error(`createExpert failed: ${result.error.message}`);
+  expect(result.value).toBeInstanceOf(RecoverableExpert);
+  return result.value as RecoverableExpert;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('classifyExpertFailure', () => {
+  const detector = new FailureDetector();
+
+  it('classifies a caller-aborted signal as permanent (guard, not transient)', () => {
+    const controller = new AbortController();
+    controller.abort();
+    // Message matches /aborted/i which is otherwise transport-retryable.
+    const c = classifyExpertFailure(
+      new Error('request aborted'),
+      detector,
+      'task',
+      controller.signal
+    );
+    expect(c).toEqual({ kind: 'permanent', source: 'default' });
+  });
+
+  it('classifies a 503 status error as transient transport', () => {
+    const c = classifyExpertFailure(statusError(503, 'Service Unavailable'), detector);
+    expect(c.kind).toBe('transient');
+    expect(c.source).toBe('transport');
+  });
+
+  it('classifies a wrapped NexusError rate-limit (via cause chain) as transient', () => {
+    const cause = new ModelError('rate limited', { code: ErrorCode.MODEL_RATE_LIMITED });
+    const wrapped = new AgentError('Model completion failed: rate limited', { cause });
+    expect(classifyExpertFailure(wrapped, detector).kind).toBe('transient');
+  });
+
+  it('classifies a 401 as permanent (fail closed)', () => {
+    const c = classifyExpertFailure(statusError(401, 'Invalid API key'), detector);
+    expect(c.kind).toBe('permanent');
+  });
+
+  it('maps a recoverable behavioral archetype to transient/archetype', () => {
+    const lowThreshold = new FailureDetector({ confidenceThreshold: 0.1 });
+    const c = classifyExpertFailure(
+      new Error('failed to parse tool output'),
+      lowThreshold,
+      'run the tool'
+    );
+    expect(c.source).toBe('archetype');
+    expect(c.kind).toBe('transient');
+    expect(c.archetype).toBe('fragile_execution');
+  });
+});
+
+describe('RecoverableExpert.execute', () => {
+  it('retries a transient failure then succeeds (adapter called 2x)', async () => {
+    const complete = vi.fn();
+    complete.mockRejectedValueOnce(statusError(503, 'Service Unavailable'));
+    complete.mockResolvedValueOnce(ok(textResponse('Recovered')));
+    const expert = createRecoverableExpert({ maxRetries: 1, baseDelayMs: 0 }, complete);
+
+    const result = await expert.execute(makeTask());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.output).toBe('Recovered');
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed on a permanent failure without retrying (adapter called 1x)', async () => {
+    const complete = vi.fn().mockRejectedValue(statusError(401, 'Invalid API key'));
+    const expert = createRecoverableExpert({ maxRetries: 2, baseDelayMs: 0 }, complete);
+
+    const result = await expert.execute(makeTask());
+
+    expect(result.ok).toBe(false);
+    expect(complete).toHaveBeenCalledTimes(1);
+    if (!result.ok) {
+      const recovery = (result.error.context?.['recovery'] ?? {}) as Record<string, unknown>;
+      expect(recovery['classification']).toBe('permanent');
+    }
+  });
+
+  it('retries a recoverable archetype and injects guidance into the retry', async () => {
+    const complete = vi.fn();
+    complete.mockRejectedValueOnce(new Error('failed to parse tool output'));
+    complete.mockResolvedValueOnce(ok(textResponse('Fixed')));
+    const expert = createRecoverableExpert(
+      { maxRetries: 1, baseDelayMs: 0, detectorConfig: { confidenceThreshold: 0.1 } },
+      complete
+    );
+
+    const result = await expert.execute(makeTask('call the parser'));
+
+    expect(result.ok).toBe(true);
+    expect(complete).toHaveBeenCalledTimes(2);
+    // The retried request must carry the injected recovery guidance.
+    const secondCall = complete.mock.calls[1]?.[0] as { messages: { content: string }[] };
+    const combined = secondCall.messages.map((m) => m.content).join('\n');
+    expect(combined).toContain('RECOVERY MODE');
+  });
+
+  it('bounds retries: always-503 with maxRetries:2 → exactly 3 attempts', async () => {
+    const complete = vi.fn().mockRejectedValue(statusError(503, 'Service Unavailable'));
+    const expert = createRecoverableExpert({ maxRetries: 2, baseDelayMs: 0 }, complete);
+
+    const result = await expert.execute(makeTask());
+
+    expect(result.ok).toBe(false);
+    expect(complete).toHaveBeenCalledTimes(3);
+    if (!result.ok) {
+      const recovery = (result.error.context?.['recovery'] ?? {}) as Record<string, unknown>;
+      expect(recovery['attempts']).toBe(3);
+    }
+  });
+
+  it('does not retry when the caller signal is pre-aborted (1 attempt, permanent)', async () => {
+    const complete = vi.fn().mockResolvedValue(ok(textResponse()));
+    const expert = createRecoverableExpert({ maxRetries: 3, baseDelayMs: 0 }, complete);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await expert.execute(makeTask(), { signal: controller.signal });
+
+    expect(result.ok).toBe(false);
+    // Pre-aborted → base execute() returns the cancel error before any model call.
+    expect(complete).toHaveBeenCalledTimes(0);
+    if (!result.ok) {
+      const recovery = (result.error.context?.['recovery'] ?? {}) as Record<string, unknown>;
+      expect(recovery['classification']).toBe('permanent');
+    }
+  });
+});
+
+describe('createExpert without a recovery policy (default no-op)', () => {
+  it('returns a plain Expert whose failing adapter is called exactly once', async () => {
+    const complete = vi.fn().mockRejectedValue(statusError(503, 'Service Unavailable'));
+    const result = createExpert(baseConfig(), {
+      adapter: createMockAdapter(complete),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBeInstanceOf(Expert);
+    expect(result.value).not.toBeInstanceOf(RecoverableExpert);
+
+    const execResult = await result.value.execute(makeTask());
+
+    expect(execResult.ok).toBe(false);
+    // No recovery wrapper → no retry: exactly one model call.
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/agents/experts/expert-recovery.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-recovery.ts
@@ -1,0 +1,357 @@
+/**
+ * nexus-agents/agents/experts - Expert Execution Recovery (#4286)
+ *
+ * Wires the resilience {@link FailureDetector} + {@link RecoveryManager} into an
+ * opt-in expert-execution recovery policy. {@link RecoverableExpert} overrides
+ * `execute()` to wrap the base run in the canonical `withRetry` primitive
+ * (adapters/retry.ts) with a transient-vs-permanent classification predicate:
+ *
+ *  1. caller cancellation (`options.signal` aborted)     → PERMANENT
+ *  2. transport-retryable (429/408/5xx/network/NexusError) → TRANSIENT
+ *  3. behavioral archetype (arxiv:2512.07497)            → per-strategy action
+ *  4. otherwise                                          → PERMANENT (fail closed)
+ *
+ * The retry loop, backoff, and jitter are NOT reimplemented here — they are the
+ * shared `withRetry`/`isRetryableError` primitives (adapters/retry.ts:9-19
+ * forbids a third retry loop). Delay/attempt knobs default to
+ * `DEFAULT_RETRY_CONFIG` (derived from config/defaults.ts RETRY_DEFAULTS).
+ */
+
+import type {
+  Result,
+  Task,
+  TaskResult,
+  TaskHistoryItem,
+  Message,
+  ILogger,
+} from '../../core/index.js';
+import {
+  ok,
+  err,
+  AgentError,
+  getErrorMessage,
+  getTimeProvider,
+  createLogger,
+} from '../../core/index.js';
+import type { BaseAgentOptions } from '../base-agent.js';
+import {
+  withRetry,
+  isRetryableError,
+  DEFAULT_RETRY_CONFIG,
+  RetryExhaustedError,
+  type RetryConfig,
+  type RetryAttemptInfo,
+} from '../../adapters/index.js';
+import {
+  FailureDetector,
+  RecoveryManager,
+  DEFAULT_RECOVERY_STRATEGIES,
+  DEFAULT_DETECTOR_CONFIG,
+  type DetectorConfig,
+  type FailureArchetype,
+  type DetectedFailure,
+  type RecoveryAction,
+} from '../resilience/index.js';
+import { Expert } from './expert-agent.js';
+import type { ExpertConfig } from './expert-config.js';
+
+/**
+ * Opt-in recovery policy attached to an expert at creation time. All fields are
+ * optional and fall through to {@link DEFAULT_RETRY_CONFIG} (retry knobs) and
+ * {@link DEFAULT_DETECTOR_CONFIG} (detector).
+ */
+export interface ExpertRecoveryPolicy {
+  /** Maximum retries (attempts = maxRetries + 1). Default: DEFAULT_RETRY_CONFIG. */
+  maxRetries?: number;
+  /** Base backoff delay (ms). Default: DEFAULT_RETRY_CONFIG. */
+  baseDelayMs?: number;
+  /** Maximum backoff delay (ms). Default: DEFAULT_RETRY_CONFIG. */
+  maxDelayMs?: number;
+  /** Jitter factor (0-1). Default: DEFAULT_RETRY_CONFIG. */
+  jitterFactor?: number;
+  /** Override the failure detector configuration. */
+  detectorConfig?: Partial<DetectorConfig>;
+}
+
+/**
+ * The outcome of classifying a single failed execution attempt.
+ * - `transient`: retry (transport error, or a recoverable behavioral archetype)
+ * - `permanent`: fail closed (cancelled, non-retryable, or a terminal archetype)
+ */
+export type FailureClassification = {
+  kind: 'transient' | 'permanent';
+  source: 'transport' | 'archetype' | 'default';
+  archetype?: FailureArchetype;
+  confidence?: number;
+};
+
+/** Archetype recovery actions that warrant a retry (vs. terminate). */
+const RECOVERABLE_ACTIONS: ReadonlySet<RecoveryAction> = new Set<RecoveryAction>([
+  'retry_with_inspection',
+  'tool_validation',
+  'context_reset',
+]);
+
+/**
+ * Walks an error's `cause` chain, returning true if any link is a transport-
+ * retryable error. `execute()` wraps the underlying transport error as the
+ * `cause` of an AgentError, so the top-level error alone is not enough.
+ */
+function isRetryableErrorChain(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; current !== null && current !== undefined && depth < 10; depth++) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    if (isRetryableError(current)) return true;
+    current = current instanceof Error ? (current as { cause?: unknown }).cause : undefined;
+  }
+  return false;
+}
+
+/**
+ * Collects the messages from an error and its `cause` chain so the behavioral
+ * detector sees the underlying failure text (not just the AgentError wrapper).
+ */
+function extractErrorMessage(error: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; current !== null && current !== undefined && depth < 10; depth++) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    parts.push(getErrorMessage(current));
+    current = current instanceof Error ? (current as { cause?: unknown }).cause : undefined;
+  }
+  return parts.join(' :: ');
+}
+
+/** Selects the highest-confidence detected failure. */
+function highestConfidenceFailure(
+  failures: readonly DetectedFailure[]
+): DetectedFailure | undefined {
+  return failures.reduce<DetectedFailure | undefined>((best, f) => {
+    if (best === undefined || f.confidence > best.confidence) return f;
+    return best;
+  }, undefined);
+}
+
+/**
+ * Classifies a single failed execution attempt as transient or permanent.
+ *
+ * See the module header for the ordered decision procedure. `signal` is checked
+ * first (mandatory guard): RETRYABLE_ERROR_PATTERNS matches /aborted/i, so
+ * without this a cancelled task would otherwise be retried.
+ */
+export function classifyExpertFailure(
+  error: unknown,
+  detector: FailureDetector,
+  taskDescription?: string,
+  signal?: AbortSignal
+): FailureClassification {
+  // 1. Caller cancellation → permanent (fail closed, do not retry).
+  if (signal?.aborted === true) {
+    return { kind: 'permanent', source: 'default' };
+  }
+
+  // 2. Transport-retryable (429/408/5xx/ECONNRESET/…, NexusError rate-limit/
+  //    timeout/unavailable codes) anywhere in the cause chain → transient.
+  if (isRetryableErrorChain(error)) {
+    return { kind: 'transient', source: 'transport' };
+  }
+
+  // 3. Behavioral archetype (arxiv:2512.07497) → map to its recovery action.
+  const detection = detector.detect({
+    messages: [{ role: 'assistant', content: extractErrorMessage(error) }],
+    ...(taskDescription !== undefined ? { taskDescription } : {}),
+  });
+  if (detection.hasFailure) {
+    const top = highestConfidenceFailure(detection.failures);
+    if (top !== undefined) {
+      const action = DEFAULT_RECOVERY_STRATEGIES[top.archetype].action;
+      return {
+        kind: RECOVERABLE_ACTIONS.has(action) ? 'transient' : 'permanent',
+        source: 'archetype',
+        archetype: top.archetype,
+        confidence: top.confidence,
+      };
+    }
+  }
+
+  // 4. Fail closed.
+  return { kind: 'permanent', source: 'default' };
+}
+
+/** Merges a policy's retry knobs over DEFAULT_RETRY_CONFIG (no magic numbers). */
+function mergeRecoveryConfig(policy: ExpertRecoveryPolicy): RetryConfig {
+  return {
+    maxRetries: policy.maxRetries ?? DEFAULT_RETRY_CONFIG.maxRetries,
+    baseDelayMs: policy.baseDelayMs ?? DEFAULT_RETRY_CONFIG.baseDelayMs,
+    maxDelayMs: policy.maxDelayMs ?? DEFAULT_RETRY_CONFIG.maxDelayMs,
+    jitterFactor: policy.jitterFactor ?? DEFAULT_RETRY_CONFIG.jitterFactor,
+  };
+}
+
+/** Builds the `context.recovery` trace object. */
+function buildRecoveryTrace(
+  exhausted: RetryExhaustedError,
+  classification: FailureClassification | undefined
+): Record<string, unknown> {
+  const recovery: Record<string, unknown> = {
+    attempts: exhausted.attempts,
+    classification: classification?.kind ?? 'permanent',
+  };
+  if (classification?.source !== undefined) recovery.source = classification.source;
+  if (classification?.archetype !== undefined) recovery.archetype = classification.archetype;
+  return recovery;
+}
+
+/** Resolves the cause to preserve on the annotated error. */
+function resolveRecoveryCause(base: AgentError | undefined, lastError: unknown): Error | undefined {
+  if (base?.cause !== undefined) return base.cause;
+  return lastError instanceof Error ? lastError : undefined;
+}
+
+/**
+ * Builds the AgentError returned when recovery is exhausted or the failure is
+ * permanent. Unwraps the last underlying error (returns it enriched if it is an
+ * AgentError, else wraps it) and annotates `context.recovery` with the trace.
+ */
+function annotateRecoveryFailure(
+  exhausted: RetryExhaustedError,
+  classification: FailureClassification | undefined,
+  expertId: string
+): AgentError {
+  const lastError = exhausted.lastError;
+  const base = lastError instanceof AgentError ? lastError : undefined;
+  const context: Record<string, unknown> = {
+    ...(base?.context ?? {}),
+    expertId,
+    recovery: buildRecoveryTrace(exhausted, classification),
+  };
+  const opts: { context: Record<string, unknown>; cause?: Error } = { context };
+  const cause = resolveRecoveryCause(base, lastError);
+  if (cause !== undefined) opts.cause = cause;
+  return new AgentError(base?.message ?? getErrorMessage(lastError), opts);
+}
+
+/**
+ * An {@link Expert} whose `execute()` applies a transient-vs-permanent recovery
+ * policy. Wrapping at `execute()` (not `executeTask()`) reuses the base
+ * state-machine auto-reset (#1060) and per-attempt heartbeat/timeout.
+ */
+export class RecoverableExpert extends Expert {
+  private readonly detector: FailureDetector;
+  private readonly recoveryManager: RecoveryManager;
+  private readonly recoveryConfig: RetryConfig;
+  private readonly recoveryLogger: ILogger;
+
+  constructor(options: BaseAgentOptions, config: ExpertConfig, policy: ExpertRecoveryPolicy) {
+    super(options, config);
+    this.detector = new FailureDetector(policy.detectorConfig ?? {});
+    this.recoveryManager = new RecoveryManager();
+    this.recoveryConfig = mergeRecoveryConfig(policy);
+    this.recoveryLogger =
+      options.logger ?? createLogger({ component: 'RecoverableExpert', expert: config.id });
+  }
+
+  override async execute(
+    task: Task,
+    options?: { signal?: AbortSignal }
+  ): Promise<Result<TaskResult, AgentError>> {
+    let currentTask = task;
+    let lastClassification: FailureClassification | undefined;
+    const signal = options?.signal;
+
+    const outcome = await withRetry<TaskResult>(
+      async () => {
+        const r = await super.execute(currentTask, options);
+        // Convert err() → throw so withRetry drives the retry loop.
+        if (!r.ok) throw r.error;
+        return r.value;
+      },
+      {
+        config: this.recoveryConfig,
+        isRetryable: (error: unknown): boolean => {
+          lastClassification = classifyExpertFailure(
+            error,
+            this.detector,
+            currentTask.description,
+            signal
+          );
+          return lastClassification.kind === 'transient';
+        },
+        onRetry: (info: RetryAttemptInfo): void => {
+          this.recoveryLogger.info('Expert execution retry', {
+            expertId: this.expertConfig.id,
+            attempt: info.attempt,
+            delayMs: info.delayMs,
+            classification: lastClassification?.kind,
+            source: lastClassification?.source,
+            archetype: lastClassification?.archetype,
+          });
+          // Archetype recovery: inject archetype-specific guidance into the next
+          // attempt's prompt via a mutable task copy.
+          if (
+            lastClassification?.source === 'archetype' &&
+            lastClassification.archetype !== undefined
+          ) {
+            currentTask = this.injectRecoveryGuidance(
+              currentTask,
+              lastClassification.archetype,
+              info
+            );
+          }
+        },
+      }
+    );
+
+    if (outcome.ok) return ok(outcome.value);
+    return err(annotateRecoveryFailure(outcome.error, lastClassification, this.expertConfig.id));
+  }
+
+  /** Appends archetype recovery guidance to a mutable copy of the task. */
+  private injectRecoveryGuidance(
+    task: Task,
+    archetype: FailureArchetype,
+    info: RetryAttemptInfo
+  ): Task {
+    const failure = this.buildDetectedFailure(archetype, info.error, task.description);
+    const instructions = this.recoveryManager.generateRecoveryInstructions({
+      task,
+      messages: [],
+      failure,
+      attemptNumber: info.attempt,
+    });
+    const historyItem: TaskHistoryItem = {
+      role: 'user',
+      content: instructions.systemPromptAddition,
+      timestamp: getTimeProvider().nowIso(),
+    };
+    const history = task.context.history ?? [];
+    return {
+      ...task,
+      context: { ...task.context, history: [...history, historyItem] },
+    };
+  }
+
+  /** Recovers the DetectedFailure for an archetype (re-detect, else synthesize). */
+  private buildDetectedFailure(
+    archetype: FailureArchetype,
+    error: unknown,
+    taskDescription: string
+  ): DetectedFailure {
+    const messages: Message[] = [{ role: 'assistant', content: extractErrorMessage(error) }];
+    const detection = this.detector.detect({ messages, taskDescription });
+    const match = detection.failures.find((f) => f.archetype === archetype);
+    if (match !== undefined) return match;
+    return {
+      archetype,
+      severity: 'medium',
+      description: DEFAULT_RECOVERY_STRATEGIES[archetype].instructions,
+      indicators: [],
+      confidence: DEFAULT_DETECTOR_CONFIG.confidenceThreshold,
+      timestamp: getTimeProvider().now(),
+    };
+  }
+}

--- a/packages/nexus-agents/src/agents/experts/index.ts
+++ b/packages/nexus-agents/src/agents/experts/index.ts
@@ -105,6 +105,14 @@ export {
   type CreateExpertOptions,
 } from './expert-factory.js';
 
+// Opt-in expert execution recovery (#4286)
+export {
+  RecoverableExpert,
+  classifyExpertFailure,
+  type ExpertRecoveryPolicy,
+  type FailureClassification,
+} from './expert-recovery.js';
+
 // Registry for managing experts
 export {
   ExpertRegistry,

--- a/packages/nexus-agents/src/agents/index.ts
+++ b/packages/nexus-agents/src/agents/index.ts
@@ -207,6 +207,11 @@ export {
   FactoryError,
   createFromICTM,
   type CreateExpertOptions,
+  // Opt-in execution recovery (#4286)
+  RecoverableExpert,
+  classifyExpertFailure,
+  type ExpertRecoveryPolicy,
+  type FailureClassification,
   // Registry
   ExpertRegistry,
   RegistryError,

--- a/packages/nexus-agents/src/exports/agents.ts
+++ b/packages/nexus-agents/src/exports/agents.ts
@@ -76,6 +76,11 @@ export {
   Expert,
   FactoryError,
   type CreateExpertOptions,
+  // Opt-in execution recovery (#4286)
+  RecoverableExpert,
+  classifyExpertFailure,
+  type ExpertRecoveryPolicy,
+  type FailureClassification,
   ExpertRegistry,
   RegistryError,
   getExpertRegistry,

--- a/packages/nexus-agents/src/mcp/tools/create-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/create-expert.ts
@@ -25,6 +25,7 @@ import {
   ExpertFactory,
   Expert,
   type BuiltInExpertType,
+  type ExpertRecoveryPolicy,
   BUILT_IN_EXPERTS,
 } from '../../agents/index.js';
 import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.js';
@@ -91,7 +92,7 @@ export type CreateExpertInput = z.infer<typeof CreateExpertInputSchema>;
 export interface IExpertFactory {
   createBuiltIn(
     type: BuiltInExpertType,
-    options?: { modelOverrides?: { modelId?: string } }
+    options?: { modelOverrides?: { modelId?: string }; recoveryPolicy?: ExpertRecoveryPolicy }
   ): { ok: true; value: Expert } | { ok: false; error: Error };
 }
 
@@ -195,6 +196,12 @@ function createExpertFromFactory(
   if (adapter !== undefined) {
     options.adapter = adapter;
   }
+
+  // Opt-in execution recovery (#4286): experts run via `execute_expert` get a
+  // conservative 1-retry transient policy (transport 429/5xx/network + recoverable
+  // behavioral archetypes). The rate-limit CLI-fallback (#1532) in execute-expert
+  // remains the OUTER recovery layer, engaged only if this inner retry still fails.
+  options.recoveryPolicy = { maxRetries: 1 };
 
   const factoryOptions = Object.keys(options).length > 0 ? options : undefined;
   const result = deps.expertFactory.createBuiltIn(expertType, factoryOptions);

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.test.ts
@@ -3,9 +3,11 @@
  * (Source: Issue #500 - Add missing MCP tool test files)
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { ILogger } from '../../core/index.js';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import type { ILogger, IModelAdapter, CompletionResponse, StreamChunk } from '../../core/index.js';
+import { ok } from '../../core/index.js';
 import type { Expert } from '../../agents/index.js';
+import { ExpertFactory, RecoverableExpert } from '../../agents/index.js';
 import { RateLimiter } from '../middleware/index.js';
 import {
   ExecuteExpertInputSchema,
@@ -610,5 +612,65 @@ describe('maybeFetchContextPrefix gate (#3238)', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('execute_expert recovery policy integration (#4286)', () => {
+  /** Mock adapter whose `complete` is a caller-supplied vi.fn. */
+  function mockAdapter(complete: Mock): IModelAdapter {
+    return {
+      providerId: 'test-provider',
+      modelId: 'test-model',
+      capabilities: ['completion'],
+      complete,
+      stream: vi.fn().mockImplementation(function* (): Iterable<StreamChunk> {
+        yield { type: 'message_start', message: { model: 'test-model' } };
+        yield { type: 'message_stop' };
+      }),
+      countTokens: vi.fn().mockResolvedValue(10),
+      validateConfig: vi.fn().mockReturnValue(ok(undefined)),
+    };
+  }
+
+  function textResponse(text: string): CompletionResponse {
+    return {
+      content: [{ type: 'text', text }],
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      stopReason: 'end_turn',
+      model: 'test-model',
+    };
+  }
+
+  it('recovers a transient failure through the expert.execute tool call without CLI fallback', async () => {
+    // Mirror create_expert (#4286): experts get a conservative { maxRetries: 1 }.
+    const complete = vi.fn();
+    complete.mockRejectedValueOnce(
+      Object.assign(new Error('Service Unavailable'), { status: 503 })
+    );
+    complete.mockResolvedValueOnce(ok(textResponse('Recovered answer')));
+
+    const created = ExpertFactory.create(
+      {
+        id: 'code-expert',
+        name: 'Code Expert',
+        role: 'code_expert',
+        systemPrompt: 'You are a code expert.',
+        capabilities: ['task_execution'],
+      },
+      { adapter: mockAdapter(complete), recoveryPolicy: { maxRetries: 1, baseDelayMs: 0 } }
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    expect(created.value).toBeInstanceOf(RecoverableExpert);
+
+    // Exactly the call the tool makes at runExpert (execute-expert.ts:~603).
+    const task = buildTask({ expertId: 'code-expert', task: 'Review this code' });
+    const result = await created.value.execute(task);
+
+    // Inner transient recovery succeeds → the tool's rate-limit CLI fallback
+    // (#1532, engaged only on !result.ok) is never reached.
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.output).toBe('Recovered answer');
+    expect(complete).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -496,7 +496,14 @@ async function tryExpertFallback(
   const fallbackAdapter = registry.getAdapterForCli(fallbackCli);
   logger?.info('Retrying expert with fallback CLI', { role: expert.role, fallbackCli });
 
-  const fallbackResult = createExpert(expert.expertConfig, { adapter: fallbackAdapter });
+  // #4286: the outer CLI-fallback expert (#1532) also gets the conservative
+  // inner transient recovery, so a one-off transient blip on the fallback
+  // adapter doesn't collapse the last recovery layer. The primary expert's own
+  // { maxRetries: 1 } policy is wired at its creation site (create-expert.ts).
+  const fallbackResult = createExpert(expert.expertConfig, {
+    adapter: fallbackAdapter,
+    recoveryPolicy: { maxRetries: 1 },
+  });
   if (!fallbackResult.ok) return undefined;
 
   const fallbackStart = getTimeProvider().now();


### PR DESCRIPTION
## Summary

Closes #4286. Wires the `FailureDetector` + `RecoveryManager` resilience module into `ExpertFactory` as an **opt-in**, transient-vs-permanent expert-execution recovery policy. Default (no policy) is bit-for-bit the current behavior.

## Approach

- **`CreateExpertOptions.recoveryPolicy?: ExpertRecoveryPolicy`** (new). When present, `createExpert` returns a `RecoverableExpert extends Expert` whose `execute()` wraps `super.execute()` in the shared `withRetry`/`isRetryableError` primitives (adapters/retry.ts) — **no new retry loop**. Wrapping at `execute()` (not `executeTask()`) reuses the base state-machine auto-reset (#1060) and per-attempt heartbeat/timeout. When absent, a plain `Expert` is constructed (unchanged path).
- **Classification predicate** (`classifyExpertFailure`), per failed attempt on the AgentError (the wrapper converts `err()` -> `throw` so `withRetry` drives it):
  1. caller `options.signal` aborted -> **permanent** (mandatory guard: `RETRYABLE_ERROR_PATTERNS` matches `/aborted/i`).
  2. transport-retryable (429/408/5xx/ECONNRESET/…, NexusError rate-limit/timeout/unavailable) anywhere in the `cause` chain -> **transient**.
  3. else behavioral archetype (arxiv:2512.07497) via `FailureDetector` -> highest-confidence archetype mapped to `DEFAULT_RECOVERY_STRATEGIES[archetype].action`: `retry_with_inspection`/`tool_validation`/`context_reset` -> transient; `request_clarification`/`escalate`/`abort` -> permanent.
  4. else -> **permanent** (fail closed).
  On archetype retry, `RecoveryManager.generateRecoveryInstructions` guidance is appended to a mutable task copy's `context.history`. On exhaustion the underlying AgentError is annotated with `context.recovery = { attempts, classification, archetype? }`. No magic numbers — delay/attempt knobs derive from `DEFAULT_RETRY_CONFIG`.
- **Consumer wiring**: experts created via `create_expert` (`create-expert.ts`) get a conservative `{ maxRetries: 1 }` inner recovery layer, so every expert run through `execute_expert` is recoverable. `execute-expert.ts` also creates its CLI-fallback expert (#1532) with the same policy; that rate-limit CLI fallback remains the **outer** recovery layer.
- **Import cycle**: the `Expert` class was extracted into a new `expert-agent.ts` so both the factory and the recovery wrapper reference it without a factory<->recovery cycle; `expert-factory.ts` re-exports `Expert` for backward compatibility.
- **Barrels** (all three): `agents/experts/index.ts`, `agents/index.ts`, `exports/agents.ts` export `RecoverableExpert`, `classifyExpertFailure`, `ExpertRecoveryPolicy`, `FailureClassification`.

## Tests

- New `expert-recovery.test.ts` (11): transient->retry, permanent->fail-closed, archetype->retry+guidance-injection, bounded exhaustion, abort->no-retry, default no-op; plus `classifyExpertFailure` unit cases.
- Extended `expert-factory.test.ts`: returns `RecoverableExpert` with a policy, plain `Expert` without.
- Extended `execute-expert.test.ts`: transient-then-success through the `expert.execute` tool call succeeds without engaging the CLI fallback.

Results:
- `pnpm build`: clean.
- Affected suites (`expert-recovery expert-factory execute-expert`): **103 passed / 0 failed** (5 files).
- Full `nexus-agents` suite: **27620 passed, 16 skipped, 0 failed**.
- `pnpm lint` on changed files: clean.

## Deviations from the plan

- **`retry.ts` path**: the plan cited `agents/adapters/retry.ts`; it actually lives at `src/adapters/retry.ts`. Imported from there.
- **New file `expert-agent.ts`**: not in the plan. Required to break the `expert-factory` <-> `expert-recovery` static import cycle (`RecoverableExpert extends Expert` needs `Expert` at class-eval time). Holds only the extracted `Expert` class; re-exported from the factory so all existing `import { Expert }` sites are unchanged.
- **Consumer site**: the plan named `execute-expert.ts` at "the expert-creation site feeding runExpert (~line 603)", but that file **looks the expert up from the shared registry** — it does not create it. The expert that `runExpert` executes is created in `create-expert.ts`, so the primary policy is wired there; `execute-expert.ts` additionally wires the policy on its one creation site (the CLI-fallback expert). Both files are now real consumers.

Zod-input exposure of the recovery policy (surfacing it on the `create_expert`/`execute_expert` MCP tool schemas) is intentionally deferred to a follow-up (#4291).