### PR TITLE
fix(codex-mcp): use supported approval policy

### DIFF
--- a/.changeset/calm-tools-agree.md
+++ b/.changeset/calm-tools-agree.md
@@ -1,0 +1,5 @@
+---
+'nexus-agents': patch
+---
+
+Use a supported non-interactive approval policy when the Codex MCP adapter starts a read-only task.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.test.ts
@@ -276,7 +276,7 @@ describe('CodexMcpAdapter', () => {
           prompt: 'Test task',
           model: 'o3-mini',
           sandbox: 'read-only',
-          'approval-policy': 'on-failure',
+          'approval-policy': 'never',
         },
       });
     });

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
@@ -173,7 +173,7 @@ export class CodexMcpAdapter extends BaseCliAdapter {
       : {
           ...baseArgs,
           sandbox: 'read-only' as const,
-          'approval-policy': 'on-failure' as const,
+          'approval-policy': 'never' as const,
         };
 
     const result = await this.client.callTool({


### PR DESCRIPTION
## Summary

- replace the obsolete Codex MCP `on-failure` approval policy with supported `never`
- retain the existing read-only sandbox and non-interactive behavior
- update the exact payload regression assertion
- add a patch changeset

## Verification

- focused Codex MCP adapter tests: 20 passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm changeset status`
- independent review: no findings
- host smoke progressed past configuration parsing; a separate request-timeout condition remains outside this focused fix

Closes #4348