### PR TITLE
chore(audit): explicit git commit -o recipe for pr-review ledger record (#4235)

### DIFF
--- a/scripts/pr-review-local-ledger.ts
+++ b/scripts/pr-review-local-ledger.ts
@@ -23,6 +23,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { canonicalGitDiffArgs } from '../packages/nexus-agents/src/audit/reviewed-diff-hash.js';
+import { PR_REVIEW_RECORDS_REL_PATH } from '../packages/nexus-agents/src/audit/pr-review-record-store.js';
 import {
   persistReviewRecord,
   type PrReviewCounts,
@@ -302,11 +303,21 @@ export async function feedLedgerRecord(summary: LocalReviewSummary): Promise<voi
   if (outcome.persisted) {
     console.log(
       `  ledger: wrote pr-review record seq=${String(outcome.sequence)} ` +
-        `(reviewedDiffHash=${outcome.reviewedDiffHash.slice(0, 12)}…) to governance/pr-review-records.jsonl.`
+        `(reviewedDiffHash=${outcome.reviewedDiffHash.slice(0, 12)}…) to ${PR_REVIEW_RECORDS_REL_PATH}.`
     );
     console.log(
       `  ledger: commit this record onto PR #${String(summary.prNumber)}'s head branch to satisfy the ` +
         `governor-review gate — the ledger is excluded from the reviewed diff, so committing it is hash-safe (#4229).`
+    );
+    // #4235: print an explicit `git commit -o` (--only) recipe. Committing ONLY the
+    // ledger path — regardless of what else is staged — closes the residual window
+    // where the uncommitted record could be swept into an unrelated commit by a later
+    // `git add -A` on the wrong branch. The record is authentic + integrity-chained
+    // either way, but this keeps the ledger clean.
+    console.log(
+      `  ledger: to commit only this record (avoids a stray \`git add -A\` sweeping it):\n` +
+        `           git commit -o ${PR_REVIEW_RECORDS_REL_PATH} -m ` +
+        `"chore(audit): pr-review record for #${String(summary.prNumber)} (seq ${String(outcome.sequence)})"`
     );
   } else {
     console.log(`  ledger: no record written (${outcome.reason}): ${outcome.detail}`);


### PR DESCRIPTION
Closes #4235.

## What
The pr-review-local ledger feeder (`scripts/pr-review-local-ledger.ts`) persists an authentic, integrity-chained pr_review record to the working tree but deliberately does not auto-commit. The #4233 adversarial review flagged a LOW-prio residual: the uncommitted write could be swept into an unrelated commit by a later `git add -A` on the wrong branch (worst case = ledger noise; the record is chained so it can't defeat the gate).

## Change
On persist-success, print a copy-pasteable `git commit -o <ledger-path> -m ...` (`--only`) recipe. `-o` commits ONLY the ledger path regardless of what else is staged, so the operator can immediately isolate-commit the record and close the sweep window. Also replaces the hardcoded path literal with the canonical `PR_REVIEW_RECORDS_REL_PATH` export (DRY).

Scripts-only (no `packages/nexus-agents/src/**` change) → no changeset / no release impact. Behavior of the audit record itself is unchanged; this is operator-guidance only.

## Test
Logging-only change to an ops script; typecheck + lint clean on the changed file.