### PR TITLE
feat(eval): add v6 pr_review eval batch runner (#4311)

### DIFF
--- a/.changeset/eval-run-v6-harness.md
+++ b/.changeset/eval-run-v6-harness.md
@@ -1,0 +1,7 @@
+---
+'nexus-agents': minor
+---
+
+feat(eval): add the v6 pr_review eval batch runner (#4311, epic #3845; unblocks #3849)
+
+Adds `scripts/pr-review-eval-run.ts` (+ pure core `scripts/pr-review-eval-run-core.ts`), the previously-missing connective harness that feeds the rubric-adjudicated corpus (`testing/datasets/pr-review-sample.json`, n=19) through the live 5-voter `pr_review` panel, applies rubric Rule 2 location-tolerance matching, scores each voter's verdict against the case's gold `class`/`knownBugs` via the existing #3848 scorer (`scoreVoterCase` / `computePerVoterPrecisionRecall`), appends verdicts to the `PrReviewEvalStore`, and regenerates `docs/research/pr-review-experiment-results-v6.md`. New `eval:run` npm script. The panel invocation is injectable (`PanelRunner`); the plumbing (corpus load → diff resolution → scoring → aggregation → doc/store write) is unit-tested with a deterministic stub panel — no live model calls in CI. The live v6 pass (real LLM calls, needs model auth) is run on-demand via `npm run eval:run`.

--- a/.changeset/eval-run-v6-harness.md
+++ b/.changeset/eval-run-v6-harness.md
@@ -1,7 +1,4 @@
 ---
-'nexus-agents': minor
 ---
 
-feat(eval): add the v6 pr_review eval batch runner (#4311, epic #3845; unblocks #3849)
-
-Adds `scripts/pr-review-eval-run.ts` (+ pure core `scripts/pr-review-eval-run-core.ts`), the previously-missing connective harness that feeds the rubric-adjudicated corpus (`testing/datasets/pr-review-sample.json`, n=19) through the live 5-voter `pr_review` panel, applies rubric Rule 2 location-tolerance matching, scores each voter's verdict against the case's gold `class`/`knownBugs` via the existing #3848 scorer (`scoreVoterCase` / `computePerVoterPrecisionRecall`), appends verdicts to the `PrReviewEvalStore`, and regenerates `docs/research/pr-review-experiment-results-v6.md`. New `eval:run` npm script. The panel invocation is injectable (`PanelRunner`); the plumbing (corpus load → diff resolution → scoring → aggregation → doc/store write) is unit-tested with a deterministic stub panel — no live model calls in CI. The live v6 pass (real LLM calls, needs model auth) is run on-demand via `npm run eval:run`.
+dev-tooling only (#4311): adds the v6 pr_review eval batch runner as a root `scripts/` harness (`scripts/pr-review-eval-run.ts` + `pr-review-eval-run-core.ts`) plus a research doc. Nothing under `packages/nexus-agents/**` changed and the published package's `files` field does not include root `scripts/`, so no release is warranted.

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,13 +158,14 @@ Nothing ships without passing a gate. Adversarial PR review, multi-voter consens
 
 **Evidence (gate evaluations):**
 
-| Document                                                                            | Description                                                             | Status    |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------- |
-| [pr-review-experiment-results.md](./research/pr-review-experiment-results.md)       | pr_review #2233 baseline experiment results                             | Canonical |
-| [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug | Canonical |
-| [pr-review-eval-labeling-rubric.md](./research/pr-review-eval-labeling-rubric.md)   | pr_review eval labeling rubric v1 + v5 re-adjudication (#3846)          | Canonical |
-| [pr-review-dataset-curation.md](./research/pr-review-dataset-curation.md)           | pr_review eval dataset curation pipeline + n≥50 assessment (#3847)      | Canonical |
-| [pr-review-eval-curation.md](./research/pr-review-eval-curation.md)                 | pr_review eval candidate-mining curation pipeline (#3847)               | Canonical |
+| Document                                                                            | Description                                                                                    | Status    |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------- |
+| [pr-review-experiment-results.md](./research/pr-review-experiment-results.md)       | pr_review #2233 baseline experiment results                                                    | Canonical |
+| [pr-review-experiment-results-v5.md](./research/pr-review-experiment-results-v5.md) | pr_review v5 — JSON-native findings; 100% bug-catch + caught a real bug                        | Canonical |
+| [pr-review-experiment-results-v6.md](./research/pr-review-experiment-results-v6.md) | pr_review v6 eval batch runner (#4311) — results doc is a PENDING placeholder until a live run | Canonical |
+| [pr-review-eval-labeling-rubric.md](./research/pr-review-eval-labeling-rubric.md)   | pr_review eval labeling rubric v1 + v5 re-adjudication (#3846)                                 | Canonical |
+| [pr-review-dataset-curation.md](./research/pr-review-dataset-curation.md)           | pr_review eval dataset curation pipeline + n≥50 assessment (#3847)                             | Canonical |
+| [pr-review-eval-curation.md](./research/pr-review-eval-curation.md)                 | pr_review eval candidate-mining curation pipeline (#3847)                                      | Canonical |
 
 ---
 

--- a/docs/research/pr-review-experiment-results-v6.md
+++ b/docs/research/pr-review-experiment-results-v6.md
@@ -1,0 +1,63 @@
+---
+title: pr_review experiment v6 — per-voter precision/recall from the eval batch harness
+description: Placeholder for the v6 batch run of the pr_review panel against the rubric-adjudicated corpus (#3846/#3847), scored per-voter via the #3848 scorer. Populated by scripts/pr-review-eval-run.ts (#4311, epic #3845, unblocks #3849) once a live pass is run.
+tier: 2
+keywords: [pr-review, eval, v6, precision, recall, autonomous-sdlc]
+---
+
+# pr_review experiment v6 — per-voter precision/recall from the eval batch harness
+
+**Status: PENDING — no live run has been executed against this doc yet.**
+
+## Why this doc is a placeholder
+
+This issue (#4311, epic #3845; unblocks #3849) builds the missing **harness** —
+`scripts/pr-review-eval-run.ts` — that feeds the rubric-adjudicated corpus
+(`testing/datasets/pr-review-sample.json`, n=19; #3846/#3847) through the live
+5-voter `pr_review` panel and scores each voter's verdict against ground truth
+via the #3848 scorer (`scoreVoterCase` / `computePerVoterPrecisionRecall`).
+
+The harness itself is fully built and unit-tested with a **deterministic stub
+panel** (`scripts/pr-review-eval-run-core.test.ts`,
+`scripts/pr-review-eval-run.test.ts`) — the corpus load, rubric Rule 2
+location-tolerance matching, per-voter scoring, aggregation, store append, and
+doc-rendering plumbing are all verified without touching a model. Per the
+task's non-negotiable constraint, no `simulateVotes` output or stub-panel
+result is presented here as real evidence, and no live model calls happen in
+CI or in this package's automated test suite.
+
+**The actual v6 numbers require a live pass**, which needs model auth (a CLI
+adapter — `claude`/`gemini`/`codex` — or `ANTHROPIC_API_KEY`) that this build
+environment does not have. Running it is explicitly out of scope for this PR;
+see [#3849](https://github.com/nexus-substrate/nexus-agents/issues/3849) for
+the tracked follow-up that consumes these numbers (a voter promotion
+criterion) once they exist.
+
+## How to run the live v6 pass
+
+```bash
+npm run eval:run
+# or: npx tsx scripts/pr-review-eval-run.ts
+```
+
+This runs the LIVE 5-voter `pr_review` panel — 5 LLM calls per case (19 cases
+in the current corpus, ~95 calls total) — against every case in
+`testing/datasets/pr-review-sample.json`. For synthetic cases it reviews the
+stored `customDiff` directly; for the three real-PR cases with no stored diff
+(#2228, #2235, #2238) it fetches the diff live via `gh`. Results are:
+
+- appended to the #3848 JSONL eval store
+  (`~/.nexus-agents/learning/pr-review-eval.jsonl` by default,
+  `NEXUS_DATA_DIR`-relocatable), and
+- written to **this file**, replacing this placeholder with the real
+  per-voter precision/recall tables (see `renderResultsDoc` in
+  `scripts/pr-review-eval-run-core.ts` for the exact shape: a per-voter
+  TP/FP/FN/precision/recall table, a per-case verified-findings table, and the
+  reproduction command).
+
+> **Metric-honesty guardrail (#3903).** Once populated, n=19 is still a small
+> corpus — the resulting numbers must be reported as directional, not
+> statistically significant, the same guardrail that governs every prior
+> pr_review eval doc in this series
+> (`pr-review-experiment-results-v5.md`). Always carry the n and the class
+> split (buggy/clean/borderline) when citing any figure from this run.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "build:registry:dry": "npx tsx scripts/build-model-registry.ts --dry",
     "review": "npx tsx scripts/review-pr.ts",
     "eval:mine-candidates": "npx tsx scripts/mine-pr-review-candidates.ts",
+    "eval:run": "npx tsx scripts/pr-review-eval-run.ts",
     "link-check": "npx lychee --config lychee.toml .",
     "git:cleanup": "./scripts/git-housekeeping.sh",
     "git:cleanup:dry": "./scripts/git-housekeeping.sh --dry-run",

--- a/scripts/pr-review-eval-run-core.test.ts
+++ b/scripts/pr-review-eval-run-core.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for the pure v6 eval-run core (#4311, epic #3845; unblocks #3849).
+ *
+ * Covers the two load-bearing pure pieces:
+ * - {@link matchesKnownBug}: rubric Rule 2 location-tolerance matching.
+ * - {@link scoreCaseVoters}: per-case, per-voter verdict scoring (buggy catch,
+ *   clean false-positive, borderline exclusion, errored-voter exclusion).
+ * - {@link renderResultsDoc}: results-doc shape (frontmatter, per-voter table,
+ *   per-case table, reproduction command).
+ *
+ * Zero I/O, zero live model calls — a deterministic stub panel feeds every
+ * scenario (never `simulateVotes` standing in for a live run: this is
+ * explicitly test-only plumbing, not a pretend measurement).
+ *
+ * @module scripts/pr-review-eval-run-core.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  matchesKnownBug,
+  scoreCaseVoters,
+  renderResultsDoc,
+  type PanelFinding,
+  type PanelVoterOutcome,
+  type EvalCaseResult,
+} from './pr-review-eval-run-core.js';
+import { computePerVoterPrecisionRecall } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.js';
+import type { KnownBug } from './curate-pr-review-dataset-schema.js';
+
+const TS = '2026-07-17T00:00:00Z';
+
+function finding(over: Partial<PanelFinding>): PanelFinding {
+  return {
+    summary: 'issue',
+    location: 'packages/nexus-agents/src/foo.ts:100',
+    severity: 'medium',
+    verified: true,
+    ...over,
+  };
+}
+
+function bug(over: Partial<KnownBug>): KnownBug {
+  return {
+    summary: 'a known bug',
+    severity: 'medium',
+    location: 'packages/nexus-agents/src/foo.ts:100',
+    locationTolerance: 'line',
+    fixReference: 'synthetic',
+    ...over,
+  };
+}
+
+function outcome(over: Partial<PanelVoterOutcome>): PanelVoterOutcome {
+  return {
+    role: 'architect',
+    decision: 'approve',
+    findings: [],
+    source: 'llm',
+    ...over,
+  };
+}
+
+// ============================================================================
+// matchesKnownBug — rubric Rule 2
+// ============================================================================
+
+describe('matchesKnownBug (rubric Rule 2 location tolerance)', () => {
+  it('matches a line-tolerance bug when file matches and line is within ±5', () => {
+    const b = bug({ location: 'src/foo.ts:100', locationTolerance: 'line' });
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:104' }), b)).toBe(true);
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:95' }), b)).toBe(true);
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:100' }), b)).toBe(true);
+  });
+
+  it('does not match a line-tolerance bug when the line is more than ±5 away', () => {
+    const b = bug({ location: 'src/foo.ts:100', locationTolerance: 'line' });
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:106' }), b)).toBe(false);
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:1' }), b)).toBe(false);
+  });
+
+  it('does not match a line-tolerance bug on a different file', () => {
+    const b = bug({ location: 'src/foo.ts:100', locationTolerance: 'line' });
+    expect(matchesKnownBug(finding({ location: 'src/bar.ts:100' }), b)).toBe(false);
+  });
+
+  it('matches a structural-tolerance bug on file alone, regardless of line', () => {
+    const b = bug({ location: 'src/voter-execution.ts', locationTolerance: 'structural' });
+    expect(matchesKnownBug(finding({ location: 'src/voter-execution.ts:9999' }), b)).toBe(true);
+    expect(matchesKnownBug(finding({ location: 'src/voter-execution.ts' }), b)).toBe(true);
+  });
+
+  it('does not match a structural-tolerance bug on a different file', () => {
+    const b = bug({ location: 'src/voter-execution.ts', locationTolerance: 'structural' });
+    expect(matchesKnownBug(finding({ location: 'src/other.ts:1' }), b)).toBe(false);
+  });
+
+  it('tolerates repo-root-relative vs monorepo-relative path citations of the same file', () => {
+    const b = bug({
+      location: 'packages/nexus-agents/src/foo.ts:100',
+      locationTolerance: 'line',
+    });
+    expect(matchesKnownBug(finding({ location: 'src/foo.ts:100' }), b)).toBe(true);
+  });
+});
+
+// ============================================================================
+// scoreCaseVoters — per-case, per-voter scoring
+// ============================================================================
+
+describe('scoreCaseVoters (per-case, per-voter verdict scoring)', () => {
+  it('a buggy case: a verified finding matching the known bug scores as a true positive', () => {
+    const knownBugs = [bug({ location: 'src/foo.ts:100', locationTolerance: 'line' })];
+    const outcomes = [
+      outcome({
+        role: 'security',
+        decision: 'request_changes',
+        findings: [finding({ location: 'src/foo.ts:101', verified: true })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'synthetic-redos',
+        caseClass: 'buggy',
+        knownBugs,
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0]).toMatchObject({
+      role: 'security',
+      caseClass: 'buggy',
+      truePositives: 1,
+      falsePositives: 0,
+      falseNegatives: 0,
+    });
+  });
+
+  it('a buggy case: a voter with no matching verified finding scores a false negative', () => {
+    const knownBugs = [bug({ location: 'src/foo.ts:100', locationTolerance: 'line' })];
+    const outcomes = [outcome({ role: 'devex', decision: 'approve', findings: [] })];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'c',
+        caseClass: 'buggy',
+        knownBugs,
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts[0]).toMatchObject({ truePositives: 0, falseNegatives: 1, falsePositives: 0 });
+  });
+
+  it('a clean case: any verified finding is a strict false positive', () => {
+    const outcomes = [
+      outcome({
+        role: 'catfish',
+        decision: 'request_changes',
+        findings: [finding({ location: 'src/anything.ts:1', verified: true })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'synthetic-clean-docs',
+        caseClass: 'clean',
+        knownBugs: [],
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts[0]).toMatchObject({ truePositives: 0, falsePositives: 1, falseNegatives: 0 });
+  });
+
+  it('a clean case: an UNVERIFIED finding is not a false positive', () => {
+    const outcomes = [
+      outcome({
+        role: 'catfish',
+        decision: 'request_changes',
+        findings: [finding({ verified: false })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'c',
+        caseClass: 'clean',
+        knownBugs: [],
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts[0]).toMatchObject({ truePositives: 0, falsePositives: 0, falseNegatives: 0 });
+  });
+
+  it('a borderline case: verified findings are excluded from all numerators', () => {
+    const outcomes = [
+      outcome({
+        role: 'devex',
+        decision: 'request_changes',
+        findings: [finding({ verified: true })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'synthetic-clean-refactor',
+        caseClass: 'borderline',
+        knownBugs: [],
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts[0]).toMatchObject({ truePositives: 0, falsePositives: 0, falseNegatives: 0 });
+  });
+
+  it('excludes errored voters entirely (no verdict emitted for that role)', () => {
+    const knownBugs = [bug({})];
+    const outcomes = [
+      outcome({ role: 'architect', source: 'error', findings: [] }),
+      outcome({
+        role: 'security',
+        source: 'llm',
+        findings: [finding({ verified: true })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'c',
+        caseClass: 'buggy',
+        knownBugs,
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0]?.role).toBe('security');
+  });
+
+  it('multiple known bugs: only bugs with a matching verified finding count as TP, rest as FN', () => {
+    const knownBugs = [
+      bug({ location: 'src/a.ts:10', locationTolerance: 'line' }),
+      bug({ location: 'src/b.ts:20', locationTolerance: 'line' }),
+    ];
+    const outcomes = [
+      outcome({
+        role: 'architect',
+        findings: [finding({ location: 'src/a.ts:11', verified: true })],
+      }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'run-1',
+        caseNumber: 'c',
+        caseClass: 'buggy',
+        knownBugs,
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    expect(verdicts[0]).toMatchObject({ truePositives: 1, falseNegatives: 1 });
+  });
+
+  it('produces verdicts whose caseNumber/runId/id round-trip through the #3848 report', () => {
+    const knownBugs = [bug({})];
+    const outcomes = [
+      outcome({ role: 'architect', findings: [finding({ verified: true })] }),
+      outcome({ role: 'security', findings: [] }),
+    ];
+    const verdicts = scoreCaseVoters(
+      {
+        runId: 'v6-run',
+        caseNumber: 'synthetic-redos',
+        caseClass: 'buggy',
+        knownBugs,
+        rubricVersion: '1.0.0',
+        timestamp: TS,
+      },
+      outcomes
+    );
+    const report = computePerVoterPrecisionRecall(verdicts);
+    expect(report.byRole.architect.truePositives).toBe(1);
+    expect(report.byRole.security.falseNegatives).toBe(1);
+    expect(verdicts.every((v) => v.id.startsWith('v6-run:synthetic-redos:'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// renderResultsDoc — v6 doc shape
+// ============================================================================
+
+describe('renderResultsDoc (v6 results doc shape)', () => {
+  it('renders frontmatter, per-voter table, per-case table, and the reproduction command', () => {
+    const caseResults: EvalCaseResult[] = [
+      {
+        number: 'synthetic-redos',
+        class: 'buggy',
+        title: 'a buggy case',
+        outcomes: [outcome({ role: 'architect', findings: [finding({ verified: true })] })],
+        verdicts: [],
+      },
+      {
+        number: 'synthetic-clean-docs',
+        class: 'clean',
+        title: 'a clean case',
+        outcomes: [outcome({ role: 'architect', findings: [] })],
+        verdicts: [],
+      },
+    ];
+    const report = computePerVoterPrecisionRecall([]);
+    const doc = renderResultsDoc({
+      runId: 'v6-2026-07-17T00-00-00',
+      timestamp: TS,
+      dataset: { rubricVersion: '1.0.0' },
+      report,
+      caseResults,
+    });
+
+    expect(doc.startsWith('---\n')).toBe(true);
+    expect(doc).toContain('title: pr_review experiment v6');
+    expect(doc).toContain('#4311');
+    expect(doc).toContain('n=2: 1 buggy / 1 clean / 0 borderline');
+    expect(doc).toContain('| Role | TP | FP | FN | Precision | Recall | Cases |');
+    expect(doc).toContain('| architect |');
+    expect(doc).toContain('| security |');
+    expect(doc).toContain('| devex |');
+    expect(doc).toContain('| catfish |');
+    expect(doc).toContain('| scope_steward |');
+    expect(doc).toContain('| **aggregate** |');
+    expect(doc).toContain('| Case | Class | Verified findings (all voters) |');
+    expect(doc).toContain('| synthetic-redos | buggy | 1 |');
+    expect(doc).toContain('| synthetic-clean-docs | clean | 0 |');
+    expect(doc).toContain('npm run eval:run');
+    expect(doc).toContain('#3903');
+  });
+
+  it('is deterministic for identical input', () => {
+    const report = computePerVoterPrecisionRecall([]);
+    const params = {
+      runId: 'r',
+      timestamp: TS,
+      dataset: { rubricVersion: '1.0.0' },
+      report,
+      caseResults: [] as EvalCaseResult[],
+    };
+    expect(renderResultsDoc(params)).toBe(renderResultsDoc(params));
+  });
+});

--- a/scripts/pr-review-eval-run-core.ts
+++ b/scripts/pr-review-eval-run-core.ts
@@ -1,0 +1,342 @@
+/**
+ * pr-review-eval-run-core.ts — PURE scoring + doc-rendering core for the v6
+ * pr_review eval batch runner (#4311, epic #3845; unblocks #3849).
+ *
+ * The connective tissue this issue exists to build: feed the rubric-adjudicated
+ * corpus (`testing/datasets/pr-review-sample.json`, #3846/#3847) through the
+ * pr_review panel and the #3848 scorer to produce per-voter precision/recall.
+ * This module owns the two PURE pieces —
+ *
+ * - {@link matchesKnownBug}: rubric Rule 2 location-tolerance matching (a panel
+ *   finding vs one known bug — `±5` lines for `line`-tolerance bugs, same-file
+ *   for `structural`-tolerance bugs whose defect has no single line).
+ * - {@link scoreCaseVoters}: turn one case's per-voter panel outcomes into
+ *   {@link VoterEvalVerdict} records via the #3848 `scoreVoterCase`.
+ * - {@link renderResultsDoc}: render the v6 results markdown doc.
+ *
+ * ZERO I/O. The panel invocation (live LLM calls) and file/gh access live in the
+ * thin `pr-review-eval-run.ts` orchestrator, which injects a {@link PanelRunner}
+ * — this keeps the scoring/aggregation/doc-shape plumbing deterministically
+ * unit-testable with a stub panel (no model auth needed in CI).
+ *
+ * @module scripts/pr-review-eval-run-core
+ * (Source: #4311, epic #3845, unblocks #3849; scorer from #3848; rubric #3846)
+ */
+
+import { scoreVoterCase } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.js';
+import { PR_REVIEW_EVAL_ROLES } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-types.js';
+import type {
+  PrReviewCaseClass,
+  PrReviewEvalRole,
+  VoterEvalVerdict,
+  PerVoterPrecisionRecallReport,
+  VoterPrecisionRecall,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-types.js';
+import type { KnownBug, PrReviewDataset } from './curate-pr-review-dataset-schema.js';
+
+// ============================================================================
+// Panel output shapes — the injectable seam's contract (#4311)
+// ============================================================================
+
+/** One finding as the eval harness needs it — a trimmed, verification-resolved
+ * projection of `mcp/tools/pr-review-findings.ts`'s `Finding` (no raw gate
+ * detail; the harness only needs whether it passed the gate). */
+export interface PanelFinding {
+  readonly summary: string;
+  /** `path/file.ext:line` or `path/file.ext` (structural). */
+  readonly location: string;
+  readonly severity: 'critical' | 'high' | 'medium' | 'low';
+  /** Did all 4 verification-gate checks pass (`isFindingVerified`)? Only
+   * verified findings are scored — see rubric Rules 1-4. */
+  readonly verified: boolean;
+}
+
+/** One voter's outcome on one case, as the panel runner reports it. */
+export interface PanelVoterOutcome {
+  readonly role: PrReviewEvalRole;
+  readonly decision: 'approve' | 'request_changes' | 'abstain';
+  readonly findings: readonly PanelFinding[];
+  /** Mirrors `AgentVoteResult.source` — 'error' outcomes are excluded from
+   * scoring by {@link scoreCaseVoters} (a transport/auth failure is not a
+   * scored miss). */
+  readonly source: 'llm' | 'simulation' | 'error';
+}
+
+/** The input one case resolves to before it reaches the panel. */
+export interface EvalPanelInput {
+  readonly caseNumber: string;
+  readonly title: string;
+  readonly description: string;
+  readonly diff: string;
+}
+
+/** The injectable seam: production wires the live 5-voter pr_review panel;
+ * tests inject a deterministic stub. NEVER `simulateVotes` standing in for a
+ * live run — a stub used here is explicitly test-only plumbing, not a
+ * pretend measurement. */
+export type PanelRunner = (input: EvalPanelInput) => Promise<readonly PanelVoterOutcome[]>;
+
+// ============================================================================
+// Location-tolerance matching (rubric Rule 2)
+// ============================================================================
+
+interface ParsedLocation {
+  readonly file: string;
+  readonly line: number | undefined;
+}
+
+/** Splits a `path:line` or bare `path` citation into file + optional line. */
+function parseLocation(loc: string): ParsedLocation {
+  const trimmed = loc.trim();
+  const m = /^(.*):(\d+)$/.exec(trimmed);
+  if (m?.[1] !== undefined && m[2] !== undefined && m[1] !== '') {
+    return { file: m[1], line: Number(m[2]) };
+  }
+  return { file: trimmed, line: undefined };
+}
+
+/** Same file when the paths are equal or one is a path-suffix of the other —
+ * tolerates a voter citing a repo-root-relative path against a monorepo-
+ * relative (or vice versa) known-bug location. */
+function sameFile(a: string, b: string): boolean {
+  if (a === '' || b === '') return false;
+  if (a === b) return true;
+  return a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+}
+
+/**
+ * Rubric Rule 2 (`docs/research/pr-review-eval-labeling-rubric.md`): a panel
+ * finding MATCHES a known bug when both cite the same file, AND:
+ * - `locationTolerance: 'line'` — the finding's cited line is within ±5 lines
+ *   of the bug's line;
+ * - `locationTolerance: 'structural'` — matches on file alone; the defect (a
+ *   missing `Record` entry, a union-member gap) has no single line to compare,
+ *   so requiring a line match would score a real catch as a miss.
+ */
+export function matchesKnownBug(finding: PanelFinding, bug: KnownBug): boolean {
+  const findingLoc = parseLocation(finding.location);
+  const bugLoc = parseLocation(bug.location);
+  if (!sameFile(findingLoc.file, bugLoc.file)) return false;
+  if (bug.locationTolerance === 'structural') return true;
+  if (findingLoc.line === undefined || bugLoc.line === undefined) return false;
+  return Math.abs(findingLoc.line - bugLoc.line) <= 5;
+}
+
+// ============================================================================
+// Per-case, per-voter scoring
+// ============================================================================
+
+export interface ScoreCaseInput {
+  readonly runId: string;
+  readonly caseNumber: string;
+  readonly caseClass: PrReviewCaseClass;
+  readonly knownBugs: readonly KnownBug[];
+  readonly rubricVersion: string;
+  readonly timestamp: string;
+}
+
+/**
+ * Score every non-errored voter outcome for one eval case against its ground
+ * truth. Applies rubric Rule 2 matching ({@link matchesKnownBug}) to resolve
+ * `matchedBugCount` and `verifiedFindingCount`, then hands off to the pure
+ * #3848 {@link scoreVoterCase} for the TP/FP/FN tally.
+ *
+ * Errored voters (`source: 'error'`) are excluded entirely — an LLM/transport
+ * failure produces no verdict for that role on this case, rather than being
+ * scored as a full miss (which would unfairly inflate false negatives).
+ */
+export function scoreCaseVoters(
+  input: ScoreCaseInput,
+  outcomes: readonly PanelVoterOutcome[]
+): readonly VoterEvalVerdict[] {
+  const verdicts: VoterEvalVerdict[] = [];
+  for (const outcome of outcomes) {
+    if (outcome.source === 'error') continue;
+    const verifiedFindings = outcome.findings.filter((f) => f.verified);
+    const matchedBugCount = input.knownBugs.filter((bug) =>
+      verifiedFindings.some((f) => matchesKnownBug(f, bug))
+    ).length;
+    verdicts.push(
+      scoreVoterCase({
+        runId: input.runId,
+        caseNumber: input.caseNumber,
+        caseClass: input.caseClass,
+        role: outcome.role,
+        knownBugCount: input.knownBugs.length,
+        matchedBugCount,
+        verifiedFindingCount: verifiedFindings.length,
+        rubricVersion: input.rubricVersion,
+        timestamp: input.timestamp,
+      })
+    );
+  }
+  return verdicts;
+}
+
+// ============================================================================
+// Results doc rendering (markdown)
+// ============================================================================
+
+/** One case's outcomes + verdicts, folded for the results doc. */
+export interface EvalCaseResult {
+  readonly number: string;
+  readonly class: PrReviewCaseClass;
+  readonly title: string;
+  readonly outcomes: readonly PanelVoterOutcome[];
+  readonly verdicts: readonly VoterEvalVerdict[];
+}
+
+export interface RenderDocParams {
+  readonly runId: string;
+  readonly timestamp: string;
+  readonly dataset: Pick<PrReviewDataset, 'rubricVersion'>;
+  readonly report: PerVoterPrecisionRecallReport;
+  readonly caseResults: readonly EvalCaseResult[];
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function roleRow(role: PrReviewEvalRole, r: VoterPrecisionRecall): string {
+  return (
+    `| ${role} | ${String(r.truePositives)} | ${String(r.falsePositives)} | ` +
+    `${String(r.falseNegatives)} | ${pct(r.precision)} | ${pct(r.recall)} | ${String(r.caseCount)} |`
+  );
+}
+
+function caseRow(c: EvalCaseResult): string {
+  const verifiedCount = c.outcomes.reduce(
+    (n, o) => n + o.findings.filter((f) => f.verified).length,
+    0
+  );
+  return `| ${c.number} | ${c.class} | ${String(verifiedCount)} |`;
+}
+
+function renderFrontmatterAndTitle(): readonly string[] {
+  return [
+    '---',
+    'title: pr_review experiment v6 — per-voter precision/recall from the eval batch harness',
+    'description: Batch run of the pr_review panel against the rubric-adjudicated ' +
+      'corpus (#3846/#3847), scored per-voter via the #3848 scorer. Generated by ' +
+      'scripts/pr-review-eval-run.ts (#4311, epic #3845, unblocks #3849).',
+    'tier: 2',
+    'keywords: [pr-review, eval, v6, precision, recall, autonomous-sdlc]',
+    '---',
+    '',
+    '# pr_review experiment v6 — per-voter precision/recall from the eval batch harness',
+    '',
+  ];
+}
+
+interface HeaderCounts {
+  readonly n: number;
+  readonly buggyN: number;
+  readonly cleanN: number;
+  readonly borderlineN: number;
+}
+
+function renderHeader(
+  runId: string,
+  timestamp: string,
+  rubricVersion: string,
+  counts: HeaderCounts
+): readonly string[] {
+  return [
+    `**Run id:** \`${runId}\``,
+    '',
+    `**Generated:** ${timestamp}`,
+    '',
+    `**Dataset:** \`testing/datasets/pr-review-sample.json\` (rubricVersion ` +
+      `${rubricVersion}, n=${String(counts.n)}: ${String(counts.buggyN)} buggy / ` +
+      `${String(counts.cleanN)} clean / ${String(counts.borderlineN)} borderline)`,
+    '',
+    '**Harness:** `scripts/pr-review-eval-run.ts` (#4311, epic #3845; unblocks #3849) — ' +
+      'feeds the corpus through the live 5-voter pr_review panel and scores each voter ' +
+      'verdict against ground truth via the #3848 scorer (`scoreVoterCase` / ' +
+      '`computePerVoterPrecisionRecall`).',
+    '',
+    `> **Metric-honesty guardrail (#3903).** n=${String(counts.n)} remains a small corpus — ` +
+      'treat every figure below as directional, not statistically significant, the same ' +
+      'guardrail that governs every prior pr_review eval doc in this series ' +
+      '(`pr-review-experiment-results-v5.md`). Always carry the n and the class split ' +
+      'when citing any number from this run.',
+    '',
+  ];
+}
+
+function renderVoterTable(report: PerVoterPrecisionRecallReport): readonly string[] {
+  return [
+    '## Per-voter precision / recall',
+    '',
+    '| Role | TP | FP | FN | Precision | Recall | Cases |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+    ...PR_REVIEW_EVAL_ROLES.map((role) => roleRow(role, report.byRole[role])),
+    `| **aggregate** | ${String(report.aggregate.truePositives)} | ` +
+      `${String(report.aggregate.falsePositives)} | ${String(report.aggregate.falseNegatives)} | ` +
+      `${pct(report.aggregate.precision)} | ${pct(report.aggregate.recall)} | ` +
+      `${String(report.aggregate.caseCount)} |`,
+    '',
+    `Total verdicts recorded: ${String(report.totalVerdicts)}.`,
+    '',
+  ];
+}
+
+function renderCaseTable(caseResults: readonly EvalCaseResult[]): readonly string[] {
+  return [
+    '## Per-case results',
+    '',
+    '| Case | Class | Verified findings (all voters) |',
+    '| --- | --- | --- |',
+    ...caseResults.map(caseRow),
+    '',
+  ];
+}
+
+function renderReproSection(n: number): readonly string[] {
+  return [
+    '## How to reproduce / run live',
+    '',
+    '```bash',
+    'npm run eval:run',
+    '# or: npx tsx scripts/pr-review-eval-run.ts',
+    '```',
+    '',
+    'The default invocation runs the LIVE 5-voter pr_review panel — 5 LLM calls per ' +
+      `case (${String(n)} cases in the current corpus) — and requires model auth (a CLI ` +
+      'adapter such as claude/gemini/codex, or `ANTHROPIC_API_KEY`). Results are appended ' +
+      'to the #3848 JSONL store (`~/.nexus-agents/learning/pr-review-eval.jsonl` by default, ' +
+      '`NEXUS_DATA_DIR`-relocatable) and this doc is regenerated in place. The plumbing above ' +
+      '(corpus load, scoring, aggregation, doc/store write) is unit-tested with a deterministic ' +
+      'stub panel — see `scripts/pr-review-eval-run.test.ts` and ' +
+      '`scripts/pr-review-eval-run-core.test.ts`; no live model calls happen in CI.',
+    '',
+  ];
+}
+
+/**
+ * Render the v6 results markdown doc (`docs/research/pr-review-experiment-results-v6.md`).
+ * Pure string building — no file I/O (the orchestrator writes the returned
+ * string). Mirrors the frontmatter + per-voter/per-case table shape of the
+ * prior `pr-review-experiment-results-v5.md`, carries forward the #3903
+ * metric-honesty guardrail note, and documents the live-run reproduction
+ * command.
+ */
+export function renderResultsDoc(params: RenderDocParams): string {
+  const { runId, timestamp, dataset, report, caseResults } = params;
+  const counts: HeaderCounts = {
+    n: caseResults.length,
+    buggyN: caseResults.filter((c) => c.class === 'buggy').length,
+    cleanN: caseResults.filter((c) => c.class === 'clean').length,
+    borderlineN: caseResults.filter((c) => c.class === 'borderline').length,
+  };
+
+  const lines: readonly string[] = [
+    ...renderFrontmatterAndTitle(),
+    ...renderHeader(runId, timestamp, dataset.rubricVersion, counts),
+    ...renderVoterTable(report),
+    ...renderCaseTable(caseResults),
+    ...renderReproSection(counts.n),
+  ];
+  return `${lines.join('\n')}\n`;
+}

--- a/scripts/pr-review-eval-run.test.ts
+++ b/scripts/pr-review-eval-run.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for the v6 pr_review eval batch orchestrator (#4311, epic #3845;
+ * unblocks #3849).
+ *
+ * Drives {@link runEval} end-to-end with EVERY collaborator injected: a
+ * deterministic STUB panel (fixed votes, never `simulateVotes` standing in
+ * for a live run — this is test-only plumbing), an in-memory dataset, a
+ * temp-file-backed real `PrReviewEvalStore`, and a captured doc sink. No live
+ * model calls, no `gh` calls, no writes outside a tmpdir.
+ *
+ * Covers: corpus load -> per-case panel run -> #3848 scoring -> aggregation
+ * -> store append -> doc write, for a buggy case (catch + miss) and a clean
+ * case (false positive), plus the real-dataset smoke test (loads the actual
+ * n=19 corpus and validates every case resolves a diff).
+ *
+ * @module scripts/pr-review-eval-run.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runEval, loadDatasetFromDisk, resolveDiff, DATASET_PATH } from './pr-review-eval-run.js';
+import type { PanelRunner, PanelVoterOutcome } from './pr-review-eval-run-core.js';
+import { PrReviewEvalStore } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-store.js';
+import type { PrReviewDataset } from './curate-pr-review-dataset-schema.js';
+
+const TS = '2026-07-17T12:00:00.000Z';
+
+function dataset(over: Partial<PrReviewDataset> = {}): PrReviewDataset {
+  return {
+    rubricVersion: '1.0.0',
+    curatedAt: '2026-07-17',
+    methodology: 'test fixture',
+    prs: [
+      {
+        number: 'buggy-case',
+        rubricVersion: '1.0.0',
+        class: 'buggy',
+        title: 'a buggy fixture case',
+        customDescription: 'desc',
+        customDiff: 'diff --git a/src/foo.ts b/src/foo.ts\n+bug here',
+        provenance: { source: 'synthetic', fixReference: null, discoveredBy: null },
+        knownBugs: [
+          {
+            summary: 'a real bug',
+            severity: 'high',
+            location: 'src/foo.ts:10',
+            locationTolerance: 'line',
+            fixReference: 'synthetic',
+          },
+        ],
+        borderlineConcerns: [],
+        adjudication: {
+          adjudicatedAt: '2026-07-17',
+          adjudicatedUnder: '1.0.0',
+          rationale: 'fixture rationale text long enough',
+        },
+      },
+      {
+        number: 'clean-case',
+        rubricVersion: '1.0.0',
+        class: 'clean',
+        title: 'a clean fixture case',
+        customDescription: 'desc',
+        customDiff: 'diff --git a/src/bar.ts b/src/bar.ts\n+harmless',
+        provenance: { source: 'synthetic', fixReference: null, discoveredBy: null },
+        knownBugs: [],
+        borderlineConcerns: [],
+        adjudication: {
+          adjudicatedAt: '2026-07-17',
+          adjudicatedUnder: '1.0.0',
+          rationale: 'fixture rationale text long enough',
+        },
+      },
+    ],
+    ...over,
+  };
+}
+
+/**
+ * A deterministic stub panel: architect+security flag the buggy case's known
+ * bug (one at the exact line, one nearby, within ±5); devex/catfish/scope_steward
+ * approve. On the clean case, catfish raises an unverified concern (must not
+ * count as FP) and everyone else approves.
+ */
+const stubPanel: PanelRunner = (input) => {
+  if (input.caseNumber === 'buggy-case') {
+    const outcomes: PanelVoterOutcome[] = [
+      {
+        role: 'architect',
+        decision: 'request_changes',
+        source: 'llm',
+        findings: [
+          {
+            summary: 'the known bug',
+            location: 'src/foo.ts:10',
+            severity: 'high',
+            verified: true,
+          },
+        ],
+      },
+      {
+        role: 'security',
+        decision: 'request_changes',
+        source: 'llm',
+        findings: [
+          {
+            summary: 'the known bug, nearby line',
+            location: 'src/foo.ts:12',
+            severity: 'high',
+            verified: true,
+          },
+        ],
+      },
+      { role: 'devex', decision: 'approve', source: 'llm', findings: [] },
+      { role: 'catfish', decision: 'approve', source: 'llm', findings: [] },
+      { role: 'scope_steward', decision: 'approve', source: 'llm', findings: [] },
+    ];
+    return Promise.resolve(outcomes);
+  }
+  // clean-case
+  const outcomes: PanelVoterOutcome[] = [
+    { role: 'architect', decision: 'approve', source: 'llm', findings: [] },
+    { role: 'security', decision: 'approve', source: 'llm', findings: [] },
+    { role: 'devex', decision: 'approve', source: 'llm', findings: [] },
+    {
+      role: 'catfish',
+      decision: 'approve',
+      source: 'llm',
+      findings: [
+        { summary: 'minor nit', location: 'src/bar.ts:1', severity: 'low', verified: false },
+      ],
+    },
+    { role: 'scope_steward', decision: 'approve', source: 'llm', findings: [] },
+  ];
+  return Promise.resolve(outcomes);
+};
+
+let dir: string;
+let storeFile: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'pr-review-eval-run-'));
+  storeFile = join(dir, 'pr-review-eval.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('runEval (v6 batch orchestrator, stub panel)', () => {
+  it('scores a buggy case: two catches (architect+security) and three approvers with no findings', async () => {
+    let writtenDoc = '';
+    const result = await runEval({
+      loadDataset: dataset,
+      panelRunner: stubPanel,
+      store: new PrReviewEvalStore({ filePath: storeFile }),
+      writeDoc: (md) => {
+        writtenDoc = md;
+      },
+      now: () => new Date(TS),
+      runId: 'test-run',
+      onProgress: () => {},
+    });
+
+    expect(result.runId).toBe('test-run');
+    const buggyCase = result.caseResults.find((c) => c.number === 'buggy-case');
+    expect(buggyCase).toBeDefined();
+    expect(buggyCase?.verdicts).toHaveLength(5); // one per non-error voter
+
+    const architectV = buggyCase?.verdicts.find((v) => v.role === 'architect');
+    expect(architectV).toMatchObject({ truePositives: 1, falseNegatives: 0, falsePositives: 0 });
+    const securityV = buggyCase?.verdicts.find((v) => v.role === 'security');
+    expect(securityV).toMatchObject({ truePositives: 1, falseNegatives: 0, falsePositives: 0 });
+    const devexV = buggyCase?.verdicts.find((v) => v.role === 'devex');
+    expect(devexV).toMatchObject({ truePositives: 0, falseNegatives: 1, falsePositives: 0 });
+
+    expect(result.report.byRole.architect.truePositives).toBe(1);
+    expect(result.report.byRole.security.truePositives).toBe(1);
+    expect(result.report.byRole.devex.falseNegatives).toBe(1);
+
+    expect(writtenDoc).toContain('| buggy-case | buggy | 2 |');
+    expect(writtenDoc).toBe(result.doc);
+  });
+
+  it('scores a clean case: an unverified finding is not a false positive', async () => {
+    const result = await runEval({
+      loadDataset: dataset,
+      panelRunner: stubPanel,
+      store: new PrReviewEvalStore({ filePath: storeFile }),
+      writeDoc: () => {},
+      now: () => new Date(TS),
+      onProgress: () => {},
+    });
+
+    const cleanCase = result.caseResults.find((c) => c.number === 'clean-case');
+    expect(cleanCase?.verdicts.every((v) => v.falsePositives === 0)).toBe(true);
+    expect(result.report.aggregate.falsePositives).toBe(0);
+  });
+
+  it('persists every verdict to the injected store (JSONL round-trip)', async () => {
+    const store = new PrReviewEvalStore({ filePath: storeFile });
+    const result = await runEval({
+      loadDataset: dataset,
+      panelRunner: stubPanel,
+      store,
+      writeDoc: () => {},
+      now: () => new Date(TS),
+      onProgress: () => {},
+    });
+
+    expect(existsSync(storeFile)).toBe(true);
+    const totalVerdicts = result.caseResults.reduce((n, c) => n + c.verdicts.length, 0);
+    expect(store.size).toBe(totalVerdicts);
+
+    // Fresh store instance hydrates the same verdicts (persistence is real).
+    const reader = new PrReviewEvalStore({ filePath: storeFile });
+    expect(reader.size).toBe(totalVerdicts);
+    expect(reader.query({ runId: result.runId })).toHaveLength(totalVerdicts);
+  });
+
+  it('writes the results doc via the injected sink, matching renderResultsDoc shape', async () => {
+    let doc = '';
+    await runEval({
+      loadDataset: dataset,
+      panelRunner: stubPanel,
+      store: new PrReviewEvalStore({ filePath: storeFile }),
+      writeDoc: (md) => {
+        doc = md;
+      },
+      now: () => new Date(TS),
+      onProgress: () => {},
+    });
+
+    expect(doc.startsWith('---\n')).toBe(true);
+    expect(doc).toContain('title: pr_review experiment v6');
+    expect(doc).toContain('n=2: 1 buggy / 1 clean / 0 borderline');
+    expect(doc).toContain('| Role | TP | FP | FN | Precision | Recall | Cases |');
+  });
+
+  it('resolveDiff returns customDiff verbatim for synthetic cases (no gh fetch)', async () => {
+    const ds = dataset();
+    const c = ds.prs[0];
+    if (c === undefined) throw new Error('fixture missing');
+    const diff = await resolveDiff(c);
+    expect(diff).toBe(c.customDiff);
+  });
+
+  it('resolveDiff throws for a non-numeric case number with no customDiff', async () => {
+    const c = {
+      number: 'synthetic-no-diff',
+      rubricVersion: '1.0.0',
+      class: 'clean' as const,
+      title: 'missing diff',
+      provenance: { source: 'synthetic' as const, fixReference: null, discoveredBy: null },
+      knownBugs: [],
+      borderlineConcerns: [],
+      adjudication: {
+        adjudicatedAt: '2026-07-17',
+        adjudicatedUnder: '1.0.0',
+        rationale: 'x'.repeat(20),
+      },
+    };
+    await expect(resolveDiff(c)).rejects.toThrow(/cannot resolve a diff/);
+  });
+});
+
+describe('loadDatasetFromDisk (real corpus smoke test)', () => {
+  it('loads the real n=19 corpus and every case resolves either customDiff or a numeric PR number', () => {
+    const ds = loadDatasetFromDisk(DATASET_PATH);
+    expect(ds.prs.length).toBeGreaterThanOrEqual(19);
+    for (const c of ds.prs) {
+      const hasCustomDiff = c.customDiff !== undefined && c.customDiff !== '';
+      const hasNumericPr = typeof c.number === 'number';
+      expect(hasCustomDiff || hasNumericPr).toBe(true);
+    }
+  });
+});

--- a/scripts/pr-review-eval-run.ts
+++ b/scripts/pr-review-eval-run.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env npx tsx
+/**
+ * pr-review-eval-run.ts — v6 pr_review eval batch runner (#4311, epic #3845;
+ * unblocks #3849).
+ *
+ * The missing connective harness: loads the rubric-adjudicated corpus
+ * (`testing/datasets/pr-review-sample.json`, #3846/#3847), obtains each case's
+ * diff (`customDiff` for synthetic cases; `gh` fetch for real PR numbers that
+ * carry none), runs it through the live 5-voter pr_review panel, scores each
+ * voter's verdict against the case's gold `class`/`knownBugs` via the #3848
+ * scorer, aggregates per-voter TP/FP/FN + precision/recall, writes the
+ * verdicts to the #3848 JSONL eval store, and regenerates
+ * `docs/research/pr-review-experiment-results-v6.md`.
+ *
+ * All scoring/aggregation/doc-shape logic is PURE and lives in
+ * `pr-review-eval-run-core.ts`; this file is the thin I/O edge (mirrors the
+ * curate-pr-review-harvest / -labeling split and mine-pr-review-candidates'
+ * assemble/thin-script split).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * LIVE MODEL CALLS (read before running)
+ * ─────────────────────────────────────────────────────────────────────────
+ * The default panel runner calls `collectRealVotes` — 5 real LLM calls per
+ * case (n cases in the corpus). This requires model auth: a CLI adapter
+ * (claude/gemini/codex) or `ANTHROPIC_API_KEY`. It is NOT run in CI or in this
+ * package's automated test suite — the tests inject a deterministic STUB
+ * panel (`PanelRunner`) so the plumbing (corpus load → diff resolution →
+ * scoring → aggregation → doc/store write) is verified without touching a
+ * model. Never `simulateVotes` standing in for a live run.
+ *
+ * Usage:
+ *   npm run eval:run
+ *   npx tsx scripts/pr-review-eval-run.ts
+ *
+ * @module scripts/pr-review-eval-run
+ * (Source: #4311, epic #3845, unblocks #3849; scorer from #3848; rubric #3846)
+ */
+
+/* eslint-disable no-console -- CLI script that prints progress */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  parseDataset,
+  type PrReviewCase,
+  type PrReviewDataset,
+} from './curate-pr-review-dataset-schema.js';
+import { ROOT } from './script-paths.js';
+import { fetchGhDiff } from './pr-review-local-ledger.js';
+import {
+  scoreCaseVoters,
+  renderResultsDoc,
+  type PanelRunner,
+  type PanelVoterOutcome,
+  type EvalCaseResult,
+} from './pr-review-eval-run-core.js';
+
+import {
+  buildPrReviewProposal,
+  PR_REVIEW_ROLES,
+  mapVoteDecisionToPrDecision,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-tool.js';
+import { collectRealVotes } from '../packages/nexus-agents/src/cli/voter-agents.js';
+import { isFindingVerified } from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
+import { PrReviewEvalStore } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-store.js';
+import { computePerVoterPrecisionRecall } from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-scoring.js';
+import type {
+  PrReviewEvalRole,
+  VoterEvalVerdict,
+} from '../packages/nexus-agents/src/mcp/tools/pr-review-eval-types.js';
+
+export const DATASET_PATH = path.join(ROOT, 'testing/datasets/pr-review-sample.json');
+export const RESULTS_DOC_PATH = path.join(ROOT, 'docs/research/pr-review-experiment-results-v6.md');
+
+// ============================================================================
+// Dataset load (read-only file I/O)
+// ============================================================================
+
+/** Load + validate the corpus off disk. Throws on any schema violation —
+ * a bad dataset must fail loudly, never silently score against garbage. */
+export function loadDatasetFromDisk(filePath: string = DATASET_PATH): PrReviewDataset {
+  const raw: unknown = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  const parsed = parseDataset(raw);
+  if (!parsed.success) {
+    throw new Error(`invalid pr_review eval dataset (${filePath}):\n${parsed.errors.join('\n')}`);
+  }
+  return parsed.data;
+}
+
+// ============================================================================
+// Diff resolution (customDiff, or gh fetch for real PR numbers)
+// ============================================================================
+
+/**
+ * Resolve the diff a case's panel run reviews. Synthetic cases carry
+ * `customDiff` directly (no fetch). Real PR numbers without a stored diff are
+ * fetched live via `gh` (the #4229 fallback path — the eval's diff does not
+ * need ledger-hash parity, so the plain `v3.diff` fetch is sufficient here).
+ */
+export async function resolveDiff(c: PrReviewCase): Promise<string> {
+  if (c.customDiff !== undefined && c.customDiff !== '') return c.customDiff;
+  if (typeof c.number === 'number') {
+    const { diff } = await fetchGhDiff(c.number);
+    return diff;
+  }
+  throw new Error(
+    `case "${c.number}": no customDiff and a non-numeric number — cannot resolve a diff`
+  );
+}
+
+// ============================================================================
+// Live panel runner (default; injectable for tests)
+// ============================================================================
+
+/**
+ * The default {@link PanelRunner}: runs the live 5-voter pr_review panel via
+ * `collectRealVotes` (real LLM calls — see the module-level auth note).
+ * Mirrors `scripts/pr-review-local.ts`'s vote-mapping so a live v6 run scores
+ * the SAME finding/verification shape a real `pr_review` invocation produces.
+ */
+export const livePanelRunner: PanelRunner = async (input) => {
+  const proposal = buildPrReviewProposal({
+    prTitle: input.title,
+    prDescription: input.description,
+    prDiff: input.diff,
+  });
+  const voteResults = await collectRealVotes({ roles: PR_REVIEW_ROLES, proposal, simulate: false });
+  return voteResults.map((r): PanelVoterOutcome => {
+    const rawFindings = r.vote.findings ?? [];
+    return {
+      role: r.role as PrReviewEvalRole,
+      decision: mapVoteDecisionToPrDecision(r.vote.decision),
+      findings: rawFindings.map((f) => ({
+        summary: f.summary,
+        location: f.location,
+        severity: f.severity,
+        verified: isFindingVerified(f.gate),
+      })),
+      source: r.source,
+    };
+  });
+};
+
+// ============================================================================
+// Orchestration
+// ============================================================================
+
+export interface EvalRunDeps {
+  readonly loadDataset?: () => PrReviewDataset;
+  readonly resolveDiff?: (c: PrReviewCase) => Promise<string>;
+  readonly panelRunner?: PanelRunner;
+  readonly store?: PrReviewEvalStore;
+  readonly writeDoc?: (markdown: string) => void;
+  readonly now?: () => Date;
+  readonly runId?: string;
+  /** Progress hook (defaults to `console.log`); tests can silence/capture it. */
+  readonly onProgress?: (message: string) => void;
+}
+
+export interface EvalRunResult {
+  readonly runId: string;
+  readonly report: ReturnType<typeof computePerVoterPrecisionRecall>;
+  readonly caseResults: readonly EvalCaseResult[];
+  readonly doc: string;
+}
+
+/** Every {@link EvalRunDeps} collaborator with its default filled in. */
+interface ResolvedDeps {
+  readonly loadDataset: () => PrReviewDataset;
+  readonly resolveDiff: (c: PrReviewCase) => Promise<string>;
+  readonly panelRunner: PanelRunner;
+  readonly store: PrReviewEvalStore;
+  readonly writeDoc: (markdown: string) => void;
+  readonly now: () => Date;
+  readonly onProgress: (message: string) => void;
+}
+
+function resolveDeps(deps: EvalRunDeps): ResolvedDeps {
+  return {
+    loadDataset: deps.loadDataset ?? (() => loadDatasetFromDisk()),
+    resolveDiff: deps.resolveDiff ?? resolveDiff,
+    panelRunner: deps.panelRunner ?? livePanelRunner,
+    store: deps.store ?? new PrReviewEvalStore(),
+    writeDoc:
+      deps.writeDoc ??
+      ((md: string) => {
+        fs.writeFileSync(RESULTS_DOC_PATH, md, 'utf-8');
+      }),
+    now: deps.now ?? (() => new Date()),
+    onProgress:
+      deps.onProgress ??
+      ((msg: string) => {
+        console.log(msg);
+      }),
+  };
+}
+
+/** Run one case through the panel + #3848 scorer, appending its verdicts to the store. */
+async function runCase(
+  c: PrReviewCase,
+  ctx: { readonly runId: string; readonly timestamp: string; readonly rubricVersion: string },
+  resolved: ResolvedDeps
+): Promise<EvalCaseResult> {
+  const caseNumber = String(c.number);
+  resolved.onProgress(`[${caseNumber}] resolving diff…`);
+  const diff = await resolved.resolveDiff(c);
+  resolved.onProgress(`[${caseNumber}] running panel (${String(PR_REVIEW_ROLES.length)} voters)…`);
+  const outcomes = await resolved.panelRunner({
+    caseNumber,
+    title: c.title,
+    description: c.customDescription ?? '',
+    diff,
+  });
+  const verdicts = scoreCaseVoters(
+    {
+      runId: ctx.runId,
+      caseNumber,
+      caseClass: c.class,
+      knownBugs: c.knownBugs,
+      rubricVersion: ctx.rubricVersion,
+      timestamp: ctx.timestamp,
+    },
+    outcomes
+  );
+  for (const v of verdicts) resolved.store.append(v);
+  resolved.onProgress(`[${caseNumber}] scored ${String(verdicts.length)} voter verdict(s).`);
+  return { number: caseNumber, class: c.class, title: c.title, outcomes, verdicts };
+}
+
+/**
+ * Run the full v6 batch: dataset -> per-case panel run -> per-voter scoring ->
+ * store append -> results doc. Every collaborator is injectable so this is
+ * unit-testable end-to-end with a deterministic stub panel and an in-memory
+ * doc sink — see `pr-review-eval-run.test.ts`.
+ */
+export async function runEval(deps: EvalRunDeps = {}): Promise<EvalRunResult> {
+  const resolved = resolveDeps(deps);
+  const timestamp = resolved.now().toISOString();
+  const runId = deps.runId ?? `v6-${timestamp}`;
+  const dataset = resolved.loadDataset();
+
+  const caseResults: EvalCaseResult[] = [];
+  for (const c of dataset.prs) {
+    const result = await runCase(
+      c,
+      { runId, timestamp, rubricVersion: dataset.rubricVersion },
+      resolved
+    );
+    caseResults.push(result);
+  }
+
+  const allVerdicts: VoterEvalVerdict[] = caseResults.flatMap((c) => c.verdicts);
+  const report = computePerVoterPrecisionRecall(allVerdicts);
+  const doc = renderResultsDoc({
+    runId,
+    timestamp,
+    dataset: { rubricVersion: dataset.rubricVersion },
+    report,
+    caseResults,
+  });
+  resolved.writeDoc(doc);
+
+  return { runId, report, caseResults, doc };
+}
+
+// ============================================================================
+// CLI entry
+// ============================================================================
+
+async function main(): Promise<void> {
+  console.log(
+    'Running pr_review v6 eval batch — LIVE panel (requires model auth: a CLI ' +
+      'adapter or ANTHROPIC_API_KEY). See the module doc for the stub-panel test path.'
+  );
+  const result = await runEval();
+  console.log(`\nDone. runId=${result.runId}`);
+  console.log(`Wrote ${RESULTS_DOC_PATH}`);
+  for (const role of Object.keys(result.report.byRole) as PrReviewEvalRole[]) {
+    const r = result.report.byRole[role];
+    console.log(
+      `  ${role}: precision=${r.precision.toFixed(2)} recall=${r.recall.toFixed(2)} ` +
+        `(tp=${String(r.truePositives)} fp=${String(r.falsePositives)} fn=${String(r.falseNegatives)})`
+    );
+  }
+}
+
+const invokedPath = process.argv[1] ?? '';
+if (import.meta.url === `file://${invokedPath}`) {
+  await main();
+}


### PR DESCRIPTION
## Summary

Builds the missing connective harness for epic #3845 (unblocks #3849): closes #4311.

- **`scripts/pr-review-eval-run.ts`** (thin I/O orchestrator) + **`scripts/pr-review-eval-run-core.ts`** (pure scoring/doc-rendering core) — loads the rubric-adjudicated corpus (`testing/datasets/pr-review-sample.json`, n=19, #3846/#3847), resolves each case's diff (`customDiff` for synthetic cases; `gh` fetch for the 3 real-PR cases — #2228, #2235, #2238 — that carry no stored diff), runs it through the live 5-voter `pr_review` panel, applies rubric **Rule 2 location-tolerance matching** (`matchesKnownBug`: ±5 lines for `line`-tolerance bugs, same-file for `structural`-tolerance bugs), scores each voter's verdict against the case's gold `class`/`knownBugs` via the existing **#3848 scorer** (`scoreVoterCase` / `computePerVoterPrecisionRecall`), appends verdicts to `PrReviewEvalStore`, and regenerates `docs/research/pr-review-experiment-results-v6.md`.
- New `eval:run` npm script (`npx tsx scripts/pr-review-eval-run.ts`).
- Changeset (minor, references #4311).

## What's stub-tested vs. live

- **Stub-tested (this PR, runs in CI):** the panel invocation is injectable (`PanelRunner`). All plumbing — corpus load → diff resolution → rubric-matching → per-voter scoring → aggregation → JSONL store append → results-doc rendering — is unit-tested against a **deterministic stub panel** (fixed votes/findings), never `simulateVotes` presented as real evidence. 23 new tests across `scripts/pr-review-eval-run-core.test.ts` (matching + scoring + doc-shape) and `scripts/pr-review-eval-run.test.ts` (end-to-end orchestration with a temp-file-backed real `PrReviewEvalStore` + captured doc sink), plus a real-corpus smoke test that loads the actual n=19 dataset and checks every case resolves a diff.
- **Live, on-demand (not run in this PR):** the actual v6 numbers require `npm run eval:run` — 5 real LLM calls per case (~95 calls for n=19), needs model auth (a CLI adapter — claude/gemini/codex — or `ANTHROPIC_API_KEY`), which this build environment does not have. `docs/research/pr-review-experiment-results-v6.md` is committed as an explicit **PENDING placeholder** documenting the reproduction command and the #3903 metric-honesty guardrail; it is overwritten in place by a live run.

## Gate results (all green)

- `pnpm --filter nexus-agents typecheck` (tsc --noEmit, src+tests) — green
- Root scripts suite `pnpm test:scripts` (vitest, includes the 23 new tests) — 33 files / 455 tests, all green
- `pnpm lint` (turbo, per-package eslint) — green; new root `scripts/*.ts` files additionally verified clean via a direct `npx eslint` pass (root eslint config type-checks scripts/ too, `strictTypeChecked`)
- `pnpm docs:tools:check` — green (no MCP tool Zod input shape touched)
- `npx tsx scripts/generate-repo-index.ts --check` — green (no new CLI command/MCP tool/workflow)
- `pnpm governance:check` — green
- `markdownlint` + `cspell` on the new doc — green
- `prettier --check` — green
- `npx changeset status` — nexus-agents bumped at minor, as expected

Note: `packages/nexus-agents/src` was **not touched** by this PR (all new logic lives in root `scripts/` + `docs/`), so the package's full 1170-file test suite is out of scope for "touched tests" — the relevant touched-test gate is the root `pnpm test:scripts` run above, which is green.

## Test plan

- [x] `pnpm test:scripts` — 455/455 green (includes the 23 new tests)
- [x] `pnpm --filter nexus-agents typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm docs:tools:check`, repo-index check, `pnpm governance:check` — green
- [ ] Live v6 pass (`npm run eval:run`, needs model auth) — deferred, on-demand, tracked by #3849

🤖 Generated with [Claude Code](https://claude.com/claude-code)