### PR TITLE
harden(resilience): classifyExpertFailure fails closed on a throwing error getter (#4303)

### DIFF
--- a/.changeset/harden-4303-classifier-fail-closed.md
+++ b/.changeset/harden-4303-classifier-fail-closed.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+harden(resilience): make `classifyExpertFailure` fail closed on a throwing error
+getter. `RecoverableExpert.execute()` classifies failures inside `withRetry`'s
+`isRetryable` predicate and in `annotateExhausted`; neither call site is
+try-guarded by `withRetry` (its `try` wraps only the operation), so an Error-like
+object with a throwing `.message`/`.cause` getter made the classifier throw and
+REJECT the `Promise<Result<…>>`, breaking the never-throws contract
+`execute_expert` relies on. The classifier now wraps its body in a single
+try/catch and returns `permanent` on any classifier fault, and the per-retry
+guidance-injection (also outside `withRetry`'s guarded region) is guarded too so
+`execute()` always resolves to a `Result` (#4303).

--- a/packages/nexus-agents/src/agents/experts/expert-recovery.test.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-recovery.test.ts
@@ -147,6 +147,39 @@ describe('classifyExpertFailure', () => {
     const c = classifyExpertFailure(statusError(401, 'Invalid API key'), calibrated);
     expect(c).toEqual({ kind: 'permanent', source: 'default' });
   });
+
+  it('fails closed (does NOT throw) on an error with a throwing .message getter (#4303)', () => {
+    // A pathological Error-like object whose `.message` getter throws would make
+    // getErrorMessage/extractErrorMessage throw. Classification MUST swallow it
+    // and fail closed rather than let the throw escape.
+    const evil = {};
+    Object.defineProperty(evil, 'message', {
+      get() {
+        throw new Error('boom');
+      },
+    });
+    let c: ReturnType<typeof classifyExpertFailure> | undefined;
+    expect(() => {
+      c = classifyExpertFailure(evil, detector, 'task');
+    }).not.toThrow();
+    expect(c).toEqual({ kind: 'permanent', source: 'default' });
+  });
+
+  it('fails closed on an Error subclass whose .cause getter throws (#4303)', () => {
+    // The cause-chain walk reads `.cause`; a throwing `.cause` getter must also be
+    // caught. Use a real Error (so the chain walk descends into `.cause`).
+    const evil = new Error('outer');
+    Object.defineProperty(evil, 'cause', {
+      get() {
+        throw new Error('boom cause');
+      },
+    });
+    let c: ReturnType<typeof classifyExpertFailure> | undefined;
+    expect(() => {
+      c = classifyExpertFailure(evil, detector, 'task');
+    }).not.toThrow();
+    expect(c).toEqual({ kind: 'permanent', source: 'default' });
+  });
 });
 
 describe('RecoverableExpert.execute', () => {
@@ -288,6 +321,34 @@ describe('RecoverableExpert.execute', () => {
     if (!result.ok) {
       const recovery = (result.error.context?.['recovery'] ?? {}) as Record<string, unknown>;
       expect(recovery['attempts']).toBe(2);
+    }
+  });
+
+  it('resolves to err (never throws) when the failure has a throwing .cause getter (#4303)', async () => {
+    // A pathological error: normal `.message` (survives base-agent error wrapping)
+    // but a throwing `.cause` getter. The cause-chain walk in classifyExpertFailure
+    // (isRetryableErrorChain) reads `.cause` and would throw; without the fail-closed
+    // guard that throw escapes withRetry's un-guarded isRetryable/annotateExhausted
+    // and REJECTS the Promise, breaking execute_expert's never-throws contract.
+    const evil = new Error('model call blew up');
+    Object.defineProperty(evil, 'cause', {
+      get() {
+        throw new Error('cause getter boom');
+      },
+    });
+    const complete = vi.fn().mockRejectedValue(evil);
+    const expert = createRecoverableExpert({ maxRetries: 2, baseDelayMs: 0 }, complete);
+
+    // Must RESOLVE (not reject). Assert on the resolved Result, then the classification.
+    const result = await expert.execute(makeTask());
+
+    expect(result.ok).toBe(false);
+    // Failed closed → classified permanent → no retries (called exactly once).
+    expect(complete).toHaveBeenCalledTimes(1);
+    if (!result.ok) {
+      const recovery = (result.error.context?.['recovery'] ?? {}) as Record<string, unknown>;
+      expect(recovery['classification']).toBe('permanent');
+      expect(recovery['source']).toBe('default');
     }
   });
 

--- a/packages/nexus-agents/src/agents/experts/expert-recovery.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-recovery.ts
@@ -184,6 +184,16 @@ function highestConfidenceFailure(
  * See the module header for the ordered decision procedure. `signal` is checked
  * first (mandatory guard): RETRYABLE_ERROR_PATTERNS matches /aborted/i, so
  * without this a cancelled task would otherwise be retried.
+ *
+ * Fails CLOSED on a throwing classifier (#4303): the body reads `error.message`
+ * and walks `.cause` (via getErrorMessage/extractErrorMessage/isRetryableErrorChain)
+ * and calls `detector.detect`. An Error-like object with a throwing `.message` or
+ * `.cause` getter would make any of those throw. `execute()` runs this INSIDE
+ * `withRetry`'s isRetryable predicate and again in annotateExhausted, neither of
+ * which is try-guarded by withRetry (adapters/retry.ts:339-363 catches only
+ * `operation()`), so an escaping throw would reject the `Promise<Result<…>>` and
+ * break the never-throws contract `execute_expert` relies on. This single outer
+ * guard covers BOTH call sites: any throw during classification → permanent.
  */
 export function classifyExpertFailure(
   error: unknown,
@@ -191,37 +201,43 @@ export function classifyExpertFailure(
   taskDescription?: string,
   signal?: AbortSignal
 ): FailureClassification {
-  // 1. Caller cancellation → permanent (fail closed, do not retry).
-  if (signal?.aborted === true) {
+  try {
+    // 1. Caller cancellation → permanent (fail closed, do not retry).
+    if (signal?.aborted === true) {
+      return { kind: 'permanent', source: 'default' };
+    }
+
+    // 2. Transport-retryable (429/408/5xx/ECONNRESET/…, NexusError rate-limit/
+    //    timeout/unavailable codes) anywhere in the cause chain → transient.
+    if (isRetryableErrorChain(error)) {
+      return { kind: 'transient', source: 'transport' };
+    }
+
+    // 3. Behavioral archetype (arxiv:2512.07497) → map to its recovery action.
+    const detection = detector.detect({
+      messages: [{ role: 'assistant', content: extractErrorMessage(error) }],
+      ...(taskDescription !== undefined ? { taskDescription } : {}),
+    });
+    if (detection.hasFailure) {
+      const top = highestConfidenceFailure(detection.failures);
+      if (top !== undefined) {
+        const action = DEFAULT_RECOVERY_STRATEGIES[top.archetype].action;
+        return {
+          kind: RECOVERABLE_ACTIONS.has(action) ? 'transient' : 'permanent',
+          source: 'archetype',
+          archetype: top.archetype,
+          confidence: top.confidence,
+        };
+      }
+    }
+
+    // 4. Fail closed.
+    return { kind: 'permanent', source: 'default' };
+  } catch {
+    // A throwing `.message`/`.cause` getter (or any classifier fault) MUST NOT
+    // escape — fail closed so `execute()` still resolves to a Result.
     return { kind: 'permanent', source: 'default' };
   }
-
-  // 2. Transport-retryable (429/408/5xx/ECONNRESET/…, NexusError rate-limit/
-  //    timeout/unavailable codes) anywhere in the cause chain → transient.
-  if (isRetryableErrorChain(error)) {
-    return { kind: 'transient', source: 'transport' };
-  }
-
-  // 3. Behavioral archetype (arxiv:2512.07497) → map to its recovery action.
-  const detection = detector.detect({
-    messages: [{ role: 'assistant', content: extractErrorMessage(error) }],
-    ...(taskDescription !== undefined ? { taskDescription } : {}),
-  });
-  if (detection.hasFailure) {
-    const top = highestConfidenceFailure(detection.failures);
-    if (top !== undefined) {
-      const action = DEFAULT_RECOVERY_STRATEGIES[top.archetype].action;
-      return {
-        kind: RECOVERABLE_ACTIONS.has(action) ? 'transient' : 'permanent',
-        source: 'archetype',
-        archetype: top.archetype,
-        confidence: top.confidence,
-      };
-    }
-  }
-
-  // 4. Fail closed.
-  return { kind: 'permanent', source: 'default' };
 }
 
 /**
@@ -336,32 +352,52 @@ export class RecoverableExpert extends Expert {
           return lastClassification.kind === 'transient';
         },
         onRetry: (info: RetryAttemptInfo): void => {
-          this.recoveryLogger.info('Expert execution retry', {
-            expertId: this.expertConfig.id,
-            attempt: info.attempt,
-            delayMs: info.delayMs,
-            classification: lastClassification?.kind,
-            source: lastClassification?.source,
-            archetype: lastClassification?.archetype,
-          });
-          // Archetype recovery: inject archetype-specific guidance into the next
-          // attempt's prompt via a mutable task copy.
-          if (
-            lastClassification?.source === 'archetype' &&
-            lastClassification.archetype !== undefined
-          ) {
-            currentTask = this.injectRecoveryGuidance(
-              currentTask,
-              lastClassification.archetype,
-              info
-            );
-          }
+          currentTask = this.handleRetry(info, lastClassification, currentTask);
         },
       }
     );
 
     if (outcome.ok) return ok(outcome.value);
     return err(this.annotateExhausted(outcome.error, currentTask, signal));
+  }
+
+  /**
+   * Per-retry callback: logs the attempt and, for a recoverable archetype,
+   * injects archetype-specific guidance into the next attempt's task.
+   *
+   * Returns the (possibly augmented) task. onRetry runs INSIDE withRetry's catch
+   * but is NOT itself try-guarded (adapters/retry.ts:352-359 — the try wraps only
+   * `operation()`), so a throw here would escape withRetry and reject the Promise.
+   * The guidance path re-reads the error (extractErrorMessage) and calls
+   * detector.detect, so a pathological error (#4303 throwing getter) could throw —
+   * guard it: on failure, skip injection and retry with the un-augmented task.
+   */
+  private handleRetry(
+    info: RetryAttemptInfo,
+    classification: FailureClassification | undefined,
+    currentTask: Task
+  ): Task {
+    this.recoveryLogger.info('Expert execution retry', {
+      expertId: this.expertConfig.id,
+      attempt: info.attempt,
+      delayMs: info.delayMs,
+      classification: classification?.kind,
+      source: classification?.source,
+      archetype: classification?.archetype,
+    });
+    if (classification?.source !== 'archetype' || classification.archetype === undefined) {
+      return currentTask;
+    }
+    try {
+      return this.injectRecoveryGuidance(currentTask, classification.archetype, info);
+    } catch (guidanceError: unknown) {
+      this.recoveryLogger.warn('Skipping recovery guidance injection (threw)', {
+        expertId: this.expertConfig.id,
+        archetype: classification.archetype,
+        error: getErrorMessage(guidanceError),
+      });
+      return currentTask;
+    }
   }
 
   /**


### PR DESCRIPTION
## The never-throws-contract gap

`RecoverableExpert.execute()` (`packages/nexus-agents/src/agents/experts/expert-recovery.ts`) runs `classifyExpertFailure` in two places:
1. inside `withRetry`'s `isRetryable` predicate, and
2. in `annotateExhausted` on the final error.

`classifyExpertFailure` reads `error.message` and walks the `.cause` chain (via `getErrorMessage` / `extractErrorMessage` / `isRetryableErrorChain`) and calls `detector.detect`. If an Error-like object has a **throwing `.message` or `.cause` getter**, the classifier throws.

`withRetry`'s `catch` block (`adapters/retry.ts:339-363`) only try-guards `operation()` — both `isRetryable(error)` (line 344) and `onRetry(...)` (lines 352-359) run **inside** that `catch` but are **not** themselves guarded. So a throw from either escapes `withRetry` and **rejects** the `Promise<Result<...>>` instead of returning `err(...)`, breaking the never-throws contract `execute_expert` relies on.

## The fix

- Wrap the body of `classifyExpertFailure` in a single `try/catch`: on any classifier fault, return `{ kind: 'permanent', source: 'default' }` (**fail closed**). This one guard covers **both** call sites.
- Guard the per-retry guidance-injection path too: `onRetry` → `injectRecoveryGuidance` → `extractErrorMessage` also runs outside `withRetry`'s guarded region, so a throw there would likewise escape. On failure it now logs and skips injection (retries with the un-augmented task). Extracted into a `handleRetry` helper to keep `execute()` within the line budget.
- Behavior is **unchanged** for all normal errors (transport/archetype/abort classification untouched).

## Tests

- `classifyExpertFailure` unit tests for a throwing `.message` getter and a throwing `.cause` getter — both fail closed and never throw.
- An `execute()`-level regression: adapter rejects with an error carrying a throwing `.cause` getter; `execute()` **resolves** to `err(...)` with a `permanent`/`default` classification (does not reject). Verified load-bearing: all three new tests fail if the guard is reverted.

Existing recovery tests pass unchanged (20 total in the file). Changeset: **patch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)