### PR TITLE
feat(learning): add MetaOrchestrator shadow-training soak trigger (#4310)

### DIFF
--- a/.changeset/meta-shadow-training-soak-4310.md
+++ b/.changeset/meta-shadow-training-soak-4310.md
@@ -1,0 +1,14 @@
+---
+---
+
+feat(learning): add the MetaOrchestrator shadow-training soak trigger (#4310, feeder for #3552)
+
+The shadow-training mechanism (`NEXUS_META_SHADOW_TRAIN=1` persisting sanitized bandit outcomes to `learning/meta-outcomes.jsonl`, #3593) worked, but nothing ever triggered it — training only fires on a live `run{execute:true}` call, and no CI/cron/CLI ever made one.
+
+Adds `scripts/meta-shadow-soak.ts` (thin `gh` + live-`executeGoal` edge) and `scripts/meta-shadow-soak-core.ts` (pure, unit-tested goal selection/formatting) to drive a bounded set of REAL backlog issues through the router with shadow training enabled, plus `.github/workflows/meta-shadow-soak.yml` (`workflow_dispatch`-only, secret-gated so it skips cleanly without model credentials, single-flight concurrency, accumulating `actions/cache`, an explicit feeder-only mode assert) mirroring the #4224 remediation-audit-soak precedent.
+
+Feeder only: `NEXUS_META_SHADOW_TRAIN=1` is the only lever pulled — it never alters what `run` dispatches. The #3552 shadow→route flip stays a separate, human-gated change.
+
+CI-workflow + scripts + docs only (no `packages/nexus-agents/src` change), so this ships no
+package update — empty changeset per repo convention (matches #4224's
+`scheduled-audit-soak-4224.md`).

--- a/.github/workflows/meta-shadow-soak.yml
+++ b/.github/workflows/meta-shadow-soak.yml
@@ -1,0 +1,190 @@
+name: Meta Shadow-Training Soak
+
+# On-demand MetaOrchestrator shadow-training trigger (#4310, feeder for #3552).
+#
+# Why this exists: the shadow-training MECHANISM already works —
+# `NEXUS_META_SHADOW_TRAIN=1` makes `executeGoal` (run-tool.ts) feed every live
+# `run{execute:true}` dispatch outcome into the MetaOrchestrator shadow
+# selector and persist a sanitized record (feature values + success only,
+# never task text, #3593) to `<NEXUS_DATA_DIR>/learning/meta-outcomes.jsonl`.
+# But nothing ever TRIGGERED it: training only fires on a live `run` call, and
+# no CI/cron/CLI ever made one, so the shadow-agreement evidence #3552's
+# shadow→route flip decision depends on could not accumulate. This workflow
+# is that trigger — it drives `scripts/meta-shadow-soak.ts` against a bounded
+# set of REAL backlog issues (gh-sourced, not synthetic; ratified for #4310)
+# through the actual `run` router + dispatcher.
+#
+# Mirrors the #4224 remediation-audit-soak precedent (concurrency-serialized,
+# actions/cache rolling-key accumulation, NEXUS_DATA_DIR under the workspace,
+# an explicit mode-assert safety step) with ONE deliberate difference:
+# NO `schedule:` trigger. Unlike #4224's audit-mode cycle (zero LLM cost
+# without credentials — `createAutoAdapter` throws before any network call),
+# this soak DISPATCHES REAL strategies (dev-pipeline / pipeline / research /
+# consensus) through real model gateways when credentials are present, so a
+# recurring cron would recur real API cost with no CI-cost mandate to justify
+# it. `workflow_dispatch` only: an owner runs it on demand as the evidence
+# window needs topping up (see the LOCAL run command in
+# docs/getting-started/CONFIGURATION.md for the credential-rich alternative).
+#
+# SAFETY (feeder only, never wired to routing — see the "Assert shadow/feeder-
+# only mode" step below): this workflow ONLY ever sets
+# NEXUS_META_SHADOW_TRAIN=1. That env var feeds the SHADOW selector and the
+# offline eval surface (meta-outcomes.jsonl) — it never alters which strategy
+# `run` actually dispatches. The #3552 shadow→route flip stays a separate,
+# human-gated change; nothing here can enable it.
+#
+# SECRET-GATED: without at least one model-gateway API key configured as a
+# repo secret, the soak step is a structural no-op — `check-secrets` sets
+# `has_key=false` and every downstream step is skipped (job stays GREEN, not
+# failed), so this workflow is safe to leave present even on a fork or a repo
+# that hasn't configured model credentials.
+
+on:
+  workflow_dispatch:
+    inputs:
+      count:
+        description: 'Number of real backlog goals to drive through executeGoal'
+        required: false
+        default: '12'
+        type: string
+      repo:
+        description: 'owner/repo to source backlog issues from'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+# Serialize runs so an overlapping manual trigger (or a slow prior run) can
+# never interleave writes to — or race the cache save of — the same
+# meta-outcomes.jsonl. cancel-in-progress: false lets a running soak FINISH
+# its append + cache-save rather than being killed mid-write.
+concurrency:
+  group: meta-shadow-soak
+  cancel-in-progress: false
+
+jobs:
+  soak:
+    name: Shadow-training soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # The ONLY lever this workflow pulls: feeds the SHADOW selector, never
+      # routing. See the safety note above and the assert step below.
+      NEXUS_META_SHADOW_TRAIN: '1'
+      # Persist the shadow-training evidence under a workspace path the cache covers.
+      NEXUS_DATA_DIR: ${{ github.workspace }}/.nexus-soak-data
+      # This is a frozen CI checkout — never touch the tree or route state per-repo.
+      NEXUS_GITIGNORE_AUTO: '0'
+      NEXUS_REPO_PREFERRED: '0'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Assert shadow/feeder-only mode (never wired to routing)
+        run: |
+          if [ "${NEXUS_META_SHADOW_TRAIN}" != "1" ]; then
+            echo "::error::NEXUS_META_SHADOW_TRAIN must be '1' in this workflow (got '${NEXUS_META_SHADOW_TRAIN}')"
+            exit 1
+          fi
+          echo "Shadow-training mode confirmed: feeds learning/meta-outcomes.jsonl only."
+          echo "This workflow does not set, and #4310 does not introduce, any env var or"
+          echo "flag that routes a live decision through the learned selector — the #3552"
+          echo "shadow-to-route flip remains a separate, human-gated change."
+
+      - name: Check for model-gateway secrets
+        id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_AI_API_KEY: ${{ secrets.GOOGLE_AI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY}${OPENAI_API_KEY}${GOOGLE_AI_API_KEY}${OPENROUTER_API_KEY}" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+            echo "At least one model-gateway secret is configured — soak will run."
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "No model-gateway secret configured (ANTHROPIC_API_KEY / OPENAI_API_KEY /"
+            echo "GOOGLE_AI_API_KEY / OPENROUTER_API_KEY). This is expected for an on-demand,"
+            echo "no-CI-cost-mandate soak — skipping cleanly rather than failing. Add one of"
+            echo "those repo secrets to enable this workflow, or run the soak LOCALLY (see"
+            echo "docs/getting-started/CONFIGURATION.md)."
+          fi
+
+      - if: steps.check.outputs.has_key == 'true'
+        uses: ./.github/actions/setup-node
+
+      # `executeGoal`'s dispatch path can reach the memory-registry surface
+      # (nexus-memory), a separate workspace package whose dist is not built by
+      # a bare `pnpm install`. Mirrors the "Script Tests" CI job.
+      - name: Build nexus-memory (workspace dep)
+        if: steps.check.outputs.has_key == 'true'
+        run: pnpm --filter nexus-memory build
+
+      # Restore the prior soak so this run APPENDS to it — the shadow-training
+      # sink appends-on-write and the selector hydrates-on-construct, so a
+      # restored meta-outcomes.jsonl grows rather than being overwritten.
+      #
+      # Rolling key + restore-keys prefix (NOT a fixed key), mirroring #4224:
+      #   * `key` embeds `github.run_id` so the post-job save always writes a
+      #     NEW cache entry (a fixed key would hit on restore and GitHub would
+      #     then SKIP the save — the file would never grow).
+      #   * `restore-keys` is a bare prefix, so each run restores the MOST
+      #     RECENT prior cache under it.
+      - name: Restore + persist accumulating soak
+        if: steps.check.outputs.has_key == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ github.workspace }}/.nexus-soak-data/learning
+          key: meta-shadow-soak-${{ github.run_id }}
+          restore-keys: |
+            meta-shadow-soak-
+
+      - name: Record pre-run shadow-record volume
+        if: steps.check.outputs.has_key == 'true'
+        id: pre
+        run: |
+          FILE="${NEXUS_DATA_DIR}/learning/meta-outcomes.jsonl"
+          before=0
+          [ -f "$FILE" ] && before=$(wc -l < "$FILE" | tr -d ' ')
+          echo "before=${before}" >> "$GITHUB_OUTPUT"
+          echo "meta-outcomes.jsonl records before this run: ${before}"
+
+      - name: Run shadow-training soak
+        if: steps.check.outputs.has_key == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_AI_API_KEY: ${{ secrets.GOOGLE_AI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "${NEXUS_DATA_DIR}/learning"
+          npx tsx scripts/meta-shadow-soak.ts \
+            --count "${{ inputs.count || '12' }}" \
+            --repo "${{ inputs.repo != '' && inputs.repo || github.repository }}"
+
+      - name: Report accrual to job summary
+        if: always()
+        run: |
+          {
+            echo "### Meta shadow-training soak (#4310)"
+            echo ""
+            if [ "${{ steps.check.outputs.has_key }}" != "true" ]; then
+              echo "- Skipped: no model-gateway secret configured (expected for this"
+              echo "  on-demand, no-CI-cost-mandate workflow). See"
+              echo "  docs/getting-started/CONFIGURATION.md for the local run command."
+              exit 0
+            fi
+            FILE="${NEXUS_DATA_DIR}/learning/meta-outcomes.jsonl"
+            after=0
+            [ -f "$FILE" ] && after=$(wc -l < "$FILE" | tr -d ' ')
+            before="${{ steps.pre.outputs.before }}"
+            echo "- Mode: shadow-training only (\`NEXUS_META_SHADOW_TRAIN=1\`); never routes"
+            echo "- meta-outcomes.jsonl records before: **${before:-0}**"
+            echo "- meta-outcomes.jsonl records after:  **${after}**"
+            echo "- Accrued this run:                   **$(( after - ${before:-0} ))**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -444,6 +444,75 @@ readiness gate reflects **genuine** soundness over real, plan-bearing selections
 > tracked as follow-up to #4224 (and would also need the dry-run audit `detail` to
 > carry plan content rather than just `ok`/error).
 
+### On-demand MetaOrchestrator shadow-training soak (#4310)
+
+The shadow-training MECHANISM has worked since #3593: with
+`NEXUS_META_SHADOW_TRAIN=1`, `executeGoal` (the `run{execute:true}` engine)
+feeds every live dispatch outcome into the MetaOrchestrator shadow selector
+and appends a sanitized record — bandit feature values + a success flag only,
+**never task text** — to `learning/meta-outcomes.jsonl`. But nothing ever
+TRIGGERED it: training only fires on a live `run` call, and no CI/cron/CLI
+ever made one, so the shadow-agreement evidence the #3552 shadow→route flip
+decision depends on could not accumulate. `.github/workflows/meta-shadow-soak.yml`
+and `scripts/meta-shadow-soak.ts` give it an organic feed, mirroring the #4224
+remediation-audit-soak precedent above.
+
+> **This is a FEEDER, not a router.** `NEXUS_META_SHADOW_TRAIN=1` is the only
+> lever this soak pulls. It never alters which strategy `run` actually
+> dispatches, and it never feeds the enforce/routing path — the #3552
+> shadow→route flip stays a separate, human-gated change. The workflow asserts
+> this invariant explicitly before running.
+
+**Goal sourcing (ratified for #4310): REAL backlog issues, not synthetic.**
+The script fetches open issues from the repo via `gh issue list`, formats
+each as `#<number>: <title>` plus its first body paragraph, and deterministically
+selects a bounded set (default 12, most-recent-first by issue number — a
+reproducible proxy for recency). Synthetic goals would exercise the router on
+a distribution that doesn't resemble what `run` actually sees in production,
+undermining the shadow-agreement evidence the flip decision depends on. The
+selection/formatting logic is pure and unit-tested
+(`scripts/meta-shadow-soak-core.ts`); the `gh` fetch and the live `executeGoal`
+dispatch are the thin, untested-by-unit I/O edge (`scripts/meta-shadow-soak.ts`),
+mirroring the curate-pr-review-harvest.ts / mine-pr-review-candidates-core.ts
+split (#3847).
+
+**1. `workflow_dispatch` only — deliberately NO `schedule:` trigger.** The #4224
+audit-mode cycle costs zero LLM spend without credentials (`createAutoAdapter`
+throws before any network call), but this soak dispatches REAL strategies
+(dev-pipeline / pipeline / research / consensus) through real model gateways
+when credentials are present, so a recurring cron would recur real API cost
+with no CI-cost mandate to justify it. An owner triggers it manually from the
+Actions tab as the evidence window needs topping up.
+
+**Secret-gated — skips cleanly, never fails, when no model-gateway credential
+is configured.** A `check-secrets` step inspects `ANTHROPIC_API_KEY` /
+`OPENAI_API_KEY` / `GOOGLE_AI_API_KEY` / `OPENROUTER_API_KEY` (the same set
+`pr-review.yml` checks) and every downstream step is conditioned on at least
+one being present. Without one, the job reports "skipped" in the step summary
+and exits green — this workflow is safe to leave present even before model
+credentials are configured as repo secrets.
+
+**2. LOCAL on-demand run (no CI cost, uses your own credentials/telemetry):**
+
+```bash
+NEXUS_META_SHADOW_TRAIN=1 npx tsx scripts/meta-shadow-soak.ts --count 12 --repo nexus-substrate/nexus-agents
+```
+
+Requires `gh` authenticated against the target repo (`gh auth status`) and
+model-gateway credentials for whichever strategies the router selects. A goal
+that routes to an unwired strategy (`graph-workflow` / `spec` / `orchestrate` /
+`single-shot`) still accrues a **failure** shadow-training record — the
+dispatcher records an outcome even for a `no_executor` dispatch — so even
+those goals are not wasted soak volume. The script prints a summary: goals
+run, `meta-outcomes.jsonl` record count before/after, and file size.
+
+> **Stub vs. live:** goal selection/formatting (`meta-shadow-soak-core.ts`) is
+> pure and fully unit-tested against fixtures — no network, no live models.
+> The `gh` fetch and the `executeGoal` dispatch are real I/O with no stub or
+> mock path; there is no `simulateVotes`/synthetic-outcome mode by design (a
+> mocked evidence trail would be worse than no evidence trail for a decision
+> #3552 depends on).
+
 ### Removed in 2.82.0 (#2977)
 
 These 8 env vars were declared but never read by any production code (silent

--- a/scripts/meta-shadow-soak-core.test.ts
+++ b/scripts/meta-shadow-soak-core.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the PURE goal-selection/formatting core of the MetaOrchestrator
+ * shadow-training soak (#4310). Fixture-based only — no `gh`, no live model
+ * calls, no network. Mirrors mine-pr-review-candidates-core.test.ts's split
+ * (fixtures in, deterministic assertions out).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SOAK_GOAL_COUNT,
+  extractFirstParagraph,
+  formatGoal,
+  selectSoakGoals,
+  type BacklogIssue,
+} from './meta-shadow-soak-core.js';
+
+function issue(over: Partial<BacklogIssue> & { number: number }): BacklogIssue {
+  return {
+    title: `Issue ${String(over.number)}`,
+    body: 'Some body text.',
+    ...over,
+  };
+}
+
+describe('extractFirstParagraph', () => {
+  it('returns the empty string for an empty/whitespace-only body', () => {
+    expect(extractFirstParagraph('')).toBe('');
+    expect(extractFirstParagraph('   \n\n  ')).toBe('');
+  });
+
+  it('takes only the first paragraph, dropping later ones', () => {
+    const body = 'First paragraph line one.\n\nSecond paragraph should be dropped.';
+    expect(extractFirstParagraph(body)).toBe('First paragraph line one.');
+  });
+
+  it('collapses internal newlines/whitespace within the first paragraph', () => {
+    const body = 'Line one\nline two   line three.\n\nDropped.';
+    expect(extractFirstParagraph(body)).toBe('Line one line two line three.');
+  });
+
+  it('normalizes CRLF line endings', () => {
+    const body = 'First.\r\n\r\nSecond dropped.';
+    expect(extractFirstParagraph(body)).toBe('First.');
+  });
+
+  it('truncates an oversized paragraph with an ellipsis', () => {
+    const long = 'x'.repeat(600);
+    const result = extractFirstParagraph(long);
+    expect(result.length).toBe(501); // 500 chars + ellipsis
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.startsWith('x'.repeat(500))).toBe(true);
+  });
+
+  it('does not truncate a paragraph at exactly the cap', () => {
+    const exact = 'x'.repeat(500);
+    expect(extractFirstParagraph(exact)).toBe(exact);
+  });
+});
+
+describe('formatGoal', () => {
+  it('formats issue number + title + first paragraph', () => {
+    const result = formatGoal(
+      issue({ number: 42, title: 'Fix the widget', body: 'Widgets break under load.' })
+    );
+    expect(result).toBe('#42: Fix the widget\n\nWidgets break under load.');
+  });
+
+  it('omits the blank-line paragraph section when the body is empty', () => {
+    const result = formatGoal(issue({ number: 7, title: 'No body here', body: '' }));
+    expect(result).toBe('#7: No body here');
+  });
+
+  it('trims whitespace from the title', () => {
+    const result = formatGoal(issue({ number: 1, title: '  Padded title  ', body: '' }));
+    expect(result).toBe('#1: Padded title');
+  });
+});
+
+describe('selectSoakGoals', () => {
+  it('is deterministic: same input (any order) yields the same output', () => {
+    const issues: BacklogIssue[] = [
+      issue({ number: 10 }),
+      issue({ number: 30 }),
+      issue({ number: 20 }),
+    ];
+    const shuffled: BacklogIssue[] = [issues[1]!, issues[2]!, issues[0]!];
+
+    const a = selectSoakGoals(issues, 10);
+    const b = selectSoakGoals(shuffled, 10);
+
+    expect(a.map((g) => g.issueNumber)).toEqual([30, 20, 10]);
+    expect(b.map((g) => g.issueNumber)).toEqual([30, 20, 10]);
+  });
+
+  it('selects most-recent-first by issue number descending', () => {
+    const issues = [issue({ number: 1 }), issue({ number: 100 }), issue({ number: 50 })];
+    const result = selectSoakGoals(issues, 3);
+    expect(result.map((g) => g.issueNumber)).toEqual([100, 50, 1]);
+  });
+
+  it('bounds the selection to the requested limit', () => {
+    const issues = Array.from({ length: 20 }, (_, i) => issue({ number: i + 1 }));
+    const result = selectSoakGoals(issues, 5);
+    expect(result).toHaveLength(5);
+    expect(result.map((g) => g.issueNumber)).toEqual([20, 19, 18, 17, 16]);
+  });
+
+  it('defaults the limit to DEFAULT_SOAK_GOAL_COUNT', () => {
+    const issues = Array.from({ length: 20 }, (_, i) => issue({ number: i + 1 }));
+    const result = selectSoakGoals(issues);
+    expect(result).toHaveLength(DEFAULT_SOAK_GOAL_COUNT);
+  });
+
+  it('dedupes by issue number, keeping the first occurrence', () => {
+    const issues = [
+      issue({ number: 5, title: 'first copy' }),
+      issue({ number: 5, title: 'second copy (should be dropped)' }),
+      issue({ number: 6 }),
+    ];
+    const result = selectSoakGoals(issues, 10);
+    expect(result).toHaveLength(2);
+    expect(result.find((g) => g.issueNumber === 5)?.title).toBe('first copy');
+  });
+
+  it('returns an empty array for a non-positive limit', () => {
+    const issues = [issue({ number: 1 }), issue({ number: 2 })];
+    expect(selectSoakGoals(issues, 0)).toEqual([]);
+    expect(selectSoakGoals(issues, -5)).toEqual([]);
+  });
+
+  it('returns an empty array for an empty issue list', () => {
+    expect(selectSoakGoals([], 12)).toEqual([]);
+  });
+
+  it('each selected goal carries provenance (issueNumber, title) plus the formatted goal string', () => {
+    const result = selectSoakGoals(
+      [issue({ number: 9, title: 'Provenance check', body: 'Body text.' })],
+      1
+    );
+    expect(result).toEqual([
+      {
+        issueNumber: 9,
+        title: 'Provenance check',
+        goal: '#9: Provenance check\n\nBody text.',
+      },
+    ]);
+  });
+});

--- a/scripts/meta-shadow-soak-core.ts
+++ b/scripts/meta-shadow-soak-core.ts
@@ -1,0 +1,111 @@
+/**
+ * meta-shadow-soak-core.ts — PURE goal-selection/formatting logic for the
+ * MetaOrchestrator shadow-training soak (#4310, feeder for #3552).
+ *
+ * The shadow-training MECHANISM already works: `NEXUS_META_SHADOW_TRAIN=1`
+ * makes `executeGoal` (packages/nexus-agents/src/mcp/tools/run-tool.ts) feed
+ * every live `run` dispatch outcome into the MetaOrchestrator shadow selector
+ * and persist a sanitized record to `learning/meta-outcomes.jsonl` (#3593).
+ * Nothing ever TRIGGERS it, though — training only fires on a live `run
+ * {execute:true}` call, and no CI/cron/CLI ever makes one. This module is the
+ * TESTABLE half of the trigger: given an already-fetched list of backlog
+ * issues, deterministically select a bounded set and format each into a goal
+ * string. It contains ZERO I/O — the `gh issue list` shelling-out and the live
+ * `executeGoal` calls live in the thin edge script (meta-shadow-soak.ts), like
+ * the curate-pr-review-harvest.ts / mine-pr-review-candidates-core.ts split
+ * (#3847).
+ *
+ * Sourcing REAL backlog goals (not synthetic) is a ratified decision for
+ * #4310: synthetic goals would exercise the router on distributions that
+ * don't resemble what `run` actually sees in production, undermining the
+ * shadow-agreement evidence the #3552 flip decision depends on.
+ *
+ * @module scripts/meta-shadow-soak-core
+ * (Source: Issue #4310, feeder for #3552)
+ */
+
+/** Default number of backlog goals one soak run drives through `executeGoal`. */
+export const DEFAULT_SOAK_GOAL_COUNT = 12;
+
+/** Cap on the formatted goal-body paragraph so a runaway issue body can't blow up prompt size. */
+const MAX_PARAGRAPH_CHARS = 500;
+
+/**
+ * The minimal shape of a `gh issue list --json number,title,body` entry this
+ * module consumes. Deliberately narrow — the gh-fetch edge may return more
+ * fields, but only these three are objective, real backlog signal.
+ */
+export interface BacklogIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+}
+
+/** One selected + formatted soak goal, ready to hand to `executeGoal`. */
+export interface SoakGoal {
+  /** Source issue number — provenance, and the dedup key. */
+  readonly issueNumber: number;
+  /** Source issue title, unformatted. */
+  readonly title: string;
+  /** The natural-language goal string passed to `executeGoal({ goal })`. */
+  readonly goal: string;
+}
+
+/**
+ * Extracts the first non-empty paragraph from a (markdown) issue body, with
+ * internal whitespace/newlines collapsed to single spaces and a length cap
+ * (truncated with an ellipsis) so one oversized issue body can't dominate the
+ * goal string. Empty/whitespace-only input returns `''`.
+ */
+export function extractFirstParagraph(body: string): string {
+  const normalized = body.replace(/\r\n/g, '\n').trim();
+  if (normalized.length === 0) return '';
+  const firstBlock = normalized.split(/\n\s*\n/)[0] ?? '';
+  const collapsed = firstBlock.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= MAX_PARAGRAPH_CHARS) return collapsed;
+  return `${collapsed.slice(0, MAX_PARAGRAPH_CHARS).trimEnd()}…`;
+}
+
+/**
+ * Formats one backlog issue into a natural-language goal string: `#<number>:
+ * <title>` plus the first body paragraph (when present) on a blank line
+ * after, mirroring how a human would paste an issue into `run`.
+ */
+export function formatGoal(issue: BacklogIssue): string {
+  const title = issue.title.trim();
+  const header = `#${String(issue.number)}: ${title}`;
+  const paragraph = extractFirstParagraph(issue.body);
+  return paragraph.length > 0 ? `${header}\n\n${paragraph}` : header;
+}
+
+/**
+ * Deterministically selects up to `limit` backlog issues and formats each
+ * into a {@link SoakGoal}. Deterministic in two ways, so the same input list
+ * always yields the same output regardless of the order `gh` happened to
+ * return it in:
+ *   1. Dedupes by issue number (first occurrence wins).
+ *   2. Stable-sorts most-recent-first by issue number descending — issue
+ *      numbers are monotonically assigned, so this is a reproducible proxy
+ *      for "most recently filed" without depending on wall-clock `Date.now()`
+ *      or a `createdAt` timestamp the caller may not have fetched.
+ *
+ * `limit <= 0` returns an empty array.
+ */
+export function selectSoakGoals(
+  issues: readonly BacklogIssue[],
+  limit: number = DEFAULT_SOAK_GOAL_COUNT
+): SoakGoal[] {
+  const seen = new Set<number>();
+  const deduped: BacklogIssue[] = [];
+  for (const issue of issues) {
+    if (seen.has(issue.number)) continue;
+    seen.add(issue.number);
+    deduped.push(issue);
+  }
+  const sorted = [...deduped].sort((a, b) => b.number - a.number);
+  return sorted.slice(0, Math.max(0, limit)).map((issue): SoakGoal => ({
+    issueNumber: issue.number,
+    title: issue.title,
+    goal: formatGoal(issue),
+  }));
+}

--- a/scripts/meta-shadow-soak.ts
+++ b/scripts/meta-shadow-soak.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env npx tsx
+/**
+ * meta-shadow-soak.ts — the gh-fetch + live-execution TRIGGER for the
+ * MetaOrchestrator shadow-training soak (#4310, feeder for #3552).
+ *
+ * The shadow-training MECHANISM already works: with `NEXUS_META_SHADOW_TRAIN=1`,
+ * `executeGoal` (packages/nexus-agents/src/mcp/tools/run-tool.ts) feeds every
+ * live `run` dispatch outcome into the MetaOrchestrator shadow selector and
+ * appends a sanitized record — feature values + success only, never task text
+ * (#3593) — to `<NEXUS_DATA_DIR>/learning/meta-outcomes.jsonl`. Nothing ever
+ * TRIGGERED it, though: training only fires on a live `run {execute:true}`
+ * call, and no CI/cron/CLI ever made one, so the evidence #3552's shadow→route
+ * flip decision needs could not accumulate. This script is that trigger,
+ * mirroring the #4224 remediation-audit-soak precedent.
+ *
+ * It sources REAL backlog issues via `gh` (ratified decision for #4310 —
+ * synthetic goals would not resemble the goal distribution `run` actually sees
+ * in production) and drives each through `executeGoal` with shadow training
+ * enabled. Goal selection/formatting is PURE and unit-tested in
+ * meta-shadow-soak-core.ts; this file is the thin, untested-by-unit I/O edge
+ * (like curate-pr-review-harvest.ts / mine-pr-review-candidates-core.ts, #3847)
+ * — the `gh` shelling-out AND the live `executeGoal` dispatch (which needs real
+ * model-gateway credentials this script does not provide) both live here.
+ *
+ * SAFETY (feeder only, never wired to routing):
+ *   - This ONLY ever sets `NEXUS_META_SHADOW_TRAIN=1`. That env var feeds the
+ *     SHADOW selector and the offline eval surface — it never alters which
+ *     strategy `run` actually dispatches (see `isShadowTrainEnabled` /
+ *     `buildShadowTrainObserver` in run-tool.ts). The #3552 shadow→route flip
+ *     stays a separate, human-gated change; this script cannot enable it.
+ *   - No `simulateVotes` / mock outcomes — every goal is dispatched through the
+ *     REAL `executeGoal` path, so accrued shadow-training evidence reflects
+ *     genuine dispatch outcomes, not synthetic ones.
+ *
+ * Usage (local, on-demand — see docs/getting-started/CONFIGURATION.md):
+ *   NEXUS_META_SHADOW_TRAIN=1 npx tsx scripts/meta-shadow-soak.ts [--count N] [--repo OWNER/NAME]
+ *
+ * Requires: `gh` authenticated against the target repo, and model-gateway
+ * credentials for whichever strategies the router selects (dev-pipeline /
+ * pipeline / research / consensus are wired executors; others fail closed and
+ * still accrue a FAILURE shadow-training record — see meta-dispatcher.ts,
+ * which records an outcome even for a `no_executor` dispatch).
+ *
+ * @module scripts/meta-shadow-soak
+ * (Source: Issue #4310, feeder for #3552; precedent #4224)
+ */
+
+/* eslint-disable no-console -- CLI script that prints progress */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync, statSync, readFileSync } from 'node:fs';
+import {
+  DEFAULT_SOAK_GOAL_COUNT,
+  selectSoakGoals,
+  type BacklogIssue,
+  type SoakGoal,
+} from './meta-shadow-soak-core.js';
+import {
+  executeGoal,
+  isShadowTrainEnabled,
+} from '../packages/nexus-agents/src/mcp/tools/run-tool.js';
+import { getMetaOutcomesFile } from '../packages/nexus-agents/src/config/learning-persistence.js';
+import { getErrorMessage } from '../packages/nexus-agents/src/core/index.js';
+import { CLI_SUBPROCESS_TIMEOUTS } from '../packages/nexus-agents/src/config/timeouts.js';
+
+const execFileP = promisify(execFile);
+
+const DEFAULT_REPO = 'nexus-substrate/nexus-agents';
+/** Fetch a wider page than the selection count so a stable sort has real headroom. */
+const FETCH_MULTIPLIER = 3;
+
+// ============================================================================
+// gh fetch (the only I/O besides executeGoal)
+// ============================================================================
+
+/** Raw shape of one `gh issue list --json number,title,body` entry. */
+interface RawIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string | null;
+}
+
+/** Fetches open issues from `repo` via `gh`. Throws on `gh` failure. */
+async function fetchBacklogIssues(repo: string, limit: number): Promise<BacklogIssue[]> {
+  const { stdout } = await execFileP(
+    'gh',
+    [
+      'issue',
+      'list',
+      '--repo',
+      repo,
+      '--state',
+      'open',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,body',
+    ],
+    { timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs, maxBuffer: 16 * 1024 * 1024 }
+  );
+  const raw = JSON.parse(stdout) as readonly RawIssue[];
+  return raw.map((i) => ({ number: i.number, title: i.title, body: i.body ?? '' }));
+}
+
+// ============================================================================
+// Soak run
+// ============================================================================
+
+interface GoalRunResult {
+  readonly issueNumber: number;
+  readonly ok: boolean;
+  readonly strategy?: string;
+  readonly error?: string;
+}
+
+/** Line count of a JSONL file, or 0 when it does not exist yet. */
+function jsonlLineCount(path: string): number {
+  if (!existsSync(path)) return 0;
+  const text = readFileSync(path, 'utf-8');
+  return text.split('\n').filter((l) => l.trim().length > 0).length;
+}
+
+/** Byte size of a file, or 0 when it does not exist. */
+function fileSize(path: string): number {
+  if (!existsSync(path)) return 0;
+  return statSync(path).size;
+}
+
+/**
+ * Drives one {@link SoakGoal} through the REAL `executeGoal` path. Never
+ * throws — a dispatch failure (including `no_executor` for an unwired
+ * strategy) still accrues a shadow-training record via the dispatcher's
+ * outcome observer (see meta-dispatcher.ts `recordOutcome`), so it is reported
+ * as a completed (if failed) goal run, not aborted.
+ */
+async function runOneGoal(goal: SoakGoal): Promise<GoalRunResult> {
+  try {
+    const result = await executeGoal({ goal: goal.goal, execute: true });
+    return { issueNumber: goal.issueNumber, ok: true, strategy: result.strategy };
+  } catch (err) {
+    return { issueNumber: goal.issueNumber, ok: false, error: getErrorMessage(err) };
+  }
+}
+
+interface SoakOptions {
+  readonly repo: string;
+  readonly count: number;
+}
+
+function parseArgs(argv: readonly string[]): SoakOptions {
+  let repo = DEFAULT_REPO;
+  let count = DEFAULT_SOAK_GOAL_COUNT;
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === '--repo' && value !== undefined) {
+      repo = value;
+      i++;
+    } else if (flag === '--count' && value !== undefined) {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed) && parsed > 0) count = parsed;
+      i++;
+    }
+  }
+  return { repo, count };
+}
+
+async function runSoak(options: SoakOptions): Promise<void> {
+  if (!isShadowTrainEnabled()) {
+    console.error(
+      '::error::NEXUS_META_SHADOW_TRAIN=1 is not set (or learning persistence is disabled). ' +
+        'This soak is a no-op without it — see docs/getting-started/CONFIGURATION.md.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const outcomesFile = getMetaOutcomesFile();
+  const before = jsonlLineCount(outcomesFile);
+
+  console.log(`Fetching backlog issues from ${options.repo} …`);
+  const issues = await fetchBacklogIssues(options.repo, options.count * FETCH_MULTIPLIER);
+  const goals = selectSoakGoals(issues, options.count);
+  console.log(
+    `Selected ${String(goals.length)} real backlog goals (of ${String(issues.length)} fetched).`
+  );
+
+  const results: GoalRunResult[] = [];
+  for (const goal of goals) {
+    console.log(`  → #${String(goal.issueNumber)}: ${goal.title}`);
+    // Serial (not Promise.all): shadow-training records accrue in a stable,
+    // reviewable order and per-goal model-gateway load stays bounded.
+    const result = await runOneGoal(goal);
+    results.push(result);
+    console.log(
+      result.ok
+        ? `    ok — strategy=${String(result.strategy)}`
+        : `    failed (still records a shadow-training outcome) — ${String(result.error)}`
+    );
+  }
+
+  const after = jsonlLineCount(outcomesFile);
+  const succeeded = results.filter((r) => r.ok).length;
+
+  console.log('');
+  console.log('=== meta-shadow-soak summary (#4310) ===');
+  console.log(
+    `Goals run:        ${String(results.length)} (${String(succeeded)} succeeded, ${String(results.length - succeeded)} failed/no-executor)`
+  );
+  console.log(
+    `Shadow records:   ${String(before)} -> ${String(after)} (+${String(after - before)})`
+  );
+  console.log(
+    `meta-outcomes.jsonl size: ${String(fileSize(outcomesFile))} bytes (${outcomesFile})`
+  );
+}
+
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  await runSoak(parseArgs(process.argv.slice(2)));
+}
+
+export { fetchBacklogIssues, runOneGoal, runSoak, parseArgs, jsonlLineCount, fileSize };


### PR DESCRIPTION
## Summary

Feeder for #3552. The MetaOrchestrator shadow-training **mechanism** already worked (`NEXUS_META_SHADOW_TRAIN=1` makes `executeGoal` persist sanitized bandit outcomes to `learning/meta-outcomes.jsonl`, #3593) — but nothing ever **triggered** it: training only fires on a live `run{execute:true}` call, and no CI/cron/CLI ever made one, so the shadow-agreement evidence #3552's shadow→route flip decision depends on could not accumulate.

This PR adds the trigger, mirroring the #4224 remediation-audit-soak precedent:

- `scripts/meta-shadow-soak-core.ts` — **pure**, fully unit-tested goal selection/formatting (dedup, deterministic most-recent-first sort by issue number, first-paragraph extraction with a length cap).
- `scripts/meta-shadow-soak.ts` — thin `gh issue list` fetch + live `executeGoal` dispatch edge (untested by unit, like `curate-pr-review-harvest.ts` / `mine-pr-review-candidates-core.ts`, #3847). Sources **REAL** backlog issues (ratified decision — synthetic goals would not resemble the goal distribution `run` sees in production), drives each through the router with shadow training enabled, prints a summary (goals run, `meta-outcomes.jsonl` record count before/after, file size).
- `.github/workflows/meta-shadow-soak.yml` — `workflow_dispatch` only (see "secret-gating & no cron" below), concurrency-serialized, `NEXUS_DATA_DIR` under the workspace, accumulating `actions/cache` (rolling `run_id` key + prefix restore-keys, same shape as #4224), an explicit mode-assert step.
- `docs/getting-started/CONFIGURATION.md` — new "On-demand MetaOrchestrator shadow-training soak (#4310)" section documenting the local run command, mirroring the #4224 doc section.
- `.changeset/meta-shadow-training-soak-4310.md` — **empty** changeset (workflow + scripts + docs only, no `packages/nexus-agents/src` change — same convention as #4224's `scheduled-audit-soak-4224.md`; `check-changeset.ts` confirms no shippable source changed).

## Feeder-only safety (never wired to routing)

- The workflow, the script, and the docs each assert/state the same invariant: `NEXUS_META_SHADOW_TRAIN=1` is the **only** lever pulled. It feeds the shadow selector + `meta-outcomes.jsonl` only — it never alters which strategy `run` actually dispatches. The #3552 shadow→route flip stays a separate, human-gated change; nothing here can enable it.
- No `simulateVotes` / mock outcomes anywhere — every goal is dispatched through the real `executeGoal` path, so accrued evidence reflects genuine dispatch outcomes. A goal that routes to an unwired strategy (`graph-workflow` / `spec` / `orchestrate` / `single-shot`) still accrues a **failure** shadow-training record (the dispatcher records an outcome even for a `no_executor` dispatch), so it isn't wasted soak volume either.

## Secret-gating (why no `schedule:` trigger)

Unlike #4224's audit-mode cycle (zero LLM cost without credentials — `createAutoAdapter` throws before any network call), this soak dispatches **real** strategies (dev-pipeline / pipeline / research / consensus) through real model gateways when credentials are present. A recurring cron would recur real API cost with no CI-cost mandate to justify it, so this workflow is `workflow_dispatch`-only. A `check-secrets` step inspects `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_AI_API_KEY` / `OPENROUTER_API_KEY` (same set `pr-review.yml` checks); every downstream step is conditioned on at least one being present, and the job reports "skipped" in the step summary and exits **green** (not failed) when none is configured.

## Local on-demand run command

```bash
NEXUS_META_SHADOW_TRAIN=1 npx tsx scripts/meta-shadow-soak.ts --count 12 --repo nexus-substrate/nexus-agents
```

Requires `gh` authenticated against the target repo and model-gateway credentials for whichever strategies the router selects.

## Stub vs. live

- **Unit-tested (stub/fixture-based):** `meta-shadow-soak-core.ts` — `extractFirstParagraph`, `formatGoal`, `selectSoakGoals` — 17 tests against fixture issue lists, no network, no live models. Verified red→green (temporarily stubbed the implementations to `throw`, confirmed all 17 tests failed, then restored the real implementation and confirmed all pass).
- **Real I/O, not covered by unit tests (by design — no model auth in CI/this worktree):** `meta-shadow-soak.ts`'s `gh issue list` fetch and the `executeGoal` dispatch. Manually smoke-tested locally against this environment's `gh` auth + model credentials with `--count 1`: fetched real issues, dispatched through the real router (landed on `pipeline`), and a correctly-shaped record was appended to `meta-outcomes.jsonl` end-to-end.

## Gates run

- `pnpm --filter nexus-agents typecheck` — clean.
- `pnpm --filter nexus-agents test -- run-tool meta-shadow-selector` — 51 passing, no regressions.
- `pnpm --filter nexus-agents lint` — clean.
- `pnpm test:scripts` (root, covers `scripts/**/*.test.ts` incl. the new core tests) — 449 passing, 32 files.
- `npx tsc --noEmit -p tsconfig.json` (root) — no errors in the new files (pre-existing unrelated errors elsewhere in `scripts/`/`website` are untouched by this change and not gated by CI today).
- `npx tsx scripts/generate-repo-index.ts --check` — up to date (no new CLI command/MCP tool/workflow-template registered by this change).
- `npx tsx scripts/check-mcp-description-drift.ts` — passes (47 tools, unchanged).
- `npx markdownlint` / `npx cspell` on the touched docs file — clean.
- `npx tsx scripts/check-changeset.ts` — confirms the empty changeset is correct (no shippable source changed).

**Do NOT merge** — vote-gated per repo convention.
