### PR TITLE
refactor(eval): extract per-role confidence rubric into BaseEvaluator (#4290)

### DIFF
--- a/.changeset/chore-4290-evaluator-confidence-dry.md
+++ b/.changeset/chore-4290-evaluator-confidence-dry.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+refactor(eval): extract the per-role confidence rubric into a parameterized
+`BaseEvaluator.computeConfidence`. Architecture-fit, practical-value, and
+code-quality each keep their own base/cap/coeff (and code-quality its concern
+penalty) — the method is parameterized, not flattened, so confidence output is
+byte-identical for every input (#4290).

--- a/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.test.ts
+++ b/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.test.ts
@@ -257,6 +257,45 @@ describe('ArchitectureFitEvaluator - confidence', () => {
     const withoutNode = await evaluator.evaluate(makeComponent({ dependencies: ['./a.js'] }));
     expect(withNode.confidence).toBeGreaterThanOrEqual(withoutNode.confidence);
   });
+
+  it('pins the per-role rubric (behavior-preserving): base 0.6, cap 0.3, coeff 0.05', async () => {
+    const evaluator = new ArchitectureFitEvaluator();
+    // Default component emits 4 metrics (dependencies, relativeDependencies,
+    // externalDependencies, exports) ⇒ 0.6 + min(0.3, 4*0.05=0.2) = 0.8
+    const result = await evaluator.evaluate(makeComponent());
+    expect(result.metrics).toHaveLength(4);
+    expect(result.confidence).toBeCloseTo(0.8, 10);
+  });
+
+  it('pins metric-bonus saturation at the +0.3 cap', async () => {
+    const evaluator = new ArchitectureFitEvaluator();
+    // node: import (+1) and maxDependencies breach (+1) push to 6 metrics ⇒
+    // 0.6 + min(0.3, 6*0.05=0.3) = 0.9
+    const result = await evaluator.evaluate(
+      makeComponent({
+        dependencies: [
+          'node:fs',
+          './a.js',
+          './b.js',
+          './c.js',
+          './d.js',
+          './e.js',
+          './f.js',
+          './g.js',
+          './h.js',
+          './i.js',
+          './j.js',
+          './k.js',
+          './l.js',
+          './m.js',
+          './n.js',
+          './o.js',
+        ],
+      })
+    );
+    expect(result.metrics).toHaveLength(6);
+    expect(result.confidence).toBeCloseTo(0.9, 10);
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/architecture-fit-evaluator.ts
@@ -45,12 +45,15 @@ export class ArchitectureFitEvaluator extends BaseEvaluator {
     this.checkNodeProtocolImports(component, metrics);
 
     const recommendation = this.scoreToRecommendation(score);
-    // Confidence rubric (mirrors CodeQualityEvaluator.calculateConfidence): more
+    // Confidence rubric (shared BaseEvaluator.computeConfidence): more
     // architectural metrics observed ⇒ higher confidence, capped at +0.3. No
     // concern penalty — architecture fit is judged on positive signals here.
-    const base = 0.6;
-    const metricBonus = Math.min(0.3, metrics.length * 0.05);
-    const confidence = base + metricBonus;
+    const confidence = this.computeConfidence({
+      base: 0.6,
+      metricCount: metrics.length,
+      metricCap: 0.3,
+      metricCoeff: 0.05,
+    });
 
     return this.createResult(component, recommendation, confidence, metrics, concerns);
   }

--- a/packages/nexus-agents/src/self-eval/base-evaluator.test.ts
+++ b/packages/nexus-agents/src/self-eval/base-evaluator.test.ts
@@ -50,6 +50,10 @@ class TestEvaluator extends BaseEvaluator {
   ): ReturnType<BaseEvaluator['cite']> {
     return this.cite(metric, value, source, threshold);
   }
+
+  public testComputeConfidence(opts: Parameters<BaseEvaluator['computeConfidence']>[0]): number {
+    return this.computeConfidence(opts);
+  }
 }
 
 // ============================================================================
@@ -196,5 +200,132 @@ describe('BaseEvaluator - cite', () => {
   it('creates citation with string value', () => {
     const citation = evaluator.testCite('category', 'implementation', 'scanner');
     expect(citation.value).toBe('implementation');
+  });
+});
+
+// ============================================================================
+// computeConfidence (shared per-role rubric)
+// ============================================================================
+
+describe('BaseEvaluator - computeConfidence', () => {
+  const evaluator = new TestEvaluator('code-quality');
+
+  it('no-penalty case: base + uncapped metric bonus', () => {
+    // 0.6 + min(0.3, 3 * 0.05) = 0.6 + 0.15 = 0.75
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.6,
+        metricCount: 3,
+        metricCap: 0.3,
+        metricCoeff: 0.05,
+      })
+    ).toBeCloseTo(0.75, 10);
+  });
+
+  it('metric bonus saturates at the cap', () => {
+    // 0.6 + min(0.3, 10 * 0.05=0.5) = 0.6 + 0.3 = 0.9
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.6,
+        metricCount: 10,
+        metricCap: 0.3,
+        metricCoeff: 0.05,
+      })
+    ).toBeCloseTo(0.9, 10);
+  });
+
+  it('zero metrics returns the base', () => {
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.5,
+        metricCount: 0,
+        metricCap: 0.4,
+        metricCoeff: 0.08,
+      })
+    ).toBeCloseTo(0.5, 10);
+  });
+
+  it('penalty case: base + capped bonus - capped penalty', () => {
+    // 0.5 + min(0.4, 5*0.1=0.5) - min(0.2, 3*0.05=0.15) = 0.5 + 0.4 - 0.15 = 0.75
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.5,
+        metricCount: 5,
+        metricCap: 0.4,
+        metricCoeff: 0.1,
+        concernCount: 3,
+        concernCap: 0.2,
+        concernCoeff: 0.05,
+      })
+    ).toBeCloseTo(0.75, 10);
+  });
+
+  it('concern penalty saturates at the cap', () => {
+    // 0.5 + 0.4 - min(0.2, 10*0.05=0.5) = 0.5 + 0.4 - 0.2 = 0.7
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.5,
+        metricCount: 5,
+        metricCap: 0.4,
+        metricCoeff: 0.1,
+        concernCount: 10,
+        concernCap: 0.2,
+        concernCoeff: 0.05,
+      })
+    ).toBeCloseTo(0.7, 10);
+  });
+
+  it('omitting concern fields applies no penalty', () => {
+    const withoutConcerns = evaluator.testComputeConfidence({
+      base: 0.5,
+      metricCount: 2,
+      metricCap: 0.4,
+      metricCoeff: 0.08,
+    });
+    const withZeroConcernCount = evaluator.testComputeConfidence({
+      base: 0.5,
+      metricCount: 2,
+      metricCap: 0.4,
+      metricCoeff: 0.08,
+      concernCount: 0,
+      concernCap: 0.2,
+      concernCoeff: 0.05,
+    });
+    // 0.5 + min(0.4, 2*0.08=0.16) = 0.66 either way
+    expect(withoutConcerns).toBeCloseTo(0.66, 10);
+    expect(withZeroConcernCount).toBeCloseTo(0.66, 10);
+  });
+
+  it('reproduces each role formula byte-identically', () => {
+    // architecture-fit: 10 metrics ⇒ 0.6 + min(0.3, 0.5) = 0.9
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.6,
+        metricCount: 10,
+        metricCap: 0.3,
+        metricCoeff: 0.05,
+      })
+    ).toBe(0.6 + Math.min(0.3, 10 * 0.05));
+    // practical-value: 2 metrics ⇒ 0.5 + min(0.4, 0.16) = 0.66
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.5,
+        metricCount: 2,
+        metricCap: 0.4,
+        metricCoeff: 0.08,
+      })
+    ).toBe(0.5 + Math.min(0.4, 2 * 0.08));
+    // code-quality: 5 metrics + 3 concerns ⇒ 0.5 + 0.4 - 0.15 = 0.75
+    expect(
+      evaluator.testComputeConfidence({
+        base: 0.5,
+        metricCount: 5,
+        metricCap: 0.4,
+        metricCoeff: 0.1,
+        concernCount: 3,
+        concernCap: 0.2,
+        concernCoeff: 0.05,
+      })
+    ).toBe(0.5 + Math.min(0.4, 5 * 0.1) - Math.min(0.2, 3 * 0.05));
   });
 });

--- a/packages/nexus-agents/src/self-eval/base-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/base-evaluator.ts
@@ -55,11 +55,12 @@ export abstract class BaseEvaluator {
       }, this.timeoutMs);
     });
     try {
-      const result = await Promise.race([this.performEvaluation(component), timeoutPromise]).finally(
-        () => {
-          if (timeoutId !== undefined) clearTimeout(timeoutId);
-        }
-      );
+      const result = await Promise.race([
+        this.performEvaluation(component),
+        timeoutPromise,
+      ]).finally(() => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      });
 
       this.log.debug('Evaluation complete', {
         component: component.path,
@@ -119,4 +120,32 @@ export abstract class BaseEvaluator {
     return { metric, value, source, ...(threshold !== undefined ? { threshold } : {}) };
   }
 
+  /**
+   * Shared per-role confidence rubric: `base + min(metricCap, metricCount *
+   * metricCoeff) - concernPenalty`. More observed metrics ⇒ higher confidence
+   * (bonus capped); more concerns ⇒ lower confidence (penalty capped).
+   *
+   * Each evaluator role passes its OWN base/cap/coeff — the constants are
+   * intentionally NOT unified (architecture-fit, practical-value, and
+   * code-quality each weight evidence differently). Omit the concern fields to
+   * skip the penalty entirely (roles that judge on positive signals only).
+   *
+   * The returned value is later clamped to [0, 1] by {@link createResult}.
+   */
+  protected computeConfidence(opts: {
+    base: number;
+    metricCount: number;
+    metricCap: number;
+    metricCoeff: number;
+    concernCount?: number;
+    concernCap?: number;
+    concernCoeff?: number;
+  }): number {
+    const metricBonus = Math.min(opts.metricCap, opts.metricCount * opts.metricCoeff);
+    const concernPenalty =
+      opts.concernCount !== undefined && opts.concernCoeff !== undefined
+        ? Math.min(opts.concernCap ?? Infinity, opts.concernCount * opts.concernCoeff)
+        : 0;
+    return opts.base + metricBonus - concernPenalty;
+  }
 }

--- a/packages/nexus-agents/src/self-eval/code-quality-evaluator.test.ts
+++ b/packages/nexus-agents/src/self-eval/code-quality-evaluator.test.ts
@@ -246,6 +246,28 @@ describe('CodeQualityEvaluator - confidence', () => {
     const withoutCoverage = await evaluator.evaluate(makeComponent({ testCoverage: null }));
     expect(withCoverage.confidence).toBeGreaterThanOrEqual(withoutCoverage.confidence);
   });
+
+  it('pins the per-role rubric (behavior-preserving): base 0.5, cap 0.4, coeff 0.1, no concerns', async () => {
+    const evaluator = new CodeQualityEvaluator();
+    // Healthy default: 2 metrics (complexity, lines), 0 concerns ⇒
+    // 0.5 + min(0.4, 2*0.1=0.2) - 0 = 0.7
+    const result = await evaluator.evaluate(makeComponent());
+    expect(result.metrics).toHaveLength(2);
+    expect(result.concerns).toHaveLength(0);
+    expect(result.confidence).toBeCloseTo(0.7, 10);
+  });
+
+  it('pins the concern penalty path (the only role that penalizes)', async () => {
+    const evaluator = new CodeQualityEvaluator();
+    // complexity 25 (>20), lines 500 (>400), coverage 30 (<50):
+    // 3 metrics + 3 concerns ⇒ 0.5 + min(0.4, 3*0.1=0.3) - min(0.2, 3*0.05=0.15) = 0.65
+    const result = await evaluator.evaluate(
+      makeComponent({ complexity: 25, lines: 500, testCoverage: 30 })
+    );
+    expect(result.metrics).toHaveLength(3);
+    expect(result.concerns).toHaveLength(3);
+    expect(result.confidence).toBeCloseTo(0.65, 10);
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/self-eval/code-quality-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/code-quality-evaluator.ts
@@ -42,7 +42,18 @@ export class CodeQualityEvaluator extends BaseEvaluator {
     score = this.evaluateTestCoverage(component, metrics, concerns, score);
 
     const recommendation = this.scoreToRecommendation(score);
-    const confidence = this.calculateConfidence(metrics.length, concerns.length);
+    // Confidence rubric (shared BaseEvaluator.computeConfidence): more metrics ⇒
+    // higher confidence (capped at +0.4); more concerns ⇒ lower confidence
+    // (penalty capped at -0.2). Code quality is the only role that penalizes.
+    const confidence = this.computeConfidence({
+      base: 0.5,
+      metricCount: metrics.length,
+      metricCap: 0.4,
+      metricCoeff: 0.1,
+      concernCount: concerns.length,
+      concernCap: 0.2,
+      concernCoeff: 0.05,
+    });
 
     return this.createResult(component, recommendation, confidence, metrics, concerns);
   }
@@ -121,13 +132,5 @@ export class CodeQualityEvaluator extends BaseEvaluator {
     if (score >= 0.5) return 'review';
     if (score >= 0.3) return 'refactor';
     return 'deprecate';
-  }
-
-  private calculateConfidence(metricCount: number, concernCount: number): number {
-    // More metrics = higher confidence, more concerns = slightly lower
-    const base = 0.5;
-    const metricBonus = Math.min(0.4, metricCount * 0.1);
-    const concernPenalty = Math.min(0.2, concernCount * 0.05);
-    return base + metricBonus - concernPenalty;
   }
 }

--- a/packages/nexus-agents/src/self-eval/practical-value-evaluator.test.ts
+++ b/packages/nexus-agents/src/self-eval/practical-value-evaluator.test.ts
@@ -225,4 +225,13 @@ describe('PracticalValueEvaluator - confidence', () => {
     expect(result.confidence).toBeGreaterThanOrEqual(0);
     expect(result.confidence).toBeLessThanOrEqual(1);
   });
+
+  it('pins the per-role rubric (behavior-preserving): base 0.5, cap 0.4, coeff 0.08, no penalty', async () => {
+    const evaluator = new PracticalValueEvaluator();
+    // Default component emits 3 metrics (exports, linesPerExport, sizeBytes) ⇒
+    // 0.5 + min(0.4, 3*0.08=0.24) = 0.74. No concern penalty for this role.
+    const result = await evaluator.evaluate(makeComponent());
+    expect(result.metrics).toHaveLength(3);
+    expect(result.confidence).toBeCloseTo(0.74, 10);
+  });
 });

--- a/packages/nexus-agents/src/self-eval/practical-value-evaluator.ts
+++ b/packages/nexus-agents/src/self-eval/practical-value-evaluator.ts
@@ -42,12 +42,15 @@ export class PracticalValueEvaluator extends BaseEvaluator {
     score = this.evaluateSizeHeuristics(component, metrics, concerns, score);
 
     const recommendation = this.scoreToRecommendation(score);
-    // Confidence rubric (mirrors CodeQualityEvaluator.calculateConfidence): more
+    // Confidence rubric (shared BaseEvaluator.computeConfidence): more
     // practical-value metrics observed ⇒ higher confidence, capped at +0.4.
     // Practical value weights evidence presence, so there's no concern penalty.
-    const base = 0.5;
-    const metricBonus = Math.min(0.4, metrics.length * 0.08);
-    const confidence = base + metricBonus;
+    const confidence = this.computeConfidence({
+      base: 0.5,
+      metricCount: metrics.length,
+      metricCap: 0.4,
+      metricCoeff: 0.08,
+    });
 
     return this.createResult(component, recommendation, confidence, metrics, concerns);
   }


### PR DESCRIPTION
## Summary

The three self-eval evaluators each inlined the same confidence shape — `base + min(cap, metricCount*coeff) [- concernPenalty]` — but with **diverged constants**. This extracts a single **parameterized** `BaseEvaluator.computeConfidence` and has each role pass its own base/cap/coeff.

**Parameterized, NOT flattened.** The constants are intentionally kept distinct; confidence output is byte-identical for every input.

### Divergence (why it can't be flattened)

| role              | base | metricCap | metricCoeff | concern penalty     |
|-------------------|------|-----------|-------------|---------------------|
| architecture-fit  | 0.6  | 0.3       | 0.05        | none                |
| practical-value   | 0.5  | 0.4       | 0.08        | none                |
| code-quality      | 0.5  | 0.4       | 0.10        | cap 0.2, coeff 0.05 |

## Changes

- Add `protected computeConfidence(opts)` to `BaseEvaluator` (alongside `createResult`/`cite`), JSDoc'd as the shared rubric.
- Replace the three inline computations with calls; keep each role's explanatory comment.
- Delete code-quality's now-redundant private `calculateConfidence` (only self-referenced — grep-confirmed).

## Tests

- New `BaseEvaluator.computeConfidence` unit tests: no-penalty, penalty, metric-cap saturation, concern-cap saturation, zero metrics → base, omitted-vs-zero concern fields, and per-role byte-identical reproduction.
- Behavior-preserving pins at representative inputs:
  - architecture-fit: default component → **0.8** (4 metrics); saturated → **0.9** (6 metrics)
  - practical-value: default → **0.74** (3 metrics)
  - code-quality: healthy default → **0.7** (2 metrics, 0 concerns); penalty path → **0.65** (3 metrics, 3 concerns)
- No pre-existing confidence assertion changed value.

## Acceptance

- `pnpm --filter nexus-agents typecheck`: 0 errors
- Self-eval suite: **232 passed** (13 files); the 4 changed test files: **89 passed** (base 18, architecture-fit 24, practical-value 21, code-quality 26)
- `pnpm build`: clean; `pnpm lint` (eslint on changed files): clean
- Changeset: **patch** (behavior-preserving refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)