### PR TITLE
feat(context): evidence-weighted research insights (#4287)

### DIFF
--- a/.changeset/evidence-weighted-research.md
+++ b/.changeset/evidence-weighted-research.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(context): evidence-weight the `researchInsights` context path (#4287)
+
+Join `TechniqueEntry.source_papers` against `papers.yaml` quality/evidence at
+status-read time and carry the resulting `evidenceTier`/`qualityScore` on
+`TechniqueStatusSummary`. `selectRelevantResearch` now stable-sorts matched
+techniques by evidence tier (high > medium > low > none) before applying the
+cap, and the injected "Prior research" section renders the tier when present.
+
+No new persistence — `papers.yaml` stays the single source of truth and the
+join is recomputed on every read. Fail-soft throughout: a missing/unparsable
+registry or unresolved paper ids simply leave the new fields absent, so output
+is byte-identical to before the change.

--- a/packages/nexus-agents/src/cli/research-helpers-status.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-status.test.ts
@@ -417,9 +417,12 @@ describe('research-helpers-status', () => {
       const entry = createMockTechnique({ source_papers: ['p-1'] });
       const papers = makePapersRegistry({
         // `moderate`/`High`/`strong` are plausible typos in unvalidated YAML.
+        // Typed as a concrete literal (not the widened, undefined-including
+        // PaperEntry['evidence_tier']) so it satisfies exactOptionalPropertyTypes;
+        // the runtime value stays the out-of-enum 'moderate' the test needs.
         'p-1': createMockPaper({
           quality_score: 8.0,
-          evidence_tier: 'moderate' as unknown as PaperEntry['evidence_tier'],
+          evidence_tier: 'moderate' as unknown as 'low',
         }),
       });
 

--- a/packages/nexus-agents/src/cli/research-helpers-status.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-status.test.ts
@@ -400,6 +400,75 @@ describe('research-helpers-status', () => {
 
       expect(computeTechniqueEvidence(entry, malformed)).toBeUndefined();
     });
+
+    it('is fail-soft against a null parse (yaml.parse of an empty file)', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      // `yaml.parse('') === null` — must not throw on `(null).papers`.
+      expect(computeTechniqueEvidence(entry, null as unknown as PapersRegistry)).toBeUndefined();
+    });
+
+    it('is fail-soft against a `papers: null` parse (yaml.parse of "papers:\\n")', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      const nullMap = { schema_version: '1.0', papers: null } as unknown as PapersRegistry;
+      expect(computeTechniqueEvidence(entry, nullMap)).toBeUndefined();
+    });
+
+    it('normalizes an out-of-enum evidence_tier to "low" (#4287 finding 1)', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      const papers = makePapersRegistry({
+        // `moderate`/`High`/`strong` are plausible typos in unvalidated YAML.
+        'p-1': createMockPaper({
+          quality_score: 8.0,
+          evidence_tier: 'moderate' as unknown as PaperEntry['evidence_tier'],
+        }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'low',
+        qualityScore: 8.0,
+      });
+    });
+
+    it('skips a paper whose quality_score is NaN (#4287 finding 4)', () => {
+      const entry = createMockTechnique({ source_papers: ['p-nan', 'p-good'] });
+      const papers = makePapersRegistry({
+        // NaN is `typeof 'number'` — must be rejected so it can't mask p-good.
+        'p-nan': createMockPaper({ quality_score: NaN, evidence_tier: 'high' }),
+        'p-good': createMockPaper({ quality_score: 5.0, evidence_tier: 'medium' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'medium',
+        qualityScore: 5.0,
+      });
+    });
+
+    it('returns the highest VALIDATED tier, tie-broken by score (#4287 finding 5)', () => {
+      const entry = createMockTechnique({ source_papers: ['p-hi-lowscore', 'p-lo-highscore'] });
+      const papers = makePapersRegistry({
+        // Highest tier wins even though its score is lower than the low-tier sibling.
+        'p-hi-lowscore': createMockPaper({ quality_score: 4.0, evidence_tier: 'high' }),
+        'p-lo-highscore': createMockPaper({ quality_score: 9.9, evidence_tier: 'low' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'high',
+        qualityScore: 4.0,
+      });
+    });
+
+    it('tie-breaks equal tiers by the higher quality_score', () => {
+      const entry = createMockTechnique({ source_papers: ['p-a', 'p-b'] });
+      const papers = makePapersRegistry({
+        'p-a': createMockPaper({ quality_score: 6.0, evidence_tier: 'medium' }),
+        'p-b': createMockPaper({ quality_score: 7.5, evidence_tier: 'medium' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'medium',
+        qualityScore: 7.5,
+      });
+    });
   });
 
   // =============================================================================
@@ -631,6 +700,33 @@ describe('research-helpers-status', () => {
         expect(t.qualityScore).toBeUndefined();
       }
     });
+
+    it.each([
+      ['a null parse (empty/whitespace-only file)', null],
+      ['a `papers: null` parse', { schema_version: '1.0', papers: null }],
+      ['a scalar/malformed parse', 'not-an-object'],
+    ])(
+      'does not throw and leaves fields absent when papers.yaml is %s (fail-soft #4287)',
+      async (_label, parsed) => {
+        vi.mocked(researchIO.loadTechniquesRegistry).mockResolvedValue({
+          ok: true,
+          value: mockRegistry,
+        });
+        vi.mocked(researchIO.loadPapersRegistry).mockResolvedValue({
+          ok: true,
+          value: parsed as unknown as PapersRegistry,
+        });
+
+        const result = await getResearchStatus({ status: 'all', format: 'json' });
+
+        expect(result.success).toBe(true);
+        expect(result.techniques).toHaveLength(3);
+        for (const t of result.techniques) {
+          expect(t.evidenceTier).toBeUndefined();
+          expect(t.qualityScore).toBeUndefined();
+        }
+      }
+    );
   });
 
   // =============================================================================

--- a/packages/nexus-agents/src/cli/research-helpers-status.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-status.test.ts
@@ -11,10 +11,13 @@ import {
   countByStatus,
   getResearchStatus,
   formatStatusResult,
+  computeTechniqueEvidence,
 } from './research-helpers-status.js';
 import type {
   TechniqueEntry,
   TechniquesRegistry,
+  PapersRegistry,
+  PaperEntry,
   ResearchStatusOptions,
   ResearchStatusResult,
 } from './research-types.js';
@@ -24,7 +27,38 @@ import * as researchIO from './research-helpers-io.js';
 // Mock research-helpers-io module
 vi.mock('./research-helpers-io.js', () => ({
   loadTechniquesRegistry: vi.fn(),
+  loadPapersRegistry: vi.fn(),
 }));
+
+// Helper to create a mock paper entry (only the fields the evidence join reads
+// need be meaningful; the rest satisfy the PaperEntry shape).
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createMockPaper(overrides: Partial<PaperEntry> = {}) {
+  const defaults: PaperEntry = {
+    title: 'A Paper',
+    authors: [],
+    source: 'arxiv',
+    arxiv_id: '0000.00000',
+    url: 'https://example.com',
+    publication_date: '2025-01-01',
+    venue: null,
+    topics: [],
+    tags: [],
+    reviewed_date: '2025-01-01',
+    reviewed_in: '',
+    summary: '',
+    key_findings: [],
+    relevance: 'medium',
+    techniques_extracted: [],
+    related_issues: [],
+    implementation_status: 'not-started',
+  };
+  return { ...defaults, ...overrides };
+}
+
+function makePapersRegistry(papers: Record<string, PaperEntry>): PapersRegistry {
+  return { schema_version: '1.0', papers };
+}
 
 // Helper to create mock technique entry
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -289,6 +323,86 @@ describe('research-helpers-status', () => {
   });
 
   // =============================================================================
+  // computeTechniqueEvidence (#4287)
+  // =============================================================================
+
+  describe('computeTechniqueEvidence', () => {
+    it('returns the MAX quality_score (and its tier) across resolved source papers', () => {
+      const entry = createMockTechnique({ source_papers: ['p-low', 'p-high', 'p-mid'] });
+      const papers = makePapersRegistry({
+        'p-low': createMockPaper({ quality_score: 3.0, evidence_tier: 'low' }),
+        'p-high': createMockPaper({ quality_score: 9.5, evidence_tier: 'high' }),
+        'p-mid': createMockPaper({ quality_score: 6.0, evidence_tier: 'medium' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'high',
+        qualityScore: 9.5,
+      });
+    });
+
+    it('defaults a scored paper without an evidence_tier to "low"', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      const papers = makePapersRegistry({
+        'p-1': createMockPaper({ quality_score: 8.0 }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'low',
+        qualityScore: 8.0,
+      });
+    });
+
+    it('returns undefined for a technique with zero source papers', () => {
+      const entry = createMockTechnique({ source_papers: [] });
+      const papers = makePapersRegistry({
+        'p-1': createMockPaper({ quality_score: 9.0, evidence_tier: 'high' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toBeUndefined();
+    });
+
+    it('skips source paper ids missing from the registry', () => {
+      const entry = createMockTechnique({ source_papers: ['missing', 'p-present'] });
+      const papers = makePapersRegistry({
+        'p-present': createMockPaper({ quality_score: 5.5, evidence_tier: 'medium' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toEqual({
+        evidenceTier: 'medium',
+        qualityScore: 5.5,
+      });
+    });
+
+    it('returns undefined when no source paper resolves (all ids missing)', () => {
+      const entry = createMockTechnique({ source_papers: ['nope-1', 'nope-2'] });
+      const papers = makePapersRegistry({
+        other: createMockPaper({ quality_score: 9.0, evidence_tier: 'high' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toBeUndefined();
+    });
+
+    it('returns undefined when resolved papers carry no numeric quality_score', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      const papers = makePapersRegistry({
+        // Registered, but no quality_score — nothing to weight on.
+        'p-1': createMockPaper({ evidence_tier: 'high' }),
+      });
+
+      expect(computeTechniqueEvidence(entry, papers)).toBeUndefined();
+    });
+
+    it('is fail-soft against a malformed registry with no papers map', () => {
+      const entry = createMockTechnique({ source_papers: ['p-1'] });
+      // Simulate an unparsable/partial papers.yaml where `papers` is absent.
+      const malformed = { schema_version: '1.0' } as unknown as PapersRegistry;
+
+      expect(computeTechniqueEvidence(entry, malformed)).toBeUndefined();
+    });
+  });
+
+  // =============================================================================
   // getResearchStatus
   // =============================================================================
 
@@ -453,6 +567,69 @@ describe('research-helpers-status', () => {
       expect(result.counts.implemented).toBe(1);
       expect(result.counts.planned).toBe(1);
       expect(result.counts.notStarted).toBe(1);
+    });
+
+    it('joins papers.yaml evidence onto summaries when the registry resolves (#4287)', async () => {
+      const registryWithPapers: TechniquesRegistry = {
+        schema_version: '1.0',
+        techniques: {
+          'tech-001': createMockTechnique({
+            name: 'Alpha',
+            status: 'implemented',
+            priority: 'P1',
+            topic: 'optimization',
+            source_papers: ['p-a', 'p-b'],
+          }),
+          'tech-002': createMockTechnique({
+            name: 'Beta',
+            status: 'planned',
+            priority: 'P2',
+            topic: 'routing',
+            source_papers: ['p-missing'],
+          }),
+        },
+      };
+      vi.mocked(researchIO.loadTechniquesRegistry).mockResolvedValue({
+        ok: true,
+        value: registryWithPapers,
+      });
+      vi.mocked(researchIO.loadPapersRegistry).mockResolvedValue({
+        ok: true,
+        value: makePapersRegistry({
+          'p-a': createMockPaper({ quality_score: 4.0, evidence_tier: 'medium' }),
+          'p-b': createMockPaper({ quality_score: 9.0, evidence_tier: 'high' }),
+        }),
+      });
+
+      const result = await getResearchStatus({ status: 'all', format: 'json' });
+      const alpha = result.techniques.find((t) => t.id === 'tech-001');
+      const beta = result.techniques.find((t) => t.id === 'tech-002');
+
+      // Alpha weights on its best (max) source paper.
+      expect(alpha?.evidenceTier).toBe('high');
+      expect(alpha?.qualityScore).toBe(9.0);
+      // Beta's only source paper is unresolved → fields stay absent (fail-soft).
+      expect(beta?.evidenceTier).toBeUndefined();
+      expect(beta?.qualityScore).toBeUndefined();
+    });
+
+    it('leaves summaries unchanged when papers.yaml fails to load (fail-soft #4287)', async () => {
+      vi.mocked(researchIO.loadTechniquesRegistry).mockResolvedValue({
+        ok: true,
+        value: mockRegistry,
+      });
+      vi.mocked(researchIO.loadPapersRegistry).mockResolvedValue({
+        ok: false,
+        error: new ParseError('papers.yaml unparsable'),
+      });
+
+      const result = await getResearchStatus({ status: 'all', format: 'json' });
+
+      expect(result.success).toBe(true);
+      for (const t of result.techniques) {
+        expect(t.evidenceTier).toBeUndefined();
+        expect(t.qualityScore).toBeUndefined();
+      }
     });
   });
 

--- a/packages/nexus-agents/src/cli/research-helpers-status.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-status.ts
@@ -11,10 +11,51 @@ import type {
   TechniqueEntry,
   TechniqueStatus,
   TechniqueStatusSummary,
+  PapersRegistry,
+  PaperEntry,
   ResearchStatusOptions,
   ResearchStatusResult,
 } from './research-types.js';
-import { loadTechniquesRegistry } from './research-helpers-io.js';
+import { loadTechniquesRegistry, loadPapersRegistry } from './research-helpers-io.js';
+
+// =============================================================================
+// EVIDENCE JOIN (#4287)
+// =============================================================================
+
+/**
+ * Read-time evidence weight for a technique, joined from papers.yaml.
+ *
+ * Resolves each id in `entry.source_papers` against the papers registry and
+ * returns the MAX `quality_score` found (with that paper's `evidence_tier`,
+ * defaulting to `'low'` when a scored paper omits the tier — mirroring
+ * {@link research-helpers-synthesize}). Returns `undefined` when no source
+ * paper resolves to a registry entry carrying a numeric `quality_score`.
+ *
+ * Pure and fail-soft: no I/O, no persistence. papers.yaml stays the single
+ * source of truth — the result is derived fresh on every status read.
+ */
+export function computeTechniqueEvidence(
+  entry: TechniqueEntry,
+  papers: PapersRegistry
+): { evidenceTier: 'high' | 'medium' | 'low'; qualityScore: number } | undefined {
+  // Defensive against a malformed/partial registry object (fail-soft #4287):
+  // a parsed YAML may not actually carry a `papers` map, so treat it as
+  // optional at the boundary even though the declared type requires it.
+  const registry = (papers as { papers?: Record<string, PaperEntry> }).papers;
+  if (registry === undefined) return undefined;
+
+  let best: { evidenceTier: 'high' | 'medium' | 'low'; qualityScore: number } | undefined;
+  for (const paperId of entry.source_papers) {
+    const paper = registry[paperId];
+    if (paper === undefined) continue;
+    const score = paper.quality_score;
+    if (typeof score !== 'number') continue;
+    if (best === undefined || score > best.qualityScore) {
+      best = { evidenceTier: paper.evidence_tier ?? 'low', qualityScore: score };
+    }
+  }
+  return best;
+}
 
 // =============================================================================
 // CONVERSION HELPERS
@@ -22,8 +63,17 @@ import { loadTechniquesRegistry } from './research-helpers-io.js';
 
 /**
  * Convert technique entry to status summary.
+ *
+ * When `papers` is supplied, best-effort joins evidence weight (#4287) onto the
+ * summary. Fields are omitted entirely when no source paper resolves, keeping
+ * output byte-identical to the pre-#4287 shape.
  */
-export function toStatusSummary(id: string, entry: TechniqueEntry): TechniqueStatusSummary {
+export function toStatusSummary(
+  id: string,
+  entry: TechniqueEntry,
+  papers?: PapersRegistry
+): TechniqueStatusSummary {
+  const evidence = papers !== undefined ? computeTechniqueEvidence(entry, papers) : undefined;
   return {
     id,
     name: entry.name,
@@ -31,6 +81,9 @@ export function toStatusSummary(id: string, entry: TechniqueEntry): TechniqueSta
     priority: entry.priority,
     topic: entry.topic,
     implementationIssue: entry.implementation_issue,
+    ...(evidence !== undefined
+      ? { evidenceTier: evidence.evidenceTier, qualityScore: evidence.qualityScore }
+      : {}),
   };
 }
 
@@ -43,11 +96,12 @@ export function toStatusSummary(id: string, entry: TechniqueEntry): TechniqueSta
  */
 export function filterByStatus(
   techniques: Record<string, TechniqueEntry>,
-  status: TechniqueStatus | 'all'
+  status: TechniqueStatus | 'all',
+  papers?: PapersRegistry
 ): TechniqueStatusSummary[] {
   return Object.entries(techniques)
     .filter(([, entry]) => status === 'all' || entry.status === status)
-    .map(([id, entry]) => toStatusSummary(id, entry))
+    .map(([id, entry]) => toStatusSummary(id, entry, papers))
     .sort((a, b) => {
       // Sort by priority (P1 first), then by name
       const priorityOrder: Record<string, number> = { P1: 0, P2: 1, P3: 2, P4: 3 };
@@ -105,6 +159,21 @@ export function countByStatus(
 // =============================================================================
 
 /**
+ * Load papers.yaml for the read-time evidence join, swallowing every failure
+ * mode (#4287). Returns `undefined` on a missing/unparsable registry, a load
+ * error, or when the loader is not available (e.g. mocked out in a unit test),
+ * so callers can treat evidence weighting as a pure best-effort enrichment.
+ */
+async function loadPapersRegistrySoft(): Promise<PapersRegistry | undefined> {
+  try {
+    const papersResult = await loadPapersRegistry();
+    return papersResult.ok ? papersResult.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Get status of techniques.
  */
 export async function getResearchStatus(
@@ -120,6 +189,12 @@ export async function getResearchStatus(
   }
   const registry = result.value;
 
+  // Best-effort evidence join (#4287): load papers.yaml and weight each
+  // technique by its highest-quality source paper at read time. Fail-soft —
+  // any missing/unparsable registry (or a mock that doesn't stub it) leaves
+  // `papers` undefined, so the summaries stay byte-identical to pre-#4287.
+  const papers = await loadPapersRegistrySoft();
+
   // If specific technique requested
   if (options.techniqueId !== undefined && options.techniqueId !== '') {
     const entry = registry.techniques[options.techniqueId];
@@ -132,14 +207,14 @@ export async function getResearchStatus(
     }
     return {
       success: true,
-      techniques: [toStatusSummary(options.techniqueId, entry)],
+      techniques: [toStatusSummary(options.techniqueId, entry, papers)],
       counts: countByStatus(registry.techniques),
     };
   }
 
   // Filter by status
   const statusFilter = options.status === 'all' ? 'all' : (options.status as TechniqueStatus);
-  const techniques = filterByStatus(registry.techniques, statusFilter);
+  const techniques = filterByStatus(registry.techniques, statusFilter, papers);
 
   return {
     success: true,

--- a/packages/nexus-agents/src/cli/research-helpers-status.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-status.ts
@@ -12,7 +12,6 @@ import type {
   TechniqueStatus,
   TechniqueStatusSummary,
   PapersRegistry,
-  PaperEntry,
   ResearchStatusOptions,
   ResearchStatusResult,
 } from './research-types.js';
@@ -22,37 +21,75 @@ import { loadTechniquesRegistry, loadPapersRegistry } from './research-helpers-i
 // EVIDENCE JOIN (#4287)
 // =============================================================================
 
+/** Evidence tier, most-authoritative first. */
+type EvidenceTier = 'high' | 'medium' | 'low';
+
+/** Tier authority rank — higher wins when comparing two scored papers. */
+const TIER_RANK: Record<EvidenceTier, number> = { high: 3, medium: 2, low: 1 };
+
+/** True when candidate `a` should replace the running best `b` (higher tier, tie-break higher score). */
+function outranksBest(
+  a: { evidenceTier: EvidenceTier; qualityScore: number },
+  b: { evidenceTier: EvidenceTier; qualityScore: number } | undefined
+): boolean {
+  if (b === undefined) return true;
+  if (TIER_RANK[a.evidenceTier] !== TIER_RANK[b.evidenceTier]) {
+    return TIER_RANK[a.evidenceTier] > TIER_RANK[b.evidenceTier];
+  }
+  return a.qualityScore > b.qualityScore;
+}
+
+/**
+ * Type guard for a validated evidence tier (#4287). papers.yaml is parsed with
+ * `parseYaml(...) as PapersRegistry` — NO Zod validation — so an out-of-enum
+ * typo (`High`, `moderate`, `strong`) or a non-string could otherwise flow
+ * through into the ordering path and produce a NaN comparator. Anything not
+ * exactly one of the three tiers is rejected here at the join boundary.
+ */
+function isEvidenceTier(x: unknown): x is EvidenceTier {
+  return x === 'high' || x === 'medium' || x === 'low';
+}
+
 /**
  * Read-time evidence weight for a technique, joined from papers.yaml.
  *
  * Resolves each id in `entry.source_papers` against the papers registry and
- * returns the MAX `quality_score` found (with that paper's `evidence_tier`,
- * defaulting to `'low'` when a scored paper omits the tier — mirroring
- * {@link research-helpers-synthesize}). Returns `undefined` when no source
- * paper resolves to a registry entry carrying a numeric `quality_score`.
+ * returns the highest VALIDATED `evidence_tier` found (tie-broken by the higher
+ * `quality_score`), so the returned tier is the true max tier the ordering path
+ * downstream sorts on. A resolved paper with a missing/invalid tier is
+ * normalized to `'low'`. Returns `undefined` when no source paper resolves to a
+ * registry entry carrying a finite `quality_score`.
  *
- * Pure and fail-soft: no I/O, no persistence. papers.yaml stays the single
- * source of truth — the result is derived fresh on every status read.
+ * Treats `papers` as UNTRUSTED (unvalidated YAML): the container, its `papers`
+ * map, each paper, the score, and the tier are all shape/enum-checked. Pure and
+ * fail-soft — no I/O, no persistence, never throws. papers.yaml stays the single
+ * source of truth; the result is derived fresh on every status read.
  */
 export function computeTechniqueEvidence(
   entry: TechniqueEntry,
   papers: PapersRegistry
-): { evidenceTier: 'high' | 'medium' | 'low'; qualityScore: number } | undefined {
-  // Defensive against a malformed/partial registry object (fail-soft #4287):
-  // a parsed YAML may not actually carry a `papers` map, so treat it as
-  // optional at the boundary even though the declared type requires it.
-  const registry = (papers as { papers?: Record<string, PaperEntry> }).papers;
-  if (registry === undefined) return undefined;
+): { evidenceTier: EvidenceTier; qualityScore: number } | undefined {
+  // A parsed YAML may be `null` (`yaml.parse('')`), carry `papers: null`
+  // (`yaml.parse('papers:\n')`), or omit the map entirely — treat every shape
+  // as untrusted at the boundary even though the declared type requires it.
+  const registry = (papers as { papers?: unknown } | null | undefined)?.papers;
+  if (registry === null || typeof registry !== 'object') return undefined;
+  const map = registry as Record<string, unknown>;
 
-  let best: { evidenceTier: 'high' | 'medium' | 'low'; qualityScore: number } | undefined;
+  let best: { evidenceTier: EvidenceTier; qualityScore: number } | undefined;
   for (const paperId of entry.source_papers) {
-    const paper = registry[paperId];
-    if (paper === undefined) continue;
-    const score = paper.quality_score;
-    if (typeof score !== 'number') continue;
-    if (best === undefined || score > best.qualityScore) {
-      best = { evidenceTier: paper.evidence_tier ?? 'low', qualityScore: score };
-    }
+    const paper = map[paperId];
+    if (paper === null || typeof paper !== 'object') continue;
+    const score = (paper as { quality_score?: unknown }).quality_score;
+    // Number.isFinite rejects non-numbers, NaN, and ±Infinity (#4287 finding 4:
+    // `typeof NaN === 'number'` would otherwise pass and mask later papers).
+    if (!Number.isFinite(score)) continue;
+    const rawTier = (paper as { evidence_tier?: unknown }).evidence_tier;
+    const candidate = {
+      evidenceTier: isEvidenceTier(rawTier) ? rawTier : 'low',
+      qualityScore: score as number,
+    };
+    if (outranksBest(candidate, best)) best = candidate;
   }
   return best;
 }
@@ -167,7 +204,13 @@ export function countByStatus(
 async function loadPapersRegistrySoft(): Promise<PapersRegistry | undefined> {
   try {
     const papersResult = await loadPapersRegistry();
-    return papersResult.ok ? papersResult.value : undefined;
+    if (!papersResult.ok) return undefined;
+    // `parseYaml` can return `null` for an empty/whitespace-only file even on
+    // the ok branch (`yaml.parse('') === null`), despite the declared non-null
+    // type; map that to undefined so the join treats it as "no registry" rather
+    // than dereferencing null.
+    const value = papersResult.value as PapersRegistry | null;
+    return value ?? undefined;
   } catch {
     return undefined;
   }

--- a/packages/nexus-agents/src/cli/research-types.ts
+++ b/packages/nexus-agents/src/cli/research-types.ts
@@ -75,11 +75,7 @@ export interface PaperEntry {
   readonly has_code?: boolean;
   readonly code_url?: string;
   readonly rigor_tags?: readonly (
-    | 'has-code'
-    | 'has-dataset'
-    | 'has-baselines'
-    | 'peer-reviewed'
-    | 'single-model-eval'
+    'has-code' | 'has-dataset' | 'has-baselines' | 'peer-reviewed' | 'single-model-eval'
   )[];
   readonly quality_notes?: string;
   readonly last_quality_check?: string;
@@ -229,6 +225,16 @@ export interface TechniqueStatusSummary {
   readonly priority: Priority;
   readonly topic: string;
   readonly implementationIssue: number | null;
+  /**
+   * Read-time evidence weight joined from papers.yaml (#4287). Present only
+   * when at least one of the technique's `source_papers` resolves to a paper
+   * carrying a `quality_score`; absent otherwise (fail-soft — no papers.yaml,
+   * unresolved ids, or an unparsable registry all leave these undefined so the
+   * summary is byte-identical to the pre-#4287 shape). Not persisted:
+   * papers.yaml remains the single source of truth.
+   */
+  readonly evidenceTier?: 'high' | 'medium' | 'low';
+  readonly qualityScore?: number;
 }
 
 /**
@@ -258,11 +264,7 @@ export interface OverlapMatch {
   readonly sharedTags: readonly string[];
   readonly sharedTopic: boolean;
   readonly relationship:
-    | 'complementary'
-    | 'overlapping'
-    | 'conflicting'
-    | 'enhances'
-    | 'supersedes';
+    'complementary' | 'overlapping' | 'conflicting' | 'enhances' | 'supersedes';
 }
 
 /**

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -326,6 +326,10 @@ function makeTechnique(over: Partial<TechniqueStatusSummary>): TechniqueStatusSu
     priority: over.priority ?? 'P2',
     topic: over.topic ?? 'general',
     implementationIssue: over.implementationIssue ?? null,
+    // Evidence fields (#4287) are optional — carry them only when supplied so
+    // techniques without a papers.yaml join keep the pre-#4287 shape.
+    ...(over.evidenceTier !== undefined ? { evidenceTier: over.evidenceTier } : {}),
+    ...(over.qualityScore !== undefined ? { qualityScore: over.qualityScore } : {}),
   };
 }
 
@@ -364,6 +368,39 @@ describe('selectRelevantResearch', () => {
     // "api"/"web" are <4 chars → no match even though the word appears.
     expect(selectRelevantResearch(techs, 'design the api for web', 5)).toEqual([]);
   });
+
+  // #4287 — read-time evidence weighting reorders matches by tier.
+  it('orders matches by evidence tier (high > medium > low > none), stable within a tier', () => {
+    const techs = [
+      makeTechnique({ id: 'low', topic: 'routing', evidenceTier: 'low' }),
+      makeTechnique({ id: 'none', topic: 'routing' }),
+      makeTechnique({ id: 'high', topic: 'routing', evidenceTier: 'high' }),
+      makeTechnique({ id: 'med', topic: 'routing', evidenceTier: 'medium' }),
+    ];
+    const result = selectRelevantResearch(techs, 'improve routing decisions', 5);
+    expect(result.map((t) => t.id)).toEqual(['high', 'med', 'low', 'none']);
+  });
+
+  it('applies the evidence ordering before the limit (high-tier survives the cap)', () => {
+    const techs = [
+      makeTechnique({ id: 'a', topic: 'routing' }),
+      makeTechnique({ id: 'b', topic: 'routing' }),
+      makeTechnique({ id: 'c', topic: 'routing', evidenceTier: 'high' }),
+    ];
+    // Without weighting this would be ['a','b']; the high-tier 'c' is promoted.
+    const result = selectRelevantResearch(techs, 'improve routing decisions', 2);
+    expect(result.map((t) => t.id)).toEqual(['c', 'a']);
+  });
+
+  it('preserves insertion order when no technique carries evidence data (byte-unchanged)', () => {
+    const techs = [
+      makeTechnique({ id: 'a', topic: 'routing' }),
+      makeTechnique({ id: 'b', topic: 'routing' }),
+      makeTechnique({ id: 'c', topic: 'routing' }),
+    ];
+    const result = selectRelevantResearch(techs, 'improve routing decisions', 2);
+    expect(result.map((t) => t.id)).toEqual(['a', 'b']);
+  });
 });
 
 // ============================================================================
@@ -394,6 +431,34 @@ describe('summarizeContextForPrompt — research insights', () => {
     const out = summarizeContextForPrompt(ctx);
     expect(out).toContain('### Prior research on this topic');
     expect(out).toContain('- Speculative Decoding (rejected) — inference');
+  });
+
+  it('appends the evidence tier when the papers.yaml join resolved (#4287)', () => {
+    const ctx = emptyContext({
+      researchInsights: [
+        makeTechnique({
+          name: 'Speculative Decoding',
+          status: 'implemented',
+          topic: 'inference',
+          evidenceTier: 'high',
+          qualityScore: 9.0,
+        }),
+      ],
+    });
+    const out = summarizeContextForPrompt(ctx);
+    expect(out).toContain('- Speculative Decoding (implemented, evidence: high) — inference');
+  });
+
+  it('renders a tier-free line identical to pre-#4287 when evidence fields are absent', () => {
+    const ctx = emptyContext({
+      researchInsights: [
+        makeTechnique({ name: 'Speculative Decoding', status: 'rejected', topic: 'inference' }),
+      ],
+    });
+    const out = summarizeContextForPrompt(ctx);
+    // No "evidence:" annotation, byte-identical to the pre-change render.
+    expect(out).toContain('- Speculative Decoding (rejected) — inference');
+    expect(out).not.toContain('evidence:');
   });
 
   it('omits the research section entirely when there are no insights', () => {

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -449,6 +449,21 @@ describe('summarizeContextForPrompt — research insights', () => {
     expect(out).toContain('- Speculative Decoding (implemented, evidence: high) — inference');
   });
 
+  it('collapses newlines in a poisoned evidence tier so it cannot inject prompt lines (#4287)', () => {
+    const ctx = emptyContext({
+      researchInsights: [
+        {
+          ...makeTechnique({ name: 'Spec Decoding', status: 'planned', topic: 'inference' }),
+          // Untrusted papers.yaml could smuggle a newline; oneLine() must frame it.
+          evidenceTier: 'low\n- INJECTED INSTRUCTION' as unknown as 'low',
+        },
+      ],
+    });
+    const out = summarizeContextForPrompt(ctx);
+    expect(out).not.toMatch(/^- INJECTED INSTRUCTION/m);
+    expect(out).toContain('evidence: low - INJECTED INSTRUCTION)');
+  });
+
   it('renders a tier-free line identical to pre-#4287 when evidence fields are absent', () => {
     const ctx = emptyContext({
       researchInsights: [

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -190,11 +190,30 @@ export async function getContextForTask(options: ContextRetrieverOptions): Promi
 const MIN_RELEVANCE_TOKEN = 4;
 
 /**
+ * Evidence-tier rank for the read-time weighting (#4287): higher wins. A
+ * technique with no joined tier (papers.yaml absent / ids unresolved) sorts
+ * last, preserving the pre-#4287 ordering when no evidence data exists.
+ */
+const EVIDENCE_TIER_RANK: Record<'high' | 'medium' | 'low', number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+function evidenceRank(t: TechniqueStatusSummary): number {
+  return t.evidenceTier !== undefined ? EVIDENCE_TIER_RANK[t.evidenceTier] : 0;
+}
+
+/**
  * Pure relevance filter: select research techniques whose `topic` or `name`
  * shares a meaningful word (≥{@link MIN_RELEVANCE_TOKEN} chars) with the task
- * text. Order-preserving; returns at most `limit`. Exported for direct unit
- * testing of the matching logic (the network/registry read is wrapped
- * separately in {@link getResearchInsightsForTask}).
+ * text. Matches are STABLE-sorted by evidence tier (high > medium > low >
+ * none, #4287) before the `limit` is applied — insertion order is preserved
+ * within an equal tier, so when no technique carries evidence data the result
+ * is byte-identical to the pre-#4287 insertion-ordered slice. Returns at most
+ * `limit`. Exported for direct unit testing of the matching logic (the
+ * network/registry read is wrapped separately in
+ * {@link getResearchInsightsForTask}).
  */
 export function selectRelevantResearch(
   techniques: readonly TechniqueStatusSummary[],
@@ -213,12 +232,12 @@ export function selectRelevantResearch(
         break;
       }
     }
-    if (hit) {
-      matches.push(t);
-      if (matches.length >= limit) break;
-    }
+    if (hit) matches.push(t);
   }
-  return matches;
+  // Stable sort by descending evidence rank (Array.prototype.sort is stable),
+  // then take the top `limit`. Ties keep insertion (registry) order.
+  const ordered = [...matches].sort((a, b) => evidenceRank(b) - evidenceRank(a));
+  return ordered.slice(0, limit);
 }
 
 /** Lowercase word set, keeping only tokens long enough to be discriminating. */
@@ -565,9 +584,12 @@ function summarizeLegacyContext(ctx: UnifiedContext): string {
   }
 
   if (ctx.researchInsights.length > 0) {
-    const lines = ctx.researchInsights
-      .slice(0, 5)
-      .map((r) => `- ${oneLine(r.name)} (${oneLine(r.status)}) — ${oneLine(r.topic)}`);
+    const lines = ctx.researchInsights.slice(0, 5).map((r) => {
+      // Evidence tier (#4287) is appended only when the papers.yaml join
+      // resolved; absent ⇒ the line is byte-identical to the pre-#4287 render.
+      const evidence = r.evidenceTier !== undefined ? `, evidence: ${r.evidenceTier}` : '';
+      return `- ${oneLine(r.name)} (${oneLine(r.status)}${evidence}) — ${oneLine(r.topic)}`;
+    });
     sections.push(`### Prior research on this topic\n${lines.join('\n')}`);
   }
 

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -193,15 +193,23 @@ const MIN_RELEVANCE_TOKEN = 4;
  * Evidence-tier rank for the read-time weighting (#4287): higher wins. A
  * technique with no joined tier (papers.yaml absent / ids unresolved) sorts
  * last, preserving the pre-#4287 ordering when no evidence data exists.
+ *
+ * Explicit branches (rather than a map lookup) guarantee a finite numeric rank
+ * for `undefined` AND for any unexpected out-of-enum value — the sort
+ * comparator can never see a NaN, so ordering stays deterministic even though
+ * the tier originates from unvalidated papers.yaml.
  */
-const EVIDENCE_TIER_RANK: Record<'high' | 'medium' | 'low', number> = {
-  high: 3,
-  medium: 2,
-  low: 1,
-};
-
 function evidenceRank(t: TechniqueStatusSummary): number {
-  return t.evidenceTier !== undefined ? EVIDENCE_TIER_RANK[t.evidenceTier] : 0;
+  switch (t.evidenceTier) {
+    case 'high':
+      return 3;
+    case 'medium':
+      return 2;
+    case 'low':
+      return 1;
+    default:
+      return 0;
+  }
 }
 
 /**
@@ -587,7 +595,9 @@ function summarizeLegacyContext(ctx: UnifiedContext): string {
     const lines = ctx.researchInsights.slice(0, 5).map((r) => {
       // Evidence tier (#4287) is appended only when the papers.yaml join
       // resolved; absent ⇒ the line is byte-identical to the pre-#4287 render.
-      const evidence = r.evidenceTier !== undefined ? `, evidence: ${r.evidenceTier}` : '';
+      // Wrap in oneLine() like every other rendered field so an untrusted
+      // papers.yaml value can't escape the `- ` framing with embedded newlines.
+      const evidence = r.evidenceTier !== undefined ? `, evidence: ${oneLine(r.evidenceTier)}` : '';
       return `- ${oneLine(r.name)} (${oneLine(r.status)}${evidence}) — ${oneLine(r.topic)}`;
     });
     sections.push(`### Prior research on this topic\n${lines.join('\n')}`);


### PR DESCRIPTION
## Approach

Read-time evidence-weighting of the `researchInsights` context path (issue #4287, reframed). Join `TechniqueEntry.source_papers` against `papers.yaml` quality/evidence **at status-read time** and:

- carry optional `evidenceTier` / `qualityScore` on `TechniqueStatusSummary`;
- pure exported `computeTechniqueEvidence(entry, papers)` → MAX `quality_score` (and its `evidence_tier`, defaulting to `low` when a scored paper omits the tier) across the technique's resolved source papers; `undefined` when none resolve;
- `getResearchStatus` best-effort loads `papers.yaml` and threads it through `toStatusSummary` / `filterByStatus`;
- `selectRelevantResearch` **stable-sorts** matched techniques by evidence tier (high > medium > low > none) before applying the cap;
- the injected "Prior research" renderer appends `evidence: <tier>` when present.

**No new persistence** — `papers.yaml` stays the single source of truth (DRY); the join is recomputed on every read. **Fail-soft everywhere:** a missing/unparsable `papers.yaml`, an unresolved source-paper id, or a resolved paper without a numeric `quality_score` all leave the new optional fields absent, so output is byte-identical to pre-change.

## Why MemoryIngestor was descoped

Per the issue #4287 investigation + reframe comment (https://github.com/nexus-substrate/nexus-agents/issues/4287#issuecomment-5011038902): the agentic/adaptive backends have no schema fit for research metadata, a belief-only write would be near-dormant (exact-subject-match read path) and risky (prior arXiv→belief path needed a cleanup migration, #2766 Phase 9), and no named consumer exists for research-in-a-backend today. The reframe targets the non-dormant increment with a strong named consumer (`getContextForTask` → planning/voting): read-time evidence-weighting of the existing pull path.

## Blast radius

`getResearchInsightsForTask` is the shared read used by both `getContextForTask` and the dev-pipeline (#3472). Injected-context ordering for `getContextForTask` now **evidence-weights** research insights: matches are stable-sorted by tier before the cap, so equal-tier and no-evidence cases preserve insertion (registry) order and the **cap (5) is unchanged**. When no technique carries evidence data, ordering and rendering are byte-identical to before.

## Test results

- `pnpm build`: clean (ESM + DTS success)
- Affected suites — `pnpm --filter nexus-agents test -- research-helpers-status context-retriever`: **115 passed** (research-helpers-status 44, context-retriever 47, context-retriever-helpers 24)
- Broader suites — `pnpm --filter nexus-agents test -- research context`: **2597 passed / 8 skipped** (108 files), no regression
- `pnpm lint` on changed files: clean
- Changeset: present (minor, `nexus-agents`)

New coverage: `computeTechniqueEvidence` (multi-paper max, zero source papers, missing id, no numeric score, malformed registry → fail-soft undefined; join happy path returns max tier); `getResearchStatus` join + fail-soft-on-load-failure; `selectRelevantResearch` tier ordering (deterministic, limit-respecting, insertion-order-preserving when no evidence); renderer with and without tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)