### PR TITLE
chore(deps): bump @google/genai 1.52 → 2.x (#4045)

### DIFF
--- a/.changeset/bump-google-genai-2x.md
+++ b/.changeset/bump-google-genai-2x.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+chore(deps): bump `@google/genai` from 1.52 to 2.x (#4045)
+
+Dependency `@google/genai` majors 1.x→2.x. The 2.x breaking changes are
+Interactions-API-only and do not touch our `models.generateContent`,
+`generateContentStream`, `models.list`, or `countTokens` usage
+(upstream-guaranteed: "GenerateContent usage is unaffected"). No code
+migration required — the adapter layer (`gemini-adapter.ts`,
+`gemini-types.ts`) and `token-counter.ts` compile and pass unchanged.
+
+Classified as a patch because the actual API-surface risk to this package
+is nil. Node engines are satisfied (2.x requires >=20; this repo targets
+22). This does NOT resolve the separate `node-domexception` transitive
+fetch-blob edge.

--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -82,7 +82,7 @@
     "@ast-grep/lang-go": "0.0.6",
     "@ast-grep/lang-python": "0.0.6",
     "@ast-grep/napi": "0.44.1",
-    "@google/genai": "^1.52.0",
+    "@google/genai": "^2.12.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.11.1",
     "jsonc-parser": "^3.3.1",

--- a/packages/nexus-agents/src/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.ts
@@ -5,8 +5,9 @@
  * Implements the IModelAdapter interface with streaming support, tool calling,
  * and proper error handling.
  *
- * Verified 2026-01-03: @google/genai@1.34.0 is current stable
- * (Source: npm registry - last modified 2025-12-17)
+ * Verified 2026-07-18: @google/genai@2.12.0 is current stable (#4045).
+ * 2.x breaking changes are Interactions-API-only; the stable
+ * models.generateContent* surface used here is unaffected.
  */
 
 import { GoogleGenAI } from '@google/genai';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 0.44.1
         version: 0.44.1
       '@google/genai':
-        specifier: ^1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.12.0
+        version: 2.12.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -1130,8 +1130,8 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+  '@google/genai@2.12.0':
+    resolution: {integrity: sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -6766,7 +6766,7 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.12.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2


### PR DESCRIPTION
## Summary

Bumps `@google/genai` from `^1.52.0` to `^2.12.0` (latest stable), closing #4045.

## GO rationale

The 2.x breaking changes are **Interactions-API-only**. Upstream explicitly guarantees "GenerateContent usage is unaffected." This repo uses only the stable `models.generateContent` / `generateContentStream` / `models.list` / `countTokens` surface, fully insulated behind the adapter layer:

- `src/adapters/gemini-adapter.ts` — client construction, generateContent, generateContentStream, models.list Pager, response.text/functionCalls/candidates/usageMetadata
- `src/adapters/gemini-types.ts` — Content/Part/FunctionDeclaration type imports
- `src/context/token-counter.ts` — countTokens, response.totalTokens

**Accessor changes needed: none — drop-in.** No code migration required; all consumers compile and pass unchanged. Node engines are satisfied (2.x requires >=20; repo targets 22). Also picks up an upstream "timeout not functioning" bugfix.

This does **NOT** resolve the separate `node-domexception` transitive fetch-blob edge — that is unrelated and unchanged.

## Verification

- `pnpm typecheck` (tsc --noEmit, src+tests): **0 errors**
- `pnpm test -- gemini-adapter token-counter`: **156 passed** (6 files: gemini-adapter 55, token-counter 42, plus helpers/list-models)
- `pnpm build`: **clean**
- `pnpm eslint` on changed files: **clean**
- Changeset added (patch — real API-surface risk is nil), lockfile updated.

Also refreshed the stale pinned-version comment in `gemini-adapter.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)