### PR TITLE
fix(cli-adapters): register codex in the model-discovery probe (#4318)

### DIFF
--- a/.changeset/great-hoops-mate.md
+++ b/.changeset/great-hoops-mate.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): register codex in the model-discovery probe (#4318)
+
+`list_available_models` reported `claude`, `gemini` and `opencode` but never
+`codex`, despite the CLI being installed and authenticated.
+
+The cause was a silent capability gap rather than a registration bug.
+`buildDefaultModelSources` includes an adapter only when `hasListModels(adapter)`
+is true, and `createAllAdapters` defaults codex to the **mcp** transport
+(`codexTransport: CliTransport = 'mcp'`). `CodexMcpAdapter` had no `listModels()`
+— only the subprocess `CodexCliAdapter` did — so codex was filtered out of the
+source list with no error logged anywhere. The probe reported one fewer transport
+than it had.
+
+`CodexMcpAdapter.listModels()` now delegates to the same key-free models.dev
+snapshot lookup the subprocess adapter uses. Model enumeration is
+transport-independent, so which transport codex happens to be running must not
+change which transports are discoverable — pinned by a test asserting both
+transports yield the same probe set.
+
+This is one item of #4318; the agy/Antigravity migration and auth-tier health
+detection remain open there.

--- a/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/codex-mcp-adapter.ts
@@ -24,6 +24,8 @@ import type {
 } from '../types.js';
 import type { Result } from '../../core/index.js';
 import { getErrorMessage, ok, err, getTimeProvider, createLogger } from '../../core/index.js';
+import type { CliModelInfo } from '../types-capability.js';
+import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import { BaseCliAdapter } from '../base-adapter.js';
 
 import {
@@ -62,6 +64,21 @@ export class CodexMcpAdapter extends BaseCliAdapter {
   constructor(options?: BaseAdapterOptions) {
     super(options?.logger ?? createLogger({ component: 'codex-mcp-adapter' }));
     this.model = options?.model ?? getCliModelName(getDefaultModelForCli('codex'));
+  }
+
+  /**
+   * Key-free model enumeration via the models.dev snapshot (#3405), matching
+   * `CodexCliAdapter`.
+   *
+   * #4318: this was missing, and `buildDefaultModelSources` includes an adapter
+   * only when `hasListModels(adapter)` is true. Since `createAllAdapters`
+   * defaults codex to the mcp transport, codex was silently filtered out of
+   * `list_available_models` — the probe reported one fewer transport than it
+   * had, with no error anywhere. Model enumeration is transport-independent, so
+   * the two adapters must answer identically.
+   */
+  listModels(): Promise<readonly CliModelInfo[]> {
+    return Promise.resolve(listModelsForCli(this.name));
   }
 
   /**

--- a/packages/nexus-agents/src/config/codex-probe-registration.test.ts
+++ b/packages/nexus-agents/src/config/codex-probe-registration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test: codex must appear in the model-discovery probe (#4318).
+ *
+ * `list_available_models` reported `claude`, `gemini` and `opencode` but never
+ * `codex`, despite the CLI being installed and authenticated. The cause was a
+ * silent capability gap, not a registration bug: `buildDefaultModelSources`
+ * includes an adapter only when `hasListModels(adapter)` is true, and
+ * `createAllAdapters` defaults codex to the **mcp** transport
+ * (`codexTransport: CliTransport = 'mcp'`). `CodexMcpAdapter` had no
+ * `listModels()`, so codex was filtered out of the source list with no error
+ * anywhere — the probe simply reported one fewer transport than it had.
+ *
+ * @module config/codex-probe-registration.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createAllAdapters } from '../cli-adapters/factory.js';
+import { buildDefaultModelSources } from './register-model-sources.js';
+
+function probedTransports(codexTransport: 'mcp' | 'subprocess'): string[] {
+  const adapters = createAllAdapters(undefined, codexTransport);
+  return buildDefaultModelSources(adapters, { includeOpenRouter: false }).map((s) => s.name);
+}
+
+describe('model-discovery probe registration (#4318)', () => {
+  it('includes codex under the default (mcp) transport', () => {
+    // The default is what the MCP tool actually runs, so this is the case that
+    // produced the missing transport in the field.
+    expect(probedTransports('mcp')).toContain('codex');
+  });
+
+  it('includes codex under the subprocess transport', () => {
+    expect(probedTransports('subprocess')).toContain('codex');
+  });
+
+  it('still includes the other CLI transports', () => {
+    const names = probedTransports('mcp');
+
+    expect(names).toEqual(expect.arrayContaining(['claude', 'gemini', 'opencode']));
+  });
+
+  it('reports the same transport set on either codex transport', () => {
+    // Which transport codex uses is a routing detail; it must not change which
+    // transports are discoverable.
+    expect([...probedTransports('mcp')].sort()).toEqual([...probedTransports('subprocess')].sort());
+  });
+});


### PR DESCRIPTION
Partial for #4318 — the codex-transport item. Does **not** close the issue; the agy/Antigravity migration and auth-tier health detection remain open there.

## A silent capability gap, not a registration bug

`list_available_models` reported `claude`, `gemini` and `opencode` but never `codex`, despite the CLI being installed and logged in. The issue guessed "either the adapter isn't registered or the probe skips it". It is neither, exactly:

- `buildDefaultModelSources` (`config/register-model-sources.ts:89-97`) includes an adapter **only when** `hasListModels(adapter)` is true
- `createAllAdapters` (`cli-adapters/factory.ts:115-124`) defaults codex to the **mcp** transport: `codexTransport: CliTransport = 'mcp'`
- `CodexMcpAdapter` had no `listModels()`. Only the subprocess `CodexCliAdapter` did.

So codex was registered as an adapter and then filtered out of the source list by a duck-typing check, with **no error logged anywhere**. The probe reported one fewer transport than it had — which reads as "codex is not available" rather than "codex could not be asked".

## The fix

`CodexMcpAdapter.listModels()` delegates to the same key-free models.dev snapshot lookup the subprocess adapter uses (`listModelsForCli`). Model enumeration is transport-independent — which transport codex happens to be running on must not change which transports are discoverable.

That invariant is pinned directly: one test asserts both transports yield the **same** probe set, so a future adapter cannot reintroduce the asymmetry by adding a capability to one side only.

## Verification

- 4 new tests; 2 red against the old code, reproducing the reported symptom exactly (`expected [ 'claude', 'gemini', 'opencode' ] to include 'codex'`)
- Full package suite **27757 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

## Note on the rest of #4318

The remaining items need the owner's environment and a larger decision:

- **gemini → agy** is a new adapter with its own settings file, permission grammar, and a scratch-dir artifact-harvesting contract — not a repoint
- **auth-tier health detection** ("ok, 0 models" for a CLI that fails every invocation) is the same gap as #4376: `healthCheck()` verifies binary + version, `cli-auth-probe.ts` reads credential files locally, and nothing issues a real completion. Those two should be solved together rather than twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)