### PR TITLE
fix(cli-adapters): exclude circuit-broken voter CLIs

### DIFF
--- a/.changeset/clever-paws-sneeze.md
+++ b/.changeset/clever-paws-sneeze.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+exclude circuit-broken CLIs from voter panel selection so quota/rate-dead CLIs are skipped and do not waste retries

--- a/packages/nexus-agents/src/adapters/rate-limit-detector.test.ts
+++ b/packages/nexus-agents/src/adapters/rate-limit-detector.test.ts
@@ -80,6 +80,10 @@ describe('isRateLimitLikeError', () => {
     expect(isRateLimitLikeError(new Error('API quota exceeded'))).toBe(true);
   });
 
+  it('detects "key limit" provider quota errors', () => {
+    expect(isRateLimitLikeError(new Error('Key limit exceeded'))).toBe(true);
+  });
+
   it('detects "throttle"', () => {
     expect(isRateLimitLikeError(new Error('Request throttled'))).toBe(true);
   });

--- a/packages/nexus-agents/src/adapters/rate-limit-detector.ts
+++ b/packages/nexus-agents/src/adapters/rate-limit-detector.ts
@@ -24,6 +24,7 @@ export const RATE_LIMIT_PATTERNS = [
   'too many requests',
   '429',
   'quota exceeded',
+  'key limit',
   'throttl',
   'usage limit',
   'requests per minute',

--- a/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.test.ts
@@ -36,6 +36,7 @@ vi.mock('../agents/collaboration/event-bus.js', () => ({
 }));
 
 vi.mock('./rate-limit-detector.js', () => ({
+  isRateLimitText: vi.fn((text: string) => text.toLowerCase().includes('rate limit')),
   isRateLimitLikeError: vi.fn().mockReturnValue(false),
   toRateLimitError: vi.fn().mockReturnValue({ message: 'rate limit', retryAfterMs: undefined }),
   recordRateLimitEvent: vi.fn(),

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker-types.ts
@@ -7,6 +7,7 @@
  */
 
 import { NexusError, ErrorCode } from '../core/errors.js';
+import { isRateLimitText } from '../adapters/rate-limit-detector.js';
 import type { CliName } from './types.js';
 
 // ============================================================================
@@ -216,7 +217,6 @@ export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
  */
 const TIMEOUT_PATTERNS = ['timeout', 'timed out'];
 const AUTH_PATTERNS = ['auth', 'unauthorized', 'forbidden', 'oauth'];
-const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429'];
 const CONNECTION_PATTERNS = [
   'connection',
   'econnrefused',
@@ -248,7 +248,7 @@ export function categorizeError(error: unknown): FailureCategory {
 
   if (matchesPatterns(combined, TIMEOUT_PATTERNS)) return 'timeout';
   if (matchesPatterns(combined, AUTH_PATTERNS)) return 'authentication';
-  if (matchesPatterns(combined, RATE_LIMIT_PATTERNS)) return 'rate_limit';
+  if (isRateLimitText(combined)) return 'rate_limit';
   if (matchesPatterns(combined, CONNECTION_PATTERNS)) return 'connection';
   if (matchesPatterns(combined, CRASH_PATTERNS)) return 'crash';
 

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
@@ -779,6 +779,7 @@ describe('categorizeError', () => {
     expect(categorizeError(new Error('Rate limit exceeded'))).toBe('rate_limit');
     expect(categorizeError(new Error('Too many requests'))).toBe('rate_limit');
     expect(categorizeError(new Error('HTTP 429 error'))).toBe('rate_limit');
+    expect(categorizeError(new Error('Key limit exceeded'))).toBe('rate_limit');
   });
 
   it('should categorize connection errors', () => {

--- a/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.test.ts
@@ -11,6 +11,8 @@ import type { ICliAdapter, CliName, CliTask, CliResponse, CliError } from './typ
 import {
   CliCircuitBreakerIntegration,
   createCliCircuitBreakerIntegration,
+  getCliCircuitBreakerSnapshot,
+  getDefaultCliCircuitBreakerRegistry,
   type CliCircuitBreakerConfig,
 } from './cli-circuit-breaker.js';
 import { CircuitError, CircuitErrorCode, type CircuitStateChangeEvent } from './circuit-breaker.js';
@@ -74,6 +76,13 @@ function createTask(content = 'test task') {
   } as unknown as CliTask;
 }
 
+function createAdapterReturningError(name: CliName, error: CliError): ICliAdapter {
+  return {
+    name,
+    execute: vi.fn<() => Promise<Result<CliResponse, CliError>>>().mockResolvedValue(err(error)),
+  } as unknown as ICliAdapter;
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -84,6 +93,7 @@ describe('CliCircuitBreakerIntegration', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    getDefaultCliCircuitBreakerRegistry().resetAll();
     adapters = [
       createMockAdapter('claude', 'success'),
       createMockAdapter('gemini', 'success'),
@@ -93,6 +103,7 @@ describe('CliCircuitBreakerIntegration', () => {
   });
 
   afterEach(() => {
+    getDefaultCliCircuitBreakerRegistry().resetAll();
     vi.useRealTimers();
   });
 
@@ -157,6 +168,42 @@ describe('CliCircuitBreakerIntegration', () => {
       const custom = new CliCircuitBreakerIntegration(adapters, config);
       const result2 = await custom.execute(failingAdapter, createTask());
       expect(result2.ok).toBe(false);
+    });
+
+    it.each([
+      ['OpenRouter quota exhaustion', 'OpenRouter error: Key limit exceeded'],
+      ['HTTP 5xx with no response body', 'HTTP 503 with no response body'],
+    ])('records %s as a breaker failure', async (_label, message) => {
+      const quotaAdapter = createAdapterReturningError('opencode', {
+        code: 'EXECUTION_ERROR',
+        message,
+        cli: 'opencode',
+        retryable: true,
+      });
+      const custom = new CliCircuitBreakerIntegration([quotaAdapter], {
+        perCliConfig: { opencode: { failureThreshold: 1 } },
+      });
+
+      const result = await custom.execute(quotaAdapter, createTask());
+
+      expect(result.ok).toBe(false);
+      expect(custom.getCircuitSnapshots().get('opencode')?.state).toBe('open');
+    });
+
+    it('exposes default integration failures through the shared breaker snapshot', async () => {
+      const quotaAdapter = createAdapterReturningError('opencode', {
+        code: 'EXECUTION_ERROR',
+        message: 'OpenRouter error: Key limit exceeded',
+        cli: 'opencode',
+        retryable: true,
+      });
+      const defaultIntegration = new CliCircuitBreakerIntegration([quotaAdapter]);
+
+      for (let i = 0; i < 5; i++) {
+        await defaultIntegration.execute(quotaAdapter, createTask());
+      }
+
+      expect(getCliCircuitBreakerSnapshot('opencode')?.state).toBe('open');
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.ts
@@ -87,6 +87,21 @@ const DEFAULT_CONFIG: Required<CliCircuitBreakerConfig> = {
   enableFallback: true,
   maxFallbackAttempts: 2,
 };
+const defaultCliCircuitBreakerRegistry = new CircuitBreakerRegistry();
+
+/** Returns the shared CLI circuit-breaker registry used by default integrations. */
+export function getDefaultCliCircuitBreakerRegistry(): CircuitBreakerRegistry {
+  return defaultCliCircuitBreakerRegistry;
+}
+
+/**
+ * Reads the current snapshot for a CLI without creating a new breaker.
+ *
+ * `undefined` means no circuit state is known yet, so callers should fail open.
+ */
+export function getCliCircuitBreakerSnapshot(cliName: CliName): CircuitBreakerSnapshot | undefined {
+  return defaultCliCircuitBreakerRegistry.getAllSnapshots().get(cliName);
+}
 
 /**
  * Integrates circuit breaker pattern with CLI adapters.
@@ -105,7 +120,8 @@ export class CliCircuitBreakerIntegration implements ICliCircuitBreakerIntegrati
   ) {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.logger = logger ?? createLogger({ component: 'cli-circuit-breaker-integration' });
-    this.registry = new CircuitBreakerRegistry();
+    this.registry =
+      config === undefined ? defaultCliCircuitBreakerRegistry : new CircuitBreakerRegistry();
     for (const adapter of adapters) {
       this.adapters.set(adapter.name, adapter);
       this.registry.getBreaker(adapter.name, this.config.perCliConfig[adapter.name]);
@@ -181,7 +197,15 @@ export class CliCircuitBreakerIntegration implements ICliCircuitBreakerIntegrati
   }
 
   getCircuitSnapshots(): Map<CliName, CircuitBreakerSnapshot> {
-    return this.registry.getAllSnapshots();
+    const allSnapshots = this.registry.getAllSnapshots();
+    const snapshots = new Map<CliName, CircuitBreakerSnapshot>();
+    for (const name of this.adapters.keys()) {
+      const snapshot = allSnapshots.get(name);
+      if (snapshot !== undefined) {
+        snapshots.set(name, snapshot);
+      }
+    }
+    return snapshots;
   }
 
   resetCircuit(cliName: CliName): void {

--- a/packages/nexus-agents/src/cli-adapters/factory-serving-gate.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory-serving-gate.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { CliName, HealthStatus } from './types.js';
+
+const mocks = vi.hoisted(() => {
+  const healthy: HealthStatus = {
+    healthy: true,
+    version: '1.0.0',
+    versionStatus: 'supported',
+    message: 'ok',
+    lastChecked: new Date(0),
+  };
+
+  return {
+    healthy,
+    healthByCli: new Map<string, HealthStatus>(),
+    probeCli: vi.fn(),
+    getCliCircuitBreakerSnapshot: vi.fn(),
+  };
+});
+
+function mockAdapterClass(cli: CliName): new () => { healthCheck: () => Promise<HealthStatus> } {
+  return class {
+    healthCheck(): Promise<HealthStatus> {
+      return Promise.resolve(mocks.healthByCli.get(cli) ?? mocks.healthy);
+    }
+  };
+}
+
+vi.mock('./adapters/claude-adapter.js', () => ({
+  ClaudeCliAdapter: mockAdapterClass('claude'),
+}));
+
+vi.mock('./adapters/gemini-adapter.js', () => ({
+  GeminiCliAdapter: mockAdapterClass('gemini'),
+}));
+
+vi.mock('./adapters/codex-adapter.js', () => ({
+  CodexCliAdapter: mockAdapterClass('codex'),
+}));
+
+vi.mock('./adapters/codex-mcp-adapter.js', () => ({
+  CodexMcpAdapter: mockAdapterClass('codex'),
+}));
+
+vi.mock('./adapters/opencode-adapter.js', () => ({
+  OpenCodeCliAdapter: mockAdapterClass('opencode'),
+}));
+
+vi.mock('../cli/cli-auth-probe.js', () => ({
+  probeCli: mocks.probeCli,
+}));
+
+vi.mock('./cli-circuit-breaker.js', () => ({
+  getCliCircuitBreakerSnapshot: mocks.getCliCircuitBreakerSnapshot,
+}));
+
+describe('getAvailableClis serving gate', () => {
+  beforeEach(() => {
+    mocks.healthByCli.clear();
+    mocks.probeCli.mockImplementation((cli: CliName) =>
+      Promise.resolve({ cli, state: 'authenticated', via: 'cli-credentials' })
+    );
+    mocks.getCliCircuitBreakerSnapshot.mockReturnValue(undefined);
+  });
+
+  it('excludes an authenticated healthy CLI whose circuit breaker is open', async () => {
+    const { getAvailableClis } = await import('./factory.js');
+    mocks.getCliCircuitBreakerSnapshot.mockImplementation((cli: CliName) =>
+      cli === 'opencode'
+        ? {
+            state: 'open',
+            failureCount: 5,
+            successCount: 0,
+            lastFailureTime: 1,
+            lastStateChange: 1,
+            halfOpenRequests: 0,
+            config: {
+              failureThreshold: 5,
+              resetTimeoutMs: 30_000,
+              halfOpenSuccessThreshold: 2,
+              countTimeoutsAsFailures: true,
+              countAuthFailuresAsFailures: false,
+              countRateLimitsAsFailures: true,
+              halfOpenMaxRequests: 3,
+            },
+          }
+        : undefined
+    );
+
+    await expect(getAvailableClis()).resolves.toEqual(['claude', 'gemini', 'codex']);
+  });
+
+  it('includes an authenticated healthy CLI when breaker state is unavailable', async () => {
+    const { getAvailableClis } = await import('./factory.js');
+    mocks.getCliCircuitBreakerSnapshot.mockImplementation((cli: CliName) => {
+      if (cli === 'opencode') {
+        throw new Error('breaker unavailable');
+      }
+      return undefined;
+    });
+
+    await expect(getAvailableClis()).resolves.toEqual(['claude', 'gemini', 'codex', 'opencode']);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/factory.ts
+++ b/packages/nexus-agents/src/cli-adapters/factory.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ICliAdapter, CliName, RoutingArmId, CliTransport } from './types.js';
-import { getTimeProvider } from '../core/index.js';
+import { createLogger, getTimeProvider } from '../core/index.js';
 import { collectApiRoutingArms } from '../adapters/auto-adapter.js';
 import { ClaudeCliAdapter } from './adapters/claude-adapter.js';
 import { GeminiCliAdapter } from './adapters/gemini-adapter.js';
@@ -21,6 +21,9 @@ import type { ILogger } from '../core/index.js';
 import type { ICliDetectionCache } from './cli-detection-cache.js';
 import { CliDetectionCache } from './cli-detection-cache.js';
 import { probeCli } from '../cli/cli-auth-probe.js';
+import { getCliCircuitBreakerSnapshot } from './cli-circuit-breaker.js';
+
+const factoryLogger = createLogger({ component: 'cli-adapter-factory' });
 
 /**
  * Configuration for creating a CLI adapter.
@@ -226,5 +229,23 @@ export async function getAvailableClis(cache?: ICliDetectionCache): Promise<CliN
       (r): r is PromiseFulfilledResult<{ cli: CliName; available: boolean }> =>
         r.status === 'fulfilled' && r.value.available
     )
+    .filter((r) => isCliServingForVoters(r.value.cli))
     .map((r) => r.value.cli);
+}
+
+function isCliServingForVoters(cli: CliName): boolean {
+  try {
+    const snapshot = getCliCircuitBreakerSnapshot(cli);
+    if (snapshot?.state !== 'open') {
+      return true;
+    }
+    factoryLogger.warn('CLI excluded from voter availability because circuit is open', {
+      cli,
+      circuitState: snapshot.state,
+      failureCount: snapshot.failureCount,
+    });
+    return false;
+  } catch {
+    return true;
+  }
 }


### PR DESCRIPTION
## Problem

Present + authenticated but not-serving CLIs still entered the voter round-robin. In the 2026-07-19 opencode-quota finding, an OpenRouter quota-dead OpenCode slot was assigned anyway and wasted ~73s in retries before failover.

## Fix

- Gate `getAvailableClis()` after the existing health/auth check by consulting the shared CLI circuit-breaker snapshot.
- Exclude only currently open/tripped CLI circuits from voter availability and log the excluded CLI.
- Fail open when breaker state is unknown or unavailable, so missing state never wrongly excludes a CLI.
- Treat OpenRouter-style `Key limit exceeded` as canonical rate-limit text so quota/rate-dead CLIs trip the breaker as serving failures.
- Preserve self-healing: half-open/closed circuits remain eligible, so recovered CLIs can re-enter selection.

## Validation

- `pnpm --filter nexus-agents typecheck`
- `pnpm --filter nexus-agents test -- src/cli-adapters/factory.test.ts src/cli-adapters/factory-serving-gate.test.ts src/cli-adapters/circuit-breaker.test.ts src/cli-adapters/cli-circuit-breaker.test.ts src/adapters/rate-limit-detector.test.ts`
- `pnpm lint`
- `npx tsx scripts/check-changeset.ts origin/main`