### PR TITLE
fix(cli-adapters): give the voter serving-gate a failure signal to read (#4330)

### DIFF
--- a/.changeset/warm-melons-repeat.md
+++ b/.changeset/warm-melons-repeat.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): give the voter serving-gate a failure signal to read (#4330)
+
+The circuit-breaker serving-gate shipped in 2.173.6 (#4325) could never exclude a
+quota-dead CLI, because nothing on the voter path fed the registry it reads.
+
+`isCliServingForVoters` excludes a CLI only when
+`getCliCircuitBreakerSnapshot(cli)?.state === 'open'`, reading
+`defaultCliCircuitBreakerRegistry`. But `BaseCliAdapter.executeWithRetry` passed no
+`circuitBreaker` into `executeCliRetryLoop`, making its `recordFailure` call
+unreachable for every subprocess CLI (claude, codex, opencode). The snapshot stayed
+`undefined` forever and the gate took its fail-open branch on every panel — the
+observed symptom being opencode failing `Key limit exceeded` on all 64 panels of a
+v6 eval run while remaining in the roster.
+
+`BaseCliAdapter` now resolves its breaker from the shared registry and records both
+failures (via the retry loop) and successes. Recording successes is what keeps the
+threshold meaning "consecutive failures" — without it a long-lived process would
+accumulate scattered blips and eventually evict a healthy CLI. Every circuit state
+change is now logged, so a CLI dropping out of a panel roster leaves a trail.
+
+No new gate logic was needed: `resolveDiverseAdapters` already re-resolves
+availability once per panel, so with the signal present a CLI that trips during
+panel N is excluded from panel N+1 in the same process.

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -40,6 +40,7 @@ import { CLI_VERSION_REQUIREMENTS, DEFAULT_CAPABILITIES } from './types.js';
 import { getTimeoutForTaskAuto } from './cli-timeout-profiles.js';
 import { CapacityTracker, createCapacityTracker } from './capacity-tracker.js';
 import { executeCliRetryLoop } from './cli-retry-loop.js';
+import { getDefaultCliCircuitBreakerRegistry } from './cli-circuit-breaker.js';
 
 const execAsync = promisify(exec);
 
@@ -178,16 +179,29 @@ export abstract class BaseCliAdapter implements ICliAdapter {
     task: CliTask,
     opts: ResolvedExecutionOptions
   ): Promise<Result<CliResponse, CliError>> {
+    // #4330: this used to pass no breaker, which made the `recordFailure` in
+    // `executeCliRetryLoop` unreachable for every subprocess CLI. The voter
+    // serving-gate reads exactly this registry, so a quota-dead CLI's snapshot
+    // stayed `undefined` and the gate fail-opened on every panel — #4325's
+    // exclusion could never fire because nothing produced the signal.
+    const circuitBreaker = getDefaultCliCircuitBreakerRegistry().getBreaker(this.name);
     const result = await executeCliRetryLoop(() => this.executeTask(task, opts), {
       maxRetries: opts.maxRetries,
       allowRetry: this.shouldOuterRetry(opts),
       baseDelayMs: 1_000,
       maxDelayMs: 16_000,
+      circuitBreaker,
       cli: this.name,
       logger: this.logger,
     });
 
     if (result.ok) {
+      // Recording the success is the caller's job (`executeCliRetryLoop` only
+      // records failures — see its test), and it matters: in the closed state
+      // `recordSuccess` zeroes the failure count, which is what makes the
+      // threshold mean "consecutive failures". Without it a long-lived process
+      // accumulates scattered blips and eventually evicts a healthy CLI.
+      circuitBreaker.recordSuccess();
       this.recordUsage(result.value.response);
       this.logger.info('Task executed successfully', {
         cli: this.name,

--- a/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-circuit-breaker.ts
@@ -89,6 +89,21 @@ const DEFAULT_CONFIG: Required<CliCircuitBreakerConfig> = {
 };
 const defaultCliCircuitBreakerRegistry = new CircuitBreakerRegistry();
 
+// #4330: the shared registry now gates voter-panel availability, so a CLI can
+// vanish from a panel roster because its circuit opened. Log every transition —
+// otherwise the next person debugging a "missing voter" has no trail, and a
+// misclassified transient error silently costs the panel its diversity.
+const registryLogger = createLogger({ component: 'cli-circuit-breaker' });
+defaultCliCircuitBreakerRegistry.addGlobalStateChangeListener((event) => {
+  registryLogger.warn('CLI circuit state changed', {
+    cli: event.cliName,
+    previousState: event.previousState,
+    newState: event.newState,
+    failureCount: event.failureCount,
+    reason: event.reason,
+  });
+});
+
 /** Returns the shared CLI circuit-breaker registry used by default integrations. */
 export function getDefaultCliCircuitBreakerRegistry(): CircuitBreakerRegistry {
   return defaultCliCircuitBreakerRegistry;

--- a/packages/nexus-agents/src/cli-adapters/serving-gate-signal.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/serving-gate-signal.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the voter serving-gate's failure signal (#4330).
+ *
+ * The gate `isCliServingForVoters` (factory.ts) excludes a CLI only when
+ * `getCliCircuitBreakerSnapshot(cli)?.state === 'open'`, reading
+ * `defaultCliCircuitBreakerRegistry`. Nothing on the voter path ever wrote to
+ * that registry: `BaseCliAdapter.executeWithRetry` passed no `circuitBreaker`
+ * into `executeCliRetryLoop`, so its `recordFailure` call was unreachable for
+ * every subprocess CLI. A quota-dead CLI's snapshot stayed `undefined` forever
+ * and the gate took its fail-open branch on every panel — which is why #4325
+ * (2.173.6) changed nothing for the observed 64-panel run.
+ *
+ * @module cli-adapters/serving-gate-signal.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CliName, CliTransport, CliTask, ModelInfo } from './types.js';
+import type { CliResponse, CliError, ResolvedExecutionOptions } from './types.js';
+import type { Result } from '../core/index.js';
+import { ok, err } from '../core/index.js';
+import { BaseCliAdapter } from './base-adapter.js';
+import {
+  getCliCircuitBreakerSnapshot,
+  getDefaultCliCircuitBreakerRegistry,
+} from './cli-circuit-breaker.js';
+
+/** A subprocess-style adapter whose task execution is driven by the test. */
+class FlakyCliAdapter extends BaseCliAdapter {
+  readonly name: CliName;
+  readonly transport: CliTransport = 'subprocess';
+
+  private result: Result<CliResponse, CliError> = ok({ text: 'ok' });
+
+  constructor(name: CliName) {
+    super();
+    this.name = name;
+  }
+
+  setResult(result: Result<CliResponse, CliError>): void {
+    this.result = result;
+  }
+
+  executeTask(
+    _task: CliTask,
+    _options: ResolvedExecutionOptions
+  ): Promise<Result<CliResponse, CliError>> {
+    return Promise.resolve(this.result);
+  }
+
+  getModelInfo(): ModelInfo {
+    return {
+      id: 'flaky',
+      name: 'Flaky',
+      contextWindow: 1000,
+      maxOutput: 100,
+      costPerMillionInput: 0,
+      costPerMillionOutput: 0,
+    };
+  }
+
+  initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** The quota exhaustion actually observed on opencode in the #3849 v6 run. */
+function quotaError(): Result<CliResponse, CliError> {
+  return err({
+    code: 'RATE_LIMITED',
+    message: 'Key limit exceeded',
+    cli: 'opencode',
+    retryable: false,
+  });
+}
+
+const TASK: CliTask = { content: 'vote on this' };
+
+/** Drive `count` failing executions through the adapter's public entry point. */
+async function failNTimes(adapter: FlakyCliAdapter, count: number): Promise<void> {
+  adapter.setResult(quotaError());
+  for (let i = 0; i < count; i++) {
+    await adapter.execute(TASK);
+  }
+}
+
+describe('voter serving-gate failure signal (#4330)', () => {
+  beforeEach(() => {
+    getDefaultCliCircuitBreakerRegistry().resetAll();
+  });
+
+  it('records a subprocess CLI failure against the shared registry', async () => {
+    const adapter = new FlakyCliAdapter('opencode');
+
+    await failNTimes(adapter, 1);
+
+    // Before the fix this was `undefined` — nothing ever fed the registry, so
+    // the gate had no signal to read.
+    expect(getCliCircuitBreakerSnapshot('opencode')?.failureCount).toBeGreaterThan(0);
+  });
+
+  it('opens the circuit once the failure threshold is crossed', async () => {
+    const adapter = new FlakyCliAdapter('opencode');
+
+    // Default failureThreshold is 5.
+    await failNTimes(adapter, 5);
+
+    expect(getCliCircuitBreakerSnapshot('opencode')?.state).toBe('open');
+  });
+
+  it('does not open the circuit for a CLI that keeps succeeding', async () => {
+    const adapter = new FlakyCliAdapter('codex');
+
+    for (let i = 0; i < 10; i++) {
+      await adapter.execute(TASK);
+    }
+
+    expect(getCliCircuitBreakerSnapshot('codex')?.state).not.toBe('open');
+  });
+
+  it('clears the failure count on a success, so intermittent errors never trip it', async () => {
+    // Without a `recordSuccess` on the happy path the count would accumulate
+    // monotonically and evict a healthy CLI after enough scattered blips.
+    const adapter = new FlakyCliAdapter('gemini');
+
+    for (let i = 0; i < 12; i++) {
+      await failNTimes(adapter, 4);
+      adapter.setResult(ok({ text: 'recovered' }));
+      await adapter.execute(TASK);
+    }
+
+    expect(getCliCircuitBreakerSnapshot('gemini')?.state).not.toBe('open');
+  });
+
+  it('keeps each CLI’s failures on its own breaker', async () => {
+    const dead = new FlakyCliAdapter('opencode');
+
+    await failNTimes(dead, 5);
+
+    expect(getCliCircuitBreakerSnapshot('opencode')?.state).toBe('open');
+    expect(getCliCircuitBreakerSnapshot('claude')?.state).not.toBe('open');
+  });
+
+  it('re-admits the CLI once the reset timeout elapses', async () => {
+    // Quota resets. A voter panel must be able to get the CLI back — otherwise
+    // a long eval loses a voter permanently after one bad hour, since breaker
+    // state is in-memory and there is no probe to re-test it.
+    const adapter = new FlakyCliAdapter('opencode');
+    await failNTimes(adapter, 5);
+    expect(getCliCircuitBreakerSnapshot('opencode')?.state).toBe('open');
+
+    vi.useFakeTimers();
+    try {
+      // Default resetTimeoutMs is 30s.
+      vi.advanceTimersByTime(31_000);
+      expect(getCliCircuitBreakerSnapshot('opencode')?.state).toBe('half-open');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('excludes an open CLI from voter availability, and only that one', async () => {
+    // The gate itself: `isCliServingForVoters` reads these snapshots. Asserted
+    // through the same predicate `getAvailableClis` applies, without shelling
+    // out to real CLI detection.
+    const dead = new FlakyCliAdapter('opencode');
+    await failNTimes(dead, 5);
+
+    const serving = (['claude', 'gemini', 'codex', 'opencode'] as CliName[]).filter(
+      (cli) => getCliCircuitBreakerSnapshot(cli)?.state !== 'open'
+    );
+
+    expect(serving).not.toContain('opencode');
+    expect(serving).toEqual(expect.arrayContaining(['claude', 'gemini', 'codex']));
+  });
+});


### PR DESCRIPTION
Closes #4330.

## The gate was reading a register nothing wrote to

The circuit-breaker serving-gate shipped in 2.173.6 (#4325) could never exclude a quota-dead CLI. `isCliServingForVoters` (`cli-adapters/factory.ts:236-251`) excludes a CLI only when its snapshot is `open`:

```ts
const snapshot = getCliCircuitBreakerSnapshot(cli);
if (snapshot?.state !== 'open') return true;   // fail-open on undefined
```

That snapshot reads `defaultCliCircuitBreakerRegistry`. The only production writer to it was `CliCircuitBreakerIntegration.executeWithBreaker`, reachable solely from `pipeline/expert-bridge.ts:284`. The voter panel does not use it — `resolveDiverseAdapters` (`cli/voter-agents.ts:391`) calls `getAvailableClis()` then `createCliAdapterMap()` and uses those adapters directly.

Meanwhile `BaseCliAdapter.executeWithRetry` passed **no** `circuitBreaker` into `executeCliRetryLoop`, so the `recordFailure` at `cli-retry-loop.ts:125` was unreachable for every subprocess CLI — claude, codex and opencode all extend `BaseCliAdapter`. Only `GeminiCliAdapter` wired one, and to a locally-`new`ed instance rather than the shared registry.

Net: opencode's snapshot stayed `undefined` forever, the gate fail-opened on every panel, and #3587 quietly recovered each vote on claude so nothing surfaced. Observed in the #3849 v6 run: opencode assigned to the devex role and failing `Key limit exceeded` on **all 64 panels**.

The issue body listed three candidate causes; all three are wrong or secondary. Full trace with citations is [in the issue](https://github.com/nexus-substrate/nexus-agents/issues/4330#issuecomment-5215366441).

## The fix

`BaseCliAdapter` resolves its breaker from `getDefaultCliCircuitBreakerRegistry()` and passes it into the retry loop, making the existing `recordFailure(categorizeError(...))` live. **No new error classifier** — the panel flagged a second quota/auth/rate-limit taxonomy as the main DRY risk here, and the retry loop already has the canonical one.

Successes are recorded too, on the caller side. This matters: `recordSuccess` zeroes the failure count in the closed state, which is what makes `failureThreshold` mean *consecutive* failures. Without it a long-lived process accumulates scattered blips and eventually evicts a perfectly healthy CLI. Recording stays the caller's job — that is the retry loop's documented contract (it has a test pinning it) and matches `GeminiCliAdapter`'s existing pattern.

Circuit state changes are now logged on the shared registry. A CLI can now vanish from a panel roster, and a silent disappearance would leave the next person debugging a "missing voter" with nothing to go on.

## Part B turned out to be unnecessary

The vote approved a Part B — "re-resolve availability per panel". Reading the code, that already happens: `resolveDiverseAdapters` runs once per `collectRealVotes` call, i.e. once per panel. With the signal present, a CLI that trips during panel N is excluded from panel N+1 with no further change. Reporting this rather than adding redundant re-resolution logic.

## Scope limit, stated plainly

Breaker state is in-memory per-process. This fixes **panel N+1 onward within a process**; the first panel still spends one failed attempt per assigned role before the threshold trips (#3587 recovers those votes). Cross-process exclusion needs either the init-time serving probe or breaker persistence, both deliberately deferred — they cost real latency or new on-disk state and are only needed if the eval runs each panel in a fresh process, which is **unverified**. Tracked in #4368 with that verification as the unblock trigger, rather than left as a prose note.

## Decision

`consensus_vote` (`higher_order`, live 7-voter panel, **7/0 unanimous**) approved A+B with the probe and persistence deferred. Binding conditions from the panel, all addressed: no second error classifier (1), target the default registry deliberately not a private one (2), no per-panel CLI re-detection (3 — nothing added, existing path reused), observability on trips and exclusions (4), half-open re-admission confirmed (5, test), first-panel cost stated in the PR (6).

## Verification

- Red/green: 7 new tests in `serving-gate-signal.test.ts`; 3 were red against the old code (`undefined` snapshot), including the exact quota shape from the observed run
- Covers the healthy-CLI cases the panel warned about: a CLI that keeps succeeding never trips, and 12 rounds of 4-failures-then-a-success never trip it either
- Half-open re-admission after `resetTimeoutMs` asserted, so a CLI whose quota resets mid-run comes back
- Full package suite **27705 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)