### PR TITLE
fix(pipeline,mcp): fail closed at the three source sites (#4362)

### DIFF
--- a/.changeset/tall-pears-sniff.md
+++ b/.changeset/tall-pears-sniff.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': patch
+---
+
+fix: stop three fail-open sites reporting failed work as success (#4362)
+
+Increment 1 of the unanimous Option C decision on #4351. Each site let a failure
+that was detected somewhere in the stack reach the caller as a success:
+
+- **`pipeline/pipeline-graph.ts`** — `createNodeHandler` discarded
+  `StageOutput.success`/`.error`, so a stage that failed cleanly was
+  indistinguishable from one that succeeded. It now throws a `StageFailureError`,
+  routing the failure through the graph executor's existing channel
+  (`NodeResult.status: 'failed'`).
+- **`pipeline/graph-pipeline-runner.ts`** — `executeAndReport` derived `success`
+  from "the BSP loop returned", never inspecting `nodeResults`. It now reports
+  `success: false` when any node failed, names the failed stage ids, and keeps the
+  partial `finalState`.
+- **`mcp/tools/run-tool.ts`** — `executeRunBody` wrapped any resolved dispatch in
+  `toolSuccess`. It now returns a `business` error when the engine reported its own
+  failure (`success: false` from the pipeline engines, `completed: false` from the
+  dev pipeline), and the async path rejects so the job records `failed` rather than
+  `complete`. A `rejected` consensus verdict stays a success — it is the answer the
+  caller asked for, not a fault.
+- **`mcp/tools/consensus-vote.ts`** — `dispatchAsyncConsensusVote` passed
+  `handleConsensusVote`'s `{ ok: false }` straight into `runAsJob`, which records
+  `complete` for anything that resolves; a dead voter panel therefore produced a job
+  a caller read as successful. It now rejects, mirroring the sync path.
+
+The throw-based mechanism was chosen by `consensus_vote` (`higher_order`, 7/0) over
+adding a parallel error key to graph state. No behaviour changes on any wired
+template: every in-tree template is a linear chain, and the only production producer
+of `StageOutput` already wrote `null` on failure.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-async-dispatch.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-async-dispatch.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for consensus_vote's async-mode dispatch envelope (#4362).
+ *
+ * `dispatchAsyncConsensusVote` handed `handleConsensusVote` — which resolves the
+ * `{ ok, error } | { ok: true, value }` shape — straight into `runAsJob`'s `run`
+ * callback with no transform. `runAsJob` records `complete` whenever `run`
+ * RESOLVES, so a vote that failed (`ok: false`) landed as a `complete` job: a
+ * caller polling `get_job_result` saw success and never looked at the payload.
+ * The sync sibling has always converted `ok: false` into a structured error.
+ *
+ * Lives in its own file because reaching the failure path means mocking
+ * `collectRealVotes`, and consensus-vote.test.ts exercises the real collector.
+ *
+ * @module mcp/tools/consensus-vote-async-dispatch.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AgentVoteResult, VoterRole } from '../../cli/vote-types.js';
+
+// Every voter errors — the realistic shape of a dead voter panel (expired auth,
+// adapter outage), and the exact input for which `handleConsensusVote` returns
+// `{ ok: false }` rather than manufacturing a "rejected" verdict (#1552).
+const collectRealVotesMock = vi.fn<(opts: { roles: readonly VoterRole[] }) => Promise<unknown>>();
+vi.mock('../../cli/voter-agents.js', () => ({
+  collectRealVotes: (opts: { roles: readonly VoterRole[] }): Promise<unknown> =>
+    collectRealVotesMock(opts),
+}));
+
+// Pass the registered callback through untouched so the test can invoke it.
+vi.mock('../middleware/tool-wrapper.js', () => ({
+  wrapToolWithTimeout: (_name: string, fn: unknown) => fn,
+  toSdkCallback: (fn: unknown) => fn,
+  toSdkCallbackWithBudgetCheck: (fn: unknown) => fn,
+  getToolTimeout: () => 900_000,
+}));
+vi.mock('../middleware/secure-handler.js', () => ({
+  createSecureHandler:
+    (fn: (args: unknown, ctx: unknown) => unknown) => (args: unknown, ctx: unknown) =>
+      fn(args, ctx),
+}));
+
+import { registerConsensusVoteTool, unwrapVoteOrThrow } from './consensus-vote.js';
+import { readJobResult } from '../jobs/job-result-store.js';
+import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
+import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
+
+interface CapturedToolResult {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+function erroredVotes(roles: readonly VoterRole[]): AgentVoteResult[] {
+  return roles.map((role) => ({
+    role,
+    vote: { decision: 'abstain' as const, reasoning: 'adapter unauthorized', confidence: 0 },
+    processingTimeMs: 1,
+    source: 'error' as const,
+    error: 'adapter unauthorized',
+  }));
+}
+
+/** Registers the tool against a mock server and returns the captured callback. */
+function captureHandler(): (args: unknown, ctx: unknown) => Promise<CapturedToolResult> {
+  let captured: ((args: unknown, ctx: unknown) => Promise<CapturedToolResult>) | undefined;
+  const mockServer = {
+    registerTool: (_name: string, _schema: unknown, handler: unknown) => {
+      captured = handler as (args: unknown, ctx: unknown) => Promise<CapturedToolResult>;
+    },
+  };
+  registerConsensusVoteTool(mockServer as never, {
+    rateLimiter: { tryConsume: () => ({ allowed: true, remaining: 99 }) } as never,
+  });
+  if (captured === undefined) throw new Error('handler not registered');
+  return captured;
+}
+
+const CTX = {
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  requestContext: {},
+};
+
+describe('consensus_vote async dispatch fails closed (#4362)', () => {
+  let tmpDir: string;
+  const originalDataDir = process.env['NEXUS_DATA_DIR'];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'nexus-vote-async-'));
+    process.env['NEXUS_DATA_DIR'] = tmpDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    collectRealVotesMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
+    resetNexusDataDirCache();
+    resetJobConcurrency();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function dispatch(): Promise<string> {
+    const handler = captureHandler();
+    const result = await handler(
+      { proposal: 'ship the thing', quickMode: true, mode: 'async' },
+      CTX
+    );
+    const env = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    expect(env['status']).toBe('pending');
+    const jobId = env['jobId'] as string;
+    // The background run is fire-and-forget — poll the sidecar the way a caller
+    // would rather than guessing a settle delay.
+    for (let i = 0; i < 100 && readJobResult(jobId)?.status === 'pending'; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    return jobId;
+  }
+
+  it('records a failed job when every voter errored', async () => {
+    collectRealVotesMock.mockImplementation((opts: { roles: readonly VoterRole[] }) =>
+      Promise.resolve(erroredVotes(opts.roles))
+    );
+
+    expect(readJobResult(await dispatch())?.status).toBe('failed');
+  });
+
+  it('carries the failure reason into the job record', async () => {
+    collectRealVotesMock.mockImplementation((opts: { roles: readonly VoterRole[] }) =>
+      Promise.resolve(erroredVotes(opts.roles))
+    );
+
+    const record = readJobResult(await dispatch());
+    expect(JSON.stringify(record)).toContain('voters failed');
+  });
+});
+
+// The success half of the transform is asserted directly: exercising it through
+// the dispatcher would stand up the whole memory substrate (CompositeRouter and
+// its on-disk backends), which is neither fast nor side-effect-free in a unit
+// test. The failure half is covered end-to-end above.
+describe('unwrapVoteOrThrow (#4362)', () => {
+  type VotePromise = Parameters<typeof unwrapVoteOrThrow>[0];
+
+  it('passes an ok result through untouched, so the job records complete', async () => {
+    const ok = { ok: true as const, value: { proposal: 'p' } };
+
+    await expect(unwrapVoteOrThrow(Promise.resolve(ok) as unknown as VotePromise)).resolves.toBe(
+      ok
+    );
+  });
+
+  it('rejects with the vote error, so runAsJob records failed', async () => {
+    const failed = { ok: false as const, error: 'All 3 voters failed' };
+
+    await expect(
+      unwrapVoteOrThrow(Promise.resolve(failed) as unknown as VotePromise)
+    ).rejects.toThrow('All 3 voters failed');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -890,6 +890,23 @@ type ConsensusVoteToolResponse = ToolResult;
  * Concurrency cap is enforced via `tryAcquire('consensus_vote')`
  * (default 2; voting is 7-fan-out so caps multiply adapter load fast).
  */
+/**
+ * Reject when the vote failed, so `runAsJob` records the job `failed` rather
+ * than `complete` (#4362). Increment 2 (#4363) folds this fail-closed check into
+ * `runAsJob` itself for every caller.
+ *
+ * Exported so the transform can be asserted without standing up a live voter
+ * panel (the success path initializes the whole memory substrate).
+ * @internal
+ */
+export async function unwrapVoteOrThrow(
+  pending: ReturnType<typeof handleConsensusVote>
+): Promise<Awaited<ReturnType<typeof handleConsensusVote>>> {
+  const result = await pending;
+  if (!result.ok) throw new Error(result.error);
+  return result;
+}
+
 function dispatchAsyncConsensusVote(
   deps: ConsensusVoteDeps,
   args: import('./consensus-vote-types.js').ConsensusVoteInput
@@ -906,7 +923,12 @@ function dispatchAsyncConsensusVote(
     input: args,
     idempotencyKey: args.idempotencyKey,
     freshJobId: () => `job-vote-${randomUUID()}`,
-    run: (_jobId, input) => handleConsensusVote(deps, input),
+    // #4362: `handleConsensusVote`'s `{ ok: false }` used to flow into the job
+    // record verbatim, and `runAsJob` records `complete` for anything its `run`
+    // callback RESOLVES — so a dead voter panel produced a job a caller polling
+    // `get_job_result` read as a success. Reject instead, mirroring the sync
+    // sibling's `toolStructuredError` on the same condition.
+    run: (_jobId, input) => unwrapVoteOrThrow(handleConsensusVote(deps, input)),
     ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });
 }

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -24,6 +24,30 @@ vi.mock('./dev-pipeline-tool.js', () => ({
     runDevPipelineForGoalMock(goal, trustTier),
 }));
 
+// #4362: drive the pipeline executor's reported success/failure. run-tool only
+// imports runPipelineForGoal from this module.
+interface FakePipelineResult {
+  success: boolean;
+  templateId: string;
+  stepsExecuted: number;
+  durationMs: number;
+  finalState: Record<string, unknown>;
+  error?: string;
+}
+const runPipelineForGoalMock = vi.fn(
+  (_goal: string, _logger?: unknown): Promise<FakePipelineResult> =>
+    Promise.resolve({
+      success: true,
+      templateId: 'general',
+      stepsExecuted: 3,
+      durationMs: 5,
+      finalState: {},
+    })
+);
+vi.mock('./pipeline-tool.js', () => ({
+  runPipelineForGoal: (goal: string, logger?: unknown) => runPipelineForGoalMock(goal, logger),
+}));
+
 // #4042: capture the gatewayAdapters threaded into the consensus executor. Keep
 // every other consensus-vote export real (run-tool only imports runConsensusForGoal).
 const runConsensusForGoalMock = vi.fn((_goal: string, _logger?: unknown, _gw?: unknown) =>
@@ -325,6 +349,7 @@ describe('run async dispatch (execute:true, #3732)', () => {
   interface CapturedToolResult {
     isError?: boolean;
     content: Array<{ type: string; text: string }>;
+    _meta?: Record<string, unknown>;
   }
 
   /** Registers the tool against a mock server and returns the captured callback. */
@@ -347,6 +372,16 @@ describe('run async dispatch (execute:true, #3732)', () => {
 
   function envelope(result: CapturedToolResult): Record<string, unknown> {
     return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+  }
+
+  /**
+   * The structured error envelope, which `toolStructuredError` puts in `_meta`
+   * (content[0].text carries only the bare message, so it is not JSON).
+   */
+  function errorEnvelope(result: CapturedToolResult): Record<string, unknown> | undefined {
+    const meta = result._meta;
+    if (meta === undefined) return undefined;
+    return Object.values(meta)[0] as Record<string, unknown> | undefined;
   }
 
   beforeEach(() => {
@@ -413,5 +448,93 @@ describe('run async dispatch (execute:true, #3732)', () => {
     await new Promise((r) => setImmediate(r));
     const record = readJobResult(jobId);
     expect(record?.status).toBe('complete');
+  });
+
+  // #4362 (increment 1 of the #4351 Option C decision): `executeRunBody` wrapped
+  // ANY resolved dispatch in `toolSuccess`, so an engine that ran to completion
+  // while reporting its own business failure was handed back as a success — and,
+  // on the async path, recorded as a `complete` job. Only a THROWN dispatch error
+  // was ever surfaced.
+  describe('engine-reported failure is not a tool success (#4362)', () => {
+    it('surfaces a dev-pipeline that did not complete as a structured error', async () => {
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: 'plan',
+        tasks: [],
+        voteIterations: 1,
+        qaIterations: 0,
+        securityPassed: false,
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(errorEnvelope(result)?.['errorCategory']).toBe('business');
+    });
+
+    it('surfaces a pipeline that reported success:false as a structured error', async () => {
+      runPipelineForGoalMock.mockResolvedValueOnce({
+        success: false,
+        templateId: 'general',
+        stepsExecuted: 2,
+        durationMs: 5,
+        error: 'stage plan failed',
+        finalState: {},
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'analyze the repository',
+        forceStrategy: 'pipeline',
+        execute: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(errorEnvelope(result)?.['message']).toContain('stage plan failed');
+    });
+
+    it('records a failed job (not complete) when the backgrounded engine fails', async () => {
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: 'plan',
+        tasks: [],
+        voteIterations: 1,
+        qaIterations: 0,
+        securityPassed: false,
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+        dispatch: 'async',
+      });
+      const jobId = envelope(result)['jobId'] as string;
+      await new Promise((r) => setImmediate(r));
+      expect(readJobResult(jobId)?.status).toBe('failed');
+    });
+
+    it('still reports a successful engine run as a tool success', async () => {
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(envelope(result)['executed']).toBe(true);
+    });
+
+    it('leaves a rejected consensus vote a success — a verdict is not a failure', async () => {
+      runConsensusForGoalMock.mockResolvedValueOnce({ result: { outcome: 'rejected' } });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'should we adopt A or B',
+        forceStrategy: 'consensus',
+        execute: true,
+      });
+      expect(result.isError).toBeFalsy();
+    });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -378,6 +378,33 @@ export async function executeGoal(
 }
 
 /**
+ * Detect a business failure an engine reported in its own result, or null when
+ * the run is honest-success (#4362).
+ *
+ * The MetaDispatcher types `DispatchResult.result` as `unknown`, so this reads
+ * the two shapes the wired executors actually produce:
+ *
+ * - `AdaptiveOrchestratorResult` (pipeline / research) — `success: false`
+ * - `DevPipelineResult` (dev-pipeline) — `completed: false`
+ *
+ * `ExtendedVotingResult` (consensus) is deliberately absent: a `rejected`
+ * outcome is the verdict the caller asked for, not an engine fault.
+ */
+function detectEngineFailure(result: unknown): string | null {
+  if (typeof result !== 'object' || result === null) return null;
+  const record = result as Record<string, unknown>;
+
+  if (record['success'] === false) {
+    const detail = typeof record['error'] === 'string' ? record['error'] : 'no error message';
+    return `Engine reported failure: ${detail}`;
+  }
+  if (record['completed'] === false) {
+    return 'Engine reported failure: the dev pipeline did not complete';
+  }
+  return null;
+}
+
+/**
  * Run the `execute: true` body — dispatch the selected strategy via the
  * MetaDispatcher and shape the `ToolResult`. The sync path awaits this inline;
  * the async dispatcher backgrounds it via {@link runAsJob} (#3732). Catches the
@@ -404,6 +431,17 @@ async function executeRunBody(
       strategy: exec.strategy,
       durationMs: exec.durationMs,
     });
+    // #4362: a dispatch that RESOLVED used to be an unconditional success, so an
+    // engine reporting its own failure was handed back as `toolSuccess` — and,
+    // backgrounded, recorded as a `complete` job. Only a throw was surfaced.
+    const engineFailure = detectEngineFailure(exec.result);
+    if (engineFailure !== null) {
+      logger.warn('run: engine reported failure', {
+        decisionId: exec.decisionId,
+        strategy: exec.strategy,
+      });
+      return toolStructuredError({ errorCategory: 'business', message: engineFailure });
+    }
     return toolSuccess(JSON.stringify(exec, null, 2));
   } catch (err) {
     const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
@@ -416,6 +454,29 @@ async function executeRunBody(
       message: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+/**
+ * Async-path wrapper around {@link executeRunBody} that rejects on an error
+ * envelope (#4362).
+ *
+ * `runAsJob` records `complete` whenever its `run` callback RESOLVES, so
+ * returning a structured error would still land a `complete` job — the caller
+ * would poll `get_job_result`, see success, and never look at the payload.
+ * Rejecting routes it through `writeJobFailed`. Increment 2 (#4363) folds this
+ * into `runAsJob` itself as the fail-closed default for every caller.
+ */
+async function executeRunBodyOrThrow(
+  input: RunInput,
+  logger: ILogger,
+  trustTier?: string,
+  gatewayAdapters?: readonly IModelAdapter[]
+): Promise<ToolResult> {
+  const result = await executeRunBody(input, logger, trustTier, gatewayAdapters);
+  if (result.isError === true) {
+    throw new Error(result.content[0]?.text ?? 'run failed');
+  }
+  return result;
 }
 
 async function runHandler(
@@ -444,7 +505,7 @@ async function runHandler(
         toolName: 'run',
         input,
         freshJobId: () => `rn-${randomUUID()}`,
-        run: () => executeRunBody(input, logger, trustTier, gatewayAdapters),
+        run: () => executeRunBodyOrThrow(input, logger, trustTier, gatewayAdapters),
         logger,
       });
     }

--- a/packages/nexus-agents/src/pipeline/graph-pipeline-runner.test.ts
+++ b/packages/nexus-agents/src/pipeline/graph-pipeline-runner.test.ts
@@ -10,6 +10,7 @@ import { DEV_PIPELINE_TEMPLATE } from './templates.js';
 import { createDevStageRegistry } from './stage-wrappers.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
 import type { PipelineTemplate } from './stage-types.js';
+import type { StageRegistry } from './pipeline-graph.js';
 
 // Mock pipeline-observability to avoid event bus side effects
 vi.mock('./pipeline-observability.js', () => ({
@@ -111,5 +112,124 @@ describe('runGraphPipeline', () => {
     const result = await runGraphPipeline('My task', DEV_PIPELINE_TEMPLATE, registry);
 
     expect(result.finalState[K.TASK]).toBe('My task');
+  });
+});
+
+// #4362 (increment 1 of the unanimous Option C decision on #4351). Two fail-open
+// links used to swallow stage failure end to end: `createNodeHandler` discarded
+// `StageOutput.success`/`.error`, and `executeAndReport` derived `success` purely
+// from "the BSP loop returned", never inspecting `nodeResults`. A pipeline whose
+// stages all failed therefore reported `success: true`.
+//
+// Mechanism chosen by `consensus_vote` (higher_order, 7/0): signal through the
+// executor's ONE existing failure channel (`NodeResult.status`) rather than adding
+// a parallel error key to graph state.
+describe('stage failure propagation (#4362)', () => {
+  /** Minimal single-stage template + registry with a stage that fails. */
+  function failingSetup(error: string): { template: PipelineTemplate; registry: StageRegistry } {
+    const template: PipelineTemplate = { id: 'failing', name: 'Failing', stages: ['boom'] };
+    const registry: StageRegistry = new Map([
+      [
+        'boom',
+        {
+          id: 'boom',
+          name: 'Boom',
+          execute: () =>
+            Promise.resolve({
+              stateKey: K.RESEARCH,
+              value: null,
+              durationMs: 1,
+              success: false,
+              error,
+            }),
+        },
+      ],
+    ]);
+    return { template, registry };
+  }
+
+  it('reports success: false when a stage returns success: false', async () => {
+    const { template, registry } = failingSetup('adapter rejected the request');
+
+    const result = await runGraphPipeline('Task', template, registry);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('names the failed stage and surfaces its error message', async () => {
+    const { template, registry } = failingSetup('adapter rejected the request');
+
+    const result = await runGraphPipeline('Task', template, registry);
+
+    expect(result.error).toContain('boom');
+    expect(result.error).toContain('adapter rejected the request');
+  });
+
+  it('keeps the partial finalState from stages that did succeed', async () => {
+    const template: PipelineTemplate = {
+      id: 'partial',
+      name: 'Partial',
+      stages: ['ok', 'boom'],
+    };
+    const registry: StageRegistry = new Map([
+      [
+        'ok',
+        {
+          id: 'ok',
+          name: 'Ok',
+          execute: () =>
+            Promise.resolve({ stateKey: K.PLAN, value: 'planned', durationMs: 1, success: true }),
+        },
+      ],
+      [
+        'boom',
+        {
+          id: 'boom',
+          name: 'Boom',
+          execute: () =>
+            Promise.resolve({
+              stateKey: K.RESEARCH,
+              value: null,
+              durationMs: 1,
+              success: false,
+              error: 'nope',
+            }),
+        },
+      ],
+    ]);
+
+    const result = await runGraphPipeline('Task', template, registry);
+
+    expect(result.success).toBe(false);
+    // The failure must not throw away what earlier stages produced — callers
+    // inspect finalState to see how far the run got.
+    expect(result.finalState[K.PLAN]).toBe('planned');
+  });
+
+  it('does not write the failed stage’s state key', async () => {
+    // A thrown handler contributes `stateUpdates: {}`, so the key keeps its
+    // registered defaultValue rather than the `null` that stage-wrappers’
+    // `failOutput` would have written. Every in-tree template is a linear
+    // START→…→END chain (no template populates `edges`), so no stage can
+    // observe a stale prior-iteration value here. Pinned so the semantics are
+    // documented rather than accidental.
+    const { template, registry } = failingSetup('nope');
+
+    const result = await runGraphPipeline('Task', template, registry);
+
+    expect(result.finalState[K.RESEARCH]).toBe('');
+  });
+
+  it('still reports success for a template that never sets COMPLETED', async () => {
+    // Regression against the design the #4351 panel rejected: deriving success
+    // from `finalState.completed` would fail-wrong on every dev/general/
+    // greenfield run, because those templates never write that key.
+    const stages = createMockStages();
+    const registry = createDevStageRegistry(stages);
+
+    const result = await runGraphPipeline('Build feature', DEV_PIPELINE_TEMPLATE, registry);
+
+    expect(result.finalState[K.COMPLETED]).toBeFalsy();
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/pipeline/graph-pipeline-runner.ts
+++ b/packages/nexus-agents/src/pipeline/graph-pipeline-runner.ts
@@ -10,7 +10,7 @@
 
 import { createLogger, getTimeProvider } from '../core/index.js';
 import { executeGraph } from '../orchestration/graph/graph-executor.js';
-import type { CompiledGraph } from '../orchestration/graph/graph-types.js';
+import type { CompiledGraph, NodeResult } from '../orchestration/graph/graph-types.js';
 import { compilePipelineGraph } from './pipeline-graph.js';
 import type { PipelineTemplate } from './stage-types.js';
 import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
@@ -120,6 +120,27 @@ async function executeAndReport(
     return buildError(template.id, result.error.message, startTime);
   }
 
+  // #4362: `result.ok` only says the BSP loop returned. The executor absorbs a
+  // failed node into an `ok` result (it records `NodeResult.status: 'failed'`
+  // and keeps going), so reporting success on `result.ok` alone made every
+  // failed stage invisible to callers. Read the node results instead —
+  // template-agnostic, unlike a `finalState.completed` predicate, which would
+  // fail-wrong on the dev/general/greenfield templates that never set that key.
+  const failures = describeFailedNodes(result.value.nodeResults);
+  if (failures !== null) {
+    emitPipelineStageEvent(template.id, 'pipeline', 'failed', { error: failures });
+    return {
+      success: false,
+      templateId: template.id,
+      stepsExecuted: result.value.stepsExecuted,
+      durationMs,
+      // Keep whatever earlier stages produced — callers inspect finalState to
+      // see how far the run got before it failed.
+      finalState: result.value.finalState,
+      error: failures,
+    };
+  }
+
   emitPipelineStageEvent(template.id, 'pipeline', 'completed', { durationMs });
   return {
     success: true,
@@ -128,6 +149,19 @@ async function executeAndReport(
     durationMs,
     finalState: result.value.finalState,
   };
+}
+
+/**
+ * Summarize the failed nodes of a graph run, or null when every node succeeded.
+ *
+ * Reports only what each node already recorded — stage errors can embed command
+ * output, so this must not widen the message beyond `NodeResult.error`.
+ */
+function describeFailedNodes(nodeResults: readonly NodeResult[]): string | null {
+  const failed = nodeResults.filter((n) => n.status === 'failed');
+  if (failed.length === 0) return null;
+  const detail = failed.map((n) => `${n.nodeId}: ${n.error ?? 'no error message'}`).join('; ');
+  return `${String(failed.length)} stage(s) failed — ${detail}`;
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/pipeline/pipeline-graph.ts
+++ b/packages/nexus-agents/src/pipeline/pipeline-graph.ts
@@ -30,6 +30,27 @@ export interface PipelineGraphResult {
 /** Map of stage ID → stage implementation. */
 export type StageRegistry = ReadonlyMap<string, IPipelineStage>;
 
+/**
+ * Thrown by a node handler when its stage reported `success: false` (#4362).
+ *
+ * The graph executor has exactly one failure channel — it catches a thrown
+ * handler and records the node as `NodeResult.status: 'failed'` with this
+ * message. Throwing routes stage failure through that existing channel instead
+ * of adding a second, parallel one in graph state (`consensus_vote`,
+ * `higher_order`, 7/0 on #4362).
+ */
+export class StageFailureError extends Error {
+  constructor(
+    readonly stageId: string,
+    stageError: string | undefined
+  ) {
+    // Carries only what the stage already reported — stage errors can embed
+    // command output, so this must not widen the message beyond `output.error`.
+    super(`Stage '${stageId}' failed: ${stageError ?? 'no error message'}`);
+    this.name = 'StageFailureError';
+  }
+}
+
 // ============================================================================
 // Graph Compilation
 // ============================================================================
@@ -146,6 +167,14 @@ function createNodeHandler(
     };
 
     const output = await stage.execute(context);
+    // #4362: `output.success`/`output.error` used to be discarded here, so a
+    // stage that failed cleanly (returned rather than threw) was indistinguishable
+    // from one that succeeded — and every caller up the chain reported success.
+    // Throwing hands the failure to the executor's own channel; it records this
+    // node `status: 'failed'` with the message below and drops its stateUpdates.
+    if (!output.success) {
+      throw new StageFailureError(stage.id, output.error);
+    }
     return { [output.stateKey]: output.value };
   };
 }


### PR DESCRIPTION
Closes #4362. Increment 1 of the unanimous Option C decision on #4351.

Three sites let a failure that had **already been detected** reach the caller as a success.

## The chain

`createNodeHandler` (`pipeline/pipeline-graph.ts`) did:

```ts
const output = await stage.execute(context);
return { [output.stateKey]: output.value };   // output.success and output.error dropped
```

so a stage that failed cleanly was indistinguishable from one that succeeded. Downstream, `executeAndReport` derived `success` from `result.ok` — which only says the BSP loop returned. Verified with a read-only trace: `executeGraph` **never throws and never returns `err(...)` for a node failure**; `executeSingleNode` catches a throwing handler and records `NodeResult.status: 'failed'` while the overall call still resolves `ok(...)`. Nothing between the stage and the caller ever looked at `nodeResults`.

Two MCP tools then repackaged that as success:

- `executeRunBody` wrapped **any** resolved dispatch in `toolSuccess` — only a *thrown* dispatch error was surfaced
- `dispatchAsyncConsensusVote` handed `handleConsensusVote`'s `{ok: false}` straight to `runAsJob`, which records `complete` for anything its callback resolves, so a dead voter panel produced a job a caller read as successful

## The fix

1. **`pipeline-graph.ts`** — `createNodeHandler` throws `StageFailureError` on `output.success === false`
2. **`graph-pipeline-runner.ts`** — `executeAndReport` derives `success` from `nodeResults`, names the failed stage ids, keeps the partial `finalState`
3. **`run-tool.ts`** — `executeRunBody` returns a `business` error when the engine reported its own failure; the async path rejects so the job records `failed`
4. **`consensus-vote.ts`** — the async `run` callback rejects on `ok: false`, mirroring the sync sibling

A `rejected` consensus verdict deliberately stays a success — that is the answer the caller asked for, not a fault.

## Mechanism decided by vote

`consensus_vote` (`higher_order`, live 7-voter panel, **7/0 unanimous**) chose throwing over adding a reserved `stageFailures` key to graph state. The executor already has **one** canonical failure channel; a state key would be a second, parallel representation — Scope Steward classified it `OVER_ENGINEERING`, Security noted a state channel would be in-band and forgeable by a template, whereas `NodeResult.status` is written only by the executor.

The naive `finalState.completed === false` predicate named in the issue body was rejected earlier and is regression-tested here: `dev`/`general`/`greenfield` never set that key, so it would fail-wrong on every such run. Reading `nodeResults` is template-agnostic.

## Why this is behaviour-preserving on real runs

The Contrarian gated approval on whether any template routes on a failed stage's state key, since a thrown handler contributes `stateUpdates: {}` instead of the `null` `failOutput` would have written. Checked: **`routerKey` has exactly one occurrence in the tree — its own type declaration** at `pipeline/stage-types.ts:66`. No template populates `edges`, so every pipeline is a linear START→…→END chain and no stage can observe the dropped write. `stage-wrappers.ts` is also the only production producer of `StageOutput`, and its `failOutput` already wrote `null`. Pinned by a test either way.

## Verification

- Red/green per site: 4 red → green in `graph-pipeline-runner.test.ts`, 3 red → green in `run-tool.test.ts`, 1 red → green in the new `consensus-vote-async-dispatch.test.ts`
- Full package suite **27698 passed**, 1 skipped — no downstream churn, which is itself the finding: nothing had ever asserted on the fail-open
- `pnpm typecheck` ✓, `pnpm lint` ✓

## Follow-up

Increment 2 (#4363) folds the fail-closed check into `runAsJob` itself so every caller gets it by default; the two local `*OrThrow` wrappers added here are its explicit precursors and are referenced from that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)