### PR TITLE
docs+fix: archive the removed RESEARCH_PIPELINE doc and stop expert prompts citing it

### DIFF
--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+fix(experts): stop pointing the research and infrastructure experts at a removed subsystem
+
+Both expert prompts cited `docs/architecture/RESEARCH_PIPELINE.md` as a reference
+implementation — the research expert called it "the template for new research
+workflows". That subsystem (`research-pipeline.ts`, `runResearchPipeline`, the
+`nexus:research-pipeline` plugin) was deleted in #3492 / PR #3590, so the prompts
+were sending agents to a spec for code that no longer exists.
+
+The research expert now points at the live research-loop tools
+(`research_discover` → `research_analyze` → `research_synthesize` →
+`research_query`) plus `.rules/research.md` for the provenance invariants; the
+infrastructure expert now cites `ORCHESTRATOR_WORKFLOW_ENGINE.md` for staged data
+flow. Adds a regression test asserting no expert prompt cites the removed doc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,7 +129,6 @@ The scheduler is `run` / MetaOrchestrator: one entry point picks (and optionally
 | [ORCHESTRATOR_WORKFLOW_ENGINE.md](./architecture/ORCHESTRATOR_WORKFLOW_ENGINE.md) | Orchestrator vs WorkflowEngine | Canonical |
 | [ICTM_PATTERN.md](./architecture/ICTM_PATTERN.md)                                 | Dynamic sub-agent creation     | Canonical |
 | [MULTI_REPO_ORCHESTRATION.md](./architecture/MULTI_REPO_ORCHESTRATION.md)         | Cross-repo task coordination   | Canonical |
-| [RESEARCH_PIPELINE.md](./architecture/RESEARCH_PIPELINE.md)                       | Research-to-project runner     | Canonical |
 | [MEMORY_SYSTEM.md](./architecture/MEMORY_SYSTEM.md)                               | 7-type memory architecture     | Canonical |
 
 **How-to (composing & routing):**
@@ -223,10 +222,9 @@ The autonomic loops. Each maps to a shipped mechanism and sits at a declared run
 
 ### Self-configuring & self-optimizing
 
-| Document                                                    | Description                                   | Status    |
-| ----------------------------------------------------------- | --------------------------------------------- | --------- |
-| [MEMORY_SYSTEM.md](./architecture/MEMORY_SYSTEM.md)         | 7-type memory architecture (shared Knowledge) | Canonical |
-| [RESEARCH_PIPELINE.md](./architecture/RESEARCH_PIPELINE.md) | Research-to-project runner                    | Canonical |
+| Document                                            | Description                                   | Status    |
+| --------------------------------------------------- | --------------------------------------------- | --------- |
+| [MEMORY_SYSTEM.md](./architecture/MEMORY_SYSTEM.md) | 7-type memory architecture (shared Knowledge) | Canonical |
 
 ### Self-protecting (security)
 
@@ -447,6 +445,7 @@ Documents kept for historical reference only:
 | [archive/SECURITY_AUDIT_2026-01-23.md](./archive/SECURITY_AUDIT_2026-01-23.md) | Archived security audit                   | Current security docs                          |
 | [archive/consensus-vote-2026-01-17.md](./archive/consensus-vote-2026-01-17.md) | Archived consensus vote                   | Current consensus protocols                    |
 | [archive/system-review-2026-05-31.md](./archive/system-review-2026-05-31.md)   | Full 13-domain system review (epic #3143) | [ALIGNMENT_ROADMAP.md](./ALIGNMENT_ROADMAP.md) |
+| [archive/RESEARCH_PIPELINE.md](./archive/RESEARCH_PIPELINE.md)                 | Subsystem removed in #3492 (PR #3590)     | [ENTRYPOINTS.md](./ENTRYPOINTS.md)             |
 
 **Previously Archived/Removed:**
 

--- a/docs/archive/RESEARCH_PIPELINE.md
+++ b/docs/archive/RESEARCH_PIPELINE.md
@@ -1,9 +1,30 @@
-# Research-to-Project Pipeline
+# Research-to-Project Pipeline (removed)
 
-**Status:** Canonical
-**Issue:** [#1822](https://github.com/nexus-substrate/nexus-agents/issues/1822) (supersedes closed [#1731](https://github.com/nexus-substrate/nexus-agents/pull/1731))
-**Module:** `packages/nexus-agents/src/pipeline/research-pipeline.ts`
-**Plugin id:** `nexus:research-pipeline` (registered via `core-plugins.ts`)
+**Status:** Archived — the subsystem this document describes no longer exists.
+**Removed in:** [#3492](https://github.com/nexus-substrate/nexus-agents/issues/3492) (PR [#3590](https://github.com/nexus-substrate/nexus-agents/pull/3590), commit `fa9d7cbcc6`), on a 5/0 `consensus_vote` to REMOVE.
+**Originally:** [#1822](https://github.com/nexus-substrate/nexus-agents/issues/1822) (superseded closed [#1731](https://github.com/nexus-substrate/nexus-agents/pull/1731))
+
+> **Do not use this document as a guide.** `packages/nexus-agents/src/pipeline/research-pipeline.ts`, the
+> `runResearchPipeline` export, and the `nexus:research-pipeline` plugin id were all deleted. Everything below is
+> retained only as a historical record of what the subsystem was intended to do.
+
+## What replaced it
+
+The `research` pipeline template was retired first, in [#3488](https://github.com/nexus-substrate/nexus-agents/issues/3488): its `investigate` and `synthesize` stages had no stage implementation and the stage order was incoherent, so the template could never actually run. Research-classified tasks now fall back to the `general` / `dev` templates ([#3489](https://github.com/nexus-substrate/nexus-agents/issues/3489)), which already cover research → plan → vote.
+
+The complete-but-unwired `runResearchPipeline` subsystem ([#1711](https://github.com/nexus-substrate/nexus-agents/issues/1711)) was then removed as dead lineage — it had zero runtime call sites once its only consumer was retired. The capability is served today by:
+
+- **AdaptiveOrchestrator templates** — see `packages/nexus-agents/src/pipeline/templates.ts` (the removal rationale is recorded in a comment at the `research` entry).
+- **The MetaOrchestrator `research` strategy**, which routes to `run_pipeline`.
+- **The `research_discover` / `research_synthesize` MCP tools** for the discovery and synthesis halves.
+
+See [ENTRYPOINTS.md](../ENTRYPOINTS.md) for the current research surface.
+
+---
+
+## Historical record
+
+Everything below described the removed implementation as of 2026-04.
 
 ## Purpose
 

--- a/docs/getting-started/PLUGIN_INSTALL.md
+++ b/docs/getting-started/PLUGIN_INSTALL.md
@@ -73,5 +73,4 @@ Cache at `~/.claude/plugins/` is cleared automatically.
 
 - [AGENTS.md](../../AGENTS.md) — guidance for non-Claude agents
 - [docs/ENTRYPOINTS.md](../ENTRYPOINTS.md) — full CLI/MCP reference
-- [docs/architecture/RESEARCH_PIPELINE.md](../architecture/RESEARCH_PIPELINE.md) — research pipeline component
 - Epic [#1825](https://github.com/nexus-substrate/nexus-agents/issues/1825) — plugin integration

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/infrastructure-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/infrastructure-expert.ts
@@ -215,7 +215,7 @@ Respond with JSON matching this structure:
 ## Reference Implementation
 - **Sandbox + threat model**: \`docs/architecture/SECURITY.md\` — trust boundaries, isolation guarantees, CVE mitigations.
 - **MCP protocol contract**: \`docs/architecture/MCP_PROTOCOL.md\` — transport + capability surface; template for inter-system contracts.
-- **Pipeline architecture**: \`docs/architecture/RESEARCH_PIPELINE.md\` — staged data flow with explicit stage boundaries.
+- **Pipeline architecture**: \`docs/architecture/ORCHESTRATOR_WORKFLOW_ENGINE.md\` — staged data flow with explicit stage boundaries.
 - Always document the access path (SSH, OOB, console) and the fallback before recommending any infrastructure change.
 
 ## Output Guidance

--- a/packages/nexus-agents/src/agents/experts/expert-prompts/research-expert.ts
+++ b/packages/nexus-agents/src/agents/experts/expert-prompts/research-expert.ts
@@ -61,7 +61,8 @@ When analyzing research, consider the existing registry:
 
 ## Reference Implementation
 - **Research registry**: \`docs/research/RESEARCH_INDEX.md\` — the canonical index of every paper/technique/repo tracked. Every new finding must be added here.
-- **Pipeline spec**: \`docs/architecture/RESEARCH_PIPELINE.md\` — staged data flow (discover → evaluate → synthesize → align). Use as the template for new research workflows.
+- **Research loop surface**: \`research_discover\` → \`research_analyze\` → \`research_synthesize\` → \`research_query\` (schemas in \`docs/ENTRYPOINTS.md\`). Use these tools rather than hand-rolling a research workflow.
+- **Provenance invariants**: \`.rules/research.md\` — every merged claim must stay attributed to its source. Non-negotiable for synthesis output.
 - **Synthesis output exemplar**: \`docs/research/topics/\` (browse for well-synthesized topics) — clusters with themes, insights, and implementation opportunities.
 
 ## Output Guidance

--- a/packages/nexus-agents/src/agents/experts/reference-implementation.test.ts
+++ b/packages/nexus-agents/src/agents/experts/reference-implementation.test.ts
@@ -73,9 +73,18 @@ describe('Expert-specific reference cites', () => {
     expect(PM_EXPERT_BASE_PROMPT).toContain('Canonical Paths');
   });
 
-  it('research cites RESEARCH_INDEX + RESEARCH_PIPELINE', () => {
+  it('research cites RESEARCH_INDEX + the live research-loop surface', () => {
     expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('RESEARCH_INDEX.md');
-    expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('RESEARCH_PIPELINE.md');
+    expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('research_synthesize');
+    expect(RESEARCH_EXPERT_BASE_PROMPT).toContain('.rules/research.md');
+  });
+
+  it('no expert prompt cites the removed RESEARCH_PIPELINE.md (#3492)', () => {
+    // The subsystem was deleted in fa9d7cbcc6; pointing an expert at its doc
+    // sent agents to a spec for code that no longer exists.
+    for (const prompt of [RESEARCH_EXPERT_BASE_PROMPT, INFRASTRUCTURE_EXPERT_BASE_PROMPT]) {
+      expect(prompt).not.toContain('RESEARCH_PIPELINE.md');
+    }
   });
 
   it('security cites test-secrets + UNTRUSTED_INPUT_HARDENING', () => {


### PR DESCRIPTION
## Summary

A vestigial-code audit turned up a doc describing a subsystem that was deleted two months ago — and, more importantly, **two live expert prompts still pointing agents at it**.

`packages/nexus-agents/src/pipeline/research-pipeline.ts`, the `runResearchPipeline` export, and the `nexus:research-pipeline` plugin id were all removed in #3492 / PR #3590 (commit `fa9d7cbcc6`) on a 5/0 `consensus_vote`. `docs/architecture/RESEARCH_PIPELINE.md` was never updated and still read **`Status: Canonical`**.

## What this changes

**1. The doc** — moved to `docs/archive/RESEARCH_PIPELINE.md` with an `Archived` header recording what removed it and what serves the capability now (AdaptiveOrchestrator templates, the MetaOrchestrator `research` strategy, `research_discover`/`research_synthesize`). Original text kept below as a historical record.

**2. Index + inbound links** — dropped the two stale `Canonical` rows from `docs/README.md`, removed the stale link from `PLUGIN_INSTALL.md`, added the archive row.

**3. Expert prompts (the part that actually mattered).** Both cited the dead doc under *Reference Implementation*:

- `research-expert.ts:64` — *"staged data flow (discover → evaluate → synthesize → align). **Use as the template for new research workflows.**"*
- `infrastructure-expert.ts:218` — *"staged data flow with explicit stage boundaries."*

These are live prompts fed to agents, so every research/infrastructure expert invocation was being told to model its work on a spec for code that no longer exists. The research expert now points at the actual research-loop surface (`research_discover` → `research_analyze` → `research_synthesize` → `research_query`) plus `.rules/research.md` for the provenance invariants; the infrastructure expert now cites `ORCHESTRATOR_WORKFLOW_ENGINE.md`.

## Why it wasn't caught

The `Canonical Index Check` gate verifies a doc **is** indexed, not that its content is accurate — so a doc can claim `Status: Canonical` about deleted code indefinitely. The new regression test (`no expert prompt cites the removed RESEARCH_PIPELINE.md`) closes the narrower hole for expert prompts.

## Verification

- `npx vitest run src/agents/experts/` — **28 files, 692 tests passed**.
- `npx tsx scripts/check-docs-indexed.ts` — 0 unindexed, 0 stale references.
- `markdownlint-cli2` clean on all three touched markdown files.
- `eslint` clean; patch changeset added.
- `grep -rn RESEARCH_PIPELINE` — remaining hits are only the archived doc itself, the `CHANGELOG.md` removal entry, and an `export-contracts.test.ts` comment about the removal, all correct.

Found during backlog grooming alongside #4323 (closed — same removed subsystem, stale bug report).