### PR TITLE
fix(audit): resolve pr_review governance record path via optional repoPath input (#4278)

### DIFF
--- a/.changeset/fix-pr-review-record-path-4278.md
+++ b/.changeset/fix-pr-review-record-path-4278.md
@@ -1,0 +1,9 @@
+---
+'nexus-agents': patch
+---
+
+fix(audit): pr_review governance record no longer silently fails to persist when cwd has no `.git` ancestor (#4278)
+
+`resolvePrReviewRecordsPath()` only resolved the ledger path from `NEXUS_PR_REVIEW_RECORDS_PATH` or `findRepoRoot(process.cwd())`. In an MCP server process the cwd often has no `.git` ancestor, so `findRepoRoot` returned `null` and the pr-review governance record silently failed to persist ("records path unresolved"), with no way for the caller to say where the repo is.
+
+`pr_review` now accepts an optional `repoPath` input (absolute path to the repo root) that is threaded through `persistReviewRecord` → `persistPrReviewRecord` → `resolvePrReviewRecordsPath` as a `repoPathOverride`. Precedence is unchanged and additive: `NEXUS_PR_REVIEW_RECORDS_PATH` env var still wins over everything, `repoPath`/`repoPathOverride` is used next when cwd auto-detection would otherwise fail, and `findRepoRoot(process.cwd())` remains the final fallback — existing callers that pass neither see byte-identical behavior.

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,6 +1,6 @@
 {
   "_comment": "Portable MCP config for distributing nexus-agents as a Claude Code plugin (#1826). Copy to .mcp.json (gitignored) or ship this file at plugin-root as .mcp.json in the marketplace repo.",
-  "_comment_env": "env is optional. NEXUS_PR_REVIEW_RECORDS_PATH (#4278): the MCP server's cwd often has no `.git` ancestor, so pr_review's governance-record write silently fails to resolve a path — set this to force an absolute records-file path (e.g. `/abs/path/to/repo/governance/pr-review-records.jsonl`). Per-call `pr_review({ repoPath: '/abs/path/to/repo' })` is the alternative escape hatch: it overrides cwd auto-detection but NOT this env var. See docs/getting-started/CONFIGURATION.md.",
+  "_comment_env": "env is optional. NEXUS_PR_REVIEW_RECORDS_PATH (#4278): the MCP server's cwd often has no `.git` ancestor, so pr_review's governance-record write silently fails to resolve a path — set this to force an absolute records-file path (e.g. `/abs/path/to/repo/governance/pr-review-records.jsonl`); unrestricted (operator-trust). Per-call `pr_review({ repoPath: '/abs/path/to/repo' })` is the alternative escape hatch: it overrides cwd auto-detection but NOT this env var, and (#4312, call-time input is not operator-trust) is only honored when it resolves to a real repo root (a `.git` ancestor) — otherwise it is ignored. See docs/getting-started/CONFIGURATION.md.",
   "mcpServers": {
     "nexus-agents": {
       "command": "npx",

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,9 +1,13 @@
 {
   "_comment": "Portable MCP config for distributing nexus-agents as a Claude Code plugin (#1826). Copy to .mcp.json (gitignored) or ship this file at plugin-root as .mcp.json in the marketplace repo.",
+  "_comment_env": "env is optional. NEXUS_PR_REVIEW_RECORDS_PATH (#4278): the MCP server's cwd often has no `.git` ancestor, so pr_review's governance-record write silently fails to resolve a path — set this to force an absolute records-file path (e.g. `/abs/path/to/repo/governance/pr-review-records.jsonl`). Per-call `pr_review({ repoPath: '/abs/path/to/repo' })` is the alternative escape hatch: it overrides cwd auto-detection but NOT this env var. See docs/getting-started/CONFIGURATION.md.",
   "mcpServers": {
     "nexus-agents": {
       "command": "npx",
-      "args": ["-y", "nexus-agents", "--mode=server"]
+      "args": ["-y", "nexus-agents", "--mode=server"],
+      "env": {
+        "NEXUS_PR_REVIEW_RECORDS_PATH": "/abs/path/to/repo/governance/pr-review-records.jsonl"
+      }
     }
   }
 }

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -268,12 +268,13 @@ Files stored:
 
 ### Security & Governance Variables
 
-| Variable                       | Description                                                                      | Default          |
-| ------------------------------ | -------------------------------------------------------------------------------- | ---------------- |
-| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce` (#1977, #2279)     | `audit` (v2.50+) |
-| `NEXUS_REPUTATION_GATING`      | Author-reputation tier gating: `off` / `audit` / `enforce` (#3122, epic #3118)   | `audit`          |
-| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log + Magentic-One ledgers (`0`/`false` to disable, #2278) | enabled (v2.50+) |
-| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                                      | `0.85`           |
+| Variable                       | Description                                                                                                                                                                                                                                                                                                                                         | Default                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `NEXUS_ACCESS_POLICY_MODE`     | ClawGuard mode: `off` / `audit` / `confirm_risky` / `enforce` (#1977, #2279)                                                                                                                                                                                                                                                                        | `audit` (v2.50+)        |
+| `NEXUS_REPUTATION_GATING`      | Author-reputation tier gating: `off` / `audit` / `enforce` (#3122, epic #3118)                                                                                                                                                                                                                                                                      | `audit`                 |
+| `NEXUS_TASK_STATE_ENABLED`     | Structured task-state log + Magentic-One ledgers (`0`/`false` to disable, #2278)                                                                                                                                                                                                                                                                    | enabled (v2.50+)        |
+| `NEXUS_CONTEXT_WARN_THRESHOLD` | Per-expert context-warning threshold (0..1]                                                                                                                                                                                                                                                                                                         | `0.85`                  |
+| `NEXUS_PR_REVIEW_RECORDS_PATH` | Forces the `pr_review` governance-record ledger path to an explicit absolute file. Escape hatch for MCP server processes whose `process.cwd()` has no `.git` ancestor, where cwd-based auto-detection silently fails to persist the record (#4278). Takes precedence over the per-call `pr_review({ repoPath })` input and over cwd auto-detection. | unset (cwd auto-detect) |
 
 **`NEXUS_ACCESS_POLICY_MODE` graduation path:**
 

--- a/docs/reference/tools/pr_review.md
+++ b/docs/reference/tools/pr_review.md
@@ -24,6 +24,7 @@ Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, secu
 | `headRef` | string | no | maxLength 200 | Head branch ref |
 | `prNumber` | integer | no | max 9007199254740991; > 0 | PR number — with baseSha, enables Option-C audit-record persistence (#4031) |
 | `baseSha` | string | no | pattern `^[0-9a-f]{40}$` | 40-hex base commit sha the reviewed diff was computed from (Option-C binding, #4031) |
+| `repoPath` | string | no | maxLength 1024 | Absolute path to the repo root for persisting the governance pr-review record (overrides cwd auto-detection; env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence). |
 | `simulate` | boolean | no | default false | Use simulated voters (testing only; never ship live with this true) |
 | `errorPolicy` | enum | no | one of: standard \| absolute_quorum; default standard | Error policy (#4132). 'standard' (default): errored voters excluded. 'absolute_quorum': any errored voter — esp. the contrarian — degrades a would-be approve to a recoverable abstain (verified:false); never manufactures a verified approve from an induced error. |
 | `dispatch` | enum | no | one of: sync \| async; default sync | Dispatch mode (#3731). 'sync' (default): run inline. 'async': return a jobId immediately + run the panel in background (poll get_job_result). |

--- a/docs/reference/tools/pr_review.md
+++ b/docs/reference/tools/pr_review.md
@@ -24,7 +24,7 @@ Run multi-voter consensus review on a PR diff (#2233). 5 voters (architect, secu
 | `headRef` | string | no | maxLength 200 | Head branch ref |
 | `prNumber` | integer | no | max 9007199254740991; > 0 | PR number — with baseSha, enables Option-C audit-record persistence (#4031) |
 | `baseSha` | string | no | pattern `^[0-9a-f]{40}$` | 40-hex base commit sha the reviewed diff was computed from (Option-C binding, #4031) |
-| `repoPath` | string | no | maxLength 1024 | Absolute path to the repo root for persisting the governance pr-review record (overrides cwd auto-detection; env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence). |
+| `repoPath` | string | no | maxLength 1024 | Repo root path for persisting the governance pr-review record (overrides cwd auto-detection). Must contain a .git ancestor — relative paths are resolved against cwd; ignored (falls back to cwd auto-detection) if it is not a real repo root. Env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence and is unrestricted. |
 | `simulate` | boolean | no | default false | Use simulated voters (testing only; never ship live with this true) |
 | `errorPolicy` | enum | no | one of: standard \| absolute_quorum; default standard | Error policy (#4132). 'standard' (default): errored voters excluded. 'absolute_quorum': any errored voter — esp. the contrarian — degrades a would-be approve to a recoverable abstain (verified:false); never manufactures a verified approve from an induced error. |
 | `dispatch` | enum | no | one of: sync \| async; default sync | Dispatch mode (#3731). 'sync' (default): run inline. 'async': return a jobId immediately + run the panel in background (poll get_job_result). |

--- a/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
@@ -7,7 +7,7 @@
  * builder/reader/path resolution are exercised by `pr-review-record.test.ts`.
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -144,6 +144,13 @@ describe('resolvePrReviewRecordsPath (#4278)', () => {
   // resolve. `repoPathOverride` (threaded from the pr_review `repoPath`
   // input) lets the caller say where the repo is, without disturbing the
   // existing env-var / cwd-detection precedence.
+  //
+  // #4312 security review (BLOCKING, addressed): call-time `repoPathOverride`
+  // is NOT operator-trust — any MCP client can supply it — so it is only
+  // honored when it resolves to a REAL repo root (a `.git` ancestor).
+  // Otherwise it is ignored (falls through to cwd detection) rather than
+  // letting a caller redirect the producer's mkdirSync+appendFileSync to an
+  // arbitrary writable directory.
   let originalCwd: string;
   let originalEnv: string | undefined;
   let noGitDir: string;
@@ -163,9 +170,11 @@ describe('resolvePrReviewRecordsPath (#4278)', () => {
     else process.env[PR_REVIEW_RECORDS_PATH_ENV] = originalEnv;
   });
 
-  it('(a) resolves <repoPathOverride>/governance/pr-review-records.jsonl when cwd has no .git ancestor', () => {
+  it('(a) resolves <repoPathOverride>/governance/pr-review-records.jsonl when the override IS a real repo root', () => {
     const overrideRoot = mkdtempSync(join(tmpdir(), 'pr-review-override-'));
     try {
+      // Give the override a `.git` marker so findRepoRoot(overrideRoot) succeeds.
+      mkdirSync(join(overrideRoot, '.git'));
       process.chdir(noGitDir);
       expect(findRepoRoot(process.cwd())).toBeNull();
 
@@ -173,6 +182,24 @@ describe('resolvePrReviewRecordsPath (#4278)', () => {
       expect(resolved).toBe(join(overrideRoot, PR_REVIEW_RECORDS_REL_PATH));
     } finally {
       rmSync(overrideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('(a2) #4312: an override with NO .git ancestor is NOT used — falls through to cwd detection', () => {
+    // Stay in the real repo cwd (has a resolvable repo root) so the fallthrough
+    // path is observable as a concrete value, not just `undefined`.
+    const cwdRoot = findRepoRoot(originalCwd);
+    expect(cwdRoot).not.toBeNull();
+
+    const notARepo = mkdtempSync(join(tmpdir(), 'pr-review-not-a-repo-'));
+    try {
+      const resolved = resolvePrReviewRecordsPath(notARepo);
+      // Must NOT redirect to the arbitrary directory...
+      expect(resolved).not.toBe(join(notARepo, PR_REVIEW_RECORDS_REL_PATH));
+      // ...it falls through to the cwd-based path instead.
+      expect(resolved).toBe(join(cwdRoot as string, PR_REVIEW_RECORDS_REL_PATH));
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
     }
   });
 

--- a/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.test.ts
@@ -16,10 +16,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { verifyPrReviewRecordSet } from './pr-review-record.js';
 import type { PrReviewVoteCounts } from './pr-review-record.js';
 import {
+  PR_REVIEW_RECORDS_PATH_ENV,
+  PR_REVIEW_RECORDS_REL_PATH,
   persistPrReviewRecord,
   readPrReviewRecords,
+  resolvePrReviewRecordsPath,
   type PersistPrReviewRecordOptions,
 } from './pr-review-record-store.js';
+import { findRepoRoot } from '../config/repo-root-detection.js';
 
 const BASE_SHA = 'a'.repeat(40);
 const DIFF_HASH = 'b'.repeat(64);
@@ -131,5 +135,66 @@ describe('persistPrReviewRecord (#4031)', () => {
         JSON.parse(line);
       }).not.toThrow();
     }
+  });
+});
+
+describe('resolvePrReviewRecordsPath (#4278)', () => {
+  // #4278: an MCP server process's cwd often has no `.git` ancestor, so
+  // findRepoRoot(cwd) returns null and the ledger path silently fails to
+  // resolve. `repoPathOverride` (threaded from the pr_review `repoPath`
+  // input) lets the caller say where the repo is, without disturbing the
+  // existing env-var / cwd-detection precedence.
+  let originalCwd: string;
+  let originalEnv: string | undefined;
+  let noGitDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalEnv = process.env[PR_REVIEW_RECORDS_PATH_ENV];
+    Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
+    // A fresh mkdtemp'd dir has no `.git` ancestor within the temp filesystem.
+    noGitDir = mkdtempSync(join(tmpdir(), 'pr-review-no-git-'));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(noGitDir, { recursive: true, force: true });
+    if (originalEnv === undefined) Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
+    else process.env[PR_REVIEW_RECORDS_PATH_ENV] = originalEnv;
+  });
+
+  it('(a) resolves <repoPathOverride>/governance/pr-review-records.jsonl when cwd has no .git ancestor', () => {
+    const overrideRoot = mkdtempSync(join(tmpdir(), 'pr-review-override-'));
+    try {
+      process.chdir(noGitDir);
+      expect(findRepoRoot(process.cwd())).toBeNull();
+
+      const resolved = resolvePrReviewRecordsPath(overrideRoot);
+      expect(resolved).toBe(join(overrideRoot, PR_REVIEW_RECORDS_REL_PATH));
+    } finally {
+      rmSync(overrideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('(b) env var still wins over repoPathOverride', () => {
+    const overrideRoot = mkdtempSync(join(tmpdir(), 'pr-review-override-'));
+    const envOverridePath = join(overrideRoot, 'elsewhere', 'records.jsonl');
+    process.env[PR_REVIEW_RECORDS_PATH_ENV] = envOverridePath;
+    try {
+      process.chdir(noGitDir);
+      const resolved = resolvePrReviewRecordsPath(overrideRoot);
+      expect(resolved).toBe(envOverridePath);
+    } finally {
+      rmSync(overrideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('(c) no override + resolvable cwd = unchanged findRepoRoot(cwd) behavior', () => {
+    // originalCwd is inside this repo checkout, so findRepoRoot resolves it.
+    const root = findRepoRoot(originalCwd);
+    expect(root).not.toBeNull();
+
+    const resolved = resolvePrReviewRecordsPath();
+    expect(resolved).toBe(join(root as string, PR_REVIEW_RECORDS_REL_PATH));
   });
 });

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -111,17 +111,24 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
  * Resolve the committable artifact path (mirrors #3927). Precedence:
  *  1. {@link PR_REVIEW_RECORDS_PATH_ENV} when set non-empty — a RELATIVE value is
  *     resolved against `process.cwd()` to an absolute path; an already-absolute
- *     value is returned unchanged.
+ *     value is returned unchanged. Operator-trust (set at process start):
+ *     intentionally UNRESTRICTED — no repo-root check.
  *  2. otherwise, when `repoPathOverride` is a non-whitespace string (#4278 —
- *     threaded from the pr_review tool's optional `repoPath` input), it is
- *     resolved to an absolute path and joined with {@link PR_REVIEW_RECORDS_REL_PATH}.
- *     The escape hatch for MCP server processes whose `process.cwd()` has no
- *     `.git` ancestor (so {@link findRepoRoot} would otherwise return `null` and
- *     the record would silently fail to persist).
+ *     threaded from the pr_review tool's optional `repoPath` input) AND it
+ *     resolves to a REAL repo root ({@link findRepoRoot} finds a `.git`
+ *     ancestor from it), `<that root>/`{@link PR_REVIEW_RECORDS_REL_PATH} is
+ *     used. Call-time input is NOT operator-trust — any MCP client can supply
+ *     `repoPath`, so (unlike the env var) it is constrained to a real repo
+ *     root rather than accepted as an arbitrary writable directory (security
+ *     review on #4312: an unconstrained override would let a caller redirect
+ *     the producer's `mkdirSync`+`appendFileSync` to any path the process can
+ *     write, e.g. `repoPath: '/var/www/html'`). An override that is NOT a real
+ *     repo root is NOT used — falls through to tier 3, never to an arbitrary
+ *     directory.
  *  3. otherwise `<repo-root>/governance/pr-review-records.jsonl` resolved from
  *     {@link findRepoRoot}(`process.cwd()`).
  * Returns `undefined` when none of the above yields a path. A whitespace-only
- * env value or override is treated as unset (falls through to the next tier).
+ * env value is treated as unset (falls through to the next tier).
  */
 export function resolvePrReviewRecordsPath(repoPathOverride?: string): string | undefined {
   const envPath = process.env[PR_REVIEW_RECORDS_PATH_ENV];
@@ -129,8 +136,10 @@ export function resolvePrReviewRecordsPath(repoPathOverride?: string): string | 
     return isAbsolute(envPath) ? envPath : resolve(envPath);
   }
   if (repoPathOverride !== undefined && repoPathOverride.trim() !== '') {
-    const repoRoot = isAbsolute(repoPathOverride) ? repoPathOverride : resolve(repoPathOverride);
-    return join(repoRoot, PR_REVIEW_RECORDS_REL_PATH);
+    const overrideRoot = findRepoRoot(repoPathOverride);
+    if (overrideRoot !== null) return join(overrideRoot, PR_REVIEW_RECORDS_REL_PATH);
+    // Not a real repo root — do NOT write to an arbitrary directory; fall
+    // through to cwd detection below.
   }
   const root = findRepoRoot(process.cwd());
   if (root === null) return undefined;
@@ -208,8 +217,10 @@ export interface PersistPrReviewRecordOptions extends Omit<
   /**
    * Repo-root override (#4278) forwarded to {@link resolvePrReviewRecordsPath}
    * when `filePath` is not given. Sits below {@link PR_REVIEW_RECORDS_PATH_ENV}
-   * but above `findRepoRoot(process.cwd())` in the resolution precedence — see
-   * that function's doc comment.
+   * but above `findRepoRoot(process.cwd())` in the resolution precedence.
+   * Call-time input (not operator-trust): only honored when it resolves to a
+   * REAL repo root (a `.git` ancestor); otherwise ignored and the resolver
+   * falls through to cwd detection — see that function's doc comment.
    */
   readonly repoPathOverride?: string | undefined;
   readonly logger?: ILogger | undefined;

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -112,15 +112,25 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
  *  1. {@link PR_REVIEW_RECORDS_PATH_ENV} when set non-empty — a RELATIVE value is
  *     resolved against `process.cwd()` to an absolute path; an already-absolute
  *     value is returned unchanged.
- *  2. otherwise `<repo-root>/governance/pr-review-records.jsonl` resolved from
+ *  2. otherwise, when `repoPathOverride` is a non-whitespace string (#4278 —
+ *     threaded from the pr_review tool's optional `repoPath` input), it is
+ *     resolved to an absolute path and joined with {@link PR_REVIEW_RECORDS_REL_PATH}.
+ *     The escape hatch for MCP server processes whose `process.cwd()` has no
+ *     `.git` ancestor (so {@link findRepoRoot} would otherwise return `null` and
+ *     the record would silently fail to persist).
+ *  3. otherwise `<repo-root>/governance/pr-review-records.jsonl` resolved from
  *     {@link findRepoRoot}(`process.cwd()`).
- * Returns `undefined` when neither yields a path. A whitespace-only override is
- * treated as unset (falls through to root detection).
+ * Returns `undefined` when none of the above yields a path. A whitespace-only
+ * env value or override is treated as unset (falls through to the next tier).
  */
-export function resolvePrReviewRecordsPath(): string | undefined {
+export function resolvePrReviewRecordsPath(repoPathOverride?: string): string | undefined {
   const envPath = process.env[PR_REVIEW_RECORDS_PATH_ENV];
   if (envPath !== undefined && envPath.trim() !== '') {
     return isAbsolute(envPath) ? envPath : resolve(envPath);
+  }
+  if (repoPathOverride !== undefined && repoPathOverride.trim() !== '') {
+    const repoRoot = isAbsolute(repoPathOverride) ? repoPathOverride : resolve(repoPathOverride);
+    return join(repoRoot, PR_REVIEW_RECORDS_REL_PATH);
   }
   const root = findRepoRoot(process.cwd());
   if (root === null) return undefined;
@@ -195,6 +205,13 @@ export interface PersistPrReviewRecordOptions extends Omit<
    * and the {@link resolvePrReviewRecordsPath} resolution.
    */
   readonly filePath?: string | undefined;
+  /**
+   * Repo-root override (#4278) forwarded to {@link resolvePrReviewRecordsPath}
+   * when `filePath` is not given. Sits below {@link PR_REVIEW_RECORDS_PATH_ENV}
+   * but above `findRepoRoot(process.cwd())` in the resolution precedence — see
+   * that function's doc comment.
+   */
+  readonly repoPathOverride?: string | undefined;
   readonly logger?: ILogger | undefined;
 }
 
@@ -218,13 +235,14 @@ export interface PersistPrReviewRecordOptions extends Omit<
  * (#3831) MUST NOT treat `baseSha` as verified provenance without adding that check.
  *
  * Path precedence: `opts.filePath` > {@link PR_REVIEW_RECORDS_PATH_ENV} >
- * {@link resolvePrReviewRecordsPath}.
+ * `opts.repoPathOverride` > {@link resolvePrReviewRecordsPath}'s
+ * `findRepoRoot(process.cwd())` fallback.
  */
 export function persistPrReviewRecord(
   opts: PersistPrReviewRecordOptions
 ): PrReviewRecord | undefined {
   const logger = opts.logger ?? createLogger({ component: 'pr-review-record-store' });
-  const filePath = opts.filePath ?? resolvePrReviewRecordsPath();
+  const filePath = opts.filePath ?? resolvePrReviewRecordsPath(opts.repoPathOverride);
   if (filePath === undefined) {
     logger.warn('Cannot persist pr-review record: no records path resolved', {
       prNumber: opts.prNumber,

--- a/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
@@ -130,6 +130,9 @@ function buildAndPersist(
       total: reviewCount,
     },
     summary: `${aggregate.decision} (${String(counts.approveCount)} approve / ${String(counts.requestChangesCount)} request_changes / ${String(counts.abstainCount)} abstain) — ${input.prTitle}${coverageSuffix}`,
+    // #4278: lets a caller (e.g. an MCP server whose cwd has no `.git`
+    // ancestor) say where the repo is, so the record isn't silently dropped.
+    ...(input.repoPath !== undefined ? { repoPathOverride: input.repoPath } : {}),
     logger,
   });
   if (record === undefined) {

--- a/packages/nexus-agents/src/mcp/tools/pr-review-result-mapping.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-result-mapping.ts
@@ -1,0 +1,63 @@
+/**
+ * nexus-agents/mcp - PR Review Result Mapping (split out of pr-review-tool.ts, #4278).
+ *
+ * Pure per-voter → per-review mapping and summarization helpers for the pr_review
+ * tool. Split into its own module (no behavior change) to keep pr-review-tool.ts
+ * under the repo's `max-lines` lint budget after adding the #4278 `repoPath` input.
+ *
+ * @module mcp/tools/pr-review-result-mapping
+ */
+
+import type { AgentVoteResult } from '../../cli/vote-types.js';
+import { isFindingVerified, parseFindings, type Finding } from './pr-review-findings.js';
+import { mapVoteDecisionToPrDecision, type PrReviewVote } from './pr-review-tool.js';
+
+/** Resolves findings for a voter result. Preferred path is the top-level
+ * `vote.findings` array (#2245 v4 follow-up — JSON-native, lossless). Falls
+ * back to parsing a YAML block from reasoning text for older voter outputs
+ * that may still emit the legacy format. */
+export function resolveFindings(result: AgentVoteResult): readonly Finding[] {
+  const raw = result.vote.findings;
+  if (raw !== undefined && raw.length > 0) {
+    return raw.map((f) => ({
+      summary: f.summary,
+      location: f.location,
+      severity: f.severity,
+      gate: f.gate,
+      claim: f.claim,
+      verified: isFindingVerified(f.gate),
+    }));
+  }
+  // Fallback: legacy YAML-in-reasoning format.
+  return parseFindings(result.vote.reasoning);
+}
+
+export function toPrReviewVote(result: AgentVoteResult): PrReviewVote {
+  return {
+    role: result.role,
+    decision: mapVoteDecisionToPrDecision(result.vote.decision),
+    confidence: result.vote.confidence,
+    reasoning: result.vote.reasoning,
+    findings: resolveFindings(result),
+    source: result.source,
+    cli: result.cli,
+    processingTimeMs: result.processingTimeMs,
+    ...(result.error !== undefined && { errorMessage: result.error }),
+  };
+}
+
+export function summarizeReviews(reviews: readonly PrReviewVote[]): {
+  approveCount: number;
+  requestChangesCount: number;
+  abstainCount: number;
+  errorCount: number;
+} {
+  return {
+    approveCount: reviews.filter((r) => r.source !== 'error' && r.decision === 'approve').length,
+    requestChangesCount: reviews.filter(
+      (r) => r.source !== 'error' && r.decision === 'request_changes'
+    ).length,
+    abstainCount: reviews.filter((r) => r.source !== 'error' && r.decision === 'abstain').length,
+    errorCount: reviews.filter((r) => r.source === 'error').length,
+  };
+}

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -802,3 +802,105 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     expect(readPrReviewRecords(path).records).toHaveLength(0);
   });
 });
+
+describe('pr_review repoPath input (#4278)', () => {
+  const BASE_SHA = 'd'.repeat(40);
+  const APPROVE_AGG: PrReviewAggregate = { decision: 'approve', verified: true };
+  const COUNTS = { approveCount: 5, requestChangesCount: 0, abstainCount: 0, errorCount: 0 };
+  const logger = createLogger({ tool: 'pr-review-test' });
+
+  it('is accepted by PrReviewInputSchema as an optional string', () => {
+    const r = PrReviewInputSchema.safeParse({
+      prTitle: 'x',
+      prDiff: 'y',
+      repoPath: '/some/repo/root',
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.repoPath).toBe('/some/repo/root');
+  });
+
+  it('omits repoPath from parsed output when not supplied', () => {
+    const r = PrReviewInputSchema.parse({ prTitle: 'x', prDiff: 'y' });
+    expect(r.repoPath).toBeUndefined();
+  });
+
+  // #4278 root cause: resolvePrReviewRecordsPath() falls back to
+  // findRepoRoot(process.cwd()), which returns null in an MCP server process
+  // whose cwd has no `.git` ancestor — so the record silently fails to
+  // persist. `repoPath` is the caller-supplied escape hatch. This test
+  // exercises the FULL path: schema -> persistReviewRecord -> persistPrReviewRecord
+  // -> resolvePrReviewRecordsPath, from a cwd with no `.git` ancestor and the
+  // env override unset.
+  describe('end-to-end persistence with no .git ancestor in cwd', () => {
+    let originalCwd: string;
+    let originalEnv: string | undefined;
+    let noGitDir: string;
+    let repoRoot: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      originalEnv = process.env[PR_REVIEW_RECORDS_PATH_ENV];
+      Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
+      noGitDir = mkdtempSync(join(tmpdir(), 'pr-review-repopath-no-git-'));
+      repoRoot = mkdtempSync(join(tmpdir(), 'pr-review-repopath-root-'));
+      process.chdir(noGitDir);
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      if (originalEnv === undefined)
+        Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
+      else process.env[PR_REVIEW_RECORDS_PATH_ENV] = originalEnv;
+      rmSync(noGitDir, { recursive: true, force: true });
+      rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    it('persists to <repoPath>/governance/pr-review-records.jsonl when cwd has no .git ancestor', () => {
+      const parsed = PrReviewInputSchema.parse({
+        prTitle: 'Add repoPath escape hatch',
+        prDiff: 'diff --git a/x b/x\n+line\n',
+        simulate: false,
+        prNumber: 4278,
+        baseSha: BASE_SHA,
+        repoPath: repoRoot,
+      });
+
+      const outcome = persistReviewRecord({
+        input: parsed,
+        aggregate: APPROVE_AGG,
+        counts: COUNTS,
+        reviewCount: 5,
+        logger,
+      });
+
+      expect(outcome.persisted).toBe(true);
+      const expectedPath = join(repoRoot, 'governance', 'pr-review-records.jsonl');
+      const { records, invalidLines } = readPrReviewRecords(expectedPath);
+      expect(invalidLines).toEqual([]);
+      expect(records).toHaveLength(1);
+      expect(records[0]?.prNumber).toBe(4278);
+    });
+
+    it('without repoPath, persistence is skipped (write-failed) — the #4278 bug reproduced', () => {
+      const parsed = PrReviewInputSchema.parse({
+        prTitle: 'No repoPath supplied',
+        prDiff: 'diff --git a/x b/x\n+line\n',
+        simulate: false,
+        prNumber: 4279,
+        baseSha: BASE_SHA,
+      });
+
+      const outcome = persistReviewRecord({
+        input: parsed,
+        aggregate: APPROVE_AGG,
+        counts: COUNTS,
+        reviewCount: 5,
+        logger,
+      });
+
+      expect(outcome).toEqual(
+        expect.objectContaining({ persisted: false, reason: 'write-failed' })
+      );
+    });
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -831,6 +831,11 @@ describe('pr_review repoPath input (#4278)', () => {
   // exercises the FULL path: schema -> persistReviewRecord -> persistPrReviewRecord
   // -> resolvePrReviewRecordsPath, from a cwd with no `.git` ancestor and the
   // env override unset.
+  //
+  // #4312 security review (BLOCKING, addressed): `repoPath` is call-time input
+  // from any MCP client, not operator-trust — it is only honored when it
+  // resolves to a REAL repo root (`.git` ancestor), never as an arbitrary
+  // writable directory.
   describe('end-to-end persistence with no .git ancestor in cwd', () => {
     let originalCwd: string;
     let originalEnv: string | undefined;
@@ -843,6 +848,8 @@ describe('pr_review repoPath input (#4278)', () => {
       Reflect.deleteProperty(process.env, PR_REVIEW_RECORDS_PATH_ENV);
       noGitDir = mkdtempSync(join(tmpdir(), 'pr-review-repopath-no-git-'));
       repoRoot = mkdtempSync(join(tmpdir(), 'pr-review-repopath-root-'));
+      // Give repoRoot a `.git` marker so it IS a real repo root (#4312).
+      mkdirSync(join(repoRoot, '.git'));
       process.chdir(noGitDir);
     });
 
@@ -855,7 +862,7 @@ describe('pr_review repoPath input (#4278)', () => {
       rmSync(repoRoot, { recursive: true, force: true });
     });
 
-    it('persists to <repoPath>/governance/pr-review-records.jsonl when cwd has no .git ancestor', () => {
+    it('persists to <repoPath>/governance/pr-review-records.jsonl when cwd has no .git ancestor and repoPath IS a real repo root', () => {
       const parsed = PrReviewInputSchema.parse({
         prTitle: 'Add repoPath escape hatch',
         prDiff: 'diff --git a/x b/x\n+line\n',
@@ -901,6 +908,39 @@ describe('pr_review repoPath input (#4278)', () => {
       expect(outcome).toEqual(
         expect.objectContaining({ persisted: false, reason: 'write-failed' })
       );
+    });
+
+    it('#4312: a repoPath that is NOT a real repo root is ignored — never writes into it', () => {
+      const notARepo = mkdtempSync(join(tmpdir(), 'pr-review-not-a-repo-'));
+      try {
+        const parsed = PrReviewInputSchema.parse({
+          prTitle: 'Malicious repoPath',
+          prDiff: 'diff --git a/x b/x\n+line\n',
+          simulate: false,
+          prNumber: 4280,
+          baseSha: BASE_SHA,
+          repoPath: notARepo,
+        });
+
+        const outcome = persistReviewRecord({
+          input: parsed,
+          aggregate: APPROVE_AGG,
+          counts: COUNTS,
+          reviewCount: 5,
+          logger,
+        });
+
+        // cwd (noGitDir) also has no `.git` ancestor, so the resolver has
+        // nothing left to fall through to — the write must be skipped, NOT
+        // redirected into the arbitrary `notARepo` directory.
+        expect(outcome).toEqual(
+          expect.objectContaining({ persisted: false, reason: 'write-failed' })
+        );
+        const wouldBeArbitraryPath = join(notARepo, 'governance', 'pr-review-records.jsonl');
+        expect(readPrReviewRecords(wouldBeArbitraryPath).records).toHaveLength(0);
+      } finally {
+        rmSync(notARepo, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -147,7 +147,7 @@ export const PrReviewInputSchema = z.object({
     .max(1024)
     .optional()
     .describe(
-      'Absolute path to the repo root for persisting the governance pr-review record (overrides cwd auto-detection; env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence).'
+      'Repo root path for persisting the governance pr-review record (overrides cwd auto-detection). Must contain a .git ancestor — relative paths are resolved against cwd; ignored (falls back to cwd auto-detection) if it is not a real repo root. Env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence and is unrestricted.'
     ),
   simulate: z
     .boolean()

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -33,7 +33,7 @@ import {
   type BaseMcpToolDeps,
   type ToolResult,
 } from './tool-result.js';
-import type { VoterRole, AgentVoteResult } from '../../cli/vote-types.js';
+import type { VoterRole } from '../../cli/vote-types.js';
 import { collectRealVotes } from '../../cli/voter-agents.js';
 import { checkSimulationAllowed, simulationDeniedResult } from './simulation-guard.js';
 import { getToolAnnotations } from '../tool-annotations.js';
@@ -41,15 +41,12 @@ import { recordDecisionCost } from './decision-cost-recording.js';
 import type { DecisionCostSummary } from '../../observability/decision-cost.js';
 // #3731 / epic #2631: async-mode dispatch via the shared `runAsJob` helper.
 import { runAsJob } from '../jobs/run-as-job.js';
-import {
-  FINDINGS_FORMAT_INSTRUCTIONS,
-  isFindingVerified,
-  parseFindings,
-  type Finding,
-} from './pr-review-findings.js';
+import { FINDINGS_FORMAT_INSTRUCTIONS, type Finding } from './pr-review-findings.js';
 import { persistReviewRecord, type PrReviewRecordOutcome } from './pr-review-record-producer.js';
 // prettier-ignore
 import { applyPartialCoverageGate, packDiffForReview, type PrReviewCoverage } from './pr-review-diff-budget.js';
+// #4278: split out of this file to stay under the max-lines budget (no behavior change).
+import { toPrReviewVote, summarizeReviews } from './pr-review-result-mapping.js';
 
 export type { Finding, VerificationGate, FindingSeverity } from './pr-review-findings.js';
 
@@ -144,6 +141,13 @@ export const PrReviewInputSchema = z.object({
     .optional()
     .describe(
       '40-hex base commit sha the reviewed diff was computed from (Option-C binding, #4031)'
+    ),
+  repoPath: z
+    .string()
+    .max(1024)
+    .optional()
+    .describe(
+      'Absolute path to the repo root for persisting the governance pr-review record (overrides cwd auto-detection; env NEXUS_PR_REVIEW_RECORDS_PATH still takes precedence).'
     ),
   simulate: z
     .boolean()
@@ -411,60 +415,6 @@ export function buildPrReviewProposal(
   parts.push(`\n${FINDINGS_FORMAT_INSTRUCTIONS}\n`);
 
   return parts.join('');
-}
-
-// ============================================================================
-// Result Mapping
-// ============================================================================
-
-/** Resolves findings for a voter result. Preferred path is the top-level
- * `vote.findings` array (#2245 v4 follow-up — JSON-native, lossless). Falls
- * back to parsing a YAML block from reasoning text for older voter outputs
- * that may still emit the legacy format. */
-function resolveFindings(result: AgentVoteResult): readonly Finding[] {
-  const raw = result.vote.findings;
-  if (raw !== undefined && raw.length > 0) {
-    return raw.map((f) => ({
-      summary: f.summary,
-      location: f.location,
-      severity: f.severity,
-      gate: f.gate,
-      claim: f.claim,
-      verified: isFindingVerified(f.gate),
-    }));
-  }
-  // Fallback: legacy YAML-in-reasoning format.
-  return parseFindings(result.vote.reasoning);
-}
-
-function toPrReviewVote(result: AgentVoteResult): PrReviewVote {
-  return {
-    role: result.role,
-    decision: mapVoteDecisionToPrDecision(result.vote.decision),
-    confidence: result.vote.confidence,
-    reasoning: result.vote.reasoning,
-    findings: resolveFindings(result),
-    source: result.source,
-    cli: result.cli,
-    processingTimeMs: result.processingTimeMs,
-    ...(result.error !== undefined && { errorMessage: result.error }),
-  };
-}
-
-function summarizeReviews(reviews: readonly PrReviewVote[]): {
-  approveCount: number;
-  requestChangesCount: number;
-  abstainCount: number;
-  errorCount: number;
-} {
-  return {
-    approveCount: reviews.filter((r) => r.source !== 'error' && r.decision === 'approve').length,
-    requestChangesCount: reviews.filter(
-      (r) => r.source !== 'error' && r.decision === 'request_changes'
-    ).length,
-    abstainCount: reviews.filter((r) => r.source !== 'error' && r.decision === 'abstain').length,
-    errorCount: reviews.filter((r) => r.source === 'error').length,
-  };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Root cause

`resolvePrReviewRecordsPath()` in `packages/nexus-agents/src/audit/pr-review-record-store.ts` resolved the pr-review governance ledger path from only two sources: the `NEXUS_PR_REVIEW_RECORDS_PATH` env var, or `findRepoRoot(process.cwd())`. In an MCP server process the working directory frequently has no `.git` ancestor, so `findRepoRoot` returns `null` and `persistPrReviewRecord()` silently skips the write ("records path unresolved" — logged only as a WARN). `PrReviewInputSchema` had no way for the caller to say where the repo actually is, so a live `pr_review` call in a server context would produce a normal review response but never write to `governance/pr-review-records.jsonl`, silently starving the warn-first governor-review gate (#3831) of records.

Closes #4278.

## Fix

- Added an optional `repoPath` input to `PrReviewInputSchema` (`packages/nexus-agents/src/mcp/tools/pr-review-tool.ts`): absolute path to the repo root, used to persist the governance record.
- Threaded it through the existing producer chain: `pr_review` handler → `persistReviewRecord` (`pr-review-record-producer.ts`) → `persistPrReviewRecord` (`pr-review-record-store.ts`), as a new `repoPathOverride` option.
- `resolvePrReviewRecordsPath()` now accepts an optional `repoPathOverride?: string` parameter. Precedence (additive, backward compatible):
  1. `NEXUS_PR_REVIEW_RECORDS_PATH` env var (unchanged, still wins)
  2. `repoPathOverride` (new) — joined with `governance/pr-review-records.jsonl`
  3. `findRepoRoot(process.cwd())` (unchanged fallback)

  Existing callers that pass neither `repoPath` nor the env var see byte-identical behavior.

- Documented `NEXUS_PR_REVIEW_RECORDS_PATH` in `.mcp.json.example` (new `env` block) and in `docs/getting-started/CONFIGURATION.md`'s Security & Governance Variables table.
- Regenerated `docs/reference/tools/pr_review.md` via `pnpm docs:tools` (Tool Reference Drift gate — the `repoPath` Zod input shape changed).

### Incidental: file-size split

Adding the `repoPath` field pushed `pr-review-tool.ts` over the repo's `max-lines` (400) ESLint budget. Fixed by extracting the pure per-voter result-mapping helpers (`resolveFindings`, `toPrReviewVote`, `summarizeReviews` — previously private, not referenced anywhere else) into a new co-located module `pr-review-result-mapping.ts`. No behavior change; verified via the full existing test suite.

## Test coverage (TDD, red before green)

`packages/nexus-agents/src/audit/pr-review-record-store.test.ts` — new `resolvePrReviewRecordsPath` describe block:
- (a) with a `repoPathOverride` and a cwd with **no** `.git` ancestor, resolves to `<override>/governance/pr-review-records.jsonl`
- (b) env var still wins over `repoPathOverride`
- (c) no override + resolvable cwd = unchanged `findRepoRoot(cwd)` behavior

`packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts` — new `pr_review repoPath input` describe block:
- schema accepts/omits `repoPath` correctly
- end-to-end: from a cwd with no `.git` ancestor and the env var unset, `persistReviewRecord` with `repoPath` set persists the record to `<repoPath>/governance/pr-review-records.jsonl`
- same setup without `repoPath` reproduces the original #4278 bug (`persisted: false, reason: 'write-failed'`)

## Gates (all green)

- `pnpm --filter nexus-agents typecheck` (tsc --noEmit over src+tests) — clean
- `pnpm --filter nexus-agents test` — 153 test files / 2789 tests passing
- `pnpm lint` (turbo lint across nexus-agents / nexus-memory / website) — clean
- `pnpm docs:tools:check` — up to date
- `pnpm --filter nexus-agents build` — succeeds
- Changeset added (`patch`, references #4278)

## Not merging

Per process, this PR is vote-gated — not merging it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)