### PR TITLE
fix(review): wire the model adapter into PR review, and fail closed without one (#4350)

### DIFF
--- a/.changeset/brown-jars-tell.md
+++ b/.changeset/brown-jars-tell.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+fix(review): wire the model adapter into PR review, and fail closed without one (#4350)
+
+`nexus-agents review` never ran a model. Both CLI entry points called
+`createPRReviewer({ dryRun })`, but the adapter is that factory's **second**
+parameter — so `PRReviewer.adapter` was always `undefined`, every expert logged
+`hasAdapter: false`, and each one silently fell through to its heuristic branch.
+The command then printed a confident decision (`67% REQUEST CHANGES` in the report)
+built from generic findings with no file, no line, no PR-specific reasoning and
+`tokensUsed: 0`, and exited 0 — so automation could not tell it apart from a real
+adapter-backed review. `verify` and `doctor` correctly reported three authenticated
+CLIs the whole time, because they inspect the CLIs directly; the review path simply
+never asked for an adapter.
+
+Both entry points now resolve one through the canonical
+`getGlobalRegistry().getDefault()` path — the same acquisition the voter CLI uses —
+and **fail closed** with actionable guidance when none is configured, rather than
+producing a review nobody should trust. Decided by `consensus_vote`
+(`higher_order`, 7/0): a labelled "degraded mode" was rejected because the labelling
+would have to survive every render path, and deleting the heuristic path outright
+was rejected as a breaking library change out of scope for a bug fix. It remains
+reachable for library consumers that construct `PRReviewer` with no adapter.
+
+Also fixes a mislabelled count in the same report: the demo command's progress line
+printed `expertReviews.length` (the expert count) under a "files" label, so a
+7-file PR reported "3 files". `PRReviewResult` now carries `filesReviewed`.

--- a/packages/nexus-agents/src/cli/review-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-command.test.ts
@@ -15,6 +15,12 @@ vi.mock('../dogfooding/index.js', () => ({
   formatReviewComment: vi.fn(),
 }));
 
+// #4350: the review path resolves its adapter from the canonical registry.
+const getDefaultMock = vi.fn(() => ({ name: 'test-adapter' }));
+vi.mock('../adapters/unified-registry.js', () => ({
+  getGlobalRegistry: () => ({ getDefault: getDefaultMock }),
+}));
+
 // Mock the core module
 vi.mock('../core/index.js', () => ({
   createLogger: vi.fn(() => ({
@@ -24,13 +30,14 @@ vi.mock('../core/index.js', () => ({
     debug: vi.fn(),
   })),
   formatPercentage: vi.fn((n: number) => `${String(Math.round(n * 100))}%`),
+  getErrorMessage: vi.fn((e: unknown) => (e instanceof Error ? e.message : String(e))),
 }));
 
 import { createPRReviewer, formatReviewComment } from '../dogfooding/index.js';
 import type { PRReviewResult } from '../dogfooding/index.js';
-
 const mockCreatePRReviewer = vi.mocked(createPRReviewer);
 const mockFormatReviewComment = vi.mocked(formatReviewComment);
+const mockGetDefault = getDefaultMock;
 
 describe('review-command', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,11 +79,13 @@ describe('review-command', () => {
     },
     expertReviews: [],
     postOutcome: { status: 'posted' },
+    filesReviewed: 7,
     ...overrides,
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    getDefaultMock.mockReturnValue({ name: 'test-adapter' });
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockFormatReviewComment.mockReturnValue('# Review Comment Preview');
@@ -328,7 +337,9 @@ describe('review-command', () => {
         verbose: false,
       });
 
-      expect(mockCreatePRReviewer).toHaveBeenCalledWith({ dryRun: true });
+      // #4350: the factory now also receives the resolved adapter as its second
+      // argument — the parameter the CLI used to leave empty.
+      expect(mockCreatePRReviewer).toHaveBeenCalledWith({ dryRun: true }, expect.anything());
     });
   });
 
@@ -408,6 +419,60 @@ describe('review-command', () => {
 
       const output = stdoutWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
       expect(output).not.toContain('GitHub Comment Preview');
+    });
+  });
+
+  // #4350: both CLI entry points called `createPRReviewer({ dryRun })`, but the
+  // adapter is that factory's SECOND parameter — so the review path never wired
+  // one. Every expert logged `hasAdapter: false` and fell through to its
+  // heuristic branch, and the command printed a confident decision built from
+  // generic findings with `tokensUsed: 0` and exited 0.
+  describe('model adapter wiring (#4350)', () => {
+    it('passes the registry adapter to the reviewer', async () => {
+      const adapter = { name: 'claude-resilient' };
+      mockGetDefault.mockReturnValue(adapter);
+      mockCreatePRReviewer.mockReturnValue({
+        reviewPR: vi.fn().mockResolvedValue({ ok: true, value: createMockReview() }),
+      } as never);
+
+      await reviewCommand({ prUrl: 'test/pr', dryRun: false, verbose: false });
+
+      // Assert on the SECOND argument specifically — passing it positionally
+      // wrong is exactly the slip that caused this bug, and a looser assertion
+      // would not catch a repeat.
+      expect(mockCreatePRReviewer).toHaveBeenCalledWith(expect.anything(), adapter);
+    });
+
+    it('fails closed when no adapter is configured', async () => {
+      mockGetDefault.mockImplementation(() => {
+        throw new Error('No model adapter configured');
+      });
+
+      const exitCode = await reviewCommand({ prUrl: 'test/pr', dryRun: false, verbose: false });
+
+      expect(exitCode).toBe(1);
+      expect(mockCreatePRReviewer).not.toHaveBeenCalled();
+    });
+
+    it('tells the user what to do, not just what is missing', async () => {
+      // The confusing part of this bug is that `doctor` reports healthy CLIs
+      // while the review path ignored them — the message has to bridge that.
+      mockGetDefault.mockImplementation(() => {
+        throw new Error('No model adapter configured');
+      });
+
+      await reviewCommand({ prUrl: 'test/pr', dryRun: false, verbose: false });
+
+      const stderr = stderrWriteSpy.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(stderr).toContain('nexus-agents doctor');
+    });
+
+    it('fails closed in dry-run too — a dry run still needs a real review', async () => {
+      mockGetDefault.mockImplementation(() => {
+        throw new Error('No model adapter configured');
+      });
+
+      expect(await reviewCommand({ prUrl: 'test/pr', dryRun: true, verbose: false })).toBe(1);
     });
   });
 

--- a/packages/nexus-agents/src/cli/review-command.ts
+++ b/packages/nexus-agents/src/cli/review-command.ts
@@ -7,7 +7,9 @@
  * (Source: Issue #161, Alignment Roadmap Phase 3)
  */
 
-import { createLogger, formatPercentage } from '../core/index.js';
+import { createLogger, formatPercentage, getErrorMessage } from '../core/index.js';
+import type { IModelAdapter } from '../core/index.js';
+import { getGlobalRegistry } from '../adapters/unified-registry.js';
 import { createPRReviewer, formatReviewComment } from '../dogfooding/index.js';
 import type { PRReviewResult, ReviewSeverity, ReviewPostOutcome } from '../dogfooding/index.js';
 import { capitalize } from '../utils/text-utils.js';
@@ -38,7 +40,15 @@ export async function reviewCommand(options: ReviewCommandOptions): Promise<numb
 
   printHeader(prUrl, dryRun);
 
-  const reviewer = createPRReviewer({ dryRun });
+  // #4350: this used to be `createPRReviewer({ dryRun })` — the adapter is that
+  // factory's SECOND parameter, so the CLI never wired one and every expert
+  // silently fell through to its heuristic branch, producing a confident
+  // decision with `tokensUsed: 0` and exit 0. Fail closed instead: a review
+  // nobody should trust must not look like one that succeeded.
+  const adapter = resolveAdapter();
+  if (adapter === null) return 1;
+
+  const reviewer = createPRReviewer({ dryRun }, adapter);
   const result = await reviewer.reviewPR(prUrl);
 
   if (!result.ok) {
@@ -51,6 +61,30 @@ export async function reviewCommand(options: ReviewCommandOptions): Promise<numb
   // used to print "Review posted to GitHub." and exit 0 over an HTTP 422, so a
   // script gating on the exit code saw a review that never existed.
   return result.value.postOutcome.status === 'failed' ? 1 : 0;
+}
+
+/**
+ * Resolve the model adapter the experts will run on, or null after reporting
+ * why the review cannot proceed (#4350).
+ *
+ * Uses the canonical acquisition path (`getGlobalRegistry().getDefault()`), the
+ * same one the voter CLI uses. The guidance matters as much as the error: the
+ * confusing part of this failure is that `doctor` reports healthy, authenticated
+ * CLIs while the review path was ignoring them entirely.
+ */
+function resolveAdapter(): IModelAdapter | null {
+  try {
+    return getGlobalRegistry({ logger }).getDefault();
+  } catch (error) {
+    // Report only our own guidance plus the registry's message — never the
+    // adapter configuration itself, which can carry credentials.
+    process.stderr.write(
+      `Error: no model adapter is available, so the review would fall back to generic heuristics rather than reading this PR.\n` +
+        `  ${getErrorMessage(error)}\n` +
+        `  Run "nexus-agents doctor" to see which CLIs are detected and authenticated.\n`
+    );
+    return null;
+  }
 }
 
 function printHeader(prUrl: string, dryRun: boolean): void {

--- a/packages/nexus-agents/src/cli/review-demo-command.test.ts
+++ b/packages/nexus-agents/src/cli/review-demo-command.test.ts
@@ -21,6 +21,13 @@ vi.mock('../core/index.js', () => ({
     now: vi.fn(() => 1000),
   })),
   formatPercentage: vi.fn((v: number) => `${String(Math.round(v * 100))}%`),
+  getErrorMessage: vi.fn((e: unknown) => (e instanceof Error ? e.message : String(e))),
+}));
+
+// #4350: the demo path resolves its adapter from the canonical registry.
+const getDefaultMock = vi.fn(() => ({ name: 'test-adapter' }));
+vi.mock('../adapters/unified-registry.js', () => ({
+  getGlobalRegistry: () => ({ getDefault: getDefaultMock }),
 }));
 
 vi.mock('./review-demo-helpers.js', () => ({
@@ -120,6 +127,7 @@ function makeReviewResult(overrides: Partial<PRReviewResult> = {}) {
       isSuspicious: false,
     },
     postOutcome: { status: 'posted' },
+    filesReviewed: 7,
     ...overrides,
   } satisfies PRReviewResult;
 }

--- a/packages/nexus-agents/src/cli/review-demo-command.ts
+++ b/packages/nexus-agents/src/cli/review-demo-command.ts
@@ -8,7 +8,9 @@
  * (Source: Issue #258 - PR Review Demo Workflow)
  */
 
-import { getTimeProvider, formatPercentage } from '../core/index.js';
+import { getTimeProvider, formatPercentage, getErrorMessage } from '../core/index.js';
+import type { IModelAdapter } from '../core/index.js';
+import { getGlobalRegistry } from '../adapters/unified-registry.js';
 import { createPRReviewer, formatReviewComment } from '../dogfooding/index.js';
 import type { PRReviewResult, ReviewSeverity, ReviewPostOutcome } from '../dogfooding/index.js';
 import type { ReviewDemoOptions, ProgressStep } from './review-demo-types.js';
@@ -132,7 +134,17 @@ async function runReviewWithProgress(
   steps = updateProgress(steps, 1, { status: 'in_progress' });
   printProgress(steps, verbose);
 
-  const reviewer = createPRReviewer({ dryRun });
+  // #4350: the adapter is createPRReviewer's SECOND parameter and was never
+  // passed here either, so every expert ran its heuristic branch while the
+  // progress display reported a clean multi-agent review. Fail closed.
+  const adapter = resolveAdapter();
+  if (adapter === null) {
+    steps = updateProgress(steps, 0, { status: 'failed', message: 'no model adapter' });
+    printProgress(steps, verbose);
+    return 1;
+  }
+
+  const reviewer = createPRReviewer({ dryRun }, adapter);
   const result = await reviewer.reviewPR(prUrl);
 
   if (!result.ok) {
@@ -157,6 +169,26 @@ async function runReviewWithProgress(
   printSuccessMessage(durationMs);
 
   return 0;
+}
+
+/**
+ * Resolve the model adapter the experts will run on, or null after reporting why
+ * the review cannot proceed (#4350). Mirrors `review-command.ts`.
+ */
+function resolveAdapter(): IModelAdapter | null {
+  try {
+    // No logger threaded: this command has none, and the registry's is optional.
+    return getGlobalRegistry().getDefault();
+  } catch (error) {
+    // Our guidance plus the registry's message only — never the adapter
+    // configuration, which can carry credentials.
+    process.stderr.write(
+      `\nError: no model adapter is available, so the review would fall back to generic heuristics rather than reading this PR.\n` +
+        `  ${getErrorMessage(error)}\n` +
+        `  Run "nexus-agents doctor" to see which CLIs are detected and authenticated.\n`
+    );
+    return null;
+  }
 }
 
 /**
@@ -238,7 +270,9 @@ function updateAllStepsCompleted(
 function getStepMessage(index: number, review: PRReviewResult): string {
   const msgMap: Record<number, string> = {
     0: 'OK',
-    1: `${String(review.expertReviews.length)} files`,
+    // #4350: this printed `expertReviews.length` — the EXPERT count — under a
+    // "files" label, so a 7-file PR reported "3 files".
+    1: `${String(review.filesReviewed)} files`,
     2: getExpertMessage(review, 'security'),
     3: getExpertMessage(review, 'code_quality'),
     4: getExpertMessage(review, 'testing'),

--- a/packages/nexus-agents/src/dogfooding/pr-review-types.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-review-types.ts
@@ -187,6 +187,14 @@ export interface PRReviewResult {
   readonly totalDurationMs: number;
   /** Number of experts that participated */
   readonly expertCount: number;
+  /**
+   * Number of changed files the review covered (#4350).
+   *
+   * The demo command's progress line printed `expertReviews.length` under a
+   * "files" label, so a 7-file PR reported "3 files" — the expert count. The
+   * fetch was always correct; the result simply carried no file count to print.
+   */
+  readonly filesReviewed: number;
   /** Consensus score (0-1) */
   readonly consensusScore: number;
   /** Debate rounds completed */

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
@@ -744,6 +744,7 @@ function createMockPRMetadata(overrides: Partial<PRMetadata> = {}): PRMetadata {
 function createMockPRReviewResult(overrides: Partial<PRReviewResult> = {}): PRReviewResult {
   return {
     postOutcome: { status: 'posted' },
+    filesReviewed: 7,
     prNumber: 1,
     repository: 'owner/repo',
     decision: 'approve',

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer.ts
@@ -361,6 +361,7 @@ Provide a structured review with:
       findingsByCategory: countByCategory(allFindings),
       totalDurationMs: getTimeProvider().now() - startTime,
       expertCount: reviews.length,
+      filesReviewed: pr.files.length,
       consensusScore,
       debateRounds: 1,
       timestamp: getTimeProvider().nowIso(),


### PR DESCRIPTION
Closes #4350.

## `nexus-agents review` never ran a model

Both CLI entry points constructed the reviewer with no adapter:

```
cli/review-command.ts:41       createPRReviewer({ dryRun })
cli/review-demo-command.ts:135 createPRReviewer({ dryRun })
```

`createPRReviewer(config?, adapter?)` takes the adapter as its **second** parameter. So `PRReviewer.adapter` was always `undefined`, `createExpert` built its options without one, and every expert hit:

```ts
if (this.adapter === undefined) {
  return this.executeHeuristic(task, startTime);
}
```

The command then printed a confident `67% REQUEST CHANGES` assembled from generic heuristics — "Potential code/command injection risk", "Authentication-related code requires careful review" — with no file, no line, no PR-specific reasoning, `tokensUsed: 0`, and **exit 0**.

Authentication was never the problem. `verify` and `doctor` correctly reported three authenticated CLIs the whole time because they inspect the CLIs directly; the review path simply never asked for an adapter. That mismatch is what made this hard to diagnose from the outside.

## The fix

Both entry points resolve an adapter through `getGlobalRegistry().getDefault()` — the canonical acquisition already used at `cli/voter-agents.ts:261` — and **fail closed** when none is configured:

```
Error: no model adapter is available, so the review would fall back to generic
heuristics rather than reading this PR.
  No model adapter configured
  Run "nexus-agents doctor" to see which CLIs are detected and authenticated.
```

The `doctor` pointer is deliberate: the confusing part of this bug is that `doctor` reports healthy CLIs while the review path ignored them, so the message has to bridge that gap. The text carries only our own guidance plus the registry's message — never adapter configuration, which can hold credentials.

Dry-run fails closed too. A dry run is still a real review; it just does not post.

## Decision

`consensus_vote` (`higher_order`, live 7-voter panel, **7/0 unanimous**) chose fail-closed over the two alternatives:

- **Labelled degraded mode** rejected — the Contrarian's point carried it: humans read stdout, not exit codes, so a "loudly labelled" heuristic verdict still gets trusted, and the labelling would have to survive every render path (console, JSON, markdown, posted comment) where one miss silently recreates this exact bug. Its claimed benefit, a zero-dependency smoke path, has no named consumer.
- **Deleting `executeHeuristic`** rejected as a breaking library change bolted onto a bug fix. It stays reachable for consumers that construct `PRReviewer` directly, and is exercised by tests across six expert classes.

The AI/ML voter drew the precedent worth keeping: a heuristic review with `tokensUsed: 0` presented as model-backed judgment is the same epistemic failure as `simulateVotes`, which this repo already banned and made fail-closed by default (#2319).

## Second defect: the "3 files" was the expert count

`review-demo-command.ts:237` printed `${review.expertReviews.length} files` — three **experts**, labelled as files. The PR genuinely had 7 and the fetch was always correct; `PRReviewResult` simply carried no file count to print. It now has `filesReviewed`. Separate concern, verified separately.

## Fallout check

Grepped the docs for anything advertising adapterless review — nothing does, so no documentation contradicts the new behaviour.

## Verification

- Red/green: 4 new tests red against the old code. One asserts the adapter arrives as the **second** positional argument specifically — a looser assertion would not catch a repeat of the exact slip that caused this.
- Two pre-existing tests needed updating for the new signature and the `filesReviewed` field
- Full package suite **27730 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

## Same family

Third fix on this command in the fail-open series: #4354 fixed the *posting* dishonesty, this fixes the *content* dishonesty, alongside #4362/#4363 in the MCP job layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)