### PR TITLE
fix(mcp): make runAsJob fail closed on failure-shaped results (#4363)

### DIFF
--- a/.changeset/olive-donkeys-clap.md
+++ b/.changeset/olive-donkeys-clap.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): make `runAsJob` fail closed on failure-shaped results (#4363)
+
+Increment 2 of the unanimous Option C decision on #4351. `writeJobComplete` fired
+on **any** resolved value, so a `run` callback that resolved a failure-shaped
+payload recorded `status: 'complete'` — a caller polling `get_job_result` read it
+as a success and never looked inside. Increment 1 (#4362) normalized the two known
+offenders; this makes the chokepoint itself refuse the shape, so the next caller
+cannot reintroduce the bug by omission.
+
+The check inspects the payload's **root** keys only — `isError === true`,
+`ok === false`, `success === false` — and never deep-scans. A vote whose _decision_
+is `reject`, and a pipeline summary listing a stage it recovered from, both carry a
+nested falsy `success` and are successful jobs; misreading them would trade
+fail-open for fail-wrong. The job record names which key tripped and carries the
+payload's own message, so it is debuggable rather than a bare `failed`.
+
+Callers that legitimately resolve a failure-shaped payload set
+`allowFailureShapedResult` with a stated reason, which is logged whenever it
+actually suppresses a detection — an opted-out caller is a visible policy decision,
+not a silent kwarg.
+
+The accompanying caller audit found one site still bypassing the guard:
+`run_pipeline` wrapped its result in `toolSuccessStructured`, which nests the
+payload under `structuredContent` and left the `ToolResult` root clean, so a
+`success: false` pipeline was recorded `complete` on both the sync and async paths.
+It now hoists the verdict to the root the way `run_graph_workflow` does.

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
@@ -234,6 +234,162 @@ describe('runAsJob', () => {
       expect(getInFlight('orchestrate')).toBe(0);
     });
   });
+
+  // ==========================================================================
+  // fail-closed default (#4363, increment 2 of the #4351 Option C decision)
+  // ==========================================================================
+
+  // `writeJobComplete` fired on ANY resolved value, so a callback that resolved
+  // a failure-shaped payload recorded `complete`: a caller polling
+  // `get_job_result` saw success and never looked inside. Increment 1 (#4362)
+  // normalized the two known offenders; this makes the chokepoint itself refuse
+  // the shape, so the next caller cannot reintroduce it by omission.
+  describe('fail-closed default (#4363)', () => {
+    /** Dispatch + drive one background run deterministically. */
+    async function runJob(
+      jobId: string,
+      result: unknown,
+      extra: Record<string, unknown> = {}
+    ): Promise<ReturnType<typeof readJobResult>> {
+      const params = {
+        toolName: 'orchestrate',
+        input: { task: 't' } as DummyInput,
+        freshJobId: () => jobId,
+        run: () => Promise.resolve(result),
+        ...extra,
+      };
+      runAsJob<DummyInput, unknown>({ ...params, run: () => new Promise(() => {}) });
+      await runJobInBackground(jobId, params);
+      return readJobResult(jobId);
+    }
+
+    it('refuses to record an isError ToolResult as complete', async () => {
+      const record = await runJob('job-fc-iserror', {
+        isError: true,
+        content: [{ type: 'text', text: 'adapter unauthorized' }],
+      });
+
+      expect(record?.status).toBe('failed');
+    });
+
+    it('refuses to record an { ok: false } result as complete', async () => {
+      expect((await runJob('job-fc-ok', { ok: false, error: 'no quorum' }))?.status).toBe('failed');
+    });
+
+    it('refuses to record a { success: false } result as complete', async () => {
+      expect((await runJob('job-fc-success', { success: false }))?.status).toBe('failed');
+    });
+
+    it('names the key that tripped, so the record is debuggable', async () => {
+      const record = await runJob('job-fc-why', { ok: false, error: 'no quorum' });
+
+      expect(record?.error).toContain('ok');
+      // …and carries the payload's own message rather than a bare "failed".
+      expect(record?.error).toContain('no quorum');
+    });
+
+    it('records an ordinary success as complete', async () => {
+      const record = await runJob('job-fc-happy', { value: 42 });
+
+      expect(record?.status).toBe('complete');
+      expect(record?.result).toEqual({ value: 42 });
+    });
+
+    // The false-positive class the #4351 panel made binding: fail-closed must
+    // not become fail-wrong. These payloads all describe work that SUCCEEDED.
+    describe('does not misread success payloads as failures', () => {
+      it('a rejected consensus verdict is a successful job', async () => {
+        const record = await runJob('job-fc-verdict', {
+          ok: true,
+          value: { decision: 'rejected', approvalPercentage: 28 },
+        });
+
+        expect(record?.status).toBe('complete');
+      });
+
+      it('a nested success:false carried as DATA is a successful job', async () => {
+        // A pipeline summary listing a stage it recovered from. Only root keys
+        // are checked — never a deep scan.
+        const record = await runJob('job-fc-nested', {
+          success: true,
+          stages: [
+            { id: 'plan', success: true },
+            { id: 'research', success: false, recovered: true },
+          ],
+        });
+
+        expect(record?.status).toBe('complete');
+      });
+
+      it('a root isError:false is a successful job', async () => {
+        expect((await runJob('job-fc-noterror', { isError: false }))?.status).toBe('complete');
+      });
+
+      it('a non-object payload is a successful job', async () => {
+        expect((await runJob('job-fc-scalar', 'plain text result'))?.status).toBe('complete');
+      });
+
+      it('a null payload is a successful job', async () => {
+        expect((await runJob('job-fc-null', null))?.status).toBe('complete');
+      });
+    });
+
+    describe('opt-out is explicit and observable', () => {
+      it('records complete when the caller opted out with a stated reason', async () => {
+        const record = await runJob(
+          'job-fc-optout',
+          { ok: false, error: 'partial vote set after cancel' },
+          { allowFailureShapedResult: 'partial results are the point of this tool' }
+        );
+
+        expect(record?.status).toBe('complete');
+      });
+
+      it('logs the opt-out when it actually suppresses a detection', async () => {
+        // In a governance substrate an opted-out caller is a policy decision and
+        // has to appear in the audit trail, not vanish into a silent kwarg.
+        const warn = vi.fn();
+        const logger = {
+          warn,
+          error: vi.fn(),
+          info: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as import('../../core/index.js').ILogger;
+
+        await runJob(
+          'job-fc-optout-logged',
+          { ok: false },
+          { allowFailureShapedResult: 'documented reason', logger }
+        );
+
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('failure-shaped'),
+          expect.objectContaining({
+            jobId: 'job-fc-optout-logged',
+            reason: 'documented reason',
+          })
+        );
+      });
+
+      it('does not log an opt-out that never had anything to suppress', async () => {
+        const warn = vi.fn();
+        const logger = {
+          warn,
+          error: vi.fn(),
+          info: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as import('../../core/index.js').ILogger;
+
+        await runJob(
+          'job-fc-optout-quiet',
+          { value: 1 },
+          { allowFailureShapedResult: 'documented reason', logger }
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+  });
 });
 
 describe('runAsJob — cancellation aborts in-flight work (#4086)', () => {

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
@@ -196,6 +196,75 @@ export interface RunAsJobParams<I, R, E = ToolResult> {
   readonly toEnvelope?: JobEnvelopeBuilders<E>;
   /** Optional logger for the background failure path. */
   readonly logger?: ILogger | undefined;
+  /**
+   * Opt out of the fail-closed result check (#4363), stating why.
+   *
+   * By default a `run` callback that RESOLVES a failure-shaped payload records
+   * the job `failed` rather than `complete`. A handful of tools legitimately
+   * resolve such a payload as their real answer — `consensus_vote` records the
+   * partial vote set collected before a `cancel_job`, for instance. Those set
+   * this field; the reason is logged whenever it actually suppresses a
+   * detection, so an opted-out caller is a visible policy decision rather than
+   * a silent kwarg.
+   */
+  readonly allowFailureShapedResult?: string | undefined;
+}
+
+/** A root envelope key whose value marks the payload as a failure (#4363). */
+interface FailureShape {
+  /** Which key tripped — recorded so the job record is debuggable. */
+  readonly key: string;
+  /** The payload's own message, when it carries one. */
+  readonly detail: string | undefined;
+}
+
+/** Root envelope keys and the value that means "this failed". */
+const FAILURE_KEYS: ReadonlyArray<{ key: string; failsWhen: boolean }> = [
+  // toolStructuredError
+  { key: 'isError', failsWhen: true },
+  // handleConsensusVote and the other Result-shaped handlers
+  { key: 'ok', failsWhen: false },
+  // GraphPipelineResult / AdaptiveOrchestratorResult
+  { key: 'success', failsWhen: false },
+];
+
+/** Root keys carrying a human-readable reason, in order of preference. */
+const DETAIL_KEYS: readonly string[] = ['error', 'message'];
+
+/**
+ * Render a failure shape for the job record. Names the key that tripped so the
+ * record is debuggable, and carries the payload's own message when it has one —
+ * a bare `failed` tells whoever polls the job nothing.
+ */
+function describeFailureShape(failure: FailureShape): string {
+  const suffix = failure.detail === undefined ? '' : `: ${failure.detail}`;
+  return `Job result reported failure via '${failure.key}'${suffix}`;
+}
+
+/**
+ * Detect a failure-shaped job payload, or null when the result is a success
+ * (#4363).
+ *
+ * Inspects the payload's ROOT keys only. A deep scan would turn fail-open into
+ * fail-wrong: a vote whose *decision* is `reject` and a pipeline summary listing
+ * a stage it recovered from both carry a nested falsy `success`, and both are
+ * successful jobs. Only the top-level envelope says whether the job itself
+ * failed.
+ *
+ * Exported for tests.
+ * @internal
+ */
+export function detectFailureShapedResult(result: unknown): FailureShape | null {
+  if (typeof result !== 'object' || result === null) return null;
+  const record = result as Record<string, unknown>;
+
+  for (const { key, failsWhen } of FAILURE_KEYS) {
+    if (record[key] === failsWhen) {
+      const detailKey = DETAIL_KEYS.find((k) => typeof record[k] === 'string');
+      return { key, detail: detailKey === undefined ? undefined : (record[detailKey] as string) };
+    }
+  }
+  return null;
 }
 
 /**
@@ -280,7 +349,23 @@ export async function runJobInBackground<I, R, E>(
       params.run(jobId, params.input, controller.signal),
       guard.expired,
     ]);
-    writeJobComplete(jobId, params.toolName, result);
+    // #4363: `writeJobComplete` used to fire on ANY resolved value, so a
+    // callback resolving a failure-shaped payload recorded `complete` and a
+    // caller polling `get_job_result` read it as a success. Fail closed by
+    // default — an opt-in predicate was rejected because "caller forgot to
+    // normalize" would just become "caller forgot to pass the predicate".
+    const failure = detectFailureShapedResult(result);
+    if (failure !== null && params.allowFailureShapedResult === undefined) {
+      writeJobFailed(jobId, params.toolName, describeFailureShape(failure));
+    } else {
+      if (failure !== null) {
+        params.logger?.warn(
+          `Recorded a failure-shaped ${params.toolName} result as complete (opted out)`,
+          { jobId, key: failure.key, reason: params.allowFailureShapedResult }
+        );
+      }
+      writeJobComplete(jobId, params.toolName, result);
+    }
   } catch (err: unknown) {
     const errObj = err instanceof Error ? err : new Error(String(err));
     params.logger?.error(`Async ${params.toolName} dispatch failed`, errObj, { jobId });

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.test.ts
@@ -20,7 +20,17 @@ vi.mock('../middleware/secure-handler.js', () => ({
 
 // #3730: stub the adaptive orchestrator so the async background run resolves
 // fast and deterministically (no live adapters in unit tests).
-const ORCHESTRATOR_RESULT = {
+interface StubOrchestratorResult {
+  success: boolean;
+  templateId: string;
+  selectionMethod: string;
+  taskClassification: { pipelineType: string };
+  stepsExecuted: number;
+  durationMs: number;
+  /** Present only on the #4363 failure fixtures. */
+  error?: string;
+}
+const ORCHESTRATOR_RESULT: StubOrchestratorResult = {
   success: true,
   templateId: 'general',
   selectionMethod: 'auto',
@@ -159,6 +169,50 @@ describe('run_pipeline async dispatch (#3730)', () => {
     await new Promise((r) => setImmediate(r));
     const record = readJobResult(jobId);
     expect(record?.status).toBe('complete');
+  });
+
+  // #4363 caller audit. `toolSuccessStructured` nests the payload under
+  // `structuredContent`, so a `success: false` run left the ToolResult's own
+  // root clean — it slipped past both the caller and `runAsJob`'s root-key
+  // fail-closed check, and the job recorded `complete` for a failed pipeline.
+  describe('a failed pipeline is not a successful job (#4363)', () => {
+    function failedRun(): typeof ORCHESTRATOR_RESULT {
+      return {
+        ...ORCHESTRATOR_RESULT,
+        success: false,
+        error: '1 stage(s) failed — plan: adapter rejected the request',
+      };
+    }
+
+    it('returns a business error envelope on the sync path', async () => {
+      runAdaptiveOrchestratorMock.mockResolvedValueOnce(failedRun());
+      const handler = captureHandler();
+
+      const result = await handler({ task: 'Build feature X' });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('records the job failed on the async path', async () => {
+      runAdaptiveOrchestratorMock.mockResolvedValueOnce(failedRun());
+      const handler = captureHandler();
+
+      const result = await handler({ task: 'Build feature X', dispatch: 'async' });
+      const jobId = envelope(result)['jobId'] as string;
+      await new Promise((r) => setImmediate(r));
+
+      expect(readJobResult(jobId)?.status).toBe('failed');
+    });
+
+    it('still records a successful pipeline as complete', async () => {
+      const handler = captureHandler();
+
+      const result = await handler({ task: 'Build feature X', dispatch: 'async' });
+      const jobId = envelope(result)['jobId'] as string;
+      await new Promise((r) => setImmediate(r));
+
+      expect(readJobResult(jobId)?.status).toBe('complete');
+    });
   });
 });
 

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -289,7 +289,20 @@ async function executePipelineBody(
     templateId,
     dryRun,
   });
-  return toolSuccessStructured(buildOutput(result, simulated));
+  const output = buildOutput(result, simulated);
+  // #4363 caller audit: `toolSuccessStructured` nests the payload under
+  // `structuredContent`, so a `success: false` run left the ToolResult's own
+  // root clean and slipped past both the caller and `runAsJob`'s fail-closed
+  // check — the job recorded `complete` for a pipeline that failed. Hoist the
+  // verdict to the root, the same way run_graph_workflow does.
+  if (!result.success) {
+    return toolStructuredError({
+      errorCategory: 'business',
+      message: result.error ?? `Pipeline '${result.templateId}' did not complete successfully`,
+      detail: output,
+    });
+  }
+  return toolSuccessStructured(output);
 }
 
 /** Validates input, runs the adaptive orchestrator, and shapes the result. */


### PR DESCRIPTION
Closes #4363. Increment 2 of the unanimous Option C decision on #4351, unblocked by #4362.

## The systemic root

`mcp/jobs/run-as-job.ts` recorded `writeJobComplete` on **any** resolved value:

```ts
const result = await Promise.race([params.run(...), guard.expired]);
writeJobComplete(jobId, params.toolName, result);
```

It had no way to tell "resolved and succeeded" from "resolved, but the payload says it failed". #4362 normalized the two callbacks that were getting this wrong; this makes the chokepoint itself refuse the shape, so caller #7 cannot reintroduce it by omission.

An opt-in `isFailure` predicate was explicitly rejected by the panel, and the reasoning holds up: the failure mode today is "caller forgot to normalize", and an opt-in guard turns it into "caller forgot to pass the predicate" — the same omission with a new spelling.

## Root keys only — fail-closed must not become fail-wrong

The check reads `isError === true`, `ok === false`, `success === false` at the payload **root**, matching the existing envelope conventions (`toolStructuredError`'s `isError`, `handleConsensusVote`'s `ok`, `GraphPipelineResult`'s `success`). It never deep-scans, because a deep scan would invert the bug:

- a vote whose **decision** is `reject` is a *successful* job
- a pipeline summary listing a stage it recovered from is a *successful* job

Both carry a nested falsy `success`. Five explicit regression tests pin this class, including nested-`success:false`-as-data, scalar and `null` payloads.

The job record names which key tripped and carries the payload's own `error`/`message`, so it is debuggable rather than a bare `failed`.

## Opt-out is explicit and observable

`allowFailureShapedResult: string` takes a stated reason and is logged **whenever it actually suppresses a detection** — not on every dispatch, so the log means something. In a governance substrate an opted-out caller is a policy decision that belongs in the audit trail, not a silent kwarg. Tested both ways: it logs when it suppresses, and stays quiet when there was nothing to suppress.

## Caller audit — one site was still bypassing the guard

Audited the ten `runAsJob` call sites for the async-bypass pattern. Eight were already correct: `orchestrate`, `run_workflow`, `execute_spec` and `run_graph_workflow` all hoist failure to a root `isError` (`run-graph-workflow.ts:263-265` is the reference-correct shape); `pr_review` and `supply_chain_tradeoff_panel` never resolve a root failure key at all; `run` and `consensus_vote` were fixed in #4362. No caller's legitimate *success* payload carries a root `isError`/`ok`/`success`, so there are no false-positive risks — `toolSuccess`/`toolSuccessStructured` always nest business data a level down.

**`run_pipeline` was the exception.** `executePipelineBody` wrapped its result in `toolSuccessStructured`, which nests the payload under `structuredContent` and leaves the `ToolResult` root clean — so a `success: false` pipeline slipped past both the caller and this new root check, and recorded `complete`. It now hoists the verdict to the root the way `run_graph_workflow` does. Note this path became *newly reachable* with #4362, which is what made `GraphPipelineResult.success` honest in the first place.

The sync path was fail-open here too, so this fixes both.

## On the two `*OrThrow` wrappers from #4362

Kept, deliberately. They throw with the callback's *specific* error text, which is strictly more debuggable than the generic guard message; the guard is the backstop for callers that do not self-normalize. That layering is what the vote's "guard applies to already-normalized callbacks" ordering asked for.

## Verification

- Red/green: 5 of the 14 new `run-as-job.test.ts` tests were red against the old code; 2 of the 3 new `pipeline-tool.test.ts` tests were red (verified by stashing the source change and re-running)
- Full package suite **27721 passed**, 1 skipped — no downstream churn
- `pnpm typecheck` ✓, `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)