### PR TITLE
fix(cli-adapters): classify codex-mcp quota errors, and honor provider retry-after (#4373)

### DIFF
--- a/.changeset/nine-pears-shave.md
+++ b/.changeset/nine-pears-shave.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): classify codex-mcp quota errors, and honor provider retry-after (#4373)
+
+Two gaps found while auditing error surfaces for #4351 criterion 3.
+
+**codex-mcp never classified a quota error.** Every other CLI adapter extends
+`SubprocessCliAdapter` and inherits a pipeline that checks `isRateLimitText`.
+`CodexMcpAdapter` extends `BaseCliAdapter` and classified on its own:
+`determineErrorCode` matched only ENOENT / timeout / connection, and
+`parseToolResult` hardcoded `EXECUTION_ERROR` for any `isError: true` result
+without reading the message at all. That matters beyond naming — the voter
+serving-gate (#4330) excludes a CLI whose circuit has opened, and the breaker
+counts `RATE_LIMITED` where `EXECUTION_ERROR` is generic, so a quota-dead
+codex-mcp never looked like a serving failure. Both paths now reuse the shared
+pattern set rather than growing a second taxonomy, with the terminal readings
+(missing binary, timeout) still taking precedence — a rate-limit reading would
+route the caller into a retry that can never succeed.
+
+**A provider-stated retry window was parsed and thrown away.**
+`parseRetryAfterMs` has existed with regexes for "retry after Xs" / "try again in
+Xs" and was called from nowhere under `cli-adapters/`; `CliError` had no field to
+carry it. So when a provider named its window, the retry loop ignored it in favour
+of its own exponential backoff. `CliError.retryAfterMs` now carries the value on
+retryable errors, and `resolveRetryDelayMs` prefers it — still clamped to the
+caller's ceiling, so a CLI claiming a multi-hour window cannot wedge the loop, and
+a zero or negative hint is ignored rather than retried instantly.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter-helpers.ts
@@ -9,6 +9,7 @@
 
 import type { ResolvedExecutionOptions, CliError, CliName } from '../types.js';
 import { CODEX_MCP_TIMEOUTS } from '../../config/timeouts.js';
+import { isRateLimitText } from '../../adapters/rate-limit-detector.js';
 import {
   createCliError as sharedCreateCliError,
   isRetryableErrorCode as sharedIsRetryableErrorCode,
@@ -139,7 +140,14 @@ export function createTimeout(ms: number): Promise<null> {
   });
 }
 
-/** Determines error code from error message. */
+/**
+ * Determines error code from error message.
+ *
+ * The terminal/actionable readings are checked first: a missing binary or a
+ * timeout is a better answer than "rate limited" even when the text mentions a
+ * rate limit, because a rate-limit reading routes the caller into a retry that
+ * can never succeed.
+ */
 export function determineErrorCode(message: string): CliError['code'] {
   if (message.includes('ENOENT') || message.includes('not found')) {
     return 'NOT_FOUND';
@@ -151,6 +159,16 @@ export function determineErrorCode(message: string): CliError['code'] {
 
   if (message.includes('connection') || message.includes('disconnect')) {
     return 'CONNECTION_ERROR';
+  }
+
+  // #4373: this check was missing entirely. Every other adapter extends
+  // SubprocessCliAdapter and inherits it; CodexMcpAdapter extends
+  // BaseCliAdapter and classified on its own, so a quota-dead codex-mcp came
+  // back as a generic EXECUTION_ERROR and never registered as a serving failure
+  // with the circuit breaker the voter serving-gate reads (#4330).
+  // Reuses the shared pattern set rather than adding a second taxonomy.
+  if (isRateLimitText(message)) {
+    return 'RATE_LIMITED';
   }
 
   return 'EXECUTION_ERROR';

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
@@ -190,7 +190,13 @@ export class CodexMcpAdapter extends BaseCliAdapter {
   private parseToolResult(result: McpToolResult, startTime: number): Result<CliResponse, CliError> {
     if (result.isError === true) {
       const errorText = extractTextFromContent(result.content);
-      return err(this.createError('EXECUTION_ERROR', errorText ?? 'Tool execution failed'));
+      // #4373: this hardcoded EXECUTION_ERROR and never looked at the message,
+      // so a quota-dead codex-mcp was indistinguishable from any other failure
+      // and never counted as a serving failure against the circuit breaker the
+      // voter gate reads (#4330). Classify the text the same way the error path
+      // below does.
+      const code = errorText === null ? 'EXECUTION_ERROR' : determineErrorCode(errorText);
+      return err(this.createError(code, errorText ?? 'Tool execution failed'));
     }
 
     const text = extractTextFromContent(result.content);

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-classification.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-classification.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for codex-mcp error classification (#4373, from the #4351 audit).
+ *
+ * Every other CLI adapter extends `SubprocessCliAdapter` and inherits the shared
+ * classification pipeline, which checks `isRateLimitText` before falling back.
+ * `CodexMcpAdapter` extends `BaseCliAdapter` instead and classifies on its own:
+ * `determineErrorCode` only matched ENOENT / timeout / connection, and
+ * `parseToolResult` hardcoded `EXECUTION_ERROR` for any `isError: true` result
+ * without looking at the message at all.
+ *
+ * The consequence is not cosmetic. The voter serving-gate (#4330) excludes a CLI
+ * whose circuit has opened, and the circuit only counts failures the breaker is
+ * configured to count — `RATE_LIMITED` counts, `EXECUTION_ERROR` is generic. A
+ * quota-dead codex-mcp therefore never looked like a serving failure.
+ *
+ * @module cli-adapters/adapters/codex-mcp-classification.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { determineErrorCode } from './codex-mcp-adapter-helpers.js';
+
+describe('codex-mcp error classification (#4373)', () => {
+  describe('rate-limit and quota messages', () => {
+    // The same corpus the shared `RATE_LIMIT_PATTERNS` recognises, so the two
+    // paths agree rather than drifting.
+    const rateLimited = [
+      'Rate limit exceeded, please retry',
+      'Key limit exceeded',
+      '429 Too Many Requests',
+      'quota exceeded for this key',
+      'You have hit your usage limit',
+      'Request throttled',
+    ];
+
+    for (const message of rateLimited) {
+      it(`classifies "${message}" as RATE_LIMITED`, () => {
+        expect(determineErrorCode(message)).toBe('RATE_LIMITED');
+      });
+    }
+  });
+
+  describe('existing classifications are unchanged', () => {
+    it('still detects a missing binary', () => {
+      expect(determineErrorCode('spawn codex ENOENT')).toBe('NOT_FOUND');
+    });
+
+    it('still detects a timeout', () => {
+      expect(determineErrorCode('operation timeout after 30s')).toBe('TIMEOUT');
+    });
+
+    it('still detects a dropped connection', () => {
+      expect(determineErrorCode('connection reset by peer')).toBe('CONNECTION_ERROR');
+    });
+
+    it('falls back to EXECUTION_ERROR for anything else', () => {
+      expect(determineErrorCode('something went sideways')).toBe('EXECUTION_ERROR');
+    });
+  });
+
+  describe('classification precedence', () => {
+    it('prefers NOT_FOUND over rate-limit when both could match', () => {
+      // A missing binary is actionable and terminal; a rate-limit reading would
+      // send the caller down a retry path that can never succeed.
+      expect(determineErrorCode('ENOENT: rate limit config not found')).toBe('NOT_FOUND');
+    });
+
+    it('prefers a timeout reading over rate-limit', () => {
+      expect(determineErrorCode('timeout waiting for rate limit window')).toBe('TIMEOUT');
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -41,6 +41,7 @@ import { getTimeoutForTaskAuto } from './cli-timeout-profiles.js';
 import { CapacityTracker, createCapacityTracker } from './capacity-tracker.js';
 import { executeCliRetryLoop } from './cli-retry-loop.js';
 import { getDefaultCliCircuitBreakerRegistry } from './cli-circuit-breaker.js';
+import { parseRetryAfterMs } from '../adapters/rate-limit-detector.js';
 
 const execAsync = promisify(exec);
 
@@ -366,12 +367,18 @@ export abstract class BaseCliAdapter implements ICliAdapter {
    */
   protected createError(code: CliErrorCode, message: string, cause?: Error): CliError {
     const retryable = ['RATE_LIMITED', 'TIMEOUT', 'CONNECTION_ERROR'].includes(code);
+    // #4373: `parseRetryAfterMs` existed with regexes for "retry after Xs" /
+    // "try again in Xs" and was called from nowhere under cli-adapters, so a
+    // provider telling us exactly how long to wait was ignored in favour of our
+    // own exponential backoff. Only meaningful on a retryable error.
+    const retryAfterMs = retryable ? parseRetryAfterMs(message) : undefined;
 
     return {
       code,
       message,
       cli: this.name,
       retryable,
+      ...(retryAfterMs !== undefined && { retryAfterMs }),
       ...(cause !== undefined && { cause }),
     };
   }

--- a/packages/nexus-agents/src/cli-adapters/cli-error-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-error-helpers.ts
@@ -17,6 +17,7 @@
  * @module cli-adapters/cli-error-helpers
  */
 
+import { parseRetryAfterMs } from '../adapters/rate-limit-detector.js';
 import type { CliError, CliErrorCode, CliName } from './types.js';
 
 /** Error codes the retry machinery treats as transient. */
@@ -43,11 +44,18 @@ export function createCliError(
   cli: CliName,
   cause?: Error
 ): CliError {
+  const retryable = isRetryableErrorCode(code);
+  // #4373: honor a provider-stated retry window here too, so the shared helper
+  // and BaseCliAdapter.createError produce the same shape — otherwise which
+  // construction path an adapter happened to use would decide whether the hint
+  // survived.
+  const retryAfterMs = retryable ? parseRetryAfterMs(message) : undefined;
   return {
     code,
     message,
     cli,
-    retryable: isRetryableErrorCode(code),
+    retryable,
+    ...(retryAfterMs !== undefined && { retryAfterMs }),
     ...(cause !== undefined && { cause }),
   };
 }

--- a/packages/nexus-agents/src/cli-adapters/cli-retry-loop.ts
+++ b/packages/nexus-agents/src/cli-adapters/cli-retry-loop.ts
@@ -70,6 +70,28 @@ export function calculateBackoffDelay(
   return Math.min(delayMs, maxDelayMs);
 }
 
+/**
+ * Resolve how long to wait before the next attempt (#4373).
+ *
+ * Prefers a provider-supplied `retryAfterMs` over the computed exponential
+ * backoff — a provider that names its window knows better than our guess — but
+ * still clamps to the caller's ceiling so a CLI claiming a multi-hour window
+ * cannot wedge the retry loop. A zero or negative hint is ignored rather than
+ * retried instantly.
+ */
+export function resolveRetryDelayMs(
+  error: CliError,
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number
+): number {
+  const hint = error.retryAfterMs;
+  if (hint !== undefined && hint > 0) {
+    return Math.min(hint, maxDelayMs);
+  }
+  return calculateBackoffDelay(attempt, baseDelayMs, maxDelayMs);
+}
+
 /** Determines if an error code is retryable. */
 export function isRetryableError(code: CliErrorCode): boolean {
   return RETRYABLE_ERROR_CODES.has(code);
@@ -130,7 +152,7 @@ export async function executeCliRetryLoop(
       return err(lastError);
     }
 
-    const delayMs = calculateBackoffDelay(attempt, config.baseDelayMs, config.maxDelayMs);
+    const delayMs = resolveRetryDelayMs(lastError, attempt, config.baseDelayMs, config.maxDelayMs);
     config.logger.debug('Retrying CLI execution', {
       cli: config.cli,
       attempt,

--- a/packages/nexus-agents/src/cli-adapters/retry-after-honored.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/retry-after-honored.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for honoring a provider-supplied retry-after hint (#4373).
+ *
+ * `parseRetryAfterMs` (`adapters/rate-limit-detector.ts:55-79`) has existed with
+ * regexes for "retry after Xs" / "try again in Xs" and was called from nowhere
+ * under `cli-adapters/`. `CliError` had no field to carry the value, so when a
+ * provider told us exactly how long to wait, the retry loop ignored it and used
+ * its own exponential backoff instead — retrying too early (wasting an attempt
+ * against a window that has not reopened) or too late.
+ *
+ * @module cli-adapters/retry-after-honored.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveRetryDelayMs } from './cli-retry-loop.js';
+import type { CliError } from './types.js';
+
+function rateLimited(overrides: Partial<CliError> = {}): CliError {
+  return {
+    code: 'RATE_LIMITED',
+    message: 'rate limit exceeded',
+    cli: 'opencode',
+    retryable: true,
+    ...overrides,
+  };
+}
+
+describe('retry-after is honored over computed backoff (#4373)', () => {
+  it('uses the provider hint when the error carries one', () => {
+    const error = rateLimited({ retryAfterMs: 45_000 });
+
+    expect(resolveRetryDelayMs(error, 1, 1_000, 60_000)).toBe(45_000);
+  });
+
+  it('falls back to computed backoff when there is no hint', () => {
+    const delay = resolveRetryDelayMs(rateLimited(), 1, 1_000, 16_000);
+
+    // Exponential base with jitter — bounded, but definitely not a fixed hint.
+    expect(delay).toBeGreaterThanOrEqual(1_000);
+    expect(delay).toBeLessThanOrEqual(16_000);
+  });
+
+  it('clamps a hint longer than the ceiling', () => {
+    // A provider claiming a multi-hour window must not wedge the retry loop for
+    // hours; the caller's ceiling still governs.
+    const error = rateLimited({ retryAfterMs: 7_200_000 });
+
+    expect(resolveRetryDelayMs(error, 1, 1_000, 16_000)).toBe(16_000);
+  });
+
+  it('ignores a zero or negative hint rather than retrying instantly', () => {
+    expect(resolveRetryDelayMs(rateLimited({ retryAfterMs: 0 }), 1, 1_000, 16_000)).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('grows the computed backoff across attempts, unlike a fixed hint', () => {
+    const first = resolveRetryDelayMs(rateLimited(), 1, 1_000, 60_000);
+    const third = resolveRetryDelayMs(rateLimited(), 3, 1_000, 60_000);
+
+    expect(third).toBeGreaterThan(first);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -131,6 +131,14 @@ export interface CliError {
   readonly cause?: Error;
   /** Whether the error is retryable */
   readonly retryable: boolean;
+  /**
+   * How long the provider asked us to wait before retrying, in milliseconds
+   * (#4373). Present only when the CLI's own message stated one — parsed by
+   * `parseRetryAfterMs`. The retry loop prefers this over its computed
+   * exponential backoff, since a provider that names its window knows better
+   * than our guess.
+   */
+  readonly retryAfterMs?: number;
 }
 
 /**


### PR DESCRIPTION
Partial for #4373 — items 2 and 3 of the [revised shape](https://github.com/nexus-substrate/nexus-agents/issues/4373#issuecomment-5215698412) I posted after the recon fan-out. Deliberately **does not close** the issue; see the scope note at the bottom.

## codex-mcp never classified a quota error

Every other CLI adapter extends `SubprocessCliAdapter` and inherits a pipeline that runs `isRateLimitText`. `CodexMcpAdapter` extends `BaseCliAdapter` and classified on its own, with two holes:

- `determineErrorCode` (`codex-mcp-adapter-helpers.ts:143`) matched only ENOENT / timeout / connection, then fell through to `EXECUTION_ERROR`
- `parseToolResult` (`codex-mcp-adapter.ts:190`) hardcoded `EXECUTION_ERROR` for **any** `isError: true` result without reading the message at all

This is not cosmetic. The voter serving-gate excludes a CLI whose circuit has opened (#4330), and the breaker counts `RATE_LIMITED` while `EXECUTION_ERROR` is generic — so a quota-dead codex-mcp never registered as a serving failure, and the gate that #4330 just gave a signal to still could not see it.

Both paths now use the shared pattern set. **No second taxonomy** — that was the DRY condition the #4330 panel attached, and it applies identically here.

Precedence is deliberate and tested: a missing binary or a timeout still wins over a rate-limit reading even when the text mentions a rate limit, because classifying a terminal failure as rate-limited routes the caller into a retry that can never succeed.

## A provider-stated retry window was parsed and thrown away

`parseRetryAfterMs` (`adapters/rate-limit-detector.ts:55-79`) has existed with regexes for "retry after Xs", "wait X ms" and "try again in Xs" — and was called from **nowhere** under `cli-adapters/`. `CliError` had no field to carry the value anyway. So when a provider told us exactly how long to wait, the retry loop ignored it and used its own exponential backoff: retrying too early against a window that had not reopened, or too late.

`CliError.retryAfterMs` now carries it on retryable errors, populated in **both** construction paths (`BaseCliAdapter.createError` and the shared `createCliError`) so that which one an adapter happens to use does not decide whether the hint survives. `resolveRetryDelayMs` prefers it over the computed backoff, with two guards:

- **clamped to the caller's ceiling**, so a CLI claiming a multi-hour window cannot wedge the retry loop
- **a zero or negative hint is ignored** rather than retried instantly

## Scope — what this does NOT do

The issue also asks for a normalized `capacity_exhausted` diagnostic and capacity-aware routing exclusion. Both are held back deliberately:

- **Distinguishing a hard quota from a transient throttle** is the higher-risk half. Today `RATE_LIMITED` is unconditionally `retryable: true` and covers both. Getting the patterns wrong in the non-retryable direction evicts a healthy CLI — the fail-wrong direction the panels keep flagging — so it deserves its own change and its own vote rather than riding along here.
- **Routing exclusion has no consumer to hook into.** `CompositeRouter.getCapacityDashboard()` has zero production callers and `WorkBalancer` is never instantiated. Building capacity-driven routing before settling their fate (#4378) would create a second capacity-decision implementation alongside a dormant one.

## Verification

- 12 new codex-mcp classification tests (6 red against the old code) covering the shared rate-limit corpus, the unchanged existing classifications, and both precedence cases
- 5 new retry-delay tests (all red — `resolveRetryDelayMs` did not exist) covering hint-preferred, fallback, ceiling clamp, zero-hint rejection, and that computed backoff still grows across attempts
- Full package suite **27753 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)