### PR TITLE
fix(review): stop reporting a review as posted when GitHub rejected it (#4354)

### DIFF
--- a/.changeset/khaki-moons-jam.md
+++ b/.changeset/khaki-moons-jam.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(review): stop reporting a review as posted when GitHub rejected it (#4354)
+
+`nexus-agents review` printed `Review posted to GitHub.` and exited 0 whenever the
+review itself completed, regardless of what GitHub did with it. `postReviewToGitHub`
+logged a `createReview` rejection and returned `void`, and a Rule-of-Two policy block
+returned early the same way — so an HTTP 422 (the case that surfaced this: GitHub
+refuses to let an author request changes on their own PR) produced a confident
+success message over a review that does not exist, and a script gating on the exit
+code saw nothing wrong.
+
+`PRReviewResult` now carries a `postOutcome` of `posted` / `skipped` (with a reason)
+/ `failed` (with the error). Both `review` and `review --demo` report what actually
+happened and exit 1 when the post failed. A policy-gate skip is stated plainly and
+still exits 0 — it is a deliberate governance outcome, not a fault — and dry-run
+stays quiet because the header already says so.
+
+The aggregated review is typed as `PRReviewDraft` until the posting step runs, so
+`postOutcome` cannot be defaulted to a hopeful value.

--- a/packages/nexus-agents/src/cli/review-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-command.test.ts
@@ -71,6 +71,7 @@ describe('review-command', () => {
       architecture: 0,
     },
     expertReviews: [],
+    postOutcome: { status: 'posted' },
     ...overrides,
   });
 
@@ -212,6 +213,71 @@ describe('review-command', () => {
     });
   });
 
+  // #4354: the command printed "Review posted to GitHub." and exited 0 whenever
+  // the review itself succeeded, regardless of what GitHub did with the post. A
+  // real HTTP 422 (requesting changes on your own PR) was logged and discarded,
+  // so a script gating on the exit code saw a review that did not exist.
+  describe('posting failure is not reported as success (#4354)', () => {
+    function withOutcome(postOutcome: PRReviewResult['postOutcome']): void {
+      mockCreatePRReviewer.mockReturnValue({
+        reviewPR: vi.fn().mockResolvedValue({ ok: true, value: createMockReview({ postOutcome }) }),
+      } as never);
+    }
+
+    const run = async (): Promise<number> =>
+      reviewCommand({ prUrl: 'test/pr', dryRun: false, verbose: false });
+
+    it('exits non-zero when GitHub rejected the review', async () => {
+      withOutcome({ status: 'failed', error: 'gh: Unprocessable Entity (HTTP 422)' });
+
+      expect(await run()).toBe(1);
+    });
+
+    it('does not claim the review was posted', async () => {
+      withOutcome({ status: 'failed', error: 'gh: Unprocessable Entity (HTTP 422)' });
+
+      await run();
+
+      const stdout = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stdout).not.toContain('Review posted to GitHub');
+    });
+
+    it('reports the rejection reason on stderr', async () => {
+      withOutcome({ status: 'failed', error: 'gh: Unprocessable Entity (HTTP 422)' });
+
+      await run();
+
+      const stderr = stderrWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stderr).toContain('HTTP 422');
+    });
+
+    it('says so when a policy gate blocked the post, and still exits 0', async () => {
+      // A Rule of Two block is a deliberate governance outcome, not a fault —
+      // but it must not read as "posted" either.
+      withOutcome({ status: 'skipped', reason: 'Rule of Two: rule-of-two' });
+
+      expect(await run()).toBe(0);
+      const stdout = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stdout).toContain('Review NOT posted to GitHub');
+      expect(stdout).not.toContain('Review posted to GitHub');
+    });
+
+    it('stays silent about posting in dry-run — the header already said so', async () => {
+      mockCreatePRReviewer.mockReturnValue({
+        reviewPR: vi.fn().mockResolvedValue({
+          ok: true,
+          value: createMockReview({ postOutcome: { status: 'skipped', reason: 'dry-run' } }),
+        }),
+      } as never);
+
+      const code = await reviewCommand({ prUrl: 'test/pr', dryRun: true, verbose: false });
+
+      expect(code).toBe(0);
+      const stdout = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stdout).not.toContain('Review NOT posted');
+    });
+  });
+
   describe('dry run mode', () => {
     it('should show dry-run indicator', async () => {
       const mockReview = createMockReview();
@@ -230,7 +296,12 @@ describe('review-command', () => {
     });
 
     it('should not show "posted to GitHub" in dry run', async () => {
-      const mockReview = createMockReview();
+      // #4354: the message now follows the reviewer's reported outcome rather
+      // than the caller's dryRun flag, so the fixture has to carry the outcome a
+      // dry run actually produces.
+      const mockReview = createMockReview({
+        postOutcome: { status: 'skipped', reason: 'dry-run' },
+      });
       mockCreatePRReviewer.mockReturnValue({
         reviewPR: vi.fn().mockResolvedValue({ ok: true, value: mockReview }),
       } as never);

--- a/packages/nexus-agents/src/cli/review-command.ts
+++ b/packages/nexus-agents/src/cli/review-command.ts
@@ -9,7 +9,7 @@
 
 import { createLogger, formatPercentage } from '../core/index.js';
 import { createPRReviewer, formatReviewComment } from '../dogfooding/index.js';
-import type { PRReviewResult, ReviewSeverity } from '../dogfooding/index.js';
+import type { PRReviewResult, ReviewSeverity, ReviewPostOutcome } from '../dogfooding/index.js';
 import { capitalize } from '../utils/text-utils.js';
 
 const logger = createLogger({ component: 'ReviewCommand' });
@@ -47,7 +47,10 @@ export async function reviewCommand(options: ReviewCommandOptions): Promise<numb
   }
 
   printReviewResult(result.value, verbose, dryRun);
-  return 0;
+  // #4354: a review that ran but failed to post is not a success. The command
+  // used to print "Review posted to GitHub." and exit 0 over an HTTP 422, so a
+  // script gating on the exit code saw a review that never existed.
+  return result.value.postOutcome.status === 'failed' ? 1 : 0;
 }
 
 function printHeader(prUrl: string, dryRun: boolean): void {
@@ -69,8 +72,27 @@ function printReviewResult(review: PRReviewResult, verbose: boolean, dryRun: boo
     }
   }
 
-  if (!dryRun) {
-    process.stdout.write('Review posted to GitHub.\n');
+  printPostOutcome(review.postOutcome);
+}
+
+/**
+ * Report what actually happened to the review, rather than assuming a
+ * non-dry-run means it landed (#4354).
+ */
+function printPostOutcome(outcome: ReviewPostOutcome): void {
+  switch (outcome.status) {
+    case 'posted':
+      process.stdout.write('Review posted to GitHub.\n');
+      return;
+    case 'skipped':
+      // dry-run already says so in the header; a policy block does not.
+      if (outcome.reason !== 'dry-run') {
+        process.stdout.write(`Review NOT posted to GitHub: ${outcome.reason}\n`);
+      }
+      return;
+    case 'failed':
+      process.stderr.write(`Review NOT posted to GitHub: ${outcome.error}\n`);
+      return;
   }
 }
 

--- a/packages/nexus-agents/src/cli/review-demo-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-demo-command.test.ts
@@ -119,6 +119,7 @@ function makeReviewResult(overrides: Partial<PRReviewResult> = {}) {
       suspiciousSignals: [],
       isSuspicious: false,
     },
+    postOutcome: { status: 'posted' },
     ...overrides,
   } satisfies PRReviewResult;
 }

--- a/packages/nexus-agents/src/cli/review-demo-command.ts
+++ b/packages/nexus-agents/src/cli/review-demo-command.ts
@@ -10,7 +10,7 @@
 
 import { getTimeProvider, formatPercentage } from '../core/index.js';
 import { createPRReviewer, formatReviewComment } from '../dogfooding/index.js';
-import type { PRReviewResult, ReviewSeverity } from '../dogfooding/index.js';
+import type { PRReviewResult, ReviewSeverity, ReviewPostOutcome } from '../dogfooding/index.js';
 import type { ReviewDemoOptions, ProgressStep } from './review-demo-types.js';
 import {
   checkSetupStatus,
@@ -150,6 +150,10 @@ async function runReviewWithProgress(
   // Print result
   process.stdout.write('\n');
   printReviewResult(result.value, verbose, dryRun);
+  // #4354: only claim success when the review actually landed.
+  if (result.value.postOutcome.status === 'failed') {
+    return 1;
+  }
   printSuccessMessage(durationMs);
 
   return 0;
@@ -275,8 +279,26 @@ function printReviewResult(review: PRReviewResult, verbose: boolean, dryRun: boo
     }
   }
 
-  if (!dryRun) {
-    process.stdout.write('Review posted to GitHub.\n');
+  // #4354: same false-success as `review` — a non-dry-run was assumed to mean
+  // the post landed, so an HTTP 422 printed "Review posted to GitHub."
+  printPostOutcome(review.postOutcome);
+}
+
+/** Report what actually happened to the review (#4354). */
+function printPostOutcome(outcome: ReviewPostOutcome): void {
+  switch (outcome.status) {
+    case 'posted':
+      process.stdout.write('Review posted to GitHub.\n');
+      return;
+    case 'skipped':
+      // dry-run already says so in the header; a policy block does not.
+      if (outcome.reason !== 'dry-run') {
+        process.stdout.write(`Review NOT posted to GitHub: ${outcome.reason}\n`);
+      }
+      return;
+    case 'failed':
+      process.stderr.write(`Review NOT posted to GitHub: ${outcome.error}\n`);
+      return;
   }
 }
 

--- a/packages/nexus-agents/src/dogfooding/index.ts
+++ b/packages/nexus-agents/src/dogfooding/index.ts
@@ -17,6 +17,8 @@ export type {
   ExpertReviewResult,
   ReviewDecision,
   PRReviewResult,
+  PRReviewDraft,
+  ReviewPostOutcome,
   PRReviewConfig,
 } from './pr-review-types.js';
 

--- a/packages/nexus-agents/src/dogfooding/pr-review-types.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-review-types.ts
@@ -77,12 +77,7 @@ export type ReviewSeverity = (typeof FINDING_SEVERITY_LEVELS)[number];
  * Review category for organizing findings.
  */
 export type ReviewCategory =
-  | 'security'
-  | 'performance'
-  | 'code_quality'
-  | 'testing'
-  | 'documentation'
-  | 'architecture';
+  'security' | 'performance' | 'code_quality' | 'testing' | 'documentation' | 'architecture';
 
 /**
  * Individual review finding from an expert.
@@ -200,7 +195,35 @@ export interface PRReviewResult {
   readonly timestamp: string;
   /** Author trust + reputation assessment (#3123). */
   readonly trustAssessment: PRTrustAssessment;
+  /**
+   * What actually happened when the review was posted to GitHub (#4354).
+   *
+   * The review previously reported success whether or not the post landed: a
+   * `createReview` rejection was logged and discarded, and a Rule-of-Two block
+   * returned early, both leaving the CLI to print "Review posted to GitHub."
+   * over a review that does not exist. Callers must consult this rather than
+   * inferring a successful post from a successful review.
+   */
+  readonly postOutcome: ReviewPostOutcome;
 }
+
+/**
+ * A completed review before the posting step has run (#4354).
+ *
+ * Everything the reviewer aggregates is known before the post is attempted; the
+ * outcome is stamped on afterwards. Keeping the two apart in the types is what
+ * stops `postOutcome` from being defaulted to a hopeful value.
+ */
+export type PRReviewDraft = Omit<PRReviewResult, 'postOutcome'>;
+
+/** Terminal state of the GitHub review-posting step (#4354). */
+export type ReviewPostOutcome =
+  /** The review was created on GitHub. */
+  | { readonly status: 'posted' }
+  /** Posting was deliberately not attempted (dry-run, or a policy gate blocked it). */
+  | { readonly status: 'skipped'; readonly reason: string }
+  /** Posting was attempted and GitHub rejected it. */
+  | { readonly status: 'failed'; readonly error: string };
 
 /**
  * Configuration for PR review.

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
@@ -743,6 +743,7 @@ function createMockPRMetadata(overrides: Partial<PRMetadata> = {}): PRMetadata {
 
 function createMockPRReviewResult(overrides: Partial<PRReviewResult> = {}): PRReviewResult {
   return {
+    postOutcome: { status: 'posted' },
     prNumber: 1,
     repository: 'owner/repo',
     decision: 'approve',

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
@@ -13,7 +13,7 @@ import { getTimeProvider, createLogger } from '../core/index.js';
 import type { ScmUserMetadata } from '../scm/types.js';
 import type {
   PRMetadata,
-  PRReviewResult,
+  PRReviewDraft,
   PRTrustAssessment,
   ExpertReviewResult,
   ReviewFinding,
@@ -339,7 +339,7 @@ ${expertSummaries}`;
 /**
  * Formats the review result as a GitHub comment.
  */
-export function formatReviewComment(result: PRReviewResult): string {
+export function formatReviewComment(result: PRReviewDraft): string {
   const emoji = DECISION_EMOJI[result.decision];
   const decisionText = result.decision.replaceAll('_', ' ').toUpperCase();
 
@@ -358,7 +358,7 @@ ${statsSection}
 *Reviewed by [nexus-agents](https://github.com/nexus-substrate/nexus-agents) in ${String(result.totalDurationMs)}ms*`;
 }
 
-function formatFindingsSection(result: PRReviewResult): string {
+function formatFindingsSection(result: PRReviewDraft): string {
   const allFindings = result.expertReviews.flatMap((r) => r.findings);
 
   if (allFindings.length === 0) {
@@ -388,7 +388,7 @@ function formatFindingsSection(result: PRReviewResult): string {
   return lines.join('\n');
 }
 
-function formatStatsSection(result: PRReviewResult): string {
+function formatStatsSection(result: PRReviewDraft): string {
   const { findingsBySeverity } = result;
   const total = sumFindings(findingsBySeverity);
 

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
@@ -24,6 +24,8 @@ import type {
   PRMetadata,
   PRReviewConfig,
   PRReviewResult,
+  PRReviewDraft,
+  ReviewPostOutcome,
   PRTrustAssessment,
   PRFetchData,
   ExpertReviewResult,
@@ -112,18 +114,19 @@ export class PRReviewer {
     const expertReviews = await this.runExpertReviews(prMetadata, traceId);
     const result = this.aggregateReviews(prMetadata, expertReviews, startTime, trustAssessment);
 
-    if (!this.config.dryRun) {
-      await this.postReviewToGitHub(provider, parseResult.value, result, gateDecision);
-    }
+    const postOutcome: ReviewPostOutcome = this.config.dryRun
+      ? { status: 'skipped', reason: 'dry-run' }
+      : await this.postReviewToGitHub(provider, parseResult.value, result, gateDecision);
 
     logger.info('PR review completed', {
       prNumber,
       decision: result.decision,
       findingsCount: sumFindings(result.findingsBySeverity),
       durationMs: result.totalDurationMs,
+      postStatus: postOutcome.status,
     });
 
-    return ok(result);
+    return ok({ ...result, postOutcome });
   }
 
   /**
@@ -343,7 +346,7 @@ Provide a structured review with:
     reviews: ExpertReviewResult[],
     startTime: number,
     trustAssessment: PRTrustAssessment
-  ): PRReviewResult {
+  ): PRReviewDraft {
     const allFindings = reviews.flatMap((r) => r.findings);
     const decision = determineDecision(reviews, allFindings);
     const consensusScore = calculateConsensus(reviews);
@@ -375,16 +378,19 @@ Provide a structured review with:
   private async postReviewToGitHub(
     provider: FullCapableProvider,
     pr: { owner: string; repo: string; prNumber: number },
-    result: PRReviewResult,
+    result: PRReviewDraft,
     gateDecision: ReputationGateDecision
-  ): Promise<void> {
+  ): Promise<ReviewPostOutcome> {
     const policyResult = this.auditReviewAction(gateDecision.enforcedTier);
     if (policyResult.hasRuleOfTwoViolation) {
       logger.warn('Rule of Two: review posting blocked', {
         prNumber: pr.prNumber,
         violations: policyResult.violations,
       });
-      return;
+      return {
+        status: 'skipped',
+        reason: `Rule of Two: ${policyResult.violations.map((v) => v.rule).join(', ')}`,
+      };
     }
     if (policyResult.violations.length > 0) {
       logger.info('Policy gate warnings for review posting', {
@@ -398,7 +404,13 @@ Provide a structured review with:
     const postResult = await provider.createReview(pr.prNumber, body, result.decision);
     if (!postResult.ok) {
       logger.error('Failed to post review', postResult.error);
+      // #4354: this used to end here. The rejection was logged and dropped, the
+      // review resolved ok, and the CLI printed "Review posted to GitHub." over
+      // a review GitHub had refused to create (HTTP 422 when the reviewer is the
+      // PR author, for instance).
+      return { status: 'failed', error: postResult.error.message };
     }
+    return { status: 'posted' };
   }
 
   /**


### PR DESCRIPTION
Closes #4354.

## The bug

`nexus-agents review` printed `Review posted to GitHub.` and exited **0** whenever the review itself completed — regardless of what GitHub did with it.

`postReviewToGitHub` (`dogfooding/pr-reviewer.ts:377`) returned `void` and had two silent exits:

```ts
if (!postResult.ok) {
  logger.error("Failed to post review", postResult.error);   // …and that was the end of it
}
```

plus an early `return` when the Rule-of-Two policy gate blocked posting. `reviewPR` then resolved `ok`, and `printReviewResult` decided what to print from the caller's **`dryRun` flag** — a value that says what the user asked for, not what happened.

So the reported reproduction (GitHub returns HTTP 422 because an author cannot request changes on their own PR) produced a confident success message over a review that does not exist, with the real error visible only in the structured log. A script gating on the exit code saw nothing wrong.

## The fix

`PRReviewResult` now carries a `postOutcome`:

```ts
export type ReviewPostOutcome =
  | { readonly status: posted }
  | { readonly status: skipped; readonly reason: string }
  | { readonly status: failed; readonly error: string };
```

Both `review` and `review --demo` report the actual outcome and exit 1 when the post failed. Three cases, deliberately distinct:

- **failed** → reason on stderr, exit 1
- **skipped by a policy gate** → stated plainly on stdout, exit **0**. A Rule-of-Two block is a deliberate governance decision, not a fault — but it must not read as "posted" either, which is the half of this bug that is easy to miss.
- **skipped by dry-run** → silent, because the header already said so

## Why a separate draft type

The aggregated review is typed `PRReviewDraft = Omit<PRReviewResult, 'postOutcome'>` until the posting step runs. Everything else is known before the post is attempted, so keeping the two apart makes a missing `postOutcome` a compile error rather than something a future caller can default to a hopeful value — which is the shape of the bug being fixed.

## Same family as #4362 / #4363

This is the CLI-surface instance of the fail-open class those two addressed inside the MCP job layer: work that failed somewhere in the stack, reported upward as success. Different surface, identical failure mode.

## Verification

- Red/green: 4 of the 5 new tests were red against the old code, verified by stashing `review-command.ts` and re-running
- One pre-existing dry-run test needed its fixture updated — it asserted on the old `dryRun`-flag behaviour with a fixture that claimed `posted`; a dry run now yields `skipped: dry-run`
- Full package suite **27726 passed**, 1 skipped
- `pnpm typecheck` ✓, `pnpm lint` ✓

## Not covered

The reported run also chose `REQUEST_CHANGES` on a PR authored by the same account as the `gh` token. Deciding whether the reviewer should *avoid* an event GitHub will reject is a separate behavioural question from reporting the rejection honestly, and is not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)